### PR TITLE
fvp: fix compiler warning

### DIFF
--- a/core/arch/arm32/plat-vexpress/main.c
+++ b/core/arch/arm32/plat-vexpress/main.c
@@ -383,7 +383,7 @@ uint32_t main_cpu_on_handler(uint32_t a0, uint32_t a1)
 	(void)&a1;
 
 	DMSG("cpu %zu: a0 0%x", pos, a0);
-	main_init_helper(false, get_core_pos(), NSEC_ENTRY_INVALID);
+	main_init_helper(false, pos, NSEC_ENTRY_INVALID);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes compiler warning when compiling with default
CFG_TEE_CORE_LOG_LEVEL.
