### PR TITLE
Cleanup loading/unloading of a TA

### DIFF
--- a/core/arch/arm32/include/kernel/thread.h
+++ b/core/arch/arm32/include/kernel/thread.h
@@ -149,11 +149,9 @@ void thread_init_handlers(const struct thread_handlers *handlers);
 bool thread_init_stack(uint32_t stack_id, vaddr_t sp);
 
 /*
- * Set Thread Specific Data (TSD) pointer together a function
- * to free the TSD on thread_exit.
+ * Set Thread Specific Data (TSD) pointer.
  */
-typedef void (*thread_tsd_free_t)(void *tsd);
-void thread_set_tsd(void *tsd, thread_tsd_free_t free_func);
+void thread_set_tsd(void *tsd);
 
 /* Returns Thread Specific Data (TSD) pointer. */
 void *thread_get_tsd(void);

--- a/core/arch/arm32/kernel/thread_private.h
+++ b/core/arch/arm32/kernel/thread_private.h
@@ -76,7 +76,6 @@ struct thread_ctx {
 	enum thread_state state;
 	vaddr_t stack_va_end;
 	void *tsd;
-	thread_tsd_free_t tsd_free;
 	uint32_t hyp_clnt_id;
 	uint32_t flags;
 	struct thread_ctx_regs regs;

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -63,7 +63,6 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 			       struct tee_ta_session **sess,
 			       struct tee_ta_session_head *open_sessions,
 			       const TEE_UUID *uuid,
-			       const kta_signed_header_t *ta,
 			       const TEE_Identity *clnt_id,
 			       uint32_t cancel_req_to,
 			       struct tee_ta_param *param);
@@ -78,15 +77,6 @@ TEE_Result tee_ta_cancel_command(TEE_ErrorOrigin *err,
 				 struct tee_ta_session *sess,
 				 const TEE_Identity *clnt_id);
 
-/*
- * Load a TA via RPC with UUID defined by input param uuid. The virtual
- * address of the TA is recieved in out parameter ta
- *
- * Function is not thread safe
- */
-TEE_Result tee_ta_rpc_load(const TEE_UUID *uuid, kta_signed_header_t **ta,
-			   struct tee_ta_nwumap *map, uint32_t *ret_orig);
-
 /*-----------------------------------------------------------------------------
  * Function called to close a TA.
  * Parameters:
@@ -100,9 +90,6 @@ TEE_Result tee_ta_close_session(uint32_t id,
 TEE_Result tee_ta_get_current_session(struct tee_ta_session **sess);
 
 void tee_ta_set_current_session(struct tee_ta_session *sess);
-
-TEE_Result tee_ta_make_current_session_resident(void);
-void tee_ta_unlock_current_session(void);
 
 TEE_Result tee_ta_get_client_id(TEE_Identity *id);
 

--- a/core/include/kernel/tee_ta_manager_unpg.h
+++ b/core/include/kernel/tee_ta_manager_unpg.h
@@ -63,9 +63,7 @@ struct tee_ta_ctx {
 	/* List of storage enumerators opened by this TA */
 	struct tee_storage_enum_head storage_enums;
 	ta_head_t *head;	/* ptr to the ta head in secure memory */
-	void *nmem;		/* ptr to code and data in normal world mem */
-	/* Normal world user mapping of the TA */
-	struct tee_ta_nwumap nwumap;
+	uintptr_t mem_swap;	/* ptr to code and data in memory swap */
 	tee_mm_entry_t *mm;	/* secure world memory */
 	uint32_t smem_size;	/* the size of the secure memory */
 	uint32_t rw_data;	/* rw data stored on heap */
@@ -80,7 +78,6 @@ struct tee_ta_ctx {
 	uint32_t panicked;	/* True if TA has panicked, written from asm */
 	uint32_t panic_code;	/* Code supplied for panic */
 	uint32_t ref_count;	/* Reference counter for multi session TA */
-	bool locked;		/* session is locked and cannot be closed */
 	bool busy;		/* context is busy and cannot be entered */
 	void *ta_time_offs;	/* Time reference used by the TA */
 	ta_static_head_t *static_ta;	/* TA head struct for other cores */

--- a/core/kernel/tee_dispatch.c
+++ b/core/kernel/tee_dispatch.c
@@ -86,7 +86,6 @@ TEE_Result tee_dispatch_open_session(struct tee_dispatch_open_session_in *in,
 	TEE_Result res = TEE_ERROR_BAD_PARAMETERS;
 	struct tee_ta_session *s = NULL;
 	uint32_t res_orig = TEE_ORIGIN_TEE;
-
 	struct tee_ta_param *param = malloc(sizeof(struct tee_ta_param));
 	TEE_Identity *clnt_id = malloc(sizeof(TEE_Identity));
 
@@ -105,25 +104,7 @@ TEE_Result tee_dispatch_open_session(struct tee_dispatch_open_session_in *in,
 	memcpy(param->param_attr, in->param_attr, sizeof(in->param_attr));
 
 	res = tee_ta_open_session(&res_orig, &s, &tee_open_sessions, &in->uuid,
-				  in->ta, clnt_id, TEE_TIMEOUT_INFINITE, param);
-	if (res_orig == TEE_ORIGIN_TEE && res == TEE_ERROR_ITEM_NOT_FOUND) {
-		kta_signed_header_t *ta = NULL;
-		struct tee_ta_nwumap lp;
-
-		/* Load TA */
-		res = tee_ta_rpc_load(&in->uuid, &ta, &lp, &res_orig);
-		if (res != TEE_SUCCESS)
-			goto cleanup_return;
-
-		res = tee_ta_open_session(&res_orig, &s, &tee_open_sessions,
-					  NULL, ta, clnt_id,
-					  TEE_TIMEOUT_INFINITE, param);
-		if (res != TEE_SUCCESS)
-			goto cleanup_return;
-
-		s->ctx->nwumap = lp;
-
-	}
+				  clnt_id, TEE_TIMEOUT_INFINITE, param);
 	if (res != TEE_SUCCESS)
 		goto cleanup_return;
 

--- a/core/kernel/tee_ta_manager_unpg.c
+++ b/core/kernel/tee_ta_manager_unpg.c
@@ -79,7 +79,7 @@ void *tee_ta_load_page(const uint32_t va_addr)
 
 	spage = va_addr & 0xFFFFF000;
 	smem = tee_mm_get_smem(ts->mm);
-	npage = (uint32_t) (ts->nmem) + spage - smem;
+	npage = ts->mem_swap + spage - smem;
 	page_idx = ((spage - smem) >> SMALL_PAGE_SHIFT);
 	page_bit = 1 << page_idx;
 	if (tee_hash_get_digest_size(ts->head->hash_type, &hash_size) !=

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -518,28 +518,9 @@ TEE_Result tee_svc_open_ta_session(const TEE_UUID *dest,
 	 * code
 	 */
 	res = tee_ta_open_session(&ret_o, &s, &sess->ctx->open_sessions, uuid,
-				  NULL, clnt_id, cancel_req_to, param);
-
-	if (ret_o != TEE_ORIGIN_TEE || res != TEE_ERROR_ITEM_NOT_FOUND)
+				  clnt_id, cancel_req_to, param);
+	if (res != TEE_SUCCESS)
 		goto function_exit;
-
-	if (ret_o == TEE_ORIGIN_TEE && res == TEE_ERROR_ITEM_NOT_FOUND) {
-		kta_signed_header_t *ta = NULL;
-		struct tee_ta_nwumap lp;
-
-		/* Load TA */
-		res = tee_ta_rpc_load(uuid, &ta, &lp, &ret_o);
-		if (res != TEE_SUCCESS)
-			goto function_exit;
-
-		res = tee_ta_open_session(&ret_o, &s, &sess->ctx->open_sessions,
-					  uuid, ta, clnt_id, cancel_req_to,
-					  param);
-		if (res != TEE_SUCCESS)
-			goto function_exit;
-
-		s->ctx->nwumap = lp;
-	}
 
 	res = tee_svc_update_out_param(sess, NULL, param, tmp_buf_pa, params);
 	if (res != TEE_SUCCESS)

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -31,21 +31,34 @@
 #include <tee_api_types.h>
 
 /*
-   signed_header
-   ta_head_t
-   ta_func_head_t (1)
-   ta_func_head_t (2)
-   ...
-   ta_func_head_t (N) N = ta_head(_t).nbr_func
-   func_1
-   func_1
-   ...
-   func_N
-   hash_1
-   hash_2
-   ...
-   hash_M
-*/
+ * The generic format of a TA header.
+ *
+ * signed_header
+ * ta_head_t
+ * ta_func_head_t (1)
+ * ta_func_head_t (2)
+ * ...
+ * ta_func_head_t (N) N = ta_head(_t).nbr_func
+ * func_1
+ * func_1
+ * ...
+ * func_N
+ * hash_1
+ * hash_2
+ * ...
+ * hash_M
+ *
+ * The currently this format is limited to N = 5, resulting in a TA header as
+ *
+ * signed_header
+ * struct user_ta_head
+ * struct user_ta_func_head (1)
+ * struct user_ta_func_head (2)
+ * struct user_ta_func_head (3)
+ * struct user_ta_sub_head
+ *
+ * Note that the last two func heads are replaced by struct user_ta_sub_head.
+ */
 
 struct user_ta_head {
 	TEE_UUID uuid;

--- a/ta/arch/arm32/user_ta_header.c
+++ b/ta/arch/arm32/user_ta_header.c
@@ -36,17 +36,17 @@
 
 /* exprted to user_ta_header.c, built within TA */
 void ta_entry_close_session(uint32_t session_id)
-	/*__attribute__((noreturn))*/ ;
+	/*__attribute__((noreturn))*/;
 
 void ta_entry_open_session(uint32_t param_types,
 			   TEE_Param params[TEE_NUM_PARAMS],
 			   uint32_t session_id)
-	/*__attribute__((noreturn))*/ ;
+	/*__attribute__((noreturn))*/;
 
 void ta_entry_invoke_command(uint32_t cmd_id, uint32_t param_types,
 			     TEE_Param params[TEE_NUM_PARAMS],
 			     uint32_t session_id)
-	/*__attribute__((noreturn))*/ ;
+	/*__attribute__((noreturn))*/;
 
 /* These externs are defined in the ld link script */
 extern uint32_t linker_RO_sections_size;
@@ -56,30 +56,28 @@ extern uint32_t linker_rel_dyn_GOT;
 
 /* Note that cmd_id is not used in a User Mode TA */
 const struct user_ta_func_head user_ta_func_head[]
-    __attribute__ ((section(".ta_func_head"))) =
-{
-	{
-	0, (uint32_t) ta_entry_open_session}, {
-	0, (uint32_t) ta_entry_close_session}, {
-	0, (uint32_t) ta_entry_invoke_command}, {
-	TA_FLAGS, 0 /* Spare */ },
-	{
-TA_DATA_SIZE, TA_STACK_SIZE},};
+			__attribute__ ((section(".ta_func_head"))) = {
+	{ 0, (uint32_t)ta_entry_open_session },
+	{ 0, (uint32_t)ta_entry_close_session },
+	{ 0, (uint32_t)ta_entry_invoke_command },
+	{ (TA_FLAG_USER_MODE | TA_FLAGS), 0 /* Spare */ },
+	{ (TA_DATA_SIZE), (TA_STACK_SIZE) },
+};
 
 const struct user_ta_head ta_head __attribute__ ((section(".ta_head"))) = {
 	/* UUID, unique to each TA */
 	TA_UUID,
-	    /* Number of functions in the TA */
-	    sizeof(user_ta_func_head) / sizeof(struct user_ta_func_head),
-	    /* Section size information */
-	    (uint32_t) & linker_RO_sections_size,
-	    (uint32_t) & linker_RW_sections_size,
-	    (uint32_t) & linker_res_funcs_ZI_sections_size,
-	    (uint32_t) & linker_rel_dyn_GOT,
-	    /* Hash type, filled in by sign-tool */
-	    0,
-	    /* TA trace level */
-	    /* TA_TRACE_LEVEL_DEFAULT, */
+	/* Number of functions in the TA */
+	sizeof(user_ta_func_head) / sizeof(struct user_ta_func_head),
+	/* Section size information */
+	(uint32_t)&linker_RO_sections_size,
+	(uint32_t)&linker_RW_sections_size,
+	(uint32_t)&linker_res_funcs_ZI_sections_size,
+	(uint32_t)&linker_rel_dyn_GOT,
+	/* Hash type, filled in by sign-tool */
+	0,
+	/* TA trace level */
+	/* TA_TRACE_LEVEL_DEFAULT, */
 };
 
 /* Filled in by TEE Core when loading the TA */
@@ -89,19 +87,19 @@ const size_t ta_data_size = TA_DATA_SIZE;
 
 const struct user_ta_property ta_props[] = {
 	{"gpd.ta.singleInstance", USER_TA_PROP_TYPE_BOOL,
-	 &(const bool){(TA_FLAGS & TA_FLAG_SINGLE_INSTANCE) != 0}},
+	 &(const bool){(TA_FLAGS & TA_FLAG_SINGLE_INSTANCE) != 0} },
 
 	{"gpd.ta.multiSession", USER_TA_PROP_TYPE_BOOL,
-	 &(const bool){(TA_FLAGS & TA_FLAG_MULTI_SESSION) != 0}},
+	 &(const bool){(TA_FLAGS & TA_FLAG_MULTI_SESSION) != 0} },
 
 	{"gpd.ta.instanceKeepAlive", USER_TA_PROP_TYPE_BOOL,
-	 &(const bool){(TA_FLAGS & TA_FLAG_INSTANCE_KEEP_ALIVE) != 0}},
+	 &(const bool){(TA_FLAGS & TA_FLAG_INSTANCE_KEEP_ALIVE) != 0} },
 
 	{"gpd.ta.dataSize", USER_TA_PROP_TYPE_U32,
-	 &(const uint32_t){TA_DATA_SIZE}},
+	 &(const uint32_t){TA_DATA_SIZE} },
 
 	{"gpd.ta.stackSize", USER_TA_PROP_TYPE_U32,
-	 &(const uint32_t){TA_STACK_SIZE}},
+	 &(const uint32_t){TA_STACK_SIZE} },
 /*
  * Extended propietary properties, name of properties must not begin with
  * "gpd."


### PR DESCRIPTION
- A TA is only loaded via tee-supplicant, directly supplying a
  pointer to the TA binary is not supported any longer.
  This requires and update to the client lib to avoid leaking
  shared memory.
- The shared memory used to load the TA is freed as soon as the
  TA have been loaded into secure memory
- Divides tee_ta_init_session() into sevaral functions
- Divides tee_ta_close_session() into two functions
- Divides tee_ta_load() into several functions with one
  separate function for signature verification
- Removes some unused code for kernel TAs
- Removes the option to lock/unlock a TA is only used by kernel
  TAs which we don't support any longer.
- Removes the static global tee_rs. Switch to use Thread Local
  Storage pointer provided by the thread handler.
