### PR TITLE
Bugfix TA dev kit

### DIFF
--- a/ta/arch/arm32/fix_ta_binary
+++ b/ta/arch/arm32/fix_ta_binary
@@ -1,0 +1,121 @@
+#!/usr/bin/env perl
+# Copyright (c) 2014, STMicroelectronics International N.V.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use diagnostics;
+use Env qw($READELF);
+
+sub usage
+{
+    print STDERR "usage: $0 [-v] <elf> <binary>\n";
+    exit(1);
+}
+
+usage if ($#ARGV < 1);
+
+my $verbose = 0;
+
+if ($ARGV[0] =~ m/^-v$/) {
+    $verbose = 1;
+    shift @ARGV;
+}
+
+usage if ($#ARGV != 1);
+my ($elf, $bin) = @ARGV;
+
+open(BIN, "+<$bin") || die("Error opening TA file $bin");
+binmode(BIN);
+
+my $readelf = "readelf";
+$readelf = $READELF if ($READELF);
+
+my $readelfcmd = "$readelf -s -W $elf";
+print "$readelfcmd\n" if ($verbose);
+open(ELF, "$readelfcmd|") || die "Error exec $readelfcmd";
+
+my $offs_0x14;
+my $offs_0x14sym = "linker_RO_sections_size";
+my $offs_0x18;
+my $offs_0x18sym = "linker_RW_sections_size";
+my $offs_0x1c;
+my $offs_0x1csym = "linker_res_funcs_ZI_sections_size";
+my $offs_0x20;
+my $offs_0x20sym = "linker_rel_dyn_GOT";
+
+sub read_value
+{
+    my @args = split;
+    my $value = $args[1];
+    return $value;
+}
+
+while (<ELF>) {
+    last if defined $offs_0x14 && defined $offs_0x18 &&
+            defined $offs_0x1c && defined $offs_0x20;
+    #print "Got $_";
+    my @line = split;
+    my $line_elems = @line;
+    if ($line_elems > 6 && $line[6] =~ m/^ABS$/) {
+        if ($_ =~ m/$offs_0x14sym/) {
+            $offs_0x14 = read_value($_);
+        } elsif ($_ =~ m/$offs_0x18sym/) {
+            $offs_0x18 = read_value($_);
+        } elsif ($_ =~ m/$offs_0x1csym/) {
+            $offs_0x1c = read_value($_);
+        } elsif ($_ =~ m/$offs_0x20sym/) {
+            $offs_0x20 = read_value($_);
+        }
+    }
+}
+
+die "Didn't find required symbol $offs_0x14sym in $elf"
+    unless defined $offs_0x14;
+die "Didn't find required symbol $offs_0x18sym in $elf"
+    unless defined $offs_0x18;
+die "Didn't find required symbol $offs_0x1csym in $elf"
+    unless defined $offs_0x1c;
+die "Didn't find required symbol $offs_0x20sym in $elf"
+    unless defined $offs_0x20;
+
+sub write_value
+{
+    my ($val, $offs, $sym) = @_;
+    printf("%s = 0x%08x offset 0x%x\n", $sym, $val, $offs) if $verbose;
+    my $b = pack( 'V', $val);
+    seek(BIN, $offs, 0) || die "Couldn't seek to $_[1]: $!\n";
+    syswrite(BIN, $b, 4) || die "$!";
+}
+
+write_value(hex $offs_0x14, 0x14, $offs_0x14sym);
+write_value(hex $offs_0x18, 0x18, $offs_0x18sym);
+write_value(hex $offs_0x1c, 0x1c, $offs_0x1csym);
+write_value(hex $offs_0x20, 0x20, $offs_0x20sym);
+
+close(BIN);
+close(ELF);
+exit;
+

--- a/ta/arch/arm32/link.mk
+++ b/ta/arch/arm32/link.mk
@@ -3,7 +3,8 @@ link-out-dir = $(out-dir)
 link-script = $(TA_DEV_KIT_DIR)/src/user_ta_elf_arm.lds
 link-script-pp = $(link-out-dir)ta.lds
 
-AWK	 = awk
+FIX_TA_BINARY = $(TA_DEV_KIT_DIR)/scripts/fix_ta_binary
+
 
 all: $(link-out-dir)$(binary).elf $(link-out-dir)$(binary).dmp \
 	$(link-out-dir)$(binary).bin
@@ -13,6 +14,7 @@ cleanfiles += $(link-out-dir)$(binary).bin
 cleanfiles += $(link-script-pp)
 
 link-ldflags  = $(LDFLAGS)
+link-ldflags += -pie
 link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)$(binary).map
 link-ldflags += --sort-section=alignment
 
@@ -41,3 +43,4 @@ $(link-out-dir)$(binary).dmp: $(link-out-dir)$(binary).elf
 $(link-out-dir)$(binary).bin: $(link-out-dir)$(binary).elf
 	@echo OBJCOPY $@
 	$(q)$(OBJCOPY) -O binary $< $@
+	$(q)$(FIX_TA_BINARY) $< $@

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -23,7 +23,7 @@ q :=
 cmd-echo := echo
 endif
 
-cflags$(sm) += -fno-short-enums
+cflags$(sm) += -fno-short-enums -fpie
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
 
 ifeq ($(DEBUG),1)
@@ -36,7 +36,7 @@ aflags$(sm) += -g -g3
 
 
 libdirs += $(ta-dev-kit-dir)/lib
-libnames += c mpa utee
+libnames += utils mpa utee
 libdeps += $(ta-dev-kit-dir)/lib/libutils.a
 libdeps += $(ta-dev-kit-dir)/lib/libmpa.a
 libdeps += $(ta-dev-kit-dir)/lib/libutee.a
@@ -52,5 +52,6 @@ include  $(ta-dev-kit-dir)/mk/subdir.mk
 vpath %.c $(ta-dev-kit-dir)/src
 srcs += user_ta_header.c
 
+include  $(ta-dev-kit-dir)/mk/gcc.mk
 include  $(ta-dev-kit-dir)/mk/compile.mk
 include  $(ta-dev-kit-dir)/mk/link.mk

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -49,7 +49,8 @@ $(foreach f, $(libfiles), \
 	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/lib)))
 
 # Copy .mk files
-ta-mkfiles = mk/compile.mk mk/subdir.mk $(wildcard ta/arch/$(ARCH)/link.mk) \
+ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk \
+	$(wildcard ta/arch/$(ARCH)/link.mk) \
 	ta/mk/ta_dev_kit.mk
 $(foreach f, $(ta-mkfiles), \
 	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/mk)))
@@ -72,3 +73,8 @@ ta-srcfiles = ta/arch/$(ARCH)/user_ta_header.c \
 	$(wildcard ta/arch/$(ARCH)/user_ta_elf_arm.lds)
 $(foreach f, $(ta-srcfiles), \
 	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/src)))
+
+# Copy the scripts
+ta-scripts = $(wildcard ta/arch/$(ARCH)/fix_ta_binary)
+$(foreach f, $(ta-scripts), \
+	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/scripts)))


### PR DESCRIPTION
- Small bugfixes to bring the mk-files for TA dev kit up to date.
- Compile TAs with -fpie
- Add fix_ta_binary to fix the absolute relocation issue in TA header
