### PR TITLE
TEE_ROUNDxxx renamed in ROUNDxxx in libutee

### DIFF
--- a/core/arch/arm32/include/mm/core_memprot.h
+++ b/core/arch/arm32/include/mm/core_memprot.h
@@ -72,8 +72,6 @@ enum buf_is_attr {
 #define tee_vbuf_is_sec(buf, len) \
 		core_vbuf_is(CORE_MEM_SEC, (void *)(buf), (len))
 
-/* See kta_mem.h for flags to tee_pbuf_is() and tee_kbuf_is() */
-
 /*
  * This function return true if the buf complies with supplied flags.
  * If this function returns false buf doesn't comply with supplied flags

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -131,10 +131,10 @@ typedef enum {
 #endif
 
 /* Round up the even multiple of size, size has to be a multiple of 2 */
-#define TEE_ROUNDUP(v, size) (((v) + (size - 1)) & ~(size - 1))
+#define ROUNDUP(v, size) (((v) + (size - 1)) & ~(size - 1))
 
 /* Round down the even multiple of size, size has to be a multiple of 2 */
-#define TEE_ROUNDDOWN(v, size) ((v) & ~(size - 1))
+#define ROUNDDOWN(v, size) ((v) & ~(size - 1))
 
 #define TEE_U32_BSWAP(x) ( \
         (((x) & 0xff000000) >> 24) | \

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -538,7 +538,7 @@ static TEE_Result tee_buffer_update(
 
 	/* If we can feed from buffer */
 	if (op->buffer_offs > 0 && (op->buffer_offs + slen) > buffer_size) {
-		l = TEE_ROUNDUP(op->buffer_offs + slen - buffer_size,
+		l = ROUNDUP(op->buffer_offs + slen - buffer_size,
 				op->block_size);
 		l = MIN(op->buffer_offs, l);
 		tmp_dlen = dlen;
@@ -563,7 +563,7 @@ static TEE_Result tee_buffer_update(
 	if (slen > buffer_size) {
 		/* Buffer is empty, feed as much as possible from src */
 		if (TEE_ALIGNMENT_IS_OK(src, uint32_t)) {
-			l = TEE_ROUNDUP(slen - buffer_size + 1, op->block_size);
+			l = ROUNDUP(slen - buffer_size + 1, op->block_size);
 
 			tmp_dlen = dlen;
 			res = update_func(op->state, src, l, dst, &tmp_dlen);
@@ -855,7 +855,7 @@ TEE_Result TEE_AEUpdate(TEE_OperationHandle op, const void *srcData,
 	 * data to the algorithm. Errors during feeding of data are fatal as we
 	 * can't restore sync with this API.
 	 */
-	req_dlen = TEE_ROUNDDOWN(op->buffer_offs + srcLen, op->block_size);
+	req_dlen = ROUNDDOWN(op->buffer_offs + srcLen, op->block_size);
 	if (*destLen < req_dlen) {
 		*destLen = req_dlen;
 		return TEE_ERROR_SHORT_BUFFER;


### PR DESCRIPTION
This change is to have the same macro names in core
part and libutee part
