### PR TITLE
Cosmetic fixes for build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ include ta/ta.mk
 
 .PHONY: clean
 clean:
-	@echo Cleaning
+	@echo '  CLEAN   .'
 	${q}rm -f $(cleanfiles)
 
 .PHONY: cscope
 cscope:
-	@echo Creating cscope database
+	@echo '  CSCOPE  .'
 	${q}rm -f cscope.*
 	${q}find $(PWD) -name "*.[chSs]" > cscope.files
 	${q}cscope -b -q -k

--- a/core/arch/arm32/plat-stm/conf.mk
+++ b/core/arch/arm32/plat-stm/conf.mk
@@ -9,7 +9,7 @@ platform-cflags	 = -mcpu=$(platform-cpuarch) -mthumb
 platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
 platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
 platform-aflags	 = -mcpu=$(platform-cpuarch)
-core-platform-cppflags	 = -I$(arch-dir)/include
+core-platform-cppflags	 = -I$(arch-dir)include
 core-platform-cppflags	+= -DNUM_THREADS=2
 core-platform-cppflags	+= -DWITH_STACK_CANARIES=1
 user_ta-platform-cflags = -fpie
@@ -24,13 +24,13 @@ platform-cflags += -g
 platform-aflags += -g
 
 core-platform-subdirs += \
-	$(addprefix $(arch-dir)/, kernel mm sm tee sta) $(platform-dir)
+	$(addprefix $(arch-dir), kernel mm sm tee sta) $(patsubst %/,%,$(platform-dir))
 
 libutil_with_isoc := y
 WITH_PL310 := y
 
 include mk/config.mk
-include $(platform-dir)/system_config.in
+include $(platform-dir)system_config.in
 
 core-platform-cppflags += -DCFG_TEE_CORE_NB_CORE=$(CFG_TEE_CORE_NB_CORE)
 
@@ -77,10 +77,10 @@ SECONDARY_STARTUP_PHYS	 = $(shell echo $$((\
 else ifeq ($(PLATFORM_FLAVOR),orly2)
 
 PRIMARY_STARTUP_PHYS	 = \
-	0x$(shell grep stext $(platform-dir)/System.map | grep -v _stext | \
+	0x$(shell grep stext $(platform-dir)System.map | grep -v _stext | \
 		cut -d' ' -f 1)
 SECONDARY_STARTUP_PHYS	 = \
-	0x$(shell grep stm_secondary_startup $(platform-dir)/System.map | \
+	0x$(shell grep stm_secondary_startup $(platform-dir)System.map | \
 		cut -d' ' -f 1)
 else
 $(error PLATFORM_FLAVOR=$(PLATFORM_FLAVOR) is not supported)

--- a/core/arch/arm32/plat-stm/link.mk
+++ b/core/arch/arm32/plat-stm/link.mk
@@ -1,7 +1,7 @@
-link-out-dir = $(out-dir)/core/
+link-out-dir = $(out-dir)core/
 
-link-script = $(platform-dir)/tz-template.lds
-link-script-pp = $(link-out-dir)/tz.lds
+link-script = $(platform-dir)tz-template.lds
+link-script-pp = $(link-out-dir)tz.lds
 
 all: $(link-out-dir)tee.elf $(link-out-dir)tee.dmp $(link-out-dir)tee.bin
 all: $(link-out-dir)tee.symb_sizes
@@ -20,22 +20,22 @@ ldargs-tee.elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc)
 
 
 $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
-	@echo PP $<
+	@echo '  SED     $@'
 	$(q)sed -e "s/%in_TEE_SCATTER_START%/$(TEE_SCATTER_START)/g" < $< > $@
 
 
 $(link-out-dir)tee.elf: $(objs) $(libdeps) $(link-script-pp)
-	@echo LD $@
+	@echo '  LD      $@'
 	$(q)$(LD) $(ldargs-tee.elf) -o $@
 
 $(link-out-dir)tee.dmp: $(link-out-dir)tee.elf
-	@echo OBJDUMP $@
+	@echo '  OBJDUMP $@'
 	$(q)$(OBJDUMP) -l -x -d $< > $@
 
 $(link-out-dir)tee.bin: $(link-out-dir)tee.elf
-	@echo OBJCOPY $@
+	@echo '  OBJCOPY $@'
 	$(q)$(OBJCOPY) -O binary $< $@
 
 $(link-out-dir)tee.symb_sizes: $(link-out-dir)tee.elf
-	@echo Symb sizes $@
+	@echo '  GEN     $@'
 	$(q)$(NM) --print-size --reverse-sort --size-sort $< > $@

--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -10,7 +10,7 @@ platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
 platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
 platform-cflags += -mno-unaligned-access
 platform-aflags	 = -mcpu=$(platform-cpuarch)
-core-platform-cppflags	 = -I$(arch-dir)/include
+core-platform-cppflags	 = -I$(arch-dir)include
 core-platform-cppflags	+= -DNUM_THREADS=2
 core-platform-cppflags	+= -DWITH_STACK_CANARIES=1
 user_ta-platform-cflags = -fpie
@@ -35,9 +35,9 @@ platform-aflags += -g3
 endif
 
 core-platform-subdirs += \
-	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
+	$(addprefix $(arch-dir), kernel mm tee sta) $(patsubst %/,%,$(platform-dir))
 ifneq ($(PLATFORM_FLAVOR),fvp)
-core-platform-subdirs += $(arch-dir)/sm
+core-platform-subdirs += $(arch-dir)sm
 core-platform-cppflags += -DWITH_SEC_MON=1
 else
 core-platform-cppflags += -DWITH_ARM_TRUSTED_FW=1

--- a/core/arch/arm32/plat-vexpress/link.mk
+++ b/core/arch/arm32/plat-vexpress/link.mk
@@ -1,8 +1,8 @@
-link-out-dir = $(out-dir)/core/
+link-out-dir = $(out-dir)core/
 
-link-script = $(platform-dir)/kern.ld.S
-link-script-pp = $(link-out-dir)/kern.ld
-link-script-dep = $(link-out-dir)/.kern.ld.d
+link-script = $(platform-dir)kern.ld.S
+link-script-pp = $(link-out-dir)kern.ld
+link-script-dep = $(link-out-dir).kern.ld.d
 
 AWK	 = awk
 
@@ -31,24 +31,24 @@ link-script-cppflags :=  \
 -include $(link-script-dep)
 
 $(link-script-pp): $(link-script)
-	@echo PP $<
+	@echo '  CPP     $@'
 	@mkdir -p $(dir $@)
 	$(q)$(CPP) -Wp,-P,-MT,$@,-MD,$(link-script-dep) \
 		$(link-script-cppflags) $< > $@
 
 
 $(link-out-dir)tee.elf: $(objs) $(libdeps) $(link-script-pp)
-	@echo LD $@
+	@echo '  LD      $@'
 	$(q)$(LD) $(ldargs-tee.elf) -o $@
 
 $(link-out-dir)tee.dmp: $(link-out-dir)tee.elf
-	@echo OBJDUMP $@
+	@echo '  OBJDUMP $@'
 	$(q)$(OBJDUMP) -l -x -d $< > $@
 
 $(link-out-dir)tee.bin: $(link-out-dir)tee.elf
-	@echo OBJCOPY $@
+	@echo '  OBJCOPY $@'
 	$(q)$(OBJCOPY) -O binary $< $@
 
 $(link-out-dir)tee.symb_sizes: $(link-out-dir)tee.elf
-	@echo Symb sizes $@
+	@echo '  GEN     $@'
 	$(q)$(NM) --print-size --reverse-sort --size-sort $< > $@

--- a/core/core.mk
+++ b/core/core.mk
@@ -4,9 +4,9 @@ include mk/cleanvars.mk
 sm := core
 sm-$(sm) := y
 
-arch-dir	:= core/arch/$(ARCH)
-platform-dir	:= $(arch-dir)/plat-$(PLATFORM)
-include $(platform-dir)/conf.mk
+arch-dir	:= core/arch/$(ARCH)/
+platform-dir	:= $(arch-dir)plat-$(PLATFORM)/
+include $(platform-dir)conf.mk
 
 PLATFORM_FLAVOR ?= default
 platform_$(PLATFORM) := y
@@ -51,6 +51,6 @@ include mk/lib.mk
 subdirs = $(core-platform-subdirs) core
 include mk/subdir.mk
 include mk/compile.mk
-include $(platform-dir)/link.mk
+include $(platform-dir)link.mk
 
 

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -97,7 +97,7 @@ $2: $1 FORCE
 	    $$(filter-out $$(old-cmd-$2), $$(comp-cmd-$2))), \
 		@set -e ;\
 		mkdir -p $$(dir $2) ;\
-		echo [$$(comp-sm-$2)] CC $1 ;\
+		echo '  CC      $$@' ;\
 		$(cmd-echo) $$(subst \",\\\",$$(comp-cmd-$2)) ;\
 		$$(comp-cmd-$2) ;\
 		echo "old-cmd-$2 := $$(subst \",\\\",$$(comp-cmd-$2))" > \

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -22,7 +22,7 @@ libnames	:= $(libname) $(libnames)
 libdeps		:= $(lib-libfile) $(libdeps) 
 
 $(lib-libfile): $(objs)
-	@echo AR $@
+	@echo '  AR      $@'
 	@mkdir -p $(dir $@)
 	$(q)$(AR) rcs $@ $^
 

--- a/ta/arch/arm32/link.mk
+++ b/ta/arch/arm32/link.mk
@@ -28,19 +28,19 @@ ldargs-$(binary).elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc)
 
 
 $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
-	@echo PP $<
+	@echo '  CPP     $@'
 	$(q)cat < $< > $@
 
 
 $(link-out-dir)$(binary).elf: $(objs) $(libdeps) $(link-script-pp)
-	@echo LD $@
+	@echo '  LD      $@'
 	$(q)$(LD) $(ldargs-$(binary).elf) -o $@
 
 $(link-out-dir)$(binary).dmp: $(link-out-dir)$(binary).elf
-	@echo OBJDUMP $@
+	@echo '  OBJDUMP $@'
 	$(q)$(OBJDUMP) -l -x -d $< > $@
 
 $(link-out-dir)$(binary).bin: $(link-out-dir)$(binary).elf
-	@echo OBJCOPY $@
+	@echo '  OBJCOPY $@'
 	$(q)$(OBJCOPY) -O binary $< $@
 	$(q)$(FIX_TA_BINARY) $< $@

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -43,7 +43,7 @@ libdeps += $(ta-dev-kit-dir)/lib/libutee.a
 
 .PHONY: clean
 clean:
-	@echo Cleaning
+	@echo '  CLEAN   .'
 	${q}rm -f $(cleanfiles)
 
 

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -37,7 +37,9 @@ incdirs-host := $(filter-out lib/libutils%, $(incdirs$(sm)))
 
 define copy-file
 $2/$$(notdir $1): $1
-	@mkdir -p $$(dir $$@)
+	@set -e; \
+	mkdir -p $$(dir $$@) ; \
+	echo '  INSTALL $$@' ; \
 	cp $$< $$@
 
 cleanfiles += $2/$$(notdir $1)
@@ -59,7 +61,7 @@ $(foreach f, $(ta-mkfiles), \
 define copy-incdir
 sf := $(subst $1/, , $(shell find $1 -name "*.h"))
 $$(foreach h, $$(sf), $$(eval $$(call copy-file, $1/$$(h), \
-	$$(subst /./,/,$2/$$(dir $$(h))))))
+	$$(patsubst %/,%,$$(subst /./,/,$2/$$(dir $$(h)))))))
 endef
 $(foreach d, $(incdirs$(sm)), \
 	$(eval $(call copy-incdir, $(d), $(out-dir)export-user_ta/include)))


### PR DESCRIPTION
By default, the OP-TEE build shows abbreviated output similar to the Linux
kernel. This commit fixes a number of deviations/inconsistencies.
- Always print a command in uppercase, followed by the target file.
- Make sure commands and file paths are nicely aligned, with two leading spaces
  to make command output/errors better stand out.
- Remove some duplicate slashes in file paths. We use the following rule:
  variables that hold directory names such as $(arch-dir) or $(platform-dir)
  always have a trailing slash. The 'subdirs' and 'incdirs' variables used in
  sub-makefiles are an exception because doing otherwise would needlessly
  clutter the sub-makefiles.
