### PR TITLE
Generic secure time layer

### DIFF
--- a/core/arch/arm32/include/kernel/time_source.h
+++ b/core/arch/arm32/include/kernel/time_source.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <kernel/tee_time.h>
+
+struct time_source {
+	const char *name;
+	TEE_Result (*get_sys_time)(TEE_Time *time);
+	void (*wait_specific)(uint32_t milliseconds_delay);
+};
+void time_source_init(void);
+
+#define REGISTER_TIME_SOURCE(source)	\
+	void time_source_init(void) { \
+		_time_source = source; \
+	}
+
+extern struct time_source _time_source;

--- a/core/arch/arm32/include/kernel/time_source.h
+++ b/core/arch/arm32/include/kernel/time_source.h
@@ -30,7 +30,6 @@
 struct time_source {
 	const char *name;
 	TEE_Result (*get_sys_time)(TEE_Time *time);
-	void (*wait_specific)(uint32_t milliseconds_delay);
 };
 void time_source_init(void);
 

--- a/core/arch/arm32/kernel/sub.mk
+++ b/core/arch/arm32/kernel/sub.mk
@@ -12,7 +12,10 @@ srcs-y += tee_sleep_services.c
 cflags-tee_sleep_services.c-y += -Wno-unused-parameter
 
 srcs-y += tee_time.c
-cflags-tee_time.c-y += -Wno-unused-parameter
+
+srcs-$(WITH_SECURE_TIME_SOURCE_CNTPCT) += tee_time_arm_cntpct.c
+srcs-$(WITH_SECURE_TIME_SOURCE_RTT) += tee_time_rtt.c
+srcs-$(WITH_SECURE_TIME_SOURCE_REE) += tee_time_ree.c
 
 srcs-y += chip_services.c
 

--- a/core/arch/arm32/kernel/tee_time.c
+++ b/core/arch/arm32/kernel/tee_time.c
@@ -27,175 +27,24 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <io.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/tee_time.h>
-#include <utee_defines.h>
-#include <kernel/tee_time_unpg.h>
-#include <kernel/tee_core_trace.h>
+#include <kernel/time_source.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <sm/teesmc.h>
 #include <kernel/tee_rpc.h>
 #include <mm/core_mmu.h>
 
-#define TEE_TIME_SHIFT 5
-
-#define TEE_RTT0_HZ                 32768UL
-
-#define TEE_RTT0_TICKS_PER_SECOND   (TEE_RTT0_HZ)
-#define TEE_RTT0_TICKS_PER_MINUTE   (TEE_RTT0_TICKS_PER_SECOND * 60)
-#define TEE_RTT0_TICKS_PER_HOUR     (TEE_RTT0_TICKS_PER_MINUTE * 60)
-
-/* We'll receive one interrupt per hour */
-#define TEE_RTT0_WRAP_TICKS         TEE_RTT0_TICKS_PER_HOUR
-
-#define TEE_RTT1_HZ                 10UL
-#define TEE_RTT1_WRAP_TICKS         0xffffffff
-
-/*
- * Following is code example that could be used to activate time
- * functionalities in TEE for arm32
- *
-TEE_Result tee_time_init(void)
-{
-	- Disable timer and later change to 32kHz
-	IO(RTT0_CR) &= ~RTT_CR_EN;
-
-	if (!(IO(RTT1_CR) & RTT_CR_EN)) {
-		IO(RTT1_IMSC) |= RTT_IMSC_IMSC;	        - disable interrupts
-		IO(RTT1_LR) = TEE_RTT1_WRAP_TICKS;	- start the timer
-
-		TEE_COMPILE_TIME_ASSERT(TEE_RTT1_HZ == TEE_TIME_BOOT_TICKS_HZ);
-	}
-
-	return TEE_SUCCESS;
-}
-
-uint32_t tee_time_get_boot_ticks(void)
-{
-	return TEE_RTT1_WRAP_TICKS - IO(RTT1_DR);
-}
-
-uint32_t tee_time_get_boot_time_in_seconds(void)
-{
-	return tee_time_get_boot_ticks() / TEE_RTT1_HZ;
-}
-*/
-
-static void tee_time_rtt0_init(void)
-{
-	static bool inited; /* initialized to false */
-
-	if (!inited) {
-		volatile uint32_t *cr = (uint32_t *)RTT0_CR;
-		volatile uint32_t *ctcr = (uint32_t *)RTT0_CTCR;
-		volatile uint32_t *lr = (uint32_t *)RTT0_LR;
-		volatile uint32_t *imsc = (uint32_t *)RTT0_IMSC;
-
-		DMSG("tee_time_rtt0_init: First call may take a few secs");
-
-		/*
-		 * Make sure timer is disabled. RTT_CR_EN is not accurate,
-		 * enabling can be in progress too. Checking *ctcr takes
-		 * care of that since updates to ctcr only propagates once
-		 * timer really is disabled.
-		 */
-		while (*ctcr != 0 || (*cr & (RTT_CR_EN | RTT_CR_ENS)) != 0) {
-			*cr &= ~RTT_CR_EN;
-			*ctcr = 0;
-		}
-
-		/* Change to 32kHz */
-		*ctcr = 0;
-
-		/* Enable interrupts on wrap */
-		*imsc |= RTT_IMSC_IMSC;
-
-		/* Start with the desired interrupt interval */
-		*lr = TEE_RTT0_WRAP_TICKS;
-
-		inited = true;
-	}
-}
-
-
-/*
- * Following is code example that could be used to activate time
- * functionalities in TEE for arm32
- *
-TEE_Result tee_time_stamp(uint32_t *stamp)
-{
-	tee_time_rtt0_init();
-
-	*stamp = IO(RTT0_DR);
-
-	return TEE_SUCCESS;
-}
-
-TEE_Result tee_time_get(uint32_t stamp, uint32_t *time)
-{
-	TEE_Result res;
-	uint32_t val;
-
-	res = tee_time_stamp(&val);
-	if (res != TEE_SUCCESS)
-		return res;
-
-	*time = (stamp - val) >> TEE_TIME_SHIFT;
-
-	return TEE_SUCCESS;
-}
-
-TEE_Result tee_time_secure_rtc_update(const void *time, uint32_t time_size)
-{
-	return TEE_SUCCESS;
-}
-
-TEE_Result tee_time_secure_rtc_update_check(bool *ok)
-{
-	*ok = true;
-	return TEE_SUCCESS;
-}
-*/
+struct time_source _time_source;
 
 TEE_Result tee_time_get_sys_time(TEE_Time *time)
 {
-	uint32_t wrap0;
-	uint32_t wrap;
-	uint32_t timer;
-
-	/* Stub system time support until a HW secure timer is supported */
-	return tee_time_get_ree_time(time);
-
-	tee_time_rtt0_init();
-
-	/*
-	 * Reading wrap before and after we're reading DR to be able to
-	 * detect if the timer wrapped while we where reading it.
-	 */
-	do {
-		wrap0 = tee_time_rtt0_wrap;
-		timer = TEE_RTT0_WRAP_TICKS - IO(RTT0_DR);
-		wrap = tee_time_rtt0_wrap;
-	} while (wrap0 != wrap);
-
-	time->seconds = wrap * TEE_RTT0_WRAP_TICKS / TEE_RTT0_HZ +
-	    timer / TEE_RTT0_HZ;
-	time->millis =
-	    (timer % TEE_RTT0_HZ) / (TEE_RTT0_HZ / TEE_TIME_MILLIS_BASE);
-
-	return TEE_SUCCESS;
+	return _time_source.get_sys_time(time);
 }
 
 void tee_wait_specific(uint32_t milliseconds_delay)
 {
-	/*
-	 * Any implementation must check it is secure, and robust to idle states
-	 * of the arm
-	 */
-	/* usleep to be implemented */
-	/* usleep(milliseconds_delay * 1000); */
+	_time_source.wait_specific(milliseconds_delay);
 }
 
 /*

--- a/core/arch/arm32/kernel/tee_time.c
+++ b/core/arch/arm32/kernel/tee_time.c
@@ -42,9 +42,47 @@ TEE_Result tee_time_get_sys_time(TEE_Time *time)
 	return _time_source.get_sys_time(time);
 }
 
-void tee_wait_specific(uint32_t milliseconds_delay)
+void tee_time_wait(uint32_t milliseconds_delay)
 {
-	_time_source.wait_specific(milliseconds_delay);
+	struct tee_ta_session *sess = NULL;
+	struct teesmc32_arg *arg;
+	struct teesmc32_param *params;
+	const size_t num_params = 1;
+	paddr_t pharg = 0;
+
+	tee_ta_get_current_session(&sess);
+	if (sess)
+		tee_ta_set_current_session(NULL);
+
+	pharg = thread_rpc_alloc_arg(TEESMC32_GET_ARG_SIZE(num_params));
+
+	/*
+	 * If allocation fails, spin on the mutex, maybe there's another
+	 * thread that will release the mutex. The only other option is to
+	 * panic.
+	 */
+
+	if (!pharg)
+		goto exit;
+
+	if (!TEE_ALIGNMENT_IS_OK(pharg, struct teesmc32_arg))
+		goto exit;
+
+	if (core_pa2va(pharg, (uint32_t *)&arg))
+		goto exit;
+
+	arg->cmd = TEE_RPC_WAIT;
+	arg->ret = TEE_ERROR_GENERIC;
+	arg->num_params = num_params;
+	params = TEESMC32_GET_PARAMS(arg);
+	params[0].attr = TEESMC_ATTR_TYPE_VALUE_INPUT;
+	params[0].u.value.a = milliseconds_delay;
+
+	thread_rpc_cmd(pharg);
+exit:
+	thread_rpc_free_arg(pharg);
+	if (sess)
+		tee_ta_set_current_session(sess);
 }
 
 /*

--- a/core/arch/arm32/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm32/kernel/tee_time_arm_cntpct.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <kernel/misc.h>
+#include <kernel/tee_time.h>
+#include <kernel/tee_core_trace.h>
+#include <kernel/time_source.h>
+#include <mm/core_mmu.h>
+#include <utee_defines.h>
+
+#include <assert.h>
+#include <stdint.h>
+#include <mpa.h>
+
+static uint32_t do_div(uint64_t *dividend, uint32_t divisor)
+{
+	mpa_word_t remainder = 0, n0, n1;
+	n0 = (*dividend) & UINT_MAX;
+	n1 = ((*dividend) >> WORD_SIZE) & UINT_MAX;
+	*dividend = __mpa_div_dword(n0, n1, divisor, &remainder);
+	return remainder;
+}
+
+static uint64_t read_cntpct(void)
+{
+	uint64_t val;
+	uint32_t low, high;
+	__asm__ volatile("mrrc	p15, 0, %0, %1, c14\n"
+		: "=r"(low), "=r"(high)
+		:
+		: "memory");
+	val = low | ((uint64_t)high << WORD_SIZE);
+	return val;
+}
+
+static uint32_t read_cntfrq(void)
+{
+	uint32_t frq;
+	__asm__ volatile("mrc	p15, 0, %0, c14, c0, 0\n"
+		: "=r"(frq)
+		:
+		: "memory");
+	return frq;
+}
+
+static uint64_t usec_to_tick(uint32_t usec)
+{
+	uint64_t tick = usec;
+	tick *= read_cntfrq();
+	do_div(&tick, 1000000);
+	return tick;
+}
+
+static TEE_Result arm_cntpct_get_sys_time(TEE_Time *time)
+{
+	uint64_t cntpct = read_cntpct();
+	uint32_t cntfrq = read_cntfrq();
+	uint32_t remainder;
+
+	remainder = do_div(&cntpct, cntfrq);
+
+	time->seconds = (uint32_t)cntpct;
+	time->millis = remainder / (cntfrq / TEE_TIME_MILLIS_BASE);
+
+	return TEE_SUCCESS;
+}
+
+static void arm_cntpct_wait_specific(uint32_t milliseconds_delay)
+{
+	/*
+	 * Any implementation must check it is secure, and robust to idle states
+	 * of the arm
+	 */
+	uint64_t delta_tick = usec_to_tick(milliseconds_delay * 1000);
+	uint64_t target_tick = read_cntpct() + delta_tick;
+
+	while (target_tick > read_cntpct());
+}
+
+static const struct time_source arm_cntpct_time_source = {
+	.name = "arm cntpct",
+	.get_sys_time = arm_cntpct_get_sys_time,
+	.wait_specific = arm_cntpct_wait_specific
+};
+
+REGISTER_TIME_SOURCE(arm_cntpct_time_source)

--- a/core/arch/arm32/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm32/kernel/tee_time_arm_cntpct.c
@@ -67,14 +67,6 @@ static uint32_t read_cntfrq(void)
 	return frq;
 }
 
-static uint64_t usec_to_tick(uint32_t usec)
-{
-	uint64_t tick = usec;
-	tick *= read_cntfrq();
-	do_div(&tick, 1000000);
-	return tick;
-}
-
 static TEE_Result arm_cntpct_get_sys_time(TEE_Time *time)
 {
 	uint64_t cntpct = read_cntpct();
@@ -89,22 +81,9 @@ static TEE_Result arm_cntpct_get_sys_time(TEE_Time *time)
 	return TEE_SUCCESS;
 }
 
-static void arm_cntpct_wait_specific(uint32_t milliseconds_delay)
-{
-	/*
-	 * Any implementation must check it is secure, and robust to idle states
-	 * of the arm
-	 */
-	uint64_t delta_tick = usec_to_tick(milliseconds_delay * 1000);
-	uint64_t target_tick = read_cntpct() + delta_tick;
-
-	while (target_tick > read_cntpct());
-}
-
 static const struct time_source arm_cntpct_time_source = {
 	.name = "arm cntpct",
 	.get_sys_time = arm_cntpct_get_sys_time,
-	.wait_specific = arm_cntpct_wait_specific
 };
 
 REGISTER_TIME_SOURCE(arm_cntpct_time_source)

--- a/core/arch/arm32/kernel/tee_time_ree.c
+++ b/core/arch/arm32/kernel/tee_time_ree.c
@@ -28,21 +28,9 @@
 #include <kernel/tee_time.h>
 #include <kernel/time_source.h>
 
-static void ree_wait_specific(uint32_t milliseconds_delay)
-{
-	(void)&milliseconds_delay;
-	/*
-	 * Any implementation must check it is secure, and robust to idle states
-	 * of the arm
-	 */
-	/* usleep to be implemented */
-	/* usleep(milliseconds_delay * 1000); */
-}
-
 static const struct time_source ree_time_source = {
 	.name = "ree",
 	.get_sys_time = tee_time_get_ree_time,
-	.wait_specific = ree_wait_specific,
 };
 
 REGISTER_TIME_SOURCE(ree_time_source)

--- a/core/arch/arm32/kernel/tee_time_ree.c
+++ b/core/arch/arm32/kernel/tee_time_ree.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <kernel/tee_time.h>
+#include <kernel/time_source.h>
+
+static void ree_wait_specific(uint32_t milliseconds_delay)
+{
+	(void)&milliseconds_delay;
+	/*
+	 * Any implementation must check it is secure, and robust to idle states
+	 * of the arm
+	 */
+	/* usleep to be implemented */
+	/* usleep(milliseconds_delay * 1000); */
+}
+
+static const struct time_source ree_time_source = {
+	.name = "ree",
+	.get_sys_time = tee_time_get_ree_time,
+	.wait_specific = ree_wait_specific,
+};
+
+REGISTER_TIME_SOURCE(ree_time_source)

--- a/core/arch/arm32/kernel/tee_time_rtt.c
+++ b/core/arch/arm32/kernel/tee_time_rtt.c
@@ -178,21 +178,9 @@ static TEE_Result rtt_get_sys_time(TEE_Time *time)
 	return TEE_SUCCESS;
 }
 
-static void rtt_wait_specific(uint32_t milliseconds_delay)
-{
-	(void)&milliseconds_delay;
-	/*
-	 * Any implementation must check it is secure, and robust to idle states
-	 * of the arm
-	 */
-	/* usleep to be implemented */
-	/* usleep(milliseconds_delay * 1000); */
-}
-
 static const struct time_source rtt_time_source = {
 	.name = "rtt0",
 	.get_sys_time = rtt_get_sys_time,
-	.wait_specific = rtt_wait_specific,
 };
 
 REGISTER_TIME_SOURCE(rtt_time_source)

--- a/core/arch/arm32/kernel/tee_time_rtt.c
+++ b/core/arch/arm32/kernel/tee_time_rtt.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <io.h>
+#include <kernel/tee_common_unpg.h>
+#include <kernel/tee_time.h>
+#include <kernel/tee_time_unpg.h>
+#include <kernel/time_source.h>
+#include <kernel/tee_core_trace.h>
+#include <utee_defines.h>
+
+#define TEE_TIME_SHIFT 5
+
+#define TEE_RTT0_HZ                 32768UL
+
+#define TEE_RTT0_TICKS_PER_SECOND   (TEE_RTT0_HZ)
+#define TEE_RTT0_TICKS_PER_MINUTE   (TEE_RTT0_TICKS_PER_SECOND * 60)
+#define TEE_RTT0_TICKS_PER_HOUR     (TEE_RTT0_TICKS_PER_MINUTE * 60)
+
+/* We'll receive one interrupt per hour */
+#define TEE_RTT0_WRAP_TICKS         TEE_RTT0_TICKS_PER_HOUR
+
+#define TEE_RTT1_HZ                 10UL
+#define TEE_RTT1_WRAP_TICKS         0xffffffff
+
+/*
+ * Following is code example that could be used to activate time
+ * functionalities in TEE for arm32
+ *
+TEE_Result tee_time_init(void)
+{
+	- Disable timer and later change to 32kHz
+	IO(RTT0_CR) &= ~RTT_CR_EN;
+
+	if (!(IO(RTT1_CR) & RTT_CR_EN)) {
+		IO(RTT1_IMSC) |= RTT_IMSC_IMSC;	        - disable interrupts
+		IO(RTT1_LR) = TEE_RTT1_WRAP_TICKS;	- start the timer
+
+		TEE_COMPILE_TIME_ASSERT(TEE_RTT1_HZ == TEE_TIME_BOOT_TICKS_HZ);
+	}
+
+	return TEE_SUCCESS;
+}
+
+uint32_t tee_time_get_boot_ticks(void)
+{
+	return TEE_RTT1_WRAP_TICKS - IO(RTT1_DR);
+}
+
+uint32_t tee_time_get_boot_time_in_seconds(void)
+{
+	return tee_time_get_boot_ticks() / TEE_RTT1_HZ;
+}
+*/
+
+static void tee_time_rtt0_init(void)
+{
+	static bool inited; /* initialized to false */
+
+	if (!inited) {
+		volatile uint32_t *cr = (uint32_t *)RTT0_CR;
+		volatile uint32_t *ctcr = (uint32_t *)RTT0_CTCR;
+		volatile uint32_t *lr = (uint32_t *)RTT0_LR;
+		volatile uint32_t *imsc = (uint32_t *)RTT0_IMSC;
+
+		DMSG("tee_time_rtt0_init: First call may take a few secs");
+
+		/*
+		 * Make sure timer is disabled. RTT_CR_EN is not accurate,
+		 * enabling can be in progress too. Checking *ctcr takes
+		 * care of that since updates to ctcr only propagates once
+		 * timer really is disabled.
+		 */
+		while (*ctcr != 0 || (*cr & (RTT_CR_EN | RTT_CR_ENS)) != 0) {
+			*cr &= ~RTT_CR_EN;
+			*ctcr = 0;
+		}
+
+		/* Change to 32kHz */
+		*ctcr = 0;
+
+		/* Enable interrupts on wrap */
+		*imsc |= RTT_IMSC_IMSC;
+
+		/* Start with the desired interrupt interval */
+		*lr = TEE_RTT0_WRAP_TICKS;
+
+		inited = true;
+	}
+}
+
+/*
+ * Following is code example that could be used to activate time
+ * functionalities in TEE for arm32
+ *
+TEE_Result tee_time_stamp(uint32_t *stamp)
+{
+	tee_time_rtt0_init();
+
+	*stamp = IO(RTT0_DR);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result tee_time_get(uint32_t stamp, uint32_t *time)
+{
+	TEE_Result res;
+	uint32_t val;
+
+	res = tee_time_stamp(&val);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	*time = (stamp - val) >> TEE_TIME_SHIFT;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result tee_time_secure_rtc_update(const void *time, uint32_t time_size)
+{
+	return TEE_SUCCESS;
+}
+
+TEE_Result tee_time_secure_rtc_update_check(bool *ok)
+{
+	*ok = true;
+	return TEE_SUCCESS;
+}
+*/
+
+static TEE_Result rtt_get_sys_time(TEE_Time *time)
+{
+	uint32_t wrap0;
+	uint32_t wrap;
+	uint32_t timer;
+
+	tee_time_rtt0_init();
+
+	/*
+	 * Reading wrap before and after we're reading DR to be able to
+	 * detect if the timer wrapped while we where reading it.
+	 */
+	do {
+		wrap0 = tee_time_rtt0_wrap;
+		timer = TEE_RTT0_WRAP_TICKS - IO(RTT0_DR);
+		wrap = tee_time_rtt0_wrap;
+	} while (wrap0 != wrap);
+
+	time->seconds = wrap * TEE_RTT0_WRAP_TICKS / TEE_RTT0_HZ +
+	    timer / TEE_RTT0_HZ;
+	time->millis =
+	    (timer % TEE_RTT0_HZ) / (TEE_RTT0_HZ / TEE_TIME_MILLIS_BASE);
+
+	return TEE_SUCCESS;
+}
+
+static void rtt_wait_specific(uint32_t milliseconds_delay)
+{
+	(void)&milliseconds_delay;
+	/*
+	 * Any implementation must check it is secure, and robust to idle states
+	 * of the arm
+	 */
+	/* usleep to be implemented */
+	/* usleep(milliseconds_delay * 1000); */
+}
+
+static const struct time_source rtt_time_source = {
+	.name = "rtt0",
+	.get_sys_time = rtt_get_sys_time,
+	.wait_specific = rtt_wait_specific,
+};
+
+REGISTER_TIME_SOURCE(rtt_time_source)

--- a/core/arch/arm32/plat-stm/conf.mk
+++ b/core/arch/arm32/plat-stm/conf.mk
@@ -28,6 +28,7 @@ core-platform-subdirs += \
 
 libutil_with_isoc := y
 WITH_PL310 := y
+WITH_SECURE_TIME_SOURCE_REE := y
 
 include mk/config.mk
 include $(platform-dir)/system_config.in

--- a/core/arch/arm32/plat-stm/main.c
+++ b/core/arch/arm32/plat-stm/main.c
@@ -38,6 +38,7 @@
 
 #include <arm32.h>
 #include <kernel/thread.h>
+#include <kernel/time_source.h>
 #include <kernel/panic.h>
 #include <kernel/util.h>
 #include <kernel/tee_core_trace.h>
@@ -179,6 +180,7 @@ void main_init(uint32_t nsec_entry)
 		panic();
 
 	thread_init_handlers(&handlers);
+	time_source_init();
 
 	/* Initialize secure monitor */
 	sm_init(GET_STACK(stack_sm[pos]));

--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -50,6 +50,7 @@ core-platform-cppflags += \
 endif
 
 libutil_with_isoc := y
+WITH_SECURE_TIME_SOURCE_CNTPCT := y
 
 include mk/config.mk
 

--- a/core/arch/arm32/plat-vexpress/main.c
+++ b/core/arch/arm32/plat-vexpress/main.c
@@ -44,9 +44,11 @@
 
 #include <arm32.h>
 #include <kernel/thread.h>
+#include <kernel/time_source.h>
 #include <kernel/panic.h>
 #include <kernel/tee_core_trace.h>
 #include <kernel/misc.h>
+#include <kernel/tee_time.h>
 #include <mm/tee_pager_unpg.h>
 #include <mm/core_mmu.h>
 #include <tee/entry.h>
@@ -310,6 +312,7 @@ static void main_init_helper(bool is_primary, size_t pos, uint32_t nsec_entry)
 		panic();
 
 	thread_init_handlers(&handlers);
+	time_source_init();
 
 	main_init_sec_mon(pos, nsec_entry);
 

--- a/core/include/kernel/tee_rpc.h
+++ b/core/include/kernel/tee_rpc.h
@@ -42,6 +42,7 @@
 #define TEE_WAIT_MUTEX_SLEEP	0
 #define TEE_WAIT_MUTEX_WAKEUP	1
 #define TEE_WAIT_MUTEX_DELETE	2
+#define TEE_RPC_WAIT		0x30000000
 
 
 #endif

--- a/core/include/kernel/tee_time.h
+++ b/core/include/kernel/tee_time.h
@@ -39,6 +39,6 @@ TEE_Result tee_time_get_sys_time(TEE_Time *time);
 TEE_Result tee_time_get_ta_time(const TEE_UUID *uuid, TEE_Time *time);
 TEE_Result tee_time_get_ree_time(TEE_Time *time);
 TEE_Result tee_time_set_ta_time(const TEE_UUID *uuid, const TEE_Time *time);
-void tee_wait_specific(uint32_t milliseconds_delay);
+void tee_time_wait(uint32_t milliseconds_delay);
 
 #endif

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -782,7 +782,7 @@ TEE_Result tee_svc_wait(uint32_t timeout)
 		if (mytime >= timeout)
 			return TEE_SUCCESS;
 
-		tee_wait_specific(timeout - mytime);
+		tee_time_wait(timeout - mytime);
 	}
 
 	return res;


### PR DESCRIPTION
Provided a time source api in order to let soc vendors implement their
own secure counter
- Moved platform-dependent code out of tee_time.c to make it a generic
  time layer.
- Added an abstract layer for platforms to implement their own secure
  time source.
- Implemented arm cntpct as one of secure time source.
- Moved rtt0 related time operation from tee_time.c to tee_time_rtt.c,
  act as another secure time source.
- Added tee_time_ree.c for the plaform that doesn't have secure time
  source. In this case, using ree time as secure time source.
