### PR TITLE
MMU: Simplify tee_mmu_switch function

### DIFF
--- a/core/arch/arm32/include/arm32_macros.S
+++ b/core/arch/arm32/include/arm32_macros.S
@@ -25,6 +25,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+        /* Please keep them sorted based on the CRn register */
+	.macro read_mpidr reg
+	mrc	p15, 0, \reg, c0, c0, 5
+	.endm
+
 	.macro read_sctlr reg
 	mrc	p15, 0, \reg, c1, c0, 0
 	.endm
@@ -41,8 +46,8 @@
 	mcr	p15, 0, \reg, c1, c1, 0
 	.endm
 
-	.macro read_mpidr reg
-	mrc	p15, 0, \reg, c0, c0, 5
+	.macro write_ttbr0 reg
+	mcr	p15, 0, \reg, c2, c0, 0
 	.endm
 
 	.macro write_vbar reg
@@ -50,5 +55,9 @@
 	.endm
 
 	.macro write_mvbar reg
-	mcr     p15, 0, \reg, c12, c0, 1
+	mcr	p15, 0, \reg, c12, c0, 1
+	.endm
+
+	.macro write_context_id reg
+	mcr	p15, 0, \reg, c13, c0, 1
 	.endm

--- a/core/arch/arm32/mm/tee_mmu_unpg_asm.S
+++ b/core/arch/arm32/mm/tee_mmu_unpg_asm.S
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arm32_macros.S>
 #include <kernel/tz_proc_def.h>
 
         .global tee_mmu_switch
@@ -45,28 +46,22 @@
          */
         .func tee_mmu_switch
 tee_mmu_switch:
+        mrs     r3, cpsr        /* Save CPSR for later use */
+        cpsid   if              /* Disable both IRQ and FIQ */
 
-        /* save/mask IRQs/FIQs */
-        mrs     r2, cpsr
-        and     r3, r2, #CPSR_FIQ_IRQ_MASK
-        orr     r2, r2, #CPSR_FIQ_IRQ_MASK
-        msr     cpsr_cxsf, r2
-        /* set reserved context id */
+        /* Update the reserved Context ID and TTBR0 in CP15 */
         dsb                     /* ARM erratum 754322 */
         mov     r2, #0
-        mcr     p15, 0, r2, c13, c0, 1
+        write_context_id r2     /* Clear the CONTEXTIDR register */
+
         isb
-        /* set ttbr0 */
-        mcr     p15, 0, r0, c2, c0, 0
+        write_ttbr0 r0          /* Update TTBR0 with value from function arg. */
+
         isb
-        /* set context id */
-        mcr     p15, 0, r1, c13, c0, 1
+        write_context_id r1     /* Write Context ID from function arg. */
+
         isb
-        /* restore irq/fiq mask */
-        mrs     r1, cpsr
-        bic     r1, r1, #CPSR_FIQ_IRQ_MASK
-        orr     r1, r1, r3
-        msr     cpsr_cxsf, r1
+        msr     cpsr_cxsf, r3   /* Restore the saved CPSR */
 
         bx      lr
         .endfunc


### PR DESCRIPTION
Replaced direct CP15 instructions with macros instead and removed some
unnecessary code.
