### PR TITLE
Makefile variables $(*-dir) should not have a trailing slash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ O		?= out/$(ARCH)-plat-$(PLATFORM)
 arch_$(ARCH)	:= y
 
 ifneq ($O,)
-out-dir := $O/
+out-dir := $O
 endif
 
 ifneq ($V,1)

--- a/core/arch/arm32/plat-stm/conf.mk
+++ b/core/arch/arm32/plat-stm/conf.mk
@@ -9,7 +9,7 @@ platform-cflags	 = -mcpu=$(platform-cpuarch) -mthumb
 platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
 platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
 platform-aflags	 = -mcpu=$(platform-cpuarch)
-core-platform-cppflags	 = -I$(arch-dir)include
+core-platform-cppflags	 = -I$(arch-dir)/include
 core-platform-cppflags	+= -DNUM_THREADS=2
 core-platform-cppflags	+= -DWITH_STACK_CANARIES=1
 user_ta-platform-cflags = -fpie
@@ -24,13 +24,13 @@ platform-cflags += -g
 platform-aflags += -g
 
 core-platform-subdirs += \
-	$(addprefix $(arch-dir), kernel mm sm tee sta) $(patsubst %/,%,$(platform-dir))
+	$(addprefix $(arch-dir)/, kernel mm sm tee sta) $(platform-dir)
 
 libutil_with_isoc := y
 WITH_PL310 := y
 
 include mk/config.mk
-include $(platform-dir)system_config.in
+include $(platform-dir)/system_config.in
 
 core-platform-cppflags += -DCFG_TEE_CORE_NB_CORE=$(CFG_TEE_CORE_NB_CORE)
 
@@ -77,10 +77,10 @@ SECONDARY_STARTUP_PHYS	 = $(shell echo $$((\
 else ifeq ($(PLATFORM_FLAVOR),orly2)
 
 PRIMARY_STARTUP_PHYS	 = \
-	0x$(shell grep stext $(platform-dir)System.map | grep -v _stext | \
+	0x$(shell grep stext $(platform-dir)/System.map | grep -v _stext | \
 		cut -d' ' -f 1)
 SECONDARY_STARTUP_PHYS	 = \
-	0x$(shell grep stm_secondary_startup $(platform-dir)System.map | \
+	0x$(shell grep stm_secondary_startup $(platform-dir)/System.map | \
 		cut -d' ' -f 1)
 else
 $(error PLATFORM_FLAVOR=$(PLATFORM_FLAVOR) is not supported)

--- a/core/arch/arm32/plat-stm/link.mk
+++ b/core/arch/arm32/plat-stm/link.mk
@@ -1,17 +1,17 @@
-link-out-dir = $(out-dir)core/
+link-out-dir = $(out-dir)/core
 
-link-script = $(platform-dir)tz-template.lds
-link-script-pp = $(link-out-dir)tz.lds
+link-script = $(platform-dir)/tz-template.lds
+link-script-pp = $(link-out-dir)/tz.lds
 
-all: $(link-out-dir)tee.elf $(link-out-dir)tee.dmp $(link-out-dir)tee.bin
-all: $(link-out-dir)tee.symb_sizes
-cleanfiles += $(link-out-dir)tee.elf $(link-out-dir)tee.dmp $(link-out-dir)tee.map
-cleanfiles += $(link-out-dir)tee.bin
-cleanfiles += $(link-out-dir)tee.symb_sizes
+all: $(link-out-dir)/tee.elf $(link-out-dir)/tee.dmp $(link-out-dir)/tee.bin
+all: $(link-out-dir)/tee.symb_sizes
+cleanfiles += $(link-out-dir)/tee.elf $(link-out-dir)/tee.dmp $(link-out-dir)/tee.map
+cleanfiles += $(link-out-dir)/tee.bin
+cleanfiles += $(link-out-dir)/tee.symb_sizes
 cleanfiles += $(link-script-pp)
 
 link-ldflags  = $(LDFLAGS)
-link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)tee.map
+link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
 link-ldflags += --sort-section=alignment
 
 link-ldadd  = $(LDADD)
@@ -24,18 +24,18 @@ $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
 	$(q)sed -e "s/%in_TEE_SCATTER_START%/$(TEE_SCATTER_START)/g" < $< > $@
 
 
-$(link-out-dir)tee.elf: $(objs) $(libdeps) $(link-script-pp)
+$(link-out-dir)/tee.elf: $(objs) $(libdeps) $(link-script-pp)
 	@echo '  LD      $@'
 	$(q)$(LD) $(ldargs-tee.elf) -o $@
 
-$(link-out-dir)tee.dmp: $(link-out-dir)tee.elf
+$(link-out-dir)/tee.dmp: $(link-out-dir)/tee.elf
 	@echo '  OBJDUMP $@'
 	$(q)$(OBJDUMP) -l -x -d $< > $@
 
-$(link-out-dir)tee.bin: $(link-out-dir)tee.elf
+$(link-out-dir)/tee.bin: $(link-out-dir)/tee.elf
 	@echo '  OBJCOPY $@'
 	$(q)$(OBJCOPY) -O binary $< $@
 
-$(link-out-dir)tee.symb_sizes: $(link-out-dir)tee.elf
+$(link-out-dir)/tee.symb_sizes: $(link-out-dir)/tee.elf
 	@echo '  GEN     $@'
 	$(q)$(NM) --print-size --reverse-sort --size-sort $< > $@

--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -10,7 +10,7 @@ platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
 platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
 platform-cflags += -mno-unaligned-access
 platform-aflags	 = -mcpu=$(platform-cpuarch)
-core-platform-cppflags	 = -I$(arch-dir)include
+core-platform-cppflags	 = -I$(arch-dir)/include
 core-platform-cppflags	+= -DNUM_THREADS=2
 core-platform-cppflags	+= -DWITH_STACK_CANARIES=1
 user_ta-platform-cflags = -fpie
@@ -35,9 +35,9 @@ platform-aflags += -g3
 endif
 
 core-platform-subdirs += \
-	$(addprefix $(arch-dir), kernel mm tee sta) $(patsubst %/,%,$(platform-dir))
+	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 ifneq ($(PLATFORM_FLAVOR),fvp)
-core-platform-subdirs += $(arch-dir)sm
+core-platform-subdirs += $(arch-dir)/sm
 core-platform-cppflags += -DWITH_SEC_MON=1
 else
 core-platform-cppflags += -DWITH_ARM_TRUSTED_FW=1

--- a/core/arch/arm32/plat-vexpress/link.mk
+++ b/core/arch/arm32/plat-vexpress/link.mk
@@ -1,20 +1,20 @@
-link-out-dir = $(out-dir)core/
+link-out-dir = $(out-dir)/core
 
-link-script = $(platform-dir)kern.ld.S
-link-script-pp = $(link-out-dir)kern.ld
-link-script-dep = $(link-out-dir).kern.ld.d
+link-script = $(platform-dir)/kern.ld.S
+link-script-pp = $(link-out-dir)/kern.ld
+link-script-dep = $(link-out-dir)/.kern.ld.d
 
 AWK	 = awk
 
-all: $(link-out-dir)tee.elf $(link-out-dir)tee.dmp $(link-out-dir)tee.bin
-all: $(link-out-dir)tee.symb_sizes
-cleanfiles += $(link-out-dir)tee.elf $(link-out-dir)tee.dmp $(link-out-dir)tee.map
-cleanfiles += $(link-out-dir)tee.bin
-cleanfiles += $(link-out-dir)tee.symb_sizes
+all: $(link-out-dir)/tee.elf $(link-out-dir)/tee.dmp $(link-out-dir)/tee.bin
+all: $(link-out-dir)/tee.symb_sizes
+cleanfiles += $(link-out-dir)/tee.elf $(link-out-dir)/tee.dmp $(link-out-dir)/tee.map
+cleanfiles += $(link-out-dir)/tee.bin
+cleanfiles += $(link-out-dir)/tee.symb_sizes
 cleanfiles += $(link-script-pp) $(link-script-dep)
 
 link-ldflags  = $(LDFLAGS)
-link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)tee.map
+link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
 link-ldflags += --sort-section=alignment
 
 link-ldadd  = $(LDADD)
@@ -37,18 +37,18 @@ $(link-script-pp): $(link-script)
 		$(link-script-cppflags) $< > $@
 
 
-$(link-out-dir)tee.elf: $(objs) $(libdeps) $(link-script-pp)
+$(link-out-dir)/tee.elf: $(objs) $(libdeps) $(link-script-pp)
 	@echo '  LD      $@'
 	$(q)$(LD) $(ldargs-tee.elf) -o $@
 
-$(link-out-dir)tee.dmp: $(link-out-dir)tee.elf
+$(link-out-dir)/tee.dmp: $(link-out-dir)/tee.elf
 	@echo '  OBJDUMP $@'
 	$(q)$(OBJDUMP) -l -x -d $< > $@
 
-$(link-out-dir)tee.bin: $(link-out-dir)tee.elf
+$(link-out-dir)/tee.bin: $(link-out-dir)/tee.elf
 	@echo '  OBJCOPY $@'
 	$(q)$(OBJCOPY) -O binary $< $@
 
-$(link-out-dir)tee.symb_sizes: $(link-out-dir)tee.elf
+$(link-out-dir)/tee.symb_sizes: $(link-out-dir)/tee.elf
 	@echo '  GEN     $@'
 	$(q)$(NM) --print-size --reverse-sort --size-sort $< > $@

--- a/core/core.mk
+++ b/core/core.mk
@@ -4,9 +4,9 @@ include mk/cleanvars.mk
 sm := core
 sm-$(sm) := y
 
-arch-dir	:= core/arch/$(ARCH)/
-platform-dir	:= $(arch-dir)plat-$(PLATFORM)/
-include $(platform-dir)conf.mk
+arch-dir	:= core/arch/$(ARCH)
+platform-dir	:= $(arch-dir)/plat-$(PLATFORM)
+include $(platform-dir)/conf.mk
 
 PLATFORM_FLAVOR ?= default
 platform_$(PLATFORM) := y
@@ -51,6 +51,6 @@ include mk/lib.mk
 subdirs = $(core-platform-subdirs) core
 include mk/subdir.mk
 include mk/compile.mk
-include $(platform-dir)link.mk
+include $(platform-dir)/link.mk
 
 

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -107,4 +107,4 @@ $2: $1 FORCE
 endef
 
 $(foreach f, $(srcs), $(eval $(call \
-	process_srcs,$(f),$(out-dir)$(base-prefix)$$(basename $f).o)))
+	process_srcs,$(f),$(out-dir)/$(base-prefix)$$(basename $f).o)))

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -14,10 +14,10 @@ subdirs = $(libdir)
 include mk/subdir.mk
 include mk/compile.mk
 
-lib-libfile	 = $(out-dir)$(base-prefix)$(libdir)/lib$(libname).a
+lib-libfile	 = $(out-dir)/$(base-prefix)$(libdir)/lib$(libname).a
 cleanfiles	:= $(cleanfiles) $(lib-libfile)
 libfiles	:= $(lib-libfile) $(libfiles) 
-libdirs 	:= $(out-dir)$(base-prefix)$(libdir) $(libdirs) 
+libdirs 	:= $(out-dir)/$(base-prefix)$(libdir) $(libdirs)
 libnames	:= $(libname) $(libnames)
 libdeps		:= $(lib-libfile) $(libdeps) 
 

--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -16,15 +16,15 @@ srcs :=
 define process-subdir-srcs-y
 ifeq ($$(sub-dir),.)
 srcs 				+= $1
-oname				:= $(out-dir)$(base-prefix)$(basename $1).o
+oname				:= $(out-dir)/$(base-prefix)$(basename $1).o
 else
 ifneq ($(filter /%,$(1)),)
 # $1 is an absolute path - start with "/"
 srcs 				+= $1
-oname				:= $(out-dir)$(base-prefix)$(basename $1).o
+oname				:= $(out-dir)/$(base-prefix)$(basename $1).o
 else
 srcs				+= $(sub-dir)/$1
-oname				:= $(out-dir)$(base-prefix)$(basename $$(sub-dir)/$1).o
+oname				:= $(out-dir)/$(base-prefix)$(basename $$(sub-dir)/$1).o
 endif
 endif
 cflags-$$(oname) 		:= $$(cflags-y) $$(cflags-$(1)-y)

--- a/ta/arch/arm32/link.mk
+++ b/ta/arch/arm32/link.mk
@@ -1,21 +1,21 @@
 link-out-dir = $(out-dir)
 
 link-script = $(TA_DEV_KIT_DIR)/src/user_ta_elf_arm.lds
-link-script-pp = $(link-out-dir)ta.lds
+link-script-pp = $(link-out-dir)/ta.lds
 
 FIX_TA_BINARY = $(TA_DEV_KIT_DIR)/scripts/fix_ta_binary
 
 
-all: $(link-out-dir)$(binary).elf $(link-out-dir)$(binary).dmp \
-	$(link-out-dir)$(binary).bin
-cleanfiles += $(link-out-dir)$(binary).elf $(link-out-dir)$(binary).dmp
-cleanfiles += $(link-out-dir)$(binary).map
-cleanfiles += $(link-out-dir)$(binary).bin
+all: $(link-out-dir)/$(binary).elf $(link-out-dir)/$(binary).dmp \
+	$(link-out-dir)/$(binary).bin
+cleanfiles += $(link-out-dir)/$(binary).elf $(link-out-dir)/$(binary).dmp
+cleanfiles += $(link-out-dir)/$(binary).map
+cleanfiles += $(link-out-dir)/$(binary).bin
 cleanfiles += $(link-script-pp)
 
 link-ldflags  = $(LDFLAGS)
 link-ldflags += -pie
-link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)$(binary).map
+link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/$(binary).map
 link-ldflags += --sort-section=alignment
 
 # Macro to reverse a list
@@ -32,15 +32,15 @@ $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
 	$(q)cat < $< > $@
 
 
-$(link-out-dir)$(binary).elf: $(objs) $(libdeps) $(link-script-pp)
+$(link-out-dir)/$(binary).elf: $(objs) $(libdeps) $(link-script-pp)
 	@echo '  LD      $@'
 	$(q)$(LD) $(ldargs-$(binary).elf) -o $@
 
-$(link-out-dir)$(binary).dmp: $(link-out-dir)$(binary).elf
+$(link-out-dir)/$(binary).dmp: $(link-out-dir)/$(binary).elf
 	@echo '  OBJDUMP $@'
 	$(q)$(OBJDUMP) -l -x -d $< > $@
 
-$(link-out-dir)$(binary).bin: $(link-out-dir)$(binary).elf
+$(link-out-dir)/$(binary).bin: $(link-out-dir)/$(binary).elf
 	@echo '  OBJCOPY $@'
 	$(q)$(OBJCOPY) -O binary $< $@
 	$(q)$(FIX_TA_BINARY) $< $@

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -1,7 +1,7 @@
 
 
 # Get the dir of the ta-dev-kit, requires make version 3.81 or later
-ta-dev-kit-dir := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))..)
+ta-dev-kit-dir := $(patsubst %/,%,$(abspath $(dir $(lastword $(MAKEFILE_LIST)))..))
 
 
 .PHONY: all
@@ -12,7 +12,7 @@ sm-$(ta) := y
 binary := $(BINARY)
 
 ifneq ($O,)
-out-dir := $O/
+out-dir := $O
 endif
 
 ifneq ($V,1)

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -48,14 +48,14 @@ endef
 
 # Copy the .a files
 $(foreach f, $(libfiles), \
-	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/lib)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/lib)))
 
 # Copy .mk files
 ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk \
 	$(wildcard ta/arch/$(ARCH)/link.mk) \
 	ta/mk/ta_dev_kit.mk
 $(foreach f, $(ta-mkfiles), \
-	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/mk)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/mk)))
 
 # Copy the .h files for TAs
 define copy-incdir
@@ -64,19 +64,19 @@ $$(foreach h, $$(sf), $$(eval $$(call copy-file, $1/$$(h), \
 	$$(patsubst %/,%,$$(subst /./,/,$2/$$(dir $$(h)))))))
 endef
 $(foreach d, $(incdirs$(sm)), \
-	$(eval $(call copy-incdir, $(d), $(out-dir)export-user_ta/include)))
+	$(eval $(call copy-incdir, $(d), $(out-dir)/export-user_ta/include)))
 
 # Copy the .h files needed by host
 $(foreach d, $(incdirs-host), \
-	$(eval $(call copy-incdir, $(d), $(out-dir)export-user_ta/host_include)))
+	$(eval $(call copy-incdir, $(d), $(out-dir)/export-user_ta/host_include)))
 
 # Copy the src files
 ta-srcfiles = ta/arch/$(ARCH)/user_ta_header.c \
 	$(wildcard ta/arch/$(ARCH)/user_ta_elf_arm.lds)
 $(foreach f, $(ta-srcfiles), \
-	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/src)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/src)))
 
 # Copy the scripts
 ta-scripts = $(wildcard ta/arch/$(ARCH)/fix_ta_binary)
 $(foreach f, $(ta-scripts), \
-	$(eval $(call copy-file, $(f), $(out-dir)export-user_ta/scripts)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/scripts)))


### PR DESCRIPTION
As a general rule, Makefile variables that are directories should not have
a trailing slash, and should be used as: $(some-dir)/some-file rather than
$(some-dir)some-file. This is more readable.
