### PR TITLE
Fix TA build error

### DIFF
--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -13,6 +13,8 @@ binary := $(BINARY)
 
 ifneq ($O,)
 out-dir := $O
+else
+out-dir := .
 endif
 
 ifneq ($V,1)


### PR DESCRIPTION
This fixes a bug introduced by commit 4334e8d. In ta_dev_kit.mk, out-dir must
be set to '.' and not left empty when output directory (O=) is not specified.
Otherwise, when building a trusted app, the compile rule will have an unwanted
leading slash (result from the expansion of $(out-dir)/$(...) in compile.mk).
Error is:

make[1]: Entering directory `/home/jerome/tmp/lcu14_optee_hello_world/ta'
  CC      /hello_world_ta.o
hello_world_ta.c:101:1: fatal error: opening dependency file /.hello_world_ta.o.d: Permission denied
 }
 ^
compilation terminated.
