### PR TITLE
plat-vexpress: fix non-debug build

### DIFF
--- a/core/arch/arm32/kernel/mutex.c
+++ b/core/arch/arm32/kernel/mutex.c
@@ -184,8 +184,8 @@ void mutex_lock(struct mutex *m)
 	while (true) {
 		enum mutex_value old_value;
 		uint32_t old_itr_status;
-		uint32_t tick;
-		int handle;
+		uint32_t tick = 0;
+		int handle = -1;
 
 		old_itr_status = itr_disable();
 		cpu_spin_lock(&m->spin_lock);

--- a/core/arch/arm32/kernel/sub.mk
+++ b/core/arch/arm32/kernel/sub.mk
@@ -6,6 +6,7 @@ srcs-y += tee_ta_manager.c
 cflags-tee_ta_manager.c-y += -Wno-declaration-after-statement -Wno-format
 cflags-tee_ta_manager.c-y += -Wno-unused-parameter
 cflags-tee_ta_manager.c-y += -Wno-format-nonliteral -Wno-format-security
+cflags-tee_ta_manager.c-y += -fno-strict-aliasing
 
 
 srcs-y += tee_sleep_services.c
@@ -16,6 +17,8 @@ srcs-y += tee_time.c
 srcs-$(WITH_SECURE_TIME_SOURCE_CNTPCT) += tee_time_arm_cntpct.c
 srcs-$(WITH_SECURE_TIME_SOURCE_RTT) += tee_time_rtt.c
 srcs-$(WITH_SECURE_TIME_SOURCE_REE) += tee_time_ree.c
+cflags-tee_time.c-y += -Wno-unused-parameter
+cflags-tee_time.c-y += -fno-strict-aliasing
 
 srcs-y += chip_services.c
 
@@ -30,3 +33,4 @@ srcs-y += thread_asm.S
 srcs-y += thread.c
 srcs-y += misc.S
 srcs-y += mutex.c
+cflags-mutex.c-y += -fno-strict-aliasing

--- a/core/arch/arm32/kernel/tee_ta_manager.c
+++ b/core/arch/arm32/kernel/tee_ta_manager.c
@@ -1339,7 +1339,7 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 			       struct tee_ta_param *param)
 {
 	TEE_Result res;
-	struct tee_ta_session *s;
+	struct tee_ta_session *s = NULL;
 	struct tee_ta_ctx *ctx;
 	bool panicked;
 

--- a/core/arch/arm32/mm/sub.mk
+++ b/core/arch/arm32/mm/sub.mk
@@ -7,6 +7,7 @@ cflags-tee_pager_unpg.c-y += -Wno-unused-parameter
 
 srcs-y += tee_mmu.c
 cflags-tee_mmu.c-y += -Wno-unused-parameter
+cflags-tee_mmu.c-y += -fno-strict-aliasing
 
 srcs-y += kta_table_unpg_asm.S
 srcs-y += tee_mm.c

--- a/core/arch/arm32/tee/sub.mk
+++ b/core/arch/arm32/tee/sub.mk
@@ -1,6 +1,8 @@
 srcs-y += arch_tee_fs.c
+cflags-arch_tee_fs.c-y += -fno-strict-aliasing
 srcs-y += tee_rpmb.c
 cflags-tee_rpmb.c-y += -Wno-unused-parameter
+cflags-tee_rpmb.c-y += -fno-strict-aliasing
 srcs-y += tee_svc_asm.S
 srcs-y += entry.c
 srcs-y += init.c

--- a/core/arch/arm32/tee/tee_svc_asm.S
+++ b/core/arch/arm32/tee/tee_svc_asm.S
@@ -198,6 +198,7 @@ tee_svc_user_ta_panic_from_pager:
 
 
         .section .rodata
+.balign 4
 tee_svc_syscall_table:
 .word tee_svc_sys_return
 .word tee_svc_sys_log

--- a/core/lib/libtomcrypt/src/sub.mk
+++ b/core/lib/libtomcrypt/src/sub.mk
@@ -6,6 +6,7 @@ cflags-mpa_desc.c-y += -Wno-unused-parameter
 
 srcs-y += tee_ltc_wrapper.c
 cflags-tee_ltc_wrapper.c-y += -Wno-unused-parameter
+cflags-tee_ltc_wrapper.c-y += -fno-strict-aliasing
 
 subdirs-y += ciphers
 subdirs-y += encauth

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -2,21 +2,25 @@ srcs-y += tee_svc.c
 cflags-tee_svc.c-y += -Wno-format -Wno-declaration-after-statement
 cflags-tee_svc.c-y += -Wno-unused-parameter
 cflags-tee_svc.c-y += -Wno-format-nonliteral -Wno-format-security
-
+cflags-tee_svc.c-y += -fno-strict-aliasing
 
 srcs-y += tee_svc_cryp.c
 cflags-tee_svc_cryp.c-y += -Wno-declaration-after-statement
 cflags-tee_svc_cryp.c-y += -Wno-unused-parameter
 cflags-tee_svc_cryp.c-y += -Wno-cast-align
+cflags-tee_svc_cryp.c-y += -fno-strict-aliasing
 
 srcs-y += tee_acipher.c
 cflags-tee_acipher.c-y += -Wno-unused-parameter
+cflags-tee_acipher.c-y += -fno-strict-aliasing
 
 srcs-y += tee_authenc.c
 cflags-tee_authenc.c-y += -Wno-unused-parameter
+cflags-tee_authenc.c-y += -fno-strict-aliasing
 
 srcs-y += tee_mac.c
 cflags-tee_mac.c-y += -Wno-unused-parameter
+cflags-tee_mac.c-y += -fno-strict-aliasing
 
 srcs-y += tee_cipher.c
 srcs-y += tee_fs.c

--- a/lib/libmpa/sub.mk
+++ b/lib/libmpa/sub.mk
@@ -6,6 +6,7 @@ cflags-mpa_misc.c-y += -Wno-sign-compare
 
 srcs-y += mpa_montgomery.c
 cflags-remove-mpa_montgomery.c-y += -Wdeclaration-after-statement
+cflags-mpa_montgomery.c-y += -fno-strict-aliasing
 
 srcs-y += mpa_primetest.c
 cflags-remove-mpa_primetest.c-y += -pedantic
@@ -35,7 +36,9 @@ srcs-y += mpa_addsub.c
 srcs-y += mpa_cmp.c
 srcs-y += mpa_debug.c
 srcs-y += mpa_expmod.c
+cflags-mpa_expmod.c-y += -fno-strict-aliasing
 srcs-y += mpa_init.c
+cflags-mpa_init.c-y += -fno-strict-aliasing
 srcs-y += mpa_io.c
 srcs-y += mpa_modulus.c
 

--- a/lib/libutee/sub.mk
+++ b/lib/libutee/sub.mk
@@ -18,8 +18,11 @@ cflags-assert.c-y += -Wno-missing-prototypes -Wno-missing-declarations
 
 srcs-y += base64.c
 srcs-y += tee_api_arith.c
+cflags-tee_api_arith.c-y += -fno-strict-aliasing
 srcs-y += tee_api.c
 srcs-y += tee_api_objects.c
+cflags-tee_api_objects.c-y += -fno-strict-aliasing
 srcs-y += tee_api_operations.c
+cflags-tee_api_operations.c-y += -fno-strict-aliasing
 
 subdirs-y += arch/$(ARCH)

--- a/lib/libutils/isoc/sub.mk
+++ b/lib/libutils/isoc/sub.mk
@@ -11,6 +11,7 @@ srcs-y += snprintf.c
 
 srcs-y += stack_check.c
 srcs-y += qsort.c
+cflags-qsort.c-y += -Wno-inline
 cflags-remove-qsort.c-y += -Wcast-align
 
 srcs-y += strdup.c


### PR DESCRIPTION
On Foundation_v8 FVP, -O2 allows much faster execution than default debug mode
(-O0). The minor rework in core/arch/arm32/kernel/mutex.c is to avoid a GCC
warning: '<variable> may be used uninitialized in this function'.
