### PR TITLE
Update references to ARM Trusted Firmware

### DIFF
--- a/core/arch/arm32/kernel/thread_asm.S
+++ b/core/arch/arm32/kernel/thread_asm.S
@@ -131,13 +131,13 @@ LOCAL_FUNC vector_system_reset_entry , :
 END_FUNC vector_system_reset_entry
 
 /*
- * Vector table supplied to ARM Trusted Firmware (ATF) at initialization.
- * Also used when compiled with the internal monitor, but the
- * cpu_*_entry and system_*_entry are not used then.
+ * Vector table supplied to ARM Trusted Firmware (ARM-TF) at
+ * initialization.  Also used when compiled with the internal monitor, but
+ * the cpu_*_entry and system_*_entry are not used then.
  *
- * Note that ATF depends on the layout of this vector table, any change in
- * layout has to be synced with ATF. This layout must also be kept in sync
- * with sm_entry_vector in sm.c
+ * Note that ARM-TF depends on the layout of this vector table, any change
+ * in layout has to be synced with ARM-TF. This layout must also be kept in
+ * sync with sm_entry_vector in sm.c
  */
 FUNC thread_vector_table , :
 	b	vector_std_smc_entry

--- a/core/arch/arm32/plat-vexpress/main.c
+++ b/core/arch/arm32/plat-vexpress/main.c
@@ -253,7 +253,7 @@ static void main_init_gic(void)
 #if PLATFORM_FLAVOR_IS(fvp)
 {
 	/*
-	 * In FVP, GIC configuration is initialized in ATF,
+	 * In FVP, GIC configuration is initialized in ARM-TF,
 	 * Initialize GIC base address here for debugging.
 	 */
 	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);

--- a/documentation/arm_trusted_firmware.md
+++ b/documentation/arm_trusted_firmware.md
@@ -14,22 +14,22 @@ Contents :
 1.  Introduction
 ----------------
 This document describes how to build [OP-TEE OS] and run it together with
-ARM Trusted Firmware ([ATF]).
+ARM Trusted Firmware ([ARM-TF]).
 
-The bridge between normal world and [OP-TEE OS] resides in [ATF] and is a
+The bridge between normal world and [OP-TEE OS] resides in [ARM-TF] and is a
 [secure monitor] referred to as the OP-TEE Dispatcher.
 
-This document is limited to only describe how to boot ATF together with
+This document is limited to only describe how to boot ARM-TF together with
 OP-TEE. It does not cover how to enable normal world TEE Client API to
 comunicate with OP-TEE.
 
 2.  Host machine requirements
 -----------------------------
-See "Host machine requirements" in [ATF User Guide].
+See "Host machine requirements" in [ARM-TF User Guide].
 
 3.  Tools
 ---------
-See "Tools" in [ATF User Guide].
+See "Tools" in [ARM-TF User Guide].
 
 In addition to that is gcc-linaro-arm-linux-gnueabihf-4.8-2013.12_linux.tar.bz2
 used as to compile OP-TEE.
@@ -65,10 +65,10 @@ To get debug prints from OP-TEE OS add for instance:
 
 5.  Building the Trusted Firmware
 ---------------------------------
-See "Building the Trusted Firmware" in [ATF User Guide].
+See "Building the Trusted Firmware" in [ARM-TF User Guide].
 
-Before the OP-TEE Dispatcher is integrated in [ATF] it may be
-nececcary to clone [ATF] from an inofficial repository.
+Before the OP-TEE Dispatcher is integrated in [ARM-TF] it may be
+nececcary to clone [ARM-TF] from an inofficial repository.
 
 Build ARM Trusted Firmware with OP-TEE Dispatcher:
 
@@ -81,11 +81,11 @@ Build ARM Trusted Firmware with OP-TEE Dispatcher:
 	
 6.  Obtaining the normal world software
 ---------------------------------------
-See "Obtaining the normal world software" in [ATF User Guide]
+See "Obtaining the normal world software" in [ARM-TF User Guide]
 
 7.  Running the software
 ------------------------
-See "Running the software" in [ATF User Guide]
+See "Running the software" in [ARM-TF User Guide]
 
 To do anything more than watching the psci hooks getting called in [OP-TEE OS]
 there's some additional software required,
@@ -98,7 +98,7 @@ It's outside then scope of this document to guide how to use that software.
 _Copyright (c) 2014, Linaro Limited. All rights reserved._
 [OP-TEE]:               http://github.com/OP-TEE
 [OP-TEE OS]:            http://github.com/OP-TEE/optee_os.git
-[ATF]:                  http://github.com/ARM-software/arm-trusted-firmware
-[ATF User Guide]:       http://github.com/ARM-software/arm-trusted-firmware/tree/master/docs/user-guide.md
+[ARM-TF]:               http://github.com/ARM-software/arm-trusted-firmware
+[ARM-TF User Guide]:    http://github.com/ARM-software/arm-trusted-firmware/tree/master/docs/user-guide.md
 [secure monitor]:       http://www.arm.com/products/processors/technologies/trustzone/tee-smc.php
 


### PR DESCRIPTION
We must never abbreviate ARM so we either reference as "ARM
Trusted Firmware" or "ARM-TF".
