### PR TITLE
XTS implementation

### DIFF
--- a/core/lib/libtomcrypt/include/tomcrypt_cipher.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_cipher.h
@@ -557,12 +557,20 @@ int xts_start(                int  cipher,
 int xts_encrypt(
    const unsigned char *pt, unsigned long ptlen,
          unsigned char *ct,
+#ifdef LTC_LINARO_FIX_XTS
+         unsigned char *tweak,
+#else
    const unsigned char *tweak,
+#endif
          symmetric_xts *xts);
 int xts_decrypt(
    const unsigned char *ct, unsigned long ptlen,
          unsigned char *pt,
+#ifdef LTC_LINARO_FIX_XTS
+         unsigned char *tweak,
+#else
    const unsigned char *tweak,
+#endif
          symmetric_xts *xts);
 
 void xts_done(symmetric_xts *xts);

--- a/core/lib/libtomcrypt/include/tomcrypt_custom.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_custom.h
@@ -387,6 +387,13 @@
  */
 #define LTC_LINARO_FIX_DH
 
+/*
+ * XTS encryption / decryption does not update the tweak when successive
+ * operations are performed.
+ * Defining LTC_LINARO_FIX_XTS fixes this.
+ */
+#define LTC_LINARO_FIX_XTS
+
 /* Debuggers */
 
 /* define this if you use Valgrind, note: it CHANGES the way SOBER-128 and LTC_RC4 work (see the code) */

--- a/core/lib/libtomcrypt/src/modes/xts/xts_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_decrypt.c
@@ -87,7 +87,11 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
 */int xts_decrypt(
    const unsigned char *ct, unsigned long ptlen,
          unsigned char *pt,
+#ifdef LTC_LINARO_FIX_XTS
+         unsigned char *tweak,
+#else
    const unsigned char *tweak,
+#endif
          symmetric_xts *xts)
 {
    unsigned char PP[16], CC[16], T[16];
@@ -156,6 +160,13 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
          return err;
       }
    }
+
+#ifdef LTC_LINARO_FIX_XTS
+   /* Decrypt the tweak back */
+   if ((err = cipher_descriptor[xts->cipher].ecb_decrypt(T, tweak, &xts->key2)) != CRYPT_OK) {
+      return err;
+   }
+#endif
 
    return CRYPT_OK;
 }

--- a/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
@@ -90,7 +90,11 @@ static int tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *
 int xts_encrypt(
    const unsigned char *pt, unsigned long ptlen,
          unsigned char *ct,
+#ifdef LTC_LINARO_FIX_XTS
+         unsigned char *tweak,
+#else
    const unsigned char *tweak,
+#endif
          symmetric_xts *xts)
 {
    unsigned char PP[16], CC[16], T[16];
@@ -157,6 +161,13 @@ int xts_encrypt(
          return err;
       }
    }
+
+#ifdef LTC_LINARO_FIX_XTS
+   /* Decrypt the tweak back */
+   if ((err = cipher_descriptor[xts->cipher].ecb_decrypt(T, tweak, &xts->key2)) != CRYPT_OK) {
+      return err;
+   }
+#endif
 
    return err;
 }


### PR DESCRIPTION
Fix libtomcrypt XTS: when applying XTS
encryption / decryption, onto partial buffers,
the tweak is now updated.

Signed-off-by: Pascal Brand pascal.brand@st.com
