### PR TITLE
Drivers gic and uart are optional

### DIFF
--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -51,6 +51,8 @@ endif
 
 libutil_with_isoc := y
 WITH_SECURE_TIME_SOURCE_CNTPCT := y
+WITH_UART_DRV := y
+WITH_GIC_DRV := y
 
 include mk/config.mk
 

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -1,2 +1,2 @@
-srcs-y += uart.c
-srcs-y += gic.c
+srcs-$(WITH_UART_DRV) += uart.c
+srcs-$(WITH_GIC_DRV) += gic.c


### PR DESCRIPTION
Platforms stm do not use gic and uart drivers, whereas vexpress (fvp / qemu)
does. So the conf.mk of the latter case defines the following:
    WITH_UART_DRV := y
    WITH_GIC_DRV := y

Signed-off-by: Pascal Brand pascal.brand@st.com
