### PR TITLE
CCM Authentication optimization

### DIFF
--- a/core/lib/libtomcrypt/include/tomcrypt_mac.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_mac.h
@@ -225,6 +225,44 @@ int s_ocb_done(ocb_state *ocb, const unsigned char *pt, unsigned long ptlen,
 #define CCM_ENCRYPT 0
 #define CCM_DECRYPT 1
 
+typedef struct {
+   symmetric_key       K;
+   int                 cipher,               /* which cipher */
+                       taglen,               /* length of the tag */
+                       x;                    /* index in PAD */
+
+   unsigned long       L,                    /* L value */
+                       ptlen,                /* length that will be enc / dec */
+                       current_ptlen,        /* current processed length */
+                       aadlen,               /* length of the aad */
+                       current_aadlen,       /* length of the currently provided add */
+                       noncelen;             /* length of the nonce */
+
+   unsigned char       PAD[16],
+                       ctr[16],
+                       CTRPAD[16],
+                       CTRlen;
+} ccm_state;
+
+int ccm_init(ccm_state *ccm, int cipher,
+             const unsigned char *key, int keylen, int ptlen, int taglen, int aad_len);
+
+int ccm_reset(ccm_state *ccm);
+
+int ccm_add_nonce(ccm_state *ccm,
+                  const unsigned char *nonce,     unsigned long noncelen);
+
+int ccm_add_aad(ccm_state *ccm,
+                const unsigned char *adata,  unsigned long adatalen);
+
+int ccm_process(ccm_state *ccm,
+                unsigned char *pt,     unsigned long ptlen,
+                unsigned char *ct,
+                int direction);
+
+int ccm_done(ccm_state *ccm,
+             unsigned char *tag,    unsigned long *taglen);
+
 int ccm_memory(int cipher,
     const unsigned char *key,    unsigned long keylen,
     symmetric_key       *uskey,

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Add AAD to the CCM state
+  @param ccm       The CCM state
+  @param adata     The additional authentication data to add to the CCM state
+  @param adatalen  The length of the AAD data.
+  @return CRYPT_OK on success
+ */
+int ccm_add_aad(ccm_state *ccm,
+                const unsigned char *adata,  unsigned long adatalen)
+{
+   unsigned long y;
+   int            err;
+
+   if (ccm->aadlen < ccm->current_aadlen + adatalen) {
+      return CRYPT_INVALID_ARG;
+   }
+   ccm->current_aadlen += adatalen;
+
+   /* now add the data */
+   for (y = 0; y < adatalen; y++) {
+      if (ccm->x == 16) {
+         /* full block so let's encrypt it */
+         if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+            return CRYPT_ERROR;
+         }
+         ccm->x = 0;
+      }
+      ccm->PAD[ccm->x++] ^= adata[y];
+   }
+
+   /* remainder? */
+   if (ccm->aadlen == ccm->current_aadlen) {
+      if (ccm->x != 0) {
+         if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+            return CRYPT_ERROR;
+         }
+      }
+      ccm->x = 0;
+   }
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Add nonce data to the CCM state
+  @param ccm       The CCM state
+  @param nonce     The nonce data to add
+  @param noncelen  The length of the nonce
+  @return CRYPT_OK on success
+ */
+int ccm_add_nonce(ccm_state *ccm,
+                  const unsigned char *nonce,     unsigned long noncelen)
+{
+   unsigned long x, y, len;
+   int           err;
+
+   /* increase L to match the nonce len */
+   ccm->noncelen = (noncelen > 13) ? 13 : noncelen;
+   if ((15 - ccm->noncelen) > ccm->L) {
+      ccm->L = 15 - ccm->noncelen;
+   }
+
+   /* decrease noncelen to match L */
+   if ((ccm->noncelen + ccm->L) > 15) {
+      ccm->noncelen = 15 - ccm->L;
+   }
+
+   /* form B_0 == flags | Nonce N | l(m) */
+   x = 0;
+   ccm->PAD[x++] = (unsigned char)(((ccm->aadlen > 0) ? (1<<6) : 0) |
+		   (((ccm->taglen - 2)>>1)<<3)        |
+		   (ccm->L-1));
+
+   /* nonce */
+   for (y = 0; y < (16 - (ccm->L + 1)); y++) {
+      ccm->PAD[x++] = nonce[y];
+   }
+
+   /* store len */
+   len = ccm->ptlen;
+
+   /* shift len so the upper bytes of len are the contents of the length */
+   for (y = ccm->L; y < 4; y++) {
+      len <<= 8;
+   }
+
+   /* store l(m) (only store 32-bits) */
+   for (y = 0; ccm->L > 4 && (ccm->L-y)>4; y++) {
+      ccm->PAD[x++] = 0;
+   }
+   for (; y < ccm->L; y++) {
+      ccm->PAD[x++] = (unsigned char)((len >> 24) & 255);
+      len <<= 8;
+   }
+
+   /* encrypt PAD */
+   if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+      return err;
+   }
+
+   /* handle header */
+   ccm->x = 0;
+   if (ccm->aadlen > 0) {
+      /* store length */
+      if (ccm->aadlen < ((1UL<<16) - (1UL<<8))) {
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>8) & 255;
+         ccm->PAD[ccm->x++] ^= ccm->aadlen & 255;
+      } else {
+         ccm->PAD[ccm->x++] ^= 0xFF;
+         ccm->PAD[ccm->x++] ^= 0xFE;
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>24) & 255;
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>16) & 255;
+         ccm->PAD[ccm->x++] ^= (ccm->aadlen>>8) & 255;
+         ccm->PAD[ccm->x++] ^= ccm->aadlen & 255;
+      }
+   }
+
+   /* setup the ctr counter */
+   x = 0;
+
+   /* flags */
+   ccm->ctr[x++] = (unsigned char)ccm->L-1;
+
+   /* nonce */
+   for (y = 0; y < (16 - (ccm->L+1)); ++y) {
+      ccm->ctr[x++] = nonce[y];
+   }
+   /* offset */
+   while (x < 16) {
+      ccm->ctr[x++] = 0;
+   }
+
+   ccm->CTRlen = 16;
+   return CRYPT_OK;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Terminate a CCM stream
+  @param ccm     The CCM state
+  @param tag     [out] The destination for the MAC tag
+  @param taglen  [in/out]  The length of the MAC tag
+  @return CRYPT_OK on success
+ */
+int ccm_done(ccm_state *ccm,
+             unsigned char *tag,    unsigned long *taglen)
+{
+   unsigned long x, y;
+   int            err;
+
+   /* Check all data have been processed */
+   if (ccm->ptlen != ccm->current_ptlen) {
+      return CRYPT_ERROR;
+   }
+
+   LTC_ARGCHK(tag    != NULL);
+   LTC_ARGCHK(taglen != NULL);
+
+   if (ccm->x != 0) {
+      if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+         return err;
+      }
+   }
+
+   /* setup CTR for the TAG (zero the count) */
+   for (y = 15; y > 15 - ccm->L; y--) {
+      ccm->ctr[y] = 0x00;
+   }
+   if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
+      return err;
+   }
+
+   cipher_descriptor[ccm->cipher].done(&ccm->K);
+
+   /* store the TAG */
+   for (x = 0; x < 16 && x < *taglen; x++) {
+      tag[x] = ccm->PAD[x] ^ ccm->CTRPAD[x];
+   }
+   *taglen = x;
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Initialize a CCM state
+  @param ccm     The CCM state to initialize
+  @param cipher  The index of the cipher to use
+  @param key     The secret key
+  @param keylen  The length of the secret key
+  @param ptlen   The length of the plain/cipher text that will be processed
+  @param taglen  The max length of the MAC tag
+  @param aadlen  The length of the AAD
+
+  @return CRYPT_OK on success
+ */
+int ccm_init(ccm_state *ccm, int cipher,
+             const unsigned char *key, int keylen, int ptlen, int taglen, int aadlen)
+{
+   int            err;
+
+   LTC_ARGCHK(key    != NULL);
+   LTC_ARGCHK(taglen != 0);
+
+   memset(ccm, 0, sizeof(ccm_state));
+
+   /* check cipher input */
+   if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {
+      return err;
+   }
+   if (cipher_descriptor[cipher].block_length != 16) {
+      return CRYPT_INVALID_CIPHER;
+   }
+
+   /* make sure the taglen is even and <= 16 */
+   ccm->taglen = taglen;
+   ccm->taglen &= ~1;
+   if (ccm->taglen > 16) {
+      ccm->taglen = 16;
+   }
+
+   /* can't use < 4 */
+   if (ccm->taglen < 4) {
+      return CRYPT_INVALID_ARG;
+   }
+
+   /* schedule key */
+   if ((err = cipher_descriptor[cipher].setup(key, keylen, 0, &ccm->K)) != CRYPT_OK) {
+      return err;
+   }
+   ccm->cipher = cipher;
+
+   /* let's get the L value */
+   ccm->ptlen = ptlen;
+   ccm->L   = 0;
+   while (ptlen) {
+      ++ccm->L;
+      ptlen >>= 8;
+   }
+   if (ccm->L <= 1) {
+      ccm->L = 2;
+   }
+
+   ccm->aadlen = aadlen;
+   return CRYPT_OK;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Process plaintext/ciphertext through CCM
+  @param ccm       The CCM state
+  @param pt        The plaintext
+  @param ptlen     The plaintext length (ciphertext length is the same)
+  @param ct        The ciphertext
+  @param direction Encrypt or Decrypt mode (CCM_ENCRYPT or CCM_DECRYPT)
+  @return CRYPT_OK on success
+ */
+int ccm_process(ccm_state *ccm,
+                unsigned char *pt,     unsigned long ptlen,
+                unsigned char *ct,
+                int direction)
+{
+   unsigned char  y, z, b;
+   int err;
+
+   /* Check aad has been correctly added */
+   if (ccm->aadlen != ccm->current_aadlen) {
+      return CRYPT_ERROR;
+   }
+
+   /* Check we do not process too much data */
+   if (ccm->ptlen < ccm->current_ptlen + ptlen) {
+      return CRYPT_ERROR;
+   }
+   ccm->current_ptlen += ptlen;
+
+   /* now handle the PT */
+   if (ptlen > 0) {
+      LTC_ARGCHK(pt != NULL);
+      LTC_ARGCHK(ct != NULL);
+      y = 0;
+
+      for (; y < ptlen; y++) {
+         /* increment the ctr? */
+         if (ccm->CTRlen == 16) {
+            for (z = 15; z > 15-ccm->L; z--) {
+               ccm->ctr[z] = (ccm->ctr[z] + 1) & 255;
+               if (ccm->ctr[z]) break;
+            }
+            if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
+               return err;
+            }
+            ccm->CTRlen = 0;
+         }
+
+         /* if we encrypt we add the bytes to the MAC first */
+         if (direction == CCM_ENCRYPT) {
+            b     = pt[y];
+            ct[y] = b ^ ccm->CTRPAD[ccm->CTRlen++];
+         } else {
+            b     = ct[y] ^ ccm->CTRPAD[ccm->CTRlen++];
+            pt[y] = b;
+         }
+
+         if (ccm->x == 16) {
+            if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+               return err;
+            }
+            ccm->x = 0;
+         }
+         ccm->PAD[ccm->x++] ^= b;
+      }
+   }
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_reset.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_reset.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_CCM_MODE
+
+/**
+  Reset a CCM state to as if you just called ccm_init().  This saves the initialization time.
+  @param ccm   The CCM state to reset
+  @return CRYPT_OK on success
+*/
+int ccm_reset(ccm_state *ccm)
+{
+   LTC_ARGCHK(ccm != NULL);
+   zeromem(ccm->PAD, sizeof(ccm->PAD));
+   zeromem(ccm->ctr, sizeof(ccm->ctr));
+   zeromem(ccm->CTRPAD, sizeof(ccm->CTRPAD));
+   ccm->CTRlen = 0;
+   ccm->current_ptlen = 0;
+   ccm->current_aadlen = 0;
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/encauth/ccm/sub.mk
+++ b/core/lib/libtomcrypt/src/encauth/ccm/sub.mk
@@ -1,2 +1,8 @@
+srcs-y += ccm_init.c
+srcs-y += ccm_add_nonce.c
+srcs-y += ccm_add_aad.c
+srcs-y += ccm_process.c
+srcs-y += ccm_done.c
+srcs-y += ccm_reset.c
 srcs-y += ccm_memory.c
 # srcs-y += ccm_test.c


### PR DESCRIPTION
CCM   is now optimized. Instead of being computed twice,
libtomcrypt code has been optimized so that classical ccm_init, ccm_process,...
can be used incrementally (when the whole stream is not available when
starting the authentication).
CCM way of proceeding is now very closed to GCM authentication.
