### PR TITLE
plat-vexpress: build with -mfloat-abi=soft

### DIFF
--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -8,6 +8,7 @@ platform-cpuarch = cortex-a15
 platform-cflags	 = -mcpu=$(platform-cpuarch) -mthumb
 platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
 platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
+platform-cflags += -mfloat-abi=soft
 platform-cflags += -mno-unaligned-access
 platform-aflags	 = -mcpu=$(platform-cpuarch)
 core-platform-cppflags	 = -I$(arch-dir)/include


### PR DESCRIPTION
OP-TEE on plat-vexpress does not support Neon. This patch prevents generating
Neon instructions when the cross-compiler is configured to use
'-mfloat-abi=hard' by default (such as arm-linux-gnueabihf-gcc).
