### PR TITLE
Add support for per-directory/per-library/per-file includes, and per-lib...

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -57,6 +57,7 @@ objs		+= $2
 comp-dep-$2	:= $$(dir $2).$$(notdir $2).d
 comp-cmd-file-$2:= $$(dir $2).$$(notdir $2).cmd
 comp-sm-$2	:= $(sm)
+comp-lib-$2	:= $(libname)
 
 cleanfiles := $$(cleanfiles) $$(comp-dep-$2) $$(comp-cmd-file-$2) $2
 
@@ -81,7 +82,10 @@ comp-flags-$2 += -MD -MF $$(comp-dep-$2) -MT $$@ \
 			 $$(cppflags-remove-$2), \
 	      $$(nostdinc) $$(CPPFLAGS) \
 	      $$(addprefix -I,$$(incdirs$$(comp-sm-$2))) \
-	      $$(cppflags$$(comp-sm-$2)) $$(cppflags-$2))
+	      $$(addprefix -I,$$(incdirs-lib$$(comp-lib-$2))) \
+	      $$(addprefix -I,$$(incdirs-$2)) \
+	      $$(cppflags$$(comp-sm-$2)) \
+	      $$(cppflags-lib$$(comp-lib-$2)) $$(cppflags-$2))
 
 comp-cmd-$2 = $$(CC) $$(comp-flags-$2) -c $$< -o $$@
 

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -28,3 +28,4 @@ $(lib-libfile): $(objs)
 
 # Clean residues from processing
 objs		:=
+libname		:=

--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -8,6 +8,9 @@
 # set     cflags-$(oname) cflags-remove-$(oname)
 #         aflags-$(oname) aflags-remove-$(oname)
 #         cppflags-$(oname) cppflags-remove-$(oname)
+#         incdirs-$(oname)
+#         incdirs-lib$(libname)  [if libname is defined]
+#         cppflags-lib$(libname) [if libname is defined]
 # for each file found, oname is the name of the object file for corresponding
 # source file
 
@@ -36,14 +39,17 @@ cppflags-remove-$$(oname) 	:= $$(cppflags-remove-y) \
 aflags-$$(oname) 		:= $$(aflags-y) $$(aflags-$(1)-y)
 aflags-remove-$$(oname) 	:= $$(aflags-remove-y) \
 					$$(aflags-remove-$(1)-y)
+incdirs-$$(oname)		:= $$(thissubdir-incdirs) $$(addprefix $(sub-dir)/,$$(incdirs-$(1)-y))
 # Clear local filename specific variables to avoid accidental reuse
 # in another subdirectory
 cflags-$(1)-y 			:=
 cflags-remove-$(1)-y		:=
 cppflags-$(1)-y			:=
 cppflags-remove-$(1)-y		:=
+cppflags-lib-y			:=
 aflags-$(1)-y 			:=
 aflags-remove-$(1)-y		:=
+incdirs-$(1)-y			:=
 fname				:=
 oname				:=
 endef #process-subdir-srcs-y
@@ -53,6 +59,11 @@ sub-dir := $1
 include $1/sub.mk
 sub-subdirs := $$(addprefix $1/,$$(subdirs-y))
 incdirs$(sm) := $(incdirs$(sm)) $$(addprefix $1/,$$(global-incdirs-y))
+thissubdir-incdirs := $$(addprefix $1/,$$(incdirs-y))
+ifneq ($$(libname),)
+incdirs-lib$$(libname) := $$(incdirs-lib$$(libname)) $$(addprefix $1/,$$(incdirs-lib-y))
+cppflags-lib$$(libname) := $$(cppflags-lib$$(libname)) $$(cppflags-lib-y)
+endif
 
 # Process files in current directory
 $$(foreach s, $$(srcs-y), $$(eval $$(call process-subdir-srcs-y,$$(s))))
@@ -60,10 +71,13 @@ $$(foreach s, $$(srcs-y), $$(eval $$(call process-subdir-srcs-y,$$(s))))
 srcs-y :=
 cflags-y :=
 cppflags-y :=
+cppflags-lib-y :=
 aflags-y :=
 cflags-remove-y :=
 subdirs-y :=
 global-incdirs-y :=
+incdirs-lib-y :=
+incdirs-y :=
 
 # Process subdirectories in current directory
 $$(foreach sd, $$(sub-subdirs), $$(eval $$(call process-subdir,$$(sd))))


### PR DESCRIPTION
...rary CPP flags

The new variables that can be used in sub.mk are:

  1) For includes: incdirs-y, incdirs-lib-y, incdirs-<filename>-y

For example, suppose core/lib/libfoo/sub.mk contains the following:

  # All source files declared in $(srcs-y) in this sub.mk will
  # have -Icore/lib/libfoo/include
  incdirs-y := include

  # All source files for the current library $(libname) will be built
  # with -Icore/lib/libfoo/include/baz (even files that are in other
  # directories)
  incdirs-lib-y := include/baz

  # In addition to the above, bar.c will be compiled with
  # -Icore/lib/libfoo/include/bar
  incdirs-bar.c-y := include/bar

  2) For CPP flags: cppflags-lib-y

For example, to add -DLIBFOO to all the source files that belong to the same
library, add this to any of the sub.mk files:

  cppflags-lib-y := -DLIBFOO

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
