### PR TITLE
Digest operations now supports NULL arguments

### DIFF
--- a/core/tee/tee_hash.c
+++ b/core/tee/tee_hash.c
@@ -86,7 +86,8 @@ TEE_Result tee_hash_init(void *ctx, uint32_t algo)
 TEE_Result tee_hash_update(void *ctx, uint32_t algo,
 			   const uint8_t *data, size_t len)
 {
-	int ltc_res, ltc_hashindex;
+	int ltc_res;
+	int ltc_hashindex;
 
 	ltc_res = tee_algo_to_ltc_hashindex(algo, &ltc_hashindex);
 	if (ltc_res != TEE_SUCCESS)
@@ -100,9 +101,11 @@ TEE_Result tee_hash_update(void *ctx, uint32_t algo,
 
 TEE_Result tee_hash_final(void *ctx, uint32_t algo, uint8_t *digest, size_t len)
 {
-	int ltc_res, ltc_hashindex;
+	int ltc_res;
+	int ltc_hashindex;
 	size_t hash_size;
-	uint8_t block_digest[MAX_DIGEST], *tmp_digest;
+	uint8_t block_digest[MAX_DIGEST];
+	uint8_t *tmp_digest;
 
 	ltc_res = tee_algo_to_ltc_hashindex(algo, &ltc_hashindex);
 	if (ltc_res != TEE_SUCCESS)
@@ -120,19 +123,16 @@ TEE_Result tee_hash_final(void *ctx, uint32_t algo, uint8_t *digest, size_t len)
 		return  TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	if (hash_size > len) {
-		/* use a tempory buffer */
-		tmp_digest = block_digest;
-	} else {
+	if (hash_size > len)
+		tmp_digest = block_digest; /* use a tempory buffer */
+	else
 		tmp_digest = digest;
-	}
 
 	if (hash_descriptor[ltc_hashindex].done(ctx, tmp_digest) == CRYPT_OK) {
 		if (hash_size > len)
 			memcpy(digest, tmp_digest, len);
-	} else {
+	} else
 		return TEE_ERROR_BAD_STATE;
-	}
 
 	return TEE_SUCCESS;
 }

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -460,12 +460,12 @@ void TEE_CopyOperation(TEE_OperationHandle dst_op, TEE_OperationHandle src_op)
 void TEE_DigestUpdate(TEE_OperationHandle operation,
 		      void *chunk, size_t chunkSize)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
-	if (operation == TEE_HANDLE_NULL || chunk == NULL)
+	if (operation == TEE_HANDLE_NULL ||
+	    operation->info.operationClass != TEE_OPERATION_DIGEST)
 		TEE_Panic(0);
-	if (operation->info.operationClass != TEE_OPERATION_DIGEST)
-		TEE_Panic(0);
+
 	res = utee_hash_update(operation->state, chunk, chunkSize);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -474,11 +474,11 @@ void TEE_DigestUpdate(TEE_OperationHandle operation,
 TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, const void *chunk,
 			     size_t chunkLen, void *hash, size_t *hashLen)
 {
-	if (operation == TEE_HANDLE_NULL || (chunk == NULL && chunkLen != 0) ||
-	    hash == NULL || hashLen == NULL)
+	if ((operation == TEE_HANDLE_NULL) || (!chunk && chunkLen) ||
+	    !hash || !hashLen ||
+	    (operation->info.operationClass != TEE_OPERATION_DIGEST))
 		TEE_Panic(0);
-	if (operation->info.operationClass != TEE_OPERATION_DIGEST)
-		TEE_Panic(0);
+
 	return utee_hash_final(operation->state, chunk, chunkLen, hash,
 			       hashLen);
 }


### PR DESCRIPTION
Hash algorithms should support NULL arguments and zero length strings.
Following changes will make is possible to call TEE_DigestUpdate and
TEE_DigestDoFinal interchangeably.

Following combinations are now working.

---

   | TEE_DigestUpdate | TEE_DigestDoFinal |

---

   |       NULL       |       NULL        |
   |       NULL       |       MESSAGE     |
   |       MESSAGE    |       NULL        |
   |       MESSAGE    |       MESSAGE     |
   |       N/A        |       NULL        |
   |       N/A        |       MESSAGE     |

---

Signed-off-by: Joakim Bech joakim.bech@linaro.org
Tested-by: Joakim Bech joakim.bech@linaro.org (FVP)
