### PR TITLE
Less traces in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 
   # Download the arm compiler to use
   - wget http://releases.linaro.org/14.05/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.9-2014.05_linux.tar.xz
-  - tar xvf gcc-linaro-arm-linux-gnueabihf-4.9-2014.05_linux.tar.xz
+  - tar xf gcc-linaro-arm-linux-gnueabihf-4.9-2014.05_linux.tar.xz
   - export PATH=$PATH:$PWD/gcc-linaro-arm-linux-gnueabihf-4.9-2014.05_linux/bin
 
   # Download checkpatch.pl, emulating kernel root tree


### PR DESCRIPTION
Verbose of tar is removed so that the complete build trace is available in the
Travis console, without having to look at the raw data.

Signed-off-by: Pascal Brand pascal.brand@st.com
