### PR TITLE
thread: remove THREAD_LOCAL_EXCEPTION_SPS

### DIFF
--- a/core/arch/arm32/kernel/thread_asm.S
+++ b/core/arch/arm32/kernel/thread_asm.S
@@ -183,25 +183,9 @@ FUNC thread_resume , :
 	cps	#CPSR_MODE_SYS
 	ldm	r12!, {sp, lr}
 
-#ifdef THREAD_LOCAL_EXCEPTION_SPS
-	cps	#CPSR_MODE_IRQ
-	ldm	r12!, {r1, sp, lr}
-	msr	spsr_fsxc, r1
-#endif /*THREAD_LOCAL_EXCEPTION_SPS*/
-
 	cps	#CPSR_MODE_SVC
 	ldm	r12!, {r1, sp, lr}
 	msr	spsr_fsxc, r1
-
-#ifdef THREAD_LOCAL_EXCEPTION_SPS
-	cps	#CPSR_MODE_ABT
-	ldm	r12!, {r1, sp, lr}
-	msr	spsr_fsxc, r1
-
-	cps	#CPSR_MODE_UND
-	ldm	r12!, {r1, sp, lr}
-	msr	spsr_fsxc, r1
-#endif /*THREAD_LOCAL_EXCEPTION_SPS*/
 
 	cps	#CPSR_MODE_SVC
 	ldm	r12, {r1, r2}
@@ -249,25 +233,9 @@ LOCAL_FUNC thread_save_state , :
         cps     #CPSR_MODE_SYS
         stm     r0!, {sp, lr}
 
-#ifdef THREAD_LOCAL_EXCEPTION_SPS
-        cps     #CPSR_MODE_IRQ
-        mrs     r1, spsr
-        stm     r0!, {r1, sp, lr}
-#endif /*THREAD_LOCAL_EXCEPTION_SPS*/
-
         cps     #CPSR_MODE_SVC
         mrs     r1, spsr
         stm     r0!, {r1, sp, lr}
-
-#ifdef THREAD_LOCAL_EXCEPTION_SPS
-        cps     #CPSR_MODE_ABT
-        mrs     r1, spsr
-        stm     r0!, {r1, sp, lr}
-
-        cps     #CPSR_MODE_UND
-        mrs     r1, spsr
-        stm     r0!, {r1, sp, lr}
-#endif /*THREAD_LOCAL_EXCEPTION_SPS*/
 
 	msr	cpsr, r6		/* Restore mode */
 

--- a/core/arch/arm32/kernel/thread_private.h
+++ b/core/arch/arm32/kernel/thread_private.h
@@ -52,22 +52,9 @@ struct thread_ctx_regs {
 	uint32_t r12;
 	uint32_t usr_sp;
 	uint32_t usr_lr;
-#ifdef THREAD_LOCAL_EXCEPTION_SPS
-	uint32_t irq_spsr;
-	uint32_t irq_sp;
-	uint32_t irq_lr;
-#endif /*THREAD_LOCAL_EXCEPTION_SPS*/
 	uint32_t svc_spsr;
 	uint32_t svc_sp;
 	uint32_t svc_lr;
-#ifdef THREAD_LOCAL_EXCEPTION_SPS
-	uint32_t abt_spsr;
-	uint32_t abt_sp;
-	uint32_t abt_lr;
-	uint32_t und_spsr;
-	uint32_t und_sp;
-	uint32_t und_lr;
-#endif /*THREAD_LOCAL_EXCEPTION_SPS*/
 	uint32_t pc;
 	uint32_t cpsr;
 };


### PR DESCRIPTION
Removes unused THREAD_LOCAL_EXCEPTION_SPS code.

Signed-off-by: Jens Wiklander jens.wiklander@linaro.org
Tested-by: Jens Wiklander jens.wiklander@linaro.org (QEMU virt platform)
