### PR TITLE
Clean cache_l1 and cache_l2 maintenance

### DIFF
--- a/core/arch/arm32/include/kernel/tz_ssvce.h
+++ b/core/arch/arm32/include/kernel/tz_ssvce.h
@@ -33,19 +33,11 @@ unsigned int secure_get_cpu_id(void);
 void arm_cl1_d_cleanbysetway(void);
 void arm_cl1_d_invbysetway(void);
 void arm_cl1_d_cleaninvbysetway(void);
-void arm_cl1_d_cleanbypa(unsigned long start, unsigned long end);
-void arm_cl1_d_invbypa(unsigned long start, unsigned long end);
-void arm_cl1_d_cleaninvbypa(unsigned long start, unsigned long end);
-
+void arm_cl1_d_cleanbyva(void *start, void *end);
+void arm_cl1_d_invbyva(void *start, void *end);
+void arm_cl1_d_cleaninvbyva(void *start, void *end);
 void arm_cl1_i_inv_all(void);
-void arm_cl1_i_inv(unsigned long start, unsigned long end);
-
-void arm_cl2_cleaninvbyway(void);
-void arm_cl2_invbyway(void);
-void arm_cl2_cleanbyway(void);
-void arm_cl2_cleanbypa(unsigned long start, unsigned long end);
-void arm_cl2_invbypa(unsigned long start, unsigned long end);
-void arm_cl2_cleaninvbypa(unsigned long start, unsigned long end);
+void arm_cl1_i_inv(void *start, void *end);
 
 void secure_mmu_datatlbinvall(void);
 void secure_mmu_unifiedtlbinvall(void);

--- a/core/arch/arm32/include/kernel/tz_ssvce_def.h
+++ b/core/arch/arm32/include/kernel/tz_ssvce_def.h
@@ -74,6 +74,8 @@
 /*
  * Outer cache iomem
  */
+#define PL310_WAY_SIZE	32
+
 #define PL310_BASE_H	((PL310_BASE >> 16) & 0xFFFF)
 #define PL310_BASE_L	(PL310_BASE & 0xFFFF)
 /* reg1 */

--- a/core/arch/arm32/include/kernel/tz_ssvce_pl310.h
+++ b/core/arch/arm32/include/kernel/tz_ssvce_pl310.h
@@ -28,11 +28,27 @@
 #ifndef TZ_SSVCE_PL310_H
 #define TZ_SSVCE_PL310_H
 
+#include <util.h>
+#include <kernel/tz_ssvce_def.h>
+#include <types_ext.h>
+
+#define arm_cl2_cleanbypa(start, end) \
+	_arm_cl2_cleanbypa(ROUNDDOWN((start), PL310_WAY_SIZE), \
+			ROUNDUP((end), PL310_WAY_SIZE))
+
+#define arm_cl2_invbypa(start, end) \
+	_arm_cl2_invbypa(ROUNDDOWN((start), PL310_WAY_SIZE), \
+			ROUNDUP((end), PL310_WAY_SIZE))
+
+#define arm_cl2_cleaninvbypa(start, end) \
+	_arm_cl2_cleaninvbypa(ROUNDDOWN((start), PL310_WAY_SIZE), \
+			ROUNDUP((end), PL310_WAY_SIZE))
+
 void arm_cl2_cleaninvbyway(void);
 void arm_cl2_invbyway(void);
 void arm_cl2_cleanbyway(void);
-void arm_cl2_cleanbypa(unsigned long start, unsigned long end);
-void arm_cl2_invbypa(unsigned long start, unsigned long end);
-void arm_cl2_cleaninvbypa(unsigned long start, unsigned long end);
+void _arm_cl2_cleanbypa(paddr_t start, paddr_t end);
+void _arm_cl2_invbypa(paddr_t start, paddr_t end);
+void _arm_cl2_cleaninvbypa(paddr_t start, paddr_t end);
 
 #endif /* TZ_SSVCE_PL310_H */

--- a/core/arch/arm32/include/mm/core_mmu.h
+++ b/core/arch/arm32/include/mm/core_mmu.h
@@ -132,8 +132,8 @@ int core_pa2va_helper(paddr_t pa, void **va);
 bool core_mmu_is_shm_cached(void);
 
 /* L1/L2 cache maintenance (op: refer to ???) */
-unsigned int core_cache_maintenance(int op, void *start, size_t len);
-unsigned int cache_maintenance_l2(int op, void *start, size_t len);
+unsigned int cache_maintenance_l1(int op, void *va, size_t len);
+unsigned int cache_maintenance_l2(int op, paddr_t pa, size_t len);
 void core_l2cc_mutex_set(void *mutex);
 void core_l2cc_mutex_activate(bool en);
 void core_l2cc_mutex_lock(void);

--- a/core/arch/arm32/kernel/tz_ssvce.S
+++ b/core/arch/arm32/kernel/tz_ssvce.S
@@ -50,9 +50,9 @@
 .global arm_cl1_d_cleanbysetway
 .global arm_cl1_d_invbysetway
 .global arm_cl1_d_cleaninvbysetway
-.global arm_cl1_d_cleanbypa
-.global arm_cl1_d_invbypa
-.global arm_cl1_d_cleaninvbypa
+.global arm_cl1_d_cleanbyva
+.global arm_cl1_d_invbyva
+.global arm_cl1_d_cleaninvbyva
 .global arm_cl1_i_inv_all
 .global arm_cl1_i_inv
 
@@ -219,9 +219,9 @@ _cli_nextLine:
 	MOV PC, LR
 
 /*
- * void arm_cl1_d_cleanbypa(unsigned long s, unsigned long e);
+ * void arm_cl1_d_cleanbyva(void *s, void *e);
  */
-arm_cl1_d_cleanbypa:
+arm_cl1_d_cleanbyva:
 
 	CMP     R0, R1                  @ ; check that end >= start. Otherwise return.
 	BHI     _cl_area_exit
@@ -243,9 +243,9 @@ _cl_area_exit:
 	MOV PC, LR
 
 /*
- * void arm_cl1_d_invbypa(unsigned long s, unsigned long e);
+ * void arm_cl1_d_invbyva(void *s, void *e);
  */
-arm_cl1_d_invbypa:
+arm_cl1_d_invbyva:
 
 	CMP     R0, R1                      @ ; check that end >= start. Otherwise return.
 	BHI     _inv_area_dcache_exit
@@ -267,9 +267,9 @@ _inv_area_dcache_exit:
 	MOV PC, LR
 
 /*
- * void arm_cl1_d_cleaninvbypa(unsigned long s, unsigned long e);
+ * void arm_cl1_d_cleaninvbyva(void *s, void *e);
  */
-arm_cl1_d_cleaninvbypa:
+arm_cl1_d_cleaninvbyva:
 
 	CMP     R0, R1                  @ ; check that end >= start. Otherwise return.
 	BHI     _cli_area_exit
@@ -312,9 +312,9 @@ arm_cl1_i_inv_all:
     BX      LR
 
 /*
- * void arm_cl1_i_inv(unsigned long start, unsigned long p_end);
+ * void arm_cl1_i_inv(void *start, void *end);
  *
- * Invalidates instruction cache area whose (physical) limits are given in parameters.
+ * Invalidates instruction cache area whose limits are given in parameters.
  * It also invalidates the BTAC.
  */
 arm_cl1_i_inv:

--- a/core/arch/arm32/kernel/tz_ssvce_pl310.S
+++ b/core/arch/arm32/kernel/tz_ssvce_pl310.S
@@ -32,9 +32,9 @@
 .global arm_cl2_cleaninvbyway
 .global arm_cl2_invbyway
 .global arm_cl2_cleanbyway
-.global arm_cl2_cleanbypa
-.global arm_cl2_invbypa
-.global arm_cl2_cleaninvbypa
+.global _arm_cl2_cleanbypa
+.global _arm_cl2_invbypa
+.global _arm_cl2_cleaninvbypa
 
 /*
  * void arm_cl2_cleaninvbyway(void) - clean & invalidate the whole L2 cache.
@@ -155,11 +155,11 @@ loop_cl_way_sync_done:
 	mov pc, lr
 
 /*
- * void arm_cl2_cleanbypa(unsigned long start, unsigned long end);
+ * void _arm_cl2_cleanbypa(paddr_t start, paddr_t end);
  *
  * clean L2 cache by physical address range.
  */
-arm_cl2_cleanbypa:
+_arm_cl2_cleanbypa:
 
 	/*
 	 * ARM ERRATA #764369
@@ -185,7 +185,7 @@ loop_cl_pa_done:
 	cmp R3, #0
 	bne loop_cl_pa_done
 
-	add R0, R0, #32
+	add R0, R0, #PL310_WAY_SIZE
 	cmp R1, R0
 	bne loop_cl2_clean_by_pa
 
@@ -211,11 +211,11 @@ loop_cl_pa_sync_done:
 	mov pc, lr
 
 /*
- * void arm_cl2_invbypa(unsigned long start, unsigned long end);
+ * void _arm_cl2_invbypa(paddr_t start, paddr_t end);
  *
  * invalidate L2 cache by physical address range.
  */
-arm_cl2_invbypa:
+_arm_cl2_invbypa:
 
 	/*
 	 * ARM ERRATA #764369
@@ -241,7 +241,7 @@ loop_inv_pa_done:
 	CMP R3, #0
 	BNE loop_inv_pa_done
 
-	ADD R0, R0, #32
+	ADD R0, R0, #PL310_WAY_SIZE
 	CMP R1, R0
 	BNE loop_cl2_inv_by_pa
 
@@ -268,11 +268,11 @@ loop_inv_pa_sync_done:
 	MOV PC, LR
 
 /*
- * void arm_cl2_cleaninvbypa(unsigned long start, unsigned long end);
+ * void _arm_cl2_cleaninvbypa(paddr_t start, paddr_t end);
  *
  * clean and invalidate L2 cache by physical address range.
  */
-arm_cl2_cleaninvbypa:
+_arm_cl2_cleaninvbypa:
 
 	mov r2, r0
 	/*

--- a/core/arch/arm32/mm/tee_pager_unpg.c
+++ b/core/arch/arm32/mm/tee_pager_unpg.c
@@ -318,13 +318,11 @@ static uint32_t tee_pager_handle_abort(const uint32_t flags, const uint32_t pc,
 		apage->ctx_handle = tee_ta_load_page(w_addr);
 		TEE_PAGER_SET_COPY(1);
 
-		core_cache_maintenance(DCACHE_AREA_CLEAN,
-				      (void *)(w_addr & 0xFFFFF000),
-				      SMALL_PAGE_SIZE);
+		cache_maintenance_l1(DCACHE_AREA_CLEAN,
+			(void *)(w_addr & 0xFFFFF000), SMALL_PAGE_SIZE);
 
-		core_cache_maintenance(ICACHE_AREA_INVALIDATE,
-				      (void *)(w_addr & 0xFFFFF000),
-				      SMALL_PAGE_SIZE);
+		cache_maintenance_l1(ICACHE_AREA_INVALIDATE,
+			(void *)(w_addr & 0xFFFFF000), SMALL_PAGE_SIZE);
 	}
 
 	/* end protect (multithreded version) */

--- a/core/arch/arm32/plat-stm/cache_maintenance.c
+++ b/core/arch/arm32/plat-stm/cache_maintenance.c
@@ -24,12 +24,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include <compiler.h>
+#include <arm32.h>
 #include <mm/core_mmu.h>
 #include <kernel/tz_ssvce_pl310.h>
 
-unsigned int cache_maintenance_l2(int op __unused, void *start __unused, size_t len __unused)
+unsigned int cache_maintenance_l2(int op __unused,
+				   paddr_t pa __unused, size_t len __unused)
 {
 	unsigned int ret = TEE_SUCCESS;
 


### PR DESCRIPTION
L1 cache maintenance is using Virtual Memory, wherease cache L2 maintenance
uses Physical Memory

Signed-off-by: Pascal Brand pascal.brand@st.com
