### PR TITLE
core: create conf.h from CFG_* Makefile variables

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -13,7 +13,8 @@ platform_$(PLATFORM) := y
 platform_flavor_$(PLATFORM_FLAVOR) := y
 cppflags$(sm)	+= -DPLATFORM_FLAVOR=PLATFORM_FLAVOR_ID_$(PLATFORM_FLAVOR)
 
-cppflags$(sm)	+= -Icore/include $(platform-cppflags) $(core-platform-cppflags)
+cppflags$(sm)	+= -Icore/include -I$(out-dir)/core/include
+cppflags$(sm)	+= $(platform-cppflags) $(core-platform-cppflags)
 cflags$(sm)	+= $(platform-cflags) $(core-platform-cflags)
 aflags$(sm)	+= $(platform-aflags) $(core-platform-aflags)
 
@@ -23,6 +24,16 @@ cppflags$(sm) += -DCFG_TEE_FW_DEBUG=$(CFG_TEE_FW_DEBUG)
 cppflags$(sm) += -DCFG_TEE_CORE_LOG_LEVEL=$(CFG_TEE_CORE_LOG_LEVEL)
 
 cppflags$(sm)	+= -Ilib/libutee/include
+
+# Tell all libraries and sub-directories (included below) that we have a
+# configuration file
+
+conf-file := $(out-dir)/core/include/generated/conf.h
+cleanfiles += $(conf-file)
+
+include mk/checkconf.mk
+$(conf-file): FORCE
+	$(call check-conf-h)
 
 #
 # Do libraries

--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -1,0 +1,54 @@
+# Generate/check/update a .h file to reflect the values of Makefile
+# variables
+#
+# Example usage (by default, check-conf-h will consider all CFG_*
+# variables):
+#
+# path/to/conf.h: FORCE
+#	$(call check-conf-h)
+#
+# Or, to include only the variables with the given prefix(es):
+#
+# path/to/crypto_config.h: FORCE
+#	$(call check-conf-h,CFG_CRYPTO_ CRYPTO_)
+
+define check-conf-h
+	$(q)set -e;						\
+	echo '  CHK     $@';					\
+	cnf="$(strip $(foreach var,				\
+		$(call cfg-vars-by-prefix,$1),			\
+		$(call cfg-make-define,$(var))))";		\
+	guard="_`echo $@ | tr -- -/. ___`_";			\
+	mkdir -p $(dir $@);					\
+	echo "#ifndef $${guard}" >$@.tmp;			\
+	echo "#define $${guard}" >>$@.tmp;			\
+	echo -n "$${cnf}" | sed 's/_nl_ */\n/g' >>$@.tmp;	\
+	echo "#endif" >>$@.tmp;					\
+	if [ -r $@ ] && cmp -s $@ $@.tmp; then			\
+		rm -f $@.tmp;					\
+	else							\
+		echo '  UPD     $@';				\
+		mv $@.tmp $@;					\
+	fi
+endef
+
+define cfg-vars-by-prefix
+	$(strip $(if $(1),$(call _cfg-vars-by-prefix,$(1)),
+			  $(call _cfg-vars-by-prefix,CFG_)))
+endef
+
+define _cfg-vars-by-prefix
+	$(sort $(foreach prefix,$(1),$(filter $(prefix)%,$(.VARIABLES))))
+endef
+
+# Convert a makefile variable to a #define
+# <undefined>, n => <undefined>
+# y              => 1
+# <other value>  => <other value>
+define cfg-make-define
+	$(strip $(if $(filter y,$($1)),
+		     #define $1 1 /* '$($1)' */_nl_,
+		     $(if $(filter xn x,x$($1)),
+			  /* $1 is not set ('$($1)') */_nl_,
+			  #define $1 $($1) /* '$($1)' */_nl_)))
+endef

--- a/mk/cleanvars.mk
+++ b/mk/cleanvars.mk
@@ -8,3 +8,4 @@ libnames	:=
 libdeps		:=
 sm-$(sm)	:=
 incdirs		:=
+conf-file	:=

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -2,6 +2,7 @@
 #
 # The output from mk/sub.mk
 # base-prefix
+# conf-file [optional] if set, all objects will depend on $(conf-file)
 #
 # Output
 #
@@ -113,3 +114,5 @@ endef
 
 $(foreach f, $(srcs), $(eval $(call \
 	process_srcs,$(f),$(out-dir)/$(base-prefix)$$(basename $f).o)))
+
+$(objs): $(conf-file)

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -3,6 +3,7 @@
 # libname	tells the name of the lib and
 # libdir	tells directory of lib which also is used as input to
 #		mk/subdir.mk
+# conf-file     [optional] if set, all objects will depend on $(conf-file)
 #
 # Output
 #
@@ -36,6 +37,8 @@ endif
 endef #process-lib
 
 $(eval $(call process-lib))
+
+$(objs): $(conf-file)
 
 # Clean residues from processing
 objs		:=


### PR DESCRIPTION
Simplify the use of makefile configuration variables from C code.
With this patch, one can #include <generated/conf.h> instead of adding
CPP flags definitions to the .mk files.
- CFG_\* variables that are set to 'y' are converted to: #define CFG_FOO 1
- Undefined variables, or variables set to 'n' remain undefined in conf.h
- CFG_\* variables with any other value are output unchanged

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
