### PR TITLE
fix processing R_ARM_ABS32 info of  TA's rel.dyn section 

### DIFF
--- a/core/arch/arm32/kernel/tee_ta_manager.c
+++ b/core/arch/arm32/kernel/tee_ta_manager.c
@@ -283,14 +283,24 @@ static void tee_ta_init_reldyn(struct tee_ta_ctx *const ctx)
 	uint32_t n;
 	uint32_t saddr =
 	    tee_ta_get_exec(ctx) + ctx->head->ro_size - rel_dyn_size;
+	uint32_t dynsym_addr = tee_ta_get_exec(ctx) + ctx->head->ro_size +
+			ctx->head->rw_size + ctx->head->zi_size;
 
 	for (n = 0; n < rel_dyn_size; n += sizeof(struct ta_rel_dyn)) {
 		struct ta_rel_dyn *rel_dyn = (struct ta_rel_dyn *)(saddr + n);
 		uint32_t *data;
 
-		if (rel_dyn->info != 0x17) {
+		if (rel_dyn->info != 0x17 ||
+			ELF32_R_TYPE(rel_dyn->info) != 0x02) {
 			DMSG("Unknown rel_dyn info 0x%x", rel_dyn->info);
 			TEE_ASSERT(0);
+		}
+
+		if (ELF32_R_TYPE(rel_dyn->info) == 0x02) {
+			int offset = ELF32_R_SYM(rel_dyn->info);
+			struct elf32_sym *sym =
+				((struct elf32_sym *)dynsym_addr) + offset;
+			*data += sym->st_value;
 		}
 
 		data = (uint32_t *)(ctx->load_addr + rel_dyn->addr);
@@ -458,7 +468,8 @@ static TEE_Result tee_ta_load_user_ta(struct tee_ta_ctx *ctx,
 	void *dst;
 
 	/* full required execution size (not stack etc...) */
-	size = ctx->head->ro_size + ctx->head->rw_size + ctx->head->zi_size;
+	size = ctx->head->ro_size + ctx->head->rw_size + ctx->head->zi_size +
+		ctx->head->dynsym_size;
 
 	if (ctx->num_res_funcs != 2)
 		return TEE_ERROR_BAD_FORMAT;

--- a/core/include/kernel/tee_ta.h
+++ b/core/include/kernel/tee_ta.h
@@ -46,6 +46,7 @@ typedef struct {
 	uint32_t rw_size;
 	uint32_t zi_size;
 	uint32_t rel_dyn_got_size;
+	uint32_t dynsym_size;
 	uint32_t hash_type;
 	/* uint32_t prop_tracelevel; */
 } ta_head_t;
@@ -54,6 +55,19 @@ struct ta_rel_dyn {
 	uint32_t addr;
 	uint32_t info;
 };
+
+struct elf32_sym {
+	uint32_t	st_name;
+	uint32_t	st_value;
+	uint32_t	st_size;
+	unsigned char	st_info;
+	unsigned char	st_other;
+	unsigned short st_shndx;
+};
+
+
+#define ELF32_R_SYM(x) ((x) >> 8)
+#define ELF32_R_TYPE(x) ((x) & 0xff)
 
 /*-----------------------------------------------------------------------------
    signed header

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -67,6 +67,7 @@ struct user_ta_head {
 	uint32_t rw_size;
 	uint32_t zi_size;
 	uint32_t got_size;
+	uint32_t linker_dynsym_size;
 	uint32_t hash_type;
 };
 

--- a/ta/arch/arm32/fix_ta_binary
+++ b/ta/arch/arm32/fix_ta_binary
@@ -65,6 +65,8 @@ my $offs_0x1c;
 my $offs_0x1csym = "linker_res_funcs_ZI_sections_size";
 my $offs_0x20;
 my $offs_0x20sym = "linker_rel_dyn_GOT";
+my $offs_0x24;
+my $offs_0x24sym = "linker_dynsym_size";
 
 sub read_value
 {
@@ -75,7 +77,8 @@ sub read_value
 
 while (<ELF>) {
     last if defined $offs_0x14 && defined $offs_0x18 &&
-            defined $offs_0x1c && defined $offs_0x20;
+            defined $offs_0x1c && defined $offs_0x20 &&
+	    defined $offs_0x24;
     #print "Got $_";
     my @line = split;
     my $line_elems = @line;
@@ -88,7 +91,9 @@ while (<ELF>) {
             $offs_0x1c = read_value($_);
         } elsif ($_ =~ m/$offs_0x20sym/) {
             $offs_0x20 = read_value($_);
-        }
+        } elsif ($_ =~ m/$offs_0x24sym/) {
+	    $offs_0x24 = read_value($_);
+	}
     }
 }
 
@@ -100,6 +105,8 @@ die "Didn't find required symbol $offs_0x1csym in $elf"
     unless defined $offs_0x1c;
 die "Didn't find required symbol $offs_0x20sym in $elf"
     unless defined $offs_0x20;
+die "Didn't find required symbol $offs_0x24sym in $elf"
+    unless defined $offs_0x24;
 
 sub write_value
 {
@@ -114,6 +121,7 @@ write_value(hex $offs_0x14, 0x14, $offs_0x14sym);
 write_value(hex $offs_0x18, 0x18, $offs_0x18sym);
 write_value(hex $offs_0x1c, 0x1c, $offs_0x1csym);
 write_value(hex $offs_0x20, 0x20, $offs_0x20sym);
+write_value(hex $offs_0x24, 0x24, $offs_0x24sym);
 
 close(BIN);
 close(ELF);

--- a/ta/arch/arm32/user_ta_elf_arm.lds
+++ b/ta/arch/arm32/user_ta_elf_arm.lds
@@ -101,9 +101,12 @@ SECTIONS
 
     end_of_ZI_sections = .;
 
+    start_of_dynsym_section = .;
+    .dynsym         ALIGN(4) : { *(.dynsym) }
+    end_of_dynsym_section = .;
+
     .interp         ALIGN(4) : { *(.interp) }
     .hash           ALIGN(4) : { *(.hash) }
-    .dynsym         ALIGN(4) : { *(.dynsym) }
     .dynstr         ALIGN(4) : { *(.dynstr) }
     .gnu.version    ALIGN(4) : { *(.gnu.version) }
     .gnu.version_d  ALIGN(4) : { *(.gnu.version_d) }
@@ -148,6 +151,7 @@ SECTIONS
     ASSERT(GOT_sections_size <= 0xffff, "Too large GOT_sections_size")
     ASSERT(rel_sections_size <= 0xffff, "Too large rel_sections_size")
     linker_rel_dyn_GOT = (rel_sections_size << 16) + GOT_sections_size;
+    linker_dynsym_size = end_of_dynsym_section - start_of_dynsym_section;
 
 }
 

--- a/ta/arch/arm32/user_ta_header.c
+++ b/ta/arch/arm32/user_ta_header.c
@@ -72,6 +72,7 @@ const struct user_ta_head ta_head __attribute__ ((section(".ta_head"))) = {
 	(uint32_t)&linker_RW_sections_size,
 	(uint32_t)&linker_res_funcs_ZI_sections_size,
 	(uint32_t)&linker_rel_dyn_GOT,
+	(uint32_t)&linker_dynsym_size,
 	/* Hash type, filled in by sign-tool */
 	0,
 	/* TA trace level */


### PR DESCRIPTION
add path for processing R_ARM_ABS32 info of TA's rel.dyn section
Avoid going to dead loop
(sometimes TA may contain this type section)

Signed-off-by: RockPZhang RockPZhang@viatech.com.cn
