### PR TITLE
Fix memory leak in tee_svc_cryp_obj_copy()

### DIFF
--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -131,6 +131,7 @@ struct bignum_ops {
 	void (*bn2bin)(const struct bignum *from, uint8_t *to);
 	void (*copy)(struct bignum *to, const struct bignum *from);
 	void (*free)(struct bignum *a);
+	void (*clear)(struct bignum *a);
 };
 
 /* Asymmetric algorithms */

--- a/core/include/tee/tee_obj.h
+++ b/core/include/tee/tee_obj.h
@@ -41,7 +41,7 @@ struct tee_obj {
 	uint32_t have_attrs;	/* bitfield identifying set properties */
 	void *data;
 	size_t data_size;
-	void (*finalize)(void *); /* called with data ptr before it's freed */
+	void (*cleanup)(void *data, bool del); /* clear or delete data */
 	struct tee_pobj *pobj;	/* ptr to persistant object */
 	int fd;
 	uint32_t ds_size;	/* data stream size */

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -549,6 +549,13 @@ static void bn_free(struct bignum *s)
 	free(s);
 }
 
+static void bn_clear(struct bignum *s)
+{
+	struct mpa_numbase_struct *bn = (struct mpa_numbase_struct *)s;
+
+	memset(bn, 0, bn->alloc);
+}
+
 static bool bn_alloc_max(struct bignum **s)
 {
 	size_t sz = mpa_StaticVarSizeInU32(LTC_MAX_BITS_PER_VARIABLE) *
@@ -2204,5 +2211,6 @@ struct crypto_ops crypto_ops = {
 		.bin2bn = bin2bn,
 		.copy = copy,
 		.free = bn_free,
+		.clear = bn_clear
 	}
 };

--- a/core/tee/tee_obj.c
+++ b/core/tee/tee_obj.c
@@ -62,8 +62,8 @@ void tee_obj_close(struct tee_ta_ctx *ctx, struct tee_obj *o)
 		tee_pobj_release(o->pobj);
 	}
 
-	if (o->finalize)
-		o->finalize(o->data);
+	if (o->cleanup)
+		o->cleanup(o->data, true);
 	free(o->data);
 	free(o);
 }


### PR DESCRIPTION
The following Trusted App would lead to a memory leak in the TEE core:

  TEE_ObjectHandle o1, o2;
  TEE_AllocateTransientObject(TEE_TYPE_RSA_KEYPAIR, 256, &o1);
  TEE_GenerateKey(o1, 256, NULL, 0);
  TEE_AllocateTransientObject(TEE_TYPE_RSA_KEYPAIR, 256, &o2);
  TEE_CopyObjectAttributes(o2, o1);
  TEE_FreeTransientObject(o1);
  TEE_FreeTransientObject(o2);

The leak was introduced by commit ffe0403 (Add crypto provider internal API).

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
