### PR TITLE
plat-stm: fix parallel build error

### DIFF
--- a/core/arch/arm32/plat-stm/link.mk
+++ b/core/arch/arm32/plat-stm/link.mk
@@ -21,6 +21,7 @@ ldargs-tee.elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc)
 
 $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
 	@echo '  SED     $@'
+	@mkdir -p $(dir $@)
 	$(q)sed -e "s/%in_TEE_SCATTER_START%/$(TEE_SCATTER_START)/g" < $< > $@
 
 


### PR DESCRIPTION
Generation of out/arm32-plat-stm/core/tz.lds may occur when the directory
out/arm32-plat-stm/core does not exist yet. The command should therefore
create it.
Note: plat-vexpress is correct.

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
