### PR TITLE
MAC operations now supports NULL arguments

### DIFF
--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -78,11 +78,9 @@ struct mac_ops {
 	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
 	TEE_Result (*init)(void *ctx, uint32_t algo,
 			   const uint8_t *key, size_t len);
-
 	TEE_Result (*update)(void *ctx, uint32_t algo,
 			     const uint8_t *data, size_t len);
 	TEE_Result (*final)(void *ctx, uint32_t algo,
-			    const uint8_t *data, size_t data_len,
 			    uint8_t *digest, size_t digest_len);
 };
 

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -1743,8 +1743,7 @@ static TEE_Result mac_update(void *ctx, uint32_t algo,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result mac_final(void *ctx, uint32_t algo, const uint8_t *data,
-			    size_t data_len, uint8_t *digest,
+static TEE_Result mac_final(void *ctx, uint32_t algo, uint8_t *digest,
 			    size_t digest_len)
 {
 	struct cbc_state *cbc;
@@ -1758,11 +1757,6 @@ static TEE_Result mac_final(void *ctx, uint32_t algo, const uint8_t *data,
 	case TEE_ALG_HMAC_SHA256:
 	case TEE_ALG_HMAC_SHA384:
 	case TEE_ALG_HMAC_SHA512:
-		if (data && data_len) {
-			if (CRYPT_OK != hmac_process((hmac_state *)ctx, data,
-						     data_len))
-				return TEE_ERROR_BAD_STATE;
-		}
 		if (CRYPT_OK != hmac_done((hmac_state *)ctx, digest,
 					  &ltc_digest_len))
 			return TEE_ERROR_BAD_STATE;
@@ -1775,9 +1769,6 @@ static TEE_Result mac_final(void *ctx, uint32_t algo, const uint8_t *data,
 	case TEE_ALG_DES3_CBC_MAC_NOPAD:
 	case TEE_ALG_DES3_CBC_MAC_PKCS5:
 		cbc = (struct cbc_state *)ctx;
-
-		if (TEE_SUCCESS != mac_update(ctx, algo, data, data_len))
-			return TEE_ERROR_BAD_STATE;
 
 		/* Padding is required */
 		switch (algo) {
@@ -1811,11 +1802,6 @@ static TEE_Result mac_final(void *ctx, uint32_t algo, const uint8_t *data,
 		break;
 
 	case TEE_ALG_AES_CMAC:
-		if (data && data_len) {
-			if (CRYPT_OK != omac_process((omac_state *)ctx, data,
-						     data_len))
-				return TEE_ERROR_BAD_STATE;
-		}
 		if (CRYPT_OK != omac_done((omac_state *)ctx, digest,
 					  &ltc_digest_len))
 			return TEE_ERROR_BAD_STATE;


### PR DESCRIPTION
MAC algorithms support NULL arguments and zero length strings.

Note that the fix consists in a change of API in the internal crypto
interface. This change make hash_ops and mac_ops look the same in terms of
update and final step

Signed-off-by: Pascal Brand pascal.brand@st.com
Tested-by: Pascal Brand pascal.brand@linaro.org (STM platform)
