### PR TITLE
Add HMAC-based extract-and-expand key derivation function (HKDF)

### DIFF
--- a/core/include/tee/tee_cryp_hkdf.h
+++ b/core/include/tee/tee_cryp_hkdf.h
@@ -25,42 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef TEE_API_DEFINES_EXTENSIONS_H
-#define TEE_API_DEFINES_EXTENSIONS_H
+#ifndef TEE_CRYP_HKDF_H
+#define TEE_CRYP_HKDF_H
 
-/*
- * HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
- */
+#include <tee_api_types.h>
 
-#define TEE_ALG_HKDF_MD5_DERIVE_KEY     0x800010C0
-#define TEE_ALG_HKDF_SHA1_DERIVE_KEY    0x800020C0
-#define TEE_ALG_HKDF_SHA224_DERIVE_KEY  0x800030C0
-#define TEE_ALG_HKDF_SHA256_DERIVE_KEY  0x800040C0
-#define TEE_ALG_HKDF_SHA384_DERIVE_KEY  0x800050C0
-#define TEE_ALG_HKDF_SHA512_DERIVE_KEY  0x800060C0
+TEE_Result tee_cryp_hkdf(uint32_t hash_id, const uint8_t *ikm, size_t ikm_len,
+			 const uint8_t *salt, size_t salt_len,
+			 const uint8_t *info, size_t info_len, uint8_t *okm,
+			 size_t okm_len);
 
-#define TEE_TYPE_HKDF_IKM               0xA10000C0
-
-#define TEE_ATTR_HKDF_IKM               0xC00001C0
-#define TEE_ATTR_HKDF_SALT              0xD00002C0
-#define TEE_ATTR_HKDF_INFO              0xD00003C0
-#define TEE_ATTR_HKDF_OKM_LENGTH        0xF00004C0
-
-/*
- * Concatenation Key Derivation Function (Concat KDF)
- * NIST SP 800-56A section 5.8.1
- */
-
-#define TEE_ALG_CONCAT_KDF_SHA1_DERIVE_KEY    0x800020C1
-#define TEE_ALG_CONCAT_KDF_SHA224_DERIVE_KEY  0x800030C1
-#define TEE_ALG_CONCAT_KDF_SHA256_DERIVE_KEY  0x800040C1
-#define TEE_ALG_CONCAT_KDF_SHA384_DERIVE_KEY  0x800050C1
-#define TEE_ALG_CONCAT_KDF_SHA512_DERIVE_KEY  0x800060C1
-
-#define TEE_TYPE_CONCAT_KDF_Z                 0xA10000C1
-
-#define TEE_ATTR_CONCAT_KDF_Z                 0xC00001C1
-#define TEE_ATTR_CONCAT_KDF_OTHER_INFO        0xD00002C1
-#define TEE_ATTR_CONCAT_KDF_DKM_LENGTH        0xF00003C1
-
-#endif /* TEE_API_DEFINES_EXTENSIONS_H */
+#endif /* TEE_CRYP_HKDF_H */

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -1693,14 +1693,17 @@ static TEE_Result mac_init(void *ctx, uint32_t algo, const uint8_t *key,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result mac_update(void *ctx, uint32_t algo,
-				     const uint8_t *data, size_t len)
+static TEE_Result mac_update(void *ctx, uint32_t algo, const uint8_t *data,
+			     size_t len)
 {
 #if defined(CFG_CRYPTO_CBC_MAC)
 	int ltc_res;
 	struct cbc_state *cbc;
 	size_t pad_len;
 #endif
+
+	if (!data || !len)
+		return TEE_SUCCESS;
 
 	switch (algo) {
 #if defined(CFG_CRYPTO_HMAC)

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -1,16 +1,23 @@
 CFG_CRYPTO ?= y
 
 ifeq (y,$(CFG_CRYPTO))
+
+# HMAC-based Extract-and-Expand Key Derivation Function
+# http://tools.ietf.org/html/rfc5869
+# This is an OP-TEE extension, not part of the GlobalPlatform Internal API v1.0
+CFG_CRYPTO_HKDF ?= y
+
 # NIST SP800-56A Concatenation Key Derivation Function
 # This is an OP-TEE extension
 CFG_CRYPTO_CONCAT_KDF ?= y
+
 endif
 
 srcs-y += tee_svc.c
 srcs-y += tee_svc_cryp.c
 srcs-y += tee_svc_storage.c
-
 srcs-y += tee_cryp_utl.c
+srcs-$(CFG_CRYPTO_HKDF) += tee_cryp_hkdf.c
 srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
 srcs-y += tee_fs.c
 srcs-y += tee_obj.c

--- a/core/tee/tee_cryp_hkdf.c
+++ b/core/tee/tee_cryp_hkdf.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <tee/tee_cryp_hkdf.h>
+#include <tee/tee_cryp_provider.h>
+#include <tee/tee_cryp_utl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <utee_defines.h>
+
+
+static const uint8_t zero_salt[TEE_MAX_HASH_SIZE];
+
+static TEE_Result hkdf_extract(uint32_t hash_id, const uint8_t *ikm,
+			       size_t ikm_len, const uint8_t *salt,
+			       size_t salt_len, uint8_t *prk, size_t *prk_len)
+{
+	TEE_Result res;
+	size_t ctx_size;
+	void *ctx = NULL;
+	uint32_t hash_algo = TEE_ALG_HASH_ALGO(hash_id);
+	uint32_t hmac_algo = (TEE_OPERATION_MAC << 28) | hash_id;
+	struct mac_ops *m = &crypto_ops.mac;
+
+	if (!m->get_ctx_size || !m->init || !m->update) {
+		res = TEE_ERROR_NOT_IMPLEMENTED;
+		goto out;
+	}
+
+	if (!salt || !salt_len) {
+		/*
+		 * RFC 5869 section 2.2:
+		 * If not provided, [the salt] is set to a string of HashLen
+		 * zeros
+		 */
+		salt = zero_salt;
+		res = tee_hash_get_digest_size(hash_algo, &salt_len);
+		if (res != TEE_SUCCESS)
+			goto out;
+	}
+
+	res = m->get_ctx_size(hmac_algo, &ctx_size);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	ctx = malloc(ctx_size);
+	if (!ctx) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	/*
+	 * RFC 5869 section 2.1: "Note that in the extract step, 'IKM' is used
+	 * as the HMAC input, not as the HMAC key."
+	 * Therefore, salt is the HMAC key in the formula from section 2.2:
+	 * "PRK = HMAC-Hash(salt, IKM)"
+	 */
+	res = m->init(ctx, hmac_algo, salt, salt_len);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = m->update(ctx, hmac_algo, ikm, ikm_len);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = m->final(ctx, hmac_algo, prk, *prk_len);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = tee_hash_get_digest_size(hash_algo, prk_len);
+out:
+	free(ctx);
+	return res;
+}
+
+static TEE_Result hkdf_expand(uint32_t hash_id, const uint8_t *prk,
+			      size_t prk_len, const uint8_t *info,
+			      size_t info_len, uint8_t *okm, size_t okm_len)
+{
+	uint8_t tn[TEE_MAX_HASH_SIZE];
+	size_t tn_len, hash_len, i, n, where, ctx_size;
+	TEE_Result res = TEE_SUCCESS;
+	void *ctx = NULL;
+	struct mac_ops *m = &crypto_ops.mac;
+	uint32_t hash_algo = TEE_ALG_HASH_ALGO(hash_id);
+	uint32_t hmac_algo = TEE_ALG_HMAC_ALGO(hash_id);
+
+	if (!m->get_ctx_size || !m->init || !m->update || !m->final) {
+		res = TEE_ERROR_NOT_IMPLEMENTED;
+		goto out;
+	}
+
+	res = tee_hash_get_digest_size(hash_algo, &hash_len);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	if (!okm || prk_len < hash_len) {
+		res = TEE_ERROR_BAD_STATE;
+		goto out;
+	}
+
+	if (!info)
+		info_len = 0;
+
+	res = m->get_ctx_size(hmac_algo, &ctx_size);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	ctx = malloc(ctx_size);
+	if (!ctx) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	/* N = ceil(L/HashLen) */
+	n = okm_len / hash_len;
+	if ((okm_len % hash_len) != 0)
+		n++;
+
+	if (n > 255) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+
+	/*
+	 * RFC 5869 section 2.3
+	 *   T = T(1) | T(2) | T(3) | ... | T(N)
+	 *   OKM = first L octets of T
+	 *   T(0) = empty string (zero length)
+	 *   T(1) = HMAC-Hash(PRK, T(0) | info | 0x01)
+	 *   T(2) = HMAC-Hash(PRK, T(1) | info | 0x02)
+	 *   T(3) = HMAC-Hash(PRK, T(2) | info | 0x03)
+	 *   ...
+	 */
+	tn_len = 0;
+	where = 0;
+	for (i = 1; i <= n; i++) {
+		uint8_t c = i;
+
+		res = m->init(ctx, hmac_algo, prk, prk_len);
+		if (res != TEE_SUCCESS)
+			goto out;
+		res = m->update(ctx, hmac_algo, tn, tn_len);
+		if (res != TEE_SUCCESS)
+			goto out;
+		res = m->update(ctx, hmac_algo, info, info_len);
+		if (res != TEE_SUCCESS)
+			goto out;
+		res = m->update(ctx, hmac_algo, &c, 1);
+		if (res != TEE_SUCCESS)
+			goto out;
+		res = m->final(ctx, hmac_algo, tn, sizeof(tn));
+		if (res != TEE_SUCCESS)
+			goto out;
+
+		memcpy(okm + where, tn, (i < n) ? hash_len : (okm_len - where));
+		where += hash_len;
+		tn_len = hash_len;
+	}
+
+out:
+	free(ctx);
+	return res;
+}
+
+TEE_Result tee_cryp_hkdf(uint32_t hash_id, const uint8_t *ikm, size_t ikm_len,
+			 const uint8_t *salt, size_t salt_len,
+			 const uint8_t *info, size_t info_len, uint8_t *okm,
+			 size_t okm_len)
+{
+	TEE_Result res;
+	uint8_t prk[TEE_MAX_HASH_SIZE];
+	size_t prk_len = sizeof(prk);
+
+	res = hkdf_extract(hash_id, ikm, ikm_len, salt, salt_len, prk,
+			   &prk_len);
+	if (res != TEE_SUCCESS)
+		return res;
+	res = hkdf_expand(hash_id, prk, prk_len, info, info_len, okm,
+			  okm_len);
+
+	return res;
+}

--- a/documentation/extensions/crypto_hkdf.md
+++ b/documentation/extensions/crypto_hkdf.md
@@ -1,0 +1,99 @@
+# OP-TEE HKDF key derivation support
+
+OP-TEE implements the *HMAC-based Extract-and-Expand Key Derivation Function
+(HKDF)* specified in [RFC 5869](http://tools.ietf.org/html/rfc5869). This
+file documents the extensions to the *GlobalPlatform TEE Internal API
+Specification v1.0* that were implemented to support this algorithm. Trusted
+Applications should include `<tee_api_defines_extensions.h>` to import the
+definitions.
+
+Note that the implementation follows the recommendations of version 1.1 of the
+specification for adding new algorithms. It should make it compatible with
+future changes to the official specification.
+
+You can disable this extension by setting the following in `conf.mk`:
+
+    CFG_CRYPTO_HKDF := n
+
+## p.95 Add new object type to TEE_PopulateTransientObject
+
+The following entry shall be added to Table 5-8:
+
+Object type       | Parts
+:-----------------|:--------------------------------------------
+TEE_TYPE_HKDF_IKM | The TEE_ATTR_HKDF_IKM (Input Keying Material) part must be provided.
+
+## p.121 Add new algorithms for TEE_AllocateOperation
+
+The following entry shall be added to Table 6-3:
+
+Algorithm                   | Possible Modes
+:---------------------------|:--------------
+TEE_ALG_HKDF_MD5_DERIVE_KEY <br> TEE_ALG_HKDF_SHA1_DERIVE_KEY <br> TEE_ALG_HKDF_SHA224_DERIVE_KEY <br> TEE_ALG_HKDF_SHA256_DERIVE_KEY <br> TEE_ALG_HKDF_SHA384_DERIVE_KEY <br> TEE_ALG_HKDF_SHA512_DERIVE_KEY <br> TEE_ALG_HKDF_SHA512_DERIVE_KEY | TEE_MODE_DERIVE
+
+## p.126 Explain usage of HKDF algorithms in TEE_SetOperationKey
+
+In the bullet list about operation mode, the following shall be added:
+
+    * For the HKDF algorithms, the only supported mode is TEE_MODE_DERIVE.
+
+## p.150 Define TEE_DeriveKey input attributes for new algorithms
+
+The following sentence shall be deleted:
+
+    The TEE_DeriveKey function can only be used with the algorithm
+    TEE_ALG_DH_DERIVE_SHARED_SECRET
+
+The following entry shall be added to Table 6-7:
+
+Algorithm                   | Possible operation parameters
+:---------------------------|:-----------------------------
+TEE_ALG_HKDF_MD5_DERIVE_KEY <br> TEE_ALG_HKDF_SHA1_DERIVE_KEY <br> TEE_ALG_HKDF_SHA224_DERIVE_KEY <br> TEE_ALG_HKDF_SHA256_DERIVE_KEY <br> TEE_ALG_HKDF_SHA384_DERIVE_KEY <br> TEE_ALG_HKDF_SHA512_DERIVE_KEY <br> TEE_ALG_HKDF_SHA512_DERIVE_KEY | TEE_ATTR_HKDF_OKM_LENGTH: Number of bytes in the Output Keying Material <br> TEE_ATTR_HKDF_SALT (optional) Salt to be used during the extract step <br> TEE_ATTR_HKDF_INFO (optional) Info to be used during the expand step <br>
+
+## p.152 Add new algorithm identifiers
+
+The following entries shall be added to Table 6-8:
+
+Algorithm                      | Identifier
+:------------------------------|:----------
+TEE_ALG_HKDF_MD5_DERIVE_KEY    | 0x800010C0
+TEE_ALG_HKDF_SHA1_DERIVE_KEY   | 0x800020C0
+TEE_ALG_HKDF_SHA224_DERIVE_KEY | 0x800030C0
+TEE_ALG_HKDF_SHA256_DERIVE_KEY | 0x800040C0
+TEE_ALG_HKDF_SHA384_DERIVE_KEY | 0x800050C0
+TEE_ALG_HKDF_SHA512_DERIVE_KEY | 0x800060C0
+
+## p.154 Define new main algorithm
+
+In Table 6-9 in section 6.10.1, a new value shall be added to the value column
+for row bits [7:0]:
+
+Bits       | Function                                       | Value
+:----------|:-----------------------------------------------|:-----------------
+Bits [7:0] | Identifiy the main underlying algorithm itself | ...<br>0xC0: HKDF
+
+The function column for bits[15:12] shall also be modified to read:
+
+Bits         | Function                                     | Value
+:------------|:---------------------------------------------|:-----------
+Bits [15:12] | Define the message digest for asymmetric signature algorithms or HKDF |
+
+## p.155 Add new object type for HKDF input keying material
+
+The following entry shall be added to Table 6-10:
+
+Name              | Identifier | Possible sizes
+:-----------------|:-----------|:--------------------------------
+TEE_TYPE_HKDF_IKM | 0xA10000C0 | 8 to 4096 bits (multiple of 8)
+
+## p.156 Add new operation attributes for HKDF salt and info
+
+The following entries shall be added to Table 6-11:
+
+Name                     | Value      | Protection | Type  | Comment
+:------------------------|:-----------|:-----------|:------|:--------
+TEE_ATTR_HKDF_IKM        | 0xC00001C0 | Protected  | Ref   |
+TEE_ATTR_HKDF_SALT       | 0xD00002C0 | Public     | Ref   |
+TEE_ATTR_HKDF_INFO       | 0xD00003C0 | Public     | Ref   |
+TEE_ATTR_HKDF_OKM_LENGTH | 0xF00004C0 | Public     | Value |
+

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -44,6 +44,7 @@
 #define TEE_MAIN_ALGO_RSA        0x30
 #define TEE_MAIN_ALGO_DSA        0x31
 #define TEE_MAIN_ALGO_DH         0x32
+#define TEE_MAIN_ALGO_HKDF       0xC0 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_CONCAT_KDF 0xC1 /* OP-TEE extension */
 
 
@@ -88,6 +89,10 @@
 	/* Extract digest hash and return hash algorithm */
 #define TEE_DIGEST_HASH_TO_ALGO(algo) \
                 TEE_ALG_HASH_ALGO(TEE_ALG_GET_DIGEST_HASH(algo))
+
+/* Return HMAC algorithm based on main hash */
+#define TEE_ALG_HMAC_ALGO(main_hash) \
+	(TEE_OPERATION_MAC << 28 | (main_hash))
 
 #define TEE_AES_BLOCK_SIZE  16UL
 #define TEE_DES_BLOCK_SIZE  8UL

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -144,6 +144,12 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		break;
 
 	case TEE_ALG_DH_DERIVE_SHARED_SECRET:
+	case TEE_ALG_HKDF_MD5_DERIVE_KEY:
+	case TEE_ALG_HKDF_SHA1_DERIVE_KEY:
+	case TEE_ALG_HKDF_SHA224_DERIVE_KEY:
+	case TEE_ALG_HKDF_SHA256_DERIVE_KEY:
+	case TEE_ALG_HKDF_SHA384_DERIVE_KEY:
+	case TEE_ALG_HKDF_SHA512_DERIVE_KEY:
 	case TEE_ALG_CONCAT_KDF_SHA1_DERIVE_KEY:
 	case TEE_ALG_CONCAT_KDF_SHA224_DERIVE_KEY:
 	case TEE_ALG_CONCAT_KDF_SHA256_DERIVE_KEY:
@@ -1108,6 +1114,7 @@ void TEE_DeriveKey(TEE_OperationHandle operation,
 		TEE_Panic(0);
 	if (paramCount != 0 && params == NULL)
 		TEE_Panic(0);
+
 	if (TEE_ALG_GET_CLASS(operation->info.algorithm) !=
 			TEE_OPERATION_KEY_DERIVATION)
 		TEE_Panic(0);


### PR DESCRIPTION
HKDF (http://tools.ietf.org/html/rfc5869) is a key derivation algorithm.
As per the RFC:

   A key derivation function (KDF) is a basic and essential component of
   cryptographic systems.  Its goal is to take some source of initial
   keying material and derive from it one or more cryptographically
   strong secret keys.
   [...]
   HKDF follows the "extract-then-expand" paradigm, where the KDF
   logically consists of two modules.
   [...]
   The goal of the "extract" stage is to "concentrate" the possibly
   dispersed entropy of the input keying material into a short, but
   cryptographically strong, pseudorandom key.
   [...]
   The second stage "expands" the pseudorandom key to the desired
   length; the number and lengths of the output keys depend on the
   specific cryptographic algorithms for which the keys are needed.

Since HKDF is not covered by the GlobalPlatform Internal API specification
v1.0/v1.1, this commit introduces extensions to the specification.
More specifically: it defines new algorithms, a new object type and new
object attributes. This implementation supports all the usual hash
functions (MD5, SHA-1, SHA-224, SHA-256, SHA-384, SHA-512) and may
produce output keys of length up to 4096 bits (currently limited only by
the maximum size allowed for an object of type TEE_TYPE_GENERIC_SECRET).
Aside from minor updates to object manipulation functions to support
the new data, the function TEE_DeriveKey() is mostly impacted.

The file documentation/crypto_hkdf.md contains the modifications to
the GP Internal API v1.0 spec in order to support HKDF.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>