### PR TITLE
Add PKCS #5 v2.0 key derivation function 2 (PBKDF2)

### DIFF
--- a/core/include/tee/tee_cryp_pbkdf2.h
+++ b/core/include/tee/tee_cryp_pbkdf2.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TEE_CRYP_PBKDF2_H
+#define TEE_CRYP_PBKDF2_H
+
+#include <tee_api_types.h>
+
+TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
+			   size_t password_len, const uint8_t *salt,
+			   size_t salt_len, uint32_t iteration_count,
+			   uint8_t *derived_key, size_t derived_key_len);
+
+#endif /* TEE_CRYP_PBKDF2_H */

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -11,6 +11,10 @@ CFG_CRYPTO_HKDF ?= y
 # This is an OP-TEE extension
 CFG_CRYPTO_CONCAT_KDF ?= y
 
+# PKCS #5 v2.0 / RFC 2898 key derivation function 2
+# This is an OP-TEE extension
+CFG_CRYPTO_PBKDF2 ?= y
+
 endif
 
 srcs-y += tee_svc.c
@@ -19,6 +23,7 @@ srcs-y += tee_svc_storage.c
 srcs-y += tee_cryp_utl.c
 srcs-$(CFG_CRYPTO_HKDF) += tee_cryp_hkdf.c
 srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
+srcs-$(CFG_CRYPTO_PBKDF2) += tee_cryp_pbkdf2.c
 srcs-y += tee_fs.c
 srcs-y += tee_obj.c
 srcs-y += tee_pobj.c

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <tee/tee_cryp_pbkdf2.h>
+#include <tee/tee_cryp_provider.h>
+#include <tee/tee_cryp_utl.h>
+#include <utee_defines.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct hmac_parms {
+	uint32_t algo;
+	size_t hash_len;
+	void *ctx;
+};
+
+struct pbkdf2_parms {
+	const uint8_t *password;
+	size_t password_len;
+	const uint8_t *salt;
+	size_t salt_len;
+	uint32_t iteration_count;
+};
+
+static TEE_Result pbkdf2_f(uint8_t *out, size_t len, uint32_t idx,
+			   struct hmac_parms *h, struct pbkdf2_parms *p)
+{
+	TEE_Result res;
+	uint8_t u[TEE_MAX_HASH_SIZE];
+	uint32_t be_index;
+	size_t i, j;
+	struct mac_ops *mac = &crypto_ops.mac;
+
+	memset(out, 0, len);
+	for (i = 1; i <= p->iteration_count; i++) {
+		res = mac->init(h->ctx, h->algo, p->password, p->password_len);
+		if (res != TEE_SUCCESS)
+			return res;
+
+		if (i == 1) {
+			if (p->salt && p->salt_len) {
+				res = mac->update(h->ctx, h->algo, p->salt,
+						  p->salt_len);
+				if (res != TEE_SUCCESS)
+					return res;
+			}
+
+			be_index = TEE_U32_TO_BIG_ENDIAN(idx);
+
+			res = mac->update(h->ctx, h->algo,
+					  (uint8_t *)&be_index,
+					  sizeof(be_index));
+			if (res != TEE_SUCCESS)
+				return res;
+		} else {
+			res = mac->update(h->ctx, h->algo, u, h->hash_len);
+			if (res != TEE_SUCCESS)
+				return res;
+		}
+
+		res = mac->final(h->ctx, h->algo, u, sizeof(u));
+		if (res != TEE_SUCCESS)
+			return res;
+
+		for (j = 0; j < len; j++)
+			out[j] ^= u[j];
+	}
+	return TEE_SUCCESS;
+}
+
+TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
+			   size_t password_len, const uint8_t *salt,
+			   size_t salt_len, uint32_t iteration_count,
+			   uint8_t *derived_key, size_t derived_key_len)
+{
+	TEE_Result res;
+	size_t ctx_size, i, l, r;
+	uint8_t *out = derived_key;
+	struct pbkdf2_parms pbkdf2_parms;
+	struct hmac_parms hmac_parms = {0, };
+	struct mac_ops *mac = &crypto_ops.mac;
+
+	if (!mac->get_ctx_size || !mac->init || !mac->update ||
+	    !mac->final)
+		return TEE_ERROR_NOT_IMPLEMENTED;
+
+	hmac_parms.algo = TEE_ALG_HMAC_ALGO(hash_id);
+
+	res = tee_mac_get_digest_size(hmac_parms.algo, &hmac_parms.hash_len);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = mac->get_ctx_size(hmac_parms.algo, &ctx_size);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	hmac_parms.ctx = malloc(ctx_size);
+	if (!hmac_parms.ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	pbkdf2_parms.password = password;
+	pbkdf2_parms.password_len = password_len;
+	pbkdf2_parms.salt = salt;
+	pbkdf2_parms.salt_len = salt_len;
+	pbkdf2_parms.iteration_count = iteration_count;
+
+	l = derived_key_len / hmac_parms.hash_len;
+	r = derived_key_len % hmac_parms.hash_len;
+
+	for (i = 1; i <= l; i++) {
+		res = pbkdf2_f(out, hmac_parms.hash_len, i, &hmac_parms,
+			       &pbkdf2_parms);
+		if (res != TEE_SUCCESS)
+			goto out;
+		out += hmac_parms.hash_len;
+	}
+	if (r)
+		res = pbkdf2_f(out, r, i, &hmac_parms, &pbkdf2_parms);
+
+out:
+	free(hmac_parms.ctx);
+	return res;
+}

--- a/documentation/extensions/crypto_pbkdf2.md
+++ b/documentation/extensions/crypto_pbkdf2.md
@@ -1,0 +1,94 @@
+# PKCS #5 v2.0 Key Derivation Function 2 (PBKDF2)
+
+This document describes the OP-TEE implementation of the key derivation function
+specified in [RFC 2898](https://www.ietf.org/rfc/rfc2898.txt) section 5.2. This
+RFC is a republication of PKCS #5 v2.0 from RSA Laboratories' Public-Key
+Cryptography Standards (PKCS) series.
+
+You may disable this extension by setting the following configuration variable
+in `conf.mk`:
+
+    CFG_CRYPTO_PBKDF2 := n
+
+## API extension
+
+To support PBKDF2, the *GlobalPlatform TEE Internal API Specification
+v1.0* was extended with a new algorithm descriptor, new object types, and new
+object attributes as described below.
+
+### p.95 Add new object type to TEE_PopulateTransientObject
+
+The following entry shall be added to Table 5-8:
+
+Object type              | Parts
+:------------------------|:--------------------------------------------
+TEE_TYPE_PBKDF2_PASSWORD | The TEE_ATTR_PBKDF2_PASSWORD part must be provided.
+
+### p.121 Add new algorithms for TEE_AllocateOperation
+
+The following entry shall be added to Table 6-3:
+
+Algorithm                   | Possible Modes
+:---------------------------|:--------------
+TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY | TEE_MODE_DERIVE
+
+### p.126 Explain usage of PBKDF2 algorithm in TEE_SetOperationKey
+
+In the bullet list about operation mode, the following shall be added:
+
+    * For the PBKDF2 algorithm, the only supported mode is TEE_MODE_DERIVE.
+
+### p.150 Define TEE_DeriveKey input attributes for new algorithms
+
+The following sentence shall be deleted:
+
+    The TEE_DeriveKey function can only be used with the algorithm
+    TEE_ALG_DH_DERIVE_SHARED_SECRET
+
+The following entry shall be added to Table 6-7:
+
+Algorithm                   | Possible operation parameters
+:---------------------------|:-----------------------------
+TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY | TEE_ATTR_PBKDF2_DKM_LENGTH: up to 512 bytes. This parameter is mandatory. <br> TEE_ATTR_PBKDF2_SALT <br> TEE_ATTR_PBKDF2_ITERATION_COUNT: This parameter is mandatory.
+
+### p.152 Add new algorithm identifiers
+
+The following entries shall be added to Table 6-8:
+
+Algorithm                            | Identifier
+:------------------------------------|:----------
+TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY  | 0x800020C2
+
+### p.154 Define new main algorithm
+
+In Table 6-9 in section 6.10.1, a new value shall be added to the value column
+for row bits [7:0]:
+
+Bits       | Function                                       | Value
+:----------|:-----------------------------------------------|:-----------------
+Bits [7:0] | Identifiy the main underlying algorithm itself | ...<br>0xC2: PBKDF2
+
+The function column for bits[15:12] shall also be modified to read:
+
+Bits         | Function                                     | Value
+:------------|:---------------------------------------------|:-----------
+Bits [15:12] | Define the message digest for asymmetric signature algorithms or PBKDF2 |
+
+### p.155 Add new object type for PBKDF2 password
+
+The following entry shall be added to Table 6-10:
+
+Name                              | Identifier | Possible sizes
+:---------------------------------|:-----------|:--------------------------------
+TEE_TYPE_PBKDF2_PASSWORD          | 0xA10000C2 | 8 to 4096 bits (multiple of 8)
+
+### p.156 Add new operation attributes for Concat KDF
+
+The following entries shall be added to Table 6-11:
+
+Name                               | Value      | Protection | Type  | Comment
+:----------------------------------|:-----------|:-----------|:------|:--------
+TEE_ATTR_PBKDF2_PASSWORD           | 0xC00001C2 | Protected  | Ref   |
+TEE_ATTR_PBKDF2_SALT               | 0xD00002C2 | Public     | Ref   |
+TEE_ATTR_PBKDF2_ITERATION_COUNT    | 0xF00003C2 | Public     | Value |
+TEE_ATTR_PBKDF2_DKM_LENGTH         | 0xF00004C2 | Public     | Value | The length (in bytes) of the derived keying material to be generated, maximum 512.

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -63,4 +63,19 @@
 #define TEE_ATTR_CONCAT_KDF_OTHER_INFO        0xD00002C1
 #define TEE_ATTR_CONCAT_KDF_DKM_LENGTH        0xF00003C1
 
+/*
+ * PKCS #5 v2.0 Key Derivation Function 2 (PBKDF2)
+ * RFC 2898 section 5.2
+ * https://www.ietf.org/rfc/rfc2898.txt
+ */
+
+#define TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY 0x800020C2
+
+#define TEE_TYPE_PBKDF2_PASSWORD            0xA10000C2
+
+#define TEE_ATTR_PBKDF2_PASSWORD            0xC00001C2
+#define TEE_ATTR_PBKDF2_SALT                0xD00002C2
+#define TEE_ATTR_PBKDF2_ITERATION_COUNT     0xF00003C2
+#define TEE_ATTR_PBKDF2_DKM_LENGTH          0xF00004C2
+
 #endif /* TEE_API_DEFINES_EXTENSIONS_H */

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -46,6 +46,7 @@
 #define TEE_MAIN_ALGO_DH         0x32
 #define TEE_MAIN_ALGO_HKDF       0xC0 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_CONCAT_KDF 0xC1 /* OP-TEE extension */
+#define TEE_MAIN_ALGO_PBKDF2     0xC2 /* OP-TEE extension */
 
 
 #define TEE_CHAIN_MODE_ECB_NOPAD        0x0

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -155,6 +155,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_CONCAT_KDF_SHA256_DERIVE_KEY:
 	case TEE_ALG_CONCAT_KDF_SHA384_DERIVE_KEY:
 	case TEE_ALG_CONCAT_KDF_SHA512_DERIVE_KEY:
+	case TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY:
 		if (mode != TEE_MODE_DERIVE)
 			return TEE_ERROR_NOT_SUPPORTED;
 		with_private_key = true;
@@ -1114,7 +1115,6 @@ void TEE_DeriveKey(TEE_OperationHandle operation,
 		TEE_Panic(0);
 	if (paramCount != 0 && params == NULL)
 		TEE_Panic(0);
-
 	if (TEE_ALG_GET_CLASS(operation->info.algorithm) !=
 			TEE_OPERATION_KEY_DERIVATION)
 		TEE_Panic(0);


### PR DESCRIPTION
This commit implements a crypto extension to support the key derivation
function defined in section 5.2 of RFC 2898
(https://www.ietf.org/rfc/rfc2898.txt), which is a re-publish of PKCS #5 v2.0.
The underlying pseudorandom function is HMAC-SHA1, which is the default PRF
specified in the RFC. It would be trivial to support the other HMAC functions
already implemented in OP-TEE.

See documentation/extensions/crypto_pbkdf2.md for details.

Tested on PLATFORM=vexpress-qemu_virt with the test vectors from RFC 6070
(https://www.ietf.org/rfc/rfc6070.txt).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Signed-off-by: Xiaoqiang Du <xiaoqiang.du@linaro.org>