### PR TITLE
Move platform-specific flags to their own files, use them in TA dev kit

### DIFF
--- a/core/arch/arm32/plat-stm/conf.mk
+++ b/core/arch/arm32/plat-stm/conf.mk
@@ -1,30 +1,12 @@
+include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
+
 CROSS_PREFIX	?= armv7-linux
 CROSS_COMPILE	?= $(CROSS_PREFIX)-
 include mk/gcc.mk
 
-PLATFORM_FLAVOR ?= orly2
-
-platform-cpuarch = cortex-a9
-platform-cflags	 = -mcpu=$(platform-cpuarch) -mthumb
-platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
-platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
-platform-cflags += -mfloat-abi=soft
-platform-aflags	 = -mcpu=$(platform-cpuarch)
 core-platform-cppflags	 = -I$(arch-dir)/include
 core-platform-cppflags	+= -DNUM_THREADS=2
 core-platform-cppflags	+= -DWITH_STACK_CANARIES=1
-user_ta-platform-cflags = -fpie
-
-platform-cflags += -ffunction-sections -fdata-sections
-
-DEBUG		?= 1
-ifeq ($(DEBUG),1)
-platform-cflags += -O0
-else
-platform-cflags += -Os
-endif
-platform-cflags += -g
-platform-aflags += -g
 
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm sm tee sta) $(platform-dir)

--- a/core/arch/arm32/plat-stm/platform_flags.mk
+++ b/core/arch/arm32/plat-stm/platform_flags.mk
@@ -1,0 +1,21 @@
+PLATFORM_FLAVOR ?= orly2
+
+platform-cpuarch = cortex-a9
+platform-cflags	 = -mcpu=$(platform-cpuarch) -mthumb
+platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
+platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
+platform-cflags += -mfloat-abi=soft
+platform-aflags	 = -mcpu=$(platform-cpuarch)
+
+platform-cflags += -ffunction-sections -fdata-sections
+
+DEBUG		?= 1
+ifeq ($(DEBUG),1)
+platform-cflags += -O0
+else
+platform-cflags += -Os
+endif
+platform-cflags += -g
+platform-aflags += -g
+
+user_ta-platform-cflags = -fpie

--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -1,49 +1,12 @@
+include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
+
 CROSS_PREFIX	?= arm-linux-gnueabihf
 CROSS_COMPILE	?= $(CROSS_PREFIX)-
 include mk/gcc.mk
 
-PLATFORM_FLAVOR ?= fvp
-PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
-
-platform-cpuarch = cortex-a15
-platform-cflags	 = -mcpu=$(platform-cpuarch) -mthumb
-platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
-platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
-platform-cflags += -mfloat-abi=soft
-platform-cflags += -mno-unaligned-access
-platform-aflags	 = -mcpu=$(platform-cpuarch)
 core-platform-cppflags	 = -I$(arch-dir)/include
 core-platform-cppflags	+= -DNUM_THREADS=2
 core-platform-cppflags	+= -DWITH_STACK_CANARIES=1
-user_ta-platform-cflags = -fpie
-
-platform-cflags += -ffunction-sections -fdata-sections
-
-DEBUG		?= 1
-ifeq ($(DEBUG),1)
-platform-cflags += -O0
-else
-platform-cflags += -Os
-endif
-
-platform-cflags += -g
-platform-aflags += -g
-
-ifeq ($(PLATFORM_FLAVOR),fvp)
-platform-flavor-armv8 := 1
-endif
-ifeq ($(PLATFORM_FLAVOR),juno)
-platform-flavor-armv8 := 1
-endif
-
-ifeq ($(platform-flavor-armv8),1)
-# ARM debugger needs this
-platform-cflags += -gdwarf-2
-platform-aflags += -gdwarf-2
-else
-platform-cflags += -g3
-platform-aflags += -g3
-endif
 
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)

--- a/core/arch/arm32/plat-vexpress/platform_flags.mk
+++ b/core/arch/arm32/plat-vexpress/platform_flags.mk
@@ -1,0 +1,40 @@
+PLATFORM_FLAVOR ?= fvp
+PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
+
+platform-cpuarch = cortex-a15
+platform-cflags	 = -mcpu=$(platform-cpuarch) -mthumb
+platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
+platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
+platform-cflags += -mfloat-abi=soft
+platform-cflags += -mno-unaligned-access
+platform-aflags	 = -mcpu=$(platform-cpuarch)
+
+platform-cflags += -ffunction-sections -fdata-sections
+
+DEBUG		?= 1
+ifeq ($(DEBUG),1)
+platform-cflags += -O0
+else
+platform-cflags += -Os
+endif
+
+platform-cflags += -g
+platform-aflags += -g
+
+ifeq ($(PLATFORM_FLAVOR),fvp)
+platform-flavor-armv8 := 1
+endif
+ifeq ($(PLATFORM_FLAVOR),juno)
+platform-flavor-armv8 := 1
+endif
+
+ifeq ($(platform-flavor-armv8),1)
+# ARM debugger needs this
+platform-cflags += -gdwarf-2
+platform-aflags += -gdwarf-2
+else
+platform-cflags += -g3
+platform-aflags += -g3
+endif
+
+user_ta-platform-cflags = -fpie

--- a/documentation/build_system.md
+++ b/documentation/build_system.md
@@ -13,9 +13,11 @@ Name              | Description
 `mk/lib.mk`       | Create rules to make a libraries (.a)
 `mk/subdir.mk`    | Process `sub.mk` files recursively
 `mk/config.mk`    | Global configuration variable
-`core/arch/$(ARCH)/plat-$(PLATFORM)/conf.mk` | Arch and platform-specific compiler flags and configuration variables for TEE Core and TA libraries
-`core/arch/$(ARCH)/plat-$(PLATFORM)/link.mk` | Make recipes link the TEE Core
-`ta/arch/arm32/link.mk` | Make recipes link Trusted Applications
+`core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk` | Arch and platform-specific compiler flags
+`core/arch/$(ARCH)/plat-$(PLATFORM)/conf.mk` | Arch and platform-specific compiler flags and configuration variables for the TEE Core only
+`core/arch/$(ARCH)/plat-$(PLATFORM)/link.mk` | Make recipes to link the TEE Core
+`ta/arch/arm32/link.mk` | Make recipes to link Trusted Applications
+`ta/mk/ta_dev_kit.mk` | Main Makefile to be included when building Trusted Applications
 `mk/checkconf.mk` | Utility functions to manipulate configuration variables and generate a C header file
 `sub.mk`          | List source files and define compiler flags
 
@@ -99,28 +101,29 @@ change in case you want to use
 $ make CROSS_COMPILE="ccache arm-linux-gnueabihf-"
 ```
 
-## Platform-specific configuration (conf.mk)
+## Platform-specific configuration and flags
 
-The file `core/arch/$(ARCH)/plat-$(PLATFORM)/conf.mk` is included from
-`mk/core.mk`. Its purpose is to define some compiler flags and configuration
-variables for OP-TEE.
+The following variables are defined in `core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk`:
 
 - **$(platform-aflags)**, **$(platform-cflags)** and **$(platform-cppflags)**
   are added to the assembler / C compiler / preprocessor flags for all source
   files
+- **$(user_ta-platform-aflags)**, **$(user_ta-platform-cflags)** and
+  **$(user_ta-platform-cppflags)** are added to the assembler / C compiler /
+  preprocessor flags when building the user-mode libraries (**libutee.a**,
+  **libutils.a**, **libmpa.a**) or Trusted Applications.
+
+The following variables are defined in `core/arch/$(ARCH)/plat-$(PLATFORM)/conf.mk`:
+
 - **$(core-platform-aflags)**, **$(core-platform-cflags)** and
   **$(core-platform-cppflags)** are added to the assembler / C compiler /
   preprocessor flags when building files that will run in kernel mode in the
   TEE Core. This applies to core-only files, but also to the kernel versions of
   **libmpa.a** and **libutils.a**.
-- **$(user_ta-platform-aflags)**, **$(user_ta-platform-cflags)** and
-  **$(user_ta-platform-cppflags)** are added to the assembler / C compiler /
-  preprocessor flags when building the user-mode libraries (**libutee.a**,
-  **libutils.a**, **libmpa.a**).
 - **$(core-platform-subdirs)** is the list of the subdirectories that are
   added to the TEE Core.
 
-## Platform-specific link recipes (link.mk)
+## Platform-specific link recipes for the TEE Core
 
 The file `core/arch/$(ARCH)/plat-$(PLATFORM)/link.mk` contains the rules to
 link the TEE Core and perform any related tasks, such as running **objdump**
@@ -158,8 +161,7 @@ directories and/or configuration variables as explained below.
 
 ## Compiler flags
 
-Default compiler flags are defined in `mk/compile.mk`. Platform-specific flags
-are defined in `core/arch/arm32/plat-vexpress/conf.mk`
+Default compiler flags are defined in `mk/compile.mk`. Note that platform-specific flags must not appear in this file which is common to all platforms.
 
 To add flags for a given source file, you may use the following variables in
 `sub.mk`:

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -25,17 +25,12 @@ q :=
 cmd-echo := echo
 endif
 
-cflags$(sm) += -fno-short-enums -fpie -mfloat-abi=soft
+-include $(ta-dev-kit-dir)/mk/platform_flags.mk
+
+aflags$(sm) += $(platform-aflags) $(user_ta-platform-aflags)
+cflags$(sm) += $(platform-cflags) $(user_ta-platform-cflags)
+
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
-
-ifeq ($(DEBUG),1)
-cflags$(sm) += -O0
-else
-cflags$(sm) += -Os
-endif
-cflags$(sm) += -g -g3
-aflags$(sm) += -g -g3
-
 
 libdirs += $(ta-dev-kit-dir)/lib
 libnames += utils mpa utee

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -1,4 +1,5 @@
 include mk/cleanvars.mk
+include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
 # Set current submodule (used for module specific flags compile result etc)
 sm := user_ta
@@ -52,8 +53,10 @@ $(foreach f, $(libfiles), \
 
 # Copy .mk files
 ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk \
+	$(wildcard core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk) \
 	$(wildcard ta/arch/$(ARCH)/link.mk) \
 	ta/mk/ta_dev_kit.mk
+
 $(foreach f, $(ta-mkfiles), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/mk)))
 


### PR DESCRIPTION
Platform-specific flags that do not apply only to the TEE core are removed
from core/arch/$(ARCH)plat-$(PLATFORM)/conf.mk. They are moved to a new file:
mk/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk.

This file is used by ta/mk/ta_dev_kit.mk so that the Trusted Applications
are built with the same flags used when building the user-mode TEE code.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>