### PR TITLE
core: get value of CFG_ variables from <generated/conf.h>

### DIFF
--- a/core/arch/arm32/mm/tee_pager.c
+++ b/core/arch/arm32/mm/tee_pager.c
@@ -25,7 +25,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <generated/conf.h>
 #include <sys/queue.h>
 #include <stdlib.h>
 #include <inttypes.h>

--- a/core/arch/arm32/plat-stm/conf.mk
+++ b/core/arch/arm32/plat-stm/conf.mk
@@ -39,8 +39,6 @@ include $(platform-dir)/system_config.in
 ifndef CFG_TEE_CORE_EMBED_INTERNAL_TESTS
 $(error "CFG_TEE_CORE_EMBED_INTERNAL_TESTS should be set from system_config.in")
 endif
-core-platform-cppflags += \
-	-DCFG_TEE_CORE_EMBED_INTERNAL_TESTS=$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS)
 
 ifndef CFG_DDR_TEETZ_RESERVED_START
 $(error "CFG_DDR_TEETZ_RESERVED_START should be set from system_config.in")
@@ -48,12 +46,9 @@ endif
 ifndef CFG_DDR_TEETZ_RESERVED_SIZE
 $(error "CFG_DDR_TEETZ_RESERVED_SIZE should be set from system_config.in")
 endif
-core-platform-cppflags += \
-	-DCFG_DDR_TEETZ_RESERVED_START=$(CFG_DDR_TEETZ_RESERVED_START) \
-	-DCFG_DDR_TEETZ_RESERVED_SIZE=$(CFG_DDR_TEETZ_RESERVED_SIZE)
 
 core-platform-cppflags += -DCONFIG_TEE_GDB_BOOT
-core-platform-cppflags += -DCFG_NO_TA_HASH_SIGN
+CFG_NO_TA_HASH_SIGN ?= y
 
 ifeq ($(PLATFORM_FLAVOR),cannes)
 

--- a/core/arch/arm32/plat-stm/platform_config.h
+++ b/core/arch/arm32/plat-stm/platform_config.h
@@ -28,8 +28,6 @@
 #ifndef PLATFORM_CONFIG_H
 #define PLATFORM_CONFIG_H
 
-#include <generated/conf.h>
-
 #define PLATFORM_FLAVOR_ID_orly2	0
 #define PLATFORM_FLAVOR_ID_cannes	1
 #define PLATFORM_FLAVOR_IS(flav) \

--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -54,11 +54,7 @@ core-platform-subdirs += $(arch-dir)/sm
 core-platform-cppflags += -DWITH_SEC_MON=1
 endif
 
-CFG_PM_DEBUG ?= 0
-ifeq ($(CFG_PM_DEBUG),1)
-core-platform-cppflags += \
-	-DCFG_PM_DEBUG
-endif
+CFG_PM_DEBUG ?= n
 
 libutil_with_isoc := y
 libtomcrypt_with_optimize_size := y
@@ -69,8 +65,6 @@ WITH_GIC_DRV := y
 include mk/config.mk
 
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= 1
-core-platform-cppflags += \
-	-DCFG_TEE_CORE_EMBED_INTERNAL_TESTS=$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS)
 
 core-platform-cppflags += -D_USE_SLAPORT_LIB
 
@@ -79,6 +73,6 @@ core-platform-cppflags += -D_USE_SLAPORT_LIB
 core-platform-cppflags += -DTEE_MULTI_CPU
 # define flag to support booting from GDB
 core-platform-cppflags += -DCONFIG_TEE_GDB_BOOT
-core-platform-cppflags += -DCFG_NO_TA_HASH_SIGN
+CFG_NO_TA_HASH_SIGN ?= y
 
 core-platform-cppflags += -DWITH_UART_DRV=1

--- a/core/arch/arm32/plat-vexpress/platform_config.h
+++ b/core/arch/arm32/plat-vexpress/platform_config.h
@@ -28,8 +28,6 @@
 #ifndef PLATFORM_CONFIG_H
 #define PLATFORM_CONFIG_H
 
-#include <generated/conf.h>
-
 #define PLATFORM_FLAVOR_ID_fvp		0
 #define PLATFORM_FLAVOR_ID_qemu		1
 #define PLATFORM_FLAVOR_ID_qemu_virt	2

--- a/core/arch/arm32/sta/core_self_tests.c
+++ b/core/arch/arm32/sta/core_self_tests.c
@@ -39,7 +39,8 @@
 
 #if (CFG_TEE_CORE_EMBED_INTERNAL_TESTS == 0)
 
-TEE_Result core_self_tests(void)
+TEE_Result core_self_tests(uint32_t nParamTypes __unused,
+			   TEE_Param pParams[TEE_NUM_PARAMS] __unused)
 {
 	return TEE_SUCCESS;
 }

--- a/core/core.mk
+++ b/core/core.mk
@@ -13,7 +13,8 @@ platform_$(PLATFORM) := y
 platform_flavor_$(PLATFORM_FLAVOR) := y
 cppflags$(sm)	+= -DPLATFORM_FLAVOR=PLATFORM_FLAVOR_ID_$(PLATFORM_FLAVOR)
 
-cppflags$(sm)	+= -Icore/include -I$(out-dir)/core/include
+cppflags$(sm)	+= -Icore/include
+cppflags$(sm)	+= -include $(out-dir)/core/include/generated/conf.h
 cppflags$(sm)	+= $(platform-cppflags) $(core-platform-cppflags)
 cflags$(sm)	+= $(platform-cflags) $(core-platform-cflags)
 aflags$(sm)	+= $(platform-aflags) $(core-platform-aflags)

--- a/core/lib/libtomcrypt/include/tomcrypt_custom.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_custom.h
@@ -138,7 +138,6 @@
 #endif   
 
 /* Set LTC_ options based on OP-TEE configuration */
-#include <generated/conf.h>
 
 #define LTC_NO_CIPHERS
 

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -25,7 +25,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <generated/conf.h>
 #include <tee/tee_cryp_provider.h>
 #include <tee/tee_cryp_utl.h>
 

--- a/documentation/build_system.md
+++ b/documentation/build_system.md
@@ -213,7 +213,10 @@ may be defined in `sub.mk` when then pertain to a specific library for instance.
 Variables with the `CFG_` prefix are treated in a special
 way: their value is automatically reflected in the generated header
 file `$(out-dir)/core/include/generated/conf.h`, after all the included
-makefiles have been processed. Depending on their value, variables may
+makefiles have been processed. `conf.h` is automatically included by the
+preprocessor when a source file belonging to the TEE core is built.
+
+Depending on their value, variables may
 be considered either boolean or non-boolean, which affects how they are
 translated into `conf.h`.
 
@@ -254,8 +257,6 @@ code to use constructs like:
 
 ```C
 /* core/lib/libtomcrypt/src/tee_ltc_provider.c */
-
-#include <generated/conf.h>
 
 /* ... */
 


### PR DESCRIPTION
It is cleaner to include <generated/conf.h> rather defining CPP flags.

A small number of CFG_ variables are still handled differently because
they are used in user mode code (currently, conf.h is generated only for
the TEE core).

This commit also fixes a compile error when
CFG_TEE_CORE_EMBED_INTERNAL_TESTS=0.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>