### PR TITLE
Fix #6686: Support passing Public Exponent when generating RSA key pair

### DIFF
--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -533,9 +533,13 @@ static TEE_Result gen_rsa_key(struct rsa_keypair *key, size_t key_size)
 	TEE_Result res;
 	rsa_key ltc_tmp_key;
 	int ltc_res;
+	long e;
+
+	/* get the public exponent */
+	e = mp_get_int(key->e);
 
 	/* Generate a temporary RSA key */
-	ltc_res = rsa_make_key(0, tee_ltc_get_rng_mpa(), key_size/8, 65537,
+	ltc_res = rsa_make_key(0, tee_ltc_get_rng_mpa(), key_size/8, e,
 			       &ltc_tmp_key);
 	if (ltc_res != CRYPT_OK) {
 		res = TEE_ERROR_BAD_PARAMETERS;

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1245,10 +1245,15 @@ static TEE_Result tee_svc_obj_generate_key_rsa(
 	uint32_t key_size)
 {
 	TEE_Result res;
+	struct rsa_keypair *key = o->data;
+	uint32_t e = TEE_U32_TO_BIG_ENDIAN(65537);
 
 	TEE_ASSERT(sizeof(struct rsa_keypair) == o->data_size);
-	if (!crypto_ops.acipher.gen_rsa_key)
+	if (!crypto_ops.acipher.gen_rsa_key || !crypto_ops.bignum.bin2bn)
 		return TEE_ERROR_NOT_IMPLEMENTED;
+	if (!GET_ATTRIBUTE(o, type_props, TEE_ATTR_RSA_PUBLIC_EXPONENT))
+		crypto_ops.bignum.bin2bn((const uint8_t *)&e, sizeof(e),
+					 key->e);
 	res = crypto_ops.acipher.gen_rsa_key(o->data, key_size);
 	if (res != TEE_SUCCESS)
 		return res;


### PR DESCRIPTION
Global Platform Internal API 1.0 is not accurate when describing
RSA key pair generation. It only indicates
    No parameter is required
This is why RSA key pair generation was always using 65537
as the public exponent.

Version 1.1 of the API is much more precise:
    No parameter is required.
    The TEE_ATTR_RSA_PUBLIC_EXPONENT attribute may be
    specified; if omitted, the default value is 65537.

This patch implements this requirement.

Change-Id: I9e4beb43d38d67b3d0cb9cbec505d8905239d8b0
Signed-off-by: Pascal Brand <pascal.brand@st.com>
Reviewed-on: https://gerrit.st.com/19866
Reviewed-by: Laurent GERARD <laurent.gerard@st.com>
Reviewed-by: Jean-Michel DELORME <jean-michel.delorme@st.com>