### PR TITLE
adjust Persistent Object Sharing Rules implementation based GP internel ...

### DIFF
--- a/core/tee/tee_pobj.c
+++ b/core/tee/tee_pobj.c
@@ -37,20 +37,21 @@ TAILQ_HEAD_INITIALIZER(tee_pobjs);
 static TEE_Result tee_pobj_check_access(uint32_t oflags, uint32_t nflags)
 {
 	/* meta is exclusive */
-	if (oflags | TEE_DATA_FLAG_ACCESS_WRITE_META ||
-	    nflags | TEE_DATA_FLAG_ACCESS_WRITE_META)
+	if (oflags & TEE_DATA_FLAG_ACCESS_WRITE_META)
 		return TEE_ERROR_ACCESS_CONFLICT;
 
-	if (oflags | TEE_DATA_FLAG_ACCESS_READ &&
-	    !((nflags | TEE_DATA_FLAG_SHARE_READ) &&
-	      oflags | TEE_DATA_FLAG_SHARE_READ))
-		return TEE_ERROR_ACCESS_CONFLICT;
+	/*second open/create need set flags to TEE_DATA_FLAG_SHARE_READ */
+	if ((oflags & TEE_DATA_FLAG_ACCESS_READ) ||
+		(oflags & TEE_DATA_FLAG_SHARE_READ) &&
+		!(nflags & TEE_DATA_FLAG_SHARE_READ))
+			return TEE_ERROR_ACCESS_CONFLICT;
 
-	if (oflags | TEE_DATA_FLAG_ACCESS_WRITE &&
-	    !((nflags | TEE_DATA_FLAG_SHARE_WRITE) &&
-	      oflags | TEE_DATA_FLAG_SHARE_WRITE))
-		return TEE_ERROR_ACCESS_CONFLICT;
-
+	/*second open/create need set flags to TEE_DATA_FLAG_SHARE_WRITE */
+	if ((oflags & TEE_DATA_FLAG_ACCESS_WRITE) ||
+		(oflags & TEE_DATA_FLAG_SHARE_WRITE) &&
+		!(nflags & TEE_DATA_FLAG_SHARE_WRITE ))
+			return TEE_ERROR_ACCESS_CONFLICT;
+	
 	return TEE_SUCCESS;
 }
 

--- a/core/tee/tee_pobj.c
+++ b/core/tee/tee_pobj.c
@@ -41,14 +41,14 @@ static TEE_Result tee_pobj_check_access(uint32_t oflags, uint32_t nflags)
 		return TEE_ERROR_ACCESS_CONFLICT;
 
 	/*second open/create need set flags to TEE_DATA_FLAG_SHARE_READ */
-	if ((oflags & TEE_DATA_FLAG_ACCESS_READ) ||
-		(oflags & TEE_DATA_FLAG_SHARE_READ) &&
+	if (((oflags & TEE_DATA_FLAG_ACCESS_READ) ||
+		(oflags & TEE_DATA_FLAG_SHARE_READ)) &&
 		!(nflags & TEE_DATA_FLAG_SHARE_READ))
 			return TEE_ERROR_ACCESS_CONFLICT;
 
 	/*second open/create need set flags to TEE_DATA_FLAG_SHARE_WRITE */
-	if ((oflags & TEE_DATA_FLAG_ACCESS_WRITE) ||
-		(oflags & TEE_DATA_FLAG_SHARE_WRITE) &&
+	if (((oflags & TEE_DATA_FLAG_ACCESS_WRITE) ||
+		(oflags & TEE_DATA_FLAG_SHARE_WRITE)) &&
 		!(nflags & TEE_DATA_FLAG_SHARE_WRITE ))
 			return TEE_ERROR_ACCESS_CONFLICT;
 	

--- a/documentation/arm_trusted_firmware.md
+++ b/documentation/arm_trusted_firmware.md
@@ -1,0 +1,104 @@
+ARM Trusted Firmware with OP-TEE
+================================
+
+Contents :
+
+1.  Introduction
+2.  Host machine requirements
+3.  Tools
+4.  Building OP-TEE
+5.  Building the Trusted Firmware
+6.  Obtaining the normal world software
+7.  Running the software
+
+1.  Introduction
+----------------
+This document describes how to build [OP-TEE OS] and run it together with
+ARM Trusted Firmware ([ATF]).
+
+The bridge between normal world and [OP-TEE OS] resides in [ATF] and is a
+[secure monitor] referred to as the OP-TEE Dispatcher.
+
+This document is limited to only describe how to boot ATF together with
+OP-TEE. It does not cover how to enable normal world TEE Client API to
+comunicate with OP-TEE.
+
+2.  Host machine requirements
+-----------------------------
+See "Host machine requirements" in [ATF User Guide].
+
+3.  Tools
+---------
+See "Tools" in [ATF User Guide].
+
+In addition to that is gcc-linaro-arm-linux-gnueabihf-4.8-2013.12_linux.tar.bz2
+used as to compile OP-TEE.
+
+	wget http://releases.linaro.org/13.12/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.8-2013.12_linux.tar.bz2
+	tar -xf gcc-linaro-arm-linux-gnueabihf-4.8-2013.12_linux.tar.bz2
+
+
+4.  Building OP-TEE
+-------------------
+
+To build OP-TEE for FVP, follow these steps:
+
+1. Clone OP-TEE OS from the repository on GitHub:
+
+        git clone https://github.com/OP-TEE/optee_os.git
+
+2. Change to OP-TEE OS directory:
+
+        cd optee_os
+
+3. Set compiler path and build:
+
+        export PATH="<path-to-armv7-gcc>/bin:${PATH}"           \
+        export PLATFORM=vexpress                                \
+        export PLATFORM_FLAVOR=fvp                              \
+        export O=out                                            \
+        make all
+
+To get debug prints from OP-TEE OS add for instance:
+
+        export CFG_TEE_CORE_LOG_LEVEL=5
+
+5.  Building the Trusted Firmware
+---------------------------------
+See "Building the Trusted Firmware" in [ATF User Guide].
+
+Before the OP-TEE Dispatcher is integrated in [ATF] it may be
+nececcary to clone [ATF] from an inofficial repository.
+
+Build ARM Trusted Firmware with OP-TEE Dispatcher:
+
+        export CROSS_COMPILE=<path-to-aarch64-gcc>/bin/aarch64-none-elf- \
+        export BL33=<path-to>/<bl33_image>                               \
+        export BL32=<path-to>/tee.bin                                    \
+        make FVP_TSP_RAM_LOCATION=tdram FVP_SHARED_DATA_LOCATION=tdram   \
+                SPD=opteed PLAT=fvp all fip
+
+	
+6.  Obtaining the normal world software
+---------------------------------------
+See "Obtaining the normal world software" in [ATF User Guide]
+
+7.  Running the software
+------------------------
+See "Running the software" in [ATF User Guide]
+
+To do anything more than watching the psci hooks getting called in [OP-TEE OS]
+there's some additional software required,
+[OP-TEE Client](https://github.com/OP-TEE/optee_client.git) and
+[OP-TEE Linux driver](https://github.com/OP-TEE/optee_linuxdriver.git).
+It's outside then scope of this document to guide how to use that software.
+
+- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+_Copyright (c) 2014, Linaro Limited. All rights reserved._
+[OP-TEE]:               http://github.com/OP-TEE
+[OP-TEE OS]:            http://github.com/OP-TEE/optee_os.git
+[ATF]:                  http://github.com/ARM-software/arm-trusted-firmware
+[ATF User Guide]:       http://github.com/ARM-software/arm-trusted-firmware/tree/master/docs/user-guide.md
+[secure monitor]:       http://www.arm.com/products/processors/technologies/trustzone/tee-smc.php
+


### PR DESCRIPTION
adjust Persistent Object Sharing Rules implementation based GP internel core API v1.1
I saw Persistent Object Sharing Rules check done in tee-pobj.c, function tee_pobj_check_access. However the code is obviously wrong.
The origin code done like below, it will always return TEE_ERROR_ACCESS_CONFLICT;
static TEE_Result tee_pobj_check_access(uint32_t oflags, uint32_t nflags)
{
	/* meta is exclusive */
	if (oflags | TEE_DATA_FLAG_ACCESS_WRITE_META ||
	    nflags | TEE_DATA_FLAG_ACCESS_WRITE_META)
		return TEE_ERROR_ACCESS_CONFLICT;

	if (oflags | TEE_DATA_FLAG_ACCESS_READ &&
	    !((nflags | TEE_DATA_FLAG_SHARE_READ) &&
	      oflags | TEE_DATA_FLAG_SHARE_READ))
		return TEE_ERROR_ACCESS_CONFLICT;

	if (oflags | TEE_DATA_FLAG_ACCESS_WRITE &&
	    !((nflags | TEE_DATA_FLAG_SHARE_WRITE) &&
	      oflags | TEE_DATA_FLAG_SHARE_WRITE))
		return TEE_ERROR_ACCESS_CONFLICT;

	return TEE_SUCCESS;
}
I change the code based Global Platform's internal API document, and it works well:
static TEE_Result tee_pobj_check_access(uint32_t oflags, uint32_t nflags)
{
	/* meta is exclusive */
	if (oflags & TEE_DATA_FLAG_ACCESS_WRITE_META)
		return TEE_ERROR_ACCESS_CONFLICT;

	/*second open/create need set flags to TEE_DATA_FLAG_SHARE_READ */
	if ((oflags &TEE_DATA_FLAG_ACCESS_READ) ||
		(oflags & TEE_DATA_FLAG_SHARE_READ) &&
		!(nflags & TEE_DATA_FLAG_SHARE_READ))
			return TEE_ERROR_ACCESS_CONFLICT;

	/*second open/create need set flags to TEE_DATA_FLAG_SHARE_WRITE */
	if ((oflags & TEE_DATA_FLAG_ACCESS_WRITE) ||
		(oflags & TEE_DATA_FLAG_SHARE_WRITE) &&
		!(nflags & TEE_DATA_FLAG_SHARE_WRITE ))
			return TEE_ERROR_ACCESS_CONFLICT;
	
	return TEE_SUCCESS;
}
