### PR TITLE
Disable TEX Remap before enable MMU

### DIFF
--- a/core/arch/arm32/include/arm32.h
+++ b/core/arch/arm32/include/arm32.h
@@ -183,6 +183,23 @@ static inline uint32_t read_ttbr0(void)
 	return ttbr0;
 }
 
+static inline void write_ats1cpw(uint32_t va)
+{
+	asm volatile ("mcr	p15, 0, %[va], c7, c8, 1"
+			: : [va] "r" (va)
+	);
+}
+
+static inline uint32_t read_par(void)
+{
+	uint32_t par;
+
+	asm volatile ("mrc	p15, 0, %[par], c7, c4, 0"
+			: [par] "=r" (par)
+	);
+	return par;
+}
+
 static inline void write_ttbr1(uint32_t ttbr1)
 {
 	asm volatile ("mcr	p15, 0, %[ttbr1], c2, c0, 1"

--- a/core/arch/arm32/mm/core_mmu.c
+++ b/core/arch/arm32/mm/core_mmu.c
@@ -343,6 +343,7 @@ void core_init_mmu_tables(void)
 
 void core_init_mmu_regs(void)
 {
+	uint32_t sctlr;
 	paddr_t ttb_pa = core_mmu_get_main_ttb_pa();
 
 	/*
@@ -352,6 +353,14 @@ void core_init_mmu_regs(void)
 	 */
 	write_dacr(DACR_DOMAIN(0, DACR_DOMAIN_PERM_CLIENT) |
 		   DACR_DOMAIN(1, DACR_DOMAIN_PERM_CLIENT));
+
+	/*
+	 * Disable TEX Remap
+	 * (This allows TEX field in page table entry take affect)
+	 */
+	sctlr = read_sctlr();
+	sctlr &= ~SCTLR_TRE;
+	write_sctlr(sctlr);
 
 	/*
 	 * Enable lookups using TTBR0 and TTBR1 with the split of addresses


### PR DESCRIPTION
- Add write_ats1cpw() and read_par() for page description debug
- Clear TEX bit beofre enable MMU

Signed-off-by: SY Chiu <sy.chiu@linaro.org>
Tested-by: SY Chiu <sy.chiu@linaro.org> (QEMU)