### PR TITLE
Fix information leakage in key generator

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1462,8 +1462,6 @@ TEE_Result tee_svc_obj_generate_key(
 		if (res != TEE_SUCCESS)
 			return res;
 
-		/* Force the last bit to have exactly a value on byte_size */
-		((char *)key)[sizeof(key->key_size) + byte_size - 1] |= 0x80;
 		key->key_size = byte_size;
 
 		/* Set bits for all known attributes for this object type */


### PR DESCRIPTION
When generating keys we are using the RNG available for the particular
platform in use. For some reason we always or'ed a bit in the last byte,
which means that we leak information. Leaking information like this is
considered as a security flaw and therefore we have removed the line
setting this bit.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (QEMU)