### PR TITLE
mk/compile.mk: GNU make 4.0 compatibility

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -103,7 +103,8 @@ comp-objcpy-cmd-$2 = $$(OBJCOPY) \
 $2: $1 FORCE
 # Check if any prerequisites are newer than the target and
 # check if command line has changed
-	$$(if $$(strip $$? $$(filter-out $$(comp-cmd-$2), $$(old-cmd-$2)) \
+	$$(if $$(strip $$(filter-out FORCE, $$?) \
+	    $$(filter-out $$(comp-cmd-$2), $$(old-cmd-$2)) \
 	    $$(filter-out $$(old-cmd-$2), $$(comp-cmd-$2))), \
 		@set -e ;\
 		mkdir -p $$(dir $2) ;\


### PR DESCRIPTION
Fixes issue https://github.com/OP-TEE/optee_os/issues/179 (GNU make 4.0
rebuilds everything each time it is run).

GNU make 4.0 includes a fix for bug http://savannah.gnu.org/bugs/?16051
which breaks the C compilation rule in mk/compile.mk. Previous versions
of make would not add the FORCE target to $?, whereas version 4.0 does.
Therefore, one must explicitly exclude FORCE from $? to properly detect
if dependencies have changed.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>