### PR TITLE
sunxi: fix parallel build errors

### DIFF
--- a/core/arch/arm32/plat-sunxi/link.mk
+++ b/core/arch/arm32/plat-sunxi/link.mk
@@ -30,7 +30,7 @@ link-script-cppflags :=  \
 
 -include $(link-script-dep)
 
-$(link-script-pp): $(link-script)
+$(link-script-pp): $(link-script) $(conf-file)
 	@echo '  CPP     $@'
 	@mkdir -p $(dir $@)
 	$(q)$(CPP) -Wp,-P,-MT,$@,-MD,$(link-script-dep) \

--- a/core/arch/arm32/plat-vexpress/link.mk
+++ b/core/arch/arm32/plat-vexpress/link.mk
@@ -84,6 +84,7 @@ link-script-extra-deps += $(link-out-dir)/text_unpaged.ld.S
 link-script-extra-deps += $(link-out-dir)/rodata_unpaged.ld.S
 link-script-extra-deps += $(link-out-dir)/text_init.ld.S
 link-script-extra-deps += $(link-out-dir)/rodata_init.ld.S
+link-script-extra-deps += $(conf-file)
 cleanfiles += $(link-script-pp) $(link-script-dep)
 $(link-script-pp): $(link-script) $(link-script-extra-deps)
 	@echo '  CPP     $@'


### PR DESCRIPTION
Fixes https://github.com/OP-TEE/optee_os/issues/181.

plat-sunxi/link.mk uses CPP to generate its core linker script.
Commit a3911433960a ("core: get value of CFG_ variables directly from
generated/conf.h") has modified the core CPP flags to include conf.h
automatically, so one must make sure that this file exists when the linker
script is generated. This is done by adding a dependency on $(conf-file).

The vexpress platforms also lack the dependency, but the bug won't show
because of other dependencies which cause conf.h to be generated anyways.

PLATFORM=stm is fine because it does not use CPP.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>