### PR TITLE
OP-TEE Benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,17 @@ script:
   -                                  PLATFORM=vexpress-fvp                                                                 make -j8 all
   - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=fvp                                       make -j8 all
   - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress           PLATFORM_FLAVOR=fvp                                       make -j8 all
+  - CFG_TEE_TA_LOG_LEVEL=0           PLATFORM=vexpress           PLATFORM_FLAVOR=fvp                                       make -j8 all
+  - CFG_TEE_TRACE_PERFORMANCE=y      PLATFORM=vexpress           PLATFORM_FLAVOR=fvp                                       make -j8 all
+  - CFG_TEE_CORE_LOG_LEVEL=0 CFG_TEE_TRACE_PERFORMANCE=y         PLATFORM=vexpress        PLATFORM_FLAVOR=fvp              make -j8 all
 
   # QEMU
   -                                  PLATFORM=vexpress-qemu                                                                make -j8 all
   - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all
   - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all
+  - CFG_TEE_TA_LOG_LEVEL=0           PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all
+  - CFG_TEE_TRACE_PERFORMANCE=y      PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all
+  - CFG_TEE_CORE_LOG_LEVEL=0 CFG_TEE_TRACE_PERFORMANCE=y         PLATFORM=vexpress        PLATFORM_FLAVOR=qemu             make -j8 all
 
   # QEMU-virt
   -                                  PLATFORM=vexpress-qemu_virt                                                           make -j8 all

--- a/core/arch/arm32/include/arm32.h
+++ b/core/arch/arm32/include/arm32.h
@@ -491,21 +491,39 @@ static inline void write_nsacr(uint32_t nsacr)
 	);
 }
 
+static inline uint64_t read_cntvct(void)
+{
+	uint64_t cntvct;
+
+	asm volatile ("mrrc	p15, 1, %Q[cntvct], %R[cntvct], c14"
+			: [cntvct] "=r" (cntvct)
+	);
+
+	return cntvct;
+}
+
 static inline uint64_t read_cntpct(void)
 {
-	uint64_t val;
+	uint64_t cntpct;
 
-	asm volatile("mrrc p15, 0, %Q0, %R0, c14" : "=r" (val));
-	return val;
+	asm volatile ("mrrc	p15, 0, %Q[cntpct], %R[cntpct], c14"
+			: [cntpct] "=r" (cntpct)
+	);
+
+	return cntpct;
 }
 
 static inline uint32_t read_cntfrq(void)
 {
-	uint32_t frq;
+	uint32_t cntfrq;
 
-	asm volatile("mrc p15, 0, %0, c14, c0, 0" : "=r" (frq));
-	return frq;
+	asm volatile ("mrc	p15, 0, %[cntfrq], c14, c0, 0"
+			: [cntfrq] "=r" (cntfrq)
+	);
+
+	return cntfrq;
 }
+
 #endif /*ASM*/
 
 #endif /*ARM32_H*/

--- a/core/arch/arm32/kernel/sub.mk
+++ b/core/arch/arm32/kernel/sub.mk
@@ -1,14 +1,14 @@
 srcs-y += tee_ta_manager.c
 srcs-y += tee_time.c
 
-srcs-$(WITH_SECURE_TIME_SOURCE_CNTPCT) += tee_time_arm_cntpct.c
-srcs-$(WITH_SECURE_TIME_SOURCE_RTT) += tee_time_rtt.c
-srcs-$(WITH_SECURE_TIME_SOURCE_REE) += tee_time_ree.c
+srcs-$(CFG_SECURE_TIME_SOURCE_ARM_GENERIC_TIMER) += tee_time_arm_generic_timer.c
+srcs-$(CFG_SECURE_TIME_SOURCE_RTT) += tee_time_rtt.c
+srcs-$(CFG_SECURE_TIME_SOURCE_REE) += tee_time_ree.c
 
 srcs-y += tee_time_unpg.c
 srcs-y += tz_proc.S
 srcs-y += tz_ssvce.S
-srcs-$(WITH_PL310) += tz_ssvce_pl310.S
+srcs-$(CFG_WITH_PL310) += tz_ssvce_pl310.S
 srcs-y += tee_l2cc_mutex.c
 
 srcs-y += thread_asm.S

--- a/core/arch/arm32/kernel/tee_time.c
+++ b/core/arch/arm32/kernel/tee_time.c
@@ -34,6 +34,7 @@
 #include <sm/teesmc.h>
 #include <kernel/tee_rpc.h>
 #include <mm/core_mmu.h>
+#include <arm32.h>
 
 struct time_source _time_source;
 
@@ -146,3 +147,15 @@ exit:
 	tee_ta_set_current_session(sess);
 	return res;
 }
+
+int tee_time_get_generic_timer_info(struct generic_timer_info *timer_info)
+{
+	if (timer_info == NULL)
+		return -1;
+
+	timer_info->counter_frequency = read_cntfrq();
+	timer_info->counter_value = read_cntvct();
+
+	return 0;
+}
+

--- a/core/arch/arm32/kernel/tee_time_arm_generic_timer.c
+++ b/core/arch/arm32/kernel/tee_time_arm_generic_timer.c
@@ -31,6 +31,7 @@
 #include <kernel/time_source.h>
 #include <mm/core_mmu.h>
 #include <utee_defines.h>
+#include <arm32.h>
 
 #include <assert.h>
 #include <stdint.h>
@@ -40,13 +41,14 @@
 static uint32_t do_div(uint64_t *dividend, uint32_t divisor)
 {
 	mpa_word_t remainder = 0, n0, n1;
+
 	n0 = (*dividend) & UINT_MAX;
 	n1 = ((*dividend) >> WORD_SIZE) & UINT_MAX;
 	*dividend = __mpa_div_dword(n0, n1, divisor, &remainder);
 	return remainder;
 }
 
-static TEE_Result arm_cntpct_get_sys_time(TEE_Time *time)
+static TEE_Result arm_generic_timer_get_sys_time(TEE_Time *time)
 {
 	uint64_t cntpct = read_cntpct();
 	uint32_t cntfrq = read_cntfrq();
@@ -60,9 +62,9 @@ static TEE_Result arm_cntpct_get_sys_time(TEE_Time *time)
 	return TEE_SUCCESS;
 }
 
-static const struct time_source arm_cntpct_time_source = {
-	.name = "arm cntpct",
-	.get_sys_time = arm_cntpct_get_sys_time,
+static const struct time_source arm_generic_timer_time_source = {
+	.name = "arm generic timer",
+	.get_sys_time = arm_generic_timer_get_sys_time,
 };
 
-REGISTER_TIME_SOURCE(arm_cntpct_time_source)
+REGISTER_TIME_SOURCE(arm_generic_timer_time_source)

--- a/core/arch/arm32/plat-stm/conf.mk
+++ b/core/arch/arm32/plat-stm/conf.mk
@@ -12,8 +12,8 @@ core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm sm tee sta) $(platform-dir)
 
 libutil_with_isoc := y
-WITH_PL310 := y
-WITH_SECURE_TIME_SOURCE_REE := y
+CFG_WITH_PL310 := y
+CFG_SECURE_TIME_SOURCE_REE := y
 CFG_CACHE_API := y
 
 include mk/config.mk

--- a/core/arch/arm32/plat-sunxi/conf.mk
+++ b/core/arch/arm32/plat-sunxi/conf.mk
@@ -19,7 +19,7 @@ core-platform-cppflags += \
 endif
 
 libutil_with_isoc := y
-WITH_SECURE_TIME_SOURCE_CNTPCT := y
+CFG_SECURE_TIME_SOURCE_ARM_GENERIC_TIMER := y
 
 include mk/config.mk
 

--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -21,7 +21,7 @@ CFG_PM_DEBUG ?= n
 
 libutil_with_isoc := y
 libtomcrypt_with_optimize_size := y
-WITH_SECURE_TIME_SOURCE_CNTPCT := y
+CFG_SECURE_TIME_SOURCE_ARM_GENERIC_TIMER := y
 WITH_UART_DRV := y
 WITH_GIC_DRV := y
 CFG_HWSUPP_MEM_PERM_PXN := y

--- a/core/include/kernel/tee_time.h
+++ b/core/include/kernel/tee_time.h
@@ -28,6 +28,7 @@
 #ifndef TEE_TIME_H
 #define TEE_TIME_H
 
+#include <utee_types.h>
 #include "tee_api_types.h"
 
 #define TEE_TIME_BOOT_TICKS_HZ  10UL
@@ -40,5 +41,6 @@ TEE_Result tee_time_get_ta_time(const TEE_UUID *uuid, TEE_Time *time);
 TEE_Result tee_time_get_ree_time(TEE_Time *time);
 TEE_Result tee_time_set_ta_time(const TEE_UUID *uuid, const TEE_Time *time);
 void tee_time_wait(uint32_t milliseconds_delay);
+int tee_time_get_generic_timer_info(struct generic_timer_info *timer_info);
 
 #endif

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -243,6 +243,16 @@ struct acipher_ops {
 				 const uint8_t *sig, size_t sig_len);
 };
 
+/* Encode/Decode operations */
+
+struct codec_ops {
+	TEE_Result (*base64_encode)(const uint8_t *in, uint32_t inlen,
+				 uint8_t *out, uint32_t *outlen);
+	TEE_Result (*base64_decode)(const uint8_t *in,  uint32_t inlen,
+				 uint8_t *out, uint32_t *outlen);
+};
+
+
 /* Cryptographic Provider API */
 struct crypto_ops {
 	/* Human-readable provider name */
@@ -254,6 +264,7 @@ struct crypto_ops {
 	struct mac_ops mac;
 	struct authenc_ops authenc;
 	struct acipher_ops acipher;
+	struct codec_ops codec;
 	struct bignum_ops bignum;
 };
 

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -35,6 +35,9 @@ CFG_CRYPTO_DH ?= y
 CFG_CRYPTO_CCM ?= y
 CFG_CRYPTO_GCM ?= y
 
+# Encode/Decode
+CFG_CRYPTO_BASE64 ?= y
+
 endif
 
 ifeq ($(CFG_WITH_PAGER),y)
@@ -77,6 +80,7 @@ _CFG_CRYPTO_WITH_HASH := $(call cryp-one-enabled, MD5 SHA1 SHA224 SHA256 SHA384 
 _CFG_CRYPTO_WITH_MAC := $(call cryp-one-enabled, HMAC CMAC CBC_MAC)
 _CFG_CRYPTO_WITH_CBC := $(call cryp-one-enabled, CBC CBC_MAC)
 _CFG_CRYPTO_WITH_ASN1 := $(call cryp-one-enabled, RSA DSA)
+_CFG_CRYPTO_WITH_CODEC := $(call cryp-one-enabled, BASE64)
 
 cppflags-lib-$(libtomcrypt_with_optimize_size) += -DLTC_SMALL_CODE -DLTC_NO_FAST
 

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -28,7 +28,8 @@
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
 
-void _assert_log(const char *expr, const char *file, int line)
+void _assert_log(const char *expr __unused, const char *file __unused,
+		int line __unused)
 {
 	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
 }

--- a/lib/libutee/include/utee_types.h
+++ b/lib/libutee/include/utee_types.h
@@ -28,12 +28,15 @@
 #ifndef UTEE_TYPES_H
 #define UTEE_TYPES_H
 
+#include <stdint.h>
+
 enum utee_property {
 	UTEE_PROP_TEE_API_VERSION = 0,
 	UTEE_PROP_TEE_DESCR,
 	UTEE_PROP_TEE_DEV_ID,
 	UTEE_PROP_TEE_SYS_TIME_PROT_LEVEL,
 	UTEE_PROP_TEE_TA_TIME_PROT_LEVEL,
+	UTEE_PROP_TEE_GENERIC_TIMER_INFO,
 	UTEE_PROP_CLIENT_ID,
 	UTEE_PROP_TA_APP_ID,
 };
@@ -53,6 +56,11 @@ enum utee_cache_operation {
 	TEE_CACHECLEAN = 0,
 	TEE_CACHEFLUSH,
 	TEE_CACHEINVALIDATE,
+};
+
+struct generic_timer_info {
+	uint32_t counter_frequency;
+	uint64_t counter_value;
 };
 
 #endif /* UTEE_TYPES_H */

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -125,6 +125,13 @@ static TEE_Result propget_gpd_tee_arith_max_big_int_size(struct prop_value *pv)
 	return TEE_SUCCESS;
 }
 
+static TEE_Result propget_ext_tee_generic_timer_info(struct prop_value *pv)
+{
+	pv->type = USER_TA_PROP_TYPE_BINARY_BLOCK;
+	return utee_get_property(UTEE_PROP_TEE_GENERIC_TIMER_INFO,
+				 &pv->u.str_val, sizeof(pv->u.str_val));
+}
+
 static const struct prop_set propset_current_ta[] = {
 	{"gpd.ta.appID", propget_gpd_ta_app_id},
 };
@@ -148,6 +155,8 @@ static const struct prop_set propset_implementation[] = {
 	{"gpd.tee.TAPersistentTime.protectionLevel",
 	 propget_gpd_tee_ta_time_protection_level},
 	{"gpd.tee.arith.maxBigIntSize", propget_gpd_tee_arith_max_big_int_size},
+	{"ext.tee.arm.genericTimerInfo",
+	 propget_ext_tee_generic_timer_info},
 };
 
 static const size_t propset_implementation_len =

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -32,3 +32,8 @@ CFG_TEE_TA_LOG_LEVEL?=1
 #   marck/check heap feature
 #   Enabling this could decrease efficiency
 CFG_TEE_CORE_USER_MEM_DEBUG?=1
+
+# CFG_TEE_TRACE_PERFORMANCE
+#   If 'y', TEECore will print CNTVCT (virtual counter) register values to console
+#   after receiving SMC call and before returning to normal world
+CFG_TEE_TRACE_PERFORMANCE?=n


### PR DESCRIPTION
  - Add new secure system call for system call performance measurement
  - Print CNTVCT value for smc call performance measurement
  - Fix compile warning message issue that will happen when compiling libutee and change log level to 0

Signed-off-by: James Kung <kong1191@gmail.com>
Tested-by: James Kung <kong1191@gmail.com> (QEMU, FVP)