### PR TITLE
RSA decode in constant time

### DIFF
--- a/core/lib/libtomcrypt/src/misc/mem_neq.c
+++ b/core/lib/libtomcrypt/src/misc/mem_neq.c
@@ -25,27 +25,58 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* ---- LTC_BASE64 Routines ---- */
-#ifdef LTC_BASE64
-int base64_encode(const unsigned char *in,  unsigned long len, 
-                        unsigned char *out, unsigned long *outlen);
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
 
-int base64_decode(const unsigned char *in,  unsigned long len, 
-                        unsigned char *out, unsigned long *outlen);
-#endif
+/**
+   @file mem_neq.c
+   Compare two blocks of memory for inequality.
+   Steffen Jaeckel
+*/
 
-/* ---- MEM routines ---- */
-int mem_neq(const void *a, const void *b, size_t len);
-void zeromem(void *dst, size_t len);
-void burn_stack(unsigned long len);
+/**
+   Compare two blocks of memory for inequality.
 
-const char *error_to_string(int err);
+   The usage is similar to that of standard memcmp(), but you can only test
+   if the memory is equal or not - you can not determine by how much the
+   first different byte differs.
 
-extern const char *crypt_build_settings;
+   @param a     The first memory region
+   @param b     The second memory region
+   @param len   The length of the area to compare (octets)
 
-/* ---- HMM ---- */
-int crypt_fsa(void *mp, ...);
+   @return 0 when a and b are equal for len bytes, else they are not equal.
+*/
+int mem_neq(const void *a, const void *b, size_t len)
+{
+   unsigned char ret = 0;
+   const unsigned char* pa;
+   const unsigned char* pb;
 
-/* $Source: /cvs/libtom/libtomcrypt/src/headers/tomcrypt_misc.h,v $ */
-/* $Revision: 1.5 $ */
-/* $Date: 2007/05/12 14:32:35 $ */
+   LTC_ARGCHK(a != NULL);
+   LTC_ARGCHK(b != NULL);
+
+   pa = a;
+   pb = b;
+
+   while (len-- > 0) {
+      ret |= *pa ^ *pb;
+      ++pa;
+      ++pb;
+   }
+
+   return ret;
+}
+
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/misc/sub.mk
+++ b/core/lib/libtomcrypt/src/misc/sub.mk
@@ -1,5 +1,6 @@
 srcs-y += burn_stack.c
 srcs-y += error_to_string.c
+srcs-y += mem_neq.c
 srcs-y += zeromem.c
 subdirs-y += base64
 subdirs-y += crypt

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -176,7 +176,7 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
    }
 
    /* mask == hash means valid signature */
-   if (XMEMCMP(mask, hash, hLen) == 0) {
+   if (mem_neq(mask, hash, hLen) == 0) {
       *res = 1;
    }
 


### PR DESCRIPTION
This is a cherry-pick of the libtomcrypt pull-request
https://github.com/libtom/libtomcrypt/pull/57

As pointed by Herve Sibert, verification has been kept non-constant time
in this patch.

Excerpt from original libtomcrypt pull-request:
  as proposed in RFC 3447 only one error return code is used when there are
  errors while decoding the pkcs#1 format.
  also, all steps are executed and only the "output" is skipped if something
  went wrong.

  Sorry this could break backwards compatibility, since there's no more
  BUFFER_OVERFLOW messaging.
  Former error-handling code could also be affected because now there's only
  OK as return code in cases where "res" is also set to '1'.

Signed-off-by: Pascal Brand <pascal.brand@st.com>