### PR TITLE
Fix user TA trace issue

### DIFF
--- a/core/arch/arm32/kernel/trace_ext.c
+++ b/core/arch/arm32/kernel/trace_ext.c
@@ -29,6 +29,7 @@
 #include <console.h>
 
 const char trace_ext_prefix[] = "TEE-CORE";
+int trace_level = CFG_TRACE_LEVEL;
 
 void trace_ext_puts(bool sync, const char *str)
 {

--- a/lib/libutee/trace_ext.c
+++ b/lib/libutee/trace_ext.c
@@ -35,8 +35,6 @@
 
 #if CFG_TRACE_LEVEL > 0
 
-const char trace_ext_prefix[] = "USER-TA";
-
 void trace_ext_puts(bool sync __unused, const char *str)
 {
 	utee_log(str, strlen(str));

--- a/lib/libutils/ext/include/trace.h
+++ b/lib/libutils/ext/include/trace.h
@@ -42,6 +42,7 @@
 /*
  * Symbols provided by the entity that uses this API.
  */
+extern int trace_level;
 extern const char trace_ext_prefix[];
 void trace_ext_puts(bool sync, const char *str);
 int trace_ext_get_thread_id(void);

--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -36,7 +36,6 @@
 #if (CFG_TRACE_LEVEL < TRACE_MIN) || (CFG_TRACE_LEVEL > TRACE_MAX)
 #error "Invalid value of CFG_TRACE_LEVEL"
 #endif
-static int trace_level = CFG_TRACE_LEVEL;
 
 void trace_set_level(int level)
 {

--- a/ta/arch/arm32/user_ta_header.c
+++ b/ta/arch/arm32/user_ta_header.c
@@ -31,8 +31,12 @@
 #include <user_ta_header_defines.h>
 #include <trace.h>
 
-#ifndef TA_TRACE_LEVEL_DEFAULT
-#define TA_TRACE_LEVEL_DEFAULT CFG_TRACE_LEVEL
+int trace_level = CFG_TRACE_LEVEL;
+
+#ifdef TA_LOG_PREFIX
+const char trace_ext_prefix[]  = TA_LOG_PREFIX;
+#else
+const char trace_ext_prefix[]  = "USER-TA";
 #endif
 
 /* exprted to user_ta_header.c, built within TA */
@@ -115,5 +119,5 @@ int tahead_get_trace_level(void)
 	/*
 	 * Store trace level in TA head structure, as ta_head.prop_tracelevel
 	 */
-	return TA_TRACE_LEVEL_DEFAULT;
+	return CFG_TRACE_LEVEL;
 }


### PR DESCRIPTION
Definition of the global "trace_level" variable has been
moved from the libutil to a TA file (user_ta_header.c).
This allows to initialize it with the correct value/level
CFG_TEE_TA_LOG_LEVEL when the TA code is compiled.
Same trace level is now applied at all TA code and associated
libraries: libutee/libutils/libmpa.

Change-Id: Id6bda7f0611f78fe7ad3ee6b61193f4b80aba94d
Signed-off-by: Jean-Michel Delorme <jean-michel.delorme@st.com>
Reviewed-on: https://gerrit.st.com/22472
Reviewed-by: Emmanuel MICHEL <emmanuel.michel@st.com>