### PR TITLE
Update setup_fvp_optee.sh/setup_qemu_optee.sh for GP test suite 1.1.0.4

### DIFF
--- a/scripts/setup_fvp_optee.sh
+++ b/scripts/setup_fvp_optee.sh
@@ -54,7 +54,7 @@ STABLE_LK_COMMIT=eb4ea6b1094ce3452c376c12a529178d202d229b
 
 SRC_OPTEE_TEST=ssh://$LINARO_USERNAME@linaro-private.git.linaro.org/srv/linaro-private.git.linaro.org/swg/optee_test.git
 DST_OPTEE_TEST=$DEV_PATH/optee_test
-STABLE_OPTEE_TEST_COMMIT=7f3746c396b61117dca0729577ce10b6a4be49ec
+STABLE_OPTEE_TEST_COMMIT=71e52146d2cef1325dea14099255ac06c13fe63d
 
 SRC_GEN_ROOTFS=https://github.com/jbech-linaro/gen_rootfs.git
 DST_GEN_ROOTFS=$DEV_PATH/gen_rootfs
@@ -376,17 +376,18 @@ export CFG_DEV_PATH=$DEV_PATH
 export CFG_ROOTFS_DIR=\$CFG_DEV_PATH/out
 
 if [ "\$CFG_GP_TESTSUITE_ENABLE" = y ]; then
-export CFG_GP_PACKAGE_PATH=\${CFG_GP_PACKAGE_PATH:-$DST_OPTEE_TEST/TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM}
+export CFG_GP_PACKAGE_PATH=\${CFG_GP_PACKAGE_PATH:-$DST_OPTEE_TEST/TEE_Initial_Configuration-Test_Suite_v1_1_0_4-2014_11_07}
 if [ ! -d "\$CFG_GP_PACKAGE_PATH" ]; then
   echo "CFG_GP_PACKAGE_PATH must be the path to the GP testsuite directory"
   exit 1
 fi
+make patch
 fi
 
 export PATH=\$CFG_DEV_PATH/toolchains/aarch64/bin:\$PATH
 export PATH=\$CFG_DEV_PATH/toolchains/aarch32/bin:\$PATH
 
-make $@
+make \$@
 EOF
 
 chmod 711 $DEV_PATH/build_optee_tests.sh

--- a/scripts/setup_qemu_optee.sh
+++ b/scripts/setup_qemu_optee.sh
@@ -72,7 +72,7 @@ STABLE_OPTEE_LK_COMMIT=f435628cbba777d7e46f46f9f813a1dd9206a68b
 
 SRC_OPTEE_TEST=ssh://$LINARO_USERNAME@linaro-private.git.linaro.org/srv/linaro-private.git.linaro.org/swg/optee_test.git
 DST_OPTEE_TEST=$DEV_PATH/optee_test
-STABLE_OPTEE_TEST_COMMIT=7f3746c396b61117dca0729577ce10b6a4be49ec
+STABLE_OPTEE_TEST_COMMIT=71e52146d2cef1325dea14099255ac06c13fe63d
 
 QEMU_PCSC_PASSTHRU_PATCHES=https://github.com/m943040028/qemu/releases/download/0.1/pcsc_patches.tbz2
 
@@ -466,14 +466,15 @@ export CFG_PLATFORM_FLAVOR=qemu_virt
 export CFG_ROOTFS_DIR=\$CFG_DEV_PATH/out
 
 if [ "\$CFG_GP_TESTSUITE_ENABLE" = y ]; then
-export CFG_GP_PACKAGE_PATH=\${CFG_GP_PACKAGE_PATH:-$DST_OPTEE_TEST/TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM}
+export CFG_GP_PACKAGE_PATH=\${CFG_GP_PACKAGE_PATH:-$DST_OPTEE_TEST/TEE_Initial_Configuration-Test_Suite_v1_1_0_4-2014_11_07}
 if [ ! -d "\$CFG_GP_PACKAGE_PATH" ]; then
   echo "CFG_GP_PACKAGE_PATH must be the path to the GP testsuite directory"
   exit 1
 fi
+make patch
 fi
 
-make -j\`getconf _NPROCESSORS_ONLN\` $@
+make -j\`getconf _NPROCESSORS_ONLN\` \$@
 EOF
 
 chmod 711 $DEV_PATH/build_optee_tests.sh


### PR DESCRIPTION
Use stable commit for optee_test that supports the GlobalPlatform test
package: TEE_Initial_Configuration-Test_Suite_v1_1_0_4-2014_11_07.7z

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>