### PR TITLE
core: enable/disable TA trace per TA instance

### DIFF
--- a/core/arch/arm32/kernel/tee_ta_manager.c
+++ b/core/arch/arm32/kernel/tee_ta_manager.c
@@ -625,6 +625,9 @@ static TEE_Result tee_ta_load(const kta_signed_header_t *signed_ta,
 #if defined(CFG_SE_API)
 	ctx->se_service = NULL;
 #endif
+#if !defined(CFG_TEE_CORE_NO_TA_TRACE)
+	ctx->trace = true;
+#endif
 
 	/* by default NSec DDR: starts at TA function code. */
 	ctx->mem_swap = (uintptr_t)(nmem_ta + sizeof(ta_head_t) +
@@ -1626,11 +1629,22 @@ void tee_ta_dump_current(void)
 	dump_state(s->ctx);
 }
 
-
 void tee_ta_dump_all(void)
 {
 	struct tee_ta_ctx *ctx;
 
 	TAILQ_FOREACH(ctx, &tee_ctxes, link)
 		dump_state(ctx);
+}
+
+bool tee_ta_is_crash_logged(void)
+{
+	struct tee_ta_session *s = NULL;
+
+	if (tee_ta_get_current_session(&s) != TEE_SUCCESS) {
+		EMSG("no valid session found: log wath you can...");
+		return true;
+	}
+
+	return s->ctx->trace;
 }

--- a/core/arch/arm32/mm/tee_pager.c
+++ b/core/arch/arm32/mm/tee_pager.c
@@ -282,6 +282,9 @@ static __unused const char *abort_type_to_str(uint32_t abort_type)
 
 static void tee_pager_print_user_abort(struct tee_pager_abort_info *ai __unused)
 {
+	if (!tee_ta_is_crash_logged())
+		return;
+
 	EMSG_RAW("\nUser TA %s-abort at address 0x%x\n",
 		abort_type_to_str(ai->abort_type), ai->va);
 	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x   ttbr1 0x%08x   cidr 0x%X\n",

--- a/core/arch/arm32/plat-stm/system_config.in
+++ b/core/arch/arm32/plat-stm/system_config.in
@@ -40,6 +40,7 @@ endif
 # Common values
 
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= 1
+CFG_TEE_CORE_NO_TA_TRACE ?= n
 
 # undef these to disable the related feature
 CFG_PL310_LOCKED ?= n

--- a/core/arch/arm32/tee/arch_svc.c
+++ b/core/arch/arm32/tee/arch_svc.c
@@ -126,7 +126,7 @@ void tee_svc_handler(struct thread_svc_regs *regs)
 	/* Restore IRQ which are disabled on exception entry */
 	thread_restore_irq();
 
-#if (CFG_TRACE_LEVEL == TRACE_FLOW)
+#if (CFG_TRACE_LEVEL == TRACE_FLOW) && (!defined(CFG_TEE_CORE_NO_TA_TRACE))
 	tee_svc_trace_syscall(scn);
 #endif
 

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -104,6 +104,7 @@ TEE_Result tee_ta_verify_session_pointer(struct tee_ta_session *sess,
 int tee_ta_set_trace_level(int level);
 void tee_ta_dump_current(void);
 void tee_ta_dump_all(void);
+bool tee_ta_is_crash_logged(void);
 
 #ifdef CFG_CACHE_API
 TEE_Result tee_uta_cache_operation(struct tee_ta_session *s,

--- a/core/include/kernel/tee_ta_manager_unpg.h
+++ b/core/include/kernel/tee_ta_manager_unpg.h
@@ -81,6 +81,7 @@ struct tee_ta_ctx {
 	uint32_t panic_code;	/* Code supplied for panic */
 	uint32_t ref_count;	/* Reference counter for multi session TA */
 	bool busy;		/* context is busy and cannot be entered */
+	bool trace;		/* TA traces to be flushed */
 	void *ta_time_offs;	/* Time reference used by the TA */
 	ta_static_head_t *static_ta;	/* TA head struct for other cores */
 	void *rlhandle;		/* private handle for other cores */

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -56,9 +56,18 @@ void tee_svc_trace_syscall(int num)
 
 void tee_svc_sys_log(const void *buf, size_t len)
 {
+	struct tee_ta_session *sess;
+	TEE_Result res;
 	char *kbuf;
 
 	if (len == 0)
+		return;
+
+	res = tee_ta_get_current_session(&sess);
+	if (res != TEE_SUCCESS)
+		return;
+
+	if (!sess->ctx->trace)
 		return;
 
 	kbuf = malloc(len);


### PR DESCRIPTION
Add a field in the TA context structure to enable/disable
related TA instance traces.

TA traces may include kernel traces related to the TA handling
(i.e crash context) and hence out of the trace_level value
internal to the TA.

Default implementation enables all traces for all TAs.
CFG_TEE_CORE_NO_TA_TRACE disables all the TAs traces.

Reviewed-by: Etienne CARRIERE <etienne.carriere@st.com>
Tested-by: Etienne CARRIERE <etienne.carriere@st.com>
Signed-off-by: Pascal Brand <pascal.brand@st.com>