### PR TITLE
ltc: prealloc 32kB buffer for RSA key import

### DIFF
--- a/core/arch/arm32/plat-stm/system_config.in
+++ b/core/arch/arm32/plat-stm/system_config.in
@@ -40,6 +40,7 @@ endif
 # Common values
 
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= 1
+CFG_LTC_USE_MRSA_PREALLOC_TMPBUF := y
 
 # undef these to disable the related feature
 CFG_PL310_LOCKED ?= n

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_import.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_import.c
@@ -44,6 +44,21 @@
 
 #ifdef LTC_MRSA
 
+#ifdef CFG_LTC_USE_MRSA_PREALLOC_TMPBUF
+/*
+ * Prevent 32kByte buffer allocation at each RSA key import.
+ * This cost 30kByte of statically allocated rw data.
+ */
+static unsigned char rsa_prealloc_tmpbuf[MAX_RSA_SIZE*8];
+#undef XCALLOC
+#define XCALLOC(_n1, _n2) \
+	(memset(rsa_prealloc_tmpbuf, 0, sizeof(rsa_prealloc_tmpbuf)), \
+	rsa_prealloc_tmpbuf)
+
+#undef XFREE
+#define XFREE(_p)
+#endif
+
 /**
   Import an RSAPublicKey or RSAPrivateKey [two-prime only, only support >= 1024-bit keys, defined in LTC_PKCS #1 v2.1]
   @param in      The packet to import from


### PR DESCRIPTION
At runtime LTC needs to import a RSA key, it needs a 32kB buffer.
Default libtomcrypt implementation allocates this tempory buffer
in the heap. As teecore operates in a small RAM footprint,
heap is small and such 32kB allocation may fail.

CFG_LTC_USE_MRSA_PREALLOC_TMPBUF=y allows to use a tempory
buffer statically allocated in BSS.

Reviewed-by: Etienne CARRIERE <etienne.carriere@st.com>
Tested-by: Etienne CARRIERE <etienne.carriere@st.com>
Signed-off-by: Pascal Brand <pascal.brand@st.com>