### PR TITLE
Libtomcrypt: use buf_compare_ct instead of mem_neq

### DIFF
--- a/core/lib/libtomcrypt/include/tomcrypt_custom.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_custom.h
@@ -80,6 +80,10 @@
    #endif
 #define XMEMCMP  memcmp
 #endif
+#ifndef XMEM_NEQ
+#include <string_ext.h>
+#define XMEM_NEQ  buf_compare_ct
+#endif
 #ifndef XSTRCMP
    #ifdef strcmp
    #define LTC_NO_PROTOTYPES

--- a/core/lib/libtomcrypt/src/misc/sub.mk
+++ b/core/lib/libtomcrypt/src/misc/sub.mk
@@ -1,6 +1,5 @@
 srcs-y += burn_stack.c
 srcs-y += error_to_string.c
-srcs-y += mem_neq.c
 srcs-y += zeromem.c
 subdirs-y += base64
 subdirs-y += crypt

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_decode.c
@@ -165,7 +165,7 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
    }
 
    /* compare the lhash'es */
-   if (mem_neq(seed, DB, hLen) != 0) {
+   if (XMEM_NEQ(seed, DB, hLen) != 0) {
       ret = CRYPT_INVALID_PACKET;
    }
 

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -176,7 +176,7 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
    }
 
    /* mask == hash means valid signature */
-   if (mem_neq(mask, hash, hLen) == 0) {
+   if (XMEM_NEQ(mask, hash, hLen) == 0) {
       *res = 1;
    }
 


### PR DESCRIPTION
Signed-off-by: Pascal Brand <pascal.brand@st.com>