### PR TITLE
CFG_TEE_CORE_TA_TRACE to disable TA traces

### DIFF
--- a/core/arch/arm32/mm/tee_pager.c
+++ b/core/arch/arm32/mm/tee_pager.c
@@ -299,6 +299,7 @@ static __unused const char *abort_type_to_str(uint32_t abort_type)
 
 static void tee_pager_print_user_abort(struct tee_pager_abort_info *ai __unused)
 {
+#ifdef CFG_TEE_CORE_TA_TRACE
 	EMSG_RAW("\nUser TA %s-abort at address 0x%x\n",
 		abort_type_to_str(ai->abort_type), ai->va);
 	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x   ttbr1 0x%08x   cidr 0x%X\n",
@@ -315,6 +316,7 @@ static void tee_pager_print_user_abort(struct tee_pager_abort_info *ai __unused)
 		 ai->regs->r3, ai->regs->r7, ai->regs->r11, ai->pc);
 
 	tee_ta_dump_current();
+#endif
 }
 
 static void tee_pager_print_abort(struct tee_pager_abort_info *ai __unused)

--- a/core/arch/arm32/tee/arch_svc.c
+++ b/core/arch/arm32/tee/arch_svc.c
@@ -126,7 +126,7 @@ void tee_svc_handler(struct thread_svc_regs *regs)
 	/* Restore IRQ which are disabled on exception entry */
 	thread_restore_irq();
 
-#if (CFG_TRACE_LEVEL == TRACE_FLOW)
+#if (CFG_TRACE_LEVEL == TRACE_FLOW) && defined(CFG_TEE_CORE_TA_TRACE)
 	tee_svc_trace_syscall(scn);
 #endif
 

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -44,7 +44,7 @@
 #include <kernel/trace_ta.h>
 #include <kernel/chip_services.h>
 
-#if (CFG_TRACE_LEVEL == TRACE_FLOW)
+#if (CFG_TRACE_LEVEL == TRACE_FLOW) && defined(CFG_TEE_CORE_TA_TRACE)
 void tee_svc_trace_syscall(int num)
 {
 	/* #0 is syscall return, not really interesting */
@@ -54,8 +54,9 @@ void tee_svc_trace_syscall(int num)
 }
 #endif
 
-void tee_svc_sys_log(const void *buf, size_t len)
+void tee_svc_sys_log(const void *buf __unused, size_t len __unused)
 {
+#ifdef CFG_TEE_CORE_TA_TRACE
 	char *kbuf;
 
 	if (len == 0)
@@ -71,6 +72,7 @@ void tee_svc_sys_log(const void *buf, size_t len)
 		TAMSG_RAW("%.*s", (int)len, kbuf);
 
 	free(kbuf);
+#endif
 }
 
 TEE_Result tee_svc_reserved(void)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1,7 +1,7 @@
 # WARNS from undefined, 1, 2 and 3. 3 means we have the most warning messages
 WARNS ?= 3
 
-# Define NOWERROR=1 so that warnings are not treated as errors 
+# Define NOWERROR=1 so that warnings are not treated as errors
 # NOWERROR=1
 
 # Define DEBUG=1 to compile with -g option
@@ -25,6 +25,11 @@ CFG_TEE_CORE_LOG_LEVEL?=1
 #   dynamically changes via debugfs in the range 1 => CFG_TEE_TA_LOG_LEVEL
 CFG_TEE_TA_LOG_LEVEL?=1
 
+# CFG_TEE_CORE_TA_TRACE
+#   TA enablement
+#   When defined to "y", TA traces are output according to
+#   CFG_TEE_TA_LOG_LEVEL. Otherwise, they are not output at all
+CFG_TEE_CORE_TA_TRACE?=y
 
 #   If 1, enable debug features of the user mem module. This module track memory
 #   allocation of the user ta.


### PR DESCRIPTION
In order to disable TA traces, whatever the compilation options of the
TAs, CFG_TEE_CORE_TA_TRACE can be defined to n

Signed-off-by: Pascal Brand <pascal.brand@st.com>