### PR TITLE
core: load/generate TEE fmw build configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ all:
 .PHONY: mem_usage
 mem_usage:
 
+# log and load eventual tee config file
+# path is absolute or relative to current source root directory.
+ifdef CFG_OPTEE_CONFIG
+$(info Loading OPTEE configuration file $(CFG_OPTEE_CONFIG))
+include $(CFG_OPTEE_CONFIG)
+endif
+
 # If $(PLATFORM) is defined and contains a hyphen, parse it as
 # $(PLATFORM)-$(PLATFORM_FLAVOR) for convenience
 ifneq (,$(findstring -,$(PLATFORM)))

--- a/core/core.mk
+++ b/core/core.mk
@@ -29,11 +29,18 @@ cppflags$(sm)	+= -Ilib/libutee/include
 # configuration file
 
 conf-file := $(out-dir)/core/include/generated/conf.h
+conf-mk-file := $(out-dir)/core/conf.mk
+$(conf-file): $(conf-mk-file)
+
 cleanfiles += $(conf-file)
+cleanfiles += $(conf-mk-file)
 
 include mk/checkconf.mk
 $(conf-file): FORCE
 	$(call check-conf-h)
+
+$(conf-mk-file):  FORCE
+	$(call build-conf-mk)
 
 #
 # Do libraries

--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -31,6 +31,22 @@ define check-conf-h
 	fi
 endef
 
+define build-conf-mk
+	$(q)set -e;						\
+	cnf="$(strip $(foreach var,				\
+		$(call cfg-vars-by-prefix,CFG_),		\
+		$(call cfg-make-variable,$(var))))";		\
+	mkdir -p $(dir $@);					\
+	echo "# auto-generated TEE configuration file" >$@.tmp; \
+	echo "# TEE version $${CFG_TEE_VERSION:-(undefined)}" >>$@.tmp; \
+	echo "ARCH=${ARCH}" >>$@.tmp;				\
+	echo "PLATFORM=${PLATFORM}" >>$@.tmp;			\
+	echo "PLATFORM_FLAVOR=${PLATFORM_FLAVOR}" >>$@.tmp; 	\
+	echo -n "$${cnf}" | sed 's/_nl_ */\n/g' >>$@.tmp;	\
+	echo '  UPD     $@';					\
+	mv $@.tmp $@;
+endef
+
 define cfg-vars-by-prefix
 	$(strip $(if $(1),$(call _cfg-vars-by-prefix,$(1)),
 			  $(call _cfg-vars-by-prefix,CFG_ _CFG_)))
@@ -50,6 +66,12 @@ define cfg-make-define
 		     $(if $(filter xn x,x$($1)),
 			  /* $1 is not set ('$($1)') */_nl_,
 			  #define $1 $($1) /* '$($1)' */_nl_)))
+endef
+
+define cfg-make-variable
+	$(strip $(if $(filter xn x,x$($1)),
+			  # $1 is not set ('$($1)')_nl_,
+			  $1=$($1)_nl_))
 endef
 
 # Returns 'y' if at least one variable is 'y', empty otherwise

--- a/mk/cleanvars.mk
+++ b/mk/cleanvars.mk
@@ -9,3 +9,4 @@ libdeps		:=
 sm-$(sm)	:=
 incdirs		:=
 conf-file	:=
+conf-mk-file	:=


### PR DESCRIPTION
At build time, conf.in file is generated at output root directory.

At build entry, if CFG_OPTEE_CONFIG is defined, it specifies the
path of the target TEE build configuration to use.

Tested-by: Etienne CARRIERE <etienne.carriere@st.com>
Reviewed-by: Pascal BRAND <pascal.brand@st.com>
Reviewed-by: Etienne CARRIERE <etienne.carriere@st.com>