### PR TITLE
Check of the identity of the TA invoking a TA operation

### DIFF
--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -37,6 +37,11 @@
 #include "tee_ta_manager_unpg.h"
 #include "utee_types.h"
 
+/* Magic TEE identity pointer: set when teecore requests a TA close */
+#define KERN_IDENTITY	((TEE_Identity *)-1)
+/* Operation is initiated by a client (non-secure) app */
+#define NSAPP_IDENTITY	(NULL)
+
 /*-----------------------------------------------------------------------------
  * Initializes virtual memory management by reserving virtual memory for
  * memory areas not available TA virtual memroy allocation.
@@ -69,11 +74,13 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 
 TEE_Result tee_ta_invoke_command(TEE_ErrorOrigin *err,
 				 struct tee_ta_session *sess,
+				 const TEE_Identity *clnt_id,
 				 uint32_t cancel_req_to, uint32_t cmd,
 				 struct tee_ta_param *param);
 
 TEE_Result tee_ta_cancel_command(TEE_ErrorOrigin *err,
-				 struct tee_ta_session *sess);
+				 struct tee_ta_session *sess,
+				 const TEE_Identity *clnt_id);
 
 /*-----------------------------------------------------------------------------
  * Function called to close a TA.
@@ -83,7 +90,8 @@ TEE_Result tee_ta_cancel_command(TEE_ErrorOrigin *err,
  *        TEE_Result
  *---------------------------------------------------------------------------*/
 TEE_Result tee_ta_close_session(uint32_t id,
-				struct tee_ta_session_head *open_sessions);
+				struct tee_ta_session_head *open_sessions,
+				const TEE_Identity *clnt_id);
 
 TEE_Result tee_ta_get_current_session(struct tee_ta_session **sess);
 

--- a/core/kernel/tee_dispatch.c
+++ b/core/kernel/tee_dispatch.c
@@ -125,7 +125,8 @@ cleanup_return:
 
 TEE_Result tee_dispatch_close_session(struct tee_close_session_in *in)
 {
-	return tee_ta_close_session(in->sess, &tee_open_sessions);
+	return tee_ta_close_session(in->sess, &tee_open_sessions,
+				    NSAPP_IDENTITY);
 }
 
 TEE_Result tee_dispatch_invoke_command(struct tee_dispatch_invoke_command_in *
@@ -152,7 +153,7 @@ TEE_Result tee_dispatch_invoke_command(struct tee_dispatch_invoke_command_in *
 	memcpy(out->params, in->params, sizeof(in->params));
 	memcpy(param.param_attr, in->param_attr, sizeof(in->param_attr));
 
-	res = tee_ta_invoke_command(&err, sess,
+	res = tee_ta_invoke_command(&err, sess, NSAPP_IDENTITY,
 				    TEE_TIMEOUT_INFINITE, in->cmd, &param);
 	update_out_param(&param, out->params);
 
@@ -175,7 +176,7 @@ TEE_Result tee_dispatch_cancel_command(struct tee_dispatch_cancel_command_in *
 	if (res != TEE_SUCCESS)
 		goto cleanup_return;
 
-	res = tee_ta_cancel_command(&res_orig, sess);
+	res = tee_ta_cancel_command(&res_orig, sess, NSAPP_IDENTITY);
 
 cleanup_return:
 	out->msg.err = res_orig;


### PR DESCRIPTION
On the following operations
    invoke command
    close
    cancel
the one that is at the origin of the operations is checked. It could
be a TA or the core. In case of a TA, this is checked that it is the
same as the one that opened the session.

Signed-off-by: Pascal Brand <pascal.brand@st.com>