### PR TITLE
Define 32-bit ABI

### DIFF
--- a/core/include/tee/abi.h
+++ b/core/include/tee/abi.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TEE_ABI_H
+#define TEE_ABI_H
+
+#include <types_ext.h>
+#include <tee_api_types.h>
+
+/*
+ * This file defines types specific to the ABI (Application Binary
+ * Interface) provided by TEE Core. More types than those below are used,
+ * but when they differ between 64-bit and 32-bit they are added in this
+ * file.
+ */
+
+
+/* Defines parameters for 32-bit user TAs */
+struct abi_user32_param {
+	union {
+		struct {
+			uint32_t buf_ptr;
+			uint32_t size;
+		} memref;
+		struct {
+			uint32_t a;
+			uint32_t b;
+		} value;
+	} u[TEE_NUM_PARAMS];
+};
+
+void abi_param_to_user32_param(struct abi_user32_param *usr_param,
+			const TEE_Param *param, uint32_t param_types);
+void abi_user32_param_to_param(TEE_Param *param,
+			const struct abi_user32_param *usr_param,
+			uint32_t param_types);
+
+
+/* Defines TEE_Attribute for 32-bit user TAs */
+struct abi_user32_attribute {
+	uint32_t attr_id;
+	union {
+		struct {
+			uint32_t buf_ptr;
+			uint32_t length;
+		} ref;
+		struct {
+			uint32_t a;
+			uint32_t b;
+		} value;
+	} u;
+};
+
+void abi_attr_to_user32_attr(struct abi_user32_attribute *usr_attr,
+			const TEE_Attribute *attr, size_t num_attrs);
+void abi_user_attr32_to_attr(TEE_Attribute *attr,
+			const struct abi_user32_attribute *usr_attr,
+			size_t num_attrs);
+
+#endif /*TEE_ABI_H*/
+

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -30,7 +30,7 @@
 #include <stdint.h>
 #include <kernel/tee_common_unpg.h>	/* tee_uaddr_t */
 #include <tee_api_types.h>
-#include <tee_api_types.h>
+#include <tee/abi.h>
 #include <utee_types.h>
 
 struct tee_ta_session;
@@ -57,7 +57,7 @@ TEE_Result tee_svc_sys_get_property(uint32_t prop, tee_uaddr_t buf,
 
 TEE_Result tee_svc_open_ta_session(const TEE_UUID *dest,
 				   uint32_t cancel_req_to, uint32_t param_types,
-				   TEE_Param params[4],
+				   struct abi_user32_param *usr_params,
 				   TEE_TASessionHandle *sess,
 				   uint32_t *ret_orig);
 
@@ -65,7 +65,8 @@ TEE_Result tee_svc_close_ta_session(TEE_TASessionHandle sess);
 
 TEE_Result tee_svc_invoke_ta_command(TEE_TASessionHandle sess,
 				     uint32_t cancel_req_to, uint32_t cmd_id,
-				     uint32_t param_types, TEE_Param params[4],
+				     uint32_t param_types,
+				     struct abi_user32_param *usr_params,
 				     uint32_t *ret_orig);
 
 TEE_Result tee_svc_check_access_rights(uint32_t flags, const void *buf,

--- a/core/include/tee/tee_svc_cryp.h
+++ b/core/include/tee/tee_svc_cryp.h
@@ -33,17 +33,17 @@
 TEE_Result tee_svc_cryp_obj_get_info(uint32_t obj, TEE_ObjectInfo *info);
 TEE_Result tee_svc_cryp_obj_restrict_usage(uint32_t obj, uint32_t usage);
 TEE_Result tee_svc_cryp_obj_get_attr(uint32_t obj, uint32_t attr_id,
-			     void *buffer, size_t *size);
+			     void *buffer, uint32_t *size);
 
 TEE_Result tee_svc_cryp_obj_alloc(TEE_ObjectType obj_type,
 			  uint32_t max_obj_size, uint32_t *obj);
 TEE_Result tee_svc_cryp_obj_close(uint32_t obj);
 TEE_Result tee_svc_cryp_obj_reset(uint32_t obj);
-TEE_Result tee_svc_cryp_obj_populate(uint32_t obj, TEE_Attribute *attrs,
-			     uint32_t attr_count);
+TEE_Result tee_svc_cryp_obj_populate(uint32_t obj,
+		struct abi_user32_attribute *usr_attrs, uint32_t attr_count);
 TEE_Result tee_svc_cryp_obj_copy(uint32_t dst_obj, uint32_t src_obj);
 TEE_Result tee_svc_obj_generate_key(uint32_t obj, uint32_t key_size,
-			    const TEE_Attribute *params,
+			    const struct abi_user32_attribute *usr_params,
 			    uint32_t param_count);
 
 TEE_Result tee_svc_cryp_state_alloc(uint32_t algo, uint32_t op_mode,
@@ -58,16 +58,17 @@ TEE_Result tee_svc_hash_init(uint32_t state, const void *iv, size_t iv_len);
 TEE_Result tee_svc_hash_update(uint32_t state, const void *chunk,
 		       size_t chunk_size);
 TEE_Result tee_svc_hash_final(uint32_t state, const void *chunk,
-		      size_t chunk_size, void *hash, size_t *hash_len);
+		      size_t chunk_size, void *hash, uint32_t *hash_len);
 
 TEE_Result tee_svc_cipher_init(uint32_t state, const void *iv, size_t iv_len);
 TEE_Result tee_svc_cipher_update(uint32_t state, const void *src,
-			 size_t src_len, void *dest, size_t *dest_len);
+			 size_t src_len, void *dest, uint32_t *dest_len);
 TEE_Result tee_svc_cipher_final(uint32_t state, const void *src,
-			size_t src_len, void *dest, size_t *dest_len);
+			size_t src_len, void *dest, uint32_t *dest_len);
 
-TEE_Result tee_svc_cryp_derive_key(uint32_t state, const TEE_Attribute *params,
-			   uint32_t param_count, uint32_t derived_key);
+TEE_Result tee_svc_cryp_derive_key(uint32_t state,
+			const struct abi_user32_attribute *usr_params,
+			uint32_t param_count, uint32_t derived_key);
 
 TEE_Result tee_svc_cryp_random_number_generate(void *buf, size_t blen);
 
@@ -78,23 +79,23 @@ TEE_Result tee_svc_authenc_update_aad(uint32_t state, const void *aad_data,
 			      size_t aad_data_len);
 TEE_Result tee_svc_authenc_update_payload(uint32_t state, const void *src_data,
 				  size_t src_len, void *dest_data,
-				  size_t *dest_len);
+				  uint32_t *dest_len);
 TEE_Result tee_svc_authenc_enc_final(uint32_t state, const void *src_data,
 			     size_t src_len, void *dest_data,
-			     size_t *dest_len, void *tag,
-			     size_t *tag_len);
+			     uint32_t *dest_len, void *tag,
+			     uint32_t *tag_len);
 TEE_Result tee_svc_authenc_dec_final(uint32_t state, const void *src_data,
 			     size_t src_len, void *dest_data,
-			     size_t *dest_len, const void *tag,
+			     uint32_t *dest_len, const void *tag,
 			     size_t tag_len);
 
-TEE_Result tee_svc_asymm_operate(uint32_t state, const TEE_Attribute *params,
-			 uint32_t num_params, const void *src_data,
-			 size_t src_len, void *dest_data,
-			 size_t *dest_len);
-TEE_Result tee_svc_asymm_verify(uint32_t state, const TEE_Attribute *params,
+TEE_Result tee_svc_asymm_operate(uint32_t state,
+			const struct abi_user32_attribute *usr_params,
+			uint32_t num_params, const void *src_data,
+			size_t src_len, void *dest_data, uint32_t *dest_len);
+TEE_Result tee_svc_asymm_verify(uint32_t state,
+			const struct abi_user32_attribute *usr_params,
 			uint32_t num_params, const void *data,
-			size_t data_len, const void *sig,
-			size_t sig_len);
+			size_t data_len, const void *sig, size_t sig_len);
 
 #endif /* TEE_SVC_CRYP_H */

--- a/core/tee/abi.c
+++ b/core/tee/abi.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <tee/abi.h>
+
+void abi_param_to_user32_param(struct abi_user32_param *usr_param,
+			const TEE_Param *param, uint32_t param_types)
+{
+	size_t n;
+
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
+		switch (TEE_PARAM_TYPE_GET(param_types, n)) {
+		case TEE_PARAM_TYPE_MEMREF_INPUT:
+		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+		case TEE_PARAM_TYPE_MEMREF_INOUT:
+			usr_param->u[n].memref.buf_ptr =
+				(uintptr_t)param[n].memref.buffer;
+			usr_param->u[n].memref.size = param[n].memref.size;
+			break;
+		case TEE_PARAM_TYPE_VALUE_INPUT:
+		case TEE_PARAM_TYPE_VALUE_OUTPUT:
+		case TEE_PARAM_TYPE_VALUE_INOUT:
+			usr_param->u[n].value.a = param[n].value.a;
+			usr_param->u[n].value.b = param[n].value.b;
+		default:
+			break;
+		}
+	}
+}
+
+void abi_user32_param_to_param(TEE_Param *param,
+			const struct abi_user32_param *usr_param,
+			uint32_t param_types)
+{
+	size_t n;
+
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
+		switch (TEE_PARAM_TYPE_GET(param_types, n)) {
+		case TEE_PARAM_TYPE_MEMREF_INPUT:
+		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+		case TEE_PARAM_TYPE_MEMREF_INOUT:
+			param[n].memref.buffer = (void *)(uintptr_t)
+					usr_param->u[n].memref.buf_ptr;
+			param[n].memref.size = usr_param->u[n].memref.size;
+			break;
+		case TEE_PARAM_TYPE_VALUE_INPUT:
+		case TEE_PARAM_TYPE_VALUE_OUTPUT:
+		case TEE_PARAM_TYPE_VALUE_INOUT:
+			param[n].value.a = usr_param->u[n].value.a;
+			param[n].value.b = usr_param->u[n].value.b;
+		default:
+			break;
+		}
+	}
+}
+
+void abi_attr_to_user32_attr(struct abi_user32_attribute *usr_attr,
+			const TEE_Attribute *attr, size_t num_attrs)
+{
+	size_t n;
+
+	for (n = 0; n < num_attrs; n++) {
+		usr_attr[n].attr_id = attr[n].attributeID;
+		if (attr[n].attributeID & TEE_ATTR_BIT_VALUE) {
+			usr_attr[n].u.value.a = attr[n].content.value.a;
+			usr_attr[n].u.value.b = attr[n].content.value.b;
+		} else {
+			usr_attr[n].u.ref.buf_ptr =
+				(uintptr_t)attr[n].content.ref.buffer;
+			usr_attr[n].u.ref.length = attr[n].content.ref.length;
+		}
+	}
+}
+
+void abi_user_attr32_to_attr(TEE_Attribute *attr,
+			const struct abi_user32_attribute *usr_attr,
+			size_t num_attrs)
+{
+	size_t n;
+
+	for (n = 0; n < num_attrs; n++) {
+		attr[n].attributeID = usr_attr[n].attr_id;
+		if (usr_attr[n].attr_id & TEE_ATTR_BIT_VALUE) {
+			attr[n].content.value.a = usr_attr[n].u.value.a;
+			attr[n].content.value.b = usr_attr[n].u.value.b;
+		} else {
+			attr[n].content.ref.buffer = (void *)(uintptr_t)
+						     usr_attr[n].u.ref.buf_ptr;
+			attr[n].content.ref.length = usr_attr[n].u.ref.length;
+		}
+	}
+}

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -29,5 +29,6 @@ srcs-y += tee_obj.c
 srcs-y += tee_pobj.c
 srcs-y += tee_rpmb_fs.c
 srcs-y += tee_time_generic.c
+srcs-y += abi.c
 
 subdirs-${CFG_SE_API} += se

--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -260,6 +260,9 @@
 #define TEE_ATTR_ECC_PRIVATE_VALUE          0xC0000341
 #define TEE_ATTR_ECC_CURVE                  0xF0000441
 
+#define TEE_ATTR_BIT_PROTECTED		    (1 << 28)
+#define TEE_ATTR_BIT_VALUE		    (1 << 29)
+
 /*
  * The macro TEE_PARAM_TYPES can be used to construct a value that you can
  * compare against an incoming paramTypes to check the type of all the


### PR DESCRIPTION
Defines 32-bit ABI for various types passed by reference. Either by an
explicit conversion to/from TEE_Param and TEE_Attribute or by changing
size_t to uint32_t. Affected interfaces are SVC interface and parameters
passed to user TA inside tee_user_ta_enter().

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU, FVP)