### PR TITLE
Added new interface in PRNG Hal to inject entropy

### DIFF
--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -244,6 +244,9 @@ struct acipher_ops {
 };
 
 struct prng_ops {
+	/* add entropy to PRNG entropy pool */
+	TEE_Result (*add_entropy)(const uint8_t *inbuf, size_t len);
+
 	/* to read random data from PRNG implementation	 */
 	TEE_Result (*read)(void *buf, size_t blen);
 };

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -51,5 +51,6 @@ TEE_Result tee_aes_cbc_cts_update(void *cbc_ctx, void *ecb_ctx,
 				  const uint8_t *data, size_t len,
 				  uint8_t *dst);
 
+TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len);
 
 #endif

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -2309,6 +2309,25 @@ static TEE_Result prng_read(void *buf, size_t blen)
 	return TEE_SUCCESS;
 }
 
+static TEE_Result prng_add_entropy(const uint8_t *inbuf, size_t len)
+{
+	int err;
+	struct tee_ltc_prng *prng = tee_ltc_get_prng();
+
+	err = prng_is_valid(prng->index);
+
+	if (err != CRYPT_OK)
+		return TEE_ERROR_BAD_STATE;
+
+	err = prng_descriptor[prng->index].add_entropy(
+			inbuf, len, &prng->state);
+
+	if (err != CRYPT_OK)
+		return TEE_ERROR_BAD_STATE;
+
+	return TEE_SUCCESS;
+}
+
 static TEE_Result tee_ltc_init(void)
 {
 #if defined(_CFG_CRYPTO_WITH_ACIPHER)
@@ -2395,6 +2414,7 @@ struct crypto_ops crypto_ops = {
 	},
 #endif /* _CFG_CRYPTO_WITH_ACIPHER */
 	.prng = {
+		.add_entropy = prng_add_entropy,
 		.read = prng_read,
 	}
 };

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -394,6 +394,14 @@ TEE_Result tee_aes_cbc_cts_update(void *cbc_ctx, void *ecb_ctx,
 	return TEE_SUCCESS;
 }
 
+TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len)
+{
+	if (crypto_ops.prng.add_entropy)
+		return crypto_ops.prng.add_entropy(in, len);
+
+	return TEE_SUCCESS;
+}
+
 TEE_Result tee_cryp_init(void)
 {
 	if (crypto_ops.init)


### PR DESCRIPTION
- Added add_entropy interface in crypto_ops.prng, and expose
  new interface tee_prng_add_entropy() for platform vendor to
  inject entropy.
- On FVP, inject entropy using current timestamp every time
  when a core is bring up.

Signed-off-by: SY Chiu <sy.chiu@linaro.org>
Tested-by: SY Chiu <sy.chiu@linaro.org> (FVP)