### PR TITLE
Get rid of CROSS_PREFIX, restore CROSS_COMPILE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,14 @@ script:
   - git format-patch -1 --stdout | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -
 
   # Orly2
-  -                                  PLATFORM=stm-orly2                                  CROSS_PREFIX=arm-linux-gnueabihf  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_PREFIX=arm-linux-gnueabihf  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_PREFIX=arm-linux-gnueabihf  make -j8 all
+  -                                  PLATFORM=stm-orly2                                  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
 
   # Cannes
-  -                                  PLATFORM=stm-cannes                                 CROSS_PREFIX=arm-linux-gnueabihf  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_PREFIX=arm-linux-gnueabihf  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_PREFIX=arm-linux-gnueabihf  make -j8 all
+  -                                  PLATFORM=stm-cannes                                 CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
 
   # FVP
   -                                  PLATFORM=vexpress-fvp                                                                 make -j8 all

--- a/core/arch/arm32/plat-stm/conf.mk
+++ b/core/arch/arm32/plat-stm/conf.mk
@@ -1,7 +1,6 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_PREFIX	?= armv7-linux
-CROSS_COMPILE	?= $(CROSS_PREFIX)-
+CROSS_COMPILE	?= armv7-linux-
 COMPILER	?= gcc
 
 core-platform-cppflags	 = -I$(arch-dir)/include

--- a/core/arch/arm32/plat-sunxi/conf.mk
+++ b/core/arch/arm32/plat-sunxi/conf.mk
@@ -1,7 +1,6 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_PREFIX	?= arm-linux-gnueabihf
-CROSS_COMPILE	?= $(CROSS_PREFIX)-
+CROSS_COMPILE	?= arm-linux-gnueabihf-
 COMPILER	?= gcc
 
 core-platform-cppflags	 = -I$(arch-dir)/include

--- a/core/arch/arm32/plat-vexpress/conf.mk
+++ b/core/arch/arm32/plat-vexpress/conf.mk
@@ -1,7 +1,6 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_PREFIX	?= arm-linux-gnueabihf
-CROSS_COMPILE	?= $(CROSS_PREFIX)-
+CROSS_COMPILE	?= arm-linux-gnueabihf-
 COMPILER	?= gcc
 
 ifeq ($(CFG_ARM64_core),y)

--- a/core/core.mk
+++ b/core/core.mk
@@ -9,8 +9,7 @@ platform-dir	:= $(arch-dir)/plat-$(PLATFORM)
 include $(platform-dir)/conf.mk
 
 # Setup compiler for this sub module
-CROSS_PREFIX_$(sm)	?= $(CROSS_PREFIX)
-CROSS_COMPILE_$(sm)	?= $(CROSS_PREFIX_$(sm))-
+CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)
 COMPILER_$(sm)		?= $(COMPILER)
 include mk/$(COMPILER_$(sm)).mk
 

--- a/documentation/build_system.md
+++ b/documentation/build_system.md
@@ -101,10 +101,10 @@ change in case you want to use
 $ make CROSS_COMPILE="ccache arm-linux-gnueabihf-"
 ```
 
-The CROSS_PREFIX variable can be overridden with **CROSS_PREFIX_core** and
-**CROSS_PREFIX_ta** for TEE Core and Trusted Applications respectively.
-This is needed TEE Core and Trusted Application libraries need to be
-compiled with different compilers due to a mix of 64bit and 32bit code
+The CROSS_COMPILE variable can be overridden with **CROSS_COMPILE_core** and
+**CROSS_COMPILE_user_ta** for TEE Core and Trusted Applications respectively.
+This is needed if TEE Core and Trusted Application libraries need to be
+compiled with different compilers due to a mix of 64bit and 32bit code.
 
 
 ## Platform-specific configuration and flags

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -5,8 +5,7 @@ sm := user_ta
 sm-$(sm) := y
 
 # Setup compiler for this sub module
-CROSS_PREFIX_$(sm)	?= $(CROSS_PREFIX)
-CROSS_COMPILE_$(sm)	?= $(CROSS_PREFIX_$(sm))-
+CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)
 COMPILER_$(sm)		?= $(COMPILER)
 include mk/$(COMPILER_$(sm)).mk
 


### PR DESCRIPTION
Use CROSS_COMPILE to set the cross-compiler (CROSS_PREFIX is not supported
anymore). Use CROSS_COMPILE_core and CROSS_COMPILE_user_ta to override the
compiler for TEE core and user space code (Trusted Applications),
respectively.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>