### PR TITLE
TA-dev-kit: Adds usage of the $(sm) variable

### DIFF
--- a/ta/arch/arm32/fix_ta_binary
+++ b/ta/arch/arm32/fix_ta_binary
@@ -27,7 +27,7 @@
 use strict;
 use warnings;
 use diagnostics;
-use Env qw($READELF);
+use Env qw($READELF $CROSS_COMPILE_user_ta);
 
 sub usage
 {
@@ -51,7 +51,17 @@ open(BIN, "+<$bin") || die("Error opening TA file $bin");
 binmode(BIN);
 
 my $readelf = "readelf";
-$readelf = $READELF if ($READELF);
+
+# In some build environments $READELF is not defined.
+# As a 2nd alternative we use the environment variable $CROSS_COMPILE_user_ta
+# to target the correct "readelf"
+
+if ($READELF) {
+    $readelf = $READELF
+}
+elsif ($CROSS_COMPILE_user_ta) {
+    $readelf = "${CROSS_COMPILE_user_ta}readelf"
+}
 
 my $readelfcmd = "$readelf -s -W $elf";
 print "$readelfcmd\n" if ($verbose);

--- a/ta/arch/arm32/link.mk
+++ b/ta/arch/arm32/link.mk
@@ -24,7 +24,7 @@ reverse = $(if $(wordlist 2,2,$(1)),$(call reverse,$(wordlist 2,$(words $(1)),$(
 link-ldadd  = $(LDADD)
 link-ldadd += $(addprefix -L,$(libdirs))
 link-ldadd += $(addprefix -l,$(call reverse,$(libnames)))
-ldargs-$(binary).elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc)
+ldargs-$(binary).elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc$(sm))
 
 
 $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
@@ -34,13 +34,13 @@ $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
 
 $(link-out-dir)/$(binary).elf: $(objs) $(libdeps) $(link-script-pp)
 	@echo '  LD      $@'
-	$(q)$(LD) $(ldargs-$(binary).elf) -o $@
+	$(q)$(LD$(sm)) $(ldargs-$(binary).elf) -o $@
 
 $(link-out-dir)/$(binary).dmp: $(link-out-dir)/$(binary).elf
 	@echo '  OBJDUMP $@'
-	$(q)$(OBJDUMP) -l -x -d $< > $@
+	$(q)$(OBJDUMP$(sm)) -l -x -d $< > $@
 
 $(link-out-dir)/$(binary).bin: $(link-out-dir)/$(binary).elf
 	@echo '  OBJCOPY $@'
-	$(q)$(OBJCOPY) -O binary $< $@
+	$(q)$(OBJCOPY$(sm)) -O binary $< $@
 	$(q)$(FIX_TA_BINARY) $< $@

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -7,9 +7,11 @@ ta-dev-kit-dir := $(patsubst %/,%,$(abspath $(dir $(lastword $(MAKEFILE_LIST))).
 .PHONY: all
 all:
 
-sm := ta
+sm := user_ta
 sm-$(ta) := y
 binary := $(BINARY)
+
+CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)
 
 ifneq ($O,)
 out-dir := $O


### PR DESCRIPTION
Making use of the $(sm) variable that was missing in a couple of places
when building Trusted Applications. Also the CROSS_COMPILER flag for
building TA's has been updated since it didn't propagate correctly.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (QEMU)