### PR TITLE
TA build fixes for MinGW32 build on Windows

### DIFF
--- a/ta/arch/arm32/fix_ta_binary
+++ b/ta/arch/arm32/fix_ta_binary
@@ -27,7 +27,7 @@
 use strict;
 use warnings;
 use diagnostics;
-use Env qw($READELF);
+use Env qw($READELF $CROSS_COMPILE_ta);
 
 sub usage
 {
@@ -51,7 +51,17 @@ open(BIN, "+<$bin") || die("Error opening TA file $bin");
 binmode(BIN);
 
 my $readelf = "readelf";
-$readelf = $READELF if ($READELF);
+
+# In some build environments $READELF is not defined.
+# As a 2nd alternative we use the environment variable $CROSS_COMPILE_ta
+# to target the correct "readelf"
+
+if ($READELF) {
+    $readelf = $READELF
+}
+elsif ($CROSS_COMPILE_ta) {
+    $readelf = "${CROSS_COMPILE_ta}readelf"
+}
 
 my $readelfcmd = "$readelf -s -W $elf";
 print "$readelfcmd\n" if ($verbose);

--- a/ta/arch/arm32/link.mk
+++ b/ta/arch/arm32/link.mk
@@ -24,7 +24,7 @@ reverse = $(if $(wordlist 2,2,$(1)),$(call reverse,$(wordlist 2,$(words $(1)),$(
 link-ldadd  = $(LDADD)
 link-ldadd += $(addprefix -L,$(libdirs))
 link-ldadd += $(addprefix -l,$(call reverse,$(libnames)))
-ldargs-$(binary).elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc)
+ldargs-$(binary).elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc$(sm))
 
 
 $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
@@ -34,13 +34,13 @@ $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
 
 $(link-out-dir)/$(binary).elf: $(objs) $(libdeps) $(link-script-pp)
 	@echo '  LD      $@'
-	$(q)$(LD) $(ldargs-$(binary).elf) -o $@
+	$(q)$(LD$(sm)) $(ldargs-$(binary).elf) -o $@
 
 $(link-out-dir)/$(binary).dmp: $(link-out-dir)/$(binary).elf
 	@echo '  OBJDUMP $@'
-	$(q)$(OBJDUMP) -l -x -d $< > $@
+	$(q)$(OBJDUMP$(sm)) -l -x -d $< > $@
 
 $(link-out-dir)/$(binary).bin: $(link-out-dir)/$(binary).elf
 	@echo '  OBJCOPY $@'
-	$(q)$(OBJCOPY) -O binary $< $@
+	$(q)$(OBJCOPY$(sm)) -O binary $< $@
 	$(q)$(FIX_TA_BINARY) $< $@


### PR DESCRIPTION
Hi,
Using a simple "hello world" Trusted Application I needed to make the attached changes to the TA build files in order for the tool chain references to work properly. I'm using the following build command for trusted applications...
$ CROSS_COMPILE_ta=arm-none-eabi- TA_DEV_KIT_DIR=$HOME/devel/optee_os/out/arm32
-plat-stm/export-user_ta make clean
...in a MinGW32(MSYS) build environment on Windows. The central problem seems to be that things like $(LD) are defined as "false" and instead should be $(LD$(sm)) to match the optee_os mk setup?
Thanks,
Paul.

Edit: Added the missing tag lines for CheckPatch.

Signed-off-by: Paul Swan paswan@microsoft.com
Tested-by: Paul Swan paswan@microsoft.com (ST build only)