### PR TITLE
arm32: dynamic user va range

### DIFF
--- a/core/arch/arm32/include/mm/core_mmu.h
+++ b/core/arch/arm32/include/mm/core_mmu.h
@@ -59,9 +59,6 @@
 #define CORE_MMU_USER_PARAM_SIZE	(1 << CORE_MMU_USER_PARAM_SHIFT)
 #define CORE_MMU_USER_PARAM_MASK	(CORE_MMU_USER_PARAM_SIZE - 1)
 
-/* The maximum VA for user space */
-#define CORE_MMU_USER_MAX_ADDR	(32 * 1024 * 1024)
-
 /*
  * @type:  enumerate: specifiy the purpose of the memory area.
  * @pa:    memory area physical start address
@@ -119,15 +116,15 @@ void core_init_mmu_regs(void);
 #ifdef CFG_WITH_LPAE
 /*
  * struct core_mmu_user_map - current user mapping register state
- * @ttbr0:	content of ttbr0
- * @enabled:	true if usage of ttbr0 is enabled
+ * @user_map:	physical address of user map translation table
+ * @asid:	ASID for the user map
  *
  * Note that this struct should be treated as an opaque struct since
  * the content depends on descriptor table format.
  */
 struct core_mmu_user_map {
-	uint64_t ttbr0;
-	bool enabled;
+	uint64_t user_map;
+	uint32_t asid;
 };
 #else
 /*
@@ -143,6 +140,13 @@ struct core_mmu_user_map {
 	uint32_t ctxid;
 };
 #endif
+
+/*
+ * core_mmu_get_user_va_range() - Return range of user va space
+ * @base:	Lowest user virtual address
+ * @size:	Size in bytes of user address space
+ */
+void core_mmu_get_user_va_range(vaddr_t *base, size_t *size);
 
 /*
  * enum core_mmu_fault - different kinds of faults

--- a/core/arch/arm32/include/mm/tee_mm_def.h
+++ b/core/arch/arm32/include/mm/tee_mm_def.h
@@ -32,10 +32,6 @@
 #define SMALL_PAGE_MASK		0x00000fff
 #define SMALL_PAGE_SIZE		0x00001000
 
-/* define section to load */
-#define TEE_DDR_VLOFFSET    0x1
-
-
 /*
  * Register addresses related to time
  * RTT = Real-Time Timer

--- a/core/arch/arm32/kernel/tee_ta_manager.c
+++ b/core/arch/arm32/kernel/tee_ta_manager.c
@@ -312,6 +312,7 @@ static void tee_ta_init_heap(struct tee_ta_ctx *const ctx, size_t heap_size)
 {
 	uint32_t *data;
 	tee_uaddr_t heap_start_addr;
+	vaddr_t va_start;
 
 	/*
 	 * User TA
@@ -319,9 +320,9 @@ static void tee_ta_init_heap(struct tee_ta_ctx *const ctx, size_t heap_size)
 	 * Heap base follows right after GOT
 	 */
 
+	core_mmu_get_user_va_range(&va_start, NULL);
 	/* XXX this function shouldn't know this mapping */
-	heap_start_addr = ((TEE_DDR_VLOFFSET + 1) << CORE_MMU_USER_CODE_SHIFT) -
-			  heap_size;
+	heap_start_addr = va_start + CORE_MMU_USER_CODE_SIZE - heap_size;
 
 	data = (uint32_t *)(tee_ta_get_exec(ctx) + ctx->head->ro_size +
 			     (ctx->head->rel_dyn_got_size & TA_HEAD_GOT_MASK));

--- a/core/arch/arm32/mm/core_mmu_v7.c
+++ b/core/arch/arm32/mm/core_mmu_v7.c
@@ -363,6 +363,10 @@ static paddr_t populate_user_map(struct tee_mmu_info *mmu)
 	struct core_mmu_table_info tbl_info;
 	unsigned n;
 	struct tee_mmap_region region;
+	vaddr_t va_range_base;
+	size_t va_range_size;
+
+	core_mmu_get_user_va_range(&va_range_base, &va_range_size);
 
 	tbl_info.table = (void *)core_mmu_get_ul1_ttb_va();
 	tbl_info.va_base = 0;
@@ -371,7 +375,7 @@ static paddr_t populate_user_map(struct tee_mmu_info *mmu)
 	tbl_info.num_entries = TEE_MMU_UL1_NUM_ENTRIES;
 
 	region.pa = 0;
-	region.va = 0;
+	region.va = va_range_base;
 	region.attr = 0;
 
 	for (n = 0; n < mmu->size; n++) {
@@ -384,9 +388,9 @@ static paddr_t populate_user_map(struct tee_mmu_info *mmu)
 
 		set_region(&tbl_info, mmu->table + n);
 		region.va = mmu->table[n].va + mmu->table[n].size;
-		assert(region.va <= CORE_MMU_USER_MAX_ADDR);
+		assert((region.va - va_range_base) <= va_range_size);
 	}
-	region.size = CORE_MMU_USER_MAX_ADDR - region.va;
+	region.size = va_range_size - (region.va - va_range_base);
 	set_region(&tbl_info, &region);
 
 	return core_mmu_get_ul1_ttb_pa() | TEE_MMU_DEFAULT_ATTRS;
@@ -487,6 +491,19 @@ void core_mmu_get_entry(struct core_mmu_table_info *tbl_info, unsigned idx,
 	if (attr)
 		*attr = desc_to_mattr(tbl_info->level, table[idx]);
 }
+
+void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
+{
+	if (base) {
+		/* Leaving the first entry unmapped to make NULL unmapped */
+		*base = 1 << SECTION_SHIFT;
+	}
+
+	if (size)
+		*size = (TEE_MMU_UL1_NUM_ENTRIES - 1) << SECTION_SHIFT;
+}
+
+
 
 void core_mmu_get_user_map(struct core_mmu_user_map *map)
 {

--- a/core/arch/arm32/mm/tee_mmu.c
+++ b/core/arch/arm32/mm/tee_mmu.c
@@ -190,10 +190,13 @@ static TEE_Result tee_mmu_umap_set_vas(struct tee_mmu_info *mmu)
 {
 	size_t n;
 	vaddr_t va;
+	vaddr_t va_range_base;
+	size_t va_range_size;
 
 	assert(mmu->table && mmu->size == TEE_MMU_UMAP_MAX_ENTRIES);
 
-	va = CORE_MMU_USER_CODE_SIZE;
+	core_mmu_get_user_va_range(&va_range_base, &va_range_size);
+	va = va_range_base;
 	for (n = 0; n < TEE_MMU_UMAP_PARAM_IDX; n++) {
 		assert(mmu->table[n].size); /* PA must be assigned by now */
 		mmu->table[n].va = va;
@@ -208,7 +211,7 @@ static TEE_Result tee_mmu_umap_set_vas(struct tee_mmu_info *mmu)
 		va += mmu->table[n].size;
 		/* Put some empty space between each area */
 		va += CORE_MMU_USER_PARAM_SIZE;
-		if (va >= CORE_MMU_USER_MAX_ADDR)
+		if ((va - va_range_base) >= va_range_size)
 			return TEE_ERROR_EXCESS_DATA;
 	}
 


### PR DESCRIPTION
core_mmu_get_user_va_range() selects user va range. No change in user TA
va address when configured with V7 MMU tables.

When configured with LPAE only use TTBR0. The top L0 table is CPU
specific with all entries common except one which is used when mapping
user TAs. User TA va range is dependent on the first unused L0 entry.

This is needed in Aarch64 since we can't use TTBR0 and TTBR1 in the same way as before.