### PR TITLE
Remove __noreturn from TEE_Panic prototype

### DIFF
--- a/lib/libutee/abort.c
+++ b/lib/libutee/abort.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <tee_api.h>
+#include <utee_syscalls.h>
 
 /*
  * Not used directly from any source file, but required by some compiler
@@ -37,5 +38,5 @@ void abort(void);
 void abort(void)
 {
 	printf("Abort!\n");
-	TEE_Panic(0);
+	utee_panic(0);
 }

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
+#include <utee_syscalls.h>
 
 void _assert_log(const char *expr, const char *file, int line)
 {
@@ -35,5 +36,5 @@ void _assert_log(const char *expr, const char *file, int line)
 
 void _assert_break(void)
 {
-	TEE_Panic(TEE_ERROR_GENERIC);
+	utee_panic(TEE_ERROR_GENERIC);
 }

--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -72,7 +72,7 @@ TEE_Result TEE_GetNextProperty(TEE_PropSetHandle enumerator);
 
 /* System API - Misc */
 
-void TEE_Panic(TEE_Result panicCode) __noreturn;
+void TEE_Panic(TEE_Result panicCode);
 
 /* System API - Internal Client API */
 

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -36,7 +36,7 @@ static void *tee_api_instance_data;
 
 /* System API - Misc */
 
-void TEE_Panic(TEE_Result panicCode)
+void __noreturn TEE_Panic(TEE_Result panicCode)
 {
 	utee_panic(panicCode);
 }


### PR DESCRIPTION
According to the Global Plaform Internal Core API v1.1, the prototype
of the function TEE_Panic must be
    void TEE_Panic(TEE_Result panicCode);

Signed-off-by: Pascal Brand <pascal.brand@st.com>