### PR TITLE
Remove __noreturn from TEE_Panic prototype

### DIFF
--- a/lib/libutee/abort.c
+++ b/lib/libutee/abort.c
@@ -27,15 +27,17 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <tee_api.h>
+#include <compiler.h>
+#include <utee_syscalls.h>
 
 /*
  * Not used directly from any source file, but required by some compiler
  * library with some compiler options.
  */
-void abort(void);
+void abort(void) __noreturn;
 
 void abort(void)
 {
 	printf("Abort!\n");
-	TEE_Panic(0);
+	utee_panic(0);
 }

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -25,15 +25,18 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <assert.h>
+#include <compiler.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
+#include <utee_syscalls.h>
 
-void _assert_log(const char *expr, const char *file, int line)
+void _assert_log(const char *expr __unused, const char *file __unused,
+		 int line __unused)
 {
 	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
 }
 
-void _assert_break(void)
+void __noreturn _assert_break(void)
 {
-	TEE_Panic(TEE_ERROR_GENERIC);
+	utee_panic(TEE_ERROR_GENERIC);
 }

--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -72,7 +72,7 @@ TEE_Result TEE_GetNextProperty(TEE_PropSetHandle enumerator);
 
 /* System API - Misc */
 
-void TEE_Panic(TEE_Result panicCode) __noreturn;
+void TEE_Panic(TEE_Result panicCode);
 
 /* System API - Internal Client API */
 

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -36,7 +36,7 @@ static void *tee_api_instance_data;
 
 /* System API - Misc */
 
-void TEE_Panic(TEE_Result panicCode)
+void __noreturn TEE_Panic(TEE_Result panicCode)
 {
 	utee_panic(panicCode);
 }


### PR DESCRIPTION
According to the Global Plaform Internal Core API v1.1, the prototype
of the function TEE_Panic must be
    void TEE_Panic(TEE_Result panicCode);

Signed-off-by: Pascal Brand <pascal.brand@st.com>