### PR TITLE
Travis arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,14 @@ notifications:
 
 # Install the cross compiler
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y gcc-arm-linux-gnueabihf
+  - wget http://releases.linaro.org/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-x86_64_arm-linux-gnueabihf.tar.xz
+  - tar xf gcc-linaro-4.9-2015.02-x86_64_arm-linux-gnueabihf.tar.xz
+  - export PATH=${PWD}/gcc-linaro-4.9-2015.02-x86_64_arm-linux-gnueabihf/bin:${PATH}
   - arm-linux-gnueabihf-gcc --version
+  - wget http://releases.linaro.org/15.02/components/toolchain/binaries/aarch64-linux-gnu/gcc-linaro-4.9-2015.02-x86_64_aarch64-linux-gnu.tar.xz
+  - tar xf gcc-linaro-4.9-2015.02-x86_64_aarch64-linux-gnu.tar.xz
+  - export PATH=${PWD}/gcc-linaro-4.9-2015.02-x86_64_aarch64-linux-gnu/bin:${PATH}
+  - aarch64-linux-gnu-gcc --version
 
 before_script:
   # Store the home repository
@@ -27,41 +32,52 @@ script:
   - git format-patch -1 --stdout | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -
 
   # Orly2
-  -                                  PLATFORM=stm-orly2                                  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
+  -                                  PLATFORM=stm-orly2                                  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=orly2   CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all -s
 
   # Cannes
-  -                                  PLATFORM=stm-cannes                                 CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all
+  -                                  PLATFORM=stm-cannes                                 CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=stm                PLATFORM_FLAVOR=cannes  CROSS_COMPILE=arm-linux-gnueabihf-  make -j8 all -s
 
   # FVP
-  -                                  PLATFORM=vexpress-fvp                                                                 make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=fvp                                       make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress           PLATFORM_FLAVOR=fvp                                       make -j8 all
+  -                                  PLATFORM=vexpress-fvp       CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-fvp       CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-fvp       CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
+  -                                  PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+
+  # Juno
+  -                                  PLATFORM=vexpress-juno      CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-juno      CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-juno      CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
+  -                                  PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
 
   # QEMU
-  -                                  PLATFORM=vexpress-qemu                                                                make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all
+  -                                  PLATFORM=vexpress-qemu                                                                make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu                                      make -j8 all -s
 
   # QEMU-virt
-  -                                  PLATFORM=vexpress-qemu_virt                                                           make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu_virt                                 make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu_virt CFG_TEE_CORE_DEBUG=1            make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu_virt                                 make -j8 all
-  - make -j8 all PLATFORM=vexpress-qemu_virt CFG_CRYPTO=n
-  - make -j8 all PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{AES,DES}=n
-  - make -j8 all PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{DSA,RSA,DH}=n
-  - make -j8 all PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{H,C,CBC_}MAC=n
-  - make -j8 all PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{G,C}CM=n
-  - make -j8 all PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{MD5,SHA{1,224,256,384,512}}=n
-  - make -j8 all PLATFORM=vexpress-qemu_virt CFG_WITH_PAGER=y
+  -                                  PLATFORM=vexpress-qemu_virt                                                           make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu_virt                                 make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu_virt CFG_TEE_CORE_DEBUG=1            make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress           PLATFORM_FLAVOR=qemu_virt                                 make -j8 all -s
+  - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_CRYPTO=n
+  - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{AES,DES}=n
+  - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{DSA,RSA,DH}=n
+  - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{H,C,CBC_}MAC=n
+  - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{G,C}CM=n
+  - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{MD5,SHA{1,224,256,384,512}}=n
+  - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_WITH_PAGER=y
 
   # SUNXI(Allwinner A80)
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=sunxi make -j8 all
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=sunxi make -j8 all
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=sunxi make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=sunxi make -j8 all -s
 
   # HiKey board (HiSilicon Kirin 620)
-  - make -j8 PLATFORM=hikey
+  - make -j8 -s PLATFORM=hikey

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,23 @@ endif
 ifneq ($V,1)
 q := @
 cmd-echo := true
+cmd-echo-silent := echo
 else
 q :=
 cmd-echo := echo
+cmd-echo-silent := true
 endif
+
+ifneq ($(filter 4.%,$(MAKE_VERSION)),)  # make-4
+ifneq ($(filter %s ,$(firstword x$(MAKEFLAGS))),)
+cmd-echo-silent := true
+endif
+else                                    # make-3.8x
+ifneq ($(filter s% -s%,$(MAKEFLAGS)),)
+cmd-echo-silent := true
+endif
+endif
+
 
 include core/core.mk
 
@@ -45,7 +58,7 @@ include ta/ta.mk
 
 .PHONY: clean
 clean:
-	@echo '  CLEAN   .'
+	@$(cmd-echo-silent) '  CLEAN   .'
 	${q}rm -f $(cleanfiles)
 
 .PHONY: cscope

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -38,17 +38,17 @@ ldargs-unpaged := -i --gc-sections \
 	$(objs-unpaged) $(link-ldadd) $(libgcccore)
 cleanfiles += $(link-out-dir)/unpaged.o
 $(link-out-dir)/unpaged.o: $(objs-unpaged) $(libdeps) $(MAKEFILE_LIST)
-	@echo '  LD      $@'
+	@$(cmd-echo-silent) '  LD      $@'
 	$(q)$(LDcore) $(ldargs-unpaged) -o $@
 
 cleanfiles += $(link-out-dir)/text_unpaged.ld.S:
 $(link-out-dir)/text_unpaged.ld.S: $(link-out-dir)/unpaged.o
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | ${AWK} -f ./scripts/gen_ld_text_sects.awk > $@
 
 cleanfiles += $(link-out-dir)/rodata_unpaged.ld.S:
 $(link-out-dir)/rodata_unpaged.ld.S: $(link-out-dir)/unpaged.o
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | \
 		${AWK} -f ./scripts/gen_ld_rodata_sects.awk > $@
 
@@ -64,17 +64,17 @@ ldargs-init := -i --gc-sections \
 	$(objs-init) $(link-ldadd) $(libgcccore)
 cleanfiles += $(link-out-dir)/init.o
 $(link-out-dir)/init.o: $(objs-init) $(libdeps) $(MAKEFILE_LIST)
-	@echo '  LD      $@'
+	@$(cmd-echo-silent) '  LD      $@'
 	$(q)$(LDcore) $(ldargs-init) -o $@
 
 cleanfiles += $(link-out-dir)/text_init.ld.S:
 $(link-out-dir)/text_init.ld.S: $(link-out-dir)/init.o
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | ${AWK} -f ./scripts/gen_ld_text_sects.awk > $@
 
 cleanfiles += $(link-out-dir)/rodata_init.ld.S:
 $(link-out-dir)/rodata_init.ld.S: $(link-out-dir)/init.o
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | \
 		${AWK} -f ./scripts/gen_ld_rodata_sects.awk > $@
 
@@ -87,7 +87,7 @@ link-script-extra-deps += $(link-out-dir)/rodata_init.ld.S
 link-script-extra-deps += $(conf-file)
 cleanfiles += $(link-script-pp) $(link-script-dep)
 $(link-script-pp): $(link-script) $(link-script-extra-deps)
-	@echo '  CPP     $@'
+	@$(cmd-echo-silent) '  CPP     $@'
 	@mkdir -p $(dir $@)
 	$(q)$(CPPcore) -Wp,-P,-MT,$@,-MD,$(link-script-dep) \
 		$(link-script-cppflags) $< > $@
@@ -95,20 +95,20 @@ $(link-script-pp): $(link-script) $(link-script-extra-deps)
 all: $(link-out-dir)/tee.elf
 cleanfiles += $(link-out-dir)/tee.elf $(link-out-dir)/tee.map
 $(link-out-dir)/tee.elf: $(objs) $(libdeps) $(link-script-pp)
-	@echo '  LD      $@'
+	@$(cmd-echo-silent) '  LD      $@'
 	$(q)$(LDcore) $(ldargs-tee.elf) -o $@
 
 all: $(link-out-dir)/tee.dmp
 cleanfiles += $(link-out-dir)/tee.dmp
 $(link-out-dir)/tee.dmp: $(link-out-dir)/tee.elf
-	@echo '  OBJDUMP $@'
+	@$(cmd-echo-silent) '  OBJDUMP $@'
 	$(q)$(OBJDUMPcore) -l -x -d $< > $@
 
 pageable_sections := .*_pageable
 init_sections := .*_init
 cleanfiles += $(link-out-dir)/tee-pager.bin
 $(link-out-dir)/tee-pager.bin: $(link-out-dir)/tee.elf
-	@echo '  OBJCOPY $@'
+	@$(cmd-echo-silent) '  OBJCOPY $@'
 	$(q)$(OBJCOPYcore) -O binary \
 		--remove-section="$(pageable_sections)" \
 		--remove-section="$(init_sections)" \
@@ -116,7 +116,7 @@ $(link-out-dir)/tee-pager.bin: $(link-out-dir)/tee.elf
 
 cleanfiles += $(link-out-dir)/tee-pageable.bin
 $(link-out-dir)/tee-pageable.bin: $(link-out-dir)/tee.elf
-	@echo '  OBJCOPY $@'
+	@$(cmd-echo-silent) '  OBJCOPY $@'
 	$(q)$(OBJCOPYcore) -O binary \
 		--only-section="$(init_sections)" \
 		--only-section="$(pageable_sections)" \
@@ -124,19 +124,19 @@ $(link-out-dir)/tee-pageable.bin: $(link-out-dir)/tee.elf
 
 cleanfiles += $(link-out-dir)/tee-init_size.txt
 $(link-out-dir)/tee-init_size.txt: $(link-out-dir)/tee.elf
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	@echo -n 0x > $@
 	$(q)$(NMcore) $< | grep __init_size | sed 's/ .*$$//' >> $@
 
 cleanfiles += $(link-out-dir)/tee-init_load_addr.txt
 $(link-out-dir)/tee-init_load_addr.txt: $(link-out-dir)/tee.elf
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	@echo -n 0x > $@
 	$(q)$(NMcore) $< | grep ' _start' | sed 's/ .*$$//' >> $@
 
 cleanfiles += $(link-out-dir)/tee-init_mem_usage.txt
 $(link-out-dir)/tee-init_mem_usage.txt: $(link-out-dir)/tee.elf
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	@echo -n 0x > $@
 	$(q)$(NMcore) $< | grep ' __init_mem_usage' | sed 's/ .*$$//' >> $@
 
@@ -148,7 +148,7 @@ $(link-out-dir)/tee.bin: $(link-out-dir)/tee-pager.bin \
 			 $(link-out-dir)/tee-init_load_addr.txt \
 			 $(link-out-dir)/tee-init_mem_usage.txt \
 			./scripts/gen_hashed_bin.py
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)./scripts/gen_hashed_bin.py \
 		--arch $(core-tee-bin-arch) \
 		--init_size `cat $(link-out-dir)/tee-init_size.txt` \
@@ -163,7 +163,7 @@ $(link-out-dir)/tee.bin: $(link-out-dir)/tee-pager.bin \
 all: $(link-out-dir)/tee.symb_sizes
 cleanfiles += $(link-out-dir)/tee.symb_sizes
 $(link-out-dir)/tee.symb_sizes: $(link-out-dir)/tee.elf
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(NMcore) --print-size --reverse-sort --size-sort $< > $@
 
 cleanfiles += $(link-out-dir)/tee.mem_usage
@@ -171,6 +171,6 @@ ifneq ($(filter mem_usage,$(MAKECMDGOALS)),)
 mem_usage: $(link-out-dir)/tee.mem_usage
 
 $(link-out-dir)/tee.mem_usage: $(link-out-dir)/tee.elf
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | ${AWK} -f ./scripts/mem_usage.awk > $@
 endif

--- a/core/arch/arm/plat-stm/link.mk
+++ b/core/arch/arm/plat-stm/link.mk
@@ -20,23 +20,23 @@ ldargs-tee.elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcccore)
 
 
 $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
-	@echo '  SED     $@'
+	@$(cmd-echo-silent) '  SED     $@'
 	@mkdir -p $(dir $@)
 	$(q)sed -e "s/%in_TEE_SCATTER_START%/$(TEE_SCATTER_START)/g" < $< > $@
 
 
 $(link-out-dir)/tee.elf: $(objs) $(libdeps) $(link-script-pp)
-	@echo '  LD      $@'
+	@$(cmd-echo-silent) '  LD      $@'
 	$(q)$(LDcore) $(ldargs-tee.elf) -o $@
 
 $(link-out-dir)/tee.dmp: $(link-out-dir)/tee.elf
-	@echo '  OBJDUMP $@'
+	@$(cmd-echo-silent) '  OBJDUMP $@'
 	$(q)$(OBJDUMPcore) -l -x -d $< > $@
 
 $(link-out-dir)/tee.bin: $(link-out-dir)/tee.elf
-	@echo '  OBJCOPY $@'
+	@$(cmd-echo-silent) '  OBJCOPY $@'
 	$(q)$(OBJCOPYcore) -O binary $< $@
 
 $(link-out-dir)/tee.symb_sizes: $(link-out-dir)/tee.elf
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(NMcore) --print-size --reverse-sort --size-sort $< > $@

--- a/core/arch/arm/plat-sunxi/link.mk
+++ b/core/arch/arm/plat-sunxi/link.mk
@@ -31,24 +31,24 @@ link-script-cppflags :=  \
 -include $(link-script-dep)
 
 $(link-script-pp): $(link-script) $(conf-file)
-	@echo '  CPP     $@'
+	@$(cmd-echo-silent) '  CPP     $@'
 	@mkdir -p $(dir $@)
 	$(q)$(CPPcore) -Wp,-P,-MT,$@,-MD,$(link-script-dep) \
 		$(link-script-cppflags) $< > $@
 
 
 $(link-out-dir)/tee.elf: $(objs) $(libdeps) $(link-script-pp)
-	@echo '  LD      $@'
+	@$(cmd-echo-silent) '  LD      $@'
 	$(q)$(LDcore) $(ldargs-tee.elf) -o $@
 
 $(link-out-dir)/tee.dmp: $(link-out-dir)/tee.elf
-	@echo '  OBJDUMP $@'
+	@$(cmd-echo-silent) '  OBJDUMP $@'
 	$(q)$(OBJDUMPcore) -l -x -d $< > $@
 
 $(link-out-dir)/tee.bin: $(link-out-dir)/tee.elf
-	@echo '  OBJCOPY $@'
+	@$(cmd-echo-silent) '  OBJCOPY $@'
 	$(q)$(OBJCOPYcore) -O binary $< $@
 
 $(link-out-dir)/tee.symb_sizes: $(link-out-dir)/tee.elf
-	@echo '  GEN     $@'
+	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(NMcore) --print-size --reverse-sort --size-sort $< > $@

--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -13,7 +13,7 @@
 #	$(call check-conf-h,CFG_CRYPTO_ CRYPTO_)
 define check-conf-h
 	$(q)set -e;						\
-	echo '  CHK     $@';					\
+	$(cmd-echo-silent) '  CHK     $@';			\
 	cnf="$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,$1),			\
 		$(call cfg-make-define,$(var))))";		\
@@ -28,7 +28,7 @@ endef
 
 define check-conf-mk
 	$(q)set -e;						\
-	echo '  CHK     $@';					\
+	$(cmd-echo-silent) '  CHK     $@';			\
 	cnf="$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,CFG_),		\
 		$(call cfg-make-variable,$(var))))";		\
@@ -47,7 +47,7 @@ define mv-if-changed
 	if [ -r $2 ] && cmp -s $2 $1; then			\
 		rm -f $1;					\
 	else							\
-		echo '  UPD     $2';				\
+		$(cmd-echo-silent) '  UPD     $2';		\
 		mv $1 $2;					\
 	fi
 endef

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -107,7 +107,7 @@ $2: $1 FORCE
 	    $$(filter-out $$(old-cmd-$2), $$(comp-cmd-$2))), \
 		@set -e ;\
 		mkdir -p $$(dir $2) ;\
-		echo '  $$(comp-q-$2)      $$@' ;\
+		$(cmd-echo-silent) '  $$(comp-q-$2)      $$@' ;\
 		$(cmd-echo) $$(subst \",\\\",$$(comp-cmd-$2)) ;\
 		$$(comp-cmd-$2) ;\
 		$(cmd-echo) $$(comp-objcpy-cmd-$2) ;\

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -30,7 +30,7 @@ $(lib-libfile): $(objs)
 	$$(q)$$(LD$(sm)) $(lib-ldflags) -o $$@ $$^
 else
 $(lib-libfile): $(objs)
-	@echo '  AR      $$@'
+	@$(cmd-echo-silent) '  AR      $$@'
 	@mkdir -p $$(dir $$@)
 	$$(q)$$(AR$(sm)) rcs $$@ $$^
 endif

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -22,10 +22,23 @@ endif
 ifneq ($V,1)
 q := @
 cmd-echo := true
+cmd-echo-silent := echo
 else
 q :=
 cmd-echo := echo
+cmd-echo-silent := true
 endif
+
+ifneq ($(filter 4.%,$(MAKE_VERSION)),)  # make-4
+ifneq ($(filter %s ,$(firstword x$(MAKEFLAGS))),)
+cmd-echo-silent := true
+endif
+else                                    # make-3.8x
+ifneq ($(filter s% -s%,$(MAKEFLAGS)),)
+cmd-echo-silent := true
+endif
+endif
+
 
 include $(ta-dev-kit-dir)/mk/arch.mk
 -include $(ta-dev-kit-dir)/mk/platform_flags.mk
@@ -52,7 +65,7 @@ libdeps += $(ta-dev-kit-dir)/lib/libutee.a
 
 .PHONY: clean
 clean:
-	@echo '  CLEAN   .'
+	@$(cmd-echo-silent) '  CLEAN   .'
 	${q}rm -f $(cleanfiles)
 
 

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -48,7 +48,7 @@ define copy-file
 $2/$$(notdir $1): $1
 	@set -e; \
 	mkdir -p $$(dir $$@) ; \
-	echo '  INSTALL $$@' ; \
+	$(cmd-echo-silent) '  INSTALL $$@' ; \
 	cp $$< $$@
 
 cleanfiles += $2/$$(notdir $1)
@@ -73,7 +73,7 @@ arch-arch-mk := $(out-dir)/export-user_ta/mk/arch.mk
 $(arch-arch-mk): ta/arch/$(ARCH)/$(ARCH).mk
 	@set -e; \
 	mkdir -p $(dir $@) ; \
-	echo '  INSTALL $@' ; \
+	$(cmd-echo-silent) '  INSTALL $@' ; \
 	cp $< $@
 
 cleanfiles += $(arch-arch-mk)


### PR DESCRIPTION
build system: support for building with V=-1 to be really quiet
travis: adds builds for Juno and FVP ARM64
travis: build using V=-1

I've changed the arm32 compiler to use the same release as the arm64 compiler. This was needed due to a build error for Juno that came from a bug in the old arm32 toolchain.