### PR TITLE
Add support for the HiKey board (make PLATFORM=hikey)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,3 +62,6 @@ script:
   # SUNXI(Allwinner A80)
   - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=sunxi make -j8 all
   - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=sunxi make -j8 all
+
+  # HiKey board (HiSilicon Kirin 620)
+  - make -j8 PLATFORM=hikey

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ please read the file [build_system.md](documentation/build_system.md).
 | [STMicroelectronics b2120 - h310 / h410](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-cannes`|
 | [STMicroelectronics b2020-h416](http://www.st.com/web/catalog/mmc/FM131/SC999/SS1633/PF253155?sc=internet/imag_video/product/253155.jsp)|`PLATFORM=stm-orly2`|
 | [Allwinner A80 Board](http://www.allwinnertech.com/en/clq/processora/A80.html)|`PLATFORM=sunxi`|
+| [HiKey Board (HiSilicon Kirin 620)](https://www.96boards.org/products/hikey/)|`PLATFORM=hikey`|
 
 ## 4. Get and build the software
 There are a couple of different build options depending on the target you are

--- a/core/arch/arm/kernel/generic_core_bootcfg.c
+++ b/core/arch/arm/kernel/generic_core_bootcfg.c
@@ -146,11 +146,13 @@ static struct map_area bootcfg_memory_map[] = {
 	 .pa = DEVICE0_BASE, .size = DEVICE0_SIZE,
 	 .device = true, .secure = true, .rw = true,
 	 },
+#ifdef DEVICE1_BASE
 	{
 	 .type = MEM_AREA_IO_SEC,
 	 .pa = DEVICE1_BASE, .size = DEVICE1_SIZE,
 	 .device = true, .secure = true, .rw = true,
 	 },
+#endif
 #ifdef DEVICE2_BASE
 	{
 	 .type = MEM_AREA_IO_SEC,

--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -1,0 +1,40 @@
+include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
+
+CROSS_COMPILE	?= arm-linux-gnueabihf-
+COMPILER	?= gcc
+
+CFG_ARM32_core ?= y
+
+core-tee-bin-arch := 0
+
+core-platform-cppflags += $(arm32-platform-cppflags)
+core-platform-cflags += $(arm32-platform-cflags)
+core-platform-aflags += $(arm32-platform-aflags)
+
+core-platform-cppflags	+= -I$(arch-dir)/include
+
+core-platform-subdirs += \
+	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
+
+libutil_with_isoc := y
+libtomcrypt_with_optimize_size := y
+
+CFG_WITH_ARM_TRUSTED_FW := y
+CFG_SECURE_TIME_SOURCE_CNTPCT ?= y
+CFG_PL011 ?= y
+CFG_HWSUPP_MEM_PERM_PXN ?= y
+CFG_WITH_STACK_CANARIES ?= y
+CFG_NO_TA_HASH_SIGN ?= y
+CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= n
+CFG_MMU_V7_TTB ?= y
+CFG_GENERIC_BOOT ?= y
+CFG_PM_STUBS ?= y
+
+ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
+CFG_WITH_VFP := y
+endif
+ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
+CFG_WITH_VFP := y
+endif
+
+include mk/config.mk

--- a/core/arch/arm/plat-hikey/kern.ld.S
+++ b/core/arch/arm/plat-hikey/kern.ld.S
@@ -1,0 +1,1 @@
+#include "../kernel/kern.ld.S"

--- a/core/arch/arm/plat-hikey/link.mk
+++ b/core/arch/arm/plat-hikey/link.mk
@@ -1,0 +1,1 @@
+include core/arch/arm/kernel/link.mk

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <console.h>
+#include <drivers/pl011.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/tee_pager.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/arch_svc.h>
+#include <tee/entry.h>
+
+static void main_fiq(void);
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry,
+	.fast_smc = tee_entry,
+	.fiq = main_fiq,
+	.svc = tee_svc_handler,
+	.abort = tee_pager_abort_handler,
+	.cpu_on = cpu_on_handler,
+	.cpu_off = pm_do_nothing,
+	.cpu_suspend = pm_do_nothing,
+	.cpu_resume = pm_do_nothing,
+	.system_off = pm_do_nothing,
+	.system_reset = pm_do_nothing,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+static void main_fiq(void)
+{
+	panic();
+}
+
+void console_putc(int ch)
+{
+	pl011_putc(ch, CONSOLE_UART_BASE);
+	if (ch == '\n')
+		pl011_putc('\r', CONSOLE_UART_BASE);
+}
+
+void console_flush(void)
+{
+	pl011_flush(CONSOLE_UART_BASE);
+}

--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#ifdef ARM32
+#define PLATFORM_LINKER_FORMAT	"elf32-littlearm"
+#define PLATFORM_LINKER_ARCH	arm
+#else
+#error "Only ARM32 is supported"
+#endif
+
+/* PL011 UART */
+#define CONSOLE_UART_BASE	0xF8015000
+#define CONSOLE_BAUDRATE	115200
+#define CONSOLE_UART_CLK_IN_HZ	19200000
+
+#define HEAP_SIZE		(24 * 1024)
+
+/*
+ * HiKey memory map
+ *
+ * We use only non-secure DRAM (TZDRAM and TZSRAM are emulated).
+ *
+ * CFG_WITH_PAGER=n
+ *
+ *  0x4000_0000                               -
+ *    TA RAM: 15 MiB                          |
+ *  0x3F10_0000                               | TZDRAM
+ *    TEE RAM: 1 MiB (CFG_TEE_RAM_VA_SIZE)    |
+ *  0x3F00_0000 [TZDRAM_BASE, BL32_LOAD_ADDR] -
+ *    Shared memory: 1 MiB                    |
+ *  0x3EF0_0000                               | DRAM0
+ *    Available to Linux                      |
+ *  0x0000_0000 [DRAM0_BASE]                  -
+ *
+ * CFG_WITH_PAGER=y
+ *
+ *  0x4000_0000                               -
+ *    TA RAM: 15 MiB                          | TZDRAM
+ *  0x3F10_0000                               -
+ *    Unused
+ *  0x3F03_2000                               -
+ *    TEE RAM: 200 KiB                        | TZSRAM
+ *  0x3F00_0000 [TZSRAM_BASE, BL32_LOAD_ADDR] -
+ *    Shared memory: 1 MiB                    |
+ *  0x3EF0_0000                               | DRAM0
+ *    Available to Linux                      |
+ *  0x0000_0000 [DRAM0_BASE]                  -
+ */
+
+#define DRAM0_BASE		0x00000000
+#define DRAM0_SIZE		0x3F000000
+
+#ifdef CFG_WITH_PAGER
+
+#define TZSRAM_BASE		0x3F000000
+#define TZSRAM_SIZE		(200 * 1024)
+
+#define TZDRAM_BASE		0x3F100000
+#define TZDRAM_SIZE		(15 * 1024 * 1024)
+
+#else /* CFG_WITH_PAGER */
+
+#define TZDRAM_BASE		0x3F000000
+#define TZDRAM_SIZE		(16 * 1024 * 1024)
+
+#endif /* CFG_WITH_PAGER */
+
+#define CFG_SHMEM_START		0x3EF00000
+#define CFG_SHMEM_SIZE		(1024 * 1024)
+
+#define CFG_TEE_CORE_NB_CORE	8
+
+#define CFG_TEE_RAM_VA_SIZE	(1024 * 1024)
+
+#define CFG_TEE_LOAD_ADDR	0x3F000000
+
+#ifdef CFG_WITH_PAGER
+
+#define CFG_TEE_RAM_START	TZSRAM_BASE
+#define CFG_TEE_RAM_PH_SIZE	TZSRAM_SIZE
+#define CFG_TA_RAM_START	ROUNDUP(TZDRAM_BASE, CORE_MMU_DEVICE_SIZE)
+#define CFG_TA_RAM_SIZE		ROUNDDOWN(TZDRAM_SIZE, CORE_MMU_DEVICE_SIZE)
+
+#else /* CFG_WITH_PAGER */
+
+#define CFG_TEE_RAM_PH_SIZE	CFG_TEE_RAM_VA_SIZE
+#define CFG_TEE_RAM_START	TZDRAM_BASE
+#define CFG_TA_RAM_START	ROUNDUP((TZDRAM_BASE + CFG_TEE_RAM_VA_SIZE), \
+					CORE_MMU_DEVICE_SIZE)
+
+#define CFG_TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - CFG_TEE_RAM_VA_SIZE),\
+					  CORE_MMU_DEVICE_SIZE)
+
+#endif /* CFG_WITH_PAGER */
+
+#define DEVICE0_BASE		ROUNDDOWN(CONSOLE_UART_BASE, \
+					  CORE_MMU_DEVICE_SIZE)
+#define DEVICE0_SIZE		CORE_MMU_DEVICE_SIZE
+
+#endif /* PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-hikey/platform_flags.mk
+++ b/core/arch/arm/plat-hikey/platform_flags.mk
@@ -1,0 +1,26 @@
+arm32-platform-cpuarch	:= cortex-a15
+arm32-platform-cflags	+= -mcpu=$(arm32-platform-cpuarch) -mthumb
+arm32-platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
+arm32-platform-cflags	+= -fno-short-enums -mno-apcs-float -fno-common
+arm32-platform-cflags	+= -mfloat-abi=soft
+arm32-platform-cflags	+= -mno-unaligned-access
+arm32-platform-aflags	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags	+= -mfpu=neon
+
+platform-cflags += -ffunction-sections -fdata-sections
+
+DEBUG		?= 1
+ifeq ($(DEBUG),1)
+platform-cflags += -O0
+else
+platform-cflags += -Os
+endif
+
+platform-cflags += -g
+platform-aflags += -g
+
+CFG_ARM32_user_ta := y
+user_ta-platform-cflags += $(arm32-platform-cflags)
+user_ta-platform-cflags += -fpie
+user_ta-platform-cppflags += $(arm32-platform-cppflags)
+user_ta-platform-aflags += $(arm32-platform-aflags)

--- a/core/arch/arm/plat-hikey/sub.mk
+++ b/core/arch/arm/plat-hikey/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
This commit adds support for the HiKey board [1] in 32-bit mode.
Tested with and without CFG_WITH_PAGER=y. Note that everything
is loaded in DRAM which is non-secure by default.

[1] https://www.96boards.org/products/hikey/

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>