### PR TITLE
Mediatek mt8173 platform support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,3 +81,6 @@ script:
 
   # HiKey board (HiSilicon Kirin 620)
   - make -j8 -s PLATFORM=hikey
+
+  # Mediatek mt8173 EVB
+  - PLATFORM=mediatek  PLATFORM_FLAVOR=mt8173  CFG_ARM64_core=y  CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ please read the file [build_system.md](documentation/build_system.md).
 | [STMicroelectronics b2020-h416](http://www.st.com/web/catalog/mmc/FM131/SC999/SS1633/PF253155?sc=internet/imag_video/product/253155.jsp)|`PLATFORM=stm-orly2`|
 | [Allwinner A80 Board](http://www.allwinnertech.com/en/clq/processora/A80.html)|`PLATFORM=sunxi`|
 | [HiKey Board (HiSilicon Kirin 620)](https://www.96boards.org/products/hikey/)|`PLATFORM=hikey`|
+| MediaTek MT8173 EVB Board|`PLATFORM=mediatek-mt8173`|
 
 ## 4. Get and build the software
 There are a couple of different build options depending on the target you are

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -122,16 +122,8 @@ copy_init:
 	sub	r1, r1, #1
 	bl	arm_cl1_d_invbyva
 
-	/* Enable UART */
-	ldr	r0, =CONSOLE_UART_BASE
-	ldr	r1, =CONSOLE_UART_CLK_IN_HZ
-	ldr	r2, =CONSOLE_BAUDRATE
-#ifdef CFG_PL011
-	bl	pl011_init
-#endif
-#ifdef CFG_8250_UART
-	bl	serial8250_uart_init
-#endif
+	/* Enable Console */
+	bl	console_init
 
 	bl	core_init_mmu_map
 	bl	core_init_mmu_regs

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -126,7 +126,12 @@ copy_init:
 	ldr	r0, =CONSOLE_UART_BASE
 	ldr	r1, =CONSOLE_UART_CLK_IN_HZ
 	ldr	r2, =CONSOLE_BAUDRATE
+#ifdef CFG_PL011
 	bl	pl011_init
+#endif
+#ifdef CFG_8250_UART
+	bl	serial8250_uart_init
+#endif
 
 	bl	core_init_mmu_map
 	bl	core_init_mmu_regs

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -106,7 +106,12 @@ copy_init:
 	ldr	x0, =CONSOLE_UART_BASE
 	ldr	x1, =CONSOLE_UART_CLK_IN_HZ
 	ldr	x2, =CONSOLE_BAUDRATE
+#ifdef CFG_PL011
 	bl	pl011_init
+#endif
+#ifdef CFG_8250_UART
+	bl	serial8250_uart_init
+#endif
 
 	bl	core_init_mmu_map
 	bl	core_init_mmu_regs

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -102,16 +102,8 @@ copy_init:
 	sub	x1, x1, x0
 	bl	inv_dcache_range
 
-	/* Enable UART */
-	ldr	x0, =CONSOLE_UART_BASE
-	ldr	x1, =CONSOLE_UART_CLK_IN_HZ
-	ldr	x2, =CONSOLE_BAUDRATE
-#ifdef CFG_PL011
-	bl	pl011_init
-#endif
-#ifdef CFG_8250_UART
-	bl	serial8250_uart_init
-#endif
+	/* Enable Console */
+	bl	console_init
 
 	bl	core_init_mmu_map
 	bl	core_init_mmu_regs

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -62,6 +62,13 @@ static void main_fiq(void)
 	panic();
 }
 
+void console_init(void)
+{
+	pl011_init(CONSOLE_UART_BASE,
+		   CONSOLE_UART_CLK_IN_HZ,
+		   CONSOLE_BAUDRATE);
+}
+
 void console_putc(int ch)
 {
 	pl011_putc(ch, CONSOLE_UART_BASE);

--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -1,0 +1,38 @@
+include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
+
+CROSS_COMPILE	?= arm-linux-gnueabihf-
+COMPILER	?= gcc
+
+ifeq ($(CFG_ARM64_core),y)
+CFG_WITH_LPAE := y
+else
+CFG_ARM32_core ?= y
+CFG_MMU_V7_TTB ?= y
+endif
+
+core-platform-cppflags	+= -I$(arch-dir)/include
+
+core-platform-subdirs += \
+	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
+
+libutil_with_isoc := y
+libtomcrypt_with_optimize_size := y
+
+CFG_WITH_ARM_TRUSTED_FW := y
+CFG_SECURE_TIME_SOURCE_CNTPCT ?= y
+CFG_8250_UART ?= y
+CFG_HWSUPP_MEM_PERM_PXN ?= y
+CFG_WITH_STACK_CANARIES ?= y
+CFG_NO_TA_HASH_SIGN ?= y
+CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= n
+CFG_GENERIC_BOOT ?= y
+CFG_PM_STUBS ?= y
+
+ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
+CFG_WITH_VFP := y
+endif
+ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
+CFG_WITH_VFP := y
+endif
+
+include mk/config.mk

--- a/core/arch/arm/plat-mediatek/kern.ld.S
+++ b/core/arch/arm/plat-mediatek/kern.ld.S
@@ -1,0 +1,1 @@
+#include "../kernel/kern.ld.S"

--- a/core/arch/arm/plat-mediatek/link.mk
+++ b/core/arch/arm/plat-mediatek/link.mk
@@ -1,0 +1,1 @@
+include core/arch/arm/kernel/link.mk

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <console.h>
+#include <drivers/serial8250_uart.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/tee_pager.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/arch_svc.h>
+#include <tee/entry.h>
+
+static void main_fiq(void);
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry,
+	.fast_smc = tee_entry,
+	.fiq = main_fiq,
+	.svc = tee_svc_handler,
+	.abort = tee_pager_abort_handler,
+	.cpu_on = cpu_on_handler,
+	.cpu_off = pm_do_nothing,
+	.cpu_suspend = pm_do_nothing,
+	.cpu_resume = pm_do_nothing,
+	.system_off = pm_do_nothing,
+	.system_reset = pm_do_nothing,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+static void main_fiq(void)
+{
+	panic();
+}
+
+void console_putc(int ch)
+{
+	serial8250_uart_putc(ch, CONSOLE_UART_BASE);
+	if (ch == '\n')
+		serial8250_uart_putc('\r', CONSOLE_UART_BASE);
+}
+
+void console_flush(void)
+{
+	serial8250_uart_flush_tx_fifo(CONSOLE_UART_BASE);
+}

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -62,6 +62,13 @@ static void main_fiq(void)
 	panic();
 }
 
+void console_init(void)
+{
+	serial8250_uart_init(CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ,
+			     CONSOLE_BAUDRATE);
+}
+
 void console_putc(int ch)
 {
 	serial8250_uart_putc(ch, CONSOLE_UART_BASE);

--- a/core/arch/arm/plat-mediatek/mt8173_core_pos_a32.S
+++ b/core/arch/arm/plat-mediatek/mt8173_core_pos_a32.S
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <asm.S>
+#include <arm.h>
+#include <arm32_macros.S>
+
+FUNC get_core_pos , :
+	read_mpidr r0
+	and	r1, r0, #MPIDR_CPU_MASK
+	and	r0, r0, #MPIDR_CLUSTER_MASK
+	/*
+	 * Number of cores in cluster is 2,
+	 * we should have the following mapping:
+	 * MPIDR     core_pos
+	 * 0x0000 -> 0
+	 * 0x0001 -> 1
+	 * 0x0100 -> 2
+	 * 0x0101 -> 3
+	 */
+	add	r0, r1, r0, LSR #7
+	bx	lr
+END_FUNC get_core_pos
+

--- a/core/arch/arm/plat-mediatek/mt8173_core_pos_a64.S
+++ b/core/arch/arm/plat-mediatek/mt8173_core_pos_a64.S
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <asm.S>
+#include <arm.h>
+
+FUNC get_core_pos , :
+	mrs	x0, mpidr_el1
+	and	x1, x0, #MPIDR_CPU_MASK
+	and	x0, x0, #MPIDR_CLUSTER_MASK
+	/*
+	 * Number of cores in cluster is 2,
+	 * we should have the following mapping:
+	 * MPIDR     core_pos
+	 * 0x0000 -> 0
+	 * 0x0001 -> 1
+	 * 0x0100 -> 2
+	 * 0x0101 -> 3
+	 */
+	add	x0, x1, x0, LSR #7
+	ret
+END_FUNC get_core_pos
+

--- a/core/arch/arm/plat-mediatek/platform_config.h
+++ b/core/arch/arm/plat-mediatek/platform_config.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#define PLATFORM_FLAVOR_ID_mt8173	0
+#define PLATFORM_FLAVOR_IS(flav) \
+	(PLATFORM_FLAVOR == PLATFORM_FLAVOR_ID_ ## flav)
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#ifdef ARM64
+#ifdef CFG_WITH_PAGER
+#error "Pager not supported for ARM64"
+#endif
+#ifdef CFG_WITH_VFP
+#error "VFP not supported for ARM64"
+#endif
+#endif /*ARM64*/
+
+#if PLATFORM_FLAVOR_IS(mt8173)
+
+#define GIC_BASE		0x10220000
+#define GICC_OFFSET		0x2000
+#define GICD_OFFSET		0x1000
+
+#define UART0_BASE		0x11002000
+#define UART1_BASE		0x11003000
+#define UART2_BASE		0x11004000
+#define UART3_BASE		0x11005000
+
+#define CONSOLE_UART_BASE	UART0_BASE
+#define CONSOLE_BAUDRATE	921600
+#define CONSOLE_UART_CLK_IN_HZ	26000000
+
+#define DRAM0_BASE		0x40000000
+#define DRAM0_SIZE		0x80000000
+
+/* Location of trusted dram */
+#define TZDRAM_BASE		0xBE000000
+#define TZDRAM_SIZE		0x02000000
+
+#define CFG_TEE_CORE_NB_CORE	4
+
+#define CFG_SHMEM_START		(TZDRAM_BASE - 0x100000)
+#define CFG_SHMEM_SIZE		0x100000
+
+#else
+#error "Unknown platform flavor"
+#endif
+
+#define HEAP_SIZE		(24 * 1024)
+
+#define CFG_TEE_RAM_VA_SIZE	(1024 * 1024)
+
+#ifndef CFG_TEE_LOAD_ADDR
+#define CFG_TEE_LOAD_ADDR	CFG_TEE_RAM_START
+#endif
+
+/*
+ * Everything is in TZDRAM.
+ * +------------------+
+ * |        | TEE_RAM |
+ * + TZDRAM +---------+
+ * |        | TA_RAM  |
+ * +--------+---------+
+ */
+#define CFG_TEE_RAM_PH_SIZE	CFG_TEE_RAM_VA_SIZE
+#define CFG_TEE_RAM_START	TZDRAM_BASE
+#define CFG_TA_RAM_START	ROUNDUP((TZDRAM_BASE + CFG_TEE_RAM_VA_SIZE), \
+					CORE_MMU_DEVICE_SIZE)
+#define CFG_TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - CFG_TEE_RAM_VA_SIZE), \
+					  CORE_MMU_DEVICE_SIZE)
+
+#define DEVICE0_BASE		ROUNDDOWN(CONSOLE_UART_BASE, \
+					  CORE_MMU_DEVICE_SIZE)
+#define DEVICE0_SIZE		CORE_MMU_DEVICE_SIZE
+#define DEVICE0_TYPE		MEM_AREA_IO_NSEC
+
+#define DEVICE1_BASE		ROUNDDOWN(GIC_BASE, CORE_MMU_DEVICE_SIZE)
+#define DEVICE1_SIZE		CORE_MMU_DEVICE_SIZE
+#define DEVICE1_TYPE		MEM_AREA_IO_SEC
+
+#ifdef CFG_WITH_LPAE
+#define MAX_XLAT_TABLES		5
+#endif
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-mediatek/platform_flags.mk
+++ b/core/arch/arm/plat-mediatek/platform_flags.mk
@@ -1,0 +1,38 @@
+PLATFORM_FLAVOR ?= mt8173
+PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
+
+# 32-bit flags
+arm32-platform-cpuarch	:= cortex-a15
+arm32-platform-cflags	+= -mcpu=$(arm32-platform-cpuarch) -mthumb
+arm32-platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
+arm32-platform-cflags	+= -fno-short-enums -mno-apcs-float -fno-common
+arm32-platform-cflags	+= -mfloat-abi=soft
+arm32-platform-cflags	+= -mno-unaligned-access
+arm32-platform-aflags	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags	+= -mfpu=neon
+
+# 64-bit flags
+arm64-platform-cflags	+= -mgeneral-regs-only
+arm64-platform-cflags	+= -mstrict-align
+
+platform-cflags += -ffunction-sections -fdata-sections
+
+DEBUG		?= 1
+ifeq ($(DEBUG),1)
+platform-cflags += -O0
+else
+platform-cflags += -Os
+endif
+
+platform-cflags += -g3
+platform-aflags += -g3
+
+ifeq ($(PLATFORM_FLAVOR),mt8173)
+platform-flavor-armv8 := 1
+endif
+
+CFG_ARM32_user_ta := y
+user_ta-platform-cflags += $(arm32-platform-cflags)
+user_ta-platform-cflags += -fpie
+user_ta-platform-cppflags += $(arm32-platform-cppflags)
+user_ta-platform-aflags += $(arm32-platform-aflags)

--- a/core/arch/arm/plat-mediatek/sub.mk
+++ b/core/arch/arm/plat-mediatek/sub.mk
@@ -1,0 +1,6 @@
+global-incdirs-y += .
+srcs-y += main.c
+ifeq ($(PLATFORM_FLAVOR),mt8173)
+srcs-$(CFG_ARM32_core) += mt8173_core_pos_a32.S
+srcs-$(CFG_ARM64_core) += mt8173_core_pos_a64.S
+endif

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -384,6 +384,10 @@ static void main_tee_entry(struct thread_smc_args *args)
 	tee_entry(args);
 }
 
+void console_init(void)
+{
+}
+
 void console_putc(int ch)
 {
 	__asc_xmit_char((char)ch);

--- a/core/arch/arm/plat-sunxi/console.c
+++ b/core/arch/arm/plat-sunxi/console.c
@@ -29,6 +29,11 @@
 #include <drivers/sunxi_uart.h>
 #include <console.h>
 
+void console_init(void)
+{
+	sunxi_uart_init(CONSOLE_UART_BASE);
+}
+
 void console_putc(int ch)
 {
 	sunxi_uart_putc(ch, CONSOLE_UART_BASE);

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -124,6 +124,13 @@ static void main_fiq(void)
 	DMSG("return");
 }
 
+void console_init(void)
+{
+	pl011_init(CONSOLE_UART_BASE,
+		   CONSOLE_UART_CLK_IN_HZ,
+		   CONSOLE_BAUDRATE);
+}
+
 void console_putc(int ch)
 {
 	pl011_putc(ch, CONSOLE_UART_BASE);

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <platform_config.h>
+
+#include <drivers/serial8250_uart.h>
+#include <console.h>
+#include <io.h>
+#include <assert.h>
+#include <compiler.h>
+
+/* uart register defines */
+#define UART_RHR	0x0
+#define UART_THR	0x0
+#define UART_IER	0x4
+#define UART_ISR	0x8
+#define UART_FCR	0x8
+#define UART_LCR	0xc
+#define UART_MCR	0x10
+#define UART_LSR	0x14
+#define UART_MSR	0x18
+#define UART_SPR	0x1c
+
+/* uart status register bits */
+#define LSR_TEMT	0x40 /* Transmitter empty */
+#define LSR_THRE	0x20 /* Transmit-hold-register empty */
+#define LSR_EMPTY	(LSR_TEMT | LSR_THRE)
+#define LSR_DR		0x01 /* DATA Ready */
+
+void serial8250_uart_init(vaddr_t __unused base,
+		uint32_t __unused uart_clk, uint32_t __unused baud_rate)
+{
+	/*
+	 * do nothing, debug uart(uart0) share with normal world,
+	 * everything for uart0 is ready now.
+	 */
+}
+
+void serial8250_uart_flush_tx_fifo(vaddr_t base)
+{
+	while (1) {
+		uint8_t state = read8(base + UART_LSR);
+
+		/* waiting transmit fifo empty */
+		if ((state & LSR_EMPTY) == LSR_EMPTY)
+			break;
+	}
+}
+
+bool serial8250_uart_have_rx_data(vaddr_t base)
+{
+	return (read32(base + UART_LSR) & LSR_DR);
+}
+
+void serial8250_uart_putc(int ch, vaddr_t base)
+{
+	serial8250_uart_flush_tx_fifo(base);
+
+	/* write out charset to transmit fifo */
+	write8(ch, base + UART_THR);
+}
+
+int serial8250_uart_getchar(vaddr_t base)
+{
+	while (!serial8250_uart_have_rx_data(base)) {
+		/* transmit fifo is empty, waiting again. */
+		;
+	}
+	return read8(base + UART_RHR);
+}
+

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -1,3 +1,4 @@
 srcs-$(CFG_PL011) += pl011.c
 srcs-$(CFG_GIC) += gic.c
 srcs-$(CFG_SUNXI_UART) += sunxi_uart.c
+srcs-$(CFG_8250_UART) += serial8250_uart.c

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -28,6 +28,7 @@
 #ifndef CONSOLE_H
 #define CONSOLE_H
 
+void console_init(void);
 void console_putc(int ch);
 void console_flush(void);
 

--- a/core/include/drivers/serial8250_uart.h
+++ b/core/include/drivers/serial8250_uart.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SERIAL8250_UART_H
+#define SERIAL8250_UART_H
+
+#include <types_ext.h>
+
+void serial8250_uart_init(vaddr_t base,
+		uint32_t uart_clk, uint32_t baud_rate);
+
+void serial8250_uart_putc(int ch, vaddr_t base);
+
+void serial8250_uart_flush_tx_fifo(vaddr_t base);
+
+bool serial8250_uart_have_rx_data(vaddr_t base);
+
+int serial8250_uart_getchar(vaddr_t base);
+
+#endif /* SERIAL8250_UART_H */
+

--- a/scripts/setup_mtk_optee.sh
+++ b/scripts/setup_mtk_optee.sh
@@ -1,0 +1,446 @@
+#!/bin/bash
+################################################################################
+# EDIT so these match your credentials/preferences                             #
+################################################################################
+DEV_PATH=$HOME/devel/mtk_optee
+
+# You only need to set these variables if you have access to the OPTEE_TEST
+# (requires a Linaro account and access to the git called optee_test.git)
+# If, in addition to the base OPTEE_TEST, you have access to the GlobalPlatform
+# "TEE Initial Configuration" test suite, you may add the tests by extracting
+# the test package in the current directory and run:
+#   $ export CFG_GP_PACKAGE_PATH=<path to the test suite directory>
+#   $ export CFG_GP_TESTSUITE_ENABLE=y
+#   $ ./setup_mtk_optee.sh
+#   $ ./build.sh
+#LINARO_USERNAME=firstname.lastname # Should _NOT_ contain @linaro.org.
+#HAVE_ACCESS_TO_OPTEE_TEST=1
+
+# If the downloaded toolchain can't execute it could be that you're in a
+# 64-bit system without required 32-bit libs
+# For Ubuntu 14.04 the following helps:
+# sudo apt-get install libc6:i386 libstdc++6:i386 libz1:i386
+
+################################################################################
+# Don't touch anything below this comment                                      #
+################################################################################
+set -e
+mkdir -p $DEV_PATH
+
+SRC_KERNEL=https://github.com/ibanezchen/linux-8173.git
+DST_KERNEL=$DEV_PATH/linux
+STABLE_KERNLE_COMMIT=origin/4.0rc1
+
+SRC_KERNEL_PATCHES=https://github.com/ibanezchen/patches-upstream
+DST_KERNEL_PATCHES=$DEV_PATH/patches-upstream
+
+SRC_OPTEE_OS=https://github.com/jamescfkung/optee_os.git
+DST_OPTEE_OS=$DEV_PATH/optee_os
+STABLE_OPTEE_OS_COMMIT=origin/mt8173_64bit
+
+SRC_OPTEE_CLIENT=https://github.com/OP-TEE/optee_client.git
+DST_OPTEE_CLIENT=$DEV_PATH/optee_client
+STABLE_OPTEE_CLIENT_COMMIT=73531b90450f284a8caf46f5020dbfd85bb5e3ac
+
+SRC_OPTEE_LK=https://github.com/OP-TEE/optee_linuxdriver.git
+DST_OPTEE_LK=$DEV_PATH/optee_linuxdriver
+STABLE_OPTEE_LK_COMMIT=eb40f63e9db8cf187e6e23fdf3edd9754129e1aa
+
+SRC_OPTEE_TEST=ssh://$LINARO_USERNAME@linaro-private.git.linaro.org/srv/linaro-private.git.linaro.org/swg/optee_test.git
+DST_OPTEE_TEST=$DEV_PATH/optee_test
+STABLE_OPTEE_TEST_COMMIT=origin/james_mt8173
+
+SRC_GEN_ROOTFS=https://github.com/m943040028/gen_rootfs.git
+DST_GEN_ROOTFS=$DEV_PATH/gen_rootfs
+STATBLE_GEN_ROOTFS_COMMIT=2756038a0a44bbea92c2c401b029cbd753973663
+
+SRC_MTK_TOOLS=https://github.com/m943040028/mtk_tools.git
+DST_MTK_TOOLS=$DEV_PATH/mtk_tools
+
+AARCH64_NONE_GCC=aarch64-none-elf
+AARCH64_NONE_GCC_VERSION=gcc-linaro-aarch64-none-elf-4.9-2014.07_linux
+SRC_AARCH64_NONE_GCC=http://releases.linaro.org/14.07/components/toolchain/binaries/${AARCH64_NONE_GCC_VERSION}.tar.xz
+DST_AARCH64_NONE_GCC=$DEV_PATH/toolchains/$AARCH64_NONE_GCC
+
+AARCH64_GCC=aarch64
+AARCH64_GCC_VERSION=gcc-linaro-aarch64-linux-gnu-4.9-2014.08_linux
+SRC_AARCH64_GCC=http://releases.linaro.org/14.08/components/toolchain/binaries/${AARCH64_GCC_VERSION}.tar.xz
+DST_AARCH64_GCC=$DEV_PATH/toolchains/$AARCH64_GCC
+
+AARCH32_GCC=aarch32
+AARCH32_GCC_VERSION=gcc-linaro-arm-linux-gnueabihf-4.9-2014.08_linux
+SRC_AARCH32_GCC=http://releases.linaro.org/14.08/components/toolchain/binaries/${AARCH32_GCC_VERSION}.tar.xz
+DST_AARCH32_GCC=$DEV_PATH/toolchains/$AARCH32_GCC
+
+
+
+################################################################################
+# Cloning all needed repositories                                              #
+################################################################################
+
+if [ ! -d "$DST_KERNEL" ]; then
+	git clone $SRC_KERNEL $DST_KERNEL
+	(cd $DST_KERNEL && git reset --hard $STABLE_KERNLE_COMMIT)
+else
+	echo " `basename $DST_KERNEL` already exist, not cloning"
+fi
+
+if [ ! -d "$DST_KERNEL_PATCHES" ]; then
+	git clone $SRC_KERNEL_PATCHES $DST_KERNEL_PATCHES
+else
+	echo " `basename $DST_KERNEL_PATCHES` already exist, not cloning"
+fi
+
+if [ ! -d "$DST_OPTEE_OS" ]; then
+	git clone $SRC_OPTEE_OS $DST_OPTEE_OS
+	(cd $DST_OPTEE_OS && git reset --hard $STABLE_OPTEE_OS_COMMIT)
+else
+	echo " `basename $DST_OPTEE_OS` already exist, not cloning"
+fi
+
+if [ ! -d "$DST_OPTEE_CLIENT" ]; then
+	git clone $SRC_OPTEE_CLIENT $DST_OPTEE_CLIENT
+	(cd $DST_OPTEE_CLIENT && git reset --hard $STABLE_OPTEE_CLIENT_COMMIT)
+else
+	echo " `basename $DST_OPTEE_CLIENT` already exist, not cloning"
+fi
+
+if [ ! -d "$DST_OPTEE_LK" ]; then
+	git clone $SRC_OPTEE_LK $DST_OPTEE_LK
+	(cd $DST_OPTEE_LK && git reset --hard $STABLE_OPTEE_LK_COMMIT)
+else
+	echo " `basename $DST_OPTEE_LK` already exist, not cloning"
+fi
+
+if [ ! -d "$DST_OPTEE_TEST" ] && [ -n "$HAVE_ACCESS_TO_OPTEE_TEST" ]; then
+	git clone $SRC_OPTEE_TEST $DST_OPTEE_TEST
+	(cd $DST_OPTEE_TEST && git reset --hard $STABLE_OPTEE_TEST_COMMIT)
+else
+	echo " `basename $DST_OPTEE_TEST` already exist (or no access), not cloning"
+fi
+
+if [ ! -d "$DST_GEN_ROOTFS" ]; then
+	git clone $SRC_GEN_ROOTFS $DST_GEN_ROOTFS
+	(cd $DST_GEN_ROOTFS && git reset --hard $STATBLE_GEN_ROOTFS_COMMIT)
+else
+	echo " `basename $DST_GEN_ROOTFS` already exist, not cloning"
+fi
+
+if [ ! -d "$DST_MTK_TOOLS" ]; then
+	git clone $SRC_MTK_TOOLS $DST_MTK_TOOLS
+else
+	echo " `basename $DST_MTK_TOOLS` already exist, not cloning"
+fi
+
+################################################################################
+# Download and install the needed toolchains                                   #
+################################################################################
+mkdir -p $DEV_PATH/toolchains
+cd $DEV_PATH/toolchains
+
+if [ ! -f "${AARCH64_NONE_GCC_VERSION}.tar.xz" ]; then
+	wget $SRC_AARCH64_NONE_GCC
+fi
+if [ ! -d "$DST_AARCH64_NONE_GCC" ]; then
+	echo "Untar $AARCH64_NONE_GCC_VERSION ..."
+	tar xf ${AARCH64_NONE_GCC_VERSION}.tar.xz && mv $AARCH64_NONE_GCC_VERSION $DST_AARCH64_NONE_GCC
+fi
+
+if [ ! -f "${AARCH64_GCC_VERSION}.tar.xz" ]; then
+	wget $SRC_AARCH64_GCC
+fi
+if [ ! -d "$DST_AARCH64_GCC" ]; then
+	echo "Untar $AARCH64_GCC_VERSION ..."
+	tar xf ${AARCH64_GCC_VERSION}.tar.xz && mv $AARCH64_GCC_VERSION $DST_AARCH64_GCC
+fi
+
+if [ ! -f "${AARCH32_GCC_VERSION}.tar.xz" ]; then
+	wget $SRC_AARCH32_GCC
+fi
+if [ ! -d "$DST_AARCH32_GCC" ]; then
+	echo "Untar $AARCH32_GCC_VERSION ..."
+	tar xf ${AARCH32_GCC_VERSION}.tar.xz && mv $AARCH32_GCC_VERSION $DST_AARCH32_GCC
+fi
+
+################################################################################
+# Apply MediaTek specific patches to Linux kernel                              #
+################################################################################
+cd $DST_KERNEL
+git reset --hard $STABLE_KERNLE_COMMIT
+rm -f .config
+$DST_KERNEL_PATCHES/patch-all.sh
+
+################################################################################
+# Generate the build script for Linux kernel                                   #
+################################################################################
+cd $DEV_PATH
+cat > $DEV_PATH/build_linux.sh << EOF
+#/bin/bash
+export PATH=$DST_AARCH64_NONE_GCC/bin:\$PATH
+export CROSS_COMPILE=$DST_AARCH64_NONE_GCC/bin/aarch64-none-elf-
+cd $DST_KERNEL
+
+if [ ! -f ".config" ]; then
+	sed -i '/config ARM64$/a  select DMA_SHARED_BUFFER' arch/arm64/Kconfig
+	make ARCH=arm64 defconfig
+fi
+
+make -j\`getconf _NPROCESSORS_ONLN\` LOCALVERSION= ARCH=arm64 \$@
+EOF
+
+chmod 711 $DEV_PATH/build_linux.sh
+# We must also build it since we need gen_init_cpio during the setup
+$DEV_PATH/build_linux.sh Image dtbs
+
+# Save kernel version for later use
+export KERNEL_VERSION=`cd $DST_KERNEL && make kernelversion`
+
+################################################################################
+# Generate the filesystem using gen_init_cpio                                  #
+################################################################################
+cd $DST_GEN_ROOTFS
+export CC_DIR=$DST_AARCH64_GCC
+
+# Set path to gen_init_cpio
+export PATH=$DST_KERNEL/usr:$PATH
+
+if [ ! -f "$DST_GEN_ROOTFS/filelist-tee.txt" ]; then
+	echo "Generting the file system"
+	./generate-cpio-rootfs.sh fvp-aarch64
+fi
+
+cp $DST_GEN_ROOTFS/filelist-final.txt $DST_GEN_ROOTFS/filelist-tee.txt
+
+# Remove last line about fbtest in the filelist
+head -n -1 $DST_GEN_ROOTFS/filelist-tee.txt > temp.txt ; mv temp.txt $DST_GEN_ROOTFS/filelist-tee.txt
+
+cat >> $DST_GEN_ROOTFS/filelist-tee.txt << EOF
+# OP-TEE device
+dir /lib/modules 755 0 0
+dir /lib/modules/$KERNEL_VERSION 755 0 0
+file /lib/modules/$KERNEL_VERSION/optee.ko $DST_OPTEE_LK/core/optee.ko 755 0 0
+file /lib/modules/$KERNEL_VERSION/optee_armtz.ko $DST_OPTEE_LK/armtz/optee_armtz.ko 755 0 0
+
+# OP-TEE Client
+file /bin/tee-supplicant $DEV_PATH/optee_client/out/export/bin/tee-supplicant 755 0 0
+dir /lib/aarch64-linux-gnu 755 0 0
+file /lib/aarch64-linux-gnu/libteec.so.1.0 $DEV_PATH/optee_client/out/export/lib/libteec.so.1.0 755 0 0
+slink /lib/aarch64-linux-gnu/libteec.so.1 libteec.so.1.0 755 0 0
+slink /lib/aarch64-linux-gnu/libteec.so libteec.so.1 755 0 0
+
+# Secure storage dig
+dir /data 755 0 0
+dir /data/tee 755 0 0
+
+# TAs
+dir /lib/optee_armtz 755 0 0
+EOF
+
+if [ -n "$HAVE_ACCESS_TO_OPTEE_TEST" ]; then
+cat >> $DST_GEN_ROOTFS/filelist-tee.txt << EOF
+# Trusted Applications
+file /lib/optee_armtz/d17f73a0-36ef-11e1-984a0002a5d5c51b.ta $DEV_PATH/out/utest/user_ta/armv7/rpc_test/d17f73a0-36ef-11e1-984a0002a5d5c51b.ta 444 0 0
+file /lib/optee_armtz/cb3e5ba0-adf1-11e0-998b0002a5d5c51b.ta $DEV_PATH/out/utest/user_ta/armv7/crypt/cb3e5ba0-adf1-11e0-998b0002a5d5c51b.ta 444 0 0
+file /lib/optee_armtz/b689f2a7-8adf-477a-9f9932e90c0ad0a2.ta $DEV_PATH/out/utest/user_ta/armv7/storage/b689f2a7-8adf-477a-9f9932e90c0ad0a2.ta 444 0 0
+file /lib/optee_armtz/5b9e0e40-2636-11e1-ad9e0002a5d5c51b.ta $DEV_PATH/out/utest/user_ta/armv7/os_test/5b9e0e40-2636-11e1-ad9e0002a5d5c51b.ta 444 0 0
+file /lib/optee_armtz/c3f6e2c0-3548-11e1-b86c0800200c9a66.ta $DEV_PATH/out/utest/user_ta/armv7/create_fail_test/c3f6e2c0-3548-11e1-b86c0800200c9a66.ta 444 0 0
+file /lib/optee_armtz/e6a33ed4-562b-463a-bb7eff5e15a493c8.ta $DEV_PATH/out/utest/user_ta/armv7/sims/e6a33ed4-562b-463a-bb7eff5e15a493c8.ta 444 0 0
+
+# OP-TEE Tests
+file /bin/xtest $DEV_PATH/out/utest/host/xtest/bin/xtest 755 0 0
+EOF
+
+if [ "$CFG_GP_TESTSUITE_ENABLE" = y ]; then
+cat >> $DST_GEN_ROOTFS/filelist-tee.txt << EOF
+
+# Additional TAs for GP tests
+file /lib/optee_armtz/534d4152-5443-534c-4d4c54494e535443.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_TCF_MultipleInstanceTA/534d4152-5443-534c-4d4c54494e535443.ta 444 0 0
+file /lib/optee_armtz/534d4152-542d-4353-4c542d54412d5354.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_testingClientAPI/534d4152-542d-4353-4c542d54412d5354.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-5444415441535431.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_DS/534d4152-5443-534c-5444415441535431.ta 444 0 0
+file /lib/optee_armtz/534d4152-542d-4353-4c542d54412d5355.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_answerSuccessTo_OpenSession_Invoke/534d4152-542d-4353-4c542d54412d5355.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-5443525950544f31.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_Crypto/534d4152-5443-534c-5443525950544f31.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-5f54494d45415049.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_Time/534d4152-5443-534c-5f54494d45415049.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-4c53-41524954484d4554.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_Arithmetical/534d4152-5443-4c53-41524954484d4554.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-544f53345041524d.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_check_OpenSession_with_4_parameters/534d4152-5443-534c-544f53345041524d.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-54455252544f4f53.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_answerErrorTo_OpenSession/534d4152-5443-534c-54455252544f4f53.ta 444 0 0
+file /lib/optee_armtz/534d4152-542d-4353-4c542d54412d4552.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_answerErrorTo_Invoke/534d4152-542d-4353-4c542d54412d4552.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-53474c494e535443.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_TCF_SingleInstanceTA/534d4152-5443-534c-53474c494e535443.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-5441544346494341.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_TCF_ICA/534d4152-5443-534c-5441544346494341.ta 444 0 0
+file /lib/optee_armtz/534d4152-5443-534c-5454434649434132.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_TCF_ICA2/534d4152-5443-534c-5454434649434132.ta 444 0 0
+file /lib/optee_armtz/534d4152-542d-4353-4c542d54412d3031.ta $DEV_PATH/out/utest/user_ta/armv7/GP_TTA_TCF/534d4152-542d-4353-4c542d54412d3031.ta 444 0 0
+EOF
+fi
+
+fi
+
+################################################################################
+# Generate build_optee_os.sh for building optee_os                             #
+################################################################################
+cd $DEV_PATH
+cat > $DEV_PATH/build_optee_os.sh << EOF
+#/bin/bash
+export PATH=$DST_AARCH64_GCC/bin:$DST_AARCH32_GCC/bin:\$PATH
+
+export CFG_ARM64_core=y
+if [ "\$CFG_ARM64_core" == "y" ]; then
+  echo "Enable arm64 OP-TEE OS support"
+  export CROSS_COMPILE=aarch64-linux-gnu-
+else
+  #export CROSS_COMPILE=arm-linux-gnueabihf-
+  echo "Warning: Mediatek platform did not support arm32 OP-TEE OS"
+  exit
+fi
+
+export CROSS_COMPILE_user_ta=arm-linux-gnueabihf-
+export PLATFORM=mediatek
+export PLATFORM_FLAVOR=mt8173
+export CFG_TEE_CORE_LOG_LEVEL=4
+export DEBUG=0
+
+cd $DST_OPTEE_OS
+make -j\`getconf _NPROCESSORS_ONLN\` \$@
+EOF
+
+chmod 711 $DEV_PATH/build_optee_os.sh
+
+################################################################################
+# Generate build_optee_client.sh for building optee_client                     #
+################################################################################
+cd $DEV_PATH
+
+cat > $DEV_PATH/build_optee_client.sh << EOF
+#!/bin/bash
+export PATH=$DST_AARCH64_GCC/bin:\$PATH
+
+cd $DST_OPTEE_CLIENT
+make -j\`getconf _NPROCESSORS_ONLN\` CROSS_COMPILE=aarch64-linux-gnu- \$@
+EOF
+
+chmod 711 $DEV_PATH/build_optee_client.sh
+
+if [ -n "$HAVE_ACCESS_TO_OPTEE_TEST" ]; then
+################################################################################
+# Generate build_optee_tests.sh                                                #
+################################################################################
+cd $DEV_PATH
+
+cat > $DEV_PATH/build_optee_tests.sh << EOF
+#!/bin/bash
+cd $DST_OPTEE_TEST
+export PATH=$DST_AARCH64_GCC/bin:\$PATH
+export PATH=$DST_AARCH32_GCC/bin:\$PATH
+
+export CFG_DEV_PATH=$DEV_PATH
+export CFG_PLATFORM_FLAVOR=mt8173
+export CFG_ROOTFS_DIR=\$CFG_DEV_PATH/out
+
+if [ "\$CFG_GP_TESTSUITE_ENABLE" = y ]; then
+export CFG_GP_PACKAGE_PATH=\${CFG_GP_PACKAGE_PATH:-$DST_OPTEE_TEST/TEE_Initial_Configuration-Test_Suite_v1_1_0_4-2014_11_07}
+if [ ! -d "\$CFG_GP_PACKAGE_PATH" ]; then
+  echo "CFG_GP_PACKAGE_PATH must be the path to the GP testsuite directory"
+  exit 1
+fi
+make patch
+fi
+
+make -j\`getconf _NPROCESSORS_ONLN\` \$@
+EOF
+
+chmod 711 $DEV_PATH/build_optee_tests.sh
+fi
+
+################################################################################
+# Generate build_optee_linuxkernel.sh                                          #
+################################################################################
+cd $DEV_PATH
+
+cat > $DEV_PATH/build_optee_linuxkernel.sh << EOF
+#!/bin/bash
+export PATH=$DST_AARCH64_GCC/bin:\$PATH
+
+cd $DST_KERNEL
+make V=0 ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- LOCALVERSION= M=$DST_OPTEE_LK modules \$@
+EOF
+
+chmod 711 $DEV_PATH/build_optee_linuxkernel.sh
+$DEV_PATH/build_optee_linuxkernel.sh
+
+################################################################################
+# Generate the files system using gen_init_cpio part 2 - update_rootfs.sh      #
+################################################################################
+cd $DEV_PATH
+cat > $DEV_PATH/update_rootfs.sh << EOF
+#!/bin/bash
+export PATH=$DST_KERNEL/usr:\$PATH
+
+cd $DST_GEN_ROOTFS
+gen_init_cpio $DST_GEN_ROOTFS/filelist-tee.txt | gzip > filesystem.cpio.gz
+EOF
+
+chmod 711 $DEV_PATH/update_rootfs.sh
+
+################################################################################
+# Generate build_image.sh                                                      #
+################################################################################
+cd $DEV_PATH
+cat > $DEV_PATH/build_image.sh << EOF
+#!/bin/bash
+
+(cd mtk_tools &&
+./build_trustzone.sh $DST_OPTEE_OS/out/arm-plat-mediatek/core/tee-pager.bin &&
+./build_bootimg.sh $DST_KERNEL $DST_GEN_ROOTFS/filesystem.cpio.gz)
+EOF
+
+chmod 711 $DEV_PATH/build_image.sh
+
+################################################################################
+# Generate flash_image.sh                                                      #
+################################################################################
+cd $DEV_PATH
+cat > $DEV_PATH/flash_image.sh << EOF
+#!/bin/bash
+
+echo "Please press reset button ..."
+
+(cd mtk_tools &&
+./fastboot flash boot ./boot.img &&
+./fastboot flash TEE1 ./trustzone.bin)
+
+echo "Please press reset button again..."
+EOF
+
+chmod 711 $DEV_PATH/flash_image.sh
+
+################################################################################
+# Generate build.sh                                                            #
+################################################################################
+cd $DEV_PATH
+
+cat > $DEV_PATH/build.sh << EOF
+#!/bin/bash
+set -e
+cd $DEV_PATH
+./build_optee_os.sh all
+./build_optee_client.sh
+if [ -f "build_optee_tests.sh" ]; then
+	./build_optee_tests.sh
+fi
+./build_optee_linuxkernel.sh
+./update_rootfs.sh
+./build_image.sh
+EOF
+
+chmod 711 $DEV_PATH/build.sh
+
+echo "OP-TEE setup completed."
+if [ ! -n "$HAVE_ACCESS_TO_OPTEE_TEST" ]; then
+	echo "LINARO_USERNAME and HAVE_ACCESS_TO_OPTEE_TEST wasn't updated, therefore no tests"
+	echo "has been included."
+fi
+
+cat << EOF
+To build OP-TEE:
+cd $DEV_PATH
+./build.sh
+EOF
+


### PR DESCRIPTION
Add support for Mediatek mt8173 platform with 32bit
and 64bit OP-TEE OS. Due to Mediatek ATF firmware
limitation, this commit only tested with 64bit OP-TEE OS.

Tested-by: James Kung <james.kung@linaro.org> (MT8173 platform)
Signed-off-by: James Kung <james.kung@linaro.org>