### PR TITLE
GP Internal Core API v1.1 : TA configuration properties

### DIFF
--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -103,6 +103,8 @@ struct user_ta_sub_head {
 #define TA_PROP_STR_KEEP_ALIVE		"gpd.ta.instanceKeepAlive"
 #define TA_PROP_STR_DATA_SIZE		"gpd.ta.dataSize"
 #define TA_PROP_STR_STACK_SIZE		"gpd.ta.stackSize"
+#define TA_PROP_STR_VERSION		"gpd.ta.version"
+#define TA_PROP_STR_DESCRIPTION		"gpd.ta.description"
 #define TA_PROP_STR_UNSAFE_PARAM	"op-tee.unsafe_param"
 #define TA_PROP_STR_REMAP		"op-tee.remap"
 #define TA_PROP_STR_CACHE_SYNC		"op-tee.cache_sync"

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -39,6 +39,14 @@ const char trace_ext_prefix[]  = TA_LOG_PREFIX;
 const char trace_ext_prefix[]  = "USER-TA";
 #endif
 
+#ifndef TA_VERSION
+#define TA_VERSION "Undefined version"
+#endif
+
+#ifndef TA_DESCRIPTION
+#define TA_DESCRIPTION "Undefined description"
+#endif
+
 /* exprted to user_ta_header.c, built within TA */
 void ta_entry_close_session(uint32_t session_id) __noreturn;
 
@@ -102,6 +110,12 @@ const struct user_ta_property ta_props[] = {
 
 	{TA_PROP_STR_STACK_SIZE, USER_TA_PROP_TYPE_U32,
 	 &(const uint32_t){TA_STACK_SIZE}},
+
+	{TA_PROP_STR_VERSION, USER_TA_PROP_TYPE_STRING,
+	 TA_VERSION},
+
+	{TA_PROP_STR_DESCRIPTION, USER_TA_PROP_TYPE_STRING,
+	 TA_DESCRIPTION},
 
 /*
  * Extended propietary properties, name of properties must not begin with


### PR DESCRIPTION
add gpd.ta.version and gpd.ta.description

Signed-off-by: Cedric Chaumont <cedric.chaumont@st.com>

Note: For testing use optee_test with dev/gp11_ta_prop branch