### PR TITLE
core arm: remove unused open session option

### DIFF
--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -30,7 +30,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include <kernel/kta_types.h>
 #include <utee_defines.h>
 
 struct tee_hw_unique_key {

--- a/core/include/kernel/tee_common_unpg.h
+++ b/core/include/kernel/tee_common_unpg.h
@@ -31,7 +31,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <kernel/kta_types.h>
 #include <tee_api_types.h>
 #include <mm/tee_mm_def.h>
 #include <kernel/tee_misc_unpg.h>

--- a/core/include/kernel/tee_dispatch.h
+++ b/core/include/kernel/tee_dispatch.h
@@ -46,7 +46,6 @@ struct tee_dispatch_out {
 
 /* Input arg structure specific to TEE service 'open session'. */
 struct tee_dispatch_open_session_in {
-	kta_signed_header_t *ta;
 	TEE_UUID uuid;
 	uint32_t param_types;
 	TEE_Param params[4];


### PR DESCRIPTION
OP-TEE no longer supports loading the TA directly in open session.

* Removes ta field in struct tee_dispatch_open_session_in.
* Removes get_open_session_ta()
* Removes unneeded inclusions of kernel/kta_types.h

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)