### PR TITLE
plat-hikey: enable ARM64

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -3,7 +3,12 @@ include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 CROSS_COMPILE	?= arm-linux-gnueabihf-
 COMPILER	?= gcc
 
+ifeq ($(CFG_ARM64_core),y)
+CFG_WITH_LPAE := y
+else
 CFG_ARM32_core ?= y
+CFG_MMU_V7_TTB ?= y
+endif
 
 core-platform-cppflags	+= -I$(arch-dir)/include
 
@@ -20,7 +25,6 @@ CFG_HWSUPP_MEM_PERM_PXN ?= y
 CFG_WITH_STACK_CANARIES ?= y
 CFG_NO_TA_HASH_SIGN ?= y
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= n
-CFG_MMU_V7_TTB ?= y
 CFG_GENERIC_BOOT ?= y
 CFG_PM_STUBS ?= y
 

--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -31,9 +31,14 @@
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		64
 
-#ifndef ARM32
-#error "Only ARM32 is supported"
+#ifdef ARM64
+#ifdef CFG_WITH_PAGER
+#error "Pager not supported for ARM64"
 #endif
+#ifdef CFG_WITH_VFP
+#error "VFP not supported for ARM64"
+#endif
+#endif /* ARM64 */
 
 /* PL011 UART */
 #define CONSOLE_UART_BASE	0xF8015000

--- a/core/arch/arm/plat-hikey/platform_flags.mk
+++ b/core/arch/arm/plat-hikey/platform_flags.mk
@@ -1,3 +1,4 @@
+# 32-bit flags
 arm32-platform-cpuarch	:= cortex-a15
 arm32-platform-cflags	+= -mcpu=$(arm32-platform-cpuarch) -mthumb
 arm32-platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
@@ -6,6 +7,10 @@ arm32-platform-cflags	+= -mfloat-abi=soft
 arm32-platform-cflags	+= -mno-unaligned-access
 arm32-platform-aflags	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags	+= -mfpu=neon
+
+# 64-bit flags
+arm64-platform-cflags	+= -mgeneral-regs-only
+arm64-platform-cflags	+= -mstrict-align
 
 platform-cflags += -ffunction-sections -fdata-sections
 


### PR DESCRIPTION
make PLATFORM=hikey CFG_ARM64_core=y \
     CROSS_COMPILE_core=aarch64-linux-gnu-

Note: xtest 1010 fails (writing to supposedly invalid memory at 0x40000000
does not panic the TA). The same test also fails on FVP.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>