### PR TITLE
Add sparse support [C=1]

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -1,10 +1,10 @@
 ifeq ($(CFG_ARM64_core),y)
-core-platform-cppflags += -DARM64=1
+core-platform-cppflags += -DARM64=1 -DLP64=1
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64
 CFG_KERN_LINKER_ARCH ?= aarch64
 endif
 ifeq ($(CFG_ARM32_core),y)
-core-platform-cppflags += -DARM32=1
+core-platform-cppflags += -DARM32=1 -D__ILP32__=1
 CFG_KERN_LINKER_FORMAT ?= elf32-littlearm
 CFG_KERN_LINKER_ARCH ?= arm
 endif

--- a/ta/arch/arm/arm.mk
+++ b/ta/arch/arm/arm.mk
@@ -1,6 +1,6 @@
 ifeq ($(CFG_ARM64_user_ta),y)
-user_ta-platform-cppflags += -DARM64=1
+user_ta-platform-cppflags += -DARM64=1 -DLP64=1
 endif
 ifeq ($(CFG_ARM32_user_ta),y)
-user_ta-platform-cppflags += -DARM32=1
+user_ta-platform-cppflags += -DARM32=1 -D__ILP32__=1
 endif


### PR DESCRIPTION
Adds support to check source files with sparse when C=1 on the command
line. Only files that are recompiled are checked.

Note that sparse isn't very useful at this stage since the source code
need changes to be more sparse friendly.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>