### PR TITLE
Clean/simplify supplicant RPC parameters

### DIFF
--- a/core/include/kernel/tee_rpc_types.h
+++ b/core/include/kernel/tee_rpc_types.h
@@ -32,7 +32,7 @@
 
 struct tee_rpc_load_ta_cmd {
 	TEE_UUID uuid;
-	void *va;
+	uint32_t supp_ta_handle;
 };
 
 #endif

--- a/core/include/kernel/tee_ta_manager_unpg.h
+++ b/core/include/kernel/tee_ta_manager_unpg.h
@@ -47,12 +47,6 @@ TAILQ_HEAD(tee_cryp_state_head, tee_cryp_state);
 TAILQ_HEAD(tee_obj_head, tee_obj);
 TAILQ_HEAD(tee_storage_enum_head, tee_storage_enum);
 
-/* normal world user mapping if loaded by tee supplicant */
-struct tee_ta_nwumap {
-	paddr_t ph;
-	size_t size;
-};
-
 /* Context of a loaded TA */
 struct tee_ta_ctx {
 	TAILQ_ENTRY(tee_ta_ctx) link;


### PR DESCRIPTION
Tested on HiKey with 32-bit and 64-bit TEE Core.

Note: this commit depends on:

[optee_linuxdriver]
  "tz: Fix handling of RPC parameters to supplicant"
[optee_client]
  "Drop TEE_RPC_FREE_TA_WTH_FD, let it be TEE_RPC_FREE_TA"

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>