### PR TITLE
Fix possible TA build error with make -j: "Directory nonexistent"

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -30,6 +30,7 @@ ldargs-$(binary).elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc$(sm))
 
 $(link-script-pp): $(link-script) $(MAKEFILE_LIST)
 	@echo '  CPP     $@'
+	$(q)mkdir -p $(dir $@)
 	$(q)cat < $< > $@
 
 


### PR DESCRIPTION
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>