### PR TITLE
build: remove conf-file from cleanvars.mk

### DIFF
--- a/mk/cleanvars.mk
+++ b/mk/cleanvars.mk
@@ -8,5 +8,3 @@ libnames	:=
 libdeps		:=
 sm-$(sm)	:=
 incdirs		:=
-conf-file	:=
-conf-mk-file	:=


### PR DESCRIPTION
conf-file and conf-mk-file are valid for core and lib
compilation. These variables are set only once, when
starting the building.

Without this patch, the variables are cleaned when
compiling the libs. This affects the rules
   $(objs): $(conf-file)
which forces the conf-file generation.
In case of parallel build, if libs are compiled before the
core, then conf-file is not created, which results in a
compilation error.

Signed-off-by: Pascal Brand <pascal.brand@st.com>