### PR TITLE
Build: fix silent mode with make 3.8x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifneq ($(filter %s ,$(firstword x$(MAKEFLAGS))),)
 cmd-echo-silent := true
 endif
 else                                    # make-3.8x
-ifneq ($(filter s% -s%,$(MAKEFLAGS)),)
+ifneq ($(findstring s, $(MAKEFLAGS)),)
 cmd-echo-silent := true
 endif
 endif

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -34,7 +34,7 @@ ifneq ($(filter %s ,$(firstword x$(MAKEFLAGS))),)
 cmd-echo-silent := true
 endif
 else                                    # make-3.8x
-ifneq ($(filter s% -s%,$(MAKEFLAGS)),)
+ifneq ($(findstring s, $(MAKEFLAGS)),)
 cmd-echo-silent := true
 endif
 endif


### PR DESCRIPTION
With make 3.8x, in case of 'make all -s -w', MAKEFLAGS equals 'ws'
This patch correctly catches the flag 's'

Signed-off-by: Pascal Brand <pascal.brand@st.com>