### PR TITLE
Add SERVICEID_VENDOR_START to easily include vendor specific services

### DIFF
--- a/core/include/core_serviceid.h
+++ b/core/include/core_serviceid.h
@@ -69,6 +69,8 @@ typedef enum {
 	SERVICEID_SET_L2CC_MUTEX = 0x20000003,
 	SERVICEID_LOAD_TEE = 0x20000004,
 
+	/* Vendor specific services start here */
+	SERVICEID_VENDOR_START = 0x30000000,
 } t_service_id;
 
 #endif

--- a/core/include/kernel/tee_dispatch.h
+++ b/core/include/kernel/tee_dispatch.h
@@ -33,7 +33,6 @@
 
 #include <trace.h>
 
-
 /*
  * output argument data structure is always TEE service specific but always
  * starts with the generic output data structure tee_dispatch_out.
@@ -95,14 +94,6 @@ struct tee_dispatch_memory_in {
 	void *buffer;
 	uint32_t size;
 };
-
-#if (CFG_TEE_CORE_DEBUG == 1)
-/* Output arg structure specific to TEE service 'get core status'. */
-struct tee_core_status_out {
-	struct tee_dispatch_out msg;
-	char raw[80];
-};
-#endif /* CFG_TEE_CORE_DEBUG */
 
 TEE_Result tee_dispatch_open_session(struct tee_dispatch_open_session_in *in,
 				     struct tee_dispatch_open_session_out *out);

--- a/core/include/kernel/tee_kta_trace.h
+++ b/core/include/kernel/tee_kta_trace.h
@@ -49,7 +49,4 @@
 #define DTAMSG_RAW	DMSG_RAW
 #define FTAMSG_RAW	FMSG_RAW
 
-#define set_ta_trace_level(l)	trace_set_level((l))
-#define get_ta_trace_level()	trace_get_level()
-
 #endif /*KERNEL_TEE_KTA_TRACE_H*/


### PR DESCRIPTION
Also remove useless struct tee_core_status_out
and set_ta_trace_level()/get_ta_trace_level()

Signed-off-by: Pascal Brand <pascal.brand@st.com>