### PR TITLE
arm32: core_mmu_v7 clear tbl_info.table before use

### DIFF
--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -379,6 +379,12 @@ static paddr_t populate_user_map(struct tee_mmu_info *mmu)
 	tbl_info.shift = SECTION_SHIFT;
 	tbl_info.num_entries = TEE_MMU_UL1_NUM_ENTRIES;
 
+	/*
+	 * Need to clear the table before use, because there maybe junk
+	 * data at tlb_info.table, which may corrupt system when set ttbr0
+	 */
+	memset(tbl_info.table, 0x00, TEE_MMU_UL1_SIZE);
+
 	region.pa = 0;
 	region.va = va_range_base;
 	region.attr = 0;


### PR DESCRIPTION
Clear tlb_info.table before use, because there maybe junk
data in this area. If not, system may crash when setting
ttbr0 as following:
	core_mmu_set_user_map->write_ttbr0(map->ttbr0);

On my platform, the first entry of ttbr0 table is not set and it's
value is a random value. Switching ttbr0 crashes the system.

Signed-off-by: Peng Fan \<van.freenix@gmail.com\>