### PR TITLE
core: mm: fix adding integer overflow issue

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -81,7 +81,7 @@ static struct map_area *find_map_by_va(void *va)
 	unsigned long a = (unsigned long)va;
 
 	while (map->type != MEM_AREA_NOTYPE) {
-		if ((a >= map->va) && (a < (map->va + map->size)))
+		if ((a >= map->va) && (a <= (map->va - 1 + map->size)))
 			return map;
 		map++;
 	}

--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -94,7 +94,7 @@ static bool is_valid_conf_and_notnull_size(
 		vaddr_t b, size_t bl, vaddr_t a, size_t al)
 {
 	/* invalid config return false */
-	if ((b + bl < b) || (a + al < a))
+	if ((b - 1 + bl < b) || (a - 1 + al < a))
 		return false;
 	/* null sized areas are never inside / outside / overlap */
 	if (!bl || !al)
@@ -109,7 +109,7 @@ bool _core_is_buffer_inside(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 	if (!is_valid_conf_and_notnull_size(b, bl, a, al))
 		return false;
 
-	if ((b >= a) && (b + bl <= a + al))
+	if ((b >= a) && (b - 1 + bl <= a - 1 + al))
 		return true;
 	return false;
 }


### PR DESCRIPTION
On ARMv7 platform, it is easy that "base + size" wraps down to 0.
For example, base is 0xfc100000, size is 0x3f00000, then base + size is 0.
We should use the "end" address to do the comparation, but not "end + 1".

This patch also can be used for ARMv8.

Signed-off-by: Peng Fan <van.freenix@gmail.com>