### PR TITLE
arm64: fix buffer overflows when copying kernel addresses to user space

### DIFF
--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -76,6 +76,8 @@ TEE_Result tee_svc_copy_from_user(struct tee_ta_session *sess, void *kaddr,
 				  const void *uaddr, size_t len);
 TEE_Result tee_svc_copy_to_user(struct tee_ta_session *sess, void *uaddr,
 				const void *kaddr, size_t len);
+TEE_Result tee_svc_copy_kaddr_to_user32(struct tee_ta_session *sess,
+					uint32_t *uaddr, const void *kaddr);
 
 TEE_Result tee_svc_get_cancellation_flag(bool *cancel);
 

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1033,7 +1033,7 @@ TEE_Result tee_svc_cryp_obj_alloc(TEE_ObjectType obj_type,
 
 	tee_obj_add(sess->ctx, o);
 
-	res = tee_svc_copy_to_user(sess, obj, &o, sizeof(o));
+	res = tee_svc_copy_kaddr_to_user32(sess, obj, o);
 	if (res != TEE_SUCCESS)
 		tee_obj_close(sess->ctx, o);
 	return res;

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -476,7 +476,7 @@ TEE_Result tee_svc_storage_obj_open(uint32_t storage_id, void *object_id,
 
 	tee_obj_add(sess->ctx, o);
 
-	res = tee_svc_copy_to_user(sess, obj, &o, sizeof(o));
+	res = tee_svc_copy_kaddr_to_user32(sess, obj, o);
 	if (res != TEE_SUCCESS)
 		tee_obj_close(sess->ctx, o);
 
@@ -626,7 +626,7 @@ TEE_Result tee_svc_storage_obj_create(uint32_t storage_id, void *object_id,
 
 	tee_obj_add(sess->ctx, o);
 
-	res = tee_svc_copy_to_user(sess, obj, &o, sizeof(o));
+	res = tee_svc_copy_kaddr_to_user32(sess, obj, o);
 	if (res != TEE_SUCCESS)
 		goto oclose;
 
@@ -818,8 +818,7 @@ TEE_Result tee_svc_storage_alloc_enum(uint32_t *obj_enum)
 	e->dir = NULL;
 	TAILQ_INSERT_TAIL(&sess->ctx->storage_enums, e, link);
 
-	return tee_svc_copy_to_user(sess, obj_enum, &e,
-				    sizeof(TEE_ObjectEnumHandle *));
+	return tee_svc_copy_kaddr_to_user32(sess, obj_enum, e);
 }
 
 TEE_Result tee_svc_storage_free_enum(uint32_t obj_enum)


### PR DESCRIPTION
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>