### PR TITLE
arm64: AES XTS using ARMv8-A cryptographic extensions

### DIFF
--- a/core/lib/libtomcrypt/include/tomcrypt_cipher.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_cipher.h
@@ -407,6 +407,36 @@ extern struct ltc_cipher_descriptor {
        const unsigned char *key, unsigned long keylen,
        const unsigned char *in,  unsigned long inlen,
              unsigned char *out, unsigned long *outlen);
+
+   /** Accelerated XTS encryption
+       @param pt      Plaintext
+       @param ct      Ciphertext
+       @param blocks  The number of complete blocks to process
+       @param tweak   The 128-bit encryption tweak (input/output).
+                      The tweak should not be encrypted on input, but
+                      next tweak will be copied encrypted on output.
+       @param skey1   The first scheduled key context
+       @param skey2   The second scheduled key context
+       @return CRYPT_OK if successful
+    */
+    int (*accel_xts_encrypt)(const unsigned char *pt, unsigned char *ct,
+        unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
+        symmetric_key *skey2);
+
+    /** Accelerated XTS decryption
+        @param ct      Ciphertext
+        @param pt      Plaintext
+        @param blocks  The number of complete blocks to process
+        @param tweak   The 128-bit encryption tweak (input/output).
+                       The tweak should not be encrypted on input, but
+                       next tweak will be copied encrypted on output.
+        @param skey1   The first scheduled key context
+        @param skey2   The second scheduled key context
+        @return CRYPT_OK if successful
+     */
+     int (*accel_xts_decrypt)(const unsigned char *ct, unsigned char *pt,
+         unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
+         symmetric_key *skey2);
 } cipher_descriptor[];
 
 

--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_arm64_ce_a64.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_arm64_ce_a64.S
@@ -520,9 +520,9 @@ ENDPROC(ce_aes_ctr_encrypt)
 
 	/*
 	 * aes_xts_decrypt(u8 out[], u8 const in[], u8 const rk1[], int rounds,
-	 *		   int blocks, u8 const rk2[], u8 iv[], int first)
+	 *		   int blocks, u8 const rk2[], u8 iv[])
 	 * aes_xts_decrypt(u8 out[], u8 const in[], u8 const rk1[], int rounds,
-	 *		   int blocks, u8 const rk2[], u8 iv[], int first)
+	 *		   int blocks, u8 const rk2[], u8 iv[])
 	 */
 
 	.macro		next_tweak, out, in, const, tmp
@@ -538,7 +538,6 @@ ENDPROC(ce_aes_ctr_encrypt)
 
 ENTRY(ce_aes_xts_encrypt)
 	FRAME_PUSH
-	cbz		w7, .LxtsencloopNx
 
 	ld1		{v4.16b}, [x6]
 	enc_prepare	w3, x5, x6
@@ -603,6 +602,8 @@ ENTRY(ce_aes_xts_encrypt)
 	next_tweak	v4, v4, v7, v8
 	b		.Lxtsencloop
 .Lxtsencout:
+	next_tweak	v4, v4, v7, v8
+	st1		{v4.16b}, [x6], #16
 	FRAME_POP
 	ret
 ENDPROC(ce_aes_xts_encrypt)
@@ -610,7 +611,6 @@ ENDPROC(ce_aes_xts_encrypt)
 
 ENTRY(ce_aes_xts_decrypt)
 	FRAME_PUSH
-	cbz		w7, .LxtsdecloopNx
 
 	ld1		{v4.16b}, [x6]
 	enc_prepare	w3, x5, x6
@@ -676,5 +676,7 @@ ENTRY(ce_aes_xts_decrypt)
 	b		.Lxtsdecloop
 .Lxtsdecout:
 	FRAME_POP
+	next_tweak	v4, v4, v7, v8
+	st1		{v4.16b}, [x6], #16
 	ret
 ENDPROC(ce_aes_xts_decrypt)

--- a/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
@@ -97,6 +97,7 @@ int xts_encrypt(
 #endif
          symmetric_xts *xts)
 {
+   struct ltc_cipher_descriptor *desc;
    unsigned char PP[16], CC[16], T[16];
    unsigned long i, m, mo, lim;
    int           err;
@@ -116,29 +117,45 @@ int xts_encrypt(
    m  = ptlen >> 4;
    mo = ptlen & 15;
 
-	   /* must have at least one full block */
+   /* must have at least one full block */
    if (m == 0) {
       return CRYPT_INVALID_ARG;
    }
 
-   /* encrypt the tweak */
-   if ((err = cipher_descriptor[xts->cipher].ecb_encrypt(tweak, T, &xts->key2)) != CRYPT_OK) {
-      return err;
-   }
-
-   /* for i = 0 to m-2 do */
    if (mo == 0) {
       lim = m;
    } else {
       lim = m - 1;
    }
 
-   for (i = 0; i < lim; i++) {
-      err = tweak_crypt(pt, ct, T, xts);
-      ct += 16;
-      pt += 16;
+   desc = &cipher_descriptor[xts->cipher];
+
+   if (desc->accel_xts_encrypt && lim > 0) {
+
+      /* use accelerated encryption for whole blocks */
+      if ((err = desc->accel_xts_encrypt(pt, ct, lim, tweak, &xts->key1,
+					 &xts->key2) != CRYPT_OK)) {
+	 return err;
+      }
+      ct += lim * 16;
+      pt += lim * 16;
+
+      /* tweak is encrypted on output */
+      memcpy(T, tweak, sizeof(T));
+   } else {
+
+      /* encrypt the tweak */
+      if ((err = desc->ecb_encrypt(tweak, T, &xts->key2)) != CRYPT_OK) {
+	 return err;
+      }
+
+      for (i = 0; i < lim; i++) {
+	 err = tweak_crypt(pt, ct, T, xts);
+	 ct += 16;
+	 pt += 16;
+      }
    }
-   
+
    /* if ptlen not divide 16 then */
    if (mo > 0) {
       /* CC = tweak encrypt block m-1 */
@@ -164,7 +181,7 @@ int xts_encrypt(
 
 #ifdef LTC_LINARO_FIX_XTS
    /* Decrypt the tweak back */
-   if ((err = cipher_descriptor[xts->cipher].ecb_decrypt(T, tweak, &xts->key2)) != CRYPT_OK) {
+   if ((err = desc->ecb_decrypt(T, tweak, &xts->key2)) != CRYPT_OK) {
       return err;
    }
 #endif


### PR DESCRIPTION
This completes the work started with commit:
7e8f94166c6f ("arm64: AES using ARMv8-A cryptographic extensions").

The ltc_cipher_descriptor structure of LibTomCrypt is updated to include
pointers to accelerated XTS routines, which can handle multiple blocks
of data. The actual processing is done in assembly by
ce_aes_xts_encrypt() and ce_aes_xts_decrypt().

aes-perf results on HiKey are now on par with other AES modes.
In the table below, XTS is non-accelerated (CFG_CRYPTO_AES_ARM64_CE=n),
XTS+ is commit 7e8f94166c6f, and XTS++ is this commit.

Average encryption speed (MiB/s):

```
   Size |       Mode
  (KiB) |  XTS  XTS+  XTS++
  ------+------------------
      1 |  9.2  13.0   21.3
      2 | 11.7  18.3   41.4
      4 | 13.6  23.0   78.3
      8 | 14.7  26.3  141.4
     16 | 15.4  28.4  236.6
     32 | 15.8  29.6  362.2
     64 | 16.0  30.3  495.3
    128 | 16.1  30.6  605.8
```
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>