### PR TITLE
Correct the duplicate ssize_t typedef to exclude one when the other is defined.

### DIFF
--- a/lib/libutils/ext/include/types_ext.h
+++ b/lib/libutils/ext/include/types_ext.h
@@ -38,6 +38,9 @@ typedef uintptr_t vaddr_t;
 typedef uintptr_t paddr_t;
 #define PRIxPA	PRIxPTR
 
+#ifndef __ssize_t_defined
+#define __ssize_t_defined
 typedef intptr_t ssize_t;
+#endif
 
 #endif /* TYPES_EXT_H */

--- a/lib/libutils/isoc/include/unistd.h
+++ b/lib/libutils/isoc/include/unistd.h
@@ -30,7 +30,9 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#ifndef __ssize_t_defined
 #define __ssize_t_defined
 typedef int32_t ssize_t;
+#endif
 
 #endif


### PR DESCRIPTION
Correct the duplicate ssize_t typedef to exclude one when the other is  already defined.

Building OpenSSL as part of a TA results in both being included causing a build break.
The fix uses the existing definition that was present in one of the occurances.

Signed-off-by: Paul Swan <paswan@microsoft.com>
Reviewed-by: Youssef Esmat <Youssef.Esmat@microsoft.com>