### PR TITLE
Align __start_ta_head_section on 8-byte boundary

### DIFF
--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -125,7 +125,12 @@ SECTIONS
 #else
 		*(.rodata .rodata.*)
 
-		. = ALIGN(4);
+		/*
+		 * 8 to avoid unwanted padding between __start_ta_head_section
+		 * and the first structure in ta_head_section, in 64-bit
+		 * builds
+		 */
+		. = ALIGN(8);
 		__start_ta_head_section = . ;
 		KEEP(*(ta_head_section))
 		__stop_ta_head_section = . ;


### PR DESCRIPTION
Fixes an issue on 64-bit HiKey when running the self-tests of
https://github.com/OP-TEE/optee_os/pull/371. The tests would pass
when CFG_TEE_CORE_LOG_LEVEL=2 but fail with static TA not found
when log level is 3.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>