### PR TITLE
Build for PLATFORM=vexpress-qemu_virt by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ endif
 
 # Make these default for now
 ARCH            ?= arm
-PLATFORM        ?= stm
+PLATFORM        ?= vexpress
+PLATFORM_FLAVOR ?= qemu_virt
 O		?= out/$(ARCH)-plat-$(PLATFORM)
 
 arch_$(ARCH)	:= y

--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -1,8 +1,5 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_COMPILE	?= arm-linux-gnueabihf-
-COMPILER	?= gcc
-
 ifeq ($(CFG_ARM64_core),y)
 CFG_WITH_LPAE := y
 else

--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -1,8 +1,5 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_COMPILE	?= arm-linux-gnueabihf-
-COMPILER	?= gcc
-
 ifeq ($(CFG_ARM64_core),y)
 CFG_WITH_LPAE := y
 else

--- a/core/arch/arm/plat-stm/conf.mk
+++ b/core/arch/arm/plat-stm/conf.mk
@@ -1,8 +1,5 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_COMPILE	?= armv7-linux-
-COMPILER	?= gcc
-
 CFG_ARM32_core ?= y
 
 core-platform-cppflags	+= -I$(arch-dir)/include

--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -1,8 +1,5 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_COMPILE	?= arm-linux-gnueabihf-
-COMPILER	?= gcc
-
 CFG_ARM32_core ?= y
 CFG_NUM_THREADS ?= 4
 

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -1,8 +1,5 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_COMPILE	?= arm-linux-gnueabihf-
-COMPILER	?= gcc
-
 ifeq ($(CFG_ARM64_core),y)
 CFG_WITH_LPAE := y
 else

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -16,6 +16,10 @@
 # Actual values used during the build are output to $(out-dir)/core/conf.mk
 # (CFG_* variables only).
 
+# Cross-compiler prefix and suffix
+CROSS_COMPILE ?= arm-linux-gnueabihf-
+COMPILER ?= gcc
+
 # Compiler warning level.
 # Supported values: undefined, 1, 2 and 3. 3 gives more warnings.
 WARNS ?= 3


### PR DESCRIPTION
Also, for STM platforms, set CROSS_COMPILE=arm-linux-gnueabihf-
by default (which is a more standard prefix for the 32-bit
compiler).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>