### PR TITLE
Remove the duplicate definition of ssize_t

### DIFF
--- a/lib/libutils/ext/include/types_ext.h
+++ b/lib/libutils/ext/include/types_ext.h
@@ -31,13 +31,12 @@
 #include <stddef.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 typedef uintptr_t vaddr_t;
 #define PRIxVA	PRIxPTR
 
 typedef uintptr_t paddr_t;
 #define PRIxPA	PRIxPTR
-
-typedef intptr_t ssize_t;
 
 #endif /* TYPES_EXT_H */

--- a/lib/libutils/isoc/include/unistd.h
+++ b/lib/libutils/isoc/include/unistd.h
@@ -31,6 +31,6 @@
 #include <stddef.h>
 
 #define __ssize_t_defined
-typedef int32_t ssize_t;
+typedef intptr_t ssize_t;
 
 #endif


### PR DESCRIPTION
Remove the duplicate definition of ssize_t to instead use a single definition.

Building OpenSSL as part of a TA resulted in both being included causing a build break.

Signed-off-by: Paul Swan paswan@microsoft.com
Reviewed-by: Youssef Esmat Youssef.Esmat@microsoft.com