### PR TITLE
arm: imx: add i.MX 6UltraLite and EVK board support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,9 @@ script:
   # Mediatek mt8173 EVB
   - PLATFORM=mediatek  PLATFORM_FLAVOR=mt8173  CFG_ARM64_core=y  CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
 
+  # i.MX6UL 14X14 EVK
+  - PLATFORM=imx PLATFORM_FLAVOR=mx6ulevk make -j8 all -s
+
   # Texas Instruments dra7xx
   - PLATFORM=ti  PLATFORM_FLAVOR=dra7xx  make -j8 all -s
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     4. [Allwinner A80](#46-allwinner-a80)
     4. [Mediatek MT8173 EVB](#47-mediatek-mt8173-evb)
     4. [HiKey Board](#48-hikey-board)
+    4. [Freescale MX6UL EVK](#49-freescale-mx6ul-evk)
 5. [Coding standards](#5-coding-standards)
 	5. [checkpatch](#51-checkpatch)
 6. [repo manifests](#6-repo-manifests)
@@ -72,6 +73,7 @@ please read the file [build_system.md](documentation/build_system.md).
 | [MediaTek MT8173 EVB Board](http://www.mediatek.com/en/products/mobile-communications/tablet/mt8173/)|`PLATFORM=mediatek-mt8173`|
 | Texas Instruments DRA7xx|`PLATFORM=ti-dra7xx`|
 | [FSL ls1021a](http://www.freescale.com/tools/embedded-software-and-tools/hardware-development-tools/tower-development-boards/mcu-and-processor-modules/powerquicc-and-qoriq-modules/qoriq-ls1021a-tower-system-module:TWR-LS1021A?lang_cd=en)|`PLATFORM=ls-ls1021atwr`|
+| [FSL i.MX6 UltraLite EVK Board](http://www.freescale.com/products/arm-processors/i.mx-applications-processors-based-on-arm-cores/i.mx-6-processors/i.mx6qp/i.mx6ultralite-evaluation-kit:MCIMX6UL-EVK) |`PLATFORM=imx`|
 
 ### 3.1 Development board for community user
 For community users, we suggest using [Hikey board](https://www.96boards.org/products/ce/hikey/)
@@ -416,6 +418,26 @@ Edition compliant board equipped with a HiSilicon Kirin 620 SoC (8-core,
 64-bit ARM Cortex A53). It can run OP-TEE in 32- and 64-bit modes.
 
 To build for HiKey, please refer to [6. repo manifests](#6-repo-manifests).
+
+---
+### 4.9 Freescale MX6UL EVK
+Build:
+```
+    PLATFORM_FLAVOR=mx6ulevk make PLATFORM=imx
+    ${CROSS_COMPILE}-objcopy -O binary out/arm-plat-imx/core/tee.elf optee.bin
+    copy optee.bin to the first partition of SD card which is used for boot.
+```
+Run using uboot:
+```
+    run loadfdt;
+    run loadimage;
+    fatload mmc 1:1 0x9c100000 optee.bin;
+    run mmcargs;
+    bootz ${loadaddr} - ${fdt_addr};
+```
+
+Note:
+    CAAM is not implemented now, this will be added later.
 
 ## 5. Coding standards
 In this project we are trying to adhere to the same coding convention as used in

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -1,0 +1,29 @@
+include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
+
+CROSS_COMPILE	?= arm-linux-gnueabihf-
+COMPILER	?= gcc
+
+CFG_ARM32_core ?= y
+CFG_MMU_V7_TTB ?= y
+
+core-platform-cppflags	 = -I$(arch-dir)/include
+core-platform-subdirs += \
+	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
+core-platform-subdirs += $(arch-dir)/sm
+
+libutil_with_isoc := y
+CFG_GENERIC_BOOT ?= y
+CFG_IMX_UART ?= y
+CFG_MMU_V7_TTB ?= y
+CFG_NO_TA_HASH_SIGN ?= y
+CFG_PM_STUBS ?= y
+CFG_SECURE_TIME_SOURCE_CNTPCT := y
+CFG_WITH_SOFTWARE_PRNG ?= y
+CFG_WITH_STACK_CANARIES := y
+
+include mk/config.mk
+
+core-platform-cppflags += -D_USE_SLAPORT_LIB
+
+core-platform-cppflags += -DCFG_NO_TA_HASH_SIGN
+CFG_GIC := y

--- a/core/arch/arm/plat-imx/kern.ld.S
+++ b/core/arch/arm/plat-imx/kern.ld.S
@@ -1,0 +1,1 @@
+#include "../kernel/kern.ld.S"

--- a/core/arch/arm/plat-imx/link.mk
+++ b/core/arch/arm/plat-imx/link.mk
@@ -1,0 +1,1 @@
+include core/arch/arm/kernel/link.mk

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <console.h>
+#include <drivers/imx_uart.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/tee_pager.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/arch_svc.h>
+#include <tee/entry.h>
+
+static void main_fiq(void);
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry,
+	.fast_smc = tee_entry,
+	.fiq = main_fiq,
+	.svc = tee_svc_handler,
+	.abort = tee_pager_abort_handler,
+	.cpu_on = pm_panic,
+	.cpu_off = pm_panic,
+	.cpu_suspend = pm_panic,
+	.cpu_resume = pm_panic,
+	.system_off = pm_panic,
+	.system_reset = pm_panic,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+static void main_fiq(void)
+{
+	panic();
+}
+
+void console_init(void)
+{
+	imx_uart_init(CONSOLE_UART_BASE);
+}
+
+void console_putc(int ch)
+{
+	imx_uart_putc(ch, CONSOLE_UART_BASE);
+
+	/* If \n, also do \r */
+	if (ch == '\n')
+		imx_uart_putc('\r', CONSOLE_UART_BASE);
+}
+
+void console_flush(void)
+{
+	imx_uart_flush_tx_fifo(CONSOLE_UART_BASE);
+}

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#define PLATFORM_FLAVOR_ID_mx6ulevk	0
+#define PLATFORM_FLAVOR_IS(flav) \
+	(PLATFORM_FLAVOR_ID_ ## flav == PLATFORM_FLAVOR)
+
+#define STACK_ALIGNMENT			64
+
+#ifdef CFG_WITH_PAGER
+#error "Pager not supported for platform imx"
+#endif
+#ifdef CFG_WITH_LPAE
+#error "LPAE not supported for now"
+#endif
+
+/* For i.MX 6UltraLite EVK board */
+#if  PLATFORM_FLAVOR_IS(mx6ulevk)
+#define GIC_BASE			0xA00000
+#define GIC_SIZE			0x8000
+#define GICC_OFFSET			0x2000
+#define GICD_OFFSET			0x1000
+#define UART0_BASE			0x2020000
+#define UART1_BASE			0x21E8000
+#define UART2_BASE			0x21EC000
+
+#define AHB1_BASE			0x02000000
+#define AHB1_SIZE			0x100000
+#define AHB2_BASE			0x02100000
+#define AHB2_SIZE			0x100000
+#define AHB3_BASE			0x02200000
+#define AHB3_SIZE			0x100000
+
+#define AIPS_TZ1_BASE_ADDR		0x02000000
+#define AIPS1_OFF_BASE_ADDR             (AIPS_TZ1_BASE_ADDR + 0x80000)
+
+#define DRAM0_BASE			0x80000000
+#define DRAM0_SIZE			0x20000000
+
+#define CFG_TEE_CORE_NB_CORE		1
+
+#define DDR_PHYS_START			DRAM0_BASE
+#define DDR_SIZE			DRAM0_SIZE
+
+#define CFG_DDR_START			DDR_PHYS_START
+#define CFG_DDR_SIZE			DDR_SIZE
+
+#define CFG_SHMEM_START			(TZDRAM_BASE - 0x100000)
+#define CFG_SHMEM_SIZE			0x100000
+
+#else
+#error "Unknown platform flavor"
+#endif
+
+#define HEAP_SIZE			(24 * 1024)
+
+/* console uart define */
+#define CONSOLE_UART_BASE		UART0_BASE
+
+/* Location of trusted dram on imx */
+#define TZDRAM_BASE			(0x9c100000)
+#define TZDRAM_SIZE			(0x03000000)
+
+#define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
+
+#ifndef CFG_TEE_LOAD_ADDR
+#define CFG_TEE_LOAD_ADDR		CFG_TEE_RAM_START
+#endif
+
+/*
+ * Everything is in TZDRAM.
+ * +------------------+
+ * |        | TEE_RAM |
+ * + TZDRAM +---------+
+ * |        | TA_RAM  |
+ * +--------+---------+
+ */
+#define CFG_TEE_RAM_PH_SIZE	CFG_TEE_RAM_VA_SIZE
+#define CFG_TEE_RAM_START	TZDRAM_BASE
+#define CFG_TA_RAM_START	ROUNDUP((TZDRAM_BASE + CFG_TEE_RAM_VA_SIZE), \
+					CORE_MMU_DEVICE_SIZE)
+#define CFG_TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - CFG_TEE_RAM_VA_SIZE), \
+					  CORE_MMU_DEVICE_SIZE)
+
+#define DEVICE0_BASE		ROUNDDOWN(CONSOLE_UART_BASE, \
+					  CORE_MMU_DEVICE_SIZE)
+#define DEVICE0_SIZE		CORE_MMU_DEVICE_SIZE
+#define DEVICE0_TYPE		MEM_AREA_IO_NSEC
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-imx/platform_flags.mk
+++ b/core/arch/arm/plat-imx/platform_flags.mk
@@ -1,0 +1,25 @@
+platform-cpuarch = cortex-a7
+platform-cflags = -mcpu=$(platform-cpuarch) -mthumb
+platform-cflags += -pipe -mthumb-interwork -mlong-calls
+platform-cflags += -fno-short-enums -mno-apcs-float -fno-common
+platform-cflags += -mfloat-abi=soft
+platform-cflags += -mno-unaligned-access
+platform-aflags = -mcpu=$(platform-cpuarch)
+
+platform-cflags += -ffunction-sections -fdata-sections
+
+DEBUG ?= 1
+ifeq ($(DEBUG),1)
+platform-cflags += -O0
+else
+platform-cflags += -Os
+endif
+
+platform-cflags += -g
+platform-aflags += -g
+
+platform-cflags += -g3
+platform-aflags += -g3
+
+CFG_ARM32_user_ta := y
+user_ta-platform-cflags = -fpie

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <platform_config.h>
+
+#include <drivers/imx_uart.h>
+#include <console.h>
+#include <io.h>
+#include <assert.h>
+#include <compiler.h>
+
+/* Register definitions */
+#define URXD  0x0  /* Receiver Register */
+#define UTXD  0x40 /* Transmitter Register */
+#define UCR1  0x80 /* Control Register 1 */
+#define UCR2  0x84 /* Control Register 2 */
+#define UCR3  0x88 /* Control Register 3 */
+#define UCR4  0x8c /* Control Register 4 */
+#define UFCR  0x90 /* FIFO Control Register */
+#define USR1  0x94 /* Status Register 1 */
+#define USR2  0x98 /* Status Register 2 */
+#define UESC  0x9c /* Escape Character Register */
+#define UTIM  0xa0 /* Escape Timer Register */
+#define UBIR  0xa4 /* BRM Incremental Register */
+#define UBMR  0xa8 /* BRM Modulator Register */
+#define UBRC  0xac /* Baud Rate Count Register */
+#define UTS   0xb4 /* UART Test Register (mx31) */
+
+/* UART Control Register Bit Fields.*/
+#define  URXD_CHARRDY    (1<<15)
+#define  URXD_ERR        (1<<14)
+#define  URXD_OVRRUN     (1<<13)
+#define  URXD_FRMERR     (1<<12)
+#define  URXD_BRK        (1<<11)
+#define  URXD_PRERR      (1<<10)
+#define  URXD_RX_DATA    (0xFF)
+#define  UCR1_ADEN       (1<<15) /* Auto dectect interrupt */
+#define  UCR1_ADBR       (1<<14) /* Auto detect baud rate */
+#define  UCR1_TRDYEN     (1<<13) /* Transmitter ready interrupt enable */
+#define  UCR1_IDEN       (1<<12) /* Idle condition interrupt */
+#define  UCR1_RRDYEN     (1<<9)	 /* Recv ready interrupt enable */
+#define  UCR1_RDMAEN     (1<<8)	 /* Recv ready DMA enable */
+#define  UCR1_IREN       (1<<7)	 /* Infrared interface enable */
+#define  UCR1_TXMPTYEN   (1<<6)	 /* Transimitter empty interrupt enable */
+#define  UCR1_RTSDEN     (1<<5)	 /* RTS delta interrupt enable */
+#define  UCR1_SNDBRK     (1<<4)	 /* Send break */
+#define  UCR1_TDMAEN     (1<<3)	 /* Transmitter ready DMA enable */
+#define  UCR1_UARTCLKEN  (1<<2)	 /* UART clock enabled */
+#define  UCR1_DOZE       (1<<1)	 /* Doze */
+#define  UCR1_UARTEN     (1<<0)	 /* UART enabled */
+
+#define  UTS_FRCPERR	 (1<<13) /* Force parity error */
+#define  UTS_LOOP        (1<<12) /* Loop tx and rx */
+#define  UTS_TXEMPTY	 (1<<6)	 /* TxFIFO empty */
+#define  UTS_RXEMPTY	 (1<<5)	 /* RxFIFO empty */
+#define  UTS_TXFULL	 (1<<4)	 /* TxFIFO full */
+#define  UTS_RXFULL	 (1<<3)	 /* RxFIFO full */
+#define  UTS_SOFTRST	 (1<<0)	 /* Software reset */
+
+void imx_uart_init(vaddr_t __unused vbase)
+{
+	/*
+	 * Do nothing, debug uart(uart0) share with normal world,
+	 * everything for uart0 intialization is done in bootloader.
+	 */
+}
+
+void imx_uart_flush_tx_fifo(vaddr_t base)
+{
+	while (!(read32(base + UTS) & UTS_TXEMPTY))
+		;
+}
+
+int imx_uart_getchar(vaddr_t base)
+{
+	while (read32(base + UTS) & UTS_RXEMPTY)
+		;
+
+	return (read32(base + URXD) & URXD_RX_DATA);
+}
+
+void imx_uart_putc(const char c, vaddr_t base)
+{
+	write32(c, base + UTXD);
+
+	/* wait until sent */
+	while (!(read32(base + UTS) & UTS_TXEMPTY))
+		;
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -3,3 +3,4 @@ srcs-$(CFG_GIC) += gic.c
 srcs-$(CFG_SUNXI_UART) += sunxi_uart.c
 srcs-$(CFG_8250_UART) += serial8250_uart.c
 srcs-$(CFG_16550_UART) += ns16550.c
+srcs-$(CFG_IMX_UART) += imx_uart.c

--- a/core/include/drivers/imx_uart.h
+++ b/core/include/drivers/imx_uart.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef IMX_UART_H
+#define IMX_UART_H
+
+#include <types_ext.h>
+
+void imx_uart_init(vaddr_t base);
+
+void imx_uart_putc(const char ch, vaddr_t base);
+
+void imx_uart_flush_tx_fifo(vaddr_t base);
+
+bool imx_uart_have_rx_data(vaddr_t base);
+
+int imx_uart_getchar(vaddr_t base);
+
+#endif /* IMX_UART_H */


### PR DESCRIPTION
The i.MX 6UltraLite[1] is a high performance, ultra-efficient processor
family featuring an advanced implementation of a single ARM® Cortex®-A7
core.

This patch add i.MX 6Ulralite EVK board support:
1. Add a uart driver for i.MX platforms
2. Introduce plat-imx for i.MX platforms
3. Introduce i.MX6 UltraLite platform
4. This patch has been tested using the following step,
 4.1. build step:
   PLATFORM_FLAVOR=mx6ulevk make ARCH=arm PLATFORM=imx
   ${CROSS_COMPILE}-objcopy -O binary out/arm-plat-imx/core/tee.elf optee.bin
   copy optee.bin to the first partition of SD card which is used for boot.
 4.2. Boot setting in uboot:
   run loadfdt;
   run loadimage;
   fatload mmc 1:1 0x9c100000 optee.bin;
   run mmcargs;
   bootz ${loadaddr} - ${fdt_addr};

Note:
CAAM is not implemented now, this will be added later.

[1] http://www.freescale.com/webapp/sps/site/prod_summary.jsp?code=i.MX6UL&tid=redI.MX6UL-FAMILY&uc=true&lang_cd=en

Signed-off-by: Peng Fan <van.freenix@gmail.com>