### PR TITLE
arm: Update SHA-1 32-bit CE implementation to process multiple blocks

### DIFF
--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce.c
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce.c
@@ -60,36 +60,6 @@ const struct ltc_hash_descriptor sha1_desc =
     NULL
 };
 
-#if defined(LTC_SHA1_ARM32_CE)
-
-/* Implemented in assembly */
-int sha1_transform(ulong32 *state, unsigned char *buf);
-
-static int sha1_compress(hash_state *md, unsigned char *buf)
-{
-    struct tomcrypt_arm_neon_state state;
-
-    tomcrypt_arm_neon_enable(&state);
-    sha1_transform(md->sha1.state, buf);
-    tomcrypt_arm_neon_disable(&state);
-#ifdef LTC_CLEAN_STACK
-    burn_stack(sizeof(ulong32) * 87);
-#endif
-    return CRYPT_OK;
-}
-
-/**
-   Process a block of memory though the hash
-   @param md     The hash state
-   @param in     The data to hash
-   @param inlen  The length of the data (octets)
-   @return CRYPT_OK if successful
-*/
-HASH_PROCESS(sha1_process, sha1_compress, sha1, 64)
-
-#endif /* LTC_SHA1_ARM32_CE */
-
-#if defined(LTC_SHA1_ARM64_CE)
 
 /* Implemented in assembly */
 void sha1_ce_transform(ulong32 *state, unsigned char *src, int blocks);
@@ -120,9 +90,6 @@ static int sha1_compress(hash_state *md, unsigned char *buf)
    @return CRYPT_OK if successful
 */
 HASH_PROCESS_NBLOCKS(sha1_process, sha1_compress_nblocks, sha1, 64)
-
-#endif /* LTC_SHA1_ARM64_CE */
-
 
 /**
    Initialize the hash state

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
@@ -76,9 +76,9 @@
 	.word		0x8f1bbcdc, 0x8f1bbcdc, 0x8f1bbcdc, 0x8f1bbcdc
 	.word		0xca62c1d6, 0xca62c1d6, 0xca62c1d6, 0xca62c1d6
 
-	.global		sha1_transform
-	.type		sha1_transform, %function
-sha1_transform:
+	.global		sha1_ce_transform
+	.type		sha1_ce_transform, %function
+sha1_ce_transform:
 	/* load round constants */
 	adr		r3, .Lsha1_rcon
 	vld1.32		{k0-k1}, [r3]!
@@ -88,13 +88,14 @@ sha1_transform:
 	vld1.32		{dga}, [r0]
 	vldr		dgbs, [r0, #16]
 
-	/* load input */
+0:	/* load input */
 	vld1.8		{q8-q9}, [r1]!
 	vrev32.8	q8, q8
 	vrev32.8	q9, q9
 	vld1.8		{q10-q11}, [r1]
 	vrev32.8	q10, q10
 	vrev32.8	q11, q11
+	subs		r2, r2, #1
 
 	vadd.u32	ta0, q8, k0
 	vmov		dg0, dga
@@ -126,6 +127,7 @@ sha1_transform:
 	/* update state */
 	vadd.u32	dga, dga, dg0
 	vadd.u32	dgb, dgb, dg1a0
+	bne		0b
 
 	/* store new state */
 	vst1.32		{dga}, [r0]


### PR DESCRIPTION
This is some small refactoring to benefit from the HASH_PROCESS_NBLOCKS macro introduced in https://github.com/OP-TEE/optee_os/pull/418. As such please ignore the first two commits, they are from PR418.
