### PR TITLE
arm: Update SHA-256 32-bit CE implementation to process multiple blocks

### DIFF
--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
@@ -82,23 +82,24 @@
 	.word		0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208
 	.word		0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
 
-	.global		sha256_transform
-	.type		sha256_transform, %function
-sha256_transform:
-	/* load round constants */
-	adr		r3, .Lsha256_rcon
-	vld1.32		{k0}, [r3]!
-
+	.global		sha256_ce_transform
+	.type		sha256_ce_transform, %function
+sha256_ce_transform:
 	/* load state */
 	vld1.8		{dga-dgb}, [r0]
 
 	/* load input */
-	vld1.8		{q0-q1}, [r1]!
+0:	vld1.8		{q0-q1}, [r1]!
 	vrev32.8	q0, q0
 	vrev32.8	q1, q1
-	vld1.8		{q2-q3}, [r1]
+	vld1.8		{q2-q3}, [r1]!
 	vrev32.8	q2, q2
 	vrev32.8	q3, q3
+	subs            r2, r2, #1
+
+	/* load round constants */
+	adr		r3, .Lsha256_rcon
+	vld1.32		{k0}, [r3]!
 
 	vadd.u32	ta0, q0, k0
 	vmov		dg0, dga
@@ -125,6 +126,7 @@ sha256_transform:
 	/* update state */
 	vadd.u32	dga, dga, dg0
 	vadd.u32	dgb, dgb, dg1
+	bne		0b
 
 	/* store new state */
 	vst1.8		{dga-dgb}, [r0]

--- a/core/lib/libtomcrypt/src/hashes/sha2/sub.mk
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sub.mk
@@ -1,8 +1,8 @@
 srcs-$(CFG_CRYPTO_SHA224) += sha224.c
 
 ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
-srcs-y += sha256_arm32_ce.c
-srcs-y += sha256_arm32_ce_a32.S
+srcs-y += sha256_armv8a_ce.c
+srcs-y += sha256_armv8a_ce_a32.S
 else
 srcs-$(CFG_CRYPTO_SHA256) += sha256.c
 endif


### PR DESCRIPTION
~~The first two commits are from https://github.com/OP-TEE/optee_os/pull/418 so please focus on the last one.~~ Edit: PR rebased on latest master.