### PR TITLE
Align Session handle for generic ta interface entry

### DIFF
--- a/core/arch/arm/tee/entry.c
+++ b/core/arch/arm/tee/entry.c
@@ -206,7 +206,7 @@ static void entry_close_session(struct thread_smc_args *args,
 		struct tee_close_session_in in;
 		uint32_t ret;
 
-		in.sess = arg32->session;
+		in.sess = (TEE_Session *)(vaddr_t)arg32->session;
 		ret = tee_dispatch_close_session(&in);
 		if (ret == TEE_ERROR_SYSTEM_BUSY) {
 			args->a0 = TEESMC_RETURN_EBUSY;

--- a/core/include/kernel/tee_dispatch.h
+++ b/core/include/kernel/tee_dispatch.h
@@ -87,7 +87,7 @@ struct tee_dispatch_cancel_command_out {
 
 /* Input arg structure specific to TEE service 'close session'. */
 struct tee_close_session_in {
-	uint32_t sess;
+	TEE_Session *sess;
 };
 
 /* Input arg structure specific to TEE service 'register shared memory'. */

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -89,7 +89,7 @@ TEE_Result tee_ta_cancel_command(TEE_ErrorOrigin *err,
  * Returns:
  *        TEE_Result
  *---------------------------------------------------------------------------*/
-TEE_Result tee_ta_close_session(uint32_t id,
+TEE_Result tee_ta_close_session(struct tee_ta_session *sess,
 				struct tee_ta_session_head *open_sessions,
 				const TEE_Identity *clnt_id);
 

--- a/core/kernel/tee_dispatch.c
+++ b/core/kernel/tee_dispatch.c
@@ -143,8 +143,8 @@ TEE_Result tee_dispatch_close_session(struct tee_close_session_in *in)
 {
 	inject_entropy_with_timestamp();
 
-	return tee_ta_close_session(in->sess, &tee_open_sessions,
-				    NSAPP_IDENTITY);
+	return tee_ta_close_session((struct tee_ta_session *)in->sess,
+				    &tee_open_sessions, NSAPP_IDENTITY);
 }
 
 TEE_Result tee_dispatch_invoke_command(struct tee_dispatch_invoke_command_in *
@@ -153,7 +153,7 @@ TEE_Result tee_dispatch_invoke_command(struct tee_dispatch_invoke_command_in *
 				       out)
 {
 	struct tee_ta_param param;
-	struct tee_ta_session *sess; /*= (struct tee_ta_session *)arg->sess; */
+	struct tee_ta_session *sess;
 	TEE_Result res;
 	TEE_ErrorOrigin err = TEE_ORIGIN_TEE;
 

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -612,7 +612,8 @@ TEE_Result tee_svc_close_ta_session(TEE_TASessionHandle ta_sess)
 	memcpy(&clnt_id.uuid, &sess->ctx->head->uuid, sizeof(TEE_UUID));
 
 	tee_ta_set_current_session(NULL);
-	res = tee_ta_close_session((vaddr_t)ta_sess, &sess->ctx->open_sessions,
+	res = tee_ta_close_session((struct tee_ta_session *)ta_sess,
+			&sess->ctx->open_sessions,
 				   &clnt_id);
 	tee_ta_set_current_session(sess);
 	return res;


### PR DESCRIPTION
TEE session handle is now used by all tee_dispatch_xx
function. uint32_t type ID parameter has be removed for
the tee_dispatch_close_session() function.

Signed-off-by: Jean-Michel Delorme <jean-michel.delorme@st.com>
Reviewed-by: Pascal BRAND <pascal.brand@st.com>
Reviewed-by: Etienne CARRIERE <etienne.carriere@st.com>