### PR TITLE
arm: Fix SHA-1 with cryptographic extensions

### DIFF
--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
@@ -92,7 +92,7 @@ sha1_ce_transform:
 	vld1.8		{q8-q9}, [r1]!
 	vrev32.8	q8, q8
 	vrev32.8	q9, q9
-	vld1.8		{q10-q11}, [r1]
+	vld1.8		{q10-q11}, [r1]!
 	vrev32.8	q10, q10
 	vrev32.8	q11, q11
 	subs		r2, r2, #1


### PR DESCRIPTION
Commit 23900b599a98 ("arm: update SHA-1 32-bit CE implementation to
process multiple blocks") has introduced a regression on 32-bit
platforms when CFG_CRYPTO_SHA1_ARM32_CE=y. Test case: xtest 4006.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>