### PR TITLE
Add 'make check' target to run xtest in QEMU, use it in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ notifications:
 
 sudo: false
 
-# Install the cross compiler
+cache: ccache
+
 before_install:
+  # Install the cross compilers
   - wget http://releases.linaro.org/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
   - tar xf gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
   - export PATH=${PWD}/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf/bin:${PATH}
@@ -26,6 +28,25 @@ before_script:
   - export DST_KERNEL=$PWD/linux && mkdir -p $DST_KERNEL/scripts && cd $DST_KERNEL/scripts
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl && chmod a+x checkpatch.pl
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+  - cd $MYHOME
+
+  # Tools required for 'make check'
+  # 'apt-get install' cannot be used in the new container-based infrastructure
+  # (which is the only allowing caching), so we just build from sources
+  # bc
+  - cd $HOME
+  - wget http://ftp.gnu.org/gnu/bc/bc-1.06.tar.gz
+  - tar xf bc-1.06.tar.gz
+  - (cd bc-1.06 && CC="ccache gcc" ./configure --quiet && make -j4)
+  - export PATH=${HOME}/bc-1.06/bc:$PATH
+  # Tcl/Expect
+  - wget http://prdownloads.sourceforge.net/tcl/tcl8.6.4-src.tar.gz
+  - tar xf tcl8.6.4-src.tar.gz
+  - (cd tcl8.6.4/unix && ./configure --quiet --prefix=${HOME}/inst CC="ccache gcc" && make -j4 install)
+  - wget http://sourceforge.net/projects/expect/files/Expect/5.45/expect5.45.tar.gz/download -O expect5.45.tar.gz
+  - tar xf expect5.45.tar.gz
+  - (cd expect5.45 && ./configure --quiet --with-tcl=${HOME}/inst/lib --prefix=${HOME}/inst CC="ccache gcc" && make -j4 expect && make -j4 install)
+  - export PATH=${HOME}/inst/bin:$PATH
   - cd $MYHOME
 
 # Several compilation options are checked
@@ -88,3 +109,6 @@ script:
 
   # Mediatek mt8173 EVB
   - PLATFORM=mediatek  PLATFORM_FLAVOR=mt8173  CFG_ARM64_core=y  CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+
+  # Run regression tests in QEMU
+  - make -j8 check CROSS_COMPILE="ccache arm-linux-gnueabihf-" DUMP_LOGS_ON_ERROR=1

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ include core/core.mk
 
 include ta/ta.mk
 
+include mk/check.mk
+
 .PHONY: clean
 clean:
 	@$(cmd-echo-silent) '  CLEAN   .'

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -1,0 +1,251 @@
+# This file implements the following targets:
+#
+# 'make check'           -- fetch, build and run tests in QEMU environment
+# 'make check-only'      -- only run tests (don't go through dependency checks)
+# 'make clean-check'     -- delete build files
+# 'make distclean-check' -- delete all files related to 'make check',
+#                           including cloned repositories
+
+# Everything is stored under this directory (Git repositories, build output)
+checkdir := $(out-dir)/check
+abscheckdir := $(abspath $(checkdir))
+
+topdir := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+
+# Clone a branch of a Git repostory. Limit depth to reduce download size.
+# $(call clone,<repo_url>,<dest_dir>[,<branch_or_tag_name>])
+define clone
+	@$(cmd-echo-silent) '  CLONE   $(2)'
+	${q}git clone -q -b $(if $(3),$(3),master) --depth=1 $(1) $(2)
+endef
+
+$(checkdir):
+	@$(cmd-echo-silent) '  MKDIR   $@'
+	${q}mkdir -p $@
+
+$(checkdir)/optee_os: | $(checkdir)
+	@$(cmd-echo-silent) '  LN      $@'
+	${q}ln -s $(topdir) $@
+
+$(checkdir)/optee_linuxdriver: | $(checkdir)
+	$(call clone,https://github.com/OP-TEE/optee_linuxdriver,$@)
+
+$(checkdir)/optee_client: | $(checkdir)
+	$(call clone,https://github.com/OP-TEE/optee_client,$@)
+
+$(checkdir)/optee_test: | $(checkdir)
+	$(call clone,https://github.com/OP-TEE/optee_test,$@)
+
+$(checkdir)/busybox: | $(checkdir)
+	$(call clone,git://busybox.net/busybox.git,$@)
+
+$(checkdir)/linux: | $(checkdir)
+	$(call clone,https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git,$@)
+
+$(checkdir)/gen_rootfs: | $(checkdir)
+	$(call clone,https://github.com/linaro-swg/gen_rootfs.git,$@,optee-make-check-qemu)
+
+$(checkdir)/bios_qemu_tz_arm: | $(checkdir)
+	$(call clone,https://github.com/linaro-swg/bios_qemu_tz_arm.git,$@)
+
+$(checkdir)/qemu: | $(checkdir)
+	$(call clone,https://github.com/linaro-swg/qemu.git,$@,pmm.v6.uart)
+	@$(cmd-echo-silent) '  CHK     /usr/include/libfdt.h'
+	${q}[ -e /usr/include/libfdt.h ] || \
+		(cd $(checkdir)/qemu ; \
+		 $(cmd-echo-silent) '  CLONE   qemu/dtc' ; \
+		 git submodule update --init dtc)
+
+check-args := --bios $(abscheckdir)/out/bios-qemu/bios.bin
+ifneq ($(TIMEOUT),)
+check-args += --timeout $(TIMEOUT)
+endif
+
+define check-command
+cd $(checkdir) && PATH=$(abscheckdir)/qemu/arm-softmmu:$(PATH) \
+	expect $(topdir)/mk/qemu-check.exp -- $(check-args) || \
+	(if [ "$(DUMP_LOGS_ON_ERROR)" ]; then \
+		echo "== $(abscheckdir)/serial0.log:"; \
+		cat $(abscheckdir)/serial0.log; \
+		echo "== end of $(abscheckdir)/serial0.log:"; \
+		echo "== $(abscheckdir)/serial1.log:"; \
+		cat $(abscheckdir)/serial1.log; \
+		echo "== end of $(abscheckdir)/serial1.log:"; \
+	fi; false)
+endef
+
+check: chk-bios-qemu $(checkdir)/qemu/arm-softmmu/qemu-system-arm
+	$(check-command)
+
+check-only:
+	$(check-command)
+
+# FIXME: the xtest-clean target of build/qemu.mk fails if optee_os
+# has been cleaned already (because te_dev_kit.mk is no longer accessible)
+clean-optee-test:
+	@$(cmd-echo-silent) '  CLEAN   $(checkdir)/out/optee_test'
+	${q}rm -rf $(checkdir)/out/optee_test
+
+clean-check: chk-bios-qemu-clean chk-busybox-clean chk-linux-clean \
+	chk-optee-client-clean chk-optee-linuxdriver-clean chk-optee-os-clean \
+	chk-qemu-clean chk-xtest-clean
+	@$(cmd-echo-silent) '  RM      $(chk-cleanfiles)'
+	${q}rm -f $(chk-cleanfiles)
+
+distclean-check:
+	@$(cmd-echo-silent) '  DISTCL  $(checkdir)'
+	${q}rm -rf $(checkdir)
+
+#
+# Build targets
+#
+
+chk-optee-os: $(checkdir)/optee_os
+	$(MAKE) -C $(checkdir)/optee_os
+
+chk-optee-os-clean:
+	$(MAKE) -C $(checkdir)/optee_os clean
+
+chk-optee-client: $(checkdir)/optee_client
+	$(MAKE) -C $(checkdir)/optee_client
+
+chk-optee-client-clean:
+	$(MAKE) -C $(checkdir)/optee_client clean
+
+define make-linux
+$(MAKE) -C $(checkdir)/linux ARCH=arm LOCALVERSION=
+endef
+
+define make-linux-modules
+$(make-linux) M=$(abscheckdir)/optee_linuxdriver
+endef
+
+chk-optee-linuxdriver: $(checkdir)/optee_linuxdriver chk-linux
+	+$(make-linux-modules) modules
+
+chk-optee-linuxdriver-clean:
+	+$(make-linux-modules) clean
+
+chk-linux: $(checkdir)/linux/.config
+	+$(make-linux)
+
+chk-linux-clean:
+	+$(make-linux) clean
+
+# Note: with kernel 4.1-rc1 this generates warnings for 4 symbols:
+# 'Value requested for CONFIG_... not in final .config'
+# It looks like they're all obsolete (not used in KConfig's) so we should
+# be safe
+$(checkdir)/linux/.config: $(checkdir)/linux $(checkdir)/dmabuf.conf
+	@$(cmd-echo-silent) '  GEN     $@'
+	${q}cd $(checkdir)/linux && ARCH=arm scripts/kconfig/merge_config.sh \
+		arch/arm/configs/vexpress_defconfig \
+		$(abscheckdir)/dmabuf.conf
+
+chk-cleanfiles += $(checkdir)/linux/.config
+
+$(checkdir)/dmabuf.conf: | $(checkdir)
+	@$(cmd-echo-silent) '  GEN     $@'
+	${q}echo '# DMA_SHARED_BUFFER cannot be enabled alone' >$@
+	${q}echo '# DRM will force it' >>$@
+	${q}echo 'CONFIG_DRM=y' >>$@
+
+chk-cleanfiles += $(checkdir)/dmabuf.conf
+
+define make-xtest
+$(MAKE) -C $(checkdir)/optee_test \
+	CROSS_COMPILE_HOST="$(CROSS_COMPILE)" \
+	CROSS_COMPILE_TA="$(CROSS_COMPILE)" \
+	TA_DEV_KIT_DIR=$(abscheckdir)/optee_os/out/arm-plat-vexpress/export-user_ta \
+	CFG_ARM32=y \
+	CFG_DEV_PATH=$(abscheckdir) \
+	O=$(abscheckdir)/out/optee_test
+endef
+
+chk-xtest: $(checkdir)/optee_test chk-optee-os chk-optee-client
+	+$(make-xtest)
+
+chk-xtest-clean:
+	@$(cmd-echo-silent) '  RM      $(checkdir)/out/optee_test'
+	${q}rm -rf $(checkdir)/out/optee_test
+
+define kernel-version
+$(shell $(make-linux) --no-print-directory kernelversion)
+endef
+
+$(checkdir)/gen_rootfs/filelist-tee.txt: chk-xtest chk-optee-linuxdriver
+	@$(cmd-echo-silent) '  GEN     $@'
+	${q}echo "# xtest / optee_test" >$@
+	${q}find $(abscheckdir)/out/optee_test -type f -name "xtest" | sed 's/\(.*\)/file \/bin\/xtest \1 755 0 0/g' >>$@
+	${q}echo "# TAs" >>$@
+	${q}echo "dir /lib/optee_armtz 755 0 0" >>$@
+	${q}find $(abscheckdir)/out/optee_test -name "*.ta" | \
+	        sed 's/\(.*\)\/\(.*\)/file \/lib\/optee_armtz\/\2 \1\/\2 444 0 0/g' >>$@
+	${q}echo "# Secure storage dig" >>$@
+	${q}echo "dir /data 755 0 0" >>$@
+	${q}echo "dir /data/tee 755 0 0" >>$@
+	${q}echo "# OP-TEE device" >>$@
+	${q}echo "dir /lib/modules 755 0 0" >>$@
+	${q}echo "dir /lib/modules/$(kernel-version) 755 0 0" >>$@
+	${q}echo "file /lib/modules/$(kernel-version)/optee.ko $(abscheckdir)/optee_linuxdriver/core/optee.ko 755 0 0" >>$@
+	${q}echo "file /lib/modules/$(kernel-version)/optee_armtz.ko $(abscheckdir)/optee_linuxdriver/armtz/optee_armtz.ko 755 0 0" >>$@
+	${q}echo "# OP-TEE Client" >>$@
+	${q}echo "file /bin/tee-supplicant $(abscheckdir)/optee_client/out/export/bin/tee-supplicant 755 0 0" >>$@
+	${q}echo "dir /lib/arm-linux-gnueabihf 755 0 0" >>$@
+	${q}echo "file /lib/arm-linux-gnueabihf/libteec.so.1.0 $(abscheckdir)/optee_client/out/export/lib/libteec.so.1.0 755 0 0" >>$@
+	${q}echo "slink /lib/arm-linux-gnueabihf/libteec.so.1 libteec.so.1.0 755 0 0" >>$@
+	${q}echo "slink /lib/arm-linux-gnueabihf/libteec.so libteec.so.1 755 0 0" >>$@
+
+$(checkdir)/gen_rootfs/filelist.tmp: chk-busybox $(checkdir)/gen_rootfs/filelist-tee.txt
+	@$(cmd-echo-silent) '  GEN     $@'
+	${q}cd $(checkdir)/gen_rootfs && cat filelist-final.txt filelist-tee.txt >filelist.tmp
+
+
+$(checkdir)/gen_rootfs/filesystem.cpio.gz: $(checkdir)/gen_rootfs/filelist.tmp chk-optee-client
+	@$(cmd-echo-silent) '  GEN     $@'
+	${q}(cd $(checkdir)/gen_rootfs && \
+		../linux/usr/gen_init_cpio $(abscheckdir)/gen_rootfs/filelist.tmp) \
+		| gzip >$@
+
+define busybox-env
+CROSS_COMPILE="$(CROSS_COMPILE)" \
+	CFLAGS="-Wno-strict-aliasing -Wno-unused-result \
+		-marm -mabi=aapcs-linux -mthumb \
+		-mthumb-interwork -mcpu=cortex-a15" \
+	PATH=$(PATH):$(abscheckdir)/linux/usr
+endef
+
+chk-busybox: $(checkdir)/gen_rootfs $(checkdir)/busybox chk-linux
+	${q}cd $(checkdir)/gen_rootfs && \
+		$(busybox-env) \
+		./generate-cpio-rootfs.sh vexpress
+
+chk-busybox-clean:
+	${q}cd $(checkdir)/gen_rootfs && \
+		$(busybox-env) \
+		./generate-cpio-rootfs.sh vexpress clean
+
+define make-bios-qemu
+$(MAKE) -C $(checkdir)/bios_qemu_tz_arm O=$(abscheckdir)/out/bios-qemu \
+	BIOS_NSEC_BLOB=$(abscheckdir)/linux/arch/arm/boot/zImage \
+	BIOS_NSEC_ROOTFS=$(abscheckdir)/gen_rootfs/filesystem.cpio.gz \
+	BIOS_SECURE_BLOB=$(abscheckdir)/optee_os/out/arm-plat-vexpress/core/tee.bin \
+	PLATFORM_FLAVOR=virt
+endef
+
+chk-bios-qemu: $(checkdir)/bios_qemu_tz_arm chk-optee-os $(checkdir)/gen_rootfs/filesystem.cpio.gz
+	+$(make-bios-qemu)
+
+chk-bios-qemu-clean:
+	+$(make-bios-qemu) clean
+
+$(checkdir)/qemu/arm-softmmu/qemu-system-arm: $(checkdir)/qemu/Makefile
+	$(MAKE) -C $(checkdir)/qemu
+
+$(checkdir)/qemu/Makefile: $(checkdir)/qemu
+	@$(cmd-echo-silent) '  GEN     $@'
+	${q}cd $(checkdir)/qemu && ./configure --target-list=arm-softmmu --cc="$(CCACHE)gcc"
+
+chk-qemu-clean:
+	$(MAKE) -C $(checkdir)/qemu clean
+

--- a/mk/qemu-check.exp
+++ b/mk/qemu-check.exp
@@ -1,0 +1,100 @@
+#!/usr/bin/expect -f
+#
+# This scripts starts QEMU, loads and boots Linux/OP-TEE, then runs
+# xtest in the guest. The return code is 0 for success, >0 for error.
+#
+# Options:
+#   --bios    Path to the binary to be run [../out/bios-qemu/bios.bin]
+#   -q        Suppress output to stdout (quiet)
+#   --timeout Timeout for each test (sub)case, in seconds [480]
+
+set bios "../out/bios-qemu/bios.bin"
+set cmd "xtest"
+set quiet 0
+
+# The time required to run some tests (e.g., key generation tests [4007.*])
+# can be significant and vary widely -- typically, from about one minute to
+# several minutes depending on the host machine.
+set timeout 480
+
+# Parse command line
+set myargs $argv
+while {[llength $myargs]} {
+	set myargs [lassign $myargs arg]
+	switch -exact -- $arg {
+		"--bios"	{set myargs [lassign $myargs ::bios]}
+		"--timeout"	{set myargs [lassign $myargs ::timeout]}
+		"-q"		{set ::quiet 1}
+	}
+}
+
+proc info arg {
+	if {$::quiet==1} { return }
+	puts -nonewline $arg
+	flush stdout
+}
+
+# Disable echoing of guest output
+log_user 0
+# Save guest console output to a file
+log_file -a -noappend "serial0.log"
+info "Starting QEMU..."
+spawn qemu-system-arm -nographic -monitor none -machine virt -cpu cortex-a15 -m 1057 -serial stdio -serial file:serial1.log -bios $bios
+expect "Freeing unused kernel memory"
+#expect "Please press Enter to activate this console. "
+send -- "\r"
+expect "root@Vexpress:/ "
+info " done, guest is booted.\nLoading OP-TEE driver and tee-supplicant..."
+# FIXME: this should not be needed, but for some reason tee-supplicant
+# (or xtest) will not load on the Travis server without this. I failed
+# to reproduce the issue on my PC ; is it due to the use of different
+# toolchains?
+send -- "export LD_LIBRARY_PATH=/lib:/lib/arm-linux-gnueabihf\r"
+expect "root@Vexpress:/ "
+send -- "modprobe optee_armtz\r"
+expect "root@Vexpress:/ "
+sleep 1
+send -- "tee-supplicant&\r"
+expect "root@Vexpress:/ "
+sleep 1
+info " done.\nRunning: $cmd...\n"
+send -- "$cmd\r"
+set casenum "none"
+expect {
+	# Exit with error status as soon as a test fails
+	-re {  XTEST_TEE_([^ ]+) FAIL} {
+		info " $expect_out(1,string) FAIL\n"
+		exit 1
+	}
+	-re {rcu_sched detected stalls} {
+		info " Kernel error: '$expect_out(0,string)'\n"
+		exit 1
+	}
+	# Crude progress indicator: print one # when each test [sub]case starts
+	-re {([\*o]) XTEST_TEE_([^ ]+) } {
+		set casenum $expect_out(2,string)
+		if {$expect_out(1,string) == "o"} {
+			if {$star == 1} {
+				# Do not count first subcase ('o') since start
+				# of test ('*') was counted already
+				set star 0
+				exp_continue
+			}
+		} else {
+			set star 1
+		}
+		info "#"
+		incr ncases
+		if {$ncases % 50 == 0} { info "\n" }
+		exp_continue
+	}
+	# Exit when result separator is seen
+	"+-----------------------------------------------------\r\r" {}
+	timeout {
+		info "!!! Timeout\n"
+		info "TIMEOUT - test case too long or hung? (last test started: $casenum)\n"
+		exit 2
+	}
+}
+info "\nStatus: PASS ($ncases test cases)\n"
+


### PR DESCRIPTION
```
This is a RFC (request for comments) pull request that I am submitting
as I am about to leave for a 1-week vacation ;-)
I got this finally working today, so I decided to share. Please let me
know if you think it is the good approach, or if we should do things
differently maybe. Here is what this does.

The check target clones a number of Git repositories under
$(outdir)/check and builds a bootable image containing Linux, OP-TEE
and xtest. Then it runs it in QEMU and reports a pass/fail status.

The Travis configuration file is updated to run "make check" each time
it is invoked. Since it is time-consuming (see below), we may want to
check only pull requests and/or branches that match a given pattern,
TBD.

The "make check" step adds about 12 minutes to the Travis run when
ccache is correctly populated (which should be the case most of the
time, because Travis preserves the cache content between builds).
Add this to the time it takes to run the usual build tests, and the
complete sequence takes 20 minutes, approximately.

Some tools that are required for "make check" are unfortunately not
available in the Travis container infrastructure, which is needed to
enable ccache. Since apt-get is not allowed in that environment, we
have to build the tools from sources: bc, Tcl, Expect.

Note: I have chosen to include the build recipes for the various
projects in mk/check.mk, and also to import the Expect script as
mk/qemu-check.mk rather than use the external 'build' project
(https://github.com/OP-TEE/build). I think it may be easier to
maintain that way.

Note 2: "make check" sometimes fails with Expect error
'send: spawn id exp7 not open' as the kernel is booting, and we are
waiting for the shell prompt to come up (or just after that).
I have not yet investigated this issue.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```