### PR TITLE
Fix leaking information from mem_neq

### DIFF
--- a/core/lib/libtomcrypt/src/misc/mem_neq.c
+++ b/core/lib/libtomcrypt/src/misc/mem_neq.c
@@ -74,6 +74,11 @@ int mem_neq(const void *a, const void *b, size_t len)
       ++pb;
    }
 
+   ret |= ret >> 4;
+   ret |= ret >> 2;
+   ret |= ret >> 1;
+   ret &= 1;
+
    return ret;
 }
 

--- a/lib/libutils/ext/buf_compare_ct.c
+++ b/lib/libutils/ext/buf_compare_ct.c
@@ -38,5 +38,10 @@ int buf_compare_ct(const void *s1, const void *s2, size_t n)
 		c2++;
 	}
 
+	res |= res >> 4;
+	res |= res >> 2;
+	res |= res >> 1;
+	res &= 1;
+
 	return res;
 }


### PR DESCRIPTION
This fix comes from https://github.com/libtom/libtomcrypt/issues/74
    mem_neq is a constant time comparison function, but it leaks information
    on the secret data that is being compared in the value that is returned.

Signed-off-by: Pascal Brand <pascal.brand@st.com>