### PR TITLE
libtomcrypt: sync ccm code

### DIFF
--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
@@ -53,6 +53,9 @@ int ccm_add_aad(ccm_state *ccm,
    unsigned long y;
    int            err;
 
+   LTC_ARGCHK(ccm   != NULL);
+   LTC_ARGCHK(adata != NULL);
+
    if (ccm->aadlen < ccm->current_aadlen + adatalen) {
       return CRYPT_INVALID_ARG;
    }

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
@@ -53,6 +53,9 @@ int ccm_add_nonce(ccm_state *ccm,
    unsigned long x, y, len;
    int           err;
 
+   LTC_ARGCHK(ccm   != NULL);
+   LTC_ARGCHK(nonce != NULL);
+
    /* increase L to match the nonce len */
    ccm->noncelen = (noncelen > 13) ? 13 : noncelen;
    if ((15 - ccm->noncelen) > ccm->L) {

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
@@ -53,6 +53,8 @@ int ccm_done(ccm_state *ccm,
    unsigned long x, y;
    int            err;
 
+   LTC_ARGCHK(ccm != NULL);
+
    /* Check all data have been processed */
    if (ccm->ptlen != ccm->current_ptlen) {
       return CRYPT_ERROR;

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
@@ -57,10 +57,11 @@ int ccm_init(ccm_state *ccm, int cipher,
 {
    int            err;
 
+   LTC_ARGCHK(ccm    != NULL);
    LTC_ARGCHK(key    != NULL);
    LTC_ARGCHK(taglen != 0);
 
-   memset(ccm, 0, sizeof(ccm_state));
+   XMEMSET(ccm, 0, sizeof(ccm_state));
 
    /* check cipher input */
    if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_memory.c
@@ -46,6 +46,9 @@
 
 /**
    CCM encrypt/decrypt and produce an authentication tag
+
+     *1 'pt', 'ct' and 'tag' can both be 'in' or 'out', depending on 'direction'
+
    @param cipher     The index of the cipher desired
    @param key        The secret key to use
    @param keylen     The length of the secret key (octets)
@@ -54,11 +57,11 @@
    @param noncelen   The length of the nonce
    @param header     The header for the session
    @param headerlen  The length of the header (octets)
-   @param pt         [out] The plaintext
+   @param pt         [*1] The plaintext
    @param ptlen      The length of the plaintext (octets)
-   @param ct         [out] The ciphertext
-   @param tag        [out] The destination tag
-   @param taglen     [in/out] The max size and resulting size of the authentication tag
+   @param ct         [*1] The ciphertext
+   @param tag        [*1] The destination tag
+   @param taglen     The max size and resulting size of the authentication tag
    @param direction  Encrypt or Decrypt direction (0 or 1)
    @return CRYPT_OK if successful
 */
@@ -72,10 +75,15 @@ int ccm_memory(int cipher,
           unsigned char *tag,    unsigned long *taglen,
                     int  direction)
 {
-   unsigned char  PAD[16], ctr[16], CTRPAD[16], b;
+   unsigned char  PAD[16], ctr[16], CTRPAD[16], ptTag[16], b, *pt_real;
+   unsigned char *pt_work = NULL;
    symmetric_key *skey;
    int            err;
    unsigned long  len, L, x, y, z, CTRlen;
+#ifdef LTC_FAST
+   LTC_FAST_TYPE fastMask = -1; /* initialize fastMask at all zeroes */
+#endif
+   unsigned char mask = 0xff; /* initialize mask at all zeroes */
 
    if (uskey == NULL) {
       LTC_ARGCHK(key    != NULL);
@@ -88,6 +96,8 @@ int ccm_memory(int cipher,
    LTC_ARGCHK(ct     != NULL);
    LTC_ARGCHK(tag    != NULL);
    LTC_ARGCHK(taglen != NULL);
+
+   pt_real = pt;
 
 #ifdef LTC_FAST
    if (16 % sizeof(LTC_FAST_TYPE)) {
@@ -122,7 +132,7 @@ int ccm_memory(int cipher,
            nonce,  noncelen,
            header, headerlen,
            pt,     ptlen,
-           ct, 
+           ct,
            tag,    taglen,
            direction);
    }
@@ -164,6 +174,15 @@ int ccm_memory(int cipher,
    } else {
       skey = uskey;
    }
+   
+   /* initialize buffer for pt */
+   if (direction == CCM_DECRYPT) {
+      pt_work = XMALLOC(ptlen);
+      if (pt_work == NULL) {
+         goto error;
+      }
+      pt = pt_work;
+   }
 
    /* form B_0 == flags | Nonce N | l(m) */
    x = 0;
@@ -201,7 +220,7 @@ int ccm_memory(int cipher,
    /* handle header */
    if (headerlen > 0) {
       x = 0;
-      
+
       /* store length */
       if (headerlen < ((1UL<<16) - (1UL<<8))) {
          PAD[x++] ^= (headerlen>>8) & 255;
@@ -227,11 +246,9 @@ int ccm_memory(int cipher,
           PAD[x++] ^= header[y];
       }
 
-      /* remainder? */
-      if (x != 0) {
-         if ((err = cipher_descriptor[cipher].ecb_encrypt(PAD, PAD, skey)) != CRYPT_OK) {
-            goto error;
-         }
+      /* remainder */
+      if ((err = cipher_descriptor[cipher].ecb_encrypt(PAD, PAD, skey)) != CRYPT_OK) {
+         goto error;
       }
    }
 
@@ -240,7 +257,7 @@ int ccm_memory(int cipher,
 
    /* flags */
    ctr[x++] = (unsigned char)L-1;
- 
+
    /* nonce */
    for (y = 0; y < (16 - (L+1)); ++y) {
       ctr[x++] = nonce[y];
@@ -278,7 +295,7 @@ int ccm_memory(int cipher,
                    goto error;
                 }
              }
-         } else {
+          } else { /* direction == CCM_DECRYPT */
              for (; y < (ptlen & ~15); y += 16) {
                 /* increment the ctr? */
                 for (z = 15; z > 15-L; z--) {
@@ -332,7 +349,7 @@ int ccm_memory(int cipher,
           }
           PAD[x++] ^= b;
       }
-             
+
       if (x != 0) {
          if ((err = cipher_descriptor[cipher].ecb_encrypt(PAD, PAD, skey)) != CRYPT_OK) {
             goto error;
@@ -352,18 +369,60 @@ int ccm_memory(int cipher,
       cipher_descriptor[cipher].done(skey);
    }
 
-   /* store the TAG */
-   for (x = 0; x < 16 && x < *taglen; x++) {
-       tag[x] = PAD[x] ^ CTRPAD[x];
+   if (direction == CCM_ENCRYPT) {
+      /* store the TAG */
+      for (x = 0; x < 16 && x < *taglen; x++) {
+          tag[x] = PAD[x] ^ CTRPAD[x];
+      }
+      *taglen = x;
+   } else { /* direction == CCM_DECRYPT */
+      /* decrypt the tag */
+      for (x = 0; x < 16 && x < *taglen; x++) {
+         ptTag[x] = tag[x] ^ CTRPAD[x];
+      }
+      *taglen = x;
+
+      /* check validity of the decrypted tag against the computed PAD (in constant time) */
+      /* HACK: the boolean value of XMEM_NEQ becomes either 0 (CRYPT_OK) or 1 (CRYPT_ERR).
+       *       there should be a better way of setting the correct error code in constant
+       *       time.
+       */
+      err = XMEM_NEQ(ptTag, PAD, *taglen);
+
+      /* Zero the plaintext if the tag was invalid (in constant time) */
+      if (ptlen > 0) {
+         y = 0;
+         mask *= 1 - err; /* mask = ( err ? 0 : 0xff ) */
+#ifdef LTC_FAST
+         fastMask *= 1 - err;
+         if (ptlen & ~15) {
+            for (; y < (ptlen & ~15); y += 16) {
+              for (z = 0; z < 16; z += sizeof(LTC_FAST_TYPE)) {
+                *((LTC_FAST_TYPE*)(&pt_real[y+z])) = *((LTC_FAST_TYPE*)(&pt[y+z])) & fastMask;
+              }
+            }
+         }
+#endif
+         for (; y < ptlen; y++) {
+            pt_real[y] = pt[y] & mask;
+         }
+      }
    }
-   *taglen = x;
 
 #ifdef LTC_CLEAN_STACK
+   fastMask = 0;
+   mask = 0;
    zeromem(skey,   sizeof(*skey));
    zeromem(PAD,    sizeof(PAD));
    zeromem(CTRPAD, sizeof(CTRPAD));
+   if (pt_work != NULL) {
+     zeromem(pt_work, ptlen);
+   }
 #endif
 error:
+   if (pt_work) {
+      XFREE(pt_work);
+   }
    if (skey != uskey) {
       XFREE(skey);
    }
@@ -373,6 +432,6 @@ error:
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/encauth/ccm/ccm_memory.c,v $ */
-/* $Revision: 1.20 $ */
-/* $Date: 2007/05/12 14:32:35 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
@@ -57,6 +57,8 @@ int ccm_process(ccm_state *ccm,
    unsigned char  y, z, b;
    int err;
 
+   LTC_ARGCHK(ccm != NULL);
+
    /* Check aad has been correctly added */
    if (ccm->aadlen != ccm->current_aadlen) {
       return CRYPT_ERROR;

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_test.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_test.c
@@ -59,14 +59,14 @@ int ccm_test(void)
        int           ptlen;
        unsigned char ct[64];
        unsigned char tag[16];
-       int           taglen;
+       unsigned long taglen;
    } tests[] = {
 
 /* 13 byte nonce, 8 byte auth, 23 byte pt */
 {
-   { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 
+   { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7,
      0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF },
-   { 0x00, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0xA0, 
+   { 0x00, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0xA0,
      0xA1, 0xA2, 0xA3, 0xA4, 0xA5 },
    13,
    { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 },
@@ -84,20 +84,20 @@ int ccm_test(void)
 
 /* 13 byte nonce, 12 byte header, 19 byte pt */
 {
-   { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 
+   { 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7,
      0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF },
-   { 0x00, 0x00, 0x00, 0x06, 0x05, 0x04, 0x03, 0xA0, 
+   { 0x00, 0x00, 0x00, 0x06, 0x05, 0x04, 0x03, 0xA0,
      0xA1, 0xA2, 0xA3, 0xA4, 0xA5 },
    13,
    { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
      0x08, 0x09, 0x0A, 0x0B },
    12,
-   { 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 
-     0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 
+   { 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13,
+     0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B,
      0x1C, 0x1D, 0x1E },
    19,
-   { 0xA2, 0x8C, 0x68, 0x65, 0x93, 0x9A, 0x9A, 0x79, 
-     0xFA, 0xAA, 0x5C, 0x4C, 0x2A, 0x9D, 0x4A, 0x91, 
+   { 0xA2, 0x8C, 0x68, 0x65, 0x93, 0x9A, 0x9A, 0x79,
+     0xFA, 0xAA, 0x5C, 0x4C, 0x2A, 0x9D, 0x4A, 0x91,
      0xCD, 0xAC, 0x8C },
    { 0x96, 0xC8, 0x61, 0xB9, 0xC9, 0xE6, 0x1E, 0xF1 },
    8
@@ -105,7 +105,7 @@ int ccm_test(void)
 
 /* supplied by Brian Gladman */
 {
-   { 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 
+   { 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
      0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f },
    { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16  },
    7,
@@ -119,31 +119,34 @@ int ccm_test(void)
 },
 
 {
-   { 0xc9, 0x7c, 0x1f, 0x67, 0xce, 0x37, 0x11, 0x85, 
+   { 0xc9, 0x7c, 0x1f, 0x67, 0xce, 0x37, 0x11, 0x85,
      0x51, 0x4a, 0x8a, 0x19, 0xf2, 0xbd, 0xd5, 0x2f },
-   { 0x00, 0x50, 0x30, 0xf1, 0x84, 0x44, 0x08, 0xb5, 
+   { 0x00, 0x50, 0x30, 0xf1, 0x84, 0x44, 0x08, 0xb5,
      0x03, 0x97, 0x76, 0xe7, 0x0c },
    13,
-   { 0x08, 0x40, 0x0f, 0xd2, 0xe1, 0x28, 0xa5, 0x7c, 
-     0x50, 0x30, 0xf1, 0x84, 0x44, 0x08, 0xab, 0xae, 
+   { 0x08, 0x40, 0x0f, 0xd2, 0xe1, 0x28, 0xa5, 0x7c,
+     0x50, 0x30, 0xf1, 0x84, 0x44, 0x08, 0xab, 0xae,
      0xa5, 0xb8, 0xfc, 0xba, 0x00, 0x00 },
    22,
-   { 0xf8, 0xba, 0x1a, 0x55, 0xd0, 0x2f, 0x85, 0xae, 
-     0x96, 0x7b, 0xb6, 0x2f, 0xb6, 0xcd, 0xa8, 0xeb, 
+   { 0xf8, 0xba, 0x1a, 0x55, 0xd0, 0x2f, 0x85, 0xae,
+     0x96, 0x7b, 0xb6, 0x2f, 0xb6, 0xcd, 0xa8, 0xeb,
      0x7e, 0x78, 0xa0, 0x50 },
    20,
-   { 0xf3, 0xd0, 0xa2, 0xfe, 0x9a, 0x3d, 0xbf, 0x23, 
-     0x42, 0xa6, 0x43, 0xe4, 0x32, 0x46, 0xe8, 0x0c, 
+   { 0xf3, 0xd0, 0xa2, 0xfe, 0x9a, 0x3d, 0xbf, 0x23,
+     0x42, 0xa6, 0x43, 0xe4, 0x32, 0x46, 0xe8, 0x0c,
      0x3c, 0x04, 0xd0, 0x19 },
    { 0x78, 0x45, 0xce, 0x0b, 0x16, 0xf9, 0x76, 0x23 },
    8
 },
 
 };
-  unsigned long taglen, x;
-  unsigned char buf[64], buf2[64], tag2[16], tag[16];
+  unsigned long taglen, x, y;
+  unsigned char buf[64], buf2[64], tag[16], tag2[16], tag3[16], zero[64];
   int           err, idx;
   symmetric_key skey;
+  ccm_state ccm;
+  
+  zeromem(zero, 64);
 
   idx = find_cipher("aes");
   if (idx == -1) {
@@ -154,54 +157,155 @@ int ccm_test(void)
   }
 
   for (x = 0; x < (sizeof(tests)/sizeof(tests[0])); x++) {
+    for (y = 0; y < 2; y++) {
       taglen = tests[x].taglen;
-      if ((err = cipher_descriptor[idx].setup(tests[x].key, 16, 0, &skey)) != CRYPT_OK) {
-         return err;
-      }
-      
-      if ((err = ccm_memory(idx,
-                            tests[x].key, 16,
-                            &skey,
-                            tests[x].nonce, tests[x].noncelen,
-                            tests[x].header, tests[x].headerlen,
-                            (unsigned char*)tests[x].pt, tests[x].ptlen,
-                            buf,
-                            tag, &taglen, 0)) != CRYPT_OK) {
-         return err;
+      if (y == 0) {
+         if ((err = cipher_descriptor[idx].setup(tests[x].key, 16, 0, &skey)) != CRYPT_OK) {
+            return err;
+         }
+
+         if ((err = ccm_memory(idx,
+                               tests[x].key, 16,
+                               &skey,
+                               tests[x].nonce, tests[x].noncelen,
+                               tests[x].header, tests[x].headerlen,
+                               (unsigned char*)tests[x].pt, tests[x].ptlen,
+                               buf,
+                               tag, &taglen, 0)) != CRYPT_OK) {
+            return err;
+         }
+      } else {
+         if ((err = ccm_init(&ccm, idx, tests[x].key, 16, tests[x].ptlen, tests[x].taglen, tests[x].headerlen)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_add_nonce(&ccm, tests[x].nonce, tests[x].noncelen)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_add_aad(&ccm, tests[x].header, tests[x].headerlen)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_process(&ccm, (unsigned char*)tests[x].pt, tests[x].ptlen, buf, CCM_ENCRYPT)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_done(&ccm, tag, &taglen)) != CRYPT_OK) {
+            return err;
+         }
       }
 
       if (XMEMCMP(buf, tests[x].ct, tests[x].ptlen)) {
+#if defined(LTC_TEST_DBG)
+         printf("\n%d: x=%lu y=%lu\n", __LINE__, x, y);
+         print_hex("ct is    ", buf, tests[x].ptlen);
+         print_hex("ct should", tests[x].ct, tests[x].ptlen);
+#endif
+         return CRYPT_FAIL_TESTVECTOR;
+      }
+      if (tests[x].taglen != taglen) {
+#if defined(LTC_TEST_DBG)
+         printf("\n%d: x=%lu y=%lu\n", __LINE__, x, y);
+         printf("taglen %lu (is) %lu (should)\n", taglen, tests[x].taglen);
+#endif
          return CRYPT_FAIL_TESTVECTOR;
       }
       if (XMEMCMP(tag, tests[x].tag, tests[x].taglen)) {
+#if defined(LTC_TEST_DBG)
+         printf("\n%d: x=%lu y=%lu\n", __LINE__, x, y);
+         print_hex("tag is    ", tag, tests[x].taglen);
+         print_hex("tag should", tests[x].tag, tests[x].taglen);
+#endif
          return CRYPT_FAIL_TESTVECTOR;
       }
 
-      if ((err = ccm_memory(idx,
-                            tests[x].key, 16,
-                            NULL,
-                            tests[x].nonce, tests[x].noncelen,
-                            tests[x].header, tests[x].headerlen,
-                            buf2, tests[x].ptlen,
-                            buf,
-                            tag2, &taglen, 1   )) != CRYPT_OK) {
-         return err;
+      if (y == 0) {
+          XMEMCPY(tag3, tests[x].tag, tests[x].taglen);
+          taglen = tests[x].taglen;
+          if ((err = ccm_memory(idx,
+                               tests[x].key, 16,
+                               NULL,
+                               tests[x].nonce, tests[x].noncelen,
+                               tests[x].header, tests[x].headerlen,
+                               buf2, tests[x].ptlen,
+                               buf,
+                               tag3, &taglen, 1   )) != CRYPT_OK) {
+            return err;
+         }
+      } else {
+         if ((err = ccm_init(&ccm, idx, tests[x].key, 16, tests[x].ptlen, tests[x].taglen, tests[x].headerlen)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_add_nonce(&ccm, tests[x].nonce, tests[x].noncelen)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_add_aad(&ccm, tests[x].header, tests[x].headerlen)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_process(&ccm, buf2, tests[x].ptlen, buf, CCM_DECRYPT)) != CRYPT_OK) {
+            return err;
+         }
+         if ((err = ccm_done(&ccm, tag2, &taglen)) != CRYPT_OK) {
+            return err;
+         }
       }
 
       if (XMEMCMP(buf2, tests[x].pt, tests[x].ptlen)) {
+#if defined(LTC_TEST_DBG)
+         printf("\n%d: x=%lu y=%lu\n", __LINE__, x, y);
+         print_hex("pt is    ", buf2, tests[x].ptlen);
+         print_hex("pt should", tests[x].pt, tests[x].ptlen);
+#endif
          return CRYPT_FAIL_TESTVECTOR;
       }
-      if (XMEMCMP(tag2, tests[x].tag, tests[x].taglen)) {
-         return CRYPT_FAIL_TESTVECTOR;
+      if (y == 0) {
+        /* check if decryption with the wrong tag does not reveal the plaintext */
+        XMEMCPY(tag3, tests[x].tag, tests[x].taglen);
+        tag3[0] ^= 0xff; /* set the tag to the wrong value */
+        taglen = tests[x].taglen;
+        if ((err = ccm_memory(idx,
+                              tests[x].key, 16,
+                              NULL,
+                              tests[x].nonce, tests[x].noncelen,
+                              tests[x].header, tests[x].headerlen,
+                              buf2, tests[x].ptlen,
+                              buf,
+                              tag3, &taglen, 1   )) != CRYPT_ERROR) {
+          return CRYPT_FAIL_TESTVECTOR;
+        }
+        if (XMEMCMP(buf2, zero, tests[x].ptlen)) {
+#if defined(LTC_CCM_TEST_DBG)
+          printf("\n%d: x=%lu y=%lu\n", __LINE__, x, y);
+          print_hex("pt is    ", buf2, tests[x].ptlen);
+          print_hex("pt should", zero, tests[x].ptlen);
+#endif
+          return CRYPT_FAIL_TESTVECTOR;
+        }
+      } else {
+        /* FIXME: Only check the tag if ccm_memory was not called: ccm_memory already
+           validates the tag. ccm_process and ccm_done should somehow do the same,
+           although with current setup it is impossible to keep the plaintext hidden
+           if the tag is incorrect.
+        */
+        if (XMEMCMP(tag2, tests[x].tag, tests[x].taglen)) {
+#if defined(LTC_TEST_DBG)
+          printf("\n%d: x=%lu y=%lu\n", __LINE__, x, y);
+          print_hex("tag is    ", tag2, tests[x].taglen);
+          print_hex("tag should", tests[x].tag, tests[x].taglen);
+#endif
+          return CRYPT_FAIL_TESTVECTOR;
+        }
       }
-      cipher_descriptor[idx].done(&skey);
+
+      if (y == 0) {
+         cipher_descriptor[idx].done(&skey);
+      }
+    }
   }
+
   return CRYPT_OK;
 #endif
 }
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/encauth/ccm/ccm_test.c,v $ */
-/* $Revision: 1.10 $ */
-/* $Date: 2007/05/12 14:32:35 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/encauth/ccm/sub.mk
+++ b/core/lib/libtomcrypt/src/encauth/ccm/sub.mk
@@ -4,5 +4,5 @@ srcs-y += ccm_add_aad.c
 srcs-y += ccm_process.c
 srcs-y += ccm_done.c
 srcs-y += ccm_reset.c
-srcs-y += ccm_memory.c
+# srcs-y += ccm_memory.c
 # srcs-y += ccm_test.c


### PR DESCRIPTION
https://github.com/libtom/libtomcrypt/issues/73 highlighted NIST specifications
are not met in previous implementation. Here is the description of this issue:
    According to the NIST specification of CCM, the authentication tag is
    part of the ciphertext. In order to decrypt, this full ciphertext must
    be decrypted, resulting in a "plaintext" tag. The tag must then be
    recomputed upon the plaintext and compared with the decrypted value.
    However, upon decryption in the libtom implementation, the ciphertext
    is decrypted, and a tag is computed upon the header and (decrypted)
    plaintext. This is then re-encrypted, so that the caller of the function
    must compare the resulting (encryped) tag with the received (encrypted) tag.

    The NIST specification specifies that "only the error message INVALID is
    returned" when the decryption-verification fails. In that case "the payload
    P and the MAC T shall not be revealed" and that "the implementation shall
    ensure that an unauthorized party cannot distinguish whether the error
    message results from [invalid message format] or from [authentication
    failure], for example, from the timing of the error message."

Current patch:
- sync CCM libtomcrypt code with the ones in optee_os
  - NIST specifications are now met.
    Note that ccm_memory() API has been modified.
  - check of non-null pointers
  - remove spurious space
- remove compilation of ccm_memory which is not used in optee_os

Signed-off-by: Pascal Brand <pascal.brand@st.com>