### PR TITLE
Add TI dra7xx platform support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,3 +88,6 @@ script:
 
   # Mediatek mt8173 EVB
   - PLATFORM=mediatek  PLATFORM_FLAVOR=mt8173  CFG_ARM64_core=y  CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+
+  # Texas Instruments dra7xx
+  - PLATFORM=ti  PLATFORM_FLAVOR=dra7xx  make -j8 all -s

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ please read the file [build_system.md](documentation/build_system.md).
 | [Allwinner A80 Board](http://www.allwinnertech.com/en/clq/processora/A80.html)|`PLATFORM=sunxi`|
 | [HiKey Board (HiSilicon Kirin 620)](https://www.96boards.org/products/hikey/)|`PLATFORM=hikey`|
 | MediaTek MT8173 EVB Board|`PLATFORM=mediatek-mt8173`|
+| Texas Instruments DRA7xx|`PLATFORM=ti-dra7xx`|
 
 ## 4. Get and build the software
 There are a couple of different build options depending on the target you are

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -40,6 +40,8 @@ void generic_boot_init_secondary(uint32_t nsec_entry);
 
 void main_init_gic(void);
 
+void init_sec_mon(uint32_t nsec_entry);
+
 const struct thread_handlers *generic_boot_get_handlers(void);
 
 extern uint8_t __text_init_start[];

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -71,13 +71,14 @@ __weak void main_init_gic(void)
 }
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
-static void init_sec_mon(uint32_t nsec_entry __unused)
+void init_sec_mon(uint32_t nsec_entry __unused)
 {
 	assert(nsec_entry == PADDR_INVALID);
 	/* Do nothing as we don't have a secure monitor */
 }
 #else
-static void init_sec_mon(uint32_t nsec_entry)
+/* May be overridden in plat-$(PLATFORM)/main.c */
+__weak void init_sec_mon(uint32_t nsec_entry)
 {
 	struct sm_nsec_ctx *nsec_ctx;
 

--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -1,0 +1,24 @@
+include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
+
+CFG_ARM32_core ?= y
+CFG_MMU_V7_TTB ?= y
+
+core-platform-cppflags	+= -I$(arch-dir)/include
+
+core-platform-subdirs += \
+	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
+core-platform-subdirs += $(arch-dir)/sm
+
+libutil_with_isoc := y
+libtomcrypt_with_optimize_size := y
+CFG_SECURE_TIME_SOURCE_CNTPCT := y
+CFG_8250_UART ?= y
+CFG_HWSUPP_MEM_PERM_PXN := y
+CFG_WITH_STACK_CANARIES := y
+CFG_PM_STUBS := y
+CFG_GENERIC_BOOT := y
+CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+CFG_NO_TA_HASH_SIGN ?= y
+CFG_WITH_SOFTWARE_PRNG ?= y
+
+include mk/config.mk

--- a/core/arch/arm/plat-ti/kern.ld.S
+++ b/core/arch/arm/plat-ti/kern.ld.S
@@ -1,0 +1,1 @@
+#include "../kernel/kern.ld.S"

--- a/core/arch/arm/plat-ti/link.mk
+++ b/core/arch/arm/plat-ti/link.mk
@@ -1,0 +1,1 @@
+include core/arch/arm/kernel/link.mk

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <platform_config.h>
+
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <drivers/gic.h>
+#include <drivers/serial8250_uart.h>
+#include <arm.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <trace.h>
+#include <kernel/misc.h>
+#include <kernel/mutex.h>
+#include <kernel/tee_time.h>
+#include <mm/tee_pager.h>
+#include <mm/core_mmu.h>
+#include <tee/entry.h>
+#include <tee/arch_svc.h>
+#include <console.h>
+#include <sm/sm.h>
+
+static void main_fiq(void);
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry,
+	.fast_smc = tee_entry,
+	.fiq = main_fiq,
+	.svc = tee_svc_handler,
+	.abort = tee_pager_abort_handler,
+	.cpu_on = pm_panic,
+	.cpu_off = pm_panic,
+	.cpu_suspend = pm_panic,
+	.cpu_resume = pm_panic,
+	.system_off = pm_panic,
+	.system_reset = pm_panic,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+static void main_fiq(void)
+{
+	panic();
+}
+
+void console_init(void)
+{
+	serial8250_uart_init(CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ,
+			     CONSOLE_BAUDRATE);
+}
+
+void console_putc(int ch)
+{
+	serial8250_uart_putc(ch, CONSOLE_UART_BASE);
+	if (ch == '\n')
+		serial8250_uart_putc('\r', CONSOLE_UART_BASE);
+}
+
+void console_flush(void)
+{
+	serial8250_uart_flush_tx_fifo(CONSOLE_UART_BASE);
+}
+
+struct plat_nsec_ctx {
+	uint32_t usr_sp;
+	uint32_t usr_lr;
+	uint32_t svc_sp;
+	uint32_t svc_lr;
+	uint32_t svc_spsr;
+	uint32_t abt_sp;
+	uint32_t abt_lr;
+	uint32_t abt_spsr;
+	uint32_t und_sp;
+	uint32_t und_lr;
+	uint32_t und_spsr;
+	uint32_t irq_sp;
+	uint32_t irq_lr;
+	uint32_t irq_spsr;
+	uint32_t fiq_sp;
+	uint32_t fiq_lr;
+	uint32_t fiq_spsr;
+	uint32_t fiq_rx[5];
+	uint32_t mon_lr;
+	uint32_t mon_spsr;
+};
+
+void init_sec_mon(uint32_t nsec_entry)
+{
+	struct plat_nsec_ctx *plat_ctx = (struct plat_nsec_ctx *)nsec_entry;
+	struct sm_nsec_ctx *nsec_ctx;
+
+	/* Invalidate cache to fetch data from external memory */
+	cache_maintenance_l1(DCACHE_AREA_INVALIDATE, (void *)nsec_entry,
+		sizeof(struct plat_nsec_ctx));
+
+	/* Initialize secure monitor */
+	nsec_ctx = sm_get_nsec_ctx();
+
+	nsec_ctx->usr_sp = plat_ctx->usr_sp;
+	nsec_ctx->usr_lr = plat_ctx->usr_lr;
+	nsec_ctx->irq_spsr = plat_ctx->irq_spsr;
+	nsec_ctx->irq_sp = plat_ctx->irq_sp;
+	nsec_ctx->irq_lr = plat_ctx->irq_lr;
+	nsec_ctx->svc_spsr = plat_ctx->svc_spsr;
+	nsec_ctx->svc_sp = plat_ctx->svc_sp;
+	nsec_ctx->svc_lr = plat_ctx->svc_lr;
+	nsec_ctx->abt_spsr = plat_ctx->abt_spsr;
+	nsec_ctx->abt_sp = plat_ctx->abt_sp;
+	nsec_ctx->abt_lr = plat_ctx->abt_lr;
+	nsec_ctx->und_spsr = plat_ctx->und_spsr;
+	nsec_ctx->und_sp = plat_ctx->und_sp;
+	nsec_ctx->und_lr = plat_ctx->und_lr;
+	nsec_ctx->mon_lr = plat_ctx->mon_lr;
+	nsec_ctx->mon_spsr = plat_ctx->mon_spsr;
+}
+
+

--- a/core/arch/arm/plat-ti/platform_config.h
+++ b/core/arch/arm/plat-ti/platform_config.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#define PLATFORM_FLAVOR_ID_dra7xx	0
+#define PLATFORM_FLAVOR_IS(flav) \
+	(PLATFORM_FLAVOR == PLATFORM_FLAVOR_ID_ ## flav)
+
+#if PLATFORM_FLAVOR_IS(dra7xx)
+
+#define DRAM0_BASE		0x94C00000
+#define DRAM0_SIZE		0x00800000
+
+#ifdef CFG_WITH_PAGER
+#error Pager not supported on this platform
+#endif /*CFG_WITH_PAGER*/
+
+/* Location of protected DDR on the DRA7xx platform */
+#define TZDRAM_BASE		0x94D00000
+#define TZDRAM_SIZE		0x00700000
+
+#define CFG_TEE_CORE_NB_CORE	2
+
+/* UART1 */
+#define CONSOLE_UART_BASE		0x4806A000
+#define CONSOLE_UART_CLK_IN_HZ	48000000
+#define UART_BAUDRATE			115200
+
+#define GIC_BASE            0x48211000
+#define SECRAM_BASE         0x40200000
+
+#else
+#error "Unknown platform flavor"
+#endif
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#define HEAP_SIZE		(24 * 1024)
+
+#define CFG_SHMEM_START		(DRAM0_BASE)
+#define CFG_SHMEM_SIZE		0x100000
+
+#define CFG_TEE_RAM_VA_SIZE	(1024 * 1024)
+
+#ifndef CFG_TEE_LOAD_ADDR
+#define CFG_TEE_LOAD_ADDR	(CFG_TEE_RAM_START + 0x100)
+#endif
+
+/*
+ * Assumes that either TZSRAM isn't large enough or TZSRAM doesn't exist,
+ * everything is in TZDRAM.
+ * +------------------+
+ * |        | TEE_RAM |
+ * + TZDRAM +---------+
+ * |        | TA_RAM  |
+ * +--------+---------+
+ */
+#define CFG_TEE_RAM_PH_SIZE	CFG_TEE_RAM_VA_SIZE
+#define CFG_TEE_RAM_START	TZDRAM_BASE
+#define CFG_TA_RAM_START	ROUNDUP((TZDRAM_BASE + CFG_TEE_RAM_VA_SIZE), \
+					CORE_MMU_DEVICE_SIZE)
+#define CFG_TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - CFG_TEE_RAM_VA_SIZE), \
+					  CORE_MMU_DEVICE_SIZE)
+
+#define GICC_OFFSET         0x1000
+#define GICD_OFFSET         0x0
+
+#define DEVICE0_BASE		ROUNDDOWN(CONSOLE_UART_BASE, \
+					  CORE_MMU_DEVICE_SIZE)
+#define DEVICE0_SIZE		CORE_MMU_DEVICE_SIZE
+#define DEVICE0_TYPE		MEM_AREA_IO_NSEC
+
+#define DEVICE1_BASE		ROUNDDOWN(GIC_BASE, CORE_MMU_DEVICE_SIZE)
+#define DEVICE1_SIZE		CORE_MMU_DEVICE_SIZE
+#define DEVICE1_TYPE		MEM_AREA_IO_SEC
+
+#define DEVICE2_BASE		ROUNDDOWN(SECRAM_BASE, CORE_MMU_DEVICE_SIZE)
+#define DEVICE2_SIZE		CORE_MMU_DEVICE_SIZE
+#define DEVICE2_TYPE		MEM_AREA_IO_SEC
+
+#ifndef UART_BAUDRATE
+#define UART_BAUDRATE		115200
+#endif
+#ifndef CONSOLE_BAUDRATE
+#define CONSOLE_BAUDRATE	UART_BAUDRATE
+#endif
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-ti/platform_flags.mk
+++ b/core/arch/arm/plat-ti/platform_flags.mk
@@ -1,0 +1,29 @@
+PLATFORM_FLAVOR ?= dra7xx
+PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
+
+# 32-bit flags
+arm32-platform-cpuarch	:= cortex-a15
+arm32-platform-cflags	+= -mcpu=$(arm32-platform-cpuarch) -mthumb
+arm32-platform-cflags	+= -pipe -mthumb-interwork -mlong-calls
+arm32-platform-cflags	+= -fno-short-enums -mno-apcs-float -fno-common
+arm32-platform-cflags	+= -mfloat-abi=soft
+arm32-platform-cflags	+= -mno-unaligned-access
+arm32-platform-aflags	+= -mcpu=$(arm32-platform-cpuarch)
+
+platform-cflags += -ffunction-sections -fdata-sections
+
+DEBUG		?= 1
+ifeq ($(DEBUG),1)
+platform-cflags += -O0
+else
+platform-cflags += -Os
+endif
+
+platform-cflags += -g3
+platform-aflags += -g3
+
+CFG_ARM32_user_ta := y
+user_ta-platform-cflags += $(arm32-platform-cflags)
+user_ta-platform-cflags += -fpie
+user_ta-platform-cppflags += $(arm32-platform-cppflags)
+user_ta-platform-aflags += $(arm32-platform-aflags)

--- a/core/arch/arm/plat-ti/sub.mk
+++ b/core/arch/arm/plat-ti/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
Added plat-ti, with initial support for TI dra7xx platform.

Changed generic init_sec_mon to be overriden by platform/main.c
because initial return to non-secure world needs to restore full
NS context for this platform.

Signed-off-by: Harinarayan Bhatta <harinarayan.bhatta@linaro.org>