### PR TITLE
Change the kernel binary block interface from Base64 to raw binary

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -294,7 +294,7 @@ TEE_Result tee_svc_sys_get_property(uint32_t prop, tee_uaddr_t buf, size_t blen)
 			uint8_t bin[sizeof(size_t)
 				+ ta_endorsement_seed_size];
 
-			size_t *bin_len = (size_t*) (void*) (&bin[0]);
+			size_t *bin_len = (size_t *) (void *) (&bin[0]);
 			uint8_t *bin_val = &bin[sizeof(size_t)];
 
 			if (blen < sizeof(bin))
@@ -303,8 +303,8 @@ TEE_Result tee_svc_sys_get_property(uint32_t prop, tee_uaddr_t buf, size_t blen)
 			memcpy(&data[0], &sess->ctx->head->uuid,
 				sizeof(TEE_UUID));
 
-			if (tee_otp_get_die_id
-				(&data[sizeof(TEE_UUID)], ta_endorsement_seed_size))
+			if (tee_otp_get_die_id(&data[sizeof(TEE_UUID)],
+									ta_endorsement_seed_size))
 				return TEE_ERROR_BAD_STATE;
 
 			res = tee_hash_createdigest(TEE_ALG_SHA256, data,
@@ -318,7 +318,7 @@ TEE_Result tee_svc_sys_get_property(uint32_t prop, tee_uaddr_t buf, size_t blen)
 
 			return tee_svc_copy_to_user(sess, (void *)buf, bin,
 					sizeof(bin));
-        }
+		}
 #endif
 	default:
 		if (blen < tee_props_lut[prop].len)

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -169,6 +169,11 @@ static const uint32_t fw_impl_bin_version; /* 0 by default */
 /* Trusted firmware manufacturer name */
 static const char fw_manufacturer[] = TO_STR(CFG_TEE_FW_MANUFACTURER);
 
+#ifdef CFG_MICROSOFT_PROPERTIES
+/* Size of the TA endorsement seed */
+static const size_t ta_endorsement_seed_size = 32;
+#endif
+
 struct tee_props {
 	const void *data;
 	const size_t len;
@@ -192,6 +197,9 @@ const struct tee_props tee_props_lut[] = {
 	{fw_manufacturer, sizeof(fw_manufacturer)},
 	{0, 0}, /* client_id */
 	{0, 0}, /* ta_app_id */
+#ifdef CFG_MICROSOFT_PROPERTIES
+	{0, 0}, /* ta_endorsement_seed */
+#endif
 };
 
 TEE_Result tee_svc_sys_get_property(uint32_t prop, tee_uaddr_t buf, size_t blen)
@@ -262,6 +270,56 @@ TEE_Result tee_svc_sys_get_property(uint32_t prop, tee_uaddr_t buf, size_t blen)
 		return tee_svc_copy_to_user(sess, (void *)buf,
 					    &sess->ctx->head->uuid,
 					    sizeof(TEE_UUID));
+
+#ifdef CFG_MICROSOFT_PROPERTIES
+	case UTEE_PROP_TA_ENDORSEMENT_SEED:
+		{
+			/*
+			 * The data to hash is 48 bytes made up of:
+			 * - 16 bytes: the UUID of the calling TA.
+			 * - 32 bytes: the hardware device ID
+			 * The resulting endorsement seed is 32 bytes.
+			 *
+			 * The output buffer is the "binary" struct defined in
+			 * the "prop_value" union and therefore comprises:
+			 * -  4 bytes: the size of the binary value data (32)
+			 * - 32 bytes: the binary value data (endorsement seed)
+			 *
+			 * Note that this code assumes an endoresement seed
+			 * size == device ID size for convenience.
+			 */
+			uint8_t data[sizeof(TEE_UUID)
+				+ ta_endorsement_seed_size];
+
+			uint8_t bin[sizeof(size_t)
+				+ ta_endorsement_seed_size];
+
+			size_t *bin_len = (size_t*) (void*) (&bin[0]);
+			uint8_t *bin_val = &bin[sizeof(size_t)];
+
+			if (blen < sizeof(bin))
+				return TEE_ERROR_SHORT_BUFFER;
+
+			memcpy(&data[0], &sess->ctx->head->uuid,
+				sizeof(TEE_UUID));
+
+			if (tee_otp_get_die_id
+				(&data[sizeof(TEE_UUID)], ta_endorsement_seed_size))
+				return TEE_ERROR_BAD_STATE;
+
+			res = tee_hash_createdigest(TEE_ALG_SHA256, data,
+					sizeof(data),
+					bin_val,
+					ta_endorsement_seed_size);
+			if (res != TEE_SUCCESS)
+				return TEE_ERROR_BAD_STATE;
+
+			*bin_len = ta_endorsement_seed_size;
+
+			return tee_svc_copy_to_user(sess, (void *)buf, bin,
+					sizeof(bin));
+        }
+#endif
 	default:
 		if (blen < tee_props_lut[prop].len)
 			return TEE_ERROR_SHORT_BUFFER;

--- a/lib/libutee/include/utee_types.h
+++ b/lib/libutee/include/utee_types.h
@@ -44,6 +44,9 @@ enum utee_property {
 	UTEE_PROP_TEE_FW_MANUFACTURER,
 	UTEE_PROP_CLIENT_ID,
 	UTEE_PROP_TA_APP_ID,
+#ifdef CFG_MICROSOFT_PROPERTIES
+	UTEE_PROP_TA_ENDORSEMENT_SEED,
+#endif
 };
 
 enum utee_time_category {

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -59,10 +59,10 @@ struct prop_value {
 		TEE_UUID uuid_val;
 		TEE_Identity identity_val;
 		char str_val[PROP_STR_MAX];
-        struct {
-            size_t len;
-            uint8_t val[PROP_BIN_MAX];
-        } binary;
+		struct {
+			size_t len;
+			uint8_t val[PROP_BIN_MAX];
+		} binary;
 	} u;
 };
 
@@ -407,38 +407,38 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 		l = strlcpy(valueBuffer, pv.u.str_val, bufferlen);
 		break;
 
-    /*
-     * This is returned as a binary blob and thus must be converted
-     * into base64 per the GP specification.
-     *
-     * Note that the behaviour of base64_enc does not copy any data
-     * into the buffer if all of it will not fit. This appears slightly
-     * different than the above implementations that copy into the buffer
-     * as many bytes as will fit and return a short buffer error.
-     * The GP specification for TEE_GetPropertyAsString does not explicitly
-     * state this partial data behaviour in response to a short buffer.
-     */
+	/*
+	 * This is returned as a binary blob and thus must be converted
+	 * into base64 per the GP specification.
+	 *
+	 * Note that the behaviour of base64_enc does not copy any data
+	 * into the buffer if all of it will not fit. This appears slightly
+	 * different than the above implementations that copy into the buffer
+	 * as many bytes as will fit and return a short buffer error.
+	 * The GP specification for TEE_GetPropertyAsString does not explicitly
+	 * state this partial data behaviour in response to a short buffer.
+	 */
 	case USER_TA_PROP_TYPE_BINARY_BLOCK: {
 
-        size_t blen = bufferlen;
+		size_t blen = bufferlen;
 
-        if (!base64_enc(pv.u.binary.val, pv.u.binary.len,
-                valueBuffer, &blen)) {
-            assert(blen > bufferlen);
-        }
-        else {
-            assert(blen <= bufferlen);
-        }
+		if (!base64_enc(pv.u.binary.val, pv.u.binary.len,
+				valueBuffer, &blen)) {
+			assert(blen > bufferlen);
+		}
+		else {
+			assert(blen <= bufferlen);
+		}
 
-        /*
-         * The base64_enc call above returns the size including the null
-         * terminator so we need to subtract it because the null is
-         * accounted for below for all types.
-         */
-        assert(blen > 0);
-        l = (blen - 1);
+		/*
+		 * The base64_enc call above returns the size including the null
+		 * terminator so we need to subtract it because the null is
+		 * accounted for below for all types.
+		 */
+		assert(blen > 0);
+		l = (blen - 1);
 
-        break;
+		break;
 	}
 
 	default:
@@ -558,8 +558,8 @@ TEE_Result TEE_GetPropertyAsBinaryBlock(TEE_PropSetHandle propsetOrEnumerator,
 	val = pv.u.binary.val;
 	val_len = pv.u.binary.len;
 
-    assert(pv.u.binary.len
-        <= (sizeof(pv.u.binary) - sizeof(pv.u.binary.len)));
+	assert(pv.u.binary.len
+		<= (sizeof(pv.u.binary) - sizeof(pv.u.binary.len)));
 
 	size = (size_t) *valueBufferLen;
 
@@ -568,7 +568,7 @@ TEE_Result TEE_GetPropertyAsBinaryBlock(TEE_PropSetHandle propsetOrEnumerator,
 		goto err;
 	}
 
-    memcpy(valueBuffer, val, val_len);
+	memcpy(valueBuffer, val, val_len);
 	*valueBufferLen = (uint32_t) val_len;
 
 	goto out;

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -425,8 +425,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 		if (!base64_enc(pv.u.binary.val, pv.u.binary.len,
 				valueBuffer, &blen)) {
 			assert(blen > bufferlen);
-		}
-		else {
+		} else {
 			assert(blen <= bufferlen);
 		}
 

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -39,8 +39,10 @@
 
 #include "string_ext.h"
 #include "base64.h"
+#include "assert.h"
 
 #define PROP_STR_MAX    80
+#define PROP_BIN_MAX    64
 
 #define PROP_ENUMERATOR_NOT_STARTED 0xffffffff
 
@@ -57,6 +59,10 @@ struct prop_value {
 		TEE_UUID uuid_val;
 		TEE_Identity identity_val;
 		char str_val[PROP_STR_MAX];
+        struct {
+            size_t len;
+            uint8_t val[PROP_BIN_MAX];
+        } binary;
 	} u;
 };
 
@@ -398,9 +404,42 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 		break;
 
 	case USER_TA_PROP_TYPE_STRING:
-	case USER_TA_PROP_TYPE_BINARY_BLOCK:
 		l = strlcpy(valueBuffer, pv.u.str_val, bufferlen);
 		break;
+
+    /*
+     * This is returned as a binary blob and thus must be converted
+     * into base64 per the GP specification.
+     *
+     * Note that the behaviour of base64_enc does not copy any data
+     * into the buffer if all of it will not fit. This appears slightly
+     * different than the above implementations that copy into the buffer
+     * as many bytes as will fit and return a short buffer error.
+     * The GP specification for TEE_GetPropertyAsString does not explicitly
+     * state this partial data behaviour in response to a short buffer.
+     */
+	case USER_TA_PROP_TYPE_BINARY_BLOCK: {
+
+        size_t blen = bufferlen;
+
+        if (!base64_enc(pv.u.binary.val, pv.u.binary.len,
+                valueBuffer, &blen)) {
+            assert(blen > bufferlen);
+        }
+        else {
+            assert(blen <= bufferlen);
+        }
+
+        /*
+         * The base64_enc call above returns the size including the null
+         * terminator so we need to subtract it because the null is
+         * accounted for below for all types.
+         */
+        assert(blen > 0);
+        l = (blen - 1);
+
+        break;
+	}
 
 	default:
 		res = TEE_ERROR_BAD_FORMAT;
@@ -499,7 +538,7 @@ TEE_Result TEE_GetPropertyAsBinaryBlock(TEE_PropSetHandle propsetOrEnumerator,
 	TEE_Result res;
 	struct prop_value pv;
 	void *val;
-	int val_len;
+	size_t val_len;
 	size_t size;
 
 	if (valueBuffer == NULL || valueBufferLen == NULL) {
@@ -516,15 +555,21 @@ TEE_Result TEE_GetPropertyAsBinaryBlock(TEE_PropSetHandle propsetOrEnumerator,
 		goto err;
 	}
 
-	val = pv.u.str_val;
-	val_len = strlen(val);
-	size = *valueBufferLen;
-	if (!base64_dec(val, val_len, valueBuffer, &size)) {
+	val = pv.u.binary.val;
+	val_len = pv.u.binary.len;
+
+    assert(pv.u.binary.len
+        <= (sizeof(pv.u.binary) - sizeof(pv.u.binary.len)));
+
+	size = (size_t) *valueBufferLen;
+
+	if (size < val_len) {
 		res = TEE_ERROR_SHORT_BUFFER;
 		goto err;
 	}
 
-	*valueBufferLen = size;
+    memcpy(valueBuffer, val, val_len);
+	*valueBufferLen = (uint32_t) val_len;
 
 	goto out;
 

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -81,7 +81,8 @@ static TEE_Result propget_gpd_ta_app_id(struct prop_value *pv)
 }
 
 #ifdef CFG_MICROSOFT_PROPERTIES
-static TEE_Result propget_com_microsoft_ta_endorsement_seed(struct prop_value *pv)
+static TEE_Result propget_com_microsoft_ta_endorsement_seed(
+	struct prop_value *pv)
 {
 	pv->type = USER_TA_PROP_TYPE_BINARY_BLOCK;
 	return utee_get_property(UTEE_PROP_TA_ENDORSEMENT_SEED, &pv->u.binary,
@@ -202,8 +203,8 @@ static TEE_Result propget_gpd_tee_fw_manufacturer(struct prop_value *pv)
 static const struct prop_set propset_current_ta[] = {
 	{"gpd.ta.appID", propget_gpd_ta_app_id},
 #ifdef CFG_MICROSOFT_PROPERTIES
-    {"com.microsoft.ta.endorsementSeed",
-     propget_com_microsoft_ta_endorsement_seed},
+	{"com.microsoft.ta.endorsementSeed",
+	propget_com_microsoft_ta_endorsement_seed},
 #endif
 };
 
@@ -435,7 +436,8 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 
 		size_t blen = bufferlen;
 
-		base64_enc(pv.u.binary.val, pv.u.binary.len, valueBuffer, &blen);
+		base64_enc(pv.u.binary.val, pv.u.binary.len,
+			valueBuffer, &blen);
 
 		/*
 		 * The base64_enc call above returns the size including the null


### PR DESCRIPTION
Change the kernel binary block interface from Base64 to raw binary to elliminate the need to perform a Base64 encode in the kernel.

Signed-off-by: Paul Swan <paswan@microsoft.com>