### PR TITLE
Travis: run xtest in QEMU

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ notifications:
 
 sudo: false
 
-# Install the cross compiler
+cache: ccache
+
 before_install:
+  # Install the cross compilers
   - wget http://releases.linaro.org/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
   - tar xf gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
   - export PATH=${PWD}/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf/bin:${PATH}
@@ -26,6 +28,35 @@ before_script:
   - export DST_KERNEL=$PWD/linux && mkdir -p $DST_KERNEL/scripts && cd $DST_KERNEL/scripts
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl && chmod a+x checkpatch.pl
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+  - cd $MYHOME
+
+  # Tools required for QEMU tests
+  # 'apt-get install' cannot be used in the new container-based infrastructure
+  # (which is the only allowing caching), so we just build from sources
+  # bc is used during kernel configuration
+  - cd $HOME
+  - wget http://ftp.gnu.org/gnu/bc/bc-1.06.tar.gz
+  - tar xf bc-1.06.tar.gz
+  - (cd bc-1.06 && CC="ccache gcc" ./configure --quiet && make -j4)
+  - export PATH=${HOME}/bc-1.06/bc:$PATH
+  # Tcl/Expect
+  - wget http://prdownloads.sourceforge.net/tcl/tcl8.6.4-src.tar.gz
+  - tar xf tcl8.6.4-src.tar.gz
+  - (cd tcl8.6.4/unix && ./configure --quiet --prefix=${HOME}/inst CC="ccache gcc" && make -j4 install)
+  - wget http://sourceforge.net/projects/expect/files/Expect/5.45/expect5.45.tar.gz/download -O expect5.45.tar.gz
+  - tar xf expect5.45.tar.gz
+  - (cd expect5.45 && ./configure --quiet --with-tcl=${HOME}/inst/lib --prefix=${HOME}/inst CC="ccache gcc" && make -j4 expect && make -j4 install)
+  - export PATH=$HOME/inst/bin:$PATH
+  # pycrypto 2.6.1 or later has Crypto.Signature, 2.4.1 does not. It is needed to sign the test TAs.
+  - pip install --upgrade --user pycrypto
+  # Clone repositories for the QEMU test environment
+  - mkdir $HOME/bin
+  - (cd $HOME/bin && wget https://storage.googleapis.com/git-repo-downloads/repo && chmod +x repo)
+  - export PATH=$HOME/bin:$PATH
+  - mkdir $HOME/optee_repo
+  - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git </dev/null && repo sync --no-clone-bundle --no-tags --quiet -j 2)
+  - (cd $HOME/optee_repo/qemu && git submodule update --init dtc)
+  - (cd $HOME/optee_repo && mv optee_os optee_os_old && ln -s $MYHOME optee_os)
   - cd $MYHOME
 
 # Several compilation options are checked
@@ -91,3 +122,6 @@ script:
 
   # Texas Instruments dra7xx
   - PLATFORM=ti  PLATFORM_FLAVOR=dra7xx  make -j8 all -s
+
+  # Run regression tests (xtest in QEMU)
+  - (cd ${HOME}/optee_repo/build && make -s -j8 check CROSS_COMPILE="ccache arm-linux-gnueabihf-" DUMP_LOGS_ON_ERROR=1)


### PR DESCRIPTION
.travis.yml is updated to run functional tests in QEMU after the
multi-platform builds. This involves:

- Cloning Git repositories using the Android 'repo' script (the
manifest is at https://github.com/OP-TEE/manifest)
- Building a bootable image containing Linux, OP-TEE and xtest, then
booting the image in QEMU and running the test suite ("make check")

Travis will report success only if all tests pass.

Now it takes 20 ~ 22 minutes to run .travis.yml on the Travis servers,
about 12 ~ 14 minutes more than before. ccache is enabled to speed up
the compilation as much as possible.

Some required tools are downloaded and compiled during the
before_install step: bc, Tcl and Expect. Indeed, they are not available
in the Travis container-based infrastructure, which we have to use to
enable ccache. Since apt-get is not allowed in that environment, we
have to build from sources. This is usually quite fast (less than a
minute) thanks to ccache.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>