### PR TITLE
Secure Storage: fix data abort issue

### DIFF
--- a/core/tee/tee_fs_private.h
+++ b/core/tee/tee_fs_private.h
@@ -111,7 +111,7 @@ static inline uint8_t get_backup_version_of_block(
 	return !!(meta->info.backup_version_table[index] & block_mask);
 }
 
-static inline void toggle_backup_version_for_block(
+static inline void toggle_backup_version_of_block(
 		struct tee_fs_file_meta *meta,
 		size_t block_num)
 {

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -594,7 +594,7 @@ TEE_Result tee_svc_storage_obj_create(uint32_t storage_id, void *object_id,
 		/* file exists */
 		if (!(flags & TEE_DATA_FLAG_OVERWRITE)) {
 			res = TEE_ERROR_ACCESS_CONFLICT;
-			goto rmfile;
+			goto err;
 		}
 	}
 


### PR DESCRIPTION
- Tmpfile is NULL before checking whether file exists, if this check failed
  we will unlink(tmpfile). This caused data abort.

- Minor fixes in tee_fs_common.c for consistent naming and error checking.

Signed-off-by: SY Chiu <sy.chiu@linaro.org>
Tested-by: SY Chiu <sy.chiu@linaro.org> (QEMU)