### PR TITLE
Secure Storage: export TEE file header structure for xtest

### DIFF
--- a/core/include/tee/tee_fs_key_manager.h
+++ b/core/include/tee/tee_fs_key_manager.h
@@ -44,6 +44,20 @@ enum tee_fs_file_type {
 	BLOCK_FILE
 };
 
+struct common_header {
+	uint8_t iv[TEE_FS_KM_IV_LEN];
+	uint8_t tag[TEE_FS_KM_MAX_TAG_LEN];
+};
+
+struct meta_header {
+	uint8_t encrypted_key[TEE_FS_KM_FEK_SIZE];
+	struct common_header common;
+};
+
+struct block_header {
+	struct common_header common;
+};
+
 size_t tee_fs_get_header_size(enum tee_fs_file_type type);
 TEE_Result tee_fs_generate_fek(uint8_t *encrypted_fek, int fek_size);
 TEE_Result tee_fs_encrypt_file(enum tee_fs_file_type file_type,

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -63,21 +63,6 @@ struct km_header {
 	uint8_t *tag;
 };
 
-
-struct common_header {
-	uint8_t iv[TEE_FS_KM_IV_LEN];
-	uint8_t tag[TEE_FS_KM_MAX_TAG_LEN];
-};
-
-struct meta_header {
-	uint8_t encrypted_key[TEE_FS_KM_FEK_SIZE];
-	struct common_header common;
-};
-
-struct block_header {
-	struct common_header common;
-};
-
 static struct tee_fs_ssk tee_fs_ssk;
 static uint8_t string_for_ssk_gen[] = "ONLY_FOR_tee_fs_ssk";
 

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -39,6 +39,7 @@ base-prefix :=
 incdirs-host := $(filter-out lib/libutils%, $(incdirs$(sm)))
 incfiles-extra-host := lib/libutils/ext/include/compiler.h
 incfiles-extra-host += lib/libutils/ext/include/util.h
+incfiles-extra-host += core/include/tee/tee_fs_key_manager.h
 
 #
 # Copy lib files and exported headers from each lib


### PR DESCRIPTION
Export 'struct meta_header' and 'struct block_header' to
$TA_DEV_KIT_DIR/host_include, those structures can be used
by xtest. This prevents hard-coding the structure in xtest.

Signed-off-by: SY Chiu <sy.chiu@linaro.org>
Tested-by: SY Chiu <sy.chiu@linaro.org> (QEMU)