### PR TITLE
Flush traces synchronously

### DIFF
--- a/core/arch/arm/kernel/trace_ext.c
+++ b/core/arch/arm/kernel/trace_ext.c
@@ -31,18 +31,16 @@
 const char trace_ext_prefix[] = "TEE-CORE";
 int trace_level = TRACE_LEVEL;
 
-void trace_ext_puts(bool sync, const char *str)
+void trace_ext_puts(const char *str)
 {
 	const char *p;
 
-	if (sync)
-		console_flush();
+	console_flush();
 
 	for (p = str; *p; p++)
 		console_putc(*p);
 
-	if (sync)
-		console_flush();
+	console_flush();
 }
 
 int trace_ext_get_thread_id(void)

--- a/lib/libutee/tee_user_mem.c
+++ b/lib/libutee/tee_user_mem.c
@@ -162,7 +162,7 @@ static int is_buffer_valid(void *buffer)
 static void print_buf(int tl, const char *func, int line, const char *prefix,
 		      const struct user_mem_elem *e)
 {
-	trace_printf(NULL, 0, tl, true, false,
+	trace_printf(NULL, 0, tl, true,
 		    "%s:%d: %slink:[%p], buf:[%p:%d]\n",
 		    func, line, prefix, (void *)e, buf_addr(e), buf_size(e));
 }

--- a/lib/libutee/trace_ext.c
+++ b/lib/libutee/trace_ext.c
@@ -35,7 +35,7 @@
 
 #if TRACE_LEVEL > 0
 
-void trace_ext_puts(bool sync __unused, const char *str)
+void trace_ext_puts(const char *str)
 {
 	utee_log(str, strlen(str));
 }
@@ -92,7 +92,7 @@ int printf(const char *fmt, ...)
 int puts(const char *str)
 {
 	if (trace_get_level() >= TRACE_PRINTF_LEVEL)
-		trace_ext_puts(false, str);
+		trace_ext_puts(str);
 	return 1;
 }
 

--- a/lib/libutils/ext/include/trace.h
+++ b/lib/libutils/ext/include/trace.h
@@ -44,18 +44,18 @@
  */
 extern int trace_level;
 extern const char trace_ext_prefix[];
-void trace_ext_puts(bool sync, const char *str);
+void trace_ext_puts(const char *str);
 int trace_ext_get_thread_id(void);
 void trace_set_level(int level);
 int trace_get_level(void);
 
 /* Internal functions used by the macros below */
 void trace_printf(const char *func, int line, int level, bool level_ok,
-		  bool sync, const char *fmt, ...) __printf(6, 7);
+		  const char *fmt, ...) __printf(5, 6);
 
 #define trace_printf_helper(level, level_ok, ...) \
 	trace_printf(__func__, __LINE__, (level), (level_ok), \
-		     false, __VA_ARGS__)
+		     __VA_ARGS__)
 
 /* Formatted trace tagged with level independent */
 #if (TRACE_LEVEL <= 0)
@@ -117,7 +117,7 @@ void dhex_dump(const char *function, int line, int level,
 /* Trace api without trace formatting */
 
 #define trace_printf_helper_raw(level, level_ok, ...) \
-	trace_printf(NULL, 0, (level), (level_ok), false, __VA_ARGS__)
+	trace_printf(NULL, 0, (level), (level_ok), __VA_ARGS__)
 
 /* No formatted trace tagged with level independent */
 #if (TRACE_LEVEL <= 0)
@@ -163,7 +163,7 @@ void dhex_dump(const char *function, int line, int level,
  * in another context.
  */
 #define SMSG(...)   \
-	trace_printf(__func__, __LINE__, TRACE_ERROR, true, true, __VA_ARGS__)
+	trace_printf(__func__, __LINE__, TRACE_ERROR, true, __VA_ARGS__)
 
 #endif /* TRACE_LEVEL */
 

--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -67,7 +67,7 @@ static const char *trace_level_to_string(int level, bool level_ok)
 
 /* Format trace of user ta. Inline with kernel ta */
 void trace_printf(const char *function, int line, int level, bool level_ok,
-		  bool sync, const char *fmt, ...)
+		  const char *fmt, ...)
 {
 	va_list ap;
 	char buf[MAX_PRINT_SIZE];
@@ -110,7 +110,7 @@ void trace_printf(const char *function, int line, int level, bool level_ok,
 		buf[boffs + 1] = '\0';
 	}
 
-	trace_ext_puts(sync, buf);
+	trace_ext_puts(buf);
 }
 
 #else
@@ -132,7 +132,7 @@ int trace_get_level(void)
 
 void trace_printf(const char *function __unused, int line __unused,
 		  int level __unused, bool level_ok __unused,
-		  bool sync __unused, const char *fmt __unused, ...)
+		  const char *fmt __unused, ...)
 {
 }
 
@@ -187,15 +187,15 @@ void dhex_dump(const char *function, int line, int level,
 				if (!ok)
 					goto err;
 			} else if ((i % 16) == 15) {
-				trace_printf(function, line, level, true, false,
-					      "%s", sbuf.buf);
+				trace_printf(function, line, level, true, "%s",
+					     sbuf.buf);
 				sbuf.ptr = NULL;
 			}
 		}
 		if (sbuf.ptr) {
 			/* Buffer is not empty: flush it */
-			trace_printf(function, line, level, true, false, "%s",
-				      sbuf.buf);
+			trace_printf(function, line, level, true, "%s",
+				     sbuf.buf);
 
 		}
 	}


### PR DESCRIPTION
Avoids random mixing of secure world traces with ones from the normal
world (assuming the normal world also flushes its debug traces
synchronously).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>