### PR TITLE
core: avoid deadlocks caused by single-instance TA

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -36,6 +36,7 @@
 #endif
 
 #define THREAD_ID_0		0
+#define THREAD_ID_INVALID	-1
 
 #ifndef ASM
 extern uint32_t thread_vector_table[];
@@ -282,7 +283,7 @@ bool thread_init_stack(uint32_t stack_id, vaddr_t sp);
 /*
  * Returns current thread id.
  */
-uint32_t thread_get_id(void);
+int thread_get_id(void);
 
 /*
  * Set Thread Specific Data (TSD) pointer.

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -686,7 +686,7 @@ bool thread_init_stack(uint32_t thread_id, vaddr_t sp)
 	return true;
 }
 
-uint32_t thread_get_id(void)
+int thread_get_id(void)
 {
 	/* thread_get_core_local() requires IRQs to be disabled */
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_IRQ);


### PR DESCRIPTION
Protect against deadlocks caused by single-instance TAs calling another
single-instance TAs directly or indirectly. When a TA is invoked but
already is busy with another operation the calling thread is suspended
using condvar_wait() until the TA is available again. This is
effectively a lock which can cause a deadlock if several such locks are
used at the same time but in different order.

This patch avoids this problem by only allowing one thread at a time to
set a single-instance TA context busy. If the thread with a
single-instance TA busy in the call stack tries to set an already busy
TA context busy it will return TEE_ERROR_BUSY instead as there is a
recursive loop in how the different TAs has invoked each other.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)