### PR TITLE
plat-stm: increase secure memory

### DIFF
--- a/core/arch/arm/plat-stm/platform_config.h
+++ b/core/arch/arm/plat-stm/platform_config.h
@@ -50,15 +50,15 @@
 /*
  * TEE/TZ RAM layout:
  *
- *  +-----------------------------------------+  <- CFG_DDR_TEETZ_RESERVED_START
- *  | TEETZ private RAM  |  TEE_RAM           |   ^
- *  |                    +--------------------+   |
- *  |                    |  TA_RAM            |   |
- *  +-----------------------------------------+   | CFG_DDR_TEETZ_RESERVED_SIZE
- *  |                    |      teecore alloc |   |
- *  |  TEE/TZ and NSec   |  PUB_RAM   --------|   |
- *  |   shared memory    |         NSec alloc |   |
- *  +-----------------------------------------+   v
+ *  +---------------------------------------+  <- CFG_DDR_TEETZ_RESERVED_START
+ *  | TEETZ private RAM  |  TEE_RAM         |   ^
+ *  |                    +------------------+   |
+ *  |                    |  TA_RAM          |   |
+ *  +---------------------------------------+   | CFG_DDR_TEETZ_RESERVED_SIZE
+ *  |                    |    teecore alloc |   |
+ *  |  TEE/TZ and NSec   |  PUB_RAM   ------|   |
+ *  |   shared memory    |       NSec alloc |   |
+ *  +---------------------------------------+   v
  *
  *  TEE_RAM : 1MByte
  *  PUB_RAM : 1MByte
@@ -70,21 +70,19 @@
 #error "Invalid CFG_DDR_TEETZ_RESERVED_SIZE: at least 4MB expected"
 #endif
 
-#define CFG_PUB_RAM_SIZE                (1 * 1024 * 1024)
-#define CFG_TEE_RAM_PH_SIZE                (1 * 1024 * 1024)
-#define CFG_TA_RAM_SIZE                 (CFG_DDR_TEETZ_RESERVED_SIZE - \
-					 CFG_TEE_RAM_PH_SIZE - CFG_PUB_RAM_SIZE)
+#define CFG_SHMEM_SIZE		(1 * 1024 * 1024)
+#define CFG_TEE_RAM_PH_SIZE	(1 * 1024 * 1024)
+#define CFG_TA_RAM_SIZE		(CFG_DDR_TEETZ_RESERVED_SIZE - \
+				 CFG_TEE_RAM_PH_SIZE - CFG_SHMEM_SIZE)
 
-/* define the secure/unsecure memory areas */
-#define TZDRAM_BASE                     (CFG_DDR_TEETZ_RESERVED_START)
-#define TZDRAM_SIZE                     (CFG_TEE_RAM_PH_SIZE + CFG_TA_RAM_SIZE)
-
-#define CFG_SHMEM_START                 (TZDRAM_BASE + TZDRAM_SIZE)
-#define CFG_SHMEM_SIZE                  CFG_PUB_RAM_SIZE
+/* define the secure memory area */
+#define TZDRAM_BASE		(CFG_DDR_TEETZ_RESERVED_START)
+#define TZDRAM_SIZE		(CFG_TEE_RAM_PH_SIZE + CFG_TA_RAM_SIZE)
 
 /* define the memory areas (TEE_RAM must start at reserved DDR start addr */
-#define CFG_TEE_RAM_START               (TZDRAM_BASE)
-#define CFG_TA_RAM_START                (CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE)
+#define CFG_TEE_RAM_START	(TZDRAM_BASE)
+#define CFG_TA_RAM_START	(CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE)
+#define CFG_SHMEM_START		(CFG_TA_RAM_START + CFG_TA_RAM_SIZE)
 
 #if PLATFORM_FLAVOR_IS(cannes)
 

--- a/core/arch/arm/plat-stm/system_config.mk
+++ b/core/arch/arm/plat-stm/system_config.mk
@@ -5,8 +5,8 @@ ifeq ($(PLATFORM_FLAVOR),cannes)
 # Static configuration of DDR reserved to TEE/TZ
 # Provide here only start address and size. TEEcore will adapt.
 # Allow these settings to be overridden.
-CFG_DDR_TEETZ_RESERVED_START ?= 0x94200000
-CFG_DDR_TEETZ_RESERVED_SIZE ?= 0x00800000
+CFG_DDR_TEETZ_RESERVED_START ?= 0x93a00000
+CFG_DDR_TEETZ_RESERVED_SIZE ?= 0x01000000
 
 else ifeq ($(PLATFORM_FLAVOR),orly2)
 


### PR DESCRIPTION
On plat-stm, available RAM for TA was 6MB. This is too small to run
xtest 1005 and 1006, which are opening multiple session of os_test
TA, which is huge.

This patch increases the available memory to TAs, to 14MB.

Signed-off-by: Pascal Brand <pascal.brand@st.com>