### PR TITLE
pager: remove pages used by scratch memory

### DIFF
--- a/core/arch/arm/include/mm/tee_pager.h
+++ b/core/arch/arm/include/mm/tee_pager.h
@@ -79,4 +79,19 @@ void tee_pager_abort_handler(uint32_t abort_type,
  */
 void tee_pager_add_pages(vaddr_t vaddr, size_t npages, bool unmap);
 
+/*
+ * Unmap vmem and free physical pages for the pager.
+ *
+ * vaddr is the first virtual address (must be page aligned)
+ * size is the vmem size in bytes (must be page size aligned)
+ */
+void tee_pager_release_zi(vaddr_t vaddr, size_t size);
+
+/*
+ * allocate RW vmem and register to the pager.
+ *
+ * size is the vmem size in bytes
+ */
+void *tee_pager_request_zi(size_t size);
+
 #endif /*MM_TEE_PAGER_H*/

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -31,6 +31,9 @@ entries-unpaged += core_init_mmu_regs
 entries-unpaged += stack_tmp_top
 entries-unpaged += sem_cpu_sync
 entries-unpaged += generic_boot_get_handlers
+entries-unpaged += tee_pager_release_zi
+entries-unpaged += tee_pager_request_zi
+
 objs-unpaged-rem += core/arch/arm/tee/entry.o
 objs-unpaged-rem += core/arch/arm/tee/arch_svc.o
 objs-unpaged := \


### PR DESCRIPTION
Libtomcrypt is using, because of mpa, some scratch memory
used in intermediate computation. These data are useless
once the acipher computation is completed. That means
that these data pages can be unmapped.

On QEMU, compiled with CFG_WITH_PAGER=y, "time xtest 4006" returns:
- Before the patch
	real	3m 46.24s
	user	0m 0.19s
	sys	3m 45.51s
- After the patch
	real	1m 29.00s
	user	0m 0.17s
	sys	1m 28.51s

Signed-off-by: Pascal Brand <pascal.brand@st.com>