### PR TITLE
arm/pager: move init temp storage of hashes

### DIFF
--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -51,6 +51,8 @@ extern uint8_t __bss_start[];
 extern uint8_t __bss_end[];
 extern uint8_t __init_start[];
 extern uint8_t __init_size[];
+extern uint8_t __tmp_hashes_start[];
+extern uint8_t __tmp_hashes_size[];
 extern uint8_t __heap1_start[];
 extern uint8_t __heap1_end[];
 extern uint8_t __heap2_start[];

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -161,15 +161,10 @@ static void init_runtime(uint32_t pageable_part)
 	tee_mm_entry_t *mm;
 	uint8_t *paged_store;
 	uint8_t *hashes;
-	uint8_t *tmp_hashes = __init_start + init_size;
 	size_t block_size;
 
-
 	TEE_ASSERT(pageable_size % SMALL_PAGE_SIZE == 0);
-
-
-	/* Copy it right after the init area. */
-	memcpy(tmp_hashes, __data_end + init_size, hash_size);
+	TEE_ASSERT(hash_size == (size_t)__tmp_hashes_size);
 
 	/*
 	 * Zero BSS area. Note that globals that would normally would go
@@ -184,7 +179,7 @@ static void init_runtime(uint32_t pageable_part)
 	hashes = malloc(hash_size);
 	EMSG("hash_size %zu", hash_size);
 	TEE_ASSERT(hashes);
-	memcpy(hashes, tmp_hashes, hash_size);
+	memcpy(hashes, __tmp_hashes_start, hash_size);
 
 	/*
 	 * Need tee_mm_sec_ddr initialized to be able to allocate secure

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -178,21 +178,18 @@ LOCAL_FUNC reset_primary , :
 
 #ifdef CFG_WITH_PAGER
 	/*
-	 * Move init code into correct location
+	 * Move init code into correct location and move hashes to a
+	 * temporary safe location until the heap is initialized.
 	 *
 	 * The binary is built as:
 	 * [Pager code, rodata and data] : In correct location
 	 * [Init code and rodata] : Should be copied to __text_init_start
-	 * [Hashes] : Should be saved before clearing bss
+	 * [Hashes] : Should be saved before initializing pager
 	 *
-	 * When we copy init code and rodata into correct location we don't
-	 * need to worry about hashes being overwritten as size of .bss,
-	 * .heap, .nozi and .heap3 is much larger than the size of init
-	 * code and rodata and hashes.
 	 */
 	ldr	r0, =__text_init_start	/* dst */
 	ldr	r1, =__data_end 	/* src */
-	ldr	r2, =__rodata_init_end	/* dst limit */
+	ldr	r2, =__tmp_hashes_end	/* dst limit */
 copy_init:
 	ldm	r1!, {r6-r12}
 	stm	r0!, {r6-r12}

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -232,7 +232,6 @@ SECTIONS
 	__init_start = __text_init_start;
 	__init_end = .;
 	__init_size = __init_end - __text_init_start;
-	__init_mem_usage = __init_end - CFG_TEE_LOAD_ADDR;
 
 	.text_pageable : ALIGN(4) {
 		__text_pageable_start = .;
@@ -256,6 +255,17 @@ SECTIONS
 	__pageable_part_end = __rodata_pageable_end;
 	__pageable_start = __text_init_start;
 	__pageable_end = __pageable_part_end;
+
+	/*
+	 * Assign a safe spot to store the hashes of the pages before
+	 * heap is initialized.
+	 */
+	__tmp_hashes_start = __rodata_init_end;
+	__tmp_hashes_size = ((__pageable_end - __pageable_start) /
+				(4 * 1024)) * 32;
+	__tmp_hashes_end = __tmp_hashes_start + __tmp_hashes_size;
+
+	__init_mem_usage = __tmp_hashes_end - CFG_TEE_LOAD_ADDR;
 
 	ASSERT(CFG_TEE_LOAD_ADDR >= CFG_TEE_RAM_START,
 		"Load address before start of physical memory")


### PR DESCRIPTION
When a paged OP-TEE binary is copied into secure memory with unpaged
code and data in the correct location, but with init code and hashes of
paged pages starting at the start of the .bss section. If .bss is large
enough init code and hashes will fit entirely in the .bss section and as
long as .bss is unused the data there is safe.

This assumption will not be true any longer if .bss shrinks dramatically
due to reduced size of mpa scratch memory.

With this patch the hashes will be copied to a temporary safe location
right after the init code. This location is the same as the start of the
.text_pageable section so the hashes must be copied to the final
location before the pager is initialized.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>