### PR TITLE
plat-*/conf.mk cleanup

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -1,45 +1,43 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-ifeq ($(CFG_ARM64_core),y)
-CFG_WITH_LPAE := y
-else
-CFG_ARM32_core ?= y
-CFG_MMU_V7_TTB ?= y
-endif
-
 core-platform-cppflags	+= -I$(arch-dir)/include
-
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
 
-libutil_with_isoc := y
-libtomcrypt_with_optimize_size := y
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_PL011,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-CFG_WITH_ARM_TRUSTED_FW := y
-CFG_SECURE_TIME_SOURCE_CNTPCT ?= y
-CFG_PL011 ?= y
-CFG_HWSUPP_MEM_PERM_PXN ?= y
-CFG_WITH_STACK_CANARIES ?= y
-CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= n
-CFG_GENERIC_BOOT ?= y
-CFG_PM_STUBS ?= y
-CFG_CRYPTO_SHA256_ARM32_CE ?= $(CFG_ARM32_core)
-CFG_CRYPTO_SHA256_ARM64_CE ?= $(CFG_ARM64_core)
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+else
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_MMU_V7_TTB,y)
+endif
+
+libtomcrypt_with_optimize_size ?= y
+CFG_CRYPTO_AES_ARM64_CE ?= $(CFG_ARM64_core)
 CFG_CRYPTO_SHA1_ARM32_CE ?= $(CFG_ARM32_core)
 CFG_CRYPTO_SHA1_ARM64_CE ?= $(CFG_ARM64_core)
-CFG_CRYPTO_AES_ARM64_CE ?= $(CFG_ARM64_core)
+CFG_CRYPTO_SHA256_ARM32_CE ?= $(CFG_ARM32_core)
+CFG_CRYPTO_SHA256_ARM64_CE ?= $(CFG_ARM64_core)
+CFG_WITH_STACK_CANARIES ?= y
 
 ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
 endif
 ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
 endif
 ifeq ($(CFG_CRYPTO_SHA1_ARM64_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
 endif
 ifeq ($(CFG_CRYPTO_AES_ARM64_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
 endif
 
 include mk/config.mk

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -1,29 +1,20 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_COMPILE	?= arm-linux-gnueabihf-
-COMPILER	?= gcc
-
-CFG_ARM32_core ?= y
-CFG_MMU_V7_TTB ?= y
-
-core-platform-cppflags	 = -I$(arch-dir)/include
+core-platform-cppflags  = -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-libutil_with_isoc := y
-CFG_GENERIC_BOOT ?= y
-CFG_IMX_UART ?= y
-CFG_MMU_V7_TTB ?= y
-CFG_NO_TA_HASH_SIGN ?= y
-CFG_PM_STUBS ?= y
-CFG_SECURE_TIME_SOURCE_CNTPCT := y
-CFG_WITH_SOFTWARE_PRNG ?= y
-CFG_WITH_STACK_CANARIES := y
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_GIC,y)
+$(call force,CFG_IMX_UART,y)
+$(call force,CFG_MMU_V7_TTB,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+
+CFG_WITH_STACK_CANARIES ?= y
 
 include mk/config.mk
-
-core-platform-cppflags += -D_USE_SLAPORT_LIB
-
-core-platform-cppflags += -DCFG_NO_TA_HASH_SIGN
-CFG_GIC := y

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -1,28 +1,19 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CROSS_PREFIX	?= arm-linux-gnueabihf
-CROSS_COMPILE	?= $(CROSS_PREFIX)-
-include mk/gcc.mk
-
-PLATFORM_FLAVOR ?= ls1021atwr
-
-CFG_ARM32_core ?= y
-CFG_MMU_V7_TTB ?= y
-
 core-platform-cppflags	 = -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
-
 core-platform-subdirs += $(arch-dir)/sm
 
-libutil_with_isoc := y
-CFG_SECURE_TIME_SOURCE_CNTPCT := y
-CFG_WITH_STACK_CANARIES := y
-CFG_16550_UART ?= y
-CFG_GENERIC_BOOT ?= y
-CFG_PM_STUBS ?= y
-CFG_BOOT_SYNC_CPU ?= y
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_MMU_V7_TTB,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_16550_UART,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_BOOT_SYNC_CPU,y)
+
+CFG_WITH_STACK_CANARIES ?= y
 
 include mk/config.mk
-
-CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= n

--- a/core/arch/arm/plat-ls/platform_flags.mk
+++ b/core/arch/arm/plat-ls/platform_flags.mk
@@ -1,3 +1,6 @@
+PLATFORM_FLAVOR ?= ls1021atwr
+PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
+
 platform-cpuarch = cortex-a7
 platform-cflags = -mcpu=$(platform-cpuarch) -mthumb
 platform-cflags += -pipe -mthumb-interwork -mlong-calls

--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -1,34 +1,32 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-ifeq ($(CFG_ARM64_core),y)
-CFG_WITH_LPAE := y
-else
-CFG_ARM32_core ?= y
-CFG_MMU_V7_TTB ?= y
-endif
-
 core-platform-cppflags	+= -I$(arch-dir)/include
-
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
 
-libutil_with_isoc := y
-libtomcrypt_with_optimize_size := y
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_8250_UART,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-CFG_WITH_ARM_TRUSTED_FW := y
-CFG_SECURE_TIME_SOURCE_CNTPCT ?= y
-CFG_8250_UART ?= y
-CFG_HWSUPP_MEM_PERM_PXN ?= y
-CFG_WITH_STACK_CANARIES ?= y
-CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= n
-CFG_GENERIC_BOOT ?= y
-CFG_PM_STUBS ?= y
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+else
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_MMU_V7_TTB,y)
+endif
 
 ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
 endif
 ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
 endif
+
+libtomcrypt_with_optimize_size ?= y
+CFG_WITH_STACK_CANARIES ?= y
 
 include mk/config.mk

--- a/core/arch/arm/plat-stm/conf.mk
+++ b/core/arch/arm/plat-stm/conf.mk
@@ -1,28 +1,26 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CFG_ARM32_core ?= y
-
 core-platform-cppflags	+= -I$(arch-dir)/include
-
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-libutil_with_isoc ?= y
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_SECURE_TIME_SOURCE_REE,y)
+$(call force,CFG_PL310,y)
+$(call force,CFG_CACHE_API,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_MMU_V7_TTB,y)
+$(call force,CFG_BOOT_SYNC_CPU,y)
+
 libtomcrypt_with_optimize_size ?= y
-CFG_SECURE_TIME_SOURCE_REE ?= y
-CFG_PL310 ?= y
-CFG_CACHE_API ?= y
-CFG_WITH_STACK_CANARIES ?= y
-CFG_PM_STUBS ?= y
-CFG_GENERIC_BOOT ?= y
-CFG_WITH_SOFTWARE_PRNG ?= n
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+CFG_WITH_STACK_CANARIES ?= y
 CFG_WITH_STATS ?= y
-CFG_MMU_V7_TTB ?= y
-CFG_PL310_LOCKED ?= n
+CFG_WITH_SOFTWARE_PRNG ?= n
 CFG_TEE_GDB_BOOT ?= y
-CFG_BOOT_SYNC_CPU ?= y
 
 include mk/config.mk
 include $(platform-dir)/system_config.mk

--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -1,26 +1,21 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CFG_ARM32_core ?= y
-CFG_NUM_THREADS ?= 4
-
-core-platform-cppflags	 = -I$(arch-dir)/include
+core-platform-cppflags = -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-libutil_with_isoc := y
-CFG_SECURE_TIME_SOURCE_CNTPCT := y
-CFG_WITH_STACK_CANARIES := y
-CFG_SUNXI_UART ?= y
-CFG_MMU_V7_TTB ?= y
-CFG_PM_STUBS ?= y
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_SUNXI_UART,y)
+$(call force,CFG_MMU_V7_TTB,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_GIC,y)
 
-include mk/config.mk
-
+CFG_NUM_THREADS ?= 4
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+CFG_WITH_STACK_CANARIES ?= y
 CFG_WITH_STATS ?= y
 
-core-platform-cppflags += -DTEE_USE_DLMALLOC
-core-platform-cppflags += -D_USE_SLAPORT_LIB
-
-CFG_GIC := y
+include mk/config.mk

--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -1,25 +1,23 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-CFG_ARM32_core ?= y
-CFG_MMU_V7_TTB ?= y
-
 core-platform-cppflags	+= -I$(arch-dir)/include
-
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-libutil_with_isoc := y
-libtomcrypt_with_optimize_size := y
-CFG_SECURE_TIME_SOURCE_CNTPCT := y
-CFG_8250_UART ?= y
-CFG_HWSUPP_MEM_PERM_PXN := y
-CFG_WITH_STACK_CANARIES := y
-CFG_PM_STUBS := y
-CFG_GENERIC_BOOT := y
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_8250_UART,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_MMU_V7_TTB,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+
+libtomcrypt_with_optimize_size ?= y
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+CFG_WITH_STACK_CANARIES ?= y
 CFG_WITH_STATS ?= y
-CFG_NO_TA_HASH_SIGN ?= y
-CFG_WITH_SOFTWARE_PRNG ?= y
 
 include mk/config.mk

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -1,52 +1,53 @@
 include core/arch/$(ARCH)/plat-$(PLATFORM)/platform_flags.mk
 
-ifeq ($(CFG_ARM64_core),y)
-CFG_WITH_LPAE := y
-else
-CFG_ARM32_core ?= y
-CFG_MMU_V7_TTB ?= y
-endif
-
 core-platform-cppflags	+= -I$(arch-dir)/include
-
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
+
+$(call force,libutil_with_isoc,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_GIC,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_PL011,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+else
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_MMU_V7_TTB,y)
+endif
+
 ifeq ($(platform-flavor-armv8),1)
-CFG_WITH_ARM_TRUSTED_FW := y
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 else
 core-platform-subdirs += $(arch-dir)/sm
 endif
 
-libutil_with_isoc := y
-libtomcrypt_with_optimize_size := y
-CFG_SECURE_TIME_SOURCE_CNTPCT := y
-CFG_PL011 := y
-CFG_GIC := y
-CFG_HWSUPP_MEM_PERM_PXN := y
-CFG_WITH_STACK_CANARIES := y
-CFG_PM_STUBS := y
-CFG_GENERIC_BOOT := y
+libtomcrypt_with_optimize_size ?= y
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+CFG_TEE_FS_KEY_MANAGER_TEST ?= y
+CFG_WITH_STACK_CANARIES ?= y
 CFG_WITH_STATS ?= y
-CFG_TEE_FS_KEY_MANAGER_TEST := y
 
 ifeq ($(PLATFORM_FLAVOR),juno)
 CFG_CRYPTO_SHA256_ARM32_CE ?= $(CFG_ARM32_core)
 CFG_CRYPTO_SHA1_ARM32_CE ?= $(CFG_ARM32_core)
 endif
 
-# SE API is only supported by QEMU Virt platform
-ifeq ($(PLATFORM_FLAVOR),qemu_virt)
-CFG_SE_API := y
-CFG_SE_API_SELF_TEST := y
-CFG_PCSC_PASSTHRU_READER_DRV := y
-endif
-
 ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
 endif
 ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
-CFG_WITH_VFP := y
+$(call force,CFG_WITH_VFP,y)
+endif
+
+# SE API is only supported by QEMU Virt platform
+ifeq ($(PLATFORM_FLAVOR),qemu_virt)
+CFG_SE_API ?= y
+CFG_SE_API_SELF_TEST ?= y
+CFG_PCSC_PASSTHRU_READER_DRV ?= y
 endif
 
 include mk/config.mk

--- a/core/core.mk
+++ b/core/core.mk
@@ -6,6 +6,7 @@ sm-$(sm) := y
 
 arch-dir	:= core/arch/$(ARCH)
 platform-dir	:= $(arch-dir)/plat-$(PLATFORM)
+include mk/checkconf.mk
 include $(platform-dir)/conf.mk
 include core/arch/$(ARCH)/$(ARCH).mk
 
@@ -39,7 +40,6 @@ $(conf-file): $(conf-mk-file)
 cleanfiles += $(conf-file)
 cleanfiles += $(conf-mk-file)
 
-include mk/checkconf.mk
 $(conf-file): FORCE
 	$(call check-conf-h)
 

--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -146,3 +146,19 @@ cfg-enable-all-depends =                                                        
              ,                                                                             \
         )                                                                                  \
      )
+
+# Set a variable and error out if it was previously set to a different value
+# Example:
+# $(call force,CFG_FOO,foo)
+define force
+$(eval $(call _force,$(1),$(2)))
+endef
+
+define _force
+ifdef $(1)
+ifneq ($($(1)),$(2))
+$$(error $(1) is set to '$($(1))' (from $(origin $(1))) but its value must be '$2')
+endif
+endif
+$(1) := $(2)
+endef


### PR DESCRIPTION
- Do not set CFG_ values that do not change the default
- Always use '?=' as opposed to ':=' for consistent behavior with
  'X=Y make' and 'make X=Y'
- Always include mk/conf.mk last so that the platform definitions
  always take precedence over the global configuration

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>