### PR TITLE
ta-dev-kit: export signed_hdr.h and types_ext.h

### DIFF
--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -27,7 +27,7 @@
 #ifndef SIGNED_HDR_H
 #define SIGNED_HDR_H
 
-#include <types_ext.h>
+#include <inttypes.h>
 
 enum shdr_img_type {
 	SHDR_TA = 0,

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -42,6 +42,7 @@ incfiles-extra-host += lib/libutils/ext/include/util.h
 incfiles-extra-host += $(out-dir)/core/include/generated/conf.h
 incfiles-extra-host += $(out-dir)/core/conf.mk
 incfiles-extra-host += core/include/tee/tee_fs_key_manager.h
+incfiles-extra-host += core/include/signed_hdr.h
 
 #
 # Copy lib files and exported headers from each lib


### PR DESCRIPTION
Exports `core/include/signed_hdr.h` and `lib/libutils/ext/include/types_ext.h` to `host_include` to be able to use `struct shdr` when testing TAs corrupted at different places.

Needed by https://github.com/OP-TEE/optee_test/pull/46