### PR TITLE
Bug fix

### DIFF
--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -33,6 +33,9 @@
 #include <compiler.h>
 #include <tee_api_defines.h>
 #include <tee_api_types.h>
+#if defined(CFG_TEE_PANIC_DEBUG)
+#include <trace.h>
+#endif
 
 /* Property access functions */
 
@@ -72,7 +75,14 @@ TEE_Result TEE_GetNextProperty(TEE_PropSetHandle enumerator);
 
 /* System API - Misc */
 
+void __TEE_Panic(TEE_Result panicCode);
 void TEE_Panic(TEE_Result panicCode);
+#if defined(CFG_TEE_PANIC_DEBUG)
+#define TEE_Panic(c) do { \
+		EMSG("Panic 0x%x", (c)); \
+		__TEE_Panic(c); \
+	} while (0)
+#endif
 
 /* System API - Internal Client API */
 

--- a/lib/libutee/sub.mk
+++ b/lib/libutee/sub.mk
@@ -11,5 +11,6 @@ srcs-y += tee_api.c
 srcs-y += tee_api_objects.c
 srcs-y += tee_api_operations.c
 srcs-y += tee_api_se.c
+srcs-y += tee_api_panic.c
 
 subdirs-y += arch/$(ARCH)

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -34,13 +34,6 @@
 
 static void *tee_api_instance_data;
 
-/* System API - Misc */
-
-void __noreturn TEE_Panic(TEE_Result panicCode)
-{
-	utee_panic(panicCode);
-}
-
 /* System API - Internal Client API */
 
 TEE_Result TEE_OpenTASession(const TEE_UUID *destination,

--- a/lib/libutee/tee_api_panic.c
+++ b/lib/libutee/tee_api_panic.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <tee_api.h>
+#include <utee_syscalls.h>
+
+#undef TEE_Panic
+
+/* System API - Misc */
+
+void __noreturn __TEE_Panic(TEE_Result panicCode)
+{
+	utee_panic(panicCode);
+}
+
+void __noreturn TEE_Panic(TEE_Result panicCode)
+{
+	__TEE_Panic(panicCode);
+}
+

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -50,6 +50,11 @@ CFG_TEE_TA_LOG_LEVEL ?= 1
 # CFG_TEE_TA_LOG_LEVEL. Otherwise, they are not output at all
 CFG_TEE_CORE_TA_TRACE ?= y
 
+# Define TEE_Panic as a macro to help debugging panics caused by calls to
+# TEE_Panic. This flag can have a different value when later compiling the
+# TA
+CFG_TEE_PANIC_DEBUG ?= y
+
 # If 1, enable debug features in TA memory allocation.
 # Debug features include check of buffer overflow, statistics, mark/check heap
 # feature.

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -53,6 +53,10 @@ cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 CFG_TEE_CORE_USER_MEM_DEBUG ?= 0
 cppflags$(sm) += -DCFG_TEE_CORE_USER_MEM_DEBUG=$(CFG_TEE_CORE_USER_MEM_DEBUG)
 
+ifeq ($(CFG_TEE_PANIC_DEBUG),y)
+cppflags$(sm) += -DCFG_TEE_PANIC_DEBUG=1
+endif
+
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
 
 include $(ta-dev-kit-dir)/mk/arch.mk


### PR DESCRIPTION
This fixes occasional TA panics observed when running xtest as:
```
xtest 4006 & xtest 4006 & xtest 4006 & xtest 4006 & xtest 4006 &
```
on QEMU. The test case still fails but in an expected way.

The "libutee: Replace TEE_Panic() with macro" commit isn't really needed, but it's quite handy when tracking down a TA panic.