### PR TITLE
drivers/core/gic.c: Set priority mask to allow NS interrupts

### DIFF
--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -112,16 +112,16 @@ out:
 
 void gic_cpu_init(void)
 {
-    /* per-CPU inerrupts config:
-    * ID0-ID7(SGI)   for Non-secure interrupts
-    * ID8-ID15(SGI)  for Secure interrupts.
-    * All PPI config as Non-secure interrupts.
-    */
-    write32(0xffff00ff, gic.gicd_base + GICD_IGROUPR(0));
+	/* per-CPU interrupts config:
+	 * ID0-ID7(SGI)   for Non-secure interrupts
+	 * ID8-ID15(SGI)  for Secure interrupts.
+	 * All PPI config as Non-secure interrupts.
+	 */
+	write32(0xffff00ff, gic.gicd_base + GICD_IGROUPR(0));
 
-    /* Enable GIC */
-    write32(GICC_CTLR_ENABLEGRP0 | GICC_CTLR_ENABLEGRP1 | GICC_CTLR_FIQEN,
-        gic.gicc_base + GICC_CTLR);
+	/* Enable GIC */
+	write32(GICC_CTLR_ENABLEGRP0 | GICC_CTLR_ENABLEGRP1 | GICC_CTLR_FIQEN,
+		gic.gicc_base + GICC_CTLR);
 }
 
 void gic_init(vaddr_t gicc_base, vaddr_t gicd_base)

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -33,6 +33,7 @@
 
 /* Offsets from gic.gicc_base */
 #define GICC_CTLR		(0x000)
+#define GICC_PMR		(0x004)
 #define GICC_IAR		(0x00C)
 #define GICC_EOIR		(0x010)
 
@@ -119,6 +120,11 @@ void gic_cpu_init(void)
 	 */
 	write32(0xffff00ff, gic.gicd_base + GICD_IGROUPR(0));
 
+	/* Set the priority mask to permit Non-secure interrupts, and to
+	 * allow the Non-secure world to adjust the priority mask itself
+	 */
+	write32(0x80, gic.gicc_base + GICC_PMR);
+
 	/* Enable GIC */
 	write32(GICC_CTLR_ENABLEGRP0 | GICC_CTLR_ENABLEGRP1 | GICC_CTLR_FIQEN,
 		gic.gicc_base + GICC_CTLR);
@@ -151,6 +157,11 @@ void gic_init(vaddr_t gicc_base, vaddr_t gicd_base)
 			write32(0xffffffff, gic.gicd_base + GICD_IGROUPR(n));
 		}
 	}
+
+	/* Set the priority mask to permit Non-secure interrupts, and to
+	 * allow the Non-secure world to adjust the priority mask itself
+	 */
+	write32(0x80, gic.gicc_base + GICC_PMR);
 
 	/* Enable GIC */
 	write32(GICC_CTLR_ENABLEGRP0 | GICC_CTLR_ENABLEGRP1 | GICC_CTLR_FIQEN,


### PR DESCRIPTION
The non-secure world's view of interrupt priorities only allows it to set priorities between 0x80 and 0xff. This means that the secure world has to set the GICC_PMR (priority mask register) to a value that allows NS interrupts, otherwise the non-secure world will never see interrupts and has no way to set the priorities so that it will ever see them.

This wasn't causing problems for the version of QEMU OP-TEE is currently using, because that has a GIC which does not support TrustZone. However it is essential for being able to move forward to a newer QEMU with a TZ-aware GIC. Otherwise the Non-secure OS hangs late in boot because of the lack of interrupts.

Patch 1 is just a coding style fix, since the function is short and patch 2 needs to modify it anyway.

WARNING: I have tested this with QEMU, but don't have any access to hardware for testing.
