### PR TITLE
plat-vexpress: Configure secure UART interrupt in qemu_virt startup

### DIFF
--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -103,6 +103,10 @@ void main_init_gic(void)
 {
 	/* Initialize GIC */
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_it_add(IT_CONSOLE_UART);
+	gic_it_set_cpu_mask(IT_CONSOLE_UART, 0x1);
+	gic_it_set_prio(IT_CONSOLE_UART, 0x1);
+	gic_it_enable(IT_CONSOLE_UART);
 }
 #endif
 


### PR DESCRIPTION
Configure the secure UART interrupt for the qemu_virt platform flavour, rather than letting it default to non-secure. This doesn't seem to be necessary for the tests to run, presumably because the Non-secure guest doesn't spend long periods with interrupts disabled and the Secure world doesn't have critical requirements for interrupt delivery, but it makes sense and brings qemu_virt closer into line with the other platforms.

Note that we set the interrupt priority to 1 (following 'fvp' and 'juno'), rather than 0xff (which 'qemu' uses, and which would make the S interrupt have a lower priority than NS interrupts).
