### PR TITLE
Delete libutil_with_isoc

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -4,7 +4,6 @@ core-platform-cppflags	+= -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
 $(call force,CFG_PL011,y)

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -5,7 +5,6 @@ core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_GIC,y)

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -5,7 +5,6 @@ core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_MMU_V7_TTB,y)

--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -4,7 +4,6 @@ core-platform-cppflags	+= -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_8250_UART,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_HWSUPP_MEM_PERM_PXN,y)

--- a/core/arch/arm/plat-stm/conf.mk
+++ b/core/arch/arm/plat-stm/conf.mk
@@ -5,7 +5,6 @@ core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_SECURE_TIME_SOURCE_REE,y)
 $(call force,CFG_PL310,y)

--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -5,7 +5,6 @@ core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_SUNXI_UART,y)

--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -5,7 +5,6 @@ core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 core-platform-subdirs += $(arch-dir)/sm
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_8250_UART,y)
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_GENERIC_BOOT,y)

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -4,7 +4,6 @@ core-platform-cppflags	+= -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee sta) $(platform-dir)
 
-$(call force,libutil_with_isoc,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_HWSUPP_MEM_PERM_PXN,y)

--- a/lib/libutils/sub.mk
+++ b/lib/libutils/sub.mk
@@ -1,2 +1,2 @@
-subdirs-$(libutil_with_isoc) += isoc
+subdirs-y += isoc
 subdirs-y += ext


### PR DESCRIPTION
OP-TEE won't build unless $(libutil_with_isoc) is 'y', so this variable
is not needed.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>