### PR TITLE
plat-vexpress: bugfix reading char from uart

### DIFF
--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -120,8 +120,9 @@ static void main_fiq(void)
 	iar = gic_read_iar();
 
 	while (pl011_have_rx_data(CONSOLE_UART_BASE)) {
-		DMSG("cpu %zu: got 0x%x",
-		     get_core_pos(), pl011_getchar(CONSOLE_UART_BASE));
+		int ch __unused = pl011_getchar(CONSOLE_UART_BASE);
+
+		DMSG("cpu %zu: got 0x%x", get_core_pos(), ch);
 	}
 
 	gic_write_eoir(iar);


### PR DESCRIPTION
If debug prints aren't enabled plat-vexpress doesn't read characters
from the uart resulting in an endless loop.

This patch always reads the character regardless of debug prints.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (Juno)