### PR TITLE
core: remove unused code related to the TEE_ALIGNMENT_IS_OK() macro

### DIFF
--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -265,7 +265,7 @@ static TEE_Result elf_process_rel(struct elf_load_state *state, size_t rel_sidx,
 			return TEE_ERROR_BAD_FORMAT;
 
 		sym_tab = (Elf32_Sym *)(vabase + shdr[sym_tab_idx].sh_addr);
-		if (!TEE_ALIGNMENT_IS_OK(sym_tab, Elf32_Sym))
+		if (!ALIGNMENT_IS_OK(sym_tab, Elf32_Sym))
 			return TEE_ERROR_BAD_FORMAT;
 
 		num_syms = shdr[sym_tab_idx].sh_size / sizeof(Elf32_Sym);
@@ -275,7 +275,7 @@ static TEE_Result elf_process_rel(struct elf_load_state *state, size_t rel_sidx,
 	if (shdr[rel_sidx].sh_addr >= state->vasize)
 		return TEE_ERROR_BAD_FORMAT;
 	rel = (Elf32_Rel *)(vabase + shdr[rel_sidx].sh_addr);
-	if (!TEE_ALIGNMENT_IS_OK(rel, Elf32_Rel))
+	if (!ALIGNMENT_IS_OK(rel, Elf32_Rel))
 		return TEE_ERROR_BAD_FORMAT;
 
 	/* Check the address is inside TA memory */
@@ -291,7 +291,7 @@ static TEE_Result elf_process_rel(struct elf_load_state *state, size_t rel_sidx,
 			return TEE_ERROR_BAD_FORMAT;
 
 		where = (Elf32_Addr *)(vabase + rel->r_offset);
-		if (!TEE_ALIGNMENT_IS_OK(where, Elf32_Addr))
+		if (!ALIGNMENT_IS_OK(where, Elf32_Addr))
 			return TEE_ERROR_BAD_FORMAT;
 
 		switch (ELF32_R_TYPE(rel->r_info)) {

--- a/core/arch/arm/kernel/tee_ta_manager.c
+++ b/core/arch/arm/kernel/tee_ta_manager.c
@@ -934,7 +934,7 @@ static TEE_Result tee_ta_rpc_load(const TEE_UUID *uuid,
 		goto out;
 	}
 
-	if (!TEE_ALIGNMENT_IS_OK(phpayload, struct tee_rpc_load_ta_cmd)) {
+	if (!ALIGNMENT_IS_OK(phpayload, struct tee_rpc_load_ta_cmd)) {
 		*ret_orig = TEE_ORIGIN_TEE;
 		res = TEE_ERROR_GENERIC;
 		goto out;

--- a/core/arch/arm/kernel/tee_time.c
+++ b/core/arch/arm/kernel/tee_time.c
@@ -34,6 +34,7 @@
 #include <sm/teesmc.h>
 #include <kernel/tee_rpc.h>
 #include <mm/core_mmu.h>
+#include <util.h>
 
 struct time_source _time_source;
 
@@ -90,7 +91,7 @@ TEE_Result tee_time_get_ree_time(TEE_Time *time)
 	if (!phpayload)
 		goto exit;
 
-	if (!TEE_ALIGNMENT_IS_OK(phpayload, TEE_Time))
+	if (!ALIGNMENT_IS_OK(phpayload, TEE_Time))
 		goto exit;
 
 	if (core_pa2va(phpayload, &payload))

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -540,7 +540,7 @@ void __thread_std_smc_entry(struct thread_smc_args *args)
 
 		parg = thread_rpc_alloc_arg(
 				TEESMC32_GET_ARG_SIZE(RPC_MAX_PARAMS));
-		if (!parg || !TEE_ALIGNMENT_IS_OK(parg, struct teesmc32_arg) ||
+		if (!parg || !ALIGNMENT_IS_OK(parg, struct teesmc32_arg) ||
 		     core_pa2va(parg, &arg)) {
 			thread_rpc_free_arg(parg);
 			args->a0 = TEESMC_RETURN_ENOMEM;

--- a/core/arch/arm/tee/arch_tee_fs.c
+++ b/core/arch/arm/tee/arch_tee_fs.c
@@ -57,7 +57,7 @@ int tee_fs_send_cmd(struct tee_fs_rpc *bf_cmd, void *data, uint32_t len,
 	if (!phpayload)
 		goto exit;
 
-	if (!TEE_ALIGNMENT_IS_OK(phpayload, struct tee_fs_rpc))
+	if (!ALIGNMENT_IS_OK(phpayload, struct tee_fs_rpc))
 		goto exit;
 
 	if (core_pa2va(phpayload, &bf))

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -29,10 +29,10 @@
 
 #include <tee/entry_std.h>
 #include <sm/teesmc.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/tee_dispatch.h>
 #include <kernel/panic.h>
 #include <mm/core_mmu.h>
+#include <util.h>
 
 #include <assert.h>
 
@@ -272,7 +272,7 @@ void tee_entry_std(struct thread_smc_args *args)
 
 	arg_pa = args->a1;
 	if (!tee_pbuf_is_non_sec(arg_pa, sizeof(struct teesmc32_arg)) ||
-	    !TEE_ALIGNMENT_IS_OK(arg_pa, struct teesmc32_arg) ||
+	    !ALIGNMENT_IS_OK(arg_pa, struct teesmc32_arg) ||
 	    core_pa2va(arg_pa, &arg32)) {
 		EMSG("Bad arg address 0x%" PRIxPA, arg_pa);
 		args->a0 = TEESMC_RETURN_EBADADDR;

--- a/core/include/kernel/tee_common_unpg.h
+++ b/core/include/kernel/tee_common_unpg.h
@@ -71,30 +71,6 @@ typedef uintptr_t tee_uaddr_t;
 
 #endif
 
-#define TEE_ASSERT_ALIGNMENT(p, type)                       \
-		TEE_ASSERT(TEE_ALIGNMENT_IS_OK(p, type))
-
-#ifndef TEE_ALIGNMENT_IS_OK
-#ifdef CFG_TC_NO_ALIGNOF
-#define TEE_ALIGNMENT_1B_IS_OK(p, type)    (true)
-#define TEE_ALIGNMENT_2B_IS_OK(p, type)    ((&(p) & 1 == 0) ? true : false)
-#define TEE_ALIGNMENT_4B_IS_OK(p, type)    ((&(p) & 3 == 0) ? true : false)
-#define TEE_ALIGNMENT_8B_IS_OK(p, type)    ((&(p) & 7 == 0) ? true : false)
-#define TEE_ALIGNMENT_IS_OK(p, type)       TEE_ALIGNMENT_4B_IS_OK(p, type)
-#else
-#define TEE_ALIGNMENT_1B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_2B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_4B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_8B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_IS_OK(p, type)       TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-
-#define TEE_ALIGNMENT_WRAP_IS_OK(p, type)                        \
-		(((uintptr_t)p & (__tee_assert_alignof__(type) - 1)) == 0)
-
-#define __tee_assert_alignof__(type) __alignof__(type)
-#endif
-#endif
-
 /*-----------------------------------------------------------------------------
  * tee_ta_load_page - Loads a page at address va_addr
  * Parameters:

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -36,6 +36,7 @@
 #include <tee/tee_cryp_provider.h>
 #include <trace.h>
 #include <string_ext.h>
+#include <util.h>
 #if defined(CFG_CRYPTO_HKDF) || defined(CFG_CRYPTO_CONCAT_KDF) || \
 	defined(CFG_CRYPTO_PBKDF2)
 #include <tee_api_defines_extensions.h>
@@ -641,7 +642,7 @@ static TEE_Result tee_svc_cryp_obj_copy_out(struct tee_ta_session *sess,
 					    raw_data_size);
 	case TEE_TYPE_CONV_FUNC_SECRET:
 
-		if (!TEE_ALIGNMENT_IS_OK(raw_data, struct tee_cryp_obj_secret))
+		if (!ALIGNMENT_IS_OK(raw_data, struct tee_cryp_obj_secret))
 			return TEE_ERROR_BAD_STATE;
 		obj = (struct tee_cryp_obj_secret *)(void *)raw_data;
 		key_size = obj->key_size;
@@ -1144,7 +1145,7 @@ static TEE_Result tee_svc_cryp_obj_store_attr_raw(uint16_t conv_func,
 		return TEE_SUCCESS;
 
 	case TEE_TYPE_CONV_FUNC_SECRET:
-		if (!TEE_ALIGNMENT_IS_OK(data, struct tee_cryp_obj_secret))
+		if (!ALIGNMENT_IS_OK(data, struct tee_cryp_obj_secret))
 			return TEE_ERROR_BAD_STATE;
 		obj = (struct tee_cryp_obj_secret *)(void *)data;
 

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -142,27 +142,6 @@ typedef enum {
 #define TEE_U32_TO_BIG_ENDIAN(x)    TEE_U32_BSWAP(x)
 #define TEE_U16_TO_BIG_ENDIAN(x)    TEE_U16_BSWAP(x)
 
-#ifndef TEE_ALIGNMENT_IS_OK
-#ifdef CFG_TC_NO_ALIGNOF
-#define TEE_ALIGNMENT_1B_IS_OK(p, type)    (true)
-#define TEE_ALIGNMENT_2B_IS_OK(p, type)    (((((unsigned long)&(p)) & 1) == 0) ? true : false)
-#define TEE_ALIGNMENT_4B_IS_OK(p, type)    (((((unsigned long)&(p)) & 3) == 0) ? true : false)
-#define TEE_ALIGNMENT_8B_IS_OK(p, type)    (((((unsigned long)&(p)) & 7) == 0) ? true : false)
-#define TEE_ALIGNMENT_IS_OK(p, type)       TEE_ALIGNMENT_4B_IS_OK(p, type)
-#else
-#define TEE_ALIGNMENT_1B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_2B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_4B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_8B_IS_OK(p, type)    TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-#define TEE_ALIGNMENT_IS_OK(p, type)       TEE_ALIGNMENT_WRAP_IS_OK(p, type)
-
-#define TEE_ALIGNMENT_WRAP_IS_OK(p, type)                        \
-        (((uintptr_t)p & (__tee_assert_alignof__(type) - 1)) == 0)
-
-#define __tee_assert_alignof__(type) __alignof__(type)
-#endif
-#endif
-
 #define TEE_TIME_MILLIS_BASE    1000
 
 #define TEE_TIME_LT(t1, t2)				\

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -50,6 +50,9 @@
 /* x has to be of an unsigned type */
 #define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & (~(x) + 1)) == (x)))
 
+#define ALIGNMENT_IS_OK(p, type) \
+	(((uintptr_t)(p) & (__alignof__(type) - 1)) == 0)
+
 #define TO_STR(x) _TO_STR(x)
 #define _TO_STR(x) #x
 


### PR DESCRIPTION
It is assumed that the compiler keyword __alignof__ is available, so
CFG_TC_NO_ALIGNOF is of no use. We also remove unused definitions:
TEE_ALIGNMENT_*B_IS_OK().

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>