### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ before_script:
   - (cd $HOME/optee_repo/qemu && git submodule update --init dtc)
   - (cd $HOME/optee_repo && mv optee_os optee_os_old && ln -s $MYHOME optee_os)
   - cd $MYHOME
+  - unset CC
 
 # Several compilation options are checked
 script:


### PR DESCRIPTION
The Travis build was broken by optee_test commit 0e00914b378d ("Make
cross compile variables configurable via the environment"), because the
CC environment variable is set to the host compiler during Travis
builds. Simply unset this variable in the before_script step to avoid
any side-effect.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>