### PR TITLE
debug: enable bget memory leak detection

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -29,6 +29,7 @@ cflags$(sm)	+= $(platform-cflags) $(core-platform-cflags)
 aflags$(sm)	+= $(platform-aflags) $(core-platform-aflags)
 
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_CORE_LOG_LEVEL)
+cppflags$(sm) += -DENABLE_MDBG=$(CFG_TEE_CORE_MALLOC_DEBUG)
 
 cppflags$(sm)	+= -Ilib/libutee/include
 

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -35,10 +35,11 @@ enum mdbg_mode {
 	MDBG_MODE_DYNAMIC
 };
 
+void free(void *ptr);
+
 #ifdef ENABLE_MDBG
 
 void *mdbg_malloc(const char *fname, int lineno, size_t size);
-void mdbg_free(void *ptr);
 void *mdbg_calloc(const char *fname, int lineno, size_t nmemb, size_t size);
 void *mdbg_realloc(const char *fname, int lineno, void *ptr, size_t size);
 void *mdbg_memalign(const char *fname, int lineno, size_t alignment,
@@ -48,7 +49,6 @@ enum mdbg_mode mdbg_set_mode(enum mdbg_mode mode);
 void mdbg_check(int bufdump);
 
 #define malloc(size)	mdbg_malloc(__FILE__, __LINE__, (size))
-#define free(ptr)	mdbg_free((ptr))
 #define calloc(nmemb, size) \
 		mdbg_calloc(__FILE__, __LINE__, (nmemb), (size))
 #define realloc(ptr, size) \
@@ -59,7 +59,6 @@ void mdbg_check(int bufdump);
 #else
 
 void *malloc(size_t size);
-void free(void *ptr);
 void *calloc(size_t nmemb, size_t size);
 void *realloc(void *ptr, size_t size);
 void *memalign(size_t alignment, size_t size);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -60,6 +60,10 @@ CFG_TEE_PANIC_DEBUG ?= y
 # feature.
 CFG_TEE_CORE_USER_MEM_DEBUG ?= 1
 
+# If y, enable memory leak detection feature in bget memory allocator.
+CFG_TEE_CORE_MALLOC_DEBUG ?= n
+CFG_TEE_TA_MALLOC_DEBUG ?= n
+
 # PRNG configuration
 # If CFG_WITH_SOFTWARE_PRNG is enabled, crypto provider provided
 # software PRNG implementation is used.

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -58,6 +58,7 @@ cppflags$(sm) += -DCFG_TEE_PANIC_DEBUG=1
 endif
 
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
+cppflags$(sm) += -DENABLE_MDBG=$(CFG_TEE_TA_MALLOC_DEBUG)
 
 include $(ta-dev-kit-dir)/mk/arch.mk
 

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -18,6 +18,7 @@ aflags$(sm)	+= $(platform-aflags) $(user_ta-platform-aflags)
 # Config flags from mk/config.mk
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 cppflags$(sm) += -DCFG_TEE_CORE_USER_MEM_DEBUG=$(CFG_TEE_CORE_USER_MEM_DEBUG)
+cppflags$(sm) += -DENABLE_MDBG=$(CFG_TEE_TA_MALLOC_DEBUG)
 
 
 base-prefix := $(sm)-


### PR DESCRIPTION
This patch enables built-in memory leak detection in
bget allocator. This is very helpful to find memory
leakage issue in teecore. To enable it, build optee_os
with 'CFG_TEE_CORE_ENABLE_MDBG=y'.

Then, add the following statement at some point of your
code that might frequently been triggered:

  mdbg_check(1);

It will dump allocated memory blocks and the holders of
them. If you find a memory block appears multiple times
after the system runs a period of time, it is very likely
the source of memory leakage.

Here is an exmaple output:

ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 0 bytes core/tee/tee_svc_storage.c:260
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 104 bytes core/tee/tee_svc_storage.c:444
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 18 bytes core/tee/tee_pobj.c:119
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 56 bytes core/tee/tee_pobj.c:110
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 192 bytes core/arch/arm/mm/tee_mmu.c:93
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 32 bytes core/arch/arm/mm/tee_mmu.c:241
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 24 bytes core/arch/arm/mm/tee_mm.c:75
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 24 bytes core/arch/arm/mm/tee_mm.c:75
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 224 bytes core/arch/arm/kernel/tee_ta_manager.c:573
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 72 bytes core/arch/arm/kernel/tee_ta_manager.c:1202
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 7 bytes lib/libutils/isoc/strdup.c:34
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 7 bytes lib/libutils/isoc/strdup.c:34
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 7 bytes lib/libutils/isoc/strdup.c:34
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 7 bytes lib/libutils/isoc/strdup.c:34
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 32 bytes core/kernel/handle.c:70
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 24 bytes core/arch/arm/mm/tee_mm.c:48
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 24 bytes core/arch/arm/mm/tee_mm.c:48
ERR TEE-CORE:mdbg_check:720: Orphaned buffer: 24 bytes core/arch/arm/mm/tee_mm.c:48
ERR TEE-CORE:mdbg_check:720: Ignore buffer: 16 bytes lib/libutils/isoc/bget_malloc.c:794

You can see the buffer hold by strdup.c:34 appears 4 times,
so it's very likely to be the source of memory leakage.

Signed-off-by: SY Chiu <sy.chiu@linaro.org>
Tested-by: SY Chiu <sy.chiu@linaro.org> (MT8173 EVB)