### PR TITLE
core: TEE_GetSystemTime() updates

### DIFF
--- a/core/arch/arm/include/kernel/time_source.h
+++ b/core/arch/arm/include/kernel/time_source.h
@@ -29,6 +29,7 @@
 
 struct time_source {
 	const char *name;
+	uint32_t protection_level;
 	TEE_Result (*get_sys_time)(TEE_Time *time);
 };
 void time_source_init(void);

--- a/core/arch/arm/kernel/tee_time.c
+++ b/core/arch/arm/kernel/tee_time.c
@@ -42,6 +42,11 @@ TEE_Result tee_time_get_sys_time(TEE_Time *time)
 	return _time_source.get_sys_time(time);
 }
 
+uint32_t tee_time_get_sys_time_protection_level(void)
+{
+	return _time_source.protection_level;
+}
+
 void tee_time_wait(uint32_t milliseconds_delay)
 {
 	struct tee_ta_session *sess = NULL;

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -50,6 +50,7 @@ static TEE_Result arm_cntpct_get_sys_time(TEE_Time *time)
 
 static const struct time_source arm_cntpct_time_source = {
 	.name = "arm cntpct",
+	.protection_level = 1000,
 	.get_sys_time = arm_cntpct_get_sys_time,
 };
 

--- a/core/include/kernel/tee_time.h
+++ b/core/include/kernel/tee_time.h
@@ -32,10 +32,8 @@
 
 #define TEE_TIME_BOOT_TICKS_HZ  10UL
 
-/*
- * Init boot time and start the secure time init
- */
 TEE_Result tee_time_get_sys_time(TEE_Time *time);
+uint32_t tee_time_get_sys_time_protection_level(void);
 TEE_Result tee_time_get_ta_time(const TEE_UUID *uuid, TEE_Time *time);
 TEE_Result tee_time_get_ree_time(TEE_Time *time);
 TEE_Result tee_time_set_ta_time(const TEE_UUID *uuid, const TEE_Time *time);


### PR DESCRIPTION
- Set gpd.tee.systemTime.protectionLevel to 1000 when the time source
is the physical count register (CNTPCT), that is, when
CFG_SECURE_TIME_SOURCE_CNTPCT=y. The protection level value is moved
into the time_source struct for better modularity.
- When the time source is REE (CFG_SECURE_TIME_SOURCE_REE=y), make sure
that successive calls return increasing values as required by the GP
TEE Core Internal API v1.1.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>