### PR TITLE
Ensure sctl programming before resuming system

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -152,6 +152,7 @@ LOCAL_FUNC reset , :
 	bic	r0, r0, #SCTLR_C
 	bic	r0, r0, #SCTLR_I
 	write_sctlr r0
+	isb
 
 	/* Early ARM secure MP specific configuration */
 	bl	plat_cpu_reset_early


### PR DESCRIPTION
The entry point code programs the SCTL register to enable
alignment check and disable I/D cache. Need to put an instruction
barrier to ensure SCTL programming has taken place before
resuming the system

Change-Id: I561b93d33e15d78eb0712e7d9a9c8d6b9c507f93
Reviewed-by: James King <james.king@arm.com>
Tested-by: Ashutosh Singh <ashutosh.singh@arm.com>
Signed-off-by: Ashutosh Singh <ashutosh.singh@arm.com>