### PR TITLE
Avoid duplication of $(call force,CFG_WITH_VFP,y)

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -26,17 +26,4 @@ CFG_CRYPTO_SHA256_ARM32_CE ?= $(CFG_ARM32_core)
 CFG_CRYPTO_SHA256_ARM64_CE ?= $(CFG_ARM64_core)
 CFG_WITH_STACK_CANARIES ?= y
 
-ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_SHA1_ARM64_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_AES_ARM64_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-
 include mk/config.mk

--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -18,13 +18,6 @@ $(call force,CFG_ARM32_core,y)
 $(call force,CFG_MMU_V7_TTB,y)
 endif
 
-ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-
 libtomcrypt_with_optimize_size ?= y
 CFG_WITH_STACK_CANARIES ?= y
 

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -38,22 +38,6 @@ CFG_CRYPTO_SHA256_ARM32_CE ?= $(CFG_ARM32_core)
 CFG_CRYPTO_SHA256_ARM64_CE ?= $(CFG_ARM64_core)
 endif
 
-ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_SHA256_ARM64_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_SHA1_ARM64_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-ifeq ($(CFG_CRYPTO_AES_ARM64_CE),y)
-$(call force,CFG_WITH_VFP,y)
-endif
-
 # SE API is only supported by QEMU Virt platform
 ifeq ($(PLATFORM_FLAVOR),qemu_virt)
 CFG_SE_API ?= y

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -47,6 +47,24 @@ endif
 endif
 endif
 
+# Cryptographic extensions can only be used safely when OP-TEE knows how to
+# preserve the VFP context
+ifeq ($(CFG_CRYPTO_SHA256_ARM32_CE),y)
+$(call force,CFG_WITH_VFP,y,required by CFG_CRYPTO_SHA256_ARM32_CE)
+endif
+ifeq ($(CFG_CRYPTO_SHA256_ARM64_CE),y)
+$(call force,CFG_WITH_VFP,y,required by CFG_CRYPTO_SHA256_ARM64_CE)
+endif
+ifeq ($(CFG_CRYPTO_SHA1_ARM32_CE),y)
+$(call force,CFG_WITH_VFP,y,required by CFG_CRYPTO_SHA1_ARM32_CE)
+endif
+ifeq ($(CFG_CRYPTO_SHA1_ARM64_CE),y)
+$(call force,CFG_WITH_VFP,y,required by CFG_CRYPTO_SHA1_ARM64_CE)
+endif
+ifeq ($(CFG_CRYPTO_AES_ARM64_CE),y)
+$(call force,CFG_WITH_VFP,y,required by CFG_CRYPTO_AES_ARM64_CE)
+endif
+
 cryp-enable-all-depends = $(call cfg-enable-all-depends,$(strip $(1)),$(foreach v,$(2),CFG_CRYPTO_$(v)))
 $(eval $(call cryp-enable-all-depends,CFG_ENC_FS, AES ECB CTR HMAC SHA256 GCM))
 


### PR DESCRIPTION
When cryptographic extensions are used, and whatever the platform,
we have to ensure that VFP preservation is enabled too. Therefore it
makes sense to centralize the tests in core/lib/libtomcrypt/sub.mk
instead of having them in the platform-specific configuration files.

Incidentally, this adds a few missing statements to HiKey and Mediatek.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>