### PR TITLE
Make compilation of lib/libutils/isoc configurable again

### DIFF
--- a/lib/libutils/sub.mk
+++ b/lib/libutils/sub.mk
@@ -1,2 +1,2 @@
-subdirs-y += isoc
+subdirs-$(CFG_LIBUTILS_WITH_ISOC) += isoc
 subdirs-y += ext

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -92,3 +92,7 @@ CFG_ENC_FS ?= y
 
 # Embed public part of this key in OP-TEE OS
 TA_SIGN_KEY ?= keys/default_ta.pem
+
+# Include lib/libutils/isoc in the build? Most platforms need this, but some
+# may not because they obtain the isoc functions from elsewhere
+CFG_LIBUTILS_WITH_ISOC ?= y


### PR DESCRIPTION
Commit c3e0bd7 ("Delete libutil_with_isoc") wrongly assumed that the code
in lib/libutils/isoc is mandatory for any OP-TEE build. This is not true
for some non-upstream platforms which can find the functions in external
libraries.

Therefore, this commits makes the thing configurable again through
CFG_LIBUTILS_WITH_ISOC (default: y).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Reported-by: Pascal Brand <pascal.brand@linaro.org>