### PR TITLE
tee_ta_manager.c: update DMSG() calls to display full TA UUID

### DIFF
--- a/core/arch/arm/kernel/tee_ta_manager.c
+++ b/core/arch/arm/kernel/tee_ta_manager.c
@@ -1229,10 +1229,7 @@ static TEE_Result tee_ta_init_session_with_context(struct tee_ta_ctx *ctx,
 	      (ctx->ref_count == 0)))
 		return TEE_ERROR_BUSY;
 
-	DMSG("   ... Re-open TA %08x-%04x-%04x",
-	     ctx->uuid.timeLow,
-	     ctx->uuid.timeMid, ctx->uuid.timeHiAndVersion);
-
+	DMSG("   ... Re-open TA %s", _uuid2str(&ctx->uuid));
 
 	ctx->ref_count++;
 	s->ctx = ctx;
@@ -1250,8 +1247,7 @@ static TEE_Result tee_ta_init_static_ta_session(const TEE_UUID *uuid,
 	struct tee_ta_ctx *ctx = NULL;
 	ta_static_head_t *ta = NULL;
 
-	DMSG("   Lookup for Static TA %08x-%04x-%04x",
-	     uuid->timeLow, uuid->timeMid, uuid->timeHiAndVersion);
+	DMSG("   Lookup static TA %s", _uuid2str(uuid));
 
 	ta = &__start_ta_head_section;
 	while (true) {
@@ -1279,11 +1275,7 @@ static TEE_Result tee_ta_init_static_ta_session(const TEE_UUID *uuid,
 	ctx->uuid = ta->uuid;
 	TAILQ_INSERT_TAIL(&tee_ctxes, ctx, link);
 
-	DMSG("      %s : %08x-%04x-%04x",
-	     ctx->static_ta->name,
-	     ctx->uuid.timeLow,
-	     ctx->uuid.timeMid,
-	     ctx->uuid.timeHiAndVersion);
+	DMSG("      %s: %s", ctx->static_ta->name, _uuid2str(&ctx->uuid));
 
 	return TEE_SUCCESS;
 }
@@ -1300,9 +1292,7 @@ static TEE_Result tee_ta_init_session_with_signed_ta(const TEE_UUID *uuid,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	DMSG("      dyn TA : %08x-%04x-%04x",
-	     s->ctx->uuid.timeLow, s->ctx->uuid.timeMid,
-	     s->ctx->uuid.timeHiAndVersion);
+	DMSG("      dyn TA : %s", _uuid2str(&s->ctx->uuid));
 
 	return res;
 }

--- a/core/include/kernel/tee_misc.h
+++ b/core/include/kernel/tee_misc.h
@@ -83,6 +83,15 @@ bool _core_is_buffer_intersect(vaddr_t b, size_t bl, vaddr_t a, size_t al);
 
 /*  UUID string: "XXXXXXXX-XXXX-XXXX-XXXXXXXXXXXXXXXX". Size includes '\0' */
 #define TEE_UUID_STRING_LEN		36
-int uuid2str(char *dst, TEE_UUID *uuid);
+int uuid2str(char *dst, const TEE_UUID *uuid);
+
+static inline char *_uuid2str(const TEE_UUID *uuid)
+{
+	static char str[TEE_UUID_STRING_LEN];
+
+	uuid2str(str, uuid);
+	return str;
+}
+
 
 #endif /* TEE_MISC_H */

--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -138,7 +138,7 @@ bool _core_is_buffer_intersect(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 	return true;
 }
 
-int uuid2str(char *dst, TEE_UUID *uuid)
+int uuid2str(char *dst, const TEE_UUID *uuid)
 {
 	if (dst == NULL)
 		return 0;


### PR DESCRIPTION
The debug traces in tee_ta_manager.c do not show the last 8 bytes of
the TA UUIDs, which makes the output confusing sometimes. This commit
adds a static helper function to tee_misc.h: _uuid2str(), which uses
uuid2str() on a static buffer and can conveniently be used in DMSG().
Care must be taken with reentrancy -- in tee_ta_manager.c we have the
TA lock when we print such traces so there is no problem.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>