### PR TITLE
core: RPMB (Replay Protected Memory Block) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,8 @@ script:
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_CRYPTO_{MD5,SHA{1,224,256,384,512}}=n
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_WITH_PAGER=y
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_ENC_FS=n
+  - make -j8 -s CFG_RPMB_FS=y CFG_ENC_FS=n
+  - make -j8 -s CFG_RPMB_FS=y CFG_ENC_FS=n CFG_RPMB_TESTKEY=y
 
   # SUNXI(Allwinner A80)
   - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=sunxi make -j8 all -s

--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -468,8 +468,8 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 	 */
 	if ((rawdata->msg_type == RPMB_MSG_TYPE_REQ_AUTH_DATA_WRITE) &&
 	    (nbr_frms > rpmb_ctx->rel_wr_blkcnt)) {
-		DMSG("%s: wr_blkcnt(%d) > rel_wr_blkcnt(%d)", __func__,
-		     nbr_frms, rpmb_ctx->rel_wr_blkcnt);
+		DMSG("wr_blkcnt(%d) > rel_wr_blkcnt(%d)", nbr_frms,
+		     rpmb_ctx->rel_wr_blkcnt);
 		return TEE_ERROR_GENERIC;
 	}
 
@@ -492,8 +492,8 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 			/* Check the block index is within range. */
 			if ((*rawdata->blk_idx + nbr_frms) >
 			    rpmb_ctx->max_blk_idx) {
-				DMSG("%s: blk_idx (%d+%d) > max_blk_idx(%d)",
-				     __func__, *rawdata->blk_idx, nbr_frms,
+				DMSG("blk_idx (%d+%d) > max_blk_idx(%d)",
+				     *rawdata->blk_idx, nbr_frms,
 				     rpmb_ctx->max_blk_idx);
 				res = TEE_ERROR_GENERIC;
 				goto func_exit;
@@ -534,7 +534,7 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 
 #ifdef ENABLE_RPMB_DATA_DUMP
 	for (i = 0; i < nbr_frms; i++) {
-		DMSG("%s: Dumping datafrm[%d]:", __func__, i);
+		DMSG("Dumping datafrm[%d]:", i);
 		HEX_PRINT_BUF((uint8_t *)&datafrm[i] + RPMB_STUFF_DATA_SIZE,
 			      512 - RPMB_STUFF_DATA_SIZE);
 	}
@@ -668,7 +668,7 @@ static TEE_Result tee_rpmb_resp_unpack_verify(struct rpmb_data_frame *datafrm,
 #ifdef ENABLE_RPMB_DATA_DUMP
 	uint32_t i = 0;
 	for (i = 0; i < nbr_frms; i++) {
-		DMSG("%s: Dumping datafrm[%d]:", __func__, i);
+		DMSG("Dumping datafrm[%d]:", i);
 		HEX_PRINT_BUF((uint8_t *)&datafrm[i] + RPMB_STUFF_DATA_SIZE,
 			      512 - RPMB_STUFF_DATA_SIZE);
 	}
@@ -682,21 +682,21 @@ static TEE_Result tee_rpmb_resp_unpack_verify(struct rpmb_data_frame *datafrm,
 	if (rawdata->op_result)
 		*rawdata->op_result = op_result;
 	if (op_result != RPMB_RESULT_OK) {
-		DMSG("%s: op_result != RPMB_RESULT_OK", __func__);
+		DMSG("op_result != RPMB_RESULT_OK");
 		return TEE_ERROR_GENERIC;
 	}
 
 	/* Check the response msg_type. */
 	bytes_to_u16(lastfrm.msg_type, &msg_type);
 	if (msg_type != rawdata->msg_type) {
-		DMSG("%s: Unexpected msg_type", __func__);
+		DMSG("Unexpected msg_type");
 		return TEE_ERROR_GENERIC;
 	}
 
 	if (rawdata->blk_idx) {
 		bytes_to_u16(lastfrm.address, &blk_idx);
 		if (blk_idx != *rawdata->blk_idx) {
-			DMSG("%s: Unexpected block index", __func__);
+			DMSG("Unexpected block index");
 			return TEE_ERROR_GENERIC;
 		}
 	}
@@ -707,7 +707,7 @@ static TEE_Result tee_rpmb_resp_unpack_verify(struct rpmb_data_frame *datafrm,
 		if (msg_type == RPMB_MSG_TYPE_RESP_AUTH_DATA_WRITE) {
 			/* Verify the write counter is incremented by 1 */
 			if (*rawdata->write_counter != wr_cnt + 1) {
-				DMSG("%s: write counter mismatched", __func__);
+				DMSG("Write counter mismatched");
 				return TEE_ERROR_SECURITY;
 			}
 			rpmb_ctx->wr_cnt++;
@@ -717,7 +717,7 @@ static TEE_Result tee_rpmb_resp_unpack_verify(struct rpmb_data_frame *datafrm,
 	if (rawdata->nonce) {
 		if (buf_compare_ct(rawdata->nonce, lastfrm.nonce,
 				   RPMB_NONCE_SIZE) != 0) {
-			DMSG("%s: nonce mismatched", __func__);
+			DMSG("Nonce mismatched");
 			return TEE_ERROR_SECURITY;
 		}
 	}
@@ -754,7 +754,7 @@ static TEE_Result tee_rpmb_resp_unpack_verify(struct rpmb_data_frame *datafrm,
 		if (buf_compare_ct(rawdata->key_mac,
 				   (datafrm + nbr_frms - 1)->key_mac,
 				   RPMB_KEY_MAC_SIZE) != 0) {
-			DMSG("%s: MAC mismatched:", __func__);
+			DMSG("MAC mismatched:");
 #ifdef ENABLE_RPMB_DATA_DUMP
 			HEX_PRINT_BUF((uint8_t *)rawdata->key_mac, 32);
 #endif

--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -349,6 +349,7 @@ struct tee_rpmb_mem {
 	struct teesmc32_arg *arg;
 	paddr_t pharg;
 	paddr_t phpayload;
+	paddr_t phpayload_cookie;
 	paddr_t phreq;
 	paddr_t phresp;
 	size_t req_size;
@@ -379,9 +380,10 @@ static void tee_rpmb_free(struct tee_rpmb_mem *mem)
 		return;
 
 	thread_rpc_free_arg(mem->pharg);
-	thread_rpc_free_payload(mem->phpayload);
+	thread_optee_rpc_free_payload(mem->phpayload_cookie);
 	mem->pharg = 0;
 	mem->phpayload = 0;
+	mem->phpayload_cookie = 0;
 }
 
 
@@ -396,7 +398,8 @@ static TEE_Result tee_rpmb_alloc(size_t req_size, size_t resp_size,
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	mem->pharg = thread_rpc_alloc_arg(TEESMC32_GET_ARG_SIZE(2));
-	mem->phpayload = thread_rpc_alloc_payload(req_s + resp_s);
+	thread_optee_rpc_alloc_payload(req_s + resp_s, &mem->phpayload,
+				       &mem->phpayload_cookie);
 	if (!mem->pharg || !mem->phpayload) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;

--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -460,7 +460,6 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	int i;
-	int j;
 	struct rpmb_data_frame *datafrm;
 
 	if (req == NULL || rawdata == NULL || nbr_frms == 0)
@@ -485,7 +484,7 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 	if (datafrm == NULL)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	for (i = 0, j = 0; i < nbr_frms; i++, j += RPMB_DATA_SIZE) {
+	for (i = 0; i < nbr_frms; i++) {
 		u16_to_bytes(rawdata->msg_type, datafrm[i].msg_type);
 
 		if (rawdata->block_count)
@@ -515,7 +514,7 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 
 		if (rawdata->data)
 			memcpy(datafrm[i].data,
-			       rawdata->data + j,
+			       rawdata->data + (i * RPMB_DATA_SIZE),
 			       RPMB_DATA_SIZE);
 	}
 

--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -355,7 +355,7 @@ struct tee_rpmb_mem {
 	size_t resp_size;
 };
 
-static void tee_rpmb_set_session(struct tee_ta_session **session)
+static void tee_rpmb_clear_session(struct tee_ta_session **session)
 {
 	TEE_Result res;
 	struct tee_ta_session *sess = NULL;
@@ -1012,7 +1012,7 @@ TEE_Result tee_rpmb_write_key(uint16_t dev_id, bool commercial)
 
 	(void)commercial;
 
-	tee_rpmb_set_session(&sess);
+	tee_rpmb_clear_session(&sess);
 
 	req_size = sizeof(struct rpmb_req) + RPMB_DATA_FRAME_SIZE;
 	resp_size = RPMB_DATA_FRAME_SIZE;
@@ -1073,7 +1073,7 @@ TEE_Result tee_rpmb_read(uint16_t dev_id,
 	if (data == NULL || len == 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	tee_rpmb_set_session(&sess);
+	tee_rpmb_clear_session(&sess);
 
 	blk_idx = addr / RPMB_DATA_SIZE;
 	byte_offset = addr % RPMB_DATA_SIZE;
@@ -1264,7 +1264,7 @@ TEE_Result tee_rpmb_write(uint16_t dev_id,
 	uint16_t blkcnt;
 	uint8_t byte_offset;
 
-	tee_rpmb_set_session(&sess);
+	tee_rpmb_clear_session(&sess);
 
 	blk_idx = addr / RPMB_DATA_SIZE;
 	byte_offset = addr % RPMB_DATA_SIZE;
@@ -1319,7 +1319,7 @@ TEE_Result tee_rpmb_get_write_counter(uint16_t dev_id, uint32_t *counter)
 	if (counter == NULL)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	tee_rpmb_set_session(&sess);
+	tee_rpmb_clear_session(&sess);
 
 	if (rpmb_ctx == NULL || !rpmb_ctx->wr_cnt_synced) {
 		res = tee_rpmb_init(dev_id, false, true);
@@ -1342,7 +1342,7 @@ TEE_Result tee_rpmb_get_max_block(uint16_t dev_id, uint32_t *max_block)
 	if (max_block == NULL)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	tee_rpmb_set_session(&sess);
+	tee_rpmb_clear_session(&sess);
 
 	if (rpmb_ctx == NULL || !rpmb_ctx->dev_info_synced) {
 		res = tee_rpmb_init(dev_id, false, true);

--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -395,9 +395,6 @@ static TEE_Result tee_rpmb_alloc(size_t req_size, size_t resp_size,
 	if (!mem)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	mem->pharg = 0;
-	mem->phpayload = 0;
-
 	mem->pharg = thread_rpc_alloc_arg(TEESMC32_GET_ARG_SIZE(2));
 	mem->phpayload = thread_rpc_alloc_payload(req_s + resp_s);
 	if (!mem->pharg || !mem->phpayload) {

--- a/core/include/tee/tee_rpmb.h
+++ b/core/include/tee/tee_rpmb.h
@@ -69,4 +69,13 @@ TEE_Result tee_rpmb_write(uint16_t dev_id,
  * @counter    Pointer to the counter.
  */
 TEE_Result tee_rpmb_get_write_counter(uint16_t dev_id, uint32_t *counter);
+
+/*
+ * Read the RPMB max block.
+ *
+ * @dev_id     Device ID of the eMMC device.
+ * @counter    Pointer to receive the max block.
+ */
+TEE_Result tee_rpmb_get_max_block(uint16_t dev_id, uint32_t *max_block);
+
 #endif

--- a/core/include/tee/tee_rpmb_fs.h
+++ b/core/include/tee/tee_rpmb_fs.h
@@ -31,34 +31,51 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <tee_api_types.h>
+#include <tee/tee_fs.h>
 
-#define FILENAME_LENGTH 48
+#define TEE_RPMB_FS_FILENAME_LENGTH 48
 
 struct tee_rpmb_fs_stat {
-	uint32_t size;
+	size_t size;
 	uint32_t reserved;
 };
 
 /**
+ * tee_rpmb_fs_open: Opens a file descriptor to the file.
+ * If the file does not exist and TEE_FS_O_CREATE flag is specified
+ * the file will be created empty.
+ *
+ * Returns the file descriptor or
+ * a value < 0 on failure.
+ */
+int tee_rpmb_fs_open(const char *file, int flags, ...);
+
+/**
+ * tee_rpmb_fs_close: Closes the file opened by tee_rpmb_fs_open.
+ *
+ * Returns a value < 0 on failure.
+ */
+int tee_rpmb_fs_close(int fd);
+
+/**
  * tee_rpmb_fs_read: Read entire file
- * Reads data from file pointed to by filename.
+ * Reads data from file pointed to by fd.
  * buf should be allocated by the client and its size must >= file size.
  *
  * Returns number of bytes read from the file or
  * a value < 0 on failure.
  */
-int tee_rpmb_fs_read(const char *filename, uint8_t *buf, size_t size);
+int tee_rpmb_fs_read(int fd, uint8_t *buf, size_t size);
 
 /**
  * tee_rpmb_fs_write: Write data to file
  * Write data to an existing file or create a new file and Write data.
- * If the file pointed to by filename exists, data will be overwritten,
- * otherwise the file will be created.
+ * The file contents will be overwritten with the new data.
  * size bytes of data will be copied from buf.
  *
  * Return n bytes written on success or a value < 0 on failure.
  */
-int tee_rpmb_fs_write(const char *filename, uint8_t *buf, size_t size);
+int tee_rpmb_fs_write(int fd, uint8_t *buf, size_t size);
 
 /**
  * tee_rpmb_fs_rm: Remove a file.
@@ -70,5 +87,72 @@ TEE_Result tee_rpmb_fs_rename(const char *old, const char *new);
 
 TEE_Result tee_rpmb_fs_stat(const char *filename,
 			    struct tee_rpmb_fs_stat *stat);
+
+/**
+ * tee_rpmb_fs_access: The current implementation checks if the given
+ * file exits.
+ *
+ * Return 0 if the file exists and -1 otherwise.
+ */
+int tee_rpmb_fs_access(const char *filename, int mode);
+
+/**
+ * tee_rpmb_fs_lseek: Seek to a given position.
+ * whence is one of: TEE_FS_SEEK_SET, TEE_FS_SEEK_END, TEE_FS_SEEK_CUR
+ * but only TEE_FS_SEEK_SET is currently supported.
+ * offset is an offset from 'whence' but only 0 is currently supported.
+ *
+ * Return the offset on success and -1 on failure.
+ */
+tee_fs_off_t tee_rpmb_fs_lseek(int fd, tee_fs_off_t offset, int whence);
+
+/**
+ * tee_rpmb_fs_opendir: Opens a stream to the directory 'path'.
+ * If new files are added to the directory after the open call
+ * returns they will not be reflected until the next open.
+ *
+ * Returns a pointer to tee_fs_dir or NULL on failure.
+ */
+tee_fs_dir *tee_rpmb_fs_opendir(const char *path);
+
+/**
+ * tee_rpmb_fs_readdir: Cycles through the directory contents opened
+ * by tee_rpmb_fs_opendir. A pointer to a tee_fs_dirent is returned.
+ * The memory is owned by the RPMB FS and will be freed on
+ * tee_rpmb_fs_closedir().
+ *
+ * Returns a pointer to a tee_fs_dirent or NULL on failure.
+ */
+struct tee_fs_dirent *tee_rpmb_fs_readdir(tee_fs_dir *dir);
+
+/**
+ * tee_rpmb_fs_closedir: Closes the directory opened by tee_rpmb_fs_open.
+ *
+ * Returns 0 on success and -1 on failure.
+ */
+int tee_rpmb_fs_closedir(tee_fs_dir *dir);
+
+/**
+ * tee_rpmb_fs_mkdir: Currently unsupported.
+ *
+ * Returns -1.
+ */
+int tee_rpmb_fs_mkdir(const char *path, tee_fs_mode_t mode);
+
+/**
+ * tee_rpmb_fs_ftruncate: Truncates the file to length. Only 0
+ * is supported.
+ *
+ * Returns 0 on success and -1 on failure.
+ */
+int tee_rpmb_fs_ftruncate(int fd, tee_fs_off_t length);
+
+/**
+ * tee_rpmb_fs_rmdir: Removes the directory if no children exist.
+ *
+ * Returns 0 on success -1 on failure.
+ */
+int tee_rpmb_fs_rmdir(const char *path);
+
 
 #endif

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -25,7 +25,12 @@ srcs-$(CFG_CRYPTO_HKDF) += tee_cryp_hkdf.c
 srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
 srcs-$(CFG_CRYPTO_PBKDF2) += tee_cryp_pbkdf2.c
 
+ifeq (y,$(CFG_RPMB_FS))
+$(call force,CFG_ENC_FS,n)
+srcs-y += tee_rpmb_fs_common.c
+else
 srcs-y += tee_fs_common.c
+endif
 srcs-y += tee_fs_key_manager.c
 srcs-y += tee_fs.c
 

--- a/core/tee/tee_fs_private.h
+++ b/core/tee/tee_fs_private.h
@@ -76,6 +76,7 @@ struct tee_fs_fd {
 	int pos;
 	uint32_t flags;
 	int fd;
+	int nw_fd; /* Normal world */
 	bool is_new_file;
 	char *filename;
 	void *private;

--- a/core/tee/tee_fs_private.h
+++ b/core/tee/tee_fs_private.h
@@ -76,7 +76,9 @@ struct tee_fs_fd {
 	int pos;
 	uint32_t flags;
 	int fd;
+#ifdef CFG_RPMB_FS
 	int nw_fd; /* Normal world */
+#endif
 	bool is_new_file;
 	char *filename;
 	void *private;

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -26,15 +26,18 @@
  */
 
 #include <kernel/tee_common.h>
+#include <kernel/handle.h>
 #include <tee/tee_rpmb_fs.h>
 #include <tee/tee_rpmb.h>
+#include <tee/tee_fs_defs.h>
+#include <tee/tee_fs.h>
 #include <mm/tee_mm.h>
+#include <trace.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define RPMB_STORAGE_START_ADDRESS      0
 #define RPMB_FS_FAT_START_ADDRESS       512
-#define RPMB_STORAGE_END_ADDRESS        ((1024 * 128) - 1)
 #define RPMB_BLOCK_SIZE_SHIFT           8
 
 #define DEV_ID                          0
@@ -52,6 +55,7 @@
  */
 struct rpmb_fs_parameters {
 	uint32_t fat_start_address;
+	uint32_t max_rpmb_address;
 };
 
 /**
@@ -62,18 +66,18 @@ struct rpmb_fat_entry {
 	uint32_t data_size;
 	uint32_t flags;
 	uint32_t write_counter;
-	char filename[FILENAME_LENGTH];
+	char filename[TEE_RPMB_FS_FILENAME_LENGTH];
 };
 
 /**
  * FAT entry context with reference to a FAT entry and its
  * location in RPMB.
  */
-struct file_handle {
+struct rpmb_file_handle {
 	/* Pointer to a fat_entry */
 	struct rpmb_fat_entry fat_entry;
 	/* Pointer to a filename */
-	const char *filename;
+	char filename[TEE_RPMB_FS_FILENAME_LENGTH];
 	/* Adress for current entry in RPMB */
 	uint32_t rpmb_fat_address;
 };
@@ -90,18 +94,94 @@ struct rpmb_fs_partition {
 	uint8_t reserved[112];
 };
 
+/**
+ * A node in a list of directory entries. entry->name is a
+ * pointer to name here.
+ */
+struct tee_rpmb_fs_dirent {
+	struct tee_rpmb_fs_dirent *next;
+	struct tee_fs_dirent entry;
+	char name[TEE_RPMB_FS_FILENAME_LENGTH];
+};
+
+/**
+ * The RPMB directory representation. It contains a list of
+ * RPMB directory entries pointed to by the next pointer.
+ * The current pointer points to the last returned directory entry.
+ */
+struct tee_fs_dir {
+	struct tee_rpmb_fs_dirent *current;
+	struct tee_rpmb_fs_dirent *next;
+};
+
+static TEE_Result get_fat_start_address(uint32_t *addr);
+
+
 static struct rpmb_fs_parameters *fs_par;
 
-static struct file_handle *alloc_file_handle(const char *filename)
-{
-	struct file_handle *fh = NULL;
+static struct handle_db fs_handle_db = HANDLE_DB_INITIALIZER;
 
-	fh = calloc(1, sizeof(struct file_handle));
+static void dump_fat(void)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct rpmb_fat_entry *fat_entries = NULL;
+	uint32_t fat_address;
+	size_t size;
+	int i;
+	bool last_entry_found = false;
+
+	res = get_fat_start_address(&fat_address);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
+	fat_entries = malloc(size);
+	if (fat_entries == NULL) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	while (!last_entry_found) {
+		res = tee_rpmb_read(DEV_ID, fat_address,
+				    (uint8_t *)fat_entries, size);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+		for (i = 0; i < N_ENTRIES; i++) {
+
+			FMSG("Flags 0x%x, Size %d, Address 0x%x, Filename %s\n",
+				fat_entries[i].flags,
+				fat_entries[i].data_size,
+				fat_entries[i].start_address,
+				fat_entries[i].filename);
+
+			if ((fat_entries[i].flags & FILE_IS_LAST_ENTRY) != 0) {
+				last_entry_found = true;
+				break;
+			}
+
+			/* Move to next fat_entry. */
+			fat_address += sizeof(struct rpmb_fat_entry);
+		}
+	}
+
+out:
+	free(fat_entries);
+}
+
+static struct rpmb_file_handle *alloc_file_handle(const char *filename)
+{
+	struct rpmb_file_handle *fh = NULL;
+	size_t len;
+
+	fh = calloc(1, sizeof(struct rpmb_file_handle));
 	if (fh == NULL)
 		return NULL;
 
-	if (filename != NULL)
-		fh->filename = filename;
+	if (filename != NULL) {
+		len = strlen(filename);
+		memcpy(fh->filename, filename, len);
+	}
 
 	return fh;
 }
@@ -109,10 +189,13 @@ static struct file_handle *alloc_file_handle(const char *filename)
 /**
  * write_fat_entry: Store info in a fat_entry to RPMB.
  */
-static TEE_Result write_fat_entry(struct file_handle *fh,
+static TEE_Result write_fat_entry(struct rpmb_file_handle *fh,
 				  bool update_write_counter)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+
+	DMSG("fat_address %d, update_write_counter %d", fh->rpmb_fat_address,
+	     (int)update_write_counter);
 
 	/* Protect partition data. */
 	if (fh->rpmb_fat_address < sizeof(struct rpmb_fs_partition)) {
@@ -136,7 +219,10 @@ static TEE_Result write_fat_entry(struct file_handle *fh,
 			     (uint8_t *)&fh->fat_entry,
 			     sizeof(struct rpmb_fat_entry));
 
+	dump_fat();
+
 out:
+	DMSG("res %u", res);
 	return res;
 }
 
@@ -149,7 +235,19 @@ static TEE_Result rpmb_fs_setup(void)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct rpmb_fs_partition *partition_data = NULL;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh = NULL;
+	uint32_t max_rpmb_block = 0;
+
+	if (fs_par != NULL) {
+		res = TEE_SUCCESS;
+		goto out;
+	}
+
+	DMSG("");
+
+	res = tee_rpmb_get_max_block(DEV_ID, &max_rpmb_block);
+	if (res != TEE_SUCCESS)
+		goto out;
 
 	partition_data = calloc(1, sizeof(struct rpmb_fs_partition));
 	if (partition_data == NULL) {
@@ -160,9 +258,11 @@ static TEE_Result rpmb_fs_setup(void)
 	res = tee_rpmb_read(DEV_ID, RPMB_STORAGE_START_ADDRESS,
 			    (uint8_t *)partition_data,
 			    sizeof(struct rpmb_fs_partition));
+
 	if (res != TEE_SUCCESS)
 		goto out;
 
+#ifndef CFG_RPMB_RESET_FAT
 	if (partition_data->rpmb_fs_magic == RPMB_FS_MAGIC) {
 		if (partition_data->fs_version == FS_VERSION) {
 			res = TEE_SUCCESS;
@@ -173,6 +273,9 @@ static TEE_Result rpmb_fs_setup(void)
 			goto out;
 		}
 	}
+#else
+	EMSG("**** Clearing Storage ****");
+#endif
 
 	/* Setup new partition data. */
 	partition_data->rpmb_fs_magic = RPMB_FS_MAGIC;
@@ -201,22 +304,26 @@ static TEE_Result rpmb_fs_setup(void)
 			     (uint8_t *)partition_data,
 			     sizeof(struct rpmb_fs_partition));
 
+#ifndef CFG_RPMB_RESET_FAT
 store_fs_par:
+#endif
+
 	/* Store FAT start address. */
+	fs_par = calloc(1, sizeof(struct rpmb_fs_parameters));
 	if (fs_par == NULL) {
-		fs_par = calloc(1, sizeof(struct rpmb_fs_parameters));
-		if (fs_par == NULL) {
-			res = TEE_ERROR_OUT_OF_MEMORY;
-			goto out;
-		}
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
 	}
 
 	fs_par->fat_start_address = partition_data->fat_start_address;
+	fs_par->max_rpmb_address = max_rpmb_block << RPMB_BLOCK_SIZE_SHIFT;
+
+	dump_fat();
 
 out:
 	free(fh);
 	free(partition_data);
-
+	DMSG("res %u", res);
 	return res;
 }
 
@@ -229,15 +336,11 @@ static TEE_Result get_fat_start_address(uint32_t *addr)
 	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (fs_par == NULL) {
-		res = rpmb_fs_setup();
-		if (res != TEE_SUCCESS)
-			goto out;
+		return TEE_ERROR_NO_DATA;
 	}
 
 	*addr = fs_par->fat_start_address;
 	res = TEE_SUCCESS;
-
-out:
 	return res;
 }
 
@@ -247,7 +350,7 @@ out:
  * Build up memory pool and return matching entry for write operation.
  * "Last FAT entry" can be returned during write.
  */
-static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
+static TEE_Result read_fat(struct rpmb_file_handle *fh, tee_mm_pool_t *p)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	tee_mm_entry_t *mm = NULL;
@@ -257,6 +360,10 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 	int i;
 	bool entry_found = false;
 	bool last_entry_found = false;
+	bool expand_fat = false;
+	struct rpmb_file_handle last_fh;
+
+	DMSG("fat_address %d", fh->rpmb_fat_address);
 
 	res = rpmb_fs_setup();
 	if (res != TEE_SUCCESS)
@@ -273,7 +380,13 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 		goto out;
 	}
 
-	while (!last_entry_found && !entry_found) {
+	/*
+	 * The pool is used to represent the current RPMB layout. To find
+	 * a slot for the file tee_mm_alloc is called on the pool. Thus
+	 * if it is not NULL the entire FAT must be traversed to fill in
+	 * the pool.
+	 */
+	while (!last_entry_found && (!entry_found || p != NULL)) {
 		res = tee_rpmb_read(DEV_ID, fat_address,
 				    (uint8_t *)fat_entries, size);
 		if (res != TEE_SUCCESS)
@@ -299,8 +412,9 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 
 			/* Add existing files to memory pool. (write) */
 			if (p != NULL) {
-				if ((fat_entries[i].flags & FILE_IS_ACTIVE) !=
-				    0) {
+				if ((fat_entries[i].flags & FILE_IS_ACTIVE) &&
+				    (fat_entries[i].data_size > 0)) {
+
 					mm = tee_mm_alloc2
 						(p,
 						 fat_entries[i].start_address,
@@ -322,10 +436,20 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 
 			if ((fat_entries[i].flags & FILE_IS_LAST_ENTRY) != 0) {
 				last_entry_found = true;
-				if (p != NULL && fh->rpmb_fat_address == 0) {
-					fh->rpmb_fat_address = fat_address;
-					fh->fat_entry.flags =
-					    FILE_IS_LAST_ENTRY;
+
+				/*
+				 * If the last entry was reached and was chosen
+				 * by the previous check, then the FAT needs to
+				 * be expanded.
+				 * fh->rpmb_fat_address is the address chosen
+				 * to store the files FAT entry and fat_address
+				 * is the current FAT entry address being
+				 * compared.
+				 */
+				if (p != NULL &&
+				    fh->rpmb_fat_address == fat_address) {
+
+					expand_fat = true;
 				}
 				break;
 			}
@@ -335,13 +459,38 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 		}
 	}
 
-	if ((p != NULL) && last_entry_found) {
+	/*
+	 * Represent the FAT table in the pool.
+	 */
+	if (p != NULL) {
+		/*
+		 * Since fat_address is the start of the last entry it needs to
+		 * be moved up by an entry.
+		 */
+		fat_address += sizeof(struct rpmb_fat_entry);
+
 		/* Make room for yet a FAT entry and add to memory pool. */
-		fat_address += 2 * sizeof(struct rpmb_fat_entry);
+		if (expand_fat)
+			fat_address += sizeof(struct rpmb_fat_entry);
+
 		mm = tee_mm_alloc2(p, RPMB_STORAGE_START_ADDRESS, fat_address);
 		if (mm == NULL) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;
+		}
+
+		if (expand_fat) {
+			/*
+			 * Point fat_address to the beginning of the new
+			 * entry.
+			 */
+			fat_address -= sizeof(struct rpmb_fat_entry);
+			memset(&last_fh, 0, sizeof(last_fh));
+			last_fh.fat_entry.flags = FILE_IS_LAST_ENTRY;
+			last_fh.rpmb_fat_address = fat_address;
+			res = write_fat_entry(&last_fh, true);
+			if (res != TEE_SUCCESS)
+				goto out;
 		}
 	}
 
@@ -350,6 +499,7 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 
 out:
 	free(fat_entries);
+	DMSG("res %u", res);
 	return res;
 }
 
@@ -357,7 +507,7 @@ out:
  * add_fat_entry:
  * Populate last FAT entry.
  */
-static TEE_Result add_fat_entry(struct file_handle *fh)
+static TEE_Result add_fat_entry(struct rpmb_file_handle *fh)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 
@@ -368,23 +518,141 @@ static TEE_Result add_fat_entry(struct file_handle *fh)
 	return res;
 }
 
-int tee_rpmb_fs_read(const char *filename, uint8_t *buf, size_t size)
+int tee_rpmb_fs_open(const char *file, int flags, ...)
 {
+	int fd = -1;
+	struct rpmb_file_handle *fh = NULL;
+	size_t filelen;
+	tee_mm_pool_t p;
+	bool pool_result;
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
-	int read_size = -1;
 
-	if (filename == NULL || buf == NULL ||
-	    strlen(filename) >= FILENAME_LENGTH - 1) {
+	if (file == NULL) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
-	fh = alloc_file_handle(filename);
+	filelen = strlen(file);
+	if (filelen >= TEE_RPMB_FS_FILENAME_LENGTH - 1 || filelen == 0) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	if (file[filelen - 1] == '/') {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	fh = alloc_file_handle(file);
 	if (fh == NULL) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
+
+    /* We need to do setup in order to make sure fs_par is filled in */
+	res = rpmb_fs_setup();
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	if (flags & TEE_FS_O_CREATE) {
+		/* Upper memory allocation must be used for RPMB_FS. */
+		pool_result = tee_mm_init(&p,
+					  RPMB_STORAGE_START_ADDRESS,
+					  fs_par->max_rpmb_address,
+					  RPMB_BLOCK_SIZE_SHIFT,
+					  TEE_MM_POOL_HI_ALLOC);
+
+		if (!pool_result) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto out;
+		}
+
+		res = read_fat(fh, &p);
+		tee_mm_final(&p);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+	} else {
+		res = read_fat(fh, NULL);
+		if (res != TEE_SUCCESS)
+			goto out;
+	}
+
+	/* Add the handle to the db */
+	fd = handle_get(&fs_handle_db, fh);
+	if (fd == -1) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	/*
+	 * If this is opened with create and the entry found was not active
+	 * then this is a new file and the FAT entry must be written
+	 */
+	if (flags & TEE_FS_O_CREATE) {
+		if ((fh->fat_entry.flags & FILE_IS_ACTIVE) == 0) {
+			memset(&fh->fat_entry, 0,
+				sizeof(struct rpmb_fat_entry));
+			memcpy(fh->fat_entry.filename, file, strlen(file));
+			/* Start address and size are 0 */
+			fh->fat_entry.flags = FILE_IS_ACTIVE;
+
+			res = write_fat_entry(fh, true);
+			if (res != TEE_SUCCESS) {
+				handle_put(&fs_handle_db, fd);
+				fd = -1;
+				goto out;
+			}
+		}
+	}
+
+	res = TEE_SUCCESS;
+
+out:
+	if (res != TEE_SUCCESS) {
+		if (fh)
+			free(fh);
+
+		fd = -1;
+	}
+
+	return fd;
+}
+
+int tee_rpmb_fs_close(int fd)
+{
+	struct rpmb_file_handle *fh;
+
+	fh = handle_put(&fs_handle_db, fd);
+	if (fh != NULL) {
+		free(fh);
+		return 0;
+	}
+
+	return -1;
+}
+
+int tee_rpmb_fs_read(int fd, uint8_t *buf, size_t size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct rpmb_file_handle *fh = NULL;
+	int read_size = -1;
+
+	if (buf == NULL) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	fh = handle_lookup(&fs_handle_db, fd);
+	if (fh == NULL) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	/*
+	 * Need to update the contents because the file could have already been
+	 * written to by someone else
+	 */
 
 	res = read_fat(fh, NULL);
 	if (res != TEE_SUCCESS)
@@ -395,50 +663,56 @@ int tee_rpmb_fs_read(const char *filename, uint8_t *buf, size_t size)
 		goto out;
 	}
 
-	res = tee_rpmb_read(DEV_ID, fh->fat_entry.start_address, buf,
-			    fh->fat_entry.data_size);
+	if (fh->fat_entry.data_size > 0) {
+		res = tee_rpmb_read(DEV_ID, fh->fat_entry.start_address, buf,
+				    fh->fat_entry.data_size);
+
+		if (res != TEE_SUCCESS)
+			goto out;
+	}
+
+	read_size = fh->fat_entry.data_size;
+	res = TEE_SUCCESS;
 
 out:
-	if (res == TEE_SUCCESS)
-		read_size = fh->fat_entry.data_size;
-
-	free(fh);
+	if (res != TEE_SUCCESS)
+		read_size = -1;
 
 	return read_size;
 }
 
-int tee_rpmb_fs_write(const char *filename, uint8_t *buf, size_t size)
+int tee_rpmb_fs_write(int fd, uint8_t *buf, size_t size)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh = NULL;
 	tee_mm_pool_t p;
+	bool pool_result = false;
 	tee_mm_entry_t *mm = NULL;
-	size_t length;
-	uint32_t mm_flags;
 
-	if (filename == NULL || buf == NULL) {
+	if (buf == NULL) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
-	length = strlen(filename);
-	if ((length >= FILENAME_LENGTH - 1) || (length == 0)) {
-		res = TEE_ERROR_BAD_PARAMETERS;
+	if (fs_par == NULL) {
+		res = TEE_ERROR_GENERIC;
 		goto out;
 	}
 
-	/* Create a FAT entry for the file to write. */
-	fh = alloc_file_handle(filename);
+	fh = handle_lookup(&fs_handle_db, fd);
 	if (fh == NULL) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
+		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
 	/* Upper memory allocation must be used for RPMB_FS. */
-	mm_flags = TEE_MM_POOL_HI_ALLOC;
-	if (!tee_mm_init
-	    (&p, RPMB_STORAGE_START_ADDRESS, RPMB_STORAGE_END_ADDRESS,
-	     RPMB_BLOCK_SIZE_SHIFT, mm_flags)) {
+	pool_result = tee_mm_init(&p,
+				  RPMB_STORAGE_START_ADDRESS,
+				  fs_par->max_rpmb_address,
+				  RPMB_BLOCK_SIZE_SHIFT,
+				  TEE_MM_POOL_HI_ALLOC);
+
+	if (!pool_result) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
@@ -454,13 +728,12 @@ int tee_rpmb_fs_write(const char *filename, uint8_t *buf, size_t size)
 	}
 
 	if ((fh->fat_entry.flags & FILE_IS_LAST_ENTRY) != 0) {
+		TEE_ASSERT(0);
 		res = add_fat_entry(fh);
 		if (res != TEE_SUCCESS)
 			goto out;
 	}
 
-	memset(&fh->fat_entry, 0, sizeof(struct rpmb_fat_entry));
-	memcpy(fh->fat_entry.filename, filename, length);
 	fh->fat_entry.data_size = size;
 	fh->fat_entry.flags = FILE_IS_ACTIVE;
 	fh->fat_entry.start_address = tee_mm_get_smem(mm);
@@ -472,8 +745,7 @@ int tee_rpmb_fs_write(const char *filename, uint8_t *buf, size_t size)
 	res = write_fat_entry(fh, true);
 
 out:
-	free(fh);
-	if (mm != NULL)
+	if (pool_result)
 		tee_mm_final(&p);
 
 	if (res == TEE_SUCCESS)
@@ -482,12 +754,28 @@ out:
 	return -1;
 }
 
+tee_fs_off_t tee_rpmb_fs_lseek(int fd, tee_fs_off_t offset, int whence)
+{
+	(void)fd;
+
+	/*
+	 * Currently, RPMB only returns success for seek to 0 since the
+	 * entire file must be read at once.
+	 */
+	if (whence != TEE_FS_SEEK_SET || offset != 0)
+		return -1;
+
+	return 0;
+}
+
 TEE_Result tee_rpmb_fs_rm(const char *filename)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh = NULL;
 
-	if (filename == NULL || strlen(filename) >= FILENAME_LENGTH - 1) {
+	if (filename == NULL ||
+		strlen(filename) >= TEE_RPMB_FS_FILENAME_LENGTH - 1) {
+
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
@@ -508,15 +796,15 @@ TEE_Result tee_rpmb_fs_rm(const char *filename)
 
 out:
 	free(fh);
-
+	IMSG("Deleting file %s returned 0x%x\n", filename, res);
 	return res;
 }
 
 TEE_Result tee_rpmb_fs_rename(const char *old_name, const char *new_name)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh_old = NULL;
-	struct file_handle *fh_new = NULL;
+	struct rpmb_file_handle *fh_old = NULL;
+	struct rpmb_file_handle *fh_new = NULL;
 	uint32_t old_len;
 	uint32_t new_len;
 
@@ -528,8 +816,9 @@ TEE_Result tee_rpmb_fs_rename(const char *old_name, const char *new_name)
 	old_len = strlen(old_name);
 	new_len = strlen(new_name);
 
-	if ((old_len >= FILENAME_LENGTH - 1) ||
-	    (new_len >= FILENAME_LENGTH - 1) || (new_len == 0)) {
+	if ((old_len >= TEE_RPMB_FS_FILENAME_LENGTH - 1) ||
+	    (new_len >= TEE_RPMB_FS_FILENAME_LENGTH - 1) || (new_len == 0)) {
+
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
@@ -556,7 +845,7 @@ TEE_Result tee_rpmb_fs_rename(const char *old_name, const char *new_name)
 		goto out;
 	}
 
-	memset(fh_old->fat_entry.filename, 0, FILENAME_LENGTH);
+	memset(fh_old->fat_entry.filename, 0, TEE_RPMB_FS_FILENAME_LENGTH);
 	memcpy(fh_old->fat_entry.filename, new_name, new_len);
 
 	res = write_fat_entry(fh_old, false);
@@ -568,11 +857,322 @@ out:
 	return res;
 }
 
+int tee_rpmb_fs_mkdir(const char *path, tee_fs_mode_t mode)
+{
+	(void)path;
+	(void)mode;
+
+	/* mkdir is not supported in RPMB and should not be called*/
+	EMSG("tee_rpmb_fs_mkdir called when not expected");
+
+	return -1;
+}
+
+int tee_rpmb_fs_ftruncate(int fd, tee_fs_off_t length)
+{
+	struct rpmb_file_handle *fh;
+
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (length != 0) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	fh = handle_lookup(&fs_handle_db, fd);
+	if (fh == NULL) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	/*
+	 * Need to update the contents because the file could have already been
+	 * written to by someone else
+	 */
+
+	res = read_fat(fh, NULL);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	/* Clear the size and the address */
+	fh->fat_entry.data_size = 0;
+	fh->fat_entry.start_address = 0;
+	res = write_fat_entry(fh, false);
+
+out:
+	if (res == TEE_SUCCESS)
+		return 0;
+
+	return -1;
+}
+
+static void tee_rpmb_fs_dir_free(tee_fs_dir *dir)
+{
+	struct tee_rpmb_fs_dirent *current;
+	struct tee_rpmb_fs_dirent *next;
+
+	if (dir == NULL)
+		return;
+
+	if (dir->current)
+		free(dir->current);
+
+	for (current = dir->next; current != NULL; current = next) {
+		next = current->next;
+		free(current);
+	}
+}
+
+static TEE_Result tee_rpmb_fs_dir_populate(const char *path, tee_fs_dir *dir)
+{
+	struct tee_rpmb_fs_dirent *current = NULL;
+	struct rpmb_fat_entry *fat_entries = NULL;
+	uint32_t fat_address;
+	uint32_t filelen;
+	char *filename;
+	int i;
+	bool last_entry_found = false;
+	bool matched;
+	struct tee_rpmb_fs_dirent *next = NULL;
+	uint32_t pathlen;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t size;
+	char temp;
+
+	res = rpmb_fs_setup();
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = get_fat_start_address(&fat_address);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
+	fat_entries = malloc(size);
+	if (fat_entries == NULL) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	pathlen = strlen(path);
+	while (!last_entry_found) {
+		res = tee_rpmb_read(DEV_ID, fat_address,
+				    (uint8_t *)fat_entries, size);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+		for (i = 0; i < N_ENTRIES; i++) {
+			filename = fat_entries[i].filename;
+			if (fat_entries[i].flags & FILE_IS_ACTIVE) {
+				matched = false;
+				filelen = strlen(filename);
+				if (filelen > pathlen) {
+					temp = filename[pathlen];
+					filename[pathlen] = '\0';
+					if (strcmp(filename, path) == 0)
+						matched = true;
+
+					filename[pathlen] = temp;
+				}
+
+				if (matched) {
+					next = malloc(sizeof(*next));
+					if (next == NULL) {
+						res = TEE_ERROR_OUT_OF_MEMORY;
+						goto out;
+					}
+
+					memset(next, 0, sizeof(*next));
+					next->entry.d_name = next->name;
+					memcpy(next->name,
+						&filename[pathlen],
+						filelen - pathlen);
+
+					if (current)
+						current->next = next;
+					else
+						dir->next = next;
+
+					current = next;
+					next = NULL;
+				}
+			}
+
+			if (fat_entries[i].flags & FILE_IS_LAST_ENTRY) {
+				last_entry_found = true;
+				break;
+			}
+
+			/* Move to next fat_entry. */
+			fat_address += sizeof(struct rpmb_fat_entry);
+		}
+	}
+
+	/* No directories were found. */
+	if (current == NULL) {
+		res = TEE_ERROR_NO_DATA;
+		goto out;
+	}
+
+	res = TEE_SUCCESS;
+
+out:
+	if (res != TEE_SUCCESS)
+		tee_rpmb_fs_dir_free(dir);
+
+	return res;
+}
+
+static TEE_Result tee_rpmb_fs_opendir_internal(const char *path,
+						tee_fs_dir **dir)
+{
+	uint32_t len;
+	uint32_t max_size;
+	char path_local[TEE_RPMB_FS_FILENAME_LENGTH];
+	TEE_Result res = TEE_ERROR_GENERIC;
+	tee_fs_dir *rpmb_dir = NULL;
+
+	if (path == NULL || dir == NULL) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	/*
+	 * There must be room for at least the NULL char and a char for the
+	 * filename after the path.
+	 */
+	max_size = TEE_RPMB_FS_FILENAME_LENGTH - 2;
+	len = strlen(path);
+	if (len > max_size || len == 0) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	memset(path_local, 0, sizeof(path_local));
+	memcpy(path_local, path, len);
+
+	/* Add a slash to correctly match the full directory name. */
+	if (path_local[len - 1] != '/')
+		path_local[len] = '/';
+
+	rpmb_dir = calloc(1, sizeof(tee_fs_dir));
+	if (rpmb_dir == NULL) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	res = tee_rpmb_fs_dir_populate(path_local, rpmb_dir);
+	if (res != TEE_SUCCESS) {
+		free(rpmb_dir);
+		rpmb_dir = NULL;
+		goto out;
+	}
+
+	*dir = rpmb_dir;
+
+out:
+	return res;
+}
+
+tee_fs_dir *tee_rpmb_fs_opendir(const char *path)
+{
+	tee_fs_dir *dir = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = tee_rpmb_fs_opendir_internal(path, &dir);
+	if (res != TEE_SUCCESS)
+		dir = NULL;
+
+	return dir;
+}
+
+
+struct tee_fs_dirent *tee_rpmb_fs_readdir(tee_fs_dir *dir)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (dir == NULL) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	if (dir->current != NULL) {
+		free(dir->current);
+		dir->current = NULL;
+	}
+
+	if (dir->next == NULL) {
+		res = TEE_ERROR_NO_DATA;
+		goto out;
+	}
+
+	/*
+	 * next pointer is the head of the list and represents the next entry
+	 * to be returned to the user.
+	 * Pop the head (next) of the list off and save it in current.
+	 * Current will be returned to the user and freed on subsequent
+	 * calls to read.
+	 */
+	dir->current = dir->next;
+	dir->next = dir->current->next;
+	dir->current->next = NULL;
+	res = TEE_SUCCESS;
+
+out:
+	if (res == TEE_SUCCESS)
+		return &dir->current->entry;
+
+	return NULL;
+}
+
+int tee_rpmb_fs_closedir(tee_fs_dir *dir)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (dir == NULL) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	tee_rpmb_fs_dir_free(dir);
+	free(dir);
+	res = TEE_SUCCESS;
+out:
+	if (res == TEE_SUCCESS)
+		return 0;
+
+	return -1;
+}
+
+int tee_rpmb_fs_rmdir(const char *path)
+{
+	tee_fs_dir *dir = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int ret = -1;
+
+	/* Open the directory anyting other than NO_DATA is a failure */
+	res = tee_rpmb_fs_opendir_internal(path, &dir);
+	if (res == TEE_SUCCESS) {
+		tee_rpmb_fs_closedir(dir);
+		ret = -1;
+
+	} else if (res == TEE_ERROR_NO_DATA) {
+		ret = 0;
+
+	} else {
+		/* The case any other failure is returned */
+		ret = -1;
+	}
+
+
+	return ret;
+}
+
 TEE_Result tee_rpmb_fs_stat(const char *filename,
 			    struct tee_rpmb_fs_stat *stat)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh = NULL;
 
 	if (stat == NULL || filename == NULL) {
 		res = TEE_ERROR_BAD_PARAMETERS;
@@ -589,10 +1189,27 @@ TEE_Result tee_rpmb_fs_stat(const char *filename,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	stat->size = fh->fat_entry.data_size;
+	stat->size = (size_t)fh->fat_entry.data_size;
 	stat->reserved = 0;
 
 out:
 	free(fh);
 	return res;
 }
+
+int tee_rpmb_fs_access(const char *filename, int mode)
+{
+	struct tee_rpmb_fs_stat stat;
+	TEE_Result res;
+
+	/* Mode is currently ignored, this only checks for existence */
+	(void)mode;
+
+	res = tee_rpmb_fs_stat(filename, &stat);
+
+	if (res == TEE_SUCCESS)
+		return 0;
+
+	return -1;
+}
+

--- a/core/tee/tee_rpmb_fs_common.c
+++ b/core/tee/tee_rpmb_fs_common.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <tee/tee_fs.h>
+#include <tee/tee_fs_defs.h>
+#include <tee/tee_rpmb_fs.h>
+#include <kernel/handle.h>
+#include <kernel/tee_common_unpg.h>
+#include <trace.h>
+#include <assert.h>
+
+#include "tee_fs_private.h"
+
+static struct handle_db fs_handle_db = HANDLE_DB_INITIALIZER;
+
+static void do_fail_recovery(struct tee_fs_fd *fdp)
+{
+	/* Try to delete the file for new created file */
+	if (fdp->is_new_file) {
+		tee_fs_common_unlink(fdp->filename);
+		EMSG("New created file was deleted, file=%s",
+				fdp->filename);
+		return;
+	}
+
+	/* Note: Roll back is automatic for RPMB */
+}
+
+struct tee_fs_fd *tee_fs_fd_lookup(int fd)
+{
+	return handle_lookup(&fs_handle_db, fd);
+}
+
+int tee_fs_common_open(TEE_Result *errno, const char *file, int flags, ...)
+{
+	int res = -1;
+	size_t len;
+	bool is_new_file = false;
+	int fd = -1;
+	struct tee_fs_fd *fdp = NULL;
+
+	assert(errno);
+	*errno = TEE_SUCCESS;
+
+	len = strlen(file) + 1;
+	if (len > TEE_FS_NAME_MAX) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		goto exit;
+	}
+
+	/*
+	 * try to open file without O_CREATE flag, if failed try again with
+	 * O_CREATE flag (to distinguish whether it's a new file or not)
+	 */
+	res = tee_rpmb_fs_open(file, flags & (~TEE_FS_O_CREATE));
+	if (res < 0) {
+		if (!(flags & TEE_FS_O_CREATE))
+			goto exit;
+
+		res = tee_rpmb_fs_open(file, flags);
+		if (res < 0)
+			goto exit;
+
+		is_new_file = true;
+	}
+
+	fd = res;
+	fdp = (struct tee_fs_fd *)malloc(sizeof(struct tee_fs_fd));
+	if (fdp == NULL)
+		goto exit;
+
+	/* init internal status */
+	fdp->nw_fd = fd;
+	fdp->flags = flags;
+	fdp->is_new_file = is_new_file;
+	fdp->private = NULL;
+	fdp->filename = malloc(len);
+	if (!fdp->filename) {
+		res = -1;
+		goto exit;
+	}
+	memcpy(fdp->filename, file, len);
+
+	/* return fd */
+	res = handle_get(&fs_handle_db, fdp);
+	fdp->fd = res;
+
+exit:
+	if (res == -1) {
+		free(fdp);
+		if (fd != -1)
+			tee_rpmb_fs_close(fd);
+	}
+
+	return res;
+}
+
+int tee_fs_common_close(struct tee_fs_fd *fdp)
+{
+	int res = -1;
+
+	if (fdp == NULL)
+		return -1;
+
+	handle_put(&fs_handle_db, fdp->fd);
+
+	res = tee_rpmb_fs_close(fdp->nw_fd);
+	if (res < 0) {
+		EMSG("Failed to close file, start fail recovery");
+		do_fail_recovery(fdp);
+	}
+
+	if (fdp->private)
+		free(fdp->private);
+
+	free(fdp->filename);
+	free(fdp);
+
+	return res;
+}
+
+
+tee_fs_off_t tee_fs_common_lseek(TEE_Result *errno, struct tee_fs_fd *fdp,
+				tee_fs_off_t offset, int whence)
+{
+	tee_fs_off_t res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		goto exit;
+	}
+
+	res = tee_rpmb_fs_lseek(fdp->nw_fd, offset, whence);
+	if (res < 0)
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+exit:
+	return res;
+}
+
+static TEE_Result _to_errno(int rc)
+{
+	if (rc == -1)
+		return TEE_ERROR_GENERIC;
+	else if (rc < 0)
+		return (TEE_Result)rc;
+	else
+		return TEE_SUCCESS;
+}
+
+static int _filter_rc(int rc)
+{
+	if (rc < 0)
+		return -1;
+	else
+		return rc;
+}
+
+int tee_fs_common_ftruncate(TEE_Result *errno, struct tee_fs_fd *fdp,
+			    tee_fs_off_t length)
+{
+	int rc;
+	int res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		res = -1;
+		goto exit;
+	}
+
+	rc = tee_rpmb_fs_ftruncate(fdp->nw_fd, length);
+	*errno = _to_errno(rc);
+	res = _filter_rc(rc);
+exit:
+	return res;
+}
+
+int tee_fs_common_read(TEE_Result *errno, struct tee_fs_fd *fdp,
+		       void *buf, size_t len)
+{
+	int rc;
+	int res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		res = -1;
+		goto exit;
+	}
+
+	rc = tee_rpmb_fs_read(fdp->nw_fd, (uint8_t *)buf, len);
+	*errno = _to_errno(rc);
+	res = _filter_rc(rc);
+
+exit:
+	return res;
+}
+
+int tee_fs_common_write(TEE_Result *errno, struct tee_fs_fd *fdp,
+			const void *buf, size_t len)
+{
+	int rc;
+	int res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		res = -1;
+		goto exit;
+	}
+
+	rc = tee_rpmb_fs_write(fdp->nw_fd, (uint8_t *)buf, len);
+	*errno = _to_errno(rc);
+	res = _filter_rc(rc);
+
+exit:
+	return res;
+}
+
+int tee_fs_common_rename(const char *old, const char *new)
+{
+	return tee_rpmb_fs_rename(old, new);
+}
+
+int tee_fs_common_unlink(const char *file)
+{
+	return tee_rpmb_fs_rm(file);
+}
+
+int tee_fs_common_mkdir(const char *path, tee_fs_mode_t mode)
+{
+	return tee_rpmb_fs_mkdir(path, mode);
+}
+
+tee_fs_dir *tee_fs_common_opendir(const char *name)
+{
+	return tee_rpmb_fs_opendir(name);
+}
+
+int tee_fs_common_closedir(tee_fs_dir *d)
+{
+	return tee_rpmb_fs_closedir(d);
+}
+
+struct tee_fs_dirent *tee_fs_common_readdir(tee_fs_dir *d)
+{
+	return tee_rpmb_fs_readdir(d);
+}
+
+int tee_fs_common_rmdir(const char *name)
+{
+	return tee_rpmb_fs_rmdir(name);
+}
+
+int tee_fs_common_access(const char *name, int mode)
+{
+	return tee_rpmb_fs_access(name, mode);
+}
+


### PR DESCRIPTION
Enabled by CFG_RPMB_FS=y. Requires support from the non-secure side
(e.g., tee-supplicant). Currently not compatible with CFG_ENC_FS
(file encryption), which must be set to 'n'.

** Please note: AFAIK, this patch was initially authored by
Youssef Esmat <youssef.esmat@microsoft.com> and later merged with new
code from OP-TEE master by Paul Swan <Paul.Swan@microsoft.com>.
Youssef/Paul, please let me know if I can add your Signed-off-by:
below. Also if you could provide a Tested-by: I would appreciate it
since I have currently no way of testing this. **

[Rebased onto master, fixed checkpatch warnings]
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>