### PR TITLE
RFC Ta64 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,17 +79,17 @@ script:
   -                                  PLATFORM=vexpress-fvp       CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
   - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-fvp       CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
   - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-fvp       CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
-  -                                  PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+  -                                  PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-fvp       CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- make -j8 all -s
 
   # Juno
   -                                  PLATFORM=vexpress-juno      CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
   - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-juno      CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
   - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-juno      CFG_ARM32_core=y   CROSS_COMPILE_core=arm-linux-gnueabihf- make -j8 all -s
-  -                                  PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
-  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
-  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   make -j8 all -s
+  -                                  PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- make -j8 all -s
+  - CFG_TEE_CORE_LOG_LEVEL=0 DEBUG=0 PLATFORM=vexpress-juno      CFG_ARM64_core=y   CROSS_COMPILE_core=aarch64-linux-gnu-   CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- make -j8 all -s
 
   # QEMU
   -                                  PLATFORM=vexpress-qemu                                                                make -j8 all -s

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,14 @@ endif
 
 include core/core.mk
 
+# Platform config is supposed to assign the targets
+ta-targets ?= user_ta
+
+define build-ta-target
+ta-target := $(1)
 include ta/ta.mk
+endef
+$(foreach t, $(ta-targets), $(eval $(call build-ta-target, $(t))))
 
 .PHONY: clean
 clean:

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -11,8 +11,11 @@ $(call force,CFG_PL011,y)
 $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 
+ta-targets = ta_arm32
+
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_WITH_LPAE,y)
+ta-targets += ta_arm64
 else
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_MMU_V7_TTB,y)

--- a/core/arch/arm/plat-vexpress/platform_flags.mk
+++ b/core/arch/arm/plat-vexpress/platform_flags.mk
@@ -43,8 +43,16 @@ platform-cflags += -g3
 platform-aflags += -g3
 endif
 
-CFG_ARM32_user_ta := y
-user_ta-platform-cflags += $(arm32-platform-cflags)
-user_ta-platform-cflags += -fpie
-user_ta-platform-cppflags += $(arm32-platform-cppflags)
-user_ta-platform-aflags += $(arm32-platform-aflags)
+# Variables for ta-target/sm "ta_arm32"
+CFG_ARM32_ta_arm32 := y
+ta_arm32-platform-cflags += $(arm32-platform-cflags)
+ta_arm32-platform-cflags += -fpie
+ta_arm32-platform-cppflags += $(arm32-platform-cppflags)
+ta_arm32-platform-aflags += $(arm32-platform-aflags)
+
+# Variables for ta-target/sm "ta_arm64"
+CFG_ARM64_ta_arm64 := y
+ta_arm64-platform-cflags += $(arm64-platform-cflags)
+ta_arm64-platform-cflags += -fpie
+ta_arm64-platform-cppflags += $(arm64-platform-cppflags)
+ta_arm64-platform-aflags += $(arm64-platform-aflags)

--- a/lib/libutee/arch/arm/sub.mk
+++ b/lib/libutee/arch/arm/sub.mk
@@ -2,5 +2,5 @@ cppflags-y += -I$(sub-dir)/../..
 
 srcs-y += user_ta_entry.c
 srcs-y += utee_misc.c
-srcs-$(CFG_ARM32_user_ta) += utee_syscalls_a32.S
-srcs-$(CFG_ARM64_user_ta) += utee_syscalls_a64.S
+srcs-$(CFG_ARM32_$(sm)) += utee_syscalls_a32.S
+srcs-$(CFG_ARM64_$(sm)) += utee_syscalls_a64.S

--- a/ta/arch/arm/arm.mk
+++ b/ta/arch/arm/arm.mk
@@ -1,6 +1,6 @@
-ifeq ($(CFG_ARM64_user_ta),y)
-user_ta-platform-cppflags += -DARM64=1 -D__LP64__=1
+ifeq ($(CFG_ARM64_$(sm)),y)
+$(sm)-platform-cppflags += -DARM64=1 -D__LP64__=1
 endif
-ifeq ($(CFG_ARM32_user_ta),y)
-user_ta-platform-cppflags += -DARM32=1 -D__ILP32__=1
+ifeq ($(CFG_ARM32_$(sm)),y)
+$(sm)-platform-cppflags += -DARM32=1 -D__ILP32__=1
 endif

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -1,5 +1,11 @@
+#ifdef ARM32
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
+#endif
+#ifdef ARM64
+OUTPUT_FORMAT("elf64-littleaarch64")
+OUTPUT_ARCH(aarch64)
+#endif
 
 PHDRS {
 	rodata PT_LOAD;

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -1,5 +1,3 @@
-
-
 # Get the dir of the ta-dev-kit, requires make version 3.81 or later
 ta-dev-kit-dir := $(patsubst %/,%,$(abspath $(dir $(lastword $(MAKEFILE_LIST)))..))
 
@@ -7,8 +5,8 @@ ta-dev-kit-dir := $(patsubst %/,%,$(abspath $(dir $(lastword $(MAKEFILE_LIST))).
 .PHONY: all
 all:
 
-sm := user_ta
-sm-$(ta) := y
+include $(ta-dev-kit-dir)/mk/conf.mk
+
 binary := $(BINARY)
 
 CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)
@@ -43,9 +41,9 @@ endif
 include $(ta-dev-kit-dir)/mk/arch.mk
 -include $(ta-dev-kit-dir)/mk/platform_flags.mk
 
-cppflags$(sm)  += $(platform-cppflags) $(user_ta-platform-cppflags)
-aflags$(sm)    += $(platform-aflags) $(user_ta-platform-aflags)
-cflags$(sm)    += $(platform-cflags) $(user_ta-platform-cflags)
+cppflags$(sm)  := $(platform-cppflags) $($(sm)-platform-cppflags)
+aflags$(sm)    := $(platform-aflags) $($(sm)-platform-aflags)
+cflags$(sm)    := $(platform-cflags) $($(sm)-platform-cflags)
 
 CFG_TEE_TA_LOG_LEVEL ?= 2
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -1,7 +1,7 @@
 include mk/cleanvars.mk
 
 # Set current submodule (used for module specific flags compile result etc)
-sm := user_ta
+sm := $(ta-target)
 sm-$(sm) := y
 
 # Setup compiler for this sub module
@@ -11,15 +11,16 @@ include mk/$(COMPILER_$(sm)).mk
 
 include ta/arch/$(ARCH)/$(ARCH).mk
 
-cppflags$(sm)	+= $(platform-cppflags) $(user_ta-platform-cppflags)
-cflags$(sm)	+= $(platform-cflags) $(user_ta-platform-cflags)
-aflags$(sm)	+= $(platform-aflags) $(user_ta-platform-aflags)
+# Expand platform flags here as $(sm) will change if we have several TA
+# targets. Platform flags should not change after inclusion of ta/ta.mk.
+cppflags$(sm)	:= $(platform-cppflags) $($(sm)-platform-cppflags)
+cflags$(sm)	:= $(platform-cflags) $($(sm)-platform-cflags)
+aflags$(sm)	:= $(platform-aflags) $($(sm)-platform-aflags)
 
 # Config flags from mk/config.mk
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 cppflags$(sm) += -DCFG_TEE_CORE_USER_MEM_DEBUG=$(CFG_TEE_CORE_USER_MEM_DEBUG)
 cppflags$(sm) += -DENABLE_MDBG=$(CFG_TEE_TA_MALLOC_DEBUG)
-
 
 base-prefix := $(sm)-
 
@@ -62,7 +63,7 @@ endef
 
 # Copy the .a files
 $(foreach f, $(libfiles), \
-	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/lib)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/lib)))
 
 # Copy .mk files
 ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk \
@@ -71,10 +72,10 @@ ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk \
 	ta/mk/ta_dev_kit.mk
 
 $(foreach f, $(ta-mkfiles), \
-	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/mk)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/mk)))
 
 # Special treatment for ta/arch/$(ARCH)/$(ARCH).mk
-arch-arch-mk := $(out-dir)/export-user_ta/mk/arch.mk
+arch-arch-mk := $(out-dir)/export-$(sm)/mk/arch.mk
 $(arch-arch-mk): ta/arch/$(ARCH)/$(ARCH).mk
 	@set -e; \
 	mkdir -p $(dir $@) ; \
@@ -91,26 +92,41 @@ $$(foreach h, $$(sf), $$(eval $$(call copy-file, $1/$$(h), \
 	$$(patsubst %/,%,$$(subst /./,/,$2/$$(dir $$(h)))))))
 endef
 $(foreach d, $(incdirs$(sm)), \
-	$(eval $(call copy-incdir, $(d), $(out-dir)/export-user_ta/include)))
+	$(eval $(call copy-incdir, $(d), $(out-dir)/export-$(sm)/include)))
 
 # Copy the .h files needed by host
 $(foreach d, $(incdirs-host), \
-	$(eval $(call copy-incdir, $(d), $(out-dir)/export-user_ta/host_include)))
+	$(eval $(call copy-incdir, $(d), $(out-dir)/export-$(sm)/host_include)))
 $(foreach f, $(incfiles-extra-host), \
-	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/host_include)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/host_include)))
 
 # Copy the src files
 ta-srcfiles = ta/arch/$(ARCH)/user_ta_header.c \
-	$(wildcard ta/arch/$(ARCH)/user_ta_elf_arm.lds)
+	$(wildcard ta/arch/$(ARCH)/ta.ld.S)
 $(foreach f, $(ta-srcfiles), \
-	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/src)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/src)))
 
 # Copy keys
 ta-keys = keys/default_ta.pem
 $(foreach f, $(ta-keys), \
-	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/keys)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/keys)))
 
 # Copy the scripts
 ta-scripts = $(wildcard scripts/sign.py)
 $(foreach f, $(ta-scripts), \
-	$(eval $(call copy-file, $(f), $(out-dir)/export-user_ta/scripts)))
+	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/scripts)))
+
+# Create config file
+conf-file := $(out-dir)/export-$(sm)/mk/conf.mk
+sm-$(conf-file) := $(sm)
+# The file is only created if it doesn't exist, this is currently OK as the
+# content of the file is static for a given TA dev kit.
+$(conf-file):
+	@$(cmd-echo-silent) '  GEN    ' $@
+	$(q)echo sm := $(sm-$(@)) > $@
+	$(q)echo sm-$(sm-$(@)) := y >> $@
+	$(q)echo CFG_ARM32_$(sm-$(@)) := $(CFG_ARM32_$(sm-$(@))) >> $@
+	$(q)echo CFG_ARM64_$(sm-$(@)) := $(CFG_ARM64_$(sm-$(@))) >> $@
+
+cleanfiles := $(cleanfiles) $(conf-file)
+all: $(conf-file)


### PR DESCRIPTION
This PR introduces one way of compiling 64-bit TAs. It's done by exporting two TA-dev-kits when compiling for arm64.

Another option would have been to only make one TA-dev-kit, but instead include multiple libs one set for 32-bit and another for 64-bit.

What do you think is the approach in this PR OK, or would you rather have something else?