### PR TITLE
Fix PL310 mutex allocation

### DIFF
--- a/core/arch/arm/include/kernel/tee_l2cc_mutex.h
+++ b/core/arch/arm/include/kernel/tee_l2cc_mutex.h
@@ -38,6 +38,13 @@ TEE_Result tee_get_l2cc_mutex(uint32_t *mutex);
 TEE_Result tee_set_l2cc_mutex(uint32_t *mutex);
 void tee_l2cc_mutex_lock(void);
 void tee_l2cc_mutex_unlock(void);
+
+/*
+ * Store the pa of a mutex used for l2cc
+ * It is allocated from the boot
+ */
+void tee_l2cc_store_mutex_boot_pa(uint32_t pa);
+
 #else
 static TEE_Result tee_enable_l2cc_mutex(void);
 static TEE_Result tee_disable_l2cc_mutex(void);

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -47,6 +47,10 @@
 #include <kernel/tz_ssvce.h>
 #include <kernel/panic.h>
 
+#ifdef CFG_PL310
+#include <kernel/tee_l2cc_mutex.h>
+#endif
+
 #define TEE_MMU_UMAP_HEAP_STACK_IDX	0
 #define TEE_MMU_UMAP_CODE_IDX		1
 #define TEE_MMU_UMAP_PARAM_IDX		2
@@ -757,8 +761,15 @@ void teecore_init_pub_ram(void)
 	tee_mm_final(&tee_mm_pub_ddr);
 	tee_mm_init(&tee_mm_pub_ddr, s, s + nsec_tee_size, SMALL_PAGE_SHIFT,
 		    TEE_MM_POOL_NO_FLAGS);
-
 	s += nsec_tee_size;
+
+#ifdef CFG_PL310
+	/* Allocate statically the l2cc mutex */
+	TEE_ASSERT((e - s) > 0);
+	tee_l2cc_store_mutex_boot_pa(s);
+	s += sizeof(uint32_t);		/* size of a pl310 mutex */
+#endif
+
 	default_nsec_shm_paddr = s;
 	default_nsec_shm_size = e - s;
 }


### PR DESCRIPTION
Allocation of PL310 mutex in shared memory cannot use
malloc() as it is performed in fastcall, meaning without
any active thread.

This patch statically allocates, in the boot sequence, a mutex
that can be used as the l2cc_mutex, in shared memory.

Signed-off-by: Pascal Brand <pascal.brand@st.com>