### PR TITLE
core: syscall_open_ta_session: do not copy session if TA is not found

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -599,7 +599,8 @@ function_exit:
 			tee_mmu_kunmap(va, tee_mm_get_bytes(mm_param));
 	}
 	tee_mm_free(mm_param);
-	tee_svc_copy_kaddr_to_uref(sess, ta_sess, s);
+	if (res == TEE_SUCCESS)
+		tee_svc_copy_kaddr_to_uref(sess, ta_sess, s);
 	tee_svc_copy_to_user(sess, ret_orig, &ret_o, sizeof(ret_o));
 
 out_free_only:


### PR DESCRIPTION
Fixes the following xtest failure on HiKey:

 root@HiKey:/ xtest 8031
 [...]
 * XTEST_TEE_8031 a7-a3-6b
 ERR [761] TEES:load_ta:317:   TA not found
 ERR TEE-CORE:_assert_log:38: Assertion
 '((vaddr_t)kaddr - tee_svc_uref_base) < UINT32_MAX' failed at
 core/include/tee/tee_svc.h:83

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>