### PR TITLE
Fix compile error with newer gcc

### DIFF
--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -263,7 +263,7 @@ TEE_Result tee_mmu_init(struct tee_ta_ctx *ctx)
 TEE_Result tee_mmu_map(struct tee_ta_ctx *ctx, struct tee_ta_param *param)
 {
 	TEE_Result res = TEE_SUCCESS;
-	paddr_t pa;
+	paddr_t pa = NULL;
 	uintptr_t smem;
 	size_t n;
 


### PR DESCRIPTION
$ make \
	CFG_ARM64_core=y \
	CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- \
	CROSS_COMPILE=arm-linux-gnueabihf- \
	CROSS_COMPILE_core=aarch64-linux-gnu- \
	CROSS_COMPILE_ta_arm32=arm-linux-gnueabihf- \
	DEBUG=0 \
	PLATFORM=hikey \
	CFG_TEE_CORE_LOG_LEVEL=2 \
	CFG_TEE_TA_LOG_LEVEL=3

core/arch/arm/mm/tee_mmu.c: In function 'tee_mmu_map':
core/arch/arm/mm/tee_mmu.c:266:10: error: 'pa' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  paddr_t pa;
          ^

gcc version 4.9.2 20140811 (prerelease) (crosstool-NG linaro-1.13.1-4.9-2014.08 - Linaro GCC 4.9-2014.08) is ok but
gcc version 4.9.3 20150413 (prerelease) (Linaro GCC 4.9-2015.05) generates this error.

Signed-off-by: Victor Chong <victor.chong@linaro.org>