### PR TITLE
plat-hikey: change default console to UART3

### DIFF
--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -38,11 +38,14 @@
 #endif /* ARM64 */
 
 /* PL011 UART */
-#if defined(CFG_HIKEY_UART3)
-#define CONSOLE_UART_BASE	0xF7113000
+#if defined(CFG_CONSOLE_UART) && (CFG_CONSOLE_UART == 0)
+#define CONSOLE_UART_BASE       0xF8015000
+#elif !defined(CFG_CONSOLE_UART) || (CFG_CONSOLE_UART == 3)
+#define CONSOLE_UART_BASE       0xF7113000
 #else
-#define CONSOLE_UART_BASE	0xF8015000
+#error Unknown console UART
 #endif
+
 #define CONSOLE_BAUDRATE	115200
 #define CONSOLE_UART_CLK_IN_HZ	19200000
 


### PR DESCRIPTION
96boards community now uses UART3 as default for all SW components.
Change default for optee_os to UART3 as well to be inline with them.

Signed-off-by: Victor Chong <victor.chong@linaro.org>