### PR TITLE
Generate new TA dev kit for ARM32 platforms

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -14,6 +14,8 @@ $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
 
+ta-targets = ta_arm32
+
 CFG_WITH_STACK_CANARIES ?= y
 
 include mk/config.mk

--- a/core/arch/arm/plat-imx/platform_flags.mk
+++ b/core/arch/arm/plat-imx/platform_flags.mk
@@ -21,5 +21,5 @@ platform-aflags += -g
 platform-cflags += -g3
 platform-aflags += -g3
 
-CFG_ARM32_user_ta := y
-user_ta-platform-cflags = -fpie
+CFG_ARM32_ta_arm32 := y
+ta_arm32-platform-cflags = -fpie

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -13,6 +13,8 @@ $(call force,CFG_16550_UART,y)
 $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_BOOT_SYNC_CPU,y)
 
+ta-targets = ta_arm32
+
 CFG_WITH_STACK_CANARIES ?= y
 
 include mk/config.mk

--- a/core/arch/arm/plat-ls/platform_flags.mk
+++ b/core/arch/arm/plat-ls/platform_flags.mk
@@ -24,5 +24,5 @@ platform-aflags += -g
 platform-cflags += -g3
 platform-aflags += -g3
 
-CFG_ARM32_user_ta := y
-user_ta-platform-cflags = -fpie
+CFG_ARM32_ta_arm32 := y
+ta_arm32-platform-cflags = -fpie

--- a/core/arch/arm/plat-stm/conf.mk
+++ b/core/arch/arm/plat-stm/conf.mk
@@ -14,6 +14,8 @@ $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_MMU_V7_TTB,y)
 $(call force,CFG_BOOT_SYNC_CPU,y)
 
+ta-targets = ta_arm32
+
 libtomcrypt_with_optimize_size ?= y
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-stm/platform_flags.mk
+++ b/core/arch/arm/plat-stm/platform_flags.mk
@@ -18,5 +18,5 @@ endif
 platform-cflags += -g
 platform-aflags += -g
 
-CFG_ARM32_user_ta := y
-user_ta-platform-cflags = -fpie
+CFG_ARM32_ta_arm32 := y
+ta_arm32-platform-cflags = -fpie

--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -12,6 +12,8 @@ $(call force,CFG_MMU_V7_TTB,y)
 $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_GIC,y)
 
+ta-targets = ta_arm32
+
 CFG_NUM_THREADS ?= 4
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-sunxi/platform_flags.mk
+++ b/core/arch/arm/plat-sunxi/platform_flags.mk
@@ -21,5 +21,5 @@ platform-aflags += -g
 platform-cflags += -g3
 platform-aflags += -g3
 
-CFG_ARM32_user_ta := y
-user_ta-platform-cflags = -fpie
+CFG_ARM32_ta_arm32 := y
+ta_arm32-platform-cflags = -fpie

--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -14,6 +14,8 @@ $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
 
+ta-targets = ta_arm32
+
 libtomcrypt_with_optimize_size ?= y
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-ti/platform_flags.mk
+++ b/core/arch/arm/plat-ti/platform_flags.mk
@@ -22,8 +22,8 @@ endif
 platform-cflags += -g3
 platform-aflags += -g3
 
-CFG_ARM32_user_ta := y
-user_ta-platform-cflags += $(arm32-platform-cflags)
-user_ta-platform-cflags += -fpie
-user_ta-platform-cppflags += $(arm32-platform-cppflags)
-user_ta-platform-aflags += $(arm32-platform-aflags)
+CFG_ARM32_ta_arm32 := y
+ta_arm32-platform-cflags += $(arm32-platform-cflags)
+ta_arm32-platform-cflags += -fpie
+ta_arm32-platform-cppflags += $(arm32-platform-cppflags)
+ta_arm32-platform-aflags += $(arm32-platform-aflags)

--- a/documentation/build_system.md
+++ b/documentation/build_system.md
@@ -67,12 +67,13 @@ The output directory has basically the same structure as the source tree.
 For instance, assuming **ARCH=arm PLATFORM=stm**,
 `core/kernel/panic.c` will compile into `out/arm-plat-stm/core/kernel/panic.o`.
 
-However, some libraries are compiled twice: once for user mode, and once for
-kernel mode. This is because they may be used by the TEE Core as well as by
-the Trusted Applications. As a result, the `lib` source directory gives two
-build directories: `user_ta-lib` and `core-lib`.
+However, some libraries are compiled several times: once or twice for user
+mode, and once for kernel mode. This is because they may be used by the TEE
+Core as well as by the Trusted Applications. As a result, the `lib` source
+directory gives two or three build directories: `ta_arm{32,64}-lib` and
+`core-lib`.
 
-The output directory also has an `export-user_ta` directory, which
+The output directory also has an `export-ta_arm{32,64}` directory, which
 contains:
 - All the files needed to build Trusted Applications.
   - In `lib/`: **libutee.a** (the GlobalPlatform Internal API), **libutils.a**
@@ -82,11 +83,10 @@ contains:
   - In `mk/`: **ta_dev_kit.mk**, which is a Make include file with suitable
   rules to build a TA, and its dependencies
   - `scripts/sign.py`: a Python script used by ta_dev_kit.mk to sign TAs.
-  - In `src`: **user_ta_header.c** and **user_ta_elf_arm.lds**: source file and
-  linker script to add a suitable header to the Trusted Application (as expected
-  by the loader code in the TEE Core)
+  - In `src`: **user_ta_header.c**: source file to add a suitable header to the
+  Trusted Application (as expected by the loader code in the TEE Core)
 - Some files needed to build host applications (using the Client API), under
-  `export-user_ta/host_include`.
+  `export-ta_arm{32,64}/host_include`.
 
 Finally, the build directory contains the auto-generated configuration file
 for the TEE Core: `$(O)/core/include/generated/conf.h` (see below).
@@ -102,7 +102,8 @@ $ make CROSS_COMPILE="ccache arm-linux-gnueabihf-"
 ```
 
 The CROSS_COMPILE variable can be overridden with **CROSS_COMPILE_core** and
-**CROSS_COMPILE_user_ta** for TEE Core and Trusted Applications respectively.
+**CROSS_COMPILE_ta_arm{32,64}** for TEE Core and Trusted Applications
+respectively.
 This is needed if TEE Core and Trusted Application libraries need to be
 compiled with different compilers due to a mix of 64bit and 32bit code.
 
@@ -114,10 +115,10 @@ The following variables are defined in `core/arch/$(ARCH)/plat-$(PLATFORM)/platf
 - **$(platform-aflags)**, **$(platform-cflags)** and **$(platform-cppflags)**
   are added to the assembler / C compiler / preprocessor flags for all source
   files
-- **$(user_ta-platform-aflags)**, **$(user_ta-platform-cflags)** and
-  **$(user_ta-platform-cppflags)** are added to the assembler / C compiler /
-  preprocessor flags when building the user-mode libraries (**libutee.a**,
-  **libutils.a**, **libmpa.a**) or Trusted Applications.
+- **$(ta_arm{32,64}-platform-aflags)**, **$(ta_arm{32,64}-platform-cflags)**
+  and **$(ta_arm{32,64}-platform-cppflags)** are added to the assembler / C
+  compiler / preprocessor flags when building the user-mode libraries
+  (**libutee.a**, **libutils.a**, **libmpa.a**) or Trusted Applications.
 
 The following variables are defined in `core/arch/$(ARCH)/plat-$(PLATFORM)/conf.mk`:
 
@@ -198,7 +199,7 @@ and `cflags-lib-y`.
 
 Include directories may be added to `global-incdirs-y`, in which case they will
 be accessible from all the source files and will be copied to
-`export-user_ta/include` and `export-user_ta/host_include`.
+`export-ta_arm{32,64}/include` and `export-ta_arm{32,64}/host_include`.
 
 When `sub.mk` is used to build a library, `incdirs-lib-y` may receive additional
 directories that will be used for that library only.

--- a/documentation/crypto.md
+++ b/documentation/crypto.md
@@ -31,7 +31,7 @@ Cryptographic Operations API.
 
 The Internal API is implemented in
 [tee_api_operations.c](../lib/libutee/tee_api_operations.c), which is
-compiled into a static library: `${O}/user_ta-lib/lib/libutee.a`.
+compiled into a static library: `${O}/ta_arm{32,64}-lib/libutee/libutee.a`.
 
 Most API functions perform some parameter checking and manipulations, then
 invoke some **utee_\*** function to switch to kernel mode and perform the


### PR DESCRIPTION
I didn't add ```CROSS_COMPILE_ta_arm32``` flag to ```.travis.yml``` since it should default correctly.
Update a couple of related docs as well.
Thanks!
