### PR TITLE
Fix Travis build error (QEMU check)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,4 +136,4 @@ script:
   - PLATFORM=ls  PLATFORM_FLAVOR=ls1021aqds  make -j8 all -s
 
   # Run regression tests (xtest in QEMU)
-  - (cd ${HOME}/optee_repo/build && make -s -j8 check CROSS_COMPILE="ccache arm-linux-gnueabihf-" DUMP_LOGS_ON_ERROR=1)
+  - (cd ${HOME}/optee_repo/build && make -s -j8 check CROSS_COMPILE="ccache arm-linux-gnueabihf-" AARCH32_CROSS_COMPILE=arm-linux-gnueabihf- DUMP_LOGS_ON_ERROR=1)


### PR DESCRIPTION
The QEMU build project now needs AARCH32_CROSS_COMPILE to be set.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>