### PR TITLE
documentation/arm_trusted_firmware.md: Fixed maximum debug level

### DIFF
--- a/documentation/arm_trusted_firmware.md
+++ b/documentation/arm_trusted_firmware.md
@@ -61,7 +61,7 @@ To build OP-TEE for FVP, follow these steps:
 
 To get debug prints from OP-TEE OS add for instance:
 
-        export CFG_TEE_CORE_LOG_LEVEL=5
+        export CFG_TEE_CORE_LOG_LEVEL=4
 
 5.  Building the Trusted Firmware
 ---------------------------------


### PR DESCRIPTION
Both README.md and trace_levels.h say the level ranges from 1 to 4.