### PR TITLE
ltc: mutex support, in case of no mutex

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -1,3 +1,5 @@
+CFG_LTC_OPTEE_THREAD ?= y
+
 ifeq ($(CFG_ARM64_core),y)
 core-platform-cppflags += -DARM64=1 -D__LP64__=1
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64

--- a/core/lib/libtomcrypt/include/tomcrypt_custom.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_custom.h
@@ -457,10 +457,9 @@
    #error PK requires ASN.1 DER functionality, make sure LTC_DER is enabled
 #endif
 
-#define LTC_OPTEE_THREAD
 
 /* THREAD management */
-#if defined(LTC_OPTEE_THREAD)
+#if defined(CFG_LTC_OPTEE_THREAD)
 
 #include <kernel/mutex.h>
 


### PR DESCRIPTION
Some platforms, other than arm, may not support multiple
threads, or may have other support than the LTC_OPTEE_THREAD
thread scheme.

This patch defines LTC_OPTEE_THREAD for arm only platform,
and defines the no mutex mechanism in libtomcrypt

Signed-off-by: Pascal Brand <pascal.brand@st.com>