### PR TITLE
libutee: use CFG_TEE_PANIC_DEBUG setting

### DIFF
--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -23,6 +23,9 @@ cppflags$(sm) += -DCFG_TEE_CORE_USER_MEM_DEBUG=$(CFG_TEE_CORE_USER_MEM_DEBUG)
 ifeq ($(CFG_TEE_TA_MALLOC_DEBUG),y)
 cppflags$(sm) += -DENABLE_MDBG=1
 endif
+ifeq ($(CFG_TEE_PANIC_DEBUG),y)
+cppflags$(sm) += -DCFG_TEE_PANIC_DEBUG=1
+endif
 
 base-prefix := $(sm)-
 


### PR DESCRIPTION
When libutee is compiled, the configuration variable
CFG_TEE_PANIC_DEBUG is not exported to the C code as a pre-processor
macro (contrary to TEE core build, it does not happen automatically).
As a result, all the calls to TEE_Panic() that occur in the
GlobalPlatform API wrappers do not call EMSG() when the TA is about
to panic.
This commit fixes this issue by properly defining the C macro when the
configuration variable is enabled.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

Conflicts:
	ta/ta.mk