### PR TITLE
Adjust the optional flags check to allow the KEEP_ALIVE flag

### DIFF
--- a/core/arch/arm/kernel/tee_ta_manager.c
+++ b/core/arch/arm/kernel/tee_ta_manager.c
@@ -632,7 +632,8 @@ static TEE_Result tee_ta_load(const TEE_UUID *uuid,
 	uint32_t man_flags = TA_FLAG_USER_MODE | TA_FLAG_EXEC_DDR;
 	/* opt_flags: optional flags */
 	uint32_t opt_flags = man_flags | TA_FLAG_SINGLE_INSTANCE |
-	    TA_FLAG_MULTI_SESSION | TA_FLAG_UNSAFE_NW_PARAMS;
+	    TA_FLAG_MULTI_SESSION | TA_FLAG_UNSAFE_NW_PARAMS |
+	    TA_FLAG_INSTANCE_KEEP_ALIVE;
 	struct tee_ta_ctx *ctx = NULL;
 	struct shdr *sec_shdr = NULL;
 	struct ta_head *ta_head;


### PR DESCRIPTION
Adjust the optional flags check to allow the 
TA_FLAG_INSTANCE_KEEP_ALIVE flag.

Reviewed-by: Paul Swan <paswan@microsoft.com>
Tested-by: Youssef Esmat <Youssef.Esmat@microsoft.com>
Signed-off-by: Paul Swan <paswan@microsoft.com>