### PR TITLE
Fix 64-bit build errors when CFG_TEE_TA_LOG_LEVEL == TRACE_FLOW (4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,7 @@ script:
   # HiKey board (HiSilicon Kirin 620)
   - make -j8 -s PLATFORM=hikey
   - make -j8 -s PLATFORM=hikey CFG_ARM64_core=y CROSS_COMPILE_core=aarch64-linux-gnu- CROSS_COMPILE_ta_arm64=aarch64-linux-gnu-
+  - make -j8 -s PLATFORM=hikey CFG_ARM64_core=y CROSS_COMPILE_core=aarch64-linux-gnu- CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- CFG_TEE_TA_LOG_LEVEL=4
 
   # Mediatek mt8173 EVB
   - PLATFORM=mediatek  PLATFORM_FLAVOR=mt8173  CFG_ARM64_core=y  CROSS_COMPILE_core=aarch64-linux-gnu- CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- make -j8 all -s

--- a/lib/libutee/tee_user_mem.c
+++ b/lib/libutee/tee_user_mem.c
@@ -192,22 +192,22 @@ static struct tee_user_mem_stats global_stats;
 
 static void heap_inc(size_t size)
 {
-	INMSG("%d", size);
+	INMSG("%zu", size);
 	heap_level += size;
 
 	global_stats.nb_alloc++;
 	global_stats.size += size;
-	OUTMSG("%d", global_stats.size);
+	OUTMSG("%zu", global_stats.size);
 }
 
 static void heap_dec(size_t size)
 {
-	INMSG("%d %d", heap_level, size);
+	INMSG("%zu %zu", heap_level, size);
 	heap_level -= size;
 
 	global_stats.nb_alloc--;
 	global_stats.size -= size;
-	OUTMSG("%d", global_stats.size);
+	OUTMSG("%zu", global_stats.size);
 }
 
 /*
@@ -297,7 +297,7 @@ void *tee_user_mem_alloc(size_t len, uint32_t hint)
 	    len + sizeof(struct user_mem_elem) + CANARY_LINE_SIZE;
 
 
-	INMSG("%d %p", (int)len, (void *)hint);
+	INMSG("%zu 0x%" PRIx32, len, hint);
 
 	if ((int)len < 0) {
 		OUTMSG("0x0");
@@ -480,11 +480,11 @@ void tee_user_mem_mark_heap(void)
 size_t tee_user_mem_check_heap(void)
 {
 	int res = 0;
-	INMSG("%d", heap_level);
+	INMSG("%zu", heap_level);
 
 	if (heap_level) {
 		EMSG("ta heap has changed of [%zu]", heap_level);
-		OUTMSG("%d", heap_level);
+		OUTMSG("%zu", heap_level);
 		return heap_level;
 	}
 


### PR DESCRIPTION
$ make -j9 PLATFORM=hikey CFG_ARM64_core=y \
  CROSS_COMPILE_core=aarch64-linux-gnu- \
  CROSS_COMPILE_ta_arm64=aarch64-linux-gnu- \
  CFG_TEE_TA_LOG_LEVEL=4
[...]
lib/libutee/tee_user_mem.c: In function ‘heap_inc’:
lib/libutee/tee_user_mem.c:195:2: error: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘size_t’ [-Werror=format=]
  INMSG("%d", size);
  ^

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>