### PR TITLE
core: RPMB (Replay Protected Memory Block) filesystem support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,8 @@ script:
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_ENC_FS=y CFG_FS_BLOCK_CACHE=y
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_ENC_FS=n CFG_FS_BLOCK_CACHE=y
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_WITH_STATS=y
+  - make -j8 -s CFG_RPMB_FS=y CFG_ENC_FS=n
+  - make -j8 -s CFG_RPMB_FS=y CFG_ENC_FS=n CFG_RPMB_TESTKEY=y
 
   # SUNXI(Allwinner A80)
   - CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1 PLATFORM=sunxi make -j8 all -s

--- a/core/include/tee/tee_rpmb.h
+++ b/core/include/tee/tee_rpmb.h
@@ -31,16 +31,6 @@
 #include "tee_api_types.h"
 
 /*
- * Generate RPMB key and write to eMMC.
- *
- * @dev_id      Device ID of the eMMC device.
- * @commercial  Flag indicating if we should write
- *              commercial key which is bound to
- *              the hard unique key.
- */
-TEE_Result tee_rpmb_write_key(uint16_t dev_id, bool commercial);
-
-/*
  * Read RPMB data in bytes.
  *
  * @dev_id     Device ID of the eMMC device.
@@ -69,4 +59,13 @@ TEE_Result tee_rpmb_write(uint16_t dev_id,
  * @counter    Pointer to the counter.
  */
 TEE_Result tee_rpmb_get_write_counter(uint16_t dev_id, uint32_t *counter);
+
+/*
+ * Read the RPMB max block.
+ *
+ * @dev_id     Device ID of the eMMC device.
+ * @counter    Pointer to receive the max block.
+ */
+TEE_Result tee_rpmb_get_max_block(uint16_t dev_id, uint32_t *max_block);
+
 #endif

--- a/core/include/tee/tee_rpmb_fs.h
+++ b/core/include/tee/tee_rpmb_fs.h
@@ -31,34 +31,51 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <tee_api_types.h>
+#include <tee/tee_fs.h>
 
-#define FILENAME_LENGTH 48
+#define TEE_RPMB_FS_FILENAME_LENGTH 112
 
 struct tee_rpmb_fs_stat {
-	uint32_t size;
+	size_t size;
 	uint32_t reserved;
 };
 
 /**
+ * tee_rpmb_fs_open: Opens a file descriptor to the file.
+ * If the file does not exist and TEE_FS_O_CREATE flag is specified
+ * the file will be created empty.
+ *
+ * Returns the file descriptor or
+ * a value < 0 on failure.
+ */
+int tee_rpmb_fs_open(const char *file, int flags, ...);
+
+/**
+ * tee_rpmb_fs_close: Closes the file opened by tee_rpmb_fs_open.
+ *
+ * Returns a value < 0 on failure.
+ */
+int tee_rpmb_fs_close(int fd);
+
+/**
  * tee_rpmb_fs_read: Read entire file
- * Reads data from file pointed to by filename.
+ * Reads data from file pointed to by fd.
  * buf should be allocated by the client and its size must >= file size.
  *
  * Returns number of bytes read from the file or
  * a value < 0 on failure.
  */
-int tee_rpmb_fs_read(const char *filename, uint8_t *buf, size_t size);
+int tee_rpmb_fs_read(int fd, uint8_t *buf, size_t size);
 
 /**
  * tee_rpmb_fs_write: Write data to file
  * Write data to an existing file or create a new file and Write data.
- * If the file pointed to by filename exists, data will be overwritten,
- * otherwise the file will be created.
+ * The file contents will be overwritten with the new data.
  * size bytes of data will be copied from buf.
  *
  * Return n bytes written on success or a value < 0 on failure.
  */
-int tee_rpmb_fs_write(const char *filename, uint8_t *buf, size_t size);
+int tee_rpmb_fs_write(int fd, uint8_t *buf, size_t size);
 
 /**
  * tee_rpmb_fs_rm: Remove a file.
@@ -70,5 +87,72 @@ TEE_Result tee_rpmb_fs_rename(const char *old, const char *new);
 
 TEE_Result tee_rpmb_fs_stat(const char *filename,
 			    struct tee_rpmb_fs_stat *stat);
+
+/**
+ * tee_rpmb_fs_access: The current implementation checks if the given
+ * file exits.
+ *
+ * Return 0 if the file exists and -1 otherwise.
+ */
+int tee_rpmb_fs_access(const char *filename, int mode);
+
+/**
+ * tee_rpmb_fs_lseek: Seek to a given position.
+ * whence is one of: TEE_FS_SEEK_SET, TEE_FS_SEEK_END, TEE_FS_SEEK_CUR
+ * but only TEE_FS_SEEK_SET is currently supported.
+ * offset is an offset from 'whence' but only 0 is currently supported.
+ *
+ * Return the offset on success and -1 on failure.
+ */
+tee_fs_off_t tee_rpmb_fs_lseek(int fd, tee_fs_off_t offset, int whence);
+
+/**
+ * tee_rpmb_fs_opendir: Opens a stream to the directory 'path'.
+ * If new files are added to the directory after the open call
+ * returns they will not be reflected until the next open.
+ *
+ * Returns a pointer to tee_fs_dir or NULL on failure.
+ */
+tee_fs_dir *tee_rpmb_fs_opendir(const char *path);
+
+/**
+ * tee_rpmb_fs_readdir: Cycles through the directory contents opened
+ * by tee_rpmb_fs_opendir. A pointer to a tee_fs_dirent is returned.
+ * The memory is owned by the RPMB FS and will be freed on
+ * tee_rpmb_fs_closedir().
+ *
+ * Returns a pointer to a tee_fs_dirent or NULL on failure.
+ */
+struct tee_fs_dirent *tee_rpmb_fs_readdir(tee_fs_dir *dir);
+
+/**
+ * tee_rpmb_fs_closedir: Closes the directory opened by tee_rpmb_fs_open.
+ *
+ * Returns 0 on success and -1 on failure.
+ */
+int tee_rpmb_fs_closedir(tee_fs_dir *dir);
+
+/**
+ * tee_rpmb_fs_mkdir: Currently unsupported.
+ *
+ * Returns -1.
+ */
+int tee_rpmb_fs_mkdir(const char *path, tee_fs_mode_t mode);
+
+/**
+ * tee_rpmb_fs_ftruncate: Truncates the file to length. Only 0
+ * is supported.
+ *
+ * Returns 0 on success and -1 on failure.
+ */
+int tee_rpmb_fs_ftruncate(int fd, tee_fs_off_t length);
+
+/**
+ * tee_rpmb_fs_rmdir: Removes the directory if no children exist.
+ *
+ * Returns 0 on success -1 on failure.
+ */
+int tee_rpmb_fs_rmdir(const char *path);
+
 
 #endif

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -26,13 +26,18 @@ srcs-$(CFG_CRYPTO_HKDF) += tee_cryp_hkdf.c
 srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
 srcs-$(CFG_CRYPTO_PBKDF2) += tee_cryp_pbkdf2.c
 
+ifeq (y,$(CFG_RPMB_FS))
+$(call force,CFG_ENC_FS,n)
+srcs-y += tee_rpmb_fs_common.c
+srcs-y += tee_rpmb_fs.c
+else
 srcs-y += tee_fs_common.c
+endif
 srcs-y += tee_fs_key_manager.c
 srcs-y += tee_fs.c
 
 srcs-y += tee_obj.c
 srcs-y += tee_pobj.c
-srcs-y += tee_rpmb_fs.c
 srcs-y += tee_time_generic.c
 
 subdirs-${CFG_SE_API} += se

--- a/core/tee/tee_fs_private.h
+++ b/core/tee/tee_fs_private.h
@@ -85,10 +85,15 @@ struct block_cache {
 };
 
 struct tee_fs_fd {
+#ifndef CFG_RPMB_FS
 	struct tee_fs_file_meta *meta;
+#endif
 	int pos;
 	uint32_t flags;
 	int fd;
+#ifdef CFG_RPMB_FS
+	int nw_fd; /* Normal world */
+#endif
 	bool is_new_file;
 	char *filename;
 	struct block_cache block_cache;

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -26,21 +26,27 @@
  */
 
 #include <kernel/tee_common.h>
+#include <kernel/handle.h>
 #include <tee/tee_rpmb_fs.h>
 #include <tee/tee_rpmb.h>
+#include <tee/tee_fs_defs.h>
+#include <tee/tee_fs.h>
 #include <mm/tee_mm.h>
+#include <trace.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string_ext.h>
+#include <util.h>
+#include <sys/queue.h>
 
 #define RPMB_STORAGE_START_ADDRESS      0
 #define RPMB_FS_FAT_START_ADDRESS       512
-#define RPMB_STORAGE_END_ADDRESS        ((1024 * 128) - 1)
 #define RPMB_BLOCK_SIZE_SHIFT           8
 
 #define DEV_ID                          0
 #define RPMB_FS_MAGIC                   0x52504D42
-#define FS_VERSION                      1
-#define N_ENTRIES                       16
+#define FS_VERSION                      2
+#define N_ENTRIES                       8
 
 #define FILE_IS_ACTIVE                  (1u << 0)
 #define FILE_IS_LAST_ENTRY              (1u << 1)
@@ -52,6 +58,7 @@
  */
 struct rpmb_fs_parameters {
 	uint32_t fat_start_address;
+	uint32_t max_rpmb_address;
 };
 
 /**
@@ -62,20 +69,22 @@ struct rpmb_fat_entry {
 	uint32_t data_size;
 	uint32_t flags;
 	uint32_t write_counter;
-	char filename[FILENAME_LENGTH];
+	char filename[TEE_RPMB_FS_FILENAME_LENGTH];
 };
 
 /**
  * FAT entry context with reference to a FAT entry and its
  * location in RPMB.
  */
-struct file_handle {
+struct rpmb_file_handle {
 	/* Pointer to a fat_entry */
 	struct rpmb_fat_entry fat_entry;
 	/* Pointer to a filename */
-	const char *filename;
+	char filename[TEE_RPMB_FS_FILENAME_LENGTH];
 	/* Adress for current entry in RPMB */
 	uint32_t rpmb_fat_address;
+	/* Current position */
+	uint32_t pos;
 };
 
 /**
@@ -90,18 +99,106 @@ struct rpmb_fs_partition {
 	uint8_t reserved[112];
 };
 
+/**
+ * A node in a list of directory entries. entry->name is a
+ * pointer to name here.
+ */
+struct tee_rpmb_fs_dirent {
+	struct tee_fs_dirent entry;
+	char name[TEE_RPMB_FS_FILENAME_LENGTH];
+	SIMPLEQ_ENTRY(tee_rpmb_fs_dirent) link;
+};
+
+/**
+ * The RPMB directory representation. It contains a queue of
+ * RPMB directory entries: 'next'.
+ * The current pointer points to the last directory entry
+ * returned by readdir().
+ */
+struct tee_fs_dir {
+	struct tee_rpmb_fs_dirent *current;
+	SIMPLEQ_HEAD(next_head, tee_rpmb_fs_dirent) next;
+};
+
+static TEE_Result get_fat_start_address(uint32_t *addr);
+
 static struct rpmb_fs_parameters *fs_par;
 
-static struct file_handle *alloc_file_handle(const char *filename)
-{
-	struct file_handle *fh = NULL;
+static struct handle_db fs_handle_db = HANDLE_DB_INITIALIZER;
 
-	fh = calloc(1, sizeof(struct file_handle));
-	if (fh == NULL)
+static void dump_fat(void)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct rpmb_fat_entry *fat_entries = NULL;
+	uint32_t fat_address;
+	size_t size;
+	int i;
+	bool last_entry_found = false;
+
+	res = get_fat_start_address(&fat_address);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
+	fat_entries = malloc(size);
+	if (!fat_entries) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	while (!last_entry_found) {
+		res = tee_rpmb_read(DEV_ID, fat_address,
+				    (uint8_t *)fat_entries, size);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+		for (i = 0; i < N_ENTRIES; i++) {
+
+			FMSG("flags 0x%x, size %d, address 0x%x, filename '%s'",
+				fat_entries[i].flags,
+				fat_entries[i].data_size,
+				fat_entries[i].start_address,
+				fat_entries[i].filename);
+
+			if ((fat_entries[i].flags & FILE_IS_LAST_ENTRY) != 0) {
+				last_entry_found = true;
+				break;
+			}
+
+			/* Move to next fat_entry. */
+			fat_address += sizeof(struct rpmb_fat_entry);
+		}
+	}
+
+out:
+	free(fat_entries);
+}
+
+#if (TRACE_LEVEL >= TRACE_DEBUG)
+static void dump_fh(struct rpmb_file_handle *fh)
+{
+	DMSG("fh->filename=%s", fh->filename);
+	DMSG("fh->pos=%u", fh->pos);
+	DMSG("fh->rpmb_fat_address=%u", fh->rpmb_fat_address);
+	DMSG("fh->fat_entry.start_address=%u", fh->fat_entry.start_address);
+	DMSG("fh->fat_entry.data_size=%u", fh->fat_entry.data_size);
+}
+#else
+static void dump_fh(struct rpmb_file_handle *fh __unused)
+{
+}
+#endif
+
+static struct rpmb_file_handle *alloc_file_handle(const char *filename)
+{
+	struct rpmb_file_handle *fh = NULL;
+
+	fh = calloc(1, sizeof(struct rpmb_file_handle));
+	if (!fh)
 		return NULL;
 
-	if (filename != NULL)
-		fh->filename = filename;
+	if (filename)
+		strlcpy(fh->filename, filename, sizeof(fh->filename));
 
 	return fh;
 }
@@ -109,7 +206,7 @@ static struct file_handle *alloc_file_handle(const char *filename)
 /**
  * write_fat_entry: Store info in a fat_entry to RPMB.
  */
-static TEE_Result write_fat_entry(struct file_handle *fh,
+static TEE_Result write_fat_entry(struct rpmb_file_handle *fh,
 				  bool update_write_counter)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
@@ -136,6 +233,8 @@ static TEE_Result write_fat_entry(struct file_handle *fh,
 			     (uint8_t *)&fh->fat_entry,
 			     sizeof(struct rpmb_fat_entry));
 
+	dump_fat();
+
 out:
 	return res;
 }
@@ -149,10 +248,20 @@ static TEE_Result rpmb_fs_setup(void)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct rpmb_fs_partition *partition_data = NULL;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh = NULL;
+	uint32_t max_rpmb_block = 0;
+
+	if (fs_par) {
+		res = TEE_SUCCESS;
+		goto out;
+	}
+
+	res = tee_rpmb_get_max_block(DEV_ID, &max_rpmb_block);
+	if (res != TEE_SUCCESS)
+		goto out;
 
 	partition_data = calloc(1, sizeof(struct rpmb_fs_partition));
-	if (partition_data == NULL) {
+	if (!partition_data) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
@@ -163,6 +272,7 @@ static TEE_Result rpmb_fs_setup(void)
 	if (res != TEE_SUCCESS)
 		goto out;
 
+#ifndef CFG_RPMB_RESET_FAT
 	if (partition_data->rpmb_fs_magic == RPMB_FS_MAGIC) {
 		if (partition_data->fs_version == FS_VERSION) {
 			res = TEE_SUCCESS;
@@ -173,6 +283,9 @@ static TEE_Result rpmb_fs_setup(void)
 			goto out;
 		}
 	}
+#else
+	EMSG("**** Clearing Storage ****");
+#endif
 
 	/* Setup new partition data. */
 	partition_data->rpmb_fs_magic = RPMB_FS_MAGIC;
@@ -181,7 +294,7 @@ static TEE_Result rpmb_fs_setup(void)
 
 	/* Initial FAT entry with FILE_IS_LAST_ENTRY flag set. */
 	fh = alloc_file_handle(NULL);
-	if (fh == NULL) {
+	if (!fh) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
@@ -201,22 +314,25 @@ static TEE_Result rpmb_fs_setup(void)
 			     (uint8_t *)partition_data,
 			     sizeof(struct rpmb_fs_partition));
 
+#ifndef CFG_RPMB_RESET_FAT
 store_fs_par:
+#endif
+
 	/* Store FAT start address. */
-	if (fs_par == NULL) {
-		fs_par = calloc(1, sizeof(struct rpmb_fs_parameters));
-		if (fs_par == NULL) {
-			res = TEE_ERROR_OUT_OF_MEMORY;
-			goto out;
-		}
+	fs_par = calloc(1, sizeof(struct rpmb_fs_parameters));
+	if (!fs_par) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
 	}
 
 	fs_par->fat_start_address = partition_data->fat_start_address;
+	fs_par->max_rpmb_address = max_rpmb_block << RPMB_BLOCK_SIZE_SHIFT;
+
+	dump_fat();
 
 out:
 	free(fh);
 	free(partition_data);
-
 	return res;
 }
 
@@ -226,19 +342,12 @@ out:
  */
 static TEE_Result get_fat_start_address(uint32_t *addr)
 {
-	TEE_Result res = TEE_ERROR_GENERIC;
-
-	if (fs_par == NULL) {
-		res = rpmb_fs_setup();
-		if (res != TEE_SUCCESS)
-			goto out;
-	}
+	if (!fs_par)
+		return TEE_ERROR_NO_DATA;
 
 	*addr = fs_par->fat_start_address;
-	res = TEE_SUCCESS;
 
-out:
-	return res;
+	return TEE_SUCCESS;
 }
 
 /**
@@ -247,7 +356,7 @@ out:
  * Build up memory pool and return matching entry for write operation.
  * "Last FAT entry" can be returned during write.
  */
-static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
+static TEE_Result read_fat(struct rpmb_file_handle *fh, tee_mm_pool_t *p)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	tee_mm_entry_t *mm = NULL;
@@ -257,6 +366,10 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 	int i;
 	bool entry_found = false;
 	bool last_entry_found = false;
+	bool expand_fat = false;
+	struct rpmb_file_handle last_fh;
+
+	DMSG("fat_address %d", fh->rpmb_fat_address);
 
 	res = rpmb_fs_setup();
 	if (res != TEE_SUCCESS)
@@ -268,12 +381,18 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 
 	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
 	fat_entries = malloc(size);
-	if (fat_entries == NULL) {
+	if (!fat_entries) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
 
-	while (!last_entry_found && !entry_found) {
+	/*
+	 * The pool is used to represent the current RPMB layout. To find
+	 * a slot for the file tee_mm_alloc is called on the pool. Thus
+	 * if it is not NULL the entire FAT must be traversed to fill in
+	 * the pool.
+	 */
+	while (!last_entry_found && (!entry_found || p)) {
 		res = tee_rpmb_read(DEV_ID, fat_address,
 				    (uint8_t *)fat_entries, size);
 		if (res != TEE_SUCCESS)
@@ -284,7 +403,7 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 			 * Look for an entry, matching filenames. (read, rm,
 			 * rename and stat.). Only store first filename match.
 			 */
-			if ((fh->filename != NULL) &&
+			if (fh->filename &&
 			    (strcmp(fh->filename,
 				    fat_entries[i].filename) == 0) &&
 			    (fat_entries[i].flags & FILE_IS_ACTIVE) &&
@@ -293,19 +412,20 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 				fh->rpmb_fat_address = fat_address;
 				memcpy(&fh->fat_entry, &fat_entries[i],
 				       sizeof(struct rpmb_fat_entry));
-				if (p == NULL)
+				if (!p)
 					break;
 			}
 
 			/* Add existing files to memory pool. (write) */
-			if (p != NULL) {
-				if ((fat_entries[i].flags & FILE_IS_ACTIVE) !=
-				    0) {
+			if (p) {
+				if ((fat_entries[i].flags & FILE_IS_ACTIVE) &&
+				    (fat_entries[i].data_size > 0)) {
+
 					mm = tee_mm_alloc2
 						(p,
 						 fat_entries[i].start_address,
 						 fat_entries[i].data_size);
-					if (mm == NULL) {
+					if (!mm) {
 						res = TEE_ERROR_OUT_OF_MEMORY;
 						goto out;
 					}
@@ -322,11 +442,18 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 
 			if ((fat_entries[i].flags & FILE_IS_LAST_ENTRY) != 0) {
 				last_entry_found = true;
-				if (p != NULL && fh->rpmb_fat_address == 0) {
-					fh->rpmb_fat_address = fat_address;
-					fh->fat_entry.flags =
-					    FILE_IS_LAST_ENTRY;
-				}
+
+				/*
+				 * If the last entry was reached and was chosen
+				 * by the previous check, then the FAT needs to
+				 * be expanded.
+				 * fh->rpmb_fat_address is the address chosen
+				 * to store the files FAT entry and fat_address
+				 * is the current FAT entry address being
+				 * compared.
+				 */
+				if (p && fh->rpmb_fat_address == fat_address)
+					expand_fat = true;
 				break;
 			}
 
@@ -335,17 +462,42 @@ static TEE_Result read_fat(struct file_handle *fh, tee_mm_pool_t *p)
 		}
 	}
 
-	if ((p != NULL) && last_entry_found) {
+	/*
+	 * Represent the FAT table in the pool.
+	 */
+	if (p) {
+		/*
+		 * Since fat_address is the start of the last entry it needs to
+		 * be moved up by an entry.
+		 */
+		fat_address += sizeof(struct rpmb_fat_entry);
+
 		/* Make room for yet a FAT entry and add to memory pool. */
-		fat_address += 2 * sizeof(struct rpmb_fat_entry);
+		if (expand_fat)
+			fat_address += sizeof(struct rpmb_fat_entry);
+
 		mm = tee_mm_alloc2(p, RPMB_STORAGE_START_ADDRESS, fat_address);
-		if (mm == NULL) {
+		if (!mm) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;
 		}
+
+		if (expand_fat) {
+			/*
+			 * Point fat_address to the beginning of the new
+			 * entry.
+			 */
+			fat_address -= sizeof(struct rpmb_fat_entry);
+			memset(&last_fh, 0, sizeof(last_fh));
+			last_fh.fat_entry.flags = FILE_IS_LAST_ENTRY;
+			last_fh.rpmb_fat_address = fat_address;
+			res = write_fat_entry(&last_fh, true);
+			if (res != TEE_SUCCESS)
+				goto out;
+		}
 	}
 
-	if (fh->filename != NULL && fh->rpmb_fat_address == 0)
+	if (fh->filename && !fh->rpmb_fat_address)
 		res = TEE_ERROR_FILE_NOT_FOUND;
 
 out:
@@ -353,92 +505,202 @@ out:
 	return res;
 }
 
-/**
- * add_fat_entry:
- * Populate last FAT entry.
- */
-static TEE_Result add_fat_entry(struct file_handle *fh)
+int tee_rpmb_fs_open(const char *file, int flags, ...)
 {
+	int fd = -1;
+	struct rpmb_file_handle *fh = NULL;
+	size_t filelen;
+	tee_mm_pool_t p;
+	bool pool_result;
 	TEE_Result res = TEE_ERROR_GENERIC;
 
-	fh->rpmb_fat_address += sizeof(struct rpmb_fat_entry);
-	res = write_fat_entry(fh, true);
-	fh->rpmb_fat_address -= sizeof(struct rpmb_fat_entry);
-
-	return res;
-}
-
-int tee_rpmb_fs_read(const char *filename, uint8_t *buf, size_t size)
-{
-	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
-	int read_size = -1;
-
-	if (filename == NULL || buf == NULL ||
-	    strlen(filename) >= FILENAME_LENGTH - 1) {
+	if (!file) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
-	fh = alloc_file_handle(filename);
-	if (fh == NULL) {
+	filelen = strlen(file);
+	if (filelen >= TEE_RPMB_FS_FILENAME_LENGTH - 1 || filelen == 0) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	if (file[filelen - 1] == '/') {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	fh = alloc_file_handle(file);
+	if (!fh) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
+
+	/* We need to do setup in order to make sure fs_par is filled in */
+	res = rpmb_fs_setup();
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	if (flags & TEE_FS_O_CREATE) {
+		/* Upper memory allocation must be used for RPMB_FS. */
+		pool_result = tee_mm_init(&p,
+					  RPMB_STORAGE_START_ADDRESS,
+					  fs_par->max_rpmb_address,
+					  RPMB_BLOCK_SIZE_SHIFT,
+					  TEE_MM_POOL_HI_ALLOC);
+
+		if (!pool_result) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto out;
+		}
+
+		res = read_fat(fh, &p);
+		tee_mm_final(&p);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+	} else {
+		res = read_fat(fh, NULL);
+		if (res != TEE_SUCCESS)
+			goto out;
+	}
+
+	/* Add the handle to the db */
+	fd = handle_get(&fs_handle_db, fh);
+	if (fd == -1) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	/*
+	 * If this is opened with create and the entry found was not active
+	 * then this is a new file and the FAT entry must be written
+	 */
+	if (flags & TEE_FS_O_CREATE) {
+		if ((fh->fat_entry.flags & FILE_IS_ACTIVE) == 0) {
+			memset(&fh->fat_entry, 0,
+				sizeof(struct rpmb_fat_entry));
+			memcpy(fh->fat_entry.filename, file, strlen(file));
+			/* Start address and size are 0 */
+			fh->fat_entry.flags = FILE_IS_ACTIVE;
+
+			res = write_fat_entry(fh, true);
+			if (res != TEE_SUCCESS) {
+				handle_put(&fs_handle_db, fd);
+				fd = -1;
+				goto out;
+			}
+		}
+	}
+
+	res = TEE_SUCCESS;
+
+out:
+	if (res != TEE_SUCCESS) {
+		if (fh)
+			free(fh);
+
+		fd = -1;
+	}
+
+	return fd;
+}
+
+int tee_rpmb_fs_close(int fd)
+{
+	struct rpmb_file_handle *fh;
+
+	fh = handle_put(&fs_handle_db, fd);
+	if (fh) {
+		free(fh);
+		return 0;
+	}
+
+	return -1;
+}
+
+int tee_rpmb_fs_read(int fd, uint8_t *buf, size_t size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct rpmb_file_handle *fh;
+	int read_size = -1;
+
+	if (!size)
+		return 0;
+
+	if (!buf) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	fh = handle_lookup(&fs_handle_db, fd);
+	if (!fh) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+	dump_fh(fh);
 
 	res = read_fat(fh, NULL);
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	if (size < fh->fat_entry.data_size) {
-		res = TEE_ERROR_SHORT_BUFFER;
-		goto out;
+	size = MIN(size, fh->fat_entry.data_size - fh->pos);
+	if (size > 0) {
+		res = tee_rpmb_read(DEV_ID,
+				    fh->fat_entry.start_address + fh->pos, buf,
+				    size);
+		if (res != TEE_SUCCESS)
+			goto out;
 	}
 
-	res = tee_rpmb_read(DEV_ID, fh->fat_entry.start_address, buf,
-			    fh->fat_entry.data_size);
+	read_size = size;
+	res = TEE_SUCCESS;
 
 out:
-	if (res == TEE_SUCCESS)
-		read_size = fh->fat_entry.data_size;
-
-	free(fh);
+	if (res != TEE_SUCCESS)
+		read_size = -1;
 
 	return read_size;
 }
 
-int tee_rpmb_fs_write(const char *filename, uint8_t *buf, size_t size)
+int tee_rpmb_fs_write(int fd, uint8_t *buf, size_t size)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh;
 	tee_mm_pool_t p;
-	tee_mm_entry_t *mm = NULL;
-	size_t length;
-	uint32_t mm_flags;
+	bool pool_result = false;
+	tee_mm_entry_t *mm;
+	size_t newsize;
+	uint8_t *newbuf = NULL;
+	uintptr_t newaddr;
 
-	if (filename == NULL || buf == NULL) {
+	if (!size)
+		return 0;
+
+	if (!buf) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
-	length = strlen(filename);
-	if ((length >= FILENAME_LENGTH - 1) || (length == 0)) {
-		res = TEE_ERROR_BAD_PARAMETERS;
+	if (!fs_par) {
+		res = TEE_ERROR_GENERIC;
 		goto out;
 	}
 
-	/* Create a FAT entry for the file to write. */
-	fh = alloc_file_handle(filename);
-	if (fh == NULL) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
+	fh = handle_lookup(&fs_handle_db, fd);
+	if (!fh) {
+		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
+	dump_fh(fh);
 
 	/* Upper memory allocation must be used for RPMB_FS. */
-	mm_flags = TEE_MM_POOL_HI_ALLOC;
-	if (!tee_mm_init
-	    (&p, RPMB_STORAGE_START_ADDRESS, RPMB_STORAGE_END_ADDRESS,
-	     RPMB_BLOCK_SIZE_SHIFT, mm_flags)) {
+	pool_result = tee_mm_init(&p,
+				  RPMB_STORAGE_START_ADDRESS,
+				  fs_par->max_rpmb_address,
+				  RPMB_BLOCK_SIZE_SHIFT,
+				  TEE_MM_POOL_HI_ALLOC);
+	if (!pool_result) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
@@ -447,34 +709,55 @@ int tee_rpmb_fs_write(const char *filename, uint8_t *buf, size_t size)
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	mm = tee_mm_alloc(&p, size);
-	if (mm == NULL) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
-		goto out;
-	}
+	TEE_ASSERT(!(fh->fat_entry.flags & FILE_IS_LAST_ENTRY));
 
-	if ((fh->fat_entry.flags & FILE_IS_LAST_ENTRY) != 0) {
-		res = add_fat_entry(fh);
+	newsize = fh->pos + size;
+	if (newsize <= fh->fat_entry.data_size) {
+		/* Modifying file content */
+
+		res = tee_rpmb_write(DEV_ID,
+				     fh->fat_entry.start_address + fh->pos,
+				     buf, size);
+		if (res != TEE_SUCCESS)
+			goto out;
+	} else {
+		/* Extend file: allocate, read, update, write */
+
+		mm = tee_mm_alloc(&p, newsize);
+		newbuf = calloc(newsize, 1);
+		if (!mm || !newbuf) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto out;
+		}
+
+		if (fh->fat_entry.data_size) {
+			res = tee_rpmb_read(DEV_ID,
+					    fh->fat_entry.start_address,
+					    newbuf, fh->fat_entry.data_size);
+			if (res != TEE_SUCCESS)
+				goto out;
+		}
+
+		memcpy(newbuf + fh->pos, buf, size);
+
+		newaddr = tee_mm_get_smem(mm);
+		res = tee_rpmb_write(DEV_ID, newaddr, newbuf, newsize);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+		fh->fat_entry.data_size = newsize;
+		fh->fat_entry.start_address = newaddr;
+		res = write_fat_entry(fh, true);
 		if (res != TEE_SUCCESS)
 			goto out;
 	}
 
-	memset(&fh->fat_entry, 0, sizeof(struct rpmb_fat_entry));
-	memcpy(fh->fat_entry.filename, filename, length);
-	fh->fat_entry.data_size = size;
-	fh->fat_entry.flags = FILE_IS_ACTIVE;
-	fh->fat_entry.start_address = tee_mm_get_smem(mm);
-
-	res = tee_rpmb_write(DEV_ID, fh->fat_entry.start_address, buf, size);
-	if (res != TEE_SUCCESS)
-		goto out;
-
-	res = write_fat_entry(fh, true);
-
+	fh->pos = newsize;
 out:
-	free(fh);
-	if (mm != NULL)
+	if (pool_result)
 		tee_mm_final(&p);
+	if (newbuf)
+		free(newbuf);
 
 	if (res == TEE_SUCCESS)
 		return size;
@@ -482,18 +765,63 @@ out:
 	return -1;
 }
 
+tee_fs_off_t tee_rpmb_fs_lseek(int fd, tee_fs_off_t offset, int whence)
+{
+	struct rpmb_file_handle *fh;
+	TEE_Result res;
+	tee_fs_off_t ret = -1;
+	tee_fs_off_t new_pos;
+
+	fh = handle_lookup(&fs_handle_db, fd);
+	if (!fh)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = read_fat(fh, NULL);
+	if (res != TEE_SUCCESS)
+		return -1;
+
+	switch (whence) {
+	case TEE_FS_SEEK_SET:
+		new_pos = offset;
+		break;
+
+	case TEE_FS_SEEK_CUR:
+		new_pos = fh->pos + offset;
+		break;
+
+	case TEE_FS_SEEK_END:
+		new_pos = fh->fat_entry.data_size + offset;
+		break;
+
+	default:
+		goto exit;
+	}
+
+	if (new_pos < 0)
+		new_pos = 0;
+
+	if (new_pos > TEE_DATA_MAX_POSITION) {
+		EMSG("Position is beyond TEE_DATA_MAX_POSITION");
+		goto exit;
+	}
+
+	ret = fh->pos = new_pos;
+exit:
+	return ret;
+}
+
 TEE_Result tee_rpmb_fs_rm(const char *filename)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh = NULL;
 
-	if (filename == NULL || strlen(filename) >= FILENAME_LENGTH - 1) {
+	if (!filename || strlen(filename) >= TEE_RPMB_FS_FILENAME_LENGTH - 1) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
 	fh = alloc_file_handle(filename);
-	if (fh == NULL) {
+	if (!fh) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
@@ -508,19 +836,19 @@ TEE_Result tee_rpmb_fs_rm(const char *filename)
 
 out:
 	free(fh);
-
+	IMSG("Deleting file %s returned 0x%x\n", filename, res);
 	return res;
 }
 
 TEE_Result tee_rpmb_fs_rename(const char *old_name, const char *new_name)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh_old = NULL;
-	struct file_handle *fh_new = NULL;
+	struct rpmb_file_handle *fh_old = NULL;
+	struct rpmb_file_handle *fh_new = NULL;
 	uint32_t old_len;
 	uint32_t new_len;
 
-	if (old_name == NULL || new_name == NULL) {
+	if (!old_name || !new_name) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
@@ -528,20 +856,21 @@ TEE_Result tee_rpmb_fs_rename(const char *old_name, const char *new_name)
 	old_len = strlen(old_name);
 	new_len = strlen(new_name);
 
-	if ((old_len >= FILENAME_LENGTH - 1) ||
-	    (new_len >= FILENAME_LENGTH - 1) || (new_len == 0)) {
+	if ((old_len >= TEE_RPMB_FS_FILENAME_LENGTH - 1) ||
+	    (new_len >= TEE_RPMB_FS_FILENAME_LENGTH - 1) || (new_len == 0)) {
+
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
 	fh_old = alloc_file_handle(old_name);
-	if (fh_old == NULL) {
+	if (!fh_old) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
 
 	fh_new = alloc_file_handle(new_name);
-	if (fh_new == NULL) {
+	if (!fh_new) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
@@ -556,7 +885,7 @@ TEE_Result tee_rpmb_fs_rename(const char *old_name, const char *new_name)
 		goto out;
 	}
 
-	memset(fh_old->fat_entry.filename, 0, FILENAME_LENGTH);
+	memset(fh_old->fat_entry.filename, 0, TEE_RPMB_FS_FILENAME_LENGTH);
 	memcpy(fh_old->fat_entry.filename, new_name, new_len);
 
 	res = write_fat_entry(fh_old, false);
@@ -568,19 +897,351 @@ out:
 	return res;
 }
 
+int tee_rpmb_fs_mkdir(const char *path __unused, tee_fs_mode_t mode __unused)
+{
+	/*
+	 * FIXME: mkdir() should really create some entry in the FAT so that
+	 * access() would return success when the directory exists but is
+	 * empty. This does not matter for the current use cases.
+	 */
+	return 0;
+}
+
+int tee_rpmb_fs_ftruncate(int fd, tee_fs_off_t length)
+{
+	struct rpmb_file_handle *fh;
+	tee_mm_pool_t p;
+	bool pool_result = false;
+	tee_mm_entry_t *mm;
+	uint32_t newsize;
+	uint8_t *newbuf = NULL;
+	uintptr_t newaddr;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (length < 0 || length > INT32_MAX) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+	newsize = length;
+
+	fh = handle_lookup(&fs_handle_db, fd);
+	if (!fh) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	res = read_fat(fh, NULL);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	if (newsize > fh->fat_entry.data_size) {
+		/* Extend file */
+
+		pool_result = tee_mm_init(&p,
+					  RPMB_STORAGE_START_ADDRESS,
+					  fs_par->max_rpmb_address,
+					  RPMB_BLOCK_SIZE_SHIFT,
+					  TEE_MM_POOL_HI_ALLOC);
+		if (!pool_result) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto out;
+		}
+		res = read_fat(fh, &p);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+		mm = tee_mm_alloc(&p, newsize);
+		newbuf = calloc(newsize, 1);
+		if (!mm || !newbuf) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto out;
+		}
+
+		if (fh->fat_entry.data_size) {
+			res = tee_rpmb_read(DEV_ID,
+					    fh->fat_entry.start_address,
+					    newbuf, fh->fat_entry.data_size);
+			if (res != TEE_SUCCESS)
+				goto out;
+		}
+
+		newaddr = tee_mm_get_smem(mm);
+		res = tee_rpmb_write(DEV_ID, newaddr, newbuf, newsize);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+	} else {
+		/* Don't change file location */
+		newaddr = fh->fat_entry.start_address;
+	}
+
+	/* fh->pos is unchanged */
+	fh->fat_entry.data_size = newsize;
+	fh->fat_entry.start_address = newaddr;
+	res = write_fat_entry(fh, true);
+
+out:
+	if (pool_result)
+		tee_mm_final(&p);
+	if (newbuf)
+		free(newbuf);
+
+	if (res == TEE_SUCCESS)
+		return 0;
+
+	return -1;
+}
+
+static void tee_rpmb_fs_dir_free(tee_fs_dir *dir)
+{
+	struct tee_rpmb_fs_dirent *e;
+
+	if (!dir)
+		return;
+
+	free(dir->current);
+
+	while ((e = SIMPLEQ_FIRST(&dir->next))) {
+		SIMPLEQ_REMOVE_HEAD(&dir->next, link);
+		free(e);
+	}
+}
+
+static TEE_Result tee_rpmb_fs_dir_populate(const char *path, tee_fs_dir *dir)
+{
+	struct tee_rpmb_fs_dirent *current = NULL;
+	struct rpmb_fat_entry *fat_entries = NULL;
+	uint32_t fat_address;
+	uint32_t filelen;
+	char *filename;
+	int i;
+	bool last_entry_found = false;
+	bool matched;
+	struct tee_rpmb_fs_dirent *next = NULL;
+	uint32_t pathlen;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t size;
+	char temp;
+
+	res = rpmb_fs_setup();
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = get_fat_start_address(&fat_address);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
+	fat_entries = malloc(size);
+	if (!fat_entries) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	pathlen = strlen(path);
+	while (!last_entry_found) {
+		res = tee_rpmb_read(DEV_ID, fat_address,
+				    (uint8_t *)fat_entries, size);
+		if (res != TEE_SUCCESS)
+			goto out;
+
+		for (i = 0; i < N_ENTRIES; i++) {
+			filename = fat_entries[i].filename;
+			if (fat_entries[i].flags & FILE_IS_ACTIVE) {
+				matched = false;
+				filelen = strlen(filename);
+				if (filelen > pathlen) {
+					temp = filename[pathlen];
+					filename[pathlen] = '\0';
+					if (strcmp(filename, path) == 0)
+						matched = true;
+
+					filename[pathlen] = temp;
+				}
+
+				if (matched) {
+					next = malloc(sizeof(*next));
+					if (!next) {
+						res = TEE_ERROR_OUT_OF_MEMORY;
+						goto out;
+					}
+
+					memset(next, 0, sizeof(*next));
+					next->entry.d_name = next->name;
+					memcpy(next->name,
+						&filename[pathlen],
+						filelen - pathlen);
+
+					SIMPLEQ_INSERT_TAIL(&dir->next, next,
+							    link);
+					current = next;
+				}
+			}
+
+			if (fat_entries[i].flags & FILE_IS_LAST_ENTRY) {
+				last_entry_found = true;
+				break;
+			}
+
+			/* Move to next fat_entry. */
+			fat_address += sizeof(struct rpmb_fat_entry);
+		}
+	}
+
+	/* No directories were found. */
+	if (!current) {
+		res = TEE_ERROR_NO_DATA;
+		goto out;
+	}
+
+	res = TEE_SUCCESS;
+
+out:
+	if (res != TEE_SUCCESS)
+		tee_rpmb_fs_dir_free(dir);
+	if (fat_entries)
+		free(fat_entries);
+
+	return res;
+}
+
+static TEE_Result tee_rpmb_fs_opendir_internal(const char *path,
+						tee_fs_dir **dir)
+{
+	uint32_t len;
+	uint32_t max_size;
+	char path_local[TEE_RPMB_FS_FILENAME_LENGTH];
+	TEE_Result res = TEE_ERROR_GENERIC;
+	tee_fs_dir *rpmb_dir = NULL;
+
+	if (!path || !dir) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	/*
+	 * There must be room for at least the NULL char and a char for the
+	 * filename after the path.
+	 */
+	max_size = TEE_RPMB_FS_FILENAME_LENGTH - 2;
+	len = strlen(path);
+	if (len > max_size || len == 0) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	memset(path_local, 0, sizeof(path_local));
+	memcpy(path_local, path, len);
+
+	/* Add a slash to correctly match the full directory name. */
+	if (path_local[len - 1] != '/')
+		path_local[len] = '/';
+
+	rpmb_dir = calloc(1, sizeof(tee_fs_dir));
+	if (!rpmb_dir) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+	SIMPLEQ_INIT(&rpmb_dir->next);
+
+	res = tee_rpmb_fs_dir_populate(path_local, rpmb_dir);
+	if (res != TEE_SUCCESS) {
+		free(rpmb_dir);
+		rpmb_dir = NULL;
+		goto out;
+	}
+
+	*dir = rpmb_dir;
+
+out:
+	return res;
+}
+
+tee_fs_dir *tee_rpmb_fs_opendir(const char *path)
+{
+	tee_fs_dir *dir = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = tee_rpmb_fs_opendir_internal(path, &dir);
+	if (res != TEE_SUCCESS)
+		dir = NULL;
+
+	return dir;
+}
+
+
+struct tee_fs_dirent *tee_rpmb_fs_readdir(tee_fs_dir *dir)
+{
+	if (!dir)
+		return NULL;
+
+	free(dir->current);
+
+	dir->current = SIMPLEQ_FIRST(&dir->next);
+	if (!dir->current)
+		return NULL;
+
+	SIMPLEQ_REMOVE_HEAD(&dir->next, link);
+
+	return &dir->current->entry;
+}
+
+int tee_rpmb_fs_closedir(tee_fs_dir *dir)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (!dir) {
+		res = TEE_SUCCESS;
+		goto out;
+	}
+
+	tee_rpmb_fs_dir_free(dir);
+	free(dir);
+	res = TEE_SUCCESS;
+out:
+	if (res == TEE_SUCCESS)
+		return 0;
+
+	return -1;
+}
+
+int tee_rpmb_fs_rmdir(const char *path)
+{
+	tee_fs_dir *dir = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int ret = -1;
+
+	/* Open the directory anyting other than NO_DATA is a failure */
+	res = tee_rpmb_fs_opendir_internal(path, &dir);
+	if (res == TEE_SUCCESS) {
+		tee_rpmb_fs_closedir(dir);
+		ret = -1;
+
+	} else if (res == TEE_ERROR_NO_DATA) {
+		ret = 0;
+
+	} else {
+		/* The case any other failure is returned */
+		ret = -1;
+	}
+
+
+	return ret;
+}
+
 TEE_Result tee_rpmb_fs_stat(const char *filename,
 			    struct tee_rpmb_fs_stat *stat)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct file_handle *fh = NULL;
+	struct rpmb_file_handle *fh = NULL;
 
-	if (stat == NULL || filename == NULL) {
+	if (!stat || !filename) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
 	fh = alloc_file_handle(filename);
-	if (fh == NULL) {
+	if (!fh) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
@@ -589,10 +1250,27 @@ TEE_Result tee_rpmb_fs_stat(const char *filename,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	stat->size = fh->fat_entry.data_size;
+	stat->size = (size_t)fh->fat_entry.data_size;
 	stat->reserved = 0;
 
 out:
 	free(fh);
 	return res;
 }
+
+int tee_rpmb_fs_access(const char *filename, int mode)
+{
+	struct tee_rpmb_fs_stat stat;
+	TEE_Result res;
+
+	/* Mode is currently ignored, this only checks for existence */
+	(void)mode;
+
+	res = tee_rpmb_fs_stat(filename, &stat);
+
+	if (res == TEE_SUCCESS)
+		return 0;
+
+	return -1;
+}
+

--- a/core/tee/tee_rpmb_fs_common.c
+++ b/core/tee/tee_rpmb_fs_common.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <tee/tee_fs.h>
+#include <tee/tee_fs_defs.h>
+#include <tee/tee_rpmb_fs.h>
+#include <kernel/handle.h>
+#include <kernel/tee_common_unpg.h>
+#include <trace.h>
+#include <assert.h>
+
+#include "tee_fs_private.h"
+
+static struct handle_db fs_handle_db = HANDLE_DB_INITIALIZER;
+
+static void do_fail_recovery(struct tee_fs_fd *fdp)
+{
+	/* Try to delete the file for new created file */
+	if (fdp->is_new_file) {
+		tee_fs_common_unlink(fdp->filename);
+		EMSG("New created file was deleted, file=%s",
+				fdp->filename);
+		return;
+	}
+
+	/* Note: Roll back is automatic for RPMB */
+}
+
+struct tee_fs_fd *tee_fs_fd_lookup(int fd)
+{
+	return handle_lookup(&fs_handle_db, fd);
+}
+
+int tee_fs_common_open(TEE_Result *errno, const char *file, int flags, ...)
+{
+	int res = -1;
+	size_t len;
+	bool is_new_file = false;
+	int fd = -1;
+	struct tee_fs_fd *fdp = NULL;
+
+	assert(errno);
+	*errno = TEE_SUCCESS;
+
+	len = strlen(file) + 1;
+	if (len > TEE_FS_NAME_MAX) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		goto exit;
+	}
+
+	/*
+	 * try to open file without O_CREATE flag, if failed try again with
+	 * O_CREATE flag (to distinguish whether it's a new file or not)
+	 */
+	res = tee_rpmb_fs_open(file, flags & (~TEE_FS_O_CREATE));
+	if (res < 0) {
+		if (!(flags & TEE_FS_O_CREATE)) {
+			*errno = TEE_ERROR_ITEM_NOT_FOUND;
+			goto exit;
+		}
+
+		res = tee_rpmb_fs_open(file, flags);
+		if (res < 0)
+			goto exit;
+
+		is_new_file = true;
+	} else {
+		/* File already exists */
+		if ((flags & TEE_FS_O_CREATE) && (flags & TEE_FS_O_EXCL)) {
+			*errno = TEE_ERROR_ACCESS_CONFLICT;
+			goto exit;
+		}
+	}
+
+	fd = res;
+	fdp = malloc(sizeof(struct tee_fs_fd));
+	if (!fdp)
+		goto exit;
+
+	/* init internal status */
+	fdp->nw_fd = fd;
+	fdp->flags = flags;
+	fdp->is_new_file = is_new_file;
+	fdp->filename = strdup(file);
+	if (!fdp->filename) {
+		res = -1;
+		goto exit;
+	}
+
+	/* return fd */
+	res = handle_get(&fs_handle_db, fdp);
+	fdp->fd = res;
+
+exit:
+	if (res == -1) {
+		free(fdp);
+		if (fd != -1)
+			tee_rpmb_fs_close(fd);
+	}
+
+	return res;
+}
+
+int tee_fs_common_close(struct tee_fs_fd *fdp)
+{
+	int res = -1;
+
+	if (!fdp)
+		return -1;
+
+	handle_put(&fs_handle_db, fdp->fd);
+
+	res = tee_rpmb_fs_close(fdp->nw_fd);
+	if (res < 0) {
+		EMSG("Failed to close file, start fail recovery");
+		do_fail_recovery(fdp);
+	}
+
+	free(fdp->filename);
+	free(fdp);
+
+	return res;
+}
+
+
+static TEE_Result to_errno(int rc)
+{
+	if (rc == -1)
+		return TEE_ERROR_GENERIC;
+	else if (rc < 0)
+		return (TEE_Result)rc;
+	else
+		return TEE_SUCCESS;
+}
+
+static int filter_rc(int rc)
+{
+	if (rc < 0)
+		return -1;
+	else
+		return rc;
+}
+
+
+tee_fs_off_t tee_fs_common_lseek(TEE_Result *errno, struct tee_fs_fd *fdp,
+				tee_fs_off_t offset, int whence)
+{
+	int rc;
+	int res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		res = -1;
+		goto exit;
+	}
+
+	rc = tee_rpmb_fs_lseek(fdp->nw_fd, offset, whence);
+	if (rc == -1) {
+		*errno = TEE_ERROR_GENERIC;
+		res = -1;
+	} else if (rc < 0) {
+		*errno = (TEE_Result)rc;
+		res = -1;
+	} else {
+		res = rc;
+	}
+
+exit:
+	return res;
+}
+
+int tee_fs_common_ftruncate(TEE_Result *errno, struct tee_fs_fd *fdp,
+			    tee_fs_off_t length)
+{
+	int rc;
+	int res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		res = -1;
+		goto exit;
+	}
+
+	rc = tee_rpmb_fs_ftruncate(fdp->nw_fd, length);
+	*errno = to_errno(rc);
+	res = filter_rc(rc);
+exit:
+	return res;
+}
+
+int tee_fs_common_read(TEE_Result *errno, struct tee_fs_fd *fdp,
+		       void *buf, size_t len)
+{
+	int rc;
+	int res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		res = -1;
+		goto exit;
+	}
+
+	rc = tee_rpmb_fs_read(fdp->nw_fd, (uint8_t *)buf, len);
+	*errno = to_errno(rc);
+	res = filter_rc(rc);
+
+exit:
+	return res;
+}
+
+int tee_fs_common_write(TEE_Result *errno, struct tee_fs_fd *fdp,
+			const void *buf, size_t len)
+{
+	int rc;
+	int res = -1;
+
+	assert(errno != NULL);
+	*errno = TEE_SUCCESS;
+
+	if (!fdp) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		goto exit;
+	}
+
+	if (!len) {
+		res = 0;
+		goto exit;
+	}
+
+	if (!buf) {
+		*errno = TEE_ERROR_BAD_PARAMETERS;
+		goto exit;
+	}
+
+	rc = tee_rpmb_fs_write(fdp->nw_fd, (uint8_t *)buf, len);
+	*errno = to_errno(rc);
+	res = filter_rc(rc);
+
+exit:
+	return res;
+}
+
+int tee_fs_common_rename(const char *old, const char *new)
+{
+	return tee_rpmb_fs_rename(old, new);
+}
+
+int tee_fs_common_unlink(const char *file)
+{
+	return tee_rpmb_fs_rm(file);
+}
+
+int tee_fs_common_mkdir(const char *path, tee_fs_mode_t mode)
+{
+	return tee_rpmb_fs_mkdir(path, mode);
+}
+
+tee_fs_dir *tee_fs_common_opendir(const char *name)
+{
+	return tee_rpmb_fs_opendir(name);
+}
+
+int tee_fs_common_closedir(tee_fs_dir *d)
+{
+	return tee_rpmb_fs_closedir(d);
+}
+
+struct tee_fs_dirent *tee_fs_common_readdir(tee_fs_dir *d)
+{
+	return tee_rpmb_fs_readdir(d);
+}
+
+int tee_fs_common_rmdir(const char *name)
+{
+	return tee_rpmb_fs_rmdir(name);
+}
+
+int tee_fs_common_access(const char *name, int mode)
+{
+	return tee_rpmb_fs_access(name, mode);
+}
+


### PR DESCRIPTION
This is an update to the RPMB filesystem implementation so that the
persistent object API may use RPMB rather than the REE filesystem.
This feature is enabled with CFG_RPMB_FS=y.
Note that this implementation requires support from the non-secure side
to actually access the RPMB partition, as there is no eMMC driver here.
Also, the code is currently not compatible with CFG_ENC_FS (file
encryption), which must be set to 'n'. Encryption will be added later.

** Note: Initial patches from:
   https://github.com/Microsoft/optee_os/tree/rpmb2
Youssef/Paul, please let me know if you're OK with having your
Signed-off-by: below. Also it would be good if you could provide a
Tested-by: for your platform, or discuss any issue you might have with
the changes I have introduced. I will delete this notice before the
patch is merged. **

Signed-off-by: Youssef Esmat <youssef.esmat@microsoft.com>
Signed-off-by: Paul Swan <Paul.Swan@microsoft.com>
[Rebased onto master, Linux driver/tee-supplicant support]
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>