### PR TITLE
Replace CFG_TEE_IMPL_VERSION with TEE_IMPL_VERSION

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -139,7 +139,7 @@ define gen-version-o
 	$(call update-buildcount,$(link-out-dir)/.buildcount)
 	@$(cmd-echo-silent) '  GEN     $(link-out-dir)/version.o'
 	$(q)echo -e "const char core_v_str[] =" \
-		"\"$(CFG_TEE_IMPL_VERSION) \"" \
+		"\"$(TEE_IMPL_VERSION) \"" \
 		"\"#$(BUILD_COUNT_STR) \"" \
 		"\"$(DATE_STR) \"" \
 		"\"$(CFG_KERN_LINKER_ARCH)\";\n" \

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -18,6 +18,7 @@ CFG_CRYPTO_PBKDF2 ?= y
 endif
 
 srcs-y += tee_svc.c
+cppflags-tee_svc.c-y += -DTEE_IMPL_VERSION=$(TEE_IMPL_VERSION)
 srcs-y += tee_svc_cryp.c
 srcs-y += tee_svc_storage.c
 srcs-y += tee_cryp_utl.c

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -126,7 +126,7 @@ static const bool crypto_ecc_en;
 static const uint32_t ts_antiroll_prot_lvl;
 
 /* Trusted OS implementation version */
-static const char trustedos_impl_version[] = TO_STR(CFG_TEE_IMPL_VERSION);
+static const char trustedos_impl_version[] = TO_STR(TEE_IMPL_VERSION);
 
 /* Trusted OS implementation version (binary value) */
 static const uint32_t trustedos_impl_bin_version; /* 0 by default */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -80,7 +80,7 @@ CFG_TEE_API_VERSION ?= GPD-1.1-dev
 CFG_TEE_IMPL_DESCR ?= OPTEE
 
 # Trusted OS implementation version
-CFG_TEE_IMPL_VERSION ?= $(shell git describe --always --dirty=-dev 2>/dev/null || echo Unknown)
+TEE_IMPL_VERSION ?= $(shell git describe --always --dirty=-dev 2>/dev/null || echo Unknown)
 
 # Trusted OS implementation manufacturer name
 CFG_TEE_MANUFACTURER ?= LINARO


### PR DESCRIPTION
Replaces CFG_TEE_IMPL_VERSION with TEE_IMPL_VERSION to avoid updating
<out-dir>/core/include/generated/conf.h each time description of the current
git commit is changed.

This avoids full recompiles that can't even be cached just because some
files has changed in an updated commit.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>