### PR TITLE
libtomcrypt: ASN1/DER fixes

### DIFF
--- a/core/lib/libtomcrypt/include/tomcrypt.h
+++ b/core/lib/libtomcrypt/include/tomcrypt.h
@@ -34,6 +34,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <limits.h>
+#include <stddef.h>  // for ptrdiff_t
 
 /* use configuration data */
 #include <tomcrypt_custom.h>

--- a/core/lib/libtomcrypt/include/tomcrypt_custom.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_custom.h
@@ -426,6 +426,16 @@
 
 #endif /* LTC_NO_PK */
 
+/* in cases where you want ASN.1/DER functionality, but no
+ * RSA, you can define this externally if 1024 is not enough
+ */
+#if defined(LTC_MRSA)
+#define LTC_DER_MAX_PUBKEY_SIZE MAX_RSA_SIZE
+#elif !defined(LTC_DER_MAX_PUBKEY_SIZE)
+/* this includes DSA */
+#define LTC_DER_MAX_PUBKEY_SIZE 1024
+#endif
+
 /* LTC_PKCS #1 (RSA) and #5 (Password Handling) stuff */
 #ifndef LTC_NO_PKCS
 

--- a/core/lib/libtomcrypt/include/tomcrypt_macros.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_macros.h
@@ -443,6 +443,10 @@ static inline unsigned long ROR64c(unsigned long word, const int i)
    #define MIN(x, y) ( ((x)<(y))?(x):(y) )
 #endif
 
+#ifndef LTC_UNUSED_PARAM
+   #define LTC_UNUSED_PARAM(x) (void)(x)
+#endif
+
 /* extract a byte portably */
 #ifdef _MSC_VER
    #define byte(x, n) ((unsigned char)((x) >> (8 * (n))))

--- a/core/lib/libtomcrypt/src/pk/asn1/der/bit/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/bit/sub.mk
@@ -1,3 +1,5 @@
 srcs-y += der_decode_bit_string.c
 srcs-y += der_encode_bit_string.c
 srcs-y += der_length_bit_string.c
+srcs-y += der_decode_raw_bit_string.c
+srcs-y += der_encode_raw_bit_string.c

--- a/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_decode_boolean.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_decode_boolean.c
@@ -58,7 +58,7 @@ int der_decode_boolean(const unsigned char *in, unsigned long inlen,
    LTC_ARGCHK(in  != NULL);
    LTC_ARGCHK(out != NULL);
    
-   if (inlen != 3 || in[0] != 0x01 || in[1] != 0x01 || (in[2] != 0x00 && in[2] != 0xFF)) {
+   if (inlen < 3 || in[0] != 0x01 || in[1] != 0x01 || (in[2] != 0x00 && in[2] != 0xFF)) {
       return CRYPT_INVALID_ARG;
    }
    
@@ -69,6 +69,6 @@ int der_decode_boolean(const unsigned char *in, unsigned long inlen,
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/boolean/der_decode_boolean.c,v $ */
-/* $Revision: 1.2 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/choice/der_decode_choice.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/choice/der_decode_choice.c
@@ -78,6 +78,16 @@ int der_decode_choice(const unsigned char *in,   unsigned long *inlen,
        data = list[x].data;
 
        switch (list[x].type) {
+           case LTC_ASN1_BOOLEAN:
+               if (der_decode_boolean(in, *inlen, data) == CRYPT_OK) {
+                  if (der_length_boolean(&z) == CRYPT_OK) {
+                      list[x].used = 1;
+                      *inlen       = z;
+                      return CRYPT_OK;
+                  }
+               }
+               break;
+
            case LTC_ASN1_INTEGER:
                if (der_decode_integer(in, *inlen, data) == CRYPT_OK) {
                   if (der_length_integer(data, &z) == CRYPT_OK) {
@@ -109,6 +119,17 @@ int der_decode_choice(const unsigned char *in,   unsigned long *inlen,
                }
                break;
 
+           case LTC_ASN1_RAW_BIT_STRING:
+               if (der_decode_raw_bit_string(in, *inlen, data, &size) == CRYPT_OK) {
+                  if (der_length_bit_string(size, &z) == CRYPT_OK) {
+                     list[x].used = 1;
+                     list[x].size = size;
+                     *inlen       = z;
+                     return CRYPT_OK;
+                  }
+               }
+               break;
+
            case LTC_ASN1_OCTET_STRING:
                if (der_decode_octet_string(in, *inlen, data, &size) == CRYPT_OK) {
                   if (der_length_octet_string(size, &z) == CRYPT_OK) {
@@ -127,10 +148,21 @@ int der_decode_choice(const unsigned char *in,   unsigned long *inlen,
                   return CRYPT_OK;
                }
                break;
-                  
+
            case LTC_ASN1_OBJECT_IDENTIFIER:
                if (der_decode_object_identifier(in, *inlen, data, &size) == CRYPT_OK) {
                   if (der_length_object_identifier(data, size, &z) == CRYPT_OK) {
+                     list[x].used = 1;
+                     list[x].size = size;
+                     *inlen       = z;
+                     return CRYPT_OK;
+                  }
+               }
+               break;
+
+           case LTC_ASN1_TELETEX_STRING:
+               if (der_decode_teletex_string(in, *inlen, data, &size) == CRYPT_OK) {
+                  if (der_length_teletex_string(data, size, &z) == CRYPT_OK) {
                      list[x].used = 1;
                      list[x].size = size;
                      *inlen       = z;
@@ -149,7 +181,6 @@ int der_decode_choice(const unsigned char *in,   unsigned long *inlen,
                   }
                }
                break;
-
 
            case LTC_ASN1_PRINTABLE_STRING:
                if (der_decode_printable_string(in, *inlen, data, &size) == CRYPT_OK) {
@@ -194,6 +225,11 @@ int der_decode_choice(const unsigned char *in,   unsigned long *inlen,
                }
                break;
 
+           case LTC_ASN1_CHOICE:
+           case LTC_ASN1_CONSTRUCTED:
+           case LTC_ASN1_CONTEXT_SPECIFIC:
+           case LTC_ASN1_EOL:
+               return CRYPT_INVALID_ARG;
            default:
                return CRYPT_INVALID_ARG;
        }
@@ -204,6 +240,6 @@ int der_decode_choice(const unsigned char *in,   unsigned long *inlen,
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/choice/der_decode_choice.c,v $ */
-/* $Revision: 1.9 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_encode_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_encode_integer.c
@@ -89,6 +89,7 @@ int der_encode_integer(void *num, unsigned char *out, unsigned long *outlen)
       y            = y >> 3;
       if (((mp_cnt_lsb(num)+1)==mp_count_bits(num)) && ((mp_count_bits(num)&7)==0)) --y;
    }
+
    /* now store initial data */
    *out++ = 0x02;
    if (y < 128) {
@@ -117,9 +118,8 @@ int der_encode_integer(void *num, unsigned char *out, unsigned long *outlen)
 
    /* if it's not zero store it as big endian */
    if (mp_cmp_d(num, 0) == LTC_MP_GT) {
-      err = mp_to_unsigned_bin(num, out);
       /* now store the mpint */
-      if (err != CRYPT_OK) {
+      if ((err = mp_to_unsigned_bin(num, out)) != CRYPT_OK) {
           return err;
       }
    } else if (mp_iszero(num) != LTC_MP_YES) {
@@ -152,6 +152,6 @@ int der_encode_integer(void *num, unsigned char *out, unsigned long *outlen)
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/integer/der_encode_integer.c,v $ */
-/* $Revision: 1.9 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_ex.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_ex.c
@@ -58,13 +58,14 @@
 int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                            ltc_asn1_list *list,     unsigned long  outlen, int ordered)
 {
-   int           err, type;
-   unsigned long size, x, y, z, i, blksize=0;
+   int           err, i;
+   ltc_asn1_type type;
+   unsigned long size, x, y, z, blksize;
    void          *data;
 
    LTC_ARGCHK(in   != NULL);
    LTC_ARGCHK(list != NULL);
-   
+
    /* get blk size */
    if (inlen < 2) {
       return CRYPT_INVALID_PACKET;
@@ -77,9 +78,12 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
    }
    ++x;
 
+   /* check if the msb is set, which signals that the
+    * 7 lsb bits represent the number of bytes of the length
+    */
    if (in[x] < 128) {
       blksize = in[x++];
-   } else if (in[x] & 0x80) {
+   } else {
       if (in[x] < 0x81 || in[x] > 0x83) {
          return CRYPT_INVALID_PACKET;
       }
@@ -103,20 +107,20 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
   }
 
    /* mark all as unused */
-   for (i = 0; i < outlen; i++) {
+   for (i = 0; i < (int)outlen; i++) {
        list[i].used = 0;
-   }     
+   }
 
   /* ok read data */
    inlen = blksize;
-   for (i = 0; i < outlen; i++) {
+   for (i = 0; i < (int)outlen; i++) {
        z    = 0;
        type = list[i].type;
        size = list[i].size;
        data = list[i].data;
        if (!ordered && list[i].used == 1) { continue; }
 
-       if (type == LTC_ASN1_EOL) { 
+       if (type == LTC_ASN1_EOL) {
           break;
        }
 
@@ -130,7 +134,7 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                    goto LBL_ERR;
                 }
                 break;
-          
+
            case LTC_ASN1_INTEGER:
                z = inlen;
                if ((err = der_decode_integer(in + x, z, data)) != CRYPT_OK) {
@@ -151,12 +155,24 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                if ((err = der_length_short_integer(((unsigned long*)data)[0], &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
-               
+
                break;
 
            case LTC_ASN1_BIT_STRING:
                z = inlen;
                if ((err = der_decode_bit_string(in + x, z, data, &size)) != CRYPT_OK) {
+                  if (!ordered) { continue; }
+                  goto LBL_ERR;
+               }
+               list[i].size = size;
+               if ((err = der_length_bit_string(size, &z)) != CRYPT_OK) {
+                  goto LBL_ERR;
+               }
+               break;
+
+           case LTC_ASN1_RAW_BIT_STRING:
+               z = inlen;
+               if ((err = der_decode_raw_bit_string(in + x, z, data, &size)) != CRYPT_OK) {
                   if (!ordered) { continue; }
                   goto LBL_ERR;
                }
@@ -186,7 +202,7 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                }
                z = 2;
                break;
-                  
+
            case LTC_ASN1_OBJECT_IDENTIFIER:
                z = inlen;
                if ((err = der_decode_object_identifier(in + x, z, data, &size)) != CRYPT_OK) {
@@ -195,6 +211,18 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                }
                list[i].size = size;
                if ((err = der_length_object_identifier(data, size, &z)) != CRYPT_OK) {
+                  goto LBL_ERR;
+               }
+               break;
+
+           case LTC_ASN1_TELETEX_STRING:
+               z = inlen;
+               if ((err = der_decode_teletex_string(in + x, z, data, &size)) != CRYPT_OK) {
+                  if (!ordered) { continue; }
+                  goto LBL_ERR;
+               }
+               list[i].size = size;
+               if ((err = der_length_teletex_string(data, size, &z)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
                break;
@@ -254,7 +282,7 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                   goto LBL_ERR;
                }
                break;
-           
+
            case LTC_ASN1_SETOF:
            case LTC_ASN1_SEQUENCE:
                /* detect if we have the right type */
@@ -282,6 +310,11 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                }
                break;
 
+           case LTC_ASN1_CONSTRUCTED:
+           case LTC_ASN1_CONTEXT_SPECIFIC:
+           case LTC_ASN1_EOL:
+               err = CRYPT_INVALID_ARG;
+               goto LBL_ERR;
            default:
                err = CRYPT_INVALID_ARG;
                goto LBL_ERR;
@@ -289,26 +322,26 @@ int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
        x           += z;
        inlen       -= z;
        list[i].used = 1;
-       if (!ordered) { 
+       if (!ordered) {
           /* restart the decoder */
           i = -1;
-       }          
+       }
    }
-     
-   for (i = 0; i < outlen; i++) {
+
+   for (i = 0; i < (int)outlen; i++) {
       if (list[i].used == 0) {
           err = CRYPT_INVALID_PACKET;
           goto LBL_ERR;
       }
-   }                
-   err = CRYPT_OK;   
+   }
+   err = CRYPT_OK;
 
 LBL_ERR:
    return err;
-}  
- 
+}
+
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_ex.c,v $ */
-/* $Revision: 1.16 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
@@ -44,69 +44,69 @@
 
 #ifdef LTC_DER
 
-static unsigned long fetch_length(const unsigned char *in, unsigned long inlen)
+static unsigned long fetch_length(const unsigned char *in, unsigned long inlen, unsigned long *data_offset)
 {
-   unsigned long x, y, z;
+   unsigned long x, z;
 
-   y = 0;
+   *data_offset = 0;
 
    /* skip type and read len */
    if (inlen < 2) {
       return 0xFFFFFFFF;
    }
-   ++in; ++y;
-   
+   ++in; ++(*data_offset);
+
    /* read len */
-   x = *in++; ++y;
-   
+   x = *in++; ++(*data_offset);
+
    /* <128 means literal */
    if (x < 128) {
-      return x+y;
+      return x+*data_offset;
    }
    x     &= 0x7F; /* the lower 7 bits are the length of the length */
    inlen -= 2;
-   
+
    /* len means len of len! */
    if (x == 0 || x > 4 || x > inlen) {
       return 0xFFFFFFFF;
    }
-   
-   y += x;
+
+   *data_offset += x;
    z = 0;
-   while (x--) {   
+   while (x--) {
       z = (z<<8) | ((unsigned long)*in);
       ++in;
    }
-   return z+y;
+   return z+*data_offset;
 }
 
-/** 
+/**
    ASN.1 DER Flexi(ble) decoder will decode arbitrary DER packets and create a linked list of the decoded elements.
    @param in      The input buffer
-   @param inlen   [in/out] The length of the input buffer and on output the amount of decoded data 
+   @param inlen   [in/out] The length of the input buffer and on output the amount of decoded data
    @param out     [out] A pointer to the linked list
    @return CRYPT_OK on success.
-*/   
+*/
 int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc_asn1_list **out)
 {
    ltc_asn1_list *l;
-   unsigned long err, type, len, totlen, x, y;
+   unsigned long err, type, len, totlen, data_offset;
    void          *realloc_tmp;
-   
+
    LTC_ARGCHK(in    != NULL);
    LTC_ARGCHK(inlen != NULL);
    LTC_ARGCHK(out   != NULL);
 
    l = NULL;
    totlen = 0;
-   
+
    /* scan the input and and get lengths and what not */
-   while (*inlen) {     
+   while (*inlen) {
       /* read the type byte */
       type = *in;
 
       /* fetch length */
-      len = fetch_length(in, *inlen);
+      len = fetch_length(in, *inlen, &data_offset);
       if (len > *inlen) {
          err = CRYPT_INVALID_PACKET;
          goto error;
@@ -129,17 +129,30 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
          l = l->next;
       }
 
-      /* now switch on type */
+      if ((type & 0x20) && (type != 0x30) && (type != 0x31)) {
+         /* constructed, use the 'used' field to store the original identifier */
+         l->used = type;
+         /* treat constructed elements like SETs */
+         type = 0x20;
+      }
+      else if ((type & 0xC0) == 0x80) {
+         /* context-specific, use the 'used' field to store the original identifier */
+         l->used = type;
+         /* context-specific elements are treated as opaque data */
+         type = 0x80;
+      }
+
+     /* now switch on type */
       switch (type) {
          case 0x01: /* BOOLEAN */
             l->type = LTC_ASN1_BOOLEAN;
             l->size = 1;
             l->data = XCALLOC(1, sizeof(int));
-       
+
             if ((err = der_decode_boolean(in, *inlen, l->data)) != CRYPT_OK) {
                goto error;
             }
-        
+
             if ((err = der_length_boolean(&len)) != CRYPT_OK) {
                goto error;
             }
@@ -152,12 +165,12 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
              if ((err = mp_init(&l->data)) != CRYPT_OK) {
                  goto error;
              }
-             
+
              /* decode field */
              if ((err = der_decode_integer(in, *inlen, l->data)) != CRYPT_OK) {
                  goto error;
              }
-             
+
              /* calc length of object */
              if ((err = der_length_integer(l->data, &len)) != CRYPT_OK) {
                  goto error;
@@ -173,11 +186,11 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
                err = CRYPT_MEM;
                goto error;
             }
-            
+
             if ((err = der_decode_bit_string(in, *inlen, l->data, &l->size)) != CRYPT_OK) {
                goto error;
             }
-            
+
             if ((err = der_length_bit_string(l->size, &len)) != CRYPT_OK) {
                goto error;
             }
@@ -193,34 +206,34 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
                err = CRYPT_MEM;
                goto error;
             }
-            
+
             if ((err = der_decode_octet_string(in, *inlen, l->data, &l->size)) != CRYPT_OK) {
                goto error;
             }
-            
+
             if ((err = der_length_octet_string(l->size, &len)) != CRYPT_OK) {
                goto error;
             }
             break;
 
          case 0x05: /* NULL */
-         
+
             /* valid NULL is 0x05 0x00 */
             if (in[0] != 0x05 || in[1] != 0x00) {
                err = CRYPT_INVALID_PACKET;
                goto error;
             }
-            
+
             /* simple to store ;-) */
             l->type = LTC_ASN1_NULL;
             l->data = NULL;
             l->size = 0;
             len     = 2;
-            
+
             break;
-         
+
          case 0x06: /* OID */
-         
+
             /* init field */
             l->type = LTC_ASN1_OBJECT_IDENTIFIER;
             l->size = len;
@@ -229,15 +242,15 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
                err = CRYPT_MEM;
                goto error;
             }
-            
+
             if ((err = der_decode_object_identifier(in, *inlen, l->data, &l->size)) != CRYPT_OK) {
                goto error;
             }
-            
+
             if ((err = der_length_object_identifier(l->data, l->size, &len)) != CRYPT_OK) {
                goto error;
             }
-            
+
             /* resize it to save a bunch of mem */
             if ((realloc_tmp = XREALLOC(l->data, l->size * sizeof(unsigned long))) == NULL) {
                /* out of heap but this is not an error */
@@ -245,9 +258,9 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
             }
             l->data = realloc_tmp;
             break;
-  
+
          case 0x0C: /* UTF8 */
-         
+
             /* init field */
             l->type = LTC_ASN1_UTF8_STRING;
             l->size = len;
@@ -256,18 +269,18 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
                err = CRYPT_MEM;
                goto error;
             }
-            
+
             if ((err = der_decode_utf8_string(in, *inlen, l->data, &l->size)) != CRYPT_OK) {
                goto error;
             }
-            
+
             if ((err = der_length_utf8_string(l->data, l->size, &len)) != CRYPT_OK) {
                goto error;
             }
             break;
 
          case 0x13: /* PRINTABLE */
-         
+
             /* init field */
             l->type = LTC_ASN1_PRINTABLE_STRING;
             l->size = len;
@@ -276,18 +289,38 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
                err = CRYPT_MEM;
                goto error;
             }
-            
+
             if ((err = der_decode_printable_string(in, *inlen, l->data, &l->size)) != CRYPT_OK) {
                goto error;
             }
-            
+
             if ((err = der_length_printable_string(l->data, l->size, &len)) != CRYPT_OK) {
                goto error;
             }
             break;
-         
+
+         case 0x14: /* TELETEXT */
+
+            /* init field */
+            l->type = LTC_ASN1_TELETEX_STRING;
+            l->size = len;
+
+            if ((l->data = XCALLOC(1, l->size)) == NULL) {
+               err = CRYPT_MEM;
+               goto error;
+            }
+
+            if ((err = der_decode_teletex_string(in, *inlen, l->data, &l->size)) != CRYPT_OK) {
+               goto error;
+            }
+
+            if ((err = der_length_teletex_string(l->data, l->size, &len)) != CRYPT_OK) {
+               goto error;
+            }
+            break;
+
          case 0x16: /* IA5 */
-         
+
             /* init field */
             l->type = LTC_ASN1_IA5_STRING;
             l->size = len;
@@ -296,18 +329,18 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
                err = CRYPT_MEM;
                goto error;
             }
-            
+
             if ((err = der_decode_ia5_string(in, *inlen, l->data, &l->size)) != CRYPT_OK) {
                goto error;
             }
-            
+
             if ((err = der_length_ia5_string(l->data, l->size, &len)) != CRYPT_OK) {
                goto error;
             }
             break;
-         
+
          case 0x17: /* UTC TIME */
-         
+
             /* init field */
             l->type = LTC_ASN1_UTCTIME;
             l->size = 1;
@@ -316,83 +349,97 @@ int der_decode_sequence_flexi(const unsigned char *in, unsigned long *inlen, ltc
                err = CRYPT_MEM;
                goto error;
             }
-            
+
             len = *inlen;
             if ((err = der_decode_utctime(in, &len, l->data)) != CRYPT_OK) {
                goto error;
             }
-            
+
             if ((err = der_length_utctime(l->data, &len)) != CRYPT_OK) {
                goto error;
             }
             break;
-         
+
+         case 0x20: /* Any CONSTRUCTED element that is neither SEQUENCE nor SET */
          case 0x30: /* SEQUENCE */
          case 0x31: /* SET */
-         
+
              /* init field */
-             l->type = (type == 0x30) ? LTC_ASN1_SEQUENCE : LTC_ASN1_SET;
-             
-             /* we have to decode the SEQUENCE header and get it's length */
-             
-                /* move past type */
-                ++in; --(*inlen);
-                
-                /* read length byte */
-                x = *in++; --(*inlen);
-                
-                /* smallest SEQUENCE/SET header */
-                y = 2;
-                
-                /* now if it's > 127 the next bytes are the length of the length */
-                if (x > 128) {
-                   x      &= 0x7F;
-                   in     += x;
-                   *inlen -= x;
-                   
-                   /* update sequence header len */
-                   y      += x;
-                }
-             
+             if (type == 0x20) {
+                l->type = LTC_ASN1_CONSTRUCTED;
+             }
+             else if (type == 0x30) {
+                l->type = LTC_ASN1_SEQUENCE;
+             }
+             else {
+                l->type = LTC_ASN1_SET;
+             }
+
+             /* jump to the start of the data */
+             in     += data_offset;
+             *inlen -= data_offset;
+             len = len - data_offset;
+
              /* Sequence elements go as child */
-             len = len - y;
              if ((err = der_decode_sequence_flexi(in, &len, &(l->child))) != CRYPT_OK) {
                 goto error;
              }
-             
+
              /* len update */
-             totlen += y;
-             
-             /* link them up y0 */
-             l->child->parent = l;
-             
+             totlen += data_offset;
+
+             /* the flexi decoder can also do nothing, so make sure a child has been allocated */
+             if (l->child) {
+                /* link them up y0 */
+                l->child->parent = l;
+             }
+
              break;
+
+         case 0x80: /* Context-specific */
+             l->type = LTC_ASN1_CONTEXT_SPECIFIC;
+
+             if ((l->data = XCALLOC(1, len - data_offset)) == NULL) {
+                err = CRYPT_MEM;
+                goto error;
+             }
+
+             XMEMCPY(l->data, in + data_offset, len - data_offset);
+             l->size = len - data_offset;
+
+             break;
+
          default:
            /* invalid byte ... this is a soft error */
            /* remove link */
-           l       = l->prev;
-           XFREE(l->next);
-           l->next = NULL;
+           if (l->prev) {
+              l       = l->prev;
+              XFREE(l->next);
+              l->next = NULL;
+           }
            goto outside;
       }
-      
+
       /* advance pointers */
       totlen  += len;
       in      += len;
       *inlen  -= len;
    }
-   
-outside:   
 
-   /* rewind l please */
-   while (l->prev != NULL || l->parent != NULL) {
-      if (l->parent != NULL) {
-         l = l->parent;
-      } else {
-         l = l->prev;
+outside:
+
+   /* in case we processed anything */
+   if (totlen) {
+      /* rewind l please */
+      while (l->prev != NULL || l->parent != NULL) {
+         if (l->parent != NULL) {
+            l = l->parent;
+         } else {
+            l = l->prev;
+         }
       }
    }
-   
+
    /* return */
    *out   = l;
    *inlen = totlen;
@@ -408,6 +455,6 @@ error:
 #endif
 
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c,v $ */
-/* $Revision: 1.26 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
@@ -52,10 +52,11 @@
   @param inlen Length of input in octets
   @remark <...> is of the form <type, size, data> (int, unsigned long, void*)
   @return CRYPT_OK on success
-*/  
+*/
 int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...)
 {
-   int           err, type;
+   int           err;
+   ltc_asn1_type type;
    unsigned long size, x;
    void          *data;
    va_list       args;
@@ -67,11 +68,13 @@ int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...)
    va_start(args, inlen);
    x = 0;
    for (;;) {
-       type = va_arg(args, int);
+       type = va_arg(args, ltc_asn1_type);
        size = va_arg(args, unsigned long);
        data = va_arg(args, void*);
+       LTC_UNUSED_PARAM(size);
+       LTC_UNUSED_PARAM(data);
 
-       if (type == LTC_ASN1_EOL) { 
+       if (type == LTC_ASN1_EOL) {
           break;
        }
 
@@ -91,9 +94,16 @@ int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...)
            case LTC_ASN1_SETOF:
            case LTC_ASN1_SEQUENCE:
            case LTC_ASN1_CHOICE:
-                ++x; 
+           case LTC_ASN1_RAW_BIT_STRING:
+           case LTC_ASN1_TELETEX_STRING:
+                ++x;
                 break;
-          
+
+           case LTC_ASN1_EOL:
+           case LTC_ASN1_CONSTRUCTED:
+           case LTC_ASN1_CONTEXT_SPECIFIC:
+               va_end(args);
+               return CRYPT_INVALID_ARG;
            default:
                va_end(args);
                return CRYPT_INVALID_ARG;
@@ -115,11 +125,11 @@ int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...)
    va_start(args, inlen);
    x = 0;
    for (;;) {
-       type = va_arg(args, int);
+       type = va_arg(args, ltc_asn1_type);
        size = va_arg(args, unsigned long);
        data = va_arg(args, void*);
 
-       if (type == LTC_ASN1_EOL) { 
+       if (type == LTC_ASN1_EOL) {
           break;
        }
 
@@ -137,13 +147,17 @@ int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...)
            case LTC_ASN1_UTCTIME:
            case LTC_ASN1_SEQUENCE:
            case LTC_ASN1_SET:
-           case LTC_ASN1_SETOF:          
+           case LTC_ASN1_SETOF:
            case LTC_ASN1_CHOICE:
-                list[x].type   = type;
-                list[x].size   = size;
-                list[x++].data = data;
+           case LTC_ASN1_RAW_BIT_STRING:
+           case LTC_ASN1_TELETEX_STRING:
+                LTC_SET_ASN1(list, x++, type, data, size);
                 break;
-         
+           /* coverity[dead_error_line] */
+           case LTC_ASN1_EOL:
+           case LTC_ASN1_CONSTRUCTED:
+           case LTC_ASN1_CONTEXT_SPECIFIC:
+                break;
            default:
                va_end(args);
                err = CRYPT_INVALID_ARG;
@@ -161,6 +175,6 @@ LBL_ERR:
 #endif
 
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c,v $ */
-/* $Revision: 1.13 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ */
+#include "tomcrypt.h"
+/**
+  @file der_encode_sequence_multi.c
+  ASN.1 DER, encode a Subject Public Key structure --nmav
+*/
+
+#ifdef LTC_DER
+
+/* AlgorithmIdentifier := SEQUENCE {
+ *    algorithm OBJECT IDENTIFIER,
+ *    parameters ANY DEFINED BY algorithm
+ * }
+ *
+ * SubjectPublicKeyInfo := SEQUENCE {
+ *    algorithm AlgorithmIdentifier,
+ *    subjectPublicKey BIT STRING
+ * }
+ */
+/**
+  Encode a SEQUENCE type using a VA list
+  @param out    [out] Destination for data
+  @param outlen [in/out] Length of buffer and resulting length of output
+  @remark <...> is of the form <type, size, data> (int, unsigned long, void*)
+  @return CRYPT_OK on success
+*/
+int der_decode_subject_public_key_info(const unsigned char *in, unsigned long inlen,
+        unsigned int algorithm, void* public_key, unsigned long* public_key_len,
+        unsigned long parameters_type, ltc_asn1_list* parameters, unsigned long parameters_len)
+{
+   int err;
+   unsigned long len;
+   oid_st oid;
+   unsigned char *tmpbuf;
+   unsigned long  tmpoid[16];
+   ltc_asn1_list alg_id[2];
+   ltc_asn1_list subject_pubkey[2];
+
+   LTC_ARGCHK(in    != NULL);
+   LTC_ARGCHK(inlen != 0);
+   LTC_ARGCHK(public_key_len != NULL);
+
+   err = pk_get_oid(algorithm, &oid);
+   if (err != CRYPT_OK) {
+        return err;
+   }
+
+   /* see if the OpenSSL DER format RSA public key will work */
+   tmpbuf = XCALLOC(1, LTC_DER_MAX_PUBKEY_SIZE*8);
+   if (tmpbuf == NULL) {
+       err = CRYPT_MEM;
+       goto LBL_ERR;
+   }
+
+   /* this includes the internal hash ID and optional params (NULL in this case) */
+   LTC_SET_ASN1(alg_id, 0, LTC_ASN1_OBJECT_IDENTIFIER, tmpoid, sizeof(tmpoid)/sizeof(tmpoid[0]));
+   LTC_SET_ASN1(alg_id, 1, parameters_type, parameters, parameters_len);
+
+   /* the actual format of the SSL DER key is odd, it stores a RSAPublicKey
+    * in a **BIT** string ... so we have to extract it then proceed to convert bit to octet
+    */
+   LTC_SET_ASN1(subject_pubkey, 0, LTC_ASN1_SEQUENCE, alg_id, 2);
+   LTC_SET_ASN1(subject_pubkey, 1, LTC_ASN1_RAW_BIT_STRING, tmpbuf, LTC_DER_MAX_PUBKEY_SIZE*8);
+
+   err=der_decode_sequence(in, inlen, subject_pubkey, 2UL);
+   if (err != CRYPT_OK) {
+           goto LBL_ERR;
+   }
+
+   if ((alg_id[0].size != oid.OIDlen) ||
+        XMEMCMP(oid.OID, alg_id[0].data, oid.OIDlen * sizeof(oid.OID[0]))) {
+        /* OID mismatch */
+        err = CRYPT_PK_INVALID_TYPE;
+        goto LBL_ERR;
+   }
+
+   len = subject_pubkey[1].size/8;
+   if (*public_key_len > len) {
+       XMEMCPY(public_key, subject_pubkey[1].data, len);
+       *public_key_len = len;
+    } else {
+        *public_key_len = len;
+        err = CRYPT_BUFFER_OVERFLOW;
+        goto LBL_ERR;
+    }
+
+    err = CRYPT_OK;
+
+LBL_ERR:
+
+    XFREE(tmpbuf);
+
+    return err;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
@@ -52,10 +52,11 @@
   @param outlen [in/out] Length of buffer and resulting length of output
   @remark <...> is of the form <type, size, data> (int, unsigned long, void*)
   @return CRYPT_OK on success
-*/  
+*/
 int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
 {
-   int           err, type;
+   int           err;
+   ltc_asn1_type type;
    unsigned long size, x;
    void          *data;
    va_list       args;
@@ -68,11 +69,13 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
    va_start(args, outlen);
    x = 0;
    for (;;) {
-       type = va_arg(args, int);
+       type = va_arg(args, ltc_asn1_type);
        size = va_arg(args, unsigned long);
        data = va_arg(args, void*);
+       LTC_UNUSED_PARAM(size);
+       LTC_UNUSED_PARAM(data);
 
-       if (type == LTC_ASN1_EOL) { 
+       if (type == LTC_ASN1_EOL) {
           break;
        }
 
@@ -91,9 +94,17 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
            case LTC_ASN1_SEQUENCE:
            case LTC_ASN1_SET:
            case LTC_ASN1_SETOF:
-                ++x; 
+           case LTC_ASN1_RAW_BIT_STRING:
+                ++x;
                 break;
-          
+
+           case LTC_ASN1_CHOICE:
+           case LTC_ASN1_CONSTRUCTED:
+           case LTC_ASN1_CONTEXT_SPECIFIC:
+           case LTC_ASN1_EOL:
+           case LTC_ASN1_TELETEX_STRING:
+               va_end(args);
+               return CRYPT_INVALID_ARG;
            default:
                va_end(args);
                return CRYPT_INVALID_ARG;
@@ -115,11 +126,11 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
    va_start(args, outlen);
    x = 0;
    for (;;) {
-       type = va_arg(args, int);
+       type = va_arg(args, ltc_asn1_type);
        size = va_arg(args, unsigned long);
        data = va_arg(args, void*);
 
-       if (type == LTC_ASN1_EOL) { 
+       if (type == LTC_ASN1_EOL) {
           break;
        }
 
@@ -138,11 +149,18 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
            case LTC_ASN1_SEQUENCE:
            case LTC_ASN1_SET:
            case LTC_ASN1_SETOF:
-                list[x].type   = type;
-                list[x].size   = size;
-                list[x++].data = data;
+           case LTC_ASN1_RAW_BIT_STRING:
+                LTC_SET_ASN1(list, x++, type, data, size);
                 break;
-         
+
+           case LTC_ASN1_CHOICE:
+           case LTC_ASN1_CONSTRUCTED:
+           case LTC_ASN1_CONTEXT_SPECIFIC:
+           case LTC_ASN1_EOL:
+           case LTC_ASN1_TELETEX_STRING:
+               va_end(args);
+               err = CRYPT_INVALID_ARG;
+               goto LBL_ERR;
            default:
                va_end(args);
                err = CRYPT_INVALID_ARG;
@@ -151,7 +169,7 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
    }
    va_end(args);
 
-   err = der_encode_sequence(list, x, out, outlen);   
+   err = der_encode_sequence(list, x, out, outlen);
 LBL_ERR:
    XFREE(list);
    return err;
@@ -160,6 +178,6 @@ LBL_ERR:
 #endif
 
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c,v $ */
-/* $Revision: 1.12 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_length_sequence.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_length_sequence.c
@@ -45,16 +45,17 @@
 #ifdef LTC_DER
 
 /**
-   Get the length of a DER sequence 
+   Get the length of a DER sequence
    @param list   The sequences of items in the SEQUENCE
    @param inlen  The number of items
-   @param outlen [out] The length required in octets to store it 
+   @param outlen [out] The length required in octets to store it
    @return CRYPT_OK on success
 */
 int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
-                        unsigned long *outlen) 
+                        unsigned long *outlen)
 {
-   int           err, type;
+   int           err;
+   ltc_asn1_type type;
    unsigned long size, x, y, i;
    void          *data;
 
@@ -68,7 +69,7 @@ int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
        size = list[i].size;
        data = list[i].data;
 
-       if (type == LTC_ASN1_EOL) { 
+       if (type == LTC_ASN1_EOL) {
           break;
        }
 
@@ -79,7 +80,7 @@ int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
               }
               y += x;
               break;
-          
+
            case LTC_ASN1_INTEGER:
                if ((err = der_length_integer(data, &x)) != CRYPT_OK) {
                   goto LBL_ERR;
@@ -95,6 +96,7 @@ int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
                break;
 
            case LTC_ASN1_BIT_STRING:
+           case LTC_ASN1_RAW_BIT_STRING:
                if ((err = der_length_bit_string(size, &x)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
@@ -121,6 +123,13 @@ int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
 
            case LTC_ASN1_IA5_STRING:
                if ((err = der_length_ia5_string(data, size, &x)) != CRYPT_OK) {
+                  goto LBL_ERR;
+               }
+               y += x;
+               break;
+
+           case LTC_ASN1_TELETEX_STRING:
+               if ((err = der_length_teletex_string(data, size, &x)) != CRYPT_OK) {
                   goto LBL_ERR;
                }
                y += x;
@@ -156,7 +165,13 @@ int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
                y += x;
                break;
 
-          
+
+           case LTC_ASN1_CHOICE:
+           case LTC_ASN1_CONSTRUCTED:
+           case LTC_ASN1_CONTEXT_SPECIFIC:
+           case LTC_ASN1_EOL:
+               err = CRYPT_INVALID_ARG;
+               goto LBL_ERR;
            default:
                err = CRYPT_INVALID_ARG;
                goto LBL_ERR;
@@ -190,6 +205,6 @@ LBL_ERR:
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/sequence/der_length_sequence.c,v $ */
-/* $Revision: 1.14 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_sequence_free.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_sequence_free.c
@@ -51,6 +51,8 @@
 void der_sequence_free(ltc_asn1_list *in)
 {
    ltc_asn1_list *l;
+
+   if (!in) return;
    
    /* walk to the start of the chain */
    while (in->prev != NULL || in->parent != NULL) {
@@ -80,13 +82,13 @@ void der_sequence_free(ltc_asn1_list *in)
       
       /* move to next and free current */
       l = in->next;
-      free(in);
+      XFREE(in);
       in = l;
    }     
 }
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/sequence/der_sequence_free.c,v $ */
-/* $Revision: 1.4 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/sub.mk
@@ -5,3 +5,5 @@ srcs-y += der_encode_sequence_ex.c
 srcs-y += der_encode_sequence_multi.c
 srcs-y += der_length_sequence.c
 srcs-y += der_sequence_free.c
+srcs-y += der_decode_subject_public_key_info.c
+srcs-y += der_encode_subject_public_key_info.c

--- a/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_set.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_set.c
@@ -45,35 +45,42 @@
 #ifdef LTC_DER
 
 /* LTC define to ASN.1 TAG */
-static int ltc_to_asn1(int v)
+static int ltc_to_asn1(ltc_asn1_type v)
 {
    switch (v) {
       case LTC_ASN1_BOOLEAN:                 return 0x01;
       case LTC_ASN1_INTEGER:
       case LTC_ASN1_SHORT_INTEGER:           return 0x02;
+      case LTC_ASN1_RAW_BIT_STRING:
       case LTC_ASN1_BIT_STRING:              return 0x03;
       case LTC_ASN1_OCTET_STRING:            return 0x04;
       case LTC_ASN1_NULL:                    return 0x05;
       case LTC_ASN1_OBJECT_IDENTIFIER:       return 0x06;
       case LTC_ASN1_UTF8_STRING:             return 0x0C;
       case LTC_ASN1_PRINTABLE_STRING:        return 0x13;
+      case LTC_ASN1_TELETEX_STRING:          return 0x14;
       case LTC_ASN1_IA5_STRING:              return 0x16;
       case LTC_ASN1_UTCTIME:                 return 0x17;
       case LTC_ASN1_SEQUENCE:                return 0x30;
       case LTC_ASN1_SET:
       case LTC_ASN1_SETOF:                   return 0x31;
-      default: return -1;
+      case LTC_ASN1_CHOICE:
+      case LTC_ASN1_CONSTRUCTED:
+      case LTC_ASN1_CONTEXT_SPECIFIC:
+      case LTC_ASN1_EOL:                     return -1;
+      default:                               return -1;
    }
-}         
-      
+   return -1;
+}
+
 
 static int qsort_helper(const void *a, const void *b)
 {
    ltc_asn1_list *A = (ltc_asn1_list *)a, *B = (ltc_asn1_list *)b;
    int            r;
-   
+
    r = ltc_to_asn1(A->type) - ltc_to_asn1(B->type);
-   
+
    /* for QSORT the order is UNDEFINED if they are "equal" which means it is NOT DETERMINISTIC.  So we force it to be :-) */
    if (r == 0) {
       /* their order in the original list now determines the position */
@@ -81,13 +88,13 @@ static int qsort_helper(const void *a, const void *b)
    } else {
       return r;
    }
-}   
+}
 
 /*
    Encode a SET type
    @param list      The list of items to encode
    @param inlen     The number of items in the list
-   @param out       [out] The destination 
+   @param out       [out] The destination
    @param outlen    [in/out] The size of the output
    @return CRYPT_OK on success
 */
@@ -97,34 +104,34 @@ int der_encode_set(ltc_asn1_list *list, unsigned long inlen,
    ltc_asn1_list  *copy;
    unsigned long   x;
    int             err;
-   
+
    /* make copy of list */
    copy = XCALLOC(inlen, sizeof(*copy));
    if (copy == NULL) {
       return CRYPT_MEM;
-   }      
-   
+   }
+
    /* fill in used member with index so we can fully sort it */
    for (x = 0; x < inlen; x++) {
        copy[x]      = list[x];
        copy[x].used = x;
-   }       
-   
+   }
+
    /* sort it by the "type" field */
-   XQSORT(copy, inlen, sizeof(*copy), &qsort_helper);   
-   
+   XQSORT(copy, inlen, sizeof(*copy), &qsort_helper);
+
    /* call der_encode_sequence_ex() */
-   err = der_encode_sequence_ex(copy, inlen, out, outlen, LTC_ASN1_SET);   
-   
+   err = der_encode_sequence_ex(copy, inlen, out, outlen, LTC_ASN1_SET);
+
    /* free list */
    XFREE(copy);
-   
+
    return err;
-}                   
+}
 
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/set/der_encode_set.c,v $ */
-/* $Revision: 1.12 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_setof.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_setof.c
@@ -54,10 +54,10 @@ static int qsort_helper(const void *a, const void *b)
    struct edge   *A = (struct edge *)a, *B = (struct edge *)b;
    int            r;
    unsigned long  x;
-   
+
    /* compare min length */
    r = XMEMCMP(A->start, B->start, MIN(A->size, B->size));
-   
+
    if (r == 0 && A->size != B->size) {
       if (A->size > B->size) {
          for (x = B->size; x < A->size; x++) {
@@ -71,28 +71,29 @@ static int qsort_helper(const void *a, const void *b)
                return -1;
             }
          }
-      }         
+      }
    }
-   
-   return r;      
+
+   return r;
 }
 
 /**
    Encode a SETOF stucture
    @param list      The list of items to encode
    @param inlen     The number of items in the list
-   @param out       [out] The destination 
+   @param out       [out] The destination
    @param outlen    [in/out] The size of the output
    @return CRYPT_OK on success
-*/   
+*/
 int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
                      unsigned char *out,  unsigned long *outlen)
 {
-   unsigned long  x, y, z, hdrlen;
+   unsigned long  x, y, z;
+   ptrdiff_t hdrlen;
    int            err;
    struct edge   *edges;
    unsigned char *ptr, *buf;
-   
+
    /* check that they're all the same type */
    for (x = 1; x < inlen; x++) {
       if (list[x].type != list[x-1].type) {
@@ -104,21 +105,21 @@ int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
    buf = XCALLOC(1, *outlen);
    if (buf == NULL) {
       return CRYPT_MEM;
-   }      
-                  
+   }
+
    /* encode list */
    if ((err = der_encode_sequence_ex(list, inlen, buf, outlen, LTC_ASN1_SETOF)) != CRYPT_OK) {
        XFREE(buf);
        return err;
    }
-   
+
    /* allocate edges */
    edges = XCALLOC(inlen, sizeof(*edges));
    if (edges == NULL) {
       XFREE(buf);
       return CRYPT_MEM;
-   }      
-   
+   }
+
    /* skip header */
       ptr = buf + 1;
 
@@ -127,20 +128,20 @@ int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
       if (x >= 0x80) {
          ptr += (x & 0x7F);
       }
-      
+
       /* get the size of the static header */
-      hdrlen = ((unsigned long)ptr) - ((unsigned long)buf);
-      
-      
+      hdrlen = ptr - buf;
+
+
    /* scan for edges */
    x = 0;
    while (ptr < (buf + *outlen)) {
       /* store start */
       edges[x].start = ptr;
-      
+
       /* skip type */
       z = 1;
-      
+
       /* parse length */
       y = ptr[z++];
       if (y < 128) {
@@ -152,38 +153,38 @@ int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
             edges[x].size = (edges[x].size << 8) | ((unsigned long)ptr[z++]);
          }
       }
-      
+
       /* skip content */
       edges[x].size += z;
       ptr           += edges[x].size;
       ++x;
-   }      
-      
+   }
+
    /* sort based on contents (using edges) */
    XQSORT(edges, inlen, sizeof(*edges), &qsort_helper);
-   
+
    /* copy static header */
    XMEMCPY(out, buf, hdrlen);
-   
+
    /* copy+sort using edges+indecies to output from buffer */
    for (y = hdrlen, x = 0; x < inlen; x++) {
       XMEMCPY(out+y, edges[x].start, edges[x].size);
       y += edges[x].size;
-   }      
-   
+   }
+
 #ifdef LTC_CLEAN_STACK
    zeromem(buf, *outlen);
-#endif      
-   
+#endif
+
    /* free buffers */
    XFREE(edges);
    XFREE(buf);
-   
+
    return CRYPT_OK;
 }
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/set/der_encode_setof.c,v $ */
-/* $Revision: 1.12 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sub.mk
@@ -11,3 +11,4 @@ subdirs-y += set
 subdirs-y += short_integer
 subdirs-y += utctime
 subdirs-y += utf8
+subdirs-y += teletex_string

--- a/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_decode_teletex_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_decode_teletex_string.c
@@ -38,66 +38,80 @@
 #include "tomcrypt.h"
 
 /**
-  @file der_length_integer.c
-  ASN.1 DER, get length of encoding, Tom St Denis
+  @file der_decode_teletex_string.c
+  ASN.1 DER, encode a teletex STRING
 */
-
 
 #ifdef LTC_DER
+
 /**
-  Gets length of DER encoding of num
-  @param num    The int to get the size of
-  @param outlen [out] The length of the DER encoding for the given integer
+  Store a teletex STRING
+  @param in      The DER encoded teletex STRING
+  @param inlen   The size of the DER teletex STRING
+  @param out     [out] The array of octets stored (one per char)
+  @param outlen  [in/out] The number of octets stored
   @return CRYPT_OK if successful
 */
-int der_length_integer(void *num, unsigned long *outlen)
+int der_decode_teletex_string(const unsigned char *in, unsigned long inlen,
+                                unsigned char *out, unsigned long *outlen)
 {
-   unsigned long z, len;
-   int           leading_zero;
+   unsigned long x, y, len;
+   int           t;
 
-   LTC_ARGCHK(num     != NULL);
-   LTC_ARGCHK(outlen  != NULL);
+   LTC_ARGCHK(in     != NULL);
+   LTC_ARGCHK(out    != NULL);
+   LTC_ARGCHK(outlen != NULL);
 
-   if (mp_cmp_d(num, 0) != LTC_MP_LT) {
-      /* positive */
-
-      /* we only need a leading zero if the msb of the first byte is one */
-      if ((mp_count_bits(num) & 7) == 0 || mp_iszero(num) == LTC_MP_YES) {
-         leading_zero = 1;
-      } else {
-         leading_zero = 0;
-      }
-
-      /* size for bignum */
-      z = len = leading_zero + mp_unsigned_bin_size(num);
-   } else {
-      /* it's negative */
-      /* find power of 2 that is a multiple of eight and greater than count bits */
-      z = mp_count_bits(num);
-      z = z + (8 - (z & 7));
-      if (((mp_cnt_lsb(num)+1)==mp_count_bits(num)) && ((mp_count_bits(num)&7)==0)) --z;
-      len = z = z >> 3;
+   /* must have header at least */
+   if (inlen < 2) {
+      return CRYPT_INVALID_PACKET;
    }
 
-   /* now we need a length */
-   if (z < 128) {
-      /* short form */
-      ++len;
-   } else {
-      /* long form (relies on z != 0), assumes length bytes < 128 */
-      ++len;
+   /* check for 0x14 */
+   if ((in[0] & 0x1F) != 0x14) {
+      return CRYPT_INVALID_PACKET;
+   }
+   x = 1;
 
-      while (z) {
-         ++len;
-         z >>= 8;
+   /* decode the length */
+   if (in[x] & 0x80) {
+      /* valid # of bytes in length are 1,2,3 */
+      y = in[x] & 0x7F;
+      if ((y == 0) || (y > 3) || ((x + y) > inlen)) {
+         return CRYPT_INVALID_PACKET;
       }
+
+      /* read the length in */
+      len = 0;
+      ++x;
+      while (y--) {
+         len = (len << 8) | in[x++];
+      }
+   } else {
+      len = in[x++] & 0x7F;
    }
 
-   /* we need a 0x02 to indicate it's INTEGER */
-   ++len;
+   /* is it too long? */
+   if (len > *outlen) {
+      *outlen = len;
+      return CRYPT_BUFFER_OVERFLOW;
+   }
 
-   /* return length */
-   *outlen = len;
+   if (len + x > inlen) {
+      return CRYPT_INVALID_PACKET;
+   }
+
+   /* read the data */
+   for (y = 0; y < len; y++) {
+       t = der_teletex_value_decode(in[x++]);
+       if (t == -1) {
+           return CRYPT_INVALID_ARG;
+       }
+       out[y] = t;
+   }
+
+   *outlen = y;
+
    return CRYPT_OK;
 }
 

--- a/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_length_teletex_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_length_teletex_string.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2001-2007, Tom St Denis
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
+ */
+#include "tomcrypt.h"
+
+/**
+  @file der_length_teletex_string.c
+  ASN.1 DER, get length of teletex STRING
+*/
+
+#ifdef LTC_DER
+
+static const struct {
+   int code, value;
+} teletex_table[] = {
+{ '\0',  0 },
+{ '\a',  7 },
+{ '\b',  8 },
+{ '\t',  9 },
+{ '\n', 10 },
+{ '\v', 11 },
+{ '\f', 12 },
+{ '\r', 13 },
+{ ' ',  32 }, 
+{ '!',  33 }, 
+{ '"',  34 }, 
+{ '%',  37 }, 
+{ '&',  38 }, 
+{ '\'', 39 }, 
+{ '(',  40 }, 
+{ ')',  41 }, 
+{ '+',  43 }, 
+{ ',',  44 }, 
+{ '-',  45 }, 
+{ '.',  46 }, 
+{ '/',  47 }, 
+{ '0',  48 }, 
+{ '1',  49 }, 
+{ '2',  50 }, 
+{ '3',  51 }, 
+{ '4',  52 }, 
+{ '5',  53 }, 
+{ '6',  54 }, 
+{ '7',  55 }, 
+{ '8',  56 }, 
+{ '9',  57 }, 
+{ ':',  58 }, 
+{ ';',  59 }, 
+{ '<',  60 }, 
+{ '=',  61 }, 
+{ '>',  62 }, 
+{ '?',  63 }, 
+{ '@',  64 }, 
+{ 'A',  65 }, 
+{ 'B',  66 }, 
+{ 'C',  67 }, 
+{ 'D',  68 }, 
+{ 'E',  69 }, 
+{ 'F',  70 }, 
+{ 'G',  71 }, 
+{ 'H',  72 }, 
+{ 'I',  73 }, 
+{ 'J',  74 }, 
+{ 'K',  75 }, 
+{ 'L',  76 }, 
+{ 'M',  77 }, 
+{ 'N',  78 }, 
+{ 'O',  79 }, 
+{ 'P',  80 }, 
+{ 'Q',  81 }, 
+{ 'R',  82 }, 
+{ 'S',  83 }, 
+{ 'T',  84 }, 
+{ 'U',  85 }, 
+{ 'V',  86 }, 
+{ 'W',  87 }, 
+{ 'X',  88 }, 
+{ 'Y',  89 }, 
+{ 'Z',  90 }, 
+{ '[',  91 }, 
+{ ']',  93 }, 
+{ '_',  95 }, 
+{ 'a',  97 }, 
+{ 'b',  98 }, 
+{ 'c',  99 }, 
+{ 'd',  100 }, 
+{ 'e',  101 }, 
+{ 'f',  102 }, 
+{ 'g',  103 }, 
+{ 'h',  104 }, 
+{ 'i',  105 }, 
+{ 'j',  106 }, 
+{ 'k',  107 }, 
+{ 'l',  108 }, 
+{ 'm',  109 }, 
+{ 'n',  110 }, 
+{ 'o',  111 }, 
+{ 'p',  112 }, 
+{ 'q',  113 }, 
+{ 'r',  114 }, 
+{ 's',  115 }, 
+{ 't',  116 }, 
+{ 'u',  117 }, 
+{ 'v',  118 }, 
+{ 'w',  119 }, 
+{ 'x',  120 }, 
+{ 'y',  121 }, 
+{ 'z',  122 }, 
+{ '|',  124 }, 
+{ ' ',  160 }, 
+{ 0xa1, 161 }, 
+{ 0xa2, 162 }, 
+{ 0xa3, 163 }, 
+{ '$',  164 }, 
+{ 0xa5, 165 }, 
+{ '#',  166 }, 
+{ 0xa7, 167 }, 
+{ 0xa4, 168 }, 
+{ 0xab, 171 }, 
+{ 0xb0, 176 }, 
+{ 0xb1, 177 }, 
+{ 0xb2, 178 }, 
+{ 0xb3, 179 }, 
+{ 0xd7, 180 }, 
+{ 0xb5, 181 }, 
+{ 0xb6, 182 }, 
+{ 0xb7, 183 }, 
+{ 0xf7, 184 }, 
+{ 0xbb, 187 }, 
+{ 0xbc, 188 }, 
+{ 0xbd, 189 }, 
+{ 0xbe, 190 }, 
+{ 0xbf, 191 }, 
+};
+
+int der_teletex_char_encode(int c)
+{
+   int x;
+   for (x = 0; x < (int)(sizeof(teletex_table)/sizeof(teletex_table[0])); x++) {
+       if (teletex_table[x].code == c) {
+          return teletex_table[x].value;
+       }
+   }
+   return -1;
+}
+
+int der_teletex_value_decode(int v)
+{
+   int x;
+   for (x = 0; x < (int)(sizeof(teletex_table)/sizeof(teletex_table[0])); x++) {
+       if (teletex_table[x].value == v) {
+          return teletex_table[x].code;
+       }
+   }
+   return -1;
+}
+   
+/**
+  Gets length of DER encoding of teletex STRING 
+  @param octets   The values you want to encode 
+  @param noctets  The number of octets in the string to encode
+  @param outlen   [out] The length of the DER encoding for the given string
+  @return CRYPT_OK if successful
+*/
+int der_length_teletex_string(const unsigned char *octets, unsigned long noctets, unsigned long *outlen)
+{
+   unsigned long x;
+
+   LTC_ARGCHK(outlen != NULL);
+   LTC_ARGCHK(octets != NULL);
+
+   /* scan string for validity */
+   for (x = 0; x < noctets; x++) {
+       if (der_teletex_char_encode(octets[x]) == -1) {
+          return CRYPT_INVALID_ARG;
+       }
+   }
+
+   if (noctets < 128) {
+      /* 16 LL DD DD DD ... */
+      *outlen = 2 + noctets;
+   } else if (noctets < 256) {
+      /* 16 81 LL DD DD DD ... */
+      *outlen = 3 + noctets;
+   } else if (noctets < 65536UL) {
+      /* 16 82 LL LL DD DD DD ... */
+      *outlen = 4 + noctets;
+   } else if (noctets < 16777216UL) {
+      /* 16 83 LL LL LL DD DD DD ... */
+      *outlen = 5 + noctets;
+   } else {
+      return CRYPT_INVALID_ARG;
+   }
+
+   return CRYPT_OK;
+}
+
+#endif
+
+
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/sub.mk
@@ -1,0 +1,2 @@
+srcs-y += der_decode_teletex_string.c
+srcs-y += der_length_teletex_string.c

--- a/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_encode_utf8_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_encode_utf8_string.c
@@ -106,6 +106,7 @@ int der_encode_utf8_string(const wchar_t *in,  unsigned long inlen,
       out[x++] = (unsigned char)((len>>8)&255);
       out[x++] = (unsigned char)(len&255);
    } else {
+       /* coverity[dead_error_line] */
       return CRYPT_INVALID_ARG;
    }
 
@@ -128,6 +129,6 @@ int der_encode_utf8_string(const wchar_t *in,  unsigned long inlen,
 
 #endif
 
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/utf8/der_encode_utf8_string.c,v $ */
-/* $Revision: 1.9 $ */
-/* $Date: 2006/12/28 01:27:24 $ */
+/* $Source$ */
+/* $Revision$ */
+/* $Date$ */


### PR DESCRIPTION
- Synchronization with LibTomCrypt from
  origin/develop branch
  (commit 4a3b53dbee4bca1f151d9a64e9584a4c8152f0b1)

- Only "src/pk/asn1/der" directory has been synchronized

- Additional changes over synchronization:
  Several default case added in switch case condition
  when missing.

Signed-off-by: Philippe PAGE <philippe.page@st.com>
Reviewed-by: Etienne CARRIERE <etienne.carriere@st.com>
Tested-by: Etienne CARRIERE <etienne.carriere@st.com>