### PR TITLE
Travis: cache files downloaded from Sourceforge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ notifications:
 
 sudo: false
 
-cache: ccache
+cache:
+  ccache: true
+  directories:
+    - $HOME/downloads
 
 before_install:
   # Install the cross compilers
@@ -30,21 +33,25 @@ before_script:
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
   - cd $MYHOME
 
+  - export DL_DIR=$HOME/downloads
+  - function _download() { url="$1"; f="${2:-$(basename $url)}"; if [ ! -e $DL_DIR/$f ] ; then mkdir -p $DL_DIR ; wget $url -O $DL_DIR/$f ; fi }
+  - function download() { _download "$1" "" ; }
+
   # Tools required for QEMU tests
   # 'apt-get install' cannot be used in the new container-based infrastructure
   # (which is the only allowing caching), so we just build from sources
   # bc is used during kernel configuration
   - cd $HOME
-  - wget http://ftp.gnu.org/gnu/bc/bc-1.06.tar.gz
-  - tar xf bc-1.06.tar.gz
+  - download http://ftp.gnu.org/gnu/bc/bc-1.06.tar.gz
+  - tar xf $DL_DIR/bc-1.06.tar.gz
   - (cd bc-1.06 && CC="ccache gcc" ./configure --quiet && make -j4)
   - export PATH=${HOME}/bc-1.06/bc:$PATH
   # Tcl/Expect
-  - wget http://prdownloads.sourceforge.net/tcl/tcl8.6.4-src.tar.gz
-  - tar xf tcl8.6.4-src.tar.gz
+  - download http://prdownloads.sourceforge.net/tcl/tcl8.6.4-src.tar.gz
+  - tar xf $DL_DIR/tcl8.6.4-src.tar.gz
   - (cd tcl8.6.4/unix && ./configure --quiet --prefix=${HOME}/inst CC="ccache gcc" && make -j4 install)
-  - wget http://sourceforge.net/projects/expect/files/Expect/5.45/expect5.45.tar.gz/download -O expect5.45.tar.gz
-  - tar xf expect5.45.tar.gz
+  - _download http://sourceforge.net/projects/expect/files/Expect/5.45/expect5.45.tar.gz/download expect5.45.tar.gz
+  - tar xf $DL_DIR/expect5.45.tar.gz
   - (cd expect5.45 && ./configure --quiet --with-tcl=${HOME}/inst/lib --prefix=${HOME}/inst CC="ccache gcc" && make -j4 expect && make -j4 install)
   - export PATH=$HOME/inst/bin:$PATH
   # pycrypto 2.6.1 or later has Crypto.Signature, 2.4.1 does not. It is needed to sign the test TAs.


### PR DESCRIPTION
Sourceforge has been quite unreliable recently, and we have had a
number of build failures due to Tcl or Expect failing to download.
This patch adds the files to the Travis cache so that they will not
need to be downloaded again unless the cache is purged.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>