### PR TITLE
RPMB: make sure tee_rpmb_fs_write() is atomic

### DIFF
--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -1230,6 +1230,16 @@ func_exit:
 	return res;
 }
 
+bool tee_rpmb_write_is_atomic(uint16_t dev_id __unused, uint32_t addr,
+			      uint32_t len)
+{
+	uint8_t byte_offset = addr % RPMB_DATA_SIZE;
+	uint16_t blkcnt = ROUNDUP(len + byte_offset,
+				  RPMB_DATA_SIZE) / RPMB_DATA_SIZE;
+
+	return (blkcnt <= rpmb_ctx->rel_wr_blkcnt);
+}
+
 TEE_Result tee_rpmb_write(uint16_t dev_id,
 			  uint32_t addr, uint8_t *data, uint32_t len)
 {

--- a/core/include/tee/tee_rpmb.h
+++ b/core/include/tee/tee_rpmb.h
@@ -68,4 +68,13 @@ TEE_Result tee_rpmb_get_write_counter(uint16_t dev_id, uint32_t *counter);
  */
 TEE_Result tee_rpmb_get_max_block(uint16_t dev_id, uint32_t *max_block);
 
+/*
+ * Return true if data can be written atomically, false otherwise
+ *
+ * @dev_id	Device ID of the eMMC device.
+ * @addr	Byte address of data.
+ * @len		Size of data in bytes.
+ */
+bool tee_rpmb_write_is_atomic(uint16_t dev_id, uint32_t addr, uint32_t len);
+
 #endif


### PR DESCRIPTION
File updates have to be atomic, even in case of a powerdown event for
instance. Therefore we must not write data in-place unless the update spans
less than rel_wr_blkcnt blocks.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>