### PR TITLE
arm: add TA hard-float support

### DIFF
--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -98,10 +98,12 @@
 #define NSACR_NS_L2ERR	(1 << 17)
 #define NSACR_NS_SMP	(1 << 18)
 
+#define CPACR_ASEDIS	(1 << 31)
+#define CPACR_D32DIS	(1 << 30)
 #define CPACR_CP(co_proc, access)	((access) << ((co_proc) * 2))
 #define CPACR_CP_ACCESS_DENIED		0x0
 #define CPACR_CP_ACCESS_PL1_ONLY	0x1
-#define CPACR_CP_ACCESS_FULL		0x2
+#define CPACR_CP_ACCESS_FULL		0x3
 
 
 #define DACR_DOMAIN(num, perm)		((perm) << ((num) * 2))

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -30,6 +30,7 @@
 #include <types_ext.h>
 #include <tee_api_types.h>
 #include <kernel/tee_ta_manager.h>
+#include <kernel/thread.h>
 #include <mm/tee_mm.h>
 #include <util.h>
 #include <assert.h>
@@ -59,7 +60,11 @@ struct user_ta_ctx {
 #if defined(CFG_SE_API)
 	struct tee_se_service *se_service;
 #endif
+#if defined(CFG_WITH_VFP)
+	struct thread_user_vfp_state vfp;
+#endif
 	struct tee_ta_ctx ctx;
+
 };
 
 static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx)

--- a/core/arch/arm/include/kernel/vfp.h
+++ b/core/arch/arm/include/kernel/vfp.h
@@ -76,9 +76,29 @@ struct vfp_state {
 };
 #endif
 
+#ifdef CFG_WITH_VFP
+/* vfp_is_enabled() - Returns true if VFP is enabled */
 bool vfp_is_enabled(void);
+
+/* vfp_enable() - Enables vfp */
 void vfp_enable(void);
+
+/* vfp_disable() - Disables vfp */
 void vfp_disable(void);
+#else
+static inline bool vfp_is_enabled(void)
+{
+	return false;
+}
+
+static inline void vfp_enable(void)
+{
+}
+
+static inline void vfp_disable(void)
+{
+}
+#endif
 
 /*
  * vfp_lazy_save_state_init() - Saves VFP enable status and disables VFP

--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -218,7 +218,9 @@ static TEE_Result e32_load_ehdr(struct elf_load_state *state, Elf32_Ehdr *ehdr)
 	    ehdr->e_ident[EI_OSABI] != ELFOSABI_NONE ||
 	    ehdr->e_type != ET_DYN || ehdr->e_machine != EM_ARM ||
 	    (ehdr->e_flags & EF_ARM_ABIMASK) != EF_ARM_ABI_VERSION ||
+#ifndef CFG_WITH_VFP
 	    (ehdr->e_flags & EF_ARM_ABI_FLOAT_HARD) ||
+#endif
 	    ehdr->e_phentsize != sizeof(Elf32_Phdr) ||
 	    ehdr->e_shentsize != sizeof(Elf32_Shdr))
 		return TEE_ERROR_BAD_FORMAT;

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -111,11 +111,18 @@ static void init_vfp_sec(void)
 {
 	uint32_t cpacr = read_cpacr();
 
-	/* Enable usage of CP10 and CP11 (SIMD/VFP) */
-	cpacr &= ~CPACR_CP(10, CPACR_CP_ACCESS_FULL);
-	cpacr |= CPACR_CP(10, CPACR_CP_ACCESS_PL1_ONLY);
-	cpacr &= ~CPACR_CP(11, CPACR_CP_ACCESS_FULL);
-	cpacr |= CPACR_CP(11, CPACR_CP_ACCESS_PL1_ONLY);
+	/*
+	 * Enable Advanced SIMD functionality.
+	 * Enable use of D16-D31 of the Floating-point Extension register
+	 * file.
+	 */
+	cpacr &= ~(CPACR_ASEDIS | CPACR_D32DIS);
+	/*
+	 * Enable usage of CP10 and CP11 (SIMD/VFP) (both kernel and user
+	 * mode.
+	 */
+	cpacr |= CPACR_CP(10, CPACR_CP_ACCESS_FULL);
+	cpacr |= CPACR_CP(11, CPACR_CP_ACCESS_FULL);
 	write_cpacr(cpacr);
 }
 #endif /* ARM32 */

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -482,8 +482,10 @@ thread_und_handler:
 	cps	#CPSR_MODE_ABT
 	push	{r0-r11, ip}
 	cps	#CPSR_MODE_UND
-	sub	r1, lr, #4
 	mrs	r0, spsr
+	tst	r0, #CPSR_T
+	subne	r1, lr, #2
+	subeq	r1, lr, #4
 	cps	#CPSR_MODE_ABT
 	push	{r0, r1}
 	msr	spsr_fsxc, r0	/* In case some code reads spsr directly */

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -88,6 +88,7 @@ struct thread_vfp_state {
 	bool sec_lazy_saved;
 	struct vfp_state ns;
 	struct vfp_state sec;
+	struct thread_user_vfp_state *uvfp;
 };
 
 #endif /*CFG_WITH_VFP*/
@@ -137,7 +138,7 @@ struct thread_core_local {
 #ifdef ARM64
 #ifdef CFG_WITH_VFP
 #define THREAD_VFP_STATE_SIZE				\
-	(16 + (16 * 32 + 16) * 2)
+	(16 + (16 * 32 + 16) * 2 + 16)
 #else
 #define THREAD_VFP_STATE_SIZE				0
 #endif

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -96,7 +96,7 @@ void vfp_enable(void)
 {
 	uint32_t val = read_cpacr_el1();
 
-	val |= (CPACR_EL1_FPEN_EL1 << CPACR_EL1_FPEN_SHIFT);
+	val |= (CPACR_EL1_FPEN_EL0EL1 << CPACR_EL1_FPEN_SHIFT);
 	write_cpacr_el1(val);
 	isb();
 }

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -1,6 +1,7 @@
-arm32-platform-cpuarch = cortex-a7
-arm32-platform-cflags = -mcpu=$(arm32-platform-cpuarch)
-arm32-platform-aflags = -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cpuarch		:= cortex-a7
+arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags		+= -mcpu=$(arm32-platform-cpuarch)
+core_arm32-platform-aflags	+= -mfpu=neon
 
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_GENERIC_BOOT,y)

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -1,9 +1,10 @@
 PLATFORM_FLAVOR ?= ls1021atwr
 PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
 
-arm32-platform-cpuarch = cortex-a7
-arm32-platform-cflags = -mcpu=$(arm32-platform-cpuarch)
-arm32-platform-aflags = -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cpuarch		:= cortex-a7
+arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags		+= -mcpu=$(arm32-platform-cpuarch)
+core_arm32-platform-aflags	+= -mfpu=neon
 
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_ARM32_core,y)

--- a/core/arch/arm/plat-stm/conf.mk
+++ b/core/arch/arm/plat-stm/conf.mk
@@ -3,6 +3,7 @@ PLATFORM_FLAVOR ?= orly2
 arm32-platform-cpuarch		:= cortex-a9
 arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags		+= -mcpu=$(arm32-platform-cpuarch)
+core_arm32-platform-aflags	+= -mfpu=neon
 
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_SECURE_TIME_SOURCE_REE,y)

--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -1,6 +1,7 @@
-arm32-platform-cpuarch = cortex-a15
-arm32-platform-cflags	 = -mcpu=$(arm32-platform-cpuarch)
-arm32-platform-aflags	 = -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cpuarch		:= cortex-a15
+arm32-platform-cflags	 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags	 	+= -mcpu=$(arm32-platform-cpuarch)
+core_arm32-platform-aflags	+= -mfpu=neon
 
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)

--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -2,9 +2,10 @@ PLATFORM_FLAVOR ?= dra7xx
 PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
 
 # 32-bit flags
-arm32-platform-cpuarch	:= cortex-a15
-arm32-platform-cflags	+= -mcpu=$(arm32-platform-cpuarch)
-arm32-platform-aflags	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cpuarch		:= cortex-a15
+arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags		+= -mcpu=$(arm32-platform-cpuarch)
+core_arm32-platform-aflags	+= -mfpu=neon
 
 $(call force,CFG_8250_UART,y)
 $(call force,CFG_ARM32_core,y)

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -193,6 +193,8 @@ void tee_svc_handler(struct thread_svc_regs *regs)
 	COMPILE_TIME_ASSERT(ARRAY_SIZE(tee_svc_syscall_table) ==
 				(TEE_SCN_MAX + 1));
 
+	thread_user_save_vfp();
+
 	/* Restore IRQ which are disabled on exception entry */
 	thread_restore_irq();
 

--- a/core/core.mk
+++ b/core/core.mk
@@ -8,8 +8,8 @@ arch-dir	:= core/arch/$(ARCH)
 platform-dir	:= $(arch-dir)/plat-$(PLATFORM)
 include mk/checkconf.mk
 include $(platform-dir)/conf.mk
-include core/arch/$(ARCH)/$(ARCH).mk
 include mk/config.mk
+include core/arch/$(ARCH)/$(ARCH).mk
 
 # Setup compiler for this sub module
 CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
@@ -25,47 +25,62 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <compiler.h>
 #include "platform.h"
 #include <softfloat.h>
 
 /*
- * Helpers to convert between float32 and float, and float64 and double
- * used by the AEABI functions below.
+ * On ARM32 EABI defines both a soft-float ABI and a hard-float ABI,
+ * hard-float is basically a super set of soft-float. Hard-float requires
+ * all the support routines provided for soft-float, but the compiler may
+ * choose to optimize to not use some of them.
+ *
+ * The AEABI functions uses soft-float calling convention even if the
+ * functions are compiled for hard-float. So where float and double would
+ * have been expected we use aeabi_float_t and aeabi_double_t respectively
+ * instead.
  */
-static float f32_to_f(float32_t val)
+typedef unsigned aeabi_float_t;
+typedef unsigned long long aeabi_double_t;
+
+/*
+ * Helpers to convert between float32 and aeabi_float_t, and float64 and
+ * aeabi_double_t used by the AEABI functions below.
+ */
+static aeabi_float_t f32_to_f(float32_t val)
 {
 	union {
 		float32_t from;
-		float to;
+		aeabi_float_t to;
 	} res = { .from = val };
 
 	return res.to;
 }
 
-static float32_t f32_from_f(float val)
+static float32_t f32_from_f(aeabi_float_t val)
 {
 	union {
-		float from;
+		aeabi_float_t from;
 		float32_t to;
 	} res = { .from = val };
 
 	return res.to;
 }
 
-static double f64_to_d(float64_t val)
+static aeabi_double_t f64_to_d(float64_t val)
 {
 	union {
 		float64_t from;
-		double to;
+		aeabi_double_t to;
 	} res = { .from = val };
 
 	return res.to;
 }
 
-static float64_t f64_from_d(double val)
+static float64_t f64_from_d(aeabi_double_t val)
 {
 	union {
-		double from;
+		aeabi_double_t from;
 		float64_t to;
 	} res = { .from = val };
 
@@ -80,32 +95,32 @@ static float64_t f64_from_d(double val)
  */
 
 /*
- * Table 2, Standard double precision floating-point arithmetic helper
+ * Table 2, Standard aeabi_double_t precision floating-point arithmetic helper
  * functions
  */
 
-double __aeabi_dadd(double a, double b)
+aeabi_double_t __aeabi_dadd(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_to_d(f64_add(f64_from_d(a), f64_from_d(b)));
 }
 
-double __aeabi_ddiv(double a, double b)
+aeabi_double_t __aeabi_ddiv(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_to_d(f64_div(f64_from_d(a), f64_from_d(b)));
 }
 
-double __aeabi_dmul(double a, double b)
+aeabi_double_t __aeabi_dmul(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_to_d(f64_mul(f64_from_d(a), f64_from_d(b)));
 }
 
 
-double __aeabi_drsub(double a, double b)
+aeabi_double_t __aeabi_drsub(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_to_d(f64_sub(f64_from_d(b), f64_from_d(a)));
 }
 
-double __aeabi_dsub(double a, double b)
+aeabi_double_t __aeabi_dsub(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_to_d(f64_sub(f64_from_d(a), f64_from_d(b)));
 }
@@ -114,27 +129,27 @@ double __aeabi_dsub(double a, double b)
  * Table 3, double precision floating-point comparison helper functions
  */
 
-int __aeabi_dcmpeq(double a, double b)
+int __aeabi_dcmpeq(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_eq(f64_from_d(a), f64_from_d(b));
 }
 
-int __aeabi_dcmplt(double a, double b)
+int __aeabi_dcmplt(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_lt(f64_from_d(a), f64_from_d(b));
 }
 
-int __aeabi_dcmple(double a, double b)
+int __aeabi_dcmple(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_le(f64_from_d(a), f64_from_d(b));
 }
 
-int __aeabi_dcmpge(double a, double b)
+int __aeabi_dcmpge(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_le(f64_from_d(b), f64_from_d(a));
 }
 
-int __aeabi_dcmpgt(double a, double b)
+int __aeabi_dcmpgt(aeabi_double_t a, aeabi_double_t b)
 {
 	return f64_lt(f64_from_d(b), f64_from_d(a));
 }
@@ -144,27 +159,27 @@ int __aeabi_dcmpgt(double a, double b)
  * functions
  */
 
-float __aeabi_fadd(float a, float b)
+aeabi_float_t __aeabi_fadd(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_to_f(f32_add(f32_from_f(a), f32_from_f(b)));
 }
 
-float __aeabi_fdiv(float a, float b)
+aeabi_float_t __aeabi_fdiv(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_to_f(f32_div(f32_from_f(a), f32_from_f(b)));
 }
 
-float __aeabi_fmul(float a, float b)
+aeabi_float_t __aeabi_fmul(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_to_f(f32_mul(f32_from_f(a), f32_from_f(b)));
 }
 
-float __aeabi_frsub(float a, float b)
+aeabi_float_t __aeabi_frsub(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_to_f(f32_sub(f32_from_f(b), f32_from_f(a)));
 }
 
-float __aeabi_fsub(float a, float b)
+aeabi_float_t __aeabi_fsub(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_to_f(f32_sub(f32_from_f(a), f32_from_f(b)));
 }
@@ -174,27 +189,27 @@ float __aeabi_fsub(float a, float b)
  * functions
  */
 
-int __aeabi_fcmpeq(float a, float b)
+int __aeabi_fcmpeq(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_eq(f32_from_f(a), f32_from_f(b));
 }
 
-int __aeabi_fcmplt(float a, float b)
+int __aeabi_fcmplt(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_lt(f32_from_f(a), f32_from_f(b));
 }
 
-int __aeabi_fcmple(float a, float b)
+int __aeabi_fcmple(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_le(f32_from_f(a), f32_from_f(b));
 }
 
-int __aeabi_fcmpge(float a, float b)
+int __aeabi_fcmpge(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_le(f32_from_f(b), f32_from_f(a));
 }
 
-int __aeabi_fcmpgt(float a, float b)
+int __aeabi_fcmpgt(aeabi_float_t a, aeabi_float_t b)
 {
 	return f32_lt(f32_from_f(b), f32_from_f(a));
 }
@@ -203,42 +218,42 @@ int __aeabi_fcmpgt(float a, float b)
  * Table 6, Standard floating-point to integer conversions
  */
 
-int __aeabi_d2iz(double a)
+int __aeabi_d2iz(aeabi_double_t a)
 {
 	return f64_to_i32_r_minMag(f64_from_d(a), false);
 }
 
-unsigned __aeabi_d2uiz(double a)
+unsigned __aeabi_d2uiz(aeabi_double_t a)
 {
 	return f64_to_ui32_r_minMag(f64_from_d(a), false);
 }
 
-long long __aeabi_d2lz(double a)
+long long __aeabi_d2lz(aeabi_double_t a)
 {
 	return f64_to_i64_r_minMag(f64_from_d(a), false);
 }
 
-unsigned long long __aeabi_d2ulz(double a)
+unsigned long long __aeabi_d2ulz(aeabi_double_t a)
 {
 	return f64_to_ui64_r_minMag(f64_from_d(a), false);
 }
 
-int __aeabi_f2iz(float a)
+int __aeabi_f2iz(aeabi_float_t a)
 {
 	return f32_to_i32_r_minMag(f32_from_f(a), false);
 }
 
-unsigned __aeabi_f2uiz(float a)
+unsigned __aeabi_f2uiz(aeabi_float_t a)
 {
 	return f32_to_ui32_r_minMag(f32_from_f(a), false);
 }
 
-long long __aeabi_f2lz(float a)
+long long __aeabi_f2lz(aeabi_float_t a)
 {
 	return f32_to_i64_r_minMag(f32_from_f(a), false);
 }
 
-unsigned long long __aeabi_f2ulz(float a)
+unsigned long long __aeabi_f2ulz(aeabi_float_t a)
 {
 	return f32_to_ui64_r_minMag(f32_from_f(a), false);
 }
@@ -247,12 +262,12 @@ unsigned long long __aeabi_f2ulz(float a)
  * Table 7, Standard conversions between floating types
  */
 
-float __aeabi_d2f(double a)
+aeabi_float_t __aeabi_d2f(aeabi_double_t a)
 {
 	return f32_to_f(f64_to_f32(f64_from_d(a)));
 }
 
-double __aeabi_f2d(float a)
+aeabi_double_t __aeabi_f2d(aeabi_float_t a)
 {
 	return f64_to_d(f32_to_f64(f32_from_f(a)));
 }
@@ -261,42 +276,42 @@ double __aeabi_f2d(float a)
  * Table 8, Standard integer to floating-point conversions
  */
 
-double __aeabi_i2d(int a)
+aeabi_double_t __aeabi_i2d(int a)
 {
 	return f64_to_d(i32_to_f64(a));
 }
 
-double __aeabi_ui2d(unsigned a)
+aeabi_double_t __aeabi_ui2d(unsigned a)
 {
 	return f64_to_d(ui32_to_f64(a));
 }
 
-double __aeabi_l2d(long long a)
+aeabi_double_t __aeabi_l2d(long long a)
 {
 	return f64_to_d(i64_to_f64(a));
 }
 
-double __aeabi_ul2d(unsigned long long a)
+aeabi_double_t __aeabi_ul2d(unsigned long long a)
 {
 	return f64_to_d(ui64_to_f64(a));
 }
 
-float __aeabi_i2f(int a)
+aeabi_float_t __aeabi_i2f(int a)
 {
 	return f32_to_f(i32_to_f32(a));
 }
 
-float __aeabi_ui2f(unsigned a)
+aeabi_float_t __aeabi_ui2f(unsigned a)
 {
 	return f32_to_f(ui32_to_f32(a));
 }
 
-float __aeabi_l2f(long long a)
+aeabi_float_t __aeabi_l2f(long long a)
 {
 	return f32_to_f(i64_to_f32(a));
 }
 
-float __aeabi_ul2f(unsigned long long a)
+aeabi_float_t __aeabi_ul2f(unsigned long long a)
 {
 	return f32_to_f(ui64_to_f32(a));
 }

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -104,5 +104,13 @@ TA_SIGN_KEY ?= keys/default_ta.pem
 # may not because they obtain the isoc functions from elsewhere
 CFG_LIBUTILS_WITH_ISOC ?= y
 
-# Floating point support for TAs default on only for arm32 core
-CFG_TA_FLOAT_SUPPORT ?= $(CFG_ARM32_core)
+# Enables floating point support for user TAs
+# ARM32: EABI defines both a soft-float ABI and a hard-float ABI,
+#	 hard-float is basically a super set of soft-float. Hard-float
+#	 requires all the support routines provided for soft-float, but the
+#	 compiler may choose to optimize to not use some of them and use
+#	 the floating-point registers instead.
+# ARM64: EABI doesn't define a soft-float ABI, everything is hard-float (or
+#	 nothing with ` -mgeneral-regs-only`)
+# With CFG_TA_FLOAT_SUPPORT enabled TA code is free use floating point types
+CFG_TA_FLOAT_SUPPORT ?= y


### PR DESCRIPTION
Adds support for hard-float in TAs. Hard-float is enabled by default for
all platforms which are capable, currently all. Soft-float is still
available if needed.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU, FVP)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>