### PR TITLE
core: introduce __maybe_unused

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -40,7 +40,7 @@ enum fault_type {
 	FAULT_TYPE_IGNORE,
 };
 
-static __unused const char *abort_type_to_str(uint32_t abort_type)
+static __maybe_unused const char *abort_type_to_str(uint32_t abort_type)
 {
 	if (abort_type == ABORT_TYPE_DATA)
 		return "data";
@@ -49,8 +49,9 @@ static __unused const char *abort_type_to_str(uint32_t abort_type)
 	return "undef";
 }
 
-static __unused void print_detailed_abort(struct abort_info *ai __unused,
-				const char *ctx __unused)
+static __maybe_unused void print_detailed_abort(
+				struct abort_info *ai __maybe_unused,
+				const char *ctx __maybe_unused)
 {
 	EMSG_RAW("\n");
 	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "\n",
@@ -114,7 +115,7 @@ static __unused void print_detailed_abort(struct abort_info *ai __unused,
 #endif /*ARM64*/
 }
 
-static void print_user_abort(struct abort_info *ai __unused)
+static void print_user_abort(struct abort_info *ai __maybe_unused)
 {
 #ifdef CFG_TEE_CORE_TA_TRACE
 	print_detailed_abort(ai, "user TA");
@@ -122,14 +123,14 @@ static void print_user_abort(struct abort_info *ai __unused)
 #endif
 }
 
-void abort_print(struct abort_info *ai __unused)
+void abort_print(struct abort_info *ai __maybe_unused)
 {
 #if (TRACE_LEVEL >= TRACE_INFO)
 	print_detailed_abort(ai, "core");
 #endif /*TRACE_LEVEL >= TRACE_DEBUG*/
 }
 
-void abort_print_error(struct abort_info *ai __unused)
+void abort_print_error(struct abort_info *ai __maybe_unused)
 {
 #if (TRACE_LEVEL >= TRACE_INFO)
 	/* full verbose log at DEBUG level */

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -71,7 +71,7 @@ __weak void main_init_gic(void)
 }
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
-void init_sec_mon(uint32_t nsec_entry __unused)
+void init_sec_mon(uint32_t nsec_entry __maybe_unused)
 {
 	assert(nsec_entry == PADDR_INVALID);
 	/* Do nothing as we don't have a secure monitor */
@@ -359,7 +359,8 @@ uint32_t *generic_boot_init_primary(uint32_t pageable_part)
 	return thread_vector_table;
 }
 
-uint32_t generic_boot_cpu_on_handler(uint32_t a0 __unused, uint32_t a1 __unused)
+uint32_t generic_boot_cpu_on_handler(uint32_t a0 __maybe_unused,
+				     uint32_t a1 __unused)
 {
 	DMSG("cpu %zu: a0 0x%x", get_core_pos(), a0);
 	init_secondary_helper(PADDR_INVALID);

--- a/core/arch/arm/kernel/tee_ta_manager.c
+++ b/core/arch/arm/kernel/tee_ta_manager.c
@@ -666,7 +666,7 @@ TEE_Result tee_ta_get_client_id(TEE_Identity *id)
 static void dump_state(struct tee_ta_ctx *ctx)
 {
 	struct tee_ta_session *s = NULL;
-	bool active __unused;
+	bool active __maybe_unused;
 
 	active = ((tee_ta_get_current_session(&s) == TEE_SUCCESS) &&
 		  s && s->ctx == ctx);

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -872,7 +872,7 @@ void thread_init_primary(const struct thread_handlers *handlers)
 	init_thread_stacks();
 }
 
-static void init_sec_mon(size_t __unused pos)
+static void init_sec_mon(size_t pos __maybe_unused)
 {
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)
 	/* Initialize secure monitor */

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -598,7 +598,7 @@ static void user_ta_enter_close_session(struct tee_ta_session *s)
 
 static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 {
-	struct user_ta_ctx *utc __unused = to_user_ta_ctx(ctx);
+	struct user_ta_ctx *utc __maybe_unused = to_user_ta_ctx(ctx);
 
 	EMSG_RAW("- load addr : 0x%x    ctx-idr: %d",
 		 utc->load_addr, utc->context);

--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -41,13 +41,13 @@ void wq_init(struct wait_queue *wq)
 	*wq = (struct wait_queue)WAIT_QUEUE_INITIALIZER;
 }
 
-static void wq_rpc(uint32_t cmd, int id, const void *sync_obj __unused,
-			const char *fname, int lineno __unused)
+static void wq_rpc(uint32_t cmd, int id, const void *sync_obj __maybe_unused,
+			const char *fname, int lineno __maybe_unused)
 {
 	uint32_t ret;
 	struct tee_ta_session *sess = NULL;
 	struct teesmc32_param params[2];
-	const char *cmd_str __unused =
+	const char *cmd_str __maybe_unused =
 		cmd == TEE_RPC_WAIT_QUEUE_SLEEP ? "sleep" : "wake";
 
 	if (fname)
@@ -157,7 +157,7 @@ void wq_wake_one(struct wait_queue *wq, const void *sync_obj,
 
 void wq_promote_condvar(struct wait_queue *wq, struct condvar *cv,
 			bool only_one, const void *sync_obj __unused,
-			const char *fname, int lineno __unused)
+			const char *fname, int lineno __maybe_unused)
 {
 	uint32_t old_itr_status;
 	struct wait_queue_elem *wqe;

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -120,7 +120,7 @@ static void main_fiq(void)
 	iar = gic_read_iar();
 
 	while (pl011_have_rx_data(CONSOLE_UART_BASE)) {
-		int ch __unused = pl011_getchar(CONSOLE_UART_BASE);
+		int ch __maybe_unused = pl011_getchar(CONSOLE_UART_BASE);
 
 		DMSG("cpu %zu: got 0x%x", get_core_pos(), ch);
 	}

--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -28,8 +28,8 @@
 #include <kernel/panic.h>
 #include <trace.h>
 
-void __panic(const char *file __unused, int line __unused,
-		const char *func __unused)
+void __panic(const char *file __maybe_unused, int line __maybe_unused,
+		const char *func __maybe_unused)
 {
 	EMSG_RAW("PANIC: %s %s:%d\n", func, file, line);
 	while (1)

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -1980,10 +1980,13 @@ static void get_des2_key(const uint8_t *key, size_t key_len,
 	}
 }
 
-static TEE_Result cipher_init(void *ctx, uint32_t algo, TEE_OperationMode mode,
+static TEE_Result cipher_init(void *ctx, uint32_t algo,
+			      TEE_OperationMode mode __maybe_unused,
 			      const uint8_t *key1, size_t key1_len,
-			      const uint8_t *key2, size_t key2_len,
-			      const uint8_t *iv, size_t iv_len)
+			      const uint8_t *key2 __maybe_unused,
+			      size_t key2_len __maybe_unused,
+			      const uint8_t *iv __maybe_unused,
+			      size_t iv_len __maybe_unused)
 {
 	TEE_Result res;
 	int ltc_res, ltc_cipherindex;
@@ -1996,19 +1999,6 @@ static TEE_Result cipher_init(void *ctx, uint32_t algo, TEE_OperationMode mode,
 	struct tee_symmetric_xts *xts;
 #endif
 
-	/* Unused parameters */
-#if !defined(CFG_CRYPTO_CTS) && !defined(CFG_CRYPTO_XTS)
-	(void)key2;
-	(void)key2_len;
-#endif
-#if !defined(CFG_CRYPTO_CBC) && !defined(CFG_CRYPTO_CTR) && \
-	!defined(CFG_CRYPTO_CTS) && !defined(CFG_CRYPTO_XTS)
-	(void)iv;
-	(void)iv_len;
-#endif
-#if !defined(CFG_CRYPTO_CTS)
-	(void)mode;
-#endif
 	res = tee_algo_to_ltc_cipherindex(algo, &ltc_cipherindex);
 	if (res != TEE_SUCCESS)
 		return TEE_ERROR_NOT_SUPPORTED;
@@ -2111,8 +2101,8 @@ static TEE_Result cipher_init(void *ctx, uint32_t algo, TEE_OperationMode mode,
 
 static TEE_Result cipher_update(void *ctx, uint32_t algo,
 				TEE_OperationMode mode,
-				bool last_block, const uint8_t *data,
-				size_t len, uint8_t *dst)
+				bool last_block __maybe_unused,
+				const uint8_t *data, size_t len, uint8_t *dst)
 {
 	int ltc_res = CRYPT_OK;
 #if defined(CFG_CRYPTO_CTS)
@@ -2120,11 +2110,6 @@ static TEE_Result cipher_update(void *ctx, uint32_t algo,
 #endif
 #if defined(CFG_CRYPTO_XTS)
 	struct tee_symmetric_xts *xts;
-#endif
-
-#if !defined(CFG_CRYPTO_AES) || !defined(CFG_CRYPTO_CTS)
-	/* Unused parameters */
-	(void)last_block;
 #endif
 
 	switch (algo) {
@@ -2566,8 +2551,8 @@ static TEE_Result authenc_init(void *ctx, uint32_t algo,
 			       TEE_OperationMode mode __unused,
 			       const uint8_t *key, size_t key_len,
 			       const uint8_t *nonce, size_t nonce_len,
-			       size_t tag_len, size_t aad_len,
-			       size_t payload_len)
+			       size_t tag_len, size_t aad_len __maybe_unused,
+			       size_t payload_len __maybe_unused)
 {
 	TEE_Result res;
 	int ltc_res;
@@ -2577,11 +2562,6 @@ static TEE_Result authenc_init(void *ctx, uint32_t algo,
 #endif
 #if defined(CFG_CRYPTO_GCM)
 	struct tee_gcm_state *gcm;
-#endif
-
-#if !defined(CFG_CRYPTO_CCM)
-	(void)aad_len;
-	(void)payload_len;
 #endif
 
 	res = tee_algo_to_ltc_cipherindex(algo, &ltc_cipherindex);

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -48,7 +48,7 @@
 
 vaddr_t tee_svc_uref_base;
 
-void syscall_log(const void *buf __unused, size_t len __unused)
+void syscall_log(const void *buf __maybe_unused, size_t len __maybe_unused)
 {
 #ifdef CFG_TEE_CORE_TA_TRACE
 	char *kbuf;
@@ -74,16 +74,19 @@ TEE_Result syscall_not_supported(void)
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-uint32_t syscall_dummy(uint32_t *a __unused)
+uint32_t syscall_dummy(uint32_t *a __maybe_unused)
 {
 	DMSG("tee_svc_sys_dummy: a 0x%" PRIxVA, (vaddr_t)a);
 	return 0;
 }
 
-uint32_t syscall_dummy_7args(unsigned long a1 __unused,
-			unsigned long a2 __unused, unsigned long a3 __unused,
-			unsigned long a4 __unused, unsigned long a5 __unused,
-			unsigned long a6 __unused, unsigned long a7 __unused)
+uint32_t syscall_dummy_7args(unsigned long a1 __maybe_unused,
+			     unsigned long a2 __maybe_unused,
+			     unsigned long a3 __maybe_unused,
+			     unsigned long a4 __maybe_unused,
+			     unsigned long a5 __maybe_unused,
+			     unsigned long a6 __maybe_unused,
+			     unsigned long a7 __maybe_unused)
 {
 	DMSG("tee_svc_sys_dummy_7args: 0x%lx, 0x%lx, 0x%lx, 0x%lx, 0x%lx, %lx, %lx\n",
 	     a1, a2, a3, a4, a5, a6, a7);

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2105,9 +2105,9 @@ TEE_Result syscall_cryp_state_free(unsigned long state)
 	return TEE_SUCCESS;
 }
 
-/* iv and iv_len are ignored for some algorithms */
-TEE_Result syscall_hash_init(unsigned long state, const void *iv __unused,
-			size_t iv_len __unused)
+TEE_Result syscall_hash_init(unsigned long state,
+			     const void *iv __maybe_unused,
+			     size_t iv_len __maybe_unused)
 {
 	TEE_Result res;
 	struct tee_cryp_state *cs;

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -30,8 +30,8 @@
 #include <tee_internal_api_extensions.h>
 #include <utee_syscalls.h>
 
-void _assert_log(const char *expr __unused, const char *file __unused,
-		 int line __unused)
+void _assert_log(const char *expr __maybe_unused,
+		 const char *file __maybe_unused, int line __maybe_unused)
 {
 	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
 }

--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -43,6 +43,7 @@
 #define __noinline	__attribute__((noinline))
 #define __attr_const	__attribute__((__const__))
 #define __unused	__attribute__((unused))
+#define __maybe_unused	__attribute__((unused))
 #define __used		__attribute__((__used__))
 #define __must_check	__attribute__((warn_unused_result))
 #define __cold		__attribute__((__cold__))


### PR DESCRIPTION
When a variable, parameter or function may or may not be referenced
depending on some conditional compilation setting, mark it with
__maybe_unused instead of __unused.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>