### PR TITLE
core: remove registration of svc and abort handlers

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -212,9 +212,6 @@ struct thread_svc_regs {
 #endif /*ARM64*/
 
 #ifndef ASM
-typedef void (*thread_abort_handler_t)(uint32_t abort_type,
-			struct thread_abort_regs *regs);
-typedef void (*thread_svc_handler_t)(struct thread_svc_regs *regs);
 typedef void (*thread_smc_handler_t)(struct thread_smc_args *args);
 typedef void (*thread_fiq_handler_t)(void);
 typedef uint32_t (*thread_pm_handler_t)(uint32_t a0, uint32_t a1);
@@ -260,24 +257,6 @@ struct thread_handlers {
 	thread_pm_handler_t cpu_resume;
 	thread_pm_handler_t system_off;
 	thread_pm_handler_t system_reset;
-
-
-	/*
-	 * The SVC handler is called as a normal function and should do
-	 * a normal return. Note that IRQ is masked when this function
-	 * is called, it's permitted for the function to unmask IRQ.
-	 */
-	thread_svc_handler_t svc;
-
-	/*
-	 * The abort handler is called as a normal function and should do
-	 * a normal return. The abort handler is called when an undefined,
-	 * prefetch abort, or data abort exception is received. In all
-	 * cases the abort handler is executing in abort mode. If IRQ is
-	 * unmasked in the abort handler it has to have separate abort
-	 * stacks for each thread.
-	 */
-	thread_abort_handler_t abort;
 };
 void thread_init_primary(const struct thread_handlers *handlers);
 void thread_init_per_cpu(void);

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -141,8 +141,6 @@ const vaddr_t stack_tmp_top[CFG_TEE_CORE_NB_CORE] = {
 thread_smc_handler_t thread_std_smc_handler_ptr;
 static thread_smc_handler_t thread_fast_smc_handler_ptr;
 thread_fiq_handler_t thread_fiq_handler_ptr;
-thread_svc_handler_t thread_svc_handler_ptr;
-static thread_abort_handler_t thread_abort_handler_ptr;
 thread_pm_handler_t thread_cpu_on_handler_ptr;
 thread_pm_handler_t thread_cpu_off_handler_ptr;
 thread_pm_handler_t thread_cpu_suspend_handler_ptr;
@@ -561,11 +559,6 @@ void __thread_std_smc_entry(struct thread_smc_args *args)
 	thread_std_smc_handler_ptr(args);
 }
 
-void thread_handle_abort(uint32_t abort_type, struct thread_abort_regs *regs)
-{
-	thread_abort_handler_ptr(abort_type, regs);
-}
-
 void *thread_get_tmp_sp(void)
 {
 	struct thread_core_local *l = thread_get_core_local();
@@ -717,8 +710,6 @@ static void init_handlers(const struct thread_handlers *handlers)
 	thread_std_smc_handler_ptr = handlers->std_smc;
 	thread_fast_smc_handler_ptr = handlers->fast_smc;
 	thread_fiq_handler_ptr = handlers->fiq;
-	thread_svc_handler_ptr = handlers->svc;
-	thread_abort_handler_ptr = handlers->abort;
 	thread_cpu_on_handler_ptr = handlers->cpu_on;
 	thread_cpu_off_handler_ptr = handlers->cpu_off;
 	thread_cpu_suspend_handler_ptr = handlers->cpu_suspend;

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -515,7 +515,7 @@ thread_pabort_handler:
 	cps	#CPSR_MODE_ABT
 	push	{r1-r3}
 	mov	r1, sp
-	bl	thread_handle_abort
+	bl	abort_handler
 	pop	{r1-r3}
 	cps	#CPSR_MODE_SYS
 	mov	sp, r1
@@ -533,9 +533,7 @@ LOCAL_FUNC thread_svc_handler , :
 	mrs	r0, spsr
 	push	{r0}
 	mov	r0, sp
-	ldr	lr, =thread_svc_handler_ptr;
-	ldr	lr, [lr]
-	blx	lr
+	bl	tee_svc_handler
 	pop	{r0}
 	msr	spsr_fsxc, r0
 	pop	{r0-r7, lr}

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -492,10 +492,8 @@ LOCAL_FUNC el0_svc , :
 	 */
 	msr	daifclr, #(DAIFBIT_FIQ | DAIFBIT_ABT | DAIFBIT_DBG)
 
-	/* Call the registered handler */
-	adr	x16, thread_svc_handler_ptr
-	ldr	x16, [x16]
-	blr	x16
+	/* Call the handler */
+	bl	tee_svc_handler
 
 	/* Mask all maskable exceptions since we're switching back to sp_el1 */
 	msr	daifset, #DAIFBIT_ALL
@@ -576,7 +574,7 @@ LOCAL_FUNC el1_sync_abort , :
 	 */
 	mov	x0, #0
 	mov	x1, sp
-	bl	thread_handle_abort
+	bl	abort_handler
 
 	/*
 	 * Restore state from stack
@@ -648,7 +646,7 @@ LOCAL_FUNC el0_sync_abort , :
 	 */
 	mov	x0, #0
 	mov	x1, sp
-	bl	thread_handle_abort
+	bl	abort_handler
 
 	/*
 	 * Restore state from stack

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -191,8 +191,6 @@ void thread_init_vbar(void);
 /* Handles a stdcall, r0-r7 holds the parameters */
 void thread_std_smc_entry(void);
 
-void thread_handle_abort(uint32_t abort_type, struct thread_abort_regs *regs);
-
 struct thread_core_local *thread_get_core_local(void);
 
 /*

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -33,7 +33,6 @@
 #include <mm/tee_pager.h>
 #include <platform_config.h>
 #include <stdint.h>
-#include <tee/arch_svc.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 
@@ -43,8 +42,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 	.cpu_on = cpu_on_handler,
 	.cpu_off = pm_do_nothing,
 	.cpu_suspend = pm_do_nothing,

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -30,10 +30,8 @@
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
-#include <mm/tee_pager.h>
 #include <platform_config.h>
 #include <stdint.h>
-#include <tee/arch_svc.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 
@@ -43,8 +41,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 	.cpu_on = pm_panic,
 	.cpu_off = pm_panic,
 	.cpu_suspend = pm_panic,

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -33,10 +33,8 @@
 #include <kernel/thread.h>
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
-#include <mm/tee_pager.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
-#include <tee/arch_svc.h>
 
 static void main_fiq(void);
 
@@ -44,8 +42,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 	.cpu_on = pm_panic,
 	.cpu_off = pm_panic,
 	.cpu_suspend = pm_panic,

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -30,10 +30,8 @@
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
-#include <mm/tee_pager.h>
 #include <platform_config.h>
 #include <stdint.h>
-#include <tee/arch_svc.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 
@@ -43,8 +41,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 	.cpu_on = cpu_on_handler,
 	.cpu_off = pm_do_nothing,
 	.cpu_suspend = pm_do_nothing,

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -30,10 +30,8 @@
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
-#include <mm/tee_pager.h>
 #include <platform_config.h>
 #include <stdint.h>
-#include <tee/arch_svc.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 #include <asc.h>
@@ -44,8 +42,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 	.cpu_on = pm_panic,
 	.cpu_off = pm_panic,
 	.cpu_suspend = pm_panic,

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -42,13 +42,11 @@
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
 #include <kernel/misc.h>
-#include <mm/tee_pager.h>
 #include <mm/tee_mmu.h>
 #include <mm/core_mmu.h>
 #include <mm/tee_mmu_defs.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
-#include <tee/arch_svc.h>
 #include <platform.h>
 #include <util.h>
 #include <trace.h>
@@ -66,8 +64,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = main_tee_entry_std,
 	.fast_smc = main_tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 	.cpu_on = pm_panic,
 	.cpu_off = pm_panic,
 	.cpu_suspend = pm_panic,

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -40,11 +40,9 @@
 #include <kernel/misc.h>
 #include <kernel/mutex.h>
 #include <kernel/tee_time.h>
-#include <mm/tee_pager.h>
 #include <mm/core_mmu.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
-#include <tee/arch_svc.h>
 #include <console.h>
 #include <sm/sm.h>
 
@@ -54,8 +52,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 	.cpu_on = pm_panic,
 	.cpu_off = pm_panic,
 	.cpu_suspend = pm_panic,

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -39,10 +39,8 @@
 #include <trace.h>
 #include <kernel/misc.h>
 #include <kernel/tee_time.h>
-#include <mm/tee_pager.h>
 #include <tee/entry_fast.h>
 #include <tee/entry_std.h>
-#include <tee/arch_svc.h>
 #include <console.h>
 
 static void main_fiq(void);
@@ -51,8 +49,6 @@ static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.fiq = main_fiq,
-	.svc = tee_svc_handler,
-	.abort = abort_handler,
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 	.cpu_on = cpu_on_handler,
 	.cpu_off = pm_do_nothing,


### PR DESCRIPTION
Removes the possibility to register svc and abort handlers as the same
handler is always used. The svc and abort handlers are also so closely
tied to thread system that it would be difficult and error prone to use
alternative handlers.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (FVP)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>