### PR TITLE
RPMB encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,7 @@ script:
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_ENC_FS=y CFG_FS_BLOCK_CACHE=y
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_ENC_FS=n CFG_FS_BLOCK_CACHE=y
   - make -j8 all -s PLATFORM=vexpress-qemu_virt CFG_WITH_STATS=y
+  - make -j8 -s CFG_RPMB_FS=y
   - make -j8 -s CFG_RPMB_FS=y CFG_ENC_FS=n
   - make -j8 -s CFG_RPMB_FS=y CFG_ENC_FS=n CFG_RPMB_TESTKEY=y
 

--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -190,7 +190,7 @@ static TEE_Result tee_rpmb_key_gen(uint16_t dev_id __unused,
 		goto out;
 	}
 
-	IMSG("RPMB: Using test key");
+	DMSG("RPMB: Using test key");
 	memcpy(key, rpmb_test_key, RPMB_KEY_MAC_SIZE);
 
 out:
@@ -854,7 +854,7 @@ static TEE_Result tee_rpmb_verify_key_sync_counter(uint16_t dev_id)
 		rpmb_ctx->wr_cnt_synced = true;
 	}
 
-	IMSG("Verify key returning 0x%x\n", res);
+	DMSG("Verify key returning 0x%x\n", res);
 	return res;
 }
 
@@ -933,7 +933,7 @@ static TEE_Result tee_rpmb_init(uint16_t dev_id)
 	rpmb_ctx->dev_id = dev_id;
 
 	if (!rpmb_ctx->dev_info_synced) {
-		IMSG("RPMB: Syncing device information");
+		DMSG("RPMB: Syncing device information");
 
 		dev_info.rpmb_size_mult = 0;
 		dev_info.rel_wr_sec_c = 0;
@@ -941,8 +941,8 @@ static TEE_Result tee_rpmb_init(uint16_t dev_id)
 		if (res != TEE_SUCCESS)
 			goto func_exit;
 
-		IMSG("RPMB: RPMB size is %d*128 KB", dev_info.rpmb_size_mult);
-		IMSG("RPMB: Reliable Write Sector Count is %d",
+		DMSG("RPMB: RPMB size is %d*128 KB", dev_info.rpmb_size_mult);
+		DMSG("RPMB: Reliable Write Sector Count is %d",
 		     dev_info.rel_wr_sec_c);
 
 		if (dev_info.rpmb_size_mult == 0) {
@@ -974,7 +974,7 @@ static TEE_Result tee_rpmb_init(uint16_t dev_id)
 	}
 
 	if (!rpmb_ctx->key_derived) {
-		IMSG("RPMB INIT: Deriving key");
+		DMSG("RPMB INIT: Deriving key");
 
 		res = tee_rpmb_key_gen(dev_id, rpmb_ctx->key,
 				       RPMB_KEY_MAC_SIZE);
@@ -986,17 +986,17 @@ static TEE_Result tee_rpmb_init(uint16_t dev_id)
 
 	/* Perform a write counter read to verify if the key is ok. */
 	if (!rpmb_ctx->wr_cnt_synced || !rpmb_ctx->key_verified) {
-		IMSG("RPMB INIT: Verifying Key");
+		DMSG("RPMB INIT: Verifying Key");
 
 		res = tee_rpmb_verify_key_sync_counter(dev_id);
 		if (res != TEE_SUCCESS && !rpmb_ctx->key_verified) {
 			/*
 			 * Need to write the key here and verify it.
 			 */
-			IMSG("RPMB INIT: Writing Key");
+			DMSG("RPMB INIT: Writing Key");
 			res = tee_rpmb_write_key(dev_id);
 			if (res == TEE_SUCCESS) {
-				IMSG("RPMB INIT: Verifying Key");
+				DMSG("RPMB INIT: Verifying Key");
 				res = tee_rpmb_verify_key_sync_counter(dev_id);
 			}
 		}
@@ -1057,8 +1057,8 @@ static TEE_Result tee_rpmb_read_unlocked(uint16_t dev_id, uint32_t addr,
 
 	req->block_count = blkcnt;
 
-	DMSG("BLOCK READ %u block%s at index %u", blkcnt,
-	     ((blkcnt > 1) ? "s" : ""), blk_idx);
+	DMSG("Read %u block%s at index %u", blkcnt, ((blkcnt > 1) ? "s" : ""),
+	     blk_idx);
 
 	res = tee_rpmb_invoke(&mem);
 	if (res != TEE_SUCCESS)
@@ -1119,8 +1119,8 @@ static TEE_Result tee_rpmb_write_blk(uint16_t dev_id,
 	uint16_t tmp_blk_idx;
 	uint16_t i;
 
-	DMSG("BLOCK WRITE %u block%s at index %u", blkcnt,
-	     ((tmp_blkcnt > 1) ? "s" : ""), blk_idx);
+	DMSG("Write %u block%s at index %u", blkcnt, ((blkcnt > 1) ? "s" : ""),
+	     blk_idx);
 
 	if (!data_blks || !blkcnt)
 		return TEE_ERROR_BAD_PARAMETERS;

--- a/core/include/tee/tee_fs_key_manager.h
+++ b/core/include/tee/tee_fs_key_manager.h
@@ -68,4 +68,7 @@ TEE_Result tee_fs_decrypt_file(enum tee_fs_file_type file_type,
 		const uint8_t *data_in, size_t data_in_size,
 		uint8_t *plaintext, size_t *plaintext_size,
 		uint8_t *encrypted_fek);
+TEE_Result tee_fs_crypt_block(uint8_t *out, const uint8_t *in, size_t size,
+			      uint16_t blk_idx, const uint8_t *encrypted_fek,
+			      TEE_OperationMode mode);
 #endif

--- a/core/include/tee/tee_rpmb.h
+++ b/core/include/tee/tee_rpmb.h
@@ -37,9 +37,11 @@
  * @addr       Byte address of data.
  * @data       Pointer to the data.
  * @len        Size of data in bytes.
+ * @fek        SSK-encrypted File Encryption Key or NULL.
  */
 TEE_Result tee_rpmb_read(uint16_t dev_id,
-			 uint32_t addr, uint8_t *data, uint32_t len);
+			 uint32_t addr, uint8_t *data, uint32_t len,
+			 uint8_t *fek);
 
 /*
  * Write RPMB data in bytes.
@@ -48,9 +50,11 @@ TEE_Result tee_rpmb_read(uint16_t dev_id,
  * @addr       Byte address of data.
  * @data       Pointer to the data.
  * @len        Size of data in bytes.
+ * @fek        SSK-encrypted File Encryption Key or NULL.
  */
 TEE_Result tee_rpmb_write(uint16_t dev_id,
-			  uint32_t addr, uint8_t *data, uint32_t len);
+			  uint32_t addr, uint8_t *data, uint32_t len,
+			  uint8_t *fek);
 
 /*
  * Read the RPMB write counter.

--- a/core/include/tee/tee_rpmb_fs.h
+++ b/core/include/tee/tee_rpmb_fs.h
@@ -33,7 +33,7 @@
 #include <tee_api_types.h>
 #include <tee/tee_fs.h>
 
-#define TEE_RPMB_FS_FILENAME_LENGTH 112
+#define TEE_RPMB_FS_FILENAME_LENGTH 224
 
 struct tee_rpmb_fs_stat {
 	size_t size;

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -27,7 +27,6 @@ srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
 srcs-$(CFG_CRYPTO_PBKDF2) += tee_cryp_pbkdf2.c
 
 ifeq (y,$(CFG_RPMB_FS))
-$(call force,CFG_ENC_FS,n)
 srcs-y += tee_rpmb_fs_common.c
 srcs-y += tee_rpmb_fs.c
 else

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -47,6 +47,7 @@
 #include <tee/tee_fs_key_manager.h>
 #include <compiler.h>
 #include <trace.h>
+#include <util.h>
 
 struct tee_fs_ssk {
 	bool is_init;
@@ -401,6 +402,139 @@ TEE_Result tee_fs_decrypt_file(enum tee_fs_file_type file_type,
 
 	return do_auth_enc(TEE_MODE_DECRYPT, &km_hdr, fek, TEE_FS_KM_FEK_SIZE,
 			cipher, cipher_size, plaintext, plaintext_size);
+}
+
+static TEE_Result sha256(uint8_t *out, size_t out_size, const uint8_t *in,
+			 size_t in_size)
+{
+	TEE_Result res;
+	uint8_t *ctx = NULL;
+	size_t ctx_size;
+	uint32_t algo = TEE_ALG_SHA256;
+
+	res = crypto_ops.hash.get_ctx_size(algo, &ctx_size);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	ctx = malloc(ctx_size);
+	if (!ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = crypto_ops.hash.init(ctx, algo);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = crypto_ops.hash.update(ctx, algo, in, in_size);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = crypto_ops.hash.final(ctx, algo, out, out_size);
+
+out:
+	free(ctx);
+	return res;
+}
+
+static TEE_Result aes_ecb(uint8_t out[TEE_AES_BLOCK_SIZE],
+			  const uint8_t in[TEE_AES_BLOCK_SIZE],
+			  const uint8_t *key, size_t key_size)
+{
+	TEE_Result res;
+	uint8_t *ctx = NULL;
+	size_t ctx_size;
+	uint32_t algo = TEE_ALG_AES_ECB_NOPAD;
+
+	res = crypto_ops.cipher.get_ctx_size(algo, &ctx_size);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	ctx = malloc(ctx_size);
+	if (!ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = crypto_ops.cipher.init(ctx, algo, TEE_MODE_ENCRYPT, key,
+				     key_size, NULL, 0, NULL, 0);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = crypto_ops.cipher.update(ctx, algo, TEE_MODE_ENCRYPT, true, in,
+				       TEE_AES_BLOCK_SIZE, out);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	crypto_ops.cipher.final(ctx, algo);
+	res = TEE_SUCCESS;
+
+out:
+	free(ctx);
+	return res;
+}
+
+static TEE_Result essiv(uint8_t iv[TEE_AES_BLOCK_SIZE],
+			const uint8_t fek[TEE_FS_KM_FEK_SIZE],
+			uint16_t blk_idx)
+{
+	TEE_Result res;
+	uint8_t sha[TEE_SHA256_HASH_SIZE];
+	uint8_t pad_blkid[TEE_AES_BLOCK_SIZE] = { 0, };
+
+	res = sha256(sha, sizeof(sha), fek, TEE_FS_KM_FEK_SIZE);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	pad_blkid[0] = (blk_idx & 0xFF);
+	pad_blkid[1] = (blk_idx & 0xFF00) >> 8;
+
+	return aes_ecb(iv, pad_blkid, sha, 16);
+}
+
+/*
+ * Encryption/decryption of RPMB FS file data. This is AES CBC with ESSIV.
+ */
+TEE_Result tee_fs_crypt_block(uint8_t *out, const uint8_t *in, size_t size,
+			      uint16_t blk_idx, const uint8_t *encrypted_fek,
+			      TEE_OperationMode mode)
+{
+	TEE_Result res;
+	uint8_t fek[TEE_FS_KM_FEK_SIZE];
+	uint8_t iv[TEE_AES_BLOCK_SIZE];
+	uint8_t *ctx;
+	size_t ctx_size;
+	uint32_t algo = TEE_ALG_AES_CBC_NOPAD;
+
+	DMSG("%scrypt block #%u", (mode == TEE_MODE_ENCRYPT) ? "En" : "De",
+	     blk_idx);
+
+	/* Decrypt FEK */
+	memcpy(fek, encrypted_fek, TEE_FS_KM_FEK_SIZE);
+	res = fek_crypt(TEE_MODE_DECRYPT, fek, TEE_FS_KM_FEK_SIZE);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	/* Compute initialization vector for this block */
+	res = essiv(iv, fek, blk_idx);
+
+	/* Run AES CBC */
+	res = crypto_ops.cipher.get_ctx_size(algo, &ctx_size);
+	if (res != TEE_SUCCESS)
+		return res;
+	ctx = malloc(ctx_size);
+	if (!ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = crypto_ops.cipher.init(ctx, algo, mode, fek, sizeof(fek), NULL,
+				     0, iv, TEE_AES_BLOCK_SIZE);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = crypto_ops.cipher.update(ctx, algo, mode, true, in, size, out);
+	if (res != TEE_SUCCESS)
+		goto exit;
+
+	crypto_ops.cipher.final(ctx, algo);
+
+exit:
+	free(ctx);
+	return res;
 }
 
 service_init(tee_fs_init_key_manager);

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -31,6 +31,7 @@
 #include <tee/tee_rpmb.h>
 #include <tee/tee_fs_defs.h>
 #include <tee/tee_fs.h>
+#include <tee/tee_fs_key_manager.h>
 #include <mm/tee_mm.h>
 #include <trace.h>
 #include <stdlib.h>
@@ -38,6 +39,10 @@
 #include <string_ext.h>
 #include <util.h>
 #include <sys/queue.h>
+
+#ifdef CFG_ENC_FS
+#include <tee/tee_cryp_provider.h>
+#endif
 
 #define RPMB_STORAGE_START_ADDRESS      0
 #define RPMB_FS_FAT_START_ADDRESS       512
@@ -68,6 +73,7 @@ struct rpmb_fat_entry {
 	uint32_t data_size;
 	uint32_t flags;
 	uint32_t write_counter;
+	uint8_t fek[TEE_FS_KM_FEK_SIZE];
 	char filename[TEE_RPMB_FS_FILENAME_LENGTH];
 };
 
@@ -147,7 +153,7 @@ static void dump_fat(void)
 
 	while (!last_entry_found) {
 		res = tee_rpmb_read(CFG_RPMB_FS_DEV_ID, fat_address,
-				    (uint8_t *)fat_entries, size);
+				    (uint8_t *)fat_entries, size, NULL);
 		if (res != TEE_SUCCESS)
 			goto out;
 
@@ -230,7 +236,7 @@ static TEE_Result write_fat_entry(struct rpmb_file_handle *fh,
 
 	res = tee_rpmb_write(CFG_RPMB_FS_DEV_ID, fh->rpmb_fat_address,
 			     (uint8_t *)&fh->fat_entry,
-			     sizeof(struct rpmb_fat_entry));
+			     sizeof(struct rpmb_fat_entry), NULL);
 
 	dump_fat();
 
@@ -267,7 +273,7 @@ static TEE_Result rpmb_fs_setup(void)
 
 	res = tee_rpmb_read(CFG_RPMB_FS_DEV_ID, RPMB_STORAGE_START_ADDRESS,
 			    (uint8_t *)partition_data,
-			    sizeof(struct rpmb_fs_partition));
+			    sizeof(struct rpmb_fs_partition), NULL);
 	if (res != TEE_SUCCESS)
 		goto out;
 
@@ -312,7 +318,7 @@ static TEE_Result rpmb_fs_setup(void)
 		goto out;
 	res = tee_rpmb_write(CFG_RPMB_FS_DEV_ID, RPMB_STORAGE_START_ADDRESS,
 			     (uint8_t *)partition_data,
-			     sizeof(struct rpmb_fs_partition));
+			     sizeof(struct rpmb_fs_partition), NULL);
 
 #ifndef CFG_RPMB_RESET_FAT
 store_fs_par:
@@ -394,7 +400,7 @@ static TEE_Result read_fat(struct rpmb_file_handle *fh, tee_mm_pool_t *p)
 	 */
 	while (!last_entry_found && (!entry_found || p)) {
 		res = tee_rpmb_read(CFG_RPMB_FS_DEV_ID, fat_address,
-				    (uint8_t *)fat_entries, size);
+				    (uint8_t *)fat_entries, size, NULL);
 		if (res != TEE_SUCCESS)
 			goto out;
 
@@ -505,6 +511,39 @@ out:
 	return res;
 }
 
+#ifdef CFG_ENC_FS
+static bool is_zero(const uint8_t *buf, size_t size)
+{
+	size_t i;
+
+	for (i = 0; i < size; i++)
+		if (buf[i])
+			return false;
+	return true;
+}
+
+static TEE_Result generate_fek(struct rpmb_fat_entry *fe)
+{
+	TEE_Result res;
+
+again:
+	res = crypto_ops.prng.read(fe->fek, sizeof(fe->fek));
+	if (res != TEE_SUCCESS)
+		return res;
+
+	if (is_zero(fe->fek, sizeof(fe->fek)))
+		goto again;
+
+	return res;
+}
+#else
+static TEE_Result generate_fek(struct rpmb_fat_entry *fe)
+{
+	memset(fe->fek, 0, sizeof(fe->fek));
+	return TEE_SUCCESS;
+}
+#endif
+
 int tee_rpmb_fs_open(const char *file, int flags, ...)
 {
 	int fd = -1;
@@ -558,7 +597,6 @@ int tee_rpmb_fs_open(const char *file, int flags, ...)
 		tee_mm_final(&p);
 		if (res != TEE_SUCCESS)
 			goto out;
-
 	} else {
 		res = read_fat(fh, NULL);
 		if (res != TEE_SUCCESS)
@@ -583,6 +621,16 @@ int tee_rpmb_fs_open(const char *file, int flags, ...)
 			memcpy(fh->fat_entry.filename, file, strlen(file));
 			/* Start address and size are 0 */
 			fh->fat_entry.flags = FILE_IS_ACTIVE;
+
+			res = generate_fek(&fh->fat_entry);
+			if (res != TEE_SUCCESS) {
+				handle_put(&fs_handle_db, fd);
+				fd = -1;
+				goto out;
+			}
+			DMSG("GENERATE FEK key: %p",
+			     (void *)fh->fat_entry.fek);
+			DHEXDUMP(fh->fat_entry.fek, sizeof(fh->fat_entry.fek));
 
 			res = write_fat_entry(fh, true);
 			if (res != TEE_SUCCESS) {
@@ -648,7 +696,7 @@ int tee_rpmb_fs_read(int fd, uint8_t *buf, size_t size)
 	if (size > 0) {
 		res = tee_rpmb_read(CFG_RPMB_FS_DEV_ID,
 				    fh->fat_entry.start_address + fh->pos, buf,
-				    size);
+				    size, fh->fat_entry.fek);
 		if (res != TEE_SUCCESS)
 			goto out;
 	}
@@ -721,7 +769,7 @@ int tee_rpmb_fs_write(int fd, uint8_t *buf, size_t size)
 
 		DMSG("Updating data in-place");
 		res = tee_rpmb_write(CFG_RPMB_FS_DEV_ID, start_addr, buf,
-				     size);
+				     size, fh->fat_entry.fek);
 		if (res != TEE_SUCCESS)
 			goto out;
 	} else {
@@ -742,7 +790,8 @@ int tee_rpmb_fs_write(int fd, uint8_t *buf, size_t size)
 		if (fh->fat_entry.data_size) {
 			res = tee_rpmb_read(CFG_RPMB_FS_DEV_ID,
 					    fh->fat_entry.start_address,
-					    newbuf, fh->fat_entry.data_size);
+					    newbuf, fh->fat_entry.data_size,
+					    fh->fat_entry.fek);
 			if (res != TEE_SUCCESS)
 				goto out;
 		}
@@ -751,7 +800,7 @@ int tee_rpmb_fs_write(int fd, uint8_t *buf, size_t size)
 
 		newaddr = tee_mm_get_smem(mm);
 		res = tee_rpmb_write(CFG_RPMB_FS_DEV_ID, newaddr, newbuf,
-				     newsize);
+				     newsize, fh->fat_entry.fek);
 		if (res != TEE_SUCCESS)
 			goto out;
 
@@ -969,14 +1018,15 @@ int tee_rpmb_fs_ftruncate(int fd, tee_fs_off_t length)
 		if (fh->fat_entry.data_size) {
 			res = tee_rpmb_read(CFG_RPMB_FS_DEV_ID,
 					    fh->fat_entry.start_address,
-					    newbuf, fh->fat_entry.data_size);
+					    newbuf, fh->fat_entry.data_size,
+					    fh->fat_entry.fek);
 			if (res != TEE_SUCCESS)
 				goto out;
 		}
 
 		newaddr = tee_mm_get_smem(mm);
 		res = tee_rpmb_write(CFG_RPMB_FS_DEV_ID, newaddr, newbuf,
-				     newsize);
+				     newsize, fh->fat_entry.fek);
 		if (res != TEE_SUCCESS)
 			goto out;
 
@@ -1051,7 +1101,7 @@ static TEE_Result tee_rpmb_fs_dir_populate(const char *path, tee_fs_dir *dir)
 	pathlen = strlen(path);
 	while (!last_entry_found) {
 		res = tee_rpmb_read(CFG_RPMB_FS_DEV_ID, fat_address,
-				    (uint8_t *)fat_entries, size);
+				    (uint8_t *)fat_entries, size, NULL);
 		if (res != TEE_SUCCESS)
 			goto out;
 

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -846,7 +846,6 @@ TEE_Result tee_rpmb_fs_rm(const char *filename)
 
 out:
 	free(fh);
-	IMSG("Deleting file %s returned 0x%x\n", filename, res);
 	return res;
 }
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -94,10 +94,21 @@ CFG_TEE_FW_IMPL_VERSION ?= FW_IMPL_UNDEF
 CFG_TEE_FW_MANUFACTURER ?= FW_MAN_UNDEF
 
 # Encrypted File System Support
+# Applies to both the default and the RPMB filesystems
 CFG_ENC_FS ?= y
 
 # File System Block Cache Support
+# Does not apply to the RPMB FS
 CFG_FS_BLOCK_CACHE ?= n
+
+# RPMB file system support
+# When enabled, replaces the default (REE-based) FS
+CFG_RPMB_FS ?= n
+
+# Device identifier used when CFG_RPMB_FS = y.
+# The exact meaning of this value is platform-dependent. On Linux, the
+# tee-supplicant process will open /dev/mmcblk<id>rpmb
+CFG_RPMB_FS_DEV_ID ?= 0
 
 # Embed public part of this key in OP-TEE OS
 TA_SIGN_KEY ?= keys/default_ta.pem


### PR DESCRIPTION
Minor updates to RPMB code + adding CBC/ESSIV encryption when `CFG_ENC_FS=y`.
Replaces https://github.com/OP-TEE/optee_os/pull/626.