### PR TITLE
Introduce CROSS_COMPILE32 and CROSS_COMPILE64

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -64,12 +64,14 @@ core-platform-aflags += $(platform-aflags-generic)
 core-platform-aflags += $(platform-aflags-debug-info)
 
 ifeq ($(CFG_ARM64_core),y)
+CROSS_COMPILE_core ?= $(CROSS_COMPILE64)
 core-platform-cppflags += $(arm64-platform-cppflags)
 core-platform-cflags += $(arm64-platform-cflags)
 core-platform-cflags += $(arm64-platform-cflags-generic)
 core-platform-cflags += $(arm64-platform-cflags-no-hard-float)
 core-platform-aflags += $(arm64-platform-aflags)
 else
+CROSS_COMPILE_core ?= $(CROSS_COMPILE32)
 core-platform-cppflags += $(arm32-platform-cppflags)
 core-platform-cflags += $(arm32-platform-cflags)
 core-platform-cflags += $(arm32-platform-cflags-no-hard-float)
@@ -81,6 +83,7 @@ endif
 ifneq ($(filter ta_arm32,$(ta-targets)),)
 # Variables for ta-target/sm "ta_arm32"
 CFG_ARM32_ta_arm32 := y
+CROSS_COMPILE_ta_arm32 ?= $(CROSS_COMPILE32)
 ta_arm32-platform-cppflags += $(arm32-platform-cppflags)
 ta_arm32-platform-cflags += $(arm32-platform-cflags)
 ta_arm32-platform-cflags += $(platform-cflags-optimization)
@@ -99,11 +102,15 @@ ta-mk-file-export-vars-ta_arm32 += CFG_ARM32_ta_arm32
 ta-mk-file-export-vars-ta_arm32 += ta_arm32-platform-cppflags
 ta-mk-file-export-vars-ta_arm32 += ta_arm32-platform-cflags
 ta-mk-file-export-vars-ta_arm32 += ta_arm32-platform-aflags
+
+ta-mk-file-export-add-ta_arm32 += CROSS_COMPILE32 ?= $$(CROSS_COMPILE)_nl_
+ta-mk-file-export-add-ta_arm32 += CROSS_COMPILE_ta_arm32 ?= $$(CROSS_COMPILE32)_nl_
 endif
 
 ifneq ($(filter ta_arm64,$(ta-targets)),)
 # Variables for ta-target/sm "ta_arm64"
 CFG_ARM64_ta_arm64 := y
+CROSS_COMPILE_ta_arm64 ?= $(CROSS_COMPILE64)
 ta_arm64-platform-cppflags += $(arm64-platform-cppflags)
 ta_arm64-platform-cflags += $(arm64-platform-cflags)
 ta_arm64-platform-cflags += $(platform-cflags-optimization)
@@ -122,4 +129,7 @@ ta-mk-file-export-vars-ta_arm64 += CFG_ARM64_ta_arm64
 ta-mk-file-export-vars-ta_arm64 += ta_arm64-platform-cppflags
 ta-mk-file-export-vars-ta_arm64 += ta_arm64-platform-cflags
 ta-mk-file-export-vars-ta_arm64 += ta_arm64-platform-aflags
+
+ta-mk-file-export-add-ta_arm64 += CROSS_COMPILE64 ?= $$(CROSS_COMPILE)_nl_
+ta-mk-file-export-add-ta_arm64 += CROSS_COMPILE_ta_arm64 ?= $$(CROSS_COMPILE64)_nl_
 endif

--- a/core/core.mk
+++ b/core/core.mk
@@ -12,7 +12,6 @@ include mk/config.mk
 include core/arch/$(ARCH)/$(ARCH).mk
 
 # Setup compiler for this sub module
-CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)
 COMPILER_$(sm)		?= $(COMPILER)
 include mk/$(COMPILER_$(sm)).mk
 

--- a/documentation/build_system.md
+++ b/documentation/build_system.md
@@ -91,9 +91,10 @@ contains:
 Finally, the build directory contains the auto-generated configuration file
 for the TEE Core: `$(O)/include/generated/conf.h` (see below).
 
-### CROSS_COMPILE (cross-compiler selection)
+### CROSS_COMPILE* (cross-compiler selection)
 
-**$(CROSS_COMPILE)** is the prefix used to invoke the cross-compiler toolchain.
+**$(CROSS_COMPILE)** is the prefix used to invoke the (32-bit) cross-compiler
+toolchain.
 The default value is **arm-linux-gnueabihf-**. This is the variable you want to
 change in case you want to use
 [ccache](https://ccache.samba.org/) to speed you recompilations:
@@ -101,12 +102,37 @@ change in case you want to use
 $ make CROSS_COMPILE="ccache arm-linux-gnueabihf-"
 ```
 
-The CROSS_COMPILE variable can be overridden with **CROSS_COMPILE_core** and
-**CROSS_COMPILE_ta_arm{32,64}** for TEE Core and Trusted Applications
-respectively.
-This is needed if TEE Core and Trusted Application libraries need to be
-compiled with different compilers due to a mix of 64bit and 32bit code.
+If the build includes a mix of 32-bit and 64-bit code, for instance if you
+set `CFG_ARM64_core=y` to build a 64-bit secure kernel, then two different
+toolchains are used, that are controlled by **$(CROSS_COMPILE32)** and
+**$(CROSS_COMPILE64)**.
+The default value of **$(CROSS_COMPILE32)** is the value of CROSS_COMPILE,
+which defaults to **arm-linux-gnueabihf-** as mentioned above.
+The default value of **$(CROSS_COMPILE64)** is **aarch64-linux-gnu-**.
 
+Examples:
+```shell
+# FOr this example, select HiKey which supports both 32- and 64-bit builds
+$ export PLATFORM=hikey
+
+# 1. Build everything 32-bit
+$ make
+
+# 2. Same as (1.) but override the toolchain
+$ make CROSS_COMPILE="ccache arm-linux-gnueabihf-"
+
+# 3. Same as (2.)
+$ make CROSS_COMPILE32="ccache arm-linux-gnueabihf-"
+
+# 4. Select 64-bit secure OS (and therefore both 32- and 64-bit
+# Trusted Application libraries)
+$ make CFG_ARM64_core=y
+
+# 5. Same as (4.) but override the toolchains
+$ make CFG_ARM64_core=y \
+       CROSS_COMPILE32="ccache arm-linux-gnueabihf-" \
+       CROSS_COMPILE64="ccache aarch64-linux-gnu-"
+```
 
 ## Platform-specific configuration and flags
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -18,6 +18,8 @@
 
 # Cross-compiler prefix and suffix
 CROSS_COMPILE ?= arm-linux-gnueabihf-
+CROSS_COMPILE32 ?= $(CROSS_COMPILE)
+CROSS_COMPILE64 ?= aarch64-linux-gnu-
 COMPILER ?= gcc
 
 # Compiler warning level.

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -9,8 +9,6 @@ include $(ta-dev-kit-dir)/mk/conf.mk
 
 binary := $(BINARY)
 
-CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)
-
 ifneq ($O,)
 out-dir := $O
 else

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -5,7 +5,6 @@ sm := $(ta-target)
 sm-$(sm) := y
 
 # Setup compiler for this sub module
-CROSS_COMPILE_$(sm)	?= $(CROSS_COMPILE)
 COMPILER_$(sm)		?= $(COMPILER)
 include mk/$(COMPILER_$(sm)).mk
 
@@ -116,6 +115,7 @@ $(conf-mk-file-export): $(conf-mk-file)
 	$(q)echo CFG_TA_FLOAT_SUPPORT := $(CFG_TA_FLOAT_SUPPORT) >> $@
 	$(q)($(foreach v, $(ta-mk-file-export-vars-$(sm-$(@))), \
 		echo $(v) := $($(v));)) >> $@
+	$(q)echo '$(ta-mk-file-export-add-$(sm-$(@)))' | sed 's/_nl_ */\n/g' >> $@
 
 cleanfiles := $(cleanfiles) $(conf-mk-file-export)
 all: $(conf-mk-file-export)


### PR DESCRIPTION
Currently, to build a 64-bit TEE core (as well as mixed 32- and 64-bit
TA libraries, which are automatically enabled in this case), one has to
set too many compiler variables:

 $ make PLATFORM=hikey CFG_ARM64_core=y \
        CROSS_COMPILE_core=aarch64-linux-gnu- \
        CROSS_COMPILE_ta_arm64=aarch64-linux-gnu-

This commit introduces two variables, CROSS_COMPILE32 and
CROSS_COMPILE64. They take appropriate default values, so that the
above line may be simplified as:

 $ make PLATFORM=hikey CFG_ARM64_core=y

The change remains compatible with previous builds, i.e., CROSS_COMPILE
can still be used to define the 32-bit compiler because CROSS_COMPILE32
defaults to $(CROSS_COMPILE). Similarly, CROSS_COMPILE_core and
CROSS_COMPILE_ta_arm{32,64} are still used so they may be overriden
directly.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>