### PR TITLE
Reduce memory usage

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -39,7 +39,7 @@ platform-aflags-generic ?= -g -pipe
 
 arm32-platform-cflags-no-hard-float ?= -mno-apcs-float -mfloat-abi=soft
 arm32-platform-cflags-hard-float ?= -mfloat-abi=hard -funsafe-math-optimizations
-arm32-platform-cflags-generic ?= -mthumb -mthumb-interwork -mlong-calls \
+arm32-platform-cflags-generic ?= -mthumb -mthumb-interwork \
 			-fno-short-enums -fno-common -mno-unaligned-access
 arm32-platform-aflags-no-hard-float ?=
 

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -11,7 +11,7 @@ link-ldflags  = $(LDFLAGS)
 link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
 link-ldflags += --sort-section=alignment
 link-ldflags += --fatal-warnings
-link-ldflags += --print-gc-sections
+link-ldflags += --gc-sections
 
 link-ldadd  = $(LDADD)
 link-ldadd += $(addprefix -L,$(libdirs))

--- a/core/lib/libtomcrypt/include/tomcrypt_cipher.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_cipher.h
@@ -192,7 +192,7 @@ typedef struct {
 
 
 /** cipher descriptor table, last entry has "name == NULL" to mark the end of table */
-extern struct ltc_cipher_descriptor {
+extern const struct ltc_cipher_descriptor {
    /** name of cipher */
    const char *name;
    /** internal ID */
@@ -437,7 +437,7 @@ extern struct ltc_cipher_descriptor {
      int (*accel_xts_decrypt)(const unsigned char *ct, unsigned char *pt,
          unsigned long blocks, unsigned char *tweak, symmetric_key *skey1,
          symmetric_key *skey2);
-} cipher_descriptor[];
+} *cipher_descriptor[];
 
 
 /* make aes an alias */

--- a/core/lib/libtomcrypt/include/tomcrypt_hash.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_hash.h
@@ -174,7 +174,7 @@ typedef union Hash_state {
 } hash_state;
 
 /** hash descriptor */
-extern  struct ltc_hash_descriptor {
+extern  const struct ltc_hash_descriptor {
     /** name of hash */
     const char *name;
     /** internal ID */
@@ -216,7 +216,7 @@ extern  struct ltc_hash_descriptor {
                        const unsigned char *in,  unsigned long  inlen, 
                              unsigned char *out, unsigned long *outlen);
 
-} hash_descriptor[];
+} *hash_descriptor[];
 
 #ifdef LTC_CHC_HASH
 int chc_register(int cipher);

--- a/core/lib/libtomcrypt/include/tomcrypt_prng.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_prng.h
@@ -91,7 +91,7 @@ typedef union Prng_state {
 } prng_state;
 
 /** PRNG descriptor */
-extern struct ltc_prng_descriptor {
+extern const struct ltc_prng_descriptor {
     /** Name of the PRNG */
     const char *name;
     /** size in bytes of exported state */
@@ -143,7 +143,7 @@ extern struct ltc_prng_descriptor {
         @return CRYPT_OK if successful, CRYPT_NOP if self-testing has been disabled
     */
     int (*test)(void);
-} prng_descriptor[];
+} *prng_descriptor[];
 
 #ifdef LTC_YARROW
 int yarrow_start(prng_state *prng);

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
@@ -65,7 +65,7 @@ int ccm_add_aad(ccm_state *ccm,
    for (y = 0; y < adatalen; y++) {
       if (ccm->x == 16) {
          /* full block so let's encrypt it */
-         if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+         if ((err = cipher_descriptor[ccm->cipher]->ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
             return CRYPT_ERROR;
          }
          ccm->x = 0;
@@ -76,7 +76,7 @@ int ccm_add_aad(ccm_state *ccm,
    /* remainder? */
    if (ccm->aadlen == ccm->current_aadlen) {
       if (ccm->x != 0) {
-         if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+         if ((err = cipher_descriptor[ccm->cipher]->ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
             return CRYPT_ERROR;
          }
       }

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
@@ -96,7 +96,7 @@ int ccm_add_nonce(ccm_state *ccm,
    }
 
    /* encrypt PAD */
-   if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[ccm->cipher]->ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
       return err;
    }
 

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
@@ -64,7 +64,7 @@ int ccm_done(ccm_state *ccm,
    LTC_ARGCHK(taglen != NULL);
 
    if (ccm->x != 0) {
-      if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+      if ((err = cipher_descriptor[ccm->cipher]->ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
          return err;
       }
    }
@@ -73,11 +73,11 @@ int ccm_done(ccm_state *ccm,
    for (y = 15; y > 15 - ccm->L; y--) {
       ccm->ctr[y] = 0x00;
    }
-   if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[ccm->cipher]->ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
       return err;
    }
 
-   cipher_descriptor[ccm->cipher].done(&ccm->K);
+   cipher_descriptor[ccm->cipher]->done(&ccm->K);
 
    /* store the TAG */
    for (x = 0; x < 16 && x < *taglen; x++) {

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
@@ -67,7 +67,7 @@ int ccm_init(ccm_state *ccm, int cipher,
    if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {
       return err;
    }
-   if (cipher_descriptor[cipher].block_length != 16) {
+   if (cipher_descriptor[cipher]->block_length != 16) {
       return CRYPT_INVALID_CIPHER;
    }
 
@@ -84,7 +84,7 @@ int ccm_init(ccm_state *ccm, int cipher,
    }
 
    /* schedule key */
-   if ((err = cipher_descriptor[cipher].setup(key, keylen, 0, &ccm->K)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->setup(key, keylen, 0, &ccm->K)) != CRYPT_OK) {
       return err;
    }
    ccm->cipher = cipher;

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
@@ -83,7 +83,7 @@ int ccm_process(ccm_state *ccm,
                ccm->ctr[z] = (ccm->ctr[z] + 1) & 255;
                if (ccm->ctr[z]) break;
             }
-            if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
+            if ((err = cipher_descriptor[ccm->cipher]->ecb_encrypt(ccm->ctr, ccm->CTRPAD, &ccm->K)) != CRYPT_OK) {
                return err;
             }
             ccm->CTRlen = 0;
@@ -99,7 +99,7 @@ int ccm_process(ccm_state *ccm,
          }
 
          if (ccm->x == 16) {
-            if ((err = cipher_descriptor[ccm->cipher].ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
+            if ((err = cipher_descriptor[ccm->cipher]->ecb_encrypt(ccm->PAD, ccm->PAD, &ccm->K)) != CRYPT_OK) {
                return err;
             }
             ccm->x = 0;

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_done.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_done.c
@@ -89,7 +89,7 @@ int gcm_done(gcm_state *gcm,
    gcm_mult_h(gcm, gcm->X);
 
    /* encrypt original counter */
-   if ((err = cipher_descriptor[gcm->cipher].ecb_encrypt(gcm->Y_0, gcm->buf, &gcm->K)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[gcm->cipher]->ecb_encrypt(gcm->Y_0, gcm->buf, &gcm->K)) != CRYPT_OK) {
       return err;
    }
    for (x = 0; x < 16 && x < *taglen; x++) {
@@ -97,7 +97,7 @@ int gcm_done(gcm_state *gcm,
    }
    *taglen = x;
 
-   cipher_descriptor[gcm->cipher].done(&gcm->K);
+   cipher_descriptor[gcm->cipher]->done(&gcm->K);
 
    return CRYPT_OK;
 }

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_init.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_init.c
@@ -74,18 +74,18 @@ int gcm_init(gcm_state *gcm, int cipher,
    if ((err = cipher_is_valid(cipher)) != CRYPT_OK) {
       return err;
    }
-   if (cipher_descriptor[cipher].block_length != 16) {
+   if (cipher_descriptor[cipher]->block_length != 16) {
       return CRYPT_INVALID_CIPHER;
    }
 
    /* schedule key */
-   if ((err = cipher_descriptor[cipher].setup(key, keylen, 0, &gcm->K)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->setup(key, keylen, 0, &gcm->K)) != CRYPT_OK) {
       return err;
    }
 
    /* H = E(0) */
    zeromem(B, 16);
-   if ((err = cipher_descriptor[cipher].ecb_encrypt(B, gcm->H, &gcm->K)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->ecb_encrypt(B, gcm->H, &gcm->K)) != CRYPT_OK) {
       return err;
    }
 

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_memory.c
@@ -78,9 +78,9 @@ int gcm_memory(      int           cipher,
        return err;
     }
  
-    if (cipher_descriptor[cipher].accel_gcm_memory != NULL) {
+    if (cipher_descriptor[cipher]->accel_gcm_memory != NULL) {
        return 
-         cipher_descriptor[cipher].accel_gcm_memory
+         cipher_descriptor[cipher]->accel_gcm_memory
                                           (key,   keylen,
                                            IV,    IVlen,
                                            adata, adatalen,

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_process.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_process.c
@@ -89,7 +89,7 @@ int gcm_process(gcm_state *gcm,
           if (++gcm->Y[y] & 255) { break; }
       }
       /* encrypt the counter */
-      if ((err = cipher_descriptor[gcm->cipher].ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
+      if ((err = cipher_descriptor[gcm->cipher]->ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
          return err;
       }
 
@@ -118,7 +118,7 @@ int gcm_process(gcm_state *gcm,
              for (y = 15; y >= 12; y--) {
                  if (++gcm->Y[y] & 255) { break; }
              }
-             if ((err = cipher_descriptor[gcm->cipher].ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
+             if ((err = cipher_descriptor[gcm->cipher]->ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
                 return err;
              }
          }
@@ -136,7 +136,7 @@ int gcm_process(gcm_state *gcm,
              for (y = 15; y >= 12; y--) {
                  if (++gcm->Y[y] & 255) { break; }
              }
-             if ((err = cipher_descriptor[gcm->cipher].ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
+             if ((err = cipher_descriptor[gcm->cipher]->ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
                 return err;
              }
          }
@@ -154,7 +154,7 @@ int gcm_process(gcm_state *gcm,
           for (y = 15; y >= 12; y--) {
               if (++gcm->Y[y] & 255) { break; }
           }
-          if ((err = cipher_descriptor[gcm->cipher].ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
+          if ((err = cipher_descriptor[gcm->cipher]->ecb_encrypt(gcm->Y, gcm->buf, &gcm->K)) != CRYPT_OK) {
              return err;
           }
           gcm->buflen = 0;

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_memory.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_memory.c
@@ -64,8 +64,8 @@ int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned
         return err;
     }
 
-    if (*outlen < hash_descriptor[hash].hashsize) {
-       *outlen = hash_descriptor[hash].hashsize;
+    if (*outlen < hash_descriptor[hash]->hashsize) {
+       *outlen = hash_descriptor[hash]->hashsize;
        return CRYPT_BUFFER_OVERFLOW;
     }
 
@@ -74,14 +74,14 @@ int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned
        return CRYPT_MEM;
     }
 
-    if ((err = hash_descriptor[hash].init(md)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->init(md)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    if ((err = hash_descriptor[hash].process(md, in, inlen)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->process(md, in, inlen)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    err = hash_descriptor[hash].done(md, out);
-    *outlen = hash_descriptor[hash].hashsize;
+    err = hash_descriptor[hash]->done(md, out);
+    *outlen = hash_descriptor[hash]->hashsize;
 LBL_ERR:
 #ifdef LTC_CLEAN_STACK
     zeromem(md, sizeof(hash_state));

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_memory_multi.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_memory_multi.c
@@ -69,8 +69,8 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
         return err;
     }
 
-    if (*outlen < hash_descriptor[hash].hashsize) {
-       *outlen = hash_descriptor[hash].hashsize;
+    if (*outlen < hash_descriptor[hash]->hashsize) {
+       *outlen = hash_descriptor[hash]->hashsize;
        return CRYPT_BUFFER_OVERFLOW;
     }
 
@@ -79,7 +79,7 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
        return CRYPT_MEM;
     }
 
-    if ((err = hash_descriptor[hash].init(md)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->init(md)) != CRYPT_OK) {
        goto LBL_ERR;
     }
 
@@ -88,7 +88,7 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
     curlen = inlen;
     for (;;) {
        /* process buf */
-       if ((err = hash_descriptor[hash].process(md, curptr, curlen)) != CRYPT_OK) {
+       if ((err = hash_descriptor[hash]->process(md, curptr, curlen)) != CRYPT_OK) {
           goto LBL_ERR;
        }
        /* step to next */
@@ -98,8 +98,8 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
        }
        curlen = va_arg(args, unsigned long);
     }
-    err = hash_descriptor[hash].done(md, out);
-    *outlen = hash_descriptor[hash].hashsize;
+    err = hash_descriptor[hash]->done(md, out);
+    *outlen = hash_descriptor[hash]->hashsize;
 LBL_ERR:
 #ifdef LTC_CLEAN_STACK
     zeromem(md, sizeof(hash_state));

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_done.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_done.c
@@ -44,7 +44,7 @@
 
 #ifdef LTC_HMAC
 
-#define LTC_HMAC_BLOCKSIZE hash_descriptor[hash].blocksize
+#define LTC_HMAC_BLOCKSIZE hash_descriptor[hash]->blocksize
 
 /**
    Terminate an LTC_HMAC session
@@ -69,7 +69,7 @@ int hmac_done(hmac_state *hmac, unsigned char *out, unsigned long *outlen)
     }
 
     /* get the hash message digest size */
-    hashsize = hash_descriptor[hash].hashsize;
+    hashsize = hash_descriptor[hash]->hashsize;
 
     /* allocate buffers */
     buf  = XMALLOC(LTC_HMAC_BLOCKSIZE);
@@ -85,7 +85,7 @@ int hmac_done(hmac_state *hmac, unsigned char *out, unsigned long *outlen)
     }
 
     /* Get the hash of the first LTC_HMAC vector plus the data */
-    if ((err = hash_descriptor[hash].done(&hmac->md, isha)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->done(&hmac->md, isha)) != CRYPT_OK) {
        goto LBL_ERR;
     }
 
@@ -95,16 +95,16 @@ int hmac_done(hmac_state *hmac, unsigned char *out, unsigned long *outlen)
     }
 
     /* Now calculate the "outer" hash for step (5), (6), and (7) */
-    if ((err = hash_descriptor[hash].init(&hmac->md)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->init(&hmac->md)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    if ((err = hash_descriptor[hash].process(&hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->process(&hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    if ((err = hash_descriptor[hash].process(&hmac->md, isha, hashsize)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->process(&hmac->md, isha, hashsize)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    if ((err = hash_descriptor[hash].done(&hmac->md, buf)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->done(&hmac->md, buf)) != CRYPT_OK) {
        goto LBL_ERR;
     }
 

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
@@ -44,7 +44,7 @@
 
 #ifdef LTC_HMAC
 
-#define LTC_HMAC_BLOCKSIZE hash_descriptor[hash].blocksize
+#define LTC_HMAC_BLOCKSIZE hash_descriptor[hash]->blocksize
 
 /**
    Initialize an LTC_HMAC context.
@@ -69,7 +69,7 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
         return err;
     }
     hmac->hash = hash;
-    hashsize   = hash_descriptor[hash].hashsize;
+    hashsize   = hash_descriptor[hash]->hashsize;
 
     /* valid key length? */
     if (keylen == 0) {
@@ -111,11 +111,11 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
     }
 
     /* Pre-pend that to the hash data */
-    if ((err = hash_descriptor[hash].init(&hmac->md)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->init(&hmac->md)) != CRYPT_OK) {
        goto LBL_ERR;
     }
 
-    if ((err = hash_descriptor[hash].process(&hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->process(&hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
        goto LBL_ERR;
     }
     goto done;

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_memory.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_memory.c
@@ -74,8 +74,8 @@ int hmac_memory(int hash,
     }
 
     /* is there a descriptor? */
-    if (hash_descriptor[hash].hmac_block != NULL) {
-        return hash_descriptor[hash].hmac_block(key, keylen, in, inlen, out, outlen);
+    if (hash_descriptor[hash]->hmac_block != NULL) {
+        return hash_descriptor[hash]->hmac_block(key, keylen, in, inlen, out, outlen);
     }
 
     /* nope, so call the hmac functions */

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_process.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_process.c
@@ -59,7 +59,7 @@ int hmac_process(hmac_state *hmac, const unsigned char *in, unsigned long inlen)
     if ((err = hash_is_valid(hmac->hash)) != CRYPT_OK) {
         return err;
     }
-    return hash_descriptor[hmac->hash].process(&hmac->md, in, inlen);
+    return hash_descriptor[hmac->hash]->process(&hmac->md, in, inlen);
 }
 
 #endif

--- a/core/lib/libtomcrypt/src/mac/omac/omac_done.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_done.c
@@ -88,10 +88,10 @@ int omac_done(omac_state *omac, unsigned char *out, unsigned long *outlen)
    }
 
    /* encrypt it */
-   if ((err = cipher_descriptor[omac->cipher_idx].ecb_encrypt(omac->block, omac->block, &omac->key)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[omac->cipher_idx]->ecb_encrypt(omac->block, omac->block, &omac->key)) != CRYPT_OK) {
       return err;
    }
-   cipher_descriptor[omac->cipher_idx].done(&omac->key);
+   cipher_descriptor[omac->cipher_idx]->done(&omac->key);
  
    /* output it */
    for (x = 0; x < (unsigned)omac->blklen && x < *outlen; x++) {

--- a/core/lib/libtomcrypt/src/mac/omac/omac_init.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_init.c
@@ -66,13 +66,13 @@ int omac_init(omac_state *omac, int cipher, const unsigned char *key, unsigned l
    }
 
 #ifdef LTC_FAST
-   if (cipher_descriptor[cipher].block_length % sizeof(LTC_FAST_TYPE)) {
+   if (cipher_descriptor[cipher]->block_length % sizeof(LTC_FAST_TYPE)) {
        return CRYPT_INVALID_ARG;
    }
 #endif
 
    /* now setup the system */
-   switch (cipher_descriptor[cipher].block_length) {
+   switch (cipher_descriptor[cipher]->block_length) {
        case 8:  mask = 0x1B;
                 len  = 8;
                 break;
@@ -82,15 +82,15 @@ int omac_init(omac_state *omac, int cipher, const unsigned char *key, unsigned l
        default: return CRYPT_INVALID_ARG;
    }
 
-   if ((err = cipher_descriptor[cipher].setup(key, keylen, 0, &omac->key)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->setup(key, keylen, 0, &omac->key)) != CRYPT_OK) {
       return err;
    }
 
    /* ok now we need Lu and Lu^2 [calc one from the other] */
 
    /* first calc L which is Ek(0) */
-   zeromem(omac->Lu[0], cipher_descriptor[cipher].block_length);
-   if ((err = cipher_descriptor[cipher].ecb_encrypt(omac->Lu[0], omac->Lu[0], &omac->key)) != CRYPT_OK) {
+   zeromem(omac->Lu[0], cipher_descriptor[cipher]->block_length);
+   if ((err = cipher_descriptor[cipher]->ecb_encrypt(omac->Lu[0], omac->Lu[0], &omac->key)) != CRYPT_OK) {
       return err;
    }
 

--- a/core/lib/libtomcrypt/src/mac/omac/omac_memory.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_memory.c
@@ -74,8 +74,8 @@ int omac_memory(int cipher,
    }
 
    /* Use accelerator if found */
-   if (cipher_descriptor[cipher].omac_memory != NULL) {
-      return cipher_descriptor[cipher].omac_memory(key, keylen, in, inlen, out, outlen);
+   if (cipher_descriptor[cipher]->omac_memory != NULL) {
+      return cipher_descriptor[cipher]->omac_memory(key, keylen, in, inlen, out, outlen);
    }
 
    /* allocate ram for omac state */

--- a/core/lib/libtomcrypt/src/mac/omac/omac_process.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_process.c
@@ -69,7 +69,7 @@ int omac_process(omac_state *omac, const unsigned char *in, unsigned long inlen)
    }
 
 #ifdef LTC_FAST
-   unsigned long blklen = cipher_descriptor[omac->cipher_idx].block_length;
+   unsigned long blklen = cipher_descriptor[omac->cipher_idx]->block_length;
    if (omac->buflen == 0 && inlen > blklen) {
       unsigned long y;
       for (x = 0; x < (inlen - blklen); x += blklen) {
@@ -77,7 +77,7 @@ int omac_process(omac_state *omac, const unsigned char *in, unsigned long inlen)
               *((LTC_FAST_TYPE*)(&omac->prev[y])) ^= *((LTC_FAST_TYPE*)(&in[y]));
           }
           in += blklen;
-          if ((err = cipher_descriptor[omac->cipher_idx].ecb_encrypt(omac->prev, omac->prev, &omac->key)) != CRYPT_OK) {
+          if ((err = cipher_descriptor[omac->cipher_idx]->ecb_encrypt(omac->prev, omac->prev, &omac->key)) != CRYPT_OK) {
              return err;
           }
       }
@@ -91,7 +91,7 @@ int omac_process(omac_state *omac, const unsigned char *in, unsigned long inlen)
           for (x = 0; x < (unsigned long)omac->blklen; x++) {
               omac->block[x] ^= omac->prev[x];
           }
-          if ((err = cipher_descriptor[omac->cipher_idx].ecb_encrypt(omac->block, omac->prev, &omac->key)) != CRYPT_OK) {
+          if ((err = cipher_descriptor[omac->cipher_idx]->ecb_encrypt(omac->block, omac->prev, &omac->key)) != CRYPT_OK) {
              return err;
           }
           omac->buflen = 0;

--- a/core/lib/libtomcrypt/src/math/rand_prime.c
+++ b/core/lib/libtomcrypt/src/math/rand_prime.c
@@ -77,7 +77,7 @@ int rand_prime(void *N, long len, prng_state *prng, int wprng)
 
    do {
       /* generate value */
-      if (prng_descriptor[wprng].read(buf, len, prng) != (unsigned long)len) {
+      if (prng_descriptor[wprng]->read(buf, len, prng) != (unsigned long)len) {
          XFREE(buf);
          return CRYPT_ERROR_READPRNG;
       }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_descriptor.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_descriptor.c
@@ -42,9 +42,7 @@
   Stores the cipher descriptor table, Tom St Denis
 */
 
-struct ltc_cipher_descriptor cipher_descriptor[TAB_SIZE] = {
-{ NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
- };
+const struct ltc_cipher_descriptor *cipher_descriptor[TAB_SIZE];
 
 LTC_MUTEX_GLOBAL(ltc_cipher_mutex)
 

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_is_valid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_is_valid.c
@@ -50,7 +50,7 @@
 int cipher_is_valid(int idx)
 {
    LTC_MUTEX_LOCK(&ltc_cipher_mutex);
-   if (idx < 0 || idx >= TAB_SIZE || cipher_descriptor[idx].name == NULL) {
+   if (idx < 0 || idx >= TAB_SIZE || cipher_descriptor[idx] == NULL) {
       LTC_MUTEX_UNLOCK(&ltc_cipher_mutex);
       return CRYPT_INVALID_CIPHER;
    }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher.c
@@ -53,7 +53,7 @@ int find_cipher(const char *name)
    LTC_ARGCHK(name != NULL);
    LTC_MUTEX_LOCK(&ltc_cipher_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (cipher_descriptor[x].name != NULL && !XSTRCMP(cipher_descriptor[x].name, name)) {
+       if (cipher_descriptor[x] != NULL && !XSTRCMP(cipher_descriptor[x]->name, name)) {
           LTC_MUTEX_UNLOCK(&ltc_cipher_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_any.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_any.c
@@ -60,10 +60,10 @@ int find_cipher_any(const char *name, int blocklen, int keylen)
 
    LTC_MUTEX_LOCK(&ltc_cipher_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (cipher_descriptor[x].name == NULL) {
+       if (cipher_descriptor[x] == NULL) {
           continue;
        }
-       if (blocklen <= (int)cipher_descriptor[x].block_length && keylen <= (int)cipher_descriptor[x].max_key_length) {
+       if (blocklen <= (int)cipher_descriptor[x]->block_length && keylen <= (int)cipher_descriptor[x]->max_key_length) {
           LTC_MUTEX_UNLOCK(&ltc_cipher_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_id.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_id.c
@@ -51,9 +51,8 @@ int find_cipher_id(unsigned char ID)
 {
    int x;
    LTC_MUTEX_LOCK(&ltc_cipher_mutex);
-   for (x = 0; x < TAB_SIZE; x++) {
-       if (cipher_descriptor[x].ID == ID) {
-          x = (cipher_descriptor[x].name == NULL) ? -1 : x;
+   for (x = 0; x < TAB_SIZE && cipher_descriptor[x] != NULL; x++) {
+       if (cipher_descriptor[x]->ID == ID) {
           LTC_MUTEX_UNLOCK(&ltc_cipher_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash.c
@@ -53,7 +53,7 @@ int find_hash(const char *name)
    LTC_ARGCHK(name != NULL);
    LTC_MUTEX_LOCK(&ltc_hash_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (hash_descriptor[x].name != NULL && XSTRCMP(hash_descriptor[x].name, name) == 0) {
+       if (hash_descriptor[x] != NULL && XSTRCMP(hash_descriptor[x]->name, name) == 0) {
           LTC_MUTEX_UNLOCK(&ltc_hash_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_any.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_any.c
@@ -59,12 +59,12 @@
    y = MAXBLOCKSIZE+1;
    z = -1;
    for (x = 0; x < TAB_SIZE; x++) {
-       if (hash_descriptor[x].name == NULL) {
+       if (hash_descriptor[x] == NULL) {
           continue;
        }
-       if ((int)hash_descriptor[x].hashsize >= digestlen && (int)hash_descriptor[x].hashsize < y) {
+       if ((int)hash_descriptor[x]->hashsize >= digestlen && (int)hash_descriptor[x]->hashsize < y) {
           z = x;
-          y = hash_descriptor[x].hashsize;
+          y = hash_descriptor[x]->hashsize;
        }
    }
    LTC_MUTEX_UNLOCK(&ltc_hash_mutex);

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_id.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_id.c
@@ -52,8 +52,7 @@ int find_hash_id(unsigned char ID)
    int x;
    LTC_MUTEX_LOCK(&ltc_hash_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-      if (hash_descriptor[x].ID == ID) {
-          x = (hash_descriptor[x].name == NULL) ? -1 : x;
+      if (hash_descriptor[x] && hash_descriptor[x]->ID == ID) {
           LTC_MUTEX_UNLOCK(&ltc_hash_mutex);
           return x;
       }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_oid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_oid.c
@@ -48,7 +48,7 @@ int find_hash_oid(const unsigned long *ID, unsigned long IDlen)
    LTC_ARGCHK(ID != NULL);
    LTC_MUTEX_LOCK(&ltc_hash_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (hash_descriptor[x].name != NULL && hash_descriptor[x].OIDlen == IDlen && !XMEMCMP(hash_descriptor[x].OID, ID, sizeof(unsigned long) * IDlen)) {
+       if (hash_descriptor[x] != NULL && hash_descriptor[x]->OIDlen == IDlen && !XMEMCMP(hash_descriptor[x]->OID, ID, sizeof(unsigned long) * IDlen)) {
           LTC_MUTEX_UNLOCK(&ltc_hash_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_prng.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_prng.c
@@ -53,7 +53,7 @@ int find_prng(const char *name)
    LTC_ARGCHK(name != NULL);
    LTC_MUTEX_LOCK(&ltc_prng_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if ((prng_descriptor[x].name != NULL) && XSTRCMP(prng_descriptor[x].name, name) == 0) {
+       if ((prng_descriptor[x]->name != NULL) && XSTRCMP(prng_descriptor[x]->name, name) == 0) {
           LTC_MUTEX_UNLOCK(&ltc_prng_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_descriptor.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_descriptor.c
@@ -42,9 +42,7 @@
   Stores the hash descriptor table, Tom St Denis  
 */
 
-struct ltc_hash_descriptor hash_descriptor[TAB_SIZE] = {
-{ NULL, 0, 0, 0, { 0 }, 0, NULL, NULL, NULL, NULL, NULL }
-};
+const struct ltc_hash_descriptor *hash_descriptor[TAB_SIZE];
 
 LTC_MUTEX_GLOBAL(ltc_hash_mutex)
 

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_is_valid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_is_valid.c
@@ -50,7 +50,7 @@
 int hash_is_valid(int idx)
 {
    LTC_MUTEX_LOCK(&ltc_hash_mutex);
-   if (idx < 0 || idx >= TAB_SIZE || hash_descriptor[idx].name == NULL) {
+   if (idx < 0 || idx >= TAB_SIZE || hash_descriptor[idx] == NULL) {
       LTC_MUTEX_UNLOCK(&ltc_hash_mutex);
       return CRYPT_INVALID_HASH;
    }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_descriptor.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_descriptor.c
@@ -41,9 +41,7 @@
   @file crypt_prng_descriptor.c
   Stores the PRNG descriptors, Tom St Denis
 */  
-struct ltc_prng_descriptor prng_descriptor[TAB_SIZE] = {
-{ NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
-};
+const struct ltc_prng_descriptor *prng_descriptor[TAB_SIZE];
 
 LTC_MUTEX_GLOBAL(ltc_prng_mutex)
 

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_is_valid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_is_valid.c
@@ -50,7 +50,7 @@
 int prng_is_valid(int idx)
 {
    LTC_MUTEX_LOCK(&ltc_prng_mutex);
-   if (idx < 0 || idx >= TAB_SIZE || prng_descriptor[idx].name == NULL) {
+   if (idx < 0 || idx >= TAB_SIZE || prng_descriptor[idx] == NULL) {
       LTC_MUTEX_UNLOCK(&ltc_prng_mutex);
       return CRYPT_INVALID_PRNG;
    }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_register_cipher.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_register_cipher.c
@@ -56,7 +56,7 @@ int register_cipher(const struct ltc_cipher_descriptor *cipher)
    /* is it already registered? */
    LTC_MUTEX_LOCK(&ltc_cipher_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (cipher_descriptor[x].name != NULL && cipher_descriptor[x].ID == cipher->ID) {
+       if (cipher_descriptor[x] != NULL && cipher_descriptor[x]->ID == cipher->ID) {
           LTC_MUTEX_UNLOCK(&ltc_cipher_mutex);
           return x;
        }
@@ -64,8 +64,8 @@ int register_cipher(const struct ltc_cipher_descriptor *cipher)
 
    /* find a blank spot */
    for (x = 0; x < TAB_SIZE; x++) {
-       if (cipher_descriptor[x].name == NULL) {
-          XMEMCPY(&cipher_descriptor[x], cipher, sizeof(struct ltc_cipher_descriptor));
+       if (cipher_descriptor[x] == NULL) {
+          cipher_descriptor[x] = cipher;
           LTC_MUTEX_UNLOCK(&ltc_cipher_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_register_hash.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_register_hash.c
@@ -56,7 +56,7 @@ int register_hash(const struct ltc_hash_descriptor *hash)
    /* is it already registered? */
    LTC_MUTEX_LOCK(&ltc_hash_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (XMEMCMP(&hash_descriptor[x], hash, sizeof(struct ltc_hash_descriptor)) == 0) {
+       if (hash_descriptor[x] == hash) {
           LTC_MUTEX_UNLOCK(&ltc_hash_mutex);
           return x;
        }
@@ -64,8 +64,8 @@ int register_hash(const struct ltc_hash_descriptor *hash)
 
    /* find a blank spot */
    for (x = 0; x < TAB_SIZE; x++) {
-       if (hash_descriptor[x].name == NULL) {
-          XMEMCPY(&hash_descriptor[x], hash, sizeof(struct ltc_hash_descriptor));
+       if (hash_descriptor[x] == NULL) {
+          hash_descriptor[x] = hash;
           LTC_MUTEX_UNLOCK(&ltc_hash_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_register_prng.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_register_prng.c
@@ -56,7 +56,7 @@ int register_prng(const struct ltc_prng_descriptor *prng)
    /* is it already registered? */
    LTC_MUTEX_LOCK(&ltc_prng_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (XMEMCMP(&prng_descriptor[x], prng, sizeof(struct ltc_prng_descriptor)) == 0) {
+       if (prng_descriptor[x] == prng) {
           LTC_MUTEX_UNLOCK(&ltc_prng_mutex);
           return x;
        }
@@ -64,8 +64,8 @@ int register_prng(const struct ltc_prng_descriptor *prng)
 
    /* find a blank spot */
    for (x = 0; x < TAB_SIZE; x++) {
-       if (prng_descriptor[x].name == NULL) {
-          XMEMCPY(&prng_descriptor[x], prng, sizeof(struct ltc_prng_descriptor));
+       if (prng_descriptor[x] == NULL) {
+	  prng_descriptor[x] = prng;
           LTC_MUTEX_UNLOCK(&ltc_prng_mutex);
           return x;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_cipher.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_cipher.c
@@ -56,9 +56,8 @@ int unregister_cipher(const struct ltc_cipher_descriptor *cipher)
    /* is it already registered? */
    LTC_MUTEX_LOCK(&ltc_cipher_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (XMEMCMP(&cipher_descriptor[x], cipher, sizeof(struct ltc_cipher_descriptor)) == 0) {
-          cipher_descriptor[x].name = NULL;
-          cipher_descriptor[x].ID   = 255;
+       if (cipher_descriptor[x] == cipher) {
+          cipher_descriptor[x] = NULL;
           LTC_MUTEX_UNLOCK(&ltc_cipher_mutex);
           return CRYPT_OK;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_hash.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_hash.c
@@ -56,8 +56,8 @@ int unregister_hash(const struct ltc_hash_descriptor *hash)
    /* is it already registered? */
    LTC_MUTEX_LOCK(&ltc_hash_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (XMEMCMP(&hash_descriptor[x], hash, sizeof(struct ltc_hash_descriptor)) == 0) {
-          hash_descriptor[x].name = NULL;
+       if (hash_descriptor[x] == hash) {
+          hash_descriptor[x] = NULL;
           LTC_MUTEX_UNLOCK(&ltc_hash_mutex);
           return CRYPT_OK;
        }

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_prng.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_prng.c
@@ -56,8 +56,8 @@ int unregister_prng(const struct ltc_prng_descriptor *prng)
    /* is it already registered? */
    LTC_MUTEX_LOCK(&ltc_prng_mutex);
    for (x = 0; x < TAB_SIZE; x++) {
-       if (XMEMCMP(&prng_descriptor[x], prng, sizeof(struct ltc_prng_descriptor)) != 0) {
-          prng_descriptor[x].name = NULL;
+       if (prng_descriptor[x] == prng) {
+          prng_descriptor[x] = NULL;
           LTC_MUTEX_UNLOCK(&ltc_prng_mutex);
           return CRYPT_OK;
        }

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_decrypt.c
@@ -85,12 +85,12 @@ int cbc_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, s
    }
 #endif
    
-   if (cipher_descriptor[cbc->cipher].accel_cbc_decrypt != NULL) {
-      return cipher_descriptor[cbc->cipher].accel_cbc_decrypt(ct, pt, len / cbc->blocklen, cbc->IV, &cbc->key);
+   if (cipher_descriptor[cbc->cipher]->accel_cbc_decrypt != NULL) {
+      return cipher_descriptor[cbc->cipher]->accel_cbc_decrypt(ct, pt, len / cbc->blocklen, cbc->IV, &cbc->key);
    } else {
       while (len) {
          /* decrypt */
-         if ((err = cipher_descriptor[cbc->cipher].ecb_decrypt(ct, tmp, &cbc->key)) != CRYPT_OK) {
+         if ((err = cipher_descriptor[cbc->cipher]->ecb_decrypt(ct, tmp, &cbc->key)) != CRYPT_OK) {
             return err;
          }
 

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_done.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_done.c
@@ -56,7 +56,7 @@ int cbc_done(symmetric_CBC *cbc)
    if ((err = cipher_is_valid(cbc->cipher)) != CRYPT_OK) {
       return err;
    }
-   cipher_descriptor[cbc->cipher].done(&cbc->key);
+   cipher_descriptor[cbc->cipher]->done(&cbc->key);
    return CRYPT_OK;
 }
 

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_encrypt.c
@@ -79,8 +79,8 @@ int cbc_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
    }
 #endif
 
-   if (cipher_descriptor[cbc->cipher].accel_cbc_encrypt != NULL) {
-      return cipher_descriptor[cbc->cipher].accel_cbc_encrypt(pt, ct, len / cbc->blocklen, cbc->IV, &cbc->key);
+   if (cipher_descriptor[cbc->cipher]->accel_cbc_encrypt != NULL) {
+      return cipher_descriptor[cbc->cipher]->accel_cbc_encrypt(pt, ct, len / cbc->blocklen, cbc->IV, &cbc->key);
    } else {
       while (len) {
          /* xor IV against plaintext */
@@ -95,7 +95,7 @@ int cbc_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
     #endif
 
          /* encrypt */
-         if ((err = cipher_descriptor[cbc->cipher].ecb_encrypt(cbc->IV, ct, &cbc->key)) != CRYPT_OK) {
+         if ((err = cipher_descriptor[cbc->cipher]->ecb_encrypt(cbc->IV, ct, &cbc->key)) != CRYPT_OK) {
             return err;
          }
 

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_start.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_start.c
@@ -69,12 +69,12 @@ int cbc_start(int cipher, const unsigned char *IV, const unsigned char *key,
    }
 
    /* setup cipher */
-   if ((err = cipher_descriptor[cipher].setup(key, keylen, num_rounds, &cbc->key)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->setup(key, keylen, num_rounds, &cbc->key)) != CRYPT_OK) {
       return err;
    }
 
    /* copy IV */
-   cbc->blocklen = cipher_descriptor[cipher].block_length;
+   cbc->blocklen = cipher_descriptor[cipher]->block_length;
    cbc->cipher   = cipher;
    for (x = 0; x < cbc->blocklen; x++) {
        cbc->IV[x] = IV[x];

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_done.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_done.c
@@ -56,7 +56,7 @@ int ctr_done(symmetric_CTR *ctr)
    if ((err = cipher_is_valid(ctr->cipher)) != CRYPT_OK) {
       return err;
    }
-   cipher_descriptor[ctr->cipher].done(&ctr->key);
+   cipher_descriptor[ctr->cipher]->done(&ctr->key);
    return CRYPT_OK;
 }
 

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
@@ -78,8 +78,8 @@ int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
 #endif
    
    /* handle acceleration only if pad is empty, accelerator is present and length is >= a block size */
-   if ((ctr->padlen == ctr->blocklen) && cipher_descriptor[ctr->cipher].accel_ctr_encrypt != NULL && (len >= (unsigned long)ctr->blocklen)) {
-      if ((err = cipher_descriptor[ctr->cipher].accel_ctr_encrypt(pt, ct, len/ctr->blocklen, ctr->ctr, ctr->mode, &ctr->key)) != CRYPT_OK) {
+   if ((ctr->padlen == ctr->blocklen) && cipher_descriptor[ctr->cipher]->accel_ctr_encrypt != NULL && (len >= (unsigned long)ctr->blocklen)) {
+      if ((err = cipher_descriptor[ctr->cipher]->accel_ctr_encrypt(pt, ct, len/ctr->blocklen, ctr->ctr, ctr->mode, &ctr->key)) != CRYPT_OK) {
          return err;
       }
       len %= ctr->blocklen;
@@ -108,7 +108,7 @@ int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
          }
 
          /* encrypt it */
-         if ((err = cipher_descriptor[ctr->cipher].ecb_encrypt(ctr->ctr, ctr->pad, &ctr->key)) != CRYPT_OK) {
+         if ((err = cipher_descriptor[ctr->cipher]->ecb_encrypt(ctr->ctr, ctr->pad, &ctr->key)) != CRYPT_OK) {
             return err;
          }
          ctr->padlen = 0;

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_setiv.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_setiv.c
@@ -72,7 +72,7 @@ int ctr_setiv(const unsigned char *IV, unsigned long len, symmetric_CTR *ctr)
    
    /* force next block */
    ctr->padlen = 0;
-   return cipher_descriptor[ctr->cipher].ecb_encrypt(IV, ctr->pad, &ctr->key);
+   return cipher_descriptor[ctr->cipher]->ecb_encrypt(IV, ctr->pad, &ctr->key);
 }
 
 #endif 

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_start.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_start.c
@@ -74,22 +74,22 @@ int ctr_start(               int   cipher,
    }
 
    /* ctrlen == counter width */
-   ctr->ctrlen   = (ctr_mode & 255) ? (ctr_mode & 255) : cipher_descriptor[cipher].block_length;
-   if (ctr->ctrlen > cipher_descriptor[cipher].block_length) {
+   ctr->ctrlen   = (ctr_mode & 255) ? (ctr_mode & 255) : cipher_descriptor[cipher]->block_length;
+   if (ctr->ctrlen > cipher_descriptor[cipher]->block_length) {
       return CRYPT_INVALID_ARG;
    }
 
    if ((ctr_mode & 0x1000) == CTR_COUNTER_BIG_ENDIAN) {
-      ctr->ctrlen = cipher_descriptor[cipher].block_length - ctr->ctrlen;
+      ctr->ctrlen = cipher_descriptor[cipher]->block_length - ctr->ctrlen;
    }
 
    /* setup cipher */
-   if ((err = cipher_descriptor[cipher].setup(key, keylen, num_rounds, &ctr->key)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->setup(key, keylen, num_rounds, &ctr->key)) != CRYPT_OK) {
       return err;
    }
 
    /* copy ctr */
-   ctr->blocklen = cipher_descriptor[cipher].block_length;
+   ctr->blocklen = cipher_descriptor[cipher]->block_length;
    ctr->cipher   = cipher;
    ctr->padlen   = 0;
    ctr->mode     = ctr_mode & 0x1000;
@@ -118,7 +118,7 @@ int ctr_start(               int   cipher,
       }
    }
 
-   return cipher_descriptor[ctr->cipher].ecb_encrypt(ctr->ctr, ctr->pad, &ctr->key); 
+   return cipher_descriptor[ctr->cipher]->ecb_encrypt(ctr->ctr, ctr->pad, &ctr->key); 
 }
 
 #endif

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_decrypt.c
@@ -61,21 +61,21 @@ int ecb_decrypt(const unsigned char *ct, unsigned char *pt, unsigned long len, s
    if ((err = cipher_is_valid(ecb->cipher)) != CRYPT_OK) {
        return err;
    }
-   if (len % cipher_descriptor[ecb->cipher].block_length) {
+   if (len % cipher_descriptor[ecb->cipher]->block_length) {
       return CRYPT_INVALID_ARG;
    }
 
    /* check for accel */
-   if (cipher_descriptor[ecb->cipher].accel_ecb_decrypt != NULL) {
-      return cipher_descriptor[ecb->cipher].accel_ecb_decrypt(ct, pt, len / cipher_descriptor[ecb->cipher].block_length, &ecb->key);
+   if (cipher_descriptor[ecb->cipher]->accel_ecb_decrypt != NULL) {
+      return cipher_descriptor[ecb->cipher]->accel_ecb_decrypt(ct, pt, len / cipher_descriptor[ecb->cipher]->block_length, &ecb->key);
    } else {
       while (len) {
-         if ((err = cipher_descriptor[ecb->cipher].ecb_decrypt(ct, pt, &ecb->key)) != CRYPT_OK) {
+         if ((err = cipher_descriptor[ecb->cipher]->ecb_decrypt(ct, pt, &ecb->key)) != CRYPT_OK) {
             return err;
          }
-         pt  += cipher_descriptor[ecb->cipher].block_length;
-         ct  += cipher_descriptor[ecb->cipher].block_length;
-         len -= cipher_descriptor[ecb->cipher].block_length;
+         pt  += cipher_descriptor[ecb->cipher]->block_length;
+         ct  += cipher_descriptor[ecb->cipher]->block_length;
+         len -= cipher_descriptor[ecb->cipher]->block_length;
       }
    }
    return CRYPT_OK;

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_done.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_done.c
@@ -56,7 +56,7 @@ int ecb_done(symmetric_ECB *ecb)
    if ((err = cipher_is_valid(ecb->cipher)) != CRYPT_OK) {
       return err;
    }
-   cipher_descriptor[ecb->cipher].done(&ecb->key);
+   cipher_descriptor[ecb->cipher]->done(&ecb->key);
    return CRYPT_OK;
 }
 

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_encrypt.c
@@ -61,21 +61,21 @@ int ecb_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
    if ((err = cipher_is_valid(ecb->cipher)) != CRYPT_OK) {
        return err;
    }
-   if (len % cipher_descriptor[ecb->cipher].block_length) {
+   if (len % cipher_descriptor[ecb->cipher]->block_length) {
       return CRYPT_INVALID_ARG;
    }
 
    /* check for accel */
-   if (cipher_descriptor[ecb->cipher].accel_ecb_encrypt != NULL) {
-      return cipher_descriptor[ecb->cipher].accel_ecb_encrypt(pt, ct, len / cipher_descriptor[ecb->cipher].block_length, &ecb->key);
+   if (cipher_descriptor[ecb->cipher]->accel_ecb_encrypt != NULL) {
+      return cipher_descriptor[ecb->cipher]->accel_ecb_encrypt(pt, ct, len / cipher_descriptor[ecb->cipher]->block_length, &ecb->key);
    } else {
       while (len) {
-         if ((err = cipher_descriptor[ecb->cipher].ecb_encrypt(pt, ct, &ecb->key)) != CRYPT_OK) {
+         if ((err = cipher_descriptor[ecb->cipher]->ecb_encrypt(pt, ct, &ecb->key)) != CRYPT_OK) {
             return err;
          }
-         pt  += cipher_descriptor[ecb->cipher].block_length;
-         ct  += cipher_descriptor[ecb->cipher].block_length;
-         len -= cipher_descriptor[ecb->cipher].block_length;
+         pt  += cipher_descriptor[ecb->cipher]->block_length;
+         ct  += cipher_descriptor[ecb->cipher]->block_length;
+         len -= cipher_descriptor[ecb->cipher]->block_length;
       }
    }
    return CRYPT_OK;

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_start.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_start.c
@@ -64,8 +64,8 @@ int ecb_start(int cipher, const unsigned char *key, int keylen, int num_rounds, 
       return err;
    }
    ecb->cipher = cipher;
-   ecb->blocklen = cipher_descriptor[cipher].block_length;
-   return cipher_descriptor[cipher].setup(key, keylen, num_rounds, &ecb->key);
+   ecb->blocklen = cipher_descriptor[cipher]->block_length;
+   return cipher_descriptor[cipher]->setup(key, keylen, num_rounds, &ecb->key);
 }
 
 #endif

--- a/core/lib/libtomcrypt/src/modes/xts/xts_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_decrypt.c
@@ -59,7 +59,7 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
    }
 #endif
      
-   err = cipher_descriptor[xts->cipher].ecb_decrypt(P, P, &xts->key1);  
+   err = cipher_descriptor[xts->cipher]->ecb_decrypt(P, P, &xts->key1);  
 
 #ifdef LTC_FAST
    for (x = 0; x < 16; x += sizeof(LTC_FAST_TYPE)) {
@@ -94,7 +94,7 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
 #endif
          symmetric_xts *xts)
 {
-   struct ltc_cipher_descriptor *desc;
+   const struct ltc_cipher_descriptor *desc;
    unsigned char PP[16], CC[16], T[16];
    unsigned long i, m, mo, lim;
    int           err;
@@ -125,7 +125,7 @@ static int tweak_uncrypt(const unsigned char *C, unsigned char *P, unsigned char
       lim = m - 1;
    }
 
-   desc = &cipher_descriptor[xts->cipher];
+   desc = cipher_descriptor[xts->cipher];
 
    if (desc->accel_xts_encrypt && lim > 0) {
 

--- a/core/lib/libtomcrypt/src/modes/xts/xts_done.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_done.c
@@ -49,8 +49,8 @@
 void xts_done(symmetric_xts *xts)
 {
    LTC_ARGCHKVD(xts != NULL);
-   cipher_descriptor[xts->cipher].done(&xts->key1);
-   cipher_descriptor[xts->cipher].done(&xts->key2);
+   cipher_descriptor[xts->cipher]->done(&xts->key1);
+   cipher_descriptor[xts->cipher]->done(&xts->key2);
 }
 
 #endif

--- a/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
@@ -59,7 +59,7 @@ static int tweak_crypt(const unsigned char *P, unsigned char *C, unsigned char *
    }
 #endif
      
-   if ((err = cipher_descriptor[xts->cipher].ecb_encrypt(C, C, &xts->key1)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[xts->cipher]->ecb_encrypt(C, C, &xts->key1)) != CRYPT_OK) {
       return err;
    }
 
@@ -97,7 +97,7 @@ int xts_encrypt(
 #endif
          symmetric_xts *xts)
 {
-   struct ltc_cipher_descriptor *desc;
+   const struct ltc_cipher_descriptor *desc;
    unsigned char PP[16], CC[16], T[16];
    unsigned long i, m, mo, lim;
    int           err;
@@ -128,7 +128,7 @@ int xts_encrypt(
       lim = m - 1;
    }
 
-   desc = &cipher_descriptor[xts->cipher];
+   desc = cipher_descriptor[xts->cipher];
 
    if (desc->accel_xts_encrypt && lim > 0) {
 

--- a/core/lib/libtomcrypt/src/modes/xts/xts_init.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_init.c
@@ -72,15 +72,15 @@ int xts_start(                int  cipher,
       return err;
    }
 
-   if (cipher_descriptor[cipher].block_length != 16) {
+   if (cipher_descriptor[cipher]->block_length != 16) {
       return CRYPT_INVALID_ARG;
    }
 
    /* schedule the two ciphers */
-   if ((err = cipher_descriptor[cipher].setup(key1, keylen, num_rounds, &xts->key1)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->setup(key1, keylen, num_rounds, &xts->key1)) != CRYPT_OK) {
       return err;
    }
-   if ((err = cipher_descriptor[cipher].setup(key2, keylen, num_rounds, &xts->key2)) != CRYPT_OK) {
+   if ((err = cipher_descriptor[cipher]->setup(key2, keylen, num_rounds, &xts->key2)) != CRYPT_OK) {
       return err;
    }
    xts->cipher = cipher;

--- a/core/lib/libtomcrypt/src/pk/dh/dh.c
+++ b/core/lib/libtomcrypt/src/pk/dh/dh.c
@@ -111,7 +111,7 @@ int dh_make_key(prng_state *prng, int wprng, void *q, int xbits, dh_key *key)
 
 	for (i = 0; (i < limit) && (!found); i++) {
 		/* generate the private key in a raw-buffer */
-		if (prng_descriptor[wprng].read(buf, key_size, prng) !=
+		if (prng_descriptor[wprng]->read(buf, key_size, prng) !=
 		    (unsigned long)key_size) {
 			err = CRYPT_ERROR_READPRNG;
 			goto error;

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_encrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_encrypt_key.c
@@ -80,7 +80,7 @@ int dsa_encrypt_key(const unsigned char *in,   unsigned long inlen,
        return err;
     }
 
-    if (inlen > hash_descriptor[hash].hashsize) {
+    if (inlen > hash_descriptor[hash]->hashsize) {
        return CRYPT_INVALID_HASH;
     }
 
@@ -136,7 +136,7 @@ int dsa_encrypt_key(const unsigned char *in,   unsigned long inlen,
     }
 
     err = der_encode_sequence_multi(out, outlen,
-                                    LTC_ASN1_OBJECT_IDENTIFIER,  hash_descriptor[hash].OIDlen,   hash_descriptor[hash].OID,
+                                    LTC_ASN1_OBJECT_IDENTIFIER,  hash_descriptor[hash]->OIDlen,   hash_descriptor[hash]->OID,
                                     LTC_ASN1_INTEGER,            1UL,                            g_pub,
                                     LTC_ASN1_OCTET_STRING,       inlen,                          skey,
                                     LTC_ASN1_EOL,                0UL,                            NULL);

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_encrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_encrypt_key.c
@@ -104,7 +104,7 @@ int dsa_encrypt_key(const unsigned char *in,   unsigned long inlen,
     
     /* make a random x, g^x pair */
     x = mp_unsigned_bin_size(key->q);
-    if (prng_descriptor[wprng].read(expt, x, prng) != x) {
+    if (prng_descriptor[wprng]->read(expt, x, prng) != x) {
        err = CRYPT_ERROR_READPRNG;
        goto LBL_ERR;
     }

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_make_key.c
@@ -92,7 +92,7 @@ int dsa_make_key(prng_state *prng, int wprng, int group_size, int modulus_size, 
    if ((err = mp_add(key->q, key->q, tmp)) != CRYPT_OK)                                { goto error; }
 
    /* now make a random string and multply it against q */
-   if (prng_descriptor[wprng].read(buf+1, modulus_size - group_size, prng) != (unsigned long)(modulus_size - group_size)) {
+   if (prng_descriptor[wprng]->read(buf+1, modulus_size - group_size, prng) != (unsigned long)(modulus_size - group_size)) {
       err = CRYPT_ERROR_READPRNG;
       goto error;
    }
@@ -132,7 +132,7 @@ int dsa_make_key(prng_state *prng, int wprng, int group_size, int modulus_size, 
       Now we need a random exponent [mod q] and it's power g^x mod p 
     */
    do {
-      if (prng_descriptor[wprng].read(buf, group_size, prng) != (unsigned long)group_size) {
+      if (prng_descriptor[wprng]->read(buf, group_size, prng) != (unsigned long)group_size) {
          err = CRYPT_ERROR_READPRNG;
          goto error;
       }

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_sign_hash.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_sign_hash.c
@@ -92,7 +92,7 @@ retry:
 
    do {
       /* gen random k */
-      if (prng_descriptor[wprng].read(buf, key->qord, prng) != (unsigned long)key->qord) {
+      if (prng_descriptor[wprng]->read(buf, key->qord, prng) != (unsigned long)key->qord) {
          err = CRYPT_ERROR_READPRNG;
          goto error;
       }

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_make_key.c
@@ -103,7 +103,7 @@ int ecc_make_key_ex(prng_state *prng, int wprng, ecc_key *key, const ltc_ecc_set
    }
 
    /* make up random string */
-   if (prng_descriptor[wprng].read(buf, (unsigned long)keysize, prng) != (unsigned long)keysize) {
+   if (prng_descriptor[wprng]->read(buf, (unsigned long)keysize, prng) != (unsigned long)keysize) {
       err = CRYPT_ERROR_READPRNG;
       goto ERR_BUF;
    }

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_mgf1.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_mgf1.c
@@ -72,7 +72,7 @@ int pkcs_1_mgf1(int                  hash_idx,
    }
 
    /* get hash output size */
-   hLen = hash_descriptor[hash_idx].hashsize;
+   hLen = hash_descriptor[hash_idx]->hashsize;
 
    /* allocate memory */
    md  = XMALLOC(sizeof(hash_state));
@@ -96,16 +96,16 @@ int pkcs_1_mgf1(int                  hash_idx,
        ++counter;
 
        /* get hash of seed || counter */
-       if ((err = hash_descriptor[hash_idx].init(md)) != CRYPT_OK) {
+       if ((err = hash_descriptor[hash_idx]->init(md)) != CRYPT_OK) {
           goto LBL_ERR;
        }
-       if ((err = hash_descriptor[hash_idx].process(md, seed, seedlen)) != CRYPT_OK) {
+       if ((err = hash_descriptor[hash_idx]->process(md, seed, seedlen)) != CRYPT_OK) {
           goto LBL_ERR;
        }
-       if ((err = hash_descriptor[hash_idx].process(md, buf, 4)) != CRYPT_OK) {
+       if ((err = hash_descriptor[hash_idx]->process(md, buf, 4)) != CRYPT_OK) {
           goto LBL_ERR;
        }
-       if ((err = hash_descriptor[hash_idx].done(md, buf)) != CRYPT_OK) {
+       if ((err = hash_descriptor[hash_idx]->done(md, buf)) != CRYPT_OK) {
           goto LBL_ERR;
        }
 

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_decode.c
@@ -79,7 +79,7 @@ int pkcs_1_oaep_decode(const unsigned char *msg,    unsigned long msglen,
    if ((err = hash_is_valid(hash_idx)) != CRYPT_OK) { 
       return err;
    }
-   hLen        = hash_descriptor[hash_idx].hashsize;
+   hLen        = hash_descriptor[hash_idx]->hashsize;
    modulus_len = (modulus_bitlen >> 3) + (modulus_bitlen & 7 ? 1 : 0);
 
    /* test hash/message size */

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_encode.c
@@ -82,7 +82,7 @@ int pkcs_1_oaep_encode(const unsigned char *msg,    unsigned long msglen,
       return err;
    }
 
-   hLen        = hash_descriptor[hash_idx].hashsize;
+   hLen        = hash_descriptor[hash_idx]->hashsize;
    modulus_len = (modulus_bitlen >> 3) + (modulus_bitlen & 7 ? 1 : 0);
 
    /* test message size */

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_encode.c
@@ -135,7 +135,7 @@ int pkcs_1_oaep_encode(const unsigned char *msg,    unsigned long msglen,
    x += msglen;
 
    /* now choose a random seed */
-   if (prng_descriptor[prng_idx].read(seed, hLen, prng) != hLen) {
+   if (prng_descriptor[prng_idx]->read(seed, hLen, prng) != hLen) {
       err = CRYPT_ERROR_READPRNG;
       goto LBL_ERR;
    }

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -77,7 +77,7 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
       return err;
    }
 
-   hLen        = hash_descriptor[hash_idx].hashsize;
+   hLen        = hash_descriptor[hash_idx]->hashsize;
    modulus_len = (modulus_bitlen>>3) + (modulus_bitlen & 7 ? 1 : 0);
 
    /* check sizes */
@@ -158,20 +158,20 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
    }
 
    /* M = (eight) 0x00 || msghash || salt, mask = H(M) */
-   if ((err = hash_descriptor[hash_idx].init(&md)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->init(&md)) != CRYPT_OK) {
       goto LBL_ERR;
    }
    zeromem(mask, 8);
-   if ((err = hash_descriptor[hash_idx].process(&md, mask, 8)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->process(&md, mask, 8)) != CRYPT_OK) {
       goto LBL_ERR;
    }
-   if ((err = hash_descriptor[hash_idx].process(&md, msghash, msghashlen)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->process(&md, msghash, msghashlen)) != CRYPT_OK) {
       goto LBL_ERR;
    }
-   if ((err = hash_descriptor[hash_idx].process(&md, DB+x, saltlen)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->process(&md, DB+x, saltlen)) != CRYPT_OK) {
       goto LBL_ERR;
    }
-   if ((err = hash_descriptor[hash_idx].done(&md, mask)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->done(&md, mask)) != CRYPT_OK) {
       goto LBL_ERR;
    }
 

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_encode.c
@@ -112,7 +112,7 @@ int pkcs_1_pss_encode(const unsigned char *msghash, unsigned long msghashlen,
 
    /* generate random salt */
    if (saltlen > 0) {
-      if (prng_descriptor[prng_idx].read(salt, saltlen, prng) != saltlen) {
+      if (prng_descriptor[prng_idx]->read(salt, saltlen, prng) != saltlen) {
          err = CRYPT_ERROR_READPRNG;
          goto LBL_ERR;
       }

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_encode.c
@@ -80,7 +80,7 @@ int pkcs_1_pss_encode(const unsigned char *msghash, unsigned long msghashlen,
       return err;
    }
 
-   hLen        = hash_descriptor[hash_idx].hashsize;
+   hLen        = hash_descriptor[hash_idx]->hashsize;
    modulus_len = (modulus_bitlen>>3) + (modulus_bitlen & 7 ? 1 : 0);
 
    /* check sizes */
@@ -119,20 +119,20 @@ int pkcs_1_pss_encode(const unsigned char *msghash, unsigned long msghashlen,
    }
 
    /* M = (eight) 0x00 || msghash || salt, hash = H(M) */
-   if ((err = hash_descriptor[hash_idx].init(&md)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->init(&md)) != CRYPT_OK) {
       goto LBL_ERR;
    }
    zeromem(DB, 8);
-   if ((err = hash_descriptor[hash_idx].process(&md, DB, 8)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->process(&md, DB, 8)) != CRYPT_OK) {
       goto LBL_ERR;
    }
-   if ((err = hash_descriptor[hash_idx].process(&md, msghash, msghashlen)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->process(&md, msghash, msghashlen)) != CRYPT_OK) {
       goto LBL_ERR;
    }
-   if ((err = hash_descriptor[hash_idx].process(&md, salt, saltlen)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->process(&md, salt, saltlen)) != CRYPT_OK) {
       goto LBL_ERR;
    }
-   if ((err = hash_descriptor[hash_idx].done(&md, hash)) != CRYPT_OK) {
+   if ((err = hash_descriptor[hash_idx]->done(&md, hash)) != CRYPT_OK) {
       goto LBL_ERR;
    }
 

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_encode.c
@@ -101,7 +101,7 @@ int pkcs_1_v1_5_encode(const unsigned char *msg,
 
   if (block_type == LTC_LTC_PKCS_1_EME) {
     /* now choose a random ps */
-    if (prng_descriptor[prng_idx].read(ps, ps_len, prng) != ps_len) {
+    if (prng_descriptor[prng_idx]->read(ps, ps_len, prng) != ps_len) {
       result = CRYPT_ERROR_READPRNG;
       goto bail;
     }
@@ -109,7 +109,7 @@ int pkcs_1_v1_5_encode(const unsigned char *msg,
     /* transform zero bytes (if any) to non-zero random bytes */
     for (i = 0; i < ps_len; i++) {
       while (ps[i] == 0) {
-        if (prng_descriptor[prng_idx].read(&ps[i], 1, prng) != 1) {
+        if (prng_descriptor[prng_idx]->read(&ps[i], 1, prng) != 1) {
           result = CRYPT_ERROR_READPRNG;
           goto bail;
         }

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_sign_hash.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_sign_hash.c
@@ -111,7 +111,7 @@ int rsa_sign_hash_ex(const unsigned char *in,       unsigned long  inlen,
     ltc_asn1_list digestinfo[2], siginfo[2];
 
     /* not all hashes have OIDs... so sad */
-    if (hash_descriptor[hash_idx].OIDlen == 0) {
+    if (hash_descriptor[hash_idx]->OIDlen == 0) {
        return CRYPT_INVALID_ARG;
     }
 
@@ -123,7 +123,7 @@ int rsa_sign_hash_ex(const unsigned char *in,       unsigned long  inlen,
          hash    OCTET STRING 
       }
    */
-    LTC_SET_ASN1(digestinfo, 0, LTC_ASN1_OBJECT_IDENTIFIER, hash_descriptor[hash_idx].OID, hash_descriptor[hash_idx].OIDlen);
+    LTC_SET_ASN1(digestinfo, 0, LTC_ASN1_OBJECT_IDENTIFIER, hash_descriptor[hash_idx]->OID, hash_descriptor[hash_idx]->OIDlen);
     LTC_SET_ASN1(digestinfo, 1, LTC_ASN1_NULL,              NULL,                          0);
     LTC_SET_ASN1(siginfo,    0, LTC_ASN1_SEQUENCE,          digestinfo,                    2);
     LTC_SET_ASN1(siginfo,    1, LTC_ASN1_OCTET_STRING,      in,                            inlen);

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
@@ -128,7 +128,7 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
     ltc_asn1_list digestinfo[2], siginfo[2];
 
     /* not all hashes have OIDs... so sad */
-    if (hash_descriptor[hash_idx].OIDlen == 0) {
+    if (hash_descriptor[hash_idx]->OIDlen == 0) {
        err = CRYPT_INVALID_ARG;
        goto bail_2;
     }
@@ -166,8 +166,8 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
     }
 
     /* test OID */
-    if ((digestinfo[0].size == hash_descriptor[hash_idx].OIDlen) &&
-        (XMEMCMP(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
+    if ((digestinfo[0].size == hash_descriptor[hash_idx]->OIDlen) &&
+        (XMEMCMP(digestinfo[0].data, hash_descriptor[hash_idx]->OID, sizeof(unsigned long) * hash_descriptor[hash_idx]->OIDlen) == 0) &&
         (siginfo[1].size == hashlen) &&
         (XMEMCMP(siginfo[1].data, hash, hashlen) == 0)) {
        *stat = 1;

--- a/core/lib/libtomcrypt/src/prngs/rng_make_prng.c
+++ b/core/lib/libtomcrypt/src/prngs/rng_make_prng.c
@@ -67,7 +67,7 @@ int rng_make_prng(int bits, int wprng, prng_state *prng,
       return CRYPT_INVALID_PRNGSIZE;
    }
 
-   if ((err = prng_descriptor[wprng].start(prng)) != CRYPT_OK) {
+   if ((err = prng_descriptor[wprng]->start(prng)) != CRYPT_OK) {
       return err;
    }
 
@@ -76,11 +76,11 @@ int rng_make_prng(int bits, int wprng, prng_state *prng,
       return CRYPT_ERROR_READPRNG;
    }
 
-   if ((err = prng_descriptor[wprng].add_entropy(buf, (unsigned long)bits, prng)) != CRYPT_OK) {
+   if ((err = prng_descriptor[wprng]->add_entropy(buf, (unsigned long)bits, prng)) != CRYPT_OK) {
       return err;
    }
 
-   if ((err = prng_descriptor[wprng].ready(prng)) != CRYPT_OK) {
+   if ((err = prng_descriptor[wprng]->ready(prng)) != CRYPT_OK) {
       return err;
    }
 

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -1899,7 +1899,7 @@ static TEE_Result cipher_get_block_size(uint32_t algo, size_t *size)
 	if (res != TEE_SUCCESS)
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	*size = cipher_descriptor[ltc_cipherindex].block_length;
+	*size = cipher_descriptor[ltc_cipherindex]->block_length;
 	return TEE_SUCCESS;
 }
 
@@ -2025,7 +2025,7 @@ static TEE_Result cipher_init(void *ctx, uint32_t algo,
 	case TEE_ALG_AES_CBC_NOPAD:
 	case TEE_ALG_DES_CBC_NOPAD:
 		if (iv_len !=
-		    (size_t)cipher_descriptor[ltc_cipherindex].block_length)
+		    (size_t)cipher_descriptor[ltc_cipherindex]->block_length)
 			return TEE_ERROR_BAD_PARAMETERS;
 		ltc_res = cbc_start(
 			ltc_cipherindex, iv, key1, key1_len,
@@ -2037,7 +2037,7 @@ static TEE_Result cipher_init(void *ctx, uint32_t algo,
 		get_des2_key(key1, key1_len, key_array,
 			     &real_key, &real_key_len);
 		if (iv_len !=
-		    (size_t)cipher_descriptor[ltc_cipherindex].block_length)
+		    (size_t)cipher_descriptor[ltc_cipherindex]->block_length)
 			return TEE_ERROR_BAD_PARAMETERS;
 		ltc_res = cbc_start(
 			ltc_cipherindex, iv, real_key, real_key_len,
@@ -2047,7 +2047,7 @@ static TEE_Result cipher_init(void *ctx, uint32_t algo,
 #if defined(CFG_CRYPTO_CTR)
 	case TEE_ALG_AES_CTR:
 		if (iv_len !=
-		    (size_t)cipher_descriptor[ltc_cipherindex].block_length)
+		    (size_t)cipher_descriptor[ltc_cipherindex]->block_length)
 			return TEE_ERROR_BAD_PARAMETERS;
 		ltc_res = ctr_start(
 			ltc_cipherindex, iv, key1, key1_len,
@@ -2314,7 +2314,7 @@ static TEE_Result mac_init(void *ctx, uint32_t algo, const uint8_t *key,
 			return res;
 
 		cbc->block_len =
-			cipher_descriptor[ltc_cipherindex].block_length;
+			cipher_descriptor[ltc_cipherindex]->block_length;
 		if (CBCMAC_MAX_BLOCK_LEN < cbc->block_len)
 			return TEE_ERROR_BAD_PARAMETERS;
 		memset(iv, 0, cbc->block_len);

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -156,11 +156,11 @@ static TEE_Result tee_ltc_prng_init(struct tee_ltc_prng *prng)
 	if (prng_index == -1)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = prng_descriptor[prng_index].start(&prng->state);
+	res = prng_descriptor[prng_index]->start(&prng->state);
 	if (res != CRYPT_OK)
 		return TEE_ERROR_BAD_STATE;
 
-	res = prng_descriptor[prng_index].ready(&prng->state);
+	res = prng_descriptor[prng_index]->ready(&prng->state);
 	if (res != CRYPT_OK)
 		return TEE_ERROR_BAD_STATE;
 
@@ -2892,7 +2892,7 @@ static TEE_Result prng_read(void *buf, size_t blen)
 	if (err != CRYPT_OK)
 		return TEE_ERROR_BAD_STATE;
 
-	if (prng_descriptor[prng->index].read(buf, blen, &prng->state) !=
+	if (prng_descriptor[prng->index]->read(buf, blen, &prng->state) !=
 			(unsigned long)blen)
 		return TEE_ERROR_BAD_STATE;
 
@@ -2909,7 +2909,7 @@ static TEE_Result prng_add_entropy(const uint8_t *inbuf, size_t len)
 	if (err != CRYPT_OK)
 		return TEE_ERROR_BAD_STATE;
 
-	err = prng_descriptor[prng->index].add_entropy(
+	err = prng_descriptor[prng->index]->add_entropy(
 			inbuf, len, &prng->state);
 
 	if (err != CRYPT_OK)

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -401,7 +401,7 @@ static TEE_Result hash_init(void *ctx, uint32_t algo)
 	if (ltc_res != TEE_SUCCESS)
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	if (hash_descriptor[ltc_hashindex].init(ctx) == CRYPT_OK)
+	if (hash_descriptor[ltc_hashindex]->init(ctx) == CRYPT_OK)
 		return TEE_SUCCESS;
 	else
 		return TEE_ERROR_BAD_STATE;
@@ -417,7 +417,7 @@ static TEE_Result hash_update(void *ctx, uint32_t algo,
 	if (ltc_res != TEE_SUCCESS)
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	if (hash_descriptor[ltc_hashindex].process(ctx, data, len) == CRYPT_OK)
+	if (hash_descriptor[ltc_hashindex]->process(ctx, data, len) == CRYPT_OK)
 		return TEE_SUCCESS;
 	else
 		return TEE_ERROR_BAD_STATE;
@@ -439,7 +439,7 @@ static TEE_Result hash_final(void *ctx, uint32_t algo, uint8_t *digest,
 	if (len == 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	hash_size = hash_descriptor[ltc_hashindex].hashsize;
+	hash_size = hash_descriptor[ltc_hashindex]->hashsize;
 
 	if (hash_size > len) {
 		if (hash_size > sizeof(block_digest))
@@ -448,7 +448,7 @@ static TEE_Result hash_final(void *ctx, uint32_t algo, uint8_t *digest,
 	} else {
 		tmp_digest = digest;
 	}
-	if (hash_descriptor[ltc_hashindex].done(ctx, tmp_digest) == CRYPT_OK) {
+	if (hash_descriptor[ltc_hashindex]->done(ctx, tmp_digest) == CRYPT_OK) {
 		if (hash_size > len)
 			memcpy(digest, tmp_digest, len);
 	} else {


### PR DESCRIPTION
Meassured on qemu target this PR reduces memory usage from:
```
RAM Usage        7DF00000 - 7DF4E000 size 0004E000 312 KiB 78 pages
.text            7DF00000 - 7DF224E0 size 000224E0 137 KiB
.rodata          7DF224E0 - 7DF29060 size 00006B80  26 KiB
.data            7DF29060 - 7DF2B168 size 00002108   8 KiB
.bss             7DF2B168 - 7DF3BBC0 size 00010A58  66 KiB
.heap1           7DF3BBC0 - 7DF44000 size 00008440  33 KiB
.nozi            7DF44000 - 7DF4E000 size 0000A000  40 KiB
```
to
```
RAM Usage        7DF00000 - 7DF46000 size 00046000 280 KiB 70 pages
.text            7DF00000 - 7DF1E200 size 0001E200 120 KiB
.rodata          7DF1E200 - 7DF24CD0 size 00006AD0  26 KiB
.data            7DF24CD0 - 7DF26DC0 size 000020F0   8 KiB
.bss             7DF26DC0 - 7DF35A94 size 0000ECD4  59 KiB
.heap1           7DF35A94 - 7DF3C000 size 0000656C  25 KiB
.nozi            7DF3C000 - 7DF46000 size 0000A000  40 KiB
```
