### PR TITLE
arm: fix stack size

### DIFF
--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -54,10 +54,27 @@ void __utee_entry(unsigned long func, unsigned long session_id,
 			struct utee_params *up, unsigned long cmd_id)
 			__noreturn;
 
+/*
+ * According to GP Internal API, TA_STACK_SIZE corresponds to the stack
+ * size used by the TA code itself and does not include stack space
+ * possibly used by the Trusted Core Framework.
+ * Hence, stack_size which is the size of the stack to use,
+ * must be enlarged
+ * It has been set to 2048 to include trace framework and invoke commands
+ */
+#define TA_FRAMEWORK_STACK_SIZE 2048
+
 const struct ta_head ta_head __section(".ta_head") = {
 	/* UUID, unique to each TA */
 	.uuid = TA_UUID,
-	.stack_size = TA_STACK_SIZE,
+	/*
+	 * According to GP Internal API, TA_FRAMEWORK_STACK_SIZE corresponds to
+	 * the stack size used by the TA code itself and does not include stack
+	 * space possibly used by the Trusted Core Framework.
+	 * Hence, stack_size which is the size of the stack to use,
+	 * must be enlarged
+	 */
+	.stack_size = TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
 	.flags = TA_FLAG_USER_MODE | TA_FLAGS,
 #ifdef __ILP32__
 	/*


### PR DESCRIPTION
According to GP Internal API, TA_STACK_SIZE corresponds to the stack
size used by the TA code itself and does not include stack space
possibly used by the Trusted Core Framework.
Hence, stack_size which is the size of the stack to use,
must be enlarged.

Without this patch, on FVP, xtest 1012, based on ta/sims, fails because
TA_STACK_SIZE is defined as 1024, which is too low.

Note that the number 1152 has been found experimentally, using a
TA that does nothing, on FVP.

Signed-off-by: Pascal Brand <pascal.brand@st.com>