### PR TITLE
Add CLFAGS to libgcc lookup command

### DIFF
--- a/mk/gcc.mk
+++ b/mk/gcc.mk
@@ -12,7 +12,7 @@ nostdinc$(sm)	:= -nostdinc -isystem $(shell $(CC$(sm)) \
 			-print-file-name=include 2> /dev/null)
 
 # Get location of libgcc from gcc
-libgcc$(sm)  	:= $(shell $(CC$(sm)) $(comp-cflags$(sm)) \
+libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS) $(comp-cflags$(sm)) \
 			-print-libgcc-file-name 2> /dev/null)
 
 # Define these to something to discover accidental use


### PR DESCRIPTION
GCC requires the --sysroot command line parameter
to find libgcc.a

Signed-off-by: Zoltan Kuscsik <zoltan.kuscsik@linaro.org>