### PR TITLE
Introduce CFLAGS32 and CFLAGS64

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -64,14 +64,14 @@ core-platform-aflags += $(platform-aflags-generic)
 core-platform-aflags += $(platform-aflags-debug-info)
 
 ifeq ($(CFG_ARM64_core),y)
-CROSS_COMPILE_core ?= $(CROSS_COMPILE64)
+arch-bits-core := 64
 core-platform-cppflags += $(arm64-platform-cppflags)
 core-platform-cflags += $(arm64-platform-cflags)
 core-platform-cflags += $(arm64-platform-cflags-generic)
 core-platform-cflags += $(arm64-platform-cflags-no-hard-float)
 core-platform-aflags += $(arm64-platform-aflags)
 else
-CROSS_COMPILE_core ?= $(CROSS_COMPILE32)
+arch-bits-core := 32
 core-platform-cppflags += $(arm32-platform-cppflags)
 core-platform-cflags += $(arm32-platform-cflags)
 core-platform-cflags += $(arm32-platform-cflags-no-hard-float)
@@ -86,7 +86,7 @@ endif
 ifneq ($(filter ta_arm32,$(ta-targets)),)
 # Variables for ta-target/sm "ta_arm32"
 CFG_ARM32_ta_arm32 := y
-CROSS_COMPILE_ta_arm32 ?= $(CROSS_COMPILE32)
+arch-bits-ta_arm32 := 32
 ta_arm32-platform-cppflags += $(arm32-platform-cppflags)
 ta_arm32-platform-cflags += $(arm32-platform-cflags)
 ta_arm32-platform-cflags += $(platform-cflags-optimization)
@@ -113,7 +113,7 @@ endif
 ifneq ($(filter ta_arm64,$(ta-targets)),)
 # Variables for ta-target/sm "ta_arm64"
 CFG_ARM64_ta_arm64 := y
-CROSS_COMPILE_ta_arm64 ?= $(CROSS_COMPILE64)
+arch-bits-ta_arm64 := 64
 ta_arm64-platform-cppflags += $(arm64-platform-cppflags)
 ta_arm64-platform-cflags += $(arm64-platform-cflags)
 ta_arm64-platform-cflags += $(platform-cflags-optimization)
@@ -136,3 +136,6 @@ ta-mk-file-export-vars-ta_arm64 += ta_arm64-platform-aflags
 ta-mk-file-export-add-ta_arm64 += CROSS_COMPILE64 ?= $$(CROSS_COMPILE)_nl_
 ta-mk-file-export-add-ta_arm64 += CROSS_COMPILE_ta_arm64 ?= $$(CROSS_COMPILE64)_nl_
 endif
+
+# Set cross compiler prefix for each submodule
+$(foreach sm, core $(ta-targets), $(eval CROSS_COMPILE_$(sm) ?= $(CROSS_COMPILE$(arch-bits-$(sm)))))

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -71,7 +71,7 @@ ifeq ($$(filter %.c,$1),$1)
 comp-q-$2 := CC
 comp-flags-$2 = $$(filter-out $$(CFLAGS_REMOVE) $$(cflags-remove) \
 			      $$(cflags-remove-$2), \
-		   $$(CFLAGS) $$(CFLAGS_WARNS) \
+		   $$(CFLAGS$$(arch-bits-$$(comp-sm-$2))) $$(CFLAGS_WARNS) \
 		   $$(comp-cflags$$(comp-sm-$2)) $$(cflags$$(comp-sm-$2)) \
 		   $$(cflags-lib$$(comp-lib-$2)) $$(cflags-$2))
 ifeq ($C,1)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -22,6 +22,12 @@ CROSS_COMPILE32 ?= $(CROSS_COMPILE)
 CROSS_COMPILE64 ?= aarch64-linux-gnu-
 COMPILER ?= gcc
 
+# For convenience
+ifdef CFLAGS
+CFLAGS32 ?= $(CFLAGS)
+CFLAGS64 ?= $(CFLAGS)
+endif
+
 # Compiler warning level.
 # Supported values: undefined, 1, 2 and 3. 3 gives more warnings.
 WARNS ?= 3

--- a/mk/gcc.mk
+++ b/mk/gcc.mk
@@ -12,7 +12,7 @@ nostdinc$(sm)	:= -nostdinc -isystem $(shell $(CC$(sm)) \
 			-print-file-name=include 2> /dev/null)
 
 # Get location of libgcc from gcc
-libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS) $(comp-cflags$(sm)) \
+libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) $(comp-cflags$(sm)) \
 			-print-libgcc-file-name 2> /dev/null)
 
 # Define these to something to discover accidental use


### PR DESCRIPTION
This is a fix on top of https://github.com/OP-TEE/optee_os/pull/664.
