### PR TITLE
TA: clean $(link-script-dep)

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -13,7 +13,7 @@ cleanfiles += $(link-out-dir)/$(binary).elf $(link-out-dir)/$(binary).dmp
 cleanfiles += $(link-out-dir)/$(binary).map
 cleanfiles += $(link-out-dir)/$(binary).stripped.elf
 cleanfiles += $(link-out-dir)/$(binary).ta
-cleanfiles += $(link-script-pp)
+cleanfiles += $(link-script-pp) $(link-script-dep)
 
 link-ldflags  = $(LDFLAGS)
 link-ldflags += -pie


### PR DESCRIPTION
Cleaning TA $(link-script-dep) is especially important when
switching from 32bits mode to 64bits mode compilation of the TAs

Signed-off-by: Pascal Brand <pascal.brand@st.com>