### PR TITLE
arm64: add fault type to crash dump

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -108,13 +108,31 @@ static __maybe_unused const char *abort_type_to_str(uint32_t abort_type)
 	return "undef";
 }
 
+static __maybe_unused const char *fault_to_str(uint32_t fault_descr)
+{
+
+	switch (core_mmu_get_fault_type(fault_descr)) {
+	case CORE_MMU_FAULT_ALIGNMENT:
+		return " (alignment fault)";
+	case CORE_MMU_FAULT_TRANSLATION:
+		return " (translation fault)";
+	case CORE_MMU_FAULT_READ_PERMISSION:
+		return " (read permission fault)";
+	case CORE_MMU_FAULT_WRITE_PERMISSION:
+		return " (write permission fault)";
+	default:
+		return "";
+	}
+}
+
 static __maybe_unused void print_detailed_abort(
 				struct abort_info *ai __maybe_unused,
 				const char *ctx __maybe_unused)
 {
 	EMSG_RAW("\n");
-	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "\n",
-		ctx, abort_type_to_str(ai->abort_type), ai->va);
+	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s\n",
+		ctx, abort_type_to_str(ai->abort_type), ai->va,
+		fault_to_str(ai->fault_descr));
 #ifdef ARM32
 	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x  ttbr1 0x%08x  cidr 0x%X\n",
 		 ai->fault_descr, read_ttbr0(), read_ttbr1(),

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -813,6 +813,8 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 	case ESR_EC_SP_ALIGN:
 	case ESR_EC_PC_ALIGN:
 		return CORE_MMU_FAULT_ALIGNMENT;
+	case ESR_EC_IABT_EL0:
+	case ESR_EC_DABT_EL0:
 	case ESR_EC_IABT_EL1:
 	case ESR_EC_DABT_EL1:
 		switch (fault_descr & ESR_FSC_MASK) {


### PR DESCRIPTION
Currently, when a data or instruction abort occurs in a TA, the crash
dump does not clearly show the fault type. One has to decode the
Exception Syndrome Register to understand if it's a translation or
alignment fault for instance. This commit decodes these two likely
values for convenience.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>