### PR TITLE
fix: Add fault type to crash dump

### DIFF
--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -39,7 +39,7 @@
 
 struct abort_info {
 	uint32_t abort_type;
-	uint32_t fault_descr;
+	uint32_t fault_descr;	/* only valid for data of prefetch abort */
 	vaddr_t va;
 	uint32_t pc;
 	struct thread_abort_regs *regs;

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -108,8 +108,12 @@ static __maybe_unused const char *abort_type_to_str(uint32_t abort_type)
 	return "undef";
 }
 
-static __maybe_unused const char *fault_to_str(uint32_t fault_descr)
+static __maybe_unused const char *fault_to_str(uint32_t abort_type,
+			uint32_t fault_descr)
 {
+	/* fault_descr is only valid for data or prefetch abort */
+	if (abort_type != ABORT_TYPE_DATA && abort_type != ABORT_TYPE_PREFETCH)
+		return "";
 
 	switch (core_mmu_get_fault_type(fault_descr)) {
 	case CORE_MMU_FAULT_ALIGNMENT:
@@ -132,7 +136,7 @@ static __maybe_unused void print_detailed_abort(
 	EMSG_RAW("\n");
 	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s\n",
 		ctx, abort_type_to_str(ai->abort_type), ai->va,
-		fault_to_str(ai->fault_descr));
+		fault_to_str(ai->abort_type, ai->fault_descr));
 #ifdef ARM32
 	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x  ttbr1 0x%08x  cidr 0x%X\n",
 		 ai->fault_descr, read_ttbr0(), read_ttbr1(),


### PR DESCRIPTION
Fixes previous f2930adaf8a10f2a6154ae21ec991ce7133fde82 "Add fault type
to crash dump" to only interpret fault_descr for data and prefetch abort
to avoid asserting if fault_descr is 0 for LPAE.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU with LPAE)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>