### PR TITLE
Minimal OP-TEE without user TAs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,7 @@ script:
   - $make CFG_RPMB_FS=y
   - $make CFG_RPMB_FS=y CFG_ENC_FS=n
   - $make CFG_RPMB_FS=y CFG_ENC_FS=n CFG_RPMB_TESTKEY=y
+  - $make CFG_WITH_USER_TA=n CFG_CRYPTO=n CFG_ENC_FS=n CFG_SE_API=n CFG_PCSC_PASSTHRU_READER_DRV=n
 
   # QEMU-ARMv8A
   - $make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,13 @@ include core/core.mk
 # Platform config is supposed to assign the targets
 ta-targets ?= user_ta
 
+ifeq ($(CFG_WITH_USER_TA),y)
 define build-ta-target
 ta-target := $(1)
 include ta/ta.mk
 endef
 $(foreach t, $(ta-targets), $(eval $(call build-ta-target, $(t))))
+endif
 
 .PHONY: clean
 clean:

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -78,7 +78,16 @@ static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
 	return container_of(ctx, struct user_ta_ctx, ctx);
 }
 
+#ifdef CFG_WITH_USER_TA
 TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 			struct tee_ta_session *s);
+#else
+static inline TEE_Result tee_ta_init_user_ta_session(
+			const TEE_UUID *uuid __unused,
+			struct tee_ta_session *s __unused)
+{
+	return TEE_ERROR_ITEM_NOT_FOUND;
+}
+#endif
 
 #endif /*KERNEL_USER_TA_H*/

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -347,6 +347,7 @@ static void handle_user_ta_vfp(void)
 }
 #endif /*CFG_WITH_VFP*/
 
+#ifdef CFG_WITH_USER_TA
 #ifdef ARM32
 /* Returns true if the exception originated from user mode */
 static bool is_user_exception(struct abort_info *ai)
@@ -369,6 +370,12 @@ static bool is_user_exception(struct abort_info *ai)
 	return false;
 }
 #endif /*ARM64*/
+#else /*CFG_WITH_USER_TA*/
+static bool is_user_exception(struct abort_info *ai __unused)
+{
+	return false;
+}
+#endif /*CFG_WITH_USER_TA*/
 
 #ifdef ARM32
 /* Returns true if the exception originated from abort mode */
@@ -386,6 +393,8 @@ static bool is_abort_in_abort_handler(struct abort_info *ai __unused)
 }
 #endif /*ARM64*/
 
+
+#if defined(CFG_WITH_VFP) && defined(CFG_WITH_USER_TA)
 #ifdef ARM32
 
 #define T32_INSTR(w1, w0) \
@@ -467,6 +476,12 @@ static bool is_vfp_fault(struct abort_info *ai)
 	}
 }
 #endif /*ARM64*/
+#else /*CFG_WITH_VFP && CFG_WITH_USER_TA*/
+static bool is_vfp_fault(struct abort_info *ai __unused)
+{
+	return false;
+}
+#endif  /*CFG_WITH_VFP && CFG_WITH_USER_TA*/
 
 static enum fault_type get_fault_type(struct abort_info *ai)
 {

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -1,5 +1,5 @@
 srcs-y += tee_ta_manager.c
-srcs-y += user_ta.c
+srcs-$(CFG_WITH_USER_TA) += user_ta.c
 srcs-y += static_ta.c
 srcs-y += elf_load.c
 srcs-y += tee_time.c

--- a/core/arch/arm/sta/sub.mk
+++ b/core/arch/arm/sta/sub.mk
@@ -2,7 +2,11 @@ srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += sta_self_tests.c
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += core_self_tests.c
 srcs-$(CFG_WITH_STATS) += stats.c
 
+ifeq ($(CFG_SE_API),y)
 srcs-$(CFG_SE_API_SELF_TEST) += se_api_self_tests.c
 cppflags-se_api_self_tests.c-y += -Icore/tee/se
+endif
 
+ifeq ($(CFG_WITH_USER_TA),y)
 srcs-$(CFG_TEE_FS_KEY_MANAGER_TEST) += tee_fs_key_manager_tests.c
+endif

--- a/core/arch/arm/tee/sub.mk
+++ b/core/arch/arm/tee/sub.mk
@@ -1,9 +1,13 @@
+ifeq ($(CFG_WITH_USER_TA),y)
 srcs-y += arch_tee_fs.c
 srcs-y += tee_rpmb.c
 srcs-$(CFG_ARM32_core) += arch_svc_a32.S
 srcs-$(CFG_ARM64_core) += arch_svc_a64.S
 srcs-$(CFG_CACHE_API) += svc_cache.c
 srcs-y += arch_svc.c
+else
+srcs-y += svc_dummy.c
+endif
 srcs-y += entry_std.c
 srcs-y += entry_fast.c
 srcs-y += init.c

--- a/core/arch/arm/tee/svc_dummy.c
+++ b/core/arch/arm/tee/svc_dummy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,62 +24,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <assert.h>
-#include <initcall.h>
-#include <malloc.h>		/* required for inits */
+#include <kernel/thread.h>
+#include <kernel/panic.h>
+#include <tee/arch_svc.h>
 
-#include <sm/tee_mon.h>
-#include <kernel/tee_misc.h>
-#include <mm/core_memprot.h>
-#include <trace.h>
-#include <kernel/time_source.h>
-#include <mm/tee_mmu.h>
-#include <tee/tee_fs.h>
-#include <tee/tee_cryp_provider.h>
-#include <tee/tee_svc.h>
-#include <platform_config.h>
-
-
-#define TEE_MON_MAX_NUM_ARGS    8
-
-extern initcall_t __initcall_start, __initcall_end;
-static void call_initcalls(void)
+void __noreturn tee_svc_handler(struct thread_svc_regs *regs __unused)
 {
-	initcall_t *call;
-
-	for (call = &__initcall_start; call < &__initcall_end; call++) {
-		TEE_Result ret;
-		ret = (*call)();
-		if (ret != TEE_SUCCESS) {
-			EMSG("Initial call 0x%08" PRIxVA " failed",
-			     (vaddr_t)call);
-		}
-	}
-}
-
-TEE_Result init_teecore(void)
-{
-	static int is_first = 1;
-
-	/* (DEBUG) for inits at 1st TEE service: when UART is setup */
-	if (!is_first)
-		return TEE_SUCCESS;
-	is_first = 0;
-
-#ifdef CFG_WITH_USER_TA
-	tee_svc_uref_base = CFG_TEE_LOAD_ADDR;
-#endif
-
-	/* init support for futur mapping of TAs */
-	tee_mmu_kmap_init();
-	teecore_init_pub_ram();
-
-	/* time initialization */
-	time_source_init();
-
-	/* call pre-define initcall routines */
-	call_initcalls();
-
-	IMSG("teecore inits done");
-	return TEE_SUCCESS;
+	/* "Can't happen" as we have no user space TAs */
+	panic();
 }

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -17,14 +17,17 @@ CFG_CRYPTO_PBKDF2 ?= y
 
 endif
 
-srcs-y += tee_svc.c
-cppflags-tee_svc.c-y += -DTEE_IMPL_VERSION=$(TEE_IMPL_VERSION)
-srcs-y += tee_svc_cryp.c
-srcs-y += tee_svc_storage.c
 srcs-y += tee_cryp_utl.c
 srcs-$(CFG_CRYPTO_HKDF) += tee_cryp_hkdf.c
 srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
 srcs-$(CFG_CRYPTO_PBKDF2) += tee_cryp_pbkdf2.c
+
+ifeq ($(CFG_WITH_USER_TA),y)
+
+srcs-y += tee_svc.c
+cppflags-tee_svc.c-y += -DTEE_IMPL_VERSION=$(TEE_IMPL_VERSION)
+srcs-y += tee_svc_cryp.c
+srcs-y += tee_svc_storage.c
 
 ifeq (y,$(CFG_RPMB_FS))
 srcs-y += tee_rpmb_fs_common.c
@@ -39,4 +42,6 @@ srcs-y += tee_obj.c
 srcs-y += tee_pobj.c
 srcs-y += tee_time_generic.c
 
-subdirs-${CFG_SE_API} += se
+endif #CFG_WITH_USER_TA,y
+
+subdirs-$(CFG_SE_API) += se

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -144,3 +144,6 @@ CFG_TA_FLOAT_SUPPORT ?= y
 ifeq ($(CFG_TEE_CORE_DEBUG),1)
 CFG_CORE_UNWIND ?= y
 endif
+
+# Enable support for dynamically loaded user TAs
+CFG_WITH_USER_TA ?= y


### PR DESCRIPTION
Hide all user TA related code under CFG_WITH_USER_TA. When compiled
with:
export CFG_WITH_USER_TA=n
export CFG_SE_API_SELF_TEST=n
export CFG_TEE_FS_KEY_MANAGER_TEST=n
export CFG_CRYPTO=n
export CFG_ENC_FS=n

The size of OP-TEE is reduced to one third of its original size.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU xtest 1001)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>