### PR TITLE
arm: sm: [bugfix] save/restore fiq core registers

### DIFF
--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -36,6 +36,9 @@ struct sm_nsec_ctx {
 	uint32_t irq_spsr;
 	uint32_t irq_sp;
 	uint32_t irq_lr;
+	uint32_t fiq_spsr;
+	uint32_t fiq_sp;
+	uint32_t fiq_lr;
 	uint32_t svc_spsr;
 	uint32_t svc_sp;
 	uint32_t svc_lr;
@@ -69,6 +72,9 @@ struct sm_sec_ctx {
 	uint32_t irq_spsr;
 	uint32_t irq_sp;
 	uint32_t irq_lr;
+	uint32_t fiq_spsr;
+	uint32_t fiq_sp;
+	uint32_t fiq_lr;
 	uint32_t svc_spsr;
 	uint32_t svc_sp;
 	uint32_t svc_lr;

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -384,12 +384,18 @@ UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
 	/* FIQ has a +4 offset for lr compared to preferred return address */
 	sub     lr, lr, #4
-	push	{r0-r12, lr}
+	/*
+	 * We're saving {r0-r3} and the banked fiq registers {r8-r12}. The
+	 * banked fiq registers need to be saved because the secure monitor
+	 * doesn't save those. The treatment of the banked fiq registers is
+	 * somewhat analogous to the lazy save of VFP registers.
+	 */
+	push	{r0-r3, r8-r12, lr}
 	bl	thread_check_canaries
 	ldr	lr, =thread_fiq_handler_ptr
 	ldr	lr, [lr]
 	blx	lr
-	pop	{r0-r12, lr}
+	pop	{r0-r3, r8-r12, lr}
 	movs	pc, lr
 UNWIND(	.fnend)
 END_FUNC thread_fiq_handler

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -43,6 +43,10 @@ UNWIND(	.cantunwind)
 	mrs	r2, spsr
 	stm	r0!, {r2, sp, lr}
 
+	cps	#CPSR_MODE_FIQ
+	mrs	r2, spsr
+	stm	r0!, {r2, sp, lr}
+
 	cps	#CPSR_MODE_SVC
 	mrs	r2, spsr
 	stm	r0!, {r2, sp, lr}
@@ -71,6 +75,10 @@ UNWIND(	.cantunwind)
 	ldm	r0!, {sp, lr}
 
 	cps	#CPSR_MODE_IRQ
+	ldm	r0!, {r2, sp, lr}
+	msr	spsr_fsxc, r2
+
+	cps	#CPSR_MODE_FIQ
 	ldm	r0!, {r2, sp, lr}
 	msr	spsr_fsxc, r2
 
@@ -183,7 +191,7 @@ UNWIND(	.cantunwind)
 
 	/* Update SCR */
 	read_scr r1
-	bic	r1, r1, #(SCR_NS | SCR_FIQ) /* Set NS and FIQ bit in SCR */
+	bic	r1, r1, #(SCR_NS | SCR_FIQ) /* Clear NS and FIQ bit in SCR */
 	write_scr r1
 
 	/* Save non-secure context */


### PR DESCRIPTION
Currently there's a security problem with the FIQ registers for armv7
targets, both with leaking information and that normal world can change
stack pointer for FIQ mode. This patch fixes this problem.

Saves and restores FIQ core registers (spsr, sp, lr) when switching
secre/non-secure state.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (modified QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>