### PR TITLE
Travis: QEMU check: use travis.xml manifest to speed up repo download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_script:
   - (cd $HOME/bin && wget https://storage.googleapis.com/git-repo-downloads/repo && chmod +x repo)
   - export PATH=$HOME/bin:$PATH
   - mkdir $HOME/optee_repo
-  - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git </dev/null && repo sync --no-clone-bundle --no-tags --quiet -j 2)
+  - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git -m travis.xml </dev/null && repo sync --no-clone-bundle --no-tags --quiet -j 2)
   - (cd $HOME/optee_repo/qemu && git submodule update --init dtc)
   - (cd $HOME/optee_repo && mv optee_os optee_os_old && ln -s $MYHOME optee_os)
   - cd $MYHOME


### PR DESCRIPTION
travis.xml clones the Git repositories with depth 1, thereby reducing
the duration of the "repo sync" step from 4-6 minutes down to about 1
min.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>