### PR TITLE
optee_msg: add OPTEE_MSG_RPC_CMD_SHM_FREE

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -483,22 +483,21 @@ bool thread_disable_prealloc_rpc_cache(uint64_t *cookie);
 bool thread_enable_prealloc_rpc_cache(void);
 
 /**
- * Free physical memory previously allocated with one of the
- * thread_rpc_alloc*() functions
+ * Allocates data for struct optee_msg_arg.
  *
- * @cookie: cookie received when allocating the buffer
- */
-void thread_rpc_free(uint64_t cookie);
-
-/**
- * Allocates data for struct teesmc_arg.
- *
- * @size:	size in bytes of struct teesmc_arg
- * @arg:	returned physcial pointer to a struct teesmc_arg buffer, 0 if
- *		allocation failed.
+ * @size:	size in bytes of struct optee_msg_arg
+ * @arg:	returned physcial pointer to a struct optee_msg_arg buffer,
+ *		0 if allocation failed.
  * @cookie:	returned cookie used when freeing the buffer
  */
 void thread_rpc_alloc_arg(size_t size, paddr_t *arg, uint64_t *cookie);
+
+/**
+ * Free physical memory previously allocated with thread_rpc_alloc_arg()
+ *
+ * @cookie:	cookie received when allocating the buffer
+ */
+void thread_rpc_free_arg(uint64_t cookie);
 
 /**
  * Allocates data for payload buffers.
@@ -509,6 +508,13 @@ void thread_rpc_alloc_arg(size_t size, paddr_t *arg, uint64_t *cookie);
  * @cookie:	returned cookie used when freeing the buffer
  */
 void thread_rpc_alloc_payload(size_t size, paddr_t *payload, uint64_t *cookie);
+
+/**
+ * Free physical memory previously allocated with thread_rpc_alloc_payload()
+ *
+ * @cookie:	cookie received when allocating the buffer
+ */
+void thread_rpc_free_payload(uint64_t cookie);
 
 /**
  * Does an RPC using a preallocated argument buffer

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -421,7 +421,7 @@
  * Free memory previously allocated by OPTEE_SMC_RETURN_RPC_ALLOC
  *
  * "Call" register usage:
- * a0	This value, OPTEE_SMC_RETURN_RPC_FREE_ARG
+ * a0	This value, OPTEE_SMC_RETURN_RPC_FREE
  * a1	Upper 32 bits of 64-bit shared memory cookie belonging to this
  *	argument memory
  * a2	Lower 32 bits of 64-bit shared memory cookie belonging to this

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -544,7 +544,7 @@ static TEE_Result rpc_load(const TEE_UUID *uuid, struct shdr **ta,
 	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_LOAD_TA, 2, params);
 out:
 	if (res != TEE_SUCCESS)
-		thread_rpc_free(cta);
+		thread_rpc_free_payload(cta);
 	return res;
 }
 
@@ -686,7 +686,7 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 	 * Free normal world shared memory now that the TA either has been
 	 * copied into secure memory or the TA failed to be initialized.
 	 */
-	thread_rpc_free(cookie_ta);
+	thread_rpc_free_payload(cookie_ta);
 
 	if (res == TEE_SUCCESS)
 		s->ctx->ops = &user_ta_ops;

--- a/core/arch/arm/tee/arch_tee_fs.c
+++ b/core/arch/arm/tee/arch_tee_fs.c
@@ -86,6 +86,6 @@ int tee_fs_send_cmd(struct tee_fs_rpc *bf_cmd, void *data, uint32_t len,
 	res = 0;
 
 exit:
-	thread_rpc_free(cpayload);
+	thread_rpc_free_payload(cpayload);
 	return res;
 }

--- a/core/arch/arm/tee/tee_rpmb.c
+++ b/core/arch/arm/tee/tee_rpmb.c
@@ -347,8 +347,8 @@ static void tee_rpmb_free(struct tee_rpmb_mem *mem)
 	if (!mem)
 		return;
 
-	thread_rpc_free(mem->phreq_cookie);
-	thread_rpc_free(mem->phresp_cookie);
+	thread_rpc_free_payload(mem->phreq_cookie);
+	thread_rpc_free_payload(mem->phresp_cookie);
 	mem->phreq = 0;
 	mem->phreq_cookie = 0;
 	mem->phresp = 0;

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -418,4 +418,16 @@ struct optee_msg_arg {
 /* Memory only shared with non-secure kernel */
 #define OPTEE_MSG_RPC_SHM_TYPE_KERNEL	1
 
+/*
+ * Free shared memory previously allocated with OPTEE_MSG_RPC_CMD_SHM_ALLOC
+ *
+ * [in]  param[0].u.value.a		type of memory one of
+ *					OPTEE_MSG_RPC_SHM_TYPE_* above
+ * [in]  param[0].u.value.b		value of shared memory reference
+ *					returned in param[0].u.tmem.shm_ref
+ *					above
+ */
+#define OPTEE_MSG_RPC_CMD_SHM_FREE	7
+
+
 #endif /* _OPTEE_MSG_H */


### PR DESCRIPTION
Buffers allocated with OPTEE_MSG_RPC_CMD_SHM_ALLOC must be freed
with OPTEE_MSG_RPC_CMD_SHM_FREE to help normal world driver to
route the message correctly.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

This PR depends on using https://github.com/linaro-swg/linux/tree/optee or a branch with corresponding tee driver patches

Merging this PR needs to be synchronized with PRs in optee_client, optee_test, build and manifest.