### PR TITLE
hikey: increase shared memory size from 1 to 2 MiB

### DIFF
--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -101,8 +101,8 @@
 
 #endif /* CFG_WITH_PAGER */
 
-#define CFG_SHMEM_START		0x3EF00000
-#define CFG_SHMEM_SIZE		(1024 * 1024)
+#define CFG_SHMEM_START		0x3EE00000
+#define CFG_SHMEM_SIZE		(2 * 1024 * 1024)
 
 #define CFG_TEE_CORE_NB_CORE	8
 


### PR DESCRIPTION
This is needed to run the latest "generic driver" configuration, i.e.:
  https://github.com/OP-TEE/optee_os/pull/702
  https://github.com/OP-TEE/optee_client/pull/47
  https://github.com/OP-TEE/optee_test/pull/75
  https://github.com/linaro-swg/linux/tree/optee

When the shared memory pool is 1 MiB, xtest 7633 fails with a TA panic
due to memory allocation error. This commit increases the size of the
shared memory pool so that the test will pass.
Note that UEFI (EDK2) reserves the top 32 MiB of the physical address
space (0x3E000000-0x3FFFFFFF) for OP-TEE, so we still have 14 MiB unused
(0x3E000000-0x3EDFFFFF).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>