### PR TITLE
fs: do not call thread_rpc_free() when allocation fails

### DIFF
--- a/core/arch/arm/tee/arch_tee_fs.c
+++ b/core/arch/arm/tee/arch_tee_fs.c
@@ -49,7 +49,7 @@ int tee_fs_send_cmd(struct tee_fs_rpc *bf_cmd, void *data, uint32_t len,
 	thread_rpc_alloc_payload(sizeof(struct tee_fs_rpc) + len,
 				 &phpayload, &cpayload);
 	if (!phpayload)
-		goto exit;
+		return -1;
 
 	if (!ALIGNMENT_IS_OK(phpayload, struct tee_fs_rpc))
 		goto exit;


### PR DESCRIPTION
When thread_rpc_alloc_payload() fails, the cookie is not valid, so
thread_rpc_free() must not be called. This fixes a crash in xtest
7633 when shared memory is not large enough.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>