### PR TITLE
juno: bug fix initialize TCR_EL1

### DIFF
--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -123,6 +123,8 @@
 #define TCR_SH1_SHIFT		28
 #define TCR_EL1_IPS_SHIFT	32
 #define TCR_TG1_4KB		(2ull << 30)
+#define TCR_RES1		(1 << 31)
+
 
 /* Normal memory, Inner/Outer Non-cacheable */
 #define TCR_XRGNX_NC		0x0

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -507,7 +507,8 @@ void core_init_mmu_regs(void)
 	mair |= MAIR_ATTR_SET(ATTR_IWBWA_OWBWA_NTR, ATTR_IWBWA_OWBWA_NTR_INDEX);
 	write_mair_el1(mair);
 
-	tcr  = TCR_XRGNX_WBWA << TCR_IRGN0_SHIFT;
+	tcr = TCR_RES1;
+	tcr |= TCR_XRGNX_WBWA << TCR_IRGN0_SHIFT;
 	tcr |= TCR_XRGNX_WBWA << TCR_ORGN0_SHIFT;
 	tcr |= TCR_SHX_ISH << TCR_SH0_SHIFT;
 	tcr |= tcr_ps_bits << TCR_EL1_IPS_SHIFT;


### PR DESCRIPTION
Prior to this patch TCR_EL1 was incorrectly initialized with bit 32 set
to 0. On Cortex-A57 this bit is RES1 so this bit should always be set to
1, this patch fixes that.

This is related to errata 822227
"Using unsupported 16K translation granules might cause Cortex-A57 to
incorrectly trigger a domain fault"

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (Juno)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>