### PR TITLE
plat-stm: fix traces

### DIFF
--- a/core/arch/arm/plat-stm/asc.S
+++ b/core/arch/arm/plat-stm/asc.S
@@ -53,86 +53,8 @@
 #define BOARD_ASC_TXRESET_REG       ST_ASC_TXRESET(ASC_NUM)
 #define BOARD_ASC_RXRESET_REG       ST_ASC_RXRESET(ASC_NUM)
 
-.section .data
-.balign 4
+.section .text.asc
 
-/*
- * ASC IP HW state: 1 not initialized, 0 HW is ready
- * Note that we rely on NonSecure host to setup the HW.
- */
-asc_state:
-	.word 1
-
-
-.section .text
-.align 5
-
-/*
- * int asc_init(void) - init ASC driver.
- *
- * At least only maps (MMU) the ASC register addresses.
- * We rely on some other SW layer to enable ASC IP (power/clamps/clocks/...)
- */
-FUNC asc_init , :
-UNWIND(	.fnstart)
-    ldr r1, =asc_state
-    mov r0, #0
-    str r0, [r1]
-
-    /* TODO: insure ASC is mapped (check against core_init_mmu()/core_mmu.c) */
-    ldr r0, =0
-    bx lr
-UNWIND(	.fnend)
-END_FUNC asc_init
-
-/*
- * int __asc_xmit(char*) - Transmit a numm terminated string.
- *
- *    R0 is pointer to null-terminated string
- *    Clobbers r0-r3
- */
-FUNC __asc_xmit , :
-UNWIND(	.fnstart)
-
-    ldr r1, =asc_state
-    ldr r1, [r1]
-    cmp r1, #0
-    bne _asc_exit
-
-    LDR r2, =BOARD_ASC_TXBUFFER_REG
-    LDR r3, =BOARD_ASC_STATUS_REG
-
-    /* Output byte */
-nextchr:
-    /* Spin until TX FIFO ready */
-crwait:
-    LDR r1, [r3]
-    ANDS r1, r1, #0x04    /* AND TX FIFO HALF EMPTY flag */
-    BEQ crwait            /* ANDS should have set Z bit if zero */
-
-    LDRB r1, [r0], #1
-    ANDS r1, r1, r1
-    BEQ  _asc_exit
-    CMP r1, #0xa          /* r1 == \n (line feed) ? */
-    BNE notlf
-
-    /* Transmit character extra carriage return for each line feed */
-    LDR r1, =0x0d
-    STR r1, [r2]
-
-    LDR r1, =0x0a         /* replace line feed */
-
-notlf:
-    /* Transmit character */
-    STR r1, [r2]
-
-    /* Keep going */
-    B nextchr
-_asc_exit:
-    LDR r0, =0
-    BX lr
-UNWIND(	.fnend)
-END_FUNC __asc_xmit
 
 /*
  * void __asc_flush(void) - flush ASC tx fifo.
@@ -142,11 +64,6 @@ END_FUNC __asc_xmit
 FUNC __asc_flush , :
 UNWIND(	.fnstart)
 
-    ldr r1, =asc_state
-    ldr r1, [r1]
-    cmp r1, #0
-    bne _flush_exit
-
     LDR r3, =BOARD_ASC_STATUS_REG
 
 flush_wait:
@@ -154,7 +71,6 @@ flush_wait:
     ANDS r1, r1, #0x02   /* AND TX FIFO EMPTY flag */
     BEQ flush_wait          /* ANDS should have set Z bit if zero */
 
-_flush_exit:
     LDR r0, =0
     BX lr
 UNWIND(	.fnend)
@@ -168,11 +84,6 @@ END_FUNC __asc_flush
  */
 FUNC __asc_xmit_char , :
 UNWIND(	.fnstart)
-
-    ldr r1, =asc_state
-    ldr r1, [r1]
-    cmp r1, #0
-    bne __asc_char_exit
 
     LDR r2, =BOARD_ASC_TXBUFFER_REG
     LDR r3, =BOARD_ASC_STATUS_REG

--- a/core/arch/arm/plat-stm/tz_a9init.S
+++ b/core/arch/arm/plat-stm/tz_a9init.S
@@ -36,46 +36,12 @@
 #include <asm.S>
 #include <kernel/unwind.h>
 
-#define CPUID_A9_R2P2_H 0x412f
-#define CPUID_A9_R2P2_L 0xc092
-
 #define CPUID_A9_R3P0_H 0x413f
 #define CPUID_A9_R3P0_L 0xc090
 
 .section .text
 .balign 4
 .code 32
-
-/*
- * arm_secboot_identify_cpu - identify and save CPU version
- *
- * Use scratables registers R0-R3.
- * No stack usage.
- * LR store return address.
- * Trap CPU in case of error.
- */
-FUNC arm_secboot_identify_cpu , :
-UNWIND(	.fnstart)
-
-	mrc  p15, 0, r0, c0, c0, 0  /* read A9 ID */
-	movw r1, #CPUID_A9_R2P2_L
-	movt r1, #CPUID_A9_R2P2_H
-	cmp  r0, r1
-	beq  _ident_a9_r2p2
-	movw r1, #CPUID_A9_R3P0_L
-	movt r1, #CPUID_A9_R3P0_H
-	cmp  r0, r1
-	beq  _ident_a9_r3p0
-	b . /* TODO: unknown id: reset? log? */
-
-_ident_a9_r2p2:
-	/* unsupported version. TODO: needs to be supported */
-	b . /* TODO: unknown id: reset? log? */
-
-_ident_a9_r3p0:
-	mov pc, lr /* back to tzinit */
-UNWIND(	.fnend)
-END_FUNC arm_secboot_identify_cpu
 
 /*
  * Memory Cache Level2 Configuration Function
@@ -306,37 +272,6 @@ _early_a9_r3p0:
 	mov pc, lr /* back to tzinit */
 UNWIND(	.fnend)
 END_FUNC plat_cpu_reset_early
-
-/*
- * arm_secboot_errata - arm errata, specific per core revision
- *
- * Use scratables registers R0-R3.
- * No stack usage.
- * LR store return address.
- * Trap CPU in case of error.
- */
-FUNC arm_secboot_errata , :
-UNWIND(	.fnstart)
-
-	mrc  p15, 0, r0, c0, c0, 0  /* read A9 ID */
-	movw r1, #CPUID_A9_R2P2_L
-	movt r1, #CPUID_A9_R2P2_H
-	cmp  r0, r1
-	beq  _errata_a9_r2p2
-	movw r1, #CPUID_A9_R3P0_L
-	movt r1, #CPUID_A9_R3P0_H
-	cmp  r0, r1
-	beq  _errata_a9_r3p0
-	b . /* TODO: unknown id: reset? log? */
-
-_errata_a9_r2p2:
-	/* unsupported version. TODO: needs to be supported */
-	b . /* TODO: unknown id: reset? log? */
-
-_errata_a9_r3p0:
-	mov pc, lr
-UNWIND(	.fnend)
-END_FUNC arm_secboot_errata
 
 /*
  * A9 secured config, needed only from a single core


### PR DESCRIPTION
On plat-stm, traces IP is initialized by Non Secure world.
Hence no traces can be output while in the booting process.

Signed-off-by: Pascal Brand <pascal.brand@st.com>