### PR TITLE
core: fix build error with CFG_TEE_CORE_DEBUG=y

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ script:
   - $make CFG_CRYPTO_{G,C}CM=n
   - $make CFG_CRYPTO_{MD5,SHA{1,224,256,384,512}}=n
   - $make CFG_WITH_PAGER=y
+  - $make CFG_WITH_PAGER=y CFG_TEE_CORE_DEBUG=y
   - $make CFG_ENC_FS=n
   - $make CFG_ENC_FS=y CFG_FS_BLOCK_CACHE=y
   - $make CFG_ENC_FS=n CFG_FS_BLOCK_CACHE=y

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -48,6 +48,8 @@
 #else
 #define CORE_MMU_PGDIR_SHIFT	20
 #endif
+#define CORE_MMU_PGDIR_SIZE		(1 << CORE_MMU_PGDIR_SHIFT)
+#define CORE_MMU_PGDIR_MASK		(CORE_MMU_PGDIR_SIZE - 1)
 
 /* Devices are mapped using this granularity */
 #define CORE_MMU_DEVICE_SHIFT		CORE_MMU_PGDIR_SHIFT


### PR DESCRIPTION
Fixes build error when CFG_TEE_CORE_DEBUG=y and CFG_WITH_PAGER=y are set
by adding ing CORE_MMU_PGDIR_SIZE and CORE_MMU_PGDIR_MASK.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>