### PR TITLE
core: map TA with strict permissions

### DIFF
--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -72,6 +72,7 @@ struct elf_ehdr {
 /* Replicates the fields we need from Elf{32,64}_Phdr */
 struct elf_phdr {
 	uint32_t p_type;
+	uint32_t p_flags;
 	uintptr_t p_vaddr;
 	size_t p_filesz;
 	size_t p_memsz;
@@ -120,6 +121,7 @@ static uint32_t get_shdr_type(struct elf_load_state *state, size_t idx)
 		(dst)->p_filesz = (src)->p_filesz; \
 		(dst)->p_memsz = (src)->p_memsz; \
 		(dst)->p_offset = (src)->p_offset; \
+		(dst)->p_flags = (src)->p_flags; \
 	} while (0)
 static void copy_phdr(struct elf_phdr *phdr, struct elf_load_state *state,
 			size_t idx)
@@ -386,6 +388,30 @@ TEE_Result elf_load_head(struct elf_load_state *state, size_t head_size,
 		*is_32bit = state->is_32bit;
 	}
 	return res;
+}
+
+TEE_Result elf_load_get_next_segment(struct elf_load_state *state, size_t *idx,
+			vaddr_t *vaddr, size_t *size, uint32_t *flags)
+{
+	struct elf_ehdr ehdr;
+
+	copy_ehdr(&ehdr, state);
+	while (*idx < ehdr.e_phnum) {
+		struct elf_phdr phdr;
+
+		copy_phdr(&phdr, state, *idx);
+		(*idx)++;
+		if (phdr.p_type == PT_LOAD) {
+			if (vaddr)
+				*vaddr = phdr.p_vaddr;
+			if (size)
+				*size = phdr.p_memsz;
+			if (flags)
+				*flags = phdr.p_flags;
+			return TEE_SUCCESS;
+		}
+	}
+	return TEE_ERROR_ITEM_NOT_FOUND;
 }
 
 static TEE_Result e32_process_rel(struct elf_load_state *state, size_t rel_sidx,

--- a/core/arch/arm/kernel/elf_load.h
+++ b/core/arch/arm/kernel/elf_load.h
@@ -37,6 +37,8 @@ TEE_Result elf_load_init(void *hash_ctx, uint32_t hash_algo, uint8_t *nwdata,
 TEE_Result elf_load_head(struct elf_load_state *state, size_t head_size,
 			void **head, size_t *vasize, bool *is_32bit);
 TEE_Result elf_load_body(struct elf_load_state *state, vaddr_t vabase);
+TEE_Result elf_load_get_next_segment(struct elf_load_state *state, size_t *idx,
+			vaddr_t *vaddr, size_t *size, uint32_t *flags);
 void elf_load_final(struct elf_load_state *state);
 
 #endif /*ELF_LOAD_H*/

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -50,6 +50,7 @@
 #include <util.h>
 
 #include "elf_load.h"
+#include "elf_common.h"
 
 #define STACK_ALIGNMENT   (sizeof(long) * 2)
 
@@ -122,11 +123,69 @@ out:
 	return TEE_SUCCESS;
 }
 
+static uint32_t elf_flags_to_mattr(uint32_t flags, bool init_attrs)
+{
+	uint32_t mattr = TEE_MATTR_PRW;
+
+	if (!init_attrs) {
+		if (flags & PF_X)
+			mattr |= TEE_MATTR_UX;
+		if (flags & PF_W)
+			mattr |= TEE_MATTR_UW;
+		if (flags & PF_R)
+			mattr |= TEE_MATTR_UR;
+	}
+
+	return mattr;
+}
+
+static TEE_Result load_elf_segments(struct user_ta_ctx *utc,
+			struct elf_load_state *elf_state, bool init_attrs)
+{
+	TEE_Result res;
+	paddr_t pa;
+	uint32_t mattr;
+	size_t idx = 0;
+
+	tee_mmu_map_clear(utc);
+	/*
+	 * Add stack segment
+	 */
+	pa = virt_to_phys((void *)tee_mm_get_smem(utc->mm_stack));
+	if (!pa)
+		return TEE_ERROR_SECURITY;
+	mattr = elf_flags_to_mattr(PF_W | PF_R, init_attrs);
+	tee_mmu_map_stack(utc, pa, tee_mm_get_bytes(utc->mm_stack), mattr);
+
+	/*
+	 * Add code segment
+	 */
+	pa = virt_to_phys((void *)tee_mm_get_smem(utc->mm));
+	if (!pa)
+		return TEE_ERROR_SECURITY;
+	while (true) {
+		vaddr_t offs;
+		size_t size;
+		uint32_t flags;
+
+		res = elf_load_get_next_segment(elf_state, &idx, &offs, &size,
+						&flags);
+		if (res == TEE_ERROR_ITEM_NOT_FOUND)
+			return TEE_SUCCESS;
+		if (res != TEE_SUCCESS)
+			return res;
+
+		mattr = elf_flags_to_mattr(flags, init_attrs);
+		res = tee_mmu_map_add_segment(utc, pa, offs, size, mattr);
+		if (res != TEE_SUCCESS)
+			return res;
+	}
+}
+
 static TEE_Result load_elf(struct user_ta_ctx *utc, struct shdr *shdr,
 			const struct shdr *nmem_shdr)
 {
 	TEE_Result res;
-	struct tee_ta_param param = { 0 };
 	size_t hash_ctx_size;
 	void *hash_ctx = NULL;
 	uint32_t hash_algo;
@@ -207,7 +266,7 @@ static TEE_Result load_elf(struct user_ta_ctx *utc, struct shdr *shdr,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	res = tee_mmu_map(utc, &param);
+	res = load_elf_segments(utc, elf_state, true /* init attrs */);
 	if (res != TEE_SUCCESS)
 		goto out;
 
@@ -228,8 +287,18 @@ static TEE_Result load_elf(struct user_ta_ctx *utc, struct shdr *shdr,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	if (memcmp(digest, SHDR_GET_HASH(shdr), shdr->hash_size) != 0)
+	if (memcmp(digest, SHDR_GET_HASH(shdr), shdr->hash_size) != 0) {
 		res = TEE_ERROR_SECURITY;
+		goto out;
+	}
+
+	/*
+	 * Replace the init attributes with attributes used when the TA is
+	 * running.
+	 */
+	res = load_elf_segments(utc, elf_state, false /* final attrs */);
+	if (res != TEE_SUCCESS)
+		goto out;
 
 	cache_maintenance_l1(DCACHE_AREA_CLEAN,
 			     (void *)tee_mmu_get_load_addr(&utc->ctx), vasize);
@@ -427,7 +496,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	TEE_ASSERT((utc->ctx.flags & TA_FLAG_EXEC_DDR) != 0);
 
 	/* Map user space memory */
-	res = tee_mmu_map(utc, param);
+	res = tee_mmu_map_param(utc, param);
 	if (res != TEE_SUCCESS)
 		goto cleanup_return;
 

--- a/core/include/mm/tee_mmu.h
+++ b/core/include/mm/tee_mmu.h
@@ -41,11 +41,21 @@ TEE_Result tee_mmu_init(struct user_ta_ctx *utc);
  *---------------------------------------------------------------------------*/
 void tee_mmu_final(struct user_ta_ctx *utc);
 
-/*-----------------------------------------------------------------------------
- * tee_mmu_map - Map parameters, heap, stack and code to user memory map to
- * context
- *---------------------------------------------------------------------------*/
-TEE_Result tee_mmu_map(struct user_ta_ctx *utc, struct tee_ta_param *param);
+/* Map stack of a user TA.  */
+void tee_mmu_map_stack(struct user_ta_ctx *utc, paddr_t pa, size_t size,
+			uint32_t prot);
+/*
+ * Map a code segment of a user TA, this function may be called multiple
+ * times if there's several segments.
+ */
+TEE_Result tee_mmu_map_add_segment(struct user_ta_ctx *utc, paddr_t base_pa,
+			size_t offs, size_t size, uint32_t prot);
+
+void tee_mmu_map_clear(struct user_ta_ctx *utc);
+
+/* Map parameters for a user TA */
+TEE_Result tee_mmu_map_param(struct user_ta_ctx *utc,
+			struct tee_ta_param *param);
 
 
 bool tee_mmu_is_vbuf_inside_ta_private(const struct user_ta_ctx *utc,

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -8,14 +8,20 @@ OUTPUT_ARCH(aarch64)
 #endif
 
 PHDRS {
-	rodata PT_LOAD;
+	/*
+	 * Exec and rodata headers are hard coded to RX and RO
+	 * respectively. This is needed because the binary is relocatable
+	 * and the linker would automatically make any header writeable
+	 * that need to be updated during relocation.
+	 */
+	exec PT_LOAD FLAGS (5);		/* RX */
+	rodata PT_LOAD FLAGS (4);	/* RO */
 	rwdata PT_LOAD;
-	rodata2 PT_LOAD;
 	dyn PT_DYNAMIC;
 }
 
 SECTIONS {
-	.ta_head : {*(.ta_head)} :rodata
+	.ta_head : {*(.ta_head)} :exec
 
 	.text : {
 		*(.text .text.*)
@@ -26,7 +32,7 @@ SECTIONS {
 		/* Workaround for an erratum in ARM's VFP11 coprocessor */
 		*(.vfp11_veneer)
 	}
-	.eh_frame : { *(.eh_frame) }
+	.eh_frame : { *(.eh_frame) } :rodata
 	.rodata : {
 		*(.gnu.linkonce.r.*)
 		*(.rodata .rodata.*)
@@ -61,6 +67,11 @@ SECTIONS {
 	.rel.plt : { *(.rel.plt) }
 	.rela.plt : { *(.rela.plt) }
 
+	.dynamic : { *(.dynamic) } :dyn :rodata
+	.dynsym : { *(.dynsym) } :rodata
+	.dynstr : { *(.dynstr) }
+	.hash : { *(.hash) }
+
 	/* Page align to allow dropping execute bit for RW data */
 	. = ALIGN(4096);
 
@@ -68,19 +79,6 @@ SECTIONS {
 
 	.bss : { *(.bss .bss.* .gnu.linkonce.b.* COMMON) }
 
-	/* Page align to separate from RW data */
-	. = ALIGN(4096);
-
-	.dynamic : { *(.dynamic) } :dyn :rodata2
-	.dynsym : { *(.dynsym) } :rodata2
-	.dynstr : { *(.dynstr) }
-	.hash : { *(.hash) }
-
 	/DISCARD/ : { *(.interp) }
-
-	linker_RO_sections_size = 12;
-	linker_RW_sections_size = 12;
-	linker_res_funcs_ZI_sections_size = 12;
-	linker_rel_dyn_GOT = 12;
 }
 


### PR DESCRIPTION
Maps user TA with strict permissions. Blocks with mixed permissions are
mapped with the union of the permissions. In order to take full
advantage of the strict permissions TAs should be mapped using small
pages, that is, using the config option CFG_SMALL_PAGE_USER_TA = y.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

I've found and corrected the problem (cache attributes for stack and code in user mode) in the original pull request. This pull request replaces  https://github.com/OP-TEE/optee_os/pull/689