### PR TITLE
newlib: Add -fno-builtin to all functions/files

### DIFF
--- a/lib/libutils/isoc/newlib/sub.mk
+++ b/lib/libutils/isoc/newlib/sub.mk
@@ -27,3 +27,5 @@ cflags-remove-strlen.c-y += -Wcast-align
 srcs-y += strnlen.c
 
 srcs-y += abs.c
+
+cflags-y += -ffreestanding


### PR DESCRIPTION
When doing builds with –O3, the GCC compiler in some cases generates
re-entrant code for memset() function which can result in calling itself
infinitely causing overflow of stack & data corruption. One way to
prevent this from happening is to enable the -fno-builtin compiler flag.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (QEMU)
Suggested-by: Alexei Fedorov <alexei.fedorov@arm.com>