### PR TITLE
core: add interrupt framework

### DIFF
--- a/core/arch/arm/plat-sunxi/platform.c
+++ b/core/arch/arm/plat-sunxi/platform.c
@@ -53,6 +53,8 @@ void sunxi_secondary_entry(void);
 
 uint32_t sunxi_secondary_ns_entry;
 
+struct gic_data gic_data;
+
 static int platform_smp_init(void)
 {
 	write32((uint32_t)sunxi_secondary_entry, (PRCM_BASE + PRCM_CPU_SOFT_ENTRY_REG));
@@ -66,7 +68,9 @@ void platform_init(void)
 	 * GIC configuration is initialized in Secure bootloader,
 	 * Initialize GIC base address here for debugging.
 	 */
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
+			   GIC_BASE + GICD_OFFSET);
+	itr_init(&gic_data.chip);
 
 	/* platform smp initialize */
 	platform_smp_init();

--- a/core/arch/arm/plat-sunxi/smp_boot.S
+++ b/core/arch/arm/plat-sunxi/smp_boot.S
@@ -80,6 +80,7 @@ UNWIND(	.cantunwind)
 	bl	sunxi_secondary_fixup
 	
 	/* initialize gic cpu interface */
+	ldr	r0, =gic_data
     	bl      gic_cpu_init
 	
 	/* secure env initialization */

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -3,3 +3,4 @@ srcs-y += tee_dispatch.c
 srcs-y += tee_misc.c
 srcs-y += panic.c
 srcs-y += handle.c
+srcs-y += interrupt.c


### PR DESCRIPTION
Adds interrupt frameworks and adjusts gic driver to fit in.

Update plat-vexpress and sunxi platforms to initialize gic with slightly
modified interface.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU, FVP)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>