### PR TITLE
Update on Debug documentation: there is no tee_entry() function anymore 

### DIFF
--- a/documentation/debug.md
+++ b/documentation/debug.md
@@ -96,8 +96,8 @@ terminal]
 Now it is time to set the breakpoints. For example
 
 ```
-(gdb) b tee_entry
-Breakpoint 1 at 0x7df0e5ba: file core/arch/arm/tee/entry.c, line 386.
+(gdb) b tee_entry_std
+Breakpoint 1 at 0x7df0c7be: file core/arch/arm/tee/entry_std.c, line 268.
 ```
 
 and then start the execution by writing the continue command in gdb.
@@ -111,8 +111,9 @@ When the driver has been loaded and you start using OP-TEE the breakpoint will
 trigger, which will look something like this:
 
 ```
-Breakpoint 1, tee_entry (args=0x7df70918 <stack_tmp+1048>) at core/arch/arm/tee/entry.c:386
-386		switch (args->a0) {
+Breakpoint 1, tee_entry_std (smc_args=0x7df6ff98 <stack_thread+8216>)
+    at core/arch/arm/tee/entry_std.c:268
+268		struct optee_msg_arg *arg = NULL;
 (gdb)
 ```
 


### PR DESCRIPTION
The tee_entry() function is no more, it's replaced by tee_entry_std() and tee_entry_fast().
So updated the Debug documentation accordingly.  Please refer to [issue 768](https://github.com/OP-TEE/optee_os/issues/768)