### PR TITLE
pl061 gpio v2

### DIFF
--- a/core/drivers/gpio.c
+++ b/core/drivers/gpio.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * GPIO -- General Purpose Input/Output
+ *
+ * Defines a simple and generic interface to access GPIO device.
+ *
+ */
+
+#include <assert.h>
+#include <trace.h>
+#include <gpio.h>
+
+/*
+ * The gpio implementation
+ */
+static const struct gpio_ops *ops;
+
+enum gpio_dir gpio_get_direction(int gpio_pin)
+{
+	assert(ops);
+	assert(ops->get_direction != 0);
+	assert(gpio_pin >= 0);
+
+	return ops->get_direction(gpio_pin);
+}
+
+void gpio_set_direction(int gpio_pin, enum gpio_dir direction)
+{
+	assert(ops);
+	assert(ops->set_direction != 0);
+	assert((direction == GPIO_DIR_OUT) || (direction == GPIO_DIR_IN));
+	assert(gpio_pin >= 0);
+
+	ops->set_direction(gpio_pin, direction);
+}
+
+enum gpio_level gpio_get_value(int gpio_pin)
+{
+	assert(ops);
+	assert(ops->get_value != 0);
+	assert(gpio_pin >= 0);
+
+	return ops->get_value(gpio_pin);
+}
+
+void gpio_set_value(int gpio_pin, enum gpio_level value)
+{
+	assert(ops);
+	assert(ops->set_value != 0);
+	assert((value == GPIO_LEVEL_LOW) || (value == GPIO_LEVEL_HIGH));
+	assert(gpio_pin >= 0);
+
+	ops->set_value(gpio_pin, value);
+}
+
+/*
+ * Initialize the gpio. The fields in the provided gpio
+ * ops pointer must be valid.
+ */
+void gpio_init(const struct gpio_ops *ops_ptr)
+{
+	assert(ops_ptr != 0  &&
+		(ops_ptr->get_direction != 0) &&
+		(ops_ptr->set_direction != 0) &&
+		(ops_ptr->get_value != 0) &&
+		(ops_ptr->set_value != 0));
+
+	ops = ops_ptr;
+}

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <trace.h>
+#include <gpio.h>
+#include <io.h>
+#include <util.h>
+#include <drivers/pl061_gpio.h>
+
+#ifndef PLAT_PL061_MAX_GPIOS
+# define PLAT_PL061_MAX_GPIOS	32
+#endif	/* PLAT_PL061_MAX_GPIOS */
+
+#define MAX_GPIO_DEVICES	((PLAT_PL061_MAX_GPIOS + \
+	(GPIOS_PER_PL061 - 1)) / GPIOS_PER_PL061)
+
+#define PL061_GPIO_DIR		0x400
+
+#define GPIOS_PER_PL061		8
+
+static enum gpio_dir pl061_get_direction(int gpio_pin);
+static void pl061_set_direction(int gpio_pin, enum gpio_dir direction);
+static enum gpio_level pl061_get_value(int gpio_pin);
+static void pl061_set_value(int gpio_pin, enum gpio_level value);
+
+static vaddr_t pl061_reg_base[MAX_GPIO_DEVICES];
+
+static const struct gpio_ops pl061_gpio_ops = {
+	.get_direction	= pl061_get_direction,
+	.set_direction	= pl061_set_direction,
+	.get_value	= pl061_get_value,
+	.set_value	= pl061_set_value,
+};
+
+static enum gpio_dir pl061_get_direction(int gpio_pin)
+{
+	vaddr_t base_addr;
+	int data, offset;
+
+	assert((gpio_pin >= 0) && (gpio_pin < PLAT_PL061_MAX_GPIOS));
+
+	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
+	offset = gpio_pin % GPIOS_PER_PL061;
+	data = read8(base_addr + PL061_GPIO_DIR);
+	if (data & BIT(offset))
+		return GPIO_DIR_OUT;
+	return GPIO_DIR_IN;
+}
+
+static void pl061_set_direction(int gpio_pin, enum gpio_dir direction)
+{
+	vaddr_t base_addr;
+	int data, offset;
+
+	assert((gpio_pin >= 0) && (gpio_pin < PLAT_PL061_MAX_GPIOS));
+
+	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
+	offset = gpio_pin % GPIOS_PER_PL061;
+	if (direction == GPIO_DIR_OUT) {
+		data = read8(base_addr + PL061_GPIO_DIR) | BIT(offset);
+		write8(base_addr + PL061_GPIO_DIR, data);
+	} else {
+		data = read8(base_addr + PL061_GPIO_DIR) & ~BIT(offset);
+		write8(base_addr + PL061_GPIO_DIR, data);
+	}
+}
+
+/*
+ * The offset of GPIODATA register is 0.
+ * The values read from GPIODATA are determined for each bit, by the mask bit
+ * derived from the address used to access the data register, PADDR[9:2].
+ * Bits that are 1 in the address mask cause the corresponding bits in GPIODATA
+ * to be read, and bits that are 0 in the address mask cause the corresponding
+ * bits in GPIODATA to be read as 0, regardless of their value.
+ */
+static enum gpio_level pl061_get_value(int gpio_pin)
+{
+	vaddr_t base_addr;
+	int offset;
+
+	assert((gpio_pin >= 0) && (gpio_pin < PLAT_PL061_MAX_GPIOS));
+
+	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
+	offset = gpio_pin % GPIOS_PER_PL061;
+	if (read8(base_addr + BIT(offset + 2)))
+		return GPIO_LEVEL_HIGH;
+	return GPIO_LEVEL_LOW;
+}
+
+/*
+ * In order to write GPIODATA, the corresponding bits in the mask, resulting
+ * from the address bus, PADDR[9:2], must be HIGH. Otherwise the bit values
+ * remain unchanged by the write.
+ */
+static void pl061_set_value(int gpio_pin, enum gpio_level value)
+{
+	vaddr_t base_addr;
+	int offset;
+
+	assert((gpio_pin >= 0) && (gpio_pin < PLAT_PL061_MAX_GPIOS));
+
+	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
+	offset = gpio_pin % GPIOS_PER_PL061;
+	if (value == GPIO_LEVEL_HIGH)
+		write8(base_addr + BIT(offset + 2), BIT(offset));
+	else
+		write8(base_addr + BIT(offset + 2), 0);
+}
+
+
+/*
+ * Register the PL061 GPIO controller with a base address and the offset
+ * of start pin in this GPIO controller.
+ * This function is called after pl061_gpio_ops_init().
+ */
+void pl061_gpio_register(vaddr_t base_addr, int gpio_dev)
+{
+	assert((gpio_dev >= 0) && (gpio_dev < MAX_GPIO_DEVICES));
+
+	pl061_reg_base[gpio_dev] = base_addr;
+}
+
+/*
+ * Initialize PL061 GPIO controller with the total GPIO numbers in SoC.
+ */
+void pl061_gpio_init(void)
+{
+	COMPILE_TIME_ASSERT(PLAT_PL061_MAX_GPIOS > 0);
+	gpio_init(&pl061_gpio_ops);
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -1,5 +1,11 @@
+ifeq ($(CFG_PL061),y)
+$(call force,CFG_GPIO,y,required by CFG_PL061)
+endif
+
 srcs-$(CFG_PL011) += pl011.c
 srcs-$(CFG_GIC) += gic.c
+srcs-$(CFG_GPIO) += gpio.c
+srcs-$(CFG_PL061) += pl061_gpio.c
 srcs-$(CFG_SUNXI_UART) += sunxi_uart.c
 srcs-$(CFG_8250_UART) += serial8250_uart.c
 srcs-$(CFG_16550_UART) += ns16550.c

--- a/core/include/drivers/pl061_gpio.h
+++ b/core/include/drivers/pl061_gpio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,44 +24,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef UTIL_H
-#define UTIL_H
 
-#ifndef MAX
-#define MAX(a, b) \
-	(__extension__({ __typeof__(a) _a = (a); \
-	   __typeof__(b) _b = (b); \
-	 _a > _b ? _a : _b; }))
+#ifndef __PL061_GPIO_H__
+#define __PL061_GPIO_H__
 
-#define MIN(a, b) \
-	(__extension__({ __typeof__(a) _a = (a); \
-	   __typeof__(b) _b = (b); \
-	 _a < _b ? _a : _b; }))
-#endif
+#include <gpio.h>
 
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+void pl061_gpio_register(vaddr_t base_addr, int gpio_dev);
+void pl061_gpio_init(void);
 
-/* Round up the even multiple of size, size has to be a multiple of 2 */
-#define ROUNDUP(v, size) (((v) + ((size) - 1)) & ~((size) - 1))
-
-/* Round down the even multiple of size, size has to be a multiple of 2 */
-#define ROUNDDOWN(v, size) ((v) & ~((size) - 1))
-
-/* x has to be of an unsigned type */
-#define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & (~(x) + 1)) == (x)))
-
-#define ALIGNMENT_IS_OK(p, type) \
-	(((uintptr_t)(p) & (__alignof__(type) - 1)) == 0)
-
-#define TO_STR(x) _TO_STR(x)
-#define _TO_STR(x) #x
-
-#define container_of(ptr, type, member) \
-	(__extension__({ \
-		const typeof(((type *)0)->member) *__ptr = (ptr); \
-		(type *)((unsigned long)(__ptr) - offsetof(type, member)); \
-	}))
-
-#define BIT(nr)			(1UL << (nr))
-
-#endif /*UTIL_H*/
+#endif	/* __PL061_GPIO_H__ */

--- a/core/include/gpio.h
+++ b/core/include/gpio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,44 +24,31 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef UTIL_H
-#define UTIL_H
 
-#ifndef MAX
-#define MAX(a, b) \
-	(__extension__({ __typeof__(a) _a = (a); \
-	   __typeof__(b) _b = (b); \
-	 _a > _b ? _a : _b; }))
+#ifndef __GPIO_H__
+#define __GPIO_H__
 
-#define MIN(a, b) \
-	(__extension__({ __typeof__(a) _a = (a); \
-	   __typeof__(b) _b = (b); \
-	 _a < _b ? _a : _b; }))
-#endif
+enum gpio_dir {
+	GPIO_DIR_OUT,
+	GPIO_DIR_IN
+};
 
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+enum gpio_level {
+	GPIO_LEVEL_LOW,
+	GPIO_LEVEL_HIGH
+};
 
-/* Round up the even multiple of size, size has to be a multiple of 2 */
-#define ROUNDUP(v, size) (((v) + ((size) - 1)) & ~((size) - 1))
+struct gpio_ops {
+	enum gpio_dir (*get_direction)(int gpio_pin);
+	void (*set_direction)(int gpio_pin, enum gpio_dir direction);
+	enum gpio_level (*get_value)(int gpio_pin);
+	void (*set_value)(int gpio_pin, enum gpio_level value);
+};
 
-/* Round down the even multiple of size, size has to be a multiple of 2 */
-#define ROUNDDOWN(v, size) ((v) & ~((size) - 1))
+enum gpio_dir gpio_get_direction(int gpio_pin);
+void gpio_set_direction(int gpio_pin, enum gpio_dir direction);
+enum gpio_level gpio_get_value(int gpio_pin);
+void gpio_set_value(int gpio_pin, enum gpio_level value);
+void gpio_init(const struct gpio_ops *ops);
 
-/* x has to be of an unsigned type */
-#define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & (~(x) + 1)) == (x)))
-
-#define ALIGNMENT_IS_OK(p, type) \
-	(((uintptr_t)(p) & (__alignof__(type) - 1)) == 0)
-
-#define TO_STR(x) _TO_STR(x)
-#define _TO_STR(x) #x
-
-#define container_of(ptr, type, member) \
-	(__extension__({ \
-		const typeof(((type *)0)->member) *__ptr = (ptr); \
-		(type *)((unsigned long)(__ptr) - offsetof(type, member)); \
-	}))
-
-#define BIT(nr)			(1UL << (nr))
-
-#endif /*UTIL_H*/
+#endif	/* __GPIO_H__ */


### PR DESCRIPTION
v2:

1. Move BIT definition to `util.h`
1. Use `enum` instead of `int` for `gpio_dir` and `gpio_level` to make interface clearer
1. Rename function arg `gpio` to `gpio_pin` to prevent confusion 
1. Make `CFG_PL061` depend on `CFG_GPIO`
1. Add `Suggested-by`
