### PR TITLE
core: fix fiq delivery in Aarch64

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -416,7 +416,7 @@ el0_irq_a64:
 	.align	7
 el0_fiq_a64:
 	store_xregs sp, THREAD_CORE_LOCAL_X0, 0, 3
-	b	elx_irq
+	b	elx_fiq
 	check_vector_size el0_fiq_a64
 
 	.align	7


### PR DESCRIPTION
Prior to this patch reception of a FIQ while in secure user mode (secure
EL0) would be treated as if an IRQ was received instead. This resulted
in an exit to normal world and when FIQ was unmasked it would be
re-triggered but this time received as an FIQ received while in normal
world.

This patch fixes this and handles FIQ directly when received while in
secure user mode.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (FVP)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>