### PR TITLE
core: arm: invalidate i-cache inner shareable

### DIFF
--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -71,9 +71,25 @@
 	mcr	p15, 0, r0, c7, c5, 0
 	.endm
 
+	.macro write_icialluis
+	/*
+	 * Invalidate all instruction caches to PoU, Inner Shareable
+	 * (register ignored)
+	 */
+	mcr	p15, 0, r0, c7, c1, 0
+	.endm
+
 	.macro write_bpiall
 	/* Invalidate entire branch predictor array (register ignored) */
 	mcr	p15, 0, r0, c7, c5, 0
+	.endm
+
+	.macro write_bpiallis
+	/*
+	 * Invalidate entire branch predictor array, Inner Shareable
+	 * (register ignored)
+	 */
+	mcr	p15, 0, r0, c7, c1, 6
 	.endm
 
 	.macro write_tlbiall

--- a/core/arch/arm/kernel/ssvce_a32.S
+++ b/core/arch/arm/kernel/ssvce_a32.S
@@ -289,13 +289,11 @@ FUNC arm_cl1_i_inv_all , :
 UNWIND(	.fnstart)
 
     /* Invalidate Entire Instruction Cache */
-    MOV     R0, #0
-    MCR     p15, 0, R0, c7, c5, 0
+    write_icialluis
     DSB
 
     /* Flush entire branch target cache */
-    MOV     R1, #0
-    MCR     p15, 0, R1, c7, c5, 6   /* write to Cache operations register */
+    write_bpiallis
 
     DSB                             /* ensure that maintenance operations are seen */
     ISB                             /* by the instructions rigth after the ISB */


### PR DESCRIPTION
When invalidating i-cache and branch predictor use inner shareable
(icialluis and bpiallis) versions of the operations to make it visible
to other cores.

Fixes occasional problem with pager with multiple active threads.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (HiKey)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Fixes https://github.com/OP-TEE/optee_os/issues/794