### PR TITLE
core: send traces to tee-supplicant when CFG_LOG_SYSLOG=y

### DIFF
--- a/core/arch/arm/include/kernel/syslog.h
+++ b/core/arch/arm/include/kernel/syslog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,33 +24,31 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#ifndef KERNEL_SYSLOG_H
+#define KERNEL_SYSLOG_H
+
 #include <stdbool.h>
-#include <trace.h>
-#include <console.h>
-#include <kernel/thread.h>
-#include <kernel/syslog.h>
-
-const char trace_ext_prefix[] = "TEE-CORE";
-int trace_level = TRACE_LEVEL;
-
-void trace_ext_puts(const char *str)
-{
-	const char *p;
 
 #ifdef CFG_LOG_SYSLOG
-	if (syslog(str))
-		return;
+
+void enable_syslog(void);
+
+/* Send message to normal world for logging. Return true on success. */
+bool syslog(const char *str);
+
+#else
+
+#include <compiler.h>
+
+static inline void enable_syslog(void)
+{
+}
+
+static inline bool syslog(const char *str __unused)
+{
+	return false;
+}
 #endif
 
-	console_flush();
-
-	for (p = str; *p; p++)
-		console_putc(*p);
-
-	console_flush();
-}
-
-int trace_ext_get_thread_id(void)
-{
-	return thread_get_id_may_fail();
-}
+#endif /* KERNEL_SYSLOG_H */

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -43,3 +43,5 @@ ifeq ($(CFG_CORE_UNWIND),y)
 srcs-$(CFG_ARM32_core) += unwind_arm32.c
 srcs-$(CFG_ARM64_core) += unwind_arm64.c
 endif
+
+srcs-$(CFG_LOG_SYSLOG) += syslog.c

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -30,6 +30,7 @@
 #include <keep.h>
 #include <types_ext.h>
 #include <stdlib.h>
+#include <kernel/syslog.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <kernel/user_ta.h>
@@ -560,6 +561,13 @@ static TEE_Result rpc_load(const TEE_UUID *uuid, struct shdr **ta,
 	paddr_t phta = 0;
 	uint64_t cta = 0;
 
+	/*
+	 * HACK - FIXME
+	 * Here we expect tee-supplicant to be available, so tell the syslog
+	 * code that it can start forwarding logs to tee-supplicant.
+	 * Where is the best place to do this?
+	 */
+	enable_syslog();
 
 	if (!uuid || !ta || !cookie_ta)
 		return TEE_ERROR_BAD_PARAMETERS;

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -429,5 +429,9 @@ struct optee_msg_arg {
  */
 #define OPTEE_MSG_RPC_CMD_SHM_FREE	7
 
+/*
+ * Send a log to tee-supplicant
+ */
+#define OPTEE_MSG_RPC_CMD_LOG		8
 
 #endif /* _OPTEE_MSG_H */


### PR DESCRIPTION
Enables integration of TEE messages with the normal world system log
facility (such as syslog).

When CFG_LOG_SYSLOG=y (default: n), log messages are not sent to the
console but to tee-supplicant which then forwards them to the normal
world system logger. "Log messages" means anything logged through
DMSG() etc. or passed to syscall_log(). So, both the TEE core and the
TAs can benefit from this mechanism.

Note that logs are redirected to tee-supplicant only when the first
"load TA" request is received. Before this point, the console is used.

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
Suggested-by: Zoltan Kuscsik zoltan.kuscsik@linaro.org
