### PR TITLE
Change some fs messages to debug

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -1459,7 +1459,7 @@ static int ree_fs_open(TEE_Result *errno, const char *file, int flags, ...)
 	file_exist = tee_file_exists(file);
 	if (flags & TEE_FS_O_CREATE) {
 		if ((flags & TEE_FS_O_EXCL) && file_exist) {
-			EMSG("tee file already exists");
+			DMSG("tee file already exists");
 			*errno = TEE_ERROR_ACCESS_CONFLICT;
 			goto exit;
 		}
@@ -1471,7 +1471,7 @@ static int ree_fs_open(TEE_Result *errno, const char *file, int flags, ...)
 
 	} else {
 		if (!file_exist) {
-			EMSG("tee file not exists");
+			DMSG("tee file not exists");
 			*errno = TEE_ERROR_ITEM_NOT_FOUND;
 			goto exit;
 		}


### PR DESCRIPTION
Trying to open a file that doesn't exist, or trying to write to a file
that does exist are part of normal use of a filesystem.  Demote these
two messages to debug instead of error to avoid flooding the error log
with messages that come from ordinary use.

Signed-off-by: David Brown <david.brown@linaro.org>