### PR TITLE
core: arm32: fix masking exceptions on exit

### DIFF
--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -285,6 +285,7 @@ UNWIND(	.cantunwind)
         mrs     r1, spsr
         stm     r0!, {r1, sp, lr}
 
+	orr	r6, r6, #ARM32_CPSR_FIA	/* Disable Async abort, IRQ and FIQ */
 	msr	cpsr, r6		/* Restore mode */
 
 	mov	r0, r5			/* Return original CPSR */
@@ -308,7 +309,7 @@ UNWIND(	.cantunwind)
 	add	sp, #(4 * 4)
 
 	/* Disable interrupts before switching to temporary stack */
-	cpsid	if
+	cpsid	aif
 	bl	thread_get_tmp_sp
 	mov	sp, r0
 


### PR DESCRIPTION
Before this patch FIQ and asynchronous abort wasn't masked on
all exit paths. This patch fixes that.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>