### PR TITLE
Removing legacy pub_ddr init code

### DIFF
--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -316,9 +316,6 @@ bool tee_mm_is_empty(tee_mm_pool_t *pool)
 	return pool == NULL || pool->entry == NULL || pool->entry->next == NULL;
 }
 
-/* Physical Public DDR pool */
-tee_mm_pool_t tee_mm_pub_ddr __data; /* XXX __data is a workaround */
-
 /* Physical Secure DDR pool */
 tee_mm_pool_t tee_mm_sec_ddr __data; /* XXX __data is a workaround */
 

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -657,7 +657,6 @@ void teecore_init_pub_ram(void)
 {
 	vaddr_t s;
 	vaddr_t e;
-	unsigned int nsec_tee_size = 32 * 1024;
 
 	/* get virtual addr/size of NSec shared mem allcated from teecore */
 	core_mmu_get_mem_by_type(MEM_AREA_NSEC_SHM, &s, &e);
@@ -667,18 +666,6 @@ void teecore_init_pub_ram(void)
 	TEE_ASSERT((e & SMALL_PAGE_MASK) == 0);
 	/* extra check: we could rely on  core_mmu_get_mem_by_type() */
 	TEE_ASSERT(tee_vbuf_is_non_sec(s, e - s) == true);
-
-	/*
-	 * 32kByte first bytes are allocated from teecore.
-	 * Remaining is under control of the NSec allocator.
-	 */
-	TEE_ASSERT((e - s) > nsec_tee_size);
-
-	TEE_ASSERT(tee_mm_is_empty(&tee_mm_pub_ddr));
-	tee_mm_final(&tee_mm_pub_ddr);
-	tee_mm_init(&tee_mm_pub_ddr, s, s + nsec_tee_size, SMALL_PAGE_SHIFT,
-		    TEE_MM_POOL_NO_FLAGS);
-	s += nsec_tee_size;
 
 #ifdef CFG_PL310
 	/* Allocate statically the l2cc mutex */

--- a/core/arch/arm/sta/stats.c
+++ b/core/arch/arm/sta/stats.c
@@ -96,9 +96,7 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[4])
 			break;
 
 		case 2:
-			strlcpy(stats->desc, "Public DDR", sizeof(stats->desc));
-			tee_mm_get_pool_stats(&tee_mm_pub_ddr, stats,
-					      !!p[0].value.b);
+			EMSG("public DDR not managed by secure side anymore");
 			break;
 
 		case 3:

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -57,9 +57,6 @@ struct _tee_mm_pool_t {
 };
 typedef struct _tee_mm_pool_t tee_mm_pool_t;
 
-/* Physical Public DDR pool */
-extern tee_mm_pool_t tee_mm_pub_ddr;
-
 /* Physical Secure DDR pool */
 extern tee_mm_pool_t tee_mm_sec_ddr;
 


### PR DESCRIPTION
Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org>
Suggested-by: Sandeep Tripathy <sandeep.tripathy@broadcom.com>