### PR TITLE
core: fix tee object attribute management

### DIFF
--- a/core/include/tee/tee_obj.h
+++ b/core/include/tee/tee_obj.h
@@ -39,9 +39,7 @@ struct tee_obj {
 	TEE_ObjectInfo info;
 	bool busy;		/* true if used by an operation */
 	uint32_t have_attrs;	/* bitfield identifying set properties */
-	void *data;
-	size_t data_size;
-	void (*cleanup)(void *data, bool del); /* clear or delete data */
+	void *attr;
 	struct tee_pobj *pobj;	/* ptr to persistant object */
 	int fd;
 	uint32_t ds_size;	/* data stream size */
@@ -58,5 +56,8 @@ void tee_obj_close(struct user_ta_ctx *utc, struct tee_obj *o);
 void tee_obj_close_all(struct user_ta_ctx *utc);
 
 TEE_Result tee_obj_verify(struct tee_ta_session *sess, struct tee_obj *o);
+
+struct tee_obj *tee_obj_alloc(void);
+void tee_obj_free(struct tee_obj *o);
 
 #endif

--- a/core/include/tee/tee_svc_cryp.h
+++ b/core/include/tee/tee_svc_cryp.h
@@ -29,6 +29,7 @@
 
 #include <tee_api_types.h>
 #include <utee_types.h>
+#include <tee/tee_obj.h>
 
 struct user_ta_ctx;
 
@@ -101,5 +102,16 @@ TEE_Result syscall_asymm_verify(unsigned long state,
 			const struct utee_attribute *usr_params,
 			size_t num_params, const void *data, size_t data_len,
 			const void *sig, size_t sig_len);
+
+TEE_Result tee_obj_set_type(struct tee_obj *o, uint32_t obj_type,
+			    size_t max_key_size);
+
+void tee_obj_attr_free(struct tee_obj *o);
+void tee_obj_attr_clear(struct tee_obj *o);
+TEE_Result tee_obj_attr_to_binary(struct tee_obj *o, void *data,
+				  size_t *data_len);
+TEE_Result tee_obj_attr_from_binary(struct tee_obj *o, const void *data,
+				    size_t data_len);
+TEE_Result tee_obj_attr_copy_from(struct tee_obj *o, const struct tee_obj *src);
 
 #endif /* TEE_SVC_CRYP_H */

--- a/core/tee/tee_obj.c
+++ b/core/tee/tee_obj.c
@@ -35,6 +35,7 @@
 #include <tee/tee_pobj.h>
 #include <trace.h>
 #include <tee/tee_svc_storage.h>
+#include <tee/tee_svc_cryp.h>
 
 void tee_obj_add(struct user_ta_ctx *utc, struct tee_obj *o)
 {
@@ -64,10 +65,7 @@ void tee_obj_close(struct user_ta_ctx *utc, struct tee_obj *o)
 		tee_pobj_release(o->pobj);
 	}
 
-	if (o->cleanup)
-		o->cleanup(o->data, true);
-	free(o->data);
-	free(o);
+	tee_obj_free(o);
 }
 
 void tee_obj_close_all(struct user_ta_ctx *utc)
@@ -129,4 +127,18 @@ err:
 		fops->close(fd);
 exit:
 	return res;
+}
+
+struct tee_obj *tee_obj_alloc(void)
+{
+	return calloc(1, sizeof(struct tee_obj));
+}
+
+void tee_obj_free(struct tee_obj *o)
+{
+	if (o) {
+		tee_obj_attr_free(o);
+		free(o->attr);
+		free(o);
+	}
 }


### PR DESCRIPTION
Prior to the patch the attribute management of tee objects occasionally
assumed that the attribute data didn't contain any addresses. This
assumption is incorrect for asymmetric key objects. This patch fixes
that by introducing an operation struct for each basic attribute type.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>