### PR TITLE
hikey: enable 8 threads by default

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -20,5 +20,6 @@ else
 $(call force,CFG_ARM32_core,y)
 endif
 
+CFG_NUM_THREADS ?= 8
 CFG_CRYPTO_WITH_CE ?= y
 CFG_WITH_STACK_CANARIES ?= y


### PR DESCRIPTION
Set CFG_NUM_THREADS to 8 by default for HiKey since the board has
8 cores.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>