### PR TITLE
tee_obj_attr_to_binary: fix short buffer check

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1021,7 +1021,7 @@ TEE_Result tee_obj_attr_to_binary(struct tee_obj *o, void *data,
 	}
 
 	*data_len = offs;
-	if (data && offs > *data_len)
+	if (data && offs > len)
 		return TEE_ERROR_SHORT_BUFFER;
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Fixes short buffer check at end of tee_obj_attr_to_binary().

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>