### PR TITLE
Travis: download Linaro toolchain over HTTP rather than HTTPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - tar xf gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf.tar.xz
   - export PATH=${PWD}/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf/bin:${PATH}
   - arm-linux-gnueabihf-gcc --version
-  - wget https://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/aarch64-linux-gnu/gcc-linaro-5.3-2016.02-x86_64_aarch64-linux-gnu.tar.xz
+  - wget http://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/aarch64-linux-gnu/gcc-linaro-5.3-2016.02-x86_64_aarch64-linux-gnu.tar.xz
   - tar xf gcc-linaro-5.3-2016.02-x86_64_aarch64-linux-gnu.tar.xz
   - export PATH=${PWD}/gcc-linaro-5.3-2016.02-x86_64_aarch64-linux-gnu/bin:${PATH}
   - aarch64-linux-gnu-gcc --version


### PR DESCRIPTION
It happened a few times that the Linaro release server cannot be
reached over HTTPS. The error is as follows:

  wget https://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/aarch64-linux-gnu/gcc-linaro-5.3-2016.02-x86_64_aarch64-linux-gnu.tar.xz
  --2016-06-14 08:52:10--  https://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/aarch64-linux-gnu/gcc-linaro-5.3-2016.02-x86_64_aarch64-linux-gnu.tar.xz
  Resolving releases.linaro.org (releases.linaro.org)... 54.188.124.233
  Connecting to releases.linaro.org (releases.linaro.org)|54.188.124.233|:443... connected.
  OpenSSL: error:0407006A:rsa routines:RSA_padding_check_PKCS1_type_1:block type is not 01
  OpenSSL: error:04067072:rsa routines:RSA_EAY_PUBLIC_DECRYPT:padding check failed
  OpenSSL: error:1408D07B:SSL routines:SSL3_GET_KEY_EXCHANGE:bad signature
  Unable to establish SSL connection.

Let's use HTTP instead for better reliability.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>