### PR TITLE
docs: Add mtools to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ $ sudo apt-get install android-tools-adb android-tools-fastboot autoconf bison \
                cscope curl flex gdisk libc6:i386 libfdt-dev \
                libglib2.0-dev libpixman-1-dev libstdc++6:i386 \
                libz1:i386 netcat python-crypto python-serial \
-                       python-wand uuid-dev xdg-utils xz-utils zlib1g-dev
+               python-wand uuid-dev xdg-utils xz-utils zlib1g-dev \
+               mtools
 ```
 
 ---


### PR DESCRIPTION
Changing hikey build to use mtools instead of sudo/mount eliminates
the need for root access during the build.  Document this dependency.

Signed-off-by: David Brown <david.brown@linaro.org>