### PR TITLE
mem leak bug fixed, Update static_ta.c, self-test monitor memory pages normal

### DIFF
--- a/core/arch/arm/kernel/static_ta.c
+++ b/core/arch/arm/kernel/static_ta.c
@@ -132,9 +132,8 @@ static void static_ta_destroy(struct tee_ta_ctx *ctx __unused)
 {
 	if (ctx) {
 		struct static_ta_ctx *stc = to_static_ta_ctx(ctx);
-		if (stc) {
+		if (stc)
 			free(stc);
-		}
 	}
 }
 

--- a/core/arch/arm/kernel/static_ta.c
+++ b/core/arch/arm/kernel/static_ta.c
@@ -130,9 +130,9 @@ static void static_ta_enter_close_session(struct tee_ta_session *s)
 
 static void static_ta_destroy(struct tee_ta_ctx *ctx __unused)
 {
-	if(ctx){
+	if(ctx) {
 		struct static_ta_ctx *stc = to_static_ta_ctx(ctx);
-		if(stc){
+		if(stc) {
 			free(stc);
 		}
 	}

--- a/core/arch/arm/kernel/static_ta.c
+++ b/core/arch/arm/kernel/static_ta.c
@@ -130,9 +130,9 @@ static void static_ta_enter_close_session(struct tee_ta_session *s)
 
 static void static_ta_destroy(struct tee_ta_ctx *ctx __unused)
 {
-	if(ctx) {
+	if (ctx) {
 		struct static_ta_ctx *stc = to_static_ta_ctx(ctx);
-		if(stc) {
+		if (stc) {
 			free(stc);
 		}
 	}

--- a/core/arch/arm/kernel/static_ta.c
+++ b/core/arch/arm/kernel/static_ta.c
@@ -130,7 +130,12 @@ static void static_ta_enter_close_session(struct tee_ta_session *s)
 
 static void static_ta_destroy(struct tee_ta_ctx *ctx __unused)
 {
-	/* Nothing to do */
+	if(ctx){
+		struct static_ta_ctx *stc = to_static_ta_ctx(ctx);
+		if(stc){
+			free(stc);
+		}
+	}
 }
 
 static const struct tee_ta_ops static_ta_ops = {


### PR DESCRIPTION
bug fixed,  The difference between the number of times there is a tendency by the presence of the growth in the op-tee os add memory debug debugging information, to track allocation and deallocation of memory. Prove the existence of a memory leak problem,  
We use this follow script, run it in Linux for one night, then we can reproduce it:
#!/bin/sh
i=1
while [ true ]
do
echo -----------------begin------------
xtest
let i=i+1
echo $i > file
echo -----------------end-------------
done

when optee os goes errors, it print the info on console:
ERROR:   TEE-CORE: Assertion 'bn->prevfree == 0' failed at lib/libutils/isoc/bget_malloc.c:387

here, it is memory leak:
	/* Load a new TA and create a session */
	DMSG("      Open %s", ta->name);
	stc = calloc(1, sizeof(struct static_ta_ctx));		--> Here the application memory is not released
	if (!stc)
		return TEE_ERROR_OUT_OF_MEMORY;
	ctx = &stc->ctx;
