### PR TITLE
core: fix race to allocate secure buffer

### DIFF
--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -98,6 +98,8 @@ struct tee_ta_session {
 /* Registered contexts */
 extern struct tee_ta_ctx_head tee_ctxes;
 
+extern struct mutex tee_ta_mutex;
+
 TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 			       struct tee_ta_session **sess,
 			       struct tee_ta_session_head *open_sessions,

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -52,7 +52,7 @@
 #include <assert.h>
 
 /* This mutex protects the critical section in tee_ta_init_session */
-static struct mutex tee_ta_mutex = MUTEX_INITIALIZER;
+struct mutex tee_ta_mutex = MUTEX_INITIALIZER;
 static struct condvar tee_ta_cv = CONDVAR_INITIALIZER;
 static int tee_ta_single_instance_thread = THREAD_ID_INVALID;
 static size_t tee_ta_single_instance_count;


### PR DESCRIPTION
Fixes race to allocate secure buffer for TA to TA communication.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>