### PR TITLE
Support CFG_TEE_CORE_NB_CORE > 8

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -185,6 +185,11 @@ struct thread_svc_regs {
 #endif /*ASM*/
 
 #ifndef ASM
+/* Called from assembly with SP == stack_tmp_top[0] */
+void init_stack_tmp_top(void);
+#endif
+
+#ifndef ASM
 typedef void (*thread_smc_handler_t)(struct thread_smc_args *args);
 typedef void (*thread_fiq_handler_t)(void);
 typedef unsigned long (*thread_pm_handler_t)(unsigned long a0,

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -233,6 +233,11 @@ copy_init:
 	bgt	copy_init
 #endif
 
+	/* Initialize stack_tmp_top[i] for i > 0 */
+	ldr	r0, =stack_tmp_top
+	ldr	sp, [r0]
+	bl	init_stack_tmp_top
+
 	bl	get_core_pos
 	cmp	r0, #CFG_TEE_CORE_NB_CORE
 	/* Unsupported CPU, park it before it breaks something */

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -72,6 +72,13 @@ copy_init:
 	b.lt	copy_init
 #endif
 
+	/* Initialize stack_tmp_top[i] for i > 0 */
+	msr	spsel, #0
+	adr	x0, stack_tmp_top
+	ldr	x0, [x0]
+	mov	sp, x0
+	bl	init_stack_tmp_top
+
 	/*
 	 * Setup SP_EL0 and SPEL1, SP will be set to SP_EL0.
 	 * SP_EL0 is assigned stack_tmp_top[cpu_id]

--- a/core/arch/arm/plat-sunxi/entry.S
+++ b/core/arch/arm/plat-sunxi/entry.S
@@ -57,6 +57,11 @@ UNWIND(	.cantunwind)
 
 	ldr	   r0, =_start
 	write_vbar r0
+
+	/* Initialize stack_tmp_top[i] for i > 0 */
+	ldr	r0, =stack_tmp_top
+	ldr	sp, [r0]
+	bl	init_stack_tmp_top
 	
 	mov	r4, r1
 	bl	get_core_pos


### PR DESCRIPTION
The stack_tmp_top[] array is now initialized at runtime by the boot
CPU. Only stack_tmp_top[0] is set at compile time and is used as a
temporary stack by the boot CPU to call the C function that sets the
other entries.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>