### PR TITLE
Support CFG_TEE_CORE_NB_CORE > 8

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -198,6 +198,23 @@ UNWIND(	.cantunwind)
 UNWIND(	.fnend)
 END_FUNC reset
 
+	/*
+	 * Setup sp to point to the top of the tmp stack for the current CPU:
+	 * sp is assigned stack_tmp + (cpu_id + 1) * stack_tmp_stride
+	 */
+	.macro set_sp
+		bl	get_core_pos
+		cmp	r0, #CFG_TEE_CORE_NB_CORE
+		/* Unsupported CPU, park it before it breaks something */
+		bge	unhandled_cpu
+		add	r0, r0, #1
+		ldr	r2, =stack_tmp_stride
+		ldr	r1, [r2]
+		mul	r2, r0, r1
+		ldr	r1, =stack_tmp
+		add	sp, r1, r2
+	.endm
+
 LOCAL_FUNC reset_primary , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
@@ -233,13 +250,7 @@ copy_init:
 	bgt	copy_init
 #endif
 
-	bl	get_core_pos
-	cmp	r0, #CFG_TEE_CORE_NB_CORE
-	/* Unsupported CPU, park it before it breaks something */
-	bge	unhandled_cpu
-	lsl	r0, #2
-	ldr	r1, =stack_tmp_top
-	ldr	sp, [r1, r0]
+	set_sp
 
 	/* complete ARM secure MP common configuration */
 	bl	plat_cpu_reset_late
@@ -387,13 +398,7 @@ UNWIND(	.cantunwind)
 	write_vbar r0
 
 	mov	r4, lr
-	bl	get_core_pos
-	cmp	r0, #CFG_TEE_CORE_NB_CORE
-	/* Unsupported CPU, park it before it breaks something */
-	bge	unhandled_cpu
-	lsl	r0, #2
-	ldr	r1, =stack_tmp_top
-	ldr	sp, [r1, r0]
+	set_sp
 
 	bl	core_init_mmu_regs
 	bl	cpu_mmu_enable
@@ -415,13 +420,7 @@ UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
 	bl	wait_primary
 
-	bl	get_core_pos
-	cmp	r0, #CFG_TEE_CORE_NB_CORE
-	/* Unsupported CPU, park it before it breaks something */
-	bge	unhandled_cpu
-	lsl	r0, #2
-	ldr	r1, =stack_tmp_top
-	ldr	sp, [r1, r0]
+	set_sp
 
 	bl	plat_cpu_reset_late
 

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -33,6 +33,30 @@
 #include <sm/teesmc_opteed_macros.h>
 #include <sm/teesmc_opteed.h>
 
+	/*
+	 * Setup SP_EL0 and SPEL1, SP will be set to SP_EL0.
+	 * SP_EL0 is assigned stack_tmp + (cpu_id + 1) * stack_tmp_stride
+	 * SP_EL1 is assigned thread_core_local[cpu_id]
+	 */
+	.macro set_sp
+		bl	get_core_pos
+		cmp	x0, #CFG_TEE_CORE_NB_CORE
+		/* Unsupported CPU, park it before it breaks something */
+		bge	unhandled_cpu
+		add	x0, x0, #1
+		adr	x2, stack_tmp_stride
+		ldr	w1, [x2]
+		mul	x2, x0, x1
+		adr	x1, stack_tmp
+		add	x1, x1, x2
+		msr	spsel, #0
+		mov	sp, x1
+		bl	thread_get_core_local
+		msr	spsel, #1
+		mov	sp, x0
+		msr	spsel, #0
+	.endm
+
 .section .text.boot
 FUNC _start , :
 	mov	x19, x0		/* Save pagable part address */
@@ -72,24 +96,8 @@ copy_init:
 	b.lt	copy_init
 #endif
 
-	/*
-	 * Setup SP_EL0 and SPEL1, SP will be set to SP_EL0.
-	 * SP_EL0 is assigned stack_tmp_top[cpu_id]
-	 * SP_EL1 is assigned thread_core_local[cpu_id]
-	 */
-	bl	get_core_pos
-	cmp	x0, #CFG_TEE_CORE_NB_CORE
-	/* Unsupported CPU, park it before it breaks something */
-	bge	unhandled_cpu
-	lsl	x2, x0, #3
-	adr	x1, stack_tmp_top
-	ldr	x1, [x1, x2]
-	msr	spsel, #0
-	mov	sp, x1
-	bl	thread_get_core_local
-	msr	spsel, #1
-	mov	sp, x0
-	msr	spsel, #0
+	/* Setup SP_EL0 and SP_EL1, SP will be set to SP_EL0 */
+	set_sp
 
 	/* Enable aborts now that we can receive exceptions */
 	msr	daifclr, #DAIFBIT_ABT
@@ -164,24 +172,8 @@ FUNC cpu_on_handler , :
 	msr	sctlr_el1, x0
 	isb
 
-	/*
-	 * Setup SP_EL0 and SPEL1, SP will be set to SP_EL0.
-	 * SP_EL0 is assigned stack_tmp_top[cpu_id]
-	 * SP_EL1 is assigned thread_core_local[cpu_id]
-	 */
-	bl	get_core_pos
-	cmp	x0, #CFG_TEE_CORE_NB_CORE
-	/* Unsupported CPU, park it before it breaks something */
-	bge	unhandled_cpu
-	lsl	x2, x0, #3
-	adr	x1, stack_tmp_top
-	ldr	x1, [x1, x2]
-	msr	spsel, #0
-	mov	sp, x1
-	bl	thread_get_core_local
-	msr	spsel, #1
-	mov	sp, x0
-	msr	spsel, #0
+	/* Setup SP_EL0 and SP_EL1, SP will be set to SP_EL0 */
+	set_sp
 
 	/* Enable aborts now that we can receive exceptions */
 	msr	daifclr, #DAIFBIT_ABT

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -28,7 +28,6 @@ link-script-cppflags := -DASM=1 \
 entries-unpaged += thread_init_vbar
 entries-unpaged += sm_init
 entries-unpaged += core_init_mmu_regs
-entries-unpaged += stack_tmp_top
 entries-unpaged += sem_cpu_sync
 entries-unpaged += generic_boot_get_handlers
 

--- a/core/arch/arm/plat-sunxi/entry.S
+++ b/core/arch/arm/plat-sunxi/entry.S
@@ -60,9 +60,12 @@ UNWIND(	.cantunwind)
 	
 	mov	r4, r1
 	bl	get_core_pos
-	lsl	r0, #2
-	ldr	r1, =stack_tmp_top
-	ldr	sp, [r1, r0]
+	add	r0, r0, #1
+	ldr	r2, =stack_tmp_stride
+	ldr	r1, [r2]
+	mul	r2, r0, r1
+	ldr	r1, =stack_tmp
+	ldr	sp, [r1, r2]
 
     	/* NSACR configuration */
     	read_nsacr  r1

--- a/core/arch/arm/plat-sunxi/smp_boot.S
+++ b/core/arch/arm/plat-sunxi/smp_boot.S
@@ -58,10 +58,13 @@ UNWIND(	.cantunwind)
 	write_vbar r0
 
 	/* Setup tmp stack */
-	bl	get_core_pos
-	lsl	r0, #2
-	ldr	r1, =stack_tmp_top
-	ldr	sp, [r1, r0]
+        bl      get_core_pos
+        add     r0, r0, #1
+        ldr     r2, =stack_tmp_stride
+        ldr     r1, [r2]
+        mul     r2, r0, r1
+        ldr     r1, =stack_tmp
+        ldr     sp, [r1, r2]
 
         /* NSACR configuration */
     	read_nsacr  r1


### PR DESCRIPTION
Remove the stack_tmp_top[] array. Instead, compute the stack top for
each CPU in the assembly code:

  sp = stack_tmp + (cpu_id + 1) * stack_tmp_stride

stack_tmp and stack_tmp_stride are exported by thread.c.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>