### PR TITLE
assert(): honor NDEBUG

### DIFF
--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -680,7 +680,7 @@ void teecore_init_pub_ram(void)
 
 uint32_t tee_mmu_user_get_cache_attr(struct user_ta_ctx *utc, void *va)
 {
-	TEE_Result res;
+	TEE_Result res __maybe_unused;
 	paddr_t pa;
 	uint32_t attr;
 

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -26,13 +26,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <drivers/gic.h>
-#include <kernel/interrupt.h>
-#include <util.h>
-#include <io.h>
-#include <trace.h>
-
 #include <assert.h>
+#include <compiler.h>
+#include <drivers/gic.h>
+#include <io.h>
+#include <kernel/interrupt.h>
+#include <trace.h>
+#include <util.h>
+
 
 /* Offsets from gic.gicc_base */
 #define GICC_CTLR		(0x000)
@@ -208,8 +209,8 @@ static void gic_it_add(struct gic_data *gd, size_t it)
 static void gic_it_set_cpu_mask(struct gic_data *gd, size_t it,
 				uint8_t cpu_mask)
 {
-	size_t idx = it / NUM_INTS_PER_REG;
-	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
+	size_t idx __maybe_unused = it / NUM_INTS_PER_REG;
+	uint32_t mask __maybe_unused = 1 << (it % NUM_INTS_PER_REG);
 	uint32_t target, target_shift;
 
 	assert(it <= gd->max_it); /* Not too large */
@@ -232,8 +233,8 @@ static void gic_it_set_cpu_mask(struct gic_data *gd, size_t it,
 
 static void gic_it_set_prio(struct gic_data *gd, size_t it, uint8_t prio)
 {
-	size_t idx = it / NUM_INTS_PER_REG;
-	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
+	size_t idx __maybe_unused = it / NUM_INTS_PER_REG;
+	uint32_t mask __maybe_unused = 1 << (it % NUM_INTS_PER_REG);
 
 	assert(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */

--- a/lib/libmpa/mpa_io.c
+++ b/lib/libmpa/mpa_io.c
@@ -26,6 +26,7 @@
  */
 #include "mpa.h"
 #include "assert.h"
+#include <compiler.h>
 
 /*
  * Big #ifdef to get rid of string conversion routines
@@ -100,7 +101,8 @@ static int __mpa_digit_value(int c)
  *  Returns the maximum number of words needed to binary represent a number
  *  consisting of "digits" digits and each digits is in base "base".
  */
-static mpa_word_t __mpa_digitstr_to_binary_wsize_base_16(int digits)
+static
+mpa_word_t __maybe_unused __mpa_digitstr_to_binary_wsize_base_16(int digits)
 {
 		return (digits + 7) >> 3;
 }
@@ -258,7 +260,7 @@ int mpa_get_str_size(void)
 int mpa_set_str(mpanum dest, const char *digitstr)
 {
 	/* length of digitstr after removal of base indicator and spaces */
-	int dlen;
+	int dlen __maybe_unused;
 	int negative;		/* ==1 if number is negative, 0 otherwise */
 	int c;			/* value of characters in digitstr */
 	/* a buffer holding the integer values of the digits */

--- a/lib/libmpa/mpa_io.c
+++ b/lib/libmpa/mpa_io.c
@@ -101,8 +101,8 @@ static int __mpa_digit_value(int c)
  *  Returns the maximum number of words needed to binary represent a number
  *  consisting of "digits" digits and each digits is in base "base".
  */
-static
-mpa_word_t __maybe_unused __mpa_digitstr_to_binary_wsize_base_16(int digits)
+static mpa_word_t __maybe_unused
+__mpa_digitstr_to_binary_wsize_base_16(int digits)
 {
 		return (digits + 7) >> 3;
 }

--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -33,7 +33,7 @@ void _assert_break(void) __noreturn;
 void _assert_log(const char *expr, const char *file, int line);
 
 #ifdef NDEBUG
-#define assert(expr)
+#define assert(expr) do { } while (0)
 #else
 #define assert(expr) \
 	do { \

--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -32,6 +32,9 @@
 void _assert_break(void) __noreturn;
 void _assert_log(const char *expr, const char *file, int line);
 
+#ifdef NDEBUG
+#define assert(expr)
+#else
 #define assert(expr) \
 	do { \
 		if (!(expr)) { \
@@ -39,6 +42,7 @@ void _assert_log(const char *expr, const char *file, int line);
 			_assert_break(); \
 		} \
 	} while (0)
+#endif
 
 
 #define COMPILE_TIME_ASSERT(x) \


### PR DESCRIPTION
The assert() macro should expand to a no-op when NDEBUG is defined.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>