### PR TITLE
fix assert() vs TEE_ASSERT()

### DIFF
--- a/core/arch/arm/include/kernel/static_ta.h
+++ b/core/arch/arm/include/kernel/static_ta.h
@@ -27,11 +27,11 @@
 #ifndef KERNEL_STATIC_TA_H
 #define KERNEL_STATIC_TA_H
 
+#include <assert.h>
 #include <compiler.h>
 #include <kernel/tee_ta_manager.h>
 #include <tee_api_types.h>
 #include <util.h>
-#include <assert.h>
 
 struct static_ta_head {
 	TEE_UUID uuid;
@@ -63,7 +63,7 @@ static inline bool is_static_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct static_ta_ctx *to_static_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	assert(is_static_ta_ctx(ctx));
+	TEE_ASSERT(is_static_ta_ctx(ctx));
 	return container_of(ctx, struct static_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -74,7 +74,7 @@ static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	assert(is_user_ta_ctx(ctx));
+	TEE_ASSERT(is_user_ta_ctx(ctx));
 	return container_of(ctx, struct user_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -28,9 +28,8 @@
 #ifndef CORE_MEMPROT_H
 #define CORE_MEMPROT_H
 
-#include <types_ext.h>
-#include <kernel/tee_common_unpg.h>
 #include <mm/core_mmu.h>
+#include <types_ext.h>
 
 /*
  * "pbuf_is" support.

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -28,12 +28,9 @@
 #ifndef CORE_MMU_H
 #define CORE_MMU_H
 
-#include <kernel/tee_common_unpg.h>
 #include <kernel/user_ta.h>
 #include <mm/tee_mmu_types.h>
 #include <types_ext.h>
-
-#include <assert.h>
 
 /* A small page is the smallest unit of memory that can be mapped */
 #define SMALL_PAGE_SHIFT	12

--- a/core/arch/arm/include/tee/arch_svc.h
+++ b/core/arch/arm/include/tee/arch_svc.h
@@ -27,8 +27,6 @@
 #ifndef TEE_ARCH_SVC_H
 #define TEE_ARCH_SVC_H
 
-#include <kernel/tee_common_unpg.h>
-
 struct thread_svc_regs;
 
 void tee_svc_handler(struct thread_svc_regs *regs);

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -88,7 +88,7 @@ __weak void main_init_gic(void)
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 void init_sec_mon(unsigned long nsec_entry __maybe_unused)
 {
-	assert(nsec_entry == PADDR_INVALID);
+	TEE_ASSERT(nsec_entry == PADDR_INVALID);
 	/* Do nothing as we don't have a secure monitor */
 }
 #else
@@ -97,7 +97,7 @@ __weak void init_sec_mon(unsigned long nsec_entry)
 {
 	struct sm_nsec_ctx *nsec_ctx;
 
-	assert(nsec_entry != PADDR_INVALID);
+	TEE_ASSERT(nsec_entry != PADDR_INVALID);
 
 	/* Initialize secure monitor */
 	nsec_ctx = sm_get_nsec_ctx();
@@ -216,7 +216,7 @@ static void init_runtime(unsigned long pageable_part)
 
 	hashes = malloc(hash_size);
 	IMSG("Pager is enabled. Hashes: %zu bytes", hash_size);
-	TEE_ASSERT(hashes);
+	assert(hashes);
 	memcpy(hashes, __tmp_hashes_start, hash_size);
 
 	/*
@@ -226,7 +226,7 @@ static void init_runtime(unsigned long pageable_part)
 	teecore_init_ta_ram();
 
 	mm = tee_mm_alloc(&tee_mm_sec_ddr, pageable_size);
-	TEE_ASSERT(mm);
+	assert(mm);
 	paged_store = phys_to_virt(tee_mm_get_smem(mm), MEM_AREA_TA_RAM);
 	/* Copy init part into pageable area */
 	memcpy(paged_store, __init_start, init_size);
@@ -292,7 +292,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore,
 		(vaddr_t)tee_mm_vcore.hi - TZSRAM_SIZE, TZSRAM_SIZE);
-	TEE_ASSERT(mm);
+	assert(mm);
 	tee_pager_init(mm);
 
 	/*
@@ -310,7 +310,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, (vaddr_t)__pageable_start,
 			   pageable_size);
-	TEE_ASSERT(mm);
+	assert(mm);
 	if (!tee_pager_add_core_area(tee_mm_get_smem(mm), tee_mm_get_bytes(mm),
 				     TEE_MATTR_PRX, paged_store, hashes))
 		panic();

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -24,10 +24,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <assert.h>
 #include <kernel/mutex.h>
 #include <kernel/tz_proc.h>
 #include <kernel/thread.h>
-#include <kernel/tee_common_unpg.h>
 #include <trace.h>
 
 void mutex_init(struct mutex *m)

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -32,7 +32,6 @@
 #include <mm/core_mmu.h>
 #include <utee_defines.h>
 
-#include <assert.h>
 #include <stdint.h>
 #include <mpa.h>
 #include <arm.h>

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -486,9 +486,9 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	tee_uaddr_t usr_stack;
 	struct user_ta_ctx *utc = to_user_ta_ctx(session->ctx);
 	TEE_ErrorOrigin serr = TEE_ORIGIN_TEE;
-	struct tee_ta_session *s __maybe_unused;
+	struct tee_ta_session *s;
 
-	TEE_ASSERT((utc->ctx.flags & TA_FLAG_EXEC_DDR) != 0);
+	TEE_ASSERT(utc->ctx.flags & TA_FLAG_EXEC_DDR);
 
 	/* Map user space memory */
 	res = tee_mmu_map_param(utc, param);
@@ -528,7 +528,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	update_from_utee_param(param, usr_params);
 
 	s = tee_ta_pop_current_session();
-	assert(s == session);
+	TEE_ASSERT(s == session);
 cleanup_return:
 
 	/*

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -26,9 +26,9 @@
  */
 
 #include <arm.h>
+#include <assert.h>
 #include <kernel/vfp.h>
 #include "vfp_private.h"
-#include <assert.h>
 
 #ifdef ARM32
 bool vfp_is_enabled(void)
@@ -59,7 +59,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 	if (state->fpexc & FPEXC_EN) {
 		uint32_t fpexc = vfp_read_fpexc();
 
-		assert(!(fpexc & FPEXC_EN));
+		TEE_ASSERT(!(fpexc & FPEXC_EN));
 		vfp_write_fpexc(fpexc | FPEXC_EN);
 		state->fpscr = vfp_read_fpscr();
 		vfp_save_extension_regs(state->reg);
@@ -120,7 +120,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 {
 	if ((CPACR_EL1_FPEN(state->cpacr_el1) & CPACR_EL1_FPEN_EL0EL1) ||
 	    state->force_save) {
-		assert(!vfp_is_enabled());
+		TEE_ASSERT(!vfp_is_enabled());
 		vfp_enable();
 		state->fpcr = read_fpcr();
 		state->fpsr = read_fpsr();

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -33,8 +33,8 @@
  */
 #include <platform_config.h>
 
-#include <stdlib.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <kernel/tz_proc.h>
 #include <kernel/tz_ssvce.h>
 #include <mm/core_mmu.h>
@@ -341,7 +341,7 @@ static void init_mem_map(struct tee_mmap_region *memory_map, size_t num_elems)
 	 */
 
 	map = memory_map;
-	assert(map->type == MEM_AREA_TEE_RAM);
+	TEE_ASSERT(map->type == MEM_AREA_TEE_RAM);
 	map->va = map->pa;
 #ifdef CFG_WITH_PAGER
 	map->region_size = SMALL_PAGE_SIZE,
@@ -701,7 +701,7 @@ unsigned int cache_maintenance_l2(int op, paddr_t pa, size_t len)
 void core_mmu_set_entry(struct core_mmu_table_info *tbl_info, unsigned idx,
 			paddr_t pa, uint32_t attr)
 {
-	assert(idx < tbl_info->num_entries);
+	TEE_ASSERT(idx < tbl_info->num_entries);
 	core_mmu_set_entry_primitive(tbl_info->table, tbl_info->level,
 				     idx, pa, attr);
 }
@@ -709,7 +709,7 @@ void core_mmu_set_entry(struct core_mmu_table_info *tbl_info, unsigned idx,
 void core_mmu_get_entry(struct core_mmu_table_info *tbl_info, unsigned idx,
 			paddr_t *pa, uint32_t *attr)
 {
-	assert(idx < tbl_info->num_entries);
+	TEE_ASSERT(idx < tbl_info->num_entries);
 	core_mmu_get_entry_primitive(tbl_info->table, tbl_info->level,
 				     idx, pa, attr);
 }
@@ -722,9 +722,9 @@ static void set_region(struct core_mmu_table_info *tbl_info,
 	paddr_t pa;
 
 	/* va, len and pa should be block aligned */
-	assert(!core_mmu_get_block_offset(tbl_info, region->va));
-	assert(!core_mmu_get_block_offset(tbl_info, region->size));
-	assert(!core_mmu_get_block_offset(tbl_info, region->pa));
+	TEE_ASSERT(!core_mmu_get_block_offset(tbl_info, region->va));
+	TEE_ASSERT(!core_mmu_get_block_offset(tbl_info, region->size));
+	TEE_ASSERT(!core_mmu_get_block_offset(tbl_info, region->pa));
 
 	idx = core_mmu_va2idx(tbl_info, region->va);
 	end = core_mmu_va2idx(tbl_info, region->va + region->size);
@@ -754,10 +754,10 @@ static void set_pg_region(struct core_mmu_table_info *dir_info,
 			 */
 			unsigned int idx;
 
-			assert(*pgt); /* We should have alloced enough */
+			TEE_ASSERT(*pgt); /* We should have alloced enough */
 
 			/* Virtual addresses must grow */
-			assert(r.va > pg_info->va_base);
+			TEE_ASSERT(r.va > pg_info->va_base);
 
 			idx = core_mmu_va2idx(dir_info, r.va);
 			pg_info->table = (*pgt)->tbl;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -56,11 +56,11 @@
  */
 #include <platform_config.h>
 
+#include <assert.h>
 #include <types_ext.h>
 #include <inttypes.h>
 #include <string.h>
 #include <compiler.h>
-#include <assert.h>
 #include <trace.h>
 #include <mm/tee_mmu_defs.h>
 #include <mm/pgt_cache.h>
@@ -344,7 +344,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 	uint64_t level_index_mask = SHIFT_U64(XLAT_TABLE_ENTRIES_MASK,
 					      level_size_shift);
 
-	assert(level <= 3);
+	TEE_ASSERT(level <= 3);
 
 	debug_print("New xlat table (level %u):", level);
 
@@ -393,7 +393,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 			/* Clear table before use */
 			memset(new_table, 0, XLAT_TABLE_SIZE);
 
-			assert(next_xlat <= MAX_XLAT_TABLES);
+			TEE_ASSERT(next_xlat <= MAX_XLAT_TABLES);
 			desc = TABLE_DESC | (uint64_t)(uintptr_t)new_table;
 
 			/* Recurse to fill in new table */
@@ -411,7 +411,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 static unsigned int calc_physical_addr_size_bits(uint64_t max_addr)
 {
 	/* Physical address can't exceed 48 bits */
-	assert((max_addr & ADDR_MASK_48_TO_63) == 0);
+	TEE_ASSERT((max_addr & ADDR_MASK_48_TO_63) == 0);
 
 	/* 48 bits address */
 	if (max_addr & ADDR_MASK_44_TO_47)
@@ -449,8 +449,8 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 		debug_print(" %010" PRIxVA " %010" PRIxPA " %10zx %x",
 			    mm[n].va, mm[n].pa, mm[n].size, mm[n].attr);
 
-		assert(IS_PAGE_ALIGNED(mm[n].pa));
-		assert(IS_PAGE_ALIGNED(mm[n].size));
+		TEE_ASSERT(IS_PAGE_ALIGNED(mm[n].pa));
+		TEE_ASSERT(IS_PAGE_ALIGNED(mm[n].size));
 
 		pa_end = mm[n].pa + mm[n].size - 1;
 		va_end = mm[n].va + mm[n].size - 1;
@@ -473,11 +473,11 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 			break;
 		}
 	}
-	assert(user_va_idx != -1);
+	TEE_ASSERT(user_va_idx != -1);
 
 	tcr_ps_bits = calc_physical_addr_size_bits(max_pa);
 	COMPILE_TIME_ASSERT(ADDR_SPACE_SIZE > 0);
-	assert(max_va < ADDR_SPACE_SIZE);
+	TEE_ASSERT(max_va < ADDR_SPACE_SIZE);
 }
 
 bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
@@ -552,7 +552,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 	tbl_info->va_base = va_base;
 	tbl_info->shift = L1_XLAT_ADDRESS_SHIFT -
 			  (level - 1) * XLAT_TABLE_ENTRIES_SHIFT;
-	assert(level <= 3);
+	TEE_ASSERT(level <= 3);
 	if (level == 1)
 		tbl_info->num_entries = NUM_L1_ENTRIES;
 	else
@@ -642,7 +642,7 @@ void core_mmu_get_entry_primitive(const void *table, size_t level __unused,
 
 void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 {
-	assert(user_va_idx != -1);
+	TEE_ASSERT(user_va_idx != -1);
 
 	if (base)
 		*base = (vaddr_t)user_va_idx << L1_XLAT_ADDRESS_SHIFT;
@@ -652,14 +652,14 @@ void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 
 bool core_mmu_user_mapping_is_active(void)
 {
-	assert(user_va_idx != -1);
+	TEE_ASSERT(user_va_idx != -1);
 	return !!l1_xlation_table[get_core_pos()][user_va_idx];
 }
 
 #ifdef ARM32
 void core_mmu_get_user_map(struct core_mmu_user_map *map)
 {
-	assert(user_va_idx != -1);
+	TEE_ASSERT(user_va_idx != -1);
 
 	map->user_map = l1_xlation_table[get_core_pos()][user_va_idx];
 	if (map->user_map) {
@@ -675,7 +675,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 	uint64_t ttbr;
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
-	assert(user_va_idx != -1);
+	TEE_ASSERT(user_va_idx != -1);
 
 	ttbr = read_ttbr0_64bit();
 	/* Clear ASID */
@@ -702,7 +702,8 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 {
-	assert(fault_descr & FSR_LPAE);
+	TEE_ASSERT(fault_descr & FSR_LPAE);
+
 	switch (fault_descr & FSR_STATUS_MASK) {
 	case 0x21: /* b100001 Alignment fault */
 		return CORE_MMU_FAULT_ALIGNMENT;
@@ -732,7 +733,7 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 #ifdef ARM64
 void core_mmu_get_user_map(struct core_mmu_user_map *map)
 {
-	assert(user_va_idx != -1);
+	TEE_ASSERT(user_va_idx != -1);
 
 	map->user_map = l1_xlation_table[get_core_pos()][user_va_idx];
 	if (map->user_map) {

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -27,15 +27,15 @@
  */
 #include <platform_config.h>
 
-#include <stdlib.h>
-#include <assert.h>
 #include <arm.h>
+#include <assert.h>
+#include <kernel/panic.h>
+#include <kernel/thread.h>
 #include <mm/core_mmu.h>
 #include <mm/tee_mmu_defs.h>
 #include <mm/pgt_cache.h>
+#include <stdlib.h>
 #include <trace.h>
-#include <kernel/panic.h>
-#include <kernel/thread.h>
 #include <util.h>
 #include "core_mmu_private.h"
 
@@ -202,7 +202,7 @@ static void *core_mmu_alloc_l2(struct tee_mmap_region *mm)
 
 static enum desc_type get_desc_type(unsigned level, uint32_t desc)
 {
-	assert(level >= 1 && level <= 2);
+	TEE_ASSERT(level >= 1 && level <= 2);
 
 	if (level == 1) {
 		if ((desc & 0x3) == 0x1)
@@ -385,7 +385,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 	tbl_info->level = level;
 	tbl_info->table = table;
 	tbl_info->va_base = va_base;
-	assert(level <= 2);
+	TEE_ASSERT(level <= 2);
 	if (level == 1) {
 		tbl_info->shift = SECTION_SHIFT;
 		tbl_info->num_entries = TEE_MMU_L1_NUM_ENTRIES;
@@ -573,7 +573,7 @@ static void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
 	paddr_t pa;
 	uint32_t region_size;
 
-	TEE_ASSERT(mm && ttb);
+	assert(mm && ttb);
 
 	/*
 	 * If mm->va is smaller than 32M, then mm->va will conflict with
@@ -683,7 +683,8 @@ void core_init_mmu_regs(void)
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fsr)
 {
-	assert(!(fsr & FSR_LPAE));
+	TEE_ASSERT(!(fsr & FSR_LPAE));
+
 	switch (fsr & FSR_FS_MASK) {
 	case 0x1: /* DFSR[10,3:0] 0b00001 Alignment fault (DFSR only) */
 		return CORE_MMU_FAULT_ALIGNMENT;

--- a/core/arch/arm/mm/pager_aes_gcm.c
+++ b/core/arch/arm/mm/pager_aes_gcm.c
@@ -42,6 +42,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <compiler.h>
 #include "pager_private.h"
 #include <tomcrypt.h>

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <mm/pgt_cache.h>
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
@@ -33,7 +34,6 @@
 #include <stdlib.h>
 #include <util.h>
 #include <trace.h>
-#include <assert.h>
 
 /*
  * With pager enabled we allocate page table from the pager.
@@ -166,7 +166,7 @@ static struct pgt *pop_from_free_list(void)
 static void push_to_free_list(struct pgt *p)
 {
 	SLIST_INSERT_HEAD(&p->parent->pgt_cache, p, link);
-	assert(p->parent->num_used > 0);
+	TEE_ASSERT(p->parent->num_used > 0);
 	p->parent->num_used--;
 	if (!p->parent->num_used) {
 		vaddr_t va = (vaddr_t)p->tbl & ~SMALL_PAGE_MASK;

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <kernel/tee_common.h>
 #include <util.h>
 #include <trace.h>
@@ -289,7 +290,7 @@ void tee_mm_free(tee_mm_entry_t *p)
 
 	if (entry->next == NULL) {
 		DMSG("invalid mm_entry %p", (void *)p);
-		TEE_ASSERT(0);
+		panic();
 	}
 	entry->next = entry->next->next;
 

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -25,27 +25,27 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <assert.h>
-#include <stdlib.h>
-#include <types_ext.h>
 
 #include <arm.h>
-#include <util.h>
+#include <assert.h>
+#include <kernel/panic.h>
 #include <kernel/tee_common.h>
+#include <kernel/tee_misc.h>
+#include <kernel/tz_ssvce.h>
 #include <mm/tee_mmu.h>
 #include <mm/tee_mmu_types.h>
 #include <mm/tee_mmu_defs.h>
 #include <mm/pgt_cache.h>
-#include <user_ta_header.h>
 #include <mm/tee_mm.h>
-#include "tee_api_types.h"
-#include <kernel/tee_misc.h>
-#include <trace.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <sm/optee_smc.h>
-#include <kernel/tz_ssvce.h>
-#include <kernel/panic.h>
+#include <stdlib.h>
+#include <trace.h>
+#include <types_ext.h>
+#include <user_ta_header.h>
+#include <util.h>
+#include "tee_api_types.h"
 
 #ifdef CFG_PL310
 #include <kernel/tee_l2cc_mutex.h>
@@ -171,10 +171,10 @@ static TEE_Result tee_mmu_umap_set_vas(struct tee_mmu_info *mmu)
 	while (n && !mmu->table[n].size)
 		n--;
 	va = mmu->table[n].va + mmu->table[n].size;
-	assert(va);
+	TEE_ASSERT(va);
 
 	core_mmu_get_user_va_range(&va_range_base, &va_range_size);
-	assert(va_range_base == mmu->ta_private_vmem_start);
+	TEE_ASSERT(va_range_base == mmu->ta_private_vmem_start);
 
 	/*
 	 * Assign parameters in secure memory.
@@ -293,10 +293,10 @@ TEE_Result tee_mmu_map_add_segment(struct user_ta_ctx *utc, paddr_t base_pa,
 
 	if (!tbl[n].size) {
 		/* We're continuing the va space from previous entry. */
-		assert(tbl[n - 1].size);
+		TEE_ASSERT(tbl[n - 1].size);
 
 		/* This is the first segment */
-		assert(offs < granule);
+		TEE_ASSERT(offs < granule);
 		va = tbl[n - 1].va + tbl[n - 1].size;
 		end_va = ROUNDUP(offs + size, granule) + va;
 		pa = base_pa;
@@ -669,7 +669,6 @@ void teecore_init_pub_ram(void)
 
 #ifdef CFG_PL310
 	/* Allocate statically the l2cc mutex */
-	TEE_ASSERT((e - s) > 0);
 	tee_l2cc_store_mutex_boot_pa(s);
 	s += sizeof(uint32_t);		/* size of a pl310 mutex */
 #endif
@@ -680,12 +679,9 @@ void teecore_init_pub_ram(void)
 
 uint32_t tee_mmu_user_get_cache_attr(struct user_ta_ctx *utc, void *va)
 {
-	TEE_Result res;
 	paddr_t pa;
 	uint32_t attr;
 
-	res = tee_mmu_user_va2pa_attr(utc, va, &pa, &attr);
-	assert(res == TEE_SUCCESS);
-
+	TEE_ASSERT(TEE_SUCCESS == tee_mmu_user_va2pa_attr(utc, va, &pa, &attr));
 	return (attr >> TEE_MATTR_CACHE_SHIFT) & TEE_MATTR_CACHE_MASK;
 }

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -26,6 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <sys/queue.h>
 #include <kernel/abort.h>
 #include <kernel/panic.h>
@@ -223,10 +224,7 @@ static void set_alias_area(tee_mm_entry_t *mm)
 
 static void generate_ae_key(void)
 {
-	TEE_Result res;
-
-	res = rng_generate(pager_ae_key, sizeof(pager_ae_key));
-	TEE_ASSERT(res == TEE_SUCCESS);
+	TEE_ASSERT(TEE_SUCCESS == rng_generate(pager_ae_key, sizeof(pager_ae_key)));
 }
 
 void tee_pager_init(tee_mm_entry_t *mm_alias)
@@ -387,7 +385,7 @@ static void encrypt_page(struct pager_rw_pstate *rwp, void *src, void *dst)
 {
 	struct pager_aes_gcm_iv iv;
 
-	assert((rwp->iv + 1) > rwp->iv);
+	TEE_ASSERT((rwp->iv + 1) > rwp->iv);
 	rwp->iv++;
 	/*
 	 * IV is constructed as recommended in section "8.2.1 Deterministic
@@ -444,14 +442,14 @@ static void tee_pager_save_page(struct tee_pager_pmem *pmem, uint32_t attr)
 	const uint32_t dirty_bits = TEE_MATTR_PW | TEE_MATTR_UW |
 				    TEE_MATTR_HIDDEN_DIRTY_BLOCK;
 
-	assert(!(pmem->area->flags & TEE_MATTR_LOCKED));
+	TEE_ASSERT(!(pmem->area->flags & TEE_MATTR_LOCKED));
 
 	if (attr & dirty_bits) {
 		size_t idx = pmem->pgidx - core_mmu_va2idx(ti,
 							   pmem->area->base);
 		void *stored_page = pmem->area->store + idx * SMALL_PAGE_SIZE;
 
-		assert(pmem->area->flags & TEE_MATTR_PW);
+		TEE_ASSERT(pmem->area->flags & TEE_MATTR_PW);
 		encrypt_page(&pmem->area->u.rwp[idx], pmem->va_alias,
 			     stored_page);
 		FMSG("Saved %#" PRIxVA " iv %#" PRIx64,
@@ -483,7 +481,7 @@ static bool tee_pager_unhide_page(vaddr_t page_va)
 			uint32_t a = get_area_mattr(pmem->area);
 
 			/* page is hidden, show and move to back */
-			assert(pa == get_pmem_pa(pmem));
+			TEE_ASSERT(pa == get_pmem_pa(pmem));
 			/*
 			 * If it's not a dirty block, then it should be
 			 * read only.
@@ -534,7 +532,7 @@ static void tee_pager_hide_pages(void)
 		if (!(attr & TEE_MATTR_VALID_BLOCK))
 			continue;
 
-		assert(pa == get_pmem_pa(pmem));
+		TEE_ASSERT(pa == get_pmem_pa(pmem));
 		if (attr & (TEE_MATTR_PW | TEE_MATTR_UW)){
 			a = TEE_MATTR_HIDDEN_DIRTY_BLOCK;
 			FMSG("Hide %#" PRIxVA,
@@ -570,7 +568,7 @@ static bool tee_pager_release_one_phys(vaddr_t page_va)
 		if (pmem->pgidx != pgidx)
 			continue;
 
-		assert(pa == get_pmem_pa(pmem));
+		TEE_ASSERT(pa == get_pmem_pa(pmem));
 		core_mmu_set_entry(ti, pgidx, 0, 0);
 		TAILQ_REMOVE(&tee_pager_lock_pmem_head, pmem, link);
 		pmem->area = NULL;
@@ -848,7 +846,7 @@ void tee_pager_add_pages(vaddr_t vaddr, size_t npages, bool unmap)
 			 */
 			pmem->area = tee_pager_find_area(va);
 			pmem->pgidx = pgidx;
-			assert(pa == get_pmem_pa(pmem));
+			TEE_ASSERT(pa == get_pmem_pa(pmem));
 			core_mmu_set_entry(ti, pgidx, pa,
 					   get_area_mattr(pmem->area));
 		}

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -37,6 +37,7 @@
 #include <arm.h>
 #include <kernel/generic_boot.h>
 #include <kernel/pm_stubs.h>
+#include <assert.h>
 #include <trace.h>
 #include <kernel/misc.h>
 #include <kernel/tee_time.h>

--- a/core/arch/arm/sta/se_api_self_tests.c
+++ b/core/arch/arm/sta/se_api_self_tests.c
@@ -30,7 +30,7 @@
 #include <tee_api_types.h>
 #include <tee_api_defines.h>
 #include <trace.h>
-#include <kernel/tee_common_unpg.h>
+
 #include <tee/se/manager.h>
 #include <tee/se/reader.h>
 #include <tee/se/session.h>

--- a/core/arch/arm/sta/tee_fs_key_manager_tests.c
+++ b/core/arch/arm/sta/tee_fs_key_manager_tests.c
@@ -25,13 +25,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <kernel/static_ta.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <kernel/static_ta.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <string.h>
 #include <tee/tee_fs_key_manager.h>
-
+#include <trace.h>
 
 #define TA_NAME		"tee_fs_key_manager_tests.ta"
 

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -26,6 +26,7 @@
  */
 
 #include <arm.h>
+#include <assert.h>
 #include <kernel/thread.h>
 #include <tee/tee_svc.h>
 #include <tee/arch_svc.h>
@@ -35,7 +36,6 @@
 #include <tee_syscall_numbers.h>
 #include <util.h>
 #include "arch_svc_private.h"
-#include <assert.h>
 #include <trace.h>
 #include <kernel/misc.h>
 #include <kernel/trace_ta.h>

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -35,8 +35,6 @@
 #include <kernel/misc.h>
 #include <mm/core_mmu.h>
 
-#include <assert.h>
-
 static void tee_entry_get_shm_config(struct thread_smc_args *args)
 {
 	args->a0 = OPTEE_SMC_RETURN_OK;

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -36,8 +36,6 @@
 #include <mm/core_memprot.h>
 #include <util.h>
 
-#include <assert.h>
-
 #define SHM_CACHE_ATTRS	\
 	(uint32_t)(core_mmu_is_shm_cached() ?  OPTEE_SMC_SHM_CACHED : 0)
 

--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <assert.h>
+
 #include <initcall.h>
 #include <malloc.h>		/* required for inits */
 

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -26,13 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <drivers/gic.h>
 #include <kernel/interrupt.h>
 #include <util.h>
 #include <io.h>
 #include <trace.h>
-
-#include <assert.h>
 
 /* Offsets from gic.gicc_base */
 #define GICC_CTLR		(0x000)
@@ -194,7 +193,7 @@ static void gic_it_add(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	TEE_ASSERT(it <= gd->max_it); /* Not too large */
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));
@@ -212,9 +211,9 @@ static void gic_it_set_cpu_mask(struct gic_data *gd, size_t it,
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 	uint32_t target, target_shift;
 
-	assert(it <= gd->max_it); /* Not too large */
+	TEE_ASSERT(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	TEE_ASSERT(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Route it to selected CPUs */
 	target = read32(gd->gicd_base +
@@ -235,9 +234,9 @@ static void gic_it_set_prio(struct gic_data *gd, size_t it, uint8_t prio)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	TEE_ASSERT(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	TEE_ASSERT(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Set prio it to selected CPUs */
 	DMSG("prio: writing 0x%x to 0x%" PRIxVA,
@@ -250,11 +249,11 @@ static void gic_it_enable(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	TEE_ASSERT(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	TEE_ASSERT(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 	/* Not enabled yet */
-	assert(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
+	TEE_ASSERT(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
 
 	/* Enable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ISENABLER(idx));
@@ -265,9 +264,9 @@ static void gic_it_disable(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	TEE_ASSERT(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	TEE_ASSERT(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));

--- a/core/drivers/gpio.c
+++ b/core/drivers/gpio.c
@@ -41,35 +41,27 @@ static const struct gpio_ops *ops;
 
 enum gpio_dir gpio_get_direction(unsigned int gpio_pin)
 {
-	assert(ops);
-	assert(ops->get_direction != 0);
-
+	assert(ops && ops->get_direction);
 	return ops->get_direction(gpio_pin);
 }
 
 void gpio_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
 {
-	assert(ops);
-	assert(ops->set_direction != 0);
-	assert((direction == GPIO_DIR_OUT) || (direction == GPIO_DIR_IN));
-
+	assert(ops && ops->set_direction);
+	TEE_ASSERT((direction == GPIO_DIR_OUT) || (direction == GPIO_DIR_IN));
 	ops->set_direction(gpio_pin, direction);
 }
 
 enum gpio_level gpio_get_value(unsigned int gpio_pin)
 {
-	assert(ops);
-	assert(ops->get_value != 0);
-
+	assert(ops && ops->get_value);
 	return ops->get_value(gpio_pin);
 }
 
 void gpio_set_value(unsigned int gpio_pin, enum gpio_level value)
 {
-	assert(ops);
-	assert(ops->set_value != 0);
-	assert((value == GPIO_LEVEL_LOW) || (value == GPIO_LEVEL_HIGH));
-
+	assert(ops && ops->set_value);
+	TEE_ASSERT((value == GPIO_LEVEL_LOW) || (value == GPIO_LEVEL_HIGH));
 	ops->set_value(gpio_pin, value);
 }
 
@@ -79,11 +71,12 @@ void gpio_set_value(unsigned int gpio_pin, enum gpio_level value)
  */
 void gpio_init(const struct gpio_ops *ops_ptr)
 {
-	assert(ops_ptr != 0  &&
-		(ops_ptr->get_direction != 0) &&
-		(ops_ptr->set_direction != 0) &&
-		(ops_ptr->get_value != 0) &&
-		(ops_ptr->set_value != 0));
+	assert(!ops &&
+		ops_ptr &&
+		ops_ptr->get_direction &&
+		ops_ptr->set_direction &&
+		ops_ptr->get_value &&
+		ops_ptr->set_value);
 
 	ops = ops_ptr;
 }

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -30,7 +30,6 @@
 #include <drivers/imx_uart.h>
 #include <console.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* Register definitions */

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -63,7 +63,7 @@ static enum gpio_dir pl061_get_direction(unsigned int gpio_pin)
 	uint8_t data;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	TEE_ASSERT(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -79,7 +79,7 @@ static void pl061_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
 	uint8_t data;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	TEE_ASSERT(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -105,7 +105,7 @@ static enum gpio_level pl061_get_value(unsigned int gpio_pin)
 	vaddr_t base_addr;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	TEE_ASSERT(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -124,7 +124,7 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
 	vaddr_t base_addr;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	TEE_ASSERT(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -142,7 +142,7 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
  */
 void pl061_gpio_register(vaddr_t base_addr, unsigned int gpio_dev)
 {
-	assert(gpio_dev < MAX_GPIO_DEVICES);
+	TEE_ASSERT(gpio_dev < MAX_GPIO_DEVICES);
 
 	pl061_reg_base[gpio_dev] = base_addr;
 }

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -29,7 +29,6 @@
 #include <drivers/serial8250_uart.h>
 #include <console.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* uart register defines */

--- a/core/drivers/sunxi_uart.c
+++ b/core/drivers/sunxi_uart.c
@@ -28,7 +28,6 @@
 
 #include <drivers/sunxi_uart.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* uart register defines */

--- a/core/include/kernel/tee_common.h
+++ b/core/include/kernel/tee_common.h
@@ -27,7 +27,6 @@
 #ifndef TEE_COMMON_H
 #define TEE_COMMON_H
 
-#include <kernel/tee_common_unpg.h>
 #include <stdlib.h>
 
 #ifdef MEASURE_TIME

--- a/core/include/kernel/tee_common_unpg.h
+++ b/core/include/kernel/tee_common_unpg.h
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <tee_api_types.h>
-#include <kernel/panic.h>
 
 #define TEE_MEMBER_SIZE(type, member) sizeof(((type *)0)->member)
 
@@ -43,30 +42,6 @@ typedef uintptr_t tee_paddr_t;
 typedef uintptr_t tee_vaddr_t;
 /* Virtual address valid in user mode */
 typedef uintptr_t tee_uaddr_t;
-
-
-#if (CFG_TEE_CORE_DEBUG == 0)
-
-#define TEE_ASSERT(expr) \
-	do { \
-		if (!(expr)) { \
-			DMSG("assertion failed"); \
-			panic(); \
-		} \
-	} while (0)
-
-#else
-
-#define TEE_ASSERT(expr) \
-	do { \
-		if (!(expr)) { \
-			EMSG("assertion '%s' failed at %s:%d (func '%s')", \
-				#expr, __FILE__, __LINE__, __func__); \
-			panic(); \
-		} \
-	} while (0)
-
-#endif
 
 /*-----------------------------------------------------------------------------
  * tee_ta_load_page - Loads a page at address va_addr

--- a/core/include/kernel/tee_dispatch.h
+++ b/core/include/kernel/tee_dispatch.h
@@ -28,9 +28,7 @@
 #define TEE_DISPATCH_H
 
 #include <stdarg.h>
-#include <kernel/tee_common_unpg.h>
 #include <tee_api_types.h>
-
 #include <trace.h>
 
 /*

--- a/core/include/kernel/tee_misc.h
+++ b/core/include/kernel/tee_misc.h
@@ -27,7 +27,6 @@
 #ifndef TEE_MISC_H
 #define TEE_MISC_H
 
-#include <kernel/tee_common_unpg.h>
 #include <types_ext.h>
 
 /*

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -33,7 +33,6 @@
 #include <tee_api_types.h>
 #include <utee_types.h>
 #include <kernel/tee_common.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/mutex.h>
 #include <tee_api_types.h>
 #include <user_ta_header.h>

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -27,12 +27,11 @@
 #ifndef TEE_SVC_H
 #define TEE_SVC_H
 
+#include <assert.h>
 #include <stdint.h>
-#include <kernel/tee_common_unpg.h>	/* tee_uaddr_t */
+#include <types_ext.h>
 #include <tee_api_types.h>
 #include <utee_types.h>
-#include <assert.h>
-#include <types_ext.h>
 
 extern vaddr_t tee_svc_uref_base;
 
@@ -95,7 +94,7 @@ TEE_Result tee_svc_copy_kaddr_to_uref(uint32_t *uref, void *kaddr);
 
 static inline uint32_t tee_svc_kaddr_to_uref(void *kaddr)
 {
-	assert(((vaddr_t)kaddr - tee_svc_uref_base) < UINT32_MAX);
+	TEE_ASSERT(((vaddr_t)kaddr - tee_svc_uref_base) < UINT32_MAX);
 	return (vaddr_t)kaddr - tee_svc_uref_base;
 }
 

--- a/core/kernel/assert.c
+++ b/core/kernel/assert.c
@@ -24,17 +24,25 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <assert.h>
-#include <trace.h>
 #include <compiler.h>
+#include <trace.h>
 #include <kernel/panic.h>
 
-/* indirected assert (see TEE_ASSERT()) */
+/* assert log and break for the optee kernel */
 
 void _assert_log(const char *expr __maybe_unused,
-		 const char *file __maybe_unused, int line __maybe_unused)
+		 const char *file __maybe_unused,
+		 const int line __maybe_unused,
+		 const char *func __maybe_unused)
 {
-	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
+#if (CFG_TEE_CORE_DEBUG == 0)
+	EMSG("assertion failed");
+#else
+	EMSG("assertion '%s' failed at %s:%d (func '%s')",
+				expr, file, line, func);
+#endif
 }
 
 void __noreturn _assert_break(void)

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -24,6 +24,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <assert.h>
 #include <types_ext.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -49,7 +51,6 @@
 #include <trace.h>
 #include <utee_types.h>
 #include <util.h>
-#include <assert.h>
 
 /* This mutex protects the critical section in tee_ta_init_session */
 struct mutex tee_ta_mutex = MUTEX_INITIALIZER;
@@ -67,7 +68,7 @@ static void lock_single_instance(void)
 			condvar_wait(&tee_ta_cv, &tee_ta_mutex);
 
 		tee_ta_single_instance_thread = thread_get_id();
-		assert(tee_ta_single_instance_count == 0);
+		TEE_ASSERT(!tee_ta_single_instance_count);
 	}
 
 	tee_ta_single_instance_count++;
@@ -76,8 +77,8 @@ static void lock_single_instance(void)
 static void unlock_single_instance(void)
 {
 	/* Requires tee_ta_mutex to be held */
-	assert(tee_ta_single_instance_thread == thread_get_id());
-	assert(tee_ta_single_instance_count > 0);
+	TEE_ASSERT(tee_ta_single_instance_thread == thread_get_id());
+	TEE_ASSERT(tee_ta_single_instance_count > 0);
 
 	tee_ta_single_instance_count--;
 	if (tee_ta_single_instance_count == 0) {
@@ -138,7 +139,7 @@ static void tee_ta_clear_busy(struct tee_ta_ctx *ctx)
 {
 	mutex_lock(&tee_ta_mutex);
 
-	assert(ctx->busy);
+	TEE_ASSERT(ctx->busy);
 	ctx->busy = false;
 	condvar_signal(&ctx->busy_cv);
 
@@ -150,7 +151,7 @@ static void tee_ta_clear_busy(struct tee_ta_ctx *ctx)
 
 static void dec_session_ref_count(struct tee_ta_session *s)
 {
-	assert(s->ref_count > 0);
+	TEE_ASSERT(s->ref_count > 0);
 	s->ref_count--;
 	if (s->ref_count == 1)
 		condvar_signal(&s->refc_cv);
@@ -200,7 +201,7 @@ struct tee_ta_session *tee_ta_get_session(uint32_t id, bool exclusive,
 		if (!exclusive)
 			break;
 
-		assert(s->lock_thread != thread_get_id());
+		TEE_ASSERT(s->lock_thread != thread_get_id());
 
 		while (s->lock_thread != THREAD_ID_INVALID && !s->unlink)
 			condvar_wait(&s->lock_cv, &tee_ta_mutex);
@@ -224,9 +225,9 @@ static void tee_ta_unlink_session(struct tee_ta_session *s,
 {
 	mutex_lock(&tee_ta_mutex);
 
-	assert(s->ref_count >= 1);
-	assert(s->lock_thread == thread_get_id());
-	assert(!s->unlink);
+	TEE_ASSERT(s->ref_count >= 1);
+	TEE_ASSERT(s->lock_thread == thread_get_id());
+	TEE_ASSERT(!s->unlink);
 
 	s->unlink = true;
 	condvar_broadcast(&s->lock_cv);
@@ -621,7 +622,7 @@ static void update_current_ctx(struct thread_specific_data *tsd)
 	 * If ctx->mmu == NULL we must not have user mapping active,
 	 * if ctx->mmu != NULL we must have user mapping active.
 	 */
-	assert(((ctx && is_user_ta_ctx(ctx) ?
+	TEE_ASSERT(((ctx && is_user_ta_ctx(ctx) ?
 			to_user_ta_ctx(ctx)->mmu : NULL) == NULL) ==
 		!core_mmu_user_mapping_is_active());
 }

--- a/core/lib/libtomcrypt/include/tomcrypt.h
+++ b/core/lib/libtomcrypt/include/tomcrypt.h
@@ -27,7 +27,6 @@
 
 #ifndef TOMCRYPT_H_
 #define TOMCRYPT_H_
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/core/lib/libtomcrypt/include/tomcrypt_argchk.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_argchk.h
@@ -39,7 +39,7 @@ void crypt_argchk(const char *v, const char *s, int d);
 #elif ARGTYPE == 1
 
 /* fatal type of error */
-#define LTC_ARGCHK(x) assert((x))
+#define LTC_ARGCHK(x) assert((x))		// FIXME: TEE_ASSERT() or assert() ?
 #define LTC_ARGCHKVD(x) LTC_ARGCHK(x)
 
 #elif ARGTYPE == 2

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -25,9 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+
 #include <tee/tee_cryp_provider.h>
 #include <tee/tee_cryp_utl.h>
-#include <kernel/tee_common_unpg.h>
 
 #include <tomcrypt.h>
 #include <mpalib.h>
@@ -151,7 +152,7 @@ static TEE_Result tee_ltc_prng_init(struct tee_ltc_prng *prng)
 	int res;
 	int prng_index;
 
-	TEE_ASSERT(prng != NULL);
+	assert(prng);
 
 	prng_index = find_prng(prng->name);
 	if (prng_index == -1)
@@ -546,7 +547,7 @@ static void pool_postactions(void)
 {
 	mpa_scratch_mem pool = (void *)_ltc_mempool_u32;
 
-	TEE_ASSERT(pool->last_offset == 0);
+	TEE_ASSERT(!pool->last_offset);
 	release_unused_mpa_scratch_memory();
 }
 
@@ -582,7 +583,7 @@ static void get_pool(struct mpa_scratch_mem_sync *sync)
 			condvar_wait(&sync->cv, &sync->mu);
 
 		sync->owner = thread_get_id();
-		assert(sync->count == 0);
+		TEE_ASSERT(!sync->count);
 	}
 
 	sync->count++;
@@ -595,8 +596,8 @@ static void put_pool(struct mpa_scratch_mem_sync *sync)
 {
 	mutex_lock(&sync->mu);
 
-	assert(sync->owner == thread_get_id());
-	assert(sync->count > 0);
+	TEE_ASSERT(sync->owner == thread_get_id());
+	TEE_ASSERT(sync->count > 0);
 
 	sync->count--;
 	if (!sync->count) {

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -25,15 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/aid.h>
 #include <tee/se/util.h>
-
-#include <stdlib.h>
-#include <string.h>
 
 #include "aid_priv.h"
 
@@ -42,7 +41,7 @@ TEE_Result tee_se_aid_create(const char *name, struct tee_se_aid **aid)
 	size_t str_length = strlen(name);
 	size_t aid_length = str_length / 2;
 
-	TEE_ASSERT(aid != NULL && *aid == NULL);
+	assert(aid && !*aid);
 	if (str_length < MIN_AID_LENGTH || str_length > MAX_AID_LENGTH)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -71,19 +70,19 @@ TEE_Result tee_se_aid_create_from_buffer(uint8_t *id, size_t length,
 
 void tee_se_aid_acquire(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL);
+	assert(aid);
 	aid->refcnt++;
 }
 
 int tee_se_aid_get_refcnt(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL);
+	assert(aid);
 	return aid->refcnt;
 }
 
 void tee_se_aid_release(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL && aid->refcnt > 0);
+	assert(aid && aid->refcnt > 0);
 	aid->refcnt--;
 	if (aid->refcnt == 0)
 		free(aid);

--- a/core/tee/se/apdu.c
+++ b/core/tee/se/apdu.c
@@ -25,14 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/apdu.h>
 #include <tee/se/util.h>
-
-#include <stdlib.h>
 
 #include "apdu_priv.h"
 
@@ -119,51 +119,51 @@ struct resp_apdu *alloc_resp_apdu(uint8_t le)
 
 uint8_t *resp_apdu_get_data(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->resp_data;
 }
 
 size_t resp_apdu_get_data_len(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->resp_data_len;
 }
 
 uint8_t resp_apdu_get_sw1(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->sw1;
 }
 
 uint8_t resp_apdu_get_sw2(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->sw2;
 }
 
 uint8_t *apdu_get_data(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->data_buf;
 }
 size_t apdu_get_length(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->length;
 }
 int apdu_get_refcnt(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->refcnt;
 }
 void apdu_acquire(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	apdu->refcnt++;
 }
 void apdu_release(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	apdu->refcnt--;
 	if (apdu->refcnt == 0)
 		free(apdu);

--- a/core/tee/se/channel.c
+++ b/core/tee/se/channel.c
@@ -25,10 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/session.h>
 #include <tee/se/channel.h>
 #include <tee/se/iso7816.h>
@@ -58,7 +58,7 @@ struct tee_se_channel *tee_se_channel_alloc(struct tee_se_session *s,
 
 void tee_se_channel_free(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	if (c->aid)
 		tee_se_aid_release(c->aid);
 	if (c->select_resp)
@@ -67,20 +67,21 @@ void tee_se_channel_free(struct tee_se_channel *c)
 
 struct tee_se_session *tee_se_channel_get_session(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return c->session;
 }
 
 int tee_se_channel_get_id(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return c->channel_id;
 }
 
 void tee_se_channel_set_select_response(struct tee_se_channel *c,
 		struct resp_apdu *resp)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
+
 	if (c->select_resp)
 		apdu_release(to_apdu_base(c->select_resp));
 	apdu_acquire(to_apdu_base(resp));
@@ -90,7 +91,7 @@ void tee_se_channel_set_select_response(struct tee_se_channel *c,
 TEE_Result tee_se_channel_get_select_response(struct tee_se_channel *c,
 		struct resp_apdu **resp)
 {
-	TEE_ASSERT(c != NULL && resp != NULL);
+	assert(c && resp);
 
 	if (c->select_resp) {
 		*resp = c->select_resp;
@@ -103,7 +104,7 @@ TEE_Result tee_se_channel_get_select_response(struct tee_se_channel *c,
 void tee_se_channel_set_aid(struct tee_se_channel *c,
 		struct tee_se_aid *aid)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	if (c->aid)
 		tee_se_aid_release(c->aid);
 	tee_se_aid_acquire(aid);
@@ -114,13 +115,13 @@ void tee_se_channel_set_aid(struct tee_se_channel *c,
 TEE_Result tee_se_channel_select(struct tee_se_channel *c,
 		struct tee_se_aid *aid)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return iso7816_select(c, aid);
 }
 
 TEE_Result tee_se_channel_select_next(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return iso7816_select_next(c);
 }
 
@@ -131,7 +132,7 @@ TEE_Result tee_se_channel_transmit(struct tee_se_channel *c,
 	uint8_t *cmd_buf;
 	int cla_channel;
 
-	TEE_ASSERT(c != NULL && cmd_apdu != NULL && resp_apdu != NULL);
+	assert(c && cmd_apdu && resp_apdu);
 
 	s = c->session;
 	cla_channel = iso7816_get_cla_channel(c->channel_id);

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -25,9 +25,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/reader.h>
 #include <tee/se/session.h>
 #include <tee/se/iso7816.h>
@@ -36,10 +38,7 @@
 #include <tee/se/channel.h>
 #include <tee/se/util.h>
 #include <tee/se/reader/interface.h>
-
-#include <malloc.h>
-#include <stdlib.h>
-#include <string.h>
+#include <trace.h>
 
 #include "session_priv.h"
 #include "aid_priv.h"
@@ -50,7 +49,7 @@ TEE_Result iso7816_exchange_apdu(struct tee_se_reader_proxy *proxy,
 {
 	TEE_Result ret;
 
-	TEE_ASSERT(cmd != NULL && resp != NULL);
+	assert(cmd && resp);
 	ret = tee_se_reader_transmit(proxy,
 			cmd->base.data_buf, cmd->base.length,
 			resp->base.data_buf, &resp->base.length);
@@ -89,7 +88,7 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 	int channel_id;
 	uint8_t cla_channel;
 
-	TEE_ASSERT(c != NULL);
+	assert(c);
 
 	s = tee_se_channel_get_session(c);
 	channel_id = tee_se_channel_get_id(c);
@@ -98,7 +97,7 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 
 	cla_channel = iso7816_get_cla_channel(channel_id);
 	if (select_ops == FIRST_OR_ONLY_OCCURRENCE) {
-		TEE_ASSERT(aid != NULL);
+		assert(aid);
 		cmd = alloc_cmd_apdu(ISO7816_CLA | cla_channel,
 				SELECT_CMD, SELECT_BY_AID,
 				select_ops, aid->length,
@@ -152,7 +151,7 @@ static TEE_Result internal_manage_channel(struct tee_se_session *s,
 	uint8_t channel_flag =
 		(open_flag == OPEN_CHANNEL) ? OPEN_NEXT_AVAILABLE : *channel_id;
 
-	TEE_ASSERT(s != NULL);
+	assert(s);
 
 	cmd = alloc_cmd_apdu(ISO7816_CLA, MANAGE_CHANNEL_CMD, open_flag,
 			channel_flag, tx_buf_len, rx_buf_len, NULL);

--- a/core/tee/se/manager.c
+++ b/core/tee/se/manager.c
@@ -27,7 +27,6 @@
 
 #include <initcall.h>
 #include <trace.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/mutex.h>
 #include <tee/se/manager.h>
 #include <tee/se/session.h>

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -25,11 +25,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <kernel/mutex.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
-#include <kernel/mutex.h>
 #include <tee/se/reader.h>
 #include <tee/se/reader/interface.h>
 
@@ -63,8 +64,7 @@ TEE_Result tee_se_reader_get_name(struct tee_se_reader_proxy *proxy,
 {
 	size_t name_len;
 
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
-
+	assert(proxy && proxy->reader);
 	name_len = strlen(proxy->reader->name);
 	*reader_name = proxy->reader->name;
 	*reader_name_len = name_len;
@@ -75,13 +75,13 @@ TEE_Result tee_se_reader_get_name(struct tee_se_reader_proxy *proxy,
 void tee_se_reader_get_properties(struct tee_se_reader_proxy *proxy,
 		TEE_SEReaderProperties *prop)
 {
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	*prop = proxy->reader->prop;
 }
 
 int tee_se_reader_get_refcnt(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	return proxy->refcnt;
 }
 
@@ -129,7 +129,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 	struct tee_se_reader *r;
 	TEE_Result ret;
 
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	ret = tee_se_reader_check_state(proxy);
 	if (ret != TEE_SUCCESS)
 		return ret;
@@ -137,7 +137,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 	mutex_lock(&proxy->mutex);
 	r = proxy->reader;
 
-	TEE_ASSERT(r->ops->transmit);
+	assert(r->ops->transmit);
 	ret = r->ops->transmit(r, tx_buf, tx_buf_len, rx_buf, rx_buf_len);
 
 	mutex_unlock(&proxy->mutex);
@@ -147,7 +147,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 
 void tee_se_reader_lock_basic_channel(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 
 	mutex_lock(&proxy->mutex);
 	proxy->basic_channel_locked = true;
@@ -156,7 +156,7 @@ void tee_se_reader_lock_basic_channel(struct tee_se_reader_proxy *proxy)
 
 void tee_se_reader_unlock_basic_channel(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 
 	mutex_lock(&proxy->mutex);
 	proxy->basic_channel_locked = false;
@@ -165,7 +165,7 @@ void tee_se_reader_unlock_basic_channel(struct tee_se_reader_proxy *proxy)
 
 bool tee_se_reader_is_basic_channel_locked(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 	return proxy->basic_channel_locked;
 }
 
@@ -175,7 +175,7 @@ TEE_Result tee_se_reader_get_atr(struct tee_se_reader_proxy *proxy,
 	TEE_Result ret;
 	struct tee_se_reader *r;
 
-	TEE_ASSERT(proxy != NULL && atr != NULL && atr_len != NULL);
+	assert(proxy && atr && atr_len);
 	ret = tee_se_reader_check_state(proxy);
 	if (ret != TEE_SUCCESS)
 		return ret;
@@ -183,7 +183,7 @@ TEE_Result tee_se_reader_get_atr(struct tee_se_reader_proxy *proxy,
 	mutex_lock(&proxy->mutex);
 	r = proxy->reader;
 
-	TEE_ASSERT(r->ops->get_atr);
+	assert(r->ops->get_atr);
 	ret = r->ops->get_atr(r, atr, atr_len);
 
 	mutex_unlock(&proxy->mutex);
@@ -196,8 +196,8 @@ TEE_Result tee_se_reader_open_session(struct tee_se_reader_proxy *proxy,
 	TEE_Result ret;
 	struct tee_se_session *s;
 
-	TEE_ASSERT(session != NULL && *session == NULL);
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(session && !*session);
+	assert(proxy && proxy->reader);
 
 	s = tee_se_session_alloc(proxy);
 	if (!s)

--- a/core/tee/se/reader/passthru_reader/reader.c
+++ b/core/tee/se/reader/passthru_reader/reader.c
@@ -25,15 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <io.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
 #include <mm/core_memprot.h>
+#include <stdio.h>
+#include <trace.h>
 
 #include <tee/se/util.h>
 #include <tee/se/reader/interface.h>
-
-#include <stdio.h>
 
 #include "pcsc.h"
 #include "reader.h"

--- a/core/tee/se/service.c
+++ b/core/tee/se/service.c
@@ -25,11 +25,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
 #include <kernel/tee_ta_manager.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/user_ta.h>
 #include <tee/se/service.h>
 #include <tee/se/session.h>
@@ -52,7 +52,7 @@ TEE_Result tee_se_service_open(
 		return ret;
 	utc = to_user_ta_ctx(sess->ctx);
 
-	TEE_ASSERT(service != NULL);
+	assert(service);
 	if (utc->se_service != NULL)
 		return TEE_ERROR_ACCESS_CONFLICT;
 
@@ -74,7 +74,7 @@ TEE_Result tee_se_service_add_session(
 		struct tee_se_service *service,
 		struct tee_se_session *session)
 {
-	TEE_ASSERT(service != NULL && session != NULL);
+	assert(service && session);
 
 	mutex_lock(&service->mutex);
 	TAILQ_INSERT_TAIL(&service->opened_sessions, session, link);
@@ -101,7 +101,7 @@ void tee_se_service_close_session(
 		struct tee_se_service *service,
 		struct tee_se_session *session)
 {
-	TEE_ASSERT(service != NULL && session != NULL);
+	assert(service && session);
 
 	tee_se_session_close(session);
 
@@ -121,7 +121,7 @@ void tee_se_service_close_sessions_by_reader(
 {
 	struct tee_se_session *s;
 
-	TEE_ASSERT(service != NULL && proxy != NULL);
+	assert(service && proxy);
 
 	TAILQ_FOREACH(s, &service->opened_sessions, link) {
 		if (s->reader_proxy == proxy)
@@ -130,7 +130,7 @@ void tee_se_service_close_sessions_by_reader(
 }
 
 TEE_Result tee_se_service_close(
-		struct tee_se_service *service)
+		struct tee_se_service *service __unused)
 {
 	TEE_Result ret;
 	struct tee_se_service *h;
@@ -143,9 +143,7 @@ TEE_Result tee_se_service_close(
 		return ret;
 
 	utc = to_user_ta_ctx(sess->ctx);
-	TEE_ASSERT(service != NULL);
-	TEE_ASSERT(utc->se_service != NULL);
-
+	assert(utc->se_service);
 	h = utc->se_service;
 
 	/* clean up all sessions */

--- a/core/tee/se/session.c
+++ b/core/tee/se/session.c
@@ -25,17 +25,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <assert.h>
 #include <kernel/mutex.h>
+#include <stdlib.h>
+#include <sys/queue.h>
+#include <trace.h>
 
 #include <tee/se/reader.h>
 #include <tee/se/session.h>
 #include <tee/se/channel.h>
 #include <tee/se/iso7816.h>
-
-#include <stdlib.h>
-#include <sys/queue.h>
 
 #include "session_priv.h"
 #include "channel_priv.h"
@@ -44,8 +43,8 @@ struct tee_se_session *tee_se_session_alloc(
 		struct tee_se_reader_proxy *proxy)
 {
 	struct tee_se_session *s;
-	TEE_ASSERT(proxy != NULL);
 
+	assert(proxy);
 	s = malloc(sizeof(struct tee_se_session));
 	if (s) {
 		TAILQ_INIT(&s->channels);
@@ -74,7 +73,7 @@ bool tee_se_session_is_channel_exist(struct tee_se_session *s,
 TEE_Result tee_se_session_get_atr(struct tee_se_session *s,
 		uint8_t **atr, size_t *atr_len)
 {
-	TEE_ASSERT(s != NULL && atr != NULL && atr_len != NULL);
+	assert(s && atr && atr_len);
 
 	return tee_se_reader_get_atr(s->reader_proxy, atr, atr_len);
 }
@@ -85,7 +84,7 @@ TEE_Result tee_se_session_open_basic_channel(struct tee_se_session *s,
 	struct tee_se_channel *c;
 	TEE_Result ret;
 
-	TEE_ASSERT(s != NULL && channel != NULL && *channel == NULL);
+	assert(s && channel && !*channel);
 
 	if (tee_se_reader_is_basic_channel_locked(s->reader_proxy)) {
 		*channel = NULL;
@@ -120,7 +119,7 @@ TEE_Result tee_se_session_open_logical_channel(struct tee_se_session *s,
 	struct tee_se_channel *c;
 	TEE_Result ret;
 
-	TEE_ASSERT(s != NULL && channel != NULL && *channel == NULL);
+	assert(s && channel && !*channel);
 
 	ret = iso7816_open_available_logical_channel(s, &channel_id);
 	if (ret != TEE_SUCCESS)
@@ -154,7 +153,7 @@ void tee_se_session_close_channel(struct tee_se_session *s,
 {
 	int channel_id;
 
-	TEE_ASSERT(s != NULL && c != NULL);
+	assert(s && c);
 	channel_id = tee_se_channel_get_id(c);
 	if (channel_id > 0) {
 		iso7816_close_logical_channel(s, channel_id);
@@ -184,7 +183,7 @@ void tee_se_session_close(struct tee_se_session *s)
 {
 	struct tee_se_channel *c;
 
-	TEE_ASSERT(s != NULL);
+	assert(s);
 
 	TAILQ_FOREACH(c, &s->channels, link)
 		tee_se_session_close_channel(s, c);

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -41,7 +41,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <kernel/tee_common_otp.h>
-#include <kernel/tee_common_unpg.h>
+#include <kernel/panic.h>
 #include <tee/tee_cryp_utl.h>
 #include <tee/tee_cryp_provider.h>
 #include <tee/tee_fs_key_manager.h>
@@ -275,7 +275,7 @@ size_t tee_fs_get_header_size(enum tee_fs_file_type type)
 		break;
 	default:
 		EMSG("Unknown file type, type=%d", type);
-		TEE_ASSERT(0);
+		panic();
 	}
 
 	return header_size;

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -26,7 +26,6 @@
  */
 
 #include <assert.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/thread.h>
 #include <kernel/handle.h>
 #include <kernel/mutex.h>
@@ -585,8 +584,7 @@ static int get_file_length(int fd, size_t *length)
 	size_t file_len;
 	int res;
 
-	TEE_ASSERT(length);
-
+	assert(length);
 	*length = 0;
 
 	res = ree_fs_lseek_ree(fd, 0, TEE_FS_SEEK_END);
@@ -1442,7 +1440,7 @@ static int ree_fs_open(TEE_Result *errno, const char *file, int flags, ...)
 	struct tee_fs_fd *fdp = NULL;
 	bool file_exist;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!file) {
@@ -1563,7 +1561,7 @@ static tee_fs_off_t ree_fs_lseek(TEE_Result *errno, int fd,
 	size_t filelen;
 	struct tee_fs_fd *fdp = handle_lookup(&fs_handle_db, fd);
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1631,7 +1629,7 @@ static int ree_fs_ftruncate_internal(TEE_Result *errno, struct tee_fs_fd *fdp,
 	struct tee_fs_file_meta *new_meta = NULL;
 	uint8_t *buf = NULL;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1756,7 +1754,7 @@ static int ree_fs_read(TEE_Result *errno, int fd, void *buf, size_t len)
 	uint8_t *data_ptr = buf;
 	struct tee_fs_fd *fdp = handle_lookup(&fs_handle_db, fd);
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1854,7 +1852,7 @@ static int ree_fs_write(TEE_Result *errno, int fd, const void *buf, size_t len)
 	size_t file_size;
 	int orig_pos;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -538,7 +538,9 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 {
 	uint8_t *tmp __maybe_unused;
 
-	TEE_ASSERT(size + offset <= RPMB_DATA_SIZE);
+
+	TEE_ASSERT((size + offset >= size) &&
+		   (size + offset <= RPMB_DATA_SIZE));
 
 	if (!fek) {
 		/* Block is not encrypted (not a file data block) */
@@ -568,7 +570,6 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 			memcpy(out, tmp + offset, size);
 			free(tmp);
 		} else {
-			TEE_ASSERT(!offset);
 			decrypt_block(out, frm->data, blk_idx, fek);
 		}
 #else

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -43,8 +43,6 @@
 #include <kernel/chip_services.h>
 #include <kernel/static_ta.h>
 
-#include <assert.h>
-
 vaddr_t tee_svc_uref_base;
 
 void syscall_log(const void *buf __maybe_unused, size_t len __maybe_unused)

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -24,6 +24,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <assert.h>
 #include <tee_api_types.h>
 #include <kernel/tee_ta_manager.h>
 #include <utee_defines.h>
@@ -3223,7 +3225,7 @@ static int pkcs1_get_salt_len(const TEE_Attribute *params, uint32_t num_params,
 {
 	size_t n;
 
-	assert(default_len < INT_MAX);
+	TEE_ASSERT(default_len < INT_MAX);
 
 	for (n = 0; n < num_params; n++) {
 		if (params[n].attributeID == TEE_ATTR_RSA_PSS_SALT_LENGTH) {

--- a/lib/libmpa/mpa_io.c
+++ b/lib/libmpa/mpa_io.c
@@ -24,8 +24,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "mpa.h"
-#include "assert.h"
+
+#include <assert.h>
+#include <mpa.h>
 
 /*
  * Big #ifdef to get rid of string conversion routines
@@ -318,7 +319,7 @@ int mpa_set_str(mpanum dest, const char *digitstr)
 
 	/* + 1 since we have one character in 'c' */
 	dlen = (int)(endp - digitstr) + 1;
-	assert(dlen <= MPA_STR_MAX_SIZE);
+	TEE_ASSERT(dlen <= MPA_STR_MAX_SIZE);
 	/* convert to a buffer of bytes */
 	bufidx = 0;
 	while (__mpa_is_char_in_base(16, c)) {
@@ -332,8 +333,8 @@ int mpa_set_str(mpanum dest, const char *digitstr)
 		goto cleanup;
 	}
 
-	assert((__mpa_digitstr_to_binary_wsize_base_16(bufidx) <=
-		__mpanum_alloced(dest)));
+	TEE_ASSERT(__mpa_digitstr_to_binary_wsize_base_16(bufidx) <=
+						__mpanum_alloced(dest));
 
 	retval = bufidx;
 	w = dest->d;
@@ -386,7 +387,7 @@ char *mpa_get_str(char *str, int mode, const mpanum n)
 {
 	char *s = str;
 
-	assert(str != 0);
+	assert(str);
 
 	/* insert a minus sign */
 	if (__mpanum_sign(n) == MPA_NEG_SIGN) {

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -24,16 +24,21 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <assert.h>
 #include <compiler.h>
+#include <trace.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
 #include <utee_syscalls.h>
 
 void _assert_log(const char *expr __maybe_unused,
-		 const char *file __maybe_unused, int line __maybe_unused)
+		 const char *file __maybe_unused,
+		 const int line __maybe_unused,
+		 const char *func __maybe_unused)
 {
-	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
+	EMSG("assertion '%s' failed at %s:%d (func '%s')",
+				expr, file, line, func);
 }
 
 void __noreturn _assert_break(void)

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -31,8 +31,6 @@
 #include <utee_syscalls.h>
 #include "tee_api_private.h"
 
-#include <assert.h>
-
 #define TEE_USAGE_DEFAULT   0xffffffff
 
 #define TEE_ATTR_BIT_VALUE                  (1 << 29)

--- a/lib/libutee/tee_user_mem.c
+++ b/lib/libutee/tee_user_mem.c
@@ -24,12 +24,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <assert.h>
 #include <inttypes.h>
 #include <string.h>
 #include <compiler.h>
 #include <utee_defines.h>
 #include <sys/queue.h>
-#include <assert.h>
 #include <tee_api.h>
 #include <util.h>
 #include "tee_user_mem.h"
@@ -236,10 +237,10 @@ static int check_elem(struct user_mem_elem *ap)
 	struct user_mem_elem *e;
 
 	/* Validate queue links */
-	if (ap == NULL)
+	if (!ap)
 		return 0;
 
-	assert(((uintptr_t) ap & 0x3) == 0);
+	TEE_ASSERT(!((uintptr_t)ap & 0x3));
 
 	e = TAILQ_NEXT(ap, link);
 	if (e != NULL && TAILQ_PREV(e, user_mem_head, link) != ap) {
@@ -256,7 +257,7 @@ static int check_elem(struct user_mem_elem *ap)
 	return check_elem_end(ap);
 }
 
-/* Trap PC element are corrupted. */
+/* In debug mode, trap PC element are corrupted. */
 static int is_mem_coherent(void)
 {
 	struct user_mem_elem *e;
@@ -438,7 +439,7 @@ void tee_user_mem_free(void *buffer)
 	PB(TRACE_DEBUG, "Free: ", (void *)e);
 
 #if (CFG_TEE_CORE_USER_MEM_DEBUG == 1)
-	assert(check_elem(e));
+	TEE_ASSERT(check_elem(e));
 #endif
 
 	TAILQ_REMOVE(&user_mem_head, e, link);

--- a/lib/libutee/tui/font.c
+++ b/lib/libutee/tui/font.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <util.h>
@@ -33,7 +34,6 @@
 #include "default_regular.h"
 #include "default_bold.h"
 #include <trace.h>
-#include <assert.h>
 
 #define UCP_CARRIAGE_RETURN	0x000D
 #define UCP_TUI_BOLD		0xE000
@@ -149,7 +149,7 @@ static bool letter_get_bit(const struct font_letter *letter, size_t x, size_t y)
 	size_t byte_pos = pos / 8;
 	uint8_t bit_mask = 1 << (7 - (pos & 0x7));
 
-	assert(byte_pos < letter->blob_size);
+	TEE_ASSERT(byte_pos < letter->blob_size);
 	return !!(bstr[byte_pos] & bit_mask);
 }
 

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -262,6 +262,7 @@ static bool bpool_foreach_pool(struct bpool_iterator *iterator, void **buf,
 		*isfree = true;
 
 		/* Assert that the free list links are intact */
+		/* FIXME: assert() or TEE_ASSERT() ? */
 		assert(b->ql.blink->ql.flink == b);
 		assert(b->ql.flink->ql.blink == b);
 	}
@@ -380,6 +381,7 @@ static void *raw_realloc(void *ptr, size_t hdr_size, size_t ftr_size,
 
 static void create_free_block(struct bfhead *bf, bufsize size, struct bhead *bn)
 {
+	// TODO: assert() or TEE_ASSERT() ?
 	assert(BH((char *)bf + size) == bn);
 	assert(bn->bsize < 0); /* Next block should be allocated */
 	/* Next block shouldn't already have free block in front */

--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -28,18 +28,33 @@
 #define ASSERT_H
 
 #include <compiler.h>
+#include <trace.h>
 
 void _assert_break(void) __noreturn;
-void _assert_log(const char *expr, const char *file, int line);
+void _assert_log(const char *expr, const char *file, const int line,
+			const char *func);
 
+/* assert() generates a log but does not panic if NDEBUG is defined */
+#ifdef NDEBUG
+#define assert(expr)	do { } while (0)
+#else
 #define assert(expr) \
 	do { \
 		if (!(expr)) { \
-			_assert_log(#expr, __FILE__, __LINE__); \
+			_assert_log(#expr, __FILE__, __LINE__, __func__); \
 			_assert_break(); \
 		} \
 	} while (0)
+#endif
 
+/* TEE_ASSERT() always panics if expr is false, whatever debug configuration */
+#define TEE_ASSERT(expr) \
+	do { \
+		if (!(expr)) { \
+			_assert_log(#expr, __FILE__, __LINE__, __func__); \
+			_assert_break(); \
+		} \
+	} while (0)
 
 #define COMPILE_TIME_ASSERT(x) \
 	do { \


### PR DESCRIPTION
This patch fixes use of assert() and TEE_ASSERT().
Both are declared in assert.h and defined in optee kernel and in the
utee library.

- If NDEBUG is defined, assert() is expected to produce no code and
  hence does not perform any check, trace or abort. If NDEBUG is not
  defined, assert() generates a trace and aborts execution.

- On contrary, TEE_ASSERT() will always abort execution. It generates
  a trace which verbosity depends on debug level.

Hence assert() shall be used only when one expects a nice debug trace
"pointer is null, i will soon crash" instead of a straight crash log.
When a sequence really needs a protection and cannot return with some
error code, TEE_ASSERT() shall be used.

For sake of simplicity, assert() and TEE_ASSERT() in optee kernel rely
on the same trace content: error level trace and verbosity upon
CFG_TEE_CORE_DEBUG value.

This patch removes several inclusions on tee_common_unpg.h as it used
to declare TEE_ASSERT() and now TEE_ASSERT() is declared in assert.h.
This change lead to including few string.h here and there.

Signed-off-by: jerome forissier <jerome.forissier@linaro.org>
Signed-off-by: etienne carriere <etienne.carriere@linaro.org>