### PR TITLE
assert() honor NDEBUG; replace TEE_ASSERT() with panic_unless()

### DIFF
--- a/core/arch/arm/include/kernel/static_ta.h
+++ b/core/arch/arm/include/kernel/static_ta.h
@@ -27,8 +27,8 @@
 #ifndef KERNEL_STATIC_TA_H
 #define KERNEL_STATIC_TA_H
 
+#include <assert.h>
 #include <compiler.h>
-#include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <tee_api_types.h>
 #include <util.h>
@@ -63,7 +63,7 @@ static inline bool is_static_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct static_ta_ctx *to_static_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	panic_if(!is_static_ta_ctx(ctx));
+	assert(is_static_ta_ctx(ctx));
 	return container_of(ctx, struct static_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/kernel/static_ta.h
+++ b/core/arch/arm/include/kernel/static_ta.h
@@ -63,7 +63,7 @@ static inline bool is_static_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct static_ta_ctx *to_static_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	panic_unless(is_static_ta_ctx(ctx));
+	panic_if(!is_static_ta_ctx(ctx));
 	return container_of(ctx, struct static_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/kernel/static_ta.h
+++ b/core/arch/arm/include/kernel/static_ta.h
@@ -28,10 +28,10 @@
 #define KERNEL_STATIC_TA_H
 
 #include <compiler.h>
+#include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <tee_api_types.h>
 #include <util.h>
-#include <assert.h>
 
 struct static_ta_head {
 	TEE_UUID uuid;
@@ -63,7 +63,7 @@ static inline bool is_static_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct static_ta_ctx *to_static_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	assert(is_static_ta_ctx(ctx));
+	panic_unless(is_static_ta_ctx(ctx));
 	return container_of(ctx, struct static_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -27,12 +27,12 @@
 #ifndef KERNEL_USER_TA_H
 #define KERNEL_USER_TA_H
 
-#include <types_ext.h>
-#include <tee_api_types.h>
-#include <kernel/panic.h>
+#include <assert.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <mm/tee_mm.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
 #include <util.h>
 
 TAILQ_HEAD(tee_cryp_state_head, tee_cryp_state);
@@ -74,7 +74,7 @@ static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	panic_if(!is_user_ta_ctx(ctx));
+	assert(is_user_ta_ctx(ctx));
 	return container_of(ctx, struct user_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -74,7 +74,7 @@ static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	panic_unless(is_user_ta_ctx(ctx));
+	panic_if(!is_user_ta_ctx(ctx));
 	return container_of(ctx, struct user_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -29,11 +29,11 @@
 
 #include <types_ext.h>
 #include <tee_api_types.h>
+#include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <mm/tee_mm.h>
 #include <util.h>
-#include <assert.h>
 
 TAILQ_HEAD(tee_cryp_state_head, tee_cryp_state);
 TAILQ_HEAD(tee_obj_head, tee_obj);
@@ -74,7 +74,7 @@ static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx)
 
 static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	assert(is_user_ta_ctx(ctx));
+	panic_unless(is_user_ta_ctx(ctx));
 	return container_of(ctx, struct user_ta_ctx, ctx);
 }
 

--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -28,9 +28,8 @@
 #ifndef CORE_MEMPROT_H
 #define CORE_MEMPROT_H
 
-#include <types_ext.h>
-#include <kernel/tee_common_unpg.h>
 #include <mm/core_mmu.h>
+#include <types_ext.h>
 
 /*
  * "pbuf_is" support.

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -28,12 +28,9 @@
 #ifndef CORE_MMU_H
 #define CORE_MMU_H
 
-#include <kernel/tee_common_unpg.h>
 #include <kernel/user_ta.h>
 #include <mm/tee_mmu_types.h>
 #include <types_ext.h>
-
-#include <assert.h>
 
 /* A small page is the smallest unit of memory that can be mapped */
 #define SMALL_PAGE_SHIFT	12

--- a/core/arch/arm/include/tee/arch_svc.h
+++ b/core/arch/arm/include/tee/arch_svc.h
@@ -27,8 +27,6 @@
 #ifndef TEE_ARCH_SVC_H
 #define TEE_ARCH_SVC_H
 
-#include <kernel/tee_common_unpg.h>
-
 struct thread_svc_regs;
 
 void tee_svc_handler(struct thread_svc_regs *regs);

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -336,13 +336,9 @@ static void handle_user_ta_panic(struct abort_info *ai)
 #ifdef CFG_WITH_VFP
 static void handle_user_ta_vfp(void)
 {
-	TEE_Result res;
 	struct tee_ta_session *s;
 
-	res = tee_ta_get_current_session(&s);
-	if (res != TEE_SUCCESS)
-		panic();
-
+	panic_if(tee_ta_get_current_session(&s) != TEE_SUCCESS);
 	thread_user_enable_vfp(&to_user_ta_ctx(s->ctx)->vfp);
 }
 #endif /*CFG_WITH_VFP*/
@@ -495,16 +491,14 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 
 	if (is_abort_in_abort_handler(ai)) {
 		abort_print_error(ai);
-		EMSG("[abort] abort in abort handler (trap CPU)");
-		panic();
+		panic_msg("[abort] abort in abort handler (trap CPU)");
 	}
 
 	if (ai->abort_type == ABORT_TYPE_UNDEF) {
 		if (abort_is_user_exception(ai))
 			return FAULT_TYPE_USER_TA_PANIC;
 		abort_print_error(ai);
-		EMSG("[abort] undefined abort (trap CPU)");
-		panic();
+		panic_msg("[abort] undefined abort (trap CPU)");
 	}
 
 	switch (core_mmu_get_fault_type(ai->fault_descr)) {
@@ -512,16 +506,14 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 		if (abort_is_user_exception(ai))
 			return FAULT_TYPE_USER_TA_PANIC;
 		abort_print_error(ai);
-		EMSG("[abort] alignement fault!  (trap CPU)");
-		panic();
+		panic_msg("[abort] alignement fault!  (trap CPU)");
 		break;
 
 	case CORE_MMU_FAULT_ACCESS_BIT:
 		if (abort_is_user_exception(ai))
 			return FAULT_TYPE_USER_TA_PANIC;
 		abort_print_error(ai);
-		EMSG("[abort] access bit fault!  (trap CPU)");
-		panic();
+		panic_msg("[abort] access bit fault!  (trap CPU)");
 		break;
 
 	case CORE_MMU_FAULT_DEBUG_EVENT:

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -88,7 +88,7 @@ __weak void main_init_gic(void)
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 void init_sec_mon(unsigned long nsec_entry __maybe_unused)
 {
-	assert(nsec_entry == PADDR_INVALID);
+	panic_unless(nsec_entry == PADDR_INVALID);
 	/* Do nothing as we don't have a secure monitor */
 }
 #else
@@ -97,7 +97,7 @@ __weak void init_sec_mon(unsigned long nsec_entry)
 {
 	struct sm_nsec_ctx *nsec_ctx;
 
-	assert(nsec_entry != PADDR_INVALID);
+	panic_unless(nsec_entry != PADDR_INVALID);
 
 	/* Initialize secure monitor */
 	nsec_ctx = sm_get_nsec_ctx();
@@ -185,8 +185,8 @@ static void init_runtime(unsigned long pageable_part)
 	uint8_t *hashes;
 	size_t block_size;
 
-	TEE_ASSERT(pageable_size % SMALL_PAGE_SIZE == 0);
-	TEE_ASSERT(hash_size == (size_t)__tmp_hashes_size);
+	panic_unless(pageable_size % SMALL_PAGE_SIZE == 0);
+	panic_unless(hash_size == (size_t)__tmp_hashes_size);
 
 	/*
 	 * Zero BSS area. Note that globals that would normally would go
@@ -216,7 +216,7 @@ static void init_runtime(unsigned long pageable_part)
 
 	hashes = malloc(hash_size);
 	IMSG("Pager is enabled. Hashes: %zu bytes", hash_size);
-	TEE_ASSERT(hashes);
+	assert(hashes);
 	memcpy(hashes, __tmp_hashes_start, hash_size);
 
 	/*
@@ -226,7 +226,7 @@ static void init_runtime(unsigned long pageable_part)
 	teecore_init_ta_ram();
 
 	mm = tee_mm_alloc(&tee_mm_sec_ddr, pageable_size);
-	TEE_ASSERT(mm);
+	assert(mm);
 	paged_store = phys_to_virt(tee_mm_get_smem(mm), MEM_AREA_TA_RAM);
 	/* Copy init part into pageable area */
 	memcpy(paged_store, __init_start, init_size);
@@ -292,7 +292,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore,
 		(vaddr_t)tee_mm_vcore.hi - TZSRAM_SIZE, TZSRAM_SIZE);
-	TEE_ASSERT(mm);
+	assert(mm);
 	tee_pager_init(mm);
 
 	/*
@@ -302,7 +302,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, tee_mm_vcore.lo,
 			(vaddr_t)(__text_init_start - tee_mm_vcore.lo));
-	TEE_ASSERT(mm);
+	panic_unless(mm);
 
 	/*
 	 * Allocate virtual memory for the pageable area and let the pager
@@ -310,7 +310,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, (vaddr_t)__pageable_start,
 			   pageable_size);
-	TEE_ASSERT(mm);
+	assert(mm);
 	if (!tee_pager_add_core_area(tee_mm_get_smem(mm), tee_mm_get_bytes(mm),
 				     TEE_MATTR_PRX, paged_store, hashes))
 		panic();

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -88,7 +88,7 @@ __weak void main_init_gic(void)
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 void init_sec_mon(unsigned long nsec_entry __maybe_unused)
 {
-	panic_if(nsec_entry != PADDR_INVALID);
+	assert(nsec_entry == PADDR_INVALID);
 	/* Do nothing as we don't have a secure monitor */
 }
 #else
@@ -97,7 +97,7 @@ __weak void init_sec_mon(unsigned long nsec_entry)
 {
 	struct sm_nsec_ctx *nsec_ctx;
 
-	panic_if(nsec_entry == PADDR_INVALID);
+	assert(nsec_entry != PADDR_INVALID);
 
 	/* Initialize secure monitor */
 	nsec_ctx = sm_get_nsec_ctx();
@@ -183,8 +183,8 @@ static void init_runtime(unsigned long pageable_part)
 	uint8_t *hashes;
 	size_t block_size;
 
-	panic_if(pageable_size % SMALL_PAGE_SIZE);
-	panic_if(hash_size != (size_t)__tmp_hashes_size);
+	assert(pageable_size % SMALL_PAGE_SIZE == 0);
+	assert(hash_size == (size_t)__tmp_hashes_size);
 
 	/*
 	 * Zero BSS area. Note that globals that would normally would go
@@ -289,7 +289,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore,
 		(vaddr_t)tee_mm_vcore.hi - TZSRAM_SIZE, TZSRAM_SIZE);
-	panic_if(!mm);
+	assert(mm);
 	tee_pager_init(mm);
 
 	/*
@@ -299,7 +299,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, tee_mm_vcore.lo,
 			(vaddr_t)(__text_init_start - tee_mm_vcore.lo));
-	panic_if(!mm);
+	assert(mm);
 
 	/*
 	 * Allocate virtual memory for the pageable area and let the pager
@@ -307,7 +307,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, (vaddr_t)__pageable_start,
 			   pageable_size);
-	panic_if(!mm);
+	assert(mm);
 	panic_if(!tee_pager_add_core_area(tee_mm_get_smem(mm),
 					  tee_mm_get_bytes(mm),
 					  TEE_MATTR_PRX, paged_store, hashes));

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -88,7 +88,7 @@ __weak void main_init_gic(void)
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 void init_sec_mon(unsigned long nsec_entry __maybe_unused)
 {
-	panic_unless(nsec_entry == PADDR_INVALID);
+	panic_if(nsec_entry != PADDR_INVALID);
 	/* Do nothing as we don't have a secure monitor */
 }
 #else
@@ -97,7 +97,7 @@ __weak void init_sec_mon(unsigned long nsec_entry)
 {
 	struct sm_nsec_ctx *nsec_ctx;
 
-	panic_unless(nsec_entry != PADDR_INVALID);
+	panic_if(nsec_entry == PADDR_INVALID);
 
 	/* Initialize secure monitor */
 	nsec_ctx = sm_get_nsec_ctx();
@@ -165,11 +165,9 @@ static size_t get_block_size(void)
 	struct core_mmu_table_info tbl_info;
 	unsigned l;
 
-	if (!core_mmu_find_table(CFG_TEE_RAM_START, UINT_MAX, &tbl_info))
-		panic();
+	panic_if(!core_mmu_find_table(CFG_TEE_RAM_START, UINT_MAX, &tbl_info));
 	l = tbl_info.level - 1;
-	if (!core_mmu_find_table(CFG_TEE_RAM_START, l, &tbl_info))
-		panic();
+	panic_if(!core_mmu_find_table(CFG_TEE_RAM_START, l, &tbl_info));
 	return 1 << tbl_info.shift;
 }
 
@@ -185,8 +183,8 @@ static void init_runtime(unsigned long pageable_part)
 	uint8_t *hashes;
 	size_t block_size;
 
-	panic_unless(pageable_size % SMALL_PAGE_SIZE == 0);
-	panic_unless(hash_size == (size_t)__tmp_hashes_size);
+	panic_if(pageable_size % SMALL_PAGE_SIZE);
+	panic_if(hash_size != (size_t)__tmp_hashes_size);
 
 	/*
 	 * Zero BSS area. Note that globals that would normally would go
@@ -200,9 +198,8 @@ static void init_runtime(unsigned long pageable_part)
 	 * This needs to be initialized early to support address lookup
 	 * in MEM_AREA_TEE_RAM
 	 */
-	if (!core_mmu_find_table(CFG_TEE_RAM_START, UINT_MAX,
-				 &tee_pager_tbl_info))
-		panic();
+	panic_if(!core_mmu_find_table(CFG_TEE_RAM_START, UINT_MAX,
+				 &tee_pager_tbl_info));
 	if (tee_pager_tbl_info.shift != SMALL_PAGE_SHIFT) {
 		EMSG("Unsupported page size in translation table %u",
 		     BIT(tee_pager_tbl_info.shift));
@@ -292,7 +289,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore,
 		(vaddr_t)tee_mm_vcore.hi - TZSRAM_SIZE, TZSRAM_SIZE);
-	assert(mm);
+	panic_if(!mm);
 	tee_pager_init(mm);
 
 	/*
@@ -302,7 +299,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, tee_mm_vcore.lo,
 			(vaddr_t)(__text_init_start - tee_mm_vcore.lo));
-	panic_unless(mm);
+	panic_if(!mm);
 
 	/*
 	 * Allocate virtual memory for the pageable area and let the pager
@@ -310,10 +307,11 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, (vaddr_t)__pageable_start,
 			   pageable_size);
-	assert(mm);
-	if (!tee_pager_add_core_area(tee_mm_get_smem(mm), tee_mm_get_bytes(mm),
-				     TEE_MATTR_PRX, paged_store, hashes))
-		panic();
+	panic_if(!mm);
+	panic_if(!tee_pager_add_core_area(tee_mm_get_smem(mm),
+					  tee_mm_get_bytes(mm),
+					  TEE_MATTR_PRX, paged_store, hashes));
+
 	tee_pager_add_pages((vaddr_t)__pageable_start,
 		ROUNDUP(init_size, SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE, false);
 	tee_pager_add_pages((vaddr_t)__pageable_start +
@@ -483,8 +481,7 @@ static void init_fdt(unsigned long phys_fdt)
 	if (!core_mmu_add_mapping(MEM_AREA_IO_NSEC, phys_fdt, CFG_DTB_MAX_SIZE))
 		panic();
 	fdt = phys_to_virt(phys_fdt, MEM_AREA_IO_NSEC);
-	if (!fdt)
-		panic();
+	panic_if(!fdt);
 
 	ret = fdt_open_into(fdt, fdt, CFG_DTB_MAX_SIZE);
 	if (ret < 0) {
@@ -538,8 +535,7 @@ static void init_primary_helper(unsigned long pageable_part,
 	main_init_gic();
 	init_vfp_nsec();
 
-	if (init_teecore() != TEE_SUCCESS)
-		panic();
+	panic_if(init_teecore() != TEE_SUCCESS);
 	DMSG("Primary CPU switching to normal world boot\n");
 }
 

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -24,10 +24,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <kernel/mutex.h>
+#include <kernel/panic.h>
 #include <kernel/tz_proc.h>
 #include <kernel/thread.h>
-#include <kernel/tee_common_unpg.h>
 #include <trace.h>
 
 void mutex_init(struct mutex *m)
@@ -83,7 +84,7 @@ static void __mutex_unlock(struct mutex *m, const char *fname, int lineno)
 	old_itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
 	cpu_spin_lock(&m->spin_lock);
 
-	TEE_ASSERT(m->value == MUTEX_VALUE_LOCKED);
+	panic_unless(m->value == MUTEX_VALUE_LOCKED);
 	thread_rem_mutex(m);
 	m->value = MUTEX_VALUE_UNLOCKED;
 
@@ -154,8 +155,8 @@ void mutex_destroy(struct mutex *m)
 	 * Caller guarantees that no one will try to take the mutex so
 	 * there's no need to take the spinlock before accessing it.
 	 */
-	TEE_ASSERT(m->value == MUTEX_VALUE_UNLOCKED);
-	TEE_ASSERT(wq_is_empty(&m->wq));
+	panic_unless(m->value == MUTEX_VALUE_UNLOCKED);
+	panic_unless(wq_is_empty(&m->wq));
 }
 
 void condvar_init(struct condvar *cv)
@@ -166,7 +167,7 @@ void condvar_init(struct condvar *cv)
 void condvar_destroy(struct condvar *cv)
 {
 	if (cv->m)
-		TEE_ASSERT(!wq_have_condvar(&cv->m->wq, cv));
+		panic_unless(!wq_have_condvar(&cv->m->wq, cv));
 	condvar_init(cv);
 }
 
@@ -220,7 +221,7 @@ static void __condvar_wait(struct condvar *cv, struct mutex *m,
 
 	/* Link this condvar to this mutex until reinitialized */
 	cpu_spin_lock(&cv->spin_lock);
-	TEE_ASSERT(!cv->m || cv->m == m);
+	panic_unless(!cv->m || cv->m == m);
 	cv->m = m;
 	cpu_spin_unlock(&cv->spin_lock);
 
@@ -230,7 +231,7 @@ static void __condvar_wait(struct condvar *cv, struct mutex *m,
 	wq_wait_init_condvar(&m->wq, &wqe, cv);
 
 	/* Unlock the mutex */
-	TEE_ASSERT(m->value == MUTEX_VALUE_LOCKED);
+	panic_unless(m->value == MUTEX_VALUE_LOCKED);
 	thread_rem_mutex(m);
 	m->value = MUTEX_VALUE_UNLOCKED;
 

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -32,7 +32,6 @@
 #include <mm/core_mmu.h>
 #include <utee_defines.h>
 
-#include <assert.h>
 #include <stdint.h>
 #include <mpa.h>
 #include <arm.h>

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -25,6 +25,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <platform_config.h>
 #include <kernel/panic.h>
 #include <kernel/thread.h>
@@ -46,7 +47,6 @@
 #include <kernel/tee_ta_manager.h>
 #include <util.h>
 #include <trace.h>
-#include <assert.h>
 #include <keep.h>
 
 #ifdef ARM32
@@ -85,8 +85,8 @@ static struct thread_core_local thread_core_local[CFG_TEE_CORE_NB_CORE];
 #ifdef ARM64
 #define STACK_CANARY_SIZE	(8 * sizeof(uint32_t))
 #endif
-#define START_CANARY_VALUE	0xdededede
-#define END_CANARY_VALUE	0xabababab
+#define START_CANARY		0xdededede
+#define END_CANARY		0xabababab
 #define GET_START_CANARY(name, stack_num) name[stack_num][0]
 #define GET_END_CANARY(name, stack_num) \
 	name[stack_num][sizeof(name[stack_num]) / sizeof(uint32_t) - 1]
@@ -143,8 +143,8 @@ static void init_canaries(void)
 		uint32_t *start_canary = &GET_START_CANARY(name, n);	\
 		uint32_t *end_canary = &GET_END_CANARY(name, n);	\
 									\
-		*start_canary = START_CANARY_VALUE;			\
-		*end_canary = END_CANARY_VALUE;				\
+		*start_canary = START_CANARY;				\
+		*end_canary = END_CANARY;				\
 		DMSG("#Stack canaries for %s[%zu] with top at %p\n",	\
 			#name, n, (void *)(end_canary - 1));		\
 		DMSG("watch *%p\n", (void *)end_canary);		\
@@ -167,24 +167,24 @@ void thread_check_canaries(void)
 	size_t n;
 
 	for (n = 0; n < ARRAY_SIZE(stack_tmp); n++) {
-		assert(GET_START_CANARY(stack_tmp, n) == START_CANARY_VALUE);
-		assert(GET_END_CANARY(stack_tmp, n) == END_CANARY_VALUE);
+		panic_unless(GET_START_CANARY(stack_tmp, n) == START_CANARY);
+		panic_unless(GET_END_CANARY(stack_tmp, n) == END_CANARY);
 	}
 
 	for (n = 0; n < ARRAY_SIZE(stack_abt); n++) {
-		assert(GET_START_CANARY(stack_abt, n) == START_CANARY_VALUE);
-		assert(GET_END_CANARY(stack_abt, n) == END_CANARY_VALUE);
+		panic_unless(GET_START_CANARY(stack_abt, n) == START_CANARY);
+		panic_unless(GET_END_CANARY(stack_abt, n) == END_CANARY);
 	}
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)
 	for (n = 0; n < ARRAY_SIZE(stack_sm); n++) {
-		assert(GET_START_CANARY(stack_sm, n) == START_CANARY_VALUE);
-		assert(GET_END_CANARY(stack_sm, n) == END_CANARY_VALUE);
+		panic_unless(GET_START_CANARY(stack_sm, n) == START_CANARY);
+		panic_unless(GET_END_CANARY(stack_sm, n) == END_CANARY);
 	}
 #endif
 #ifndef CFG_WITH_PAGER
 	for (n = 0; n < ARRAY_SIZE(stack_thread); n++) {
-		assert(GET_START_CANARY(stack_thread, n) == START_CANARY_VALUE);
-		assert(GET_END_CANARY(stack_thread, n) == END_CANARY_VALUE);
+		panic_unless(GET_START_CANARY(stack_thread, n) == START_CANARY);
+		panic_unless(GET_END_CANARY(stack_thread, n) == END_CANARY);
 	}
 #endif
 #endif/*CFG_WITH_STACK_CANARIES*/
@@ -259,9 +259,9 @@ struct thread_core_local *thread_get_core_local(void)
 	 * we otherwise may be rescheduled to a different core in the
 	 * middle of this function.
 	 */
-	assert(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
 
-	assert(cpu_id < CFG_TEE_CORE_NB_CORE);
+	panic_unless(cpu_id < CFG_TEE_CORE_NB_CORE);
 	return &thread_core_local[cpu_id];
 }
 
@@ -289,7 +289,7 @@ static void thread_lazy_restore_ns_vfp(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	assert(!thr->vfp_state.sec_lazy_saved && !thr->vfp_state.sec_saved);
+	panic_unless(!thr->vfp_state.sec_lazy_saved && !thr->vfp_state.sec_saved);
 
 	if (tuv && tuv->lazy_saved && !tuv->saved) {
 		vfp_lazy_save_state_final(&tuv->vfp);
@@ -388,9 +388,9 @@ void thread_clr_boot_thread(void)
 {
 	struct thread_core_local *l = thread_get_core_local();
 
-	assert(l->curr_thread >= 0 && l->curr_thread < CFG_NUM_THREADS);
-	assert(threads[l->curr_thread].state == THREAD_STATE_ACTIVE);
-	assert(TAILQ_EMPTY(&threads[l->curr_thread].mutexes));
+	panic_unless(l->curr_thread >= 0 && l->curr_thread < CFG_NUM_THREADS);
+	panic_unless(threads[l->curr_thread].state == THREAD_STATE_ACTIVE);
+	panic_unless(TAILQ_EMPTY(&threads[l->curr_thread].mutexes));
 	threads[l->curr_thread].state = THREAD_STATE_FREE;
 	l->curr_thread = -1;
 }
@@ -401,7 +401,7 @@ static void thread_alloc_and_run(struct thread_smc_args *args)
 	struct thread_core_local *l = thread_get_core_local();
 	bool found_thread = false;
 
-	assert(l->curr_thread == -1);
+	panic_unless(l->curr_thread == -1);
 
 	lock_global();
 
@@ -472,7 +472,7 @@ static void thread_resume_from_rpc(struct thread_smc_args *args)
 	struct thread_core_local *l = thread_get_core_local();
 	uint32_t rv = 0;
 
-	assert(l->curr_thread == -1);
+	panic_unless(l->curr_thread == -1);
 
 	lock_global();
 
@@ -513,7 +513,7 @@ void thread_handle_fast_smc(struct thread_smc_args *args)
 	thread_check_canaries();
 	thread_fast_smc_handler_ptr(args);
 	/* Fast handlers must not unmask any exceptions */
-	assert(thread_get_exceptions() == THREAD_EXCP_ALL);
+	panic_unless(thread_get_exceptions() == THREAD_EXCP_ALL);
 }
 
 void thread_handle_std_smc(struct thread_smc_args *args)
@@ -572,7 +572,7 @@ vaddr_t thread_get_saved_thread_sp(void)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	assert(ct != -1);
+	panic_unless(ct != -1);
 	return threads[ct].kern_sp;
 }
 #endif /*ARM64*/
@@ -590,8 +590,8 @@ void thread_state_free(void)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	assert(ct != -1);
-	assert(TAILQ_EMPTY(&threads[ct].mutexes));
+	panic_unless(ct != -1);
+	panic_unless(TAILQ_EMPTY(&threads[ct].mutexes));
 
 	thread_lazy_restore_ns_vfp();
 	tee_pager_release_phys(
@@ -600,7 +600,7 @@ void thread_state_free(void)
 
 	lock_global();
 
-	assert(threads[ct].state == THREAD_STATE_ACTIVE);
+	panic_unless(threads[ct].state == THREAD_STATE_ACTIVE);
 	threads[ct].state = THREAD_STATE_FREE;
 	threads[ct].flags = 0;
 	l->curr_thread = -1;
@@ -647,7 +647,7 @@ int thread_state_suspend(uint32_t flags, uint32_t cpsr, vaddr_t pc)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	assert(ct != -1);
+	panic_unless(ct != -1);
 
 	thread_check_canaries();
 
@@ -659,7 +659,7 @@ int thread_state_suspend(uint32_t flags, uint32_t cpsr, vaddr_t pc)
 
 	lock_global();
 
-	assert(threads[ct].state == THREAD_STATE_ACTIVE);
+	panic_unless(threads[ct].state == THREAD_STATE_ACTIVE);
 	threads[ct].flags |= flags;
 	threads[ct].regs.cpsr = cpsr;
 	threads[ct].regs.pc = pc;
@@ -732,7 +732,7 @@ int thread_get_id(void)
 {
 	int ct = thread_get_id_may_fail();
 
-	assert((ct >= 0) && (ct < CFG_NUM_THREADS));
+	panic_unless((ct >= 0) && (ct < CFG_NUM_THREADS));
 	return ct;
 }
 
@@ -764,7 +764,7 @@ static void init_thread_stacks(void)
 		/* Find vmem for thread stack and its protection gap */
 		mm = tee_mm_alloc(&tee_mm_vcore,
 				  SMALL_PAGE_SIZE + STACK_THREAD_SIZE);
-		TEE_ASSERT(mm);
+		panic_unless(mm);
 
 		/* Claim eventual physical page */
 		tee_pager_add_pages(tee_mm_get_smem(mm), tee_mm_get_size(mm),
@@ -837,7 +837,7 @@ struct thread_ctx_regs *thread_get_ctx_regs(void)
 {
 	struct thread_core_local *l = thread_get_core_local();
 
-	assert(l->curr_thread != -1);
+	panic_unless(l->curr_thread != -1);
 	return &threads[l->curr_thread].regs;
 }
 
@@ -849,7 +849,7 @@ void thread_set_irq(bool enable)
 
 	l = thread_get_core_local();
 
-	assert(l->curr_thread != -1);
+	panic_unless(l->curr_thread != -1);
 
 	if (enable) {
 		threads[l->curr_thread].flags |= THREAD_FLAGS_IRQ_ENABLE;
@@ -871,7 +871,7 @@ void thread_restore_irq(void)
 
 	l = thread_get_core_local();
 
-	assert(l->curr_thread != -1);
+	panic_unless(l->curr_thread != -1);
 
 	if (threads[l->curr_thread].flags & THREAD_FLAGS_IRQ_ENABLE)
 		thread_set_exceptions(exceptions & ~THREAD_EXCP_IRQ);
@@ -884,7 +884,7 @@ uint32_t thread_kernel_enable_vfp(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	assert(!vfp_is_enabled());
+	panic_unless(!vfp_is_enabled());
 
 	if (!thr->vfp_state.ns_saved) {
 		vfp_lazy_save_state_final(&thr->vfp_state.ns);
@@ -914,11 +914,11 @@ void thread_kernel_disable_vfp(uint32_t state)
 {
 	uint32_t exceptions;
 
-	assert(vfp_is_enabled());
+	panic_unless(vfp_is_enabled());
 
 	vfp_disable();
 	exceptions = thread_get_exceptions();
-	assert(exceptions & THREAD_EXCP_IRQ);
+	panic_unless(exceptions & THREAD_EXCP_IRQ);
 	exceptions &= ~THREAD_EXCP_IRQ;
 	exceptions |= state & THREAD_EXCP_IRQ;
 	thread_set_exceptions(exceptions);
@@ -928,7 +928,7 @@ void thread_kernel_save_vfp(void)
 {
 	struct thread_ctx *thr = threads + thread_get_id();
 
-	assert(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
 	if (vfp_is_enabled()) {
 		vfp_lazy_save_state_init(&thr->vfp_state.sec);
 		thr->vfp_state.sec_lazy_saved = true;
@@ -939,8 +939,8 @@ void thread_kernel_restore_vfp(void)
 {
 	struct thread_ctx *thr = threads + thread_get_id();
 
-	assert(thread_get_exceptions() & THREAD_EXCP_IRQ);
-	assert(!vfp_is_enabled());
+	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_unless(!vfp_is_enabled());
 	if (thr->vfp_state.sec_lazy_saved) {
 		vfp_lazy_restore_state(&thr->vfp_state.sec,
 				       thr->vfp_state.sec_saved);
@@ -954,8 +954,8 @@ void thread_user_enable_vfp(struct thread_user_vfp_state *uvfp)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	assert(thread_get_exceptions() & THREAD_EXCP_IRQ);
-	assert(!vfp_is_enabled());
+	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_unless(!vfp_is_enabled());
 
 	if (!thr->vfp_state.ns_saved) {
 		vfp_lazy_save_state_final(&thr->vfp_state.ns);
@@ -981,11 +981,11 @@ void thread_user_save_vfp(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	assert(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
 	if (!vfp_is_enabled())
 		return;
 
-	assert(tuv && !tuv->lazy_saved && !tuv->saved);
+	panic_unless(tuv && !tuv->lazy_saved && !tuv->saved);
 	vfp_lazy_save_state_init(&tuv->vfp);
 	tuv->lazy_saved = true;
 }
@@ -1058,8 +1058,8 @@ void thread_add_mutex(struct mutex *m)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	assert(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
-	assert(m->owner_id == -1);
+	panic_unless(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
+	panic_unless(m->owner_id == -1);
 	m->owner_id = ct;
 	TAILQ_INSERT_TAIL(&threads[ct].mutexes, m, link);
 }
@@ -1069,8 +1069,8 @@ void thread_rem_mutex(struct mutex *m)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	assert(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
-	assert(m->owner_id == ct);
+	panic_unless(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
+	panic_unless(m->owner_id == ct);
 	m->owner_id = -1;
 	TAILQ_REMOVE(&threads[ct].mutexes, m, link);
 }
@@ -1141,7 +1141,7 @@ static uint32_t rpc_cmd_nolock(uint32_t cmd, size_t num_params,
 	const size_t params_size = sizeof(struct optee_msg_param) * num_params;
 	size_t n;
 
-	TEE_ASSERT(arg && carg && num_params <= RPC_MAX_NUM_PARAMS);
+	panic_unless(arg && carg && num_params <= RPC_MAX_NUM_PARAMS);
 
 	memset(arg, 0, OPTEE_MSG_GET_ARG_SIZE(RPC_MAX_NUM_PARAMS));
 	arg->cmd = cmd;

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -167,24 +167,24 @@ void thread_check_canaries(void)
 	size_t n;
 
 	for (n = 0; n < ARRAY_SIZE(stack_tmp); n++) {
-		panic_unless(GET_START_CANARY(stack_tmp, n) == START_CANARY);
-		panic_unless(GET_END_CANARY(stack_tmp, n) == END_CANARY);
+		panic_if(GET_START_CANARY(stack_tmp, n) != START_CANARY);
+		panic_if(GET_END_CANARY(stack_tmp, n) != END_CANARY);
 	}
 
 	for (n = 0; n < ARRAY_SIZE(stack_abt); n++) {
-		panic_unless(GET_START_CANARY(stack_abt, n) == START_CANARY);
-		panic_unless(GET_END_CANARY(stack_abt, n) == END_CANARY);
+		panic_if(GET_START_CANARY(stack_abt, n) != START_CANARY);
+		panic_if(GET_END_CANARY(stack_abt, n) != END_CANARY);
 	}
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)
 	for (n = 0; n < ARRAY_SIZE(stack_sm); n++) {
-		panic_unless(GET_START_CANARY(stack_sm, n) == START_CANARY);
-		panic_unless(GET_END_CANARY(stack_sm, n) == END_CANARY);
+		panic_if(GET_START_CANARY(stack_sm, n) != START_CANARY);
+		panic_if(GET_END_CANARY(stack_sm, n) != END_CANARY);
 	}
 #endif
 #ifndef CFG_WITH_PAGER
 	for (n = 0; n < ARRAY_SIZE(stack_thread); n++) {
-		panic_unless(GET_START_CANARY(stack_thread, n) == START_CANARY);
-		panic_unless(GET_END_CANARY(stack_thread, n) == END_CANARY);
+		panic_if(GET_START_CANARY(stack_thread, n) != START_CANARY);
+		panic_if(GET_END_CANARY(stack_thread, n) != END_CANARY);
 	}
 #endif
 #endif/*CFG_WITH_STACK_CANARIES*/
@@ -259,9 +259,9 @@ struct thread_core_local *thread_get_core_local(void)
 	 * we otherwise may be rescheduled to a different core in the
 	 * middle of this function.
 	 */
-	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_if(!(thread_get_exceptions() & THREAD_EXCP_IRQ));
 
-	panic_unless(cpu_id < CFG_TEE_CORE_NB_CORE);
+	panic_if(cpu_id >= CFG_TEE_CORE_NB_CORE);
 	return &thread_core_local[cpu_id];
 }
 
@@ -289,7 +289,7 @@ static void thread_lazy_restore_ns_vfp(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	panic_unless(!thr->vfp_state.sec_lazy_saved && !thr->vfp_state.sec_saved);
+	panic_if(thr->vfp_state.sec_lazy_saved || thr->vfp_state.sec_saved);
 
 	if (tuv && tuv->lazy_saved && !tuv->saved) {
 		vfp_lazy_save_state_final(&tuv->vfp);
@@ -388,9 +388,9 @@ void thread_clr_boot_thread(void)
 {
 	struct thread_core_local *l = thread_get_core_local();
 
-	panic_unless(l->curr_thread >= 0 && l->curr_thread < CFG_NUM_THREADS);
-	panic_unless(threads[l->curr_thread].state == THREAD_STATE_ACTIVE);
-	panic_unless(TAILQ_EMPTY(&threads[l->curr_thread].mutexes));
+	panic_if(l->curr_thread < 0 || l->curr_thread >= CFG_NUM_THREADS);
+	panic_if(threads[l->curr_thread].state != THREAD_STATE_ACTIVE);
+	panic_if(!TAILQ_EMPTY(&threads[l->curr_thread].mutexes));
 	threads[l->curr_thread].state = THREAD_STATE_FREE;
 	l->curr_thread = -1;
 }
@@ -401,7 +401,7 @@ static void thread_alloc_and_run(struct thread_smc_args *args)
 	struct thread_core_local *l = thread_get_core_local();
 	bool found_thread = false;
 
-	panic_unless(l->curr_thread == -1);
+	panic_if(l->curr_thread != -1);
 
 	lock_global();
 
@@ -472,7 +472,7 @@ static void thread_resume_from_rpc(struct thread_smc_args *args)
 	struct thread_core_local *l = thread_get_core_local();
 	uint32_t rv = 0;
 
-	panic_unless(l->curr_thread == -1);
+	panic_if(l->curr_thread != -1);
 
 	lock_global();
 
@@ -513,7 +513,7 @@ void thread_handle_fast_smc(struct thread_smc_args *args)
 	thread_check_canaries();
 	thread_fast_smc_handler_ptr(args);
 	/* Fast handlers must not unmask any exceptions */
-	panic_unless(thread_get_exceptions() == THREAD_EXCP_ALL);
+	panic_if(thread_get_exceptions() != THREAD_EXCP_ALL);
 }
 
 void thread_handle_std_smc(struct thread_smc_args *args)
@@ -572,7 +572,7 @@ vaddr_t thread_get_saved_thread_sp(void)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	panic_unless(ct != -1);
+	panic_if(ct == -1);
 	return threads[ct].kern_sp;
 }
 #endif /*ARM64*/
@@ -590,8 +590,8 @@ void thread_state_free(void)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	panic_unless(ct != -1);
-	panic_unless(TAILQ_EMPTY(&threads[ct].mutexes));
+	panic_if(ct == -1);
+	panic_if(!TAILQ_EMPTY(&threads[ct].mutexes));
 
 	thread_lazy_restore_ns_vfp();
 	tee_pager_release_phys(
@@ -600,7 +600,7 @@ void thread_state_free(void)
 
 	lock_global();
 
-	panic_unless(threads[ct].state == THREAD_STATE_ACTIVE);
+	panic_if(threads[ct].state != THREAD_STATE_ACTIVE);
 	threads[ct].state = THREAD_STATE_FREE;
 	threads[ct].flags = 0;
 	l->curr_thread = -1;
@@ -647,7 +647,7 @@ int thread_state_suspend(uint32_t flags, uint32_t cpsr, vaddr_t pc)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	panic_unless(ct != -1);
+	panic_if(ct == -1);
 
 	thread_check_canaries();
 
@@ -659,7 +659,7 @@ int thread_state_suspend(uint32_t flags, uint32_t cpsr, vaddr_t pc)
 
 	lock_global();
 
-	panic_unless(threads[ct].state == THREAD_STATE_ACTIVE);
+	panic_if(threads[ct].state != THREAD_STATE_ACTIVE);
 	threads[ct].flags |= flags;
 	threads[ct].regs.cpsr = cpsr;
 	threads[ct].regs.pc = pc;
@@ -732,7 +732,7 @@ int thread_get_id(void)
 {
 	int ct = thread_get_id_may_fail();
 
-	panic_unless((ct >= 0) && (ct < CFG_NUM_THREADS));
+	panic_if(ct < 0 || ct >= CFG_NUM_THREADS);
 	return ct;
 }
 
@@ -764,7 +764,7 @@ static void init_thread_stacks(void)
 		/* Find vmem for thread stack and its protection gap */
 		mm = tee_mm_alloc(&tee_mm_vcore,
 				  SMALL_PAGE_SIZE + STACK_THREAD_SIZE);
-		panic_unless(mm);
+		panic_if(!mm);
 
 		/* Claim eventual physical page */
 		tee_pager_add_pages(tee_mm_get_smem(mm), tee_mm_get_size(mm),
@@ -778,8 +778,7 @@ static void init_thread_stacks(void)
 
 		/* init effective stack */
 		sp = tee_mm_get_smem(mm) + tee_mm_get_bytes(mm);
-		if (!thread_init_stack(n, sp))
-			panic();
+		panic_if(!thread_init_stack(n, sp));
 	}
 }
 #else
@@ -788,10 +787,8 @@ static void init_thread_stacks(void)
 	size_t n;
 
 	/* Assign the thread stacks */
-	for (n = 0; n < CFG_NUM_THREADS; n++) {
-		if (!thread_init_stack(n, GET_STACK(stack_thread[n])))
-			panic();
-	}
+	for (n = 0; n < CFG_NUM_THREADS; n++)
+		panic_if(!thread_init_stack(n, GET_STACK(stack_thread[n])));
 }
 #endif /*CFG_WITH_PAGER*/
 
@@ -837,7 +834,7 @@ struct thread_ctx_regs *thread_get_ctx_regs(void)
 {
 	struct thread_core_local *l = thread_get_core_local();
 
-	panic_unless(l->curr_thread != -1);
+	panic_if(l->curr_thread == -1);
 	return &threads[l->curr_thread].regs;
 }
 
@@ -849,7 +846,7 @@ void thread_set_irq(bool enable)
 
 	l = thread_get_core_local();
 
-	panic_unless(l->curr_thread != -1);
+	panic_if(l->curr_thread == -1);
 
 	if (enable) {
 		threads[l->curr_thread].flags |= THREAD_FLAGS_IRQ_ENABLE;
@@ -871,7 +868,7 @@ void thread_restore_irq(void)
 
 	l = thread_get_core_local();
 
-	panic_unless(l->curr_thread != -1);
+	panic_if(l->curr_thread == -1);
 
 	if (threads[l->curr_thread].flags & THREAD_FLAGS_IRQ_ENABLE)
 		thread_set_exceptions(exceptions & ~THREAD_EXCP_IRQ);
@@ -884,7 +881,7 @@ uint32_t thread_kernel_enable_vfp(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	panic_unless(!vfp_is_enabled());
+	panic_if(vfp_is_enabled());
 
 	if (!thr->vfp_state.ns_saved) {
 		vfp_lazy_save_state_final(&thr->vfp_state.ns);
@@ -914,11 +911,11 @@ void thread_kernel_disable_vfp(uint32_t state)
 {
 	uint32_t exceptions;
 
-	panic_unless(vfp_is_enabled());
+	panic_if(!vfp_is_enabled());
 
 	vfp_disable();
 	exceptions = thread_get_exceptions();
-	panic_unless(exceptions & THREAD_EXCP_IRQ);
+	panic_if(!(exceptions & THREAD_EXCP_IRQ));
 	exceptions &= ~THREAD_EXCP_IRQ;
 	exceptions |= state & THREAD_EXCP_IRQ;
 	thread_set_exceptions(exceptions);
@@ -928,7 +925,7 @@ void thread_kernel_save_vfp(void)
 {
 	struct thread_ctx *thr = threads + thread_get_id();
 
-	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_if(!(thread_get_exceptions() & THREAD_EXCP_IRQ));
 	if (vfp_is_enabled()) {
 		vfp_lazy_save_state_init(&thr->vfp_state.sec);
 		thr->vfp_state.sec_lazy_saved = true;
@@ -939,8 +936,8 @@ void thread_kernel_restore_vfp(void)
 {
 	struct thread_ctx *thr = threads + thread_get_id();
 
-	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
-	panic_unless(!vfp_is_enabled());
+	panic_if(!(thread_get_exceptions() & THREAD_EXCP_IRQ));
+	panic_if(vfp_is_enabled());
 	if (thr->vfp_state.sec_lazy_saved) {
 		vfp_lazy_restore_state(&thr->vfp_state.sec,
 				       thr->vfp_state.sec_saved);
@@ -954,8 +951,8 @@ void thread_user_enable_vfp(struct thread_user_vfp_state *uvfp)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
-	panic_unless(!vfp_is_enabled());
+	panic_if(!(thread_get_exceptions() & THREAD_EXCP_IRQ));
+	panic_if(vfp_is_enabled());
 
 	if (!thr->vfp_state.ns_saved) {
 		vfp_lazy_save_state_final(&thr->vfp_state.ns);
@@ -981,11 +978,11 @@ void thread_user_save_vfp(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct thread_user_vfp_state *tuv = thr->vfp_state.uvfp;
 
-	panic_unless(thread_get_exceptions() & THREAD_EXCP_IRQ);
+	panic_if(!(thread_get_exceptions() & THREAD_EXCP_IRQ));
 	if (!vfp_is_enabled())
 		return;
 
-	panic_unless(tuv && !tuv->lazy_saved && !tuv->saved);
+	panic_if(!tuv || tuv->lazy_saved || tuv->saved);
 	vfp_lazy_save_state_init(&tuv->vfp);
 	tuv->lazy_saved = true;
 }
@@ -1058,8 +1055,8 @@ void thread_add_mutex(struct mutex *m)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	panic_unless(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
-	panic_unless(m->owner_id == -1);
+	panic_if(ct == -1 || threads[ct].state != THREAD_STATE_ACTIVE);
+	panic_if(m->owner_id != -1);
 	m->owner_id = ct;
 	TAILQ_INSERT_TAIL(&threads[ct].mutexes, m, link);
 }
@@ -1069,8 +1066,8 @@ void thread_rem_mutex(struct mutex *m)
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
 
-	panic_unless(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
-	panic_unless(m->owner_id == ct);
+	panic_if(ct == -1 || threads[ct].state != THREAD_STATE_ACTIVE);
+	panic_if(m->owner_id != ct);
 	m->owner_id = -1;
 	TAILQ_REMOVE(&threads[ct].mutexes, m, link);
 }
@@ -1141,7 +1138,7 @@ static uint32_t rpc_cmd_nolock(uint32_t cmd, size_t num_params,
 	const size_t params_size = sizeof(struct optee_msg_param) * num_params;
 	size_t n;
 
-	panic_unless(arg && carg && num_params <= RPC_MAX_NUM_PARAMS);
+	panic_if(!arg || !carg || num_params > RPC_MAX_NUM_PARAMS);
 
 	memset(arg, 0, OPTEE_MSG_GET_ARG_SIZE(RPC_MAX_NUM_PARAMS));
 	arg->cmd = cmd;

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -487,7 +487,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	tee_uaddr_t usr_stack;
 	struct user_ta_ctx *utc = to_user_ta_ctx(session->ctx);
 	TEE_ErrorOrigin serr = TEE_ORIGIN_TEE;
-	struct tee_ta_session *s;
+	struct tee_ta_session *s __maybe_unused;
 
 	panic_if(!(utc->ctx.flags & TA_FLAG_EXEC_DDR));
 
@@ -529,7 +529,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	update_from_utee_param(param, usr_params);
 
 	s = tee_ta_pop_current_session();
-	panic_if(s != session);
+	assert(s == session);
 cleanup_return:
 
 	/*

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -30,6 +30,7 @@
 #include <keep.h>
 #include <types_ext.h>
 #include <stdlib.h>
+#include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <kernel/user_ta.h>
@@ -486,9 +487,9 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	tee_uaddr_t usr_stack;
 	struct user_ta_ctx *utc = to_user_ta_ctx(session->ctx);
 	TEE_ErrorOrigin serr = TEE_ORIGIN_TEE;
-	struct tee_ta_session *s __maybe_unused;
+	struct tee_ta_session *s;
 
-	TEE_ASSERT((utc->ctx.flags & TA_FLAG_EXEC_DDR) != 0);
+	panic_unless(utc->ctx.flags & TA_FLAG_EXEC_DDR);
 
 	/* Map user space memory */
 	res = tee_mmu_map_param(utc, param);
@@ -528,7 +529,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	update_from_utee_param(param, usr_params);
 
 	s = tee_ta_pop_current_session();
-	assert(s == session);
+	panic_unless(s == session);
 cleanup_return:
 
 	/*

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -489,7 +489,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	TEE_ErrorOrigin serr = TEE_ORIGIN_TEE;
 	struct tee_ta_session *s;
 
-	panic_unless(utc->ctx.flags & TA_FLAG_EXEC_DDR);
+	panic_if(!(utc->ctx.flags & TA_FLAG_EXEC_DDR));
 
 	/* Map user space memory */
 	res = tee_mmu_map_param(utc, param);
@@ -529,7 +529,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	update_from_utee_param(param, usr_params);
 
 	s = tee_ta_pop_current_session();
-	panic_unless(s == session);
+	panic_if(s != session);
 cleanup_return:
 
 	/*

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -59,7 +59,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 	if (state->fpexc & FPEXC_EN) {
 		uint32_t fpexc = vfp_read_fpexc();
 
-		panic_unless(!(fpexc & FPEXC_EN));
+		panic_if(fpexc & FPEXC_EN);
 		vfp_write_fpexc(fpexc | FPEXC_EN);
 		state->fpscr = vfp_read_fpscr();
 		vfp_save_extension_regs(state->reg);
@@ -120,7 +120,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 {
 	if ((CPACR_EL1_FPEN(state->cpacr_el1) & CPACR_EL1_FPEN_EL0EL1) ||
 	    state->force_save) {
-		panic_unless(!vfp_is_enabled());
+		panic_if(vfp_is_enabled());
 		vfp_enable();
 		state->fpcr = read_fpcr();
 		state->fpsr = read_fpsr();

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -26,9 +26,9 @@
  */
 
 #include <arm.h>
+#include <kernel/panic.h>
 #include <kernel/vfp.h>
 #include "vfp_private.h"
-#include <assert.h>
 
 #ifdef ARM32
 bool vfp_is_enabled(void)
@@ -59,7 +59,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 	if (state->fpexc & FPEXC_EN) {
 		uint32_t fpexc = vfp_read_fpexc();
 
-		assert(!(fpexc & FPEXC_EN));
+		panic_unless(!(fpexc & FPEXC_EN));
 		vfp_write_fpexc(fpexc | FPEXC_EN);
 		state->fpscr = vfp_read_fpscr();
 		vfp_save_extension_regs(state->reg);
@@ -120,7 +120,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 {
 	if ((CPACR_EL1_FPEN(state->cpacr_el1) & CPACR_EL1_FPEN_EL0EL1) ||
 	    state->force_save) {
-		assert(!vfp_is_enabled());
+		panic_unless(!vfp_is_enabled());
 		vfp_enable();
 		state->fpcr = read_fpcr();
 		state->fpsr = read_fpsr();

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -26,7 +26,7 @@
  */
 
 #include <arm.h>
-#include <kernel/panic.h>
+#include <assert.h>
 #include <kernel/vfp.h>
 #include "vfp_private.h"
 
@@ -59,7 +59,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 	if (state->fpexc & FPEXC_EN) {
 		uint32_t fpexc = vfp_read_fpexc();
 
-		panic_if(fpexc & FPEXC_EN);
+		assert(!(fpexc & FPEXC_EN));
 		vfp_write_fpexc(fpexc | FPEXC_EN);
 		state->fpscr = vfp_read_fpscr();
 		vfp_save_extension_regs(state->reg);
@@ -120,7 +120,7 @@ void vfp_lazy_save_state_final(struct vfp_state *state)
 {
 	if ((CPACR_EL1_FPEN(state->cpacr_el1) & CPACR_EL1_FPEN_EL0EL1) ||
 	    state->force_save) {
-		panic_if(vfp_is_enabled());
+		assert(!vfp_is_enabled());
 		vfp_enable();
 		state->fpcr = read_fpcr();
 		state->fpsr = read_fpsr();

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -925,7 +925,7 @@ out:
 	return ret;
 }
 
-#if defined(CFG_TEE_CORE_DEBUG) && CFG_TEE_CORE_DEBUG != 0
+#if defined(CFG_TEE_CORE_DEBUG)
 static void check_pa_matches_va(void *va, paddr_t pa)
 {
 	TEE_Result res;
@@ -997,7 +997,7 @@ paddr_t virt_to_phys(void *va)
 	return pa;
 }
 
-#if defined(CFG_TEE_CORE_DEBUG) && CFG_TEE_CORE_DEBUG != 0
+#if defined(CFG_TEE_CORE_DEBUG)
 static void check_va_matches_pa(paddr_t pa, void *va)
 {
 	panic_if(va && virt_to_phys(va) != pa);

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -344,7 +344,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 	uint64_t level_index_mask = SHIFT_U64(XLAT_TABLE_ENTRIES_MASK,
 					      level_size_shift);
 
-	panic_if(level > 3);
+	assert(level <= 3);
 
 	debug_print("New xlat table (level %u):", level);
 
@@ -411,7 +411,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 static unsigned int calc_physical_addr_size_bits(uint64_t max_addr)
 {
 	/* Physical address can't exceed 48 bits */
-	panic_if(max_addr & ADDR_MASK_48_TO_63);
+	assert(!(max_addr & ADDR_MASK_48_TO_63));
 
 	/* 48 bits address */
 	if (max_addr & ADDR_MASK_44_TO_47)
@@ -449,8 +449,8 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 		debug_print(" %010" PRIxVA " %010" PRIxPA " %10zx %x",
 			    mm[n].va, mm[n].pa, mm[n].size, mm[n].attr);
 
-		panic_if(!IS_PAGE_ALIGNED(mm[n].pa));
-		panic_if(!IS_PAGE_ALIGNED(mm[n].size));
+		panic_if(!IS_PAGE_ALIGNED(mm[n].pa) ||
+			 !IS_PAGE_ALIGNED(mm[n].size));
 
 		pa_end = mm[n].pa + mm[n].size - 1;
 		va_end = mm[n].va + mm[n].size - 1;
@@ -473,11 +473,11 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 			break;
 		}
 	}
-	panic_if(user_va_idx == -1);
+	assert(user_va_idx != -1);
 
 	tcr_ps_bits = calc_physical_addr_size_bits(max_pa);
 	COMPILE_TIME_ASSERT(ADDR_SPACE_SIZE > 0);
-	panic_if(max_va >= ADDR_SPACE_SIZE);
+	assert(max_va < ADDR_SPACE_SIZE);
 }
 
 bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
@@ -552,7 +552,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 	tbl_info->va_base = va_base;
 	tbl_info->shift = L1_XLAT_ADDRESS_SHIFT -
 			  (level - 1) * XLAT_TABLE_ENTRIES_SHIFT;
-	panic_if(level > 3);
+	assert(level <= 3);
 	if (level == 1)
 		tbl_info->num_entries = NUM_L1_ENTRIES;
 	else
@@ -642,7 +642,7 @@ void core_mmu_get_entry_primitive(const void *table, size_t level __unused,
 
 void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 {
-	panic_if(user_va_idx == -1);
+	assert(user_va_idx != -1);
 
 	if (base)
 		*base = (vaddr_t)user_va_idx << L1_XLAT_ADDRESS_SHIFT;
@@ -652,14 +652,14 @@ void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 
 bool core_mmu_user_mapping_is_active(void)
 {
-	panic_if(user_va_idx == -1);
+	assert(user_va_idx != -1);
 	return !!l1_xlation_table[get_core_pos()][user_va_idx];
 }
 
 #ifdef ARM32
 void core_mmu_get_user_map(struct core_mmu_user_map *map)
 {
-	panic_if(user_va_idx == -1);
+	assert(user_va_idx != -1);
 
 	map->user_map = l1_xlation_table[get_core_pos()][user_va_idx];
 	if (map->user_map) {
@@ -675,7 +675,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 	uint64_t ttbr;
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
-	panic_if(user_va_idx == -1);
+	assert(user_va_idx != -1);
 
 	ttbr = read_ttbr0_64bit();
 	/* Clear ASID */
@@ -702,7 +702,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 {
-	panic_if(!(fault_descr & FSR_LPAE));
+	panic_if((fault_descr & FSR_LPAE) == 0);
 
 	switch (fault_descr & FSR_STATUS_MASK) {
 	case 0x21: /* b100001 Alignment fault */
@@ -733,7 +733,7 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 #ifdef ARM64
 void core_mmu_get_user_map(struct core_mmu_user_map *map)
 {
-	panic_if(user_va_idx == -1);
+	assert(user_va_idx != -1);
 
 	map->user_map = l1_xlation_table[get_core_pos()][user_va_idx];
 	if (map->user_map) {

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -56,11 +56,11 @@
  */
 #include <platform_config.h>
 
+#include <assert.h>
 #include <types_ext.h>
 #include <inttypes.h>
 #include <string.h>
 #include <compiler.h>
-#include <assert.h>
 #include <trace.h>
 #include <mm/tee_mmu_defs.h>
 #include <mm/pgt_cache.h>
@@ -344,7 +344,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 	uint64_t level_index_mask = SHIFT_U64(XLAT_TABLE_ENTRIES_MASK,
 					      level_size_shift);
 
-	assert(level <= 3);
+	panic_unless(level <= 3);
 
 	debug_print("New xlat table (level %u):", level);
 
@@ -393,7 +393,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 			/* Clear table before use */
 			memset(new_table, 0, XLAT_TABLE_SIZE);
 
-			assert(next_xlat <= MAX_XLAT_TABLES);
+			panic_unless(next_xlat <= MAX_XLAT_TABLES);
 			desc = TABLE_DESC | (uint64_t)(uintptr_t)new_table;
 
 			/* Recurse to fill in new table */
@@ -411,7 +411,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 static unsigned int calc_physical_addr_size_bits(uint64_t max_addr)
 {
 	/* Physical address can't exceed 48 bits */
-	assert((max_addr & ADDR_MASK_48_TO_63) == 0);
+	panic_unless((max_addr & ADDR_MASK_48_TO_63) == 0);
 
 	/* 48 bits address */
 	if (max_addr & ADDR_MASK_44_TO_47)
@@ -449,8 +449,8 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 		debug_print(" %010" PRIxVA " %010" PRIxPA " %10zx %x",
 			    mm[n].va, mm[n].pa, mm[n].size, mm[n].attr);
 
-		assert(IS_PAGE_ALIGNED(mm[n].pa));
-		assert(IS_PAGE_ALIGNED(mm[n].size));
+		panic_unless(IS_PAGE_ALIGNED(mm[n].pa));
+		panic_unless(IS_PAGE_ALIGNED(mm[n].size));
 
 		pa_end = mm[n].pa + mm[n].size - 1;
 		va_end = mm[n].va + mm[n].size - 1;
@@ -473,11 +473,11 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 			break;
 		}
 	}
-	assert(user_va_idx != -1);
+	panic_unless(user_va_idx != -1);
 
 	tcr_ps_bits = calc_physical_addr_size_bits(max_pa);
 	COMPILE_TIME_ASSERT(ADDR_SPACE_SIZE > 0);
-	assert(max_va < ADDR_SPACE_SIZE);
+	panic_unless(max_va < ADDR_SPACE_SIZE);
 }
 
 bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
@@ -552,7 +552,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 	tbl_info->va_base = va_base;
 	tbl_info->shift = L1_XLAT_ADDRESS_SHIFT -
 			  (level - 1) * XLAT_TABLE_ENTRIES_SHIFT;
-	assert(level <= 3);
+	panic_unless(level <= 3);
 	if (level == 1)
 		tbl_info->num_entries = NUM_L1_ENTRIES;
 	else
@@ -642,7 +642,7 @@ void core_mmu_get_entry_primitive(const void *table, size_t level __unused,
 
 void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 {
-	assert(user_va_idx != -1);
+	panic_unless(user_va_idx != -1);
 
 	if (base)
 		*base = (vaddr_t)user_va_idx << L1_XLAT_ADDRESS_SHIFT;
@@ -652,14 +652,14 @@ void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 
 bool core_mmu_user_mapping_is_active(void)
 {
-	assert(user_va_idx != -1);
+	panic_unless(user_va_idx != -1);
 	return !!l1_xlation_table[get_core_pos()][user_va_idx];
 }
 
 #ifdef ARM32
 void core_mmu_get_user_map(struct core_mmu_user_map *map)
 {
-	assert(user_va_idx != -1);
+	panic_unless(user_va_idx != -1);
 
 	map->user_map = l1_xlation_table[get_core_pos()][user_va_idx];
 	if (map->user_map) {
@@ -675,7 +675,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 	uint64_t ttbr;
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
-	assert(user_va_idx != -1);
+	panic_unless(user_va_idx != -1);
 
 	ttbr = read_ttbr0_64bit();
 	/* Clear ASID */
@@ -702,7 +702,8 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 {
-	assert(fault_descr & FSR_LPAE);
+	panic_unless(fault_descr & FSR_LPAE);
+
 	switch (fault_descr & FSR_STATUS_MASK) {
 	case 0x21: /* b100001 Alignment fault */
 		return CORE_MMU_FAULT_ALIGNMENT;
@@ -732,7 +733,7 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 #ifdef ARM64
 void core_mmu_get_user_map(struct core_mmu_user_map *map)
 {
-	assert(user_va_idx != -1);
+	panic_unless(user_va_idx != -1);
 
 	map->user_map = l1_xlation_table[get_core_pos()][user_va_idx];
 	if (map->user_map) {

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -202,7 +202,7 @@ static void *core_mmu_alloc_l2(struct tee_mmap_region *mm)
 
 static enum desc_type get_desc_type(unsigned level, uint32_t desc)
 {
-	panic_if(level != 1 && level != 2);
+	assert(level == 1 || level == 2);
 
 	if (level == 1) {
 		if ((desc & 0x3) == 0x1)
@@ -385,18 +385,13 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 	tbl_info->level = level;
 	tbl_info->table = table;
 	tbl_info->va_base = va_base;
-
-	switch(level) {
-	case 1:
+	assert(level <= 2);
+	if (level == 1) {
 		tbl_info->shift = SECTION_SHIFT;
 		tbl_info->num_entries = TEE_MMU_L1_NUM_ENTRIES;
-		return;
-	case 2:
+	} else {
 		tbl_info->shift = SMALL_PAGE_SHIFT;
 		tbl_info->num_entries = TEE_MMU_L2_NUM_ENTRIES;
-		return;
-	default:
-		panic_msg("invalid level");
 	}
 }
 

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -27,15 +27,15 @@
  */
 #include <platform_config.h>
 
-#include <stdlib.h>
-#include <assert.h>
 #include <arm.h>
+#include <assert.h>
+#include <kernel/panic.h>
+#include <kernel/thread.h>
 #include <mm/core_mmu.h>
 #include <mm/tee_mmu_defs.h>
 #include <mm/pgt_cache.h>
+#include <stdlib.h>
 #include <trace.h>
-#include <kernel/panic.h>
-#include <kernel/thread.h>
 #include <util.h>
 #include "core_mmu_private.h"
 
@@ -166,7 +166,7 @@ static paddr_t core_mmu_get_main_ttb_pa(void)
 	/* Note that this depends on flat mapping of TEE Core */
 	paddr_t pa = (paddr_t)core_mmu_get_main_ttb_va();
 
-	TEE_ASSERT(!(pa & ~TEE_MMU_TTB_L1_MASK));
+	panic_unless(!(pa & ~TEE_MMU_TTB_L1_MASK));
 	return pa;
 }
 
@@ -180,7 +180,7 @@ static paddr_t core_mmu_get_ul1_ttb_pa(void)
 	/* Note that this depends on flat mapping of TEE Core */
 	paddr_t pa = (paddr_t)core_mmu_get_ul1_ttb_va();
 
-	TEE_ASSERT(!(pa & ~TEE_MMU_TTB_UL1_MASK));
+	panic_unless(!(pa & ~TEE_MMU_TTB_UL1_MASK));
 	return pa;
 }
 
@@ -202,7 +202,7 @@ static void *core_mmu_alloc_l2(struct tee_mmap_region *mm)
 
 static enum desc_type get_desc_type(unsigned level, uint32_t desc)
 {
-	assert(level >= 1 && level <= 2);
+	panic_unless(level >= 1 && level <= 2);
 
 	if (level == 1) {
 		if ((desc & 0x3) == 0x1)
@@ -385,7 +385,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 	tbl_info->level = level;
 	tbl_info->table = table;
 	tbl_info->va_base = va_base;
-	assert(level <= 2);
+	panic_unless(level <= 2);
 	if (level == 1) {
 		tbl_info->shift = SECTION_SHIFT;
 		tbl_info->num_entries = TEE_MMU_L1_NUM_ENTRIES;
@@ -534,7 +534,7 @@ static paddr_t map_page_memarea(struct tee_mmap_region *mm)
 	size_t pg_idx;
 	uint32_t attr;
 
-	TEE_ASSERT(l2);
+	panic_unless(l2);
 
 	attr = mattr_to_desc(2, mm->attr);
 
@@ -573,7 +573,7 @@ static void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
 	paddr_t pa;
 	uint32_t region_size;
 
-	TEE_ASSERT(mm && ttb);
+	assert(mm && ttb);
 
 	/*
 	 * If mm->va is smaller than 32M, then mm->va will conflict with
@@ -683,7 +683,8 @@ void core_init_mmu_regs(void)
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fsr)
 {
-	assert(!(fsr & FSR_LPAE));
+	panic_unless(!(fsr & FSR_LPAE));
+
 	switch (fsr & FSR_FS_MASK) {
 	case 0x1: /* DFSR[10,3:0] 0b00001 Alignment fault (DFSR only) */
 		return CORE_MMU_FAULT_ALIGNMENT;

--- a/core/arch/arm/mm/pager_aes_gcm.c
+++ b/core/arch/arm/mm/pager_aes_gcm.c
@@ -42,6 +42,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <compiler.h>
 #include "pager_private.h"
 #include <tomcrypt.h>

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <mm/pgt_cache.h>
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
@@ -33,7 +34,6 @@
 #include <stdlib.h>
 #include <util.h>
 #include <trace.h>
-#include <assert.h>
 
 /*
  * With pager enabled we allocate page table from the pager.
@@ -166,7 +166,7 @@ static struct pgt *pop_from_free_list(void)
 static void push_to_free_list(struct pgt *p)
 {
 	SLIST_INSERT_HEAD(&p->parent->pgt_cache, p, link);
-	assert(p->parent->num_used > 0);
+	panic_unless(p->parent->num_used > 0);
 	p->parent->num_used--;
 	if (!p->parent->num_used) {
 		vaddr_t va = (vaddr_t)p->tbl & ~SMALL_PAGE_MASK;

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -166,7 +166,7 @@ static struct pgt *pop_from_free_list(void)
 static void push_to_free_list(struct pgt *p)
 {
 	SLIST_INSERT_HEAD(&p->parent->pgt_cache, p, link);
-	panic_unless(p->parent->num_used > 0);
+	panic_if(p->parent->num_used <= 0);
 	p->parent->num_used--;
 	if (!p->parent->num_used) {
 		vaddr_t va = (vaddr_t)p->tbl & ~SMALL_PAGE_MASK;

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -28,7 +28,6 @@
 #include <assert.h>
 #include <mm/pgt_cache.h>
 #include <kernel/mutex.h>
-#include <kernel/panic.h>
 #include <mm/tee_pager.h>
 #include <mm/core_mmu.h>
 #include <stdlib.h>
@@ -166,7 +165,7 @@ static struct pgt *pop_from_free_list(void)
 static void push_to_free_list(struct pgt *p)
 {
 	SLIST_INSERT_HEAD(&p->parent->pgt_cache, p, link);
-	panic_if(p->parent->num_used <= 0);
+	assert(p->parent->num_used > 0);
 	p->parent->num_used--;
 	if (!p->parent->num_used) {
 		vaddr_t va = (vaddr_t)p->tbl & ~SMALL_PAGE_MASK;

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -176,7 +176,7 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, uint32_t size)
 				/* out of memory */
 				return NULL;
 		} else {
-			panic_unless(pool->hi > pool->lo);
+			panic_if(pool->hi <= pool->lo);
 			remaining = (pool->hi - pool->lo);
 			remaining -= ((entry->offset + entry->size) <<
 				      pool->shift);

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <kernel/panic.h>
 #include <kernel/tee_common.h>
 #include <util.h>
 #include <trace.h>
@@ -175,7 +176,7 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, uint32_t size)
 				/* out of memory */
 				return NULL;
 		} else {
-			TEE_ASSERT(pool->hi > pool->lo);
+			panic_unless(pool->hi > pool->lo);
 			remaining = (pool->hi - pool->lo);
 			remaining -= ((entry->offset + entry->size) <<
 				      pool->shift);
@@ -289,7 +290,7 @@ void tee_mm_free(tee_mm_entry_t *p)
 
 	if (entry->next == NULL) {
 		DMSG("invalid mm_entry %p", (void *)p);
-		TEE_ASSERT(0);
+		panic();
 	}
 	entry->next = entry->next->next;
 

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -171,10 +171,10 @@ static TEE_Result tee_mmu_umap_set_vas(struct tee_mmu_info *mmu)
 	while (n && !mmu->table[n].size)
 		n--;
 	va = mmu->table[n].va + mmu->table[n].size;
-	panic_if(!va);
+	assert(va);
 
 	core_mmu_get_user_va_range(&va_range_base, &va_range_size);
-	panic_if(va_range_base != mmu->ta_private_vmem_start);
+	assert(va_range_base == mmu->ta_private_vmem_start);
 
 	/*
 	 * Assign parameters in secure memory.
@@ -293,10 +293,10 @@ TEE_Result tee_mmu_map_add_segment(struct user_ta_ctx *utc, paddr_t base_pa,
 
 	if (!tbl[n].size) {
 		/* We're continuing the va space from previous entry. */
-		panic_if(!tbl[n - 1].size);
+		assert(tbl[n - 1].size);
 
 		/* This is the first segment */
-		panic_if(offs >= granule);
+		assert(offs < granule);
 		va = tbl[n - 1].va + tbl[n - 1].size;
 		end_va = ROUNDUP(offs + size, granule) + va;
 		pa = base_pa;
@@ -661,9 +661,7 @@ void teecore_init_pub_ram(void)
 	/* get virtual addr/size of NSec shared mem allcated from teecore */
 	core_mmu_get_mem_by_type(MEM_AREA_NSEC_SHM, &s, &e);
 
-	panic_if(s >= e);
-	panic_if(s & SMALL_PAGE_MASK);
-	panic_if(e & SMALL_PAGE_MASK);
+	panic_if(s >= e || s & SMALL_PAGE_MASK || e & SMALL_PAGE_MASK);
 	/* extra check: we could rely on  core_mmu_get_mem_by_type() */
 	panic_if(!tee_vbuf_is_non_sec(s, e - s));
 

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -186,7 +186,7 @@ static void set_alias_area(tee_mm_entry_t *mm)
 
 	DMSG("0x%" PRIxVA " - 0x%" PRIxVA, smem, smem + nbytes);
 
-	TEE_ASSERT(!pager_alias_area);
+	panic_unless(!pager_alias_area);
 	if (!ti->num_entries && !core_mmu_find_table(smem, UINT_MAX, ti)) {
 		DMSG("Can't find translation table");
 		panic();
@@ -205,8 +205,8 @@ static void set_alias_area(tee_mm_entry_t *mm)
 		panic();
 	}
 
-	TEE_ASSERT(!(smem & SMALL_PAGE_MASK));
-	TEE_ASSERT(!(nbytes & SMALL_PAGE_MASK));
+	panic_unless(!(smem & SMALL_PAGE_MASK));
+	panic_unless(!(nbytes & SMALL_PAGE_MASK));
 
 	pager_alias_area = mm;
 	pager_alias_next_free = smem;
@@ -223,10 +223,8 @@ static void set_alias_area(tee_mm_entry_t *mm)
 
 static void generate_ae_key(void)
 {
-	TEE_Result res;
-
-	res = rng_generate(pager_ae_key, sizeof(pager_ae_key));
-	TEE_ASSERT(res == TEE_SUCCESS);
+	panic_unless(rng_generate(pager_ae_key,
+				  sizeof(pager_ae_key)) == TEE_SUCCESS);
 }
 
 void tee_pager_init(tee_mm_entry_t *mm_alias)
@@ -245,7 +243,7 @@ static void *pager_add_alias_page(paddr_t pa)
 
 	DMSG("0x%" PRIxPA, pa);
 
-	TEE_ASSERT(pager_alias_next_free && ti->num_entries);
+	panic_unless(pager_alias_next_free && ti->num_entries);
 	idx = core_mmu_va2idx(ti, pager_alias_next_free);
 	core_mmu_set_entry(ti, idx, pa, attr);
 	pager_alias_next_free += SMALL_PAGE_SIZE;
@@ -317,13 +315,13 @@ bool tee_pager_add_core_area(vaddr_t base, size_t size, uint32_t flags,
 	DMSG("0x%" PRIxPTR " - 0x%" PRIxPTR " : flags 0x%x, store %p, hashes %p",
 		base, base + size, flags, store, hashes);
 
-	TEE_ASSERT(!(base & SMALL_PAGE_MASK) &&
+	panic_unless(!(base & SMALL_PAGE_MASK) &&
 			size && !(size & SMALL_PAGE_MASK));
 
 	if (!(flags & TEE_MATTR_PW))
-		TEE_ASSERT(store && hashes);
+		panic_unless(store && hashes);
 	else if (flags & TEE_MATTR_PW)
-		TEE_ASSERT(!store && !hashes);
+		panic_unless(!store && !hashes);
 	else
 		panic();
 
@@ -387,7 +385,7 @@ static void encrypt_page(struct pager_rw_pstate *rwp, void *src, void *dst)
 {
 	struct pager_aes_gcm_iv iv;
 
-	assert((rwp->iv + 1) > rwp->iv);
+	panic_unless((rwp->iv + 1) > rwp->iv);
 	rwp->iv++;
 	/*
 	 * IV is constructed as recommended in section "8.2.1 Deterministic
@@ -444,14 +442,14 @@ static void tee_pager_save_page(struct tee_pager_pmem *pmem, uint32_t attr)
 	const uint32_t dirty_bits = TEE_MATTR_PW | TEE_MATTR_UW |
 				    TEE_MATTR_HIDDEN_DIRTY_BLOCK;
 
-	assert(!(pmem->area->flags & TEE_MATTR_LOCKED));
+	panic_unless(!(pmem->area->flags & TEE_MATTR_LOCKED));
 
 	if (attr & dirty_bits) {
 		size_t idx = pmem->pgidx - core_mmu_va2idx(ti,
 							   pmem->area->base);
 		void *stored_page = pmem->area->store + idx * SMALL_PAGE_SIZE;
 
-		assert(pmem->area->flags & TEE_MATTR_PW);
+		panic_unless(pmem->area->flags & TEE_MATTR_PW);
 		encrypt_page(&pmem->area->u.rwp[idx], pmem->va_alias,
 			     stored_page);
 		FMSG("Saved %#" PRIxVA " iv %#" PRIx64,
@@ -483,7 +481,7 @@ static bool tee_pager_unhide_page(vaddr_t page_va)
 			uint32_t a = get_area_mattr(pmem->area);
 
 			/* page is hidden, show and move to back */
-			assert(pa == get_pmem_pa(pmem));
+			panic_unless(pa == get_pmem_pa(pmem));
 			/*
 			 * If it's not a dirty block, then it should be
 			 * read only.
@@ -534,7 +532,7 @@ static void tee_pager_hide_pages(void)
 		if (!(attr & TEE_MATTR_VALID_BLOCK))
 			continue;
 
-		assert(pa == get_pmem_pa(pmem));
+		panic_unless(pa == get_pmem_pa(pmem));
 		if (attr & (TEE_MATTR_PW | TEE_MATTR_UW)){
 			a = TEE_MATTR_HIDDEN_DIRTY_BLOCK;
 			FMSG("Hide %#" PRIxVA,
@@ -570,7 +568,7 @@ static bool tee_pager_release_one_phys(vaddr_t page_va)
 		if (pmem->pgidx != pgidx)
 			continue;
 
-		assert(pa == get_pmem_pa(pmem));
+		panic_unless(pa == get_pmem_pa(pmem));
 		core_mmu_set_entry(ti, pgidx, 0, 0);
 		TAILQ_REMOVE(&tee_pager_lock_pmem_head, pmem, link);
 		pmem->area = NULL;
@@ -611,7 +609,7 @@ static struct tee_pager_pmem *tee_pager_get_page(uint32_t next_area_flags)
 	pmem->area = NULL;
 	if (next_area_flags & TEE_MATTR_LOCKED) {
 		/* Move page to lock list */
-		TEE_ASSERT(tee_pager_npages > 0);
+		panic_unless(tee_pager_npages > 0);
 		tee_pager_npages--;
 		set_npages();
 		TAILQ_INSERT_TAIL(&tee_pager_lock_pmem_head, pmem, link);
@@ -848,7 +846,7 @@ void tee_pager_add_pages(vaddr_t vaddr, size_t npages, bool unmap)
 			 */
 			pmem->area = tee_pager_find_area(va);
 			pmem->pgidx = pgidx;
-			assert(pa == get_pmem_pa(pmem));
+			panic_unless(pa == get_pmem_pa(pmem));
 			core_mmu_set_entry(ti, pgidx, pa,
 					   get_area_mattr(pmem->area));
 		}

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -677,7 +677,7 @@ static bool pager_update_permissions(struct tee_pager_area *area,
 
 }
 
-#ifdef CFG_TEE_CORE_DEBUG
+#if defined(CFG_TEE_CORE_DEBUG)
 static void stat_handle_fault(void)
 {
 	static size_t num_faults;

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -64,7 +64,7 @@ void main_init_gic(void)
 					  MEM_AREA_IO_SEC);
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
-	panic_unless(gicc_base && gicd_base);
+	panic_if(!gicc_base || !gicd_base);
 
 	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
 

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -64,7 +64,7 @@ void main_init_gic(void)
 					  MEM_AREA_IO_SEC);
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
-	TEE_ASSERT(gicc_base && gicd_base);
+	panic_unless(gicc_base && gicd_base);
 
 	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
 

--- a/core/arch/arm/plat-sunxi/platform.c
+++ b/core/arch/arm/plat-sunxi/platform.c
@@ -46,7 +46,6 @@
 
 #include <trace.h>
 #include <io.h>
-#include <assert.h>
 #include <util.h>
 #include <platform.h>
 #include <console.h>
@@ -61,7 +60,7 @@ static int platform_smp_init(void)
 {
 	vaddr_t base = (vaddr_t)phys_to_virt(PRCM_BASE, MEM_AREA_IO_SEC);
 
-	TEE_ASSERT(base);
+	panic_unless(base);
 	write32((uint32_t)sunxi_secondary_entry,
 		base + PRCM_CPU_SOFT_ENTRY_REG);
 
@@ -79,7 +78,7 @@ void platform_init(void)
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
 	cci400_base = (vaddr_t)phys_to_virt(CCI400_BASE, MEM_AREA_IO_SEC);
-	TEE_ASSERT(gicc_base && gicd_base && cci400_base);
+	panic_unless(gicc_base && gicd_base && cci400_base);
 
 	/*
 	 * GIC configuration is initialized in Secure bootloader,

--- a/core/arch/arm/plat-sunxi/platform.c
+++ b/core/arch/arm/plat-sunxi/platform.c
@@ -60,7 +60,7 @@ static int platform_smp_init(void)
 {
 	vaddr_t base = (vaddr_t)phys_to_virt(PRCM_BASE, MEM_AREA_IO_SEC);
 
-	panic_unless(base);
+	panic_if(!base);
 	write32((uint32_t)sunxi_secondary_entry,
 		base + PRCM_CPU_SOFT_ENTRY_REG);
 
@@ -78,7 +78,7 @@ void platform_init(void)
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
 	cci400_base = (vaddr_t)phys_to_virt(CCI400_BASE, MEM_AREA_IO_SEC);
-	panic_unless(gicc_base && gicd_base && cci400_base);
+	panic_if(!gicc_base || !gicd_base || !cci400_base);
 
 	/*
 	 * GIC configuration is initialized in Secure bootloader,

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -39,6 +39,7 @@
 #include <kernel/pm_stubs.h>
 #include <trace.h>
 #include <kernel/misc.h>
+#include <kernel/panic.h>
 #include <kernel/tee_time.h>
 #include <tee/entry_fast.h>
 #include <tee/entry_std.h>
@@ -94,7 +95,7 @@ void main_init_gic(void)
 					  MEM_AREA_IO_SEC);
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
-	TEE_ASSERT(gicc_base && gicd_base);
+	panic_unless(gicc_base && gicd_base);
 
 #if PLATFORM_FLAVOR_IS(fvp) || PLATFORM_FLAVOR_IS(juno) || \
     PLATFORM_FLAVOR_IS(qemu_armv8a)

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -95,7 +95,7 @@ void main_init_gic(void)
 					  MEM_AREA_IO_SEC);
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
-	panic_unless(gicc_base && gicd_base);
+	panic_if(!gicc_base || !gicd_base);
 
 #if PLATFORM_FLAVOR_IS(fvp) || PLATFORM_FLAVOR_IS(juno) || \
     PLATFORM_FLAVOR_IS(qemu_armv8a)

--- a/core/arch/arm/sta/se_api_self_tests.c
+++ b/core/arch/arm/sta/se_api_self_tests.c
@@ -30,7 +30,7 @@
 #include <tee_api_types.h>
 #include <tee_api_defines.h>
 #include <trace.h>
-#include <kernel/tee_common_unpg.h>
+
 #include <tee/se/manager.h>
 #include <tee/se/reader.h>
 #include <tee/se/session.h>

--- a/core/arch/arm/sta/tee_fs_key_manager_tests.c
+++ b/core/arch/arm/sta/tee_fs_key_manager_tests.c
@@ -25,13 +25,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <kernel/static_ta.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <kernel/static_ta.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <string.h>
 #include <tee/tee_fs_key_manager.h>
-
+#include <trace.h>
 
 #define TA_NAME		"tee_fs_key_manager_tests.ta"
 

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -26,6 +26,7 @@
  */
 
 #include <arm.h>
+#include <assert.h>
 #include <kernel/thread.h>
 #include <tee/tee_svc.h>
 #include <tee/arch_svc.h>
@@ -35,7 +36,6 @@
 #include <tee_syscall_numbers.h>
 #include <util.h>
 #include "arch_svc_private.h"
-#include <assert.h>
 #include <trace.h>
 #include <kernel/misc.h>
 #include <kernel/trace_ta.h>

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -31,7 +31,6 @@
 #include <optee_msg.h>
 #include <sm/optee_smc.h>
 #include <kernel/tee_l2cc_mutex.h>
-#include <kernel/panic.h>
 #include <kernel/misc.h>
 #include <mm/core_mmu.h>
 

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -35,8 +35,6 @@
 #include <kernel/misc.h>
 #include <mm/core_mmu.h>
 
-#include <assert.h>
-
 static void tee_entry_get_shm_config(struct thread_smc_args *args)
 {
 	args->a0 = OPTEE_SMC_RETURN_OK;

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -36,8 +36,6 @@
 #include <mm/core_memprot.h>
 #include <util.h>
 
-#include <assert.h>
-
 #define SHM_CACHE_ATTRS	\
 	(uint32_t)(core_mmu_is_shm_cached() ?  OPTEE_SMC_SHM_CACHED : 0)
 

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -31,7 +31,6 @@
 #include <optee_msg.h>
 #include <sm/optee_smc.h>
 #include <kernel/tee_dispatch.h>
-#include <kernel/panic.h>
 #include <mm/core_mmu.h>
 #include <mm/core_memprot.h>
 #include <util.h>

--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <assert.h>
+
 #include <initcall.h>
 #include <malloc.h>		/* required for inits */
 

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -26,6 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <drivers/gic.h>
 #include <kernel/interrupt.h>
 #include <kernel/panic.h>
@@ -213,7 +214,7 @@ static void gic_it_set_cpu_mask(struct gic_data *gd, size_t it,
 
 	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
+	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Route it to selected CPUs */
 	target = read32(gd->gicd_base +
@@ -236,7 +237,7 @@ static void gic_it_set_prio(struct gic_data *gd, size_t it, uint8_t prio)
 
 	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
+	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Set prio it to selected CPUs */
 	DMSG("prio: writing 0x%x to 0x%" PRIxVA,
@@ -251,9 +252,9 @@ static void gic_it_enable(struct gic_data *gd, size_t it)
 
 	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
+	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 	/* Not enabled yet */
-	panic_if(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask);
+	assert(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
 
 	/* Enable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ISENABLER(idx));
@@ -266,7 +267,7 @@ static void gic_it_disable(struct gic_data *gd, size_t it)
 
 	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
+	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -28,11 +28,10 @@
 
 #include <drivers/gic.h>
 #include <kernel/interrupt.h>
+#include <kernel/panic.h>
 #include <util.h>
 #include <io.h>
 #include <trace.h>
-
-#include <assert.h>
 
 /* Offsets from gic.gicc_base */
 #define GICC_CTLR		(0x000)
@@ -194,7 +193,7 @@ static void gic_it_add(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	panic_unless(it <= gd->max_it); /* Not too large */
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));
@@ -212,9 +211,9 @@ static void gic_it_set_cpu_mask(struct gic_data *gd, size_t it,
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 	uint32_t target, target_shift;
 
-	assert(it <= gd->max_it); /* Not too large */
+	panic_unless(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Route it to selected CPUs */
 	target = read32(gd->gicd_base +
@@ -235,9 +234,9 @@ static void gic_it_set_prio(struct gic_data *gd, size_t it, uint8_t prio)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	panic_unless(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Set prio it to selected CPUs */
 	DMSG("prio: writing 0x%x to 0x%" PRIxVA,
@@ -250,11 +249,11 @@ static void gic_it_enable(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	panic_unless(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 	/* Not enabled yet */
-	assert(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
+	panic_unless(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
 
 	/* Enable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ISENABLER(idx));
@@ -265,9 +264,9 @@ static void gic_it_disable(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	assert(it <= gd->max_it); /* Not too large */
+	panic_unless(it <= gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -193,7 +193,7 @@ static void gic_it_add(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	panic_unless(it <= gd->max_it); /* Not too large */
+	panic_if(it > gd->max_it); /* Not too large */
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));
@@ -211,9 +211,9 @@ static void gic_it_set_cpu_mask(struct gic_data *gd, size_t it,
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 	uint32_t target, target_shift;
 
-	panic_unless(it <= gd->max_it); /* Not too large */
+	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
 
 	/* Route it to selected CPUs */
 	target = read32(gd->gicd_base +
@@ -234,9 +234,9 @@ static void gic_it_set_prio(struct gic_data *gd, size_t it, uint8_t prio)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	panic_unless(it <= gd->max_it); /* Not too large */
+	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
 
 	/* Set prio it to selected CPUs */
 	DMSG("prio: writing 0x%x to 0x%" PRIxVA,
@@ -249,11 +249,11 @@ static void gic_it_enable(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	panic_unless(it <= gd->max_it); /* Not too large */
+	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
 	/* Not enabled yet */
-	panic_unless(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
+	panic_if(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask);
 
 	/* Enable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ISENABLER(idx));
@@ -264,9 +264,9 @@ static void gic_it_disable(struct gic_data *gd, size_t it)
 	size_t idx = it / NUM_INTS_PER_REG;
 	uint32_t mask = 1 << (it % NUM_INTS_PER_REG);
 
-	panic_unless(it <= gd->max_it); /* Not too large */
+	panic_if(it > gd->max_it); /* Not too large */
 	/* Assigned to group0 */
-	panic_unless(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+	panic_if(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask);
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));

--- a/core/drivers/gpio.c
+++ b/core/drivers/gpio.c
@@ -31,6 +31,7 @@
  */
 
 #include <assert.h>
+#include <kernel/panic.h>
 #include <trace.h>
 #include <gpio.h>
 
@@ -41,34 +42,29 @@ static const struct gpio_ops *ops;
 
 enum gpio_dir gpio_get_direction(unsigned int gpio_pin)
 {
-	assert(ops);
-	assert(ops->get_direction != 0);
-
+	assert(ops && ops->get_direction);
 	return ops->get_direction(gpio_pin);
 }
 
 void gpio_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
 {
-	assert(ops);
-	assert(ops->set_direction != 0);
-	assert((direction == GPIO_DIR_OUT) || (direction == GPIO_DIR_IN));
+	assert(ops && ops->set_direction);
+	panic_unless((direction == GPIO_DIR_OUT) || (direction == GPIO_DIR_IN));
 
 	ops->set_direction(gpio_pin, direction);
 }
 
 enum gpio_level gpio_get_value(unsigned int gpio_pin)
 {
-	assert(ops);
-	assert(ops->get_value != 0);
+	assert(ops && ops->get_value);
 
 	return ops->get_value(gpio_pin);
 }
 
 void gpio_set_value(unsigned int gpio_pin, enum gpio_level value)
 {
-	assert(ops);
-	assert(ops->set_value != 0);
-	assert((value == GPIO_LEVEL_LOW) || (value == GPIO_LEVEL_HIGH));
+	assert(ops && ops->set_value);
+	panic_unless((value == GPIO_LEVEL_LOW) || (value == GPIO_LEVEL_HIGH));
 
 	ops->set_value(gpio_pin, value);
 }
@@ -79,11 +75,12 @@ void gpio_set_value(unsigned int gpio_pin, enum gpio_level value)
  */
 void gpio_init(const struct gpio_ops *ops_ptr)
 {
-	assert(ops_ptr != 0  &&
-		(ops_ptr->get_direction != 0) &&
-		(ops_ptr->set_direction != 0) &&
-		(ops_ptr->get_value != 0) &&
-		(ops_ptr->set_value != 0));
+	assert(!ops &&
+		ops_ptr &&
+		ops_ptr->get_direction &&
+		ops_ptr->set_direction &&
+		ops_ptr->get_value &&
+		ops_ptr->set_value);
 
 	ops = ops_ptr;
 }

--- a/core/drivers/gpio.c
+++ b/core/drivers/gpio.c
@@ -49,7 +49,7 @@ enum gpio_dir gpio_get_direction(unsigned int gpio_pin)
 void gpio_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
 {
 	assert(ops && ops->set_direction);
-	panic_unless((direction == GPIO_DIR_OUT) || (direction == GPIO_DIR_IN));
+	panic_if((direction != GPIO_DIR_OUT) && (direction != GPIO_DIR_IN));
 
 	ops->set_direction(gpio_pin, direction);
 }
@@ -64,7 +64,7 @@ enum gpio_level gpio_get_value(unsigned int gpio_pin)
 void gpio_set_value(unsigned int gpio_pin, enum gpio_level value)
 {
 	assert(ops && ops->set_value);
-	panic_unless((value == GPIO_LEVEL_LOW) || (value == GPIO_LEVEL_HIGH));
+	panic_if((value != GPIO_LEVEL_LOW) && (value != GPIO_LEVEL_HIGH));
 
 	ops->set_value(gpio_pin, value);
 }

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -30,7 +30,6 @@
 #include <drivers/imx_uart.h>
 #include <console.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* Register definitions */

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -29,6 +29,7 @@
 #include <trace.h>
 #include <gpio.h>
 #include <io.h>
+#include <kernel/panic.h>
 #include <util.h>
 #include <drivers/pl061_gpio.h>
 
@@ -63,7 +64,7 @@ static enum gpio_dir pl061_get_direction(unsigned int gpio_pin)
 	uint8_t data;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -79,7 +80,7 @@ static void pl061_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
 	uint8_t data;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -105,7 +106,7 @@ static enum gpio_level pl061_get_value(unsigned int gpio_pin)
 	vaddr_t base_addr;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -124,7 +125,7 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
 	vaddr_t base_addr;
 	unsigned int offset;
 
-	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -142,7 +143,7 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
  */
 void pl061_gpio_register(vaddr_t base_addr, unsigned int gpio_dev)
 {
-	assert(gpio_dev < MAX_GPIO_DEVICES);
+	panic_unless(gpio_dev < MAX_GPIO_DEVICES);
 
 	pl061_reg_base[gpio_dev] = base_addr;
 }

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -64,7 +64,7 @@ static enum gpio_dir pl061_get_direction(unsigned int gpio_pin)
 	uint8_t data;
 	unsigned int offset;
 
-	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_if(gpio_pin >= PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -80,7 +80,7 @@ static void pl061_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
 	uint8_t data;
 	unsigned int offset;
 
-	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_if(gpio_pin >= PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -106,7 +106,7 @@ static enum gpio_level pl061_get_value(unsigned int gpio_pin)
 	vaddr_t base_addr;
 	unsigned int offset;
 
-	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_if(gpio_pin >= PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -125,7 +125,7 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
 	vaddr_t base_addr;
 	unsigned int offset;
 
-	panic_unless(gpio_pin < PLAT_PL061_MAX_GPIOS);
+	panic_if(gpio_pin >= PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
@@ -143,7 +143,7 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
  */
 void pl061_gpio_register(vaddr_t base_addr, unsigned int gpio_dev)
 {
-	panic_unless(gpio_dev < MAX_GPIO_DEVICES);
+	panic_if(gpio_dev >= MAX_GPIO_DEVICES);
 
 	pl061_reg_base[gpio_dev] = base_addr;
 }

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -29,7 +29,6 @@
 #include <drivers/serial8250_uart.h>
 #include <console.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* uart register defines */

--- a/core/drivers/sunxi_uart.c
+++ b/core/drivers/sunxi_uart.c
@@ -28,7 +28,6 @@
 
 #include <drivers/sunxi_uart.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* uart register defines */

--- a/core/include/kernel/panic.h
+++ b/core/include/kernel/panic.h
@@ -39,8 +39,7 @@
 #define panic_if(expr) \
 	do { \
 		if (expr) \
-			__panic(__FILE__, __LINE__, __func__, \
-				"on \"" #expr "\""); \
+			__panic(__FILE__, __LINE__, __func__, #expr); \
 	} while (0)
 
 void __panic(const char *file, const int line, const char *func, const char *m)

--- a/core/include/kernel/panic.h
+++ b/core/include/kernel/panic.h
@@ -30,8 +30,12 @@
 
 #include <compiler.h>
 
-#define panic()	__panic(__FILE__, __LINE__, __func__)
+#define panic()		__panic(__FILE__, __LINE__, __func__)
+#define panic_unless(e)	__panic_unless(!!(e), #e, __FILE__, __LINE__, __func__)
 
-void __panic(const char *file, int line, const char *func) __noreturn;
+void __panic(const char *file, const int line, const char *func) __noreturn;
+
+void __panic_unless(int expr, const char *expr_string,
+			const char *file, const int line, const char *func);
 
 #endif /*KERNEL_PANIC_H*/

--- a/core/include/kernel/panic.h
+++ b/core/include/kernel/panic.h
@@ -30,12 +30,20 @@
 
 #include <compiler.h>
 
-#define panic()		__panic(__FILE__, __LINE__, __func__)
-#define panic_unless(e)	__panic_unless(!!(e), #e, __FILE__, __LINE__, __func__)
+#define panic()	\
+		__panic(__FILE__, __LINE__, __func__, (void*)0)
 
-void __panic(const char *file, const int line, const char *func) __noreturn;
+#define panic_msg(str)	\
+		__panic(__FILE__, __LINE__, __func__, str)
 
-void __panic_unless(int expr, const char *expr_string,
-			const char *file, const int line, const char *func);
+#define panic_if(expr) \
+	do { \
+		if (expr) \
+			__panic(__FILE__, __LINE__, __func__, \
+				"on \"" #expr "\""); \
+	} while (0)
+
+void __panic(const char *file, const int line, const char *func, const char *m)
+	__noreturn;
 
 #endif /*KERNEL_PANIC_H*/

--- a/core/include/kernel/tee_common.h
+++ b/core/include/kernel/tee_common.h
@@ -27,7 +27,6 @@
 #ifndef TEE_COMMON_H
 #define TEE_COMMON_H
 
-#include <kernel/tee_common_unpg.h>
 #include <stdlib.h>
 
 #ifdef MEASURE_TIME

--- a/core/include/kernel/tee_common_unpg.h
+++ b/core/include/kernel/tee_common_unpg.h
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <tee_api_types.h>
-#include <kernel/panic.h>
 
 #define TEE_MEMBER_SIZE(type, member) sizeof(((type *)0)->member)
 
@@ -43,30 +42,6 @@ typedef uintptr_t tee_paddr_t;
 typedef uintptr_t tee_vaddr_t;
 /* Virtual address valid in user mode */
 typedef uintptr_t tee_uaddr_t;
-
-
-#if (CFG_TEE_CORE_DEBUG == 0)
-
-#define TEE_ASSERT(expr) \
-	do { \
-		if (!(expr)) { \
-			DMSG("assertion failed"); \
-			panic(); \
-		} \
-	} while (0)
-
-#else
-
-#define TEE_ASSERT(expr) \
-	do { \
-		if (!(expr)) { \
-			EMSG("assertion '%s' failed at %s:%d (func '%s')", \
-				#expr, __FILE__, __LINE__, __func__); \
-			panic(); \
-		} \
-	} while (0)
-
-#endif
 
 /*-----------------------------------------------------------------------------
  * tee_ta_load_page - Loads a page at address va_addr

--- a/core/include/kernel/tee_dispatch.h
+++ b/core/include/kernel/tee_dispatch.h
@@ -28,9 +28,7 @@
 #define TEE_DISPATCH_H
 
 #include <stdarg.h>
-#include <kernel/tee_common_unpg.h>
 #include <tee_api_types.h>
-
 #include <trace.h>
 
 /*

--- a/core/include/kernel/tee_misc.h
+++ b/core/include/kernel/tee_misc.h
@@ -27,7 +27,6 @@
 #ifndef TEE_MISC_H
 #define TEE_MISC_H
 
-#include <kernel/tee_common_unpg.h>
 #include <types_ext.h>
 
 /*

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -33,7 +33,6 @@
 #include <tee_api_types.h>
 #include <utee_types.h>
 #include <kernel/tee_common.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/mutex.h>
 #include <tee_api_types.h>
 #include <user_ta_header.h>

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -27,7 +27,7 @@
 #ifndef TEE_SVC_H
 #define TEE_SVC_H
 
-#include <kernel/panic.h>
+#include <assert.h>
 #include <stdint.h>
 #include <types_ext.h>
 #include <tee_api_types.h>
@@ -94,7 +94,7 @@ TEE_Result tee_svc_copy_kaddr_to_uref(uint32_t *uref, void *kaddr);
 
 static inline uint32_t tee_svc_kaddr_to_uref(void *kaddr)
 {
-	panic_if(((vaddr_t)kaddr - tee_svc_uref_base) >= UINT32_MAX);
+	assert(((vaddr_t)kaddr - tee_svc_uref_base) < UINT32_MAX);
 	return (vaddr_t)kaddr - tee_svc_uref_base;
 }
 

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -94,7 +94,7 @@ TEE_Result tee_svc_copy_kaddr_to_uref(uint32_t *uref, void *kaddr);
 
 static inline uint32_t tee_svc_kaddr_to_uref(void *kaddr)
 {
-	panic_unless(((vaddr_t)kaddr - tee_svc_uref_base) < UINT32_MAX);
+	panic_if(((vaddr_t)kaddr - tee_svc_uref_base) >= UINT32_MAX);
 	return (vaddr_t)kaddr - tee_svc_uref_base;
 }
 

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -27,12 +27,11 @@
 #ifndef TEE_SVC_H
 #define TEE_SVC_H
 
+#include <kernel/panic.h>
 #include <stdint.h>
-#include <kernel/tee_common_unpg.h>	/* tee_uaddr_t */
+#include <types_ext.h>
 #include <tee_api_types.h>
 #include <utee_types.h>
-#include <assert.h>
-#include <types_ext.h>
 
 extern vaddr_t tee_svc_uref_base;
 
@@ -95,7 +94,7 @@ TEE_Result tee_svc_copy_kaddr_to_uref(uint32_t *uref, void *kaddr);
 
 static inline uint32_t tee_svc_kaddr_to_uref(void *kaddr)
 {
-	assert(((vaddr_t)kaddr - tee_svc_uref_base) < UINT32_MAX);
+	panic_unless(((vaddr_t)kaddr - tee_svc_uref_base) < UINT32_MAX);
 	return (vaddr_t)kaddr - tee_svc_uref_base;
 }
 

--- a/core/kernel/assert.c
+++ b/core/kernel/assert.c
@@ -37,11 +37,11 @@ void _assert_log(const char *expr __maybe_unused,
 		 const int line __maybe_unused,
 		 const char *func __maybe_unused)
 {
-#if (CFG_TEE_CORE_DEBUG == 0)
-	EMSG_RAW("assertion failed");
-#else
+#if defined(CFG_TEE_CORE_DEBUG)
 	EMSG_RAW("assertion '%s' failed at %s:%d <%s>",
 				expr, file , line, func);
+#else
+	EMSG_RAW("assertion failed");
 #endif
 }
 

--- a/core/kernel/assert.c
+++ b/core/kernel/assert.c
@@ -24,17 +24,25 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <assert.h>
-#include <trace.h>
 #include <compiler.h>
+#include <trace.h>
 #include <kernel/panic.h>
 
-/* indirected assert (see TEE_ASSERT()) */
+/* assert log and break for the optee kernel */
 
 void _assert_log(const char *expr __maybe_unused,
-		 const char *file __maybe_unused, int line __maybe_unused)
+		 const char *file __maybe_unused,
+		 const int line __maybe_unused,
+		 const char *func __maybe_unused)
 {
-	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
+#if (CFG_TEE_CORE_DEBUG == 0)
+	EMSG_RAW("assertion failed");
+#else
+	EMSG_RAW("assertion '%s' failed at %s:%d in %s()",
+				expr, file, line, func);
+#endif
 }
 
 void __noreturn _assert_break(void)

--- a/core/kernel/assert.c
+++ b/core/kernel/assert.c
@@ -40,8 +40,8 @@ void _assert_log(const char *expr __maybe_unused,
 #if (CFG_TEE_CORE_DEBUG == 0)
 	EMSG_RAW("assertion failed");
 #else
-	EMSG_RAW("assertion '%s' failed at %s:%d in %s()",
-				expr, file, line, func);
+	EMSG_RAW("assertion '%s' failed at %s:%d <%s>",
+				expr, file , line, func);
 #endif
 }
 

--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -36,13 +36,13 @@ void __panic(const char *file __maybe_unused,
 {
 	uint32_t __unused exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
-#if (CFG_TEE_CORE_DEBUG == 0)
-	EMSG_RAW("PANIC");
-#else
+#if defined(CFG_TEE_CORE_DEBUG)
 	if (msg)
 		EMSG_RAW("PANIC '%s' at %s:%d <%s>", msg, file, line, func);
 	else
 		EMSG_RAW("PANIC at %s:%d <%s>", file, line, func);
+#else
+	EMSG_RAW("PANIC");
 #endif
 
 	while (1)

--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -31,33 +31,20 @@
 
 void __panic(const char *file __maybe_unused,
 		const int line __maybe_unused,
-		const char *func __maybe_unused)
+		const char *func __maybe_unused,
+		const char *msg __maybe_unused)
 {
 	uint32_t __unused exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
 #if (CFG_TEE_CORE_DEBUG == 0)
 	EMSG_RAW("PANIC\n");
 #else
-	EMSG_RAW("PANIC at %s:%d in %s()\n", file, line, func);
+	if (msg)
+		EMSG_RAW("PANIC '%s' at %s:%d <%s>\n", msg, file, line, func);
+	else
+		EMSG_RAW("PANIC %s:%d <%s>\n", file, line, func);
 #endif
+
 	while (1)
 		;
 }
-
-void __panic_unless(int expr,
-		const char *expr_string __maybe_unused,
-		const char *file __maybe_unused,
-		const int line __maybe_unused,
-		const char *func __maybe_unused)
-{
-	if (!expr) {
-		uint32_t __unused f = thread_mask_exceptions(THREAD_EXCP_ALL);
-
-#if (CFG_TEE_CORE_DEBUG != 0)
-		EMSG_RAW("Conditional PANIC: \"%s\" is false\n",
-								expr_string);
-#endif
-		__panic(file, line, func);
-	}
-}
-

--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -37,12 +37,12 @@ void __panic(const char *file __maybe_unused,
 	uint32_t __unused exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
 #if (CFG_TEE_CORE_DEBUG == 0)
-	EMSG_RAW("PANIC\n");
+	EMSG_RAW("PANIC");
 #else
 	if (msg)
-		EMSG_RAW("PANIC '%s' at %s:%d <%s>\n", msg, file, line, func);
+		EMSG_RAW("PANIC '%s' at %s:%d <%s>", msg, file, line, func);
 	else
-		EMSG_RAW("PANIC %s:%d <%s>\n", file, line, func);
+		EMSG_RAW("PANIC at %s:%d <%s>", file, line, func);
 #endif
 
 	while (1)

--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -29,12 +29,35 @@
 #include <kernel/thread.h>
 #include <trace.h>
 
-void __panic(const char *file __maybe_unused, int line __maybe_unused,
+void __panic(const char *file __maybe_unused,
+		const int line __maybe_unused,
 		const char *func __maybe_unused)
 {
 	uint32_t __unused exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
-	EMSG_RAW("PANIC: %s %s:%d\n", func, file, line);
+#if (CFG_TEE_CORE_DEBUG == 0)
+	EMSG_RAW("PANIC\n");
+#else
+	EMSG_RAW("PANIC at %s:%d in %s()\n", file, line, func);
+#endif
 	while (1)
 		;
 }
+
+void __panic_unless(int expr,
+		const char *expr_string __maybe_unused,
+		const char *file __maybe_unused,
+		const int line __maybe_unused,
+		const char *func __maybe_unused)
+{
+	if (!expr) {
+		uint32_t __unused f = thread_mask_exceptions(THREAD_EXCP_ALL);
+
+#if (CFG_TEE_CORE_DEBUG != 0)
+		EMSG_RAW("Conditional PANIC: \"%s\" is false\n",
+								expr_string);
+#endif
+		__panic(file, line, func);
+	}
+}
+

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -582,7 +582,7 @@ static void get_pool(struct mpa_scratch_mem_sync *sync)
 			condvar_wait(&sync->cv, &sync->mu);
 
 		sync->owner = thread_get_id();
-		panic_if(sync->count);
+		assert(!sync->count);
 	}
 
 	sync->count++;
@@ -595,8 +595,8 @@ static void put_pool(struct mpa_scratch_mem_sync *sync)
 {
 	mutex_lock(&sync->mu);
 
-	panic_if(sync->owner != thread_get_id());
-	panic_if(sync->count <= 0);
+	assert(sync->owner == thread_get_id());
+	assert(sync->count > 0);
 
 	sync->count--;
 	if (!sync->count) {

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -26,6 +26,7 @@
  */
 
 #include <assert.h>
+#include <kernel/panic.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tee_api_types.h>
@@ -41,7 +42,8 @@ TEE_Result tee_se_aid_create(const char *name, struct tee_se_aid **aid)
 	size_t str_length = strlen(name);
 	size_t aid_length = str_length / 2;
 
-	assert(aid && !*aid);
+	assert(aid);
+	panic_if(*aid);
 	if (str_length < MIN_AID_LENGTH || str_length > MAX_AID_LENGTH)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -82,7 +84,8 @@ int tee_se_aid_get_refcnt(struct tee_se_aid *aid)
 
 void tee_se_aid_release(struct tee_se_aid *aid)
 {
-	assert(aid && aid->refcnt > 0);
+	assert(aid);
+	panic_if(aid->refcnt <= 0);
 	aid->refcnt--;
 	if (aid->refcnt == 0)
 		free(aid);

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -25,15 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/aid.h>
 #include <tee/se/util.h>
-
-#include <stdlib.h>
-#include <string.h>
 
 #include "aid_priv.h"
 
@@ -42,7 +41,7 @@ TEE_Result tee_se_aid_create(const char *name, struct tee_se_aid **aid)
 	size_t str_length = strlen(name);
 	size_t aid_length = str_length / 2;
 
-	TEE_ASSERT(aid != NULL && *aid == NULL);
+	assert(aid && !*aid);
 	if (str_length < MIN_AID_LENGTH || str_length > MAX_AID_LENGTH)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -71,19 +70,19 @@ TEE_Result tee_se_aid_create_from_buffer(uint8_t *id, size_t length,
 
 void tee_se_aid_acquire(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL);
+	assert(aid);
 	aid->refcnt++;
 }
 
 int tee_se_aid_get_refcnt(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL);
+	assert(aid);
 	return aid->refcnt;
 }
 
 void tee_se_aid_release(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL && aid->refcnt > 0);
+	assert(aid && aid->refcnt > 0);
 	aid->refcnt--;
 	if (aid->refcnt == 0)
 		free(aid);

--- a/core/tee/se/apdu.c
+++ b/core/tee/se/apdu.c
@@ -25,14 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/apdu.h>
 #include <tee/se/util.h>
-
-#include <stdlib.h>
 
 #include "apdu_priv.h"
 
@@ -119,51 +119,51 @@ struct resp_apdu *alloc_resp_apdu(uint8_t le)
 
 uint8_t *resp_apdu_get_data(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->resp_data;
 }
 
 size_t resp_apdu_get_data_len(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->resp_data_len;
 }
 
 uint8_t resp_apdu_get_sw1(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->sw1;
 }
 
 uint8_t resp_apdu_get_sw2(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->sw2;
 }
 
 uint8_t *apdu_get_data(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->data_buf;
 }
 size_t apdu_get_length(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->length;
 }
 int apdu_get_refcnt(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->refcnt;
 }
 void apdu_acquire(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	apdu->refcnt++;
 }
 void apdu_release(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	apdu->refcnt--;
 	if (apdu->refcnt == 0)
 		free(apdu);

--- a/core/tee/se/channel.c
+++ b/core/tee/se/channel.c
@@ -25,10 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/session.h>
 #include <tee/se/channel.h>
 #include <tee/se/iso7816.h>
@@ -58,7 +58,7 @@ struct tee_se_channel *tee_se_channel_alloc(struct tee_se_session *s,
 
 void tee_se_channel_free(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	if (c->aid)
 		tee_se_aid_release(c->aid);
 	if (c->select_resp)
@@ -67,20 +67,21 @@ void tee_se_channel_free(struct tee_se_channel *c)
 
 struct tee_se_session *tee_se_channel_get_session(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return c->session;
 }
 
 int tee_se_channel_get_id(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return c->channel_id;
 }
 
 void tee_se_channel_set_select_response(struct tee_se_channel *c,
 		struct resp_apdu *resp)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
+
 	if (c->select_resp)
 		apdu_release(to_apdu_base(c->select_resp));
 	apdu_acquire(to_apdu_base(resp));
@@ -90,7 +91,7 @@ void tee_se_channel_set_select_response(struct tee_se_channel *c,
 TEE_Result tee_se_channel_get_select_response(struct tee_se_channel *c,
 		struct resp_apdu **resp)
 {
-	TEE_ASSERT(c != NULL && resp != NULL);
+	assert(c && resp);
 
 	if (c->select_resp) {
 		*resp = c->select_resp;
@@ -103,7 +104,7 @@ TEE_Result tee_se_channel_get_select_response(struct tee_se_channel *c,
 void tee_se_channel_set_aid(struct tee_se_channel *c,
 		struct tee_se_aid *aid)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	if (c->aid)
 		tee_se_aid_release(c->aid);
 	tee_se_aid_acquire(aid);
@@ -114,13 +115,13 @@ void tee_se_channel_set_aid(struct tee_se_channel *c,
 TEE_Result tee_se_channel_select(struct tee_se_channel *c,
 		struct tee_se_aid *aid)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return iso7816_select(c, aid);
 }
 
 TEE_Result tee_se_channel_select_next(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return iso7816_select_next(c);
 }
 
@@ -131,7 +132,7 @@ TEE_Result tee_se_channel_transmit(struct tee_se_channel *c,
 	uint8_t *cmd_buf;
 	int cla_channel;
 
-	TEE_ASSERT(c != NULL && cmd_apdu != NULL && resp_apdu != NULL);
+	assert(c && cmd_apdu && resp_apdu);
 
 	s = c->session;
 	cla_channel = iso7816_get_cla_channel(c->channel_id);

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -25,9 +25,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <kernel/panic.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/reader.h>
 #include <tee/se/session.h>
 #include <tee/se/iso7816.h>
@@ -36,10 +39,7 @@
 #include <tee/se/channel.h>
 #include <tee/se/util.h>
 #include <tee/se/reader/interface.h>
-
-#include <malloc.h>
-#include <stdlib.h>
-#include <string.h>
+#include <trace.h>
 
 #include "session_priv.h"
 #include "aid_priv.h"
@@ -50,7 +50,7 @@ TEE_Result iso7816_exchange_apdu(struct tee_se_reader_proxy *proxy,
 {
 	TEE_Result ret;
 
-	TEE_ASSERT(cmd != NULL && resp != NULL);
+	assert(cmd && resp);
 	ret = tee_se_reader_transmit(proxy,
 			cmd->base.data_buf, cmd->base.length,
 			resp->base.data_buf, &resp->base.length);
@@ -89,16 +89,16 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 	int channel_id;
 	uint8_t cla_channel;
 
-	TEE_ASSERT(c != NULL);
+	assert(c);
 
 	s = tee_se_channel_get_session(c);
 	channel_id = tee_se_channel_get_id(c);
 
-	TEE_ASSERT(channel_id < MAX_LOGICAL_CHANNEL);
+	panic_unless(channel_id < MAX_LOGICAL_CHANNEL);
 
 	cla_channel = iso7816_get_cla_channel(channel_id);
 	if (select_ops == FIRST_OR_ONLY_OCCURRENCE) {
-		TEE_ASSERT(aid != NULL);
+		assert(aid);
 		cmd = alloc_cmd_apdu(ISO7816_CLA | cla_channel,
 				SELECT_CMD, SELECT_BY_AID,
 				select_ops, aid->length,
@@ -152,7 +152,7 @@ static TEE_Result internal_manage_channel(struct tee_se_session *s,
 	uint8_t channel_flag =
 		(open_flag == OPEN_CHANNEL) ? OPEN_NEXT_AVAILABLE : *channel_id;
 
-	TEE_ASSERT(s != NULL);
+	assert(s);
 
 	cmd = alloc_cmd_apdu(ISO7816_CLA, MANAGE_CHANNEL_CMD, open_flag,
 			channel_flag, tx_buf_len, rx_buf_len, NULL);

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -94,7 +94,7 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 	s = tee_se_channel_get_session(c);
 	channel_id = tee_se_channel_get_id(c);
 
-	panic_unless(channel_id < MAX_LOGICAL_CHANNEL);
+	panic_if(channel_id >= MAX_LOGICAL_CHANNEL);
 
 	cla_channel = iso7816_get_cla_channel(channel_id);
 	if (select_ops == FIRST_OR_ONLY_OCCURRENCE) {

--- a/core/tee/se/manager.c
+++ b/core/tee/se/manager.c
@@ -27,7 +27,6 @@
 
 #include <initcall.h>
 #include <trace.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/mutex.h>
 #include <tee/se/manager.h>
 #include <tee/se/session.h>

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -25,11 +25,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <kernel/mutex.h>
+#include <kernel/panic.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
-#include <kernel/mutex.h>
 #include <tee/se/reader.h>
 #include <tee/se/reader/interface.h>
 
@@ -63,8 +65,7 @@ TEE_Result tee_se_reader_get_name(struct tee_se_reader_proxy *proxy,
 {
 	size_t name_len;
 
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
-
+	assert(proxy && proxy->reader);
 	name_len = strlen(proxy->reader->name);
 	*reader_name = proxy->reader->name;
 	*reader_name_len = name_len;
@@ -75,13 +76,13 @@ TEE_Result tee_se_reader_get_name(struct tee_se_reader_proxy *proxy,
 void tee_se_reader_get_properties(struct tee_se_reader_proxy *proxy,
 		TEE_SEReaderProperties *prop)
 {
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	*prop = proxy->reader->prop;
 }
 
 int tee_se_reader_get_refcnt(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	return proxy->refcnt;
 }
 
@@ -108,7 +109,7 @@ TEE_Result tee_se_reader_attach(struct tee_se_reader_proxy *proxy)
 
 void tee_se_reader_detach(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy->refcnt > 0);
+	panic_unless(proxy->refcnt > 0);
 
 	mutex_lock(&proxy->mutex);
 	proxy->refcnt--;
@@ -129,7 +130,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 	struct tee_se_reader *r;
 	TEE_Result ret;
 
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	ret = tee_se_reader_check_state(proxy);
 	if (ret != TEE_SUCCESS)
 		return ret;
@@ -137,7 +138,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 	mutex_lock(&proxy->mutex);
 	r = proxy->reader;
 
-	TEE_ASSERT(r->ops->transmit);
+	assert(r->ops->transmit);
 	ret = r->ops->transmit(r, tx_buf, tx_buf_len, rx_buf, rx_buf_len);
 
 	mutex_unlock(&proxy->mutex);
@@ -147,7 +148,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 
 void tee_se_reader_lock_basic_channel(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 
 	mutex_lock(&proxy->mutex);
 	proxy->basic_channel_locked = true;
@@ -156,7 +157,7 @@ void tee_se_reader_lock_basic_channel(struct tee_se_reader_proxy *proxy)
 
 void tee_se_reader_unlock_basic_channel(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 
 	mutex_lock(&proxy->mutex);
 	proxy->basic_channel_locked = false;
@@ -165,7 +166,7 @@ void tee_se_reader_unlock_basic_channel(struct tee_se_reader_proxy *proxy)
 
 bool tee_se_reader_is_basic_channel_locked(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 	return proxy->basic_channel_locked;
 }
 
@@ -175,7 +176,7 @@ TEE_Result tee_se_reader_get_atr(struct tee_se_reader_proxy *proxy,
 	TEE_Result ret;
 	struct tee_se_reader *r;
 
-	TEE_ASSERT(proxy != NULL && atr != NULL && atr_len != NULL);
+	assert(proxy && atr && atr_len);
 	ret = tee_se_reader_check_state(proxy);
 	if (ret != TEE_SUCCESS)
 		return ret;
@@ -183,7 +184,7 @@ TEE_Result tee_se_reader_get_atr(struct tee_se_reader_proxy *proxy,
 	mutex_lock(&proxy->mutex);
 	r = proxy->reader;
 
-	TEE_ASSERT(r->ops->get_atr);
+	assert(r->ops->get_atr);
 	ret = r->ops->get_atr(r, atr, atr_len);
 
 	mutex_unlock(&proxy->mutex);
@@ -196,8 +197,8 @@ TEE_Result tee_se_reader_open_session(struct tee_se_reader_proxy *proxy,
 	TEE_Result ret;
 	struct tee_se_session *s;
 
-	TEE_ASSERT(session != NULL && *session == NULL);
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(session && !*session);
+	assert(proxy && proxy->reader);
 
 	s = tee_se_session_alloc(proxy);
 	if (!s)

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -109,7 +109,7 @@ TEE_Result tee_se_reader_attach(struct tee_se_reader_proxy *proxy)
 
 void tee_se_reader_detach(struct tee_se_reader_proxy *proxy)
 {
-	panic_unless(proxy->refcnt > 0);
+	panic_if(proxy->refcnt <= 0);
 
 	mutex_lock(&proxy->mutex);
 	proxy->refcnt--;

--- a/core/tee/se/reader/passthru_reader/reader.c
+++ b/core/tee/se/reader/passthru_reader/reader.c
@@ -26,14 +26,13 @@
  */
 
 #include <io.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <kernel/panic.h>
 #include <mm/core_memprot.h>
+#include <stdio.h>
+#include <trace.h>
 
 #include <tee/se/util.h>
 #include <tee/se/reader/interface.h>
-
-#include <stdio.h>
 
 #include "pcsc.h"
 #include "reader.h"
@@ -113,7 +112,7 @@ static void pcsc_reader_get_atr(struct pcsc_reader *r)
 
 static void pcsc_reader_connect(struct pcsc_reader *r)
 {
-	TEE_ASSERT(!r->connected);
+	panic_unless(!r->connected);
 
 	pcsc_reader_write_reg(r, PCSC_REG_READER_CONTROL,
 			PCSC_READER_CTL_CONNECT |
@@ -125,7 +124,7 @@ static void pcsc_reader_connect(struct pcsc_reader *r)
 
 static void pcsc_reader_disconnect(struct pcsc_reader *r)
 {
-	TEE_ASSERT(r->connected);
+	panic_unless(r->connected);
 
 	pcsc_reader_write_reg(r, PCSC_REG_READER_CONTROL,
 			PCSC_READER_CTL_DISCONNECT |
@@ -139,7 +138,7 @@ static TEE_Result pcsc_reader_transmit(struct pcsc_reader *r, uint8_t *tx_buf,
 {
 	uint32_t tx_buf_paddr = 0, rx_buf_paddr = 0;
 
-	TEE_ASSERT(r->connected);
+	panic_unless(r->connected);
 
 	tx_buf_paddr = virt_to_phys((void *)tx_buf);
 	rx_buf_paddr = virt_to_phys((void *)rx_buf);

--- a/core/tee/se/reader/passthru_reader/reader.c
+++ b/core/tee/se/reader/passthru_reader/reader.c
@@ -112,7 +112,7 @@ static void pcsc_reader_get_atr(struct pcsc_reader *r)
 
 static void pcsc_reader_connect(struct pcsc_reader *r)
 {
-	panic_unless(!r->connected);
+	panic_if(r->connected);
 
 	pcsc_reader_write_reg(r, PCSC_REG_READER_CONTROL,
 			PCSC_READER_CTL_CONNECT |
@@ -124,7 +124,7 @@ static void pcsc_reader_connect(struct pcsc_reader *r)
 
 static void pcsc_reader_disconnect(struct pcsc_reader *r)
 {
-	panic_unless(r->connected);
+	panic_if(!r->connected);
 
 	pcsc_reader_write_reg(r, PCSC_REG_READER_CONTROL,
 			PCSC_READER_CTL_DISCONNECT |
@@ -138,7 +138,7 @@ static TEE_Result pcsc_reader_transmit(struct pcsc_reader *r, uint8_t *tx_buf,
 {
 	uint32_t tx_buf_paddr = 0, rx_buf_paddr = 0;
 
-	panic_unless(r->connected);
+	panic_if(!r->connected);
 
 	tx_buf_paddr = virt_to_phys((void *)tx_buf);
 	rx_buf_paddr = virt_to_phys((void *)rx_buf);

--- a/core/tee/se/service.c
+++ b/core/tee/se/service.c
@@ -25,11 +25,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
 #include <kernel/tee_ta_manager.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/user_ta.h>
 #include <tee/se/service.h>
 #include <tee/se/session.h>
@@ -52,7 +52,7 @@ TEE_Result tee_se_service_open(
 		return ret;
 	utc = to_user_ta_ctx(sess->ctx);
 
-	TEE_ASSERT(service != NULL);
+	assert(service);
 	if (utc->se_service != NULL)
 		return TEE_ERROR_ACCESS_CONFLICT;
 
@@ -74,7 +74,7 @@ TEE_Result tee_se_service_add_session(
 		struct tee_se_service *service,
 		struct tee_se_session *session)
 {
-	TEE_ASSERT(service != NULL && session != NULL);
+	assert(service && session);
 
 	mutex_lock(&service->mutex);
 	TAILQ_INSERT_TAIL(&service->opened_sessions, session, link);
@@ -101,7 +101,7 @@ void tee_se_service_close_session(
 		struct tee_se_service *service,
 		struct tee_se_session *session)
 {
-	TEE_ASSERT(service != NULL && session != NULL);
+	assert(service && session);
 
 	tee_se_session_close(session);
 
@@ -121,7 +121,7 @@ void tee_se_service_close_sessions_by_reader(
 {
 	struct tee_se_session *s;
 
-	TEE_ASSERT(service != NULL && proxy != NULL);
+	assert(service && proxy);
 
 	TAILQ_FOREACH(s, &service->opened_sessions, link) {
 		if (s->reader_proxy == proxy)
@@ -130,7 +130,7 @@ void tee_se_service_close_sessions_by_reader(
 }
 
 TEE_Result tee_se_service_close(
-		struct tee_se_service *service)
+		struct tee_se_service *service __unused)
 {
 	TEE_Result ret;
 	struct tee_se_service *h;
@@ -143,9 +143,7 @@ TEE_Result tee_se_service_close(
 		return ret;
 
 	utc = to_user_ta_ctx(sess->ctx);
-	TEE_ASSERT(service != NULL);
-	TEE_ASSERT(utc->se_service != NULL);
-
+	assert(utc->se_service);
 	h = utc->se_service;
 
 	/* clean up all sessions */

--- a/core/tee/se/session.c
+++ b/core/tee/se/session.c
@@ -25,17 +25,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <assert.h>
 #include <kernel/mutex.h>
+#include <stdlib.h>
+#include <sys/queue.h>
+#include <trace.h>
 
 #include <tee/se/reader.h>
 #include <tee/se/session.h>
 #include <tee/se/channel.h>
 #include <tee/se/iso7816.h>
-
-#include <stdlib.h>
-#include <sys/queue.h>
 
 #include "session_priv.h"
 #include "channel_priv.h"
@@ -44,8 +43,8 @@ struct tee_se_session *tee_se_session_alloc(
 		struct tee_se_reader_proxy *proxy)
 {
 	struct tee_se_session *s;
-	TEE_ASSERT(proxy != NULL);
 
+	assert(proxy);
 	s = malloc(sizeof(struct tee_se_session));
 	if (s) {
 		TAILQ_INIT(&s->channels);
@@ -74,7 +73,7 @@ bool tee_se_session_is_channel_exist(struct tee_se_session *s,
 TEE_Result tee_se_session_get_atr(struct tee_se_session *s,
 		uint8_t **atr, size_t *atr_len)
 {
-	TEE_ASSERT(s != NULL && atr != NULL && atr_len != NULL);
+	assert(s && atr && atr_len);
 
 	return tee_se_reader_get_atr(s->reader_proxy, atr, atr_len);
 }
@@ -85,7 +84,7 @@ TEE_Result tee_se_session_open_basic_channel(struct tee_se_session *s,
 	struct tee_se_channel *c;
 	TEE_Result ret;
 
-	TEE_ASSERT(s != NULL && channel != NULL && *channel == NULL);
+	assert(s && channel && !*channel);
 
 	if (tee_se_reader_is_basic_channel_locked(s->reader_proxy)) {
 		*channel = NULL;
@@ -120,7 +119,7 @@ TEE_Result tee_se_session_open_logical_channel(struct tee_se_session *s,
 	struct tee_se_channel *c;
 	TEE_Result ret;
 
-	TEE_ASSERT(s != NULL && channel != NULL && *channel == NULL);
+	assert(s && channel && !*channel);
 
 	ret = iso7816_open_available_logical_channel(s, &channel_id);
 	if (ret != TEE_SUCCESS)
@@ -154,7 +153,7 @@ void tee_se_session_close_channel(struct tee_se_session *s,
 {
 	int channel_id;
 
-	TEE_ASSERT(s != NULL && c != NULL);
+	assert(s && c);
 	channel_id = tee_se_channel_get_id(c);
 	if (channel_id > 0) {
 		iso7816_close_logical_channel(s, channel_id);
@@ -184,7 +183,7 @@ void tee_se_session_close(struct tee_se_session *s)
 {
 	struct tee_se_channel *c;
 
-	TEE_ASSERT(s != NULL);
+	assert(s);
 
 	TAILQ_FOREACH(c, &s->channels, link)
 		tee_se_session_close_channel(s, c);

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -41,7 +41,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <kernel/tee_common_otp.h>
-#include <kernel/tee_common_unpg.h>
+#include <kernel/panic.h>
 #include <tee/tee_cryp_utl.h>
 #include <tee/tee_cryp_provider.h>
 #include <tee/tee_fs_key_manager.h>
@@ -275,7 +275,7 @@ size_t tee_fs_get_header_size(enum tee_fs_file_type type)
 		break;
 	default:
 		EMSG("Unknown file type, type=%d", type);
-		TEE_ASSERT(0);
+		panic();
 	}
 
 	return header_size;

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -744,7 +744,7 @@ static int read_and_decrypt_file(int fd,
 	if (res < 0)
 		return res;
 
-	panic_unless(file_size >= header_size);
+	panic_if(file_size < header_size);
 
 	ciphertext = malloc(file_size);
 	if (!ciphertext) {
@@ -1995,7 +1995,7 @@ static int ree_fs_rename(const char *old, const char *new)
 	}
 
 	/* finally, link the meta file, rename operation completed */
-	panic_unless(meta_filename);
+	panic_if(!meta_filename);
 
 	/*
 	 * TODO: This will cause memory leakage at previous strdup()

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -26,10 +26,10 @@
  */
 
 #include <assert.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/thread.h>
 #include <kernel/handle.h>
 #include <kernel/mutex.h>
+#include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <optee_msg.h>
 #include <stdio.h>
@@ -585,8 +585,7 @@ static int get_file_length(int fd, size_t *length)
 	size_t file_len;
 	int res;
 
-	TEE_ASSERT(length);
-
+	assert(length);
 	*length = 0;
 
 	res = ree_fs_lseek_ree(fd, 0, TEE_FS_SEEK_END);
@@ -745,7 +744,7 @@ static int read_and_decrypt_file(int fd,
 	if (res < 0)
 		return res;
 
-	TEE_ASSERT(file_size >= header_size);
+	panic_unless(file_size >= header_size);
 
 	ciphertext = malloc(file_size);
 	if (!ciphertext) {
@@ -1442,7 +1441,7 @@ static int ree_fs_open(TEE_Result *errno, const char *file, int flags, ...)
 	struct tee_fs_fd *fdp = NULL;
 	bool file_exist;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!file) {
@@ -1563,7 +1562,7 @@ static tee_fs_off_t ree_fs_lseek(TEE_Result *errno, int fd,
 	size_t filelen;
 	struct tee_fs_fd *fdp = handle_lookup(&fs_handle_db, fd);
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1631,7 +1630,7 @@ static int ree_fs_ftruncate_internal(TEE_Result *errno, struct tee_fs_fd *fdp,
 	struct tee_fs_file_meta *new_meta = NULL;
 	uint8_t *buf = NULL;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1756,7 +1755,7 @@ static int ree_fs_read(TEE_Result *errno, int fd, void *buf, size_t len)
 	uint8_t *data_ptr = buf;
 	struct tee_fs_fd *fdp = handle_lookup(&fs_handle_db, fd);
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1854,7 +1853,7 @@ static int ree_fs_write(TEE_Result *errno, int fd, const void *buf, size_t len)
 	size_t file_size;
 	int orig_pos;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1996,7 +1995,7 @@ static int ree_fs_rename(const char *old, const char *new)
 	}
 
 	/* finally, link the meta file, rename operation completed */
-	TEE_ASSERT(meta_filename);
+	panic_unless(meta_filename);
 
 	/*
 	 * TODO: This will cause memory leakage at previous strdup()

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -540,8 +540,8 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 	uint8_t *tmp __maybe_unused;
 
 
-	panic_unless((size + offset >= size) &&
-		   (size + offset <= RPMB_DATA_SIZE));
+	panic_if((size + offset < size) ||
+		   (size + offset > RPMB_DATA_SIZE));
 
 	if (!fek) {
 		/* Block is not encrypted (not a file data block) */
@@ -2182,7 +2182,7 @@ static int rpmb_fs_write(TEE_Result *errno, int fd, const void *buf,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	panic_unless(!(fh->fat_entry.flags & FILE_IS_LAST_ENTRY));
+	panic_if(fh->fat_entry.flags & FILE_IS_LAST_ENTRY);
 
 	end = fh->pos + size;
 	start_addr = fh->fat_entry.start_address + fh->pos;

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -29,6 +29,7 @@
 #include <kernel/tee_common.h>
 #include <kernel/handle.h>
 #include <kernel/mutex.h>
+#include <kernel/panic.h>
 #include <kernel/tee_common_otp.h>
 #include <kernel/thread.h>
 #include <optee_msg.h>
@@ -538,7 +539,9 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 {
 	uint8_t *tmp __maybe_unused;
 
-	TEE_ASSERT(size + offset <= RPMB_DATA_SIZE);
+
+	panic_unless((size + offset >= size) &&
+		   (size + offset <= RPMB_DATA_SIZE));
 
 	if (!fek) {
 		/* Block is not encrypted (not a file data block) */
@@ -568,7 +571,6 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 			memcpy(out, tmp + offset, size);
 			free(tmp);
 		} else {
-			TEE_ASSERT(!offset);
 			decrypt_block(out, frm->data, blk_idx, fek);
 		}
 #else
@@ -2180,7 +2182,7 @@ static int rpmb_fs_write(TEE_Result *errno, int fd, const void *buf,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	TEE_ASSERT(!(fh->fat_entry.flags & FILE_IS_LAST_ENTRY));
+	panic_unless(!(fh->fat_entry.flags & FILE_IS_LAST_ENTRY));
 
 	end = fh->pos + size;
 	start_addr = fh->fat_entry.start_address + fh->pos;

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -43,8 +43,6 @@
 #include <kernel/chip_services.h>
 #include <kernel/static_ta.h>
 
-#include <assert.h>
-
 vaddr_t tee_svc_uref_base;
 
 void syscall_log(const void *buf __maybe_unused, size_t len __maybe_unused)

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -24,7 +24,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <tee_api_types.h>
+#include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <utee_defines.h>
 #include <mm/tee_mmu.h>
@@ -3223,7 +3225,7 @@ static int pkcs1_get_salt_len(const TEE_Attribute *params, uint32_t num_params,
 {
 	size_t n;
 
-	assert(default_len < INT_MAX);
+	panic_unless(default_len < INT_MAX);
 
 	for (n = 0; n < num_params; n++) {
 		if (params[n].attributeID == TEE_ATTR_RSA_PSS_SALT_LENGTH) {

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -25,8 +25,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee_api_types.h>
-#include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <utee_defines.h>
 #include <mm/tee_mmu.h>
@@ -3225,7 +3225,7 @@ static int pkcs1_get_salt_len(const TEE_Attribute *params, uint32_t num_params,
 {
 	size_t n;
 
-	panic_if(default_len >= INT_MAX);
+	assert(default_len < INT_MAX);
 
 	for (n = 0; n < num_params; n++) {
 		if (params[n].attributeID == TEE_ATTR_RSA_PSS_SALT_LENGTH) {

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -3225,7 +3225,7 @@ static int pkcs1_get_salt_len(const TEE_Attribute *params, uint32_t num_params,
 {
 	size_t n;
 
-	panic_unless(default_len < INT_MAX);
+	panic_if(default_len >= INT_MAX);
 
 	for (n = 0; n < num_params; n++) {
 		if (params[n].attributeID == TEE_ATTR_RSA_PSS_SALT_LENGTH) {

--- a/lib/libmpa/mpa_io.c
+++ b/lib/libmpa/mpa_io.c
@@ -353,7 +353,7 @@ int mpa_set_str(mpanum dest, const char *digitstr)
 	*w = 0;
 	i = BYTES_PER_WORD;
 	dest->size = 1;
-	bufidx--;		/* dec to get insid);e buf range */
+	bufidx--;		/* dec to get inside buf range */
 	while (bufidx > 1) {
 		*w ^= ((((mpa_word_t)buf[bufidx - 1] << 4) ^ (buf[bufidx])) <<
 			((mpa_word_t)(BYTES_PER_WORD - i) << 3));

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -24,16 +24,21 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <assert.h>
 #include <compiler.h>
+#include <trace.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
 #include <utee_syscalls.h>
 
 void _assert_log(const char *expr __maybe_unused,
-		 const char *file __maybe_unused, int line __maybe_unused)
+		 const char *file __maybe_unused,
+		 const int line __maybe_unused,
+		 const char *func __maybe_unused)
 {
-	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
+	EMSG_RAW("assertion '%s' failed at %s:%d in %s()",
+				expr, file, line, func);
 }
 
 void __noreturn _assert_break(void)

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -31,8 +31,6 @@
 #include <utee_syscalls.h>
 #include "tee_api_private.h"
 
-#include <assert.h>
-
 #define TEE_USAGE_DEFAULT   0xffffffff
 
 #define TEE_ATTR_BIT_VALUE                  (1 << 29)

--- a/lib/libutee/tui/font.c
+++ b/lib/libutee/tui/font.c
@@ -33,7 +33,8 @@
 #include "default_regular.h"
 #include "default_bold.h"
 #include <trace.h>
-#include <assert.h>
+
+#include <tee_api.h>
 
 #define UCP_CARRIAGE_RETURN	0x000D
 #define UCP_TUI_BOLD		0xE000
@@ -149,7 +150,9 @@ static bool letter_get_bit(const struct font_letter *letter, size_t x, size_t y)
 	size_t byte_pos = pos / 8;
 	uint8_t bit_mask = 1 << (7 - (pos & 0x7));
 
-	assert(byte_pos < letter->blob_size);
+	if (byte_pos >= letter->blob_size)
+		TEE_Panic(0);
+
 	return !!(bstr[byte_pos] & bit_mask);
 }
 

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -25,6 +25,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+		/* FIXME: BGET relies on assert(). Change to panic_unless() ? */
+
 #define PROTOTYPES
 
 /*

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -25,7 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-		/* FIXME: BGET relies on assert(). Change to panic_unless() ? */
+		/* FIXME: BGET relies on assert(). Change to panic_if() ? */
 
 #define PROTOTYPES
 

--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -28,18 +28,24 @@
 #define ASSERT_H
 
 #include <compiler.h>
+#include <trace.h>
 
 void _assert_break(void) __noreturn;
-void _assert_log(const char *expr, const char *file, int line);
+void _assert_log(const char *expr, const char *file, const int line,
+			const char *func);
 
+/* assert() specs: generates a log but does not panic if NDEBUG is defined */
+#ifdef NDEBUG
+#define assert(expr)	do { } while (0)
+#else
 #define assert(expr) \
 	do { \
 		if (!(expr)) { \
-			_assert_log(#expr, __FILE__, __LINE__); \
+			_assert_log(#expr, __FILE__, __LINE__, __func__); \
 			_assert_break(); \
 		} \
 	} while (0)
-
+#endif
 
 #define COMPILE_TIME_ASSERT(x) \
 	do { \

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -38,8 +38,10 @@ WARNS ?= 3
 # Define DEBUG=1 to compile with -g option
 # DEBUG=1
 
-# If 1, debug mode of the tee firmware (CPU restart, Core Status)
-CFG_TEE_CORE_DEBUG ?= 0
+# Core debug mode enablement
+# When defined to "y", tee firmware is in debug mode. Core and pager status,
+# panics verbosity, physical/virtual address paranoid verifications.
+CFG_TEE_CORE_DEBUG ?= n
 
 # Max level of the tee core traces. 0 means disable, 4 is max.
 # Supported values: 0 (no traces) to 4 (all traces)


### PR DESCRIPTION
The assert() macro should expand to a no-op when NDEBUG is defined.
Current implementation provides a TEE_ASSERT() that aborts execution
(if condition fails) whatever debug configuration is. For clarity,
TEE_ASSERT() is renamed panic_unless() and declared in panic.h.

This patch removes several inclusions on tee_common_unpg.h as it used
to declare TEE_ASSERT() and now TEE_ASSERT() is declared in panic.h.
This change lead to including few string.h here and there.

Signed-off-by: jerome forissier <jerome.forissier@linaro.org>
Signed-off-by: etienne carriere <etienne.carriere@linaro.org>