### PR TITLE
asset vs panic

### DIFF
--- a/core/arch/arm/include/kernel/static_ta.h
+++ b/core/arch/arm/include/kernel/static_ta.h
@@ -27,11 +27,11 @@
 #ifndef KERNEL_STATIC_TA_H
 #define KERNEL_STATIC_TA_H
 
+#include <assert.h>
 #include <compiler.h>
 #include <kernel/tee_ta_manager.h>
 #include <tee_api_types.h>
 #include <util.h>
-#include <assert.h>
 
 struct static_ta_head {
 	TEE_UUID uuid;

--- a/core/arch/arm/include/kernel/tz_ssvce.h
+++ b/core/arch/arm/include/kernel/tz_ssvce.h
@@ -29,6 +29,9 @@
 #define TZ_SSVCE_H
 
 #ifndef ASM
+
+#include <types_ext.h>
+
 unsigned int secure_get_cpu_id(void);
 
 void arm_cl1_d_cleanbysetway(void);

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -27,13 +27,13 @@
 #ifndef KERNEL_USER_TA_H
 #define KERNEL_USER_TA_H
 
-#include <types_ext.h>
-#include <tee_api_types.h>
+#include <assert.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <mm/tee_mm.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
 #include <util.h>
-#include <assert.h>
 
 TAILQ_HEAD(tee_cryp_state_head, tee_cryp_state);
 TAILQ_HEAD(tee_obj_head, tee_obj);

--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -28,9 +28,8 @@
 #ifndef CORE_MEMPROT_H
 #define CORE_MEMPROT_H
 
-#include <types_ext.h>
-#include <kernel/tee_common_unpg.h>
 #include <mm/core_mmu.h>
+#include <types_ext.h>
 
 /*
  * "pbuf_is" support.

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -28,12 +28,9 @@
 #ifndef CORE_MMU_H
 #define CORE_MMU_H
 
-#include <kernel/tee_common_unpg.h>
 #include <kernel/user_ta.h>
 #include <mm/tee_mmu_types.h>
 #include <types_ext.h>
-
-#include <assert.h>
 
 /* A small page is the smallest unit of memory that can be mapped */
 #define SMALL_PAGE_SHIFT	12

--- a/core/arch/arm/include/tee/arch_svc.h
+++ b/core/arch/arm/include/tee/arch_svc.h
@@ -27,8 +27,6 @@
 #ifndef TEE_ARCH_SVC_H
 #define TEE_ARCH_SVC_H
 
-#include <kernel/tee_common_unpg.h>
-
 struct thread_svc_regs;
 
 void tee_svc_handler(struct thread_svc_regs *regs);

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -336,11 +336,9 @@ static void handle_user_ta_panic(struct abort_info *ai)
 #ifdef CFG_WITH_VFP
 static void handle_user_ta_vfp(void)
 {
-	TEE_Result res;
 	struct tee_ta_session *s;
 
-	res = tee_ta_get_current_session(&s);
-	if (res != TEE_SUCCESS)
+	if (tee_ta_get_current_session(&s) != TEE_SUCCESS)
 		panic();
 
 	thread_user_enable_vfp(&to_user_ta_ctx(s->ctx)->vfp);

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -493,16 +493,14 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 
 	if (is_abort_in_abort_handler(ai)) {
 		abort_print_error(ai);
-		EMSG("[abort] abort in abort handler (trap CPU)");
-		panic();
+		panic("[abort] abort in abort handler (trap CPU)");
 	}
 
 	if (ai->abort_type == ABORT_TYPE_UNDEF) {
 		if (abort_is_user_exception(ai))
 			return FAULT_TYPE_USER_TA_PANIC;
 		abort_print_error(ai);
-		EMSG("[abort] undefined abort (trap CPU)");
-		panic();
+		panic("[abort] undefined abort (trap CPU)");
 	}
 
 	switch (core_mmu_get_fault_type(ai->fault_descr)) {
@@ -510,16 +508,14 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 		if (abort_is_user_exception(ai))
 			return FAULT_TYPE_USER_TA_PANIC;
 		abort_print_error(ai);
-		EMSG("[abort] alignement fault!  (trap CPU)");
-		panic();
+		panic("[abort] alignement fault!  (trap CPU)");
 		break;
 
 	case CORE_MMU_FAULT_ACCESS_BIT:
 		if (abort_is_user_exception(ai))
 			return FAULT_TYPE_USER_TA_PANIC;
 		abort_print_error(ai);
-		EMSG("[abort] access bit fault!  (trap CPU)");
-		panic();
+		panic("[abort] access bit fault!  (trap CPU)");
 		break;
 
 	case CORE_MMU_FAULT_DEBUG_EVENT:
@@ -574,7 +570,7 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 		if (!handled) {
 			if (!abort_is_user_exception(&ai)) {
 				abort_print_error(&ai);
-				panic();
+				panic("unhandled pageable abort");
 			}
 			print_user_abort(&ai);
 			DMSG("[abort] abort in User mode (TA will panic)");

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -185,8 +185,8 @@ static void init_runtime(unsigned long pageable_part)
 	uint8_t *hashes;
 	size_t block_size;
 
-	TEE_ASSERT(pageable_size % SMALL_PAGE_SIZE == 0);
-	TEE_ASSERT(hash_size == (size_t)__tmp_hashes_size);
+	assert(pageable_size % SMALL_PAGE_SIZE == 0);
+	assert(hash_size == (size_t)__tmp_hashes_size);
 
 	/*
 	 * Zero BSS area. Note that globals that would normally would go
@@ -216,7 +216,7 @@ static void init_runtime(unsigned long pageable_part)
 
 	hashes = malloc(hash_size);
 	IMSG("Pager is enabled. Hashes: %zu bytes", hash_size);
-	TEE_ASSERT(hashes);
+	assert(hashes);
 	memcpy(hashes, __tmp_hashes_start, hash_size);
 
 	/*
@@ -226,7 +226,7 @@ static void init_runtime(unsigned long pageable_part)
 	teecore_init_ta_ram();
 
 	mm = tee_mm_alloc(&tee_mm_sec_ddr, pageable_size);
-	TEE_ASSERT(mm);
+	assert(mm);
 	paged_store = phys_to_virt(tee_mm_get_smem(mm), MEM_AREA_TA_RAM);
 	/* Copy init part into pageable area */
 	memcpy(paged_store, __init_start, init_size);
@@ -292,7 +292,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore,
 		(vaddr_t)tee_mm_vcore.hi - TZSRAM_SIZE, TZSRAM_SIZE);
-	TEE_ASSERT(mm);
+	assert(mm);
 	tee_pager_init(mm);
 
 	/*
@@ -302,7 +302,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, tee_mm_vcore.lo,
 			(vaddr_t)(__text_init_start - tee_mm_vcore.lo));
-	TEE_ASSERT(mm);
+	assert(mm);
 
 	/*
 	 * Allocate virtual memory for the pageable area and let the pager
@@ -310,7 +310,7 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	mm = tee_mm_alloc2(&tee_mm_vcore, (vaddr_t)__pageable_start,
 			   pageable_size);
-	TEE_ASSERT(mm);
+	assert(mm);
 	if (!tee_pager_add_core_area(tee_mm_get_smem(mm), tee_mm_get_bytes(mm),
 				     TEE_MATTR_PRX, paged_store, hashes))
 		panic();

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -166,10 +166,12 @@ static size_t get_block_size(void)
 	unsigned l;
 
 	if (!core_mmu_find_table(CFG_TEE_RAM_START, UINT_MAX, &tbl_info))
-		panic();
+		panic("can't find mmu tables");
+
 	l = tbl_info.level - 1;
 	if (!core_mmu_find_table(CFG_TEE_RAM_START, l, &tbl_info))
-		panic();
+		panic("can't find mmu table upper level");
+
 	return 1 << tbl_info.shift;
 }
 
@@ -202,12 +204,10 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	if (!core_mmu_find_table(CFG_TEE_RAM_START, UINT_MAX,
 				 &tee_pager_tbl_info))
-		panic();
-	if (tee_pager_tbl_info.shift != SMALL_PAGE_SHIFT) {
-		EMSG("Unsupported page size in translation table %u",
-		     BIT(tee_pager_tbl_info.shift));
-		panic();
-	}
+		panic("can't find mmu tables");
+
+	if (tee_pager_tbl_info.shift != SMALL_PAGE_SHIFT)
+		panic("Unsupported page size in translation table");
 
 	thread_init_boot_thread();
 
@@ -282,7 +282,7 @@ static void init_runtime(unsigned long pageable_part)
 			ROUNDUP(CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE,
 				block_size),
 			SMALL_PAGE_SHIFT, 0))
-		panic();
+		panic("tee_mm_vcore init failed");
 
 	/*
 	 * Assign alias area for pager end of the small page block the rest
@@ -313,7 +313,8 @@ static void init_runtime(unsigned long pageable_part)
 	assert(mm);
 	if (!tee_pager_add_core_area(tee_mm_get_smem(mm), tee_mm_get_bytes(mm),
 				     TEE_MATTR_PRX, paged_store, hashes))
-		panic();
+		panic("failed to add pageable to vcore");
+
 	tee_pager_add_pages((vaddr_t)__pageable_start,
 		ROUNDUP(init_size, SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE, false);
 	tee_pager_add_pages((vaddr_t)__pageable_start +
@@ -481,7 +482,8 @@ static void init_fdt(unsigned long phys_fdt)
 	}
 
 	if (!core_mmu_add_mapping(MEM_AREA_IO_NSEC, phys_fdt, CFG_DTB_MAX_SIZE))
-		panic();
+		panic("failed to map fdt");
+
 	fdt = phys_to_virt(phys_fdt, MEM_AREA_IO_NSEC);
 	if (!fdt)
 		panic();
@@ -493,14 +495,11 @@ static void init_fdt(unsigned long phys_fdt)
 		panic();
 	}
 
-	if (add_optee_dt_node(fdt)) {
-		EMSG("Failed to add OP-TEE Device Tree node");
-		panic();
-	}
-	if (add_optee_res_mem_dt_node(fdt)) {
-		EMSG("Failed to add OP-TEE reserved memory Device Tree node");
-		panic();
-	}
+	if (add_optee_dt_node(fdt))
+		panic("Failed to add OP-TEE Device Tree node");
+
+	if (add_optee_res_mem_dt_node(fdt))
+		panic("Failed to add OP-TEE reserved memory DT node");
 
 	ret = fdt_pack(fdt);
 	if (ret < 0) {

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -247,7 +247,7 @@ static void init_runtime(unsigned long pageable_part)
 		res = hash_sha256_check(hash, page, SMALL_PAGE_SIZE);
 		if (res != TEE_SUCCESS) {
 			EMSG("Hash failed for page %zu at %p: res 0x%x",
-				n, page, res);
+			     n, page, res);
 			panic();
 		}
 	}

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -24,10 +24,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <kernel/mutex.h>
+#include <kernel/panic.h>
 #include <kernel/tz_proc.h>
 #include <kernel/thread.h>
-#include <kernel/tee_common_unpg.h>
 #include <trace.h>
 
 void mutex_init(struct mutex *m)
@@ -83,7 +84,9 @@ static void __mutex_unlock(struct mutex *m, const char *fname, int lineno)
 	old_itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
 	cpu_spin_lock(&m->spin_lock);
 
-	TEE_ASSERT(m->value == MUTEX_VALUE_LOCKED);
+	if (m->value != MUTEX_VALUE_LOCKED)
+		panic();
+
 	thread_rem_mutex(m);
 	m->value = MUTEX_VALUE_UNLOCKED;
 
@@ -154,8 +157,10 @@ void mutex_destroy(struct mutex *m)
 	 * Caller guarantees that no one will try to take the mutex so
 	 * there's no need to take the spinlock before accessing it.
 	 */
-	TEE_ASSERT(m->value == MUTEX_VALUE_UNLOCKED);
-	TEE_ASSERT(wq_is_empty(&m->wq));
+	if (m->value != MUTEX_VALUE_UNLOCKED)
+		panic();
+	if (!wq_is_empty(&m->wq))
+		panic();
 }
 
 void condvar_init(struct condvar *cv)
@@ -165,8 +170,9 @@ void condvar_init(struct condvar *cv)
 
 void condvar_destroy(struct condvar *cv)
 {
-	if (cv->m)
-		TEE_ASSERT(!wq_have_condvar(&cv->m->wq, cv));
+	if (cv->m && wq_have_condvar(&cv->m->wq, cv))
+		panic();
+
 	condvar_init(cv);
 }
 
@@ -220,7 +226,8 @@ static void __condvar_wait(struct condvar *cv, struct mutex *m,
 
 	/* Link this condvar to this mutex until reinitialized */
 	cpu_spin_lock(&cv->spin_lock);
-	TEE_ASSERT(!cv->m || cv->m == m);
+	if (cv->m && cv->m != m)
+		panic();
 	cv->m = m;
 	cpu_spin_unlock(&cv->spin_lock);
 
@@ -230,7 +237,9 @@ static void __condvar_wait(struct condvar *cv, struct mutex *m,
 	wq_wait_init_condvar(&m->wq, &wqe, cv);
 
 	/* Unlock the mutex */
-	TEE_ASSERT(m->value == MUTEX_VALUE_LOCKED);
+	if (m->value != MUTEX_VALUE_LOCKED)
+		panic();
+
 	thread_rem_mutex(m);
 	m->value = MUTEX_VALUE_UNLOCKED;
 

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -160,7 +160,7 @@ void mutex_destroy(struct mutex *m)
 	if (m->value != MUTEX_VALUE_UNLOCKED)
 		panic();
 	if (!wq_is_empty(&m->wq))
-		panic();
+		panic("waitqueue not empty");
 }
 
 void condvar_init(struct condvar *cv)
@@ -227,7 +227,8 @@ static void __condvar_wait(struct condvar *cv, struct mutex *m,
 	/* Link this condvar to this mutex until reinitialized */
 	cpu_spin_lock(&cv->spin_lock);
 	if (cv->m && cv->m != m)
-		panic();
+		panic("invalid mutex");
+
 	cv->m = m;
 	cpu_spin_unlock(&cv->spin_lock);
 

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -32,7 +32,6 @@
 #include <mm/core_mmu.h>
 #include <utee_defines.h>
 
-#include <assert.h>
 #include <stdint.h>
 #include <mpa.h>
 #include <arm.h>

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -797,7 +797,7 @@ static void init_thread_stacks(void)
 		/* init effective stack */
 		sp = tee_mm_get_smem(mm) + tee_mm_get_bytes(mm);
 		if (!thread_init_stack(n, sp))
-			panic();
+			panic("init stack failed");
 	}
 }
 #else
@@ -808,7 +808,7 @@ static void init_thread_stacks(void)
 	/* Assign the thread stacks */
 	for (n = 0; n < CFG_NUM_THREADS; n++) {
 		if (!thread_init_stack(n, GET_STACK(stack_thread[n])))
-			panic();
+			panic("thread_init_stack failed");
 	}
 }
 #endif /*CFG_WITH_PAGER*/

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -26,10 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <compiler.h>
 #include <keep.h>
 #include <types_ext.h>
 #include <stdlib.h>
+#include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <kernel/user_ta.h>
@@ -488,7 +490,8 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	TEE_ErrorOrigin serr = TEE_ORIGIN_TEE;
 	struct tee_ta_session *s __maybe_unused;
 
-	TEE_ASSERT((utc->ctx.flags & TA_FLAG_EXEC_DDR) != 0);
+	if (!(utc->ctx.flags & TA_FLAG_EXEC_DDR))
+		panic();
 
 	/* Map user space memory */
 	res = tee_mmu_map_param(utc, param);

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -491,7 +491,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	struct tee_ta_session *s __maybe_unused;
 
 	if (!(utc->ctx.flags & TA_FLAG_EXEC_DDR))
-		panic();
+		panic("TA does not exec in DDR");
 
 	/* Map user space memory */
 	res = tee_mmu_map_param(utc, param);

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -26,9 +26,9 @@
  */
 
 #include <arm.h>
+#include <assert.h>
 #include <kernel/vfp.h>
 #include "vfp_private.h"
-#include <assert.h>
 
 #ifdef ARM32
 bool vfp_is_enabled(void)

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -392,7 +392,8 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 			/* Area not covered by a region so need finer table */
 			uint64_t *new_table = xlat_tables[next_xlat++];
 			/* Clear table before use */
-			TEE_ASSERT(next_xlat <= MAX_XLAT_TABLES);
+			if (next_xlat > MAX_XLAT_TABLES)
+				panic();
 			memset(new_table, 0, XLAT_TABLE_SIZE);
 
 			desc = TABLE_DESC | (uint64_t)(uintptr_t)new_table;
@@ -450,8 +451,8 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 		debug_print(" %010" PRIxVA " %010" PRIxPA " %10zx %x",
 			    mm[n].va, mm[n].pa, mm[n].size, mm[n].attr);
 
-		TEE_ASSERT(IS_PAGE_ALIGNED(mm[n].pa));
-		TEE_ASSERT(IS_PAGE_ALIGNED(mm[n].size));
+		if (!IS_PAGE_ALIGNED(mm[n].pa) || !IS_PAGE_ALIGNED(mm[n].size))
+			panic();
 
 		pa_end = mm[n].pa + mm[n].size - 1;
 		va_end = mm[n].va + mm[n].size - 1;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -393,7 +393,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 			uint64_t *new_table = xlat_tables[next_xlat++];
 			/* Clear table before use */
 			if (next_xlat > MAX_XLAT_TABLES)
-				panic();
+				panic("running out of xlat tables");
 			memset(new_table, 0, XLAT_TABLE_SIZE);
 
 			desc = TABLE_DESC | (uint64_t)(uintptr_t)new_table;
@@ -452,7 +452,7 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 			    mm[n].va, mm[n].pa, mm[n].size, mm[n].attr);
 
 		if (!IS_PAGE_ALIGNED(mm[n].pa) || !IS_PAGE_ALIGNED(mm[n].size))
-			panic();
+			panic("unaligned region");
 
 		pa_end = mm[n].pa + mm[n].size - 1;
 		va_end = mm[n].va + mm[n].size - 1;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -56,19 +56,20 @@
  */
 #include <platform_config.h>
 
-#include <types_ext.h>
-#include <inttypes.h>
-#include <string.h>
-#include <compiler.h>
+#include <arm.h>
 #include <assert.h>
-#include <trace.h>
-#include <mm/tee_mmu_defs.h>
-#include <mm/pgt_cache.h>
+#include <compiler.h>
+#include <inttypes.h>
 #include <kernel/thread.h>
 #include <kernel/panic.h>
 #include <kernel/misc.h>
-#include <arm.h>
+#include <mm/tee_mmu_defs.h>
+#include <mm/pgt_cache.h>
+#include <string.h>
+#include <trace.h>
+#include <types_ext.h>
 #include <util.h>
+
 #include "core_mmu_private.h"
 
 #ifndef DEBUG_XLAT_TABLE
@@ -391,9 +392,9 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 			/* Area not covered by a region so need finer table */
 			uint64_t *new_table = xlat_tables[next_xlat++];
 			/* Clear table before use */
+			TEE_ASSERT(next_xlat <= MAX_XLAT_TABLES);
 			memset(new_table, 0, XLAT_TABLE_SIZE);
 
-			assert(next_xlat <= MAX_XLAT_TABLES);
 			desc = TABLE_DESC | (uint64_t)(uintptr_t)new_table;
 
 			/* Recurse to fill in new table */
@@ -411,7 +412,7 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 static unsigned int calc_physical_addr_size_bits(uint64_t max_addr)
 {
 	/* Physical address can't exceed 48 bits */
-	assert((max_addr & ADDR_MASK_48_TO_63) == 0);
+	assert(!(max_addr & ADDR_MASK_48_TO_63));
 
 	/* 48 bits address */
 	if (max_addr & ADDR_MASK_44_TO_47)
@@ -449,8 +450,8 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 		debug_print(" %010" PRIxVA " %010" PRIxPA " %10zx %x",
 			    mm[n].va, mm[n].pa, mm[n].size, mm[n].attr);
 
-		assert(IS_PAGE_ALIGNED(mm[n].pa));
-		assert(IS_PAGE_ALIGNED(mm[n].size));
+		TEE_ASSERT(IS_PAGE_ALIGNED(mm[n].pa));
+		TEE_ASSERT(IS_PAGE_ALIGNED(mm[n].size));
 
 		pa_end = mm[n].pa + mm[n].size - 1;
 		va_end = mm[n].va + mm[n].size - 1;
@@ -703,6 +704,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 {
 	assert(fault_descr & FSR_LPAE);
+
 	switch (fault_descr & FSR_STATUS_MASK) {
 	case 0x21: /* b100001 Alignment fault */
 		return CORE_MMU_FAULT_ALIGNMENT;

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -167,7 +167,7 @@ static paddr_t core_mmu_get_main_ttb_pa(void)
 	paddr_t pa = (paddr_t)core_mmu_get_main_ttb_va();
 
 	if (pa & ~TEE_MMU_TTB_L1_MASK)
-		panic();
+		panic("invalid core l1 table");
 	return pa;
 }
 
@@ -182,7 +182,7 @@ static paddr_t core_mmu_get_ul1_ttb_pa(void)
 	paddr_t pa = (paddr_t)core_mmu_get_ul1_ttb_va();
 
 	if (pa & ~TEE_MMU_TTB_UL1_MASK)
-		panic();
+		panic("invalid user l1 table");
 	return pa;
 }
 
@@ -537,7 +537,7 @@ static paddr_t map_page_memarea(struct tee_mmap_region *mm)
 	uint32_t attr;
 
 	if (!l2)
-		panic();
+		panic("no l2 table");
 
 	attr = mattr_to_desc(2, mm->attr);
 
@@ -592,7 +592,7 @@ static void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
 	 * the same as the physical address.
 	 */
 	if (mm->va < (TEE_MMU_UL1_NUM_ENTRIES * SECTION_SIZE))
-		panic();
+		panic("va conflicts with user ta address");
 
 	if ((mm->va | mm->pa | mm->size) & SECTION_MASK) {
 		region_size = SMALL_PAGE_SIZE;
@@ -602,7 +602,7 @@ static void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
 		 * good enough, panic.
 		 */
 		if ((mm->va | mm->pa | mm->size) & SMALL_PAGE_MASK)
-			panic();
+			panic("memarea can't be mapped");
 
 		attr = mattr_to_desc(1, mm->attr | TEE_MATTR_TABLE);
 		pa = map_page_memarea(mm);

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -27,15 +27,15 @@
  */
 #include <platform_config.h>
 
-#include <stdlib.h>
-#include <assert.h>
 #include <arm.h>
+#include <assert.h>
+#include <kernel/panic.h>
+#include <kernel/thread.h>
 #include <mm/core_mmu.h>
 #include <mm/tee_mmu_defs.h>
 #include <mm/pgt_cache.h>
+#include <stdlib.h>
 #include <trace.h>
-#include <kernel/panic.h>
-#include <kernel/thread.h>
 #include <util.h>
 #include "core_mmu_private.h"
 
@@ -573,7 +573,7 @@ static void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
 	paddr_t pa;
 	uint32_t region_size;
 
-	TEE_ASSERT(mm && ttb);
+	assert(mm && ttb);
 
 	/*
 	 * If mm->va is smaller than 32M, then mm->va will conflict with
@@ -684,6 +684,7 @@ void core_init_mmu_regs(void)
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fsr)
 {
 	assert(!(fsr & FSR_LPAE));
+
 	switch (fsr & FSR_FS_MASK) {
 	case 0x1: /* DFSR[10,3:0] 0b00001 Alignment fault (DFSR only) */
 		return CORE_MMU_FAULT_ALIGNMENT;

--- a/core/arch/arm/mm/pager_aes_gcm.c
+++ b/core/arch/arm/mm/pager_aes_gcm.c
@@ -42,6 +42,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <compiler.h>
 #include "pager_private.h"
 #include <tomcrypt.h>

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -25,15 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <mm/pgt_cache.h>
 #include <kernel/mutex.h>
-#include <kernel/panic.h>
 #include <mm/tee_pager.h>
 #include <mm/core_mmu.h>
 #include <stdlib.h>
 #include <util.h>
 #include <trace.h>
-#include <assert.h>
 
 /*
  * With pager enabled we allocate page table from the pager.

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <kernel/panic.h>
 #include <kernel/tee_common.h>
 #include <util.h>
 #include <trace.h>
@@ -175,7 +176,8 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, uint32_t size)
 				/* out of memory */
 				return NULL;
 		} else {
-			TEE_ASSERT(pool->hi > pool->lo);
+			if (pool->hi <= pool->lo)
+				panic();
 			remaining = (pool->hi - pool->lo);
 			remaining -= ((entry->offset + entry->size) <<
 				      pool->shift);
@@ -287,10 +289,8 @@ void tee_mm_free(tee_mm_entry_t *p)
 	while (entry->next != NULL && entry->next != p)
 		entry = entry->next;
 
-	if (entry->next == NULL) {
-		DMSG("invalid mm_entry %p", (void *)p);
-		TEE_ASSERT(0);
-	}
+	if (!entry->next)
+		panic();
 	entry->next = entry->next->next;
 
 	free(p);

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -177,7 +177,8 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, uint32_t size)
 				return NULL;
 		} else {
 			if (pool->hi <= pool->lo)
-				panic();
+				panic("invalid pool");
+
 			remaining = (pool->hi - pool->lo);
 			remaining -= ((entry->offset + entry->size) <<
 				      pool->shift);
@@ -290,7 +291,8 @@ void tee_mm_free(tee_mm_entry_t *p)
 		entry = entry->next;
 
 	if (!entry->next)
-		panic();
+		panic("invalid mm_entry");
+
 	entry->next = entry->next->next;
 
 	free(p);

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -25,27 +25,27 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <assert.h>
-#include <stdlib.h>
-#include <types_ext.h>
 
 #include <arm.h>
-#include <util.h>
+#include <assert.h>
+#include <kernel/panic.h>
 #include <kernel/tee_common.h>
+#include <kernel/tee_misc.h>
+#include <kernel/tz_ssvce.h>
 #include <mm/tee_mmu.h>
 #include <mm/tee_mmu_types.h>
 #include <mm/tee_mmu_defs.h>
 #include <mm/pgt_cache.h>
-#include <user_ta_header.h>
 #include <mm/tee_mm.h>
-#include "tee_api_types.h"
-#include <kernel/tee_misc.h>
-#include <trace.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <sm/optee_smc.h>
-#include <kernel/tz_ssvce.h>
-#include <kernel/panic.h>
+#include <stdlib.h>
+#include <trace.h>
+#include <types_ext.h>
+#include <user_ta_header.h>
+#include <util.h>
+#include "tee_api_types.h"
 
 #ifdef CFG_PL310
 #include <kernel/tee_l2cc_mutex.h>
@@ -619,8 +619,8 @@ uintptr_t tee_mmu_get_load_addr(const struct tee_ta_ctx *const ctx)
 {
 	const struct user_ta_ctx *utc = to_user_ta_ctx((void *)ctx);
 
-	TEE_ASSERT(utc->mmu && utc->mmu->table &&
-		   utc->mmu->size == TEE_MMU_UMAP_MAX_ENTRIES);
+	assert(utc->mmu && utc->mmu->table);
+	TEE_ASSERT(utc->mmu->size == TEE_MMU_UMAP_MAX_ENTRIES);
 
 	return utc->mmu->table[1].va;
 }
@@ -680,12 +680,10 @@ void teecore_init_pub_ram(void)
 
 uint32_t tee_mmu_user_get_cache_attr(struct user_ta_ctx *utc, void *va)
 {
-	TEE_Result res;
 	paddr_t pa;
 	uint32_t attr;
 
-	res = tee_mmu_user_va2pa_attr(utc, va, &pa, &attr);
-	assert(res == TEE_SUCCESS);
+	TEE_ASSERT(tee_mmu_user_va2pa_attr(utc, va, &pa, &attr) == TEE_SUCCESS);
 
 	return (attr >> TEE_MATTR_CACHE_SHIFT) & TEE_MATTR_CACHE_MASK;
 }

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -621,7 +621,7 @@ uintptr_t tee_mmu_get_load_addr(const struct tee_ta_ctx *const ctx)
 
 	assert(utc->mmu && utc->mmu->table);
 	if (utc->mmu->size != TEE_MMU_UMAP_MAX_ENTRIES)
-		panic();
+		panic("invalid size");
 
 	return utc->mmu->table[1].va;
 }
@@ -641,13 +641,14 @@ void teecore_init_ta_ram(void)
 
 	if (!ps || (ps & CORE_MMU_USER_CODE_MASK) ||
 	    !pe || (pe & CORE_MMU_USER_CODE_MASK))
-		panic();
+		panic("invalid TA RAM");
+
 	/* extra check: we could rely on  core_mmu_get_mem_by_type() */
 	if (!tee_pbuf_is_sec(ps, pe - ps))
-		panic();
+		panic("TA RAM is not secure");
 
 	if (!tee_mm_is_empty(&tee_mm_sec_ddr))
-		panic();
+		panic("TA RAM pool is not empty");
 
 	/* remove previous config and init TA ddr memory pool */
 	tee_mm_final(&tee_mm_sec_ddr);
@@ -664,11 +665,11 @@ void teecore_init_pub_ram(void)
 	core_mmu_get_mem_by_type(MEM_AREA_NSEC_SHM, &s, &e);
 
 	if (s >= e || s & SMALL_PAGE_MASK || e & SMALL_PAGE_MASK)
-		panic();
+		panic("invalid PUB RAM");
 
 	/* extra check: we could rely on  core_mmu_get_mem_by_type() */
 	if (!tee_vbuf_is_non_sec(s, e - s))
-		panic();
+		panic("PUB RAM is not non-secure");
 
 #ifdef CFG_PL310
 	/* Allocate statically the l2cc mutex */
@@ -686,7 +687,7 @@ uint32_t tee_mmu_user_get_cache_attr(struct user_ta_ctx *utc, void *va)
 	uint32_t attr;
 
 	if (tee_mmu_user_va2pa_attr(utc, va, &pa, &attr) != TEE_SUCCESS)
-		panic();
+		panic("cannot get attr");
 
 	return (attr >> TEE_MATTR_CACHE_SHIFT) & TEE_MATTR_CACHE_MASK;
 }

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -26,6 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <keep.h>
 #include <sys/queue.h>
 #include <kernel/abort.h>
 #include <kernel/panic.h>
@@ -44,7 +46,7 @@
 #include <trace.h>
 #include <utee_defines.h>
 #include <util.h>
-#include <keep.h>
+
 #include "pager_private.h"
 
 #define PAGER_AE_KEY_BITS	256
@@ -483,7 +485,7 @@ static bool tee_pager_unhide_page(vaddr_t page_va)
 			uint32_t a = get_area_mattr(pmem->area);
 
 			/* page is hidden, show and move to back */
-			assert(pa == get_pmem_pa(pmem));
+			TEE_ASSERT(pa == get_pmem_pa(pmem));
 			/*
 			 * If it's not a dirty block, then it should be
 			 * read only.

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -27,6 +27,7 @@
 
 #include <drivers/gic.h>
 #include <kernel/generic_boot.h>
+#include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
@@ -64,7 +65,8 @@ void main_init_gic(void)
 					  MEM_AREA_IO_SEC);
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
-	TEE_ASSERT(gicc_base && gicd_base);
+	if (!gicc_base || !gicd_base)
+		panic();
 
 	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
 

--- a/core/arch/arm/plat-sunxi/platform.c
+++ b/core/arch/arm/plat-sunxi/platform.c
@@ -61,7 +61,7 @@ static int platform_smp_init(void)
 {
 	vaddr_t base = (vaddr_t)phys_to_virt(PRCM_BASE, MEM_AREA_IO_SEC);
 
-	TEE_ASSERT(base);
+	assert(base);
 	write32((uint32_t)sunxi_secondary_entry,
 		base + PRCM_CPU_SOFT_ENTRY_REG);
 

--- a/core/arch/arm/plat-sunxi/platform.c
+++ b/core/arch/arm/plat-sunxi/platform.c
@@ -79,7 +79,8 @@ void platform_init(void)
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
 	cci400_base = (vaddr_t)phys_to_virt(CCI400_BASE, MEM_AREA_IO_SEC);
-	TEE_ASSERT(gicc_base && gicd_base && cci400_base);
+	if (!gicc_base || !gicd_base || !cci400_base)
+		panic();
 
 	/*
 	 * GIC configuration is initialized in Secure bootloader,
@@ -90,7 +91,7 @@ void platform_init(void)
 
 	/* platform smp initialize */
 	platform_smp_init();
-	
+
 	/* enable non-secure access cci-400 registers */
 	write32(0x1, cci400_base + CCI400_SECURE_ACCESS_REG);
 

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -39,6 +39,7 @@
 #include <kernel/pm_stubs.h>
 #include <trace.h>
 #include <kernel/misc.h>
+#include <kernel/panic.h>
 #include <kernel/tee_time.h>
 #include <tee/entry_fast.h>
 #include <tee/entry_std.h>
@@ -94,7 +95,8 @@ void main_init_gic(void)
 					  MEM_AREA_IO_SEC);
 	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
 					  MEM_AREA_IO_SEC);
-	TEE_ASSERT(gicc_base && gicd_base);
+	if (!gicc_base || !gicd_base)
+		panic();
 
 #if defined(PLATFORM_FLAVOR_fvp) || defined(PLATFORM_FLAVOR_juno) || \
 	defined(PLATFORM_FLAVOR_qemu_armv8a)

--- a/core/arch/arm/sta/se_api_self_tests.c
+++ b/core/arch/arm/sta/se_api_self_tests.c
@@ -30,7 +30,7 @@
 #include <tee_api_types.h>
 #include <tee_api_defines.h>
 #include <trace.h>
-#include <kernel/tee_common_unpg.h>
+
 #include <tee/se/manager.h>
 #include <tee/se/reader.h>
 #include <tee/se/session.h>

--- a/core/arch/arm/sta/tee_fs_key_manager_tests.c
+++ b/core/arch/arm/sta/tee_fs_key_manager_tests.c
@@ -25,13 +25,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <kernel/static_ta.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <kernel/static_ta.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <string.h>
 #include <tee/tee_fs_key_manager.h>
-
+#include <trace.h>
 
 #define TA_NAME		"tee_fs_key_manager_tests.ta"
 

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -26,19 +26,20 @@
  */
 
 #include <arm.h>
+#include <assert.h>
+#include <kernel/misc.h>
 #include <kernel/thread.h>
+#include <kernel/trace_ta.h>
 #include <tee/tee_svc.h>
 #include <tee/arch_svc.h>
 #include <tee/tee_svc_cryp.h>
 #include <tee/tee_svc_storage.h>
 #include <tee/se/svc.h>
 #include <tee_syscall_numbers.h>
-#include <util.h>
-#include "arch_svc_private.h"
-#include <assert.h>
 #include <trace.h>
-#include <kernel/misc.h>
-#include <kernel/trace_ta.h>
+#include <util.h>
+
+#include "arch_svc_private.h"
 #include "svc_cache.h"
 
 #if (TRACE_LEVEL == TRACE_FLOW) && defined(CFG_TEE_CORE_TA_TRACE)

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -31,11 +31,8 @@
 #include <optee_msg.h>
 #include <sm/optee_smc.h>
 #include <kernel/tee_l2cc_mutex.h>
-#include <kernel/panic.h>
 #include <kernel/misc.h>
 #include <mm/core_mmu.h>
-
-#include <assert.h>
 
 static void tee_entry_get_shm_config(struct thread_smc_args *args)
 {

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -31,12 +31,9 @@
 #include <optee_msg.h>
 #include <sm/optee_smc.h>
 #include <kernel/tee_dispatch.h>
-#include <kernel/panic.h>
 #include <mm/core_mmu.h>
 #include <mm/core_memprot.h>
 #include <util.h>
-
-#include <assert.h>
 
 #define SHM_CACHE_ATTRS	\
 	(uint32_t)(core_mmu_is_shm_cached() ?  OPTEE_SMC_SHM_CACHED : 0)

--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -24,7 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <assert.h>
+
 #include <initcall.h>
 #include <malloc.h>		/* required for inits */
 

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -29,7 +29,7 @@
 #include <assert.h>
 #include <drivers/gic.h>
 #include <kernel/interrupt.h>
-#include <kernel/tee_common_unpg.h>
+#include <kernel/panic.h>
 #include <util.h>
 #include <io.h>
 #include <trace.h>
@@ -340,7 +340,9 @@ static void gic_op_add(struct itr_chip *chip, size_t it,
 {
 	struct gic_data *gd = container_of(chip, struct gic_data, chip);
 
-	TEE_ASSERT(it < gd->max_it);
+	if (it >= gd->max_it)
+		panic();
+
 	gic_it_add(gd, it);
 	/* Set the CPU mask to deliver interrupts to any online core */
 	gic_it_set_cpu_mask(gd, it, 0xff);
@@ -351,7 +353,9 @@ static void gic_op_enable(struct itr_chip *chip, size_t it)
 {
 	struct gic_data *gd = container_of(chip, struct gic_data, chip);
 
-	TEE_ASSERT(it < gd->max_it);
+	if (it >= gd->max_it)
+		panic();
+
 	gic_it_enable(gd, it);
 }
 
@@ -359,6 +363,8 @@ static void gic_op_disable(struct itr_chip *chip, size_t it)
 {
 	struct gic_data *gd = container_of(chip, struct gic_data, chip);
 
-	TEE_ASSERT(it < gd->max_it);
+	if (it >= gd->max_it)
+		panic();
+
 	gic_it_disable(gd, it);
 }

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -30,7 +30,6 @@
 #include <drivers/imx_uart.h>
 #include <console.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* Register definitions */

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -29,7 +29,6 @@
 #include <drivers/serial8250_uart.h>
 #include <console.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* uart register defines */

--- a/core/drivers/sunxi_uart.c
+++ b/core/drivers/sunxi_uart.c
@@ -28,7 +28,6 @@
 
 #include <drivers/sunxi_uart.h>
 #include <io.h>
-#include <assert.h>
 #include <compiler.h>
 
 /* uart register defines */

--- a/core/include/kernel/panic.h
+++ b/core/include/kernel/panic.h
@@ -30,8 +30,29 @@
 
 #include <compiler.h>
 
-#define panic()	__panic(__FILE__, __LINE__, __func__)
+/* debug disabled => __FILE__, ... and panic message are not built. */
+#if defined(CFG_TEE_CORE_DEBUG) && CFG_TEE_CORE_DEBUG != 0
+#define __panic(str)	__do_panic(__FILE__, __LINE__, __func__, str)
+#else
+#define __panic(str)	__do_panic((void *)0, 0, (void *)0, (void *)0)
+#endif
 
-void __panic(const char *file, int line, const char *func) __noreturn;
+void __do_panic(const char *file, const int line, const char *func,
+		const char *msg) __noreturn;
+
+/*
+ * Suppress GCC warning on expansion of the panic() macro with no argument:
+ *  'ISO C99 requires at least one argument for the "..." in a variadic macro'
+ * Occurs when '-pedantic' is combined with '-std=gnu99'.
+ * Suppression applies only to this file and the expansion of macros defined in
+ * this file.
+ */
+#pragma GCC system_header
+
+/* panic() can get a string or no argument */
+#define _panic0()	__panic((void *)0)
+#define _panic1(s)	__panic(s)
+#define _panic_fn(a, b, name, ...) name
+#define panic(...) _panic_fn("", ##__VA_ARGS__, _panic1, _panic0)(__VA_ARGS__)
 
 #endif /*KERNEL_PANIC_H*/

--- a/core/include/kernel/tee_common.h
+++ b/core/include/kernel/tee_common.h
@@ -27,7 +27,6 @@
 #ifndef TEE_COMMON_H
 #define TEE_COMMON_H
 
-#include <kernel/tee_common_unpg.h>
 #include <stdlib.h>
 
 #ifdef MEASURE_TIME

--- a/core/include/kernel/tee_common_unpg.h
+++ b/core/include/kernel/tee_common_unpg.h
@@ -32,7 +32,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <tee_api_types.h>
-#include <kernel/panic.h>
 
 #define TEE_MEMBER_SIZE(type, member) sizeof(((type *)0)->member)
 
@@ -43,30 +42,6 @@ typedef uintptr_t tee_paddr_t;
 typedef uintptr_t tee_vaddr_t;
 /* Virtual address valid in user mode */
 typedef uintptr_t tee_uaddr_t;
-
-
-#if (CFG_TEE_CORE_DEBUG == 0)
-
-#define TEE_ASSERT(expr) \
-	do { \
-		if (!(expr)) { \
-			DMSG("assertion failed"); \
-			panic(); \
-		} \
-	} while (0)
-
-#else
-
-#define TEE_ASSERT(expr) \
-	do { \
-		if (!(expr)) { \
-			EMSG("assertion '%s' failed at %s:%d (func '%s')", \
-				#expr, __FILE__, __LINE__, __func__); \
-			panic(); \
-		} \
-	} while (0)
-
-#endif
 
 /*-----------------------------------------------------------------------------
  * tee_ta_load_page - Loads a page at address va_addr

--- a/core/include/kernel/tee_dispatch.h
+++ b/core/include/kernel/tee_dispatch.h
@@ -28,9 +28,7 @@
 #define TEE_DISPATCH_H
 
 #include <stdarg.h>
-#include <kernel/tee_common_unpg.h>
 #include <tee_api_types.h>
-
 #include <trace.h>
 
 /*

--- a/core/include/kernel/tee_misc.h
+++ b/core/include/kernel/tee_misc.h
@@ -27,7 +27,6 @@
 #ifndef TEE_MISC_H
 #define TEE_MISC_H
 
-#include <kernel/tee_common_unpg.h>
 #include <types_ext.h>
 
 /*

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -33,7 +33,6 @@
 #include <tee_api_types.h>
 #include <utee_types.h>
 #include <kernel/tee_common.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/mutex.h>
 #include <tee_api_types.h>
 #include <user_ta_header.h>

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -27,12 +27,11 @@
 #ifndef TEE_SVC_H
 #define TEE_SVC_H
 
+#include <assert.h>
 #include <stdint.h>
-#include <kernel/tee_common_unpg.h>	/* tee_uaddr_t */
+#include <types_ext.h>
 #include <tee_api_types.h>
 #include <utee_types.h>
-#include <assert.h>
-#include <types_ext.h>
 
 extern vaddr_t tee_svc_uref_base;
 

--- a/core/kernel/assert.c
+++ b/core/kernel/assert.c
@@ -33,9 +33,16 @@
 /* assert log and break for the optee kernel */
 
 void _assert_log(const char *expr __maybe_unused,
-		 const char *file __maybe_unused, int line __maybe_unused)
+		 const char *file __maybe_unused,
+		 const int line __maybe_unused,
+		 const char *func __maybe_unused)
 {
-	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
+#if defined(CFG_TEE_CORE_DEBUG) && CFG_TEE_CORE_DEBUG != 0
+	EMSG_RAW("assertion '%s' failed at %s:%d <%s>",
+		 expr, file, line, func);
+#else
+	EMSG_RAW("assertion failed");
+#endif
 }
 
 void __noreturn _assert_break(void)

--- a/core/kernel/assert.c
+++ b/core/kernel/assert.c
@@ -24,12 +24,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <assert.h>
-#include <trace.h>
 #include <compiler.h>
+#include <trace.h>
 #include <kernel/panic.h>
 
-/* indirected assert (see TEE_ASSERT()) */
+/* assert log and break for the optee kernel */
 
 void _assert_log(const char *expr __maybe_unused,
 		 const char *file __maybe_unused, int line __maybe_unused)

--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
  *
@@ -29,12 +30,26 @@
 #include <kernel/thread.h>
 #include <trace.h>
 
-void __panic(const char *file __maybe_unused, int line __maybe_unused,
-		const char *func __maybe_unused)
+void __do_panic(const char *file __maybe_unused,
+		const int line __maybe_unused,
+		const char *func __maybe_unused,
+		const char *msg __maybe_unused)
 {
-	uint32_t __unused exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+	/* disable prehemption */
+	(void)thread_mask_exceptions(THREAD_EXCP_ALL);
 
-	EMSG_RAW("PANIC: %s %s:%d\n", func, file, line);
+	/* TODO: notify other cores */
+
+	/* trace: Panic ['panic-string-message' ]at FILE:LINE [<FUNCTION>]" */
+	if (!file && !func && !msg)
+		EMSG_RAW("Panic");
+	else
+		EMSG_RAW("Panic %s%s%sat %s:%d %s%s%s",
+			 msg ? "'" : "", msg ? msg : "", msg ? "' " : "",
+			 file ? file : "?", file ? line : 0,
+			 func ? "<" : "", func ? func : "", func ? ">" : "");
+
+	/* abort current execution */
 	while (1)
 		;
 }

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -24,12 +24,14 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <types_ext.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <arm.h>
+#include <assert.h>
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
 #include <kernel/static_ta.h>
@@ -49,7 +51,6 @@
 #include <trace.h>
 #include <utee_types.h>
 #include <util.h>
-#include <assert.h>
 
 /* This mutex protects the critical section in tee_ta_init_session */
 struct mutex tee_ta_mutex = MUTEX_INITIALIZER;
@@ -621,7 +622,7 @@ static void update_current_ctx(struct thread_specific_data *tsd)
 	 * If ctx->mmu == NULL we must not have user mapping active,
 	 * if ctx->mmu != NULL we must have user mapping active.
 	 */
-	assert(((ctx && is_user_ta_ctx(ctx) ?
+	TEE_ASSERT(((ctx && is_user_ta_ctx(ctx) ?
 			to_user_ta_ctx(ctx)->mmu : NULL) == NULL) ==
 		!core_mmu_user_mapping_is_active());
 }

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -627,7 +627,7 @@ static void update_current_ctx(struct thread_specific_data *tsd)
 	if (((ctx && is_user_ta_ctx(ctx) ?
 			to_user_ta_ctx(ctx)->mmu : NULL) == NULL) ==
 					core_mmu_user_mapping_is_active())
-		panic();
+		panic("unexpected active mapping");
 }
 
 void tee_ta_push_current_session(struct tee_ta_session *sess)

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee/tee_cryp_provider.h>
 #include <tee/tee_cryp_utl.h>
 #include <kernel/tee_common_unpg.h>
@@ -151,7 +152,7 @@ static TEE_Result tee_ltc_prng_init(struct tee_ltc_prng *prng)
 	int res;
 	int prng_index;
 
-	TEE_ASSERT(prng != NULL);
+	assert(prng);
 
 	prng_index = find_prng(prng->name);
 	if (prng_index == -1)

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -547,7 +547,7 @@ static void pool_postactions(void)
 	mpa_scratch_mem pool = (void *)_ltc_mempool_u32;
 
 	if (pool->last_offset)
-		panic();
+		panic("release issue in mpa scratch memory");
 	release_unused_mpa_scratch_memory();
 }
 

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -28,7 +28,6 @@
 #include <assert.h>
 #include <tee/tee_cryp_provider.h>
 #include <tee/tee_cryp_utl.h>
-#include <kernel/tee_common_unpg.h>
 
 #include <tomcrypt.h>
 #include <mpalib.h>
@@ -39,6 +38,7 @@
 #include <tee_api_types.h>
 #include <string_ext.h>
 #include <util.h>
+#include <kernel/panic.h>
 #include "tomcrypt_mpa.h"
 
 #if defined(CFG_WITH_VFP)
@@ -481,7 +481,6 @@ static TEE_Result hash_final(void *ctx, uint32_t algo, uint8_t *digest,
 #if defined(CFG_WITH_PAGER)
 #include <mm/tee_pager.h>
 #include <util.h>
-#include <kernel/panic.h>
 #include <mm/core_mmu.h>
 
 static uint32_t *_ltc_mempool_u32;
@@ -547,7 +546,8 @@ static void pool_postactions(void)
 {
 	mpa_scratch_mem pool = (void *)_ltc_mempool_u32;
 
-	TEE_ASSERT(pool->last_offset == 0);
+	if (pool->last_offset)
+		panic();
 	release_unused_mpa_scratch_memory();
 }
 

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -44,7 +44,8 @@ TEE_Result tee_se_aid_create(const char *name, struct tee_se_aid **aid)
 
 	assert(aid);
 	if (*aid)
-		panic();
+		panic("aid already allocated");
+
 	if (str_length < MIN_AID_LENGTH || str_length > MAX_AID_LENGTH)
 		return TEE_ERROR_BAD_PARAMETERS;
 

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -27,7 +27,6 @@
 
 #include <assert.h>
 #include <kernel/panic.h>
-#include <kernel/tee_common_unpg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tee_api_types.h>
@@ -44,7 +43,8 @@ TEE_Result tee_se_aid_create(const char *name, struct tee_se_aid **aid)
 	size_t aid_length = str_length / 2;
 
 	assert(aid);
-	TEE_ASSERT(!*aid);
+	if (*aid)
+		panic();
 	if (str_length < MIN_AID_LENGTH || str_length > MAX_AID_LENGTH)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -86,7 +86,8 @@ int tee_se_aid_get_refcnt(struct tee_se_aid *aid)
 void tee_se_aid_release(struct tee_se_aid *aid)
 {
 	assert(aid);
-	TEE_ASSERT(aid->refcnt > 0);
+	if (aid->refcnt <= 0)
+		panic();
 	aid->refcnt--;
 	if (!aid->refcnt)
 		free(aid);

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -25,15 +25,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <kernel/panic.h>
+#include <kernel/tee_common_unpg.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/aid.h>
 #include <tee/se/util.h>
-
-#include <stdlib.h>
-#include <string.h>
 
 #include "aid_priv.h"
 
@@ -42,7 +43,8 @@ TEE_Result tee_se_aid_create(const char *name, struct tee_se_aid **aid)
 	size_t str_length = strlen(name);
 	size_t aid_length = str_length / 2;
 
-	TEE_ASSERT(aid != NULL && *aid == NULL);
+	assert(aid);
+	TEE_ASSERT(!*aid);
 	if (str_length < MIN_AID_LENGTH || str_length > MAX_AID_LENGTH)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -71,20 +73,21 @@ TEE_Result tee_se_aid_create_from_buffer(uint8_t *id, size_t length,
 
 void tee_se_aid_acquire(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL);
+	assert(aid);
 	aid->refcnt++;
 }
 
 int tee_se_aid_get_refcnt(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL);
+	assert(aid);
 	return aid->refcnt;
 }
 
 void tee_se_aid_release(struct tee_se_aid *aid)
 {
-	TEE_ASSERT(aid != NULL && aid->refcnt > 0);
+	assert(aid);
+	TEE_ASSERT(aid->refcnt > 0);
 	aid->refcnt--;
-	if (aid->refcnt == 0)
+	if (!aid->refcnt)
 		free(aid);
 }

--- a/core/tee/se/apdu.c
+++ b/core/tee/se/apdu.c
@@ -25,14 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/apdu.h>
 #include <tee/se/util.h>
-
-#include <stdlib.h>
 
 #include "apdu_priv.h"
 
@@ -119,51 +119,51 @@ struct resp_apdu *alloc_resp_apdu(uint8_t le)
 
 uint8_t *resp_apdu_get_data(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->resp_data;
 }
 
 size_t resp_apdu_get_data_len(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->resp_data_len;
 }
 
 uint8_t resp_apdu_get_sw1(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->sw1;
 }
 
 uint8_t resp_apdu_get_sw2(struct resp_apdu *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->sw2;
 }
 
 uint8_t *apdu_get_data(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->data_buf;
 }
 size_t apdu_get_length(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->length;
 }
 int apdu_get_refcnt(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	return apdu->refcnt;
 }
 void apdu_acquire(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	apdu->refcnt++;
 }
 void apdu_release(struct apdu_base *apdu)
 {
-	TEE_ASSERT(apdu != NULL);
+	assert(apdu);
 	apdu->refcnt--;
 	if (apdu->refcnt == 0)
 		free(apdu);

--- a/core/tee/se/channel.c
+++ b/core/tee/se/channel.c
@@ -25,10 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
 #include <tee/se/session.h>
 #include <tee/se/channel.h>
 #include <tee/se/iso7816.h>
@@ -58,7 +58,7 @@ struct tee_se_channel *tee_se_channel_alloc(struct tee_se_session *s,
 
 void tee_se_channel_free(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	if (c->aid)
 		tee_se_aid_release(c->aid);
 	if (c->select_resp)
@@ -67,20 +67,21 @@ void tee_se_channel_free(struct tee_se_channel *c)
 
 struct tee_se_session *tee_se_channel_get_session(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return c->session;
 }
 
 int tee_se_channel_get_id(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return c->channel_id;
 }
 
 void tee_se_channel_set_select_response(struct tee_se_channel *c,
 		struct resp_apdu *resp)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
+
 	if (c->select_resp)
 		apdu_release(to_apdu_base(c->select_resp));
 	apdu_acquire(to_apdu_base(resp));
@@ -90,7 +91,7 @@ void tee_se_channel_set_select_response(struct tee_se_channel *c,
 TEE_Result tee_se_channel_get_select_response(struct tee_se_channel *c,
 		struct resp_apdu **resp)
 {
-	TEE_ASSERT(c != NULL && resp != NULL);
+	assert(c && resp);
 
 	if (c->select_resp) {
 		*resp = c->select_resp;
@@ -103,7 +104,7 @@ TEE_Result tee_se_channel_get_select_response(struct tee_se_channel *c,
 void tee_se_channel_set_aid(struct tee_se_channel *c,
 		struct tee_se_aid *aid)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	if (c->aid)
 		tee_se_aid_release(c->aid);
 	tee_se_aid_acquire(aid);
@@ -114,13 +115,13 @@ void tee_se_channel_set_aid(struct tee_se_channel *c,
 TEE_Result tee_se_channel_select(struct tee_se_channel *c,
 		struct tee_se_aid *aid)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return iso7816_select(c, aid);
 }
 
 TEE_Result tee_se_channel_select_next(struct tee_se_channel *c)
 {
-	TEE_ASSERT(c != NULL);
+	assert(c);
 	return iso7816_select_next(c);
 }
 
@@ -131,7 +132,7 @@ TEE_Result tee_se_channel_transmit(struct tee_se_channel *c,
 	uint8_t *cmd_buf;
 	int cla_channel;
 
-	TEE_ASSERT(c != NULL && cmd_apdu != NULL && resp_apdu != NULL);
+	assert(c && cmd_apdu && resp_apdu);
 
 	s = c->session;
 	cla_channel = iso7816_get_cla_channel(c->channel_id);

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -95,7 +95,7 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 	channel_id = tee_se_channel_get_id(c);
 
 	if (channel_id >= MAX_LOGICAL_CHANNEL)
-		panic();
+		panic("invalid channel id");
 
 	cla_channel = iso7816_get_cla_channel(channel_id);
 	if (select_ops == FIRST_OR_ONLY_OCCURRENCE) {

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -27,7 +27,6 @@
 
 #include <assert.h>
 #include <kernel/panic.h>
-#include <kernel/tee_common_unpg.h>
 #include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
@@ -95,7 +94,8 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 	s = tee_se_channel_get_session(c);
 	channel_id = tee_se_channel_get_id(c);
 
-	TEE_ASSERT(channel_id < MAX_LOGICAL_CHANNEL);
+	if (channel_id >= MAX_LOGICAL_CHANNEL)
+		panic();
 
 	cla_channel = iso7816_get_cla_channel(channel_id);
 	if (select_ops == FIRST_OR_ONLY_OCCURRENCE) {

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -25,9 +25,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tee_api_types.h>
-#include <trace.h>
+#include <assert.h>
+#include <kernel/panic.h>
 #include <kernel/tee_common_unpg.h>
+#include <malloc.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee_api_types.h>
 #include <tee/se/reader.h>
 #include <tee/se/session.h>
 #include <tee/se/iso7816.h>
@@ -36,10 +40,7 @@
 #include <tee/se/channel.h>
 #include <tee/se/util.h>
 #include <tee/se/reader/interface.h>
-
-#include <malloc.h>
-#include <stdlib.h>
-#include <string.h>
+#include <trace.h>
 
 #include "session_priv.h"
 #include "aid_priv.h"
@@ -50,7 +51,7 @@ TEE_Result iso7816_exchange_apdu(struct tee_se_reader_proxy *proxy,
 {
 	TEE_Result ret;
 
-	TEE_ASSERT(cmd != NULL && resp != NULL);
+	assert(cmd && resp);
 	ret = tee_se_reader_transmit(proxy,
 			cmd->base.data_buf, cmd->base.length,
 			resp->base.data_buf, &resp->base.length);
@@ -89,7 +90,7 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 	int channel_id;
 	uint8_t cla_channel;
 
-	TEE_ASSERT(c != NULL);
+	assert(c);
 
 	s = tee_se_channel_get_session(c);
 	channel_id = tee_se_channel_get_id(c);
@@ -98,7 +99,7 @@ static TEE_Result internal_select(struct tee_se_channel *c,
 
 	cla_channel = iso7816_get_cla_channel(channel_id);
 	if (select_ops == FIRST_OR_ONLY_OCCURRENCE) {
-		TEE_ASSERT(aid != NULL);
+		assert(aid);
 		cmd = alloc_cmd_apdu(ISO7816_CLA | cla_channel,
 				SELECT_CMD, SELECT_BY_AID,
 				select_ops, aid->length,
@@ -152,7 +153,7 @@ static TEE_Result internal_manage_channel(struct tee_se_session *s,
 	uint8_t channel_flag =
 		(open_flag == OPEN_CHANNEL) ? OPEN_NEXT_AVAILABLE : *channel_id;
 
-	TEE_ASSERT(s != NULL);
+	assert(s);
 
 	cmd = alloc_cmd_apdu(ISO7816_CLA, MANAGE_CHANNEL_CMD, open_flag,
 			channel_flag, tx_buf_len, rx_buf_len, NULL);

--- a/core/tee/se/manager.c
+++ b/core/tee/se/manager.c
@@ -27,7 +27,6 @@
 
 #include <initcall.h>
 #include <trace.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/mutex.h>
 #include <tee/se/manager.h>
 #include <tee/se/session.h>

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -25,11 +25,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <kernel/mutex.h>
+#include <kernel/panic.h>
+#include <kernel/tee_common_unpg.h>
+#include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
-#include <kernel/tee_common_unpg.h>
-#include <kernel/mutex.h>
 #include <tee/se/reader.h>
 #include <tee/se/reader/interface.h>
 
@@ -63,8 +66,7 @@ TEE_Result tee_se_reader_get_name(struct tee_se_reader_proxy *proxy,
 {
 	size_t name_len;
 
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
-
+	assert(proxy && proxy->reader);
 	name_len = strlen(proxy->reader->name);
 	*reader_name = proxy->reader->name;
 	*reader_name_len = name_len;
@@ -75,13 +77,13 @@ TEE_Result tee_se_reader_get_name(struct tee_se_reader_proxy *proxy,
 void tee_se_reader_get_properties(struct tee_se_reader_proxy *proxy,
 		TEE_SEReaderProperties *prop)
 {
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	*prop = proxy->reader->prop;
 }
 
 int tee_se_reader_get_refcnt(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	return proxy->refcnt;
 }
 
@@ -129,7 +131,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 	struct tee_se_reader *r;
 	TEE_Result ret;
 
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(proxy && proxy->reader);
 	ret = tee_se_reader_check_state(proxy);
 	if (ret != TEE_SUCCESS)
 		return ret;
@@ -137,7 +139,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 	mutex_lock(&proxy->mutex);
 	r = proxy->reader;
 
-	TEE_ASSERT(r->ops->transmit);
+	assert(r->ops->transmit);
 	ret = r->ops->transmit(r, tx_buf, tx_buf_len, rx_buf, rx_buf_len);
 
 	mutex_unlock(&proxy->mutex);
@@ -147,7 +149,7 @@ TEE_Result tee_se_reader_transmit(struct tee_se_reader_proxy *proxy,
 
 void tee_se_reader_lock_basic_channel(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 
 	mutex_lock(&proxy->mutex);
 	proxy->basic_channel_locked = true;
@@ -156,7 +158,7 @@ void tee_se_reader_lock_basic_channel(struct tee_se_reader_proxy *proxy)
 
 void tee_se_reader_unlock_basic_channel(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 
 	mutex_lock(&proxy->mutex);
 	proxy->basic_channel_locked = false;
@@ -165,7 +167,7 @@ void tee_se_reader_unlock_basic_channel(struct tee_se_reader_proxy *proxy)
 
 bool tee_se_reader_is_basic_channel_locked(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy != NULL);
+	assert(proxy);
 	return proxy->basic_channel_locked;
 }
 
@@ -175,7 +177,7 @@ TEE_Result tee_se_reader_get_atr(struct tee_se_reader_proxy *proxy,
 	TEE_Result ret;
 	struct tee_se_reader *r;
 
-	TEE_ASSERT(proxy != NULL && atr != NULL && atr_len != NULL);
+	assert(proxy && atr && atr_len);
 	ret = tee_se_reader_check_state(proxy);
 	if (ret != TEE_SUCCESS)
 		return ret;
@@ -183,7 +185,7 @@ TEE_Result tee_se_reader_get_atr(struct tee_se_reader_proxy *proxy,
 	mutex_lock(&proxy->mutex);
 	r = proxy->reader;
 
-	TEE_ASSERT(r->ops->get_atr);
+	assert(r->ops->get_atr);
 	ret = r->ops->get_atr(r, atr, atr_len);
 
 	mutex_unlock(&proxy->mutex);
@@ -196,8 +198,8 @@ TEE_Result tee_se_reader_open_session(struct tee_se_reader_proxy *proxy,
 	TEE_Result ret;
 	struct tee_se_session *s;
 
-	TEE_ASSERT(session != NULL && *session == NULL);
-	TEE_ASSERT(proxy != NULL && proxy->reader != NULL);
+	assert(session && !*session);
+	assert(proxy && proxy->reader);
 
 	s = tee_se_session_alloc(proxy);
 	if (!s)

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -110,7 +110,7 @@ TEE_Result tee_se_reader_attach(struct tee_se_reader_proxy *proxy)
 void tee_se_reader_detach(struct tee_se_reader_proxy *proxy)
 {
 	if (proxy->refcnt <= 0)
-		panic();
+		panic("invalid refcnf");
 
 	mutex_lock(&proxy->mutex);
 	proxy->refcnt--;

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -28,7 +28,6 @@
 #include <assert.h>
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
-#include <kernel/tee_common_unpg.h>
 #include <string.h>
 #include <tee_api_types.h>
 #include <trace.h>
@@ -110,7 +109,8 @@ TEE_Result tee_se_reader_attach(struct tee_se_reader_proxy *proxy)
 
 void tee_se_reader_detach(struct tee_se_reader_proxy *proxy)
 {
-	TEE_ASSERT(proxy->refcnt > 0);
+	if (proxy->refcnt <= 0)
+		panic();
 
 	mutex_lock(&proxy->mutex);
 	proxy->refcnt--;

--- a/core/tee/se/reader/passthru_reader/reader.c
+++ b/core/tee/se/reader/passthru_reader/reader.c
@@ -26,14 +26,13 @@
  */
 
 #include <io.h>
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <kernel/panic.h>
 #include <mm/core_memprot.h>
+#include <stdio.h>
+#include <trace.h>
 
 #include <tee/se/util.h>
 #include <tee/se/reader/interface.h>
-
-#include <stdio.h>
 
 #include "pcsc.h"
 #include "reader.h"
@@ -113,7 +112,8 @@ static void pcsc_reader_get_atr(struct pcsc_reader *r)
 
 static void pcsc_reader_connect(struct pcsc_reader *r)
 {
-	TEE_ASSERT(!r->connected);
+	if (r->connected)
+		panic();
 
 	pcsc_reader_write_reg(r, PCSC_REG_READER_CONTROL,
 			PCSC_READER_CTL_CONNECT |
@@ -125,7 +125,8 @@ static void pcsc_reader_connect(struct pcsc_reader *r)
 
 static void pcsc_reader_disconnect(struct pcsc_reader *r)
 {
-	TEE_ASSERT(r->connected);
+	if (!r->connected)
+		panic();
 
 	pcsc_reader_write_reg(r, PCSC_REG_READER_CONTROL,
 			PCSC_READER_CTL_DISCONNECT |
@@ -139,7 +140,8 @@ static TEE_Result pcsc_reader_transmit(struct pcsc_reader *r, uint8_t *tx_buf,
 {
 	uint32_t tx_buf_paddr = 0, rx_buf_paddr = 0;
 
-	TEE_ASSERT(r->connected);
+	if (!r->connected)
+		panic();
 
 	tx_buf_paddr = virt_to_phys((void *)tx_buf);
 	rx_buf_paddr = virt_to_phys((void *)rx_buf);

--- a/core/tee/se/service.c
+++ b/core/tee/se/service.c
@@ -25,11 +25,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <tee_api_types.h>
 #include <trace.h>
 
 #include <kernel/tee_ta_manager.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/user_ta.h>
 #include <tee/se/service.h>
 #include <tee/se/session.h>
@@ -52,7 +52,7 @@ TEE_Result tee_se_service_open(
 		return ret;
 	utc = to_user_ta_ctx(sess->ctx);
 
-	TEE_ASSERT(service != NULL);
+	assert(service);
 	if (utc->se_service != NULL)
 		return TEE_ERROR_ACCESS_CONFLICT;
 
@@ -74,7 +74,7 @@ TEE_Result tee_se_service_add_session(
 		struct tee_se_service *service,
 		struct tee_se_session *session)
 {
-	TEE_ASSERT(service != NULL && session != NULL);
+	assert(service && session);
 
 	mutex_lock(&service->mutex);
 	TAILQ_INSERT_TAIL(&service->opened_sessions, session, link);
@@ -101,7 +101,7 @@ void tee_se_service_close_session(
 		struct tee_se_service *service,
 		struct tee_se_session *session)
 {
-	TEE_ASSERT(service != NULL && session != NULL);
+	assert(service && session);
 
 	tee_se_session_close(session);
 
@@ -121,7 +121,7 @@ void tee_se_service_close_sessions_by_reader(
 {
 	struct tee_se_session *s;
 
-	TEE_ASSERT(service != NULL && proxy != NULL);
+	assert(service && proxy);
 
 	TAILQ_FOREACH(s, &service->opened_sessions, link) {
 		if (s->reader_proxy == proxy)
@@ -130,7 +130,7 @@ void tee_se_service_close_sessions_by_reader(
 }
 
 TEE_Result tee_se_service_close(
-		struct tee_se_service *service)
+		struct tee_se_service *service __unused)
 {
 	TEE_Result ret;
 	struct tee_se_service *h;
@@ -143,9 +143,7 @@ TEE_Result tee_se_service_close(
 		return ret;
 
 	utc = to_user_ta_ctx(sess->ctx);
-	TEE_ASSERT(service != NULL);
-	TEE_ASSERT(utc->se_service != NULL);
-
+	assert(utc->se_service);
 	h = utc->se_service;
 
 	/* clean up all sessions */

--- a/core/tee/se/session.c
+++ b/core/tee/se/session.c
@@ -25,17 +25,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <trace.h>
-#include <kernel/tee_common_unpg.h>
+#include <assert.h>
 #include <kernel/mutex.h>
+#include <stdlib.h>
+#include <sys/queue.h>
+#include <trace.h>
 
 #include <tee/se/reader.h>
 #include <tee/se/session.h>
 #include <tee/se/channel.h>
 #include <tee/se/iso7816.h>
-
-#include <stdlib.h>
-#include <sys/queue.h>
 
 #include "session_priv.h"
 #include "channel_priv.h"
@@ -44,8 +43,8 @@ struct tee_se_session *tee_se_session_alloc(
 		struct tee_se_reader_proxy *proxy)
 {
 	struct tee_se_session *s;
-	TEE_ASSERT(proxy != NULL);
 
+	assert(proxy);
 	s = malloc(sizeof(struct tee_se_session));
 	if (s) {
 		TAILQ_INIT(&s->channels);
@@ -74,7 +73,7 @@ bool tee_se_session_is_channel_exist(struct tee_se_session *s,
 TEE_Result tee_se_session_get_atr(struct tee_se_session *s,
 		uint8_t **atr, size_t *atr_len)
 {
-	TEE_ASSERT(s != NULL && atr != NULL && atr_len != NULL);
+	assert(s && atr && atr_len);
 
 	return tee_se_reader_get_atr(s->reader_proxy, atr, atr_len);
 }
@@ -85,7 +84,7 @@ TEE_Result tee_se_session_open_basic_channel(struct tee_se_session *s,
 	struct tee_se_channel *c;
 	TEE_Result ret;
 
-	TEE_ASSERT(s != NULL && channel != NULL && *channel == NULL);
+	assert(s && channel && !*channel);
 
 	if (tee_se_reader_is_basic_channel_locked(s->reader_proxy)) {
 		*channel = NULL;
@@ -120,7 +119,7 @@ TEE_Result tee_se_session_open_logical_channel(struct tee_se_session *s,
 	struct tee_se_channel *c;
 	TEE_Result ret;
 
-	TEE_ASSERT(s != NULL && channel != NULL && *channel == NULL);
+	assert(s && channel && !*channel);
 
 	ret = iso7816_open_available_logical_channel(s, &channel_id);
 	if (ret != TEE_SUCCESS)
@@ -154,7 +153,7 @@ void tee_se_session_close_channel(struct tee_se_session *s,
 {
 	int channel_id;
 
-	TEE_ASSERT(s != NULL && c != NULL);
+	assert(s && c);
 	channel_id = tee_se_channel_get_id(c);
 	if (channel_id > 0) {
 		iso7816_close_logical_channel(s, channel_id);
@@ -184,7 +183,7 @@ void tee_se_session_close(struct tee_se_session *s)
 {
 	struct tee_se_channel *c;
 
-	TEE_ASSERT(s != NULL);
+	assert(s);
 
 	TAILQ_FOREACH(c, &s->channels, link)
 		tee_se_session_close_channel(s, c);

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -286,7 +286,7 @@ size_t tee_fs_get_header_size(enum tee_fs_file_type type)
 		header_size = sizeof(struct block_header);
 		break;
 	default:
-		panic();
+		panic("Unknown file type");
 	}
 
 	return header_size;

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -40,8 +40,8 @@
 #include <initcall.h>
 #include <stdlib.h>
 #include <string.h>
+#include <kernel/panic.h>
 #include <kernel/tee_common_otp.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/tee_ta_manager.h>
 #include <tee/tee_cryp_utl.h>
 #include <tee/tee_cryp_provider.h>
@@ -286,8 +286,7 @@ size_t tee_fs_get_header_size(enum tee_fs_file_type type)
 		header_size = sizeof(struct block_header);
 		break;
 	default:
-		EMSG("Unknown file type, type=%d", type);
-		TEE_ASSERT(0);
+		panic();
 	}
 
 	return header_size;

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -26,10 +26,10 @@
  */
 
 #include <assert.h>
-#include <kernel/tee_common_unpg.h>
 #include <kernel/thread.h>
 #include <kernel/handle.h>
 #include <kernel/mutex.h>
+#include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <optee_msg.h>
 #include <stdio.h>
@@ -744,7 +744,8 @@ static int read_and_decrypt_file(int fd,
 	if (res < 0)
 		return res;
 
-	TEE_ASSERT(file_size >= header_size);
+	if (file_size < header_size)
+		panic();
 
 	ciphertext = malloc(file_size);
 	if (!ciphertext) {
@@ -1995,7 +1996,8 @@ static int ree_fs_rename(const char *old, const char *new)
 	}
 
 	/* finally, link the meta file, rename operation completed */
-	TEE_ASSERT(meta_filename);
+	if (!meta_filename)
+		panic();
 
 	/*
 	 * TODO: This will cause memory leakage at previous strdup()

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -745,7 +745,7 @@ static int read_and_decrypt_file(int fd,
 		return res;
 
 	if (file_size < header_size)
-		panic();
+		panic("file too short");
 
 	ciphertext = malloc(file_size);
 	if (!ciphertext) {
@@ -1997,7 +1997,7 @@ static int ree_fs_rename(const char *old, const char *new)
 
 	/* finally, link the meta file, rename operation completed */
 	if (!meta_filename)
-		panic();
+		panic("no meta file");
 
 	/*
 	 * TODO: This will cause memory leakage at previous strdup()

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -585,8 +585,7 @@ static int get_file_length(int fd, size_t *length)
 	size_t file_len;
 	int res;
 
-	TEE_ASSERT(length);
-
+	assert(length);
 	*length = 0;
 
 	res = ree_fs_lseek_ree(fd, 0, TEE_FS_SEEK_END);
@@ -1442,7 +1441,7 @@ static int ree_fs_open(TEE_Result *errno, const char *file, int flags, ...)
 	struct tee_fs_fd *fdp = NULL;
 	bool file_exist;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!file) {
@@ -1563,7 +1562,7 @@ static tee_fs_off_t ree_fs_lseek(TEE_Result *errno, int fd,
 	size_t filelen;
 	struct tee_fs_fd *fdp = handle_lookup(&fs_handle_db, fd);
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1631,7 +1630,7 @@ static int ree_fs_ftruncate_internal(TEE_Result *errno, struct tee_fs_fd *fdp,
 	struct tee_fs_file_meta *new_meta = NULL;
 	uint8_t *buf = NULL;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1756,7 +1755,7 @@ static int ree_fs_read(TEE_Result *errno, int fd, void *buf, size_t len)
 	uint8_t *data_ptr = buf;
 	struct tee_fs_fd *fdp = handle_lookup(&fs_handle_db, fd);
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {
@@ -1854,7 +1853,7 @@ static int ree_fs_write(TEE_Result *errno, int fd, const void *buf, size_t len)
 	size_t file_size;
 	int orig_pos;
 
-	assert(errno != NULL);
+	assert(errno);
 	*errno = TEE_SUCCESS;
 
 	if (!fdp) {

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -541,7 +541,7 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 
 
 	if ((size + offset < size) || (size + offset > RPMB_DATA_SIZE))
-		panic();
+		panic("invalid size or offset");
 
 	if (!fek) {
 		/* Block is not encrypted (not a file data block) */
@@ -2183,7 +2183,7 @@ static int rpmb_fs_write(TEE_Result *errno, int fd, const void *buf,
 		goto out;
 
 	if (fh->fat_entry.flags & FILE_IS_LAST_ENTRY)
-		panic();
+		panic("invalid last entry flag");
 
 	end = fh->pos + size;
 	start_addr = fh->fat_entry.start_address + fh->pos;

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -29,6 +29,7 @@
 #include <kernel/tee_common.h>
 #include <kernel/handle.h>
 #include <kernel/mutex.h>
+#include <kernel/panic.h>
 #include <kernel/tee_common_otp.h>
 #include <kernel/thread.h>
 #include <optee_msg.h>
@@ -538,7 +539,9 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 {
 	uint8_t *tmp __maybe_unused;
 
-	TEE_ASSERT(size + offset <= RPMB_DATA_SIZE);
+
+	if ((size + offset < size) || (size + offset > RPMB_DATA_SIZE))
+		panic();
 
 	if (!fek) {
 		/* Block is not encrypted (not a file data block) */
@@ -568,7 +571,6 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 			memcpy(out, tmp + offset, size);
 			free(tmp);
 		} else {
-			TEE_ASSERT(!offset);
 			decrypt_block(out, frm->data, blk_idx, fek);
 		}
 #else
@@ -2180,7 +2182,8 @@ static int rpmb_fs_write(TEE_Result *errno, int fd, const void *buf,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	TEE_ASSERT(!(fh->fat_entry.flags & FILE_IS_LAST_ENTRY));
+	if (fh->fat_entry.flags & FILE_IS_LAST_ENTRY)
+		panic();
 
 	end = fh->pos + size;
 	start_addr = fh->fat_entry.start_address + fh->pos;

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -43,8 +43,6 @@
 #include <kernel/chip_services.h>
 #include <kernel/static_ta.h>
 
-#include <assert.h>
-
 vaddr_t tee_svc_uref_base;
 
 void syscall_log(const void *buf __maybe_unused, size_t len __maybe_unused)

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -24,6 +24,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <assert.h>
 #include <tee_api_types.h>
 #include <kernel/tee_ta_manager.h>
 #include <utee_defines.h>

--- a/lib/libmpa/mpa_io.c
+++ b/lib/libmpa/mpa_io.c
@@ -24,8 +24,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "mpa.h"
-#include "assert.h"
+
+#include <assert.h>
+#include <mpa.h>
+#include <trace.h>
 
 /*
  * Big #ifdef to get rid of string conversion routines
@@ -318,7 +320,12 @@ int mpa_set_str(mpanum dest, const char *digitstr)
 
 	/* + 1 since we have one character in 'c' */
 	dlen = (int)(endp - digitstr) + 1;
-	assert(dlen <= MPA_STR_MAX_SIZE);
+	if (dlen > MPA_STR_MAX_SIZE) {
+		EMSG("data len (%d) > max size (%d)", dlen, MPA_STR_MAX_SIZE);
+		retval = -1;
+		goto cleanup;
+	}
+
 	/* convert to a buffer of bytes */
 	bufidx = 0;
 	while (__mpa_is_char_in_base(16, c)) {
@@ -331,9 +338,14 @@ int mpa_set_str(mpanum dest, const char *digitstr)
 		retval = -1;
 		goto cleanup;
 	}
-
-	assert((__mpa_digitstr_to_binary_wsize_base_16(bufidx) <=
-		__mpanum_alloced(dest)));
+	if (__mpa_digitstr_to_binary_wsize_base_16(bufidx) >
+						__mpanum_alloced(dest)) {
+		EMSG("binary buffer (%d) > alloced buffer (%d)",
+				__mpa_digitstr_to_binary_wsize_base_16(bufidx),
+				__mpanum_alloced(dest));
+		retval = -1;
+		goto cleanup;
+	}
 
 	retval = bufidx;
 	w = dest->d;
@@ -386,7 +398,7 @@ char *mpa_get_str(char *str, int mode, const mpanum n)
 {
 	char *s = str;
 
-	assert(str != 0);
+	assert(str);
 
 	/* insert a minus sign */
 	if (__mpanum_sign(n) == MPA_NEG_SIGN) {

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -24,16 +24,21 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <assert.h>
 #include <compiler.h>
+#include <trace.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
 #include <utee_syscalls.h>
 
 void _assert_log(const char *expr __maybe_unused,
-		 const char *file __maybe_unused, int line __maybe_unused)
+		 const char *file __maybe_unused,
+		 const int line __maybe_unused,
+		 const char *func __maybe_unused)
 {
-	EMSG("Assertion '%s' failed at %s:%d", expr, file, line);
+	EMSG_RAW("assertion '%s' failed at %s:%d in %s()",
+				expr, file, line, func);
 }
 
 void __noreturn _assert_break(void)

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -31,8 +31,6 @@
 #include <utee_syscalls.h>
 #include "tee_api_private.h"
 
-#include <assert.h>
-
 #define TEE_USAGE_DEFAULT   0xffffffff
 
 #define TEE_ATTR_BIT_VALUE                  (1 << 29)

--- a/lib/libutee/tui/font.c
+++ b/lib/libutee/tui/font.c
@@ -25,15 +25,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <util.h>
+
 #include "font.h"
-#include "utf8.h"
-#include "default_regular.h"
 #include "default_bold.h"
-#include <trace.h>
-#include <assert.h>
+#include "default_regular.h"
+#include "utf8.h"
 
 #define UCP_CARRIAGE_RETURN	0x000D
 #define UCP_TUI_BOLD		0xE000

--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -32,6 +32,10 @@
 void _assert_break(void) __noreturn;
 void _assert_log(const char *expr, const char *file, int line);
 
+/* assert() specs: generates a log but does not panic if NDEBUG is defined */
+#ifdef NDEBUG
+#define assert(expr)	do { } while (0)
+#else
 #define assert(expr) \
 	do { \
 		if (!(expr)) { \
@@ -39,7 +43,7 @@ void _assert_log(const char *expr, const char *file, int line);
 			_assert_break(); \
 		} \
 	} while (0)
-
+#endif
 
 #define COMPILE_TIME_ASSERT(x) \
 	do { \

--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -28,9 +28,11 @@
 #define ASSERT_H
 
 #include <compiler.h>
+#include <trace.h>
 
 void _assert_break(void) __noreturn;
-void _assert_log(const char *expr, const char *file, int line);
+void _assert_log(const char *expr, const char *file, const int line,
+			const char *func);
 
 /* assert() specs: generates a log but does not panic if NDEBUG is defined */
 #ifdef NDEBUG
@@ -39,7 +41,7 @@ void _assert_log(const char *expr, const char *file, int line);
 #define assert(expr) \
 	do { \
 		if (!(expr)) { \
-			_assert_log(#expr, __FILE__, __LINE__); \
+			_assert_log(#expr, __FILE__, __LINE__, __func__); \
 			_assert_break(); \
 		} \
 	} while (0)


### PR DESCRIPTION
Implementation of assert() shall honor NDEBUG.
Review use of assert() and TEE_ASSERT() since assert() may not halt execution.
For clarity, TEE_ASSERT() is renamed panic_trace().
Review panic and assert traces content.