### PR TITLE
Persistent objects : save informations after close

### DIFF
--- a/core/include/tee/tee_pobj.h
+++ b/core/include/tee/tee_pobj.h
@@ -40,6 +40,7 @@ struct tee_pobj {
 	void *obj_id;
 	uint32_t obj_id_len;
 	uint32_t flags;
+	void *head;
 	/* Filesystem handling this object */
 	const struct tee_file_operations *fops;
 };

--- a/core/tee/tee_pobj.c
+++ b/core/tee/tee_pobj.c
@@ -117,6 +117,7 @@ TEE_Result tee_pobj_get(TEE_UUID *uuid, void *obj_id, uint32_t obj_id_len,
 	o->refcnt = 1;
 	memcpy(&o->uuid, uuid, sizeof(TEE_UUID));
 	o->flags = flags;
+	o->head = NULL;
 	o->fops = fops;
 
 	o->obj_id = malloc(obj_id_len);
@@ -141,6 +142,7 @@ TEE_Result tee_pobj_release(struct tee_pobj *obj)
 	obj->refcnt--;
 	if (obj->refcnt == 0) {
 		TAILQ_REMOVE(&tee_pobjs, obj, link);
+		free(obj->head);
 		free(obj->obj_id);
 		free(obj);
 	}


### PR DESCRIPTION
When persistent objects are created, a header is written
into storage with its sizes. However, if additional data
is written into the persistent object, the header is not
updated properly

This fix adds a new pointer to save a copy of the header
in struct tee_pobj when it is opened or created. If
additional data is written during TEE_WriteObjectData call,
it will re-update the header in storage

Signed-off-by: Hoi-Ho Chan hoiho.chan@gmail.com
