### PR TITLE
mk: add library common makefile support

### DIFF
--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -8,6 +8,17 @@ all:
 include $(ta-dev-kit-dir)/mk/conf.mk
 
 binary := $(BINARY)
+libname := $(LIBNAME)
+
+ifneq ($(BINARY),)
+ifneq ($(LIBNAME),)
+$(error You can only specify one of BINARY or LIBNAME)
+endif
+else
+ifeq ($(LIBNAME),)
+$(error You must specify one of BINARY or LIBNAME)
+endif
+endif
 
 ifneq ($O,)
 out-dir := $O
@@ -65,9 +76,24 @@ clean:
 
 subdirs = .
 include  $(ta-dev-kit-dir)/mk/subdir.mk
+
+#the build target is ta
+ifneq ($(binary),)
 vpath %.c $(ta-dev-kit-dir)/src
 srcs += user_ta_header.c
+endif
 
 include  $(ta-dev-kit-dir)/mk/gcc.mk
 include  $(ta-dev-kit-dir)/mk/compile.mk
+ifneq ($(binary),)
 include  $(ta-dev-kit-dir)/mk/link.mk
+else
+ifneq ($(libname),)
+all: $(libname).a
+cleanfiles += $(libname).a
+
+$(libname).a: $(objs)
+	@echo '  AR      $@'
+	$(q)rm -f $@ && $(AR$(sm)) rcs -o $@ $^
+endif
+endif


### PR DESCRIPTION
 It is not always suitable to place the third party library source in the optee-os directory, so we provide exported common library makefile support.
Usage as follow: 
TA Makefile:
BINARY :=  xxx
LIB Makefile:
LIBNAME := libxxx
And  xxx.ta or libxxx.a will be the target. 