### PR TITLE
init support for VxWorks-7 on Freescale i.MX6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -168,6 +168,7 @@ script:
   - $make CFG_SQL_FS=y
   - $make CFG_WITH_PAGER=y CFG_WITH_LPAE=y CFG_RPMB_FS=y CFG_SQL_FS=y CFG_DT=y CFG_PS2MOUSE=y CFG_PL050=y CFG_PL111=y CFG_TEE_CORE_LOG_LEVEL=1 CFG_TEE_CORE_DEBUG=y DEBUG=1
   - $make CFG_WITH_PAGER=y CFG_WITH_LPAE=y CFG_RPMB_FS=y CFG_SQL_FS=y CFG_DT=y CFG_PS2MOUSE=y CFG_PL050=y CFG_PL111=y CFG_TEE_CORE_LOG_LEVEL=0 CFG_TEE_CORE_DEBUG=n DEBUG=0
+  - $make CFG_BUILT_IN_ARGS=y CFG_PAGEABLE_ADDR=0 CFG_NS_ENTRY_ADDR=0 CFG_DT_ADDR=0 CFG_DT=y
 
   # QEMU-ARMv8A
   - $make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y
@@ -187,6 +188,10 @@ script:
 
   # i.MX6UL 14X14 EVK
   - $make PLATFORM=imx-mx6ulevk
+
+  # i.MX6Quad SABRE
+  - $make PLATFORM=imx-mx6qsabrelite
+  - $make PLATFORM=imx-mx6qsabresd
 
   # Texas Instruments dra7xx
   - $make PLATFORM=ti-dra7xx

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,8 @@ for these platforms.
 | Allwinner A80 Board			|`Sun Yangbang <sunny@allwinnertech.com>`|
 | ARM Juno Board			|`Linaro <op-tee@linaro.org>`|
 | FSL ls1021a				|`Sumit Garg <sumit.garg@freescale.com>`|
+| FSL i.MX6 Quad SABRE Lite Board	|`Yan Yan <yan.yan@windriver.com>`|
+| FSL i.MX6 Quad SABRE SD Board		|`Yan Yan <yan.yan@windriver.com>`|
 | FSL i.MX6 UltraLite EVK Board		|`Peng Fan <peng.fan@nxp.com>`|
 | ARM Foundation FVP			|`Linaro <op-tee@linaro.org>`|
 | HiKey Board (HiSilicon Kirin 620)	|`Linaro <op-tee@linaro.org>`|

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ platforms have different sub-maintainers, please refer to the file
 | [Allwinner A80 Board](http://www.allwinnertech.com/en/clq/processora/A80.html)|`PLATFORM=sunxi`| No |
 | [ARM Juno Board](http://www.arm.com/products/tools/development-boards/versatile-express/juno-arm-development-platform.php) |`PLATFORM=vexpress-juno`| Yes |
 | [FSL ls1021a](http://www.freescale.com/tools/embedded-software-and-tools/hardware-development-tools/tower-development-boards/mcu-and-processor-modules/powerquicc-and-qoriq-modules/qoriq-ls1021a-tower-system-module:TWR-LS1021A?lang_cd=en)|`PLATFORM=ls-ls1021atwr`| Yes |
+| [FSL i.MX6 Quad SABRE Lite Board](https://boundarydevices.com/product/sabre-lite-imx6-sbc/) |`PLATFORM=imx`| Yes |
+| [FSL i.MX6 Quad SABRE SD Board](http://www.nxp.com/products/software-and-tools/hardware-development-tools/sabre-development-system/sabre-board-for-smart-devices-based-on-the-i.mx-6quad-applications-processors:RD-IMX6Q-SABRE) |`PLATFORM=imx`| Yes |
 | [FSL i.MX6 UltraLite EVK Board](http://www.freescale.com/products/arm-processors/i.mx-applications-processors-based-on-arm-cores/i.mx-6-processors/i.mx6qp/i.mx6ultralite-evaluation-kit:MCIMX6UL-EVK) |`PLATFORM=imx`| Yes |
 | [ARM Foundation FVP](http://www.arm.com/fvp) |`PLATFORM=vexpress-fvp`| Yes |
 | [HiSilicon D02](http://open-estuary.org/d02-2)|`PLATFORM=d02`| No |

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -1,5 +1,14 @@
 CFG_LTC_OPTEE_THREAD ?= y
 
+# When used together with ARM Trusted FW, arguments shall
+# come from the Firwmware. Do not allow built-in arguments
+
+ifeq ($(CFG_BUILT_IN_ARGS),y)
+ifeq ($(CFG_WITH_ARM_TRUSTED_FW),y)
+$(error error: CFG_BUILD_IN_ARGS is incompatible with CFG_WITH_ARM_TRUSTED_FW)
+endif
+endif
+
 ifeq ($(CFG_ARM64_core),y)
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64
 CFG_KERN_LINKER_ARCH ?= aarch64

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -47,6 +47,10 @@ void init_sec_mon(unsigned long nsec_entry);
 
 const struct thread_handlers *generic_boot_get_handlers(void);
 
+#ifdef CFG_BOOT_SECONDARY_REQUEST
+extern uint32_t ns_entry_addrs[];
+#endif
+
 extern uint8_t __text_init_start[];
 extern uint8_t __text_start[];
 extern initcall_t __initcall_start;

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -326,7 +326,6 @@
 #define OPTEE_SMC_DISABLE_SHM_CACHE \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_DISABLE_SHM_CACHE)
 
-
 /*
  * Enable cache of shared memory objects
  *
@@ -351,6 +350,39 @@
 #define OPTEE_SMC_FUNCID_ENABLE_SHM_CACHE	11
 #define OPTEE_SMC_ENABLE_SHM_CACHE \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_ENABLE_SHM_CACHE)
+
+/*
+ * Release of secondary cores
+ *
+ * OP-TEE in secure world is in charge of the release process of secondary
+ * cores. The Rich OS issue the this request to ask OP-TEE to boot up the
+ * secondary cores, go through the OP-TEE per-core initialization, and then
+ * switch to the Non-seCure world with the Rich OS provided entry address.
+ * The secondary cores enter Non-Secure world in SVC mode, with Thumb, FIQ,
+ * IRQ and Abort bits disabled.
+ *
+ * Call register usage:
+ * a0	SMC Function ID, OPTEE_SMC_BOOT_SECONDARY
+ * a1	Index of secondary core to boot
+ * a2	Upper 32 bits of a 64-bit Non-Secure world entry physical address
+ * a3	Lower 32 bits of a 64-bit Non-Secure world entry physical address
+ * a4-7	Not used
+ *
+ * Normal return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1-7	Preserved
+ *
+ * Error return:
+ * a0	OPTEE_SMC_RETURN_EBADCMD		Core index out of range
+ * a1-7	Preserved
+ *
+ * Not idle return register usage:
+ * a0	OPTEE_SMC_RETURN_EBUSY
+ * a1-7	Preserved
+ */
+#define OPTEE_SMC_FUNCID_BOOT_SECONDARY  12
+#define OPTEE_SMC_BOOT_SECONDARY \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_BOOT_SECONDARY)
 
 /*
  * Resume from RPC (for example after processing an IRQ)

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -72,6 +72,10 @@
 
 #define PADDR_INVALID		ULONG_MAX
 
+#ifdef CFG_BOOT_SECONDARY_REQUEST
+uint32_t ns_entry_addrs[CFG_TEE_CORE_NB_CORE] __data;
+#endif
+
 #ifdef CFG_BOOT_SYNC_CPU
 /*
  * Array used when booting, to synchronize cpu.

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -165,10 +165,12 @@ UNWIND(	.cantunwind)
 	mov	r6, r0
 	mov	r7, r1
 	mov	r8, r2
-#if defined(CFG_WITH_PAGER) || defined (CFG_DT)
+
+#if !defined(CFG_BUILT_IN_ARGS) && (defined(CFG_WITH_PAGER) || defined (CFG_DT))
 	/*
 	 * r0/r2 are used for different purposes by GDB boot and pager/DT
-	 * so these configurations are incompatible
+	 * so these configurations are incompatible. however, if built-in
+	 * argumements are used, r0/r2 are free for GDB boot use.
 	 */
 #error CFG_TEE_GDB_BOOT and (CFG_WITH_PAGER || CFG_DT) are incompatible
 #endif
@@ -328,9 +330,15 @@ shadow_stack_access_ok:
 	bl	cpu_mmu_enable_icache
 	bl	cpu_mmu_enable_dcache
 
+#if defined (CFG_BUILT_IN_ARGS)
+    ldr r0, =CFG_PAGEABLE_ADDR
+    ldr r1, =CFG_NS_ENTRY_ADDR
+    ldr r2, =CFG_DT_ADDR
+#else
 	mov	r0, r4		/* pageable part address */
 	mov	r1, r5		/* ns-entry address */
 	mov	r2, r6		/* DT address */
+#endif
 	bl	generic_boot_init_primary
 	mov	r4, r0		/* save entry test vector */
 
@@ -451,6 +459,11 @@ UNWIND(	.cantunwind)
 
 	bl	plat_cpu_reset_late
 
+#if defined (CFG_BOOT_SECONDARY_REQUEST)
+	/* if L1 is not invalidated before, do it here */
+	bl	arm_cl1_d_invbysetway
+#endif
+
 	bl	core_init_mmu_regs
 	bl	cpu_mmu_enable
 	bl	cpu_mmu_enable_icache
@@ -459,7 +472,15 @@ UNWIND(	.cantunwind)
 	bl	get_core_pos
 	bl	cpu_is_ready
 
+#if defined (CFG_BOOT_SECONDARY_REQUEST)
+	/* get ns entry from ns_entry_addrs array */
+	bl  get_core_pos
+	ldr r1, =ns_entry_addrs
+	add r1, r1, r0, lsl #2	/* size of uint32_t */
+	ldr r0, [r1]
+#else
 	mov	r0, r5		/* ns-entry address */
+#endif
 	bl	generic_boot_init_secondary
 
 	mov	r0, #TEESMC_OPTEED_RETURN_ENTRY_DONE

--- a/core/arch/arm/plat-imx/a9_plat_init.S
+++ b/core/arch/arm/plat-imx/a9_plat_init.S
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ * Copyright (c) 2016, Wind River Systems.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Entry points for the A9 inits, A9 revision specific or not.
+ * It is assume no stack is available when these routines are called.
+ * It is assume each routine is called with return address in LR
+ * and with ARM registers R0, R1, R2, R3 being scratchable.
+ */
+
+#include <arm32.h>
+#include <arm32_macros.S>
+#include <asm.S>
+#include <kernel/tz_ssvce_def.h>
+#include <kernel/unwind.h>
+#include <platform_config.h>
+
+.section .text
+.balign 4
+.code 32
+
+/*
+ * void arm_cl2_config(vaddr_t pl310_base) - Memory Cache Level2 Configuration
+ *
+ * Use scratables registers R0-R3.
+ * No stack usage.
+ * LR store return address.
+ * Trap CPU in case of error.
+ */
+FUNC arm_cl2_config , :
+UNWIND(	.fnstart)
+
+	/* disable PL310 ctrl */
+	mov  r1, #0x0
+	str  r1, [r0, #PL310_CTRL]
+
+	/*
+	 * TAG RAM Control Register
+	 *
+	 * bit[10:8]:1 - 2 cycle of write accesses latency
+	 * bit[6:4]:1 - 2 cycle of read accesses latency
+	 * bit[2:0]:1 - 2 cycle of setup latency
+	 */
+	ldr  r2, [r0, #PL310_TAG_RAM_CTRL]
+	movw r1, #0xf888
+	movt r1, #0xffff
+	and  r2,r2,r1
+	movw r1, #0xf999
+	movt r1, #0xffff
+	orr  r2,r2,r1
+	str  r2, [r0, #PL310_TAG_RAM_CTRL]
+
+	/*
+	 * DATA RAM Control Register
+	 *
+	 * bit[10:8]:2 - 3 cycle of write accesses latency
+	 * bit[6:4]:2 - 3 cycle of read accesses latency
+	 * bit[2:0]:2 - 3 cycle of setup latency
+	 */
+	ldr  r2, [r0, #PL310_DATA_RAM_CTRL]
+	movw r1, #0xf888
+	movt r1, #0xffff
+	and  r2,r2,r1
+	movw r1, #0xfaaa
+	movt r1, #0xffff
+	orr  r2,r2,r1
+	str  r2, [r0, #PL310_DATA_RAM_CTRL]
+
+	/*
+	 * Auxiliary Control Register
+	 *
+	 * I/Dcache prefetch enabled (bit29:28=2b11)
+	 * NS can access interrupts (bit27=1)
+	 * NS can lockown cache lines (bit26=1)
+	 * Pseudo-random replacement policy (bit25=0)
+	 * Force write allocated (default)
+	 * Shared attribute internally ignored (bit22=1, bit13=0)
+	 * Parity disabled (bit21=0)
+	 * Event monitor disabled (bit20=0)
+	 * 64kB ways, 16-way associativity (bit19:17=3b011 bit16=1)
+	 * Store buffer device limitation enabled (bit11=1)
+	 * Cacheable accesses have high prio (bit10=0)
+	 * Full Line Zero (FLZ) disabled (bit0=0)
+	 */
+	movw r1, #0x0800
+	movt r1, #0x3C47
+	str  r1, [r0, #PL310_AUX_CTRL]
+
+	/*
+	 * Prefetch Control Register
+	 *
+	 * Double linefill disabled (bit30=0)
+	 * I/D prefetch enabled (bit29:28=2b11)
+	 * Prefetch drop enabled (bit24=1)
+	 * Incr double linefill disable (bit23=0)
+	 * Prefetch offset = 7 (bit4:0)
+	 */
+	movw r1, #0x0007
+	movt r1, #0x3100
+	str  r1, [r0, #PL310_PREFETCH_CTRL]
+
+	/*
+	 * Power Register = 0x00000003
+	 *
+	 * Dynamic clock gating enabled
+	 * Standby mode enabled
+	 */
+	movw r1, #0x0003
+	movt r1, #0x0000
+	str  r1, [r0, #PL310_POWER_CTRL]
+
+	/* invalidate all cache ways */
+
+	movw r1, #0xFFFF
+	movt r1, #0x0000
+	str  r1, [r0, #PL310_INV_BY_WAY]
+
+	mov pc, lr
+UNWIND(	.fnend)
+END_FUNC arm_cl2_config
+/* End of arm_cl2_config */
+
+
+/*
+ * void arm_cl2_enable(vaddr_t pl310_base) - Memory Cache Level2 Enable Function
+ *
+ * If PL310 supports FZLW, enable also FZL in A9 core
+ *
+ * Use scratables registers R0-R3.
+ * No stack usage.
+ * LR store return address.
+ * Trap CPU in case of error.
+ * TODO: to be moved to PL310 code (tz_svce_pl310.S ?)
+ */
+FUNC arm_cl2_enable , :
+UNWIND(	.fnstart)
+
+
+	/* Enable PL310 ctrl -> only set lsb bit */
+	mov  r1, #0x1
+	str  r1, [r0, #PL310_CTRL]
+
+	/* if L2 FLZW enable, enable in L1 */
+	ldr  r1, [r0, #PL310_AUX_CTRL]
+	tst  r1, #(1 << 0) /* test AUX_CTRL[FLZ] */
+	read_actlr r0
+	orrne r0, r0, #(1 << 3) /* enable ACTLR[FLZW] */
+	write_actlr r0
+
+	mov pc, lr
+UNWIND(	.fnend)
+END_FUNC arm_cl2_enable
+
+/*
+ * Cortex A9 configuration early configuration
+ *
+ * Use scratables registers R0-R3.
+ * No stack usage.
+ * LR store return address.
+ * Trap CPU in case of error.
+ */
+FUNC plat_cpu_reset_early , :
+UNWIND(	.fnstart)
+
+	/*
+	 * Mandated HW config loaded
+	 *
+	 * SCTLR = 0x00004000
+	 * - Round-Robin replac. for icache, btac, i/duTLB (bit14: RoundRobin)
+	 *
+	 * ACTRL = 0x00000041
+	 * - core always in full SMP (FW bit0=1, SMP bit6=1)
+	 * - L2 write full line of zero disabled (bit3=0)
+	 *   (keep WFLZ low. Will be set once outer L2 is ready)
+	 *
+	 * NSACR = 0x00020C00
+	 * - NSec cannot change ACTRL.SMP (NS_SMP bit18=0)
+	 * - Nsec can lockdown TLB (TL bit17=1)
+	 * - NSec cannot access PLE (PLE bit16=0)
+	 * - NSec can use SIMD/VFP (CP10/CP11) (bit15:14=2b00, bit11:10=2b11)
+	 *
+	 * PCR = 0x00000001
+	 * - no change latency, enable clk gating
+	 */
+
+	movw r0, #0x4000
+	movt r0, #0x0000
+	write_sctlr r0
+
+	movw r0, #0x0041
+	movt r0, #0x0000
+	write_actlr r0
+
+	movw r0, #0x0C00
+	movt r0, #0x0002
+	write_nsacr r0
+
+	movw r0, #0x0000
+	movt r0, #0x0001
+	write_pcr r0
+
+	/*
+	 * GIC configuration
+	 *
+	 * per-CPU interrupts config are in accordance with GIC driver:
+	 *
+	 * ID0-ID7(SGI)   for Non-secure interrupts
+	 * ID8-ID15(SGI)  for Secure interrupts.
+	 * All PPI config as Non-secure interrupts.
+	 *
+	 * Register ICDISR0 = 0xFFFF00FF
+	 *
+	 * Register ICCPMR = 0x80
+	 */
+
+	ldr  r0, =GIC_DIST_BASE
+	mov  r1, #0xFFFF00FF
+	str  r1, [r0, #GIC_DIST_ISR0]
+
+	ldr  r0, =GIC_CPU_BASE
+	mov  r1, #0x80
+	str  r1, [r0, #CORE_ICC_ICCPMR]
+
+	mov pc, lr
+UNWIND(	.fnend)
+END_FUNC plat_cpu_reset_early
+
+/*
+ * A9 secured config, needed only from a single core
+ *
+ * Use scratables registers R0-R3.
+ * No stack usage.
+ * LR store return address.
+ * Trap CPU in case of error.
+ *
+ * TODO: size optim in code
+ */
+FUNC plat_cpu_reset_late , :
+UNWIND(	.fnstart)
+
+	read_mpidr r0
+	ands r0, #3
+	beq _boot_late_primary_cpu
+
+_boot_late_secondary_cpu:
+	mov pc, lr
+
+_boot_late_primary_cpu:
+
+	/*
+	 * Snoop Control Unit configuration
+	 *
+	 * SCU is enabled with filtering off.
+	 * Both Secure/Unsecure can access SCU and timers
+	 *
+	 * 0x00 SCUControl
+	 * 0x04 SCUConfiguration
+	 * 0x0C SCUInvalidateAll (Secure cfg)
+	 * 0x40 FilteringStartAddress = 0x40000000
+	 * 0x44 FilteeringEndAddress - 0x80000000
+	 * 0x50 SCUAccessControl
+	 * 0x54 SCUSecureAccessControl
+	 */
+
+	/* Invalidate all register */
+	ldr  r0, =SCU_BASE
+	movw r1, #0xFFFF
+	movt r1, #0xFFFF
+	str  r1, [r0, #SCU_INV_SEC]
+
+	/*
+	 * SCU Access Register : SAC = 0x0000000F
+	 * - both secure CPU access SCU
+	 */
+	ldr  r0, =SCU_BASE
+	movw r1, #0x000F
+	movt r1, #0x0000
+	str  r1, [r0, #SCU_SAC]
+
+	/*
+	 * SCU NonSecure Access Register : SNSAC : 0x00000FFF
+	 * - both nonsec cpu access SCU, private and global timer
+	 */
+	movw r1, #0x0FFF
+	movt r1, #0x0000
+	str  r1, [r0, #SCU_NSAC]
+
+	/* Enable SCU */
+	ldr  r0, =SCU_BASE
+	movw r2, #0x0001
+	movt r2, #0x0000
+	ldr  r1, [r0, #SCU_CTRL]
+	orr  r1, r1, r2
+	str  r1, [r0, #SCU_CTRL]
+
+	/*
+	 * Disallow NSec to mask FIQ [bit4: FW=0]
+	 * Allow NSec to manage Imprecise Abort [bit5: AW=1]
+	 * Imprecise Abort trapped to Abort Mode [bit3: EA=0]
+	 * In Sec world, FIQ trapped to FIQ Mode [bit2: FIQ=0]
+	 * IRQ always trapped to IRQ Mode [bit1: IRQ=0]
+	 * Secure World [bit0: NS=0]
+	 */
+	mov r0, #SCR_AW
+	write_scr r0		/* write Secure Configuration Register */
+
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
+
+	/* configure imx6 CSU */
+
+	/* first grant access of all peripherals to NS... */
+	ldr r0, =CSU_CSL_START
+	ldr r1, =CSU_CSL_END
+	ldr r2, =0x00FF00FF
+
+loop_csu:
+	str r2, [r0]
+	add r0, r0, #4
+	cmp r0, r1
+	bne loop_csu
+
+	/* then restrict key peripherals */
+
+	ldr r0, =CSU_CSL_16 /* TZASC1,TZASC2 */
+	ldr r2, =0x00330033
+	str r2, [r0]
+
+	/* TODO: TZASC init */
+
+#endif
+	mov pc, lr
+UNWIND(	.fnend)
+END_FUNC plat_cpu_reset_late
+

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -1,4 +1,11 @@
+PLATFORM_FLAVOR ?= mx6ulevk
+
+ifeq ($(PLATFORM_FLAVOR),mx6ulevk)
 arm32-platform-cpuarch		:= cortex-a7
+endif
+ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd))
+arm32-platform-cpuarch		:= cortex-a9
+endif
 arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags		+= -mcpu=$(arm32-platform-cpuarch)
 core_arm32-platform-aflags	+= -mfpu=neon
@@ -8,8 +15,16 @@ $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_IMX_UART,y)
 $(call force,CFG_PM_STUBS,y)
-$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
+ifeq ($(PLATFORM_FLAVOR),mx6ulevk)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+endif
+ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd))
+$(call force,CFG_PL310,y)
+$(call force,CFG_PL310_LOCKED,y)
+$(call force,CFG_SECURE_TIME_SOURCE_REE,y)
+CFG_BOOT_SECONDARY_REQUEST ? = y
+endif
 
 ta-targets = ta_arm32
 

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * Copyright (c) 2016, Wind River Systems.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -27,6 +29,7 @@
 
 #include <console.h>
 #include <drivers/imx_uart.h>
+#include <io.h>
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
@@ -34,14 +37,22 @@
 #include <mm/core_memprot.h>
 #include <platform_config.h>
 #include <stdint.h>
+#include <sm/optee_smc.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
+#include <drivers/gic.h>
+#include <kernel/tz_ssvce_pl310.h>
+#endif
+
 static void main_fiq(void);
+static void platform_tee_entry_fast(struct thread_smc_args *args);
 
 static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
-	.fast_smc = tee_entry_fast,
+	.fast_smc = platform_tee_entry_fast,
 	.fiq = main_fiq,
 	.cpu_on = pm_panic,
 	.cpu_off = pm_panic,
@@ -50,6 +61,16 @@ static const struct thread_handlers handlers = {
 	.system_off = pm_panic,
 	.system_reset = pm_panic,
 };
+
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
+static struct gic_data gic_data;
+
+register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CORE_MMU_DEVICE_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_DEVICE_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_DEVICE_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, SRC_BASE, CORE_MMU_DEVICE_SIZE);
+#endif
 
 const struct thread_handlers *generic_boot_get_handlers(void)
 {
@@ -96,4 +117,93 @@ void console_flush(void)
 	vaddr_t base = console_base();
 
 	imx_uart_flush_tx_fifo(base);
+}
+
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
+#ifdef CFG_BOOT_SECONDARY_REQUEST
+static vaddr_t src_base(void)
+{
+	static void *va __data; /* in case it's used before .bss is cleared */
+
+	if (cpu_mmu_enabled()) {
+		if (!va)
+			va = phys_to_virt(SRC_BASE, MEM_AREA_IO_SEC);
+		return (vaddr_t)va;
+	}
+	return SRC_BASE;
+}
+
+static int platform_smp_boot(size_t core_idx, uint32_t entry)
+{
+	uint32_t val;
+	vaddr_t va = src_base();
+
+	if ((core_idx == 0) || (core_idx >= CFG_TEE_CORE_NB_CORE))
+		return OPTEE_SMC_RETURN_EBADCMD;
+
+	/* set secondary cores' NS entry addresses */
+
+	ns_entry_addrs[core_idx] = entry;
+	cache_maintenance_l1(DCACHE_AREA_CLEAN,
+		&ns_entry_addrs[core_idx],
+		sizeof(uint32_t));
+	cache_maintenance_l2(L2CACHE_AREA_CLEAN,
+		(paddr_t)&ns_entry_addrs[core_idx],
+		sizeof(uint32_t));
+
+	/* boot secondary cores from OP-TEE load address */
+
+	write32((uint32_t)CFG_TEE_LOAD_ADDR, va + SRC_GPR1 + core_idx * 8);
+
+	/* release secondary core */
+
+	val = read32(va + SRC_SCR);
+	val = val | BIT32(SRC_SCR_ENABLE_OFFSET + (core_idx - 1));
+	write32(val, va + SRC_SCR);
+	return OPTEE_SMC_RETURN_OK;
+}
+#endif /* CFG_BOOT_SECONDARY_REQUEST */
+
+vaddr_t pl310_base(void)
+{
+	static void *va __data; /* in case it's used before .bss is cleared */
+
+	if (cpu_mmu_enabled()) {
+		if (!va)
+			va = phys_to_virt(PL310_BASE, MEM_AREA_IO_SEC);
+		return (vaddr_t)va;
+	}
+	return PL310_BASE;
+}
+
+void main_init_gic(void)
+{
+	vaddr_t gicc_base;
+	vaddr_t gicd_base;
+
+	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
+					  MEM_AREA_IO_SEC);
+	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
+					  MEM_AREA_IO_SEC);
+
+	if (!gicc_base || !gicd_base)
+		panic();
+
+	/* Initialize GIC */
+	gic_init(&gic_data, gicc_base, gicd_base);
+
+	itr_init(&gic_data.chip);
+}
+#endif
+
+static void platform_tee_entry_fast(struct thread_smc_args *args)
+{
+#ifdef CFG_BOOT_SECONDARY_REQUEST
+	if (args->a0 == OPTEE_SMC_BOOT_SECONDARY) {
+		args->a0 = platform_smp_boot(args->a1, (uint32_t)(args->a3));
+		return;
+	}
+#endif /* CFG_BOOT_SECONDARY_REQUEST */
+	tee_entry_fast(args);
 }

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * Copyright (c) 2016, Wind River Systems.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -30,15 +32,17 @@
 
 #define STACK_ALIGNMENT			64
 
+/* For i.MX 6UltraLite EVK board */
+
+#if defined(PLATFORM_FLAVOR_mx6ulevk)
+
 #ifdef CFG_WITH_PAGER
-#error "Pager not supported for platform imx"
+#error "Pager not supported for platform mx6ulevk"
 #endif
 #ifdef CFG_WITH_LPAE
 #error "LPAE not supported for now"
 #endif
 
-/* For i.MX 6UltraLite EVK board */
-#if defined(PLATFORM_FLAVOR_mx6ulevk)
 #define GIC_BASE			0xA00000
 #define GIC_SIZE			0x8000
 #define GICC_OFFSET			0x2000
@@ -54,27 +58,23 @@
 #define AHB3_BASE			0x02200000
 #define AHB3_SIZE			0x100000
 
-#define AIPS_TZ1_BASE_ADDR		0x02000000
-#define AIPS1_OFF_BASE_ADDR             (AIPS_TZ1_BASE_ADDR + 0x80000)
+#define AIPS_TZ1_BASE_ADDR	0x02000000
+#define AIPS1_OFF_BASE_ADDR	(AIPS_TZ1_BASE_ADDR + 0x80000)
 
 #define DRAM0_BASE			0x80000000
 #define DRAM0_SIZE			0x20000000
 
 #define CFG_TEE_CORE_NB_CORE		1
 
-#define DDR_PHYS_START			DRAM0_BASE
+#define DDR_PHYS_START		DRAM0_BASE
 #define DDR_SIZE			DRAM0_SIZE
 
-#define CFG_DDR_START			DDR_PHYS_START
-#define CFG_DDR_SIZE			DDR_SIZE
+#define CFG_DDR_START		DDR_PHYS_START
+#define CFG_DDR_SIZE		DDR_SIZE
 
 /* Full GlobalPlatform test suite requires CFG_SHMEM_SIZE to be at least 2MB */
-#define CFG_SHMEM_START			(TZDRAM_BASE - 0x100000)
-#define CFG_SHMEM_SIZE			0x100000
-
-#else
-#error "Unknown platform flavor"
-#endif
+#define CFG_SHMEM_START		(TZDRAM_BASE - 0x100000)
+#define CFG_SHMEM_SIZE		0x100000
 
 #define HEAP_SIZE			(24 * 1024)
 
@@ -82,10 +82,10 @@
 #define TZDRAM_BASE			(0x9c100000)
 #define TZDRAM_SIZE			(0x03000000)
 
-#define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
+#define CFG_TEE_RAM_VA_SIZE	(1024 * 1024)
 
 #ifndef CFG_TEE_LOAD_ADDR
-#define CFG_TEE_LOAD_ADDR		CFG_TEE_RAM_START
+#define CFG_TEE_LOAD_ADDR	CFG_TEE_RAM_START
 #endif
 
 /*
@@ -99,12 +99,12 @@
 #define CFG_TEE_RAM_PH_SIZE	CFG_TEE_RAM_VA_SIZE
 #define CFG_TEE_RAM_START	TZDRAM_BASE
 #define CFG_TA_RAM_START	ROUNDUP((TZDRAM_BASE + CFG_TEE_RAM_VA_SIZE), \
-					CORE_MMU_DEVICE_SIZE)
+						CORE_MMU_DEVICE_SIZE)
 #define CFG_TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - CFG_TEE_RAM_VA_SIZE), \
-					  CORE_MMU_DEVICE_SIZE)
+						CORE_MMU_DEVICE_SIZE)
 
 #define DEVICE0_PA_BASE		ROUNDDOWN(UART0_BASE, \
-					  CORE_MMU_DEVICE_SIZE)
+						CORE_MMU_DEVICE_SIZE)
 #define DEVICE0_VA_BASE		(64 * 1024 * 1024)
 #define DEVICE0_SIZE		CORE_MMU_DEVICE_SIZE
 #define DEVICE0_TYPE		MEM_AREA_IO_NSEC
@@ -114,7 +114,157 @@
  * The physical address is 0x2020000, we mapped it to 0x4020000,
  * see DEVICE0_VA_BASE and DEVICE0_PA_BASE
  */
-#define CONSOLE_UART_BASE	(0x4020000)
+#define CONSOLE_UART_BASE		(0x4020000)
 #define CONSOLE_UART_PA_BASE	(UART0_BASE)
+
+/* For i.MX6 Quad SABRE Lite and Smart Device board */
+
+#elif defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
+
+#define SCU_BASE				0x00A00000
+#define PL310_BASE				0x00A02000
+#define SRC_BASE				0x020D8000
+#define SRC_SCR					0x000
+#define SRC_GPR1				0x020
+#define SRC_SCR_ENABLE_OFFSET	22
+#define GIC_BASE				0x00A00000
+#define GICC_OFFSET				0x100
+#define GICD_OFFSET				0x1000
+#define GIC_CPU_BASE			(GIC_BASE + GICC_OFFSET)
+#define GIC_DIST_BASE			(GIC_BASE + GICD_OFFSET)
+#define UART1_BASE				0x02020000
+#define UART2_BASE				0x021E8000
+#define CSU_CSL_START			0x021C0000
+#define CSU_CSL_END				0x021C00A0
+#define CSU_CSL_5				0x021C0014
+#define CSU_CSL_16				0x021C0040
+
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite)
+#define CONSOLE_UART_BASE		UART2_BASE
+#define CONSOLE_UART_PA_BASE	UART2_BASE
+#endif
+#if defined(PLATFORM_FLAVOR_mx6qsabresd)
+#define CONSOLE_UART_BASE		UART1_BASE
+#define CONSOLE_UART_PA_BASE	UART1_BASE
+#endif
+#define DRAM0_BASE				0x10000000
+#define DRAM0_SIZE				0x40000000
+
+#define HEAP_SIZE				(24 * 1024)
+
+#define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
+
+#define CFG_TEE_CORE_NB_CORE	4
+
+#define DDR_PHYS_START			DRAM0_BASE
+#define DDR_SIZE				DRAM0_SIZE
+
+#define CFG_DDR_START			DDR_PHYS_START
+#define CFG_DDR_SIZE			DDR_SIZE
+
+/* define the memory areas */
+
+#ifdef CFG_WITH_PAGER
+
+/*
+ * TEE/TZ RAM layout:
+ *
+ *  +-----------------------------------------+  <- CFG_DDR_TEETZ_RESERVED_START
+ *  | TEETZ private RAM  |  TEE_RAM (SRAM)    |   ^
+ *  |                    +--------------------+   |
+ *  |                    |  TA_RAM            |   |
+ *  +-----------------------------------------+   | CFG_DDR_TEETZ_RESERVED_SIZE
+ *  |                    |      teecore alloc |   |
+ *  |  TEE/TZ and NSec   |  PUB_RAM   --------|   |
+ *  |   shared memory    |         NSec alloc |   |
+ *  +-----------------------------------------+   v
+ *
+ *  TEE_RAM : 256KByte
+ *  PUB_RAM : 1MByte
+ *  TA_RAM  : all what is left (at least 2MByte !)
+ */
+
+/* emulated SRAM, 256K at start of secure DDR */
+
+#define TZSRAM_BASE				0x4E000000
+#define TZSRAM_SIZE				0x00040000
+
+/* Location of trusted dram */
+
+#define CFG_DDR_TEETZ_RESERVED_START	0x4E100000
+#define CFG_DDR_TEETZ_RESERVED_SIZE		0x01F00000
+
+#define CFG_PUB_RAM_SIZE		(1 * 1024 * 1024)
+
+#define TZDRAM_BASE				(CFG_DDR_TEETZ_RESERVED_START)
+#define TZDRAM_SIZE				(CFG_DDR_TEETZ_RESERVED_SIZE - \
+						CFG_PUB_RAM_SIZE)
+
+#define CFG_TA_RAM_START		TZDRAM_BASE
+#define CFG_TA_RAM_SIZE			TZDRAM_SIZE
+
+#define CFG_SHMEM_START			(CFG_DDR_TEETZ_RESERVED_START + \
+						TZDRAM_SIZE)
+#define CFG_SHMEM_SIZE			CFG_PUB_RAM_SIZE
+
+#define CFG_TEE_RAM_START		TZSRAM_BASE
+#define CFG_TEE_RAM_PH_SIZE		TZSRAM_SIZE
+
+#ifndef CFG_TEE_LOAD_ADDR
+#define CFG_TEE_LOAD_ADDR		TZSRAM_BASE
+#endif
+
+#else /* CFG_WITH_PAGER */
+
+/*
+ * TEE/TZ RAM layout:
+ *
+ *  +-----------------------------------------+  <- CFG_DDR_TEETZ_RESERVED_START
+ *  | TEETZ private RAM  |  TEE_RAM           |   ^
+ *  |                    +--------------------+   |
+ *  |                    |  TA_RAM            |   |
+ *  +-----------------------------------------+   | CFG_DDR_TEETZ_RESERVED_SIZE
+ *  |                    |      teecore alloc |   |
+ *  |  TEE/TZ and NSec   |  PUB_RAM   --------|   |
+ *  |   shared memory    |         NSec alloc |   |
+ *  +-----------------------------------------+   v
+ *
+ *  TEE_RAM : 1MByte
+ *  PUB_RAM : 1MByte
+ *  TA_RAM  : all what is left (at least 2MByte !)
+ */
+
+#define CFG_DDR_TEETZ_RESERVED_START	0x4E000000
+#define CFG_DDR_TEETZ_RESERVED_SIZE		0x02000000
+
+#define CFG_PUB_RAM_SIZE		(1 * 1024 * 1024)
+#define CFG_TEE_RAM_PH_SIZE		(1 * 1024 * 1024)
+
+#define TZDRAM_BASE				(CFG_DDR_TEETZ_RESERVED_START)
+#define TZDRAM_SIZE				(CFG_DDR_TEETZ_RESERVED_SIZE - \
+						CFG_PUB_RAM_SIZE)
+
+#define CFG_TA_RAM_START		(CFG_DDR_TEETZ_RESERVED_START + \
+						CFG_TEE_RAM_PH_SIZE)
+#define CFG_TA_RAM_SIZE			(CFG_DDR_TEETZ_RESERVED_SIZE - \
+						CFG_TEE_RAM_PH_SIZE - \
+						CFG_PUB_RAM_SIZE)
+
+#define CFG_SHMEM_START			(CFG_DDR_TEETZ_RESERVED_START + \
+				TZDRAM_SIZE)
+#define CFG_SHMEM_SIZE			CFG_PUB_RAM_SIZE
+
+#define CFG_TEE_RAM_START		TZDRAM_BASE
+
+#ifndef CFG_TEE_LOAD_ADDR
+#define CFG_TEE_LOAD_ADDR		TZDRAM_BASE
+#endif
+
+#endif /* CFG_WITH_PAGER */
+
+#else
+#error "Unknown platform flavor"
+#endif /* defined(PLATFORM_FLAVOR_mx6ulevk) */
 
 #endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -1,2 +1,4 @@
 global-incdirs-y += .
 srcs-y += main.c
+srcs-$(PLATFORM_FLAVOR_mx6qsabrelite) += a9_plat_init.S
+srcs-$(PLATFORM_FLAVOR_mx6qsabresd) += a9_plat_init.S

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -189,3 +189,18 @@ CFG_DTB_MAX_SIZE ?= 0x10000
 
 # Enable static TA and core self tests
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+
+# This option enables OP-TEE to respond to SMP boot request: the Rich OS
+# issues this to request OP-TEE to release secondaries cores out of reset,
+# with specific core number and non-secure entry address.
+CFG_BOOT_SECONDARY_REQUEST ?= n
+
+# For firmwares that do not pass arguments to OP-TEE, this option enables the
+# built-in arguments which are specified as CFG items in the build time:
+# CFG_PAGEABLE_ADDR: pageable data address, normally passed in R0;
+# CFG_NS_ENTRY_ADDR: NS World entry address, normally passed in LR;
+# CFG_DT_ADDR: Device Tree data address, normally passed in R2;
+CFG_BUILT_IN_ARGS ?= n
+CFG_PAGEABLE_ADDR ?= 0x0
+CFG_NS_ENTRY_ADDR ?=0x0
+CFG_DT_ADDR ?= 0x0


### PR DESCRIPTION
Add changes to work with VxWorks as Rich OS:

1. added VxWorks specific SMC requests definition. OP-TEE is to be used as both a TEE and a Monitor for VxWorks, so additional SMC requests must be handled by OP-TEE.

2. added a new the hand-off protocol between loader and OP-TEE, that is, no hand-off at all. OP-TEE will not require loader to pass any arguments, instead, things such as paged data, NS entry and DT address are from configuration parameters. This hand-off is to be used by VxWorks.

3. Added the i.MX6 Sabre Lite board support.