### PR TITLE
storage: return TEE_ERROR_ITEM_NOT_FOUND when storage ID is unknown

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -498,7 +498,7 @@ TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,
 	size_t attr_size;
 
 	if (!fops) {
-		res = TEE_ERROR_STORAGE_NOT_AVAILABLE;
+		res = TEE_ERROR_ITEM_NOT_FOUND;
 		goto exit;
 	}
 
@@ -633,7 +633,7 @@ TEE_Result syscall_storage_obj_create(unsigned long storage_id, void *object_id,
 	size_t attr_size;
 
 	if (!fops)
-		return TEE_ERROR_STORAGE_NOT_AVAILABLE;
+		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	if (object_id_len > TEE_OBJECT_ID_MAX_LEN)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -1063,7 +1063,7 @@ TEE_Result syscall_storage_start_enum(unsigned long obj_enum,
 		return res;
 
 	if (!fops)
-		return TEE_ERROR_STORAGE_NOT_AVAILABLE;
+		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	dir = tee_svc_storage_create_dirname(sess);
 	if (dir == NULL)


### PR DESCRIPTION
As per the GP specification for functions TEE_OpenPersistentObject(),
TEE_CreatePersistentObject() and TEE_StartPersitetntObjectEnumerator(),
return TEE_ERROR_ITEM_NOT_FOUND when the storage ID is invalid instead
of TEE_ERROR_STORAGE_NOT_AVAILABLE.

Note:
The code modified in this commit cannot currently be reached because
libutee rejects invalid storage IDs with TEE_ERROR_ITEM_NOT_FOUND
already. But a patch is on the way [1] that will remove this user-mode
test, so fix the bug before it can happen.

[1] https://github.com/OP-TEE/optee_os/pull/938

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>