### PR TITLE
Arch linux

### DIFF
--- a/scripts/gen_hashed_bin.py
+++ b/scripts/gen_hashed_bin.py
@@ -47,7 +47,7 @@ def write_header(outf, init_size, args, paged_size):
 def append_to(outf, start_offs, in_fname, max_bytes=0xffffffff):
 	#print "Appending %s@0x%x 0x%x bytes at position 0x%x" % \
 		#( in_fname, start_offs, max_bytes, int(outf.tell()) )
-	inf = open(in_fname, 'r');
+	inf = open(in_fname, 'rb');
 	inf.seek(start_offs)
 	while True :
 		nbytes = min(16 * 1024, max_bytes)
@@ -74,7 +74,7 @@ def append_hashes(outf, in_fname):
 		elif len(page) == 0 :
 			break
 		else :
-			print "Error: short read, got " + repr(len(page))
+			print("Error: short read, got " + repr(len(page)))
 			sys.exit(1)
 
 	inf.close()
@@ -117,7 +117,7 @@ def get_args():
 		help='The input tee_pageable.bin')
 
 	parser.add_argument('--out', \
-		required=True, type=argparse.FileType('w'), \
+		required=True, type=argparse.FileType('wb'), \
 		help='The output tee.bin')
 
 	return parser.parse_args();

--- a/scripts/render_font.py
+++ b/scripts/render_font.py
@@ -49,17 +49,26 @@ def get_args():
 
 def c_hex_print(f, str):
 	n = 0
+	s = ""
 	for x in str:
 		if n % 8 == 0:
-			f.write("\t")
+			s += "\t"
 		else:
-			f.write(" ")
-		f.write("0x" + ("0" + (hex(ord(x)))[2:])[-2:] + ",")
+			s += " "
+		# Hack to satisfy both Python 2.x and 3.x. In 2.x the variable x
+		# is string, while it in Python 3.x it's considered as a class
+		# int.
+		if sys.version_info > (3, 0):
+		    s += "0x%02x," % x
+		else:
+		    s += "0x%02x," % ord(x)
 		n = n + 1
 		if n % 8 == 0:
-			f.write("\n")
+			f.write(s + "\n")
+			s = ""
 	if n % 8 != 0:
-		f.write("\n")
+		f.write(s + "\n")
+		s = ""
 
 def write_comment(f):
 	f.write("/*\n * This file is auto generated with\n")
@@ -82,8 +91,8 @@ def main():
 	img_ref = Image(width=1000, height=1000)
 
 	if args.verbose:
-		print "Writing " + out_dir + "/" + font_name + ".c"
-	f = open(out_dir + "/" + font_name + ".c", 'wb+')
+		print("Writing " + out_dir + "/" + font_name + ".c")
+	f = open(out_dir + "/" + font_name + ".c", 'w+')
 	write_comment(f)
 	f.write("#include \"font.h\"\n\n")
 
@@ -136,8 +145,8 @@ def main():
 	f.close()
 
 	if args.verbose:
-		print "Writing " + out_dir + "/" + font_name + ".h"
-	f = open(out_dir + "/" + font_name + ".h", 'wb+')
+		print("Writing " + out_dir + "/" + font_name + ".h")
+	f = open(out_dir + "/" + font_name + ".h", 'w+')
 	write_comment(f)
 	f.write("#ifndef __" + font_name.upper() + "_H\n");
 	f.write("#define __" + font_name.upper() + "_H\n");

--- a/scripts/tee_bin_parser.py
+++ b/scripts/tee_bin_parser.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2016, Linaro Limited
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import struct
+
+def main():
+    with open ("../out/arm/core/tee.bin", "rb") as f:
+        data = f.read(4)
+        magic = struct.unpack('<I', data)
+        print("Magic: \t\t0x%08x" % magic)
+
+        data = f.read(1)
+        version = struct.unpack('<B', data)
+        print("Version: \t0x%02x" % version)
+
+        data = f.read(1)
+        arch_id = struct.unpack('<B', data)
+        print("ArchID: \t0x%02x" % arch_id)
+
+        data = f.read(2)
+        flags = struct.unpack('<H', data)
+        print("Arch Flags: \t0x%04x" % arch_id)
+
+        data = f.read(4)
+        init_size = struct.unpack('<I', data)
+        print("Init size: \t0x%04x" % init_size)
+
+        data = f.read(4)
+        laddr_h = struct.unpack('<I', data)
+        print("Load addr high:\t0x%04x" % laddr_h)
+
+        data = f.read(4)
+        laddr_l = struct.unpack('<I', data)
+        print("Load addr low: \t0x%04x" % laddr_l)
+
+        data = f.read(4)
+        mem_usage = struct.unpack('<I', data)
+        print("Mem usage: \t0x%04x" % mem_usage)
+
+        data = f.read(4)
+        pgd_size = struct.unpack('<I', data)
+        print("Pages size: \t0x%04x" % pgd_size)
+
+if __name__ == "__main__":
+        main()


### PR DESCRIPTION
During my vacation, I'm reinstalling one of my computers and plan to use something else than Ubuntu based stuff (Arch Linux) and I encountered a couple of problems when trying to compile and test OP-TEE. This patch set and the the one in https://github.com/OP-TEE/build/pull/73 makes everything run fine on Arch Linux.

The "parser" script is a bit crude, but we can easily expand it later on (like non hardcoded paths etc).