### PR TITLE
core: add memory type MEM_AREA_RAM_SEC, MEM_AREA_RAM_NSEC

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -86,7 +86,8 @@ extern vaddr_t core_mmu_linear_map_end;
  * MEM_AREA_TEE_COHERENT: teecore coherent RAM (secure, reserved to TEEtz)
  * MEM_AREA_TA_RAM:   Secure RAM where teecore loads/exec TA instances.
  * MEM_AREA_NS_SHM:   NonSecure shared RAM between NSec and TEEtz.
- * MEM_AREA_KEYVAULT: Secure RAM storing some secrets
+ * MEM_AREA_RAM_NSEC: NonSecure RAM storing data
+ * MEM_AREA_RAM_SEC:  Secure RAM storing some secrets
  * MEM_AREA_IO_SEC:   Secure HW mapped registers
  * MEM_AREA_IO_NSEC:  NonSecure HW mapped registers
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
@@ -99,7 +100,8 @@ enum teecore_memtypes {
 	MEM_AREA_TEE_COHERENT,
 	MEM_AREA_TA_RAM,
 	MEM_AREA_NSEC_SHM,
-	MEM_AREA_KEYVAULT,
+	MEM_AREA_RAM_NSEC,
+	MEM_AREA_RAM_SEC,
 	MEM_AREA_IO_NSEC,
 	MEM_AREA_IO_SEC,
 	MEM_AREA_RES_VASPACE,

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -306,6 +306,10 @@ static uint32_t type_to_attr(enum teecore_memtypes t)
 		return attr | noncache;
 	case MEM_AREA_IO_SEC:
 		return attr | TEE_MATTR_SECURE | noncache;
+	case MEM_AREA_RAM_NSEC:
+		return attr | cached;
+	case MEM_AREA_RAM_SEC:
+		return attr | TEE_MATTR_SECURE | cached;
 	case MEM_AREA_RES_VASPACE:
 		return 0;
 	default:
@@ -441,6 +445,8 @@ void core_init_mmu_map(void)
 			break;
 		case MEM_AREA_IO_SEC:
 		case MEM_AREA_IO_NSEC:
+		case MEM_AREA_RAM_SEC:
+		case MEM_AREA_RAM_NSEC:
 		case MEM_AREA_RES_VASPACE:
 			break;
 		default:


### PR DESCRIPTION
replace memory type MEM_AREA_KEYVAULT with MEM_AREA_RAM_SEC
MEM_AREA_RAM_SEC: for cached, secure memory
MEM_AREA_RAM_NSEC: for cached, nonsecure memory

Signed-off-by: Pengguang Zhu <zpghao@163.com>