### PR TITLE
storage: rpmb: call tee_fs_generate_fek() to generate FEK

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1941,7 +1941,7 @@ static TEE_Result generate_fek(struct rpmb_fat_entry *fe)
 	TEE_Result res;
 
 again:
-	res = crypto_ops.prng.read(fe->fek, sizeof(fe->fek));
+	res = tee_fs_generate_fek(fe->fek, sizeof(fe->fek));
 	if (res != TEE_SUCCESS)
 		return res;
 


### PR DESCRIPTION
The File Encryption Key is generated randomly but not encrypted by the
key manager before being written to the RPMB FAT. In other words, we
consider that the RNG outputs an already encrypted key.
For consistency, call tee_fs_generate_fek() instead.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>