### PR TITLE
storage: encrypt the FEK with a TA-specific key

### DIFF
--- a/core/include/tee/tee_fs_key_manager.h
+++ b/core/include/tee/tee_fs_key_manager.h
@@ -29,12 +29,14 @@
 #define TEE_FS_KEY_MANAGER_H
 
 #include <tee_api_types.h>
+#include <utee_defines.h>
 
 #define TEE_FS_KM_CHIP_ID_LENGTH    32
 #define TEE_FS_KM_HMAC_ALG          TEE_ALG_HMAC_SHA256
 #define TEE_FS_KM_AUTH_ENC_ALG      TEE_ALG_AES_GCM
 #define TEE_FS_KM_ENC_FEK_ALG       TEE_ALG_AES_ECB_NOPAD
 #define TEE_FS_KM_SSK_SIZE          TEE_SHA256_HASH_SIZE
+#define TEE_FS_KM_TSK_SIZE          TEE_SHA256_HASH_SIZE
 #define TEE_FS_KM_FEK_SIZE          16  /* bytes */
 #define TEE_FS_KM_IV_LEN            12  /* bytes */
 #define TEE_FS_KM_MAX_TAG_LEN       16  /* bytes */

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1406,7 +1406,7 @@ out:
  * @addr       Byte address of data.
  * @data       Pointer to the data.
  * @len        Size of data in bytes.
- * @fek        SSK-encrypted File Encryption Key or NULL.
+ * @fek        Encrypted File Encryption Key or NULL.
  */
 static TEE_Result tee_rpmb_read(uint16_t dev_id, uint32_t addr, uint8_t *data,
 				uint32_t len, uint8_t *fek)
@@ -1437,7 +1437,7 @@ static bool tee_rpmb_write_is_atomic(uint16_t dev_id __unused, uint32_t addr,
  * @addr       Byte address of data.
  * @data       Pointer to the data.
  * @len        Size of data in bytes.
- * @fek        SSK-encrypted File Encryption Key or NULL.
+ * @fek        Encrypted File Encryption Key or NULL.
  */
 static TEE_Result tee_rpmb_write(uint16_t dev_id, uint32_t addr,
 				 const uint8_t *data, uint32_t len,

--- a/documentation/secure_storage.md
+++ b/documentation/secure_storage.md
@@ -108,14 +108,13 @@ TEE file is 1024.
 
 Key manager is an component in TEE file system, and is responsible for handling
 data encryption and decryption and also management of the sensitive key
-materials. There are two types of keys used by key manager. One is Secure
-Storage Key (SSK) and another one is File Encryption Key (FEK).
+materials. There are three types of keys used by the key manager: the Secure
+Storage Key (SSK), the TA Storage KEY (TSK) and the File Encryption Key (FEK).
 
 ### Secure Storage Key (SSK)
 
 SSK is a per-device key and is generated and stored in secure memory when OP-TEE
-is booting. SSK is used for protecting FEK, in other words, is used for
-encrypting/decrypting FEK.
+is booting. SSK is used to derive the TA Storage Key (TSK).
 
 SSK is derived by:
 > SSK = HMAC<sub>SHA256</sub> (HUK, Chip ID || "static string")
@@ -128,6 +127,15 @@ secure storage subsystem, but, for the future we might need to create different
 per-device keys for different subsystems using the same algorithm as we
 generate the SSK; An easy way to generate different per-device keys for
 different subsystems is using different static strings to generate the keys.
+
+### Trusted Application Storage Key (TKS)
+
+The TSK is a per-Trusted Application key, which is generated from the SSK and
+the TA's identifier (UUID). It is used to protect the FEK, in other words,
+to encrypt/decrypt the FEK.
+
+TSK is derived by:
+> TSK = HMAC<sub>SHA256</sub> (SSK, TA_UUID)
 
 ### File Encryption Key (FEK)
 

--- a/documentation/secure_storage_rpmb.md
+++ b/documentation/secure_storage_rpmb.md
@@ -110,16 +110,17 @@ off with `CFG_ENC_FS=n`. The algorithm is 128-bit AES in Cipher Block Chaining
 
 - During OP-TEE initialization, a 128-bit AES Secure Storage Key (SSK) is
 derived from a Hardware Unique Key (HUK). It is kept in secure memory and never
-written to disk.
+written to disk. A Trusted Application Storage Key is derived from the SSK and
+the TA UUID.
 - For each file, a 128-bit encrypted File Encryption Key (FEK) is randomly
-generated when the file is created and stored in the FAT entry for the file.
-Before use, this key is decrypted using the SSK.
+generated when the file is created, encrypted with the TSK and stored in the FAT
+entry for the file.
 - Each 256-byte block of data is then encrypted in CBC mode. The initialization
 vector is obtained by the ESSIV algorithm, that is, by encrypting the block
 number with a hash of the FEK. This allows direct access to any block in the
 file, as follows:
 ```
-    FEK = AES-Decrypt(encrypted FEK);
+    FEK = AES-Decrypt(TSK, encrypted FEK);
     k = SHA256(FEK);
     IV = AES-Encrypt(128 bits of k, block index padded to 16 bytes)
 	Encrypted block = AES-CBC-Encrypt(FEK, IV, block data);


### PR DESCRIPTION
The File Encryption Key is now encrypted with a Trusted application
Storage Key (TSK) rather than directly with the Secure Storage Key.
The TSK is derived from the SSK and the TA UUID. This improves
isolation between TAs, and makes it impossible to read the data of a
TA from another TA after manually moving files in the REE filesystem
for instance.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>