### PR TITLE
Change the access right from w to r in virt_to_phy

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -898,7 +898,7 @@ static bool arm_va2pa_helper(void *va, paddr_t *pa)
 	bool ret = false;
 
 #ifdef ARM32
-	write_ats1cpw((vaddr_t)va);
+	write_ats1cpr((vaddr_t)va);
 	isb();
 #ifdef CFG_WITH_LPAE
 	par = read_par64();


### PR DESCRIPTION
Currently we are using the write_ats1cpw to do the
virt_to_phys translation, but when the input addresss
is readonly, the translation will fail, fix it using
write_ats1cpr.

Signed-off-by: Zeng Tao <prime.zeng@huawei.com>