### PR TITLE
RFC: Scrypt

### DIFF
--- a/core/include/tee/cryp_scrypt.h
+++ b/core/include/tee/cryp_scrypt.h
@@ -1,0 +1,52 @@
+/*-
+ * Copyright (c) 2016, Linaro Limited
+ * Copyright 2009 Colin Percival
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file was originally written by Colin Percival as part of the Tarsnap
+ * online backup system.
+ */
+#ifndef __CRYP_SCRYPT_H
+#define __CRYP_SCRYPT_H
+
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+TEE_Result tee_scrypt_validate_param(size_t n, size_t r, size_t p);
+
+/**
+ * tee_cryp_scrypt(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
+ * Compute scrypt(passwd[0 .. passwdlen - 1], salt[0 .. saltlen - 1], N, r,
+ * p, buflen) and write the result into buf.  The parameters r, p, and buflen
+ * must satisfy r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter N
+ * must be a power of 2 greater than 1.
+ *
+ * Returns TEE_Result
+ */
+TEE_Result tee_cryp_scrypt(const uint8_t *passwd, size_t passwdlen,
+			   const uint8_t *salt, size_t saltlen, uint64_t n,
+			   size_t r, size_t p, uint8_t *buf,
+			   size_t buflen);
+
+#endif /*__CRYP_SCRYPT_H*/

--- a/core/lib/libtomcrypt/include/tomcrypt_custom.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_custom.h
@@ -127,6 +127,7 @@
    
    #define LTC_NO_MACS
    #define LTC_HMAC
+   #define LTC_HMAC_ZERO_KEYLEN_OK
    #define LTC_OMAC
    #define LTC_CCM_MODE
 
@@ -203,6 +204,7 @@
 
 #ifdef CFG_CRYPTO_HMAC
    #define LTC_HMAC
+   #define LTC_HMAC_ZERO_KEYLEN_OK
 #endif
 #ifdef CFG_CRYPTO_CMAC
    #define LTC_OMAC
@@ -334,6 +336,7 @@
 #ifndef LTC_NO_MACS
 
 #define LTC_HMAC
+#define LTC_HMAC_ZERO_KEYLEN_OK
 #define LTC_OMAC
 #define LTC_PMAC
 #define LTC_XCBC

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
@@ -71,10 +71,12 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
     hmac->hash = hash;
     hashsize   = hash_descriptor[hash]->hashsize;
 
+#ifndef LTC_HMAC_ZERO_KEYLEN_OK
     /* valid key length? */
     if (keylen == 0) {
         return CRYPT_INVALID_KEYSIZE;
     }
+#endif
 
     /* allocate ram for buf */
     buf = XMALLOC(LTC_HMAC_BLOCKSIZE);

--- a/core/tee/cryp_scrypt.c
+++ b/core/tee/cryp_scrypt.c
@@ -1,0 +1,393 @@
+/*-
+ * Copyright (c) 2016, Linaro Limited
+ * Copyright 2009 Colin Percival
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file was originally written by Colin Percival as part of the Tarsnap
+ * online backup system.
+ */
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee/cryp_scrypt.h>
+#include <tee/tee_cryp_pbkdf2.h>
+#include <types_ext.h>
+#include <utee_defines.h>
+#include <kernel/panic.h>
+#include <mpalib.h>
+#include <tomcrypt_mpa.h>
+#include <trace.h>
+#include <util.h>
+
+static void blkxor(void *, const void *, size_t);
+static void salsa20_8(uint32_t[16]);
+static void blockmix_salsa8(const uint32_t *, uint32_t *, uint32_t *, size_t);
+static uint64_t integerify(const void *, size_t);
+
+static void
+blkcpy(void *dest, const void *src, size_t len)
+{
+	size_t *D = dest;
+	const size_t *S = src;
+	size_t L = len / sizeof(size_t);
+	size_t i;
+
+	for (i = 0; i < L; i++)
+		D[i] = S[i];
+}
+
+static void
+blkxor(void *dest, const void *src, size_t len)
+{
+	size_t *D = dest;
+	const size_t *S = src;
+	size_t L = len / sizeof(size_t);
+	size_t i;
+
+	for (i = 0; i < L; i++)
+		D[i] ^= S[i];
+}
+
+/**
+ * salsa20_8(B):
+ * Apply the salsa20/8 core to the provided block.
+ */
+static void
+salsa20_8(uint32_t B[16])
+{
+	uint32_t x[16];
+	size_t i;
+
+	blkcpy(x, B, 64);
+	for (i = 0; i < 8; i += 2) {
+#define R(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
+		/* Operate on columns. */
+		x[4] ^= R(x[0]+x[12], 7);
+		x[8] ^= R(x[4]+x[0], 9);
+		x[12] ^= R(x[8]+x[4], 13);
+		x[0] ^= R(x[12]+x[8], 18);
+
+		x[9] ^= R(x[5]+x[1], 7);
+		x[13] ^= R(x[9]+x[5], 9);
+		x[1] ^= R(x[13]+x[9], 13);
+		x[5] ^= R(x[1]+x[13], 18);
+
+		x[14] ^= R(x[10]+x[6], 7);
+		x[2] ^= R(x[14]+x[10], 9);
+		x[6] ^= R(x[2]+x[14], 13);
+		x[10] ^= R(x[6]+x[2], 18);
+
+		x[3] ^= R(x[15]+x[11], 7);
+		x[7] ^= R(x[3]+x[15], 9);
+		x[11] ^= R(x[7]+x[3], 13);
+		x[15] ^= R(x[11]+x[7], 18);
+
+		/* Operate on rows. */
+		x[1] ^= R(x[0]+x[3], 7);
+		x[2] ^= R(x[1]+x[0], 9);
+		x[3] ^= R(x[2]+x[1], 13);
+		x[0] ^= R(x[3]+x[2], 18);
+
+		x[6] ^= R(x[5]+x[4], 7);
+		x[7] ^= R(x[6]+x[5], 9);
+		x[4] ^= R(x[7]+x[6], 13);
+		x[5] ^= R(x[4]+x[7], 18);
+
+		x[11] ^= R(x[10]+x[9], 7);
+		x[8] ^= R(x[11]+x[10], 9);
+		x[9] ^= R(x[8]+x[11], 13);
+		x[10] ^= R(x[9]+x[8], 18);
+
+		x[12] ^= R(x[15]+x[14], 7);
+		x[13] ^= R(x[12]+x[15], 9);
+		x[14] ^= R(x[13]+x[12], 13);
+		x[15] ^= R(x[14]+x[13], 18);
+#undef R
+	}
+	for (i = 0; i < 16; i++)
+		B[i] += x[i];
+}
+
+/**
+ * blockmix_salsa8(Bin, Bout, X, r):
+ * Compute Bout = BlockMix_{salsa20/8, r}(Bin).  The input Bin must be 128r
+ * bytes in length; the output Bout must also be the same size.  The
+ * temporary space X must be 64 bytes.
+ */
+static void
+blockmix_salsa8(const uint32_t *Bin, uint32_t *Bout, uint32_t *X, size_t r)
+{
+	size_t i;
+
+	/* 1: X <-- B_{2r - 1} */
+	blkcpy(X, &Bin[(2 * r - 1) * 16], 64);
+
+	/* 2: for i = 0 to 2r - 1 do */
+	for (i = 0; i < 2 * r; i += 2) {
+		/* 3: X <-- H(X \xor B_i) */
+		blkxor(X, &Bin[i * 16], 64);
+		salsa20_8(X);
+
+		/* 4: Y_i <-- X */
+		/* 6: B' <-- (Y_0, Y_2 ... Y_{2r-2}, Y_1, Y_3 ... Y_{2r-1}) */
+		blkcpy(&Bout[i * 8], X, 64);
+
+		/* 3: X <-- H(X \xor B_i) */
+		blkxor(X, &Bin[i * 16 + 16], 64);
+		salsa20_8(X);
+
+		/* 4: Y_i <-- X */
+		/* 6: B' <-- (Y_0, Y_2 ... Y_{2r-2}, Y_1, Y_3 ... Y_{2r-1}) */
+		blkcpy(&Bout[i * 8 + r * 16], X, 64);
+	}
+}
+
+/**
+ * integerify(B, r):
+ * Return the result of parsing B_{2r-1} as a little-endian integer.
+ */
+static uint64_t
+integerify(const void *B, size_t r)
+{
+	const uint32_t *X = (const void *)((uintptr_t)(B) + (2 * r - 1) * 64);
+
+	return (((uint64_t)(X[1]) << 32) + X[0]);
+}
+
+static inline uint32_t
+le32dec(const void *pp)
+{
+	const uint8_t *p = (uint8_t const *)pp;
+
+	return ((uint32_t)(p[0]) + ((uint32_t)(p[1]) << 8) +
+		((uint32_t)(p[2]) << 16) + ((uint32_t)(p[3]) << 24));
+}
+
+static inline void
+le32enc(void *pp, uint32_t x)
+{
+	uint8_t *p = (uint8_t *)pp;
+
+	p[0] = x & 0xff;
+	p[1] = (x >> 8) & 0xff;
+	p[2] = (x >> 16) & 0xff;
+	p[3] = (x >> 24) & 0xff;
+}
+
+
+
+/**
+ * crypto_scrypt_smix(B, r, N, V, XY):
+ * Compute B = SMix_r(B, N).  The input B must be 128r bytes in length;
+ * the temporary storage V must be 128rN bytes in length; the temporary
+ * storage XY must be 256r + 64 bytes in length.  The value N must be a
+ * power of 2 greater than 1.  The arrays B, V, and XY must be aligned to a
+ * multiple of 64 bytes.
+ */
+static void
+crypto_scrypt_smix(uint8_t *B, size_t r, uint64_t N, void *_V, void *XY)
+{
+	uint32_t *X = XY;
+	uint32_t *Y = (void *)((uint8_t *)(XY) + 128 * r);
+	uint32_t *Z = (void *)((uint8_t *)(XY) + 256 * r);
+	uint32_t *V = _V;
+	uint64_t i;
+	uint64_t j;
+	size_t k;
+
+	/* 1: X <-- B */
+	for (k = 0; k < 32 * r; k++)
+		X[k] = le32dec(&B[4 * k]);
+
+	/* 2: for i = 0 to N - 1 do */
+	for (i = 0; i < N; i += 2) {
+		/* 3: V_i <-- X */
+		blkcpy(&V[i * (32 * r)], X, 128 * r);
+
+		/* 4: X <-- H(X) */
+		blockmix_salsa8(X, Y, Z, r);
+
+		/* 3: V_i <-- X */
+		blkcpy(&V[(i + 1) * (32 * r)], Y, 128 * r);
+
+		/* 4: X <-- H(X) */
+		blockmix_salsa8(Y, X, Z, r);
+	}
+
+	/* 6: for i = 0 to N - 1 do */
+	for (i = 0; i < N; i += 2) {
+		/* 7: j <-- Integerify(X) mod N */
+		j = integerify(X, r) & (N - 1);
+
+		/* 8: X <-- H(X \xor V_j) */
+		blkxor(X, &V[j * (32 * r)], 128 * r);
+		blockmix_salsa8(X, Y, Z, r);
+
+		/* 7: j <-- Integerify(X) mod N */
+		j = integerify(Y, r) & (N - 1);
+
+		/* 8: X <-- H(X \xor V_j) */
+		blkxor(Y, &V[j * (32 * r)], 128 * r);
+		blockmix_salsa8(Y, X, Z, r);
+	}
+
+	/* 10: B' <-- X */
+	for (k = 0; k < 32 * r; k++)
+		le32enc(&B[4 * k], X[k]);
+}
+
+struct scrypt_temp_vars {
+	mpanum tmp_b;
+	mpanum tmp_v;
+	mpanum tmp_xy;
+	uint8_t *b;
+	uint32_t *v;
+	uint32_t *xy;
+};
+
+static void *alloc_temp_var(size_t sz_bytes, mpanum *mpa)
+{
+	const size_t align = 64;
+	vaddr_t va;
+
+	if (!mpa_alloc_static_temp_var_size((sz_bytes + align) * 8, mpa,
+					    external_mem_pool))
+		return NULL;
+	va = (vaddr_t)(*mpa)->d;
+	va += align;
+	va &= ~(align - 1);
+	return (void *)va;
+}
+
+static void free_temp_vars(struct scrypt_temp_vars *vars)
+{
+	mpa_free_static_temp_var(&vars->tmp_b, external_mem_pool);
+	mpa_free_static_temp_var(&vars->tmp_xy, external_mem_pool);
+	mpa_free_static_temp_var(&vars->tmp_v, external_mem_pool);
+	memset(vars, 0, sizeof(*vars));
+}
+
+static TEE_Result alloc_temp_vars(size_t n, size_t r, size_t p,
+				  struct scrypt_temp_vars *vars)
+{
+	vars->tmp_b = NULL;
+	vars->tmp_xy = NULL;
+	vars->tmp_v = NULL;
+	vars->b = alloc_temp_var(128 * r * p, &vars->tmp_b);
+	vars->xy = alloc_temp_var(256 * r + 64, &vars->tmp_xy);
+	vars->v = alloc_temp_var(128 * r * n, &vars->tmp_v);
+
+	if (!vars->b || !vars->xy || !vars->v) {
+		free_temp_vars(vars);
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+	return TEE_SUCCESS;
+}
+
+static TEE_Result validate_param(size_t n, size_t r, size_t p)
+{
+	const size_t rp_prod_max = BIT(30);
+
+	if (r >= rp_prod_max || p >= rp_prod_max ||
+	    (uint64_t)r * (uint64_t)p >= rp_prod_max)
+		return TEE_ERROR_GENERIC;
+	if (((n & (n - 1)) != 0) || (n < 2))
+		return TEE_ERROR_BAD_PARAMETERS;
+	if ((r > SIZE_MAX / 128 / p) ||
+#if SIZE_MAX / 256 <= UINT32_MAX
+	    (r > (SIZE_MAX - 64) / 256) ||
+#endif
+	    (n > SIZE_MAX / 128 / r))
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result tee_scrypt_validate_param(size_t n, size_t r, size_t p)
+{
+	TEE_Result res = validate_param(n, r, p);
+	struct scrypt_temp_vars vars;
+
+	if (res != TEE_SUCCESS)
+		return res;
+	res = alloc_temp_vars(n, r, p, &vars);
+	free_temp_vars(&vars);
+	return res;
+}
+
+/**
+ * _crypto_scrypt(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen, smix):
+ * Perform the requested scrypt computation, using ${smix} as the smix routine.
+ */
+/**
+ * crypto_scrypt(passwd, passwdlen, salt, saltlen, N, r, p, buf, buflen):
+ * Compute scrypt(passwd[0 .. passwdlen - 1], salt[0 .. saltlen - 1], N, r,
+ * p, buflen) and write the result into buf.  The parameters r, p, and buflen
+ * must satisfy r * p < 2^30 and buflen <= (2^32 - 1) * 32.  The parameter N
+ * must be a power of 2 greater than 1.
+ *
+ * Return 0 on success; or -1 on error.
+ */
+
+TEE_Result tee_cryp_scrypt(const uint8_t *passwd, size_t passwdlen,
+			   const uint8_t *salt, size_t saltlen, uint64_t N,
+			   size_t r, size_t p, uint8_t *buf,
+			   size_t buflen)
+{
+	TEE_Result res = validate_param(N, r, p);
+	struct scrypt_temp_vars vars;
+	size_t i;
+
+	if (res != TEE_SUCCESS)
+		return res;
+
+	/* Sanity-check parameters. */
+#if SIZE_MAX > UINT32_MAX
+	if (buflen > (((uint64_t)(1) << 32) - 1) * 32)
+		return TEE_ERROR_GENERIC;
+#endif
+
+	res = alloc_temp_vars(N, r, p, &vars);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	/* 1: (B_0 ... B_{p-1}) <-- PBKDF2(P, S, 1, p * MFLen) */
+	res = tee_cryp_pbkdf2(TEE_MAIN_ALGO_SHA256, passwd, passwdlen,
+			      salt, saltlen, 1, vars.b, p * 128 * r);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	/* 2: for i = 0 to p - 1 do */
+	for (i = 0; i < p; i++) {
+		/* 3: B_i <-- MF(B_i, N) */
+		crypto_scrypt_smix(&vars.b[i * 128 * r], r, N, vars.v, vars.xy);
+	}
+
+	/* 5: DK <-- PBKDF2(P, B, 1, dkLen) */
+	res = tee_cryp_pbkdf2(TEE_MAIN_ALGO_SHA256, passwd, passwdlen,
+			      vars.b, p * 128 * r, 1, buf, buflen);
+out:
+	free_temp_vars(&vars);
+	return res;
+}

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -15,12 +15,18 @@ CFG_CRYPTO_CONCAT_KDF ?= y
 # This is an OP-TEE extension
 CFG_CRYPTO_PBKDF2 ?= y
 
+# The scrypt Password-Based Key Derivation Function
+# https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-05
+# This is an OP-TEE extension
+CFG_CRYPTO_SCRYPT ?= y
+
 endif
 
 srcs-y += tee_cryp_utl.c
 srcs-$(CFG_CRYPTO_HKDF) += tee_cryp_hkdf.c
 srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
 srcs-$(CFG_CRYPTO_PBKDF2) += tee_cryp_pbkdf2.c
+srcs-$(CFG_CRYPTO_SCRYPT) += cryp_scrypt.c
 
 ifeq ($(CFG_WITH_USER_TA),y)
 

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -76,15 +76,9 @@ struct tee_cryp_state {
 };
 
 struct tee_cryp_obj_secret {
-	uint32_t key_size;
-	uint32_t alloc_size;
-
-	/*
-	 * Pseudo code visualize layout of structure
-	 * Next follows data, such as:
-	 *	uint8_t data[alloc_size]
-	 * key_size must never exceed alloc_size
-	 */
+	size_t key_size;
+	size_t alloc_size;
+	void *key;
 };
 
 #define TEE_TYPE_ATTR_OPTIONAL       0x0
@@ -419,57 +413,49 @@ struct tee_cryp_obj_type_props {
 
 static const struct tee_cryp_obj_type_props tee_cryp_obj_props[] = {
 	PROP(TEE_TYPE_AES, 64, 128, 256,	/* valid sizes 128, 192, 256 */
-		256 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
-	PROP(TEE_TYPE_DES, 56, 56, 56,
-		/*
-		* Valid size 56 without parity, note that we still allocate
-		* for 64 bits since the key is supplied with parity.
-		*/
-		64 / 8 + sizeof(struct tee_cryp_obj_secret),
+	PROP(TEE_TYPE_DES, 56, 56, 56, /* Valid size 56 without parity */
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_DES3, 56, 112, 168,
-		/*
-		* Valid sizes 112, 168 without parity, note that we still
-		* allocate for with space for the parity since the key is
-		* supplied with parity.
-		*/
-		192 / 8 + sizeof(struct tee_cryp_obj_secret),
+		/* Valid sizes 112, 168 without parity */
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_HMAC_MD5, 8, 64, 512,
-		512 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_HMAC_SHA1, 8, 80, 512,
-		512 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_HMAC_SHA224, 8, 112, 512,
-		512 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_HMAC_SHA256, 8, 192, 1024,
-		1024 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_HMAC_SHA384, 8, 256, 1024,
-		1024 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_HMAC_SHA512, 8, 256, 1024,
-		1024 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 	PROP(TEE_TYPE_GENERIC_SECRET, 8, 0, 4096,
-		4096 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_secret_value_attrs),
 #if defined(CFG_CRYPTO_HKDF)
 	PROP(TEE_TYPE_HKDF_IKM, 8, 0, 4096,
-		4096 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_hkdf_ikm_attrs),
 #endif
 #if defined(CFG_CRYPTO_CONCAT_KDF)
 	PROP(TEE_TYPE_CONCAT_KDF_Z, 8, 0, 4096,
-		4096 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_concat_kdf_z_attrs),
 #endif
 #if defined(CFG_CRYPTO_PBKDF2)
 	PROP(TEE_TYPE_PBKDF2_PASSWORD, 8, 0, 4096,
-		4096 / 8 + sizeof(struct tee_cryp_obj_secret),
+		sizeof(struct tee_cryp_obj_secret),
 		tee_cryp_obj_pbkdf2_passwd_attrs),
 #endif
 	PROP(TEE_TYPE_RSA_PUBLIC_KEY, 1, 256, 2048,
@@ -556,7 +542,7 @@ static TEE_Result op_attr_secret_value_from_user(void *attr, const void *buffer,
 	/* Data size has to fit in allocated buffer */
 	if (size > key->alloc_size)
 		return TEE_ERROR_SECURITY;
-	memcpy(key + 1, buffer, size);
+	memcpy(key->key, buffer, size);
 	key->key_size = size;
 	return TEE_SUCCESS;
 }
@@ -582,7 +568,7 @@ static TEE_Result op_attr_secret_value_to_user(void *attr,
 	if (s < key->key_size)
 		return TEE_ERROR_SHORT_BUFFER;
 
-	return tee_svc_copy_to_user(buffer, key + 1, key->key_size);
+	return tee_svc_copy_to_user(buffer, key->key, key->key_size);
 }
 
 static void op_attr_secret_value_to_binary(void *attr, void *data,
@@ -592,7 +578,7 @@ static void op_attr_secret_value_to_binary(void *attr, void *data,
 
 	op_u32_to_binary_helper(key->key_size, data, data_len, offs);
 	if (data && (*offs + key->key_size) <= data_len)
-		memcpy((uint8_t *)data + *offs, key + 1, key->key_size);
+		memcpy((uint8_t *)data + *offs, key->key, key->key_size);
 	(*offs) += key->key_size;
 }
 
@@ -612,7 +598,7 @@ static bool op_attr_secret_value_from_binary(void *attr, const void *data,
 	if (s > key->alloc_size)
 		return false;
 	key->key_size = s;
-	memcpy(key + 1, (const uint8_t *)data + *offs, s);
+	memcpy(key->key, (const uint8_t *)data + *offs, s);
 	(*offs) += s;
 	return true;
 }
@@ -625,7 +611,7 @@ static TEE_Result op_attr_secret_value_from_obj(void *attr, void *src_attr)
 
 	if (src_key->key_size > key->alloc_size)
 		return TEE_ERROR_BAD_STATE;
-	memcpy(key + 1, src_key + 1, src_key->key_size);
+	memcpy(key->key, src_key->key, src_key->key_size);
 	key->key_size = src_key->key_size;
 	return TEE_SUCCESS;
 }
@@ -635,7 +621,17 @@ static void op_attr_secret_value_clear(void *attr)
 	struct tee_cryp_obj_secret *key = attr;
 
 	key->key_size = 0;
-	memset(key + 1, 0, key->alloc_size);
+	memset(key->key, 0, key->alloc_size);
+}
+
+static void op_attr_secret_value_free(void *attr)
+{
+	struct tee_cryp_obj_secret *key = attr;
+
+	op_attr_secret_value_clear(attr);
+	key->alloc_size = 0;
+	free(key->key);
+	key->key = NULL;
 }
 
 static TEE_Result op_attr_bignum_from_user(void *attr, const void *buffer,
@@ -813,7 +809,7 @@ static const struct attr_ops attr_ops[] = {
 		.to_binary = op_attr_secret_value_to_binary,
 		.from_binary = op_attr_secret_value_from_binary,
 		.from_obj = op_attr_secret_value_from_obj,
-		.free = op_attr_secret_value_clear, /* not a typo */
+		.free = op_attr_secret_value_free,
 		.clear = op_attr_secret_value_clear,
 	},
 	[ATTR_OPS_INDEX_BIGNUM] = {
@@ -1212,12 +1208,23 @@ TEE_Result tee_obj_set_type(struct tee_obj *o, uint32_t obj_type,
 		res = crypto_ops.acipher.alloc_ecc_keypair(o->attr,
 							   max_key_size);
 		break;
+	case TEE_TYPE_DATA:
+		break;
 	default:
-		if (obj_type != TEE_TYPE_DATA) {
+		{
 			struct tee_cryp_obj_secret *key = o->attr;
+			size_t s;
 
-			key->alloc_size = type_props->alloc_size -
-					  sizeof(*key);
+			if (obj_type == TEE_TYPE_DES ||
+			    obj_type == TEE_TYPE_DES3)
+				s = max_key_size / 7; /* parity bits */
+			else
+				s = max_key_size / 8;
+
+			key->key = calloc(1, s);
+			if (!key->key)
+				return TEE_ERROR_OUT_OF_MEMORY;
+			key->alloc_size = s;
 		}
 		break;
 	}
@@ -1784,7 +1791,7 @@ TEE_Result syscall_obj_generate_key(unsigned long obj, unsigned long key_size,
 			goto out;
 		}
 
-		res = crypto_ops.prng.read((void *)(key + 1), byte_size);
+		res = crypto_ops.prng.read(key->key, byte_size);
 		if (res != TEE_SUCCESS)
 			goto out;
 
@@ -2189,8 +2196,7 @@ TEE_Result syscall_hash_init(unsigned long state,
 			if (!crypto_ops.mac.init)
 				return TEE_ERROR_NOT_IMPLEMENTED;
 			res = crypto_ops.mac.init(cs->ctx, cs->algo,
-						  (void *)(key + 1),
-						  key->key_size);
+						  key->key, key->key_size);
 			if (res != TEE_SUCCESS)
 				return res;
 			break;
@@ -2399,17 +2405,13 @@ TEE_Result syscall_cipher_init(unsigned long state, const void *iv,
 			return TEE_ERROR_BAD_PARAMETERS;
 
 		res = crypto_ops.cipher.init(cs->ctx, cs->algo, cs->mode,
-					     (uint8_t *)(key1 + 1),
-					     key1->key_size,
-					     (uint8_t *)(key2 + 1),
-					     key2->key_size,
+					     key1->key, key1->key_size,
+					     key2->key, key2->key_size,
 					     iv, iv_len);
 	} else {
 		res = crypto_ops.cipher.init(cs->ctx, cs->algo, cs->mode,
-					     (uint8_t *)(key1 + 1),
-					     key1->key_size,
-					     NULL,
-					     0,
+					     key1->key, key1->key_size,
+					     NULL, 0,
 					     iv, iv_len);
 	}
 	if (res != TEE_SUCCESS)
@@ -2720,8 +2722,7 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 								  pub, ss);
 			if (res == TEE_SUCCESS) {
 				sk->key_size = crypto_ops.bignum.num_bytes(ss);
-				crypto_ops.bignum.bn2bin(ss,
-							 (uint8_t *)(sk + 1));
+				crypto_ops.bignum.bn2bin(ss, sk->key);
 				so->info.handleFlags |=
 						TEE_HANDLE_FLAG_INITIALIZED;
 				SET_ATTRIBUTE(so, type_props,
@@ -2735,7 +2736,6 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 	} else if (TEE_ALG_GET_MAIN_ALG(cs->algo) == TEE_MAIN_ALGO_ECDH) {
 		size_t alloc_size;
 		struct ecc_public_key key_public;
-		uint8_t *pt_secret;
 		unsigned long pt_secret_len;
 
 		if (!crypto_ops.bignum.bin2bn ||
@@ -2786,10 +2786,9 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 					 params[1].content.ref.length,
 					 key_public.y);
 
-		pt_secret = (uint8_t *)(sk + 1);
 		pt_secret_len = sk->alloc_size;
 		res = crypto_ops.acipher.ecc_shared_secret(ko->attr,
-				&key_public, pt_secret, &pt_secret_len);
+				&key_public, sk->key, &pt_secret_len);
 
 		if (res == TEE_SUCCESS) {
 			sk->key_size = pt_secret_len;
@@ -2806,7 +2805,6 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 		size_t salt_len, info_len, okm_len;
 		uint32_t hash_id = TEE_ALG_GET_DIGEST_HASH(cs->algo);
 		struct tee_cryp_obj_secret *ik = ko->attr;
-		const uint8_t *ikm = (const uint8_t *)(ik + 1);
 
 		res = get_hkdf_params(params, param_count, &salt, &salt_len,
 				      &info, &info_len, &okm_len);
@@ -2819,9 +2817,9 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 			goto out;
 		}
 
-		res = tee_cryp_hkdf(hash_id, ikm, ik->key_size, salt, salt_len,
-				    info, info_len, (uint8_t *)(sk + 1),
-				    okm_len);
+		res = tee_cryp_hkdf(hash_id, ik->key, ik->key_size,
+				    salt, salt_len, info, info_len,
+				    sk->key, okm_len);
 		if (res == TEE_SUCCESS) {
 			sk->key_size = okm_len;
 			so->info.handleFlags |= TEE_HANDLE_FLAG_INITIALIZED;
@@ -2835,7 +2833,6 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 		size_t info_len, derived_key_len;
 		uint32_t hash_id = TEE_ALG_GET_DIGEST_HASH(cs->algo);
 		struct tee_cryp_obj_secret *ss = ko->attr;
-		const uint8_t *shared_secret = (const uint8_t *)(ss + 1);
 
 		res = get_concat_kdf_params(params, param_count, &info,
 					    &info_len, &derived_key_len);
@@ -2848,8 +2845,8 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 			goto out;
 		}
 
-		res = tee_cryp_concat_kdf(hash_id, shared_secret, ss->key_size,
-					  info, info_len, (uint8_t *)(sk + 1),
+		res = tee_cryp_concat_kdf(hash_id, ss->key, ss->key_size,
+					  info, info_len, sk->key,
 					  derived_key_len);
 		if (res == TEE_SUCCESS) {
 			sk->key_size = derived_key_len;
@@ -2864,7 +2861,6 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 		size_t salt_len, iteration_count, derived_key_len;
 		uint32_t hash_id = TEE_ALG_GET_DIGEST_HASH(cs->algo);
 		struct tee_cryp_obj_secret *ss = ko->attr;
-		const uint8_t *password = (const uint8_t *)(ss + 1);
 
 		res = get_pbkdf2_params(params, param_count, &salt, &salt_len,
 					&derived_key_len, &iteration_count);
@@ -2877,9 +2873,9 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 			goto out;
 		}
 
-		res = tee_cryp_pbkdf2(hash_id, password, ss->key_size, salt,
+		res = tee_cryp_pbkdf2(hash_id, ss->key, ss->key_size, salt,
 				      salt_len, iteration_count,
-				      (uint8_t *)(sk + 1), derived_key_len);
+				      sk->key, derived_key_len);
 		if (res == TEE_SUCCESS) {
 			sk->key_size = derived_key_len;
 			so->info.handleFlags |= TEE_HANDLE_FLAG_INITIALIZED;
@@ -2946,7 +2942,7 @@ TEE_Result syscall_authenc_init(unsigned long state, const void *nonce,
 		return TEE_ERROR_NOT_IMPLEMENTED;
 	key = o->attr;
 	res = crypto_ops.authenc.init(cs->ctx, cs->algo, cs->mode,
-				      (uint8_t *)(key + 1), key->key_size,
+				      key->key, key->key_size,
 				      nonce, nonce_len, tag_len, aad_len,
 				      payload_len);
 	if (res != TEE_SUCCESS)

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -79,6 +79,21 @@
 #define TEE_ATTR_PBKDF2_DKM_LENGTH          0xF00004C2
 
 /*
+ * The scrypt Password-Based Key Derivation Function
+ * https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-05
+ */
+#define TEE_ALG_SCRYPT_DERIVE_KEY	0x800000C3
+
+#define TEE_TYPE_SCRYPT			0xA10000C3
+
+#define TEE_ATTR_SCRYPT_PASSWORD	0xC00001C3
+#define TEE_ATTR_SCRYPT_SALT		0xD00002C3
+#define TEE_ATTR_SCRYPT_N		0xF00003C3
+#define TEE_ATTR_SCRYPT_R		0xF00004C3
+#define TEE_ATTR_SCRYPT_P		0xF00005C3
+#define TEE_ATTR_SCRYPT_DK_LENGTH	0xF00006C3
+
+/*
  * Implementation-specific object storage constants
  */
 

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -52,6 +52,7 @@
 #define TEE_MAIN_ALGO_HKDF       0xC0 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_CONCAT_KDF 0xC1 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_PBKDF2     0xC2 /* OP-TEE extension */
+#define TEE_MAIN_ALGO_SCRYPT     0xC3 /* OP-TEE extension */
 
 
 #define TEE_CHAIN_MODE_ECB_NOPAD        0x0

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -227,6 +227,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_CONCAT_KDF_SHA384_DERIVE_KEY:
 	case TEE_ALG_CONCAT_KDF_SHA512_DERIVE_KEY:
 	case TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY:
+	case TEE_ALG_SCRYPT_DERIVE_KEY:
 		if (mode != TEE_MODE_DERIVE)
 			return TEE_ERROR_NOT_SUPPORTED;
 		with_private_key = true;


### PR DESCRIPTION
This implements Scrypt. The implementation is limited by our memory constrained environment, but could still make sense.

There's one issue that needs to be dealt with before this can be merged. To make a predictable amount of contiguous memory available to Scrypt I'm using the same memory pool normally used by asymmetric ciphers. As that pool isn't properly exported it doesn't look that nice. One way forward is to move the handling of this pool outside LTC and MPA into for instance `core/mm`. Comments, other ideas?
