### PR TITLE
Travis: exclude some paths when running the coding style tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,10 +77,14 @@ before_script:
   - git fetch https://github.com/OP-TEE/optee_os --tags
   - unset CC
 
+  # checkpatch.pl will ignore the following paths
+  - CHECKPATCH_IGNORE=$(echo core/lib/lib{fdt,tomcrypt} lib/lib{png,utils,zlib})
+  - _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo "':\!$p'" ; done)
+
 # Several compilation options are checked
 script:
   # Run checkpatch.pl
-  - git format-patch -1 --stdout | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -
+  - git format-patch -1 --stdout -- . $_CP_EXCL | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -
 
   # Orly2
   - $make PLATFORM=stm PLATFORM_FLAVOR=orly2


### PR DESCRIPTION
OP-TEE contains code imported from Open Source libraries or
designed to comply with GlobalPlatform specifications. Such code will
trigger checkpatch.pl errors whenever the Linux kernel coding rules are
violated. Such message are useless and actually make the CI loop look
like the builds are failing when they are actually correct.

To fix this, add a list of directories that should be ignored by
'git format-patch' when producing the diff fed into checkpatch.pl.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>