### PR TITLE
add code for the interrupt framework in optee-os

### DIFF
--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -170,7 +170,7 @@ KEEP_PAGER(console_itr);
 static TEE_Result init_console_itr(void)
 {
 	itr_add(&console_itr);
-	itr_enable(&console_itr);
+	itr_enable(IT_CONSOLE_UART);
 	return TEE_SUCCESS;
 }
 driver_init(init_console_itr);

--- a/core/arch/arm/sta/interrupt_tests.c
+++ b/core/arch/arm/sta/interrupt_tests.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2016, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <keep.h>
+#include <kernel/interrupt.h>
+#include <kernel/misc.h>
+#include <kernel/static_ta.h>
+#include <kernel/tee_time.h>
+#include <kernel/thread.h>
+#include <platform_config.h>
+#include <string.h>
+#include <tee/tee_cryp_provider.h>
+#include <trace.h>
+
+#define TA_NAME		"interrupt_tests.ta"
+
+#define INTERRUPT_TESTS_UUID \
+		{ 0x48d58475, 0x3d5e, 0x4202, \
+		{ 0xa7, 0x75, 0x97, 0x85, 0xd2, 0x0f, 0x78, 0xae } }
+
+#define CMD_INTERRUPT_TESTS	0
+
+#define SGI_NUM		16
+#define PPI_NUM		32
+
+#ifndef TEST_SGI_ID
+#define TEST_SGI_ID	11
+#endif
+#ifndef TEST_PPI_ID
+#define TEST_PPI_ID	29
+#endif
+#ifndef TEST_SPI_ID
+#define TEST_SPI_ID	61
+#endif
+#ifndef TEST_TIMES
+#define TEST_TIMES	3
+#endif
+
+/*
+ * Trusted Application Entry Points
+ */
+
+static TEE_Result create_ta(void)
+{
+	return TEE_SUCCESS;
+}
+
+static void destroy_ta(void)
+{
+}
+
+static TEE_Result open_session(uint32_t ptype __unused,
+			       TEE_Param params[4] __unused,
+			       void **ppsess __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static void close_session(void *psess __unused)
+{
+}
+
+static size_t test_sgi_value[CFG_TEE_CORE_NB_CORE];
+static size_t test_spi_value[CFG_TEE_CORE_NB_CORE];
+static size_t test_ppi_value[CFG_TEE_CORE_NB_CORE];
+static size_t expect_sgi_value[CFG_TEE_CORE_NB_CORE];
+static size_t expect_spi_value[CFG_TEE_CORE_NB_CORE];
+static size_t expect_ppi_value[CFG_TEE_CORE_NB_CORE];
+
+static enum itr_return __maybe_unused ihandler_ok(struct itr_handler *handler)
+{
+	size_t core_num = get_core_pos();
+
+	assert(core_num < CFG_TEE_CORE_NB_CORE);
+
+	if (handler->it < SGI_NUM)
+		test_sgi_value[core_num]++;
+	else if (handler->it < PPI_NUM)
+		test_ppi_value[core_num]++;
+	else
+		test_spi_value[core_num]++;
+
+	return ITRR_HANDLED;
+}
+KEEP_PAGER(ihandler_ok);
+
+struct itr_handler sgi_handler = {
+	.it = TEST_SGI_ID,
+	.handler = ihandler_ok,
+};
+
+struct itr_handler spi_handler = {
+	.it = TEST_SPI_ID,
+	.handler = ihandler_ok,
+};
+
+struct itr_handler ppi_handler = {
+	.it = TEST_PPI_ID,
+	.handler = ihandler_ok,
+};
+
+static TEE_Result test_sgi(void)
+{
+	TEE_Result res;
+	uint8_t i;
+	uint8_t j;
+	uint8_t num;
+	uint8_t cpu_mask;
+
+	itr_add(&sgi_handler);
+	itr_enable(TEST_SGI_ID);
+
+	for (i = 0; i < CFG_TEE_CORE_NB_CORE; i++)
+		expect_sgi_value[i]++;
+	itr_raise_sgi(TEST_SGI_ID,
+		     (uint8_t)(SHIFT_U32(1, CFG_TEE_CORE_NB_CORE) - 1));
+	tee_time_wait(200);
+	if (memcmp(test_sgi_value, expect_sgi_value, sizeof(test_sgi_value)))
+		return TEE_ERROR_GENERIC;
+
+	for (i = 0; i < TEST_TIMES; i++) {
+		res = crypto_ops.prng.read(&num, 1);
+		if (res != TEE_SUCCESS)
+			return TEE_ERROR_GENERIC;
+		num = num % CFG_TEE_CORE_NB_CORE;
+		cpu_mask = 0x0;
+		for (j = 0; j < num; j++) {
+			expect_sgi_value[j]++;
+			cpu_mask |= (0x1 << j);
+		}
+		itr_raise_sgi(TEST_SGI_ID, cpu_mask);
+		tee_time_wait(200);
+		if (memcmp(test_sgi_value, expect_sgi_value,
+		    sizeof(test_sgi_value)))
+			return TEE_ERROR_GENERIC;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result test_spi(void)
+{
+	TEE_Result res;
+	uint8_t i;
+	uint8_t num;
+
+	itr_add(&spi_handler);
+	itr_enable(TEST_SPI_ID);
+
+	for (i = 0; i < TEST_TIMES; i++) {
+		res = crypto_ops.prng.read(&num, 1);
+		if (res != TEE_SUCCESS)
+			return TEE_ERROR_GENERIC;
+		num = num % CFG_TEE_CORE_NB_CORE;
+		expect_spi_value[num]++;
+		itr_set_affinity(TEST_SPI_ID, 0x1 << num);
+		itr_raise_pi(TEST_SPI_ID);
+		tee_time_wait(200);
+		if (memcmp(test_spi_value, expect_spi_value,
+		    sizeof(test_spi_value)))
+			return TEE_ERROR_GENERIC;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result test_ppi(void)
+{
+	uint32_t exceptions;
+
+	itr_add(&ppi_handler);
+	itr_enable(TEST_PPI_ID);
+
+	exceptions = thread_mask_exceptions(THREAD_EXCP_IRQ);
+	expect_ppi_value[get_core_pos()]++;
+	itr_raise_pi(TEST_PPI_ID);
+	thread_unmask_exceptions(exceptions);
+	tee_time_wait(200);
+	if (memcmp(test_ppi_value, expect_ppi_value, sizeof(test_ppi_value)))
+		return TEE_ERROR_GENERIC;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result interrupt_tests(uint32_t nParamTypes __unused,
+			TEE_Param pParams[TEE_NUM_PARAMS]__unused)
+{
+	TEE_Result res;
+
+	assert(crypto_ops.prng.read);
+
+	res = test_sgi();
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = test_spi();
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = test_ppi();
+	if (res != TEE_SUCCESS)
+		return res;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result invoke_command(void *psess __unused,
+				 uint32_t cmd, uint32_t ptypes,
+				 TEE_Param params[4])
+{
+	TEE_Result res;
+	uint8_t i;
+
+	switch (cmd) {
+	case CMD_INTERRUPT_TESTS:
+		res = interrupt_tests(ptypes, params);
+		DMSG("test value: sgi spi ppi");
+		for (i = 0; i < CFG_TEE_CORE_NB_CORE; i++)
+			DMSG("------------[%zu] [%zu] [%zu]",
+			    test_sgi_value[i], test_spi_value[i],
+			    test_ppi_value[i]);
+		DMSG("expc value: sgi spi ppi");
+		for (i = 0; i < CFG_TEE_CORE_NB_CORE; i++)
+			DMSG("------------[%zu] [%zu] [%zu]",
+			    expect_sgi_value[i], expect_spi_value[i],
+			    expect_ppi_value[i]);
+		return res;
+	default:
+		break;
+	}
+	return TEE_ERROR_BAD_PARAMETERS;
+}
+
+static_ta_register(.uuid = INTERRUPT_TESTS_UUID, .name = TA_NAME,
+		   .create_entry_point = create_ta,
+		   .destroy_entry_point = destroy_ta,
+		   .open_session_entry_point = open_session,
+		   .close_session_entry_point = close_session,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/sta/sub.mk
+++ b/core/arch/arm/sta/sub.mk
@@ -1,5 +1,6 @@
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += sta_self_tests.c
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += core_self_tests.c
+srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += interrupt_tests.c
 srcs-$(CFG_WITH_STATS) += stats.c
 
 ifeq ($(CFG_SE_API),y)

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -50,15 +50,23 @@
 #define GICD_IGROUPR(n)		(0x080 + (n) * 4)
 #define GICD_ISENABLER(n)	(0x100 + (n) * 4)
 #define GICD_ICENABLER(n)	(0x180 + (n) * 4)
+#define GICD_ISPENDR(n)		(0x200 + (n) * 4)
 #define GICD_ICPENDR(n)		(0x280 + (n) * 4)
 #define GICD_IPRIORITYR(n)	(0x400 + (n) * 4)
 #define GICD_ITARGETSR(n)	(0x800 + (n) * 4)
+#define GICD_SGIR		(0xF00)
 
 #define GICD_CTLR_ENABLEGRP0	(1 << 0)
 #define GICD_CTLR_ENABLEGRP1	(1 << 1)
 
 /* Number of Private Peripheral Interrupt */
 #define NUM_PPI	32
+
+/* Number of Software Generated Interrupt */
+#define NUM_SGI			16
+
+/* Number of Non-secure Software Generated Interrupt */
+#define NUM_NS_SGI		8
 
 /* Number of interrupts in one register */
 #define NUM_INTS_PER_REG	32
@@ -82,11 +90,19 @@
 static void gic_op_add(struct itr_chip *chip, size_t it, uint32_t flags);
 static void gic_op_enable(struct itr_chip *chip, size_t it);
 static void gic_op_disable(struct itr_chip *chip, size_t it);
+static void gic_op_raise_pi(struct itr_chip *chip, size_t it);
+static void gic_op_raise_sgi(struct itr_chip *chip, size_t it,
+			uint8_t cpu_mask);
+static void gic_op_set_affinity(struct itr_chip *chip, size_t it,
+			uint8_t cpu_mask);
 
 static const struct itr_ops gic_ops = {
 	.add = gic_op_add,
 	.enable = gic_op_enable,
 	.disable = gic_op_disable,
+	.raise_pi = gic_op_raise_pi,
+	.raise_sgi = gic_op_raise_sgi,
+	.set_affinity = gic_op_set_affinity,
 };
 
 static size_t probe_max_it(vaddr_t gicc_base, vaddr_t gicd_base)
@@ -250,8 +266,13 @@ static void gic_it_enable(struct gic_data *gd, size_t it)
 
 	/* Assigned to group0 */
 	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
-	/* Not enabled yet */
-	assert(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
+	if (it >= NUM_SGI) {
+		/*
+		 * Not enabled yet, except Software Generated Interrupt
+		 * which is implementation defined
+		 */
+		assert(!(read32(gd->gicd_base + GICD_ISENABLER(idx)) & mask));
+	}
 
 	/* Enable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ISENABLER(idx));
@@ -267,6 +288,36 @@ static void gic_it_disable(struct gic_data *gd, size_t it)
 
 	/* Disable the interrupt */
 	write32(mask, gd->gicd_base + GICD_ICENABLER(idx));
+}
+
+static void gic_it_set_pending(struct gic_data *gd, size_t it)
+{
+	size_t idx = it / NUM_INTS_PER_REG;
+	uint32_t mask = BIT32(it % NUM_INTS_PER_REG);
+
+	/* Should be Peripheral Interrupt */
+	assert(it >= NUM_SGI);
+	/* Assigned to group0 */
+	assert(!(read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
+
+	/* Raise the interrupt */
+	write32(mask, gd->gicd_base + GICD_ISPENDR(idx));
+}
+
+static void gic_it_raise_sgi(struct gic_data *gd, size_t it,
+		uint8_t cpu_mask, uint8_t group)
+{
+	uint32_t mask_id = it & 0xf;
+	uint32_t mask_group = group & 0x1;
+	uint32_t mask_cpu = cpu_mask & 0xff;
+	uint32_t mask = (mask_id | SHIFT_U32(mask_group, 15) |
+		SHIFT_U32(mask_cpu, 16));
+
+	/* Should be Software Generated Interrupt */
+	assert(it < NUM_SGI);
+
+	/* Raise the interrupt */
+	write32(mask, gd->gicd_base + GICD_SGIR);
 }
 
 static uint32_t gic_read_iar(struct gic_data *gd)
@@ -369,4 +420,38 @@ static void gic_op_disable(struct itr_chip *chip, size_t it)
 		panic();
 
 	gic_it_disable(gd, it);
+}
+
+static void gic_op_raise_pi(struct itr_chip *chip, size_t it)
+{
+	struct gic_data *gd = container_of(chip, struct gic_data, chip);
+
+	if (it >= gd->max_it)
+		panic();
+
+	gic_it_set_pending(gd, it);
+}
+
+static void gic_op_raise_sgi(struct itr_chip *chip, size_t it,
+			uint8_t cpu_mask)
+{
+	struct gic_data *gd = container_of(chip, struct gic_data, chip);
+
+	if (it >= gd->max_it)
+		panic();
+
+	if (it < NUM_NS_SGI)
+		gic_it_raise_sgi(gd, it, cpu_mask, 1);
+	else
+		gic_it_raise_sgi(gd, it, cpu_mask, 0);
+}
+static void gic_op_set_affinity(struct itr_chip *chip, size_t it,
+			uint8_t cpu_mask)
+{
+	struct gic_data *gd = container_of(chip, struct gic_data, chip);
+
+	if (it >= gd->max_it)
+		panic();
+
+	gic_it_set_cpu_mask(gd, it, cpu_mask);
 }

--- a/core/drivers/ps2mouse.c
+++ b/core/drivers/ps2mouse.c
@@ -155,6 +155,6 @@ void ps2mouse_init(struct ps2mouse_data *d, struct serial_chip *serial,
 	d->callback_data = cb_data;
 
 	itr_add(&d->itr_handler);
-	itr_enable(&d->itr_handler);
+	itr_enable(serial_it);
 	d->serial->ops->putc(d->serial, PS2_CMD_RESET);
 }

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -40,6 +40,11 @@ struct itr_ops {
 	void (*add)(struct itr_chip *chip, size_t it, uint32_t flags);
 	void (*enable)(struct itr_chip *chip, size_t it);
 	void (*disable)(struct itr_chip *chip, size_t it);
+	void (*raise_pi)(struct itr_chip *chip, size_t it);
+	void (*raise_sgi)(struct itr_chip *chip, size_t it,
+		uint8_t cpu_mask);
+	void (*set_affinity)(struct itr_chip *chip, size_t it,
+		uint8_t cpu_mask);
 };
 
 enum itr_return {
@@ -59,7 +64,19 @@ void itr_init(struct itr_chip *data);
 void itr_handle(size_t it);
 
 void itr_add(struct itr_handler *handler);
-void itr_enable(struct itr_handler *handler);
-void itr_disable(struct itr_handler *handler);
+void itr_enable(size_t it);
+void itr_disable(size_t it);
+/* raise the Peripheral Interrupt corresponding to the interrupt ID */
+void itr_raise_pi(size_t it);
+/*
+ * raise the Software Generated Interrupt corresponding to the interrupt ID,
+ * the cpu_mask represents which cpu interface to forward.
+ */
+void itr_raise_sgi(size_t it, uint8_t cpu_mask);
+/*
+ * let corresponding interrupt forward to the cpu interface
+ * according to the cpu_mask.
+ */
+void itr_set_affinity(size_t it, uint8_t cpu_mask);
 
 #endif /*__KERNEL_INTERRUPT_H*/

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -76,12 +76,27 @@ void itr_add(struct itr_handler *h)
 	SLIST_INSERT_HEAD(&handlers, h, link);
 }
 
-void itr_enable(struct itr_handler *h)
+void itr_enable(size_t it)
 {
-	itr_chip->ops->enable(itr_chip, h->it);
+	itr_chip->ops->enable(itr_chip, it);
 }
 
-void itr_disable(struct itr_handler *h)
+void itr_disable(size_t it)
 {
-	itr_chip->ops->disable(itr_chip, h->it);
+	itr_chip->ops->disable(itr_chip, it);
+}
+
+void itr_raise_pi(size_t it)
+{
+	itr_chip->ops->raise_pi(itr_chip, it);
+}
+
+void itr_raise_sgi(size_t it, uint8_t cpu_mask)
+{
+	itr_chip->ops->raise_sgi(itr_chip, it, cpu_mask);
+}
+
+void itr_set_affinity(size_t it, uint8_t cpu_mask)
+{
+	itr_chip->ops->set_affinity(itr_chip, it, cpu_mask);
 }


### PR DESCRIPTION
With this commit, we add three more GIC APIs for the kernel of OPTEE-OS:
`itr_raise_sgi` : can raise software generate interrupt(SGI) from secure world to no-secure world, or secure world to secure world. It's a quick communication between different worlds and different cores. Because SGI is using the GIC N-N model, so with this API, every core can receive the interrupt if want.
`itr_raise_pi` : can trigger the peripheral interrupt with the corresponding interrupt number. When sending it to N cores, just one core can receive the effective interrupt.
`itr_set_affinity` : can target the peripheral interrupt to the core you want, it means that one can bind the interrupt to the corresponding core use this API.

The usage may as follow:
`itr_raise_sgi(11, 0x1 << 1)`
 it will raise SGI11 to core 1, and if you want not only core 1 can receive SGI11 but also core 2, then you can change the code to `itr_raise_sgi(11, 0x1 << 1 || 0x1 << 2)`
`itr_set_affinity(61, 0x1 << 1)`
`itr_raise_pi(61)`
These two APIs may use together, the operation set_affinity set the PI61 can just sent to core 1, then raise_pi, core 1 will receive the peripheral interrupt 61.

Signed-off-by: Guanchao Liang liang.guanchao@linaro.org
