### PR TITLE
core: arm64: fix masking exceptions on normal exit

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -193,8 +193,8 @@ FUNC thread_std_smc_entry , :
 	load_xregs sp, THREAD_SMC_ARGS_X0, 20, 23
 	add	sp, sp, #THREAD_SMC_ARGS_SIZE
 
-	/* Disable interrupts before switching to temporary stack */
-	msr	daifset, #(DAIFBIT_FIQ | DAIFBIT_IRQ)
+	/* Mask all maskable exceptions before switching to temporary stack */
+	msr	daifset, #DAIFBIT_ALL
 	bl	thread_get_tmp_sp
 	mov	sp, x0
 
@@ -215,6 +215,7 @@ FUNC thread_rpc , :
 	mrs	x1, daif
 	orr	x1, x1, #(SPSR_64_MODE_EL1 << SPSR_64_MODE_EL_SHIFT)
 
+	/* Mask all maskable exceptions before switching to temporary stack */
 	msr	daifset, #DAIFBIT_ALL
 	push	x0, xzr
 	push	x1, x30


### PR DESCRIPTION
Before this patch debug and asynchronous abort wasn't masked
when doing a normal return from call. This patch fixes that.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMUv8)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>