### PR TITLE
build: add PLATFORM_FLAVOR for BUILD_OPTEE_OS

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -6,6 +6,7 @@
 ##    OPTEE_TA_TARGETS                                  ##
 ##    OPTEE_CFG_ARM64_CORE                              ##
 ##    OPTEE_PLATFORM                                    ##
+##    OPTEE_PLATFORM_FLAVOR                             ##
 ## And BUILD_OPTEE_MK needs to be defined in device.mk  ##
 ## to point to this file                                ##
 ##                                                      ##
@@ -48,6 +49,7 @@ BUILD_OPTEE_OS:
 		ta-targets=$(OPTEE_TA_TARGETS) \
 		CFG_ARM64_core=$(OPTEE_CFG_ARM64_CORE) \
 		PLATFORM=$(OPTEE_PLATFORM) \
+		PLATFORM_FLAVOR=$(OPTEE_PLATFORM_FLAVOR) \
 		$(CROSS_COMPILE_LINE)
 	@echo "Finished building optee_os..."
 


### PR DESCRIPTION
fix build error:
In file included from core/arch/arm/kernel/thread.c:29:0:
core/arch/arm/plat-aquila/./platform_config.h:51:2: error: #error "Unknown platform flavor"
 #error "Unknown platform flavor"

Signed-off-by: Zhizhou Zhang <zhizhou.zh@gmail.com>