### PR TITLE
Add support for Renesas RCAR H3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,5 +186,9 @@ script:
   - $make PLATFORM=d02
   - $make PLATFORM=d02 CFG_ARM64_core=y
 
+  # Renesas RCAR H3
+  - $make PLATFORM=rcar
+  - $make PLATFORM=rcar CFG_ARM64_core=y
+
   # Run regression tests (xtest in QEMU)
   - (cd ${HOME}/optee_repo/build && $make check CROSS_COMPILE="ccache arm-linux-gnueabihf-" AARCH32_CROSS_COMPILE=arm-linux-gnueabihf- DUMP_LOGS_ON_ERROR=1)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,7 @@ for these platforms.
 | HiKey Board (HiSilicon Kirin 620)	|`Linaro <op-tee@linaro.org>`|
 | MediaTek MT8173 EVB Board		|`Linaro <op-tee@linaro.org>`|
 | QEMU					|`Linaro <op-tee@linaro.org>`|
+| Renesas RCAR			|`Volodymyr Babchuk <vlad.babchuk@gmail.com>`|
 | STMicroelectronics b2120 - h310 / h410|`Linaro <op-tee@linaro.org>`|
 | STMicroelectronics b2020-h416		|`Linaro <op-tee@linaro.org>`|
 | Texas Instruments DRA7xx		|`Harinarayan Bhatta <harinarayan@ti.com>`|

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ platforms have different sub-maintainers, please refer to the file
 | [QEMU](http://wiki.qemu.org/Main_Page) |`PLATFORM=vexpress-qemu_virt`| Yes |
 | [QEMUv8](http://wiki.qemu.org/Main_Page) |`PLATFORM=vexpress-qemu_armv8a`| Yes |
 | [Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b) |`PLATFORM=rpi3`| Yes |
+| [Renesas RCAR](https://www.renesas.com/en-sg/solutions/automotive/products/rcar-h3.html)|`PLATFORM=rcar`| No |
 | [STMicroelectronics b2120 - h310 / h410](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-cannes`| No |
 | [STMicroelectronics b2020-h416](http://www.st.com/web/catalog/mmc/FM131/SC999/SS1633/PF253155?sc=internet/imag_video/product/253155.jsp)|`PLATFORM=stm-orly2`| No |
 | [Texas Instruments DRA7xx](http://www.ti.com/product/DRA746)|`PLATFORM=ti-dra7xx`| Yes |

--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -1,0 +1,27 @@
+PLATFORM_FLAVOR ?= h3
+
+# 32-bit flags
+arm32-platform-cpuarch	:= cortex-a57
+arm32-platform-cflags	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags	+= -mfpu=neon
+
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_SCIF,y)
+
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+ta-targets += ta_arm64
+else
+$(call force,CFG_ARM32_core,y)
+endif
+
+ifeq ($(CFG_ARM32_core),y)
+ta-targets = ta_arm32
+endif
+
+CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-rcar/kern.ld.S
+++ b/core/arch/arm/plat-rcar/kern.ld.S
@@ -1,0 +1,1 @@
+#include "../kernel/kern.ld.S"

--- a/core/arch/arm/plat-rcar/link.mk
+++ b/core/arch/arm/plat-rcar/link.mk
@@ -1,0 +1,7 @@
+include core/arch/arm/kernel/link.mk
+
+all: $(link-out-dir)/tee.srec
+cleanfiles += $(link-out-dir)/tee.srec
+$(link-out-dir)/tee.srec: $(link-out-dir)/tee.elf
+	@$(cmd-echo-silent) '  GEN     $@'
+	$(q)$(OBJCOPYcore) -O srec $< $@

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2016, GlobalLogic
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <console.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/entry_std.h>
+#include <tee/entry_fast.h>
+#include <drivers/scif.h>
+#include <drivers/gic.h>
+
+register_phys_mem(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, SCIF_REG_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
+
+static void main_fiq(void);
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry_std,
+	.fast_smc = tee_entry_fast,
+	.fiq = main_fiq,
+	.cpu_on = cpu_on_handler,
+	.cpu_off = pm_do_nothing,
+	.cpu_suspend = pm_do_nothing,
+	.cpu_resume = pm_do_nothing,
+	.system_off = pm_do_nothing,
+	.system_reset = pm_do_nothing,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+static void main_fiq(void)
+{
+	panic();
+}
+
+static vaddr_t console_base(void)
+{
+	static void *va;
+
+	if (cpu_mmu_enabled()) {
+		if (!va)
+			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_SEC);
+		return (vaddr_t)va;
+	}
+	return CONSOLE_UART_BASE;
+}
+
+void console_init(void)
+{
+	scif_uart_init(console_base());
+}
+
+void console_putc(int ch)
+{
+	if (ch == '\n')
+		scif_uart_putc('\r', console_base());
+	scif_uart_putc(ch, console_base());
+}
+
+void console_flush(void)
+{
+	scif_uart_flush(console_base());
+}

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016, GlobalLogic
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#ifdef ARM64
+#ifdef CFG_WITH_PAGER
+#error "Pager not supported for ARM64"
+#endif
+#endif /*ARM64*/
+
+#define GIC_BASE		0xF1000000
+#define GICC_BASE		0xF1020000
+#define GICD_BASE		0xF1010000
+
+#define CONSOLE_UART_BASE	0xE6E88000
+
+#define DRAM0_BASE		0x44000000
+#define DRAM0_SIZE		0x04000000
+
+/* Location of trusted dram */
+#define TZDRAM_BASE		0x44000000
+#define TZDRAM_SIZE		0x03E00000
+
+#define CFG_TEE_CORE_NB_CORE	8
+
+/* Full GlobalPlatform test suite requires CFG_SHMEM_SIZE to be at least 2MB */
+#define CFG_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
+#define CFG_SHMEM_SIZE		0x100000
+
+#define HEAP_SIZE		(24 * 1024)
+
+#define CFG_TEE_RAM_VA_SIZE	(1024 * 1024)
+
+#ifndef CFG_TEE_LOAD_ADDR
+#define CFG_TEE_LOAD_ADDR	CFG_TEE_RAM_START
+#endif
+
+/*
+ * Everything is in TZDRAM.
+ * +------------------+
+ * |        | TEE_RAM |
+ * + TZDRAM +---------+
+ * |        | TA_RAM  |
+ * +--------+---------+
+ */
+#define CFG_TEE_RAM_PH_SIZE	CFG_TEE_RAM_VA_SIZE
+#define CFG_TEE_RAM_START	(TZDRAM_BASE + 0x00100000)
+#define CFG_TA_RAM_START	ROUNDUP((CFG_TEE_RAM_START + \
+					CFG_TEE_RAM_VA_SIZE), \
+					CORE_MMU_DEVICE_SIZE)
+#define CFG_TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - CFG_TEE_RAM_VA_SIZE), \
+					  CORE_MMU_DEVICE_SIZE)
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-rcar/sub.mk
+++ b/core/arch/arm/plat-rcar/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c

--- a/core/drivers/scif.c
+++ b/core/drivers/scif.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016, GlobalLogic
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <compiler.h>
+#include <io.h>
+#include <util.h>
+#include <drivers/scif.h>
+
+#define SCIF_SCFSR		(0x10)
+#define SCIF_SCFTDR		(0x0C)
+#define SCIF_SCFCR		(0x18)
+#define SCIF_SCFDR		(0x1C)
+
+#define SCFSR_TDFE		BIT(5)
+#define SCFSR_TEND		BIT(6)
+
+#define SCFDR_T_SHIFT		8
+
+#define SCIF_TX_FIFO_SIZE	16
+
+void scif_uart_flush(vaddr_t base)
+{
+	while (!(read16(base + SCIF_SCFSR) & SCFSR_TEND))
+		;
+}
+
+void scif_uart_init(vaddr_t base)
+{
+	/* Bootloader should initialize device for us */
+	scif_uart_flush(base);
+}
+
+void scif_uart_putc(int ch, vaddr_t base)
+{
+	/* Wait until there is space in the FIFO */
+	while ((read16(base + SCIF_SCFDR) >> SCFDR_T_SHIFT) >=
+		SCIF_TX_FIFO_SIZE)
+		;
+	write8(ch, base + SCIF_SCFTDR);
+	write16(read16(base + SCIF_SCFSR) & ~(SCFSR_TEND | SCFSR_TDFE),
+		base + SCIF_SCFSR);
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -15,3 +15,4 @@ srcs-$(CFG_IMX_UART) += imx_uart.c
 srcs-$(CFG_SPRD_UART) += sprd_uart.c
 srcs-$(CFG_HI16XX_UART) += hi16xx_uart.c
 srcs-$(CFG_HI16XX_RNG) += hi16xx_rng.c
+srcs-$(CFG_SCIF) += scif.c

--- a/core/include/drivers/scif.h
+++ b/core/include/drivers/scif.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, GlobalLogic
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SCIF_H
+#define SCIF_H
+
+#include <types_ext.h>
+
+#define SCIF_REG_SIZE	0x1000
+
+void scif_uart_flush(vaddr_t base);
+
+void scif_uart_init(vaddr_t base);
+
+void scif_uart_putc(int ch, vaddr_t base);
+
+#endif /* SCIF */


### PR DESCRIPTION
I have added new platform - plat-rcar.

There are only minimal peripherals support at this time. Only debug UART is working. Anyways, it was tested on renesas salvator-x board. All tests from xtest suite have passed successfully.