### PR TITLE
libfdt: undef sanitizer fix fdt_setprop()

### DIFF
--- a/core/lib/libfdt/fdt_rw.c
+++ b/core/lib/libfdt/fdt_rw.c
@@ -285,7 +285,8 @@ int fdt_setprop(void *fdt, int nodeoffset, const char *name,
 	if (err)
 		return err;
 
-	memcpy(prop->data, val, len);
+	if (len)
+		memcpy(prop->data, val, len);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes undefined sanitizer problem in fdt_setprop().

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMUv7)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>