### PR TITLE
travis: fix coding style path exclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,15 @@ before_script:
   # https://docs.travis-ci.com/user/ci-environment/
   - export make="make -j3 -s"
 
+  # Download  and build Git to be used by the checkpatch step
+  # The Travis container-based infrastructure runs Ubuntu 12.04 (Precise) which
+  # comes with git 1.8.5.6. The path exclusion syntax ':(exclude)' used below
+  # requires a more recent version.
+  - cd $HOME
+  - _download https://github.com/git/git/archive/v2.9.3.tar.gz git-2.9.3.tar.gz
+  - tar xf $DL_DIR/git-2.9.3.tar.gz
+  - $make -C git-2.9.3 CC="ccache gcc" NO_CURL=1
+
   # Tools required for QEMU tests
   # 'apt-get install' cannot be used in the new container-based infrastructure
   # (which is the only allowing caching), so we just build from sources
@@ -79,12 +88,12 @@ before_script:
 
   # checkpatch.pl will ignore the following paths
   - CHECKPATCH_IGNORE=$(echo core/lib/lib{fdt,tomcrypt} lib/lib{png,utils,zlib})
-  - _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo "':\!$p'" ; done)
+  - _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
 
 # Several compilation options are checked
 script:
   # Run checkpatch.pl
-  - git format-patch -1 --stdout -- . $_CP_EXCL | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -
+  - $HOME/git-2.9.3/git format-patch -1 --stdout -- . $_CP_EXCL | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -
 
   # Orly2
   - $make PLATFORM=stm


### PR DESCRIPTION
Commit 0bbd70a5c13c ("travis: exclude some paths when running the
coding style tool") is broken in several ways:

- It will not properly exclude the specified paths from the diff output
because the exclamation mark (!) is not correctly protected when
setting $_CP_EXCL. Let's use ":(exclude)" instead of ":!".
- Even with the above fixed, Travis runs an older version of Git that
does not support pathspec magic ":!" or ":(exclude)". Address that by
compiling Git 2.9.3 from source. This adds about 60-75 seconds to the
build time with a cold cache, 8 seconds when the cache is warm.
- In addition, git format-patch need a commit range (HEAD^..HEAD).
Otherwise it will pick the next oldest patch in case the diff is empty
(due to all changes being excluded).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>