### PR TITLE
travis: run coding style tool on each commit in a pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,14 @@ before_script:
   # checkpatch.pl will ignore the following paths
   - CHECKPATCH_IGNORE=$(echo core/lib/lib{fdt,tomcrypt} lib/lib{png,utils,zlib})
   - _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
+  - function checkpatch() { echo "Checking commit $1"; $HOME/git-2.9.3/git format-patch -1 $1 --stdout -- . $_CP_EXCL | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -; }
 
 # Several compilation options are checked
 script:
-  # Run checkpatch.pl
-  - $HOME/git-2.9.3/git format-patch -1 --stdout -- . $_CP_EXCL | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -
+  # Run checkpatch.pl on:
+  # - the tip of the branch if we're not in a pull request
+  # - each commit in the development branch that's not in the target branch otherwise
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then checkpatch HEAD; else for c in $(git rev-list HEAD^1..HEAD^2); do checkpatch $c || failed=1; done; [ -z "$failed" ]; fi
 
   # Orly2
   - $make PLATFORM=stm


### PR DESCRIPTION
`git format-patch --stdout -1` do not work as expected. In addition to
checking only one commit (as opposed to all the commits in a PR), it
may pick the wrong commit. For instance, when the PR contains several
commits, it shows the tip of the target branch instead of the tip of
the PR branch. So we have to modify the way the commits are selected.

There are two reasons why a Travis build is triggered: either a pull
request, or a branch is pushed to a monitored repository. One can tell
the two cases appart thanks to the $TRAVIS_PULL_REQUEST environment
variable.

- In the first case (pull request), HEAD is always a merge commit
between the development branch and the target branch. Use `git
rev-list` to expand the list of commits in HEAD^1..HEAD^2 (those that
are in the dev branch but not in the target branch) and ask
format-patch to show exactly those commits with `-1 <commit-sha1>`.
As a result, all the patches will be checked individually.
- In the second case (not a pull request), HEAD is typically not a
merge, it is simply the tip of the development branch being monitored.
Using '-1 HEAD' is fine.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>