### PR TITLE
hikey: increase heap size from 24 KiB to 32 KiB

### DIFF
--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -49,7 +49,7 @@
 #define CONSOLE_BAUDRATE	115200
 #define CONSOLE_UART_CLK_IN_HZ	19200000
 
-#define HEAP_SIZE		(24 * 1024)
+#define HEAP_SIZE		(32 * 1024)
 
 /*
  * HiKey memory map


### PR DESCRIPTION
The current heap size is not enough to run `xtest` when both the
default secure storage (CFG_REE_FS) and the newly added SQLite FS
(CFG_SQL_FS) are enabled. Let's increase it a bit.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>