### PR TITLE
[RFC] core: add heap allocation failure statistics

### DIFF
--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -106,9 +106,11 @@ static size_t tee_mm_stats_allocated(tee_mm_pool_t *pool)
 	return sz << pool->shift;
 }
 
-void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct tee_mm_pool_stats *stats,
+void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct malloc_stats *stats,
 			   bool reset)
 {
+	memset(stats, 0, sizeof(*stats));
+
 	stats->size = pool->hi - pool->lo;
 	stats->max_allocated = pool->max_allocated;
 	stats->allocated = tee_mm_stats_allocated(pool);

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -116,7 +116,7 @@ void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct malloc_stats *stats,
 	stats->allocated = tee_mm_stats_allocated(pool);
 
 	if (reset)
-		stats->max_allocated = 0;
+		pool->max_allocated = 0;
 }
 
 static void update_max_allocated(tee_mm_pool_t *pool)

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -28,6 +28,7 @@
 #ifndef TEE_MM_H
 #define TEE_MM_H
 
+#include <malloc.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <kernel/tee_common_unpg.h>
@@ -130,14 +131,7 @@ bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, uint32_t addr);
 bool tee_mm_is_empty(tee_mm_pool_t *pool);
 
 #ifdef CFG_WITH_STATS
-#define TEE_MM_POOL_DESC_LENGTH 32
-struct tee_mm_pool_stats {
-	char desc[TEE_MM_POOL_DESC_LENGTH];
-	uint32_t allocated;
-	uint32_t max_allocated;
-	uint32_t size;
-};
-void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct tee_mm_pool_stats *stats,
+void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct malloc_stats *stats,
 			   bool reset);
 #endif
 

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -85,10 +85,24 @@ bool malloc_buffer_overlaps_heap(void *buf, size_t len);
  */
 void malloc_add_pool(void *buf, size_t len);
 
-/* get malloc stats: curr allocated heap and max allocated heap since boot */
-void malloc_reset_max_allocated(void);
-size_t malloc_get_max_allocated(void);
-size_t malloc_get_allocated(void);
-size_t malloc_get_heap_size(void);
+#ifdef CFG_WITH_STATS
+/*
+ * Get/reset allocation statistics
+ */
+
+#define TEE_ALLOCATOR_DESC_LENGTH 32
+struct malloc_stats {
+	char desc[TEE_ALLOCATOR_DESC_LENGTH];
+	uint32_t allocated;               /* Bytes currently allocated */
+	uint32_t max_allocated;           /* Tracks max value of allocated */
+	uint32_t size;                    /* Total size for this allocator */
+	uint32_t num_alloc_fail;          /* Number of failed alloc requests */
+	uint32_t biggest_alloc_fail;      /* Size of biggest failed alloc */
+	uint32_t biggest_alloc_fail_used; /* Alloc bytes when above occurred */
+};
+
+void malloc_get_stats(struct malloc_stats *stats);
+void malloc_reset_stats(void);
+#endif /* CFG_WITH_STATS */
 
 #endif /* MALLOC_H */


### PR DESCRIPTION
Adds the following statistics to the heap allocator and export then via
the static TA `core/arch/arm/sta/stats.c` (all of them can be reset):

 - num_alloc_fail: number of calls to malloc()/calloc()/realloc() that
returned NULL
 - biggest_alloc_fail: the size in bytes of the largest allocation
request that resulted in a failure
 - biggest_alloc_fail_used: the number of bytes that were allocated at
that time

Depends on CFG_WITH_STATS=y.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>