### PR TITLE
core: arm64: thread_std_smc_entry(): set FP to 0 before calling C code

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -379,6 +379,9 @@ static void init_regs(struct thread_ctx *thread,
 	thread->regs.x[5] = args->a5;
 	thread->regs.x[6] = args->a6;
 	thread->regs.x[7] = args->a7;
+
+	/* Set up frame pointer as per the Aarch64 AAPCS */
+	thread->regs.x[29] = 0;
 }
 #endif /*ARM64*/
 


### PR DESCRIPTION
thread_std_smc_entry() should set the frame pointer (x29) to zero to
indicate the end of the frame record chain, as required by the Aarch64
AAPCS. Without this, there is no guarantee that unwind_stack() will
terminate.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>