### PR TITLE
core: arm: add no-map property to res mem

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -518,6 +518,9 @@ static int add_optee_res_mem_dt_node(void *fdt)
 		ret = fdt_setprop(fdt, offs, "reg", data, sizeof(data));
 		if (ret < 0)
 			return -1;
+		ret = fdt_setprop(fdt, offs, "no-map", NULL, 0);
+		if (ret < 0)
+			return -1;
 	} else {
 		return -1;
 	}


### PR DESCRIPTION
Adds a "no-map" property to the optee@xxx node. Before this patch the node
looked like:
optee@78000000 {
    reg = <0x78000000 0x800000>;
};
With this patch it becomes:
optee@78000000 {
    reg = <0x78000000 0x800000>;
    no-map;
};

This makes it clear to the Linux kernel that it must leave it to the
OP-TEE driver to map the reserved memory.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Fixes https://github.com/OP-TEE/optee_os/issues/1034