### PR TITLE
travis: also check whole diff when pull request has several commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,9 @@ before_script:
   # checkpatch.pl will ignore the following paths
   - CHECKPATCH_IGNORE=$(echo core/lib/lib{fdt,tomcrypt} lib/lib{png,utils,zlib})
   - _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
-  - function checkpatch() { echo "Checking commit $1"; $HOME/git-2.9.3/git format-patch -1 $1 --stdout -- . $_CP_EXCL | $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -; }
+  - function _checkpatch() { $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -; }
+  - function checkpatch() { echo "Checking commit $1"; $HOME/git-2.9.3/git format-patch -1 $1 --stdout -- . $_CP_EXCL | _checkpatch; }
+  - function checkdiff() { echo "Checking squashed commits (diff $1...$2)"; $HOME/git-2.9.3/git diff $1...$2 -- . $_CP_EXCL | _checkpatch; }
 
 # Several compilation options are checked
 script:
@@ -97,6 +99,9 @@ script:
   # - the tip of the branch if we're not in a pull request
   # - each commit in the development branch that's not in the target branch otherwise
   - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then checkpatch HEAD; else for c in $(git rev-list HEAD^1..HEAD^2); do checkpatch $c || failed=1; done; [ -z "$failed" ]; fi
+  # If we have a pull request with more than 1 commit, also check the squashed commits
+  # Useful to check if fix-up commits do indeed solve previous checkpatch errors
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then if [ "$(git rev-list --count HEAD^1..HEAD^2)" -gt 1 ]; then checkdiff $(git rev-parse HEAD^1) $(git rev-parse HEAD^2); fi; fi
 
   # Orly2
   - $make PLATFORM=stm

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ before_script:
   - CHECKPATCH_IGNORE=$(echo core/lib/lib{fdt,tomcrypt} lib/lib{png,utils,zlib})
   - _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
   - function _checkpatch() { $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -; }
-  - function checkpatch() { echo "Checking commit $1"; $HOME/git-2.9.3/git format-patch -1 $1 --stdout -- . $_CP_EXCL | _checkpatch; }
+  - function checkpatch() { printf "Checking commit:\n  "; $HOME/git-2.9.3/git show --oneline --no-patch $1; $HOME/git-2.9.3/git format-patch -1 $1 --stdout -- . $_CP_EXCL | _checkpatch; }
   - function checkdiff() { echo "Checking squashed commits (diff $1...$2)"; $HOME/git-2.9.3/git diff $1...$2 -- . $_CP_EXCL | _checkpatch; }
 
 # Several compilation options are checked

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_script:
   # checkpatch.pl will ignore the following paths
   - CHECKPATCH_IGNORE=$(echo core/lib/lib{fdt,tomcrypt} lib/lib{png,utils,zlib})
   - _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
-  - function _checkpatch() { $DST_KERNEL/scripts/checkpatch.pl --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -; }
+  - function _checkpatch() { $DST_KERNEL/scripts/checkpatch.pl --quiet --ignore FILE_PATH_CHANGES --ignore GERRIT_CHANGE_ID --no-tree -; }
   - function checkpatch() { printf "Checking commit:\n  "; $HOME/git-2.9.3/git show --oneline --no-patch $1; $HOME/git-2.9.3/git format-patch -1 $1 --stdout -- . $_CP_EXCL | _checkpatch; }
   - function checkdiff() { echo "Checking squashed commits (diff $1...$2)"; $HOME/git-2.9.3/git diff $1...$2 -- . $_CP_EXCL | _checkpatch; }
 


### PR DESCRIPTION
Address a common situation when a pull request is reviewed. Suppose a
PR contains one commit, which causes checkpatch warnings. The author
pushes a new commit to fix the warnings. Travis will still complain
because it checks every commit in the PR, and the author has no way to
make sure the fix is actually correct.
To alleviate this problem, add a call to checkpatch that will process
the whole diff added by the PR branch to the target branch (i.e., git
diff HEAD^1...HEAD^2). In the above example, the Travis status will
still be fail until all commits actually comply with the rules, but the
PR author can check that his/her contribution is OK as a whole.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>