### PR TITLE
core: bugfix reading beyond end of file

### DIFF
--- a/core/tee/tee_sql_fs.c
+++ b/core/tee/tee_sql_fs.c
@@ -737,7 +737,9 @@ static int sql_fs_read(TEE_Result *errno, int fd, void *buf, size_t len)
 		goto exit_ret;
 	}
 
-	if (fdp->pos + len > fdp->meta.length)
+	if ((fdp->pos + len) < len || fdp->pos > fdp->meta.length)
+		len = 0;
+	else if (fdp->pos + len > fdp->meta.length)
 		len = fdp->meta.length - fdp->pos;
 
 	if (!len) {


### PR DESCRIPTION
Bugfix for reading beyond end of a persistent object when the file
position is larger the the size of the data stream. Applies to both REE
FS and SQL FS.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>