### PR TITLE
syscall storage_obj_seek: fix sign extension

### DIFF
--- a/core/include/tee/tee_svc_storage.h
+++ b/core/include/tee/tee_svc_storage.h
@@ -75,7 +75,7 @@ TEE_Result syscall_storage_obj_write(unsigned long obj, void *data,
 
 TEE_Result syscall_storage_obj_trunc(unsigned long obj, size_t len);
 
-TEE_Result syscall_storage_obj_seek(unsigned long obj, long offset,
+TEE_Result syscall_storage_obj_seek(unsigned long obj, int32_t offset,
 				    unsigned long whence);
 
 void tee_svc_storage_close_all_enum(struct user_ta_ctx *utc);

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -1430,7 +1430,7 @@ exit:
 	return res;
 }
 
-TEE_Result syscall_storage_obj_seek(unsigned long obj, long offset,
+TEE_Result syscall_storage_obj_seek(unsigned long obj, int32_t offset,
 				    unsigned long whence)
 {
 	TEE_Result res;

--- a/lib/libutee/include/utee_syscalls.h
+++ b/lib/libutee/include/utee_syscalls.h
@@ -37,10 +37,11 @@
 #include <trace.h>
 
 /*
- * Arguments must use the native register width. To keep it simple, only
- * use pointers, long, unsigned long and size_t. Pointers may only point
- * structures or types based on fixed width integer types. Only exception
- * are buffers with opaque data.
+ * Arguments must use the native register width, unless it's a signed
+ * argument then it must be a 32-bit value instead to avoid problems with
+ * sign extension. To keep it simple, only use pointers, int32_t, unsigned
+ * long and size_t. Pointers may only point structures or types based on
+ * fixed width integer types. Only exception are buffers with opaque data.
  *
  * Return values should not use a fixed width larger than 32 bits, unsigned
  * long and pointers are OK though.
@@ -223,7 +224,7 @@ TEE_Result utee_storage_obj_trunc(unsigned long obj, size_t len);
 
 /* obj is of type TEE_ObjectHandle */
 /* whence is of type TEE_Whence */
-TEE_Result utee_storage_obj_seek(unsigned long obj, long offset,
+TEE_Result utee_storage_obj_seek(unsigned long obj, int32_t offset,
 				 unsigned long whence);
 
 /* seServiceHandle is of type TEE_SEServiceHandle */


### PR DESCRIPTION
Fixes problem with sign extension (or lack thereof) for the syscall
storage_obj_seek. Updates the general rules of arguments for syscalls to
use signed 32-bit parameters when a signed parameter is needed.

Suggested-by: Jerome Forissier <jerome.forissier@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU and FVP)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>