### PR TITLE
fix an error in cipher

### DIFF
--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -2219,7 +2219,7 @@ static void cipher_final(void *ctx, uint32_t algo)
 		break;
 #endif
 	default:
-		/* TEE_ERROR_NOT_SUPPORTED; */
+		assert(TEE_ALG_GET_CLASS(algo) == TEE_OPERATION_CIPHER);
 		break;
 	}
 }

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2471,7 +2471,7 @@ static TEE_Result tee_svc_cipher_update_helper(unsigned long state,
 	}
 
 	if (last_block && cs->ctx_finalize != NULL) {
-		cs->ctx_finalize(cs->ctx, cs->mode);
+		cs->ctx_finalize(cs->ctx, cs->algo);
 		cs->ctx_finalize = NULL;
 	}
 


### PR DESCRIPTION
Fix an error in function tee_svc_cipher_update_helper, and add assert in function cipher_final to prevent it being called by an algorithm that is not a symmetric cipher.

Signed-off-by: lackan <liang.guanchao@linaro.org>