### PR TITLE
hikey: 32-bit: use -mcpu=cortex-a53 instead of cortex-a15

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -1,5 +1,5 @@
 # 32-bit flags
-arm32-platform-cpuarch		:= cortex-a15
+arm32-platform-cpuarch		:= cortex-a53
 arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags		+= -mcpu=$(arm32-platform-cpuarch)
 core_arm32-platform-aflags	+= -mfpu=neon


### PR DESCRIPTION
Use the proper CPU architecture when building 32-bit binaries for HiKey.
Note: this triggers a compiler warning:
   CC      out/arm-plat-hikey/core/tee/tee_svc_cryp.o
 {standard input}: Assembler messages:
 {standard input}:632: Warning: IT blocks containing 32-bit Thumb instructions are deprecated in ARMv8
(compiler is gcc-linaro-arm-linux-gnueabihf-4.9-2014.09_linux).
This seems to be harmless and is registered as a compiler bug [1].

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67591

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>