### PR TITLE
mtk: map entire MEM_AREA_NSEC_SHM area

### DIFF
--- a/core/arch/arm/plat-mediatek/platform_config.h
+++ b/core/arch/arm/plat-mediatek/platform_config.h
@@ -62,8 +62,8 @@
 #define CFG_TEE_CORE_NB_CORE	4
 
 /* Full GlobalPlatform test suite requires CFG_SHMEM_SIZE to be at least 2MB */
-#define CFG_SHMEM_START		(TZDRAM_BASE - 0x100000)
-#define CFG_SHMEM_SIZE		0x100000
+#define CFG_SHMEM_START		(TZDRAM_BASE - 0x200000)
+#define CFG_SHMEM_SIZE		0x200000
 
 #else
 #error "Unknown platform flavor"


### PR DESCRIPTION
Running MTK8173 panics in tee_entry_std just after mapping the
arguments. The reason for this is because only 1MB out of 2MB has been
mapped and therefore leaving a gap between MEM_AREA_NSEC_SHM and
MEM_AREA_TA_RAM. I.e.,

  DEBUG:   [0x0] TEE-CORE:init_mem_map:398: type va 4
    0xbc000000..0xbc0fffff pa 0xbdf00000..0xbdffffff size 0x100000

  DEBUG:   [0x0] TEE-CORE:init_mem_map:398: type va 3
    0xbc200000..0xbdffffff pa 0xbe200000..0xbfffffff size 0x1e00000

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>