### PR TITLE
core: fix spinlock for armv7 and aarch32

### DIFF
--- a/core/arch/arm/kernel/proc_a32.S
+++ b/core/arch/arm/kernel/proc_a32.S
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
  *
@@ -12,6 +13,10 @@
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
  *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -23,10 +28,6 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- */
-
-/*
- * ARMv7 core support routines
  */
 
 #include <kernel/tz_proc.h>
@@ -46,10 +47,8 @@ _spinlock_loop:
 	ldrex r1, [r0]
 	cmp r1, #SPINLOCK_UNLOCK
 	wfene
-	bne _spinlock_loop
-	strex r1, r2, [r0]
-	cmp r1, #0
-	wfene
+	strexeq r1, r2, [r0]
+	cmpeq r1, #0
 	bne _spinlock_loop
 	dmb
 	bx lr


### PR DESCRIPTION
Failure to acquire exclusivity when storing locked value on a
spinlock should not yield to wait for an event, just attempting
'strex' execution again.

Tested-by: Etienne Carriere <etienne.carriere@linaro.org> (b2260/qemu)
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>