### PR TITLE
travis: prevent warning from code checking tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_script:
   - export DST_KERNEL=$PWD/linux && mkdir -p $DST_KERNEL/scripts && cd $DST_KERNEL/scripts
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl && chmod a+x checkpatch.pl
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+  - touch const_structs.checkpatch
   - cd $MYHOME
 
   - export DL_DIR=$HOME/downloads


### PR DESCRIPTION
The checkpatch.pl script uses a file called const_structs.checkpatch to
check for correct usage of some kernel structures. We don't want those
checks, which are linux-specific, but we still need the file to be
present otherwise the tool will log a warning message [1].

[1] https://travis-ci.org/OP-TEE/optee_os/builds/167271505#L1720

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>