### PR TITLE
Fix per-library flags (cflags-lib-y / cppflags-lib-y) with multiple builds

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -63,7 +63,7 @@ objs		+= $2
 comp-dep-$2	:= $$(dir $2).$$(notdir $2).d
 comp-cmd-file-$2:= $$(dir $2).$$(notdir $2).cmd
 comp-sm-$2	:= $(sm)
-comp-lib-$2	:= $(libname)
+comp-lib-$2	:= $(libname)-$(sm)
 
 cleanfiles := $$(cleanfiles) $$(comp-dep-$2) $$(comp-cmd-file-$2) $2
 

--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -9,9 +9,9 @@
 #         aflags-$(oname) aflags-remove-$(oname)
 #         cppflags-$(oname) cppflags-remove-$(oname)
 #         incdirs-$(oname)
-#         incdirs-lib$(libname)  [if libname is defined]
-#         cppflags-lib$(libname) [if libname is defined]
-#         cflags-lib$(libname)   [if libname is defined]
+#         incdirs-lib$(libname)-$(sm)  [if libname is defined]
+#         cppflags-lib$(libname)-$(sm) [if libname is defined]
+#         cflags-lib$(libname)-$(sm)   [if libname is defined]
 # for each file found, oname is the name of the object file for corresponding
 # source file
 
@@ -119,9 +119,9 @@ sub-subdirs := $$(addprefix $1/,$$(subdirs-y))
 incdirs$(sm) := $(incdirs$(sm)) $$(addprefix $1/,$$(global-incdirs-y))
 thissubdir-incdirs := $(out-dir)/$(base-prefix)$1 $$(addprefix $1/,$$(incdirs-y))
 ifneq ($$(libname),)
-incdirs-lib$$(libname) := $$(incdirs-lib$$(libname)) $$(addprefix $1/,$$(incdirs-lib-y))
-cflags-lib$$(libname) := $$(cflags-lib$$(libname)) $$(cflags-lib-y)
-cppflags-lib$$(libname) := $$(cppflags-lib$$(libname)) $$(cppflags-lib-y)
+incdirs-lib$$(libname)-$$(sm) := $$(incdirs-lib$$(libname)-$$(sm)) $$(addprefix $1/,$$(incdirs-lib-y))
+cflags-lib$$(libname)-$$(sm) := $$(cflags-lib$$(libname)-$$(sm)) $$(cflags-lib-y)
+cppflags-lib$$(libname)-$$(sm) := $$(cppflags-lib$$(libname)-$$(sm)) $$(cppflags-lib-y)
 endif
 
 # Process files in current directory


### PR DESCRIPTION
Because a library may be built several times (for example, libutils.a
is built differently for kernel and user mode), the variables that hold
the library-specific flags have to be cleared when done.
These variables are: cflags-lib$(libname) and cppflags-lib$(libname).
They may be set manually set in the makefiles (sub.mk), and they also
contain the value of $(cflags-lib-y) or $(cppflags-lib-y) respectively.

Fixes: 3d34e125a253 ("Add support for $(cflags-lib-y)")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>