### PR TITLE
core: TA private memory does not include the memref parameters

### DIFF
--- a/core/include/mm/tee_mmu.h
+++ b/core/include/mm/tee_mmu.h
@@ -57,7 +57,12 @@ void tee_mmu_map_clear(struct user_ta_ctx *utc);
 TEE_Result tee_mmu_map_param(struct user_ta_ctx *utc,
 			struct tee_ta_param *param);
 
-
+/*
+ * TA private memory is defined as TA image static segment (code, ro/rw static
+ * data, heap, stack). The sole other virtual memory mapped to TA are memref
+ * parameters. These later are considered outside TA private memory as it
+ * might be accessed by the TA and its client(s).
+ */
 bool tee_mmu_is_vbuf_inside_ta_private(const struct user_ta_ctx *utc,
 				       const void *va, size_t size);
 


### PR DESCRIPTION
This change limits ta_private_vmem_end to TA segments defined when
TA is loaded.

Currently 'ta_private_vmem_end' only used to prevent a TA from exposing
its code/data/stack memory to another TA it invokes. A shared memory
buffer passed as TA invocation parameter is obviously not inside the TA
private memory an can be exposed to another TA.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>