### PR TITLE
travis: workaround false positive in code checking tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   - export DST_KERNEL=$PWD/linux && mkdir -p $DST_KERNEL/scripts && cd $DST_KERNEL/scripts
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl && chmod a+x checkpatch.pl
   - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
-  - touch const_structs.checkpatch
+  - echo "invalid.struct.name" >const_structs.checkpatch
   - cd $MYHOME
 
   - export DL_DIR=$HOME/downloads


### PR DESCRIPTION
Workaround a checkpatch bug [1] by creating a non-empty file
const_structs.checkpatch. By adding the name of a struct that cannot
appear in valid code, we avoid the false warning (which occurs only
no name is given) and this can't produce any unwanted side-effect.

[1] https://www.spinics.net/lists/kernel/threads.html#2364905

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>