### PR TITLE
syscall_log: do not prepend TEE core prefix

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -56,11 +56,11 @@ void syscall_log(const void *buf __maybe_unused, size_t len __maybe_unused)
 	kbuf = malloc(len);
 	if (kbuf == NULL)
 		return;
-	*kbuf = '\0';
 
-	/* log as Info/Raw traces */
-	if (tee_svc_copy_from_user(kbuf, buf, len) == TEE_SUCCESS)
-		TAMSG_RAW("%.*s", (int)len, kbuf);
+	if (tee_svc_copy_from_user(kbuf, buf, len) == TEE_SUCCESS) {
+		kbuf[len] = '\0';
+		trace_ext_puts(kbuf);
+	}
 
 	free(kbuf);
 #endif


### PR DESCRIPTION
Fixes the debug output of Trusted Applications. For example:
- Previous output:
ERROR:   TEE-CORE: DEBUG:   USER-TA:TA_CreateEntryPoint:41: Blah
- New output:
DEBUG:   USER-TA:TA_CreateEntryPoint:41: Blah

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>