### PR TITLE
ta_dev_kit.mk: get optional flags from $(CFLAGS_$(sm))/$(CPPFLAGS_$(sm))

### DIFF
--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -46,9 +46,9 @@ cmd-echo-silent := true
 endif
 endif
 
-cppflags$(sm)  := $($(sm)-platform-cppflags)
+cppflags$(sm)  := $($(sm)-platform-cppflags) $(CPPFLAGS_$(sm))
 aflags$(sm)    := $($(sm)-platform-aflags)
-cflags$(sm)    := $($(sm)-platform-cflags)
+cflags$(sm)    := $($(sm)-platform-cflags) $(CFLAGS_$(sm))
 
 CFG_TEE_TA_LOG_LEVEL ?= 2
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)


### PR DESCRIPTION
This provides an easy way to append some flags to the TA build, for
instance: `make CFLAGS_ta_arm64=-O0' to disable optimizations in 64-bit
TAs.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>