### PR TITLE
core: pass back the user data in the irq callback

### DIFF
--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -148,7 +148,7 @@ void console_flush(void)
 }
 
 #ifdef IT_CONSOLE_UART
-static enum itr_return console_itr_cb(struct itr_handler *h __unused)
+static enum itr_return console_itr_cb(void *data __unused)
 {
 	paddr_t uart_base = console_base();
 

--- a/core/drivers/ps2mouse.c
+++ b/core/drivers/ps2mouse.c
@@ -126,9 +126,9 @@ reset:
 	d->serial->ops->putc(d->serial, PS2_CMD_RESET);
 }
 
-static enum itr_return ps2mouse_itr_cb(struct itr_handler *h)
+static enum itr_return ps2mouse_itr_cb(void *data)
 {
-	struct ps2mouse_data *d = h->data;
+	struct ps2mouse_data *d = data;
 
 	if (!d->serial->ops->have_rx_data(d->serial))
 		return ITRR_NONE;

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -50,7 +50,7 @@ enum itr_return {
 struct itr_handler {
 	size_t it;
 	uint32_t flags;
-	enum itr_return (*handler)(struct itr_handler *h);
+	enum itr_return (*handler)(void *data);
 	void *data;
 	SLIST_ENTRY(itr_handler) link;
 };

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -64,7 +64,7 @@ void itr_handle(size_t it)
 		return;
 	}
 
-	if (h->handler(h) != ITRR_HANDLED) {
+	if (h->handler(h->data) != ITRR_HANDLED) {
 		EMSG("Disabling interrupt %zu not handled by handler", it);
 		itr_chip->ops->disable(itr_chip, it);
 	}


### PR DESCRIPTION
Pass back the user data instead of the handler pointer.

Signed-off-by: Zeng Tao prime.zeng@hisilicon.com
