### PR TITLE
core: fix 'flow' traces in pager

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -72,10 +72,6 @@
 #define CORE_MMU_USER_PARAM_SIZE	(1 << CORE_MMU_USER_PARAM_SHIFT)
 #define CORE_MMU_USER_PARAM_MASK	(CORE_MMU_USER_PARAM_SIZE - 1)
 
-#ifdef CFG_WITH_PAGER
-extern vaddr_t core_mmu_linear_map_end;
-#endif
-
 /*
  * Memory area type:
  * MEM_AREA_NOTYPE:   Undefined type. Used as end of table.

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -207,7 +207,6 @@ static void init_runtime(unsigned long pageable_part)
 	 */
 	memset(__bss_start, 0, __bss_end - __bss_start);
 
-	core_mmu_linear_map_end = (vaddr_t)__heap2_end;
 	/*
 	 * This needs to be initialized early to support address lookup
 	 * in MEM_AREA_TEE_RAM

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -615,6 +615,11 @@ static size_t area_va2idx(struct tee_pager_area *area, vaddr_t va)
 	return (va - (area->base & ~CORE_MMU_PGDIR_MASK)) >> SMALL_PAGE_SHIFT;
 }
 
+static vaddr_t __unused area_idx2va(struct tee_pager_area *area, size_t idx)
+{
+	return (idx << SMALL_PAGE_SHIFT) + (area->base & ~CORE_MMU_PGDIR_MASK);
+}
+
 #ifdef CFG_PAGED_USER_TA
 bool tee_pager_set_uta_area(struct user_ta_ctx *utc, vaddr_t base, size_t size,
 			    uint32_t flags)
@@ -732,6 +737,7 @@ static bool tee_pager_unhide_page(vaddr_t page_va)
 
 static void tee_pager_hide_pages(void)
 {
+	struct core_mmu_table_info __unused *ti = &pager_alias_tbl_info;
 	struct tee_pager_pmem *pmem;
 	size_t n = 0;
 
@@ -756,7 +762,7 @@ static void tee_pager_hide_pages(void)
 		if (attr & (TEE_MATTR_PW | TEE_MATTR_UW)){
 			a = TEE_MATTR_HIDDEN_DIRTY_BLOCK;
 			FMSG("Hide %#" PRIxVA,
-			     pmem->area->ti->va_base +
+			     ti->va_base +
 			     pmem->pgidx * SMALL_PAGE_SIZE);
 		} else
 			a = TEE_MATTR_HIDDEN_BLOCK;

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -615,11 +615,6 @@ static size_t area_va2idx(struct tee_pager_area *area, vaddr_t va)
 	return (va - (area->base & ~CORE_MMU_PGDIR_MASK)) >> SMALL_PAGE_SHIFT;
 }
 
-static vaddr_t __unused area_idx2va(struct tee_pager_area *area, size_t idx)
-{
-	return (idx << SMALL_PAGE_SHIFT) + (area->base & ~CORE_MMU_PGDIR_MASK);
-}
-
 #ifdef CFG_PAGED_USER_TA
 bool tee_pager_set_uta_area(struct user_ta_ctx *utc, vaddr_t base, size_t size,
 			    uint32_t flags)
@@ -737,7 +732,6 @@ static bool tee_pager_unhide_page(vaddr_t page_va)
 
 static void tee_pager_hide_pages(void)
 {
-	struct core_mmu_table_info __unused *ti = &pager_alias_tbl_info;
 	struct tee_pager_pmem *pmem;
 	size_t n = 0;
 
@@ -762,7 +756,7 @@ static void tee_pager_hide_pages(void)
 		if (attr & (TEE_MATTR_PW | TEE_MATTR_UW)){
 			a = TEE_MATTR_HIDDEN_DIRTY_BLOCK;
 			FMSG("Hide %#" PRIxVA,
-			     ti->va_base +
+			     pmem->area->ti->va_base +
 			     pmem->pgidx * SMALL_PAGE_SIZE);
 		} else
 			a = TEE_MATTR_HIDDEN_BLOCK;


### PR DESCRIPTION
Fix 2 broken `FMSG()` traces in tee_pager.c.
