### PR TITLE
core: mm: use paddr_t for pool address

### DIFF
--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -34,7 +34,7 @@
 #include <mm/tee_mm.h>
 #include <mm/tee_pager.h>
 
-bool tee_mm_init(tee_mm_pool_t *pool, uint32_t lo, uint32_t hi, uint8_t shift,
+bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_t hi, uint8_t shift,
 		 uint32_t flags)
 {
 	if (pool == NULL)
@@ -310,7 +310,7 @@ size_t tee_mm_get_bytes(const tee_mm_entry_t *mm)
 		return mm->size << mm->pool->shift;
 }
 
-bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, uint32_t addr)
+bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, paddr_t addr)
 {
 	return (pool && ((addr >= pool->lo) && (addr <= pool->hi)));
 }
@@ -326,7 +326,7 @@ tee_mm_pool_t tee_mm_sec_ddr __early_bss;
 /* Virtual eSRAM pool */
 tee_mm_pool_t tee_mm_vcore __early_bss;
 
-tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uint32_t addr)
+tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, paddr_t addr)
 {
 	tee_mm_entry_t *entry = pool->entry;
 	uint16_t offset = (addr - pool->lo) >> pool->shift;

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -48,8 +48,8 @@ typedef struct _tee_mm_entry_t tee_mm_entry_t;
 
 struct _tee_mm_pool_t {
 	tee_mm_entry_t *entry;
-	uint32_t lo;		/* low boundery pf the pool */
-	uint32_t hi;		/* high boundery pf the pool */
+	paddr_t lo;		/* low boundery pf the pool */
+	paddr_t hi;		/* high boundery pf the pool */
 	uint32_t flags;		/* Config flags for the pool */
 	uint8_t shift;		/* size shift */
 #ifdef CFG_WITH_STATS
@@ -68,7 +68,7 @@ extern tee_mm_pool_t tee_mm_vcore;
  * Returns a pointer to the mm covering the supplied address,
  * if no mm is found NULL is returned.
  */
-tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uint32_t addr);
+tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, paddr_t addr);
 
 /*
  * Validates that an address (addr) is part of the secure virtual memory
@@ -76,7 +76,7 @@ tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uint32_t addr);
  * NOTE: This function is executed in abort mode.
  *       Please take care of stack usage
  */
-static inline bool tee_mm_validate(const tee_mm_pool_t *pool, uint32_t addr)
+static inline bool tee_mm_validate(const tee_mm_pool_t *pool, paddr_t addr)
 {
 	return tee_mm_find(pool, addr) != 0;
 }
@@ -88,7 +88,7 @@ static inline bool tee_mm_validate(const tee_mm_pool_t *pool, uint32_t addr)
 uintptr_t tee_mm_get_smem(const tee_mm_entry_t *mm);
 
 /* Init managed memory area */
-bool tee_mm_init(tee_mm_pool_t *pool, uint32_t lo, uint32_t hi, uint8_t shift,
+bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_t hi, uint8_t shift,
 		 uint32_t flags);
 
 /* Kill managed memory area*/
@@ -126,7 +126,7 @@ static inline uint32_t tee_mm_get_offset(tee_mm_entry_t *p)
 /* Return size of the mm entry in bytes */
 size_t tee_mm_get_bytes(const tee_mm_entry_t *mm);
 
-bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, uint32_t addr);
+bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, paddr_t addr);
 
 bool tee_mm_is_empty(tee_mm_pool_t *pool);
 


### PR DESCRIPTION
Use paddr_t to replace uint32_t.

tee_mm_init use paddr_t type for 'lo' and 'hi', but tee_mm_pool_t use uint32_t
for pool 'lo' and 'hi'. on ARM64, this is not correct.

Use paddr_t to fix this.

Signed-off-by: Peng Fan peng.fan@nxp.com
