### PR TITLE
tee_mm: use correct types for addresses and sizes

### DIFF
--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -34,7 +34,7 @@
 #include <mm/tee_mm.h>
 #include <mm/tee_pager.h>
 
-bool tee_mm_init(tee_mm_pool_t *pool, uint32_t lo, uint32_t hi, uint8_t shift,
+bool tee_mm_init(tee_mm_pool_t *pool, uintptr_t lo, uintptr_t hi, uint8_t shift,
 		 uint32_t flags)
 {
 	if (pool == NULL)
@@ -132,12 +132,12 @@ static inline void update_max_allocated(tee_mm_pool_t *pool __unused)
 }
 #endif /* CFG_WITH_STATS */
 
-tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, uint32_t size)
+tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, size_t size)
 {
-	uint32_t psize;
+	size_t psize;
 	tee_mm_entry_t *entry;
 	tee_mm_entry_t *nn;
-	uint32_t remaining;
+	size_t remaining;
 
 	/* Check that pool is initialized */
 	if (!pool || !pool->entry)
@@ -210,7 +210,7 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, uint32_t size)
 }
 
 static inline bool fit_in_gap(tee_mm_pool_t *pool, tee_mm_entry_t *e,
-			      uint32_t offslo, uint32_t offshi)
+			      uintptr_t offslo, uintptr_t offshi)
 {
 	if (pool->flags & TEE_MM_POOL_HI_ALLOC) {
 		if (offshi > e->offset ||
@@ -233,8 +233,8 @@ static inline bool fit_in_gap(tee_mm_pool_t *pool, tee_mm_entry_t *e,
 tee_mm_entry_t *tee_mm_alloc2(tee_mm_pool_t *pool, vaddr_t base, size_t size)
 {
 	tee_mm_entry_t *entry;
-	uint32_t offslo;
-	uint32_t offshi;
+	uintptr_t offslo;
+	uintptr_t offshi;
 	tee_mm_entry_t *mm;
 
 	/* Check that pool is initialized */
@@ -309,7 +309,7 @@ size_t tee_mm_get_bytes(const tee_mm_entry_t *mm)
 		return mm->size << mm->pool->shift;
 }
 
-bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, uint32_t addr)
+bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, uintptr_t addr)
 {
 	return (pool && ((addr >= pool->lo) && (addr <= pool->hi)));
 }
@@ -325,7 +325,7 @@ tee_mm_pool_t tee_mm_sec_ddr __early_bss;
 /* Virtual eSRAM pool */
 tee_mm_pool_t tee_mm_vcore __early_bss;
 
-tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uint32_t addr)
+tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uintptr_t addr)
 {
 	tee_mm_entry_t *entry = pool->entry;
 	uint16_t offset = (addr - pool->lo) >> pool->shift;

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -39,15 +39,15 @@
 struct _tee_mm_entry_t {
 	struct _tee_mm_pool_t *pool;
 	struct _tee_mm_entry_t *next;
-	uint32_t offset;	/* offset in pages/sections */
-	uint32_t size;		/* size in pages/sections */
+	uintptr_t offset;	/* offset in pages/sections */
+	size_t size;		/* size in pages/sections */
 };
 typedef struct _tee_mm_entry_t tee_mm_entry_t;
 
 struct _tee_mm_pool_t {
 	tee_mm_entry_t *entry;
-	uint32_t lo;		/* low boundery pf the pool */
-	uint32_t hi;		/* high boundery pf the pool */
+	uintptr_t lo;		/* low boundery pf the pool */
+	uintptr_t hi;		/* high boundery pf the pool */
 	uint32_t flags;		/* Config flags for the pool */
 	uint8_t shift;		/* size shift */
 #ifdef CFG_WITH_STATS
@@ -66,7 +66,7 @@ extern tee_mm_pool_t tee_mm_vcore;
  * Returns a pointer to the mm covering the supplied address,
  * if no mm is found NULL is returned.
  */
-tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uint32_t addr);
+tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uintptr_t addr);
 
 /*
  * Validates that an address (addr) is part of the secure virtual memory
@@ -74,7 +74,7 @@ tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, uint32_t addr);
  * NOTE: This function is executed in abort mode.
  *       Please take care of stack usage
  */
-static inline bool tee_mm_validate(const tee_mm_pool_t *pool, uint32_t addr)
+static inline bool tee_mm_validate(const tee_mm_pool_t *pool, uintptr_t addr)
 {
 	return tee_mm_find(pool, addr) != 0;
 }
@@ -86,7 +86,7 @@ static inline bool tee_mm_validate(const tee_mm_pool_t *pool, uint32_t addr)
 uintptr_t tee_mm_get_smem(const tee_mm_entry_t *mm);
 
 /* Init managed memory area */
-bool tee_mm_init(tee_mm_pool_t *pool, uint32_t lo, uint32_t hi, uint8_t shift,
+bool tee_mm_init(tee_mm_pool_t *pool, uintptr_t lo, uintptr_t hi, uint8_t shift,
 		 uint32_t flags);
 
 /* Kill managed memory area*/
@@ -97,7 +97,7 @@ void tee_mm_final(tee_mm_pool_t *pool);
  * Returns a handle to the memory. The handle is used as an input to
  * the tee_mm_free function.
  */
-tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, uint32_t size);
+tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, size_t size);
 
 /* Allocate supplied memory range if it's free */
 tee_mm_entry_t *tee_mm_alloc2(tee_mm_pool_t *pool, vaddr_t base,
@@ -110,13 +110,13 @@ tee_mm_entry_t *tee_mm_alloc2(tee_mm_pool_t *pool, vaddr_t base,
 void tee_mm_free(tee_mm_entry_t *p);
 
 /* Returns size in sections or pages */
-static inline uint32_t tee_mm_get_size(tee_mm_entry_t *p)
+static inline size_t tee_mm_get_size(tee_mm_entry_t *p)
 {
 	return p->size;
 }
 
 /* Returns offset from start of area in sections or pages */
-static inline uint32_t tee_mm_get_offset(tee_mm_entry_t *p)
+static inline uintptr_t tee_mm_get_offset(tee_mm_entry_t *p)
 {
 	return p->offset;
 }
@@ -124,7 +124,7 @@ static inline uint32_t tee_mm_get_offset(tee_mm_entry_t *p)
 /* Return size of the mm entry in bytes */
 size_t tee_mm_get_bytes(const tee_mm_entry_t *mm);
 
-bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, uint32_t addr);
+bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, uintptr_t addr);
 
 bool tee_mm_is_empty(tee_mm_pool_t *pool);
 


### PR DESCRIPTION
uint32_t is not suitable for holding addresses and sizes. Especially on
64-bit architectures. This patch will make tee_mm architecture-agnostic.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>