### PR TITLE
mk/checkconf.mk: allow spaces and double quotes in CFG_ config variables

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -14,9 +14,9 @@
 define check-conf-h
 	$(q)set -e;						\
 	$(cmd-echo-silent) '  CHK     $@';			\
-	cnf="$(strip $(foreach var,				\
+	cnf='$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,$1),			\
-		$(call cfg-make-define,$(var))))";		\
+		$(call cfg-make-define,$(var))))';		\
 	guard="_`echo $@ | tr -- -/. ___`_";			\
 	mkdir -p $(dir $@);					\
 	echo "#ifndef $${guard}" >$@.tmp;			\
@@ -29,9 +29,9 @@ endef
 define check-conf-mk
 	$(q)set -e;						\
 	$(cmd-echo-silent) '  CHK     $@';			\
-	cnf="$(strip $(foreach var,				\
+	cnf='$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,CFG_),		\
-		$(strip $(var)=$($(var))_nl_)))"; \
+		$(strip $(var)=$($(var))_nl_)))';		\
 	mkdir -p $(dir $@);					\
 	echo "# auto-generated TEE configuration file" >$@.tmp; \
 	echo "# TEE version ${TEE_IMPL_VERSION}" >>$@.tmp; \
@@ -67,10 +67,10 @@ endef
 # <other value>  => <other value>
 define cfg-make-define
 	$(strip $(if $(filter y,$($1)),
-		     #define $1 1 /* '$($1)' */_nl_,
+		     #define $1 1_nl_,
 		     $(if $(filter xn x,x$($1)),
-			  /* $1 is not set ('$($1)') */_nl_,
-			  #define $1 $($1) /* '$($1)' */_nl_)))
+			  /* $1 is not set */_nl_,
+			  #define $1 $($1)_nl_)))
 endef
 
 # Returns 'y' if at least one variable is 'y', empty otherwise


### PR DESCRIPTION
Fixes issues with the check-conf-h and check-conf-mk functions, which
would error out or generate incorrect output on strings containing spaces
and/or double quotes.

The single quote character is used in the shell commands that builds
the list of values, instead of the double quote, so that there is no
conflict with double quotes appearing in the variables themselves. As a
consequence, single quotes cannot appear anywhere in the output string.
So remove the comments that contained quotes, and which were not that
useful anyway.

Test case:

 $ grep CFG_TEST core/arch/arm/plat-vexpress/conf.mk
 CFG_TEST1 ?= "test string"
 CFG_TEST2 ?= test string
 CFG_TEST3 ?= "test"
 CFG_TEST4 ?= test
 $ make -s
 $ grep CFG_TEST out/arm-plat-vexpress/conf.mk
 CFG_TEST1="test string"
 CFG_TEST2=test string
 CFG_TEST3="test"
 CFG_TEST4=test
 $ grep CFG_TEST out/arm-plat-vexpress/include/generated/conf.h
 #define CFG_TEST1 "test string"
 #define CFG_TEST2 test string
 #define CFG_TEST3 "test"
 #define CFG_TEST4 test

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>