### PR TITLE
core/libutee: perform cleanup for magic "4"

### DIFF
--- a/core/arch/arm/include/kernel/static_ta.h
+++ b/core/arch/arm/include/kernel/static_ta.h
@@ -40,11 +40,12 @@ struct static_ta_head {
 	TEE_Result (*create_entry_point)(void);
 	void (*destroy_entry_point)(void);
 	TEE_Result (*open_session_entry_point)(uint32_t nParamTypes,
-			TEE_Param pParams[4], void **ppSessionContext);
+			TEE_Param pParams[TEE_NUM_PARAMS],
+			void **ppSessionContext);
 	void (*close_session_entry_point)(void *pSessionContext);
 	TEE_Result (*invoke_command_entry_point)(void *pSessionContext,
 			uint32_t nCommandID, uint32_t nParamTypes,
-			TEE_Param pParams[4]);
+			TEE_Param pParams[TEE_NUM_PARAMS]);
 };
 
 #define static_ta_register(...) static const struct static_ta_head __head \

--- a/core/arch/arm/kernel/static_ta.c
+++ b/core/arch/arm/kernel/static_ta.c
@@ -49,7 +49,7 @@ static TEE_Result tee_ta_param_pa2va(struct tee_ta_param *param)
 	if (tee_ta_get_calling_session())
 		return TEE_SUCCESS;
 
-	for (n = 0; n < 4; n++) {
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
 		switch (TEE_PARAM_TYPE_GET(param->types, n)) {
 		case TEE_PARAM_TYPE_MEMREF_INPUT:
 		case TEE_PARAM_TYPE_MEMREF_OUTPUT:

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -58,7 +58,8 @@
 
 #define TEE_MMU_UMAP_PARAM_IDX		(TEE_MMU_UMAP_CODE_IDX + \
 					 TEE_MMU_UMAP_NUM_CODE_SEGMENTS)
-#define TEE_MMU_UMAP_MAX_ENTRIES	(TEE_MMU_UMAP_PARAM_IDX + 4)
+#define TEE_MMU_UMAP_MAX_ENTRIES	(TEE_MMU_UMAP_PARAM_IDX + \
+				TEE_NUM_PARAMS)
 
 #define TEE_MMU_UDATA_ATTR		(TEE_MATTR_VALID_BLOCK | \
 					 TEE_MATTR_PRW | TEE_MATTR_URW | \
@@ -390,7 +391,7 @@ TEE_Result tee_mmu_map_param(struct user_ta_ctx *utc,
 		sizeof(struct tee_mmap_region));
 
 	/* Map secure memory params first then nonsecure memory params */
-	for (n = 0; n < 4; n++) {
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
 		uint32_t param_type = TEE_PARAM_TYPE_GET(param->types, n);
 		TEE_Param *p = &param->params[n];
 		uint32_t attr = TEE_MMU_UDATA_ATTR;
@@ -417,7 +418,7 @@ TEE_Result tee_mmu_map_param(struct user_ta_ctx *utc,
 		if (res != TEE_SUCCESS)
 			return res;
 	}
-	for (n = 0; n < 4; n++) {
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
 		uint32_t param_type = TEE_PARAM_TYPE_GET(param->types, n);
 		TEE_Param *p = &param->params[n];
 		uint32_t attr = TEE_MMU_UDATA_ATTR & ~TEE_MATTR_SECURE;
@@ -448,7 +449,7 @@ TEE_Result tee_mmu_map_param(struct user_ta_ctx *utc,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	for (n = 0; n < 4; n++) {
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
 		uint32_t param_type = TEE_PARAM_TYPE_GET(param->types, n);
 		TEE_Param *p = &param->params[n];
 

--- a/core/arch/arm/sta/se_api_self_tests.c
+++ b/core/arch/arm/sta/se_api_self_tests.c
@@ -89,7 +89,8 @@ static void destroy_ta(void)
 }
 
 static TEE_Result open_session(uint32_t nParamTypes __unused,
-		TEE_Param pParams[4] __unused, void **ppSessionContext __unused)
+		TEE_Param pParams[TEE_NUM_PARAMS] __unused,
+		void **ppSessionContext __unused)
 {
 	DMSG("open entry point for static ta \"%s\"", TA_NAME);
 	return TEE_SUCCESS;
@@ -502,7 +503,8 @@ static TEE_Result se_api_self_tests(uint32_t nParamTypes __attribute__((__unused
 }
 
 static TEE_Result invoke_command(void *pSessionContext __unused,
-		uint32_t nCommandID, uint32_t nParamTypes, TEE_Param pParams[4])
+		uint32_t nCommandID, uint32_t nParamTypes,
+		TEE_Param pParams[TEE_NUM_PARAMS])
 {
 	DMSG("command entry point for static ta \"%s\"", TA_NAME);
 

--- a/core/arch/arm/sta/sta_self_tests.c
+++ b/core/arch/arm/sta/sta_self_tests.c
@@ -43,7 +43,7 @@
 #define CMD_SELF_TESTS	2
 
 static TEE_Result test_trace(uint32_t param_types __unused,
-			TEE_Param params[4] __unused)
+			TEE_Param params[TEE_NUM_PARAMS] __unused)
 {
 	IMSG("static TA \"%s\" says \"Hello world !\"", TA_NAME);
 
@@ -61,7 +61,7 @@ static TEE_Result test_trace(uint32_t param_types __unused,
  * Case 3: command parameters type are: 1 in/out memref, 3 empty.
  *         => process = outI[0] = sum(inI[0..len-1])
  */
-static TEE_Result test_entry_params(uint32_t type, TEE_Param p[4])
+static TEE_Result test_entry_params(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
 	size_t i;
 	uint8_t d8, *in;
@@ -211,7 +211,8 @@ static void destroy_ta(void)
 }
 
 static TEE_Result open_session(uint32_t nParamTypes __unused,
-		TEE_Param pParams[4] __unused, void **ppSessionContext __unused)
+		TEE_Param pParams[TEE_NUM_PARAMS] __unused,
+		void **ppSessionContext __unused)
 {
 	DMSG("open entry point for static ta \"%s\"", TA_NAME);
 	return TEE_SUCCESS;
@@ -223,7 +224,8 @@ static void close_session(void *pSessionContext __unused)
 }
 
 static TEE_Result invoke_command(void *pSessionContext __unused,
-		uint32_t nCommandID, uint32_t nParamTypes, TEE_Param pParams[4])
+		uint32_t nCommandID, uint32_t nParamTypes,
+		TEE_Param pParams[TEE_NUM_PARAMS])
 {
 	DMSG("command entry point for static ta \"%s\"", TA_NAME);
 

--- a/core/arch/arm/sta/stats.c
+++ b/core/arch/arm/sta/stats.c
@@ -45,7 +45,7 @@
 
 #define STATS_NB_POOLS			3
 
-static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[4])
+static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
 	struct malloc_stats *stats;
 	uint32_t size_to_retrieve;
@@ -114,7 +114,7 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[4])
 	return TEE_SUCCESS;
 }
 
-static TEE_Result get_pager_stats(uint32_t type, TEE_Param p[4])
+static TEE_Result get_pager_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
 	struct tee_pager_stats stats;
 
@@ -151,7 +151,7 @@ static void destroy_ta(void)
 }
 
 static TEE_Result open_session(uint32_t ptype __unused,
-			       TEE_Param params[4] __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
 			       void **ppsess __unused)
 {
 	return TEE_SUCCESS;
@@ -163,7 +163,7 @@ static void close_session(void *psess __unused)
 
 static TEE_Result invoke_command(void *psess __unused,
 				 uint32_t cmd, uint32_t ptypes,
-				 TEE_Param params[4])
+				 TEE_Param params[TEE_NUM_PARAMS])
 {
 	switch (cmd) {
 	case STATS_CMD_PAGER_STATS:

--- a/core/arch/arm/sta/tee_fs_key_manager_tests.c
+++ b/core/arch/arm/sta/tee_fs_key_manager_tests.c
@@ -99,7 +99,8 @@ static void destroy_ta(void)
 }
 
 static TEE_Result open_session(uint32_t nParamTypes __unused,
-		TEE_Param pParams[4] __unused, void **ppSessionContext __unused)
+		TEE_Param pParams[TEE_NUM_PARAMS] __unused,
+		void **ppSessionContext __unused)
 {
 	DMSG("open entry point for static ta \"%s\"", TA_NAME);
 	return TEE_SUCCESS;
@@ -380,7 +381,8 @@ static TEE_Result self_tests(
 }
 
 static TEE_Result invoke_command(void *pSessionContext __unused,
-		uint32_t nCommandID, uint32_t nParamTypes, TEE_Param pParams[4])
+		uint32_t nCommandID, uint32_t nParamTypes,
+		TEE_Param pParams[TEE_NUM_PARAMS])
 {
 	DMSG("command entry point for static ta \"%s\"", TA_NAME);
 

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -45,7 +45,7 @@ static bool copy_in_params(const struct optee_msg_param *params,
 		TEE_Param tee_params[TEE_NUM_PARAMS])
 {
 	size_t n;
-	uint8_t pt[4];
+	uint8_t pt[TEE_NUM_PARAMS];
 	uint32_t cache_attr;
 	uint32_t attr;
 

--- a/core/include/kernel/tee_dispatch.h
+++ b/core/include/kernel/tee_dispatch.h
@@ -45,16 +45,16 @@ struct tee_dispatch_out {
 struct tee_dispatch_open_session_in {
 	TEE_UUID uuid;
 	uint32_t param_types;
-	TEE_Param params[4];
+	TEE_Param params[TEE_NUM_PARAMS];
 	TEE_Identity clnt_id;
-	uint32_t param_attr[4];
+	uint32_t param_attr[TEE_NUM_PARAMS];
 };
 
 /* Output arg structure specific to TEE service 'open session'. */
 struct tee_dispatch_open_session_out {
 	struct tee_dispatch_out msg;
 	TEE_Session *sess;
-	TEE_Param params[4];
+	TEE_Param params[TEE_NUM_PARAMS];
 };
 
 /* Input arg structure specific to TEE service 'invoke command'. */
@@ -62,14 +62,14 @@ struct tee_dispatch_invoke_command_in {
 	TEE_Session *sess;
 	uint32_t cmd;
 	uint32_t param_types;
-	TEE_Param params[4];
-	uint32_t param_attr[4];
+	TEE_Param params[TEE_NUM_PARAMS];
+	uint32_t param_attr[TEE_NUM_PARAMS];
 };
 
 /* Output arg structure specific to TEE service 'invoke command'. */
 struct tee_dispatch_invoke_command_out {
 	struct tee_dispatch_out msg;
-	TEE_Param params[4];
+	TEE_Param params[TEE_NUM_PARAMS];
 };
 
 /* Input arg structure specific to TEE service 'cancel command'. */

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -47,8 +47,8 @@ TAILQ_HEAD(tee_ta_ctx_head, tee_ta_ctx);
 
 struct tee_ta_param {
 	uint32_t types;
-	TEE_Param params[4];
-	uint32_t param_attr[4];
+	TEE_Param params[TEE_NUM_PARAMS];
+	uint32_t param_attr[TEE_NUM_PARAMS];
 };
 
 struct tee_ta_ctx;

--- a/core/kernel/tee_dispatch.c
+++ b/core/kernel/tee_dispatch.c
@@ -41,7 +41,7 @@ static void update_out_param(const struct tee_ta_param *in, TEE_Param *out)
 {
 	size_t n;
 
-	for (n = 0; n < 4; n++) {
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
 		switch (TEE_PARAM_TYPE_GET(in->types, n)) {
 		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
 		case TEE_PARAM_TYPE_MEMREF_INOUT:

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -652,7 +652,7 @@ static TEE_Result tee_svc_copy_param(struct tee_ta_session *sess,
 	/* Get the virtual address for the section in secure DDR */
 	dst = phys_to_virt(dst_pa, MEM_AREA_TA_RAM);
 
-	for (n = 0; n < 4; n++) {
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
 
 		if (ta_private_memref[n] == false)
 			continue;

--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -87,17 +87,19 @@ void TEE_Panic(TEE_Result panicCode);
 /* System API - Internal Client API */
 
 TEE_Result TEE_OpenTASession(const TEE_UUID *destination,
-			     uint32_t cancellationRequestTimeout,
-			     uint32_t paramTypes, TEE_Param params[4],
-			     TEE_TASessionHandle *session,
-			     uint32_t *returnOrigin);
+				uint32_t cancellationRequestTimeout,
+				uint32_t paramTypes,
+				TEE_Param params[TEE_NUM_PARAMS],
+				TEE_TASessionHandle *session,
+				uint32_t *returnOrigin);
 
 void TEE_CloseTASession(TEE_TASessionHandle session);
 
 TEE_Result TEE_InvokeTACommand(TEE_TASessionHandle session,
-			       uint32_t cancellationRequestTimeout,
-			       uint32_t commandID, uint32_t paramTypes,
-			       TEE_Param params[4], uint32_t *returnOrigin);
+				uint32_t cancellationRequestTimeout,
+				uint32_t commandID, uint32_t paramTypes,
+				TEE_Param params[TEE_NUM_PARAMS],
+				uint32_t *returnOrigin);
 
 /* System API - Cancellations */
 

--- a/lib/libutee/include/tee_ta_api.h
+++ b/lib/libutee/include/tee_ta_api.h
@@ -140,8 +140,8 @@ void TA_EXPORT TA_DestroyEntryPoint(void);
  *     error code defined by the Trusted Application implementation itself.
  */
 TEE_Result TA_EXPORT TA_OpenSessionEntryPoint(uint32_t paramTypes,
-					      TEE_Param params[4],
-					      void **sessionContext);
+				TEE_Param params[TEE_NUM_PARAMS],
+				void **sessionContext);
 
 /*
  * The Framework calls this function to close a client session. During the
@@ -192,9 +192,9 @@ void TA_EXPORT TA_CloseSessionEntryPoint(void *sessionContext);
  */
 
 TEE_Result TA_EXPORT TA_InvokeCommandEntryPoint(void *sessionContext,
-						uint32_t commandID,
-						uint32_t paramTypes,
-						TEE_Param params[4]);
+			uint32_t commandID,
+			uint32_t paramTypes,
+			TEE_Param params[TEE_NUM_PARAMS]);
 
 /*
  * Correspondance Client Functions <--> TA Functions

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -96,7 +96,7 @@ extern const size_t ta_num_props;
 
 /* Needed by TEE_CheckMemoryAccessRights() */
 extern uint32_t ta_param_types;
-extern TEE_Param ta_params[4];
+extern TEE_Param ta_params[TEE_NUM_PARAMS];
 
 /* Trusted Application Function header */
 typedef struct ta_func_head {

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -98,10 +98,11 @@ void __utee_to_param(TEE_Param params[TEE_NUM_PARAMS],
 }
 
 TEE_Result TEE_OpenTASession(const TEE_UUID *destination,
-			     uint32_t cancellationRequestTimeout,
-			     uint32_t paramTypes, TEE_Param params[4],
-			     TEE_TASessionHandle *session,
-			     uint32_t *returnOrigin)
+				uint32_t cancellationRequestTimeout,
+				uint32_t paramTypes,
+				TEE_Param params[TEE_NUM_PARAMS],
+				TEE_TASessionHandle *session,
+				uint32_t *returnOrigin)
 {
 	TEE_Result res;
 	struct utee_params up;
@@ -134,9 +135,10 @@ void TEE_CloseTASession(TEE_TASessionHandle session)
 }
 
 TEE_Result TEE_InvokeTACommand(TEE_TASessionHandle session,
-			       uint32_t cancellationRequestTimeout,
-			       uint32_t commandID, uint32_t paramTypes,
-			       TEE_Param params[4], uint32_t *returnOrigin)
+				uint32_t cancellationRequestTimeout,
+				uint32_t commandID, uint32_t paramTypes,
+				TEE_Param params[TEE_NUM_PARAMS],
+				uint32_t *returnOrigin)
 {
 	TEE_Result res;
 	uint32_t ret_origin;


### PR DESCRIPTION
Perform cleanup for magic "4" constant that represents amount of tee
params

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`