### PR TITLE
core_mmu.h: align comments with code

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -79,14 +79,14 @@ extern vaddr_t core_mmu_linear_map_end;
 /*
  * Memory area type:
  * MEM_AREA_NOTYPE:   Undefined type. Used as end of table.
- * MEM_AREA_TEE_RAM:  teecore execution RAM (secure, reserved to TEEtz, unused)
- * MEM_AREA_TEE_COHERENT: teecore coherent RAM (secure, reserved to TEEtz)
+ * MEM_AREA_TEE_RAM:  teecore execution RAM (secure, reserved to TEE, unused)
+ * MEM_AREA_TEE_COHERENT: teecore coherent RAM (secure, reserved to TEE)
  * MEM_AREA_TA_RAM:   Secure RAM where teecore loads/exec TA instances.
- * MEM_AREA_NS_SHM:   NonSecure shared RAM between NSec and TEEtz.
+ * MEM_AREA_NSEC_SHM: NonSecure shared RAM between NSec and TEE.
  * MEM_AREA_RAM_NSEC: NonSecure RAM storing data
  * MEM_AREA_RAM_SEC:  Secure RAM storing some secrets
- * MEM_AREA_IO_SEC:   Secure HW mapped registers
  * MEM_AREA_IO_NSEC:  NonSecure HW mapped registers
+ * MEM_AREA_IO_SEC:   Secure HW mapped registers
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_TA_VASPACE: TA va space, only used with phys_to_virt()
  * MEM_AREA_MAXTYPE:  lower invalid 'type' value


### PR DESCRIPTION
Comment mentions MEM_AREA_NS_SHM which does not exists. Instead
there are MEM_AREA_NSEC_SHM.
Also there was different order of memory areas in comment and
in enum definition.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>