### PR TITLE
crypto:add {cipher,hash,authenc,mac}{create,destroy,copy}

### DIFF
--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -49,7 +49,10 @@
 
 /* Message digest functions */
 struct hash_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
+	TEE_Result (*create)(void **ctx, uint32_t algo);
+	void (*destroy)(void *ctx, uint32_t algo);
+	TEE_Result (*copy)(void *dst_ctx, void *src_ctx,
+			   uint32_t algo);
 	TEE_Result (*init)(void *ctx, uint32_t algo);
 	TEE_Result (*update)(void *ctx, uint32_t algo,
 			     const uint8_t *data, size_t len);
@@ -59,7 +62,10 @@ struct hash_ops {
 
 /* Symmetric ciphers */
 struct cipher_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
+	TEE_Result (*create)(void **ctx, uint32_t algo);
+	void (*destroy)(void *ctx, uint32_t algo);
+	TEE_Result (*copy)(void *dst_ctx, void *src_ctx,
+			   uint32_t algo);
 	TEE_Result (*init)(void *ctx, uint32_t algo,
 			    TEE_OperationMode mode,
 			    const uint8_t *key1, size_t key1_len,
@@ -75,7 +81,10 @@ struct cipher_ops {
 
 /* Message Authentication Code functions */
 struct mac_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
+	TEE_Result (*create)(void **ctx, uint32_t algo);
+	void (*destroy)(void *ctx, uint32_t algo);
+	TEE_Result (*copy)(void *dst_ctx, void *src_ctx,
+			   uint32_t algo);
 	TEE_Result (*init)(void *ctx, uint32_t algo,
 			   const uint8_t *key, size_t len);
 	TEE_Result (*update)(void *ctx, uint32_t algo,
@@ -86,7 +95,10 @@ struct mac_ops {
 
 /* Authenticated encryption */
 struct authenc_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
+	TEE_Result (*create)(void **ctx, uint32_t algo);
+	void (*destroy)(void *ctx, uint32_t algo);
+	TEE_Result (*copy)(void *dst_ctx, void *src_ctx,
+			   uint32_t algo);
 	TEE_Result (*init)(void *ctx, uint32_t algo,
 			   TEE_OperationMode mode,
 			   const uint8_t *key, size_t key_len,

--- a/core/lib/libtomcrypt/include/tomcrypt_hash.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_hash.h
@@ -188,24 +188,39 @@ extern  const struct ltc_hash_descriptor {
     /** Length of DER encoding */
     unsigned long OIDlen;
 
+    /** Create a hash state
+      @param hash   The hash pointer to save hash state
+      @return CRYPT_OK if successful
+    */
+    int (*create)(void **hash);
+    /** Destroy a hash state
+      @param hash   The hash to destroy
+    */
+    void (*destroy)(void *hash);
+    /** Copy a hash state
+      @param dst_hash   The hash state copy to
+      @param src_hash   The hash state copy from
+      @return CRYPT_OK if successful
+    */
+    int (*copy)(void *dst_hash, void *src_hash);
     /** Init a hash state
       @param hash   The hash to initialize
       @return CRYPT_OK if successful
     */
-    int (*init)(hash_state *hash);
+    int (*init)(void *hash);
     /** Process a block of data 
       @param hash   The hash state
       @param in     The data to hash
       @param inlen  The length of the data (octets)
       @return CRYPT_OK if successful
     */
-    int (*process)(hash_state *hash, const unsigned char *in, unsigned long inlen);
+    int (*process)(void *hash, const unsigned char *in, unsigned long inlen);
     /** Produce the digest and store it
       @param hash   The hash state
       @param out    [out] The destination of the digest
       @return CRYPT_OK if successful
     */
-    int (*done)(hash_state *hash, unsigned char *out);
+    int (*done)(void *hash, unsigned char *out);
     /** Self-test
       @return CRYPT_OK if successful, CRYPT_NOP if self-tests have been disabled
     */
@@ -220,25 +235,28 @@ extern  const struct ltc_hash_descriptor {
 
 #ifdef LTC_CHC_HASH
 int chc_register(int cipher);
-int chc_init(hash_state * md);
-int chc_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int chc_done(hash_state * md, unsigned char *hash);
+int chc_init(void * md);
+int chc_process(void * md, const unsigned char *in, unsigned long inlen);
+int chc_done(void * md, unsigned char *hash);
 int chc_test(void);
 extern const struct ltc_hash_descriptor chc_desc;
 #endif
 
 #ifdef LTC_WHIRLPOOL
-int whirlpool_init(hash_state * md);
-int whirlpool_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int whirlpool_done(hash_state * md, unsigned char *hash);
+int whirlpool_init(void * md);
+int whirlpool_process(void * md, const unsigned char *in, unsigned long inlen);
+int whirlpool_done(void * md, unsigned char *hash);
 int whirlpool_test(void);
 extern const struct ltc_hash_descriptor whirlpool_desc;
 #endif
 
 #ifdef LTC_SHA512
-int sha512_init(hash_state * md);
-int sha512_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int sha512_done(hash_state * md, unsigned char *hash);
+#define sha512_create hash_common_create
+#define sha512_destroy hash_common_destroy
+#define sha512_copy hash_common_copy
+int sha512_init(void * md);
+int sha512_process(void * md, const unsigned char *in, unsigned long inlen);
+int sha512_done(void * md, unsigned char *hash);
 int sha512_test(void);
 extern const struct ltc_hash_descriptor sha512_desc;
 #endif
@@ -247,17 +265,23 @@ extern const struct ltc_hash_descriptor sha512_desc;
 #ifndef LTC_SHA512
    #error LTC_SHA512 is required for LTC_SHA384
 #endif
-int sha384_init(hash_state * md);
+#define sha384_create hash_common_create
+#define sha384_destroy hash_common_destroy
+#define sha384_copy hash_common_copy
+int sha384_init(void * md);
 #define sha384_process sha512_process
-int sha384_done(hash_state * md, unsigned char *hash);
+int sha384_done(void * md, unsigned char *hash);
 int sha384_test(void);
 extern const struct ltc_hash_descriptor sha384_desc;
 #endif
 
 #if defined(LTC_SHA256) || defined(LTC_SHA256_ARM32_CE)
-int sha256_init(hash_state * md);
-int sha256_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int sha256_done(hash_state * md, unsigned char *hash);
+#define sha256_create hash_common_create
+#define sha256_destroy hash_common_destroy
+#define sha256_copy hash_common_copy
+int sha256_init(void * md);
+int sha256_process(void * md, const unsigned char *in, unsigned long inlen);
+int sha256_done(void * md, unsigned char *hash);
 int sha256_test(void);
 extern const struct ltc_hash_descriptor sha256_desc;
 
@@ -265,82 +289,97 @@ extern const struct ltc_hash_descriptor sha256_desc;
 #ifndef LTC_SHA256
    #error LTC_SHA256 is required for LTC_SHA224
 #endif
-int sha224_init(hash_state * md);
+#define sha224_create hash_common_create
+#define sha224_destroy hash_common_destroy
+#define sha224_copy hash_common_copy
+int sha224_init(void * md);
 #define sha224_process sha256_process
-int sha224_done(hash_state * md, unsigned char *hash);
+int sha224_done(void * md, unsigned char *hash);
 int sha224_test(void);
 extern const struct ltc_hash_descriptor sha224_desc;
 #endif
 #endif
 
 #if defined(LTC_SHA1) || defined(LTC_SHA1_ARM32_CE)
-int sha1_init(hash_state * md);
-int sha1_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int sha1_done(hash_state * md, unsigned char *hash);
+#define sha1_create hash_common_create
+#define sha1_destroy hash_common_destroy
+#define sha1_copy hash_common_copy
+int sha1_init(void * md);
+int sha1_process(void * md, const unsigned char *in, unsigned long inlen);
+int sha1_done(void * md, unsigned char *hash);
 int sha1_test(void);
 extern const struct ltc_hash_descriptor sha1_desc;
 #endif
 
 #ifdef LTC_MD5
-int md5_init(hash_state * md);
-int md5_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int md5_done(hash_state * md, unsigned char *hash);
+#define md5_create hash_common_create
+#define md5_destroy hash_common_destroy
+#define md5_copy hash_common_copy
+int md5_init(void * md);
+int md5_process(void * md, const unsigned char *in, unsigned long inlen);
+int md5_done(void * md, unsigned char *hash);
 int md5_test(void);
 extern const struct ltc_hash_descriptor md5_desc;
 #endif
 
 #ifdef LTC_MD4
-int md4_init(hash_state * md);
-int md4_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int md4_done(hash_state * md, unsigned char *hash);
+#define md4_create hash_common_create
+#define md4_destroy hash_common_destroy
+#define md4_copy hash_common_copy
+int md4_init(void * md);
+int md4_process(void * md, const unsigned char *in, unsigned long inlen);
+int md4_done(void * md, unsigned char *hash);
 int md4_test(void);
 extern const struct ltc_hash_descriptor md4_desc;
 #endif
 
 #ifdef LTC_MD2
-int md2_init(hash_state * md);
-int md2_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int md2_done(hash_state * md, unsigned char *hash);
+#define md2_create hash_common_create
+#define md2_destroy hash_common_destroy
+#define md2_copy hash_common_copy
+int md2_init(void * md);
+int md2_process(void * md, const unsigned char *in, unsigned long inlen);
+int md2_done(void * md, unsigned char *hash);
 int md2_test(void);
 extern const struct ltc_hash_descriptor md2_desc;
 #endif
 
 #ifdef LTC_TIGER
-int tiger_init(hash_state * md);
-int tiger_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int tiger_done(hash_state * md, unsigned char *hash);
+int tiger_init(void * md);
+int tiger_process(void * md, const unsigned char *in, unsigned long inlen);
+int tiger_done(void * md, unsigned char *hash);
 int tiger_test(void);
 extern const struct ltc_hash_descriptor tiger_desc;
 #endif
 
 #ifdef LTC_RIPEMD128
-int rmd128_init(hash_state * md);
-int rmd128_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd128_done(hash_state * md, unsigned char *hash);
+int rmd128_init(void * md);
+int rmd128_process(void * md, const unsigned char *in, unsigned long inlen);
+int rmd128_done(void * md, unsigned char *hash);
 int rmd128_test(void);
 extern const struct ltc_hash_descriptor rmd128_desc;
 #endif
 
 #ifdef LTC_RIPEMD160
-int rmd160_init(hash_state * md);
-int rmd160_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd160_done(hash_state * md, unsigned char *hash);
+int rmd160_init(void * md);
+int rmd160_process(void * md, const unsigned char *in, unsigned long inlen);
+int rmd160_done(void * md, unsigned char *hash);
 int rmd160_test(void);
 extern const struct ltc_hash_descriptor rmd160_desc;
 #endif
 
 #ifdef LTC_RIPEMD256
-int rmd256_init(hash_state * md);
-int rmd256_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd256_done(hash_state * md, unsigned char *hash);
+int rmd256_init(void * md);
+int rmd256_process(void * md, const unsigned char *in, unsigned long inlen);
+int rmd256_done(void * md, unsigned char *hash);
 int rmd256_test(void);
 extern const struct ltc_hash_descriptor rmd256_desc;
 #endif
 
 #ifdef LTC_RIPEMD320
-int rmd320_init(hash_state * md);
-int rmd320_process(hash_state * md, const unsigned char *in, unsigned long inlen);
-int rmd320_done(hash_state * md, unsigned char *hash);
+int rmd320_init(void * md);
+int rmd320_process(void * md, const unsigned char *in, unsigned long inlen);
+int rmd320_done(void * md, unsigned char *hash);
 int rmd320_test(void);
 extern const struct ltc_hash_descriptor rmd320_desc;
 #endif
@@ -363,13 +402,17 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
                       const unsigned char *in, unsigned long inlen, ...);
 int hash_filehandle(int hash, FILE *in, unsigned char *out, unsigned long *outlen);
 int hash_file(int hash, const char *fname, unsigned char *out, unsigned long *outlen);
+int hash_common_create(void **hash);
+void hash_common_destroy(void *hash);
+int hash_common_copy(void *dst_hash, void *src_hash);
 
 /* a macro for making hash "process" functions */
 #define HASH_PROCESS_(func_name, compress_name, compress_n_name, state_var, block_size)     \
-int func_name (hash_state * md, const unsigned char *in, unsigned long inlen)               \
+int func_name (void * hash, const unsigned char *in, unsigned long inlen)               \
 {                                                                                           \
     unsigned long n, blocks;                                                                \
     int           err;                                                                      \
+    hash_state    *md = hash;                                                               \
     int           (*compress)(hash_state *, unsigned char *) = compress_name;               \
     int           (*compress_n)(hash_state *, unsigned char *, int) = compress_n_name;      \
     LTC_ARGCHK(md != NULL);                                                                 \

--- a/core/lib/libtomcrypt/include/tomcrypt_mac.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_mac.h
@@ -27,9 +27,9 @@
 
 #ifdef LTC_HMAC
 typedef struct Hmac_state {
-     hash_state     md;
+     void           *md;
      int            hash;
-     hash_state     hashstate;
+     void           *hashstate;
      unsigned char  key[MAXBLOCKSIZE];
 } hmac_state;
 

--- a/core/lib/libtomcrypt/include/tomcrypt_prng.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_prng.h
@@ -44,7 +44,7 @@ struct rc4_prng {
 
 #ifdef LTC_FORTUNA
 struct fortuna_prng {
-    hash_state pool[LTC_FORTUNA_POOLS];     /* the  pools */
+    void *pool[LTC_FORTUNA_POOLS];     /* the  pools */
 
     symmetric_key skey;
 

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_common.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2007, Tom St Denis
+ * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,46 +25,33 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* LibTomCrypt, modular cryptographic library -- Tom St Denis
- *
- * LibTomCrypt is a library that provides various cryptographic
- * algorithms in a highly modular and flexible manner.
- *
- * The library is free for all purposes without any express
- * guarantee it works.
- *
- * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
- */
 #include "tomcrypt.h"
 
 /**
-  @file hmac_process.c
-  LTC_HMAC support, process data, Tom St Denis/Dobes Vandermeer
+  @file hash_common.c
+  Hash common helper, Linaro
 */
-
-#ifdef LTC_HMAC
-
-/** 
-  Process data through LTC_HMAC
-  @param hmac    The hmac state
-  @param in      The data to send through LTC_HMAC
-  @param inlen   The length of the data to LTC_HMAC (octets)
-  @return CRYPT_OK if successful
-*/
-int hmac_process(hmac_state *hmac, const unsigned char *in, unsigned long inlen)
+int hash_common_create(void **md)
 {
-    int err;
-    LTC_ARGCHK(hmac != NULL);
-    LTC_ARGCHK(in != NULL);
-    if ((err = hash_is_valid(hmac->hash)) != CRYPT_OK) {
-        return err;
-    }
-    return hash_descriptor[hmac->hash]->process(hmac->md, in, inlen);
+	hash_state *hash;
+
+	LTC_ARGCHK(md != NULL);
+
+	hash = calloc(1, sizeof(hash_state));
+	if (hash == NULL)
+		return CRYPT_MEM;
+	*md = hash;
+	return CRYPT_OK;
 }
-
-#endif
-
-
-/* $Source: /cvs/libtom/libtomcrypt/src/mac/hmac/hmac_process.c,v $ */
-/* $Revision: 1.7 $ */
-/* $Date: 2007/05/12 14:37:41 $ */
+void hash_common_destroy(void *md)
+{
+	if (md != NULL)
+		free(md);
+}
+int hash_common_copy(void *dst_md, void *src_md)
+{
+	LTC_ARGCHK(dst_md != NULL);
+	LTC_ARGCHK(src_md != NULL);
+	memcpy(dst_md, src_md, sizeof(hash_state));
+	return CRYPT_OK;
+}

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_memory.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_memory.c
@@ -53,7 +53,7 @@
 */
 int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned char *out, unsigned long *outlen)
 {
-    hash_state *md;
+    void *md;
     int err;
 
     LTC_ARGCHK(in     != NULL);
@@ -69,9 +69,8 @@ int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned
        return CRYPT_BUFFER_OVERFLOW;
     }
 
-    md = XMALLOC(sizeof(hash_state));
-    if (md == NULL) {
-       return CRYPT_MEM;
+    if ((err = hash_descriptor[hash]->create(&md)) != CRYPT_OK) {
+       return err;
     }
 
     if ((err = hash_descriptor[hash]->init(md)) != CRYPT_OK) {
@@ -83,10 +82,7 @@ int hash_memory(int hash, const unsigned char *in, unsigned long inlen, unsigned
     err = hash_descriptor[hash]->done(md, out);
     *outlen = hash_descriptor[hash]->hashsize;
 LBL_ERR:
-#ifdef LTC_CLEAN_STACK
-    zeromem(md, sizeof(hash_state));
-#endif
-    XFREE(md);
+    hash_descriptor[hash]->destroy(md);
 
     return err;
 }

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_memory_multi.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_memory_multi.c
@@ -55,7 +55,7 @@
 int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
                       const unsigned char *in, unsigned long inlen, ...)
 {
-    hash_state          *md;
+    void                 *md;
     int                  err;
     va_list              args;
     const unsigned char *curptr;
@@ -74,9 +74,8 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
        return CRYPT_BUFFER_OVERFLOW;
     }
 
-    md = XMALLOC(sizeof(hash_state));
-    if (md == NULL) {
-       return CRYPT_MEM;
+    if ((err = hash_descriptor[hash]->create(&md)) != CRYPT_OK) {
+       return err;
     }
 
     if ((err = hash_descriptor[hash]->init(md)) != CRYPT_OK) {
@@ -101,10 +100,7 @@ int hash_memory_multi(int hash, unsigned char *out, unsigned long *outlen,
     err = hash_descriptor[hash]->done(md, out);
     *outlen = hash_descriptor[hash]->hashsize;
 LBL_ERR:
-#ifdef LTC_CLEAN_STACK
-    zeromem(md, sizeof(hash_state));
-#endif
-    XFREE(md);
+    hash_descriptor[hash]->destroy(md);
     va_end(args);
     return err;
 }

--- a/core/lib/libtomcrypt/src/hashes/helper/sub.mk
+++ b/core/lib/libtomcrypt/src/hashes/helper/sub.mk
@@ -4,3 +4,4 @@ cflags-y += -Wno-unused-parameter
 # srcs-y += hash_filehandle.c
 srcs-y += hash_memory.c
 srcs-y += hash_memory_multi.c
+srcs-y += hash_common.c

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce.c
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce.c
@@ -53,6 +53,9 @@ const struct ltc_hash_descriptor sha1_desc =
    { 1, 3, 14, 3, 2, 26,  },
    6,
 
+    &sha1_create,
+    &sha1_destroy,
+    &sha1_copy,
     &sha1_init,
     &sha1_process,
     &sha1_done,
@@ -96,8 +99,9 @@ HASH_PROCESS_NBLOCKS(sha1_process, sha1_compress_nblocks, sha1, 64)
    @param md   The hash state you wish to initialize
    @return CRYPT_OK if successful
 */
-int sha1_init(hash_state * md)
+int sha1_init(void * hash)
 {
+   hash_state *md = hash;
    LTC_ARGCHK(md != NULL);
    md->sha1.state[0] = 0x67452301UL;
    md->sha1.state[1] = 0xefcdab89UL;
@@ -115,8 +119,9 @@ int sha1_init(hash_state * md)
    @param out [out] The destination of the hash (20 bytes)
    @return CRYPT_OK if successful
 */
-int sha1_done(hash_state * md, unsigned char *out)
+int sha1_done(void * hash, unsigned char *out)
 {
+    hash_state *md = hash;
     int i;
 
     LTC_ARGCHK(md  != NULL);
@@ -157,9 +162,6 @@ int sha1_done(hash_state * md, unsigned char *out)
     for (i = 0; i < 5; i++) {
         STORE32H(md->sha1.state[i], out+(4*i));
     }
-#ifdef LTC_CLEAN_STACK
-    zeromem(md, sizeof(hash_state));
-#endif
     return CRYPT_OK;
 }
 
@@ -190,16 +192,19 @@ int  sha1_test(void)
 
   int i;
   unsigned char tmp[20];
-  hash_state md;
+  void *md;
 
+  sha1_create(&md);
   for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0]));  i++) {
-      sha1_init(&md);
-      sha1_process(&md, (unsigned char*)tests[i].msg, (unsigned long)strlen(tests[i].msg));
-      sha1_done(&md, tmp);
+      sha1_init(md);
+      sha1_process(md, (unsigned char*)tests[i].msg, (unsigned long)strlen(tests[i].msg));
+      sha1_done(md, tmp);
       if (XMEMCMP(tmp, tests[i].hash, 20) != 0) {
+         sha1_destroy(md);
          return CRYPT_FAIL_TESTVECTOR;
       }
   }
+  sha1_destroy(md);
   return CRYPT_OK;
   #endif
 }

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha224.c
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha224.c
@@ -55,6 +55,9 @@ const struct ltc_hash_descriptor sha224_desc =
    { 2, 16, 840, 1, 101, 3, 4, 2, 4,  },
    9,
 
+    &sha224_create,
+    &sha224_destroy,
+    &sha224_copy,
     &sha224_init,
     &sha256_process,
     &sha224_done,
@@ -68,8 +71,9 @@ const struct ltc_hash_descriptor sha224_desc =
    @param md   The hash state you wish to initialize
    @return CRYPT_OK if successful
 */
-int sha224_init(hash_state * md)
+int sha224_init(void * hash)
 {
+    hash_state *md = hash;
     LTC_ARGCHK(md != NULL);
 
     md->sha256.curlen = 0;
@@ -91,7 +95,7 @@ int sha224_init(hash_state * md)
    @param out [out] The destination of the hash (28 bytes)
    @return CRYPT_OK if successful
 */
-int sha224_done(hash_state * md, unsigned char *out)
+int sha224_done(void * md, unsigned char *out)
 {
     unsigned char buf[32];
     int err;
@@ -136,16 +140,19 @@ int  sha224_test(void)
 
   int i;
   unsigned char tmp[28];
-  hash_state md;
+  void *md;
 
+  sha224_create(&md);
   for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
-      sha224_init(&md);
-      sha224_process(&md, (unsigned char*)tests[i].msg, (unsigned long)strlen(tests[i].msg));
-      sha224_done(&md, tmp);
+      sha224_init(md);
+      sha224_process(md, (unsigned char*)tests[i].msg, (unsigned long)strlen(tests[i].msg));
+      sha224_done(md, tmp);
       if (XMEMCMP(tmp, tests[i].hash, 28) != 0) {
+         sha224_destroy(md);
          return CRYPT_FAIL_TESTVECTOR;
       }
   }
+  sha224_destroy(md);
   return CRYPT_OK;
  #endif
 }

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha384.c
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha384.c
@@ -55,6 +55,9 @@ const struct ltc_hash_descriptor sha384_desc =
    { 2, 16, 840, 1, 101, 3, 4, 2, 2,  },
    9,
 
+    &sha384_create,
+    &sha384_destroy,
+    &sha384_copy,
     &sha384_init,
     &sha512_process,
     &sha384_done,
@@ -67,8 +70,9 @@ const struct ltc_hash_descriptor sha384_desc =
    @param md   The hash state you wish to initialize
    @return CRYPT_OK if successful
 */
-int sha384_init(hash_state * md)
+int sha384_init(void * hash)
 {
+    hash_state *md = hash;
     LTC_ARGCHK(md != NULL);
 
     md->sha512.curlen = 0;
@@ -90,8 +94,9 @@ int sha384_init(hash_state * md)
    @param out [out] The destination of the hash (48 bytes)
    @return CRYPT_OK if successful
 */
-int sha384_done(hash_state * md, unsigned char *out)
+int sha384_done(void * hash, unsigned char *out)
 {
+   hash_state *md = hash;
    unsigned char buf[64];
 
    LTC_ARGCHK(md  != NULL);
@@ -142,16 +147,19 @@ int  sha384_test(void)
 
   int i;
   unsigned char tmp[48];
-  hash_state md;
+  void *md;
 
+  sha384_create(&md);
   for (i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
-      sha384_init(&md);
-      sha384_process(&md, (unsigned char*)tests[i].msg, (unsigned long)strlen(tests[i].msg));
-      sha384_done(&md, tmp);
+      sha384_init(md);
+      sha384_process(md, (unsigned char*)tests[i].msg, (unsigned long)strlen(tests[i].msg));
+      sha384_done(md, tmp);
       if (XMEMCMP(tmp, tests[i].hash, 48) != 0) {
+         sha384_destroy(md);
          return CRYPT_FAIL_TESTVECTOR;
       }
   }
+  sha384_destroy(md);
   return CRYPT_OK;
  #endif
 }

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_done.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_done.c
@@ -85,7 +85,7 @@ int hmac_done(hmac_state *hmac, unsigned char *out, unsigned long *outlen)
     }
 
     /* Get the hash of the first LTC_HMAC vector plus the data */
-    if ((err = hash_descriptor[hash]->done(&hmac->md, isha)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->done(hmac->md, isha)) != CRYPT_OK) {
        goto LBL_ERR;
     }
 
@@ -95,16 +95,16 @@ int hmac_done(hmac_state *hmac, unsigned char *out, unsigned long *outlen)
     }
 
     /* Now calculate the "outer" hash for step (5), (6), and (7) */
-    if ((err = hash_descriptor[hash]->init(&hmac->md)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->init(hmac->md)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    if ((err = hash_descriptor[hash]->process(&hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->process(hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    if ((err = hash_descriptor[hash]->process(&hmac->md, isha, hashsize)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->process(hmac->md, isha, hashsize)) != CRYPT_OK) {
        goto LBL_ERR;
     }
-    if ((err = hash_descriptor[hash]->done(&hmac->md, buf)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->done(hmac->md, buf)) != CRYPT_OK) {
        goto LBL_ERR;
     }
 

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
@@ -109,11 +109,11 @@ int hmac_init(hmac_state *hmac, int hash, const unsigned char *key, unsigned lon
     }
 
     /* Pre-pend that to the hash data */
-    if ((err = hash_descriptor[hash]->init(&hmac->md)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->init(hmac->md)) != CRYPT_OK) {
        goto LBL_ERR;
     }
 
-    if ((err = hash_descriptor[hash]->process(&hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
+    if ((err = hash_descriptor[hash]->process(hmac->md, buf, LTC_HMAC_BLOCKSIZE)) != CRYPT_OK) {
        goto LBL_ERR;
     }
     goto done;

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -39,7 +39,7 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 			       size_t derived_key_len)
 {
 	TEE_Result res;
-	size_t ctx_size, hash_len, i, n, sz;
+	size_t hash_len, i, n, sz;
 	void *ctx = NULL;
 	uint8_t tmp[TEE_MAX_HASH_SIZE];
 	uint32_t be_count;
@@ -47,21 +47,15 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 	uint32_t hash_algo = TEE_ALG_HASH_ALGO(hash_id);
 	const struct hash_ops *hash = &crypto_ops.hash;
 
-	if (!hash->get_ctx_size || !hash->init || !hash->update ||
-	    !hash->final) {
+	if (!hash->create || !hash->destroy || !hash->init ||
+	    !hash->update || !hash->final) {
 		res = TEE_ERROR_NOT_IMPLEMENTED;
 		goto out;
 	}
 
-	res = hash->get_ctx_size(hash_algo, &ctx_size);
+	res = hash->create(&ctx, hash_algo);
 	if (res != TEE_SUCCESS)
-		goto out;
-
-	ctx = malloc(ctx_size);
-	if (!ctx) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
-		goto out;
-	}
+		return res;
 
 	res = tee_hash_get_digest_size(hash_algo, &hash_len);
 	if (res != TEE_SUCCESS)
@@ -100,6 +94,6 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 	}
 	res = TEE_SUCCESS;
 out:
-	free(ctx);
+	hash->destroy(ctx, hash_algo);
 	return res;
 }

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -98,14 +98,14 @@ TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
 			   uint8_t *derived_key, size_t derived_key_len)
 {
 	TEE_Result res;
-	size_t ctx_size, i, l, r;
+	size_t i, l, r;
 	uint8_t *out = derived_key;
 	struct pbkdf2_parms pbkdf2_parms;
 	struct hmac_parms hmac_parms = {0, };
 	const struct mac_ops *mac = &crypto_ops.mac;
 
-	if (!mac->get_ctx_size || !mac->init || !mac->update ||
-	    !mac->final)
+	if (!mac->create || !mac->destroy || !mac->init ||
+	    !mac->update || !mac->final)
 		return TEE_ERROR_NOT_IMPLEMENTED;
 
 	hmac_parms.algo = TEE_ALG_HMAC_ALGO(hash_id);
@@ -114,13 +114,9 @@ TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	res = mac->get_ctx_size(hmac_parms.algo, &ctx_size);
+	res = mac->create(&hmac_parms.ctx, hmac_parms.algo);
 	if (res != TEE_SUCCESS)
 		return res;
-
-	hmac_parms.ctx = malloc(ctx_size);
-	if (!hmac_parms.ctx)
-		return TEE_ERROR_OUT_OF_MEMORY;
 
 	pbkdf2_parms.password = password;
 	pbkdf2_parms.password_len = password_len;
@@ -142,6 +138,6 @@ TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
 		res = pbkdf2_f(out, r, i, &hmac_parms, &pbkdf2_parms);
 
 out:
-	free(hmac_parms.ctx);
+	mac->destroy(hmac_parms.ctx, hmac_parms.algo);
 	return res;
 }

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1851,7 +1851,27 @@ static void cryp_state_free(struct user_ta_ctx *utc, struct tee_cryp_state *cs)
 	TAILQ_REMOVE(&utc->cryp_states, cs, link);
 	if (cs->ctx_finalize != NULL)
 		cs->ctx_finalize(cs->ctx, cs->algo);
-	free(cs->ctx);
+
+	switch (TEE_ALG_GET_CLASS(cs->algo)) {
+	case TEE_OPERATION_CIPHER:
+		if (crypto_ops.cipher.destroy)
+			crypto_ops.cipher.destroy(cs->ctx, cs->algo);
+		break;
+	case TEE_OPERATION_AE:
+		if (crypto_ops.authenc.destroy)
+			crypto_ops.authenc.destroy(cs->ctx, cs->algo);
+		break;
+	case TEE_OPERATION_MAC:
+		if (crypto_ops.mac.destroy)
+			crypto_ops.mac.destroy(cs->ctx, cs->algo);
+		break;
+	case TEE_OPERATION_DIGEST:
+		if (crypto_ops.hash.destroy)
+			crypto_ops.hash.destroy(cs->ctx, cs->algo);
+		break;
+	default:
+		break;
+	}
 	free(cs);
 }
 
@@ -1986,64 +2006,52 @@ TEE_Result syscall_cryp_state_alloc(unsigned long algo, unsigned long mode,
 		    (algo != TEE_ALG_AES_XTS && (key1 == 0 || key2 != 0))) {
 			res = TEE_ERROR_BAD_PARAMETERS;
 		} else {
-			if (crypto_ops.cipher.get_ctx_size)
-				res = crypto_ops.cipher.get_ctx_size(algo,
-								&cs->ctx_size);
+			if (crypto_ops.cipher.create)
+				res = crypto_ops.cipher.create(&cs->ctx,
+								algo);
 			else
 				res = TEE_ERROR_NOT_IMPLEMENTED;
 			if (res != TEE_SUCCESS)
 				break;
-			cs->ctx = calloc(1, cs->ctx_size);
-			if (!cs->ctx)
-				res = TEE_ERROR_OUT_OF_MEMORY;
 		}
 		break;
 	case TEE_OPERATION_AE:
 		if (key1 == 0 || key2 != 0) {
 			res = TEE_ERROR_BAD_PARAMETERS;
 		} else {
-			if (crypto_ops.authenc.get_ctx_size)
-				res = crypto_ops.authenc.get_ctx_size(algo,
-								&cs->ctx_size);
+			if (crypto_ops.authenc.create)
+				res = crypto_ops.authenc.create(&cs->ctx,
+								algo);
 			else
 				res = TEE_ERROR_NOT_IMPLEMENTED;
 			if (res != TEE_SUCCESS)
 				break;
-			cs->ctx = calloc(1, cs->ctx_size);
-			if (!cs->ctx)
-				res = TEE_ERROR_OUT_OF_MEMORY;
 		}
 		break;
 	case TEE_OPERATION_MAC:
 		if (key1 == 0 || key2 != 0) {
 			res = TEE_ERROR_BAD_PARAMETERS;
 		} else {
-			if (crypto_ops.mac.get_ctx_size)
-				res = crypto_ops.mac.get_ctx_size(algo,
-								&cs->ctx_size);
+			if (crypto_ops.mac.create)
+				res = crypto_ops.mac.create(&cs->ctx,
+								algo);
 			else
 				res = TEE_ERROR_NOT_IMPLEMENTED;
 			if (res != TEE_SUCCESS)
 				break;
-			cs->ctx = calloc(1, cs->ctx_size);
-			if (!cs->ctx)
-				res = TEE_ERROR_OUT_OF_MEMORY;
 		}
 		break;
 	case TEE_OPERATION_DIGEST:
 		if (key1 != 0 || key2 != 0) {
 			res = TEE_ERROR_BAD_PARAMETERS;
 		} else {
-			if (crypto_ops.hash.get_ctx_size)
-				res = crypto_ops.hash.get_ctx_size(algo,
-								&cs->ctx_size);
+			if (crypto_ops.hash.create)
+				res = crypto_ops.hash.create(&cs->ctx,
+								algo);
 			else
 				res = TEE_ERROR_NOT_IMPLEMENTED;
 			if (res != TEE_SUCCESS)
 				break;
-			cs->ctx = calloc(1, cs->ctx_size);
-			if (!cs->ctx)
-				res = TEE_ERROR_OUT_OF_MEMORY;
 		}
 		break;
 	case TEE_OPERATION_ASYMMETRIC_CIPHER:
@@ -2106,7 +2114,46 @@ TEE_Result syscall_cryp_state_copy(unsigned long dst, unsigned long src)
 	if (cs_dst->ctx_size != cs_src->ctx_size)
 		return TEE_ERROR_BAD_STATE;
 
-	memcpy(cs_dst->ctx, cs_src->ctx, cs_src->ctx_size);
+	switch (TEE_ALG_GET_CLASS(cs_src->algo)) {
+	case TEE_OPERATION_CIPHER:
+		if (crypto_ops.cipher.copy)
+			res = crypto_ops.cipher.copy(cs_dst->ctx,
+					cs_src->ctx, cs_src->algo);
+		else
+			res = TEE_ERROR_NOT_IMPLEMENTED;
+		if (res != TEE_SUCCESS)
+			return res;
+		break;
+	case TEE_OPERATION_AE:
+		if (crypto_ops.authenc.copy)
+			res = crypto_ops.authenc.copy(cs_dst->ctx,
+					cs_src->ctx, cs_src->algo);
+		else
+			res = TEE_ERROR_NOT_IMPLEMENTED;
+		if (res != TEE_SUCCESS)
+			return res;
+		break;
+	case TEE_OPERATION_MAC:
+		if (crypto_ops.mac.copy)
+			res = crypto_ops.mac.copy(cs_dst->ctx,
+					cs_src->ctx, cs_src->algo);
+		else
+			res = TEE_ERROR_NOT_IMPLEMENTED;
+		if (res != TEE_SUCCESS)
+			return res;
+		break;
+	case TEE_OPERATION_DIGEST:
+		if (crypto_ops.hash.copy)
+			res = crypto_ops.hash.copy(cs_dst->ctx,
+					cs_src->ctx, cs_src->algo);
+		else
+			res = TEE_ERROR_NOT_IMPLEMENTED;
+		if (res != TEE_SUCCESS)
+			return res;
+		break;
+	default:
+		break;
+	}
 	return TEE_SUCCESS;
 }
 


### PR DESCRIPTION
The origin crypto operation as follow steps:
`crypto_ops.{cipher,hash,authenc,mac}.init`
`crypto_ops.{cipher,hash,authenc,mac}.update`
`...`
`crypto_ops.{cipher,hash,authenc,mac}.update`
`crypto_ops.{cipher,hash,authenc,mac}.final`

After the change, the crypto operation will like this:
`crypto_ops.{cipher,hash,authenc,mac}.create`
`crypto_ops.{cipher,hash,authenc,mac}.init`
`crypto_ops.{cipher,hash,authenc,mac}.update`
`...`
`crypto_ops.{cipher,hash,authenc,mac}.update`
`crypto_ops.{cipher,hash,authenc,mac}.final`
`crypto_ops.{cipher,hash,authenc,mac}.destroy`

Signed-off-by: Guanchao Liang <liang.guanchao@linaro.org>
Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>