### PR TITLE
core: imx: fix compile error

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -23,7 +23,7 @@ ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd))
 $(call force,CFG_PL310,y)
 $(call force,CFG_PL310_LOCKED,y)
 $(call force,CFG_SECURE_TIME_SOURCE_REE,y)
-CFG_BOOT_SECONDARY_REQUEST ? = y
+CFG_BOOT_SECONDARY_REQUEST ?= y
 endif
 
 ta-targets = ta_arm32


### PR DESCRIPTION
Error log:
core/arch/arm/plat-imx/conf.mk:26: *** missing separator.  Stop.