### PR TITLE
MemoryAccessRight and Cache maintenance for SDP (SWG-186)

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -423,7 +423,7 @@ static TEE_Result ta_load(const TEE_UUID *uuid, const struct shdr *signed_ta,
 	/* opt_flags: optional flags */
 	uint32_t opt_flags = man_flags | TA_FLAG_SINGLE_INSTANCE |
 	    TA_FLAG_MULTI_SESSION | TA_FLAG_UNSAFE_NW_PARAMS |
-	    TA_FLAG_INSTANCE_KEEP_ALIVE;
+	    TA_FLAG_INSTANCE_KEEP_ALIVE | TA_FLAG_CACHE_MAINTENANCE;
 	struct user_ta_ctx *utc = NULL;
 	struct shdr *sec_shdr = NULL;
 	struct ta_head *ta_head;

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -506,7 +506,7 @@ bool tee_mmu_is_vbuf_inside_ta_private(const struct user_ta_ctx *utc,
 {
 	return core_is_buffer_inside(va, size,
 	  utc->mmu->ta_private_vmem_start,
-	  utc->mmu->ta_private_vmem_end - utc->mmu->ta_private_vmem_start + 1);
+	  utc->mmu->ta_private_vmem_end - utc->mmu->ta_private_vmem_start);
 }
 
 /* return true only if buffer intersects TA private memory */
@@ -515,7 +515,7 @@ bool tee_mmu_is_vbuf_intersect_ta_private(const struct user_ta_ctx *utc,
 {
 	return core_is_buffer_intersect(va, size,
 	  utc->mmu->ta_private_vmem_start,
-	  utc->mmu->ta_private_vmem_end - utc->mmu->ta_private_vmem_start + 1);
+	  utc->mmu->ta_private_vmem_end - utc->mmu->ta_private_vmem_start);
 }
 
 static TEE_Result tee_mmu_user_va2pa_attr(const struct user_ta_ctx *utc,

--- a/core/arch/arm/tee/svc_cache.c
+++ b/core/arch/arm/tee/svc_cache.c
@@ -51,7 +51,15 @@ static TEE_Result cache_operation(struct tee_ta_session *sess,
 	if ((sess->ctx->flags & TA_FLAG_CACHE_MAINTENANCE) == 0)
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	ret = tee_mmu_check_access_rights(utc, TEE_MEMORY_ACCESS_WRITE,
+	/*
+	 * TAs are allowed to operate cache maintenance on TA memref parameters
+	 * only, not on the TA private memory.
+	 */
+	if (tee_mmu_is_vbuf_intersect_ta_private(utc, va, len))
+		return TEE_ERROR_ACCESS_DENIED;
+
+	ret = tee_mmu_check_access_rights(utc, TEE_MEMORY_ACCESS_READ |
+					  TEE_MEMORY_ACCESS_ANY_OWNER,
 					  (uaddr_t)va, len);
 	if (ret != TEE_SUCCESS)
 		return TEE_ERROR_ACCESS_DENIED;

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -89,4 +89,20 @@
 /* Storage is provided by a SQLite database in the normal world filesystem */
 #define TEE_STORAGE_PRIVATE_SQL  0x80000200
 
+/*
+ * Extension of "Memory Access Rights Constants"
+ * #define TEE_MEMORY_ACCESS_READ             0x00000001
+ * #define TEE_MEMORY_ACCESS_WRITE            0x00000002
+ * #define TEE_MEMORY_ACCESS_ANY_OWNER        0x00000004
+ *
+ * TEE_MEMORY_ACCESS_NONSECURE : if set TEE_CheckMemoryAccessRights()
+ * successfully returns only if target vmem range is mapped non-secure.
+ *
+ * TEE_MEMORY_ACCESS_SECURE : if set TEE_CheckMemoryAccessRights()
+ * successfully returns only if target vmem range is mapped secure.
+
+ */
+#define TEE_MEMORY_ACCESS_NONSECURE          0x10000000
+#define TEE_MEMORY_ACCESS_SECURE             0x20000000
+
 #endif /* TEE_API_DEFINES_EXTENSIONS_H */

--- a/lib/libutee/include/tee_internal_api_extensions.h
+++ b/lib/libutee/include/tee_internal_api_extensions.h
@@ -31,12 +31,9 @@
 /* trace support */
 #include <trace.h>
 #include <stdio.h>
+#include <tee_api_defines_extensions.h>
 #include <tee_api_types.h>
 
-/*
- * User mem module
- *
- */
 void tee_user_mem_mark_heap(void);
 size_t tee_user_mem_check_heap(void);
 /* Hint implementation defines */


### PR DESCRIPTION

New TEE Internal API extension: on TEE_CheckMemoryAccesRights(). 
[description here](https://docs.google.com/document/d/1QaCt3GgWwsQBTZ5xSHkYoavipgNC27cCkjiOrnOFE9s).

Fix on TA cache API.