### PR TITLE
core: FS: simplify FOP create

### DIFF
--- a/core/include/tee/tee_fs.h
+++ b/core/include/tee/tee_fs.h
@@ -49,8 +49,7 @@ struct tee_file_handle;
  */
 struct tee_file_operations {
 	TEE_Result (*open)(const char *name, struct tee_file_handle **fh);
-	TEE_Result (*create)(const char *name, bool overwrite,
-			     struct tee_file_handle **fh);
+	TEE_Result (*create)(const char *name, struct tee_file_handle **fh);
 	void (*close)(struct tee_file_handle **fh);
 	TEE_Result (*read)(struct tee_file_handle *fh, void *buf, size_t *len);
 	TEE_Result (*write)(struct tee_file_handle *fh, const void *buf,

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2577,24 +2577,9 @@ static TEE_Result rpmb_fs_open(const char *file, struct tee_file_handle **fh)
 	return rpmb_fs_open_internal(file, false, fh);
 }
 
-static TEE_Result rpmb_fs_create(const char *file, bool overwrite,
-				 struct tee_file_handle **fh)
+static TEE_Result rpmb_fs_create(const char *file, struct tee_file_handle **fh)
 {
-	TEE_Result res;
-
-	/*
-	 * try to open file without create flag, if failed try again with
-	 * create flag (to distinguish whether it's a new file or not)
-	 */
-	res = rpmb_fs_open_internal(file, false, fh);
-	if (res == TEE_SUCCESS) {
-		if (overwrite)
-			return TEE_SUCCESS;
-		rpmb_fs_close(fh);
-		return TEE_ERROR_ACCESS_CONFLICT;
-	} else {
-		return rpmb_fs_open_internal(file, true, fh);
-	}
+	return rpmb_fs_open_internal(file, true, fh);
 }
 
 const struct tee_file_operations rpmb_fs_ops = {


### PR DESCRIPTION
As the FOP create always is called with the overwrite flag it can be
simplified. This makes the implementation of create much easier.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>