### PR TITLE
[libtomcrypt] Issue and patch in TEE adaptation for clearing big numbers

### DIFF
--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -691,7 +691,8 @@ static void bn_clear(struct bignum *s)
 {
 	struct mpa_numbase_struct *bn = (struct mpa_numbase_struct *)s;
 
-	memset(bn, 0, bn->alloc);
+	/* despite mpa_numbase_struct description, 'alloc' field a byte size */
+	memset(bn->d, 0, bn->alloc);
 }
 
 static bool bn_alloc_max(struct bignum **s)


### PR DESCRIPTION
Hello all,

It seems there is an issue in the TEE adaptation of the libtomcrypt for clearing big numbers.

Issue could be seen in the sequence:
```c
TEE_AllocateTransientObject
TEE_ResetTransientObject
TEE_PopulateTransientObject
```
where `TEE_ResetTransientObject` clears (and not free) the object. Clear mean zero the data. If this object is a big number, the leaf function is:
```c
static void bn_clear(struct bignum *s)
{
        struct mpa_numbase_struct *bn = (struct mpa_numbase_struct *)s;

        memset(bn, 0, bn->alloc);
}
```
corresponding to
```c
static struct bignum *bn_allocate(size_t size_bits)
{
..
        bn->alloc = sz - MPA_NUMBASE_METADATA_SIZE_IN_U32 * sizeof(uint32_t);
..
}
```

The underlying structure describing `struct bignum` is in `lib/libmpa/include/mpalib.h`:
```c
typedef struct mpa_numbase_struct {
	mpa_asize_t alloc;
	mpa_usize_t size;
	mpa_word_t d[];
} mpa_num_base;
```
As we can see, memset fills with zero not only the data, but the metadata and the begin of the datas, instead of zero only the whole data.

Based on OP-TEE `2.2.0`, even with the last commit 36d5a31387f01357077ca74444f3fd5ce1fcc690, a proposed patch:
```diff
diff --git a/core/lib/libtomcrypt/src/tee_ltc_provider.c b/core/lib/libtomcrypt/src/tee_ltc_provider.c
index fda9454..69620c6 100644
--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -691,7 +691,7 @@ static void bn_clear(struct bignum *s)
 {
        struct mpa_numbase_struct *bn = (struct mpa_numbase_struct *)s;
 
-       memset(bn, 0, bn->alloc);
+       memset(bn->d, 0, bn->alloc);
 }
``` 

Note:
`mpa_numbase_struct.size` is never set in this case, but it is not part of this ticket.


Best regards
Manu
