### PR TITLE
core: fix mapping init deubg trace

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -391,12 +391,16 @@ static void init_mem_map(struct tee_mmap_region *memory_map, size_t num_elems)
 		}
 	}
 
-	for (map = memory_map; map->type != MEM_AREA_NOTYPE; map++)
+	for (map = memory_map; map->type != MEM_AREA_NOTYPE; map++) {
+		vaddr_t __maybe_unused vstart;
+
+		vstart = map->va + ((vaddr_t)map->pa & (map->region_size - 1));
 		DMSG("type va %d 0x%08" PRIxVA "..0x%08" PRIxVA
 		     " pa 0x%08" PRIxPA "..0x%08" PRIxPA " size %#zx",
-		     map->type, (vaddr_t)map->va,
-		     (vaddr_t)map->va + map->size - 1, (paddr_t)map->pa,
-		     (paddr_t)map->pa + map->size - 1, map->size);
+		     map->type, vstart, vstart + map->size - 1,
+		     (paddr_t)map->pa, (paddr_t)map->pa + map->size - 1,
+		     map->size);
+	}
 }
 
 /*


### PR DESCRIPTION
fix debug trace when static mapping tables are setup.

this should fix https://github.com/OP-TEE/optee_os/issues/1178 