### PR TITLE
core: arm: add more cp15 macros

### DIFF
--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -42,6 +42,10 @@
 	mcr	p15, 0, \reg, c1, c0, 1
 	.endm
 
+	.macro read_actlr reg
+	mrc	p15, 0, \reg, c1, c0, 1
+	.endm
+
 	.macro write_cpacr reg
 	mcr	p15, 0, \reg, c1, c0, 2
 	.endm
@@ -60,6 +64,10 @@
 
 	.macro write_nsacr reg
 	mcr	p15, 0, \reg, c1, c1, 2
+	.endm
+
+	.macro read_nsacr reg
+	mrc	p15, 0, \reg, c1, c1, 2
 	.endm
 
 	.macro write_ttbr0 reg
@@ -194,14 +202,6 @@
 
 	.macro read_tpidruro reg
 	mrc	p15, 0, \reg, c13, c0, 3
-	.endm
-
-	.macro read_actlr reg
-	mrc	p15, 0, \reg, c1, c0, 1
-	.endm
-
-	.macro read_nsacr reg
-	mrc	p15, 0, \reg, c1, c1, 2
 	.endm
 
 	.macro mov_imm reg, val

--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -42,6 +42,14 @@
 	mcr	p15, 0, \reg, c1, c0, 1
 	.endm
 
+	.macro write_cpacr reg
+	mcr	p15, 0, \reg, c1, c0, 2
+	.endm
+
+	.macro read_cpacr reg
+	mrc	p15, 0, \reg, c1, c0, 2
+	.endm
+
 	.macro read_scr reg
 	mrc	p15, 0, \reg, c1, c1, 0
 	.endm
@@ -58,8 +66,33 @@
 	mcr	p15, 0, \reg, c2, c0, 0
 	.endm
 
+	.macro read_ttbr0 reg
+	mrc	p15, 0, \reg, c2, c0, 0
+	.endm
+
+	.macro write_ttbr1 reg
+	mcr	p15, 0, \reg, c2, c0, 1
+	.endm
+
+	.macro read_ttbr1 reg
+	mrc	p15, 0, \reg, c2, c0, 1
+	.endm
+
+	.macro write_ttbcr reg
+	mcr	p15, 0, \reg, c2, c0, 2
+	.endm
+
+	.macro read_ttbcr reg
+	mrc	p15, 0, \reg, c2, c0, 2
+	.endm
+
+
 	.macro write_dacr reg
 	mcr	p15, 0, \reg, c3, c0, 0
+	.endm
+
+	.macro read_dacr reg
+	mrc	p15, 0, \reg, c3, c0, 0
 	.endm
 
 	.macro read_dfsr reg
@@ -107,12 +140,44 @@
 	mcr	p15, 0, \reg, c8, c3, 2
 	.endm
 
+	.macro write_prrr reg
+	mcr	p15, 0, \reg, c10, c2, 0
+	.endm
+
+	.macro read_prrr reg
+	mrc	p15, 0, \reg, c10, c2, 0
+	.endm
+
+	.macro write_nmrr reg
+	mcr	p15, 0, \reg, c10, c2, 1
+	.endm
+
+	.macro read_nmrr reg
+	mrc	p15, 0, \reg, c10, c2, 1
+	.endm
+
+	.macro read_vbar reg
+	mrc	p15, 0, \reg, c12, c0, 0
+	.endm
+
 	.macro write_vbar reg
 	mcr	p15, 0, \reg, c12, c0, 0
 	.endm
 
 	.macro write_mvbar reg
 	mcr	p15, 0, \reg, c12, c0, 1
+	.endm
+
+	.macro read_mvbar reg
+	mrc	p15, 0, \reg, c12, c0, 1
+	.endm
+
+	.macro write_fcseidr reg
+	mcr	p15, 0, \reg, c13, c0, 0
+	.endm
+
+	.macro read_fcseidr reg
+	mrc	p15, 0, \reg, c13, c0, 0
 	.endm
 
 	.macro write_contextidr reg
@@ -123,8 +188,12 @@
 	mrc	p15, 0, \reg, c13, c0, 1
 	.endm
 
-	.macro write_pcr reg
-	mcr  p15, 0, \reg, c15, c0, 0
+	.macro write_tpidruro reg
+	mcr	p15, 0, \reg, c13, c0, 3
+	.endm
+
+	.macro read_tpidruro reg
+	mrc	p15, 0, \reg, c13, c0, 3
 	.endm
 
 	.macro read_actlr reg

--- a/core/arch/arm/include/arm32_macros_cortex_a9.S
+++ b/core/arch/arm/include/arm32_macros_cortex_a9.S
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Peng Fan <peng.fan@nxp.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+	.macro write_pcr reg
+	mcr  p15, 0, \reg, c15, c0, 0
+	.endm
+
+	.macro read_pcr reg
+	mrc  p15, 0, \reg, c15, c0, 0
+	.endm
+
+	.macro write_diag reg
+	mcr  p15, 0, \reg, c15, c0, 1
+	.endm
+
+	.macro read_diag reg
+	mrc  p15, 0, \reg, c15, c0, 1
+	.endm

--- a/core/arch/arm/plat-imx/a9_plat_init.S
+++ b/core/arch/arm/plat-imx/a9_plat_init.S
@@ -36,6 +36,7 @@
 
 #include <arm32.h>
 #include <arm32_macros.S>
+#include <arm32_macros_cortex_a9.S>
 #include <asm.S>
 #include <kernel/tz_ssvce_def.h>
 #include <kernel/unwind.h>

--- a/core/arch/arm/plat-stm/tz_a9init.S
+++ b/core/arch/arm/plat-stm/tz_a9init.S
@@ -27,6 +27,7 @@
 
 #include <arm32.h>
 #include <arm32_macros.S>
+#include <arm32_macros_cortex_a9.S>
 #include <asm.S>
 #include <kernel/tz_ssvce_def.h>
 #include <kernel/unwind.h>


### PR DESCRIPTION
Add more cp15 macros.
These are useful when do suspend/resume operations in OP-TEE.