### PR TITLE
Adding assertions to spinlocks & mutexes

### DIFF
--- a/core/arch/arm/include/kernel/spinlock.h
+++ b/core/arch/arm/include/kernel/spinlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,9 +24,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
-#ifndef TZ_PROC_H
-#define TZ_PROC_H
+#ifndef KERNEL_SPINLOCK_H
+#define KERNEL_SPINLOCK_H
 
 #define SPINLOCK_LOCK       1
 #define SPINLOCK_UNLOCK     0
@@ -76,10 +75,6 @@ static inline void cpu_spin_unlock(unsigned int *lock)
 	__cpu_spin_unlock(lock);
 	spinlock_count_add(-1);
 }
+#endif /* ASM */
 
-void cpu_mmu_enable(void);
-void cpu_mmu_enable_icache(void);
-void cpu_mmu_enable_dcache(void);
-#endif /*ASM*/
-
-#endif
+#endif /* KERNEL_SPINLOCK_H */

--- a/core/arch/arm/include/kernel/spinlock.h
+++ b/core/arch/arm/include/kernel/spinlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/core/arch/arm/include/kernel/spinlock.h
+++ b/core/arch/arm/include/kernel/spinlock.h
@@ -32,6 +32,7 @@
 
 #ifndef ASM
 #include <assert.h>
+#include <compiler.h>
 #include <stdbool.h>
 #include <kernel/thread.h>
 

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -336,6 +336,12 @@ uint32_t thread_mask_exceptions(uint32_t exceptions);
  */
 void thread_unmask_exceptions(uint32_t state);
 
+
+static inline bool thread_irq_disabled(void)
+{
+	return (thread_get_exceptions() & THREAD_EXCP_IRQ);
+}
+
 #ifdef CFG_WITH_VFP
 /*
  * thread_kernel_enable_vfp() - Temporarily enables usage of VFP

--- a/core/arch/arm/include/kernel/tz_proc.h
+++ b/core/arch/arm/include/kernel/tz_proc.h
@@ -32,9 +32,30 @@
 #define SPINLOCK_UNLOCK     0
 
 #ifndef ASM
-void cpu_spin_lock(unsigned int *lock);
-unsigned int cpu_spin_trylock(unsigned int *lock);
-void cpu_spin_unlock(unsigned int *lock);
+#include <assert.h>
+#include <kernel/thread.h>
+
+void __cpu_spin_lock(unsigned int *lock);
+unsigned int __cpu_spin_trylock(unsigned int *lock);
+void __cpu_spin_unlock(unsigned int *lock);
+
+static inline void cpu_spin_lock(unsigned int *lock)
+{
+	assert(thread_irq_disabled());
+	__cpu_spin_lock(lock);
+}
+
+static inline unsigned int cpu_spin_trylock(unsigned int *lock)
+{
+	assert(thread_irq_disabled());
+        return __cpu_spin_trylock(lock);
+}
+
+static inline void cpu_spin_unlock(unsigned int *lock)
+{
+	assert(thread_irq_disabled());
+        __cpu_spin_unlock(lock);
+}
 
 void cpu_mmu_enable(void);
 void cpu_mmu_enable_icache(void);

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -33,6 +33,7 @@
 #include <sm/optee_smc.h>
 #include <sm/teesmc_opteed_macros.h>
 #include <sm/teesmc_opteed.h>
+#include <kernel/spinlock.h>
 #include <kernel/unwind.h>
 #include <kernel/asan.h>
 

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -38,6 +38,8 @@ void mutex_init(struct mutex *m)
 
 static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 {
+	assert_have_no_spinlock();
+
 	while (true) {
 		uint32_t old_itr_status;
 		enum mutex_value old_value;
@@ -80,6 +82,8 @@ static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 static void __mutex_unlock(struct mutex *m, const char *fname, int lineno)
 {
 	uint32_t old_itr_status;
+
+	assert_have_no_spinlock();
 
 	old_itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
 	cpu_spin_lock(&m->spin_lock);

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -27,7 +27,7 @@
 
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
-#include <kernel/tz_proc.h>
+#include <kernel/spinlock.h>
 #include <kernel/thread.h>
 #include <trace.h>
 

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -39,6 +39,7 @@ void mutex_init(struct mutex *m)
 static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 {
 	assert_have_no_spinlock();
+	assert(thread_get_id_may_fail() != -1);
 
 	while (true) {
 		uint32_t old_itr_status;
@@ -84,6 +85,7 @@ static void __mutex_unlock(struct mutex *m, const char *fname, int lineno)
 	uint32_t old_itr_status;
 
 	assert_have_no_spinlock();
+	assert(thread_get_id_may_fail() != -1);
 
 	old_itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
 	cpu_spin_lock(&m->spin_lock);
@@ -105,6 +107,8 @@ static bool __mutex_trylock(struct mutex *m, const char *fname __unused,
 {
 	uint32_t old_itr_status;
 	enum mutex_value old_value;
+
+	assert(thread_get_id_may_fail() != -1);
 
 	old_itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
 	cpu_spin_lock(&m->spin_lock);

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -108,6 +108,7 @@ static bool __mutex_trylock(struct mutex *m, const char *fname __unused,
 	uint32_t old_itr_status;
 	enum mutex_value old_value;
 
+	assert_have_no_spinlock();
 	assert(thread_get_id_may_fail() != -1);
 
 	old_itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);

--- a/core/arch/arm/kernel/proc_a32.S
+++ b/core/arch/arm/kernel/proc_a32.S
@@ -30,8 +30,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <kernel/tz_proc.h>
-#include <kernel/tz_proc_def.h>
 #include <kernel/unwind.h>
 #include <asm.S>
 #include <arm.h>

--- a/core/arch/arm/kernel/spin_lock_a32.S
+++ b/core/arch/arm/kernel/spin_lock_a32.S
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
@@ -30,67 +31,55 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <kernel/tz_proc.h>
-#include <kernel/tz_proc_def.h>
-#include <kernel/unwind.h>
 #include <asm.S>
-#include <arm.h>
-#include <arm32_macros.S>
+#include <kernel/tz_proc.h>
+#include <kernel/unwind.h>
 
-	.section .text.proc
-
-/*
- * void cpu_mmu_enable(void) - enable MMU
- *
- * TLBs are invalidated before MMU is enabled.
- * An DSB and ISB insures MMUs is enabled before routine returns
- */
-FUNC cpu_mmu_enable , :
+/* void cpu_spin_lock(lock address) - lock mutex */
+FUNC cpu_spin_lock , :
 UNWIND(	.fnstart)
-	/* Invalidate TLB */
-	write_tlbiall
-
-	/* Enable the MMU */
-	read_sctlr r0
-	orr	r0, r0, #SCTLR_M
-	write_sctlr r0
-
-	dsb
-	isb
-
-	bx	lr
+	mov r2, #SPINLOCK_LOCK
+_spinlock_loop:
+	ldrex r1, [r0]
+	cmp r1, #SPINLOCK_UNLOCK
+	wfene
+	strexeq r1, r2, [r0]
+	cmpeq r1, #0
+	bne _spinlock_loop
+	dmb
+	bx lr
 UNWIND(	.fnend)
-END_FUNC cpu_mmu_enable
+END_FUNC cpu_spin_lock
 
-/* void cpu_mmu_enable_icache(void) - enable instruction cache */
-FUNC cpu_mmu_enable_icache , :
+/* int cpu_spin_trylock(lock address) - return 0 on success */
+FUNC cpu_spin_trylock , :
 UNWIND(	.fnstart)
-	/* Invalidate instruction cache and branch predictor */
-	write_iciallu
-	write_bpiall
-
-	/* Enable the instruction cache */
-	read_sctlr r1
-	orr	r1, r1, #SCTLR_I
-	write_sctlr r1
-
-	dsb
-	isb
-
-	bx	lr
+	mov r2, #SPINLOCK_LOCK
+	mov r1, r0
+_trylock_loop:
+	ldrex r0, [r1]
+	cmp r0, #0
+	bne _trylock_out
+	strex r0, r2, [r1]
+	cmp r0, #0
+	bne _trylock_loop
+	dmb
+	bx lr
+_trylock_out:
+	clrex
+	dmb
+	bx lr
 UNWIND(	.fnend)
-END_FUNC cpu_mmu_enable_icache
+END_FUNC cpu_spin_trylock
 
-/* void cpu_mmu_enable_dcache(void) - enable data cache */
-FUNC cpu_mmu_enable_dcache , :
+/* void cpu_spin_unlock(lock address) - unlock mutex */
+FUNC cpu_spin_unlock , :
 UNWIND(	.fnstart)
-	read_sctlr r0
-	orr	r0, r0, #SCTLR_C
-	write_sctlr r0
-
+	dmb
+	mov r1, #SPINLOCK_UNLOCK
+	str r1, [r0]
 	dsb
-	isb
-
-	bx	lr
+	sev
+	bx lr
 UNWIND(	.fnend)
-END_FUNC cpu_mmu_enable_dcache
+END_FUNC cpu_spin_unlock

--- a/core/arch/arm/kernel/spin_lock_a32.S
+++ b/core/arch/arm/kernel/spin_lock_a32.S
@@ -39,13 +39,13 @@
 FUNC __cpu_spin_lock , :
 UNWIND(	.fnstart)
 	mov r2, #SPINLOCK_LOCK
-_spinlock_loop:
+1:
 	ldrex r1, [r0]
 	cmp r1, #SPINLOCK_UNLOCK
 	wfene
 	strexeq r1, r2, [r0]
 	cmpeq r1, #0
-	bne _spinlock_loop
+	bne 1b
 	dmb
 	bx lr
 UNWIND(	.fnend)
@@ -56,16 +56,16 @@ FUNC __cpu_spin_trylock , :
 UNWIND(	.fnstart)
 	mov r2, #SPINLOCK_LOCK
 	mov r1, r0
-_trylock_loop:
+1:
 	ldrex r0, [r1]
 	cmp r0, #0
-	bne _trylock_out
+	bne 1f
 	strex r0, r2, [r1]
 	cmp r0, #0
-	bne _trylock_loop
+	bne 1b
 	dmb
 	bx lr
-_trylock_out:
+1:
 	clrex
 	dmb
 	bx lr

--- a/core/arch/arm/kernel/spin_lock_a32.S
+++ b/core/arch/arm/kernel/spin_lock_a32.S
@@ -35,7 +35,7 @@
 #include <kernel/tz_proc.h>
 #include <kernel/unwind.h>
 
-/* void __cpu_spin_lock(lock address) - lock mutex */
+/* void __cpu_spin_lock(unsigned int *lock) */
 FUNC __cpu_spin_lock , :
 UNWIND(	.fnstart)
 	mov r2, #SPINLOCK_LOCK
@@ -51,7 +51,7 @@ _spinlock_loop:
 UNWIND(	.fnend)
 END_FUNC __cpu_spin_lock
 
-/* int __cpu_spin_trylock(lock address) - return 0 on success */
+/* int __cpu_spin_trylock(unsigned int *lock) - return 0 on success */
 FUNC __cpu_spin_trylock , :
 UNWIND(	.fnstart)
 	mov r2, #SPINLOCK_LOCK
@@ -72,7 +72,7 @@ _trylock_out:
 UNWIND(	.fnend)
 END_FUNC __cpu_spin_trylock
 
-/* void __cpu_spin_unlock(lock address) - unlock mutex */
+/* void __cpu_spin_unlock(unsigned int *lock) */
 FUNC __cpu_spin_unlock , :
 UNWIND(	.fnstart)
 	dmb

--- a/core/arch/arm/kernel/spin_lock_a32.S
+++ b/core/arch/arm/kernel/spin_lock_a32.S
@@ -35,8 +35,8 @@
 #include <kernel/tz_proc.h>
 #include <kernel/unwind.h>
 
-/* void cpu_spin_lock(lock address) - lock mutex */
-FUNC cpu_spin_lock , :
+/* void __cpu_spin_lock(lock address) - lock mutex */
+FUNC __cpu_spin_lock , :
 UNWIND(	.fnstart)
 	mov r2, #SPINLOCK_LOCK
 _spinlock_loop:
@@ -49,10 +49,10 @@ _spinlock_loop:
 	dmb
 	bx lr
 UNWIND(	.fnend)
-END_FUNC cpu_spin_lock
+END_FUNC __cpu_spin_lock
 
-/* int cpu_spin_trylock(lock address) - return 0 on success */
-FUNC cpu_spin_trylock , :
+/* int __cpu_spin_trylock(lock address) - return 0 on success */
+FUNC __cpu_spin_trylock , :
 UNWIND(	.fnstart)
 	mov r2, #SPINLOCK_LOCK
 	mov r1, r0
@@ -70,10 +70,10 @@ _trylock_out:
 	dmb
 	bx lr
 UNWIND(	.fnend)
-END_FUNC cpu_spin_trylock
+END_FUNC __cpu_spin_trylock
 
-/* void cpu_spin_unlock(lock address) - unlock mutex */
-FUNC cpu_spin_unlock , :
+/* void __cpu_spin_unlock(lock address) - unlock mutex */
+FUNC __cpu_spin_unlock , :
 UNWIND(	.fnstart)
 	dmb
 	mov r1, #SPINLOCK_UNLOCK
@@ -82,4 +82,4 @@ UNWIND(	.fnstart)
 	sev
 	bx lr
 UNWIND(	.fnend)
-END_FUNC cpu_spin_unlock
+END_FUNC __cpu_spin_unlock

--- a/core/arch/arm/kernel/spin_lock_a32.S
+++ b/core/arch/arm/kernel/spin_lock_a32.S
@@ -35,6 +35,12 @@
 #include <kernel/spinlock.h>
 #include <kernel/unwind.h>
 
+	/*
+	 * WARNING: FIXME: this .section is needed for plat-stm to boot
+	 * when CFG_WITH_PAGER==y. No idea why at the moment.
+	 */
+	.section .text.proc
+
 /* void __cpu_spin_lock(unsigned int *lock) */
 FUNC __cpu_spin_lock , :
 UNWIND(	.fnstart)

--- a/core/arch/arm/kernel/spin_lock_a32.S
+++ b/core/arch/arm/kernel/spin_lock_a32.S
@@ -32,7 +32,7 @@
  */
 
 #include <asm.S>
-#include <kernel/tz_proc.h>
+#include <kernel/spinlock.h>
 #include <kernel/unwind.h>
 
 /* void __cpu_spin_lock(unsigned int *lock) */

--- a/core/arch/arm/kernel/spin_lock_a64.S
+++ b/core/arch/arm/kernel/spin_lock_a64.S
@@ -55,28 +55,29 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <kernel/tz_proc.h>
+
 #include <asm.S>
 
 /* void __cpu_spin_lock(unsigned int *lock); */
 FUNC __cpu_spin_lock , :
 	mov	w2, #SPINLOCK_LOCK
 	sevl
-1:	wfe
-2:	ldaxr	w1, [x0]
-	cbnz	w1, 1b
+l1:	wfe
+l2:	ldaxr	w1, [x0]
+	cbnz	w1, l1
 	stxr	w1, w2, [x0]
-	cbnz	w1, 2b
+	cbnz	w1, l2
 	ret
 END_FUNC __cpu_spin_lock
 
 /* int __cpu_spin_trylock(unsigned int *lock); */
 FUNC __cpu_spin_trylock , :
 	mov	w2, #SPINLOCK_LOCK
-1:	ldaxr	w1, [x0]
-	cbnz	w1, 1f
+.loop:	ldaxr	w1, [x0]
+	cbnz	w1, .cpu_spin_trylock_out
 	stxr	w1, w2, [x0]
-	cbnz	w1, 1b
-1:
+	cbnz	w1, .loop
+.cpu_spin_trylock_out:
 	ret
 END_FUNC __cpu_spin_trylock
 

--- a/core/arch/arm/kernel/spin_lock_a64.S
+++ b/core/arch/arm/kernel/spin_lock_a64.S
@@ -57,8 +57,8 @@
 #include <kernel/tz_proc.h>
 #include <asm.S>
 
-/* void cpu_spin_lock(unsigned int *lock); */
-FUNC cpu_spin_lock , :
+/* void __cpu_spin_lock(unsigned int *lock); */
+FUNC __cpu_spin_lock , :
 	mov	w2, #SPINLOCK_LOCK
 	sevl
 1:	wfe
@@ -67,10 +67,10 @@ FUNC cpu_spin_lock , :
 	stxr	w1, w2, [x0]
 	cbnz	w1, 2b
 	ret
-END_FUNC cpu_spin_lock
+END_FUNC __cpu_spin_lock
 
-/* int cpu_spin_trylock(unsigned int *lock); */
-FUNC cpu_spin_trylock , :
+/* int __cpu_spin_trylock(unsigned int *lock); */
+FUNC __cpu_spin_trylock , :
 	mov	w2, #SPINLOCK_LOCK
 1:	ldaxr	w1, [x0]
 	cbnz	w1, 1f
@@ -78,11 +78,11 @@ FUNC cpu_spin_trylock , :
 	cbnz	w1, 1b
 1:
 	ret
-END_FUNC cpu_spin_trylock
+END_FUNC __cpu_spin_trylock
 
 
-/* void cpu_spin_unlock(unsigned int *lock); */
-FUNC cpu_spin_unlock , :
+/* void __cpu_spin_unlock(unsigned int *lock); */
+FUNC __cpu_spin_unlock , :
 	stlr	wzr, [x0]
 	ret
-END_FUNC cpu_spin_unlock
+END_FUNC __cpu_spin_unlock

--- a/core/arch/arm/kernel/spin_lock_a64.S
+++ b/core/arch/arm/kernel/spin_lock_a64.S
@@ -54,7 +54,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <kernel/tz_proc.h>
+#include <kernel/spinlock.h>
 
 #include <asm.S>
 

--- a/core/arch/arm/kernel/spin_lock_a64.S
+++ b/core/arch/arm/kernel/spin_lock_a64.S
@@ -55,29 +55,28 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <kernel/tz_proc.h>
-
 #include <asm.S>
 
 /* void cpu_spin_lock(unsigned int *lock); */
 FUNC cpu_spin_lock , :
 	mov	w2, #SPINLOCK_LOCK
 	sevl
-l1:	wfe
-l2:	ldaxr	w1, [x0]
-	cbnz	w1, l1
+1:	wfe
+2:	ldaxr	w1, [x0]
+	cbnz	w1, 1b
 	stxr	w1, w2, [x0]
-	cbnz	w1, l2
+	cbnz	w1, 2b
 	ret
 END_FUNC cpu_spin_lock
 
 /* int cpu_spin_trylock(unsigned int *lock); */
 FUNC cpu_spin_trylock , :
 	mov	w2, #SPINLOCK_LOCK
-.loop:	ldaxr	w1, [x0]
-	cbnz	w1, .cpu_spin_trylock_out
+1:	ldaxr	w1, [x0]
+	cbnz	w1, 1f
 	stxr	w1, w2, [x0]
-	cbnz	w1, .loop
-.cpu_spin_trylock_out:
+	cbnz	w1, 1b
+1:
 	ret
 END_FUNC cpu_spin_trylock
 

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -11,6 +11,7 @@ srcs-$(CFG_ARM32_core) += proc_a32.S
 srcs-$(CFG_ARM32_core) += spin_lock_a32.S
 srcs-$(CFG_ARM64_core) += proc_a64.S
 srcs-$(CFG_ARM64_core) += spin_lock_a64.S
+srcs-$(CFG_TEE_CORE_DEBUG) += spin_lock_debug.c
 srcs-$(CFG_ARM32_core) += ssvce_a32.S
 srcs-$(CFG_ARM64_core) += ssvce_a64.S
 srcs-$(CFG_ARM64_core) += cache_helpers_a64.S

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -8,6 +8,7 @@ srcs-$(CFG_SECURE_TIME_SOURCE_CNTPCT) += tee_time_arm_cntpct.c
 srcs-$(CFG_SECURE_TIME_SOURCE_REE) += tee_time_ree.c
 
 srcs-$(CFG_ARM32_core) += proc_a32.S
+srcs-$(CFG_ARM32_core) += spin_lock_a32.S
 srcs-$(CFG_ARM64_core) += proc_a64.S
 srcs-$(CFG_ARM64_core) += spin_lock_a64.S
 srcs-$(CFG_ARM32_core) += ssvce_a32.S

--- a/core/arch/arm/kernel/tee_l2cc_mutex.c
+++ b/core/arch/arm/kernel/tee_l2cc_mutex.c
@@ -26,10 +26,11 @@
  */
 #include <kernel/tee_common.h>
 #include <kernel/tee_l2cc_mutex.h>
+#include <kernel/spinlock.h>
 #include <mm/tee_mm.h>
-#include <tee_api_defines.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <tee_api_defines.h>
 #include <trace.h>
 
 /*

--- a/core/arch/arm/kernel/tee_l2cc_mutex.c
+++ b/core/arch/arm/kernel/tee_l2cc_mutex.c
@@ -30,7 +30,6 @@
 #include <tee_api_defines.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
-#include <kernel/tz_proc.h>
 #include <trace.h>
 
 /*

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -235,6 +235,10 @@ void thread_set_exceptions(uint32_t exceptions)
 {
 	uint32_t cpsr = read_cpsr();
 
+	/* IRQ must not be unmasked while holding a spinlock */
+	if (!(exceptions & THREAD_EXCP_IRQ))
+		assert_have_no_spinlock();
+
 	cpsr &= ~(THREAD_EXCP_ALL << CPSR_F_SHIFT);
 	cpsr |= ((exceptions & THREAD_EXCP_ALL) << CPSR_F_SHIFT);
 	write_cpsr(cpsr);
@@ -252,6 +256,10 @@ uint32_t thread_get_exceptions(void)
 void thread_set_exceptions(uint32_t exceptions)
 {
 	uint32_t daif = read_daif();
+
+	/* IRQ must not be unmasked while holding a spinlock */
+	if (!(exceptions & THREAD_EXCP_IRQ))
+		assert_have_no_spinlock();
 
 	daif &= ~(THREAD_EXCP_ALL << DAIF_F_SHIFT);
 	daif |= ((exceptions & THREAD_EXCP_ALL) << DAIF_F_SHIFT);

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -33,11 +33,10 @@
 #include <keep.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
+#include <kernel/spinlock.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread_defs.h>
 #include <kernel/thread.h>
-#include <kernel/tz_proc_def.h>
-#include <kernel/tz_proc.h>
 #include <mm/core_memprot.h>
 #include <mm/tee_mm.h>
 #include <mm/tee_mmu_defs.h>

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -135,6 +135,9 @@ struct thread_core_local {
 	vaddr_t abt_stack_va_end;
 	uint64_t x[4];
 #endif
+#ifdef CFG_TEE_CORE_DEBUG
+	uint32_t locked_count; /* Number of spinlocks held */
+#endif
 } THREAD_CORE_LOCAL_ALIGNED;
 
 #endif /*ASM*/

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -136,7 +136,7 @@ struct thread_core_local {
 	uint64_t x[4];
 #endif
 #ifdef CFG_TEE_CORE_DEBUG
-	uint32_t locked_count; /* Number of spinlocks held */
+	unsigned int locked_count; /* Number of spinlocks held */
 #endif
 } THREAD_CORE_LOCAL_ALIGNED;
 

--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -29,7 +29,7 @@
 #include <tee_api_defines.h>
 #include <string.h>
 #include <optee_msg.h>
-#include <kernel/tz_proc.h>
+#include <kernel/spinlock.h>
 #include <kernel/wait_queue.h>
 #include <kernel/thread.h>
 #include <trace.h>

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -40,7 +40,6 @@
 #include <kernel/tee_misc.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
-#include <kernel/tz_proc.h>
 #include <kernel/tz_ssvce.h>
 #include <kernel/tz_ssvce_pl310.h>
 #include <mm/core_memprot.h>

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -32,6 +32,7 @@
 #include <sys/queue.h>
 #include <kernel/abort.h>
 #include <kernel/panic.h>
+#include <kernel/spinlock.h>
 #include <kernel/tee_misc.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -35,7 +35,6 @@
 #include <kernel/tee_misc.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
-#include <kernel/tz_proc.h>
 #include <mm/core_memprot.h>
 #include <mm/tee_mm.h>
 #include <mm/tee_mmu_defs.h>


### PR DESCRIPTION
A number of usage constraints for spinlocks and mutexes are documented in `documentation/optee_design.md`. This PR adds a few assertions to the code so that they are actually enforced at runtime when `CFG_TEE_CORE_DEBUG==y`.