### PR TITLE
Corrected dead link for legacy compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ However, if you only want to compile optee_os, then you can do like this:
 $ cd $HOME
 $ mkdir toolchains
 $ cd toolchains
-$ wget http://releases.linaro.org/14.08/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.9-2014.08_linux.tar.xz
+$ wget http://releases.linaro.org/archive/14.08/components/toolchain/binaries/gcc-linaro-arm-linux-gnueabihf-4.9-2014.08_linux.tar.xz
 $ tar xvf gcc-linaro-arm-linux-gnueabihf-4.9-2014.08_linux.tar.xz
 $ export PATH=$HOME/toolchains/gcc-linaro-arm-linux-gnueabihf-4.9-2014.08_linux/bin:$PATH
 ```

--- a/documentation/debug.md
+++ b/documentation/debug.md
@@ -39,7 +39,7 @@ start by downloading this toolchain
 
 
 ```
-wget https://releases.linaro.org/14.09/components/toolchain/binaries/gcc-linaro-arm-none-eabi-4.9-2014.09_linux.tar.xz
+wget https://releases.linaro.org/archive/14.09/components/toolchain/binaries/gcc-linaro-arm-none-eabi-4.9-2014.09_linux.tar.xz
 ```
 
 and put it in the toolchain folder


### PR DESCRIPTION
Compilers are now in archive folder.

Fixes: https://github.com/OP-TEE/optee_os/issues/1220
```
Signed-off-by: Sylvain Pelissier <sylvain.pelissier@gmail.com>
```