### PR TITLE
Makefile: unexport MAKEFILE_LIST to reduce the size of the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,19 @@
 SHELL = /bin/bash
 
+# It can happen that a makefile calls us, which contains an 'export' directive
+# or the '.EXPORT_ALL_VARIABLES:' special target. In this case, all the make
+# variables are added to the environment for each line of the recipes, so that
+# any sub-makefile can use them.
+# We have observed this can cause issues such as 'Argument list too long'
+# errors as the shell runs out of memory.
+# Since this Makefile won't call any sub-makefiles, and since the commands do
+# not expect to implicitely obtain any make variable from the environment, we
+# can safely cancel this export mechanism. Unfortunately, it can't be done
+# globally, only by name. Let's unexport MAKEFILE_LIST which is by far the
+# biggest one due to our way of tracking dependencies and compile flags
+# (we include many *.cmd and *.d files).
+unexport MAKEFILE_LIST
+
 .PHONY: all
 all:
 


### PR DESCRIPTION
To avoid issues [1] with some projects that call us from a top-level
Makefile that has an 'export' directive or a '.EXPORT_ALL_VARIABLES:'
target, we prevent $(MAKEFILE_LIST) from being exported, thereby
greatly reducing the size of the environment.

[1] Typically, the build succeeds the first time (because there is no
.cmd/.d files yet), then the second invocation of make fails with:

    CHK     out/arm-plat-vexpress/conf.mk
  make[3]: execvp: /bin/bash: Argument list too long

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>