### PR TITLE
secure storage: change struct tee_fs_file_info member type

### DIFF
--- a/core/include/tee/tee_fs_key_manager.h
+++ b/core/include/tee/tee_fs_key_manager.h
@@ -54,7 +54,7 @@ enum tee_fs_file_type {
 };
 
 struct tee_fs_file_info {
-	size_t length;
+	uint64_t length;
 	uint32_t backup_version_table[NUM_BLOCKS_PER_FILE / 32];
 };
 

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -639,7 +639,8 @@ static TEE_Result ree_fs_read(struct tee_file_handle *fh, void *buf,
 	if ((fdp->pos + remain_bytes) < remain_bytes ||
 	    fdp->pos > (tee_fs_off_t)fdp->meta.info.length)
 		remain_bytes = 0;
-	else if (fdp->pos + remain_bytes > fdp->meta.info.length)
+	else if (fdp->pos + (tee_fs_off_t)remain_bytes >
+		(tee_fs_off_t)fdp->meta.info.length)
 		remain_bytes = fdp->meta.info.length - fdp->pos;
 
 	*len = remain_bytes;


### PR DESCRIPTION
In struct tee_fs_file_info, the member length's origin type is size_t,
when NS user is 64 bits, and secure kernel is 32 bits, the type size_t
will have different width, which will cause xtest 20022 case fail.
This commit change the member length's type from size_t to uint64_t,
which can keep a fixed width.

Relates to:
#1185 

Signed-off-by: Guanchao Liang <liang.guanchao@linaro.org>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (HiKey)