### PR TITLE
core: fix the user ta memory access permissions

### DIFF
--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -32,6 +32,9 @@ SECTIONS {
 		/* Workaround for an erratum in ARM's VFP11 coprocessor */
 		*(.vfp11_veneer)
 	}
+
+	/* Page align to allow dropping execute bit for non-text sections */
+	. = ALIGN(4096);
 	.eh_frame : { *(.eh_frame) } :rodata
 	.rodata : {
 		*(.gnu.linkonce.r.*)
@@ -72,7 +75,7 @@ SECTIONS {
 	.dynstr : { *(.dynstr) }
 	.hash : { *(.hash) }
 
-	/* Page align to allow dropping execute bit for RW data */
+	/* Page align to allow dropping write bit for RO data */
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata


### PR DESCRIPTION
Currently the text and rodata has got the same permissions,
fix it with strict section alignment.

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>