### PR TITLE
mm: use more strict user ta memory access control

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -129,9 +129,11 @@ out:
 
 static uint32_t elf_flags_to_mattr(uint32_t flags, bool init_attrs)
 {
-	uint32_t mattr = TEE_MATTR_PRW;
+	uint32_t mattr = 0;
 
-	if (!init_attrs) {
+	if (init_attrs)
+		mattr = TEE_MATTR_PRW;
+	else {
 		if (flags & PF_X)
 			mattr |= TEE_MATTR_UX;
 		if (flags & PF_W)


### PR DESCRIPTION
There are two stages for ta memory access permissions:
1. TA is in loading process, PL1(kernel) has got the RW permission only.
2. TA is loaded, PL0(user ta) has got the required permissions.

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>