### PR TITLE
[RFC] Dynamic shared memory implementation.

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -63,7 +63,7 @@ struct thread_specific_data {
 	struct tee_ta_ctx *ctx;
 	struct pgt_cache pgt_cache;
 	void *rpc_fs_payload;
-	paddr_t rpc_fs_payload_pa;
+	struct mobj *rpc_fs_payload_mobj;
 	uint64_t rpc_fs_payload_cookie;
 	size_t rpc_fs_payload_size;
 };
@@ -529,11 +529,11 @@ bool thread_enable_prealloc_rpc_cache(void);
  * Allocates data for struct optee_msg_arg.
  *
  * @size:	size in bytes of struct optee_msg_arg
- * @arg:	returned physcial pointer to a struct optee_msg_arg buffer,
- *		0 if allocation failed.
  * @cookie:	returned cookie used when freeing the buffer
+ *
+ * @returns	mobj that describes allocated buffer or NULL on error
  */
-void thread_rpc_alloc_arg(size_t size, paddr_t *arg, uint64_t *cookie);
+struct mobj *thread_rpc_alloc_arg(size_t size, uint64_t *cookie);
 
 /**
  * Free physical memory previously allocated with thread_rpc_alloc_arg()
@@ -546,18 +546,19 @@ void thread_rpc_free_arg(uint64_t cookie);
  * Allocates data for payload buffers.
  *
  * @size:	size in bytes of payload buffer
- * @payload:	returned physcial pointer to payload buffer, 0 if allocation
- *		failed.
  * @cookie:	returned cookie used when freeing the buffer
+ *
+ * @returns	mobj that describes allocated buffer or NULL on error
  */
-void thread_rpc_alloc_payload(size_t size, paddr_t *payload, uint64_t *cookie);
+struct mobj *thread_rpc_alloc_payload(size_t size, uint64_t *cookie);
 
 /**
  * Free physical memory previously allocated with thread_rpc_alloc_payload()
  *
  * @cookie:	cookie received when allocating the buffer
+ * @mobj:	mobj that describes the buffer
  */
-void thread_rpc_free_payload(uint64_t cookie);
+void thread_rpc_free_payload(uint64_t cookie, struct mobj *mobj);
 
 /**
  * Does an RPC using a preallocated argument buffer

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -139,6 +139,8 @@ struct mobj *mobj_reg_shm_find_by_cookie(uint64_t cookie);
 struct mobj *mobj_mapped_shm_alloc(paddr_t *pages, size_t num_pages,
 				   paddr_t page_offset, uint64_t cookie);
 
+struct mobj *mobj_shm_alloc(paddr_t pa, size_t size);
+
 struct mobj *mobj_paged_alloc(size_t size);
 
 #ifdef CFG_PAGED_USER_TA

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -290,6 +290,8 @@
 #define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	(1 << 0)
 /* Secure world can communicate via previously unregistered shared memory */
 #define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	(1 << 1)
+/* Secure world supporst commands "register/unregister shared memory" */
+#define OPTEE_SMC_SEC_CAP_REGISTER_SHM		(1 << 2)
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES)

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1201,8 +1201,7 @@ struct mobj *thread_rpc_alloc_arg(size_t size, uint64_t *cookie)
 		goto err;
 	/* Check if this region is in static shared space */
 	if (core_pbuf_is(CORE_MEM_NSEC_SHM, pa, size)) {
-		mobj = mobj_phys_alloc(pa, size, TEE_MATTR_CACHE_CACHED,
-				       CORE_MEM_NSEC_SHM);
+		mobj = mobj_shm_alloc(pa, size);
 	} else {
 		page = pa & ~SMALL_PAGE_MASK;
 		mobj = mobj_mapped_shm_alloc(&page, 1, 0, co);
@@ -1370,10 +1369,8 @@ static struct mobj *thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
 		   core_pbuf_is(CORE_MEM_NSEC_SHM,
 				arg->params[0].u.tmem.buf_ptr,
 				arg->params[0].u.tmem.size)) {
-		mobj = mobj_phys_alloc(arg->params[0].u.tmem.buf_ptr,
-				       arg->params[0].u.tmem.size,
-				       TEE_MATTR_CACHE_CACHED,
-				       CORE_MEM_NSEC_SHM);
+		mobj = mobj_shm_alloc(arg->params[0].u.tmem.buf_ptr,
+				      arg->params[0].u.tmem.size);
 		*cookie = arg->params[0].u.tmem.shm_ref;
 	} else
 		goto fail;

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1334,7 +1334,7 @@ static struct mobj *get_registed_mobj(struct optee_msg_param *params)
 	int num_pages;
 	struct mobj *mobj = NULL;
 
-	assert(params->attr == OPTEE_MSG_ATTR_TYPE_NONCONTIG);
+	assert(params->attr & OPTEE_MSG_ATTR_NONCONTIG);
 
 	page_offset = params->u.tmem.buf_ptr & SMALL_PAGE_MASK;
 
@@ -1391,7 +1391,8 @@ static struct mobj *thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
 	if (arg->num_params != 1)
 		goto fail;
 
-	if (arg->params[0].attr == OPTEE_MSG_ATTR_TYPE_NONCONTIG) {
+	if ((arg->params[0].attr =
+	     (OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT | OPTEE_MSG_ATTR_TYPE_MASK))) {
 		*cookie = arg->params[0].u.nested.shm_ref;
 		mobj = get_registed_mobj(arg->params);
 	} else if ((arg->params[0].attr == OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT) &&
@@ -1399,7 +1400,7 @@ static struct mobj *thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
 				arg->params[0].u.tmem.buf_ptr,
 				arg->params[0].u.tmem.size)) {
 		mobj = mobj_phys_alloc(arg->params[0].u.tmem.buf_ptr,
-				       arg->params[0].u.tmem.size,
+			       arg->params[0].u.tmem.size,
 				       TEE_MATTR_CACHE_CACHED,
 				       CORE_MEM_NSEC_SHM);
 		*cookie = arg->params[0].u.tmem.shm_ref;

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -113,6 +113,7 @@ struct thread_ctx {
 #endif
 	void *rpc_arg;
 	uint64_t rpc_carg;
+	struct mobj *rpc_mobj;
 	struct mutex_head mutexes;
 	struct thread_specific_data tsd;
 };

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <compiler.h>
 #include <keep.h>
+#include <kernel/msg_param.h>
 #include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1060,6 +1060,9 @@ static void set_pg_region(struct core_mmu_table_info *dir_info,
 
 		r.size = MIN(CORE_MMU_PGDIR_SIZE - (r.va - pg_info->va_base),
 			     end - r.va);
+		r.size = MIN(r.size, mobj_get_phys_granule(region->mobj));
+		r.size = ROUNDUP(r.size, SMALL_PAGE_SIZE);
+
 		if (!mobj_is_paged(region->mobj)) {
 			size_t granule = BIT(pg_info->shift);
 			size_t offset = r.va - region->va + region->offset;

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -348,7 +348,7 @@ static TEE_Result mobj_reg_shm_get_pa(struct mobj *mobj, size_t offst,
 	switch (granule) {
 	case 0:
 		p = mobj_reg_shm->pages[offst / SMALL_PAGE_SIZE] +
-			offst % SMALL_PAGE_SIZE;
+			(full_offset & SMALL_PAGE_MASK);
 		break;
 	case SMALL_PAGE_SIZE:
 		p = mobj_reg_shm->pages[offst / SMALL_PAGE_SIZE];

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -588,6 +588,92 @@ static TEE_Result mobj_mapped_shm_init(void)
 
 service_init(mobj_mapped_shm_init);
 
+/*
+ * mobj_shm implementation. mobj_shm represents buffer in predefined shm region
+ */
+
+struct mobj_shm {
+	struct mobj mobj;
+	paddr_t pa;
+};
+
+static struct mobj_shm *to_mobj_shm(struct mobj *mobj);
+
+static void *mobj_shm_get_va(struct mobj *mobj, size_t offset)
+{
+	struct mobj_shm *m = to_mobj_shm(mobj);
+
+	if (offset >= mobj->size)
+		return NULL;
+
+	return phys_to_virt(m->pa + offset, MEM_AREA_NSEC_SHM);
+}
+
+static TEE_Result mobj_shm_get_pa(struct mobj *mobj, size_t offs,
+				   size_t granule, paddr_t *pa)
+{
+	struct mobj_shm *m = to_mobj_shm(mobj);
+	paddr_t p;
+
+	if (!pa || offs >= mobj->size)
+		return TEE_ERROR_GENERIC;
+
+	p = m->pa + offs;
+
+	if (granule) {
+		if (granule != SMALL_PAGE_SIZE &&
+		    granule != CORE_MMU_PGDIR_SIZE)
+			return TEE_ERROR_GENERIC;
+		p &= ~(granule - 1);
+	}
+
+	*pa = p;
+	return TEE_SUCCESS;
+}
+
+static bool mobj_shm_matches(struct mobj *mobj __unused, enum buf_is_attr attr)
+{
+	return attr == CORE_MEM_NSEC_SHM;
+}
+
+static void mobj_shm_free(struct mobj *mobj)
+{
+	struct mobj_shm *m = to_mobj_shm(mobj);
+
+	free(m);
+}
+
+static const struct mobj_ops mobj_shm_ops __rodata_unpaged = {
+	.get_va = mobj_shm_get_va,
+	.get_pa = mobj_shm_get_pa,
+	.matches = mobj_shm_matches,
+	.free = mobj_shm_free,
+};
+
+static struct mobj_shm *to_mobj_shm(struct mobj *mobj)
+{
+	assert(mobj->ops == &mobj_shm_ops);
+	return container_of(mobj, struct mobj_shm, mobj);
+}
+
+struct mobj *mobj_shm_alloc(paddr_t pa, size_t size)
+{
+	struct mobj_shm *m;
+
+	if (!core_pbuf_is(CORE_MEM_NSEC_SHM, pa, size))
+		return NULL;
+
+	m = calloc(1, sizeof(*m));
+	if (!m)
+		return NULL;
+
+	m->mobj.size = size;
+	m->mobj.ops = &mobj_shm_ops;
+	m->pa = pa;
+
+	return &m->mobj;
+}
+
 #ifdef CFG_PAGED_USER_TA
 /*
  * mobj_paged implementation

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -31,6 +31,7 @@
 #include <kernel/user_ta.h>
 #include <kernel/thread.h>
 #include <mm/core_memprot.h>
+#include <mm/mobj.h>
 #include <mm/tee_mmu.h>
 #include <optee_msg_supplicant.h>
 #include <pta_gprof.h>
@@ -40,16 +41,16 @@ static TEE_Result gprof_send_rpc(TEE_UUID *uuid, void *buf, size_t len,
 				 uint32_t *id)
 {
 	struct optee_msg_param params[3];
+	struct mobj *mobj;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	uint64_t c = 0;
-	paddr_t pa;
 	char *va;
 
-	thread_rpc_alloc_payload(sizeof(*uuid) + len, &pa, &c);
-	if (!pa)
+	mobj = thread_rpc_alloc_payload(sizeof(*uuid) + len, &c);
+	if (!mobj)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	va = phys_to_virt(pa, MEM_AREA_NSEC_SHM);
+	va = mobj_get_va(mobj, 0);
 	if (!va)
 		goto exit;
 
@@ -60,15 +61,10 @@ static TEE_Result gprof_send_rpc(TEE_UUID *uuid, void *buf, size_t len,
 	params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INOUT;
 	params[0].u.value.a = *id;
 
-	params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	params[1].u.tmem.buf_ptr = pa;
-	params[1].u.tmem.size = sizeof(*uuid);
-	params[1].u.tmem.shm_ref = c;
-
-	params[2].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	params[2].u.tmem.buf_ptr = pa + sizeof(*uuid);
-	params[2].u.tmem.size = len;
-	params[2].u.tmem.shm_ref = c;
+	msg_param_init_memparam(params + 1, mobj, 0, sizeof(*uuid), c,
+				MSG_PARAM_MEM_DIR_IN);
+	msg_param_init_memparam(params + 2, mobj, sizeof(*uuid), len, c,
+				MSG_PARAM_MEM_DIR_IN);
 
 	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_GPROF, 3, params);
 	if (res != TEE_SUCCESS)
@@ -76,7 +72,7 @@ static TEE_Result gprof_send_rpc(TEE_UUID *uuid, void *buf, size_t len,
 
 	*id = (uint32_t)params[0].u.value.a;
 exit:
-	thread_rpc_free_payload(c);
+	thread_rpc_free_payload(c, mobj);
 	return res;
 }
 

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -104,7 +104,6 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 	args->a0 = OPTEE_SMC_RETURN_OK;
 
 	args->a1 = OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM;
-#ifdef CFG_SMALL_PAGE_USER_TA
 	if (core_mmu_nsec_ddr_is_defined()) {
 		IMSG("NS DDR configured. Enabling dynamic SHM");
 		args->a1 |= OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM |
@@ -112,7 +111,6 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 	} else {
 		EMSG("No NS DDR configured for the platform. Disabling dynamic SHM");
 	}
-#endif
 }
 
 static void tee_entry_disable_shm_cache(struct thread_smc_args *args)

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -102,7 +102,17 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 	}
 
 	args->a0 = OPTEE_SMC_RETURN_OK;
+
 	args->a1 = OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM;
+#ifdef CFG_SMALL_PAGE_USER_TA
+	if (core_mmu_nsec_ddr_is_defined()) {
+		IMSG("NS DDR configured. Enabling dynamic SHM");
+		args->a1 |= OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM |
+			OPTEE_SMC_SEC_CAP_REGISTER_SHM;
+	} else {
+		EMSG("No NS DDR configured for the platform. Disabling dynamic SHM");
+	}
+#endif
 }
 
 static void tee_entry_disable_shm_cache(struct thread_smc_args *args)

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -473,7 +473,6 @@ static struct mobj *map_cmd_buffer(paddr_t parg, uint32_t *num_params)
 
 static struct mobj *get_cmd_buffer(paddr_t parg, uint32_t *num_params)
 {
-	struct mobj *mobj = NULL;
 	struct optee_msg_arg *arg;
 	size_t args_size;
 
@@ -484,10 +483,7 @@ static struct mobj *get_cmd_buffer(paddr_t parg, uint32_t *num_params)
 	*num_params = arg->num_params;
 	args_size = OPTEE_MSG_GET_ARG_SIZE(*num_params);
 
-	mobj = mobj_phys_alloc(parg, args_size,
-			       TEE_MATTR_CACHE_CACHED,
-			       CORE_MEM_NSEC_SHM);
-	return mobj;
+	return mobj_shm_alloc(parg, args_size);
 }
 
 void tee_entry_std(struct thread_smc_args *smc_args)

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -128,8 +128,6 @@ static TEE_Result copy_in_params(const struct optee_msg_param *params,
 
 		if (params[n].attr & OPTEE_MSG_ATTR_META)
 			return TEE_ERROR_BAD_PARAMETERS;
-		if (params[n].attr & OPTEE_MSG_ATTR_FRAGMENT)
-			return TEE_ERROR_BAD_PARAMETERS;
 
 		attr = params[n].attr & OPTEE_MSG_ATTR_TYPE_MASK;
 
@@ -388,10 +386,12 @@ static void register_shm(struct thread_smc_args *smc_args,
 	ssize_t num_pages, pages_cnt;
 
 	if (num_params != 1 ||
-	    arg->params[0].attr != OPTEE_MSG_ATTR_TYPE_NONCONTIG) {
+	    (arg->params[0].attr != (OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT |
+				     OPTEE_MSG_ATTR_NONCONTIG))) {
 		arg->ret = TEE_ERROR_BAD_PARAMETERS;
 		return;
 	}
+
 	page_offset = arg->params[0].u.tmem.buf_ptr & SMALL_PAGE_MASK;
 	num_pages = (arg->params[0].u.tmem.size + page_offset - 1)
 		/ SMALL_PAGE_SIZE + 1;

--- a/core/arch/arm/tee/pta_socket.c
+++ b/core/arch/arm/tee/pta_socket.c
@@ -26,7 +26,9 @@
  */
 
 #include <assert.h>
+#include <mm/mobj.h>
 #include <kernel/pseudo_ta.h>
+#include <kernel/msg_param.h>
 #include <optee_msg.h>
 #include <optee_msg_supplicant.h>
 #include <pta_socket.h>
@@ -41,8 +43,8 @@ static uint32_t get_instance_id(struct tee_ta_session *sess)
 static TEE_Result socket_open(uint32_t instance_id, uint32_t param_types,
 			      TEE_Param params[TEE_NUM_PARAMS])
 {
+	struct mobj *mobj;
 	TEE_Result res;
-	paddr_t pa;
 	uint64_t cookie;
 	void *va;
 	struct optee_msg_param msg_params[4];
@@ -59,7 +61,7 @@ static TEE_Result socket_open(uint32_t instance_id, uint32_t param_types,
 
 	memset(msg_params, 0, sizeof(msg_params));
 
-	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -73,10 +75,10 @@ static TEE_Result socket_open(uint32_t instance_id, uint32_t param_types,
 	msg_params[1].u.value.c = params[0].value.a; /* ip version */
 
 	/* server address */
-	msg_params[2].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	msg_params[2].u.tmem.buf_ptr = pa;
-	msg_params[2].u.tmem.size = params[1].memref.size;
-	msg_params[2].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(msg_params + 2, mobj, 0,
+				     params[1].memref.size, cookie,
+				     MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
 	memcpy(va, params[1].memref.buffer, params[1].memref.size);
 
 	/* socket handle */
@@ -118,8 +120,8 @@ static TEE_Result socket_close(uint32_t instance_id, uint32_t param_types,
 static TEE_Result socket_send(uint32_t instance_id, uint32_t param_types,
 			      TEE_Param params[TEE_NUM_PARAMS])
 {
+	struct mobj *mobj;
 	TEE_Result res;
-	paddr_t pa;
 	uint64_t cookie;
 	void *va;
 	struct optee_msg_param msg_params[3];
@@ -136,7 +138,7 @@ static TEE_Result socket_send(uint32_t instance_id, uint32_t param_types,
 
 	memset(msg_params, 0, sizeof(msg_params));
 
-	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -146,10 +148,11 @@ static TEE_Result socket_send(uint32_t instance_id, uint32_t param_types,
 	msg_params[0].u.value.c = params[0].value.a; /* handle */
 
 	/* buffer */
-	msg_params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	msg_params[1].u.tmem.buf_ptr = pa;
-	msg_params[1].u.tmem.size = params[1].memref.size;
-	msg_params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(msg_params + 1, mobj, 0,
+				     params[1].memref.size, cookie,
+				     MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
 	memcpy(va, params[1].memref.buffer, params[1].memref.size);
 
 	msg_params[2].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INOUT;
@@ -164,8 +167,8 @@ static TEE_Result socket_send(uint32_t instance_id, uint32_t param_types,
 static TEE_Result socket_recv(uint32_t instance_id, uint32_t param_types,
 			      TEE_Param params[TEE_NUM_PARAMS])
 {
+	struct mobj *mobj;
 	TEE_Result res;
-	paddr_t pa;
 	uint64_t cookie;
 	void *va;
 	struct optee_msg_param msg_params[3];
@@ -182,7 +185,7 @@ static TEE_Result socket_recv(uint32_t instance_id, uint32_t param_types,
 
 	memset(msg_params, 0, sizeof(msg_params));
 
-	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -192,27 +195,27 @@ static TEE_Result socket_recv(uint32_t instance_id, uint32_t param_types,
 	msg_params[0].u.value.c = params[0].value.a; /* handle */
 
 	/* buffer */
-	msg_params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
-	msg_params[1].u.tmem.buf_ptr = pa;
-	msg_params[1].u.tmem.size = params[1].memref.size;
-	msg_params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(msg_params + 1, mobj, 0,
+				     params[1].memref.size, cookie,
+				     MSG_PARAM_MEM_DIR_OUT))
+		return TEE_ERROR_BAD_STATE;
 
 	msg_params[2].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	msg_params[2].u.value.a = params[0].value.b /* timeout */;
 
 
 	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_SOCKET, 3, msg_params);
-	params[1].memref.size = msg_params[1].u.tmem.size;
-	if (msg_params[1].u.tmem.size)
-		memcpy(params[1].memref.buffer, va, msg_params[1].u.tmem.size);
+	params[1].memref.size = msg_param_get_buf_size(msg_params + 1);
+	if (params[1].memref.size)
+		memcpy(params[1].memref.buffer, va, params[1].memref.size);
 	return res;
 }
 
 static TEE_Result socket_ioctl(uint32_t instance_id, uint32_t param_types,
 			       TEE_Param params[TEE_NUM_PARAMS])
 {
+	struct mobj *mobj;
 	TEE_Result res;
-	paddr_t pa;
 	uint64_t cookie;
 	void *va;
 	struct optee_msg_param msg_params[3];
@@ -229,7 +232,7 @@ static TEE_Result socket_ioctl(uint32_t instance_id, uint32_t param_types,
 
 	memset(msg_params, 0, sizeof(msg_params));
 
-	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(params[1].memref.size, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -239,19 +242,21 @@ static TEE_Result socket_ioctl(uint32_t instance_id, uint32_t param_types,
 	msg_params[0].u.value.c = params[0].value.a; /* handle */
 
 	/* buffer */
-	msg_params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INOUT;
-	msg_params[1].u.tmem.buf_ptr = pa;
-	msg_params[1].u.tmem.size = params[1].memref.size;
-	msg_params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(msg_params + 1, mobj, 0,
+				     params[1].memref.size, cookie,
+				     MSG_PARAM_MEM_DIR_INOUT))
+		return TEE_ERROR_BAD_STATE;
+
 	memcpy(va, params[1].memref.buffer, params[1].memref.size);
 
 	msg_params[2].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	msg_params[2].u.value.a = params[0].value.b; /* ioctl command */
 
 	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_SOCKET, 3, msg_params);
-	if (msg_params[1].u.tmem.size <= params[1].memref.size)
-		memcpy(params[1].memref.buffer, va, msg_params[1].u.tmem.size);
-	params[1].memref.size = msg_params[1].u.tmem.size;
+	if (msg_param_get_buf_size(msg_params + 1) <= params[1].memref.size)
+		memcpy(params[1].memref.buffer, va,
+		       msg_param_get_buf_size(msg_params + 1));
+	params[1].memref.size = msg_param_get_buf_size(msg_params + 1);
 	return res;
 }
 

--- a/core/include/kernel/msg_param.h
+++ b/core/include/kernel/msg_param.h
@@ -46,29 +46,18 @@ enum msg_param_mem_dir {
 
 /**
  * msg_param_extract_pages() - extract list of pages from
- * OPTEE_MSG_ATTR_FRAGMENT parameters
+ * OPTEE_MSG_ATTR_TYPE_NONCONTIG buffer
  *
- * @params:	pointer to parameters array
+ * @buffer:	pointer to parameters array
  * @pages:	output array of page addresses
- * @num_params: number of parameters in array
+ * @num_pages:  number of pages in array
  *
  * return:
  *   page count on success
  *   <0 on error
  */
-ssize_t msg_param_extract_pages(struct optee_msg_param *params, paddr_t *pages,
-				size_t num_params);
-
-/**
- * msg_param_map_buffer() - map parameters buffer into OP-TEE VA space
- * @pa_params - physical pointer to parameters
- * @num_params - number of parameters
- *
- * return:
- *  struct shmem_mapping of mapped buffer on success
- *  NULL on error.
- */
-struct mobj *msg_param_map_buffer(paddr_t pa_params, size_t num_params);
+ssize_t msg_param_extract_pages(paddr_t buffer, paddr_t *pages,
+				size_t num_pages);
 
 /**
  * msg_param_init_memparam() - fill memory reference parameter for RPC call

--- a/core/include/kernel/msg_param.h
+++ b/core/include/kernel/msg_param.h
@@ -45,19 +45,18 @@ enum msg_param_mem_dir {
 };
 
 /**
- * msg_param_extract_pages() - extract list of pages from
- * OPTEE_MSG_ATTR_TYPE_NONCONTIG buffer
+ * msg_param_mobj_from_noncontig_param() - construct mobj from non-contigous
+ * list of pages.
  *
- * @buffer:	pointer to parameters array
- * @pages:	output array of page addresses
- * @num_pages:  number of pages in array
+ * @param - pointer to msg_param with OPTEE_MSG_ATTR_TYPE_NONCONTIG flag set
+ * @bool  - true of buffer needs to be mapped into OP-TEE address space
  *
  * return:
- *   page count on success
- *   <0 on error
+ *	mobj or NULL on error
  */
-ssize_t msg_param_extract_pages(paddr_t buffer, paddr_t *pages,
-				size_t num_pages);
+struct mobj *msg_param_mobj_from_noncontig_param(
+	const struct optee_msg_param *param,
+	bool map_buffer);
 
 /**
  * msg_param_init_memparam() - fill memory reference parameter for RPC call

--- a/core/include/kernel/msg_param.h
+++ b/core/include/kernel/msg_param.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2017, EPAM Systems
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KERNEL_MSG_PARAM_H
+#define KERNEL_MSG_PARAM_H
+
+#include <optee_msg.h>
+#include <stdio.h>
+#include <types_ext.h>
+#include <kernel/msg_param.h>
+#include <mm/mobj.h>
+
+/*
+ * This enum is used in tee_fill_memparam(). It describes direction of memory
+ * parameter.
+ */
+enum msg_param_mem_dir {
+	MSG_PARAM_MEM_DIR_IN = 0,
+	MSG_PARAM_MEM_DIR_OUT,
+	MSG_PARAM_MEM_DIR_INOUT,
+};
+
+/**
+ * msg_param_extract_pages() - extract list of pages from
+ * OPTEE_MSG_ATTR_FRAGMENT parameters
+ *
+ * @params:	pointer to parameters array
+ * @pages:	output array of page addresses
+ * @num_params: number of parameters in array
+ *
+ * return:
+ *   page count on success
+ *   <0 on error
+ */
+ssize_t msg_param_extract_pages(struct optee_msg_param *params, paddr_t *pages,
+				size_t num_params);
+
+/**
+ * msg_param_map_buffer() - map parameters buffer into OP-TEE VA space
+ * @pa_params - physical pointer to parameters
+ * @num_params - number of parameters
+ *
+ * return:
+ *  struct shmem_mapping of mapped buffer on success
+ *  NULL on error.
+ */
+struct mobj *msg_param_map_buffer(paddr_t pa_params, size_t num_params);
+
+/**
+ * msg_param_init_memparam() - fill memory reference parameter for RPC call
+ * @param	- parameter to fill
+ * @mobj	- mobj describing the shared memory buffer
+ * @offset	- offset of the buffer
+ * @size	- size of the buffer
+ * @cookie	- NW cookie of the shared buffer
+ * @dir		- data direction
+ *
+ * Idea behind this function is that thread_rpc_alloc() can return
+ * either buffer from preallocated memory pool, of buffer constructed
+ * from supplicant's memory. In first case parameter will have type
+ * OPTEE_MSG_ATTR_TYPE_TMEM_* and OPTEE_MSG_ATTR_TYPE_RMEM_ in second case.
+ * This function will fill parameter structure with right type, depending on
+ * the passed mobj.
+ *
+ * return:
+ *	true on success, false on failure
+ */
+bool msg_param_init_memparam(struct optee_msg_param *param, struct mobj *mobj,
+			     size_t offset, size_t size,
+			     uint64_t cookie, enum msg_param_mem_dir dir);
+/**
+ * msg_param_get_buf_size() - helper functions that reads [T/R]MEM
+ *			      parameter size
+ *
+ * @param - struct optee_msg_param to read size from
+ *
+ * return:
+ *	corresponding size field
+ */
+static inline size_t msg_param_get_buf_size(struct optee_msg_param *param)
+{
+	switch (param->attr & OPTEE_MSG_ATTR_TYPE_MASK) {
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INOUT:
+		return param->u.tmem.size;
+	case OPTEE_MSG_ATTR_TYPE_RMEM_INPUT:
+	case OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT:
+	case OPTEE_MSG_ATTR_TYPE_RMEM_INOUT:
+		return param->u.rmem.size;
+	default:
+		return 0;
+	}
+}
+
+/**
+ * msg_param_attr_is_tmem - helper functions that cheks if parameter is tmem
+ *
+ * @param - struct optee_msg_param to check
+ *
+ * return:
+ *	corresponding size field
+ */
+static inline bool msg_param_attr_is_tmem(struct optee_msg_param *param)
+{
+	switch (param->attr & OPTEE_MSG_ATTR_TYPE_MASK) {
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INOUT:
+		return true;
+	default:
+		return false;
+	}
+}
+#endif	/*KERNEL_MSG_PARAM_H*/

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -70,6 +70,19 @@
  */
 #define OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT	0xc
 
+/*
+ * Special parameter type that points to real command buffer. It is used
+ * when dynamic shared memory is enabled. In this case when OPTEE issues
+ * "allocate shared buffer" RPC it expects that address of that shared buffer
+ * will be returned in RPC params. But problem is that shared buffer is not
+ * physically contiguous, so one parameter is not enough to describe the whole
+ * buffer. Thus, NW returns type OPTEE_MSG_ATTR_TYPE_NESTED.
+ * @optee_msg_param_nested describes this buffer. It holds address with actual
+ * list of pages and also count of pages. Pages are stored as
+ * OPTEE_MSG_ATTR_TYPE_TMEM_* parameters.
+ */
+#define OPTEE_MSG_ATTR_TYPE_NESTED		0xd
+
 #define OPTEE_MSG_ATTR_TYPE_MASK		GENMASK_32(7, 0)
 
 /*
@@ -153,15 +166,29 @@ struct optee_msg_param_value {
 };
 
 /**
+ * struct optee_msg_param_nested - nested params
+ * @buf_ptr: Address of the buffer with nested params
+ * @params_num: Number of nested params
+ * @shm_ref: Shared memory reference, pointer to a struct tee_shm
+ */
+struct optee_msg_param_nested {
+	uint64_t buf_ptr;
+	uint64_t params_num;
+	uint64_t shm_ref;
+};
+
+/**
  * struct optee_msg_param - parameter
  * @attr: attributes
  * @memref: a memory reference
  * @value: a value
+ * @nested: nested params
  *
  * @attr & OPTEE_MSG_ATTR_TYPE_MASK indicates if tmem, rmem or value is used in
  * the union. OPTEE_MSG_ATTR_TYPE_VALUE_* indicates value,
- * OPTEE_MSG_ATTR_TYPE_TMEM_* indicates tmem and
- * OPTEE_MSG_ATTR_TYPE_RMEM_* indicates rmem.
+ * OPTEE_MSG_ATTR_TYPE_TMEM_* indicates @tmem and
+ * OPTEE_MSG_ATTR_TYPE_RMEM_* indicates @rmem,
+ * OPTEE_MSG_ATTR_TYPE_NESTED indicates @nested parameters.
  * OPTEE_MSG_ATTR_TYPE_NONE indicates that none of the members are used.
  */
 struct optee_msg_param {
@@ -170,6 +197,7 @@ struct optee_msg_param {
 		struct optee_msg_param_tmem tmem;
 		struct optee_msg_param_rmem rmem;
 		struct optee_msg_param_value value;
+		struct optee_msg_param_nested nested;
 	} u;
 };
 

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -57,31 +57,15 @@
 #define OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT		0xa
 #define OPTEE_MSG_ATTR_TYPE_TMEM_INOUT		0xb
 /*
- * Special parameter type denoting that command buffer continues on
- * specified page. It is used together with registered memory
- * buffers. When NW tries to register shared memory, it passes list
- * of pages to OP-TEE. List of pages can be so long, that it overlaps
- * over physical page boundary. In this case the last entry of
- * of optee_msg_param should have type OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT
- * and param.u.tmem.buf_ptr should point to next page, where list of
- * parameter continues. The same mechanism applies not only for
- * registered memory buffers, but for shared memory buffers requested by
- * OPTEE via RPC.
+ * Pointer to a list of pages used to registed user-defined SHM buffer.
+ * Uses the same union as OPTEE_MSG_ATTR_TYPE_TMEM_INOUT.
+ * buf_ptr should point to the beginning of the buffer. Buffer will contain
+ * list of page addresses. OP-TEE core can reconstruct contigous buffer from
+ * that page adresses list. Page addresses are stored as 64 bit values.
+ * Last entry on a page should point to the next page of buffer.
+ * 12 least significant of buf_ptr should hold page offset of user buffer.
  */
-#define OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT	0xc
-
-/*
- * Special parameter type that points to real command buffer. It is used
- * when dynamic shared memory is enabled. In this case when OPTEE issues
- * "allocate shared buffer" RPC it expects that address of that shared buffer
- * will be returned in RPC params. But problem is that shared buffer is not
- * physically contiguous, so one parameter is not enough to describe the whole
- * buffer. Thus, NW returns type OPTEE_MSG_ATTR_TYPE_NESTED.
- * @optee_msg_param_nested describes this buffer. It holds address with actual
- * list of pages and also count of pages. Pages are stored as
- * OPTEE_MSG_ATTR_TYPE_TMEM_* parameters.
- */
-#define OPTEE_MSG_ATTR_TYPE_NESTED		0xd
+#define OPTEE_MSG_ATTR_TYPE_NONCONTIG		0xc
 
 #define OPTEE_MSG_ATTR_TYPE_MASK		GENMASK_32(7, 0)
 

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -56,16 +56,6 @@
 #define OPTEE_MSG_ATTR_TYPE_TMEM_INPUT		0x9
 #define OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT		0xa
 #define OPTEE_MSG_ATTR_TYPE_TMEM_INOUT		0xb
-/*
- * Pointer to a list of pages used to registed user-defined SHM buffer.
- * Uses the same union as OPTEE_MSG_ATTR_TYPE_TMEM_INOUT.
- * buf_ptr should point to the beginning of the buffer. Buffer will contain
- * list of page addresses. OP-TEE core can reconstruct contigous buffer from
- * that page adresses list. Page addresses are stored as 64 bit values.
- * Last entry on a page should point to the next page of buffer.
- * 12 least significant of buf_ptr should hold page offset of user buffer.
- */
-#define OPTEE_MSG_ATTR_TYPE_NONCONTIG		0xc
 
 #define OPTEE_MSG_ATTR_TYPE_MASK		GENMASK_32(7, 0)
 
@@ -78,11 +68,15 @@
 #define OPTEE_MSG_ATTR_META			BIT(8)
 
 /*
- * The temporary shared memory object is not physically contiguous and this
- * temp memref is followed by another fragment until the last temp memref
- * that doesn't have this bit set.
+ * Pointer to a list of pages used to registed user-defined SHM buffer.
+ * Used with OPTEE_MSG_ATTR_TYPE_TMEM_*.
+ * buf_ptr should point to the beginning of the buffer. Buffer will contain
+ * list of page addresses. OP-TEE core can reconstruct contigous buffer from
+ * that page adresses list. Page addresses are stored as 64 bit values.
+ * Last entry on a page should point to the next page of buffer.
+ * 12 least significant of buf_ptr should hold page offset of user buffer.
  */
-#define OPTEE_MSG_ATTR_FRAGMENT			BIT(9)
+#define OPTEE_MSG_ATTR_NONCONTIG		BIT(9)
 
 /*
  * Memory attributes for caching passed with temp memrefs. The actual value

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -56,6 +56,19 @@
 #define OPTEE_MSG_ATTR_TYPE_TMEM_INPUT		0x9
 #define OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT		0xa
 #define OPTEE_MSG_ATTR_TYPE_TMEM_INOUT		0xb
+/*
+ * Special parameter type denoting that command buffer continues on
+ * specified page. It is used together with registered memory
+ * buffers. When NW tries to register shared memory, it passes list
+ * of pages to OP-TEE. List of pages can be so long, that it overlaps
+ * over physical page boundary. In this case the last entry of
+ * of optee_msg_param should have type OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT
+ * and param.u.tmem.buf_ptr should point to next page, where list of
+ * parameter continues. The same mechanism applies not only for
+ * registered memory buffers, but for shared memory buffers requested by
+ * OPTEE via RPC.
+ */
+#define OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT	0xc
 
 #define OPTEE_MSG_ATTR_TYPE_MASK		GENMASK_32(7, 0)
 

--- a/core/include/tee/tee_fs_rpc.h
+++ b/core/include/tee/tee_fs_rpc.h
@@ -96,6 +96,6 @@ static inline void tee_fs_rpc_cache_clear(
  * cache. The pointer is guaranteed to point to a large enough area or to
  * be NULL.
  */
-void *tee_fs_rpc_cache_alloc(size_t size, paddr_t *pa, uint64_t *cookie);
+void *tee_fs_rpc_cache_alloc(size_t size, struct mobj **mobj, uint64_t *cookie);
 
 #endif /* TEE_FS_RPC_H */

--- a/core/kernel/msg_param.c
+++ b/core/kernel/msg_param.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2017, EPAM Systems
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <optee_msg.h>
+#include <stdio.h>
+#include <types_ext.h>
+#include <kernel/msg_param.h>
+#include <mm/mobj.h>
+
+/**
+ * msg_param_extract_pages() - extract list of pages from
+ * OPTEE_MSG_ATTR_FRAGMENT parameters
+ *
+ * @params:	pointer to parameters array
+ * @pages:	output array of page addresses
+ * @num_params: number of parameters in array
+ *
+ * return:
+ *   page count on success
+ *   <0 on error
+ */
+ssize_t msg_param_extract_pages(struct optee_msg_param *params, paddr_t *pages,
+				size_t num_params)
+{
+	size_t pages_cnt = 0;
+	size_t i;
+	uint32_t attr;
+
+	if (params[num_params - 1].attr & OPTEE_MSG_ATTR_FRAGMENT)
+		return -1;
+
+	for (i = 0; i < num_params; i++) {
+		attr = params[i].attr & OPTEE_MSG_ATTR_TYPE_MASK;
+
+		switch (attr) {
+		case OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT:
+			continue;
+		case OPTEE_MSG_ATTR_TYPE_TMEM_INPUT:
+		case OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT:
+		case OPTEE_MSG_ATTR_TYPE_TMEM_INOUT:
+			if (pages_cnt >= num_params)
+				return -1;
+			if (!(params[i].attr & OPTEE_MSG_ATTR_FRAGMENT) &&
+			    (i != num_params - 1))
+				return -1;
+			pages[pages_cnt++] = params[i].u.tmem.buf_ptr
+				& ~SMALL_PAGE_MASK;
+			break;
+		default:
+			return -1;
+		}
+	}
+	return pages_cnt;
+}
+
+/**
+ * msg_param_map_buffer() - map parameters buffer into OP-TEE VA space
+ * @pa_params - physical pointer to parameters
+ * @num_params - number of parameters
+ *
+ * return:
+ *  struct shmem_mapping of mapped buffer on success
+ *  NULL on error.
+ */
+struct mobj *msg_param_map_buffer(paddr_t pa_params, size_t num_params)
+{
+	struct mobj *mobj = NULL;
+	struct optee_msg_param *params;
+	paddr_t *pages = NULL;
+	size_t pages_cnt = 1;
+	size_t max_pages;
+	size_t args_size;
+	size_t i;
+
+	args_size = OPTEE_MSG_GET_ARG_SIZE(num_params);
+	max_pages = args_size / SMALL_PAGE_SIZE + 1;
+
+	pages = calloc(max_pages, sizeof(paddr_t));
+	if (!pages)
+		goto err;
+
+	pages[0] = pa_params & ~SMALL_PAGE_MASK;
+	mobj = mobj_mapped_shm_alloc(pages, 1, 0, 0);
+	if (!mobj)
+		goto err;
+
+	params = mobj_get_va(mobj, pa_params & SMALL_PAGE_MASK);
+
+	for (i = 0; i < num_params; i++) {
+		if ((params->attr & OPTEE_MSG_ATTR_TYPE_MASK) ==
+		    OPTEE_MSG_ATTR_TYPE_NEXT_FRAGMENT) {
+			if (pages_cnt >= max_pages)
+				goto err;
+
+			pages[pages_cnt] = params->u.tmem.buf_ptr;
+			mobj_free(mobj);
+
+			mobj = mobj_mapped_shm_alloc(pages + pages_cnt,
+						     1, 0, 0);
+			if (!mobj)
+				goto err;
+
+			pages_cnt++;
+			params = mobj_get_va(mobj, 0);
+		} else {
+			params++;
+			/* Check if we are not overflowing over page */
+			if (((vaddr_t)params & SMALL_PAGE_MASK) == 0)
+				goto err;
+		}
+	}
+
+	mobj_free(mobj);
+
+	mobj = mobj_mapped_shm_alloc(pages, pages_cnt, 0, 0);
+	if (!mobj)
+		goto err;
+
+	free(pages);
+	return mobj;
+err:
+	free(pages);
+	mobj_free(mobj);
+	return NULL;
+}
+
+
+/**
+ * msg_param_init_memparam() - fill memory reference parameter for RPC call
+ * @param	- parameter to fill
+ * @mobj	- mobj describing the shared memory buffer
+ * @offset	- offset of the buffer
+ * @size	- size of the buffer
+ * @cookie	- NW cookie of the shared buffer
+ * @dir		- data direction
+ *
+ * Idea behind this function is that thread_rpc_alloc() can return
+ * either buffer from preallocated memory pool, of buffer constructed
+ * from supplicant's memory. In first case parameter will have type
+ * OPTEE_MSG_ATTR_TYPE_TMEM_* and OPTEE_MSG_ATTR_TYPE_RMEM_ in second case.
+ * This function will fill parameter structure with right type, depending on
+ * the passed mobj.
+ *
+ * return:
+ *	true on success, false on failure
+ */
+bool msg_param_init_memparam(struct optee_msg_param *param, struct mobj *mobj,
+			     size_t offset, size_t size,
+			     uint64_t cookie, enum msg_param_mem_dir dir)
+{
+	if (mobj_matches(mobj, CORE_MEM_REG_SHM)) {
+		/* Registered SHM mobj */
+		switch (dir) {
+		case MSG_PARAM_MEM_DIR_IN:
+			param->attr = OPTEE_MSG_ATTR_TYPE_RMEM_INPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_OUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_INOUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_RMEM_INOUT;
+			break;
+		default:
+			return false;
+		}
+
+		param->u.rmem.size = size;
+		param->u.rmem.offs = offset;
+		param->u.rmem.shm_ref = cookie;
+	} else if (mobj_matches(mobj, CORE_MEM_NSEC_SHM)) {
+		/* MOBJ from from predefined pool */
+		paddr_t pa;
+
+		if (mobj_get_pa(mobj, 0, 0, &pa) != TEE_SUCCESS)
+			return false;
+
+		switch (dir) {
+		case MSG_PARAM_MEM_DIR_IN:
+			param->attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_OUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_INOUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_TMEM_INOUT;
+			break;
+		default:
+			return false;
+		}
+
+		param->u.tmem.buf_ptr = pa + offset;
+		param->u.tmem.shm_ref = cookie;
+		param->u.tmem.size = size;
+	} else
+		return false;
+	return true;
+}

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -1,6 +1,7 @@
 srcs-y += assert.c
 srcs-y += console.c
 srcs-$(CFG_DT) += dt.c
+srcs-y += msg_param.c
 srcs-y += tee_ta_manager.c
 srcs-y += tee_misc.c
 srcs-y += panic.c

--- a/core/tee/tee_fs_rpc.c
+++ b/core/tee/tee_fs_rpc.c
@@ -26,6 +26,7 @@
  */
 
 #include <assert.h>
+#include <kernel/msg_param.h>
 #include <kernel/tee_misc.h>
 #include <kernel/thread.h>
 #include <mm/core_memprot.h>
@@ -54,22 +55,22 @@ static TEE_Result operation_open(uint32_t id, unsigned int cmd,
 				 struct tee_pobj *po, int *fd)
 {
 	struct tee_fs_rpc_operation op = { .id = id, .num_params = 3 };
+	struct mobj *mobj;
 	TEE_Result res;
 	void *va;
-	paddr_t pa;
 	uint64_t cookie;
 
-	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
 	op.params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	op.params[0].u.value.a = cmd;
 
-	op.params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op.params[1].u.tmem.buf_ptr = pa;
-	op.params[1].u.tmem.size = TEE_FS_NAME_MAX;
-	op.params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
 	res = tee_svc_storage_create_filename(va, TEE_FS_NAME_MAX,
 					      po, po->temporary);
 	if (res != TEE_SUCCESS)
@@ -99,22 +100,22 @@ static TEE_Result operation_open_dfh(uint32_t id, unsigned int cmd,
 				 int *fd)
 {
 	struct tee_fs_rpc_operation op = { .id = id, .num_params = 3 };
+	struct mobj *mobj;
 	TEE_Result res;
 	void *va;
-	paddr_t pa;
 	uint64_t cookie;
 
-	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
 	op.params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	op.params[0].u.value.a = cmd;
 
-	op.params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op.params[1].u.tmem.buf_ptr = pa;
-	op.params[1].u.tmem.size = TEE_FS_NAME_MAX;
-	op.params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
 	res = tee_svc_storage_create_filename_dfh(va, TEE_FS_NAME_MAX, dfh);
 	if (res != TEE_SUCCESS)
 		return res;
@@ -158,14 +159,14 @@ TEE_Result tee_fs_rpc_read_init(struct tee_fs_rpc_operation *op,
 				uint32_t id, int fd, tee_fs_off_t offset,
 				size_t data_len, void **out_data)
 {
+	struct mobj *mobj;
 	uint8_t *va;
-	paddr_t pa;
 	uint64_t cookie;
 
 	if (offset < 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	va = tee_fs_rpc_cache_alloc(data_len, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(data_len, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -178,10 +179,9 @@ TEE_Result tee_fs_rpc_read_init(struct tee_fs_rpc_operation *op,
 	op->params[0].u.value.b = fd;
 	op->params[0].u.value.c = offset;
 
-	op->params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
-	op->params[1].u.tmem.buf_ptr = pa;
-	op->params[1].u.tmem.size = data_len;
-	op->params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op->params + 1, mobj, 0, data_len, cookie,
+				     MSG_PARAM_MEM_DIR_OUT))
+		return TEE_ERROR_BAD_STATE;
 
 	*out_data = va;
 
@@ -194,7 +194,7 @@ TEE_Result tee_fs_rpc_read_final(struct tee_fs_rpc_operation *op,
 	TEE_Result res = operation_commit(op);
 
 	if (res == TEE_SUCCESS)
-		*data_len = op->params[1].u.tmem.size;
+		*data_len = msg_param_get_buf_size(op->params + 1);
 	return res;
 }
 
@@ -202,14 +202,14 @@ TEE_Result tee_fs_rpc_write_init(struct tee_fs_rpc_operation *op,
 				 uint32_t id, int fd, tee_fs_off_t offset,
 				 size_t data_len, void **data)
 {
+	struct mobj *mobj;
 	uint8_t *va;
-	paddr_t pa;
 	uint64_t cookie;
 
 	if (offset < 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	va = tee_fs_rpc_cache_alloc(data_len, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(data_len, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -217,16 +217,14 @@ TEE_Result tee_fs_rpc_write_init(struct tee_fs_rpc_operation *op,
 	op->id = id;
 	op->num_params = 2;
 
-
 	op->params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	op->params[0].u.value.a = OPTEE_MRF_WRITE;
 	op->params[0].u.value.b = fd;
 	op->params[0].u.value.c = offset;
 
-	op->params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op->params[1].u.tmem.buf_ptr = pa;
-	op->params[1].u.tmem.size = data_len;
-	op->params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op->params + 1, mobj, 0, data_len, cookie,
+				     MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
 
 	*data = va;
 
@@ -254,21 +252,21 @@ TEE_Result tee_fs_rpc_remove(uint32_t id, struct tee_pobj *po)
 {
 	TEE_Result res;
 	struct tee_fs_rpc_operation op = { .id = id, .num_params = 2 };
+	struct mobj *mobj;
 	void *va;
-	paddr_t pa;
 	uint64_t cookie;
 
-	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
 	op.params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	op.params[0].u.value.a = OPTEE_MRF_REMOVE;
 
-	op.params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op.params[1].u.tmem.buf_ptr = pa;
-	op.params[1].u.tmem.size = TEE_FS_NAME_MAX;
-	op.params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
 	res = tee_svc_storage_create_filename(va, TEE_FS_NAME_MAX,
 					      po, po->temporary);
 	if (res != TEE_SUCCESS)
@@ -282,21 +280,21 @@ TEE_Result tee_fs_rpc_remove_dfh(uint32_t id,
 {
 	TEE_Result res;
 	struct tee_fs_rpc_operation op = { .id = id, .num_params = 2 };
+	struct mobj *mobj;
 	void *va;
-	paddr_t pa;
 	uint64_t cookie;
 
-	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
 	op.params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	op.params[0].u.value.a = OPTEE_MRF_REMOVE;
 
-	op.params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op.params[1].u.tmem.buf_ptr = pa;
-	op.params[1].u.tmem.size = TEE_FS_NAME_MAX;
-	op.params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
 	res = tee_svc_storage_create_filename_dfh(va, TEE_FS_NAME_MAX, dfh);
 	if (res != TEE_SUCCESS)
 		return res;
@@ -309,12 +307,12 @@ TEE_Result tee_fs_rpc_rename(uint32_t id, struct tee_pobj *old,
 {
 	TEE_Result res;
 	struct tee_fs_rpc_operation op = { .id = id, .num_params = 3 };
+	struct mobj *mobj;
 	char *va;
-	paddr_t pa;
 	uint64_t cookie;
 	bool temp;
 
-	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX * 2, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX * 2, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -322,10 +320,10 @@ TEE_Result tee_fs_rpc_rename(uint32_t id, struct tee_pobj *old,
 	op.params[0].u.value.a = OPTEE_MRF_RENAME;
 	op.params[0].u.value.b = overwrite;
 
-	op.params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op.params[1].u.tmem.buf_ptr = pa;
-	op.params[1].u.tmem.size = TEE_FS_NAME_MAX;
-	op.params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
 	if (new)
 		temp = old->temporary;
 	else
@@ -335,10 +333,12 @@ TEE_Result tee_fs_rpc_rename(uint32_t id, struct tee_pobj *old,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	op.params[2].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op.params[2].u.tmem.buf_ptr = pa + TEE_FS_NAME_MAX;
-	op.params[2].u.tmem.size = TEE_FS_NAME_MAX;
-	op.params[2].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 2, mobj, TEE_FS_NAME_MAX,
+				     TEE_FS_NAME_MAX, cookie,
+				     MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
+
 	if (new) {
 		res = tee_svc_storage_create_filename(va + TEE_FS_NAME_MAX,
 						      TEE_FS_NAME_MAX,
@@ -359,15 +359,15 @@ TEE_Result tee_fs_rpc_opendir(uint32_t id, const TEE_UUID *uuid,
 {
 	TEE_Result res;
 	struct tee_fs_rpc_operation op = { .id = id, .num_params = 3 };
+	struct mobj *mobj;
 	void *va;
-	paddr_t pa;
 	uint64_t cookie;
 	struct tee_fs_dir *dir = calloc(1, sizeof(*dir));
 
 	if (!dir)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &mobj, &cookie);
 	if (!va) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto err_exit;
@@ -376,10 +376,10 @@ TEE_Result tee_fs_rpc_opendir(uint32_t id, const TEE_UUID *uuid,
 	op.params[0].attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT;
 	op.params[0].u.value.a = OPTEE_MRF_OPENDIR;
 
-	op.params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	op.params[1].u.tmem.buf_ptr = pa;
-	op.params[1].u.tmem.size = TEE_FS_NAME_MAX;
-	op.params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
 	res = tee_svc_storage_create_dirname(va, TEE_FS_NAME_MAX, uuid);
 	if (res != TEE_SUCCESS)
 		return res;
@@ -418,15 +418,15 @@ TEE_Result tee_fs_rpc_readdir(uint32_t id, struct tee_fs_dir *d,
 {
 	TEE_Result res;
 	struct tee_fs_rpc_operation op = { .id = id, .num_params = 2 };
+	struct mobj *mobj;
 	void *va;
-	paddr_t pa;
 	uint64_t cookie;
 	const size_t max_name_len = TEE_FS_NAME_MAX + 1;
 
 	if (!d)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	va = tee_fs_rpc_cache_alloc(max_name_len, &pa, &cookie);
+	va = tee_fs_rpc_cache_alloc(max_name_len, &mobj, &cookie);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -434,10 +434,9 @@ TEE_Result tee_fs_rpc_readdir(uint32_t id, struct tee_fs_dir *d,
 	op.params[0].u.value.a = OPTEE_MRF_READDIR;
 	op.params[0].u.value.b = d->nw_dir;
 
-	op.params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
-	op.params[1].u.tmem.buf_ptr = pa;
-	op.params[1].u.tmem.size = max_name_len;
-	op.params[1].u.tmem.shm_ref = cookie;
+	if (!msg_param_init_memparam(op.params + 1, mobj, 0, max_name_len,
+				     cookie, MSG_PARAM_MEM_DIR_OUT))
+		return TEE_ERROR_BAD_STATE;
 
 	res = operation_commit(&op);
 	if (res != TEE_SUCCESS)

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -26,13 +26,16 @@
  */
 
 #include <assert.h>
+#include <kernel/misc.h>
 #include <kernel/mutex.h>
+#include <kernel/msg_param.h>
 #include <kernel/panic.h>
 #include <kernel/tee_common.h>
 #include <kernel/tee_common_otp.h>
 #include <kernel/tee_misc.h>
 #include <kernel/thread.h>
 #include <mm/core_memprot.h>
+#include <mm/mobj.h>
 #include <mm/tee_mm.h>
 #include <optee_msg_supplicant.h>
 #include <stdlib.h>
@@ -421,9 +424,9 @@ func_exit:
 }
 
 struct tee_rpmb_mem {
-	paddr_t phreq;
+	struct mobj *phreq_mobj;
 	uint64_t phreq_cookie;
-	paddr_t phresp;
+	struct mobj *phresp_mobj;
 	uint64_t phresp_cookie;
 	size_t req_size;
 	size_t resp_size;
@@ -434,15 +437,15 @@ static void tee_rpmb_free(struct tee_rpmb_mem *mem)
 	if (!mem)
 		return;
 
-	if (mem->phreq) {
-		thread_rpc_free_payload(mem->phreq_cookie);
+	if (mem->phreq_mobj) {
+		thread_rpc_free_payload(mem->phreq_cookie, mem->phreq_mobj);
 		mem->phreq_cookie = 0;
-		mem->phreq = 0;
+		mem->phreq_mobj = NULL;
 	}
-	if (mem->phresp) {
-		thread_rpc_free_payload(mem->phresp_cookie);
+	if (mem->phresp_mobj) {
+		thread_rpc_free_payload(mem->phresp_cookie, mem->phresp_mobj);
 		mem->phresp_cookie = 0;
-		mem->phresp = 0;
+		mem->phresp_mobj = NULL;
 	}
 }
 
@@ -458,15 +461,18 @@ static TEE_Result tee_rpmb_alloc(size_t req_size, size_t resp_size,
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	memset(mem, 0, sizeof(*mem));
-	thread_rpc_alloc_payload(req_s, &mem->phreq, &mem->phreq_cookie);
-	thread_rpc_alloc_payload(resp_s, &mem->phresp, &mem->phresp_cookie);
-	if (!mem->phreq || !mem->phresp) {
+
+	mem->phreq_mobj = thread_rpc_alloc_payload(req_s, &mem->phreq_cookie);
+	mem->phresp_mobj =
+		thread_rpc_alloc_payload(resp_s, &mem->phresp_cookie);
+
+	if (!mem->phreq_mobj || !mem->phresp_mobj) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
 
-	*req = phys_to_virt(mem->phreq, MEM_AREA_NSEC_SHM);
-	*resp = phys_to_virt(mem->phresp, MEM_AREA_NSEC_SHM);
+	*req = mobj_get_va(mem->phreq_mobj, 0);
+	*resp = mobj_get_va(mem->phresp_mobj, 0);
 	if (!*req || !*resp) {
 		res = TEE_ERROR_GENERIC;
 		goto out;
@@ -486,14 +492,16 @@ static TEE_Result tee_rpmb_invoke(struct tee_rpmb_mem *mem)
 	struct optee_msg_param params[2];
 
 	memset(params, 0, sizeof(params));
-	params[0].attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
-	params[1].attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
-	params[0].u.tmem.buf_ptr = mem->phreq;
-	params[0].u.tmem.size = mem->req_size;
-	params[0].u.tmem.shm_ref = mem->phreq_cookie;
-	params[1].u.tmem.buf_ptr = mem->phresp;
-	params[1].u.tmem.size = mem->resp_size;
-	params[1].u.tmem.shm_ref = mem->phresp_cookie;
+
+	if (!msg_param_init_memparam(params + 0, mem->phreq_mobj, 0,
+				     mem->req_size, mem->phreq_cookie,
+				     MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
+	if (!msg_param_init_memparam(params + 1, mem->phresp_mobj, 0,
+				     mem->resp_size, mem->phresp_cookie,
+				     MSG_PARAM_MEM_DIR_OUT))
+		return TEE_ERROR_BAD_STATE;
 
 	return thread_rpc_cmd(OPTEE_MSG_RPC_CMD_RPMB, 2, params);
 }


### PR DESCRIPTION
Hello,

I want to propose new approach for shared memory. Idea is not to use carveout in memory, but to use memory provided by Normal World. Normal World allocates memory at its side and provided list of pages to OP-TEE, so OP-TEE kernel can map them into its virtual space.

This is not the final version, because it should be merged with @jenswi-linaro MOBJs framework. But anyway, it was tested on simple tests. With this approach I was able to number allocate large shared buffers (e.g. 2M each).

There are number of patches in this PR. First patches are quite generic and I can create separate PRs to merge them if maintainers wish. Most important are two last patches: one of them adds shared memory subsystem and second one puts it into use.

There are one problem that is not resolved at this time - we need to list of shared pages to TA memory manager. I hope MOBJs will help with this.

There are corresponding kernel and client changes based on @jenswi-linaro patches for registering shared memory. I'll present them later. 