### PR TITLE
Fix i.MX6ULEVK boot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ script:
   - $make PLATFORM=mediatek-mt8173 CFG_ARM64_core=y
 
   # i.MX6UL 14X14 EVK
-  - $make PLATFORM=imx-mx6ulevk
+  - $make PLATFORM=imx-mx6ulevk ARCH=arm CFG_PAGEABLE_ADDR=0 CFG_NS_ENTRY_ADDR=0x80800000 CFG_DT_ADDR=0x83000000 CFG_DT=y DEBUG=y CFG_TEE_CORE_LOG_LEVEL=4
 
   # i.MX6Quad SABRE
   - $make PLATFORM=imx-mx6qsabrelite

--- a/README.md
+++ b/README.md
@@ -310,8 +310,7 @@ $ /system/bin/tee-helloworld
 ---
 ### 4.6 Freescale MX6UL EVK
 
-Get U-Boot source:
-https://github.com/MrVan/uboot/commit/4f016adae573aaadd7bf6a37f8c58a882b391ae6
+Get [U-Boot](https://github.com/MrVan/u-boot/commits/imx_v2016.03_4.1.15_2.0.0_ga)
 
 Build U-Boot:
 ```
@@ -320,57 +319,25 @@ Build U-Boot:
     Burn u-boot.imx to offset 0x400 of SD card
 ```
 
-Get Kernel source: https://github.com/linaro-swg/linux/tree/optee
+Get [Kernel](https://github.com/MrVan/linux/tree/imx_4.1.15_2.0.0_ga)
 
-Patch kernel:
-```c
-    diff --git a/arch/arm/boot/dts/imx6ul-14x14-evk.dts b/arch/arm/boot/dts/imx6ul-14x14-evk.dts
-    index 6aaa5ec..2ac9c80 100644
-    --- a/arch/arm/boot/dts/imx6ul-14x14-evk.dts
-    +++ b/arch/arm/boot/dts/imx6ul-14x14-evk.dts
-    @@ -23,6 +23,13 @@
-		reg = <0x80000000 0x20000000>;
-	 };
-
-    +	firmware {
-    +		optee {
-    +			compatible = "linaro,optee-tz";
-    +			method = "smc";
-    +		};
-    +	};
-    +
-	regulators {
-		compatible = "simple-bus";
-		#address-cells = <1>;
-```
-
-Compile the Kernel:
+Build Kernel:
 
 ```
-make ARCH=arm imx_v6_v7_defconfig
-make menuconfig
-select the two entries
-	CONFIG_TEE=y
-	CONFIG_OPTEE
+make ARCH=arm imx_v7_defconfig
 make ARCH=arm
 ```
 Copy zImage and imx6ul_14x14_evk.dtb to SD card.
 
 OPTEE OS Build:
 ```
-    PLATFORM_FLAVOR=mx6ulevk make PLATFORM=imx
-    ${CROSS_COMPILE}-objcopy -O binary out/arm-plat-imx/core/tee.elf optee.bin
-    copy optee.bin to the first partition of SD card which is used for boot.
-```
+make PLATFORM=imx-mx6ulevk ARCH=arm CFG_PAGEABLE_ADDR=0
+CFG_NS_ENTRY_ADDR=0x80800000 CFG_DT_ADDR=0x83000000
+CFG_DT=y DEBUG=y CFG_TEE_CORE_LOG_LEVEL=4
 
-Run using U-Boot:
+mkimage -A arm -O linux -C none -a 0x9c0fffe4 -e 0x9c100000 -d ./out/arm-plat-imx/core/tee.bin uTee
 ```
-    run loadfdt;
-    run loadimage;
-    fatload mmc 1:1 0x9c100000 optee.bin;
-    run mmcargs;
-    bootz ${loadaddr} - ${fdt_addr};
-```
+Copy uTee to sd card FAT partition.
 
 Note:
     CAAM is not implemented now, this will be added later.

--- a/core/arch/arm/plat-imx/imx6ul.c
+++ b/core/arch/arm/plat-imx/imx6ul.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Peng Fan <peng.fan@nxp.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arm32.h>
+#include <io.h>
+#include <kernel/generic_boot.h>
+#include <platform_config.h>
+#include <stdint.h>
+
+static void init_csu(void)
+{
+	uintptr_t addr;
+
+	/* first grant all peripherals */
+	for (addr = CSU_BASE + CSU_CSL_START;
+	     addr != CSU_BASE + CSU_CSL_END;
+	     addr += 4)
+		write32(CSU_ACCESS_ALL, addr);
+
+	/* lock the settings */
+	for (addr = CSU_BASE + CSU_CSL_START;
+	     addr != CSU_BASE + CSU_CSL_END;
+	     addr += 4)
+		write32(read32(addr) | CSU_SETTING_LOCK, addr);
+}
+
+/* MMU not enabled now */
+void plat_cpu_reset_late(void)
+{
+	init_csu();
+}

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -29,6 +29,7 @@
 
 #include <arm32.h>
 #include <console.h>
+#include <drivers/gic.h>
 #include <drivers/imx_uart.h>
 #include <io.h>
 #include <kernel/generic_boot.h>
@@ -45,11 +46,11 @@
 
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
 	defined(PLATFORM_FLAVOR_mx6qsabresd)
-#include <drivers/gic.h>
 #include <kernel/tz_ssvce_pl310.h>
 #endif
 
 static void main_fiq(void);
+static struct gic_data gic_data;
 
 static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
@@ -63,12 +64,11 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_panic,
 };
 
-#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
-static struct gic_data gic_data;
-
 register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CORE_MMU_DEVICE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_DEVICE_SIZE);
+
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
 register_phys_mem(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_DEVICE_SIZE);
 #endif
 
@@ -162,20 +162,6 @@ void console_flush(void)
 	imx_uart_flush_tx_fifo(base);
 }
 
-#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
-vaddr_t pl310_base(void)
-{
-	static void *va __early_bss;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(PL310_BASE, MEM_AREA_IO_SEC);
-		return (vaddr_t)va;
-	}
-	return PL310_BASE;
-}
-
 void main_init_gic(void)
 {
 	vaddr_t gicc_base;
@@ -192,6 +178,20 @@ void main_init_gic(void)
 	/* Initialize GIC */
 	gic_init(&gic_data, gicc_base, gicd_base);
 	itr_init(&gic_data.chip);
+}
+
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
+vaddr_t pl310_base(void)
+{
+	static void *va __early_bss;
+
+	if (cpu_mmu_enabled()) {
+		if (!va)
+			va = phys_to_virt(PL310_BASE, MEM_AREA_IO_SEC);
+		return (vaddr_t)va;
+	}
+	return PL310_BASE;
 }
 
 void main_secondary_init_gic(void)

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -131,7 +131,7 @@ static vaddr_t console_base(void)
 
 	if (cpu_mmu_enabled()) {
 		if (!va)
-			va = phys_to_virt(CONSOLE_UART_PA_BASE,
+			va = phys_to_virt(CONSOLE_UART_BASE,
 					  MEM_AREA_IO_NSEC);
 		return (vaddr_t)va;
 	}

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -108,7 +108,6 @@
 #define DEVICE0_TYPE		MEM_AREA_IO_NSEC
 
 #define CONSOLE_UART_BASE		(UART0_BASE)
-#define CONSOLE_UART_PA_BASE		(UART0_BASE)
 
 /* For i.MX6 Quad SABRE Lite and Smart Device board */
 
@@ -140,11 +139,9 @@
 
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite)
 #define CONSOLE_UART_BASE		UART2_BASE
-#define CONSOLE_UART_PA_BASE		UART2_BASE
 #endif
 #if defined(PLATFORM_FLAVOR_mx6qsabresd)
 #define CONSOLE_UART_BASE		UART1_BASE
-#define CONSOLE_UART_PA_BASE		UART1_BASE
 #endif
 #define DRAM0_BASE			0x10000000
 #define DRAM0_SIZE			0x40000000

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -107,12 +107,7 @@
 #define DEVICE0_SIZE		CORE_MMU_DEVICE_SIZE
 #define DEVICE0_TYPE		MEM_AREA_IO_NSEC
 
-/*
- * console uart virtual address
- * The physical address is 0x2020000, we mapped it to 0x4020000,
- * see DEVICE0_VA_BASE and DEVICE0_PA_BASE
- */
-#define CONSOLE_UART_BASE		(0x4020000)
+#define CONSOLE_UART_BASE		(UART0_BASE)
 #define CONSOLE_UART_PA_BASE		(UART0_BASE)
 
 /* For i.MX6 Quad SABRE Lite and Smart Device board */

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -101,13 +101,14 @@
 #define CFG_TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - CFG_TEE_RAM_VA_SIZE), \
 						CORE_MMU_DEVICE_SIZE)
 
-#define DEVICE0_PA_BASE		ROUNDDOWN(UART0_BASE, \
-						CORE_MMU_DEVICE_SIZE)
-#define DEVICE0_VA_BASE		(64 * 1024 * 1024)
-#define DEVICE0_SIZE		CORE_MMU_DEVICE_SIZE
-#define DEVICE0_TYPE		MEM_AREA_IO_NSEC
-
 #define CONSOLE_UART_BASE		(UART0_BASE)
+
+/* Central Security Unit register values */
+#define CSU_BASE			0x021C0000
+#define CSU_CSL_START			0x0
+#define CSU_CSL_END			0xA0
+#define CSU_ACCESS_ALL			0x00FF00FF
+#define CSU_SETTING_LOCK		0x01000100
 
 /* For i.MX6 Quad SABRE Lite and Smart Device board */
 

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -5,3 +5,4 @@ srcs-$(CFG_PL310) += imx_pl310.c
 
 srcs-$(PLATFORM_FLAVOR_mx6qsabrelite) += a9_plat_init.S
 srcs-$(PLATFORM_FLAVOR_mx6qsabresd) += a9_plat_init.S
+srcs-$(PLATFORM_FLAVOR_mx6ulevk) += imx6ul.c


### PR DESCRIPTION
The three patches is to
- fix the uart address, which will cause panic.
- Handle gic/csu in optee
- Update readme, drop the hacked code in uboot.