### PR TITLE
core: lpae: deal with unaligned regions

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -376,8 +376,9 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 			desc = INVALID_DESC;
 			debug_print("%*s%010" PRIx64 " %8x",
 					level * 2, "", base_va, level_size);
-		} else if (mm->va <= base_va && mm->va + mm->size >=
-				base_va + level_size) {
+		} else if (mm->va <= base_va &&
+			   mm->va + mm->size >= base_va + level_size &&
+			   !(mm->pa & (level_size - 1))) {
 			/* Next region covers all of area */
 			int attr = mmap_region_attr(mm, base_va, level_size);
 


### PR DESCRIPTION
Fixes problem in defined memory regions where physical address isn't
pgdir aligned.

Fixes: 0f8333b888f1 ("plat-vexpress/qemu: correct DRAM layout")
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU, FVP)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Fixes LPAE breakage introduced in https://github.com/OP-TEE/optee_os/pull/1236