### PR TITLE
core: fix cpu_spin_trylock() against debug lock counting

### DIFF
--- a/core/arch/arm/include/kernel/spinlock.h
+++ b/core/arch/arm/include/kernel/spinlock.h
@@ -53,8 +53,9 @@ static inline void assert_have_no_spinlock(void) { }
 #endif
 
 void __cpu_spin_lock(unsigned int *lock);
-unsigned int __cpu_spin_trylock(unsigned int *lock);
 void __cpu_spin_unlock(unsigned int *lock);
+/* returns 0 on locking success, non zero on failure */
+unsigned int __cpu_spin_trylock(unsigned int *lock);
 
 static inline void cpu_spin_lock(unsigned int *lock)
 {

--- a/core/arch/arm/include/kernel/spinlock.h
+++ b/core/arch/arm/include/kernel/spinlock.h
@@ -64,15 +64,15 @@ static inline void cpu_spin_lock(unsigned int *lock)
 	spinlock_count_incr();
 }
 
-static inline unsigned int cpu_spin_trylock(unsigned int *lock)
+static inline bool cpu_spin_trylock(unsigned int *lock)
 {
-	unsigned int locked;
+	unsigned int rc;
 
 	assert(thread_irq_disabled());
-	locked = __cpu_spin_trylock(lock);
-	if (locked)
+	rc = __cpu_spin_trylock(lock);
+	if (!rc)
 		spinlock_count_incr();
-	return locked;
+	return !rc;
 }
 
 static inline void cpu_spin_unlock(unsigned int *lock)

--- a/core/arch/arm/kernel/spin_lock_a64.S
+++ b/core/arch/arm/kernel/spin_lock_a64.S
@@ -70,17 +70,17 @@ l2:	ldaxr	w1, [x0]
 	ret
 END_FUNC __cpu_spin_lock
 
-/* int __cpu_spin_trylock(unsigned int *lock); */
+/* unsigned int __cpu_spin_trylock(unsigned int *lock); */
 FUNC __cpu_spin_trylock , :
-	mov	w2, #SPINLOCK_LOCK
-.loop:	ldaxr	w1, [x0]
-	cbnz	w1, .cpu_spin_trylock_out
-	stxr	w1, w2, [x0]
-	cbnz	w1, .loop
+	mov     x1, x0
+	mov     w2, #SPINLOCK_LOCK
+.loop:	ldaxr   w0, [x1]
+	cbnz    w0, .cpu_spin_trylock_out
+	stxr    w0, w2, [x1]
+	cbnz    w0, .loop
 .cpu_spin_trylock_out:
 	ret
 END_FUNC __cpu_spin_trylock
-
 
 /* void __cpu_spin_unlock(unsigned int *lock); */
 FUNC __cpu_spin_unlock , :


### PR DESCRIPTION
i found this reading Joakim updates on docs.
I think we missed this...  seems we don't have any test that could stress `trylock`.