### PR TITLE
build: clean should delete out dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,15 @@ endif
 ARCH            ?= arm
 PLATFORM        ?= vexpress
 # Default value for PLATFORM_FLAVOR is set in plat-$(PLATFORM)/conf.mk
-O		?= out/$(ARCH)-plat-$(PLATFORM)
+O		?= out
+out-dir:=
 
 arch_$(ARCH)	:= y
 
 ifneq ($O,)
-out-dir := $O
+out-dir :=$O
 endif
+out-dir:=$(out-dir)/optee_os_out/$(ARCH)-plat-$(PLATFORM)
 
 ifneq ($V,1)
 q := @
@@ -66,7 +68,6 @@ cmd-echo-silent := true
 endif
 endif
 
-
 include core/core.mk
 
 # Platform config is supposed to assign the targets
@@ -83,7 +84,7 @@ endif
 .PHONY: clean
 clean:
 	@$(cmd-echo-silent) '  CLEAN   .'
-	${q}rm -f $(cleanfiles)
+	${q}rm -f $(out-dir)/..
 
 .PHONY: cscope
 cscope:

--- a/core/arch/arm/plat-rcar/link.mk
+++ b/core/arch/arm/plat-rcar/link.mk
@@ -1,7 +1,6 @@
 include core/arch/arm/kernel/link.mk
 
 all: $(link-out-dir)/tee.srec
-cleanfiles += $(link-out-dir)/tee.srec
 $(link-out-dir)/tee.srec: $(link-out-dir)/tee.elf
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(OBJCOPYcore) -O srec $< $@

--- a/core/arch/arm/plat-sunxi/link.mk
+++ b/core/arch/arm/plat-sunxi/link.mk
@@ -8,10 +8,6 @@ AWK	 = awk
 
 all: $(link-out-dir)/tee.elf $(link-out-dir)/tee.dmp $(link-out-dir)/tee.bin
 all: $(link-out-dir)/tee.symb_sizes
-cleanfiles += $(link-out-dir)/tee.elf $(link-out-dir)/tee.dmp $(link-out-dir)/tee.map
-cleanfiles += $(link-out-dir)/tee.bin
-cleanfiles += $(link-out-dir)/tee.symb_sizes
-cleanfiles += $(link-script-pp) $(link-script-dep)
 
 link-ldflags  = $(LDFLAGS)
 link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map

--- a/core/core.mk
+++ b/core/core.mk
@@ -60,9 +60,6 @@ conf-file := $(out-dir)/include/generated/conf.h
 conf-mk-file := $(out-dir)/conf.mk
 $(conf-file): $(conf-mk-file)
 
-cleanfiles += $(conf-file)
-cleanfiles += $(conf-mk-file)
-
 $(conf-file): FORCE
 	$(call check-conf-h)
 

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -7,7 +7,6 @@
 # Output
 #
 # set	  objs
-# update  cleanfiles
 #
 # Generates explicit rules for all objs
 
@@ -64,8 +63,6 @@ comp-dep-$2	:= $$(dir $2).$$(notdir $2).d
 comp-cmd-file-$2:= $$(dir $2).$$(notdir $2).cmd
 comp-sm-$2	:= $(sm)
 comp-lib-$2	:= $(libname)-$(sm)
-
-cleanfiles := $$(cleanfiles) $$(comp-dep-$2) $$(comp-cmd-file-$2) $2
 
 ifeq ($$(filter %.c,$1),$1)
 comp-q-$2 := CC
@@ -161,8 +158,6 @@ FORCE-GENSRC: $(2)
 comp-dep-$3	:= $$(dir $3)$$(notdir $3).d
 comp-cmd-file-$3:= $$(dir $3)$$(notdir $3).cmd
 comp-sm-$3	:= $(sm)
-
-cleanfiles := $$(cleanfiles) $$(comp-dep-$3) $$(comp-cmd-file-$3) $3 $2
 
 comp-flags-$3 = $$(filter-out $$(CFLAGS_REMOVE) $$(cflags-remove) \
 			      $$(cflags-remove-$$(comp-sm-$3)) \

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -7,7 +7,6 @@
 #
 # Output
 #
-# updated cleanfiles and
 # updated libfiles, libdirs, libnames and libdeps
 
 
@@ -16,7 +15,6 @@ include mk/subdir.mk
 include mk/compile.mk
 
 lib-libfile	 = $(out-dir)/$(base-prefix)$(libdir)/lib$(libname).a
-cleanfiles	:= $(cleanfiles) $(lib-libfile)
 libfiles	:= $(lib-libfile) $(libfiles)
 libdirs 	:= $(out-dir)/$(base-prefix)$(libdir) $(libdirs)
 libnames	:= $(libname) $(libnames)

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -9,11 +9,6 @@ TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 
 all: $(link-out-dir)/$(binary).elf $(link-out-dir)/$(binary).dmp \
 	$(link-out-dir)/$(binary).stripped.elf $(link-out-dir)/$(binary).ta
-cleanfiles += $(link-out-dir)/$(binary).elf $(link-out-dir)/$(binary).dmp
-cleanfiles += $(link-out-dir)/$(binary).map
-cleanfiles += $(link-out-dir)/$(binary).stripped.elf
-cleanfiles += $(link-out-dir)/$(binary).ta
-cleanfiles += $(link-script-pp) $(link-script-dep)
 
 link-ldflags  = $(LDFLAGS)
 link-ldflags += -pie

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -90,7 +90,6 @@ include  $(ta-dev-kit-dir)/mk/link.mk
 else
 ifneq ($(libname),)
 all: $(libname).a
-cleanfiles += $(libname).a
 
 $(libname).a: $(objs)
 	@echo '  AR      $@'

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -23,8 +23,11 @@ endif
 ifneq ($O,)
 out-dir := $O
 else
-out-dir := .
+out-dir := out
 endif
+
+out-dir := $out-dir/optee_os_out/$(ARCH)-plat-$(PLATFORM)
+
 
 ifneq ($V,1)
 q := @
@@ -71,7 +74,7 @@ libdeps += $(ta-dev-kit-dir)/lib/libpng.a
 .PHONY: clean
 clean:
 	@$(cmd-echo-silent) '  CLEAN   .'
-	${q}rm -f $(cleanfiles)
+	${q}rm -f $(out-dir)/..
 
 
 subdirs = .

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -66,7 +66,6 @@ $2/$$(notdir $1): $1
 	$(cmd-echo-silent) '  INSTALL $$@' ; \
 	cp $$< $$@
 
-cleanfiles += $2/$$(notdir $1)
 all: $2/$$(notdir $1)
 endef
 
@@ -125,5 +124,4 @@ $(conf-mk-file-export): $(conf-mk-file)
 		echo $(v) := $($(v));)) >> $@
 	$(q)echo '$(ta-mk-file-export-add-$(sm-$(@)))' | sed 's/_nl_ */\n/g' >> $@
 
-cleanfiles := $(cleanfiles) $(conf-mk-file-export)
 all: $(conf-mk-file-export)


### PR DESCRIPTION
'./out' dir is generated by the build action.

As well as .o, it also contains generated deps.

If you change your compiler, or optee version, the deps become invalid and
break the build.

It's the job of `make clean` to blow all this kind of thing away.

Signed-off-by: Andy Green <andy@warmcat.com>