### PR TITLE
Make sure "make clean" removes everything "make" has created under $(O)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,14 @@ endif
 ARCH            ?= arm
 PLATFORM        ?= vexpress
 # Default value for PLATFORM_FLAVOR is set in plat-$(PLATFORM)/conf.mk
-O		?= out/$(ARCH)-plat-$(PLATFORM)
+ifeq ($O,)
+O               := out
+out-dir         := $(O)/$(ARCH)-plat-$(PLATFORM)
+else
+out-dir         := $(O)
+endif
 
 arch_$(ARCH)	:= y
-
-ifneq ($O,)
-out-dir := $O
-endif
 
 ifneq ($V,1)
 q := @
@@ -80,10 +81,15 @@ endef
 $(foreach t, $(ta-targets), $(eval $(call build-ta-target, $(t))))
 endif
 
+include mk/cleandirs.mk
+
 .PHONY: clean
 clean:
-	@$(cmd-echo-silent) '  CLEAN   .'
+	@$(cmd-echo-silent) '  CLEAN   $(out-dir)'
 	${q}rm -f $(cleanfiles)
+	${q}dirs="$(call cleandirs-for-rmdir)"; if [ "$$dirs" ]; then rmdir $$dirs; fi
+	@if [ "$(out-dir)" != "$(O)" ]; then $(cmd-echo-silent) '  CLEAN   $(O)'; fi
+	${q}if [ -d "$(O)" ]; then rmdir --ignore-fail-on-non-empty $(O); fi
 
 .PHONY: cscope
 cscope:

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -56,12 +56,12 @@ $(link-out-dir)/unpaged.o: $(link-out-dir)/unpaged_entries.txt
 		`cat $(link-out-dir)/unpaged_entries.txt` \
 		$(ldargs-unpaged-objs) -o $@
 
-cleanfiles += $(link-out-dir)/text_unpaged.ld.S:
+cleanfiles += $(link-out-dir)/text_unpaged.ld.S
 $(link-out-dir)/text_unpaged.ld.S: $(link-out-dir)/unpaged.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | ${AWK} -f ./scripts/gen_ld_text_sects.awk > $@
 
-cleanfiles += $(link-out-dir)/rodata_unpaged.ld.S:
+cleanfiles += $(link-out-dir)/rodata_unpaged.ld.S
 $(link-out-dir)/rodata_unpaged.ld.S: $(link-out-dir)/unpaged.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | \
@@ -93,12 +93,12 @@ $(link-out-dir)/init.o: $(link-out-dir)/init_entries.txt
 		`cat $(link-out-dir)/init_entries.txt` \
 		$(ldargs-init-objs) -o $@
 
-cleanfiles += $(link-out-dir)/text_init.ld.S:
+cleanfiles += $(link-out-dir)/text_init.ld.S
 $(link-out-dir)/text_init.ld.S: $(link-out-dir)/init.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | ${AWK} -f ./scripts/gen_ld_text_sects.awk > $@
 
-cleanfiles += $(link-out-dir)/rodata_init.ld.S:
+cleanfiles += $(link-out-dir)/rodata_init.ld.S
 $(link-out-dir)/rodata_init.ld.S: $(link-out-dir)/init.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -a -W $< | \

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -7,3 +7,4 @@ produce-ta_pub_key = ta_pub_key.c
 depends-ta_pub_key = $(TA_SIGN_KEY)
 recipe-ta_pub_key = scripts/pem_to_pub_c.py --prefix ta_pub_key \
 		--key $(TA_SIGN_KEY) --out $(sub-dir-out)/ta_pub_key.c
+cleanfiles += $(sub-dir-out)/ta_pub_key.c

--- a/lib/libutee/tui/sub.mk
+++ b/lib/libutee/tui/sub.mk
@@ -15,6 +15,7 @@ recipe-default_bold := scripts/render_font.py \
 		--font_file $(sub-dir)/fonts/amble/Amble-Bold.ttf \
 		--font_size 20 --font_name default_bold \
 		--out_dir $(sub-dir-out)
+cleanfiles += $(sub-dir-out)/default_bold.c $(sub-dir-out)/default_bold.h
 
 gensrcs-y += default_regular
 produce-additional-default_regular = default_regular.h
@@ -25,5 +26,5 @@ recipe-default_regular := scripts/render_font.py \
 		--font_file $(sub-dir)/fonts/amble/Amble-Regular.ttf \
 		--font_size 20 --font_name default_regular \
 		--out_dir $(sub-dir-out)
-
+cleanfiles += $(sub-dir-out)/default_regular.c $(sub-dir-out)/default_regular.h
 

--- a/mk/cleandirs.mk
+++ b/mk/cleandirs.mk
@@ -1,0 +1,26 @@
+# Cleaning directories generated during a previous build,
+# a failed previous build or even no previous build.
+# Track build directories through 'cleanfiles'.
+
+define _enum-parent-dirs
+$(if $(1),$(1) $(if $(filter / ./,$(dir $(1))),,$(call enum-parent-dirs,$(dir $(1)))),)
+endef
+
+define enum-parent-dirs
+$(call _enum-parent-dirs,$(patsubst %/,%,$(1)))
+endef
+
+define _reverse
+$(if $(1),$(call _reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
+endef
+
+# Returns the list of all existing output directories up to $(O) including all
+# intermediate levels, in depth first order so that rmdir can process them in
+# order. May return an empty string.
+# Example: if cleanfiles is "foo/a/file1 foo/b/c/d/file2" and O=foo, this will
+# return "foo/b/c/d foo/b/c foo/b foo/a" (assuming all exist).
+define cleandirs-for-rmdir
+$(wildcard $(addprefix $(O)/,$(call _reverse,$(sort
+			$(foreach d,$(patsubst $(O)/%,%,$(dir $(cleanfiles))),
+				    $(call enum-parent-dirs,$(d)))))))
+endef

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -68,11 +68,15 @@ libdeps += $(ta-dev-kit-dir)/lib/libutee.a
 libdeps += $(ta-dev-kit-dir)/lib/libzlib.a
 libdeps += $(ta-dev-kit-dir)/lib/libpng.a
 
+include $(ta-dev-kit-dir)/mk/cleandirs.mk
+
 .PHONY: clean
 clean:
-	@$(cmd-echo-silent) '  CLEAN   .'
+	@$(cmd-echo-silent) '  CLEAN   $(out-dir)'
 	${q}rm -f $(cleanfiles)
-
+	${q}dirs="$(call cleandirs-for-rmdir)"; if [ "$$dirs" ]; then rmdir $$dirs; fi
+	@$(cmd-echo-silent) '  CLEAN   $(O)'
+	${q}if [ -d "$(O)" ]; then rmdir --ignore-fail-on-non-empty $(O); fi
 
 subdirs = .
 include  $(ta-dev-kit-dir)/mk/subdir.mk

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -75,7 +75,7 @@ $(foreach f, $(libfiles), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/lib)))
 
 # Copy .mk files
-ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk \
+ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk mk/cleandirs.mk \
 	$(wildcard ta/arch/$(ARCH)/link.mk) \
 	ta/mk/ta_dev_kit.mk
 


### PR DESCRIPTION
"make clean" would leave behind some files and many directories. Fix
this by correctly tracking the files and directories created under $(O)
during the build process:
- Fix incorrect file names in $(cleanfiles) and add a few missing
ones.
- Introduce $(cleandirs) which is updated whenever a sub-directory is
entered (and in a couple of special cases such as the generation of
conf.h and conf.mk)
The clean target removes the files, then all the directories in depth-
first order. $(O) is also removed, if found to be empty.

Note that a more straightforward approach was discussed in [1]: use
"rm -rf $(O)/some_dir" and get rid of the whole file and directory
tracking via $(cleanfiles) and $(cleandirs). Altough it was agreed it
would be safe, doing so would necessarily break the backward
compatibility for build scripts relying on "make O=<some path>", due to
the additional level ($(O)/some_dir).

[1] https://github.com/OP-TEE/optee_os/pull/1270

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>