### PR TITLE
Fix build error when $(O) starts with ./

### DIFF
--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -116,14 +116,17 @@ $(foreach f, $(ta-scripts), \
 # Create config file
 conf-mk-file-export := $(out-dir)/export-$(sm)/mk/conf.mk
 sm-$(conf-mk-file-export) := $(sm)
+define mk-file-export
 $(conf-mk-file-export): $(conf-mk-file)
-	@$(cmd-echo-silent) '  GEN    ' $@
-	$(q)echo sm := $(sm-$(@)) > $@
-	$(q)echo sm-$(sm-$(@)) := y >> $@
-	$(q)echo CFG_TA_FLOAT_SUPPORT := $(CFG_TA_FLOAT_SUPPORT) >> $@
-	$(q)($(foreach v, $(ta-mk-file-export-vars-$(sm-$(@))), \
-		echo $(v) := $($(v));)) >> $@
-	$(q)echo '$(ta-mk-file-export-add-$(sm-$(@)))' | sed 's/_nl_ */\n/g' >> $@
+	@$$(cmd-echo-silent) '  GEN    ' $$@
+	$(q)echo sm := $$(sm-$(conf-mk-file-export)) > $$@
+	$(q)echo sm-$$(sm-$(conf-mk-file-export)) := y >> $$@
+	$(q)echo CFG_TA_FLOAT_SUPPORT := $$(CFG_TA_FLOAT_SUPPORT) >> $$@
+	$(q)($$(foreach v, $$(ta-mk-file-export-vars-$$(sm-$(conf-mk-file-export))), \
+		echo $$(v) := $$($$(v));)) >> $$@
+	$(q)echo '$$(ta-mk-file-export-add-$$(sm-$(conf-mk-file-export)))' | sed 's/_nl_ */\n/g' >> $$@
+endef
+$(eval $(mk-file-export))
 
 cleanfiles := $(cleanfiles) $(conf-mk-file-export)
 all: $(conf-mk-file-export)


### PR DESCRIPTION
When a target starts with './', $@ does not. Therefore we must not use
$@ to access a variable if its name is created from $(out-dir) which
might start with './'. Fixes the following issue:

$ make O=./build
<snip>
  GEN     build/export-ta_arm32/mk/conf.mk
/bin/bash: -c: line 0: syntax error near unexpected token `)'
/bin/bash: -c: line 0: `() >> build/export-ta_arm32/mk/conf.mk'
ta/ta.mk:120: recipe for target 'build/export-ta_arm32/mk/conf.mk' failed
make: *** [build/export-ta_arm32/mk/conf.mk] Error 1

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>