### PR TITLE
ltc: Add missing file pk_get_oid.c

### DIFF
--- a/core/lib/libtomcrypt/src/misc/pk_get_oid.c
+++ b/core/lib/libtomcrypt/src/misc/pk_get_oid.c
@@ -1,0 +1,41 @@
+/* LibTomCrypt, modular cryptographic library
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ */
+#include "tomcrypt.h"
+
+#ifdef LTC_DER
+static const oid_st rsa_oid = {
+   { 1, 2, 840, 113549, 1, 1, 1  },
+   7,
+};
+
+static const oid_st dsa_oid = {
+   { 1, 2, 840, 10040, 4, 1  },
+   6,
+};
+
+/*
+   Returns the OID of the public key algorithm.
+   @return CRYPT_OK if valid
+*/
+int pk_get_oid(int pk, oid_st *st)
+{
+   switch (pk) {
+      case PKA_RSA:
+         XMEMCPY(st, &rsa_oid, sizeof(*st));
+         break;
+      case PKA_DSA:
+         XMEMCPY(st, &dsa_oid, sizeof(*st));
+         break;
+      default:
+         return CRYPT_INVALID_ARG;
+   }
+   return CRYPT_OK;
+}
+#endif

--- a/core/lib/libtomcrypt/src/misc/sub.mk
+++ b/core/lib/libtomcrypt/src/misc/sub.mk
@@ -1,6 +1,7 @@
 srcs-y += burn_stack.c
 srcs-y += error_to_string.c
 srcs-y += zeromem.c
+srcs-y += pk_get_oid.c
 subdirs-y += base64
 subdirs-y += crypt
 subdirs-y += pkcs5


### PR DESCRIPTION
Hello all,

I rebased  ``libmpa`` and ``libtomcrypt`` with ``optee_os-2.2.0``.

It appears ``rsa`` and ``dsa`` algorithms now use ``der_decode_subject_public_key_info`` (in ``der_decode_subject_public_key_info.c``) instead ``der_decode_sequence``.
This ``der_decode_subject_public_key_info`` utility requires a ``pk_get_oid`` function, located in ``pk_get_oid.c`` file.
But this file is not present in ``optee_os``.

So i picked up the file at ``https://github.com/libtom/libtomcrypt`` from the (last) commit ``f7847938919a15732884641be6bee3e8fa5862dc``.
Last (old) official label ``1.17`` have not this file...

Our unitary tests are OK with that setup.

Cheers
Manu


