### PR TITLE
libutee: bugfix srcData == NULL cases

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -875,6 +875,12 @@ static TEE_Result tee_buffer_update(
 	size_t buffer_size;
 	size_t buffer_left;
 
+	if (!src) {
+		if (slen)
+			TEE_Panic(0);
+		goto out;
+	}
+
 	if (op->buffer_two_blocks) {
 		buffer_size = op->block_size * 2;
 		buffer_left = 1;
@@ -977,6 +983,7 @@ TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, void *srcData,
 	}
 
 	if (!srcData && !srcLen) {
+		*destLen = 0;
 		res = TEE_SUCCESS;
 		goto out;
 	}
@@ -1062,11 +1069,6 @@ TEE_Result TEE_CipherDoFinal(TEE_OperationHandle operation,
 			res = TEE_ERROR_BAD_PARAMETERS;
 			goto out;
 		}
-	}
-
-	if (!srcData && !srcLen) {
-		res = TEE_SUCCESS;
-		goto out;
 	}
 
 	/*
@@ -1355,6 +1357,7 @@ TEE_Result TEE_AEUpdate(TEE_OperationHandle operation, void *srcData,
 	}
 
 	if (!srcData && !srcLen) {
+		*destLen = 0;
 		res = TEE_SUCCESS;
 		goto out;
 	}
@@ -1415,11 +1418,6 @@ TEE_Result TEE_AEEncryptFinal(TEE_OperationHandle operation,
 
 	if ((operation->info.handleState & TEE_HANDLE_FLAG_INITIALIZED) == 0) {
 		res = TEE_ERROR_BAD_PARAMETERS;
-		goto out;
-	}
-
-	if (!srcData && !srcLen) {
-		res = TEE_SUCCESS;
 		goto out;
 	}
 
@@ -1505,11 +1503,6 @@ TEE_Result TEE_AEDecryptFinal(TEE_OperationHandle operation,
 
 	if ((operation->info.handleState & TEE_HANDLE_FLAG_INITIALIZED) == 0) {
 		res = TEE_ERROR_BAD_PARAMETERS;
-		goto out;
-	}
-
-	if (!srcData && !srcLen) {
-		res = TEE_SUCCESS;
 		goto out;
 	}
 


### PR DESCRIPTION
Fixes faulty treatment of srcData == NULL in TEE_CipherUpdate(),
TEE_AEUpdate(), TEE_AEEncryptFinal(), TEE_AEDecryptFinal().

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Note that the current test cases doesn't detect this problem.
It's visible with "core: introduce MOBJ abstraction" from https://github.com/OP-TEE/optee_os/pull/1253 applied.