### PR TITLE
cruft: remove unreferenced HEAP_SIZE

### DIFF
--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -147,8 +147,6 @@
 #define DRAM0_BASE			0x10000000
 #define DRAM0_SIZE			0x40000000
 
-#define HEAP_SIZE			(24 * 1024)
-
 #define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
 
 #define CFG_TEE_CORE_NB_CORE		4

--- a/core/arch/arm/plat-zynq7k/platform_config.h
+++ b/core/arch/arm/plat-zynq7k/platform_config.h
@@ -68,8 +68,6 @@
 #define DRAM0_BASE			0x00100000
 #define DRAM0_SIZE			0x3FF00000
 
-#define HEAP_SIZE			(24 * 1024)
-
 #define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
 
 #define CFG_TEE_CORE_NB_CORE		2


### PR DESCRIPTION
There are no consumers of this and it just confuses the issue of how to set the heap size.

Signed-off-by: Andy Green <andy@warmcat.com>