### PR TITLE
libutee: fix off-by-one error in tee_buffer_update()

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -930,7 +930,7 @@ static TEE_Result tee_buffer_update(
 
 	if (slen >= (buffer_size + buffer_left)) {
 		/* Buffer is empty, feed as much as possible from src */
-		l = ROUNDUP(slen - buffer_size + 1, op->block_size);
+		l = ROUNDUP(slen - buffer_size, op->block_size);
 
 		tmp_dlen = dlen;
 		res = update_func(op->state, src, l, dst, &tmp_dlen);


### PR DESCRIPTION
Makes the ROUNDUP() call in the "feeding from src" case consistent with
the "feeding from buffer" case a few lines earlier. Without this fix,
AES CTR encryption or decryption could fail because update would feed
blocks too soon, leaving less than two blocks in the internal buffer
thus causing utee_cipher_final() (called from TEE_CipherDoFinal()) to
fail and panic the TA.

Fixes: https://github.com/OP-TEE/optee_os/issues/1203
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>