### PR TITLE
libutee: AES CTS fix

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -930,7 +930,10 @@ static TEE_Result tee_buffer_update(
 
 	if (slen >= (buffer_size + buffer_left)) {
 		/* Buffer is empty, feed as much as possible from src */
-		l = ROUNDUP(slen - buffer_size, op->block_size);
+		if (op->info.algorithm == TEE_ALG_AES_CTS)
+			l = ROUNDUP(slen - buffer_size, op->block_size);
+		else
+			l = ROUNDUP(slen - buffer_size + 1, op->block_size);
 
 		tmp_dlen = dlen;
 		res = update_func(op->state, src, l, dst, &tmp_dlen);


### PR DESCRIPTION
Ad-hoc fix for regressions introduced by [1].
Tested on HiKey using latest optee_test including GlobalPlatform tests
(32/64-bit TEE core, 32/64-bit libutee, with/without ARMv8 CE
acceleration).

Fixes: b1ecda78bab4 ("libutee: fix off-by-one error in tee_buffer_update()") [1]
Fixes: https://github.com/OP-TEE/optee_os/issues/1305
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>