### PR TITLE
platform jitter entropy

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -1,7 +1,7 @@
 CFG_LTC_OPTEE_THREAD ?= y
-# Size of emulated TrustZone protected SRAM, 300 kB.
+# Size of emulated TrustZone protected SRAM, 360 kB.
 # Only applicable when paging is enabled.
-CFG_CORE_TZSRAM_EMUL_SIZE ?= 307200
+CFG_CORE_TZSRAM_EMUL_SIZE ?= 368640
 CFG_LPAE_ADDR_SPACE_SIZE ?= (1ull << 32)
 
 ifeq ($(CFG_ARM64_core),y)

--- a/core/arch/arm/include/kernel/time_source.h
+++ b/core/arch/arm/include/kernel/time_source.h
@@ -40,3 +40,5 @@ void time_source_init(void);
 	}
 
 extern struct time_source _time_source;
+
+void arm_prng_add_jitter_entropy(void);

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -45,6 +45,7 @@
 #include <sm/optee_smc.h>
 #include <sm/sm.h>
 #include <tee/tee_fs_rpc.h>
+#include <tee/tee_cryp_utl.h>
 #include <trace.h>
 #include <util.h>
 
@@ -1192,6 +1193,8 @@ static uint32_t rpc_cmd_nolock(uint32_t cmd, size_t num_params,
 	size_t n;
 
 	assert(arg && carg && num_params <= THREAD_RPC_MAX_NUM_PARAMS);
+
+	plat_prng_add_jitter_entropy();
 
 	memset(arg, 0, OPTEE_MSG_GET_ARG_SIZE(THREAD_RPC_MAX_NUM_PARAMS));
 	arg->cmd = cmd;

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -49,5 +49,6 @@ TEE_Result tee_aes_cbc_cts_update(void *cbc_ctx, void *ecb_ctx,
 				  uint8_t *dst);
 
 TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len);
+void plat_prng_add_jitter_entropy(void);
 
 #endif

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -170,6 +170,9 @@ static TEE_Result tee_ltc_prng_init(struct tee_ltc_prng *prng)
 	}
 
 	prng->index = prng_index;
+
+	plat_prng_add_jitter_entropy();
+
 	return  TEE_SUCCESS;
 }
 

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -378,6 +378,14 @@ TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len)
 	return TEE_SUCCESS;
 }
 
+/*
+ * override this in your platform code to feed the PRNG
+ * platform-specific jitter entropy.
+ */
+__weak void plat_prng_add_jitter_entropy(void)
+{
+}
+
 static TEE_Result tee_cryp_init(void)
 {
 	if (crypto_ops.init)

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -31,6 +31,7 @@
 #include <utee_defines.h>
 #include <tee/tee_cryp_utl.h>
 #include <tee/tee_cryp_provider.h>
+#include <kernel/tee_time.h>
 #include <rng_support.h>
 #include <initcall.h>
 
@@ -379,11 +380,16 @@ TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len)
 }
 
 /*
- * override this in your platform code to feed the PRNG
- * platform-specific jitter entropy.
+ * Override this in your platform code to feed the PRNG platform-specific
+ * jitter entropy. This implementation does not efficiently deliver entropy
+ * and is here for backwards-compatibility.
  */
 __weak void plat_prng_add_jitter_entropy(void)
 {
+	TEE_Time current;
+
+	if (tee_time_get_sys_time(&current) == TEE_SUCCESS)
+		tee_prng_add_entropy((uint8_t *)&current, sizeof(current));
 }
 
 static TEE_Result tee_cryp_init(void)


### PR DESCRIPTION
At the moment if no HWRNG support as on Hikey, a deterministic RC4 PRNG is used.  That's not nice for the reasons listed in the first patch.

These two patches add an internal api that indicates it is a good time to harvest jitter from a platform time source.  By default it does nothing with an empty weak implementation.

An implementation for Hikey is also added using the ARMv8 TSC.

The api to harvest entropy is added to the PRNG init, where it gets 16 bits in the hikey implementation, and at the start of RPC calls, where it harvests 2 bits of jitter.