### PR TITLE
Pseudo device id

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -237,6 +237,7 @@ static void init_runtime(unsigned long pageable_part)
 	malloc_add_pool(__heap2_start, __heap2_end - __heap2_start);
 
 	hashes = malloc(hash_size);
+	IMSG_RAW("\n");
 	IMSG("Pager is enabled. Hashes: %zu bytes", hash_size);
 	assert(hashes);
 	memcpy(hashes, __tmp_hashes_start, hash_size);
@@ -425,6 +426,7 @@ static void init_runtime(unsigned long pageable_part __unused)
 	 * above
 	 */
 	teecore_init_ta_ram();
+	IMSG_RAW("\n");
 }
 #endif
 

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -437,7 +437,7 @@ static int add_optee_dt_node(void *fdt)
 	int ret;
 
 	if (fdt_path_offset(fdt, "/firmware/optee") >= 0) {
-		IMSG("OP-TEE Device Tree node already exists!\n");
+		DMSG("OP-TEE Device Tree node already exists!\n");
 		return 0;
 	}
 

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -31,6 +31,7 @@
 #include <inttypes.h>
 #include <keep.h>
 #include <kernel/generic_boot.h>
+#include <kernel/tee_common_otp.h>
 #include <kernel/thread.h>
 #include <kernel/panic.h>
 #include <kernel/misc.h>
@@ -71,9 +72,6 @@
  * 64-bit systems on the other hand can use full 64-bit physical pointers.
  */
 #define PADDR_INVALID		ULONG_MAX
-
-static uint8_t secure_device_id[160] __early_bss __aligned(8);
-static size_t secure_device_id_len __early_bss;
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
 paddr_t ns_entry_addrs[CFG_TEE_CORE_NB_CORE] __early_bss;
@@ -559,11 +557,6 @@ static void read_optee_secure_device_node(void *fdt)
 	const uint32_t *p;
 	int offs;
 	int len;
-#if (TRACE_LEVEL >= TRACE_INFO)
-	char s[33];
-	int n = 0;
-	int m;
-#endif
 
 	offs = fdt_path_offset(fdt, "/firmware/optee");
 	if (offs < 0)
@@ -578,18 +571,6 @@ static void read_optee_secure_device_node(void *fdt)
 
 	memcpy(secure_device_id, p, len);
 	secure_device_id_len = len;
-
-#if (TRACE_LEVEL >= TRACE_INFO)
-	if (len > 16)
-		len = 16;
-
-	for (m = 0; m < len; m++)
-		n += snprintf(&s[n], sizeof(s) - n - 1, "%02X",
-			      secure_device_id[m]);
-
-	IMSG("secure-device-id: len %d: %s\n",
-	     (int)secure_device_id_len, s);
-#endif
 }
 
 static void init_fdt(unsigned long phys_fdt)

--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -28,25 +28,50 @@
 #include <inttypes.h>
 #include <kernel/tee_common_otp.h>
 
+uint8_t secure_device_id[MAX_SECURE_DEVICE_ID_LEN];
+size_t secure_device_id_len;
+
 /*
  * Override these in your platform code to really fetch device-unique
  * bits from e-fuses or whatever.
  *
  * The default implementation just sets it to a constant.
+ *
+ * If your bootloader passes OP-TEE a DTB, then if it has a property
+ * firmware/optee/secure-device-id, the data found in there is
+ * used to generate a pseudo-id.  This may have been sourced from,
+ * eg, eMMC CID serial number that is specific to the individual
+ * PCB, if not the SoC.
  */
 
 __weak void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
-	memset(&hwkey->data[0], 0, sizeof(hwkey->data));
+	const uint8_t *p = secure_device_id;
+	size_t n;
+
+	if (!secure_device_id_len) {
+		memset(hwkey->data, 0, sizeof(hwkey->data));
+		return;
+	}
+
+	for (n = 0; n < sizeof(hwkey->data); n++)
+		hwkey->data[n] = p[n % secure_device_id_len] ^ 0xff;
 }
 
 __weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 {
-	static const char pattern[4] = { 'B', 'E', 'E', 'F' };
-	size_t i;
+	static const uint8_t default_pattern[] = { 'B', 'E', 'E', 'F' };
+	size_t plen = sizeof(default_pattern);
+	const uint8_t *p = default_pattern;
+	size_t n;
 
-	for (i = 0; i < len; i++)
-		buffer[i] = pattern[i % 4];
+	if (secure_device_id_len) {
+		p = (const uint8_t *)&secure_device_id;
+		plen = secure_device_id_len;
+	}
+
+	for (n = 0; n < len; n++)
+		*buffer++ = p[n % plen];
 
 	return 0;
 }

--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,19 +24,29 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef TEE_COMMON_OTP_H
-#define TEE_COMMON_OTP_H
 
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
-#include <utee_defines.h>
+#include <inttypes.h>
+#include <kernel/tee_common_otp.h>
 
-struct tee_hw_unique_key {
-	uint8_t data[HW_UNIQUE_KEY_LENGTH];
-};
+/*
+ * Override these in your platform code to really fetch device-unique
+ * bits from e-fuses or whatever.
+ *
+ * The default implementation just sets it to a constant.
+ */
 
-void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
-int tee_otp_get_die_id(uint8_t *buffer, size_t len);
+__weak void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+{
+	memset(&hwkey->data[0], 0, sizeof(hwkey->data));
+}
 
-#endif /* TEE_COMMON_OTP_H */
+__weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)
+{
+	static const char pattern[4] = { 'B', 'E', 'E', 'F' };
+	size_t i;
+
+	for (i = 0; i < len; i++)
+		buffer[i] = pattern[i % 4];
+
+	return 0;
+}

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -2,6 +2,7 @@ srcs-$(CFG_WITH_USER_TA) += user_ta.c
 srcs-y += static_ta.c
 srcs-y += elf_load.c
 srcs-y += tee_time.c
+srcs-y += otp_stubs.c
 
 srcs-$(CFG_SECURE_TIME_SOURCE_CNTPCT) += tee_time_arm_cntpct.c
 srcs-$(CFG_SECURE_TIME_SOURCE_REE) += tee_time_ree.c

--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -24,6 +24,15 @@ CFG_NUM_THREADS ?= 8
 CFG_CRYPTO_WITH_CE ?= y
 CFG_WITH_STACK_CANARIES ?= y
 
+# If your arm-trusted-firmware supports it, you can enable DT
+# here, and a-t-f will pass OP-TEE a DTB containing a
+# /firmware/optee/secure-device-id property initialized with
+# the eMMC CID serial number,  This 32-bit token is different
+# for each hikey and serves as a stand-in for a real SoC
+# unique ID.
+#
+CFG_DT ?= n
+
 CFG_PL061 ?= y
 CFG_PL022 ?= y
 CFG_SPI ?= y

--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -36,7 +36,12 @@ struct tee_hw_unique_key {
 	uint8_t data[HW_UNIQUE_KEY_LENGTH];
 };
 
+#define MAX_SECURE_DEVICE_ID_LEN 160
+
 void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
 int tee_otp_get_die_id(uint8_t *buffer, size_t len);
+
+extern uint8_t secure_device_id[MAX_SECURE_DEVICE_ID_LEN];
+extern size_t secure_device_id_len;
 
 #endif /* TEE_COMMON_OTP_H */

--- a/documentation/dt-bindings.md
+++ b/documentation/dt-bindings.md
@@ -1,0 +1,55 @@
+## Secure World OP-TEE DT bindings
+
+OP-TEE has a formal DT binding at
+
+```
+	firmware {
+		optee {
+		};
+	};
+```
+
+The Linux kernel device tree bindings documentation
+explains the properties that may appear there that
+are of interest to Normal World.
+
+OP-TEE may also be passed a DTB at boot-time, which
+may be different to, or modified from, the DTB passed
+to Normal World.
+
+The following properties inside /firmware/optee are
+understood by OP-TEE itself in the Secure World.
+
+### secure-device-id
+
+This allows the bootloader to declare an array of bytes
+which OP-TEE will use as the Secure Device ID.  For
+example OP-TEE uses this information to produce the
+key used for Secure Storage on that device.
+
+Since almost no SoC has public documentation on how to
+read the real device key data from e-fuses, this allows
+alternate ways to get per-device stable identity bits,
+eg, read the eMMC CID serial number on the same board.
+
+This may produce less data than a real key on the SoC,
+but it is still very useful since it requires no
+configuration to get a unique number.
+
+1) The secure-device-id property
+
+The bootloader adds this, which contains a byte array
+of arbitrary length.  If present, and there is no
+SoC platform implementation to get the real SoC key
+data, OP-TEE will take up to 160 bytes from the
+property for use as the Device ID.
+
+Example secure-device-id property
+
+```
+	firmware {
+		optee {
+			secure-device-id = [01 23 34 56];
+		};
+	};
+```

--- a/documentation/secure_storage.md
+++ b/documentation/secure_storage.md
@@ -228,11 +228,8 @@ considered sensitive by the vendors and it is not freely available.
 In OP-TEE, there are apis for reading the keys generically from "One-Time
 Programmable" memory, or OTP.  But there are no existing platform implementations.
 
-To allow Secure Storage to operate securely on your platform, you must:
-
- - enable CFG_OTP_SUPPORT on your platform
-
- - In your platform code, define implementations for:
+To allow Secure Storage to operate securely on your platform, you must define
+implementations in your platform code for:
 
 ```
  void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);


### PR DESCRIPTION
These patches give OP-TEE the concept of a "Pseudo Device ID" that is passed in by the caller of OP-TEE.  If the OP-TEE platform is configured to use it, then it becomes the "unique device ID" inside OP-TEE.  As this is used to compute keys for "Secure Storage", that now becomes able to use per-device keys.  TAs may also use the per-device ID using existing APIs for identity purposes.

When combined with a patch on arm-trusted-firmware[1], on Hikey a 32-bit unique ID is passed into OP-TEE, taken from the MMC CID serial number.

[1] See top patch on https://github.com/lws-team/arm-trusted-firmware/commits/pseudo-device-id