### PR TITLE
libutee: API: add 'const' qualifiers

### DIFF
--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -40,24 +40,24 @@
 /* Property access functions */
 
 TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
-				   char *name, char *valueBuffer,
+				   const char *name, char *valueBuffer,
 				   uint32_t *valueBufferLen);
 
 TEE_Result TEE_GetPropertyAsBool(TEE_PropSetHandle propsetOrEnumerator,
-				 char *name, bool *value);
+				 const char *name, bool *value);
 
 TEE_Result TEE_GetPropertyAsU32(TEE_PropSetHandle propsetOrEnumerator,
-				char *name, uint32_t *value);
+				const char *name, uint32_t *value);
 
 TEE_Result TEE_GetPropertyAsBinaryBlock(TEE_PropSetHandle propsetOrEnumerator,
-					char *name, void *valueBuffer,
+					const char *name, void *valueBuffer,
 					uint32_t *valueBufferLen);
 
 TEE_Result TEE_GetPropertyAsUUID(TEE_PropSetHandle propsetOrEnumerator,
-				 char *name, TEE_UUID *value);
+				 const char *name, TEE_UUID *value);
 
 TEE_Result TEE_GetPropertyAsIdentity(TEE_PropSetHandle propsetOrEnumerator,
-				     char *name, TEE_Identity *value);
+				     const char *name, TEE_Identity *value);
 
 TEE_Result TEE_AllocatePropertyEnumerator(TEE_PropSetHandle *enumerator);
 
@@ -114,13 +114,13 @@ bool TEE_MaskCancellation(void);
 TEE_Result TEE_CheckMemoryAccessRights(uint32_t accessFlags, void *buffer,
 				       uint32_t size);
 
-void TEE_SetInstanceData(void *instanceData);
+void TEE_SetInstanceData(const void *instanceData);
 
-void *TEE_GetInstanceData(void);
+const void *TEE_GetInstanceData(void);
 
 void *TEE_Malloc(uint32_t size, uint32_t hint);
 
-void *TEE_Realloc(void *buffer, uint32_t newSize);
+void *TEE_Realloc(const void *buffer, uint32_t newSize);
 
 void TEE_Free(void *buffer);
 
@@ -159,11 +159,11 @@ void TEE_FreeTransientObject(TEE_ObjectHandle object);
 void TEE_ResetTransientObject(TEE_ObjectHandle object);
 
 TEE_Result TEE_PopulateTransientObject(TEE_ObjectHandle object,
-				       TEE_Attribute *attrs,
+				       const TEE_Attribute *attrs,
 				       uint32_t attrCount);
 
 void TEE_InitRefAttribute(TEE_Attribute *attr, uint32_t attributeID,
-			  void *buffer, uint32_t length);
+			  const void *buffer, uint32_t length);
 
 void TEE_InitValueAttribute(TEE_Attribute *attr, uint32_t attributeID,
 			    uint32_t a, uint32_t b);
@@ -175,15 +175,15 @@ TEE_Result TEE_CopyObjectAttributes1(TEE_ObjectHandle destObject,
 			      TEE_ObjectHandle srcObject);
 
 TEE_Result TEE_GenerateKey(TEE_ObjectHandle object, uint32_t keySize,
-			   TEE_Attribute *params, uint32_t paramCount);
+			   const TEE_Attribute *params, uint32_t paramCount);
 
 /* Data and Key Storage API  - Persistent Object Functions */
 
-TEE_Result TEE_OpenPersistentObject(uint32_t storageID, void *objectID,
+TEE_Result TEE_OpenPersistentObject(uint32_t storageID, const void *objectID,
 				    uint32_t objectIDLen, uint32_t flags,
 				    TEE_ObjectHandle *object);
 
-TEE_Result TEE_CreatePersistentObject(uint32_t storageID, void *objectID,
+TEE_Result TEE_CreatePersistentObject(uint32_t storageID, const void *objectID,
 				      uint32_t objectIDLen, uint32_t flags,
 				      TEE_ObjectHandle attributes,
 				      const void *initialData,
@@ -218,7 +218,7 @@ TEE_Result TEE_GetNextPersistentObject(TEE_ObjectEnumHandle objectEnumerator,
 TEE_Result TEE_ReadObjectData(TEE_ObjectHandle object, void *buffer,
 			      uint32_t size, uint32_t *count);
 
-TEE_Result TEE_WriteObjectData(TEE_ObjectHandle object, void *buffer,
+TEE_Result TEE_WriteObjectData(TEE_ObjectHandle object, const void *buffer,
 			       uint32_t size);
 
 TEE_Result TEE_TruncateObjectData(TEE_ObjectHandle object, uint32_t size);
@@ -255,84 +255,85 @@ void TEE_CopyOperation(TEE_OperationHandle dstOperation,
 /* Cryptographic Operations API - Message Digest Functions */
 
 void TEE_DigestUpdate(TEE_OperationHandle operation,
-		      void *chunk, uint32_t chunkSize);
+		      const void *chunk, uint32_t chunkSize);
 
-TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, void *chunk,
+TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, const void *chunk,
 			     uint32_t chunkLen, void *hash, uint32_t *hashLen);
 
 /* Cryptographic Operations API - Symmetric Cipher Functions */
 
-void TEE_CipherInit(TEE_OperationHandle operation, void *IV,
+void TEE_CipherInit(TEE_OperationHandle operation, const void *IV,
 		    uint32_t IVLen);
 
-TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, void *srcData,
+TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, const void *srcData,
 			    uint32_t srcLen, void *destData, uint32_t *destLen);
 
 TEE_Result TEE_CipherDoFinal(TEE_OperationHandle operation,
-			     void *srcData, uint32_t srcLen, void *destData,
-			     uint32_t *destLen);
+			     const void *srcData, uint32_t srcLen,
+			     void *destData, uint32_t *destLen);
 
 /* Cryptographic Operations API - MAC Functions */
 
-void TEE_MACInit(TEE_OperationHandle operation, void *IV, uint32_t IVLen);
+void TEE_MACInit(TEE_OperationHandle operation, const void *IV,
+		 uint32_t IVLen);
 
-void TEE_MACUpdate(TEE_OperationHandle operation, void *chunk,
+void TEE_MACUpdate(TEE_OperationHandle operation, const void *chunk,
 		   uint32_t chunkSize);
 
 TEE_Result TEE_MACComputeFinal(TEE_OperationHandle operation,
-			       void *message, uint32_t messageLen,
+			       const void *message, uint32_t messageLen,
 			       void *mac, uint32_t *macLen);
 
 TEE_Result TEE_MACCompareFinal(TEE_OperationHandle operation,
-			       void *message, uint32_t messageLen,
-			       void *mac, uint32_t macLen);
+			       const void *message, uint32_t messageLen,
+			       const void *mac, uint32_t macLen);
 
 /* Cryptographic Operations API - Authenticated Encryption Functions */
 
-TEE_Result TEE_AEInit(TEE_OperationHandle operation, void *nonce,
+TEE_Result TEE_AEInit(TEE_OperationHandle operation, const void *nonce,
 		      uint32_t nonceLen, uint32_t tagLen, uint32_t AADLen,
 		      uint32_t payloadLen);
 
-void TEE_AEUpdateAAD(TEE_OperationHandle operation, void *AADdata,
+void TEE_AEUpdateAAD(TEE_OperationHandle operation, const void *AADdata,
 		     uint32_t AADdataLen);
 
-TEE_Result TEE_AEUpdate(TEE_OperationHandle operation, void *srcData,
+TEE_Result TEE_AEUpdate(TEE_OperationHandle operation, const void *srcData,
 			uint32_t srcLen, void *destData, uint32_t *destLen);
 
 TEE_Result TEE_AEEncryptFinal(TEE_OperationHandle operation,
-			      void *srcData, uint32_t srcLen,
+			      const void *srcData, uint32_t srcLen,
 			      void *destData, uint32_t *destLen, void *tag,
 			      uint32_t *tagLen);
 
 TEE_Result TEE_AEDecryptFinal(TEE_OperationHandle operation,
-			      void *srcData, uint32_t srcLen,
+			      const void *srcData, uint32_t srcLen,
 			      void *destData, uint32_t *destLen, void *tag,
 			      uint32_t tagLen);
 
 /* Cryptographic Operations API - Asymmetric Functions */
 
 TEE_Result TEE_AsymmetricEncrypt(TEE_OperationHandle operation,
-				 TEE_Attribute *params,
-				 uint32_t paramCount, void *srcData,
+				 const TEE_Attribute *params,
+				 uint32_t paramCount, const void *srcData,
 				 uint32_t srcLen, void *destData,
 				 uint32_t *destLen);
 
 TEE_Result TEE_AsymmetricDecrypt(TEE_OperationHandle operation,
-				 TEE_Attribute *params,
-				 uint32_t paramCount, void *srcData,
+				 const TEE_Attribute *params,
+				 uint32_t paramCount, const void *srcData,
 				 uint32_t srcLen, void *destData,
 				 uint32_t *destLen);
 
 TEE_Result TEE_AsymmetricSignDigest(TEE_OperationHandle operation,
-				    TEE_Attribute *params,
-				    uint32_t paramCount, void *digest,
+				    const TEE_Attribute *params,
+				    uint32_t paramCount, const void *digest,
 				    uint32_t digestLen, void *signature,
 				    uint32_t *signatureLen);
 
 TEE_Result TEE_AsymmetricVerifyDigest(TEE_OperationHandle operation,
-				      TEE_Attribute *params,
-				      uint32_t paramCount, void *digest,
-				      uint32_t digestLen, void *signature,
+				      const TEE_Attribute *params,
+				      uint32_t paramCount, const void *digest,
+				      uint32_t digestLen, const void *signature,
 				      uint32_t signatureLen);
 
 /* Cryptographic Operations API - Key Derivation Functions */
@@ -368,100 +369,100 @@ uint32_t TEE_BigIntFMMContextSizeInU32(uint32_t modulusSizeInBits);
 void TEE_BigIntInit(TEE_BigInt *bigInt, uint32_t len);
 
 void TEE_BigIntInitFMMContext(TEE_BigIntFMMContext *context, uint32_t len,
-			      TEE_BigInt *modulus);
+			      const TEE_BigInt *modulus);
 
 void TEE_BigIntInitFMM(TEE_BigIntFMM *bigIntFMM, uint32_t len);
 
 /* TEE Arithmetical API - Converter functions */
 
 TEE_Result TEE_BigIntConvertFromOctetString(TEE_BigInt *dest,
-					    uint8_t *buffer,
+					    const uint8_t *buffer,
 					    uint32_t bufferLen,
 					    int32_t sign);
 
 TEE_Result TEE_BigIntConvertToOctetString(uint8_t *buffer, uint32_t *bufferLen,
-					  TEE_BigInt *bigInt);
+					  const TEE_BigInt *bigInt);
 
 void TEE_BigIntConvertFromS32(TEE_BigInt *dest, int32_t shortVal);
 
-TEE_Result TEE_BigIntConvertToS32(int32_t *dest, TEE_BigInt *src);
+TEE_Result TEE_BigIntConvertToS32(int32_t *dest, const TEE_BigInt *src);
 
 /* TEE Arithmetical API - Logical operations */
 
-int32_t TEE_BigIntCmp(TEE_BigInt *op1, TEE_BigInt *op2);
+int32_t TEE_BigIntCmp(const TEE_BigInt *op1, const TEE_BigInt *op2);
 
-int32_t TEE_BigIntCmpS32(TEE_BigInt *op, int32_t shortVal);
+int32_t TEE_BigIntCmpS32(const TEE_BigInt *op, int32_t shortVal);
 
-void TEE_BigIntShiftRight(TEE_BigInt *dest, TEE_BigInt *op,
+void TEE_BigIntShiftRight(TEE_BigInt *dest, const TEE_BigInt *op,
 			  size_t bits);
 
-bool TEE_BigIntGetBit(TEE_BigInt *src, uint32_t bitIndex);
+bool TEE_BigIntGetBit(const TEE_BigInt *src, uint32_t bitIndex);
 
-uint32_t TEE_BigIntGetBitCount(TEE_BigInt *src);
+uint32_t TEE_BigIntGetBitCount(const TEE_BigInt *src);
 
-void TEE_BigIntAdd(TEE_BigInt *dest, TEE_BigInt *op1,
-		   TEE_BigInt *op2);
+void TEE_BigIntAdd(TEE_BigInt *dest, const TEE_BigInt *op1,
+		   const TEE_BigInt *op2);
 
-void TEE_BigIntSub(TEE_BigInt *dest, TEE_BigInt *op1,
-		   TEE_BigInt *op2);
+void TEE_BigIntSub(TEE_BigInt *dest, const TEE_BigInt *op1,
+		   const TEE_BigInt *op2);
 
-void TEE_BigIntNeg(TEE_BigInt *dest, TEE_BigInt *op);
+void TEE_BigIntNeg(TEE_BigInt *dest, const TEE_BigInt *op);
 
-void TEE_BigIntMul(TEE_BigInt *dest, TEE_BigInt *op1,
-		   TEE_BigInt *op2);
+void TEE_BigIntMul(TEE_BigInt *dest, const TEE_BigInt *op1,
+		   const TEE_BigInt *op2);
 
-void TEE_BigIntSquare(TEE_BigInt *dest, TEE_BigInt *op);
+void TEE_BigIntSquare(TEE_BigInt *dest, const TEE_BigInt *op);
 
 void TEE_BigIntDiv(TEE_BigInt *dest_q, TEE_BigInt *dest_r,
-		   TEE_BigInt *op1, TEE_BigInt *op2);
+		   const TEE_BigInt *op1, const TEE_BigInt *op2);
 
 /* TEE Arithmetical API - Modular arithmetic operations */
 
-void TEE_BigIntMod(TEE_BigInt *dest, TEE_BigInt *op,
-		   TEE_BigInt *n);
+void TEE_BigIntMod(TEE_BigInt *dest, const TEE_BigInt *op,
+		   const TEE_BigInt *n);
 
-void TEE_BigIntAddMod(TEE_BigInt *dest, TEE_BigInt *op1,
-		      TEE_BigInt *op2, TEE_BigInt *n);
+void TEE_BigIntAddMod(TEE_BigInt *dest, const TEE_BigInt *op1,
+		      const TEE_BigInt *op2, const TEE_BigInt *n);
 
-void TEE_BigIntSubMod(TEE_BigInt *dest, TEE_BigInt *op1,
-		      TEE_BigInt *op2, TEE_BigInt *n);
+void TEE_BigIntSubMod(TEE_BigInt *dest, const TEE_BigInt *op1,
+		      const TEE_BigInt *op2, const TEE_BigInt *n);
 
-void TEE_BigIntMulMod(TEE_BigInt *dest, TEE_BigInt *op1,
-		      TEE_BigInt *op2, TEE_BigInt *n);
+void TEE_BigIntMulMod(TEE_BigInt *dest, const  TEE_BigInt *op1,
+		      const TEE_BigInt *op2, const TEE_BigInt *n);
 
-void TEE_BigIntSquareMod(TEE_BigInt *dest, TEE_BigInt *op,
-			 TEE_BigInt *n);
+void TEE_BigIntSquareMod(TEE_BigInt *dest, const TEE_BigInt *op,
+			 const TEE_BigInt *n);
 
-void TEE_BigIntInvMod(TEE_BigInt *dest, TEE_BigInt *op,
-		      TEE_BigInt *n);
+void TEE_BigIntInvMod(TEE_BigInt *dest, const TEE_BigInt *op,
+		      const TEE_BigInt *n);
 
 /* TEE Arithmetical API - Other arithmetic operations */
 
-bool TEE_BigIntRelativePrime(TEE_BigInt *op1, TEE_BigInt *op2);
+bool TEE_BigIntRelativePrime(const TEE_BigInt *op1, const TEE_BigInt *op2);
 
 void TEE_BigIntComputeExtendedGcd(TEE_BigInt *gcd, TEE_BigInt *u,
-				  TEE_BigInt *v, TEE_BigInt *op1,
-				  TEE_BigInt *op2);
+				  TEE_BigInt *v, const TEE_BigInt *op1,
+				  const TEE_BigInt *op2);
 
-int32_t TEE_BigIntIsProbablePrime(TEE_BigInt *op,
+int32_t TEE_BigIntIsProbablePrime(const TEE_BigInt *op,
 				  uint32_t confidenceLevel);
 
 /* TEE Arithmetical API - Fast modular multiplication operations */
 
-void TEE_BigIntConvertToFMM(TEE_BigIntFMM *dest, TEE_BigInt *src,
-			    TEE_BigInt *n,
-			    TEE_BigIntFMMContext *context);
+void TEE_BigIntConvertToFMM(TEE_BigIntFMM *dest, const TEE_BigInt *src,
+			    const TEE_BigInt *n,
+			    const TEE_BigIntFMMContext *context);
 
-void TEE_BigIntConvertFromFMM(TEE_BigInt *dest, TEE_BigIntFMM *src,
-			      TEE_BigInt *n,
-			      TEE_BigIntFMMContext *context);
+void TEE_BigIntConvertFromFMM(TEE_BigInt *dest, const TEE_BigIntFMM *src,
+			      const TEE_BigInt *n,
+			      const TEE_BigIntFMMContext *context);
 
-void TEE_BigIntFMMConvertToBigInt(TEE_BigInt *dest, TEE_BigIntFMM *src,
-				  TEE_BigInt *n,
-				  TEE_BigIntFMMContext *context);
+void TEE_BigIntFMMConvertToBigInt(TEE_BigInt *dest, const TEE_BigIntFMM *src,
+				  const TEE_BigInt *n,
+				  const TEE_BigIntFMMContext *context);
 
-void TEE_BigIntComputeFMM(TEE_BigIntFMM *dest, TEE_BigIntFMM *op1,
-			  TEE_BigIntFMM *op2, TEE_BigInt *n,
-			  TEE_BigIntFMMContext *context);
+void TEE_BigIntComputeFMM(TEE_BigIntFMM *dest, const TEE_BigIntFMM *op1,
+			  const TEE_BigIntFMM *op2, const TEE_BigInt *n,
+			  const TEE_BigIntFMMContext *context);
 
 #endif /* TEE_API_H */

--- a/lib/libutee/include/utee_syscalls.h
+++ b/lib/libutee/include/utee_syscalls.h
@@ -62,7 +62,8 @@ TEE_Result utee_get_property(unsigned long prop_set, unsigned long index,
 			     void *name, uint32_t *name_len,
 			     void *buf, uint32_t *blen,
 				uint32_t *prop_type);
-TEE_Result utee_get_property_name_to_index(unsigned long prop_set, void *name,
+TEE_Result utee_get_property_name_to_index(unsigned long prop_set,
+					   const void *name,
 					   unsigned long name_len,
 					   uint32_t *index);
 
@@ -171,7 +172,8 @@ TEE_Result utee_asymm_verify(unsigned long state,
 
 /* Persistant Object Functions */
 /* obj is of type TEE_ObjectHandle */
-TEE_Result utee_storage_obj_open(unsigned long storage_id, void *object_id,
+TEE_Result utee_storage_obj_open(unsigned long storage_id,
+				 const void *object_id,
 				 size_t object_id_len, unsigned long flags,
 				 uint32_t *obj);
 
@@ -179,10 +181,11 @@ TEE_Result utee_storage_obj_open(unsigned long storage_id, void *object_id,
  * attr is of type TEE_ObjectHandle
  * obj is of type TEE_ObjectHandle
  */
-TEE_Result utee_storage_obj_create(unsigned long storage_id, void *object_id,
-				size_t object_id_len, unsigned long flags,
-				unsigned long attr, const void *data,
-				size_t len, uint32_t *obj);
+TEE_Result utee_storage_obj_create(unsigned long storage_id,
+				   const void *object_id,
+				   size_t object_id_len, unsigned long flags,
+				   unsigned long attr, const void *data,
+				   size_t len, uint32_t *obj);
 
 /* obj is of type TEE_ObjectHandle */
 TEE_Result utee_storage_obj_del(unsigned long obj);

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -33,7 +33,7 @@
 #include "tee_user_mem.h"
 #include "tee_api_private.h"
 
-static void *tee_api_instance_data;
+static const void *tee_api_instance_data;
 
 /* System API - Internal Client API */
 
@@ -221,12 +221,12 @@ out:
 	return res;
 }
 
-void TEE_SetInstanceData(void *instanceData)
+void TEE_SetInstanceData(const void *instanceData)
 {
 	tee_api_instance_data = instanceData;
 }
 
-void *TEE_GetInstanceData(void)
+const void *TEE_GetInstanceData(void)
 {
 	return tee_api_instance_data;
 }
@@ -314,13 +314,13 @@ void *TEE_Malloc(uint32_t len, uint32_t hint)
 	return tee_user_mem_alloc(len, hint);
 }
 
-void *TEE_Realloc(void *buffer, uint32_t newSize)
+void *TEE_Realloc(const void *buffer, uint32_t newSize)
 {
 	/*
 	 * GP TEE Internal API specifies newSize as 'uint32_t'.
 	 * use unsigned 'size_t' type. it is at least 32bit!
 	 */
-	return tee_user_mem_realloc(buffer, (size_t) newSize);
+	return tee_user_mem_realloc((void *)buffer, (size_t) newSize);
 }
 
 void TEE_Free(void *buffer)

--- a/lib/libutee/tee_api_arith.c
+++ b/lib/libutee/tee_api_arith.c
@@ -104,7 +104,7 @@ void TEE_BigIntInitFMM(TEE_BigIntFMM *bigIntFMM, uint32_t len)
  * TEE_BigIntInitFMMContext
  */
 void TEE_BigIntInitFMMContext(TEE_BigIntFMMContext *context,
-			      uint32_t len, TEE_BigInt *modulus)
+			      uint32_t len, const TEE_BigInt *modulus)
 {
 	mpa_fmm_context mpa_context = (mpa_fmm_context_base *)context;
 	mpanum mpa_modulus = (mpa_num_base *)modulus;
@@ -143,7 +143,7 @@ uint32_t TEE_BigIntFMMContextSizeInU32(uint32_t modulusSizeInBits)
  * TEE_BigIntConvertFromOctetString
  */
 TEE_Result TEE_BigIntConvertFromOctetString(TEE_BigInt *dest,
-					    uint8_t *buffer,
+					    const uint8_t *buffer,
 					    uint32_t bufferLen,
 					    int32_t sign)
 {
@@ -168,7 +168,7 @@ TEE_Result TEE_BigIntConvertFromOctetString(TEE_BigInt *dest,
  */
 TEE_Result TEE_BigIntConvertToOctetString(uint8_t *buffer,
 					  uint32_t *bufferLen,
-					  TEE_BigInt *bigInt)
+					  const TEE_BigInt *bigInt)
 {
 	mpanum n = (mpa_num_base *)bigInt;
 	size_t size = *bufferLen;
@@ -205,7 +205,7 @@ void TEE_BigIntConvertFromS32(TEE_BigInt *dest, int32_t shortVal)
 /*
  * TEE_BigIntConvertToS32
  */
-TEE_Result TEE_BigIntConvertToS32(int32_t *dest, TEE_BigInt *src)
+TEE_Result TEE_BigIntConvertToS32(int32_t *dest, const TEE_BigInt *src)
 {
 	TEE_Result res;
 	mpanum mpa_src = (mpa_num_base *)src;
@@ -229,7 +229,7 @@ TEE_Result TEE_BigIntConvertToS32(int32_t *dest, TEE_BigInt *src)
 /*
  * TEE_BigIntCmp
  */
-int32_t TEE_BigIntCmp(TEE_BigInt *op1, TEE_BigInt *op2)
+int32_t TEE_BigIntCmp(const TEE_BigInt *op1, const TEE_BigInt *op2)
 {
 	mpanum mpa_op1 = (mpa_num_base *)op1;
 	mpanum mpa_op2 = (mpa_num_base *)op2;
@@ -240,7 +240,7 @@ int32_t TEE_BigIntCmp(TEE_BigInt *op1, TEE_BigInt *op2)
 /*
  * TEE_BigIntCmpS32
  */
-int32_t TEE_BigIntCmpS32(TEE_BigInt *op, int32_t shortVal)
+int32_t TEE_BigIntCmpS32(const TEE_BigInt *op, int32_t shortVal)
 {
 	mpanum mpa_op = (mpa_num_base *)op;
 
@@ -250,7 +250,7 @@ int32_t TEE_BigIntCmpS32(TEE_BigInt *op, int32_t shortVal)
 /*
  * TEE_BigIntShiftRight
  */
-void TEE_BigIntShiftRight(TEE_BigInt *dest, TEE_BigInt *op,
+void TEE_BigIntShiftRight(TEE_BigInt *dest, const TEE_BigInt *op,
 			  size_t bits)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
@@ -262,7 +262,7 @@ void TEE_BigIntShiftRight(TEE_BigInt *dest, TEE_BigInt *op,
 /*
  * TEE_BigIntGetBit
  */
-bool TEE_BigIntGetBit(TEE_BigInt *src, uint32_t bitIndex)
+bool TEE_BigIntGetBit(const TEE_BigInt *src, uint32_t bitIndex)
 {
 	mpanum mpa_src = (mpa_num_base *)src;
 
@@ -272,7 +272,7 @@ bool TEE_BigIntGetBit(TEE_BigInt *src, uint32_t bitIndex)
 /*
  * TEE_BigIntGetBitCount
  */
-uint32_t TEE_BigIntGetBitCount(TEE_BigInt *src)
+uint32_t TEE_BigIntGetBitCount(const TEE_BigInt *src)
 {
 	mpanum mpa_src = (mpa_num_base *)src;
 
@@ -286,8 +286,8 @@ uint32_t TEE_BigIntGetBitCount(TEE_BigInt *src)
 /*
  * TEE_BigIntAdd
  */
-void TEE_BigIntAdd(TEE_BigInt *dest, TEE_BigInt *op1,
-		   TEE_BigInt *op2)
+void TEE_BigIntAdd(TEE_BigInt *dest, const TEE_BigInt *op1,
+		   const TEE_BigInt *op2)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)op1;
@@ -299,8 +299,8 @@ void TEE_BigIntAdd(TEE_BigInt *dest, TEE_BigInt *op1,
 /*
  * TEE_BigIntSub
  */
-void TEE_BigIntSub(TEE_BigInt *dest, TEE_BigInt *op1,
-		   TEE_BigInt *op2)
+void TEE_BigIntSub(TEE_BigInt *dest, const TEE_BigInt *op1,
+		   const TEE_BigInt *op2)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)op1;
@@ -312,7 +312,7 @@ void TEE_BigIntSub(TEE_BigInt *dest, TEE_BigInt *op1,
 /*
  * TEE_BigIntNeg
  */
-void TEE_BigIntNeg(TEE_BigInt *dest, TEE_BigInt *src)
+void TEE_BigIntNeg(TEE_BigInt *dest, const TEE_BigInt *src)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_src = (mpa_num_base *)src;
@@ -323,8 +323,8 @@ void TEE_BigIntNeg(TEE_BigInt *dest, TEE_BigInt *src)
 /*
  * TEE_BigIntMul
  */
-void TEE_BigIntMul(TEE_BigInt *dest, TEE_BigInt *op1,
-		   TEE_BigInt *op2)
+void TEE_BigIntMul(TEE_BigInt *dest, const TEE_BigInt *op1,
+		   const TEE_BigInt *op2)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)op1;
@@ -336,7 +336,7 @@ void TEE_BigIntMul(TEE_BigInt *dest, TEE_BigInt *op1,
 /*
  * TEE_BigIntSquare
  */
-void TEE_BigIntSquare(TEE_BigInt *dest, TEE_BigInt *op)
+void TEE_BigIntSquare(TEE_BigInt *dest, const TEE_BigInt *op)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op = (mpa_num_base *)op;
@@ -348,7 +348,7 @@ void TEE_BigIntSquare(TEE_BigInt *dest, TEE_BigInt *op)
  * TEE_BigIntDiv
  */
 void TEE_BigIntDiv(TEE_BigInt *dest_q, TEE_BigInt *dest_r,
-		   TEE_BigInt *op1, TEE_BigInt *op2)
+		   const TEE_BigInt *op1, const TEE_BigInt *op2)
 {
 	mpanum mpa_dest_q = (mpa_num_base *)dest_q;
 	mpanum mpa_dest_r = (mpa_num_base *)dest_r;
@@ -368,8 +368,8 @@ void TEE_BigIntDiv(TEE_BigInt *dest_q, TEE_BigInt *dest_r,
 /*
  * TEE_BigIntMod
  */
-void TEE_BigIntMod(TEE_BigInt *dest, TEE_BigInt *op,
-		   TEE_BigInt *n)
+void TEE_BigIntMod(TEE_BigInt *dest, const TEE_BigInt *op,
+		   const TEE_BigInt *n)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op = (mpa_num_base *)op;
@@ -387,8 +387,8 @@ void TEE_BigIntMod(TEE_BigInt *dest, TEE_BigInt *op,
 /*
  * TEE_BigIntAddMod
  */
-void TEE_BigIntAddMod(TEE_BigInt *dest, TEE_BigInt *op1,
-		      TEE_BigInt *op2, TEE_BigInt *n)
+void TEE_BigIntAddMod(TEE_BigInt *dest, const TEE_BigInt *op1,
+		      const TEE_BigInt *op2, const TEE_BigInt *n)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)op1;
@@ -406,8 +406,8 @@ void TEE_BigIntAddMod(TEE_BigInt *dest, TEE_BigInt *op1,
 /*
  * TEE_BigIntSubMod
  */
-void TEE_BigIntSubMod(TEE_BigInt *dest, TEE_BigInt *op1,
-		      TEE_BigInt *op2, TEE_BigInt *n)
+void TEE_BigIntSubMod(TEE_BigInt *dest, const TEE_BigInt *op1,
+		      const TEE_BigInt *op2, const TEE_BigInt *n)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)op1;
@@ -425,8 +425,8 @@ void TEE_BigIntSubMod(TEE_BigInt *dest, TEE_BigInt *op1,
 /*
  *  TEE_BigIntMulMod
  */
-void TEE_BigIntMulMod(TEE_BigInt *dest, TEE_BigInt *op1,
-		      TEE_BigInt *op2, TEE_BigInt *n)
+void TEE_BigIntMulMod(TEE_BigInt *dest, const TEE_BigInt *op1,
+		      const TEE_BigInt *op2, const TEE_BigInt *n)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)op1;
@@ -456,8 +456,8 @@ void TEE_BigIntMulMod(TEE_BigInt *dest, TEE_BigInt *op1,
 /*
  * TEE_BigIntSquareMod
  */
-void TEE_BigIntSquareMod(TEE_BigInt *dest, TEE_BigInt *op,
-			 TEE_BigInt *n)
+void TEE_BigIntSquareMod(TEE_BigInt *dest, const TEE_BigInt *op,
+			 const TEE_BigInt *n)
 {
 	TEE_BigIntMulMod(dest, op, op, n);
 }
@@ -465,8 +465,8 @@ void TEE_BigIntSquareMod(TEE_BigInt *dest, TEE_BigInt *op,
 /*
  * TEE_BigIntInvMod
  */
-void TEE_BigIntInvMod(TEE_BigInt *dest, TEE_BigInt *op,
-		      TEE_BigInt *n)
+void TEE_BigIntInvMod(TEE_BigInt *dest, const TEE_BigInt *op,
+		      const TEE_BigInt *n)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op = (mpa_num_base *)op;
@@ -485,7 +485,7 @@ void TEE_BigIntInvMod(TEE_BigInt *dest, TEE_BigInt *op,
 /*
  * TEE_BigIntRelativePrime
  */
-bool TEE_BigIntRelativePrime(TEE_BigInt *op1, TEE_BigInt *op2)
+bool TEE_BigIntRelativePrime(const TEE_BigInt *op1, const TEE_BigInt *op2)
 {
 	mpanum mpa_op1 = (mpa_num_base *)op1;
 	mpanum mpa_op2 = (mpa_num_base *)op2;
@@ -506,8 +506,8 @@ bool TEE_BigIntRelativePrime(TEE_BigInt *op1, TEE_BigInt *op2)
  * TEE_BigIntExtendedGcd
  */
 void TEE_BigIntComputeExtendedGcd(TEE_BigInt *gcd, TEE_BigInt *u,
-				  TEE_BigInt *v, TEE_BigInt *op1,
-				  TEE_BigInt *op2)
+				  TEE_BigInt *v, const TEE_BigInt *op1,
+				  const TEE_BigInt *op2)
 {
 	mpanum mpa_gcd_res = (mpa_num_base *)gcd;
 	mpanum mpa_u = (mpa_num_base *)u;
@@ -521,7 +521,7 @@ void TEE_BigIntComputeExtendedGcd(TEE_BigInt *gcd, TEE_BigInt *u,
 /*
  *  TEE_BigIntIsProbablePrime
  */
-int32_t TEE_BigIntIsProbablePrime(TEE_BigInt *op,
+int32_t TEE_BigIntIsProbablePrime(const TEE_BigInt *op,
 				  uint32_t confidenceLevel)
 {
 	mpanum mpa_op = (mpa_num_base *)op;
@@ -543,9 +543,9 @@ int32_t TEE_BigIntIsProbablePrime(TEE_BigInt *op,
  * TEE_BigIntConvertToFMM
  */
 void TEE_BigIntConvertToFMM(TEE_BigIntFMM *dest,
-			    TEE_BigInt *src,
-			    TEE_BigInt *n,
-			    TEE_BigIntFMMContext *context)
+			    const TEE_BigInt *src,
+			    const TEE_BigInt *n,
+			    const TEE_BigIntFMMContext *context)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)src;
@@ -561,9 +561,9 @@ void TEE_BigIntConvertToFMM(TEE_BigIntFMM *dest,
  * TEE_BigIntConvertFromFMM
  */
 void TEE_BigIntConvertFromFMM(TEE_BigInt *dest,
-			      TEE_BigIntFMM *src,
-			      TEE_BigInt *n,
-			      TEE_BigIntFMMContext *context)
+			      const TEE_BigIntFMM *src,
+			      const TEE_BigInt *n,
+			      const TEE_BigIntFMMContext *context)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op2 = (mpa_num_base *)src;
@@ -590,10 +590,10 @@ void TEE_BigIntConvertFromFMM(TEE_BigInt *dest,
  *  TEE_BigIntComputeFMM
  */
 void TEE_BigIntComputeFMM(TEE_BigIntFMM *dest,
-			  TEE_BigIntFMM *op1,
-			  TEE_BigIntFMM *op2,
-			  TEE_BigInt *n,
-			  TEE_BigIntFMMContext *context)
+			  const TEE_BigIntFMM *op1,
+			  const TEE_BigIntFMM *op2,
+			  const TEE_BigInt *n,
+			  const TEE_BigIntFMMContext *context)
 {
 	mpanum mpa_dest = (mpa_num_base *)dest;
 	mpanum mpa_op1 = (mpa_num_base *)op1;

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -279,7 +279,7 @@ void TEE_ResetTransientObject(TEE_ObjectHandle object)
 }
 
 TEE_Result TEE_PopulateTransientObject(TEE_ObjectHandle object,
-				       TEE_Attribute *attrs,
+				       const TEE_Attribute *attrs,
 				       uint32_t attrCount)
 {
 	TEE_Result res;
@@ -306,14 +306,14 @@ TEE_Result TEE_PopulateTransientObject(TEE_ObjectHandle object,
 }
 
 void TEE_InitRefAttribute(TEE_Attribute *attr, uint32_t attributeID,
-			  void *buffer, uint32_t length)
+			  const void *buffer, uint32_t length)
 {
 	if (attr == NULL)
 		TEE_Panic(0);
 	if ((attributeID & TEE_ATTR_BIT_VALUE) != 0)
 		TEE_Panic(0);
 	attr->attributeID = attributeID;
-	attr->content.ref.buffer = buffer;
+	attr->content.ref.buffer = (void *)buffer;
 	attr->content.ref.length = length;
 }
 
@@ -387,7 +387,7 @@ exit:
 }
 
 TEE_Result TEE_GenerateKey(TEE_ObjectHandle object, uint32_t keySize,
-			   TEE_Attribute *params, uint32_t paramCount)
+			   const TEE_Attribute *params, uint32_t paramCount)
 {
 	TEE_Result res;
 	struct utee_attribute ua[paramCount];
@@ -404,7 +404,7 @@ TEE_Result TEE_GenerateKey(TEE_ObjectHandle object, uint32_t keySize,
 
 /* Data and Key Storage API  - Persistent Object Functions */
 
-TEE_Result TEE_OpenPersistentObject(uint32_t storageID, void *objectID,
+TEE_Result TEE_OpenPersistentObject(uint32_t storageID, const void *objectID,
 				    uint32_t objectIDLen, uint32_t flags,
 				    TEE_ObjectHandle *object)
 {
@@ -443,7 +443,7 @@ out:
 	return res;
 }
 
-TEE_Result TEE_CreatePersistentObject(uint32_t storageID, void *objectID,
+TEE_Result TEE_CreatePersistentObject(uint32_t storageID, const void *objectID,
 				      uint32_t objectIDLen, uint32_t flags,
 				      TEE_ObjectHandle attributes,
 				      const void *initialData,
@@ -690,7 +690,7 @@ out:
 	return res;
 }
 
-TEE_Result TEE_WriteObjectData(TEE_ObjectHandle object, void *buffer,
+TEE_Result TEE_WriteObjectData(TEE_ObjectHandle object, const void *buffer,
 			       uint32_t size)
 {
 	TEE_Result res;

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -762,7 +762,7 @@ void TEE_CopyOperation(TEE_OperationHandle dst_op, TEE_OperationHandle src_op)
 
 /* Cryptographic Operations API - Message Digest Functions */
 
-static void init_hash_operation(TEE_OperationHandle operation, void *IV,
+static void init_hash_operation(TEE_OperationHandle operation, const void *IV,
 				uint32_t IVLen)
 {
 	TEE_Result res;
@@ -779,7 +779,7 @@ static void init_hash_operation(TEE_OperationHandle operation, void *IV,
 }
 
 void TEE_DigestUpdate(TEE_OperationHandle operation,
-		      void *chunk, uint32_t chunkSize)
+		      const void *chunk, uint32_t chunkSize)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 
@@ -794,7 +794,7 @@ void TEE_DigestUpdate(TEE_OperationHandle operation,
 		TEE_Panic(res);
 }
 
-TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, void *chunk,
+TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, const void *chunk,
 			     uint32_t chunkLen, void *hash, uint32_t *hashLen)
 {
 	TEE_Result res;
@@ -830,7 +830,8 @@ out:
 
 /* Cryptographic Operations API - Symmetric Cipher Functions */
 
-void TEE_CipherInit(TEE_OperationHandle operation, void *IV, uint32_t IVLen)
+void TEE_CipherInit(TEE_OperationHandle operation, const void *IV,
+		    uint32_t IVLen)
 {
 	TEE_Result res;
 
@@ -955,7 +956,7 @@ out:
 	return TEE_SUCCESS;
 }
 
-TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, void *srcData,
+TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, const void *srcData,
 			    uint32_t srcLen, void *destData, uint32_t *destLen)
 {
 	TEE_Result res;
@@ -1025,8 +1026,8 @@ out:
 }
 
 TEE_Result TEE_CipherDoFinal(TEE_OperationHandle operation,
-			     void *srcData, uint32_t srcLen, void *destData,
-			     uint32_t *destLen)
+			     const void *srcData, uint32_t srcLen,
+			     void *destData, uint32_t *destLen)
 {
 	TEE_Result res;
 	uint8_t *dst = destData;
@@ -1118,7 +1119,7 @@ out:
 
 /* Cryptographic Operations API - MAC Functions */
 
-void TEE_MACInit(TEE_OperationHandle operation, void *IV, uint32_t IVLen)
+void TEE_MACInit(TEE_OperationHandle operation, const void *IV, uint32_t IVLen)
 {
 	if (operation == TEE_HANDLE_NULL)
 		TEE_Panic(0);
@@ -1138,7 +1139,7 @@ void TEE_MACInit(TEE_OperationHandle operation, void *IV, uint32_t IVLen)
 	init_hash_operation(operation, IV, IVLen);
 }
 
-void TEE_MACUpdate(TEE_OperationHandle operation, void *chunk,
+void TEE_MACUpdate(TEE_OperationHandle operation, const void *chunk,
 		   uint32_t chunkSize)
 {
 	TEE_Result res;
@@ -1161,7 +1162,7 @@ void TEE_MACUpdate(TEE_OperationHandle operation, void *chunk,
 }
 
 TEE_Result TEE_MACComputeFinal(TEE_OperationHandle operation,
-			       void *message, uint32_t messageLen,
+			       const void *message, uint32_t messageLen,
 			       void *mac, uint32_t *macLen)
 {
 	TEE_Result res;
@@ -1209,8 +1210,8 @@ out:
 }
 
 TEE_Result TEE_MACCompareFinal(TEE_OperationHandle operation,
-			       void *message, uint32_t messageLen,
-			       void *mac, uint32_t macLen)
+			       const void *message, uint32_t messageLen,
+			       const void *mac, uint32_t macLen)
 {
 	TEE_Result res;
 	uint8_t computed_mac[TEE_MAX_HASH_SIZE];
@@ -1258,7 +1259,7 @@ out:
 
 /* Cryptographic Operations API - Authenticated Encryption Functions */
 
-TEE_Result TEE_AEInit(TEE_OperationHandle operation, void *nonce,
+TEE_Result TEE_AEInit(TEE_OperationHandle operation, const void *nonce,
 		      uint32_t nonceLen, uint32_t tagLen, uint32_t AADLen,
 		      uint32_t payloadLen)
 {
@@ -1311,7 +1312,7 @@ out:
 	return res;
 }
 
-void TEE_AEUpdateAAD(TEE_OperationHandle operation, void *AADdata,
+void TEE_AEUpdateAAD(TEE_OperationHandle operation, const void *AADdata,
 		     uint32_t AADdataLen)
 {
 	TEE_Result res;
@@ -1334,7 +1335,7 @@ void TEE_AEUpdateAAD(TEE_OperationHandle operation, void *AADdata,
 		TEE_Panic(res);
 }
 
-TEE_Result TEE_AEUpdate(TEE_OperationHandle operation, void *srcData,
+TEE_Result TEE_AEUpdate(TEE_OperationHandle operation, const void *srcData,
 			uint32_t srcLen, void *destData, uint32_t *destLen)
 {
 	TEE_Result res;
@@ -1394,7 +1395,7 @@ out:
 }
 
 TEE_Result TEE_AEEncryptFinal(TEE_OperationHandle operation,
-			      void *srcData, uint32_t srcLen,
+			      const void *srcData, uint32_t srcLen,
 			      void *destData, uint32_t *destLen, void *tag,
 			      uint32_t *tagLen)
 {
@@ -1480,7 +1481,7 @@ out:
 }
 
 TEE_Result TEE_AEDecryptFinal(TEE_OperationHandle operation,
-			      void *srcData, uint32_t srcLen,
+			      const void *srcData, uint32_t srcLen,
 			      void *destData, uint32_t *destLen, void *tag,
 			      uint32_t tagLen)
 {
@@ -1560,8 +1561,8 @@ out:
 /* Cryptographic Operations API - Asymmetric Functions */
 
 TEE_Result TEE_AsymmetricEncrypt(TEE_OperationHandle operation,
-				 TEE_Attribute *params,
-				 uint32_t paramCount, void *srcData,
+				 const TEE_Attribute *params,
+				 uint32_t paramCount, const void *srcData,
 				 uint32_t srcLen, void *destData,
 				 uint32_t *destLen)
 {
@@ -1596,8 +1597,8 @@ TEE_Result TEE_AsymmetricEncrypt(TEE_OperationHandle operation,
 }
 
 TEE_Result TEE_AsymmetricDecrypt(TEE_OperationHandle operation,
-				 TEE_Attribute *params,
-				 uint32_t paramCount, void *srcData,
+				 const TEE_Attribute *params,
+				 uint32_t paramCount, const void *srcData,
 				 uint32_t srcLen, void *destData,
 				 uint32_t *destLen)
 {
@@ -1632,8 +1633,8 @@ TEE_Result TEE_AsymmetricDecrypt(TEE_OperationHandle operation,
 }
 
 TEE_Result TEE_AsymmetricSignDigest(TEE_OperationHandle operation,
-				    TEE_Attribute *params,
-				    uint32_t paramCount, void *digest,
+				    const TEE_Attribute *params,
+				    uint32_t paramCount, const void *digest,
 				    uint32_t digestLen, void *signature,
 				    uint32_t *signatureLen)
 {
@@ -1668,9 +1669,10 @@ TEE_Result TEE_AsymmetricSignDigest(TEE_OperationHandle operation,
 }
 
 TEE_Result TEE_AsymmetricVerifyDigest(TEE_OperationHandle operation,
-				      TEE_Attribute *params,
-				      uint32_t paramCount, void *digest,
-				      uint32_t digestLen, void *signature,
+				      const TEE_Attribute *params,
+				      uint32_t paramCount, const void *digest,
+				      uint32_t digestLen,
+				      const void *signature,
 				      uint32_t signatureLen)
 {
 	TEE_Result res;

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -134,7 +134,7 @@ static TEE_Result propget_get_ext_prop(const struct user_ta_property *ep,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result propget_get_property(TEE_PropSetHandle h, char *name,
+static TEE_Result propget_get_property(TEE_PropSetHandle h, const char *name,
 				       enum user_ta_prop_type *type,
 				       void *buf, uint32_t *len)
 {
@@ -191,7 +191,7 @@ static TEE_Result propget_get_property(TEE_PropSetHandle h, char *name,
 }
 
 TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
-				   char *name, char *value,
+				   const char *name, char *value,
 				   uint32_t *value_len)
 {
 	TEE_Result res;
@@ -293,7 +293,7 @@ out:
 }
 
 TEE_Result TEE_GetPropertyAsBool(TEE_PropSetHandle propsetOrEnumerator,
-				 char *name, bool *value)
+				 const char *name, bool *value)
 {
 	TEE_Result res;
 	enum user_ta_prop_type type;
@@ -324,7 +324,7 @@ out:
 }
 
 TEE_Result TEE_GetPropertyAsU32(TEE_PropSetHandle propsetOrEnumerator,
-				char *name, uint32_t *value)
+				const char *name, uint32_t *value)
 {
 	TEE_Result res;
 	enum user_ta_prop_type type;
@@ -351,7 +351,7 @@ out:
 }
 
 TEE_Result TEE_GetPropertyAsBinaryBlock(TEE_PropSetHandle propsetOrEnumerator,
-					char *name, void *value,
+					const char *name, void *value,
 					uint32_t *value_len)
 {
 	TEE_Result res;
@@ -379,7 +379,7 @@ out:
 }
 
 TEE_Result TEE_GetPropertyAsUUID(TEE_PropSetHandle propsetOrEnumerator,
-				 char *name, TEE_UUID *value)
+				 const char *name, TEE_UUID *value)
 {
 	TEE_Result res;
 	enum user_ta_prop_type type;
@@ -406,7 +406,7 @@ out:
 }
 
 TEE_Result TEE_GetPropertyAsIdentity(TEE_PropSetHandle propsetOrEnumerator,
-				     char *name, TEE_Identity *value)
+				     const char *name, TEE_Identity *value)
 {
 	TEE_Result res;
 	enum user_ta_prop_type type;


### PR DESCRIPTION
As per the GlobalPlatform Internal Core API Specification v1.1,
section 3.4 Parameter Annotations: "[...] the [in], [inbuf],
[instring], [instringopt], and [ctx] annotations can make use of the
const C keyword [...] the C header file of a compliant Implementation
SHOULD use the const keyword when these annotations appear."

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>