### PR TITLE
libutee: preserve error code when calling TEE_Panic()

### DIFF
--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -253,7 +253,7 @@ void TEE_GetSystemTime(TEE_Time *time)
 	TEE_Result res = utee_get_time(UTEE_TIME_CAT_SYSTEM, time);
 
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 TEE_Result TEE_Wait(uint32_t timeout)
@@ -306,7 +306,7 @@ void TEE_GetREETime(TEE_Time *time)
 	TEE_Result res = utee_get_time(UTEE_TIME_CAT_REE, time);
 
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 void *TEE_Malloc(uint32_t len, uint32_t hint)

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -111,7 +111,7 @@ void TEE_RestrictObjectUsage(TEE_ObjectHandle object, uint32_t objectUsage)
 	res = TEE_RestrictObjectUsage1(object, objectUsage);
 
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 TEE_Result TEE_RestrictObjectUsage1(TEE_ObjectHandle object, uint32_t objectUsage)
@@ -157,7 +157,7 @@ exit:
 	    res != TEE_ERROR_SHORT_BUFFER &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -189,7 +189,7 @@ exit:
 	    res != TEE_ERROR_ITEM_NOT_FOUND &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	if (size != sizeof(buf))
 		TEE_Panic(0);
@@ -213,7 +213,7 @@ void TEE_CloseObject(TEE_ObjectHandle object)
 
 	res = utee_cryp_obj_close((unsigned long)object);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 /* Data and Key Storage API  - Transient Object Functions */
@@ -230,7 +230,7 @@ TEE_Result TEE_AllocateTransientObject(TEE_ObjectType objectType,
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_OUT_OF_MEMORY &&
 	    res != TEE_ERROR_NOT_SUPPORTED)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	if (res == TEE_SUCCESS)
 		*object = (TEE_ObjectHandle)(uintptr_t)obj;
@@ -248,14 +248,14 @@ void TEE_FreeTransientObject(TEE_ObjectHandle object)
 
 	res = utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	if ((info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT) != 0)
 		TEE_Panic(0);
 
 	res = utee_cryp_obj_close((unsigned long)object);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 void TEE_ResetTransientObject(TEE_ObjectHandle object)
@@ -268,14 +268,14 @@ void TEE_ResetTransientObject(TEE_ObjectHandle object)
 
 	res = utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	if ((info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT) != 0)
 		TEE_Panic(0);
 
 	res = utee_cryp_obj_reset((unsigned long)object);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 TEE_Result TEE_PopulateTransientObject(TEE_ObjectHandle object,
@@ -288,7 +288,7 @@ TEE_Result TEE_PopulateTransientObject(TEE_ObjectHandle object,
 
 	res = utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	/* Must be a transient object */
 	if ((info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT) != 0)
@@ -347,7 +347,7 @@ void TEE_CopyObjectAttributes(TEE_ObjectHandle destObject,
 
 	res = TEE_CopyObjectAttributes1(destObject, srcObject);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 TEE_Result TEE_CopyObjectAttributes1(TEE_ObjectHandle destObject,
@@ -397,7 +397,7 @@ TEE_Result TEE_GenerateKey(TEE_ObjectHandle object, uint32_t keySize,
 					 ua, paramCount);
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_BAD_PARAMETERS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -438,7 +438,7 @@ out:
 	    res != TEE_ERROR_OUT_OF_MEMORY &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -484,7 +484,7 @@ err:
 	    res == TEE_ERROR_CORRUPT_OBJECT ||
 	    res == TEE_ERROR_STORAGE_NOT_AVAILABLE)
 		return res;
-	TEE_Panic(0);
+	TEE_Panic(res);
 out:
 	return TEE_SUCCESS;
 }
@@ -518,7 +518,7 @@ TEE_Result TEE_CloseAndDeletePersistentObject1(TEE_ObjectHandle object)
 	res = utee_storage_obj_del((unsigned long)object);
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -553,7 +553,7 @@ out:
 	    res != TEE_ERROR_ACCESS_CONFLICT &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -576,7 +576,7 @@ TEE_Result TEE_AllocatePersistentObjectEnumerator(TEE_ObjectEnumHandle *
 
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_ACCESS_CONFLICT)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -591,7 +591,7 @@ void TEE_FreePersistentObjectEnumerator(TEE_ObjectEnumHandle objectEnumerator)
 	res = utee_storage_free_enum((unsigned long)objectEnumerator);
 
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 void TEE_ResetPersistentObjectEnumerator(TEE_ObjectEnumHandle objectEnumerator)
@@ -604,7 +604,7 @@ void TEE_ResetPersistentObjectEnumerator(TEE_ObjectEnumHandle objectEnumerator)
 	res = utee_storage_reset_enum((unsigned long)objectEnumerator);
 
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 }
 
 TEE_Result TEE_StartPersistentObjectEnumerator(TEE_ObjectEnumHandle
@@ -620,7 +620,7 @@ TEE_Result TEE_StartPersistentObjectEnumerator(TEE_ObjectEnumHandle
 	    res != TEE_ERROR_ITEM_NOT_FOUND &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -658,7 +658,7 @@ out:
 	    res != TEE_ERROR_ITEM_NOT_FOUND &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -685,7 +685,7 @@ out:
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -713,7 +713,7 @@ out:
 	    res != TEE_ERROR_OVERFLOW &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -734,7 +734,7 @@ out:
 	    res != TEE_ERROR_STORAGE_NO_SPACE &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -791,7 +791,7 @@ out:
 	    res != TEE_ERROR_OVERFLOW &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -346,7 +346,7 @@ out:
 	if (res != TEE_SUCCESS) {
 		if (res != TEE_ERROR_OUT_OF_MEMORY &&
 		    res != TEE_ERROR_NOT_SUPPORTED)
-			TEE_Panic(0);
+			TEE_Panic(res);
 		if (op) {
 			if (op->state) {
 				TEE_FreeOperation(op);
@@ -376,7 +376,7 @@ void TEE_FreeOperation(TEE_OperationHandle operation)
 	 */
 	res = utee_cryp_state_free(operation->state);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	TEE_Free(operation->buffer);
 	TEE_Free(operation);
@@ -485,7 +485,7 @@ TEE_Result TEE_GetOperationInfoMultiple(TEE_OperationHandle operation,
 out:
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_SHORT_BUFFER)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -583,7 +583,7 @@ out:
 	if (res != TEE_SUCCESS  &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -708,7 +708,7 @@ out:
 	    res != TEE_ERROR_CORRUPT_OBJECT_2 &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE &&
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE_2)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -823,7 +823,7 @@ TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, void *chunk,
 out:
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_SHORT_BUFFER)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -1019,7 +1019,7 @@ TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, void *srcData,
 out:
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_SHORT_BUFFER)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -1111,7 +1111,7 @@ TEE_Result TEE_CipherDoFinal(TEE_OperationHandle operation,
 out:
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_SHORT_BUFFER)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	return res;
 }
@@ -1729,7 +1729,7 @@ void TEE_DeriveKey(TEE_OperationHandle operation,
 
 	res = utee_cryp_obj_get_info((unsigned long)derivedKey, &key_info);
 	if (res != TEE_SUCCESS)
-		TEE_Panic(0);
+		TEE_Panic(res);
 
 	if (key_info.objectType != TEE_TYPE_GENERIC_SECRET)
 		TEE_Panic(0);


### PR DESCRIPTION
On many occasions, libutee calls TEE_Panic(0) to kill a TA. When an
error status from a lower layer is available, it is much more helpful
to pass it instead of zero, because the code is shown in the debug
traces.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>