### PR TITLE
core: RPMB FS: nullify fops when resetting an enumerator

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -128,10 +128,9 @@ static TEE_Result tee_svc_close_enum(struct user_ta_ctx *utc,
 
 	TAILQ_REMOVE(&utc->storage_enums, e, link);
 
-	if (!e->fops)
-		return TEE_ERROR_ITEM_NOT_FOUND;
+	if (e->fops)
+		e->fops->closedir(e->dir);
 
-	e->fops->closedir(e->dir);
 	e->dir = NULL;
 	e->fops = NULL;
 
@@ -845,6 +844,7 @@ TEE_Result syscall_storage_reset_enum(unsigned long obj_enum)
 		return res;
 
 	e->fops->closedir(e->dir);
+	e->fops = NULL;
 	e->dir = NULL;
 
 	return TEE_SUCCESS;


### PR DESCRIPTION
According to the GP spec, TEE_ResetPersistentObjectEnumerator() "resets
an object enumerator handle to its initial state after allocation".
Therefore, syscall_storage_reset_enum() should set e->fops = NULL.

This fixes a regression introduced when the FOP interface was reworked.
I'm not simply reverting the return code from TEE_ERROR_GENERIC back to
TEE_ERROR_ITEM_NOT_FOUND, because the new code makes sense and it is
more sane to properly reset the state of the enumerator.

Consequently, tee_svc_close_enum() is updated to accept e->fops == NULL
which is valid when the enum has just been allocated or reset but not
started. We should not return an error status in this case.

Tested on HiKey using xtest with GP tests (all 3 filesystems: REE, SQL,
RPMB).

Fixes: b86c18ecc7d3 ("core: RPMB FS: prepare for new FOP interface")
Fixes: https://github.com/OP-TEE/optee_os/issues/1332
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>