### PR TITLE
core: fix parameters type reference in SVC parameters update

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -716,7 +716,7 @@ static TEE_Result tee_svc_update_out_param(
 	bool have_private_mem_map = is_user_ta_ctx(called_sess->ctx);
 
 	for (n = 0; n < TEE_NUM_PARAMS; n++) {
-		switch (TEE_PARAM_TYPE_GET(param->types, n)) {
+		switch (TEE_PARAM_TYPE_GET(usr_param->types, n)) {
 		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
 		case TEE_PARAM_TYPE_MEMREF_INOUT:
 			p = (void *)(uintptr_t)usr_param->vals[n * 2];


### PR DESCRIPTION
After a TA is invoked, callee parameters are updated according
to called TA return status and parameter types.
tee_svc_update_out_param() should rather rely on the parameter
"type" value provided by callee TA rather than the "type" value
returned by called TA.

I found this issue (at least i belive it is) while looking at https://github.com/OP-TEE/optee_os/issues/1323. Howeveer, this change does not fix any "xtest" issue already reported.