### PR TITLE
fix build issue

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -220,8 +220,12 @@ $(link-out-dir)/tee.bin: $(link-out-dir)/tee-pager.bin \
 	$(q)./scripts/gen_hashed_bin.py \
 		--arch $(if $(filter y,$(CFG_ARM64_core)),arm64,arm32) \
 		--init_size `cat $(link-out-dir)/tee-init_size.txt` \
+		--init_load_addr_hi \
+			`cat $(link-out-dir)/tee-init_load_addr.txt | \
+			${AWK} '{printf("0x%x\n",rshift(strtonum($$0),32))}'` \
 		--init_load_addr_lo \
-			`cat $(link-out-dir)/tee-init_load_addr.txt` \
+			`cat $(link-out-dir)/tee-init_load_addr.txt | \
+			${AWK} '{printf("0x%x\n",and(strtonum($$0),0xffffffff))}'` \
 		--init_mem_usage `cat $(link-out-dir)/tee-init_mem_usage.txt` \
 		--tee_pager_bin $(link-out-dir)/tee-pager.bin \
 		--tee_pageable_bin $(link-out-dir)/tee-pageable.bin \


### PR DESCRIPTION
If tee-init_load_addr is higher than 0xffffffff. building failed with:

```bash
Traceback (most recent call last):
  File "./scripts/gen_hashed_bin.py", line 148, in <module>
    main()
  File "./scripts/gen_hashed_bin.py", line 132, in main
    write_header(outf, 0, args, 0)
  File "./scripts/gen_hashed_bin.py", line 44, in write_header
    args.init_mem_usage, paged_size))
struct.error: 'I' format requires 0 <= number <= 4294967295
make: *** [out/arm-plat-vexpress/core/tee.bin] Error 1
make: Leaving directory `/home/zh/work/github/optee_os'
```

Signed-off-by: Zhizhou Zhang <zhizhouzhang@asrmicro.com>