### PR TITLE
make clean: don't fail on non-empty directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,9 @@ include mk/cleandirs.mk
 clean:
 	@$(cmd-echo-silent) '  CLEAN   $(out-dir)'
 	${q}rm -f $(cleanfiles)
-	${q}dirs="$(call cleandirs-for-rmdir)"; if [ "$$dirs" ]; then rmdir $$dirs; fi
+	${q}dirs="$(call cleandirs-for-rmdir)"; if [ "$$dirs" ]; then $(RMDIR) $$dirs; fi
 	@if [ "$(out-dir)" != "$(O)" ]; then $(cmd-echo-silent) '  CLEAN   $(O)'; fi
-	${q}if [ -d "$(O)" ]; then rmdir --ignore-fail-on-non-empty $(O); fi
+	${q}if [ -d "$(O)" ]; then $(RMDIR) $(O); fi
 
 .PHONY: cscope
 cscope:

--- a/mk/cleandirs.mk
+++ b/mk/cleandirs.mk
@@ -24,3 +24,5 @@ $(eval _O:=$(if $(O),$(O),.))$(wildcard $(addprefix $(_O)/,$(call _reverse,
 	$(sort $(foreach d,$(patsubst $(_O)/%,%,$(dir $(cleanfiles))),
 			   $(call enum-parent-dirs,$(d)))))))
 endef
+
+RMDIR := rmdir --ignore-fail-on-non-empty

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -74,9 +74,9 @@ include $(ta-dev-kit-dir)/mk/cleandirs.mk
 clean:
 	@$(cmd-echo-silent) '  CLEAN   $(out-dir)'
 	${q}rm -f $(cleanfiles)
-	${q}dirs="$(call cleandirs-for-rmdir)"; if [ "$$dirs" ]; then rmdir $$dirs; fi
+	${q}dirs="$(call cleandirs-for-rmdir)"; if [ "$$dirs" ]; then $(RMDIR) $$dirs; fi
 	@$(cmd-echo-silent) '  CLEAN   $(O)'
-	${q}if [ -d "$(O)" ]; then rmdir --ignore-fail-on-non-empty $(O); fi
+	${q}if [ -d "$(O)" ]; then $(RMDIR) $(O); fi
 
 subdirs = .
 include  $(ta-dev-kit-dir)/mk/subdir.mk


### PR DESCRIPTION
"make clean" may report errors when trying to clean with different
configuration values than the ones used during the build. For instance:

$ make -s CFG_RPMB_FS=y
$ make clean
  CLEAN   out/arm-plat-vexpress
rmdir: failed to remove 'out/arm-plat-vexpress/core/tee': Directory not empty
rmdir: failed to remove 'out/arm-plat-vexpress/core': Directory not empty
rmdir: failed to remove 'out/arm-plat-vexpress': Directory not empty
Makefile:88: recipe for target 'clean' failed
make: *** [clean] Error 1

The clean command should not fail, since the build tree was properly
cleaned for the requested configuration. Fix this by using
'rmdir --ignore-fail-on-non-empty'.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>