### PR TITLE
fixes for extending va to 64-bit

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -2,6 +2,7 @@ CFG_LTC_OPTEE_THREAD ?= y
 # Size of emulated TrustZone protected SRAM, 300 kB.
 # Only applicable when paging is enabled.
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 307200
+CFG_LPAE_ADDR_SPACE_SIZE ?= (1ull << 32)
 
 ifeq ($(CFG_ARM64_core),y)
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -215,7 +215,7 @@ END_FUNC unhandled_cpu
 	  .endif
 	.endm
 
-	.align	7
+	.align	11
 LOCAL_FUNC reset_vect_table , :
 	/* -----------------------------------------------------
 	 * Current EL with SP0 : 0x0 - 0x180

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -590,7 +590,7 @@ static void *map_pa2va(struct tee_mmap_region *map, paddr_t pa)
 	if (!pa_is_in_map(map, pa))
 		return NULL;
 	return (void *)((pa & (map->region_size - 1)) |
-		(((map->va + pa - map->pa)) & ~(map->region_size - 1)));
+		((map->va + pa - map->pa) & ~((vaddr_t)map->region_size - 1)));
 }
 
 /*

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -168,11 +168,9 @@
 #define L1_XLAT_ADDRESS_SHIFT	(L2_XLAT_ADDRESS_SHIFT + \
 				 XLAT_TABLE_ENTRIES_SHIFT)
 
-
-
-#define ADDR_SPACE_SIZE		(1ull << 32)
 #define MAX_MMAP_REGIONS	16
-#define NUM_L1_ENTRIES		(ADDR_SPACE_SIZE >> L1_XLAT_ADDRESS_SHIFT)
+#define NUM_L1_ENTRIES		\
+		(CFG_LPAE_ADDR_SPACE_SIZE >> L1_XLAT_ADDRESS_SHIFT)
 
 #ifndef MAX_XLAT_TABLES
 #define MAX_XLAT_TABLES		5
@@ -491,8 +489,8 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 	assert(user_va_idx != -1);
 
 	tcr_ps_bits = calc_physical_addr_size_bits(max_pa);
-	COMPILE_TIME_ASSERT(ADDR_SPACE_SIZE > 0);
-	assert(max_va < ADDR_SPACE_SIZE);
+	COMPILE_TIME_ASSERT(CFG_LPAE_ADDR_SPACE_SIZE > 0);
+	assert(max_va < CFG_LPAE_ADDR_SPACE_SIZE);
 }
 
 bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
@@ -549,7 +547,7 @@ void core_init_mmu_regs(void)
 	tcr |= TCR_XRGNX_WBWA << TCR_ORGN0_SHIFT;
 	tcr |= TCR_SHX_ISH << TCR_SH0_SHIFT;
 	tcr |= tcr_ps_bits << TCR_EL1_IPS_SHIFT;
-	tcr |= 64 - __builtin_ctzl(ADDR_SPACE_SIZE);
+	tcr |= 64 - __builtin_ctzl(CFG_LPAE_ADDR_SPACE_SIZE);
 
 	/* Disable the use of TTBR1 */
 	tcr |= TCR_EPD1;


### PR DESCRIPTION
There is still a problem I didn't fix here. In `find_session`, `id` is `uint32_t`, but it's compared to a point. I'm not sure how to fix it. I just cut the high part of `s`. as shown below:

```
diff --git a/core/kernel/tee_ta_manager.c b/core/kernel/tee_ta_manager.c
index c0c4545..1faad7b 100644
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -176,7 +176,7 @@ static struct tee_ta_session *find_session(uint32_t id,
        struct tee_ta_session *s;
 
        TAILQ_FOREACH(s, open_sessions, link) {
-               if ((vaddr_t)s == id)
+               if ((unsigned)(vaddr_t)s == id)
                        return s;
        }
        return NULL;

```