### PR TITLE
Refactor spinlock && exception masking usage, add locking to tee_mm.c

### DIFF
--- a/core/arch/arm/include/kernel/spinlock.h
+++ b/core/arch/arm/include/kernel/spinlock.h
@@ -81,6 +81,21 @@ static inline void cpu_spin_unlock(unsigned int *lock)
 	__cpu_spin_unlock(lock);
 	spinlock_count_decr();
 }
+
+static inline uint32_t cpu_spin_lock_xsave(unsigned int *lock)
+{
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+
+	cpu_spin_lock(lock);
+	return exceptions;
+}
+
+static inline void cpu_spin_unlock_xrestore(unsigned int *lock,
+					    uint32_t exceptions)
+{
+	cpu_spin_unlock(lock);
+	thread_unmask_exceptions(exceptions);
+}
 #endif /* ASM */
 
 #endif /* KERNEL_SPINLOCK_H */

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -26,6 +26,7 @@
  */
 
 #include <kernel/panic.h>
+#include <kernel/spinlock.h>
 #include <kernel/tee_common.h>
 #include <util.h>
 #include <trace.h>
@@ -57,6 +58,7 @@ bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_t hi, uint8_t shift,
 	if (pool->flags & TEE_MM_POOL_HI_ALLOC)
 		pool->entry->offset = ((hi - lo - 1) >> shift) + 1;
 	pool->entry->pool = pool;
+	pool->lock = SPINLOCK_UNLOCK;
 
 	return true;
 }
@@ -72,23 +74,11 @@ void tee_mm_final(tee_mm_pool_t *pool)
 	pool->entry = NULL;
 }
 
-static tee_mm_entry_t *tee_mm_add(tee_mm_entry_t *p)
+static void tee_mm_add(tee_mm_entry_t *p, tee_mm_entry_t *nn)
 {
 	/* add to list */
-	if (p->next == NULL) {
-		p->next = malloc(sizeof(tee_mm_entry_t));
-		if (p->next == NULL)
-			return NULL;
-		p->next->next = NULL;
-	} else {
-		tee_mm_entry_t *nn = malloc(sizeof(tee_mm_entry_t));
-
-		if (nn == NULL)
-			return NULL;
-		nn->next = p->next;
-		p->next = nn;
-	}
-	return p->next;
+	nn->next = p->next;
+	p->next = nn;
 }
 
 #ifdef CFG_WITH_STATS
@@ -112,7 +102,14 @@ static size_t tee_mm_stats_allocated(tee_mm_pool_t *pool)
 void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct malloc_stats *stats,
 			   bool reset)
 {
+	uint32_t exceptions;
+
+	if (!pool)
+		return;
+
 	memset(stats, 0, sizeof(*stats));
+
+	exceptions = cpu_spin_lock_xsave(&pool->lock);
 
 	stats->size = pool->hi - pool->lo;
 	stats->max_allocated = pool->max_allocated;
@@ -120,6 +117,7 @@ void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct malloc_stats *stats,
 
 	if (reset)
 		pool->max_allocated = 0;
+	cpu_spin_unlock_xrestore(&pool->lock, exceptions);
 }
 
 static void update_max_allocated(tee_mm_pool_t *pool)
@@ -141,17 +139,23 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, size_t size)
 	tee_mm_entry_t *entry;
 	tee_mm_entry_t *nn;
 	size_t remaining;
+	uint32_t exceptions;
 
 	/* Check that pool is initialized */
 	if (!pool || !pool->entry)
 		return NULL;
+
+	nn = malloc(sizeof(tee_mm_entry_t));
+	if (!nn)
+		return NULL;
+
+	exceptions = cpu_spin_lock_xsave(&pool->lock);
 
 	entry = pool->entry;
 	if (size == 0)
 		psize = 0;
 	else
 		psize = ((size - 1) >> pool->shift) + 1;
-	/* Protect with mutex (multi thread) */
 
 	/* find free slot */
 	if (pool->flags & TEE_MM_POOL_HI_ALLOC) {
@@ -177,9 +181,10 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, size_t size)
 			 * validate there is sufficient memory validate that
 			 * (entry->offset << pool->shift) > size.
 			 */
-			if ((entry->offset << pool->shift) < size)
+			if ((entry->offset << pool->shift) < size) {
 				/* out of memory */
-				return NULL;
+				goto err;
+			}
 		} else {
 			if (pool->hi <= pool->lo)
 				panic("invalid pool");
@@ -188,15 +193,14 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, size_t size)
 			remaining -= ((entry->offset + entry->size) <<
 				      pool->shift);
 
-			if (remaining < size)
+			if (remaining < size) {
 				/* out of memory */
-				return NULL;
+				goto err;
+			}
 		}
 	}
 
-	nn = tee_mm_add(entry);
-	if (nn == NULL)
-		return NULL;
+	tee_mm_add(entry, nn);
 
 	if (pool->flags & TEE_MM_POOL_HI_ALLOC)
 		nn->offset = entry->offset - psize;
@@ -207,9 +211,12 @@ tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, size_t size)
 
 	update_max_allocated(pool);
 
-	/* Protect with mutex end (multi thread) */
-
+	cpu_spin_unlock_xrestore(&pool->lock, exceptions);
 	return nn;
+err:
+	cpu_spin_unlock_xrestore(&pool->lock, exceptions);
+	free(nn);
+	return NULL;
 }
 
 static inline bool fit_in_gap(tee_mm_pool_t *pool, tee_mm_entry_t *e,
@@ -239,6 +246,7 @@ tee_mm_entry_t *tee_mm_alloc2(tee_mm_pool_t *pool, paddr_t base, size_t size)
 	paddr_t offslo;
 	paddr_t offshi;
 	tee_mm_entry_t *mm;
+	uint32_t exceptions;
 
 	/* Check that pool is initialized */
 	if (!pool || !pool->entry)
@@ -247,6 +255,12 @@ tee_mm_entry_t *tee_mm_alloc2(tee_mm_pool_t *pool, paddr_t base, size_t size)
 	/* Wrapping and sanity check */
 	if ((base + size) < base || base < pool->lo)
 		return NULL;
+
+	mm = malloc(sizeof(tee_mm_entry_t));
+	if (!mm)
+		return NULL;
+
+	exceptions = cpu_spin_lock_xsave(&pool->lock);
 
 	entry = pool->entry;
 	offslo = (base - pool->lo) >> pool->shift;
@@ -264,31 +278,33 @@ tee_mm_entry_t *tee_mm_alloc2(tee_mm_pool_t *pool, paddr_t base, size_t size)
 
 	/* Check that memory is available */
 	if (!fit_in_gap(pool, entry, offslo, offshi))
-		return NULL;
+		goto err;
 
-	mm = tee_mm_add(entry);
-	if (mm == NULL)
-		return NULL;
+	tee_mm_add(entry, mm);
 
 	mm->offset = offslo;
 	mm->size = offshi - offslo;
 	mm->pool = pool;
 
 	update_max_allocated(pool);
-
+	cpu_spin_unlock_xrestore(&pool->lock, exceptions);
 	return mm;
+err:
+	cpu_spin_unlock_xrestore(&pool->lock, exceptions);
+	free(mm);
+	return NULL;
 }
 
 void tee_mm_free(tee_mm_entry_t *p)
 {
 	tee_mm_entry_t *entry;
+	uint32_t exceptions;
 
 	if (!p || !p->pool)
 		return;
 
+	exceptions = cpu_spin_lock_xsave(&p->pool->lock);
 	entry = p->pool->entry;
-
-	/* Protect with mutex (multi thread) */
 
 	/* remove entry from list */
 	while (entry->next != NULL && entry->next != p)
@@ -298,10 +314,9 @@ void tee_mm_free(tee_mm_entry_t *p)
 		panic("invalid mm_entry");
 
 	entry->next = entry->next->next;
+	cpu_spin_unlock_xrestore(&p->pool->lock, exceptions);
 
 	free(p);
-
-	/* Protect with mutex end (multi thread) */
 }
 
 size_t tee_mm_get_bytes(const tee_mm_entry_t *mm)
@@ -319,7 +334,17 @@ bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, paddr_t addr)
 
 bool tee_mm_is_empty(tee_mm_pool_t *pool)
 {
-	return pool == NULL || pool->entry == NULL || pool->entry->next == NULL;
+	bool ret;
+	uint32_t exceptions;
+
+	if (pool == NULL || pool->entry == NULL)
+		return true;
+
+	exceptions = cpu_spin_lock_xsave(&pool->lock);
+	ret = pool->entry == NULL || pool->entry->next == NULL;
+	cpu_spin_unlock_xrestore(&pool->lock, exceptions);
+
+	return ret;
 }
 
 /* Physical Secure DDR pool */
@@ -332,19 +357,25 @@ tee_mm_entry_t *tee_mm_find(const tee_mm_pool_t *pool, paddr_t addr)
 {
 	tee_mm_entry_t *entry = pool->entry;
 	uint16_t offset = (addr - pool->lo) >> pool->shift;
+	uint32_t exceptions;
 
 	if (addr > pool->hi || addr < pool->lo)
 		return NULL;
+
+	exceptions = cpu_spin_lock_xsave(&((tee_mm_pool_t *)pool)->lock);
 
 	while (entry->next != NULL) {
 		entry = entry->next;
 
 		if ((offset >= entry->offset) &&
 		    (offset < (entry->offset + entry->size))) {
+			cpu_spin_unlock_xrestore(&((tee_mm_pool_t *)pool)->lock,
+						 exceptions);
 			return entry;
 		}
 	}
 
+	cpu_spin_unlock_xrestore(&((tee_mm_pool_t *)pool)->lock, exceptions);
 	return NULL;
 }
 

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -190,16 +190,12 @@ static uintptr_t pager_alias_next_free;
 
 static uint32_t pager_lock(void)
 {
-	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
-
-	cpu_spin_lock(&pager_spinlock);
-	return exceptions;
+	return cpu_spin_lock_xsave(&pager_spinlock);
 }
 
 static void pager_unlock(uint32_t exceptions)
 {
-	cpu_spin_unlock(&pager_spinlock);
-	thread_set_exceptions(exceptions);
+	cpu_spin_unlock_xrestore(&pager_spinlock, exceptions);
 }
 
 static void set_alias_area(tee_mm_entry_t *mm)

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -50,6 +50,7 @@ struct _tee_mm_pool_t {
 	paddr_t hi;		/* high boundary of the pool */
 	uint32_t flags;		/* Config flags for the pool */
 	uint8_t shift;		/* size shift */
+	unsigned int lock;
 #ifdef CFG_WITH_STATS
 	size_t max_allocated;
 #endif

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -115,18 +115,12 @@
 
 static uint32_t malloc_lock(void)
 {
-	uint32_t exceptions;
-
-	exceptions = thread_mask_exceptions(
-			THREAD_EXCP_NATIVE_INTR | THREAD_EXCP_FOREIGN_INTR);
-	cpu_spin_lock(&__malloc_spinlock);
-	return exceptions;
+	return cpu_spin_lock_xsave(&__malloc_spinlock);
 }
 
 static void malloc_unlock(uint32_t exceptions)
 {
-	cpu_spin_unlock(&__malloc_spinlock);
-	thread_unmask_exceptions(exceptions);
+	cpu_spin_unlock_xrestore(&__malloc_spinlock, exceptions);
 }
 
 static void tag_asan_free(void *buf, size_t len)


### PR DESCRIPTION
There are two patches in this PR:

- First one just eases up spinlock usage.
- Second one fixes race condition in tee_mm.c

I have spotted this race condition during shmem mobj implementation. 
At first I wanted to add `tee_mm_lock()` and `tee_mm_unlock()` pair of functions. But I don't think this is best approach, because we already have (and there will be more) such pairs in different modules. 

So I decided to implement generic functions. 