### PR TITLE
Allow Pseudo TAs to define their TA property flags

### DIFF
--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -31,11 +31,20 @@
 #include <compiler.h>
 #include <kernel/tee_ta_manager.h>
 #include <tee_api_types.h>
+#include <user_ta_header.h>
 #include <util.h>
+
+#define PTA_MANDATORY_FLAGS	(TA_FLAG_SINGLE_INSTANCE | \
+				TA_FLAG_MULTI_SESSION | \
+				TA_FLAG_INSTANCE_KEEP_ALIVE)
+
+#define PTA_ALLOWED_FLAGS	PTA_MANDATORY_FLAGS
+#define PTA_DEFAULT_FLAGS	PTA_MANDATORY_FLAGS
 
 struct pseudo_ta_head {
 	TEE_UUID uuid;
 	const char *name;
+	uint32_t flags;
 
 	TEE_Result (*create_entry_point)(void);
 	void (*destroy_entry_point)(void);

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -180,15 +180,6 @@ static TEE_Result gprof_stop_pc_sampling(struct tee_ta_session *s,
  * Trusted Application Entry Points
  */
 
-static TEE_Result create_ta(void)
-{
-	return TEE_SUCCESS;
-}
-
-static void destroy_ta(void)
-{
-}
-
 static TEE_Result open_session(uint32_t param_types __unused,
 			       TEE_Param params[TEE_NUM_PARAMS] __unused,
 			       void **sess_ctx __unused)
@@ -203,10 +194,6 @@ static TEE_Result open_session(uint32_t param_types __unused,
 		return TEE_ERROR_ACCESS_DENIED;
 
 	return TEE_SUCCESS;
-}
-
-static void close_session(void *sess_ctx __unused)
-{
 }
 
 static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
@@ -230,8 +217,5 @@ static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
 
 pseudo_ta_register(.uuid = PTA_GPROF_UUID, .name = "gprof",
 		   .flags = PTA_DEFAULT_FLAGS,
-		   .create_entry_point = create_ta,
-		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,
-		   .close_session_entry_point = close_session,
 		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -229,6 +229,7 @@ static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
 }
 
 pseudo_ta_register(.uuid = PTA_GPROF_UUID, .name = "gprof",
+		   .flags = PTA_DEFAULT_FLAGS,
 		   .create_entry_point = create_ta,
 		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,

--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -255,6 +255,7 @@ static TEE_Result invoke_command(void *psess __unused,
 }
 
 pseudo_ta_register(.uuid = INTERRUPT_TESTS_UUID, .name = TA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
 		   .create_entry_point = create_ta,
 		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,

--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -63,26 +63,6 @@
  * Trusted Application Entry Points
  */
 
-static TEE_Result create_ta(void)
-{
-	return TEE_SUCCESS;
-}
-
-static void destroy_ta(void)
-{
-}
-
-static TEE_Result open_session(uint32_t ptype __unused,
-			       TEE_Param params[4] __unused,
-			       void **ppsess __unused)
-{
-	return TEE_SUCCESS;
-}
-
-static void close_session(void *psess __unused)
-{
-}
-
 static size_t test_sgi_value[CFG_TEE_CORE_NB_CORE];
 static size_t test_spi_value[CFG_TEE_CORE_NB_CORE];
 static size_t test_ppi_value[CFG_TEE_CORE_NB_CORE];
@@ -256,8 +236,4 @@ static TEE_Result invoke_command(void *psess __unused,
 
 pseudo_ta_register(.uuid = INTERRUPT_TESTS_UUID, .name = TA_NAME,
 		   .flags = PTA_DEFAULT_FLAGS,
-		   .create_entry_point = create_ta,
-		   .destroy_entry_point = destroy_ta,
-		   .open_session_entry_point = open_session,
-		   .close_session_entry_point = close_session,
 		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/pta/pta_self_tests.c
+++ b/core/arch/arm/pta/pta_self_tests.c
@@ -45,7 +45,7 @@
 static TEE_Result test_trace(uint32_t param_types __unused,
 			TEE_Param params[TEE_NUM_PARAMS] __unused)
 {
-	IMSG("static TA \"%s\" says \"Hello world !\"", TA_NAME);
+	IMSG("pseudo TA \"%s\" says \"Hello world !\"", TA_NAME);
 
 	return TEE_SUCCESS;
 }
@@ -201,33 +201,33 @@ static TEE_Result test_entry_params(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 
 static TEE_Result create_ta(void)
 {
-	DMSG("create entry point for static ta \"%s\"", TA_NAME);
+	DMSG("create entry point for pseudo TA \"%s\"", TA_NAME);
 	return TEE_SUCCESS;
 }
 
 static void destroy_ta(void)
 {
-	DMSG("destroy entry point for static ta \"%s\"", TA_NAME);
+	DMSG("destroy entry point for pseudo ta \"%s\"", TA_NAME);
 }
 
 static TEE_Result open_session(uint32_t nParamTypes __unused,
 		TEE_Param pParams[TEE_NUM_PARAMS] __unused,
 		void **ppSessionContext __unused)
 {
-	DMSG("open entry point for static ta \"%s\"", TA_NAME);
+	DMSG("open entry point for pseudo ta \"%s\"", TA_NAME);
 	return TEE_SUCCESS;
 }
 
 static void close_session(void *pSessionContext __unused)
 {
-	DMSG("close entry point for static ta \"%s\"", TA_NAME);
+	DMSG("close entry point for pseudo ta \"%s\"", TA_NAME);
 }
 
 static TEE_Result invoke_command(void *pSessionContext __unused,
 		uint32_t nCommandID, uint32_t nParamTypes,
 		TEE_Param pParams[TEE_NUM_PARAMS])
 {
-	DMSG("command entry point for static ta \"%s\"", TA_NAME);
+	DMSG("command entry point for pseudo ta \"%s\"", TA_NAME);
 
 	switch (nCommandID) {
 	case CMD_TRACE:

--- a/core/arch/arm/pta/pta_self_tests.c
+++ b/core/arch/arm/pta/pta_self_tests.c
@@ -243,6 +243,7 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 }
 
 pseudo_ta_register(.uuid = STA_SELF_TEST_UUID, .name = TA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
 		   .create_entry_point = create_ta,
 		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,

--- a/core/arch/arm/pta/se_api_self_tests.c
+++ b/core/arch/arm/pta/se_api_self_tests.c
@@ -77,30 +77,6 @@
  * Trusted Application Entry Points
  */
 
-static TEE_Result create_ta(void)
-{
-	DMSG("create entry point for static ta \"%s\"", TA_NAME);
-	return TEE_SUCCESS;
-}
-
-static void destroy_ta(void)
-{
-	DMSG("destroy entry point for static ta \"%s\"", TA_NAME);
-}
-
-static TEE_Result open_session(uint32_t nParamTypes __unused,
-		TEE_Param pParams[TEE_NUM_PARAMS] __unused,
-		void **ppSessionContext __unused)
-{
-	DMSG("open entry point for static ta \"%s\"", TA_NAME);
-	return TEE_SUCCESS;
-}
-
-static void close_session(void *pSessionContext __unused)
-{
-	DMSG("close entry point for static ta \"%s\"", TA_NAME);
-}
-
 static TEE_Result test_reader(struct tee_se_reader_proxy **handle)
 {
 	TEE_Result ret;
@@ -519,8 +495,4 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 
 pseudo_ta_register(.uuid = SE_API_SELF_TEST_UUID, .name = TA_NAME,
 		   .flags = PTA_DEFAULT_FLAGS,
-		   .create_entry_point = create_ta,
-		   .destroy_entry_point = destroy_ta,
-		   .open_session_entry_point = open_session,
-		   .close_session_entry_point = close_session,
 		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/pta/se_api_self_tests.c
+++ b/core/arch/arm/pta/se_api_self_tests.c
@@ -518,6 +518,7 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 }
 
 pseudo_ta_register(.uuid = SE_API_SELF_TEST_UUID, .name = TA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
 		   .create_entry_point = create_ta,
 		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,

--- a/core/arch/arm/pta/stats.c
+++ b/core/arch/arm/pta/stats.c
@@ -141,26 +141,6 @@ static TEE_Result get_pager_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
  * Trusted Application Entry Points
  */
 
-static TEE_Result create_ta(void)
-{
-	return TEE_SUCCESS;
-}
-
-static void destroy_ta(void)
-{
-}
-
-static TEE_Result open_session(uint32_t ptype __unused,
-			       TEE_Param params[TEE_NUM_PARAMS] __unused,
-			       void **ppsess __unused)
-{
-	return TEE_SUCCESS;
-}
-
-static void close_session(void *psess __unused)
-{
-}
-
 static TEE_Result invoke_command(void *psess __unused,
 				 uint32_t cmd, uint32_t ptypes,
 				 TEE_Param params[TEE_NUM_PARAMS])
@@ -178,8 +158,4 @@ static TEE_Result invoke_command(void *psess __unused,
 
 pseudo_ta_register(.uuid = STATS_UUID, .name = TA_NAME,
 		   .flags = PTA_DEFAULT_FLAGS,
-		   .create_entry_point = create_ta,
-		   .destroy_entry_point = destroy_ta,
-		   .open_session_entry_point = open_session,
-		   .close_session_entry_point = close_session,
 		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/pta/stats.c
+++ b/core/arch/arm/pta/stats.c
@@ -177,6 +177,7 @@ static TEE_Result invoke_command(void *psess __unused,
 }
 
 pseudo_ta_register(.uuid = STATS_UUID, .name = TA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
 		   .create_entry_point = create_ta,
 		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,

--- a/core/arch/arm/pta/tee_fs_key_manager_tests.c
+++ b/core/arch/arm/pta/tee_fs_key_manager_tests.c
@@ -87,31 +87,6 @@ static void print_hex(uint8_t *input_buf, size_t input_size)
  * Trusted Application Entry Points
  */
 
-static TEE_Result create_ta(void)
-{
-	DMSG("create entry point for static ta \"%s\"", TA_NAME);
-	return TEE_SUCCESS;
-}
-
-static void destroy_ta(void)
-{
-	DMSG("destroy entry point for static ta \"%s\"", TA_NAME);
-}
-
-static TEE_Result open_session(uint32_t nParamTypes __unused,
-		TEE_Param pParams[TEE_NUM_PARAMS] __unused,
-		void **ppSessionContext __unused)
-{
-	DMSG("open entry point for static ta \"%s\"", TA_NAME);
-	return TEE_SUCCESS;
-}
-
-static void close_session(void *pSessionContext __unused)
-{
-	DMSG("close entry point for static ta \"%s\"", TA_NAME);
-}
-
-
 static TEE_Result test_file_decrypt_with_invalid_content(void)
 {
 	TEE_Result res = TEE_SUCCESS;
@@ -397,8 +372,4 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 
 pseudo_ta_register(.uuid = ENC_FS_KEY_MANAGER_TEST_UUID, .name = TA_NAME,
 		   .flags = PTA_DEFAULT_FLAGS,
-		   .create_entry_point = create_ta,
-		   .destroy_entry_point = destroy_ta,
-		   .open_session_entry_point = open_session,
-		   .close_session_entry_point = close_session,
 		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/pta/tee_fs_key_manager_tests.c
+++ b/core/arch/arm/pta/tee_fs_key_manager_tests.c
@@ -396,6 +396,7 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 }
 
 pseudo_ta_register(.uuid = ENC_FS_KEY_MANAGER_TEST_UUID, .name = TA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
 		   .create_entry_point = create_ta,
 		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,


### PR DESCRIPTION
As part of the Secure Data Path, pseudo TAs may need to access SDP memory buffers using the memory reference provided as invocation parameters by their client.
As most pseudo TAs are likely to be not much interested with the SDP feature, these change aims at allowing pseudo TA to declare to OP-TEE core whether or not they do handle SDP memory references (and the several related constraints). Only such TAs will be able to be invoked with SDP memref parameters.

This PR does not talk about SDP. It proposes pseduo TA features that will be required for the SDP support intergration (https://github.com/OP-TEE/optee_os/pull/1322).
