### PR TITLE
core: arm: trace: make the trace output atomic

### DIFF
--- a/core/arch/arm/kernel/trace_ext.c
+++ b/core/arch/arm/kernel/trace_ext.c
@@ -27,21 +27,40 @@
 #include <stdbool.h>
 #include <trace.h>
 #include <console.h>
+#include <kernel/spinlock.h>
 #include <kernel/thread.h>
+#include <mm/core_mmu.h>
 
 const char trace_ext_prefix[] = "TEE-CORE";
 int trace_level = TRACE_LEVEL;
+static unsigned int puts_lock = SPINLOCK_UNLOCK;
 
 void trace_ext_puts(const char *str)
 {
+	uint32_t itr_status = thread_mask_exceptions(THREAD_EXCP_ALL);
+	bool mmu_enabled = cpu_mmu_enabled();
+	bool was_contended = false;
 	const char *p;
 
+	if (mmu_enabled && !cpu_spin_trylock(&puts_lock)) {
+		was_contended = true;
+		cpu_spin_lock(&puts_lock);
+	}
+
 	console_flush();
+
+	if (was_contended)
+		console_putc('*');
 
 	for (p = str; *p; p++)
 		console_putc(*p);
 
 	console_flush();
+
+	if (mmu_enabled)
+		cpu_spin_unlock(&puts_lock);
+
+	thread_unmask_exceptions(itr_status);
 }
 
 int trace_ext_get_thread_id(void)


### PR DESCRIPTION
Use spinlock to make the trace output atomic.
On SMP cores, different cores may puts out log
to uart. If there is no lock, the log will be a mess.

Signed-off-by: Peng Fan `<peng.fan@nxp.com>`