### PR TITLE
core: arm: sm: fix psci reset

### DIFF
--- a/core/arch/arm/sm/psci.c
+++ b/core/arch/arm/sm/psci.c
@@ -149,7 +149,7 @@ void tee_psci_handler(struct thread_smc_args *args)
 			;
 		break;
 	case PSCI_SYSTEM_RESET:
-		psci_system_off();
+		psci_system_reset();
 		while (1)
 			;
 		break;


### PR DESCRIPTION
Fix psci reset entry.
Drop the dead loop. When reset fails, need to back to Linux.
