### PR TITLE
core: prng: Don't try to read REE time when it's not possible

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1199,7 +1199,7 @@ static uint32_t rpc_cmd_nolock(uint32_t cmd, size_t num_params,
 
 	assert(arg && carg && num_params <= THREAD_RPC_MAX_NUM_PARAMS);
 
-	plat_prng_add_jitter_entropy();
+	plat_prng_add_jitter_entropy_norpc();
 
 	memset(arg, 0, OPTEE_MSG_GET_ARG_SIZE(THREAD_RPC_MAX_NUM_PARAMS));
 	arg->cmd = cmd;

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -50,5 +50,6 @@ TEE_Result tee_aes_cbc_cts_update(void *cbc_ctx, void *ecb_ctx,
 
 TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len);
 void plat_prng_add_jitter_entropy(void);
+void plat_prng_add_jitter_entropy_norpc(void);
 
 #endif

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -171,7 +171,7 @@ static TEE_Result tee_ltc_prng_init(struct tee_ltc_prng *prng)
 
 	prng->index = prng_index;
 
-	plat_prng_add_jitter_entropy();
+	plat_prng_add_jitter_entropy_norpc();
 
 	return  TEE_SUCCESS;
 }

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -392,6 +392,13 @@ __weak void plat_prng_add_jitter_entropy(void)
 		tee_prng_add_entropy((uint8_t *)&current, sizeof(current));
 }
 
+__weak void plat_prng_add_jitter_entropy_norpc(void)
+{
+#ifndef CFG_SECURE_TIME_SOURCE_REE
+	plat_prng_add_jitter_entropy();
+#endif
+}
+
 static TEE_Result tee_cryp_init(void)
 {
 	if (crypto_ops.init)


### PR DESCRIPTION
The commit referenced below extends entropy gathering to two locations
where it is unfortunately not OK to invoke Normal World through RPC:

1. tee_ltc_prng_init(), because at this point the RPC subsystem has not
yet been initialized,
2. rpc_cmd_nolock(), because doing so would cause recursion and would
be inefficient (doubling the number of RPC calls).

The problem is: if CFG_SECURE_TIME_SOURCE_REE=y and if the platform
does not override plat_prng_add_jitter_entropy(), the function will end
up calling the RPC service where it's not permitted and the TEE will
crash.

This commit introduces plat_prng_add_jitter_entropy_norpc() and
provides a default implementation which does nothing if the time source
is the REE, thus fixing the issue while still allowing platform code to
implement a specific behavior.

Fixes: 82f97f19fe2d ("prng: call plat_prng_add_jitter_entropy() at PRNG init and before NW RPC")
Reported-by: Etienne Carriere <etienne.carriere@linaro.org>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>