### PR TITLE
libutee: Remove debug traces in tee_user_mem_alloc()/tee_user_mem_free()

### DIFF
--- a/lib/libutee/tee_user_mem.c
+++ b/lib/libutee/tee_user_mem.c
@@ -340,7 +340,7 @@ void *tee_user_mem_alloc(size_t len, uint32_t hint)
 		    (((uintptr_t) cp) & 0xFF) ^ 0xC5;
 #endif
 
-		PB(TRACE_DEBUG, "Allocate: ", (void *)e);
+		PB(TRACE_FLOW, "Allocate: ", (void *)e);
 
 		buf = buf_addr(e);
 
@@ -439,7 +439,7 @@ void tee_user_mem_free(void *buffer)
 	cp = elem_addr(buffer);
 	e = (struct user_mem_elem *)(void *)cp;
 
-	PB(TRACE_DEBUG, "Free: ", (void *)e);
+	PB(TRACE_FLOW, "Free: ", (void *)e);
 
 #if (CFG_TEE_CORE_USER_MEM_DEBUG == 1)
 	if (!check_elem(e)) {


### PR DESCRIPTION
When CFG_TEE_CORE_USER_MEM_DEBUG=1 (which is the default, enables
additional checks in tee_user_mem.c and also enables traces) and
CFG_TEE_TA_LOG_LEVEL=3 (debug), libutee logs messages for each and
every allocation and deallocation, as follows:

DEBUG:   USER-TA: tee_user_mem_alloc:343: Allocate: link:[0x1211a0], buf:[0x1211b0:12]
DEBUG:   USER-TA: tee_user_mem_free:442: Free: link:[0x1211a0], buf:[0x1211b0:12]
...

That's annoying and pretty much useless so let's just remove them.
Higher severity messages, which are printed if an inconsistency is
detected, are preserved.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>