### PR TITLE
core: plat_prng_add_jitter_entropy() logging

### DIFF
--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -93,7 +93,7 @@ void plat_prng_add_jitter_entropy(void)
 		}
 	}
 	if (bytes) {
-		DMSG("%s: 0x%02X\n", __func__,
+		FMSG("%s: 0x%02X\n", __func__,
 		     (int)acc & ((1 << (bytes * 8)) - 1));
 		tee_prng_add_entropy((uint8_t *)&acc, bytes);
 	}


### PR DESCRIPTION
Changes the DMSG() logging to FMSG() to avoid flooding the logs when
debug logs are enabled.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>