### PR TITLE
core: workaround PRNG pr1377

### DIFF
--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -394,7 +394,7 @@ __weak void plat_prng_add_jitter_entropy(void)
 
 __weak void plat_prng_add_jitter_entropy_norpc(void)
 {
-#ifndef CFG_SECURE_TIME_SOURCE_REE
+#if !defined(CFG_SECURE_TIME_SOURCE_REE) && defined(CFG_ENABLE_BUG_PRNG_PR1377)
 	plat_prng_add_jitter_entropy();
 #endif
 }


### PR DESCRIPTION
Ifdefs out problematic PRNG entropy collecting.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (Hikey)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>