### PR TITLE
core: prng: Don't lock a mutex from rpc_cmd_nolock()

### DIFF
--- a/core/arch/arm/include/kernel/mutex.h
+++ b/core/arch/arm/include/kernel/mutex.h
@@ -36,6 +36,15 @@ enum mutex_value {
 	MUTEX_VALUE_LOCKED,
 };
 
+/*
+ * Positive owner ids signifies actual threads, negative ids has special
+ * meanings according to the defines below. Note that only the first of the
+ * defines is allowed in struct mutex::owener_id.
+ */
+#define MUTEX_OWNER_ID_NONE		-1
+#define MUTEX_OWNER_ID_CONDVAR_SLEEP	-2
+#define MUTEX_OWNER_ID_MUTEX_UNLOCK	-3
+
 struct mutex {
 	enum mutex_value value;
 	unsigned spin_lock;	/* used when operating on this struct */
@@ -44,7 +53,7 @@ struct mutex {
 	TAILQ_ENTRY(mutex) link;
 };
 #define MUTEX_INITIALIZER \
-	{ .value = MUTEX_VALUE_UNLOCKED, .owner_id = -1, \
+	{ .value = MUTEX_VALUE_UNLOCKED, .owner_id = MUTEX_OWNER_ID_NONE, \
 	  .wq = WAIT_QUEUE_INITIALIZER, }
 
 TAILQ_HEAD(mutex_head, mutex);

--- a/core/arch/arm/include/kernel/wait_queue.h
+++ b/core/arch/arm/include/kernel/wait_queue.h
@@ -67,7 +67,8 @@ static inline void wq_wait_init(struct wait_queue *wq,
 
 /* Waits for the wait queue element to the awakened. */
 void wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
-			const void *sync_obj, const char *fname, int lineno);
+		   const void *sync_obj, int owner, const char *fname,
+		   int lineno);
 
 /* Wakes up the first wait queue element in the wait queue, if there is one */
 void wq_wake_one(struct wait_queue *wq, const void *sync_obj,

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1199,7 +1199,14 @@ static uint32_t rpc_cmd_nolock(uint32_t cmd, size_t num_params,
 
 	assert(arg && carg && num_params <= THREAD_RPC_MAX_NUM_PARAMS);
 
-	plat_prng_add_jitter_entropy_norpc();
+
+	/*
+	 * Break recursion in case plat_prng_add_jitter_entropy_norpc()
+	 * sleeps on a mutex or unlocks a mutex with a sleeper (contended
+	 * mutex).
+	 */
+	if (cmd != OPTEE_MSG_RPC_CMD_WAIT_QUEUE)
+		plat_prng_add_jitter_entropy_norpc();
 
 	memset(arg, 0, OPTEE_MSG_GET_ARG_SIZE(THREAD_RPC_MAX_NUM_PARAMS));
 	arg->cmd = cmd;

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1115,7 +1115,7 @@ void thread_add_mutex(struct mutex *m)
 	int ct = l->curr_thread;
 
 	assert(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
-	assert(m->owner_id == -1);
+	assert(m->owner_id == MUTEX_OWNER_ID_NONE);
 	m->owner_id = ct;
 	TAILQ_INSERT_TAIL(&threads[ct].mutexes, m, link);
 }
@@ -1127,7 +1127,7 @@ void thread_rem_mutex(struct mutex *m)
 
 	assert(ct != -1 && threads[ct].state == THREAD_STATE_ACTIVE);
 	assert(m->owner_id == ct);
-	m->owner_id = -1;
+	m->owner_id = MUTEX_OWNER_ID_NONE;
 	TAILQ_REMOVE(&threads[ct].mutexes, m, link);
 }
 

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -50,6 +50,10 @@ TEE_Result tee_aes_cbc_cts_update(void *cbc_ctx, void *ecb_ctx,
 
 TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len);
 void plat_prng_add_jitter_entropy(void);
+/*
+ * The _norpc version must not invoke Normal World, or infinite recursion
+ * may occur. As an exception however, using mutexes is allowed.
+ */
 void plat_prng_add_jitter_entropy_norpc(void);
 
 #endif


### PR DESCRIPTION
Obsoletes https://github.com/OP-TEE/optee_os/pull/1385