### PR TITLE
Introduce get_base and MEM_AREA_TEE_RAM_UNCACHED

### DIFF
--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -99,4 +99,9 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m);
  */
 paddr_t virt_to_phys(void *va);
 
+/*
+ * Return runtime usable address
+ */
+vaddr_t get_base(paddr_t base, enum teecore_memtypes type);
+
 #endif /* CORE_MEMPROT_H */

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -397,5 +397,6 @@ typedef enum {
 
 /* Check cpu mmu enabled or not */
 bool cpu_mmu_enabled(void);
+void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb);
 
 #endif /* CORE_MMU_H */

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -86,6 +86,7 @@
  * MEM_AREA_IO_SEC:   Secure HW mapped registers
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_TA_VASPACE: TA va space, only used with phys_to_virt()
+ * MEM_AREA_TEE_RAM_UNCACHED:  Same as MEM_AREA_TEE_RAM, but cache disabled.
  * MEM_AREA_MAXTYPE:  lower invalid 'type' value
  */
 enum teecore_memtypes {
@@ -100,6 +101,7 @@ enum teecore_memtypes {
 	MEM_AREA_IO_SEC,
 	MEM_AREA_RES_VASPACE,
 	MEM_AREA_TA_VASPACE,
+	MEM_AREA_TEE_RAM_UNCACHED,
 	MEM_AREA_MAXTYPE
 };
 

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1166,6 +1166,14 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m)
 	return va;
 }
 
+vaddr_t get_base(paddr_t base, enum teecore_memtypes type)
+{
+	if (cpu_mmu_enabled())
+		return (vaddr_t)phys_to_virt(base, type);
+
+	return (vaddr_t)base;
+}
+
 bool cpu_mmu_enabled(void)
 {
 	uint32_t sctlr;

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -328,6 +328,8 @@ uint32_t core_mmu_type_to_attr(enum teecore_memtypes t)
 		return attr | TEE_MATTR_SECURE | cached;
 	case MEM_AREA_RES_VASPACE:
 		return 0;
+	case MEM_AREA_TEE_RAM_UNCACHED:
+		return attr | TEE_MATTR_SECURE | TEE_MATTR_PX | noncache;
 	default:
 		panic("invalid type");
 	}
@@ -471,6 +473,7 @@ void core_init_mmu_map(void)
 				panic("NS_SHM can't fit in nsec_shared");
 			map_nsec_shm = map;
 			break;
+		case MEM_AREA_TEE_RAM_UNCACHED:
 		case MEM_AREA_IO_SEC:
 		case MEM_AREA_IO_NSEC:
 		case MEM_AREA_RAM_SEC:

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -649,7 +649,7 @@ static paddr_t map_page_memarea(struct tee_mmap_region *mm)
 * map_memarea - load mapping in target L1 table
 * A finer mapping must be supported. Currently section mapping only!
 */
-static void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
+void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
 {
 	size_t m, n;
 	uint32_t attr;
@@ -671,8 +671,10 @@ static void map_memarea(struct tee_mmap_region *mm, uint32_t *ttb)
 	 * TODO: support mapping devices at a virtual address which isn't
 	 * the same as the physical address.
 	 */
-	if (mm->va < (NUM_UL1_ENTRIES * SECTION_SIZE))
-		panic("va conflicts with user ta address");
+	if (ttb == (void *)core_mmu_get_main_ttb_va()) {
+		if (mm->va < (NUM_UL1_ENTRIES * SECTION_SIZE))
+			panic("va conflicts with user ta address");
+	}
 
 	if ((mm->va | mm->pa | mm->size) & SECTION_MASK) {
 		region_size = SMALL_PAGE_SIZE;


### PR DESCRIPTION
Introduce get_base helper function.
Introduce MEM_AREA_TEE_RAM_UNCACHED, which has same attr as MEM_AREA_TEE_RAM, but cache disabled.
Export map_memarea.