### PR TITLE
Serial drivers rework

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -335,7 +335,7 @@ shadow_stack_access_ok:
 	/* complete ARM secure MP common configuration */
 	bl	plat_cpu_reset_late
 
-	/* Enable Console */
+	/* Enable the console using physical addresses */
 	bl	console_init
 
 #ifdef CFG_PL310
@@ -345,7 +345,7 @@ shadow_stack_access_ok:
 
 	/*
 	 * Invalidate dcache for all memory used during initialization to
-	 * avoid nasty surprices when the cache is turned on. We must not
+	 * avoid nasty surprises when the cache is turned on. We must not
 	 * invalidate memory not used by OP-TEE since we may invalidate
 	 * entries used by for instance ARM Trusted Firmware.
 	 */
@@ -361,11 +361,23 @@ shadow_stack_access_ok:
 	bl	arm_cl2_enable
 #endif
 
+	/* Configure the MMU */
 	bl	core_init_mmu_map
 	bl	core_init_mmu_regs
+
+	/* Avoid losing any output due to the console_init call below */
+	bl	console_flush
+
+	/* Enable the MMU */
 	bl	cpu_mmu_enable
 	bl	cpu_mmu_enable_icache
 	bl	cpu_mmu_enable_dcache
+
+	/*
+	 * MMU is turned on: re-initialize the console so that the driver
+	 * uses the proper virtual addresses from now on
+	 */
+	bl	console_init
 
 	mov	r0, r4		/* pageable part address */
 	mov	r1, r5		/* ns-entry address */

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -118,14 +118,26 @@ copy_init:
 	sub	x1, x1, x0
 	bl	inv_dcache_range
 
-	/* Enable Console */
+	/* Enable the console using physical addresses */
 	bl	console_init
 
+	/* Configure the MMU */
 	bl	core_init_mmu_map
 	bl	core_init_mmu_regs
+
+	/* Avoid losing any output due to the console_init call below */
+	bl	console_flush
+
+	/* Enable the MMU */
 	bl	cpu_mmu_enable
 	bl	cpu_mmu_enable_icache
 	bl	cpu_mmu_enable_dcache
+
+	/*
+	 * MMU is turned on: re-initialize the console so that the driver
+	 * uses the proper virtual addresses from now on
+	 */
+	bl	console_init
 
 	mov	x0, x19		/* pagable part address */
 	mov	x1, #-1

--- a/core/arch/arm/plat-d02/main.c
+++ b/core/arch/arm/plat-d02/main.c
@@ -74,20 +74,5 @@ void console_init(void)
 	}
 	hi16xx_uart_init(&console_data, CONSOLE_UART_BASE,
 			 CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }

--- a/core/arch/arm/plat-d02/main.c
+++ b/core/arch/arm/plat-d02/main.c
@@ -51,6 +51,8 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_do_nothing,
 };
 
+static struct hi16xx_uart_data console_data __early_bss;
+
 register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, HI16XX_UART_REG_SIZE);
 
 const struct thread_handlers *generic_boot_get_handlers(void)
@@ -63,34 +65,29 @@ static void main_fiq(void)
 	panic();
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_NSEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	hi16xx_uart_init(console_base(), CONSOLE_UART_CLK_IN_HZ,
-			 CONSOLE_BAUDRATE);
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	hi16xx_uart_init(&console_data, CONSOLE_UART_BASE,
+			 CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
 	if (ch == '\n')
-		hi16xx_uart_putc('\r', base);
-	hi16xx_uart_putc(ch, base);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	hi16xx_uart_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -58,6 +58,8 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_do_nothing,
 };
 
+static struct pl011_data console_data __early_bss;
+
 register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
 register_phys_mem(MEM_AREA_IO_NSEC, PMUSSI_BASE, PMUSSI_REG_SIZE);
 #ifdef CFG_SPI
@@ -78,35 +80,31 @@ static void main_fiq(void)
 	panic();
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_NSEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	pl011_init(console_base(), CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_NSEC);
+		return;
+	}
+	pl011_init(&console_data, CONSOLE_UART_BASE, CONSOLE_UART_CLK_IN_HZ,
+		   CONSOLE_BAUDRATE);
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
 	if (ch == '\n')
-		pl011_putc('\r', base);
-	pl011_putc(ch, base);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	pl011_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }
 
 vaddr_t nsec_periph_base(paddr_t pa)

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -89,22 +89,7 @@ void console_init(void)
 	}
 	pl011_init(&console_data, CONSOLE_UART_BASE, CONSOLE_UART_CLK_IN_HZ,
 		   CONSOLE_BAUDRATE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }
 
 vaddr_t nsec_periph_base(paddr_t pa)

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -144,22 +144,7 @@ void console_init(void)
 		return;
 	}
 	imx_uart_init(&console_data, console_base());
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }
 
 void main_init_gic(void)

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -64,6 +64,8 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_panic,
 };
 
+static struct imx_uart_data console_data __early_bss;
+
 register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CORE_MMU_DEVICE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_DEVICE_SIZE);
 
@@ -128,39 +130,36 @@ void plat_cpu_reset_late(void)
 
 static vaddr_t console_base(void)
 {
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE,
-					  MEM_AREA_IO_NSEC);
-		return (vaddr_t)va;
-	}
+	if (cpu_mmu_enabled())
+		return (vaddr_t)phys_to_virt(CONSOLE_UART_BASE,
+					     MEM_AREA_IO_NSEC);
 	return CONSOLE_UART_BASE;
 }
 
 void console_init(void)
 {
-	vaddr_t base = console_base();
-
-	imx_uart_init(base);
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	imx_uart_init(&console_data, console_base());
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
-	/* If \n, also do \r */
 	if (ch == '\n')
-		imx_uart_putc('\r', base);
-	imx_uart_putc(ch, base);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
-	imx_uart_flush_tx_fifo(base);
+	cons->ops->flush(cons);
 }
 
 void main_init_gic(void)

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -129,22 +129,7 @@ void console_init(void)
 		return;
 	}
 	ns16550_init(&console_data, CONSOLE_UART_BASE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }
 
 void main_init_gic(void)

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -58,6 +58,7 @@ static const struct thread_handlers handlers = {
 };
 
 static struct gic_data gic_data;
+static struct ns16550_data console_data __early_bss;
 
 register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CORE_MMU_DEVICE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_DEVICE_SIZE);
@@ -120,38 +121,30 @@ void plat_cpu_reset_late(void)
 	}
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va __early_bss;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_NSEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	/*
-	 * Do nothing, uart driver shared with normal world,
-	 * everything for uart driver intialization is done in bootloader.
-	 */
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	ns16550_init(&console_data, CONSOLE_UART_BASE);
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
 	if (ch == '\n')
-		ns16550_putc('\r', base);
-	ns16550_putc(ch, base);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	ns16550_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }
 
 void main_init_gic(void)

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -71,20 +71,5 @@ void console_init(void)
 	}
 	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
 			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -50,6 +50,8 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_do_nothing,
 };
 
+static struct serial8250_uart_data console_data __early_bss;
+
 const struct thread_handlers *generic_boot_get_handlers(void)
 {
 	return &handlers;
@@ -60,34 +62,29 @@ static void main_fiq(void)
 	panic();
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_NSEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	serial8250_uart_init(console_base(), CONSOLE_UART_CLK_IN_HZ,
-			     CONSOLE_BAUDRATE);
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
 	if (ch == '\n')
-		serial8250_uart_putc('\r', base);
-	serial8250_uart_putc(ch, base);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	serial8250_uart_flush_tx_fifo(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -75,21 +75,6 @@ void console_init(void)
 		return;
 	}
 	scif_uart_init(&console_data, CONSOLE_UART_BASE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }
 

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -55,6 +55,8 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_do_nothing,
 };
 
+static struct scif_uart_data console_data __early_bss;
+
 const struct thread_handlers *generic_boot_get_handlers(void)
 {
 	return &handlers;
@@ -65,31 +67,29 @@ static void main_fiq(void)
 	panic();
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_SEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	scif_uart_init(console_base());
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	scif_uart_init(&console_data, CONSOLE_UART_BASE);
 }
 
 void console_putc(int ch)
 {
+	struct serial_chip *cons = &console_data.chip;
+
 	if (ch == '\n')
-		scif_uart_putc('\r', console_base());
-	scif_uart_putc(ch, console_base());
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	scif_uart_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }
+

--- a/core/arch/arm/plat-rpi3/main.c
+++ b/core/arch/arm/plat-rpi3/main.c
@@ -54,41 +54,36 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_do_nothing,
 };
 
+static struct serial8250_uart_data console_data __early_bss;
+
 const struct thread_handlers *generic_boot_get_handlers(void)
 {
 	return &handlers;
 }
 
-static vaddr_t console_base(void)
+void console_init(void)
 {
-	static vaddr_t va;
-
 	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = (vaddr_t)phys_to_virt(CONSOLE_UART_BASE,
-						   MEM_AREA_IO_NSEC);
-		return va;
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
 	}
-
-	return CONSOLE_UART_BASE;
+	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
 	if (ch == '\n')
-		serial8250_uart_putc('\r', base);
-	serial8250_uart_putc(ch, base);
-}
-
-void console_init(void)
-{
-	serial8250_uart_init(console_base(), CONSOLE_UART_CLK_IN_HZ,
-			     CONSOLE_BAUDRATE);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	serial8250_uart_flush_tx_fifo(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }

--- a/core/arch/arm/plat-rpi3/main.c
+++ b/core/arch/arm/plat-rpi3/main.c
@@ -70,20 +70,5 @@ void console_init(void)
 	}
 	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
 			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }

--- a/core/arch/arm/plat-sprd/console.c
+++ b/core/arch/arm/plat-sprd/console.c
@@ -29,30 +29,31 @@
 #include <mm/core_memprot.h>
 #include <platform_config.h>
 
+static struct sprd_uart_data console_data __early_bss;
+
 static vaddr_t console_base(void)
 {
-	static vaddr_t base;
-
 	if (cpu_mmu_enabled())
-		base = (vaddr_t)phys_to_virt(CONSOLE_UART_BASE,
-					     MEM_AREA_IO_SEC);
-	else
-		base = CONSOLE_UART_BASE;
-
-	return base;
+		return (vaddr_t)phys_to_virt(CONSOLE_UART_BASE,
+					     MEM_AREA_IO_NSEC);
+	return CONSOLE_UART_BASE;
 }
 
-/* Do nothing in this function */
 void console_init(void)
 {
+	sprd_uart_init(&console_data, console_base());
 }
 
 void console_putc(int ch)
 {
-	sprd_uart_putc(console_base(), (unsigned char)(ch & 0xff));
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->putc(cons, ch & 0xff);
 }
 
 void console_flush(void)
 {
-	sprd_uart_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }

--- a/core/arch/arm/plat-sprd/console.c
+++ b/core/arch/arm/plat-sprd/console.c
@@ -42,6 +42,7 @@ static vaddr_t console_base(void)
 void console_init(void)
 {
 	sprd_uart_init(&console_data, console_base());
+	serial_console = &console_data.chip;
 }
 
 void console_putc(int ch)
@@ -51,9 +52,3 @@ void console_putc(int ch)
 	cons->ops->putc(cons, ch & 0xff);
 }
 
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
-}

--- a/core/arch/arm/plat-sunxi/console.c
+++ b/core/arch/arm/plat-sunxi/console.c
@@ -40,6 +40,7 @@ void console_init(void)
 		return;
 	}
 	sunxi_uart_init(&console_data, CONSOLE_UART_BASE);
+	serial_console = &console_data.chip;
 }
 
 void console_putc(int ch)
@@ -47,11 +48,4 @@ void console_putc(int ch)
 	struct serial_chip *cons = &console_data.chip;
 
 	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
 }

--- a/core/arch/arm/plat-ti/console.c
+++ b/core/arch/arm/plat-ti/console.c
@@ -30,38 +30,35 @@
 #include <mm/core_memprot.h>
 #include <platform_config.h>
 
+static struct serial8250_uart_data console_data __early_bss;
+
 register_phys_mem(MEM_AREA_IO_NSEC,
 		  CONSOLE_UART_BASE,
 		  SERIAL8250_UART_REG_SIZE);
 
-static vaddr_t console_base(void)
-{
-	static void *va __early_bss;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_NSEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	serial8250_uart_init(console_base(), CONSOLE_UART_CLK_IN_HZ,
-			     CONSOLE_BAUDRATE);
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
 	if (ch == '\n')
-		serial8250_uart_putc('\r', base);
-	serial8250_uart_putc(ch, base);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	serial8250_uart_flush_tx_fifo(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -126,22 +126,7 @@ void console_init(void)
 	}
 	pl011_init(&console_data, CONSOLE_UART_BASE, CONSOLE_UART_CLK_IN_HZ,
 		   CONSOLE_BAUDRATE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }
 
 #ifdef IT_CONSOLE_UART

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -74,6 +74,7 @@ static const struct thread_handlers handlers = {
 };
 
 static struct gic_data gic_data;
+static struct pl011_data console_data __early_bss;
 
 register_phys_mem(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
 
@@ -116,44 +117,40 @@ static void main_fiq(void)
 	gic_it_handle(&gic_data);
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_SEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	pl011_init(console_base(), CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	pl011_init(&console_data, CONSOLE_UART_BASE, CONSOLE_UART_CLK_IN_HZ,
+		   CONSOLE_BAUDRATE);
 }
 
 void console_putc(int ch)
 {
-	vaddr_t base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
 	if (ch == '\n')
-		pl011_putc('\r', base);
-	pl011_putc(ch, base);
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	pl011_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }
 
 #ifdef IT_CONSOLE_UART
 static enum itr_return console_itr_cb(struct itr_handler *h __unused)
 {
-	paddr_t uart_base = console_base();
+	struct serial_chip *cons = &console_data.chip;
 
-	while (pl011_have_rx_data(uart_base)) {
-		int ch __maybe_unused = pl011_getchar(uart_base);
+	while (cons->ops->have_rx_data(cons)) {
+		int ch __maybe_unused = cons->ops->getchar(cons);
 
 		DMSG("cpu %zu: got 0x%x", get_core_pos(), ch);
 	}

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -61,6 +61,7 @@ static const struct thread_handlers handlers = {
 };
 
 static struct gic_data gic_data;
+static struct cdns_uart_data console_data __early_bss;
 
 register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CORE_MMU_DEVICE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_DEVICE_SIZE);
@@ -117,33 +118,30 @@ void plat_cpu_reset_late(void)
 	}
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va __early_bss;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE,
-					  MEM_AREA_IO_NSEC);
-		return (vaddr_t)va;
-	}
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	cdns_uart_init(&console_data, CONSOLE_UART_BASE, 0, 0);
 }
 
 void console_putc(int ch)
 {
+	struct serial_chip *cons = &console_data.chip;
+
 	if (ch == '\n')
-		cdns_uart_putc('\r', console_base());
-	cdns_uart_putc(ch, console_base());
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	cdns_uart_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }
 
 vaddr_t pl310_base(void)

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -126,22 +126,7 @@ void console_init(void)
 		return;
 	}
 	cdns_uart_init(&console_data, CONSOLE_UART_BASE, 0, 0);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }
 
 vaddr_t pl310_base(void)

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -100,20 +100,5 @@ void console_init(void)
 	}
 	cdns_uart_init(&console_data, CONSOLE_UART_BASE,
 		       CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
-}
-
-void console_putc(int ch)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	if (ch == '\n')
-		cons->ops->putc(cons, '\r');
-	cons->ops->putc(cons, ch);
-}
-
-void console_flush(void)
-{
-	struct serial_chip *cons = &console_data.chip;
-
-	cons->ops->flush(cons);
+	serial_console = &console_data.chip;
 }

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -46,6 +46,7 @@
 
 static void main_fiq(void);
 static struct gic_data gic_data;
+static struct cdns_uart_data console_data __early_bss;
 
 static const struct thread_handlers handlers = {
 	.std_smc = tee_entry_std,
@@ -90,33 +91,29 @@ static void main_fiq(void)
 	gic_it_handle(&gic_data);
 }
 
-static vaddr_t console_base(void)
-{
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(CONSOLE_UART_BASE, MEM_AREA_IO_SEC);
-		return (vaddr_t)va;
-	}
-
-	return CONSOLE_UART_BASE;
-}
-
 void console_init(void)
 {
-	cdns_uart_init(console_base(), CONSOLE_UART_CLK_IN_HZ,
-		       CONSOLE_BAUDRATE);
+	if (cpu_mmu_enabled()) {
+		console_data.vbase = (vaddr_t)phys_to_virt(console_data.pbase,
+							   MEM_AREA_IO_SEC);
+		return;
+	}
+	cdns_uart_init(&console_data, CONSOLE_UART_BASE,
+		       CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
 }
 
 void console_putc(int ch)
 {
+	struct serial_chip *cons = &console_data.chip;
+
 	if (ch == '\n')
-		cdns_uart_putc('\r', console_base());
-	cdns_uart_putc(ch, console_base());
+		cons->ops->putc(cons, '\r');
+	cons->ops->putc(cons, ch);
 }
 
 void console_flush(void)
 {
-	cdns_uart_flush(console_base());
+	struct serial_chip *cons = &console_data.chip;
+
+	cons->ops->flush(cons);
 }

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -25,12 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <platform_config.h>
-
 #include <drivers/imx_uart.h>
-#include <console.h>
 #include <io.h>
-#include <compiler.h>
+#include <mm/core_mmu.h>
+#include <util.h>
 
 /* Register definitions */
 #define URXD  0x0  /* Receiver Register */
@@ -80,33 +78,62 @@
 #define  UTS_RXFULL	 (1<<3)	 /* RxFIFO full */
 #define  UTS_SOFTRST	 (1<<0)	 /* Software reset */
 
-void imx_uart_init(vaddr_t __unused vbase)
+static vaddr_t base_addr(struct imx_uart_data *pd)
 {
-	/*
-	 * Do nothing, debug uart(uart0) share with normal world,
-	 * everything for uart0 intialization is done in bootloader.
-	 */
+	return cpu_mmu_enabled() ? pd->vbase : pd->pbase;
 }
 
-void imx_uart_flush_tx_fifo(vaddr_t base)
+static void imx_uart_flush(struct serial_chip *chip)
 {
+	struct imx_uart_data *pd = container_of(chip, struct imx_uart_data,
+						chip);
+	vaddr_t base = base_addr(pd);
+
 	while (!(read32(base + UTS) & UTS_TXEMPTY))
 		;
 }
 
-int imx_uart_getchar(vaddr_t base)
+static int imx_uart_getchar(struct serial_chip *chip)
 {
+	struct imx_uart_data *pd = container_of(chip, struct imx_uart_data,
+						chip);
+	vaddr_t base = base_addr(pd);
+
 	while (read32(base + UTS) & UTS_RXEMPTY)
 		;
 
 	return (read32(base + URXD) & URXD_RX_DATA);
 }
 
-void imx_uart_putc(const char c, vaddr_t base)
+static void imx_uart_putc(struct serial_chip *chip, int ch)
 {
-	write32(c, base + UTXD);
+	struct imx_uart_data *pd = container_of(chip, struct imx_uart_data,
+						chip);
+	vaddr_t base = base_addr(pd);
 
-	/* wait until sent */
+	write32(ch, base + UTXD);
+
+	/* Wait until sent */
 	while (!(read32(base + UTS) & UTS_TXEMPTY))
 		;
+}
+
+static const struct serial_ops imx_uart_ops = {
+	.flush = imx_uart_flush,
+	.getchar = imx_uart_getchar,
+	.putc = imx_uart_putc,
+};
+
+void imx_uart_init(struct imx_uart_data *pd, vaddr_t base)
+{
+	if (cpu_mmu_enabled())
+		pd->vbase = base;
+	else
+		pd->pbase = base;
+	pd->chip.ops = &imx_uart_ops;
+
+	/*
+	 * Do nothing, debug uart(uart0) share with normal world,
+	 * everything for uart0 initialization is done in bootloader.
+	 */
 }

--- a/core/drivers/ns16550.c
+++ b/core/drivers/ns16550.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +28,8 @@
 
 #include <drivers/ns16550.h>
 #include <io.h>
+#include <mm/core_mmu.h>
+#include <util.h>
 
 /* uart register defines */
 #define UART_RBR	0x0
@@ -42,16 +45,46 @@
 /* uart status register bits */
 #define UART_LSR_THRE	0x20 /* Transmit-hold-register empty */
 
-void ns16550_flush(vaddr_t base)
+static vaddr_t base_addr(struct ns16550_data *pd)
 {
+	return cpu_mmu_enabled() ? pd->vbase : pd->pbase;
+}
+
+static void ns16550_flush(struct serial_chip *chip)
+{
+	struct ns16550_data *pd = container_of(chip, struct ns16550_data, chip);
+	vaddr_t base = base_addr(pd);
+
 	while ((read8(base + UART_LSR) & UART_LSR_THRE) == 0)
 		;
 }
 
-void ns16550_putc(int ch, vaddr_t base)
+static void ns16550_putc(struct serial_chip *chip, int ch)
 {
-	ns16550_flush(base);
+	struct ns16550_data *pd = container_of(chip, struct ns16550_data, chip);
+	vaddr_t base = base_addr(pd);
+
+	ns16550_flush(chip);
 
 	/* write out charset to Transmit-hold-register */
 	write8(ch, base + UART_THR);
+}
+
+static const struct serial_ops ns16550_ops = {
+	.flush = ns16550_flush,
+	.putc = ns16550_putc,
+};
+
+void ns16550_init(struct ns16550_data *pd, vaddr_t base)
+{
+	if (cpu_mmu_enabled())
+		pd->vbase = base;
+	else
+		pd->pbase = base;
+	pd->chip.ops = &ns16550_ops;
+
+	/*
+	 * Do nothing, uart driver shared with normal world,
+	 * everything for uart driver initialization is done in bootloader.
+	 */
 }

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -28,9 +28,14 @@
 #ifndef CONSOLE_H
 #define CONSOLE_H
 
+#include <compiler.h>
+
 void console_init(void);
 void console_putc(int ch);
 void console_flush(void);
+
+struct serial_chip;
+extern struct serial_chip *serial_console __early_bss;
 
 #endif /* CONSOLE_H */
 

--- a/core/include/drivers/cdns_uart.h
+++ b/core/include/drivers/cdns_uart.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016, Xilinx Inc
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,15 +29,15 @@
 #define CDNS_UART_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
-void cdns_uart_init(vaddr_t base, uint32_t uart_clk, uint32_t baud_rate);
+struct cdns_uart_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void cdns_uart_putc(int ch, vaddr_t base);
-
-void cdns_uart_flush(vaddr_t base);
-
-bool cdns_uart_have_rx_data(vaddr_t base);
-
-int cdns_uart_getchar(vaddr_t base);
+void cdns_uart_init(struct cdns_uart_data *pd, vaddr_t base, uint32_t uart_clk,
+		uint32_t baud_rate);
 
 #endif /* CDNS_UART_H */

--- a/core/include/drivers/hi16xx_uart.h
+++ b/core/include/drivers/hi16xx_uart.h
@@ -33,18 +33,17 @@
 #define HI16XX_UART_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
 #define HI16XX_UART_REG_SIZE 0xF8
 
-void hi16xx_uart_init(vaddr_t base, uint32_t uart_clk, uint32_t baud_rate);
+struct hi16xx_uart_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void hi16xx_uart_putc(int ch, vaddr_t base);
-
-void hi16xx_uart_flush(vaddr_t base);
-
-bool hi16xx_uart_have_rx_data(vaddr_t base);
-
-int hi16xx_uart_getchar(vaddr_t base);
+void hi16xx_uart_init(struct hi16xx_uart_data *pd, vaddr_t base,
+		      uint32_t uart_clk, uint32_t baud_rate);
 
 #endif /* HI16XX_UART_H */
-

--- a/core/include/drivers/imx_uart.h
+++ b/core/include/drivers/imx_uart.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,15 +29,14 @@
 #define IMX_UART_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
-void imx_uart_init(vaddr_t base);
+struct imx_uart_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void imx_uart_putc(const char ch, vaddr_t base);
-
-void imx_uart_flush_tx_fifo(vaddr_t base);
-
-bool imx_uart_have_rx_data(vaddr_t base);
-
-int imx_uart_getchar(vaddr_t base);
+void imx_uart_init(struct imx_uart_data *pd, vaddr_t base);
 
 #endif /* IMX_UART_H */

--- a/core/include/drivers/ns16550.h
+++ b/core/include/drivers/ns16550.h
@@ -28,9 +28,14 @@
 #define NS16550_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
-void ns16550_putc(int ch, vaddr_t base);
+struct ns16550_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void ns16550_flush(vaddr_t base);
+void ns16550_init(struct ns16550_data *pd, vaddr_t base);
 
 #endif /* NS16550_H */

--- a/core/include/drivers/pl011.h
+++ b/core/include/drivers/pl011.h
@@ -28,18 +28,17 @@
 #define PL011_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
 #define PL011_REG_SIZE	0x1000
 
-void pl011_init(vaddr_t base, uint32_t uart_clk, uint32_t baud_rate);
+struct pl011_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void pl011_putc(int ch, vaddr_t base);
-
-void pl011_flush(vaddr_t base);
-
-bool pl011_have_rx_data(vaddr_t base);
-
-int pl011_getchar(vaddr_t base);
+void pl011_init(struct pl011_data *pd, vaddr_t base, uint32_t uart_clk,
+		uint32_t baud_rate);
 
 #endif /* PL011_H */
-

--- a/core/include/drivers/scif.h
+++ b/core/include/drivers/scif.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016, GlobalLogic
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,13 +29,16 @@
 #define SCIF_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
 #define SCIF_REG_SIZE	0x1000
 
-void scif_uart_flush(vaddr_t base);
+struct scif_uart_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void scif_uart_init(vaddr_t base);
-
-void scif_uart_putc(int ch, vaddr_t base);
+void scif_uart_init(struct scif_uart_data *pd, vaddr_t base);
 
 #endif /* SCIF */

--- a/core/include/drivers/serial.h
+++ b/core/include/drivers/serial.h
@@ -27,6 +27,8 @@
 #ifndef __DRIVERS_SERIAL_H
 #define __DRIVERS_SERIAL_H
 
+#include <stdbool.h>
+
 struct serial_chip {
 	const struct serial_ops *ops;
 };

--- a/core/include/drivers/serial8250_uart.h
+++ b/core/include/drivers/serial8250_uart.h
@@ -28,19 +28,18 @@
 #define SERIAL8250_UART_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
 #define SERIAL8250_UART_REG_SIZE 0x20
 
-void serial8250_uart_init(vaddr_t base,
-		uint32_t uart_clk, uint32_t baud_rate);
+struct serial8250_uart_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void serial8250_uart_putc(int ch, vaddr_t base);
-
-void serial8250_uart_flush_tx_fifo(vaddr_t base);
-
-bool serial8250_uart_have_rx_data(vaddr_t base);
-
-int serial8250_uart_getchar(vaddr_t base);
+void serial8250_uart_init(struct serial8250_uart_data *pd, vaddr_t base,
+			  uint32_t uart_clk, uint32_t baud_rate);
 
 #endif /* SERIAL8250_UART_H */
 

--- a/core/include/drivers/sprd_uart.h
+++ b/core/include/drivers/sprd_uart.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016, Spreadtrum Communications Inc.
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,12 +29,15 @@
 #define SPRD_UART_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
-void sprd_uart_flush(vaddr_t base);
+struct sprd_uart_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void sprd_uart_putc(vaddr_t base, unsigned char ch);
-
-unsigned char sprd_uart_getc(vaddr_t base);
+void sprd_uart_init(struct sprd_uart_data *pd, vaddr_t base);
 
 #endif /* SPRD_UART_H */
 

--- a/core/include/drivers/sunxi_uart.h
+++ b/core/include/drivers/sunxi_uart.h
@@ -28,16 +28,15 @@
 #define SUNXI_UART_H
 
 #include <types_ext.h>
+#include <drivers/serial.h>
 
-void sunxi_uart_init(vaddr_t base);
+struct sunxi_uart_data {
+	paddr_t pbase;
+	vaddr_t vbase;
+	struct serial_chip chip;
+};
 
-void sunxi_uart_putc(int ch, vaddr_t base);
-
-void sunxi_uart_flush(vaddr_t base);
-
-bool sunxi_uart_have_rx_data(vaddr_t base);
-
-int sunxi_uart_getchar(vaddr_t base);
+void sunxi_uart_init(struct sunxi_uart_data *pd, vaddr_t base);
 
 #endif /*SUNXI_UART_H*/
 

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -1,4 +1,5 @@
 srcs-y += assert.c
+srcs-y += console.c
 srcs-y += tee_ta_manager.c
 srcs-y += tee_misc.c
 srcs-y += panic.c


### PR DESCRIPTION
Rework the UART drivers in order to use the previously introduced `struct serial_chip` and `struct serial_ops`. The console initialization code is updated accordingly.
One advantage of doing this is, it allows a more flexible abstraction of the console so that it can be set from the Device tree (for example).
