### PR TITLE
plat-zynq7k: fix cpu PCR/NASCR init (and few other assembly source files)

### DIFF
--- a/core/arch/arm/plat-ls/plat_init.S
+++ b/core/arch/arm/plat-ls/plat_init.S
@@ -76,16 +76,13 @@ UNWIND(	.fnstart)
 	 * - NSec cannot change ACTRL.SMP (NS_SMP bit18=0)
 	 * - NSec can use SIMD/VFP (CP10/CP11) (bit15:14=2b00, bit11:10=2b11)
 	 */
-	movw r0, #0x0000
-	movt r0, #0x0000
+	mov_imm r0, 0x00000000
 	write_sctlr r0
 
-	movw r0, #0x0040
-	movt r0, #0x0000
+	mov_imm r0, 0x00000040
 	write_actlr r0
 
-	movw r0, #0x0C00
-	movt r0, #0x0000
+	mov_imm r0, 0x00000C00
 	write_nsacr r0
 
 	mov pc, lr

--- a/core/arch/arm/plat-ls/plat_init.S
+++ b/core/arch/arm/plat-ls/plat_init.S
@@ -69,10 +69,10 @@ UNWIND(	.fnstart)
 	 *
 	 * SCTLR = 0x00000000
 	 *
-	 * ACTRL = 0x00000041
-	 * - core always in full SMP (FW bit0=1)
+	 * ACTRL = 0x00000040
+	 * - core NOT booted in full SMP (FW bit0=0)
 	 *
-	 * NSACR = 0x00020C00
+	 * NSACR = 0x00000C00
 	 * - NSec cannot change ACTRL.SMP (NS_SMP bit18=0)
 	 * - NSec can use SIMD/VFP (CP10/CP11) (bit15:14=2b00, bit11:10=2b11)
 	 */

--- a/core/arch/arm/plat-stm/tz_a9init.S
+++ b/core/arch/arm/plat-stm/tz_a9init.S
@@ -78,20 +78,16 @@ END_FUNC arm_cl2_enable
 FUNC plat_cpu_reset_early , :
 UNWIND(	.fnstart)
 
-	movw r0, #(CPU_SCTLR_INIT & 0xFFFF)
-	movt r0, #((CPU_SCTLR_INIT >> 16) & 0xFFFF)
+	mov_imm r0, CPU_SCTLR_INIT
 	write_sctlr r0
 
-	movw r0, #(CPU_ACTLR_INIT & 0xFFFF)
-	movt r0, #((CPU_ACTLR_INIT >> 16) & 0xFFFF)
+	mov_imm r0, CPU_ACTLR_INIT
 	write_actlr r0
 
-	movw r0, #(CPU_NSACR_INIT & 0xFFFF)
-	movt r0, #((CPU_NSACR_INIT >> 16) & 0xFFFF)
+	mov_imm r0, CPU_NSACR_INIT
 	write_nsacr r0
 
-	movw r0, #(CPU_PCR_INIT & 0xFFFF)
-	movt r0, #((CPU_PCR_INIT >> 16) & 0xFFFF)
+	mov_imm r0, CPU_PCR_INIT
 	write_pcr r0
 
 	mov pc, lr

--- a/core/arch/arm/plat-zynq7k/plat_init.S
+++ b/core/arch/arm/plat-zynq7k/plat_init.S
@@ -96,7 +96,7 @@ UNWIND(	.fnstart)
 	mov_imm r0, 0x00000041
 	write_actlr r0
 
-	mov_imm r0, 0x00020FFF
+	mov_imm r0, 0x00020C00
 	write_nsacr r0
 
 	mov_imm r0, 0x00000001

--- a/core/arch/arm/plat-zynq7k/plat_init.S
+++ b/core/arch/arm/plat-zynq7k/plat_init.S
@@ -102,8 +102,8 @@ UNWIND(	.fnstart)
 	movt r0, #0x0002
 	write_nsacr r0
 
-	movw r0, #0x0000
-	movt r0, #0x0001
+	movw r0, #0x0001
+	movt r0, #0x0000
 	write_pcr r0
 
 	mov pc, lr

--- a/core/arch/arm/plat-zynq7k/plat_init.S
+++ b/core/arch/arm/plat-zynq7k/plat_init.S
@@ -90,20 +90,16 @@ UNWIND(	.fnstart)
 	 * PCR = 0x00000001
 	 * - no change latency, enable clk gating
 	 */
-	movw r0, #0x4000
-	movt r0, #0x0000
+	mov_imm r0, 0x00004000
 	write_sctlr r0
 
-	movw r0, #0x0041
-	movt r0, #0x0000
+	mov_imm r0, 0x00000041
 	write_actlr r0
 
-	movw r0, #0x0FFF
-	movt r0, #0x0002
+	mov_imm r0, 0x00020FFF
 	write_nsacr r0
 
-	movw r0, #0x0001
-	movt r0, #0x0000
+	mov_imm r0, 0x00000001
 	write_pcr r0
 
 	mov pc, lr


### PR DESCRIPTION
Before this change, a reserved bit was set in the PCR instead of
enabling the clock gating support, as configured in other supported
Cortex-A9 platforms.

Issue found thanks to reviews for https://github.com/OP-TEE/optee_os/pull/1394 (hence the proposed reported-by tag)