### PR TITLE
core: fix core_mmu_find_table() failure

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -640,7 +640,7 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 		if (!tbl)
 			return false;
 
-		va_base += n << level_size_shift;
+		va_base += (vaddr_t)n << level_size_shift;
 		level++;
 		num_entries = XLAT_TABLE_ENTRIES;
 	}


### PR DESCRIPTION
If va is larger than 0xffffffff, a unsigned n left shift by
level_size_shift results undefined behavior. Lead
core_mmu_find_table() return false mistakenly.

Signed-off-by: Zhizhou Zhang <zhizhouzhang@asrmicro.com>