### PR TITLE
core: introduce TA_FLAG_SECURE_DATA_PATH

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -386,7 +386,7 @@ static TEE_Result ta_load(const TEE_UUID *uuid, const struct shdr *signed_ta,
 	uint32_t man_flags = TA_FLAG_USER_MODE | TA_FLAG_EXEC_DDR;
 	/* opt_flags: optional flags */
 	uint32_t opt_flags = man_flags | TA_FLAG_SINGLE_INSTANCE |
-	    TA_FLAG_MULTI_SESSION | TA_FLAG_UNSAFE_NW_PARAMS |
+	    TA_FLAG_MULTI_SESSION | TA_FLAG_SECURE_DATA_PATH |
 	    TA_FLAG_INSTANCE_KEEP_ALIVE | TA_FLAG_CACHE_MAINTENANCE;
 	struct user_ta_ctx *utc = NULL;
 	struct shdr *sec_shdr = NULL;

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -36,11 +36,7 @@
 #define TA_FLAG_SINGLE_INSTANCE		(1 << 2)
 #define TA_FLAG_MULTI_SESSION		(1 << 3)
 #define TA_FLAG_INSTANCE_KEEP_ALIVE	(1 << 4) /* remains after last close */
-/*
- * TA_FLAG_UNSAFE_NW_PARAMS: May manipulate some secure memory based on
- * physical pointers from non-secure world
- */
-#define TA_FLAG_UNSAFE_NW_PARAMS	(1 << 5)
+#define TA_FLAG_SECURE_DATA_PATH	(1 << 5) /* accesses SDP memory */
 #define TA_FLAG_REMAP_SUPPORT		(1 << 6) /* use map/unmap syscalls */
 #define TA_FLAG_CACHE_MAINTENANCE	(1 << 7) /* use cache flush syscall */
 


### PR DESCRIPTION
Rename TA_FLAG_UNSAFE_NW_PARAMS into TA_FLAG_SECURE_DATA_PATH.

This change does NOT able secure data path support in OP-TEE. It is
rather a pre-requisite for later changes in OP-TEE regarding SDP
support.

This change expects https://github.com/OP-TEE/optee_test/pull/181 is previous merged.

This PR is extracted from https://github.com/OP-TEE/optee_os/pull/1322 and supersedes change proposal from https://github.com/OP-TEE/optee_os/pull/1322/commits/00317254274a5b6b24403c57496b9492e90de903 . It has already been reviewed in this scope.

