### PR TITLE
core: arm64: support relocation type R_AARCH64_ABS64 (257)

### DIFF
--- a/core/arch/arm/kernel/elf_common.h
+++ b/core/arch/arm/kernel/elf_common.h
@@ -645,6 +645,7 @@ typedef struct {
 #define	R_386_TLS_TPOFF32	37	/* GOT entry of -ve static TLS offset */
 #define	R_386_IRELATIVE		42	/* PLT entry resolved indirectly at runtime */
 
+#define	R_AARCH64_ABS64		257
 #define	R_AARCH64_RELATIVE 	1027
 
 #define	R_ARM_NONE		0	/* No relocation. */


### PR DESCRIPTION
If a 64-bit TA contains relocations of type R_AARCH64_ABS64, OP-TEE
refuses to load it and logs the following error:

  ERROR:   TEE-CORE: Unknown relocation type 257

This relocation type does not seem to happen in our test applications,
but someone has experienced the issue after linking a TA against a
third-party static library [1]. I could reporoduce the issue by adding
the following assembly code to a TA:

```
        .pushsection .rodata
        .global _reloc__text_start
_reloc__text_start:
        .quad __text_start
        .popsection
```
(this adds a 64-bit value into the .rodata section of the TA, exported
as a global symbol called _reloc__text_start, its value is set to the
__text_start address).

This commit adds the necessary code to support R_AARCH64_ABS64.

[1] https://github.com/OP-TEE/optee_os/issues/1399

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (qemu_v8)