### PR TITLE
core: syscall_storage_reset_enum() must check e->fops before using it

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -705,9 +705,12 @@ TEE_Result syscall_storage_reset_enum(unsigned long obj_enum)
 	if (res != TEE_SUCCESS)
 		return res;
 
-	e->fops->closedir(e->dir);
-	e->fops = NULL;
-	e->dir = NULL;
+	if (e->fops) {
+		e->fops->closedir(e->dir);
+		e->fops = NULL;
+		e->dir = NULL;
+	}
+	assert(!e->dir);
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
An object enumerator that has just been allocated or reset has its fops
field set to NULL. So, syscall_storage_reset_enum() must take care of
this.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Fixes: https://github.com/OP-TEE/optee_os/issues/1417