### PR TITLE
core: arm: add support for i.MX6 Dual Lite SabreSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,6 +191,7 @@ script:
   # i.MX6Quad SABRE
   - $make PLATFORM=imx-mx6qsabrelite
   - $make PLATFORM=imx-mx6qsabresd
+  - $make PLATFORM=imx-mx6dlsabresd
 
   # Texas Instruments dra7xx
   - $make PLATFORM=ti-dra7xx

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -3,7 +3,7 @@ PLATFORM_FLAVOR ?= mx6ulevk
 ifeq ($(PLATFORM_FLAVOR),mx6ulevk)
 arm32-platform-cpuarch		:= cortex-a7
 endif
-ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd))
+ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd mx6dlsabresd))
 arm32-platform-cpuarch		:= cortex-a9
 endif
 arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
@@ -19,7 +19,7 @@ $(call force,CFG_WITH_SOFTWARE_PRNG,y)
 ifeq ($(PLATFORM_FLAVOR),mx6ulevk)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 endif
-ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd))
+ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd mx6dlsabresd))
 $(call force,CFG_PL310,y)
 $(call force,CFG_PL310_LOCKED,y)
 $(call force,CFG_SECURE_TIME_SOURCE_REE,y)

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -45,7 +45,8 @@
 #include <tee/entry_std.h>
 
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
+	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
+	defined(PLATFORM_FLAVOR_mx6dlsabresd)
 #include <kernel/tz_ssvce_pl310.h>
 #endif
 
@@ -70,7 +71,8 @@ register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CORE_MMU_DEVICE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_DEVICE_SIZE);
 
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
+	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
+	defined(PLATFORM_FLAVOR_mx6dlsabresd)
 register_phys_mem(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_DEVICE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, SRC_BASE, CORE_MMU_DEVICE_SIZE);
 #endif
@@ -86,7 +88,8 @@ static void main_fiq(void)
 }
 
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
+	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
+	defined(PLATFORM_FLAVOR_mx6dlsabresd)
 void plat_cpu_reset_late(void)
 {
 	uintptr_t addr;
@@ -153,7 +156,8 @@ void main_init_gic(void)
 }
 
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
+	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
+	defined(PLATFORM_FLAVOR_mx6dlsabresd)
 vaddr_t pl310_base(void)
 {
 	static void *va __early_bss;

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -113,7 +113,8 @@
 /* For i.MX6 Quad SABRE Lite and Smart Device board */
 
 #elif defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
+	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
+	defined(PLATFORM_FLAVOR_mx6dlsabresd)
 
 #define SCU_BASE			0x00A00000
 #define PL310_BASE			0x00A02000
@@ -128,8 +129,16 @@
 #define GICD_OFFSET			0x1000
 #define GIC_CPU_BASE			(GIC_BASE + GICC_OFFSET)
 #define GIC_DIST_BASE			(GIC_BASE + GICD_OFFSET)
+
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
 #define UART1_BASE			0x02020000
 #define UART2_BASE			0x021E8000
+#else
+#define UART1_BASE			0x02020000
+#define UART3_BASE			0x021EC000
+#define UART5_BASE			0x021F4000
+#endif
 
 /* Central Security Unit register values */
 #define CSU_BASE			0x021C0000
@@ -146,12 +155,20 @@
 #if defined(PLATFORM_FLAVOR_mx6qsabresd)
 #define CONSOLE_UART_BASE		UART1_BASE
 #endif
+#if defined(PLATFORM_FLAVOR_mx6dlsabresd)
+#define CONSOLE_UART_BASE		UART1_BASE
+#endif
 #define DRAM0_BASE			0x10000000
 #define DRAM0_SIZE			0x40000000
 
 #define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
 
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
 #define CFG_TEE_CORE_NB_CORE		4
+#else
+#define CFG_TEE_CORE_NB_CORE		2
+#endif
 
 #define DDR_PHYS_START			DRAM0_BASE
 #define DDR_SIZE			DRAM0_SIZE
@@ -200,7 +217,12 @@
  * Full Line Zero (FLZ) disabled (bit0=0)
  */
 #ifndef PL310_AUX_CTRL_INIT
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
 #define PL310_AUX_CTRL_INIT		0x3C470800
+#else
+#define PL310_AUX_CTRL_INIT		0x3C440800
+#endif
 #endif
 
 /*
@@ -384,7 +406,12 @@
  * Cacheable accesses have high prio (bit10=0)
  * Full Line Zero (FLZ) disabled (bit0=0)
  */
+#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
+	defined(PLATFORM_FLAVOR_mx6qsabresd)
 #define PL310_AUX_CTRL_INIT		0x3C470800
+#else
+#define PL310_AUX_CTRL_INIT		0x3C440800
+#endif
 
 /*
  * Prefetch Control Register

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -6,4 +6,5 @@ srcs-$(CFG_PSCI_ARM32) += psci.c
 
 srcs-$(PLATFORM_FLAVOR_mx6qsabrelite) += a9_plat_init.S
 srcs-$(PLATFORM_FLAVOR_mx6qsabresd) += a9_plat_init.S
+srcs-$(PLATFORM_FLAVOR_mx6dlsabresd) += a9_plat_init.S
 srcs-$(PLATFORM_FLAVOR_mx6ulevk) += imx6ul.c


### PR DESCRIPTION
This patch adds support for the Dual Lite version of the i.MX6 Sabre SD reference board.

In addition to add support for yet another board, it adds support for the Solo/DualLite family of NXP i.MX6 SoCs.

Signed-off-by: Mathieu Briand <mbriand@witekio.com>