### PR TITLE
core: arm: Rework i.MX6 source files

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -1,11 +1,28 @@
 PLATFORM_FLAVOR ?= mx6ulevk
 
-ifeq ($(PLATFORM_FLAVOR),mx6ulevk)
-arm32-platform-cpuarch		:= cortex-a7
+# Get SoC associated with the PLATFORM_FLAVOR
+mx6ul-flavorlist = mx6ulevk
+mx6q-flavorlist = mx6qsabrelite mx6qsabresd
+mx6d-flavorlist =
+mx6dl-flavorlist = mx6dlsabresd
+mx6s-flavorlist =
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6ul-flavorlist)))
+$(call force,CFG_MX6UL,y)
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6q-flavorlist)))
+$(call force,CFG_MX6Q,y)
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6d-flavorlist)))
+$(call force,CFG_MX6D,y)
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6dl-flavorlist)))
+$(call force,CFG_MX6DL,y)
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6s-flavorlist)))
+$(call force,CFG_MX6S,y)
+else
+$(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif
-ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd mx6dlsabresd))
-arm32-platform-cpuarch		:= cortex-a9
-endif
+
+
+# Common i.MX6 config
 arm32-platform-cflags		+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags		+= -mcpu=$(arm32-platform-cpuarch)
 core_arm32-platform-aflags	+= -mfpu=neon
@@ -16,10 +33,23 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_IMX_UART,y)
 $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
-ifeq ($(PLATFORM_FLAVOR),mx6ulevk)
+
+CFG_CRYPTO_SIZE_OPTIMIZATION ?= n
+CFG_WITH_STACK_CANARIES ?= y
+
+
+# i.MX6UL specific config
+ifeq ($(CFG_MX6UL),y)
+arm32-platform-cpuarch		:= cortex-a7
+
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 endif
-ifeq ($(PLATFORM_FLAVOR),$(filter $(PLATFORM_FLAVOR),mx6qsabrelite mx6qsabresd mx6dlsabresd))
+
+
+# i.MX6 Solo/DualLite/Dual/Quad specific config
+ifeq ($(filter y, $(CFG_MX6Q) $(CFG_MX6D) $(CFG_MX6DL) $(CFG_MX6S)), y)
+arm32-platform-cpuarch		:= cortex-a9
+
 $(call force,CFG_PL310,y)
 $(call force,CFG_PL310_LOCKED,y)
 $(call force,CFG_SECURE_TIME_SOURCE_REE,y)
@@ -28,7 +58,6 @@ CFG_BOOT_SYNC_CPU ?= y
 CFG_BOOT_SECONDARY_REQUEST ?= y
 endif
 
+
 ta-targets = ta_arm32
 
-CFG_CRYPTO_SIZE_OPTIMIZATION ?= n
-CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-imx/imx6-regs.h
+++ b/core/arch/arm/plat-imx/imx6-regs.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ * Copyright (c) 2016, Wind River Systems.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define SCU_BASE			0x00A00000
+#define PL310_BASE			0x00A02000
+#define SRC_BASE			0x020D8000
+#define SRC_SCR				0x000
+#define SRC_GPR1			0x020
+#define SRC_SCR_CPU_ENABLE_ALL		SHIFT_U32(0x7, 22)
+#define SRC_SCR_CORE1_RST_OFFSET	14
+#define SRC_SCR_CORE1_ENABLE_OFFSET	22
+#define GIC_BASE			0x00A00000
+#define GICC_OFFSET			0x100
+#define GICD_OFFSET			0x1000
+#define GIC_CPU_BASE			(GIC_BASE + GICC_OFFSET)
+#define GIC_DIST_BASE			(GIC_BASE + GICD_OFFSET)
+
+#define UART1_BASE			0x02020000
+#define UART2_BASE			0x021E8000
+#define UART4_BASE			0x021F0000
+
+#if defined(CFG_MX6Q) || defined(CFG_MX6D)
+#define UART3_BASE			0x021EC000
+#define UART5_BASE			0x021F4000
+#endif
+
+/* Central Security Unit register values */
+#define CSU_BASE			0x021C0000
+#define CSU_CSL_START			0x0
+#define CSU_CSL_END			0xA0
+#define CSU_CSL5			0x14
+#define CSU_CSL16			0x40
+#define CSU_ACCESS_ALL			0x00FF00FF
+#define CSU_SETTING_LOCK		0x01000100
+
+#define DRAM0_BASE			0x10000000

--- a/core/arch/arm/plat-imx/imx6ul-regs.h
+++ b/core/arch/arm/plat-imx/imx6ul-regs.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * All rights reserved.
+ * Copyright (c) 2016, Wind River Systems.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define GIC_BASE			0xA00000
+#define GIC_SIZE			0x8000
+#define GICC_OFFSET			0x2000
+#define GICD_OFFSET			0x1000
+#define UART0_BASE			0x2020000
+#define UART1_BASE			0x21E8000
+#define UART2_BASE			0x21EC000
+
+#define AHB1_BASE			0x02000000
+#define AHB1_SIZE			0x100000
+#define AHB2_BASE			0x02100000
+#define AHB2_SIZE			0x100000
+#define AHB3_BASE			0x02200000
+#define AHB3_SIZE			0x100000
+
+#define AIPS_TZ1_BASE_ADDR		0x02000000
+#define AIPS1_OFF_BASE_ADDR		(AIPS_TZ1_BASE_ADDR + 0x80000)
+
+#define DRAM0_BASE			0x80000000
+#define DRAM0_SIZE			0x20000000
+
+/* Central Security Unit register values */
+#define CSU_BASE			0x021C0000
+#define CSU_CSL_START			0x0
+#define CSU_CSL_END			0xA0
+#define CSU_ACCESS_ALL			0x00FF00FF
+#define CSU_SETTING_LOCK		0x01000100
+

--- a/core/arch/arm/plat-imx/imx_pl310.c
+++ b/core/arch/arm/plat-imx/imx_pl310.c
@@ -31,8 +31,12 @@
 #include <kernel/generic_boot.h>
 #include <kernel/tz_ssvce_def.h>
 #include <kernel/tz_ssvce_pl310.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
 #include <platform_config.h>
 #include <stdint.h>
+
+register_phys_mem(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_DEVICE_SIZE);
 
 void arm_cl2_config(vaddr_t pl310_base)
 {
@@ -61,3 +65,16 @@ void arm_cl2_enable(vaddr_t pl310_base)
 	if (val & 1)
 		write_actlr(read_actlr() | (1 << 3));
 }
+
+vaddr_t pl310_base(void)
+{
+	static void *va __early_bss;
+
+	if (cpu_mmu_enabled()) {
+		if (!va)
+			va = phys_to_virt(PL310_BASE, MEM_AREA_IO_SEC);
+		return (vaddr_t)va;
+	}
+	return PL310_BASE;
+}
+

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -34,7 +34,8 @@
 
 /* For i.MX 6UltraLite EVK board */
 
-#if defined(PLATFORM_FLAVOR_mx6ulevk)
+#if defined(CFG_MX6UL)
+#include <imx6ul-regs.h>
 
 #ifdef CFG_WITH_PAGER
 #error "Pager not supported for platform mx6ulevk"
@@ -43,26 +44,6 @@
 #error "LPAE not supported for now"
 #endif
 
-#define GIC_BASE			0xA00000
-#define GIC_SIZE			0x8000
-#define GICC_OFFSET			0x2000
-#define GICD_OFFSET			0x1000
-#define UART0_BASE			0x2020000
-#define UART1_BASE			0x21E8000
-#define UART2_BASE			0x21EC000
-
-#define AHB1_BASE			0x02000000
-#define AHB1_SIZE			0x100000
-#define AHB2_BASE			0x02100000
-#define AHB2_SIZE			0x100000
-#define AHB3_BASE			0x02200000
-#define AHB3_SIZE			0x100000
-
-#define AIPS_TZ1_BASE_ADDR	0x02000000
-#define AIPS1_OFF_BASE_ADDR	(AIPS_TZ1_BASE_ADDR + 0x80000)
-
-#define DRAM0_BASE			0x80000000
-#define DRAM0_SIZE			0x20000000
 
 #define CFG_TEE_CORE_NB_CORE		1
 
@@ -103,52 +84,14 @@
 
 #define CONSOLE_UART_BASE		(UART0_BASE)
 
-/* Central Security Unit register values */
-#define CSU_BASE			0x021C0000
-#define CSU_CSL_START			0x0
-#define CSU_CSL_END			0xA0
-#define CSU_ACCESS_ALL			0x00FF00FF
-#define CSU_SETTING_LOCK		0x01000100
-
 /* For i.MX6 Quad SABRE Lite and Smart Device board */
 
-#elif defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
-	defined(PLATFORM_FLAVOR_mx6dlsabresd)
+#elif defined(CFG_MX6Q) || defined(CFG_MX6D) || defined(CFG_MX6DL) || \
+	defined(CFG_MX6S)
 
-#define SCU_BASE			0x00A00000
-#define PL310_BASE			0x00A02000
-#define SRC_BASE			0x020D8000
-#define SRC_SCR				0x000
-#define SRC_GPR1			0x020
-#define SRC_SCR_CPU_ENABLE_ALL		SHIFT_U32(0x7, 22)
-#define SRC_SCR_CORE1_RST_OFFSET	14
-#define SRC_SCR_CORE1_ENABLE_OFFSET	22
-#define GIC_BASE			0x00A00000
-#define GICC_OFFSET			0x100
-#define GICD_OFFSET			0x1000
-#define GIC_CPU_BASE			(GIC_BASE + GICC_OFFSET)
-#define GIC_DIST_BASE			(GIC_BASE + GICD_OFFSET)
+#include <imx6-regs.h>
 
-#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
-#define UART1_BASE			0x02020000
-#define UART2_BASE			0x021E8000
-#else
-#define UART1_BASE			0x02020000
-#define UART3_BASE			0x021EC000
-#define UART5_BASE			0x021F4000
-#endif
-
-/* Central Security Unit register values */
-#define CSU_BASE			0x021C0000
-#define CSU_CSL_START			0x0
-#define CSU_CSL_END			0xA0
-#define CSU_CSL5			0x14
-#define CSU_CSL16			0x40
-#define	CSU_ACCESS_ALL			0x00FF00FF
-#define CSU_SETTING_LOCK		0x01000100
-
+/* Board specific console UART */
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite)
 #define CONSOLE_UART_BASE		UART2_BASE
 #endif
@@ -158,17 +101,27 @@
 #if defined(PLATFORM_FLAVOR_mx6dlsabresd)
 #define CONSOLE_UART_BASE		UART1_BASE
 #endif
-#define DRAM0_BASE			0x10000000
-#define DRAM0_SIZE			0x40000000
 
-#define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
-
+/* Board specific RAM size */
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
+	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
+	defined(PLATFORM_FLAVOR_mx6dlsabresd)
+#define DRAM0_SIZE			0x40000000
+#endif
+
+/* Core number depends of SoC version. */
+#if defined(CFG_MX6Q)
 #define CFG_TEE_CORE_NB_CORE		4
-#else
+#endif
+#if defined(CFG_MX6D) || defined(CFG_MX6DL)
 #define CFG_TEE_CORE_NB_CORE		2
 #endif
+#if defined(CFG_MX6S)
+#define CFG_TEE_CORE_NB_CORE		1
+#endif
+
+/* Common RAM and cache controller configuration */
+#define CFG_TEE_RAM_VA_SIZE		(1024 * 1024)
 
 #define DDR_PHYS_START			DRAM0_BASE
 #define DDR_SIZE			DRAM0_SIZE
@@ -209,16 +162,18 @@
  * Shared attribute internally ignored (bit22=1, bit13=0)
  * Parity disabled (bit21=0)
  * Event monitor disabled (bit20=0)
- * Platform fmavor specific way config:
+ * Platform fmavor specific way config (dual / quad):
  * - 64kb way size (bit19:17=3b011)
  * - 16-way associciativity (bit16=1)
+ * Platform fmavor specific way config (dual lite / solo):
+ * - 32kb way size (bit19:17=3b010)
+ * - no 16-way associciativity (bit16=0)
  * Store buffer device limitation enabled (bit11=1)
  * Cacheable accesses have high prio (bit10=0)
  * Full Line Zero (FLZ) disabled (bit0=0)
  */
 #ifndef PL310_AUX_CTRL_INIT
-#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
+#if defined(CFG_MX6Q) || defined(CFG_MX6D)
 #define PL310_AUX_CTRL_INIT		0x3C470800
 #else
 #define PL310_AUX_CTRL_INIT		0x3C440800
@@ -310,16 +265,6 @@
 #define CFG_TA_RAM_START		TZDRAM_BASE
 #define CFG_TA_RAM_SIZE			TZDRAM_SIZE
 
-#define CFG_SHMEM_START			(CFG_DDR_TEETZ_RESERVED_START + \
-						TZDRAM_SIZE)
-#define CFG_SHMEM_SIZE			CFG_PUB_RAM_SIZE
-
-#define CFG_TEE_RAM_START		TZSRAM_BASE
-
-#ifndef CFG_TEE_LOAD_ADDR
-#define CFG_TEE_LOAD_ADDR		TZSRAM_BASE
-#endif
-
 #else /* CFG_WITH_PAGER */
 
 /*
@@ -355,8 +300,10 @@
 				CFG_TEE_RAM_PH_SIZE - \
 				CFG_PUB_RAM_SIZE)
 
+#endif /* CFG_WITH_PAGER */
+
 #define CFG_SHMEM_START			(CFG_DDR_TEETZ_RESERVED_START + \
-				TZDRAM_SIZE)
+					 TZDRAM_SIZE)
 #define CFG_SHMEM_SIZE			CFG_PUB_RAM_SIZE
 
 #define CFG_TEE_RAM_START		TZDRAM_BASE
@@ -365,73 +312,8 @@
 #define CFG_TEE_LOAD_ADDR		TZDRAM_BASE
 #endif
 
-#endif /* CFG_WITH_PAGER */
-
 #else
 #error "Unknown platform flavor"
-#endif /* defined(PLATFORM_FLAVOR_mx6ulevk) */
-
-#ifdef CFG_PL310
-/*
- * PL310 TAG RAM Control Register
- *
- * bit[10:8]:1 - 2 cycle of write accesses latency
- * bit[6:4]:1 - 2 cycle of read accesses latency
- * bit[2:0]:1 - 2 cycle of setup latency
- */
-#define PL310_TAG_RAM_CTRL_INIT		0x00000111
-
-/*
- * DATA RAM Control Register
- *
- * bit[10:8]:2 - 3 cycle of write accesses latency
- * bit[6:4]:2 - 3 cycle of read accesses latency
- * bit[2:0]:2 - 3 cycle of setup latency
- */
-#define PL310_DATA_RAM_CTRL_INIT	0x00000222
-
-/*
- * Auxiliary Control Register
- *
- * I/Dcache prefetch enabled (bit29:28=2b11)
- * NS can access interrupts (bit27=1)
- * NS can lockown cache lines (bit26=1)
- * Pseudo-random replacement policy (bit25=0)
- * Force write allocated (default)
- * Shared attribute internally ignored (bit22=1, bit13=0)
- * Parity disabled (bit21=0)
- * Event monitor disabled (bit20=0)
- * 64kB ways, 16-way associativity (bit19:17=3b011 bit16=1)
- * Store buffer device limitation enabled (bit11=1)
- * Cacheable accesses have high prio (bit10=0)
- * Full Line Zero (FLZ) disabled (bit0=0)
- */
-#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd)
-#define PL310_AUX_CTRL_INIT		0x3C470800
-#else
-#define PL310_AUX_CTRL_INIT		0x3C440800
-#endif
-
-/*
- * Prefetch Control Register
- *
- * Double linefill disabled (bit30=0)
- * I/D prefetch enabled (bit29:28=2b11)
- * Prefetch drop enabled (bit24=1)
- * Incr double linefill disable (bit23=0)
- * Prefetch offset = 7 (bit4:0)
- */
-#define PL310_PREFETCH_CTRL_INIT	0x31000007
-
-/*
- * Power Register = 0x00000003
- *
- * Dynamic clock gating enabled
- * Standby mode enabled
- */
-#define PL310_POWER_CTRL_INIT		0x00000003
-
 #endif
 
 #endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -4,7 +4,8 @@ srcs-y += main.c
 srcs-$(CFG_PL310) += imx_pl310.c
 srcs-$(CFG_PSCI_ARM32) += psci.c
 
-srcs-$(PLATFORM_FLAVOR_mx6qsabrelite) += a9_plat_init.S
-srcs-$(PLATFORM_FLAVOR_mx6qsabresd) += a9_plat_init.S
-srcs-$(PLATFORM_FLAVOR_mx6dlsabresd) += a9_plat_init.S
-srcs-$(PLATFORM_FLAVOR_mx6ulevk) += imx6ul.c
+ifneq (,$(filter y, $(CFG_MX6Q) $(CFG_MX6D) $(CFG_MX6DL)))
+srcs-y += a9_plat_init.S imx6.c
+endif
+
+srcs-$(CFG_MX6UL) += imx6ul.c


### PR DESCRIPTION
Add a CFG_MX6xxx variable for every i.MX6 SoC variants and get register
addresses and values based on these variables instead of relying on
board names.

Signed-off-by: Mathieu Briand <mbriand@witekio.com>

This patch cleans the i.MX6 support and makes the process of adding a new i.MX6 based board easier, as discussed in #1434 .

@MrVan , does it match the modifications you had in mind ? Do you see any other point that may be enhanced ?

Code and defines are grouped by ultralight vs non-ultralight SoC. Non ultralight is simply named "imx6" as naming it "imx6-sdldq" for Solo/DualLite/Dual/Quad seems quite complicated to read. Any opinion ?

Modifications only consist of code refactoring so it should not break anything. It was tested on mx6qsabrelite, mx6qsabresd and mx6dlsabresd boards. It was not tested on mx6ulevk board as I don't have one, maybe somebody can check if everything is still OK ?