### PR TITLE
core: arm: Enable interruptions on i.MX6

### DIFF
--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -84,7 +84,7 @@ const struct thread_handlers *generic_boot_get_handlers(void)
 
 static void main_fiq(void)
 {
-	panic();
+	gic_it_handle(&gic_data);
 }
 
 #if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \


### PR DESCRIPTION
Signed-off-by: Mathieu Briand <mbriand@witekio.com>

@MrVan : Do you know why it currently is a call to panic() ? Is there any known issue with interruptions on this platform ? I have been using interruptions on i.MX6 Quad/DualLite without seeing any issue on my side.