### PR TITLE
core: arm: Do not try to handle unsupported IRQ

### DIFF
--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -81,8 +81,6 @@
 /* Maximum number of interrups a GIC can support */
 #define GIC_MAX_INTS		1020
 
-#define GIC_SPURIOUS_ID		1023
-
 #define GICC_IAR_IT_ID_MASK	0x3ff
 #define GICC_IAR_CPU_ID_MASK	0x7
 #define GICC_IAR_CPU_ID_SHIFT	10
@@ -380,10 +378,10 @@ void gic_it_handle(struct gic_data *gd)
 	iar = gic_read_iar(gd);
 	id = iar & GICC_IAR_IT_ID_MASK;
 
-	if (id == GIC_SPURIOUS_ID)
-		DMSG("ignoring spurious interrupt");
-	else
+	if (id < gd->max_it)
 		itr_handle(id);
+	else
+		DMSG("ignoring interrupt %" PRIu32, id);
 
 	gic_write_eoir(gd, iar);
 }


### PR DESCRIPTION
Trying to handle an interrupt with an ID above the maximum  will result 
in a kernel panic as the itr_handle() function will try to disable this 
unhandled interruption.

Interrupts with a high ID will now be simply ignored.

Signed-off-by: Mathieu Briand <mbriand@witekio.com>

I believe the only cases where we can have an interrupt ID above the maximum are:
- Spurious interrupt (1023), already handled by existing code.
- Group interrupt (1022).

If I understood correctly the GIC documentation, group interrupt means the unhandled pending interrupt with the highest priority is for the non-secure world. I believe the only thing we can do in the secure world is to ignore it as it will be handled by the REE kernel.