### PR TITLE
mk/aosp_optee.mk: Allow extra flags for aosp builds

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -1,13 +1,14 @@
 ##########################################################
 ## Common mk file used for Android to compile and       ##
-## integrate OP-TEE related components                   ##
-## Following flags need to be defined in device.mk    ##
+## integrate OP-TEE related components                  ##
+## Following flags need to be defined in optee*.mk      ##
 ##    OPTEE_OS_DIR                                      ##
 ##    OPTEE_TA_TARGETS                                  ##
 ##    OPTEE_CFG_ARM64_CORE                              ##
 ##    OPTEE_PLATFORM                                    ##
 ##    OPTEE_PLATFORM_FLAVOR                             ##
-## And BUILD_OPTEE_MK needs to be defined in device.mk  ##
+##    OPTEE_EXTRA_FLAGS (optional)                      ##
+## And BUILD_OPTEE_MK needs to be defined in optee*.mk  ##
 ## to point to this file                                ##
 ##                                                      ##
 ## local_module needs to be defined before including    ##
@@ -50,7 +51,8 @@ BUILD_OPTEE_OS:
 		CFG_ARM64_core=$(OPTEE_CFG_ARM64_CORE) \
 		PLATFORM=$(OPTEE_PLATFORM) \
 		PLATFORM_FLAVOR=$(OPTEE_PLATFORM_FLAVOR) \
-		$(CROSS_COMPILE_LINE)
+		$(CROSS_COMPILE_LINE) \
+		$(OPTEE_EXTRA_FLAGS)
 	@echo "Finished building optee_os..."
 
 endif


### PR DESCRIPTION
Set core and TA log level to 3.
Set debug build.

Signed-off-by: Victor Chong <victor.chong@linaro.org>