### PR TITLE
core: arm: imx: correct PCR settings

### DIFF
--- a/core/arch/arm/plat-imx/a9_plat_init.S
+++ b/core/arch/arm/plat-imx/a9_plat_init.S
@@ -85,7 +85,7 @@ UNWIND(	.fnstart)
 	 * - NSec cannot access PLE (PLE bit16=0)
 	 * - NSec can use SIMD/VFP (CP10/CP11) (bit15:14=2b00, bit11:10=2b11)
 	 *
-	 * PCR = 0x00000001
+	 * PCR
 	 * - no change latency, enable clk gating
 	 */
 	movw r0, #0x4000
@@ -100,8 +100,8 @@ UNWIND(	.fnstart)
 	movt r0, #0x0002
 	write_nsacr r0
 
-	movw r0, #0x0000
-	movt r0, #0x0001
+	read_pcr r0
+	orr r0, r0, #0x1
 	write_pcr r0
 
 	mov pc, lr


### PR DESCRIPTION
According to Cortex A9 TRM, bit[10:8] of PCR is max_clk_latency:
Samples the value present on the MAXCLKLATENCY pins on exit from reset.
This value reflects an implementation-specific parameter.
ARM strongly recommends that the software does not modify it.

So change the value to 0 is not wise, correct it.

Signed-off-by: `Peng Fan <peng.fan@nxp.com>`