### PR TITLE
Update the Maintainer of some boards

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,8 +10,8 @@ for these platforms.
 | Allwinner A80 Board			|`Sun Yangbang <sunny@allwinnertech.com>`|
 | ARM Juno Board			|`Linaro <op-tee@linaro.org>`|
 | FSL ls1021a				|`Sumit Garg <sumit.garg@freescale.com>`|
-| FSL i.MX6 Quad SABRE Lite Board	|`Yan Yan <yan.yan@windriver.com>`|
-| FSL i.MX6 Quad SABRE SD Board		|`Yan Yan <yan.yan@windriver.com>`|
+| FSL i.MX6 Quad SABRE Lite Board	|`Yan Yan <yan.yan@windriver.com>`,`Feng Yu <Yu.Feng@windriver.com>`|
+| FSL i.MX6 Quad SABRE SD Board		|`Yan Yan <yan.yan@windriver.com>`,`Feng Yu <Yu.Feng@windriver.com>`|
 | FSL i.MX6 UltraLite EVK Board		|`Peng Fan <peng.fan@nxp.com>`|
 | ARM Foundation FVP			|`Linaro <op-tee@linaro.org>`|
 | HiKey Board (HiSilicon Kirin 620)	|`Linaro <op-tee@linaro.org>`|
@@ -23,6 +23,6 @@ for these platforms.
 | STMicroelectronics b2260 - h410	|`Linaro <op-tee@linaro.org>`|
 | STMicroelectronics b2120 - h310 / h410|`Linaro <op-tee@linaro.org>`|
 | Texas Instruments DRA7xx		|`Harinarayan Bhatta <harinarayan@ti.com>`|
-| Xilinx Zynq 7000 ZC702 Board		|`Yan Yan <yan.yan@windriver.com>`|
+| Xilinx Zynq 7000 ZC702 Board		|`Yan Yan <yan.yan@windriver.com>`,`Feng Yu <Yu.Feng@windriver.com>`|
 | Xilinx Zynq UltraScale+ MPSOC		|`Sören Brinkmann <soren.brinkmann@xilinx.com`|
 | Spreadtrum SC9860			|`Aijun Sun <aijun.sun@spreadtrum.com>`|


### PR DESCRIPTION
Update the Maintainer of i.MX6 Quad SABRE Lite, i.MX6 Quad SABRE SD and Zynq 7000 ZC702.