### PR TITLE
core: fix console drivers against pager

### DIFF
--- a/core/drivers/cdns_uart.c
+++ b/core/drivers/cdns_uart.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <drivers/cdns_uart.h>
 #include <io.h>
+#include <keep.h>
 #include <mm/core_mmu.h>
 #include <util.h>
 
@@ -107,6 +108,7 @@ static const struct serial_ops cdns_uart_ops = {
 	.have_rx_data = cdns_uart_have_rx_data,
 	.putc = cdns_uart_putc,
 };
+KEEP_PAGER(cdns_uart_ops);
 
 /*
  * we rely on the bootloader having set up the HW correctly, we just enable

--- a/core/drivers/hi16xx_uart.c
+++ b/core/drivers/hi16xx_uart.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <drivers/hi16xx_uart.h>
 #include <io.h>
+#include <keep.h>
 #include <mm/core_mmu.h>
 #include <util.h>
 
@@ -129,6 +130,7 @@ static const struct serial_ops hi16xx_uart_ops = {
 	.have_rx_data = hi16xx_uart_have_rx_data,
 	.putc = hi16xx_uart_putc,
 };
+KEEP_PAGER(hi16xx_uart_ops);
 
 void hi16xx_uart_init(struct hi16xx_uart_data *pd, paddr_t base,
 		      uint32_t uart_clk, uint32_t baud_rate)

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <drivers/imx_uart.h>
 #include <io.h>
+#include <keep.h>
 #include <util.h>
 
 /* Register definitions */
@@ -120,6 +121,7 @@ static const struct serial_ops imx_uart_ops = {
 	.getchar = imx_uart_getchar,
 	.putc = imx_uart_putc,
 };
+KEEP_PAGER(imx_uart_ops);
 
 void imx_uart_init(struct imx_uart_data *pd, paddr_t base)
 {

--- a/core/drivers/ns16550.c
+++ b/core/drivers/ns16550.c
@@ -28,6 +28,7 @@
 
 #include <drivers/ns16550.h>
 #include <io.h>
+#include <keep.h>
 #include <util.h>
 
 /* uart register defines */
@@ -74,6 +75,7 @@ static const struct serial_ops ns16550_ops = {
 	.flush = ns16550_flush,
 	.putc = ns16550_putc,
 };
+KEEP_PAGER(ns16550_ops);
 
 void ns16550_init(struct ns16550_data *pd, paddr_t base)
 {

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <drivers/pl011.h>
 #include <io.h>
+#include <keep.h>
 #include <util.h>
 
 #define UART_DR		0x00 /* data register */
@@ -141,6 +142,7 @@ static const struct serial_ops pl011_ops = {
 	.have_rx_data = pl011_have_rx_data,
 	.putc = pl011_putc,
 };
+KEEP_PAGER(pl011_ops);
 
 void pl011_init(struct pl011_data *pd, paddr_t base, uint32_t uart_clk,
 		uint32_t baud_rate)

--- a/core/drivers/pl050.c
+++ b/core/drivers/pl050.c
@@ -26,8 +26,9 @@
  */
 #include <compiler.h>
 #include <drivers/pl050.h>
-#include <util.h>
 #include <io.h>
+#include <keep.h>
+#include <util.h>
 
 #define KMI_ICR		0x00
 #define KMI_STAT	0x04
@@ -91,6 +92,7 @@ static const struct serial_ops pl050_ops = {
 	.have_rx_data = pl050_have_rx_data,
 	.getchar = pl050_getchar,
 };
+KEEP_PAGER(pl050_ops);
 
 void pl050_init(struct pl050_data *pd, vaddr_t base, uint32_t clk)
 {

--- a/core/drivers/scif.c
+++ b/core/drivers/scif.c
@@ -27,6 +27,7 @@
  */
 #include <drivers/scif.h>
 #include <io.h>
+#include <keep.h>
 #include <util.h>
 
 #define SCIF_SCFSR		(0x10)
@@ -74,6 +75,7 @@ static const struct serial_ops scif_uart_ops = {
 	.flush = scif_uart_flush,
 	.putc = scif_uart_putc,
 };
+KEEP_PAGER(scif_uart_ops);
 
 void scif_uart_init(struct scif_uart_data *pd, vaddr_t base)
 {

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -26,9 +26,10 @@
  */
 
 #include <compiler.h>
-#include <drivers/serial8250_uart.h>
 #include <console.h>
+#include <drivers/serial8250_uart.h>
 #include <io.h>
+#include <keep.h>
 #include <util.h>
 
 /* uart register defines */
@@ -104,6 +105,7 @@ static const struct serial_ops serial8250_uart_ops = {
 	.have_rx_data = serial8250_uart_have_rx_data,
 	.putc = serial8250_uart_putc,
 };
+KEEP_PAGER(serial8250_uart_ops);
 
 void serial8250_uart_init(struct serial8250_uart_data *pd, paddr_t base,
 			  uint32_t __unused uart_clk,

--- a/core/drivers/sprd_uart.c
+++ b/core/drivers/sprd_uart.c
@@ -27,6 +27,7 @@
  */
 #include <drivers/sprd_uart.h>
 #include <io.h>
+#include <keep.h>
 #include <util.h>
 
 /* Register definitions */
@@ -85,6 +86,7 @@ static const struct serial_ops sprd_uart_ops = {
 	.have_rx_data = sprd_uart_have_rx_data,
 	.putc = sprd_uart_putc,
 };
+KEEP_PAGER(sprd_uart_ops);
 
 void sprd_uart_init(struct sprd_uart_data *pd, paddr_t base)
 {

--- a/core/drivers/sunxi_uart.c
+++ b/core/drivers/sunxi_uart.c
@@ -26,6 +26,7 @@
  */
 #include <drivers/sunxi_uart.h>
 #include <io.h>
+#include <keep.h>
 #include <util.h>
 
 /* uart register defines */
@@ -108,6 +109,7 @@ static const struct serial_ops sunxi_uart_ops = {
 	.have_rx_data = sunxi_uart_have_rx_data,
 	.putc = sunxi_uart_putc,
 };
+KEEP_PAGER(sunxi_uart_ops);
 
 void sunxi_uart_init(struct sunxi_uart_data *pd, paddr_t base)
 {


### PR DESCRIPTION
Console operations structures must be kept in the unpaged sections
when pager is enable.
This PR fixes the OP-TEE when pager is enable.