### PR TITLE
core: arm: imx use early bss attribute for static variable

### DIFF
--- a/core/arch/arm/plat-imx/psci.c
+++ b/core/arch/arm/plat-imx/psci.c
@@ -43,7 +43,8 @@
 
 static vaddr_t src_base(void)
 {
-	static void *va __data; /* in case it's used before .bss is cleared */
+	/* in case it's used before .bss is cleared */
+	static void *va __early_bss;
 
 	if (cpu_mmu_enabled()) {
 		if (!va)


### PR DESCRIPTION
Use __early_bss attribute for the static variable.

Signed-off-by: `Peng Fan <peng.fan@nxp.com>`