### PR TITLE
core: fix typo in pager mapping setup

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -489,7 +489,7 @@ static void init_mem_map(struct tee_mmap_region *memory_map, size_t num_elems)
 	assert(map->type == MEM_AREA_TEE_RAM);
 	map->va = map->pa;
 #ifdef CFG_WITH_PAGER
-	map->region_size = SMALL_PAGE_SIZE,
+	map->region_size = SMALL_PAGE_SIZE;
 #endif
 	map->attr = core_mmu_type_to_attr(map->type);
 


### PR DESCRIPTION
This change fixes a typo in the core mapping setup when pager is enabled.
Looking back in OP-TEE history show this typo has been there since quite
a while.

Various build test showed the previous buggy implementation gave valid
settings. Yet, it looks far better once fixed.