### PR TITLE
Make executable memory non writable in the core

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -26,6 +26,8 @@ platform-hard-float-enabled := y
 endif
 endif
 
+CFG_CORE_RWDATA_NOEXEC ?= y
+
 ifeq ($(CFG_WITH_PAGER),y)
 ifeq ($(CFG_CORE_SANITIZE_KADDRESS),y)
 $(error Error: CFG_CORE_SANITIZE_KADDRESS not compatible with CFG_WITH_PAGER)

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -27,6 +27,10 @@ endif
 endif
 
 CFG_CORE_RWDATA_NOEXEC ?= y
+CFG_CORE_RODATA_NOEXEC ?= n
+ifeq ($(CFG_CORE_RODATA_NOEXEC),y)
+$(call force,CFG_CORE_RWDATA_NOEXEC,y)
+endif
 
 ifeq ($(CFG_WITH_PAGER),y)
 ifeq ($(CFG_CORE_SANITIZE_KADDRESS),y)

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -61,8 +61,17 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry);
 paddr_t generic_boot_core_hpen(void);
 #endif
 
-extern uint8_t __vcore_unpg_rwx_start[];
-extern uint8_t __vcore_unpg_rwx_size[];
+#define VCORE_UNPG_RX_PA	((paddr_t)__vcore_unpg_rx_start)
+#define VCORE_UNPG_RX_SZ	((size_t)__vcore_unpg_rx_size)
+#define VCORE_UNPG_RO_PA	((paddr_t)__vcore_unpg_ro_start)
+#define VCORE_UNPG_RO_SZ	((size_t)__vcore_unpg_ro_size)
+#define VCORE_UNPG_RW_PA	((paddr_t)__vcore_unpg_rw_start)
+#define VCORE_UNPG_RW_SZ	((size_t)__vcore_unpg_rw_size)
+#define VCORE_INIT_RX_PA	((paddr_t)__vcore_init_rx_start)
+#define VCORE_INIT_RX_SZ	((size_t)__vcore_init_rx_size)
+#define VCORE_INIT_RO_PA	((paddr_t)__vcore_init_ro_start)
+#define VCORE_INIT_RO_SZ	((size_t)__vcore_init_ro_size)
+
 extern uint8_t __vcore_unpg_rx_start[];
 extern uint8_t __vcore_unpg_rx_size[];
 extern uint8_t __vcore_unpg_ro_start[];

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -61,7 +61,6 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry);
 paddr_t generic_boot_core_hpen(void);
 #endif
 
-extern uint8_t __text_init_start[];
 extern uint8_t __text_start[];
 extern initcall_t __initcall_start;
 extern initcall_t __initcall_end;

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -61,6 +61,19 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry);
 paddr_t generic_boot_core_hpen(void);
 #endif
 
+extern uint8_t __vcore_unpg_rwx_start[];
+extern uint8_t __vcore_unpg_rwx_size[];
+extern uint8_t __vcore_unpg_rx_start[];
+extern uint8_t __vcore_unpg_rx_size[];
+extern uint8_t __vcore_unpg_ro_start[];
+extern uint8_t __vcore_unpg_ro_size[];
+extern uint8_t __vcore_unpg_rw_start[];
+extern uint8_t __vcore_unpg_rw_size[];
+extern uint8_t __vcore_init_rx_start[];
+extern uint8_t __vcore_init_rx_size[];
+extern uint8_t __vcore_init_ro_start[];
+extern uint8_t __vcore_init_ro_size[];
+
 extern uint8_t __text_start[];
 extern initcall_t __initcall_start;
 extern initcall_t __initcall_end;

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -148,6 +148,8 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 	return names[type];
 }
 
+#define MEM_AREA_TEE_RAM_RW_DATA	MEM_AREA_TEE_RAM
+
 struct core_mmu_phys_mem {
 	const char *name;
 	enum teecore_memtypes type;

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -87,7 +87,10 @@
 /*
  * Memory area type:
  * MEM_AREA_NOTYPE:   Undefined type. Used as end of table.
- * MEM_AREA_TEE_RAM:  teecore execution RAM (secure, reserved to TEE, unused)
+ * MEM_AREA_TEE_RAM:  core RAM (read/write/executable, secure, reserved to TEE)
+ * MEM_AREA_TEE_RAM_RX:  core private read-only/executable memory (secure)
+ * MEM_AREA_TEE_RAM_RO:  core private read-only/non-executable memory (secure)
+ * MEM_AREA_TEE_RAM_RW:  core private read/write/non-executable memory (secure)
  * MEM_AREA_TEE_COHERENT: teecore coherent RAM (secure, reserved to TEE)
  * MEM_AREA_TA_RAM:   Secure RAM where teecore loads/exec TA instances.
  * MEM_AREA_NSEC_SHM: NonSecure shared RAM between NSec and TEE.
@@ -103,6 +106,9 @@
 enum teecore_memtypes {
 	MEM_AREA_NOTYPE = 0,
 	MEM_AREA_TEE_RAM,
+	MEM_AREA_TEE_RAM_RX,
+	MEM_AREA_TEE_RAM_RO,
+	MEM_AREA_TEE_RAM_RW,
 	MEM_AREA_TEE_COHERENT,
 	MEM_AREA_TA_RAM,
 	MEM_AREA_NSEC_SHM,
@@ -121,7 +127,10 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 {
 	static const char * const names[] = {
 		[MEM_AREA_NOTYPE] = "NOTYPE",
-		[MEM_AREA_TEE_RAM] = "TEE_RAM",
+		[MEM_AREA_TEE_RAM] = "TEE_RAM_RWX",
+		[MEM_AREA_TEE_RAM_RX] = "TEE_RAM_RX",
+		[MEM_AREA_TEE_RAM_RO] = "TEE_RAM_RO",
+		[MEM_AREA_TEE_RAM_RW] = "TEE_RAM_RW",
 		[MEM_AREA_TEE_COHERENT] = "TEE_COHERENT",
 		[MEM_AREA_TA_RAM] = "TA_RAM",
 		[MEM_AREA_NSEC_SHM] = "NSEC_SHM",

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -148,7 +148,11 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 	return names[type];
 }
 
+#ifdef CFG_CORE_RWDATA_NOEXEC
+#define MEM_AREA_TEE_RAM_RW_DATA	MEM_AREA_TEE_RAM_RW
+#else
 #define MEM_AREA_TEE_RAM_RW_DATA	MEM_AREA_TEE_RAM
+#endif
 
 struct core_mmu_phys_mem {
 	const char *name;

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -293,18 +293,18 @@ UNWIND(	.cantunwind)
 	 *
 	 * The binary is built as:
 	 * [Pager code, rodata and data] : In correct location
-	 * [Init code and rodata] : Should be copied to __text_init_start
+	 * [Init code and rodata] : Should be copied to __init_start
 	 * [Hashes] : Should be saved before initializing pager
 	 *
 	 */
-	ldr	r0, =__text_init_start	/* dst */
+	ldr	r0, =__init_start	/* dst */
 	ldr	r1, =__data_end 	/* src */
 	ldr	r2, =__tmp_hashes_end	/* dst limit */
 	/* Copy backwards (as memmove) in case we're overlapping */
 	sub	r2, r2, r0		/* len */
 	add	r0, r0, r2
 	add	r1, r1, r2
-	ldr	r2, =__text_init_start
+	ldr	r2, =__init_start
 copy_init:
 	ldmdb	r1!, {r3, r8-r12, sp}
 	stmdb	r0!, {r3, r8-r12, sp}

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -83,7 +83,7 @@ FUNC _start , :
 	 *
 	 * The binary is built as:
 	 * [Pager code, rodata and data] : In correct location
-	 * [Init code and rodata] : Should be copied to __text_init_start
+	 * [Init code and rodata] : Should be copied to __init_start
 	 * [Hashes] : Should be saved before clearing bss
 	 *
 	 * When we copy init code and rodata into correct location we don't
@@ -91,9 +91,9 @@ FUNC _start , :
 	 * .heap, .nozi and .heap3 is much larger than the size of init
 	 * code and rodata and hashes.
 	 */
-	adr	x0, __text_init_start	/* dst */
-	adr	x1, __data_end 	/* src */
-	adr	x2, __rodata_init_end	/* dst limit */
+	adr	x0, __init_start	/* dst */
+	adr	x1, __data_end		/* src */
+	adr	x2, __init_end		/* dst limit */
 copy_init:
 	ldp	x3, x4, [x1], #16
 	stp	x3, x4, [x0], #16

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -93,6 +93,9 @@ SECTIONS
 	}
 	__text_end = .;
 
+#ifdef CFG_CORE_RODATA_NOEXEC
+	. = ALIGN(SMALL_PAGE_SIZE);
+#endif
 	__flatmap_unpg_rx_size = . - __flatmap_unpg_rx_start;
 	__flatmap_unpg_ro_start = .;
 
@@ -282,6 +285,9 @@ SECTIONS
 		. = ALIGN(8);
 	}
 
+#ifdef CFG_CORE_RODATA_NOEXEC
+	. = ALIGN(SMALL_PAGE_SIZE);
+#endif
 	__flatmap_init_rx_size = . - __flatmap_init_rx_start;
 	__flatmap_init_ro_start = .;
 
@@ -305,11 +311,6 @@ SECTIONS
 	/* vcore flat map stops here. No need to page align, rodata follows. */
 	__flatmap_init_ro_size = __init_end - __flatmap_init_ro_start;
 
-	.text_pageable : ALIGN(8) {
-		*(.text*)
-		. = ALIGN(8);
-	}
-
 	.rodata_pageable : ALIGN(8) {
 #ifdef CFG_DT
 		__rodata_dtdrv_start = .;
@@ -326,6 +327,14 @@ SECTIONS
 		__start_ta_head_section = . ;
 		KEEP(*(ta_head_section))
 		__stop_ta_head_section = . ;
+	}
+
+#ifdef CFG_CORE_RODATA_NOEXEC
+	. = ALIGN(SMALL_PAGE_SIZE);
+#endif
+
+	.text_pageable : ALIGN(8) {
+		*(.text*)
 		. = ALIGN(SMALL_PAGE_SIZE);
 	}
 
@@ -393,9 +402,14 @@ SECTIONS
 /* Unpaged read-only memories */
 PROVIDE(__vcore_unpg_rx_start = __flatmap_unpg_rx_start);
 PROVIDE(__vcore_unpg_ro_start = __flatmap_unpg_ro_start);
+#ifdef CFG_CORE_RODATA_NOEXEC
+PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size);
+PROVIDE(__vcore_unpg_ro_size = __flatmap_unpg_ro_size);
+#else
 PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size +
 				__flatmap_unpg_ro_size);
 PROVIDE(__vcore_unpg_ro_size = 0);
+#endif
 
 /* Unpaged read-write memory */
 PROVIDE(__vcore_unpg_rw_start = __flatmap_unpg_rw_start);
@@ -414,8 +428,14 @@ PROVIDE(__vcore_unpg_rw_size = __flatmap_unpg_rw_size);
 /* Paged/init read-only memories */
 PROVIDE(__vcore_init_rx_start = __flatmap_init_rx_start);
 PROVIDE(__vcore_init_ro_start = __flatmap_init_ro_start);
+#ifdef CFG_CORE_RODATA_NOEXEC
+PROVIDE(__vcore_init_rx_size = __flatmap_init_rx_size);
+PROVIDE(__vcore_init_ro_size = __flatmap_init_ro_size +
+				__FLATMAP_PAGER_TRAILING_SPACE);
+#else
 PROVIDE(__vcore_init_rx_size = __flatmap_init_rx_size +
 				__flatmap_init_ro_size +
 				__FLATMAP_PAGER_TRAILING_SPACE);
 PROVIDE(__vcore_init_ro_size = 0);
+#endif /* CFG_CORE_RODATA_NOEXEC */
 #endif /* CFG_WITH_PAGER */

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -63,6 +63,8 @@ SECTIONS
 	. = CFG_TEE_LOAD_ADDR;
 
 	__text_start = .;
+	__flatmap_unpg_rx_start = __text_start;
+
 	.text : {
 		KEEP(*(.text.boot.vectab1))
 		KEEP(*(.text.boot.vectab2))
@@ -87,6 +89,9 @@ SECTIONS
 		. = ALIGN(8);
 	}
 	__text_end = .;
+
+	__flatmap_unpg_rx_size = . - __flatmap_unpg_rx_start;
+	__flatmap_unpg_ro_start = .;
 
 	.rodata : ALIGN(8) {
 		__rodata_start = .;
@@ -163,6 +168,9 @@ SECTIONS
 		*(.ARM.extab*)
 		__extab_end = .;
 	}
+
+	__flatmap_unpg_ro_size = . - __flatmap_unpg_ro_start;
+	__flatmap_unpg_rw_start = .;
 
 	.data : ALIGN(8) {
 		/* writable data  */
@@ -248,7 +256,15 @@ SECTIONS
 		__heap2_end = .;
 	}
 
+	/* Start page aligned read-only memory */
+	__flatmap_unpg_rw_size = . - __flatmap_unpg_rw_start;
+
 	__init_start = .;
+	__flatmap_init_rx_start = .;
+
+	ASSERT(!(__flatmap_init_rx_start & (SMALL_PAGE_SIZE - 1)),
+		"read-write memory is not paged aligned")
+
 	.text_init : {
 /*
  * Include list of sections needed for boot initialization, this list
@@ -258,6 +274,9 @@ SECTIONS
 #include <text_init.ld.S>
 		. = ALIGN(8);
 	}
+
+	__flatmap_init_rx_size = . - __flatmap_init_rx_start;
+	__flatmap_init_ro_start = .;
 
 	.rodata_init : {
 #include <rodata_init.ld.S>
@@ -274,6 +293,9 @@ SECTIONS
 
 	__init_end = .;
 	__init_size = __init_end - __init_start;
+
+	/* vcore flat map stops here. No need to page align, rodata follows. */
+	__flatmap_init_ro_size = __init_end - __flatmap_init_ro_start;
 
 	.text_pageable : ALIGN(8) {
 		*(.text*)
@@ -344,7 +366,12 @@ SECTIONS
 	__init_mem_usage = __end - CFG_TEE_LOAD_ADDR;
 #endif
 	. = CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE;
+
 	_end_of_ram = .;
+
+#ifndef CFG_WITH_PAGER
+	__flatmap_unpg_rw_size = _end_of_ram - __flatmap_unpg_rw_start;
+#endif
 
 	/DISCARD/ : {
 		/* Strip unnecessary stuff */
@@ -354,3 +381,29 @@ SECTIONS
 	}
 
 }
+
+PROVIDE(__vcore_unpg_rwx_start = __flatmap_unpg_rx_start);
+#ifdef CFG_WITH_PAGER
+PROVIDE(__vcore_unpg_rwx_size = CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE -
+				__flatmap_unpg_rx_start);
+#else
+PROVIDE(__vcore_unpg_rwx_size = _end_of_ram - __flatmap_unpg_rx_start);
+#endif
+
+/* Unpaged read-only memories */
+PROVIDE(__vcore_unpg_rx_start = __flatmap_unpg_rx_start);
+PROVIDE(__vcore_unpg_ro_start = __flatmap_unpg_ro_start);
+PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size);
+PROVIDE(__vcore_unpg_ro_size = __flatmap_unpg_ro_size);
+
+/* Unpaged read-write memory */
+PROVIDE(__vcore_unpg_rw_start = __flatmap_unpg_rw_start);
+PROVIDE(__vcore_unpg_rw_size = __flatmap_unpg_rw_size);
+
+#ifdef CFG_WITH_PAGER
+/* Paged/init read-only memories */
+PROVIDE(__vcore_init_rx_start = __flatmap_init_rx_start);
+PROVIDE(__vcore_init_ro_start = __flatmap_init_ro_start);
+PROVIDE(__vcore_init_rx_size = __flatmap_init_rx_size);
+PROVIDE(__vcore_init_ro_size = __flatmap_init_ro_size);
+#endif /* CFG_WITH_PAGER */

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -50,6 +50,10 @@
 
 #include <platform_config.h>
 
+#ifndef SMALL_PAGE_SIZE
+#define SMALL_PAGE_SIZE		4096
+#endif
+
 OUTPUT_FORMAT(CFG_KERN_LINKER_FORMAT)
 OUTPUT_ARCH(CFG_KERN_LINKER_ARCH)
 
@@ -58,9 +62,8 @@ SECTIONS
 {
 	. = CFG_TEE_LOAD_ADDR;
 
-	/* text/read-only data */
+	__text_start = .;
 	.text : {
-		__text_start = .;
 		KEEP(*(.text.boot.vectab1))
 		KEEP(*(.text.boot.vectab2))
 		KEEP(*(.text.boot))
@@ -82,8 +85,8 @@ SECTIONS
 #endif
 		*(.sram.text.glue_7* .gnu.linkonce.t.*)
 		. = ALIGN(8);
-		__text_end = .;
 	}
+	__text_end = .;
 
 	.rodata : ALIGN(8) {
 		__rodata_start = .;
@@ -219,8 +222,10 @@ SECTIONS
 	 *
 	 * L1 mmu table requires 16 KiB alignment
 	 */
-	.nozi (NOLOAD) : ALIGN(16 * 1024) {
+	.nozi (NOLOAD) : {
 		__nozi_start = .;
+		ASSERT(!(__nozi_start & (16 * 1024 - 1)), "align nozi to 16kB");
+
 		KEEP(*(.nozi .nozi.*))
 		. = ALIGN(16);
 		__nozi_end = .;
@@ -239,12 +244,12 @@ SECTIONS
 		 * been reserved in .heap1
 		 */
 		. += CFG_CORE_HEAP_SIZE - (__heap1_end - __heap1_start);
-		. = ALIGN(4 * 1024);
+		. = ALIGN(SMALL_PAGE_SIZE);
 		__heap2_end = .;
 	}
 
-	.text_init : ALIGN(4 * 1024) {
-		__text_init_start = .;
+	__init_start = .;
+	.text_init : {
 /*
  * Include list of sections needed for boot initialization, this list
  * overlaps with unpaged.ld.S but since unpaged.ld.S is first all those
@@ -252,11 +257,9 @@ SECTIONS
  */
 #include <text_init.ld.S>
 		. = ALIGN(8);
-		__text_init_end = .;
 	}
 
-	.rodata_init : ALIGN(8) {
-		__rodata_init_start = .;
+	.rodata_init : {
 #include <rodata_init.ld.S>
 		. = ALIGN(8);
 		__start_phys_mem_map_section = . ;
@@ -267,21 +270,17 @@ SECTIONS
 		KEEP(*(phys_sdp_mem_section))
 		__end_phys_sdp_mem_section = . ;
 		. = ALIGN(8);
-		__rodata_init_end = .;
 	}
-	__init_start = __text_init_start;
+
 	__init_end = .;
-	__init_size = __init_end - __text_init_start;
+	__init_size = __init_end - __init_start;
 
 	.text_pageable : ALIGN(8) {
-		__text_pageable_start = .;
 		*(.text*)
 		. = ALIGN(8);
-		__text_pageable_end = .;
 	}
 
 	.rodata_pageable : ALIGN(8) {
-		__rodata_pageable_start = .;
 #ifdef CFG_DT
 		__rodata_dtdrv_start = .;
 		KEEP(*(.rodata.dtdrv))
@@ -297,22 +296,21 @@ SECTIONS
 		__start_ta_head_section = . ;
 		KEEP(*(ta_head_section))
 		__stop_ta_head_section = . ;
-		. = ALIGN(4 * 1024);
-		__rodata_pageable_end = .;
+		. = ALIGN(SMALL_PAGE_SIZE);
 	}
 
-	__pageable_part_start = __rodata_init_end;
-	__pageable_part_end = __rodata_pageable_end;
-	__pageable_start = __text_init_start;
+	__pageable_part_end = .;
+	__pageable_part_start = __init_end;
+	__pageable_start = __init_start;
 	__pageable_end = __pageable_part_end;
 
 	/*
 	 * Assign a safe spot to store the hashes of the pages before
 	 * heap is initialized.
 	 */
-	__tmp_hashes_start = __rodata_init_end;
+	__tmp_hashes_start = __init_end;
 	__tmp_hashes_size = ((__pageable_end - __pageable_start) /
-				(4 * 1024)) * 32;
+				SMALL_PAGE_SIZE) * 32;
 	__tmp_hashes_end = __tmp_hashes_start + __tmp_hashes_size;
 
 	__init_mem_usage = __tmp_hashes_end - CFG_TEE_LOAD_ADDR;
@@ -324,7 +322,7 @@ SECTIONS
 	ASSERT(__tmp_hashes_end < (CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE),
 		"OP-TEE can't fit init part into available physical memory")
 	ASSERT((CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE - __init_end) >
-		1 * 4096, "Too few free pages to initialize paging")
+		SMALL_PAGE_SIZE, "Too few free pages to initialize paging")
 
 
 #endif /*CFG_WITH_PAGER*/

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -53,6 +53,9 @@
 #ifndef SMALL_PAGE_SIZE
 #define SMALL_PAGE_SIZE		4096
 #endif
+#ifndef ROUNDUP
+#define ROUNDUP(x, y)		((((x) + (y) - 1) / (y)) * (y))
+#endif
 
 OUTPUT_FORMAT(CFG_KERN_LINKER_FORMAT)
 OUTPUT_ARCH(CFG_KERN_LINKER_ARCH)
@@ -169,6 +172,10 @@ SECTIONS
 		__extab_end = .;
 	}
 
+	/* Start page aligned read-write memory */
+#ifdef CFG_CORE_RWDATA_NOEXEC
+	. = ALIGN(SMALL_PAGE_SIZE);
+#endif
 	__flatmap_unpg_ro_size = . - __flatmap_unpg_ro_start;
 	__flatmap_unpg_rw_start = .;
 
@@ -290,8 +297,9 @@ SECTIONS
 		__end_phys_sdp_mem_section = . ;
 		. = ALIGN(8);
 	}
+	__rodata_init_end = .;
 
-	__init_end = .;
+	__init_end = ROUNDUP(__rodata_init_end, SMALL_PAGE_SIZE);
 	__init_size = __init_end - __init_start;
 
 	/* vcore flat map stops here. No need to page align, rodata follows. */
@@ -382,28 +390,32 @@ SECTIONS
 
 }
 
-PROVIDE(__vcore_unpg_rwx_start = __flatmap_unpg_rx_start);
-#ifdef CFG_WITH_PAGER
-PROVIDE(__vcore_unpg_rwx_size = CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE -
-				__flatmap_unpg_rx_start);
-#else
-PROVIDE(__vcore_unpg_rwx_size = _end_of_ram - __flatmap_unpg_rx_start);
-#endif
-
 /* Unpaged read-only memories */
 PROVIDE(__vcore_unpg_rx_start = __flatmap_unpg_rx_start);
 PROVIDE(__vcore_unpg_ro_start = __flatmap_unpg_ro_start);
-PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size);
-PROVIDE(__vcore_unpg_ro_size = __flatmap_unpg_ro_size);
+PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size +
+				__flatmap_unpg_ro_size);
+PROVIDE(__vcore_unpg_ro_size = 0);
 
 /* Unpaged read-write memory */
 PROVIDE(__vcore_unpg_rw_start = __flatmap_unpg_rw_start);
 PROVIDE(__vcore_unpg_rw_size = __flatmap_unpg_rw_size);
 
 #ifdef CFG_WITH_PAGER
+/*
+ * Core init mapping shall cover up to end of the physical RAM.
+ * This is required since the hash table is appended to the
+ * binary data after the firmware build sequence.
+ */
+#define __FLATMAP_PAGER_TRAILING_SPACE	\
+	(CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE - \
+		(__flatmap_init_ro_start + __flatmap_init_ro_size))
+
 /* Paged/init read-only memories */
 PROVIDE(__vcore_init_rx_start = __flatmap_init_rx_start);
 PROVIDE(__vcore_init_ro_start = __flatmap_init_ro_start);
-PROVIDE(__vcore_init_rx_size = __flatmap_init_rx_size);
-PROVIDE(__vcore_init_ro_size = __flatmap_init_ro_size);
+PROVIDE(__vcore_init_rx_size = __flatmap_init_rx_size +
+				__flatmap_init_ro_size +
+				__FLATMAP_PAGER_TRAILING_SPACE);
+PROVIDE(__vcore_init_ro_size = 0);
 #endif /* CFG_WITH_PAGER */

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -49,7 +49,7 @@
 
 #include "core_mmu_private.h"
 
-#define MAX_MMAP_REGIONS	10
+#define MAX_MMAP_REGIONS	13
 #define RES_VASPACE_SIZE	(CORE_MMU_PGDIR_SIZE * 10)
 #define SHM_VASPACE_SIZE	(1024 * 1024 * 32)
 
@@ -89,7 +89,18 @@ static struct memaccess_area nsec_shared[] = {
 register_sdp_mem(CFG_TEE_SDP_MEM_BASE, CFG_TEE_SDP_MEM_SIZE);
 #endif
 
+#ifdef CFG_CORE_RWDATA_NOEXEC
+register_phys_mem(MEM_AREA_TEE_RAM_RX, VCORE_UNPG_RX_PA, VCORE_UNPG_RX_SZ);
+register_phys_mem(MEM_AREA_TEE_RAM_RO, VCORE_UNPG_RO_PA, VCORE_UNPG_RO_SZ);
+register_phys_mem(MEM_AREA_TEE_RAM_RW, VCORE_UNPG_RW_PA, VCORE_UNPG_RW_SZ);
+#ifdef CFG_WITH_PAGER
+register_phys_mem(MEM_AREA_TEE_RAM_RX, VCORE_INIT_RX_PA, VCORE_INIT_RX_SZ);
+register_phys_mem(MEM_AREA_TEE_RAM_RO, VCORE_INIT_RO_PA, VCORE_INIT_RO_SZ);
+#endif
+#else
 register_phys_mem(MEM_AREA_TEE_RAM, CFG_TEE_RAM_START, CFG_TEE_RAM_PH_SIZE);
+#endif
+
 register_phys_mem(MEM_AREA_TA_RAM, CFG_TA_RAM_START, CFG_TA_RAM_SIZE);
 register_phys_mem(MEM_AREA_NSEC_SHM, CFG_SHMEM_START, CFG_SHMEM_SIZE);
 

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -642,7 +642,7 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 		/* Copy bits 39:12 from tbl[n] to ntbl */
 		ntbl = (tbl[n] & ((1ULL << 40) - 1)) & ~((1 << 12) - 1);
 
-		tbl = phys_to_virt(ntbl, MEM_AREA_TEE_RAM);
+		tbl = phys_to_virt(ntbl, MEM_AREA_TEE_RAM_RW_DATA);
 		if (!tbl)
 			return false;
 

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -495,7 +495,7 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 		core_mmu_set_info_table(tbl_info, 1, 0, tbl);
 	} else {
 		paddr_t ntbl = tbl[n] & ~((1 << 10) - 1);
-		void *l2tbl = phys_to_virt(ntbl, MEM_AREA_TEE_RAM);
+		void *l2tbl = phys_to_virt(ntbl, MEM_AREA_TEE_RAM_RW_DATA);
 
 		if (!l2tbl)
 			return false;
@@ -678,7 +678,7 @@ static paddr_t map_page_memarea(const struct tee_mmap_region *mm, uint32_t xlat)
 		l2 = core_mmu_alloc_l2(mm->size);
 	else
 		l2 = phys_to_virt(xlat & SECTION_PT_ATTR_MASK,
-				  MEM_AREA_TEE_RAM_DATA);
+				  MEM_AREA_TEE_RAM_RW_DATA);
 
 	/*
 	 * If allocation above failed, it panicked.

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -160,7 +160,7 @@ struct mobj *mobj_phys_alloc(paddr_t pa, size_t size, uint32_t cattr,
 
 	switch (battr) {
 	case CORE_MEM_TEE_RAM:
-		area_type = MEM_AREA_TEE_RAM;
+		area_type = MEM_AREA_TEE_RAM_RW_DATA;
 		break;
 	case CORE_MEM_TA_RAM:
 		area_type = MEM_AREA_TA_RAM;

--- a/core/arch/arm/plat-sunxi/kern.ld.S
+++ b/core/arch/arm/plat-sunxi/kern.ld.S
@@ -50,6 +50,10 @@
 
 #include <platform_config.h>
 
+#ifndef SMALL_PAGE_SIZE
+#define SMALL_PAGE_SIZE		4096
+#endif
+
 OUTPUT_FORMAT(CFG_KERN_LINKER_FORMAT)
 OUTPUT_ARCH(CFG_KERN_LINKER_ARCH)
 
@@ -57,6 +61,7 @@ ENTRY(_start)
 SECTIONS
 {
 	. = TEE_RAM_START;
+	__flatmap_unpg_rx_start = .;
 
 	/* text/read-only data */
 	.text : {
@@ -76,6 +81,13 @@ SECTIONS
 		*(.initcall4)
 		__initcall_end = .;
 	}
+
+#ifdef CFG_CORE_RODATA_NOEXEC
+	. = ALIGN(SMALL_PAGE_SIZE);
+#endif
+	__flatmap_unpg_rx_size = . - __flatmap_unpg_rx_start;
+	__flatmap_unpg_ro_start = .;
+
 
 	.interp : { *(.interp) }
 	.hash : { *(.hash) }
@@ -137,6 +149,12 @@ SECTIONS
 		__rodata_end = .;
 	}
 
+	/* Start page aligned read-write memory */
+#ifdef CFG_CORE_RWDATA_NOEXEC
+	. = ALIGN(SMALL_PAGE_SIZE);
+#endif
+	__flatmap_unpg_ro_size = . - __flatmap_unpg_ro_start;
+	__flatmap_unpg_rw_start = .;
 
 	.data : ALIGN(4) {
 		/* writable data  */
@@ -193,6 +211,25 @@ SECTIONS
 	. = TEE_RAM_START + TEE_RAM_SIZE;
 	_end_of_ram = .;
 
+	__flatmap_unpg_rw_size = _end_of_ram - __flatmap_unpg_rw_start;
+
 	/* Strip unnecessary stuff */
 	/DISCARD/ : { *(.comment .note .eh_frame) }
 }
+
+/* Read-only memories */
+PROVIDE(__vcore_unpg_rx_start = __flatmap_unpg_rx_start);
+PROVIDE(__vcore_unpg_ro_start = __flatmap_unpg_ro_start);
+
+#ifdef CFG_CORE_RODATA_NOEXEC
+PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size);
+PROVIDE(__vcore_unpg_ro_size = __flatmap_unpg_ro_size);
+#else
+PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size +
+				__flatmap_unpg_ro_size);
+PROVIDE(__vcore_unpg_ro_size = 0);
+#endif
+
+/* Read-write memory */
+PROVIDE(__vcore_unpg_rw_start = __flatmap_unpg_rw_start);
+PROVIDE(__vcore_unpg_rw_size = __flatmap_unpg_rw_size);


### PR DESCRIPTION
Make executable memory non writable in the OP-TEE core static mapping

(P-R title changed: drop the RFC state)

-1 core reuses the mmu xlat table when possible (allows core to map inside xlat already mapped)
 - Needed for non-LPAE mapping only.

-2 new core rx/ro/rw memory, align of core (private ?) memory on attributes boundaries, apply to map
 - `CFG_CORE_RWDATA_NOEXEC=y/n`    Separate executable and writable memories. Defaults to 'y'.
 - `CFG_CORE_RODATA_NOEXEC=y/n`     Separate executable and from rodata. Defaults to 'n'.

~-3 pager specific case: try to make rx pages non writable through the pager aliasing.~  => postponed
~-4 Last: enable write-implies-execute-never in mmu (when applicable, updated plat configs)~  => postponed
   

Happy review...