### PR TITLE
Fix OPTEE startup on RCAR H3 platform.

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -500,6 +500,7 @@ static void init_mem_map(struct tee_mmap_region *memory_map, size_t num_elems)
 		while (map->type != MEM_AREA_NOTYPE) {
 			map->attr = core_mmu_type_to_attr(map->type);
 			va -= map->size;
+			va = ROUNDDOWN(va, map->region_size);
 			map->va = va;
 			map++;
 		}
@@ -520,6 +521,7 @@ static void init_mem_map(struct tee_mmap_region *memory_map, size_t num_elems)
 		map++;
 		while (map->type != MEM_AREA_NOTYPE) {
 			map->attr = core_mmu_type_to_attr(map->type);
+			va = ROUNDUP(va, map->region_size);
 			map->va = va;
 			va += map->size;
 			map++;

--- a/core/drivers/scif.c
+++ b/core/drivers/scif.c
@@ -30,11 +30,13 @@
 #include <keep.h>
 #include <util.h>
 
+#define SCIF_SCSCR		(0x08)
 #define SCIF_SCFSR		(0x10)
 #define SCIF_SCFTDR		(0x0C)
 #define SCIF_SCFCR		(0x18)
 #define SCIF_SCFDR		(0x1C)
 
+#define SCSCR_TE		BIT(5)
 #define SCFSR_TDFE		BIT(5)
 #define SCFSR_TEND		BIT(6)
 
@@ -77,11 +79,13 @@ static const struct serial_ops scif_uart_ops = {
 };
 KEEP_PAGER(scif_uart_ops);
 
-void scif_uart_init(struct scif_uart_data *pd, vaddr_t base)
+void scif_uart_init(struct scif_uart_data *pd, paddr_t base)
 {
 	pd->base.pa = base;
 	pd->chip.ops = &scif_uart_ops;
 
-	/* Bootloader should initialize device for us */
+	/* Set Transmit Enable in Control register */
+	write16(read16(base + SCIF_SCSCR) | SCSCR_TE, base + SCIF_SCSCR);
+
 	scif_uart_flush(&pd->chip);
 }

--- a/core/include/drivers/scif.h
+++ b/core/include/drivers/scif.h
@@ -38,6 +38,6 @@ struct scif_uart_data {
 	struct serial_chip chip;
 };
 
-void scif_uart_init(struct scif_uart_data *pd, vaddr_t base);
+void scif_uart_init(struct scif_uart_data *pd, paddr_t base);
 
 #endif /* SCIF */


### PR DESCRIPTION
There are two patches that together fix https://github.com/OP-TEE/optee_os/issues/1460

One of them is RCAR-specific. Another one is more general, as it applicable to all platforms.