### PR TITLE
core: fix compile error with CFG_WITH_USER_TA=n

### DIFF
--- a/core/arch/arm/pta/pta_invoke_tests.c
+++ b/core/arch/arm/pta/pta_invoke_tests.c
@@ -350,8 +350,10 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 		return test_dump_sdp(nParamTypes, pParams);
 	case PTA_INVOKE_TESTS_CMD_SELF_TESTS:
 		return core_self_tests(nParamTypes, pParams);
+#if defined(CFG_WITH_USER_TA)
 	case PTA_INVOKE_TESTS_CMD_FS_HTREE:
 		return core_fs_htree_tests(nParamTypes, pParams);
+#endif
 	default:
 		break;
 	}

--- a/core/arch/arm/pta/sub.mk
+++ b/core/arch/arm/pta/sub.mk
@@ -1,7 +1,9 @@
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += pta_invoke_tests.c
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += core_self_tests.c
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += interrupt_tests.c
+ifeq ($(CFG_WITH_USER_TA),y)
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += core_fs_htree_tests.c
+endif
 srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_TA_GPROF_SUPPORT) += gprof.c
 


### PR DESCRIPTION
Fixes: 040bc0f04138 ("core: add test case for hash-tree")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>