### PR TITLE
mk/subdir.mk: clear gen-srcs when initializing

### DIFF
--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -4,7 +4,7 @@
 #
 # Output
 #
-# set srcs
+# set     srcs gen-srcs
 # set     cflags-$(oname) cflags-remove-$(oname)
 #         aflags-$(oname) aflags-remove-$(oname)
 #         cppflags-$(oname) cppflags-remove-$(oname)
@@ -16,6 +16,7 @@
 # source file
 
 srcs :=
+gen-srcs :=
 
 define process-subdir-srcs-y
 ifeq ($$(sub-dir),.)


### PR DESCRIPTION
When initializing in mk/subdir.mk to process another sub.mk clear
gen-srcs also to avoid leftovers from previous sub.mk.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Should fix issue https://github.com/OP-TEE/optee_os/issues/1466