### PR TITLE
core: increase size of the exception stack in AArch32 mode

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -66,14 +66,10 @@
 #endif
 #define STACK_THREAD_SIZE	8192
 
-#if TRACE_LEVEL > 0
 #ifdef CFG_CORE_SANITIZE_KADDRESS
 #define STACK_ABT_SIZE		3072
 #else
 #define STACK_ABT_SIZE		2048
-#endif
-#else
-#define STACK_ABT_SIZE		1024
 #endif
 
 #endif /*ARM32*/


### PR DESCRIPTION
'stack_abt' is too small when pager is enabled and needs to be increased.
'stack_abt' is used for aborts (prefetch/data/undef) and native/foreign
interruptions exceptions.

Tests on ARMv7 targets show that between 1000 and 1500 bytes of these
stacks are consumed at runtime. Tests considered configurations with
trace/debug/LPAE/VFP enabled and disabled. Tests were based on running
OP-TEE with the xtest non-regression suite.

Tested qemu_virt and b2260.