### PR TITLE
core: mm: print memory type name instead of numerical value

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -28,11 +28,13 @@
 #ifndef CORE_MMU_H
 #define CORE_MMU_H
 
+#include <assert.h>
 #include <compiler.h>
 #include <kernel/user_ta.h>
 #include <mm/tee_mmu_types.h>
 #include <platform_config.h>
 #include <types_ext.h>
+#include <util.h>
 
 /* A small page is the smallest unit of memory that can be mapped */
 #define SMALL_PAGE_SHIFT	12
@@ -112,6 +114,27 @@ enum teecore_memtypes {
 	MEM_AREA_SDP_MEM,
 	MEM_AREA_MAXTYPE
 };
+
+static inline const char *teecore_memtype_name(enum teecore_memtypes type)
+{
+	static const char * const names[] = {
+		[MEM_AREA_NOTYPE] = "NOTYPE",
+		[MEM_AREA_TEE_RAM] = "TEE_RAM",
+		[MEM_AREA_TEE_COHERENT] = "TEE_COHERENT",
+		[MEM_AREA_TA_RAM] = "TA_RAM",
+		[MEM_AREA_NSEC_SHM] = "NSEC_SHM",
+		[MEM_AREA_RAM_NSEC] = "RAM_NSEC",
+		[MEM_AREA_RAM_SEC] = "RAM_SEC",
+		[MEM_AREA_IO_NSEC] = "IO_NSEC",
+		[MEM_AREA_IO_SEC] = "IO_SEC",
+		[MEM_AREA_RES_VASPACE] = "RES_VASPACE",
+		[MEM_AREA_TA_VASPACE] = "TA_VASPACE",
+		[MEM_AREA_SDP_MEM] = "SDP_MEM",
+	};
+
+	COMPILE_TIME_ASSERT(ARRAY_SIZE(names) == MEM_AREA_MAXTYPE);
+	return names[type];
+}
 
 struct core_mmu_phys_mem {
 	const char *name;

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -320,8 +320,8 @@ static void add_phys_mem(struct tee_mmap_region *memory_map, size_t num_elems,
 	 * mapped as both secure and non-secure. This will probably not
 	 * happen often in practice.
 	 */
-	DMSG("%s %d 0x%08" PRIxPA " size 0x%08zx",
-	     mem->name, mem->type, mem->addr, mem->size);
+	DMSG("%s type %s 0x%08" PRIxPA " size 0x%08zx",
+	     mem->name, teecore_memtype_name(mem->type), mem->addr, mem->size);
 	while (true) {
 		if (n >= (num_elems - 1)) {
 			EMSG("Out of entries (%zu) in memory_map", num_elems);
@@ -356,10 +356,11 @@ static void add_phys_mem(struct tee_mmap_region *memory_map, size_t num_elems,
 }
 
 static void add_va_space(struct tee_mmap_region *memory_map, size_t num_elems,
-			 unsigned int type, size_t size, size_t *last) {
+			 enum teecore_memtypes type, size_t size, size_t *last)
+{
 	size_t n = 0;
 
-	DMSG("type %d size 0x%08zx", type, size);
+	DMSG("type %s size 0x%08zx", teecore_memtype_name(type), size);
 	while (true) {
 		if (n >= (num_elems - 1)) {
 			EMSG("Out of entries (%zu) in memory_map", num_elems);
@@ -467,11 +468,11 @@ static void dump_mmap_table(struct tee_mmap_region *memory_map)
 		vaddr_t __maybe_unused vstart;
 
 		vstart = map->va + ((vaddr_t)map->pa & (map->region_size - 1));
-		DMSG("type va %d 0x%08" PRIxVA "..0x%08" PRIxVA
-		     " pa 0x%08" PRIxPA "..0x%08" PRIxPA " size %#zx (%s)",
-		     map->type, vstart, vstart + map->size - 1,
-		     map->pa, (paddr_t)(map->pa + map->size - 1),
-		     map->size,
+		DMSG("type %-12s va 0x%08" PRIxVA "..0x%08" PRIxVA
+		     " pa 0x%08" PRIxPA "..0x%08" PRIxPA " size 0x%08zx (%s)",
+		     teecore_memtype_name(map->type), vstart,
+		     vstart + map->size - 1, map->pa,
+		     (paddr_t)(map->pa + map->size - 1), map->size,
 		     map->region_size == SMALL_PAGE_SIZE ? "smallpg" : "pgdir");
 	}
 }


### PR DESCRIPTION
Improve the legibility of the memory manager debug traces by
converting the memory types to strings before printing them in
dump_mmap_table() and add_phys_mem().

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>