### PR TITLE
am57xx: fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,6 +196,9 @@ script:
   # Texas Instruments DRA7xx
   - $make PLATFORM=ti-dra7xx
 
+  # Texas Instruments AM57xx
+  - $make PLATFORM=ti-am57xx
+
   # Texas Instruments AM43xx
   - $make PLATFORM=ti-am43xx
 

--- a/core/arch/arm/plat-ti/platform_config.h
+++ b/core/arch/arm/plat-ti/platform_config.h
@@ -45,8 +45,10 @@
 
 #if defined(PLATFORM_FLAVOR_dra7xx)
 #define CONSOLE_UART_BASE       UART1_BASE
-#elif
+#elif defined(PLATFORM_FLAVOR_am57xx)
 #define CONSOLE_UART_BASE       UART3_BASE
+#else
+#error "Unknown platform flavor"
 #endif
 
 #define CONSOLE_BAUDRATE        115200


### PR DESCRIPTION
Fix "#elif with no expression" error when building with `ti-am57xx` flavor

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`