### PR TITLE
core: fix build with DEBUG=y and LOG_LEVEL=0

### DIFF
--- a/core/arch/arm/include/kernel/unwind.h
+++ b/core/arch/arm/include/kernel/unwind.h
@@ -34,6 +34,7 @@
 #define KERNEL_UNWIND
 
 #ifndef ASM
+#include <compiler.h>
 #include <types_ext.h>
 
 #ifdef ARM32


### PR DESCRIPTION
Fix build issue with CFG_TEE_CORE_DEBUG=y and CFG_TEE_CORE_LOG_LEVEL=0.