### PR TITLE
core: mm: change type of tee_mmap_region.region_size

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -776,7 +776,7 @@ static void *map_pa2va(struct tee_mmap_region *map, paddr_t pa)
 	if (!pa_is_in_map(map, pa))
 		return NULL;
 	return (void *)((pa & (map->region_size - 1)) |
-		((map->va + pa - map->pa) & ~((vaddr_t)map->region_size - 1)));
+		((map->va + pa - map->pa) & ~(map->region_size - 1)));
 }
 
 /*

--- a/core/include/mm/tee_mmu_types.h
+++ b/core/include/mm/tee_mmu_types.h
@@ -68,11 +68,11 @@
 
 struct tee_mmap_region {
 	unsigned int type; /* enum teecore_memtypes */
-	unsigned int region_size;
+	uint32_t attr; /* TEE_MATTR_* above */
 	paddr_t pa;
 	vaddr_t va;
 	size_t size;
-	uint32_t attr; /* TEE_MATTR_* above */
+	size_t region_size;
 };
 
 struct tee_ta_region {


### PR DESCRIPTION
tee_mmap_region.region_size is widely used across the source.
It's often manipulated by ROUNDDOWN()/ROUNDUP(). And because of
the type of region_size is uint32_t, (region_size - 1) in the micros
shall be 0xffffffff. As a result, in 64-bit platform, they discard
upper 32-bit by accident. This patch also removed a former fix that
doing explicitly type conversion in map_pa2va().

Signed-off-by: Zhizhou Zhang <zhizhouzhang@asrmicro.com>