### PR TITLE
core: arm: mm: LPAE: init_xlation_table(): skip dynamic entries properly

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -361,12 +361,14 @@ static struct tee_mmap_region *init_xlation_table(struct tee_mmap_region *mm,
 	do  {
 		uint64_t desc = UNSET_DESC;
 
-		if ((mm->va + mm->size <= base_va) ||
-		    core_mmu_is_dynamic_vaspace(mm)) {
-			/*
-			 * Area now after the region or area should not be
-			 * mapped at init so skip it
-			 */
+		/* Skip unmapped entries */
+		while (mm->size && core_mmu_is_dynamic_vaspace(mm))
+			mm++;
+		if (!mm->size)
+			break;
+
+		if (mm->va + mm->size <= base_va) {
+			/* Area now after the region so skip it */
 			mm++;
 			continue;
 		}


### PR DESCRIPTION
When enumerating static_memory_map to setup the translation table, the
"dynamic" entries are skipped incorrectly. As a result, if the first
entry is MEM_AREA_RES_VASPACE, the function does nothing (because
core_mmu_is_dynamic_vaspace(mm) is true and base_va is NULL) and the
translation tables are left uninitialized.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Fixes: c6c69797168c ("mm: add new VA region for dynamic shared buffers")
Fixes: https://github.com/OP-TEE/optee_os/issues/1511
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (HiKey)