### PR TITLE
Take some GP types into account when running patch check tool

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -8,7 +8,8 @@ _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
 
 function _checkpatch() {
 		$CHECKPATCH --quiet --ignore FILE_PATH_CHANGES \
-				--ignore GERRIT_CHANGE_ID --no-tree -
+				--ignore GERRIT_CHANGE_ID \
+				--typedefsfile typedefs.checkpatch --no-tree -
 }
 
 function checkpatch() {

--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -1,0 +1,2 @@
+TEE_Result
+TEE_UUID


### PR DESCRIPTION
When running checkpatch on the OP-TEE code, for instance during the
Travis checks, it happens that we get false warnings and errors caused
by the use of GlobalPlatform typedefs. In the following example, the
patch introduces pointers to functions returning TEE_Result, but
checkpatch won't accept it as a valid type:

 $ ./scripts/checkpatch.sh d776721 | tail -1
 total: 1 errors, 5 warnings, 555 lines checked

To address such issues, declare our custom types in a local file
(typedefs.checkpatch) and use the new --typedefsfile option provided by
checkpatch.pl.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>