### PR TITLE
drivers: refine GIC driver with CFG_WITH_ARM_TRUSTED_FW

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -496,7 +496,11 @@ LOCAL_FUNC el0_svc , :
 	 * nothing left in sp_el1. Note that the SVC handler is excepted to
 	 * re-enable foreign interrupts by itself.
 	 */
+#if defined(CFG_ARM_GICV3)
+	msr	daifclr, #(DAIFBIT_IRQ | DAIFBIT_ABT | DAIFBIT_DBG)
+#else
 	msr	daifclr, #(DAIFBIT_FIQ | DAIFBIT_ABT | DAIFBIT_DBG)
+#endif
 
 	/* Call the handler */
 	bl	tee_svc_handler


### PR DESCRIPTION
On ARMv8, GIC configuration is initialized in ARM-TF. We should
not touch interrupt configure registers. And an interrupt for optee
is secure group 1(G1S), so we should handle this irq by reading
ICC_IAR1 and writing ICC_EOIR1 instead.

Signed-off-by: Zhizhou Zhang <zhizhouzhang@asrmicro.com>

It look current GICv3 patch doesn't work well for me.
This patch fix my problem. I don't have a ARMv7 board, I don't know whether this problem also afects ARMv7 or not. However, I add `#if defined (ARM64)` for this patch to ensure  not breaking ARMv7 board.
I also found another problem. A-TF set ARE to 1. That means, to enable/disable SGIs and PPIs, we should write to GICR_ISENABLER0 instead. I'm afraid of bringing new problems for I'm so ignorant, so I didn't fix this issue. If someone could give me some guide, I'd like to take a try. ;-)