### PR TITLE
Support for *flat mapped* coherent secure RAM

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -118,10 +118,10 @@
  * MEM_AREA_TEE_ASAN: core address sanitizer RAM (secure, reserved to TEE)
  * MEM_AREA_TA_RAM:   Secure RAM where teecore loads/exec TA instances.
  * MEM_AREA_NSEC_SHM: NonSecure shared RAM between NSec and TEE.
- * MEM_AREA_RAM_NSEC: NonSecure RAM storing data
- * MEM_AREA_RAM_SEC:  Secure RAM storing some secrets
- * MEM_AREA_IO_NSEC:  NonSecure HW mapped registers
- * MEM_AREA_IO_SEC:   Secure HW mapped registers
+ * MEM_AREA_RAM_NSEC: NonSecure RAM storing data, cached, read/write.
+ * MEM_AREA_RAM_SEC:  Secure RAM storing some secrets, cached, read/write.
+ * MEM_AREA_IO_NSEC:  NonSecure noncached read/write (i.e HW mapped registers)
+ * MEM_AREA_IO_SEC:   Secure noncached read/write (i.e HW mapped registers)
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_SHM_VASPACE: Virtual memory space for dynamic shared memory buffers
  * MEM_AREA_TA_VASPACE: TA va space, only used with phys_to_virt()

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -114,6 +114,7 @@
  * MEM_AREA_TEE_RAM_RO:  core private read-only/non-executable memory (secure)
  * MEM_AREA_TEE_RAM_RW:  core private read/write/non-executable memory (secure)
  * MEM_AREA_TEE_COHERENT: teecore coherent RAM (secure, reserved to TEE)
+ * MEM_AREA_COHERENT_FLAT: flat mapped uncached RAM (secure, reserved to TEE)
  * MEM_AREA_TEE_ASAN: core address sanitizer RAM (secure, reserved to TEE)
  * MEM_AREA_TA_RAM:   Secure RAM where teecore loads/exec TA instances.
  * MEM_AREA_NSEC_SHM: NonSecure shared RAM between NSec and TEE.
@@ -133,6 +134,7 @@ enum teecore_memtypes {
 	MEM_AREA_TEE_RAM_RO,
 	MEM_AREA_TEE_RAM_RW,
 	MEM_AREA_TEE_COHERENT,
+	MEM_AREA_COHERENT_FLAT,
 	MEM_AREA_TEE_ASAN,
 	MEM_AREA_TA_RAM,
 	MEM_AREA_NSEC_SHM,
@@ -158,6 +160,7 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 		[MEM_AREA_TEE_RAM_RW] = "TEE_RAM_RW",
 		[MEM_AREA_TEE_ASAN] = "TEE_ASAN",
 		[MEM_AREA_TEE_COHERENT] = "TEE_COHERENT",
+		[MEM_AREA_COHERENT_FLAT] = "COHERENT_FLAT",
 		[MEM_AREA_TA_RAM] = "TA_RAM",
 		[MEM_AREA_NSEC_SHM] = "NSEC_SHM",
 		[MEM_AREA_RAM_NSEC] = "RAM_NSEC",

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -70,9 +70,28 @@
 OUTPUT_FORMAT(CFG_KERN_LINKER_FORMAT)
 OUTPUT_ARCH(CFG_KERN_LINKER_ARCH)
 
+#define  LINK_COHERENT_FLATMAP_RAM \
+		. = COHERENT_FLATMAP_BASE; \
+		.coherent (NOLOAD) : { \
+			ASSERT(!(. & (SMALL_PAGE_SIZE - 1)), \
+				"Coherent memory start is not aligned"); \
+			__coherent_start = .; \
+			KEEP(*(.coherent_ram)); \
+			. = ALIGN(SMALL_PAGE_SIZE); \
+			__coherent_end = .; \
+			ASSERT(COHERENT_FLATMAP_SIZE >= \
+				(. - __coherent_start), \
+				"Coherent memory is undersized"); \
+		}
+
 ENTRY(_start)
 SECTIONS
 {
+#if defined(COHERENT_FLATMAP_BASE) && COHERENT_FLATMAP_BASE < TEE_TEXT_VA_START
+	LINK_COHERENT_FLATMAP_RAM
+	ASSERT(. <= TEE_TEXT_VA_START, "Coherent memory is oversized")
+#endif
+
 	. = TEE_TEXT_VA_START;
 #ifdef ARM32
 	ASSERT(!(TEE_TEXT_VA_START & 31), "text start should align to 32bytes")
@@ -438,6 +457,11 @@ SECTIONS
 
 #ifndef CFG_WITH_PAGER
 	__flatmap_unpg_rw_size = _end_of_ram - __flatmap_unpg_rw_start;
+#endif
+
+#if defined(COHERENT_FLATMAP_BASE) && COHERENT_FLATMAP_BASE > CFG_TEE_RAM_START
+	ASSERT(. <= COHERENT_FLATMAP_BASE, "Coherent memory does not fit")
+	LINK_COHERENT_FLATMAP_RAM
 #endif
 
 	/DISCARD/ : {

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -90,6 +90,11 @@ static struct memaccess_area nsec_shared[] = {
 register_sdp_mem(CFG_TEE_SDP_MEM_BASE, CFG_TEE_SDP_MEM_SIZE);
 #endif
 
+#if defined COHERENT_FLATMAP_BASE && COHERENT_FLATMAP_SIZE
+register_phys_mem(MEM_AREA_COHERENT_FLAT, COHERENT_FLATMAP_BASE,
+					  COHERENT_FLATMAP_SIZE);
+#endif
+
 #ifdef CFG_CORE_RWDATA_NOEXEC
 register_phys_mem_ul(MEM_AREA_TEE_RAM_RO, CFG_TEE_RAM_START,
 		     VCORE_UNPG_RX_PA - CFG_TEE_RAM_START);

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -682,7 +682,7 @@ static void dump_mmap_table(struct tee_mmap_region *memory_map)
 		vaddr_t __maybe_unused vstart;
 
 		vstart = map->va + ((vaddr_t)map->pa & (map->region_size - 1));
-		DMSG("type %-12s va 0x%08" PRIxVA "..0x%08" PRIxVA
+		DMSG("type %-13s va 0x%08" PRIxVA "..0x%08" PRIxVA
 		     " pa 0x%08" PRIxPA "..0x%08" PRIxPA " size 0x%08zx (%s)",
 		     teecore_memtype_name(map->type), vstart,
 		     vstart + map->size - 1, map->pa,

--- a/core/arch/arm/plat-sunxi/kern.ld.S
+++ b/core/arch/arm/plat-sunxi/kern.ld.S
@@ -55,12 +55,31 @@
 #define SMALL_PAGE_SIZE		4096
 #endif
 
+#define  LINK_COHERENT_FLATMAP_RAM \
+                . = COHERENT_FLATMAP_BASE; \
+                .coherent (NOLOAD) : { \
+                        ASSERT(!(. & (SMALL_PAGE_SIZE - 1)), \
+                                "Coherent memory start is not aligned"); \
+                        __coherent_start = .; \
+                        KEEP(*(.coherent_ram)); \
+                        . = ALIGN(SMALL_PAGE_SIZE); \
+                        __coherent_end = .; \
+                        ASSERT(COHERENT_FLATMAP_SIZE >= \
+				(. - __coherent_start), \
+                                "Coherent memory is undersized"); \
+                }
+
 OUTPUT_FORMAT(CFG_KERN_LINKER_FORMAT)
 OUTPUT_ARCH(CFG_KERN_LINKER_ARCH)
 
 ENTRY(_start)
 SECTIONS
 {
+#if defined(COHERENT_FLATMAP_BASE) && COHERENT_FLATMAP_BASE < CFG_TEE_RAM_START
+	LINK_COHERENT_FLATMAP_RAM
+	ASSERT(. <= TEE_RAM_START, "Coherent memory is oversized")
+#endif
+
 	. = TEE_RAM_START;
 	__flatmap_unpg_rx_start = .;
 
@@ -223,6 +242,11 @@ SECTIONS
 	_end_of_ram = .;
 
 	__flatmap_unpg_rw_size = _end_of_ram - __flatmap_unpg_rw_start;
+
+#if defined(COHERENT_FLATMAP_BASE) && COHERENT_FLATMAP_BASE > CFG_TEE_RAM_START
+	ASSERT(. <= COHERENT_FLATMAP_BASE, "Coherent memory does not fit")
+	LINK_COHERENT_FLATMAP_RAM
+#endif
 
 	/* Strip unnecessary stuff */
 	/DISCARD/ : { *(.comment .note .eh_frame) }

--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -55,6 +55,7 @@
 #define __rodata_unpaged __section(".rodata.__unpaged")
 #define __early_ta	__section(".rodata.early_ta")
 #define __noprof	__attribute__((no_instrument_function))
+#define __coherent	__section(".coherent_ram")
 
 #define __compiler_bswap64(x)	__builtin_bswap64((x))
 #define __compiler_bswap32(x)	__builtin_bswap32((x))


### PR DESCRIPTION
This change enables secure coherent memory support and allow platform vexpress-qemu_virt to easily define a coherent memory at top of the secure RAM.