### PR TITLE
core: fix non-LPAE mapping

### DIFF
--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -783,7 +783,7 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 	memset(ttb1, 0, L1_TBL_SIZE);
 
 	for (n = 0; mm[n].size; n++)
-		if (!core_mmu_is_dynamic_vaspace(mm))
+		if (!core_mmu_is_dynamic_vaspace(mm + n))
 			map_memarea(mm + n, ttb1);
 }
 


### PR DESCRIPTION
Fixes: c6c69797168c  ("mm: add new VA region for dynamic shared buffers")
Fixes: https://github.com/OP-TEE/optee_os/issues/1536