### PR TITLE
core: workaround KEEP_*() macro problem

### DIFF
--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -88,10 +88,7 @@ static TEE_Result mobj_phys_get_pa(struct mobj *mobj, size_t offs,
 	*pa = p;
 	return TEE_SUCCESS;
 }
-/* ifndef due to an asserting AArch64 linker */
-#ifndef ARM64
 KEEP_PAGER(mobj_phys_get_pa);
-#endif
 
 static TEE_Result mobj_phys_get_cattr(struct mobj *mobj, uint32_t *cattr)
 {
@@ -254,10 +251,7 @@ static TEE_Result mobj_mm_get_pa(struct mobj *mobj, size_t offs,
 	return mobj_get_pa(to_mobj_mm(mobj)->parent_mobj,
 			   mobj_mm_offs(mobj, offs), granule, pa);
 }
-/* ifndef due to an asserting AArch64 linker */
-#ifndef ARM64
 KEEP_PAGER(mobj_mm_get_pa);
-#endif
 
 static TEE_Result mobj_mm_get_cattr(struct mobj *mobj, uint32_t *cattr)
 {

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -27,7 +27,15 @@
 #ifndef KEEP_H
 #define KEEP_H
 
+/*
+ * A bug in the Aarch64 linker sometimes triggers an assert when linking.
+ * These macros are only needed when the pager is active so stub them when
+ * not needed.
+ */
+
 #ifdef ASM
+
+#ifdef CFG_WITH_PAGER
 
 	.macro KEEP_PAGER sym
 	.pushsection __keep_meta_vars_pager
@@ -43,9 +51,21 @@
 	.popsection
 	.endm
 
+#else /* CFG_WITH_PAGER */
+
+	.macro KEEP_PAGER sym
+	.endm
+
+	.macro KEEP_INIT sym
+	.endm
+
+#endif /* CFG_WITH_PAGER */
+
 #else
 
 #include <compiler.h>
+
+#ifdef CFG_WITH_PAGER
 
 #define KEEP_PAGER(sym) \
 	const unsigned long ____keep_pager_##sym  \
@@ -54,6 +74,16 @@
 #define KEEP_INIT(sym) \
 	const unsigned long ____keep_init_##sym  \
 		__section("__keep_meta_vars_init") = (unsigned long)&sym
+
+#else /* CFG_WITH_PAGER */
+
+#define KEEP_PAGER(sym) \
+	extern const unsigned long ____keep_pager_##sym
+
+#define KEEP_INIT(sym) \
+	extern const unsigned long ____keep_init_##sym
+
+#endif /* CFG_WITH_PAGER */
 
 #endif /* ASM */
 


### PR DESCRIPTION
Workaround the KEEP_*() macro problem that sometimes causes the Aarch64
linker to assert. Since the pager is not enabled for Aarch64 yet we can
stub these macros in the definition.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>