### PR TITLE
Remove some useless mandated mapping verifications

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -419,7 +419,11 @@ void core_mmu_get_mem_by_type(enum teecore_memtypes type, vaddr_t *s,
 enum teecore_memtypes core_mmu_get_type_by_pa(paddr_t pa);
 
 /* routines to retreive shared mem configuration */
-bool core_mmu_is_shm_cached(void);
+static inline bool core_mmu_is_shm_cached(void)
+{
+	return core_mmu_type_to_attr(MEM_AREA_NSEC_SHM) &
+		(TEE_MATTR_CACHE_CACHED << TEE_MATTR_CACHE_SHIFT);
+}
 
 bool core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len);
 


### PR DESCRIPTION
Those 3 commits could be squashed into a single one.

These changes are quite useful for integration of https://github.com/OP-TEE/optee_os/pull/1459 and https://github.com/OP-TEE/optee_os/pull/1533 regarding physical TEE_RAM identification (1st commit).

The 2 later commits are cleanup related.