### PR TITLE
TA unwinding on abort (print call stack)

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -97,7 +97,7 @@ arch-bits-core := 32
 core-platform-cppflags += $(arm32-platform-cppflags)
 core-platform-cflags += $(arm32-platform-cflags)
 core-platform-cflags += $(arm32-platform-cflags-no-hard-float)
-ifeq ($(CFG_CORE_UNWIND),y)
+ifeq ($(CFG_UNWIND),y)
 core-platform-cflags += -funwind-tables
 endif
 core-platform-cflags += $(arm32-platform-cflags-generic)
@@ -119,6 +119,9 @@ ifeq ($(platform-hard-float-enabled),y)
 ta_arm32-platform-cflags += $(arm32-platform-cflags-hard-float)
 else
 ta_arm32-platform-cflags += $(arm32-platform-cflags-no-hard-float)
+endif
+ifeq ($(CFG_UNWIND),y)
+ta_arm32-platform-cflags += -funwind-tables
 endif
 ta_arm32-platform-aflags += $(platform-aflags-debug-info)
 ta_arm32-platform-aflags += $(arm32-platform-aflags)

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -489,7 +489,15 @@ void thread_unwind_user_mode(uint32_t ret, uint32_t exit_status0,
 vaddr_t thread_get_saved_thread_sp(void);
 #endif /*ARM64*/
 
-bool thread_addr_is_in_stack(vaddr_t va);
+/*
+ * Returns the start address (bottom) of the stack for the current thread,
+ * zero if there is no current thread.
+ */
+vaddr_t thread_stack_start(void);
+
+
+/* Returns the stack size for the current thread */
+size_t thread_stack_size(void);
 
 /*
  * Adds a mutex to the list of held mutexes for current thread

--- a/core/arch/arm/include/kernel/unwind.h
+++ b/core/arch/arm/include/kernel/unwind.h
@@ -37,9 +37,8 @@
 #include <compiler.h>
 #include <types_ext.h>
 
-#ifdef ARM32
-/* The state of the unwind process */
-struct unwind_state {
+/* The state of the unwind process (32-bit mode) */
+struct unwind_state_arm32 {
 	uint32_t registers[16];
 	uint32_t start_pc;
 	uint32_t *insn;
@@ -47,29 +46,42 @@ struct unwind_state {
 	unsigned byte;
 	uint16_t update_mask;
 };
-#endif /*ARM32*/
+
+/*
+ * Unwind a 32-bit user or kernel stack.
+ * @exidx, @exidx_sz: address and size of the binary search index table
+ * (.ARM.exidx section).
+ */
+bool unwind_stack_arm32(struct unwind_state_arm32 *state, uaddr_t exidx,
+			size_t exidx_sz);
 
 #ifdef ARM64
-struct unwind_state {
+/* The state of the unwind process (64-bit mode) */
+struct unwind_state_arm64 {
 	uint64_t fp;
 	uint64_t sp;
 	uint64_t pc;
 };
+
+/*
+ * Unwind a 64-bit user or kernel stack.
+ * @stack, @stack_size: the bottom of the stack and its size, respectively.
+ */
+bool unwind_stack_arm64(struct unwind_state_arm64 *state, uaddr_t stack,
+			size_t stack_size);
 #endif /*ARM64*/
 
-bool unwind_stack(struct unwind_state *state);
-
-#if defined(CFG_CORE_UNWIND) && (TRACE_LEVEL > 0)
-void print_stack(int level);
+#if defined(CFG_UNWIND) && (TRACE_LEVEL > 0)
+void print_kernel_stack(int level);
 #else
-static inline void print_stack(int level __unused)
+static inline void print_kernel_stack(int level __unused)
 {
 }
 #endif
 
 #endif /*ASM*/
 
-#ifdef CFG_CORE_UNWIND
+#ifdef CFG_UNWIND
 #define UNWIND(...)	__VA_ARGS__
 #else
 #define UNWIND(...)

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -41,6 +41,8 @@ TAILQ_HEAD(tee_storage_enum_head, tee_storage_enum);
 
 struct user_ta_ctx {
 	uaddr_t entry_func;
+	uaddr_t exidx_start;	/* 32-bit TA: exception handling index table */
+	size_t exidx_size;
 	bool is_32bit;		/* true if 32-bit ta, false if 64-bit ta */
 	/* list of sessions opened by this TA */
 	struct tee_ta_session_head open_sessions;

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -113,7 +113,7 @@ static void __print_stack_unwind_arm32(struct abort_info *ai)
 
 	EMSG_RAW("Call stack:");
 	do {
-		EMSG_RAW(" pc 0x%08x", state.registers[15]);
+		EMSG_RAW(" 0x%08x", state.registers[15]);
 	} while (exidx && unwind_stack_arm32(&state, exidx, exidx_sz));
 }
 #else /* ARM32 */
@@ -149,7 +149,7 @@ static void __print_stack_unwind_arm32(struct abort_info *ai __unused)
 
 	EMSG_RAW("Call stack:");
 	do {
-		EMSG_RAW(" pc 0x%08x", state.registers[15]);
+		EMSG_RAW(" 0x%08x", state.registers[15]);
 	} while (exidx && unwind_stack_arm32(&state, exidx, exidx_sz));
 }
 #endif /* ARM32 */
@@ -184,7 +184,7 @@ static void __print_stack_unwind_arm64(struct abort_info *ai)
 
 	EMSG_RAW("Call stack:");
 	do {
-		EMSG_RAW("pc  0x%016" PRIx64, state.pc);
+		EMSG_RAW(" 0x%016" PRIx64, state.pc);
 	} while (stack && unwind_stack_arm64(&state, stack, stack_size));
 }
 #else
@@ -237,66 +237,66 @@ static __maybe_unused void __print_abort_info(
 				struct abort_info *ai __maybe_unused,
 				const char *ctx __maybe_unused)
 {
-	EMSG_RAW("\n");
-	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s\n",
+	EMSG_RAW("");
+	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s",
 		ctx, abort_type_to_str(ai->abort_type), ai->va,
 		fault_to_str(ai->abort_type, ai->fault_descr));
 #ifdef ARM32
-	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x  ttbr1 0x%08x  cidr 0x%X\n",
+	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x  ttbr1 0x%08x  cidr 0x%X",
 		 ai->fault_descr, read_ttbr0(), read_ttbr1(),
 		 read_contextidr());
-	EMSG_RAW(" cpu #%zu          cpsr 0x%08x\n",
+	EMSG_RAW(" cpu #%zu          cpsr 0x%08x",
 		 get_core_pos(), ai->regs->spsr);
-	EMSG_RAW(" r0 0x%08x      r4 0x%08x    r8 0x%08x   r12 0x%08x\n",
+	EMSG_RAW(" r0 0x%08x      r4 0x%08x    r8 0x%08x   r12 0x%08x",
 		 ai->regs->r0, ai->regs->r4, ai->regs->r8, ai->regs->ip);
-	EMSG_RAW(" r1 0x%08x      r5 0x%08x    r9 0x%08x    sp 0x%08x\n",
+	EMSG_RAW(" r1 0x%08x      r5 0x%08x    r9 0x%08x    sp 0x%08x",
 		 ai->regs->r1, ai->regs->r5, ai->regs->r9,
 		 read_mode_sp(ai->regs->spsr & CPSR_MODE_MASK));
-	EMSG_RAW(" r2 0x%08x      r6 0x%08x   r10 0x%08x    lr 0x%08x\n",
+	EMSG_RAW(" r2 0x%08x      r6 0x%08x   r10 0x%08x    lr 0x%08x",
 		 ai->regs->r2, ai->regs->r6, ai->regs->r10,
 		 read_mode_lr(ai->regs->spsr & CPSR_MODE_MASK));
-	EMSG_RAW(" r3 0x%08x      r7 0x%08x   r11 0x%08x    pc 0x%08x\n",
+	EMSG_RAW(" r3 0x%08x      r7 0x%08x   r11 0x%08x    pc 0x%08x",
 		 ai->regs->r3, ai->regs->r7, ai->regs->r11, ai->pc);
 #endif /*ARM32*/
 #ifdef ARM64
-	EMSG_RAW(" esr 0x%08x  ttbr0 0x%08" PRIx64 "   ttbr1 0x%08" PRIx64 "   cidr 0x%X\n",
-		 ai->fault_descr, read_ttbr0_el1(), read_ttbr1_el1(),
-		 read_contextidr_el1());
-	EMSG_RAW(" cpu #%zu          cpsr 0x%08x\n",
+	EMSG_RAW(" esr 0x%08x  ttbr0 0x%08" PRIx64 "   ttbr1 0x%08" PRIx64
+		 "   cidr 0x%X", ai->fault_descr, read_ttbr0_el1(),
+		 read_ttbr1_el1(), read_contextidr_el1());
+	EMSG_RAW(" cpu #%zu          cpsr 0x%08x",
 		 get_core_pos(), (uint32_t)ai->regs->spsr);
-	EMSG_RAW("x0  %016" PRIx64 " x1  %016" PRIx64,
+	EMSG_RAW(" x0  %016" PRIx64 " x1  %016" PRIx64,
 		 ai->regs->x0, ai->regs->x1);
-	EMSG_RAW("x2  %016" PRIx64 " x3  %016" PRIx64,
+	EMSG_RAW(" x2  %016" PRIx64 " x3  %016" PRIx64,
 		 ai->regs->x2, ai->regs->x3);
-	EMSG_RAW("x4  %016" PRIx64 " x5  %016" PRIx64,
+	EMSG_RAW(" x4  %016" PRIx64 " x5  %016" PRIx64,
 		 ai->regs->x4, ai->regs->x5);
-	EMSG_RAW("x6  %016" PRIx64 " x7  %016" PRIx64,
+	EMSG_RAW(" x6  %016" PRIx64 " x7  %016" PRIx64,
 		 ai->regs->x6, ai->regs->x7);
-	EMSG_RAW("x8  %016" PRIx64 " x9  %016" PRIx64,
+	EMSG_RAW(" x8  %016" PRIx64 " x9  %016" PRIx64,
 		 ai->regs->x8, ai->regs->x9);
-	EMSG_RAW("x10 %016" PRIx64 " x11 %016" PRIx64,
+	EMSG_RAW(" x10 %016" PRIx64 " x11 %016" PRIx64,
 		 ai->regs->x10, ai->regs->x11);
-	EMSG_RAW("x12 %016" PRIx64 " x13 %016" PRIx64,
+	EMSG_RAW(" x12 %016" PRIx64 " x13 %016" PRIx64,
 		 ai->regs->x12, ai->regs->x13);
-	EMSG_RAW("x14 %016" PRIx64 " x15 %016" PRIx64,
+	EMSG_RAW(" x14 %016" PRIx64 " x15 %016" PRIx64,
 		 ai->regs->x14, ai->regs->x15);
-	EMSG_RAW("x16 %016" PRIx64 " x17 %016" PRIx64,
+	EMSG_RAW(" x16 %016" PRIx64 " x17 %016" PRIx64,
 		 ai->regs->x16, ai->regs->x17);
-	EMSG_RAW("x18 %016" PRIx64 " x19 %016" PRIx64,
+	EMSG_RAW(" x18 %016" PRIx64 " x19 %016" PRIx64,
 		 ai->regs->x18, ai->regs->x19);
-	EMSG_RAW("x20 %016" PRIx64 " x21 %016" PRIx64,
+	EMSG_RAW(" x20 %016" PRIx64 " x21 %016" PRIx64,
 		 ai->regs->x20, ai->regs->x21);
-	EMSG_RAW("x22 %016" PRIx64 " x23 %016" PRIx64,
+	EMSG_RAW(" x22 %016" PRIx64 " x23 %016" PRIx64,
 		 ai->regs->x22, ai->regs->x23);
-	EMSG_RAW("x24 %016" PRIx64 " x25 %016" PRIx64,
+	EMSG_RAW(" x24 %016" PRIx64 " x25 %016" PRIx64,
 		 ai->regs->x24, ai->regs->x25);
-	EMSG_RAW("x26 %016" PRIx64 " x27 %016" PRIx64,
+	EMSG_RAW(" x26 %016" PRIx64 " x27 %016" PRIx64,
 		 ai->regs->x26, ai->regs->x27);
-	EMSG_RAW("x28 %016" PRIx64 " x29 %016" PRIx64,
+	EMSG_RAW(" x28 %016" PRIx64 " x29 %016" PRIx64,
 		 ai->regs->x28, ai->regs->x29);
-	EMSG_RAW("x30 %016" PRIx64 " elr %016" PRIx64,
+	EMSG_RAW(" x30 %016" PRIx64 " elr %016" PRIx64,
 		 ai->regs->x30, ai->regs->elr);
-	EMSG_RAW("sp_el0 %016" PRIx64, ai->regs->sp_el0);
+	EMSG_RAW(" sp_el0 %016" PRIx64, ai->regs->sp_el0);
 #endif /*ARM64*/
 }
 
@@ -335,12 +335,12 @@ static void __abort_print(struct abort_info *ai, bool stack_dump)
 		paged_ta = true;
 #endif
 
-		__print_abort_info(ai, "user TA");
+		__print_abort_info(ai, "User TA");
 		tee_ta_dump_current();
 	} else {
 		is_32bit = kernel_is32bit;
 
-		__print_abort_info(ai, "core");
+		__print_abort_info(ai, "Core");
 	}
 
 	if (!stack_dump || paged_ta)

--- a/core/arch/arm/kernel/elf_common.h
+++ b/core/arch/arm/kernel/elf_common.h
@@ -355,6 +355,7 @@ typedef struct {
 #define	PT_HISUNW	0x6fffffff
 #define	PT_HIOS		0x6fffffff	/* Last OS-specific. */
 #define	PT_LOPROC	0x70000000	/* First processor-specific type. */
+#define PT_ARM_EXIDX	0x70000001	/* .ARM.exidx segment */
 #define	PT_HIPROC	0x7fffffff	/* Last processor-specific type. */
 
 /* Values for p_flags. */

--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -397,25 +397,26 @@ TEE_Result elf_load_head(struct elf_load_state *state, size_t head_size,
 }
 
 TEE_Result elf_load_get_next_segment(struct elf_load_state *state, size_t *idx,
-			vaddr_t *vaddr, size_t *size, uint32_t *flags)
+			vaddr_t *vaddr, size_t *size, uint32_t *flags,
+			uint32_t *type)
 {
 	struct elf_ehdr ehdr;
 
 	copy_ehdr(&ehdr, state);
-	while (*idx < ehdr.e_phnum) {
+	if (*idx < ehdr.e_phnum) {
 		struct elf_phdr phdr;
 
 		copy_phdr(&phdr, state, *idx);
 		(*idx)++;
-		if (phdr.p_type == PT_LOAD) {
-			if (vaddr)
-				*vaddr = phdr.p_vaddr;
-			if (size)
-				*size = phdr.p_memsz;
-			if (flags)
-				*flags = phdr.p_flags;
-			return TEE_SUCCESS;
-		}
+		if (vaddr)
+			*vaddr = phdr.p_vaddr;
+		if (size)
+			*size = phdr.p_memsz;
+		if (flags)
+			*flags = phdr.p_flags;
+		if (type)
+			*type = phdr.p_type;
+		return TEE_SUCCESS;
 	}
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }

--- a/core/arch/arm/kernel/elf_load.h
+++ b/core/arch/arm/kernel/elf_load.h
@@ -71,7 +71,8 @@ TEE_Result elf_load_head(struct elf_load_state *state, size_t head_size,
 			void **head, size_t *vasize, bool *is_32bit);
 TEE_Result elf_load_body(struct elf_load_state *state, vaddr_t vabase);
 TEE_Result elf_load_get_next_segment(struct elf_load_state *state, size_t *idx,
-			vaddr_t *vaddr, size_t *size, uint32_t *flags);
+			vaddr_t *vaddr, size_t *size, uint32_t *flags,
+			uint32_t *type);
 void elf_load_final(struct elf_load_state *state);
 
 #endif /*ELF_LOAD_H*/

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -43,7 +43,7 @@ srcs-$(CFG_ARM32_core) += generic_entry_a32.S
 srcs-$(CFG_ARM64_core) += generic_entry_a64.S
 endif
 
-ifeq ($(CFG_CORE_UNWIND),y)
-srcs-$(CFG_ARM32_core) += unwind_arm32.c
+ifeq ($(CFG_UNWIND),y)
+srcs-y += unwind_arm32.c
 srcs-$(CFG_ARM64_core) += unwind_arm64.c
 endif

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -619,17 +619,21 @@ vaddr_t thread_get_saved_thread_sp(void)
 }
 #endif /*ARM64*/
 
-bool thread_addr_is_in_stack(vaddr_t va)
+vaddr_t thread_stack_start(void)
 {
 	struct thread_ctx *thr;
 	int ct = thread_get_id_may_fail();
 
 	if (ct == -1)
-		return false;
+		return 0;
 
 	thr = threads + ct;
-	return va < thr->stack_va_end &&
-	       va >= (thr->stack_va_end - STACK_THREAD_SIZE);
+	return thr->stack_va_end - STACK_THREAD_SIZE;
+}
+
+size_t thread_stack_size(void)
+{
+	return STACK_THREAD_SIZE;
 }
 
 void thread_state_free(void)

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -305,6 +305,8 @@ FUNC __thread_enter_user_mode , :
 	msr	sp_el0, x4	/* Used when running TA in Aarch64 */
 	/* Set user function */
 	msr	elr_el1, x5
+	/* Set frame pointer (user stack can't be unwound past this point) */
+	mov x29, #0
 
 	/* Jump into user mode */
 	eret

--- a/core/arch/arm/kernel/unwind_arm64.c
+++ b/core/arch/arm/kernel/unwind_arm64.c
@@ -34,12 +34,13 @@
 #include <string.h>
 #include <trace.h>
 
-bool unwind_stack(struct unwind_state *frame)
+bool unwind_stack_arm64(struct unwind_state_arm64 *frame, uaddr_t stack,
+		      size_t stack_size)
 {
 	uint64_t fp;
 
 	fp = frame->fp;
-	if (!thread_addr_is_in_stack(fp))
+	if (fp < stack || fp >= stack + stack_size)
 		return false;
 
 	frame->sp = fp + 0x10;
@@ -51,11 +52,11 @@ bool unwind_stack(struct unwind_state *frame)
 	return true;
 }
 
-#if defined(CFG_CORE_UNWIND) && (TRACE_LEVEL > 0)
+#if defined(CFG_UNWIND) && (TRACE_LEVEL > 0)
 
-void print_stack(int level)
+void print_kernel_stack(int level)
 {
-	struct unwind_state state;
+	struct unwind_state_arm64 state;
 
 	memset(&state, 0, sizeof(state));
 	state.pc = read_pc();
@@ -78,7 +79,7 @@ void print_stack(int level)
 		default:
 			break;
 		}
-	} while (unwind_stack(&state));
+	} while (unwind_stack_arm64(&state, 0, 0));
 }
 
-#endif /* defined(CFG_CORE_UNWIND) && (TRACE_LEVEL > 0) */
+#endif

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -502,8 +502,9 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 	struct user_ta_ctx *utc __maybe_unused = to_user_ta_ctx(ctx);
 	size_t n;
 
-	EMSG_RAW(" load address: 0x%x    ctx-idr: %d",
-		 utc->load_addr, utc->context);
+	EMSG_RAW(" arch: %s  load address: 0x%x  ctx-idr: %d",
+		 utc->is_32bit ? "arm" : "aarch64", utc->load_addr,
+		 utc->context);
 	EMSG_RAW(" stack: 0x%" PRIxVA " %zu",
 		 utc->mmu->regions[0].va, utc->mobj_stack->size);
 	for (n = 0; n < ARRAY_SIZE(utc->mmu->regions); n++) {

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -502,9 +502,9 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 	struct user_ta_ctx *utc __maybe_unused = to_user_ta_ctx(ctx);
 	size_t n;
 
-	EMSG_RAW("- load addr : 0x%x    ctx-idr: %d",
+	EMSG_RAW(" load address: 0x%x    ctx-idr: %d",
 		 utc->load_addr, utc->context);
-	EMSG_RAW("- stack: 0x%" PRIxVA " %zu",
+	EMSG_RAW(" stack: 0x%" PRIxVA " %zu",
 		 utc->mmu->regions[0].va, utc->mobj_stack->size);
 	for (n = 0; n < ARRAY_SIZE(utc->mmu->regions); n++) {
 		paddr_t pa = 0;
@@ -513,7 +513,8 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 			mobj_get_pa(utc->mmu->regions[n].mobj,
 				    utc->mmu->regions[n].offset, 0, &pa);
 
-		EMSG_RAW("sect %zu : va %#" PRIxVA " pa %#" PRIxPA " %#zx",
+		EMSG_RAW(" region %zu: va %#" PRIxVA " pa %#" PRIxPA
+			 " size %#zx",
 			 n, utc->mmu->regions[n].va, pa,
 			 utc->mmu->regions[n].size);
 	}

--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -216,6 +216,14 @@ void __noreturn __utee_entry(unsigned long func, unsigned long session_id,
 {
 	TEE_Result res;
 
+#if defined(ARM32) && defined(CFG_UNWIND)
+	/*
+	 * This function is the bottom of the user call stack: mark it as such
+	 * so that the unwinding code won't try to go further down.
+	 */
+	asm(".cantunwind");
+#endif
+
 	switch (func) {
 	case UTEE_ENTRY_FUNC_OPEN_SESSION:
 		res = entry_open_session(session_id, up);

--- a/lib/libutils/ext/arch/arm/aeabi_unwind.c
+++ b/lib/libutils/ext/arch/arm/aeabi_unwind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,35 +25,18 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef KERNEL_ABORT_H
-#define KERNEL_ABORT_H
+void __aeabi_unwind_cpp_pr0(void);
+void __aeabi_unwind_cpp_pr0(void)
+{
+}
 
-#define ABORT_TYPE_UNDEF	0
-#define ABORT_TYPE_PREFETCH	1
-#define ABORT_TYPE_DATA		2
+void __aeabi_unwind_cpp_pr1(void);
+void __aeabi_unwind_cpp_pr1(void)
+{
+}
 
-#ifndef ASM
-
-#include <compiler.h>
-#include <types_ext.h>
-
-struct abort_info {
-	uint32_t abort_type;
-	uint32_t fault_descr;	/* only valid for data of prefetch abort */
-	vaddr_t va;
-	uint32_t pc;
-	struct thread_abort_regs *regs;
-};
-
-/* Print abort info to the console */
-void abort_print(struct abort_info *ai);
-/* Print abort info + stack dump to the console */
-void abort_print_error(struct abort_info *ai);
-
-void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs);
-
-bool abort_is_user_exception(struct abort_info *ai);
-
-#endif /*ASM*/
-#endif /*KERNEL_ABORT_H*/
+void __aeabi_unwind_cpp_pr2(void);
+void __aeabi_unwind_cpp_pr2(void)
+{
+}
 

--- a/lib/libutils/ext/arch/arm/sub.mk
+++ b/lib/libutils/ext/arch/arm/sub.mk
@@ -1,2 +1,3 @@
+srcs-$(CFG_ARM32_$(sm)) += aeabi_unwind.c
 srcs-$(CFG_ARM32_$(sm)) += atomic_a32.S
 srcs-$(CFG_ARM64_$(sm)) += atomic_a64.S

--- a/lib/libutils/ext/include/trace.h
+++ b/lib/libutils/ext/include/trace.h
@@ -167,36 +167,36 @@ void dhex_dump(const char *function, int line, int level,
 
 #endif /* TRACE_LEVEL */
 
-#if defined(__KERNEL__) && defined(CFG_CORE_UNWIND)
+#if defined(__KERNEL__) && defined(CFG_UNWIND)
 #include <kernel/unwind.h>
 #define _PRINT_STACK
 #endif
 
 #if defined(_PRINT_STACK) && (TRACE_LEVEL >= TRACE_ERROR)
-#define EPRINT_STACK() print_stack(TRACE_ERROR)
+#define EPRINT_STACK() print_kernel_stack(TRACE_ERROR)
 #else
 #define EPRINT_STACK() (void)0
 #endif
 
 #if defined(_PRINT_STACK) && (TRACE_LEVEL >= TRACE_INFO)
-#define IPRINT_STACK() print_stack(TRACE_INFO)
+#define IPRINT_STACK() print_kernel_stack(TRACE_INFO)
 #else
 #define IPRINT_STACK() (void)0
 #endif
 
 #if defined(_PRINT_STACK) && (TRACE_LEVEL >= TRACE_DEBUG)
-#define DPRINT_STACK() print_stack(TRACE_DEBUG)
+#define DPRINT_STACK() print_kernel_stack(TRACE_DEBUG)
 #else
 #define DPRINT_STACK() (void)0
 #endif
 
 #if defined(_PRINT_STACK) && (TRACE_LEVEL >= TRACE_FLOW)
-#define FPRINT_STACK() print_stack(TRACE_FLOW)
+#define FPRINT_STACK() print_kernel_stack(TRACE_FLOW)
 #else
 #define FPRINT_STACK() (void)0
 #endif
 
-#if defined(__KERNEL__) && defined(CFG_CORE_UNWIND)
+#if defined(__KERNEL__) && defined(CFG_UNWIND)
 #undef _PRINT_STACK
 #endif
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -155,10 +155,15 @@ CFG_LIBUTILS_WITH_ISOC ?= y
 # With CFG_TA_FLOAT_SUPPORT enabled TA code is free use floating point types
 CFG_TA_FLOAT_SUPPORT ?= y
 
-# Enable stack unwinding for aborts from kernel mode if CFG_TEE_CORE_DEBUG
-# is enabled
+# Stack unwinding: print a stack dump to the console on abort
+# If CFG_UNWIND is enabled, both the kernel and user mode call stacks can be
+# unwound (not paged TAs, however).
+# Note that 32-bit ARM code needs unwind tables for this to work, so enabling
+# this option will increase the size of the 32-bit TEE binary by a few KB.
+# Similarly, TAs have to be compiled with -funwind-tables (default when the
+# option is set) otherwise they can't be unwound.
 ifeq ($(CFG_TEE_CORE_DEBUG),y)
-CFG_CORE_UNWIND ?= y
+CFG_UNWIND ?= y
 endif
 
 # Enable support for dynamically loaded user TAs

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2017, Linaro Limited
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+import argparse
+import glob
+import re
+import subprocess
+import sys
+
+TA_UUID_RE = re.compile(r'Status of TA (?P<uuid>[0-9a-f\-]+)')
+TA_INFO_RE = re.compile(':  arch: (?P<arch>\w+)  '
+                        'load address: (?P<load_addr>0x[0-9a-f]+)')
+CALL_STACK_RE = re.compile('Call stack:')
+STACK_ADDR_RE = re.compile(r':  (?P<addr>0x[0-9a-f]+)')
+X64_REGS_RE = re.compile(':  x0  [0-9a-f]{16} x1  [0-9a-f]{16}')
+
+epilog = '''
+This scripts reads an OP-TEE abort message from stdin and adds debug
+information ('function at file:line') next to each address in the call stack.
+It uses the paths provided on the command line to locate the appropriate ELF
+binary (tee.elf or Trusted Application) and runs arm-linux-gnueabihf-addr2line
+or aarch64-linux-gnu-addr2line to process the addresses.
+
+OP-TEE abort messages are sent to the secure console. They look like the
+following:
+
+  ERROR:   TEE-CORE: User TA data-abort at address 0xffffdecd (alignment fault)
+  ...
+  ERROR:   TEE-CORE: Call stack:
+  ERROR:   TEE-CORE:  0x4000549e
+  ERROR:   TEE-CORE:  0x40001f4b
+  ERROR:   TEE-CORE:  0x4000273f
+  ERROR:   TEE-CORE:  0x40005da7
+
+Inspired by a script of the same name by the Chromium project.
+
+Sample usage:
+
+  $ scripts/symbolize.py -d out/arm-plat-hikey/core -d ../optee_test/out/ta/*
+  <paste whole dump here>
+  ^D
+'''
+
+def get_args():
+    parser = argparse.ArgumentParser(
+                formatter_class=argparse.RawDescriptionHelpFormatter,
+                description='Symbolizes OP-TEE abort dumps',
+                epilog=epilog)
+    parser.add_argument('-d', '--dir', action='append', nargs='+',
+        help='Search for ELF file in DIR. tee.elf is needed to decode '
+             'a TEE Core or pseudo-TA abort, while <TA_uuid>.elf is required '
+             'if a user-mode TA has crashed.')
+    parser.add_argument('-s', '--strip_path',
+        help='Strip STRIP_PATH from file paths')
+
+    return parser.parse_args()
+
+class Symbolizer(object):
+    def __init__(self, out, dirs, strip_path):
+        self._out = out
+        self._dirs = dirs
+        self._strip_path = strip_path
+        self._addr2line = None
+        self._bin = 'tee.elf'
+        self.reset()
+
+    def get_elf(self, elf_or_uuid):
+        if not elf_or_uuid.endswith('.elf'):
+            elf_or_uuid += '.elf'
+        for d in self._dirs:
+            elf = glob.glob(d + '/' + elf_or_uuid)
+            if elf:
+                return elf[0]
+
+    def spawn_addr2line(self):
+        if not self._addr2line:
+            elf = self.get_elf(self._bin)
+            if not elf:
+                return
+            if self._arch == 'arm':
+                cmd = 'arm-linux-gnueabihf-addr2line'
+            elif self._arch == 'aarch64':
+                cmd = 'aarch64-linux-gnu-addr2line'
+            else:
+                return
+            self._addr2line = subprocess.Popen([cmd, '-f', '-p', '-e', elf],
+                                                stdin = subprocess.PIPE,
+                                                stdout = subprocess.PIPE)
+
+    def resolve(self, addr):
+        offs = self._load_addr
+        if int(offs, 0) > int(addr, 0):
+            return '???'
+        reladdr = '0x{:x}'.format(int(addr, 0) - int(offs, 0))
+        self.spawn_addr2line()
+        if not self._addr2line:
+            return '???'
+        try:
+            print >> self._addr2line.stdin, reladdr
+            ret = self._addr2line.stdout.readline().rstrip('\n')
+        except IOError:
+            ret = '!!!'
+        return ret
+
+    def reset(self):
+        self._call_stack_found = False
+        self._load_addr = '0'
+        if self._addr2line:
+            self._addr2line.terminate()
+            self._addr2line = None
+        self._arch = 'arm'
+
+    def write(self, line):
+            if self._call_stack_found:
+                match = re.search(STACK_ADDR_RE, line)
+                if match:
+                    addr = match.group('addr')
+                    pre = match.start('addr')
+                    post = match.end('addr')
+                    self._out.write(line[:pre])
+                    self._out.write(addr)
+                    res = self.resolve(addr)
+                    if self._strip_path:
+                        res = re.sub(re.escape(self._strip_path) + '/*', '',
+                              res)
+                    self._out.write(' ' + res)
+                    self._out.write(line[post:])
+                    return
+                else:
+                    self.reset()
+            match = re.search(CALL_STACK_RE, line)
+            if match:
+                self._call_stack_found = True
+            match = re.search(TA_UUID_RE, line)
+            if match:
+                self._bin = match.group('uuid')
+            match = re.search(TA_INFO_RE, line)
+            if match:
+                self._arch = match.group('arch')
+                self._load_addr = match.group('load_addr')
+            match = re.search(X64_REGS_RE, line)
+            if match:
+                # Assume _arch represents the TEE core. If we have a TA dump,
+                # it will be overwritten later
+                self._arch = 'aarch64'
+            self._out.write(line)
+
+    def flush(self):
+        self._out.flush()
+
+def main():
+    args = get_args()
+    if args.dir:
+        # Flatten list in case -d is used several times *and* with multiple
+        # arguments
+        args.dirs = [item for sublist in args.dir for item in sublist]
+    else:
+        args.dirs = []
+    symbolizer = Symbolizer(sys.stdout, args.dirs, args.strip_path)
+
+    for line in sys.stdin:
+        symbolizer.write(line)
+    symbolizer.flush()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add TA call stack to the abort message. Here is an example:
```
root@HiKey:/ xtest 9148
Test ID: 9148
Run test suite with level=0

TEE test application started with device [(null)]
######################################################
#
# regression+gp
#
######################################################
 
* gp_9148 50-51-15
ERROR:   TEE-CORE: 
ERROR:   TEE-CORE: User TA data-abort at address 0xffffdecd (alignment fault)
ERROR:   TEE-CORE:  esr 0x92000021  ttbr0 0x100003f0810c0   ttbr1 0x00000000   cidr 0x0
ERROR:   TEE-CORE:  cpu #6          cpsr 0x60000130
ERROR:   TEE-CORE:  x0  00000000ffffdead x1  0000000000000000
ERROR:   TEE-CORE:  x2  0000000000000000 x3  0000000040201000
ERROR:   TEE-CORE:  x4  00000000ffffdead x5  0000000040000f74
ERROR:   TEE-CORE:  x6  0000000000000000 x7  0000000040000ec8
ERROR:   TEE-CORE:  x8  0000000000000000 x9  0000000000010014
ERROR:   TEE-CORE:  x10 0000000040000ec0 x11 0000000040200000
ERROR:   TEE-CORE:  x12 000000004000b000 x13 0000000040000eb0
ERROR:   TEE-CORE:  x14 0000000040001f4b x15 0000000000000000
ERROR:   TEE-CORE:  x16 000000003f016750 x17 0000000000000000
ERROR:   TEE-CORE:  x18 0000000000000000 x19 000000003f08d2a0
ERROR:   TEE-CORE:  x20 0000000000000000 x21 000000003f04fa30
ERROR:   TEE-CORE:  x22 00000000000005f0 x23 000000003f08d468
ERROR:   TEE-CORE:  x24 0000000000000000 x25 000000003f063980
ERROR:   TEE-CORE:  x26 000000003f08d450 x27 0000000000010014
ERROR:   TEE-CORE:  x28 0000000040000f88 x29 0000000000000000
ERROR:   TEE-CORE:  x30 000000003f0043c4 elr 000000004000549e
ERROR:   TEE-CORE:  sp_el0 0000000040000f80
ERROR:   TEE-CORE: Status of TA 534d4152-5443-534c-5443-525950544f31 (0x3f063ba0) (active)
ERROR:   TEE-CORE:  arch: arm  load address: 0x40001000  ctx-idr: 1
ERROR:   TEE-CORE:  stack: 0x40000000 4096
ERROR:   TEE-CORE:  region 0: va 0x40000000 pa 0x3f218000 size 0x1000
ERROR:   TEE-CORE:  region 1: va 0x40001000 pa 0x3f200000 size 0xa000
ERROR:   TEE-CORE:  region 2: va 0x4000b000 pa 0x3f20a000 size 0x3000
ERROR:   TEE-CORE:  region 3: va 0x4000e000 pa 0x3f20d000 size 0xb000
ERROR:   TEE-CORE:  region 4: va 0x40200000 pa 0x3ee01000 size 0x2000
ERROR:   TEE-CORE:  region 5: va 0 pa 0 size 0
ERROR:   TEE-CORE:  region 6: va 0 pa 0 size 0
ERROR:   TEE-CORE:  region 7: va 0 pa 0 size 0
ERROR:   TEE-CORE: Call stack:
ERROR:   TEE-CORE:  0x4000549e
ERROR:   TEE-CORE:  0x40001f4b
ERROR:   TEE-CORE:  0x4000273f
ERROR:   TEE-CORE:  0x40005da7
  gp_9148 OK
+-----------------------------------------------------
Result of testsuite regression+gp filtered by "9148":
gp_9148 OK
+-----------------------------------------------------
23 subtests of which 0 failed
1 test case of which 0 failed
722 test cases was skipped
TEE test application done!
```

A script is also added to help decode the stack dump:

```
$ cat dump.txt | optee_os/scripts/symbolize.py -d optee_test/out/ta/* -s `pwd`
* gp_9148 50-51-15
ERROR:   TEE-CORE: 
ERROR:   TEE-CORE: User TA data-abort at address 0xffffdecd (alignment fault)
ERROR:   TEE-CORE:  esr 0x92000021  ttbr0 0x100003f0810c0   ttbr1 0x00000000   cidr 0x0
ERROR:   TEE-CORE:  cpu #6          cpsr 0x60000130
ERROR:   TEE-CORE:  x0  00000000ffffdead x1  0000000000000000
ERROR:   TEE-CORE:  x2  0000000000000000 x3  0000000040201000
ERROR:   TEE-CORE:  x4  00000000ffffdead x5  0000000040000f74
ERROR:   TEE-CORE:  x6  0000000000000000 x7  0000000040000ec8
ERROR:   TEE-CORE:  x8  0000000000000000 x9  0000000000010014
ERROR:   TEE-CORE:  x10 0000000040000ec0 x11 0000000040200000
ERROR:   TEE-CORE:  x12 00000000ffffb4a8 x13 0000000040000eb0
ERROR:   TEE-CORE:  x14 0000000040001f4b x15 0000000000000000
ERROR:   TEE-CORE:  x16 000000003f0167d0 x17 0000000000000000
ERROR:   TEE-CORE:  x18 0000000000000000 x19 000000003f08d2a0
ERROR:   TEE-CORE:  x20 0000000000000000 x21 000000003f04fad0
ERROR:   TEE-CORE:  x22 00000000000005f0 x23 000000003f08d468
ERROR:   TEE-CORE:  x24 0000000000000000 x25 000000003f063980
ERROR:   TEE-CORE:  x26 000000003f08d450 x27 0000000000010014
ERROR:   TEE-CORE:  x28 0000000040000f88 x29 0000000000000000
ERROR:   TEE-CORE:  x30 000000003f0043c4 elr 000000004000549e
ERROR:   TEE-CORE:  sp_el0 0000000040000f80
ERROR:   TEE-CORE: Status of TA 534d4152-5443-534c-5443-525950544f31 (0x3f063ba0) (active)
ERROR:   TEE-CORE:  arch: arm  load address: 0x40001000  ctx-idr: 1
ERROR:   TEE-CORE:  stack: 0x40000000 4096
ERROR:   TEE-CORE:  region 0: va 0x40000000 pa 0x3f218000 size 0x1000
ERROR:   TEE-CORE:  region 1: va 0x40001000 pa 0x3f200000 size 0xa000
ERROR:   TEE-CORE:  region 2: va 0x4000b000 pa 0x3f20a000 size 0x3000
ERROR:   TEE-CORE:  region 3: va 0x4000e000 pa 0x3f20d000 size 0xb000
ERROR:   TEE-CORE:  region 4: va 0x40200000 pa 0x3ee01000 size 0x2000
ERROR:   TEE-CORE:  region 5: va 0 pa 0 size 0
ERROR:   TEE-CORE:  region 6: va 0 pa 0 size 0
ERROR:   TEE-CORE:  region 7: va 0 pa 0 size 0
ERROR:   TEE-CORE: Call stack:
ERROR:   TEE-CORE:  0x4000549e TEE_AsymmetricDecrypt at optee_os/lib/libutee/tee_api_operations.c:1614
ERROR:   TEE-CORE:  0x40001f4b CmdAsymmetricDecryptNoParam at optee_test/ta/GP_TTA_Crypto/TTA_Crypto.c:1179
ERROR:   TEE-CORE:  0x4000273f TA_InvokeCommandEntryPoint at optee_test/ta/GP_TTA_Crypto/TTA_Crypto.c:1675
ERROR:   TEE-CORE:  0x40005da7 entry_invoke_command at optee_os/lib/libutee/arch/arm/user_ta_entry.c:210
  gp_9148 OK
```