### PR TITLE
plat-ti: Reserve first page of SRAM for secure boot software

### DIFF
--- a/core/arch/arm/plat-ti/platform_config.h
+++ b/core/arch/arm/plat-ti/platform_config.h
@@ -132,7 +132,7 @@
 #define CFG_TEE_RAM_VA_SIZE     (1 * 1024 * 1024)
 #define CFG_TEE_RAM_PH_SIZE     TZSRAM_SIZE
 #define CFG_TEE_RAM_START       TZSRAM_BASE
-#define CFG_TEE_LOAD_ADDR       CFG_TEE_RAM_START
+#define CFG_TEE_LOAD_ADDR       (CFG_TEE_RAM_START + 0x1000)
 
 #else /* CFG_WITH_PAGER */
 /*


### PR DESCRIPTION
The first 4KB of SRAM is used by the initial secure software and
OP-TEE should not be loaded to this address. Adjust the TEE_LOAD_ADDR
to reflect this.

Signed-off-by: Andrew F. Davis <afd@ti.com>