### PR TITLE
add get_base and get_io_base helper function

### DIFF
--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -106,4 +106,10 @@ void *phys_to_virt_io(paddr_t pa);
  */
 paddr_t virt_to_phys(void *va);
 
+/*
+ * Return runtime usable address, irrespective of whether
+ * the MMU is enabled or not.
+ */
+vaddr_t core_mmu_get_va(paddr_t pa, enum teecore_memtypes type);
+
 #endif /* CORE_MEMPROT_H */

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1455,3 +1455,11 @@ bool cpu_mmu_enabled(void)
 
 	return sctlr & SCTLR_M ? true : false;
 }
+
+vaddr_t core_mmu_get_va(paddr_t pa, enum teecore_memtypes type)
+{
+	if (cpu_mmu_enabled())
+		return (vaddr_t)phys_to_virt(pa, type);
+
+	return (vaddr_t)pa;
+}

--- a/core/arch/arm/plat-imx/imx_pl310.c
+++ b/core/arch/arm/plat-imx/imx_pl310.c
@@ -68,13 +68,6 @@ void arm_cl2_enable(vaddr_t pl310_base)
 
 vaddr_t pl310_base(void)
 {
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(PL310_BASE, MEM_AREA_IO_SEC);
-		return (vaddr_t)va;
-	}
-	return PL310_BASE;
+	return core_mmu_get_va(PL310_BASE, MEM_AREA_IO_SEC);
 }
 

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -86,10 +86,8 @@ void main_init_gic(void)
 	vaddr_t gicc_base;
 	vaddr_t gicd_base;
 
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC);
+	gicc_base = core_mmu_get_va(GIC_BASE + GICC_OFFSET, MEM_AREA_IO_SEC);
+	gicd_base = core_mmu_get_va(GIC_BASE + GICD_OFFSET, MEM_AREA_IO_SEC);
 
 	if (!gicc_base || !gicd_base)
 		panic();

--- a/core/arch/arm/plat-imx/psci.c
+++ b/core/arch/arm/plat-imx/psci.c
@@ -41,23 +41,14 @@
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 
-static vaddr_t src_base(void)
-{
-	static void *va;
-
-	if (cpu_mmu_enabled()) {
-		if (!va)
-			va = phys_to_virt(SRC_BASE, MEM_AREA_IO_SEC);
-		return (vaddr_t)va;
-	}
-	return SRC_BASE;
-}
-
 int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 		uint32_t context_id __attribute__((unused)))
 {
 	uint32_t val;
-	vaddr_t va = src_base();
+	vaddr_t va = core_mmu_get_va(SRC_BASE, MEM_AREA_IO_SEC);
+
+	if (!va)
+		EMSG("No SRC mapping\n");
 
 	if ((core_idx == 0) || (core_idx >= CFG_TEE_CORE_NB_CORE))
 		return PSCI_RET_INVALID_PARAMETERS;


### PR DESCRIPTION
Add get_base and get_io_base function helper function. These two functions are only to wrap phys_to_virt and phy_to_virt_io and add cpu_mmu_enabled checking.