### PR TITLE
Use `mobj`s to pass shared buffers

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -63,7 +63,7 @@ struct thread_specific_data {
 	struct tee_ta_ctx *ctx;
 	struct pgt_cache pgt_cache;
 	void *rpc_fs_payload;
-	paddr_t rpc_fs_payload_pa;
+	struct mobj *rpc_fs_payload_mobj;
 	uint64_t rpc_fs_payload_cookie;
 	size_t rpc_fs_payload_size;
 };
@@ -529,11 +529,11 @@ bool thread_enable_prealloc_rpc_cache(void);
  * Allocates data for struct optee_msg_arg.
  *
  * @size:	size in bytes of struct optee_msg_arg
- * @arg:	returned physcial pointer to a struct optee_msg_arg buffer,
- *		0 if allocation failed.
  * @cookie:	returned cookie used when freeing the buffer
+ *
+ * @returns	mobj that describes allocated buffer or NULL on error
  */
-void thread_rpc_alloc_arg(size_t size, paddr_t *arg, uint64_t *cookie);
+struct mobj *thread_rpc_alloc_arg(size_t size, uint64_t *cookie);
 
 /**
  * Free physical memory previously allocated with thread_rpc_alloc_arg()
@@ -546,18 +546,19 @@ void thread_rpc_free_arg(uint64_t cookie);
  * Allocates data for payload buffers.
  *
  * @size:	size in bytes of payload buffer
- * @payload:	returned physcial pointer to payload buffer, 0 if allocation
- *		failed.
  * @cookie:	returned cookie used when freeing the buffer
+ *
+ * @returns	mobj that describes allocated buffer or NULL on error
  */
-void thread_rpc_alloc_payload(size_t size, paddr_t *payload, uint64_t *cookie);
+struct mobj *thread_rpc_alloc_payload(size_t size, uint64_t *cookie);
 
 /**
  * Free physical memory previously allocated with thread_rpc_alloc_payload()
  *
  * @cookie:	cookie received when allocating the buffer
+ * @mobj:	mobj that describes the buffer
  */
-void thread_rpc_free_payload(uint64_t cookie);
+void thread_rpc_free_payload(uint64_t cookie, struct mobj *mobj);
 
 /**
  * Does an RPC using a preallocated argument buffer

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -139,6 +139,8 @@ struct mobj *mobj_reg_shm_find_by_cookie(uint64_t cookie);
 struct mobj *mobj_mapped_shm_alloc(paddr_t *pages, size_t num_pages,
 				   paddr_t page_offset, uint64_t cookie);
 
+struct mobj *mobj_shm_alloc(paddr_t pa, size_t size);
+
 struct mobj *mobj_paged_alloc(size_t size);
 
 #ifdef CFG_PAGED_USER_TA

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -32,12 +32,14 @@
 #include <assert.h>
 #include <keep.h>
 #include <kernel/misc.h>
+#include <kernel/msg_param.h>
 #include <kernel/panic.h>
 #include <kernel/spinlock.h>
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread_defs.h>
 #include <kernel/thread.h>
 #include <mm/core_memprot.h>
+#include <mm/mobj.h>
 #include <mm/tee_mm.h>
 #include <mm/tee_mmu.h>
 #include <mm/tee_pager.h>
@@ -584,7 +586,6 @@ void thread_handle_std_smc(struct thread_smc_args *args)
 /* Helper routine for the assembly function thread_std_smc_entry() */
 void __thread_std_smc_entry(struct thread_smc_args *args)
 {
-
 	thread_std_smc_handler_ptr(args);
 
 	if (args->a0 == OPTEE_SMC_RETURN_OK) {
@@ -593,8 +594,10 @@ void __thread_std_smc_entry(struct thread_smc_args *args)
 		tee_fs_rpc_cache_clear(&thr->tsd);
 		if (!thread_prealloc_rpc_cache) {
 			thread_rpc_free_arg(thr->rpc_carg);
+			mobj_free(thr->rpc_mobj);
 			thr->rpc_carg = 0;
 			thr->rpc_arg = 0;
+			thr->rpc_mobj = NULL;
 		}
 	}
 }
@@ -1169,13 +1172,6 @@ out:
 	return rv;
 }
 
-static bool check_alloced_shm(paddr_t pa, size_t len, size_t align)
-{
-	if (pa & (align - 1))
-		return false;
-	return core_pbuf_is(CORE_MEM_NSEC_SHM, pa, len);
-}
-
 void thread_rpc_free_arg(uint64_t cookie)
 {
 	if (cookie) {
@@ -1188,26 +1184,34 @@ void thread_rpc_free_arg(uint64_t cookie)
 	}
 }
 
-void thread_rpc_alloc_arg(size_t size, paddr_t *arg, uint64_t *cookie)
+struct mobj *thread_rpc_alloc_arg(size_t size, uint64_t *cookie)
 {
 	paddr_t pa;
 	uint64_t co;
 	uint32_t rpc_args[THREAD_RPC_NUM_ARGS] = {
 		OPTEE_SMC_RETURN_RPC_ALLOC, size
 	};
+	struct mobj *mobj = NULL;
 
 	thread_rpc(rpc_args);
 
 	pa = reg_pair_to_64(rpc_args[1], rpc_args[2]);
 	co = reg_pair_to_64(rpc_args[4], rpc_args[5]);
-	if (!check_alloced_shm(pa, size, sizeof(uint64_t))) {
-		thread_rpc_free_arg(co);
-		pa = 0;
-		co = 0;
-	}
 
-	*arg = pa;
+	if (!ALIGNMENT_IS_OK(pa, struct optee_msg_arg))
+		goto err;
+
+	mobj = mobj_shm_alloc(pa, size);
+	if (!mobj)
+		goto err;
+
 	*cookie = co;
+	return mobj;
+err:
+	thread_rpc_free_arg(co);
+	mobj_free(mobj);
+	*cookie = 0;
+	return NULL;
 }
 
 static bool get_rpc_arg(uint32_t cmd, size_t num_params,
@@ -1215,25 +1219,25 @@ static bool get_rpc_arg(uint32_t cmd, size_t num_params,
 {
 	struct thread_ctx *thr = threads + thread_get_id();
 	struct optee_msg_arg *arg = thr->rpc_arg;
+	struct mobj *mobj;
 	size_t sz = OPTEE_MSG_GET_ARG_SIZE(THREAD_RPC_MAX_NUM_PARAMS);
-	paddr_t p;
 	uint64_t c;
 
 	if (num_params > THREAD_RPC_MAX_NUM_PARAMS)
 		return false;
 
 	if (!arg) {
-		thread_rpc_alloc_arg(sz, &p, &c);
-		if (!p)
+		mobj = thread_rpc_alloc_arg(sz, &c);
+		if (!mobj)
 			return false;
-		if (!ALIGNMENT_IS_OK(p, struct optee_msg_arg))
-			goto bad;
-		arg = phys_to_virt(p, MEM_AREA_NSEC_SHM);
+
+		arg = mobj_get_va(mobj, 0);
 		if (!arg)
 			goto bad;
 
 		thr->rpc_arg = arg;
 		thr->rpc_carg = c;
+		thr->rpc_mobj = mobj;
 	}
 
 	memset(arg, 0, OPTEE_MSG_GET_ARG_SIZE(num_params));
@@ -1295,8 +1299,11 @@ uint32_t thread_rpc_cmd(uint32_t cmd, size_t num_params,
  *
  * @cookie:	cookie received when allocating the buffer
  * @bt:		must be the same as supplied when allocating
+ * @mobj:	mobj that describes allocated buffer
+ *
+ * This function also frees corresponding mobj.
  */
-static void thread_rpc_free(unsigned int bt, uint64_t cookie)
+static void thread_rpc_free(unsigned int bt, uint64_t cookie, struct mobj *mobj)
 {
 	uint32_t rpc_args[THREAD_RPC_NUM_ARGS] = { OPTEE_SMC_RETURN_RPC_CMD };
 	struct optee_msg_arg *arg;
@@ -1309,6 +1316,8 @@ static void thread_rpc_free(unsigned int bt, uint64_t cookie)
 	arg->params[0].u.value.a = bt;
 	arg->params[0].u.value.b = cookie;
 	arg->params[0].u.value.c = 0;
+
+	mobj_free(mobj);
 
 	reg_pair_from_64(carg, rpc_args + 1, rpc_args + 2);
 	thread_rpc(rpc_args);
@@ -1324,12 +1333,13 @@ static void thread_rpc_free(unsigned int bt, uint64_t cookie)
  *		failed.
  * @cookie:	returned cookie used when freeing the buffer
  */
-static void thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
-			paddr_t *payload, uint64_t *cookie)
+static struct mobj *thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
+				     uint64_t *cookie)
 {
 	uint32_t rpc_args[THREAD_RPC_NUM_ARGS] = { OPTEE_SMC_RETURN_RPC_CMD };
 	struct optee_msg_arg *arg;
 	uint64_t carg;
+	struct mobj *mobj = NULL;
 
 	if (!get_rpc_arg(OPTEE_MSG_RPC_CMD_SHM_ALLOC, 1, &arg, &carg))
 		goto fail;
@@ -1341,34 +1351,36 @@ static void thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
 
 	reg_pair_from_64(carg, rpc_args + 1, rpc_args + 2);
 	thread_rpc(rpc_args);
+
 	if (arg->ret != TEE_SUCCESS)
 		goto fail;
 
 	if (arg->num_params != 1)
 		goto fail;
 
-	if (arg->params[0].attr != OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT)
-		goto fail;
-
-	if (!check_alloced_shm(arg->params[0].u.tmem.buf_ptr, size, align)) {
-		thread_rpc_free(bt, arg->params[0].u.tmem.shm_ref);
-		goto fail;
-	}
-
-	*payload = arg->params[0].u.tmem.buf_ptr;
+	mobj = mobj_shm_alloc(arg->params[0].u.tmem.buf_ptr,
+			      arg->params[0].u.tmem.size);
 	*cookie = arg->params[0].u.tmem.shm_ref;
-	return;
+
+	if (!mobj)
+		goto free_first;
+
+	assert(mobj_is_nonsec(mobj));
+	return mobj;
+
+free_first:
+	thread_rpc_free(bt, *cookie, mobj);
 fail:
-	*payload = 0;
 	*cookie = 0;
+	return NULL;
 }
 
-void thread_rpc_alloc_payload(size_t size, paddr_t *payload, uint64_t *cookie)
+struct mobj *thread_rpc_alloc_payload(size_t size, uint64_t *cookie)
 {
-	thread_rpc_alloc(size, 8, OPTEE_MSG_RPC_SHM_TYPE_APPL, payload, cookie);
+	return thread_rpc_alloc(size, 8, OPTEE_MSG_RPC_SHM_TYPE_APPL, cookie);
 }
 
-void thread_rpc_free_payload(uint64_t cookie)
+void thread_rpc_free_payload(uint64_t cookie, struct mobj *mobj)
 {
-	thread_rpc_free(OPTEE_MSG_RPC_SHM_TYPE_APPL, cookie);
+	thread_rpc_free(OPTEE_MSG_RPC_SHM_TYPE_APPL, cookie, mobj);
 }

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -113,6 +113,7 @@ struct thread_ctx {
 #endif
 	void *rpc_arg;
 	uint64_t rpc_carg;
+	struct mobj *rpc_mobj;
 	struct mutex_head mutexes;
 	struct thread_specific_data tsd;
 };

--- a/core/include/kernel/msg_param.h
+++ b/core/include/kernel/msg_param.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2017, EPAM Systems
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KERNEL_MSG_PARAM_H
+#define KERNEL_MSG_PARAM_H
+
+#include <optee_msg.h>
+#include <stdio.h>
+#include <types_ext.h>
+#include <kernel/msg_param.h>
+#include <mm/mobj.h>
+
+/*
+ * This enum is used in tee_fill_memparam(). It describes direction of memory
+ * parameter.
+ */
+enum msg_param_mem_dir {
+	MSG_PARAM_MEM_DIR_IN = 0,
+	MSG_PARAM_MEM_DIR_OUT,
+	MSG_PARAM_MEM_DIR_INOUT,
+};
+
+/**
+ * msg_param_init_memparam() - fill memory reference parameter for RPC call
+ * @param	- parameter to fill
+ * @mobj	- mobj describing the shared memory buffer
+ * @offset	- offset of the buffer
+ * @size	- size of the buffer
+ * @cookie	- NW cookie of the shared buffer
+ * @dir		- data direction
+ *
+ * Idea behind this function is that thread_rpc_alloc() can return
+ * either buffer from preallocated memory pool, of buffer constructed
+ * from supplicant's memory. In first case parameter will have type
+ * OPTEE_MSG_ATTR_TYPE_TMEM_* and OPTEE_MSG_ATTR_TYPE_RMEM_ in second case.
+ * This function will fill parameter structure with right type, depending on
+ * the passed mobj.
+ *
+ * return:
+ *	true on success, false on failure
+ */
+bool msg_param_init_memparam(struct optee_msg_param *param, struct mobj *mobj,
+			     size_t offset, size_t size,
+			     uint64_t cookie, enum msg_param_mem_dir dir);
+/**
+ * msg_param_get_buf_size() - helper functions that reads [T/R]MEM
+ *			      parameter size
+ *
+ * @param - struct optee_msg_param to read size from
+ *
+ * return:
+ *	corresponding size field
+ */
+static inline size_t msg_param_get_buf_size(struct optee_msg_param *param)
+{
+	switch (param->attr & OPTEE_MSG_ATTR_TYPE_MASK) {
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INOUT:
+		return param->u.tmem.size;
+	case OPTEE_MSG_ATTR_TYPE_RMEM_INPUT:
+	case OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT:
+	case OPTEE_MSG_ATTR_TYPE_RMEM_INOUT:
+		return param->u.rmem.size;
+	default:
+		return 0;
+	}
+}
+
+/**
+ * msg_param_attr_is_tmem - helper functions that cheks if parameter is tmem
+ *
+ * @param - struct optee_msg_param to check
+ *
+ * return:
+ *	corresponding size field
+ */
+static inline bool msg_param_attr_is_tmem(struct optee_msg_param *param)
+{
+	switch (param->attr & OPTEE_MSG_ATTR_TYPE_MASK) {
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT:
+	case OPTEE_MSG_ATTR_TYPE_TMEM_INOUT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+#endif	/*KERNEL_MSG_PARAM_H*/

--- a/core/include/tee/tee_fs_rpc.h
+++ b/core/include/tee/tee_fs_rpc.h
@@ -96,6 +96,6 @@ static inline void tee_fs_rpc_cache_clear(
  * cache. The pointer is guaranteed to point to a large enough area or to
  * be NULL.
  */
-void *tee_fs_rpc_cache_alloc(size_t size, paddr_t *pa, uint64_t *cookie);
+void *tee_fs_rpc_cache_alloc(size_t size, struct mobj **mobj, uint64_t *cookie);
 
 #endif /* TEE_FS_RPC_H */

--- a/core/kernel/msg_param.c
+++ b/core/kernel/msg_param.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, EPAM Systems
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <optee_msg.h>
+#include <stdio.h>
+#include <types_ext.h>
+#include <kernel/msg_param.h>
+#include <mm/mobj.h>
+
+bool msg_param_init_memparam(struct optee_msg_param *param, struct mobj *mobj,
+			     size_t offset, size_t size,
+			     uint64_t cookie, enum msg_param_mem_dir dir)
+{
+	if (mobj_matches(mobj, CORE_MEM_REG_SHM)) {
+		/* Registered SHM mobj */
+		switch (dir) {
+		case MSG_PARAM_MEM_DIR_IN:
+			param->attr = OPTEE_MSG_ATTR_TYPE_RMEM_INPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_OUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_INOUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_RMEM_INOUT;
+			break;
+		default:
+			return false;
+		}
+
+		param->u.rmem.size = size;
+		param->u.rmem.offs = offset;
+		param->u.rmem.shm_ref = cookie;
+	} else if (mobj_matches(mobj, CORE_MEM_NSEC_SHM)) {
+		/* MOBJ from from predefined pool */
+		paddr_t pa;
+
+		if (mobj_get_pa(mobj, 0, 0, &pa) != TEE_SUCCESS)
+			return false;
+
+		switch (dir) {
+		case MSG_PARAM_MEM_DIR_IN:
+			param->attr = OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_OUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
+			break;
+		case MSG_PARAM_MEM_DIR_INOUT:
+			param->attr = OPTEE_MSG_ATTR_TYPE_TMEM_INOUT;
+			break;
+		default:
+			return false;
+		}
+
+		param->u.tmem.buf_ptr = pa + offset;
+		param->u.tmem.shm_ref = cookie;
+		param->u.tmem.size = size;
+	} else
+		return false;
+	return true;
+}

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -1,6 +1,7 @@
 srcs-y += assert.c
 srcs-y += console.c
 srcs-$(CFG_DT) += dt.c
+srcs-y += msg_param.c
 srcs-y += tee_ta_manager.c
 srcs-y += tee_misc.c
 srcs-y += panic.c

--- a/core/tee/tee_fs_rpc_cache.c
+++ b/core/tee/tee_fs_rpc_cache.c
@@ -28,19 +28,22 @@
 #include <kernel/thread.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <mm/mobj.h>
 #include <tee/tee_fs_rpc.h>
 
 void tee_fs_rpc_cache_clear(struct thread_specific_data *tsd)
 {
 	if (tsd->rpc_fs_payload) {
-		thread_rpc_free_payload(tsd->rpc_fs_payload_cookie);
+		thread_rpc_free_payload(tsd->rpc_fs_payload_cookie,
+					tsd->rpc_fs_payload_mobj);
 		tsd->rpc_fs_payload = NULL;
 		tsd->rpc_fs_payload_cookie = 0;
 		tsd->rpc_fs_payload_size = 0;
+		tsd->rpc_fs_payload_mobj = NULL;
 	}
 }
 
-void *tee_fs_rpc_cache_alloc(size_t size, paddr_t *pa, uint64_t *cookie)
+void *tee_fs_rpc_cache_alloc(size_t size, struct mobj **mobj, uint64_t *cookie)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
 	size_t sz = size;
@@ -60,26 +63,30 @@ void *tee_fs_rpc_cache_alloc(size_t size, paddr_t *pa, uint64_t *cookie)
 	if (sz > tsd->rpc_fs_payload_size) {
 		tee_fs_rpc_cache_clear(tsd);
 
-		thread_rpc_alloc_payload(sz, &p, &c);
-		if (!p)
+		*mobj = thread_rpc_alloc_payload(sz,  &c);
+		if (!*mobj)
 			return NULL;
+
+		if (mobj_get_pa(*mobj, 0, 0, &p))
+			goto err;
+
 		if (!ALIGNMENT_IS_OK(p, uint64_t))
 			goto err;
 
-		va = phys_to_virt(p, MEM_AREA_NSEC_SHM);
+		va = mobj_get_va(*mobj, 0);
 		if (!va)
 			goto err;
 
 		tsd->rpc_fs_payload = va;
-		tsd->rpc_fs_payload_pa = p;
+		tsd->rpc_fs_payload_mobj = *mobj;
 		tsd->rpc_fs_payload_cookie = c;
 		tsd->rpc_fs_payload_size = sz;
-	}
+	} else
+		*mobj = tsd->rpc_fs_payload_mobj;
 
-	*pa = tsd->rpc_fs_payload_pa;
 	*cookie = tsd->rpc_fs_payload_cookie;
 	return tsd->rpc_fs_payload;
 err:
-	thread_rpc_free_payload(c);
+	thread_rpc_free_payload(c, *mobj);
 	return NULL;
 }


### PR DESCRIPTION
This patch series includes three patches:

 * added `msg_parm.c` to ease up REE-TEE parameters handling
 * added new `mobj` type `mobj_shm`. This `mobj` describes buffer in preshared memory region (` CORE_MEM_NSEC_SHM`).
 *  All shared buffers are wrapped into `mobjs` (both command buffers, and buffers allocated in `thread.c`). All users of shared buffers (e.g. user TA loader) now work with `mobj`s. This allows to pass another `mobj` types, like registered `mobj` which will be introduced in #1232  