### PR TITLE
Fix of the _core_is_buffer_intersect check

### DIFF
--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -129,9 +129,9 @@ bool _core_is_buffer_outside(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 /* Returns true when buffer 'b' intersects area 'a' */
 bool _core_is_buffer_intersect(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 {
-	/* invalid config or "null size" return false */
+	/* invalid config or "null size" return true */
 	if (!is_valid_conf_and_notnull_size(b, bl, a, al))
-		return false;
+		return true;
 
 	if ((b + bl <= a) || (b >= a + al))
 		return false;


### PR DESCRIPTION
Function _core_is_buffer_intersect() was returning false in case is_valid_conf_and_notnull_size() returns false. Which means that if buffer is zero length or if there is an overflow due to very big length of the buffer the function _core_is_buffer_intersect() will return false indicating that there is no intersection which is not correct since in case of an overflow the buffers still can intersect.