### PR TITLE
trace.c: show file/line info for flow, debug and error messages

### DIFF
--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -86,7 +86,7 @@ void trace_printf(const char *function, int line, int level, bool level_ok,
 		return;
 	boffs += res;
 
-	if (level_ok && level < CFG_MSG_LONG_PREFIX_THRESHOLD)
+	if (level_ok && !(BIT(level) & CFG_MSG_LONG_PREFIX_MASK))
 		thread_id = -1;
 	else
 		thread_id = trace_ext_get_thread_id();
@@ -105,7 +105,7 @@ void trace_printf(const char *function, int line, int level, bool level_ok,
 		return;
 	boffs += res;
 
-	if (level_ok && level < CFG_MSG_LONG_PREFIX_THRESHOLD)
+	if (level_ok && !(BIT(level) & CFG_MSG_LONG_PREFIX_MASK))
 		function = NULL;
 
 	if (function) {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -75,12 +75,12 @@ CFG_TEE_CORE_USER_MEM_DEBUG ?= 1
 CFG_TEE_CORE_MALLOC_DEBUG ?= n
 CFG_TEE_TA_MALLOC_DEBUG ?= n
 
-# All message with level equal or higher to the following value will be
-# prefixed with long debugging information (severity, thread ID, component
-# name, function name, line number). Otherwise a short prefix is used
-# (severity and component name only).
+# Mask to select which messages are prefixed with long debugging information
+# (severity, thread ID, component name, function name, line number) based on
+# the message level. If BIT(level) is set, the long prefix is shown.
+# Otherwise a short prefix is used (severity and component name only).
 # Levels: 0=none 1=error 2=info 3=debug 4=flow
-CFG_MSG_LONG_PREFIX_THRESHOLD ?= 3
+CFG_MSG_LONG_PREFIX_MASK ?= 0x1a
 
 # PRNG configuration
 # If CFG_WITH_SOFTWARE_PRNG is enabled, crypto provider provided


### PR DESCRIPTION
Since commit f4aa5b11f9a3 ("Update trace format to be less verbose in
INFO and ERROR levels"), INFO and ERROR messages don't show source file
and line information by default, while message with lower severity
(DEBUG and FLOW) do contain such information. While it is OK for INFO,
it turns out to be inconvenient for ERRORs during development, because
one typically wants to be able to quickly locate the source of errors.
This patch fixes the problem by introducing a mask rather than a level
to control the long output format. This allows individual selection of
which level should use a long vs. short format.
The compile-time setting CFG_MSG_LONG_PREFIX_THRESHOLD is replaced by
CFG_MSG_LONG_PREFIX_MASK with default value 8 (= ERROR | DEBUG | FLOW).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>