### PR TITLE
core: enable debug mode by default

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -38,9 +38,11 @@ WARNS ?= 3
 # Define DEBUG=1 to compile without optimization (forces -O0)
 # DEBUG=1
 
-# If y, enable debug mode of the tee firmware (CPU restart, Core Status
-# verbose, panic & assert verbose). When disable, NDEBUG directive is defined.
-CFG_TEE_CORE_DEBUG ?= n
+# If y, enable debug features of the TEE core (assertions and lock checks
+# are enabled, panic and assert messages are more verbose, data and prefetch
+# aborts show a stack dump). When disabled, the NDEBUG directive is defined
+# so assertions are disabled.
+CFG_TEE_CORE_DEBUG ?= y
 
 # Max level of the tee core traces. 0 means disable, 4 is max.
 # Supported values: 0 (no traces) to 4 (all traces)


### PR DESCRIPTION
Assume the default build environment is meant for development, so set
CFG_TEE_CORE_DEBUG=y by default.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>