### PR TITLE
ta: TA_FLAG_EXEC_DDR and TA_FLAG_USER_MODE are implicit in optee

### DIFF
--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -47,10 +47,7 @@ struct pseudo_ta_ctx {
 	struct tee_ta_ctx ctx;
 };
 
-static inline bool is_pseudo_ta_ctx(struct tee_ta_ctx *ctx)
-{
-	return !(ctx->flags & TA_FLAG_USER_MODE);
-}
+bool is_pseudo_ta_ctx(struct tee_ta_ctx *ctx);
 
 static inline struct pseudo_ta_ctx *to_pseudo_ta_ctx(struct tee_ta_ctx *ctx)
 {

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -64,10 +64,14 @@ struct user_ta_ctx {
 
 };
 
-static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx)
+#ifdef CFG_WITH_USER_TA
+bool is_user_ta_ctx(struct tee_ta_ctx *ctx);
+#else
+static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx __unused)
 {
-	return !!(ctx->flags & TA_FLAG_USER_MODE);
+	return false;
 }
+#endif
 
 static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
 {

--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -319,14 +319,7 @@ static TEE_Result load_head(struct elf_load_state *state, size_t head_size)
 	if (ADD_OVERFLOW(phdr.p_vaddr, phdr.p_memsz, &state->vasize))
 		return TEE_ERROR_SECURITY;
 
-	/*
-	 * Read .ta_head from first segment, make sure the segment is large
-	 * enough. We're only interested in seeing that the
-	 * TA_FLAG_EXEC_DDR flag is set. If that's true we set that flag in
-	 * the TA context to enable mapping the TA. Later when this
-	 * function has returned and the hash has been verified the flags
-	 * field will be updated with eventual other flags.
-	 */
+	/* Read .ta_head from first segment if the segment is large enough */
 	if (ptload0.p_filesz < head_size)
 		return TEE_ERROR_BAD_FORMAT;
 	res = alloc_and_copy_to(&p, state, ptload0.p_offset, head_size);

--- a/core/arch/arm/kernel/pseudo_ta.c
+++ b/core/arch/arm/kernel/pseudo_ta.c
@@ -249,6 +249,10 @@ static const struct tee_ta_ops pseudo_ta_ops = {
 	.destroy = pseudo_ta_destroy,
 };
 
+bool is_pseudo_ta_ctx(struct tee_ta_ctx *ctx)
+{
+	return ctx->ops == &pseudo_ta_ops;
+}
 
 /* Insures declared pseudo TAs conforms with core expectations */
 static TEE_Result verify_pseudo_tas_conformance(void)

--- a/core/arch/arm/kernel/pseudo_ta.c
+++ b/core/arch/arm/kernel/pseudo_ta.c
@@ -70,7 +70,7 @@ static bool validate_in_param(struct tee_ta_session *s __unused,
 }
 #endif
 
-/* Maps static TA params */
+/* Maps pseudo TA params */
 static TEE_Result copy_in_param(struct tee_ta_session *s __maybe_unused,
 				struct tee_ta_param *param,
 				TEE_Param tee_param[TEE_NUM_PARAMS],

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -165,7 +165,7 @@ static TEE_Result open_session(uint32_t param_types __unused,
 	s = tee_ta_get_calling_session();
 	if (!s)
 		return TEE_ERROR_ACCESS_DENIED;
-	if (is_pseudo_ta_ctx(s->ctx))
+	if (!is_user_ta_ctx(s->ctx))
 		return TEE_ERROR_ACCESS_DENIED;
 
 	return TEE_SUCCESS;

--- a/core/arch/arm/pta/se_api_self_tests.c
+++ b/core/arch/arm/pta/se_api_self_tests.c
@@ -460,7 +460,7 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 		uint32_t nCommandID, uint32_t nParamTypes,
 		TEE_Param pParams[TEE_NUM_PARAMS])
 {
-	DMSG("command entry point for static ta \"%s\"", TA_NAME);
+	DMSG("command entry point for pseudo TA \"%s\"", TA_NAME);
 
 	switch (nCommandID) {
 	case CMD_SELF_TESTS:

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -525,7 +525,7 @@ static TEE_Result tee_ta_init_session(TEE_ErrorOrigin *err,
 			goto out;
 	}
 
-	/* Look for static TA */
+	/* Look for pseudo TA */
 	res = tee_ta_init_pseudo_ta_session(uuid, s);
 	if (res == TEE_SUCCESS || res != TEE_ERROR_ITEM_NOT_FOUND)
 		goto out;

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -602,10 +602,7 @@ static TEE_Result tee_svc_copy_param(struct tee_ta_session *sess,
 	}
 
 	if (called_sess && is_pseudo_ta_ctx(called_sess->ctx)) {
-		/*
-		 * static TA, borrow the mapping of the calling
-		 * during this call.
-		 */
+		/* pseudo TA borrows the mapping of the calling TA */
 		return TEE_SUCCESS;
 	}
 
@@ -805,9 +802,9 @@ TEE_Result syscall_open_ta_session(const TEE_UUID *dest,
 		goto function_exit;
 
 	/*
-	 * Find session of a multi session TA or a static TA
+	 * Find session of a multi session TA or a pseudo TA.
 	 * In such a case, there is no need to ask the supplicant for the TA
-	 * code
+	 * code.
 	 */
 	res = tee_ta_open_session(&ret_o, &s, &utc->open_sessions, uuid,
 				  clnt_id, cancel_req_to, param);

--- a/lib/libutee/arch/arm/gprof/gmon.h
+++ b/lib/libutee/arch/arm/gprof/gmon.h
@@ -65,6 +65,7 @@
 #define GMON_H
 
 #include <stdint.h>
+#include <util.h>
 
 /* Exported by the TA linker script */
 extern uint8_t __text_start[];
@@ -162,12 +163,6 @@ struct rawarc {
 	unsigned long	raw_selfpc;
 	long		raw_count;
 };
-
-/*
- * General rounding functions.
- */
-#define ROUNDDOWN(x, y)	(((x)/(y))*(y))
-#define ROUNDUP(x, y)	((((x)+(y)-1)/(y))*(y))
 
 /*
  * The profiling data structures are housed in this structure.

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
- * All rights reserved.
+ * Copyright (c) 2018, Linaro Limited.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -30,10 +30,8 @@
 #define USER_TA_HEADER_H
 
 #include <tee_api_types.h>
+#include <util.h>
 
-
-#define TA_FLAG_USER_MODE		(1 << 0)
-#define TA_FLAG_EXEC_DDR		(1 << 1)
 #define TA_FLAG_SINGLE_INSTANCE		(1 << 2)
 #define TA_FLAG_MULTI_SESSION		(1 << 3)
 #define TA_FLAG_INSTANCE_KEEP_ALIVE	(1 << 4) /* remains after last close */
@@ -45,6 +43,12 @@
 	 * (pseudo-TAs only).
 	 */
 #define TA_FLAG_CONCURRENT		(1 << 8)
+
+#define TA_FLAGS_MASK			GENMASK_32(8, 2)
+
+/* Deprecated macros that will be removed in the 3.2 release */
+#define TA_FLAG_USER_MODE		0
+#define TA_FLAG_EXEC_DDR		0
 
 union ta_head_func_ptr {
 	uint64_t ptr64;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -242,7 +242,7 @@ CFG_DT ?= n
 # editing of the supplied DTB.
 CFG_DTB_MAX_SIZE ?= 0x10000
 
-# Enable static TA and core self tests
+# Enable core self tests and related pseudo TAs
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 
 # This option enables OP-TEE to respond to SMP boot request: the Rich OS

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -72,7 +72,7 @@ const struct ta_head ta_head __section(".ta_head") = {
 	 * must be enlarged
 	 */
 	.stack_size = TA_STACK_SIZE + TA_FRAMEWORK_STACK_SIZE,
-	.flags = TA_FLAG_USER_MODE | TA_FLAGS,
+	.flags = TA_FLAGS,
 #ifdef __ILP32__
 	/*
 	 * This workaround is neded on 32-bit because it seems we can't


### PR DESCRIPTION
Current optee mandates these but does not support their misconfiguration.
This change insures the required flags are in place.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>