### PR TITLE
plat-d02: enable 64-bit paging

### DIFF
--- a/core/arch/arm/plat-d02/conf.mk
+++ b/core/arch/arm/plat-d02/conf.mk
@@ -4,7 +4,6 @@ CFG_NUM_THREADS ?= 16
 CFG_CRYPTO_WITH_CE ?= y
 CFG_WITH_STACK_CANARIES ?= y
 CFG_WITH_SOFTWARE_PRNG ?= n
-CFG_CORE_TZSRAM_EMUL_SIZE ?= 524288
 # Overrides default in mk/config.mk with 96 kB
 CFG_CORE_HEAP_SIZE ?= 98304
 
@@ -25,7 +24,9 @@ ta-targets = ta_arm32
 
 ifeq ($(CFG_ARM64_core),y)
 ta-targets += ta_arm64
+CFG_CORE_TZSRAM_EMUL_SIZE ?= 655360
 else
 $(call force,CFG_ARM32_core,y)
+CFG_CORE_TZSRAM_EMUL_SIZE ?= 524288
 endif
 

--- a/core/arch/arm/plat-d02/platform_config.h
+++ b/core/arch/arm/plat-d02/platform_config.h
@@ -31,12 +31,6 @@
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		64
 
-#ifdef ARM64
-#ifdef CFG_WITH_PAGER
-#error "Pager not supported for ARM64"
-#endif
-#endif /* ARM64 */
-
 /* UART */
 #define PERI_SUB_CTRL_ADDR	0x80000000
 #define CONSOLE_UART_BASE       (PERI_SUB_CTRL_ADDR + 0x00300000)


### PR DESCRIPTION
~Please ignore the first commit, it is a fix to the 32-bit pager configuration for D02 that's already up for review in https://github.com/OP-TEE/optee_os/pull/1596.~ *Edit: PR 1596 has been merged.*
