### PR TITLE
Review TLB invalidation sequence

### DIFF
--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -432,6 +432,13 @@ static inline uint64_t read_par64(void)
 }
 #endif
 
+static inline void write_tlbimvaais(uint32_t mva)
+{
+	asm volatile ("mcr	p15, 0, %[mva], c8, c3, 3"
+			: : [mva] "r" (mva)
+	);
+}
+
 static inline void write_mair0(uint32_t mair0)
 {
 	asm volatile ("mcr	p15, 0, %[mair0], c10, c2, 0"

--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -368,6 +368,16 @@ static inline void dsb(void)
 	asm volatile ("dsb");
 }
 
+static inline void dsb_ish(void)
+{
+	asm volatile ("dsb ish");
+}
+
+static inline void dsb_ishst(void)
+{
+	asm volatile ("dsb ishst");
+}
+
 static inline void dmb(void)
 {
 	asm volatile ("dmb");

--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -188,6 +188,11 @@
 	mcr	p15, 0, \reg, c8, c3, 2
 	.endm
 
+	.macro write_tlbimvaais reg
+	/* Invalidate unified TLB by MVA all ASID Inner Sharable */
+	mcr	p15, 0, \reg, c8, c3, 3
+	.endm
+
 	.macro write_prrr reg
 	mcr	p15, 0, \reg, c10, c2, 0
 	.endm

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -207,6 +207,10 @@
 #define PAR_PA_SHIFT		12
 #define PAR_PA_MASK		(BIT64(36) - 1)
 
+#define TLBI_MVA_SHIFT		12
+#define TLBI_ASID_SHIFT		48
+#define TLBI_ASID_MASK		0xff
+
 #ifndef ASM
 static inline void isb(void)
 {
@@ -255,6 +259,11 @@ static inline uint64_t read_pmu_ccnt(void)
 
 	asm volatile("mrs %0, PMCCNTR_EL0" : "=r"(val));
 	return val;
+}
+
+static inline void tlbi_vaae1is(uint64_t mva)
+{
+	asm volatile ("tlbi	vaae1is, %0" : : "r" (mva));
 }
 
 /*

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -218,6 +218,16 @@ static inline void dsb(void)
 	asm volatile ("dsb sy");
 }
 
+static inline void dsb_ish(void)
+{
+	asm volatile ("dsb ish");
+}
+
+static inline void dsb_ishst(void)
+{
+	asm volatile ("dsb ishst");
+}
+
 static inline void write_at_s1e1r(uint64_t va)
 {
 	asm volatile ("at	S1E1R, %0" : : "r" (va));

--- a/core/arch/arm/include/kernel/tz_ssvce.h
+++ b/core/arch/arm/include/kernel/tz_ssvce.h
@@ -37,7 +37,6 @@ unsigned int secure_get_cpu_id(void);
 void secure_mmu_datatlbinvall(void);
 void secure_mmu_unifiedtlbinvall(void);
 void secure_mmu_unifiedtlbinvbymva(unsigned long addr);
-void secure_mmu_unifiedtlbinv_curasid(void);
 void secure_mmu_unifiedtlbinv_byasid(unsigned long asid);
 
 void secure_mmu_disable(void);

--- a/core/arch/arm/include/kernel/tz_ssvce.h
+++ b/core/arch/arm/include/kernel/tz_ssvce.h
@@ -35,9 +35,10 @@
 unsigned int secure_get_cpu_id(void);
 
 void secure_mmu_datatlbinvall(void);
-void secure_mmu_unifiedtlbinvall(void);
-void secure_mmu_unifiedtlbinvbymva(unsigned long addr);
-void secure_mmu_unifiedtlbinv_byasid(unsigned long asid);
+
+void tlbi_all(void);
+void tlbi_asid(unsigned long asid);
+void tlbi_mva_curasid(unsigned long addr);
 
 void secure_mmu_disable(void);
 #endif /*!ASM*/

--- a/core/arch/arm/include/kernel/tz_ssvce.h
+++ b/core/arch/arm/include/kernel/tz_ssvce.h
@@ -28,6 +28,8 @@
 #ifndef TZ_SSVCE_H
 #define TZ_SSVCE_H
 
+#include <arm.h>
+
 #ifndef ASM
 
 #include <types_ext.h>
@@ -38,7 +40,15 @@ void secure_mmu_datatlbinvall(void);
 
 void tlbi_all(void);
 void tlbi_asid(unsigned long asid);
-void tlbi_mva_curasid(unsigned long addr);
+void tlbi_mva_allasid(unsigned long addr);
+static inline void tlbi_mva_allasid_nosync(vaddr_t va)
+{
+#ifdef ARM64
+	tlbi_vaae1is(va >> TLBI_MVA_SHIFT);
+#else
+	write_tlbimvaais(va);
+#endif
+}
 
 void secure_mmu_disable(void);
 #endif /*!ASM*/

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -446,6 +446,9 @@ enum teecore_tlb_op {
 	TLBINV_BY_MVA,		/* invalidate unified tlb by MVA */
 };
 
+/* TLB invalidation for a range of virtual address */
+void tlbi_mva_range(vaddr_t va, size_t size, size_t granule);
+
 /* deprecated: please call straight tlbi_all() and friends */
 int core_tlb_maintenance(int op, unsigned long a) __deprecated;
 

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -446,9 +446,10 @@ enum teecore_tlb_op {
 	TLBINV_BY_MVA,		/* invalidate unified tlb by MVA */
 };
 
-int core_tlb_maintenance(int op, unsigned int a);
+/* deprecated: please call straight tlbi_all() and friends */
+int core_tlb_maintenance(int op, unsigned long a) __deprecated;
 
-/* Cache maintenance operation type */
+/* Cache maintenance operation type (deprecated with core_tlb_maintenance()) */
 enum cache_op {
 	DCACHE_CLEAN,
 	DCACHE_AREA_CLEAN,

--- a/core/arch/arm/kernel/ssvce_a32.S
+++ b/core/arch/arm/kernel/ssvce_a32.S
@@ -49,43 +49,31 @@
  */
 
 
-/*
- * void secure_mmu_unifiedtlbinvall(void);
- */
+/* void secure_mmu_unifiedtlbinvall(void); */
 FUNC secure_mmu_unifiedtlbinvall , :
 UNWIND(	.fnstart)
-
-	dsb	/* Ensure visibility of the update to translation table walks */
-	write_tlbiallis
-
-	DSB
-	ISB
-
-	MOV     PC, LR
+	dsb	ishst		/* Sync with table update */
+	write_tlbiallis 	/* Invalidate TLBs */
+	dsb	ish		/* Sync with tlb invalidation completion */
+	isb			/* Sync execution on tlb update */
+	bx	lr
 UNWIND(	.fnend)
 END_FUNC secure_mmu_unifiedtlbinvall
 
-/*
- * void secure_mmu_unifiedtlbinvbymva(mva);
- *
- * Combine VA and current ASID, and invalidate matching TLB
- */
+/* void secure_mmu_unifiedtlbinvbymva(mva); FIXME: DISABLED */
 FUNC secure_mmu_unifiedtlbinvbymva , :
 UNWIND(	.fnstart)
 
 	b .	@ Wrong code to force fix/check the routine before using it
-	dsb	/* Ensure visibility of the update to translation table walks */
 
+	dsb	ishst		/* Sync with table update */
 	MRC     p15, 0, R1, c13, c0, 1		/* Read CP15 Context ID Register (CONTEXTIDR) */
 	ANDS    R1, R1, #0xFF			/* Get current ASID */
 	ORR     R1, R1, R0			/* Combine MVA and ASID */
-
 	MCR     p15, 0, R1, c8, c7, 1		/* Invalidate Unified TLB entry by MVA */
-
-	DSB
-	ISB
-
-	MOV     PC, LR
+	dsb	ish		/* Sync with tlb invalidation completion */
+	isb			/* Sync execution on tlb update */
+	bx	lr
 UNWIND(	.fnend)
 END_FUNC secure_mmu_unifiedtlbinvbymva
 
@@ -97,12 +85,11 @@ END_FUNC secure_mmu_unifiedtlbinvbymva
 FUNC secure_mmu_unifiedtlbinv_byasid , :
 UNWIND(	.fnstart)
 	and     r0, r0, #0xff               /* Get ASID */
-	dsb	/* Ensure visibility of the update to translation table walks */
-	/* Invalidate unified TLB by ASID Inner Sharable */
-	write_tlbiasidis r0
-	dsb
-	isb
-	mov	pc, lr
+	dsb	ishst		/* Sync with table update */
+	write_tlbiasidis r0	/* Inval unified TLB by ASID Inner Sharable */
+	dsb	ish		/* Sync with tlb invalidation completion */
+	isb			/* Sync execution on tlb update */
+	bx	lr
 UNWIND(	.fnend)
 END_FUNC secure_mmu_unifiedtlbinv_byasid
 

--- a/core/arch/arm/kernel/ssvce_a32.S
+++ b/core/arch/arm/kernel/ssvce_a32.S
@@ -60,22 +60,16 @@ UNWIND(	.fnstart)
 UNWIND(	.fnend)
 END_FUNC tlbi_all
 
-/* void tlbi_mva_asid(unsigned long mva); FIXME: DISABLED */
-FUNC tlbi_mva_asid , :
+/* void tlbi_mva_allasid(vaddr_t mva); */
+FUNC tlbi_mva_allasid , :
 UNWIND(	.fnstart)
-
-	b .	@ Wrong code to force fix/check the routine before using it
-
 	dsb	ishst		/* Sync with table update */
-	MRC     p15, 0, R1, c13, c0, 1		/* Read CP15 Context ID Register (CONTEXTIDR) */
-	ANDS    R1, R1, #0xFF			/* Get current ASID */
-	ORR     R1, R1, R0			/* Combine MVA and ASID */
-	MCR     p15, 0, R1, c8, c7, 1		/* Invalidate Unified TLB entry by MVA */
+	write_tlbimvaais r0	/* Inval TLB by MVA all ASID Inner Sharable */
 	dsb	ish		/* Sync with tlb invalidation completion */
 	isb			/* Sync execution on tlb update */
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC tlbi_mva_asid
+END_FUNC tlbi_mva_allasid
 
 /* void tlbi_asid(unsigned long asid); */
 FUNC tlbi_asid , :

--- a/core/arch/arm/kernel/ssvce_a32.S
+++ b/core/arch/arm/kernel/ssvce_a32.S
@@ -49,8 +49,8 @@
  */
 
 
-/* void secure_mmu_unifiedtlbinvall(void); */
-FUNC secure_mmu_unifiedtlbinvall , :
+/* void tlbi_all(void); */
+FUNC tlbi_all , :
 UNWIND(	.fnstart)
 	dsb	ishst		/* Sync with table update */
 	write_tlbiallis 	/* Invalidate TLBs */
@@ -58,10 +58,10 @@ UNWIND(	.fnstart)
 	isb			/* Sync execution on tlb update */
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC secure_mmu_unifiedtlbinvall
+END_FUNC tlbi_all
 
-/* void secure_mmu_unifiedtlbinvbymva(mva); FIXME: DISABLED */
-FUNC secure_mmu_unifiedtlbinvbymva , :
+/* void tlbi_mva_asid(unsigned long mva); FIXME: DISABLED */
+FUNC tlbi_mva_asid , :
 UNWIND(	.fnstart)
 
 	b .	@ Wrong code to force fix/check the routine before using it
@@ -75,14 +75,10 @@ UNWIND(	.fnstart)
 	isb			/* Sync execution on tlb update */
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC secure_mmu_unifiedtlbinvbymva
+END_FUNC tlbi_mva_asid
 
-/*
- * void secure_mmu_unifiedtlbinv_byasid(unsigned int asid)
- *
- * Invalidate TLB matching current ASID
- */
-FUNC secure_mmu_unifiedtlbinv_byasid , :
+/* void tlbi_asid(unsigned long asid); */
+FUNC tlbi_asid , :
 UNWIND(	.fnstart)
 	and     r0, r0, #0xff               /* Get ASID */
 	dsb	ishst		/* Sync with table update */
@@ -91,6 +87,6 @@ UNWIND(	.fnstart)
 	isb			/* Sync execution on tlb update */
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC secure_mmu_unifiedtlbinv_byasid
+END_FUNC tlbi_asid
 
 

--- a/core/arch/arm/kernel/ssvce_a32.S
+++ b/core/arch/arm/kernel/ssvce_a32.S
@@ -90,24 +90,6 @@ UNWIND(	.fnend)
 END_FUNC secure_mmu_unifiedtlbinvbymva
 
 /*
- * void secure_mmu_unifiedtlbinv_curasid(void)
- *
- * Invalidate TLB matching current ASID
- */
-FUNC secure_mmu_unifiedtlbinv_curasid , :
-UNWIND(	.fnstart)
-	read_contextidr r0
-	and     r0, r0, #0xff               /* Get current ASID */
-	dsb	/* Ensure visibility of the update to translation table walks */
-	/* Invalidate unified TLB by ASID Inner Sharable */
-	write_tlbiasidis r0
-	dsb
-	isb
-	mov	pc, lr
-UNWIND(	.fnend)
-END_FUNC secure_mmu_unifiedtlbinv_curasid
-
-/*
  * void secure_mmu_unifiedtlbinv_byasid(unsigned int asid)
  *
  * Invalidate TLB matching current ASID

--- a/core/arch/arm/kernel/ssvce_a64.S
+++ b/core/arch/arm/kernel/ssvce_a64.S
@@ -24,9 +24,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <kernel/tz_ssvce.h>
+
 #include <arm64.h>
 #include <asm.S>
+#include <kernel/tz_ssvce.h>
 
 /* void tlbi_all(void); */
 FUNC tlbi_all , :
@@ -36,6 +37,16 @@ FUNC tlbi_all , :
 	isb			/* Sync execution on tlb update */
 	ret
 END_FUNC tlbi_all
+
+/* void tlbi_mva_allasid(vaddr_t mva); */
+FUNC tlbi_mva_allasid , :
+	lsr	x0, x0, #TLBI_MVA_SHIFT
+	dsb	ishst		/* Sync with table update */
+	tlbi	vaae1is, x0	/* Invalidate tlb by mva in inner shareable */
+	dsb	ish		/* Sync with tlb invalidation completion */
+	isb			/* Sync execution on tlb update */
+	ret
+END_FUNC tlbi_mva_allasid
 
 /* void tlbi_asid(unsigned int asid); */
 FUNC tlbi_asid , :

--- a/core/arch/arm/kernel/ssvce_a64.S
+++ b/core/arch/arm/kernel/ssvce_a64.S
@@ -30,26 +30,19 @@
 
 /* void secure_mmu_unifiedtlbinvall(void); */
 FUNC secure_mmu_unifiedtlbinvall , :
-	/* Ensure visibility of the update to translation table walks */
-	dsb	ishst
-
-	tlbi	vmalle1is
-
-	dsb	ish /* Ensure completion of TLB invalidation */
-	isb
+	dsb	ishst		/* Sync with table update */
+	tlbi	vmalle1is	/* All tlb in inner shareable */
+	dsb	ish		/* Sync with tlb invalidation completion */
+	isb			/* Sync execution on tlb update */
 	ret
 END_FUNC secure_mmu_unifiedtlbinvall
 
 /* void secure_mmu_unifiedtlbinv_byasid(unsigned int asid); */
 FUNC secure_mmu_unifiedtlbinv_byasid , :
 	and	x0, x0, #TTBR_ASID_MASK
-
-	/* Ensure visibility of the update to translation table walks */
-	dsb	ishst
-
-	tlbi	aside1is, x0
-
-	dsb	ish /* Ensure completion of TLB invalidation */
-	isb
+	dsb	ishst		/* Sync with table update */
+	tlbi	aside1is, x0	/* Tlb by asid in inner shareable */
+	dsb	ish		/* Sync with tlb invalidation completion */
+	isb			/* Sync execution on tlb update */
 	ret
 END_FUNC secure_mmu_unifiedtlbinv_byasid

--- a/core/arch/arm/kernel/ssvce_a64.S
+++ b/core/arch/arm/kernel/ssvce_a64.S
@@ -50,9 +50,10 @@ END_FUNC tlbi_mva_allasid
 
 /* void tlbi_asid(unsigned int asid); */
 FUNC tlbi_asid , :
-	and	x0, x0, #TTBR_ASID_MASK
+	and	x0, x0, #TLBI_ASID_MASK
+	lsl	x0, x0, #TLBI_ASID_SHIFT
 	dsb	ishst		/* Sync with table update */
-	tlbi	aside1is, x0	/* Tlb by asid in inner shareable */
+	tlbi	aside1is, x0	/* Invalidate tlb by asid in inner shareable */
 	dsb	ish		/* Sync with tlb invalidation completion */
 	isb			/* Sync execution on tlb update */
 	ret

--- a/core/arch/arm/kernel/ssvce_a64.S
+++ b/core/arch/arm/kernel/ssvce_a64.S
@@ -28,21 +28,21 @@
 #include <arm64.h>
 #include <asm.S>
 
-/* void secure_mmu_unifiedtlbinvall(void); */
-FUNC secure_mmu_unifiedtlbinvall , :
+/* void tlbi_all(void); */
+FUNC tlbi_all , :
 	dsb	ishst		/* Sync with table update */
 	tlbi	vmalle1is	/* All tlb in inner shareable */
 	dsb	ish		/* Sync with tlb invalidation completion */
 	isb			/* Sync execution on tlb update */
 	ret
-END_FUNC secure_mmu_unifiedtlbinvall
+END_FUNC tlbi_all
 
-/* void secure_mmu_unifiedtlbinv_byasid(unsigned int asid); */
-FUNC secure_mmu_unifiedtlbinv_byasid , :
+/* void tlbi_asid(unsigned int asid); */
+FUNC tlbi_asid , :
 	and	x0, x0, #TTBR_ASID_MASK
 	dsb	ishst		/* Sync with table update */
 	tlbi	aside1is, x0	/* Tlb by asid in inner shareable */
 	dsb	ish		/* Sync with tlb invalidation completion */
 	isb			/* Sync execution on tlb update */
 	ret
-END_FUNC secure_mmu_unifiedtlbinv_byasid
+END_FUNC tlbi_asid

--- a/core/arch/arm/kernel/ssvce_a64.S
+++ b/core/arch/arm/kernel/ssvce_a64.S
@@ -40,13 +40,6 @@ FUNC secure_mmu_unifiedtlbinvall , :
 	ret
 END_FUNC secure_mmu_unifiedtlbinvall
 
-/* void secure_mmu_unifiedtlbinv_curasid(void) */
-FUNC secure_mmu_unifiedtlbinv_curasid , :
-	mrs	x0, ttbr0_el1
-	lsr	x0, x0, #TTBR_ASID_SHIFT
-	b	secure_mmu_unifiedtlbinv_byasid
-END_FUNC secure_mmu_unifiedtlbinv_curasid
-
 /* void secure_mmu_unifiedtlbinv_byasid(unsigned int asid); */
 FUNC secure_mmu_unifiedtlbinv_byasid , :
 	and	x0, x0, #TTBR_ASID_MASK

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -884,7 +884,12 @@ int core_tlb_maintenance(int op, unsigned int a)
 		secure_mmu_unifiedtlbinvall();
 		break;
 	case TLBINV_CURRENT_ASID:
-		secure_mmu_unifiedtlbinv_curasid();
+#ifdef ARM32
+		secure_mmu_unifiedtlbinv_byasid(read_contextidr());
+#endif
+#ifdef ARM64
+		secure_mmu_unifiedtlbinv_byasid(read_contextidr_el1());
+#endif
 		break;
 	case TLBINV_BY_ASID:
 		secure_mmu_unifiedtlbinv_byasid(a);

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -898,7 +898,6 @@ int core_tlb_maintenance(int op, unsigned int a)
 		EMSG("TLB_INV_SECURE_MVA is not yet supported!");
 		while (1)
 			;
-		tlbi_mva_curasid(a);
 		break;
 	default:
 		return 1;

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -877,7 +877,7 @@ enum teecore_memtypes core_mmu_get_type_by_pa(paddr_t pa)
 	return map->type;
 }
 
-int core_tlb_maintenance(int op, unsigned int a)
+int __deprecated core_tlb_maintenance(int op, unsigned long a)
 {
 	switch (op) {
 	case TLBINV_UNIFIEDTLB:
@@ -895,10 +895,7 @@ int core_tlb_maintenance(int op, unsigned int a)
 		tlbi_asid(a);
 		break;
 	case TLBINV_BY_MVA:
-		EMSG("TLB_INV_SECURE_MVA is not yet supported!");
-		while (1)
-			;
-		break;
+		panic();
 	default:
 		return 1;
 	}
@@ -1152,7 +1149,7 @@ void core_mmu_unmap_pages(vaddr_t vstart, size_t num_pages)
 		idx = core_mmu_va2idx(&tbl_info, vstart);
 		core_mmu_set_entry(&tbl_info, idx, 0, 0);
 	}
-	core_tlb_maintenance(TLBINV_UNIFIEDTLB, 0);
+	tlbi_all();
 }
 
 void core_mmu_populate_user_map(struct core_mmu_table_info *dir_info,

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -902,6 +902,24 @@ int __deprecated core_tlb_maintenance(int op, unsigned long a)
 	return 0;
 }
 
+void tlbi_mva_range(vaddr_t va, size_t size, size_t granule)
+{
+	size_t sz = size;
+
+	assert(granule == CORE_MMU_PGDIR_SIZE || granule == SMALL_PAGE_SIZE);
+
+	dsb_ishst();
+	while (sz) {
+		tlbi_mva_allasid_nosync(va);
+		if (sz < granule)
+			break;
+		sz -= granule;
+		va += granule;
+	}
+	dsb_ish();
+	isb();
+}
+
 TEE_Result cache_op_inner(enum cache_op op, void *va, size_t len)
 {
 	switch (op) {

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -881,24 +881,24 @@ int core_tlb_maintenance(int op, unsigned int a)
 {
 	switch (op) {
 	case TLBINV_UNIFIEDTLB:
-		secure_mmu_unifiedtlbinvall();
+		tlbi_all();
 		break;
 	case TLBINV_CURRENT_ASID:
 #ifdef ARM32
-		secure_mmu_unifiedtlbinv_byasid(read_contextidr());
+		tlbi_asid(read_contextidr());
 #endif
 #ifdef ARM64
-		secure_mmu_unifiedtlbinv_byasid(read_contextidr_el1());
+		tlbi_asid(read_contextidr_el1());
 #endif
 		break;
 	case TLBINV_BY_ASID:
-		secure_mmu_unifiedtlbinv_byasid(a);
+		tlbi_asid(a);
 		break;
 	case TLBINV_BY_MVA:
 		EMSG("TLB_INV_SECURE_MVA is not yet supported!");
 		while (1)
 			;
-		secure_mmu_unifiedtlbinvbymva(a);
+		tlbi_mva_curasid(a);
 		break;
 	default:
 		return 1;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -64,6 +64,7 @@
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 #include <kernel/thread.h>
+#include <kernel/tz_ssvce.h>
 #include <mm/core_memprot.h>
 #include <mm/core_memprot.h>
 #include <mm/pgt_cache.h>
@@ -705,7 +706,7 @@ bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
 	*entry = new_table_desc;
 
 	if (flush_tlb)
-		core_tlb_maintenance(TLBINV_UNIFIEDTLB, 0);
+		tlbi_all();
 	return true;
 }
 
@@ -790,7 +791,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 		dsb();	/* Make sure the write above is visible */
 	}
 
-	core_tlb_maintenance(TLBINV_UNIFIEDTLB, 0);
+	tlbi_all();
 
 	thread_unmask_exceptions(exceptions);
 }
@@ -864,7 +865,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 		dsb();	/* Make sure the write above is visible */
 	}
 
-	core_tlb_maintenance(TLBINV_UNIFIEDTLB, 0);
+	tlbi_all();
 
 	write_daif(daif);
 }

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -553,6 +553,7 @@ bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
 	/* Update descriptor at current level */
 	*entry = new_table_desc;
 
+	/* TODO: only invalidate entries touched above */
 	if (flush_tlb)
 		tlbi_all();
 	return true;

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -31,6 +31,7 @@
 #include <keep.h>
 #include <kernel/panic.h>
 #include <kernel/thread.h>
+#include <kernel/tz_ssvce.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <mm/pgt_cache.h>
@@ -553,7 +554,7 @@ bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
 	*entry = new_table_desc;
 
 	if (flush_tlb)
-		core_tlb_maintenance(TLBINV_UNIFIEDTLB, 0);
+		tlbi_all();
 	return true;
 }
 
@@ -639,11 +640,13 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 		write_ttbr0(map->ttbr0);
 		isb();
 		write_contextidr(map->ctxid);
+		isb();
 	} else {
 		write_ttbr0(read_ttbr1());
+		isb();
 	}
-	isb();
-	core_tlb_maintenance(TLBINV_UNIFIEDTLB, 0);
+
+	tlbi_all();
 
 	/* Restore interrupts */
 	thread_unmask_exceptions(exceptions);

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -618,7 +618,7 @@ void tee_mmu_final(struct user_ta_ctx *utc)
 	g_asid |= asid;
 
 	/* clear MMU entries to avoid clash when asid is reused */
-	secure_mmu_unifiedtlbinv_byasid(utc->context & 0xff);
+	tlbi_asid(utc->context & 0xff);
 	utc->context = 0;
 
 	free(utc->mmu);


### PR DESCRIPTION
These changes reviews the TLB invalidation support and somewhat optimizes the TLB maintenance in the pager to prevent executing to many synchronization barriers when possible.

~~This change also removes the statck unwind from cache maintenance primitives, including data/instr. cache and TLBs.~~ **edited:** good question, why removing the stack unwind? no answer. discard.