### PR TITLE
plat-sunxi: providing bss section initialization before usage.

### DIFF
--- a/core/arch/arm/plat-sunxi/entry.S
+++ b/core/arch/arm/plat-sunxi/entry.S
@@ -83,18 +83,18 @@ UNWIND(	.cantunwind)
 	orr     r0, r0, #ACTLR_SMP
 	write_actlr  r0
 
+	/* init BSS section */
+	ldr	r0, =__bss_start
+	ldr	r2, =__bss_end
+	sub	r2, r2, r0
+	ldr	r1, =0
+	bl	memset
+
 	bl	core_init_mmu_map
 	bl	core_init_mmu_regs
 	bl	cpu_mmu_enable
 	bl	cpu_mmu_enable_icache
 	bl	cpu_mmu_enable_dcache
-
-	/* init BSS section */
-	ldr     r0, =__bss_start
-	ldr     r2, =__bss_end
-	sub     r2, r2, r0
-	ldr     r1, =0
-	bl      memset
 	
 	/* r4: the return address of normal world */
 	mov	r0, r4


### PR DESCRIPTION
Before. BSS initialization executed AFTER the initialization of the
MMU table (global variable array "static_memory_map[]").
Now. BSS initialization executes BEFORE static_memory_map[]
initialized by core_init_mmu_map.

Signed-off-by: Victor Signaevskyi <piligrim2007@meta.ua>