### PR TITLE
core: fix 'keep_init' handling in link.mk

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -70,7 +70,7 @@ cleanfiles += $(link-out-dir)/init_entries.txt
 $(link-out-dir)/init_entries.txt: $(link-out-dir)/all_objs.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(NMcore) $< | \
-		$(AWK) '/ ____keep_init/ { printf "-u%s", $$3 }' > $@
+		$(AWK) '/ ____keep_init/ { printf "-u%s ", $$3 }' > $@
 
 funcs-init-rem = $(funcs-unpaged-rem)
 funcs-init-rem += .text.init_teecore


### PR DESCRIPTION
Fix generation of init_entries.txt: spaces were missing and made the
tool fail to generate the 'init' dependency resource list.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>