### PR TITLE
Assign non-sec DDR configuration from DT

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -484,6 +484,11 @@ bool cpu_mmu_enabled(void);
  */
 bool core_mmu_nsec_ddr_is_defined(void);
 
+#ifdef CFG_DT
+void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
+				      size_t nelems);
+#endif
+
 #ifdef CFG_SECURE_DATA_PATH
 /* Alloc and fill SDP memory objects table - table is NULL terminated */
 struct mobj **core_sdp_mem_create_mobjs(void);

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -77,6 +77,7 @@ static struct gic_data gic_data;
 static struct pl011_data console_data;
 
 register_phys_mem(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
+register_nsec_ddr(DRAM0_BASE, DRAM0_SIZE);
 
 const struct thread_handlers *generic_boot_get_handlers(void)
 {


### PR DESCRIPTION
This should take care of the problem with unexpected non-sec addresses from normal world in for instance https://github.com/OP-TEE/optee_os/pull/1232 by updating the non-sec DDR config from DT instead of using hard coded value on QEMU.

@lorc please confirm