### PR TITLE
core: fix incorrect IRQ mask for CFG_ARM_GICV3

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -496,7 +496,11 @@ LOCAL_FUNC el0_svc , :
 	 * nothing left in sp_el1. Note that the SVC handler is excepted to
 	 * re-enable foreign interrupts by itself.
 	 */
+#if defined(CFG_ARM_GICV3)
+	msr	daifclr, #(DAIFBIT_IRQ | DAIFBIT_ABT | DAIFBIT_DBG)
+#else
 	msr	daifclr, #(DAIFBIT_FIQ | DAIFBIT_ABT | DAIFBIT_DBG)
+#endif
 
 	/* Call the handler */
 	bl	tee_svc_handler


### PR DESCRIPTION
For GICV3 situation, IRQ is used as native interrupt. This patch
also suppressed assert in thread_user_save_vfp().

Signed-off-by: Zhizhou Zhang <zhizhouzhang@asrmicro.com>