### PR TITLE
Enable dynamic SHM support

### DIFF
--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -290,6 +290,13 @@
 #define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	(1 << 0)
 /* Secure world can communicate via previously unregistered shared memory */
 #define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	(1 << 1)
+
+/*
+ * Secure world supports commands "register/unregister shared memory",
+ * secure world accepts command buffers located in any parts of non-secure RAM
+ */
+#define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM		(1 << 2)
+
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES)

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1249,7 +1249,12 @@ struct mobj *thread_rpc_alloc_arg(size_t size, uint64_t *cookie)
 	if (!ALIGNMENT_IS_OK(pa, struct optee_msg_arg))
 		goto err;
 
-	mobj = mobj_shm_alloc(pa, size);
+	/* Check if this region is in static shared space */
+	if (core_pbuf_is(CORE_MEM_NSEC_SHM, pa, size))
+		mobj = mobj_shm_alloc(pa, size);
+	else if ((!(pa & SMALL_PAGE_MASK)) && size <= SMALL_PAGE_SIZE)
+		mobj = mobj_mapped_shm_alloc(&pa, 1, 0, co);
+
 	if (!mobj)
 		goto err;
 
@@ -1406,9 +1411,16 @@ static struct mobj *thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
 	if (arg->num_params != 1)
 		goto fail;
 
-	mobj = mobj_shm_alloc(arg->params[0].u.tmem.buf_ptr,
-			      arg->params[0].u.tmem.size);
-	*cookie = arg->params[0].u.tmem.shm_ref;
+	if (arg->params[0].attr == OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT) {
+		*cookie = arg->params[0].u.tmem.shm_ref;
+		mobj = mobj_shm_alloc(arg->params[0].u.tmem.buf_ptr,
+				      arg->params[0].u.tmem.size);
+	} else if (arg->params[0].attr == (OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT |
+					   OPTEE_MSG_ATTR_NONCONTIG)) {
+		*cookie = arg->params[0].u.tmem.shm_ref;
+		mobj = msg_param_mobj_from_noncontig(arg->params, true);
+	} else
+		goto fail;
 
 	if (!mobj)
 		goto free_first;

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1418,7 +1418,11 @@ static struct mobj *thread_rpc_alloc(size_t size, size_t align, unsigned int bt,
 	} else if (arg->params[0].attr == (OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT |
 					   OPTEE_MSG_ATTR_NONCONTIG)) {
 		*cookie = arg->params[0].u.tmem.shm_ref;
-		mobj = msg_param_mobj_from_noncontig(arg->params, true);
+		mobj = msg_param_mobj_from_noncontig(
+			arg->params[0].u.tmem.buf_ptr,
+			arg->params[0].u.tmem.size,
+			*cookie,
+			true);
 	} else
 		goto fail;
 

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1273,9 +1273,14 @@ static void set_pg_region(struct core_mmu_table_info *dir_info,
 
 		r.size = MIN(CORE_MMU_PGDIR_SIZE - (r.va - pg_info->va_base),
 			     end - r.va);
+
 		if (!mobj_is_paged(region->mobj)) {
 			size_t granule = BIT(pg_info->shift);
 			size_t offset = r.va - region->va + region->offset;
+
+			r.size = MIN(r.size,
+				     mobj_get_phys_granule(region->mobj));
+			r.size = ROUNDUP(r.size, SMALL_PAGE_SIZE);
 
 			if (mobj_get_pa(region->mobj, offset, granule,
 					&r.pa) != TEE_SUCCESS)

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -106,9 +106,11 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 	args->a0 = OPTEE_SMC_RETURN_OK;
 	args->a1 = OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM;
 
+#if defined(CFG_DYN_SHM_CAP)
 	dyn_shm_en = core_mmu_nsec_ddr_is_defined();
 	if (dyn_shm_en)
 		args->a1 |= OPTEE_SMC_SEC_CAP_DYNAMIC_SHM;
+#endif
 
 	IMSG("Dynamic shared memory is %sabled", dyn_shm_en ? "en" : "dis");
 }

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -82,6 +82,8 @@ static void tee_entry_fastcall_l2cc_mutex(struct thread_smc_args *args)
 
 static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 {
+	bool dyn_shm_en = false;
+
 	/*
 	 * Currently we ignore OPTEE_SMC_NSEC_CAP_UNIPROCESSOR.
 	 *
@@ -103,6 +105,12 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 
 	args->a0 = OPTEE_SMC_RETURN_OK;
 	args->a1 = OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM;
+
+	dyn_shm_en = core_mmu_nsec_ddr_is_defined();
+	if (dyn_shm_en)
+		args->a1 |= OPTEE_SMC_SEC_CAP_DYNAMIC_SHM;
+
+	IMSG("Dynamic shared memory is %sabled", dyn_shm_en ? "en" : "dis");
 }
 
 static void tee_entry_disable_shm_cache(struct thread_smc_args *args)

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -81,7 +81,7 @@ static TEE_Result assign_mobj_to_param_mem(const paddr_t pa, const size_t sz,
 {
 	struct mobj __maybe_unused **mobj;
 
-	/* NULL Memory Rerefence ? */
+	/* NULL Memory Rerefence? */
 	if (!pa && !sz) {
 		mem->mobj = NULL;
 		mem->offs = 0;
@@ -100,12 +100,12 @@ static TEE_Result assign_mobj_to_param_mem(const paddr_t pa, const size_t sz,
 		return TEE_SUCCESS;
 	}
 
-	/* belongs to nonsecure shared memory ? */
+	/* Belongs to nonsecure shared memory? */
 	if (param_mem_from_mobj(mem, shm_mobj, pa, sz))
 		return TEE_SUCCESS;
 
 #ifdef CFG_SECURE_DATA_PATH
-	/* belongs to SDP memories ? */
+	/* Belongs to SDP memories? */
 	for (mobj = sdp_mem_mobjs; *mobj; mobj++)
 		if (param_mem_from_mobj(mem, *mobj, pa, sz))
 			return TEE_SUCCESS;

--- a/core/include/kernel/msg_param.h
+++ b/core/include/kernel/msg_param.h
@@ -48,14 +48,16 @@ enum msg_param_mem_dir {
  * msg_param_mobj_from_noncontig() - construct mobj from non-contiguous
  * list of pages.
  *
- * @param - pointer to msg_param with OPTEE_MSG_ATTR_NONCONTIG flag set
+ * @buf_ptr - optee_msg_param.u.tmem.buf_ptr value
+ * @size - optee_msg_param.u.tmem.size value
+ * @shm_ref - optee_msg_param.u.tmem.shm_ref value
  * @map_buffer - true if buffer needs to be mapped into OP-TEE address space
  *
  * return:
  *	mobj or NULL on error
  */
-struct mobj *msg_param_mobj_from_noncontig(const struct optee_msg_param *param,
-					   bool map_buffer);
+struct mobj *msg_param_mobj_from_noncontig(paddr_t buf_ptr, size_t size,
+					   uint64_t shm_ref, bool map_buffer);
 
 /**
  * msg_param_init_memparam() - fill memory reference parameter for RPC call
@@ -105,16 +107,16 @@ static inline size_t msg_param_get_buf_size(const struct optee_msg_param *param)
 }
 
 /**
- * msg_param_attr_is_tmem - helper functions that cheks if parameter is tmem
+ * msg_param_attr_is_tmem - helper functions that cheks if attribute is tmem
  *
- * @param - struct optee_msg_param to check
+ * @attr - attribute to check
  *
  * return:
  *	corresponding size field
  */
-static inline bool msg_param_attr_is_tmem(const struct optee_msg_param *param)
+static inline bool msg_param_attr_is_tmem(uint64_t attr)
 {
-	switch (param->attr & OPTEE_MSG_ATTR_TYPE_MASK) {
+	switch (attr & OPTEE_MSG_ATTR_TYPE_MASK) {
 	case OPTEE_MSG_ATTR_TYPE_TMEM_INPUT:
 	case OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT:
 	case OPTEE_MSG_ATTR_TYPE_TMEM_INOUT:

--- a/core/kernel/msg_param.c
+++ b/core/kernel/msg_param.c
@@ -110,23 +110,16 @@ out:
 	return ret;
 }
 
-struct mobj *msg_param_mobj_from_noncontig(const struct optee_msg_param *param,
-					   bool map_buffer)
+struct mobj *msg_param_mobj_from_noncontig(paddr_t buf_ptr, size_t size,
+					   uint64_t shm_ref, bool map_buffer)
 {
 	struct mobj *mobj = NULL;
 	paddr_t *pages;
 	paddr_t page_offset;
 	size_t num_pages;
-	uint64_t buf_ptr;
-
-	assert(param->attr & OPTEE_MSG_ATTR_NONCONTIG);
-
-	/* Make sure that NW will not change value in SHM */
-	buf_ptr = param->u.tmem.buf_ptr;
 
 	page_offset = buf_ptr & SMALL_PAGE_MASK;
-	num_pages = (param->u.tmem.size + page_offset - 1) /
-		    SMALL_PAGE_SIZE + 1;
+	num_pages = (size + page_offset - 1) / SMALL_PAGE_SIZE + 1;
 
 	pages = malloc(num_pages * sizeof(paddr_t));
 	if (!pages)
@@ -138,10 +131,10 @@ struct mobj *msg_param_mobj_from_noncontig(const struct optee_msg_param *param,
 
 	if (map_buffer)
 		mobj = mobj_mapped_shm_alloc(pages, num_pages, page_offset,
-					     param->u.tmem.shm_ref);
+					     shm_ref);
 	else
 		mobj = mobj_reg_shm_alloc(pages, num_pages, page_offset,
-					  param->u.tmem.shm_ref);
+					  shm_ref);
 out:
 	free(pages);
 	return mobj;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -263,3 +263,10 @@ CFG_SECURE_DATA_PATH ?= n
 # so its value represents log2(cores/cluster).
 # Default is 2**(2) = 4 cores per cluster.
 CFG_CORE_CLUSTER_SHIFT ?= 2
+
+# Do not report to NW that dynamic shared memory (shared memory outside
+# predefined region) is enabled.
+# Note that you can disable this feature for debug purposes. OP-TEE will not
+# report to Normal World that it support dynamic SHM. But, nevertheles it
+# will accept dynamic SHM buffers.
+CFG_DYN_SHM_CAP ?= y


### PR DESCRIPTION
Hello.

There are last patches for dynamic SHM. 

I'm not sure, if I did right thing, when created two patches with ABI changes, because 4e5d00d ("ABI change: add shared memory support") enables new capability and 30260ae ("ABI change: enable TMEM parameters with non-contiguous shm") extends it.

Probably I should squash those two patches into one, or create one additional patch for `entry_fast.c`, that enables `OPTEE_SMC_SEC_CAP_DYNAMIC_SHM`. What do you think?