### PR TITLE
core: demote a couple of messages from IMSG() to DMSG()

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -459,7 +459,7 @@ static void verify_special_mem_areas(struct tee_mmap_region *mem_map,
 	size_t n;
 
 	if (start == end) {
-		IMSG("No %s memory area defined", area_name);
+		DMSG("No %s memory area defined", area_name);
 		return;
 	}
 

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -588,7 +588,7 @@ static TEE_Result mobj_mapped_shm_init(void)
 		    TEE_MM_POOL_NO_FLAGS))
 		panic("Could not create shmem pool");
 
-	IMSG("Shared memory address range: %" PRIxVA ", %" PRIxVA,
+	DMSG("Shared memory address range: %" PRIxVA ", %" PRIxVA,
 	     pool_start, pool_end);
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
The first and and fourth lines in the boot sequence below are debug
messages that should not be printed when the log level is INFO:

 INFO:    TEE-CORE: No NSEC DDR memory area defined
 INFO:    TEE-CORE:
 INFO:    TEE-CORE: OP-TEE version: 2.5.0-rc1 #1 Wed Jun 28 15:11:06 UTC 2017 aarch64
 INFO:    TEE-CORE: Shared memory address range: 3dc00000, 3f000000
 INFO:    TEE-CORE: Initialized

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>