### PR TITLE
core: introduce CFG_SCTLR_ENABLE_Z for ARMv7 cores

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -3,6 +3,8 @@ CFG_LTC_OPTEE_THREAD ?= y
 # Only applicable when paging is enabled.
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 458752
 CFG_LPAE_ADDR_SPACE_SIZE ?= (1ull << 32)
+# Early branch prediction may be unsafe against uncontrolled memory prefetches.
+CFG_SCTLR_ENABLE_Z ?= n
 
 ifeq ($(CFG_ARM64_core),y)
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -4,7 +4,7 @@ CFG_LTC_OPTEE_THREAD ?= y
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 458752
 CFG_LPAE_ADDR_SPACE_SIZE ?= (1ull << 32)
 # Early branch prediction may be unsafe against uncontrolled memory prefetches.
-CFG_SCTLR_ENABLE_Z ?= n
+CFG_ENABLE_SCTLR_Z ?= n
 
 ifeq ($(CFG_ARM64_core),y)
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64

--- a/core/arch/arm/cpu/cortex-armv8-0.mk
+++ b/core/arch/arm/cpu/cortex-armv8-0.mk
@@ -1,6 +1,6 @@
 $(call force,CFG_HWSUPP_MEM_PERM_WXN,y)
 $(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
-$(call force,CFG_SCTLR_ENABLE_Z,n)
+$(call force,CFG_ENABLE_SCTLR_Z,n)
 # cortex-a53 and cortex-a57 complies on arm32 architectures
 arm32-platform-cpuarch 	:= cortex-a53
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)

--- a/core/arch/arm/cpu/cortex-armv8-0.mk
+++ b/core/arch/arm/cpu/cortex-armv8-0.mk
@@ -1,5 +1,6 @@
 $(call force,CFG_HWSUPP_MEM_PERM_WXN,y)
 $(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_SCTLR_ENABLE_Z,n)
 # cortex-a53 and cortex-a57 complies on arm32 architectures
 arm32-platform-cpuarch 	:= cortex-a53
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -204,7 +204,7 @@ UNWIND(	.cantunwind)
 	/* Early ARM secure MP specific configuration */
 	bl	plat_cpu_reset_early
 
-#if defined(CFG_SCTLR_ENABLE_Z)
+#if defined(CFG_ENABLE_SCTLR_Z)
 	/* Some ARMv7 architectures need btac flush */
 	write_bpiall
 	dsb
@@ -485,7 +485,7 @@ UNWIND(	.cantunwind)
 #endif
 	write_sctlr r0
 
-#if defined(CFG_SCTLR_ENABLE_Z)
+#if defined(CFG_ENABLE_SCTLR_Z)
 	/* Some ARMv7 architectures need btac flush */
 	write_bpiall
 	dsb

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -204,6 +204,16 @@ UNWIND(	.cantunwind)
 	/* Early ARM secure MP specific configuration */
 	bl	plat_cpu_reset_early
 
+#if defined(CFG_SCTLR_ENABLE_Z)
+	/* Some ARMv7 architectures need btac flush */
+	write_bpiall
+	dsb
+	isb
+	read_sctlr r0
+	orr	r0, r0, #SCTLR_Z
+	write_sctlr r0
+#endif
+
 	ldr	r0, =_start
 	write_vbar r0
 
@@ -474,6 +484,16 @@ UNWIND(	.cantunwind)
 	orr	r0, r0, #(SCTLR_WXN | SCTLR_UWXN)
 #endif
 	write_sctlr r0
+
+#if defined(CFG_SCTLR_ENABLE_Z)
+	/* Some ARMv7 architectures need btac flush */
+	write_bpiall
+	dsb
+	isb
+	read_sctlr r0
+	orr	r0, r0, #SCTLR_Z
+	write_sctlr r0
+#endif
 
 	ldr	r0, =_start
 	write_vbar r0


### PR DESCRIPTION
CFG_SCTLR_ENABLE_Z to enable SCTLR[Z] from the generic boot.
SCTLR[Z] enables program flow prediction support from the core.

Early branch prediction may be unsafe against uncontrolled memory
prefetches that could hit some hard memory access control firewalls.
It is usually safer to enable after the mmu is enabled.

CFG_SCTLR_ENABLE_Z allows to use vanilla op-tee on development board
to exercise benchmark and performance tests over the op-tee system.