### PR TITLE
core: pager: fix tee_pager_set_uta_area_attr()

### DIFF
--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -901,6 +901,11 @@ bool tee_pager_set_uta_area_attr(struct user_ta_ctx *utc, vaddr_t base,
 				tee_pager_save_page(pmem, a);
 
 			area_set_entry(pmem->area, pmem->pgidx, pa, f);
+			/*
+			 * Make sure the table update is visible before
+			 * continuing.
+			 */
+			dsb_ishst();
 
 			if (flags & TEE_MATTR_UX) {
 				void *va = (void *)area_idx2va(pmem->area,


### PR DESCRIPTION
Adds missing synchronization, dsb_ishst(), required to make sure that
translation table update is visible after the final update of the
attributes of a page.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (Hikey)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>