### PR TITLE
core: clean arm32_aeabi_ldivmod_a32.S

### DIFF
--- a/core/arch/arm/sm/psci-helper.S
+++ b/core/arch/arm/sm/psci-helper.S
@@ -54,6 +54,7 @@ END_FUNC psci_enable_smp
 FUNC psci_armv7_cpu_off, :
 UNWIND(	.fnstart)
 	push	{r12, lr}
+UNWIND(	.save	{r12, lr})
 
 	mov     r0, #DCACHE_OP_CLEAN_INV
 	bl	dcache_op_all

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
@@ -27,20 +27,34 @@
 
 #include <asm.S>
 
-	.section .text
+/*
+ * This assembly source is used both in kernel and userland
+ * hence define unwind resources that match both environments.
+ */
+#if defined(CFG_UNWIND)
+#define LOCAL_UNWIND(...)	__VA_ARGS__
+#else
+#define LOCAL_UNWIND(...)
+#endif
 
 /*
  * signed ret_idivmod_values(signed quot, signed rem);
  * return quotient and remaining the EABI way (regs r0,r1)
  */
+.section .text.ret_idivmod_values
 FUNC ret_idivmod_values , :
+LOCAL_UNWIND(.fnstart)
         bx lr
+LOCAL_UNWIND(.fnend)
 END_FUNC ret_idivmod_values
 
 /*
  * unsigned ret_uidivmod_values(unsigned quot, unsigned rem);
  * return quotient and remaining the EABI way (regs r0,r1)
  */
+.section .text.ret_uidivmod_values
 FUNC ret_uidivmod_values , :
+LOCAL_UNWIND(.fnstart)
         bx      lr
+LOCAL_UNWIND(.fnend)
 END_FUNC ret_uidivmod_values

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
@@ -25,41 +25,49 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-	.macro FUNC name colon
-	.global \name
-	.type \name , %function
-	\name \colon
-	.endm
+#include <asm.S>
 
-	.macro END_FUNC name
-	.size \name , .-\name
-	.endm
-
-	.section .text
-	.balign 4
-	.code  32
+/*
+ * This assembly source is used both in kernel and userland
+ * hence define unwind resources that match both environments.
+ */
+#if defined(CFG_UNWIND)
+#define LOCAL_UNWIND(...)	__VA_ARGS__
+#else
+#define LOCAL_UNWIND(...)
+#endif
 
 /*
  * __value_in_regs lldiv_t __aeabi_ldivmod( long long n, long long d)
  */
+.section .text.__aeabi_ldivmod
 FUNC __aeabi_ldivmod , :
+LOCAL_UNWIND(.fnstart)
 	push	{ip, lr}
+LOCAL_UNWIND(.save {ip, lr})
 	push	{r0-r3}
+LOCAL_UNWIND(.save {r0-r3})
 	mov	r0, sp
 	bl	__l_divmod
 	pop	{r0-r3}
 	pop	{ip, pc}
-END_FUNC __aeabi_uldivmod
+LOCAL_UNWIND(.fnend)
+END_FUNC __aeabi_ldivmod
 
 /*
  * __value_in_regs ulldiv_t __aeabi_uldivmod(
  *		unsigned long long n, unsigned long long d)
  */
+.section .text.__aeabi_uldivmod
 FUNC __aeabi_uldivmod , :
+LOCAL_UNWIND(.fnstart)
 	push	{ip, lr}
+LOCAL_UNWIND(.save {ip, lr})
 	push	{r0-r3}
+LOCAL_UNWIND(.save {r0-r3})
 	mov	r0, sp
 	bl	__ul_divmod
 	pop	{r0-r3}
 	pop	{ip, pc}
+LOCAL_UNWIND(.fnend)
 END_FUNC __aeabi_uldivmod


### PR DESCRIPTION
Clean from locally defined arm.S macros.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>