### PR TITLE
core: fix print_kernel_stack()

### DIFF
--- a/core/arch/arm/kernel/unwind_arm32.c
+++ b/core/arch/arm/kernel/unwind_arm32.c
@@ -30,6 +30,7 @@
  */
 
 #include <arm.h>
+#include <kernel/linker.h>
 #include <kernel/misc.h>
 #include <kernel/unwind.h>
 #include <string.h>
@@ -360,6 +361,8 @@ bool unwind_stack_arm32(struct unwind_state_arm32 *state, uaddr_t exidx,
 void print_kernel_stack(int level)
 {
 	struct unwind_state_arm32 state;
+	uaddr_t exidx = (vaddr_t)__exidx_start;
+	size_t exidx_sz = (vaddr_t)__exidx_end - (vaddr_t)__exidx_start;
 
 	memset(state.registers, 0, sizeof(state.registers));
 	/* r7: Thumb-style frame pointer */
@@ -387,7 +390,7 @@ void print_kernel_stack(int level)
 		default:
 			break;
 		}
-	} while (unwind_stack_arm32(&state, 0, 0));
+	} while (unwind_stack_arm32(&state, exidx, exidx_sz));
 }
 
 #endif


### PR DESCRIPTION
Previously was print_kernel_stack() supplying zeroes instead of real
values for start and size of exidx tables needed for unwind.  With this
patch are correct values for exidx and exidx_sz supplied.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>