### PR TITLE
core: abort: fix get_fault_type()

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -498,6 +498,14 @@ vaddr_t thread_stack_start(void);
 size_t thread_stack_size(void);
 
 /*
+ * Returns true if previous exeception also was in abort mode.
+ *
+ * Note: it's only valid to call this function from an abort exception
+ * handler before interrupts has been re-enabled.
+ */
+bool thread_is_from_abort_mode(struct thread_abort_regs *regs);
+
+/*
  * Adds a mutex to the list of held mutexes for current thread
  * Requires foreign interrupts to be disabled.
  */

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -493,23 +493,6 @@ bool abort_is_user_exception(struct abort_info *ai __unused)
 }
 #endif /*CFG_WITH_USER_TA*/
 
-#ifdef ARM32
-/* Returns true if the exception originated from abort mode */
-static bool is_abort_in_abort_handler(struct abort_info *ai)
-{
-	return (ai->regs->spsr & ARM32_CPSR_MODE_MASK) == ARM32_CPSR_MODE_ABT;
-}
-#endif /*ARM32*/
-
-#ifdef ARM64
-/* Returns true if the exception originated from abort mode */
-static bool is_abort_in_abort_handler(struct abort_info *ai __unused)
-{
-	return false;
-}
-#endif /*ARM64*/
-
-
 #if defined(CFG_WITH_VFP) && defined(CFG_WITH_USER_TA)
 #ifdef ARM32
 
@@ -609,7 +592,7 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 #endif
 	}
 
-	if (is_abort_in_abort_handler(ai)) {
+	if (thread_is_from_abort_mode(ai->regs)) {
 		abort_print_error(ai);
 		panic("[abort] abort in abort handler (trap CPU)");
 	}

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -642,6 +642,18 @@ size_t thread_stack_size(void)
 	return STACK_THREAD_SIZE;
 }
 
+bool thread_is_from_abort_mode(struct thread_abort_regs __maybe_unused *regs)
+{
+#ifdef ARM32
+	return (regs->spsr & ARM32_CPSR_MODE_MASK) == ARM32_CPSR_MODE_ABT;
+#endif
+#ifdef ARM64
+	struct thread_core_local *l = thread_get_core_local();
+
+	return (l->flags >> THREAD_CLF_SAVED_SHIFT) & THREAD_CLF_ABORT;
+#endif
+}
+
 void thread_state_free(void)
 {
 	struct thread_core_local *l = thread_get_core_local();


### PR DESCRIPTION
Fixes get_fault_type() to accurately report abort in abort handler also
in AArch64.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU v8)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>