### PR TITLE
core: remove mem_map_inited and fix the SHM_VASPACE_SIZE

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -735,7 +735,7 @@ static void init_mem_map(struct tee_mmap_region *memory_map, size_t num_elems)
 		     RES_VASPACE_SIZE, &last);
 
 	add_va_space(memory_map, num_elems, MEM_AREA_SHM_VASPACE,
-		     RES_VASPACE_SIZE, &last);
+		     SHM_VASPACE_SIZE, &last);
 
 	memory_map[last].type = MEM_AREA_END;
 

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -67,7 +67,6 @@ unsigned long default_nsec_shm_paddr;
 
 static struct tee_mmap_region
 	static_memory_map[MAX_MMAP_REGIONS + 1];
-static bool mem_map_inited;
 
 /* Define the platform's memory layout. */
 struct memaccess_area {
@@ -868,8 +867,7 @@ void core_init_mmu_map(void)
 			panic("Invalid memory access config: sec/nsec");
 	}
 
-	if (!mem_map_inited)
-		init_mem_map(static_memory_map, ARRAY_SIZE(static_memory_map));
+	init_mem_map(static_memory_map, ARRAY_SIZE(static_memory_map));
 
 	map = static_memory_map;
 	while (!core_mmap_is_end_of_table(map)) {


### PR DESCRIPTION
The mem_map_inited is useless,so remove it.
The MEM_AREA_SHM_VASPACE vapsace should have the size of
SHM_VASPACE_SIZE, fix it here.

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>