### PR TITLE
core: arm: imx: fix imx6solo boot

### DIFF
--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -5,7 +5,7 @@ srcs-$(CFG_PL310) += imx_pl310.c
 srcs-$(CFG_PSCI_ARM32) += psci.c gpcv2.c
 cflags-psci.c-y += -Wno-suggest-attribute=noreturn
 
-ifneq (,$(filter y, $(CFG_MX6Q) $(CFG_MX6D) $(CFG_MX6DL)))
+ifneq (,$(filter y, $(CFG_MX6Q) $(CFG_MX6D) $(CFG_MX6DL) $(CFG_MX6S)))
 srcs-y += a9_plat_init.S imx6.c
 endif
 


### PR DESCRIPTION
Reported in #1685 
i.MX6SOLO is almost same with i.MX6DualLite, with difference that
6S has one cpu core, but DualLite has two cpu cores.
i.MX6Solo also needs a9_plat_init.S and imx6.c for basic initialization.

Signed-off-by: Peng Fan <peng.fan@nxp.com>