### PR TITLE
mk/gcc.mk: define LD to bfd version by default

### DIFF
--- a/mk/gcc.mk
+++ b/mk/gcc.mk
@@ -1,7 +1,7 @@
 
 CC$(sm)		:= $(CROSS_COMPILE_$(sm))gcc
 CPP$(sm)	:= $(CROSS_COMPILE_$(sm))cpp
-LD$(sm)		:= $(CROSS_COMPILE_$(sm))ld
+LD$(sm)		:= $(CROSS_COMPILE_$(sm))ld.bfd
 AR$(sm)		:= $(CROSS_COMPILE_$(sm))ar
 NM$(sm)		:= $(CROSS_COMPILE_$(sm))nm
 OBJCOPY$(sm)	:= $(CROSS_COMPILE_$(sm))objcopy


### PR DESCRIPTION
In some cases, ld is linked to gold version,
and it will cause compiling error for 32bit like following:

prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-ld: fatal error: --sort-section=alignment: must take one of the following arguments: none, name

with the bfd version ld, there will be no such error reported.

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>