### PR TITLE
core: mmu: flush entry after updating mmu tables

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1426,6 +1426,10 @@ bool core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len)
 	map->pa = p;
 
 	set_region(&tbl_info, map);
+
+	/* Make sure the new entry is visible before continuing. */
+	dsb_ishst();
+
 	return true;
 }
 


### PR DESCRIPTION
Flush the mmu entry after updating mmu tables. If not, mmu
hardware may not see the entry which is cached in dcache or L2 cache.
Then optee panic when accessing the virtual address.

This issue was found on i.MX6Q-SDB when init_fdt.

core_mmu_v7 tested. lpae changes not tested.

Signed-off-by: Peng Fan <peng.fan@nxp.com>