### PR TITLE
core: arm: boot: fix get_memory

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -541,11 +541,11 @@ static struct core_mmu_phys_mem *get_memory(void *fdt, size_t *nelems)
 		return NULL;
 
 	prop_len = addr_size;
-	addr_size = fdt_address_cells(fdt, offs);
+	addr_size = fdt_address_cells(fdt, 0);
 	if (addr_size < 0)
 		return NULL;
 
-	len_size = fdt_size_cells(fdt, offs);
+	len_size = fdt_size_cells(fdt, 0);
 	if (len_size < 0)
 		return NULL;
 


### PR DESCRIPTION
From Power_ePAPR_APPROVED_v1.1.pdf chapter 3.4 Memory node,
there is no address-cells and size-cells property for in
memory node. Memory node only support three properties "device_type",
"reg" and "initial-mapped-area".

When prase the memory node, need to use the address/size-cells of
root node.

Without this patch, I have to add address-cells and size-cells to memory node of device tree. Also this patch should fix #1710

Signed-off-by: Peng Fan <peng.fan@nxp.com>