### PR TITLE
Build everything with -ffreestanding

### DIFF
--- a/lib/libutils/isoc/newlib/sub.mk
+++ b/lib/libutils/isoc/newlib/sub.mk
@@ -1,4 +1,3 @@
-cflags-y += -ffreestanding
 cflags-y += -Wno-sign-compare
 cflags-remove-y += -Wcast-align
 

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -16,7 +16,7 @@ objs		:=
 # Disable all builtin rules
 .SUFFIXES:
 
-comp-cflags$(sm) = -std=gnu99
+comp-cflags$(sm) = -std=gnu99 -ffreestanding
 comp-aflags$(sm) =
 comp-cppflags$(sm) =
 


### PR DESCRIPTION
```
As per the GCC documentation: "A freestanding environment is one in
which the standard library may not exist, and program startup may not
necessarily be at main.". This is exactly the case for all the binaries
we are building, including TAs, because our libc replacement (libutils)
is only a partial implementation.

This fixes link-time issues that may happen when a TA calls a builtin
function, for example:

  39  TEE_Result TA_CreateEntryPoint(void)
  40  {
  41          printf(".");
  42          /* ... */
  43  }

  hello_world_ta.o: In function `TA_CreateEntryPoint':
  hello_world_ta.c:41: undefined reference to `putchar'

(In this case, the compiler has optimized the printf() call into a call
to putchar(), assuming that a complete C library is available. Since
libutils.a does not provide putchar(), a link error occurs. By adding
the -ffreestanding option, which implies -fno-builtin, we prevent such
invalid optimizations).

Reported-by: Zeng Tao <prime.zeng@hisilicon.com>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```