### PR TITLE
RSA algorithm improvements

### DIFF
--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -1130,6 +1130,9 @@ static TEE_Result rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 
 	ltc_sig_len = mod_size;
 
+	if (ltc_rsa_algo == LTC_PKCS_1_PSS && salt_len == -1)
+		salt_len = hash_size;
+
 	ltc_res = rsa_sign_hash_ex(msg, msg_len, sig, &ltc_sig_len,
 				   ltc_rsa_algo, &prng->state, prng->index,
 				   ltc_hashindex, salt_len, &ltc_key);
@@ -1202,6 +1205,9 @@ static TEE_Result rsassa_verify(uint32_t algo, struct rsa_public_key *key,
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto err;
 	}
+
+	if (ltc_rsa_algo == LTC_PKCS_1_PSS && salt_len == -1)
+		salt_len = hash_size;
 
 	ltc_res = rsa_verify_hash_ex(sig, sig_len, msg, msg_len, ltc_rsa_algo,
 				     ltc_hashindex, salt_len, &stat, &ltc_key);

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -200,9 +200,9 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		break;
 
 	case TEE_ALG_RSA_NOPAD:
-		if (mode == TEE_MODE_ENCRYPT) {
+		if (mode == TEE_MODE_ENCRYPT || mode == TEE_MODE_VERIFY) {
 			req_key_usage = TEE_USAGE_ENCRYPT | TEE_USAGE_VERIFY;
-		} else if (mode == TEE_MODE_DECRYPT) {
+		} else if (mode == TEE_MODE_DECRYPT || mode == TEE_MODE_SIGN) {
 			with_private_key = true;
 			req_key_usage = TEE_USAGE_DECRYPT | TEE_USAGE_SIGN;
 		} else {


### PR DESCRIPTION
1. Can be allowed to use TEE_MODE_SIGN and TEE_MODE_VERIFY with TEE_ALG_RSA_NOPAD
2. Use default salt size for RSA PSS
