### PR TITLE
Travis: add -p to mkdir $HOME/bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_script:
   - pip install --upgrade --user pycrypto
   - pip install --upgrade --user wand
   # Clone repositories for the QEMU test environment
-  - mkdir $HOME/bin
+  - mkdir -p $HOME/bin
   - (cd $HOME/bin && wget https://storage.googleapis.com/git-repo-downloads/repo && chmod +x repo)
   - export PATH=$HOME/bin:$PATH
   - mkdir $HOME/optee_repo


### PR DESCRIPTION
Travis are currently migrating Linux distributions from Ubuntu Precise
(12.04) to Trusty (14.04). It seems that $HOME/bin already exists in
the new images, which causes an error as we do mkdir $HOME/bin.
Add a -p so that the directory creation doesn't fail when bin
exists. This allows the script to run on both Precise and Trusty.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>