### PR TITLE
core: fix memory address comparison

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -284,8 +284,10 @@ static size_t discovered_nsec_ddr_nelems;
 
 static int cmp_pmem_by_addr(const void *a, const void *b)
 {
-	return ((const struct core_mmu_phys_mem *)a)->addr -
-	       ((const struct core_mmu_phys_mem *)b)->addr;
+	const struct core_mmu_phys_mem *pmem_a = a;
+	const struct core_mmu_phys_mem *pmem_b = b;
+
+	return CMP_TRILEAN(pmem_a->addr, pmem_b->addr);
 }
 
 void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
@@ -651,7 +653,7 @@ static int cmp_mmap_by_lower_va(const void *a, const void *b)
 	const struct tee_mmap_region *mm_a = a;
 	const struct tee_mmap_region *mm_b = b;
 
-	return mm_a->va - mm_b->va;
+	return CMP_TRILEAN(mm_a->va, mm_b->va);
 }
 
 static int __maybe_unused cmp_mmap_by_secure_attr(const void *a, const void *b)

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -103,4 +103,13 @@
 #define SUB_OVERFLOW(a, b, res) __compiler_sub_overflow((a), (b), (res))
 #define MUL_OVERFLOW(a, b, res) __compiler_mul_overflow((a), (b), (res))
 
+/* Return a signed +1, 0 or -1 value based on data comparison */
+#define CMP_TRILEAN(a, b) \
+	(__extension__({ \
+		__typeof__(a) _a = (a); \
+		__typeof__(b) _b = (b); \
+		\
+		_a > _b ? 1 : _a < _b ? -1 : 0; \
+	}))
+
 #endif /*UTIL_H*/


### PR DESCRIPTION
Addresses are unsigned value. Subtracting address values results
in a unsigned value. Since qsort comparison function expects a signed
integer return value, the unsigned address subtraction value gets
signed and can produce a wrong result. This change overcomes the issue
by producing a +1 or -1 signed value based on the unsigned address
values comparison.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>