### PR TITLE
TA: Enable (per-function) stack canaries.

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -82,6 +82,9 @@ CFG_TEE_TA_MALLOC_DEBUG ?= n
 # Levels: 0=none 1=error 2=info 3=debug 4=flow
 CFG_MSG_LONG_PREFIX_MASK ?= 0x1a
 
+# If y, enable stack protection (per-function stack canaries) for TAs.
+CFG_TEE_TA_STACK_GUARD ?= y
+
 # PRNG configuration
 # If CFG_WITH_SOFTWARE_PRNG is enabled, crypto provider provided
 # software PRNG implementation is used.

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -58,6 +58,10 @@ ifeq ($(CFG_TEE_PANIC_DEBUG),y)
 cppflags$(sm) += -DCFG_TEE_PANIC_DEBUG=1
 endif
 
+ifeq ($(CFG_TEE_TA_STACK_GUARD),y)
+cppflags$(sm) += -fstack-protector
+endif
+
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
 
 libdirs += $(ta-dev-kit-dir)/lib

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -22,6 +22,10 @@ ifeq ($(CFG_TEE_TA_MALLOC_DEBUG),y)
 cppflags$(sm) += -DENABLE_MDBG=1
 endif
 
+ifeq ($(CFG_TEE_TA_STACK_GUARD),y)
+cppflags$(sm) += -fstack-protector
+endif
+
 base-prefix := $(sm)-
 
 libname = utils
@@ -123,6 +127,7 @@ $(conf-mk-file-export): $(conf-mk-file)
 	$(q)echo sm := $$(sm-$(conf-mk-file-export)) > $$@
 	$(q)echo sm-$$(sm-$(conf-mk-file-export)) := y >> $$@
 	$(q)echo CFG_TA_FLOAT_SUPPORT := $$(CFG_TA_FLOAT_SUPPORT) >> $$@
+	$(q)echo CFG_TEE_TA_STACK_GUARD := $$(CFG_TEE_TA_STACK_GUARD) >> $$@
 	$(q)($$(foreach v, $$(ta-mk-file-export-vars-$$(sm-$(conf-mk-file-export))), \
 		echo $$(v) := $$($$(v));)) >> $$@
 	$(q)echo '$$(ta-mk-file-export-add-$$(sm-$(conf-mk-file-export)))' | sed 's/_nl_ */\n/g' >> $$@


### PR DESCRIPTION
This adds a flag (on by default) which enables the -fstack-protector flag for TAs and randomizes the canary in __utee_entry. libutils already provides a __stack_chk_fail function which loops forever, so this patch is very simple.

I had to add the cppflags to both ta.mk and ta_dev_kit.mk so that the whole TA is built with the protector. This does require that all TAs are linked against libutils if you enable the flag.

__utee_entry doesn't return and TEE_GenerateRandom shouldn't get instrumented with the protector enabled unless you use -fstack-protector-all, so it shouldn't be a problem that the canary changes from underneath us when we initialize it.

I don't know how well-supported this is by vendor toolchains; it can always be turned off by default if necessary.