### PR TITLE
libutee: provide an implementation of putchar()

### DIFF
--- a/lib/libutee/trace_ext.c
+++ b/lib/libutee/trace_ext.c
@@ -96,6 +96,20 @@ int puts(const char *str)
 	return 1;
 }
 
+int putchar(int c)
+{
+	char str[2] = { (char)c, '\0' };
+
+	if (trace_get_level() >= TRACE_PRINTF_LEVEL)
+		trace_ext_puts(str);
+	/*
+	 * From the putchar() man page:
+	 * "fputc(), putc() and putchar() return the character written as an
+	 * unsigned char cast to an int or EOF on error."
+	 */
+	return (int)(unsigned char)c;
+}
+
 #else
 
 int printf(const char *fmt __unused, ...)
@@ -106,6 +120,11 @@ int printf(const char *fmt __unused, ...)
 int puts(const char *str __unused)
 {
 	return 0;
+}
+
+int putchar(int c)
+{
+	return (int)(unsigned char)c;
 }
 
 #endif

--- a/lib/libutils/isoc/include/stdio.h
+++ b/lib/libutils/isoc/include/stdio.h
@@ -40,5 +40,6 @@ int vsnprintf (char *str, size_t size, const char *fmt, va_list ap)
                     __attribute__ ((__format__ (__printf__, 3, 0)));
 
 int puts(const char *str);
+int putchar(int c);
 
 #endif /*STDIO_H*/


### PR DESCRIPTION
```
Calling printf() from a TA to print a single character results in a
linker error:

  39  TEE_Result TA_CreateEntryPoint(void)
  40  {
  41          printf(".");
  42          /* ... */
  43  }

  hello_world_ta.o: In function `TA_CreateEntryPoint':
  hello_world_ta.c:41: undefined reference to `putchar'

In this case, the compiler has optimized the printf() call into a call
to putchar(), assuming that we have a C library and that it complies to
the relevant standards (so that printf() and putchar() may be used
interchangeably).

One way to fix the issue is to prevent such optimizations by using
-fno-builtin or -ffreestanding, at the cost of slightly larger code
size and possibly reduced performance.

Another option is to simply provide the missing putchar() function. It
is the purpose of this commit.

Reported-by: Zeng Tao <prime.zeng@hisilicon.com>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```