### PR TITLE
Add GlobalPlatform license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -25,3 +25,13 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+GlobalPlatform API license
+
+Since OP-TEE is a TEE implementing GlobalPlatform APIs, users of OP-TEE should
+get the license for the GlobalPlatform TEE API either by joining GlobalPlatform
+as a member or, they can get it for free by going to and download the
+specifications at:
+https://www.globalplatform.org/specificationsdevice.asp


### PR DESCRIPTION
We have been asked by Linaro members to add this clarification. If we are all OK with this, I'll make the same change in optee_client and optee_test also (I cannot see that we need to add it to the other gits since they are not implementing anything directly related to the GP APIs).

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>