### PR TITLE
[RFC]Rockchip: add SRAM section in kern.ld.S

### DIFF
--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -394,6 +394,12 @@ SECTIONS
 	__init_size = __data_end - CFG_TEE_LOAD_ADDR;
 	__init_mem_usage = __end - CFG_TEE_LOAD_ADDR;
 #endif
+
+#ifdef CFG_PLAT_EXTRA_LD_SCRIPT
+	__tee_plat_extra_base = .;
+	#include <plat.ld.S>
+#endif
+
 	/*
 	 * Guard against moving the location counter backwards in the assignment
 	 * below.

--- a/core/arch/arm/plat-rockchip/common.h
+++ b/core/arch/arm/plat-rockchip/common.h
@@ -46,4 +46,7 @@
 #define BITS_WITH_WMASK(bits, msk, shift) \
 				(SHIFT_U32(bits, shift) | BITS_WMSK(msk, shift))
 
+#define __sramfunc __attribute__((section(".sram.text"))) \
+					__attribute__((noinline))
+
 #endif

--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -15,6 +15,10 @@ $(call force,CFG_PSCI_ARM32,y)
 $(call force,CFG_BOOT_SECONDARY_REQUEST,y)
 $(call force,CFG_8250_UART,y)
 
+ifeq ($(PLATFORM_FLAVOR),rk322x)
+$(call force,CFG_PLAT_EXTRA_LD_SCRIPT,y)
+endif
+
 ta-targets = ta_arm32
 
 CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-rockchip/plat.ld.S
+++ b/core/arch/arm/plat-rockchip/plat.ld.S
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __ROCKCHIP_PLAT_LD_S__
+#define __ROCKCHIP_PLAT_LD_S__
+
+	/*
+	 * The SRAM space allocation
+	 * +-------------+
+	 * | sram text	 |
+	 * +-------------+
+	 * | sram rodata |
+	 * +-------------+
+	 * | sram data   |
+	 * +-------------+
+	 */
+
+	.text_sram ISRAM_LDS_BASE : AT(__tee_plat_extra_base) {
+		. = ALIGN(4);
+		__tee_sram_text_start = .;
+		*(.sram.text)
+		*(.sram.rodata)
+		__tee_sram_text_end = .;
+		. = ALIGN(4);
+		__tee_sram_data_start = .;
+		*(.sram.data)
+		__tee_sram_data_end = .;
+	}
+
+#endif /* __ROCKCHIP_PLAT_LD_S__ */

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -31,6 +31,8 @@
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		64
 
+#include <common.h>
+
 #if defined(PLATFORM_FLAVOR_rk322x)
 
 #define GIC_BASE		0x32010000
@@ -53,6 +55,9 @@
 /* Periph IO */
 #define PERIPH_BASE		0x10100000
 #define PERIPH_SIZE		0x22000000
+
+#define ISRAM_LDS_BASE		(ISRAM_BASE + BOOT_ADDR_OFFSET)
+#define ISRAM_LDS_SIZE		(ISRAM_SIZE - BOOT_ADDR_OFFSET)
 
 #define CFG_TEE_CORE_NB_CORE	4
 #else

--- a/core/arch/arm/plat-rockchip/psci_rk322x.c
+++ b/core/arch/arm/plat-rockchip/psci_rk322x.c
@@ -377,12 +377,18 @@ int psci_system_suspend(uintptr_t entry __unused,
 	return PSCI_RET_SUCCESS;
 }
 
+__sramfunc static void foo(void)
+{
+	IMSG("This is a foo function test for sram section");
+}
+
 /* When SMP bootup, we release cores one by one */
 static TEE_Result reset_nonboot_cores(void)
 {
 	vaddr_t va_base = (vaddr_t)phys_to_virt_io(CRU_BASE);
 
 	write32(NONBOOT_CORES_SOFT_RESET, va_base + CRU_SOFTRST_CON(0));
+	foo();
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
I have some code and data must be put on SRAM for some requirements,  I refer to implementation on arm-trusted-firmware[0] and try to add a SRAM section in kern.ld.S. But: 
1. I am not sure whether it's a good way or not, if not, I wish you experts can give me some advice.
2. for these patches, I meet a problem while compiling:  I add a foo() function on SRAM for test, but there comes error compile log: **out/arm-plat-rockchip/core/arch/arm/plat-rockchip/psci_rk322x.o:(.ARM.exidx.sram.text+0x0): relocation truncated to fit: R_ARM_PREL31 against `.sram.text'**  I tried, I have to ask for your experts help.

[0]: web link:
https://github.com/ARM-software/arm-trusted-firmware/blob/master/plat/rockchip/rk3328/include/plat.ld.S 
https://github.com/ARM-software/arm-trusted-firmware/blob/master/bl31/bl31.ld.S

Signed-off-by: Joseph Chen <chenjh@rock-chips.com>