### PR TITLE
scripts/symbolize.py: accept -d <ELF_file> in addition to -d <dir>

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -29,6 +29,7 @@
 
 import argparse
 import glob
+import os
 import re
 import subprocess
 import sys
@@ -75,7 +76,8 @@ def get_args():
     parser.add_argument('-d', '--dir', action='append', nargs='+',
         help='Search for ELF file in DIR. tee.elf is needed to decode '
              'a TEE Core or pseudo-TA abort, while <TA_uuid>.elf is required '
-             'if a user-mode TA has crashed.')
+             'if a user-mode TA has crashed. For convenience, ELF files '
+             'may also be given.')
     parser.add_argument('-s', '--strip_path',
         help='Strip STRIP_PATH from file paths')
 
@@ -94,6 +96,8 @@ class Symbolizer(object):
         if not elf_or_uuid.endswith('.elf'):
             elf_or_uuid += '.elf'
         for d in self._dirs:
+            if d.endswith(elf_or_uuid) and os.path.isfile(d):
+                return d
             elf = glob.glob(d + '/' + elf_or_uuid)
             if elf:
                 return elf[0]


### PR DESCRIPTION
The -d option of symbolize.py normally expects one or more directories,
where the script will look for ELF files (TEE or TA, depending on the
input dump). For convenience, let's also accept paths to the actual ELF
files. Previously, the script would just ignore file arguments and
silently fail to resolve stack traces.

Reported-by: Lijianhui <airbak.li@hisilicon.com>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>