### PR TITLE
scripts/symbolize.py: try to resolve abort address to symbol/section[+offset]

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -115,9 +115,9 @@ class Symbolizer(object):
 
     def resolve(self, addr):
         offs = self._load_addr
-        if int(offs, 0) > int(addr, 0):
+        if int(offs, 16) > int(addr, 16):
             return '???'
-        reladdr = '0x{:x}'.format(int(addr, 0) - int(offs, 0))
+        reladdr = '0x{:x}'.format(int(addr, 16) - int(offs, 16))
         self.spawn_addr2line()
         if not self._addr2line:
             return '???'


### PR DESCRIPTION
```
Use nm and objdump to find the symbol and ELF section that match the
address reported in the the abort line. This can help debug writes to
read-only data or unaligned accesses to global data, for example.

If the address can be resolved to a symbol plus some offset and/or a
section plus some offset, the abort line is printed again just before
the call stack with the symbolic information added. Not that the
translation cannot be done immediately when the abort line is seen
because at this point we don't know the architecture, and we don't have
the load address of the TA.

Here is an example (the line added by this patch is marked with >>):

   User TA data-abort at address 0x1314d0 (write permission fault)
    fsr 0x0000080f  ttbr0 0x0e07a06a  ttbr1 0x0e07406a  cidr 0x1
    cpu #0          cpsr 0x60000030
    r0 0x00000001      r4 0x00102780    r8 0x00000000   r12 0xb736e358
    r1 0x00102724      r5 0x00121e4f    r9 0x00000000    sp 0x001026e0
    r2 0x00000001      r6 0x001026dc   r10 0x00000000    lr 0x00105cf1
    r3 0x001314d0      r7 0x001026e0   r11 0x00000000    pc 0x00105790
   Status of TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b (0xe073b70) (active)
    arch: arm  load address: 0x103000  ctx-idr: 1
    stack: 0x100000 10240
    region 0: va 0x100000 pa 0xe21e000 size 0x3000
    region 1: va 0x103000 pa 0xe100000 size 0x2e000
    region 2: va 0x131000 pa 0xe12e000 size 0xa000
    region 3: va 0x13b000 pa 0xe138000 size 0xe6000
    region 4: va 0 pa 0 size 0
    region 5: va 0 pa 0 size 0
    region 6: va 0 pa 0 size 0
    region 7: va 0 pa 0 size 0
>> User TA data-abort at address 0x1314d0 const_val+4 .rodata+4452 (write permission fault)
   Call stack:
    0x00105790 ta_entry_bad_mem_access at optee_test/ta/os_test/os_test.c:917
    0x00105cf1 TA_InvokeCommandEntryPoint at optee_test/ta/os_test/ta_entry.c:101
    0x00121e33 entry_invoke_command at optee_os/lib/libutee/arch/arm/user_ta_entry.c:207
    0x00121e8f __utee_entry at optee_os/lib/libutee/arch/arm/user_ta_entry.c:235

The test TA does the following:

  const int const_val[3] = { 1, };
  /* ... */
  ((int *)const_val)[1] = 2;

Suggested-by: Zeng Tao <prime.zeng@hisilicon.com>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```