### PR TITLE
libutee: printf() fix: remove newline added by mistake

### DIFF
--- a/lib/libutee/trace_ext.c
+++ b/lib/libutee/trace_ext.c
@@ -66,7 +66,7 @@ int printf(const char *fmt, ...)
 	if (s < 0)
 		return s;
 
-	puts(to_format);
+	trace_ext_puts(to_format);
 
 	return s;
 }


### PR DESCRIPTION
puts() was recently modified [1] to always add a trailing newline (\n).
This change has broken printf() which uses puts() internally.

Fix the issue by calling trace_ext_puts() instead.

Fixes: 6246cc9d957c ("libutee: puts(): add trailing newline")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>