### PR TITLE
core: bugfix core_mmu_user_mapping_is_active()

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -744,8 +744,14 @@ void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 
 bool core_mmu_user_mapping_is_active(void)
 {
+	bool ret;
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+
 	assert(user_va_idx != -1);
-	return !!l1_xlation_table[get_core_pos()][user_va_idx];
+	ret = l1_xlation_table[get_core_pos()][user_va_idx];
+	thread_unmask_exceptions(exceptions);
+
+	return ret;
 }
 
 #ifdef ARM32

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -655,7 +655,13 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 
 bool core_mmu_user_mapping_is_active(void)
 {
-	return read_ttbr0() != read_ttbr1();
+	bool ret;
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+
+	ret = read_ttbr0() != read_ttbr1();
+	thread_unmask_exceptions(exceptions);
+
+	return ret;
 }
 
 static void print_mmap_area(const struct tee_mmap_region *mm __maybe_unused,


### PR DESCRIPTION
Fixes race in both v7 and lpae versions of
core_mmu_user_mapping_is_active() by temporarily disabling interrupts.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU v8)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>