### PR TITLE
core: introduce TEE_RAM_VA_START and TEE_TEXT_VA_START

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -74,6 +74,18 @@
 #define CFG_TEE_RAM_VA_SIZE		CORE_MMU_PGDIR_SIZE
 #endif
 
+/*
+ * TEE_RAM_VA_START:            The start virtual address of the TEE RAM
+ * TEE_TEXT_VA_START:           The start virtual address of the OP-TEE text
+ */
+
+/*
+ * Identify mapping constraint: virtual base address is the physical start addr.
+ */
+#define TEE_RAM_VA_START		CFG_TEE_RAM_START
+#define TEE_TEXT_VA_START		(TEE_RAM_VA_START + \
+				(CFG_TEE_LOAD_ADDR - CFG_TEE_RAM_START))
+
 #ifndef STACK_ALIGNMENT
 #define STACK_ALIGNMENT			(sizeof(long) * 2)
 #endif

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -257,8 +257,8 @@ static void init_runtime(unsigned long pageable_part)
 	 * Initialize the virtual memory pool used for main_mmu_l2_ttb which
 	 * is supplied to tee_pager_init() below.
 	 */
-	if (!tee_mm_init(&tee_mm_vcore, CFG_TEE_RAM_START,
-			 CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE,
+	if (!tee_mm_init(&tee_mm_vcore, TEE_RAM_VA_START,
+			 TEE_RAM_VA_START + CFG_TEE_RAM_VA_SIZE,
 			 SMALL_PAGE_SHIFT, 0))
 		panic("tee_mm_vcore init failed");
 
@@ -324,10 +324,10 @@ static void init_asan(void)
 	 */
 
 #define __ASAN_SHADOW_START \
-	ROUNDUP(CFG_TEE_RAM_START + (CFG_TEE_RAM_VA_SIZE * 8) / 9 - 8, 8)
+	ROUNDUP(TEE_RAM_VA_START + (CFG_TEE_RAM_VA_SIZE * 8) / 9 - 8, 8)
 	assert(__ASAN_SHADOW_START == (vaddr_t)&__asan_shadow_start);
 #define __CFG_ASAN_SHADOW_OFFSET \
-	(__ASAN_SHADOW_START - (CFG_TEE_RAM_START / 8))
+	(__ASAN_SHADOW_START - (TEE_RAM_VA_START / 8))
 	COMPILE_TIME_ASSERT(CFG_ASAN_SHADOW_OFFSET == __CFG_ASAN_SHADOW_OFFSET);
 #undef __ASAN_SHADOW_START
 #undef __CFG_ASAN_SHADOW_OFFSET
@@ -336,7 +336,7 @@ static void init_asan(void)
 	 * Assign area covered by the shadow area, everything from start up
 	 * to the beginning of the shadow area.
 	 */
-	asan_set_shadowed((void *)CFG_TEE_LOAD_ADDR, &__asan_shadow_start);
+	asan_set_shadowed((void *)TEE_TEXT_VA_START, &__asan_shadow_start);
 
 	/*
 	 * Add access to areas that aren't opened automatically by a

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -58,18 +58,31 @@
 #define ROUNDDOWN(x, y)		(((x) / (y)) * (y))
 #endif
 
+/*
+ * TEE_RAM_VA_START:            The start virtual address of the TEE RAM
+ * TEE_TEXT_VA_START:           The start virtual address of the OP-TEE text
+ */
+#define TEE_RAM_VA_START                CFG_TEE_RAM_START
+#define TEE_TEXT_VA_START               (TEE_RAM_VA_START + \
+			(CFG_TEE_LOAD_ADDR - CFG_TEE_RAM_START))
+
 OUTPUT_FORMAT(CFG_KERN_LINKER_FORMAT)
 OUTPUT_ARCH(CFG_KERN_LINKER_ARCH)
 
 ENTRY(_start)
 SECTIONS
 {
-	. = CFG_TEE_LOAD_ADDR;
-
+	. = TEE_TEXT_VA_START;
+#ifdef ARM32
+	ASSERT(!(TEE_TEXT_VA_START & 31), "text start should align to 32bytes")
+#endif
+#ifdef ARM64
+	ASSERT(!(TEE_TEXT_VA_START & 127), "text start should align to 128bytes")
+#endif
 	__text_start = .;
 
 	/*
-	 * Memory between CFG_TEE_LOAD_ADDR and page aligned rounded down
+	 * Memory between TEE_TEXT_VA_START and page aligned rounded down
 	 * value will be mapped with unpaged "text" section attributes:
 	 * likely to be read-only/executable.
 	 */
@@ -377,22 +390,22 @@ SECTIONS
 				SMALL_PAGE_SIZE) * 32;
 	__tmp_hashes_end = __tmp_hashes_start + __tmp_hashes_size;
 
-	__init_mem_usage = __tmp_hashes_end - CFG_TEE_LOAD_ADDR;
+	__init_mem_usage = __tmp_hashes_end - TEE_TEXT_VA_START;
 
 	ASSERT(CFG_TEE_LOAD_ADDR >= CFG_TEE_RAM_START,
 		"Load address before start of physical memory")
 	ASSERT(CFG_TEE_LOAD_ADDR < (CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE),
 		"Load address after end of physical memory")
-	ASSERT(__tmp_hashes_end < (CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE),
+	ASSERT(__tmp_hashes_end < (TEE_RAM_VA_START + CFG_TEE_RAM_PH_SIZE),
 		"OP-TEE can't fit init part into available physical memory")
-	ASSERT((CFG_TEE_RAM_START + CFG_TEE_RAM_PH_SIZE - __init_end) >
+	ASSERT((TEE_RAM_VA_START + CFG_TEE_RAM_PH_SIZE - __init_end) >
 		SMALL_PAGE_SIZE, "Too few free pages to initialize paging")
 
 
 #endif /*CFG_WITH_PAGER*/
 
 #ifdef CFG_CORE_SANITIZE_KADDRESS
-	. = CFG_TEE_RAM_START + (CFG_TEE_RAM_VA_SIZE * 8) / 9 - 8;
+	. = TEE_RAM_VA_START + (CFG_TEE_RAM_VA_SIZE * 8) / 9 - 8;
 	. = ALIGN(8);
 	.asan_shadow : {
 		__asan_shadow_start = .;
@@ -404,16 +417,16 @@ SECTIONS
 	__end = .;
 
 #ifndef CFG_WITH_PAGER
-	__init_size = __data_end - CFG_TEE_LOAD_ADDR;
-	__init_mem_usage = __end - CFG_TEE_LOAD_ADDR;
+	__init_size = __data_end - TEE_TEXT_VA_START;
+	__init_mem_usage = __end - TEE_TEXT_VA_START;
 #endif
 	/*
 	 * Guard against moving the location counter backwards in the assignment
 	 * below.
 	 */
-	ASSERT(. <= (CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE),
+	ASSERT(. <= (TEE_RAM_VA_START + CFG_TEE_RAM_VA_SIZE),
 		"CFG_TEE_RAM_VA_SIZE is too small")
-	. = CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE;
+	. = TEE_RAM_VA_START + CFG_TEE_RAM_VA_SIZE;
 
 	_end_of_ram = .;
 

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -835,8 +835,8 @@ static void init_mem_map(struct tee_mmap_region *memory_map, size_t num_elems)
 		va = MIN(va, ROUNDDOWN(map->va, map->region_size));
 		end = MAX(end, ROUNDUP(map->va + map->size, map->region_size));
 	}
-	assert(va >= CFG_TEE_RAM_START);
-	assert(end <= CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE);
+	assert(va >= TEE_RAM_VA_START);
+	assert(end <= TEE_RAM_VA_START + CFG_TEE_RAM_VA_SIZE);
 
 	add_pager_vaspace(memory_map, num_elems, va, &end, &last);
 
@@ -1554,7 +1554,7 @@ static void check_pa_matches_va(void *va, paddr_t pa)
 		}
 	}
 #ifdef CFG_WITH_PAGER
-	if (v >= CFG_TEE_LOAD_ADDR && v < get_linear_map_end()) {
+	if (v >= TEE_TEXT_VA_ADDR && v < get_linear_map_end()) {
 		if (v != pa)
 			panic("issue in linear address space");
 		return;

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -180,9 +180,9 @@ void tee_pager_get_stats(struct tee_pager_stats *stats)
 #define TBL_SHIFT	SMALL_PAGE_SHIFT
 
 #define EFFECTIVE_VA_SIZE \
-	(ROUNDUP(CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE, \
+	(ROUNDUP(TEE_RAM_VA_START + CFG_TEE_RAM_VA_SIZE, \
 		 CORE_MMU_PGDIR_SIZE) - \
-	 ROUNDDOWN(CFG_TEE_RAM_START, CORE_MMU_PGDIR_SIZE))
+	 ROUNDDOWN(TEE_RAM_VA_START, CORE_MMU_PGDIR_SIZE))
 
 static struct pager_table {
 	struct pgt pgt;
@@ -280,11 +280,11 @@ void *tee_pager_phys_to_virt(paddr_t pa)
 		return (void *)core_mmu_idx2va(&ti, idx);
 
 	n = 0;
-	idx = core_mmu_va2idx(&pager_tables[n].tbl_info, CFG_TEE_RAM_START);
+	idx = core_mmu_va2idx(&pager_tables[n].tbl_info, TEE_RAM_VA_START);
 	while (true) {
 		while (idx < TBL_NUM_ENTRIES) {
 			v = core_mmu_idx2va(&pager_tables[n].tbl_info, idx);
-			if (v >= (CFG_TEE_RAM_START + CFG_TEE_RAM_VA_SIZE))
+			if (v >= (TEE_RAM_VA_START + CFG_TEE_RAM_VA_SIZE))
 				return NULL;
 
 			core_mmu_get_entry(&pager_tables[n].tbl_info,
@@ -438,7 +438,7 @@ void tee_pager_early_init(void)
 	 * after end of memory.
 	 */
 	for (n = 0; n < ARRAY_SIZE(pager_tables); n++) {
-		if (!core_mmu_find_table(CFG_TEE_RAM_START +
+		if (!core_mmu_find_table(TEE_RAM_VA_START +
 					 n * CORE_MMU_PGDIR_SIZE, UINT_MAX,
 					 &pager_tables[n].tbl_info))
 			panic("can't find mmu tables");

--- a/core/arch/arm/plat-imx/imx6.c
+++ b/core/arch/arm/plat-imx/imx6.c
@@ -45,9 +45,12 @@ void plat_cpu_reset_late(void)
 		/* primary core */
 #if defined(CFG_BOOT_SYNC_CPU)
 		/* set secondary entry address and release core */
-		write32(CFG_TEE_LOAD_ADDR, SRC_BASE + SRC_GPR1 + 8);
-		write32(CFG_TEE_LOAD_ADDR, SRC_BASE + SRC_GPR1 + 16);
-		write32(CFG_TEE_LOAD_ADDR, SRC_BASE + SRC_GPR1 + 24);
+		write32(virt_to_phys(TEE_TEXT_VA_START),
+			SRC_BASE + SRC_GPR1 + 8);
+		write32(virt_to_phys(TEE_TEXT_VA_START),
+			SRC_BASE + SRC_GPR1 + 16);
+		write32(virt_to_phys(TEE_TEXT_VA_START),
+			SRC_BASE + SRC_GPR1 + 24);
 
 		write32(SRC_SCR_CPU_ENABLE_ALL, SRC_BASE + SRC_SCR);
 #endif

--- a/core/arch/arm/plat-imx/psci.c
+++ b/core/arch/arm/plat-imx/psci.c
@@ -61,7 +61,7 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	ns_entry_addrs[core_idx] = entry;
 
 	if (soc_is_imx7ds()) {
-		write32((uint32_t)CFG_TEE_LOAD_ADDR,
+		write32((uint32_t)virt_to_phys(TEE_TEXT_VA_START),
 			va + SRC_GPR1_MX7 + core_idx * 8);
 
 		imx_gpcv2_set_core1_pup_by_software();
@@ -76,7 +76,8 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	}
 
 	/* boot secondary cores from OP-TEE load address */
-	write32((uint32_t)CFG_TEE_LOAD_ADDR, va + SRC_GPR1 + core_idx * 8);
+	write32((uint32_t)virt_to_phys(TEE_TEXT_VA_START),
+		va + SRC_GPR1 + core_idx * 8);
 
 	/* release secondary core */
 	val = read32(va + SRC_SCR);

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -55,7 +55,7 @@ endif
 ifeq ($(PLATFORM_FLAVOR),qemu_virt)
 ifeq ($(CFG_CORE_SANITIZE_KADDRESS),y)
 # CFG_ASAN_SHADOW_OFFSET is calculated as:
-# (&__asan_shadow_start - (CFG_TEE_RAM_START / 8)
+# (&__asan_shadow_start - (TEE_RAM_VA_START / 8)
 # This is unfortunately currently not possible to do in make so we have to
 # calculate it offline, there's some asserts in
 # core/arch/arm/kernel/generic_boot.c to check that we got it right

--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -71,7 +71,7 @@ TEE_Result __weak init_teecore(void)
 	is_first = 0;
 
 #ifdef CFG_WITH_USER_TA
-	tee_svc_uref_base = CFG_TEE_LOAD_ADDR;
+	tee_svc_uref_base = TEE_TEXT_VA_START;
 #endif
 
 	/* init support for future mapping of TAs */


### PR DESCRIPTION
The currently OP-TEE implementation depends on the identity mapping, and
the CFG_TEE_RAM_START and CFG_TEE_LOAD_ADDR are used as both physic and
virtual address which is not extensible.
This patch introduce the virtual address of these two marcos and as a
base of non-identity mapping.

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>