### PR TITLE
core: add missing barrier to page table write

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -713,6 +713,8 @@ void core_mmu_set_entry_primitive(void *table, size_t level, size_t idx,
 	uint64_t desc = mattr_to_desc(level, attr);
 
 	tbl[idx] = desc | pa;
+
+	dsb();	/* Make sure the write above is visible */
 }
 
 void core_mmu_get_entry_primitive(const void *table, size_t level,


### PR DESCRIPTION
When updating a PTE, we need to make sure that the write to memory
is visible before any possible reads of that virtual address occur.

Signed-off-by: Stuart Yoder <stuart.yoder@arm.com>
Reviewed-by: James King <james.king@arm.com>