### PR TITLE
core: arm32: remove extra 'x' in core stack dump

### DIFF
--- a/core/arch/arm/kernel/unwind_arm32.c
+++ b/core/arch/arm/kernel/unwind_arm32.c
@@ -363,7 +363,7 @@ void print_stack_arm32(int level, struct unwind_state_arm32 *state, uaddr_t exid
 {
 	trace_printf_helper_raw(level, true, "Call stack:");
 	do {
-		trace_printf_helper_raw(level, true, " 0x%08x" PRIx32,
+		trace_printf_helper_raw(level, true, " 0x%08" PRIx32,
 					state->registers[PC]);
 	} while (unwind_stack_arm32(state, exidx, exidx_sz));
 }


### PR DESCRIPTION
Commit 6693786dda1a ("core: make panic call stack consistent with abort
call stack") has mistakenly introduced an extra 'x' in the TEE core
stack dumps. Remove it.

Fixes: 6693786dda1a ("core: make panic call stack consistent with abort call stack")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>