### PR TITLE
arm timers: add read/write functions for counter PL1 control register

### DIFF
--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -27,6 +27,7 @@
 #ifndef ARM_H
 #define ARM_H
 
+#include <util.h>
 
 #define MPIDR_CPU_MASK		0xff
 #define MPIDR_CLUSTER_SHIFT	8
@@ -75,6 +76,9 @@
 #define ARM32_CPSR_IT_MASK1	0x06000000
 #define ARM32_CPSR_IT_MASK2	0x0000fc00
 
+/* ARM Generic timer definitions */
+#define CNTKCTL_PL0PCTEN	BIT(0) /* physical counter el0 access enable */
+#define CNTKCTL_PL0VCTEN	BIT(1) /* virtual counter el0 access enable */
 
 #ifdef ARM32
 #include <arm32.h>

--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -579,6 +579,19 @@ static inline void write_cntfrq(uint32_t frq)
 	asm volatile("mcr p15, 0, %0, c14, c0, 0" : : "r" (frq));
 }
 
+static inline uint32_t read_cntkctl(void)
+{
+	uint32_t cntkctl;
+
+	asm volatile("mrc p15, 0, %0, c14, c1, 0" : "=r" (cntkctl));
+	return cntkctl;
+}
+
+static inline void write_cntkctl(uint32_t cntkctl)
+{
+	asm volatile("mcr p15, 0, %0, c14, c1, 0" : : "r" (cntkctl));
+}
+
 static __always_inline uint32_t read_pc(void)
 {
 	uint32_t val;

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -317,7 +317,11 @@ DEFINE_U32_REG_READWRITE_FUNCS(fpsr)
 DEFINE_U32_REG_READ_FUNC(contextidr_el1)
 DEFINE_U32_REG_READ_FUNC(sctlr_el1)
 
+/* ARM Generic timer functions */
 DEFINE_REG_READ_FUNC_(cntfrq, uint32_t, cntfrq_el0)
+DEFINE_REG_READ_FUNC_(cntpct, uint64_t, cntpct_el0)
+DEFINE_REG_READ_FUNC_(cntkctl, uint32_t, cntkctl_el1)
+DEFINE_REG_WRITE_FUNC_(cntkctl, uint32_t, cntkctl_el1)
 
 DEFINE_U64_REG_READWRITE_FUNCS(ttbr0_el1)
 DEFINE_U64_REG_READWRITE_FUNCS(ttbr1_el1)
@@ -329,8 +333,6 @@ DEFINE_U64_REG_READ_FUNC(mpidr_el1)
 DEFINE_U64_REG_READ_FUNC(par_el1)
 
 DEFINE_U64_REG_WRITE_FUNC(mair_el1)
-
-DEFINE_REG_READ_FUNC_(cntpct, uint64_t, cntpct_el0)
 
 /* Register read/write functions for GICC registers by using system interface */
 DEFINE_REG_READ_FUNC_(icc_ctlr, uint32_t, S3_0_C12_C12_4)


### PR DESCRIPTION
Can be used for enabling user access to both Physical/Virtual counter
registers. Example of usage:

```c
uint32_t cntkctl;
cntkctl = read_cntkctl();
cntkctl |= CNTKCTL_PL0VCTEN;
write_cntkctl(cntkctl);
```

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`