### PR TITLE
Update link rules for User TA

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -25,7 +25,7 @@ reverse = $(if $(wordlist 2,2,$(1)),$(call reverse,$(wordlist 2,$(words $(1)),$(
 
 link-ldadd  = $(LDADD)
 link-ldadd += $(addprefix -L,$(libdirs))
-link-ldadd += $(addprefix -l,$(call reverse,$(libnames)))
+link-ldadd += --start-group $(addprefix -l,$(call reverse,$(libnames))) --end-group
 ldargs-$(binary).elf := $(link-ldflags) $(objs) $(link-ldadd)
 
 

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -61,7 +61,7 @@ endif
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
 
 libdirs += $(ta-dev-kit-dir)/lib
-libnames += utils utee mpa utils zlib png utee
+libnames += utils utee mpa zlib png
 libdeps += $(ta-dev-kit-dir)/lib/libutils.a
 libdeps += $(ta-dev-kit-dir)/lib/libmpa.a
 libdeps += $(ta-dev-kit-dir)/lib/libutee.a


### PR DESCRIPTION
Let's use --start-group / --end-group to allow all libraries added by the user
to use any symbols provided by optee-os lib without having to add that library
again.

For example, if one provides its own library libexample.a that use strcmp(),
which is provided by libutils.a, and he want to compile its TA with
libexample.a, he'll add

libdirs += ...
libnames += example

in his TA Makefile

But the linker will not find strcmp() symbol unless he adds utils lib
explicitely:
libnames += utils example
even if it is already specified in ta_dev_kit.mk because the order matter,
unless it uses -start-group / --end-group

Signed-off-by: Pierre Peiffer <ppeiffer@invensense.com>