### PR TITLE
Add Marvell ARMADA A7K A8K platform support

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -151,6 +151,7 @@ build:
     - _make PLATFORM=rockchip-rk322x
     - _make PLATFORM=rockchip-rk322x CFG_TEE_CORE_LOG_LEVEL=4 DEBUG=1
     - _make PLATFORM=sam
+    - _make PLATFORM=marvell-armada7k8k CFG_ARM64_core=y
 
     #
     # Regressions tests (QEMU)

--- a/.travis.yml
+++ b/.travis.yml
@@ -252,6 +252,9 @@ script:
   # Atmel ATSAMA5D2-XULT
   - $make PLATFORM=sam
 
+  # Marvell ARMADA 7K 8K
+  - $make PLATFORM=marvell-armada7k8k CFG_ARM64_core=y
+
   # Run regression tests (xtest in QEMU)
   - (cd ${HOME}/optee_repo/build && $make check CROSS_COMPILE="ccache arm-linux-gnueabihf-" AARCH32_CROSS_COMPILE=arm-linux-gnueabihf- CFG_TEE_CORE_DEBUG=y DUMP_LOGS_ON_ERROR=1)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,8 @@ for these platforms.
 | HiKey Board (HiSilicon Kirin 620)	|`Linaro <op-tee@linaro.org>`|
 | HiKey960 Board (HiSilicon Kirin 960)	|`Linaro <op-tee@linaro.org>`|
 | HiSilicon D02				|`Linaro <op-tee@linaro.org>`|
+| Marvell Armada 70x0		|`Kevin Peng <kevinp@marvell.com>`|
+| Marvell Armada 80x0		|`Kevin Peng <kevinp@marvell.com>`|
 | MediaTek MT8173 EVB Board		|`Linaro <op-tee@linaro.org>`|
 | QEMU					|`Linaro <op-tee@linaro.org>`|
 | Raspberry Pi3				|`Linaro <op-tee@linaro.org>`|

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ platforms have different sub-maintainers, please refer to the file
 | [HiSilicon D02](http://open-estuary.org/d02-2)|`PLATFORM=d02`| No |
 | [HiKey Board (HiSilicon Kirin 620)](https://www.96boards.org/product/hikey)|`PLATFORM=hikey` or `PLATFORM=hikey-hikey`| Yes |
 | [HiKey960 Board (HiSilicon Kirin 960)](https://www.96boards.org/product/hikey960)|`PLATFORM=hikey-hikey960`| Yes |
+| [Marvell ARMADA 7K Family](http://www.marvell.com/embedded-processors/armada-70xx/)|`PLATFORM=marvell-armada7k8k`| No |
+| [Marvell ARMADA 8K Family](http://www.marvell.com/embedded-processors/armada-80xx/)|`PLATFORM=marvell-armada7k8k`| No |
 | [MediaTek MT8173 EVB Board](https://www.mediatek.com/products/tablets/mt8173)|`PLATFORM=mediatek-mt8173`| No |
 | [QEMU](http://wiki.qemu.org/Main_Page) |`PLATFORM=vexpress-qemu_virt`| Yes |
 | [QEMUv8](http://wiki.qemu.org/Main_Page) |`PLATFORM=vexpress-qemu_armv8a`| Yes |

--- a/core/arch/arm/plat-marvell/armada7k8k/hal_sec_perf.c
+++ b/core/arch/arm/plat-marvell/armada7k8k/hal_sec_perf.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2017 Marvell International Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <initcall.h>
+#include <io.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <util.h>
+
+#define PHY_2_VIR(addr)	((vaddr_t)phys_to_virt((addr), MEM_AREA_IO_SEC))
+
+#define MCU_MC_CONTROL_0_REG	PHY_2_VIR(MCU_BASE + 0x044)
+#define TRUSTZONE_LOCK			BIT(31)
+
+#define MCU_TZ_RANGE_HIGH_REG(x)	PHY_2_VIR(MCU_BASE + 0x84 + ((x) << 3))
+#define MCU_TZ_RANGE_LOW_REG(x)		PHY_2_VIR(MCU_BASE + 0x80 + ((x) << 3))
+
+#define RW_PERM	0x0
+#define RO_PERM	0x1
+#define WO_PERM	0x2
+#define ABORT_PERM	0x3
+
+#define MAX_RANGE_NUM   16
+#define INVALID_SIZE_CODE   0xff
+
+#ifdef TEE_RES_CFG_16M
+#define RSVD_SEC_MEM    (SIZE_8M + SIZE_8M)
+#elif defined(TEE_RES_CFG_24M)
+#define RSVD_SEC_MEM    (SIZE_8M + SIZE_8M + SIZE_8M)
+#elif defined(TEE_RES_CFG_8M)
+#define RSVD_SEC_MEM    SIZE_8M
+#else
+#error "no reserved secure memory defined."
+#endif
+
+#define RA_ADDR	TZDRAM_BASE
+#define RA_SIZE	TZDRAM_SIZE
+#define RA_PERM	ABORT_PERM
+
+#define TZ_IS_VALID(data)		((data) & (0x1))
+#define TZ_SET_VALID(data)		((data) |= (0x1))
+
+#define TZ_GET_PERM(data, ret)		((ret) = (((data) & (0x3 << 1)) >> 1))
+#define TZ_SET_PERM(data, val)		\
+	do {	\
+		(data) &= (~(0x3 << 1)); \
+		(data) |= (((val) & 0x3) << 1);	\
+	} while (0)
+
+#define TZ_GET_RZ_EN(data, ret)		((ret) = (((data) & (0x1 << 3)) >> 3))
+#define TZ_SET_RZ_EN(data, val)		\
+	do {	\
+		(data) &= (~(0x1 << 3)); \
+		(data) |= (((val) & 0x1) << 3);	\
+	} while (0)
+
+#define TZ_GET_AREA_LEN_CODE(data, ret)	((ret) = (((data) & (0x1F << 7)) >> 7))
+
+#define TZ_SET_AREA_LEN_CODE(data, val)	\
+	do {	\
+		(data) &= (~(0x1F << 7));	\
+		(data) |= (((val) & 0x1F) << 7);		\
+	} while (0)
+
+#define TZ_GET_START_ADDR_L(data, ret)	\
+	((ret) = (((data) & 0xFFFFF000)))
+
+#define TZ_SET_START_ADDR_L(data, val)		\
+	do {	\
+		(data) &= (~0xFFFFF000);		\
+		(data) |= (((val) & 0xFFFFF000));	\
+	} while (0)
+
+#define TZ_GET_UR_PERM(data, val)	((ret) = (((data) & (0x3 << 4)) >> 4))
+#define TZ_SET_UR_PERM(data, val)	\
+	do {	\
+		(data) &= (~(0x3 << 4)); \
+		(data) |= (((val) & 0x3) << 4);	\
+	} while (0)
+
+#define TZ_GET_UR_RZ_EN(data, val)		\
+	((ret) = (((data) & (0x1 << 6)) >> 6))
+
+#define TZ_SET_UR_RZ_EN(data, val)		\
+	do {	\
+		(data) &= (~(0x1 << 6)); \
+		(data) |= (((val) & 0x1) << 6);	\
+	} while (0)
+
+ /* armada mini region size is 1M */
+#define RANGE_SIZE_TO_CODE(size, code, i)	\
+	do {	\
+		(code) = INVALID_SIZE_CODE;	\
+		for ((i) = 8; (i) <= 0x1f; (i)++) {	   \
+			if (((uint32_t)0x1 << (i)) == ((size) >> 12)) { \
+				(code) = (i);	\
+				break;	\
+			}	\
+		}	\
+	} while (0)
+
+#define RANGE_CODE_TO_SIZE_K(code, sizek)	((sizek) = ((4) << (code)))
+
+#define TZ_LOCK_MC(x)		\
+	do {	\
+		(x) = read32(MCU_MC_CONTROL_0_REG);	\
+		(x) |= (TRUSTZONE_LOCK);	\
+		 write32((x), MCU_MC_CONTROL_0_REG);	\
+	} while (0)
+
+#define _IS_ALIGNED(_addr, _algn)	(!((_addr) & ((_algn) - 1)))
+
+register_phys_mem(MEM_AREA_IO_SEC, MCU_BASE, CORE_MMU_DEVICE_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, MC_SCR_REGISTER, CORE_MMU_DEVICE_SIZE);
+
+static int32_t _find_valid_range(void)
+{
+	uint32_t i;
+	uint32_t tmp;
+
+	for (i = 0; i < MAX_RANGE_NUM; i++) {
+		tmp = read32(MCU_TZ_RANGE_LOW_REG(i));
+		if (!TZ_IS_VALID(tmp))
+			return i;
+	}
+	return -1;
+}
+
+static int32_t set_range(uint32_t addr, uint32_t size, uint32_t perm)
+{
+	uint32_t data;
+	uint32_t sizecode;
+	int32_t valid_range;
+	uint32_t i;
+
+	if (!_IS_ALIGNED(addr, SIZE_1M)) {
+		EMSG("region addr(0x%" PRIx32 ") is not aligned with 1M!",
+			addr);
+		return -1;
+	}
+
+	if (!_IS_ALIGNED(size, SIZE_1M)) {
+		EMSG("region size(0x%" PRIx32 ") is not aligned with 1M!",
+			size);
+		return -1;
+	}
+
+	if (!_IS_ALIGNED(addr, size)) {
+		EMSG("region size(0x%" PRIx32
+			") not align with addr(0x%" PRIx32 ")",
+			size, addr);
+		return -1;
+	}
+
+	RANGE_SIZE_TO_CODE(size, sizecode, i);
+	if (sizecode == INVALID_SIZE_CODE) {
+		EMSG("not valid region size(2^n)! size:0x%" PRIx32, size);
+		return -1;
+	}
+
+	valid_range = _find_valid_range();
+	if (valid_range == -1) {
+		EMSG("ERR: can't find valid range!");
+		return -1;
+	}
+
+	data = read32(MCU_TZ_RANGE_LOW_REG(valid_range));
+
+	TZ_SET_VALID(data);
+	TZ_SET_PERM(data, perm);
+	TZ_SET_AREA_LEN_CODE(data, sizecode);
+	TZ_SET_START_ADDR_L(data, addr);
+
+	if (!valid_range) {
+		/* Set Undefine Range RW */
+		TZ_SET_UR_PERM(data, RW_PERM);
+		TZ_SET_UR_RZ_EN(data, 0);
+	}
+
+	write32(data, MCU_TZ_RANGE_LOW_REG(valid_range));
+
+	return 0;
+}
+
+static void  _dump_range(void)
+{
+	uint32_t i;
+	uint32_t tmp;
+	uint32_t sizek;
+	uint32_t sizecode_read;
+	uint32_t __maybe_unused sizem;
+	uint32_t __maybe_unused addr_read;
+	uint32_t __maybe_unused perm_read;
+
+	for (i = 0; i < MAX_RANGE_NUM; i++) {
+		tmp = read32(MCU_TZ_RANGE_LOW_REG(i));
+
+		if (TZ_IS_VALID(tmp)) {
+			TZ_GET_PERM(tmp, perm_read);
+			TZ_GET_AREA_LEN_CODE(tmp, sizecode_read);
+			TZ_GET_START_ADDR_L(tmp, addr_read);
+
+			DMSG("Range Num%" PRIu32
+				": Reg 0x%" PRIx64 " = 0x%" PRIx32,
+				i, MCU_TZ_RANGE_LOW_REG(i), tmp);
+			DMSG("AddrL: 0x%08" PRIx32, addr_read);
+			RANGE_CODE_TO_SIZE_K(sizecode_read, sizek);
+			sizem = sizek >> 10;
+			DMSG("Size: %" PRIu32 "K, %" PRIu32 "M", sizek, sizem);
+			DMSG("Perm: %" PRIu32, perm_read);
+		}
+	}
+}
+
+static uint32_t _find_granule(uint32_t addr, uint32_t size)
+{
+	/* max supported granule for armada is 8TB
+	 * but 2GB is far enough here
+	 */
+	uint32_t max_granule = SIZE_2G;
+
+	while (max_granule >= SIZE_4K) {	/* min granule is 4kB */
+		if (max_granule <= size && _IS_ALIGNED(addr, max_granule))
+			return max_granule;
+
+		max_granule >>= 1;
+	}
+
+	return 0;	/* cannot find a valid granule */
+}
+
+static void _set_range(uint32_t addr, uint32_t size, uint32_t perm)
+{
+	uint32_t rgn_addr = addr;
+	uint32_t rgn_size = size;
+	uint32_t p;
+
+	while (rgn_size) {
+		p = _find_granule(rgn_addr, rgn_size);
+		if (!p)
+			panic("cannot find a suitable granule!");
+		if (set_range(rgn_addr, p, perm))
+			panic("set_range failed!");
+
+		rgn_addr += p;
+		rgn_size -= p;
+	}
+}
+
+static TEE_Result init_sec_perf(void)
+{
+	uint32_t tmp;
+
+	/* MC_SCR config: deny NS access to MC registers */
+	tmp = read32(PHY_2_VIR(MC_SCR_REGISTER));
+	tmp |= 0x1;
+	write32(tmp, PHY_2_VIR(MC_SCR_REGISTER));
+
+	/* Set Secure Memory Region */
+	DMSG("sec-rgn size: ra = 0x%08" PRIx32 ", size = 0x%" PRIx32,
+		RA_ADDR, RA_SIZE);
+	_set_range(RA_ADDR, RA_SIZE, RA_PERM);
+
+	/* Close TZ register modification */
+	TZ_LOCK_MC(tmp);
+
+	_dump_range();
+
+	return TEE_SUCCESS;
+}
+
+service_init(init_sec_perf);

--- a/core/arch/arm/plat-marvell/conf.mk
+++ b/core/arch/arm/plat-marvell/conf.mk
@@ -1,0 +1,36 @@
+PLATFORM_FLAVOR ?= armada7k8k
+
+# 32-bit flags
+core_arm32-platform-aflags	+= -mfpu=neon
+
+ifeq ($(PLATFORM_FLAVOR),armada7k8k)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+platform-debugger-arm := 1
+endif
+
+ifeq ($(platform-debugger-arm),1)
+# ARM debugger needs this
+platform-cflags-debug-info = -gdwarf-2
+platform-aflags-debug-info = -gdwarf-2
+endif
+
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_GIC,y)
+$(call force,CFG_8250_UART,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_CORE_CLUSTER_SHIFT,1)
+
+ta-targets = ta_arm32
+
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+ta-targets += ta_arm64
+else
+$(call force,CFG_ARM32_core,y)
+endif
+
+CFG_WITH_STACK_CANARIES ?= y
+CFG_WITH_STATS ?= y

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2017 Marvell International Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arm.h>
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/serial8250_uart.h>
+#include <keep.h>
+#include <kernel/generic_boot.h>
+#include <kernel/pm_stubs.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/tee_time.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <string.h>
+#include <tee/entry_fast.h>
+#include <tee/entry_std.h>
+
+static void main_fiq(void);
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry_std,
+	.fast_smc = tee_entry_fast,
+	.nintr = main_fiq,
+	.cpu_on = cpu_on_handler,
+	.cpu_off = pm_do_nothing,
+	.cpu_suspend = pm_do_nothing,
+	.cpu_resume = pm_do_nothing,
+	.system_off = pm_do_nothing,
+	.system_reset = pm_do_nothing,
+};
+
+static struct gic_data gic_data;
+static struct serial8250_uart_data console_data;
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+register_phys_mem(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, CORE_MMU_DEVICE_SIZE);
+
+#ifdef GIC_BASE
+register_phys_mem(MEM_AREA_IO_SEC, GICD_BASE, CORE_MMU_DEVICE_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, GICC_BASE, CORE_MMU_DEVICE_SIZE);
+
+void main_init_gic(void)
+{
+	vaddr_t gicc_base;
+	vaddr_t gicd_base;
+
+	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
+					  MEM_AREA_IO_SEC);
+	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
+					  MEM_AREA_IO_SEC);
+	if (!gicc_base || !gicd_base)
+		panic();
+
+	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+
+	itr_init(&gic_data.chip);
+}
+#endif
+
+static void main_fiq(void)
+{
+	gic_it_handle(&gic_data);
+}
+
+void console_init(void)
+{
+	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+		CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-marvell/platform_config.h
+++ b/core/arch/arm/plat-marvell/platform_config.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2017 Marvell International Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <util.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#ifdef ARM64
+#ifdef CFG_WITH_PAGER
+#error "Pager not supported yet"
+#endif
+#else
+#error "32 bit mode not supported yet"
+#endif /*ARM64*/
+
+/* SDP enable but no pool defined: reserve 4MB for SDP tests */
+#if defined(CFG_SECURE_DATA_PATH) && !defined(CFG_TEE_SDP_MEM_BASE)
+#define CFG_TEE_SDP_MEM_TEST_SIZE	0x00400000
+#else
+#define CFG_TEE_SDP_MEM_TEST_SIZE	0
+#endif
+
+#if defined(PLATFORM_FLAVOR_armada7k8k)
+/*
+ * armada7k8k specifics.
+ */
+#define TEE_RES_CFG_8M
+
+#define MVEBU_REGS_BASE		0xF0000000
+
+/* GICv2 */
+#define MVEBU_GICD_BASE		0x210000
+#define MVEBU_GICC_BASE		0x220000
+#define GIC_DIST_BASE			(MVEBU_REGS_BASE + MVEBU_GICD_BASE)
+#define GIC_CPU_BASE			(MVEBU_REGS_BASE + MVEBU_GICC_BASE)
+
+#define GIC_BASE		GIC_DIST_BASE
+
+/* UART */
+#define PLAT_MARVELL_BOOT_UART_BASE		(MVEBU_REGS_BASE + 0x512000)
+#define PLAT_MARVELL_BOOT_UART_CLK_IN_HZ        200000000
+#define MARVELL_CONSOLE_BAUDRATE                            115200
+
+#define CONSOLE_UART_BASE	PLAT_MARVELL_BOOT_UART_BASE
+
+/* Location of trusted dram */
+#define TZDRAM_BASE		0x04400000
+#define TZDRAM_SIZE		0x00C00000
+
+#define CFG_TEE_CORE_NB_CORE	4
+
+#define CFG_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
+#define CFG_SHMEM_SIZE		0x00400000
+
+#define GICC_OFFSET		0x10000
+#define GICD_OFFSET		0x0
+
+/* MCU */
+#define MCU_BASE			0xF0020000
+#define MCU_REG_SIZE		SIZE_4K
+#define MC_SCR_REGISTER	0xF06F0204
+#define MC_SCR_REG_SIZE	SIZE_4K
+
+#else
+#error "Unknown platform flavor"
+#endif
+
+#define CFG_TEE_RAM_VA_SIZE	SIZE_4M
+
+#ifndef CFG_TEE_LOAD_ADDR
+#define CFG_TEE_LOAD_ADDR	CFG_TEE_RAM_START
+#endif
+
+/*
+ * everything is in TZDRAM.
+ * +------------------+
+ * |        | TEE_RAM |
+ * | TZDRAM +---------+
+ * |        | TA_RAM  |
+ * |        +---------+
+ * |        | SDP RAM | (test pool, optional)
+ * +--------+---------+
+ */
+#define CFG_TEE_RAM_PH_SIZE	CFG_TEE_RAM_VA_SIZE
+#define CFG_TEE_RAM_START	TZDRAM_BASE
+#define CFG_TA_RAM_START	ROUNDUP(TZDRAM_BASE + CFG_TEE_RAM_VA_SIZE, \
+					CORE_MMU_DEVICE_SIZE)
+
+#define CFG_TA_RAM_SIZE		ROUNDDOWN(TZDRAM_SIZE - \
+					  (CFG_TA_RAM_START - TZDRAM_BASE) - \
+					  CFG_TEE_SDP_MEM_TEST_SIZE, \
+					  CORE_MMU_DEVICE_SIZE)
+
+/* Secure data path test memory pool: located at end of TA RAM */
+#if CFG_TEE_SDP_MEM_TEST_SIZE
+#define CFG_TEE_SDP_MEM_SIZE		CFG_TEE_SDP_MEM_TEST_SIZE
+#define CFG_TEE_SDP_MEM_BASE		(TZDRAM_BASE + TZDRAM_SIZE - \
+						CFG_TEE_SDP_MEM_SIZE)
+#endif
+
+#ifdef GIC_BASE
+#define GICD_BASE		(GIC_BASE + GICD_OFFSET)
+#define GICC_BASE			(GIC_BASE + GICC_OFFSET)
+#endif
+
+#define UART_BAUDRATE			MARVELL_CONSOLE_BAUDRATE
+#define CONSOLE_BAUDRATE		UART_BAUDRATE
+#define CONSOLE_UART_CLK_IN_HZ	PLAT_MARVELL_BOOT_UART_CLK_IN_HZ
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-marvell/sub.mk
+++ b/core/arch/arm/plat-marvell/sub.mk
@@ -1,0 +1,5 @@
+global-incdirs-y += .
+srcs-y += main.c
+ifeq ($(PLATFORM_FLAVOR_armada7k8k),y)
+srcs-y += armada7k8k/hal_sec_perf.c
+endif

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -51,12 +51,17 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
+#ifndef ASM
 /* Round up the even multiple of size, size has to be a multiple of 2 */
 #define ROUNDUP(v, size) (((v) + ((__typeof__(v))(size) - 1)) & \
 			  ~((__typeof__(v))(size) - 1))
 
 /* Round down the even multiple of size, size has to be a multiple of 2 */
 #define ROUNDDOWN(v, size) ((v) & ~((__typeof__(v))(size) - 1))
+#else
+#define ROUNDUP(x, y)			((((x) + (y) - 1) / (y)) * (y))
+#define ROUNDDOWN(x, y)		(((x) / (y)) * (y))
+#endif
 
 /* x has to be of an unsigned type */
 #define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & (~(x) + 1)) == (x)))

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -30,6 +30,13 @@
 #include <compiler.h>
 #include <stdint.h>
 
+#define SIZE_4K	UINTPTR_C(0x1000)
+#define SIZE_1M	UINTPTR_C(0x100000)
+#define SIZE_2M	UINTPTR_C(0x200000)
+#define SIZE_4M	UINTPTR_C(0x400000)
+#define SIZE_8M	UINTPTR_C(0x800000)
+#define SIZE_2G	UINTPTR_C(0x80000000)
+
 #ifndef MAX
 #define MAX(a, b) \
 	(__extension__({ __typeof__(a) _a = (a); \


### PR DESCRIPTION
Added Marvell platform with initial support for ARMADA A7K & A8K.

Only tested 64-bit mode with default configurations:
1. build command
    make PLATFORM=marvell-armada7080 CFG_ARM64_core=y
2. Passed xtest

Signed-off-by: Kevin Peng <kevinp@marvell.com>