### PR TITLE
core: imx: fix build errors

### DIFF
--- a/core/arch/arm/plat-imx/imx6.c
+++ b/core/arch/arm/plat-imx/imx6.c
@@ -27,11 +27,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <compiler.h>
 #include <drivers/gic.h>
 #include <io.h>
 #include <kernel/generic_boot.h>
 #include <kernel/misc.h>
 #include <kernel/tz_ssvce_pl310.h>
+#include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <platform_config.h>
 
@@ -40,17 +42,16 @@ register_phys_mem(MEM_AREA_IO_SEC, SRC_BASE, CORE_MMU_DEVICE_SIZE);
 void plat_cpu_reset_late(void)
 {
 	uintptr_t addr;
+	uint32_t pa __maybe_unused;
 
 	if (!get_core_pos()) {
 		/* primary core */
 #if defined(CFG_BOOT_SYNC_CPU)
+		pa = virt_to_phys((void *)TEE_TEXT_VA_START);
 		/* set secondary entry address and release core */
-		write32(virt_to_phys(TEE_TEXT_VA_START),
-			SRC_BASE + SRC_GPR1 + 8);
-		write32(virt_to_phys(TEE_TEXT_VA_START),
-			SRC_BASE + SRC_GPR1 + 16);
-		write32(virt_to_phys(TEE_TEXT_VA_START),
-			SRC_BASE + SRC_GPR1 + 24);
+		write32(pa, SRC_BASE + SRC_GPR1 + 8);
+		write32(pa, SRC_BASE + SRC_GPR1 + 16);
+		write32(pa, SRC_BASE + SRC_GPR1 + 24);
 
 		write32(SRC_SCR_CPU_ENABLE_ALL, SRC_BASE + SRC_SCR);
 #endif

--- a/core/arch/arm/plat-imx/psci.c
+++ b/core/arch/arm/plat-imx/psci.c
@@ -60,9 +60,9 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	/* set secondary cores' NS entry addresses */
 	ns_entry_addrs[core_idx] = entry;
 
+	val = virt_to_phys((void *)TEE_TEXT_VA_START);
 	if (soc_is_imx7ds()) {
-		write32((uint32_t)virt_to_phys(TEE_TEXT_VA_START),
-			va + SRC_GPR1_MX7 + core_idx * 8);
+		write32(val, va + SRC_GPR1_MX7 + core_idx * 8);
 
 		imx_gpcv2_set_core1_pup_by_software();
 
@@ -76,8 +76,7 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	}
 
 	/* boot secondary cores from OP-TEE load address */
-	write32((uint32_t)virt_to_phys(TEE_TEXT_VA_START),
-		va + SRC_GPR1 + core_idx * 8);
+	write32(val, va + SRC_GPR1 + core_idx * 8);
 
 	/* release secondary core */
 	val = read32(va + SRC_SCR);


### PR DESCRIPTION
Fix build errors in plat-imc/imx6.c and plat-imx/psci.c

Fixes: 6a815afa16230 ("core: introduce TEE_RAM_VA_START and TEE_TEXT_VA_START")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>