### PR TITLE
TEMP: plat-ti: Disable TRNG use on AM43xx

### DIFF
--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -9,6 +9,7 @@ $(call force,CFG_ARM32_core,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_PM_STUBS,y)
 ifeq ($(PLATFORM_FLAVOR),am43xx)
+CFG_WITH_SOFTWARE_PRNG = y
 $(call force,CFG_NO_SMP,y)
 $(call force,CFG_PL310,y)
 $(call force,CFG_PL310_LOCKED,y)


### PR DESCRIPTION
On AM43xx family devices the non-secure side may IDLE hardware IP
that are not in use. This will prevent the correct operation of these
IP on the secure side. Until a solution to share management of IPs is
developed, disable the secure driver for this platform.

Signed-off-by: Andrew F. Davis <afd@ti.com>