### PR TITLE
core: introduce get_core_pos_mpidr()

### DIFF
--- a/core/arch/arm/include/kernel/misc.h
+++ b/core/arch/arm/include/kernel/misc.h
@@ -33,6 +33,7 @@
 #include <kernel/thread.h>
 
 size_t get_core_pos(void);
+size_t get_core_pos_mpidr(uint32_t mpidr);
 
 uint32_t read_mode_sp(int cpu_mode);
 uint32_t read_mode_lr(int cpu_mode);

--- a/core/arch/arm/kernel/misc_a32.S
+++ b/core/arch/arm/kernel/misc_a32.S
@@ -31,18 +31,26 @@
 #include <kernel/unwind.h>
 
 /* Let platforms override this if needed */
-.weak get_core_pos
+.weak get_core_pos_mpidr
 
+/* size_t get_core_pos(void); */
 FUNC get_core_pos , :
 UNWIND(	.fnstart)
 	read_mpidr r0
+	b get_core_pos_mpidr
+UNWIND(	.fnend)
+END_FUNC get_core_pos
+
+/* size_t get_core_pos_mpidr(uint32_t mpidr); */
+FUNC get_core_pos_mpidr , :
+UNWIND(	.fnstart)
 	/* Calculate CorePos = (ClusterId * 4) + CoreId */
 	and	r1, r0, #MPIDR_CPU_MASK
 	and	r0, r0, #MPIDR_CLUSTER_MASK
 	add	r0, r1, r0, LSR #6
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC get_core_pos
+END_FUNC get_core_pos_mpidr
 
 /*
  * uint32_t temp_set_mode(int cpu_mode)

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -29,13 +29,19 @@
 #include <arm.h>
 
 /* Let platforms override this if needed */
-.weak get_core_pos
+.weak get_core_pos_mpidr
 
+/* size_t get_core_pos(void); */
 FUNC get_core_pos , :
 	mrs	x0, mpidr_el1
+	b get_core_pos_mpidr
+END_FUNC get_core_pos
+
+/* size_t get_core_pos_mpidr(uint32_t mpidr); */
+FUNC get_core_pos_mpidr , :
 	/* Calculate CorePos = (ClusterId * 4) + CoreId */
 	and	x1, x0, #MPIDR_CPU_MASK
 	and	x0, x0, #MPIDR_CLUSTER_MASK
 	add	x0, x1, x0, LSR #6
 	ret
-END_FUNC get_core_pos
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-ls/ls_core_pos_a32.S
+++ b/core/arch/arm/plat-ls/ls_core_pos_a32.S
@@ -31,11 +31,10 @@
 #include <kernel/unwind.h>
 
 /* Layerscape platform specific function to calculate core position. */
-FUNC get_core_pos , :
+FUNC get_core_pos_mpidr , :
 UNWIND(	.fnstart)
-	read_mpidr r0
 	/* Calculate CorePos =  CoreId */
 	and	r0, r0, #MPIDR_CPU_MASK
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC get_core_pos
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-ls/ls_core_pos_a64.S
+++ b/core/arch/arm/plat-ls/ls_core_pos_a64.S
@@ -29,8 +29,7 @@
 #include <arm.h>
 
 /* Layerscape platform specific function to calculate core position. */
-FUNC get_core_pos , :
-	mrs	x0, mpidr_el1
+FUNC get_core_pos_mpidr , :
 	and	x0, x0, #MPIDR_CPU_MASK
 	ret
-END_FUNC get_core_pos
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-mediatek/mt8173_core_pos_a32.S
+++ b/core/arch/arm/plat-mediatek/mt8173_core_pos_a32.S
@@ -30,9 +30,8 @@
 #include <arm32_macros.S>
 #include <kernel/unwind.h>
 
-FUNC get_core_pos , :
+FUNC get_core_pos_mpidr , :
 UNWIND(	.fnstart)
-	read_mpidr r0
 	and	r1, r0, #MPIDR_CPU_MASK
 	and	r0, r0, #MPIDR_CLUSTER_MASK
 	/*
@@ -47,5 +46,4 @@ UNWIND(	.fnstart)
 	add	r0, r1, r0, LSR #7
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC get_core_pos
-
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-mediatek/mt8173_core_pos_a64.S
+++ b/core/arch/arm/plat-mediatek/mt8173_core_pos_a64.S
@@ -28,8 +28,7 @@
 #include <asm.S>
 #include <arm.h>
 
-FUNC get_core_pos , :
-	mrs	x0, mpidr_el1
+FUNC get_core_pos_mpidr , :
 	and	x1, x0, #MPIDR_CPU_MASK
 	and	x0, x0, #MPIDR_CLUSTER_MASK
 	/*
@@ -43,5 +42,5 @@ FUNC get_core_pos , :
 	 */
 	add	x0, x1, x0, LSR #7
 	ret
-END_FUNC get_core_pos
+END_FUNC get_core_pos_mpidr
 

--- a/core/arch/arm/plat-rockchip/core_pos_a32.S
+++ b/core/arch/arm/plat-rockchip/core_pos_a32.S
@@ -30,15 +30,14 @@
 #include <arm32_macros.S>
 #include <kernel/unwind.h>
 
-FUNC get_core_pos , :
+FUNC get_core_pos_mpidr , :
 UNWIND( .fnstart)
 	/*
 	 * Because mpidr is designed mistake in hardware, ie. core0 is 0xf00,
 	 * core1 is 0xf01..., so we need implement the function to correct this.
 	 */
-	read_mpidr r0
 	and	r0, r0, #MPIDR_CPU_MASK
 	bx	lr
 UNWIND( .fnend)
-END_FUNC get_core_pos
+END_FUNC get_core_pos_mpidr
 

--- a/core/arch/arm/plat-vexpress/juno_core_pos_a32.S
+++ b/core/arch/arm/plat-vexpress/juno_core_pos_a32.S
@@ -31,9 +31,8 @@
 #include <kernel/unwind.h>
 
 /* For Juno number the two A57s as 4 to 5 and A53s as 0 to 3 */
-FUNC get_core_pos , :
+FUNC get_core_pos_mpidr , :
 UNWIND(	.fnstart)
-	read_mpidr r0
 	/* Calculate CorePos = ((ClusterId ^ 1) * 4) + CoreId */
 	and	r1, r0, #MPIDR_CPU_MASK
 	and	r0, r0, #MPIDR_CLUSTER_MASK
@@ -41,5 +40,5 @@ UNWIND(	.fnstart)
 	add	r0, r1, r0, LSR #6
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC get_core_pos
+END_FUNC get_core_pos_mpidr
 

--- a/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
+++ b/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
@@ -29,14 +29,11 @@
 #include <arm.h>
 
 /* For Juno number the two A57s as 4 to 5 and A53s as 0 to 3 */
-FUNC get_core_pos , :
-	mrs	x0, mpidr_el1
+FUNC get_core_pos_mpidr , :
 	/* Calculate CorePos = ((ClusterId ^ 1) * 4) + CoreId */
 	and	x1, x0, #MPIDR_CPU_MASK
 	and	x0, x0, #MPIDR_CLUSTER_MASK
 	eor	x0, x0, #(1 << MPIDR_CLUSTER_SHIFT)
 	add	x0, x1, x0, LSR #6
 	ret
-END_FUNC get_core_pos
-
-
+END_FUNC get_core_pos_mpidr


### PR DESCRIPTION
Adds
size_t get_core_pos_mpidr(uint32_t mpidr);
which translates from mpdir to core position, like get_core_pos() does
for the calling core.

get_core_pos_mpidr() a weak function to
allow platforms to override the implementation.

get_core_pos() now uses get_core_pos_mpidr() internally to calculate the
core position without using any stack.

With get_core_pos_mpidr() all the platform specific implementations of
get_core_pos() has been replaced with get_core_pos_mpidr() and
get_core_pos() is not weak any longer to avoid unexpected runtime errors
in out of tree rebased platforms.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU v8)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>