### PR TITLE
benchmark: use arm generic timers as time/tick source

### DIFF
--- a/core/arch/arm/pta/benchmark.c
+++ b/core/arch/arm/pta/benchmark.c
@@ -45,18 +45,24 @@ struct tee_ts_global *bench_ts_global;
 static struct mutex bench_reg_mu = MUTEX_INITIALIZER;
 static uint32_t prev_cntkctl;
 
-static void timer_enable_el0_access(void)
+static void timer_set_access(uint32_t cntkctl)
 {
-	uint32_t cntkctl;
-
-	prev_cntkctl = read_cntkctl();
-	cntkctl = prev_cntkctl | CNTKCTL_PL0VCTEN;
 	write_cntkctl(cntkctl);
 }
 
-static void timer_disable_el0_access(void)
+static uint32_t timer_get_access(void)
 {
-	write_cntkctl(prev_cntkctl);
+	return read_cntkctl();
+}
+
+static uint32_t timer_enable_el0_access(void)
+{
+	uint32_t cntkctl;
+
+	cntkctl = timer_get_access();
+	timer_set_access(cntkctl | CNTKCTL_PL0VCTEN);
+
+	return cntkctl;
 }
 
 static TEE_Result rpc_reg_global_buf(uint64_t type, paddr_t phta, size_t size)
@@ -102,7 +108,7 @@ static TEE_Result register_benchmark_memref(uint32_t type,
 	}
 
 	DMSG("Enabling EL0 access to CNTVCT\n");
-	timer_enable_el0_access();
+	prev_cntkctl = timer_enable_el0_access();
 
 	DMSG("Registering timestamp buffer, addr = %p, paddr = %" PRIxPA "\n",
 			p[0].memref.buffer,
@@ -174,7 +180,7 @@ static TEE_Result unregister_benchmark(uint32_t type,
 
 	res = rpc_reg_global_buf(OPTEE_MSG_RPC_CMD_BENCH_REG_DEL, 0, 0);
 
-	timer_disable_el0_access();
+	timer_set_access(prev_cntkctl);
 
 	return res;
 }

--- a/core/arch/arm/pta/benchmark.c
+++ b/core/arch/arm/pta/benchmark.c
@@ -92,8 +92,6 @@ static TEE_Result register_benchmark_memref(uint32_t type,
 	if (!tee_vbuf_is_non_sec(p[0].memref.buffer, p[0].memref.size))
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	timer_enable_el0_access();
-
 	mutex_lock(&bench_reg_mu);
 
 	/* Check if we have already registered buffer */
@@ -102,6 +100,9 @@ static TEE_Result register_benchmark_memref(uint32_t type,
 		mutex_unlock(&bench_reg_mu);
 		return TEE_ERROR_BAD_STATE;
 	}
+
+	DMSG("Enabling EL0 access to CNTVCT\n");
+	timer_enable_el0_access();
 
 	DMSG("Registering timestamp buffer, addr = %p, paddr = %" PRIxPA "\n",
 			p[0].memref.buffer,

--- a/core/include/bench.h
+++ b/core/include/bench.h
@@ -33,14 +33,8 @@
 #include <mm/core_mmu.h>
 #include <optee_msg.h>
 
-/*
- * Cycle count divider is enabled (in PMCR),
- * CCNT value is incremented every 64th clock cycle
- */
-#define TEE_BENCH_DIVIDER		64
-
 /* Max amount of timestamps per buffer */
-#define TEE_BENCH_MAX_STAMPS	32
+#define TEE_BENCH_MAX_STAMPS	128
 #define TEE_BENCH_MAX_MASK		(TEE_BENCH_MAX_STAMPS - 1)
 
 #define OPTEE_MSG_RPC_CMD_BENCH_REG_NEW		0
@@ -70,6 +64,7 @@ struct tee_ts_cpu_buf {
 /* memory layout for shared memory, where timestamps will be stored */
 struct tee_ts_global {
 	uint64_t cores;
+	uint64_t freq;
 	struct tee_ts_cpu_buf cpu_buf[];
 };
 


### PR DESCRIPTION
Switching to ARM Generic timers solves these problems:
1. Avoid any collisions with linux kernel perf subsystem when using PMU
as a tick source. Although perf subystem has a kernel
API(perf_event_create_kernel_counter etc.), unfortunately it doesn't
have any capabilites to enable EL0 access to cycle counter on
armv7/armv8 architectures (only for x86 platforms, where it's possible
to set bit which permits executing rdtsc from usermode)
2. Avoid any conditions, when frequency scaling occurs (moslty different
power states), or core is in wait-for-interrupt/wait-for-events states
(PMU doesn't count CPU cycles in these states).
3. Common tick source for all cores with fixed frequency

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`