### PR TITLE
ci: .shippable.yml: fix _make function

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -14,7 +14,7 @@ build:
     - export CROSS_COMPILE32="ccache arm-linux-gnueabihf-"
     - export CROSS_COMPILE64="ccache aarch64-linux-gnu-"
     - export CCACHE_DIR=${SHIPPABLE_BUILD_DIR}/.ccache
-    - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s $*; ccache -s; ccache -z; }
+    - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s $* && ccache -s && ccache -z; }
     - ccache -z
 
     #


### PR DESCRIPTION
The _make function is supposed to return an error status in case make
fails. For this to happen, we need to use && between commands, not ;.

Fixes: 5da449eaf73b ("ci: add .shippable.yml")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>