### PR TITLE
ci: .shippable.yml: fix commit range

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -44,7 +44,7 @@ build:
         checkpatch HEAD || export checkpatch_failed=1;
       else
         echo "Running checkpatch on each patch in pull request:";
-        for c in $(git rev-list --reverse ${SHIPPABLE_COMMIT_RANGE}); do
+        for c in $(git rev-list --reverse $(echo ${SHIPPABLE_COMMIT_RANGE} | sed 's/\.\.\./../')); do
           checkpatch $c || export checkpatch_failed=1;
         done;
       fi;


### PR DESCRIPTION
```
When building a pull request, we want to run checkpatch on each commit
included in the pull request. Unfortunately, it is not what the current
code does, because $SHIPPABLE_COMMIT_RANGE contains a three-dot
notation such as: <commit>...<commit>. This syntax is interpreted
differently depending on the git command that parses it.

Quoting git help diff:

  git diff [--options] <commit> <commit> [--] [<path>...]
      This is to view the changes between two arbitrary <commit>.

  git diff [--options] <commit>..<commit> [--] [<path>...]
      This is synonymous to the previous form.

  git diff [--options] <commit>...<commit> [--] [<path>...]
      This form is to view the changes on the branch containing and up
      to the second <commit>, starting at a common ancestor of both
      <commit>.

Quoting git help revisions (documents the format used by git log or
git rev-list):

   <rev1>..<rev2>
       Include commits that are reachable from <rev2> but exclude those
       that are reachable from <rev1>.

   <rev1>...<rev2>
       Include commits that are reachable from either <rev1> or <rev2>
       but exclude those that are reachable from both.

In other words, three dots for git diff is like two dots for git log or
git rev-list. What we need to use with git rev-list is the two dot
notation.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```