### PR TITLE
core: fix core_mmu_map_pages()

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1337,6 +1337,13 @@ TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 		vaddr += SMALL_PAGE_SIZE;
 	}
 
+	/*
+	 * Make sure all the changes to translation tables are visible
+	 * before returning. TLB doesn't need to be invalidated as we are
+	 * guaranteed that there's no valid mapping in this range.
+	 */
+	dsb_ishst();
+
 	return TEE_SUCCESS;
 err:
 	if (i)


### PR DESCRIPTION
Adds missing dsb_ishst() at the end of core_mmu_map_pages() needed to
guarantee that changes to translation tables are visible.

Reported-by: Stuart Yoder <stuart.yoder@arm.com>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>