### PR TITLE
Explicitly number positional argument specifiers

### DIFF
--- a/scripts/gen_ld_sects.py
+++ b/scripts/gen_ld_sects.py
@@ -30,7 +30,7 @@ import sys
 import re
 
 def usage():
-	print "Usage: {} <section reg exp match> [<skip section>...]".format( \
+	print "Usage: {0} <section reg exp match> [<skip section>...]".format( \
 		sys.argv[0])
 	sys.exit (1)
 
@@ -77,7 +77,7 @@ def main():
 		if sect_name in skip_sections :
 			continue
 
-		print '\t*({})'.format(sect_name)
+		print '\t*({0})'.format(sect_name)
 
 if __name__ == "__main__":
         main()


### PR DESCRIPTION

Before Python 2.7 omitting the positional argument specifier was not
allowed. Some may still be using earlier Python version where this
will cause build to fail. Fix this here.

Fixes: 5976a0a5b9bf ("core: avoid incremental linking with -gc")
Reported-by: Nishanth Menon <nm@ti.com>
Signed-off-by: Andrew F. Davis <afd@ti.com>