### PR TITLE
plat-stm: support registered shm buffers

### DIFF
--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -48,6 +48,13 @@ register_phys_mem(MEM_AREA_IO_SEC, CPU_IOMEM_BASE, CPU_IOMEM_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, RNG_BASE, RNG_SIZE);
 register_phys_mem(MEM_AREA_IO_NSEC, UART_CONSOLE_BASE, STIH_ASC_REG_SIZE);
 
+#ifdef DRAM0_BASE
+register_nsec_ddr(DRAM0_BASE, DRAM0_SIZE);
+#endif
+#ifdef DRAM1_BASE
+register_nsec_ddr(DRAM1_BASE, DRAM1_SIZE);
+#endif
+
 static struct gic_data gic_data;
 static struct stih_asc_pd console_data;
 

--- a/core/arch/arm/plat-stm/platform_config.h
+++ b/core/arch/arm/plat-stm/platform_config.h
@@ -46,6 +46,17 @@
 #define CFG_CORE_TZSRAM_EMUL_START	0x7FE00000
 #endif
 
+#ifdef CFG_DDR_SECURE_BASE
+/* Non-secure external RAM: DDR eventually split in 2 by TZ reserved DDR */
+#define DRAM0_BASE		CFG_DDR_START
+#define DRAM0_SIZE		(CFG_DDR_SECURE_BASE - CFG_DDR_START)
+#if ((CFG_DDR_SECURE_BASE + CFG_DDR_SECURE_SIZE) < 0x80000000ULL)
+#define DRAM1_BASE		(CFG_DDR_SECURE_BASE + CFG_DDR_SECURE_SIZE)
+#define DRAM1_SIZE		(CFG_DDR_START + CFG_DDR_SIZE - DRAM1_BASE)
+#endif
+#endif
+
+/* IOmem */
 #define CPU_IOMEM_BASE		0x08760000
 #define CPU_IOMEM_SIZE		0x000a0000
 #define CPU_PORT_FILT_START	0x40000000
@@ -73,6 +84,20 @@
 #define CFG_CORE_TZSRAM_EMUL_START	0x94a00000
 #endif
 
+#ifdef CFG_DDR_SECURE_BASE
+/*
+ * Non-secure external RAM: DDR eventually split in 2 by TZ reserved DDR.
+ * The 32 first MBytes of the DDR are not eligible to REE/TEE SHM.
+ */
+#define DRAM0_BASE		(CFG_DDR_START + 0x02000000)
+#define DRAM0_SIZE		(CFG_DDR_SECURE_BASE - CFG_DDR_START)
+#if ((CFG_DDR_SECURE_BASE + CFG_DDR_SECURE_SIZE) < 0x80000000ULL)
+#define DRAM1_BASE		(CFG_DDR_SECURE_BASE + CFG_DDR_SECURE_SIZE)
+#define DRAM1_SIZE		(CFG_DDR_START + CFG_DDR_SIZE - DRAM1_BASE)
+#endif
+#endif
+
+/* IOmem */
 #define CPU_IOMEM_BASE		0x08760000
 #define CPU_IOMEM_SIZE		0x000a0000
 #define CPU_PORT_FILT_START	0x40000000
@@ -315,14 +340,6 @@
 #define CFG_TA_RAM_SIZE		(TZDRAM_SIZE - CFG_TEE_RAM_PH_SIZE)
 
 #endif /* !CFG_WITH_PAGER */
-
-/* External DDR dies */
-#define DRAM0_BASE		CFG_DDR_START
-#define DRAM0_SIZE		CFG_DDR_SIZE
-#ifdef CFG_DDR1_START
-#define DRAM1_BASE		CFG_DDR1_START
-#define DRAM1_SIZE		CFG_DDR1_SIZE
-#endif
 
 #ifndef CFG_TEE_RAM_VA_SIZE
 #define CFG_TEE_RAM_VA_SIZE	(1024 * 1024)


### PR DESCRIPTION
CFG_DDR_SECURE_BASE/_SIZE can be used to define the extact DDR range
reserved to secure side. This can be larger than the TEETZ reserved
memory. If CFG_DDR_SECURE_BASE/_SIZE is defined, plat-stm registers
the non-secure external memory to support dynamic shm registering.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>