### PR TITLE
Fixes for core_mmu_divide_block() on 32bit mmu

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -328,10 +328,11 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
  * core_mmu_divide_block() - divide larger block/section into smaller ones
  * @tbl_info:	table where target record located
  * @idx:	index of record
+ * @secure:	true/false if pgdir maps secure/non-secure memory (32bit mmu)
  * @return true if function was able to divide block, false on error
  */
 bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
-			   unsigned int idx);
+			   unsigned int idx, bool secure);
 
 void core_mmu_set_entry_primitive(void *table, size_t level, size_t idx,
 				  paddr_t pa, uint32_t attr);

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -325,14 +325,15 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 		struct core_mmu_table_info *tbl_info);
 
 /*
- * core_mmu_divide_block() - divide larger block/section into smaller ones
+ * core_mmu_prepare_small_page_mapping() - prepare target small page parent
+ *	pgdir so that each of its entry can be used to map a page.
  * @tbl_info:	table where target record located
- * @idx:	index of record
+ * @idx:	index of record for which a pdgir must be setup.
  * @secure:	true/false if pgdir maps secure/non-secure memory (32bit mmu)
- * @return true if function was able to divide block, false on error
+ * @return true on successful, false on error
  */
-bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
-			   unsigned int idx, bool secure);
+bool core_mmu_prepare_small_page_mapping(struct core_mmu_table_info *tbl_info,
+					 unsigned int idx, bool secure);
 
 void core_mmu_set_entry_primitive(void *table, size_t level, size_t idx,
 				  paddr_t pa, uint32_t attr);

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1327,7 +1327,8 @@ TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 				break;
 
 			/* This is supertable. Need to divide it. */
-			if (!core_mmu_divide_block(&tbl_info, idx, secure))
+			if (!core_mmu_prepare_small_page_mapping(&tbl_info, idx,
+								 secure))
 				panic("Failed to spread pgdir on small tables");
 		}
 

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1296,8 +1296,11 @@ TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 	uint32_t old_attr;
 	vaddr_t vaddr = vstart;
 	size_t i;
+	bool secure;
 
 	assert(!(core_mmu_type_to_attr(memtype) & TEE_MATTR_PX));
+
+	secure = core_mmu_type_to_attr(memtype) & TEE_MATTR_SECURE;
 
 	if (vaddr & SMALL_PAGE_MASK)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -1324,8 +1327,8 @@ TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 				break;
 
 			/* This is supertable. Need to divide it. */
-			if (!core_mmu_divide_block(&tbl_info, idx))
-				panic("Could not divide block into smaller tables");
+			if (!core_mmu_divide_block(&tbl_info, idx, secure))
+				panic("Failed to spread pgdir on small tables");
 		}
 
 		core_mmu_get_entry(&tbl_info, idx, NULL, &old_attr);

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -653,8 +653,8 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 	}
 }
 
-bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
-			   unsigned int idx, bool __unused secure)
+bool core_mmu_prepare_small_page_mapping(struct core_mmu_table_info *tbl_info,
+					 unsigned int idx, bool __unused secure)
 {
 	uint64_t *new_table;
 	uint64_t *entry;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -654,7 +654,7 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 }
 
 bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
-			   unsigned int idx)
+			   unsigned int idx, bool __unused secure)
 {
 	uint64_t *new_table;
 	uint64_t *entry;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -679,6 +679,8 @@ bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
 		return false;
 
 	new_table = xlat_tables[next_xlat++];
+	if (next_xlat > MAX_XLAT_TABLES)
+		panic("running out of xlat tables");
 	memset(new_table, 0, XLAT_TABLE_SIZE);
 
 	*entry = TABLE_DESC | (uint64_t)(uintptr_t)new_table;

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -514,10 +514,7 @@ bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
 	uint32_t *new_table;
 	uint32_t *entry;
 	uint32_t new_table_desc;
-	paddr_t paddr;
 	uint32_t attr;
-	int i;
-	bool flush_tlb;
 
 	if (tbl_info->level != 1)
 		return false;
@@ -526,41 +523,30 @@ bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
 		return false;
 
 	entry = (uint32_t *)tbl_info->table + idx;
-	assert(!*entry || get_desc_type(1, *entry) == DESC_TYPE_SECTION);
-
-	/* We need to flush TLBs only if there already was some mapping */
-	flush_tlb = *entry;
-
-	/* store attributes of original block */
-	attr = desc_to_mattr(1, *entry);
-	if (attr && secure != (attr & TEE_MATTR_SECURE))
+	if (*entry && get_desc_type(1, *entry) != DESC_TYPE_SECTION)
 		return false;
-	if (!attr && secure)
-		attr = TEE_MATTR_SECURE;
 
-	paddr = *entry & ~SECTION_MASK;
+	attr = desc_to_mattr(1, *entry);
+
+	if (attr) {
+		/* If pgdir maps something, check the secure attribute fits */
+		return secure == (attr & TEE_MATTR_SECURE);
+	}
+
+	if (secure)
+		attr = TEE_MATTR_SECURE;
 
 	new_table = core_mmu_alloc_l2(NUM_L2_ENTRIES * SMALL_PAGE_SIZE);
 	if (!new_table)
 		return false;
 
 	new_table_desc = SECTION_PT_PT | (uint32_t)new_table;
-	if (!(attr & TEE_MATTR_SECURE))
+	if (!secure)
 		new_table_desc |= SECTION_PT_NOTSECURE;
-
-	/* Fill new xlat table with entries pointing to the same memory */
-	for (i = 0; i < NUM_L2_ENTRIES; i++) {
-		*new_table = paddr | mattr_to_desc(tbl_info->level + 1, attr);
-		paddr += SMALL_PAGE_SIZE;
-		new_table++;
-	}
 
 	/* Update descriptor at current level */
 	*entry = new_table_desc;
 
-	/* TODO: only invalidate entries touched above */
-	if (flush_tlb)
-		tlbi_all();
 	return true;
 }
 

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -508,8 +508,8 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 	return true;
 }
 
-bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
-			   unsigned int idx, bool secure)
+bool core_mmu_prepare_small_page_mapping(struct core_mmu_table_info *tbl_info,
+					 unsigned int idx, bool secure)
 {
 	uint32_t *new_table;
 	uint32_t *entry;

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -525,23 +525,23 @@ bool core_mmu_divide_block(struct core_mmu_table_info *tbl_info,
 	if (idx >= NUM_L1_ENTRIES)
 		return false;
 
-	new_table = core_mmu_alloc_l2(NUM_L2_ENTRIES * SMALL_PAGE_SIZE);
-	if (!new_table)
-		return false;
-
 	entry = (uint32_t *)tbl_info->table + idx;
 	assert(!*entry || get_desc_type(1, *entry) == DESC_TYPE_SECTION);
 
 	/* We need to flush TLBs only if there already was some mapping */
 	flush_tlb = *entry;
 
-	new_table_desc = SECTION_PT_PT | (uint32_t)new_table;
-	if (*entry & SECTION_NOTSECURE)
-		new_table_desc |= SECTION_PT_NOTSECURE;
-
 	/* store attributes of original block */
 	attr = desc_to_mattr(1, *entry);
 	paddr = *entry & ~SECTION_MASK;
+
+	new_table = core_mmu_alloc_l2(NUM_L2_ENTRIES * SMALL_PAGE_SIZE);
+	if (!new_table)
+		return false;
+
+	new_table_desc = SECTION_PT_PT | (uint32_t)new_table;
+	if (*entry & SECTION_NOTSECURE)
+		new_table_desc |= SECTION_PT_NOTSECURE;
 
 	/* Fill new xlat table with entries pointing to the same memory */
 	for (i = 0; i < NUM_L2_ENTRIES; i++) {


### PR DESCRIPTION
Main issue fixed here is that 32bit mmu maps dynamic shm as secure due to an issue in the `core_mmu_divide_block()` function.

This change also proposes some simplifications in `core_mmu_divide_block()` since it is currently not used to unmap already mapped memory.