### PR TITLE
Dump call stack on TA panic

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -128,6 +128,7 @@ endif
 ifeq ($(CFG_UNWIND),y)
 ta_arm32-platform-cflags += -funwind-tables
 endif
+ta_arm32-platform-aflags += $(platform-aflags-generic)
 ta_arm32-platform-aflags += $(platform-aflags-debug-info)
 ta_arm32-platform-aflags += $(arm32-platform-aflags)
 
@@ -156,6 +157,7 @@ ta_arm64-platform-cflags += $(arm64-platform-cflags-hard-float)
 else
 ta_arm64-platform-cflags += $(arm64-platform-cflags-no-hard-float)
 endif
+ta_arm64-platform-aflags += $(platform-aflags-generic)
 ta_arm64-platform-aflags += $(platform-aflags-debug-info)
 ta_arm64-platform-aflags += $(arm64-platform-aflags)
 

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -247,9 +247,22 @@ __print_abort_info(struct abort_info *ai __maybe_unused,
 #endif /*ARM32*/
 
 	EMSG_RAW("");
-	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s",
-		ctx, abort_type_to_str(ai->abort_type), ai->va,
-		fault_to_str(ai->abort_type, ai->fault_descr));
+#if defined(CFG_TEE_PANIC_DEBUG_ADDR)
+	if (ai->va == CFG_TEE_PANIC_DEBUG_ADDR) {
+		/*
+		 * This special (unmapped) address is used in libutee to
+		 * cause an abort so that we can obtain a full call stack on
+		 * TEE_Panic(). At this point, ai->r0 contains the panic code.
+		 */
+		EMSG_RAW("%s TEE_Panic()", ctx);
+	} else {
+#endif
+		EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s",
+			 ctx, abort_type_to_str(ai->abort_type), ai->va,
+			 fault_to_str(ai->abort_type, ai->fault_descr));
+#if defined(CFG_TEE_PANIC_DEBUG_ADDR)
+	}
+#endif
 #ifdef ARM32
 	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x  ttbr1 0x%08x  cidr 0x%X",
 		 ai->fault_descr, read_ttbr0(), read_ttbr1(),
@@ -426,9 +439,14 @@ static void handle_user_ta_panic(struct abort_info *ai)
 	 * It was a user exception, stop user execution and return
 	 * to TEE Core.
 	 */
+#ifdef CFG_TEE_PANIC_DEBUG_ADDR
+	ai->regs->r2 = ai->va == CFG_TEE_PANIC_DEBUG_ADDR ? ai->regs->r0
+							  : 0xdeadbeef;
+#else
+	ai->regs->r2 = 0xdeadbeef;
+#endif
 	ai->regs->r0 = TEE_ERROR_TARGET_DEAD;
 	ai->regs->r1 = true;
-	ai->regs->r2 = 0xdeadbeef;
 	ai->regs->elr = (uint32_t)thread_unwind_user_mode;
 	ai->regs->spsr &= CPSR_FIA;
 	ai->regs->spsr &= ~CPSR_MODE_MASK;
@@ -664,7 +682,10 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 	case FAULT_TYPE_IGNORE:
 		break;
 	case FAULT_TYPE_USER_TA_PANIC:
-		DMSG("[abort] abort in User mode (TA will panic)");
+#ifdef CFG_TEE_PANIC_DEBUG_ADDR
+		if (ai.va != CFG_TEE_PANIC_DEBUG_ADDR)
+#endif
+			DMSG("[abort] abort in User mode (TA will panic)");
 		abort_print_error(&ai);
 		vfp_disable();
 		handle_user_ta_panic(&ai);

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -468,9 +468,14 @@ static void handle_user_ta_panic(struct abort_info *ai)
 	 * It was a user exception, stop user execution and return
 	 * to TEE Core.
 	 */
+#ifdef CFG_TEE_PANIC_DEBUG_ADDR
+	ai->regs->x2 = ai->va == CFG_TEE_PANIC_DEBUG_ADDR ? ai->regs->x0
+							  : 0xdeadbeef;
+#else
+	ai->regs->x2 = 0xdeadbeef;
+#endif
 	ai->regs->x0 = TEE_ERROR_TARGET_DEAD;
 	ai->regs->x1 = true;
-	ai->regs->x2 = 0xdeadbeef;
 	ai->regs->elr = (vaddr_t)thread_unwind_user_mode;
 	ai->regs->sp_el0 = thread_get_saved_thread_sp();
 

--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -33,9 +33,6 @@
 #include <compiler.h>
 #include <tee_api_defines.h>
 #include <tee_api_types.h>
-#if defined(CFG_TEE_PANIC_DEBUG)
-#include <trace.h>
-#endif
 
 /* Property access functions */
 
@@ -75,14 +72,7 @@ TEE_Result TEE_GetNextProperty(TEE_PropSetHandle enumerator);
 
 /* System API - Misc */
 
-void __TEE_Panic(TEE_Result panicCode);
 void TEE_Panic(TEE_Result panicCode);
-#if defined(CFG_TEE_PANIC_DEBUG)
-#define TEE_Panic(c) do { \
-		EMSG("Panic 0x%x", (c)); \
-		__TEE_Panic(c); \
-	} while (0)
-#endif
 
 /* System API - Internal Client API */
 

--- a/lib/libutee/sub.mk
+++ b/lib/libutee/sub.mk
@@ -11,7 +11,12 @@ srcs-y += tee_api.c
 srcs-y += tee_api_objects.c
 srcs-y += tee_api_operations.c
 srcs-y += tee_api_se.c
+ifeq ($(CFG_TEE_PANIC_DEBUG_ADDR),)
 srcs-y += tee_api_panic.c
+else
+srcs-$(CFG_ARM32_$(sm)) += tee_api_panic_a32.S
+srcs-$(CFG_ARM64_$(sm)) += tee_api_panic_a64.S
+endif
 srcs-y += tee_tcpudp_socket.c
 srcs-y += tee_socket_pta.c
 

--- a/lib/libutee/tee_api_panic_a32.S
+++ b/lib/libutee/tee_api_panic_a32.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,14 +24,20 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <tee_api.h>
-#include <trace.h>
-#include <utee_syscalls.h>
 
-/* System API - Misc */
+#include <asm.S>
 
-void __noreturn TEE_Panic(TEE_Result panicCode)
-{
-	utee_panic(panicCode);
-}
+/*
+ * Cause a fault at special address CFG_TEE_PANIC_DEBUG_ADDR.
+ * The abort handler will dump the call stack, print the panic code and panic
+ * the TA.
+ */
+FUNC TEE_Panic, :
+	.fnstart
+	ldr	r1, =CFG_TEE_PANIC_DEBUG_ADDR
+	ldr	r1, [r1]
+	/* In case CFG_TEE_PANIC_DEBUG_ADDR did not cause an exception */
+	bl	utee_panic
+	.fnend
+END_FUNC TEE_Panic
 

--- a/lib/libutee/tee_api_panic_a64.S
+++ b/lib/libutee/tee_api_panic_a64.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,14 +24,18 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <tee_api.h>
-#include <trace.h>
-#include <utee_syscalls.h>
 
-/* System API - Misc */
+#include <asm.S>
 
-void __noreturn TEE_Panic(TEE_Result panicCode)
-{
-	utee_panic(panicCode);
-}
+/*
+ * Cause a fault at special address CFG_TEE_PANIC_DEBUG_ADDR.
+ * The abort handler will dump the call stack, print the panic code and panic
+ * the TA.
+ */
+FUNC TEE_Panic, :
+	mov	x1, CFG_TEE_PANIC_DEBUG_ADDR
+	ldr	w1, [x1]
+	/* In case CFG_TEE_PANIC_DEBUG_ADDR did not cause an exception */
+	bl	utee_panic
+END_FUNC TEE_Panic
 

--- a/lib/libutee/tui/image_png.c
+++ b/lib/libutee/tui/image_png.c
@@ -30,6 +30,7 @@
 #include <png.h>
 #include <tee_api.h>
 #include <string.h>
+#include <trace.h>
 #include <util.h>
 #include <utee_defines.h>
 #include "image.h"

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -61,10 +61,14 @@ CFG_TEE_TA_LOG_LEVEL ?= 1
 # CFG_TEE_TA_LOG_LEVEL. Otherwise, they are not output at all
 CFG_TEE_CORE_TA_TRACE ?= y
 
-# Define TEE_Panic as a macro to help debugging panics caused by calls to
-# TEE_Panic. This flag can have a different value when later compiling the
-# TA
-CFG_TEE_PANIC_DEBUG ?= y
+# TEE_Panic() debugging
+# This should be set to a value that is *NOT* a valid virtual address for a
+# user-space TA. When TEE_Panic() is called (by the TA code or the libutee
+# library), an invalid write is generated to this address, which is trapped
+# by the TEE core and the call stack is printed to the console.
+# Set this variable to an empty value, or do not set it, to disable this
+# debug feature.
+CFG_TEE_PANIC_DEBUG_ADDR ?= 0xbad
 
 # If 1, enable debug features in TA memory allocation.
 # Debug features include check of buffer overflow, statistics, mark/check heap

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -53,11 +53,6 @@ cflags$(sm)    := $($(sm)-platform-cflags) $(CFLAGS_$(sm))
 CFG_TEE_TA_LOG_LEVEL ?= 2
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 
-# CFG_TEE_PANIC_DEBUG is used in tee_api.h
-ifeq ($(CFG_TEE_PANIC_DEBUG),y)
-cppflags$(sm) += -DCFG_TEE_PANIC_DEBUG=1
-endif
-
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
 
 libdirs += $(ta-dev-kit-dir)/lib


### PR DESCRIPTION
- 1st commit fixes a compile error that would happen when 3rd commit is applied
- 2nd commit allows `scripts/symbolize.py` to resolve the file/line information for an assembler file, which is also useful when the 3rd commit is applied
- 3rd commit adds a stack dump when a TA panics.

Depends on https://github.com/OP-TEE/optee_test/pull/224.