### PR TITLE
dts: pass PA of reserved region

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -671,7 +671,8 @@ static int config_nsmem(void *fdt)
 
 	core_mmu_get_mem_by_type(MEM_AREA_NSEC_SHM, &shm_start, &shm_end);
 	if (shm_start != shm_end)
-		return add_res_mem_dt_node(fdt, "optee", shm_start,
+		return add_res_mem_dt_node(fdt, "optee",
+					   virt_to_phys((void *)shm_start),
 					   shm_end - shm_start);
 
 	DMSG("No SHM configured");


### PR DESCRIPTION
config_nsmem() used VA of SHM region. This is wrong and it confused
linux kernel. We need to pass physical address.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>
Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>