### PR TITLE
qemu_v8: move SHM region

### DIFF
--- a/core/arch/arm/plat-vexpress/platform_config.h
+++ b/core/arch/arm/plat-vexpress/platform_config.h
@@ -227,9 +227,6 @@
 #define DRAM0_BASE		UINTPTR_C(0x40000000)
 #define DRAM0_SIZE		(UINTPTR_C(0x40000000) - CFG_SHMEM_SIZE)
 
-#define DRAM0_TEERES_BASE	(DRAM0_BASE + DRAM0_SIZE)
-#define DRAM0_TEERES_SIZE	CFG_SHMEM_SIZE
-
 #define SECRAM_BASE		0x0e000000
 #define SECRAM_SIZE		0x01000000
 
@@ -254,8 +251,11 @@
 
 #define CFG_TEE_CORE_NB_CORE	2
 
-#define CFG_SHMEM_START		(DRAM0_TEERES_BASE + \
-					(DRAM0_TEERES_SIZE - CFG_SHMEM_SIZE))
+/*
+ * CFG_SHMEM_START chosen arbitrary, in a way that it does not interfere
+ * with initial location of linux kernel, dtb and initrd
+ */
+#define CFG_SHMEM_START	(DRAM0_BASE + 0x2000000)
 #define CFG_SHMEM_SIZE		0x200000
 
 #else


### PR DESCRIPTION
With the current setup, qemu puts initrd in the midst of reserved
SHM region. This confuses linux kernel, because it forbids self
to access that reserved region.
As there are no easy way tell qemu where to put initrd, it is easier
to move SHM in the optee-os.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>
Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>