### PR TITLE
Add GitHub template files for issues and PRs

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,21 @@
+<!--
+    General guidance when creating issues:
+
+    1. Please try to remember to close the issue when you have
+       got an answer to your question.
+
+    2. It never hurts to state which commit or release tag you are using in case
+       the question is about build issues.
+
+    3. Try to use GitHub markdown formatting to make your issue more readable:
+         https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code
+
+    4. Try to search for the issue before posting the question:
+         -> Issues tab -> Filters
+
+    5. Check the FAQ before posting a question:
+         https://www.op-tee.org/faq
+
+    NOTE: This comment will not be shown in the issue, so no harm keeping it,
+    but feel free to remove it if you like.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+    If you are new to submitting pull requests to OP-TEE, then please have a
+    look at the list below and tick them off before submitting the pull request.
+
+    1. Read our contribution guidelines:
+         documentation/github.md.
+
+    2. Read the contribution section in Notice.md and pay extra attention to the
+       "Developer Certificate of Origin" part:
+         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.
+
+    3. You should run checkpatch preferably before submitting the pull request.
+
+    4. When everything has been reviewed, you will need to squash, rebase and
+       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.
+
+    NOTE: This comment will not be shown in the pull request, so no harm keeping
+    it, but feel free to remove it if you like.
+-->


### PR DESCRIPTION
With these two files added to OP-TEE the users will get this shown when (before creating/submitting) creating issues and pull requests. Hopefully some people will pay attention to that and in the long run that would eventually save us a minute or two.

I think that we could start by adding this to `optee_os` and then later add it to the other git's that we are maintaining. 

For more information regarding GitHub templates, please see [this](https://help.github.com/articles/creating-an-issue-template-for-your-repository/) and [this](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) link.