### PR TITLE
scripts/symbolize.py: reset state when a (new) abort message is found

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -281,6 +281,7 @@ class Symbolizer(object):
         self._arch = None
         self._saved_abort_line = ''
         self._sections = []
+        self._bin = "tee.elf"
 
     def write(self, line):
             if self._call_stack_found:
@@ -322,6 +323,7 @@ class Symbolizer(object):
                 self._load_addr = match.group('load_addr')
             match = re.search(ABORT_ADDR_RE, line)
             if match:
+                self.reset()
                 # At this point the arch and TA load address are unknown.
                 # Save the line so We can translate the abort address later.
                 self._saved_abort_line = line


### PR DESCRIPTION
The symbolize script may not process correctly several dumps in a row.
For instance, if you pipe a TA abort followed by a TEE core abort, the
later is not decoded properly because the script still uses the TA
binary to interpret the core stack. Fix this by resetting the state of
the decoder each time an abort line is encountered.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
