### PR TITLE
Revert "core: core_mmu_v7: core_mmu_get_user_pgdir: remove duplicated…

### DIFF
--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -471,6 +471,7 @@ void core_mmu_get_user_pgdir(struct core_mmu_table_info *pgd_info)
 	void *tbl = (void *)core_mmu_get_ul1_ttb_va();
 
 	core_mmu_set_info_table(pgd_info, 1, 0, tbl);
+	pgd_info->num_entries = NUM_UL1_ENTRIES;
 }
 
 void core_mmu_create_user_map(struct user_ta_ctx *utc,


### PR DESCRIPTION
… code"

This reverts commit 3eb2ba74961b. core_mmu_set_info_table() sets
tbl_info->num_entries to NUM_L1_ENTRIES, not NUM_UL1_ENTRIES. So the
removed code was actually not duplicate.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
