### PR TITLE
ci: shippable: make sure QEMU test runs on the proper commit

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -165,6 +165,7 @@ build:
     # Use repo to clone the OP-TEE CI environment for QEMU and link optee_os to the current checkout
     - >
       mkdir -p ${SHIPPABLE_BUILD_DIR}/optee_repo_qemu &&
+      rm -rf ${SHIPPABLE_BUILD_DIR}/optee_repo_qemu/optee_os &&
       cd ${SHIPPABLE_BUILD_DIR}/optee_repo_qemu &&
       repo init -u https://github.com/OP-TEE/manifest.git -m travis.xml </dev/null &&
       repo sync -d --force-sync --no-clone-bundle --no-tags --quiet -j 2 &&


### PR DESCRIPTION
There is a bug in the step that prepares a source tree to build and run
OP-TEE with QEMU, at the end of the CI script. The idea is, clone the
current project forest using the repo tool, then remove optee_os and
replace it with a symbolic link to the one that has been checked out in
the CI infrastructure. So that, we are effectively testing the desired
pull request or branch.
The problem is, the symlink is not removed at the end of the script, so
it ends up being cached and restored with the next build. The repo sync
command follows the symlink and overwrites the "good" optee_os with the
current master branch and at this point we're doomed.
Fix that by making sure there is no optee_os symlink leftover from the
cache.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
