### PR TITLE
Add non-secure DDR ranges to rcar-based boards

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -10,6 +10,7 @@ $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_SCIF,y)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_WITH_LPAE,y)

--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -1,4 +1,4 @@
-PLATFORM_FLAVOR ?= h3
+PLATFORM_FLAVOR ?= salvator_h3
 
 include core/arch/arm/cpu/cortex-armv8-0.mk
 

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -41,6 +41,15 @@ register_phys_mem(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, SCIF_REG_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
 
+register_nsec_ddr(NSEC_DDR_0_BASE, NSEC_DDR_0_SIZE);
+register_nsec_ddr(NSEC_DDR_1_BASE, NSEC_DDR_1_SIZE);
+#ifdef NSEC_DDR_2_BASE
+register_nsec_ddr(NSEC_DDR_2_BASE, NSEC_DDR_2_SIZE);
+#endif
+#ifdef NSEC_DDR_3_BASE
+register_nsec_ddr(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
+#endif
+
 static void main_fiq(void);
 
 static const struct thread_handlers handlers = {

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -50,7 +50,11 @@
 #define TZDRAM_BASE		0x44000000
 #define TZDRAM_SIZE		0x03E00000
 
+#if defined(PLATFORM_FLAVOR_salvator_h3)
 #define CFG_TEE_CORE_NB_CORE	8
+#elif defined(PLATFORM_FLAVOR_salvator_m3)
+#define CFG_TEE_CORE_NB_CORE	4
+#endif
 
 /* Full GlobalPlatform test suite requires CFG_SHMEM_SIZE to be at least 2MB */
 #define CFG_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -43,17 +43,28 @@
 
 #define CONSOLE_UART_BASE	0xE6E88000
 
-#define DRAM0_BASE		0x44000000
-#define DRAM0_SIZE		0x04000000
-
 /* Location of trusted dram */
 #define TZDRAM_BASE		0x44000000
 #define TZDRAM_SIZE		0x03E00000
 
 #if defined(PLATFORM_FLAVOR_salvator_h3)
 #define CFG_TEE_CORE_NB_CORE	8
+#define NSEC_DDR_0_BASE		0x47E00000
+#define NSEC_DDR_0_SIZE		0x38200000
+#define NSEC_DDR_1_BASE		0x500000000U
+#define NSEC_DDR_1_SIZE		0x40000000
+#define NSEC_DDR_2_BASE		0x600000000U
+#define NSEC_DDR_2_SIZE		0x40000000
+#define NSEC_DDR_3_BASE		0x700000000U
+#define NSEC_DDR_3_SIZE		0x40000000
+
 #elif defined(PLATFORM_FLAVOR_salvator_m3)
 #define CFG_TEE_CORE_NB_CORE	4
+#define NSEC_DDR_0_BASE		0x47E00000
+#define NSEC_DDR_0_SIZE		0x78200000
+#define NSEC_DDR_1_BASE		0x600000000U
+#define NSEC_DDR_1_SIZE		0x80000000
+
 #endif
 
 /* Full GlobalPlatform test suite requires CFG_SHMEM_SIZE to be at least 2MB */


### PR DESCRIPTION
There are two patches that configure nonsec DDR ranges for RCAR salvator-h3 and salvator-m3 boards.