### PR TITLE
core:sdp: fix SDP test pseudo-TA against dynamic shm

### DIFF
--- a/core/arch/arm/pta/pta_invoke_tests.c
+++ b/core/arch/arm/pta/pta_invoke_tests.c
@@ -218,7 +218,7 @@ static TEE_Result test_inject_sdp(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 	}
 
 
-	if (!core_vbuf_is(CORE_MEM_NSEC_SHM, src, sz) ||
+	if (!core_vbuf_is(CORE_MEM_NON_SEC, src, sz) ||
 	    !core_vbuf_is(CORE_MEM_SDP_MEM, dst, sz)) {
 		DMSG("bad memref secure attribute");
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -287,7 +287,7 @@ static TEE_Result test_dump_sdp(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 	}
 
 	if (!core_vbuf_is(CORE_MEM_SDP_MEM, src, sz) ||
-	    !core_vbuf_is(CORE_MEM_NSEC_SHM, dst, sz)) {
+	    !core_vbuf_is(CORE_MEM_NON_SEC, dst, sz)) {
 		DMSG("bad memref secure attribute");
 		return TEE_ERROR_BAD_PARAMETERS;
 	}


### PR DESCRIPTION
Physical memory typed CORE_MEM_NSEC_SHM belong to the default
contiguous shm memory. Since dynamic SHM, now non secure memory
reference can be outside the default NSEC_SHM, hence check
non secure reference using CORE_MEM_NON_SEC type instead of
CORE_MEM_NSEC_SHM.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
