### PR TITLE
core:mmu: fix userland va/pa conversion

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1600,11 +1600,16 @@ static void check_pa_matches_va(void *va, paddr_t pa)
 #endif
 	if (!core_va2pa_helper(va, &p)) {
 		/* Verfiy only the static mapping (case non null phys addr) */
-		if (p && pa != p)
+		if (p && pa != p) {
+			DMSG("va %p maps 0x%" PRIxPA ", expect 0x%" PRIxPA,
+					va, p, pa);
 			panic();
+		}
 	} else {
-		if (pa)
+		if (pa) {
+			DMSG("va %p unmapped, expect 0x%" PRIxPA, va, pa);
 			panic();
+		}
 	}
 }
 #else
@@ -1626,8 +1631,16 @@ paddr_t virt_to_phys(void *va)
 #if defined(CFG_TEE_CORE_DEBUG)
 static void check_va_matches_pa(paddr_t pa, void *va)
 {
-	if (va && virt_to_phys(va) != pa)
+	paddr_t p;
+
+	if (!va)
+		return;
+
+	p = virt_to_phys(va);
+	if (p != pa) {
+		DMSG("va %p maps 0x%" PRIxPA " expect 0x%" PRIxPA, va, p, pa);
 		panic();
+	}
 }
 #else
 static void check_va_matches_pa(paddr_t pa __unused, void *va __unused)

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1701,6 +1701,10 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m)
 	case MEM_AREA_TEE_RAM_RW:
 		va = phys_to_virt_tee_ram(pa);
 		break;
+	case MEM_AREA_SHM_VASPACE:
+		/* Find VA from PA in dynamic SHM is not yet supported */
+		va = NULL;
+		break;
 	default:
 		va = map_pa2va(find_map_by_type_and_pa(m, pa), pa);
 	}


### PR DESCRIPTION
This change takes care that the offset in page of the target address
to be converted is not added twice when computing the address
physical page based on the memory object reference.
