### PR TITLE
Add comment about CFG_UNWIND

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -152,13 +152,17 @@ CFG_LIBUTILS_WITH_ISOC ?= y
 # With CFG_TA_FLOAT_SUPPORT enabled TA code is free use floating point types
 CFG_TA_FLOAT_SUPPORT ?= y
 
-# Stack unwinding: print a stack dump to the console on abort
+# Stack unwinding: print a stack dump to the console on core or TA abort, or
+# when a TA panics.
 # If CFG_UNWIND is enabled, both the kernel and user mode call stacks can be
 # unwound (not paged TAs, however).
 # Note that 32-bit ARM code needs unwind tables for this to work, so enabling
 # this option will increase the size of the 32-bit TEE binary by a few KB.
 # Similarly, TAs have to be compiled with -funwind-tables (default when the
 # option is set) otherwise they can't be unwound.
+# Warning: since the unwind sequence for user-mode (TA) code is implemented in
+# the privileged layer of OP-TEE, enabling this feature will weaken the
+# user/kernel isolation. Therefore it should be disabled in release builds.
 ifeq ($(CFG_TEE_CORE_DEBUG),y)
 CFG_UNWIND ?= y
 endif


### PR DESCRIPTION
Update the comment in the main configuration file to state that
CFG_UNWIND should be disabled in production builds.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Suggested-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
