### PR TITLE
RFC: Remove double offset

### DIFF
--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -46,6 +46,7 @@ struct mobj_ops {
 	void *(*get_va)(struct mobj *mobj, size_t offs);
 	TEE_Result (*get_pa)(struct mobj *mobj, size_t offs, size_t granule,
 			     paddr_t *pa);
+	size_t (*get_phys_offs)(struct mobj *mobj, size_t granule);
 	TEE_Result (*get_cattr)(struct mobj *mobj, uint32_t *cattr);
 	bool (*matches)(struct mobj *mobj, enum buf_is_attr attr);
 	void (*free)(struct mobj *mobj);
@@ -69,6 +70,13 @@ static inline TEE_Result mobj_get_pa(struct mobj *mobj, size_t offs,
 	if (mobj && mobj->ops && mobj->ops->get_pa)
 		return mobj->ops->get_pa(mobj, offs, granule, pa);
 	return TEE_ERROR_GENERIC;
+}
+
+static inline size_t mobj_get_phys_offs(struct mobj *mobj, size_t granule)
+{
+	if (mobj && mobj->ops && mobj->ops->get_phys_offs)
+		return mobj->ops->get_phys_offs(mobj, granule);
+	return 0;
 }
 
 static inline TEE_Result mobj_get_cattr(struct mobj *mobj, uint32_t *cattr)

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -117,15 +117,10 @@ static TEE_Result assign_mobj_to_param_mem(const paddr_t pa, const size_t sz,
 static TEE_Result set_rmem_param(const struct optee_msg_param *param,
 				 struct param_mem *mem)
 {
-	struct mobj *rmem_mobj =
-		mobj_reg_shm_find_by_cookie(param->u.rmem.shm_ref);
-	paddr_t b;
-
-	if (mobj_get_pa(rmem_mobj, 0, 0, &b) != TEE_SUCCESS)
+	mem->mobj = mobj_reg_shm_find_by_cookie(param->u.rmem.shm_ref);
+	if (!mem->mobj)
 		return TEE_ERROR_BAD_PARAMETERS;
-
-	mem->mobj = rmem_mobj;
-	mem->offs = param->u.rmem.offs + (b & SMALL_PAGE_MASK);
+	mem->offs = param->u.rmem.offs;
 	mem->size = param->u.rmem.size;
 
 	return TEE_SUCCESS;


### PR DESCRIPTION
Currently the offset into MOBJs is calculated in a not very obvious way.

See for instance the fixes needed in https://github.com/OP-TEE/optee_os/pull/1877 to compensate for that.

This PR aims to simplify the way we keep track of the offset by always taking all the sources into account.