### PR TITLE
Map buffers in parameters for Pseudo TAs

### DIFF
--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -140,6 +140,9 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 
 struct mobj *mobj_reg_shm_find_by_cookie(uint64_t cookie);
 
+TEE_Result mobj_reg_shm_map(struct mobj *mobj);
+TEE_Result mobj_reg_shm_unmap(struct mobj *mobj);
+
 /*
  * mapped_shm represents registered shared buffer
  * which is mapped into OPTEE va space


### PR DESCRIPTION
Please ignore the commits "core: mobj: add mobj_get_phys_offs()" and "core: mobj: remove double physical offset" which are part of https://github.com/OP-TEE/optee_os/pull/1883

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
