### PR TITLE
make clean: split file list into manageable chunks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ include mk/cleandirs.mk
 .PHONY: clean
 clean:
 	@$(cmd-echo-silent) '  CLEAN   $(out-dir)'
-	${q}rm -f $(cleanfiles)
+	$(call do-rm-f, $(cleanfiles))
 	${q}dirs="$(call cleandirs-for-rmdir)"; if [ "$$dirs" ]; then $(RMDIR) $$dirs; fi
 	@if [ "$(out-dir)" != "$(O)" ]; then $(cmd-echo-silent) '  CLEAN   $(O)'; fi
 	${q}if [ -d "$(O)" ]; then $(RMDIR) $(O); fi

--- a/mk/cleandirs.mk
+++ b/mk/cleandirs.mk
@@ -26,3 +26,17 @@ $(eval _O:=$(if $(O),$(O),.))$(wildcard $(addprefix $(_O)/,$(call _reverse,
 endef
 
 RMDIR := rmdir --ignore-fail-on-non-empty
+
+# Remove files with "rm -f".
+# Split (possibly huge) file list into more manageable lines
+# (200 files at a time), to minimize the odds of having:
+# "/bin/bash: Argument list too long"
+define do-rm-f
+        $(call _do-rm-f, $(wordlist 1, 200, $(1)))
+        $(eval _tail := $(wordlist 201, $(words $(1)), $(1)))
+        $(if $(_tail), $(call do-rm-f, $(_tail)))
+endef
+
+define _do-rm-f
+        ${q}rm -f $1
+endef


### PR DESCRIPTION
"make clean" might fail with the following error:

  make[2]: execvp: /bin/bash: Argument list too long

This error was observed on a platform that has lots of additional
source files compared to upstream (drivers, etc.), and that sets a long
output path on the command line (make ... O=/some/long/path).

Fix the error by splitting the file list into more manageable chunks.
Note that removing one file at a time is not reasonable, because
spawning too may shells takes quite a long time (up to 7-10 seconds to
"make clean").

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Reported-by: Lijianhui <airbak.li@hisilicon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
