### PR TITLE
[RFC] Initial virtualization support

### DIFF
--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -392,6 +392,58 @@
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_BOOT_SECONDARY)
 
 /*
+ * Inform OP-TEE about a new virtual machine
+ *
+ * Hypervisor issues this call during virtual machine (guest) creation.
+ * OP-TEE records VM_ID of new virtual machine and makes self ready
+ * to receive requests from it. This call available only of OP-TEE
+ * was built with virtualization support.
+ *
+ * Call requests usage:
+ * a0	SMC Function ID, OPTEE_SMC_VM_CREATED
+ * a1	VM_ID of newly created virtual machine
+ * a2-6 Not used
+ * a7	Hypervisor Client ID register. Must be 0, because only hypervisor
+ *      can issue this call
+ *
+ * Normal return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1-7	Preserved
+ *
+ * Error return:
+ * a0	OPTEE_SMC_RETURN_ENOTAVAIL	OP-TEE has no resources for
+ *					another VM
+ * a1-7	Preserved
+ *
+ */
+#define OPTEE_SMC_FUNCID_VM_CREATED	13
+#define OPTEE_SMC_VM_CREATED \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_VM_CREATED)
+
+/*
+ * Inform OP-TEE about shutdown of a virtual machine
+ *
+ * Hypervisor issues this call during virtual machine (guest) destruction.
+ * OP-TEE will clean up all resources associated with this VM. This call
+ * available only of OP-TEE  was built with virtualization support.
+ *
+ * Call requests usage:
+ * a0	SMC Function ID, OPTEE_SMC_VM_DESTROYED
+ * a1	VM_ID of virtual machine being shutted down
+ * a2-6 Not used
+ * a7	Hypervisor Client ID register. Must be 0, because only hypervisor
+ *      can issue this call
+ *
+ * Normal return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1-7	Preserved
+ *
+ */
+#define OPTEE_SMC_FUNCID_VM_DESTROYED	14
+#define OPTEE_SMC_VM_DESTROYED \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_VM_DESTROYED)
+
+/*
  * Resume from RPC (for example after processing a foreign interrupt)
  *
  * Call register usage:

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -52,4 +52,6 @@ srcs-y += unwind_arm32.c
 srcs-$(CFG_ARM64_core) += unwind_arm64.c
 endif
 
+srcs-y += virtualization.c
+
 srcs-y += link_dummies.c

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -111,9 +111,6 @@ struct thread_ctx {
 #ifdef CFG_WITH_VFP
 	struct thread_vfp_state vfp_state;
 #endif
-	void *rpc_arg;
-	uint64_t rpc_carg;
-	struct mobj *rpc_mobj;
 	struct mutex_head mutexes;
 	struct thread_specific_data tsd;
 };

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2017, EPAM Systems
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <initcall.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <kernel/virtualization.h>
+#include <kernel/thread.h>
+#include <sm/optee_smc.h>
+#include <sys/queue.h>
+#include <string.h>
+
+#ifdef CFG_VIRTUALIZATION
+
+static unsigned int ctx_list_lock = SPINLOCK_UNLOCK;
+
+static LIST_HEAD(ctx_list_head, client_context) ctx_list =
+	LIST_HEAD_INITIALIZER(ctx_list_head);
+
+struct client_context *curr_client(void)
+{
+	return thread_get_tsd()->client_ctx;
+}
+
+struct client_context *get_client_context(uint16_t client_id)
+{
+	struct client_context *ctx;
+	uint32_t exceptions;
+
+	exceptions = cpu_spin_lock_xsave(&ctx_list_lock);
+	LIST_FOREACH(ctx, &ctx_list, next) {
+		if (ctx->id == client_id) {
+			cpu_spin_unlock_xrestore(&ctx_list_lock,
+						 exceptions);
+			return ctx;
+		}
+	}
+	cpu_spin_unlock_xrestore(&ctx_list_lock, exceptions);
+
+	return NULL;
+}
+
+bool update_curr_client(uint16_t client_id)
+{
+	struct thread_specific_data *tsd = thread_get_tsd();
+	struct client_context *ctx = get_client_context(client_id);
+
+	if (!ctx)
+		EMSG("Can't find VM client with id %d", client_id);
+
+	tsd->client_ctx = ctx;
+
+	return ctx != NULL;
+}
+
+int client_created(uint16_t client_id)
+{
+	struct client_context *ctx;
+	uint32_t exceptions;
+
+	ctx = malloc(sizeof(*ctx));
+
+	if (!ctx)
+		return OPTEE_SMC_RETURN_ENOTAVAIL;
+
+	memset(ctx, 0, sizeof(*ctx));
+
+	ctx->id = client_id;
+
+	exceptions = cpu_spin_lock_xsave(&ctx_list_lock);
+	LIST_INSERT_HEAD(&ctx_list, ctx, next);
+	cpu_spin_unlock_xrestore(&ctx_list_lock, exceptions);
+
+	DMSG("Added client %d", client_id);
+
+	return OPTEE_SMC_RETURN_OK;
+}
+
+void client_destroyed(uint16_t client_id)
+{
+	struct client_context *ctx;
+	uint32_t exceptions;
+
+	DMSG("Removing client %d", client_id);
+
+	exceptions = cpu_spin_lock_xsave(&ctx_list_lock);
+	LIST_FOREACH(ctx, &ctx_list, next) {
+		if (ctx->id == client_id) {
+			LIST_REMOVE(ctx, next);
+			break;
+		}
+	}
+	cpu_spin_unlock_xrestore(&ctx_list_lock, exceptions);
+
+	if (!ctx) {
+		EMSG("client_destroyed: can't find cliend with id %d",
+		     client_id);
+		return;
+	}
+
+	/* Now we have pointer to client context and can perform cleanup */
+
+	/* This should be last step. At this point all client threads
+	 * should be stopped.
+	 * TODO: Implement thread termination.
+	 */
+	thread_force_free_prealloc_rpc_cache(ctx);
+}
+
+static TEE_Result virtualization_init(void)
+{
+	/* Create context for hypervisor manually */
+	int ret = client_created(0);
+
+	if (ret)
+		panic("Can't create hypervisor client context");
+
+	return TEE_SUCCESS;
+}
+
+service_init(virtualization_init);
+
+#else
+
+struct client_context default_ctx;
+
+#endif	/* CFG_VIRTUALIZATION */

--- a/core/include/kernel/virtualization.h
+++ b/core/include/kernel/virtualization.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017, EPAM Systems
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef KERNEL_VIRTUALIZATION_H
+#define KERNEL_VIRTUALIZATION_H
+
+#include <compiler.h>
+#include <stdint.h>
+#include <types_ext.h>
+#include <mm/mobj.h>
+
+struct thread_rpc_arg {
+	uint64_t rpc_carg;
+	void *rpc_arg;
+	struct mobj *rpc_mobj;
+};
+
+struct client_context {
+#ifdef CFG_VIRTUALIZATION
+	LIST_ENTRY(client_context) next;
+#endif
+	struct thread_rpc_arg thr_rpc_arg[CFG_NUM_THREADS];
+	bool thread_prealloc_rpc_cache;
+	uint16_t id;
+};
+
+#ifdef CFG_VIRTUALIZATION
+
+/*
+ * Get context of current VM client. Works only in std call
+ * context (e.g. after thread was created).
+ */
+struct client_context *curr_client(void);
+
+/*
+ * Get context by @client_id. Should be used in fast calls.
+ * It is slower than curr_client();
+ */
+struct client_context *get_client_context(uint16_t client_id);
+
+/*
+ * Makes curr_client() return structure for given client_id.
+ * Returns true on success, false on error.
+ * In case of error, curr_client() will return NULL
+ */
+bool update_curr_client(uint16_t client_id);
+
+int client_created(uint16_t client_id);
+void client_destroyed(uint16_t client_id);
+
+#else
+
+extern struct client_context default_ctx;
+
+static inline struct client_context *curr_client(void)
+{
+	return &default_ctx;
+}
+
+static inline struct client_context *
+		get_client_context(uint16_t client_id __unused)
+{
+	return &default_ctx;
+}
+
+static inline bool update_curr_client(uint16_t client_id __unused)
+{
+	return true;
+}
+
+#endif	/* CFG_VIRTUALIZATION */
+
+#endif	/* KERNEL_VIRTUALIZATION_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -278,3 +278,6 @@ CFG_DYN_SHM_CAP ?= y
 # Enables support for larger physical addresses, that is, it will define
 # paddr_t as a 64-bit type.
 CFG_CORE_LARGE_PHYS_ADDR ?= n
+
+# Enables support for virtualization.
+CFG_VIRTUALIZATION ?= n


### PR DESCRIPTION
Hello.

I want to discus how virtualization support can look in OP-TEE. This patch adds very basic support for it.
With this code I was able to use OP-TEE from two different VMs. Sequentially, of course. Currently, no cross-VM blocking is supported. I'll publish corresponding XEN code, if anyone is interested.

As I said in commit message, I try to move all client-bound global variables to a client context. Default client context will be used if virtualization is disabled. This adds small overhead (one extra `LDR`, for variables access, I think), but it makes code more clean.
Currently, only cached RPC commands buffers are stored in client context. 

I don't ask you to do thorough code review. I just want to discuss proposed approach. This patch alone can't be used for production. On another hand, if you are okay with it, it can be merged with big warning "DO NOT enable CFG_VIRTULIZATION in production"

The biggest problem I see currently is thread termination if client VM dies in the middle of RPC. I propose to discuss this in #1890 