### PR TITLE
Keep assembly functions in separate sections

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -52,7 +52,6 @@ panic_boot_file:
 /*
  * void assert_flat_mapped_range(uint32_t vaddr, uint32_t line)
  */
-.section .text.init
 LOCAL_FUNC __assert_flat_mapped_range , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
@@ -96,7 +95,6 @@ UNWIND(	.fnend)
 END_FUNC plat_cpu_reset_early
 KEEP_PAGER plat_cpu_reset_early
 
-.section .text.boot
 FUNC _start , :
 	b	reset
 	b	.	/* Undef */
@@ -490,7 +488,6 @@ shadow_stack_access_ok:
 UNWIND(	.fnend)
 END_FUNC reset_primary
 
-
 LOCAL_FUNC unhandled_cpu , :
 UNWIND(	.fnstart)
 	wfi
@@ -529,6 +526,7 @@ UNWIND(	.cantunwind)
 	bx	r6
 UNWIND(	.fnend)
 END_FUNC cpu_on_handler
+KEEP_PAGER cpu_on_handler
 
 #else /* defined(CFG_WITH_ARM_TRUSTED_FW) */
 

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -95,8 +95,10 @@ UNWIND(	.fnend)
 END_FUNC plat_cpu_reset_early
 KEEP_PAGER plat_cpu_reset_early
 
-FUNC _start , :
-	b	reset
+	.section .text.reset_vect_table
+	.align 5
+LOCAL_FUNC reset_vect_table , :
+	b	.
 	b	.	/* Undef */
 	b	.	/* Syscall */
 	b	.	/* Prefetch abort */
@@ -104,8 +106,7 @@ FUNC _start , :
 	b	.	/* Reserved */
 	b	.	/* IRQ */
 	b	.	/* FIQ */
-END_FUNC _start
-KEEP_INIT _start
+END_FUNC reset_vect_table
 
 	.macro cpu_is_ready
 #ifdef CFG_BOOT_SYNC_CPU
@@ -229,7 +230,7 @@ KEEP_INIT _start
 	mov	r7, r1
 	.endm
 
-LOCAL_FUNC reset , :
+FUNC _start , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
 
@@ -241,7 +242,7 @@ UNWIND(	.cantunwind)
 	set_sctlr
 	isb
 
-	ldr	r0, =_start
+	ldr	r0, =reset_vect_table
 	write_vbar r0
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
@@ -253,7 +254,8 @@ UNWIND(	.cantunwind)
 	b	reset_secondary
 #endif
 UNWIND(	.fnend)
-END_FUNC reset
+END_FUNC _start
+KEEP_INIT _start
 
 	/*
 	 * Setup sp to point to the top of the tmp stack for the current CPU:
@@ -506,7 +508,7 @@ UNWIND(	.cantunwind)
 	set_sctlr
 	isb
 
-	ldr	r0, =_start
+	ldr	r0, =reset_vect_table
 	write_vbar r0
 
 	mov	r4, lr

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -535,6 +535,8 @@ KEEP_PAGER cpu_on_handler
 LOCAL_FUNC reset_secondary , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
+	ldr	r0, =reset_vect_table
+	write_vbar r0
 
 	wait_primary
 

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -73,7 +73,6 @@
 		msr	sctlr_el1, x0
 	.endm
 
-.section .text.boot
 FUNC _start , :
 	mov	x19, x0		/* Save pagable part address */
 	mov	x20, x2		/* Save DT address */
@@ -187,7 +186,6 @@ END_FUNC _start
 KEEP_INIT _start
 
 
-.section .text.cpu_on_handler
 FUNC cpu_on_handler , :
 	mov	x19, x0
 	mov	x20, x1
@@ -216,6 +214,7 @@ FUNC cpu_on_handler , :
 	mov	x30, x21
 	b	generic_boot_cpu_on_handler
 END_FUNC cpu_on_handler
+KEEP_PAGER cpu_on_handler
 
 LOCAL_FUNC unhandled_cpu , :
 	wfi
@@ -234,6 +233,7 @@ END_FUNC unhandled_cpu
 	  .endif
 	.endm
 
+	.section .text.reset_vect_table
 	.align	11
 LOCAL_FUNC reset_vect_table , :
 	/* -----------------------------------------------------

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -89,9 +89,10 @@ SECTIONS
 	__flatmap_unpg_rx_start = ROUNDDOWN(__text_start, SMALL_PAGE_SIZE);
 
 	.text : {
-		KEEP(*(.text.boot.vectab1))
-		KEEP(*(.text.boot.vectab2))
-		KEEP(*(.text.boot))
+		KEEP(*(.text._start))
+		KEEP(*(.text.init .text.plat_cpu_reset_early \
+		       .text.reset .text.reset_primary .text.unhandled_cpu \
+		       .text.__assert_flat_mapped_range))
 
 		. = ALIGN(8);
 		__initcall_start = .;

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -189,6 +189,7 @@ UNWIND(	.cantunwind)
 	b	vector_system_reset_entry
 UNWIND(	.fnend)
 END_FUNC thread_vector_table
+KEEP_PAGER thread_vector_table
 
 FUNC thread_set_abt_sp , :
 UNWIND(	.fnstart)
@@ -440,6 +441,7 @@ UNWIND(	.save	{r0})
 	pop	{r4-r5, pc}
 UNWIND(	.fnend)
 END_FUNC thread_rpc
+KEEP_PAGER thread_rpc
 
 /* The handler of native interrupt. */
 .macro	native_intr_handler mode:req
@@ -817,6 +819,7 @@ UNWIND(	.cantunwind)
 UNWIND(	.fnend)
 END_FUNC thread_svc_handler
 
+	.section .text.thread_vect_table
         .align	5
 LOCAL_FUNC thread_vect_table , :
 UNWIND(	.fnstart)

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -210,7 +210,7 @@ UNWIND(	.cantunwind)
 	msr	cpsr, r1
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC thread_set_abt_sp
+END_FUNC thread_set_und_sp
 
 FUNC thread_set_irq_sp , :
 UNWIND(	.fnstart)

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -45,7 +45,6 @@
 		madd	x\res, x\tmp0, x\tmp1, x\res
 	.endm
 
-	.section .text.thread_asm
 LOCAL_FUNC vector_std_smc_entry , :
 	sub	sp, sp, #THREAD_SMC_ARGS_SIZE
 	store_xregs sp, THREAD_SMC_ARGS_X0, 0, 7
@@ -165,6 +164,7 @@ FUNC thread_vector_table , :
 	b	vector_system_off_entry
 	b	vector_system_reset_entry
 END_FUNC thread_vector_table
+KEEP_PAGER thread_vector_table
 
 
 /* void thread_resume(struct thread_ctx_regs *regs) */
@@ -255,6 +255,7 @@ FUNC thread_rpc , :
 	store_wregs x16, 0, 0, 5	/* Store w0-w5 into rv[] */
 	ret
 END_FUNC thread_rpc
+KEEP_PAGER thread_rpc
 
 FUNC thread_init_vbar , :
 	adr	x0, thread_vect_table
@@ -345,6 +346,7 @@ END_FUNC thread_unwind_user_mode
 	.endm
 
 
+	.section .text.thread_vect_table
 	.align	11
 LOCAL_FUNC thread_vect_table , :
 	/* -----------------------------------------------------

--- a/core/arch/arm/sm/pm_a32.S
+++ b/core/arch/arm/sm/pm_a32.S
@@ -147,6 +147,20 @@ UNWIND(	.fnend)
 END_FUNC sm_pm_cpu_resume
 
 /*
+ * The following will be located in text section whose attribute is
+ * marked as readonly, but we only need to read here
+ * _suspend_sp stores the offset between thread_core_local to _suspend_sp.
+ * _core_pos stores the offset between get_core_pos to _core_pos.
+ */
+.align 2
+.extern thread_core_local
+_suspend_sp:
+	.long	thread_core_local - .
+.extern get_core_pos
+_core_pos:
+	.long	get_core_pos - .
+
+/*
  * void sm_do_cpu_do_resume(paddr suspend_regs) __noreturn;
  * Restore the registers stored when sm_pm_cpu_do_suspend
  * r0 points to the physical base address of the suspend_regs
@@ -210,16 +224,3 @@ a7_resume:
 UNWIND(	.fnend)
 END_FUNC sm_pm_cpu_do_resume
 
-/*
- * The following will be located in text section whose attribute is
- * marked as readonly, but we only need to read here
- * _suspend_sp stores the offset between thread_core_local to _suspend_sp.
- * _core_pos stores the offset between get_core_pos to _core_pos.
- */
-.align 2
-.extern thread_core_local
-_suspend_sp:
-	.long	thread_core_local - .
-.extern get_core_pos
-_core_pos:
-	.long	get_core_pos - .

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -244,6 +244,7 @@ UNWIND(	.cantunwind)
 UNWIND(	.fnend)
 END_FUNC sm_fiq_entry
 
+	.section .text.sm_vect_table
         .align	5
 LOCAL_FUNC sm_vect_table , :
 UNWIND(	.fnstart)

--- a/lib/libutils/ext/include/asm.S
+++ b/lib/libutils/ext/include/asm.S
@@ -26,6 +26,7 @@
  */
 
 	.macro FUNC name colon
+	.section .text.\name
 	.global \name
 	.func \name
 	.type \name , %function
@@ -39,6 +40,7 @@
 	.endm
 
 	.macro LOCAL_FUNC name colon
+	.section .text.\name
 	.func \name
 	.type \name , %function
 	\name \colon


### PR DESCRIPTION
To get a more fine grained selection of which area (init, paged,
unpaged) an assembly function is assigned do the equivalent of
-ffunction-sections but in assembly.

Some functions has to be in specific places in the binary for a
successful boot, link script is updated accordingly.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU v7/v8)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
