### PR TITLE
Add CFG_CONCURRENT_SINGLE_INSTANCE_TA

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -55,11 +55,28 @@
 
 /* This mutex protects the critical section in tee_ta_init_session */
 struct mutex tee_ta_mutex = MUTEX_INITIALIZER;
+struct tee_ta_ctx_head tee_ctxes = TAILQ_HEAD_INITIALIZER(tee_ctxes);
+
+#ifndef CFG_CONCURRENT_SINGLE_INSTANCE_TA
 static struct condvar tee_ta_cv = CONDVAR_INITIALIZER;
 static int tee_ta_single_instance_thread = THREAD_ID_INVALID;
 static size_t tee_ta_single_instance_count;
-struct tee_ta_ctx_head tee_ctxes = TAILQ_HEAD_INITIALIZER(tee_ctxes);
+#endif
 
+#ifdef CFG_CONCURRENT_SINGLE_INSTANCE_TA
+static void lock_single_instance(void)
+{
+}
+
+static void unlock_single_instance(void)
+{
+}
+
+static bool has_single_instance_lock(void)
+{
+	return false;
+}
+#else
 static void lock_single_instance(void)
 {
 	/* Requires tee_ta_mutex to be held */
@@ -93,6 +110,7 @@ static bool has_single_instance_lock(void)
 	/* Requires tee_ta_mutex to be held */
 	return tee_ta_single_instance_thread == thread_get_id();
 }
+#endif
 
 static bool tee_ta_try_set_busy(struct tee_ta_ctx *ctx)
 {


### PR DESCRIPTION
Commit 2b07dcb97c5e ("core: avoid deadlocks caused by single-instance
TA") introduces a lock that allows only one single instance TA to be
executing at any time. While it does address the risk of deadlock that
can arise when several single instance TAs call each other, it also
puts a serious performance limitation on multi-core platforms, which
could otherwise execute several unrelated single instance TAs
simultaneously.

This commit makes the single instance lock optional. By setting
CFG_CONCURRENT_SINGLE_INSTANCE_TA=y, the lock is disabled and TAs are
allowed to run concurrently. In the future, we may implement a deadlock
detection algorithm; in the meantime, this simple solution should be
enough to cover the current use cases.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (HiKey960)
CC: Zeng Tao <prime.zeng@hisilicon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
