### PR TITLE
core: arm: psci: pass nsec ctx to system_suspend

### DIFF
--- a/core/arch/arm/include/sm/psci.h
+++ b/core/arch/arm/include/sm/psci.h
@@ -67,7 +67,8 @@ void psci_system_off(void);
 void psci_system_reset(void);
 int psci_features(uint32_t psci_fid);
 int psci_node_hw_state(uint32_t cpu_id, uint32_t power_level);
-int psci_system_suspend(uintptr_t entry, uint32_t context_id);
+int psci_system_suspend(uintptr_t entry, uint32_t context_id,
+			struct sm_nsec_ctx *nsec);
 int psci_stat_residency(uint32_t cpu_id, uint32_t power_state);
 int psci_stat_count(uint32_t cpu_id, uint32_t power_state);
 void tee_psci_handler(struct thread_smc_args *args, struct sm_nsec_ctx *nsec);

--- a/core/arch/arm/plat-rockchip/psci_rk322x.c
+++ b/core/arch/arm/plat-rockchip/psci_rk322x.c
@@ -360,7 +360,8 @@ void psci_system_reset(void)
 }
 
 int psci_system_suspend(uintptr_t entry __unused,
-			uint32_t context_id __unused)
+			uint32_t context_id __unused,
+			struct sm_nsec_ctx *nsec __unused)
 {
 	DMSG("system suspend");
 

--- a/core/arch/arm/sm/psci.c
+++ b/core/arch/arm/sm/psci.c
@@ -101,7 +101,8 @@ __weak int psci_node_hw_state(uint32_t cpu_id __unused,
 }
 
 __weak int psci_system_suspend(uintptr_t entry __unused,
-			       uint32_t context_id __unused)
+			       uint32_t context_id __unused,
+			       struct sm_nsec_ctx *nsec __unused)
 {
 	return PSCI_RET_NOT_SUPPORTED;
 }
@@ -167,7 +168,7 @@ void tee_psci_handler(struct thread_smc_args *args, struct sm_nsec_ctx *nsec)
 		args->a0 = psci_node_hw_state(a1, a2);
 		break;
 	case PSCI_SYSTEM_SUSPEND:
-		args->a0 = psci_system_suspend(a1, a2);
+		args->a0 = psci_system_suspend(a1, a2, nsec);
 		break;
 	default:
 		args->a0 = OPTEE_SMC_RETURN_UNKNOWN_FUNCTION;


### PR DESCRIPTION
In the commit 732fc43(core: arm: psci: pass nsec ctx to psci), we have
done the job, but we forgot to follow it in the later commit 1d40eb8
(core: arm: sm: add PSCI system suspend), fix it in this patch.

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
