### PR TITLE
core: fix access conflict status in rpmb fs that panics TA

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2251,7 +2251,7 @@ static  TEE_Result rpmb_fs_rename_internal(struct tee_pobj *old,
 	res = read_fat(fh_new, NULL);
 	if (res == TEE_SUCCESS) {
 		if (!overwrite) {
-			res = TEE_ERROR_BAD_PARAMETERS;
+			res = TEE_ERROR_ACCESS_CONFLICT;
 			goto out;
 		}
 


### PR DESCRIPTION
According to the GPD TEE Internal Core API specs, when creating
an existing persistent object without the overwrite flag, the OS
should return a TEE_ERROR_ACCESS_CONFLICT status.

This change fixes the RPMB FS layer. An effect of this correction
is that before this change, OS panicked TAs that requested such
forbidden object creation, as a TEE_ERROR_BAD_PARAMETERS return
value is considered by the API as an unexpected status.


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
