### PR TITLE
mk/aosp_optee.mk: define OPTEE_BIN for path of tee.bin

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -34,11 +34,19 @@ CROSS_COMPILE32 := $(TOP_ROOT_ABS)/$($(combo_2nd_arch_prefix)TARGET_TOOLS_PREFIX
 CROSS_COMPILE_LINE += CROSS_COMPILE32="$(CROSS_COMPILE32)"
 endif
 
-##########################################################
-## define BUILD_OPTEE_OS target, add condition check    ##
-## to make it only be defined once even though          ##
-## this file might be included multiple times           ##
-##########################################################
+OPTEE_BIN := $(TOP_ROOT_ABS)/$(OPTEE_OS_OUT_DIR)/core/tee.bin
+
+$(OPTEE_BIN) : BUILD_OPTEE_OS
+
+###########################################################
+## define BUILD_OPTEE_OS target, add condition check     ##
+## to make it only be defined once even though           ##
+## this file might be included multiple times            ##
+## This BUILD_OPTEE_OS will help to generate the header  ##
+## files under $(TA_DEV_KIT_DIR)/host_include and        ##
+## the $(OPTEE_BIN) file which will be used as dependency##
+## for other projects                                    ##
+###########################################################
 ifneq (true,$(BUILD_OPTEE_OS_DEFINED))
 BUILD_OPTEE_OS_DEFINED := true
 


### PR DESCRIPTION
so that other android projects could use OPTEE_BIN
as the dependency instead of the old BUILD_OPTEE_OS target.

Ths is workaround for the problem with following with aosp master:
external/optee_test/Android.mk: error: xtest: LOCAL_ADDITIONAL_DEPENDENCIES must only contain paths (not module names)

Reviewed-by: Victor Chong <victor.chong@linaro.org>

Tested by: Victor Chong <victor.chong@linaro.org> (hikey aosp)
Tested-by: Yongqin Liu <yongqin.liu@linaro.org> (hikey aosp master)

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
