### PR TITLE
Replace struct prng_ops with function interface

### DIFF
--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -122,7 +122,7 @@ static TEE_Result test_sgi(void)
 		return TEE_ERROR_GENERIC;
 
 	for (i = 0; i < TEST_TIMES; i++) {
-		res = crypto_ops.prng.read(&num, 1);
+		res = crypto_rng_read(&num, 1);
 		if (res != TEE_SUCCESS)
 			return TEE_ERROR_GENERIC;
 		num = num % CFG_TEE_CORE_NB_CORE;
@@ -151,7 +151,7 @@ static TEE_Result test_spi(void)
 	itr_enable(TEST_SPI_ID);
 
 	for (i = 0; i < TEST_TIMES; i++) {
-		res = crypto_ops.prng.read(&num, 1);
+		res = crypto_rng_read(&num, 1);
 		if (res != TEE_SUCCESS)
 			return TEE_ERROR_GENERIC;
 		num = num % CFG_TEE_CORE_NB_CORE;
@@ -189,8 +189,6 @@ static TEE_Result interrupt_tests(uint32_t nParamTypes __unused,
 			TEE_Param pParams[TEE_NUM_PARAMS]__unused)
 {
 	TEE_Result res;
-
-	assert(crypto_ops.prng.read);
 
 	res = test_sgi();
 	if (res != TEE_SUCCESS)

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -279,14 +279,6 @@ struct acipher_ops {
 
 };
 
-struct prng_ops {
-	/* add entropy to PRNG entropy pool */
-	TEE_Result (*add_entropy)(const uint8_t *inbuf, size_t len);
-
-	/* to read random data from PRNG implementation	 */
-	TEE_Result (*read)(void *buf, size_t blen);
-};
-
 /* Cryptographic Provider API */
 struct crypto_ops {
 	/* Human-readable provider name */
@@ -299,7 +291,6 @@ struct crypto_ops {
 	struct authenc_ops authenc;
 	struct acipher_ops acipher;
 	struct bignum_ops bignum;
-	struct prng_ops prng;
 };
 
 extern const struct crypto_ops crypto_ops;
@@ -313,6 +304,12 @@ extern const struct crypto_ops crypto_ops;
  */
 TEE_Result hash_sha256_check(const uint8_t *hash, const uint8_t *data,
 		size_t data_size);
+
+/* Add entropy to PRNG entropy pool. */
+TEE_Result crypto_rng_add_entropy(const uint8_t *inbuf, size_t len);
+
+/* To read random data from PRNG implementation.	*/
+TEE_Result crypto_rng_read(void *buf, size_t blen);
 
 TEE_Result rng_generate(void *buffer, size_t len);
 

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -638,7 +638,7 @@ static void tee_ltc_alloc_mpa(void)
 	mpa_init_scratch_mem_sync(pool, size_pool, LTC_MAX_BITS_PER_VARIABLE,
 				  get_pool, put_pool, &pool_sync);
 
-	mpa_set_random_generator(crypto_ops.prng.read);
+	mpa_set_random_generator(crypto_rng_read);
 }
 
 static size_t num_bytes(struct bignum *a)
@@ -2909,7 +2909,7 @@ static void authenc_final(void *ctx, uint32_t algo)
 /******************************************************************************
  * Pseudo Random Number Generator
  ******************************************************************************/
-static TEE_Result prng_read(void *buf, size_t blen)
+TEE_Result crypto_rng_read(void *buf, size_t blen)
 {
 	int err;
 	struct tee_ltc_prng *prng = tee_ltc_get_prng();
@@ -2950,7 +2950,7 @@ static TEE_Result _tee_ltc_prng_add_entropy(
 #endif
 }
 
-static TEE_Result prng_add_entropy(const uint8_t *inbuf, size_t len)
+TEE_Result crypto_rng_add_entropy(const uint8_t *inbuf, size_t len)
 {
 	int err;
 	struct tee_ltc_prng *prng = tee_ltc_get_prng();
@@ -3070,10 +3070,6 @@ const struct crypto_ops crypto_ops = {
 		.clear = bn_clear
 	},
 #endif /* _CFG_CRYPTO_WITH_ACIPHER */
-	.prng = {
-		.add_entropy = prng_add_entropy,
-		.read = prng_read,
-	}
 };
 
 #if defined(CFG_WITH_VFP)

--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -474,7 +474,7 @@ static TEE_Result authenc_init(void **ctx_ret, TEE_OperationMode mode,
 	}
 
 	if (mode == TEE_MODE_ENCRYPT) {
-		res = crypto_ops.prng.read(iv, TEE_FS_HTREE_IV_SIZE);
+		res = crypto_rng_read(iv, TEE_FS_HTREE_IV_SIZE);
 		if (res != TEE_SUCCESS)
 			return res;
 	}
@@ -665,7 +665,7 @@ TEE_Result tee_fs_htree_open(bool create, uint8_t *hash, const TEE_UUID *uuid,
 	if (create) {
 		const struct tee_fs_htree_image dummy_head = { .counter = 0 };
 
-		res = crypto_ops.prng.read(ht->fek, sizeof(ht->fek));
+		res = crypto_rng_read(ht->fek, sizeof(ht->fek));
 		if (res != TEE_SUCCESS)
 			goto out;
 

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -373,10 +373,7 @@ TEE_Result tee_aes_cbc_cts_update(void *cbc_ctx, void *ecb_ctx,
 
 TEE_Result tee_prng_add_entropy(const uint8_t *in, size_t len)
 {
-	if (crypto_ops.prng.add_entropy)
-		return crypto_ops.prng.add_entropy(in, len);
-
-	return TEE_SUCCESS;
+	return crypto_rng_add_entropy(in, len);
 }
 
 /*

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -166,7 +166,7 @@ exit:
 
 static TEE_Result generate_fek(uint8_t *key, uint8_t len)
 {
-	return crypto_ops.prng.read(key, len);
+	return crypto_rng_read(key, len);
 }
 
 static TEE_Result tee_fs_init_key_manager(void)

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1006,7 +1006,7 @@ static TEE_Result tee_rpmb_init_read_wr_cnt(uint16_t dev_id,
 	if (res != TEE_SUCCESS)
 		goto func_exit;
 
-	res = crypto_ops.prng.read(nonce, RPMB_NONCE_SIZE);
+	res = crypto_rng_read(nonce, RPMB_NONCE_SIZE);
 	if (res != TEE_SUCCESS)
 		goto func_exit;
 
@@ -1133,7 +1133,7 @@ static TEE_Result tee_rpmb_write_and_verify_key(uint16_t dev_id __unused)
 static bool have_crypto_ops(void)
 {
 	return (crypto_ops.mac.init && crypto_ops.mac.update &&
-		crypto_ops.mac.final && crypto_ops.prng.read);
+		crypto_ops.mac.final);
 }
 
 /* This function must never return TEE_SUCCESS if rpmb_ctx == NULL */
@@ -1270,7 +1270,7 @@ static TEE_Result tee_rpmb_read(uint16_t dev_id, uint32_t addr, uint8_t *data,
 		goto func_exit;
 
 	msg_type = RPMB_MSG_TYPE_REQ_AUTH_DATA_READ;
-	res = crypto_ops.prng.read(nonce, RPMB_NONCE_SIZE);
+	res = crypto_rng_read(nonce, RPMB_NONCE_SIZE);
 	if (res != TEE_SUCCESS)
 		goto func_exit;
 

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1785,7 +1785,7 @@ TEE_Result syscall_obj_generate_key(unsigned long obj, unsigned long key_size,
 			goto out;
 		}
 
-		res = crypto_ops.prng.read((void *)(key + 1), byte_size);
+		res = crypto_rng_read((void *)(key + 1), byte_size);
 		if (res != TEE_SUCCESS)
 			goto out;
 
@@ -2912,7 +2912,7 @@ TEE_Result syscall_cryp_random_number_generate(void *buf, size_t blen)
 	if (res != TEE_SUCCESS)
 		return res;
 
-	res = crypto_ops.prng.read(buf, blen);
+	res = crypto_rng_read(buf, blen);
 	if (res != TEE_SUCCESS)
 		return res;
 


### PR DESCRIPTION
Adds crypto_rng_add_entropy() and crypto_rng_read() replacing
struct prng_ops in crypto_ops.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>


It turns out that https://github.com/OP-TEE/optee_os/pull/1912 wasn't enough for https://github.com/OP-TEE/optee_os/pull/1856 to be compiled with 
```
CFG_CORE_SANITIZE_KADDRESS=y
CFG_WITH_PAGER=y
```

With this PR the init size becomes more reasonable.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
