### PR TITLE
build: simplify mv-if-changed

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -44,7 +44,7 @@ endef
 
 # Rename $1 to $2 only if file content differs. Otherwise just delete $1.
 define mv-if-changed
-	if [ -r $2 ] && cmp -s $2 $1; then			\
+	if cmp -s $2 $1; then					\
 		rm -f $1;					\
 	else							\
 		$(cmd-echo-silent) '  UPD     $2';		\


### PR DESCRIPTION
In mv-if-changed(file1, file2), there is no need to check if file2
exists before trying to compare both files. Indeed, if file2 does not
exist, cmp -s will return non-zero and the second branch of the
conditional will be taken anyway.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
