### PR TITLE
tee: fix improper calloc usage

### DIFF
--- a/core/tee/tee_pobj.c
+++ b/core/tee/tee_pobj.c
@@ -112,7 +112,7 @@ TEE_Result tee_pobj_get(TEE_UUID *uuid, void *obj_id, uint32_t obj_id_len,
 	}
 
 	/* new file */
-	o = calloc(sizeof(struct tee_pobj), 1);
+	o = calloc(1, sizeof(struct tee_pobj));
 	if (!o) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2130,7 +2130,7 @@ static TEE_Result rpmb_fs_write_primitive(struct rpmb_file_handle *fh,
 		DMSG("Need to re-allocate");
 		newsize = MAX(end, fh->fat_entry.data_size);
 		mm = tee_mm_alloc(&p, newsize);
-		newbuf = calloc(newsize, 1);
+		newbuf = calloc(1, newsize);
 		if (!mm || !newbuf) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;
@@ -2327,7 +2327,7 @@ static TEE_Result rpmb_fs_truncate(struct tee_file_handle *tfh, size_t length)
 			goto out;
 
 		mm = tee_mm_alloc(&p, newsize);
-		newbuf = calloc(newsize, 1);
+		newbuf = calloc(1, newsize);
 		if (!mm || !newbuf) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;

--- a/lib/libutee/arch/arm/utee_misc.c
+++ b/lib/libutee/arch/arm/utee_misc.c
@@ -51,7 +51,7 @@ void *utee_realloc(void *buffer, size_t len)
 
 void *utee_calloc(size_t nb, size_t len)
 {
-	return calloc(len, nb);
+	return calloc(nb, len);
 }
 
 void utee_free(void *buffer)


### PR DESCRIPTION
calloc() takes number of entries as first argument, and size of entry
as a second.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
