### PR TITLE
[RFC] Bootstrap ta

### DIFF
--- a/core/arch/arm/kernel/secstor_ta.c
+++ b/core/arch/arm/kernel/secstor_ta.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <tee/tadb.h>
+#include <kernel/user_ta.h>
+#include <initcall.h>
+#include "elf_load.h"
+
+static TEE_Result secstor_ta_open(const TEE_UUID *uuid,
+				  struct user_ta_store_handle **handle)
+{
+	TEE_Result res;
+	struct tee_tadb_ta_read *ta;
+	size_t l;
+	const struct tee_tadb_property *prop;
+
+	res = tee_tadb_ta_open(uuid, &ta);
+	if (res)
+		return res;
+	prop = tee_tadb_ta_get_property(ta);
+
+	l = prop->custom_size;
+	res = tee_tadb_ta_read(ta, NULL, &l);
+	if (res)
+		goto err;
+	if (l != prop->custom_size)
+		goto err;
+
+	*handle = (struct user_ta_store_handle *)ta;
+
+	return TEE_SUCCESS;
+err:
+	tee_tadb_ta_close(ta);
+	return res;
+}
+
+static TEE_Result secstor_ta_get_size(const struct user_ta_store_handle *h,
+				      size_t *size)
+{
+	struct tee_tadb_ta_read *ta = (struct tee_tadb_ta_read *)h;
+	const struct tee_tadb_property *prop = tee_tadb_ta_get_property(ta);
+
+	*size = prop->bin_size;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result secstor_ta_read(struct user_ta_store_handle *h, void *data,
+				  size_t len)
+{
+	struct tee_tadb_ta_read *ta = (struct tee_tadb_ta_read *)h;
+	size_t l = len;
+	TEE_Result res = tee_tadb_ta_read(ta, data, &l);
+
+	if (res)
+		return res;
+	if (l != len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return TEE_SUCCESS;
+}
+
+static void secstor_ta_close(struct user_ta_store_handle *h)
+{
+	struct tee_tadb_ta_read *ta = (struct tee_tadb_ta_read *)h;
+
+	tee_tadb_ta_close(ta);
+}
+
+static struct user_ta_store_ops ops = {
+	.description = "Secure Storage TA",
+	.open = secstor_ta_open,
+	.get_size = secstor_ta_get_size,
+	.read = secstor_ta_read,
+	.close = secstor_ta_close,
+	.priority = 9,
+};
+
+static TEE_Result secstor_ta_init(void)
+{
+	return tee_ta_register_ta_store(&ops);
+}
+
+service_init(secstor_ta_init);

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -2,6 +2,7 @@ ifeq ($(CFG_WITH_USER_TA),y)
 srcs-y += user_ta.c
 srcs-$(CFG_REE_FS_TA) += ree_fs_ta.c
 srcs-$(CFG_EARLY_TA) += early_ta.c
+srcs-$(CFG_SECSTOR_TA) += secstor_ta.c
 endif
 srcs-y += pseudo_ta.c
 srcs-y += elf_load.c

--- a/core/arch/arm/pta/secstor_ta_mgmt.c
+++ b/core/arch/arm/pta/secstor_ta_mgmt.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <kernel/pseudo_ta.h>
+#include <tee/tadb.h>
+#include <pta_secstor_ta_mgmt.h>
+#include <signed_hdr.h>
+#include <string_ext.h>
+#include <string.h>
+#include <tee_api_types.h>
+#include <crypto/crypto.h>
+#include <tee/uuid.h>
+#include <types_ext.h>
+#include <utee_defines.h>
+
+static TEE_Result check_install_conflict(const struct shdr_bootstrap_ta *bs_ta)
+{
+	TEE_Result res;
+	struct tee_tadb_ta_read *ta;
+	TEE_UUID uuid;
+	const struct tee_tadb_property *prop;
+
+	tee_uuid_from_octets(&uuid, bs_ta->uuid);
+	res = tee_tadb_ta_open(&uuid, &ta);
+	if (res == TEE_ERROR_ITEM_NOT_FOUND)
+		return TEE_SUCCESS;
+	if (res)
+		return res;
+
+	prop = tee_tadb_ta_get_property(ta);
+	if (prop->version > bs_ta->version)
+		res = TEE_ERROR_ACCESS_CONFLICT;
+
+	tee_tadb_ta_close(ta);
+	return res;
+}
+
+static TEE_Result install_ta(struct shdr *shdr, const uint8_t *nw,
+			     size_t nw_size)
+{
+	TEE_Result res;
+	struct tee_tadb_ta_write *ta;
+	uint32_t hash_algo;
+	void *hash_ctx = NULL;
+	size_t hash_ctx_size;
+	size_t offs;
+	const size_t buf_size = 2 * 4096;
+	void *buf;
+	struct tee_tadb_property property;
+	struct shdr_bootstrap_ta bs_ta;
+
+	if (shdr->img_type != SHDR_BOOTSTRAP_TA)
+		return TEE_ERROR_SECURITY;
+
+	if (nw_size < (sizeof(struct shdr_bootstrap_ta) + SHDR_GET_SIZE(shdr)))
+		return TEE_ERROR_SECURITY;
+
+	if (shdr->hash_size > buf_size)
+		return TEE_ERROR_SECURITY;
+
+	buf = malloc(buf_size);
+	if (!buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	/*
+	 * Initialize a hash context and run the algorithm over the signed
+	 * header (less the final file hash and its signature of course)
+	 */
+	hash_algo = TEE_DIGEST_HASH_TO_ALGO(shdr->algo);
+	res = crypto_hash_get_ctx_size(hash_algo, &hash_ctx_size);
+	if (res)
+		goto err;
+	hash_ctx = malloc(hash_ctx_size);
+	if (!hash_ctx) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
+	res = crypto_hash_init(hash_ctx, hash_algo);
+	if (res)
+		goto err_free_hash_ctx;
+	res = crypto_hash_update(hash_ctx, hash_algo, (uint8_t *)shdr,
+				     sizeof(*shdr));
+	if (res)
+		goto err_free_hash_ctx;
+
+	offs = SHDR_GET_SIZE(shdr);
+	memcpy(&bs_ta, nw + offs, sizeof(bs_ta));
+
+	/* Check that we're not downgrading a TA */
+	res = check_install_conflict(&bs_ta);
+	if (res)
+		goto err_free_hash_ctx;
+
+	res = crypto_hash_update(hash_ctx, hash_algo, (uint8_t *)&bs_ta,
+				     sizeof(bs_ta));
+	if (res)
+		goto err_free_hash_ctx;
+	offs += sizeof(bs_ta);
+
+	memset(&property, 0, sizeof(property));
+	COMPILE_TIME_ASSERT(sizeof(property.uuid) == sizeof(bs_ta.uuid));
+	tee_uuid_from_octets(&property.uuid, bs_ta.uuid);
+	property.version = bs_ta.version;
+	property.custom_size = 0;
+	property.bin_size = nw_size - offs;
+	DMSG("Installing %pUl", (void *)&property.uuid);
+
+	res = tee_tadb_ta_create(&property, &ta);
+	if (res)
+		goto err_free_hash_ctx;
+
+	while (offs < nw_size) {
+		size_t l = MIN(buf_size, nw_size - offs);
+
+		memcpy(buf, nw + offs, l);
+		res = crypto_hash_update(hash_ctx, hash_algo, buf, l);
+		if (res)
+			goto err_ta_finalize;
+		res = tee_tadb_ta_write(ta, buf, l);
+		if (res)
+			goto err_ta_finalize;
+		offs += l;
+	}
+
+	res = crypto_hash_final(hash_ctx, hash_algo, buf, shdr->hash_size);
+	if (res)
+		goto err_free_hash_ctx;
+	if (buf_compare_ct(buf, SHDR_GET_HASH(shdr), shdr->hash_size)) {
+		res = TEE_ERROR_SECURITY;
+		goto err_free_hash_ctx;
+	}
+
+	free(hash_ctx);
+	free(buf);
+	return tee_tadb_ta_close_and_commit(ta);
+
+err_ta_finalize:
+	tee_tadb_ta_close_and_delete(ta);
+err_free_hash_ctx:
+	free(hash_ctx);
+err:
+	free(buf);
+	return res;
+}
+
+static TEE_Result bootstrap(uint32_t param_types,
+			    TEE_Param params[TEE_NUM_PARAMS])
+{
+	TEE_Result res;
+	struct shdr *shdr;
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	shdr = shdr_alloc_and_copy(params->memref.buffer, params->memref.size);
+	if (!shdr)
+		return TEE_ERROR_SECURITY;
+
+	res = shdr_verify_signature(shdr);
+	if (res)
+		goto out;
+
+	res = install_ta(shdr, params->memref.buffer, params->memref.size);
+out:
+	shdr_free(shdr);
+	return res;
+}
+
+static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+				 uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	switch (cmd_id) {
+	case PTA_SECSTOR_TA_MGMT_BOOTSTRAP:
+		return bootstrap(param_types, params);
+	default:
+		break;
+	}
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+pseudo_ta_register(.uuid = PTA_SECSTOR_TA_MGMT_UUID, .name = "secstor_ta_mgmt",
+		   /*
+		    * TA_FLAG_SINGLE_INSTANCE and TA_FLAG_MULTI_SESSION are
+		    * current part of PTA_DEFAULT_FLAGS, but as this TA
+		    * depends on those two flags we add them explicitly
+		    * too.
+		    */
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_SINGLE_INSTANCE |
+			    TA_FLAG_MULTI_SESSION,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/pta/sub.mk
+++ b/core/arch/arm/pta/sub.mk
@@ -3,6 +3,7 @@ srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += core_self_tests.c
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += interrupt_tests.c
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += core_mutex_tests.c
 ifeq ($(CFG_WITH_USER_TA),y)
+srcs-$(CFG_SECSTOR_TA_MGMT_PTA) += secstor_ta_mgmt.c
 srcs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += core_fs_htree_tests.c
 endif
 srcs-$(CFG_WITH_STATS) += stats.c

--- a/core/crypto/signed_hdr.c
+++ b/core/crypto/signed_hdr.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015-2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <crypto/crypto.h>
+#include <signed_hdr.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ta_pub_key.h>
+#include <tee_api_types.h>
+#include <tee/tee_cryp_utl.h>
+#include <utee_defines.h>
+
+struct shdr *shdr_alloc_and_copy(const struct shdr *img, size_t img_size)
+{
+	size_t shdr_size;
+	struct shdr *shdr;
+
+	if (img_size < sizeof(struct shdr))
+		NULL;
+	shdr_size = SHDR_GET_SIZE(img);
+	if (img_size < shdr_size)
+		NULL;
+
+	shdr = malloc(shdr_size);
+	if (!shdr)
+		return NULL;
+	memcpy(shdr, img, shdr_size);
+
+	/* Check that the data wasn't modified before the copy was completed */
+	if (shdr_size != SHDR_GET_SIZE(shdr)) {
+		free(shdr);
+		return NULL;
+	}
+
+	return shdr;
+}
+
+TEE_Result shdr_verify_signature(const struct shdr *shdr)
+{
+	struct rsa_public_key key;
+	TEE_Result res;
+	uint32_t e = TEE_U32_TO_BIG_ENDIAN(ta_pub_key_exponent);
+	size_t hash_size;
+
+	if (shdr->magic != SHDR_MAGIC)
+		return TEE_ERROR_SECURITY;
+
+	if (TEE_ALG_GET_MAIN_ALG(shdr->algo) != TEE_MAIN_ALGO_RSA)
+		return TEE_ERROR_SECURITY;
+
+	res = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(shdr->algo),
+				       &hash_size);
+	if (res)
+		return TEE_ERROR_SECURITY;
+	if (hash_size != shdr->hash_size)
+		return TEE_ERROR_SECURITY;
+
+	res = crypto_acipher_alloc_rsa_public_key(&key, shdr->sig_size);
+	if (res)
+		return TEE_ERROR_SECURITY;
+
+	res = crypto_bignum_bin2bn((uint8_t *)&e, sizeof(e), key.e);
+	if (res)
+		goto out;
+	res = crypto_bignum_bin2bn(ta_pub_key_modulus, ta_pub_key_modulus_size,
+				   key.n);
+	if (res)
+		goto out;
+
+	res = crypto_acipher_rsassa_verify(shdr->algo, &key, -1,
+					   SHDR_GET_HASH(shdr), shdr->hash_size,
+					   SHDR_GET_SIG(shdr), shdr->sig_size);
+out:
+	crypto_acipher_free_rsa_public_key(&key);
+	if (res)
+		return TEE_ERROR_SECURITY;
+	return TEE_SUCCESS;
+}

--- a/core/crypto/sub.mk
+++ b/core/crypto/sub.mk
@@ -6,3 +6,4 @@ srcs-y += aes-gcm-ghash-tbl.c
 else
 srcs-y += aes-gcm-ghash.c
 endif
+srcs-$(CFG_WITH_USER_TA) += signed_hdr.c

--- a/core/include/kernel/refcount.h
+++ b/core/include/kernel/refcount.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef __KERNEL_REFCOUNT_H
+#define __KERNEL_REFCOUNT_H
+
+#include <atomic.h>
+
+/*
+ * Reference counter
+ *
+ * When val is 0, refcount_inc() does not change the value and returns false.
+ * Otherwise, it increments the value and returns true.
+ *
+ * refcount_dec() decrements the value and returns true when the call
+ * caused the value to become 0, false otherwise.
+ *
+ * Since each call to refcount_dec() is supposed to match a call to
+ * refcount_inc(), refcount_dec() called for val == 0 should never happen.
+ *
+ * This behaviour makes this pattern possible:
+ * if (!refcount_inc(r)) {
+ *	mutex_lock(m);
+ *	// Some other thread may have initialized o by now so check that
+ *	// we still need to initialize o.
+ *	if (!o) {
+ *		o = initialize();
+ *		refcount_set(r, 1);
+ *	}
+ *	mutex_unlock(m);
+ * }
+ *
+ * or
+ * if (refcount_dec(r)) {
+ *	mutex_lock(m);
+ *	// Now that we have the mutex o can't be ininialized/uninitialized
+ *	// by any other thread, check that the refcount value is still 0
+ *	// to guard against the thread above already having reinitialized o
+ *	if (!refcount_val(r) && o)
+ *		uninitialize(o)
+ *	mutex_unlock(m);
+ * }
+ *
+ * where r if the reference counter, o is the object and m the mutex
+ * protecting the object.
+ */
+
+struct refcount {
+	unsigned int val;
+};
+
+/* Increases refcount by 1, return true if val > 0 else false */
+bool refcount_inc(struct refcount *r);
+/* Decreases refcount by 1, return true if val == 0 else false */
+bool refcount_dec(struct refcount *r);
+
+static inline void refcount_set(struct refcount *r, unsigned int val)
+{
+	atomic_store_uint(&r->val, val);
+}
+
+static inline unsigned int refcount_val(struct refcount *r)
+{
+	return atomic_load_uint(&r->val);
+}
+
+#endif /*!__KERNEL_REFCOUNT_H*/

--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -28,9 +28,11 @@
 #define SIGNED_HDR_H
 
 #include <inttypes.h>
+#include <tee_api_types.h>
 
 enum shdr_img_type {
 	SHDR_TA = 0,
+	SHDR_BOOTSTRAP_TA = 1,
 };
 
 #define SHDR_MAGIC	0x4f545348
@@ -70,6 +72,11 @@ struct shdr {
 				 (x)->sig_size)
 #define SHDR_GET_HASH(x)	(uint8_t *)(((struct shdr *)(x)) + 1)
 #define SHDR_GET_SIG(x)		(SHDR_GET_HASH(x) + (x)->hash_size)
+
+struct shdr_bootstrap_ta {
+	uint8_t uuid[sizeof(TEE_UUID)];
+	uint32_t version;
+};
 
 #endif /*SIGNED_HDR_H*/
 

--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -29,6 +29,7 @@
 
 #include <inttypes.h>
 #include <tee_api_types.h>
+#include <stdlib.h>
 
 enum shdr_img_type {
 	SHDR_TA = 0,
@@ -78,5 +79,26 @@ struct shdr_bootstrap_ta {
 	uint32_t version;
 };
 
-#endif /*SIGNED_HDR_H*/
+/*
+ * Allocates a struct shdr large enough to hold the entire header,
+ * excluding a subheader like struct shdr_bootstrap_ta.
+ */
+struct shdr *shdr_alloc_and_copy(const struct shdr *img, size_t img_size);
 
+/* Frees a previously allocated struct shdr */
+static inline void shdr_free(struct shdr *shdr)
+{
+	free(shdr);
+}
+
+/*
+ * Verifies the signature in the @shdr.
+ *
+ * Note that the static part of struct shdr and payload still need to be
+ * checked against the hash contained in the header.
+ *
+ * Returns TEE_SUCCESS on success or TEE_ERROR_SECURITY on failure
+ */
+TEE_Result shdr_verify_signature(const struct shdr *shdr);
+
+#endif /*SIGNED_HDR_H*/

--- a/core/include/tee/tadb.h
+++ b/core/include/tee/tadb.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef __TEE_TADB_H
+#define __TEE_TADB_H
+
+#include <tee/tee_fs.h>
+
+struct tee_tadb_ta_write;
+struct tee_tadb_ta_read;
+
+/*
+ * struct tee_tadb_property
+ * @uuid:	UUID of Trusted Application (TA) or Security Domain (SD)
+ * @version:	Version of TA or SD
+ * @custom_size:Size of customized properties, prepended to the encrypted
+ *		TA binary
+ * @bin_size:	Size of the binary TA
+ */
+struct tee_tadb_property {
+	TEE_UUID uuid;
+	uint32_t version;
+	uint32_t custom_size;
+	uint32_t bin_size;
+};
+
+struct tee_fs_rpc_operation;
+
+struct tee_tadb_file_operations {
+	TEE_Result (*open)(uint32_t file_number, int *fd);
+	TEE_Result (*create)(uint32_t file_number, int *fd);
+	void (*close)(int fd);
+	TEE_Result (*remove)(uint32_t file_number);
+
+	TEE_Result (*read_init)(struct tee_fs_rpc_operation *op, int fd,
+				size_t pos, uint8_t **data, size_t bytes);
+	TEE_Result (*read_final)(struct tee_fs_rpc_operation *op,
+				size_t *bytes);
+
+	TEE_Result (*write_init)(struct tee_fs_rpc_operation *op, int fd,
+				 size_t pos, uint8_t **data, size_t len);
+	TEE_Result (*write_final)(struct tee_fs_rpc_operation *op);
+};
+
+TEE_Result tee_tadb_ta_create(const struct tee_tadb_property *property,
+			      struct tee_tadb_ta_write **ta);
+TEE_Result tee_tadb_ta_write(struct tee_tadb_ta_write *ta, const void *buf,
+			     size_t len);
+void tee_tadb_ta_close_and_delete(struct tee_tadb_ta_write *ta);
+TEE_Result tee_tadb_ta_close_and_commit(struct tee_tadb_ta_write *ta);
+
+TEE_Result tee_tadb_ta_delete(const TEE_UUID *uuid);
+
+TEE_Result tee_tadb_ta_open(const TEE_UUID *uuid, struct tee_tadb_ta_read **ta);
+const struct tee_tadb_property *
+tee_tadb_ta_get_property(struct tee_tadb_ta_read *ta);
+TEE_Result tee_tadb_ta_read(struct tee_tadb_ta_read *ta, void *buf,
+			    size_t *len);
+void tee_tadb_ta_close(struct tee_tadb_ta_read *ta);
+
+
+#endif /*__TEE_TADB_H*/

--- a/core/include/tee/tee_svc_storage.h
+++ b/core/include/tee/tee_svc_storage.h
@@ -33,6 +33,13 @@
 #include <tee/tee_fs.h>
 
 /*
+ * Returns the appropriate tee_file_operations for the specified storage ID.
+ * The value TEE_STORAGE_PRIVATE will select the REE FS if available, otherwise
+ * RPMB.
+ */
+const struct tee_file_operations *tee_svc_storage_file_ops(uint32_t storage_id);
+
+/*
  * Persistant Object Functions
  */
 TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,

--- a/core/kernel/refcount.c
+++ b/core/kernel/refcount.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <assert.h>
+#include <atomic.h>
+#include <kernel/refcount.h>
+
+bool refcount_inc(struct refcount *r)
+{
+	unsigned int nval;
+	unsigned int oval = atomic_load_uint(&r->val);
+
+	while (true) {
+		nval = oval + 1;
+
+		/* r->val is 0, we can't do anything more. */
+		if (!oval)
+			return false;
+
+		if (atomic_cas_uint(&r->val, &oval, nval))
+			return true;
+		/*
+		 * At this point atomic_cas_uint() has updated oval to the
+		 * current r->val.
+		 */
+	}
+}
+
+bool refcount_dec(struct refcount *r)
+{
+	unsigned int nval;
+	unsigned int oval = atomic_load_uint(&r->val);
+
+	while (true) {
+		assert(oval);
+		nval = oval - 1;
+
+		if (atomic_cas_uint(&r->val, &oval, nval)) {
+			/*
+			 * Value has been updated, if value was set to 0
+			 * return true to indicate that.
+			 */
+			return !nval;
+		}
+		/*
+		 * At this point atomic_cas_uint() has updated oval to the
+		 * current r->val.
+		 */
+	}
+}

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -10,3 +10,4 @@ srcs-y += interrupt.c
 srcs-$(CFG_CORE_SANITIZE_UNDEFINED) += ubsan.c
 srcs-$(CFG_CORE_SANITIZE_KADDRESS) += asan.c
 cflags-remove-asan.c-y += $(cflags_kasan)
+srcs-y += refcount.c

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -3,7 +3,7 @@ subdirs-y += crypto
 subdirs-y += tee
 subdirs-y += drivers
 
-ifeq ($(CFG_WITH_USER_TA)-$(CFG_REE_FS_TA),y-y)
+ifeq ($(CFG_WITH_USER_TA),y)
 gensrcs-y += ta_pub_key
 produce-ta_pub_key = ta_pub_key.c
 depends-ta_pub_key = $(TA_SIGN_KEY) scripts/pem_to_pub_c.py

--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -634,6 +634,7 @@ static TEE_Result init_root_node(struct tee_fs_htree *ht)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
 	ht->root.id = 1;
+	ht->root.dirty = true;
 
 	res = calc_node_hash(&ht->root, ctx, ht->root.node.hash);
 	free(ctx);

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -40,6 +40,8 @@ srcs-y += tee_obj.c
 srcs-y += tee_pobj.c
 srcs-y += tee_time_generic.c
 
+srcs-$(CFG_SECSTOR_TA) += tadb.c
+
 endif #CFG_WITH_USER_TA,y
 
 srcs-y += uuid.c

--- a/core/tee/tadb.c
+++ b/core/tee/tadb.c
@@ -1,0 +1,764 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <bitstring.h>
+#include <crypto/crypto.h>
+#include <kernel/msg_param.h>
+#include <kernel/mutex.h>
+#include <kernel/refcount.h>
+#include <kernel/thread.h>
+#include <optee_msg_supplicant.h>
+#include <string.h>
+#include <tee_api_defines_extensions.h>
+#include <tee/tadb.h>
+#include <tee/tee_fs.h>
+#include <tee/tee_fs_rpc.h>
+#include <tee/tee_pobj.h>
+#include <tee/tee_svc_storage.h>
+#include <utee_defines.h>
+
+#define TADB_MAX_BUFFER_SIZE	(64U * 1024)
+
+#define TADB_AUTH_ENC_ALG	TEE_ALG_AES_GCM
+#define TADB_IV_SIZE		TEE_AES_BLOCK_SIZE
+#define TADB_TAG_SIZE		TEE_AES_BLOCK_SIZE
+#define TADB_KEY_SIZE		TEE_AES_MAX_KEY_SIZE
+
+struct tee_tadb_dir {
+	const struct tee_file_operations *ops;
+	struct tee_file_handle *fh;
+	int nbits;
+	bitstr_t *files;
+};
+
+struct tadb_entry {
+	struct tee_tadb_property prop;
+	uint32_t file_number;
+	uint8_t iv[TADB_IV_SIZE];
+	uint8_t tag[TADB_TAG_SIZE];
+	uint8_t key[TADB_KEY_SIZE];
+};
+
+struct tadb_header {
+	uint32_t opaque_len;
+	uint8_t opaque[];
+};
+
+struct tee_tadb_ta_write {
+	struct tee_tadb_dir *db;
+	int fd;
+	struct tadb_entry entry;
+	size_t pos;
+	void *ctx;
+};
+
+struct tee_tadb_ta_read {
+	struct tee_tadb_dir *db;
+	int fd;
+	struct tadb_entry entry;
+	size_t pos;
+	void *ctx;
+	uint64_t ta_cookie;
+	struct mobj *ta_mobj;
+	uint8_t *ta_buf;
+};
+
+static const char tadb_obj_id[] = "ta.db";
+static struct tee_tadb_dir *tadb_db;
+static struct refcount tadb_db_refc;
+static struct mutex tadb_mutex = MUTEX_INITIALIZER;
+
+static void file_num_to_str(char *buf, size_t blen, uint32_t file_number)
+{
+	snprintf(buf, blen, "%" PRIu32 ".ta", file_number);
+}
+
+static bool is_null_uuid(const TEE_UUID *uuid)
+{
+	const TEE_UUID null_uuid = { 0 };
+
+	return !memcmp(uuid, &null_uuid, sizeof(*uuid));
+}
+
+static TEE_Result ta_operation_open(unsigned int cmd, uint32_t file_number,
+				    int *fd)
+{
+	struct mobj *mobj;
+	TEE_Result res;
+	void *va;
+	uint64_t cookie;
+	struct optee_msg_param params[] = {
+		[0] = { .attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT,
+			.u.value.a = cmd },
+		[2] = { .attr = OPTEE_MSG_ATTR_TYPE_VALUE_OUTPUT }
+	};
+
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &mobj, &cookie);
+	if (!va)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	if (!msg_param_init_memparam(params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
+	file_num_to_str(va, TEE_FS_NAME_MAX, file_number);
+
+	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_FS, ARRAY_SIZE(params), params);
+	if (!res)
+		*fd = params[2].u.value.a;
+
+	return res;
+}
+
+static TEE_Result ta_operation_remove(uint32_t file_number)
+{
+	struct mobj *mobj;
+	void *va;
+	uint64_t cookie;
+	struct optee_msg_param params[2] = {
+		[0] = { .attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT,
+			.u.value.a = OPTEE_MRF_REMOVE },
+	};
+
+	va = tee_fs_rpc_cache_alloc(TEE_FS_NAME_MAX, &mobj, &cookie);
+	if (!va)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	if (!msg_param_init_memparam(params + 1, mobj, 0, TEE_FS_NAME_MAX,
+				     cookie, MSG_PARAM_MEM_DIR_IN))
+		return TEE_ERROR_BAD_STATE;
+
+	file_num_to_str(va, TEE_FS_NAME_MAX, file_number);
+
+	return thread_rpc_cmd(OPTEE_MSG_RPC_CMD_FS, ARRAY_SIZE(params), params);
+}
+
+static TEE_Result maybe_grow_files(struct tee_tadb_dir *db, int idx)
+{
+	void *p;
+
+	if (idx < db->nbits)
+		return TEE_SUCCESS;
+
+	p = realloc(db->files, bitstr_size(idx + 1));
+	if (!p)
+		return TEE_ERROR_OUT_OF_MEMORY;
+	db->files = p;
+
+	bit_nclear(db->files, db->nbits, idx);
+	db->nbits = idx + 1;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result set_file(struct tee_tadb_dir *db, int idx)
+{
+	TEE_Result res = maybe_grow_files(db, idx);
+
+	if (!res)
+		bit_set(db->files, idx);
+
+	return res;
+}
+
+static void clear_file(struct tee_tadb_dir *db, int idx)
+{
+	if (idx < db->nbits)
+		bit_clear(db->files, idx);
+}
+
+static bool test_file(struct tee_tadb_dir *db, int idx)
+{
+	if (idx < db->nbits)
+		return bit_test(db->files, idx);
+
+	return false;
+}
+
+static TEE_Result read_ent(struct tee_tadb_dir *db, size_t idx,
+			   struct tadb_entry *entry)
+{
+	size_t l = sizeof(*entry);
+	TEE_Result res = db->ops->read(db->fh, idx * l, entry, &l);
+
+	if (!res && l != sizeof(*entry))
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	return res;
+}
+
+static TEE_Result write_ent(struct tee_tadb_dir *db, size_t idx,
+			    const struct tadb_entry *entry)
+{
+	const size_t l = sizeof(*entry);
+
+	return db->ops->write(db->fh, idx * l, entry, l);
+}
+
+static TEE_Result tadb_open(struct tee_tadb_dir **db_ret)
+{
+	TEE_Result res;
+	struct tee_tadb_dir *db = calloc(1, sizeof(*db));
+	struct tee_pobj po = {
+		.obj_id = (void *)tadb_obj_id,
+		.obj_id_len = sizeof(tadb_obj_id)
+	};
+
+	if (!db)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	db->ops = tee_svc_storage_file_ops(TEE_STORAGE_PRIVATE);
+
+	res = db->ops->open(&po, NULL, &db->fh);
+	if (res == TEE_ERROR_ITEM_NOT_FOUND)
+		res = db->ops->create(&po, false, NULL, 0, NULL, 0, NULL, 0,
+				      &db->fh);
+
+	if (res)
+		free(db);
+	else
+		*db_ret = db;
+
+	return res;
+}
+
+static TEE_Result tee_tadb_open(struct tee_tadb_dir **db)
+{
+	if (!refcount_inc(&tadb_db_refc)) {
+		TEE_Result res;
+
+		mutex_lock(&tadb_mutex);
+		res = tadb_open(&tadb_db);
+		if (!res)
+			refcount_set(&tadb_db_refc, 1);
+		mutex_unlock(&tadb_mutex);
+		if (res)
+			return res;
+	}
+
+	*db = tadb_db;
+	return TEE_SUCCESS;
+}
+
+static void tadb_put(struct tee_tadb_dir *db)
+{
+	if (refcount_dec(&tadb_db_refc)) {
+		mutex_lock(&tadb_mutex);
+		if (!refcount_val(&tadb_db_refc) && tadb_db) {
+			db->ops->close(&db->fh);
+			free(db->files);
+			free(db);
+			tadb_db = NULL;
+		}
+		mutex_unlock(&tadb_mutex);
+	}
+}
+
+static void tee_tadb_close(struct tee_tadb_dir *db)
+{
+	tadb_put(db);
+}
+
+static TEE_Result tadb_authenc_init(TEE_OperationMode mode,
+				    const struct tadb_entry *entry,
+				    void **ctx_ret)
+{
+	TEE_Result res;
+	void *ctx;
+	size_t sz;
+	const size_t enc_size = entry->prop.custom_size + entry->prop.bin_size;
+
+	res = crypto_authenc_get_ctx_size(TADB_AUTH_ENC_ALG, &sz);
+	if (res)
+		return res;
+
+	ctx = malloc(sz);
+	if (!ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = crypto_authenc_init(ctx, TADB_AUTH_ENC_ALG, mode,
+				  entry->key, sizeof(entry->key),
+				  entry->iv, sizeof(entry->iv),
+				  sizeof(entry->tag), 0, enc_size);
+	if (res)
+		free(ctx);
+	else
+		*ctx_ret = ctx;
+
+	return res;
+}
+
+static TEE_Result tadb_update_payload(void *ctx, TEE_OperationMode mode,
+				      const void *src, size_t len, void *dst)
+{
+	TEE_Result res;
+	size_t sz = len;
+
+	res = crypto_authenc_update_payload(ctx, TADB_AUTH_ENC_ALG, mode,
+					    (const uint8_t *)src, len, dst,
+					    &sz);
+	assert(res || sz == len);
+	return res;
+}
+
+static TEE_Result populate_files(struct tee_tadb_dir *db)
+{
+	TEE_Result res;
+	size_t idx;
+
+	/*
+	 * If db->files isn't NULL the bitfield is already populated and
+	 * there's nothing left to do here for now.
+	 */
+	if (db->files)
+		return TEE_SUCCESS;
+
+	/*
+	 * Iterate over the TA database and set the bits in the bit field
+	 * for used file numbers. Note that set_file() will allocate and
+	 * grow the bitfield as needed.
+	 *
+	 * At the same time clean out duplicate file numbers, the first
+	 * entry with the file number has precedence. Duplicate entries is
+	 * not supposed to be able to happen, but if it still does better
+	 * to clean it out here instead of letting the error spread with
+	 * unexpected side effects.
+	 */
+	for (idx = 0;; idx++) {
+		struct tadb_entry entry;
+
+		res = read_ent(db, idx, &entry);
+		if (res) {
+			if (res == TEE_ERROR_ITEM_NOT_FOUND)
+				return TEE_SUCCESS;
+			goto err;
+		}
+
+		if (is_null_uuid(&entry.prop.uuid))
+			continue;
+
+		if (test_file(db, entry.file_number)) {
+			IMSG("Clearing duplicate file number %" PRIu32,
+			     entry.file_number);
+			memset(&entry, 0, sizeof(entry));
+			res = write_ent(db, idx, &entry);
+			if (res)
+				goto err;
+			continue;
+		}
+
+		res = set_file(db, entry.file_number);
+		if (res)
+			goto err;
+	}
+
+err:
+	free(db->files);
+	db->files = NULL;
+	db->nbits = 0;
+
+	return res;
+}
+
+TEE_Result tee_tadb_ta_create(const struct tee_tadb_property *property,
+			      struct tee_tadb_ta_write **ta_ret)
+{
+	TEE_Result res;
+	struct tee_tadb_ta_write *ta;
+	int i = 0;
+
+	if (is_null_uuid(&property->uuid))
+		return TEE_ERROR_GENERIC;
+
+	ta = calloc(1, sizeof(*ta));
+	if (!ta)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = tee_tadb_open(&ta->db);
+	if (res)
+		goto err;
+
+	mutex_lock(&tadb_mutex);
+
+	/*
+	 * Since we're going to search for next free file number below we
+	 * need to populate the bitfield holding used file numbers.
+	 */
+	res = populate_files(ta->db);
+	if (res)
+		goto err_mutex;
+
+	if (ta->db->files) {
+		bit_ffc(ta->db->files, ta->db->nbits, &i);
+		if (i == -1)
+			i = ta->db->nbits;
+	}
+
+	res = set_file(ta->db, i);
+	if (res)
+		goto err_mutex;
+
+	mutex_unlock(&tadb_mutex);
+
+	ta->entry.file_number = i;
+	ta->entry.prop = *property;
+
+	res = crypto_rng_read(ta->entry.iv, sizeof(ta->entry.iv));
+	if (res)
+		goto err;
+
+	res = crypto_rng_read(ta->entry.key, sizeof(ta->entry.key));
+	if (res)
+		goto err;
+
+	res = ta_operation_open(OPTEE_MRF_CREATE, ta->entry.file_number,
+				&ta->fd);
+	if (res)
+		goto err;
+
+	res = tadb_authenc_init(TEE_MODE_ENCRYPT, &ta->entry, &ta->ctx);
+	if (res)
+		goto err;
+
+	*ta_ret = ta;
+
+	return TEE_SUCCESS;
+
+err_mutex:
+	mutex_unlock(&tadb_mutex);
+err:
+	tadb_put(ta->db);
+	free(ta);
+
+	return res;
+}
+
+TEE_Result tee_tadb_ta_write(struct tee_tadb_ta_write *ta, const void *buf,
+			     size_t len)
+{
+	TEE_Result res;
+	const uint8_t *rb = buf;
+	size_t rl = len;
+	struct tee_fs_rpc_operation op;
+
+	while (rl) {
+		size_t wl = MIN(rl, TADB_MAX_BUFFER_SIZE);
+		void *wb;
+
+		res = tee_fs_rpc_write_init(&op, OPTEE_MSG_RPC_CMD_FS, ta->fd,
+					    ta->pos, wl, &wb);
+		if (res)
+			return res;
+
+		res = tadb_update_payload(ta->ctx, TEE_MODE_ENCRYPT,
+					  rb, wl, wb);
+		if (res)
+			return res;
+
+		res = tee_fs_rpc_write_final(&op);
+		if (res)
+			return res;
+
+		rl -= wl;
+		rb += wl;
+		ta->pos += wl;
+	}
+
+	return TEE_SUCCESS;
+}
+
+void tee_tadb_ta_close_and_delete(struct tee_tadb_ta_write *ta)
+{
+	crypto_authenc_final(ta->ctx, TADB_AUTH_ENC_ALG);
+	free(ta->ctx);
+	tee_fs_rpc_close(OPTEE_MSG_RPC_CMD_FS, ta->fd);
+	ta_operation_remove(ta->entry.file_number);
+
+	mutex_lock(&tadb_mutex);
+	clear_file(ta->db, ta->entry.file_number);
+	mutex_unlock(&tadb_mutex);
+
+	tadb_put(ta->db);
+	free(ta);
+}
+
+static TEE_Result find_ent(struct tee_tadb_dir *db, const TEE_UUID *uuid,
+			   size_t *idx_ret, struct tadb_entry *entry_ret)
+{
+	TEE_Result res;
+	size_t idx;
+
+	/*
+	 * Search for the provided uuid, if it's found return the index it
+	 * has together with TEE_SUCCESS.
+	 *
+	 * If the uuid can't be found return the number indexes together
+	 * with TEE_ERROR_ITEM_NOT_FOUND.
+	 */
+	for (idx = 0;; idx++) {
+		struct tadb_entry entry;
+
+		res = read_ent(db, idx, &entry);
+		if (res) {
+			if (res == TEE_ERROR_ITEM_NOT_FOUND)
+				break;
+			return res;
+		}
+
+		if (!memcmp(&entry.prop.uuid, uuid, sizeof(*uuid))) {
+			if (entry_ret)
+				*entry_ret = entry;
+			break;
+		}
+	}
+
+	*idx_ret = idx;
+	return res;
+}
+
+static TEE_Result find_free_ent_idx(struct tee_tadb_dir *db, size_t *idx)
+{
+	const TEE_UUID null_uuid = { 0 };
+	TEE_Result res = find_ent(db, &null_uuid, idx, NULL);
+
+	/*
+	 * Note that *idx is set to the number of entries on
+	 * TEE_ERROR_ITEM_NOT_FOUND.
+	 */
+	if (res == TEE_ERROR_ITEM_NOT_FOUND)
+		return TEE_SUCCESS;
+	return res;
+}
+
+TEE_Result tee_tadb_ta_close_and_commit(struct tee_tadb_ta_write *ta)
+{
+	TEE_Result res;
+	size_t dsz = 0;
+	size_t sz = sizeof(ta->entry.tag);
+	size_t idx;
+	struct tadb_entry old_ent;
+	bool have_old_ent = false;
+
+	res = crypto_authenc_enc_final(ta->ctx, TADB_AUTH_ENC_ALG,
+				       NULL, 0, NULL, &dsz,
+				       ta->entry.tag, &sz);
+	if (res)
+		goto err;
+
+	tee_fs_rpc_close(OPTEE_MSG_RPC_CMD_FS, ta->fd);
+
+	mutex_lock(&tadb_mutex);
+	/*
+	 * First try to find an existing TA to replace. If there's one
+	 * we'll use the entry, but we should also remove the old encrypted
+	 * file.
+	 *
+	 * If there isn't an existing TA to replace, grab a new entry.
+	 */
+	res = find_ent(ta->db, &ta->entry.prop.uuid, &idx, &old_ent);
+	if (!res) {
+		have_old_ent = true;
+	} else {
+		res = find_free_ent_idx(ta->db, &idx);
+		if (res)
+			goto err_mutex;
+	}
+	res = write_ent(ta->db, idx, &ta->entry);
+	if (res)
+		goto err_mutex;
+	if (have_old_ent)
+		clear_file(ta->db, old_ent.file_number);
+	mutex_unlock(&tadb_mutex);
+
+	crypto_authenc_final(ta->ctx, TADB_AUTH_ENC_ALG);
+	free(ta->ctx);
+	tadb_put(ta->db);
+	free(ta);
+	if (have_old_ent)
+		ta_operation_remove(old_ent.file_number);
+	return TEE_SUCCESS;
+
+err_mutex:
+	mutex_unlock(&tadb_mutex);
+err:
+	tee_tadb_ta_close_and_delete(ta);
+	return res;
+}
+
+TEE_Result tee_tadb_ta_delete(const TEE_UUID *uuid)
+{
+	const struct tadb_entry null_entry = { 0 };
+	struct tee_tadb_dir *db;
+	struct tadb_entry entry;
+	size_t idx;
+	TEE_Result res;
+
+	if (is_null_uuid(uuid))
+		return TEE_ERROR_GENERIC;
+
+	res = tee_tadb_open(&db);
+	if (res)
+		return res;
+
+	mutex_lock(&tadb_mutex);
+	res = find_ent(db, uuid, &idx, &entry);
+	if (res) {
+		mutex_unlock(&tadb_mutex);
+		tee_tadb_close(db);
+		return res;
+	}
+
+	clear_file(db, entry.file_number);
+	res = write_ent(db, idx, &null_entry);
+	mutex_unlock(&tadb_mutex);
+
+	tee_tadb_close(db);
+	if (res)
+		return res;
+
+	ta_operation_remove(entry.file_number);
+	return TEE_SUCCESS;
+}
+
+TEE_Result tee_tadb_ta_open(const TEE_UUID *uuid,
+			    struct tee_tadb_ta_read **ta_ret)
+{
+	TEE_Result res;
+	size_t idx;
+	struct tee_tadb_ta_read *ta;
+	static struct tadb_entry last_entry;
+
+	if (is_null_uuid(uuid))
+		return TEE_ERROR_GENERIC;
+
+	ta = calloc(1, sizeof(*ta));
+	if (!ta)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	if (!memcmp(uuid, &last_entry.prop.uuid, sizeof(*uuid))) {
+		ta->entry = last_entry;
+	} else {
+		res = tee_tadb_open(&ta->db);
+		if (res)
+			goto err_free; /* Mustn't all tadb_put() */
+
+		mutex_read_lock(&tadb_mutex);
+		res = find_ent(ta->db, uuid, &idx, &ta->entry);
+		mutex_read_unlock(&tadb_mutex);
+		if (res)
+			goto err;
+	}
+
+	res = ta_operation_open(OPTEE_MRF_OPEN, ta->entry.file_number, &ta->fd);
+	if (res)
+		goto err;
+
+	res = tadb_authenc_init(TEE_MODE_DECRYPT, &ta->entry, &ta->ctx);
+	if (res)
+		goto err;
+
+	*ta_ret = ta;
+
+	return TEE_SUCCESS;
+err:
+	tadb_put(ta->db);
+err_free:
+	free(ta);
+	return res;
+}
+
+const struct tee_tadb_property *
+tee_tadb_ta_get_property(struct tee_tadb_ta_read *ta)
+{
+	return &ta->entry.prop;
+}
+
+static TEE_Result ta_load(struct tee_tadb_ta_read *ta)
+{
+	TEE_Result res;
+	const size_t sz = ta->entry.prop.custom_size + ta->entry.prop.bin_size;
+	struct optee_msg_param params[2] = {
+		[0] = { .attr = OPTEE_MSG_ATTR_TYPE_VALUE_INPUT,
+			.u.value.a = OPTEE_MRF_READ,
+			.u.value.b = ta->fd,
+			.u.value.c = 0 },
+	};
+
+	if (ta->ta_mobj)
+		return TEE_SUCCESS;
+
+	ta->ta_mobj = thread_rpc_alloc_payload(sz, &ta->ta_cookie);
+	if (!ta->ta_mobj)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	ta->ta_buf = mobj_get_va(ta->ta_mobj, 0);
+	assert(ta->ta_buf);
+
+	if (!msg_param_init_memparam(params + 1, ta->ta_mobj, 0, sz,
+				     ta->ta_cookie, MSG_PARAM_MEM_DIR_OUT))
+		return TEE_ERROR_BAD_STATE;
+
+	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_FS, ARRAY_SIZE(params), params);
+	if (res) {
+		thread_rpc_free_payload(ta->ta_cookie, ta->ta_mobj);
+		ta->ta_mobj = NULL;
+	}
+	return res;
+}
+
+TEE_Result tee_tadb_ta_read(struct tee_tadb_ta_read *ta, void *buf, size_t *len)
+{
+	TEE_Result res;
+	const size_t sz = ta->entry.prop.custom_size + ta->entry.prop.bin_size;
+	size_t l = MIN(*len, sz - ta->pos);
+
+	res = ta_load(ta);
+	if (res)
+		return res;
+
+	if (buf) {
+		res = tadb_update_payload(ta->ctx, TEE_MODE_DECRYPT,
+					  ta->ta_buf + ta->pos, l, buf);
+		if (res)
+			return res;
+	} else {
+		size_t num_bytes = 0;
+		size_t b_size = MIN(SIZE_4K, l);
+		uint8_t *b = malloc(b_size);
+
+		if (!b)
+			return TEE_ERROR_OUT_OF_MEMORY;
+
+		while (num_bytes < l) {
+			size_t n = MIN(b_size, l - num_bytes);
+
+			res = tadb_update_payload(ta->ctx, TEE_MODE_DECRYPT,
+						  ta->ta_buf + ta->pos, n, b);
+			if (res)
+				break;
+			num_bytes += n;
+		}
+
+		free(b);
+		if (res)
+			return res;
+	}
+
+	ta->pos += l;
+	*len = l;
+	return TEE_SUCCESS;
+}
+
+void tee_tadb_ta_close(struct tee_tadb_ta_read *ta)
+{
+	crypto_authenc_final(ta->ctx, TADB_AUTH_ENC_ALG);
+	free(ta->ctx);
+	if (ta->ta_mobj)
+		thread_rpc_free_payload(ta->ta_cookie, ta->ta_mobj);
+	tee_fs_rpc_close(OPTEE_MSG_RPC_CMD_FS, ta->fd);
+	tadb_put(ta->db);
+	free(ta);
+}

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -41,12 +41,7 @@
 #include <tee/tee_svc_storage.h>
 #include <trace.h>
 
-/*
- * Returns the appropriate tee_file_operations for the specified storage ID.
- * The value TEE_STORAGE_PRIVATE will select the REE FS if available, otherwise
- * RPMB.
- */
-static const struct tee_file_operations *file_ops(uint32_t storage_id)
+const struct tee_file_operations *tee_svc_storage_file_ops(uint32_t storage_id)
 {
 
 	switch (storage_id) {
@@ -276,8 +271,9 @@ TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,
 	char *file = NULL;
 	struct tee_pobj *po = NULL;
 	struct user_ta_ctx *utc;
-	const struct tee_file_operations *fops = file_ops(storage_id);
 	size_t attr_size;
+	const struct tee_file_operations *fops =
+			tee_svc_storage_file_ops(storage_id);
 
 	if (!fops) {
 		res = TEE_ERROR_ITEM_NOT_FOUND;
@@ -425,7 +421,8 @@ TEE_Result syscall_storage_obj_create(unsigned long storage_id, void *object_id,
 	struct tee_obj *attr_o = NULL;
 	struct tee_pobj *po = NULL;
 	struct user_ta_ctx *utc;
-	const struct tee_file_operations *fops = file_ops(storage_id);
+	const struct tee_file_operations *fops =
+			tee_svc_storage_file_ops(storage_id);
 
 	if (!fops)
 		return TEE_ERROR_ITEM_NOT_FOUND;
@@ -705,7 +702,8 @@ TEE_Result syscall_storage_start_enum(unsigned long obj_enum,
 	struct tee_storage_enum *e;
 	TEE_Result res;
 	struct tee_ta_session *sess;
-	const struct tee_file_operations *fops = file_ops(storage_id);
+	const struct tee_file_operations *fops =
+			tee_svc_storage_file_ops(storage_id);
 
 	res = tee_ta_get_current_session(&sess);
 	if (res != TEE_SUCCESS)

--- a/lib/libutee/include/pta_secstor_ta_mgmt.h
+++ b/lib/libutee/include/pta_secstor_ta_mgmt.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef __PTA_SECSTOR_TA_MGMT_H
+#define __PTA_SECSTOR_TA_MGMT_H
+
+/*
+ * Bootstrap (install initial) Trusted Application or Secure Domain into
+ * secure storage from a signed binary.
+ *
+ * [in]		memref[0]: signed binary
+ */
+#define PTA_SECSTOR_TA_MGMT_BOOTSTRAP	0
+
+#define PTA_SECSTOR_TA_MGMT_UUID { 0x6e256cba, 0xfc4d, 0x4941, { \
+				   0xad, 0x09, 0x2c, 0xa1, 0x86, 0x03, 0x42, \
+				   0xdd } }
+
+#endif /*__PTA_SECSTOR_TA_MGMT_H*/

--- a/lib/libutils/ext/include/atomic.h
+++ b/lib/libutils/ext/include/atomic.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
+ * Copyright (c) 2016-2017, Linaro Limited
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,9 +29,41 @@
 #ifndef __ATOMIC_H
 #define __ATOMIC_H
 
+#include <compiler.h>
 #include <types_ext.h>
 
 uint32_t atomic_inc32(volatile uint32_t *v);
 uint32_t atomic_dec32(volatile uint32_t *v);
+
+static inline bool atomic_cas_uint(unsigned int *p, unsigned int *oval,
+				   unsigned int nval)
+{
+	return __compiler_compare_and_swap(p, oval, nval);
+}
+
+static inline bool atomic_cas_u32(uint32_t *p, uint32_t *oval, uint32_t nval)
+{
+	return __compiler_compare_and_swap(p, oval, nval);
+}
+
+static inline unsigned int atomic_load_uint(unsigned int *p)
+{
+	return __compiler_atomic_load(p);
+}
+
+static inline unsigned int atomic_load_u32(unsigned int *p)
+{
+	return __compiler_atomic_load(p);
+}
+
+static inline void atomic_store_uint(unsigned int *p, unsigned int val)
+{
+	__compiler_atomic_store(p, val);
+}
+
+static inline void atomic_store_u32(uint32_t *p, uint32_t val)
+{
+	__compiler_atomic_store(p, val);
+}
 
 #endif /*__ATOMIC_H*/

--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -185,4 +185,12 @@
 
 #endif /*!__HAVE_BUILTIN_OVERFLOW*/
 
+#define __compiler_compare_and_swap(p, oval, nval) \
+	__atomic_compare_exchange_n((p), (oval), (nval), true, \
+				    __ATOMIC_ACQUIRE, __ATOMIC_RELAXED) \
+
+#define __compiler_atomic_load(p) __atomic_load_n((p), __ATOMIC_RELAXED)
+#define __compiler_atomic_store(p, val) \
+	__atomic_store_n((p), (val), __ATOMIC_RELAXED)
+
 #endif /*COMPILER_H*/

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -277,10 +277,9 @@ CFG_SECURE_DATA_PATH ?= n
 CFG_SECSTOR_TA ?= $(call cfg-all-enabled,CFG_REE_FS CFG_WITH_USER_TA)
 $(eval $(call cfg-depends-all,CFG_SECSTOR_TA,CFG_REE_FS CFG_WITH_USER_TA))
 
-# Enable storage for TAs in secure storage, depends on CFG_REE_FS=y
-# TA binaries are stored encrypted in the REE FS and are protected by
-# metadata in secure storage.
-CFG_SECSTOR_TA ?= y
+# Enable the pseudo TA that managages TA storage in secure storage
+CFG_SECSTOR_TA_MGMT_PTA ?= $(call cfg-all-enabled,CFG_SECSTOR_TA)
+$(eval $(call cfg-depends-all,CFG_SECSTOR_TA_MGMT_PTA,CFG_SECSTOR_TA))
 
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -271,6 +271,17 @@ CFG_GP_SOCKETS ?= y
 # invocation parameters referring to specific secure memories).
 CFG_SECURE_DATA_PATH ?= n
 
+# Enable storage for TAs in secure storage, depends on CFG_REE_FS=y
+# TA binaries are stored encrypted in the REE FS and are protected by
+# metadata in secure storage.
+CFG_SECSTOR_TA ?= $(call cfg-all-enabled,CFG_REE_FS CFG_WITH_USER_TA)
+$(eval $(call cfg-depends-all,CFG_SECSTOR_TA,CFG_REE_FS CFG_WITH_USER_TA))
+
+# Enable storage for TAs in secure storage, depends on CFG_REE_FS=y
+# TA binaries are stored encrypted in the REE FS and are protected by
+# metadata in secure storage.
+CFG_SECSTOR_TA ?= y
+
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,
 # so its value represents log2(cores/cluster).

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2015, Linaro Limited
+# Copyright (c) 2015, 2017, Linaro Limited
 # All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -24,57 +26,76 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-#
+
+def uuid_parse(s):
+    from uuid import UUID
+    return UUID(s)
+
+
+def int_parse(str):
+    return int(str, 0)
+
 
 def get_args():
-	from argparse import ArgumentParser
+    from argparse import ArgumentParser
 
-	parser = ArgumentParser()
-	parser.add_argument('--key', required=True, help='Name of key file')
-	parser.add_argument('--in', required=True, dest='inf', \
-			help='Name of in file')
-	parser.add_argument('--out', required=True, help='Name of out file')
-	return parser.parse_args()
+    parser = ArgumentParser()
+    parser.add_argument('--uuid', required=True,
+                        type=uuid_parse, help='UUID of TA')
+    parser.add_argument('--version', type=int_parse, default=0, help='Version')
+    parser.add_argument('--key', required=True, help='Name of key file')
+    parser.add_argument('--in', required=True, dest='inf',
+                        help='Name of in file')
+    parser.add_argument('--out', required=True, help='Name of out file')
+    return parser.parse_args()
+
 
 def main():
-	from Crypto.Signature import PKCS1_v1_5
-	from Crypto.Hash import SHA256
-	from Crypto.PublicKey import RSA
-	import struct
+    from Crypto.Signature import PKCS1_v1_5
+    from Crypto.Hash import SHA256
+    from Crypto.PublicKey import RSA
+    import struct
 
-	args = get_args()
+    args = get_args()
 
-	f = open(args.key, 'rb')
-	key = RSA.importKey(f.read())
-	f.close()
+    f = open(args.key, 'rb')
+    key = RSA.importKey(f.read())
+    f.close()
 
-	f = open(args.inf, 'rb')
-	img = f.read()
-	f.close()
+    f = open(args.inf, 'rb')
+    img = f.read()
+    f.close()
 
-	signer = PKCS1_v1_5.new(key)
-	h = SHA256.new()
+    signer = PKCS1_v1_5.new(key)
+    h = SHA256.new()
 
-	digest_len = h.digest_size
-	sig_len = len(signer.sign(h))
-	img_size = len(img)
+    digest_len = h.digest_size
+    sig_len = len(signer.sign(h))
+    img_size = len(img)
 
-	magic = 0x4f545348	# SHDR_MAGIC
-	img_type = 0		# SHDR_TA
-	algo = 0x70004830	# TEE_ALG_RSASSA_PKCS1_V1_5_SHA256
-	shdr = struct.pack('<IIIIHH', \
-		magic, img_type, img_size, algo, digest_len, sig_len)
+    magic = 0x4f545348    # SHDR_MAGIC
+    img_type = 1        # SHDR_BOOTSTRAP_TA
+    algo = 0x70004830    # TEE_ALG_RSASSA_PKCS1_V1_5_SHA256
+    shdr = struct.pack('<IIIIHH',
+                       magic, img_type, img_size, algo, digest_len, sig_len)
+    shdr_uuid = args.uuid.bytes
+    shdr_version = struct.pack('<I', args.version)
 
-	h.update(shdr)
-	h.update(img)
-	sig = signer.sign(h)
+    h.update(shdr)
+    h.update(shdr_uuid)
+    h.update(shdr_version)
+    h.update(img)
+    sig = signer.sign(h)
 
-	f = open(args.out, 'wb')
-	f.write(shdr)
-	f.write(h.digest())
-	f.write(sig)
-	f.write(img)
-	f.close()
+    f = open(args.out, 'wb')
+    f.write(shdr)
+    f.write(h.digest())
+    f.write(sig)
+    f.write(shdr_uuid)
+    f.write(shdr_version)
+    f.write(img)
+    f.close()
+
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -58,4 +58,5 @@ $(link-out-dir)/$(binary).stripped.elf: $(link-out-dir)/$(binary).elf
 $(link-out-dir)/$(binary).ta: $(link-out-dir)/$(binary).stripped.elf \
 				$(TA_SIGN_KEY)
 	@echo '  SIGN    $@'
-	$(q)$(SIGN) --key $(TA_SIGN_KEY) --in $< --out $@
+	$(q)$(SIGN) --key $(TA_SIGN_KEY) --uuid $(binary) --version 0 \
+		--in $< --out $@


### PR DESCRIPTION
This pull request introduces bootstrap TAs which can completely replace the current TAs depending on how we'd like to progress.

I see some ways forward:
1. Add this as yet another method of loading TAs
2. Replace the current way of loading TAs from supplicant with this
3. Wait until we have some security domain in place before starting to retire/deprecate 1

Doing 2 (or 3) doesn't mean that we have to remove the old code, we could just make it optional. But we'd change our current test setup to only install TAs via bootstrap TAs (or via a security domain).

Bootstrap TA are basically only the solution to the chicken and egg problem for security domains. Next step would be to introduce a security domain.