### PR TITLE
ltc: fix ccm_process() bug when input buffer is longer than 256 bytes

### DIFF
--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
@@ -54,7 +54,8 @@ int ccm_process(ccm_state *ccm,
                 unsigned char *ct,
                 int direction)
 {
-   unsigned char  y, z, b;
+   unsigned char z, b;
+   unsigned long y;
    int err;
 
    LTC_ARGCHK(ccm != NULL);
@@ -74,9 +75,8 @@ int ccm_process(ccm_state *ccm,
    if (ptlen > 0) {
       LTC_ARGCHK(pt != NULL);
       LTC_ARGCHK(ct != NULL);
-      y = 0;
 
-      for (; y < ptlen; y++) {
+      for (y = 0; y < ptlen; y++) {
          /* increment the ctr? */
          if (ccm->CTRlen == 16) {
             for (z = 15; z > 15-ccm->L; z--) {


### PR DESCRIPTION
Upstream commit 08dee2735956 ("fixes #323 ccm_process fails to process
input buffer longer than 256").

Link: https://github.com/libtom/libtomcrypt/pull/326
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
