### PR TITLE
Replace crypto ops

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <compiler.h>
 #include <console.h>
+#include <crypto/crypto.h>
 #include <inttypes.h>
 #include <keep.h>
 #include <kernel/asan.h>
@@ -47,7 +48,6 @@
 #include <sm/psci.h>
 #include <sm/tee_mon.h>
 #include <stdio.h>
-#include <tee/tee_cryp_provider.h>
 #include <trace.h>
 #include <utee_defines.h>
 #include <util.h>

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -489,8 +489,10 @@ PROVIDE(__vcore_init_ro_size = 0);
 #endif /* CFG_CORE_RODATA_NOEXEC */
 #endif /* CFG_WITH_PAGER */
 
+#ifdef CFG_CORE_SANITIZE_KADDRESS
 PROVIDE(__asan_map_start = (__asan_shadow_start / SMALL_PAGE_SIZE) *
 			   SMALL_PAGE_SIZE);
 PROVIDE(__asan_map_end = ((__asan_shadow_end - 1) / SMALL_PAGE_SIZE) *
 			 SMALL_PAGE_SIZE + SMALL_PAGE_SIZE);
 PROVIDE(__asan_map_size = __asan_map_end - __asan_map_start);
+#endif /*CFG_CORE_SANITIZE_KADDRESS*/

--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -98,12 +98,7 @@ static TEE_Result check_shdr(struct shdr *shdr)
 	if (hash_size != shdr->hash_size)
 		return TEE_ERROR_SECURITY;
 
-	if (!crypto_ops.acipher.alloc_rsa_public_key ||
-	    !crypto_ops.acipher.free_rsa_public_key ||
-	    !crypto_ops.acipher.rsassa_verify)
-		return TEE_ERROR_NOT_SUPPORTED;
-
-	res = crypto_ops.acipher.alloc_rsa_public_key(&key, shdr->sig_size);
+	res = crypto_acipher_alloc_rsa_public_key(&key, shdr->sig_size);
 	if (res != TEE_SUCCESS)
 		return res;
 
@@ -115,11 +110,11 @@ static TEE_Result check_shdr(struct shdr *shdr)
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	res = crypto_ops.acipher.rsassa_verify(shdr->algo, &key, -1,
-				SHDR_GET_HASH(shdr), shdr->hash_size,
-				SHDR_GET_SIG(shdr), shdr->sig_size);
+	res = crypto_acipher_rsassa_verify(shdr->algo, &key, -1,
+					   SHDR_GET_HASH(shdr), shdr->hash_size,
+					   SHDR_GET_SIG(shdr), shdr->sig_size);
 out:
-	crypto_ops.acipher.free_rsa_public_key(&key);
+	crypto_acipher_free_rsa_public_key(&key);
 	if (res != TEE_SUCCESS)
 		return TEE_ERROR_SECURITY;
 	return TEE_SUCCESS;

--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <assert.h>
+#include <crypto/crypto.h>
 #include <initcall.h>
 #include <kernel/msg_param.h>
 #include <kernel/thread.h>
@@ -36,10 +37,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ta_pub_key.h>
-#include <tee/tee_cryp_provider.h>
+#include <tee_api_types.h>
 #include <tee/tee_cryp_utl.h>
 #include <tee/tee_svc_cryp.h>
-#include <tee_api_types.h>
 #include <tee/uuid.h>
 #include <utee_defines.h>
 

--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -100,19 +100,18 @@ static TEE_Result check_shdr(struct shdr *shdr)
 
 	if (!crypto_ops.acipher.alloc_rsa_public_key ||
 	    !crypto_ops.acipher.free_rsa_public_key ||
-	    !crypto_ops.acipher.rsassa_verify ||
-	    !crypto_ops.bignum.bin2bn)
+	    !crypto_ops.acipher.rsassa_verify)
 		return TEE_ERROR_NOT_SUPPORTED;
 
 	res = crypto_ops.acipher.alloc_rsa_public_key(&key, shdr->sig_size);
 	if (res != TEE_SUCCESS)
 		return res;
 
-	res = crypto_ops.bignum.bin2bn((uint8_t *)&e, sizeof(e), key.e);
+	res = crypto_bignum_bin2bn((uint8_t *)&e, sizeof(e), key.e);
 	if (res != TEE_SUCCESS)
 		goto out;
-	res = crypto_ops.bignum.bin2bn(ta_pub_key_modulus,
-				       ta_pub_key_modulus_size, key.n);
+	res = crypto_bignum_bin2bn(ta_pub_key_modulus, ta_pub_key_modulus_size,
+				   key.n);
 	if (res != TEE_SUCCESS)
 		goto out;
 

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -45,7 +45,6 @@
 #include <stdlib.h>
 #include <sys/queue.h>
 #include <ta_pub_key.h>
-#include <tee/tee_cryp_provider.h>
 #include <tee/tee_cryp_utl.h>
 #include <tee/tee_obj.h>
 #include <tee/tee_svc_cryp.h>

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -28,6 +28,7 @@
 
 #include <arm.h>
 #include <assert.h>
+#include <crypto/crypto.h>
 #include <io.h>
 #include <keep.h>
 #include <kernel/abort.h>
@@ -44,7 +45,6 @@
 #include <stdlib.h>
 #include <sys/queue.h>
 #include <tee_api_defines.h>
-#include <tee/tee_cryp_provider.h>
 #include <trace.h>
 #include <types_ext.h>
 #include <utee_defines.h>

--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -24,6 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include <crypto/crypto.h>
 #include <keep.h>
 #include <kernel/interrupt.h>
 #include <kernel/misc.h>
@@ -32,7 +33,6 @@
 #include <kernel/thread.h>
 #include <platform_config.h>
 #include <string.h>
-#include <tee/tee_cryp_provider.h>
 #include <trace.h>
 
 #define TA_NAME		"interrupt_tests.ta"

--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -33,7 +33,6 @@
 #include <mm/core_memprot.h>
 #include <mm/tee_mmu.h>
 #include <sm/tee_mon.h>
-#include <tee/tee_cryp_provider.h>
 #include <tee/tee_fs.h>
 #include <tee/tee_svc.h>
 #include <trace.h>

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -6,8 +6,8 @@
  */
 
 #include <compiler.h>
+#include <crypto/crypto.h>
 #include <kernel/panic.h>
-#include <tee/tee_cryp_provider.h>
 
 #if !defined(_CFG_CRYPTO_WITH_HASH)
 TEE_Result crypto_hash_get_ctx_size(uint32_t algo __unused,

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -6,6 +6,7 @@
  */
 
 #include <compiler.h>
+#include <kernel/panic.h>
 #include <tee/tee_cryp_provider.h>
 
 #if !defined(_CFG_CRYPTO_WITH_HASH)
@@ -161,3 +162,73 @@ void crypto_authenc_final(void *ctx __unused, uint32_t algo __unused)
 {
 }
 #endif /*_CFG_CRYPTO_WITH_AUTHENC*/
+
+#if !defined(_CFG_CRYPTO_WITH_ACIPHER)
+struct bignum *crypto_bignum_allocate(size_t size_bits __unused)
+{
+	return NULL;
+}
+
+TEE_Result crypto_bignum_bin2bn(const uint8_t *from __unused,
+				size_t fromsize __unused,
+				struct bignum *to __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+size_t crypto_bignum_num_bytes(struct bignum *a __unused)
+{
+	return 0;
+}
+
+size_t crypto_bignum_num_bits(struct bignum *a __unused)
+{
+	return 0;
+}
+
+/*
+ * crypto_bignum_allocate() and crypto_bignum_bin2bn() failing should be
+ * enough to guarantee that the functions calling this function aren't
+ * called, but just in case add a panic() here to avoid unexpected
+ * behavoir.
+ */
+static void bignum_cant_happen(void)
+{
+	volatile bool b = true;
+
+	/* Avoid warning about function does not return */
+	if (b)
+		panic();
+}
+
+void crypto_bignum_bn2bin(const struct bignum *from __unused,
+			  uint8_t *to __unused)
+{
+	bignum_cant_happen();
+}
+
+void crypto_bignum_copy(struct bignum *to __unused,
+			const struct bignum *from __unused)
+{
+	bignum_cant_happen();
+}
+
+void crypto_bignum_free(struct bignum *a)
+{
+	if (a)
+		panic();
+}
+
+void crypto_bignum_clear(struct bignum *a __unused)
+{
+	bignum_cant_happen();
+}
+
+/* return -1 if a<b, 0 if a==b, +1 if a>b */
+int32_t crypto_bignum_compare(struct bignum *a __unused,
+			      struct bignum *b __unused)
+{
+	bignum_cant_happen();
+	return -1;
+}
+#endif /*!_CFG_CRYPTO_WITH_ACIPHER*/

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <compiler.h>
+#include <tee/tee_cryp_provider.h>
+
+#if !defined(_CFG_CRYPTO_WITH_HASH)
+TEE_Result crypto_hash_get_ctx_size(uint32_t algo __unused,
+				    size_t *size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_hash_init(void *ctx __unused, uint32_t algo __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+TEE_Result crypto_hash_update(void *ctx __unused, uint32_t algo __unused,
+			      const uint8_t *data __unused, size_t len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+TEE_Result crypto_hash_final(void *ctx __unused, uint32_t algo __unused,
+			     uint8_t *digest __unused, size_t len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*_CFG_CRYPTO_WITH_HASH*/

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -68,3 +68,31 @@ TEE_Result crypto_cipher_get_block_size(uint32_t algo __unused,
 	return TEE_ERROR_NOT_IMPLEMENTED
 }
 #endif /*_CFG_CRYPTO_WITH_CIPHER*/
+
+#if !defined(_CFG_CRYPTO_WITH_MAC)
+TEE_Result crypto_mac_get_ctx_size(uint32_t algo __unused,
+				   size_t *size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_mac_init(void *ctx __unused, uint32_t algo __unused,
+			   const uint8_t *key __unused, size_t len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_mac_update(void *ctx __unused, uint32_t algo __unused,
+			     const uint8_t *data __unused, size_t len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_mac_final(void *ctx __unused, uint32_t algo __unused,
+			    uint8_t *digest __unused,
+			    size_t digest_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*_CFG_CRYPTO_WITH_MAC*/
+

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -232,3 +232,209 @@ int32_t crypto_bignum_compare(struct bignum *a __unused,
 	return -1;
 }
 #endif /*!_CFG_CRYPTO_WITH_ACIPHER*/
+
+#if !defined(CFG_CRYPTO_RSA) || !defined(_CFG_CRYPTO_WITH_ACIPHER)
+TEE_Result crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s __unused,
+					    size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result
+crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s __unused,
+				    size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s __unused)
+{
+}
+
+TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key __unused,
+				      size_t key_size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key __unused,
+					   const uint8_t *src __unused,
+					   size_t src_len __unused,
+					   uint8_t *dst __unused,
+					   size_t *dst_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key __unused,
+					   const uint8_t *src __unused,
+					   size_t src_len __unused,
+					   uint8_t *dst __unused,
+					   size_t *dst_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo __unused,
+					struct rsa_keypair *key __unused,
+					const uint8_t *label __unused,
+					size_t label_len __unused,
+					const uint8_t *src __unused,
+					size_t src_len __unused,
+					uint8_t *dst __unused,
+					size_t *dst_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo __unused,
+					struct rsa_public_key *key __unused,
+					const uint8_t *label __unused,
+					size_t label_len __unused,
+					const uint8_t *src __unused,
+					size_t src_len __unused,
+					uint8_t *dst __unused,
+					size_t *dst_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_rsassa_sign(uint32_t algo __unused,
+				      struct rsa_keypair *key __unused,
+				      int salt_len __unused,
+				      const uint8_t *msg __unused,
+				      size_t msg_len __unused,
+				      uint8_t *sig __unused,
+				      size_t *sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_rsassa_verify(uint32_t algo __unused,
+					struct rsa_public_key *key __unused,
+					int salt_len __unused,
+					const uint8_t *msg __unused,
+					size_t msg_len __unused,
+					const uint8_t *sig __unused,
+					size_t sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*!CFG_CRYPTO_RSA || !_CFG_CRYPTO_WITH_ACIPHER*/
+
+#if !defined(CFG_CRYPTO_DSA) || !defined(_CFG_CRYPTO_WITH_ACIPHER)
+TEE_Result crypto_acipher_alloc_dsa_keypair(struct dsa_keypair *s __unused,
+					    size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result
+crypto_acipher_alloc_dsa_public_key(struct dsa_public_key *s __unused,
+				    size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_gen_dsa_key(struct dsa_keypair *key __unused,
+				      size_t key_size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_dsa_sign(uint32_t algo __unused,
+				   struct dsa_keypair *key __unused,
+				   const uint8_t *msg __unused,
+				   size_t msg_len __unused,
+				   uint8_t *sig __unused,
+				   size_t *sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_dsa_verify(uint32_t algo __unused,
+				     struct dsa_public_key *key __unused,
+				     const uint8_t *msg __unused,
+				     size_t msg_len __unused,
+				     const uint8_t *sig __unused,
+				     size_t sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*!CFG_CRYPTO_DSA || !_CFG_CRYPTO_WITH_ACIPHER*/
+
+#if !defined(CFG_CRYPTO_DH) || !defined(_CFG_CRYPTO_WITH_ACIPHER)
+TEE_Result crypto_acipher_alloc_dh_keypair(struct dh_keypair *s __unused,
+					   size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key __unused,
+				     struct bignum *q __unused,
+				     size_t xbits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result
+crypto_acipher_dh_shared_secret(struct dh_keypair *private_key __unused,
+				struct bignum *public_key __unused,
+				struct bignum *secret __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*!CFG_CRYPTO_DH || !_CFG_CRYPTO_WITH_ACIPHER*/
+
+#if !defined(CFG_CRYPTO_ECC) || !defined(_CFG_CRYPTO_WITH_ACIPHER)
+TEE_Result
+crypto_acipher_alloc_ecc_public_key(struct ecc_public_key *s __unused,
+				    size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_alloc_ecc_keypair(struct ecc_keypair *s __unused,
+					    size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s __unused)
+{
+}
+
+TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_ecc_sign(uint32_t algo __unused,
+				   struct ecc_keypair *key __unused,
+				   const uint8_t *msg __unused,
+				   size_t msg_len __unused,
+				   uint8_t *sig __unused,
+				   size_t *sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_ecc_verify(uint32_t algo __unused,
+				     struct ecc_public_key *key __unused,
+				     const uint8_t *msg __unused,
+				     size_t msg_len __unused,
+				     const uint8_t *sig __unused,
+				     size_t sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result
+crypto_acipher_ecc_shared_secret(struct ecc_keypair *private_key __unused,
+				 struct ecc_public_key *public_key __unused,
+				 void *secret __unused,
+				 unsigned long *secret_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*!CFG_CRYPTO_ECC || !_CFG_CRYPTO_WITH_ACIPHER*/

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -96,3 +96,68 @@ TEE_Result crypto_mac_final(void *ctx __unused, uint32_t algo __unused,
 }
 #endif /*_CFG_CRYPTO_WITH_MAC*/
 
+#if !defined(_CFG_CRYPTO_WITH_AUTHENC)
+TEE_Result crypto_authenc_get_ctx_size(uint32_t algo __unused,
+				       size_t *size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_authenc_init(void *ctx __unused, uint32_t algo __unused,
+			       TEE_OperationMode mode __unused,
+			       const uint8_t *key __unused,
+			       size_t key_len __unused,
+			       const uint8_t *nonce __unused,
+			       size_t nonce_len __unused,
+			       size_t tag_len __unused,
+			       size_t aad_len __unused,
+			       size_t payload_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_authenc_update_aad(void *ctx __unused, uint32_t algo __unused,
+				     TEE_OperationMode mode __unused,
+				     const uint8_t *data __unused,
+				     size_t len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_authenc_update_payload(void *ctx __unused,
+					 uint32_t algo __unused,
+					 TEE_OperationMode mode __unused,
+					 const uint8_t *src_data __unused,
+					 size_t src_len __unused,
+					 uint8_t *dst_data __unused,
+					 size_t *dst_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_authenc_enc_final(void *ctx __unused, uint32_t algo __unused,
+				    const uint8_t *src_data __unused,
+				    size_t src_len __unused,
+				    uint8_t *dst_data __unused,
+				    size_t *dst_len __unused,
+				    uint8_t *dst_tag __unused,
+				    size_t *dst_tag_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_authenc_dec_final(void *ctx __unused, uint32_t algo __unused,
+				    const uint8_t *src_data __unused,
+				    size_t src_len __unused,
+				    uint8_t *dst_data __unused,
+				    size_t *dst_len __unused,
+				    const uint8_t *tag __unused,
+				    size_t tag_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void crypto_authenc_final(void *ctx __unused, uint32_t algo __unused)
+{
+}
+#endif /*_CFG_CRYPTO_WITH_AUTHENC*/

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -30,3 +30,41 @@ TEE_Result crypto_hash_final(void *ctx __unused, uint32_t algo __unused,
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 #endif /*_CFG_CRYPTO_WITH_HASH*/
+
+#if !defined(_CFG_CRYPTO_WITH_CIPHER)
+TEE_Result crypto_cipher_get_ctx_size(uint32_t algo, size_t *size)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED
+}
+
+TEE_Result crypto_cipher_init(void *ctx __unused, uint32_t algo __unused,
+			      TEE_OperationMode mode __unused,
+			      const uint8_t *key1 __unused,
+			      size_t key1_len __unused,
+			      const uint8_t *key2 __unused,
+			      size_t key2_len __unused,
+			      const uint8_t *iv __unused,
+			      size_t iv_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED
+}
+
+TEE_Result crypto_cipher_update(void *ctx __unused, uint32_t algo __unused,
+				TEE_OperationMode mode __unused,
+				bool last_block __unused,
+				const uint8_t *data __unused,
+				size_t len __unused, uint8_t *dst __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED
+}
+
+void crypto_cipher_final(void *ctx __unused, uint32_t algo __unused)
+{
+}
+
+TEE_Result crypto_cipher_get_block_size(uint32_t algo __unused,
+					size_t *size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED
+}
+#endif /*_CFG_CRYPTO_WITH_CIPHER*/

--- a/core/crypto/sub.mk
+++ b/core/crypto/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += crypto.c

--- a/core/include/crypto/aes-ccm.h
+++ b/core/include/crypto/aes-ccm.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef __CRYPTO_AES_CCM_H
+#define __CRYPTO_AES_CCM_H
+
+#include <tee_api_types.h>
+
+size_t crypto_aes_ccm_get_ctx_size(void);
+TEE_Result crypto_aes_ccm_init(void *ctx, TEE_OperationMode mode,
+			       const uint8_t *key, size_t key_len,
+			       const uint8_t *nonce, size_t nonce_len,
+			       size_t tag_len, size_t aad_len,
+			       size_t payload_len);
+TEE_Result crypto_aes_ccm_update_aad(void *ctx, const uint8_t *data,
+				     size_t len);
+TEE_Result crypto_aes_ccm_update_payload(void *ctx, TEE_OperationMode mode,
+					 const uint8_t *src_data,
+					 size_t len, uint8_t *dst_data);
+TEE_Result crypto_aes_ccm_enc_final(void *ctx, const uint8_t *src_data,
+				    size_t len, uint8_t *dst_data,
+				    uint8_t *dst_tag, size_t *dst_tag_len);
+TEE_Result crypto_aes_ccm_dec_final(void *ctx, const uint8_t *src_data,
+				    size_t len, uint8_t *dst_data,
+				    const uint8_t *tag, size_t tag_len);
+void crypto_aes_ccm_final(void *ctx);
+
+#endif /*__CRYPTO_AES_CCM_H*/
+

--- a/core/include/crypto/aes-gcm.h
+++ b/core/include/crypto/aes-gcm.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#ifndef __CRYPTO_AES_GCM_H
+#define __CRYPTO_AES_GCM_H
+
+#include <tee_api_types.h>
+
+size_t crypto_aes_gcm_get_ctx_size(void);
+TEE_Result crypto_aes_gcm_init(void *ctx, TEE_OperationMode mode,
+			       const uint8_t *key, size_t key_len,
+			       const uint8_t *nonce, size_t nonce_len,
+			       size_t tag_len);
+TEE_Result crypto_aes_gcm_update_aad(void *ctx, const uint8_t *data,
+				     size_t len);
+TEE_Result crypto_aes_gcm_update_payload(void *ctx, TEE_OperationMode mode,
+					 const uint8_t *src_data,
+					 size_t len, uint8_t *dst_data);
+TEE_Result crypto_aes_gcm_enc_final(void *ctx, const uint8_t *src_data,
+				    size_t len, uint8_t *dst_data,
+				    uint8_t *dst_tag, size_t *dst_tag_len);
+TEE_Result crypto_aes_gcm_dec_final(void *ctx, const uint8_t *src_data,
+				    size_t len, uint8_t *dst_data,
+				    const uint8_t *tag, size_t tag_len);
+void crypto_aes_gcm_final(void *ctx);
+
+#endif /*__CRYPTO_AES_GCM_H*/

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2014-2017, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,12 +41,10 @@
  * @algo: algorithm identifier (TEE_ALG_*)
  */
 
-
-#ifndef TEE_CRYP_PROVIDER_H
-#define TEE_CRYP_PROVIDER_H
+#ifndef __CRYPTO_CRYPTO_H
+#define __CRYPTO_CRYPTO_H
 
 #include <tee_api_types.h>
-
 
 TEE_Result crypto_init(void);
 
@@ -280,4 +278,4 @@ TEE_Result crypto_rng_read(void *buf, size_t blen);
 
 TEE_Result rng_generate(void *buffer, size_t len);
 
-#endif /* TEE_CRYP_PROVIDER_H */
+#endif /* __CRYPTO_CRYPTO_H */

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -48,16 +48,7 @@
 #include <tee_api_types.h>
 
 
-/* Cryptographic Provider API */
-struct crypto_ops {
-	/* Human-readable provider name */
-	const char *name;
-
-	TEE_Result (*init)(void);
-};
-
-extern const struct crypto_ops crypto_ops;
-
+TEE_Result crypto_init(void);
 
 /* Message digest functions */
 TEE_Result crypto_hash_get_ctx_size(uint32_t algo, size_t *size);
@@ -272,7 +263,7 @@ TEE_Result crypto_acipher_ecc_shared_secret(struct ecc_keypair *private_key,
 					    unsigned long *secret_len);
 
 /*
- * Verifies a SHA-256 hash, doesn't require tee_cryp_init() to be called in
+ * Verifies a SHA-256 hash, doesn't require crypto_init() to be called in
  * advance and has as few dependencies as possible.
  *
  * This function is primarily used by pager and early initialization code

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -47,17 +47,6 @@
 
 #include <tee_api_types.h>
 
-/* Message Authentication Code functions */
-struct mac_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
-	TEE_Result (*init)(void *ctx, uint32_t algo,
-			   const uint8_t *key, size_t len);
-	TEE_Result (*update)(void *ctx, uint32_t algo,
-			     const uint8_t *data, size_t len);
-	TEE_Result (*final)(void *ctx, uint32_t algo,
-			    uint8_t *digest, size_t digest_len);
-};
-
 /* Authenticated encryption */
 struct authenc_ops {
 	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
@@ -259,7 +248,6 @@ struct crypto_ops {
 	const char *name;
 
 	TEE_Result (*init)(void);
-	struct mac_ops mac;
 	struct authenc_ops authenc;
 	struct acipher_ops acipher;
 	struct bignum_ops bignum;
@@ -287,6 +275,15 @@ TEE_Result crypto_cipher_update(void *ctx, uint32_t algo,
 				const uint8_t *data, size_t len, uint8_t *dst);
 void crypto_cipher_final(void *ctx, uint32_t algo);
 TEE_Result crypto_cipher_get_block_size(uint32_t algo, size_t *size);
+
+/* Message Authentication Code functions */
+TEE_Result crypto_mac_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_mac_init(void *ctx, uint32_t algo, const uint8_t *key,
+			   size_t len);
+TEE_Result crypto_mac_update(void *ctx, uint32_t algo, const uint8_t *data,
+			     size_t len);
+TEE_Result crypto_mac_final(void *ctx, uint32_t algo, uint8_t *digest,
+			    size_t digest_len);
 
 /*
  * Verifies a SHA-256 hash, doesn't require tee_cryp_init() to be called in

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -47,38 +47,6 @@
 
 #include <tee_api_types.h>
 
-/* Authenticated encryption */
-struct authenc_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
-	TEE_Result (*init)(void *ctx, uint32_t algo,
-			   TEE_OperationMode mode,
-			   const uint8_t *key, size_t key_len,
-			   const uint8_t *nonce, size_t nonce_len,
-			   size_t tag_len, size_t aad_len,
-			   size_t payload_len);
-	TEE_Result (*update_aad)(void *ctx, uint32_t algo,
-				 TEE_OperationMode mode,
-				 const uint8_t *data, size_t len);
-	TEE_Result (*update_payload)(void *ctx, uint32_t algo,
-				     TEE_OperationMode mode,
-				     const uint8_t *src_data,
-				     size_t src_len,
-				     uint8_t *dst_data,
-				     size_t *dst_len);
-	TEE_Result (*enc_final)(void *ctx, uint32_t algo,
-				const uint8_t *src_data,
-				size_t src_len, uint8_t *dst_data,
-				size_t *dst_len, uint8_t *dst_tag,
-				size_t *dst_tag_len);
-	TEE_Result (*dec_final)(void *ctx, uint32_t algo,
-				const uint8_t *src_data,
-				size_t src_len, uint8_t *dst_data,
-				size_t *dst_len, const uint8_t *tag,
-				size_t tag_len);
-
-	void       (*final)(void *ctx, uint32_t algo);
-};
-
 /* Implementation-defined big numbers */
 struct bignum_ops {
 	/*
@@ -248,7 +216,6 @@ struct crypto_ops {
 	const char *name;
 
 	TEE_Result (*init)(void);
-	struct authenc_ops authenc;
 	struct acipher_ops acipher;
 	struct bignum_ops bignum;
 };
@@ -284,6 +251,32 @@ TEE_Result crypto_mac_update(void *ctx, uint32_t algo, const uint8_t *data,
 			     size_t len);
 TEE_Result crypto_mac_final(void *ctx, uint32_t algo, uint8_t *digest,
 			    size_t digest_len);
+
+/* Authenticated encryption */
+TEE_Result crypto_authenc_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_authenc_init(void *ctx, uint32_t algo, TEE_OperationMode mode,
+			       const uint8_t *key, size_t key_len,
+			       const uint8_t *nonce, size_t nonce_len,
+			       size_t tag_len, size_t aad_len,
+			       size_t payload_len);
+TEE_Result crypto_authenc_update_aad(void *ctx, uint32_t algo,
+				     TEE_OperationMode mode,
+				     const uint8_t *data, size_t len);
+TEE_Result crypto_authenc_update_payload(void *ctx, uint32_t algo,
+					 TEE_OperationMode mode,
+					 const uint8_t *src_data,
+					 size_t src_len, uint8_t *dst_data,
+					 size_t *dst_len);
+TEE_Result crypto_authenc_enc_final(void *ctx, uint32_t algo,
+				    const uint8_t *src_data, size_t src_len,
+				    uint8_t *dst_data, size_t *dst_len,
+				    uint8_t *dst_tag, size_t *dst_tag_len);
+TEE_Result crypto_authenc_dec_final(void *ctx, uint32_t algo,
+				    const uint8_t *src_data, size_t src_len,
+				    uint8_t *dst_data, size_t *dst_len,
+				    const uint8_t *tag, size_t tag_len);
+void crypto_authenc_final(void *ctx, uint32_t algo);
+
 
 /*
  * Verifies a SHA-256 hash, doesn't require tee_cryp_init() to be called in

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -47,148 +47,6 @@
 
 #include <tee_api_types.h>
 
-/* Asymmetric algorithms */
-
-struct rsa_keypair {
-	struct bignum *e;	/* Public exponent */
-	struct bignum *d;	/* Private exponent */
-	struct bignum *n;	/* Modulus */
-
-	/* Optional CRT parameters (all NULL if unused) */
-	struct bignum *p;	/* N = pq */
-	struct bignum *q;
-	struct bignum *qp;	/* 1/q mod p */
-	struct bignum *dp;	/* d mod (p-1) */
-	struct bignum *dq;	/* d mod (q-1) */
-};
-
-struct rsa_public_key {
-	struct bignum *e;	/* Public exponent */
-	struct bignum *n;	/* Modulus */
-};
-
-struct dsa_keypair {
-	struct bignum *g;	/* Generator of subgroup (public) */
-	struct bignum *p;	/* Prime number (public) */
-	struct bignum *q;	/* Order of subgroup (public) */
-	struct bignum *y;	/* Public key */
-	struct bignum *x;	/* Private key */
-};
-
-struct dsa_public_key {
-	struct bignum *g;	/* Generator of subgroup (public) */
-	struct bignum *p;	/* Prime number (public) */
-	struct bignum *q;	/* Order of subgroup (public) */
-	struct bignum *y;	/* Public key */
-};
-
-struct dh_keypair {
-	struct bignum *g;	/* Generator of Z_p (shared) */
-	struct bignum *p;	/* Prime modulus (shared) */
-	struct bignum *x;	/* Private key */
-	struct bignum *y;	/* Public key y = g^x */
-
-	/*
-	 * Optional parameters used by key generation.
-	 * When not used, q == NULL and xbits == 0
-	 */
-	struct bignum *q;	/* x must be in the range [2, q-2] */
-	uint32_t xbits;		/* Number of bits in the private key */
-};
-
-struct ecc_public_key {
-	struct bignum *x;	/* Public value x */
-	struct bignum *y;	/* Public value y */
-	uint32_t curve;	        /* Curve type */
-};
-
-struct ecc_keypair {
-	struct bignum *d;	/* Private value */
-	struct bignum *x;	/* Public value x */
-	struct bignum *y;	/* Public value y */
-	uint32_t curve;	        /* Curve type */
-};
-
-struct acipher_ops {
-
-	/*
-	 * Key allocation functions
-	 * Allocate the bignum's inside a key structure.
-	 * TEE core will later use bignum.free().
-	 */
-	TEE_Result (*alloc_rsa_keypair)(struct rsa_keypair *s,
-					size_t key_size_bits);
-	TEE_Result (*alloc_rsa_public_key)(struct rsa_public_key *s,
-					   size_t key_size_bits);
-	void (*free_rsa_public_key)(struct rsa_public_key *s);
-	TEE_Result (*alloc_dsa_keypair)(struct dsa_keypair *s,
-					size_t key_size_bits);
-	TEE_Result (*alloc_dsa_public_key)(struct dsa_public_key *s,
-					   size_t key_size_bits);
-	TEE_Result (*alloc_dh_keypair)(struct dh_keypair *s,
-				       size_t key_size_bits);
-	TEE_Result (*alloc_ecc_public_key)(struct ecc_public_key *s,
-					   size_t key_size_bits);
-	TEE_Result (*alloc_ecc_keypair)(struct ecc_keypair *s,
-					size_t key_size_bits);
-	void (*free_ecc_public_key)(struct ecc_public_key *s);
-
-	/*
-	 * Key generation functions
-	 */
-	TEE_Result (*gen_rsa_key)(struct rsa_keypair *key, size_t key_size);
-	TEE_Result (*gen_dsa_key)(struct dsa_keypair *key, size_t key_size);
-	TEE_Result (*gen_dh_key)(struct dh_keypair *key, struct bignum *q,
-				 size_t xbits);
-	TEE_Result (*gen_ecc_key)(struct ecc_keypair *key);
-
-	TEE_Result (*dh_shared_secret)(struct dh_keypair *private_key,
-				       struct bignum *public_key,
-				       struct bignum *secret);
-
-	TEE_Result (*rsanopad_decrypt)(struct rsa_keypair *key,
-				       const uint8_t *src, size_t src_len,
-				       uint8_t *dst, size_t *dst_len);
-	TEE_Result (*rsanopad_encrypt)(struct rsa_public_key *key,
-				       const uint8_t *src, size_t src_len,
-				       uint8_t *dst, size_t *dst_len);
-	TEE_Result (*rsaes_decrypt)(uint32_t algo, struct rsa_keypair *key,
-				    const uint8_t *label, size_t label_len,
-				    const uint8_t *src, size_t src_len,
-				    uint8_t *dst, size_t *dst_len);
-	TEE_Result (*rsaes_encrypt)(uint32_t algo,
-				    struct rsa_public_key *key,
-				    const uint8_t *label, size_t label_len,
-				    const uint8_t *src, size_t src_len,
-				    uint8_t *dst, size_t *dst_len);
-	/* RSA SSA sign/verify: if salt_len == -1, use default value */
-	TEE_Result (*rsassa_sign)(uint32_t algo, struct rsa_keypair *key,
-				  int salt_len, const uint8_t *msg,
-				  size_t msg_len, uint8_t *sig,
-				  size_t *sig_len);
-	TEE_Result (*rsassa_verify)(uint32_t algo,
-				    struct rsa_public_key *key,
-				    int salt_len, const uint8_t *msg,
-				    size_t msg_len, const uint8_t *sig,
-				    size_t sig_len);
-	TEE_Result (*dsa_sign)(uint32_t algo, struct dsa_keypair *key,
-			       const uint8_t *msg, size_t msg_len,
-			       uint8_t *sig, size_t *sig_len);
-	TEE_Result (*dsa_verify)(uint32_t algo, struct dsa_public_key *key,
-				 const uint8_t *msg, size_t msg_len,
-				 const uint8_t *sig, size_t sig_len);
-	TEE_Result (*ecc_sign)(uint32_t algo, struct ecc_keypair *key,
-			       const uint8_t *msg, size_t msg_len,
-			       uint8_t *sig, size_t *sig_len);
-	TEE_Result (*ecc_verify)(uint32_t algo, struct ecc_public_key *key,
-				 const uint8_t *msg, size_t msg_len,
-				 const uint8_t *sig, size_t sig_len);
-	TEE_Result (*ecc_shared_secret)(struct ecc_keypair *private_key,
-					struct ecc_public_key *public_key,
-					void *secret,
-					unsigned long *secret_len);
-
-};
 
 /* Cryptographic Provider API */
 struct crypto_ops {
@@ -196,7 +54,6 @@ struct crypto_ops {
 	const char *name;
 
 	TEE_Result (*init)(void);
-	struct acipher_ops acipher;
 };
 
 extern const struct crypto_ops crypto_ops;
@@ -275,6 +132,144 @@ void crypto_bignum_clear(struct bignum *a);
 /* return -1 if a<b, 0 if a==b, +1 if a>b */
 int32_t crypto_bignum_compare(struct bignum *a, struct bignum *b);
 
+/* Asymmetric algorithms */
+
+struct rsa_keypair {
+	struct bignum *e;	/* Public exponent */
+	struct bignum *d;	/* Private exponent */
+	struct bignum *n;	/* Modulus */
+
+	/* Optional CRT parameters (all NULL if unused) */
+	struct bignum *p;	/* N = pq */
+	struct bignum *q;
+	struct bignum *qp;	/* 1/q mod p */
+	struct bignum *dp;	/* d mod (p-1) */
+	struct bignum *dq;	/* d mod (q-1) */
+};
+
+struct rsa_public_key {
+	struct bignum *e;	/* Public exponent */
+	struct bignum *n;	/* Modulus */
+};
+
+struct dsa_keypair {
+	struct bignum *g;	/* Generator of subgroup (public) */
+	struct bignum *p;	/* Prime number (public) */
+	struct bignum *q;	/* Order of subgroup (public) */
+	struct bignum *y;	/* Public key */
+	struct bignum *x;	/* Private key */
+};
+
+struct dsa_public_key {
+	struct bignum *g;	/* Generator of subgroup (public) */
+	struct bignum *p;	/* Prime number (public) */
+	struct bignum *q;	/* Order of subgroup (public) */
+	struct bignum *y;	/* Public key */
+};
+
+struct dh_keypair {
+	struct bignum *g;	/* Generator of Z_p (shared) */
+	struct bignum *p;	/* Prime modulus (shared) */
+	struct bignum *x;	/* Private key */
+	struct bignum *y;	/* Public key y = g^x */
+
+	/*
+	 * Optional parameters used by key generation.
+	 * When not used, q == NULL and xbits == 0
+	 */
+	struct bignum *q;	/* x must be in the range [2, q-2] */
+	uint32_t xbits;		/* Number of bits in the private key */
+};
+
+struct ecc_public_key {
+	struct bignum *x;	/* Public value x */
+	struct bignum *y;	/* Public value y */
+	uint32_t curve;	        /* Curve type */
+};
+
+struct ecc_keypair {
+	struct bignum *d;	/* Private value */
+	struct bignum *x;	/* Public value x */
+	struct bignum *y;	/* Public value y */
+	uint32_t curve;	        /* Curve type */
+};
+
+/*
+ * Key allocation functions
+ * Allocate the bignum's inside a key structure.
+ * TEE core will later use crypto_bignum_free().
+ */
+TEE_Result crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
+				size_t key_size_bits);
+TEE_Result crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
+				   size_t key_size_bits);
+void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s);
+TEE_Result crypto_acipher_alloc_dsa_keypair(struct dsa_keypair *s,
+				size_t key_size_bits);
+TEE_Result crypto_acipher_alloc_dsa_public_key(struct dsa_public_key *s,
+				   size_t key_size_bits);
+TEE_Result crypto_acipher_alloc_dh_keypair(struct dh_keypair *s,
+			       size_t key_size_bits);
+TEE_Result crypto_acipher_alloc_ecc_public_key(struct ecc_public_key *s,
+				   size_t key_size_bits);
+TEE_Result crypto_acipher_alloc_ecc_keypair(struct ecc_keypair *s,
+				size_t key_size_bits);
+void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s);
+
+/*
+ * Key generation functions
+ */
+TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size);
+TEE_Result crypto_acipher_gen_dsa_key(struct dsa_keypair *key, size_t key_size);
+TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
+				     size_t xbits);
+TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key);
+
+TEE_Result crypto_acipher_dh_shared_secret(struct dh_keypair *private_key,
+					   struct bignum *public_key,
+					   struct bignum *secret);
+
+TEE_Result crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
+					   const uint8_t *src, size_t src_len,
+					   uint8_t *dst, size_t *dst_len);
+TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
+					   const uint8_t *src, size_t src_len,
+					   uint8_t *dst, size_t *dst_len);
+TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
+					const uint8_t *label, size_t label_len,
+					const uint8_t *src, size_t src_len,
+					uint8_t *dst, size_t *dst_len);
+TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
+					struct rsa_public_key *key,
+					const uint8_t *label, size_t label_len,
+					const uint8_t *src, size_t src_len,
+					uint8_t *dst, size_t *dst_len);
+/* RSA SSA sign/verify: if salt_len == -1, use default value */
+TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
+				      int salt_len, const uint8_t *msg,
+				      size_t msg_len, uint8_t *sig,
+				      size_t *sig_len);
+TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
+					struct rsa_public_key *key,
+					int salt_len, const uint8_t *msg,
+					size_t msg_len, const uint8_t *sig,
+					size_t sig_len);
+TEE_Result crypto_acipher_dsa_sign(uint32_t algo, struct dsa_keypair *key,
+				   const uint8_t *msg, size_t msg_len,
+				   uint8_t *sig, size_t *sig_len);
+TEE_Result crypto_acipher_dsa_verify(uint32_t algo, struct dsa_public_key *key,
+				     const uint8_t *msg, size_t msg_len,
+				     const uint8_t *sig, size_t sig_len);
+TEE_Result crypto_acipher_ecc_sign(uint32_t algo, struct ecc_keypair *key,
+				   const uint8_t *msg, size_t msg_len,
+				   uint8_t *sig, size_t *sig_len);
+TEE_Result crypto_acipher_ecc_verify(uint32_t algo, struct ecc_public_key *key,
+				     const uint8_t *msg, size_t msg_len,
+				     const uint8_t *sig, size_t sig_len);
+TEE_Result crypto_acipher_ecc_shared_secret(struct ecc_keypair *private_key,
+					    struct ecc_public_key *public_key,
+					    void *secret,
+					    unsigned long *secret_len);
 
 /*
  * Verifies a SHA-256 hash, doesn't require tee_cryp_init() to be called in

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -308,7 +308,7 @@ TEE_Result hash_sha256_check(const uint8_t *hash, const uint8_t *data,
 /* Add entropy to PRNG entropy pool. */
 TEE_Result crypto_rng_add_entropy(const uint8_t *inbuf, size_t len);
 
-/* To read random data from PRNG implementation.	*/
+/* To read random data from PRNG implementation. */
 TEE_Result crypto_rng_read(void *buf, size_t blen);
 
 TEE_Result rng_generate(void *buffer, size_t len);

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -47,22 +47,6 @@
 
 #include <tee_api_types.h>
 
-/* Symmetric ciphers */
-struct cipher_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
-	TEE_Result (*init)(void *ctx, uint32_t algo,
-			    TEE_OperationMode mode,
-			    const uint8_t *key1, size_t key1_len,
-			    const uint8_t *key2, size_t key2_len,
-			    const uint8_t *iv, size_t iv_len);
-	TEE_Result (*update)(void *ctx, uint32_t algo,
-			     TEE_OperationMode mode,
-			     bool last_block, const uint8_t *data,
-			     size_t len, uint8_t *dst);
-	void       (*final)(void *ctx, uint32_t algo);
-	TEE_Result (*get_block_size)(uint32_t algo, size_t *size);
-};
-
 /* Message Authentication Code functions */
 struct mac_ops {
 	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
@@ -275,7 +259,6 @@ struct crypto_ops {
 	const char *name;
 
 	TEE_Result (*init)(void);
-	struct cipher_ops cipher;
 	struct mac_ops mac;
 	struct authenc_ops authenc;
 	struct acipher_ops acipher;
@@ -292,6 +275,18 @@ TEE_Result crypto_hash_update(void *ctx, uint32_t algo, const uint8_t *data,
 			      size_t len);
 TEE_Result crypto_hash_final(void *ctx, uint32_t algo, uint8_t *digest,
 			     size_t len);
+
+/* Symmetric ciphers */
+TEE_Result crypto_cipher_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_cipher_init(void *ctx, uint32_t algo, TEE_OperationMode mode,
+			      const uint8_t *key1, size_t key1_len,
+			      const uint8_t *key2, size_t key2_len,
+			      const uint8_t *iv, size_t iv_len);
+TEE_Result crypto_cipher_update(void *ctx, uint32_t algo,
+				TEE_OperationMode mode, bool last_block,
+				const uint8_t *data, size_t len, uint8_t *dst);
+void crypto_cipher_final(void *ctx, uint32_t algo);
+TEE_Result crypto_cipher_get_block_size(uint32_t algo, size_t *size);
 
 /*
  * Verifies a SHA-256 hash, doesn't require tee_cryp_init() to be called in

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -47,26 +47,6 @@
 
 #include <tee_api_types.h>
 
-/* Implementation-defined big numbers */
-struct bignum_ops {
-	/*
-	 * Allocate a bignum capable of holding an unsigned integer value of
-	 * up to bitsize bits
-	 */
-	struct bignum *(*allocate)(size_t size_bits);
-	TEE_Result (*bin2bn)(const uint8_t *from, size_t fromsize,
-			     struct bignum *to);
-	size_t (*num_bytes)(struct bignum *a);
-	size_t (*num_bits)(struct bignum *a);
-	void (*bn2bin)(const struct bignum *from, uint8_t *to);
-	void (*copy)(struct bignum *to, const struct bignum *from);
-	void (*free)(struct bignum *a);
-	void (*clear)(struct bignum *a);
-
-	/* return -1 if a<b, 0 if a==b, +1 if a>b */
-	int32_t (*compare)(struct bignum *a, struct bignum *b);
-};
-
 /* Asymmetric algorithms */
 
 struct rsa_keypair {
@@ -217,7 +197,6 @@ struct crypto_ops {
 
 	TEE_Result (*init)(void);
 	struct acipher_ops acipher;
-	struct bignum_ops bignum;
 };
 
 extern const struct crypto_ops crypto_ops;
@@ -276,6 +255,25 @@ TEE_Result crypto_authenc_dec_final(void *ctx, uint32_t algo,
 				    uint8_t *dst_data, size_t *dst_len,
 				    const uint8_t *tag, size_t tag_len);
 void crypto_authenc_final(void *ctx, uint32_t algo);
+
+/* Implementation-defined big numbers */
+
+/*
+ * Allocate a bignum capable of holding an unsigned integer value of
+ * up to bitsize bits
+ */
+struct bignum *crypto_bignum_allocate(size_t size_bits);
+TEE_Result crypto_bignum_bin2bn(const uint8_t *from, size_t fromsize,
+				struct bignum *to);
+size_t crypto_bignum_num_bytes(struct bignum *a);
+size_t crypto_bignum_num_bits(struct bignum *a);
+void crypto_bignum_bn2bin(const struct bignum *from, uint8_t *to);
+void crypto_bignum_copy(struct bignum *to, const struct bignum *from);
+void crypto_bignum_free(struct bignum *a);
+void crypto_bignum_clear(struct bignum *a);
+
+/* return -1 if a<b, 0 if a==b, +1 if a>b */
+int32_t crypto_bignum_compare(struct bignum *a, struct bignum *b);
 
 
 /*

--- a/core/include/tee/tee_cryp_provider.h
+++ b/core/include/tee/tee_cryp_provider.h
@@ -47,16 +47,6 @@
 
 #include <tee_api_types.h>
 
-/* Message digest functions */
-struct hash_ops {
-	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
-	TEE_Result (*init)(void *ctx, uint32_t algo);
-	TEE_Result (*update)(void *ctx, uint32_t algo,
-			     const uint8_t *data, size_t len);
-	TEE_Result (*final)(void *ctx, uint32_t algo, uint8_t *digest,
-			    size_t len);
-};
-
 /* Symmetric ciphers */
 struct cipher_ops {
 	TEE_Result (*get_ctx_size)(uint32_t algo, size_t *size);
@@ -285,7 +275,6 @@ struct crypto_ops {
 	const char *name;
 
 	TEE_Result (*init)(void);
-	struct hash_ops hash;
 	struct cipher_ops cipher;
 	struct mac_ops mac;
 	struct authenc_ops authenc;
@@ -294,6 +283,15 @@ struct crypto_ops {
 };
 
 extern const struct crypto_ops crypto_ops;
+
+
+/* Message digest functions */
+TEE_Result crypto_hash_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_hash_init(void *ctx, uint32_t algo);
+TEE_Result crypto_hash_update(void *ctx, uint32_t algo, const uint8_t *data,
+			      size_t len);
+TEE_Result crypto_hash_final(void *ctx, uint32_t algo, uint8_t *digest,
+			     size_t len);
 
 /*
  * Verifies a SHA-256 hash, doesn't require tee_cryp_init() to be called in

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -26,7 +26,7 @@
  */
 
 #include <assert.h>
-#include <tee/tee_cryp_provider.h>
+#include <crypto/crypto.h>
 #include <tee/tee_cryp_utl.h>
 
 #include <tomcrypt.h>

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -2254,7 +2254,7 @@ struct cbc_state {
 };
 #endif
 
-static TEE_Result mac_get_ctx_size(uint32_t algo, size_t *size)
+TEE_Result crypto_mac_get_ctx_size(uint32_t algo, size_t *size)
 {
 	switch (algo) {
 #if defined(CFG_CRYPTO_HMAC)
@@ -2289,7 +2289,7 @@ static TEE_Result mac_get_ctx_size(uint32_t algo, size_t *size)
 	return TEE_SUCCESS;
 }
 
-static TEE_Result mac_init(void *ctx, uint32_t algo, const uint8_t *key,
+TEE_Result crypto_mac_init(void *ctx, uint32_t algo, const uint8_t *key,
 			   size_t len)
 {
 	TEE_Result res;
@@ -2373,7 +2373,7 @@ static TEE_Result mac_init(void *ctx, uint32_t algo, const uint8_t *key,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result mac_update(void *ctx, uint32_t algo, const uint8_t *data,
+TEE_Result crypto_mac_update(void *ctx, uint32_t algo, const uint8_t *data,
 			     size_t len)
 {
 #if defined(CFG_CRYPTO_CBC_MAC)
@@ -2448,7 +2448,7 @@ static TEE_Result mac_update(void *ctx, uint32_t algo, const uint8_t *data,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result mac_final(void *ctx, uint32_t algo, uint8_t *digest,
+TEE_Result crypto_mac_final(void *ctx, uint32_t algo, uint8_t *digest,
 			    size_t digest_len)
 {
 #if defined(CFG_CRYPTO_CBC_MAC)
@@ -2493,8 +2493,9 @@ static TEE_Result mac_final(void *ctx, uint32_t algo, uint8_t *digest,
 			memset(cbc->block+cbc->current_block_len,
 			       pad_len, pad_len);
 			cbc->current_block_len = 0;
-			if (TEE_SUCCESS != mac_update(
-				ctx, algo, cbc->block, cbc->block_len))
+			if (TEE_SUCCESS != crypto_mac_update(ctx, algo,
+							     cbc->block,
+							     cbc->block_len))
 					return TEE_ERROR_BAD_STATE;
 			break;
 		default:
@@ -2978,14 +2979,6 @@ static TEE_Result tee_ltc_init(void)
 const struct crypto_ops crypto_ops = {
 	.name = "LibTomCrypt provider",
 	.init = tee_ltc_init,
-#if defined(_CFG_CRYPTO_WITH_MAC)
-	.mac = {
-		.get_ctx_size = mac_get_ctx_size,
-		.init = mac_init,
-		.update = mac_update,
-		.final = mac_final,
-	},
-#endif
 #if defined(_CFG_CRYPTO_WITH_AUTHENC)
 	.authenc = {
 		.dec_final = authenc_dec_final,

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -639,27 +639,27 @@ static void tee_ltc_alloc_mpa(void)
 	mpa_set_random_generator(crypto_rng_read);
 }
 
-static size_t num_bytes(struct bignum *a)
+size_t crypto_bignum_num_bytes(struct bignum *a)
 {
 	return mp_unsigned_bin_size(a);
 }
 
-static size_t num_bits(struct bignum *a)
+size_t crypto_bignum_num_bits(struct bignum *a)
 {
 	return mp_count_bits(a);
 }
 
-static int32_t compare(struct bignum *a, struct bignum *b)
+int32_t crypto_bignum_compare(struct bignum *a, struct bignum *b)
 {
 	return mp_cmp(a, b);
 }
 
-static void bn2bin(const struct bignum *from, uint8_t *to)
+void crypto_bignum_bn2bin(const struct bignum *from, uint8_t *to)
 {
 	mp_to_unsigned_bin((struct bignum *)from, to);
 }
 
-static TEE_Result bin2bn(const uint8_t *from, size_t fromsize,
+TEE_Result crypto_bignum_bin2bn(const uint8_t *from, size_t fromsize,
 			 struct bignum *to)
 {
 	if (mp_read_unsigned_bin(to, (uint8_t *)from, fromsize) != CRYPT_OK)
@@ -667,12 +667,12 @@ static TEE_Result bin2bn(const uint8_t *from, size_t fromsize,
 	return TEE_SUCCESS;
 }
 
-static void copy(struct bignum *to, const struct bignum *from)
+void crypto_bignum_copy(struct bignum *to, const struct bignum *from)
 {
 	mp_copy((void *)from, to);
 }
 
-static struct bignum *bn_allocate(size_t size_bits)
+struct bignum *crypto_bignum_allocate(size_t size_bits)
 {
 	size_t sz = mpa_StaticVarSizeInU32(size_bits) *	sizeof(uint32_t);
 	struct mpa_numbase_struct *bn = calloc(1, sz);
@@ -683,12 +683,12 @@ static struct bignum *bn_allocate(size_t size_bits)
 	return (struct bignum *)bn;
 }
 
-static void bn_free(struct bignum *s)
+void crypto_bignum_free(struct bignum *s)
 {
 	free(s);
 }
 
-static void bn_clear(struct bignum *s)
+void crypto_bignum_clear(struct bignum *s)
 {
 	struct mpa_numbase_struct *bn = (struct mpa_numbase_struct *)s;
 
@@ -701,7 +701,7 @@ static bool bn_alloc_max(struct bignum **s)
 	size_t sz = mpa_StaticVarSizeInU32(LTC_MAX_BITS_PER_VARIABLE) *
 			sizeof(uint32_t) * 8;
 
-	*s = bn_allocate(sz);
+	*s = crypto_bignum_allocate(sz);
 	return !!(*s);
 }
 
@@ -731,13 +731,13 @@ static TEE_Result alloc_rsa_keypair(struct rsa_keypair *s,
 
 	return TEE_SUCCESS;
 err:
-	bn_free(s->e);
-	bn_free(s->d);
-	bn_free(s->n);
-	bn_free(s->p);
-	bn_free(s->q);
-	bn_free(s->qp);
-	bn_free(s->dp);
+	crypto_bignum_free(s->e);
+	crypto_bignum_free(s->d);
+	crypto_bignum_free(s->n);
+	crypto_bignum_free(s->p);
+	crypto_bignum_free(s->q);
+	crypto_bignum_free(s->qp);
+	crypto_bignum_free(s->dp);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -753,7 +753,7 @@ static TEE_Result alloc_rsa_public_key(struct rsa_public_key *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	bn_free(s->e);
+	crypto_bignum_free(s->e);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -761,8 +761,8 @@ static void free_rsa_public_key(struct rsa_public_key *s)
 {
 	if (!s)
 		return;
-	bn_free(s->n);
-	bn_free(s->e);
+	crypto_bignum_free(s->n);
+	crypto_bignum_free(s->e);
 }
 
 static TEE_Result gen_rsa_key(struct rsa_keypair *key, size_t key_size)
@@ -892,7 +892,7 @@ static TEE_Result rsanopad_decrypt(struct rsa_keypair *key,
 	ltc_key.e = key->e;
 	ltc_key.N = key->n;
 	ltc_key.d = key->d;
-	if (key->p && num_bytes(key->p)) {
+	if (key->p && crypto_bignum_num_bytes(key->p)) {
 		ltc_key.p = key->p;
 		ltc_key.q = key->q;
 		ltc_key.qP = key->qp;
@@ -920,7 +920,7 @@ static TEE_Result rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
 	ltc_key.e = key->e;
 	ltc_key.d = key->d;
 	ltc_key.N = key->n;
-	if (key->p && num_bytes(key->p)) {
+	if (key->p && crypto_bignum_num_bytes(key->p)) {
 		ltc_key.p = key->p;
 		ltc_key.q = key->q;
 		ltc_key.qP = key->qp;
@@ -1073,7 +1073,7 @@ static TEE_Result rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 	ltc_key.e = key->e;
 	ltc_key.N = key->n;
 	ltc_key.d = key->d;
-	if (key->p && num_bytes(key->p)) {
+	if (key->p && crypto_bignum_num_bytes(key->p)) {
 		ltc_key.p = key->p;
 		ltc_key.q = key->q;
 		ltc_key.qP = key->qp;
@@ -1235,10 +1235,10 @@ static TEE_Result alloc_dsa_keypair(struct dsa_keypair *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	bn_free(s->g);
-	bn_free(s->p);
-	bn_free(s->q);
-	bn_free(s->y);
+	crypto_bignum_free(s->g);
+	crypto_bignum_free(s->p);
+	crypto_bignum_free(s->q);
+	crypto_bignum_free(s->y);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -1258,9 +1258,9 @@ static TEE_Result alloc_dsa_public_key(struct dsa_public_key *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	bn_free(s->g);
-	bn_free(s->p);
-	bn_free(s->q);
+	crypto_bignum_free(s->g);
+	crypto_bignum_free(s->p);
+	crypto_bignum_free(s->q);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -1438,10 +1438,10 @@ static TEE_Result alloc_dh_keypair(struct dh_keypair *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	bn_free(s->g);
-	bn_free(s->p);
-	bn_free(s->y);
-	bn_free(s->x);
+	crypto_bignum_free(s->g);
+	crypto_bignum_free(s->p);
+	crypto_bignum_free(s->y);
+	crypto_bignum_free(s->x);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -1504,9 +1504,9 @@ static TEE_Result alloc_ecc_keypair(struct ecc_keypair *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	bn_free(s->d);
-	bn_free(s->x);
-	bn_free(s->y);
+	crypto_bignum_free(s->d);
+	crypto_bignum_free(s->x);
+	crypto_bignum_free(s->y);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -1520,8 +1520,8 @@ static TEE_Result alloc_ecc_public_key(struct ecc_public_key *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	bn_free(s->x);
-	bn_free(s->y);
+	crypto_bignum_free(s->x);
+	crypto_bignum_free(s->y);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -1530,8 +1530,8 @@ static void free_ecc_public_key(struct ecc_public_key *s)
 	if (!s)
 		return;
 
-	bn_free(s->x);
-	bn_free(s->y);
+	crypto_bignum_free(s->x);
+	crypto_bignum_free(s->y);
 }
 
 /*
@@ -3020,17 +3020,6 @@ const struct crypto_ops crypto_ops = {
 		/* ECDH only */
 		.ecc_shared_secret = do_ecc_shared_secret,
 #endif
-	},
-	.bignum = {
-		.allocate = bn_allocate,
-		.num_bytes = num_bytes,
-		.num_bits = num_bits,
-		.compare = compare,
-		.bn2bin = bn2bin,
-		.bin2bn = bin2bn,
-		.copy = copy,
-		.free = bn_free,
-		.clear = bn_clear
 	},
 #endif /* _CFG_CRYPTO_WITH_ACIPHER */
 };

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -369,8 +369,7 @@ static TEE_Result tee_algo_to_ltc_cipherindex(uint32_t algo,
  ******************************************************************************/
 
 #if defined(_CFG_CRYPTO_WITH_HASH)
-
-static TEE_Result hash_get_ctx_size(uint32_t algo, size_t *size)
+TEE_Result crypto_hash_get_ctx_size(uint32_t algo, size_t *size)
 {
 	switch (algo) {
 #if defined(CFG_CRYPTO_MD5)
@@ -400,7 +399,7 @@ static TEE_Result hash_get_ctx_size(uint32_t algo, size_t *size)
 	return TEE_SUCCESS;
 }
 
-static TEE_Result hash_init(void *ctx, uint32_t algo)
+TEE_Result crypto_hash_init(void *ctx, uint32_t algo)
 {
 	int ltc_res;
 	int ltc_hashindex;
@@ -415,7 +414,7 @@ static TEE_Result hash_init(void *ctx, uint32_t algo)
 		return TEE_ERROR_BAD_STATE;
 }
 
-static TEE_Result hash_update(void *ctx, uint32_t algo,
+TEE_Result crypto_hash_update(void *ctx, uint32_t algo,
 				      const uint8_t *data, size_t len)
 {
 	int ltc_res;
@@ -431,8 +430,8 @@ static TEE_Result hash_update(void *ctx, uint32_t algo,
 		return TEE_ERROR_BAD_STATE;
 }
 
-static TEE_Result hash_final(void *ctx, uint32_t algo, uint8_t *digest,
-				     size_t len)
+TEE_Result crypto_hash_final(void *ctx, uint32_t algo, uint8_t *digest,
+			     size_t len)
 {
 	int ltc_res;
 	int ltc_hashindex;
@@ -465,8 +464,7 @@ static TEE_Result hash_final(void *ctx, uint32_t algo, uint8_t *digest,
 
 	return TEE_SUCCESS;
 }
-
-#endif /* _CFG_CRYPTO_WITH_HASH */
+#endif /*_CFG_CRYPTO_WITH_HASH*/
 
 /******************************************************************************
  * Asymmetric algorithms
@@ -2982,14 +2980,6 @@ static TEE_Result tee_ltc_init(void)
 const struct crypto_ops crypto_ops = {
 	.name = "LibTomCrypt provider",
 	.init = tee_ltc_init,
-#if defined(_CFG_CRYPTO_WITH_HASH)
-	.hash = {
-		.get_ctx_size = hash_get_ctx_size,
-		.init = hash_init,
-		.update = hash_update,
-		.final = hash_final,
-	},
-#endif
 #if defined(_CFG_CRYPTO_WITH_CIPHER)
 	.cipher = {
 		.final = cipher_final,

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -2970,7 +2970,7 @@ TEE_Result crypto_rng_add_entropy(const uint8_t *inbuf, size_t len)
 	return TEE_SUCCESS;
 }
 
-static TEE_Result tee_ltc_init(void)
+TEE_Result crypto_init(void)
 {
 #if defined(_CFG_CRYPTO_WITH_ACIPHER)
 	tee_ltc_alloc_mpa();
@@ -2979,11 +2979,6 @@ static TEE_Result tee_ltc_init(void)
 
 	return tee_ltc_prng_init(tee_ltc_get_prng());
 }
-
-const struct crypto_ops crypto_ops = {
-	.name = "LibTomCrypt provider",
-	.init = tee_ltc_init,
-};
 
 #if defined(CFG_WITH_VFP)
 void tomcrypt_arm_neon_enable(struct tomcrypt_arm_neon_state *state)

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -707,8 +707,8 @@ static bool bn_alloc_max(struct bignum **s)
 
 #if defined(CFG_CRYPTO_RSA)
 
-static TEE_Result alloc_rsa_keypair(struct rsa_keypair *s,
-				    size_t key_size_bits __unused)
+TEE_Result crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
+					    size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->e)) {
@@ -742,8 +742,8 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static TEE_Result alloc_rsa_public_key(struct rsa_public_key *s,
-				       size_t key_size_bits __unused)
+TEE_Result crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
+					       size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->e)) {
@@ -757,7 +757,7 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static void free_rsa_public_key(struct rsa_public_key *s)
+void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 {
 	if (!s)
 		return;
@@ -765,7 +765,7 @@ static void free_rsa_public_key(struct rsa_public_key *s)
 	crypto_bignum_free(s->e);
 }
 
-static TEE_Result gen_rsa_key(struct rsa_keypair *key, size_t key_size)
+TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size)
 {
 	TEE_Result res;
 	rsa_key ltc_tmp_key;
@@ -802,7 +802,6 @@ static TEE_Result gen_rsa_key(struct rsa_keypair *key, size_t key_size)
 
 	return res;
 }
-
 
 static TEE_Result rsadorep(rsa_key *ltc_key, const uint8_t *src,
 			   size_t src_len, uint8_t *dst, size_t *dst_len)
@@ -866,9 +865,9 @@ out:
 	return res;
 }
 
-static TEE_Result rsanopad_encrypt(struct rsa_public_key *key,
-				   const uint8_t *src, size_t src_len,
-				   uint8_t *dst, size_t *dst_len)
+TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
+					   const uint8_t *src, size_t src_len,
+					   uint8_t *dst, size_t *dst_len)
 {
 	TEE_Result res;
 	rsa_key ltc_key = { 0, };
@@ -881,9 +880,9 @@ static TEE_Result rsanopad_encrypt(struct rsa_public_key *key,
 	return res;
 }
 
-static TEE_Result rsanopad_decrypt(struct rsa_keypair *key,
-				   const uint8_t *src, size_t src_len,
-				   uint8_t *dst, size_t *dst_len)
+TEE_Result crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
+					   const uint8_t *src, size_t src_len,
+					   uint8_t *dst, size_t *dst_len)
 {
 	TEE_Result res;
 	rsa_key ltc_key = { 0, };
@@ -904,10 +903,10 @@ static TEE_Result rsanopad_decrypt(struct rsa_keypair *key,
 	return res;
 }
 
-static TEE_Result rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
-				    const uint8_t *label, size_t label_len,
-				    const uint8_t *src, size_t src_len,
-				    uint8_t *dst, size_t *dst_len)
+TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
+					const uint8_t *label, size_t label_len,
+					const uint8_t *src, size_t src_len,
+					uint8_t *dst, size_t *dst_len)
 {
 	TEE_Result res = TEE_SUCCESS;
 	void *buf = NULL;
@@ -1000,7 +999,8 @@ out:
 	return res;
 }
 
-static TEE_Result rsaes_encrypt(uint32_t algo, struct rsa_public_key *key,
+TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
+					struct rsa_public_key *key,
 					const uint8_t *label, size_t label_len,
 					const uint8_t *src, size_t src_len,
 					uint8_t *dst, size_t *dst_len)
@@ -1057,10 +1057,10 @@ out:
 	return res;
 }
 
-static TEE_Result rsassa_sign(uint32_t algo, struct rsa_keypair *key,
-			      int salt_len, const uint8_t *msg,
-			      size_t msg_len, uint8_t *sig,
-			      size_t *sig_len)
+TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
+				      int salt_len, const uint8_t *msg,
+				      size_t msg_len, uint8_t *sig,
+				      size_t *sig_len)
 {
 	TEE_Result res;
 	size_t hash_size, mod_size;
@@ -1144,10 +1144,11 @@ err:
 	return res;
 }
 
-static TEE_Result rsassa_verify(uint32_t algo, struct rsa_public_key *key,
-				int salt_len, const uint8_t *msg,
-				size_t msg_len, const uint8_t *sig,
-				size_t sig_len)
+TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
+					struct rsa_public_key *key,
+					int salt_len, const uint8_t *msg,
+					size_t msg_len, const uint8_t *sig,
+					size_t sig_len)
 {
 	TEE_Result res;
 	uint32_t bigint_size;
@@ -1217,8 +1218,8 @@ err:
 
 #if defined(CFG_CRYPTO_DSA)
 
-static TEE_Result alloc_dsa_keypair(struct dsa_keypair *s,
-				    size_t key_size_bits __unused)
+TEE_Result crypto_acipher_alloc_dsa_keypair(struct dsa_keypair *s,
+					    size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->g)) {
@@ -1242,8 +1243,8 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static TEE_Result alloc_dsa_public_key(struct dsa_public_key *s,
-				       size_t key_size_bits __unused)
+TEE_Result crypto_acipher_alloc_dsa_public_key(struct dsa_public_key *s,
+					       size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->g)) {
@@ -1264,7 +1265,7 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static TEE_Result gen_dsa_key(struct dsa_keypair *key, size_t key_size)
+TEE_Result crypto_acipher_gen_dsa_key(struct dsa_keypair *key, size_t key_size)
 {
 	TEE_Result res;
 	dsa_key ltc_tmp_key;
@@ -1304,9 +1305,9 @@ static TEE_Result gen_dsa_key(struct dsa_keypair *key, size_t key_size)
 	return res;
 }
 
-static TEE_Result dsa_sign(uint32_t algo, struct dsa_keypair *key,
-			   const uint8_t *msg, size_t msg_len, uint8_t *sig,
-			   size_t *sig_len)
+TEE_Result crypto_acipher_dsa_sign(uint32_t algo, struct dsa_keypair *key,
+				   const uint8_t *msg, size_t msg_len,
+				   uint8_t *sig, size_t *sig_len)
 {
 	TEE_Result res;
 	size_t hash_size;
@@ -1374,9 +1375,9 @@ err:
 	return res;
 }
 
-static TEE_Result dsa_verify(uint32_t algo, struct dsa_public_key *key,
-			     const uint8_t *msg, size_t msg_len,
-			     const uint8_t *sig, size_t sig_len)
+TEE_Result crypto_acipher_dsa_verify(uint32_t algo, struct dsa_public_key *key,
+				     const uint8_t *msg, size_t msg_len,
+				     const uint8_t *sig, size_t sig_len)
 {
 	TEE_Result res;
 	int ltc_stat, ltc_res;
@@ -1420,8 +1421,8 @@ err:
 
 #if defined(CFG_CRYPTO_DH)
 
-static TEE_Result alloc_dh_keypair(struct dh_keypair *s,
-				   size_t key_size_bits __unused)
+TEE_Result crypto_acipher_alloc_dh_keypair(struct dh_keypair *s,
+					   size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->g)) {
@@ -1445,8 +1446,8 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static TEE_Result gen_dh_key(struct dh_keypair *key, struct bignum *q,
-			     size_t xbits)
+TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
+				     size_t xbits)
 {
 	TEE_Result res;
 	dh_key ltc_tmp_key;
@@ -1471,9 +1472,9 @@ static TEE_Result gen_dh_key(struct dh_keypair *key, struct bignum *q,
 	return res;
 }
 
-static TEE_Result do_dh_shared_secret(struct dh_keypair *private_key,
-				      struct bignum *public_key,
-				      struct bignum *secret)
+TEE_Result crypto_acipher_dh_shared_secret(struct dh_keypair *private_key,
+					   struct bignum *public_key,
+					   struct bignum *secret)
 {
 	int err;
 	dh_key pk = {
@@ -1492,8 +1493,8 @@ static TEE_Result do_dh_shared_secret(struct dh_keypair *private_key,
 
 #if defined(CFG_CRYPTO_ECC)
 
-static TEE_Result alloc_ecc_keypair(struct ecc_keypair *s,
-				   size_t key_size_bits __unused)
+TEE_Result crypto_acipher_alloc_ecc_keypair(struct ecc_keypair *s,
+					    size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->d))
@@ -1510,8 +1511,8 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static TEE_Result alloc_ecc_public_key(struct ecc_public_key *s,
-				   size_t key_size_bits __unused)
+TEE_Result crypto_acipher_alloc_ecc_public_key(struct ecc_public_key *s,
+					       size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->x))
@@ -1525,7 +1526,7 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
-static void free_ecc_public_key(struct ecc_public_key *s)
+void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s)
 {
 	if (!s)
 		return;
@@ -1604,7 +1605,7 @@ static TEE_Result ecc_get_keysize(uint32_t curve, uint32_t algo,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result gen_ecc_key(struct ecc_keypair *key)
+TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key)
 {
 	TEE_Result res;
 	ecc_key ltc_tmp_key;
@@ -1726,9 +1727,9 @@ static TEE_Result ecc_populate_ltc_public_key(ecc_key *ltc_key,
 	return ecc_compute_key_idx(ltc_key, *key_size_bytes);
 }
 
-static TEE_Result ecc_sign(uint32_t algo, struct ecc_keypair *key,
-			   const uint8_t *msg, size_t msg_len, uint8_t *sig,
-			   size_t *sig_len)
+TEE_Result crypto_acipher_ecc_sign(uint32_t algo, struct ecc_keypair *key,
+				   const uint8_t *msg, size_t msg_len,
+				   uint8_t *sig, size_t *sig_len)
 {
 	TEE_Result res;
 	int ltc_res;
@@ -1780,9 +1781,9 @@ err:
 	return res;
 }
 
-static TEE_Result ecc_verify(uint32_t algo, struct ecc_public_key *key,
-			     const uint8_t *msg, size_t msg_len,
-			     const uint8_t *sig, size_t sig_len)
+TEE_Result crypto_acipher_ecc_verify(uint32_t algo, struct ecc_public_key *key,
+				     const uint8_t *msg, size_t msg_len,
+				     const uint8_t *sig, size_t sig_len)
 {
 	TEE_Result res;
 	int ltc_stat;
@@ -1827,9 +1828,10 @@ out:
 	return res;
 }
 
-static TEE_Result do_ecc_shared_secret(struct ecc_keypair *private_key,
-				       struct ecc_public_key *public_key,
-				       void *secret, unsigned long *secret_len)
+TEE_Result crypto_acipher_ecc_shared_secret(struct ecc_keypair *private_key,
+					    struct ecc_public_key *public_key,
+					    void *secret,
+					    unsigned long *secret_len)
 {
 	TEE_Result res;
 	int ltc_res;
@@ -2981,47 +2983,6 @@ static TEE_Result tee_ltc_init(void)
 const struct crypto_ops crypto_ops = {
 	.name = "LibTomCrypt provider",
 	.init = tee_ltc_init,
-#if defined(_CFG_CRYPTO_WITH_ACIPHER)
-	.acipher = {
-#if defined(CFG_CRYPTO_RSA)
-		.alloc_rsa_keypair = alloc_rsa_keypair,
-		.alloc_rsa_public_key = alloc_rsa_public_key,
-		.free_rsa_public_key = free_rsa_public_key,
-		.gen_rsa_key = gen_rsa_key,
-		.rsaes_decrypt = rsaes_decrypt,
-		.rsaes_encrypt = rsaes_encrypt,
-		.rsanopad_decrypt = rsanopad_decrypt,
-		.rsanopad_encrypt = rsanopad_encrypt,
-		.rsassa_sign = rsassa_sign,
-		.rsassa_verify = rsassa_verify,
-#endif
-#if defined(CFG_CRYPTO_DH)
-		.alloc_dh_keypair = alloc_dh_keypair,
-		.gen_dh_key = gen_dh_key,
-		.dh_shared_secret = do_dh_shared_secret,
-#endif
-#if defined(CFG_CRYPTO_DSA)
-		.alloc_dsa_keypair = alloc_dsa_keypair,
-		.alloc_dsa_public_key = alloc_dsa_public_key,
-		.gen_dsa_key = gen_dsa_key,
-		.dsa_sign = dsa_sign,
-		.dsa_verify = dsa_verify,
-#endif
-#if defined(CFG_CRYPTO_ECC)
-		/* ECDSA and ECDH */
-		.alloc_ecc_keypair = alloc_ecc_keypair,
-		.alloc_ecc_public_key = alloc_ecc_public_key,
-		.gen_ecc_key = gen_ecc_key,
-		.free_ecc_public_key = free_ecc_public_key,
-
-		/* ECDSA only */
-		.ecc_sign = ecc_sign,
-		.ecc_verify = ecc_verify,
-		/* ECDH only */
-		.ecc_shared_secret = do_ecc_shared_secret,
-#endif
-	},
-#endif /* _CFG_CRYPTO_WITH_ACIPHER */
 };
 
 #if defined(CFG_WITH_VFP)

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -1,4 +1,5 @@
 subdirs-y += kernel
+subdirs-y += crypto
 subdirs-y += tee
 subdirs-y += drivers
 

--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -26,6 +26,7 @@
  */
 
 #include <assert.h>
+#include <crypto/crypto.h>
 #include <initcall.h>
 #include <kernel/tee_common_otp.h>
 #include <optee_msg_supplicant.h>
@@ -33,7 +34,6 @@
 #include <string_ext.h>
 #include <string.h>
 #include <tee/fs_htree.h>
-#include <tee/tee_cryp_provider.h>
 #include <tee/tee_fs_key_manager.h>
 #include <tee/tee_fs_rpc.h>
 #include <utee_defines.h>

--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -427,31 +427,29 @@ static TEE_Result calc_node_hash(struct htree_node *node, void *ctx,
 	uint8_t *ndata = (uint8_t *)&node->node + sizeof(node->node.hash);
 	size_t nsize = sizeof(node->node) - sizeof(node->node.hash);
 
-	res = crypto_ops.hash.init(ctx, alg);
+	res = crypto_hash_init(ctx, alg);
 	if (res != TEE_SUCCESS)
 		return res;
 
-	res = crypto_ops.hash.update(ctx, alg, ndata, nsize);
+	res = crypto_hash_update(ctx, alg, ndata, nsize);
 	if (res != TEE_SUCCESS)
 		return res;
 
 	if (node->child[0]) {
-		res = crypto_ops.hash.update(ctx, alg,
-					     node->child[0]->node.hash,
-					     sizeof(node->child[0]->node.hash));
+		res = crypto_hash_update(ctx, alg, node->child[0]->node.hash,
+					 sizeof(node->child[0]->node.hash));
 		if (res != TEE_SUCCESS)
 			return res;
 	}
 
 	if (node->child[1]) {
-		res = crypto_ops.hash.update(ctx, alg,
-					     node->child[1]->node.hash,
-					     sizeof(node->child[1]->node.hash));
+		res = crypto_hash_update(ctx, alg, node->child[1]->node.hash,
+					 sizeof(node->child[1]->node.hash));
 		if (res != TEE_SUCCESS)
 			return res;
 	}
 
-	return crypto_ops.hash.final(ctx, alg, digest, TEE_FS_HTREE_HASH_SIZE);
+	return crypto_hash_final(ctx, alg, digest, TEE_FS_HTREE_HASH_SIZE);
 }
 
 static TEE_Result authenc_init(void **ctx_ret, TEE_OperationMode mode,
@@ -609,11 +607,7 @@ static TEE_Result verify_tree(struct tee_fs_htree *ht)
 	size_t size;
 	void *ctx;
 
-	if (!crypto_ops.hash.get_ctx_size || !crypto_ops.hash.init ||
-	    !crypto_ops.hash.update || !crypto_ops.hash.final)
-		return TEE_ERROR_NOT_SUPPORTED;
-
-	res = crypto_ops.hash.get_ctx_size(TEE_FS_HTREE_HASH_ALG, &size);
+	res = crypto_hash_get_ctx_size(TEE_FS_HTREE_HASH_ALG, &size);
 	if (res != TEE_SUCCESS)
 		return res;
 
@@ -633,7 +627,7 @@ static TEE_Result init_root_node(struct tee_fs_htree *ht)
 	size_t size;
 	void *ctx;
 
-	res = crypto_ops.hash.get_ctx_size(TEE_FS_HTREE_HASH_ALG, &size);
+	res = crypto_hash_get_ctx_size(TEE_FS_HTREE_HASH_ALG, &size);
 	if (res != TEE_SUCCESS)
 		return res;
 	ctx = malloc(size);
@@ -797,7 +791,7 @@ TEE_Result tee_fs_htree_sync_to_storage(struct tee_fs_htree **ht_arg,
 	if (!ht->dirty)
 		return TEE_SUCCESS;
 
-	res = crypto_ops.hash.get_ctx_size(TEE_FS_HTREE_HASH_ALG, &size);
+	res = crypto_hash_get_ctx_size(TEE_FS_HTREE_HASH_ALG, &size);
 	if (res != TEE_SUCCESS)
 		return res;
 	ctx = malloc(size);

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -45,15 +45,8 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 	uint32_t be_count;
 	uint8_t *out = derived_key;
 	uint32_t hash_algo = TEE_ALG_HASH_ALGO(hash_id);
-	const struct hash_ops *hash = &crypto_ops.hash;
 
-	if (!hash->get_ctx_size || !hash->init || !hash->update ||
-	    !hash->final) {
-		res = TEE_ERROR_NOT_IMPLEMENTED;
-		goto out;
-	}
-
-	res = hash->get_ctx_size(hash_algo, &ctx_size);
+	res = crypto_hash_get_ctx_size(hash_algo, &ctx_size);
 	if (res != TEE_SUCCESS)
 		goto out;
 
@@ -72,24 +65,24 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 	for (i = 1; i <= n + 1; i++) {
 		be_count = TEE_U32_TO_BIG_ENDIAN(i);
 
-		res = hash->init(ctx, hash_algo);
+		res = crypto_hash_init(ctx, hash_algo);
 		if (res != TEE_SUCCESS)
 			goto out;
-		res = hash->update(ctx, hash_algo, (uint8_t *)&be_count,
+		res = crypto_hash_update(ctx, hash_algo, (uint8_t *)&be_count,
 				   sizeof(be_count));
 		if (res != TEE_SUCCESS)
 			goto out;
-		res = hash->update(ctx, hash_algo, shared_secret,
+		res = crypto_hash_update(ctx, hash_algo, shared_secret,
 				   shared_secret_len);
 		if (res != TEE_SUCCESS)
 			goto out;
 		if (other_info && other_info_len) {
-			res = hash->update(ctx, hash_algo, other_info,
+			res = crypto_hash_update(ctx, hash_algo, other_info,
 					   other_info_len);
 			if (res != TEE_SUCCESS)
 				goto out;
 		}
-		res = hash->final(ctx, hash_algo, tmp, sizeof(tmp));
+		res = crypto_hash_final(ctx, hash_algo, tmp, sizeof(tmp));
 		if (res != TEE_SUCCESS)
 			goto out;
 

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -25,12 +25,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tee/tee_cryp_concat_kdf.h>
-#include <tee/tee_cryp_provider.h>
-#include <tee/tee_cryp_utl.h>
-#include <utee_defines.h>
+#include <crypto/crypto.h>
 #include <stdlib.h>
 #include <string.h>
+#include <tee/tee_cryp_concat_kdf.h>
+#include <tee/tee_cryp_utl.h>
+#include <utee_defines.h>
 
 TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 			       size_t shared_secret_len,

--- a/core/tee/tee_cryp_hkdf.c
+++ b/core/tee/tee_cryp_hkdf.c
@@ -25,11 +25,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tee/tee_cryp_hkdf.h>
-#include <tee/tee_cryp_provider.h>
-#include <tee/tee_cryp_utl.h>
+#include <crypto/crypto.h>
 #include <stdlib.h>
 #include <string.h>
+#include <tee/tee_cryp_hkdf.h>
+#include <tee/tee_cryp_utl.h>
 #include <utee_defines.h>
 
 

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -25,12 +25,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tee/tee_cryp_pbkdf2.h>
-#include <tee/tee_cryp_provider.h>
-#include <tee/tee_cryp_utl.h>
-#include <utee_defines.h>
+#include <crypto/crypto.h>
 #include <stdlib.h>
 #include <string.h>
+#include <tee/tee_cryp_pbkdf2.h>
+#include <tee/tee_cryp_utl.h>
+#include <utee_defines.h>
 
 struct hmac_parms {
 	uint32_t algo;

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -25,15 +25,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <string_ext.h>
-#include <utee_defines.h>
-#include <tee/tee_cryp_utl.h>
-#include <tee/tee_cryp_provider.h>
+#include <crypto/crypto.h>
+#include <initcall.h>
 #include <kernel/tee_time.h>
 #include <rng_support.h>
-#include <initcall.h>
+#include <stdlib.h>
+#include <string_ext.h>
+#include <string.h>
+#include <tee/tee_cryp_utl.h>
+#include <utee_defines.h>
 
 #if !defined(CFG_WITH_SOFTWARE_PRNG)
 TEE_Result get_rng_array(void *buffer, int len)

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -199,8 +199,6 @@ TEE_Result tee_do_cipher_update(void *ctx, uint32_t algo,
 	if (mode != TEE_MODE_ENCRYPT && mode != TEE_MODE_DECRYPT)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (crypto_ops.cipher.update == NULL)
-		return TEE_ERROR_NOT_IMPLEMENTED;
 	/*
 	 * Check that the block contains the correct number of data, apart
 	 * for the last block in some XTS / CTR / XTS mode
@@ -242,8 +240,8 @@ TEE_Result tee_do_cipher_update(void *ctx, uint32_t algo,
 		}
 	}
 
-	return crypto_ops.cipher.update(ctx, algo, mode, last_block, data, len,
-					dst);
+	return crypto_cipher_update(ctx, algo, mode, last_block, data, len,
+				    dst);
 }
 
 /*

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -97,13 +97,7 @@ TEE_Result tee_hash_createdigest(uint32_t algo, const uint8_t *data,
 	void *ctx = NULL;
 	size_t ctxsize;
 
-	if (crypto_ops.hash.get_ctx_size == NULL ||
-	    crypto_ops.hash.init == NULL ||
-	    crypto_ops.hash.update == NULL ||
-	    crypto_ops.hash.final == NULL)
-		return TEE_ERROR_NOT_IMPLEMENTED;
-
-	if (crypto_ops.hash.get_ctx_size(algo, &ctxsize) != TEE_SUCCESS) {
+	if (crypto_hash_get_ctx_size(algo, &ctxsize) != TEE_SUCCESS) {
 		res = TEE_ERROR_NOT_SUPPORTED;
 		goto out;
 	}
@@ -114,16 +108,16 @@ TEE_Result tee_hash_createdigest(uint32_t algo, const uint8_t *data,
 		goto out;
 	}
 
-	if (crypto_ops.hash.init(ctx, algo) != TEE_SUCCESS)
+	if (crypto_hash_init(ctx, algo) != TEE_SUCCESS)
 		goto out;
 
 	if (datalen != 0) {
-		if (crypto_ops.hash.update(ctx, algo, data, datalen)
+		if (crypto_hash_update(ctx, algo, data, datalen)
 		    != TEE_SUCCESS)
 			goto out;
 	}
 
-	if (crypto_ops.hash.final(ctx, algo, digest, digestlen) != TEE_SUCCESS)
+	if (crypto_hash_final(ctx, algo, digest, digestlen) != TEE_SUCCESS)
 		goto out;
 
 	res = TEE_SUCCESS;

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -390,10 +390,7 @@ __weak void plat_prng_add_jitter_entropy_norpc(void)
 
 static TEE_Result tee_cryp_init(void)
 {
-	if (crypto_ops.init)
-		return crypto_ops.init();
-
-	return TEE_SUCCESS;
+	return crypto_init();
 }
 
 service_init(tee_cryp_init);

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -70,7 +70,7 @@ static TEE_Result do_hmac(void *out_key, size_t out_key_size,
 	if (!out_key || !in_key || !message)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = crypto_ops.mac.get_ctx_size(TEE_FS_KM_HMAC_ALG, &hash_ctx_size);
+	res = crypto_mac_get_ctx_size(TEE_FS_KM_HMAC_ALG, &hash_ctx_size);
 	if (res != TEE_SUCCESS)
 		return res;
 
@@ -78,17 +78,15 @@ static TEE_Result do_hmac(void *out_key, size_t out_key_size,
 	if (!ctx)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	res = crypto_ops.mac.init(ctx, TEE_FS_KM_HMAC_ALG, in_key, in_key_size);
+	res = crypto_mac_init(ctx, TEE_FS_KM_HMAC_ALG, in_key, in_key_size);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	res = crypto_ops.mac.update(ctx, TEE_FS_KM_HMAC_ALG,
-			message, message_size);
+	res = crypto_mac_update(ctx, TEE_FS_KM_HMAC_ALG, message, message_size);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	res = crypto_ops.mac.final(ctx, TEE_FS_KM_HMAC_ALG, out_key,
-				   out_key_size);
+	res = crypto_mac_final(ctx, TEE_FS_KM_HMAC_ALG, out_key, out_key_size);
 	if (res != TEE_SUCCESS)
 		goto exit;
 

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -136,7 +136,7 @@ TEE_Result tee_fs_fek_crypt(const TEE_UUID *uuid, TEE_OperationMode mode,
 			return res;
 	}
 
-	res = crypto_ops.cipher.get_ctx_size(TEE_FS_KM_ENC_FEK_ALG, &ctx_size);
+	res = crypto_cipher_get_ctx_size(TEE_FS_KM_ENC_FEK_ALG, &ctx_size);
 	if (res != TEE_SUCCESS)
 		return res;
 
@@ -144,17 +144,17 @@ TEE_Result tee_fs_fek_crypt(const TEE_UUID *uuid, TEE_OperationMode mode,
 	if (!ctx)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	res = crypto_ops.cipher.init(ctx, TEE_FS_KM_ENC_FEK_ALG, mode, tsk,
-				     sizeof(tsk), NULL, 0, NULL, 0);
+	res = crypto_cipher_init(ctx, TEE_FS_KM_ENC_FEK_ALG, mode, tsk,
+				 sizeof(tsk), NULL, 0, NULL, 0);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	res = crypto_ops.cipher.update(ctx, TEE_FS_KM_ENC_FEK_ALG,
-			mode, true, in_key, size, dst_key);
+	res = crypto_cipher_update(ctx, TEE_FS_KM_ENC_FEK_ALG,
+				   mode, true, in_key, size, dst_key);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	crypto_ops.cipher.final(ctx, TEE_FS_KM_ENC_FEK_ALG);
+	crypto_cipher_final(ctx, TEE_FS_KM_ENC_FEK_ALG);
 
 	memcpy(out_key, dst_key, sizeof(dst_key));
 
@@ -253,7 +253,7 @@ static TEE_Result aes_ecb(uint8_t out[TEE_AES_BLOCK_SIZE],
 	size_t ctx_size;
 	uint32_t algo = TEE_ALG_AES_ECB_NOPAD;
 
-	res = crypto_ops.cipher.get_ctx_size(algo, &ctx_size);
+	res = crypto_cipher_get_ctx_size(algo, &ctx_size);
 	if (res != TEE_SUCCESS)
 		return res;
 
@@ -261,17 +261,17 @@ static TEE_Result aes_ecb(uint8_t out[TEE_AES_BLOCK_SIZE],
 	if (!ctx)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	res = crypto_ops.cipher.init(ctx, algo, TEE_MODE_ENCRYPT, key,
-				     key_size, NULL, 0, NULL, 0);
+	res = crypto_cipher_init(ctx, algo, TEE_MODE_ENCRYPT, key,
+				 key_size, NULL, 0, NULL, 0);
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	res = crypto_ops.cipher.update(ctx, algo, TEE_MODE_ENCRYPT, true, in,
-				       TEE_AES_BLOCK_SIZE, out);
+	res = crypto_cipher_update(ctx, algo, TEE_MODE_ENCRYPT, true, in,
+				   TEE_AES_BLOCK_SIZE, out);
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	crypto_ops.cipher.final(ctx, algo);
+	crypto_cipher_final(ctx, algo);
 	res = TEE_SUCCESS;
 
 out:
@@ -325,22 +325,22 @@ TEE_Result tee_fs_crypt_block(const TEE_UUID *uuid, uint8_t *out,
 	res = essiv(iv, fek, blk_idx);
 
 	/* Run AES CBC */
-	res = crypto_ops.cipher.get_ctx_size(algo, &ctx_size);
+	res = crypto_cipher_get_ctx_size(algo, &ctx_size);
 	if (res != TEE_SUCCESS)
 		return res;
 	ctx = malloc(ctx_size);
 	if (!ctx)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	res = crypto_ops.cipher.init(ctx, algo, mode, fek, sizeof(fek), NULL,
-				     0, iv, TEE_AES_BLOCK_SIZE);
+	res = crypto_cipher_init(ctx, algo, mode, fek, sizeof(fek), NULL,
+				 0, iv, TEE_AES_BLOCK_SIZE);
 	if (res != TEE_SUCCESS)
 		goto exit;
-	res = crypto_ops.cipher.update(ctx, algo, mode, true, in, size, out);
+	res = crypto_cipher_update(ctx, algo, mode, true, in, size, out);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	crypto_ops.cipher.final(ctx, algo);
+	crypto_cipher_final(ctx, algo);
 
 exit:
 	free(ctx);

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -37,16 +37,16 @@
  * RNG - Random Number Generator
  */
 
+#include <compiler.h>
+#include <crypto/crypto.h>
 #include <initcall.h>
-#include <stdlib.h>
-#include <string.h>
 #include <kernel/panic.h>
 #include <kernel/tee_common_otp.h>
 #include <kernel/tee_ta_manager.h>
+#include <stdlib.h>
+#include <string.h>
 #include <tee/tee_cryp_utl.h>
-#include <tee/tee_cryp_provider.h>
 #include <tee/tee_fs_key_manager.h>
-#include <compiler.h>
 #include <trace.h>
 #include <util.h>
 

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -221,7 +221,7 @@ static TEE_Result sha256(uint8_t *out, size_t out_size, const uint8_t *in,
 	size_t ctx_size;
 	uint32_t algo = TEE_ALG_SHA256;
 
-	res = crypto_ops.hash.get_ctx_size(algo, &ctx_size);
+	res = crypto_hash_get_ctx_size(algo, &ctx_size);
 	if (res != TEE_SUCCESS)
 		return res;
 
@@ -229,15 +229,15 @@ static TEE_Result sha256(uint8_t *out, size_t out_size, const uint8_t *in,
 	if (!ctx)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	res = crypto_ops.hash.init(ctx, algo);
+	res = crypto_hash_init(ctx, algo);
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	res = crypto_ops.hash.update(ctx, algo, in, in_size);
+	res = crypto_hash_update(ctx, algo, in, in_size);
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	res = crypto_ops.hash.final(ctx, algo, out, out_size);
+	res = crypto_hash_final(ctx, algo, out, out_size);
 
 out:
 	free(ctx);

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -38,7 +38,6 @@
 #include <sys/queue.h>
 #include <tee/fs_dirfile.h>
 #include <tee/fs_htree.h>
-#include <tee/tee_cryp_provider.h>
 #include <tee/tee_fs.h>
 #include <tee/tee_fs_rpc.h>
 #include <tee/tee_pobj.h>

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -26,6 +26,7 @@
  */
 
 #include <assert.h>
+#include <crypto/crypto.h>
 #include <kernel/misc.h>
 #include <kernel/msg_param.h>
 #include <kernel/mutex.h>
@@ -42,7 +43,6 @@
 #include <string_ext.h>
 #include <string.h>
 #include <sys/queue.h>
-#include <tee/tee_cryp_provider.h>
 #include <tee/tee_fs.h>
 #include <tee/tee_fs_key_manager.h>
 #include <tee/tee_pobj.h>

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -26,19 +26,19 @@
  */
 
 #include <assert.h>
-#include <tee_api_types.h>
+#include <crypto/crypto.h>
 #include <kernel/tee_ta_manager.h>
-#include <utee_defines.h>
 #include <mm/tee_mmu.h>
-#include <tee/tee_svc.h>
-#include <tee/tee_svc_cryp.h>
-#include <tee/tee_cryp_utl.h>
-#include <sys/queue.h>
-#include <tee/tee_obj.h>
-#include <tee/tee_cryp_provider.h>
-#include <trace.h>
 #include <string_ext.h>
 #include <string.h>
+#include <sys/queue.h>
+#include <tee_api_types.h>
+#include <tee/tee_cryp_utl.h>
+#include <tee/tee_obj.h>
+#include <tee/tee_svc_cryp.h>
+#include <tee/tee_svc.h>
+#include <trace.h>
+#include <utee_defines.h>
 #include <util.h>
 #if defined(CFG_CRYPTO_HKDF) || defined(CFG_CRYPTO_CONCAT_KDF) || \
 	defined(CFG_CRYPTO_PBKDF2)

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2076,11 +2076,7 @@ TEE_Result syscall_cryp_state_alloc(unsigned long algo, unsigned long mode,
 		if (key1 != 0 || key2 != 0) {
 			res = TEE_ERROR_BAD_PARAMETERS;
 		} else {
-			if (crypto_ops.hash.get_ctx_size)
-				res = crypto_ops.hash.get_ctx_size(algo,
-								&cs->ctx_size);
-			else
-				res = TEE_ERROR_NOT_IMPLEMENTED;
+			res = crypto_hash_get_ctx_size(algo, &cs->ctx_size);
 			if (res != TEE_SUCCESS)
 				break;
 			cs->ctx = calloc(1, cs->ctx_size);
@@ -2195,9 +2191,7 @@ TEE_Result syscall_hash_init(unsigned long state,
 
 	switch (TEE_ALG_GET_CLASS(cs->algo)) {
 	case TEE_OPERATION_DIGEST:
-		if (!crypto_ops.hash.init)
-			return TEE_ERROR_NOT_IMPLEMENTED;
-		res = crypto_ops.hash.init(cs->ctx, cs->algo);
+		res = crypto_hash_init(cs->ctx, cs->algo);
 		if (res != TEE_SUCCESS)
 			return res;
 		break;
@@ -2263,10 +2257,7 @@ TEE_Result syscall_hash_update(unsigned long state, const void *chunk,
 
 	switch (TEE_ALG_GET_CLASS(cs->algo)) {
 	case TEE_OPERATION_DIGEST:
-		if (!crypto_ops.hash.update)
-			return TEE_ERROR_NOT_IMPLEMENTED;
-		res = crypto_ops.hash.update(cs->ctx, cs->algo, chunk,
-					     chunk_size);
+		res = crypto_hash_update(cs->ctx, cs->algo, chunk, chunk_size);
 		if (res != TEE_SUCCESS)
 			return res;
 		break;
@@ -2327,8 +2318,6 @@ TEE_Result syscall_hash_final(unsigned long state, const void *chunk,
 
 	switch (TEE_ALG_GET_CLASS(cs->algo)) {
 	case TEE_OPERATION_DIGEST:
-		if (!crypto_ops.hash.update || !crypto_ops.hash.final)
-			return TEE_ERROR_NOT_IMPLEMENTED;
 		res = tee_hash_get_digest_size(cs->algo, &hash_size);
 		if (res != TEE_SUCCESS)
 			return res;
@@ -2338,14 +2327,13 @@ TEE_Result syscall_hash_final(unsigned long state, const void *chunk,
 		}
 
 		if (chunk_size) {
-			res = crypto_ops.hash.update(cs->ctx, cs->algo, chunk,
-						     chunk_size);
+			res = crypto_hash_update(cs->ctx, cs->algo, chunk,
+						 chunk_size);
 			if (res != TEE_SUCCESS)
 				return res;
 		}
 
-		res = crypto_ops.hash.final(cs->ctx, cs->algo, hash,
-					    hash_size);
+		res = crypto_hash_final(cs->ctx, cs->algo, hash, hash_size);
 		if (res != TEE_SUCCESS)
 			return res;
 		break;

--- a/documentation/crypto.md
+++ b/documentation/crypto.md
@@ -12,12 +12,12 @@ algorithms. Most of the crypto code runs in kernel mode inside the TEE core.
 Here is a schematic view of a typical call to the crypto API. The numbers in
 square brackets ([1], [2]...) refer to the sections below.
 
-        some_function()                              (Trusted App)
-    [1]   TEE_*()                       User space   (libutee.a)
-    ------- utee_*() -----------------------------------------------
-    [2]       tee_svc_*()               Kernel space
-    [3]         crypto_ops.*()                       (libtomcrypt.a)
-    [4]           /* LibTomCrypt */                  (libtomcrypt.a)
+        some_function()                             (Trusted App)
+    [1]   TEE_*()                      User space   (libutee.a)
+    ------- utee_*() ----------------------------------------------
+    [2]       tee_svc_*()              Kernel space
+    [3]         crypto_*()                          (libtomcrypt.a and crypto.c)
+    [4]           /* LibTomCrypt */                 (libtomcrypt.a)
 
 ## The TEE Cryptographic Operations API [1]
 
@@ -51,68 +51,62 @@ All cryptography-related system calls are declared in
 [tee_svc_cryp.c](../core/tee/tee_svc_cryp.c).
 In addition to dealing with the usual work required at the user/kernel interface
 (checking parameters and copying memory buffers between user and kernel space),
-the system calls invoke a private abstraction layer: the **crypto_ops**
-structure, which is declared in
-[tee_cryp_provider.h](../core/include/tee/tee_cryp_provider.h).
+the system calls invoke a private abstraction layer: the **Crypto API**,
+which is declared in [crypto.h](core/include/crypto/crypto.h).
 It serves two main purposes:
 
 1. Allow for alternative implementations, such as hardware-accelerated versions.
 2. Provide an easy way to disable some families of algorithms at compile-time
    to save space. See *LibTomCrypt* below.
 
-## struct crypto_ops [3]
+## crypto_*() [3]
 
-The **crypto_ops** structure contains pointer to functions that implement the
-actual algorithms and helper functions. The TEE Core has one global instance of
-this structure. The default implementation, based on
+The **crypto_*()** functions implement the actual algorithms and helper
+functions. The TEE Core has one global active implementeation of this interface.
+The default implementation, mostly based on
 [LibTomCrypt](https://github.com/libtom/libtomcrypt), is as follows:
 
 ```c
-/* core/lib/libtomcrypt/tee_ltc_provider.c */
+/* core/crypto/crypto.c */
 
 /*
- * static functions: tee_ltc_init(), hash_get_ctx_size(), etc.
- *     ...
+ * Default implementation for all functions in crypto.h
  */
 
-struct crypto_ops crypto_ops = {
-	.name = "LibTomCrypt provider",
-	.init = tee_ltc_init,
-#if defined(_CFG_CRYPTO_WITH_HASH)
-	.hash = {
-		.get_ctx_size = hash_get_ctx_size,
-		.init = hash_init,
-		.update = hash_update,
-		.final = hash_final,
-	},
-#endif
-#if defined(_CFG_CRYPTO_WITH_CIPHER)
-	.cipher = {
-		.final = cipher_final,
-		.get_block_size = cipher_get_block_size,
-		.get_ctx_size = cipher_get_ctx_size,
-		.init = cipher_init,
-		.update = cipher_update,
-	},
-#endif
-	/* ... */
+#if !defined(_CFG_CRYPTO_WITH_HASH)
+TEE_Result crypto_hash_get_ctx_size(uint32_t algo __unused,
+                                    size_t *size __unused)
+{
+        return TEE_ERROR_NOT_IMPLEMENTED;
 }
+...
+#endif /*_CFG_CRYPTO_WITH_HASH*/
+
+/* core/lib/libtomcrypt/tee_ltc_provider.c */
+
+#if defined(_CFG_CRYPTO_WITH_HASH)
+TEE_Result crypto_hash_get_ctx_size(uint32_t algo, size_t *size)
+{
+	/* ... */
+	return TEE_SUCCESS;
+}
+
+#endif /*_CFG_CRYPTO_WITH_HASH*/
+
 ```
 
-As shown above, it is allowed to omit some pointers, in which case they will be
-set to NULL by the compiler and not used by the system service layer.
-When a Trusted Application calls **TEE_AllocateOperation()**  to request an
-operation that is not available, it receives an error status
-(**TEE_ERROR_NOT_IMPLEMENTED**) but it will not panic.
+As shown above, families of algorithms can be disabled and
+[crypto.c]((core/include/crypto/crypto.h)) will provide default null
+implementations that will return **TEE_ERROR_NOT_IMPLEMENTED**.
 
 ## Public/private key format
 
-**crypto_ops** uses implementation-specific types to hold key data
+**<crypto/crypto.h>** uses implementation-specific types to hold key data
 for asymmetric algorithms. For instance, here is how a public RSA key is
 represented:
 
 ```c
-/* core/include/tee/tee_cryp_provider.h */
+/* core/include/crypt/crypt.h */
 
 struct rsa_public_key {
 	struct bignum *e;	/* Public exponent */
@@ -130,20 +124,14 @@ conversion to or from the big endian binary format.
 
 
 ```c
-/*  core/include/tee/tee_cryp_provider.h */
+/*  core/include/core/core.h */
 
-struct bignum_ops {
-	/* ... */
-	struct bignum *(*allocate)(size_t size_bits);
-	TEE_Result (*bin2bn)(const uint8_t *from, size_t fromsize,
-			     struct bignum *to);
-	void (*bn2bin)(const struct bignum *from, uint8_t *to);
-};
+struct bignum *crypto_bignum_allocate(size_t size_bits);
+TEE_Result crypto_bignum_bin2bn(const uint8_t *from, size_t fromsize,
+				struct bignum *to);
+void crypto_bignum_bn2bin(const struct bignum *from, uint8_t *to);
+/*...*/
 
-struct crypto_ops {
-	/* ... */
-	struct bignum_ops bignum;
-};
 ```
 
 ## LibTomCrypt [4]
@@ -169,22 +157,18 @@ return **TEE_ERROR_NOT_IMPLEMENTED**).
 ## How to add a new crypto implementation
 
 To add a new implementation, the default one in
-[core/lib/libtomcrypt](../core/lib/libtomcrypt) should
-be used as a reference. A proof-of-concept implementation based on OpenSSL was
-developed when the `crypto_ops` abstraction layer was introduced. It is not
-included in the main branch of the OP-TEE repository essentially due to
-licensing concerns; however it is available in the
-[poc/openssl_cryptolib](https://github.com/OP-TEE/optee_os/tree/poc/openssl_cryptolib)
-branch.
+[core/lib/libtomcrypt](../core/lib/libtomcrypt) in combination with what is
+in [core/crypto](../core/crypto) should be used as a reference.
 
 Here are the main things to consider when adding a new crypto provider:
 
-- Put all the new code in its own directory under `core/lib`.
+- Put all the new code in its own directory under `core/lib` unless it is
+  code that will be used regardless of which crypto provider is in use.
+  How we are dealing with AES-GCM in [core/crypto](../core/crypto) could
+  serve as an example.
 - Avoid modifying [tee_svc_cryp.c](../core/tee/tee_svc_cryp.c). It should not be
   needed.
-- Your own **struct crypto_ops crypto_ops = ...** should be defined in a file at
-  the top level of your new directory.
-- Although not all pointers in **crypto_ops** need to be defined, all are
-  required for compliance to the GlobalPlatform specification.
+- Although not all crypto families need to be defined, all are required for
+  compliance to the GlobalPlatform specification.
 - If you intend to make some algorithms optional, please try to re-use the same
   names for configuration variables as the default implementation.

--- a/documentation/porting_guidelines.md
+++ b/documentation/porting_guidelines.md
@@ -306,13 +306,14 @@ have the ability to enable Crypto Extensions that were introduced with ARMv8-A
 have hardware crypto IP's, but due to NDA's etc it has not been possible to
 enable it. If you have a device capable of doing crypto operations on a
 dedicated crypto block and you prefer to use that in favor for the software
-implementation, then you will need to implement a new `crypto_ops` structure and
-write the low level driver that communicates with the device. Our [crypto.md]
-file describes how to add and implement a new `struct crypto_ops`. Since the
-communication with crypto blocks tends to be quite different depending on what
-kind of crypto block you have, we have not written how that should be done. It
-might be that we do that in the future when get hold of a device where we can
-use the crypto block.
+implementation, then you will need to implement relevant functions defined in
+`core/include/crypto/crypto.h`, the Crypto API, and write the low level
+driver that communicates with the device. Our [crypto.md] file describes
+how the Crypto API is integrated. Since the communication with crypto
+blocks tends to be quite different depending on what kind of crypto block
+you have, we have not written how that should be done. It might be that we
+do that in the future when get hold of a device where we can use the crypto
+block.
 
 ## 7. Power Management / PSCI
 In section 2 when we talked about the file `main.c`, we added a couple of


### PR DESCRIPTION
This takes care of replacing the `crypto_ops` struct as requested in https://github.com/OP-TEE/optee_os/pull/1908

But this doesn't solve the problem of supplying AES-GCM from an OP-TEE internal implementation and AES-CCM from LTC. How can that be done? `core/tee/tee_svc_cryp.c` expects `crypto_authenc_*()` functions so those need to be provided somewhere, but not in LTC as `crypto_authenc_*()` implementation will use OP-TEE internal AES-GCM implementation further on.

One way forward could be:
1. Specify `crypto_aes_gcm_*()` and `crypto_aes_ccm_*()` in `core/include/crypto/aes-{g,c}cm.h`
2. Move the `crypto_authenc_*()` implementation to `core/crypto/crypto.c`, implemented by using the new functions above.

I suppose the best would be to solve the `crypto_authenc_*()` problem in this pull request to avoid messing with crypto interface little by little (or more truthfully much by much).

Another thing is the `core/include/tee/tee_cryp_provider.h` file, it should probably be renamed to `core/include/crypto/api.h` or something similar.

Should I move forward as proposed above? Comments/thoughts?