### PR TITLE
ci: .shippable.yml: enable RPMB FS during "make check"

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -180,7 +180,7 @@ build:
       unset CC &&
       make -k clean 2>&1 >/dev/null &&
       ccache -z &&
-      make -s -j$(getconf _NPROCESSORS_ONLN) check CROSS_COMPILE="ccache arm-linux-gnueabihf-" AARCH32_CROSS_COMPILE=arm-linux-gnueabihf- DUMP_LOGS_ON_ERROR=1 &&
+      make -s -j$(getconf _NPROCESSORS_ONLN) check CROSS_COMPILE="ccache arm-linux-gnueabihf-" AARCH32_CROSS_COMPILE=arm-linux-gnueabihf- DUMP_LOGS_ON_ERROR=1 CFG_RPMB_FS=y CFG_RPMB_WRITE_KEY=y &&
       ccache -s &&
       make -k clean 2>&1 >/dev/null;
 


### PR DESCRIPTION
For better test coverage, run xtest in QEMU with RPMB FS enabled.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
