### PR TITLE
optee: use correct type to hold exceptions state

### DIFF
--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -443,7 +443,7 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 {
 	struct mobj_reg_shm *mobj_reg_shm;
 	size_t i;
-	unsigned int exceptions;
+	uint32_t exceptions;
 
 	if (!num_pages)
 		return NULL;
@@ -484,7 +484,7 @@ err:
 struct mobj *mobj_reg_shm_find_by_cookie(uint64_t cookie)
 {
 	struct mobj_reg_shm *mobj_reg_shm;
-	unsigned int exceptions;
+	uint32_t exceptions;
 
 	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
 	SLIST_FOREACH(mobj_reg_shm, &reg_shm_list, next) {

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -195,7 +195,7 @@ static void raw_malloc_return_hook(void *p, size_t requested_size)
 
 void malloc_reset_stats(void)
 {
-	unsigned int exceptions = malloc_lock();
+	uint32_t exceptions = malloc_lock();
 
 	mstats.max_allocated = 0;
 	mstats.num_alloc_fail = 0;


### PR DESCRIPTION
cpu_spin_lock_xsave() returns exceptions state in uin32_t, not
in unsigned int.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
