### PR TITLE
core: avoid warning in wq_wake_next()

### DIFF
--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -131,7 +131,7 @@ void wq_wake_next(struct wait_queue *wq, const void *sync_obj,
 	int handle = -1;
 	bool do_wakeup = false;
 	bool wake_type_assigned = false;
-	bool wake_read;
+	bool wake_read = false; /* avoid gcc warning */
 
 	/*
 	 * If next type is wait_read wakeup all wqe with wait_read true.


### PR DESCRIPTION
avoid:
core/arch/arm/kernel/wait_queue.c: In function 'wq_wake_next':
core/arch/arm/kernel/wait_queue.c:155:7: error: 'wake_read' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    if (wqe->wait_read != wake_read)

When building with gcc 5.3.1

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
