### PR TITLE
core: pta_socket: add TA_FLAG_CONCURRENT

### DIFF
--- a/core/arch/arm/tee/pta_socket.c
+++ b/core/arch/arm/tee/pta_socket.c
@@ -318,7 +318,7 @@ static TEE_Result pta_socket_invoke_command(void *sess_ctx, uint32_t cmd_id,
 }
 
 pseudo_ta_register(.uuid = PTA_SOCKET_UUID, .name = "socket",
-		   .flags = PTA_DEFAULT_FLAGS,
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_CONCURRENT,
 		   .open_session_entry_point = pta_socket_open_session,
 		   .close_session_entry_point = pta_socket_close_session,
 		   .invoke_command_entry_point = pta_socket_invoke_command);


### PR DESCRIPTION
Adds flag TA_FLAG_CONCURRENT to PTA socket used by the socket
implementation. This avoids one TA blocking another unrelated TA both
doing socket operations.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
