### PR TITLE
mem_usage.py: fix error with ccache

### DIFF
--- a/scripts/mem_usage.py
+++ b/scripts/mem_usage.py
@@ -89,7 +89,8 @@ def main():
     args = get_args()
     env = os.environ.copy()
     env['LC_ALL'] = 'C'
-    readelf = subprocess.Popen([readelf_cmd(), '-S', '-W', args.tee_elf],
+    readelf = subprocess.Popen(str.split(readelf_cmd()) + ['-S', '-W',
+                               args.tee_elf],
                                stdout=subprocess.PIPE, env=env,
                                universal_newlines=True)
     for line in iter(readelf.stdout.readline, ''):


### PR DESCRIPTION
Fix the following error:

make mem_usage CROSS_COMPILE="ccache arm-linux-gnueabihf-"
...
  GEN     out/arm-plat-vexpress/core/tee.mem_usage
Traceback (most recent call last):
  File "./scripts/mem_usage.py", line 162, in <module>
    main()
  File "./scripts/mem_usage.py", line 94, in main
    universal_newlines=True)
  File "/usr/lib/python3.5/subprocess.py", line 947, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.5/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'ccache arm-linux-gnueabihf-readelf'
core/arch/arm/kernel/link.mk:255: recipe for target 'out/arm-plat-vexpress/core/tee.mem_usage' failed
make: *** [out/arm-plat-vexpress/core/tee.mem_usage] Error 1

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
