### PR TITLE
core: ltc: fix double free in dsa_import()

### DIFF
--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_import.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_import.c
@@ -130,10 +130,12 @@ int dsa_import(const unsigned char *in, unsigned long inlen, dsa_key *key)
         PKA_DSA, tmpbuf, &tmpbuf_len,
         LTC_ASN1_SEQUENCE, params, 3);
       if (err != CRYPT_OK) {
+         XFREE(tmpbuf);
          goto LBL_ERR;
       }
 
       if ((err=der_decode_integer(tmpbuf, tmpbuf_len, key->y)) != CRYPT_OK) {
+         XFREE(tmpbuf);
          goto LBL_ERR;
       }
 
@@ -152,7 +154,6 @@ LBL_OK:
 
   return CRYPT_OK;
 LBL_ERR:
-   XFREE(tmpbuf);
    mp_clear_multi(key->p, key->g, key->q, key->x, key->y, NULL);
    return err;
 }


### PR DESCRIPTION
Upstream commit 1e260eeaae43 ("fir coverity finding: dsa_import double
free").

Fixes: https://github.com/OP-TEE/optee_os/issues/1962
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
