### PR TITLE
core: drivers: imx_wdog: fix register access

### DIFF
--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -60,9 +60,9 @@ void imx_wdog_restart(void)
 	write16(val, wdog_base + WCR_OFF);
 	dsb();
 
-	if (read32(wdog_base + WDT_WCR) & WDT_WCR_WDE) {
-		write32(WDT_SEQ1, wdog_base + WDT_WSR);
-		write32(WDT_SEQ2, wdog_base + WDT_WSR);
+	if (read16(wdog_base + WDT_WCR) & WDT_WCR_WDE) {
+		write16(WDT_SEQ1, wdog_base + WDT_WSR);
+		write16(WDT_SEQ2, wdog_base + WDT_WSR);
 	}
 
 	write16(val, wdog_base + WCR_OFF);


### PR DESCRIPTION
The registers's base address are 16bytes aligned, so read32/write32
should be replaced with read16/write16.

Signed-off-by: Peng Fan <peng.fan@nxp.com>