### PR TITLE
core: fix potential double free in ta_open()

### DIFF
--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -56,10 +56,11 @@ struct user_ta_store_handle {
 	uint32_t hash_algo;
 };
 
-static TEE_Result alloc_and_copy_shdr(struct shdr **shdr,
+static TEE_Result alloc_and_copy_shdr(struct shdr **shdr_ret,
 				      const struct shdr *nw_ta,
 				      size_t ta_size)
 {
+	struct shdr *shdr;
 	size_t shdr_size;
 
 	if (ta_size < sizeof(struct shdr))
@@ -67,14 +68,15 @@ static TEE_Result alloc_and_copy_shdr(struct shdr **shdr,
 	shdr_size = SHDR_GET_SIZE(nw_ta);
 	if (ta_size < shdr_size)
 		return TEE_ERROR_SECURITY;
-	*shdr = malloc(shdr_size);
-	if (!*shdr)
+	shdr = malloc(shdr_size);
+	if (!shdr)
 		return TEE_ERROR_SECURITY;
-	memcpy(*shdr, nw_ta, shdr_size);
-	if (shdr_size != SHDR_GET_SIZE(*shdr)) {
-		free(*shdr);
+	memcpy(shdr, nw_ta, shdr_size);
+	if (shdr_size != SHDR_GET_SIZE(shdr)) {
+		free(shdr);
 		return TEE_ERROR_SECURITY;
 	}
+	*shdr_ret = shdr;
 	return TEE_SUCCESS;
 }
 


### PR DESCRIPTION
ta_open() relies on the local variable shdr to be NULL unless it's a valid
pointer. alloc_and_copy_shdr() can in one code path update shdr and then
free it before returning.

The fix is in alloc_and_copy_shdr() to only set the returned shdr once
the pointer is to be returned.

Fixes: https://github.com/OP-TEE/optee_os/issues/1968
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
