### PR TITLE
core/crypto/crypto.c: fix compile errors when _CFG_CRYPTO_WITH_CIPHER=n

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -35,9 +35,10 @@ TEE_Result crypto_hash_final(void *ctx __unused, uint32_t algo __unused,
 #endif /*_CFG_CRYPTO_WITH_HASH*/
 
 #if !defined(_CFG_CRYPTO_WITH_CIPHER)
-TEE_Result crypto_cipher_get_ctx_size(uint32_t algo, size_t *size)
+TEE_Result crypto_cipher_get_ctx_size(uint32_t algo __unused,
+				      size_t *size __unused)
 {
-	return TEE_ERROR_NOT_IMPLEMENTED
+	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
 TEE_Result crypto_cipher_init(void *ctx __unused, uint32_t algo __unused,
@@ -49,7 +50,7 @@ TEE_Result crypto_cipher_init(void *ctx __unused, uint32_t algo __unused,
 			      const uint8_t *iv __unused,
 			      size_t iv_len __unused)
 {
-	return TEE_ERROR_NOT_IMPLEMENTED
+	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
 TEE_Result crypto_cipher_update(void *ctx __unused, uint32_t algo __unused,
@@ -58,7 +59,7 @@ TEE_Result crypto_cipher_update(void *ctx __unused, uint32_t algo __unused,
 				const uint8_t *data __unused,
 				size_t len __unused, uint8_t *dst __unused)
 {
-	return TEE_ERROR_NOT_IMPLEMENTED
+	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
 void crypto_cipher_final(void *ctx __unused, uint32_t algo __unused)
@@ -68,7 +69,7 @@ void crypto_cipher_final(void *ctx __unused, uint32_t algo __unused)
 TEE_Result crypto_cipher_get_block_size(uint32_t algo __unused,
 					size_t *size __unused)
 {
-	return TEE_ERROR_NOT_IMPLEMENTED
+	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 #endif /*_CFG_CRYPTO_WITH_CIPHER*/
 


### PR DESCRIPTION
Although _CFG_CRYPTO_WITH_CIPHER=n does not seem to be a valid
configuration (both the REE and RPMB FS use AES and at least one has to
be enabled currently), fix build errors triggered by:

  make _CFG_CRYPTO_WITH_CIPHER=n \
       out/arm-plat-vexpress/core/crypto/crypto.o

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
