### PR TITLE
ci: shippable: configure caching properly for ccache

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,6 +1,8 @@
 language: c
 build:
   cache: true
+  cache_dir_list:
+    - /root/.ccache
   pre_ci_boot:
     image_name: jforissier/optee_os_ci
     image_tag: latest


### PR DESCRIPTION
Caching was inadvertently broken by commit 4af6a141f612 ("ci:
shippable: run only platform builds"). I wrongly assumed that Shippable
saves the ccache directory by default (~/.ccache), but is not the case.
Only $SHIPPABLE_BUILD_DIR is saved, i.e., the checked out project
(/root/src/github.com/OP-TEE/optee_os).

Fix that by giving the ccache directory in cache_dir_list.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
