### PR TITLE
Adopt SPDX

### DIFF
--- a/core/arch/arm/crypto/aes-gcm-ce.c
+++ b/core/arch/arm/crypto/aes-gcm-ce.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef ARM_H
 #define ARM_H

--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef ARM_H

--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/arm32_macros_cortex_a9.S
+++ b/core/arch/arm/include/arm32_macros_cortex_a9.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef ARM64_H
 #define ARM64_H

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef ARM64_H

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 	.altmacro

--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/crypto/ghash-ce-core.h
+++ b/core/arch/arm/include/crypto/ghash-ce-core.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef KERNEL_ABORT_H

--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/cache_helpers.h
+++ b/core/arch/arm/include/kernel/cache_helpers.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/kernel/cache_helpers.h
+++ b/core/arch/arm/include/kernel/cache_helpers.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __KERNEL_CACHE_HELPERS_H

--- a/core/arch/arm/include/kernel/cache_helpers.h
+++ b/core/arch/arm/include/kernel/cache_helpers.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/delay.h
+++ b/core/arch/arm/include/kernel/delay.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/early_ta.h
+++ b/core/arch/arm/include/kernel/early_ta.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_EARLY_TA_H
 #define KERNEL_EARLY_TA_H

--- a/core/arch/arm/include/kernel/early_ta.h
+++ b/core/arch/arm/include/kernel/early_ta.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_EARLY_TA_H

--- a/core/arch/arm/include/kernel/early_ta.h
+++ b/core/arch/arm/include/kernel/early_ta.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_GENERIC_BOOT_H
 #define KERNEL_GENERIC_BOOT_H

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_GENERIC_BOOT_H

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/linker.h
+++ b/core/arch/arm/include/kernel/linker.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef __KERNEL_LINKER_H

--- a/core/arch/arm/include/kernel/linker.h
+++ b/core/arch/arm/include/kernel/linker.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef __KERNEL_LINKER_H
 #define __KERNEL_LINKER_H

--- a/core/arch/arm/include/kernel/linker.h
+++ b/core/arch/arm/include/kernel/linker.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/misc.h
+++ b/core/arch/arm/include/kernel/misc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/mutex.h
+++ b/core/arch/arm/include/kernel/mutex.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_MUTEX_H

--- a/core/arch/arm/include/kernel/mutex.h
+++ b/core/arch/arm/include/kernel/mutex.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/mutex.h
+++ b/core/arch/arm/include/kernel/mutex.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_MUTEX_H
 #define KERNEL_MUTEX_H

--- a/core/arch/arm/include/kernel/pm_stubs.h
+++ b/core/arch/arm/include/kernel/pm_stubs.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PM_STUBS_H

--- a/core/arch/arm/include/kernel/pm_stubs.h
+++ b/core/arch/arm/include/kernel/pm_stubs.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/kernel/pm_stubs.h
+++ b/core/arch/arm/include/kernel/pm_stubs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_PSEUDO_TA_H

--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_PSEUDO_TA_H
 #define KERNEL_PSEUDO_TA_H

--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/spinlock.h
+++ b/core/arch/arm/include/kernel/spinlock.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/tee_l2cc_mutex.h
+++ b/core/arch/arm/include/kernel/tee_l2cc_mutex.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/thread_defs.h
+++ b/core/arch/arm/include/kernel/thread_defs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/time_source.h
+++ b/core/arch/arm/include/kernel/time_source.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/kernel/time_source.h
+++ b/core/arch/arm/include/kernel/time_source.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/time_source.h
+++ b/core/arch/arm/include/kernel/time_source.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kernel/tee_time.h>

--- a/core/arch/arm/include/kernel/tlb_helpers.h
+++ b/core/arch/arm/include/kernel/tlb_helpers.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/tz_proc_def.h
+++ b/core/arch/arm/include/kernel/tz_proc_def.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/tz_ssvce_def.h
+++ b/core/arch/arm/include/kernel/tz_ssvce_def.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/tz_ssvce_pl310.h
+++ b/core/arch/arm/include/kernel/tz_ssvce_pl310.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_USER_TA_H
 #define KERNEL_USER_TA_H

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_USER_TA_H

--- a/core/arch/arm/include/kernel/vfp.h
+++ b/core/arch/arm/include/kernel/vfp.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/kernel/vfp.h
+++ b/core/arch/arm/include/kernel/vfp.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef KERNEL_VFP_H

--- a/core/arch/arm/include/kernel/vfp.h
+++ b/core/arch/arm/include/kernel/vfp.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/kernel/wait_queue.h
+++ b/core/arch/arm/include/kernel/wait_queue.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_WAIT_QUEUE_H
 #define KERNEL_WAIT_QUEUE_H

--- a/core/arch/arm/include/kernel/wait_queue.h
+++ b/core/arch/arm/include/kernel/wait_queue.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_WAIT_QUEUE_H

--- a/core/arch/arm/include/kernel/wait_queue.h
+++ b/core/arch/arm/include/kernel/wait_queue.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __MM_MOBJ_H

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/mm/pgt_cache.h
+++ b/core/arch/arm/include/mm/pgt_cache.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef MM_PGT_CACHE_H
 #define MM_PGT_CACHE_H

--- a/core/arch/arm/include/mm/pgt_cache.h
+++ b/core/arch/arm/include/mm/pgt_cache.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/mm/pgt_cache.h
+++ b/core/arch/arm/include/mm/pgt_cache.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef MM_PGT_CACHE_H

--- a/core/arch/arm/include/mm/tee_pager.h
+++ b/core/arch/arm/include/mm/tee_pager.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef OPTEE_SMC_H

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef OPTEE_SMC_H
 #define OPTEE_SMC_H

--- a/core/arch/arm/include/sm/pm.h
+++ b/core/arch/arm/include/sm/pm.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/sm/tee_mon.h
+++ b/core/arch/arm/include/sm/tee_mon.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/sm/teesmc_opteed.h
+++ b/core/arch/arm/include/sm/teesmc_opteed.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/sm/teesmc_opteed.h
+++ b/core/arch/arm/include/sm/teesmc_opteed.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/sm/teesmc_opteed.h
+++ b/core/arch/arm/include/sm/teesmc_opteed.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEESMC_OPTEED_H

--- a/core/arch/arm/include/sm/teesmc_opteed_macros.h
+++ b/core/arch/arm/include/sm/teesmc_opteed_macros.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/include/sm/teesmc_opteed_macros.h
+++ b/core/arch/arm/include/sm/teesmc_opteed_macros.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEESMC_OPTEED_MACROS_H

--- a/core/arch/arm/include/sm/teesmc_opteed_macros.h
+++ b/core/arch/arm/include/sm/teesmc_opteed_macros.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/tee/arch_svc.h
+++ b/core/arch/arm/include/tee/arch_svc.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TEE_ARCH_SVC_H
 #define TEE_ARCH_SVC_H

--- a/core/arch/arm/include/tee/arch_svc.h
+++ b/core/arch/arm/include/tee/arch_svc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/tee/arch_svc.h
+++ b/core/arch/arm/include/tee/arch_svc.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef TEE_ARCH_SVC_H

--- a/core/arch/arm/include/tee/entry_fast.h
+++ b/core/arch/arm/include/tee/entry_fast.h
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/include/tee/entry_std.h
+++ b/core/arch/arm/include/tee/entry_std.h
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm.h>

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kernel/thread.h>

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/delay.c
+++ b/core/arch/arm/kernel/delay.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/early_ta.c
+++ b/core/arch/arm/kernel/early_ta.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <initcall.h>

--- a/core/arch/arm/kernel/early_ta.c
+++ b/core/arch/arm/kernel/early_ta.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <initcall.h>
 #include <kernel/early_ta.h>

--- a/core/arch/arm/kernel/early_ta.c
+++ b/core/arch/arm/kernel/early_ta.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/elf32.h
+++ b/core/arch/arm/kernel/elf32.h
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 1996-1998 John D. Polstra.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/core/arch/arm/kernel/elf64.h
+++ b/core/arch/arm/kernel/elf64.h
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 1996-1998 John D. Polstra.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/core/arch/arm/kernel/elf_common.h
+++ b/core/arch/arm/kernel/elf_common.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2000, 2001, 2008, 2011, David E. O'Brien
  * Copyright (c) 1998 John D. Polstra.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <types_ext.h>

--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <types_ext.h>
 #include <tee_api_types.h>

--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/elf_load.h
+++ b/core/arch/arm/kernel/elf_load.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef ELF_LOAD_H
 #define ELF_LOAD_H

--- a/core/arch/arm/kernel/elf_load.h
+++ b/core/arch/arm/kernel/elf_load.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef ELF_LOAD_H

--- a/core/arch/arm/kernel/elf_load.h
+++ b/core/arch/arm/kernel/elf_load.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm.h>

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm32_macros.S>

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <platform_config.h>

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  *

--- a/core/arch/arm/kernel/link_dummies.c
+++ b/core/arch/arm/kernel/link_dummies.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <compiler.h>
 #include <kernel/thread.h>

--- a/core/arch/arm/kernel/link_dummies.c
+++ b/core/arch/arm/kernel/link_dummies.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/link_dummies.c
+++ b/core/arch/arm/kernel/link_dummies.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <compiler.h>

--- a/core/arch/arm/kernel/link_dummy.ld
+++ b/core/arch/arm/kernel/link_dummy.ld
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 SECTIONS

--- a/core/arch/arm/kernel/link_dummy.ld
+++ b/core/arch/arm/kernel/link_dummy.ld
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/link_dummy.ld
+++ b/core/arch/arm/kernel/link_dummy.ld
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/misc_a32.S
+++ b/core/arch/arm/kernel/misc_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kernel/mutex.h>

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <inttypes.h>

--- a/core/arch/arm/kernel/pm_stubs.c
+++ b/core/arch/arm/kernel/pm_stubs.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/pm_stubs.c
+++ b/core/arch/arm/kernel/pm_stubs.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <compiler.h>

--- a/core/arch/arm/kernel/pm_stubs.c
+++ b/core/arch/arm/kernel/pm_stubs.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/proc_a32.S
+++ b/core/arch/arm/kernel/proc_a32.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/proc_a64.S
+++ b/core/arch/arm/kernel/proc_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <arm64.h>
 #include <asm.S>

--- a/core/arch/arm/kernel/proc_a64.S
+++ b/core/arch/arm/kernel/proc_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/proc_a64.S
+++ b/core/arch/arm/kernel/proc_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <arm64.h>

--- a/core/arch/arm/kernel/pseudo_ta.c
+++ b/core/arch/arm/kernel/pseudo_ta.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <assert.h>

--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <assert.h>
 #include <crypto/crypto.h>

--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/spin_lock_a32.S
+++ b/core/arch/arm/kernel/spin_lock_a32.S
@@ -3,6 +3,7 @@
  * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/spin_lock_a64.S
+++ b/core/arch/arm/kernel/spin_lock_a64.S
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  *

--- a/core/arch/arm/kernel/spin_lock_debug.c
+++ b/core/arch/arm/kernel/spin_lock_debug.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/arch/arm/kernel/spin_lock_debug.c
+++ b/core/arch/arm/kernel/spin_lock_debug.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/spin_lock_debug.c
+++ b/core/arch/arm/kernel/spin_lock_debug.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tee_l2cc_mutex.c
+++ b/core/arch/arm/kernel/tee_l2cc_mutex.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tee_time.c
+++ b/core/arch/arm/kernel/tee_time.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limied
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, 2015 Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, 2015 Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, 2015 Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kernel/misc.h>

--- a/core/arch/arm/kernel/tee_time_ree.c
+++ b/core/arch/arm/kernel/tee_time_ree.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/tee_time_ree.c
+++ b/core/arch/arm/kernel/tee_time_ree.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tee_time_ree.c
+++ b/core/arch/arm/kernel/tee_time_ree.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kernel/tee_time.h>

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm64.h>

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tlb_helpers_a32.S
+++ b/core/arch/arm/kernel/tlb_helpers_a32.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tlb_helpers_a64.S
+++ b/core/arch/arm/kernel/tlb_helpers_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/tlb_helpers_a64.S
+++ b/core/arch/arm/kernel/tlb_helpers_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm64.h>

--- a/core/arch/arm/kernel/tlb_helpers_a64.S
+++ b/core/arch/arm/kernel/tlb_helpers_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/trace_ext.c
+++ b/core/arch/arm/kernel/trace_ext.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <stdbool.h>

--- a/core/arch/arm/kernel/trace_ext.c
+++ b/core/arch/arm/kernel/trace_ext.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/trace_ext.c
+++ b/core/arch/arm/kernel/trace_ext.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <stdbool.h>
 #include <trace.h>

--- a/core/arch/arm/kernel/tz_ssvce_pl310_a32.S
+++ b/core/arch/arm/kernel/tz_ssvce_pl310_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/unwind_arm32.c
+++ b/core/arch/arm/kernel/unwind_arm32.c
@@ -5,6 +5,7 @@
  * Copyright 2013-2014 Rui Paulo.
  * Copyright 2013 Eitan Adler.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/core/arch/arm/kernel/unwind_arm64.c
+++ b/core/arch/arm/kernel/unwind_arm64.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 Linaro Limited
  * Copyright (c) 2015 The FreeBSD Foundation
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * This software was developed by Semihalf under
  * the sponsorship of the FreeBSD Foundation.

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2015-2017 Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm.h>

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/vfp.c
+++ b/core/arch/arm/kernel/vfp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/vfp_a32.S
+++ b/core/arch/arm/kernel/vfp_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/core/arch/arm/kernel/vfp_a32.S
+++ b/core/arch/arm/kernel/vfp_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/vfp_a32.S
+++ b/core/arch/arm/kernel/vfp_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/vfp_a64.S
+++ b/core/arch/arm/kernel/vfp_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/core/arch/arm/kernel/vfp_a64.S
+++ b/core/arch/arm/kernel/vfp_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/vfp_a64.S
+++ b/core/arch/arm/kernel/vfp_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/vfp_private.h
+++ b/core/arch/arm/kernel/vfp_private.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef VFP_PRIVATE

--- a/core/arch/arm/kernel/vfp_private.h
+++ b/core/arch/arm/kernel/vfp_private.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/kernel/vfp_private.h
+++ b/core/arch/arm/kernel/vfp_private.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <compiler.h>
 #include <types_ext.h>

--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <compiler.h>

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
  *

--- a/core/arch/arm/mm/core_mmu_private.h
+++ b/core/arch/arm/mm/core_mmu_private.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef CORE_MMU_PRIVATE_H

--- a/core/arch/arm/mm/core_mmu_private.h
+++ b/core/arch/arm/mm/core_mmu_private.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/mm/core_mmu_private.h
+++ b/core/arch/arm/mm/core_mmu_private.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef CORE_MMU_PRIVATE_H
 #define CORE_MMU_PRIVATE_H

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/mm/tee_mm.c
+++ b/core/arch/arm/mm/tee_mm.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-d02/main.c
+++ b/core/arch/arm/plat-d02/main.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-d02/main.c
+++ b/core/arch/arm/plat-d02/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-d02/main.c
+++ b/core/arch/arm/plat-d02/main.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <console.h>

--- a/core/arch/arm/plat-d02/platform_config.h
+++ b/core/arch/arm/plat-d02/platform_config.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PLATFORM_CONFIG_H

--- a/core/arch/arm/plat-d02/platform_config.h
+++ b/core/arch/arm/plat-d02/platform_config.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-d02/platform_config.h
+++ b/core/arch/arm/plat-d02/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-hikey/hikey_peripherals.h
+++ b/core/arch/arm/plat-hikey/hikey_peripherals.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Ltd and Contributors. All rights reserved.
  * Copyright (c) 2016, Hisilicon Ltd and Contributors. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <console.h>

--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PLATFORM_CONFIG_H

--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-hikey/spi_test.c
+++ b/core/arch/arm/plat-hikey/spi_test.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-hikey/spi_test.c
+++ b/core/arch/arm/plat-hikey/spi_test.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <drivers/pl022_spi.h>

--- a/core/arch/arm/plat-hikey/spi_test.c
+++ b/core/arch/arm/plat-hikey/spi_test.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/a7_plat_init.S
+++ b/core/arch/arm/plat-imx/a7_plat_init.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan  <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/a9_plat_init.S
+++ b/core/arch/arm/plat-imx/a9_plat_init.S
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/config/config_imx6sx.h
+++ b/core/arch/arm/plat-imx/config/config_imx6sx.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/config/config_imx7.h
+++ b/core/arch/arm/plat-imx/config/config_imx7.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/imx-common.c
+++ b/core/arch/arm/plat-imx/imx-common.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2016 Freescale Semiconductor, Inc.
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/imx-regs.h
+++ b/core/arch/arm/plat-imx/imx-regs.h
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/imx.h
+++ b/core/arch/arm/plat-imx/imx.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/imx6.c
+++ b/core/arch/arm/plat-imx/imx6.c
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/imx6ul.c
+++ b/core/arch/arm/plat-imx/imx6ul.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/imx7.c
+++ b/core/arch/arm/plat-imx/imx7.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/imx_pl310.c
+++ b/core/arch/arm/plat-imx/imx_pl310.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/imx_pm.h
+++ b/core/arch/arm/plat-imx/imx_pm.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/mmdc.c
+++ b/core/arch/arm/plat-imx/mmdc.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/mmdc.h
+++ b/core/arch/arm/plat-imx/mmdc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/pm/gpcv2.c
+++ b/core/arch/arm/plat-imx/pm/gpcv2.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/pm/imx7_suspend.c
+++ b/core/arch/arm/plat-imx/pm/imx7_suspend.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-imx/pm/pm-imx7.c
+++ b/core/arch/arm/plat-imx/pm/pm-imx7.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/pm/psci-suspend-imx7.S
+++ b/core/arch/arm/plat-imx/pm/psci-suspend-imx7.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-imx/pm/psci.c
+++ b/core/arch/arm/plat-imx/pm/psci.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/plat-ls/ls_core_pos_a32.S
+++ b/core/arch/arm/plat-ls/ls_core_pos_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ls/ls_core_pos_a64.S
+++ b/core/arch/arm/plat-ls/ls_core_pos_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ls/plat_init.S
+++ b/core/arch/arm/plat-ls/plat_init.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ls/platform_config.h
+++ b/core/arch/arm/plat-ls/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-marvell/armada3700/hal_sec_perf.c
+++ b/core/arch/arm/plat-marvell/armada3700/hal_sec_perf.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Marvell International Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-marvell/armada7k8k/hal_sec_perf.c
+++ b/core/arch/arm/plat-marvell/armada7k8k/hal_sec_perf.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Marvell International Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Marvell International Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-marvell/platform_config.h
+++ b/core/arch/arm/plat-marvell/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Marvell International Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <console.h>

--- a/core/arch/arm/plat-mediatek/platform_config.h
+++ b/core/arch/arm/plat-mediatek/platform_config.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PLATFORM_CONFIG_H

--- a/core/arch/arm/plat-mediatek/platform_config.h
+++ b/core/arch/arm/plat-mediatek/platform_config.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-mediatek/platform_config.h
+++ b/core/arch/arm/plat-mediatek/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, GlobalLogic
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, GlobalLogic
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/common.h
+++ b/core/arch/arm/plat-rockchip/common.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/core_pos_a32.S
+++ b/core/arch/arm/plat-rockchip/core_pos_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-rockchip/core_pos_a32.S
+++ b/core/arch/arm/plat-rockchip/core_pos_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/core/arch/arm/plat-rockchip/core_pos_a32.S
+++ b/core/arch/arm/plat-rockchip/core_pos_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/cru.h
+++ b/core/arch/arm/plat-rockchip/cru.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/grf.h
+++ b/core/arch/arm/plat-rockchip/grf.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/plat_init.S
+++ b/core/arch/arm/plat-rockchip/plat_init.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/platform.c
+++ b/core/arch/arm/plat-rockchip/platform.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rockchip/psci_rk322x.c
+++ b/core/arch/arm/plat-rockchip/psci_rk322x.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rpi3/main.c
+++ b/core/arch/arm/plat-rpi3/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Sequitur Labs Inc. All rights reserved.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-rpi3/platform_config.h
+++ b/core/arch/arm/plat-rpi3/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Sequitur Labs Inc. All rights reserved.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sam/main.c
+++ b/core/arch/arm/plat-sam/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Timesys Corporation.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sam/matrix.c
+++ b/core/arch/arm/plat-sam/matrix.c
@@ -4,6 +4,8 @@
  *
  * All rights reserved.
  *
+ * SPDX-License-Identifier: BSD-Source-Code
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/core/arch/arm/plat-sam/matrix.h
+++ b/core/arch/arm/plat-sam/matrix.h
@@ -5,6 +5,8 @@
  *
  * All rights reserved.
  *
+ * SPDX-License-Identifier: BSD-Source-Code
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/core/arch/arm/plat-sam/platform_config.h
+++ b/core/arch/arm/plat-sam/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Timesys Corporation.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sam/sama5d2.h
+++ b/core/arch/arm/plat-sam/sama5d2.h
@@ -4,6 +4,8 @@
  *
  * All rights reserved.
  *
+ * SPDX-License-Identifier: BSD-Source-Code
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/core/arch/arm/plat-sam/tz_matrix.h
+++ b/core/arch/arm/plat-sam/tz_matrix.h
@@ -3,6 +3,8 @@
  *
  * All rights reserved.
  *
+ * SPDX-License-Identifier: BSD-Source-Code
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/core/arch/arm/plat-sprd/console.c
+++ b/core/arch/arm/plat-sprd/console.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Spreadtrum Communications Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Spreadtrum Communications Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sprd/platform_config.h
+++ b/core/arch/arm/plat-sprd/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Spreadtrum Communications Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2016, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-stm/platform_config.h
+++ b/core/arch/arm/plat-stm/platform_config.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014-2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PLATFORM_CONFIG_H

--- a/core/arch/arm/plat-stm/platform_config.h
+++ b/core/arch/arm/plat-stm/platform_config.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014-2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-stm/platform_config.h
+++ b/core/arch/arm/plat-stm/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-stm/rng_support.c
+++ b/core/arch/arm/plat-stm/rng_support.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2016, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-stm/tz_a9init.S
+++ b/core/arch/arm/plat-stm/tz_a9init.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2016, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/entry.S
+++ b/core/arch/arm/plat-sunxi/entry.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/head.c
+++ b/core/arch/arm/plat-sunxi/head.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/kern.ld.S
+++ b/core/arch/arm/plat-sunxi/kern.ld.S
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
  *

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/platform.c
+++ b/core/arch/arm/plat-sunxi/platform.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/platform.h
+++ b/core/arch/arm/plat-sunxi/platform.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/platform_config.h
+++ b/core/arch/arm/plat-sunxi/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/rng_support.c
+++ b/core/arch/arm/plat-sunxi/rng_support.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/smp_boot.S
+++ b/core/arch/arm/plat-sunxi/smp_boot.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-sunxi/smp_fixup.S
+++ b/core/arch/arm/plat-sunxi/smp_fixup.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/a9_plat_init.S
+++ b/core/arch/arm/plat-ti/a9_plat_init.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Texas Instruments
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/api_monitor_index_a15.h
+++ b/core/arch/arm/plat-ti/api_monitor_index_a15.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Texas Instruments
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/api_monitor_index_a9.h
+++ b/core/arch/arm/plat-ti/api_monitor_index_a9.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Texas Instruments
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <platform_config.h>

--- a/core/arch/arm/plat-ti/platform_config.h
+++ b/core/arch/arm/plat-ti/platform_config.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PLATFORM_CONFIG_H

--- a/core/arch/arm/plat-ti/platform_config.h
+++ b/core/arch/arm/plat-ti/platform_config.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-ti/platform_config.h
+++ b/core/arch/arm/plat-ti/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/sm_platform_handler_a15.c
+++ b/core/arch/arm/plat-ti/sm_platform_handler_a15.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Texas Instruments
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/sm_platform_handler_a9.c
+++ b/core/arch/arm/plat-ti/sm_platform_handler_a9.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Texas Instruments
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-ti/ti_pl310.c
+++ b/core/arch/arm/plat-ti/ti_pl310.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Texas Instruments
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-vexpress/juno_core_pos_a32.S
+++ b/core/arch/arm/plat-vexpress/juno_core_pos_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
+++ b/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
+++ b/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
+++ b/core/arch/arm/plat-vexpress/juno_core_pos_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-vexpress/platform_config.h
+++ b/core/arch/arm/plat-vexpress/platform_config.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/plat-vexpress/platform_config.h
+++ b/core/arch/arm/plat-vexpress/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-vexpress/platform_config.h
+++ b/core/arch/arm/plat-vexpress/platform_config.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PLATFORM_CONFIG_H

--- a/core/arch/arm/plat-vexpress/vendor_props.c
+++ b/core/arch/arm/plat-vexpress/vendor_props.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited.
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <tee/tee_svc.h>

--- a/core/arch/arm/plat-vexpress/vendor_props.c
+++ b/core/arch/arm/plat-vexpress/vendor_props.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <tee/tee_svc.h>
 #include <user_ta_header.h>

--- a/core/arch/arm/plat-vexpress/vendor_props.c
+++ b/core/arch/arm/plat-vexpress/vendor_props.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-zynq7k/plat_init.S
+++ b/core/arch/arm/plat-zynq7k/plat_init.S
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-zynq7k/platform_config.h
+++ b/core/arch/arm/plat-zynq7k/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Wind River Systems.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-zynq7k/platform_smc.h
+++ b/core/arch/arm/plat-zynq7k/platform_smc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Wind River System
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Xilinx Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Xilinx Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/benchmark.c
+++ b/core/arch/arm/pta/benchmark.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <bench.h>
 #include <compiler.h>

--- a/core/arch/arm/pta/benchmark.c
+++ b/core/arch/arm/pta/benchmark.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <bench.h>

--- a/core/arch/arm/pta/benchmark.c
+++ b/core/arch/arm/pta/benchmark.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/core_fs_htree_tests.c
+++ b/core/arch/arm/pta/core_fs_htree_tests.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/pta/core_fs_htree_tests.c
+++ b/core/arch/arm/pta/core_fs_htree_tests.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/arch/arm/pta/core_fs_htree_tests.c
+++ b/core/arch/arm/pta/core_fs_htree_tests.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/core_mutex_tests.c
+++ b/core/arch/arm/pta/core_mutex_tests.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/arch/arm/pta/core_self_tests.c
+++ b/core/arch/arm/pta/core_self_tests.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/core_self_tests.h
+++ b/core/arch/arm/pta/core_self_tests.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm.h>

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <crypto/crypto.h>
 #include <keep.h>

--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <crypto/crypto.h>

--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/pta_invoke_tests.c
+++ b/core/arch/arm/pta/pta_invoke_tests.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/se_api_self_tests.c
+++ b/core/arch/arm/pta/se_api_self_tests.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/pta/se_api_self_tests.c
+++ b/core/arch/arm/pta/se_api_self_tests.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/pta/se_api_self_tests.c
+++ b/core/arch/arm/pta/se_api_self_tests.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <compiler.h>

--- a/core/arch/arm/pta/stats.c
+++ b/core/arch/arm/pta/stats.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <compiler.h>

--- a/core/arch/arm/pta/stats.c
+++ b/core/arch/arm/pta/stats.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <compiler.h>
 #include <stdio.h>

--- a/core/arch/arm/pta/stats.c
+++ b/core/arch/arm/pta/stats.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/sm/pm.c
+++ b/core/arch/arm/sm/pm.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/sm/pm_a32.S
+++ b/core/arch/arm/sm/pm_a32.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/sm/psci-helper.S
+++ b/core/arch/arm/sm/psci-helper.S
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/sm/psci.c
+++ b/core/arch/arm/sm/psci.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/sm/sm_private.h
+++ b/core/arch/arm/sm/sm_private.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/sm/std_smc.c
+++ b/core/arch/arm/sm/std_smc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <arm.h>

--- a/core/arch/arm/tee/arch_svc_a32.S
+++ b/core/arch/arm/tee/arch_svc_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/arch_svc_a64.S
+++ b/core/arch/arm/tee/arch_svc_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include "tee_syscall_numbers.h"
 #include "trace_levels.h"

--- a/core/arch/arm/tee/arch_svc_a64.S
+++ b/core/arch/arm/tee/arch_svc_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include "tee_syscall_numbers.h"

--- a/core/arch/arm/tee/arch_svc_a64.S
+++ b/core/arch/arm/tee/arch_svc_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/arch_svc_private.h
+++ b/core/arch/arm/tee/arch_svc_private.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef ARCH_SVC_PRIVATE_H

--- a/core/arch/arm/tee/arch_svc_private.h
+++ b/core/arch/arm/tee/arch_svc_private.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/arch_svc_private.h
+++ b/core/arch/arm/tee/arch_svc_private.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef ARCH_SVC_PRIVATE_H
 #define ARCH_SVC_PRIVATE_H

--- a/core/arch/arm/tee/cache.c
+++ b/core/arch/arm/tee/cache.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/pta_socket.c
+++ b/core/arch/arm/tee/pta_socket.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/arch/arm/tee/pta_socket.c
+++ b/core/arch/arm/tee/pta_socket.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/arch/arm/tee/pta_socket.c
+++ b/core/arch/arm/tee/pta_socket.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/svc_cache.c
+++ b/core/arch/arm/tee/svc_cache.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/svc_dummy.c
+++ b/core/arch/arm/tee/svc_dummy.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <kernel/thread.h>
 #include <kernel/panic.h>

--- a/core/arch/arm/tee/svc_dummy.c
+++ b/core/arch/arm/tee/svc_dummy.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/arch/arm/tee/svc_dummy.c
+++ b/core/arch/arm/tee/svc_dummy.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <kernel/thread.h>

--- a/core/crypto/aes-gcm-ghash.c
+++ b/core/crypto/aes-gcm-ghash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010 Mike Belopuhov
  * Copyright (c) 2017, Linaro Limited
+ * SPDX-License-Identifier: ISC
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above

--- a/core/crypto/aes-gcm-private.h
+++ b/core/crypto/aes-gcm-private.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/crypto/aes-gcm-sw.c
+++ b/core/crypto/aes-gcm-sw.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/crypto/aes-gcm.c
+++ b/core/crypto/aes-gcm.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/drivers/atmel_uart.c
+++ b/core/drivers/atmel_uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Timesys Corporation
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/cdns_uart.c
+++ b/core/drivers/cdns_uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Xilinx Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/dra7_rng.c
+++ b/core/drivers/dra7_rng.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <initcall.h>

--- a/core/drivers/dra7_rng.c
+++ b/core/drivers/dra7_rng.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/drivers/dra7_rng.c
+++ b/core/drivers/dra7_rng.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/hi16xx_rng.c
+++ b/core/drivers/hi16xx_rng.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/drivers/hi16xx_rng.c
+++ b/core/drivers/hi16xx_rng.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /* Driver for the internal Random Number Generator of HiSilicon P660/Hi16xx */

--- a/core/drivers/hi16xx_rng.c
+++ b/core/drivers/hi16xx_rng.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/hi16xx_uart.c
+++ b/core/drivers/hi16xx_uart.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <assert.h>
 #include <drivers/hi16xx_uart.h>

--- a/core/drivers/hi16xx_uart.c
+++ b/core/drivers/hi16xx_uart.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <assert.h>

--- a/core/drivers/hi16xx_uart.c
+++ b/core/drivers/hi16xx_uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/imx_snvs.c
+++ b/core/drivers/imx_snvs.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * Copyright (c) 2014, 2015 Linaro Limited
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/drivers/mvebu_uart.c
+++ b/core/drivers/mvebu_uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Marvell International Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/ns16550.c
+++ b/core/drivers/ns16550.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <assert.h>
 #include <drivers/pl011.h>

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <assert.h>

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -3,28 +3,6 @@
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
  */
 
 #include <assert.h>

--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  *
  */

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/scif.c
+++ b/core/drivers/scif.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, GlobalLogic
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <compiler.h>

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/sprd_uart.c
+++ b/core/drivers/sprd_uart.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Spreadtrum Communications Inc.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/stih_asc.c
+++ b/core/drivers/stih_asc.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <drivers/stih_asc.h>

--- a/core/drivers/stih_asc.c
+++ b/core/drivers/stih_asc.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <drivers/stih_asc.h>
 #include <io.h>

--- a/core/drivers/stih_asc.c
+++ b/core/drivers/stih_asc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/sunxi_uart.c
+++ b/core/drivers/sunxi_uart.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/drivers/tzc400.c
+++ b/core/drivers/tzc400.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  *

--- a/core/include/bench.h
+++ b/core/include/bench.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/bench.h
+++ b/core/include/bench.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef BENCH_H

--- a/core/include/bench.h
+++ b/core/include/bench.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef CONSOLE_H

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/crypto/aes-ccm.h
+++ b/core/include/crypto/aes-ccm.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/include/crypto/aes-gcm.h
+++ b/core/include/crypto/aes-gcm.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/core/include/crypto/internal_aes-gcm.h
+++ b/core/include/crypto/internal_aes-gcm.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/include/drivers/atmel_uart.h
+++ b/core/include/drivers/atmel_uart.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Timesys Corporation
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/cdns_uart.h
+++ b/core/include/drivers/cdns_uart.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Xilinx Inc
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/hi16xx_uart.h
+++ b/core/include/drivers/hi16xx_uart.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/drivers/hi16xx_uart.h
+++ b/core/include/drivers/hi16xx_uart.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/core/include/drivers/hi16xx_uart.h
+++ b/core/include/drivers/hi16xx_uart.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/imx_snvs.h
+++ b/core/include/drivers/imx_snvs.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/imx_uart.h
+++ b/core/include/drivers/imx_uart.h
@@ -2,6 +2,7 @@
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/imx_wdog.h
+++ b/core/include/drivers/imx_wdog.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 NXP
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/mvebu_uart.h
+++ b/core/include/drivers/mvebu_uart.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 Marvell International Ltd.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/ns16550.h
+++ b/core/include/drivers/ns16550.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/pl011.h
+++ b/core/include/drivers/pl011.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef PL011_H
 #define PL011_H

--- a/core/include/drivers/pl011.h
+++ b/core/include/drivers/pl011.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/pl011.h
+++ b/core/include/drivers/pl011.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef PL011_H

--- a/core/include/drivers/pl022_spi.h
+++ b/core/include/drivers/pl022_spi.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/pl022_spi.h
+++ b/core/include/drivers/pl022_spi.h
@@ -3,28 +3,6 @@
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- *
  */
 
 #ifndef __PL022_SPI_H__

--- a/core/include/drivers/pl022_spi.h
+++ b/core/include/drivers/pl022_spi.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  *
  */

--- a/core/include/drivers/pl061_gpio.h
+++ b/core/include/drivers/pl061_gpio.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/drivers/pl061_gpio.h
+++ b/core/include/drivers/pl061_gpio.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/pl061_gpio.h
+++ b/core/include/drivers/pl061_gpio.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __PL061_GPIO_H__

--- a/core/include/drivers/scif.h
+++ b/core/include/drivers/scif.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, GlobalLogic
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/serial.h
+++ b/core/include/drivers/serial.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef __DRIVERS_SERIAL_H
 #define __DRIVERS_SERIAL_H

--- a/core/include/drivers/serial.h
+++ b/core/include/drivers/serial.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/serial.h
+++ b/core/include/drivers/serial.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef __DRIVERS_SERIAL_H

--- a/core/include/drivers/serial8250_uart.h
+++ b/core/include/drivers/serial8250_uart.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef SERIAL8250_UART_H

--- a/core/include/drivers/serial8250_uart.h
+++ b/core/include/drivers/serial8250_uart.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SERIAL8250_UART_H
 #define SERIAL8250_UART_H

--- a/core/include/drivers/serial8250_uart.h
+++ b/core/include/drivers/serial8250_uart.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/sprd_uart.h
+++ b/core/include/drivers/sprd_uart.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Spreadtrum Communications Inc.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/stih_asc.h
+++ b/core/include/drivers/stih_asc.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef STIH_ASC_H

--- a/core/include/drivers/stih_asc.h
+++ b/core/include/drivers/stih_asc.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef STIH_ASC_H
 #define STIH_ASC_H

--- a/core/include/drivers/stih_asc.h
+++ b/core/include/drivers/stih_asc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/sunxi_uart.h
+++ b/core/include/drivers/sunxi_uart.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SUNXI_UART_H
 #define SUNXI_UART_H

--- a/core/include/drivers/sunxi_uart.h
+++ b/core/include/drivers/sunxi_uart.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/drivers/sunxi_uart.h
+++ b/core/include/drivers/sunxi_uart.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef SUNXI_UART_H

--- a/core/include/drivers/tzc380.h
+++ b/core/include/drivers/tzc380.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 NXP
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Peng Fan <peng.fan@nxp.com>
  *

--- a/core/include/drivers/tzc400.h
+++ b/core/include/drivers/tzc400.h
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  *

--- a/core/include/gpio.h
+++ b/core/include/gpio.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/gpio.h
+++ b/core/include/gpio.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __GPIO_H__

--- a/core/include/gpio.h
+++ b/core/include/gpio.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef INITCALL_H

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef IO_H

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef IO_H
 #define IO_H

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KEEP_H
 #define KEEP_H

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KEEP_H

--- a/core/include/kernel/asan.h
+++ b/core/include/kernel/asan.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef __KERNEL_ASAN_H
 #define __KERNEL_ASAN_H

--- a/core/include/kernel/asan.h
+++ b/core/include/kernel/asan.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/asan.h
+++ b/core/include/kernel/asan.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef __KERNEL_ASAN_H

--- a/core/include/kernel/chip_services.h
+++ b/core/include/kernel/chip_services.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef KERNEL_DT_H

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/handle.h
+++ b/core/include/kernel/handle.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/handle.h
+++ b/core/include/kernel/handle.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_HANDLE_H

--- a/core/include/kernel/handle.h
+++ b/core/include/kernel/handle.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_HANDLE_H
 #define KERNEL_HANDLE_H

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef __KERNEL_INTERRUPT_H

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef __KERNEL_INTERRUPT_H
 #define __KERNEL_INTERRUPT_H

--- a/core/include/kernel/msg_param.h
+++ b/core/include/kernel/msg_param.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, EPAM Systems
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/panic.h
+++ b/core/include/kernel/panic.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/tee_common.h
+++ b/core/include/kernel/tee_common.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/tee_customer_part.h
+++ b/core/include/kernel/tee_customer_part.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/tee_kta_trace.h
+++ b/core/include/kernel/tee_kta_trace.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/tee_misc.h
+++ b/core/include/kernel/tee_misc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/tee_time.h
+++ b/core/include/kernel/tee_time.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/trace_ta.h
+++ b/core/include/kernel/trace_ta.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TRACE_TA_H
 #define TRACE_TA_H

--- a/core/include/kernel/trace_ta.h
+++ b/core/include/kernel/trace_ta.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/kernel/trace_ta.h
+++ b/core/include/kernel/trace_ta.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef TRACE_TA_H

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/mm/tee_mmu.h
+++ b/core/include/mm/tee_mmu.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/mm/tee_mmu_types.h
+++ b/core/include/mm/tee_mmu_types.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef _OPTEE_MSG_H

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef _OPTEE_MSG_H
 #define _OPTEE_MSG_H

--- a/core/include/optee_msg_supplicant.h
+++ b/core/include/optee_msg_supplicant.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/optee_msg_supplicant.h
+++ b/core/include/optee_msg_supplicant.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __OPTEE_MSG_SUPPLICANT_H

--- a/core/include/optee_msg_supplicant.h
+++ b/core/include/optee_msg_supplicant.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/rng_support.h
+++ b/core/include/rng_support.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SIGNED_HDR_H
 #define SIGNED_HDR_H

--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef SIGNED_HDR_H

--- a/core/include/spi.h
+++ b/core/include/spi.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/spi.h
+++ b/core/include/spi.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __SPI_H__

--- a/core/include/spi.h
+++ b/core/include/spi.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/ta_pub_key.h
+++ b/core/include/ta_pub_key.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef KERNEL_TA_PUB_KEY_H

--- a/core/include/ta_pub_key.h
+++ b/core/include/ta_pub_key.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/ta_pub_key.h
+++ b/core/include/ta_pub_key.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef KERNEL_TA_PUB_KEY_H
 #define KERNEL_TA_PUB_KEY_H

--- a/core/include/tee/cache.h
+++ b/core/include/tee/cache.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef TEE_CACHE_H

--- a/core/include/tee/cache.h
+++ b/core/include/tee/cache.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/cache.h
+++ b/core/include/tee/cache.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TEE_CACHE_H
 #define TEE_CACHE_H

--- a/core/include/tee/fs_dirfile.h
+++ b/core/include/tee/fs_dirfile.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/fs_dirfile.h
+++ b/core/include/tee/fs_dirfile.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __TEE_FS_DIRFILE_H

--- a/core/include/tee/fs_dirfile.h
+++ b/core/include/tee/fs_dirfile.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/fs_htree.h
+++ b/core/include/tee/fs_htree.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/fs_htree.h
+++ b/core/include/tee/fs_htree.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __TEE_FS_HTREE_H

--- a/core/include/tee/fs_htree.h
+++ b/core/include/tee/fs_htree.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/aid.h
+++ b/core/include/tee/se/aid.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/aid.h
+++ b/core/include/tee/se/aid.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef TEE_SE_AID

--- a/core/include/tee/se/aid.h
+++ b/core/include/tee/se/aid.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TEE_SE_AID
 #define TEE_SE_AID

--- a/core/include/tee/se/apdu.h
+++ b/core/include/tee/se/apdu.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TEE_SE_APDU
 #define TEE_SE_APDU

--- a/core/include/tee/se/apdu.h
+++ b/core/include/tee/se/apdu.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/apdu.h
+++ b/core/include/tee/se/apdu.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef TEE_SE_APDU

--- a/core/include/tee/se/channel.h
+++ b/core/include/tee/se/channel.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/channel.h
+++ b/core/include/tee/se/channel.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_CHANNEL_H

--- a/core/include/tee/se/channel.h
+++ b/core/include/tee/se/channel.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/iso7816.h
+++ b/core/include/tee/se/iso7816.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/iso7816.h
+++ b/core/include/tee/se/iso7816.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/iso7816.h
+++ b/core/include/tee/se/iso7816.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_PROTOCOL_H

--- a/core/include/tee/se/manager.h
+++ b/core/include/tee/se/manager.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_MANAGER_H

--- a/core/include/tee/se/manager.h
+++ b/core/include/tee/se/manager.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/manager.h
+++ b/core/include/tee/se/manager.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/reader.h
+++ b/core/include/tee/se/reader.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/reader.h
+++ b/core/include/tee/se/reader.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/reader.h
+++ b/core/include/tee/se/reader.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_READER_H

--- a/core/include/tee/se/reader/interface.h
+++ b/core/include/tee/se/reader/interface.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/reader/interface.h
+++ b/core/include/tee/se/reader/interface.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_READER_INTERFACE_H

--- a/core/include/tee/se/reader/interface.h
+++ b/core/include/tee/se/reader/interface.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/service.h
+++ b/core/include/tee/se/service.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/service.h
+++ b/core/include/tee/se/service.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/service.h
+++ b/core/include/tee/se/service.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_SERVICE_H

--- a/core/include/tee/se/session.h
+++ b/core/include/tee/se/session.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/session.h
+++ b/core/include/tee/se/session.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_SESSION_H

--- a/core/include/tee/se/session.h
+++ b/core/include/tee/se/session.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/svc.h
+++ b/core/include/tee/se/svc.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/svc.h
+++ b/core/include/tee/se/svc.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SVC_SE_H

--- a/core/include/tee/se/svc.h
+++ b/core/include/tee/se/svc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/util.h
+++ b/core/include/tee/se/util.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/se/util.h
+++ b/core/include/tee/se/util.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/se/util.h
+++ b/core/include/tee/se/util.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_UTIL_H

--- a/core/include/tee/svc_cache.h
+++ b/core/include/tee/svc_cache.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef SVC_CACHE_H

--- a/core/include/tee/svc_cache.h
+++ b/core/include/tee/svc_cache.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef SVC_CACHE_H
 #define SVC_CACHE_H

--- a/core/include/tee/svc_cache.h
+++ b/core/include/tee/svc_cache.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_authenc.h
+++ b/core/include/tee/tee_authenc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_cryp_concat_kdf.h
+++ b/core/include/tee/tee_cryp_concat_kdf.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/tee_cryp_concat_kdf.h
+++ b/core/include/tee/tee_cryp_concat_kdf.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_cryp_concat_kdf.h
+++ b/core/include/tee/tee_cryp_concat_kdf.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_CRYP_CONCAT_KDF_H

--- a/core/include/tee/tee_cryp_hkdf.h
+++ b/core/include/tee/tee_cryp_hkdf.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/tee_cryp_hkdf.h
+++ b/core/include/tee/tee_cryp_hkdf.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_CRYP_HKDF_H

--- a/core/include/tee/tee_cryp_hkdf.h
+++ b/core/include/tee/tee_cryp_hkdf.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_cryp_pbkdf2.h
+++ b/core/include/tee/tee_cryp_pbkdf2.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/tee_cryp_pbkdf2.h
+++ b/core/include/tee/tee_cryp_pbkdf2.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_CRYP_PBKDF2_H

--- a/core/include/tee/tee_cryp_pbkdf2.h
+++ b/core/include/tee/tee_cryp_pbkdf2.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_CRYP_UTL_H

--- a/core/include/tee/tee_fs.h
+++ b/core/include/tee/tee_fs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_fs_key_manager.h
+++ b/core/include/tee/tee_fs_key_manager.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_FS_KEY_MANAGER_H

--- a/core/include/tee/tee_fs_key_manager.h
+++ b/core/include/tee/tee_fs_key_manager.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/tee_fs_key_manager.h
+++ b/core/include/tee/tee_fs_key_manager.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_fs_rpc.h
+++ b/core/include/tee/tee_fs_rpc.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/tee_fs_rpc.h
+++ b/core/include/tee/tee_fs_rpc.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/core/include/tee/tee_fs_rpc.h
+++ b/core/include/tee/tee_fs_rpc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_obj.h
+++ b/core/include/tee/tee_obj.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_pobj.h
+++ b/core/include/tee/tee_pobj.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_svc_cryp.h
+++ b/core/include/tee/tee_svc_cryp.h
@@ -1,6 +1,7 @@
 /*
 * Copyright (c) 2014, STMicroelectronics International N.V.
 * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/tee_svc_storage.h
+++ b/core/include/tee/tee_svc_storage.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/uuid.h
+++ b/core/include/tee/uuid.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/include/tee/uuid.h
+++ b/core/include/tee/uuid.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/include/tee/uuid.h
+++ b/core/include/tee/uuid.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __TEE_UUID

--- a/core/kernel/asan.c
+++ b/core/kernel/asan.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/kernel/asan.c
+++ b/core/kernel/asan.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/kernel/asan.c
+++ b/core/kernel/asan.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/assert.c
+++ b/core/kernel/assert.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <console.h>

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/handle.c
+++ b/core/kernel/handle.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <stdlib.h>

--- a/core/kernel/handle.c
+++ b/core/kernel/handle.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/handle.c
+++ b/core/kernel/handle.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <stdlib.h>
 #include <string.h>

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kernel/interrupt.h>

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/msg_param.c
+++ b/core/kernel/msg_param.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, EPAM Systems
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/kernel/ubsan.c
+++ b/core/kernel/ubsan.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/kernel/ubsan.c
+++ b/core/kernel/ubsan.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <compiler.h>

--- a/core/kernel/ubsan.c
+++ b/core/kernel/ubsan.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libfdt/fdt.c
+++ b/core/lib/libfdt/fdt.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/fdt_addresses.c
+++ b/core/lib/libfdt/fdt_addresses.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2014 David Gibson <david@gibson.dropbear.id.au>
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/fdt_empty_tree.c
+++ b/core/lib/libfdt/fdt_empty_tree.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2012 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/fdt_ro.c
+++ b/core/lib/libfdt/fdt_ro.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/fdt_rw.c
+++ b/core/lib/libfdt/fdt_rw.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/fdt_strerror.c
+++ b/core/lib/libfdt/fdt_strerror.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/fdt_sw.c
+++ b/core/lib/libfdt/fdt_sw.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/fdt_wip.c
+++ b/core/lib/libfdt/fdt_wip.c
@@ -1,6 +1,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/include/fdt.h
+++ b/core/lib/libfdt/include/fdt.h
@@ -4,6 +4,7 @@
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * Copyright 2012 Kim Phillips, Freescale Semiconductor.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/include/libfdt.h
+++ b/core/lib/libfdt/include/libfdt.h
@@ -3,6 +3,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/include/libfdt_env.h
+++ b/core/lib/libfdt/include/libfdt_env.h
@@ -4,6 +4,7 @@
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
  * Copyright 2012 Kim Phillips, Freescale Semiconductor.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libfdt/libfdt_internal.h
+++ b/core/lib/libfdt/libfdt_internal.h
@@ -3,6 +3,7 @@
 /*
  * libfdt - Flat Device Tree manipulation
  * Copyright (C) 2006 David Gibson, IBM Corporation.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * libfdt is dual licensed: you can use it either under the terms of
  * the GPL, or the BSD license, at your option.

--- a/core/lib/libtomcrypt/include/tomcrypt.h
+++ b/core/lib/libtomcrypt/include/tomcrypt.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_argchk.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_argchk.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_arm_neon.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_arm_neon.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TOMCRYPT_ARM_NEON_H
 #define TOMCRYPT_ARM_NEON_H

--- a/core/lib/libtomcrypt/include/tomcrypt_arm_neon.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_arm_neon.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_arm_neon.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_arm_neon.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef TOMCRYPT_ARM_NEON_H

--- a/core/lib/libtomcrypt/include/tomcrypt_cfg.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_cfg.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_cipher.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_cipher.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_custom.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_custom.h
@@ -4,6 +4,8 @@
  *
  * All rights reserved.
  *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *

--- a/core/lib/libtomcrypt/include/tomcrypt_hash.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_hash.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_mac.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_mac.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_macros.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_macros.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_math.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_math.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_misc.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_misc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_mpa.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_mpa.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_pk.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_pk.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_pkcs.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_pkcs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/include/tomcrypt_prng.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_prng.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/ciphers/aes.c
+++ b/core/lib/libtomcrypt/src/ciphers/aes.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/ciphers/aes_armv8a_ce.c
+++ b/core/lib/libtomcrypt/src/ciphers/aes_armv8a_ce.c
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * Copyright (c) 2001-2007, Tom St Denis

--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
@@ -3,7 +3,6 @@
  */
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  */
 
 /*

--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *

--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
@@ -4,28 +4,6 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a64.S
@@ -3,7 +3,6 @@
  */
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  */
 
 /*

--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a64.S
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  *

--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a64.S
@@ -4,28 +4,6 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/core/lib/libtomcrypt/src/ciphers/aes_tab.c
+++ b/core/lib/libtomcrypt/src/ciphers/aes_tab.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/ciphers/des.c
+++ b/core/lib/libtomcrypt/src/ciphers/des.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_aad.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2001-2007, Tom St Denis
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_add_nonce.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2001-2007, Tom St Denis
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_done.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2001-2007, Tom St Denis
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_init.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2001-2007, Tom St Denis
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_process.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2001-2007, Tom St Denis
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ccm/ccm_reset.c
+++ b/core/lib/libtomcrypt/src/encauth/ccm/ccm_reset.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2001-2007, Tom St Denis
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/eax/eax_addheader.c
+++ b/core/lib/libtomcrypt/src/encauth/eax/eax_addheader.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/eax/eax_decrypt.c
+++ b/core/lib/libtomcrypt/src/encauth/eax/eax_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/eax/eax_decrypt_verify_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/eax/eax_decrypt_verify_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/eax/eax_done.c
+++ b/core/lib/libtomcrypt/src/encauth/eax/eax_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/eax/eax_encrypt.c
+++ b/core/lib/libtomcrypt/src/encauth/eax/eax_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/eax/eax_encrypt_authenticate_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/eax/eax_encrypt_authenticate_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/eax/eax_init.c
+++ b/core/lib/libtomcrypt/src/encauth/eax/eax_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_add_aad.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_add_aad.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_add_iv.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_add_iv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_done.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_gf_mult.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_gf_mult.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_init.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_mult_h.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_mult_h.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_mult_h_arm_ce.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_mult_h_arm_ce.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_process.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_process.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/gcm/gcm_reset.c
+++ b/core/lib/libtomcrypt/src/encauth/gcm/gcm_reset.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_decrypt.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_decrypt_verify_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_decrypt_verify_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_done_decrypt.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_done_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_done_encrypt.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_done_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_encrypt.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_encrypt_authenticate_memory.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_encrypt_authenticate_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_init.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_ntz.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_ntz.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/ocb_shift_xor.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/ocb_shift_xor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/encauth/ocb/s_ocb_done.c
+++ b/core/lib/libtomcrypt/src/encauth/ocb/s_ocb_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_file.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_file.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_filehandle.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_filehandle.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_memory.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/helper/hash_memory_multi.c
+++ b/core/lib/libtomcrypt/src/hashes/helper/hash_memory_multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/md5.c
+++ b/core/lib/libtomcrypt/src/hashes/md5.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha1.c
+++ b/core/lib/libtomcrypt/src/hashes/sha1.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce.c
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce.c
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014-2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2014-2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /* SHA-1 secure hash using ARMv8 Crypto Extensions */

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a64.S
@@ -3,7 +3,6 @@
  */
 /*
  * Copyright (c) 2014-2015, Linaro Limited
- * All rights reserved.
  */
 
  /*

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a64.S
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2014-2015, Linaro Limited
  * All rights reserved.
  *

--- a/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/hashes/sha1_armv8a_ce_a64.S
@@ -4,28 +4,6 @@
 /*
  * Copyright (c) 2014-2015, Linaro Limited
  * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
  /*

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha224.c
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha224.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256.c
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce.c
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce.c
@@ -3,6 +3,7 @@
  * All rights reserved.
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014-2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014-2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2014-2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /* SHA-256 secure hash using ARMv8 Crypto Extensions */

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a64.S
@@ -3,7 +3,6 @@
  */
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  */
 
 /*

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a64.S
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  *

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha256_armv8a_ce_a64.S
@@ -4,28 +4,6 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha384.c
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha384.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/hashes/sha2/sha512.c
+++ b/core/lib/libtomcrypt/src/hashes/sha2/sha512.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_done.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_file.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_file.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_memory.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_memory_multi.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_memory_multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/hmac/hmac_process.c
+++ b/core/lib/libtomcrypt/src/mac/hmac/hmac_process.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/omac/omac_done.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/omac/omac_file.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_file.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/omac/omac_init.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/omac/omac_memory.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/omac/omac_memory_multi.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_memory_multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/omac/omac_process.c
+++ b/core/lib/libtomcrypt/src/mac/omac/omac_process.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_done.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_file.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_file.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_init.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_memory.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_memory_multi.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_memory_multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_ntz.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_ntz.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_process.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_process.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/pmac/pmac_shift_xor.c
+++ b/core/lib/libtomcrypt/src/mac/pmac/pmac_shift_xor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/xcbc/xcbc_done.c
+++ b/core/lib/libtomcrypt/src/mac/xcbc/xcbc_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/xcbc/xcbc_file.c
+++ b/core/lib/libtomcrypt/src/mac/xcbc/xcbc_file.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/xcbc/xcbc_init.c
+++ b/core/lib/libtomcrypt/src/mac/xcbc/xcbc_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/xcbc/xcbc_memory.c
+++ b/core/lib/libtomcrypt/src/mac/xcbc/xcbc_memory.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/xcbc/xcbc_memory_multi.c
+++ b/core/lib/libtomcrypt/src/mac/xcbc/xcbc_memory_multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mac/xcbc/xcbc_process.c
+++ b/core/lib/libtomcrypt/src/mac/xcbc/xcbc_process.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/math/fp/ltc_ecc_fp_mulmod.c
+++ b/core/lib/libtomcrypt/src/math/fp/ltc_ecc_fp_mulmod.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/math/multi.c
+++ b/core/lib/libtomcrypt/src/math/multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/math/rand_prime.c
+++ b/core/lib/libtomcrypt/src/math/rand_prime.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/base64/base64_decode.c
+++ b/core/lib/libtomcrypt/src/misc/base64/base64_decode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/base64/base64_encode.c
+++ b/core/lib/libtomcrypt/src/misc/base64/base64_encode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/burn_stack.c
+++ b/core/lib/libtomcrypt/src/misc/burn_stack.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_argchk.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_argchk.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_descriptor.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_descriptor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_is_valid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_cipher_is_valid.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_any.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_any.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_id.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_cipher_id.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_any.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_any.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_id.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_id.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_oid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_hash_oid.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_find_prng.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_find_prng.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_fsa.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_fsa.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_descriptor.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_descriptor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_is_valid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_hash_is_valid.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_descriptor.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_descriptor.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_is_valid.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_prng_is_valid.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_register_cipher.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_register_cipher.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_register_hash.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_register_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_register_prng.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_register_prng.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_cipher.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_cipher.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_hash.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_prng.c
+++ b/core/lib/libtomcrypt/src/misc/crypt/crypt_unregister_prng.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/error_to_string.c
+++ b/core/lib/libtomcrypt/src/misc/error_to_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/mem_neq.c
+++ b/core/lib/libtomcrypt/src/misc/mem_neq.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/pkcs5/pkcs_5_1.c
+++ b/core/lib/libtomcrypt/src/misc/pkcs5/pkcs_5_1.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/pkcs5/pkcs_5_2.c
+++ b/core/lib/libtomcrypt/src/misc/pkcs5/pkcs_5_2.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/misc/zeromem.c
+++ b/core/lib/libtomcrypt/src/misc/zeromem.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_done.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_getiv.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_getiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_setiv.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_setiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cbc/cbc_start.c
+++ b/core/lib/libtomcrypt/src/modes/cbc/cbc_start.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cfb/cfb_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/cfb/cfb_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cfb/cfb_done.c
+++ b/core/lib/libtomcrypt/src/modes/cfb/cfb_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cfb/cfb_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/cfb/cfb_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cfb/cfb_getiv.c
+++ b/core/lib/libtomcrypt/src/modes/cfb/cfb_getiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cfb/cfb_setiv.c
+++ b/core/lib/libtomcrypt/src/modes/cfb/cfb_setiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/cfb/cfb_start.c
+++ b/core/lib/libtomcrypt/src/modes/cfb/cfb_start.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_done.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_getiv.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_getiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_setiv.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_setiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_start.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_start.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_done.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ecb/ecb_start.c
+++ b/core/lib/libtomcrypt/src/modes/ecb/ecb_start.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/f8/f8_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/f8/f8_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/f8/f8_done.c
+++ b/core/lib/libtomcrypt/src/modes/f8/f8_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/f8/f8_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/f8/f8_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/f8/f8_getiv.c
+++ b/core/lib/libtomcrypt/src/modes/f8/f8_getiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/f8/f8_setiv.c
+++ b/core/lib/libtomcrypt/src/modes/f8/f8_setiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/f8/f8_start.c
+++ b/core/lib/libtomcrypt/src/modes/f8/f8_start.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/lrw/lrw_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/lrw/lrw_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/lrw/lrw_done.c
+++ b/core/lib/libtomcrypt/src/modes/lrw/lrw_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/lrw/lrw_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/lrw/lrw_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/lrw/lrw_getiv.c
+++ b/core/lib/libtomcrypt/src/modes/lrw/lrw_getiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/lrw/lrw_process.c
+++ b/core/lib/libtomcrypt/src/modes/lrw/lrw_process.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/lrw/lrw_setiv.c
+++ b/core/lib/libtomcrypt/src/modes/lrw/lrw_setiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/lrw/lrw_start.c
+++ b/core/lib/libtomcrypt/src/modes/lrw/lrw_start.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ofb/ofb_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ofb/ofb_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ofb/ofb_done.c
+++ b/core/lib/libtomcrypt/src/modes/ofb/ofb_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ofb/ofb_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ofb/ofb_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ofb/ofb_getiv.c
+++ b/core/lib/libtomcrypt/src/modes/ofb/ofb_getiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ofb/ofb_setiv.c
+++ b/core/lib/libtomcrypt/src/modes/ofb/ofb_setiv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/ofb/ofb_start.c
+++ b/core/lib/libtomcrypt/src/modes/ofb/ofb_start.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/xts/xts_decrypt.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_decrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/xts/xts_done.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_done.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_encrypt.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/xts/xts_init.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/modes/xts/xts_mult_x.c
+++ b/core/lib/libtomcrypt/src/modes/xts/xts_mult_x.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/mpa_desc.c
+++ b/core/lib/libtomcrypt/src/mpa_desc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_decode_bit_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_decode_bit_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_decode_raw_bit_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_encode_bit_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_encode_bit_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_encode_raw_bit_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_encode_raw_bit_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_length_bit_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/bit/der_length_bit_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_decode_boolean.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_decode_boolean.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_encode_boolean.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_encode_boolean.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_length_boolean.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/boolean/der_length_boolean.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/choice/der_decode_choice.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/choice/der_decode_choice.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/ia5/der_decode_ia5_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/ia5/der_decode_ia5_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/ia5/der_encode_ia5_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/ia5/der_encode_ia5_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/ia5/der_length_ia5_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/ia5/der_length_ia5_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_decode_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_decode_integer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_encode_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_encode_integer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_length_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/integer/der_length_integer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/object_identifier/der_decode_object_identifier.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/object_identifier/der_decode_object_identifier.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/object_identifier/der_encode_object_identifier.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/object_identifier/der_encode_object_identifier.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/object_identifier/der_length_object_identifier.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/object_identifier/der_length_object_identifier.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/octet/der_decode_octet_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/octet/der_decode_octet_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/octet/der_encode_octet_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/octet/der_encode_octet_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/octet/der_length_octet_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/octet/der_length_octet_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/printable_string/der_decode_printable_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/printable_string/der_decode_printable_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/printable_string/der_encode_printable_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/printable_string/der_encode_printable_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/printable_string/der_length_printable_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/printable_string/der_length_printable_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_ex.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_ex.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_subject_public_key_info.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_ex.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_ex.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_subject_public_key_info.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_subject_public_key_info.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_length_sequence.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_length_sequence.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_sequence_free.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_sequence_free.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_set.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_set.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_setof.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_setof.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/short_integer/der_decode_short_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/short_integer/der_decode_short_integer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/short_integer/der_encode_short_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/short_integer/der_encode_short_integer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/short_integer/der_length_short_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/short_integer/der_length_short_integer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_decode_teletex_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_decode_teletex_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_length_teletex_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/teletex_string/der_length_teletex_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/utctime/der_decode_utctime.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utctime/der_decode_utctime.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/utctime/der_encode_utctime.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utctime/der_encode_utctime.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/utctime/der_length_utctime.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utctime/der_length_utctime.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_encode_utf8_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_encode_utf8_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_length_utf8_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_length_utf8_string.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dh/dh.c
+++ b/core/lib/libtomcrypt/src/pk/dh/dh.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2001-2007, Tom St Denis
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_decrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_decrypt_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_encrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_encrypt_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_export.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_export.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_free.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_free.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_import.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_import.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_make_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_shared_secret.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_shared_secret.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_sign_hash.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_sign_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_verify_hash.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_verify_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/dsa/dsa_verify_key.c
+++ b/core/lib/libtomcrypt/src/pk/dsa/dsa_verify_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_ansi_x963_export.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_ansi_x963_export.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_ansi_x963_import.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_ansi_x963_import.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_decrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_decrypt_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_encrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_encrypt_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_export.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_export.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_free.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_free.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_get_size.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_get_size.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_import.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_import.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_make_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_shared_secret.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_shared_secret.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_sign_hash.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_sign_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_sizes.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_sizes.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ecc_verify_hash.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ecc_verify_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_is_valid_idx.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_is_valid_idx.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_map.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_map.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_mul2add.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_mul2add.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_mulmod.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_mulmod.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_mulmod_timing.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_mulmod_timing.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_points.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_points.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_projective_add_point.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_projective_add_point.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_projective_dbl_point.c
+++ b/core/lib/libtomcrypt/src/pk/ecc/ltc_ecc_projective_dbl_point.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_i2osp.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_i2osp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_mgf1.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_mgf1.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_decode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_oaep_encode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_os2ip.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_os2ip.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_encode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_decode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_encode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_encode.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_decrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_decrypt_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_encrypt_key.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_encrypt_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_export.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_export.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_exptmod.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_exptmod.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_free.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_free.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_import.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_import.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_make_key.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_sign_hash.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_sign_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/prngs/rng_get_bytes.c
+++ b/core/lib/libtomcrypt/src/prngs/rng_get_bytes.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/prngs/rng_make_prng.c
+++ b/core/lib/libtomcrypt/src/prngs/rng_make_prng.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/prngs/sprng.c
+++ b/core/lib/libtomcrypt/src/prngs/sprng.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/prngs/yarrow.c
+++ b/core/lib/libtomcrypt/src/prngs/yarrow.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/lib/zlib/adler32.c
+++ b/core/lib/zlib/adler32.c
@@ -1,5 +1,6 @@
 /* adler32.c -- compute the Adler-32 checksum of a data stream
  * Copyright (C) 1995-2011, 2016 Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/gzguts.h
+++ b/core/lib/zlib/gzguts.h
@@ -1,5 +1,6 @@
 /* gzguts.h -- zlib internal header definitions for gz* operations
  * Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013, 2016 Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/inffast.c
+++ b/core/lib/zlib/inffast.c
@@ -1,5 +1,6 @@
 /* inffast.c -- fast decoding
  * Copyright (C) 1995-2017 Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/inffast.h
+++ b/core/lib/zlib/inffast.h
@@ -1,5 +1,6 @@
 /* inffast.h -- header to use inffast.c
  * Copyright (C) 1995-2003, 2010 Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/inflate.c
+++ b/core/lib/zlib/inflate.c
@@ -1,5 +1,6 @@
 /* inflate.c -- zlib decompression
  * Copyright (C) 1995-2016 Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/inflate.h
+++ b/core/lib/zlib/inflate.h
@@ -1,5 +1,6 @@
 /* inflate.h -- internal inflate state definition
  * Copyright (C) 1995-2016 Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/inftrees.c
+++ b/core/lib/zlib/inftrees.c
@@ -1,3 +1,6 @@
+/*
+ * SPDX-License-Identifier: Zlib
+ */
 /* inftrees.c -- generate Huffman trees for efficient decoding
  * Copyright (C) 1995-2017 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h

--- a/core/lib/zlib/inftrees.h
+++ b/core/lib/zlib/inftrees.h
@@ -1,5 +1,6 @@
 /* inftrees.h -- header to use inftrees.c
  * Copyright (C) 1995-2005, 2010 Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/zconf.h
+++ b/core/lib/zlib/zconf.h
@@ -1,5 +1,6 @@
 /* zconf.h -- configuration of the zlib compression library
  * Copyright (C) 1995-2016 Jean-loup Gailly, Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/zlib.h
+++ b/core/lib/zlib/zlib.h
@@ -2,6 +2,7 @@
   version 1.2.11, January 15th, 2017
 
   Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+  SPDX-License-Identifier: Zlib
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages

--- a/core/lib/zlib/zutil.c
+++ b/core/lib/zlib/zutil.c
@@ -1,5 +1,6 @@
 /* zutil.c -- target dependent utility functions for the compression library
  * Copyright (C) 1995-2017 Jean-loup Gailly
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/lib/zlib/zutil.h
+++ b/core/lib/zlib/zutil.h
@@ -1,5 +1,6 @@
 /* zutil.h -- internal interface and configuration of the compression library
  * Copyright (C) 1995-2016 Jean-loup Gailly, Mark Adler
+ * SPDX-License-Identifier: Zlib
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 

--- a/core/tee/fs_dirfile.c
+++ b/core/tee/fs_dirfile.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/fs_dirfile.c
+++ b/core/tee/fs_dirfile.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/fs_dirfile.c
+++ b/core/tee/fs_dirfile.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/aid.c
+++ b/core/tee/se/aid.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/se/aid_priv.h
+++ b/core/tee/se/aid_priv.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_AID_PRIV_H

--- a/core/tee/se/aid_priv.h
+++ b/core/tee/se/aid_priv.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/aid_priv.h
+++ b/core/tee/se/aid_priv.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/apdu.c
+++ b/core/tee/se/apdu.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/apdu.c
+++ b/core/tee/se/apdu.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/apdu.c
+++ b/core/tee/se/apdu.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/se/apdu_priv.h
+++ b/core/tee/se/apdu_priv.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/apdu_priv.h
+++ b/core/tee/se/apdu_priv.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_APDU_PRIV_H

--- a/core/tee/se/apdu_priv.h
+++ b/core/tee/se/apdu_priv.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/channel.c
+++ b/core/tee/se/channel.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/channel.c
+++ b/core/tee/se/channel.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/channel.c
+++ b/core/tee/se/channel.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/se/channel_priv.h
+++ b/core/tee/se/channel_priv.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/channel_priv.h
+++ b/core/tee/se/channel_priv.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_CHANNEL_PRIV_H

--- a/core/tee/se/channel_priv.h
+++ b/core/tee/se/channel_priv.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/iso7816.c
+++ b/core/tee/se/iso7816.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/se/manager.c
+++ b/core/tee/se/manager.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/manager.c
+++ b/core/tee/se/manager.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <initcall.h>

--- a/core/tee/se/manager.c
+++ b/core/tee/se/manager.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/reader.c
+++ b/core/tee/se/reader.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/se/reader/passthru_reader/driver.c
+++ b/core/tee/se/reader/passthru_reader/driver.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/reader/passthru_reader/driver.c
+++ b/core/tee/se/reader/passthru_reader/driver.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/reader/passthru_reader/driver.c
+++ b/core/tee/se/reader/passthru_reader/driver.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <platform_config.h>

--- a/core/tee/se/reader/passthru_reader/pcsc.h
+++ b/core/tee/se/reader/passthru_reader/pcsc.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/reader/passthru_reader/pcsc.h
+++ b/core/tee/se/reader/passthru_reader/pcsc.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef PCSC_H

--- a/core/tee/se/reader/passthru_reader/pcsc.h
+++ b/core/tee/se/reader/passthru_reader/pcsc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/reader/passthru_reader/reader.c
+++ b/core/tee/se/reader/passthru_reader/reader.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <io.h>

--- a/core/tee/se/reader/passthru_reader/reader.c
+++ b/core/tee/se/reader/passthru_reader/reader.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/reader/passthru_reader/reader.c
+++ b/core/tee/se/reader/passthru_reader/reader.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/reader/passthru_reader/reader.h
+++ b/core/tee/se/reader/passthru_reader/reader.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/reader/passthru_reader/reader.h
+++ b/core/tee/se/reader/passthru_reader/reader.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef READER_H

--- a/core/tee/se/reader/passthru_reader/reader.h
+++ b/core/tee/se/reader/passthru_reader/reader.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/reader_priv.h
+++ b/core/tee/se/reader_priv.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/reader_priv.h
+++ b/core/tee/se/reader_priv.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_READER_PRIV_H

--- a/core/tee/se/reader_priv.h
+++ b/core/tee/se/reader_priv.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/service.c
+++ b/core/tee/se/service.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/service.c
+++ b/core/tee/se/service.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/service.c
+++ b/core/tee/se/service.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/se/service_priv.h
+++ b/core/tee/se/service_priv.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/service_priv.h
+++ b/core/tee/se/service_priv.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_SERVICE_PRIV_H

--- a/core/tee/se/service_priv.h
+++ b/core/tee/se/service_priv.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/session.c
+++ b/core/tee/se/session.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/session.c
+++ b/core/tee/se/session.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/session.c
+++ b/core/tee/se/session.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/se/session_priv.h
+++ b/core/tee/se/session_priv.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/session_priv.h
+++ b/core/tee/se/session_priv.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_SE_SESSION_PRIV_H

--- a/core/tee/se/session_priv.h
+++ b/core/tee/se/session_priv.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/svc.c
+++ b/core/tee/se/svc.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <tee_api_types.h>

--- a/core/tee/se/svc.c
+++ b/core/tee/se/svc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/svc.c
+++ b/core/tee/se/svc.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <tee_api_types.h>
 #include <kernel/tee_ta_manager.h>

--- a/core/tee/se/util.c
+++ b/core/tee/se/util.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/se/util.c
+++ b/core/tee/se/util.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/se/util.c
+++ b/core/tee/se/util.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <tee_api_types.h>

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <crypto/crypto.h>

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_cryp_hkdf.c
+++ b/core/tee/tee_cryp_hkdf.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_cryp_hkdf.c
+++ b/core/tee/tee_cryp_hkdf.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <crypto/crypto.h>

--- a/core/tee/tee_cryp_hkdf.c
+++ b/core/tee/tee_cryp_hkdf.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <crypto/crypto.h>

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <crypto/crypto.h>

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_fs_rpc.c
+++ b/core/tee/tee_fs_rpc.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/tee_fs_rpc.c
+++ b/core/tee/tee_fs_rpc.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_fs_rpc.c
+++ b/core/tee/tee_fs_rpc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_fs_rpc_cache.c
+++ b/core/tee/tee_fs_rpc_cache.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_fs_rpc_cache.c
+++ b/core/tee/tee_fs_rpc_cache.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kernel/thread.h>

--- a/core/tee/tee_fs_rpc_cache.c
+++ b/core/tee/tee_fs_rpc_cache.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_obj.c
+++ b/core/tee/tee_obj.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_pobj.c
+++ b/core/tee/tee_pobj.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <assert.h>

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/tee_time_generic.c
+++ b/core/tee/tee_time_generic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/core/tee/uuid.c
+++ b/core/tee/uuid.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/core/tee/uuid.c
+++ b/core/tee/uuid.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <string.h>

--- a/core/tee/uuid.c
+++ b/core/tee/uuid.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/documentation/copyright_and_license_headers.md
+++ b/documentation/copyright_and_license_headers.md
@@ -1,0 +1,65 @@
+OP-TEE copyright and license headers
+====================================
+
+This document deals with the format of the copyright and license headers in
+OP-TEE source files. Such headers shall comply with the rules described here.
+
+New source files
+----------------
+
+- (Rule 1.1) Shall contain at least one copyright line
+- (Rule 1.2) Shall contain at least one SPDX license identifier
+- (Rule 1.3) Shall not contain the mention 'All rights reserved' or similar
+- (Rule 1.4) Copyrights and license identifiers shall appear in a comment block at
+  the first possible line in the file which can contain a comment.
+- (Rule 1.5) Files imported from external projects are not new files. The rules for
+  pre-existing files (below) apply.
+
+Example:
+```
+    /*
+     * Copyright (c) 2017, Linaro Limited
+     * SPDX-License-Identifier: BSD-2-Clause
+     */
+```
+
+Pre-existing or imported files
+------------------------------
+
+- (Rule 2.1) SPDX license identifiers shall be added according to the license
+  notice(s) in the file.
+  - (Rule 2.1.1) If there is only one license notice, the
+    [SPDX](https://spdx.org/licenses/) identifier shall be added into the comment
+    block that contains that license, preferably immediately after the copyright
+    notice(s). For example:
+```
+     /*
+      * Copyright (c) <year>, <...>
+      * SPDX-License-Identifier: <...>
+      *
+      * <License text>
+      */
+```
+  - (Rule 2.1.2) When a file contains multiple license notices, the SPDX identifiers
+    shall be added into their own comment block at the beginning of the
+    file, like so:
+```
+      /*
+       * SPDX-License-Identifier: BSD-2-Clause
+       * SPDX-License-Identifier: BSD-3-Clause
+       */
+      /*
+       * Copyright (c) <year>, <...>
+       *
+       * <License text, BSD 2-Clause>
+       */
+      /*
+       * Copyright (c) <year>, <...>
+       *
+       * <License text, BSD 3-Clause>
+       */
+```
+- (Rule 2.2) It is recommended that license notices be removed once the corresponding
+  identifier has been added. This may only be done by the copyright
+  holder(s) of the file, however.
+- (Rule 2.3) The same recommendation holds for the text: "All rights reserved".

--- a/lib/libmpa/arch/arm/mpa_a32.S
+++ b/lib/libmpa/arch/arm/mpa_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/include/mpa.h
+++ b/lib/libmpa/include/mpa.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/include/mpalib.h
+++ b/lib/libmpa/include/mpalib.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/include/mpalib_config.h
+++ b/lib/libmpa/include/mpalib_config.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_addsub.c
+++ b/lib/libmpa/mpa_addsub.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_cmp.c
+++ b/lib/libmpa/mpa_cmp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_conv.c
+++ b/lib/libmpa/mpa_conv.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_div.c
+++ b/lib/libmpa/mpa_div.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_expmod.c
+++ b/lib/libmpa/mpa_expmod.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_gcd.c
+++ b/lib/libmpa/mpa_gcd.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_init.c
+++ b/lib/libmpa/mpa_init.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_io.c
+++ b/lib/libmpa/mpa_io.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_mem_static.c
+++ b/lib/libmpa/mpa_mem_static.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_misc.c
+++ b/lib/libmpa/mpa_misc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_modulus.c
+++ b/lib/libmpa/mpa_modulus.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_montgomery.c
+++ b/lib/libmpa/mpa_montgomery.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_mul.c
+++ b/lib/libmpa/mpa_mul.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_primetable.h
+++ b/lib/libmpa/mpa_primetable.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_primetest.c
+++ b/lib/libmpa/mpa_primetest.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_random.c
+++ b/lib/libmpa/mpa_random.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libmpa/mpa_shift.c
+++ b/lib/libmpa/mpa_shift.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/abort.c
+++ b/lib/libutee/abort.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/gprof/gmon.h
+++ b/lib/libutee/arch/arm/gprof/gmon.h
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *

--- a/lib/libutee/arch/arm/gprof/gmon_out.h
+++ b/lib/libutee/arch/arm/gprof/gmon_out.h
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+/*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *

--- a/lib/libutee/arch/arm/gprof/gprof.c
+++ b/lib/libutee/arch/arm/gprof/gprof.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  *

--- a/lib/libutee/arch/arm/gprof/gprof_a32.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/arch/arm/gprof/gprof_a32.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/lib/libutee/arch/arm/gprof/gprof_a32.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/gprof/gprof_a64.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/arch/arm/gprof/gprof_a64.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/lib/libutee/arch/arm/gprof/gprof_a64.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/gprof/gprof_pta.c
+++ b/lib/libutee/arch/arm/gprof/gprof_pta.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/arch/arm/gprof/gprof_pta.c
+++ b/lib/libutee/arch/arm/gprof/gprof_pta.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/gprof/gprof_pta.c
+++ b/lib/libutee/arch/arm/gprof/gprof_pta.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <pta_gprof.h>

--- a/lib/libutee/arch/arm/gprof/gprof_pta.h
+++ b/lib/libutee/arch/arm/gprof/gprof_pta.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/arch/arm/gprof/gprof_pta.h
+++ b/lib/libutee/arch/arm/gprof/gprof_pta.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/gprof/gprof_pta.h
+++ b/lib/libutee/arch/arm/gprof/gprof_pta.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __GPROF_PTA_H

--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/utee_misc.c
+++ b/lib/libutee/arch/arm/utee_misc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/utee_syscalls_a32.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a32.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2015, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/utee_syscalls_a64.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <tee_syscall_numbers.h>

--- a/lib/libutee/arch/arm/utee_syscalls_a64.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/arch/arm/utee_syscalls_a64.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/arch/arm/utee_syscalls_asm.S
+++ b/lib/libutee/arch/arm/utee_syscalls_asm.S
@@ -2,6 +2,7 @@
  * Copyright (c) 2015, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/base64.c
+++ b/lib/libutee/base64.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/base64.h
+++ b/lib/libutee/base64.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/errno.c
+++ b/lib/libutee/errno.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/__tee_ipsocket.h
+++ b/lib/libutee/include/__tee_ipsocket.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/__tee_ipsocket.h
+++ b/lib/libutee/include/__tee_ipsocket.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/__tee_ipsocket.h
+++ b/lib/libutee/include/__tee_ipsocket.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef ____TEE_IPSOCKET_H

--- a/lib/libutee/include/__tee_isocket_defines.h
+++ b/lib/libutee/include/__tee_isocket_defines.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef ____TEE_ISOCKET_DEFINES_H

--- a/lib/libutee/include/__tee_isocket_defines.h
+++ b/lib/libutee/include/__tee_isocket_defines.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef ____TEE_ISOCKET_DEFINES_H
 #define ____TEE_ISOCKET_DEFINES_H

--- a/lib/libutee/include/__tee_isocket_defines.h
+++ b/lib/libutee/include/__tee_isocket_defines.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/__tee_tcpsocket_defines.h
+++ b/lib/libutee/include/__tee_tcpsocket_defines.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/__tee_tcpsocket_defines.h
+++ b/lib/libutee/include/__tee_tcpsocket_defines.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/__tee_tcpsocket_defines.h
+++ b/lib/libutee/include/__tee_tcpsocket_defines.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef ____TEE_TCPSOCKET_DEFINES_H

--- a/lib/libutee/include/__tee_tcpsocket_defines_extensions.h
+++ b/lib/libutee/include/__tee_tcpsocket_defines_extensions.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/__tee_tcpsocket_defines_extensions.h
+++ b/lib/libutee/include/__tee_tcpsocket_defines_extensions.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/__tee_tcpsocket_defines_extensions.h
+++ b/lib/libutee/include/__tee_tcpsocket_defines_extensions.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef ____TEE_TCPSOCKET_DEFINES_EXTENSIONS_H

--- a/lib/libutee/include/__tee_udpsocket_defines.h
+++ b/lib/libutee/include/__tee_udpsocket_defines.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef ____TEE_UDPSOCKET_DEFINES_H

--- a/lib/libutee/include/__tee_udpsocket_defines.h
+++ b/lib/libutee/include/__tee_udpsocket_defines.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/__tee_udpsocket_defines.h
+++ b/lib/libutee/include/__tee_udpsocket_defines.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/pta_benchmark.h
+++ b/lib/libutee/include/pta_benchmark.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __PTA_BENCHMARK_H

--- a/lib/libutee/include/pta_benchmark.h
+++ b/lib/libutee/include/pta_benchmark.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/pta_benchmark.h
+++ b/lib/libutee/include/pta_benchmark.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/pta_gprof.h
+++ b/lib/libutee/include/pta_gprof.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/pta_gprof.h
+++ b/lib/libutee/include/pta_gprof.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __PTA_GPROF_H

--- a/lib/libutee/include/pta_gprof.h
+++ b/lib/libutee/include/pta_gprof.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/pta_invoke_tests.h
+++ b/lib/libutee/include/pta_invoke_tests.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/pta_invoke_tests.h
+++ b/lib/libutee/include/pta_invoke_tests.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __PTA_INVOKE_TESTS_H

--- a/lib/libutee/include/pta_invoke_tests.h
+++ b/lib/libutee/include/pta_invoke_tests.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/pta_socket.h
+++ b/lib/libutee/include/pta_socket.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/pta_socket.h
+++ b/lib/libutee/include/pta_socket.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __PTA_SOCKET

--- a/lib/libutee/include/pta_socket.h
+++ b/lib/libutee/include/pta_socket.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef TEE_API_DEFINES_EXTENSIONS_H

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_api_types.h
+++ b/lib/libutee/include/tee_api_types.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_arith_internal.h
+++ b/lib/libutee/include/tee_arith_internal.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_internal_api.h
+++ b/lib/libutee/include/tee_internal_api.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_internal_api_extensions.h
+++ b/lib/libutee/include/tee_internal_api_extensions.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_internal_se_api.h
+++ b/lib/libutee/include/tee_internal_se_api.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/tee_internal_se_api.h
+++ b/lib/libutee/include/tee_internal_se_api.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /* Based on GP TEE Secure Element API Specification Version 1.00 */

--- a/lib/libutee/include/tee_internal_se_api.h
+++ b/lib/libutee/include/tee_internal_se_api.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_isocket.h
+++ b/lib/libutee/include/tee_isocket.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/tee_isocket.h
+++ b/lib/libutee/include/tee_isocket.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __TEE_ISOCKET_H

--- a/lib/libutee/include/tee_isocket.h
+++ b/lib/libutee/include/tee_isocket.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_syscall_numbers.h
+++ b/lib/libutee/include/tee_syscall_numbers.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_ta_api.h
+++ b/lib/libutee/include/tee_ta_api.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_tcpsocket.h
+++ b/lib/libutee/include/tee_tcpsocket.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/tee_tcpsocket.h
+++ b/lib/libutee/include/tee_tcpsocket.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/tee_tcpsocket.h
+++ b/lib/libutee/include/tee_tcpsocket.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __TEE_TCPSOCKET_H

--- a/lib/libutee/include/tee_udpsocket.h
+++ b/lib/libutee/include/tee_udpsocket.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/include/tee_udpsocket.h
+++ b/lib/libutee/include/tee_udpsocket.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __TEE_UDPSOCKET_H

--- a/lib/libutee/include/tee_udpsocket.h
+++ b/lib/libutee/include/tee_udpsocket.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/utee_syscalls.h
+++ b/lib/libutee/include/utee_syscalls.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2015, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/include/utee_types.h
+++ b/lib/libutee/include/utee_types.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api_arith.c
+++ b/lib/libutee/tee_api_arith.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api_panic.c
+++ b/lib/libutee/tee_api_panic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api_private.h
+++ b/lib/libutee/tee_api_private.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api_private.h
+++ b/lib/libutee/tee_api_private.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #ifndef TEE_API_PRIVATE
 #define TEE_API_PRIVATE

--- a/lib/libutee/tee_api_private.h
+++ b/lib/libutee/tee_api_private.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #ifndef TEE_API_PRIVATE

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_api_se.c
+++ b/lib/libutee/tee_api_se.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/tee_api_se.c
+++ b/lib/libutee/tee_api_se.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 

--- a/lib/libutee/tee_api_se.c
+++ b/lib/libutee/tee_api_se.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_socket_private.h
+++ b/lib/libutee/tee_socket_private.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/tee_socket_private.h
+++ b/lib/libutee/tee_socket_private.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_socket_private.h
+++ b/lib/libutee/tee_socket_private.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __TEE_SOCKET_PRIVATE_H

--- a/lib/libutee/tee_socket_pta.c
+++ b/lib/libutee/tee_socket_pta.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/tee_socket_pta.c
+++ b/lib/libutee/tee_socket_pta.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <pta_socket.h>

--- a/lib/libutee/tee_socket_pta.c
+++ b/lib/libutee/tee_socket_pta.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_tcpudp_socket.c
+++ b/lib/libutee/tee_tcpudp_socket.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutee/tee_tcpudp_socket.c
+++ b/lib/libutee/tee_tcpudp_socket.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <pta_socket.h>

--- a/lib/libutee/tee_tcpudp_socket.c
+++ b/lib/libutee/tee_tcpudp_socket.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016-2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_user_mem.c
+++ b/lib/libutee/tee_user_mem.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/tee_user_mem.h
+++ b/lib/libutee/tee_user_mem.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/trace_ext.c
+++ b/lib/libutee/trace_ext.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutee/utee_misc.h
+++ b/lib/libutee/utee_misc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/arch/arm/aeabi_unwind.c
+++ b/lib/libutils/ext/arch/arm/aeabi_unwind.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2017, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/ext/arch/arm/aeabi_unwind.c
+++ b/lib/libutils/ext/arch/arm/aeabi_unwind.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 void __aeabi_unwind_cpp_pr0(void);

--- a/lib/libutils/ext/arch/arm/aeabi_unwind.c
+++ b/lib/libutils/ext/arch/arm/aeabi_unwind.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/arch/arm/atomic_a32.S
+++ b/lib/libutils/ext/arch/arm/atomic_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/lib/libutils/ext/arch/arm/atomic_a32.S
+++ b/lib/libutils/ext/arch/arm/atomic_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/ext/arch/arm/atomic_a32.S
+++ b/lib/libutils/ext/arch/arm/atomic_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/arch/arm/atomic_a64.S
+++ b/lib/libutils/ext/arch/arm/atomic_a64.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/lib/libutils/ext/arch/arm/atomic_a64.S
+++ b/lib/libutils/ext/arch/arm/atomic_a64.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/ext/arch/arm/atomic_a64.S
+++ b/lib/libutils/ext/arch/arm/atomic_a64.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/buf_compare_ct.c
+++ b/lib/libutils/ext/buf_compare_ct.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2014, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 #include <string_ext.h>

--- a/lib/libutils/ext/buf_compare_ct.c
+++ b/lib/libutils/ext/buf_compare_ct.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <string_ext.h>
 

--- a/lib/libutils/ext/buf_compare_ct.c
+++ b/lib/libutils/ext/buf_compare_ct.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/asm.S
+++ b/lib/libutils/ext/include/asm.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/atomic.h
+++ b/lib/libutils/ext/include/atomic.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2016-2017, Linaro Limited
  *
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifndef __ATOMIC_H

--- a/lib/libutils/ext/include/bitstring.h
+++ b/lib/libutils/ext/include/bitstring.h
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 1989, 1993
  *	The Regents of the University of California.  All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * This code is derived from software contributed to Berkeley by
  * Paul Vixie.

--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/printk.h
+++ b/lib/libutils/ext/include/printk.h
@@ -2,28 +2,6 @@
  * Copyright (c) 2015 Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/lib/libutils/ext/include/printk.h
+++ b/lib/libutils/ext/include/printk.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015 Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/ext/include/printk.h
+++ b/lib/libutils/ext/include/printk.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/string_ext.h
+++ b/lib/libutils/ext/include/string_ext.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/trace.h
+++ b/lib/libutils/ext/include/trace.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/trace_levels.h
+++ b/lib/libutils/ext/include/trace_levels.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/types_ext.h
+++ b/lib/libutils/ext/include/types_ext.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/ext/snprintk.c
+++ b/lib/libutils/ext/snprintk.c
@@ -1,4 +1,8 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+/*
  * Imported from NetBSD 5.1 with modifications to make it a vsnprintf(3)
  * function
  */

--- a/lib/libutils/ext/strlcat.c
+++ b/lib/libutils/ext/strlcat.c
@@ -5,6 +5,7 @@
 /*
  * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/lib/libutils/ext/strlcpy.c
+++ b/lib/libutils/ext/strlcpy.c
@@ -5,6 +5,7 @@
 /*
  * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <asm.S>

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_shift.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_shift.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 union dword {

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_shift.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_shift.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_shift.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_shift.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <compiler.h>

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_softfloat.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/setjmp_a32.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a32.S
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/setjmp_a64.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a64.S
@@ -1,6 +1,7 @@
 /*
    Copyright (c) 2011, 2012 ARM Ltd
    All rights reserved.
+   SPDX-License-Identifier: BSD-3-Clause
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions

--- a/lib/libutils/isoc/arch/arm/softfloat/arm32_include/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/arm32_include/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-GCC/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-GCC/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-GCC/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-GCC/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-SSE2-GCC/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-SSE2-GCC/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-SSE2-GCC/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Linux-386-SSE2-GCC/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Linux-x86_64-GCC/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Linux-x86_64-GCC/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Linux-x86_64-GCC/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Linux-x86_64-GCC/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Win32-MinGW/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Win32-MinGW/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Win32-MinGW/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Win32-MinGW/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Win32-SSE2-MinGW/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Win32-SSE2-MinGW/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Win32-SSE2-MinGW/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Win32-SSE2-MinGW/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Win64-MinGW-w64/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Win64-MinGW-w64/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/Win64-MinGW-w64/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/Win64-MinGW-w64/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/template-FAST_INT64/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/template-FAST_INT64/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/template-FAST_INT64/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/template-FAST_INT64/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/template-not-FAST_INT64/Makefile
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/template-not-FAST_INT64/Makefile
@@ -6,6 +6,7 @@
 #
 # Copyright 2011, 2012, 2013, 2014 The Regents of the University of
 # California.  All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/build/template-not-FAST_INT64/platform.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/build/template-not-FAST_INT64/platform.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/extF80M_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/extF80M_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/f128M_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/f128M_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToExtF80UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToExtF80UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF128UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF128UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF32UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF32UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF64UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_commonNaNToF64UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_extF80MToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_extF80MToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_extF80UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_extF80UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f128MToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f128MToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f128UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f128UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f32UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f32UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f64UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_f64UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNExtF80UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNExtF80UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF128UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF128UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF32UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF32UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF64UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/s_propagateNaNF64UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/softfloat_raiseFlags.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/softfloat_raiseFlags.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/specialize.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086-SSE/specialize.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/extF80M_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/extF80M_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/f128M_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/f128M_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToExtF80UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToExtF80UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF128UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF128UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF32UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF32UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF64UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_commonNaNToF64UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_extF80MToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_extF80MToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_extF80UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_extF80UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f128MToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f128MToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f128UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f128UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f32UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f32UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f64UIToCommonNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_f64UIToCommonNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNExtF80UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNExtF80UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF128UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF128UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF32UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF32UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF64UI.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/s_propagateNaNF64UI.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/softfloat_raiseFlags.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/softfloat_raiseFlags.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/8086/specialize.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/8086/specialize.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_add.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_add.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_div.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_div.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_eq.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_eq.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_eq_signaling.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_eq_signaling.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_le.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_le.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_le_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_le_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_lt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_lt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_lt_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_lt_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_mul.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_mul.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_rem.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_rem.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_roundToInt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_roundToInt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_sqrt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_sqrt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_sub.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_sub.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_f128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_f128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_f32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_f64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_i64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80M_to_ui64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_add.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_add.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_div.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_div.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_eq.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_eq.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_eq_signaling.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_eq_signaling.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_le.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_le.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_le_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_le_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_lt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_lt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_lt_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_lt_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_mul.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_mul.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_rem.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_rem.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_roundToInt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_roundToInt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_sqrt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_sqrt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_sub.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_sub.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_f128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_f128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_f32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_f64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_i64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/extF80_to_ui64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_add.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_add.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_div.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_div.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_eq.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_eq.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_eq_signaling.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_eq_signaling.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_le.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_le.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_le_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_le_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_lt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_lt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_lt_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_lt_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_mul.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_mul.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_mulAdd.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_mulAdd.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_rem.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_rem.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_roundToInt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_roundToInt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_sqrt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_sqrt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_sub.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_sub.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_extF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_extF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_f32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_f64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_i64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128M_to_ui64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_add.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_add.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_div.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_div.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_eq.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_eq.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_eq_signaling.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_eq_signaling.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_le.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_le.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_le_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_le_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_lt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_lt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_lt_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_lt_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_mul.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_mul.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_mulAdd.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_mulAdd.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_rem.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_rem.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_roundToInt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_roundToInt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_sqrt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_sqrt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_sub.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_sub.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_extF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_extF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_f32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_f64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_i64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f128_to_ui64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_add.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_add.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_div.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_div.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_eq.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_eq.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_eq_signaling.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_eq_signaling.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_le.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_le.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_le_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_le_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_lt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_lt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_lt_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_lt_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_mul.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_mul.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_mulAdd.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_mulAdd.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_rem.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_rem.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_roundToInt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_roundToInt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_sqrt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_sqrt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_sub.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_sub.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_extF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_extF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_extF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_extF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_f128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_f128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_f128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_f128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_f64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_i64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f32_to_ui64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_add.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_add.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_div.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_div.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_eq.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_eq.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_eq_signaling.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_eq_signaling.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_isSignalingNaN.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_isSignalingNaN.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_le.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_le.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_le_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_le_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_lt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_lt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_lt_quiet.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_lt_quiet.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_mul.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_mul.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_mulAdd.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_mulAdd.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_rem.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_rem.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_roundToInt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_roundToInt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_sqrt.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_sqrt.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_sub.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_sub.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_extF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_extF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_extF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_extF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_f128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_f128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_f128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_f128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_f32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_i64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui32_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui32_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui64_r_minMag.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/f64_to_ui64_r_minMag.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_extF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_extF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_extF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_extF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i32_to_f64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_extF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_extF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_extF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_extF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/i64_to_f64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/include/internals.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/include/internals.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/include/primitiveTypes.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/include/primitiveTypes.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/include/primitives.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/include/primitives.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/include/softfloat.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/include/softfloat.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/include/softfloat_types.h
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/include/softfloat_types.h
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_add128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_add128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_add256M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_add256M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addCarryM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addCarryM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addComplCarryM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addComplCarryM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsExtF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsExtF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsF128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsF128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsF32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsF32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsF64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_addMagsF64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_approxRecip32_1.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_approxRecip32_1.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_approxRecipSqrt32_1.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_approxRecipSqrt32_1.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_compare128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_compare128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_compare96M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_compare96M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_compareNonnormExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_compareNonnormExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_countLeadingZeros32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_countLeadingZeros32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_countLeadingZeros64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_countLeadingZeros64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_countLeadingZeros8.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_countLeadingZeros8.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_eq128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_eq128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_invalidExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_invalidExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_invalidF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_invalidF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_isNaNF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_isNaNF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_le128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_le128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_lt128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_lt128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mul128By32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mul128By32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mul128MTo256M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mul128MTo256M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mul128To256M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mul128To256M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mul64ByShifted32To128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mul64ByShifted32To128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mul64To128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mul64To128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mul64To128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mul64To128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_mulAddF64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_negXM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_negXM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normExtF80SigM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normExtF80SigM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackMToExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackMToExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackMToF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackMToF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToExtF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToExtF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToF128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToF128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToF32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToF32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToF64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normRoundPackToF64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalExtF80Sig.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalExtF80Sig.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF128Sig.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF128Sig.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF128SigM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF128SigM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF32Sig.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF32Sig.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF64Sig.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_normSubnormalF64Sig.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_remStepMBy32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_remStepMBy32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToI64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToI64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToUI64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackMToUI64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToExtF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToExtF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToF128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToF128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToF32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToF32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToF64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToF64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToI32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToI32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToI64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToI64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToUI32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToUI32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToUI64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_roundPackToUI64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftLeftM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftLeftM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftNormSigF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftNormSigF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam128Extra.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam128Extra.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam256M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam256M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam64Extra.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJam64Extra.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJamM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightJamM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shiftRightM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftLeft128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftLeft128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftLeft64To96M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftLeft64To96M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftLeftM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftLeftM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRight128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRight128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightExtendM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightExtendM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam128Extra.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam128Extra.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam64Extra.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJam64Extra.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJamM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightJamM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_shortShiftRightM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_sub128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_sub128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_sub1XM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_sub1XM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_sub256M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_sub256M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_subM.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_subM.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014, 2015 The Regents of the University of
 California.  All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsExtF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsExtF80.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsF128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsF128.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsF32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsF32.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsF64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_subMagsF64.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_tryPropagateNaNExtF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_tryPropagateNaNExtF80M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/s_tryPropagateNaNF128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/s_tryPropagateNaNF128M.c
@@ -6,6 +6,7 @@ Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
 All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/arch/arm/softfloat/source/softfloat_state.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/softfloat_state.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_extF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_extF80.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_extF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_extF80M.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f128.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f128M.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f32.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui32_to_f64.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_extF80.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_extF80.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_extF80M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_extF80M.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f128.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f128.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f128M.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f128M.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f32.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f32.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f64.c
+++ b/lib/libutils/isoc/arch/arm/softfloat/source/ui64_to_f64.c
@@ -5,6 +5,7 @@ This C source file is part of the SoftFloat IEEE Floating-Point Arithmetic
 Package, Release 3a, by John R. Hauser.
 
 Copyright 2011, 2012, 2013, 2014 The Regents of the University of California.
+SPDX-License-Identifier: BSD-3-Clause
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/ctype.h
+++ b/lib/libutils/isoc/include/ctype.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/inttypes.h
+++ b/lib/libutils/isoc/include/inttypes.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/limits.h
+++ b/lib/libutils/isoc/include/limits.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/memory.h
+++ b/lib/libutils/isoc/include/memory.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/setjmp.h
+++ b/lib/libutils/isoc/include/setjmp.h
@@ -2,6 +2,7 @@
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/signal.h
+++ b/lib/libutils/isoc/include/signal.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/stdint.h
+++ b/lib/libutils/isoc/include/stdint.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/stdio.h
+++ b/lib/libutils/isoc/include/stdio.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/stdlib.h
+++ b/lib/libutils/isoc/include/stdlib.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/string.h
+++ b/lib/libutils/isoc/include/string.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/sys/cdefs.h
+++ b/lib/libutils/isoc/include/sys/cdefs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/sys/queue.h
+++ b/lib/libutils/isoc/include/sys/queue.h
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/lib/libutils/isoc/include/sys/types.h
+++ b/lib/libutils/isoc/include/sys/types.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/time.h
+++ b/lib/libutils/isoc/include/time.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/unistd.h
+++ b/lib/libutils/isoc/include/unistd.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/include/wchar.h
+++ b/lib/libutils/isoc/include/wchar.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/malloc_lock.c
+++ b/lib/libutils/isoc/malloc_lock.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/isoc/malloc_lock.c
+++ b/lib/libutils/isoc/malloc_lock.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <malloc.h>

--- a/lib/libutils/isoc/malloc_lock.c
+++ b/lib/libutils/isoc/malloc_lock.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/_ansi.h
+++ b/lib/libutils/isoc/newlib/_ansi.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/abs.c
+++ b/lib/libutils/isoc/newlib/abs.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/memchr.c
+++ b/lib/libutils/isoc/newlib/memchr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/memcmp.c
+++ b/lib/libutils/isoc/newlib/memcmp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/memcpy.c
+++ b/lib/libutils/isoc/newlib/memcpy.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/memmove.c
+++ b/lib/libutils/isoc/newlib/memmove.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/memset.c
+++ b/lib/libutils/isoc/newlib/memset.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/strchr.c
+++ b/lib/libutils/isoc/newlib/strchr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/strcmp.c
+++ b/lib/libutils/isoc/newlib/strcmp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/strlen.c
+++ b/lib/libutils/isoc/newlib/strlen.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/strncmp.c
+++ b/lib/libutils/isoc/newlib/strncmp.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/newlib/strnlen.c
+++ b/lib/libutils/isoc/newlib/strnlen.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/qsort.c
+++ b/lib/libutils/isoc/qsort.c
@@ -2,6 +2,7 @@
 /*-
  * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/lib/libutils/isoc/snprintf.c
+++ b/lib/libutils/isoc/snprintf.c
@@ -2,28 +2,6 @@
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <stdio.h>

--- a/lib/libutils/isoc/snprintf.c
+++ b/lib/libutils/isoc/snprintf.c
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2015, Linaro Limited
- * All rights reserved.
  * SPDX-License-Identifier: BSD-2-Clause
  */
 

--- a/lib/libutils/isoc/snprintf.c
+++ b/lib/libutils/isoc/snprintf.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015, Linaro Limited
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/stack_check.c
+++ b/lib/libutils/isoc/stack_check.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/strdup.c
+++ b/lib/libutils/isoc/strdup.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/lib/libutils/isoc/strndup.c
+++ b/lib/libutils/isoc/strndup.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/scripts/gen_hashed_bin.py
+++ b/scripts/gen_hashed_bin.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2014-2017, Linaro Limited
-# All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 

--- a/scripts/gen_hashed_bin.py
+++ b/scripts/gen_hashed_bin.py
@@ -4,28 +4,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
 
 import argparse
 import sys

--- a/scripts/gen_hashed_bin.py
+++ b/scripts/gen_hashed_bin.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2014-2017, Linaro Limited
 # All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/scripts/gen_ld_sects.py
+++ b/scripts/gen_ld_sects.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2017, Linaro Limited
 # All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/scripts/gen_ld_sects.py
+++ b/scripts/gen_ld_sects.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2017, Linaro Limited
-# All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 

--- a/scripts/gen_ld_sects.py
+++ b/scripts/gen_ld_sects.py
@@ -4,28 +4,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
 
 import sys
 import re

--- a/scripts/mem_usage.py
+++ b/scripts/mem_usage.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2014-2017, Linaro Limited
-# All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2015, Linaro Limited
 # All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -4,28 +4,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
 
 def get_args():
 	import argparse

--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2015, Linaro Limited
-# All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -4,28 +4,6 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
 
 def uuid_parse(s):
     from uuid import UUID

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2015, 2017, Linaro Limited
-# All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2017, Linaro Limited
 # All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2017, Linaro Limited
-# All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -4,28 +4,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
 
 
 import argparse

--- a/scripts/ta_bin_to_c.py
+++ b/scripts/ta_bin_to_c.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2017, Linaro Limited
 # All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/scripts/ta_bin_to_c.py
+++ b/scripts/ta_bin_to_c.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2017, Linaro Limited
-# All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
 

--- a/scripts/ta_bin_to_c.py
+++ b/scripts/ta_bin_to_c.py
@@ -4,28 +4,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-#
 
 import argparse
 import array

--- a/scripts/tee_bin_parser.py
+++ b/scripts/tee_bin_parser.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2016, Linaro Limited
-# All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 import struct
 

--- a/scripts/tee_bin_parser.py
+++ b/scripts/tee_bin_parser.py
@@ -3,28 +3,6 @@
 # Copyright (c) 2016, Linaro Limited
 # All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
 import struct
 
 def main():

--- a/scripts/tee_bin_parser.py
+++ b/scripts/tee_bin_parser.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2016, Linaro Limited
 # All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
- Patch 1 adds SPDX license identifiers to all the source files that have some known licensing terms
- Patches 2 and 3 remove redundant/useless text from files owned by Linaro
- Patch 4 documents the format of the copyright and license headers
