### PR TITLE
pta: add pta for retrieve sdp physcial address

### DIFF
--- a/core/arch/arm/pta/sdp_pta.c
+++ b/core/arch/arm/pta/sdp_pta.c
@@ -1,0 +1,93 @@
+//SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2017 - 2018, ARM Limited
+ */
+
+#include <kernel/misc.h>
+#include <kernel/pseudo_ta.h>
+#include <mm/core_memprot.h>
+#include <mm/tee_mmu.h>
+#include <sdp_pta.h>
+
+#define PTA_NAME "sdp.pta"
+
+static TEE_Result sdp_pa_cmd_virt_to_phys(uint32_t types,
+					  TEE_Param params[TEE_NUM_PARAMS])
+{
+	char *va = params[0].memref.buffer;
+	size_t len = params[0].memref.size;
+	struct tee_ta_session *s;
+	struct user_ta_ctx *utc;
+	TEE_Result res;
+
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				     TEE_PARAM_TYPE_VALUE_OUTPUT,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("bad parameters types: 0x%" PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	s = tee_ta_get_calling_session();
+	if (!s)
+		return TEE_ERROR_ACCESS_DENIED;
+
+	utc = to_user_ta_ctx(s->ctx);
+	res = tee_mmu_check_access_rights(utc, TEE_MEMORY_ACCESS_READ |
+					  TEE_MEMORY_ACCESS_WRITE |
+					  TEE_MEMORY_ACCESS_ANY_OWNER,
+					  (uaddr_t)va, len);
+	if (res != TEE_SUCCESS)
+		return TEE_ERROR_ACCESS_DENIED;
+
+	if (!core_vbuf_is(CORE_MEM_SDP_MEM, va, len)) {
+		DMSG("bad memref secure attribute");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	reg_pair_from_64(virt_to_phys(va), &params[1].value.a,
+			 &params[1].value.b);
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Trusted Application Entry Points
+ */
+static TEE_Result open_session(uint32_t nParamTypes __unused,
+			       TEE_Param pParams[TEE_NUM_PARAMS] __unused,
+			       void **ppSessionContext __unused)
+{
+	struct tee_ta_session *s = tee_ta_get_calling_session();
+
+	if (s && (s->ctx->flags & TA_FLAG_SECURE_DATA_PATH)) {
+		DMSG("open entry point for pseudo-TA \"%s\"", PTA_NAME);
+		return TEE_SUCCESS;
+	}
+
+	DMSG("TA %pUl is unauthorised access to pseudo-TA \"%s\"",
+	     s->ctx->uuid, PTA_NAME);
+
+	return TEE_ERROR_ACCESS_DENIED;
+}
+
+static TEE_Result invoke_command(void *pSessionContext __unused,
+				 uint32_t nCommandID, uint32_t nParamTypes,
+				 TEE_Param pParams[TEE_NUM_PARAMS])
+{
+	FMSG("command entry point for pseudo-TA \"%s\"", PTA_NAME);
+
+	switch (nCommandID) {
+	case PTA_CMD_SDP_VIRT_TO_PHYS:
+		return sdp_pa_cmd_virt_to_phys(nParamTypes, pParams);
+	default:
+		break;
+	}
+
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+pseudo_ta_register(.uuid = PTA_SDP_PTA_UUID, .name = PTA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_SECURE_DATA_PATH,
+		   .open_session_entry_point = open_session,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/arch/arm/pta/sub.mk
+++ b/core/arch/arm/pta/sub.mk
@@ -9,6 +9,7 @@ endif
 srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_TA_GPROF_SUPPORT) += gprof.c
 srcs-$(CFG_TEE_BENCHMARK) += benchmark.c
+srcs-$(CFG_SDP_PTA) += sdp_pta.c
 
 ifeq ($(CFG_SE_API),y)
 srcs-$(CFG_SE_API_SELF_TEST) += se_api_self_tests.c

--- a/lib/libutee/include/sdp_pta.h
+++ b/lib/libutee/include/sdp_pta.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2017, ARM Limited, All Rights Reserved
+ */
+
+#ifndef __SDP_PTA_H
+#define __SDP_PTA_H
+
+#define PTA_SDP_PTA_UUID { 0x54c82831, 0x0170, 0x487d, \
+		{ 0xb7, 0xe6, 0xe9, 0x30, 0xf4, 0xfd, 0xc5, 0x24 } }
+
+/*
+ * PTA_CMD_SDP_VIRT_TO_PHYS - Get physical address for the SDP buffer memref
+ *
+ * param[0] (in memref) - SDP buffer memory reference
+ * param[1] (out value) - Physical address (.a=32bit MSB, .b=32bit LSB)
+ * param[2] unused
+ * param[3] unused
+ */
+#define PTA_CMD_SDP_VIRT_TO_PHYS		0x0
+
+#endif /* __SDP_PTA_H */


### PR DESCRIPTION
Hello,

Secure firmware ta needs physical address for creating pagetable; add a pta for retrieve physical address for it. There is restriction checking in pta which make sure only secure firmware could access this pta.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
