### PR TITLE
core/tee/tadb.c: Workaround error: missing braces around initializer

### DIFF
--- a/core/tee/tadb.c
+++ b/core/tee/tadb.c
@@ -590,7 +590,7 @@ err:
 
 TEE_Result tee_tadb_ta_delete(const TEE_UUID *uuid)
 {
-	const struct tadb_entry null_entry = { 0 };
+	const struct tadb_entry null_entry = { { { 0 } } };
 	struct tee_tadb_dir *db;
 	struct tadb_entry entry;
 	size_t idx;


### PR DESCRIPTION
GCC 4.9 generates below false positive:

core/tee/tadb.c:593:15: error: missing braces around initializer [-Werror=missing-braces]
const struct tadb_entry null_entry = { 0 };
             ^
core/tee/tadb.c:593:15: error: (near initialization for ‘null_entry.prop’) [-Werror=missing-braces]

Work around it by adding extra braces.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
