### PR TITLE
libutee: call TA_CreateEntryPoint() only once for keep alive TAs

### DIFF
--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -61,11 +61,12 @@ static TAILQ_HEAD(ta_sessions, ta_session) ta_sessions =
 		TAILQ_HEAD_INITIALIZER(ta_sessions);
 
 static uint32_t ta_ref_count;
-static bool context_init;
+static bool init_done;
 
 /* From user_ta_header.c, built within TA */
 extern uint8_t ta_heap[];
 extern const size_t ta_heap_size;
+extern struct ta_head ta_head;
 
 uint32_t ta_param_types;
 TEE_Param ta_params[TEE_NUM_PARAMS];
@@ -104,17 +105,19 @@ static TEE_Result ta_header_add_session(uint32_t session_id)
 	if (ta_ref_count == 1) {
 		TEE_Result res;
 
-		if (!context_init) {
+		if (!init_done) {
 			trace_set_level(tahead_get_trace_level());
 			__utee_gprof_init();
 			malloc_add_pool(ta_heap, ta_heap_size);
 			_TEE_MathAPI_Init();
-			context_init = true;
 		}
-
-		res = TA_CreateEntryPoint();
-		if (res != TEE_SUCCESS)
-			return res;
+		if (!(ta_head.flags & TA_FLAG_INSTANCE_KEEP_ALIVE) ||
+		    !init_done) {
+			res = TA_CreateEntryPoint();
+			if (res != TEE_SUCCESS)
+				return res;
+		}
+		init_done = true;
 	}
 
 	itr = TEE_Malloc(sizeof(struct ta_session),

--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -66,7 +66,6 @@ static bool init_done;
 /* From user_ta_header.c, built within TA */
 extern uint8_t ta_heap[];
 extern const size_t ta_heap_size;
-extern struct ta_head ta_head;
 
 uint32_t ta_param_types;
 TEE_Param ta_params[TEE_NUM_PARAMS];
@@ -110,14 +109,11 @@ static TEE_Result ta_header_add_session(uint32_t session_id)
 			__utee_gprof_init();
 			malloc_add_pool(ta_heap, ta_heap_size);
 			_TEE_MathAPI_Init();
-		}
-		if (!(ta_head.flags & TA_FLAG_INSTANCE_KEEP_ALIVE) ||
-		    !init_done) {
 			res = TA_CreateEntryPoint();
 			if (res != TEE_SUCCESS)
 				return res;
+			init_done = true;
 		}
-		init_done = true;
 	}
 
 	itr = TEE_Malloc(sizeof(struct ta_session),


### PR DESCRIPTION
Makes sure that TA_CreateEntryPoint() is called once and only once for
keep alive, single instance TAs, as per the GP Internal Core API v1.1.2
specification (table 4-6).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
