### PR TITLE
Define register_sdp_mem() only when CFG_SECURE_DATA_PATH is defined

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -218,9 +218,13 @@ struct core_mmu_phys_mem {
 		__register_memory1_ul(#addr, (type), (addr), (size), \
 				   phys_mem_map_section, __COUNTER__)
 
+#ifdef CFG_SECURE_DATA_PATH
 #define register_sdp_mem(addr, size) \
 		__register_memory1(#addr, MEM_AREA_SDP_MEM, (addr), (size), \
 				   phys_sdp_mem_section, __COUNTER__)
+#else
+#define register_sdp_mem(addr, size)
+#endif
 
 #define register_nsec_ddr(addr, size) \
 		__register_memory1(#addr, MEM_AREA_RAM_NSEC, (addr), (size), \


### PR DESCRIPTION
Suggested-by: Etienne Carriere <etienne.carriere@linaro.org>
Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
