### PR TITLE
Crypto alloc

### DIFF
--- a/core/crypto/aes-gcm.c
+++ b/core/crypto/aes-gcm.c
@@ -403,10 +403,27 @@ TEE_Result internal_aes_gcm_dec(const struct internal_aes_gcm_key *enc_key,
 
 #ifndef CFG_CRYPTO_AES_GCM_FROM_CRYPTOLIB
 #include <crypto/aes-gcm.h>
+#include <stdlib.h>
 
-size_t crypto_aes_gcm_get_ctx_size(void)
+TEE_Result crypto_aes_gcm_alloc_ctx(void **ctx_ret)
 {
-	return sizeof(struct internal_aes_gcm_ctx);
+	struct internal_aes_gcm_ctx *ctx = calloc(1, sizeof(*ctx));
+
+	if (!ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	*ctx_ret = ctx;
+	return TEE_SUCCESS;
+}
+
+void crypto_aes_gcm_free_ctx(void *ctx)
+{
+	free(ctx);
+}
+
+void crypto_aes_gcm_copy_state(void *dst_ctx, void *src_ctx)
+{
+	memcpy(dst_ctx, src_ctx, sizeof(struct internal_aes_gcm_ctx));
 }
 
 TEE_Result crypto_aes_gcm_init(void *c, TEE_OperationMode mode,

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -10,10 +10,20 @@
 #include <kernel/panic.h>
 
 #if !defined(_CFG_CRYPTO_WITH_HASH)
-TEE_Result crypto_hash_get_ctx_size(uint32_t algo __unused,
-				    size_t *size __unused)
+TEE_Result crypto_hash_alloc_ctx(void **ctx __unused, uint32_t algo __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void crypto_hash_free_ctx(void *ctx __unused, uint32_t algo __unused)
+{
+	assert(0);
+}
+
+void crypto_hash_copy_state(void *dst_ctx __unused, void *src_ctx __unused,
+			    uint32_t algo __unused)
+{
+	assert(0);
 }
 
 TEE_Result crypto_hash_init(void *ctx __unused, uint32_t algo __unused)

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -82,10 +82,20 @@ TEE_Result crypto_cipher_get_block_size(uint32_t algo __unused,
 #endif /*_CFG_CRYPTO_WITH_CIPHER*/
 
 #if !defined(_CFG_CRYPTO_WITH_MAC)
-TEE_Result crypto_mac_get_ctx_size(uint32_t algo __unused,
-				   size_t *size __unused)
+TEE_Result crypto_mac_alloc_ctx(void **ctx __unused, uint32_t algo __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void crypto_mac_free_ctx(void *ctx __unused, uint32_t algo __unused)
+{
+	assert(0);
+}
+
+void crypto_mac_copy_state(void *dst_ctx __unused, void *src_ctx __unused,
+			   uint32_t algo __unused)
+{
+	assert(0);
 }
 
 TEE_Result crypto_mac_init(void *ctx __unused, uint32_t algo __unused,

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -43,10 +43,20 @@ TEE_Result crypto_hash_final(void *ctx __unused, uint32_t algo __unused,
 #endif /*_CFG_CRYPTO_WITH_HASH*/
 
 #if !defined(_CFG_CRYPTO_WITH_CIPHER)
-TEE_Result crypto_cipher_get_ctx_size(uint32_t algo __unused,
-				      size_t *size __unused)
+TEE_Result crypto_cipher_alloc_ctx(void **ctx __unused, uint32_t algo __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void crypto_cipher_free_ctx(void *ctx __unused, uint32_t algo __unused)
+{
+	assert(0);
+}
+
+void crypto_cipher_copy_state(void *dst_ctx __unused, void *src_ctx __unused,
+			      uint32_t algo __unused)
+{
+	assert(0);
 }
 
 TEE_Result crypto_cipher_init(void *ctx __unused, uint32_t algo __unused,

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -3,11 +3,14 @@
  * Copyright (c) 2017, Linaro Limited
  */
 
+#include <assert.h>
 #include <compiler.h>
 #include <crypto/aes-ccm.h>
 #include <crypto/aes-gcm.h>
 #include <crypto/crypto.h>
 #include <kernel/panic.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if !defined(_CFG_CRYPTO_WITH_HASH)
 TEE_Result crypto_hash_alloc_ctx(void **ctx __unused, uint32_t algo __unused)
@@ -128,22 +131,55 @@ TEE_Result crypto_mac_final(void *ctx __unused, uint32_t algo __unused,
 }
 #endif /*_CFG_CRYPTO_WITH_MAC*/
 
-TEE_Result crypto_authenc_get_ctx_size(uint32_t algo __maybe_unused,
-				       size_t *size __maybe_unused)
+TEE_Result crypto_authenc_alloc_ctx(void **ctx, uint32_t algo)
 {
 	switch (algo) {
 #if defined(CFG_CRYPTO_CCM)
 	case TEE_ALG_AES_CCM:
-		*size = crypto_aes_ccm_get_ctx_size();
-		return TEE_SUCCESS;
+		return crypto_aes_ccm_alloc_ctx(ctx);
 #endif
 #if defined(CFG_CRYPTO_GCM)
 	case TEE_ALG_AES_GCM:
-		*size = crypto_aes_gcm_get_ctx_size();
-		return TEE_SUCCESS;
+		return crypto_aes_gcm_alloc_ctx(ctx);
 #endif
 	default:
 		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+}
+
+void crypto_authenc_free_ctx(void *ctx, uint32_t algo)
+{
+	switch (algo) {
+#if defined(CFG_CRYPTO_CCM)
+	case TEE_ALG_AES_CCM:
+		crypto_aes_ccm_free_ctx(ctx);
+		break;
+#endif
+#if defined(CFG_CRYPTO_GCM)
+	case TEE_ALG_AES_GCM:
+		crypto_aes_gcm_free_ctx(ctx);
+		break;
+#endif
+	default:
+		assert(0);
+	}
+}
+
+void crypto_authenc_copy_state(void *dst_ctx, void *src_ctx, uint32_t algo)
+{
+	switch (algo) {
+#if defined(CFG_CRYPTO_CCM)
+	case TEE_ALG_AES_CCM:
+		crypto_aes_ccm_copy_state(dst_ctx, src_ctx);
+		break;
+#endif
+#if defined(CFG_CRYPTO_GCM)
+	case TEE_ALG_AES_GCM:
+		crypto_aes_gcm_copy_state(dst_ctx, src_ctx);
+		break;
+#endif
+	default:
+		assert(0);
 	}
 }
 

--- a/core/include/crypto/aes-ccm.h
+++ b/core/include/crypto/aes-ccm.h
@@ -8,7 +8,7 @@
 
 #include <tee_api_types.h>
 
-size_t crypto_aes_ccm_get_ctx_size(void);
+TEE_Result crypto_aes_ccm_alloc_ctx(void **ctx);
 TEE_Result crypto_aes_ccm_init(void *ctx, TEE_OperationMode mode,
 			       const uint8_t *key, size_t key_len,
 			       const uint8_t *nonce, size_t nonce_len,
@@ -26,6 +26,8 @@ TEE_Result crypto_aes_ccm_dec_final(void *ctx, const uint8_t *src_data,
 				    size_t len, uint8_t *dst_data,
 				    const uint8_t *tag, size_t tag_len);
 void crypto_aes_ccm_final(void *ctx);
+void crypto_aes_ccm_free_ctx(void *ctx);
+void crypto_aes_ccm_copy_state(void *dst_ctx, void *src_ctx);
 
 #endif /*__CRYPTO_AES_CCM_H*/
 

--- a/core/include/crypto/aes-gcm.h
+++ b/core/include/crypto/aes-gcm.h
@@ -8,7 +8,7 @@
 
 #include <tee_api_types.h>
 
-size_t crypto_aes_gcm_get_ctx_size(void);
+TEE_Result crypto_aes_gcm_alloc_ctx(void **ctx);
 TEE_Result crypto_aes_gcm_init(void *ctx, TEE_OperationMode mode,
 			       const uint8_t *key, size_t key_len,
 			       const uint8_t *nonce, size_t nonce_len,
@@ -25,5 +25,7 @@ TEE_Result crypto_aes_gcm_dec_final(void *ctx, const uint8_t *src_data,
 				    size_t len, uint8_t *dst_data,
 				    const uint8_t *tag, size_t tag_len);
 void crypto_aes_gcm_final(void *ctx);
+void crypto_aes_gcm_free_ctx(void *ctx);
+void crypto_aes_gcm_copy_state(void *dst_ctx, void *src_ctx);
 
 #endif /*__CRYPTO_AES_GCM_H*/

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -62,7 +62,7 @@ void crypto_mac_free_ctx(void *ctx, uint32_t algo);
 void crypto_mac_copy_state(void *dst_ctx, void *src_ctx, uint32_t algo);
 
 /* Authenticated encryption */
-TEE_Result crypto_authenc_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_authenc_alloc_ctx(void **ctx, uint32_t algo);
 TEE_Result crypto_authenc_init(void *ctx, uint32_t algo, TEE_OperationMode mode,
 			       const uint8_t *key, size_t key_len,
 			       const uint8_t *nonce, size_t nonce_len,
@@ -85,6 +85,8 @@ TEE_Result crypto_authenc_dec_final(void *ctx, uint32_t algo,
 				    uint8_t *dst_data, size_t *dst_len,
 				    const uint8_t *tag, size_t tag_len);
 void crypto_authenc_final(void *ctx, uint32_t algo);
+void crypto_authenc_free_ctx(void *ctx, uint32_t algo);
+void crypto_authenc_copy_state(void *dst_ctx, void *src_ctx, uint32_t algo);
 
 /* Implementation-defined big numbers */
 

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -27,12 +27,14 @@
 TEE_Result crypto_init(void);
 
 /* Message digest functions */
-TEE_Result crypto_hash_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_hash_alloc_ctx(void **ctx, uint32_t algo);
 TEE_Result crypto_hash_init(void *ctx, uint32_t algo);
 TEE_Result crypto_hash_update(void *ctx, uint32_t algo, const uint8_t *data,
 			      size_t len);
 TEE_Result crypto_hash_final(void *ctx, uint32_t algo, uint8_t *digest,
 			     size_t len);
+void crypto_hash_free_ctx(void *ctx, uint32_t algo);
+void crypto_hash_copy_state(void *dst_ctx, void *src_ctx, uint32_t algo);
 
 /* Symmetric ciphers */
 TEE_Result crypto_cipher_get_ctx_size(uint32_t algo, size_t *size);

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -49,13 +49,15 @@ void crypto_cipher_final(void *ctx, uint32_t algo);
 TEE_Result crypto_cipher_get_block_size(uint32_t algo, size_t *size);
 
 /* Message Authentication Code functions */
-TEE_Result crypto_mac_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_mac_alloc_ctx(void **ctx, uint32_t algo);
 TEE_Result crypto_mac_init(void *ctx, uint32_t algo, const uint8_t *key,
 			   size_t len);
 TEE_Result crypto_mac_update(void *ctx, uint32_t algo, const uint8_t *data,
 			     size_t len);
 TEE_Result crypto_mac_final(void *ctx, uint32_t algo, uint8_t *digest,
 			    size_t digest_len);
+void crypto_mac_free_ctx(void *ctx, uint32_t algo);
+void crypto_mac_copy_state(void *dst_ctx, void *src_ctx, uint32_t algo);
 
 /* Authenticated encryption */
 TEE_Result crypto_authenc_get_ctx_size(uint32_t algo, size_t *size);

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -37,7 +37,7 @@ void crypto_hash_free_ctx(void *ctx, uint32_t algo);
 void crypto_hash_copy_state(void *dst_ctx, void *src_ctx, uint32_t algo);
 
 /* Symmetric ciphers */
-TEE_Result crypto_cipher_get_ctx_size(uint32_t algo, size_t *size);
+TEE_Result crypto_cipher_alloc_ctx(void **ctx, uint32_t algo);
 TEE_Result crypto_cipher_init(void *ctx, uint32_t algo, TEE_OperationMode mode,
 			      const uint8_t *key1, size_t key1_len,
 			      const uint8_t *key2, size_t key2_len,
@@ -47,6 +47,8 @@ TEE_Result crypto_cipher_update(void *ctx, uint32_t algo,
 				const uint8_t *data, size_t len, uint8_t *dst);
 void crypto_cipher_final(void *ctx, uint32_t algo);
 TEE_Result crypto_cipher_get_block_size(uint32_t algo, size_t *size);
+void crypto_cipher_free_ctx(void *ctx, uint32_t algo);
+void crypto_cipher_copy_state(void *dst_ctx, void *src_ctx, uint32_t algo);
 
 /* Message Authentication Code functions */
 TEE_Result crypto_mac_alloc_ctx(void **ctx, uint32_t algo);

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -2630,9 +2630,25 @@ struct tee_ccm_state {
 	size_t tag_len;			/* tag length */
 };
 
-size_t crypto_aes_ccm_get_ctx_size(void)
+TEE_Result crypto_aes_ccm_alloc_ctx(void **ctx_ret)
 {
-	return sizeof(struct tee_ccm_state);
+	struct tee_ccm_state *ctx = calloc(1, sizeof(*ctx));
+
+	if (!ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	*ctx_ret = ctx;
+	return TEE_SUCCESS;
+}
+
+void crypto_aes_ccm_free_ctx(void *ctx)
+{
+	free(ctx);
+}
+
+void crypto_aes_ccm_copy_state(void *dst_ctx, void *src_ctx)
+{
+	memcpy(dst_ctx, src_ctx, sizeof(struct tee_ccm_state));
 }
 
 TEE_Result crypto_aes_ccm_init(void *ctx, TEE_OperationMode mode __unused,
@@ -2794,9 +2810,25 @@ struct tee_gcm_state {
 	size_t tag_len;			/* tag length */
 };
 
-size_t crypto_aes_gcm_get_ctx_size(void)
+TEE_Result crypto_aes_gcm_alloc_ctx(void **ctx_ret)
 {
-	return sizeof(struct tee_gcm_state);
+	struct tee_gcm_state *ctx = calloc(1, sizeof(*ctx));
+
+	if (!ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	*ctx_ret = ctx;
+	return TEE_SUCCESS;
+}
+
+void crypto_aes_gcm_free_ctx(void *ctx)
+{
+	free(ctx);
+}
+
+void crypto_aes_gcm_copy_state(void *dst_ctx, void *src_ctx)
+{
+	memcpy(dst_ctx, src_ctx, sizeof(struct tee_gcm_state));
 }
 
 TEE_Result crypto_aes_gcm_init(void *ctx, TEE_OperationMode mode __unused,

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -17,22 +17,16 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 			       size_t derived_key_len)
 {
 	TEE_Result res;
-	size_t ctx_size, hash_len, i, n, sz;
+	size_t hash_len, i, n, sz;
 	void *ctx = NULL;
 	uint8_t tmp[TEE_MAX_HASH_SIZE];
 	uint32_t be_count;
 	uint8_t *out = derived_key;
 	uint32_t hash_algo = TEE_ALG_HASH_ALGO(hash_id);
 
-	res = crypto_hash_get_ctx_size(hash_algo, &ctx_size);
+	res = crypto_hash_alloc_ctx(&ctx, hash_algo);
 	if (res != TEE_SUCCESS)
-		goto out;
-
-	ctx = malloc(ctx_size);
-	if (!ctx) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
-		goto out;
-	}
+		return res;
 
 	res = tee_hash_get_digest_size(hash_algo, &hash_len);
 	if (res != TEE_SUCCESS)
@@ -71,6 +65,6 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 	}
 	res = TEE_SUCCESS;
 out:
-	free(ctx);
+	crypto_hash_free_ctx(ctx, hash_algo);
 	return res;
 }

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -77,7 +77,7 @@ TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
 			   uint8_t *derived_key, size_t derived_key_len)
 {
 	TEE_Result res;
-	size_t ctx_size, i, l, r;
+	size_t i, l, r;
 	uint8_t *out = derived_key;
 	struct pbkdf2_parms pbkdf2_parms;
 	struct hmac_parms hmac_parms = {0, };
@@ -88,13 +88,9 @@ TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	res = crypto_mac_get_ctx_size(hmac_parms.algo, &ctx_size);
+	res = crypto_mac_alloc_ctx(&hmac_parms.ctx, hmac_parms.algo);
 	if (res != TEE_SUCCESS)
 		return res;
-
-	hmac_parms.ctx = malloc(ctx_size);
-	if (!hmac_parms.ctx)
-		return TEE_ERROR_OUT_OF_MEMORY;
 
 	pbkdf2_parms.password = password;
 	pbkdf2_parms.password_len = password_len;
@@ -116,6 +112,6 @@ TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
 		res = pbkdf2_f(out, r, i, &hmac_parms, &pbkdf2_parms);
 
 out:
-	free(hmac_parms.ctx);
+	crypto_mac_free_ctx(hmac_parms.ctx, hmac_parms.algo);
 	return res;
 }

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -41,20 +41,15 @@ static TEE_Result do_hmac(void *out_key, size_t out_key_size,
 			  const void *in_key, size_t in_key_size,
 			  const void *message, size_t message_size)
 {
-	TEE_Result res = TEE_ERROR_GENERIC;
-	uint8_t *ctx = NULL;
-	size_t hash_ctx_size = 0;
+	TEE_Result res;
+	void *ctx = NULL;
 
 	if (!out_key || !in_key || !message)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = crypto_mac_get_ctx_size(TEE_FS_KM_HMAC_ALG, &hash_ctx_size);
+	res = crypto_mac_alloc_ctx(&ctx, TEE_FS_KM_HMAC_ALG);
 	if (res != TEE_SUCCESS)
 		return res;
-
-	ctx = malloc(hash_ctx_size);
-	if (!ctx)
-		return TEE_ERROR_OUT_OF_MEMORY;
 
 	res = crypto_mac_init(ctx, TEE_FS_KM_HMAC_ALG, in_key, in_key_size);
 	if (res != TEE_SUCCESS)
@@ -71,7 +66,7 @@ static TEE_Result do_hmac(void *out_key, size_t out_key_size,
 	res = TEE_SUCCESS;
 
 exit:
-	free(ctx);
+	crypto_mac_free_ctx(ctx, TEE_FS_KM_HMAC_ALG);
 	return res;
 }
 

--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -192,32 +192,8 @@ TEE_Result tee_fs_generate_fek(const TEE_UUID *uuid, void *buf, size_t buf_size)
 static TEE_Result sha256(uint8_t *out, size_t out_size, const uint8_t *in,
 			 size_t in_size)
 {
-	TEE_Result res;
-	uint8_t *ctx = NULL;
-	size_t ctx_size;
-	uint32_t algo = TEE_ALG_SHA256;
-
-	res = crypto_hash_get_ctx_size(algo, &ctx_size);
-	if (res != TEE_SUCCESS)
-		return res;
-
-	ctx = malloc(ctx_size);
-	if (!ctx)
-		return TEE_ERROR_OUT_OF_MEMORY;
-
-	res = crypto_hash_init(ctx, algo);
-	if (res != TEE_SUCCESS)
-		goto out;
-
-	res = crypto_hash_update(ctx, algo, in, in_size);
-	if (res != TEE_SUCCESS)
-		goto out;
-
-	res = crypto_hash_final(ctx, algo, out, out_size);
-
-out:
-	free(ctx);
-	return res;
+	return tee_hash_createdigest(TEE_ALG_SHA256, in, in_size,
+				     out, out_size);
 }
 
 static TEE_Result aes_ecb(uint8_t out[TEE_AES_BLOCK_SIZE],

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1868,6 +1868,9 @@ static void cryp_state_free(struct user_ta_ctx *utc, struct tee_cryp_state *cs)
 	case TEE_OPERATION_CIPHER:
 		crypto_cipher_free_ctx(cs->ctx, cs->algo);
 		break;
+	case TEE_OPERATION_AE:
+		crypto_authenc_free_ctx(cs->ctx, cs->algo);
+		break;
 	case TEE_OPERATION_DIGEST:
 		crypto_hash_free_ctx(cs->ctx, cs->algo);
 		break;
@@ -2021,12 +2024,9 @@ TEE_Result syscall_cryp_state_alloc(unsigned long algo, unsigned long mode,
 		if (key1 == 0 || key2 != 0) {
 			res = TEE_ERROR_BAD_PARAMETERS;
 		} else {
-			res = crypto_authenc_get_ctx_size(algo, &cs->ctx_size);
+			res = crypto_authenc_alloc_ctx(&cs->ctx, algo);
 			if (res != TEE_SUCCESS)
 				break;
-			cs->ctx = calloc(1, cs->ctx_size);
-			if (!cs->ctx)
-				res = TEE_ERROR_OUT_OF_MEMORY;
 		}
 		break;
 	case TEE_OPERATION_MAC:
@@ -2111,6 +2111,10 @@ TEE_Result syscall_cryp_state_copy(unsigned long dst, unsigned long src)
 	case TEE_OPERATION_CIPHER:
 		crypto_cipher_copy_state(cs_dst->ctx, cs_src->ctx,
 					 cs_src->algo);
+		break;
+	case TEE_OPERATION_AE:
+		crypto_authenc_copy_state(cs_dst->ctx, cs_src->ctx,
+					  cs_src->algo);
 		break;
 	case TEE_OPERATION_DIGEST:
 		crypto_hash_copy_state(cs_dst->ctx, cs_src->ctx, cs_src->algo);


### PR DESCRIPTION
The crypto api in crypt.h doesn't match the crypt api supplied by mbedtls very well with regards to how the crypto context is managed.

This pull request tries to address that by letting moving management of the crypto context into the api provided by crypt.h.