### PR TITLE
core: fix the reopen session condition for single instance TA

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -473,13 +473,9 @@ static TEE_Result tee_ta_init_session_with_context(struct tee_ta_ctx *ctx,
 
 	/*
 	 * The TA is single instance, if it isn't multi session we
-	 * can't create another session unless it's the first
-	 * new session towards a keepAlive TA.
+	 * can't create another session unless its reference is zero
 	 */
-
-	if (((ctx->flags & TA_FLAG_MULTI_SESSION) == 0) &&
-	    !(((ctx->flags & TA_FLAG_INSTANCE_KEEP_ALIVE) != 0) &&
-	      (ctx->ref_count == 0)))
+	if (!(ctx->flags & TA_FLAG_MULTI_SESSION) && ctx->ref_count)
 		return TEE_ERROR_BUSY;
 
 	DMSG("Re-open TA %pUl", (void *)&ctx->uuid);


### PR DESCRIPTION
when a single instance TA is not muti-session, it 's allowed to open a
new session only if the TA context reference is not zero, no matter
whether it is keepalive or not.

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
