### PR TITLE
Fix USER_TA_PROP_TYPE_BOOL handling

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -92,9 +92,9 @@ static const uint32_t ta_time_prot_lvl = 100;
 
 /* Elliptic Curve Cryptographic support */
 #ifdef CFG_CRYPTO_ECC
-static const uint32_t crypto_ecc_en = 1;
+static const bool crypto_ecc_en = 1;
 #else
-static const uint32_t crypto_ecc_en;
+static const bool crypto_ecc_en;
 #endif
 
 /*

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -98,7 +98,7 @@ static TEE_Result propget_get_ext_prop(const struct user_ta_property *ep,
 	*type = ep->type;
 	switch (*type) {
 	case USER_TA_PROP_TYPE_BOOL:
-		l = sizeof(uint32_t);
+		l = sizeof(bool);
 		break;
 	case USER_TA_PROP_TYPE_U32:
 		l = sizeof(uint32_t);
@@ -211,6 +211,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 	void *tmp_buf = 0;
 	uint32_t tmp_len;
 	uint32_t uint32_val;
+	bool bool_val;
 	TEE_Identity *p_identity_val;
 
 	if (!value || !value_len) {
@@ -246,9 +247,8 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 
 	switch (type) {
 	case USER_TA_PROP_TYPE_BOOL:
-		uint32_val = *((uint32_t *)tmp_buf);
-		l = strlcpy(value, (uint32_val ? "true" : "false"),
-			    *value_len);
+		bool_val = *((bool *)tmp_buf);
+		l = strlcpy(value, (bool_val ? "true" : "false"), *value_len);
 		break;
 
 	case USER_TA_PROP_TYPE_U32:
@@ -308,8 +308,7 @@ TEE_Result TEE_GetPropertyAsBool(TEE_PropSetHandle propsetOrEnumerator,
 {
 	TEE_Result res;
 	enum user_ta_prop_type type;
-	uint32_t uint32_val;
-	uint32_t uint32_len = sizeof(uint32_val);
+	uint32_t bool_len = sizeof(bool);
 	if (value == NULL) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
@@ -317,13 +316,11 @@ TEE_Result TEE_GetPropertyAsBool(TEE_PropSetHandle propsetOrEnumerator,
 
 	type = USER_TA_PROP_TYPE_BOOL;
 	res = propget_get_property(propsetOrEnumerator, name, &type,
-				   &uint32_val, &uint32_len);
+				   value, &bool_len);
 	if (type != USER_TA_PROP_TYPE_BOOL)
 		res = TEE_ERROR_BAD_FORMAT;
 	if (res != TEE_SUCCESS)
 		goto out;
-
-	*value = !!uint32_val;
 
 out:
 	if (res != TEE_SUCCESS &&


### PR DESCRIPTION
In 'ta_props' in ta/arch/arm/user_ta_header.c properties tagged as
USER_TA_PROP_TYPE_BOOL are assigned a pointer to a bool, but is in the
rest of the code handled as if it was a pointer to a uint32_t. This
works as long as a bool is four bytes, with certain compilers the size
of a `bool` is 1 instead leading to errors.

TA properties can be supplied via the define
TA_CURRENT_TA_EXT_PROPERTIES. The pattern used in
ta/arch/arm/user_ta_header.c is likely copied when assigning properties
via TA_CURRENT_TA_EXT_PROPERTIES.

This patch is fixing the assumption that the size of a `bool` is the
same as the size of a `uint32_t` by changing all handling of
USER_TA_PROP_TYPE_BOOL to base it on the type `bool` instead of
`uint32_t`.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
