### PR TITLE
arm: pl310: fix cache sync

### DIFF
--- a/core/arch/arm/kernel/tz_ssvce_pl310_a32.S
+++ b/core/arch/arm/kernel/tz_ssvce_pl310_a32.S
@@ -91,13 +91,18 @@ loop_cli_way_done:
 
 	/* Cache Sync */
 
-	/* Wait for writing cache sync */
+	/*
+	 * Wait for writing cache sync
+	 * To PL310, Cache sync is atomic opertion, no need to check
+	 * the status. For PL220, this check is needed. Keeping the loop
+	 * for PL310 is no harm for PL310.
+	 */
 loop_cli_sync:
 	ldr	r1, [r0, #PL310_SYNC]
 	cmp	r1, #0
 	bne	loop_cli_sync
 
-	mov	r1, #1
+	mov	r1, #0
 	str	r1, [r0, #PL310_SYNC]
 
 loop_cli_sync_done:
@@ -127,7 +132,7 @@ loop_inv_way_sync:
 	cmp	r1, #0
 	bne	loop_inv_way_sync
 
-	mov	r1, #1
+	mov	r1, #0
 	str	r1, [r0, #PL310_SYNC]
 
 loop_inv_way_sync_done:
@@ -157,7 +162,7 @@ loop_cl_way_sync:
 	cmp	r1, #0
 	bne	loop_cl_way_sync
 
-	mov	r1, #1
+	mov	r1, #0
 	str	r1, [r0, #PL310_SYNC]
 
 loop_cl_way_sync_done:
@@ -212,7 +217,7 @@ loop_xxx_pa_sync:
 	cmp	r12, #0
 	bne	loop_xxx_pa_sync
 
-	mov	r12, #1
+	mov	r12, #0
 	str	r12, [r0, #PL310_SYNC]
 
 loop_xxx_pa_sync_done:


### PR DESCRIPTION
According to PL310 TRM:
Atomic operations:
The following are atomic operations:
    Clean Line by PA or by Set/Way
    Invalidate Line by PA
    Clean and Invalidate Line by PA or by Set/Way
    Cache Sync.
These operations stall the slave ports until they are complete.
When these registers are read, bit [0], the C flag, indicates that
a background operation is in progress. When written, bit 0 must be
zero.

So write 1 to sync register is not correct.

Signed-off-by: Peng Fan <peng.fan@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
