### PR TITLE
core: arm32: invalidate branch predictor

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -31,6 +31,12 @@ platform-hard-float-enabled := y
 endif
 endif
 
+# Adds protection against CVE-2017-5715 also know as Spectre
+# (https://spectreattack.com)
+# See also https://developer.arm.com/-/media/Files/pdf/Cache_Speculation_Side-channels.pdf
+# Variant 2
+CFG_CORE_WORKAROUND_SPECTRE_BP ?= y
+
 CFG_CORE_RWDATA_NOEXEC ?= y
 CFG_CORE_RODATA_NOEXEC ?= n
 ifeq ($(CFG_CORE_RODATA_NOEXEC),y)

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -35,6 +35,7 @@
 #include <sm/optee_smc.h>
 #include <sm/teesmc_opteed.h>
 #include <sm/teesmc_opteed_macros.h>
+#include <util.h>
 
 	.section .text.sm_asm
 
@@ -249,6 +250,47 @@ END_FUNC sm_fiq_entry
 LOCAL_FUNC sm_vect_table , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
+#ifdef CFG_CORE_WORKAROUND_SPECTRE_BP
+	/*
+	 * This depends on SP being 8 byte aligned, that is, the lowest
+	 * three bits in SP are zero.
+	 *
+	 * The idea is to form a specific bit pattern in the lowest three
+	 * bits of SP depending on which entry in the vector we enter via.
+	 * This is done by adding 1 to SP in each entry but the last.
+	 */
+	add	sp, sp, #1	/* 7:111 Reset			*/
+	add	sp, sp, #1	/* 6:110 Undefined instruction	*/
+	add	sp, sp, #1	/* 5:101 Secure monitor call	*/
+	add	sp, sp, #1	/* 4:100 Prefetch abort		*/
+	add	sp, sp, #1	/* 3:011 Data abort		*/
+	add	sp, sp, #1	/* 2:010 Reserved		*/
+	add	sp, sp, #1	/* 1:001 IRQ			*/
+	nop			/* 0:000 FIQ			*/
+
+	/* Invalidate the branch predictor for the current processor. */
+	write_bpiall
+	isb
+
+	/*
+	 * Only two exception does normally occur, smc and fiq. With all
+	 * other exceptions it's good enough to just spinn, the lowest bits
+	 * still tells which exception we're stuck with when attaching a
+	 * debugger.
+	 */
+
+	/* Test for FIQ, all the lowest bits of SP are supposed to be 0 */
+	tst	sp, #(BIT(0) | BIT(1) | BIT(2))
+	beq	sm_fiq_entry
+
+	/* Test for SMC, xor the lowest bits of SP to be 0 */
+	eor	sp, sp, #(BIT(0) | BIT(2))
+	tst	sp, #(BIT(0) | BIT(1) | BIT(2))
+	beq	sm_smc_entry
+
+	/* unhandled exception */
+	b	.
+#else /*!CFG_CORE_WORKAROUND_SPECTRE_BP*/
 	b	.		/* Reset			*/
 	b	.		/* Undefined instruction	*/
 	b	sm_smc_entry	/* Secure monitor call		*/
@@ -257,6 +299,7 @@ UNWIND(	.cantunwind)
 	b	.		/* Reserved			*/
 	b	.		/* IRQ				*/
 	b	sm_fiq_entry	/* FIQ				*/
+#endif /*!CFG_CORE_WORKAROUND_SPECTRE_BP*/
 UNWIND(	.fnend)
 END_FUNC sm_vect_table
 


### PR DESCRIPTION
* If built with internal secure monitor, invalidates branch predictor
  on non-secure entry.
* If built for usage with ARM-TF, invalidates branch predictor on
  entry.

Fixes CVE-2017-5715

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
