### PR TITLE
mk/config.mk: remove obsolete text and clarify usage of log levels

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -44,16 +44,14 @@ WARNS ?= 3
 # so assertions are disabled.
 CFG_TEE_CORE_DEBUG ?= y
 
-# Max level of the tee core traces. 0 means disable, 4 is max.
-# Supported values: 0 (no traces) to 4 (all traces)
-# If CFG_TEE_DRV_DEBUGFS is set, the level of traces to print can be
-# dynamically changes via debugfs in the range 1 => CFG_TEE_CORE_LOG_LEVEL
+# Log levels for the TEE core and user-mode TAs
+# Defines which messages are displayed on the secure console
+# 0: none
+# 1: error
+# 2: error + warning
+# 3: error + warning + debug
+# 4: error + warning + debug + flow
 CFG_TEE_CORE_LOG_LEVEL ?= 1
-
-# TA and TEECore log level
-# Supported values: 0 (no traces) to 4 (all traces)
-# If CFG_TEE_DRV_DEBUGFS is set, the level of traces to print can be
-# dynamically changes via debugfs in the range 1 => CFG_TEE_TA_LOG_LEVEL
 CFG_TEE_TA_LOG_LEVEL ?= 1
 
 # TA enablement


### PR DESCRIPTION
The configuration variable CFG_TEE_DRV_DEBUGFS was used by an older
version of the older OP-TEE linux driver, before commit 724298b6e425
("Linux driver refactoring") [1]. It is now obsolete, so remove it.

The text explaining how to set log levels is also reworded slightly.

Link: [1] https://github.com/OP-TEE/optee_linuxdriver/commit/724298b6e425
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
