### PR TITLE
core: add missing interrupt masking in get/set user map for LPAE

### DIFF
--- a/core/arch/arm/include/kernel/misc.h
+++ b/core/arch/arm/include/kernel/misc.h
@@ -29,11 +29,23 @@
 #ifndef KERNEL_MISC_H
 #define KERNEL_MISC_H
 
-#include <types_ext.h>
 #include <arm.h>
+#include <assert.h>
 #include <kernel/thread.h>
+#include <types_ext.h>
 
-size_t get_core_pos(void);
+size_t __get_core_pos(void);
+
+static inline size_t get_core_pos(void)
+{
+	/*
+	 * Foreign interrupts must be disabled before playing with current
+	 * core since we otherwise may be rescheduled to a different core.
+	 */
+	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
+	return __get_core_pos();
+}
+
 size_t get_core_pos_mpidr(uint32_t mpidr);
 
 uint32_t read_mode_sp(int cpu_mode);

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -88,7 +88,7 @@ END_FUNC reset_vect_table
 
 	.macro cpu_is_ready
 #ifdef CFG_BOOT_SYNC_CPU
-	bl	get_core_pos
+	bl	__get_core_pos
 	lsl	r0, r0, #2
 	ldr	r1,=sem_cpu_sync
 	ldr	r2, =SEM_CPU_READY
@@ -226,7 +226,7 @@ UNWIND(	.cantunwind)
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 	b	reset_primary
 #else
-	bl	get_core_pos
+	bl	__get_core_pos
 	cmp	r0, #0
 	beq	reset_primary
 	b	reset_secondary
@@ -240,7 +240,7 @@ KEEP_INIT _start
 	 * sp is assigned stack_tmp_export + cpu_id * stack_tmp_stride
 	 */
 	.macro set_sp
-		bl	get_core_pos
+		bl	__get_core_pos
 		cmp	r0, #CFG_TEE_CORE_NB_CORE
 		/* Unsupported CPU, park it before it breaks something */
 		bge	unhandled_cpu

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -18,7 +18,7 @@
 	 * SP_EL1 is assigned thread_core_local[cpu_id]
 	 */
 	.macro set_sp
-		bl	get_core_pos
+		bl	__get_core_pos
 		cmp	x0, #CFG_TEE_CORE_NB_CORE
 		/* Unsupported CPU, park it before it breaks something */
 		bge	unhandled_cpu

--- a/core/arch/arm/kernel/misc_a32.S
+++ b/core/arch/arm/kernel/misc_a32.S
@@ -35,13 +35,13 @@
 /* Let platforms override this if needed */
 .weak get_core_pos_mpidr
 
-/* size_t get_core_pos(void); */
-FUNC get_core_pos , :
+/* size_t __get_core_pos(void); */
+FUNC __get_core_pos , :
 UNWIND(	.fnstart)
 	read_mpidr r0
 	b get_core_pos_mpidr
 UNWIND(	.fnend)
-END_FUNC get_core_pos
+END_FUNC __get_core_pos
 
 /* size_t get_core_pos_mpidr(uint32_t mpidr); */
 FUNC get_core_pos_mpidr , :

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -10,11 +10,11 @@
 /* Let platforms override this if needed */
 .weak get_core_pos_mpidr
 
-/* size_t get_core_pos(void); */
-FUNC get_core_pos , :
+/* size_t __get_core_pos(void); */
+FUNC __get_core_pos , :
 	mrs	x0, mpidr_el1
 	b get_core_pos_mpidr
-END_FUNC get_core_pos
+END_FUNC __get_core_pos
 
 /* size_t get_core_pos_mpidr(uint32_t mpidr); */
 FUNC get_core_pos_mpidr , :

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -866,9 +866,7 @@ void core_mmu_get_user_map(struct core_mmu_user_map *map)
 void core_mmu_set_user_map(struct core_mmu_user_map *map)
 {
 	uint64_t ttbr;
-	uint32_t daif = read_daif();
-
-	write_daif(daif | DAIF_AIF);
+	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
 	ttbr = read_ttbr0_el1();
 	/* Clear ASID */
@@ -898,7 +896,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 
 	tlbi_all();
 
-	write_daif(daif);
+	thread_unmask_exceptions(exceptions);
 }
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)

--- a/core/arch/arm/plat-sunxi/entry.S
+++ b/core/arch/arm/plat-sunxi/entry.S
@@ -64,7 +64,7 @@ UNWIND(	.cantunwind)
 	write_vbar r0
 	
 	mov	r4, r1
-	bl	get_core_pos
+	bl	__get_core_pos
 	ldr	r1, =stack_tmp_stride
 	ldr	r1, [r1]
 	mul	r1, r0, r1

--- a/core/arch/arm/plat-sunxi/smp_boot.S
+++ b/core/arch/arm/plat-sunxi/smp_boot.S
@@ -63,7 +63,7 @@ UNWIND(	.cantunwind)
 	write_vbar r0
 
 	/* Setup tmp stack */
-	bl	get_core_pos
+	bl	__get_core_pos
 	ldr	r1, =stack_tmp_stride
 	ldr	r1, [r1]
 	mul	r1, r0, r1

--- a/core/arch/arm/plat-ti/a9_plat_init.S
+++ b/core/arch/arm/plat-ti/a9_plat_init.S
@@ -76,7 +76,7 @@ UNWIND(	.cantunwind)
 	mov	r3, r5
 
 	/* Setup tmp stack */
-	bl	get_core_pos
+	bl	__get_core_pos
 	cmp	r0, #CFG_TEE_CORE_NB_CORE
 	/* Unsupported CPU, park it before it breaks something */
 unhandled_cpu:

--- a/core/arch/arm/sm/pm_a32.S
+++ b/core/arch/arm/sm/pm_a32.S
@@ -120,7 +120,7 @@ UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
 	cpsid	aif
 
-	/* Call into the runtime address of get_core_pos */
+	/* Call into the runtime address of __get_core_pos */
 	adr	r0, _core_pos
 	ldr	r1, [r0]
 	add	r0, r0, r1
@@ -151,15 +151,15 @@ END_FUNC sm_pm_cpu_resume
  * The following will be located in text section whose attribute is
  * marked as readonly, but we only need to read here
  * _suspend_sp stores the offset between thread_core_local to _suspend_sp.
- * _core_pos stores the offset between get_core_pos to _core_pos.
+ * _core_pos stores the offset between __get_core_pos to _core_pos.
  */
 .align 2
 .extern thread_core_local
 _suspend_sp:
 	.long	thread_core_local - .
-.extern get_core_pos
+.extern __get_core_pos
 _core_pos:
-	.long	get_core_pos - .
+	.long	__get_core_pos - .
 
 /*
  * void sm_do_cpu_do_resume(paddr suspend_regs) __noreturn;


### PR DESCRIPTION
strange that we did saw issues before...
maybe i missed something.

The proposed fixes were found from a review of the use of `get_core_pos()` in optee_os.