### PR TITLE
core: thread_a64.S: fix gcc 4.9 compile error

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -775,13 +775,14 @@ LOCAL_FUNC el0_sync_abort , :
 	/* Restore x2 to x3 */
 	load_xregs sp, THREAD_CORE_LOCAL_X2, 2, 3
 
-	b_if_spsr_is_el0 w0, eret_to_el0
+	b_if_spsr_is_el0 w0, 1f
 
 	/* Restore x0 to x1 */
 	load_xregs sp, THREAD_CORE_LOCAL_X0, 0, 1
 
 	/* Return from exception */
 	eret
+1:	b	eret_to_el0
 END_FUNC el0_sync_abort
 
 /* The handler of foreign interrupt. */
@@ -925,13 +926,14 @@ END_FUNC el0_sync_abort
 	mrs	x0, spsr_el1
 	/* Restore x2..x3 */
 	load_xregs sp, THREAD_CORE_LOCAL_X2, 2, 3
-	b_if_spsr_is_el0 w0, eret_to_el0
+	b_if_spsr_is_el0 w0, 1f
 
 	/* Restore x0..x1 */
 	load_xregs sp, THREAD_CORE_LOCAL_X0, 0, 1
 
 	/* Return from exception */
 	eret
+1:	b	eret_to_el0
 .endm
 
 LOCAL_FUNC elx_irq , :


### PR DESCRIPTION
Fixes compile errors
out/arm-plat-hikey/core/arch/arm/kernel/thread_a64.o: In function `el0_sync_abort':
/home/bla/optee_os/core/arch/arm/kernel/thread_a64.S:778:(.text.el0_sync_abort+0xf4): relocation truncated to fit: R_AARCH64_TSTBR14 against `.text.thread_vect_table'
out/arm-plat-hikey/core/arch/arm/kernel/thread_a64.o: In function `elx_fiq':
/home/bla/optee_os/core/arch/arm/kernel/thread_a64.S:949:(.text.elx_fiq+0x9c): relocation truncated to fit: R_AARCH64_TSTBR14 against `.text.thread_vect_table'
make: *** [out/arm-plat-hikey/core/tee.elf] Error 1
experienced with some gcc 4.9 compiler

Fixes: https://github.com/OP-TEE/optee_os/issues/2067
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
