### PR TITLE
core: arm32: sm_a32.S: fix assembly errors

### DIFF
--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -351,16 +351,16 @@ UNWIND(	.fnstart)
 	ubfx	r2, r1, #MIDR_PRIMARY_PART_NUM_SHIFT, \
 			#MIDR_PRIMARY_PART_NUM_WIDTH
 
-	mov	r3, #CORTEX_A8_PART_NUM
+	movw	r3, #CORTEX_A8_PART_NUM
 	cmp	r2, r3
-	movne	r3, #CORTEX_A9_PART_NUM
+	movwne	r3, #CORTEX_A9_PART_NUM
 	cmpne	r2, r3
-	movne	r3, #CORTEX_A17_PART_NUM
+	movwne	r3, #CORTEX_A17_PART_NUM
 	cmpne	r2, r3
 	ldreq	r0, =sm_vect_table_bpiall
 	beq	2f
 
-	mov	r3, #CORTEX_A15_PART_NUM
+	movw	r3, #CORTEX_A15_PART_NUM
 	cmp	r2, r3
 	ldreq	r0, =sm_vect_table_a15
 	beq	2f


### PR DESCRIPTION
Fixes assembly error:
AS out/arm/core/arch/arm/sm/sm_a32.o
core/arch/arm/sm/sm_a32.S: Assembler messages:
core/arch/arm/sm/sm_a32.S:354: Error: invalid constant (c08) after fixup
core/arch/arm/sm/sm_a32.S:356: Error: invalid constant (c09) after fixup
core/arch/arm/sm/sm_a32.S:358: Error: invalid constant (c0e) after fixup
core/arch/arm/sm/sm_a32.S:363: Error: invalid constant (c0f) after fixup
mk/compile.mk:146: recipe for target 'out/arm/core/arch/arm/sm/sm_a32.o' failed

Fixes: 2ac6322d1ab1 ("core: arm32: sm: runtime selection of spectre workaround")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
