### PR TITLE
ltc: ctr: update pt and ct after acceleration

### DIFF
--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
@@ -65,7 +65,7 @@ int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
    if ((err = cipher_is_valid(ctr->cipher)) != CRYPT_OK) {
        return err;
    }
-   
+
    /* is blocklen/padlen valid? */
    if (ctr->blocklen < 1 || ctr->blocklen > (int)sizeof(ctr->ctr) ||
        ctr->padlen   < 0 || ctr->padlen   > (int)sizeof(ctr->pad)) {
@@ -77,12 +77,14 @@ int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
       return CRYPT_INVALID_ARG;
    }
 #endif
-   
+
    /* handle acceleration only if pad is empty, accelerator is present and length is >= a block size */
    if ((ctr->padlen == ctr->blocklen) && cipher_descriptor[ctr->cipher]->accel_ctr_encrypt != NULL && (len >= (unsigned long)ctr->blocklen)) {
       if ((err = cipher_descriptor[ctr->cipher]->accel_ctr_encrypt(pt, ct, len/ctr->blocklen, ctr->ctr, ctr->mode, &ctr->key)) != CRYPT_OK) {
          return err;
       }
+      pt += (len / ctr->blocklen) * ctr->blocklen;
+      ct += (len / ctr->blocklen) * ctr->blocklen;
       len %= ctr->blocklen;
    }
 
@@ -126,7 +128,7 @@ int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
        ctr->padlen = ctr->blocklen;
        continue;
       }
-#endif    
+#endif
       *ct++ = *pt++ ^ ctr->pad[ctr->padlen++];
       --len;
    }


### PR DESCRIPTION
Problem occurs in the condition of the following case:

1st decryption:
Decrypt a ciphertext whose length is a multiple of the block size (16B)
(len = n * block_size)
2nd decryption:
Decrypt the continuing ciphertext whose length is not a multiple of the
block size
(len = m * block_size + l)

In this case accel_ctr_encrypt() is firstly used at the 2nd decryption.
If pt and ct are not updated, the top (l = len % block_size) bytes of
decryption result are sometimes destroyed.

Reported-by: Tetsuya Yoshizaki <yoshizaki.tetsuya@socionext.com>
Signed-off-by: Tetsuya Yoshizaki <yoshizaki.tetsuya@socionext.com>
Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
