### PR TITLE
core: prevent crash in tee_mmu_final() on TA loading error

### DIFF
--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -676,6 +676,9 @@ void tee_mmu_rem_rwmem(struct user_ta_ctx *utc, struct mobj *mobj, vaddr_t va)
  */
 void tee_mmu_final(struct user_ta_ctx *utc)
 {
+	if (!utc->mmu)
+		return;
+
 	/* clear MMU entries to avoid clash when asid is reused */
 	tlbi_asid(utc->mmu->asid);
 


### PR DESCRIPTION
If the creation of the TA execution context fails before the mapping
directives are initialized, tee_mmu_final() will be called with the TA
context field mmu being NULL.

This change allows tee_mmu_final() to be called with uninitialized
mapping resources without crashing the core.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
