### PR TITLE
secstor: fix memory leak in install_ta()

### DIFF
--- a/core/arch/arm/pta/secstor_ta_mgmt.c
+++ b/core/arch/arm/pta/secstor_ta_mgmt.c
@@ -120,10 +120,10 @@ static TEE_Result install_ta(struct shdr *shdr, const uint8_t *nw,
 
 	res = crypto_hash_final(hash_ctx, hash_algo, buf, shdr->hash_size);
 	if (res)
-		goto err_free_hash_ctx;
+		goto err_ta_finalize;
 	if (buf_compare_ct(buf, SHDR_GET_HASH(shdr), shdr->hash_size)) {
 		res = TEE_ERROR_SECURITY;
-		goto err_free_hash_ctx;
+		goto err_ta_finalize;
 	}
 
 	crypto_hash_free_ctx(hash_ctx, hash_algo);


### PR DESCRIPTION
If signature check failed, we need to close tadb session first.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

This fixes #2095 
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
