### PR TITLE
Revert "core: fine grained tee_ta_mutex locking"

### DIFF
--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -58,7 +58,8 @@ static inline struct pseudo_ta_ctx *to_pseudo_ta_ctx(struct tee_ta_ctx *ctx)
 	return container_of(ctx, struct pseudo_ta_ctx, ctx);
 }
 
-TEE_Result pseudo_ta_get_ctx(const TEE_UUID *uuid, struct tee_ta_ctx **ctx);
+TEE_Result tee_ta_init_pseudo_ta_session(const TEE_UUID *uuid,
+			struct tee_ta_session *s);
 
 #endif /* KERNEL_PSEUDO_TA_H */
 

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -60,11 +60,13 @@ static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
 struct user_ta_store_ops;
 
 #ifdef CFG_WITH_USER_TA
-TEE_Result user_ta_get_ctx(const TEE_UUID *uuid, struct tee_ta_ctx **ctx);
+TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
+			struct tee_ta_session *s);
 TEE_Result tee_ta_register_ta_store(struct user_ta_store_ops *ops);
 #else
-static inline TEE_Result user_ta_get_ctx(const TEE_UUID *uuid __unused,
-					 struct tee_ta_ctx **ctx __unused)
+static inline TEE_Result tee_ta_init_user_ta_session(
+			const TEE_UUID *uuid __unused,
+			struct tee_ta_session *s __unused)
 {
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }

--- a/core/arch/arm/kernel/pseudo_ta.c
+++ b/core/arch/arm/kernel/pseudo_ta.c
@@ -279,8 +279,12 @@ err:
 
 service_init(verify_pseudo_tas_conformance);
 
-/* Initializes and returns a TA context based on the UUID of a pseudo TA. */
-TEE_Result pseudo_ta_get_ctx(const TEE_UUID *uuid, struct tee_ta_ctx **ctx_ret)
+/*-----------------------------------------------------------------------------
+ * Initialises a session based on the UUID or ptr to the ta
+ * Returns ptr to the session (ta_session) and a TEE_Result
+ *---------------------------------------------------------------------------*/
+TEE_Result tee_ta_init_pseudo_ta_session(const TEE_UUID *uuid,
+			struct tee_ta_session *s)
 {
 	struct pseudo_ta_ctx *stc = NULL;
 	struct tee_ta_ctx *ctx;
@@ -305,13 +309,13 @@ TEE_Result pseudo_ta_get_ctx(const TEE_UUID *uuid, struct tee_ta_ctx **ctx_ret)
 	ctx = &stc->ctx;
 
 	ctx->ref_count = 1;
+	s->ctx = ctx;
 	ctx->flags = ta->flags;
 	stc->pseudo_ta = ta;
 	ctx->uuid = ta->uuid;
 	ctx->ops = &pseudo_ta_ops;
-	tee_ta_register_ctx(ctx);
+	TAILQ_INSERT_TAIL(&tee_ctxes, ctx, link);
 
-	*ctx_ret = ctx;
 	DMSG("%s : %pUl", stc->pseudo_ta->name, (void *)&ctx->uuid);
 
 	return TEE_SUCCESS;

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -320,7 +320,7 @@ static TEE_Result ta_load(const TEE_UUID *uuid,
 	utc->entry_func = ta_head->entry.ptr64;
 	utc->ctx.ref_count = 1;
 	condvar_init(&utc->ctx.busy_cv);
-	tee_ta_register_ctx(&utc->ctx);
+	TAILQ_INSERT_TAIL(&tee_ctxes, &utc->ctx, link);
 	*ta_ctx = &utc->ctx;
 
 	tee_mmu_set_ctx(NULL);
@@ -626,7 +626,8 @@ TEE_Result tee_ta_register_ta_store(struct user_ta_store_ops *ops)
 	return TEE_SUCCESS;
 }
 
-TEE_Result user_ta_get_ctx(const TEE_UUID *uuid, struct tee_ta_ctx **ctx)
+TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
+			struct tee_ta_session *s)
 {
 	const struct user_ta_store_ops *store;
 	TEE_Result res;
@@ -634,11 +635,11 @@ TEE_Result user_ta_get_ctx(const TEE_UUID *uuid, struct tee_ta_ctx **ctx)
 	SLIST_FOREACH(store, &uta_store_list, link) {
 		DMSG("Lookup user TA %pUl (%s)", (void *)uuid,
 		     store->description);
-		res = ta_load(uuid, store, ctx);
+		res = ta_load(uuid, store, &s->ctx);
 		if (res == TEE_ERROR_ITEM_NOT_FOUND)
 			continue;
 		if (res == TEE_SUCCESS)
-			(*ctx)->ops = &user_ta_ops;
+			s->ctx->ops = &user_ta_ops;
 		else
 			DMSG("res=0x%x", res);
 		return res;

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -129,7 +129,10 @@ struct tee_ta_session {
 #endif
 };
 
-void tee_ta_register_ctx(struct tee_ta_ctx *ctx);
+/* Registered contexts */
+extern struct tee_ta_ctx_head tee_ctxes;
+
+extern struct mutex tee_ta_mutex;
 
 TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 			       struct tee_ta_session **sess,


### PR DESCRIPTION
Commit 99f969dd6c99 ("core: fine grained tee_ta_mutex locking") fixes a
deadlock that can occur if a TA is loaded while not enough page tables
are available in pgt_cache to map the context. But it also splits up a
big critical section and there's obviously a few hidden dependencies
towards tee_ta_mutex causing stability issues with the pager. Running
'while xtest 1013; do true; done' in AArch64 with at least three
threads running in parallel will ultimately fail.

Therefore, revert the fine grained locking commit until the race
conditions are sorted out.

Reported-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
