### PR TITLE
core: fix handling of NULL memory references by Internal Client API

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -622,7 +622,7 @@ static TEE_Result tee_svc_copy_param(struct tee_ta_session *sess,
 			va = (void *)param->u[n].mem.offs;
 			s = param->u[n].mem.size;
 			if (!va) {
-				if (!s)
+				if (s)
 					return TEE_ERROR_BAD_PARAMETERS;
 				break;
 			}


### PR DESCRIPTION
GlobalPlatform TEE Internal Core API v1.1.2 section 4.9.4 states that
parameters of type *_MEMREF_* can have memref.buffer == NULL, provided
that memref.size is zero.

The corresponding test in tee_svc_copy_param() is backwards, so reverse
it.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Reported-by: Kevin Peng <kevinp@marvell.com>
Link: https://github.com/OP-TEE/optee_os/issues/2105
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (QEMU)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
