### PR TITLE
arm32: enable ACTLR_CA8_ENABLE_INVALIDATE_BTB

### DIFF
--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -87,6 +87,8 @@
 
 /* Only valid for Cortex-A15 */
 #define ACTLR_CA15_ENABLE_INVALIDATE_BTB	BIT(0)
+/* Only valid for Cortex-A8 */
+#define ACTLR_CA8_ENABLE_INVALIDATE_BTB		BIT(6)
 
 #define ACTLR_SMP	BIT32(6)
 

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -208,7 +208,7 @@ END_FUNC reset_vect_table
 	mov	r7, r1
 	.endm
 
-	.macro maybe_init_ca15_spectre_workaround
+	.macro maybe_init_spectre_workaround
 #if !defined(CFG_WITH_ARM_TRUSTED_FW) && \
     (defined(CFG_CORE_WORKAROUND_SPECTRE_BP) || \
      defined(CFG_CORE_WORKAROUND_SPECTRE_BP_SEC))
@@ -218,11 +218,19 @@ END_FUNC reset_vect_table
 	bne	1f
 	ubfx	r1, r0, #MIDR_PRIMARY_PART_NUM_SHIFT, \
 			#MIDR_PRIMARY_PART_NUM_WIDTH
+
+	movw	r2, #CORTEX_A8_PART_NUM
+	cmp	r1, r2
+	moveq	r2, #ACTLR_CA8_ENABLE_INVALIDATE_BTB
+	beq	2f
+
 	movw	r2, #CORTEX_A15_PART_NUM
 	cmp	r1, r2
-	bne	1f
+	moveq	r2, #ACTLR_CA15_ENABLE_INVALIDATE_BTB
+	bne	1f	/* Skip it for all other CPUs */
+2:
 	read_actlr r0
-	orr	r0, r0, #ACTLR_CA15_ENABLE_INVALIDATE_BTB
+	orr	r0, r0, r2
 	write_actlr r0
 	isb
 1:
@@ -237,7 +245,7 @@ UNWIND(	.cantunwind)
 
 	/* Early ARM secure MP specific configuration */
 	bl	plat_cpu_reset_early
-	maybe_init_ca15_spectre_workaround
+	maybe_init_spectre_workaround
 
 	set_sctlr
 	isb

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -812,6 +812,8 @@ exception_vector_a15:
 	bne	1f
 	/*
 	 * Invalidate the branch predictor for the current processor.
+	 * For Cortex-A8 ACTLR[6] has to be set to 1 for BPIALL to be
+	 * effective.
 	 * Note that the BPIALL instruction is not effective in
 	 * invalidating the branch predictor on Cortex-A15. For that CPU,
 	 * set ACTLR[0] to 1 during early processor initialisation, and

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -286,6 +286,8 @@ sm_vect_table_a15:
 	vector_prologue_spectre
 	/*
 	 * Invalidate the branch predictor for the current processor.
+	 * For Cortex-A8 ACTLR[6] has to be set to 1 for BPIALL to be
+	 * effective.
 	 * Note that the BPIALL instruction is not effective in
 	 * invalidating the branch predictor on Cortex-A15. For that CPU,
 	 * set ACTLR[0] to 1 during early processor initialisation, and


### PR DESCRIPTION
Enables ACTLR_CA8_ENABLE_INVALIDATE_BTB (ACTLR[6]) in generic boot if
compiled with CFG_CORE_WORKAROUND_SPECTRE_BP or
CFG_CORE_WORKAROUND_SPECTRE_BP_SEC and the cpu is discovered to be
Cortex-A8.

Fixes CVE-2017-5715
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
