### PR TITLE
cscope: skip in tree out directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,5 +95,5 @@ clean:
 cscope:
 	@echo '  CSCOPE  .'
 	${q}rm -f cscope.*
-	${q}find $(PWD) -name "*.[chSs]" > cscope.files
+	${q}find $(PWD) -name "*.[chSs]" | grep -v "$(PWD)/out" > cscope.files
 	${q}cscope -b -q -k


### PR DESCRIPTION
By default if nothing is specified OP-TEE is built keeping the output under
the directory "out" in the source tree. With this patch the cscope database
will not include those files.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
