### PR TITLE
virt: add very initial virtualization support

### DIFF
--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -53,4 +53,6 @@ srcs-y += unwind_arm32.c
 srcs-$(CFG_ARM64_core) += unwind_arm64.c
 endif
 
+srcs-$(CFG_VIRTUALIZATION) += virtualization.c
+
 srcs-y += link_dummies.c

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -578,7 +578,7 @@ void thread_handle_fast_smc(struct thread_smc_args *args)
 	thread_check_canaries();
 
 #ifdef CFG_VIRTUALIZATION
-	if (!check_client(args->a7))
+	if (!check_virt_guest(args->a7))
 		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
 #endif
 
@@ -592,7 +592,7 @@ void thread_handle_std_smc(struct thread_smc_args *args)
 	thread_check_canaries();
 
 #ifdef CFG_VIRTUALIZATION
-	if (!check_client(args->a7))
+	if (!check_virt_guest(args->a7))
 		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
 #endif
 

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#include <compiler.h>
+#include <platform_config.h>
+#include <kernel/panic.h>
+#include <kernel/virtualization.h>
+#include <sm/optee_smc.h>
+
+static uint16_t current_client_id = 0;
+
+uint32_t client_created(uint16_t client_id)
+{
+	if (current_client_id != 0)
+		return OPTEE_SMC_RETURN_ENOTAVAIL;
+
+	current_client_id = client_id;
+
+	return OPTEE_SMC_RETURN_OK;
+}
+
+uint32_t client_destroyed(uint16_t client_id)
+{
+	if (current_client_id == client_id)
+		panic("Hypervisor tries to remove client");
+
+	return OPTEE_SMC_RETURN_OK;
+}
+
+bool check_client(uint16_t client_id)
+{
+	return client_id == 0 || client_id == current_client_id;
+}

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -4,29 +4,45 @@
 #include <platform_config.h>
 #include <kernel/panic.h>
 #include <kernel/virtualization.h>
+#include <kernel/spinlock.h>
 #include <sm/optee_smc.h>
 
 static uint16_t current_client_id = 0;
+static unsigned int client_id_lock = SPINLOCK_UNLOCK;
 
-uint32_t client_created(uint16_t client_id)
+uint32_t virt_guest_created(uint16_t client_id)
 {
-	if (current_client_id != 0)
+	/* This function should be called only with masked exceptions */
+	assert(thread_get_exceptions() == THREAD_EXCP_ALL);
+
+	cpu_spin_lock(&client_id_lock);
+
+	if (current_client_id != 0) {
+		cpu_spin_unlock(&client_id_lock);
 		return OPTEE_SMC_RETURN_ENOTAVAIL;
+	}
 
 	current_client_id = client_id;
+	cpu_spin_unlock(&client_id_lock);
 
 	return OPTEE_SMC_RETURN_OK;
 }
 
-uint32_t client_destroyed(uint16_t client_id)
+uint32_t virt_guest_destroyed(uint16_t client_id)
 {
+	/* This function should be called only with masked exceptions */
+	assert(thread_get_exceptions() == THREAD_EXCP_ALL);
+
+	cpu_spin_lock(&client_id_lock);
+
 	if (current_client_id == client_id)
 		panic("Hypervisor tries to remove client");
 
+	cpu_spin_unlock(&client_id_lock);
 	return OPTEE_SMC_RETURN_OK;
 }
 
-bool check_client(uint16_t client_id)
+bool check_virt_guest(uint16_t client_id)
 {
 	return client_id == 0 || client_id == current_client_id;
 }

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+/* Copyright (c) 2018 EPAM Systems. All rights reserved. */
 
 #include <compiler.h>
 #include <platform_config.h>
@@ -6,6 +7,8 @@
 #include <kernel/virtualization.h>
 #include <kernel/spinlock.h>
 #include <sm/optee_smc.h>
+
+#define INVALID_CLIENT_ID		0xFFFF
 
 static uint16_t current_client_id = 0;
 static unsigned int client_id_lock = SPINLOCK_UNLOCK;
@@ -36,7 +39,7 @@ uint32_t virt_guest_destroyed(uint16_t client_id)
 	cpu_spin_lock(&client_id_lock);
 
 	if (current_client_id == client_id)
-		panic("Hypervisor tries to remove client");
+		current_client_id = INVALID_CLIENT_ID;
 
 	cpu_spin_unlock(&client_id_lock);
 	return OPTEE_SMC_RETURN_OK;

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -33,6 +33,7 @@
 #include <sm/optee_smc.h>
 #include <kernel/generic_boot.h>
 #include <kernel/tee_l2cc_mutex.h>
+#include <kernel/virtualization.h>
 #include <kernel/misc.h>
 #include <mm/core_mmu.h>
 
@@ -155,6 +156,33 @@ static void tee_entry_boot_secondary(struct thread_smc_args *args)
 #endif
 }
 
+#if defined(CFG_VIRTUALIZATION)
+static void tee_entry_vm_created(struct thread_smc_args *args)
+{
+	uint16_t client_id = args->a1;
+
+	/* Only hypervisor can issue this request */
+	if (args->a7 != 0) {
+		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
+		return;
+	}
+
+	args->a0 = client_created(client_id);
+}
+
+static void tee_entry_vm_destroyed(struct thread_smc_args *args)
+{
+	uint16_t client_id = args->a1;
+
+	/* Only hypervisor can issue this request */
+	if (args->a7 != 0)
+		return;
+
+	client_destroyed(client_id);
+	args->a0 = OPTEE_SMC_RETURN_OK;
+}
+#endif
+
 void tee_entry_fast(struct thread_smc_args *args)
 {
 	switch (args->a0) {
@@ -196,6 +224,15 @@ void tee_entry_fast(struct thread_smc_args *args)
 		tee_entry_boot_secondary(args);
 		break;
 
+#if defined(CFG_VIRTUALIZATION)
+	case OPTEE_SMC_VM_CREATED:
+		tee_entry_vm_created(args);
+		break;
+	case OPTEE_SMC_VM_DESTROYED:
+		tee_entry_vm_destroyed(args);
+		break;
+#endif
+
 	default:
 		args->a0 = OPTEE_SMC_RETURN_UNKNOWN_FUNCTION;
 		break;
@@ -209,7 +246,13 @@ size_t tee_entry_generic_get_api_call_count(void)
 	 * target has additional calls it will call this function and
 	 * add the number of calls the target has added.
 	 */
-	return 9;
+	size_t ret = 9;
+
+#if defined(CFG_VIRTUALIZATION)
+	ret += 2;
+#endif
+
+	return ret;
 }
 
 void __weak tee_entry_get_api_call_count(struct thread_smc_args *args)

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -167,7 +167,7 @@ static void tee_entry_vm_created(struct thread_smc_args *args)
 		return;
 	}
 
-	args->a0 = client_created(client_id);
+	args->a0 = virt_guest_created(client_id);
 }
 
 static void tee_entry_vm_destroyed(struct thread_smc_args *args)
@@ -178,7 +178,7 @@ static void tee_entry_vm_destroyed(struct thread_smc_args *args)
 	if (args->a7 != 0)
 		return;
 
-	client_destroyed(client_id);
+	virt_guest_destroyed(client_id);
 	args->a0 = OPTEE_SMC_RETURN_OK;
 }
 #endif

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -162,7 +162,7 @@ static void tee_entry_vm_created(struct thread_smc_args *args)
 	uint16_t client_id = args->a1;
 
 	/* Only hypervisor can issue this request */
-	if (args->a7 != 0) {
+	if (args->a7 != HYP_CLIENT_ID) {
 		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
 		return;
 	}
@@ -175,7 +175,7 @@ static void tee_entry_vm_destroyed(struct thread_smc_args *args)
 	uint16_t client_id = args->a1;
 
 	/* Only hypervisor can issue this request */
-	if (args->a7 != 0)
+	if (args->a7 != HYP_CLIENT_ID)
 		return;
 
 	virt_guest_destroyed(client_id);

--- a/core/include/kernel/virtualization.h
+++ b/core/include/kernel/virtualization.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#ifndef KERNEL_VIRTUALIZATION_H
+#define KERNEL_VIRTUALIZATION_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+uint32_t client_created(uint16_t client_id);
+uint32_t client_destroyed(uint16_t client_id);
+bool check_client(uint16_t client_id);
+
+#endif	/* KERNEL_VIRTUALIZATION_H */

--- a/core/include/kernel/virtualization.h
+++ b/core/include/kernel/virtualization.h
@@ -6,8 +6,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-uint32_t client_created(uint16_t client_id);
-uint32_t client_destroyed(uint16_t client_id);
-bool check_client(uint16_t client_id);
+uint32_t virt_guest_created(uint16_t client_id);
+uint32_t virt_guest_destroyed(uint16_t client_id);
+bool check_virt_guest(uint16_t client_id);
 
 #endif	/* KERNEL_VIRTUALIZATION_H */

--- a/core/include/kernel/virtualization.h
+++ b/core/include/kernel/virtualization.h
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
+/* Copyright (c) 2018 EPAM Systems. All rights reserved. */
 
 #ifndef KERNEL_VIRTUALIZATION_H
 #define KERNEL_VIRTUALIZATION_H

--- a/core/include/kernel/virtualization.h
+++ b/core/include/kernel/virtualization.h
@@ -7,6 +7,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define HYP_CLIENT_ID		0
+#define INVALID_CLIENT_ID	0xFFFF
+
 uint32_t virt_guest_created(uint16_t client_id);
 uint32_t virt_guest_destroyed(uint16_t client_id);
 bool check_virt_guest(uint16_t client_id);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -295,3 +295,7 @@ CFG_DYN_SHM_CAP ?= y
 # Enables support for larger physical addresses, that is, it will define
 # paddr_t as a 64-bit type.
 CFG_CORE_LARGE_PHYS_ADDR ?= n
+
+# Enable virtualization support. OP-TEE will not work without compatible
+# hypervisor if this option is enabled.
+CFG_VIRTUALIZATION ?= n


### PR DESCRIPTION
This patch enables vary basic virtualization support in OP-TEE.

Added new configuration variable CFG_VIRTUALIZATION. If it is
enabled, OP-TEE will be built with virtualization support. It will
rely on hypervisor, which shold inform OP-TEE about a new guest
using OPTEE_SMC_VM_CREATED call.

Only one client is allowed right now and there is no way to
unregister it.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
