### PR TITLE
Makefile: Set ARCH := arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ $(foreach op,$(ops),$(eval override $(op)))
 endif
 
 # Make these default for now
-ARCH            ?= arm
+ARCH            := arm
 PLATFORM        ?= vexpress
 # Default value for PLATFORM_FLAVOR is set in plat-$(PLATFORM)/conf.mk
 ifeq ($O,)


### PR DESCRIPTION
The only value used for ARCH is `arm` at this point, not even `aarch64`, so
setting it immediately instead of only if absent to prevent build
errors should it be already defined to something else in the environment.

This can still be changed as an argument behind the `make` command of
course, but again, no other value is used or works other than `arm`.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
