### PR TITLE
Force ARCH to arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ SHELL = /bin/bash
 # (we include many *.cmd and *.d files).
 unexport MAKEFILE_LIST
 
+include mk/checkconf.mk
+
 .PHONY: all
 all:
 
@@ -35,7 +37,7 @@ $(foreach op,$(ops),$(eval override $(op)))
 endif
 
 # Make these default for now
-ARCH            ?= arm
+$(call force,ARCH,arm)
 PLATFORM        ?= vexpress
 # Default value for PLATFORM_FLAVOR is set in plat-$(PLATFORM)/conf.mk
 ifeq ($O,)

--- a/core/core.mk
+++ b/core/core.mk
@@ -6,7 +6,6 @@ sm-$(sm) := y
 
 arch-dir	:= core/arch/$(ARCH)
 platform-dir	:= $(arch-dir)/plat-$(PLATFORM)
-include mk/checkconf.mk
 include $(platform-dir)/conf.mk
 include mk/config.mk
 include core/arch/$(ARCH)/$(ARCH).mk


### PR DESCRIPTION
It is the only value used for now. No other value works, not even
`aarch64`.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
