### PR TITLE
core: lower debug verbosity on short buffer errors

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -642,8 +642,11 @@ TEE_Result tee_ta_invoke_command(TEE_ErrorOrigin *err,
 	}
 
 	tee_ta_clear_busy(sess->ctx);
-	if (res != TEE_SUCCESS)
+
+	/* Short buffer is not an effective error case */
+	if (res != TEE_SUCCESS && res != TEE_ERROR_SHORT_BUFFER)
 		DMSG("Error: %x of %d\n", res, *err);
+
 	return res;
 }
 


### PR DESCRIPTION
TEE_ERROR_SHORT_BUFFER is unlikely to be an unexpected error
code returned by a trusted application or a core service. Therefore
this change prevents debug "Error: " in short buffer case at completion
the the invoke_command request.