### PR TITLE
Rework MMU initialization.

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -384,15 +384,15 @@ bool core_mmu_find_table(vaddr_t va, unsigned max_level,
 		struct core_mmu_table_info *tbl_info);
 
 /*
- * core_mmu_prepare_small_page_mapping() - prepare target small page parent
- *	pgdir so that each of its entry can be used to map a page.
+ * core_mmu_entry_to_finer_grained() - divide mapping at current level into
+ *     smaller ones so memory can be mapped with finer granularity
  * @tbl_info:	table where target record located
  * @idx:	index of record for which a pdgir must be setup.
  * @secure:	true/false if pgdir maps secure/non-secure memory (32bit mmu)
  * @return true on successful, false on error
  */
-bool core_mmu_prepare_small_page_mapping(struct core_mmu_table_info *tbl_info,
-					 unsigned int idx, bool secure);
+bool core_mmu_entry_to_finer_grained(struct core_mmu_table_info *tbl_info,
+				     unsigned int idx, bool secure);
 
 void core_mmu_set_entry_primitive(void *table, size_t level, size_t idx,
 				  paddr_t pa, uint32_t attr);

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1343,8 +1343,8 @@ TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 				break;
 
 			/* This is supertable. Need to divide it. */
-			if (!core_mmu_prepare_small_page_mapping(&tbl_info, idx,
-								 secure))
+			if (!core_mmu_entry_to_finer_grained(&tbl_info, idx,
+							     secure))
 				panic("Failed to spread pgdir on small tables");
 		}
 

--- a/core/arch/arm/mm/core_mmu_private.h
+++ b/core/arch/arm/mm/core_mmu_private.h
@@ -15,6 +15,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 			     unsigned level, vaddr_t va_base, void *table);
 void core_mmu_populate_user_map(struct core_mmu_table_info *dir_info,
 				struct user_ta_ctx *utc);
+void core_mmu_map_region(struct tee_mmap_region *mm);
 
 static inline bool core_mmap_is_end_of_table(const struct tee_mmap_region *mm)
 {


### PR DESCRIPTION
This is the first part #2088 with squashed and rebased patches.

Basically, it initializes MMU in single place both for v7 and lpae, by using primitives from core_mmu_v7.c and core_mmu_lpae.c