### PR TITLE
core: crypto.c: crypto_*_free_ctx() stubs should allow NULL context

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -18,9 +18,10 @@ TEE_Result crypto_hash_alloc_ctx(void **ctx __unused, uint32_t algo __unused)
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
-void crypto_hash_free_ctx(void *ctx __unused, uint32_t algo __unused)
+void crypto_hash_free_ctx(void *ctx, uint32_t algo __unused)
 {
-	assert(0);
+	if (ctx)
+		assert(0);
 }
 
 void crypto_hash_copy_state(void *dst_ctx __unused, void *src_ctx __unused,
@@ -51,9 +52,10 @@ TEE_Result crypto_cipher_alloc_ctx(void **ctx __unused, uint32_t algo __unused)
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
-void crypto_cipher_free_ctx(void *ctx __unused, uint32_t algo __unused)
+void crypto_cipher_free_ctx(void *ctx, uint32_t algo __unused)
 {
-	assert(0);
+	if (ctx)
+		assert(0);
 }
 
 void crypto_cipher_copy_state(void *dst_ctx __unused, void *src_ctx __unused,
@@ -100,9 +102,10 @@ TEE_Result crypto_mac_alloc_ctx(void **ctx __unused, uint32_t algo __unused)
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
-void crypto_mac_free_ctx(void *ctx __unused, uint32_t algo __unused)
+void crypto_mac_free_ctx(void *ctx, uint32_t algo __unused)
 {
-	assert(0);
+	if (ctx)
+		assert(0);
 }
 
 void crypto_mac_copy_state(void *dst_ctx __unused, void *src_ctx __unused,
@@ -161,7 +164,8 @@ void crypto_authenc_free_ctx(void *ctx, uint32_t algo)
 		break;
 #endif
 	default:
-		assert(0);
+		if (ctx)
+			assert(0);
 	}
 }
 

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -405,7 +405,8 @@ void crypto_hash_free_ctx(void *ctx, uint32_t algo __unused)
 	 * Check that it's a supported algo, or crypto_hash_alloc_ctx()
 	 * could never have succeded above.
 	 */
-	assert(!hash_get_ctx_size(algo, &ctx_size));
+	if (ctx)
+		assert(!hash_get_ctx_size(algo, &ctx_size));
 	free(ctx);
 }
 
@@ -2012,7 +2013,8 @@ void crypto_cipher_free_ctx(void *ctx, uint32_t algo __maybe_unused)
 	 * Check that it's a supported algo, or crypto_cipher_alloc_ctx()
 	 * could never have succeded above.
 	 */
-	assert(!cipher_get_ctx_size(algo, &ctx_size));
+	if (ctx)
+		assert(!cipher_get_ctx_size(algo, &ctx_size));
 	free(ctx);
 }
 
@@ -2364,7 +2366,8 @@ void crypto_mac_free_ctx(void *ctx, uint32_t algo __maybe_unused)
 	 * Check that it's a supported algo, or crypto_mac_alloc_ctx()
 	 * could never have succeded above.
 	 */
-	assert(!mac_get_ctx_size(algo, &ctx_size));
+	if (ctx)
+		assert(!mac_get_ctx_size(algo, &ctx_size));
 	free(ctx);
 }
 


### PR DESCRIPTION
Update the crypto_*_free_ctx() functions so that they do nothing when
passed a NULL ctx. Allows for easier error handling.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
