### PR TITLE
make config: allow '+' character in file paths

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -17,7 +17,7 @@ define check-conf-h
 	cnf='$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,$1),			\
 		$(call cfg-make-define,$(var))))';		\
-	guard="_`echo $@ | tr -- -/. ___`_";			\
+	guard="_`echo $@ | tr -- -/.+ _`_";			\
 	mkdir -p $(dir $@);					\
 	echo "#ifndef $${guard}" >$@.tmp;			\
 	echo "#define $${guard}" >>$@.tmp;			\


### PR DESCRIPTION
Some build environment (i.e yocto) may use build directory path that
include a '+' character. This change allows such '+' character(s) to be
replaced with a '_' character in the conf.h macro.
