### PR TITLE
Remove unused guard string in check-conf-cmake

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -32,7 +32,6 @@ define check-conf-cmake
 	cnf='$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,$1),			\
 		$(call cfg-cmake-set,$(var))))';		\
-	guard="_`echo $@ | tr -- -/. ___`_";			\
 	mkdir -p $(dir $@);					\
 	echo "# auto-generated TEE configuration file" >$@.tmp; \
 	echo "# TEE version ${TEE_IMPL_VERSION}" >>$@.tmp; \


### PR DESCRIPTION
There is no need to compute a guard string when generating the CMake
configuration file. Obviously the line was mistakenly copied from
check-conf-h, so remove it.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
