### PR TITLE
ta_dev_kit.mk: define ENABLE_MDBG when CFG_TEE_TA_MALLOC_DEBUG is set

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -64,7 +64,16 @@ CFG_TEE_CORE_TA_TRACE ?= y
 # feature.
 CFG_TEE_CORE_USER_MEM_DEBUG ?= 1
 
-# If y, enable memory leak detection feature in bget memory allocator.
+# If y, enable the memory leak detection feature in the bget memory allocator.
+# When this feature is enabled, calling mdbg_check(1) will print a list of all
+# the currently allocated buffers and the location of the allocation (file and
+# line number).
+# Note: make sure the log level is high enough for the messages to show up on
+# the secure console! For instance:
+# - To debug user-mode (TA) allocations: build OP-TEE *and* the TA with:
+#   $ make CFG_TEE_TA_MALLOC_DEBUG=y CFG_TEE_TA_LOG_LEVEL=3
+# - To debug TEE core allocations: build OP-TEE with:
+#   $ make CFG_TEE_CORE_MALLOC_DEBUG=y CFG_TEE_CORE_LOG_LEVEL=3
 CFG_TEE_CORE_MALLOC_DEBUG ?= n
 CFG_TEE_TA_MALLOC_DEBUG ?= n
 

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -53,6 +53,13 @@ cflags$(sm)    := $($(sm)-platform-cflags) $(CFLAGS_$(sm))
 CFG_TEE_TA_LOG_LEVEL ?= 2
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 
+ifeq ($(CFG_TEE_TA_MALLOC_DEBUG),y)
+# TAs will automatically use debug versions of the malloc() functions
+# in libutils (malloc() will be re-defined as mdbg_malloc() etc.).
+# mdbg_check() will also be visible.
+cppflags$(sm) += -DENABLE_MDBG=1
+endif
+
 cppflags$(sm) += -I. -I$(ta-dev-kit-dir)/include
 
 libdirs += $(ta-dev-kit-dir)/lib

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -19,6 +19,8 @@ cppflags$(sm)	+= -include $(conf-file)
 # Config flags from mk/config.mk
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 ifeq ($(CFG_TEE_TA_MALLOC_DEBUG),y)
+# Build malloc debug code into libutils: (mdbg_malloc(), mdbg_free(),
+# mdbg_check(), etc.).
 cppflags$(sm) += -DENABLE_MDBG=1
 endif
 


### PR DESCRIPTION
In order to use the memory leak detection code, a user-mode TA needs
two things:
- A version of libutils.a that was built with malloc debug code. This
is taken care of by ta/ta.mk which sets ENABLE_MDBG=1 when
CFG_TEE_TA_MALLOC_DEBUG is 'y'.
- The proper declarations for malloc(), mdbg_malloc(), mdbg_check()
etc. in the header files when the TA is built. This patch adds the
missing definition of ENABLE_MDBG when CFG_TEE_TA_MALLOC_DEBUG is 'y'.

In addition, the usage of CFG_TEE_TA_MALLOC_DEBUG and
CFG_TEE_CORE_MALLOC_DEBUG is better documented in mk/conf.mk.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
