### PR TITLE
core: armv7: core_init_mmu_regs() init contextidr

### DIFF
--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -774,6 +774,12 @@ void core_init_mmu_regs(void)
 		   DACR_DOMAIN(1, DACR_DOMAIN_PERM_CLIENT));
 
 	/*
+	 * The value of CONTEXTIDR is initially undefined, set it 0 since
+	 * we don't have a user mode context to activate yet.
+	 */
+	write_contextidr(0);
+
+	/*
 	 * Enable lookups using TTBR0 and TTBR1 with the split of addresses
 	 * defined by TEE_MMU_TTBCR_N_VALUE.
 	 */


### PR DESCRIPTION
The value of CONTEXTIDR is initially undefined, initialize it with a
sane value.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
