### PR TITLE
core: arm: kern.ld.S: stop using PROVIDE()

### DIFF
--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -450,20 +450,19 @@ SECTIONS
 }
 
 /* Unpaged read-only memories */
-PROVIDE(__vcore_unpg_rx_start = __flatmap_unpg_rx_start);
-PROVIDE(__vcore_unpg_ro_start = __flatmap_unpg_ro_start);
+__vcore_unpg_rx_start = __flatmap_unpg_rx_start;
+__vcore_unpg_ro_start = __flatmap_unpg_ro_start;
 #ifdef CFG_CORE_RODATA_NOEXEC
-PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size);
-PROVIDE(__vcore_unpg_ro_size = __flatmap_unpg_ro_size);
+__vcore_unpg_rx_size = __flatmap_unpg_rx_size;
+__vcore_unpg_ro_size = __flatmap_unpg_ro_size;
 #else
-PROVIDE(__vcore_unpg_rx_size = __flatmap_unpg_rx_size +
-				__flatmap_unpg_ro_size);
-PROVIDE(__vcore_unpg_ro_size = 0);
+__vcore_unpg_rx_size = __flatmap_unpg_rx_size + __flatmap_unpg_ro_size;
+__vcore_unpg_ro_size = 0;
 #endif
 
 /* Unpaged read-write memory */
-PROVIDE(__vcore_unpg_rw_start = __flatmap_unpg_rw_start);
-PROVIDE(__vcore_unpg_rw_size = __flatmap_unpg_rw_size);
+__vcore_unpg_rw_start = __flatmap_unpg_rw_start;
+__vcore_unpg_rw_size = __flatmap_unpg_rw_size;
 
 #ifdef CFG_WITH_PAGER
 /*
@@ -476,24 +475,22 @@ PROVIDE(__vcore_unpg_rw_size = __flatmap_unpg_rw_size);
 		(__flatmap_init_ro_start + __flatmap_init_ro_size))
 
 /* Paged/init read-only memories */
-PROVIDE(__vcore_init_rx_start = __flatmap_init_rx_start);
-PROVIDE(__vcore_init_ro_start = __flatmap_init_ro_start);
+__vcore_init_rx_start = __flatmap_init_rx_start;
+__vcore_init_ro_start = __flatmap_init_ro_start;
 #ifdef CFG_CORE_RODATA_NOEXEC
-PROVIDE(__vcore_init_rx_size = __flatmap_init_rx_size);
-PROVIDE(__vcore_init_ro_size = __flatmap_init_ro_size +
-				__FLATMAP_PAGER_TRAILING_SPACE);
+__vcore_init_rx_size = __flatmap_init_rx_size;
+__vcore_init_ro_size = __flatmap_init_ro_size + __FLATMAP_PAGER_TRAILING_SPACE;
 #else
-PROVIDE(__vcore_init_rx_size = __flatmap_init_rx_size +
-				__flatmap_init_ro_size +
-				__FLATMAP_PAGER_TRAILING_SPACE);
-PROVIDE(__vcore_init_ro_size = 0);
+__vcore_init_rx_size = __flatmap_init_rx_size + __flatmap_init_ro_size +
+		       __FLATMAP_PAGER_TRAILING_SPACE;
+__vcore_init_ro_size = 0;
 #endif /* CFG_CORE_RODATA_NOEXEC */
 #endif /* CFG_WITH_PAGER */
 
 #ifdef CFG_CORE_SANITIZE_KADDRESS
-PROVIDE(__asan_map_start = (__asan_shadow_start / SMALL_PAGE_SIZE) *
-			   SMALL_PAGE_SIZE);
-PROVIDE(__asan_map_end = ((__asan_shadow_end - 1) / SMALL_PAGE_SIZE) *
-			 SMALL_PAGE_SIZE + SMALL_PAGE_SIZE);
-PROVIDE(__asan_map_size = __asan_map_end - __asan_map_start);
+__asan_map_start = (__asan_shadow_start / SMALL_PAGE_SIZE) *
+		   SMALL_PAGE_SIZE;
+__asan_map_end = ((__asan_shadow_end - 1) / SMALL_PAGE_SIZE) *
+		 SMALL_PAGE_SIZE + SMALL_PAGE_SIZE;
+__asan_map_size = __asan_map_end - __asan_map_start;
 #endif /*CFG_CORE_SANITIZE_KADDRESS*/


### PR DESCRIPTION
Stop using the PROVIDE() keyword in the linker script. The current usage
causes problems like:
out/arm-plat-vexpress/core/kern.ld:168: undefined symbol
`__asan_map_end' referenced in expression
make: *** [out/arm-plat-vexpress/core/tee.elf] Error 1

when compiled with certain flags and compilers.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
