### PR TITLE
Fix psci_cpu_on() to use context parameter

### DIFF
--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -34,9 +34,13 @@ void arm_cl2_config(vaddr_t pl310);
 void arm_cl2_enable(vaddr_t pl310);
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
-extern paddr_t ns_entry_addrs[];
+struct ns_entry_context {
+	uintptr_t entry_point;
+	uintptr_t context_id;
+};
+extern struct ns_entry_context ns_entry_contexts[];
 int generic_boot_core_release(size_t core_idx, paddr_t entry);
-paddr_t generic_boot_core_hpen(void);
+struct ns_entry_context *generic_boot_core_hpen(void);
 #endif
 
 void *get_dt_blob(void);

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -55,7 +55,7 @@
 #define PADDR_INVALID		ULONG_MAX
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
-paddr_t ns_entry_addrs[CFG_TEE_CORE_NB_CORE];
+struct ns_entry_context ns_entry_contexts[CFG_TEE_CORE_NB_CORE];
 static uint32_t spin_table[CFG_TEE_CORE_NB_CORE];
 #endif
 
@@ -889,7 +889,7 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry)
 	if (!core_idx || core_idx >= CFG_TEE_CORE_NB_CORE)
 		return -1;
 
-	ns_entry_addrs[core_idx] = entry;
+	ns_entry_contexts[core_idx].entry_point = entry;
 	dmb();
 	spin_table[core_idx] = 1;
 	dsb();
@@ -902,16 +902,16 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry)
  * spin until secondary boot request, then returns with
  * the secondary core entry address.
  */
-paddr_t generic_boot_core_hpen(void)
+struct ns_entry_context *generic_boot_core_hpen(void)
 {
 #ifdef CFG_PSCI_ARM32
-	return ns_entry_addrs[get_core_pos()];
+	return &ns_entry_contexts[get_core_pos()];
 #else
 	do {
 		wfe();
 	} while (!spin_table[get_core_pos()]);
 	dmb();
-	return ns_entry_addrs[get_core_pos()];
+	return &ns_entry_contexts[get_core_pos()];
 #endif
 }
 #endif

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -568,15 +568,20 @@ UNWIND(	.cantunwind)
 	cpu_is_ready
 
 #if defined (CFG_BOOT_SECONDARY_REQUEST)
-	/* generic_boot_core_hpen return value (r0) is ns entry point */
+	/*
+	 * generic_boot_core_hpen return value (r0) is address of
+	 * ns entry context structure
+	 */
 	bl	generic_boot_core_hpen
+	ldm	r0, {r0, r6}
 #else
 	mov	r0, r5		/* ns-entry address */
+	mov	r6, #0
 #endif
 	bl	generic_boot_init_secondary
 
 	mov	r0, #TEESMC_OPTEED_RETURN_ENTRY_DONE
-	mov	r1, #0
+	mov	r1, r6
 	mov	r2, #0
 	mov	r3, #0
 	mov	r4, #0

--- a/core/arch/arm/plat-imx/pm/psci.c
+++ b/core/arch/arm/plat-imx/pm/psci.c
@@ -49,7 +49,7 @@
 
 #ifdef CFG_BOOT_SECONDARY_REQUEST
 int psci_cpu_on(uint32_t core_idx, uint32_t entry,
-		uint32_t context_id __attribute__((unused)))
+		uint32_t context_id)
 {
 	uint32_t val;
 	vaddr_t va = core_mmu_get_va(SRC_BASE, MEM_AREA_IO_SEC);
@@ -61,7 +61,8 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 		return PSCI_RET_INVALID_PARAMETERS;
 
 	/* set secondary cores' NS entry addresses */
-	ns_entry_addrs[core_idx] = entry;
+	ns_entry_contexts[core_idx].entry_point = entry;
+	ns_entry_contexts[core_idx].context_id = context_id;
 
 	val = virt_to_phys((void *)TEE_TEXT_VA_START);
 	if (soc_is_imx7ds()) {

--- a/core/arch/arm/plat-imx/pm/psci.c
+++ b/core/arch/arm/plat-imx/pm/psci.c
@@ -47,6 +47,19 @@
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 
+int psci_features(uint32_t psci_fid)
+{
+	switch (psci_fid) {
+#ifdef CFG_BOOT_SECONDARY_REQUEST
+	case PSCI_CPU_ON:
+		return 0;
+#endif
+
+	default:
+		return PSCI_RET_NOT_SUPPORTED;
+	}
+}
+
 #ifdef CFG_BOOT_SECONDARY_REQUEST
 int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 		uint32_t context_id)

--- a/core/arch/arm/plat-rockchip/psci_rk322x.c
+++ b/core/arch/arm/plat-rockchip/psci_rk322x.c
@@ -262,7 +262,7 @@ int psci_features(uint32_t psci_fid)
 }
 
 int psci_cpu_on(uint32_t core_idx, uint32_t entry,
-		uint32_t context_id __unused)
+		uint32_t context_id)
 {
 	bool wfei;
 	vaddr_t cru_base = (vaddr_t)phys_to_virt_io(CRU_BASE);
@@ -275,7 +275,8 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	DMSG("core_id: %" PRIu32, core_idx);
 
 	/* set secondary cores' NS entry addresses */
-	ns_entry_addrs[core_idx] = entry;
+	ns_entry_contexts[core_idx].entry_point = entry;
+	ns_entry_contexts[core_idx].context_id = context_id;
 
 	/* wait */
 	if (!core_held_in_reset(core_idx)) {

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -194,7 +194,7 @@ service_init(init_tzc400);
 #endif /*CFG_TZC400*/
 
 #if defined(PLATFORM_FLAVOR_qemu_virt)
-int psci_cpu_on(uint32_t core_id, uint32_t entry, uint32_t context_id __unused)
+int psci_cpu_on(uint32_t core_id, uint32_t entry, uint32_t context_id)
 {
 	size_t pos = get_core_pos_mpidr(core_id);
 	uint32_t *sec_entry_addrs = phys_to_virt(SECRAM_BASE, MEM_AREA_IO_SEC);
@@ -215,7 +215,8 @@ int psci_cpu_on(uint32_t core_id, uint32_t entry, uint32_t context_id __unused)
 	core_is_released[pos] = true;
 
 	/* set NS entry addresses of core */
-	ns_entry_addrs[pos] = entry;
+	ns_entry_contexts[pos].entry_point = entry;
+	ns_entry_contexts[pos].context_id = context_id;
 	dsb_ishst();
 
 	sec_entry_addrs[pos] = CFG_TEE_LOAD_ADDR;


### PR DESCRIPTION
The PSCI specification requires the 'context_id' parameter to be passed in r0 when the core jumps to normal world. Some OS's require this parameter.

Tested on IMX6Quad and IMX7Dual.

Signed-off-by: Jordan Rhee <jordanrh@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
