### PR TITLE
checkpatch_inc.sh: exclude files with inline assembly

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -4,6 +4,7 @@ CHECKPATCH="${CHECKPATCH:-checkpatch.pl}"
 # checkpatch.pl will ignore the following paths
 CHECKPATCH_IGNORE=$(echo core/lib/lib{fdt,tomcrypt} core/lib/zlib \
 		lib/lib{png,utils,zlib} \
+		core/arch/arm/include/arm{32,64}.h \
 		core/arch/arm/plat-ti/api_monitor_index_a{9,15}.h)
 _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
 


### PR DESCRIPTION
checkpatch.pl produces false errors when given files with inline
assembly [1]. It is best to skip those files entirely.

Link: [1] https://travis-ci.org/OP-TEE/optee_os/builds/347435939#L2115
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
