### PR TITLE
core: imx: a7_plat_init: implement get_core_pos

### DIFF
--- a/core/arch/arm/plat-imx/a7_plat_init.S
+++ b/core/arch/arm/plat-imx/a7_plat_init.S
@@ -35,6 +35,7 @@
  * and with ARM registers R0, R1, R2, R3 being scratchable.
  */
 
+#include <arm.h>
 #include <arm32.h>
 #include <arm32_macros.S>
 #include <asm.S>
@@ -65,3 +66,11 @@ UNWIND(	.fnstart)
 	bx	lr
 UNWIND(	.fnend)
 END_FUNC plat_cpu_reset_early
+
+FUNC get_core_pos_mpidr , :
+UNWIND(	.fnstart)
+	/* Drop ClusterId. There is no SoCs with more than 4 A7 Cores. */
+	and	r0, r0, #MPIDR_CPU_MASK
+	bx	lr
+UNWIND(	.fnend)
+END_FUNC get_core_pos_mpidr


### PR DESCRIPTION
Implement get_core_pos for A7.
According the DIT0017f_Cortex-A7_Integration_Manual_r0p5,
If the system contains only a single multiprocessor device,
tie all the CLUSTERID[3:0] to HIGH.
To i.MX family which use A7 core, there is no one contains
more that 4 cores. on i.MX7ULP, there is only one core.
So implement get_core_pos to avoid get wrong cpu id.

Signed-off-by: Peng Fan <peng.fan@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
