### PR TITLE
core/crypto/aes-gcm-ce.c:Remove unused included header file

### DIFF
--- a/core/arch/arm/crypto/aes-gcm-ce.c
+++ b/core/arch/arm/crypto/aes-gcm-ce.c
@@ -8,7 +8,7 @@
 #include <io.h>
 #include <kernel/panic.h>
 #include <kernel/thread.h>
-#include <tomcrypt.h>
+#include <string.h>
 #include <types_ext.h>
 
 static void get_be_block(void *dst, const void *src)


### PR DESCRIPTION
aes-gcm-ce.c is a internal GCM and it should be not relative with tomcrypt anymore.
So remove tomcrypt.h from it.

Signed-off-by: Edison Ai <edison.ai@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
