### PR TITLE
core: insert memory barrier after write to ns entry context

### DIFF
--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -34,11 +34,9 @@ void arm_cl2_config(vaddr_t pl310);
 void arm_cl2_enable(vaddr_t pl310);
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
-struct ns_entry_context {
-	uintptr_t entry_point;
-	uintptr_t context_id;
-};
-extern struct ns_entry_context ns_entry_contexts[];
+void generic_boot_set_core_ns_entry(size_t core_idx, uintptr_t entry,
+				    uintptr_t context_id);
+
 int generic_boot_core_release(size_t core_idx, paddr_t entry);
 struct ns_entry_context *generic_boot_core_hpen(void);
 #endif

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -55,6 +55,10 @@
 #define PADDR_INVALID		ULONG_MAX
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
+struct ns_entry_context {
+	uintptr_t entry_point;
+	uintptr_t context_id;
+};
 struct ns_entry_context ns_entry_contexts[CFG_TEE_CORE_NB_CORE];
 static uint32_t spin_table[CFG_TEE_CORE_NB_CORE];
 #endif
@@ -934,6 +938,14 @@ void generic_boot_init_secondary(unsigned long nsec_entry)
 #endif
 
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
+void generic_boot_set_core_ns_entry(size_t core_idx, uintptr_t entry,
+				    uintptr_t context_id)
+{
+	ns_entry_contexts[core_idx].entry_point = entry;
+	ns_entry_contexts[core_idx].context_id = context_id;
+	dsb_ishst();
+}
+
 int generic_boot_core_release(size_t core_idx, paddr_t entry)
 {
 	if (!core_idx || core_idx >= CFG_TEE_CORE_NB_CORE)

--- a/core/arch/arm/plat-imx/pm/psci.c
+++ b/core/arch/arm/plat-imx/pm/psci.c
@@ -74,8 +74,7 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 		return PSCI_RET_INVALID_PARAMETERS;
 
 	/* set secondary cores' NS entry addresses */
-	ns_entry_contexts[core_idx].entry_point = entry;
-	ns_entry_contexts[core_idx].context_id = context_id;
+	generic_boot_set_core_ns_entry(core_idx, entry, context_id);
 
 	val = virt_to_phys((void *)TEE_TEXT_VA_START);
 	if (soc_is_imx7ds()) {

--- a/core/arch/arm/plat-rockchip/psci_rk322x.c
+++ b/core/arch/arm/plat-rockchip/psci_rk322x.c
@@ -275,8 +275,7 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	DMSG("core_id: %" PRIu32, core_idx);
 
 	/* set secondary cores' NS entry addresses */
-	ns_entry_contexts[core_idx].entry_point = entry;
-	ns_entry_contexts[core_idx].context_id = context_id;
+	generic_boot_set_core_ns_entry(core_idx, entry, context_id);
 
 	/* wait */
 	if (!core_held_in_reset(core_idx)) {

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -215,9 +215,7 @@ int psci_cpu_on(uint32_t core_id, uint32_t entry, uint32_t context_id)
 	core_is_released[pos] = true;
 
 	/* set NS entry addresses of core */
-	ns_entry_contexts[pos].entry_point = entry;
-	ns_entry_contexts[pos].context_id = context_id;
-	dsb_ishst();
+	generic_boot_set_core_ns_entry(pos, entry, context_id);
 
 	sec_entry_addrs[pos] = CFG_TEE_LOAD_ADDR;
 	dsb_ishst();


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

Without a memory barrier there is no guarantee that the write to `ns_entry_contexts` will be observed by other cores.