### PR TITLE
[RFC] TA dynamic link

### DIFF
--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -16,6 +16,7 @@
 TAILQ_HEAD(tee_cryp_state_head, tee_cryp_state);
 TAILQ_HEAD(tee_obj_head, tee_obj);
 TAILQ_HEAD(tee_storage_enum_head, tee_storage_enum);
+TAILQ_HEAD(user_ta_elf_head, user_ta_elf);
 
 struct user_ta_ctx {
 	uaddr_t entry_func;
@@ -30,7 +31,8 @@ struct user_ta_ctx {
 	struct tee_obj_head objects;
 	/* List of storage enumerators opened by this TA */
 	struct tee_storage_enum_head storage_enums;
-	struct mobj *mobj_code; /* secure world memory */
+	/* List of ELF files loaded by this TA */
+	struct user_ta_elf_head elfs; /* code */
 	struct mobj *mobj_stack; /* stack */
 	uint32_t load_addr;	/* elf load addr (from TAs address space) */
 	struct tee_mmu_info *mmu;	/* Saved MMU information (ddr only) */

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -63,6 +63,10 @@ static void __print_stack_unwind_arm32(struct abort_info *ai)
 
 	if (abort_is_user_exception(ai)) {
 		get_current_ta_exidx(&exidx, &exidx_sz);
+		if (!exidx) {
+			EMSG_RAW("Call stack not available");
+			return;
+		}
 	} else {
 		exidx = (vaddr_t)__exidx_start;
 		exidx_sz = (vaddr_t)__exidx_end - (vaddr_t)__exidx_start;

--- a/core/arch/arm/kernel/elf_load.h
+++ b/core/arch/arm/kernel/elf_load.h
@@ -10,6 +10,7 @@
 #include <tee_api_types.h>
 
 struct elf_load_state;
+struct user_ta_elf_head;
 
 struct user_ta_store_handle;
 struct user_ta_store_ops {
@@ -56,7 +57,10 @@ struct user_ta_store_ops {
 };
 
 TEE_Result elf_load_init(const struct user_ta_store_ops *ta_store,
-			 struct user_ta_store_handle *ta_handle,
+			 struct user_ta_store_handle *ta_handle, bool is_main,
+			 struct user_ta_elf_head *elfs,
+			 TEE_Result (*resolve_sym)(struct user_ta_elf_head *,
+						   const char *, uintptr_t *),
 			 struct elf_load_state **state);
 TEE_Result elf_load_head(struct elf_load_state *state, size_t head_size,
 			void **head, size_t *vasize, bool *is_32bit);
@@ -64,6 +68,11 @@ TEE_Result elf_load_body(struct elf_load_state *state, vaddr_t vabase);
 TEE_Result elf_load_get_next_segment(struct elf_load_state *state, size_t *idx,
 			vaddr_t *vaddr, size_t *size, uint32_t *flags,
 			uint32_t *type);
+TEE_Result elf_process_rel(struct elf_load_state *state, vaddr_t vabase);
+TEE_Result elf_get_needed(struct elf_load_state *state, vaddr_t vabase,
+			  char ***needed);
+TEE_Result elf_resolve_symbol(struct elf_load_state *state,
+			      const char *name, uintptr_t *val);
 void elf_load_final(struct elf_load_state *state);
 
 #endif /*ELF_LOAD_H*/

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -1,0 +1,44 @@
+ifeq (,$(shlibuuid))
+$(error SHLIBUUID not set)
+endif
+link-out-dir = $(out-dir)
+
+SIGN = $(TA_DEV_KIT_DIR)/scripts/sign.py
+TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
+
+all: $(link-out-dir)/$(shlibname).so $(link-out-dir)/$(shlibname).dmp \
+	$(link-out-dir)/$(shlibname).stripped.so \
+	$(link-out-dir)/$(shlibuuid).ta
+
+cleanfiles += $(link-out-dir)/$(shlibname).so
+cleanfiles += $(link-out-dir)/$(shlibname).dmp
+cleanfiles += $(link-out-dir)/$(shlibname).stripped.so
+cleanfiles += $(link-out-dir)/$(shlibuuid).ta
+
+shlink-ldflags  = $(LDFLAGS)
+shlink-ldflags += -shared
+
+# Macro to reverse a list
+reverse = $(if $(wordlist 2,2,$(1)),$(call reverse,$(wordlist 2,$(words $(1)),$(1))) $(firstword $(1)),$(1))
+
+shlink-ldadd  = $(LDADD)
+ldargs-$(shlibname).so := $(shlink-ldflags) $(objs) $(shlink-ldadd)
+
+
+$(link-out-dir)/$(shlibname).so: $(objs) $(libdeps)
+	@$(cmd-echo-silent) '  LD      $@'
+	$(q)$(LD$(sm)) $(ldargs-$(shlibname).so) --soname=$(shlibuuid) -o $@
+
+$(link-out-dir)/$(shlibname).dmp: $(link-out-dir)/$(shlibname).so
+	@$(cmd-echo-silent) '  OBJDUMP $@'
+	$(q)$(OBJDUMP$(sm)) -l -x -d $< > $@
+
+$(link-out-dir)/$(shlibname).stripped.so: $(link-out-dir)/$(shlibname).so
+	@$(cmd-echo-silent) '  OBJCOPY $@'
+	$(q)$(OBJCOPY$(sm)) --strip-unneeded $< $@
+
+$(link-out-dir)/$(shlibuuid).ta: $(link-out-dir)/$(shlibname).stripped.so \
+				$(TA_SIGN_KEY)
+	@echo '  SIGN    $@'
+	$(q)$(SIGN) --key $(TA_SIGN_KEY) --uuid $(shlibuuid) --version 0 \
+		--in $< --out $@

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -30,7 +30,6 @@ PHDRS {
 
 SECTIONS {
 	.ta_head : {*(.ta_head)} :exec
-
 	.text : {
 		__text_start = .;
 		*(.text .text.*)
@@ -43,6 +42,8 @@ SECTIONS {
 		PROVIDE(MCOUNT_SYM = __utee_mcount);
 		__text_end = .;
 	}
+        .plt : { *(.plt) }
+
 	.eh_frame : { *(.eh_frame) } :rodata
 	.rodata : {
 		*(.gnu.linkonce.r.*)
@@ -50,12 +51,9 @@ SECTIONS {
 	}
 	/* .ARM.exidx is sorted, so has to go in its own output section.  */
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
-
         .ctors : { *(.ctors) }
         .dtors : { *(.dtors) }
-        .plt : { *(.plt) }
 	.got : { *(.got.plt) *(.got) }
-
 	.rel.text : { *(.rel.text) *(.rel.gnu.linkonce.t*) }
 	.rela.text : { *(.rela.text) *(.rela.gnu.linkonce.t*) }
 	.rel.data : { *(.rel.data) *(.rel.gnu.linkonce.d*) }
@@ -77,7 +75,6 @@ SECTIONS {
 	.rela.bss : { *(.rela.bss) }
 	.rel.plt : { *(.rel.plt) }
 	.rela.plt : { *(.rela.plt) }
-
 	.dynamic : { *(.dynamic) } :dyn :rodata
 	.dynsym : { *(.dynsym) } :rodata
 	.dynstr : { *(.dynstr) }
@@ -87,7 +84,6 @@ SECTIONS {
 	. = ALIGN(4096);
 
 	.data : { *(.data .data.* .gnu.linkonce.d.*) } :rwdata
-
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
 

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -7,12 +7,14 @@ all:
 
 include $(ta-dev-kit-dir)/mk/conf.mk
 
-ifneq (1, $(word $(BINARY) $(LIBNAME)))
-$(error You must specify exactly one of BINARY or LIBNAME)
+ifneq (1, $(words $(BINARY) $(LIBNAME) $(SHLIBNAME)))
+$(error You must specify exactly one of BINARY, LIBNAME or SHLIBNAME)
 endif
 
 binary := $(BINARY)
 libname := $(LIBNAME)
+shlibname := $(SHLIBNAME)
+shlibuuid := $(SHLIBUUID)
 
 ifneq ($O,)
 out-dir := $O
@@ -83,6 +85,7 @@ endif
 
 include  $(ta-dev-kit-dir)/mk/gcc.mk
 include  $(ta-dev-kit-dir)/mk/compile.mk
+
 ifneq ($(binary),)
 include  $(ta-dev-kit-dir)/mk/link.mk
 endif
@@ -95,4 +98,8 @@ cleanfiles += $(libname).a
 $(libname).a: $(objs)
 	@echo '  AR      $@'
 	$(q)rm -f $@ && $(AR$(sm)) rcs -o $@ $^
+endif
+
+ifneq (,$(shlibname))
+include $(ta-dev-kit-dir)/mk/link_shlib.mk
 endif

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -7,18 +7,12 @@ all:
 
 include $(ta-dev-kit-dir)/mk/conf.mk
 
+ifneq (1, $(word $(BINARY) $(LIBNAME)))
+$(error You must specify exactly one of BINARY or LIBNAME)
+endif
+
 binary := $(BINARY)
 libname := $(LIBNAME)
-
-ifneq ($(BINARY),)
-ifneq ($(LIBNAME),)
-$(error You can only specify one of BINARY or LIBNAME)
-endif
-else
-ifeq ($(LIBNAME),)
-$(error You must specify one of BINARY or LIBNAME)
-endif
-endif
 
 ifneq ($O,)
 out-dir := $O
@@ -81,8 +75,8 @@ clean:
 subdirs = .
 include  $(ta-dev-kit-dir)/mk/subdir.mk
 
-#the build target is ta
 ifneq ($(binary),)
+# Build target is TA
 vpath %.c $(ta-dev-kit-dir)/src
 srcs += user_ta_header.c
 endif
@@ -91,13 +85,14 @@ include  $(ta-dev-kit-dir)/mk/gcc.mk
 include  $(ta-dev-kit-dir)/mk/compile.mk
 ifneq ($(binary),)
 include  $(ta-dev-kit-dir)/mk/link.mk
-else
+endif
+
 ifneq ($(libname),)
+# Build target is static library
 all: $(libname).a
 cleanfiles += $(libname).a
 
 $(libname).a: $(objs)
 	@echo '  AR      $@'
 	$(q)rm -f $@ && $(AR$(sm)) rcs -o $@ $^
-endif
 endif

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -72,7 +72,8 @@ $(foreach f, $(libfiles), \
 
 # Copy .mk files
 ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk mk/cleandirs.mk \
-	ta/arch/$(ARCH)/link.mk ta/mk/ta_dev_kit.mk
+	ta/arch/$(ARCH)/link.mk ta/arch/$(ARCH)/link_shlib.mk \
+	ta/mk/ta_dev_kit.mk
 
 $(foreach f, $(ta-mkfiles), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/mk)))


### PR DESCRIPTION
This commit goes half-way to adding support for dynamically linked
Trusted Applications. Therefore I'm sending it as a RFC.

Test with https://github.com/linaro-swg/optee_examples/pull/18.

Why do this? Several reasons.

1. Save space in the TA storage area. The OP-TEE core libraries
(libutee, libutils, libmpa) could very well be provided as shared
objects rather than object archives. They would be installed only once
in the TA storage. instead of being duplicated inside each TA. 
2. Allow upgrade of library code without re-linking the TAs.
3. Pave the way to sharing code pages between TAs, thus reducing the 
memory footprint of the TEE.

The ELF loader is updated as follows:

- Locate the dynamic section in the program headers (PT_DYNAMIC entry).
- Find the required external libraries by looking for DT_NEEDED entries
in the dynamic section. Libraries are .so files signed like TAs and 
identified by a UUID so that the TA stores can be re-used unchanged.
- Load all the libraries.
- Process the dynamic relocations of type R_ARM_GLOB_DAT and 
R_ARM_JUMP_SLOT by resolving symbols by name, in breadth first order.

What's left to be done:
- Map the library code and data into the user VA space (only the main
executable is mapped currently, so the TA crashes with a translation
fault as soon as an external symbol is referenced).
- Update the stack unwinding code. There is no longer a single EXIDX
exception table, but one per ELF file. Also, the crash dumps should
show the UUID of the libraries in the region mapping section.
- Update symbolize.py to handle the updated crash dumps.
- 64-bit support.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
