### PR TITLE
doc: update documentation against out dated information

### DIFF
--- a/Notice.md
+++ b/Notice.md
@@ -6,50 +6,79 @@ the open-source TEE maintained by Linaro, with initial contributions from
 STMicroelectronics, Ericsson and Linaro Limited.
 
 What OP-TEE is
-------
+-------
 
-OP-TEE is designed primarily to rely on the ARM TrustZone(R) technology as the
-underlying hardware isolation mechanism. However, it has been structured to be
-compatible with any isolation technology suitable for the TEE concept and goals,
-such as running as a virtual machine or on a dedicated CPU.
+OP-TEE is a Trusted Execution Environment designed as companion to a non-secure
+Linux kernel running on ARM&reg; Cortex-A cores using the TrustZone&reg;
+technology. OP-TEE meets the TEE System Architecture and provides the TEE
+Internal Core API v1.1 to Trusted Applications and the TEE Client API
+v1.0, all as defined by the [GlobalPlatform TEE specifications].
+
+The non-secure OS is referred to as the Rich Execution Environment (REE) in TEE
+specifications. It is typically a Linux OS flavor as a GNU/Linux distribution
+or the AOSP.
+
+OP-TEE is designed primarily to rely on the ARM TrustZone technology as
+the underlying hardware isolation mechanism. However, it has been structured
+to be compatible with any isolation technology suitable for the TEE concept and
+goals, such as running as a virtual machine or on a dedicated CPU.
 
 The main design goals for OP-TEE are:
--	Isolation - the TEE provides isolation from the Rich OS (typically,
-	Linux/Android) and it protects the Trusted Applications (TAs) it
-	executes from each other, using underlying HW support,
--	Small footprint - the TEE should remain small enough so that the TEE
-	core, including all the code and data required to provide isolation, can
-	reside in a reasonable amount of on-chip memory,
--	Portability - the TEE must be easily pluggable to different
-	architectures and available HW, and it has to support various setups
-	such as multiple TEEs or multiple client OSes.
+-	Isolation - the TEE provides isolation from the non-secure OS and
+	protects the loaded Trusted Applications (TAs) from each other using
+	underlying HW support,
+-	Small footprint - the TEE should remain small enough to
+	reside in a reasonable amount of on-chip memory as found on ARM
+	based systems,
+-	Portability - the TEE aims at being easily pluggable to different
+	architectures and available HW and has to support various setups
+	such as multiple client OSes or multiple TEEs.
+
 
 Repository structure
 ------
 
-OP-TEE is composed of three gits:
--	The optee-client git, containing the source code for the TEE client
-	library in Linux. This component provides the TEE Client API as defined
-	by the <a href="https://www.globalplatform.org/specificationsdevice.asp">GlobalPlatform
-	TEE standard</a>. It is distributed under the BSD 2-clause open-source license.
--	The optee_os git, containing the source code for the TEE OS itself. This
-	component provides the TEE Internal APIs as defined by the
-	GlobalPlatform  TEE standard to the Trusted Applications that it
-	executes. It is distributed mostly under the BSD 2-clause open-source
-	license. It includes few external files under BSD 3-clause license or
-	other free software licenses.
--	The optee_linuxdriver git, containing the source code for the TEE driver
-	in Linux. This component implements a generic TEE driver, designed
-	primarily for TEE implementations that rely on the ARM
-	TrustZone(R)technology. It is distributed under the GPLv2 open-source
-	license. Please note that re-distribution under other versions of the
-	GPL license is not allowed. The rationale behind this limitation is to
-	ensure that this code may be used on products which have security
-	devices which prevent reloading the code. Such security devices would be
-	incompatible with some licenses such as GPLv3 and so distribution under
-	those licenses would be inconsistent with this goal. Therefore it is
-	recommended that care be taken before redistributing any of the
-	components under other license terms than those provided here.
+OP-TEE comes with several components:
+-	a secure privileged layer, executing at ARM secure PL-1 level,
+-	a set of secure userland libraries designed for Trusted Applications
+	needs,
+-	a Linux kernel driver merged since v4.12,
+-	a Linux userland library designed upon the GPD TEE Client API
+	specifications
+-	a Linux userland supplicant application for remote services expected by
+	the TEE OS,
+-	and some build scripts, debugging tools and examples to ease its
+	integration and the development of trusted applications and secure
+	services.
+
+These components are available from several git repositories. The main ones are
+the [optee_os], the [optee_client] and the [Linux kernel] since v4.12.
+
+The [optee_os] git repository contains the source code for the TEE OS itself.
+It includes the secure privileged layer hosting the Trusted Applications and
+libraries complying with the TEE Internal Core API v1.1. It is distributed mostly
+under the [BSD 2-Clause] open-source license. It includes few external files under
+[BSD 3-Clause] license or other free software licenses.
+
+The [optee_client] git repository contains the source code for the TEE client
+library in a Linux OS providing the TEE Client API v1.0. It is distributed under
+the [BSD 2-Clause] open-source license.
+
+The [Linux kernel] contains the source code for the OP-TEE Linux driver. It is
+distributed under the [GPLv2] open-source license.
+
+There are other OP-TEE components one might be interested in. The OP-TEE release tag
+references several git repositories enabling OP-TEE build and test for various
+platforms. Refer to the [build documentation] for information. The [optee_test] git
+repository proposes test materials through the `xtest` tool and dedicated trusted
+applications. The [optee_examples] git repository contains examples of TEE client
+and trusted applications and some documentation to get hands on trusted
+application development.
+
+Documentation
+------
+Documentation on design, implementation and tools can be found in
+[optee_os/documentation](optee_os/documentation).
 
 Contributions
 ------
@@ -111,3 +140,18 @@ To sign-off a patch, just add a line saying:
     Signed-off-by: Random J Developer <random@developer.example.org>
 ```
 using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+Refer also to [github.md](documentation/github.md) to setup a github accournt
+in order to contribute to the project through issues reporting and pull
+requests.
+
+[BSD 2-Clause]: http://opensource.org/licenses/BSD-2-Clause
+[BSD 3-Clause]: http://opensource.org/licenses/BSD-3-Clause
+[GPLv2]: https://opensource.org/licenses/gpl-2.0
+[build documentation]: documentation/build_system.md
+[GlobalPlatform TEE specifications]: https://www.globalplatform.org/specificationsdevice.asp
+[Linux kernel]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+[optee_client]: https://github.com/OP-TEE/optee_client
+[optee_examples]: https://github.com/OP-TEE/optee_examples
+[optee_os]: https://github.com/OP-TEE/optee_os
+[optee_test]: https://github.com/OP-TEE/optee_test

--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@
 3. [Platforms supported](#3-platforms-supported)
 4. [Get and build OP-TEE software](#4-get-and-build-op-tee-software)
 5. [Coding standards](#5-coding-standards)
-    5. [checkpatch](#51-checkpatch)
 
 ## 1. Introduction
-The `optee_os git`, contains the source code for the TEE in Linux using the
-ARM&reg; TrustZone&reg; technology. This component meets the GlobalPlatform
-TEE System Architecture specification. It also provides the TEE Internal core API
-v1.1 as defined by the GlobalPlatform TEE Standard for the development of
+The `optee_os` git repository contains the source code of a Trusted Execution
+Environment (TEE) as companion to a non-secure OS on ARM&reg;
+Cortex-A cores using the TrustZone&reg; technology. This component meets the
+[TEE System Architecture specifications](http://www.globalplatform.org/specificationsdevice.asp)
+and provides the
+[TEE Internal Core API v1.1](http://www.globalplatform.org/specificationsdevice.asp)
+as defined by the
+[GlobalPlatform Device technology TEE specifications](http://www.globalplatform.org/specificationsdevice.asp)
+for the development of
 Trusted Applications. For a general overview of OP-TEE and to find out how to
 contribute, please see the [Notice.md](Notice.md) file.
 
@@ -41,7 +45,7 @@ please read the file [build_system.md](documentation/build_system.md). Some
 platforms have different sub-maintainers, please refer to the file
 [MAINTAINERS](MAINTAINERS) for contact details for various platforms.
 
-The `Maintained` column shows:
+The **Maintained?** column shows:
 
 - A green image if the platform is actively maintained: either tested successfully
   with the latest release (N), or is a newly supported platform.
@@ -91,26 +95,27 @@ Please see [build] for instructions how to run OP-TEE on various devices.
 ---
 ## 5. Coding standards
 In this project we are trying to adhere to the same coding convention as used in
-the Linux kernel (see
-[CodingStyle](https://www.kernel.org/doc/Documentation/process/coding-style.rst)). We achieve this by running
-[checkpatch](http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/scripts/checkpatch.pl)
+the Linux kernel (see [CodingStyle]). We achieve this by running [checkpatch]
 from Linux kernel. However there are a few exceptions that we had to make since
 the code also follows GlobalPlatform standards. The exceptions are as follows:
 
-- CamelCase for GlobalPlatform types are allowed.
-- And we also exclude checking third party code that we might use in this
-  project, such as LibTomCrypt, MPA, newlib (not in this particular git, but
-  those are also part of the complete TEE solution). The reason for excluding
-  and not fixing third party code is because we would probably deviate too much
-  from upstream and therefore it would be hard to rebase against those projects
-  later on (and we don't expect that it is easy to convince other software
-  projects to change coding style).
+-	CamelCase for GlobalPlatform types are allowed.
+-	And we also exclude checking third party code that we might use in this
+	project, such as LibTomCrypt, MPA, newlib (not in this particular git, but
+	those are also part of the complete TEE solution, see
+	[Notice.md](Notice.md#repository-structure). The reason for
+	excluding and not fixing third party code is because we would probably
+	deviate too much from upstream and therefore it would be hard to rebase
+	against those projects later on and we don't expect that it is easy to
+	convince other software projects to change coding style.
 
-### 5.1 checkpatch
-Since checkpatch is licensed under the terms of GNU GPL License Version 2, we
+Regarding the checkpatch tool, since it is licensed under the terms of GNU GPL
+License Version 2, we
 cannot include this script directly into this project. Please use checkpatch
 directly from the Linux kernel git in combination with the local [checkpatch
 script].
 
 [build]: https://github.com/OP-TEE/build
 [checkpatch script]: scripts/checkpatch.sh
+[checkpatch]: http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/scripts/checkpatch.pl
+[CodingStyle]: https://www.kernel.org/doc/Documentation/process/coding-style.rst

--- a/documentation/extensions/crypto_concat_kdf.md
+++ b/documentation/extensions/crypto_concat_kdf.md
@@ -26,8 +26,8 @@ is desired.
 
 ## API extension
 
-To support the Concat KDF, the *GlobalPlatform TEE Internal API Specification
-v1.0* was extended with new algorithm descriptors, new object types, and new
+To support the Concat KDF, the *GlobalPlatform TEE Internal Core API Specification
+v1.1* was extended with new algorithm descriptors, new object types, and new
 object attributes as described below.
 
 ### p.95 Add new object type to TEE_PopulateTransientObject

--- a/documentation/extensions/crypto_hkdf.md
+++ b/documentation/extensions/crypto_hkdf.md
@@ -2,8 +2,8 @@
 
 OP-TEE implements the *HMAC-based Extract-and-Expand Key Derivation Function
 (HKDF)* specified in [RFC 5869](http://tools.ietf.org/html/rfc5869). This
-file documents the extensions to the *GlobalPlatform TEE Internal API
-Specification v1.0* that were implemented to support this algorithm. Trusted
+file documents the extensions to the *GlobalPlatform TEE Internal Core API
+Specification v1.1* that were implemented to support this algorithm. Trusted
 Applications should include `<tee_api_defines_extensions.h>` to import the
 definitions.
 

--- a/documentation/extensions/crypto_pbkdf2.md
+++ b/documentation/extensions/crypto_pbkdf2.md
@@ -12,8 +12,8 @@ in `conf.mk`:
 
 ## API extension
 
-To support PBKDF2, the *GlobalPlatform TEE Internal API Specification
-v1.0* was extended with a new algorithm descriptor, new object types, and new
+To support PBKDF2, the *GlobalPlatform TEE Internal Core API Specification
+v1.1* was extended with a new algorithm descriptor, new object types, and new
 object attributes as described below.
 
 ### p.95 Add new object type to TEE_PopulateTransientObject

--- a/documentation/extensions/extensions.md
+++ b/documentation/extensions/extensions.md
@@ -1,6 +1,7 @@
-# General Extensions to the GlobalPlatform TEE Internal API
+# General Extensions to the GlobalPlatform TEE Internal Core API
 
-This document describes the OP-TEE extensions introduced with respect to the GlobalPlatform TEE API Specifications v1.0.
+This document describes the OP-TEE extensions introduced with respect to the
+GlobalPlatform TEE Internal Core API Specifications v1.1.
 
 Specific extensions documentation are part of:
 * Cryptographic Extensions

--- a/documentation/globalplatform_api.md
+++ b/documentation/globalplatform_api.md
@@ -13,8 +13,7 @@ identify, develop and publish specifications which facilitate the secure and
 interoperable deployment and management of multiple embedded applications on
 secure chip technology. OP-TEE has support for GlobalPlatform [TEE Client API
 Specification v1.0](http://www.globalplatform.org/specificationsdevice.asp) and
-[TEE Internal API Specification
-v1.0](http://www.globalplatform.org/specificationsdevice.asp).
+[TEE Internal Core API Specification v1.1](http://www.globalplatform.org/specificationsdevice.asp).
 
 # 2. TEE Client API
 The TEE Client API describes and defines how a client running in a rich
@@ -45,8 +44,7 @@ are used in the communication between the client and the TEE.
 #### TEE Functions
 ``` c
 TEEC_Result TEEC_InitializeContext(
-	const char*
-	name,
+	const char* name,
 	TEEC_Context* context)
 
 void TEEC_FinalizeContext(
@@ -97,10 +95,11 @@ in the secure world. The TEE Internal API consists of four major parts:
 4. **Arithmetical API**
 
 ### Examples / usage
-Calling the Internal API is done in the same way as described above using Client API.
+Calling the Internal Core API is done in the same way as described above using Client API.
 The best place to find information how this should be done is in the
-[TEE Internal API Specification
-v1.0](http://www.globalplatform.org/specificationsdevice.asp) which contains a
+[TEE Internal Core API Specification
+v1.1](http://www.globalplatform.org/specificationsdevice.asp) which contains a
 lot of examples of how to call the various APIs.
 
-
+One can also have a look at the OP-TEE examples git repository
+[optee_examples](https://github.com/linaro-swg/optee_examples) documentation.


### PR DESCRIPTION
While reading back current documentation I found deprecated info. Here is an update proposal.

* OP-TEE currently target ARM Cortex-A with TZ, not all ARM TZ HW.

* Reference the GPD TEE Internal Core API v1.1 instead of the older
GPD TEE Internal API v1.0. Note: sole reference to the "Internal
core API v1.1" missed an uppercase 'C'.

* Remove reference to the deprecated optee_linuxdriver git repository.

These updates lead to few other changes, especially adding references
to other available documentation where accurate.
