### PR TITLE
ci: .travis.yml: clone stable version (3.0.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,13 @@ before_script:
   - (cd $HOME/bin && wget https://storage.googleapis.com/git-repo-downloads/repo && chmod +x repo)
   - export PATH=$HOME/bin:$PATH
   - mkdir $HOME/optee_repo
-  - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git -m travis.xml </dev/null && repo sync --no-clone-bundle --no-tags --quiet -j 2)
+  - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git -m default_stable.xml -b refs/tags/3.0.0 </dev/null && repo sync --no-clone-bundle --no-tags -j 20)
   - (cd $HOME/optee_repo/qemu && git submodule update --init dtc)
   - (cd $HOME/optee_repo && mv optee_os optee_os_old && ln -s $MYHOME optee_os)
+  - (cd $HOME/optee_repo/optee_benchmark && git fetch linaro-swg master && git checkout linaro-swg/master)
+  - (cd $HOME/optee_repo/optee_examples && git fetch linaro-swg master && git checkout linaro-swg/master)
+  - (cd $HOME/optee_repo/optee_test && git fetch optee master && git checkout optee/master)
+  - (cd $HOME/optee_repo/optee_client && git fetch optee master && git checkout optee/master)
   - cd $MYHOME
   - git fetch https://github.com/OP-TEE/optee_os --tags
   - unset CC


### PR DESCRIPTION
Due to recent changes in manifest.git and build.git for buildroot
support,  it is not possible to build with GCC4.9 anymore. One has
to use the toolchain installed by "make toolchains".

Since we want to keep GCC4.9 for now [1], let's revert to an older,
stable version of the source tree, except for the optee_* projects
which we keep at the tip of their master branch.

[1] Commit 148ea708383e ("ci: .travis.yml: use GCC 4.9")

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
