### PR TITLE
MAINTAINERS: mark Mediatek MT8173 EVB as Orphan

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -67,8 +67,7 @@ S:	Maintained
 F:	core/arch/arm/plat-marvell/
 
 MediaTek MT8173 EVB
-R:	Linaro <op-tee@linaro.org>
-S:	Maintained
+S:	Orphan
 F:	core/arch/arm/plat-mediatek/
 
 NXP LS1021A, LS1043A-RDB, LS1046A-RDB

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `Maintained` column shows:
 | [Marvell ARMADA 7K Family](http://www.marvell.com/embedded-processors/armada-70xx/)|`PLATFORM=marvell-armada7k8k`| Yes | ![Actively Maintained](documentation/images/green.svg) |
 | [Marvell ARMADA 8K Family](http://www.marvell.com/embedded-processors/armada-80xx/)|`PLATFORM=marvell-armada7k8k`| Yes | ![Actively Maintained](documentation/images/green.svg) |
 | [Marvell ARMADA 3700 Family](http://www.marvell.com/embedded-processors/armada-3700/)|`PLATFORM=marvell-armada3700`| Yes | ![Actively Maintained](documentation/images/green.svg) |
-| [MediaTek MT8173 EVB Board](https://www.mediatek.com/products/tablets/mt8173)|`PLATFORM=mediatek-mt8173`| No | ![Actively Maintained](documentation/images/green.svg) |
+| [MediaTek MT8173 EVB Board](https://www.mediatek.com/products/tablets/mt8173)|`PLATFORM=mediatek-mt8173`| No | ![Not maintained](documentation/images/green.svg) v3.0.0 |
 | [Poplar Board (HiSilicon Hi3798C V200)](https://www.96boards.org/product/poplar)|`PLATFORM=poplar`| Yes | ![Actively Maintained](documentation/images/green.svg) |
 | [QEMU](http://wiki.qemu.org/Main_Page) |`PLATFORM=vexpress-qemu_virt`| Yes | ![Actively Maintained](documentation/images/green.svg) |
 | [QEMUv8](http://wiki.qemu.org/Main_Page) |`PLATFORM=vexpress-qemu_armv8a`| Yes | ![Actively Maintained](documentation/images/green.svg) |


### PR DESCRIPTION
Mediatek MT8173 EVB is not used on a regular basis for OP-TEE by anyone
we know, so mark is as Orphan. I'm not getting rid of the platform code
because is is small and quite trivial, so there is not much to be
gained by removing it.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
