### PR TITLE
core: syscall_authenc_enc_final() initialize tlen

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -3014,7 +3014,7 @@ TEE_Result syscall_authenc_enc_final(unsigned long state,
 	struct tee_cryp_state *cs;
 	struct tee_ta_session *sess;
 	uint64_t dlen;
-	uint64_t tlen;
+	uint64_t tlen = 0;
 	size_t tmp_dlen;
 	size_t tmp_tlen;
 


### PR DESCRIPTION
Fixes problem with possibly leaking uninitialized stack content via
tlen.

Fixes: https://github.com/OP-TEE/optee_os/issues/2214
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
