### PR TITLE
libutee: out and tag buffer can be too short in TEE_AEEncryptFinal

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1472,23 +1472,25 @@ TEE_Result TEE_AEEncryptFinal(TEE_OperationHandle operation,
 	 * Check that required destLen is big enough before starting to feed
 	 * data to the algorithm. Errors during feeding of data are fatal as we
 	 * can't restore sync with this API.
+	 *
+	 * Need to check this before update_payload since sync would be lost if
+	 * we return short buffer after that.
 	 */
+	res = TEE_ERROR_GENERIC;
+
 	req_dlen = operation->buffer_offs + srcLen;
 	if (*destLen < req_dlen) {
 		*destLen = req_dlen;
 		res = TEE_ERROR_SHORT_BUFFER;
-		goto out;
 	}
 
-	/*
-	 * Need to check this before update_payload since sync would be lost if
-	 * we return short buffer after that.
-	 */
 	if (*tagLen < operation->ae_tag_len) {
 		*tagLen = operation->ae_tag_len;
 		res = TEE_ERROR_SHORT_BUFFER;
-		goto out;
 	}
+
+	if (res == TEE_ERROR_SHORT_BUFFER)
+		goto out;
 
 	tl = *tagLen;
 	tmp_dlen = *destLen - acc_dlen;


### PR DESCRIPTION
With this change, a single call to TEE_AEEncryptFinal() checks both
the output data buffer size and the tag buffer size and return
TEE_ERROR_SHORT_BUFFER with both expected size if at least one
of the provided buffer is too short.

Before this change caller may need to call twice TEE_AEEncryptFinal()
in the right order to get the output buffers sizes, first for the
output data size then for the tag data size.
