### PR TITLE
Feature/enable ta optim

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -136,6 +136,7 @@ ta_arm32-platform-cflags += $(platform-cflags-optimization)
 ta_arm32-platform-cflags += $(platform-cflags-debug-info)
 ta_arm32-platform-cflags += -fpie
 ta_arm32-platform-cflags += $(arm32-platform-cflags-generic)
+ta_arm32-platform-cflags += $(platform-cflags-generic)
 ifeq ($(platform-hard-float-enabled),y)
 ta_arm32-platform-cflags += $(arm32-platform-cflags-hard-float)
 else
@@ -168,6 +169,7 @@ ta_arm64-platform-cflags += $(platform-cflags-optimization)
 ta_arm64-platform-cflags += $(platform-cflags-debug-info)
 ta_arm64-platform-cflags += -fpie
 ta_arm64-platform-cflags += $(arm64-platform-cflags-generic)
+ta_arm64-platform-cflags += $(platform-cflags-generic)
 ifeq ($(platform-hard-float-enabled),y)
 ta_arm64-platform-cflags += $(arm64-platform-cflags-hard-float)
 else

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -29,7 +29,7 @@ PHDRS {
 }
 
 SECTIONS {
-	.ta_head : {*(.ta_head)} :exec
+	.ta_head : {KEEP(*(.ta_head))} :exec
 
 	.text : {
 		__text_start = .;


### PR DESCRIPTION
TA Build System: Enable TA size optimization

This branch contains 2 very simple patches, enabling the TA developer to optimize its TA size.

So far, optimizing the TA size was prevented by 2 issues:
- activating the --gc-sections linker flag was leading to the generation of an empty elf file (!)
- the libmpa, libutee, libutils libraries were not generated with the -ffunction-sections / -fdata-sections flags enabling the --gc-sections flag to be effective.

Signed-off-by: Jean-Luc Rigaud <jl.rigaud@trustazur.com>
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
