### PR TITLE
core: crypto: arm32: add counter increment in ce_aes_ctr_encrypt()

### DIFF
--- a/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes_modes_armv8a_ce_a32.S
@@ -296,6 +296,7 @@ ce_aes_ctr_encrypt:
 .Lctrloop3x:
 	subs		r4, r4, #3
 	bmi		.Lctr1x
+	add		r6, r6, #1
 	vmov		q0, q6
 	vmov		q1, q6
 	rev		ip, r6


### PR DESCRIPTION
Commit 628a9a10ca36 ("ltc: ctr: improve performance") reveals a bug in
the Aarch32 accelerated crypto code (AES CTR mode), which causes xtest
9159 to fail with some invalid buffer content: encrypting 96 bytes of
data in one pass does not yield the same result than encrypting 3 * 32
bytes. The problem is fixed by adding a missing counter increment in
ce_aes_ctr_encrypt().

Fixes: 9ff4f2ccc026 ("arm32: AES using ARMv8-A cryptographic extensions")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (HiKey960)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
