### PR TITLE
core/arch/arm/pta/sdp_pta.c: Fix compile error

### DIFF
--- a/core/arch/arm/pta/sdp_pta.c
+++ b/core/arch/arm/pta/sdp_pta.c
@@ -66,7 +66,7 @@ static TEE_Result open_session(uint32_t nParamTypes __unused,
 	}
 
 	DMSG("TA %pUl is unauthorised access to pseudo-TA \"%s\"",
-	     s->ctx->uuid, PTA_NAME);
+	     (void *)&s->ctx->uuid, PTA_NAME);
 
 	return TEE_ERROR_ACCESS_DENIED;
 }


### PR DESCRIPTION
There will be a "format" compile error when using gcc 6.2.1. It is not allowed to change type from "struct" to "void *" in gcc 6.2.1.

Signed-off-by: Edison Ai <edison.ai@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
