### PR TITLE
plat-ti: Restore NSACR and GIC context on resume

### DIFF
--- a/core/arch/arm/plat-ti/a9_plat_init.S
+++ b/core/arch/arm/plat-ti/a9_plat_init.S
@@ -104,6 +104,8 @@ after_resume:
 	mov	r0, r4
 	bl	init_sec_mon
 
+	bl	main_init_gic
+
 	mov	r0, #TEESMC_OPTEED_RETURN_ENTRY_DONE
 	mov	r1, #0
 	mov	r2, #0


### PR DESCRIPTION
The resume path may need to re-setup the GIC and enable non-secure
VFP access. These are cleared in some suspend paths and so should
be restored.

Signed-off-by: Andrew F. Davis <afd@ti.com>