### PR TITLE
checkpatch_inc.sh: fix case of empty commit due to path filtering

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -15,16 +15,24 @@ function _checkpatch() {
 		typedefs_opt="--typedefsfile typedefs.checkpatch"
 		$CHECKPATCH --help 2>&1 | grep -q -- --typedefsfile || \
 				typedefs_opt="";
-
+		# Ignore NOT_UNIFIED_DIFF in case patch has no diff
+		# (e.g., all paths filtered out)
 		$CHECKPATCH --quiet --ignore FILE_PATH_CHANGES \
-				--ignore GERRIT_CHANGE_ID --no-tree \
+				--ignore GERRIT_CHANGE_ID \
+				--ignore NOT_UNIFIED_DIFF \
+				--no-tree \
 				$typedefs_opt \
 				-
 }
 
 function checkpatch() {
-		git show --oneline --no-patch $1
-		git format-patch -1 $1 --stdout -- $_CP_EXCL . | _checkpatch
+	git show --oneline --no-patch $1
+	# The first git 'format-patch' shows the commit message
+	# The second one produces the diff (might be empty if _CP_EXCL
+	# filters out all diffs)
+	(git format-patch $1^..$1 --stdout | sed -n '/^diff --git/q;p'; \
+	 git format-patch $1^..$1 --stdout -- $_CP_EXCL . | \
+		sed -n '/^diff --git/,$p') | _checkpatch
 }
 
 function checkstaging() {


### PR DESCRIPTION
```
If a commit changes only paths that are filtered out by $_CP_EXCL, thus
making the diff empty, 'git format-patch -1 <sha1>' will show the parent
commit instead. As a result, checkpatch.sh will check the wrong commit.

Several things are needed to fix the issue:

1. When calling 'git format-patch', specify the commit ID as a range
(<sha1>^..<sha1>) rather than as a single revision with a maximum count
(-1 <sha1>). This avoids showing the wrong commit.
2. Show the commit message then the diff in two steps, because the
above syntax will not print anything if the diff happens to be empty.
3. Tell checkpatch.pl to ignore the "not a unified diff" error which
is triggered if the commit log is not followed by a diff.

Link: https://travis-ci.org/OP-TEE/optee_os/builds/367058383#L2199-L2204
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
