### PR TITLE
core: arm64: use 33-bit pc-relative addressing to allow bigger data sections

### DIFF
--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -115,3 +115,12 @@
 	.endif
 		movk    \_reg, :abs_g0_nc:\_val
 	.endm
+
+	/*
+	 * Load address of <sym> into <reg>, <sym> being in the range
+	 * +/- 4GB of the PC (note that 'adr reg, sym' is limited to +/- 1MB).
+	 */
+	.macro adr_l reg, sym
+	adrp	\reg, \sym
+	add	\reg, \reg, :lo12:\sym
+	.endm

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -5,6 +5,7 @@
 
 #include <platform_config.h>
 
+#include <arm64_macros.S>
 #include <arm.h>
 #include <asm.S>
 #include <keep.h>
@@ -92,8 +93,8 @@ copy_init:
 	 * Clear .bss, this code obviously depends on the linker keeping
 	 * start/end of .bss at least 8 byte aligned.
 	 */
-	adr	x0, __bss_start
-	adr	x1, __bss_end
+	adr_l	x0, __bss_start
+	adr_l	x1, __bss_end
 clear_bss:
 	str	xzr, [x0], #8
 	cmp	x0, x1
@@ -105,7 +106,7 @@ clear_bss:
 	/* Enable aborts now that we can receive exceptions */
 	msr	daifclr, #DAIFBIT_ABT
 
-	adr	x0, __text_start
+	adr_l	x0, __text_start
 #ifdef CFG_WITH_PAGER
 	adrp	x1, __tmp_hashes_end
 	add	x1, x1, :lo12:__tmp_hashes_end
@@ -136,7 +137,7 @@ clear_bss:
 	 * D-cache before exiting to normal world.
 	 */
 	mov	x19, x0
-	adr	x0, __text_start
+	adr_l	x0, __text_start
 #ifdef CFG_WITH_PAGER
 	adrp	x1, __tmp_hashes_end
 	add	x1, x1, :lo12:__tmp_hashes_end


### PR DESCRIPTION
Fixes the following linker errors which happens when adding a big
global array of data (~200 KB):

.../generic_entry_a64.o: In function `_start`:
.../generic_entry_a64.S:95:(.text._start+0x30): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `__bss_start` defined in .bss.__malloc_spinlock section in all_objs.o
.../generic_entry_a64.S:96:(.text._start+0x34): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `__bss_end` defined in .bss.__malloc_spinlock section in all_objs.o
.../generic_entry_a64.o: In function `clear_bss`:
.../generic_entry_a64.S:108:(.text._start+0x84): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `__text_start` defined in .bss.__malloc_spinlock section in all_objs.o
.../generic_entry_a64.S:139:(.text._start+0xc4): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `__text_start` defined in .bss.__malloc_spinlock section in all_objs.o

The root cause is the 'adr x0, symbol' instructions. They generate a
relocation of type R_AARCH64_ADR_PREL_LO21, therefore 'symbol' can
only be +/-1MB away from the current PC (otherwise the linker emits the
above error). The problem is, in _start() and clear_bss() there is no
guarantee that the referenced symbols are in the allowed range.

The linker script core/arch/arm/kernel/link_dummy.ld, which is used
to generate all_objs.o, places __bss_start, __bss_end, __text_start
etc. at the end of the binary. The _start() and clear_bss() functions,
on the other hand, are near the start. If the total size of the binary
is sufficiently increased (for instance by adding global data), the
error will occur.

The __text_start error could probably be avoided by modifying
link_dummy.ld -- the actual location of the __* symbols does not matter
much in this phase of the build. However, the references to __bss_start
and __bss_end are still likely to be problematic in the final link
phase, because .bss can very well be more than 1MB away from .text
(with .rodata and .data between them).

So, let's split 'adr x0, symbol' in two steps: 'adrp x0, symbol' (which
generates a relocation of type R_AARCH64_ADR_PREL_PG_HI21 for the 4K
page offset) followed by 'add x0, x0, :lo12:symbol' (which generates a
R_AARCH64_ADD_ABS_LO12 relocation for the offset into the page). The
accessible range becomes +/-4GB.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Reported-by: Guanchao Liang <liangguanchao1@huawei.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
