### PR TITLE
mmu: fix boot failure on specified SOC

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -405,9 +405,18 @@ void core_init_mmu_tables(struct tee_mmap_region *mm)
 		if (!core_mmu_is_dynamic_vaspace(mm + n))
 			core_mmu_map_region(mm + n);
 
-	for (n = 1; n < CFG_TEE_CORE_NB_CORE; n++)
-		memcpy(l1_xlation_table[0][n], l1_xlation_table[0][0],
-			XLAT_ENTRY_SIZE * NUM_L1_ENTRIES);
+	/*
+	 * Primary mapping table is ready at index `get_core_pos()`
+	 * whose value may not be ZERO. Take this index as copy source.
+	 */
+	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++) {
+		if (n == get_core_pos())
+			continue;
+
+		memcpy(l1_xlation_table[0][n],
+		       l1_xlation_table[0][get_core_pos()],
+		       XLAT_ENTRY_SIZE * NUM_L1_ENTRIES);
+	}
 
 	for (n = 1; n < NUM_L1_ENTRIES; n++) {
 		if (!l1_xlation_table[0][0][n]) {


### PR DESCRIPTION
SOC has configurable core settings (e.g., Juno) does not
take core-0 as primary core. Copying mapping table of core-0
to other cores causes boot failure on such configured SOC.
Fix this problem by taking mapping table of actual primary
core as copy source.

Signed-off-by: Ken Liu <ken.liu@arm.com>