### PR TITLE
plat-ls: move some CFG_'s from platform_config.h to conf.mk

### DIFF
--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -8,12 +8,14 @@ $(call force,CFG_PM_STUBS,y)
 
 ifeq ($(PLATFORM_FLAVOR),ls1021atwr)
 include core/arch/arm/cpu/cortex-a7.mk
+CFG_TEE_CORE_NB_CORE = 2
 CFG_BOOT_SYNC_CPU ?= y
 CFG_BOOT_SECONDARY_REQUEST ?= y
 endif
 
 ifeq ($(PLATFORM_FLAVOR),ls1021aqds)
 include core/arch/arm/cpu/cortex-a7.mk
+CFG_TEE_CORE_NB_CORE = 2
 CFG_BOOT_SYNC_CPU ?= y
 CFG_BOOT_SECONDARY_REQUEST ?= y
 endif
@@ -21,16 +23,19 @@ endif
 ifeq ($(PLATFORM_FLAVOR),ls1012ardb)
 CFG_HW_UNQ_KEY_REQUEST ?= y
 include core/arch/arm/cpu/cortex-armv8-0.mk
+CFG_TEE_CORE_NB_CORE = 1
 endif
 
 ifeq ($(PLATFORM_FLAVOR),ls1043ardb)
 CFG_HW_UNQ_KEY_REQUEST ?= y
 include core/arch/arm/cpu/cortex-armv8-0.mk
+CFG_TEE_CORE_NB_CORE = 4
 endif
 
 ifeq ($(PLATFORM_FLAVOR),ls1046ardb)
 CFG_HW_UNQ_KEY_REQUEST ?= y
 include core/arch/arm/cpu/cortex-armv8-0.mk
+CFG_TEE_CORE_NB_CORE = 4
 endif
 
 ifeq ($(platform-flavor-armv8),1)

--- a/core/arch/arm/plat-ls/platform_config.h
+++ b/core/arch/arm/plat-ls/platform_config.h
@@ -69,61 +69,44 @@
 
 #if defined(PLATFORM_FLAVOR_ls1021aqds)
 #define DRAM0_SIZE			0x80000000
-#define CFG_DDR_TEETZ_RESERVED_START	0xFC000000
-#define CFG_DDR_TEETZ_RESERVED_SIZE	0x03F00000
+#define TZDDR_START			0xFC000000
+#define TZDDR_SIZE			0x03F00000
 #define TEE_RAM_VA_SIZE			(1024 * 1024)
-#define CFG_PUB_RAM_SIZE		(1024 * 1024)
-#define CFG_TEE_CORE_NB_CORE		2
+#define TEE_SHMEM_SIZE			(1024 * 1024)
 #endif
 
 #if defined(PLATFORM_FLAVOR_ls1021atwr)
 #define DRAM0_SIZE			0x40000000
-#define CFG_DDR_TEETZ_RESERVED_START	0xBC000000
-#define CFG_DDR_TEETZ_RESERVED_SIZE	0x03F00000
+#define TZDDR_START			0xBC000000
+#define TZDDR_SIZE			0x03F00000
 #define TEE_RAM_VA_SIZE			(1024 * 1024)
-#define CFG_PUB_RAM_SIZE		(1024 * 1024)
-#define CFG_TEE_CORE_NB_CORE		2
+#define TEE_SHMEM_SIZE			(1024 * 1024)
 #endif
 
 #if defined(PLATFORM_FLAVOR_ls1043ardb) || defined(PLATFORM_FLAVOR_ls1046ardb)
 #define DRAM0_SIZE			0x80000000
-#define CFG_DDR_TEETZ_RESERVED_START	0xFC000000
-#define CFG_DDR_TEETZ_RESERVED_SIZE	0x04000000
+#define TZDDR_START			0xFC000000
+#define TZDDR_SIZE			0x04000000
 #define TEE_RAM_VA_SIZE			(2 * 1024 * 1024)
-#define CFG_PUB_RAM_SIZE		(2 * 1024 * 1024)
-#define CFG_TEE_CORE_NB_CORE		4
+#define TEE_SHMEM_SIZE			(2 * 1024 * 1024)
 #endif
 
 #if defined(PLATFORM_FLAVOR_ls1012ardb)
 #define DRAM0_SIZE			0x40000000
-#define CFG_DDR_TEETZ_RESERVED_START	0xBC000000
-#define CFG_DDR_TEETZ_RESERVED_SIZE	0x04000000
+#define TZDDR_START			0xBC000000
+#define TZDDR_SIZE			0x04000000
 #define TEE_RAM_VA_SIZE			(2 * 1024 * 1024)
-#define CFG_PUB_RAM_SIZE		(2 * 1024 * 1024)
-#define CFG_TEE_CORE_NB_CORE		1
-#endif
-
-#define DDR_PHYS_START			DRAM0_BASE
-#define DDR_SIZE			DRAM0_SIZE
-
-#define CFG_DDR_START			DDR_PHYS_START
-#define CFG_DDR_SIZE			DDR_SIZE
-
-#ifndef CFG_DDR_TEETZ_RESERVED_START
-#error "TEETZ reserved DDR start address undef: CFG_DDR_TEETZ_RESERVED_START"
-#endif
-#ifndef CFG_DDR_TEETZ_RESERVED_SIZE
-#error "TEETZ reserved DDR siez undefined: CFG_DDR_TEETZ_RESERVED_SIZE"
+#define TEE_SHMEM_SIZE			(2 * 1024 * 1024)
 #endif
 
 /*
  * TEE/TZ RAM layout:
  *
- *  +-----------------------------------------+  <- CFG_DDR_TEETZ_RESERVED_START
+ *  +-----------------------------------------+  <- TZDDR_START
  *  | TEETZ private RAM  |  TEE_RAM           |   ^
  *  |                    +--------------------+   |
  *  |                    |  TA_RAM            |   |
- *  +-----------------------------------------+   | CFG_DDR_TEETZ_RESERVED_SIZE
+ *  +-----------------------------------------+   | TZDDR_SIZE
  *  |                    |      teecore alloc |   |
  *  |  TEE/TZ and NSec   |  PUB_RAM   --------|   |
  *  |   shared memory    |         NSec alloc |   |
@@ -135,21 +118,20 @@
  */
 
 /* define the several memory area sizes */
-#if (CFG_DDR_TEETZ_RESERVED_SIZE < (4 * 1024 * 1024))
-#error "Invalid CFG_DDR_TEETZ_RESERVED_SIZE: at least 4MB expected"
+#if (TZDDR_SIZE < (4 * 1024 * 1024))
+#error "Invalid TZDDR_SIZE: at least 4MB expected"
 #endif
 
 /* Full GlobalPlatform test suite requires TEE_SHMEM_SIZE to be at least 2MB */
 #define TEE_RAM_PH_SIZE			TEE_RAM_VA_SIZE
-#define TA_RAM_SIZE			(CFG_DDR_TEETZ_RESERVED_SIZE - \
-					 TEE_RAM_PH_SIZE - CFG_PUB_RAM_SIZE)
+#define TA_RAM_SIZE			(TZDDR_SIZE - \
+					 TEE_RAM_PH_SIZE - TEE_SHMEM_SIZE)
 
 /* define the secure/unsecure memory areas */
-#define TZDRAM_BASE			(CFG_DDR_TEETZ_RESERVED_START)
+#define TZDRAM_BASE			TZDDR_START
 #define TZDRAM_SIZE			(TEE_RAM_PH_SIZE + TA_RAM_SIZE)
 
 #define TEE_SHMEM_START			(TZDRAM_BASE + TZDRAM_SIZE)
-#define TEE_SHMEM_SIZE			 CFG_PUB_RAM_SIZE
 
 /* define the memory areas (TEE_RAM must start at reserved DDR start addr */
 #define TEE_RAM_START			TZDRAM_BASE


### PR DESCRIPTION
Remove `CFG_DDR_TEETZ_RESERVED_START/_SIZE:` internal to platform.
Remove `CFG_PUB_RAM_SIZE`, use `TEE_SHMEM_SIZE` instead.
Remove useless definition of `DDR_PHYS_START`, `DDR_SIZE`, `DRAM0_BASE/_SIZE`,
`CFG_DDR_START/_SIZE`.

@@b49020 and @pangupta,
This P-R removes `CFG_` definitions from plat-lsplatform_config.h file.
Could you have a look and report comments or ack the changes.
regards

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
