### PR TITLE
plat-ti: move some CFG_'s from platform_config.h to conf.mk

### DIFF
--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -11,23 +11,36 @@ else
 CFG_TEE_SDP_MEM_SIZE ?= 0x0
 endif
 
-$(call force,CFG_8250_UART,y)
-$(call force,CFG_ARM32_core,y)
-$(call force,CFG_GENERIC_BOOT,y)
-$(call force,CFG_PM_STUBS,y)
+ifeq ($(PLATFORM_FLAVOR),dra7xx)
+include core/arch/arm/cpu/cortex-a15.mk
+CFG_TEE_CORE_NB_CORE = 2
+CFG_OTP_SUPPORT ?= y
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+endif #dra7xx
+
+ifeq ($(PLATFORM_FLAVOR),am57xx)
+include core/arch/arm/cpu/cortex-a15.mk
+CFG_TEE_CORE_NB_CORE = 2
+CFG_OTP_SUPPORT ?= y
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+endif #am57xx
+
 ifeq ($(PLATFORM_FLAVOR),am43xx)
+include core/arch/arm/cpu/cortex-a9.mk
+CFG_TEE_CORE_NB_CORE = 1
+
 CFG_WITH_SOFTWARE_PRNG = y
 $(call force,CFG_NO_SMP,y)
 $(call force,CFG_PL310,y)
 $(call force,CFG_PL310_LOCKED,y)
 $(call force,CFG_PM_ARM32,y)
 $(call force,CFG_SECURE_TIME_SOURCE_REE,y)
-include core/arch/arm/cpu/cortex-a9.mk
-else
-CFG_OTP_SUPPORT ?= y
-$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
-include core/arch/arm/cpu/cortex-a15.mk
-endif
+endif #am43xx
+
+$(call force,CFG_8250_UART,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_PM_STUBS,y)
 $(call force,CFG_SM_PLATFORM_HANDLER,y)
 $(call force,CFG_GIC,y)
 ifneq ($(CFG_WITH_SOFTWARE_PRNG),y)

--- a/core/arch/arm/plat-ti/platform_config.h
+++ b/core/arch/arm/plat-ti/platform_config.h
@@ -20,7 +20,6 @@
 #define TZSRAM_SIZE     (256 * 1024)
 #endif /* CFG_WITH_PAGER */
 
-#define CFG_TEE_CORE_NB_CORE	2
 
 #define UART1_BASE      0x4806A000
 #define UART2_BASE      0x4806C000
@@ -56,8 +55,6 @@
 /* Location of protected DDR on the AM43xx platform */
 #define TZDRAM_BASE     0xbdb00000
 #define TZDRAM_SIZE     0x01c00000
-
-#define CFG_TEE_CORE_NB_CORE	1
 
 #define UART0_BASE      0x44E09000
 #define UART1_BASE      0x48022000


### PR DESCRIPTION
@glneo,
This P-R is small changes. It removes `CFG_` definitions from **plat-ti/platform_config.h** file.
Could you please ack the changes or report issues or comments you would like to share?
regards