### PR TITLE
plat-imx: implement PL310 SMC protocol

### DIFF
--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -89,6 +89,8 @@
 #define ACTLR_CA15_ENABLE_INVALIDATE_BTB	BIT(0)
 /* Only valid for Cortex-A8 */
 #define ACTLR_CA8_ENABLE_INVALIDATE_BTB		BIT(6)
+/* Only valid for Cortex-A9 */
+#define ACTLR_CA9_WFLZ				BIT(3)
 
 #define ACTLR_SMP	BIT32(6)
 

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -296,7 +296,7 @@ KEEP_INIT _start
 	 * Use ANSI #define to trap source file line number for PL310 assertion
 	 */
 	.macro __inval_cache_vrange vbase, vend, line
-#ifdef CFG_PL310
+#if defined(CFG_PL310) && !defined(CFG_PL310_SIP_PROTOCOL)
 		assert_flat_mapped_range (\vbase), (\line)
 		bl	pl310_base
 		ldr	r1, =(\vbase)
@@ -310,7 +310,7 @@ KEEP_INIT _start
 	.endm
 
 	.macro __flush_cache_vrange vbase, vend, line
-#ifdef CFG_PL310
+#if defined(CFG_PL310) && !defined(CFG_PL310_SIP_PROTOCOL)
 		assert_flat_mapped_range (\vbase), (\line)
 		ldr	r0, =(\vbase)
 		ldr	r1, =(\vend)
@@ -436,7 +436,7 @@ shadow_stack_access_ok:
 	inval_cache_vrange(__text_start, __end)
 #endif
 
-#ifdef CFG_PL310
+#if defined(CFG_PL310) && !defined(CFG_PL310_SIP_PROTOCOL)
 	/* Enable PL310 if not yet enabled */
 	bl	pl310_base
 	bl	arm_cl2_enable
@@ -473,6 +473,9 @@ shadow_stack_access_ok:
 	wait_secondary
 
 #ifdef CFG_PL310_LOCKED
+#ifdef CFG_PL310_SIP_PROTOCOL
+#error "CFG_PL310_LOCKED must not be defined when CFG_PL310_SIP_PROTOCOL=y"
+#endif
 	/* lock/invalidate all lines: pl310 behaves as if disable */
 	bl	pl310_base
 	bl	arm_cl2_lockallways

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -75,9 +75,9 @@ include core/arch/arm/cpu/cortex-a9.mk
 
 $(call force,CFG_MX6,y)
 $(call force,CFG_PL310,y)
-$(call force,CFG_PL310_LOCKED,y)
 $(call force,CFG_SECURE_TIME_SOURCE_REE,y)
 
+CFG_PL310_LOCKED ?= y
 CFG_BOOT_SYNC_CPU ?= y
 CFG_BOOT_SECONDARY_REQUEST ?= y
 CFG_ENABLE_SCTLR_RR ?= y

--- a/core/arch/arm/plat-imx/imx_pl310.c
+++ b/core/arch/arm/plat-imx/imx_pl310.c
@@ -12,8 +12,14 @@
 #include <kernel/tz_ssvce_pl310.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <sm/optee_smc.h>
 #include <platform_config.h>
 #include <stdint.h>
+#include "imx_pl310.h"
+
+#define PL310_AUX_CTRL_FLZW			BIT(0)
+#define PL310_DEBUG_CTRL_DISABLE_WRITEBACK	BIT(1)
+#define PL310_DEBUG_CTRL_DISABLE_LINEFILL	BIT(0)
 
 register_phys_mem(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_DEVICE_SIZE);
 
@@ -34,15 +40,17 @@ void arm_cl2_config(vaddr_t pl310_base)
 
 void arm_cl2_enable(vaddr_t pl310_base)
 {
-	uint32_t val;
+	uint32_t val __maybe_unused;
 
 	/* Enable PL310 ctrl -> only set lsb bit */
 	write32(1, pl310_base + PL310_CTRL);
 
+#ifndef CFG_PL310_SIP_PROTOCOL
 	/* if L2 FLZW enable, enable in L1 */
 	val = read32(pl310_base + PL310_AUX_CTRL);
-	if (val & 1)
-		write_actlr(read_actlr() | (1 << 3));
+	if (val & PL310_AUX_CTRL_FLZW)
+		write_actlr(read_actlr() | ACTLR_CA9_WFLZ);
+#endif
 }
 
 vaddr_t pl310_base(void)
@@ -50,3 +58,43 @@ vaddr_t pl310_base(void)
 	return core_mmu_get_va(PL310_BASE, MEM_AREA_IO_SEC);
 }
 
+#ifdef CFG_PL310_SIP_PROTOCOL
+uint32_t pl310_enable(void)
+{
+	vaddr_t base = pl310_base();
+
+	arm_cl2_config(base);
+	arm_cl2_enable(base);
+	return OPTEE_SMC_RETURN_OK;
+}
+
+uint32_t pl310_disable(void)
+{
+	EMSG("not implemented");
+	return OPTEE_SMC_RETURN_ENOTAVAIL;
+}
+
+uint32_t pl310_enable_writeback(void)
+{
+	vaddr_t base = pl310_base();
+
+	write32(0, base + PL310_DEBUG_CTRL);
+	return OPTEE_SMC_RETURN_OK;
+}
+
+uint32_t pl310_disable_writeback(void)
+{
+	vaddr_t base = pl310_base();
+	uint32_t val = PL310_DEBUG_CTRL_DISABLE_WRITEBACK |
+		       PL310_DEBUG_CTRL_DISABLE_LINEFILL;
+
+	write32(val, base + PL310_DEBUG_CTRL);
+	return OPTEE_SMC_RETURN_OK;
+}
+
+uint32_t pl310_enable_wflz(void)
+{
+	write_actlr(read_actlr() | ACTLR_CA9_WFLZ);
+	return OPTEE_SMC_RETURN_OK;
+}
+#endif

--- a/core/arch/arm/plat-imx/imx_pl310.h
+++ b/core/arch/arm/plat-imx/imx_pl310.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+#ifndef __IMX_PL310_H__
+#define __IMX_PL310_H__
+
+uint32_t pl310_enable(void);
+uint32_t pl310_disable(void);
+uint32_t pl310_enable_writeback(void);
+uint32_t pl310_disable_writeback(void);
+uint32_t pl310_enable_wflz(void);
+
+#endif /* __IMX_PL310_H__ */
+

--- a/core/arch/arm/plat-imx/imx_sip.h
+++ b/core/arch/arm/plat-imx/imx_sip.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+#ifndef __IMX_SIP_H__
+#define __IMX_SIP_H__
+
+#define IMX_SIP_PL310_ENABLE			1
+#define IMX_SIP_PL310_DISABLE			2
+#define IMX_SIP_PL310_ENABLE_WRITEBACK		3
+#define IMX_SIP_PL310_DISABLE_WRITEBACK		4
+#define IMX_SIP_PL310_ENABLE_WFLZ		5
+
+#endif /* __IMX_SIP_H__ */

--- a/core/arch/arm/plat-imx/sm_platform_handler.c
+++ b/core/arch/arm/plat-imx/sm_platform_handler.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+#include <kernel/thread.h>
+#include <sm/optee_smc.h>
+#include <sm/sm.h>
+#include <trace.h>
+#include "imx_sip.h"
+#include "imx_pl310.h"
+
+static bool imx_sip_handler(struct thread_smc_args *smc_args)
+{
+	uint16_t sip_func = OPTEE_SMC_FUNC_NUM(smc_args->a0);
+
+	switch (sip_func) {
+#ifdef CFG_PL310_SIP_PROTOCOL
+	case IMX_SIP_PL310_ENABLE:
+		smc_args->a0 = pl310_enable();
+		break;
+	case IMX_SIP_PL310_DISABLE:
+		smc_args->a0 = pl310_disable();
+		break;
+	case IMX_SIP_PL310_ENABLE_WRITEBACK:
+		smc_args->a0 = pl310_enable_writeback();
+		break;
+	case IMX_SIP_PL310_DISABLE_WRITEBACK:
+		smc_args->a0 = pl310_disable_writeback();
+		break;
+	case IMX_SIP_PL310_ENABLE_WFLZ:
+		smc_args->a0 = pl310_enable_wflz();
+		break;
+#endif
+	default:
+		EMSG("Invalid SIP function code: 0x%x", sip_func);
+		smc_args->a0 = OPTEE_SMC_RETURN_EBADCMD;
+		break;
+	}
+
+	return false;
+}
+
+bool sm_platform_handler(struct sm_ctx *ctx)
+{
+	uint32_t *nsec_r0 = (uint32_t *)(&ctx->nsec.r0);
+	uint16_t smc_owner = OPTEE_SMC_OWNER_NUM(*nsec_r0);
+
+	switch (smc_owner) {
+	case OPTEE_SMC_OWNER_SIP:
+		return imx_sip_handler((struct thread_smc_args *)nsec_r0);
+	default:
+		return true;
+	}
+}

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -12,6 +12,7 @@ endif
 ifneq (,$(filter y, $(CFG_MX6Q) $(CFG_MX6D) $(CFG_MX6DL) $(CFG_MX6S) \
        $(CFG_MX6SX)))
 srcs-y += a9_plat_init.S imx6.c
+srcs-$(CFG_SM_PLATFORM_HANDLER) += sm_platform_handler.c
 endif
 
 ifneq (,$(filter y, $(CFG_MX6UL) $(CFG_MX6ULL)))


### PR DESCRIPTION
When Windows runs in normal world, it expects the PL310 to be initially
disabled. Windows then invokes SMCs to turn on the L2 cache.

@MrVan, this builds on #2036, but implements the Windows protocol for enabling the PL310.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
