### PR TITLE
Fix crash when bumping qemu to 2.12.0

### DIFF
--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -64,7 +64,7 @@ $(call force,CFG_DT,y)
 # SE API is only supported by QEMU Virt platform
 CFG_SE_API ?= y
 CFG_SE_API_SELF_TEST ?= y
-CFG_PCSC_PASSTHRU_READER_DRV ?= y
+CFG_PCSC_PASSTHRU_READER_DRV ?= n
 endif
 
 ifeq ($(PLATFORM_FLAVOR),fvp)


### PR DESCRIPTION
https://github.com/OP-TEE/manifest/pull/111 is needed for building on hosts with glibc >= 2.27. That PR causes a crash without this patch.
This has been tested on qemu with glibc 2.27 and 2.26 with and without https://github.com/OP-TEE/manifest/pull/111.
Fixes: https://github.com/OP-TEE/optee_os/issues/2291
Signed-off-by: illustris <rharikrishnan95@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
