### PR TITLE
plat-imx: ensure CNTFRQ is consistent across cores

### DIFF
--- a/core/arch/arm/plat-imx/imx7.c
+++ b/core/arch/arm/plat-imx/imx7.c
@@ -27,11 +27,17 @@
 
 void plat_cpu_reset_late(void)
 {
+	static uint32_t cntfrq;
 	uintptr_t addr;
 	uint32_t val;
 
-	if (get_core_pos() != 0)
+	if (get_core_pos() != 0) {
+		/*  Ensure the counter frequency is consistent across cores */
+		write_cntfrq(cntfrq);
 		return;
+	}
+
+	cntfrq = read_cntfrq();
 
 	/*
 	 * Configure imx7 CSU, first grant all peripherals


### PR DESCRIPTION
CNTFRQ must be consistent accross cores, and must be initialized
in secure world.

Tested-by: Jordan Rhee <jordanrh@microsoft.com>
Signed-off-by: Jordan Rhee <jordanrh@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
