### PR TITLE
arm32: stack unwinding for dynamically linked TAs

### DIFF
--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -23,6 +23,7 @@ TAILQ_HEAD(user_ta_elf_head, user_ta_elf);
  * @entry_func:		Entry address in TA
  * @exidx_start:	32-bit TA: start of exception handling index table
  * @exidx_size:		32-bit TA: size of of exception handling index table
+ * @mobj_exidx:         32-bit TA: consolidated EXIDX table (if several ELFs)
  * @is_32bit:		True if 32-bit TA, false if 64-bit TA
  * @open_sessions:	List of sessions opened by this TA
  * @cryp_states:	List of cryp states created by this TA
@@ -43,6 +44,7 @@ struct user_ta_ctx {
 	uaddr_t entry_func;
 	uaddr_t exidx_start;
 	size_t exidx_size;
+	struct mobj *mobj_exidx;
 	bool is_32bit;
 	struct tee_ta_session_head open_sessions;
 	struct tee_cryp_state_head cryp_states;


### PR DESCRIPTION
Update the ELF loader so that TAs that contain multiple ELF binaries
have a valid exception index table (EXIDX). This table is the entry
point for the call stack unwinding code. When a TA uses shared
libraries, we create a new EXIDX table by joining all the tables found
in each ELF and patching them to account for the new table address.
Information about the ARM unwind tables can be found in [1].

Link: [1] https://wiki.linaro.org/KenWerner/Sandbox/libunwind?action=AttachFile&do=get&target=libunwind-LDS.pdf
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
