### PR TITLE
Use common helper routines to initialize cntfrq on secondary cores

### DIFF
--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -49,6 +49,7 @@ $(call force,CFG_WITH_LPAE,y)
 ta-targets = ta_arm64
 else
 $(call force,CFG_ARM32_core,y)
+$(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
 endif
 
 CFG_CRYPTO_SIZE_OPTIMIZATION ?= n

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -89,13 +89,9 @@ static void main_fiq(void)
 #ifdef CFG_ARM32_core
 void plat_cpu_reset_late(void)
 {
-	static uint32_t cntfrq;
 	vaddr_t addr;
 
 	if (!get_core_pos()) {
-		/* read cnt freq */
-		cntfrq = read_cntfrq();
-
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
 		/* set secondary entry address */
 		write32(__compiler_bswap32(TEE_LOAD_ADDR),
@@ -129,9 +125,6 @@ void plat_cpu_reset_late(void)
 			write32(read32(addr) |
 				__compiler_bswap32(CSU_SETTING_LOCK),
 				addr);
-	} else {
-		/* program the cntfrq, the cntfrq is banked for each core */
-		write_cntfrq(cntfrq);
 	}
 }
 #endif


### PR DESCRIPTION
This is an alternate proposal to #2296 that uses generic code and a configuration option to initialize CNTFRQ on secondary cores.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
