### PR TITLE
core_self_tests:.c: add ADD_OVERFLOW() test

### DIFF
--- a/core/arch/arm/pta/core_self_tests.c
+++ b/core/arch/arm/pta/core_self_tests.c
@@ -92,6 +92,10 @@ static int self_test_sub_overflow(void)
 	uint32_t r_u32;
 	int32_t r_s32;
 
+	if (SUB_OVERFLOW(8U, 1U, &r_s32))
+		return -1;
+	if (r_s32 != 7)
+		return -1;
 	if (SUB_OVERFLOW(32U, 30U, &r_u32))
 		return -1;
 	if (r_u32 != 2)

--- a/core/arch/arm/pta/core_self_tests.c
+++ b/core/arch/arm/pta/core_self_tests.c
@@ -46,6 +46,10 @@ static int self_test_add_overflow(void)
 	uint32_t r_u32;
 	int32_t r_s32;
 
+	if (ADD_OVERFLOW(8U, 0U, &r_s32))
+		return -1;
+	if (r_s32 != 8)
+		return -1;
 	if (ADD_OVERFLOW(32U, 30U, &r_u32))
 		return -1;
 	if (r_u32 != 62)


### PR DESCRIPTION
Add a test that fails with GCC 4.9.4 (Linaro GCC 4.9-2017.01) [1]

Link: http://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
