### PR TITLE
core: fix OOM handling in tee_svc_storage_read_head()

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -240,10 +240,12 @@ static TEE_Result tee_svc_storage_read_head(struct tee_obj *o)
 		bytes = head.attr_size;
 		res = fops->read(o->fh, sizeof(struct tee_svc_storage_head),
 				 attr, &bytes);
-		if (res != TEE_SUCCESS || bytes != head.attr_size) {
-			res = TEE_ERROR_CORRUPT_OBJECT;
+		if (res == TEE_ERROR_OUT_OF_MEMORY)
 			goto exit;
-		}
+		if (res != TEE_SUCCESS || bytes != head.attr_size)
+			res = TEE_ERROR_CORRUPT_OBJECT;
+		if (res)
+			goto exit;
 	}
 
 	res = tee_obj_attr_from_binary(o, attr, head.attr_size);


### PR DESCRIPTION
Fixes out of memory handling error in tee_svc_storage_read_head(). Prior
to this all errors from fops->read() was reported as
TEE_ERROR_CORRUPT_OBJECT leading to removal of the object even when the
real problem was temporary memory shortage. This patch reports
TEE_ERROR_OUT_OF_MEMORY from fops->read() correctly while translating
all other errors to TEE_ERROR_CORRUPT_OBJECT.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Fixes https://github.com/OP-TEE/optee_os/issues/2310