### PR TITLE
plat-ls: move to generic RAM layout

### DIFF
--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -9,6 +9,10 @@ $(call force,CFG_PM_STUBS,y)
 ifeq ($(PLATFORM_FLAVOR),ls1021atwr)
 include core/arch/arm/cpu/cortex-a7.mk
 CFG_TEE_CORE_NB_CORE = 2
+CFG_TZDRAM_START ?= 0xbc000000
+CFG_TZDRAM_SIZE ?= 0x03e00000
+CFG_SHMEM_START ?= 0xbfe00000
+CFG_SHMEM_SIZE ?= 0x00100000
 CFG_BOOT_SYNC_CPU ?= y
 CFG_BOOT_SECONDARY_REQUEST ?= y
 endif
@@ -16,6 +20,10 @@ endif
 ifeq ($(PLATFORM_FLAVOR),ls1021aqds)
 include core/arch/arm/cpu/cortex-a7.mk
 CFG_TEE_CORE_NB_CORE = 2
+CFG_TZDRAM_START ?= 0xfc000000
+CFG_TZDRAM_SIZE ?= 0x03e00000
+CFG_SHMEM_START ?= 0xffe00000
+CFG_SHMEM_SIZE ?= 0x00100000
 CFG_BOOT_SYNC_CPU ?= y
 CFG_BOOT_SECONDARY_REQUEST ?= y
 endif
@@ -24,18 +32,30 @@ ifeq ($(PLATFORM_FLAVOR),ls1012ardb)
 CFG_HW_UNQ_KEY_REQUEST ?= y
 include core/arch/arm/cpu/cortex-armv8-0.mk
 CFG_TEE_CORE_NB_CORE = 1
+CFG_TZDRAM_START ?= 0xbc000000
+CFG_TZDRAM_SIZE ?= 0x03e00000
+CFG_SHMEM_START ?= 0xbfe00000
+CFG_SHMEM_SIZE ?= 0x00200000
 endif
 
 ifeq ($(PLATFORM_FLAVOR),ls1043ardb)
 CFG_HW_UNQ_KEY_REQUEST ?= y
 include core/arch/arm/cpu/cortex-armv8-0.mk
 CFG_TEE_CORE_NB_CORE = 4
+CFG_TZDRAM_START ?= 0xfc000000
+CFG_TZDRAM_SIZE ?= 0x03e00000
+CFG_SHMEM_START ?= 0xbfe00000
+CFG_SHMEM_SIZE ?= 0x00200000
 endif
 
 ifeq ($(PLATFORM_FLAVOR),ls1046ardb)
 CFG_HW_UNQ_KEY_REQUEST ?= y
 include core/arch/arm/cpu/cortex-armv8-0.mk
 CFG_TEE_CORE_NB_CORE = 4
+CFG_TZDRAM_START ?= 0xfc000000
+CFG_TZDRAM_SIZE ?= 0x03e00000
+CFG_SHMEM_START ?= 0xbfe00000
+CFG_SHMEM_SIZE ?= 0x00200000
 endif
 
 ifeq ($(platform-flavor-armv8),1)

--- a/core/arch/arm/plat-ls/platform_config.h
+++ b/core/arch/arm/plat-ls/platform_config.h
@@ -29,6 +29,8 @@
 #ifndef PLATFORM_CONFIG_H
 #define PLATFORM_CONFIG_H
 
+#include <mm/generic_ram_layout.h>
+
 #define STACK_ALIGNMENT			64
 
 #define GIC_BASE			0x01400000
@@ -59,7 +61,6 @@
 /*  LPUART 2 */
 #define UART3_BASE			0x02960000
 
-
 /* console uart define */
 #define CONSOLE_UART_BASE		UART0_BASE
 
@@ -69,78 +70,18 @@
 
 #if defined(PLATFORM_FLAVOR_ls1021aqds)
 #define DRAM0_SIZE			0x80000000
-#define TZDDR_START			0xFC000000
-#define TZDDR_SIZE			0x03F00000
-#define TEE_RAM_VA_SIZE			(1024 * 1024)
-#define TEE_SHMEM_SIZE			(1024 * 1024)
 #endif
 
 #if defined(PLATFORM_FLAVOR_ls1021atwr)
 #define DRAM0_SIZE			0x40000000
-#define TZDDR_START			0xBC000000
-#define TZDDR_SIZE			0x03F00000
-#define TEE_RAM_VA_SIZE			(1024 * 1024)
-#define TEE_SHMEM_SIZE			(1024 * 1024)
 #endif
 
 #if defined(PLATFORM_FLAVOR_ls1043ardb) || defined(PLATFORM_FLAVOR_ls1046ardb)
 #define DRAM0_SIZE			0x80000000
-#define TZDDR_START			0xFC000000
-#define TZDDR_SIZE			0x04000000
-#define TEE_RAM_VA_SIZE			(2 * 1024 * 1024)
-#define TEE_SHMEM_SIZE			(2 * 1024 * 1024)
 #endif
 
 #if defined(PLATFORM_FLAVOR_ls1012ardb)
 #define DRAM0_SIZE			0x40000000
-#define TZDDR_START			0xBC000000
-#define TZDDR_SIZE			0x04000000
-#define TEE_RAM_VA_SIZE			(2 * 1024 * 1024)
-#define TEE_SHMEM_SIZE			(2 * 1024 * 1024)
-#endif
-
-/*
- * TEE/TZ RAM layout:
- *
- *  +-----------------------------------------+  <- TZDDR_START
- *  | TEETZ private RAM  |  TEE_RAM           |   ^
- *  |                    +--------------------+   |
- *  |                    |  TA_RAM            |   |
- *  +-----------------------------------------+   | TZDDR_SIZE
- *  |                    |      teecore alloc |   |
- *  |  TEE/TZ and NSec   |  PUB_RAM   --------|   |
- *  |   shared memory    |         NSec alloc |   |
- *  +-----------------------------------------+   v
- *
- *  TEE_RAM : 1MByte
- *  PUB_RAM : 1MByte
- *  TA_RAM  : all what is left (at least 2MByte !)
- */
-
-/* define the several memory area sizes */
-#if (TZDDR_SIZE < (4 * 1024 * 1024))
-#error "Invalid TZDDR_SIZE: at least 4MB expected"
-#endif
-
-/* Full GlobalPlatform test suite requires TEE_SHMEM_SIZE to be at least 2MB */
-#define TEE_RAM_PH_SIZE			TEE_RAM_VA_SIZE
-#define TA_RAM_SIZE			(TZDDR_SIZE - \
-					 TEE_RAM_PH_SIZE - TEE_SHMEM_SIZE)
-
-/* define the secure/unsecure memory areas */
-#define TZDRAM_BASE			TZDDR_START
-#define TZDRAM_SIZE			(TEE_RAM_PH_SIZE + TA_RAM_SIZE)
-
-#define TEE_SHMEM_START			(TZDRAM_BASE + TZDRAM_SIZE)
-
-/* define the memory areas (TEE_RAM must start at reserved DDR start addr */
-#define TEE_RAM_START			TZDRAM_BASE
-#define TA_RAM_START			(TEE_RAM_START + TEE_RAM_PH_SIZE)
-
-#ifdef CFG_TEE_LOAD_ADDR
-#define TEE_LOAD_ADDR			CFG_TEE_LOAD_ADDR
-#else
-#define TEE_LOAD_ADDR			TEE_RAM_START
 #endif
 
 #endif /*PLATFORM_CONFIG_H*/


### PR DESCRIPTION
Move default secure and non-secure Optee memory locations from
**platform_config.h** to conf.mk using header **generic_ram_layout.h**.