### PR TITLE
util: remove unused macros

### DIFF
--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -93,13 +93,6 @@
 /*
  * Copied/inspired from https://www.fefe.de/intof.html
  */
-#define __INTOF_HALF_MAX_SIGNED(type) ((type)1 << (sizeof(type)*8-2))
-#define __INTOF_MAX_SIGNED(type) (__INTOF_HALF_MAX_SIGNED(type) - 1 + \
-			    __INTOF_HALF_MAX_SIGNED(type))
-#define __INTOF_MIN_SIGNED(type) (-1 - __INTOF_MAX_SIGNED(type))
-
-#define __INTOF_MIN(type) ((type)-1 < 1?__INTOF_MIN_SIGNED(type):(type)0)
-#define __INTOF_MAX(type) ((type)~__INTOF_MIN(type))
 
 #define __INTOF_ASSIGN(dest, src) (__extension__({ \
 	typeof(src) __intof_x = (src); \


### PR DESCRIPTION
After commit 9a8117de1263 ("util: update fallback ADD_OVERFLOW() macro")
and commit ecdedc94e720 ("util: update fallback SUB_OVERFLOW() macro"),
the following macros are not used anymore. Remove them.

 __INTOF_HALF_MAX_SIGNED(type)
 __INTOF_MAX_SIGNED(type)
 __INTOF_MIN_SIGNED(type)
 __INTOF_MIN(type)
 __INTOF_MAX(type)

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
