### PR TITLE
core: htree: fix meta inclusion in root hash

### DIFF
--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -415,7 +415,7 @@ static TEE_Result calc_node_hash(struct htree_node *node,
 		return res;
 
 	if (meta) {
-		res = crypto_hash_update(ctx, alg, (void *)meta, sizeof(meta));
+		res = crypto_hash_update(ctx, alg, (void *)meta, sizeof(*meta));
 		if (res != TEE_SUCCESS)
 			return res;
 	}


### PR DESCRIPTION
Prior to this patch was the size of the meta data supplied as the size
of the pointer to meta data. With this patch the size is corrected to be
the size of meta  data itself.

Fixes: https://github.com/OP-TEE/optee_os/issues/2330
Fixes: 94a72998bc1d ("core: fs_htree: include meta in root hash")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
