### PR TITLE
plat-marvell: support generic Ram layout

### DIFF
--- a/core/arch/arm/plat-marvell/conf.mk
+++ b/core/arch/arm/plat-marvell/conf.mk
@@ -2,14 +2,28 @@ PLATFORM_FLAVOR ?= armada7k8k
 
 ifeq ($(PLATFORM_FLAVOR),armada7k8k)
 include core/arch/arm/cpu/cortex-armv8-0.mk
-CFG_TEE_CORE_NB_CORE = 4
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+$(call force,CFG_TZDRAM_START,0x04400000)
+$(call force,CFG_TZDRAM_SIZE,0x00C00000)
+$(call force,CFG_SHMEM_START,0x05000000)
+$(call force,CFG_SHMEM_SIZE,0x00400000)
+$(call force,CFG_TEE_RAM_VA_SIZE,0x00400000)
+# If Secure Data Path is enabled, uses the TZDRAM last 4MByte
+$(call force,CFG_TEE_SDP_MEM_SIZE,0x00400000)
 platform-debugger-arm := 1
 $(call force,CFG_8250_UART,y)
 endif
 
 ifeq ($(PLATFORM_FLAVOR),armada3700)
 include core/arch/arm/cpu/cortex-armv8-0.mk
-CFG_TEE_CORE_NB_CORE = 2
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+$(call force,CFG_TZDRAM_START,0x04400000)
+$(call force,CFG_TZDRAM_SIZE,0x00C00000)
+$(call force,CFG_SHMEM_START,0x05000000)
+$(call force,CFG_SHMEM_SIZE,0x00400000)
+$(call force,CFG_TEE_RAM_VA_SIZE,0x00400000)
+# If Secure Data Path is enabled, uses the TZDRAM last 4MByte
+$(call force,CFG_TEE_SDP_MEM_SIZE,0x00400000)
 platform-debugger-arm := 1
 $(call force,CFG_MVEBU_UART,y)
 $(call force,CFG_ARM_GICV3,y)

--- a/core/arch/arm/plat-marvell/platform_config.h
+++ b/core/arch/arm/plat-marvell/platform_config.h
@@ -29,6 +29,7 @@
 #ifndef PLATFORM_CONFIG_H
 #define PLATFORM_CONFIG_H
 
+#include <mm/generic_ram_layout.h>
 #include <util.h>
 
 /* Make stacks aligned to data cache line length */
@@ -64,13 +65,6 @@
 #define MARVELL_CONSOLE_BAUDRATE                            115200
 
 #define CONSOLE_UART_BASE	PLAT_MARVELL_BOOT_UART_BASE
-
-/* Location of trusted dram */
-#define TZDRAM_BASE		0x04400000
-#define TZDRAM_SIZE		0x00C00000
-
-#define TEE_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
-#define TEE_SHMEM_SIZE		0x00400000
 
 #define GICC_OFFSET		0x10000
 #define GICD_OFFSET		0x0
@@ -109,64 +103,8 @@
 #define MARVELL_CONSOLE_BAUDRATE		115200
 #define CONSOLE_UART_BASE	PLAT_MARVELL_BOOT_UART_BASE
 
-/* Location of trusted dram */
-#define TZDRAM_BASE		0x04400000
-#define TZDRAM_SIZE		0x00C00000
-
-#define TEE_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
-#define TEE_SHMEM_SIZE		0x00400000
-
 #else
 #error "Unknown platform flavor"
-#endif
-
-#define TEE_RAM_VA_SIZE		SIZE_4M
-
-#ifdef CFG_TEE_LOAD_ADDR
-#define TEE_LOAD_ADDR			CFG_TEE_LOAD_ADDR
-#else
-#define TEE_LOAD_ADDR			TEE_RAM_START
-#endif
-
-/*
- * everything is in TZDRAM.
- * +------------------+
- * |        | TEE_RAM |
- * | TZDRAM +---------+
- * |        | TA_RAM  |
- * |        +---------+
- * |        | SDP RAM | (test pool, optional)
- * +--------+---------+
- */
-#define TEE_RAM_PH_SIZE		TEE_RAM_VA_SIZE
-#define TEE_RAM_START		TZDRAM_BASE
-#define TA_RAM_START		ROUNDUP(TZDRAM_BASE + TEE_RAM_VA_SIZE, \
-					CORE_MMU_DEVICE_SIZE)
-
-#define TA_RAM_SIZE		ROUNDDOWN(TZDRAM_SIZE - \
-					  (TA_RAM_START - TZDRAM_BASE) - \
-					  TEE_SDP_TEST_MEM_SIZE, \
-					  CORE_MMU_DEVICE_SIZE)
-
-/*
- * Secure data path test memory pool
- * - If no SDP, no SDP test memory.
- * - Can be provided by configuration directives CFG_TEE_SDP_MEM_BASE
- *   and CFG_TEE_SDP_MEM_TEST_SIZE.
- * - If only the size is defined by CFG_TEE_SDP_MEM_TEST_SIZE, default
- *   locate a SDP test memory and the end of the TA RAM.
- */
-#if defined(CFG_SECURE_DATA_PATH) && !defined(CFG_TEE_SDP_MEM_BASE)
-#if defined(CFG_TEE_SDP_MEM_TEST_SIZE)
-#define TEE_SDP_TEST_MEM_SIZE	CFG_TEE_SDP_MEM_TEST_SIZE
-#else
-#define TEE_SDP_TEST_MEM_SIZE	0x00400000
-#endif
-#define TEE_SDP_TEST_MEM_BASE	(TZDRAM_BASE + TZDRAM_SIZE - \
-					TEE_SDP_TEST_MEM_SIZE)
-#endif
-#ifndef TEE_SDP_TEST_MEM_SIZE
-#define TEE_SDP_TEST_MEM_SIZE	0
 #endif
 
 #ifdef GIC_BASE


### PR DESCRIPTION
Move default secure and non-secure Optee memory locations from
platform_config.h to conf.mk using the generic_ram_layout.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
Acked-by: Joakim Bech <joakim.bech@linaro.org>
Acked-by: Kevin Peng <kevinp@marvell.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
