### PR TITLE
core: fixed gcc 7 format-truncation errors

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -406,7 +406,7 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 	struct user_ta_ctx *utc = to_user_ta_ctx(ctx);
 	struct vm_region *r;
 	char flags[7] = { '\0', };
-	char desc[8];
+	char desc[13];
 	size_t n = 0;
 
 	EMSG_RAW(" arch: %s  load address: %#" PRIxVA " ctx-idr: %d",


### PR DESCRIPTION
gcc7 failed to build with -Werror=format-truncation.
snprintf() with format "[%d]" can output 12 bytes maximum because
the range of the argument are from 1 to 10 bytes. Thus we need to
enlarge the desc buffer to 13 bytes to avoid this error.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

> 

> CC out/arm-plat-sunxi/core/arch/arm/kernel/user_ta.o
> core/arch/arm/kernel/user_ta.c: In function ‘user_ta_dump_state’:
> core/arch/arm/kernel/user_ta.c:388:31: error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 7 [-Werror=format-truncation=]
>    snprintf(desc, desc_size, "[%d]", idx);
>                                ^~
> core/arch/arm/kernel/user_ta.c:388:29: note: directive argument in the range [0, 2147483647]
>    snprintf(desc, desc_size, "[%d]", idx);
>                              ^~~~~~
> core/arch/arm/kernel/user_ta.c:388:3: note: ‘snprintf’ output between 4 and 13 bytes into a destination of size 8
>    snprintf(desc, desc_size, "[%d]", idx);
>    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> {standard input}: Assembler messages:
> {standard input}:3569: Warning: setting incorrect section attributes for .rodata.__unpaged
> cc1: all warnings being treated as errors
> mk/compile.mk:146: recipe for target 'out/arm-plat-sunxi/core/arch/arm/kernel/user_ta.o' failed
> make: *** [out/arm-plat-sunxi/core/arch/arm/kernel/user_ta.o] Error 1
> 