### PR TITLE
user_ta: free all ELFs in case of error

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -960,10 +960,9 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 
 	/* Register context */
 	utc = calloc(1, sizeof(struct user_ta_ctx));
-	if (!utc) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
-		goto err;
-	}
+	if (!utc)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
 	TAILQ_INIT(&utc->open_sessions);
 	TAILQ_INIT(&utc->cryp_states);
 	TAILQ_INIT(&utc->objects);

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -1048,6 +1048,7 @@ err:
 		vm_info_final(utc);
 		free_elf_states(utc);
 		mobj_free(utc->mobj_stack);
+		free_elfs(utc);
 		free(utc);
 	}
 	return res;

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -1048,6 +1048,7 @@ err:
 		vm_info_final(utc);
 		free_elf_states(utc);
 		mobj_free(utc->mobj_stack);
+		mobj_free(utc->mobj_exidx);
 		free_elfs(utc);
 		free(utc);
 	}


### PR DESCRIPTION
tee_ta_init_user_ta_session() leaked allocated ELFs if
there was an error during initializastion.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

-----

This fixes another portion of #2327 
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
