### PR TITLE
plat-vexpress: qemu v8: increase default core count

### DIFF
--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -94,7 +94,7 @@ CFG_PCSC_PASSTHRU_READER_DRV ?= n
 endif
 
 ifeq ($(PLATFORM_FLAVOR),qemu_armv8a)
-CFG_TEE_CORE_NB_CORE = 2
+CFG_TEE_CORE_NB_CORE = 4
 # [0e00.0000 0e0f.ffff] is reserved to early boot
 CFG_TZDRAM_START ?= 0x0e100000
 CFG_TZDRAM_SIZE  ?= 0x00f00000


### PR DESCRIPTION
Increase CFG_TEE_CORE_NB_CORE to 4 for qemu_armv8a. This is to allow
more extensive tests of multithreading.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
