### PR TITLE
pta: add Pseudo TA for auxiliary crypto services

### DIFF
--- a/core/arch/arm/pta/sub.mk
+++ b/core/arch/arm/pta/sub.mk
@@ -10,6 +10,7 @@ srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_TA_GPROF_SUPPORT) += gprof.c
 srcs-$(CFG_TEE_BENCHMARK) += benchmark.c
 srcs-$(CFG_SDP_PTA) += sdp_pta.c
+srcs-$(CFG_SYSTEM_PTA) += system.c
 
 ifeq ($(CFG_SE_API),y)
 srcs-$(CFG_SE_API_SELF_TEST) += se_api_self_tests.c

--- a/core/arch/arm/pta/system.c
+++ b/core/arch/arm/pta/system.c
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+#include <kernel/msg_param.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/user_ta.h>
+#include <pta_system.h>
+#include <tee/tee_cryp_utl.h>
+#include <util.h>
+
+#define MAX_ENTROPY_IN			32u
+
+static TEE_Result system_rng_reseed(struct tee_ta_session *s __unused,
+				uint32_t param_types,
+				TEE_Param params[TEE_NUM_PARAMS])
+{
+	size_t entropy_sz;
+	uint8_t *entropy_input;
+	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					  TEE_PARAM_TYPE_NONE,
+					  TEE_PARAM_TYPE_NONE,
+					  TEE_PARAM_TYPE_NONE);
+
+	if (exp_pt != param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+	entropy_input = params[0].memref.buffer;
+	entropy_sz = params[0].memref.size;
+
+	/* Fortuna PRNG requires seed <= 32 bytes */
+	if (!entropy_sz)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	entropy_sz = MIN(entropy_sz, MAX_ENTROPY_IN);
+
+	return tee_prng_add_entropy(entropy_input, entropy_sz);
+}
+
+static TEE_Result open_session(uint32_t param_types __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
+			       void **sess_ctx __unused)
+{
+	struct tee_ta_session *s;
+
+	/* Check that we're called from a user TA */
+	s = tee_ta_get_calling_session();
+	if (!s)
+		return TEE_ERROR_ACCESS_DENIED;
+	if (!is_user_ta_ctx(s->ctx))
+		return TEE_ERROR_ACCESS_DENIED;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+				 uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	struct tee_ta_session *s = tee_ta_get_calling_session();
+
+	switch (cmd_id) {
+	case PTA_SYSTEM_ADD_RNG_ENTROPY:
+		return system_rng_reseed(s, param_types, params);
+	default:
+		break;
+	}
+
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+pseudo_ta_register(.uuid = PTA_SYSTEM_UUID, .name = "system.pta",
+		   .flags = PTA_DEFAULT_FLAGS,
+		   .open_session_entry_point = open_session,
+		   .invoke_command_entry_point = invoke_command);

--- a/lib/libutee/include/pta_system.h
+++ b/lib/libutee/include/pta_system.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+#ifndef __PTA_SYSTEM_H
+#define __PTA_SYSTEM_H
+
+/*
+ * Interface to the pseudo TA, which is provides misc. auxiliary services,
+ * extending existing GlobalPlatform Core API
+ */
+
+#define PTA_SYSTEM_UUID { 0x3a2f8978, 0x5dc0, 0x11e8, { \
+			 0x9c, 0x2d, 0xfa, 0x7a, 0xe0, 0x1b, 0xbe, 0xbc } }
+
+/*
+ * Add (re-seed) caller-provided entropy to the RNG pool. Keymaster
+ * implementations need to securely mix the provided entropy into their pool,
+ * which also must contain internally-generated entropy from a hardware random
+ * number generator.
+ *
+ * [in]     memref[0]: entropy input data
+ */
+#define PTA_SYSTEM_ADD_RNG_ENTROPY	0
+
+#endif /* __PTA_SYSTEM_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -286,6 +286,10 @@ $(eval $(call cfg-depends-all,CFG_SECSTOR_TA,CFG_REE_FS CFG_WITH_USER_TA))
 CFG_SECSTOR_TA_MGMT_PTA ?= $(call cfg-all-enabled,CFG_SECSTOR_TA)
 $(eval $(call cfg-depends-all,CFG_SECSTOR_TA_MGMT_PTA,CFG_SECSTOR_TA))
 
+# Enable the pseudo TA for misc. auxilary services, extending existing
+# GlobalPlatform Core API (for example, re-seeding RNG entropy pool etc.)
+CFG_SYSTEM_PTA ?= y
+
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,
 # so its value represents log2(cores/cluster).

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -28,6 +28,7 @@ ta-mk-file-export-vars-$(sm) += CFG_CACHE_API
 ta-mk-file-export-vars-$(sm) += CFG_SECURE_DATA_PATH
 ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS_SELF_TEST
 ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS
+ta-mk-file-export-vars-$(sm) += CFG_SYSTEM_PTA
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.


### PR DESCRIPTION
AOSP Keymaster implementations need to securely mix the provided entropy into
their pool, which also must contain internally-generated entropy from a
hardware random number generator.

Add PTA, which can add caller-provided entropy to the default RNG pool.

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
