### PR TITLE
tee_ree_fs: avoid race condition between fh usage/closing

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -685,10 +685,10 @@ static void ree_fs_close(struct tee_file_handle **fh)
 	if (*fh) {
 		mutex_lock(&ree_fs_mutex);
 		put_dirh_primitive(false);
-		mutex_unlock(&ree_fs_mutex);
-
 		ree_fs_close_primitive(*fh);
 		*fh = NULL;
+		mutex_unlock(&ree_fs_mutex);
+
 	}
 }
 


### PR DESCRIPTION
It is possible that one core will call ree_fs_close_primitive()
while another is calling ree_fs_read_primitive(). This patch
prevents this by putting ree_fs_close_primitive under mutex.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
