### PR TITLE
ci: .travis.yml: download GCC 4.9 toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,9 @@ before_script:
   - mkdir $HOME/optee_repo
   - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git </dev/null && repo sync --no-clone-bundle --no-tags -j 20)
   - (cd $HOME/optee_repo && mv optee_os optee_os_old && ln -s $MYHOME optee_os)
+  - download https://releases.linaro.org/archive/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
+  - mkdir -p $HOME/optee_repo/toolchains
+  - (cd $HOME/optee_repo/toolchains && tar xf $DL_DIR/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz && mv gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf aarch32-legacy)
   - cd $MYHOME
   - git fetch https://github.com/OP-TEE/optee_os --tags
   - unset CC
@@ -93,8 +96,7 @@ script:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then if [ "$(git rev-list --count HEAD^1..HEAD^2)" -gt 1 ]; then checkdiff $(git rev-parse HEAD^1) $(git rev-parse HEAD^2); fi; fi
 
   # Run regression tests (xtest in QEMU)
-  - (cd ${HOME}/optee_repo/build && make toolchains COMPILE_LEGACY=y)
-  - (cd ${HOME}/optee_repo/build && $make check COMPILE_LEGACY=y CFG_TEE_CORE_DEBUG=y DUMP_LOGS_ON_ERROR=1)
+  - (cd ${HOME}/optee_repo/build && $make check COMPILE_LEGACY=y AARCH32_CROSS_COMPILE=$HOME/optee_repo/toolchains/aarch32-legacy/bin/arm-linux-gnueabihf- LEGACY_AARCH32_CROSS_COMPILE=$HOME/optee_repo/toolchains/aarch32-legacy/bin/arm-linux-gnueabihf- DUMP_LOGS_ON_ERROR=1)
 
 env:
   global:


### PR DESCRIPTION
COMPILE_LEGACY is not needed anymore since the legacy toolchain has been
deprecated in build.git [1].
Fixes the following compile error during the Travis CI build:

   CC      /home/travis/optee_repo/build/../out/bios-qemu/bios/entry.o
 gcc: warning: ‘-mcpu=’ is deprecated; use ‘-mtune=’ or ‘-march=’ instead
 bios/entry.S:1:0: error: bad value (cortex-a15) for -mtune= switch
  /*
  ^

Link: [1] https://github.com/OP-TEE/build/pull/263
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
