### PR TITLE
[RFC]trace: print core id if in atomic context

### DIFF
--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -55,13 +55,14 @@ static char trace_level_to_string(int level, bool level_ok)
 	return lvl_strs[l];
 }
 
-static int print_thread_id(char *buf, size_t bs, int thread_id)
+static int print_thread_id(char *buf, size_t bs)
 {
 #if CFG_NUM_THREADS > 9
 	int num_thread_digits = 2;
 #else
 	int num_thread_digits = 1;
 #endif
+	int thread_id = trace_ext_get_thread_id();
 
 	if (thread_id >= 0)
 		return snprintk(buf, bs, "%0*d ", num_thread_digits, thread_id);
@@ -98,7 +99,6 @@ void trace_printf(const char *function, int line, int level, bool level_ok,
 	char buf[MAX_PRINT_SIZE];
 	size_t boffs = 0;
 	int res;
-	int thread_id;
 
 	if (level_ok && level > trace_level)
 		return;
@@ -125,8 +125,7 @@ void trace_printf(const char *function, int line, int level, bool level_ok,
 		boffs += res;
 
 		/* Print the Thread ID */
-		thread_id = trace_ext_get_thread_id();
-		res = print_thread_id(buf + boffs, sizeof(buf) - boffs, thread_id);
+		res = print_thread_id(buf + boffs, sizeof(buf) - boffs);
 		if (res < 0)
 			return;
 		boffs += res;

--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -117,37 +117,33 @@ void trace_printf(const char *function, int line, int level, bool level_ok,
 		return;
 	boffs += res;
 
-	/* Print the core ID if in atomic context  */
-	if (level_ok && (BIT(level) & CFG_MSG_LONG_PREFIX_MASK))
+	if (level_ok && (BIT(level) & CFG_MSG_LONG_PREFIX_MASK)) {
+		/* Print the core ID if in atomic context  */
 		res = print_core_id(buf + boffs, sizeof(buf) - boffs);
-	else
-		res = 0;
-	if (res < 0)
-		return;
-	boffs += res;
-
-	/* Print the Thread ID */
-	if (level_ok && !(BIT(level) & CFG_MSG_LONG_PREFIX_MASK))
-		thread_id = -1;
-	else
-		thread_id = trace_ext_get_thread_id();
-
-	res = print_thread_id(buf + boffs, sizeof(buf) - boffs, thread_id);
-
-	if (res < 0)
-		return;
-	boffs += res;
-
-	/* Print the function and line */
-	if (level_ok && !(BIT(level) & CFG_MSG_LONG_PREFIX_MASK))
-		function = NULL;
-
-	if (function) {
-		res = snprintk(buf + boffs, sizeof(buf) - boffs, "%s:%d ",
-			       function, line);
 		if (res < 0)
 			return;
 		boffs += res;
+
+		/* Print the Thread ID */
+		thread_id = trace_ext_get_thread_id();
+		res = print_thread_id(buf + boffs, sizeof(buf) - boffs, thread_id);
+		if (res < 0)
+			return;
+		boffs += res;
+
+		if (function) {
+			res = snprintk(buf + boffs, sizeof(buf) - boffs, "%s:%d ",
+				       function, line);
+			if (res < 0)
+				return;
+			boffs += res;
+		}
+	} else {
+		/* Add space after location info */
+		if (boffs >= sizeof(buf) - 1)
+		    return;
+		buf[boffs++] = ' ';
+		buf[boffs] = 0;
 	}
 
 	va_start(ap, fmt);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -73,8 +73,8 @@ CFG_TEE_CORE_MALLOC_DEBUG ?= n
 CFG_TEE_TA_MALLOC_DEBUG ?= n
 
 # Mask to select which messages are prefixed with long debugging information
-# (severity, thread ID, component name, function name, line number) based on
-# the message level. If BIT(level) is set, the long prefix is shown.
+# (severity, core ID, thread ID, component name, function name, line number)
+# based on the message level. If BIT(level) is set, the long prefix is shown.
 # Otherwise a short prefix is used (severity and component name only).
 # Levels: 0=none 1=error 2=info 3=debug 4=flow
 CFG_MSG_LONG_PREFIX_MASK ?= 0x1a


### PR DESCRIPTION
If (D|E|I|F)MSG is called with foreign interrupts masked
we can report core ID. "?" will be printed instead, if
foreign interrupts aren't masked.

With this patch log looks like this:

D/TC:2 0 core_mmu_set_user_map:940 0xe181b88 0xeee8003
D/TC:? 0 __wq_rpc:40 wake  thread 1 0xe16f028 -3
D/TC:1   thread_handle_std_smc:612 a7: 2
D/TC:3 0 core_mmu_set_user_map:940 0x0 0x0

Where first digit shows core id and second - thread id.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
