### PR TITLE
libmbedtls: refine mbedtls license header

### DIFF
--- a/lib/libmbedtls/mbedtls/include/mbedtls/aes.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/aes.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file aes.h
  *
  * \brief AES block cipher
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/aesni.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/aesni.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file aesni.h
  *
  * \brief AES-NI for hardware AES acceleration on some Intel processors
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/arc4.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/arc4.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file arc4.h
  *
  * \brief The ARCFOUR stream cipher
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/asn1.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/asn1.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file asn1.h
  *
  * \brief Generic ASN.1 parsing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/asn1write.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/asn1write.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file asn1write.h
  *
  * \brief ASN.1 buffer writing functionality
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/base64.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/base64.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file base64.h
  *
  * \brief RFC 1521 base64 encoding/decoding
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/bignum.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/bignum.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file bignum.h
  *
  * \brief  Multi-precision integer library
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/blowfish.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/blowfish.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file blowfish.h
  *
  * \brief Blowfish block cipher
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/bn_mul.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/bn_mul.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file bn_mul.h
  *
  * \brief  Multi-precision integer library
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/camellia.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/camellia.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file camellia.h
  *
  * \brief Camellia block cipher
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ccm.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ccm.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ccm.h
  *
  * \brief Counter with CBC-MAC (CCM) for 128-bit block ciphers
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/certs.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/certs.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file certs.h
  *
  * \brief Sample certificates and DHM parameters for testing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/check_config.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/check_config.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file check_config.h
  *
  * \brief Consistency checks for configuration options
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/cipher.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/cipher.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file cipher.h
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/cipher_internal.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/cipher_internal.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file cipher_internal.h
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/cmac.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/cmac.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file cmac.h
  *
@@ -5,7 +6,6 @@
  *        Authentication
  *
  *  Copyright (C) 2015-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/compat-1.3.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/compat-1.3.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file compat-1.3.h
  *
@@ -7,7 +8,6 @@
  * \deprecated Use the new names directly instead
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ctr_drbg.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ctr_drbg.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ctr_drbg.h
  *
  * \brief CTR_DRBG based on AES-256 (NIST SP 800-90)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/debug.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/debug.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file debug.h
  *
  * \brief Functions for controlling and providing debug output from the library.
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/des.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/des.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file des.h
  *
  * \brief DES block cipher
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/dhm.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/dhm.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file dhm.h
  *
  * \brief Diffie-Hellman-Merkle key exchange
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ecdh.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ecdh.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ecdh.h
  *
  * \brief Elliptic curve Diffie-Hellman
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ecdsa.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ecdsa.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ecdsa.h
  *
  * \brief Elliptic curve DSA
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ecjpake.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ecjpake.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ecjpake.h
  *
  * \brief Elliptic curve J-PAKE
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ecp.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ecp.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ecp.h
  *
  * \brief Elliptic curves over GF(p)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ecp_internal.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ecp_internal.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ecp_internal.h
  *
@@ -5,7 +6,6 @@
  * point arithmetic.
  *
  *  Copyright (C) 2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/entropy.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/entropy.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file entropy.h
  *
  * \brief Entropy accumulator implementation
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/entropy_poll.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/entropy_poll.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file entropy_poll.h
  *
  * \brief Platform-specific and custom entropy polling functions
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/error.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/error.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file error.h
  *
  * \brief Error to string translation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/gcm.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/gcm.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file gcm.h
  *
  * \brief Galois/Counter mode for 128-bit block ciphers
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/havege.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/havege.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file havege.h
  *
  * \brief HAVEGE: HArdware Volatile Entropy Gathering and Expansion
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/hmac_drbg.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/hmac_drbg.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file hmac_drbg.h
  *
  * \brief HMAC_DRBG (NIST SP 800-90A)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/md.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/md.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file md.h
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/md2.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/md2.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file md2.h
  *
  * \brief MD2 message digest algorithm (hash function)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/md4.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/md4.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file md4.h
  *
  * \brief MD4 message digest algorithm (hash function)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/md5.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/md5.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file md5.h
  *
  * \brief MD5 message digest algorithm (hash function)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/md_internal.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/md_internal.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file md_internal.h
  *
@@ -8,7 +9,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/memory_buffer_alloc.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/memory_buffer_alloc.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file memory_buffer_alloc.h
  *
  * \brief Buffer-based memory allocator
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/net.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/net.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file net.h
  *
  * \brief Deprecated header file that includes mbedtls/net_sockets.h
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/net_sockets.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/net_sockets.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file net_sockets.h
  *
  * \brief Network communication functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/oid.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/oid.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file oid.h
  *
  * \brief Object Identifier (OID) database
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/padlock.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/padlock.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file padlock.h
  *
@@ -5,7 +6,6 @@
  *        processors
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/pem.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/pem.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file pem.h
  *
  * \brief Privacy Enhanced Mail (PEM) decoding
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/pk.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/pk.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file pk.h
  *
  * \brief Public Key abstraction layer
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/pk_internal.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/pk_internal.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file pk.h
  *
  * \brief Public Key abstraction layer: wrapper functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/pkcs11.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/pkcs11.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file pkcs11.h
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/pkcs12.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/pkcs12.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file pkcs12.h
  *
  * \brief PKCS#12 Personal Information Exchange Syntax
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/pkcs5.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/pkcs5.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file pkcs5.h
  *
@@ -6,7 +7,6 @@
  * \author Mathias Olsson <mathias@kompetensum.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/platform.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/platform.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file platform.h
  *
  * \brief mbed TLS Platform abstraction layer
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/platform_time.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/platform_time.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file platform_time.h
  *
  * \brief mbed TLS Platform time abstraction
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ripemd160.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ripemd160.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ripemd160.h
  *
  * \brief RIPE MD-160 message digest
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/rsa.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/rsa.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file rsa.h
  *
  * \brief The RSA public-key cryptosystem
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/sha1.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/sha1.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file sha1.h
  *
  * \brief SHA-1 cryptographic hash function
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/sha256.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/sha256.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file sha256.h
  *
  * \brief SHA-224 and SHA-256 cryptographic hash function
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/sha512.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/sha512.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file sha512.h
  *
  * \brief SHA-384 and SHA-512 cryptographic hash function
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ssl.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ssl.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ssl.h
  *
  * \brief SSL/TLS functions.
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ssl_cache.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ssl_cache.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ssl_cache.h
  *
  * \brief SSL session cache implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ssl_ciphersuites.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ssl_ciphersuites.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ssl_ciphersuites.h
  *
  * \brief SSL Ciphersuites for mbed TLS
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ssl_cookie.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ssl_cookie.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ssl_cookie.h
  *
  * \brief DTLS cookie callbacks implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ssl_internal.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ssl_internal.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ssl_ticket.h
  *
  * \brief Internal functions shared by the SSL modules
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/ssl_ticket.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ssl_ticket.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file ssl_ticket.h
  *
  * \brief TLS server ticket callbacks implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/threading.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/threading.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file threading.h
  *
  * \brief Threading abstraction layer
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/timing.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/timing.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file timing.h
  *
  * \brief Portable interface to the CPU cycle counter
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/version.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/version.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file version.h
  *
  * \brief Run-time version information
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/x509.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/x509.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file x509.h
  *
  * \brief X.509 generic defines and structures
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/x509_crl.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/x509_crl.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file x509_crl.h
  *
  * \brief X.509 certificate revocation list parsing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/x509_crt.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/x509_crt.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file x509_crt.h
  *
  * \brief X.509 certificate parsing and writing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/x509_csr.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/x509_csr.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file x509_csr.h
  *
  * \brief X.509 certificate signing request parsing and writing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/xtea.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/xtea.h
@@ -1,10 +1,10 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /**
  * \file xtea.h
  *
  * \brief XTEA block cipher (32-bit)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/aes.c
+++ b/lib/libmbedtls/mbedtls/library/aes.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  FIPS-197 compliant AES implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/aesni.c
+++ b/lib/libmbedtls/mbedtls/library/aesni.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  AES-NI support functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/arc4.c
+++ b/lib/libmbedtls/mbedtls/library/arc4.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  An implementation of the ARCFOUR algorithm
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/asn1parse.c
+++ b/lib/libmbedtls/mbedtls/library/asn1parse.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Generic ASN.1 parsing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/asn1write.c
+++ b/lib/libmbedtls/mbedtls/library/asn1write.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * ASN.1 buffer writing functionality
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/base64.c
+++ b/lib/libmbedtls/mbedtls/library/base64.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  RFC 1521 base64 encoding/decoding
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/bignum.c
+++ b/lib/libmbedtls/mbedtls/library/bignum.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Multi-precision integer library
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/blowfish.c
+++ b/lib/libmbedtls/mbedtls/library/blowfish.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Blowfish implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/camellia.c
+++ b/lib/libmbedtls/mbedtls/library/camellia.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Camellia implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ccm.c
+++ b/lib/libmbedtls/mbedtls/library/ccm.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  NIST SP800-38C compliant CCM implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/certs.c
+++ b/lib/libmbedtls/mbedtls/library/certs.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 test certificates
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/cipher.c
+++ b/lib/libmbedtls/mbedtls/library/cipher.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file cipher.c
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/cipher_wrap.c
+++ b/lib/libmbedtls/mbedtls/library/cipher_wrap.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file cipher_wrap.c
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/cmac.c
+++ b/lib/libmbedtls/mbedtls/library/cmac.c
@@ -1,10 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file cmac.c
  *
  * \brief NIST SP800-38B compliant CMAC implementation for AES and 3DES
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ctr_drbg.c
+++ b/lib/libmbedtls/mbedtls/library/ctr_drbg.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  CTR_DRBG implementation based on AES-256 (NIST SP 800-90)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/debug.c
+++ b/lib/libmbedtls/mbedtls/library/debug.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Debugging routines
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/des.c
+++ b/lib/libmbedtls/mbedtls/library/des.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  FIPS-46-3 compliant Triple-DES implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/dhm.c
+++ b/lib/libmbedtls/mbedtls/library/dhm.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Diffie-Hellman-Merkle key exchange
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ecdh.c
+++ b/lib/libmbedtls/mbedtls/library/ecdh.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Elliptic curve Diffie-Hellman
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ecdsa.c
+++ b/lib/libmbedtls/mbedtls/library/ecdsa.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Elliptic curve DSA
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ecjpake.c
+++ b/lib/libmbedtls/mbedtls/library/ecjpake.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Elliptic curve J-PAKE
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ecp.c
+++ b/lib/libmbedtls/mbedtls/library/ecp.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Elliptic curves over GF(p): generic functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ecp_curves.c
+++ b/lib/libmbedtls/mbedtls/library/ecp_curves.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Elliptic curves over GF(p): curve-specific data and functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/entropy.c
+++ b/lib/libmbedtls/mbedtls/library/entropy.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Entropy accumulator implementation
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/entropy_poll.c
+++ b/lib/libmbedtls/mbedtls/library/entropy_poll.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Platform-specific and custom entropy polling functions
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/error.c
+++ b/lib/libmbedtls/mbedtls/library/error.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Error message information
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/gcm.c
+++ b/lib/libmbedtls/mbedtls/library/gcm.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  NIST SP800-38D compliant GCM implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/havege.c
+++ b/lib/libmbedtls/mbedtls/library/havege.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  *  \brief HAVEGE: HArdware Volatile Entropy Gathering and Expansion
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/hmac_drbg.c
+++ b/lib/libmbedtls/mbedtls/library/hmac_drbg.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  HMAC_DRBG implementation (NIST SP 800-90)
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/md.c
+++ b/lib/libmbedtls/mbedtls/library/md.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file mbedtls_md.c
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/md2.c
+++ b/lib/libmbedtls/mbedtls/library/md2.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  RFC 1115/1319 compliant MD2 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/md4.c
+++ b/lib/libmbedtls/mbedtls/library/md4.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  RFC 1186/1320 compliant MD4 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/md5.c
+++ b/lib/libmbedtls/mbedtls/library/md5.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  RFC 1321 compliant MD5 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/md_wrap.c
+++ b/lib/libmbedtls/mbedtls/library/md_wrap.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file md_wrap.c
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/memory_buffer_alloc.c
+++ b/lib/libmbedtls/mbedtls/library/memory_buffer_alloc.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Buffer-based memory allocator
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/net_sockets.c
+++ b/lib/libmbedtls/mbedtls/library/net_sockets.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  TCP/IP or UDP/IP networking functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/oid.c
+++ b/lib/libmbedtls/mbedtls/library/oid.c
@@ -1,10 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file oid.c
  *
  * \brief Object Identifier (OID) database
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/padlock.c
+++ b/lib/libmbedtls/mbedtls/library/padlock.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  VIA PadLock support functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pem.c
+++ b/lib/libmbedtls/mbedtls/library/pem.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Privacy Enhanced Mail (PEM) decoding
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pk.c
+++ b/lib/libmbedtls/mbedtls/library/pk.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Public Key abstraction layer
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pk_wrap.c
+++ b/lib/libmbedtls/mbedtls/library/pk_wrap.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Public Key abstraction layer: wrapper functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pkcs11.c
+++ b/lib/libmbedtls/mbedtls/library/pkcs11.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file pkcs11.c
  *
@@ -6,7 +7,6 @@
  * \author Adriaan de Jong <dejong@fox-it.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pkcs12.c
+++ b/lib/libmbedtls/mbedtls/library/pkcs12.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  PKCS#12 Personal Information Exchange Syntax
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pkcs5.c
+++ b/lib/libmbedtls/mbedtls/library/pkcs5.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file pkcs5.c
  *
@@ -6,7 +7,6 @@
  * \author Mathias Olsson <mathias@kompetensum.com>
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pkparse.c
+++ b/lib/libmbedtls/mbedtls/library/pkparse.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Public Key layer for parsing key files and structures
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/pkwrite.c
+++ b/lib/libmbedtls/mbedtls/library/pkwrite.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Public Key layer for writing key files and structures
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/platform.c
+++ b/lib/libmbedtls/mbedtls/library/platform.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Platform abstraction layer
  *
  *  Copyright (C) 2006-2016, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ripemd160.c
+++ b/lib/libmbedtls/mbedtls/library/ripemd160.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  RIPE MD-160 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/rsa.c
+++ b/lib/libmbedtls/mbedtls/library/rsa.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  The RSA public-key cryptosystem
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/sha1.c
+++ b/lib/libmbedtls/mbedtls/library/sha1.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  FIPS-180-1 compliant SHA-1 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/sha256.c
+++ b/lib/libmbedtls/mbedtls/library/sha256.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  FIPS-180-2 compliant SHA-256 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/sha512.c
+++ b/lib/libmbedtls/mbedtls/library/sha512.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  FIPS-180-2 compliant SHA-384/512 implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ssl_cache.c
+++ b/lib/libmbedtls/mbedtls/library/ssl_cache.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  SSL session cache implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ssl_ciphersuites.c
+++ b/lib/libmbedtls/mbedtls/library/ssl_ciphersuites.c
@@ -1,10 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * \file ssl_ciphersuites.c
  *
  * \brief SSL ciphersuites for mbed TLS
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ssl_cli.c
+++ b/lib/libmbedtls/mbedtls/library/ssl_cli.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  SSLv3/TLSv1 client-side functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ssl_cookie.c
+++ b/lib/libmbedtls/mbedtls/library/ssl_cookie.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  DTLS cookie callbacks implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ssl_srv.c
+++ b/lib/libmbedtls/mbedtls/library/ssl_srv.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  SSLv3/TLSv1 server-side functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ssl_ticket.c
+++ b/lib/libmbedtls/mbedtls/library/ssl_ticket.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  TLS server tickets callbacks implementation
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/ssl_tls.c
+++ b/lib/libmbedtls/mbedtls/library/ssl_tls.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  SSLv3/TLSv1 shared functions
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/threading.c
+++ b/lib/libmbedtls/mbedtls/library/threading.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Threading abstraction layer
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/timing.c
+++ b/lib/libmbedtls/mbedtls/library/timing.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Portable interface to the CPU cycle counter
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/version.c
+++ b/lib/libmbedtls/mbedtls/library/version.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Version information
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/version_features.c
+++ b/lib/libmbedtls/mbedtls/library/version_features.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  Version feature information
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/x509.c
+++ b/lib/libmbedtls/mbedtls/library/x509.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 common functions for parsing and verification
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/x509_create.c
+++ b/lib/libmbedtls/mbedtls/library/x509_create.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 base functions for creating certificates / CSRs
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/x509_crl.c
+++ b/lib/libmbedtls/mbedtls/library/x509_crl.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 Certidicate Revocation List (CRL) parsing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/x509_crt.c
+++ b/lib/libmbedtls/mbedtls/library/x509_crt.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 certificate parsing and verification
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/x509_csr.c
+++ b/lib/libmbedtls/mbedtls/library/x509_csr.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 Certificate Signing Request (CSR) parsing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/x509write_crt.c
+++ b/lib/libmbedtls/mbedtls/library/x509write_crt.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 certificate writing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/x509write_csr.c
+++ b/lib/libmbedtls/mbedtls/library/x509write_csr.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  X.509 Certificate Signing Request writing
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.

--- a/lib/libmbedtls/mbedtls/library/xtea.c
+++ b/lib/libmbedtls/mbedtls/library/xtea.c
@@ -1,8 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  *  An 32-bit implementation of the XTEA algorithm
  *
  *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
- *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use this file except in compliance with the License.


### PR DESCRIPTION
e0186224bba7 ("libmbedtls: refine mbedtls license header") from
branch import/mbedtls-2.6.1

New header format according to this:
https://github.com/OP-TEE/optee_os/blob/master/documentation/
copyright_and_license_headers.rst

Acked-by: Jerome Forissier <jerome.forissier@linaro.org>
Signed-off-by: Edison Ai <edison.ai@arm.com>
[jw: removed the now redundant SPDX-License-Identifier]
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
