### PR TITLE
core: arm: support relocation type R_ARM_REL32

### DIFF
--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -401,6 +401,12 @@ static TEE_Result e32_process_rel(struct elf_load_state *state, size_t rel_sidx,
 
 			*where += vabase + sym_tab[sym_idx].st_value;
 			break;
+		case R_ARM_REL32:
+			sym_idx = ELF32_R_SYM(rel->r_info);
+			if (sym_idx >= num_syms)
+				return TEE_ERROR_BAD_FORMAT;
+			*where += sym_tab[sym_idx].st_value - rel->r_offset;
+			break;
 		case R_ARM_RELATIVE:
 			*where += vabase;
 			break;


### PR DESCRIPTION
I have encounterd the relocation type R_ARM_REL32 in a shared library,
so implement it.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
