### PR TITLE
TA dev kit: shared library: strip directory part

### DIFF
--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -38,7 +38,7 @@ $(link-out-dir)/$(shlibname).stripped.so: $(link-out-dir)/$(shlibname).so
 
 $(link-out-dir)/$(shlibuuid).elf: $(link-out-dir)/$(shlibname).so
 	@$(cmd-echo-silent) '  LN      $@'
-	$(q)ln -sf $< $@
+	$(q)ln -sf $(<F) $@
 
 $(link-out-dir)/$(shlibuuid).ta: $(link-out-dir)/$(shlibname).stripped.so \
 				$(TA_SIGN_KEY)


### PR DESCRIPTION
The symbolic link and its target are in the same directory, so we need
to make sure that there is no relative path before the target filename.
The proper Make variable to use is therefore not $< but $(<F).

Fixes: 01b8b5ce011d ("TA dev kit: when building a shared library, create symlink with UUID")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
