### PR TITLE
[RFC] tzc380: simplify tzc_configure_region interface

### DIFF
--- a/core/include/drivers/tzc380.h
+++ b/core/include/drivers/tzc380.h
@@ -197,13 +197,15 @@ enum tzc_action {
 #define TZC_ATTR_REGION_DISABLE	0x0
 
 void tzc_init(vaddr_t base);
-void tzc_configure_region(uint8_t region, vaddr_t region_base, size_t size);
+void tzc_configure_region(uint8_t region, vaddr_t region_base,
+			  uint16_t attr, uint32_t size);
+void tzc_set_region_size(uint8_t region, uint32_t size);
+void tzc_set_region_attr(uint8_t region, uint16_t attr);
 void tzc_region_enable(uint8_t region);
 void tzc_security_inversion_en(vaddr_t base);
 void tzc_set_action(enum tzc_action action);
 void tzc_fail_dump(void);
 void tzc_int_clear(void);
-
 #if TRACE_LEVEL >= TRACE_DEBUG
 void tzc_dump_state(void);
 #else


### PR DESCRIPTION
At the moment "tzc_configure_region" interface assumes that user should
well in advance encode the size and attributes into a value before
pass it as the last argument.

With this patch, user need not to encode the size/attributes and let
the driver itself set size and attributes fields separately.

For instance, if user wants to configure region 1 of size 32MB starting
from region_base as read/write access only from the secure world. Following
call is sufficient without worrying about any more Maths.

tzc_configure_region(1, region_base, 0xc, TZC_REGION_SIZE_32M)

Signed-off-by: Amit Singh Tomar <amittomer25@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
