### PR TITLE
libutee: Fix the keepalive condition on last session close

### DIFF
--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -114,14 +114,17 @@ static TEE_Result ta_header_add_session(uint32_t session_id)
 static void ta_header_remove_session(uint32_t session_id)
 {
 	struct ta_session *itr;
+	bool keep_alive;
 
 	TAILQ_FOREACH(itr, &ta_sessions, link) {
 		if (itr->session_id == session_id) {
 			TAILQ_REMOVE(&ta_sessions, itr, link);
 			TEE_Free(itr);
 
-			if (TAILQ_EMPTY(&ta_sessions) &&
-			    !(ta_head.flags & TA_FLAG_INSTANCE_KEEP_ALIVE))
+			keep_alive =
+				(ta_head.flags & TA_FLAG_SINGLE_INSTANCE) &&
+				(ta_head.flags & TA_FLAG_INSTANCE_KEEP_ALIVE);
+			if (TAILQ_EMPTY(&ta_sessions) && !keep_alive)
 				uninit_instance();
 
 			return;


### PR DESCRIPTION
Keepalive condition check should involve single instance flag too, since
the keepalive flag is meaningless if the TA is not single instance.
The same fix was done earlier in the core by commit f9a64f12b542 ("core:
fix the keepalive condition in close session").

Fixes: b7ea03ff2963 ("libutee: fix TA_CreateEntryPoint() and TA_DestroyEntryPoint()")
Signed-off-by: Andrew Gabbasov <andrew_gabbasov@mentor.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
