### PR TITLE
Add new platform for the TI K3 class of SoCs

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -60,6 +60,8 @@ build:
     - _make PLATFORM=imx-mx6qsabresd
     - _make PLATFORM=imx-mx6dlsabresd
     - _make PLATFORM=imx-mx7dsabresd
+    - _make PLATFORM=k3-am65x
+    - _make PLATFORM=k3-am65x CFG_ARM64_core=y
     - _make PLATFORM=ti-dra7xx
     - _make PLATFORM=ti-am57xx
     - _make PLATFORM=ti-am43xx

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -132,10 +132,11 @@ R:	Linaro <op-tee@linaro.org>
 S:	Maintained
 F:	core/arch/arm/plat-stm/
 
-Texas Instruments AM43xx, AM57xx, DRA7xx
+Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x
 R:	Andrew F. Davis <afd@ti.com>
 S:	Maintained
 F:	core/arch/arm/plat-ti/
+F:	core/arch/arm/plat-k3/
 
 Xilinx Zynq 7000 ZC702 Board
 R:	Yan Yan <yan.yan@windriver.com>

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The **Maintained?** column shows:
 | [Rockchip RK322X](http://www.rock-chips.com/a/en/products/RK32_Series/2016/1109/799.html) |`PLATFORM=rockchip-rk322x`| No | ![Actively maintained](documentation/images/green.svg) |
 | [STMicroelectronics b2260 - h410 (96boards fmt)](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-b2260`| No | ![Actively maintained](documentation/images/green.svg) |
 | [STMicroelectronics b2120 - h310 / h410](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-cannes`| No | ![Actively maintained](documentation/images/green.svg) |
+| [Texas Instruments AM65x](http://www.ti.com/lit/ug/spruid7/spruid7.pdf)|`PLATFORM=k3-am65x`| Yes | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments DRA7xx](http://www.ti.com/processors/automotive-processors/drax-infotainment-socs/overview.html)|`PLATFORM=ti-dra7xx`| Yes | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments AM57xx](http://www.ti.com/processors/sitara/arm-cortex-a15/am57x/overview.html)|`PLATFORM=ti-am57xx`| Yes | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments AM43xx](http://www.ti.com/processors/sitara/arm-cortex-a9/am438x/overview.html)|`PLATFORM=ti-am43xx`| Yes | ![Actively maintained](documentation/images/green.svg) |

--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -1,0 +1,32 @@
+CFG_WITH_STACK_CANARIES ?= y
+CFG_WITH_STATS ?= y
+CFG_CRYPTO_WITH_CE ?= n
+CFG_WITH_SOFTWARE_PRNG ?= y
+CFG_SECURE_DATA_PATH ?= y
+
+CFG_TZDRAM_START ?= 0x9e800000
+CFG_TZDRAM_SIZE ?= 0x01400000 # 20MB
+CFG_SHMEM_START ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))
+CFG_SHMEM_SIZE ?= 0x00400000 # 4MB
+
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+$(call force,CFG_8250_UART,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_GIC,y)
+$(call force,CFG_ARM_GICV3,y)
+$(call force,CFG_CORE_CLUSTER_SHIFT,1)
+
+ta-targets = ta_arm32
+
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+ta-targets += ta_arm64
+else
+$(call force,CFG_ARM32_core,y)
+endif
+
+include core/arch/arm/cpu/cortex-armv8-0.mk

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2016-2018 Texas Instruments Incorporated - http://www.ti.com/
+ *	Andrew F. Davis <afd@ti.com>
+ */
+
+#include <platform_config.h>
+
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/serial8250_uart.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/core_memprot.h>
+#include <mm/tee_pager.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/entry_fast.h>
+#include <tee/entry_std.h>
+
+static struct gic_data gic_data;
+static struct serial8250_uart_data console_data;
+
+register_phys_mem(MEM_AREA_IO_SEC, GICC_BASE, GICC_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, GICD_BASE, GICD_SIZE);
+register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
+		  SERIAL8250_UART_REG_SIZE);
+
+void main_init_gic(void)
+{
+	vaddr_t gicc_base;
+	vaddr_t gicd_base;
+
+	gicc_base = (vaddr_t)phys_to_virt(GICC_BASE, MEM_AREA_IO_SEC);
+	gicd_base = (vaddr_t)phys_to_virt(GICD_BASE, MEM_AREA_IO_SEC);
+
+	if (!gicc_base || !gicd_base)
+		panic();
+
+	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	itr_init(&gic_data.chip);
+}
+
+void main_secondary_init_gic(void)
+{
+	gic_cpu_init(&gic_data);
+}
+
+static void main_fiq(void)
+{
+	gic_it_handle(&gic_data);
+}
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry_std,
+	.fast_smc = tee_entry_fast,
+	.nintr = main_fiq,
+	.cpu_on = cpu_on_handler,
+	.cpu_off = pm_do_nothing,
+	.cpu_suspend = pm_do_nothing,
+	.cpu_resume = pm_do_nothing,
+	.system_off = pm_do_nothing,
+	.system_reset = pm_do_nothing,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+void console_init(void)
+{
+	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2016-2018 Texas Instruments Incorporated - http://www.ti.com/
+ *	Andrew F. Davis <afd@ti.com>
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+#define UART0_BASE      0x02800000
+#define UART1_BASE      0x02810000
+#define UART2_BASE      0x02820000
+
+/* UART0 */
+#define CONSOLE_UART_BASE       UART0_BASE
+#define CONSOLE_BAUDRATE        115200
+#define CONSOLE_UART_CLK_IN_HZ  48000000
+
+#define SCU_BASE        0x01800000
+#define GICC_OFFSET     0x80000
+#define GICC_SIZE       0x90000
+#define GICD_OFFSET     0x0
+#define GICD_SIZE       0x10000
+#define GICC_BASE       (SCU_BASE + GICC_OFFSET)
+#define GICD_BASE       (SCU_BASE + GICD_OFFSET)
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-k3/sub.mk
+++ b/core/arch/arm/plat-k3/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
Add platform 'k3' for the TI K3 family. These are ARMv8 devices
and are quite different from our line of existing ARMv7 OMAP style
SoCs, hence the new platform.

Thanks,
Andrew