### PR TITLE
ci: shippable: enable parallel build

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -13,9 +13,7 @@ build:
     - export CROSS_COMPILE32="ccache arm-linux-gnueabihf-"
     - export CROSS_COMPILE64="ccache aarch64-linux-gnu-"
     - export CFG_DEBUG_INFO=n; export CCACHE_UNIFY=true
-    # No parallel build ('make -j$(getconf _NPROCESSORS_ONLN)') due to:
-    # https://github.com/Shippable/support/issues/3953
-    - function _make() { make -s O=out $* && ccache -s && ccache -z; }
+    - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && ccache -s && ccache -z; }
     - ccache -z
 
     - _make


### PR DESCRIPTION
Try to speed up the Shippable CI by re-introducing parallel builds, which
were removed by commit c330283b4a00 ("ci: .shippable.yml: disable parallel
build") due to random build errors. Although the root cause was never
identified, there are reasons to believe that the issue may not be
reproducible anymore:
- The container environment has likely seen updates
- Commit 836334a163f9 ("ci shippable: set build directory identically for
all platforms") has modified the output paths, so a race condition on
directory creation seems quite unlikely to happen.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
