### PR TITLE
user_ta: should go for other TA stores on any load error

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -843,8 +843,7 @@ static TEE_Result load_elf(const TEE_UUID *uuid, struct user_ta_ctx *utc)
 		res = load_elf_from_store(uuid, store, utc);
 		if (res == TEE_ERROR_ITEM_NOT_FOUND)
 			continue;
-		if (res)
-		{
+		if (res) {
 			DMSG("res=0x%x", res);
 			continue;
 		}

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -844,7 +844,10 @@ static TEE_Result load_elf(const TEE_UUID *uuid, struct user_ta_ctx *utc)
 		if (res == TEE_ERROR_ITEM_NOT_FOUND)
 			continue;
 		if (res)
+		{
 			DMSG("res=0x%x", res);
+			continue;
+		}
 		return res;
 	}
 	return TEE_ERROR_ITEM_NOT_FOUND;


### PR DESCRIPTION


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
user_ta.c: There seems to be a problem that if RPMB_FS is enabled in OPTEE and TA is present in REE (normal file system), if priority for secure storage TA is higher (priority value kept low w.r.t REE TA) and RPMB initialization fails, the error is returned and the OPTEE doesn't goes to find the TA in REE.

This issue generally arises when RPMB key is not been provisioned. The issue could be bypassed by setting the priority for Secure Storage TA lower then that of REE TA. 
But imagine the situation while the RPMB key is not been provisioned even though CFG_RPMB_FS is set, and the TA is present in REE FS. In that circumstance TA couldn't be loaded from REE FS.