### PR TITLE
core: don't divide by sizeof(*mem) for ddr nsec memory

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -838,7 +838,7 @@ static void discover_nsec_memory(void)
 	}
 
 	nelems = (&__end_phys_ddr_overall_section -
-		  &__start_phys_ddr_overall_section) / sizeof(*mem);
+		  &__start_phys_ddr_overall_section);
 	if (!nelems)
 		return;
 


### PR DESCRIPTION
Since the two addresses are already of type struct core_mmu_phys_mem, do not
divide by sizeof(struct core_mmu_phys_mem). This broke dynamic shared memory on
Juno r0, since nelem would be zero for two slots.

Tested on Juno r0.

Fixes: 2f82082fada3 ("core: add ddr overall register")
Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
