### PR TITLE
introduce platform stm32mp1

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -46,6 +46,7 @@ build:
     - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_TA_GPROF_SUPPORT=y CFG_ULIBS_GPROF=y
     - _make PLATFORM=stm-b2260
     - _make PLATFORM=stm-cannes
+    - _make PLATFORM=stm32mp1
     - _make PLATFORM=vexpress-fvp
     - _make PLATFORM=vexpress-fvp CFG_ARM64_core=y
     - _make PLATFORM=vexpress-juno

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -137,6 +137,11 @@ R:	Linaro <op-tee@linaro.org>
 S:	Maintained
 F:	core/arch/arm/plat-stm/
 
+STMicroelectronics stm32mp1
+R:	Etienne Carriere <etienne.carriere@st.com>
+S:	Maintained
+F:	core/arch/arm/plat-stm32mp1/
+
 Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x
 R:	Andrew F. Davis <afd@ti.com>
 S:	Maintained

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The **Maintained?** column shows:
 | [Rockchip RK322X](http://www.rock-chips.com/a/en/products/RK32_Series/2016/1109/799.html) |`PLATFORM=rockchip-rk322x`| No | ![Actively maintained](documentation/images/green.svg) |
 | [STMicroelectronics b2260 - h410 (96boards fmt)](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-b2260`| No | ![Actively maintained](documentation/images/green.svg) |
 | [STMicroelectronics b2120 - h310 / h410](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-cannes`| No | ![Actively maintained](documentation/images/green.svg) |
+| STMicroelectronics stm32mp1 |`PLATFORM=stm32mp1`| No | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments AM65x](http://www.ti.com/lit/ug/spruid7/spruid7.pdf)|`PLATFORM=k3-am65x`| Yes | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments DRA7xx](http://www.ti.com/processors/automotive-processors/drax-infotainment-socs/overview.html)|`PLATFORM=ti-dra7xx`| Yes | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments AM57xx](http://www.ti.com/processors/sitara/arm-cortex-a15/am57x/overview.html)|`PLATFORM=ti-am57xx`| Yes | ![Actively maintained](documentation/images/green.svg) |

--- a/core/arch/arm/plat-stm32mp1/boot_api.h
+++ b/core/arch/arm/plat-stm32mp1/boot_api.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (C) 2017-2018, STMicroelectronics
+ */
+
+#ifndef __BOOT_API_H__
+#define __BOOT_API_H__
+
+/*
+ * Backup registers mapping
+ */
+
+/* Backup register #4: magic to request core1 boot up */
+#define BCKR_CORE1_MAGIC_NUMBER			4
+
+/* Value for BCKR_CORE1_MAGIC_NUMBER entry */
+#define BOOT_API_A7_CORE1_MAGIC_NUMBER		0xca7face1
+
+/* Backup register #5: physical address of core1 entry at boot up */
+#define BCKR_CORE1_BRANCH_ADDRESS		5
+
+#endif /* __BOOT_API_H__*/

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -1,0 +1,33 @@
+PLATFORM_FLAVOR ?= stm32mp157c
+
+include core/arch/arm/cpu/cortex-a7.mk
+ta-targets = ta_arm32
+
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_BOOT_SECONDARY_REQUEST,y)
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_GIC,y)
+$(call force,CFG_INIT_CNTVOFF,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_PSCI_ARM32,y)
+$(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+
+CFG_TZSRAM_START ?= 0x2ffc0000
+CFG_TZSRAM_SIZE  ?= 0x00040000
+CFG_TZDRAM_START ?= 0xfe000000
+CFG_TZDRAM_SIZE  ?= 0x01e00000
+CFG_SHMEM_SIZE   ?= 0x00200000
+CFG_SHMEM_START  ?= 0xffe00000
+
+CFG_WITH_PAGER		?= y
+CFG_WITH_LPAE		?= y
+CFG_WITH_STACK_CANARIES	?= y
+
+CFG_STM32_UART ?= y
+
+# Default enable the test facitilites
+CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+CFG_WITH_STATS ?= y

--- a/core/arch/arm/plat-stm32mp1/link.mk
+++ b/core/arch/arm/plat-stm32mp1/link.mk
@@ -1,0 +1,24 @@
+include core/arch/arm/kernel/link.mk
+
+# Create stm32 formatted images from the native binary images
+
+define stm32image_cmd
+	@$(cmd-echo-silent) '  GEN     $@'
+	$(q)./core/arch/arm/plat-stm32mp1/scripts/stm32image.py \
+		--load 0 --entry 0
+endef
+
+all: $(link-out-dir)/tee-header_v2.stm32
+cleanfiles += $(link-out-dir)/tee-header_v2.stm32
+$(link-out-dir)/tee-header_v2.stm32: $(link-out-dir)/tee-header_v2.bin
+	$(stm32image_cmd) --source $< --dest $@
+
+all: $(link-out-dir)/tee-pager_v2.stm32
+cleanfiles += $(link-out-dir)/tee-pager_v2.stm32
+$(link-out-dir)/tee-pager_v2.stm32: $(link-out-dir)/tee-pager_v2.bin
+	$(stm32image_cmd) --source $< --dest $@
+
+all: $(link-out-dir)/tee-pageable_v2.stm32
+cleanfiles += $(link-out-dir)/tee-pageable_v2.stm32
+$(link-out-dir)/tee-pageable_v2.stm32: $(link-out-dir)/tee-pageable_v2.bin
+	$(stm32image_cmd) --source $< --dest $@

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics
+ * Copyright (c) 2016-2018, Linaro Limited
+ */
+
+#include <boot_api.h>
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/stm32_uart.h>
+#include <kernel/generic_boot.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <sm/psci.h>
+#include <tee/entry_std.h>
+#include <tee/entry_fast.h>
+
+register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CONSOLE_UART_SIZE);
+
+register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, BKP_REGS_BASE, SMALL_PAGE_SIZE);
+
+static struct gic_data gic_data;
+static struct console_pdata console_data;
+
+static void main_fiq(void)
+{
+	gic_it_handle(&gic_data);
+}
+
+static const struct thread_handlers handlers = {
+	.std_smc = tee_entry_std,
+	.fast_smc = tee_entry_fast,
+	.nintr = main_fiq,
+	.cpu_on = pm_panic,
+	.cpu_off = pm_panic,
+	.cpu_suspend = pm_panic,
+	.cpu_resume = pm_panic,
+	.system_off = pm_panic,
+	.system_reset = pm_panic,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+void console_init(void)
+{
+	stm32_uart_init(&console_data, CONSOLE_UART_BASE);
+	register_serial_console(&console_data.chip);
+}
+
+void main_init_gic(void)
+{
+	void *gicc_base;
+	void *gicd_base;
+
+	gicc_base = phys_to_virt(GIC_BASE + GICC_OFFSET, MEM_AREA_IO_SEC);
+	gicd_base = phys_to_virt(GIC_BASE + GICD_OFFSET, MEM_AREA_IO_SEC);
+	if (!gicc_base || !gicd_base)
+		panic();
+
+	gic_init(&gic_data, (vaddr_t)gicc_base, (vaddr_t)gicd_base);
+	itr_init(&gic_data.chip);
+}
+
+void main_secondary_init_gic(void)
+{
+	gic_cpu_init(&gic_data);
+}
+
+/*
+ * SMP boot support and access to the mailbox
+ */
+#define GIC_SEC_SGI_0		8
+
+static vaddr_t bckreg_base(void)
+{
+	static void *va;
+
+	if (!cpu_mmu_enabled())
+		return BKP_REGS_BASE + BKP_REGISTER_OFF;
+
+	if (!va)
+		va = phys_to_virt(BKP_REGS_BASE + BKP_REGISTER_OFF,
+				  MEM_AREA_IO_SEC);
+
+	return (vaddr_t)va;
+}
+
+static uint32_t *bckreg_address(unsigned int idx)
+{
+	return (uint32_t *)bckreg_base() + idx;
+}
+
+static void release_secondary_early_hpen(size_t pos)
+{
+	uint32_t *p_entry = bckreg_address(BCKR_CORE1_BRANCH_ADDRESS);
+	uint32_t *p_magic = bckreg_address(BCKR_CORE1_MAGIC_NUMBER);
+
+	*p_entry = TEE_LOAD_ADDR;
+	*p_magic = BOOT_API_A7_CORE1_MAGIC_NUMBER;
+
+	dmb();
+	isb();
+	itr_raise_sgi(GIC_SEC_SGI_0, BIT(pos));
+}
+
+int psci_cpu_on(uint32_t core_id, uint32_t entry, uint32_t context_id)
+{
+	size_t pos = get_core_pos_mpidr(core_id);
+	static bool core_is_released[CFG_TEE_CORE_NB_CORE];
+
+	if (!pos || pos >= CFG_TEE_CORE_NB_CORE)
+		return PSCI_RET_INVALID_PARAMETERS;
+
+	DMSG("core pos: %zu: ns_entry %#" PRIx32, pos, entry);
+
+	if (core_is_released[pos]) {
+		DMSG("core %zu already released", pos);
+		return PSCI_RET_DENIED;
+	}
+	core_is_released[pos] = true;
+
+	generic_boot_set_core_ns_entry(pos, entry, context_id);
+	release_secondary_early_hpen(pos);
+
+	return PSCI_RET_SUCCESS;
+}

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT			32
+
+#define GIC_BASE			0xA0021000ul
+#define GIC_SIZE			0x2000
+#define GICC_OFFSET			0x1000
+#define GICD_OFFSET			0x0000
+
+#define BKP_REGS_BASE			0x5C00A000
+#define BKP_REGISTER_OFF		0x100
+
+#define UART4_BASE			0x40010000
+#define STM32MP1_DEBUG_USART_BASE	UART4_BASE
+#define GIC_SPI_UART4			84
+
+#define CONSOLE_UART_BASE		STM32MP1_DEBUG_USART_BASE
+#define CONSOLE_UART_SIZE		1024
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-stm32mp1/reset.S
+++ b/core/arch/arm/plat-stm32mp1/reset.S
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2018, STMicroelectronics
+ */
+
+#include <arm32.h>
+#include <arm32_macros.S>
+#include <asm.S>
+#include <kernel/unwind.h>
+
+.section .text
+.balign 4
+.code 32
+
+#define STM32MP1_NSACR_PRESERVE_MASK	(0xfff << 20)
+
+FUNC plat_cpu_reset_early , :
+UNWIND(	.fnstart)
+	ldr	r0, =SCR_SIF
+	write_scr r0
+
+	read_nsacr r0
+	mov_imm	r1, STM32MP1_NSACR_PRESERVE_MASK
+	and	r0, r0, r1
+	write_nsacr r0
+
+	isb
+	bx	lr
+UNWIND(	.fnend)
+END_FUNC plat_cpu_reset_early

--- a/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
+++ b/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2017-2018, STMicroelectronics
+#
+import argparse
+import struct
+import mmap
+
+header_size = 256
+hdr_magic_number = 0x324D5453  # magic ='S' 'T' 'M' 0x32
+hdr_header_ver_variant = 0
+hdr_header_ver_minor = 0
+hdr_header_ver_major = 1
+hdr_version_number = 0
+hdr_option_flags = 1           # bit0=1 no signature
+hdr_edcsa_algo = 1
+
+
+def get_size(file):
+        file.seek(0, 2)        # End of the file
+        size = file.tell()
+        return size
+
+
+def stm32image_checksum(dest_fd, sizedest):
+        csum = 0
+        if sizedest < header_size:
+                return 0
+        dest_fd.seek(header_size, 0)
+        length = sizedest - header_size
+        while length > 0:
+            csum += ord(dest_fd.read(1))
+            length -= 1
+        return csum
+
+
+def stm32image_set_header(dest_fd, load, entry):
+        sizedest = get_size(dest_fd)
+
+        checksum = stm32image_checksum(dest_fd, sizedest)
+
+        dest_fd.seek(0, 0)
+
+        # Magic number
+        dest_fd.write(struct.pack('<I', hdr_magic_number))
+
+        # Image signature (empty)
+        dest_fd.write(b'\x00' * 64)
+
+        # Image checksum ... EDCSA algorithm
+        dest_fd.write(struct.pack('<IBBBBIIIIIIII',
+                      checksum,
+                      hdr_header_ver_variant,
+                      hdr_header_ver_minor,
+                      hdr_header_ver_major,
+                      0,
+                      sizedest - header_size,
+                      entry,
+                      0,
+                      load,
+                      0,
+                      hdr_version_number,
+                      hdr_option_flags,
+                      hdr_edcsa_algo))
+
+        # EDCSA public key (empty)
+        dest_fd.write(b'\x00' * 64)
+
+        # Padding
+        dest_fd.write(b'\x00' * 84)
+        dest_fd.close()
+
+
+def stm32image_create_header_file(source, dest, load, entry):
+        dest_fd = open(dest, 'w+b')
+        src_fd = open(source, 'rb')
+
+        dest_fd.write(b'\x00' * header_size)
+
+        sizesrc = get_size(src_fd)
+        if sizesrc > 0:
+                mmsrc = mmap.mmap(src_fd.fileno(), 0, access=mmap.ACCESS_READ)
+                dest_fd.write(mmsrc[:sizesrc])
+                mmsrc.close()
+
+        src_fd.close()
+
+        stm32image_set_header(dest_fd, load, entry)
+
+        dest_fd.close()
+
+
+def int_parse(str):
+        return int(str, 0)
+
+
+def get_args():
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--source',
+                            required=True,
+                            help='Source file')
+
+        parser.add_argument('--dest',
+                            required=True,
+                            help='Destination file')
+
+        parser.add_argument('--load',
+                            required=True, type=int_parse,
+                            help='Load address')
+
+        parser.add_argument('--entry',
+                            required=True, type=int_parse,
+                            help='Entry point')
+
+        return parser.parse_args()
+
+
+def main():
+        args = get_args()
+        source_file = args.source
+        destination_file = args.dest
+        load_address = args.load
+        entry_point = args.entry
+
+        stm32image_create_header_file(source_file,
+                                      destination_file,
+                                      load_address,
+                                      entry_point)
+
+
+if __name__ == "__main__":
+        main()

--- a/core/arch/arm/plat-stm32mp1/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/sub.mk
@@ -1,0 +1,4 @@
+global-incdirs-y += .
+
+srcs-y += main.c
+srcs-y += reset.S

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics
+ */
+
+#include <compiler.h>
+#include <drivers/serial.h>
+#include <drivers/stm32_uart.h>
+#include <io.h>
+#include <keep.h>
+#include <util.h>
+
+#define UART_REG_CR1			0x00	/* Control register 1 */
+#define UART_REG_CR2			0x04	/* Control register 2 */
+#define UART_REG_CR3			0x08	/* Control register 3 */
+#define UART_REG_BRR			0x0c	/* Baud rate register */
+#define UART_REG_RQR			0x18	/* Request register */
+#define UART_REG_ISR			0x1c	/* Interrupt & status reg. */
+#define UART_REG_ICR			0x20	/* Interrupt flag clear reg. */
+#define UART_REG_RDR			0x24	/* Receive data register */
+#define UART_REG_TDR			0x28	/* Transmit data register */
+#define UART_REG_PRESC			0x2c	/* Prescaler register */
+
+/*
+ * Uart Interrupt & status register bits
+ *
+ * Bit 5 RXNE: Read data register not empty/RXFIFO not empty
+ * Bit 6 TC: Transmission complete
+ * Bit 7 TXE/TXFNF: Transmit data register empty/TXFIFO not full
+ * Bit 27 TXFE: TXFIFO threshold reached
+ */
+#define USART_ISR_RXNE_RXFNE		BIT(5)
+#define USART_ISR_TC			BIT(6)
+#define USART_ISR_TXE_TXFNF		BIT(7)
+#define USART_ISR_TXFE			BIT(27)
+
+static vaddr_t loc_chip_to_base(struct serial_chip *chip)
+{
+	struct console_pdata *pd =
+		container_of(chip, struct console_pdata, chip);
+
+	return io_pa_or_va(&pd->base);
+}
+
+static void loc_flush(struct serial_chip *chip)
+{
+	vaddr_t base = loc_chip_to_base(chip);
+
+	while (!(read32(base + UART_REG_ISR) & USART_ISR_TXFE))
+		;
+}
+
+static void loc_putc(struct serial_chip *chip, int ch)
+{
+	vaddr_t base = loc_chip_to_base(chip);
+
+	while (!(read32(base + UART_REG_ISR) & USART_ISR_TXE_TXFNF))
+		;
+
+	write32(ch, base + UART_REG_TDR);
+}
+
+static bool loc_have_rx_data(struct serial_chip *chip)
+{
+	vaddr_t base = loc_chip_to_base(chip);
+
+	return read32(base + UART_REG_ISR) & USART_ISR_RXNE_RXFNE;
+}
+
+static int loc_getchar(struct serial_chip *chip)
+{
+	vaddr_t base = loc_chip_to_base(chip);
+
+	while (!loc_have_rx_data(chip))
+		;
+
+	return read32(base + UART_REG_RDR) & 0xff;
+}
+
+static const struct serial_ops serial_ops = {
+	.flush = loc_flush,
+	.putc = loc_putc,
+	.have_rx_data = loc_have_rx_data,
+	.getchar = loc_getchar,
+
+};
+KEEP_PAGER(serial_ops);
+
+void stm32_uart_init(struct console_pdata *pd, vaddr_t base)
+{
+	pd->base.pa = base;
+	pd->chip.ops = &serial_ops;
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -19,3 +19,4 @@ srcs-$(CFG_DRA7_RNG) += dra7_rng.c
 srcs-$(CFG_STIH_UART) += stih_asc.c
 srcs-$(CFG_ATMEL_UART) += atmel_uart.c
 srcs-$(CFG_MVEBU_UART) += mvebu_uart.c
+srcs-$(CFG_STM32_UART) += stm32_uart.c

--- a/core/include/drivers/stm32_uart.h
+++ b/core/include/drivers/stm32_uart.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics
+ */
+
+#ifndef __STM32_UART_H__
+#define __STM32_UART_H__
+
+#include <drivers/serial.h>
+
+struct console_pdata {
+	struct io_pa_va base;
+	struct serial_chip chip;
+};
+
+void stm32_uart_init(struct console_pdata *pd, vaddr_t base);
+
+#endif /*__STM32_UART_H__*/


### PR DESCRIPTION
Introduce platform stm32mp1 with board stm32mp1-stm32mp157c-ev1 based on stm32mp1 SoC family integrating Arm Cortex-A7 technology. In its default configuration, stm32mp1 OP-TEE core operates in a 256kB secure RAM with pager support enabled.

Platform flavor identifiers for the stm32mp1 do contain a hyphen, as the default stm32mp1-stm32mp157c-ev1. For optee_os to support hyphens inside platform flavor, the P-R includes a change in the core make script.