### PR TITLE
scripts/symbolize.py: ignore undefined symbols

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -200,8 +200,12 @@ class Symbolizer(object):
                 addr, size, _, name = line.split()
             except:
                 # Size is missing
-                addr, _, name = line.split()
-                size = '0'
+                try:
+                    addr, _, name = line.split()
+                    size = '0'
+                except:
+                    # E.g., undefined (external) symbols (line = "U symbol")
+                    continue
             iaddr = int(addr, 16)
             isize = int(size, 16)
             if iaddr == ireladdr:


### PR DESCRIPTION
With the introduction of dynamically linked TAs, symbolize.py may
encounter undefined (external) symbols when it parses the output of the nm
command looking for a symbol's address. The current code is not prepared
for that and will raise an exception. Fix the issue by ignoring lines that
have an unexpected format.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
