### PR TITLE
core: arm: sm: initialize PMCR.DP to 1 and save/restore PMCR

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -59,6 +59,10 @@ endif
 # Addresses CVE-2017-5715 (aka Meltdown) known to affect Arm Cortex-A75
 CFG_CORE_UNMAP_CORE_AT_EL0 ?= y
 
+# Initialize PMCR.DP to 1 to prohibit cycle counting in secure state, and
+# save/restore PMCR during world switch.
+CFG_SM_NO_CYCLE_COUNTING ?= y
+
 ifeq ($(CFG_ARM32_core),y)
 # Configration directive related to ARMv7 optee boot arguments.
 # CFG_PAGEABLE_ADDR: if defined, forces pageable data physical address.

--- a/core/arch/arm/include/arm32.h
+++ b/core/arch/arm/include/arm32.h
@@ -31,6 +31,8 @@
 #define CPSR_IT_MASK1	ARM32_CPSR_IT_MASK1
 #define CPSR_IT_MASK2	ARM32_CPSR_IT_MASK2
 
+#define PMCR_DP		BIT32(5)
+
 #define SCR_NS		BIT32(0)
 #define SCR_IRQ		BIT32(1)
 #define SCR_FIQ		BIT32(2)

--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -187,6 +187,14 @@
 	mcr	p15, 0, \reg, c8, c3, 3
 	.endm
 
+	.macro read_pmcr reg
+	mrc	p15, 0, \reg, c9, c12, 0
+	.endm
+
+	.macro write_pmcr reg
+	mcr	p15, 0, \reg, c9, c12, 0
+	.endm
+
 	.macro write_prrr reg
 	mcr	p15, 0, \reg, c10, c2, 0
 	.endm

--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -10,7 +10,7 @@
 #include <compiler.h>
 #include <types_ext.h>
 
-struct sm_mode_regs {
+struct sm_unbanked_regs {
 	uint32_t usr_sp;
 	uint32_t usr_lr;
 	uint32_t irq_spsr;
@@ -35,7 +35,7 @@ struct sm_mode_regs {
 };
 
 struct sm_nsec_ctx {
-	struct sm_mode_regs mode_regs;
+	struct sm_unbanked_regs ub_regs;
 
 	uint32_t r8;
 	uint32_t r9;
@@ -58,7 +58,7 @@ struct sm_nsec_ctx {
 };
 
 struct sm_sec_ctx {
-	struct sm_mode_regs mode_regs;
+	struct sm_unbanked_regs ub_regs;
 
 	uint32_t r0;
 	uint32_t r1;
@@ -112,6 +112,6 @@ static inline bool sm_platform_handler(__unused struct sm_ctx *ctx)
 bool sm_platform_handler(struct sm_ctx *ctx);
 #endif
 
-void sm_save_modes_regs(struct sm_mode_regs *regs);
-void sm_restore_modes_regs(struct sm_mode_regs *regs);
+void sm_save_unbanked_regs(struct sm_unbanked_regs *regs);
+void sm_restore_unbanked_regs(struct sm_unbanked_regs *regs);
 #endif /*SM_SM_H*/

--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -32,6 +32,10 @@ struct sm_unbanked_regs {
 	uint32_t und_spsr;
 	uint32_t und_sp;
 	uint32_t und_lr;
+#ifdef CFG_SM_NO_CYCLE_COUNTING
+	uint32_t pmcr;
+	uint32_t pad;
+#endif
 };
 
 struct sm_nsec_ctx {

--- a/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
+++ b/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
@@ -176,8 +176,7 @@ int imx7d_lowpower_idle(uint32_t power_state __unused,
 	p->num_online_cpus = get_online_cpus();
 	p->num_lpi_cpus++;
 
-	/* Store non-sec ctx regs */
-	sm_save_modes_regs(&nsec->mode_regs);
+	sm_save_unbanked_regs(&nsec->ub_regs);
 
 	ret = sm_pm_cpu_suspend((uint32_t)p, (int (*)(uint32_t))
 				(cpuidle_ocram_base + sizeof(*p)));
@@ -198,7 +197,7 @@ int imx7d_lowpower_idle(uint32_t power_state __unused,
 	 * When cpu powers up, after ROM init, cpu in secure SVC
 	 * mode, we first need to restore monitor regs.
 	 */
-	sm_restore_modes_regs(&nsec->mode_regs);
+	sm_restore_unbanked_regs(&nsec->ub_regs);
 
 	p->num_lpi_cpus--;
 	/* Back to Linux */

--- a/core/arch/arm/plat-imx/pm/imx7_suspend.c
+++ b/core/arch/arm/plat-imx/pm/imx7_suspend.c
@@ -39,8 +39,7 @@ int imx7_cpu_suspend(uint32_t power_state __unused, uintptr_t entry,
 		suspended_init = 1;
 	}
 
-	/* Store non-sec ctx regs */
-	sm_save_modes_regs(&nsec->mode_regs);
+	sm_save_unbanked_regs(&nsec->ub_regs);
 
 	ret = sm_pm_cpu_suspend((uint32_t)p, (int (*)(uint32_t))
 				(suspend_ocram_base + sizeof(*p)));
@@ -55,8 +54,7 @@ int imx7_cpu_suspend(uint32_t power_state __unused, uintptr_t entry,
 
 	plat_cpu_reset_late();
 
-	/* Restore register of different mode in secure world */
-	sm_restore_modes_regs(&nsec->mode_regs);
+	sm_restore_unbanked_regs(&nsec->ub_regs);
 
 	/* Set entry for back to Linux */
 	nsec->mon_lr = (uint32_t)entry;

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -125,20 +125,20 @@ void init_sec_mon(unsigned long nsec_entry)
 	/* Initialize secure monitor */
 	nsec_ctx = sm_get_nsec_ctx();
 
-	nsec_ctx->mode_regs.usr_sp = plat_boot_args->nsec_ctx.usr_sp;
-	nsec_ctx->mode_regs.usr_lr = plat_boot_args->nsec_ctx.usr_lr;
-	nsec_ctx->mode_regs.irq_spsr = plat_boot_args->nsec_ctx.irq_spsr;
-	nsec_ctx->mode_regs.irq_sp = plat_boot_args->nsec_ctx.irq_sp;
-	nsec_ctx->mode_regs.irq_lr = plat_boot_args->nsec_ctx.irq_lr;
-	nsec_ctx->mode_regs.svc_spsr = plat_boot_args->nsec_ctx.svc_spsr;
-	nsec_ctx->mode_regs.svc_sp = plat_boot_args->nsec_ctx.svc_sp;
-	nsec_ctx->mode_regs.svc_lr = plat_boot_args->nsec_ctx.svc_lr;
-	nsec_ctx->mode_regs.abt_spsr = plat_boot_args->nsec_ctx.abt_spsr;
-	nsec_ctx->mode_regs.abt_sp = plat_boot_args->nsec_ctx.abt_sp;
-	nsec_ctx->mode_regs.abt_lr = plat_boot_args->nsec_ctx.abt_lr;
-	nsec_ctx->mode_regs.und_spsr = plat_boot_args->nsec_ctx.und_spsr;
-	nsec_ctx->mode_regs.und_sp = plat_boot_args->nsec_ctx.und_sp;
-	nsec_ctx->mode_regs.und_lr = plat_boot_args->nsec_ctx.und_lr;
+	nsec_ctx->ub_regs.usr_sp = plat_boot_args->nsec_ctx.usr_sp;
+	nsec_ctx->ub_regs.usr_lr = plat_boot_args->nsec_ctx.usr_lr;
+	nsec_ctx->ub_regs.irq_spsr = plat_boot_args->nsec_ctx.irq_spsr;
+	nsec_ctx->ub_regs.irq_sp = plat_boot_args->nsec_ctx.irq_sp;
+	nsec_ctx->ub_regs.irq_lr = plat_boot_args->nsec_ctx.irq_lr;
+	nsec_ctx->ub_regs.svc_spsr = plat_boot_args->nsec_ctx.svc_spsr;
+	nsec_ctx->ub_regs.svc_sp = plat_boot_args->nsec_ctx.svc_sp;
+	nsec_ctx->ub_regs.svc_lr = plat_boot_args->nsec_ctx.svc_lr;
+	nsec_ctx->ub_regs.abt_spsr = plat_boot_args->nsec_ctx.abt_spsr;
+	nsec_ctx->ub_regs.abt_sp = plat_boot_args->nsec_ctx.abt_sp;
+	nsec_ctx->ub_regs.abt_lr = plat_boot_args->nsec_ctx.abt_lr;
+	nsec_ctx->ub_regs.und_spsr = plat_boot_args->nsec_ctx.und_spsr;
+	nsec_ctx->ub_regs.und_sp = plat_boot_args->nsec_ctx.und_sp;
+	nsec_ctx->ub_regs.und_lr = plat_boot_args->nsec_ctx.und_lr;
 	nsec_ctx->mon_lr = plat_boot_args->nsec_ctx.mon_lr;
 	nsec_ctx->mon_spsr = plat_boot_args->nsec_ctx.mon_spsr;
 

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -27,8 +27,8 @@ bool sm_from_nsec(struct sm_ctx *ctx)
 	}
 #endif
 
-	sm_save_modes_regs(&ctx->nsec.mode_regs);
-	sm_restore_modes_regs(&ctx->sec.mode_regs);
+	sm_save_unbanked_regs(&ctx->nsec.ub_regs);
+	sm_restore_unbanked_regs(&ctx->sec.ub_regs);
 
 	memcpy(&ctx->sec.r0, nsec_r0, sizeof(uint32_t) * 8);
 	if (OPTEE_SMC_IS_FAST_CALL(ctx->sec.r0))

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -17,7 +17,7 @@
 
 	.section .text.sm_asm
 
-FUNC sm_save_modes_regs , :
+FUNC sm_save_unbanked_regs , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
 	/* User mode registers has to be saved from system mode */
@@ -47,10 +47,10 @@ UNWIND(	.cantunwind)
 	cps	#CPSR_MODE_MON
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC sm_save_modes_regs
+END_FUNC sm_save_unbanked_regs
 
 /* Restores the mode specific registers */
-FUNC sm_restore_modes_regs , :
+FUNC sm_restore_unbanked_regs , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
 	/* User mode registers has to be saved from system mode */
@@ -80,7 +80,7 @@ UNWIND(	.cantunwind)
 	cps	#CPSR_MODE_MON
 	bx	lr
 UNWIND(	.fnend)
-END_FUNC sm_restore_modes_regs
+END_FUNC sm_restore_unbanked_regs
 
 /*
  * stack_tmp is used as stack, the top of the stack is reserved to hold
@@ -111,7 +111,7 @@ UNWIND(	.cantunwind)
 
 	/* Save secure context */
 	add	r0, sp, #SM_CTX_SEC
-	bl	sm_save_modes_regs
+	bl	sm_save_unbanked_regs
 
 	/*
 	 * On FIQ exit we're restoring the non-secure context unchanged, on
@@ -127,7 +127,7 @@ UNWIND(	.cantunwind)
 
 	/* Restore non-secure context */
 	add	r0, sp, #SM_CTX_NSEC
-	bl	sm_restore_modes_regs
+	bl	sm_restore_unbanked_regs
 
 .sm_ret_to_nsec:
 	/*
@@ -212,7 +212,7 @@ UNWIND(	.cantunwind)
 
 	/* Save non-secure context */
 	add	r0, sp, #SM_CTX_NSEC
-	bl	sm_save_modes_regs
+	bl	sm_save_unbanked_regs
 	stm	r0!, {r8-r12}
 
 	/* Set FIQ entry */
@@ -221,7 +221,7 @@ UNWIND(	.cantunwind)
 
 	/* Restore secure context */
 	add	r0, sp, #SM_CTX_SEC
-	bl	sm_restore_modes_regs
+	bl	sm_restore_unbanked_regs
 
 	add	sp, sp, #(SM_CTX_SEC + SM_SEC_CTX_MON_LR)
 

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -44,6 +44,10 @@ UNWIND(	.cantunwind)
 	mrs	r2, spsr
 	stm	r0!, {r2, sp, lr}
 
+#ifdef CFG_SM_NO_CYCLE_COUNTING
+	read_pmcr r2
+	stm	r0!, {r2}
+#endif
 	cps	#CPSR_MODE_MON
 	bx	lr
 UNWIND(	.fnend)
@@ -77,6 +81,10 @@ UNWIND(	.cantunwind)
 	ldm	r0!, {r2, sp, lr}
 	msr	spsr_fsxc, r2
 
+#ifdef CFG_SM_NO_CYCLE_COUNTING
+	ldm	r0!, {r2}
+	write_pmcr r2
+#endif
 	cps	#CPSR_MODE_MON
 	bx	lr
 UNWIND(	.fnend)
@@ -351,7 +359,11 @@ UNWIND(	.fnstart)
 	write_scr r0
 	isb
 #endif
-
+#ifdef CFG_SM_NO_CYCLE_COUNTING
+	read_pmcr r0
+	orr	r0, #PMCR_DP
+	write_pmcr r0
+#endif
 	msr	cpsr, r1
 
 #ifdef CFG_CORE_WORKAROUND_SPECTRE_BP


### PR DESCRIPTION
Introduce CFG_SM_NO_CYCLE_COUNTING to intitialize PMCR.DP to 1 and
save/restore PMCR on world switch. Similar to what is done in ARM TF
commit 3e61b2b54336 ("Init and save / restore of PMCR_EL0 / PMCR") [1].

The purpose of this is to (hopefully) make attacks such as CLKSCREW [2]
harder to mount, altough it is likely that timing information could be
obtained via other means.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Link: [1] https://github.com/ARM-software/arm-trusted-firmware/commit/3e61b2b54336
Link: [2] https://www.usenix.org/system/files/conference/usenixsecurity17/sec17-tang.pdf

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
