### PR TITLE
plat-sunxi: Add Allwinner A64 support

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -95,3 +95,4 @@ build:
     - _make PLATFORM=marvell-armada3700
     - _make PLATFORM=synquacer
     - _make PLATFORM=sunxi-bpi_zero
+    - _make PLATFORM=sunxi-sun50i_a64

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -46,6 +46,11 @@ R:	Ying-Chun Liu (PaulLiu) <paul.liu@linaro.org> [@grandpaul]
 S:	Maintained
 F:	core/arch/arm/plat-sunxi/
 
+AllWinner sun50i A64
+R:	Amit Singh Tomar <amittomer25@gmail.com> [@Amit-Radur]
+S:	Maintained
+F:	core/arch/arm/plat-sunxi/
+
 Atmel ATSAMA5D2-XULT
 R:	Akshay Bhat <akshay.bhat@timesys.com> [@nodeax]
 S:	Maintained

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The **Maintained?** column shows:
 | [STMicroelectronics b2260 - h410 (96boards fmt)](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-b2260`| No | ![Actively maintained](documentation/images/green.svg) |
 | [STMicroelectronics b2120 - h310 / h410](http://www.st.com/web/en/catalog/mmc/FM131/SC999/SS1628/PF258776) |`PLATFORM=stm-cannes`| No | ![Actively maintained](documentation/images/green.svg) |
 | STMicroelectronics stm32mp1 |`PLATFORM=stm32mp1`| No | ![Actively maintained](documentation/images/green.svg) |
+| [Allwinner A64 Pine64 Board](https://www.pine64.org/) |`PLATFORM=sunxi-sun50i_a64`| Yes | ![Actively Maintained](documentation/images/green.svg) |
 | [Texas Instruments AM65x](http://www.ti.com/lit/ug/spruid7/spruid7.pdf)|`PLATFORM=k3-am65x`| Yes | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments DRA7xx](http://www.ti.com/processors/automotive-processors/drax-infotainment-socs/overview.html)|`PLATFORM=ti-dra7xx`| Yes | ![Actively maintained](documentation/images/green.svg) |
 | [Texas Instruments AM57xx](http://www.ti.com/processors/sitara/arm-cortex-a15/am57x/overview.html)|`PLATFORM=ti-am57xx`| Yes | ![Actively maintained](documentation/images/green.svg) |

--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -1,16 +1,15 @@
 PLATFORM_FLAVOR ?= bpi_zero
 
-include core/arch/arm/cpu/cortex-a7.mk
-
-ta-targets = ta_arm32
-
-$(call force,CFG_SUN8I_H2_PLUS,y)
-$(call force,CFG_ARM32_core,y)
 $(call force,CFG_GENERIC_BOOT,y)
-$(call force,CFG_GIC,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_8250_UART,y)
 $(call force,CFG_PM_STUBS,y)
-$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+
+ifeq ($(PLATFORM_FLAVOR),bpi_zero)
+include core/arch/arm/cpu/cortex-a7.mk
+$(call force,CFG_SUN8I_H2_PLUS,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_GIC,y)
 $(call force,CFG_WITH_LPAE,n)
 $(call force,CFG_WITH_PAGER,n)
 
@@ -20,8 +19,6 @@ CFG_TEE_CORE_NB_CORE ?= 4
 CFG_WITH_STACK_CANARIES ?= y
 CFG_BOOT_SECONDARY_REQUEST ?= y
 CFG_PSCI_ARM32 ?= y
-CFG_WITH_STACK_CANARIES ?= y
-CFG_WITH_STATS ?= y
 CFG_NS_ENTRY_ADDR ?= 0x42000000
 CFG_DT ?= y
 CFG_INIT_CNTVOFF ?= y
@@ -30,3 +27,27 @@ CFG_TZDRAM_START ?= 0x5c000000
 CFG_TZDRAM_SIZE ?= 0x03e00000
 CFG_SHMEM_START ?= 0x5fe00000
 CFG_SHMEM_SIZE ?= 0x00200000
+endif
+
+ta-targets = ta_arm32
+
+ifeq ($(PLATFORM_FLAVOR),sun50i_a64)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_WITH_LPAE,y)
+ta-targets += ta_arm64
+
+CFG_TZDRAM_START ?= 0x40000000
+CFG_TZDRAM_SIZE  ?= 0x2000000
+CFG_SHMEM_START  ?= 0x44000000
+CFG_SHMEM_SIZE   ?= 0x00400000
+CFG_TEE_CORE_NB_CORE ?= 4
+CFG_TZC380 ?= y
+endif
+
+ifeq ($(platform-flavor-armv8),1)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+endif
+
+CFG_WITH_STACK_CANARIES ?= y
+CFG_WITH_STATS ?= y

--- a/core/arch/arm/plat-sunxi/platform_config.h
+++ b/core/arch/arm/plat-sunxi/platform_config.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2014, Allwinner Technology Co., Ltd.
  * Copyright (c) 2018, Linaro Limited
+ * Copyright (c) 2018, Amit Singh Tomar <amittomer25@gmail.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,25 +34,29 @@
 #include <mm/generic_ram_layout.h>
 
 /* Make stacks aligned to data cache line length */
-#define STACK_ALIGNMENT		32
+#define STACK_ALIGNMENT		64
 
 /* 16550 UART */
 #define CONSOLE_UART_BASE	0x01c28000 /* UART0 */
 #define CONSOLE_UART_CLK_IN_HZ	24000000
 #define CONSOLE_BAUDRATE	115200
 #define SUNXI_UART_REG_SIZE	0x400
+
+#if defined(PLATFORM_FLAVOR_bpi_zero)
 #define GIC_BASE		0x01c80000
 #define GICC_OFFSET		0x2000
 #define GICD_OFFSET		0x1000
-#define SMC_BASE		0x01c1e000
 #define SUNXI_TZPC_BASE		0x01c23400
 #define SUNXI_TZPC_REG_SIZE	0x400
-#define SUNXI_CPUCFG_BASE		0x01f01c00
+#define SUNXI_CPUCFG_BASE	0x01f01c00
 #define SUNXI_CPUCFG_REG_SIZE	0x400
 #define SUNXI_PRCM_BASE		0x01f01400
 #define SUNXI_PRCM_REG_SIZE	0x400
-#define PRCM_CPU_SOFT_ENTRY_REG   (0x164)
+#define PRCM_CPU_SOFT_ENTRY_REG	0x164
+#endif
 
-#define DRAM0_SIZE		0x20000000
+#if defined(PLATFORM_FLAVOR_sun50i_a64)
+#define SUNXI_SMC_BASE		0x01c1e000
+#endif
 
 #endif /* PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-sunxi/sub.mk
+++ b/core/arch/arm/plat-sunxi/sub.mk
@@ -1,5 +1,5 @@
 global-incdirs-y += .
 srcs-y += main.c
-srcs-y += plat_init.S
-srcs-y += psci.c
+srcs-$(CFG_ARM32_core) += plat_init.S
+srcs-$(CFG_ARM32_core) += psci.c
 cflags-psci.c-y += -Wno-suggest-attribute=noreturn


### PR DESCRIPTION
This pull request attempts to add support for pine64 board based on
Allwinner's A64 SoC.

PS: This depends on one of the patches from PR: Upstream i.MX SoC support #2216 

Signed-off-by: Amit Singh Tomar <amittomer25@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
