### PR TITLE
core: plat-vexpress: fixed translation fault issue in fvp/juno whenever dynamic shared memory is enabled

### DIFF
--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -60,10 +60,10 @@ register_phys_mem(MEM_AREA_RAM_SEC, TZCDRAM_BASE, TZCDRAM_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, SECRAM_BASE, SECRAM_COHERENT_SIZE);
 #endif
 #ifdef DRAM0_BASE
-register_ddr(DRAM0_BASE, DRAM0_SIZE);
+register_dynamic_shm(DRAM0_BASE, DRAM0_SIZE);
 #endif
 #ifdef DRAM1_BASE
-register_ddr(DRAM1_BASE, DRAM1_SIZE);
+register_dynamic_shm(DRAM1_BASE, DRAM1_SIZE);
 #endif
 
 const struct thread_handlers *generic_boot_get_handlers(void)


### PR DESCRIPTION
Fixed translation fault issue on fvp/juno whenever dynamic shared memory
from normal-world is enabled.

Found that TCR_EL1 IPS bits for fvp/juno was wrongly computed to 32bits,
4GB, which was causing a translation fault whenever normal-world was
sharing an address > 32bits, like 0x8f9568000.

TCR_EL1 IPS bits are set via the tcr_ps_bits, which is calculated based
on the MAX PA obtained from the get_nsec_ddr_max_pa() function. This
function does the computation by looping through the core_mmu_phys_mem
structures defined within the phys_nsec_ddr_section section (between
variables __start_phys_nsec_ddr_section and
__end_phys_nsec_ddr_section). But in plat-vexpress there are no
core_mmu_phys_mem structures within that section, instead the fvp DRAM0
and DRAM1 core_mmu_phys_mem structures are defined within the
phys_ddr_overall_section section (defined via the register_ddr macro).

By replacing the following in core/arch/arm/plat-vexpress/main.c:
register_ddr(DRAM0_BASE, DRAM0_SIZE);
register_ddr(DRAM1_BASE, DRAM1_SIZE);

by

register_dynamic_shm(DRAM0_BASE, DRAM0_SIZE);
register_dynamic_shm(DRAM1_BASE, DRAM1_SIZE);

TCR IPS bits are computed correctly to 36 bits (64GB), which fixes the
translation fault.

Signed-off-by: Jean-Paul Etienne <jean-paul.etienne@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
