### PR TITLE
Do not set -Werror by default

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -13,6 +13,7 @@ build:
     - export CROSS_COMPILE32="ccache arm-linux-gnueabihf-"
     - export CROSS_COMPILE64="ccache aarch64-linux-gnu-"
     - export CFG_DEBUG_INFO=n; export CCACHE_UNIFY=true
+    - export CFG_WERROR=y
     - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && ccache -s && ccache -z; }
     - ccache -z
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ script:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then if [ "$(git rev-list --count HEAD^1..HEAD^2)" -gt 1 ]; then checkdiff $(git rev-parse HEAD^1) $(git rev-parse HEAD^2); fi; fi
 
   # Run regression tests (xtest in QEMU)
+  - export CFG_WERROR=y
   - (cd ${HOME}/optee_repo/build && $make check COMPILE_LEGACY=y AARCH32_CROSS_COMPILE=$HOME/optee_repo/toolchains/aarch32-legacy/bin/arm-linux-gnueabihf- LEGACY_AARCH32_CROSS_COMPILE=$HOME/optee_repo/toolchains/aarch32-legacy/bin/arm-linux-gnueabihf- BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
 
 env:

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -20,7 +20,7 @@ comp-cflags$(sm) = -std=gnu99
 comp-aflags$(sm) =
 comp-cppflags$(sm) =
 
-ifndef NOWERROR
+ifeq ($(CFG_WERROR),y)
 comp-cflags$(sm)	+= -Werror
 endif
 comp-cflags$(sm)  	+= -fdiagnostics-show-option


### PR DESCRIPTION
Having -Werror turned on by default can be annoying, because not everyone
uses the same compiler, and different compiler versions have different
warnings.

Therefore, provide CFG_WERROR to turn it on instead. Enable CFG_WERROR in
the CI scripts because we still don't want warnings with the officially
supported compilers.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
