### PR TITLE
drivers: imx_wdog driver cleanup

### DIFF
--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -60,7 +60,7 @@ void imx_wdog_restart(void)
 
 	DMSG("val %x\n", val);
 
-	write16(val, wdog_base + WCR_OFF);
+	write16(val, wdog_base + WDT_WCR);
 	dsb();
 
 	if (read16(wdog_base + WDT_WCR) & WDT_WCR_WDE) {
@@ -68,8 +68,8 @@ void imx_wdog_restart(void)
 		write16(WDT_SEQ2, wdog_base + WDT_WSR);
 	}
 
-	write16(val, wdog_base + WCR_OFF);
-	write16(val, wdog_base + WCR_OFF);
+	write16(val, wdog_base + WDT_WCR);
+	write16(val, wdog_base + WDT_WCR);
 
 	while (1)
 		;


### PR DESCRIPTION
use WDT_WCR defined in watchdog specific imx_wdog.h
instead of  WCR_OFF defined in the platform imx-regs.h

Signed-off-by: Silvano di Ninno <silvano.dininno@nxp.com>
Acked-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
