### PR TITLE
scripts/symbolize.py: remove spurious output '(out/arm/core/tee.elf)'

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -394,13 +394,14 @@ class Symbolizer(object):
                     for k in self._elfs:
                         e = self._elfs[k]
                         if (len(e) >= 3):
+                            # TA executable or library
                             self._out.write(e[2].strip())
-                        elf = self.get_elf(e[0])
-                        if elf:
-                            rpath = os.path.realpath(elf)
-                            path = self.pretty_print_path(rpath)
-                            self._out.write(' (' + path + ')')
-                        self._out.write('\n')
+                            elf = self.get_elf(e[0])
+                            if elf:
+                                rpath = os.path.realpath(elf)
+                                path = self.pretty_print_path(rpath)
+                                self._out.write(' (' + path + ')')
+                            self._out.write('\n')
                 # Here is a good place to resolve the abort address because we
                 # have all the information we need
                 if self._saved_abort_line:


### PR DESCRIPTION
When a TA dump is processed, there is a list of ELF files just before the
call stack. However, when analyzing a TEE core dump, there is no such
list. Make sure this situation is properly handled to avoid displaying a
spurious message. This means fixing incorrect indentation in a
conditional.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
