### PR TITLE
core: fix offset in assign_mobj_to_param_mem()

### DIFF
--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -75,7 +75,7 @@ static TEE_Result assign_mobj_to_param_mem(const paddr_t pa, const size_t sz,
 							  false);
 		if (!mem->mobj)
 			return TEE_ERROR_BAD_PARAMETERS;
-		mem->offs = pa & SMALL_PAGE_MASK;
+		mem->offs = 0;
 		mem->size = sz;
 		return TEE_SUCCESS;
 	}


### PR DESCRIPTION
Prior to this patch assign_mobj_to_param_mem() stored the offset
supplied with a non-contiguous buffer in mem->offs. Since that offset
already is stored inside the resulting MOBJ that offset is added twice.
This patch fixes this by initializing mem->offs to 0 instead.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
