### PR TITLE
plat-imx: add 'generic' platform flavor to scale to more boards

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -28,6 +28,9 @@ $(call force,CFG_MX6SX,y)
 $(call force,CFG_IMX_UART,y)
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx7-flavorlist)))
 $(call force,CFG_MX7,y)
+else ifeq ($(PLATFORM_FLAVOR),generic)
+# Must set CFG_DDR_SIZE, CFG_UART_BASE, and SOC flavor (CFG_MX6Q, CFG_MX7, ...)
+# via config option
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif
@@ -127,6 +130,25 @@ CFG_PSCI_ARM32 ?= y
 CFG_BOOT_SYNC_CPU = n
 CFG_BOOT_SECONDARY_REQUEST = n
 $(call force,CFG_TEE_CORE_NB_CORE,1)
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx6qsabrelite))
+CFG_UART_BASE = UART2_BASE
+CFG_DDR_SIZE = 0x40000000
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx6qsabresd))
+CFG_UART_BASE = UART1_BASE
+CFG_DDR_SIZE = 0x40000000
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx6dlsabresd))
+CFG_UART_BASE = UART1_BASE
+CFG_DDR_SIZE = 0x40000000
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx6ulevk mx6ullevk))
+CFG_UART_BASE = UART1_BASE
 endif
 
 ifeq ($(filter y, $(CFG_PSCI_ARM32)), y)

--- a/core/arch/arm/plat-imx/platform_config.h
+++ b/core/arch/arm/plat-imx/platform_config.h
@@ -54,31 +54,12 @@
 
 #define CFG_TEE_CORE_NB_CORE		1
 
-#define CONSOLE_UART_BASE	(UART1_BASE)
+#define CONSOLE_UART_BASE	CFG_UART_BASE
 
 /* For i.MX6 Quad SABRE Lite and Smart Device board */
 
 #elif defined(CFG_MX6Q) || defined(CFG_MX6D) || defined(CFG_MX6DL) || \
 	defined(CFG_MX6S)
-
-
-/* Board specific console UART */
-#if defined(PLATFORM_FLAVOR_mx6qsabrelite)
-#define CONSOLE_UART_BASE		UART2_BASE
-#endif
-#if defined(PLATFORM_FLAVOR_mx6qsabresd)
-#define CONSOLE_UART_BASE		UART1_BASE
-#endif
-#if defined(PLATFORM_FLAVOR_mx6dlsabresd)
-#define CONSOLE_UART_BASE		UART1_BASE
-#endif
-
-/* Board specific RAM size */
-#if defined(PLATFORM_FLAVOR_mx6qsabrelite) || \
-	defined(PLATFORM_FLAVOR_mx6qsabresd) || \
-	defined(PLATFORM_FLAVOR_mx6dlsabresd)
-#define DRAM0_SIZE			0x40000000
-#endif
 
 /* Core number depends of SoC version. */
 #if defined(CFG_MX6Q)
@@ -91,12 +72,10 @@
 #define CFG_TEE_CORE_NB_CORE		1
 #endif
 
-/* Common RAM and cache controller configuration */
-#define DDR_PHYS_START			DRAM0_BASE
-#define DDR_SIZE			DRAM0_SIZE
+#define CONSOLE_UART_BASE	CFG_UART_BASE
 
-#define CFG_DDR_START			DDR_PHYS_START
-#define CFG_DDR_SIZE			DDR_SIZE
+/* Common RAM and cache controller configuration */
+#define CFG_DDR_START			DRAM0_BASE
 
 /*
  * PL310 TAG RAM Control Register


### PR DESCRIPTION
To support a board that is not in the list of platform flavors, use
PLATFORM=imx-generic and set the SOC flavor (CFG_MX6Q, CFG_MX6DL, etc..),
CFG_UART_BASE, and CFG_DDR_SIZE.

For example, for i.MX6 Quad Hummingboard Edge,

make PLATFORM=imx-generic \
CFG_MX6Q=y \
CFG_UART_BASE=UART1_BASE \
CFG_DDR_SIZE=0x80000000

Tested-by: Jordan Rhee <jordanrh@microsoft.com>
Signed-off-by: Jordan Rhee <jordanrh@microsoft.com>

This pull request is an alternative proposal to #2432.