### PR TITLE
Use inttypes.h over stdint.h on some .h files

### DIFF
--- a/lib/libutee/include/tee_api_types.h
+++ b/lib/libutee/include/tee_api_types.h
@@ -8,7 +8,7 @@
 #define TEE_API_TYPES_H
 
 #include <compiler.h>
-#include <stdint.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <tee_api_defines.h>

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -6,7 +6,7 @@
 #define UTIL_H
 
 #include <compiler.h>
-#include <stdint.h>
+#include <inttypes.h>
 
 #define SIZE_4K	UINTPTR_C(0x1000)
 #define SIZE_1M	UINTPTR_C(0x100000)


### PR DESCRIPTION
Uses inttypes.h over stdint.h on some .h files to be nice to U-boot.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Needed when compiling parts of the xtest regression suite embedded into U-boot since U-boot doesn't like stdint.h.