### PR TITLE
libmbedtls: add interfaces in mbedtls for context memory operation

### DIFF
--- a/lib/libmbedtls/mbedtls/include/mbedtls/ccm.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ccm.h
@@ -37,6 +37,13 @@ extern "C" {
  */
 typedef struct {
     mbedtls_cipher_context_t cipher_ctx;    /*!< cipher context used */
+    unsigned char b[16];
+    unsigned char y[16];
+    unsigned char ctr[16];
+    unsigned char q;
+    size_t iv_len;
+    size_t add_len;
+    int mode;                   /*!< Encrypt or Decrypt */
 }
 mbedtls_ccm_context;
 
@@ -70,6 +77,22 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
  * \param ctx       CCM context to free
  */
 void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
+
+int mbedtls_ccm_clone( mbedtls_ccm_context *dst, const mbedtls_ccm_context *src );
+
+int mbedtls_ccm_starts( mbedtls_ccm_context *ctx, int mode, size_t length,
+                        const unsigned char *iv, size_t iv_len,
+                        const unsigned char *add, size_t add_len,
+                        size_t tag_len );
+
+int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
+                        size_t length,
+                        const unsigned char *input,
+                        unsigned char *output );
+
+int mbedtls_ccm_finish( mbedtls_ccm_context *ctx,
+                        unsigned char *tag,
+                        size_t tag_len );
 
 /**
  * \brief           CCM buffer encryption

--- a/lib/libmbedtls/mbedtls/include/mbedtls/cipher.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/cipher.h
@@ -312,6 +312,21 @@ void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
 void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
 
 /**
+ * \brief           Clone the state of an cipher context
+ *
+ * \note            The two contexts must have been setup to the same type
+ *                  (cloning from AES to DES make no sense).
+ *
+ * \param dst       The destination context
+ * \param src       The context to be cloned
+ *
+ * \return          \c 0 on success,
+ *                  \c MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on parameter failure.
+ */
+int mbedtls_cipher_clone( mbedtls_cipher_context_t *dst,
+                          const mbedtls_cipher_context_t *src );
+
+/**
  * \brief               Initialises and fills the cipher context structure with
  *                      the appropriate values.
  *
@@ -328,6 +343,17 @@ void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
  *                      cipher-specific context failed.
  */
 int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info );
+
+/**
+ * \brief               setup the cipher info structure.
+ *
+ * \param ctx           cipher's context. Must have been initialised.
+ * \param cipher_info   cipher to use.
+ *
+ * \return              0 on success,
+ *                      MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on parameter failure
+ */
+int mbedtls_cipher_setup_info( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info );
 
 /**
  * \brief               Returns the block size of the given cipher.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/cipher_internal.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/cipher_internal.h
@@ -87,6 +87,9 @@ struct mbedtls_cipher_base_t
     /** Allocate a new context */
     void * (*ctx_alloc_func)( void );
 
+    /** Clone context **/
+    void (*ctx_clone_func)( void *dst, const void *src );
+
     /** Free the given context */
     void (*ctx_free_func)( void *ctx );
 

--- a/lib/libmbedtls/mbedtls/include/mbedtls/cmac.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/cmac.h
@@ -56,6 +56,19 @@ struct mbedtls_cmac_context_t
 };
 
 /**
+ * \brief               Initialises and allocat cmac context memory
+ *                      Must be called with an initialized cipher context.
+ *
+ * \param ctx           The cipher context used for the CMAC operation, initialized
+ *                      as one of the following types: MBEDTLS_CIPHER_AES_128_ECB,
+ *                      MBEDTLS_CIPHER_AES_192_ECB, MBEDTLS_CIPHER_AES_256_ECB,
+ *                      or MBEDTLS_CIPHER_DES_EDE3_ECB.
+ * \return              \c 0 on success.
+ * \return              A cipher-specific error code on failure.
+ */
+int mbedtls_cipher_cmac_setup(mbedtls_cipher_context_t *ctx);
+
+/**
  * \brief               Set the CMAC key and prepare to authenticate the input
  *                      data.
  *                      Should be called with an initialized cipher context.

--- a/lib/libmbedtls/mbedtls/include/mbedtls/cmac.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/cmac.h
@@ -56,7 +56,7 @@ struct mbedtls_cmac_context_t
 };
 
 /**
- * \brief               Initialises and allocat cmac context memory
+ * \brief               Initialises and allocat CMAC context memory
  *                      Must be called with an initialized cipher context.
  *
  * \param ctx           The cipher context used for the CMAC operation, initialized

--- a/lib/libmbedtls/mbedtls/include/mbedtls/gcm.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/gcm.h
@@ -53,6 +53,11 @@ typedef struct {
 }
 mbedtls_gcm_context;
 
+int mbedtls_gcm_clone( mbedtls_gcm_context *dst,
+                       const mbedtls_gcm_context *src );
+
+int mbedtls_gcm_gen_table( mbedtls_gcm_context *ctx );
+
 /**
  * \brief           Initialize GCM context (just makes references valid)
  *                  Makes the context ready for mbedtls_gcm_setkey() or

--- a/lib/libmbedtls/mbedtls/library/ccm.c
+++ b/lib/libmbedtls/mbedtls/library/ccm.c
@@ -65,6 +65,23 @@ void mbedtls_ccm_init( mbedtls_ccm_context *ctx )
     memset( ctx, 0, sizeof( mbedtls_ccm_context ) );
 }
 
+int mbedtls_ccm_clone( mbedtls_ccm_context *dst, const mbedtls_ccm_context *src )
+{
+    if( dst == NULL || src == NULL )
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+    memcpy(dst->b, src->b, 16);
+    memcpy(dst->y, src->y, 16);
+    memcpy(dst->ctr, src->ctr, 16);
+    dst->q = src->q;
+    dst->iv_len = src->iv_len;
+    dst->add_len = src->add_len;
+    dst->mode = src->mode;
+    return mbedtls_cipher_clone(&dst->cipher_ctx, &src->cipher_ctx);
+}
+
 int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
                         mbedtls_cipher_id_t cipher,
                         const unsigned char *key,
@@ -114,9 +131,9 @@ void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
  */
 #define UPDATE_CBC_MAC                                                      \
     for( i = 0; i < 16; i++ )                                               \
-        y[i] ^= b[i];                                                       \
+        ctx->y[i] ^= ctx->b[i];                                             \
                                                                             \
-    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, y, 16, y, &olen ) ) != 0 ) \
+    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctx->y, 16, ctx->y, &olen ) ) != 0 ) \
         return( ret );
 
 /*
@@ -125,30 +142,24 @@ void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
  * This avoids allocating one more 16 bytes buffer while allowing src == dst.
  */
 #define CTR_CRYPT( dst, src, len  )                                            \
-    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctr, 16, b, &olen ) ) != 0 )  \
+    if( ( ret = mbedtls_cipher_update( &ctx->cipher_ctx, ctx->ctr, 16, ctx->b, &olen ) ) != 0 )  \
         return( ret );                                                         \
                                                                                \
     for( i = 0; i < len; i++ )                                                 \
-        dst[i] = src[i] ^ b[i];
+        dst[i] = src[i] ^ ctx->b[i];
 
 /*
  * Authenticated encryption or decryption
  */
-static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
+int mbedtls_ccm_starts( mbedtls_ccm_context *ctx, int mode, size_t length,
                            const unsigned char *iv, size_t iv_len,
                            const unsigned char *add, size_t add_len,
-                           const unsigned char *input, unsigned char *output,
-                           unsigned char *tag, size_t tag_len )
+                           size_t tag_len )
 {
     int ret;
     unsigned char i;
-    unsigned char q;
     size_t len_left, olen;
-    unsigned char b[16];
-    unsigned char y[16];
-    unsigned char ctr[16];
     const unsigned char *src;
-    unsigned char *dst;
 
     /*
      * Check length requirements: SP800-38C A.1
@@ -165,7 +176,9 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     if( add_len > 0xFF00 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
 
-    q = 16 - 1 - (unsigned char) iv_len;
+    ctx->mode = mode;
+
+    ctx->q = 16 - 1 - (unsigned char) iv_len;
 
     /*
      * First block B_0:
@@ -179,22 +192,22 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
      * 5 .. 3   (t - 2) / 2
      * 2 .. 0   q - 1
      */
-    b[0] = 0;
-    b[0] |= ( add_len > 0 ) << 6;
-    b[0] |= ( ( tag_len - 2 ) / 2 ) << 3;
-    b[0] |= q - 1;
+    ctx->b[0] = 0;
+    ctx->b[0] |= ( add_len > 0 ) << 6;
+    ctx->b[0] |= ( ( tag_len - 2 ) / 2 ) << 3;
+    ctx->b[0] |= ctx->q - 1;
 
-    memcpy( b + 1, iv, iv_len );
+    memcpy( ctx->b + 1, iv, iv_len );
 
-    for( i = 0, len_left = length; i < q; i++, len_left >>= 8 )
-        b[15-i] = (unsigned char)( len_left & 0xFF );
+    for( i = 0, len_left = length; i < ctx->q; i++, len_left >>= 8 )
+        ctx->b[15-i] = (unsigned char)( len_left & 0xFF );
 
     if( len_left > 0 )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
 
 
     /* Start CBC-MAC with first block */
-    memset( y, 0, 16 );
+    memset( ctx->y, 0, 16 );
     UPDATE_CBC_MAC;
 
     /*
@@ -207,12 +220,12 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         len_left = add_len;
         src = add;
 
-        memset( b, 0, 16 );
-        b[0] = (unsigned char)( ( add_len >> 8 ) & 0xFF );
-        b[1] = (unsigned char)( ( add_len      ) & 0xFF );
+        memset( ctx->b, 0, 16 );
+        ctx->b[0] = (unsigned char)( ( add_len >> 8 ) & 0xFF );
+        ctx->b[1] = (unsigned char)( ( add_len      ) & 0xFF );
 
         use_len = len_left < 16 - 2 ? len_left : 16 - 2;
-        memcpy( b + 2, src, use_len );
+        memcpy( ctx->b + 2, src, use_len );
         len_left -= use_len;
         src += use_len;
 
@@ -222,8 +235,8 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
         {
             use_len = len_left > 16 ? 16 : len_left;
 
-            memset( b, 0, 16 );
-            memcpy( b, src, use_len );
+            memset( ctx->b, 0, 16 );
+            memcpy( ctx->b, src, use_len );
             UPDATE_CBC_MAC;
 
             len_left -= use_len;
@@ -241,10 +254,24 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
      * 7 .. 3   0
      * 2 .. 0   q - 1
      */
-    ctr[0] = q - 1;
-    memcpy( ctr + 1, iv, iv_len );
-    memset( ctr + 1 + iv_len, 0, q );
-    ctr[15] = 1;
+    ctx->ctr[0] = ctx->q - 1;
+    memcpy( ctx->ctr + 1, iv, iv_len );
+    memset( ctx->ctr + 1 + iv_len, 0, ctx->q );
+    ctx->ctr[15] = 1;
+
+    return 0;
+}
+
+int mbedtls_ccm_update( mbedtls_ccm_context *ctx,
+                size_t length,
+                const unsigned char *input,
+                unsigned char *output )
+{
+    int ret;
+    unsigned char i;
+    size_t len_left, olen;
+    const unsigned char *src;
+    unsigned char *dst;
 
     /*
      * Authenticate and {en,de}crypt the message.
@@ -260,19 +287,19 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
     {
         size_t use_len = len_left > 16 ? 16 : len_left;
 
-        if( mode == CCM_ENCRYPT )
+        if( ctx->mode == CCM_ENCRYPT )
         {
-            memset( b, 0, 16 );
-            memcpy( b, src, use_len );
+            memset( ctx->b, 0, 16 );
+            memcpy( ctx->b, src, use_len );
             UPDATE_CBC_MAC;
         }
 
         CTR_CRYPT( dst, src, use_len );
 
-        if( mode == CCM_DECRYPT )
+        if( ctx->mode == CCM_DECRYPT )
         {
-            memset( b, 0, 16 );
-            memcpy( b, dst, use_len );
+            memset( ctx->b, 0, 16 );
+            memcpy( ctx->b, dst, use_len );
             UPDATE_CBC_MAC;
         }
 
@@ -284,21 +311,50 @@ static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
          * Increment counter.
          * No need to check for overflow thanks to the length check above.
          */
-        for( i = 0; i < q; i++ )
-            if( ++ctr[15-i] != 0 )
+        for( i = 0; i < ctx->q; i++ )
+            if( ++ctx->ctr[15-i] != 0 )
                 break;
     }
+
+    return 0;
+}
+
+int mbedtls_ccm_finish( mbedtls_ccm_context *ctx,
+                unsigned char *tag,
+                size_t tag_len )
+{
+    int ret;
+    unsigned char i;
+    size_t olen;
 
     /*
      * Authentication: reset counter and crypt/mask internal tag
      */
-    for( i = 0; i < q; i++ )
-        ctr[15-i] = 0;
+    for( i = 0; i < ctx->q; i++ )
+        ctx->ctr[15-i] = 0;
 
-    CTR_CRYPT( y, y, 16 );
-    memcpy( tag, y, tag_len );
+    CTR_CRYPT( ctx->y, ctx->y, 16 );
+    memcpy( tag, ctx->y, tag_len );
 
     return( 0 );
+}
+
+static int ccm_auth_crypt( mbedtls_ccm_context *ctx, int mode, size_t length,
+                           const unsigned char *iv, size_t iv_len,
+                           const unsigned char *add, size_t add_len,
+                           const unsigned char *input, unsigned char *output,
+                           unsigned char *tag, size_t tag_len )
+{
+    int ret = 0;
+
+    ret = mbedtls_ccm_starts( ctx, mode, length, iv, iv_len, add, add_len, tag_len );
+    if( ret != 0 )
+        return( ret );
+    ret = mbedtls_ccm_update( ctx, length, input, output );
+    if( ret != 0 )
+        return( ret );
+    ret = mbedtls_ccm_finish( ctx, tag, tag_len );
+    return( ret );
 }
 
 /*

--- a/lib/libmbedtls/mbedtls/library/cipher.c
+++ b/lib/libmbedtls/mbedtls/library/cipher.c
@@ -152,6 +152,36 @@ void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx )
     mbedtls_zeroize( ctx, sizeof(mbedtls_cipher_context_t) );
 }
 
+int mbedtls_cipher_clone( mbedtls_cipher_context_t *dst,
+                          const mbedtls_cipher_context_t *src )
+{
+    if( dst == NULL || dst->cipher_info == NULL ||
+        src == NULL || src->cipher_info == NULL)
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+    dst->cipher_info = src->cipher_info;
+    dst->key_bitlen = src->key_bitlen;
+    dst->operation = src->operation;
+#if defined(MBEDTLS_CIPHER_MODE_WITH_PADDING)
+    dst->add_padding = src->add_padding;
+    dst->get_padding = src->get_padding;
+#endif
+    memcpy( dst->unprocessed_data, src->unprocessed_data, MBEDTLS_MAX_BLOCK_LENGTH );
+    dst->unprocessed_len = src->unprocessed_len;
+    memcpy( dst->iv, src->iv, MBEDTLS_MAX_IV_LENGTH );
+    dst->iv_size = src->iv_size;
+    if( dst->cipher_info->base->ctx_clone_func )
+        dst->cipher_info->base->ctx_clone_func( dst->cipher_ctx, src->cipher_ctx );
+
+#if defined(MBEDTLS_CMAC_C)
+    if ( dst->cmac_ctx != NULL && src->cmac_ctx != NULL )
+        memcpy( dst->cmac_ctx, src->cmac_ctx, sizeof( mbedtls_cmac_context_t ) );
+#endif
+    return( 0 );
+}
+
 int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info )
 {
     if( NULL == cipher_info || NULL == ctx )
@@ -175,6 +205,15 @@ int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_in
 #endif
 #endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
 
+    return( 0 );
+}
+
+int mbedtls_cipher_setup_info( mbedtls_cipher_context_t *ctx, const mbedtls_cipher_info_t *cipher_info )
+{
+    if( NULL == cipher_info || NULL == ctx )
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+
+    ctx->cipher_info = cipher_info;
     return( 0 );
 }
 

--- a/lib/libmbedtls/mbedtls/library/cipher_wrap.c
+++ b/lib/libmbedtls/mbedtls/library/cipher_wrap.c
@@ -29,6 +29,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include <string.h>
+
 #if defined(MBEDTLS_CIPHER_C)
 
 #include "mbedtls/cipher_internal.h"
@@ -85,6 +87,11 @@ static void *gcm_ctx_alloc( void )
     return( ctx );
 }
 
+static void gcm_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_gcm_context ) );
+}
+
 static void gcm_ctx_free( void *ctx )
 {
     mbedtls_gcm_free( ctx );
@@ -102,6 +109,11 @@ static void *ccm_ctx_alloc( void )
         mbedtls_ccm_init( (mbedtls_ccm_context *) ctx );
 
     return( ctx );
+}
+
+static void ccm_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_ccm_context ) );
 }
 
 static void ccm_ctx_free( void *ctx )
@@ -172,6 +184,11 @@ static void * aes_ctx_alloc( void )
     return( aes );
 }
 
+static void aes_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_aes_context ) );
+}
+
 static void aes_ctx_free( void *ctx )
 {
     mbedtls_aes_free( (mbedtls_aes_context *) ctx );
@@ -196,6 +213,7 @@ static const mbedtls_cipher_base_t aes_info = {
     aes_setkey_enc_wrap,
     aes_setkey_dec_wrap,
     aes_ctx_alloc,
+    aes_ctx_clone,
     aes_ctx_free
 };
 
@@ -363,6 +381,7 @@ static const mbedtls_cipher_base_t gcm_aes_info = {
     gcm_aes_setkey_wrap,
     gcm_aes_setkey_wrap,
     gcm_ctx_alloc,
+    gcm_ctx_clone,
     gcm_ctx_free,
 };
 
@@ -426,6 +445,7 @@ static const mbedtls_cipher_base_t ccm_aes_info = {
     ccm_aes_setkey_wrap,
     ccm_aes_setkey_wrap,
     ccm_ctx_alloc,
+    ccm_ctx_clone,
     ccm_ctx_free,
 };
 
@@ -529,6 +549,11 @@ static void * camellia_ctx_alloc( void )
     return( ctx );
 }
 
+static void camellia_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_camellia_context ) );
+}
+
 static void camellia_ctx_free( void *ctx )
 {
     mbedtls_camellia_free( (mbedtls_camellia_context *) ctx );
@@ -553,6 +578,7 @@ static const mbedtls_cipher_base_t camellia_info = {
     camellia_setkey_enc_wrap,
     camellia_setkey_dec_wrap,
     camellia_ctx_alloc,
+    camellia_ctx_clone,
     camellia_ctx_free
 };
 
@@ -720,6 +746,7 @@ static const mbedtls_cipher_base_t gcm_camellia_info = {
     gcm_camellia_setkey_wrap,
     gcm_camellia_setkey_wrap,
     gcm_ctx_alloc,
+    gcm_ctx_clone,
     gcm_ctx_free,
 };
 
@@ -783,6 +810,7 @@ static const mbedtls_cipher_base_t ccm_camellia_info = {
     ccm_camellia_setkey_wrap,
     ccm_camellia_setkey_wrap,
     ccm_ctx_alloc,
+    ccm_ctx_clone,
     ccm_ctx_free,
 };
 
@@ -916,6 +944,11 @@ static void * des_ctx_alloc( void )
     return( des );
 }
 
+static void des_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_des_context ) );
+}
+
 static void des_ctx_free( void *ctx )
 {
     mbedtls_des_free( (mbedtls_des_context *) ctx );
@@ -933,6 +966,11 @@ static void * des3_ctx_alloc( void )
     mbedtls_des3_init( des3 );
 
     return( des3 );
+}
+
+static void des3_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_des3_context ) );
 }
 
 static void des3_ctx_free( void *ctx )
@@ -959,6 +997,7 @@ static const mbedtls_cipher_base_t des_info = {
     des_setkey_enc_wrap,
     des_setkey_dec_wrap,
     des_ctx_alloc,
+    des_ctx_clone,
     des_ctx_free
 };
 
@@ -1004,6 +1043,7 @@ static const mbedtls_cipher_base_t des_ede_info = {
     des3_set2key_enc_wrap,
     des3_set2key_dec_wrap,
     des3_ctx_alloc,
+    des3_ctx_clone,
     des3_ctx_free
 };
 
@@ -1049,6 +1089,7 @@ static const mbedtls_cipher_base_t des_ede3_info = {
     des3_set3key_enc_wrap,
     des3_set3key_dec_wrap,
     des3_ctx_alloc,
+    des3_ctx_clone,
     des3_ctx_free
 };
 
@@ -1134,6 +1175,11 @@ static void * blowfish_ctx_alloc( void )
     return( ctx );
 }
 
+static void blowfish_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_blowfish_context ) );
+}
+
 static void blowfish_ctx_free( void *ctx )
 {
     mbedtls_blowfish_free( (mbedtls_blowfish_context *) ctx );
@@ -1158,6 +1204,7 @@ static const mbedtls_cipher_base_t blowfish_info = {
     blowfish_setkey_wrap,
     blowfish_setkey_wrap,
     blowfish_ctx_alloc,
+    blowfish_ctx_clone,
     blowfish_ctx_free
 };
 
@@ -1244,6 +1291,11 @@ static void * arc4_ctx_alloc( void )
     return( ctx );
 }
 
+static void arc4_ctx_clone( void *dst, const void *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_arc4_context ) );
+}
+
 static void arc4_ctx_free( void *ctx )
 {
     mbedtls_arc4_free( (mbedtls_arc4_context *) ctx );
@@ -1268,6 +1320,7 @@ static const mbedtls_cipher_base_t arc4_base_info = {
     arc4_setkey_wrap,
     arc4_setkey_wrap,
     arc4_ctx_alloc,
+    arc4_ctx_clone,
     arc4_ctx_free
 };
 
@@ -1308,6 +1361,12 @@ static void * null_ctx_alloc( void )
     return( (void *) 1 );
 }
 
+static void null_ctx_clone( void *dst, const void *src )
+{
+    ((void) dst);
+    ((void) src);
+}
+
 static void null_ctx_free( void *ctx )
 {
     ((void) ctx);
@@ -1331,6 +1390,7 @@ static const mbedtls_cipher_base_t null_base_info = {
     null_setkey,
     null_setkey,
     null_ctx_alloc,
+    null_ctx_clone,
     null_ctx_free
 };
 

--- a/lib/libmbedtls/mbedtls/library/cmac.c
+++ b/lib/libmbedtls/mbedtls/library/cmac.c
@@ -52,7 +52,6 @@
 
 #include <string.h>
 
-
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
 #else
@@ -199,11 +198,26 @@ static void cmac_pad( unsigned char padded_block[MBEDTLS_CIPHER_BLKSIZE_MAX],
     }
 }
 
+int mbedtls_cipher_cmac_setup(mbedtls_cipher_context_t *ctx)
+{
+    mbedtls_cmac_context_t *cmac_ctx;
+
+    /* Allocated and initialise in the cipher context memory for the CMAC
+     * context */
+    cmac_ctx = mbedtls_calloc( 1, sizeof( mbedtls_cmac_context_t ) );
+    if( cmac_ctx == NULL )
+        return( MBEDTLS_ERR_CIPHER_ALLOC_FAILED );
+
+    ctx->cmac_ctx = cmac_ctx;
+
+    mbedtls_zeroize( cmac_ctx->state, sizeof( cmac_ctx->state ) );
+    return 0;
+}
+
 int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
                                 const unsigned char *key, size_t keybits )
 {
     mbedtls_cipher_type_t type;
-    mbedtls_cmac_context_t *cmac_ctx;
     int retval;
 
     if( ctx == NULL || ctx->cipher_info == NULL || key == NULL )
@@ -226,17 +240,11 @@ int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
             return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
     }
 
-    /* Allocated and initialise in the cipher context memory for the CMAC
-     * context */
-    cmac_ctx = mbedtls_calloc( 1, sizeof( mbedtls_cmac_context_t ) );
-    if( cmac_ctx == NULL )
-        return( MBEDTLS_ERR_CIPHER_ALLOC_FAILED );
+    /*check if cmac ctx had been allocated by mbedtls_cipher_cmac_setup()*/
+     if (ctx->cmac_ctx != NULL)
+	 return 0;
 
-    ctx->cmac_ctx = cmac_ctx;
-
-    mbedtls_zeroize( cmac_ctx->state, sizeof( cmac_ctx->state ) );
-
-    return 0;
+     return mbedtls_cipher_cmac_setup( ctx );
 }
 
 int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,

--- a/lib/libmbedtls/mbedtls/library/cmac.c
+++ b/lib/libmbedtls/mbedtls/library/cmac.c
@@ -202,15 +202,17 @@ int mbedtls_cipher_cmac_setup(mbedtls_cipher_context_t *ctx)
 {
     mbedtls_cmac_context_t *cmac_ctx;
 
-    /* Allocated and initialise in the cipher context memory for the CMAC
-     * context */
+    /*
+     * Allocate and initialise a CMAC context memory in the cipher
+     * context memory
+     */
     cmac_ctx = mbedtls_calloc( 1, sizeof( mbedtls_cmac_context_t ) );
     if( cmac_ctx == NULL )
         return( MBEDTLS_ERR_CIPHER_ALLOC_FAILED );
 
     ctx->cmac_ctx = cmac_ctx;
 
-    mbedtls_zeroize( cmac_ctx->state, sizeof( cmac_ctx->state ) );
+    mbedtls_platform_zeroize( cmac_ctx->state, sizeof( cmac_ctx->state ) );
     return 0;
 }
 
@@ -240,8 +242,8 @@ int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
             return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
     }
 
-    /*check if cmac ctx had been allocated by mbedtls_cipher_cmac_setup()*/
-     if (ctx->cmac_ctx != NULL)
+    /* Check if CMAC ctx had been allocated by mbedtls_cipher_cmac_setup() */
+     if ( ctx->cmac_ctx != NULL )
 	 return 0;
 
      return mbedtls_cipher_cmac_setup( ctx );

--- a/lib/libmbedtls/mbedtls/library/gcm.c
+++ b/lib/libmbedtls/mbedtls/library/gcm.c
@@ -90,6 +90,26 @@ void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
     memset( ctx, 0, sizeof( mbedtls_gcm_context ) );
 }
 
+int mbedtls_gcm_clone( mbedtls_gcm_context *dst,
+                       const mbedtls_gcm_context *src )
+{
+    if( dst == NULL || src == NULL )
+    {
+        return( MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA );
+    }
+
+    mbedtls_cipher_clone( &dst->cipher_ctx, &src->cipher_ctx );
+    memcpy( dst->HL, src->HL, 16 * sizeof( uint64_t ) );
+    memcpy( dst->HH, src->HH, 16 * sizeof( uint64_t ) );
+    dst->len = src->len;
+    dst->add_len = src->add_len;
+    memcpy( dst->base_ectr, src->base_ectr, 16 );
+    memcpy( dst->y, src->y, 16 );
+    memcpy( dst->buf, src->buf, 16 );
+    dst->mode = src->mode;
+    return( 0 );
+}
+
 /*
  * Precompute small multiples of H, that is set
  *      HH[i] || HL[i] = H times i,
@@ -98,7 +118,7 @@ void mbedtls_gcm_init( mbedtls_gcm_context *ctx )
  * is the high-order bit of HH corresponds to P^0 and the low-order bit of HL
  * corresponds to P^127.
  */
-static int gcm_gen_table( mbedtls_gcm_context *ctx )
+int mbedtls_gcm_gen_table( mbedtls_gcm_context *ctx )
 {
     int ret, i, j;
     uint64_t hi, lo;
@@ -184,7 +204,7 @@ int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
         return( ret );
     }
 
-    if( ( ret = gcm_gen_table( ctx ) ) != 0 )
+    if( ( ret = mbedtls_gcm_gen_table( ctx ) ) != 0 )
         return( ret );
 
     return( 0 );

--- a/lib/libmbedtls/mbedtls/library/md.c
+++ b/lib/libmbedtls/mbedtls/library/md.c
@@ -212,6 +212,9 @@ int mbedtls_md_clone( mbedtls_md_context_t *dst,
 
     dst->md_info->clone_func( dst->md_ctx, src->md_ctx );
 
+    if( dst->hmac_ctx != NULL && src->hmac_ctx != NULL )
+        memcpy( dst->hmac_ctx, src->hmac_ctx, 2 * src->md_info->block_size );
+
     return( 0 );
 }
 


### PR DESCRIPTION
1. add mbedtls_cipher_clone() for cipher to copy context between two
operations.
2. add mbedtls_cipher_setup_info() for cipher. cipher need to get its
"cipher_info" according the key length, while the key length is not an
input in allocate function. So, use a default key len in the beginning.
It need to reset the cipher info again in init function.
3. add mbedtls_cipher_cmac_setup() for cmac. This function is separate
from mbedtls_cipher_cmac_starts().
4. copy hmac context in md.

Signed-off-by: Edison Ai <edison.ai@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
