### PR TITLE
core: define syscall_t as void (*)(void)

### DIFF
--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -208,7 +208,7 @@ void __weak tee_svc_handler(struct thread_svc_regs *regs)
 	}
 
 	if (scn > TEE_SCN_MAX)
-		scf = syscall_not_supported;
+		scf = (syscall_t)syscall_not_supported;
 	else
 		scf = tee_svc_syscall_table[scn].fn;
 

--- a/core/arch/arm/tee/arch_svc_private.h
+++ b/core/arch/arm/tee/arch_svc_private.h
@@ -7,8 +7,11 @@
 
 #include <tee_api_types.h>
 
-/* void argument but in reality it can be any number of arguments */
-typedef TEE_Result (*syscall_t)(void);
+/*
+ * Generic "pointer to function" type. Actual syscalls take zero or more
+ * arguments and return TEE_Result.
+ */
+typedef void (*syscall_t)(void);
 
 /* Helper function for tee_svc_handler() */
 uint32_t tee_svc_do_call(struct thread_svc_regs *regs, syscall_t func);


### PR DESCRIPTION
syscall_t is currently typedef'ed as TEE_Result (*)(void). It is used to
represent a pointer to any system call, in the syscall table for instance.
As such, the exact type behind syscall_t cannot reflect all the syscalls
since they have different prototypes. The current declaration with a
TEE_Result return type was probably chosen because it was a common
characteristic of all syscalls to return a TEE_Result.

However, this type causes compilation warnings with GCC 8.1:

core/arch/arm/tee/arch_svc.c:43:36: warning: cast between incompatible function types from ‘void (*)(long unsigned int)’ to ‘TEE_Result (*)(void)’ {aka ‘unsigned int (*)(void)’} [-Wcast-function-type]
 #define SYSCALL_ENTRY(_fn) { .fn = (syscall_t)_fn }
                                    ^
core/arch/arm/tee/arch_svc.c:50:2: note: in expansion of macro ‘SYSCALL_ENTRY’
  SYSCALL_ENTRY(syscall_sys_return),
  ^~~~~~~~~~~~~

The solution is to use 'void (*)(void)' instead, as explained in the GCC
documentation:

 -Wcast-function-type

  Warn when a function pointer is cast to an incompatible function
  pointer. [...] The function type void (*) (void) is special and matches
  everything, which can be used to suppress this warning. [...]

Link: [1] https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
