### PR TITLE
mk/config.mk: remove obsolete comment

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -32,9 +32,6 @@ endif
 # Supported values: undefined, 1, 2 and 3. 3 gives more warnings.
 WARNS ?= 3
 
-# Define NOWERROR=1 so that warnings are not treated as errors
-# NOWERROR=1
-
 # Define DEBUG=1 to compile without optimization (forces -O0)
 # DEBUG=1
 


### PR DESCRIPTION
NOWERROR=1 has been made obsolete by commit beb065df6ee5 ("Do not set
-Werror by default"). Remove it.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
