### PR TITLE
core: unwind: correct function args for print_stack_arm32/64

### DIFF
--- a/core/arch/arm/include/kernel/unwind.h
+++ b/core/arch/arm/include/kernel/unwind.h
@@ -90,15 +90,19 @@ void print_kernel_stack(int level);
 #ifdef ARM64
 static inline void print_stack_arm64(int level __unused,
 				     struct unwind_state_arm64 *state __unused,
-				     uaddr_t exidx __unused,
-				     size_t exidx_sz __unused)
+				     bool kernel_stack __unused,
+				     vaddr_t stack __unused,
+				     size_t stack_size __unused)
 {
 }
 #endif
 static inline void print_stack_arm32(int level __unused,
 				     struct unwind_state_arm32 *state __unused,
 				     uaddr_t exidx __unused,
-				     size_t exidx_sz __unused)
+				     size_t exidx_sz __unused,
+				     bool kernel_stack __unused,
+				     vaddr_t stack __unused,
+				     size_t stack_size __unused)
 {
 }
 static inline void print_kernel_stack(int level __unused)


### PR DESCRIPTION
When CFG_TEE_CORE_LOG_LEVEL=0 to make, met build failure:
"
core/arch/arm/kernel/abort.c: In function '__print_stack_unwind_arm32':
core/arch/arm/kernel/abort.c:113:2: error: too many arguments to function 'print_stack_arm32'
  print_stack_arm32(TRACE_ERROR, &state, exidx, exidx_sz, kernel_stack,
  ^~~~~~~~~~~~~~~~~
"

Signed-off-by: Peng Fan <peng.fan@nxp.com>
