### PR TITLE
imx: wdog: correct wdog_path

### DIFF
--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -97,8 +97,8 @@ static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)
 	};
 #else
 	static const char * const wdog_path[] = {
-		"/soc/aips-bus@02000000/wdog@020bc000",
-		"/soc/aips-bus@02000000/wdog@020c0000",
+		"/soc/aips-bus@2000000/wdog@20bc000",
+		"/soc/aips-bus@2000000/wdog@20c0000",
 	};
 #endif
 


### PR DESCRIPTION
The prefix `0` is removed in Linux Kernel upstream code,
so let's drop it to let wdog work.

Signed-off-by: Peng Fan <peng.fan@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
