### PR TITLE
ci: travis: do not build with legacy compiler (GCC 4.9) anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,6 @@ before_script:
   - mkdir $HOME/optee_repo
   - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git </dev/null && repo sync --no-clone-bundle --no-tags -j 20)
   - (cd $HOME/optee_repo && mv optee_os optee_os_old && ln -s $MYHOME optee_os)
-  - download https://releases.linaro.org/archive/15.02/components/toolchain/binaries/arm-linux-gnueabihf/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz
-  - mkdir -p $HOME/optee_repo/toolchains
-  - (cd $HOME/optee_repo/toolchains && tar xf $DL_DIR/gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf.tar.xz && mv gcc-linaro-4.9-2015.02-3-x86_64_arm-linux-gnueabihf aarch32-legacy)
   - cd $MYHOME
   - git fetch https://github.com/OP-TEE/optee_os --tags
   - unset CC
@@ -80,7 +77,7 @@ script:
 
   # Run regression tests (xtest in QEMU)
   - export CFG_WERROR=y
-  - (cd ${HOME}/optee_repo/build && $make check COMPILE_LEGACY=y AARCH32_CROSS_COMPILE=$HOME/optee_repo/toolchains/aarch32-legacy/bin/arm-linux-gnueabihf- LEGACY_AARCH32_CROSS_COMPILE=$HOME/optee_repo/toolchains/aarch32-legacy/bin/arm-linux-gnueabihf- BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
+  - (cd ${HOME}/optee_repo/build && $make toolchains && $make check BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
 
 env:
   global:


### PR DESCRIPTION
The QEMU test environment has recently been upgraded to use U-Boot
("qemu.mk: replace bios with u-boot" [1] and "default.xml: replace
bios_qemu_tz_arm with u-boot" [2]), which requires GCC 6 or newer.

Fixes the following CI build error:

  *** Your GCC is older than 6.0 and is not supported
  make[1]: *** [checkgcc6] Error 1
  make: *** [u-boot] Error 2

Link: [1] https://github.com/OP-TEE/build/commit/248f5733bf29
Link: [2] https://github.com/OP-TEE/manifest/commit/2067ab3f9bbe
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
