### PR TITLE
core_self_tests.c: fix p1=realloc(p1) issue

### DIFF
--- a/core/arch/arm/pta/core_self_tests.c
+++ b/core/arch/arm/pta/core_self_tests.c
@@ -331,24 +331,28 @@ static int self_test_malloc(void)
 	LOG("");
 
 	/* test realloc */
-	p1 = realloc(p1, 3 * 1024);
-	LOG("- p1 = realloc(p1, 3*1024)");
+	p3 = realloc(p1, 3 * 1024);
+	if (p3)
+		p1 = NULL;
+	LOG("- p3 = realloc(p1, 3*1024)");
 	LOG("- free p2");
 	free(p2);
 	p2 = malloc(1024);
 	LOG("- p2 = malloc(1024)");
 	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
 	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
-	r = (p1 && p2);
+	r = (p2 && p3);
 	if (!r)
 		ret = -1;
 	LOG("  => test %s", r ? "ok" : "FAILED");
 	LOG("");
-	LOG("- free p1, p2");
+	LOG("- free p1, p2, p3");
 	free(p1);
 	free(p2);
+	free(p3);
 	p1 = NULL;
 	p2 = NULL;
+	p3 = NULL;
 
 	/* test calloc */
 	p3 = calloc(4, 1024);


### PR DESCRIPTION
This is invalid use of realloc, because it can cause memory leak.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
