### PR TITLE
abort.c: manipulate with VFP state only if thread is active

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -680,9 +680,11 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 #endif
 	case FAULT_TYPE_PAGEABLE:
 	default:
-		thread_kernel_save_vfp();
+		if (!thread_foreign_intr_disabled())
+			thread_kernel_save_vfp();
 		handled = tee_pager_handle_fault(&ai);
-		thread_kernel_restore_vfp();
+		if (!thread_foreign_intr_disabled())
+			thread_kernel_restore_vfp();
 		if (!handled) {
 			abort_print_error(&ai);
 			if (!abort_is_user_exception(&ai))


### PR DESCRIPTION
`abort_handler()` can be called both within and without thread
context. In the latter case it stops on
`assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR)`
in `thread_kernel_save_vfp()` and no information about abort is displayed.

This assert fires during some initialization stages and during
fast SMCs, because they are handled with foreign interrupts disabled.

To fix this, we should call `thread_kernel_{save,restore}_vfp()` only
when foreign interrupts are enabled.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
