### PR TITLE
arm32: add assembly directive: .arch_extension sec

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -15,6 +15,8 @@
 #include <sm/teesmc_opteed.h>
 #include <sm/teesmc_opteed_macros.h>
 
+.arch_extension sec
+
 .section .data
 .balign 4
 

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -19,6 +19,8 @@
 
 #include "thread_private.h"
 
+	.arch_extension sec
+
 	.macro cmp_spsr_user_mode reg:req
 		/*
 		 * We're only testing the lower 4 bits as bit 5 (0x10)

--- a/core/arch/arm/plat-ti/a9_plat_init.S
+++ b/core/arch/arm/plat-ti/a9_plat_init.S
@@ -40,6 +40,8 @@
 #include <sm/teesmc_opteed.h>
 #include <sm/teesmc_opteed_macros.h>
 
+.arch_extension sec
+
 .section .text
 .balign 4
 .code 32


### PR DESCRIPTION
When compiling with -mcpu=cortex-a9, GCC 8.1 fails on the smc instruction:

 $ make -s PLATFORM=stm CROSS_COMPILE32=~/work/toolchains/gcc-linaro-8.1.0-20180705-09_18_46-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
 core/arch/arm/kernel/thread_a32.S: Assembler messages:
 core/arch/arm/kernel/thread_a32.S:44: Error: selected processor does not support `smc #0' in ARM mode
 [snip]
 mk/compile.mk:146: recipe for target 'out/arm-plat-stm/core/arch/arm/kernel/thread_a32.o' failed
 make: *** [out/arm-plat-stm/core/arch/arm/kernel/thread_a32.o] Error 1

Use the '.arch_extension sec' directive to allow the assembler to emit
the instruction.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
