### PR TITLE
core: arm: ree_fs: fix free hash_ctx

### DIFF
--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -249,7 +249,7 @@ static void ta_close(struct user_ta_store_handle *h)
 	if (!h)
 		return;
 	thread_rpc_free_payload(h->cookie, h->mobj);
-	free(h->hash_ctx);
+	crypto_hash_free_ctx(h->hash_ctx, h->hash_algo);
 	free(h->shdr);
 	free(h);
 }


### PR DESCRIPTION
properly free hash_ctx by calling crypto_hash_free_ctx
instead of the generic free function

Signed-off-by: Silvano di Ninno <silvano.dininno@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
