### PR TITLE
In-tree TAs: prevent double slash in object paths

### DIFF
--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -31,7 +31,7 @@ libnames += mbedtls
 endif
 libdeps = $(addsuffix .a, $(addprefix $(libdirs)/lib, $(libnames)))
 
-subdirs = $(dir $(ta-mk-file))
+subdirs = $(patsubst %/,%,$(dir $(ta-mk-file)))
 include mk/subdir.mk
 
 spec-out-dir := $(link-out-dir$(sm))


### PR DESCRIPTION
When processing the source files for an in-tree user TA (ta/*/user_ta.mk),
make sure not to insert a double slash in the object file path.

Fixes the following error:

 $ make -s
 $ make clean
    CLEAN   out/arm-plat-vexpress
 rmdir: failed to remove 'out/arm-plat-vexpress/ta/avb': No such file or directory
 Makefile:98: recipe for target 'clean' failed
 make: *** [clean] Error 1

The error results from the fact that we have two kinds of object files in
the in-tree TAs:
 - The object files built from ta/*/user_ta.mk. For AVB, we have
   out/arm-plat-vexpress/ta/avb//entry.o (notice the repeated slash).
 - The object files that correspond to "specified source files", i.e.,
   constructed from $(spec-out-dir) and $(spec-srcs). For AVB we have
   out/arm-plat-vexpress/ta/avb/user_ta_header.o.
When "make clean" creates the list of directories to be removed, it strips
the /filename part and keeps only the directory part, resulting in:

 rmdir ...  out/arm-plat-vexpress/ta/avb/ out/arm-plat-vexpress/ta/avb

Trying to remove the same directory twice: "No such file or directory".

Fixes: https://github.com/OP-TEE/optee_os/issues/2484
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
