### PR TITLE
Add dependency on ta-dev-kit when building in-tree TA

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -3,6 +3,7 @@
 # The output from mk/sub.mk
 # base-prefix
 # conf-file [optional] if set, all objects will depend on $(conf-file)
+# additional-compile-deps [optional] additional dependencies
 #
 # Output
 #
@@ -154,7 +155,7 @@ $(foreach f, $(gen-srcs), $(eval $(call process_srcs,$(f),$$(basename $f).o)))
 $(foreach f, $(spec-srcs), $(eval $(call \
 	process_srcs,$(f),$(spec-out-dir)/$$(notdir $$(basename $f)).o)))
 
-$(objs): $(conf-file)
+$(objs): $(conf-file) $(additional-compile-deps)
 
 define _gen-asm-defines-file
 # c-filename in $1
@@ -229,3 +230,5 @@ $(call _gen-asm-defines-file,$1,$2,$(dir $2).$(notdir $(2:.h=.s)))
 endef
 
 $(foreach f,$(asm-defines-files),$(eval $(call gen-asm-defines-file,$(f),$(out-dir)/$(sm)/include/generated/$(basename $(notdir $(f))).h)))
+
+additional-compile-deps :=

--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -37,5 +37,6 @@ include mk/subdir.mk
 spec-out-dir := $(link-out-dir$(sm))
 spec-srcs += $(ta-dev-kit-dir$(sm))/src/user_ta_header.c
 
+additional-compile-deps := ta_dev_kit # TA dev kit should be built before in-tree TAs
 include mk/compile.mk
 include  ta/arch/$(ARCH)/link.mk


### PR DESCRIPTION
Fixes the following errors which may reportedly be triggered by plain
"make" too [1]:

 $ make -s clean && make -s out/arm-plat-vexpress/ta/avb/entry.o
 cc1: warning: out/arm-plat-vexpress/export-ta_arm32/include: No such file or directory [-Wmissing-include-dirs]
 ta/avb/entry.c:5:30: fatal error: tee_internal_api.h: No such file or directory
 compilation terminated.
 mk/compile.mk:146: recipe for target 'out/arm-plat-vexpress/ta/avb/entry.o' failed
 make: *** [out/arm-plat-vexpress/ta/avb/entry.o] Error 1

 $ make -s clean && make -s out/arm-plat-vexpress/ta/avb/user_ta_header.o
 cc1: warning: out/arm-plat-vexpress/export-ta_arm32/include: No such file or directory [-Wmissing-include-dirs]
 out/arm-plat-vexpress/export-ta_arm32/src/user_ta_header.c:5:22: fatal error: compiler.h: No such file or directory
 compilation terminated.
 mk/compile.mk:154: recipe for target 'out/arm-plat-vexpress/ta/avb/user_ta_header.o' failed
 make: *** [out/arm-plat-vexpress/ta/avb/user_ta_header.o] Error 1

Link: [1] https://github.com/OP-TEE/build/issues/285
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
