### PR TITLE
core: tee: crypt_utl: remove one crypto_init

### DIFF
--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -366,7 +366,6 @@ static TEE_Result tee_cryp_init(void)
 {
 	TEE_Result res = crypto_init();
 
-	res = crypto_init();
 	if (res) {
 		EMSG("Failed to initialize crypto API: %#" PRIx32, res);
 		panic();


### PR DESCRIPTION
Crypto_init is called twice in tee_cryp_init.

Signed-off-by: Silvano di Ninno <silvano.dininno@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
