### PR TITLE
core: arm: sm: fix FIQ from normal world

### DIFF
--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -34,7 +34,6 @@ struct sm_unbanked_regs {
 	uint32_t und_lr;
 #ifdef CFG_SM_NO_CYCLE_COUNTING
 	uint32_t pmcr;
-	uint32_t pad;
 #endif
 };
 
@@ -79,8 +78,13 @@ struct sm_sec_ctx {
 };
 
 struct sm_ctx {
+#ifndef CFG_SM_NO_CYCLE_COUNTING
 	uint32_t pad;
+#endif
 	struct sm_sec_ctx sec;
+#ifdef CFG_SM_NO_CYCLE_COUNTING
+	uint32_t pad;
+#endif
 	struct sm_nsec_ctx nsec;
 };
 

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -17,6 +17,7 @@ DEFINES
 	DEFINE(SM_NSEC_CTX_R8, offsetof(struct sm_nsec_ctx, r8));
 	DEFINE(SM_SEC_CTX_R0, offsetof(struct sm_sec_ctx, r0));
 	DEFINE(SM_SEC_CTX_MON_LR, offsetof(struct sm_sec_ctx, mon_lr));
+	DEFINE(SM_CTX_SEC_SIZE, sizeof(struct sm_sec_ctx));
 	DEFINE(SM_CTX_SIZE, sizeof(struct sm_ctx));
 	DEFINE(SM_CTX_NSEC, offsetof(struct sm_ctx, nsec));
 	DEFINE(SM_CTX_SEC, offsetof(struct sm_ctx, sec));

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -17,6 +17,15 @@ bool sm_from_nsec(struct sm_ctx *ctx)
 {
 	uint32_t *nsec_r0 = (uint32_t *)(&ctx->nsec.r0);
 
+	/*
+	 * Check that struct sm_ctx has the different parts properly
+	 * aligned since the stack pointer will be updated to point at
+	 * different parts of this struct.
+	 */
+	COMPILE_TIME_ASSERT(!(offsetof(struct sm_ctx, sec.r0) % 8));
+	COMPILE_TIME_ASSERT(!(offsetof(struct sm_ctx, nsec.r0) % 8));
+	COMPILE_TIME_ASSERT(!(sizeof(struct sm_ctx) % 8));
+
 	if (!sm_platform_handler(ctx))
 		return false;
 

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -15,6 +15,8 @@
 #include <sm/teesmc_opteed_macros.h>
 #include <util.h>
 
+#define SM_CTX_SEC_END	(SM_CTX_SEC + SM_CTX_SEC_SIZE)
+
 	.section .text.sm_asm
 
 FUNC sm_save_unbanked_regs , :
@@ -328,7 +330,7 @@ UNWIND(	.fnstart)
 	mrs	r1, cpsr
 	cps	#CPSR_MODE_MON
 	/* Point just beyond sm_ctx.sec */
-	sub	sp, r0, #(SM_CTX_SIZE - SM_CTX_NSEC)
+	sub	sp, r0, #(SM_CTX_SIZE - SM_CTX_SEC_END)
 
 #ifdef CFG_INIT_CNTVOFF
 	read_scr r0
@@ -408,12 +410,12 @@ KEEP_PAGER sm_init
 FUNC sm_get_nsec_ctx , :
 	mrs	r1, cpsr
 	cps	#CPSR_MODE_MON
-	mov	r0, sp
+	/*
+	 * As we're in secure mode mon_sp points just beyond sm_ctx.sec,
+	 * which allows us to calculate the address of sm_ctx.nsec.
+	 */
+	add	r0, sp, #(SM_CTX_NSEC - SM_CTX_SEC_END)
 	msr	cpsr, r1
 
-	/*
-	 * As we're in secure mode mon_sp points just beyond sm_ctx.sec
-	 * which is sm_ctx.nsec
-	 */
 	bx	lr
 END_FUNC sm_get_nsec_ctx

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -221,6 +221,7 @@ UNWIND(	.cantunwind)
 	/* Save non-secure context */
 	add	r0, sp, #SM_CTX_NSEC
 	bl	sm_save_unbanked_regs
+	add     r0, sp, #(SM_CTX_NSEC + SM_NSEC_CTX_R8)
 	stm	r0!, {r8-r12}
 
 	/* Set FIQ entry */


### PR DESCRIPTION
When compiled with "CFG_SM_NO_CYCLE_COUNTING=y" sm_save_unbanked_regs()
doesn't return with r0 pointing to ctx->nsec.r8 even if that's assumed
in sm_fiq_entry(). Fixes this by calculating the pointer based on sp
instead or relying on a certain value in r0.

Fixes: 8267e19bbcce ("core: arm: sm: initialize PMCR.DP to 1 and save/restore PMCR")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
