### PR TITLE
Do not make in-tree TAs depend on a phony target

### DIFF
--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -37,6 +37,6 @@ include mk/subdir.mk
 spec-out-dir := $(link-out-dir$(sm))
 spec-srcs += $(ta-dev-kit-dir$(sm))/src/user_ta_header.c
 
-additional-compile-deps := ta_dev_kit # TA dev kit should be built before in-tree TAs
+additional-compile-deps := $(ta_dev_kit-files) # TA dev kit should be built before in-tree TAs
 include mk/compile.mk
 include  ta/arch/$(ARCH)/link.mk

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -89,6 +89,7 @@ $2/$$(notdir $1): $1
 
 cleanfiles += $2/$$(notdir $1)
 ta_dev_kit: $2/$$(notdir $1)
+ta_dev_kit-files += $2/$$(notdir $1)
 endef
 
 # Copy the .a files


### PR DESCRIPTION
Commit cf903a62bc12 ("Add dependency on ta-dev-kit when building in-tree
TA") introduces a dependency of the in-tree TA object files on the phony
target 'ta_dev_kit'. The purpose was to make sure the dev kit files are
available when make starts building the TA. Unfortunately, this introduces
useless recompilation (the lines marked with >):

 $ make -s && make
   CHK     out/arm-plat-vexpress/conf.mk
   CHK     out/arm-plat-vexpress/include/generated/conf.h
   CHK     out/arm-plat-vexpress/conf.cmake
   CHK     out/arm-plat-vexpress/export-ta_arm32/mk/conf.mk
>  CC      out/arm-plat-vexpress/ta/avb/entry.o
>  CC      out/arm-plat-vexpress/ta/avb/user_ta_header.o
>  CPP     out/arm-plat-vexpress/ta/avb/ta.lds
>  LD      out/arm-plat-vexpress/ta/avb/023f8f1a-292a-432b-8fc4-de8471358067.elf
>  OBJDUMP out/arm-plat-vexpress/ta/avb/023f8f1a-292a-432b-8fc4-de8471358067.dmp
>  OBJCOPY out/arm-plat-vexpress/ta/avb/023f8f1a-292a-432b-8fc4-de8471358067.stripped.elf
>  SIGN    out/arm-plat-vexpress/ta/avb/023f8f1a-292a-432b-8fc4-de8471358067.ta

This happens because phony targets are always considered new by the make
program, so they'd rather not be used as dependencies. Instead, replace
'ta-dev-kit' by the actual list of all the files in the TA dev kit. Then,
the second make invocation will not rebuild anything:

 $ make -s && make
   CHK     out/arm-plat-vexpress/conf.mk
   CHK     out/arm-plat-vexpress/include/generated/conf.h
   CHK     out/arm-plat-vexpress/conf.cmake
   CHK     out/arm-plat-vexpress/export-ta_arm32/mk/conf.mk

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
