### PR TITLE
ta: link.mk: filter out dependency and command files from $(MAKEFILE_LIST)

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -33,7 +33,8 @@ link-script-cppflags-$(sm) := -DASM=1 \
 
 -include $(link-script-dep$(sm))
 
-$(link-script-pp$(sm)): $(link-script$(sm)) $(conf-file) $(MAKEFILE_LIST)
+link-script-pp-makefiles$(sm) = $(filter-out %.d %.cmd,$(MAKEFILE_LIST))
+$(link-script-pp$(sm)): $(link-script$(sm)) $(conf-file) $(link-script-pp-makefiles$(sm))
 	@$(cmd-echo-silent) '  CPP     $@'
 	$(q)mkdir -p $(dir $@)
 	$(q)$(CPP$(sm)) -Wp,-P,-MT,$@,-MD,$(link-script-dep$(sm)) \


### PR DESCRIPTION
Prevents ta.lds from being needlessly re-generated, such as in the
following test case:

 $ make -s out/arm-plat-vexpress/ta/avb/ta.lds
 $ make -s out/arm-plat-vexpress/core/kernel/console.o
 $ make out/arm-plat-vexpress/ta/avb/ta.lds
   CHK     out/arm-plat-vexpress/conf.mk
   CHK     out/arm-plat-vexpress/include/generated/conf.h
   CPP     out/arm-plat-vexpress/ta/avb/ta.lds

The last line should not hapen because ta.lds exists already, and building
the unrelated console.o should not trigger a re-build.

The cause of the re-build is the dependency on $(MAKEFILE_LIST) which
contains *all* the files that record previous build command and
dependencies such as out/arm-plat-vexpress/core/kernel/.console.o.{d,cmd}.

Filter out those files, thus keeping only the static Makefiles (*.mk).
This is still more than needed since all the core *.mk are present, but
listing only the TA-related makefiles seems tricky (has to work both
inside and outside the OP-TEE build environment), and removing
$(MAKEFILE_LIST) altogether presents a risk that TA developers using the
TA dev kit  will complain that their TA doesn't get re-built after a flag
is changed in a Makefile.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
