### PR TITLE
Fix possible repeated reads  from shared memory

### DIFF
--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -8,6 +8,7 @@
 #include <bench.h>
 #include <compiler.h>
 #include <initcall.h>
+#include <io.h>
 #include <kernel/linker.h>
 #include <kernel/msg_param.h>
 #include <kernel/panic.h>
@@ -122,7 +123,7 @@ static TEE_Result copy_in_params(const struct optee_msg_param *params,
 
 	for (n = 0; n < num_params; n++) {
 		uint32_t attr;
-		saved_attr[n] = params[n].attr;
+		saved_attr[n] = READ_ONCE(params[n].attr);
 
 		if (saved_attr[n] & OPTEE_MSG_ATTR_META)
 			return TEE_ERROR_BAD_PARAMETERS;
@@ -464,7 +465,7 @@ static struct mobj *map_cmd_buffer(paddr_t parg, uint32_t *num_params)
 		return NULL;
 	}
 
-	*num_params = arg->num_params;
+	*num_params = READ_ONCE(arg->num_params);
 	args_size = OPTEE_MSG_GET_ARG_SIZE(*num_params);
 	if (args_size > SMALL_PAGE_SIZE) {
 		EMSG("Command buffer spans across page boundary");
@@ -484,7 +485,7 @@ static struct mobj *get_cmd_buffer(paddr_t parg, uint32_t *num_params)
 	if (!arg)
 		return NULL;
 
-	*num_params = arg->num_params;
+	*num_params = READ_ONCE(arg->num_params);
 	args_size = OPTEE_MSG_GET_ARG_SIZE(*num_params);
 
 	return mobj_shm_alloc(parg, args_size);

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -5,9 +5,19 @@
 #ifndef IO_H
 #define IO_H
 
+#include <compiler.h>
 #include <stdint.h>
 #include <types_ext.h>
 #include <utee_defines.h>
+
+/*
+ * Make sure that compiler reads given variable only once. This is needed
+ * in cases when we have normal shared memory, and this memory can be changed
+ * at any moment. Compiler does not knows about this, so it can optimize memory
+ * access in any way, including repeated read from the same address. This macro
+ * enforces compiler to access memory only once.
+ */
+#define READ_ONCE(p) __compiler_atomic_load(&(p))
 
 static inline void write8(uint8_t val, vaddr_t addr)
 {


### PR DESCRIPTION

Code that deals with command buffers follows rule "read once, validate, use". Problem is that compiler does not know about this rule, so it can optimize out temporary variables and read data twice from the shared buffer.

We need to explicitly tell it to not do this.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
