### PR TITLE
[RFC] ltc: asn1: der: add support of additional types

### DIFF
--- a/core/lib/libtomcrypt/include/tomcrypt_pk.h
+++ b/core/lib/libtomcrypt/include/tomcrypt_pk.h
@@ -472,6 +472,11 @@ typedef enum ltc_asn1_type_ {
  LTC_ASN1_TELETEX_STRING,
  LTC_ASN1_CONSTRUCTED,
  LTC_ASN1_CONTEXT_SPECIFIC,
+ /* 20 */
+ LTC_ASN1_GENERALIZEDTIME,
+ LTC_ASN1_EXP_TAG,
+ LTC_ASN1_ENUMERATED,
+ LTC_ASN1_LONG_INTEGER,
 } ltc_asn1_type;
 
 /** A LTC ASN.1 list type */
@@ -501,17 +506,20 @@ typedef struct ltc_asn1_list_ {
 /* SEQUENCE */
 int der_encode_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
                            unsigned char *out,  unsigned long *outlen, int type_of);
-                          
+
 #define der_encode_sequence(list, inlen, out, outlen) der_encode_sequence_ex(list, inlen, out, outlen, LTC_ASN1_SEQUENCE)
 
 int der_decode_sequence_ex(const unsigned char *in, unsigned long  inlen,
                            ltc_asn1_list *list,     unsigned long  outlen, int ordered);
-                              
+
 #define der_decode_sequence(in, inlen, list, outlen) der_decode_sequence_ex(in, inlen, list, outlen, 1)
 
 int der_length_sequence(ltc_asn1_list *list, unsigned long inlen,
                         unsigned long *outlen);
 
+/* internal helper functions */
+int der_length_sequence_ex(ltc_asn1_list *list, unsigned long inlen,
+                           unsigned long *outlen, unsigned long *payloadlen);
 /* SUBJECT PUBLIC KEY INFO */
 int der_encode_subject_public_key_info(unsigned char *out, unsigned long *outlen,
         unsigned int algorithm, void* public_key, unsigned long public_key_len,
@@ -529,7 +537,7 @@ int der_encode_set(ltc_asn1_list *list, unsigned long inlen,
 
 int der_encode_setof(ltc_asn1_list *list, unsigned long inlen,
                      unsigned char *out,  unsigned long *outlen);
-                        
+
 /* VA list handy helpers with triplets of <type, size, data> */
 int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...);
 int der_decode_sequence_multi(const unsigned char *in, unsigned long inlen, ...);
@@ -554,6 +562,10 @@ int der_length_integer(void *num, unsigned long *len);
 int der_decode_short_integer(const unsigned char *in, unsigned long inlen, unsigned long *num);
 int der_encode_short_integer(unsigned long num, unsigned char *out, unsigned long *outlen);
 int der_length_short_integer(unsigned long num, unsigned long *outlen);
+
+/* INTEGER -- handy for 0..2^64-1 values */
+int der_encode_long_integer(unsigned long num, unsigned char *out, unsigned long *outlen);
+int der_length_long_integer(unsigned long num, unsigned long *outlen);
 
 /* BIT STRING */
 int der_encode_bit_string(const unsigned char *in, unsigned long inlen,
@@ -642,7 +654,7 @@ typedef struct {
             off_mm; /* timezone offset minutes */
 } ltc_utctime;
 
-int der_encode_utctime(ltc_utctime *utctime, 
+int der_encode_utctime(ltc_utctime *utctime,
                        unsigned char *out,   unsigned long *outlen);
 
 int der_decode_utctime(const unsigned char *in, unsigned long *inlen,
@@ -650,6 +662,41 @@ int der_decode_utctime(const unsigned char *in, unsigned long *inlen,
 
 int der_length_utctime(ltc_utctime *utctime, unsigned long *outlen);
 
+/* GeneralizedTime */
+typedef struct {
+   unsigned YYYY, /* year */
+            MM, /* month */
+            DD, /* day */
+            hh, /* hour */
+            mm, /* minute */
+            ss, /* second */
+            fs, /* fractional seconds */
+            off_dir, /* timezone offset direction 0 == +, 1 == - */
+            off_hh, /* timezone offset hours */
+            off_mm; /* timezone offset minutes */
+} ltc_generalizedtime;
+
+int der_encode_generalizedtime(ltc_generalizedtime *gtime,
+                               unsigned char       *out, unsigned long *outlen);
+
+int der_decode_generalizedtime(const unsigned char *in, unsigned long *inlen,
+                               ltc_generalizedtime *out);
+
+int der_length_generalizedtime(ltc_generalizedtime *gtime, unsigned long *outlen);
+
+/* Explicit TAG */
+typedef struct {
+	unsigned long tag; /* tag value */
+	ltc_asn1_list *list; /* asn1 encoded type */
+} ltc_exp_tag;
+
+
+int der_encode_exp_tag(ltc_exp_tag *tag_st, unsigned char *out, unsigned long *outlen);
+
+int der_length_exp_tag(ltc_exp_tag *tag, unsigned long *outlen, unsigned long *payloadlen);
+
+/* Enumerated */
+int der_encode_enumerated(unsigned long num, unsigned char *out, unsigned long *outlen);
 
 #endif
 

--- a/core/lib/libtomcrypt/src/pk/asn1/der/exp_tag/der_encode_exp_tag.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/exp_tag/der_encode_exp_tag.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2017 GlobalLogic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tomcrypt.h"
+
+/**
+  @file der_encode_exp_tag.c
+  ASN.1 DER, encode a EXPLICIT TAG
+*/
+
+
+#ifdef LTC_DER
+
+/**
+  Store an EXPLICIT TAG
+  @param tag          Explicit tag structure to encode
+  @param out          The destination of the DER encoding of the explicit tag
+  @param outlen       [in/out] The length of the DER encoding
+  @return CRYPT_OK if successful
+*/
+int der_encode_exp_tag(ltc_exp_tag *tag_st, unsigned char *out, unsigned long *outlen)
+{
+   int           err;
+   ltc_asn1_type type;
+   unsigned long size, x, y, z, tag_val;
+   void          *data;
+
+   LTC_ARGCHK(tag_st    != NULL);
+   LTC_ARGCHK(out     != NULL);
+   LTC_ARGCHK(outlen  != NULL);
+
+   /* get size of output that will be required */
+   y = 0; z = 0;
+   if ((err = der_length_exp_tag(tag_st, &y, &z)) != CRYPT_OK) return CRYPT_INVALID_ARG;
+
+   /* too big ? */
+   if (*outlen < y) {
+      *outlen = y;
+      err = CRYPT_BUFFER_OVERFLOW;
+      goto LBL_ERR;
+   }
+
+   /* force to 32 bits */
+   tag_val = tag_st->tag & 0xFFFFFFFFUL;
+
+   /* store header */
+   x = 0;
+   if (tag_val <= 30) {
+	   /* calc low-tag-number form */
+	   out[x++] = 0xA0 ^ tag_val;
+   } else {
+      /* calc high-tag-number form */
+      out[x] = 0xBF;
+      y = 0; /* number of octets for tag */
+      do {
+	     tag_val >>= 7;
+	     ++y;
+      } while (tag_val);
+      tag_val = tag_st->tag;
+      x += y;
+      out[x--] = (tag_val & 0x7F); /* last octet with setting 8 bit to 0 */
+      while (x > 0) {
+         tag_val >>= 7;
+         out[x--] = 0x80 ^ (tag_val & 0x7F); /* set 8 bit to 1 and 7-bit mask */
+      }
+      x += y + 1;
+   }
+
+   if (z < 128) {
+      out[x++] = (unsigned char)z;
+   } else if (z < 256) {
+      out[x++] = 0x81;
+      out[x++] = (unsigned char)z;
+   } else if (z < 65536UL) {
+      out[x++] = 0x82;
+      out[x++] = (unsigned char)((z>>8UL)&255);
+      out[x++] = (unsigned char)(z&255);
+   } else if (z < 16777216UL) {
+      out[x++] = 0x83;
+      out[x++] = (unsigned char)((z>>16UL)&255);
+      out[x++] = (unsigned char)((z>>8UL)&255);
+      out[x++] = (unsigned char)(z&255);
+   }
+
+   /* store data */
+   *outlen -= x;
+   type = tag_st->list->type;
+   size = tag_st->list->size;
+   data = tag_st->list->data;
+
+   switch (type) {
+      case LTC_ASN1_BOOLEAN:
+         z = *outlen;
+         if ((err = der_encode_boolean(*((int *)data), out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_INTEGER:
+         z = *outlen;
+         if ((err = der_encode_integer(data, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_SHORT_INTEGER:
+         z = *outlen;
+         if ((err = der_encode_short_integer(*((unsigned long*)data), out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_LONG_INTEGER:
+         z = *outlen;
+         if ((err = der_encode_long_integer(*((unsigned long*)data), out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_BIT_STRING:
+         z = *outlen;
+         if ((err = der_encode_bit_string(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_RAW_BIT_STRING:
+         z = *outlen;
+         if ((err = der_encode_raw_bit_string(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_OCTET_STRING:
+         z = *outlen;
+         if ((err = der_encode_octet_string(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_NULL:
+         out[x] = 0x05;
+         out[x+1] = 0x00;
+         z = 2;
+         break;
+
+      case LTC_ASN1_OBJECT_IDENTIFIER:
+         z = *outlen;
+         if ((err = der_encode_object_identifier(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_IA5_STRING:
+         z = *outlen;
+         if ((err = der_encode_ia5_string(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_PRINTABLE_STRING:
+         z = *outlen;
+         if ((err = der_encode_printable_string(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_UTF8_STRING:
+         z = *outlen;
+         if ((err = der_encode_utf8_string(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_UTCTIME:
+         z = *outlen;
+         if ((err = der_encode_utctime(data, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_GENERALIZEDTIME:
+         z = *outlen;
+         if ((err = der_encode_generalizedtime(data, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_SET:
+         z = *outlen;
+         if ((err = der_encode_set(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_SETOF:
+         z = *outlen;
+         if ((err = der_encode_setof(data, size, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_SEQUENCE:
+         z = *outlen;
+         if ((err = der_encode_sequence_ex(data, size, out + x, &z, type)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_EXP_TAG:
+         z = *outlen;
+         if ((err = der_encode_exp_tag(data, out + x, &z)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         break;
+
+      case LTC_ASN1_CHOICE:
+      case LTC_ASN1_CONSTRUCTED:
+      case LTC_ASN1_CONTEXT_SPECIFIC:
+      case LTC_ASN1_EOL:
+      case LTC_ASN1_TELETEX_STRING:
+      default:
+         err = CRYPT_INVALID_ARG;
+         goto LBL_ERR;
+   }
+
+   x       += z;
+   *outlen -= z;
+   *outlen = x;
+   err = CRYPT_OK;
+
+LBL_ERR:
+   return err;
+}
+
+#endif
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/exp_tag/der_length_exp_tag.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/exp_tag/der_length_exp_tag.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2017 GlobalLogic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tomcrypt.h"
+
+/**
+  @file der_length_exp_tag.c
+  ASN.1 DER, get length of explicit tag
+*/
+
+#ifdef LTC_DER
+
+/**
+   Get the length of a DER explicit tag
+   @param tag    The structure, which contain tag value and type for tagging.
+   @param outlen [out] The length required in octets to store it
+   @return CRYPT_OK on success
+*/
+int der_length_exp_tag(ltc_exp_tag *tag, unsigned long *outlen, unsigned long *payloadlen)
+{
+   int           err;
+   ltc_asn1_type type;
+   unsigned long size, x, y, z, tag_val;
+   void          *data;
+
+   LTC_ARGCHK(tag    != NULL);
+   LTC_ARGCHK(outlen  != NULL);
+
+   /* get size of output that will be required */
+   y = 0;
+
+   /* force to 32 bits */
+   tag_val = tag->tag & 0xFFFFFFFFUL;
+   type = tag->list->type;
+   size = tag->list->size;
+   data = tag->list->data;
+
+   switch (type) {
+      case LTC_ASN1_BOOLEAN:
+         if ((err = der_length_boolean(&x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_INTEGER:
+         if ((err = der_length_integer(data, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_SHORT_INTEGER:
+         if ((err = der_length_short_integer(*((unsigned long *)data), &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_LONG_INTEGER:
+         if ((err = der_length_long_integer(*((unsigned long *)data), &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_BIT_STRING:
+      case LTC_ASN1_RAW_BIT_STRING:
+         if ((err = der_length_bit_string(size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_OCTET_STRING:
+         if ((err = der_length_octet_string(size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_NULL:
+         y += 2;
+         break;
+
+      case LTC_ASN1_OBJECT_IDENTIFIER:
+         if ((err = der_length_object_identifier(data, size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_IA5_STRING:
+         if ((err = der_length_ia5_string(data, size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_TELETEX_STRING:
+         if ((err = der_length_teletex_string(data, size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_PRINTABLE_STRING:
+         if ((err = der_length_printable_string(data, size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_UTCTIME:
+         if ((err = der_length_utctime(data, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_GENERALIZEDTIME:
+         if ((err = der_length_generalizedtime(data, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_UTF8_STRING:
+         if ((err = der_length_utf8_string(data, size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_SET:
+      case LTC_ASN1_SETOF:
+      case LTC_ASN1_SEQUENCE:
+         if ((err = der_length_sequence(data, size, &x)) != CRYPT_OK) {
+            goto LBL_ERR;
+         }
+         y += x;
+         break;
+
+      case LTC_ASN1_EXP_TAG:
+          if ((err = der_length_exp_tag(data, &x, NULL)) != CRYPT_OK) {
+             goto LBL_ERR;
+          }
+          y += x;
+          break;
+
+      case LTC_ASN1_CHOICE:
+      case LTC_ASN1_CONSTRUCTED:
+      case LTC_ASN1_CONTEXT_SPECIFIC:
+      case LTC_ASN1_EOL:
+      default:
+         err = CRYPT_INVALID_ARG;
+         goto LBL_ERR;
+   }
+
+   /* calc header size */
+   z = y;
+   if (y < 128) {
+      y += 2;
+   } else if (y < 256) {
+      /* 0x30 0x81 LL */
+      y += 3;
+   } else if (y < 65536UL) {
+      /* 0x30 0x82 LL LL */
+      y += 4;
+   } else if (y < 16777216UL) {
+      /* 0x30 0x83 LL LL LL */
+      y += 5;
+   } else {
+      err = CRYPT_INVALID_ARG;
+      goto LBL_ERR;
+   }
+
+   /* calc high-tag-number form */
+   if (tag_val > 30) {
+      do {
+         tag_val >>= 7;
+         y++;
+	   } while (tag_val);
+   }
+
+   /* store size */
+   if (payloadlen) *payloadlen = z;
+   *outlen = y;
+   err     = CRYPT_OK;
+
+LBL_ERR:
+   return err;
+}
+
+#endif
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/exp_tag/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/exp_tag/sub.mk
@@ -1,0 +1,2 @@
+srcs-y += der_encode_exp_tag.c
+srcs-y += der_length_exp_tag.c

--- a/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/der_decode_generalizedtime.c
@@ -1,0 +1,144 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+#include "tomcrypt.h"
+
+/**
+  @file der_decode_generalizedtime.c
+  ASN.1 DER, decode a GeneralizedTime, Steffen Jaeckel
+  Based on der_decode_utctime.c
+*/
+
+#ifdef LTC_DER
+
+static int _char_to_int(unsigned char x)
+{
+   switch (x)  {
+      case '0': return 0;
+      case '1': return 1;
+      case '2': return 2;
+      case '3': return 3;
+      case '4': return 4;
+      case '5': return 5;
+      case '6': return 6;
+      case '7': return 7;
+      case '8': return 8;
+      case '9': return 9;
+      default:  return 100;
+   }
+}
+
+#define DECODE_V(y, max) do {\
+   y  = _char_to_int(buf[x])*10 + _char_to_int(buf[x+1]); \
+   if (y >= max) return CRYPT_INVALID_PACKET;           \
+   x += 2; \
+} while(0)
+
+#define DECODE_V4(y, max) do {\
+   y  = _char_to_int(buf[x])*1000 + _char_to_int(buf[x+1])*100 + _char_to_int(buf[x+2])*10 + _char_to_int(buf[x+3]); \
+   if (y >= max) return CRYPT_INVALID_PACKET; \
+   x += 4; \
+} while(0)
+
+/**
+  Decodes a Generalized time structure in DER format (reads all 6 valid encoding formats)
+  @param in     Input buffer
+  @param inlen  Length of input buffer in octets
+  @param out    [out] Destination of Generalized time structure
+  @return CRYPT_OK   if successful
+*/
+int der_decode_generalizedtime(const unsigned char *in, unsigned long *inlen,
+                               ltc_generalizedtime *out)
+{
+   unsigned char buf[32];
+   unsigned long x;
+   int           y;
+
+   LTC_ARGCHK(in    != NULL);
+   LTC_ARGCHK(inlen != NULL);
+   LTC_ARGCHK(out   != NULL);
+
+   /* check header */
+   if (*inlen < 2UL || (in[1] >= sizeof(buf)) || ((in[1] + 2UL) > *inlen)) {
+      return CRYPT_INVALID_PACKET;
+   }
+
+   /* decode the string */
+   for (x = 0; x < in[1]; x++) {
+       y = der_ia5_value_decode(in[x+2]);
+       if (y == -1) {
+          return CRYPT_INVALID_PACKET;
+       }
+       if (!((y >= '0' && y <= '9')
+            || y == 'Z' || y == '.'
+            || y == '+' || y == '-')) {
+          return CRYPT_INVALID_PACKET;
+       }
+       buf[x] = y;
+   }
+   *inlen = 2 + x;
+
+   if (x < 15) {
+      return CRYPT_INVALID_PACKET;
+   }
+
+   /* possible encodings are
+YYYYMMDDhhmmssZ
+YYYYMMDDhhmmss+hh'mm'
+YYYYMMDDhhmmss-hh'mm'
+YYYYMMDDhhmmss.fsZ
+YYYYMMDDhhmmss.fs+hh'mm'
+YYYYMMDDhhmmss.fs-hh'mm'
+
+    So let's do a trivial decode upto [including] ss
+   */
+
+    x = 0;
+    DECODE_V4(out->YYYY, 10000);
+    DECODE_V(out->MM, 13);
+    DECODE_V(out->DD, 32);
+    DECODE_V(out->hh, 24);
+    DECODE_V(out->mm, 60);
+    DECODE_V(out->ss, 60);
+
+    /* clear fractional seconds info */
+    out->fs = 0;
+
+    /* now is it Z or . */
+    if (buf[x] == 'Z') {
+       return CRYPT_OK;
+    } else if (buf[x] == '.') {
+       x++;
+       while (buf[x] >= '0' && buf[x] <= '9') {
+          unsigned fs = out->fs;
+          if (x >= sizeof(buf)) return CRYPT_INVALID_PACKET;
+          out->fs *= 10;
+          out->fs += _char_to_int(buf[x]);
+          if (fs > out->fs) return CRYPT_BUFFER_OVERFLOW;
+          x++;
+       }
+    }
+
+    /* now is it Z, +, - */
+    if (buf[x] == 'Z') {
+       return CRYPT_OK;
+    } else if (buf[x] == '+' || buf[x] == '-') {
+       out->off_dir = (buf[x++] == '+') ? 0 : 1;
+       DECODE_V(out->off_hh, 24);
+       DECODE_V(out->off_mm, 60);
+       return CRYPT_OK;
+    } else {
+       return CRYPT_INVALID_PACKET;
+    }
+}
+
+#endif
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/der_encode_generalizedtime.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/der_encode_generalizedtime.c
@@ -1,0 +1,108 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+#include "tomcrypt.h"
+
+/**
+  @file der_encode_utctime.c
+  ASN.1 DER, encode a GeneralizedTime, Steffen Jaeckel
+  Based on der_encode_utctime.c
+*/
+
+#ifdef LTC_DER
+
+static const char * const baseten = "0123456789";
+
+#define STORE_V(y) do {\
+    out[x++] = der_ia5_char_encode(baseten[(y/10) % 10]); \
+    out[x++] = der_ia5_char_encode(baseten[y % 10]); \
+} while(0)
+
+#define STORE_V4(y) do {\
+    out[x++] = der_ia5_char_encode(baseten[(y/1000) % 10]); \
+    out[x++] = der_ia5_char_encode(baseten[(y/100) % 10]); \
+    out[x++] = der_ia5_char_encode(baseten[(y/10) % 10]); \
+    out[x++] = der_ia5_char_encode(baseten[y % 10]); \
+} while(0)
+
+/**
+  Encodes a Generalized time structure in DER format
+  @param gtime        The GeneralizedTime structure to encode
+  @param out          The destination of the DER encoding of the GeneralizedTime structure
+  @param outlen       [in/out] The length of the DER encoding
+  @return CRYPT_OK if successful
+*/
+int der_encode_generalizedtime(ltc_generalizedtime *gtime,
+                               unsigned char       *out,   unsigned long *outlen)
+{
+    unsigned long x, tmplen;
+    int           err;
+
+    LTC_ARGCHK(gtime != NULL);
+    LTC_ARGCHK(out     != NULL);
+    LTC_ARGCHK(outlen  != NULL);
+
+    if ((err = der_length_generalizedtime(gtime, &tmplen)) != CRYPT_OK) {
+       return err;
+    }
+    if (tmplen > *outlen) {
+        *outlen = tmplen;
+        return CRYPT_BUFFER_OVERFLOW;
+    }
+
+    /* store header */
+    out[0] = 0x18;
+
+    /* store values */
+    x = 2;
+    STORE_V4(gtime->YYYY);
+    STORE_V(gtime->MM);
+    STORE_V(gtime->DD);
+    STORE_V(gtime->hh);
+    STORE_V(gtime->mm);
+    STORE_V(gtime->ss);
+
+    if (gtime->fs) {
+       unsigned long divisor;
+       unsigned fs = gtime->fs;
+       unsigned len = 0;
+       out[x++] = der_ia5_char_encode('.');
+       divisor = 1;
+       do {
+          fs /= 10;
+          divisor *= 10;
+          len++;
+       } while(fs != 0);
+       while (len-- > 1) {
+          divisor /= 10;
+          out[x++] = der_ia5_char_encode(baseten[(gtime->fs/divisor) % 10]);
+       }
+       out[x++] = der_ia5_char_encode(baseten[gtime->fs % 10]);
+    }
+
+    if (gtime->off_mm || gtime->off_hh) {
+       out[x++] = der_ia5_char_encode(gtime->off_dir ? '-' : '+');
+       STORE_V(gtime->off_hh);
+       STORE_V(gtime->off_mm);
+    } else {
+       out[x++] = der_ia5_char_encode('Z');
+    }
+
+    /* store length */
+    out[1] = (unsigned char)(x - 2);
+
+    /* all good let's return */
+    *outlen = x;
+    return CRYPT_OK;
+}
+
+#endif
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/der_length_generalizedtime.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/der_length_generalizedtime.c
@@ -1,0 +1,58 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ */
+#include "tomcrypt.h"
+
+/**
+  @file der_length_utctime.c
+  ASN.1 DER, get length of GeneralizedTime, Steffen Jaeckel
+  Based on der_length_utctime.c
+*/
+
+#ifdef LTC_DER
+
+/**
+  Gets length of DER encoding of GeneralizedTime
+  @param gtime        The GeneralizedTime structure to get the size of
+  @param outlen [out] The length of the DER encoding
+  @return CRYPT_OK if successful
+*/
+int der_length_generalizedtime(ltc_generalizedtime *gtime, unsigned long *outlen)
+{
+   LTC_ARGCHK(outlen  != NULL);
+   LTC_ARGCHK(gtime != NULL);
+
+   if (gtime->fs == 0) {
+      /* we encode as YYYYMMDDhhmmssZ */
+      *outlen = 2 + 14 + 1;
+   } else {
+      unsigned long len = 2 + 14 + 1;
+      unsigned fs = gtime->fs;
+      do {
+         fs /= 10;
+         len++;
+      } while(fs != 0);
+      if (gtime->off_hh == 0 && gtime->off_mm == 0) {
+         /* we encode as YYYYMMDDhhmmss.fsZ */
+         len += 1;
+      }
+      else {
+         /* we encode as YYYYMMDDhhmmss.fs{+|-}hh'mm' */
+         len += 5;
+      }
+      *outlen = len;
+   }
+
+   return CRYPT_OK;
+}
+
+#endif
+
+/* ref:         $Format:%D$ */
+/* git commit:  $Format:%H$ */
+/* commit time: $Format:%ai$ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/generalizedtime/sub.mk
@@ -1,0 +1,3 @@
+srcs-y += der_decode_generalizedtime.c
+srcs-y += der_encode_generalizedtime.c
+srcs-y += der_length_generalizedtime.c

--- a/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/der_decode_long_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/der_decode_long_integer.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 GlobalLogic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tomcrypt.h"
+
+/**
+  @file der_decode_long_integer.c
+  ASN.1 DER, decode an integer, Tom St Denis
+*/
+
+
+#ifdef LTC_DER
+
+/**
+  Read a long integer
+  @param in       The DER encoded data
+  @param inlen    Size of data
+  @param num      [out] The integer to decode
+  @return CRYPT_OK if successful
+*/
+int der_decode_long_integer(const unsigned char *in, unsigned long inlen, unsigned long *num)
+{
+   unsigned long len, x, y;
+
+   LTC_ARGCHK(num    != NULL);
+   LTC_ARGCHK(in     != NULL);
+
+   /* check length */
+   if (inlen < 2) {
+      return CRYPT_INVALID_PACKET;
+   }
+
+   /* check header */
+   x = 0;
+   if ((in[x++] & 0x1F) != 0x02) {
+      return CRYPT_INVALID_PACKET;
+   }
+
+   /* get the packet len */
+   len = in[x++];
+
+   if (x + len > inlen) {
+      return CRYPT_INVALID_PACKET;
+   }
+
+   /* read number */
+   y = 0;
+   while (len--) {
+      y = (y<<8) | (unsigned long)in[x++];
+   }
+   *num = y;
+
+   return CRYPT_OK;
+
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/der_encode_long_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/der_encode_long_integer.c
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2001-2007, Tom St Denis
  * All rights reserved.
@@ -39,7 +38,7 @@
 #include "tomcrypt.h"
 
 /**
-  @file der_encode_short_integer.c
+  @file der_encode_long_integer.c
   ASN.1 DER, encode an integer, Tom St Denis
 */
 
@@ -47,46 +46,22 @@
 #ifdef LTC_DER
 
 /**
-  Store an enumerated in the range (0,2^32-1)
-  @param num      The enumerated to encode
-  @param out      [out] The destination for the DER encoded enumerated
-  @param outlen   [in/out] The max size and resulting size of the DER encoded enumerated
-  @return CRYPT_OK if successful
-*/
-int der_encode_enumerated(unsigned long num, unsigned char *out, unsigned long *outlen)
-{
-	int err;
-
-	err = der_encode_short_integer(num, out, outlen);
-
-	if (err == CRYPT_OK) {
-		/* change header for enumerated*/
-		out[0] = 0x0A;
-	}
-
-	return err;
-}
-
-/**
-  Store a short integer in the range (0,2^32-1)
+  Store a long integer in the range (0,2^64-1)
   @param num      The integer to encode
   @param out      [out] The destination for the DER encoded integers
   @param outlen   [in/out] The max size and resulting size of the DER encoded integers
   @return CRYPT_OK if successful
 */
-int der_encode_short_integer(unsigned long num, unsigned char *out, unsigned long *outlen)
-{  
+int der_encode_long_integer(unsigned long num, unsigned char *out, unsigned long *outlen)
+{
    unsigned long len, x, y, z;
    int           err;
-   
+
    LTC_ARGCHK(out    != NULL);
    LTC_ARGCHK(outlen != NULL);
 
-   /* force to 32 bits */
-   num &= 0xFFFFFFFFUL;
-
    /* find out how big this will be */
-   if ((err = der_length_short_integer(num, &len)) != CRYPT_OK) {
+   if ((err = der_length_long_integer(num, &len)) != CRYPT_OK) {
       return err;
    }
 
@@ -112,7 +87,7 @@ int der_encode_short_integer(unsigned long num, unsigned char *out, unsigned lon
    z += (num&(1UL<<((z<<3) - 1))) ? 1 : 0;
 
    /* adjust the number so the msB is non-zero */
-   for (x = 0; (z <= 4) && (x < (4 - z)); x++) {
+   for (x = 0; (z <= 8) && (x < (8 - z)); x++) {
       num <<= 8;
    }
 
@@ -122,25 +97,21 @@ int der_encode_short_integer(unsigned long num, unsigned char *out, unsigned lon
    out[x++] = (unsigned char)z;
 
    /* if 31st bit is set output a leading zero and decrement count */
-   if (z == 5) {
+   if (z == 9) {
       out[x++] = 0;
       --z;
    }
 
    /* store values */
    for (y = 0; y < z; y++) {
-      out[x++] = (unsigned char)((num >> 24) & 0xFF);
+      out[x++] = (unsigned char)((num >> 56) & 0xFF);
       num    <<= 8;
    }
 
    /* we good */
    *outlen = x;
- 
+
    return CRYPT_OK;
 }
 
 #endif
-
-/* $Source: /cvs/libtom/libtomcrypt/src/pk/asn1/der/short_integer/der_encode_short_integer.c,v $ */
-/* $Revision: 1.8 $ */
-/* $Date: 2006/12/28 01:27:24 $ */

--- a/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/der_length_long_integer.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/der_length_long_integer.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2017 GlobalLogic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tomcrypt.h"
+
+/**
+  @file der_length_long_integer.c
+  ASN.1 DER, get length of encoding, Tom St Denis
+*/
+
+
+#ifdef LTC_DER
+/**
+  Gets length of DER encoding of long integer num
+  @param num    The long integer to get the size of
+  @param outlen [out] The length of the DER encoding for the given long integer
+  @return CRYPT_OK if successful
+*/
+int der_length_long_integer(unsigned long num, unsigned long *outlen)
+{
+   unsigned long z, y, len;
+
+   LTC_ARGCHK(outlen  != NULL);
+
+   /* get the number of bytes */
+   z = 0;
+   y = num;
+   while (y) {
+     ++z;
+     y >>= 8;
+   }
+
+   /* handle zero */
+   if (z == 0) {
+      z = 1;
+   }
+
+   /* we need a 0x02 to indicate it's INTEGER */
+   len = 1;
+
+   /* length byte */
+   ++len;
+
+   /* bytes in value */
+   len += z;
+
+   /* see if msb is set */
+   len += (num&(1UL<<((z<<3) - 1))) ? 1 : 0;
+
+   /* return length */
+   *outlen = len;
+
+   return CRYPT_OK;
+}
+
+#endif

--- a/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/long_integer/sub.mk
@@ -1,0 +1,2 @@
+srcs-y += der_encode_long_integer.c
+srcs-y += der_length_long_integer.c

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
@@ -96,6 +96,10 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
            case LTC_ASN1_SET:
            case LTC_ASN1_SETOF:
            case LTC_ASN1_RAW_BIT_STRING:
+           case LTC_ASN1_GENERALIZEDTIME:
+           case LTC_ASN1_EXP_TAG:
+           case LTC_ASN1_ENUMERATED:
+           case LTC_ASN1_LONG_INTEGER:
                 ++x;
                 break;
 
@@ -104,8 +108,6 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
            case LTC_ASN1_CONTEXT_SPECIFIC:
            case LTC_ASN1_EOL:
            case LTC_ASN1_TELETEX_STRING:
-               va_end(args);
-               return CRYPT_INVALID_ARG;
            default:
                va_end(args);
                return CRYPT_INVALID_ARG;
@@ -151,6 +153,10 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
            case LTC_ASN1_SET:
            case LTC_ASN1_SETOF:
            case LTC_ASN1_RAW_BIT_STRING:
+           case LTC_ASN1_GENERALIZEDTIME:
+           case LTC_ASN1_EXP_TAG:
+           case LTC_ASN1_ENUMERATED:
+           case LTC_ASN1_LONG_INTEGER:
                 LTC_SET_ASN1(list, x++, type, data, size);
                 break;
 
@@ -159,9 +165,6 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
            case LTC_ASN1_CONTEXT_SPECIFIC:
            case LTC_ASN1_EOL:
            case LTC_ASN1_TELETEX_STRING:
-               va_end(args);
-               err = CRYPT_INVALID_ARG;
-               goto LBL_ERR;
            default:
                va_end(args);
                err = CRYPT_INVALID_ARG;

--- a/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_set.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/set/der_encode_set.c
@@ -62,11 +62,14 @@ static int ltc_to_asn1(ltc_asn1_type v)
       case LTC_ASN1_TELETEX_STRING:          return 0x14;
       case LTC_ASN1_IA5_STRING:              return 0x16;
       case LTC_ASN1_UTCTIME:                 return 0x17;
+      case LTC_ASN1_GENERALIZEDTIME:         return 0x18;
       case LTC_ASN1_SEQUENCE:                return 0x30;
       case LTC_ASN1_SET:
       case LTC_ASN1_SETOF:                   return 0x31;
       case LTC_ASN1_CHOICE:
       case LTC_ASN1_CONSTRUCTED:
+      case LTC_ASN1_EXP_TAG:
+      case LTC_ASN1_ENUMERATED:
       case LTC_ASN1_CONTEXT_SPECIFIC:
       case LTC_ASN1_EOL:                     return -1;
       default:                               return -1;

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sub.mk
@@ -1,8 +1,11 @@
 subdirs-y += bit
 subdirs-y += boolean
 subdirs-y += choice
+subdirs-y += exp_tag
+subdirs-y += generalizedtime
 subdirs-y += ia5
 subdirs-y += integer
+subdirs-y += long_integer
 subdirs-y += object_identifier
 subdirs-y += octet
 subdirs-y += printable_string


### PR DESCRIPTION
1. Add support of LTC_ASN1_GENERALIZEDTIME,
LTC_ASN1_ENUMERATED, LTC_ASN1_LONG_INTEGER types.

2. Add support of explicit tagging:
Explicitly tagged types are derived from other types by adding an
outer tag to the underlying type. In effect, explicitly tagged types
are structured types consisting of one component, the underlying type.
Explicit tagging is denoted by the ASN.1 keywords [class number] EXPLICIT.

Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
