### PR TITLE
Fix copying dirty values in copy_in_params()

### DIFF
--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -113,7 +113,7 @@ static TEE_Result copy_in_params(const struct optee_msg_param *params,
 {
 	TEE_Result res;
 	size_t n;
-	uint8_t pt[TEE_NUM_PARAMS];
+	uint8_t pt[TEE_NUM_PARAMS] = { 0 };
 
 	if (num_params > TEE_NUM_PARAMS)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -131,7 +131,6 @@ static TEE_Result copy_in_params(const struct optee_msg_param *params,
 		switch (attr) {
 		case OPTEE_MSG_ATTR_TYPE_NONE:
 			pt[n] = TEE_PARAM_TYPE_NONE;
-			memset(&ta_param->u[n], 0, sizeof(ta_param->u[n]));
 			break;
 		case OPTEE_MSG_ATTR_TYPE_VALUE_INPUT:
 		case OPTEE_MSG_ATTR_TYPE_VALUE_OUTPUT:


### PR DESCRIPTION
If the OP-TEE driver from the rich OS specifies a message with a number
of params < `TEE_NUM_PARAMS`, `copy_in_params()` will copy in undefined
values from `pt[i]` (where i >= the number of params). This is because the
`pt` array is an uninitialized local value, and per the C99 standard
6.7.8:

> If an object that has automatic storage duration is not initialized
> explicitly, its value is indeterminate.

This change fixes this issue by clearing out the unused parts of pt.

Signed-off-by: Christopher Tam <godtamit@google.com>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
