### PR TITLE
Life cycle of registered shared memory objects

### DIFF
--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -175,6 +175,22 @@ TEE_Result mobj_reg_shm_dec_map(struct mobj *mobj);
  */
 void mobj_reg_shm_unguard(struct mobj *mobj);
 
+/**
+ * mobj_anon_shm_alloc() - anonymous mapping of shared memory
+ * @pages:		array of physical pages of the shared memory
+ * @num_pages:		number of elements in @pages
+ * @page_offset:	shared memory starts at @page_offset at the first
+ *			page of the shared memory.
+ *
+ * Maps a shared memory into OP-TEE va space. It is anonymous in the sense
+ * that it's only identifiable via the returned mobj in comparison with
+ * a registered shared memory which can be found via a cookie.
+ *
+ * Returns valid pointer on success or NULL on failure.
+ */
+struct mobj *mobj_anon_shm_alloc(paddr_t *pages, size_t num_pages,
+				 paddr_t page_offset);
+
 /*
  * mapped_shm represents registered shared buffer
  * which is mapped into OPTEE va space

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -143,6 +143,30 @@ TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);
 TEE_Result mobj_reg_shm_map(struct mobj *mobj);
 TEE_Result mobj_reg_shm_unmap(struct mobj *mobj);
 
+/**
+ * mobj_reg_shm_inc_map() - increase map count
+ * @mobj:	pointer to a registered shared memory MOBJ
+ *
+ * Maps the MOBJ if it isn't mapped already and increaes the map counter
+ * Each call to mobj_reg_shm_inc_map() is supposed to be matches by a call
+ * to mobj_reg_shm_dec_map().
+ *
+ * Returns TEE_SUCCESS on success
+ */
+TEE_Result mobj_reg_shm_inc_map(struct mobj *mobj);
+
+/**
+ * mobj_reg_shm_dec_map() - decrease map count
+ * @mobj:	pointer to a registered shared memory MOBJ
+ *
+ * Decreases the map count and also unmaps the MOBJ if the map count
+ * reached 0.  Each call to mobj_reg_shm_inc_map() is supposed to be
+ * matches by a call to mobj_reg_shm_dec_map().
+ *
+ * Returns TEE_SUCCESS on success
+ */
+TEE_Result mobj_reg_shm_dec_map(struct mobj *mobj);
+
 /*
  * mapped_shm represents registered shared buffer
  * which is mapped into OPTEE va space

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -140,9 +140,6 @@ void mobj_reg_shm_put(struct mobj *mobj);
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);
 
-TEE_Result mobj_reg_shm_map(struct mobj *mobj);
-TEE_Result mobj_reg_shm_unmap(struct mobj *mobj);
-
 /**
  * mobj_reg_shm_inc_map() - increase map count
  * @mobj:	pointer to a registered shared memory MOBJ

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -164,6 +164,17 @@ TEE_Result mobj_reg_shm_inc_map(struct mobj *mobj);
  */
 TEE_Result mobj_reg_shm_dec_map(struct mobj *mobj);
 
+/**
+ * mobj_reg_shm_unguard() - unguards a reg_shm
+ * @mobj:	pointer to a registered shared memory mobj
+ *
+ * A registered shared memory mobj is normally guarded against being
+ * released with mobj_reg_shm_try_release_by_cookie(). After this function
+ * has returned the mobj can be released by a call to
+ * mobj_reg_shm_try_release_by_cookie() if the reference counter allows it.
+ */
+void mobj_reg_shm_unguard(struct mobj *mobj);
+
 /*
  * mapped_shm represents registered shared buffer
  * which is mapped into OPTEE va space

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -117,8 +117,6 @@ struct mobj *mobj_phys_alloc(paddr_t pa, size_t size, uint32_t cattr,
 struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 				paddr_t page_offset, uint64_t cookie);
 
-void mobj_reg_shm_free_by_cookie(uint64_t cookie);
-
 /**
  * mobj_reg_shm_get_by_cookie() - get a MOBJ based on cookie
  * @cookie:	Cookie used by normal world when suppling the shared memory
@@ -139,7 +137,6 @@ struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie);
  * reaches 0.
  */
 void mobj_reg_shm_put(struct mobj *mobj);
-void mobj_reg_shm_put_by_cookie(uint64_t cookie);
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);
 

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -119,7 +119,26 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 
 void mobj_reg_shm_free_by_cookie(uint64_t cookie);
 
+/**
+ * mobj_reg_shm_get_by_cookie() - get a MOBJ based on cookie
+ * @cookie:	Cookie used by normal world when suppling the shared memory
+ *
+ * Searches for a registered shared memory MOBJ and if one with a matching
+ * @cookie is found it's reference counter is increased before returning
+ * the MOBJ.
+ *
+ * Returns a valid pointer on success or NULL on failure.
+ */
 struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie);
+
+/**
+ * mobj_reg_shm_put() - put a MOBJ
+ * @mobj:	Pointer to a registered shared memory MOBJ
+ *
+ * Decreases reference counter of the @mobj and frees it if the counter
+ * reaches 0.
+ */
+void mobj_reg_shm_put(struct mobj *mobj);
 void mobj_reg_shm_put_by_cookie(uint64_t cookie);
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -300,20 +300,137 @@ struct mobj *mobj_mm_alloc(struct mobj *mobj_parent, size_t size,
 }
 
 /*
+ * dyn_shm - helpers to handle physically noncontiguos shared memory
+ * provided by normal world.
+ */
+
+struct dyn_shm {
+	tee_mm_entry_t *mm;
+	unsigned int page_offset;
+	unsigned int num_pages;
+	/*
+	 * At the end of the struct embedding this struct there should be a
+	 * paddr_t pages[];
+	 * with room for num_pages entries.
+	 */
+};
+
+static TEE_Result dyn_shm_get_pa(struct dyn_shm *d, paddr_t *pages,
+				 size_t offst, size_t granule, paddr_t *pa)
+{
+	if (!pa)
+		return TEE_ERROR_GENERIC;
+
+	size_t full_offset = offst + d->page_offset;
+
+	if (full_offset >= d->num_pages * SMALL_PAGE_SIZE)
+		return TEE_ERROR_GENERIC;
+
+	switch (granule) {
+	case 0:
+		*pa = pages[full_offset / SMALL_PAGE_SIZE] +
+		    (full_offset & SMALL_PAGE_MASK);
+		return TEE_SUCCESS;
+	case SMALL_PAGE_SIZE:
+		*pa = pages[full_offset / SMALL_PAGE_SIZE];
+		return TEE_SUCCESS;
+	default:
+		return TEE_ERROR_GENERIC;
+
+	}
+}
+
+static size_t dyn_shm_get_phys_offs(struct dyn_shm *d,
+				    struct mobj *mobj __maybe_unused,
+				    size_t granule)
+{
+	assert(granule >= mobj->phys_granule);
+	return d->page_offset;
+}
+
+static void *dyn_shm_get_va(struct dyn_shm *d, size_t offst)
+{
+	if (!d->mm)
+		return NULL;
+
+	return (void *)(vaddr_t)(tee_mm_get_smem(d->mm) + offst +
+				 d->page_offset);
+}
+
+static void dyn_shm_unmap(struct dyn_shm *d)
+{
+	if (d->mm) {
+		core_mmu_unmap_pages(tee_mm_get_smem(d->mm), d->num_pages);
+		tee_mm_free(d->mm);
+		d->mm = NULL;
+	}
+}
+
+static TEE_Result dyn_shm_map(struct dyn_shm *d, paddr_t *pages)
+{
+	assert(!d->mm);
+	d->mm = tee_mm_alloc(&tee_mm_shm, SMALL_PAGE_SIZE * d->num_pages);
+	if (!d->mm)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	TEE_Result res = core_mmu_map_pages(tee_mm_get_smem(d->mm), pages,
+					    d->num_pages, MEM_AREA_NSEC_SHM);
+	if (res) {
+		tee_mm_free(d->mm);
+		d->mm = NULL;
+	}
+
+	return res;
+}
+
+static TEE_Result dyn_shm_get_cattr(uint32_t *cattr)
+{
+	if (!cattr)
+		return TEE_ERROR_GENERIC;
+
+	*cattr = TEE_MATTR_CACHE_CACHED;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result dyn_shm_init(struct dyn_shm *d, paddr_t *pages,
+			       struct mobj *mobj, const struct mobj_ops *ops,
+			       const paddr_t *in_pages, size_t num_pages,
+			       paddr_t page_offset)
+{
+	mobj->ops = ops;
+	mobj->size =  num_pages * SMALL_PAGE_SIZE;
+	mobj->phys_granule = SMALL_PAGE_SIZE;
+	d->num_pages = num_pages;
+	d->page_offset = page_offset;
+	memcpy(pages, in_pages, sizeof(*pages) * num_pages);
+
+	/* Ensure loaded references match format and security constraints */
+	for (size_t n = 0; n < num_pages; n++) {
+		if (pages[n] & SMALL_PAGE_MASK)
+			return false;
+
+		/* Only Non-secure memory can be mapped there */
+		if (!core_pbuf_is(CORE_MEM_NON_SEC, pages[n], SMALL_PAGE_SIZE))
+			return false;
+	}
+
+	return true;
+}
+
+/*
  * mobj_reg_shm implementation. Describes shared memory provided by normal world
  */
 
 struct mobj_reg_shm {
 	struct mobj mobj;
-	SLIST_ENTRY(mobj_reg_shm) next;
+	SLIST_ENTRY(mobj_reg_shm) link;
 	uint64_t cookie;
-	tee_mm_entry_t *mm;
-	paddr_t page_offset;
+	bool guarded;
 	struct refcount refcount;
 	struct refcount mapcount;
-	int num_pages;
-	bool guarded;
-	paddr_t pages[];
+	struct dyn_shm dyn_shm;
+	paddr_t dyn_shm_pages[];
 };
 
 #define MOBJ_REG_SHM_SIZE(nr_pages) \
@@ -325,77 +442,44 @@ static SLIST_HEAD(reg_shm_head, mobj_reg_shm) reg_shm_list =
 static unsigned int reg_shm_slist_lock = SPINLOCK_UNLOCK;
 static unsigned int reg_shm_map_lock = SPINLOCK_UNLOCK;
 
-static struct mobj_reg_shm *to_mobj_reg_shm(struct mobj *mobj);
+/* Forward declaration, another declaration with initialization follows below */
+static const struct mobj_ops mobj_reg_shm_ops;
+
+static struct mobj_reg_shm *to_mobj_reg_shm_may_fail(struct mobj *mobj)
+{
+	if (mobj->ops != &mobj_reg_shm_ops)
+		return NULL;
+
+	return container_of(mobj, struct mobj_reg_shm, mobj);
+}
+
+static struct mobj_reg_shm *to_mobj_reg_shm(struct mobj *mobj)
+{
+	struct mobj_reg_shm *r = to_mobj_reg_shm_may_fail(mobj);
+
+	assert(r);
+	return r;
+}
 
 static TEE_Result mobj_reg_shm_get_pa(struct mobj *mobj, size_t offst,
 				      size_t granule, paddr_t *pa)
 {
-	struct mobj_reg_shm *mobj_reg_shm = to_mobj_reg_shm(mobj);
-	size_t full_offset;
-	paddr_t p;
+	struct mobj_reg_shm *r = to_mobj_reg_shm(mobj);
 
-	if (!pa)
-		return TEE_ERROR_GENERIC;
-
-	full_offset = offst + mobj_reg_shm->page_offset;
-	if (full_offset >= mobj->size)
-		return TEE_ERROR_GENERIC;
-
-	switch (granule) {
-	case 0:
-		p = mobj_reg_shm->pages[full_offset / SMALL_PAGE_SIZE] +
-			(full_offset & SMALL_PAGE_MASK);
-		break;
-	case SMALL_PAGE_SIZE:
-		p = mobj_reg_shm->pages[full_offset / SMALL_PAGE_SIZE];
-		break;
-	default:
-		return TEE_ERROR_GENERIC;
-
-	}
-	*pa = p;
-
-	return TEE_SUCCESS;
+	return dyn_shm_get_pa(&r->dyn_shm, r->dyn_shm_pages, offst, granule,
+			      pa);
 }
 KEEP_PAGER(mobj_reg_shm_get_pa);
 
-static size_t mobj_reg_shm_get_phys_offs(struct mobj *mobj,
-					 size_t granule __maybe_unused)
+static size_t mobj_reg_shm_get_phys_offs(struct mobj *mobj, size_t granule)
 {
-	assert(granule >= mobj->phys_granule);
-	return to_mobj_reg_shm(mobj)->page_offset;
+	return dyn_shm_get_phys_offs(&to_mobj_reg_shm(mobj)->dyn_shm,
+				     mobj, granule);
 }
 
 static void *mobj_reg_shm_get_va(struct mobj *mobj, size_t offst)
 {
-	struct mobj_reg_shm *mrs = to_mobj_reg_shm(mobj);
-
-	if (!mrs->mm)
-		return NULL;
-
-	return (void *)(vaddr_t)(tee_mm_get_smem(mrs->mm) + offst +
-				 mrs->page_offset);
-}
-
-static void reg_shm_unmap_helper(struct mobj_reg_shm *r)
-{
-	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_map_lock);
-
-	if (r->mm) {
-		core_mmu_unmap_pages(tee_mm_get_smem(r->mm),
-				     r->mobj.size / SMALL_PAGE_SIZE);
-		tee_mm_free(r->mm);
-		r->mm = NULL;
-	}
-
-	cpu_spin_unlock_xrestore(&reg_shm_map_lock, exceptions);
-}
-
-static void reg_shm_free_helper(struct mobj_reg_shm *mobj_reg_shm)
-{
-	reg_shm_unmap_helper(mobj_reg_shm);
-	SLIST_REMOVE(&reg_shm_list, mobj_reg_shm, mobj_reg_shm, next);
-	free(mobj_reg_shm);
+	return dyn_shm_get_va(&to_mobj_reg_shm(mobj)->dyn_shm, offst);
 }
 
 static void mobj_reg_shm_free(struct mobj *mobj)
@@ -403,18 +487,20 @@ static void mobj_reg_shm_free(struct mobj *mobj)
 	mobj_reg_shm_put(mobj);
 }
 
-static TEE_Result mobj_reg_shm_get_cattr(struct mobj *mobj __unused,
-					 uint32_t *cattr)
+static TEE_Result mobj_reg_shm_get_cattr(struct mobj *mobj, uint32_t *cattr)
 {
-	if (!cattr)
-		return TEE_ERROR_GENERIC;
+	assert(mobj->ops == &mobj_reg_shm_ops);
 
-	*cattr = TEE_MATTR_CACHE_CACHED;
-
-	return TEE_SUCCESS;
+	return dyn_shm_get_cattr(cattr);
 }
 
-static bool mobj_reg_shm_matches(struct mobj *mobj, enum buf_is_attr attr);
+static bool mobj_reg_shm_matches(struct mobj *mobj __maybe_unused,
+				   enum buf_is_attr attr)
+{
+	assert(mobj->ops == &mobj_reg_shm_ops);
+
+	return attr == CORE_MEM_NON_SEC || attr == CORE_MEM_REG_SHM;
+}
 
 static const struct mobj_ops mobj_reg_shm_ops __rodata_unpaged = {
 	.get_pa = mobj_reg_shm_get_pa,
@@ -425,77 +511,38 @@ static const struct mobj_ops mobj_reg_shm_ops __rodata_unpaged = {
 	.free = mobj_reg_shm_free,
 };
 
-static bool mobj_reg_shm_matches(struct mobj *mobj __maybe_unused,
-				   enum buf_is_attr attr)
-{
-	assert(mobj->ops == &mobj_reg_shm_ops);
-
-	return attr == CORE_MEM_NON_SEC || attr == CORE_MEM_REG_SHM;
-}
-
-static struct mobj_reg_shm *to_mobj_reg_shm(struct mobj *mobj)
-{
-	assert(mobj->ops == &mobj_reg_shm_ops);
-	return container_of(mobj, struct mobj_reg_shm, mobj);
-}
-
-static struct mobj_reg_shm *to_mobj_reg_shm_may_fail(struct mobj *mobj)
-{
-	if (mobj->ops != &mobj_reg_shm_ops)
-		return NULL;
-
-	return container_of(mobj, struct mobj_reg_shm, mobj);
-}
-
 struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 				paddr_t page_offset, uint64_t cookie)
 {
-	struct mobj_reg_shm *mobj_reg_shm;
-	size_t i;
-	uint32_t exceptions;
-
 	if (!num_pages)
 		return NULL;
 
-	mobj_reg_shm = calloc(1, MOBJ_REG_SHM_SIZE(num_pages));
-	if (!mobj_reg_shm)
+	struct mobj_reg_shm *r = calloc(1, MOBJ_REG_SHM_SIZE(num_pages));
+
+	if (!r)
 		return NULL;
 
-	mobj_reg_shm->mobj.ops = &mobj_reg_shm_ops;
-	mobj_reg_shm->mobj.size =  num_pages * SMALL_PAGE_SIZE;
-	mobj_reg_shm->mobj.phys_granule = SMALL_PAGE_SIZE;
-	mobj_reg_shm->cookie = cookie;
-	mobj_reg_shm->guarded = true;
-	mobj_reg_shm->num_pages = num_pages;
-	mobj_reg_shm->page_offset = page_offset;
-	memcpy(mobj_reg_shm->pages, pages, sizeof(*pages) * num_pages);
-	refcount_set(&mobj_reg_shm->refcount, 1);
-
-	/* Insure loaded references match format and security constraints */
-	for (i = 0; i < num_pages; i++) {
-		if (mobj_reg_shm->pages[i] & SMALL_PAGE_MASK)
-			goto err;
-
-		/* Only Non-secure memory can be mapped there */
-		if (!core_pbuf_is(CORE_MEM_NON_SEC, mobj_reg_shm->pages[i],
-					SMALL_PAGE_SIZE))
-			goto err;
+	if (!dyn_shm_init(&r->dyn_shm, r->dyn_shm_pages, &r->mobj,
+			  &mobj_reg_shm_ops, pages, num_pages, page_offset)) {
+		free(r);
+		return NULL;
 	}
+	r->cookie = cookie;
+	r->guarded = true;
+	refcount_set(&r->refcount, 1);
 
-	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
-	SLIST_INSERT_HEAD(&reg_shm_list, mobj_reg_shm, next);
+	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+
+	SLIST_INSERT_HEAD(&reg_shm_list, r, link);
 	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
 
-	return &mobj_reg_shm->mobj;
-err:
-	free(mobj_reg_shm);
-	return NULL;
+	return &r->mobj;
 }
 
 void mobj_reg_shm_unguard(struct mobj *mobj)
 {
 	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
-	return NULL;
+
 	to_mobj_reg_shm(mobj)->guarded = false;
 	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
 }
@@ -504,7 +551,7 @@ static struct mobj_reg_shm *reg_shm_find_unlocked(uint64_t cookie)
 {
 	struct mobj_reg_shm *mobj_reg_shm;
 
-	SLIST_FOREACH(mobj_reg_shm, &reg_shm_list, next)
+	SLIST_FOREACH(mobj_reg_shm, &reg_shm_list, link)
 		if (mobj_reg_shm->cookie == cookie)
 			return mobj_reg_shm;
 
@@ -543,8 +590,11 @@ void mobj_reg_shm_put(struct mobj *mobj)
 	 * we're at zero there's no more user and the original allocator is
 	 * done too.
 	 */
-	if (refcount_dec(&r->refcount))
-		reg_shm_free_helper(r);
+	if (refcount_dec(&r->refcount)) {
+		dyn_shm_unmap(&r->dyn_shm);
+		SLIST_REMOVE(&reg_shm_list, r, mobj_reg_shm, link);
+		free(r);
+	}
 
 	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
 
@@ -572,7 +622,9 @@ static TEE_Result try_release_reg_shm(uint64_t cookie)
 
 	res = TEE_ERROR_BUSY;
 	if (refcount_val(&r->refcount) == 1) {
-		reg_shm_free_helper(r);
+		dyn_shm_unmap(&r->dyn_shm);
+		SLIST_REMOVE(&reg_shm_list, r, mobj_reg_shm, link);
+		free(r);
 		res = TEE_SUCCESS;
 	}
 out:
@@ -622,19 +674,9 @@ TEE_Result mobj_reg_shm_inc_map(struct mobj *mobj)
 	if (refcount_val(&r->mapcount))
 		goto out;
 
-	r->mm = tee_mm_alloc(&tee_mm_shm, SMALL_PAGE_SIZE * r->num_pages);
-	if (!r->mm) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
+	res = dyn_shm_map(&r->dyn_shm, r->dyn_shm_pages);
+	if (res)
 		goto out;
-	}
-
-	res = core_mmu_map_pages(tee_mm_get_smem(r->mm), r->pages,
-				 r->num_pages, MEM_AREA_NSEC_SHM);
-	if (res) {
-		tee_mm_free(r->mm);
-		r->mm = NULL;
-		goto out;
-	}
 
 	refcount_set(&r->mapcount, 1);
 out:
@@ -655,12 +697,8 @@ TEE_Result mobj_reg_shm_dec_map(struct mobj *mobj)
 
 	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_map_lock);
 
-	if (refcount_val(&r->mapcount)) {
-		core_mmu_unmap_pages(tee_mm_get_smem(r->mm),
-				     r->mobj.size / SMALL_PAGE_SIZE);
-		tee_mm_free(r->mm);
-		r->mm = NULL;
-	}
+	if (!refcount_val(&r->mapcount))
+		dyn_shm_unmap(&r->dyn_shm);
 
 	cpu_spin_unlock_xrestore(&reg_shm_map_lock, exceptions);
 

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -464,8 +464,8 @@ static struct mobj *map_cmd_buffer(paddr_t parg, uint32_t *num_params)
 	size_t args_size;
 
 	assert(!(parg & SMALL_PAGE_MASK));
-	/* mobj_mapped_shm_alloc checks if parg resides in nonsec ddr */
-	mobj = mobj_mapped_shm_alloc(&parg, 1, 0, 0);
+	/* mobj_anon_shm_alloc() checks if parg resides in nonsec ddr */
+	mobj = mobj_anon_shm_alloc(&parg, 1, 0);
 	if (!mobj)
 		return NULL;
 

--- a/core/kernel/msg_param.c
+++ b/core/kernel/msg_param.c
@@ -72,9 +72,9 @@ static bool msg_param_extract_pages(paddr_t buffer, paddr_t *pages,
 
 	/*
 	 * There we map first page of array.
-	 * mobj_mapped_shm_alloc() will check if page resides in nonsec ddr
+	 * mobj_anon_shm_alloc() will check if page resides in nonsec ddr
 	 */
-	mobj = mobj_mapped_shm_alloc(&buffer, 1, 0, 0);
+	mobj = mobj_anon_shm_alloc(&buffer, 1, 0);
 	if (!mobj)
 		return false;
 
@@ -93,7 +93,7 @@ static bool msg_param_extract_pages(paddr_t buffer, paddr_t *pages,
 				goto out;
 
 			mobj_free(mobj);
-			mobj = mobj_mapped_shm_alloc(&page, 1, 0, 0);
+			mobj = mobj_anon_shm_alloc(&page, 1, 0);
 			if (!mobj)
 				goto out;
 

--- a/core/lib/libtomcrypt/src/sub.mk
+++ b/core/lib/libtomcrypt/src/sub.mk
@@ -2,7 +2,6 @@ ifdef _CFG_CRYPTO_WITH_ACIPHER
 srcs-y += mpa_desc.c
 # Get mpa.h which normally is an internal .h file
 cppflags-mpa_desc.c-y += -Ilib/libmpa
-cflags-mpa_desc.c-y += -Wno-declaration-after-statement
 cflags-mpa_desc.c-y += -Wno-unused-parameter
 endif
 

--- a/lib/libmpa/sub.mk
+++ b/lib/libmpa/sub.mk
@@ -9,7 +9,6 @@ cflags-remove-mpa_misc.c-y += -pedantic
 cflags-mpa_misc.c-y += -Wno-sign-compare
 
 srcs-y += mpa_montgomery.c
-cflags-remove-mpa_montgomery.c-y += -Wdeclaration-after-statement
 
 srcs-y += mpa_primetest.c
 cflags-remove-mpa_primetest.c-y += -pedantic

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -40,8 +40,7 @@ comp-cflags-warns-medium = \
 	-Waggregate-return -Wredundant-decls
 comp-cflags-warns-low = \
 	-Wold-style-definition -Wstrict-aliasing=2 \
-	-Wundef -pedantic \
-	-Wdeclaration-after-statement
+	-Wundef -pedantic
 
 comp-cflags-warns-1:= $(comp-cflags-warns-high)
 comp-cflags-warns-2:= $(comp-cflags-warns-1) $(comp-cflags-warns-medium)


### PR DESCRIPTION
This pull request relates to the life cycle of registered shared memory objects and fixes the problem of normal world trying to unregister shared memory objects which are in use.

The last four patches:
0620dec360ee core: msg_param: use mobj_anon_shm_alloc()
c230e5d3d522 core: entry_std: use mobj_anon_shm_alloc()
e0c32a0858f8 core: add mobj_anon_shm_alloc()
5a0c1a3130a0 core: refactor mobj_reg_shm
with the diffstat:
 core/arch/arm/include/mm/mobj.h |  16 ++
 core/arch/arm/mm/mobj.c         | 414 ++++++++++++++++++++++++++--------------
 core/arch/arm/tee/entry_std.c   |   4 +-
 core/kernel/msg_param.c         |   6 +-
 4 files changed, 296 insertions(+), 144 deletions(-)

are more an optimization than a fix and could be skipped at this stage if desired.

Also note the commit
84b6c3e436ca Allow mixed declaration and code
which does as you can guess from the description. It was agreed some time ago that we should give it a try to address the problem of uninitialized automatic variables.

After that commit I'm mixing declaration and code here and there.