### PR TITLE
ci: travis: delete toolchain binaries after download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
 
   # Run regression tests (xtest in QEMU)
   - export CFG_WERROR=y
-  - (cd ${HOME}/optee_repo/build && $make toolchains && $make check BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
+  - (cd ${HOME}/optee_repo/build && $make toolchains && rm -f ${HOME}/optee_repo/toolchains/gcc-*.tar.xz && $make check BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ git:
   depth: 1000000
 
 before_script:
+  - df -h
   # Store the home repository
   - export MYHOME=$PWD
 
@@ -67,6 +68,8 @@ script:
       travis_terminate 0;
     fi
 
+  - ccache -s
+  - df -h
   # Run checkpatch.pl on:
   # - the tip of the branch if we're not in a pull request
   # - each commit in the development branch that's not in the target branch otherwise
@@ -78,6 +81,8 @@ script:
   # Run regression tests (xtest in QEMU)
   - export CFG_WERROR=y
   - (cd ${HOME}/optee_repo/build && $make aarch32 && rm -f ${HOME}/optee_repo/toolchains/gcc-*.tar.xz && $make check BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
+  - ccache -s
+  - df -h
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
 
   # Run regression tests (xtest in QEMU)
   - export CFG_WERROR=y
-  - (cd ${HOME}/optee_repo/build && $make toolchains && rm -f ${HOME}/optee_repo/toolchains/gcc-*.tar.xz && $make check BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
+  - (cd ${HOME}/optee_repo/build && $make aarch32 && rm -f ${HOME}/optee_repo/toolchains/gcc-*.tar.xz && $make check BR2_CCACHE_DIR=~/.ccache DUMP_LOGS_ON_ERROR=1)
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
   - export PATH=$HOME/bin:$PATH
   - mkdir $HOME/optee_repo
   - (cd $HOME/optee_repo && repo init -u https://github.com/OP-TEE/manifest.git </dev/null && repo sync --no-clone-bundle --no-tags -j 20)
-  - (cd $HOME/optee_repo && mv optee_os optee_os_old && ln -s $MYHOME optee_os)
+  - (cd $HOME/optee_repo && rm -rf optee_os && ln -s $MYHOME optee_os)
   - cd $MYHOME
   - git fetch https://github.com/OP-TEE/optee_os --tags
   - unset CC

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
   # Expect
   - _download http://sourceforge.net/projects/expect/files/Expect/5.45/expect5.45.tar.gz/download expect5.45.tar.gz
   - tar xf $DL_DIR/expect5.45.tar.gz
-  - (cd expect5.45 && ./configure --prefix=$HOME/inst --exec-prefix=$HOME/inst CC="ccache gcc" && make && $make install)
+  - (cd expect5.45 && ./configure --prefix=$HOME/inst --exec-prefix=$HOME/inst CC="ccache gcc" && make && $make install) && rm -rf expect5.45
   # Create a wrapper script, so that expect finds its shared library, without setting LD_LIBRARY_PATH globally (buildroot doesn't like it)
   - mv $HOME/inst/bin/expect $HOME/inst/bin/expect.bin && printf '#!/bin/bash\nexport LD_LIBRARY_PATH=$HOME/inst/lib/expect5.45\n$HOME/inst/bin/expect.bin $*' >$HOME/inst/bin/expect && chmod +x $HOME/inst/bin/expect
   - export PATH=$HOME/inst/bin:$PATH;


### PR DESCRIPTION
Since build.git has been upgraded to GCC 8.2 [1], we are running out of
disk space when running the Travis CI script. This is because the GCC 8.2
binaries are much larger than 6.2:

 218M gcc-arm-8.2-2018.08-x86_64-aarch64-linux-gnu.tar.xz
 213M gcc-arm-8.2-2018.08-x86_64-arm-linux-gnueabihf.tar.xz
  94M gcc-linaro-6.2.1-2016.11-x86_64_aarch64-linux-gnu.tar.xz
  88M gcc-linaro-6.2.1-2016.11-x86_64_arm-linux-gnueabihf.tar.xz

This commit makes some room by deleting the packages once they have been
extracted.

Link: [1] https://github.com/OP-TEE/build/commit/53119b77e9f2
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
