### PR TITLE
Allow mixed declaration and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ the code also follows GlobalPlatform standards. The exceptions are as follows:
 	deviate too much from upstream and therefore it would be hard to rebase
 	against those projects later on and we don't expect that it is easy to
 	convince other software projects to change coding style.
+	Automatic variables should always be initialized. Mixed declarations
+	and statements are allowed, and may be used to avoid assigning useless
+	values. Please leave one blank line before and after such declarations.
 
 Regarding the checkpatch tool, it is not included directly into this project.
 Please use checkpatch.pl from the Linux kernel git in combination with the

--- a/core/lib/libtomcrypt/src/sub.mk
+++ b/core/lib/libtomcrypt/src/sub.mk
@@ -2,7 +2,6 @@ ifdef _CFG_CRYPTO_WITH_ACIPHER
 srcs-y += mpa_desc.c
 # Get mpa.h which normally is an internal .h file
 cppflags-mpa_desc.c-y += -Ilib/libmpa
-cflags-mpa_desc.c-y += -Wno-declaration-after-statement
 cflags-mpa_desc.c-y += -Wno-unused-parameter
 endif
 

--- a/lib/libmpa/sub.mk
+++ b/lib/libmpa/sub.mk
@@ -9,7 +9,6 @@ cflags-remove-mpa_misc.c-y += -pedantic
 cflags-mpa_misc.c-y += -Wno-sign-compare
 
 srcs-y += mpa_montgomery.c
-cflags-remove-mpa_montgomery.c-y += -Wdeclaration-after-statement
 
 srcs-y += mpa_primetest.c
 cflags-remove-mpa_primetest.c-y += -pedantic

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -40,8 +40,7 @@ comp-cflags-warns-medium = \
 	-Waggregate-return -Wredundant-decls
 comp-cflags-warns-low = \
 	-Wold-style-definition -Wstrict-aliasing=2 \
-	-Wundef -pedantic \
-	-Wdeclaration-after-statement
+	-Wundef -pedantic
 
 comp-cflags-warns-1:= $(comp-cflags-warns-high)
 comp-cflags-warns-2:= $(comp-cflags-warns-1) $(comp-cflags-warns-medium)


### PR DESCRIPTION
Removes the -Wdeclaration-after-statement compiler flag to allow mixed
declaration and code

Acked-by: Jerome Forissier <jerome.forissier@linaro.org>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
