### PR TITLE
Revert "abort.c: manipulate with VFP state only if thread is active"

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -680,11 +680,13 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 #endif
 	case FAULT_TYPE_PAGEABLE:
 	default:
-		if (!thread_foreign_intr_disabled())
-			thread_kernel_save_vfp();
+		if (thread_get_id_may_fail() < 0) {
+			abort_print_error(&ai);
+			panic("abort outside thread context");
+		}
+		thread_kernel_save_vfp();
 		handled = tee_pager_handle_fault(&ai);
-		if (!thread_foreign_intr_disabled())
-			thread_kernel_restore_vfp();
+		thread_kernel_restore_vfp();
 		if (!handled) {
 			abort_print_error(&ai);
 			if (!abort_is_user_exception(&ai))


### PR DESCRIPTION
This reverts commit cfa34ec63699e26e3eb674212fe6401fab32e98c.

The patch being revered causes problems with pager enabled together
crypto extensions. abort_handler() is always called with all exceptions
masked (THREAD_EXCP_ALL) so the condition to save VFP state will never
be true.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (Hikey AArch64 pager)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
