### PR TITLE
core: correct time conversion in delay support

### DIFF
--- a/core/arch/arm/kernel/delay.c
+++ b/core/arch/arm/kernel/delay.c
@@ -34,7 +34,7 @@ void udelay(uint32_t us)
 	uint64_t start, target;
 
 	start = read_cntpct();
-	target = read_cntfrq() / 1000000ULL * us;
+	target = ((uint64_t)read_cntfrq() * us) / 1000000ULL;
 
 	while (read_cntpct() - start <= target)
 		;


### PR DESCRIPTION
The previous code may overflow in 32bit architectures. This change
fixes the issue by forcing 64bit computation during frequency
to counter conversion.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
