### PR TITLE
core: allow console probe falls back to /chosen node

### DIFF
--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -65,13 +65,17 @@ void configure_console_from_dt(void)
 		return;
 
 	offs = fdt_path_offset(fdt, "/secure-chosen");
-	if (offs < 0)
-		return;
+	if (offs < 0) {
+		/* Fallback to node /chosen */
+		offs = fdt_path_offset(fdt, "/chosen");
+		if (offs < 0)
+			return;
+	}
 	prop = fdt_get_property(fdt, offs, "stdout-path", NULL);
 	if (!prop) {
 		/*
-		 * /secure-chosen node present but no stdout-path property
-		 * means we don't want any console output
+		 * /secure-chosen or /chosen node present but no stdout-path
+		 * property means we don't want any console output.
 		 */
 		IMSG("Switching off console");
 		register_serial_console(NULL);


### PR DESCRIPTION
If no /secure-chosen node is found is the device tree, the console
should be probed from the /chosen node if found.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
