### PR TITLE
core: correct dt_find_compatible_driver() if no driver found

### DIFF
--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -17,11 +17,17 @@ const struct dt_driver *dt_find_compatible_driver(const void *fdt, int offs)
 	const struct dt_device_match *dm;
 	const struct dt_driver *drv;
 
-	for_each_dt_driver(drv)
-		for (dm = drv->match_table; dm; dm++)
+	for_each_dt_driver(drv) {
+		for (dm = drv->match_table; dm; dm++) {
+			if (!dm->compatible) {
+				break;
+			}
 			if (!fdt_node_check_compatible(fdt, offs,
-						       dm->compatible))
+						       dm->compatible)) {
 				return drv;
+			}
+		}
+	}
 
 	return NULL;
 }


### PR DESCRIPTION
By convention the compatible array for driver probing ends with
a NULL compatible string ID reference.

This change ensures such NULL reference is properly handled as
the end of the compatible array references.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
