### PR TITLE
3.3.0 end address

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -393,8 +393,8 @@ bool core_mmu_nsec_ddr_is_defined(void)
 }
 
 #define MSG_MEM_INSTERSECT(pa1, sz1, pa2, sz2) \
-	EMSG("[%" PRIxPA " %" PRIxPA "] intersecs [%" PRIxPA " %" PRIxPA "]", \
-			pa1, pa1 + sz1, pa2, pa2 + sz2)
+	EMSG("[%" PRIxPA " %" PRIx64 "] intersects [%" PRIxPA " %" PRIx64 "]", \
+			pa1, (uint64_t)pa1 + sz1, pa2, (uint64_t)pa2 + sz2)
 
 #ifdef CFG_SECURE_DATA_PATH
 static bool pbuf_is_sdp_mem(paddr_t pbuf, size_t len)
@@ -479,8 +479,8 @@ static void verify_special_mem_areas(struct tee_mmap_region *mem_map,
 	}
 
 	for (mem = start; mem < end; mem++)
-		DMSG("%s memory [%" PRIxPA " %" PRIxPA "]",
-		     area_name, mem->addr, mem->addr + mem->size);
+		DMSG("%s memory [%" PRIxPA " %" PRIx64 "]",
+		     area_name, mem->addr, (uint64_t)mem->addr + mem->size);
 
 	/* Check memories do not intersect each other */
 	for (mem = start; mem < end - 1; mem++) {

--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -99,7 +99,7 @@ bool _core_is_buffer_outside(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 	if (!is_valid_conf_and_notnull_size(b, bl, a, al))
 		return false;
 
-	if ((b + bl <= a) || (b >= a + al))
+	if ((b + bl - 1 < a) || (b > a + al - 1))
 		return true;
 	return false;
 }
@@ -111,7 +111,7 @@ bool _core_is_buffer_intersect(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 	if (!is_valid_conf_and_notnull_size(b, bl, a, al))
 		return false;
 
-	if ((b + bl <= a) || (b >= a + al))
+	if ((b + bl - 1 < a) || (b > a + al - 1))
 		return false;
 	return true;
 }


### PR DESCRIPTION
* **core: correct overflows in range overlap functions**
 Buffers that end at end of the available address range which may happen on 32bit machine fail have an end address that of computed as 0. This change uses the computation already used in `_core_is_buffer_inside()` to ensure functions `_core_is_buffer_outside()` and `_core_is_buffer_intersect()` return a reliable result.


* **core: correct memory layout trace**
 Buffers that end at end of the available address range which may happen on 32bit machine fail have an end address that of computed as 0. This change uses a 64bit address computation to prevent the displayed end address being 0.
