### PR TITLE
core: trace out size of the pager physical page pool

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2015-2018, Linaro Limited
  */
 
 #include <arm.h>
@@ -298,6 +298,15 @@ static void carve_out_asan_mem(tee_mm_pool_t *pool __unused)
 }
 #endif
 
+static void print_pager_pool_size(void)
+{
+	struct tee_pager_stats __maybe_unused stats;
+
+	tee_pager_get_stats(&stats);
+	IMSG("Pager pool size: %zukB",
+		stats.npages_all * SMALL_PAGE_SIZE / 1024);
+}
+
 static void init_vcore(tee_mm_pool_t *mm_vcore)
 {
 	const vaddr_t begin = TEE_RAM_VA_START;
@@ -441,6 +450,8 @@ static void init_runtime(unsigned long pageable_part)
 	tee_pager_add_pages(tee_mm_vcore.lo,
 			(VCORE_UNPG_RX_PA - tee_mm_vcore.lo) / SMALL_PAGE_SIZE,
 			true);
+
+	print_pager_pool_size();
 }
 #else
 


### PR DESCRIPTION
Add a nice info trace about the size of the pager physical page pool.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
