### PR TITLE
symbolize: use CROSS_COMPILE directive if available

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -104,6 +104,9 @@ class Symbolizer(object):
     def set_arch(self):
         if self._arch:
             return
+        self._arch = os.getenv('CROSS_COMPILE');
+        if self._arch:
+            return
         elf = self.get_elf(self._elfs[0][0])
         if elf is None:
             return


### PR DESCRIPTION
Get CROSS_COMPILE prefix directive if defined in the environment.
If CROSS_COMPILE is not defined, default to aarch64-linux-gnu- or
arm-linux-gnueabihf- as done prior this change according to the
architecture read from the ELF file.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
