### PR TITLE
Life cycle of registered shared memory objects (take 2)

### DIFF
--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -143,6 +143,30 @@ TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);
 TEE_Result mobj_reg_shm_map(struct mobj *mobj);
 TEE_Result mobj_reg_shm_unmap(struct mobj *mobj);
 
+/**
+ * mobj_reg_shm_inc_map() - increase map count
+ * @mobj:	pointer to a registered shared memory MOBJ
+ *
+ * Maps the MOBJ if it isn't mapped already and increaes the map count
+ * Each call to mobj_reg_shm_inc_map() is supposed to be matches by a call
+ * to mobj_reg_shm_dec_map().
+ *
+ * Returns TEE_SUCCESS on success or an error code on failure
+ */
+TEE_Result mobj_reg_shm_inc_map(struct mobj *mobj);
+
+/**
+ * mobj_reg_shm_dec_map() - decrease map count
+ * @mobj:	pointer to a registered shared memory MOBJ
+ *
+ * Decreases the map count and also unmaps the MOBJ if the map count
+ * reaches 0.  Each call to mobj_reg_shm_inc_map() is supposed to be
+ * matched by a call to mobj_reg_shm_dec_map().
+ *
+ * Returns TEE_SUCCESS on success or an error code on failure
+ */
+TEE_Result mobj_reg_shm_dec_map(struct mobj *mobj);
+
 /*
  * mapped_shm represents registered shared buffer
  * which is mapped into OPTEE va space

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -140,9 +140,6 @@ void mobj_reg_shm_put(struct mobj *mobj);
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);
 
-TEE_Result mobj_reg_shm_map(struct mobj *mobj);
-TEE_Result mobj_reg_shm_unmap(struct mobj *mobj);
-
 /**
  * mobj_reg_shm_inc_map() - increase map count
  * @mobj:	pointer to a registered shared memory MOBJ

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -164,6 +164,17 @@ TEE_Result mobj_reg_shm_inc_map(struct mobj *mobj);
  */
 TEE_Result mobj_reg_shm_dec_map(struct mobj *mobj);
 
+/**
+ * mobj_reg_shm_unguard() - unguards a reg_shm
+ * @mobj:	pointer to a registered shared memory mobj
+ *
+ * A registered shared memory mobj is normally guarded against being
+ * released with mobj_reg_shm_try_release_by_cookie(). After this function
+ * has returned the mobj can be released by a call to
+ * mobj_reg_shm_try_release_by_cookie() if the reference counter allows it.
+ */
+void mobj_reg_shm_unguard(struct mobj *mobj);
+
 /*
  * mapped_shm represents registered shared buffer
  * which is mapped into OPTEE va space

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -117,8 +117,6 @@ struct mobj *mobj_phys_alloc(paddr_t pa, size_t size, uint32_t cattr,
 struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 				paddr_t page_offset, uint64_t cookie);
 
-void mobj_reg_shm_free_by_cookie(uint64_t cookie);
-
 /**
  * mobj_reg_shm_get_by_cookie() - get a MOBJ based on cookie
  * @cookie:	Cookie used by normal world when suppling the shared memory
@@ -139,7 +137,6 @@ struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie);
  * reaches 0.
  */
 void mobj_reg_shm_put(struct mobj *mobj);
-void mobj_reg_shm_put_by_cookie(uint64_t cookie);
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);
 

--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -119,7 +119,26 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 
 void mobj_reg_shm_free_by_cookie(uint64_t cookie);
 
+/**
+ * mobj_reg_shm_get_by_cookie() - get a MOBJ based on cookie
+ * @cookie:	Cookie used by normal world when suppling the shared memory
+ *
+ * Searches for a registered shared memory MOBJ and if one with a matching
+ * @cookie is found its reference counter is increased before returning
+ * the MOBJ.
+ *
+ * Returns a valid pointer on success or NULL on failure.
+ */
 struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie);
+
+/**
+ * mobj_reg_shm_put() - put a MOBJ
+ * @mobj:	Pointer to a registered shared memory MOBJ
+ *
+ * Decreases reference counter of the @mobj and frees it if the counter
+ * reaches 0.
+ */
+void mobj_reg_shm_put(struct mobj *mobj);
 void mobj_reg_shm_put_by_cookie(uint64_t cookie);
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie);

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -312,6 +312,7 @@ struct mobj_reg_shm {
 	struct refcount refcount;
 	struct refcount mapcount;
 	int num_pages;
+	bool guarded;
 	paddr_t pages[];
 };
 
@@ -464,6 +465,7 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 	mobj_reg_shm->mobj.size =  num_pages * SMALL_PAGE_SIZE;
 	mobj_reg_shm->mobj.phys_granule = SMALL_PAGE_SIZE;
 	mobj_reg_shm->cookie = cookie;
+	mobj_reg_shm->guarded = true;
 	mobj_reg_shm->num_pages = num_pages;
 	mobj_reg_shm->page_offset = page_offset;
 	memcpy(mobj_reg_shm->pages, pages, sizeof(*pages) * num_pages);
@@ -488,6 +490,14 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 err:
 	free(mobj_reg_shm);
 	return NULL;
+}
+
+void mobj_reg_shm_unguard(struct mobj *mobj)
+{
+	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+
+	to_mobj_reg_shm(mobj)->guarded = false;
+	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
 }
 
 static struct mobj_reg_shm *reg_shm_find_unlocked(uint64_t cookie)
@@ -557,7 +567,7 @@ static TEE_Result try_release_reg_shm(uint64_t cookie)
 	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
 	struct mobj_reg_shm *r = reg_shm_find_unlocked(cookie);
 
-	if (!r)
+	if (!r || r->guarded)
 		goto out;
 
 	res = TEE_ERROR_BUSY;


### PR DESCRIPTION
This pull request relates to the life cycle of registered shared memory objects and fixes the problem of normal world trying to unregister shared memory objects which are in use.
