### PR TITLE
libutee: Fix base64 encoding function

### DIFF
--- a/lib/libutee/base64.c
+++ b/lib/libutee/base64.c
@@ -16,7 +16,7 @@ bool base64_enc(const void *data, size_t dlen, char *buf, size_t *blen)
 {
 	size_t n;
 	size_t boffs = 0;
-	const char *d = data;
+	const unsigned char *d = data;
 
 	n = base64_enc_len(dlen);
 	if (*blen < n) {


### PR DESCRIPTION
Bitwise OR of unsinged int and a signed char is machine dependent and
could lead to invalid base64 encoding.

This commit makes it use unsigned char instead.

Signed-off-by: Krzysztof Jackiewicz <k.jackiewicz@samsung.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
