### PR TITLE
core: juno: workaround cortex-a57 errata 808870

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -28,7 +28,10 @@ ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_WITH_VFP,y)
 endif
 ifeq ($(CFG_WITH_VFP),y)
-platform-hard-float-enabled := y
+arm64-platform-hard-float-enabled := y
+ifneq ($(CFG_TA_ARM32_NO_HARD_FLOAT_SUPPORT),y)
+arm32-platform-hard-float-enabled := y
+endif
 endif
 endif
 
@@ -150,7 +153,7 @@ ta_arm32-platform-cflags += $(platform-cflags-optimization)
 ta_arm32-platform-cflags += $(platform-cflags-debug-info)
 ta_arm32-platform-cflags += -fpie
 ta_arm32-platform-cflags += $(arm32-platform-cflags-generic)
-ifeq ($(platform-hard-float-enabled),y)
+ifeq ($(arm32-platform-hard-float-enabled),y)
 ta_arm32-platform-cflags += $(arm32-platform-cflags-hard-float)
 else
 ta_arm32-platform-cflags += $(arm32-platform-cflags-no-hard-float)
@@ -182,7 +185,7 @@ ta_arm64-platform-cflags += $(platform-cflags-optimization)
 ta_arm64-platform-cflags += $(platform-cflags-debug-info)
 ta_arm64-platform-cflags += -fpie
 ta_arm64-platform-cflags += $(arm64-platform-cflags-generic)
-ifeq ($(platform-hard-float-enabled),y)
+ifeq ($(arm64-platform-hard-float-enabled),y)
 ta_arm64-platform-cflags += $(arm64-platform-cflags-hard-float)
 else
 ta_arm64-platform-cflags += $(arm64-platform-cflags-no-hard-float)

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -10,6 +10,9 @@ endif
 ifeq ($(PLATFORM_FLAVOR),juno)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 platform-debugger-arm := 1
+# Workaround 808870: Unconditional VLDM instructions might cause an
+# alignment fault even though the address is aligned
+$(call force,CFG_TA_ARM32_NO_HARD_FLOAT_SUPPORT,y)
 endif
 ifeq ($(PLATFORM_FLAVOR),qemu_armv8a)
 include core/arch/arm/cpu/cortex-armv8-0.mk


### PR DESCRIPTION
Workaround errata 808870:
Unconditional VLDM instructions might cause an alignment fault even
though the address is aligned

Products Affected: Cortex-A57 MPCore.
Present in: r0p0

The workaround is to avoid generating the problematic instructions in
AArch32 TA.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Not tested on Juno yet, all the problematic instructions seems to be gone from the TAs though.