### PR TITLE
auto-locate checkpatch.pl

### DIFF
--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -2,6 +2,20 @@
 
 DIR="${BASH_SOURCE%/*}"
 
+# if no CHECKPATCH is explicitly given by the environment, try to
+# locate checkpatch.pl: first take the one from the path, then check
+# for a local copy of the linux headers, finally try sources downloaded
+# with OP-TEE (for QEMU)
+if [ -z "$CHECKPATCH" ]; then
+  CHECKPATCH=$(command -v checkpatch.pl)
+fi
+if [ -z "$CHECKPATCH" ]; then
+  CHECKPATCH=$(find /usr/src/linux-headers* -name checkpatch.pl -print -quit)
+fi
+if [ -z "$CHECKPATCH" ]; then
+  CHECKPATCH=$(find "$PWD/../linux" -name checkpatch.pl -print -quit)
+fi
+
 source "$DIR/checkpatch_inc.sh"
 
 hash $CHECKPATCH 2>/dev/null ||


### PR DESCRIPTION
try to locate checkpatch.pl in typical location(s) if environment variable is not set

the dispatcher script now tries to populate the CHECKPATCH environment variable if it is not available or empty with a path to `checkpatch.pl` if one is found under `/usr/src/linux-headers*`, a commonly used path.

Signed-off-by: Markus S. Wamser <markus.wamser@mixed-mode.de>
