### PR TITLE
qemu: increase CFG_DTB_MAX_SIZE to 1 MiB

### DIFF
--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -90,6 +90,7 @@ endif
 $(call force,CFG_BOOT_SECONDARY_REQUEST,y)
 $(call force,CFG_PSCI_ARM32,y)
 $(call force,CFG_DT,y)
+CFG_DTB_MAX_SIZE ?= 0x100000
 # SE API is only supported by QEMU Virt platform
 CFG_SE_API ?= y
 CFG_SE_API_SELF_TEST ?= y
@@ -108,4 +109,5 @@ CFG_SHMEM_SIZE  ?= 0x00200000
 # When Secure Data Path is enable, last MByte of TZDRAM is SDP test memory.
 CFG_TEE_SDP_MEM_SIZE ?= 0x00400000
 $(call force,CFG_DT,y)
+CFG_DTB_MAX_SIZE ?= 0x100000
 endif


### PR DESCRIPTION
Since upstream QEMU commit 14ec3cbd7c1e ("device_tree: Increase
FDT_MAX_SIZE to 1 MiB"), which is included in release v2.12.1 and later,
OP-TEE initialization fails with the following error (-3 is
-FDT_ERR_NOSPACE):

 E/TC:0 0 init_fdt:808 Invalid Device Tree at 0x40000000: error -3

Increase CFG_DTB_MAX_SIZE accordingly. Tested with the current tip of the
QEMU master branch, in 32- and 64-bit modes (note that our 64-bit QEMU
setup needs a TF-A patch -- PLAT_QEMU_DT_MAX_SIZE needs to be set to 1 MiB
too).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
