### PR TITLE
hikey960: change DRAM1_SIZE_NSEC for 4GB board

### DIFF
--- a/core/arch/arm/plat-hikey/platform_config.h
+++ b/core/arch/arm/plat-hikey/platform_config.h
@@ -121,7 +121,14 @@
 #if (CFG_DRAM_SIZE_GB == 3)
 #define DRAM1_SIZE_NSEC		0x80000000
 #elif (CFG_DRAM_SIZE_GB == 4)
-#define DRAM1_SIZE_NSEC		0xC0000000
+/*
+ * SoC reference manual [1] page 2-23 says that the DRAM address range
+ * is 0x00000000 - 0xDFFFFFFF for a total of 3.5GB, so the limit would
+ * seem to be 0xE0000000.
+ *
+ * [1] https://github.com/96boards/documentation/raw/master/consumer/hikey/hikey960/hardware-docs/HiKey960_SoC_Reference_Manual.pdf
+ */
+#define DRAM1_SIZE_NSEC		0xA0000000
 #else
 #error Unknown DRAM size
 #endif


### PR DESCRIPTION
SoC reference manual [1] page 2-23 says that the DRAM address range is
0x00000000 - 0xDFFFFFFF for a total of 3.5GB, so the limit would seem
to be 0xE0000000, not 0x100000000, or 0xFFE00000 based on [2] and [3].

[1] https://github.com/96boards/documentation/raw/master/consumer/hikey/hikey960/hardware-docs/HiKey960_SoC_Reference_Manual.pdf
[2] https://github.com/OP-TEE/optee_os/issues/2597#issuecomment-428587050
[3] https://github.com/OP-TEE/optee_os/issues/2597#issuecomment-428865951

Fixes: https://github.com/OP-TEE/optee_os/issues/2597

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
