### PR TITLE
drivers: imx_uart: do not write to disabled UART

### DIFF
--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -110,11 +110,11 @@ static void imx_uart_putc(struct serial_chip *chip, int ch)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	write32(ch, base + UTXD);
-
-	/* Wait until sent */
-	while (!(read32(base + UTS) & UTS_TXEMPTY))
+	/* Wait until there's space in the TX FIFO */
+	while (read32(base + UTS) & UTS_TXFULL)
 		;
+
+	write32(ch, base + UTXD);
 }
 
 static const struct serial_ops imx_uart_ops = {

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -92,8 +92,10 @@ static void imx_uart_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
+
 	while (!(read32(base + UTS) & UTS_TXEMPTY))
-		;
+		if (!(read32(base + UCR1) & UCR1_UARTEN))
+			return;
 }
 
 static int imx_uart_getchar(struct serial_chip *chip)
@@ -112,7 +114,8 @@ static void imx_uart_putc(struct serial_chip *chip, int ch)
 
 	/* Wait until there's space in the TX FIFO */
 	while (read32(base + UTS) & UTS_TXFULL)
-		;
+		if (!(read32(base + UCR1) & UCR1_UARTEN))
+			return;
 
 	write32(ch, base + UTXD);
 }


### PR DESCRIPTION
Avoid indefinite hangs by not writing to the UART if it's disabled. If the UART is disabled, the write and flush routines will hang indefinitely which can be difficult to debug

@neilsh-msft
@MrVan 

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
