### PR TITLE
core: modify tee_otp_get_hw_unique_key to return TEE_Result

### DIFF
--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -13,9 +13,10 @@
  * The default implementation just sets it to a constant.
  */
 
-__weak void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+__weak TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	memset(&hwkey->data[0], 0, sizeof(hwkey->data));
+	return TEE_SUCCESS;
 }
 
 __weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -177,17 +177,23 @@ int get_hw_unique_key(uint64_t smc_func_id, uint64_t in_key, uint64_t size);
 			   OPTEE_SMC_OWNER_SIP, \
 			   OPTEE_SMC_FUNCID_SIP_LS_HW_UNQ_KEY)
 
-void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
+	TEE_Result res;
 	int ret = 0;
 	uint8_t hw_unq_key[sizeof(hwkey->data)] __aligned(64);
 
 	ret = get_hw_unique_key(OPTEE_SMC_FAST_CALL_SIP_LS_HW_UNQ_KEY,
 			virt_to_phys(hw_unq_key), sizeof(hwkey->data));
 
-	if (ret < 0)
+	if (ret < 0) {
 		EMSG("\nH/W Unique key is not fetched from the platform.");
-	else
+		res = TEE_ERROR_SECURITY;
+	} else {
 		memcpy(&hwkey->data[0], hw_unq_key, sizeof(hwkey->data));
+		res = TEE_SUCCESS;
+	}
+
+	return res;
 }
 #endif

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -154,9 +154,10 @@ void console_init(void)
 
 #if defined(CFG_OTP_SUPPORT)
 
-void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	memcpy(&hwkey->data[0], &plat_huk[0], sizeof(hwkey->data));
+	return TEE_SUCCESS;
 }
 
 #endif

--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -8,13 +8,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <tee_api_types.h>
 #include <utee_defines.h>
 
 struct tee_hw_unique_key {
 	uint8_t data[HW_UNIQUE_KEY_LENGTH];
 };
 
-void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
 int tee_otp_get_die_id(uint8_t *buffer, size_t len);
 
 #endif /* TEE_COMMON_OTP_H */

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -281,17 +281,13 @@ out:
  *
  * Maybe tee_get_hw_unique_key() should be exposed as
  * generic API for getting hw unique key!
- * We should change the API tee_otp_get_hw_unique_key()
- * to return error code!
  */
 static TEE_Result tee_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	if (!hwkey)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	tee_otp_get_hw_unique_key(hwkey);
-
-	return TEE_SUCCESS;
+	return tee_otp_get_hw_unique_key(hwkey);
 }
 
 static TEE_Result tee_rpmb_key_gen(uint16_t dev_id __unused,

--- a/documentation/secure_storage.md
+++ b/documentation/secure_storage.md
@@ -222,7 +222,7 @@ To allow Secure Storage to operate securely on your platform, you must define
 implementations in your platform code for:
 
 ``` c
- void tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
+ TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
  int tee_otp_get_die_id(uint8_t *buffer, size_t len);
 ```
 


### PR DESCRIPTION
Getting the hardware key can fail on some platforms. Modify the function
signature to return an appropriate error code.

@dmcilvaney 

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
