### PR TITLE
add checkpatch targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,12 @@ cscope:
 	${q}rm -f cscope.*
 	${q}find $(PWD) -name "*.[chSs]" | grep -v "$(PWD)/out" > cscope.files
 	${q}cscope -b -q -k
+
+.PHONY: checkpatch checkpatch-staging checkpatch-working
+checkpatch: checkpatch-staging checkpatch-working
+
+checkpatch-working:
+	${q}./scripts/checkpatch.sh
+
+checkpatch-staging:
+	${q}./scripts/checkpatch.sh --cached

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Regarding the checkpatch tool, it is not included directly into this project.
 Please use checkpatch.pl from the Linux kernel git in combination with the
 local [checkpatch script].
 
+There are also targets for common use cases in the [Makefile](Makefile):
+
+```
+make checkpatch			#check staging and working area
+make checkpatch-staging #check staging area (added, but not committed files)
+make checkpatch-working #check working area (modified, but not added files)
+```
+
 [build]: https://github.com/OP-TEE/build
 [checkpatch script]: scripts/checkpatch.sh
 [checkpatch]: http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/scripts/checkpatch.pl


### PR DESCRIPTION
+ added target for calling checkpatch on working and staging area
+ added documentation for targets in Readme

thsi is a follow-up PR to https://github.com/OP-TEE/optee_test/pull/311

Signed-off-by: Markus S. Wamser <markus.wamser@mixed-mode.de>
