### PR TITLE
Redefine TRACE_MIN level to 0, instead of 1 (TRACE_ERROR)

### DIFF
--- a/lib/libutils/ext/include/trace_levels.h
+++ b/lib/libutils/ext/include/trace_levels.h
@@ -23,8 +23,8 @@
  *
  */
 
-#define TRACE_MIN       1
-#define TRACE_ERROR     TRACE_MIN
+#define TRACE_MIN       0
+#define TRACE_ERROR     1
 #define TRACE_INFO      2
 #define TRACE_DEBUG     3
 #define TRACE_FLOW      4

--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -15,11 +15,11 @@
 #include <util.h>
 #include <types_ext.h>
 
-#if (TRACE_LEVEL > 0)
-
 #if (TRACE_LEVEL < TRACE_MIN) || (TRACE_LEVEL > TRACE_MAX)
 #error "Invalid value of TRACE_LEVEL"
 #endif
+
+#if (TRACE_LEVEL >= TRACE_ERROR)
 
 void trace_set_level(int level)
 {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -41,14 +41,20 @@ WARNS ?= 3
 # so assertions are disabled.
 CFG_TEE_CORE_DEBUG ?= y
 
-# Log levels for the TEE core and user-mode TAs
-# Defines which messages are displayed on the secure console
+# Log levels for the TEE core. Defines which core messages are displayed
+# on the secure console. Disabling core log (level set to 0) also disables
+# logs from the TAs.
 # 0: none
 # 1: error
 # 2: error + warning
 # 3: error + warning + debug
 # 4: error + warning + debug + flow
 CFG_TEE_CORE_LOG_LEVEL ?= 1
+
+# TA log level
+# If user-mode library libutils.a is built with CFG_TEE_TA_LOG_LEVEL=0,
+# TA tracing is disabled regardless of the value of CFG_TEE_TA_LOG_LEVEL
+# when the TA is built.
 CFG_TEE_TA_LOG_LEVEL ?= 1
 
 # TA enablement


### PR DESCRIPTION
This PR is a proposal that would fix an inconsistency related to the logging level used when TA applications are built with `CFG_TEE_TA_LOG_LEVEL=0`.

The description was detailed in the [comment](https://github.com/OP-TEE/optee_os/issues/2635#issue-377911205) from issue [#2635](https://github.com/OP-TEE/optee_os/issues/2635).