### PR TITLE
core: fix compile error with CFG_CORE_WORKAROUND_SPECTRE_BP_SEC=n

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -966,7 +966,7 @@ static bool probe_workaround_available(void)
 	return r >= 0;
 }
 
-static vaddr_t select_vector(vaddr_t a)
+static vaddr_t __maybe_unused select_vector(vaddr_t a)
 {
 	if (probe_workaround_available()) {
 		DMSG("SMCCC_ARCH_WORKAROUND_1 (%#08" PRIx32 ") available",
@@ -981,7 +981,7 @@ static vaddr_t select_vector(vaddr_t a)
 	return (vaddr_t)thread_excp_vect;
 }
 #else
-static vaddr_t select_vector(vaddr_t a)
+static vaddr_t __maybe_unused select_vector(vaddr_t a)
 {
 	return a;
 }


### PR DESCRIPTION
Fixes compile error:
  CC      ../out-os-qemu/core/arch/arm/mm/tee_mm.o
core/arch/arm/kernel/thread.c:984:16: error: ‘select_vector’ defined but not used [-Werror=unused-function]
 static vaddr_t select_vector(vaddr_t a)
                ^~~~~~~~~~~~~
cc1: all warnings being treated as errors

when compiled with CFG_CORE_WORKAROUND_SPECTRE_BP_SEC=n

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
