### PR TITLE
core: remove thread_{add,rem}_mutex()

### DIFF
--- a/core/arch/arm/include/kernel/mutex.h
+++ b/core/arch/arm/include/kernel/mutex.h
@@ -23,7 +23,6 @@ struct mutex {
 	struct wait_queue wq;
 	short state;		/* -1: write, 0: unlocked, > 0: readers */
 	short owner_id;		/* Only valid for state == -1 (write lock) */
-	TAILQ_ENTRY(mutex) link;
 };
 #define MUTEX_INITIALIZER \
 	{ .owner_id = MUTEX_OWNER_ID_NONE, .wq = WAIT_QUEUE_INITIALIZER, }

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -552,18 +552,6 @@ bool thread_is_in_normal_mode(void);
 bool thread_is_from_abort_mode(void);
 
 /*
- * Adds a mutex to the list of held mutexes for current thread
- * Requires foreign interrupts to be disabled.
- */
-void thread_add_mutex(struct mutex *m);
-
-/*
- * Removes a mutex from the list of held mutexes for current thread
- * Requires foreign interrupts to be disabled.
- */
-void thread_rem_mutex(struct mutex *m);
-
-/*
  * Disables and empties the prealloc RPC cache one reference at a time. If
  * all threads are idle this function returns true and a cookie of one shm
  * object which was removed from the cache. When the cache is empty *cookie

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -92,7 +92,6 @@ struct thread_ctx {
 #endif
 	void *rpc_arg;
 	struct mobj *rpc_mobj;
-	struct mutex_head mutexes;
 	struct thread_specific_data tsd;
 };
 #endif /*ASM*/


### PR DESCRIPTION
With the recently merged lockdep patches thread_add_mutex() and
thread_rem_mutex() are obsolete. Remove them to save memory and
overhead.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
