### PR TITLE
GICv3 interrupt handling fix

### DIFF
--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -327,7 +327,9 @@ DEFINE_REG_READ_FUNC_(icc_ctlr, uint32_t, S3_0_C12_C12_4)
 DEFINE_REG_WRITE_FUNC_(icc_ctlr, uint32_t, S3_0_C12_C12_4)
 DEFINE_REG_WRITE_FUNC_(icc_pmr, uint32_t, S3_0_C4_C6_0)
 DEFINE_REG_READ_FUNC_(icc_iar0, uint32_t, S3_0_c12_c8_0)
+DEFINE_REG_READ_FUNC_(icc_iar1, uint32_t, S3_0_c12_c12_0)
 DEFINE_REG_WRITE_FUNC_(icc_eoir0, uint32_t, S3_0_c12_c8_1)
+DEFINE_REG_WRITE_FUNC_(icc_eoir1, uint32_t, S3_0_c12_c12_1)
 #endif /*ASM*/
 
 #endif /*ARM64_H*/

--- a/core/arch/arm/plat-synquacer/conf.mk
+++ b/core/arch/arm/plat-synquacer/conf.mk
@@ -8,6 +8,7 @@ $(call force,CFG_PM_STUBS,y)
 
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,24)
+CFG_NUM_THREADS ?= 8
 CFG_TZDRAM_START ?= 0xfc000000
 CFG_TZDRAM_SIZE ?= 0x03c00000
 CFG_SHMEM_START ?= 0xffc00000

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -328,7 +328,7 @@ static void gic_it_raise_sgi(struct gic_data *gd, size_t it,
 static uint32_t gic_read_iar(struct gic_data *gd __maybe_unused)
 {
 #if defined(CFG_ARM_GICV3)
-	return read_icc_iar0();
+	return read_icc_iar1();
 #else
 	return read32(gd->gicc_base + GICC_IAR);
 #endif
@@ -337,7 +337,7 @@ static uint32_t gic_read_iar(struct gic_data *gd __maybe_unused)
 static void gic_write_eoir(struct gic_data *gd __maybe_unused, uint32_t eoir)
 {
 #if defined(CFG_ARM_GICV3)
-	write_icc_eoir0(eoir);
+	write_icc_eoir1(eoir);
 #else
 	write32(eoir, gd->gicc_base + GICC_EOIR);
 #endif


### PR DESCRIPTION
This pull request also includes patch to set default number of threads to 8 which has already been reviewed as part of https://github.com/OP-TEE/optee_os/pull/2564.