### PR TITLE
Secure device tree support and apply to platform stm32mp1

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -73,10 +73,8 @@ uint32_t sem_cpu_sync[CFG_TEE_CORE_NB_CORE];
 KEEP_PAGER(sem_cpu_sync);
 #endif
 
-#ifdef CFG_EMBEDDED_SECURE_DT
-extern uint8_t embedded_secure_dtb[];
-#endif
 #ifdef CFG_DT
+extern uint8_t embedded_secure_dtb[];
 static void *dt_blob_addr;
 #endif
 
@@ -474,7 +472,7 @@ static void init_runtime(unsigned long pageable_part __unused)
 }
 #endif
 
-#if defined(CFG_DT) && !defined(CFG_EMBEDDED_SECURE_DT)
+#if defined(CFG_DT) && !defined(CFG_EMBEDDED_DTS)
 void *get_dt_blob(void)
 {
 	assert(cpu_mmu_enabled());
@@ -839,9 +837,9 @@ static void update_fdt(void)
 		panic();
 	}
 }
-#endif /*CFG_DT && !CFG_EMBEDDED_SECURE_DT*/
+#endif /*CFG_DT && !CFG_EMBEDDED_DTS*/
 
-#if defined(CFG_DT) && defined(CFG_EMBEDDED_SECURE_DT)
+#if defined(CFG_DT) && defined(CFG_EMBEDDED_DTS)
 void *get_dt_blob(void)
 {
 	assert(cpu_mmu_enabled());
@@ -864,7 +862,7 @@ void *get_dt_blob(void)
 }
 #endif
 
-#if !defined(CFG_DT) || defined(CFG_EMBEDDED_SECURE_DT)
+#if !defined(CFG_DT) || defined(CFG_EMBEDDED_DTS)
 static void reset_dt_references(void)
 {
 }
@@ -883,7 +881,7 @@ static struct core_mmu_phys_mem *get_memory(void *fdt __unused,
 	return NULL;
 }
 
-#endif /*!CFG_DT || CFG_EMBEDDED_SECURE_DT*/
+#endif /*!CFG_DT || CFG_EMBEDDED_DTS*/
 
 static void discover_nsec_memory(void)
 {

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -73,6 +73,9 @@ uint32_t sem_cpu_sync[CFG_TEE_CORE_NB_CORE];
 KEEP_PAGER(sem_cpu_sync);
 #endif
 
+#ifdef CFG_EMBEDDED_SECURE_DT
+extern uint8_t embedded_secure_dtb[];
+#endif
 #ifdef CFG_DT
 static void *dt_blob_addr;
 #endif
@@ -471,7 +474,7 @@ static void init_runtime(unsigned long pageable_part __unused)
 }
 #endif
 
-#ifdef CFG_DT
+#if defined(CFG_DT) && !defined(CFG_EMBEDDED_SECURE_DT)
 void *get_dt_blob(void)
 {
 	assert(cpu_mmu_enabled());
@@ -836,8 +839,36 @@ static void update_fdt(void)
 		panic();
 	}
 }
+#endif /*CFG_DT && !CFG_EMBEDDED_SECURE_DT*/
 
-#else
+#if defined(CFG_DT) && defined(CFG_EMBEDDED_SECURE_DT)
+void *get_dt_blob(void)
+{
+	assert(cpu_mmu_enabled());
+
+	if (!dt_blob_addr) {
+		if (fdt_check_header(embedded_secure_dtb))
+			panic("Invalid static DTB");
+
+		dt_blob_addr = embedded_secure_dtb;
+	}
+
+	return dt_blob_addr;
+}
+#endif
+
+#ifndef CFG_DT
+void *get_dt_blob(void)
+{
+	return NULL;
+}
+#endif
+
+#if !defined(CFG_DT) || defined(CFG_EMBEDDED_SECURE_DT)
+static void reset_dt_references(void)
+{
+}
+
 static void init_fdt(unsigned long phys_fdt __unused)
 {
 }
@@ -846,22 +877,13 @@ static void update_fdt(void)
 {
 }
 
-static void reset_dt_references(void)
-{
-}
-
-void *get_dt_blob(void)
-{
-	return NULL;
-}
-
 static struct core_mmu_phys_mem *get_memory(void *fdt __unused,
 					     size_t *nelems __unused)
 {
 	return NULL;
 }
 
-#endif /*!CFG_DT*/
+#endif /*!CFG_DT || CFG_EMBEDDED_SECURE_DT*/
 
 static void discover_nsec_memory(void)
 {

--- a/core/core.mk
+++ b/core/core.mk
@@ -106,6 +106,10 @@ libdir = core/lib/zlib
 include mk/lib.mk
 endif
 
+ifneq ($(CFG_SECURE_DTS),)
+include core/secure_dt.mk
+endif
+
 #
 # Do main source
 #

--- a/core/core.mk
+++ b/core/core.mk
@@ -106,9 +106,7 @@ libdir = core/lib/zlib
 include mk/lib.mk
 endif
 
-ifneq ($(CFG_SECURE_DTS),)
 include core/secure_dt.mk
-endif
 
 #
 # Do main source

--- a/core/secure_dt.mk
+++ b/core/secure_dt.mk
@@ -6,7 +6,7 @@
 # Generating the DTB from the DTS and integrating into OP-TEE core.
 #
 # CFG_SECURE_DTS provides a list of device tree source name located
-# in directory core/arch/$(arch-dir)/fdts/.
+# in directory core/arch/$(ARCH)/dts/.
 #
 # This makefile generates a DTB file for each DTS file listed by
 # CFG_SECURE_DTS. Variable core-secure-dtb is filled with the list of
@@ -71,5 +71,5 @@ define MAKE_DTBS
         $(eval $(foreach obj,$(DTBOBJS),$(call MAKE_DTB,$(1),$(obj))))
 endef
 
-FDT_SOURCE := $(addprefix $(arch-dir)/fdts/,$(CFG_SECURE_DTS))
-$(eval $(call MAKE_DTBS,$(out-dir)/core/fdts,$(FDT_SOURCE)))
+FDT_SOURCE := $(addprefix $(arch-dir)/dts/,$(CFG_SECURE_DTS))
+$(eval $(call MAKE_DTBS,$(out-dir)/core/dts,$(FDT_SOURCE)))

--- a/core/secure_dt.mk
+++ b/core/secure_dt.mk
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2018, Linaro Limited
+# Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+#
+# Generating the DTB from the DTS and integrating into OP-TEE core.
+#
+# CFG_SECURE_DTS provides a list of device tree source name located
+# in directory core/arch/$(arch-dir)/fdts/.
+#
+# This makefile generates a DTB file for each DTS file listed by
+# CFG_SECURE_DTS. Variable core-secure-dtb is filled with the list of
+# the paths of the generated DTB.
+#
+# Build precompiles the DTS files to resolve precompilation features
+# (build directive, file inclusion, ...) then generates a DTB file of same
+# name as the input source file but with extension .dts replaced with .dtb.
+
+DTC_FLAGS += -I dts -O dtb
+DTC_FLAGS += -Wno-unit_address_vs_reg
+
+DTC := dtc
+
+# Will get filled with generated DTB paths
+core-secure-dtb :=
+
+# Convert device tree source file names to matching blobs
+#   $(1) = input dts
+define SOURCES_TO_DTBS
+    $(notdir $(patsubst %.dts,%.dtb,$(filter %.dts,$(1))))
+endef
+
+# MAKE_DTB generate the Flattened device tree binary
+#   $(1) = output directory
+#   $(2) = input dts
+define MAKE_DTB
+
+# List of DTB file(s) to generate, based on DTS file basename list
+$(eval DTBOBJ := $(addprefix $(1)/,$(call SOURCES_TO_DTBS,$(2))))
+# List of the pre-compiled DTS file(s)
+$(eval DTSPRE := $(addprefix $(1)/,$(patsubst %.dts,%.pre.dts,$(notdir $(2)))))
+# Dependencies of the pre-compiled DTS file(s) on its source and included files
+$(eval DTSDEP := $(patsubst %.dtb,%.o.d,$(DTBOBJ)))
+# Dependencies of the DT compilation on its pre-compiled DTS
+$(eval DTBDEP := $(patsubst %.dtb,%.d,$(DTBOBJ)))
+
+$(DTBOBJ)_outdir:
+	@# The $(dir ) function leaves a trailing / on the directory names
+	@# Rip off the / to match directory names with make rule targets.
+	$(q)mkdir -p "$(patsubst %/,%,$(sort $(dir ${DTBOBJ})))"
+
+$(DTBOBJ): $(2) $(DTBOBJ)_outdir $(filter-out %.d,$(MAKEFILE_LIST))
+	@$(cmd-echo-silent) "  CPP     $$<"
+	$(q)$(CPP$(sm)) $$(CPPFLAGS) -Icore/include/ -x assembler-with-cpp \
+		-E -ffreestanding -MT $(DTBOBJ) -MMD -MF $(DTSDEP) -o $(DTSPRE) $$<
+	@$(cmd-echo-silent) "  DTC     $$<"
+	$(q)$(DTC) $$(DTC_FLAGS) -d $(DTBDEP) -o $$@ $(DTSPRE)
+
+core-secure-dtb += $(DTBOBJ)
+-include $(DTBDEP)
+-include $(DTSDEP)
+endef
+
+# MAKE_DTBS builds flattened device tree sources
+#   $(1) = output directory
+#   $(2) = list of flattened device tree source files
+define MAKE_DTBS
+        $(eval DTBOBJS := $(filter %.dts,$(2)))
+        $(eval REMAIN := $(filter-out %.dts,$(2)))
+        $(and $(REMAIN),$(error FDT_SOURCE contain non-DTS files: $(REMAIN)))
+        $(eval $(foreach obj,$(DTBOBJS),$(call MAKE_DTB,$(1),$(obj))))
+endef
+
+FDT_SOURCE := $(addprefix $(arch-dir)/fdts/,$(CFG_SECURE_DTS))
+$(eval $(call MAKE_DTBS,$(out-dir)/core/fdts,$(FDT_SOURCE)))

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -27,16 +27,20 @@ $(foreach f, $(CFG_IN_TREE_EARLY_TAS), $(eval $(call \
 	process_early_ta,$(out-dir)/ta/$(f).stripped.elf)))
 endif
 
-ifeq ($(CFG_EMBEDDED_SECURE_DT),y)
-ifneq ($(firstword $(core-secure-dtb)),$(strip $(core-secure-dtb)))
-$(error CFG_EMBEDDED_SECURE_DT expects a single DTS from CFG_SECURE_DTS)
+ifneq ($(CFG_EMBEDDED_DTS),)
+ifneq ($(firstword $(CFG_EMBEDDED_DTS)),$(strip $(CFG_EMBEDDED_DTS)))
+$(error CFG_EMBEDDED_DTS shall define a single DTS file name)
 endif
+$(eval $(call MAKE_DTBS,$(out-dir)/core/dts, \
+			$(addprefix $(arch-dir)/dts/,$(CFG_EMBEDDED_DTS)), \
+			core-embedded-dtb))
+
 gensrcs-y += embedded_secure_dtb
+cleanfiles += $(out-dir)/core/dts/embedded_secure_dtb.c
 produce-embedded_secure_dtb = dts/embedded_secure_dtb.c
-depends-embedded_secure_dtb = $(core-secure-dtb) scripts/ta_bin_to_c.py
+depends-embedded_secure_dtb = $(core-embedded-dtb) scripts/ta_bin_to_c.py
 recipe-embedded_secure_dtb = scripts/bin_to_c.py \
-				--bin $(core-secure-dtb) \
+				--bin $(core-embedded-dtb) \
 				--vname embedded_secure_dtb \
 				--out $(out-dir)/core/dts/embedded_secure_dtb.c
-cleanfiles += $(out-dir)/core/dts/embedded_secure_dtb.c
 endif

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -26,3 +26,17 @@ $(foreach f, $(EARLY_TA_PATHS), $(eval $(call process_early_ta,$(f))))
 $(foreach f, $(CFG_IN_TREE_EARLY_TAS), $(eval $(call \
 	process_early_ta,$(out-dir)/ta/$(f).stripped.elf)))
 endif
+
+ifeq ($(CFG_EMBEDDED_SECURE_DT),y)
+ifneq ( $(firstword $(core-secure-dtb)),$(core-secure-dtb))
+$(error CFG_EMBEDDED_SECURE_DT expects a single DTS from CFG_SECURE_DTS)
+endif
+gensrcs-y += embedded_secure_dtb
+produce-embedded_secure_dtb = fdts/embedded_secure_dtb.c
+depends-embedded_secure_dtb = $(core-secure-dtb) scripts/ta_bin_to_c.py
+recipe-embedded_secure_dtb = scripts/bin_to_c.py \
+				--bin $(core-secure-dtb) \
+				--vname embedded_secure_dtb \
+				--out $(out-dir)/core/fdts/embedded_secure_dtb.c
+cleanfiles += $(out-dir)/core/fdts/embedded_secure_dtb.c
+endif

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -28,7 +28,7 @@ $(foreach f, $(CFG_IN_TREE_EARLY_TAS), $(eval $(call \
 endif
 
 ifeq ($(CFG_EMBEDDED_SECURE_DT),y)
-ifneq ( $(firstword $(core-secure-dtb)),$(core-secure-dtb))
+ifneq ($(firstword $(core-secure-dtb)),$(strip $(core-secure-dtb)))
 $(error CFG_EMBEDDED_SECURE_DT expects a single DTS from CFG_SECURE_DTS)
 endif
 gensrcs-y += embedded_secure_dtb

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -32,11 +32,11 @@ ifneq ( $(firstword $(core-secure-dtb)),$(core-secure-dtb))
 $(error CFG_EMBEDDED_SECURE_DT expects a single DTS from CFG_SECURE_DTS)
 endif
 gensrcs-y += embedded_secure_dtb
-produce-embedded_secure_dtb = fdts/embedded_secure_dtb.c
+produce-embedded_secure_dtb = dts/embedded_secure_dtb.c
 depends-embedded_secure_dtb = $(core-secure-dtb) scripts/ta_bin_to_c.py
 recipe-embedded_secure_dtb = scripts/bin_to_c.py \
 				--bin $(core-secure-dtb) \
 				--vname embedded_secure_dtb \
-				--out $(out-dir)/core/fdts/embedded_secure_dtb.c
-cleanfiles += $(out-dir)/core/fdts/embedded_secure_dtb.c
+				--out $(out-dir)/core/dts/embedded_secure_dtb.c
+cleanfiles += $(out-dir)/core/dts/embedded_secure_dtb.c
 endif

--- a/documentation/file_structure.md
+++ b/documentation/file_structure.md
@@ -15,15 +15,25 @@ Directory | Description
 Directory | Description
 :---------|:------------
 /arch	  | Architecture and platform specific files
+/include  | Header files of resources exported in the core
 /lib	  | Generic libraries that are likely to be replaced in a final product
 /mm	  | Generic memory management, currently empty
 /tee	  | Generic TEE files
+
+## Structure of /core/include
+Directory | Description
+:---------|:------------
+/crypto	  | Include files expoising API for /core/crypto files
+/drivers  | Include files expoising API for /core/drivers files
+/dt-bindings  | Include files for the device tree bindings
+/kernel	  | Include files expoising API for /core/kernel files
+/mm	  | Include files expoising memory management APIs for /core components
+/tee	  | Include files expoising API /core/tee files
 
 ## Structure of /core/arch
 Directory | Description
 :---------|:------------
 /arm	  | ARMv7 and Aarch32 specific architecture and platform specific files
-/user_mode| Linux used space specific files when debugging TEE Core as a user space process, only used for some development
 
 ## Structure of /core/arch/arm
 Directory | Description

--- a/documentation/file_structure.md
+++ b/documentation/file_structure.md
@@ -28,6 +28,7 @@ Directory | Description
 ## Structure of /core/arch/arm
 Directory | Description
 :---------|:------------
+/fdts	  | Device tree source files
 /include  | Include files used in rest of TEE core but not in any supporting libraries
 /kern	  | Low level and core parts of TEE Core
 /mm	  | Memory management

--- a/documentation/file_structure.md
+++ b/documentation/file_structure.md
@@ -23,12 +23,8 @@ Directory | Description
 ## Structure of /core/include
 Directory | Description
 :---------|:------------
-/crypto	  | Include files expoising API for /core/crypto files
-/drivers  | Include files expoising API for /core/drivers files
+/drivers  | Include files exposing API for /core/drivers files
 /dt-bindings  | Include files for the device tree bindings
-/kernel	  | Include files expoising API for /core/kernel files
-/mm	  | Include files expoising memory management APIs for /core components
-/tee	  | Include files expoising API /core/tee files
 
 ## Structure of /core/arch
 Directory | Description
@@ -38,7 +34,7 @@ Directory | Description
 ## Structure of /core/arch/arm
 Directory | Description
 :---------|:------------
-/fdts	  | Device tree source files
+/dts	  | Device tree source files
 /include  | Include files used in rest of TEE core but not in any supporting libraries
 /kern	  | Low level and core parts of TEE Core
 /mm	  | Memory management

--- a/documentation/optee_design.md
+++ b/documentation/optee_design.md
@@ -830,9 +830,9 @@ by early boot and passed to non secure world are the following:
 
 ## Embedded Secure Device Tree
 
-When OP-TEE core is built with `CFG_EMBEDDED_SECURE_DT=y` configuration
-directive `CFG_SECURE_DTS` shall provide a single DTS file name including
-the .dts extension, from which a device tree blob (DTB) image is generated
+When OP-TEE core is built with configuration directive `CFG_EMBEDDED_DTS`
+defined, the directive shall provide a single DTS file name (including
+its .dts extension) from which a device tree blob (DTB) image is generated
 and embedded in a read-only section of OP-TEE core.
 
 In this case, the device tree address passed to the OP-TEE entry point

--- a/documentation/optee_design.md
+++ b/documentation/optee_design.md
@@ -784,12 +784,13 @@ OP-TEE core can use the device tree format to inject platform configuration
 information during platform initialization and possibly some run time context.
 
 Device Tree technology allows to describe platforms from ASCII source files
-so-called DTS. These can be used to generate a platform description binary
-image, store it on the platform boot media and.
+so-called DTS files. These can be used to generate a platform description
+binary image embedded in the platform boot media for applying expected
+configuration settings during the platform initializations.
 
-This scheme releases design constrains on the OP-TEE core implementation as
-most of the platform specific HW can be tuned without modifying C source files
-or adding configuration directives in the build environments.
+This scheme relaxes design constrains on the OP-TEE core implementation as
+most of the platform specific hardware can be tuned without modifying C
+source files or adding configuration directives in the build environments.
 
 ## Secure and Non Secure Device Trees
 
@@ -805,12 +806,12 @@ benefit of OP-TEE secure OS and/or the non secure world.
 As one can see, there can be several device trees and some can be shared
 across the boot stages, the OP-TEE initialization being executed after
 early platform secure boot and before non secure companion execution.
-Obviously and the non secure world will not be able to access a device tree
+Obviously the non secure world will not be able to access a device tree
 image located on a secure memory which non secure world as no access to.
 
 ## Early boot device tree argument
 
-The OP-TEE core bootloader provides through arguments to OP-TEE core when it
+The OP-TEE core bootloader provides arguments to the OP-TEE core when it
 boots it. Among those, the physical memory base address of a device tree
 image accessible to OP-TEE core.
 
@@ -833,6 +834,9 @@ When OP-TEE core is built with `CFG_EMBEDDED_SECURE_DT=y` configuration
 directive `CFG_SECURE_DTS` shall provide a single DTS file name including
 the .dts extension, from which a device tree blob (DTB) image is generated
 and embedded in a read-only section of OP-TEE core.
+
+In this case, the device tree address passed to the OP-TEE entry point
+by the bootloader is ignored, only the embedded device tree is accessible.
 
 [crypto.md]: crypto.md
 [early_tas]: https://github.com/OP-TEE/optee_os/commit/d0c636148b3a

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -248,23 +248,16 @@ CFG_CORE_SANITIZE_KADDRESS ?= n
 # When CFG_DT is enabled core embeds the FDT library (libfdt) allowing DTB
 # image parsing from the core.
 #
-# When CFG_EMBEDDED_SECURE_DT is enabled, TEE core embeds a statically linked
-# device tree blob in a read-only pageable section of the core.
-#
-# When CFG_SECURE_DTS is defined, it is expected to provide the list of the base
-# name of the device tree source file for which a device tree blob is generated
+# When CFG_EMBEDDED_DTS is defined, it is expected to provide the base name
+# of the device tree source file for which a device tree blob is generated
 # when core is built.
 #
 # Note: When CFG_DT is enabled, the TEE _start function expects to find
 # the address of a Device Tree Blob (DTB) in register X2/R2 provided by
 # the early boot stage or value 0 if boot stage provides no DTB.
-ifeq ($(CFG_EMBEDDED_SECURE_DT),y)
+ifneq ($(CFG_EMBEDDED_DTS),)
 $(call force,CFG_DT,y)
-ifeq ($(CFG_SECURE_DTS),)
-$(error CFG_EMBEDDED_SECURE_DT expects CFG_SECURE_DTS defines platform DTS file)
 endif
-endif
-CFG_EMBEDDED_SECURE_DT ?= n
 CFG_DT ?= n
 
 # Maximum size of the Device Tree Blob, has to be large enough to allow

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -245,7 +245,7 @@ CFG_CORE_SANITIZE_KADDRESS ?= n
 
 # Device Tree support
 #
-# When CFG_DT is enabledn core embeds the FDT library (libfdt) allowing DTB
+# When CFG_DT is enabled core embeds the FDT library (libfdt) allowing DTB
 # image parsing from the core.
 #
 # When CFG_EMBEDDED_SECURE_DT is enabled, TEE core embeds a statically linked

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -244,10 +244,27 @@ CFG_CORE_SANITIZE_UNDEFINED ?= n
 CFG_CORE_SANITIZE_KADDRESS ?= n
 
 # Device Tree support
-# When enabled, the TEE _start function expects to find the address of a
-# Device Tree Blob (DTB) in register r2. The DT parsing code relies on
-# libfdt.  Currently only used to add the optee node and a reserved-memory
-# node for shared memory.
+#
+# When CFG_DT is enabledn core embeds the FDT library (libfdt) allowing DTB
+# image parsing from the core.
+#
+# When CFG_EMBEDDED_SECURE_DT is enabled, TEE core embeds a statically linked
+# device tree blob in a read-only pageable section of the core.
+#
+# When CFG_SECURE_DTS is defined, it is expected to provide the list of the base
+# name of the device tree source file for which a device tree blob is generated
+# when core is built.
+#
+# Note: When CFG_DT is enabled, the TEE _start function expects to find
+# the address of a Device Tree Blob (DTB) in register X2/R2 provided by
+# the early boot stage or value 0 if boot stage provides no DTB.
+ifeq ($(CFG_EMBEDDED_SECURE_DT),y)
+$(call force,CFG_DT,y)
+ifeq ($(CFG_SECURE_DTS),)
+$(error CFG_EMBEDDED_SECURE_DT expects CFG_SECURE_DTS defines platform DTS file)
+endif
+endif
+CFG_EMBEDDED_SECURE_DT ?= n
 CFG_DT ?= n
 
 # Maximum size of the Device Tree Blob, has to be large enough to allow

--- a/scripts/bin_to_c.py
+++ b/scripts/bin_to_c.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2018, Linaro Limited
+#
+
+import argparse
+import array
+import os
+import re
+
+
+def get_args():
+
+        parser = argparse.ArgumentParser(description='Converts a binary file '
+                                         'into C source file defining binary '
+                                         'data as a constant byte array.')
+
+        parser.add_argument('--bin', required=True,
+                            help='Path to the input binary file')
+
+        parser.add_argument('--vname', required=True,
+                            help='Variable name for the generated table in '
+                            'the output C source file.')
+
+        parser.add_argument('--out', required=True,
+                            help='Path for the generated C file')
+
+        return parser.parse_args()
+
+
+def main():
+
+        args = get_args()
+
+        with open(args.bin, 'rb') as indata:
+                bytes = indata.read()
+                size = len(bytes)
+
+        f = open(args.out, 'w')
+        f.write('/* Generated from ' + args.bin + ' by ' +
+                os.path.basename(__file__) + ' */\n\n')
+        f.write('#include <compiler.h>\n')
+        f.write('#include <stdint.h>\n')
+        f.write('__extension__ const uint8_t ' + args.vname + '[] ' +
+                ' __aligned(__alignof__(uint64_t)) = {\n')
+        i = 0
+        while i < size:
+                if i % 8 == 0:
+                        f.write('\t\t')
+                f.write('0x' + '{:02x}'.format(bytes[i]) + ',')
+                i = i + 1
+                if i % 8 == 0 or i == size:
+                        f.write('\n')
+                else:
+                        f.write(' ')
+        f.write('};\n')
+        f.close()
+
+if __name__ == "__main__":
+        main()


### PR DESCRIPTION
This serie introduces a way to use a secure device tree for the description of the platform.

The first change introduces a way to compile a DTS file into a DTB and embed it in a (pageable) read-only section of the TEE core.

The last changes update platform stm32mp1 with some device tree sources files the platform can embed and few changes to prepare use of the DT configuration information.

Later changes will introduce some stm32mp1 drivers and resources which configuration will be driven from the embedded built-in DTB.