### PR TITLE
lib.mk: centralize profiling flag (-pg)

### DIFF
--- a/lib/libmbedtls/sub.mk
+++ b/lib/libmbedtls/sub.mk
@@ -87,6 +87,3 @@ srcs-$(sm-$(ta-target)) += $(addprefix mbedtls/library/, $(SRCS_TLS))
 
 cflags-lib-y += -Wno-redundant-decls
 cflags-lib-y += -Wno-switch-default
-ifneq ($(sm),core) # User-mode
-cflags-lib-$(CFG_ULIBS_GPROF) += -pg
-endif

--- a/lib/libmpa/sub.mk
+++ b/lib/libmpa/sub.mk
@@ -1,9 +1,5 @@
 global-incdirs-y += include
 
-ifneq ($(sm),core) # User-mode
-cflags-lib-$(CFG_ULIBS_GPROF) += -pg
-endif
-
 srcs-y += mpa_misc.c
 cflags-remove-mpa_misc.c-y += -pedantic
 cflags-mpa_misc.c-y += -Wno-sign-compare

--- a/lib/libutee/sub.mk
+++ b/lib/libutee/sub.mk
@@ -15,5 +15,3 @@ srcs-y += tee_tcpudp_socket.c
 srcs-y += tee_socket_pta.c
 
 subdirs-y += arch/$(ARCH)
-
-cflags-lib-$(CFG_ULIBS_GPROF) += -pg

--- a/lib/libutils/sub.mk
+++ b/lib/libutils/sub.mk
@@ -1,6 +1,2 @@
 subdirs-$(CFG_LIBUTILS_WITH_ISOC) += isoc
 subdirs-y += ext
-
-ifneq ($(sm),core) # User-mode
-cflags-lib-$(CFG_ULIBS_GPROF) += -pg
-endif

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -13,6 +13,11 @@
 
 subdirs = $(libdir)
 include mk/subdir.mk
+ifneq ($(sm),core) # User-mode
+ifeq ($(CFG_ULIBS_GPROF),y)
+cflags-lib$(libname)-$(sm) += -pg
+endif
+endif
 include mk/compile.mk
 
 lib-libfile	 = $(out-dir)/$(base-prefix)$(libdir)/lib$(libname).a


### PR DESCRIPTION
Code cleanup, no functional change. This commit avoids the duplication of
the -pg flag in the library makefiles.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
