### PR TITLE
FDT compilation & CFG_EMBEDDED_DTS

### DIFF
--- a/core/sub.mk
+++ b/core/sub.mk
@@ -26,3 +26,18 @@ $(foreach f, $(EARLY_TA_PATHS), $(eval $(call process_early_ta,$(f))))
 $(foreach f, $(CFG_IN_TREE_EARLY_TAS), $(eval $(call \
 	process_early_ta,$(out-dir)/ta/$(f).stripped.elf)))
 endif
+
+ifeq ($(CFG_EMBED_DTB),y)
+core-embed-fdt-dts = $(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE)
+core-embed-fdt-dtb = $(out-dir)/$(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.dtb)
+core-embed-fdt-c = $(out-dir)/$(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.c)
+gensrcs-y += embedded_secure_dtb
+cleanfiles += $(core-embed-fdt-c)
+produce-embedded_secure_dtb = arch/$(ARCH)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.c)
+depends-embedded_secure_dtb = $(core-embed-fdt-dtb) scripts/ta_bin_to_c.py
+recipe-embedded_secure_dtb = scripts/bin_to_c.py \
+				--bin $(core-embed-fdt-dtb) \
+				--vname embedded_secure_dtb \
+				--out $(core-embed-fdt-c)
+$(eval $(call gen-dtb-file,$(core-embed-fdt-dts),$(core-embed-fdt-dtb)))
+endif

--- a/documentation/file_structure.md
+++ b/documentation/file_structure.md
@@ -28,6 +28,7 @@ Directory | Description
 ## Structure of /core/arch/arm
 Directory | Description
 :---------|:------------
+/dts	  | Device tree source files
 /include  | Include files used in rest of TEE core but not in any supporting libraries
 /kern	  | Low level and core parts of TEE Core
 /mm	  | Memory management

--- a/documentation/file_structure.md
+++ b/documentation/file_structure.md
@@ -15,15 +15,21 @@ Directory | Description
 Directory | Description
 :---------|:------------
 /arch	  | Architecture and platform specific files
+/include  | Header files of resources exported by the core
 /lib	  | Generic libraries that are likely to be replaced in a final product
 /mm	  | Generic memory management, currently empty
 /tee	  | Generic TEE files
+
+## Structure of /core/include
+Directory | Description
+:---------|:------------
+/drivers  | Include files exposing API for /core/drivers files
+/dt-bindings  | Include files for the device tree bindings
 
 ## Structure of /core/arch
 Directory | Description
 :---------|:------------
 /arm	  | ARMv7 and Aarch32 specific architecture and platform specific files
-/user_mode| Linux used space specific files when debugging TEE Core as a user space process, only used for some development
 
 ## Structure of /core/arch/arm
 Directory | Description

--- a/documentation/optee_design.md
+++ b/documentation/optee_design.md
@@ -15,6 +15,7 @@ OP-TEE design
 10. [Cryptographic abstraction layer](#10-cryptographic-abstraction-layer)
 11. [libutee](#11-libutee)
 12. [Trusted Applications](#12-trusted-applications)
+13. [Device Tree support](#13-device-tree-support)
 
 # 1. Introduction
 OP-TEE is a so called Trusted Execution Environment, in short a TEE, for ARM
@@ -776,6 +777,77 @@ consists of:
 | `uint16_t` | sig_size | size of the signature |
 | `uint8_t[hash_size]` | hash | Hash of the fields above and the `<ELF>` above |
 | `uint8_t[sig_size]` | signature | Signature of hash |
+
+# 13. Device Tree support
+
+OP-TEE core can use the device tree format to inject platform configuration
+information during platform initialization and possibly some run time contexts.
+
+Device Tree technology allows to describe platforms from ASCII source files
+so-called DTS files. These can be used to generate a platform description
+binary image, so-called DTB, embedded in the platform boot media for
+applying expected configuration settings during the platform initializations.
+
+This scheme relaxes design constraints on the OP-TEE core implementation as
+most of the platform specific hardware can be tuned without modifying C
+source files or adding configuration directives in the build environments.
+
+## Secure and Non-Secure Device Trees
+
+There can be several device trees embedded in the target system and some
+can be shared across the boot stages.
+
+* Boot loader stages may load a device tree structure in memory for all boot
+stage to get platform configuration from. If such device tree data are to be
+accessed by the non-secure world, they shall be located in non-secure memory.
+
+* Boot loader stages may load a device tree structure in secure memory for
+the benefit of the secure world only. Such device tree blob shall be located
+in secure memory.
+
+* OP-TEE core can also embedded a device tree structure to describe the
+platform.
+
+* Non-secure world can embed a device tree structure and/or rely on a device
+tree structure loaded by the secure world, being an early boot stage and/or
+OP-TEE core.
+
+Obviously the non-secure world will not be able to access a device tree
+image located on a secure memory which non-secure world as no access to.
+
+## Early boot device tree argument
+
+The bootloader provides arguments to the OP-TEE core when it
+boots it. Among those, the physical memory base address of a device tree
+image accessible to OP-TEE core.
+
+When OP-TEE core is built with `CFG_DT=y` this device tree is accessed by
+OP-TEE core to get some information: console configuration, main memory
+size.
+
+OP-TEE will also try to add the description of the OP-TEE resources for
+the non-secure world to properly communicate with OP-TEE. This assumes the
+image is located in non-secure memory.
+
+Modifications made by OP-TEE core on the non-secure device tree image provided
+by early boot and passed to non-secure world are the following:
+- Add an OP-TEE node if none found with the related invocation parameters.
+- Add a reserved memory node for the few memory areas that shall be reserved
+  to the secure world and non accessed by the non-secure world.
+- Add a PSCI description node if none found.
+
+Early boot DTB located in non-secure memory can be accessed by OP-TEE core
+only during its initialization, before non-secure world boots.
+
+## Embedded Secure Device Tree
+
+When OP-TEE core is built with configuration directive `CFG_EMBED_DTB=y`
+directive `CFG_EMBED_DTB_SOURCE_FILE` shall provide the relative path of the
+DTS file inside directory `core/arch/$(ARCH)/dts` from which a DTB is
+generated and embedded in a read-only section of OP-TEE core.
+
+In this case the device tree address passed to the OP-TEE entry point
+by the bootloader is ignored, only the embedded device tree is accessible.
 
 [crypto.md]: crypto.md
 [early_tas]: https://github.com/OP-TEE/optee_os/commit/d0c636148b3a

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -250,10 +250,25 @@ CFG_CORE_SANITIZE_UNDEFINED ?= n
 CFG_CORE_SANITIZE_KADDRESS ?= n
 
 # Device Tree support
-# When enabled, the TEE _start function expects to find the address of a
-# Device Tree Blob (DTB) in register r2. The DT parsing code relies on
-# libfdt.  Currently only used to add the optee node and a reserved-memory
-# node for shared memory.
+#
+# When CFG_DT is enabled core embeds the FDT library (libfdt) allowing
+# device tree blob (DTB) parsing from the core.
+#
+# When CFG_DT is enabled, the TEE _start function expects to find
+# the address of a DTB in register X2/R2 provided by the early boot stage
+# or value 0 if boot stage provides no DTB.
+#
+# When CFG_EMBED_DTB is enabled, CFG_EMBED_DTB_SOURCE_FILE shall define the
+# relative path of a DTS file located in core/arch/$(ARCH)/dts.
+# The DTS file is compiled into a DTB file which content is embedded in a
+# read-only section of the core.
+ifneq ($(strip $(CFG_EMBED_DTB_SOURCE_FILE)),)
+CFG_EMBED_DTB ?= y
+endif
+ifeq ($(CFG_EMBED_DTB),y)
+$(call force,CFG_DT,y)
+endif
+CFG_EMBED_DTB ?= n
 CFG_DT ?= n
 
 # Maximum size of the Device Tree Blob, has to be large enough to allow

--- a/scripts/bin_to_c.py
+++ b/scripts/bin_to_c.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2018, Linaro Limited
+#
+
+import argparse
+import array
+import os
+import re
+
+
+def get_args():
+
+        parser = argparse.ArgumentParser(description='Converts a binary file '
+                                         'into C source file defining binary '
+                                         'data as a constant byte array.')
+
+        parser.add_argument('--bin', required=True,
+                            help='Path to the input binary file')
+
+        parser.add_argument('--vname', required=True,
+                            help='Variable name for the generated table in '
+                            'the output C source file.')
+
+        parser.add_argument('--out', required=True,
+                            help='Path for the generated C file')
+
+        return parser.parse_args()
+
+
+def main():
+
+        args = get_args()
+
+        with open(args.bin, 'rb') as indata:
+                bytes = indata.read()
+                size = len(bytes)
+
+        f = open(args.out, 'w')
+        f.write('/* Generated from ' + args.bin + ' by ' +
+                os.path.basename(__file__) + ' */\n\n')
+        f.write('#include <compiler.h>\n')
+        f.write('#include <stdint.h>\n')
+        f.write('__extension__ const uint8_t ' + args.vname + '[] ' +
+                ' __aligned(__alignof__(uint64_t)) = {\n')
+        i = 0
+        while i < size:
+                if i % 8 == 0:
+                        f.write('\t\t')
+                f.write('0x' + '{:02x}'.format(bytes[i]) + ',')
+                i = i + 1
+                if i % 8 == 0 or i == size:
+                        f.write('\n')
+                else:
+                        f.write(' ')
+        f.write('};\n')
+        f.close()
+
+
+if __name__ == "__main__":
+        main()


### PR DESCRIPTION
This series introduces a way to use a secure device tree for the description of the platform.

* Add a helper in  mk/compile.mk for generating a DTB file from a DTS file.
* Introduce `CFG_EMBEDDED_DTS`: defines a DTS file from **core/arch/arm/dts/** that is embedded in a read-only section of the core and used as secure FDT reference for platform configuration.

This change is the redesign of the initial P-R https://github.com/OP-TEE/optee_os/pull/2653.