### PR TITLE
core: fix cookie handling issue

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -609,10 +609,13 @@ void __weak __thread_std_smc_entry(struct thread_smc_args *args)
 
 	if (args->a0 == OPTEE_SMC_RETURN_OK) {
 		struct thread_ctx *thr = threads + thread_get_id();
+		uint64_t cookie;
 
 		tee_fs_rpc_cache_clear(&thr->tsd);
 		if (!thread_prealloc_rpc_cache) {
-			thread_rpc_free_arg(mobj_get_cookie(thr->rpc_mobj));
+			cookie = mobj_get_cookie(thr->rpc_mobj);
+			if (cookie != MOBJ_INVALID_COOKIE)
+				thread_rpc_free_arg(cookie);
 			mobj_free(thr->rpc_mobj);
 			thr->rpc_arg = 0;
 			thr->rpc_mobj = NULL;


### PR DESCRIPTION
Commit cd278f78382b ("core: simplify shm cookie handling") introduces
cookie handling issue during return to normal world from standard smc
handler.

Issue: Cookie is not compared against MOBJ_INVALID_COOKIE before call
to thread_rpc_free_arg() api.

Fixes: cd278f78382b ("core: simplify shm cookie handling")
Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
