### PR TITLE
core: remove MOBJ_INVALID_COOKIE

### DIFF
--- a/core/arch/arm/include/mm/mobj.h
+++ b/core/arch/arm/include/mm/mobj.h
@@ -12,8 +12,6 @@
 #include <tee_api_types.h>
 #include <types_ext.h>
 
-#define MOBJ_INVALID_COOKIE	0xffffffffffffffff
-
 struct mobj {
 	const struct mobj_ops *ops;
 	size_t size;
@@ -91,7 +89,7 @@ static inline uint64_t mobj_get_cookie(struct mobj *mobj)
 	if (mobj && mobj->ops && mobj->ops->get_cookie)
 		return mobj->ops->get_cookie(mobj);
 
-	return MOBJ_INVALID_COOKIE;
+	return 0;
 }
 
 static inline bool mobj_is_nonsec(struct mobj *mobj)

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1396,7 +1396,7 @@ static bool set_rmem(struct optee_msg_param *param,
 	param->u.rmem.size = tpm->u.memref.size;
 	if (tpm->u.memref.mobj) {
 		param->u.rmem.shm_ref = mobj_get_cookie(tpm->u.memref.mobj);
-		if (param->u.rmem.shm_ref == MOBJ_INVALID_COOKIE)
+		if (!param->u.rmem.shm_ref)
 			return false;
 	} else {
 		param->u.rmem.shm_ref = 0;
@@ -1416,7 +1416,7 @@ static bool set_tmem(struct optee_msg_param *param,
 		      OPTEE_MSG_ATTR_TYPE_TMEM_INPUT;
 	if (mobj) {
 		shm_ref = mobj_get_cookie(mobj);
-		if (shm_ref == MOBJ_INVALID_COOKIE)
+		if (!shm_ref)
 			return false;
 		if (mobj_get_pa(mobj, tpm->u.memref.offs, 0, &pa))
 			return false;

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -498,7 +498,7 @@ static struct mobj *get_cmd_buffer(paddr_t parg, uint32_t *num_params)
 	*num_params = READ_ONCE(arg->num_params);
 	args_size = OPTEE_MSG_GET_ARG_SIZE(*num_params);
 
-	return mobj_shm_alloc(parg, args_size, MOBJ_INVALID_COOKIE);
+	return mobj_shm_alloc(parg, args_size, 0);
 }
 
 /*


### PR DESCRIPTION
Removes MOBJ_INVALID_COOKIE which resulted in an unexpected ABI change
against the normal world driver. Instead 0 is continued to be used as an
invalid/absent cookie value.

Reported-by: Sumit Garg <sumit.garg@linaro.org>
Fixes: cd278f78382b ("core: simplify shm cookie handling")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
