### PR TITLE
Master+optee overlay

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -485,6 +485,19 @@ static void reset_dt_references(void)
 	dt_blob_addr = NULL;
 }
 
+static int add_dt_path_subnode(void *fdt, const char *path, const char *subnode)
+{
+	int offs;
+
+	offs = fdt_path_offset(fdt, path);
+	if (offs < 0)
+		return -1;
+	offs = fdt_add_subnode(fdt, offs, subnode);
+	if (offs < 0)
+		return -1;
+	return offs;
+}
+
 static int add_optee_dt_node(void *fdt)
 {
 	int offs;

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -510,10 +510,7 @@ static int add_optee_dt_node(void *fdt)
 
 	offs = fdt_path_offset(fdt, "/firmware");
 	if (offs < 0) {
-		offs = fdt_path_offset(fdt, "/");
-		if (offs < 0)
-			return -1;
-		offs = fdt_add_subnode(fdt, offs, "firmware");
+		offs = add_dt_path_subnode(fdt, "/", "firmware");
 		if (offs < 0)
 			return -1;
 	}
@@ -546,10 +543,7 @@ static int dt_add_psci_node(void *fdt)
 		return 0;
 	}
 
-	offs = fdt_path_offset(fdt, "/");
-	if (offs < 0)
-		return -1;
-	offs = fdt_add_subnode(fdt, offs, "psci");
+	offs = add_dt_path_subnode(fdt, "/", "psci");
 	if (offs < 0)
 		return -1;
 	if (append_psci_compatible(fdt, offs, "arm,psci-1.0"))
@@ -682,10 +676,7 @@ static int add_res_mem_dt_node(void *fdt, const char *name, paddr_t pa,
 		if (len_size < 0)
 			return -1;
 	} else {
-		offs = fdt_path_offset(fdt, "/");
-		if (offs < 0)
-			return -1;
-		offs = fdt_add_subnode(fdt, offs, "reserved-memory");
+		offs = add_dt_path_subnode(fdt, "/", "reserved-memory");
 		if (offs < 0)
 			return -1;
 		ret = fdt_setprop_cell(fdt, offs, "#address-cells", addr_size);

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -76,6 +76,9 @@ KEEP_PAGER(sem_cpu_sync);
 #ifdef CFG_DT
 extern uint8_t embedded_secure_dtb[];
 static void *dt_blob_addr;
+#ifdef CFG_EXTERNAL_DTB_OVERLAY
+static int __dt_frag_id;
+#endif
 #endif
 
 #ifdef CFG_SECONDARY_INIT_CNTFRQ
@@ -484,6 +487,33 @@ static void reset_dt_references(void)
 	/* dt no more reached, reset pointer to invalid */
 	dt_blob_addr = NULL;
 }
+
+#ifdef CFG_EXTERNAL_DTB_OVERLAY
+static int add_dt_overlay_fragment(void *fdt, int ioffs)
+{
+	char frag[32];
+	int offs;
+	int ret;
+
+	snprintf(frag, sizeof(frag), "fragment@%d", __dt_frag_id);
+	offs = fdt_add_subnode(fdt, ioffs, frag);
+	if (offs < 0)
+		return offs;
+
+	__dt_frag_id += 1;
+
+	ret = fdt_setprop_string(fdt, offs, "target-path", "/");
+	if (ret < 0)
+		return -1;
+
+	return fdt_add_subnode(fdt, offs, "__overlay__");
+}
+#else
+static int add_dt_overlay_fragment(void *fdt __unused, int offs)
+{
+	return offs;
+}
+#endif /* CFG_EXTERNAL_DTB_OVERLAY */
 
 static int add_dt_path_subnode(void *fdt, const char *path, const char *subnode)
 {

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -522,6 +522,9 @@ static int add_dt_path_subnode(void *fdt, const char *path, const char *subnode)
 	offs = fdt_path_offset(fdt, path);
 	if (offs < 0)
 		return -1;
+	offs = add_dt_overlay_fragment(fdt, offs);
+	if (offs < 0)
+		return -1;
 	offs = fdt_add_subnode(fdt, offs, subnode);
 	if (offs < 0)
 		return -1;

--- a/documentation/optee_design.md
+++ b/documentation/optee_design.md
@@ -839,6 +839,27 @@ by early boot and passed to non-secure world are the following:
 Early boot DTB located in non-secure memory can be accessed by OP-TEE core
 only during its initialization, before non-secure world boots.
 
+## Early boot device tree overlay
+
+There are two possibilities for OP-TEE core to provide a device tree
+overlay to the non-secure world.
+
+* Append OP-TEE nodes to an existing DTB overlay located at CFG_DT_ADDR or
+  passed in arg2
+
+* Generate a new DTB overlay at CFG_DT_ADDR if and only if CFG_DT_ADDR does
+  not point to a valid DTB.
+
+A subsequent boot stage should merge the OP-TEE DTB overlay into another
+DTB.
+
+A typical bootflow for this would be
+
+ATF -> OP-TEE -> u-boot with u-boot merging the OP-TEE DTB overlay located
+at CFG_DT_ADDR into a DTB u-boot has loaded from elsewhere.
+
+This functionality is enabled when `CFG_EXTERNAL_DTB_OVERLAY=y`.
+
 ## Embedded Secure Device Tree
 
 When OP-TEE core is built with configuration directive `CFG_EMBED_DTB=y`

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -275,6 +275,16 @@ CFG_DT ?= n
 # editing of the supplied DTB.
 CFG_DTB_MAX_SIZE ?= 0x10000
 
+# Device Tree Overlay support.
+# This define enables support for an OP-TEE provided DTB overlay.
+# One of two modes is supported in this case:
+# 1. Append OP-TEE nodes to an existing DTB overlay located at CFG_DT_ADDR or
+#    passed in arg2
+# 2. Generate a new DTB overlay at CFG_DT_ADDR
+# A subsequent boot stage must then merge the generated overlay DTB into a main
+# DTB using the standard fdt_overlay_apply() method.
+CFG_EXTERNAL_DTB_OVERLAY ?= n
+
 # Enable core self tests and related pseudo TAs
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 


### PR DESCRIPTION
This pull request adds the ability for OPTEE to provide a DTB overlay to a subsequent boot stage.
We can either

1. Append to an existing DTB overlay located at CFG_DT_ADDR or passed in arg2
2. Generate a new DTB overlay at CFG_DT_ADDR

Providing a DT overlay means it is possible for OPTEE to provide internal dynamic data without requiring the DTB to already be in-memory.

Here is an example of merging an OPTEE provided device tree overlay into a main DTB image.

CFG_DT_ADDR = 0x82000000
CFG_DT_OVERLAY = y

u-boot:

=> load mmc 0:1 0x83000000 imx7s-warp.dtb
38564 bytes read in 10 ms (3.7 MiB/s)
=> fdt addr 0x83000000
=> fdt resize 0x1000

=> fdt print /firmware
libfdt fdt_path_offset() returned FDT_ERR_NOTFOUND

=> fdt print /psci
libfdt fdt_path_offset() returned FDT_ERR_NOTFOUND

=> fdt print /reserved-memory
```
reserved-memory {
        #address-cells = <0x00000001>;
        #size-cells = <0x00000001>;
        ranges;
        linux,cma {
                compatible = "shared-dma-pool";
                reusable;
                size = <0x02800000>;
                linux,cma-default;
        };
};

```
Now merge the DTB overlay @ 0x82000000

=> fdt apply 0x82000000
=> fdt print /firmware
```
firmware {
        optee {
                compatible = "linaro,optee-tz";
                method = "smc";
        };
```

=> fdt print /psci
```
psci {
        compatible = "arm,psci-1.0", "arm,psci-0.2", "arm,psci";
        method = "smc";
        cpu_suspend = <0x84000001>;
        cpu_off = <0x84000002>;
        cpu_on = <0x84000003>;
        sys_poweroff = <0x84000008>;
        sys_reset = <0x84000009>;
};
```
=> fdt print /reserved-memory
```
reserved-memory {
        #address-cells = <0x00000002>;
        #size-cells = <0x00000002>;
        ranges;
        optee@0x9fe00000 {
                reg = <0x00000000 0x9fe00000 0x00000000 0x00200000>;
                no-map;
        };
        linux,cma {
                compatible = "shared-dma-pool";
                reusable;
                size = <0x02800000>;
                linux,cma-default;
        };
};

```
The raw in-memory OPTEE DTB overlay looks like this:

=> fdt addr 0x82000000
=> fdt print /
```
/ {
        fragment@2 {
                target-path = "/";
                __overlay__ {
                        reserved-memory {
                                ranges;
                                #size-cells = <0x00000002>;
                                #address-cells = <0x00000002>;
                                optee@0x9fe00000 {
                                        no-map;
                                        reg = <0x00000000 0x9fe00000 0x00000000 0x00200000>;
                                };
                        };
                };
        };
        fragment@1 {
                target-path = "/";
                __overlay__ {
                        psci {
                                sys_reset = <0x84000009>;
                                sys_poweroff = <0x84000008>;
                                cpu_on = <0x84000003>;
                                cpu_off = <0x84000002>;
                                cpu_suspend = <0x84000001>;
                                method = "smc";
                                compatible = "arm,psci-1.0", "arm,psci-0.2", "arm,psci";
                        };
                };
        };
        fragment@0 {
                target-path = "/";
                __overlay__ {
                        firmware {
                                optee {
                                        method = "smc";
                                        compatible = "linaro,optee-tz";
                                };
                        };
                };
        };
};
```
Here is a trivial example of a DTB overlay passed from ATF that has been appended to.

=> fdt addr 0x82000000
=> fdt print /
```
/ {
        fragment@3 {
                target-path = "/";
                __overlay__ {
                        reserved-memory {
                                ranges;
                                #size-cells = <0x00000002>;
                                #address-cells = <0x00000002>;
                                optee@0x9fe00000 {
                                        no-map;
                                        reg = <0x00000000 0x9fe00000 0x00000000 0x00200000>;
                                };
                        };
                };
        };
        fragment@2 {
                target-path = "/";
                __overlay__ {
                        psci {
                                sys_reset = <0x84000009>;
                                sys_poweroff = <0x84000008>;
                                cpu_on = <0x84000003>;
                                cpu_off = <0x84000002>;
                                cpu_suspend = <0x84000001>;
                                method = "smc";
                                compatible = "arm,psci-1.0", "arm,psci-0.2", "arm,psci";
                        };
                };
        };
        fragment@1 {
                target-path = "/";
                __overlay__ {
                        firmware {
                                optee {
                                        method = "smc";
                                        compatible = "linaro,optee-tz";
                                };
                        };
                };
        };
        fragment@0 {
                target = "/";
                __overlay__ {
                        test-int-property = <0x0000002b>;
                };
        };
};

```