### PR TITLE
stm32mp1: release constraint on core count

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -3,8 +3,6 @@ PLATFORM_FLAVOR ?= stm32mp157c
 include core/arch/arm/cpu/cortex-a7.mk
 ta-targets = ta_arm32
 
-$(call force,CFG_TEE_CORE_NB_CORE,2)
-$(call force,CFG_ARM32_core,y)
 $(call force,CFG_BOOT_SECONDARY_REQUEST,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_GIC,y)
@@ -19,12 +17,13 @@ CFG_TZSRAM_START ?= 0x2ffc0000
 CFG_TZSRAM_SIZE  ?= 0x00040000
 CFG_TZDRAM_START ?= 0xfe000000
 CFG_TZDRAM_SIZE  ?= 0x01e00000
-CFG_SHMEM_SIZE   ?= 0x00200000
 CFG_SHMEM_START  ?= 0xffe00000
+CFG_SHMEM_SIZE   ?= 0x00200000
 
-CFG_WITH_PAGER		?= y
-CFG_WITH_LPAE		?= y
-CFG_WITH_STACK_CANARIES	?= y
+CFG_TEE_CORE_NB_CORE ?= 2
+CFG_WITH_PAGER ?= y
+CFG_WITH_LPAE ?= y
+CFG_WITH_STACK_CANARIES ?= y
 
 CFG_STM32_UART ?= y
 


### PR DESCRIPTION
Minor cleaning and allow CFG_TEE_CORE_NB_CORE to be set to 1.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
