### PR TITLE
core: console: secure/non secure chosen console

### DIFF
--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -43,10 +43,13 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry);
 struct ns_entry_context *generic_boot_core_hpen(void);
 #endif
 
-/* Returns DTB location: embedded DTB if enabled, otherwise external DTB */
+/* Returns embedded DTB if present, then external DTB if found, then NULL */
 void *get_dt(void);
 
 /* Returns embedded DTB location if present, otherwise NULL */
 void *get_embedded_dt(void);
+
+/* Returns external DTB if present, otherwise NULL */
+void *get_external_dt(void);
 
 #endif /* KERNEL_GENERIC_BOOT_H */

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -8,6 +8,8 @@
 #include <initcall.h>
 #include <types_ext.h>
 
+extern uint8_t embedded_secure_dtb[];
+
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 unsigned long cpu_on_handler(unsigned long a0, unsigned long a1);
 struct thread_vector_table *
@@ -41,6 +43,10 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry);
 struct ns_entry_context *generic_boot_core_hpen(void);
 #endif
 
+/* Returns DTB location: embedded DTB if enabled, otherwise external DTB */
 void *get_dt(void);
+
+/* Returns embedded DTB location if present, otherwise NULL */
+void *get_embedded_dt(void);
 
 #endif /* KERNEL_GENERIC_BOOT_H */

--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -41,6 +41,6 @@ int generic_boot_core_release(size_t core_idx, paddr_t entry);
 struct ns_entry_context *generic_boot_core_hpen(void);
 #endif
 
-void *get_dt_blob(void);
+void *get_dt(void);
 
 #endif /* KERNEL_GENERIC_BOOT_H */

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -475,6 +475,16 @@ static void init_runtime(unsigned long pageable_part __unused)
 }
 #endif
 
+void *get_dt(void)
+{
+	void *fdt = get_embedded_dt();
+
+	if (!fdt)
+		fdt = get_external_dt();
+
+	return fdt;
+}
+
 #if defined(CFG_EMBED_DTB)
 void *get_embedded_dt(void)
 {
@@ -498,8 +508,8 @@ void *get_embedded_dt(void)
 }
 #endif /*CFG_EMBED_DTB*/
 
-#if defined(CFG_DT) && !defined(CFG_EMBED_DTB)
-void *get_dt(void)
+#if defined(CFG_DT)
+void *get_external_dt(void)
 {
 	assert(cpu_mmu_enabled());
 	return external_dt.blob;
@@ -507,7 +517,7 @@ void *get_dt(void)
 
 static void release_external_dt(void)
 {
-	/* dt no more reached, reset pointer to invalid */
+	/* External DTB no more reached, reset pointer to invalid */
 	external_dt.blob = NULL;
 }
 
@@ -934,23 +944,12 @@ static void update_external_dt(void)
 		panic();
 	}
 }
-#endif /*CFG_DT && !CFG_EMBED_DTB*/
-
-#if defined(CFG_DT) && defined(CFG_EMBED_DTB)
-void *get_dt(void)
-{
-	return get_embedded_dt();
-}
-#endif
-
-#ifndef CFG_DT
-void *get_dt(void)
+#else /*CFG_DT*/
+void *get_external_dt(void)
 {
 	return NULL;
 }
-#endif
 
-#if !defined(CFG_DT) || defined(CFG_EMBED_DTB)
 static void release_external_dt(void)
 {
 }
@@ -968,8 +967,7 @@ static struct core_mmu_phys_mem *get_memory(void *fdt __unused,
 {
 	return NULL;
 }
-
-#endif /*!CFG_DT || CFG_EMBED_DTB*/
+#endif /*!CFG_DT*/
 
 static void discover_nsec_memory(void)
 {

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -1008,9 +1008,9 @@ static void init_primary_helper(unsigned long pageable_part,
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
 	init_external_dt(fdt);
+	discover_nsec_memory();
 	update_external_dt();
 	configure_console_from_dt();
-	discover_nsec_memory();
 
 	IMSG("OP-TEE version: %s", core_v_str);
 

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -477,7 +477,7 @@ static void init_runtime(unsigned long pageable_part __unused)
 #endif
 
 #if defined(CFG_DT) && !defined(CFG_EMBED_DTB)
-void *get_dt_blob(void)
+void *get_dt(void)
 {
 	assert(cpu_mmu_enabled());
 	return dt_desc.blob;
@@ -915,7 +915,7 @@ static void update_fdt(void)
 #endif /*CFG_DT && !CFG_EMBED_DTB*/
 
 #if defined(CFG_DT) && defined(CFG_EMBED_DTB)
-void *get_dt_blob(void)
+void *get_dt(void)
 {
 	assert(cpu_mmu_enabled());
 
@@ -931,7 +931,7 @@ void *get_dt_blob(void)
 #endif
 
 #ifndef CFG_DT
-void *get_dt_blob(void)
+void *get_dt(void)
 {
 	return NULL;
 }
@@ -962,7 +962,7 @@ static void discover_nsec_memory(void)
 {
 	struct core_mmu_phys_mem *mem;
 	size_t nelems;
-	void *fdt = get_dt_blob();
+	void *fdt = get_dt();
 
 	if (fdt) {
 		mem = get_memory(fdt, &nelems);

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -102,7 +102,7 @@ static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)
 	};
 #endif
 
-	fdt = get_dt_blob();
+	fdt = get_dt();
 	if (!fdt) {
 		EMSG("No DTB\n");
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -57,7 +57,7 @@ void configure_console_from_dt(void)
 	char *stdout_data;
 	const char *uart;
 	const char *parms = NULL;
-	void *fdt = get_dt_blob();
+	void *fdt = get_dt();
 	int offs;
 	char *p;
 


### PR DESCRIPTION
Makes chosen console selection more flexible being probed
from either secure-chosen node or chosen node, from
either secure embedded DTB or non-secure external DTB.

Secure-chosen node has precedence over chosen node. Chosen console
from the secure DTB as precedence over chosen console defined by
the non-secure device tree.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
