### PR TITLE
Update typedefs.checkpatch

### DIFF
--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -1,2 +1,31 @@
-TEE_Result
+# Note: please keep the entries in this file sorted in reverse alphabetical
+# order (sort -r)
+TEE_Whence
 TEE_UUID
+TEE_Time
+TEE_TASessionHandle
+TEE_Session
+TEE_SESessionHandle
+TEE_SEServiceHandle
+TEE_SEReaderProperties
+TEE_SEReaderHandle
+TEE_SEChannelHandle
+TEE_SEAID
+TEE_Result
+TEE_PropSetHandle
+TEE_Param
+TEE_OperationMode
+TEE_OperationInfoMultiple
+TEE_OperationInfoKey
+TEE_OperationInfo
+TEE_OperationHandle
+TEE_ObjectType
+TEE_ObjectInfo
+TEE_ObjectHandle
+TEE_ObjectEnumHandle
+TEE_Identity
+TEE_ErrorOrigin
+TEE_BigIntFMMContext
+TEE_BigIntFMM
+TEE_BigInt
+TEE_Attribute


### PR DESCRIPTION
Adds missing typedefs from lib/libutee/include/tee_api_types.h to
typedefs.checkpatch. This fixes checkpatch errors such as:

 ERROR: need consistent spacing around '*' (ctx:WxV)
 #807: FILE: lib/libutee/tee_api_arith_mpi.c:773:
 +void TEE_BigIntInitFMMContext(TEE_BigIntFMMContext *context __unused,
                                                     ^
The file is sorted in reverse alphabetical order, otherwise checkpatch
would ignore some entries that have a common radix (such as TEE_BigInt/
TEE_BigIntFMM/TEE_BigIntFMMContext). Not sure if it is expected or if it
will be fixed in upstream checkpatch at some point.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
