### PR TITLE
core: framework to register PM callbacks

### DIFF
--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -91,4 +91,7 @@ paddr_t virt_to_phys(void *va);
  */
 vaddr_t core_mmu_get_va(paddr_t pa, enum teecore_memtypes type);
 
+/* Return true if @va relates to a unpaged section else false */
+bool is_unpaged(void *va);
+
 #endif /* CORE_MEMPROT_H */

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1767,7 +1767,7 @@ static void check_pa_matches_va(void *va, paddr_t pa)
 		}
 	}
 #ifdef CFG_WITH_PAGER
-	if (v >= TEE_TEXT_VA_START && v < get_linear_map_end()) {
+	if (is_unpaged(va)) {
 		if (v != pa)
 			panic("issue in linear address space");
 		return;
@@ -1944,3 +1944,17 @@ vaddr_t core_mmu_get_va(paddr_t pa, enum teecore_memtypes type)
 
 	return (vaddr_t)pa;
 }
+
+#ifdef CFG_WITH_PAGER
+bool is_unpaged(void *va)
+{
+	vaddr_t v = (vaddr_t)va;
+
+	return v >= TEE_TEXT_VA_START && v < get_linear_map_end();
+}
+#else
+bool is_unpaged(void *va __unused)
+{
+	return true;
+}
+#endif

--- a/core/include/kernel/pm.h
+++ b/core/include/kernel/pm.h
@@ -1,0 +1,146 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+
+#ifndef __KERNEL_PM_H
+#define __KERNEL_PM_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * Platform hints on targeted power state. Hints are stored in a 32bit
+ * unsigned value. Lower bits defines generic resource bit flags. Higher
+ * bits stores a platform specific value specific platform driver may
+ * understand. Registered callbacks may choose to use or ignore these hints.
+ *
+ * PM_HINT_CLOCK_STATE - When set clock shall be suspended/restored
+ * PM_HINT_POWER_STATE - When set device power shall be suspended/restored
+ * PM_HINT_IO_STATE - When set IO pins shall be suspended/restored
+ * PM_HINT_CONTEXT_STATE - When set the full context be suspended/restored
+ * PM_HINT_PLATFORM_STATE_MASK - Bit mask reserved for platform specific hints
+ * PM_HINT_PLATFORM_STATE_SHIFT - LSBit position of platform specific hints mask
+ */
+#define PM_HINT_CLOCK_STATE		BIT(0)
+#define PM_HINT_POWER_STATE		BIT(1)
+#define PM_HINT_IO_STATE		BIT(2)
+#define PM_HINT_CONTEXT_STATE		BIT(3)
+#define PM_HINT_PLATFORM_STATE_MASK	GENMASK_32(31, 16)
+#define PM_HINT_PLATFORM_STATE_SHIFT	16
+
+/*
+ * PM_OP_SUSPEND: platform is suspending to a target low power state
+ * PM_OP_RESUME: platform is resuming from low power state
+ */
+enum pm_op {
+	PM_OP_SUSPEND = 0,
+	PM_OP_RESUME = 1,
+};
+
+/*
+ * Registered callbacks are called the ordering directives specified
+ * by the PM_CB_ORDER_* value. Driver ordered callbacks at suspended
+ * first/resumed last. Core service ordered callbacks are suspended
+ * last/resumed first.
+ */
+enum pm_callback_order {
+	PM_CB_ORDER_DRIVER = 0,
+	PM_CB_ORDER_CORE_SERVICE,
+	PM_CB_ORDER_MAX
+};
+
+#define PM_CALLBACK_HANDLE_INITIALIZER(_callback, _handle, _order)	\
+		(struct pm_callback_handle){				\
+			.callback = (_callback),			\
+			.handle = (_handle),				\
+			.order = (_order),				\
+		}
+
+#define PM_CALLBACK_GET_HANDLE(pm_handle)	((pm_handle)->handle)
+
+/*
+ * Drivers and services can register a callback function for the platform
+ * suspend and resume sequences. A private address handle can be registered
+ * with the callback and retrieved from the callback. Callback can be
+ * registered with a specific call order as defined per PM_CB_ORDER_*.
+ *
+ * Callback shall return an error if failing to complete target transition.
+ * This information may be used by the platform to resume a platform on
+ * non-fatal failure to suspend.
+ *
+ * Callback implementations should ensure their functions belong to unpaged
+ * memory sections (see KEEP_PAGER()) since the callback is likely to be
+ * called from an unpaged execution context.
+ *
+ * Power Mamagement callback functions API:
+ *
+ * TEE_Result (*callback)(enum pm_op op,
+ *			  unsigned int pm_hint,
+ *			  const struct pm_callback_handle *pm_handle);
+ *
+ * @op - Target operation: either PM_SUSPEND or PM_RESUME
+ * @pm_hint - Hints on power state platform suspends to /resumes from.
+ *		PM_STATE_HINT_* defines the supported values.
+ * @pm_handle - Reference to the struct pm_callback_handle related to to
+ *		registered callback. Callback can retrieve the registered
+ *		private handle with PM_CALLBACK_GET_HANDLE().
+ *
+ * Return a TEE_Result compliant return code
+ */
+/*
+ * struct pm_callback_handle store the callback registration directives.
+ *
+ * @callback - Registered callback function
+ * @handle - Registered private handler for the callback
+ * @order - Registered callback call order priority (PM_CB_ORDER_*)
+ */
+struct pm_callback_handle {
+	/* Set by the caller when registering a callback */
+	TEE_Result (*callback)(enum pm_op op, uint32_t pm_hint,
+			       const struct pm_callback_handle *pm_handle);
+	void *handle;
+	uint8_t order;
+	/* Set by the system according to execution context */
+	uint8_t flags;
+};
+
+/*
+ * Register a callback for suspend/resume sequence
+ * Refer to struct pm_callback_handle for description of the callbacks
+ * API and the registration directives.
+ *
+ * @pm_handle: Reference callback registration directives
+ */
+void register_pm_cb(struct pm_callback_handle *pm_handle);
+
+/*
+ * Register a driver callback for generic suspend/resume.
+ * Refer to struct pm_callback_handle for description of the callbacks
+ * API.
+ *
+ * @callback: Registered callback function
+ * @handle: Registered private handle argument for the callback
+ */
+static inline void register_pm_driver_cb(
+		TEE_Result (*callback)(
+				enum pm_op op, uint32_t pm_hint,
+				const struct pm_callback_handle *pm_handle),
+		void *handle)
+{
+	register_pm_cb(&PM_CALLBACK_HANDLE_INITIALIZER(callback, handle,
+						       PM_CB_ORDER_DRIVER));
+}
+
+/*
+ * Request call to registered PM callbacks
+ *
+ * @op: Either PM_OP_SUSPEND or PM_OP_RESUME
+ * @pm_hint: Hint (PM_HINT_*) on state the platform suspends to/resumes from.
+ *
+ * Return a TEE_Result compliant status
+ */
+TEE_Result pm_change_state(enum pm_op op, uint32_t pm_hint);
+
+#endif /*__KERNEL_PM_H*/

--- a/core/kernel/pm.c
+++ b/core/kernel/pm.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+
+#include <keep.h>
+#include <kernel/panic.h>
+#include <kernel/pm.h>
+#include <mm/core_memprot.h>
+#include <string.h>
+#include <types_ext.h>
+
+#define PM_FLAG_SUSPENDED	BIT(0)
+
+static struct pm_callback_handle *pm_cb_ref;
+static size_t pm_cb_count;
+
+static void verify_cb_args(struct pm_callback_handle *pm_hdl)
+{
+	if (is_unpaged((void *)(vaddr_t)pm_change_state) &&
+	    (!is_unpaged((void *)(vaddr_t)pm_hdl->callback) ||
+	     (pm_hdl->handle && !is_unpaged(pm_hdl->handle)))) {
+		EMSG("PM callbacks mandates unpaged arguments: %p %p",
+		     (void *)(vaddr_t)pm_hdl->callback, pm_hdl->handle);
+		panic();
+	}
+}
+
+void register_pm_cb(struct pm_callback_handle *pm_hdl)
+{
+	size_t count = pm_cb_count;
+	struct pm_callback_handle *ref;
+
+	verify_cb_args(pm_hdl);
+
+	ref = realloc(pm_cb_ref, sizeof(*ref) * (count + 1));
+	if (!ref)
+		panic();
+
+	ref[count] = *pm_hdl;
+	ref[count].flags = 0;
+
+	pm_cb_count = count + 1;
+	pm_cb_ref = ref;
+}
+
+static TEE_Result call_callbacks(enum pm_op op, uint32_t pm_hint,
+				 enum pm_callback_order order)
+{
+	struct pm_callback_handle *hdl;
+	size_t n;
+	TEE_Result res;
+
+	for (n = 0, hdl = pm_cb_ref; n < pm_cb_count; n++, hdl++) {
+		if (hdl->order != order ||
+		    (hdl->flags & PM_FLAG_SUSPENDED) == (op == PM_OP_SUSPEND))
+			continue;
+
+		res = hdl->callback(op, pm_hint, hdl);
+		if (res)
+			return res;
+
+		if (op == PM_OP_SUSPEND)
+			hdl->flags |= PM_FLAG_SUSPENDED;
+		else
+			hdl->flags &= ~PM_FLAG_SUSPENDED;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pm_change_state(enum pm_op op, uint32_t pm_hint)
+{
+	enum pm_callback_order cnt;
+	TEE_Result res;
+
+	switch (op) {
+	case PM_OP_SUSPEND:
+		for (cnt = PM_CB_ORDER_DRIVER; cnt < PM_CB_ORDER_MAX; cnt++) {
+			res = call_callbacks(op, pm_hint, cnt);
+			if (res)
+				return res;
+		}
+		break;
+	case PM_OP_RESUME:
+		for (cnt = PM_CB_ORDER_MAX; cnt > PM_CB_ORDER_DRIVER; cnt--) {
+			res = call_callbacks(op, pm_hint, cnt - 1);
+			if (res)
+				return res;
+		}
+		break;
+	default:
+		panic();
+	}
+
+	return TEE_SUCCESS;
+}

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -3,6 +3,7 @@ cflags-remove-asan.c-y += $(cflags_kasan)
 srcs-y += assert.c
 srcs-y += console.c
 srcs-$(CFG_DT) += dt.c
+srcs-y += pm.c
 srcs-y += handle.c
 srcs-y += interrupt.c
 srcs-$(CFG_LOCKDEP) += lockdep.c


### PR DESCRIPTION
This RFC is related to P-R https://github.com/OP-TEE/optee_os/pull/2683.
This proposes a framework for runtime registration of PM callback services.

Description (commit comment)
> Introduce a framework for power management callback registering.
Any core component can register a callback function that shall be
called with a cookie argument for suspend/resume sequence.
>
> Callbacks are related to a callback level. It defines the callbacks
call ordering, allowing core low level drivers (as clocks or the GIC)
to be suspended after all drivers and resume before these.
>
> Callbacks are related to a target subsystem identified with an
opaque ID. When suspending (or resuming) a target subsystem, only the
related callbacks are called. It is up to the platform to register
callbacks with appropriate subsystem IDs and to call suspend/resume
sequences for the target subsystems.
