### PR TITLE
Timeout functions based on Arm CNTP

### DIFF
--- a/core/arch/arm/include/kernel/delay.h
+++ b/core/arch/arm/include/kernel/delay.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
+ * Copyright (c) 2018, Linaro Limited
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
  *
@@ -29,7 +30,26 @@
 #ifndef __KERNEL_DELAY_H
 #define __KERNEL_DELAY_H
 
+#include <arm.h>
+#include <stdbool.h>
+#include <stdint.h>
+
 void udelay(uint32_t us);
 void mdelay(uint32_t ms);
+
+static inline uint64_t arm_cnt_us2cnt(uint32_t us)
+{
+	return ((uint64_t)us * (uint64_t)read_cntfrq()) / 1000000ULL;
+}
+
+static inline uint64_t timeout_init_us(uint32_t us)
+{
+	return read_cntpct() + arm_cnt_us2cnt(us);
+}
+
+static inline bool timeout_elapsed(uint64_t expire)
+{
+	return read_cntpct() > expire;
+}
 
 #endif

--- a/core/arch/arm/kernel/delay.c
+++ b/core/arch/arm/kernel/delay.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
+ * Copyright (c) 2018, Linaro Limited
  * Copyright (C) 2017, Fuzhou Rockchip Electronics Co., Ltd.
  * All rights reserved.
  *
@@ -26,17 +27,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <arm.h>
 #include <kernel/delay.h>
 
 void udelay(uint32_t us)
 {
-	uint64_t start, target;
+	uint64_t target = timeout_init_us(us);
 
-	start = read_cntpct();
-	target = ((uint64_t)read_cntfrq() * us) / 1000000ULL;
-
-	while (read_cntpct() - start <= target)
+	while (!timeout_elapsed(target))
 		;
 }
 


### PR DESCRIPTION
This P-R proposes timeout functions and an example of their use on the stm32_uart `putc()` and `flush()` function used for the platform console.