### PR TITLE
stm32mp1: update boot image header script tool

### DIFF
--- a/core/arch/arm/plat-stm32mp1/link.mk
+++ b/core/arch/arm/plat-stm32mp1/link.mk
@@ -11,14 +11,14 @@ endef
 all: $(link-out-dir)/tee-header_v2.stm32
 cleanfiles += $(link-out-dir)/tee-header_v2.stm32
 $(link-out-dir)/tee-header_v2.stm32: $(link-out-dir)/tee-header_v2.bin
-	$(stm32image_cmd) --source $< --dest $@
+	$(stm32image_cmd) --source $< --dest $@ --bintype 0x20
 
 all: $(link-out-dir)/tee-pager_v2.stm32
 cleanfiles += $(link-out-dir)/tee-pager_v2.stm32
 $(link-out-dir)/tee-pager_v2.stm32: $(link-out-dir)/tee-pager_v2.bin
-	$(stm32image_cmd) --source $< --dest $@
+	$(stm32image_cmd) --source $< --dest $@ --bintype 0x21
 
 all: $(link-out-dir)/tee-pageable_v2.stm32
 cleanfiles += $(link-out-dir)/tee-pageable_v2.stm32
 $(link-out-dir)/tee-pageable_v2.stm32: $(link-out-dir)/tee-pageable_v2.bin
-	$(stm32image_cmd) --source $< --dest $@
+	$(stm32image_cmd) --source $< --dest $@ --bintype 0x22

--- a/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
+++ b/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
@@ -35,7 +35,7 @@ def stm32image_checksum(dest_fd, sizedest):
         return csum
 
 
-def stm32image_set_header(dest_fd, load, entry):
+def stm32image_set_header(dest_fd, load, entry, bintype):
         sizedest = get_size(dest_fd)
 
         checksum = stm32image_checksum(dest_fd, sizedest)
@@ -68,11 +68,12 @@ def stm32image_set_header(dest_fd, load, entry):
         dest_fd.write(b'\x00' * 64)
 
         # Padding
-        dest_fd.write(b'\x00' * 84)
+        dest_fd.write(b'\x00' * 83)
+        dest_fd.write(struct.pack('<B', bintype))
         dest_fd.close()
 
 
-def stm32image_create_header_file(source, dest, load, entry):
+def stm32image_create_header_file(source, dest, load, entry, bintype):
         dest_fd = open(dest, 'w+b')
         src_fd = open(source, 'rb')
 
@@ -86,7 +87,7 @@ def stm32image_create_header_file(source, dest, load, entry):
 
         src_fd.close()
 
-        stm32image_set_header(dest_fd, load, entry)
+        stm32image_set_header(dest_fd, load, entry, bintype)
 
         dest_fd.close()
 
@@ -113,6 +114,10 @@ def get_args():
                             required=True, type=int_parse,
                             help='Entry point')
 
+        parser.add_argument('--bintype',
+                            required=True, type=int_parse,
+                            help='Binary identification')
+
         return parser.parse_args()
 
 
@@ -122,11 +127,13 @@ def main():
         destination_file = args.dest
         load_address = args.load
         entry_point = args.entry
+        binary_type = args.bintype
 
         stm32image_create_header_file(source_file,
                                       destination_file,
                                       load_address,
-                                      entry_point)
+                                      entry_point,
+                                      binary_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduce the binary image type information to the STM32 header
used for OP-TEE boot images.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
