### PR TITLE
core: arm64: pager: make sure __thread_enter_user_mode is unpaged

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -317,6 +317,7 @@ FUNC __thread_enter_user_mode , :
 	store_xregs sp, THREAD_CORE_LOCAL_X0, 0, 1
 	b eret_to_el0
 END_FUNC __thread_enter_user_mode
+KEEP_PAGER __thread_enter_user_mode
 
 /*
  * void thread_unwind_user_mode(uint32_t ret, uint32_t exit_status0,


### PR DESCRIPTION
__thread_enter_user_mode() cannot be paged out, because the pager cannot
be invoked to restore any faulting code page after SP has been switched to
use SP_EL1. At this point, a synchronous exception would take the CPU to
the 0x200 offset in the exception vector, which corresponds to
[workaround_]el1_sync_sp1 and is an error-catching infinite loop. This
explains the behavior described in [1].

Add the requisite KEEP_PAGER so that the function is kept in the unpaged
area.

Fixes: [1] https://github.com/OP-TEE/optee_os/issues/2684
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
