### PR TITLE
core: fix dependency in embedded DTB build

### DIFF
--- a/core/sub.mk
+++ b/core/sub.mk
@@ -34,7 +34,7 @@ core-embed-fdt-c = $(out-dir)/$(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.
 gensrcs-y += embedded_secure_dtb
 cleanfiles += $(core-embed-fdt-c)
 produce-embedded_secure_dtb = arch/$(ARCH)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.c)
-depends-embedded_secure_dtb = $(core-embed-fdt-dtb) scripts/ta_bin_to_c.py
+depends-embedded_secure_dtb = $(core-embed-fdt-dtb) scripts/bin_to_c.py
 recipe-embedded_secure_dtb = scripts/bin_to_c.py \
 				--bin $(core-embed-fdt-dtb) \
 				--vname embedded_secure_dtb \


### PR DESCRIPTION
Correct the name of the script used to embed a DTB in the core
when added to the core dependency list.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
