### PR TITLE
core: always save non-secure vfp state

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -296,14 +296,6 @@ static void thread_lazy_save_ns_vfp(void)
 	struct thread_ctx *thr = threads + thread_get_id();
 
 	thr->vfp_state.ns_saved = false;
-#if defined(CFG_WITH_ARM_TRUSTED_FW)
-	/*
-	 * ARM TF saves and restores CPACR_EL1, so we must assume NS world
-	 * uses VFP and always preserve the register file when secure world
-	 * is about to use it
-	 */
-	thr->vfp_state.ns_force_save = true;
-#endif
 	vfp_lazy_save_state_init(&thr->vfp_state.ns);
 #endif /*CFG_WITH_VFP*/
 }
@@ -1094,7 +1086,7 @@ uint32_t thread_kernel_enable_vfp(void)
 
 	if (!thr->vfp_state.ns_saved) {
 		vfp_lazy_save_state_final(&thr->vfp_state.ns,
-					  thr->vfp_state.ns_force_save);
+					  true /*force_save*/);
 		thr->vfp_state.ns_saved = true;
 	} else if (thr->vfp_state.sec_lazy_saved &&
 		   !thr->vfp_state.sec_saved) {
@@ -1167,7 +1159,7 @@ void thread_user_enable_vfp(struct thread_user_vfp_state *uvfp)
 
 	if (!thr->vfp_state.ns_saved) {
 		vfp_lazy_save_state_final(&thr->vfp_state.ns,
-					  thr->vfp_state.ns_force_save);
+					  true /*force_save*/);
 		thr->vfp_state.ns_saved = true;
 	} else if (tuv && uvfp != tuv) {
 		if (tuv->lazy_saved && !tuv->saved) {

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -66,7 +66,6 @@ struct thread_user_mode_rec {
 #ifdef CFG_WITH_VFP
 struct thread_vfp_state {
 	bool ns_saved;
-	bool ns_force_save; /* Save to reg even if VFP was not enabled */
 	bool sec_saved;
 	bool sec_lazy_saved;
 	struct vfp_state ns;


### PR DESCRIPTION
Prior to this patch the non-secure VFP state was only saved when it
seemed necessary based on control registers.

To make sure that non-secure VFP state isn't corrupted always save the
entire register file before modifying it. This is now the same behavior
on both ARMv8-A and ARMv7-A platforms.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
