### PR TITLE
core: io_{set|clr|clrset}bits32() helpers

### DIFF
--- a/core/include/io.h
+++ b/core/include/io.h
@@ -94,4 +94,30 @@ static inline void put_be16(void *p, uint16_t val)
 	*(uint16_t *)p = TEE_U16_TO_BIG_ENDIAN(val);
 }
 
+/*
+ * Set and clear bits helpers.
+ *
+ * @addr is the address of the memory cell accessed
+ * @set_mask represents the bit mask of the bit(s) to set, aka set to 1
+ * @clear_mask represents the bit mask of the bit(s) to clear, aka reset to 0
+ *
+ * io_clrsetbits32() clears then sets the target bits in this order. If a bit
+ * position is defined by both @set_mask and @clear_mask, the bit will be set.
+ */
+static inline void io_setbits32(uintptr_t addr, uint32_t set_mask)
+{
+	write32(read32(addr) | set_mask, addr);
+}
+
+static inline void io_clrbits32(uintptr_t addr, uint32_t clear_mask)
+{
+	write32(read32(addr) & ~clear_mask, addr);
+}
+
+static inline void io_clrsetbits32(uintptr_t addr, uint32_t clear_mask,
+				   uint32_t set_mask)
+{
+	write32((read32(addr) & ~clear_mask) | set_mask, addr);
+}
+
 #endif /*IO_H*/


### PR DESCRIPTION
Introduce new iomem util functions to set, clear or set and clear
bit masks in peripheral interfaces.

io_setbits32(addr, mask) sets the bits enabled in mask at address.
io_clrbits32(addr, mask) clears the bits enabled in mask.
io_clrsetbits32(addr, clear_mask, set_mask) clears the bits enabled in
clear_mask and sets the bits enabled in set_mask.

These functions are more friendly in instruction blocks to sets and
clears bitmasks in peripheral registers. They provide a more readable
implementation than playing with io_mask32() for the equivalent
sequence, for example, extracted from a DDR controller driver:

```C
   /* IOs powering down (PUBL registers) */

   io_setbits32(ddrphy_base + DDRPHYC_ACIOCR, DDRPHYC_ACIOCR_ACPDD);
   io_setbits_32(ddrphy_base + DDRPHYC_ACIOCR, DDRPHYC_ACIOCR_ACPDR);

   io_clrsetbits32(ddrphy_base + DDRPHYC_ACIOCR,
                   DDRPHYC_ACIOCR_CKPDD_MASK, DDRPHYC_ACIOCR_CKPDD_0);

   io_clrsetbits32(ddrphy_base + DDRPHYC_ACIOCR,
                   DDRPHYC_ACIOCR_CKPDR_MASK, DDRPHYC_ACIOCR_CKPDR_0);

   io_clrsetbits32(ddrphy_base + DDRPHYC_ACIOCR,
                   DDRPHYC_ACIOCR_CSPDD_MASK, DDRPHYC_ACIOCR_CSPDD_0);
```
