### PR TITLE
PM callbacks for the GIC

### DIFF
--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -7,12 +7,15 @@
 #include <arm.h>
 #include <assert.h>
 #include <drivers/gic.h>
+#include <io.h>
 #include <keep.h>
 #include <kernel/interrupt.h>
 #include <kernel/panic.h>
+#include <kernel/pm.h>
+#include <malloc.h>
 #include <util.h>
-#include <io.h>
 #include <trace.h>
+#include <string.h>
 
 /* Offsets from gic.gicc_base */
 #define GICC_CTLR		(0x000)
@@ -32,8 +35,10 @@
 #define GICD_ICENABLER(n)	(0x180 + (n) * 4)
 #define GICD_ISPENDR(n)		(0x200 + (n) * 4)
 #define GICD_ICPENDR(n)		(0x280 + (n) * 4)
+#define GICD_ISACTIVER(n)	(0x300 + (n) * 4)
 #define GICD_IPRIORITYR(n)	(0x400 + (n) * 4)
 #define GICD_ITARGETSR(n)	(0x800 + (n) * 4)
+#define GICD_ICFGR(n)		(0xC00 + (n) * 4)
 #define GICD_SGIR		(0xF00)
 
 #define GICD_CTLR_ENABLEGRP0	(1 << 0)
@@ -73,6 +78,19 @@ static void gic_op_raise_sgi(struct itr_chip *chip, size_t it,
 			uint8_t cpu_mask);
 static void gic_op_set_affinity(struct itr_chip *chip, size_t it,
 			uint8_t cpu_mask);
+
+#if defined(CFG_ARM_GIC_PM)
+static void gic_pm_add_it(struct gic_data *gd, unsigned int it);
+static void gic_pm_register(struct gic_data *gd);
+#else
+static void gic_pm_add_it(struct gic_data *gd __unused,
+			  unsigned int it __unused)
+{
+}
+static void gic_pm_register(struct gic_data *gd __unused)
+{
+}
+#endif
 
 static const struct itr_ops gic_ops = {
 	.add = gic_op_add,
@@ -210,6 +228,8 @@ void gic_init_base_addr(struct gic_data *gd, vaddr_t gicc_base __maybe_unused,
 	gd->gicd_base = gicd_base;
 	gd->max_it = probe_max_it(gicc_base, gicd_base);
 	gd->chip.ops = &gic_ops;
+
+	gic_pm_register(gd);
 }
 
 static void gic_it_add(struct gic_data *gd, size_t it)
@@ -417,6 +437,8 @@ static void gic_op_add(struct itr_chip *chip, size_t it,
 	/* Set the CPU mask to deliver interrupts to any online core */
 	gic_it_set_cpu_mask(gd, it, 0xff);
 	gic_it_set_prio(gd, it, 0x1);
+
+	gic_pm_add_it(gd, it);
 }
 
 static void gic_op_enable(struct itr_chip *chip, size_t it)
@@ -462,6 +484,7 @@ static void gic_op_raise_sgi(struct itr_chip *chip, size_t it,
 	else
 		gic_it_raise_sgi(gd, it, cpu_mask, 0);
 }
+
 static void gic_op_set_affinity(struct itr_chip *chip, size_t it,
 			uint8_t cpu_mask)
 {
@@ -472,3 +495,136 @@ static void gic_op_set_affinity(struct itr_chip *chip, size_t it,
 
 	gic_it_set_cpu_mask(gd, it, cpu_mask);
 }
+
+#if defined(CFG_ARM_GIC_PM)
+/*
+ * Save/restore interrupts registered from the gic_op_add_it() handler
+ */
+#define IT_PM_GPOUP1_BIT	BIT(0)
+#define IT_PM_ENABLE_BIT	BIT(1)
+#define IT_PM_PENDING_BIT	BIT(2)
+#define IT_PM_ACTIVE_BIT	BIT(3)
+#define IT_PM_CONFIG_MASK	GENMASK_32(1, 0)
+
+/*
+ * @it - interrupt ID/number
+ * @flags - bitflag IT_PM_*_BIT
+ * @iprio - 8bit prio from IPRIORITYR
+ * @itarget - 8bit target from ITARGETR
+ * @icfg - 2bit configuration from ICFGR and IT_PM_CONFIG_MASK
+ */
+struct gic_it_pm {
+	uint16_t it;
+	uint8_t flags;
+	uint8_t iprio;
+	uint8_t itarget;
+	uint8_t icfg;
+};
+
+static void gic_pm_add_it(struct gic_data *gd, unsigned int it)
+{
+	struct gic_pm *pm = &gd->pm;
+
+	pm->count++;
+	pm->pm_cfg = realloc(pm->pm_cfg, pm->count * sizeof(*pm->pm_cfg));
+	if (!pm->pm_cfg)
+		panic();
+
+	pm->pm_cfg[pm->count - 1] = (struct gic_it_pm){ .it = it };
+}
+
+static void gic_save_it(struct gic_data *gd, struct gic_it_pm *pm)
+{
+	unsigned int it = pm->it;
+	size_t idx;
+	uint32_t bit_mask = BIT(it % NUM_INTS_PER_REG);
+	uint32_t shift2 = it % (NUM_INTS_PER_REG / 2);
+	uint32_t shift8 = it % (NUM_INTS_PER_REG / 8);
+	uint32_t data32;
+
+	pm->flags = 0;
+	idx = it / NUM_INTS_PER_REG;
+
+	if (read32(gd->gicd_base + GICD_IGROUPR(idx)) & bit_mask)
+		pm->flags |= IT_PM_GPOUP1_BIT;
+	if (read32(gd->gicd_base + GICD_ISENABLER(idx)) & bit_mask)
+		pm->flags |= IT_PM_ENABLE_BIT;
+	if (read32(gd->gicd_base + GICD_ISPENDR(idx)) & bit_mask)
+		pm->flags |= IT_PM_PENDING_BIT;
+	if (read32(gd->gicd_base + GICD_ISACTIVER(idx)) & bit_mask)
+		pm->flags |= IT_PM_ACTIVE_BIT;
+
+	idx = (8 * it) / NUM_INTS_PER_REG;
+
+	data32 = read32(gd->gicd_base + GICD_IPRIORITYR(idx)) >> shift8;
+	pm->iprio = (uint8_t)data32;
+
+	data32 = read32(gd->gicd_base + GICD_ITARGETSR(idx)) >> shift8;
+	pm->itarget = (uint8_t)data32;
+
+	/* Note: ICFGR is RAO for SPIs and PPIs */
+	idx = (2 * it) / NUM_INTS_PER_REG;
+	data32 = read32(gd->gicd_base + GICD_ICFGR(idx)) >> shift2;
+	pm->icfg = (uint8_t)data32 & IT_PM_CONFIG_MASK;
+}
+
+static void gic_restore_it(struct gic_data *gd, struct gic_it_pm *pm)
+{
+	unsigned int it = pm->it;
+	size_t idx;
+	uint32_t mask = BIT(it % NUM_INTS_PER_REG);
+	uint32_t shift2 = it % (NUM_INTS_PER_REG / 2);
+	uint32_t shift8 = it % (NUM_INTS_PER_REG / 8);
+
+	idx = it / NUM_INTS_PER_REG;
+
+	io_mask32(gd->gicd_base + GICD_IGROUPR(idx),
+		  (pm->flags & IT_PM_GPOUP1_BIT) ? mask : 0, mask);
+
+	io_mask32(gd->gicd_base + GICD_ISENABLER(idx),
+		  (pm->flags & IT_PM_ENABLE_BIT) ? mask : 0, mask);
+
+	io_mask32(gd->gicd_base + GICD_ISPENDR(idx),
+		  (pm->flags & IT_PM_PENDING_BIT) ? mask : 0, mask);
+
+	io_mask32(gd->gicd_base + GICD_ISACTIVER(idx),
+		  (pm->flags & IT_PM_ACTIVE_BIT) ? mask : 0, mask);
+
+	idx = (8 * it) / NUM_INTS_PER_REG;
+
+	io_mask32(gd->gicd_base + GICD_IPRIORITYR(idx),
+		  (uint32_t)pm->iprio << shift8, UINT8_MAX << shift8);
+
+	io_mask32(gd->gicd_base + GICD_ITARGETSR(idx),
+		  (uint32_t)pm->itarget << shift8, UINT8_MAX << shift8);
+
+	/* Note: ICFGR is WI for SPIs and PPIs */
+	idx = (2 * it) / NUM_INTS_PER_REG;
+	io_mask32(gd->gicd_base + GICD_ICFGR(idx),
+		  (uint32_t)pm->icfg << shift2, IT_PM_CONFIG_MASK << shift2);
+}
+
+static TEE_Result gic_pm(enum pm_op op, unsigned int pm_hint __unused,
+			  const struct pm_callback_handle *pm_handle)
+{
+	void (*sequence)(struct gic_data *gd, struct gic_it_pm *pm);
+	struct gic_it_pm *cfg;
+	unsigned int n;
+	struct gic_data *gd =
+			(struct gic_data *)PM_CALLBACK_GET_HANDLE(pm_handle);
+	struct gic_pm *pm = &gd->pm;
+
+	sequence = (op == PM_OP_SUSPEND) ? gic_save_it : gic_restore_it;
+
+	for (n = 0, cfg = pm->pm_cfg; n < pm->count; n++, cfg++)
+		sequence(gd, cfg);
+
+	return TEE_SUCCESS;
+}
+KEEP_PAGER(gic_pm);
+
+static void gic_pm_register(struct gic_data *gd)
+{
+	register_pm_core_service_cb(gic_pm, gd);
+}
+#endif /*CFG_ARM_GIC_PM*/

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -12,11 +12,25 @@
 #define GIC_DIST_REG_SIZE	0x10000
 #define GIC_CPU_REG_SIZE	0x10000
 
+/*
+ * Save and restore some interrupts configuration during low power sequences.
+ * This is used on platforms using OP-TEE secure monitor.
+ */
+struct gic_it_pm;
+
+struct gic_pm {
+	struct gic_it_pm *pm_cfg;
+	size_t count;
+};
+
 struct gic_data {
 	vaddr_t gicc_base;
 	vaddr_t gicd_base;
 	size_t max_it;
 	struct itr_chip chip;
+#if defined(CFG_ARM_GIC_PM)
+	struct gic_pm pm;
+#endif
 };
 
 /*

--- a/core/include/kernel/pm.h
+++ b/core/include/kernel/pm.h
@@ -134,6 +134,24 @@ static inline void register_pm_driver_cb(
 }
 
 /*
+ * Register a core service callback for generic suspend/resume.
+ * Refer to struct pm_callback_handle for description of the callbacks
+ * API.
+ *
+ * @callback: Registered callback function
+ * @handle: Registered private handle argument for the callback
+ */
+static inline void register_pm_core_service_cb(
+		TEE_Result (*callback)(
+				enum pm_op op, uint32_t pm_hint,
+				const struct pm_callback_handle *pm_handle),
+		void *handle)
+{
+	register_pm_cb(&PM_CALLBACK_HANDLE_INITIALIZER(callback, handle,
+						PM_CB_ORDER_CORE_SERVICE));
+}
+
+/*
  * Request call to registered PM callbacks
  *
  * @op: Either PM_OP_SUSPEND or PM_OP_RESUME

--- a/documentation/interrupt_handling.md
+++ b/documentation/interrupt_handling.md
@@ -197,6 +197,10 @@ world (SCR_NS is set) or in secure world (SCR_NS is cleared). When the
 secure monitor is active (ARMv8 EL3 or ARMv7 Monitor mode) FIQ is masked.
 FIQ reception in the two different states is described below.
 
+ GIC driver registers to the PM suspend/resume framework when
+`CFG_ARM_GIC_PM=y`. This allows to preserve secure interrupts configuration
+across platform power transitions.
+
 ## 4.1. Deliver FIQ to secure world when SCR_NS is set
 
 When the monitor gets an FIQ exception it:


### PR DESCRIPTION
This P-R proposes PM callbacks to restore GIC state when resuming from standby and GIC hardware context is lost. 

`CFG_ARM_GIC_PM=y` enables GIC PM support.
For each interrupt registered trough the IT add operator, the interrupt configuration is saved when suspending and restore at resume.

This P-R Also introduces helper `register_pm_core_service_cb()`.