### PR TITLE
stm32mp1: uart consoles

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -33,9 +33,14 @@ CFG_TEE_CORE_NB_CORE ?= 2
 CFG_WITH_PAGER ?= y
 CFG_WITH_LPAE ?= y
 CFG_WITH_STACK_CANARIES ?= y
+CFG_MMAP_REGIONS ?= 23
 
 CFG_STM32_UART ?= y
 
-# Default enable the test facitilites
+# Default enable some test facitilites
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STATS ?= y
+# Non-secure UART for the output console
+CFG_WITH_NSEC_UARTS ?= y
+# UART instance used for early console (0 disables early console)
+CFG_STM32_EARLY_CONSOLE_UART ?= 4

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -26,7 +26,7 @@ register_phys_mem(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, CONSOLE_UART_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, TAMP_BASE, SMALL_PAGE_SIZE);
 
-static struct console_pdata console_data;
+static struct stm32_uart_pdata console_data;
 
 static void main_fiq(void);
 

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -11,11 +11,13 @@
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT			32
 
+/* SoC interface registers base address */
 #define GIC_BASE			0xa0021000ul
 #define RCC_BASE			0x50000000
 #define TAMP_BASE			0x5c00a000
-
 #define UART4_BASE			0x40010000
+
+/* Console configuration */
 #define STM32MP1_DEBUG_USART_BASE	UART4_BASE
 #define GIC_SPI_UART4			84
 

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -15,7 +15,14 @@
 #define GIC_BASE			0xa0021000ul
 #define RCC_BASE			0x50000000
 #define TAMP_BASE			0x5c00a000
+#define UART1_BASE			0x5c000000
+#define UART2_BASE			0x4000e000
+#define UART3_BASE			0x4000f000
 #define UART4_BASE			0x40010000
+#define UART5_BASE			0x40011000
+#define UART6_BASE			0x44003000
+#define UART7_BASE			0x40018000
+#define UART8_BASE			0x40019000
 
 /* Console configuration */
 #define STM32MP1_DEBUG_USART_BASE	UART4_BASE
@@ -39,5 +46,11 @@
 
 /* TAMP resources */
 #define TAMP_BKP_REGISTER_OFF		0x100
+
+/* USART/UART resources */
+#define USART1_BASE			UART1_BASE
+#define USART2_BASE			UART2_BASE
+#define USART3_BASE			UART3_BASE
+#define USART6_BASE			UART6_BASE
 
 #endif /*PLATFORM_CONFIG_H*/

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -4,6 +4,7 @@
  */
 
 #include <compiler.h>
+#include <console.h>
 #include <drivers/serial.h>
 #include <drivers/stm32_uart.h>
 #include <io.h>
@@ -40,8 +41,9 @@
 
 static vaddr_t loc_chip_to_base(struct serial_chip *chip)
 {
-	struct console_pdata *pd =
-		container_of(chip, struct console_pdata, chip);
+	struct stm32_uart_pdata *pd;
+
+	pd = container_of(chip, struct stm32_uart_pdata, chip);
 
 	return io_pa_or_va(&pd->base);
 }
@@ -85,17 +87,17 @@ static int loc_getchar(struct serial_chip *chip)
 	return read32(base + UART_REG_RDR) & 0xff;
 }
 
-static const struct serial_ops serial_ops = {
+static const struct serial_ops stm32_uart_serial_ops = {
 	.flush = loc_flush,
 	.putc = loc_putc,
 	.have_rx_data = loc_have_rx_data,
 	.getchar = loc_getchar,
 
 };
-KEEP_PAGER(serial_ops);
+KEEP_PAGER(stm32_uart_serial_ops);
 
-void stm32_uart_init(struct console_pdata *pd, vaddr_t base)
+void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base)
 {
 	pd->base.pa = base;
-	pd->chip.ops = &serial_ops;
+	pd->chip.ops = &stm32_uart_serial_ops;
 }

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -7,6 +7,8 @@
 #define CONSOLE_H
 
 #include <compiler.h>
+#include <tee_api_types.h>
+
 
 void console_init(void);
 void console_putc(int ch);
@@ -16,6 +18,32 @@ struct serial_chip;
 void register_serial_console(struct serial_chip *chip);
 
 #ifdef CFG_DT
+/*
+ * Get console info from a reacheable DTB. Check the embedded DTB and fall
+ * back to the external DTB.
+ *
+ * If the DTB does not specify a chosen (or secure-chosen) node, we assume
+ * DTB does not provide specific console directive. Early console may remain.
+ * If the DTB does not specify any console in the chosen (or secure-chosen)
+ * node, we assume there is no console. Early console would be disabled.
+ *
+ * @fdt_out: Output DTB address where console directive is found
+ * @offs_out: Output offset in the DTB where console directive is found
+ * @path_out: Output string configuration of the console from in the DTB
+ * @params_out: Output console parameters found from the DTB
+ *
+ * Return a TEE_Result compliant return value
+ *
+ */
+TEE_Result get_console_node_from_dt(void **fdt_out, int *offs_out,
+				    const char **path_out,
+				    const char **params_out);
+
+/*
+ * Check if the /secure-chosen or /chosen node in the DT contains an
+ * stdout-path value for which we have a compatible driver. If so, switch
+ * the console to this device.
+ */
 void configure_console_from_dt(void);
 #else
 static inline void configure_console_from_dt(void)

--- a/core/include/drivers/stm32_uart.h
+++ b/core/include/drivers/stm32_uart.h
@@ -12,8 +12,27 @@ struct stm32_uart_pdata {
 	struct io_pa_va base;
 	struct serial_chip chip;
 	bool secure;
+	unsigned int clock;
 };
 
+/*
+ * stm32_uart_init - Initialize a UART serial chip and base address
+ * @pd: Output initialized UART platform data
+ * @base: UART interface physical base address
+ */
 void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base);
+
+/*
+ * stm32_uart_init_from_dt_node - Initialize a UART instance from a DTB node
+ * @fdt: DTB base address
+ * @node: Target node offset in the DTB
+ * Returns an alloced (malloc) and inited UART platform data on success or NULL
+ *
+ * This function gets a STM32 UART configuration directives from a DTB node
+ * and initializes a UART driver instance.
+ * When the DTB specifies that the device is disabled, the function returns
+ * NULL. Other issues panic the sequence.
+ */
+struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node);
 
 #endif /*__STM32_UART_H__*/

--- a/core/include/drivers/stm32_uart.h
+++ b/core/include/drivers/stm32_uart.h
@@ -8,11 +8,12 @@
 
 #include <drivers/serial.h>
 
-struct console_pdata {
+struct stm32_uart_pdata {
 	struct io_pa_va base;
 	struct serial_chip chip;
+	bool secure;
 };
 
-void stm32_uart_init(struct console_pdata *pd, vaddr_t base);
+void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base);
 
 #endif /*__STM32_UART_H__*/


### PR DESCRIPTION
This P-R brings allows stm32mp1 to get the OP-TEE console configuration from the devicetree.
This P-R also provides some configuration means for the early console.

This P-R proposes 2 generic changes in the core:
* Factorize a sequence from `configure_console_from_dt()` to allow an external console driver to get the console DT info through function `get_console_node_from_dt()`.
* Introduce `_fdt_fill_device_info()` to factorize extraction of some generic device DT properties as the status, the registers address, a clock ID.