### PR TITLE
scripts: use python2 explicitly

### DIFF
--- a/scripts/gen_hashed_bin.py
+++ b/scripts/gen_hashed_bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2014-2017, Linaro Limited

--- a/scripts/gen_ld_sects.py
+++ b/scripts/gen_ld_sects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2017, Linaro Limited


### PR DESCRIPTION
Bot gen_hashed_bin.py and gen_ld_sects.py are python2-only scripts,
but theirs shabang suggests to use default system python, which
can be python3 on some systems (like Arch linux for example).

Thus, it is better to explicitly tell which python is to use.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
