### PR TITLE
core: syscall_storage_obj_rename(): fix handling of .rename() return …

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -569,7 +569,7 @@ TEE_Result syscall_storage_obj_rename(unsigned long obj, void *object_id,
 
 	/* move */
 	res = fops->rename(o->pobj, po, false /* no overwrite */);
-	if (res == TEE_ERROR_GENERIC)
+	if (res)
 		goto exit;
 
 	res = tee_pobj_rename(o->pobj, object_id, object_id_len);


### PR DESCRIPTION
…status

Any error returned by fops->rename() should be reflected by
syscall_storage_obj_rename(). There is no reason why errors other than
TEE_ERROR_GENERIC should be ignored.

Fixes the following test case: create two persistent objects (o1 and o2),
close o1, rename o2 to the name of o1. TEE_RenamePersistentObject() should
return TEE_ERROR_ACCESS_CONFLICT, but TEE_SUCCESS is returned instead.

Fixes: https://github.com/OP-TEE/optee_os/issues/2707
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
