### PR TITLE
[RFC] TA ASLR

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -395,8 +395,8 @@ static void show_elfs(struct user_ta_ctx *utc)
 	size_t __maybe_unused idx = 0;
 
 	TAILQ_FOREACH(elf, &utc->elfs, link)
-		EMSG_RAW(" [%zu] %pUl @ %#" PRIxVA, idx++,
-			 (void *)&elf->uuid, elf->load_addr);
+		EMSG_RAW(" [%zu] %pUl @ 0x%0*" PRIxVA, idx++,
+			 (void *)&elf->uuid, PRIxVA_WIDTH, elf->load_addr);
 }
 
 static void user_ta_dump_state(struct tee_ta_ctx *ctx)
@@ -407,11 +407,11 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 	char desc[13];
 	size_t n = 0;
 
-	EMSG_RAW(" arch: %s  load address: %#" PRIxVA " ctx-idr: %d",
-		 utc->is_32bit ? "arm" : "aarch64", utc->load_addr,
-		 utc->vm_info->asid);
-	EMSG_RAW(" stack: 0x%" PRIxVA " %zu",
-		 utc->stack_addr, utc->mobj_stack->size);
+	EMSG_RAW(" arch: %s  load address: 0x%0*" PRIxVA " ctx-idr: %d",
+		 utc->is_32bit ? "arm" : "aarch64", PRIxVA_WIDTH,
+		 utc->load_addr, utc->vm_info->asid);
+	EMSG_RAW(" stack: 0x%0*" PRIxVA " %zu",
+		 PRIxVA_WIDTH, utc->stack_addr, utc->mobj_stack->size);
 	TAILQ_FOREACH(r, &utc->vm_info->regions, link) {
 		paddr_t pa = 0;
 
@@ -420,9 +420,10 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 
 		mattr_perm_to_str(flags, sizeof(flags), r->attr);
 		describe_region(utc, r->va, r->size, desc, sizeof(desc));
-		EMSG_RAW(" region %zu: va %#" PRIxVA " pa %#" PRIxPA
-			 " size %#zx flags %s %s",
-			 n, r->va, pa, r->size, flags, desc);
+		EMSG_RAW(" region %zu: va 0x%0*" PRIxVA " pa 0x%0*" PRIxPA
+			 " size 0x%08zx flags %s %s",
+			 n, PRIxVA_WIDTH, r->va, PRIxPA_WIDTH, pa, r->size,
+			 flags, desc);
 		n++;
 	}
 	show_elfs(utc);

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -692,11 +692,14 @@ static TEE_Result add_deps(struct user_ta_ctx *utc __unused,
 #ifdef CFG_TA_ASLR
 static size_t aslr_offset(size_t min, size_t max)
 {
-	uint32_t rnd = 0;
+	uint32_t rnd32 = 0;
+	size_t rnd = 0;
 
-	if (crypto_rng_read(&rnd, sizeof(rnd)))
+	if (crypto_rng_read(&rnd32, sizeof(rnd)))
 		return 0;
-	return (min + rnd % max) * CORE_MMU_USER_CODE_SIZE;
+	if (max > min)
+		rnd = rnd32 % (max - min);
+	return (min + rnd) * CORE_MMU_USER_CODE_SIZE;
 }
 #else
 static size_t aslr_offset(size_t min, size_t max)

--- a/lib/libutils/ext/include/types_ext.h
+++ b/lib/libutils/ext/include/types_ext.h
@@ -31,4 +31,7 @@ typedef uintptr_t paddr_size_t;
 #define __SIZEOF_PADDR__	__SIZEOF_POINTER__
 #endif
 
+#define PRIxVA_WIDTH ((int)(sizeof(vaddr_t) * 2))
+#define PRIxPA_WIDTH ((int)(sizeof(paddr_t) * 2))
+
 #endif /* TYPES_EXT_H */

--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -218,8 +218,6 @@ static int __printf(2, 3) append(struct strbuf *sbuf, const char *fmt, ...)
 	return 1;
 }
 
-#define PRIxVA_WIDTH ((int)(sizeof(vaddr_t)*2))
-
 void dhex_dump(const char *function, int line, int level,
 	       const void *buf, int len)
 {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -214,10 +214,10 @@ CFG_WITH_USER_TA ?= y
 # ASLR makes the exploitation of memory corruption vulnerabilities more
 # difficult.
 CFG_TA_ASLR ?= y
-# How much ASLR may shift each region (in pages). Each region is randomly shifted
-# by an integer number of pages comprised between 0 and this value. Bigger
-# values result in more VA space being consummed, but also require more physical
-# memory for the page tables.
+# How much ASLR may shift each region (in pages). Each region is randomly
+# shifted by an integer number of pages comprised between 0 and this value.
+# Bigger values result in more VA space being consumed and also require more
+# physical memory for the page tables.
 CFG_TA_ASLR_MAX_OFFSET_PAGES ?= 32
 
 # Load user TAs from the REE filesystem via tee-supplicant

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -205,6 +205,21 @@ CFG_WITH_USER_TA ?= y
 # By default, in-tree TAs are built using the first architecture specified in
 # $(ta-targets).
 
+# Address Space Layout Randomization for user-mode Trusted Applications
+#
+# When this flag is enabled, the ELF loader will introduce random offsets
+# when mapping the user stack and each ELF file used by the application (main
+# executable and dynamic libraries). Note that the heap is currently part of
+# the TA's main executable; its base address will therefore be randomized too.
+# ASLR makes the exploitation of memory corruption vulnerabilities more
+# difficult.
+CFG_TA_ASLR ?= y
+# How much ASLR may shift each region (in pages). Each region is randomly shifted
+# by an integer number of pages comprised between 0 and this value. Bigger
+# values result in more VA space being consummed, but also require more physical
+# memory for the page tables.
+CFG_TA_ASLR_MAX_OFFSET_PAGES ?= 32
+
 # Load user TAs from the REE filesystem via tee-supplicant
 # There is currently no other alternative, but you may want to disable this in
 # case you implement your own TA store


### PR DESCRIPTION
This is a RFC for a quite simple implementation of some Address Space Layout Randomization for TAs.

This code simply introduces random offsets when mapping the user stack and the ELF binaries (by default, between 0 and 32 pages). I tried more drastic values so that the addresses would be harder to guess, but I'm hitting limitations quite rapidly on QEMU Aarch32 at least. It seems the page tables can't grow enough to support the mappings (too many entries? not sure).

xtest 1019 is a good test case to illustrate this PR because it causes a panic dump so the mappings can be seen, and the TA uses a dynamic library.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
