### PR TITLE
ta: avb: RSA public key validation

### DIFF
--- a/ta/avb/include/ta_avb.h
+++ b/ta/avb/include/ta_avb.h
@@ -61,4 +61,26 @@
  */
 #define TA_AVB_CMD_WRITE_PERSIST_VALUE	5
 
+/*
+ * Validates a public key data.
+ *
+ * A key data provided from NW is serialized in this sequence:
+ * +--------------+----------------------------+
+ * | Name         | Number of bytes            |
+ * +--------------+----------------------------+
+ * | key_num_bits | 4 ("modulus size in bits") |
+ * | n0inv        | 4 ("-1/n[0] (mod 2^32)")   |
+ * | n            | key_num_bits / 8 (modulus) |
+ * | rr           | key_num_bits / 8 (R^2)     |
+ * +--------------+----------------------------+
+ *
+ * Public exponent is assumed to always be 65537.
+ *
+ * So, for example, for 4096 bit(default one) key representation we
+ * need 1032 bytes (4 + 4 + 512 + 512) to store these values.
+ *
+ * in	params[0].memref:	serialized RSA public key data
+ */
+#define TA_AVB_CMD_VALIDATE_PUBLIC_KEY	6
+
 #endif /*__TA_AVB_H*/

--- a/ta/avb/include/ta_avb.h
+++ b/ta/avb/include/ta_avb.h
@@ -62,7 +62,9 @@
 #define TA_AVB_CMD_WRITE_PERSIST_VALUE	5
 
 /*
- * Validates a public key data.
+ * Provision public key data.
+ *
+ * The key can be provisioned only once.
  *
  * A key data provided from NW is serialized in this sequence:
  * +--------------+----------------------------+
@@ -81,6 +83,15 @@
  *
  * in	params[0].memref:	serialized RSA public key data
  */
-#define TA_AVB_CMD_VALIDATE_PUBLIC_KEY	6
+
+#define TA_AVB_CMD_PROVISION_PUBLIC_KEY	6
+/*
+ * Validates a public key data.
+ *
+ * For key data format check TA_AVB_CMD_PROVISION_PUBLIC_KEY
+ *
+ * in	params[0].memref:	serialized RSA public key data
+ */
+#define TA_AVB_CMD_VALIDATE_PUBLIC_KEY	7
 
 #endif /*__TA_AVB_H*/


### PR DESCRIPTION
Introduce support for validation of RSA public key, used to verify
vbmeta partition. By validation it means that the given public key
is trusted and can be used for verification of vbmeta image signature.
For additional details check `validate_vbmeta_public_key` in [1].

It is also required by AVB spec [1] that trusted key is stored in the
tamper-evident storage.

The key data provided from NW is serialized in this format:
```
+--------------+----------------------------+
| Name         | Number of bytes            |
+--------------+----------------------------+
| key_num_bits | 4 ("modulus size in bits") |
| n0inv        | 4 ("-1/n[0] (mod 2^32)")   |
| n            | key_num_bits / 8 (modulus) |
| rr           | key_num_bits / 8 (R^2)     |
+--------------+----------------------------+
```

So, for example, for 4096 bit(default one) key representation we need
1032 bytes
(4 + 4 + 512 + 512) to store these values.

Public exponent is assumed to always be 65537.

Link: [1] https://android.googlesource.com/platform/external/avb/+/master/README.md#Named-Persistent-Values

FYI: there is no any function yet to store initial public key data (for example, during factory provisioning), will add it in this commit after I receive initial feedback (I'm not sure that it should be implemented in this way).

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
