### PR TITLE
core: pta: fix tag KM_TAG_CREATION_DATETIME encoded data type

### DIFF
--- a/core/arch/arm/pta/encoders.c
+++ b/core/arch/arm/pta/encoders.c
@@ -745,6 +745,7 @@ static void set_chars(der_attestExtension *attest, int hw_flag,
 
 			switch (key_chr->params[j].tag) {
 			case KM_TAG_ACTIVE_DATETIME:
+			case KM_TAG_CREATION_DATETIME:
 			case KM_TAG_ORIGINATION_EXPIRE_DATETIME:
 			case KM_TAG_USAGE_EXPIRE_DATETIME:
 				_int =
@@ -759,7 +760,6 @@ static void set_chars(der_attestExtension *attest, int hw_flag,
 			case KM_TAG_RSA_PUBLIC_EXPONENT:
 			case KM_TAG_USER_AUTH_TYPE:
 			case KM_TAG_AUTH_TIMEOUT:
-			case KM_TAG_CREATION_DATETIME:
 			case KM_TAG_ORIGIN:
 			case KM_TAG_OS_VERSION:
 			case KM_TAG_OS_PATCHLEVEL:


### PR DESCRIPTION
all the key characteristics parameter tag KM_TAG_*_DATETIME should be encodedd as type long

Signed-off-by: andyzsh68 <andyzsh68@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
