### PR TITLE
probe_max_it overwrite the value of GICD_ISENABLER

### DIFF
--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -110,7 +110,7 @@ static size_t probe_max_it(vaddr_t gicc_base __maybe_unused, vaddr_t gicd_base)
 		old_reg = read32(gicd_base + GICD_ISENABLER(i));
 		write32(0xffffffff, gicd_base + GICD_ISENABLER(i));
 		reg = read32(gicd_base + GICD_ISENABLER(i));
-		write32(old_reg, gicd_base + GICD_ICENABLER(i));
+		write32(~old_reg, gicd_base + GICD_ICENABLER(i));
 		for (b = NUM_INTS_PER_REG - 1; b >= 0; b--) {
 			if (BIT32(b) & reg) {
 				ret = i * NUM_INTS_PER_REG + b;


### PR DESCRIPTION
probe_max_it save the original value of GICD_ISENABLER
and write the value 0xffffffff into GICD_ISENABLER to probe
the largest interrupt number.

Instead of writing the original GICD_ISENABLER value
into GICD_ISENABLER, probe_max_it write the value into GICD_ICENABLER
and cause the original GICD_ISENABLER value bit flipping.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
