### PR TITLE
cscope: do not exclude generated file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ clean:
 cscope:
 	@echo '  CSCOPE  .'
 	${q}rm -f cscope.*
-	${q}find $(PWD) -name "*.[chSs]" | grep -v "$(PWD)/out" > cscope.files
+	${q}find $(PWD) -name "*.[chSs]" | grep -v export-ta_ > cscope.files
 	${q}cscope -b -q -k
 
 .PHONY: checkpatch checkpatch-staging checkpatch-working


### PR DESCRIPTION
The build directory contains some generated source files, such as
include/generated/conf.h, core/include/generated/arm32_sysreg.{h,S} and
core/include/generated/asm-defines.h. Let cscope parse them and only
exclude the files that are copied into the export-ta_* directories (TA
dev kit).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
