### PR TITLE
core: fix thread_excp_vect_end and literal pool

### DIFF
--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -1016,6 +1016,11 @@ eret_to_user_mode:
 #endif
 
 	movs	pc, lr
+	/*
+	 * Make sure that literals are placed before the
+	 * thread_excp_vect_end label.
+	 */
+	.pool
 UNWIND(	.fnend)
 	.global thread_excp_vect_end
 thread_excp_vect_end:

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -695,7 +695,11 @@ eret_to_el0:
 #endif /*CFG_CORE_UNMAP_CORE_AT_EL0*/
 
 	eret
-
+	/*
+	 * Make sure that literals are placed before the
+	 * thread_excp_vect_end label.
+	 */
+	.pool
 	.global thread_excp_vect_end
 thread_excp_vect_end:
 END_FUNC thread_excp_vect


### PR DESCRIPTION
The two symbols thread_excp_vect and thread_excp_vect_end are used to
mark the part of the privileged code that still to be mapped in order to
transition between user mode and privileged mode when compiled with
CFG_CORE_UNMAP_CORE_AT_EL0=y.

Prior to this patch it was assumed that thread_excp_vect_end would mark
the end of the thread_excp_vect() assembly function including literals
emitted by the assembler. This assumption was wrong and an extra .pool
directive is added before the thread_excp_vect_end to guarantee that all
literals will be included in the section starting with thread_excp_vect
and ending with thread_excp_vect_end.

Reported-by: Jerome Forissier <jerome.forissier@linaro.org>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
