### PR TITLE
Introduce SKS TA

### DIFF
--- a/ta/pkcs11/Android.mk
+++ b/ta/pkcs11/Android.mk
@@ -1,0 +1,3 @@
+LOCAL_PATH := $(call my-dir)
+local_module := fd02c9da-306c-48c7-a49c-bbd827ae86ee.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/pkcs11/Makefile
+++ b/ta/pkcs11/Makefile
@@ -1,0 +1,9 @@
+# The UUID for the Trusted Application
+BINARY=fd02c9da-306c-48c7-a49c-bbd827ae86ee
+
+-include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+
+ifeq ($(wildcard $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk), )
+clean:
+	@echo 'Note: $$(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk not found, cannot clean TA'
+endif

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -6,8 +6,17 @@
 #ifndef PKCS11_TA_H
 #define PKCS11_TA_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #define PKCS11_TA_UUID { 0xfd02c9da, 0x306c, 0x48c7, \
 			 { 0xa4, 0x9c, 0xbb, 0xd8, 0x27, 0xae, 0x86, 0xee } }
+
+/* Attribute specific values */
+#define PKCS11_UNAVAILABLE_INFORMATION		UINT32_C(0xFFFFFFFF)
+#define PKCS11_UNDEFINED_ID			PKCS11_UNAVAILABLE_INFORMATION
+#define PKCS11_FALSE				false
+#define PKCS11_TRUE				true
 
 /*
  * Note on PKCS#11 TA commands ABI

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2018-2020, Linaro Limited
+ */
+
+#ifndef PKCS11_TA_H
+#define PKCS11_TA_H
+
+#define PKCS11_TA_UUID { 0xfd02c9da, 0x306c, 0x48c7, \
+			 { 0xa4, 0x9c, 0xbb, 0xd8, 0x27, 0xae, 0x86, 0xee } }
+
+/*
+ * Note on PKCS#11 TA commands ABI
+ *
+ * For evolution of the TA API and to not mess with the GPD TEE 4 parameters
+ * constraint, all the PKCS11 TA invocation commands use a subset of available
+ * the GPD TEE invocation parameter types.
+ *
+ * Param#0 is used for the so-called control arguments of the invoked command
+ * and for providing a PKCS#11 compliant status code for the request command.
+ * Param#0 is an in/out memory reference (aka memref[0]). The input buffer
+ * stores the command arguments serialized inside. The output buffer will
+ * store the 32bit TA retrun code for the command. Client shall get this
+ * return code and override the GPD TEE Client API legacy TEE_Result value.
+ *
+ * Param#1 is used for input data arguments of the invoked command.
+ * It is unused or is a input memory reference, aka memref[1].
+ * Evolution of the API may use memref[1] for output data as well.
+ *
+ * Param#2 is mostly used for output data arguments of the invoked command
+ * and for output handles generated from invoked commands.
+ * Few commands uses it for a secondary input data buffer argument.
+ * It is unused or is a input/output/in-out memory reference, aka memref[2].
+ *
+ * Param#3 is currently unused and reserved for evolution of the API.
+ */
+#endif /*PKCS11_TA_H*/

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -12,6 +12,11 @@
 #define PKCS11_TA_UUID { 0xfd02c9da, 0x306c, 0x48c7, \
 			 { 0xa4, 0x9c, 0xbb, 0xd8, 0x27, 0xae, 0x86, 0xee } }
 
+/* PKCS11 trusted application version information */
+#define PKCS11_TA_VERSION_MAJOR			0
+#define PKCS11_TA_VERSION_MINOR			1
+#define PKCS11_TA_VERSION_PATCH			0
+
 /* Attribute specific values */
 #define PKCS11_UNAVAILABLE_INFORMATION		UINT32_C(0xFFFFFFFF)
 #define PKCS11_UNDEFINED_ID			PKCS11_UNAVAILABLE_INFORMATION
@@ -29,7 +34,7 @@
  * and for providing a PKCS#11 compliant status code for the request command.
  * Param#0 is an in/out memory reference (aka memref[0]). The input buffer
  * stores the command arguments serialized inside. The output buffer will
- * store the 32bit TA retrun code for the command. Client shall get this
+ * store the 32bit TA return code for the command. Client shall get this
  * return code and override the GPD TEE Client API legacy TEE_Result value.
  *
  * Param#1 is used for input data arguments of the invoked command.
@@ -43,4 +48,16 @@
  *
  * Param#3 is currently unused and reserved for evolution of the API.
  */
+
+/*
+ * PKCS11_CMD_PING		Acknowledge TA presence and return version info
+ *
+ * Optinal invocation parameter (if none, command simply returns with success)
+ * [out]        memref[2] = [
+ *                      32bit version major value,
+ *                      32bit version minor value
+ *                      32bit version patch value
+ *              ]
+ */
+#define PKCS11_CMD_PING				0
 #endif /*PKCS11_TA_H*/

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -4,6 +4,7 @@
  */
 
 #include <compiler.h>
+#include <pkcs11_ta.h>
 #include <tee_internal_api.h>
 
 TEE_Result TA_CreateEntryPoint(void)
@@ -29,13 +30,110 @@ void TA_CloseSessionEntryPoint(void *session __unused)
 }
 
 /*
+ * Entry point for invocation command PKCS11_CMD_PING
+ *
+ * @ctrl - param memref[0] or NULL: expected NULL
+ * @in - param memref[1] or NULL: expected NULL
+ * @out - param memref[2] or NULL
+ *
+ * Return a TEE_Result value
+ */
+static TEE_Result entry_ping(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
+{
+	const uint32_t ver[] = {
+		PKCS11_TA_VERSION_MAJOR,
+		PKCS11_TA_VERSION_MINOR,
+		PKCS11_TA_VERSION_PATCH,
+	};
+	size_t size = 0;
+
+	if (ctrl || in)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!out)
+		return TEE_SUCCESS;
+
+	size = out->memref.size;
+	out->memref.size = sizeof(ver);
+
+	if (size < sizeof(ver))
+		return TEE_ERROR_SHORT_BUFFER;
+
+	TEE_MemMove(out->memref.buffer, ver, sizeof(ver));
+
+	return TEE_SUCCESS;
+}
+
+/*
  * Entry point for PKCS11 TA commands
  */
 TEE_Result TA_InvokeCommandEntryPoint(void *tee_session __unused, uint32_t cmd,
-				      uint32_t ptypes __unused,
-				      TEE_Param params[TEE_NUM_PARAMS] __unused)
+				      uint32_t ptypes,
+				      TEE_Param params[TEE_NUM_PARAMS])
 {
-	EMSG("Command 0x%"PRIx32" is not supported", cmd);
+	TEE_Param *ctrl = NULL;
+	TEE_Param *p1_in = NULL;
+	TEE_Param __maybe_unused *p2_in = NULL;
+	TEE_Param *p2_out = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
-	return TEE_ERROR_NOT_SUPPORTED;
+	/* Param#0: none or in-out buffer with serialized arguments */
+	switch (TEE_PARAM_TYPE_GET(ptypes, 0)) {
+	case TEE_PARAM_TYPE_NONE:
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INOUT:
+		ctrl = &params[0];
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Param#1: none or input data buffer */
+	switch (TEE_PARAM_TYPE_GET(ptypes, 1)) {
+	case TEE_PARAM_TYPE_NONE:
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INPUT:
+		p1_in = &params[1];
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Param#2: none or input data buffer */
+	switch (TEE_PARAM_TYPE_GET(ptypes, 2)) {
+	case TEE_PARAM_TYPE_NONE:
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INPUT:
+		p2_in = &params[2];
+		break;
+	case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+		p2_out = &params[2];
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Param#3: currently unused */
+	switch (TEE_PARAM_TYPE_GET(ptypes, 3)) {
+	case TEE_PARAM_TYPE_NONE:
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	switch (cmd) {
+	case PKCS11_CMD_PING:
+		res = entry_ping(ctrl, p1_in, p2_out);
+		break;
+
+	default:
+		EMSG("Command 0x%"PRIx32" is not supported", cmd);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	/* Currently no output data stored in output param#0 */
+	if (TEE_PARAM_TYPE_GET(ptypes, 0) == TEE_PARAM_TYPE_MEMREF_INOUT)
+		ctrl->memref.size = 0;
+
+	return res;
 }

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2018-2020, Linaro Limited
+ */
+
+#include <compiler.h>
+#include <tee_internal_api.h>
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+	return TEE_SUCCESS;
+}
+
+void TA_DestroyEntryPoint(void)
+{
+}
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t __unused param_types,
+				    TEE_Param __unused params[4],
+				    void **session)
+{
+	*session = NULL;
+
+	return TEE_SUCCESS;
+}
+
+void TA_CloseSessionEntryPoint(void *session __unused)
+{
+}
+
+/*
+ * Entry point for PKCS11 TA commands
+ */
+TEE_Result TA_InvokeCommandEntryPoint(void *tee_session __unused, uint32_t cmd,
+				      uint32_t ptypes __unused,
+				      TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	EMSG("Command 0x%"PRIx32" is not supported", cmd);
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}

--- a/ta/pkcs11/src/sub.mk
+++ b/ta/pkcs11/src/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += entry.c

--- a/ta/pkcs11/src/user_ta_header_defines.h
+++ b/ta/pkcs11/src/user_ta_header_defines.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2018-2019, Linaro Limited
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include <pkcs11_ta.h>
+
+#define TA_UUID				PKCS11_TA_UUID
+
+#define TA_FLAGS			(TA_FLAG_SINGLE_INSTANCE | \
+					 TA_FLAG_MULTI_SESSION | \
+					 TA_FLAG_INSTANCE_KEEP_ALIVE)
+
+#define TA_STACK_SIZE			(4 * 1024)
+#define TA_DATA_SIZE			(16 * 1024)
+
+#endif /*USER_TA_HEADER_DEFINES_H*/

--- a/ta/pkcs11/sub.mk
+++ b/ta/pkcs11/sub.mk
@@ -1,0 +1,3 @@
+global-incdirs-y += include
+global-incdirs-y += src
+subdirs-y += src

--- a/ta/pkcs11/user_ta.mk
+++ b/ta/pkcs11/user_ta.mk
@@ -1,0 +1,1 @@
+user-ta-uuid := fd02c9da-306c-48c7-a49c-bbd827ae86ee


### PR DESCRIPTION
Introduce in-tree SKS TA: basic source/header/make files.
Define API and implement a first command that gets the TA implementation version info.

This P-R introduces the first commits from #2732.