### PR TITLE
gen_hashed_bin.py: open file in binary mode

### DIFF
--- a/scripts/gen_hashed_bin.py
+++ b/scripts/gen_hashed_bin.py
@@ -67,7 +67,7 @@ def append_to(outf, start_offs, in_fname, max_bytes=0xffffffff):
 def append_hashes(outf, in_fname):
     page_size = 4 * 1024
 
-    inf = open(in_fname, 'r')
+    inf = open(in_fname, 'rb')
     while True:
         page = inf.read(page_size)
         if len(page) == page_size:


### PR DESCRIPTION
By default Python tries to open files in text mode. This is
okay for python2, because it uses 8-bit encoding.
But python3 tries to decode file as utf-8 encoded and fails,
because it is a binary file.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
