### PR TITLE
core: arm: mutex: remove owner_id

### DIFF
--- a/core/arch/arm/include/kernel/mutex.h
+++ b/core/arch/arm/include/kernel/mutex.h
@@ -9,23 +9,12 @@
 #include <sys/queue.h>
 #include <kernel/wait_queue.h>
 
-/*
- * Positive owner ids signifies actual threads, negative ids has special
- * meanings according to the defines below. Note that only the first of the
- * defines is allowed in struct mutex::owener_id.
- */
-#define MUTEX_OWNER_ID_NONE		-1
-#define MUTEX_OWNER_ID_CONDVAR_SLEEP	-2
-#define MUTEX_OWNER_ID_MUTEX_UNLOCK	-3
-
 struct mutex {
 	unsigned spin_lock;	/* used when operating on this struct */
 	struct wait_queue wq;
 	short state;		/* -1: write, 0: unlocked, > 0: readers */
-	short owner_id;		/* Only valid for state == -1 (write lock) */
 };
-#define MUTEX_INITIALIZER \
-	{ .owner_id = MUTEX_OWNER_ID_NONE, .wq = WAIT_QUEUE_INITIALIZER, }
+#define MUTEX_INITIALIZER { .wq = WAIT_QUEUE_INITIALIZER }
 
 TAILQ_HEAD(mutex_head, mutex);
 

--- a/core/arch/arm/include/kernel/wait_queue.h
+++ b/core/arch/arm/include/kernel/wait_queue.h
@@ -46,8 +46,7 @@ static inline void wq_wait_init(struct wait_queue *wq,
 
 /* Waits for the wait queue element to the awakened. */
 void wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
-		   const void *sync_obj, int owner, const char *fname,
-		   int lineno);
+		   const void *sync_obj, const char *fname, int lineno);
 
 /* Wakes up the first wait queue element in the wait queue, if there is one */
 void wq_wake_next(struct wait_queue *wq, const void *sync_obj,
@@ -61,8 +60,8 @@ void wq_promote_condvar(struct wait_queue *wq, struct condvar *cv,
 			int lineno);
 bool wq_have_condvar(struct wait_queue *wq, struct condvar *cv);
 
-void __wq_rpc(uint32_t func, int id, const void *sync_obj, int owner,
-	      const char *fname, int lineno);
+void __wq_rpc(uint32_t func, int id, const void *sync_obj, const char *fname,
+	      int lineno);
 
 #endif /*KERNEL_WAIT_QUEUE_H*/
 

--- a/core/arch/arm/kernel/link_dummies.c
+++ b/core/arch/arm/kernel/link_dummies.c
@@ -33,7 +33,7 @@ __thread_std_smc_entry(struct thread_smc_args *args __unused)
 }
 void __section(".text.dummy.__wq_rpc")
 __wq_rpc(uint32_t func __unused, int id __unused,
-	 const void *sync_obj __unused, int owner __unused,
-	 const char *fname __unused, int lineno  __unused)
+	 const void *sync_obj __unused, const char *fname __unused,
+	 int lineno  __unused)
 {
 }

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -28,7 +28,6 @@ static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 		uint32_t old_itr_status;
 		bool can_lock;
 		struct wait_queue_elem wqe;
-		int owner = MUTEX_OWNER_ID_NONE;
 
 		/*
 		 * If the mutex is locked we need to initialize the wqe
@@ -44,8 +43,6 @@ static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 		can_lock = !m->state;
 		if (!can_lock) {
 			wq_wait_init(&m->wq, &wqe, false /* wait_read */);
-			owner = m->owner_id;
-			assert(owner != thread_get_id_may_fail());
 		} else {
 			m->state = -1; /* write locked */
 		}
@@ -57,7 +54,7 @@ static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 			 * Someone else is holding the lock, wait in normal
 			 * world for the lock to become available.
 			 */
-			wq_wait_final(&m->wq, &wqe, m, owner, fname, lineno);
+			wq_wait_final(&m->wq, &wqe, m, fname, lineno);
 		} else
 			return;
 	}
@@ -136,7 +133,6 @@ static void __mutex_read_lock(struct mutex *m, const char *fname, int lineno)
 		uint32_t old_itr_status;
 		bool can_lock;
 		struct wait_queue_elem wqe;
-		int owner = MUTEX_OWNER_ID_NONE;
 
 		/*
 		 * If the mutex is locked we need to initialize the wqe
@@ -152,8 +148,6 @@ static void __mutex_read_lock(struct mutex *m, const char *fname, int lineno)
 		can_lock = m->state != -1;
 		if (!can_lock) {
 			wq_wait_init(&m->wq, &wqe, true /* wait_read */);
-			owner = m->owner_id;
-			assert(owner != thread_get_id_may_fail());
 		} else {
 			m->state++; /* read_locked */
 		}
@@ -165,7 +159,7 @@ static void __mutex_read_lock(struct mutex *m, const char *fname, int lineno)
 			 * Someone else is holding the lock, wait in normal
 			 * world for the lock to become available.
 			 */
-			wq_wait_final(&m->wq, &wqe, m, owner, fname, lineno);
+			wq_wait_final(&m->wq, &wqe, m, fname, lineno);
 		} else
 			return;
 	}
@@ -358,8 +352,7 @@ static void __condvar_wait(struct condvar *cv, struct mutex *m,
 	if (!new_state)
 		wq_wake_next(&m->wq, m, fname, lineno);
 
-	wq_wait_final(&m->wq, &wqe,
-		      m, MUTEX_OWNER_ID_CONDVAR_SLEEP, fname, lineno);
+	wq_wait_final(&m->wq, &wqe, m, fname, lineno);
 
 	if (old_state > 0)
 		mutex_read_lock(m);

--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -25,18 +25,17 @@ void wq_init(struct wait_queue *wq)
  * the unpaged area.
  */
 void __weak __wq_rpc(uint32_t func, int id, const void *sync_obj __maybe_unused,
-		     int owner __maybe_unused, const char *fname,
-		     int lineno __maybe_unused)
+		     const char *fname, int lineno __maybe_unused)
 {
 	uint32_t ret;
 	const char *cmd_str __maybe_unused =
 	     func == OPTEE_RPC_WAIT_QUEUE_SLEEP ? "sleep" : "wake ";
 
 	if (fname)
-		DMSG("%s thread %u %p %d %s:%d", cmd_str, id,
-		     sync_obj, owner, fname, lineno);
+		DMSG("%s thread %u %p %s:%d", cmd_str, id,
+		     sync_obj, fname, lineno);
 	else
-		DMSG("%s thread %u %p %d", cmd_str, id, sync_obj, owner);
+		DMSG("%s thread %u %p", cmd_str, id, sync_obj);
 
 	struct thread_param params = THREAD_PARAM_VALUE(IN, func, id, 0);
 
@@ -77,15 +76,14 @@ void wq_wait_init_condvar(struct wait_queue *wq, struct wait_queue_elem *wqe,
 }
 
 void wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
-		   const void *sync_obj, int owner, const char *fname,
-		   int lineno)
+		   const void *sync_obj, const char *fname, int lineno)
 {
 	uint32_t old_itr_status;
 	unsigned done;
 
 	do {
 		__wq_rpc(OPTEE_RPC_WAIT_QUEUE_SLEEP, wqe->handle,
-			 sync_obj, owner, fname, lineno);
+			 sync_obj, fname, lineno);
 
 		old_itr_status = cpu_spin_lock_xsave(&wq_spin_lock);
 
@@ -139,8 +137,7 @@ void wq_wake_next(struct wait_queue *wq, const void *sync_obj,
 
 		if (do_wakeup)
 			__wq_rpc(OPTEE_RPC_WAIT_QUEUE_WAKEUP, handle,
-				 sync_obj, MUTEX_OWNER_ID_MUTEX_UNLOCK,
-				 fname, lineno);
+				 sync_obj, fname, lineno);
 
 		if (!do_wakeup || !wake_read)
 			break;


### PR DESCRIPTION
mutex::owner_id was used for debugging purposes only. But since commit
8aff6c039ee5 "core: remove thread_{add,rem}_mutex()", it is never set to
a valid thread ID anymore. Let's just remove the field.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
