### PR TITLE
stm32mp1: introduce platform clock driver

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1,0 +1,957 @@
+// SPDX-License-Identifier:	GPL-2.0+	BSD-3-Clause
+/*
+ * Copyright (C) 2018-2019, STMicroelectronics
+ */
+
+#include <assert.h>
+#include <drivers/stm32mp1_clk.h>
+#include <drivers/stm32mp1_rcc.h>
+#include <dt-bindings/clock/stm32mp1-clks.h>
+#include <initcall.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <stm32_util.h>
+#include <trace.h>
+#include <util.h>
+
+/* Identifiers for parent clocks */
+enum stm32mp1_parent_id {
+/*
+ * Oscillators are valid IDs for parent clock and are already
+ * defined in enum stm32mp_osc_id, ending at NB_OSC - 1.
+ * This enum defines IDs are the other possible clock parents.
+ */
+	_HSI_KER = NB_OSC,
+	_HSE_KER,
+	_HSE_KER_DIV2,
+	_CSI_KER,
+	_PLL1_P,
+	_PLL1_Q,
+	_PLL1_R,
+	_PLL2_P,
+	_PLL2_Q,
+	_PLL2_R,
+	_PLL3_P,
+	_PLL3_Q,
+	_PLL3_R,
+	_PLL4_P,
+	_PLL4_Q,
+	_PLL4_R,
+	_ACLK,
+	_PCLK1,
+	_PCLK2,
+	_PCLK3,
+	_PCLK4,
+	_PCLK5,
+	_HCLK6,
+	_HCLK2,
+	_CK_PER,
+	_CK_MPU,
+	_CK_MCU,
+	_PARENT_NB,
+	_UNKNOWN_ID = 0xff,
+};
+
+/*
+ * Identifiers for parent clock selectors.
+ * This enum lists only the parent clocks we are interested in.
+ */
+enum stm32mp1_parent_sel {
+	_STGEN_SEL,
+	_I2C46_SEL,
+	_SPI6_SEL,
+	_USART1_SEL,
+	_RNG1_SEL,
+	_UART6_SEL,
+	_UART24_SEL,
+	_UART35_SEL,
+	_UART78_SEL,
+	_ASS_SEL,
+	_MSS_SEL,
+	_USBPHY_SEL,
+	_USBO_SEL,
+	_PARENT_SEL_NB,
+	_UNKNOWN_SEL = 0xff,
+};
+
+/* Identifiers for PLLs and their configuration resources */
+enum stm32mp1_pll_id {
+	_PLL1,
+	_PLL2,
+	_PLL3,
+	_PLL4,
+	_PLL_NB
+};
+
+enum stm32mp1_div_id {
+	_DIV_P,
+	_DIV_Q,
+	_DIV_R,
+	_DIV_NB,
+};
+
+enum stm32mp1_plltype {
+	PLL_800,
+	PLL_1600,
+	PLL_TYPE_NB
+};
+
+/*
+ * Clock generic gates clocks which state is controlled by a single RCC bit
+ *
+ * @offset: RCC register byte offset from RCC base where clock is controlled
+ * @bit: Bit position in the RCC 32bit register
+ * @clock_id: Identifier used for the clock in the clock driver API
+ * @set_clr: Non-null if and only-if RCC register is a CLEAR/SET register
+ *	(CLEAR register is at offset RCC_MP_ENCLRR_OFFSET from SET register)
+ * @sel: _UNKNOWN_ID (fixed parent) or reference to parent clock selector
+ *	(8bit storage of ID from enum stm32mp1_parent_sel)
+ * @fixed: _UNKNOWN_ID (selectable paranet) or reference to parent clock
+ *	(8bit storage of ID from enum stm32mp1_parent_id)
+ */
+struct stm32mp1_clk_gate {
+	uint16_t offset;
+	uint8_t bit;
+	uint8_t clock_id;
+	uint8_t set_clr;
+	uint8_t sel; /* Relates to enum stm32mp1_parent_sel */
+	uint8_t fixed; /* Relates to enum stm32mp1_parent_id */
+};
+
+/* Parent clock selection: select register info, parent clocks references */
+struct stm32mp1_clk_sel {
+	uint16_t offset;
+	uint8_t src;
+	uint8_t msk;
+	uint8_t nb_parent;
+	const uint8_t *parent;
+};
+
+#define REFCLK_SIZE 4
+/* PLL control: type, control register offsets, up-to-4 selectable parent */
+struct stm32mp1_clk_pll {
+	enum stm32mp1_plltype plltype;
+	uint16_t rckxselr;
+	uint16_t pllxcfgr1;
+	uint16_t pllxcfgr2;
+	uint16_t pllxfracr;
+	uint16_t pllxcr;
+	uint16_t pllxcsgr;
+	enum stm32mp_osc_id refclk[REFCLK_SIZE];
+};
+
+/* Clocks with selectable source and not set/clr register access */
+#define _CLK_SELEC(_offset, _bit, _clock_id, _parent_sel)	\
+	{							\
+		.offset = (_offset),				\
+		.bit = (_bit),					\
+		.clock_id = (_clock_id),			\
+		.set_clr = 0,					\
+		.sel = (_parent_sel),				\
+		.fixed = _UNKNOWN_ID,				\
+	}
+
+/* Clocks with fixed source and not set/clr register access */
+#define _CLK_FIXED(_offset, _bit, _clock_id, _parent)		\
+	{							\
+		.offset = (_offset),				\
+		.bit = (_bit),					\
+		.clock_id = (_clock_id),			\
+		.set_clr = 0,					\
+		.sel = _UNKNOWN_SEL,				\
+		.fixed = (_parent),				\
+	}
+
+/* Clocks with selectable source and set/clr register access */
+#define _CLK_SC_SELEC(_offset, _bit, _clock_id, _parent_sel)	\
+	{							\
+		.offset = (_offset),				\
+		.bit = (_bit),					\
+		.clock_id = (_clock_id),			\
+		.set_clr = 1,					\
+		.sel = (_parent_sel),				\
+		.fixed = _UNKNOWN_ID,				\
+	}
+
+/* Clocks with fixed source and set/clr register access */
+#define _CLK_SC_FIXED(_offset, _bit, _clock_id, _parent)	\
+	{							\
+		.offset = (_offset),				\
+		.bit = (_bit),					\
+		.clock_id = (_clock_id),			\
+		.set_clr = 1,					\
+		.sel = _UNKNOWN_SEL,				\
+		.fixed = (_parent),				\
+	}
+
+/*
+ * Clocks with selectable source and set/clr register access
+ * and enable bit position defined by a label (argument _bit)
+ */
+#define _CLK_SC2_SELEC(_offset, _bit, _clock_id, _parent_sel)	\
+	{							\
+		.offset = (_offset),				\
+		.clock_id = (_clock_id),			\
+		.bit = _offset ## _ ## _bit ## _POS,		\
+		.set_clr = 1,					\
+		.sel = (_parent_sel),				\
+		.fixed = _UNKNOWN_ID,				\
+	}
+#define _CLK_SC2_FIXED(_offset, _bit, _clock_id, _parent)	\
+	{							\
+		.offset = (_offset),				\
+		.clock_id = (_clock_id),			\
+		.bit = _offset ## _ ## _bit ## _POS,		\
+		.set_clr = 1,					\
+		.sel = _UNKNOWN_SEL,				\
+		.fixed = (_parent),				\
+	}
+
+#define _CLK_PARENT(idx, _offset, _src, _mask, _parent)		\
+	[(idx)] = {						\
+		.offset = (_offset),				\
+		.src = (_src),					\
+		.msk = (_mask),					\
+		.parent = (_parent),				\
+		.nb_parent = ARRAY_SIZE(_parent)		\
+	}
+
+#define _CLK_PLL(_idx, _type, _off1, _off2, _off3, _off4,	\
+		 _off5, _off6, _p1, _p2, _p3, _p4)		\
+	[(_idx)] = {						\
+		.plltype = (_type),				\
+		.rckxselr = (_off1),				\
+		.pllxcfgr1 = (_off2),				\
+		.pllxcfgr2 = (_off3),				\
+		.pllxfracr = (_off4),				\
+		.pllxcr = (_off5),				\
+		.pllxcsgr = (_off6),				\
+		.refclk[0] = (_p1),				\
+		.refclk[1] = (_p2),				\
+		.refclk[2] = (_p3),				\
+		.refclk[3] = (_p4),				\
+	}
+
+static const uint8_t stm32mp1_clks[][2] = {
+	{ CK_PER, _CK_PER },
+	{ CK_MPU, _CK_MPU },
+	{ CK_AXI, _ACLK },
+	{ CK_MCU, _CK_MCU },
+	{ CK_HSE, _HSE },
+	{ CK_CSI, _CSI },
+	{ CK_LSI, _LSI },
+	{ CK_LSE, _LSE },
+	{ CK_HSI, _HSI },
+	{ CK_HSE_DIV2, _HSE_KER_DIV2 },
+};
+
+#define NB_GATES	ARRAY_SIZE(stm32mp1_clk_gate)
+
+static const struct stm32mp1_clk_gate stm32mp1_clk_gate[] = {
+	_CLK_FIXED(RCC_DDRITFCR, 0, DDRC1, _ACLK),
+	_CLK_FIXED(RCC_DDRITFCR, 1, DDRC1LP, _ACLK),
+	_CLK_FIXED(RCC_DDRITFCR, 2, DDRC2, _ACLK),
+	_CLK_FIXED(RCC_DDRITFCR, 3, DDRC2LP, _ACLK),
+	_CLK_FIXED(RCC_DDRITFCR, 4, DDRPHYC, _PLL2_R),
+	_CLK_FIXED(RCC_DDRITFCR, 5, DDRPHYCLP, _PLL2_R),
+	_CLK_FIXED(RCC_DDRITFCR, 6, DDRCAPB, _PCLK4),
+	_CLK_FIXED(RCC_DDRITFCR, 7, DDRCAPBLP, _PCLK4),
+	_CLK_FIXED(RCC_DDRITFCR, 8, AXIDCG, _ACLK),
+	_CLK_FIXED(RCC_DDRITFCR, 9, DDRPHYCAPB, _PCLK4),
+	_CLK_FIXED(RCC_DDRITFCR, 10, DDRPHYCAPBLP, _PCLK4),
+
+	_CLK_SC2_SELEC(RCC_MP_APB5ENSETR, SPI6EN, SPI6_K, _SPI6_SEL),
+	_CLK_SC2_SELEC(RCC_MP_APB5ENSETR, I2C4EN, I2C4_K, _I2C46_SEL),
+	_CLK_SC2_SELEC(RCC_MP_APB5ENSETR, I2C6EN, I2C6_K, _I2C46_SEL),
+	_CLK_SC2_SELEC(RCC_MP_APB5ENSETR, USART1EN, USART1_K, _USART1_SEL),
+	_CLK_SC2_FIXED(RCC_MP_APB5ENSETR, RTCAPBEN, RTCAPB, _PCLK5),
+	_CLK_SC2_FIXED(RCC_MP_APB5ENSETR, TZC1EN, TZC1, _PCLK5),
+	_CLK_SC2_FIXED(RCC_MP_APB5ENSETR, TZC2EN, TZC2, _PCLK5),
+	_CLK_SC2_FIXED(RCC_MP_APB5ENSETR, TZPCEN, TZPC, _PCLK5),
+	_CLK_SC2_FIXED(RCC_MP_APB5ENSETR, IWDG1APBEN, IWDG1, _PCLK5),
+	_CLK_SC2_FIXED(RCC_MP_APB5ENSETR, BSECEN, BSEC, _PCLK5),
+	_CLK_SC2_SELEC(RCC_MP_APB5ENSETR, STGENEN, STGEN_K, _STGEN_SEL),
+
+	_CLK_SC2_FIXED(RCC_MP_AHB5ENSETR, GPIOZEN, GPIOZ, _PCLK5),
+	_CLK_SC2_FIXED(RCC_MP_AHB5ENSETR, CRYP1EN, CRYP1, _PCLK5),
+	_CLK_SC2_FIXED(RCC_MP_AHB5ENSETR, HASH1EN, HASH1, _PCLK5),
+	_CLK_SC2_SELEC(RCC_MP_AHB5ENSETR, RNG1EN, RNG1_K, _RNG1_SEL),
+	_CLK_SC2_FIXED(RCC_MP_AHB5ENSETR, BKPSRAMEN, BKPSRAM, _PCLK5),
+
+	/* Non-secure clocks */
+#ifdef CFG_WITH_NSEC_GPIOS
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 0, GPIOA, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 1, GPIOB, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 2, GPIOC, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 3, GPIOD, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 4, GPIOE, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 5, GPIOF, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 6, GPIOG, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 7, GPIOH, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 8, GPIOI, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 9, GPIOJ, _UNKNOWN_ID),
+	_CLK_SC_FIXED(RCC_MP_AHB4ENSETR, 10, GPIOK, _UNKNOWN_ID),
+#endif
+#ifdef CFG_WITH_NSEC_UARTS
+	_CLK_SC_SELEC(RCC_MP_APB1ENSETR, 14, USART2_K, _UART24_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB1ENSETR, 15, USART3_K, _UART35_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB1ENSETR, 16, UART4_K, _UART24_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB1ENSETR, 17, UART5_K, _UART35_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB1ENSETR, 18, UART7_K, _UART78_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB1ENSETR, 19, UART8_K, _UART78_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB2ENSETR, 13, USART6_K, _UART6_SEL),
+#endif
+	_CLK_SC_SELEC(RCC_MP_APB4ENSETR, 8, DDRPERFM, _UNKNOWN_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB4ENSETR, 15, IWDG2, _UNKNOWN_SEL),
+	_CLK_SC_SELEC(RCC_MP_APB4ENSETR, 16, USBPHY_K, _USBPHY_SEL),
+	_CLK_SC_SELEC(RCC_MP_AHB2ENSETR, 8, USBO_K, _USBO_SEL),
+	_CLK_SELEC(RCC_DBGCFGR, 8, CK_DBG, _UNKNOWN_SEL),
+	_CLK_SC_FIXED(RCC_MP_APB1ENSETR, 6, TIM12_K, _PCLK1),
+	_CLK_SC_FIXED(RCC_MP_APB2ENSETR, 2, TIM15_K, _PCLK2),
+};
+KEEP_PAGER(stm32mp1_clk_gate);
+
+/* Parents for secure aware clocks in the xxxSELR value ordering */
+static const uint8_t stgen_parents[] = {
+	_HSI_KER, _HSE_KER
+};
+
+static const uint8_t i2c46_parents[] = {
+	_PCLK5, _PLL3_Q, _HSI_KER, _CSI_KER
+};
+
+static const uint8_t spi6_parents[] = {
+	_PCLK5, _PLL4_Q, _HSI_KER, _CSI_KER, _HSE_KER, _PLL3_Q
+};
+
+static const uint8_t usart1_parents[] = {
+	_PCLK5, _PLL3_Q, _HSI_KER, _CSI_KER, _PLL4_Q, _HSE_KER
+};
+
+static const uint8_t rng1_parents[] = {
+	_CSI, _PLL4_R, _LSE, _LSI
+};
+
+/* Parents for (some) non-secure clocks */
+static const uint8_t uart6_parents[] = {
+	_PCLK2, _PLL4_Q, _HSI_KER, _CSI_KER, _HSE_KER
+};
+
+static const uint8_t uart234578_parents[] = {
+	_PCLK1, _PLL4_Q, _HSI_KER, _CSI_KER, _HSE_KER
+};
+
+static const uint8_t ass_parents[] = {
+	_HSI, _HSE, _PLL2
+};
+
+static const uint8_t mss_parents[] = {
+	_HSI, _HSE, _CSI, _PLL3
+};
+
+static const uint8_t usbphy_parents[] = {
+	_HSE_KER, _PLL4_R, _HSE_KER_DIV2
+};
+
+static const uint8_t usbo_parents[] = {
+	_PLL4_R, _USB_PHY_48
+};
+
+static const struct stm32mp1_clk_sel stm32mp1_clk_sel[_PARENT_SEL_NB] = {
+	/* Secure aware clocks */
+	_CLK_PARENT(_STGEN_SEL, RCC_STGENCKSELR, 0, 0x3, stgen_parents),
+	_CLK_PARENT(_I2C46_SEL, RCC_I2C46CKSELR, 0, 0x7, i2c46_parents),
+	_CLK_PARENT(_SPI6_SEL, RCC_SPI6CKSELR, 0, 0x7, spi6_parents),
+	_CLK_PARENT(_USART1_SEL, RCC_UART1CKSELR, 0, 0x7, usart1_parents),
+	_CLK_PARENT(_RNG1_SEL, RCC_RNG1CKSELR, 0, 0x3, rng1_parents),
+	/* Always non-secure clocks (maybe used in some way in secure world) */
+	_CLK_PARENT(_UART6_SEL, RCC_UART6CKSELR, 0, 0x7, uart6_parents),
+	_CLK_PARENT(_UART24_SEL, RCC_UART24CKSELR, 0, 0x7, uart234578_parents),
+	_CLK_PARENT(_UART35_SEL, RCC_UART35CKSELR, 0, 0x7, uart234578_parents),
+	_CLK_PARENT(_UART78_SEL, RCC_UART78CKSELR, 0, 0x7, uart234578_parents),
+	_CLK_PARENT(_ASS_SEL, RCC_ASSCKSELR, 0, 0x3, ass_parents),
+	_CLK_PARENT(_MSS_SEL, RCC_MSSCKSELR, 0, 0x3, mss_parents),
+	_CLK_PARENT(_USBPHY_SEL, RCC_USBCKSELR, 0, 0x3, usbphy_parents),
+	_CLK_PARENT(_USBO_SEL, RCC_USBCKSELR, 4, 0x1, usbo_parents),
+};
+
+/* PLLNCFGR2 register divider by output */
+static const uint8_t pllncfgr2[_DIV_NB] = {
+	[_DIV_P] = RCC_PLLNCFGR2_DIVP_SHIFT,
+	[_DIV_Q] = RCC_PLLNCFGR2_DIVQ_SHIFT,
+	[_DIV_R] = RCC_PLLNCFGR2_DIVR_SHIFT,
+};
+
+static const struct stm32mp1_clk_pll stm32mp1_clk_pll[_PLL_NB] = {
+	_CLK_PLL(_PLL1, PLL_1600,
+		 RCC_RCK12SELR, RCC_PLL1CFGR1, RCC_PLL1CFGR2,
+		 RCC_PLL1FRACR, RCC_PLL1CR, RCC_PLL1CSGR,
+		 _HSI, _HSE, _UNKNOWN_OSC_ID, _UNKNOWN_OSC_ID),
+	_CLK_PLL(_PLL2, PLL_1600,
+		 RCC_RCK12SELR, RCC_PLL2CFGR1, RCC_PLL2CFGR2,
+		 RCC_PLL2FRACR, RCC_PLL2CR, RCC_PLL2CSGR,
+		 _HSI, _HSE, _UNKNOWN_OSC_ID, _UNKNOWN_OSC_ID),
+	_CLK_PLL(_PLL3, PLL_800,
+		 RCC_RCK3SELR, RCC_PLL3CFGR1, RCC_PLL3CFGR2,
+		 RCC_PLL3FRACR, RCC_PLL3CR, RCC_PLL3CSGR,
+		 _HSI, _HSE, _CSI, _UNKNOWN_OSC_ID),
+	_CLK_PLL(_PLL4, PLL_800,
+		 RCC_RCK4SELR, RCC_PLL4CFGR1, RCC_PLL4CFGR2,
+		 RCC_PLL4FRACR, RCC_PLL4CR, RCC_PLL4CSGR,
+		 _HSI, _HSE, _CSI, _I2S_CKIN),
+};
+
+/* Prescaler table lookups for clock computation */
+/* div = /1 /2 /4 /8 / 16 /64 /128 /512 */
+static const uint8_t stm32mp1_mcu_div[16] = {
+	0, 1, 2, 3, 4, 6, 7, 8, 9, 9, 9, 9, 9, 9, 9, 9
+};
+
+/* div = /1 /2 /4 /8 /16 : same divider for PMU and APBX */
+#define stm32mp1_mpu_div stm32mp1_mpu_apbx_div
+#define stm32mp1_apbx_div stm32mp1_mpu_apbx_div
+static const uint8_t stm32mp1_mpu_apbx_div[8] = {
+	0, 1, 2, 3, 4, 4, 4, 4
+};
+
+/* div = /1 /2 /3 /4 */
+static const uint8_t stm32mp1_axi_div[8] = {
+	1, 2, 3, 4, 4, 4, 4, 4
+};
+
+#if TRACE_LEVEL >= TRACE_DEBUG
+static const char *const __maybe_unused stm32mp1_clk_parent_name[_PARENT_NB] = {
+	[_HSI] = "HSI",
+	[_HSE] = "HSE",
+	[_CSI] = "CSI",
+	[_LSI] = "LSI",
+	[_LSE] = "LSE",
+	[_I2S_CKIN] = "I2S_CKIN",
+	[_HSI_KER] = "HSI_KER",
+	[_HSE_KER] = "HSE_KER",
+	[_HSE_KER_DIV2] = "HSE_KER_DIV2",
+	[_CSI_KER] = "CSI_KER",
+	[_PLL1_P] = "PLL1_P",
+	[_PLL1_Q] = "PLL1_Q",
+	[_PLL1_R] = "PLL1_R",
+	[_PLL2_P] = "PLL2_P",
+	[_PLL2_Q] = "PLL2_Q",
+	[_PLL2_R] = "PLL2_R",
+	[_PLL3_P] = "PLL3_P",
+	[_PLL3_Q] = "PLL3_Q",
+	[_PLL3_R] = "PLL3_R",
+	[_PLL4_P] = "PLL4_P",
+	[_PLL4_Q] = "PLL4_Q",
+	[_PLL4_R] = "PLL4_R",
+	[_ACLK] = "ACLK",
+	[_PCLK1] = "PCLK1",
+	[_PCLK2] = "PCLK2",
+	[_PCLK3] = "PCLK3",
+	[_PCLK4] = "PCLK4",
+	[_PCLK5] = "PCLK5",
+	[_HCLK6] = "KCLK6",
+	[_HCLK2] = "HCLK2",
+	[_CK_PER] = "CK_PER",
+	[_CK_MPU] = "CK_MPU",
+	[_CK_MCU] = "CK_MCU",
+	[_USB_PHY_48] = "USB_PHY_48",
+};
+#endif
+
+/*
+ * Oscillator frequency in Hz. This array shall be initialized
+ * according to platform.
+ */
+static unsigned long stm32mp1_osc[NB_OSC];
+
+static unsigned long osc_frequency(enum stm32mp_osc_id idx)
+{
+	if (idx >= ARRAY_SIZE(stm32mp1_osc)) {
+		DMSG("clk id %d not found", idx);
+		return 0;
+	}
+
+	return stm32mp1_osc[idx];
+}
+
+/* Reference counting for clock gating */
+static unsigned int gate_refcounts[NB_GATES];
+static unsigned int refcount_lock;
+
+static const struct stm32mp1_clk_gate *gate_ref(unsigned int idx)
+{
+	return &stm32mp1_clk_gate[idx];
+}
+
+static const struct stm32mp1_clk_sel *clk_sel_ref(unsigned int idx)
+{
+	return &stm32mp1_clk_sel[idx];
+}
+
+static const struct stm32mp1_clk_pll *pll_ref(unsigned int idx)
+{
+	return &stm32mp1_clk_pll[idx];
+}
+
+static int stm32mp1_clk_get_gated_id(unsigned long id)
+{
+	unsigned int i;
+
+	for (i = 0; i < NB_GATES; i++)
+		if (gate_ref(i)->clock_id == id)
+			return i;
+
+	DMSG("clk id %lu not found", id);
+	return -1;
+}
+
+static enum stm32mp1_parent_sel stm32mp1_clk_get_sel(int i)
+{
+	return (enum stm32mp1_parent_sel)gate_ref(i)->sel;
+}
+
+static enum stm32mp1_parent_id stm32mp1_clk_get_fixed_parent(int i)
+{
+	return (enum stm32mp1_parent_id)gate_ref(i)->fixed;
+}
+
+static int stm32mp1_clk_get_parent(unsigned long id)
+{
+	const struct stm32mp1_clk_sel *sel;
+	unsigned int j;
+	uint32_t p_sel;
+	int i;
+	enum stm32mp1_parent_id p;
+	enum stm32mp1_parent_sel s;
+	uintptr_t rcc_base = stm32_rcc_base();
+
+	for (j = 0U; j < ARRAY_SIZE(stm32mp1_clks); j++)
+		if (stm32mp1_clks[j][0] == id)
+			return (int)stm32mp1_clks[j][1];
+
+	i = stm32mp1_clk_get_gated_id(id);
+	if (i < 0)
+		panic();
+
+	p = stm32mp1_clk_get_fixed_parent(i);
+	if (p < _PARENT_NB)
+		return (int)p;
+
+	s = stm32mp1_clk_get_sel(i);
+	if (s == _UNKNOWN_SEL)
+		return -1;
+	if (s >= _PARENT_SEL_NB)
+		panic();
+
+	sel = clk_sel_ref(s);
+	p_sel = (read32(rcc_base + sel->offset) >> sel->src) & sel->msk;
+	if (p_sel < sel->nb_parent)
+		return (int)sel->parent[p_sel];
+
+	DMSG("No parent selected for clk %lu", id);
+	return -1;
+}
+
+static unsigned long stm32mp1_pll_get_fref(const struct stm32mp1_clk_pll *pll)
+{
+	uint32_t selr = read32(stm32_rcc_base() + pll->rckxselr);
+	uint32_t src = selr & RCC_SELR_REFCLK_SRC_MASK;
+
+	return osc_frequency(pll->refclk[src]);
+}
+
+/*
+ * pll_get_fvco() : return the VCO or (VCO / 2) frequency for the requested PLL
+ * - PLL1 & PLL2 => return VCO / 2 with Fpll_y_ck = FVCO / 2 * (DIVy + 1)
+ * - PLL3 & PLL4 => return VCO     with Fpll_y_ck = FVCO / (DIVy + 1)
+ * => in all cases Fpll_y_ck = pll_get_fvco() / (DIVy + 1)
+ */
+static unsigned long stm32mp1_pll_get_fvco(const struct stm32mp1_clk_pll *pll)
+{
+	unsigned long refclk, fvco;
+	uint32_t cfgr1, fracr, divm, divn;
+
+	cfgr1 = read32(stm32_rcc_base() + pll->pllxcfgr1);
+	fracr = read32(stm32_rcc_base() + pll->pllxfracr);
+
+	divm = (cfgr1 & (RCC_PLLNCFGR1_DIVM_MASK)) >> RCC_PLLNCFGR1_DIVM_SHIFT;
+	divn = cfgr1 & RCC_PLLNCFGR1_DIVN_MASK;
+
+	refclk = stm32mp1_pll_get_fref(pll);
+
+	/*
+	 * With FRACV :
+	 *   Fvco = Fck_ref * ((DIVN + 1) + FRACV / 2^13) / (DIVM + 1)
+	 * Without FRACV
+	 *   Fvco = Fck_ref * ((DIVN + 1) / (DIVM + 1)
+	 */
+	if (fracr & RCC_PLLNFRACR_FRACLE) {
+		unsigned long long numerator;
+		unsigned long long denominator;
+		uint32_t fracv = (fracr & RCC_PLLNFRACR_FRACV_MASK) >>
+				 RCC_PLLNFRACR_FRACV_SHIFT;
+
+		numerator = (((unsigned long long)divn + 1U) << 13) + fracv;
+		numerator = refclk * numerator;
+		denominator = ((unsigned long long)divm + 1U) << 13;
+		fvco = (unsigned long)(numerator / denominator);
+	} else {
+		fvco = (unsigned long)(refclk * (divn + 1U) / (divm + 1U));
+	}
+
+	return fvco;
+}
+
+static unsigned long stm32mp1_read_pll_freq(enum stm32mp1_pll_id pll_id,
+					    enum stm32mp1_div_id div_id)
+{
+	const struct stm32mp1_clk_pll *pll = pll_ref(pll_id);
+	unsigned long dfout;
+	uint32_t cfgr2, divy;
+
+	if (div_id >= _DIV_NB)
+		return 0;
+
+	cfgr2 = read32(stm32_rcc_base() + pll->pllxcfgr2);
+	divy = (cfgr2 >> pllncfgr2[div_id]) & RCC_PLLNCFGR2_DIVX_MASK;
+
+	dfout = stm32mp1_pll_get_fvco(pll) / (divy + 1U);
+
+	return dfout;
+}
+
+static unsigned long get_clock_rate(int p)
+{
+	uint32_t reg;
+	uint32_t clkdiv;
+	unsigned long clock = 0;
+	uintptr_t rcc_base = stm32_rcc_base();
+
+	switch (p) {
+	case _CK_MPU:
+	/* MPU sub system */
+		reg = read32(rcc_base + RCC_MPCKSELR);
+		switch (reg & RCC_SELR_SRC_MASK) {
+		case RCC_MPCKSELR_HSI:
+			clock = osc_frequency(_HSI);
+			break;
+		case RCC_MPCKSELR_HSE:
+			clock = osc_frequency(_HSE);
+			break;
+		case RCC_MPCKSELR_PLL:
+			clock = stm32mp1_read_pll_freq(_PLL1, _DIV_P);
+			break;
+		case RCC_MPCKSELR_PLL_MPUDIV:
+			clock = stm32mp1_read_pll_freq(_PLL1, _DIV_P);
+
+			reg = read32(rcc_base + RCC_MPCKDIVR);
+			clkdiv = reg & RCC_MPUDIV_MASK;
+			if (clkdiv)
+				clock /= stm32mp1_mpu_div[clkdiv];
+			break;
+		default:
+			break;
+		}
+		break;
+	/* AXI sub system */
+	case _ACLK:
+	case _HCLK2:
+	case _HCLK6:
+	case _PCLK4:
+	case _PCLK5:
+		reg = read32(rcc_base + RCC_ASSCKSELR);
+		switch (reg & RCC_SELR_SRC_MASK) {
+		case RCC_ASSCKSELR_HSI:
+			clock = osc_frequency(_HSI);
+			break;
+		case RCC_ASSCKSELR_HSE:
+			clock = osc_frequency(_HSE);
+			break;
+		case RCC_ASSCKSELR_PLL:
+			clock = stm32mp1_read_pll_freq(_PLL2, _DIV_P);
+			break;
+		default:
+			break;
+		}
+
+		/* System clock divider */
+		reg = read32(rcc_base + RCC_AXIDIVR);
+		clock /= stm32mp1_axi_div[reg & RCC_AXIDIV_MASK];
+
+		switch (p) {
+		case _PCLK4:
+			reg = read32(rcc_base + RCC_APB4DIVR);
+			clock >>= stm32mp1_apbx_div[reg & RCC_APBXDIV_MASK];
+			break;
+		case _PCLK5:
+			reg = read32(rcc_base + RCC_APB5DIVR);
+			clock >>= stm32mp1_apbx_div[reg & RCC_APBXDIV_MASK];
+			break;
+		default:
+			break;
+		}
+		break;
+	/* MCU sub system */
+	case _CK_MCU:
+	case _PCLK1:
+	case _PCLK2:
+	case _PCLK3:
+		reg = read32(rcc_base + RCC_MSSCKSELR);
+		switch (reg & RCC_SELR_SRC_MASK) {
+		case RCC_MSSCKSELR_HSI:
+			clock = osc_frequency(_HSI);
+			break;
+		case RCC_MSSCKSELR_HSE:
+			clock = osc_frequency(_HSE);
+			break;
+		case RCC_MSSCKSELR_CSI:
+			clock = osc_frequency(_CSI);
+			break;
+		case RCC_MSSCKSELR_PLL:
+			clock = stm32mp1_read_pll_freq(_PLL3, _DIV_P);
+			break;
+		default:
+			break;
+		}
+
+		/* MCU clock divider */
+		reg = read32(rcc_base + RCC_MCUDIVR);
+		clock >>= stm32mp1_mcu_div[reg & RCC_MCUDIV_MASK];
+
+		switch (p) {
+		case _PCLK1:
+			reg = read32(rcc_base + RCC_APB1DIVR);
+			clock >>= stm32mp1_apbx_div[reg & RCC_APBXDIV_MASK];
+			break;
+		case _PCLK2:
+			reg = read32(rcc_base + RCC_APB2DIVR);
+			clock >>= stm32mp1_apbx_div[reg & RCC_APBXDIV_MASK];
+			break;
+		case _PCLK3:
+			reg = read32(rcc_base + RCC_APB3DIVR);
+			clock >>= stm32mp1_apbx_div[reg & RCC_APBXDIV_MASK];
+			break;
+		case _CK_MCU:
+		default:
+			break;
+		}
+		break;
+	case _CK_PER:
+		reg = read32(rcc_base + RCC_CPERCKSELR);
+		switch (reg & RCC_SELR_SRC_MASK) {
+		case RCC_CPERCKSELR_HSI:
+			clock = osc_frequency(_HSI);
+			break;
+		case RCC_CPERCKSELR_HSE:
+			clock = osc_frequency(_HSE);
+			break;
+		case RCC_CPERCKSELR_CSI:
+			clock = osc_frequency(_CSI);
+			break;
+		default:
+			break;
+		}
+		break;
+	case _HSI:
+	case _HSI_KER:
+		clock = osc_frequency(_HSI);
+		break;
+	case _CSI:
+	case _CSI_KER:
+		clock = osc_frequency(_CSI);
+		break;
+	case _HSE:
+	case _HSE_KER:
+		clock = osc_frequency(_HSE);
+		break;
+	case _HSE_KER_DIV2:
+		clock = osc_frequency(_HSE) >> 1;
+		break;
+	case _LSI:
+		clock = osc_frequency(_LSI);
+		break;
+	case _LSE:
+		clock = osc_frequency(_LSE);
+		break;
+	/* PLL */
+	case _PLL1_P:
+		clock = stm32mp1_read_pll_freq(_PLL1, _DIV_P);
+		break;
+	case _PLL1_Q:
+		clock = stm32mp1_read_pll_freq(_PLL1, _DIV_Q);
+		break;
+	case _PLL1_R:
+		clock = stm32mp1_read_pll_freq(_PLL1, _DIV_R);
+		break;
+	case _PLL2_P:
+		clock = stm32mp1_read_pll_freq(_PLL2, _DIV_P);
+		break;
+	case _PLL2_Q:
+		clock = stm32mp1_read_pll_freq(_PLL2, _DIV_Q);
+		break;
+	case _PLL2_R:
+		clock = stm32mp1_read_pll_freq(_PLL2, _DIV_R);
+		break;
+	case _PLL3_P:
+		clock = stm32mp1_read_pll_freq(_PLL3, _DIV_P);
+		break;
+	case _PLL3_Q:
+		clock = stm32mp1_read_pll_freq(_PLL3, _DIV_Q);
+		break;
+	case _PLL3_R:
+		clock = stm32mp1_read_pll_freq(_PLL3, _DIV_R);
+		break;
+	case _PLL4_P:
+		clock = stm32mp1_read_pll_freq(_PLL4, _DIV_P);
+		break;
+	case _PLL4_Q:
+		clock = stm32mp1_read_pll_freq(_PLL4, _DIV_Q);
+		break;
+	case _PLL4_R:
+		clock = stm32mp1_read_pll_freq(_PLL4, _DIV_R);
+		break;
+	/* Other */
+	case _USB_PHY_48:
+		clock = osc_frequency(_USB_PHY_48);
+		break;
+	default:
+		break;
+	}
+
+	return clock;
+}
+
+static void __clk_enable(struct stm32mp1_clk_gate const *gate)
+{
+	uintptr_t base = stm32_rcc_base();
+	uint32_t bit = BIT(gate->bit);
+
+	if (gate->set_clr)
+		write32(bit, base + gate->offset);
+	else
+		io_setbits32(base + gate->offset, bit);
+
+	FMSG("Clock %u has been enabled", gate->clock_id);
+}
+
+static void __clk_disable(struct stm32mp1_clk_gate const *gate)
+{
+	uintptr_t base = stm32_rcc_base();
+	uint32_t bit = BIT(gate->bit);
+
+	if (gate->set_clr)
+		write32(bit, base + gate->offset + RCC_MP_ENCLRR_OFFSET);
+	else
+		io_clrbits32(base + gate->offset, bit);
+
+	FMSG("Clock %u has been disabled", gate->clock_id);
+}
+
+static bool __clk_is_enabled(struct stm32mp1_clk_gate const *gate)
+{
+	uintptr_t base = stm32_rcc_base();
+
+	return read32(base + gate->offset) & BIT(gate->bit);
+}
+
+bool stm32mp1_clk_is_enabled(unsigned long id)
+{
+	int i = stm32mp1_clk_get_gated_id(id);
+
+	if (i < 0)
+		return false;
+
+	return __clk_is_enabled(gate_ref(i));
+}
+
+void stm32mp1_clk_enable(unsigned long id)
+{
+	int i = stm32mp1_clk_get_gated_id(id);
+	uint32_t exceptions;
+
+	if (i < 0) {
+		DMSG("Invalid clock %lu: %d", id, i);
+		panic();
+	}
+
+	exceptions = may_spin_lock(&refcount_lock);
+
+	if (!gate_refcounts[i])
+		__clk_enable(gate_ref(i));
+
+	gate_refcounts[i]++;
+
+	may_spin_unlock(&refcount_lock, exceptions);
+}
+
+void stm32mp1_clk_disable(unsigned long id)
+{
+	int i = stm32mp1_clk_get_gated_id(id);
+	uint32_t exceptions;
+
+	if (i < 0) {
+		DMSG("Invalid clock %lu: %d", id, i);
+		panic();
+	}
+
+	exceptions = may_spin_lock(&refcount_lock);
+
+	assert(gate_refcounts[i]);
+	gate_refcounts[i]--;
+	if (!gate_refcounts[i])
+		__clk_disable(gate_ref(i));
+
+	may_spin_unlock(&refcount_lock, exceptions);
+}
+
+static long get_timer_rate(long parent_rate, unsigned int apb_bus)
+{
+	uint32_t timgxpre;
+	uint32_t apbxdiv;
+	uintptr_t rcc_base = stm32_rcc_base();
+
+	switch (apb_bus) {
+	case 1:
+		apbxdiv = read32(rcc_base + RCC_APB1DIVR) &
+			  RCC_APBXDIV_MASK;
+		timgxpre = read32(rcc_base + RCC_TIMG1PRER) &
+			   RCC_TIMGXPRER_TIMGXPRE;
+		break;
+	case 2:
+		apbxdiv = read32(rcc_base + RCC_APB2DIVR) &
+			  RCC_APBXDIV_MASK;
+		timgxpre = read32(rcc_base + RCC_TIMG2PRER) &
+			   RCC_TIMGXPRER_TIMGXPRE;
+		break;
+	default:
+		panic();
+		break;
+	}
+
+	if (apbxdiv == 0)
+		return parent_rate;
+
+	return parent_rate * (timgxpre + 1) * 2;
+}
+
+unsigned long stm32mp1_clk_get_rate(unsigned long id)
+{
+	int p;
+	unsigned long rate;
+
+	p = stm32mp1_clk_get_parent(id);
+	if (p < 0)
+		return 0;
+
+	rate = get_clock_rate(p);
+
+	if ((id >= TIM2_K) && (id <= TIM14_K))
+		rate = get_timer_rate(rate, 1);
+
+	if ((id >= TIM1_K) && (id <= TIM17_K))
+		rate = get_timer_rate(rate, 2);
+
+	return rate;
+}

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -10,11 +10,16 @@
 #include <initcall.h>
 #include <io.h>
 #include <keep.h>
+#include <kernel/dt.h>
 #include <kernel/panic.h>
 #include <kernel/spinlock.h>
 #include <stm32_util.h>
 #include <trace.h>
 #include <util.h>
+
+#ifdef CFG_DT
+#include <libfdt.h>
+#endif
 
 /* Identifiers for parent clocks */
 enum stm32mp1_parent_id {
@@ -955,3 +960,132 @@ unsigned long stm32mp1_clk_get_rate(unsigned long id)
 
 	return rate;
 }
+
+#ifdef CFG_EMBED_DTB
+
+#define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"
+
+static const char *stm32mp_osc_node_label[NB_OSC] = {
+	[_LSI] = "clk-lsi",
+	[_LSE] = "clk-lse",
+	[_HSI] = "clk-hsi",
+	[_HSE] = "clk-hse",
+	[_CSI] = "clk-csi",
+	[_I2S_CKIN] = "i2s_ckin",
+	[_USB_PHY_48] = "ck_usbo_48m"
+};
+
+static unsigned int clk_freq_prop(void *fdt, int node)
+{
+	int ret;
+	const fdt32_t *cuint = fdt_getprop(fdt, node, "clock-frequency", &ret);
+
+	if (!cuint)
+		panic();
+
+	return fdt32_to_cpu(*cuint);
+}
+
+static void get_osc_freq_from_dt(void *fdt)
+{
+	enum stm32mp_osc_id idx;
+	int clk_node = fdt_path_offset(fdt, "/clocks");
+
+	if (clk_node < 0)
+		panic();
+
+	for (idx = (enum stm32mp_osc_id)0 ; idx < NB_OSC; idx++) {
+		const char *name = stm32mp_osc_node_label[idx];
+		int subnode;
+
+		fdt_for_each_subnode(subnode, fdt, clk_node) {
+			const char *cchar;
+			int ret;
+
+			cchar = fdt_get_name(fdt, subnode, &ret);
+			if (!cchar)
+				panic();
+
+			if (strncmp(cchar, name, (size_t)ret) == 0) {
+				stm32mp1_osc[idx] = clk_freq_prop(fdt, subnode);
+
+				DMSG("Osc %s: %lu Hz", name, stm32mp1_osc[idx]);
+				break;
+			}
+		}
+
+		if (!stm32mp1_osc[idx])
+			DMSG("Osc %s: no frequency info", name);
+	}
+}
+
+/*
+ * Check that the device tree does not provide clock tree configuration
+ * information. Such configuration would not be applied since the early boot
+ * loader is in charge of configuring the clock tree and enabling the PLLs.
+ */
+static TEE_Result stm32mp1_clk_early_init(void)
+{
+	void *fdt;
+	uintptr_t rcc_base = stm32_rcc_base();
+	int node;
+	unsigned int i;
+	int len;
+	int ignored = 0;
+
+	fdt = get_embedded_dt();
+	node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_CLK_COMPAT);
+
+	if (node < 0 || _fdt_reg_base_address(fdt, node) != RCC_BASE)
+		panic();
+
+	if (_fdt_get_status(fdt, node) & DT_STATUS_OK_SEC) {
+		io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
+	} else {
+		io_clrbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
+		IMSG("RCC is non-secure");
+	}
+
+	get_osc_freq_from_dt(fdt);
+
+	/*
+	 * OP-TEE core is not in charge of configuring clock parenthood.
+	 * This is expected from an earlier boot stage. Modifying the clock
+	 * tree parenthood here may jeopardize already configured clocks.
+	 * * The sequence below ignores such DT directives with a friendly
+	 * debug trace.
+	 */
+	if (fdt_getprop(fdt, node, "st,clksrc", &len)) {
+		DMSG("Ignore source clocks configuration from DT");
+		ignored++;
+	}
+	if (fdt_getprop(fdt, node, "st,clkdiv", &len)) {
+		DMSG("Ignore clock divisors configuration from DT");
+		ignored++;
+	}
+	if (fdt_getprop(fdt, node, "st,pkcs", &len)) {
+		DMSG("Ignore peripheral clocks tree configuration from DT");
+		ignored++;
+	}
+	for (i = (enum stm32mp1_pll_id)0; i < _PLL_NB; i++) {
+		char name[] = "st,pll@X";
+
+		snprintf(name, sizeof(name), "st,pll@%d", i);
+		node = fdt_subnode_offset(fdt, node, name);
+		if (node < 0)
+			continue;
+
+		if (fdt_getprop(fdt, node, "cfg", &len) ||
+		    fdt_getprop(fdt, node, "frac", &len)) {
+			DMSG("Ignore PLL%u configurations from DT", i);
+			ignored++;
+		}
+	}
+
+	if (ignored != 0)
+		IMSG("DT clock tree configurations were ignored");
+
+	return TEE_SUCCESS;
+}
+service_init(stm32mp1_clk_early_init);
+#endif /*CFG_EMBED_DTB*/

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (C) 2018-2019, STMicroelectronics
+ */
+
+#ifndef __STM32MP1_CLK_H
+#define __STM32MP1_CLK_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+enum stm32mp_osc_id {
+	_HSI = 0,
+	_HSE,
+	_CSI,
+	_LSI,
+	_LSE,
+	_I2S_CKIN,
+	_USB_PHY_48,
+	NB_OSC,
+	_UNKNOWN_OSC_ID = 0xffU
+};
+
+/*
+ * Enable target clock with reference counting
+ * @id: Target clock (see stm32mp1 clock bindings IDs)
+ */
+void stm32mp1_clk_enable(unsigned long id);
+
+/*
+ * Disable target clock with reference counting
+ * @id: Target clock (see stm32mp1 clock bindings IDs)
+ */
+void stm32mp1_clk_disable(unsigned long id);
+
+/*
+ * Return whether target clock is enabled or not
+ * @id: Target clock (see stm32mp1 clock bindings IDs)
+ */
+bool stm32mp1_clk_is_enabled(unsigned long id);
+
+/*
+ * Get target clock frequency
+ * @id: Target clock (see stm32mp1 clock bindings IDs)
+ * Return the frequency in Hertz
+ */
+unsigned long stm32mp1_clk_get_rate(unsigned long id);
+
+#endif /*__STM32MP1_CLK_H*/

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
@@ -3,8 +3,6 @@
  * Copyright (c) 2018, STMicroelectronics
  */
 
-#include <drivers/stm32mp1_rcc.h>
-#include <io.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
 

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -6,6 +6,7 @@
 #ifndef __STM32MP1_RCC_H__
 #define __STM32MP1_RCC_H__
 
+#include <io.h>
 #include <stdbool.h>
 #include <util.h>
 
@@ -240,7 +241,7 @@
 #define RCC_TZCR_TZEN			BIT(0)
 #define RCC_TZCR_MCKPROT		BIT(1)
 
-/* used for most of SELR registers */
+/* Used for most of RCC_<x>SELR registers */
 #define RCC_SELR_SRC_MASK		GENMASK_32(2, 0)
 #define RCC_SELR_REFCLK_SRC_MASK	GENMASK_32(1, 0)
 #define RCC_SELR_SRCRDY			BIT(31)
@@ -267,7 +268,7 @@
 #define RCC_CPERCKSELR_CSI		0x00000001
 #define RCC_CPERCKSELR_HSE		0x00000002
 
-/* used for most of DIVR register : max div for RTC */
+/* used for most of RCC_<x>DIVR registers: max div for RTC */
 #define RCC_DIVR_DIV_MASK		GENMASK_32(5, 0)
 #define RCC_DIVR_DIVRDY			BIT(31)
 
@@ -276,6 +277,9 @@
 #define RCC_MPUDIV_MASK			GENMASK_32(2, 0)
 #define RCC_AXIDIV_MASK			GENMASK_32(2, 0)
 #define RCC_MCUDIV_MASK			GENMASK_32(3, 0)
+
+/* Used for TIMER Prescaler */
+#define RCC_TIMGXPRER_TIMGXPRE		BIT(0)
 
 /* Offset between RCC_MP_xxxENSETR and RCC_MP_xxxENCLRR registers */
 #define RCC_MP_ENCLRR_OFFSET		4u
@@ -297,7 +301,7 @@
 #define RCC_RDLSICR_LSION		BIT(0)
 #define RCC_RDLSICR_LSIRDY		BIT(1)
 
-/* used for ALL PLLNCR registers */
+/* Used for all RCC_PLL<n>CR registers */
 #define RCC_PLLNCR_PLLON		BIT(0)
 #define RCC_PLLNCR_PLLRDY		BIT(1)
 #define RCC_PLLNCR_SSCG_CTRL		BIT(2)
@@ -306,16 +310,16 @@
 #define RCC_PLLNCR_DIVREN		BIT(6)
 #define RCC_PLLNCR_DIVEN_SHIFT		4
 
-/* used for ALL PLLNCFGR1 registers */
+/* Used for all RCC_PLL<n>CFGR1 registers */
 #define RCC_PLLNCFGR1_DIVM_SHIFT	16
 #define RCC_PLLNCFGR1_DIVM_MASK		GENMASK_32(21, 16)
 #define RCC_PLLNCFGR1_DIVN_SHIFT	0
 #define RCC_PLLNCFGR1_DIVN_MASK		GENMASK_32(8, 0)
-/* only for PLL3 and PLL4 */
+/* Only for PLL3 and PLL4 */
 #define RCC_PLLNCFGR1_IFRGE_SHIFT	24
 #define RCC_PLLNCFGR1_IFRGE_MASK	GENMASK_32(25, 24)
 
-/* used for ALL PLLNCFGR2 registers */
+/* Used for all RCC_PLL<n>CFGR2 registers */
 #define RCC_PLLNCFGR2_DIVX_MASK		GENMASK_32(6, 0)
 #define RCC_PLLNCFGR2_DIVP_SHIFT	0
 #define RCC_PLLNCFGR2_DIVP_MASK		GENMASK_32(6, 0)
@@ -324,12 +328,12 @@
 #define RCC_PLLNCFGR2_DIVR_SHIFT	16
 #define RCC_PLLNCFGR2_DIVR_MASK		GENMASK_32(22, 16)
 
-/* used for ALL PLLNFRACR registers */
+/* Used for all RCC_PLL<n>FRACR registers */
 #define RCC_PLLNFRACR_FRACV_SHIFT	3
 #define RCC_PLLNFRACR_FRACV_MASK	GENMASK_32(15, 3)
 #define RCC_PLLNFRACR_FRACLE		BIT(16)
 
-/* used for ALL PLLNCSGR registers */
+/* Used for all RCC_PLL<n>CSGR registers */
 #define RCC_PLLNCSGR_INC_STEP_SHIFT	16
 #define RCC_PLLNCSGR_INC_STEP_MASK	GENMASK_32(30, 16)
 #define RCC_PLLNCSGR_MOD_PER_SHIFT	0
@@ -337,7 +341,7 @@
 #define RCC_PLLNCSGR_SSCG_MODE_SHIFT	15
 #define RCC_PLLNCSGR_SSCG_MODE_MASK	BIT(15)
 
-/* used for RCC_OCENSETR and RCC_OCENCLRR registers */
+/* Used for RCC_OCENSETR and RCC_OCENCLRR registers */
 #define RCC_OCENR_HSION			BIT(0)
 #define RCC_OCENR_HSIKERON		BIT(1)
 #define RCC_OCENR_CSION			BIT(4)
@@ -354,7 +358,7 @@
 #define RCC_OCRDYR_CSIRDY		BIT(4)
 #define RCC_OCRDYR_HSERDY		BIT(8)
 
-/* Fields of DDRITFCR register */
+/* Fields of RCC_DDRITFCR register */
 #define RCC_DDRITFCR_DDRC1EN		BIT(0)
 #define RCC_DDRITFCR_DDRC1LPEN		BIT(1)
 #define RCC_DDRITFCR_DDRC2EN		BIT(2)
@@ -381,8 +385,18 @@
 
 /* Fields of RCC_HSICFGR register */
 #define RCC_HSICFGR_HSIDIV_MASK		GENMASK_32(1, 0)
+#define RCC_HSICFGR_HSITRIM_SHIFT	8
+#define RCC_HSICFGR_HSITRIM_MASK	GENMASK_32(14, 8)
+#define RCC_HSICFGR_HSICAL_SHIFT	16
+#define RCC_HSICFGR_HSICAL_MASK		GENMASK_32(27, 16)
 
-/* used for MCO related operations */
+/* Fields of RCC_CSICFGR register */
+#define RCC_CSICFGR_CSITRIM_SHIFT	8
+#define RCC_CSICFGR_CSITRIM_MASK	GENMASK_32(12, 8)
+#define RCC_CSICFGR_CSICAL_SHIFT	16
+#define RCC_CSICFGR_CSICAL_MASK		GENMASK_32(23, 16)
+
+/* Used for RCC_MCO related operations */
 #define RCC_MCOCFG_MCOON		BIT(12)
 #define RCC_MCOCFG_MCODIV_MASK		GENMASK_32(7, 4)
 #define RCC_MCOCFG_MCODIV_SHIFT		4
@@ -411,8 +425,6 @@
 #define RCC_MP_GRSTCSETR_MPUP1RST	BIT(5)
 
 /* Clock Source Interrupt Flag Register */
-#define RCC_MP_CIFR_MASK		(BIT(20) | BIT(16) | \
-					 GENMASK_32(11, 8) | GENMASK_32(4, 0))
 #define RCC_MP_CIFR_LSIRDYF		BIT(0)
 #define RCC_MP_CIFR_LSERDYF		BIT(1)
 #define RCC_MP_CIFR_HSIRDYF		BIT(2)
@@ -424,6 +436,12 @@
 #define RCC_MP_CIFR_PLL4DYF		BIT(11)
 #define RCC_MP_CIFR_LSECSSF		BIT(16)
 #define RCC_MP_CIFR_WKUPF		BIT(20)
+#define RCC_MP_CIFR_MASK		(RCC_MP_CIFR_LSIRDYF | RCC_MP_CIFR_LSERDYF | \
+				 RCC_MP_CIFR_HSIRDYF | RCC_MP_CIFR_HSERDYF | \
+				 RCC_MP_CIFR_CSIRDYF | RCC_MP_CIFR_PLL1DYF | \
+				 RCC_MP_CIFR_PLL2DYF | RCC_MP_CIFR_PLL3DYF | \
+				 RCC_MP_CIFR_PLL4DYF | RCC_MP_CIFR_LSECSSF | \
+				 RCC_MP_CIFR_WKUPF)
 
 /* Stop Request Set Register */
 #define RCC_MP_SREQSETR_STPREQ_P0	BIT(0)
@@ -514,8 +532,16 @@
 
 #ifndef ASM
 uintptr_t stm32_rcc_base(void);
-void stm32_rcc_secure(int enable);
-bool stm32_rcc_is_secure(void);
-#endif
+
+static inline bool stm32_rcc_is_secure(void)
+{
+	return read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN;
+}
+
+static inline bool stm32_rcc_is_mckprot(void)
+{
+	return read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_MCKPROT;
+}
+#endif /*ASM*/
 
 #endif /*__STM32MP1_RCC_H__*/

--- a/core/arch/arm/plat-stm32mp1/drivers/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/drivers/sub.mk
@@ -1,1 +1,2 @@
+srcs-y 	+= stm32mp1_clk.c
 srcs-y 	+= stm32mp1_rcc.c

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -34,6 +34,7 @@ register_phys_mem(MEM_AREA_IO_NSEC, UART8_BASE, SMALL_PAGE_SIZE);
 #endif
 
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, RCC_BASE, SMALL_PAGE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, TAMP_BASE, SMALL_PAGE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, USART1_BASE, SMALL_PAGE_SIZE);
 

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics
+ */
+
+#include <drivers/stm32mp1_clk.h>
+
+unsigned long stm32_clock_get_rate(unsigned long id)
+{
+	return stm32mp1_clk_get_rate(id);
+}
+
+bool stm32_clock_is_enabled(unsigned long id)
+{
+	return stm32mp1_clk_is_enabled(id);
+}
+
+void stm32_clock_enable(unsigned long id)
+{
+	stm32mp1_clk_enable(id);
+}
+
+void stm32_clock_disable(unsigned long id)
+{
+	stm32mp1_clk_disable(id);
+}

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -31,4 +31,13 @@ static inline void stm32mp_register_online_cpu(void)
 uint32_t may_spin_lock(unsigned int *lock);
 void may_spin_unlock(unsigned int *lock, uint32_t exceptions);
 
+/*
+ * Util for clock gating and to get clock rate for stm32 and platform drivers
+ * @id: Target clock ID, ID used in clock DT bindings
+ */
+void stm32_clock_enable(unsigned long id);
+void stm32_clock_disable(unsigned long id);
+static unsigned long stm32_clock_get_rate(unsigned long id);
+static bool stm32_clock_is_enabled(unsigned long id);
+
 #endif /*__STM32_UTIL_H__*/

--- a/core/arch/arm/plat-stm32mp1/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/sub.mk
@@ -2,6 +2,7 @@ global-incdirs-y += .
 
 srcs-y += main.c
 srcs-y += reset.S
+srcs-y += shared_resources.c
 
 subdirs-y += drivers
 subdirs-y += pm


### PR DESCRIPTION
Introduce stm32mp1 platform clock driver.

Driver API uses the clock IDs published in the DT bindings (as per later Linux kernel v4.20) to identify the clocks.

Note configuration of clock parenthood and related divisors as well as configuration of the PLLs are under to responsibility of an earlier boot stage. Such configuration directives found by OP-TEE core in the DT are ignored. DT is used to set the SoC clocks interface secure state and the frequencies of the platform source clocks.

Driver API allows to gate (enable/disable) a clock, get a clock enable state and its frequency.