### PR TITLE
mbedtls: fix memory leak in mpi_miller_rabin()

### DIFF
--- a/lib/libmbedtls/mbedtls/library/bignum.c
+++ b/lib/libmbedtls/mbedtls/library/bignum.c
@@ -2180,7 +2180,8 @@ static int mpi_miller_rabin( const mbedtls_mpi *X,
             }
 
             if (count++ > 300) {
-                return MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+                ret = MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+                goto cleanup;
             }
 
         } while ( mbedtls_mpi_cmp_mpi( &A, &W ) >= 0 ||


### PR DESCRIPTION
Fixes memory leak in mpi_miller_rabin() that occurs when the function has
failed to obtain a usable random 'A' 300 turns in a row.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.