### PR TITLE
stm32mp1: PWR support

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.c
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2018-2019, STMicroelectronics
+ */
+
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <drivers/stm32mp1_pwr.h>
+
+uintptr_t stm32_pwr_base(void)
+{
+	static void *va;
+
+	if (!cpu_mmu_enabled())
+		return PWR_BASE;
+
+	if (!va)
+		va = phys_to_virt(PWR_BASE, MEM_AREA_IO_SEC);
+
+	return (uintptr_t)va;
+}

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2018-2019, STMicroelectronics
+ */
+
+#ifndef __STM32MP1_PWR_H
+#define __STM32MP1_PWR_H
+
+#include <util.h>
+
+#define PWR_CR1_OFF		0x00
+#define PWR_CR2_OFF		0x08
+#define PWR_CR3_OFF		0x0c
+#define PWR_MPUCR_OFF		0x10
+#define PWR_WKUPCR_OFF		0x20
+#define PWR_MPUWKUPENR_OFF	0x28
+
+#define PWR_OFFSET_MASK		0x3fUL
+
+uintptr_t stm32_pwr_base(void);
+
+#endif /*__STM32MP1_PWR_H*/

--- a/core/arch/arm/plat-stm32mp1/drivers/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/drivers/sub.mk
@@ -1,1 +1,2 @@
+srcs-y 	+= stm32mp1_pwr.c
 srcs-y 	+= stm32mp1_rcc.c

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -34,6 +34,7 @@ register_phys_mem(MEM_AREA_IO_NSEC, UART8_BASE, SMALL_PAGE_SIZE);
 #endif
 
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, PWR_BASE, SMALL_PAGE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, TAMP_BASE, SMALL_PAGE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, USART1_BASE, SMALL_PAGE_SIZE);
 

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -13,6 +13,7 @@
 
 /* SoC interface registers base address */
 #define GIC_BASE			0xa0021000ul
+#define PWR_BASE			0x50001000
 #define RCC_BASE			0x50000000
 #define TAMP_BASE			0x5c00a000
 #define UART1_BASE			0x5c000000


### PR DESCRIPTION
PWR is a memory mapped SoC interface for power control. This change maps and defines the interface for the stm32mp1 platform.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
