### PR TITLE
trace: fix core id print if in non-atomic context

### DIFF
--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -73,7 +73,7 @@ static int print_thread_id(char *buf, size_t bs)
 #if defined(__KERNEL__)
 static int print_core_id(char *buf, size_t bs)
 {
-#if CFG_TEE_CORE_NB_CORE > 9
+#if CFG_TEE_CORE_NB_CORE > 10
 	const int num_digits = 2;
 #else
 	const int num_digits = 1;
@@ -82,7 +82,7 @@ static int print_core_id(char *buf, size_t bs)
 	if (thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR)
 		return snprintk(buf, bs, "%0*zu ", num_digits, get_core_pos());
 	else
-		return snprintk(buf, bs, "%*s ", num_digits, "?");
+		return snprintk(buf, bs, "%s ", num_digits > 1 ? "??" : "?");
 }
 #else  /* defined(__KERNEL__) */
 static int print_core_id(char *buf __unused, size_t bs __unused)

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -16,7 +16,7 @@ CALL_STACK_RE = re.compile('Call stack:')
 # This gets the address from lines looking like this:
 # E/TC:0  0x001044a8
 STACK_ADDR_RE = re.compile(
-    r'[UEIDFM]/T[AC]:(\?|[0-9]+) [0-9]* +(?P<addr>0x[0-9a-f]+)')
+    r'[UEIDFM]/T[AC]:(\?+|[0-9]+) [0-9]* +(?P<addr>0x[0-9a-f]+)')
 ABORT_ADDR_RE = re.compile(r'-abort at address (?P<addr>0x[0-9a-f]+)')
 REGION_RE = re.compile(r'region [0-9]+: va (?P<addr>0x[0-9a-f]+) '
                        r'pa 0x[0-9a-f]+ size (?P<size>0x[0-9a-f]+)'


### PR DESCRIPTION
We don't need 2 digits print for '?' in case of non-atomic context.
So make it single digit print only.

It causes symbolize.py script parsing failure for call stack addresses
in case number of cores is greater that 9.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
