### PR TITLE
scripts/symbolize.py: fix for platforms with more than 9 cores

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -16,7 +16,7 @@ CALL_STACK_RE = re.compile('Call stack:')
 # This gets the address from lines looking like this:
 # E/TC:0  0x001044a8
 STACK_ADDR_RE = re.compile(
-    r'[UEIDFM]/T[AC]:(\?|[0-9]+) [0-9]* +(?P<addr>0x[0-9a-f]+)')
+    r'[UEIDFM]/T[AC]:(\?|[0-9]+) +[0-9]* +(?P<addr>0x[0-9a-f]+)')
 ABORT_ADDR_RE = re.compile(r'-abort at address (?P<addr>0x[0-9a-f]+)')
 REGION_RE = re.compile(r'region [0-9]+: va (?P<addr>0x[0-9a-f]+) '
                        r'pa 0x[0-9a-f]+ size (?P<size>0x[0-9a-f]+)'

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -16,7 +16,7 @@ CALL_STACK_RE = re.compile('Call stack:')
 # This gets the address from lines looking like this:
 # E/TC:0  0x001044a8
 STACK_ADDR_RE = re.compile(
-    r'[UEIDFM]/T[AC]:(\?|[0-9]+) +[0-9]* +(?P<addr>0x[0-9a-f]+)')
+    r'[UEIDFM]/T[AC]:( *\?|[0-9]+) +[0-9]* +(?P<addr>0x[0-9a-f]+)')
 ABORT_ADDR_RE = re.compile(r'-abort at address (?P<addr>0x[0-9a-f]+)')
 REGION_RE = re.compile(r'region [0-9]+: va (?P<addr>0x[0-9a-f]+) '
                        r'pa 0x[0-9a-f]+ size (?P<size>0x[0-9a-f]+)'


### PR DESCRIPTION
On platforms with more than 9 CPU cores, the call stack printed by xMSG()
may contain additional spaces for alignment purposes. The current
regexp in symbolize.py will not match that string, causing the call stack
not to be decoded. Fix the issue by allowing an unspecified number of
spaces.

Reported-by: Sumit Garg <sumit.garg@linaro.org>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
