### PR TITLE
core:syscall_storage_obj_create():fix a memory leak

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -447,6 +447,7 @@ TEE_Result syscall_storage_obj_create(unsigned long storage_id, void *object_id,
 	    TEE_HANDLE_FLAG_PERSISTENT | TEE_HANDLE_FLAG_INITIALIZED;
 	o->flags = flags;
 	o->pobj = po;
+	o->attr = 0;
 
 	if (attr != TEE_HANDLE_NULL) {
 		res = tee_obj_get(utc, tee_svc_uref_to_vaddr(attr),
@@ -481,7 +482,7 @@ err:
 		fops->close(&o->fh);
 	if (po)
 		tee_pobj_release(po);
-	free(o);
+	tee_obj_free(o);
 
 	return res;
 }


### PR DESCRIPTION
Free the o->attr in the error handling part.

Fixes:OP-TEE#2738
Signed-off-by: Oliver Chiang <rockerfeynman@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
