### PR TITLE
plat-vexpress: disable uart IT with TF-A and GICv3

### DIFF
--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -119,7 +119,16 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
-#ifdef IT_CONSOLE_UART
+#if defined(IT_CONSOLE_UART) && \
+	!(defined(CFG_WITH_ARM_TRUSTED_FW) && defined(CFG_ARM_GICV3))
+/*
+ * This cannot be enabled with TF-A and GICv3 because TF-A then need to
+ * assign the interrupt number of the UART to OP-TEE (S-EL1). Currently
+ * there's no way of TF-A to know which interrupts that OP-TEE will serve.
+ * If TF-A doesn't assign the interrupt we're enabling below to OP-TEE it
+ * will hang in EL3 since the interrupt will just be delivered again and
+ * again.
+ */
 static enum itr_return console_itr_cb(struct itr_handler *h __unused)
 {
 	struct serial_chip *cons = &console_data.chip;


### PR DESCRIPTION
Disables uart interrupts if compiled for TF-A and GICv3 since TF-A
doesn't know which interrupts OP-TEE will handle.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
