### PR TITLE
core: check the value of tee_otp_get_die_id()

### DIFF
--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -148,7 +148,8 @@ static TEE_Result tee_fs_init_key_manager(void)
 	 *     message := concatenate(chip_id, static string)
 	 * */
 	tee_otp_get_hw_unique_key(&huk);
-	tee_otp_get_die_id(chip_id, sizeof(chip_id));
+	if (tee_otp_get_die_id(chip_id, sizeof(chip_id)))
+		return TEE_ERROR_BAD_STATE;
 
 	memcpy(message, chip_id, sizeof(chip_id));
 	memcpy(message + sizeof(chip_id), string_for_ssk_gen,


### PR DESCRIPTION
Just like the get_prop_tee_dev_id() in tee_svc.c, it returns
TEE_ERROR_BAD_STATE, when tee_otp_get_die_id() reports someting bad.
Put the same check in tee_fs_init_key_manager() as well.

Fixes: #2762
Signed-off-by: Oliver Chiang <rockerfeynman@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
