### PR TITLE
plat-rcar: Use generic memory layout

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -16,6 +16,9 @@ ifeq ($(PLATFORM_FLAVOR),salvator_m3)
 $(call force,CFG_TEE_CORE_NB_CORE,4)
 endif
 
+CFG_TZDRAM_START ?= 0x44100000
+CFG_TZDRAM_SIZE	 ?= 0x03D00000
+CFG_TEE_RAM_VA_SIZE ?= 0x100000
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_WITH_LPAE,y)
 supported-ta-targets = ta_arm64

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -29,24 +29,16 @@
 #ifndef PLATFORM_CONFIG_H
 #define PLATFORM_CONFIG_H
 
+#include <mm/generic_ram_layout.h>
+
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		64
-
-#ifdef ARM64
-#ifdef CFG_WITH_PAGER
-#error "Pager not supported for ARM64"
-#endif
-#endif /*ARM64*/
 
 #define GIC_BASE		0xF1000000
 #define GICC_BASE		0xF1020000
 #define GICD_BASE		0xF1010000
 
 #define CONSOLE_UART_BASE	0xE6E88000
-
-/* Location of trusted dram */
-#define TZDRAM_BASE		0x44000000
-#define TZDRAM_SIZE		0x03E00000
 
 #if defined(PLATFORM_FLAVOR_salvator_h3)
 #define NSEC_DDR_0_BASE		0x47E00000
@@ -69,28 +61,5 @@
 /* Full GlobalPlatform test suite requires TEE_SHMEM_SIZE to be at least 2MB */
 #define TEE_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
 #define TEE_SHMEM_SIZE		0x100000
-
-#define TEE_RAM_VA_SIZE		(1024 * 1024)
-
-#ifdef CFG_TEE_LOAD_ADDR
-#define TEE_LOAD_ADDR			CFG_TEE_LOAD_ADDR
-#else
-#define TEE_LOAD_ADDR			TEE_RAM_START
-#endif
-
-/*
- * Everything is in TZDRAM.
- * +------------------+
- * |        | TEE_RAM |
- * + TZDRAM +---------+
- * |        | TA_RAM  |
- * +--------+---------+
- */
-#define TEE_RAM_PH_SIZE		TEE_RAM_VA_SIZE
-#define TEE_RAM_START		(TZDRAM_BASE + 0x00100000)
-#define TA_RAM_START		ROUNDUP((TEE_RAM_START + TEE_RAM_VA_SIZE), \
-					CORE_MMU_DEVICE_SIZE)
-#define TA_RAM_SIZE		ROUNDDOWN((TZDRAM_SIZE - TEE_RAM_VA_SIZE), \
-					  CORE_MMU_DEVICE_SIZE)
 
 #endif /*PLATFORM_CONFIG_H*/


### PR DESCRIPTION
plat-rcar have quite standard memory layout, so there is no sense to maintain
separate configuration if it possible to use generic one.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
