### PR TITLE
mk/aosp_optee.mk: remove cp -u option

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -112,7 +112,7 @@ TA_TMP_DIR := $(subst /,_,$(LOCAL_PATH))
 TA_TMP_FILE := $(OPTEE_TA_OUT_DIR)/$(TA_TMP_DIR)/$(LOCAL_MODULE)
 $(LOCAL_PREBUILT_MODULE_FILE): $(TA_TMP_FILE)
 	@mkdir -p $(dir $@)
-	cp -uvf $< $@
+	cp -vf $< $@
 
 TA_TMP_FILE_DEPS :=
 ifneq ($(local_module_deps), )


### PR DESCRIPTION
AOPS's Toybox's version of cp doesn't support -u option

Signed-off-by: Victor Chong <victor.chong@linaro.org>
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
