### PR TITLE
scripts: re-indent Python scripts

### DIFF
--- a/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
+++ b/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
@@ -18,123 +18,123 @@ hdr_edcsa_algo = 1
 
 
 def get_size(file):
-        file.seek(0, 2)        # End of the file
-        size = file.tell()
-        return size
+    file.seek(0, 2)        # End of the file
+    size = file.tell()
+    return size
 
 
 def stm32image_checksum(dest_fd, sizedest):
-        csum = 0
-        if sizedest < header_size:
-                return 0
-        dest_fd.seek(header_size, 0)
-        length = sizedest - header_size
-        while length > 0:
-            csum += ord(dest_fd.read(1))
-            length -= 1
-        return csum
+    csum = 0
+    if sizedest < header_size:
+        return 0
+    dest_fd.seek(header_size, 0)
+    length = sizedest - header_size
+    while length > 0:
+        csum += ord(dest_fd.read(1))
+        length -= 1
+    return csum
 
 
 def stm32image_set_header(dest_fd, load, entry, bintype):
-        sizedest = get_size(dest_fd)
+    sizedest = get_size(dest_fd)
 
-        checksum = stm32image_checksum(dest_fd, sizedest)
+    checksum = stm32image_checksum(dest_fd, sizedest)
 
-        dest_fd.seek(0, 0)
+    dest_fd.seek(0, 0)
 
-        # Magic number
-        dest_fd.write(struct.pack('<I', hdr_magic_number))
+    # Magic number
+    dest_fd.write(struct.pack('<I', hdr_magic_number))
 
-        # Image signature (empty)
-        dest_fd.write(b'\x00' * 64)
+    # Image signature (empty)
+    dest_fd.write(b'\x00' * 64)
 
-        # Image checksum ... EDCSA algorithm
-        dest_fd.write(struct.pack('<IBBBBIIIIIIII',
-                      checksum,
-                      hdr_header_ver_variant,
-                      hdr_header_ver_minor,
-                      hdr_header_ver_major,
-                      0,
-                      sizedest - header_size,
-                      entry,
-                      0,
-                      load,
-                      0,
-                      hdr_version_number,
-                      hdr_option_flags,
-                      hdr_edcsa_algo))
+    # Image checksum ... EDCSA algorithm
+    dest_fd.write(struct.pack('<IBBBBIIIIIIII',
+                  checksum,
+                  hdr_header_ver_variant,
+                  hdr_header_ver_minor,
+                  hdr_header_ver_major,
+                  0,
+                  sizedest - header_size,
+                  entry,
+                  0,
+                  load,
+                  0,
+                  hdr_version_number,
+                  hdr_option_flags,
+                  hdr_edcsa_algo))
 
-        # EDCSA public key (empty)
-        dest_fd.write(b'\x00' * 64)
+    # EDCSA public key (empty)
+    dest_fd.write(b'\x00' * 64)
 
-        # Padding
-        dest_fd.write(b'\x00' * 83)
-        dest_fd.write(struct.pack('<B', bintype))
-        dest_fd.close()
+    # Padding
+    dest_fd.write(b'\x00' * 83)
+    dest_fd.write(struct.pack('<B', bintype))
+    dest_fd.close()
 
 
 def stm32image_create_header_file(source, dest, load, entry, bintype):
-        dest_fd = open(dest, 'w+b')
-        src_fd = open(source, 'rb')
+    dest_fd = open(dest, 'w+b')
+    src_fd = open(source, 'rb')
 
-        dest_fd.write(b'\x00' * header_size)
+    dest_fd.write(b'\x00' * header_size)
 
-        sizesrc = get_size(src_fd)
-        if sizesrc > 0:
-                mmsrc = mmap.mmap(src_fd.fileno(), 0, access=mmap.ACCESS_READ)
-                dest_fd.write(mmsrc[:sizesrc])
-                mmsrc.close()
+    sizesrc = get_size(src_fd)
+    if sizesrc > 0:
+        mmsrc = mmap.mmap(src_fd.fileno(), 0, access=mmap.ACCESS_READ)
+        dest_fd.write(mmsrc[:sizesrc])
+        mmsrc.close()
 
-        src_fd.close()
+    src_fd.close()
 
-        stm32image_set_header(dest_fd, load, entry, bintype)
+    stm32image_set_header(dest_fd, load, entry, bintype)
 
-        dest_fd.close()
+    dest_fd.close()
 
 
 def int_parse(str):
-        return int(str, 0)
+    return int(str, 0)
 
 
 def get_args():
-        parser = argparse.ArgumentParser()
-        parser.add_argument('--source',
-                            required=True,
-                            help='Source file')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--source',
+                        required=True,
+                        help='Source file')
 
-        parser.add_argument('--dest',
-                            required=True,
-                            help='Destination file')
+    parser.add_argument('--dest',
+                        required=True,
+                        help='Destination file')
 
-        parser.add_argument('--load',
-                            required=True, type=int_parse,
-                            help='Load address')
+    parser.add_argument('--load',
+                        required=True, type=int_parse,
+                        help='Load address')
 
-        parser.add_argument('--entry',
-                            required=True, type=int_parse,
-                            help='Entry point')
+    parser.add_argument('--entry',
+                        required=True, type=int_parse,
+                        help='Entry point')
 
-        parser.add_argument('--bintype',
-                            required=True, type=int_parse,
-                            help='Binary identification')
+    parser.add_argument('--bintype',
+                        required=True, type=int_parse,
+                        help='Binary identification')
 
-        return parser.parse_args()
+    return parser.parse_args()
 
 
 def main():
-        args = get_args()
-        source_file = args.source
-        destination_file = args.dest
-        load_address = args.load
-        entry_point = args.entry
-        binary_type = args.bintype
+    args = get_args()
+    source_file = args.source
+    destination_file = args.dest
+    load_address = args.load
+    entry_point = args.entry
+    binary_type = args.bintype
 
-        stm32image_create_header_file(source_file,
-                                      destination_file,
-                                      load_address,
-                                      entry_point,
-                                      binary_type)
+    stm32image_create_header_file(source_file,
+                                  destination_file,
+                                  load_address,
+                                  entry_point,
+                                  binary_type)
 
 
 if __name__ == "__main__":
-        main()
+    main()

--- a/scripts/bin_to_c.py
+++ b/scripts/bin_to_c.py
@@ -12,51 +12,51 @@ import re
 
 def get_args():
 
-        parser = argparse.ArgumentParser(description='Converts a binary file '
-                                         'into C source file defining binary '
-                                         'data as a constant byte array.')
+    parser = argparse.ArgumentParser(description='Converts a binary file '
+                                     'into C source file defining binary '
+                                     'data as a constant byte array.')
 
-        parser.add_argument('--bin', required=True,
-                            help='Path to the input binary file')
+    parser.add_argument('--bin', required=True,
+                        help='Path to the input binary file')
 
-        parser.add_argument('--vname', required=True,
-                            help='Variable name for the generated table in '
-                            'the output C source file.')
+    parser.add_argument('--vname', required=True,
+                        help='Variable name for the generated table in '
+                        'the output C source file.')
 
-        parser.add_argument('--out', required=True,
-                            help='Path for the generated C file')
+    parser.add_argument('--out', required=True,
+                        help='Path for the generated C file')
 
-        return parser.parse_args()
+    return parser.parse_args()
 
 
 def main():
 
-        args = get_args()
+    args = get_args()
 
-        with open(args.bin, 'rb') as indata:
-                bytes = indata.read()
-                size = len(bytes)
+    with open(args.bin, 'rb') as indata:
+        bytes = indata.read()
+        size = len(bytes)
 
-        f = open(args.out, 'w')
-        f.write('/* Generated from ' + args.bin + ' by ' +
-                os.path.basename(__file__) + ' */\n\n')
-        f.write('#include <compiler.h>\n')
-        f.write('#include <stdint.h>\n')
-        f.write('__extension__ const uint8_t ' + args.vname + '[] ' +
-                ' __aligned(__alignof__(uint64_t)) = {\n')
-        i = 0
-        while i < size:
-                if i % 8 == 0:
-                        f.write('\t\t')
-                f.write('0x' + '{:02x}'.format(bytes[i]) + ',')
-                i = i + 1
-                if i % 8 == 0 or i == size:
-                        f.write('\n')
-                else:
-                        f.write(' ')
-        f.write('};\n')
-        f.close()
+    f = open(args.out, 'w')
+    f.write('/* Generated from ' + args.bin + ' by ' +
+            os.path.basename(__file__) + ' */\n\n')
+    f.write('#include <compiler.h>\n')
+    f.write('#include <stdint.h>\n')
+    f.write('__extension__ const uint8_t ' + args.vname + '[] ' +
+            ' __aligned(__alignof__(uint64_t)) = {\n')
+    i = 0
+    while i < size:
+        if i % 8 == 0:
+            f.write('\t\t')
+        f.write('0x' + '{:02x}'.format(bytes[i]) + ',')
+        i = i + 1
+        if i % 8 == 0 or i == size:
+            f.write('\n')
+        else:
+            f.write(' ')
+    f.write('};\n')
+    f.close()
 
 
 if __name__ == "__main__":
-        main()
+    main()


### PR DESCRIPTION
Fixes the following warnings:

 $ pycodestyle --version
 2.5.0

 $ pycodestyle scripts/*.py
 scripts/bin_to_c.py:15:9: E117 over-indented
 scripts/bin_to_c.py:34:9: E117 over-indented
 scripts/bin_to_c.py:37:17: E117 over-indented
 scripts/bin_to_c.py:49:17: E117 over-indented
 scripts/bin_to_c.py:50:25: E117 over-indented
 scripts/bin_to_c.py:54:25: E117 over-indented
 scripts/bin_to_c.py:56:25: E117 over-indented
 scripts/bin_to_c.py:62:9: E117 over-indented

 $ cd core/arch/arm/plat-stm32mp1/scripts; \
   pycodestyle stm32image.py
 stm32image.py:21:9: E117 over-indented
 stm32image.py:27:9: E117 over-indented
 stm32image.py:29:17: E117 over-indented
 stm32image.py:39:9: E117 over-indented
 stm32image.py:77:9: E117 over-indented
 stm32image.py:84:17: E117 over-indented
 stm32image.py:96:9: E117 over-indented
 stm32image.py:100:9: E117 over-indented
 stm32image.py:125:9: E117 over-indented
 stm32image.py:140:9: E117 over-indented

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
