### PR TITLE
core:out_of_place_write: give it a default value

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -88,21 +88,20 @@ static void put_tmp_block(void *tmp_block)
 static TEE_Result out_of_place_write(struct tee_fs_fd *fdp, size_t pos,
 				     const void *buf, size_t len)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	size_t start_block_num = pos_to_block_num(pos);
 	size_t end_block_num = pos_to_block_num(pos + len - 1);
 	size_t remain_bytes = len;
 	uint8_t *data_ptr = (uint8_t *)buf;
-	uint8_t *block;
+	uint8_t *block = NULL;
 	struct tee_fs_htree_meta *meta = tee_fs_htree_get_meta(fdp->ht);
 
-	/*
-	 * It doesn't make sense to call this function if nothing is to be
-	 * written. This also guards against end_block_num getting an
-	 * unexpected value when pos == 0 and len == 0.
-	 */
 	if (!len)
 		return TEE_ERROR_BAD_PARAMETERS;
+	if (pos + len - 1 < pos)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	assert(start_block_num <= end_block_num);
 
 	block = get_tmp_block();
 	if (!block)


### PR DESCRIPTION
Within the confines of this function locally, it returns the
uninitialized res when start_block_num > end_block_num in the beginning
and in this case, the parameter pos is apt to be erroneous.

Fix: #2760
Signed-off-by: Oliver Chiang <rockerfeynman@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
