### PR TITLE
core:ta_open: freeing allocated memory on error

### DIFF
--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -137,8 +137,10 @@ static TEE_Result ta_open(const TEE_UUID *uuid,
 		TEE_UUID bs_uuid;
 		struct shdr_bootstrap_ta bs_hdr;
 
-		if (ta_size < SHDR_GET_SIZE(shdr) + sizeof(bs_hdr))
-			return TEE_ERROR_SECURITY;
+		if (ta_size < SHDR_GET_SIZE(shdr) + sizeof(bs_hdr)) {
+			res = TEE_ERROR_SECURITY;
+			goto error_free_hash;
+		}
 
 		memcpy(&bs_hdr, ((uint8_t *)ta + offs), sizeof(bs_hdr));
 


### PR DESCRIPTION
In error condition on checking "ta_size", was returning
error from function without cleaning allocated memory.

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Fix: #2776

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
