### PR TITLE
core: fix get_elf_segments() segs initialization

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -153,10 +153,11 @@ static TEE_Result get_elf_segments(struct user_ta_elf *elf,
 				return TEE_ERROR_OUT_OF_MEMORY;
 			}
 			segs = p;
-			segs[num_segs].offs = ROUNDDOWN(va, SMALL_PAGE_SIZE);
-			segs[num_segs].oend = ROUNDUP(va + size,
-						      SMALL_PAGE_SIZE);
-			segs[num_segs].flags = flags;
+			segs[num_segs] = (struct load_seg) {
+				.offs = ROUNDDOWN(va, SMALL_PAGE_SIZE),
+				.oend = ROUNDUP(va + size, SMALL_PAGE_SIZE),
+				.flags = flags,
+			};
 			num_segs++;
 		} else if (type == PT_ARM_EXIDX) {
 			elf->exidx_start = va;


### PR DESCRIPTION
get_elf_segments() doesn't initialize the returned segs array properly,
some fields are left uninitialized. Fix this by doing a compound
assignment when initializing new elements in the array.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
