### PR TITLE
ltc: fix the CBC_MAC error

### DIFF
--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -2216,6 +2216,7 @@ TEE_Result crypto_mac_update(void *ctx, uint32_t algo, const uint8_t *data,
 			if (CRYPT_OK != ltc_res)
 				return TEE_ERROR_BAD_STATE;
 			cbc->is_computed = 1;
+			cbc->current_block_len = 0;
 		}
 
 		while (len >= cbc->block_len) {
@@ -2228,9 +2229,11 @@ TEE_Result crypto_mac_update(void *ctx, uint32_t algo, const uint8_t *data,
 			len -= cbc->block_len;
 		}
 
-		if (len > 0)
-			memcpy(cbc->block, data, len);
-		cbc->current_block_len = len;
+		if (len > 0) {
+			assert(cbc->current_block_len + len < cbc->block_len);
+			memcpy(cbc->block + cbc->current_block_len, data, len);
+			cbc->current_block_len += len;
+		}
 		break;
 #endif
 #if defined(CFG_CRYPTO_CMAC)


### PR DESCRIPTION
When there is some data already pending in the cbc->block and the input
data size is not large enough to do cbc_encrypt(), the pending data is
going to be overwritten. For example, a serial input with size like 3,3...
uncovers this bug.

Signed-off-by: Oliver Chiang <rockerfeynman@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
