### PR TITLE
bget: check for size overflow  

### DIFF
--- a/lib/libutils/isoc/bget.c
+++ b/lib/libutils/isoc/bget.c
@@ -597,12 +597,16 @@ void *bget(requested_size, poolset)
     }
 #ifdef SizeQuant
 #if SizeQuant > 1
-    size = (size + (SizeQuant - 1)) & (~(SizeQuant - 1));
+    if (ADD_OVERFLOW(size, SizeQuant - 1, &size))
+        return NULL;
+
+    size = ROUNDDOWN(size, SizeQuant);
 #endif
 #endif
 
-    size += sizeof(struct bhead);     /* Add overhead in allocated buffer
-					 to size required. */
+    /* Add overhead in allocated buffer to size required. */
+    if (ADD_OVERFLOW(size, sizeof(struct bhead), &size))
+        return NULL;
 
 #ifdef BECtl
     /* If a compact function was provided in the call to bectl(), wrap


### PR DESCRIPTION
bget: check for size overflow
#2780 

Check size overflow to avoid size <= 0 which may be caused by
calculation "size += sizeof(struct bhead)".(url)