### PR TITLE
core: pta_stats: add memleak function

### DIFF
--- a/core/arch/arm/pta/stats.c
+++ b/core/arch/arm/pta/stats.c
@@ -20,6 +20,7 @@
 
 #define STATS_CMD_PAGER_STATS		0
 #define STATS_CMD_ALLOC_STATS		1
+#define STATS_CMD_MEMLEAK_STATS		2
 
 #define STATS_NB_POOLS			3
 
@@ -115,6 +116,19 @@ static TEE_Result get_pager_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 	return TEE_SUCCESS;
 }
 
+static TEE_Result get_memleak_stats(uint32_t type,
+				    TEE_Param p[TEE_NUM_PARAMS] __unused)
+{
+
+	if (TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE,
+			    TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE) != type)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mdbg_check(1);
+
+	return TEE_SUCCESS;
+}
+
 /*
  * Trusted Application Entry Points
  */
@@ -128,6 +142,8 @@ static TEE_Result invoke_command(void *psess __unused,
 		return get_pager_stats(ptypes, params);
 	case STATS_CMD_ALLOC_STATS:
 		return get_alloc_stats(ptypes, params);
+	case STATS_CMD_MEMLEAK_STATS:
+		return get_memleak_stats(ptypes, params);
 	default:
 		break;
 	}


### PR DESCRIPTION
Adds a memleak function to the status PTA which calls mdbg_check(1)
to dump all allocations.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
