### PR TITLE
Fix alignment of data for mempool_alloc_pool()

### DIFF
--- a/core/lib/libtomcrypt/src/mpa_desc.c
+++ b/core/lib/libtomcrypt/src/mpa_desc.c
@@ -40,7 +40,7 @@ static struct mempool *get_mpa_scratch_memory_pool(void)
 #else /* CFG_WITH_PAGER */
 static struct mempool *get_mpa_scratch_memory_pool(void)
 {
-	static uint32_t data[LTC_MEMPOOL_U32_SIZE] __aligned(__alignof__(long));
+	static uint32_t data[LTC_MEMPOOL_U32_SIZE] __aligned(MEMPOOL_ALIGN);
 
 	return mempool_alloc_pool(data, sizeof(data), NULL);
 }

--- a/core/lib/libtomcrypt/src/mpi_desc.c
+++ b/core/lib/libtomcrypt/src/mpi_desc.c
@@ -38,7 +38,7 @@ static struct mempool *get_mp_scratch_memory_pool(void)
 #else /* CFG_WITH_PAGER */
 static struct mempool *get_mp_scratch_memory_pool(void)
 {
-	static uint8_t data[MPI_MEMPOOL_SIZE] __aligned(__alignof__(long));
+	static uint8_t data[MPI_MEMPOOL_SIZE] __aligned(MEMPOOL_ALIGN);
 
 	return mempool_alloc_pool(data, sizeof(data), NULL);
 }

--- a/lib/libutee/tee_api_arith_mpa.c
+++ b/lib/libutee/tee_api_arith_mpa.c
@@ -19,7 +19,8 @@
 
 static uint32_t mempool_u32[mpa_scratch_mem_size_in_U32(
 					    MPA_INTERNAL_MEM_POOL_SIZE,
-					    CFG_TA_BIGNUM_MAX_BITS)];
+					    CFG_TA_BIGNUM_MAX_BITS)]
+						__aligned(MEMPOOL_ALIGN);
 static mpa_scratch_mem mempool;
 
 /*************************************************************

--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -42,8 +42,7 @@ static void __noreturn mpi_panic(const char *func, int line, int rc)
 
 void _TEE_MathAPI_Init(void)
 {
-	static uint8_t data[MPI_MEMPOOL_SIZE]
-		__aligned(__alignof__(mbedtls_mpi_uint));
+	static uint8_t data[MPI_MEMPOOL_SIZE] __aligned(MEMPOOL_ALIGN);
 
 	mbedtls_mpi_mempool = mempool_alloc_pool(data, sizeof(data), NULL);
 	if (!mbedtls_mpi_mempool)

--- a/lib/libutils/ext/include/mempool.h
+++ b/lib/libutils/ext/include/mempool.h
@@ -19,9 +19,12 @@ struct mempool_item {
 
 struct mempool;
 
+#define MEMPOOL_ALIGN	__alignof__(long)
+
 /*
  * mempool_alloc_pool() - Allocate a new memory pool
- * @data:		a block of memory to carve out items from
+ * @data:		a block of memory to carve out items from, must
+ *			have an alignment of MEMPOOL_ALIGN.
  * @size:		size fo the block of memory
  * @release_mem:	function to call when the pool has been emptied,
  *			ignored if NULL.

--- a/lib/libutils/ext/mempool.c
+++ b/lib/libutils/ext/mempool.c
@@ -53,7 +53,6 @@
  *   So the potential fragmentation is mitigated.
  */
 
-#define POOL_ALIGN	__alignof__(long)
 
 struct mempool {
 	size_t size;  /* size of the memory pool, in bytes */
@@ -130,8 +129,8 @@ mempool_alloc_pool(void *data, size_t size,
 {
 	struct mempool *pool = calloc(1, sizeof(*pool));
 
-	COMPILE_TIME_ASSERT(POOL_ALIGN >= __alignof__(struct mempool_item));
-	assert(!((vaddr_t)data & (POOL_ALIGN - 1)));
+	COMPILE_TIME_ASSERT(MEMPOOL_ALIGN >= __alignof__(struct mempool_item));
+	assert(!((vaddr_t)data & (MEMPOOL_ALIGN - 1)));
 
 	if (pool) {
 		pool->size = size;
@@ -163,13 +162,13 @@ void *mempool_alloc(struct mempool *pool, size_t size)
 						    pool->last_offset);
 		offset = pool->last_offset + last_item->size;
 
-		offset = ROUNDUP(offset, POOL_ALIGN);
+		offset = ROUNDUP(offset, MEMPOOL_ALIGN);
 		if (offset > pool->size)
 			goto error;
 	}
 
 	size = sizeof(struct mempool_item) + size;
-	size = ROUNDUP(size, POOL_ALIGN);
+	size = ROUNDUP(size, MEMPOOL_ALIGN);
 	if (offset + size > pool->size)
 		goto error;
 


### PR DESCRIPTION
Prior to this patch was _TEE_MathAPI_Init() in
lib/libutee/tee_api_arith_mpi.c supplying a data buffer which was only 4
byte aligned while mempool_alloc_pool() requires the alignment of long.
This will work in 32-bit mode, but could lead to alignment problem in
64-bit mode.

Incorrect alignment can result in errors like:
E/TA:  assertion '!((vaddr_t)data & (POOL_ALIGN - 1))' failed at lib/libutils/ext/mempool.c:134 in mempool_alloc_pool()

This fix introduces MEMPOOL_ALIGN which specifies required alignment of
data supplied to mempool_alloc_pool().

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
