### PR TITLE
Remove memalign()

### DIFF
--- a/core/arch/arm/pta/core_self_tests.c
+++ b/core/arch/arm/pta/core_self_tests.c
@@ -311,7 +311,7 @@ static int self_test_malloc(void)
 	bool r;
 	int ret = 0;
 
-	LOG("malloc tests (malloc, free, calloc, realloc, memalign):");
+	LOG("malloc tests (malloc, free, calloc, realloc):");
 	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
 	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
 	/* test malloc */
@@ -372,47 +372,6 @@ static int self_test_malloc(void)
 	p3 = NULL;
 	p4 = NULL;
 
-	/* test memalign */
-	p3 = memalign(0x1000, 1024);
-	LOG("- p3 = memalign(%d, 1024)", 0x1000);
-	p1 = malloc(1024);
-	LOG("- p1 = malloc(1024)");
-	p4 = memalign(0x100, 512);
-	LOG("- p4 = memalign(%d, 512)", 0x100);
-	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
-	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
-	r = (p1 && p3 && p4 &&
-	    !((vaddr_t)p3 % 0x1000) && !((vaddr_t)p4 % 0x100));
-	if (!r)
-		ret = -1;
-	LOG("  => test %s", r ? "ok" : "FAILED");
-	LOG("");
-	LOG("- free p1, p3, p4");
-	free(p1);
-	free(p3);
-	free(p4);
-	p1 = NULL;
-	p3 = NULL;
-	p4 = NULL;
-
-	/* test memalign with invalid alignments */
-	p3 = memalign(100, 1024);
-	LOG("- p3 = memalign(%d, 1024)", 100);
-	p4 = memalign(0, 1024);
-	LOG("- p4 = memalign(%d, 1024)", 0);
-	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
-	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
-	r = (!p3 && !p4);
-	if (!r)
-		ret = -1;
-	LOG("  => test %s", r ? "ok" : "FAILED");
-	LOG("");
-	LOG("- free p3, p4");
-	free(p3);
-	free(p4);
-	p3 = NULL;
-	p4 = NULL;
-
 	/* test free(NULL) */
 	LOG("- free NULL");
 	free(NULL);
@@ -431,7 +390,7 @@ static int self_test_nex_malloc(void)
 	bool r;
 	int ret = 0;
 
-	LOG("nex_malloc tests (nex_malloc, nex_free, nex_calloc, nex_realloc, nex_memalign):");
+	LOG("nex_malloc tests (nex_malloc, nex_free, nex_calloc, nex_realloc):");
 	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
 	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
 	/* test malloc */
@@ -482,47 +441,6 @@ static int self_test_nex_malloc(void)
 	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
 	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
 	r = (p3 && !p4);
-	if (!r)
-		ret = -1;
-	LOG("  => test %s", r ? "ok" : "FAILED");
-	LOG("");
-	LOG("- nex_free p3, p4");
-	nex_free(p3);
-	nex_free(p4);
-	p3 = NULL;
-	p4 = NULL;
-
-	/* test memalign */
-	p3 = nex_memalign(0x1000, 1024);
-	LOG("- p3 = nex_memalign(%d, 1024)", 0x1000);
-	p1 = nex_malloc(1024);
-	LOG("- p1 = nex_malloc(1024)");
-	p4 = nex_memalign(0x100, 512);
-	LOG("- p4 = nex_memalign(%d, 512)", 0x100);
-	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
-	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
-	r = (p1 && p3 && p4 &&
-	    !((vaddr_t)p3 % 0x1000) && !((vaddr_t)p4 % 0x100));
-	if (!r)
-		ret = -1;
-	LOG("  => test %s", r ? "ok" : "FAILED");
-	LOG("");
-	LOG("- nex_free p1, p3, p4");
-	nex_free(p1);
-	nex_free(p3);
-	nex_free(p4);
-	p1 = NULL;
-	p3 = NULL;
-	p4 = NULL;
-
-	/* test memalign with invalid alignments */
-	p3 = nex_memalign(100, 1024);
-	LOG("- p3 = nex_memalign(%d, 1024)", 100);
-	p4 = nex_memalign(0, 1024);
-	LOG("- p4 = nex_memalign(%d, 1024)", 0);
-	LOG("  p1=%p  p2=%p  p3=%p  p4=%p",
-	    (void *)p1, (void *)p2, (void *)p3, (void *)p4);
-	r = (!p3 && !p4);
 	if (!r)
 		ret = -1;
 	LOG("  => test %s", r ? "ok" : "FAILED");

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -15,8 +15,6 @@ void free(void *ptr);
 void *mdbg_malloc(const char *fname, int lineno, size_t size);
 void *mdbg_calloc(const char *fname, int lineno, size_t nmemb, size_t size);
 void *mdbg_realloc(const char *fname, int lineno, void *ptr, size_t size);
-void *mdbg_memalign(const char *fname, int lineno, size_t alignment,
-		size_t size);
 
 void mdbg_check(int bufdump);
 
@@ -25,15 +23,12 @@ void mdbg_check(int bufdump);
 		mdbg_calloc(__FILE__, __LINE__, (nmemb), (size))
 #define realloc(ptr, size) \
 		mdbg_realloc(__FILE__, __LINE__, (ptr), (size))
-#define memalign(alignment, size) \
-		mdbg_memalign(__FILE__, __LINE__, (alignment), (size))
 
 #else
 
 void *malloc(size_t size);
 void *calloc(size_t nmemb, size_t size);
 void *realloc(void *ptr, size_t size);
-void *memalign(size_t alignment, size_t size);
 
 #define mdbg_check(x)        do { } while (0)
 
@@ -91,8 +86,6 @@ void nex_free(void *ptr);
 void *nex_mdbg_malloc(const char *fname, int lineno, size_t size);
 void *nex_mdbg_calloc(const char *fname, int lineno, size_t nmemb, size_t size);
 void *nex_mdbg_realloc(const char *fname, int lineno, void *ptr, size_t size);
-void *nex_mdbg_memalign(const char *fname, int lineno, size_t alignment,
-		size_t size);
 
 void nex_mdbg_check(int bufdump);
 
@@ -101,15 +94,12 @@ void nex_mdbg_check(int bufdump);
 		nex_mdbg_calloc(__FILE__, __LINE__, (nmemb), (size))
 #define nex_realloc(ptr, size) \
 		nex_mdbg_realloc(__FILE__, __LINE__, (ptr), (size))
-#define nex_memalign(alignment, size) \
-		nex_mdbg_memalign(__FILE__, __LINE__, (alignment), (size))
 
 #else /* ENABLE_MDBG */
 
 void *nex_malloc(size_t size);
 void *nex_calloc(size_t nmemb, size_t size);
 void *nex_realloc(void *ptr, size_t size);
-void *nex_memalign(size_t alignment, size_t size);
 
 #define nex_mdbg_check(x)        do { } while (0)
 
@@ -134,7 +124,6 @@ void nex_malloc_reset_stats(void);
 #define nex_malloc(size) malloc(size)
 #define nex_calloc(nmemb, size) calloc(nmemb, size)
 #define nex_realloc(ptr, size) realloc(ptr, size)
-#define nex_memalign(alignment, size) memalign(alignment, size)
 
 #endif	/* CFG_VIRTUALIZATION */
 


### PR DESCRIPTION
Removes the unused memalign() function. Usage of this function will
cause severe fragmentation of the heap.

Another problem is with the implementation which is added on top of bget
while still depending heavily on internals of bget. The implementation was
somewhat buggy since it can sometimes can cause:
E/TC:0 0 assertion 'bn->prevfree == 0' failed at lib/libutils/isoc/bget_malloc.c
:423 <create_free_block>
E/TC:0 0 Panic at core/kernel/assert.c:28 <_assert_break>

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
