### PR TITLE
bget: fix nex_ pool building with disabled stats

### DIFF
--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -902,6 +902,8 @@ bool nex_malloc_buffer_overlaps_heap(void *buf, size_t len)
 	return gen_malloc_buffer_overlaps_heap(&nex_malloc_ctx, buf, len);
 }
 
+#ifdef BufStats
+
 void nex_malloc_reset_stats(void)
 {
 	gen_malloc_reset_stats(&nex_malloc_ctx);
@@ -911,5 +913,7 @@ void nex_malloc_get_stats(struct malloc_stats *stats)
 {
 	gen_malloc_get_stats(&nex_malloc_ctx, stats);
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
gen_malloc_reset_stats() and gen_malloc_get_stats()
are only available when BufStats is defined.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
