### PR TITLE
Enable virtualization support on Renesas RCAR platform

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -444,6 +444,7 @@ void core_mmu_set_prtn(struct mmu_partition *prtn)
 
 	write_ttbr0_el1(ttbr | ((paddr_t)prtn->asid << TTBR_ASID_SHIFT));
 	isb();
+	tlbi_all();
 }
 
 void core_mmu_set_default_prtn(void)

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -53,7 +53,7 @@ register_dynamic_shm(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
 
 static void main_fiq(void);
 
-static const struct thread_handlers handlers = {
+static const struct thread_handlers handlers __nex_data = {
 	.std_smc = tee_entry_std,
 	.fast_smc = tee_entry_fast,
 	.nintr = main_fiq,
@@ -65,7 +65,7 @@ static const struct thread_handlers handlers = {
 	.system_reset = pm_do_nothing,
 };
 
-static struct scif_uart_data console_data;
+static struct scif_uart_data console_data __nex_bss;
 
 const struct thread_handlers *generic_boot_get_handlers(void)
 {


### PR DESCRIPTION
There are two patches: 

One flushes TLB, to fix issue with page fault while writing to stack. This wasn't needed on QEMU, but is required on real HW.

Another moves platform data to `.nex` sections. Similar changes are required to other platforms, but I have no means to test them. 