### PR TITLE
stm32mp1: reset driver for platform peripheral interfaces

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
@@ -1,15 +1,72 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2018, STMicroelectronics
+ * Copyright (c) 2018-2019, STMicroelectronics
  */
 
 #include <drivers/stm32mp1_rcc.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
+#include <stm32_util.h>
+
+#define RESET_ID_MASK		GENMASK_32(31, 5)
+#define RESET_ID_SHIFT		5
+#define RESET_BIT_POS_MASK	GENMASK_32(4, 0)
+
+#define RESET_TIMEOUT_US	1000
+
+/*
+ * Loop until condition is reached or timeout elapsed. We test the condition
+ * again after timeout is detected and panic only if it is still false since
+ * TEE thread might have been suspended hence timing out when resumed.
+ */
+#define WAIT_COND_OR_PANIC(_condition, _timeout_ref) \
+	do { \
+		if (timeout_elapsed(_timeout_ref) && !(_condition)) \
+			panic(); \
+	} while (!(_condition))
 
 uintptr_t stm32_rcc_base(void)
 {
 	static struct io_pa_va base = { .pa = RCC_BASE };
 
 	return io_pa_or_va(&base);
+}
+
+static size_t reset_id2reg_offset(unsigned int id)
+{
+	return ((id & RESET_ID_MASK) >> RESET_ID_SHIFT) * sizeof(uint32_t);
+}
+
+static uint8_t reset_id2reg_bit_pos(unsigned int reset_id)
+{
+	return reset_id & RESET_BIT_POS_MASK;
+}
+
+void stm32_reset_assert(unsigned int id)
+{
+	size_t offset = reset_id2reg_offset(id);
+	uint32_t bitmsk = BIT(reset_id2reg_bit_pos(id));
+	uint64_t timeout_ref = timeout_init_us(RESET_TIMEOUT_US);
+	uintptr_t rcc_base = stm32_rcc_base();
+
+	write32(bitmsk, rcc_base + offset);
+
+	WAIT_COND_OR_PANIC(read32(rcc_base + offset) & bitmsk,
+			   timeout_ref);
+}
+
+void stm32_reset_deassert(unsigned int id)
+{
+	size_t offset = reset_id2reg_offset(id) + RCC_MP_RSTCLRR_OFFSET;
+	uint32_t bitmsk = BIT(reset_id2reg_bit_pos(id));
+	uint64_t timeout_ref = timeout_init_us(RESET_TIMEOUT_US);
+	uintptr_t rcc_base = stm32_rcc_base();
+
+	write32(bitmsk, rcc_base + offset);
+
+	WAIT_COND_OR_PANIC(!(read32(rcc_base + offset) & bitmsk),
+			   timeout_ref);
 }

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -284,6 +284,9 @@
 /* Offset between RCC_MP_xxxENSETR and RCC_MP_xxxENCLRR registers */
 #define RCC_MP_ENCLRR_OFFSET		4u
 
+/* Offset between RCC_MP_xxxRSTSETR and RCC_MP_xxxRSTCLRR registers */
+#define RCC_MP_RSTCLRR_OFFSET		4u
+
 /* Fields of RCC_BDCR register */
 #define RCC_BDCR_LSEON			BIT(0)
 #define RCC_BDCR_LSEBYP			BIT(1)

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2018, STMicroelectronics
+ * Copyright (c) 2018-2019, STMicroelectronics
  */
 
 #ifndef __STM32_UTIL_H__
@@ -39,5 +39,12 @@ void stm32_clock_enable(unsigned long id);
 void stm32_clock_disable(unsigned long id);
 unsigned long stm32_clock_get_rate(unsigned long id);
 bool stm32_clock_is_enabled(unsigned long id);
+
+/*
+ * Util for reset signal assertion/desassertion for stm32 and platform drivers
+ * @id: Target peripheral ID, ID used in reset DT bindings
+ */
+void stm32_reset_assert(unsigned int id);
+void stm32_reset_deassert(unsigned int id);
 
 #endif /*__STM32_UTIL_H__*/


### PR DESCRIPTION
Reset API functions:
- stm32_reset_assert(id) asserts reset signal on target resource.
- stm32_reset_deassert(id) releases reset signal on target resource.

Driver API relies on resource IDs defined in the platform DT bindings
header file dt-bindings/reset/stm32mp1_reset.h.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
