### PR TITLE
ta: link.mk: set linker max-page-size to 4K

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -19,6 +19,7 @@ link-ldflags  = -pie
 link-ldflags += -T $(link-script-pp$(sm))
 link-ldflags += -Map=$(link-out-dir$(sm))/$(user-ta-uuid).map
 link-ldflags += --sort-section=alignment
+link-ldflags += -z max-page-size=4096 # OP-TEE always uses 4K alignment
 
 link-ldadd  = $(user-ta-ldadd) $(addprefix -L,$(libdirs))
 link-ldadd += --start-group $(addprefix -l,$(libnames)) --end-group


### PR DESCRIPTION
TA binaries contain a lot of zero padding (almost 64 KiB) between sections
.ta_head and .text. This value can be reduced to 4 KiB by reducing the
linker's max-page-size parameter. Since the OP-TEE ELF loader always
aligns on small page boundaries, it does not make sense to request a
larger alignment.

This patch adds "-z max-page-size=4096" to the linker flags so that the
alignment constraints are relaxed from 64 KiB (the default for our 32 and
64 targets as it seems) to what OP-TEE is actually expecting (4 KiB).
The TA file size is reduced by 60 KiB. It changes nothing to the layout
of the TA in memory.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
