### PR TITLE
core: change io_{clr|set|clrset}bits32() address argument type

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -506,7 +506,7 @@ static int stm32mp1_clk_get_parent(unsigned long id)
 	int i;
 	enum stm32mp1_parent_id p;
 	enum stm32mp1_parent_sel s;
-	uintptr_t rcc_base = stm32_rcc_base();
+	vaddr_t rcc_base = stm32_rcc_base();
 
 	for (j = 0U; j < ARRAY_SIZE(stm32mp1_clks); j++)
 		if (stm32mp1_clks[j][0] == id)
@@ -608,7 +608,7 @@ static unsigned long get_clock_rate(int p)
 	uint32_t reg;
 	uint32_t clkdiv;
 	unsigned long clock = 0;
-	uintptr_t rcc_base = stm32_rcc_base();
+	vaddr_t rcc_base = stm32_rcc_base();
 
 	switch (p) {
 	case _CK_MPU:
@@ -806,7 +806,7 @@ static unsigned long get_clock_rate(int p)
 
 static void __clk_enable(struct stm32mp1_clk_gate const *gate)
 {
-	uintptr_t base = stm32_rcc_base();
+	vaddr_t base = stm32_rcc_base();
 	uint32_t bit = BIT(gate->bit);
 
 	if (gate->set_clr)
@@ -819,7 +819,7 @@ static void __clk_enable(struct stm32mp1_clk_gate const *gate)
 
 static void __clk_disable(struct stm32mp1_clk_gate const *gate)
 {
-	uintptr_t base = stm32_rcc_base();
+	vaddr_t base = stm32_rcc_base();
 	uint32_t bit = BIT(gate->bit);
 
 	if (gate->set_clr)
@@ -832,7 +832,7 @@ static void __clk_disable(struct stm32mp1_clk_gate const *gate)
 
 static bool __clk_is_enabled(struct stm32mp1_clk_gate const *gate)
 {
-	uintptr_t base = stm32_rcc_base();
+	vaddr_t base = stm32_rcc_base();
 
 	return read32(base + gate->offset) & BIT(gate->bit);
 }
@@ -891,7 +891,7 @@ static long get_timer_rate(long parent_rate, unsigned int apb_bus)
 {
 	uint32_t timgxpre;
 	uint32_t apbxdiv;
-	uintptr_t rcc_base = stm32_rcc_base();
+	vaddr_t rcc_base = stm32_rcc_base();
 
 	switch (apb_bus) {
 	case 1:

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -531,7 +531,7 @@
 #define RCC_MP_IWDGFZSETR_IWDG2			BIT(1)
 
 #ifndef ASM
-uintptr_t stm32_rcc_base(void);
+vaddr_t stm32_rcc_base(void);
 
 static inline bool stm32_rcc_is_secure(void)
 {

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -286,7 +286,7 @@ uintptr_t stm32mp_bkpreg(unsigned int idx)
 	return bkpreg_base() + (idx * sizeof(uint32_t));
 }
 
-uintptr_t stm32_get_gpio_bank_base(unsigned int bank)
+vaddr_t stm32_get_gpio_bank_base(unsigned int bank)
 {
 	static struct io_pa_va gpios_nsec_base = { .pa = GPIOS_NSEC_BASE };
 	static struct io_pa_va gpioz_base = { .pa = GPIOZ_BASE };

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -28,7 +28,7 @@ uintptr_t get_gicd_base(void);
  * check DT configuration matches platform implementation of the banks
  * description.
  */
-uintptr_t stm32_get_gpio_bank_base(unsigned int bank);
+vaddr_t stm32_get_gpio_bank_base(unsigned int bank);
 unsigned int stm32_get_gpio_bank_offset(unsigned int bank);
 unsigned int stm32_get_gpio_bank_clock(unsigned int bank);
 

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -87,7 +87,7 @@ struct etzpc_instance {
 /* Only 1 instance of the ETZPC is expected per platform */
 static struct etzpc_instance etzpc_dev;
 
-static uintptr_t etzpc_base(void)
+static vaddr_t etzpc_base(void)
 {
 	return io_pa_or_va(&etzpc_dev.base);
 }
@@ -105,10 +105,10 @@ static bool valid_tzma_id(unsigned int id)
 void etzpc_configure_decprot(uint32_t decprot_id,
 			     enum etzpc_decprot_attributes decprot_attr)
 {
-	uintptr_t offset = 4U * (decprot_id / IDS_PER_DECPROT_REGS);
+	size_t offset = 4U * (decprot_id / IDS_PER_DECPROT_REGS);
 	uint32_t shift = (decprot_id % IDS_PER_DECPROT_REGS) << DECPROT_SHIFT;
 	uint32_t masked_decprot = (uint32_t)decprot_attr & ETZPC_DECPROT0_MASK;
-	uintptr_t base = etzpc_base();
+	vaddr_t base = etzpc_base();
 
 	assert(valid_decprot_id(decprot_id));
 
@@ -126,9 +126,9 @@ void etzpc_configure_decprot(uint32_t decprot_id,
 
 enum etzpc_decprot_attributes etzpc_get_decprot(uint32_t decprot_id)
 {
-	uintptr_t offset = 4U * (decprot_id / IDS_PER_DECPROT_REGS);
+	size_t offset = 4U * (decprot_id / IDS_PER_DECPROT_REGS);
 	uint32_t shift = (decprot_id % IDS_PER_DECPROT_REGS) << DECPROT_SHIFT;
-	uintptr_t base = etzpc_base();
+	vaddr_t base = etzpc_base();
 	uint32_t value;
 
 	assert(valid_decprot_id(decprot_id));
@@ -141,9 +141,9 @@ enum etzpc_decprot_attributes etzpc_get_decprot(uint32_t decprot_id)
 
 void etzpc_lock_decprot(uint32_t decprot_id)
 {
-	uintptr_t offset = 4U * (decprot_id / IDS_PER_DECPROT_LOCK_REGS);
+	size_t offset = 4U * (decprot_id / IDS_PER_DECPROT_LOCK_REGS);
 	uint32_t mask = BIT(decprot_id % IDS_PER_DECPROT_LOCK_REGS);
-	uintptr_t base = etzpc_base();
+	vaddr_t base = etzpc_base();
 
 	assert(valid_decprot_id(decprot_id));
 
@@ -155,9 +155,9 @@ void etzpc_lock_decprot(uint32_t decprot_id)
 
 bool etzpc_get_lock_decprot(uint32_t decprot_id)
 {
-	uintptr_t offset = 4U * (decprot_id / IDS_PER_DECPROT_LOCK_REGS);
+	size_t offset = 4U * (decprot_id / IDS_PER_DECPROT_LOCK_REGS);
 	uint32_t mask = BIT(decprot_id % IDS_PER_DECPROT_LOCK_REGS);
-	uintptr_t base = etzpc_base();
+	vaddr_t base = etzpc_base();
 
 	assert(valid_decprot_id(decprot_id));
 
@@ -166,8 +166,8 @@ bool etzpc_get_lock_decprot(uint32_t decprot_id)
 
 void etzpc_configure_tzma(uint32_t tzma_id, uint16_t tzma_value)
 {
-	uintptr_t offset = sizeof(uint32_t) * tzma_id;
-	uintptr_t base = etzpc_base();
+	size_t offset = sizeof(uint32_t) * tzma_id;
+	vaddr_t base = etzpc_base();
 
 	assert(valid_tzma_id(tzma_id));
 
@@ -181,8 +181,8 @@ void etzpc_configure_tzma(uint32_t tzma_id, uint16_t tzma_value)
 
 uint16_t etzpc_get_tzma(uint32_t tzma_id)
 {
-	uintptr_t offset = sizeof(uint32_t) * tzma_id;
-	uintptr_t base = etzpc_base();
+	size_t offset = sizeof(uint32_t) * tzma_id;
+	vaddr_t base = etzpc_base();
 
 	assert(valid_tzma_id(tzma_id));
 
@@ -191,8 +191,8 @@ uint16_t etzpc_get_tzma(uint32_t tzma_id)
 
 void etzpc_lock_tzma(uint32_t tzma_id)
 {
-	uintptr_t offset = sizeof(uint32_t) * tzma_id;
-	uintptr_t base = etzpc_base();
+	size_t offset = sizeof(uint32_t) * tzma_id;
+	vaddr_t base = etzpc_base();
 
 	assert(valid_tzma_id(tzma_id));
 
@@ -204,8 +204,8 @@ void etzpc_lock_tzma(uint32_t tzma_id)
 
 bool etzpc_get_lock_tzma(uint32_t tzma_id)
 {
-	uintptr_t offset = sizeof(uint32_t) * tzma_id;
-	uintptr_t base = etzpc_base();
+	size_t offset = sizeof(uint32_t) * tzma_id;
+	vaddr_t base = etzpc_base();
 
 	assert(valid_tzma_id(tzma_id));
 
@@ -297,7 +297,7 @@ static void init_devive_from_hw_config(struct etzpc_instance *dev,
 
 	assert(!dev->base.pa && cpu_mmu_enabled());
 	dev->base.pa = pbase;
-	dev->base.va = (uintptr_t)phys_to_virt(dev->base.pa, MEM_AREA_IO_SEC);
+	dev->base.va = (vaddr_t)phys_to_virt(dev->base.pa, MEM_AREA_IO_SEC);
 	assert(etzpc_base());
 
 	get_hwcfg(&hwcfg);

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -54,7 +54,7 @@ static unsigned int gpio_lock;
 /* Save to output @cfg the current GPIO (@bank/@pin) configuration */
 static void get_gpio_cfg(uint32_t bank, uint32_t pin, struct gpio_cfg *cfg)
 {
-	uintptr_t base = stm32_get_gpio_bank_base(bank);
+	vaddr_t base = stm32_get_gpio_bank_base(bank);
 	unsigned int clock = stm32_get_gpio_bank_clock(bank);
 
 	stm32_clock_enable(clock);
@@ -93,7 +93,7 @@ static void get_gpio_cfg(uint32_t bank, uint32_t pin, struct gpio_cfg *cfg)
 /* Apply GPIO (@bank/@pin) configuration described by @cfg */
 static void set_gpio_cfg(uint32_t bank, uint32_t pin, struct gpio_cfg *cfg)
 {
-	uintptr_t base = stm32_get_gpio_bank_base(bank);
+	vaddr_t base = stm32_get_gpio_bank_base(bank);
 	unsigned int clock = stm32_get_gpio_bank_clock(bank);
 	uint32_t excep = cpu_spin_lock_xsave(&gpio_lock);
 
@@ -353,7 +353,7 @@ int stm32_pinctrl_fdt_get_pinctrl(void *fdt, int device_node,
 static __maybe_unused bool valid_gpio_config(unsigned int bank,
 					     unsigned int pin, bool input)
 {
-	uintptr_t base = stm32_get_gpio_bank_base(bank);
+	vaddr_t base = stm32_get_gpio_bank_base(bank);
 	uint32_t mode = (read32(base + GPIO_MODER_OFFSET) >> (pin << 1)) &
 			GPIO_MODE_MASK;
 
@@ -368,7 +368,7 @@ static __maybe_unused bool valid_gpio_config(unsigned int bank,
 
 int stm32_gpio_get_input_level(unsigned int bank, unsigned int pin)
 {
-	uintptr_t base = stm32_get_gpio_bank_base(bank);
+	vaddr_t base = stm32_get_gpio_bank_base(bank);
 	unsigned int clock = stm32_get_gpio_bank_clock(bank);
 	int rc = 0;
 
@@ -386,7 +386,7 @@ int stm32_gpio_get_input_level(unsigned int bank, unsigned int pin)
 
 void stm32_gpio_set_output_level(unsigned int bank, unsigned int pin, int level)
 {
-	uintptr_t base = stm32_get_gpio_bank_base(bank);
+	vaddr_t base = stm32_get_gpio_bank_base(bank);
 	unsigned int clock = stm32_get_gpio_bank_clock(bank);
 
 	assert(valid_gpio_config(bank, pin, false));
@@ -403,7 +403,7 @@ void stm32_gpio_set_output_level(unsigned int bank, unsigned int pin, int level)
 
 void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin, bool secure)
 {
-	uintptr_t base = stm32_get_gpio_bank_base(bank);
+	vaddr_t base = stm32_get_gpio_bank_base(bank);
 	unsigned int clock = stm32_get_gpio_bank_clock(bank);
 	uint32_t excep = cpu_spin_lock_xsave(&gpio_lock);
 

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -104,17 +104,17 @@ static inline void put_be16(void *p, uint16_t val)
  * io_clrsetbits32() clears then sets the target bits in this order. If a bit
  * position is defined by both @set_mask and @clear_mask, the bit will be set.
  */
-static inline void io_setbits32(uintptr_t addr, uint32_t set_mask)
+static inline void io_setbits32(vaddr_t addr, uint32_t set_mask)
 {
 	write32(read32(addr) | set_mask, addr);
 }
 
-static inline void io_clrbits32(uintptr_t addr, uint32_t clear_mask)
+static inline void io_clrbits32(vaddr_t addr, uint32_t clear_mask)
 {
 	write32(read32(addr) & ~clear_mask, addr);
 }
 
-static inline void io_clrsetbits32(uintptr_t addr, uint32_t clear_mask,
+static inline void io_clrsetbits32(vaddr_t addr, uint32_t clear_mask,
 				   uint32_t set_mask)
 {
 	write32((read32(addr) & ~clear_mask) | set_mask, addr);


### PR DESCRIPTION
Change API for `io_clrbits32()`, `io_setbits32()` and `io_clrsetbits32()` to have a `vaddr_t` type address argument, rather than `uintptr_t` as previously.