### PR TITLE
[RFC] libutil: replace write*() util functions with io_write*()

### DIFF
--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -232,8 +232,8 @@ static uint32_t pager_lock_check_stack(size_t stack_size)
 		 * the thread.
 		 */
 		for (n = 0; n < stack_size; n += SMALL_PAGE_SIZE)
-			write8(1, (vaddr_t)buf + n);
-		write8(1, (vaddr_t)buf + stack_size - 1);
+			io_write8((vaddr_t)buf + n, 1);
+		io_write8((vaddr_t)buf + stack_size - 1, 1);
 	}
 
 	return pager_lock(NULL);

--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -88,16 +88,16 @@ void spi_init(void)
 	 * no need to read PERI_SC_PERIPH_RSTDIS3 first
 	 * as all the bits are processed and cleared after writing
 	 */
-	write32(shifted_val, peri_base + PERI_SC_PERIPH_RSTDIS3);
+	io_write32(peri_base + PERI_SC_PERIPH_RSTDIS3, shifted_val);
 	DMSG("PERI_SC_PERIPH_RSTDIS3: 0x%x\n",
-		read32(peri_base + PERI_SC_PERIPH_RSTDIS3));
+		io_read32(peri_base + PERI_SC_PERIPH_RSTDIS3));
 
 	/*
 	 * wait until the requested device is out of reset
 	 * and ready to be used
 	 */
 	do {
-		read_val = read32(peri_base + PERI_SC_PERIPH_RSTSTAT3);
+		read_val = io_read32(peri_base + PERI_SC_PERIPH_RSTSTAT3);
 	} while (read_val & shifted_val);
 	DMSG("PERI_SC_PERIPH_RSTSTAT3: 0x%x\n", read_val);
 
@@ -107,12 +107,12 @@ void spi_init(void)
 	 * as all the bits are processed and cleared after writing
 	 */
 	shifted_val = PERI_CLK3_SSP;
-	write32(shifted_val, peri_base + PERI_SC_PERIPH_CLKEN3);
+	io_write32(peri_base + PERI_SC_PERIPH_CLKEN3, shifted_val);
 	DMSG("PERI_SC_PERIPH_CLKEN3: 0x%x\n",
-		read32(peri_base + PERI_SC_PERIPH_CLKEN3));
+		io_read32(peri_base + PERI_SC_PERIPH_CLKEN3));
 
 	DMSG("PERI_SC_PERIPH_CLKSTAT3: 0x%x\n",
-		read32(peri_base + PERI_SC_PERIPH_CLKSTAT3));
+		io_read32(peri_base + PERI_SC_PERIPH_CLKSTAT3));
 
 	/*
 	 * GPIO6_2 can be configured as PINMUX_GPIO, but as PINMUX_SPI, HW IP
@@ -124,16 +124,16 @@ void spi_init(void)
 	 * ref: http://infocenter.arm.com/help/topic/com.arm.doc.ddi0194h/CJACFAFG.html
 	 */
 	DMSG("configure gpio6 pins 0-3 as SPI\n");
-	write32(PINMUX_SPI, pmx0_base + PMX0_IOMG104);
-	write32(PINMUX_SPI, pmx0_base + PMX0_IOMG105);
-	write32(PINMUX_SPI, pmx0_base + PMX0_IOMG106);
-	write32(PINMUX_SPI, pmx0_base + PMX0_IOMG107);
+	io_write32(pmx0_base + PMX0_IOMG104, PINMUX_SPI);
+	io_write32(pmx0_base + PMX0_IOMG105, PINMUX_SPI);
+	io_write32(pmx0_base + PMX0_IOMG106, PINMUX_SPI);
+	io_write32(pmx0_base + PMX0_IOMG107, PINMUX_SPI);
 
 	DMSG("configure gpio6 pins 0-3 as nopull\n");
-	write32(PINCFG_NOPULL, pmx1_base + PMX1_IOCG104);
-	write32(PINCFG_NOPULL, pmx1_base + PMX1_IOCG105);
-	write32(PINCFG_NOPULL, pmx1_base + PMX1_IOCG106);
-	write32(PINCFG_NOPULL, pmx1_base + PMX1_IOCG107);
+	io_write32(pmx1_base + PMX1_IOCG104, PINCFG_NOPULL);
+	io_write32(pmx1_base + PMX1_IOCG105, PINCFG_NOPULL);
+	io_write32(pmx1_base + PMX1_IOCG106, PINCFG_NOPULL);
+	io_write32(pmx1_base + PMX1_IOCG107, PINCFG_NOPULL);
 
 #ifdef CFG_SPI_TEST
 	spi_test();
@@ -153,8 +153,8 @@ static TEE_Result peripherals_init(void)
 	 * until linux is booted.
 	 */
 	io_mask8(pmussi_base + PMUSSI_LDO21_REG_ADJ, PMUSSI_LDO21_REG_VL_1V8,
-		PMUSSI_LDO21_REG_VL_MASK);
-	write8(PMUSSI_ENA_LDO21, pmussi_base + PMUSSI_ENA_LDO17_22);
+		 PMUSSI_LDO21_REG_VL_MASK);
+	io_write8(pmussi_base + PMUSSI_ENA_LDO17_22, PMUSSI_ENA_LDO21);
 
 #ifdef CFG_SPI
 	spi_init();

--- a/core/arch/arm/plat-hikey/spi_test.c
+++ b/core/arch/arm/plat-hikey/spi_test.c
@@ -32,9 +32,9 @@ static void spi_cs_callback(enum gpio_level value)
 		inited = true;
 	}
 
-	if (read8(spi_base + PL022_STAT) & PL022_STAT_BSY)
+	if (io_read8(spi_base + PL022_STAT) & PL022_STAT_BSY)
 		DMSG("pl022 busy - do NOT set CS!");
-	while (read8(spi_base + PL022_STAT) & PL022_STAT_BSY)
+	while (io_read8(spi_base + PL022_STAT) & PL022_STAT_BSY)
 		;
 	DMSG("pl022 done - set CS!");
 
@@ -48,13 +48,13 @@ static void spi_set_cs_mux(uint32_t val)
 
 	if (val == PINMUX_SPI) {
 		DMSG("Configure gpio6 pin2 as SPI");
-		write32(PINMUX_SPI, pmx0_base + PMX0_IOMG106);
+		io_write32(pmx0_base + PMX0_IOMG106, PINMUX_SPI);
 	} else {
 		DMSG("Configure gpio6 pin2 as GPIO");
-		write32(PINMUX_GPIO, pmx0_base + PMX0_IOMG106);
+		io_write32(pmx0_base + PMX0_IOMG106, PINMUX_GPIO);
 	}
 
-	data = read32(pmx0_base + PMX0_IOMG106);
+	data = io_read32(pmx0_base + PMX0_IOMG106);
 	if (data)
 		DMSG("gpio6 pin2 is SPI");
 	else

--- a/core/arch/arm/plat-imx/imx-common.c
+++ b/core/arch/arm/plat-imx/imx-common.c
@@ -23,9 +23,9 @@ static uint32_t imx_digproc(void)
 
 		/* TODO: Handle SL here */
 #ifdef CFG_MX7
-		reg = read32(anatop_addr + OFFSET_DIGPROG_IMX7D);
+		reg = io_read32(anatop_addr + OFFSET_DIGPROG_IMX7D);
 #else
-		reg = read32(anatop_addr + OFFSET_DIGPROG);
+		reg = io_read32(anatop_addr + OFFSET_DIGPROG);
 #endif
 	}
 
@@ -77,9 +77,9 @@ uint32_t imx_get_src_gpr(int cpu)
 	vaddr_t va = core_mmu_get_va(SRC_BASE, MEM_AREA_IO_SEC);
 
 	if (soc_is_imx7ds())
-		return read32(va + SRC_GPR1_MX7 + cpu * 8 + 4);
+		return io_read32(va + SRC_GPR1_MX7 + cpu * 8 + 4);
 	else
-		return read32(va + SRC_GPR1 + cpu * 8 + 4);
+		return io_read32(va + SRC_GPR1 + cpu * 8 + 4);
 }
 
 void imx_set_src_gpr(int cpu, uint32_t val)
@@ -87,7 +87,7 @@ void imx_set_src_gpr(int cpu, uint32_t val)
 	vaddr_t va = core_mmu_get_va(SRC_BASE, MEM_AREA_IO_SEC);
 
 	if (soc_is_imx7ds())
-		write32(val, va + SRC_GPR1_MX7 + cpu * 8 + 4);
+		io_write32(va + SRC_GPR1_MX7 + cpu * 8 + 4, val);
 	else
-		write32(val, va + SRC_GPR1 + cpu * 8 + 4);
+		io_write32(va + SRC_GPR1 + cpu * 8 + 4, val);
 }

--- a/core/arch/arm/plat-imx/imx6.c
+++ b/core/arch/arm/plat-imx/imx6.c
@@ -49,21 +49,20 @@ void plat_cpu_reset_late(void)
 #if defined(CFG_BOOT_SYNC_CPU)
 		pa = virt_to_phys((void *)TEE_TEXT_VA_START);
 		/* set secondary entry address and release core */
-		write32(pa, SRC_BASE + SRC_GPR1 + 8);
-		write32(pa, SRC_BASE + SRC_GPR1 + 16);
-		write32(pa, SRC_BASE + SRC_GPR1 + 24);
+		io_write32(SRC_BASE + SRC_GPR1 + 8, pa);
+		io_write32(SRC_BASE + SRC_GPR1 + 16, pa);
+		io_write32(SRC_BASE + SRC_GPR1 + 24, pa);
 
-		write32(SRC_SCR_CPU_ENABLE_ALL, SRC_BASE + SRC_SCR);
+		io_write32(SRC_BASE + SRC_SCR, SRC_SCR_CPU_ENABLE_ALL);
 #endif
 
 		/* SCU config */
-		write32(SCU_INV_CTRL_INIT, SCU_BASE + SCU_INV_SEC);
-		write32(SCU_SAC_CTRL_INIT, SCU_BASE + SCU_SAC);
-		write32(SCU_NSAC_CTRL_INIT, SCU_BASE + SCU_NSAC);
+		io_write32(SCU_BASE + SCU_INV_SEC, SCU_INV_CTRL_INIT);
+		io_write32(SCU_BASE + SCU_SAC, SCU_SAC_CTRL_INIT);
+		io_write32(SCU_BASE + SCU_NSAC, SCU_NSAC_CTRL_INIT);
 
 		/* SCU enable */
-		write32(read32(SCU_BASE + SCU_CTRL) | 0x1,
-			SCU_BASE + SCU_CTRL);
+		io_setbits32(SCU_BASE + SCU_CTRL, 0x1);
 
 		/* configure imx6 CSU */
 
@@ -71,12 +70,12 @@ void plat_cpu_reset_late(void)
 		for (addr = CSU_BASE + CSU_CSL_START;
 			 addr != CSU_BASE + CSU_CSL_END;
 			 addr += 4)
-			write32(CSU_ACCESS_ALL, addr);
+			io_write32(addr, CSU_ACCESS_ALL);
 
 		/* lock the settings */
 		for (addr = CSU_BASE + CSU_CSL_START;
-			 addr != CSU_BASE + CSU_CSL_END;
-			 addr += 4)
-			write32(read32(addr) | CSU_SETTING_LOCK, addr);
+		     addr != CSU_BASE + CSU_CSL_END;
+		     addr += 4)
+			io_setbits32(addr, CSU_SETTING_LOCK);
 	}
 }

--- a/core/arch/arm/plat-imx/imx6ul.c
+++ b/core/arch/arm/plat-imx/imx6ul.c
@@ -19,13 +19,13 @@ static void init_csu(void)
 	for (addr = CSU_BASE + CSU_CSL_START;
 	     addr != CSU_BASE + CSU_CSL_END;
 	     addr += 4)
-		write32(CSU_ACCESS_ALL, addr);
+		io_write32(addr, CSU_ACCESS_ALL);
 
 	/* lock the settings */
 	for (addr = CSU_BASE + CSU_CSL_START;
 	     addr != CSU_BASE + CSU_CSL_END;
 	     addr += 4)
-		write32(read32(addr) | CSU_SETTING_LOCK, addr);
+		io_setbits32(addr, CSU_SETTING_LOCK);
 }
 
 /* MMU not enabled now */

--- a/core/arch/arm/plat-imx/imx7.c
+++ b/core/arch/arm/plat-imx/imx7.c
@@ -28,7 +28,6 @@
 void plat_cpu_reset_late(void)
 {
 	uintptr_t addr;
-	uint32_t val;
 
 	if (get_core_pos() != 0)
 		return;
@@ -38,29 +37,28 @@ void plat_cpu_reset_late(void)
 	 * TODO: fine tune the permissions
 	 */
 	for (addr = CSU_CSL_START; addr != CSU_CSL_END; addr += 4)
-		write32(CSU_ACCESS_ALL, core_mmu_get_va(addr, MEM_AREA_IO_SEC));
+		io_write32(core_mmu_get_va(addr, MEM_AREA_IO_SEC),
+			   CSU_ACCESS_ALL);
 
 	dsb();
 	/* Protect OCRAM_S */
-	write32(0x003300FF, core_mmu_get_va(CSU_CSL_59, MEM_AREA_IO_SEC));
+	io_write32(core_mmu_get_va(CSU_CSL_59, MEM_AREA_IO_SEC), 0x003300FF);
 	/* Proect TZASC */
-	write32(0x00FF0033, core_mmu_get_va(CSU_CSL_28, MEM_AREA_IO_SEC));
+	io_write32(core_mmu_get_va(CSU_CSL_28, MEM_AREA_IO_SEC), 0x00FF0033);
 	/*
 	 * Proect CSU
 	 * Note: Ater this settings, CSU seems still can be read,
 	 * in non-secure world but can not be written.
 	 */
-	write32(0x00FF0033, core_mmu_get_va(CSU_CSL_15, MEM_AREA_IO_SEC));
+	io_write32(core_mmu_get_va(CSU_CSL_15, MEM_AREA_IO_SEC), 0x00FF0033);
 	/*
 	 * Protect SRC
-	 * write32(0x003300FF, core_mmu_get_va(CSU_CSL_12, MEM_AREA_IO_SEC));
+	 * io_write32(core_mmu_get_va(CSU_CSL_12, MEM_AREA_IO_SEC), 0x003300FF);
 	 */
 	dsb();
 
 	/* lock the settings */
-	for (addr = CSU_CSL_START; addr != CSU_CSL_END; addr += 4) {
-		val = read32(core_mmu_get_va(addr, MEM_AREA_IO_SEC));
-		write32(val | CSU_SETTING_LOCK,
-			core_mmu_get_va(addr, MEM_AREA_IO_SEC));
-	}
+	for (addr = CSU_CSL_START; addr != CSU_CSL_END; addr += 4)
+		io_setbits32(core_mmu_get_va(addr, MEM_AREA_IO_SEC),
+			     CSU_SETTING_LOCK);
 }

--- a/core/arch/arm/plat-imx/imx_pl310.c
+++ b/core/arch/arm/plat-imx/imx_pl310.c
@@ -26,13 +26,13 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_PGDIR_SIZE);
 void arm_cl2_config(vaddr_t pl310_base)
 {
 	/* Disable PL310 */
-	write32(0, pl310_base + PL310_CTRL);
+	io_write32(pl310_base + PL310_CTRL, 0);
 
-	write32(PL310_TAG_RAM_CTRL_INIT, pl310_base + PL310_TAG_RAM_CTRL);
-	write32(PL310_DATA_RAM_CTRL_INIT, pl310_base + PL310_DATA_RAM_CTRL);
-	write32(PL310_AUX_CTRL_INIT, pl310_base + PL310_AUX_CTRL);
-	write32(PL310_PREFETCH_CTRL_INIT, pl310_base + PL310_PREFETCH_CTRL);
-	write32(PL310_POWER_CTRL_INIT, pl310_base + PL310_POWER_CTRL);
+	io_write32(pl310_base + PL310_TAG_RAM_CTRL, PL310_TAG_RAM_CTRL_INIT);
+	io_write32(pl310_base + PL310_DATA_RAM_CTRL, PL310_DATA_RAM_CTRL_INIT);
+	io_write32(pl310_base + PL310_AUX_CTRL, PL310_AUX_CTRL_INIT);
+	io_write32(pl310_base + PL310_PREFETCH_CTRL, PL310_PREFETCH_CTRL_INIT);
+	io_write32(pl310_base + PL310_POWER_CTRL, PL310_POWER_CTRL_INIT);
 
 	/* invalidate all cache ways */
 	arm_cl2_invbyway(pl310_base);
@@ -43,11 +43,11 @@ void arm_cl2_enable(vaddr_t pl310_base)
 	uint32_t val __maybe_unused;
 
 	/* Enable PL310 ctrl -> only set lsb bit */
-	write32(1, pl310_base + PL310_CTRL);
+	io_write32(pl310_base + PL310_CTRL, 1);
 
 #ifndef CFG_PL310_SIP_PROTOCOL
 	/* if L2 FLZW enable, enable in L1 */
-	val = read32(pl310_base + PL310_AUX_CTRL);
+	val = io_read32(pl310_base + PL310_AUX_CTRL);
 	if (val & PL310_AUX_CTRL_FLZW)
 		write_actlr(read_actlr() | ACTLR_CA9_WFLZ);
 #endif
@@ -78,7 +78,7 @@ uint32_t pl310_enable_writeback(void)
 {
 	vaddr_t base = pl310_base();
 
-	write32(0, base + PL310_DEBUG_CTRL);
+	io_write32(base + PL310_DEBUG_CTRL, 0);
 	return OPTEE_SMC_RETURN_OK;
 }
 
@@ -88,7 +88,7 @@ uint32_t pl310_disable_writeback(void)
 	uint32_t val = PL310_DEBUG_CTRL_DISABLE_WRITEBACK |
 		       PL310_DEBUG_CTRL_DISABLE_LINEFILL;
 
-	write32(val, base + PL310_DEBUG_CTRL);
+	io_write32(base + PL310_DEBUG_CTRL, val);
 	return OPTEE_SMC_RETURN_OK;
 }
 

--- a/core/arch/arm/plat-imx/mmdc.c
+++ b/core/arch/arm/plat-imx/mmdc.c
@@ -26,7 +26,7 @@ int imx_get_ddr_type(void)
 	else
 		off = MMDC_MDMISC;
 
-	val =  read32(mmdc_base + off);
+	val =  io_read32(mmdc_base + off);
 
 	if (is_mx7) {
 		if (val & MSTR_DDR3)

--- a/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
+++ b/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
@@ -138,7 +138,7 @@ static uint32_t get_online_cpus(void)
 {
 	vaddr_t src_a7rcr1 = core_mmu_get_va(SRC_BASE + SRC_A7RCR1,
 					     MEM_AREA_IO_SEC);
-	uint32_t val = read32(src_a7rcr1);
+	uint32_t val = io_read32(src_a7rcr1);
 
 	return (val & (1 << SRC_A7RCR1_A7_CORE1_ENABLE_OFFSET)) ? 2 : 1;
 }

--- a/core/arch/arm/plat-imx/pm/gpcv2.c
+++ b/core/arch/arm/plat-imx/pm/gpcv2.c
@@ -18,25 +18,25 @@ static vaddr_t gpc_base(void)
 
 void imx_gpcv2_set_core_pgc(bool enable, uint32_t offset)
 {
-	uint32_t val = read32(gpc_base() + offset) & (~GPC_PGC_PCG_MASK);
+	uint32_t val = io_read32(gpc_base() + offset) & (~GPC_PGC_PCG_MASK);
 
 	if (enable)
 		val |= GPC_PGC_PCG_MASK;
 
-	write32(val, gpc_base() + offset);
+	io_write32(gpc_base() + offset, val);
 }
 
 void imx_gpcv2_set_core1_pdn_by_software(void)
 {
-	uint32_t val = read32(gpc_base() + GPC_CPU_PGC_SW_PDN_REQ);
+	uint32_t val = io_read32(gpc_base() + GPC_CPU_PGC_SW_PDN_REQ);
 
 	imx_gpcv2_set_core_pgc(true, GPC_PGC_C1);
 
 	val |= GPC_PGC_SW_PDN_PUP_REQ_CORE1_MASK;
 
-	write32(val, gpc_base() + GPC_CPU_PGC_SW_PDN_REQ);
+	io_write32(gpc_base() + GPC_CPU_PGC_SW_PDN_REQ, val);
 
-	while ((read32(gpc_base() + GPC_CPU_PGC_SW_PDN_REQ) &
+	while ((io_read32(gpc_base() + GPC_CPU_PGC_SW_PDN_REQ) &
 	       GPC_PGC_SW_PDN_PUP_REQ_CORE1_MASK) != 0)
 		;
 
@@ -45,15 +45,15 @@ void imx_gpcv2_set_core1_pdn_by_software(void)
 
 void imx_gpcv2_set_core1_pup_by_software(void)
 {
-	uint32_t val = read32(gpc_base() + GPC_CPU_PGC_SW_PUP_REQ);
+	uint32_t val = io_read32(gpc_base() + GPC_CPU_PGC_SW_PUP_REQ);
 
 	imx_gpcv2_set_core_pgc(true, GPC_PGC_C1);
 
 	val |= GPC_PGC_SW_PDN_PUP_REQ_CORE1_MASK;
 
-	write32(val, gpc_base() + GPC_CPU_PGC_SW_PUP_REQ);
+	io_write32(gpc_base() + GPC_CPU_PGC_SW_PUP_REQ, val);
 
-	while ((read32(gpc_base() + GPC_CPU_PGC_SW_PUP_REQ) &
+	while ((io_read32(gpc_base() + GPC_CPU_PGC_SW_PUP_REQ) &
 	       GPC_PGC_SW_PDN_PUP_REQ_CORE1_MASK) != 0)
 		;
 

--- a/core/arch/arm/plat-imx/pm/pm-imx7.c
+++ b/core/arch/arm/plat-imx/pm/pm-imx7.c
@@ -179,7 +179,7 @@ int imx7_suspend_init(void)
 	p->gic_pa_base = GIC_BASE;
 
 	/* TODO:lpsr disabled now */
-	write32(0, p->lpsr_va_base);
+	io_write32(p->lpsr_va_base, 0);
 
 	p->ddr_type = imx_get_ddr_type();
 	switch (p->ddr_type) {
@@ -199,8 +199,8 @@ int imx7_suspend_init(void)
 	for (i = 0; i < p->ddrc_num; i++) {
 		p->ddrc_val[i][0] = ddrc_offset_array[i][0];
 		if (ddrc_offset_array[i][1] == READ_DATA_FROM_HARDWARE)
-			p->ddrc_val[i][1] = read32(p->ddrc_va_base +
-						   ddrc_offset_array[i][0]);
+			p->ddrc_val[i][1] = io_read32(p->ddrc_va_base +
+						      ddrc_offset_array[i][0]);
 		else
 			p->ddrc_val[i][1] = ddrc_offset_array[i][1];
 
@@ -213,8 +213,8 @@ int imx7_suspend_init(void)
 		p->ddrc_phy_val[i][0] = ddrc_phy_offset_array[i][0];
 		if (ddrc_phy_offset_array[i][1] == READ_DATA_FROM_HARDWARE)
 			p->ddrc_phy_val[i][1] =
-				read32(p->ddrc_phy_va_base +
-				       ddrc_phy_offset_array[i][0]);
+				io_read32(p->ddrc_phy_va_base +
+					  ddrc_phy_offset_array[i][0]);
 		else
 			p->ddrc_phy_val[i][1] = ddrc_phy_offset_array[i][1];
 	}

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -103,12 +103,12 @@ void plat_cpu_reset_late(void)
 	if (!get_core_pos()) {
 #if defined(CFG_BOOT_SECONDARY_REQUEST)
 		/* set secondary entry address */
-		write32(__compiler_bswap32(TEE_LOAD_ADDR),
-				DCFG_BASE + DCFG_SCRATCHRW1);
+		io_write32(DCFG_BASE + DCFG_SCRATCHRW1,
+			   __compiler_bswap32(TEE_LOAD_ADDR));
 
 		/* release secondary cores */
-		write32(__compiler_bswap32(0x1 << 1), /* cpu1 */
-				DCFG_BASE + DCFG_CCSR_BRR);
+		io_write32(DCFG_BASE + DCFG_CCSR_BRR /* cpu1 */,
+			   __compiler_bswap32(0x1 << 1));
 		dsb();
 		sev();
 #endif
@@ -119,21 +119,20 @@ void plat_cpu_reset_late(void)
 		for (addr = CSU_BASE + CSU_CSL_START;
 			 addr != CSU_BASE + CSU_CSL_END;
 			 addr += 4)
-			write32(__compiler_bswap32(CSU_ACCESS_ALL), addr);
+			io_write32(addr, __compiler_bswap32(CSU_ACCESS_ALL));
 
 		/* restrict key preipherals from NS */
-		write32(__compiler_bswap32(CSU_ACCESS_SEC_ONLY),
-			CSU_BASE + CSU_CSL30);
-		write32(__compiler_bswap32(CSU_ACCESS_SEC_ONLY),
-			CSU_BASE + CSU_CSL37);
+		io_write32(CSU_BASE + CSU_CSL30,
+			   __compiler_bswap32(CSU_ACCESS_SEC_ONLY));
+		io_write32(CSU_BASE + CSU_CSL37,
+			   __compiler_bswap32(CSU_ACCESS_SEC_ONLY));
 
 		/* lock the settings */
 		for (addr = CSU_BASE + CSU_CSL_START;
-			 addr != CSU_BASE + CSU_CSL_END;
-			 addr += 4)
-			write32(read32(addr) |
-				__compiler_bswap32(CSU_SETTING_LOCK),
-				addr);
+		     addr != CSU_BASE + CSU_CSL_END;
+		     addr += 4)
+			io_setbits32(addr,
+				     __compiler_bswap32(CSU_SETTING_LOCK));
 	}
 }
 #endif

--- a/core/arch/arm/plat-marvell/armada3700/hal_sec_perf.c
+++ b/core/arch/arm/plat-marvell/armada3700/hal_sec_perf.c
@@ -127,9 +127,9 @@
 
 #define TZ_LOCK_MC(x)		\
 	do {	\
-		(x) = read32(MCU_MC_CONTROL_0_REG);	\
+		(x) = io_read32(MCU_MC_CONTROL_0_REG);	\
 		(x) |= (TRUSTZONE_LOCK);	\
-		 write32((x), MCU_MC_CONTROL_0_REG);	\
+		 io_write32(MCU_MC_CONTROL_0_REG, (x));	\
 	} while (0)
 
 #define _IS_ALIGNED(_addr, _algn)	(!((_addr) & ((_algn) - 1)))
@@ -142,7 +142,7 @@ static int32_t _find_valid_range(void)
 	uint32_t tmp;
 
 	for (i = 0; i < MAX_RANGE_NUM; i++) {
-		tmp = read32(MCU_TZ_RANGE_LOW_REG(i));
+		tmp = io_read32(MCU_TZ_RANGE_LOW_REG(i));
 		if (!TZ_IS_VALID(tmp))
 			return i;
 	}
@@ -180,7 +180,7 @@ static int32_t set_range(uint32_t addr, uint32_t size, uint32_t perm)
 		return -1;
 	}
 
-	data = read32(MCU_TZ_RANGE_LOW_REG(valid_range));
+	data = io_read32(MCU_TZ_RANGE_LOW_REG(valid_range));
 
 	TZ_SET_VALID(data);
 	TZ_SET_PERM(data, perm);
@@ -193,7 +193,7 @@ static int32_t set_range(uint32_t addr, uint32_t size, uint32_t perm)
 		TZ_SET_UR_RZ_EN(data, 0);
 	}
 
-	write32(data, MCU_TZ_RANGE_LOW_REG(valid_range));
+	io_write32(MCU_TZ_RANGE_LOW_REG(valid_range), data);
 
 	return 0;
 }
@@ -208,7 +208,7 @@ static void  _dump_range(void)
 	uint32_t __maybe_unused perm_read;
 
 	for (i = 0; i < MAX_RANGE_NUM; i++) {
-		tmp = read32(MCU_TZ_RANGE_LOW_REG(i));
+		tmp = io_read32(MCU_TZ_RANGE_LOW_REG(i));
 
 		if (TZ_IS_VALID(tmp)) {
 			TZ_GET_PERM(tmp, perm_read);

--- a/core/arch/arm/plat-marvell/armada7k8k/hal_sec_perf.c
+++ b/core/arch/arm/plat-marvell/armada7k8k/hal_sec_perf.c
@@ -128,9 +128,9 @@
 
 #define TZ_LOCK_MC(x)		\
 	do {	\
-		(x) = read32(MCU_MC_CONTROL_0_REG);	\
+		(x) = io_read32(MCU_MC_CONTROL_0_REG);	\
 		(x) |= (TRUSTZONE_LOCK);	\
-		 write32((x), MCU_MC_CONTROL_0_REG);	\
+		 io_write32(MCU_MC_CONTROL_0_REG, (x));	\
 	} while (0)
 
 #define _IS_ALIGNED(_addr, _algn)	(!((_addr) & ((_algn) - 1)))
@@ -144,7 +144,7 @@ static int32_t _find_valid_range(void)
 	uint32_t tmp;
 
 	for (i = 0; i < MAX_RANGE_NUM; i++) {
-		tmp = read32(MCU_TZ_RANGE_LOW_REG(i));
+		tmp = io_read32(MCU_TZ_RANGE_LOW_REG(i));
 		if (!TZ_IS_VALID(tmp))
 			return i;
 	}
@@ -189,7 +189,7 @@ static int32_t set_range(uint32_t addr, uint32_t size, uint32_t perm)
 		return -1;
 	}
 
-	data = read32(MCU_TZ_RANGE_LOW_REG(valid_range));
+	data = io_read32(MCU_TZ_RANGE_LOW_REG(valid_range));
 
 	TZ_SET_VALID(data);
 	TZ_SET_PERM(data, perm);
@@ -202,7 +202,7 @@ static int32_t set_range(uint32_t addr, uint32_t size, uint32_t perm)
 		TZ_SET_UR_RZ_EN(data, 0);
 	}
 
-	write32(data, MCU_TZ_RANGE_LOW_REG(valid_range));
+	io_write32(MCU_TZ_RANGE_LOW_REG(valid_range), data);
 
 	return 0;
 }
@@ -218,7 +218,7 @@ static void  _dump_range(void)
 	uint32_t __maybe_unused perm_read;
 
 	for (i = 0; i < MAX_RANGE_NUM; i++) {
-		tmp = read32(MCU_TZ_RANGE_LOW_REG(i));
+		tmp = io_read32(MCU_TZ_RANGE_LOW_REG(i));
 
 		if (TZ_IS_VALID(tmp)) {
 			TZ_GET_PERM(tmp, perm_read);
@@ -277,9 +277,9 @@ static TEE_Result init_sec_perf(void)
 	uint32_t tmp;
 
 	/* MC_SCR config: deny NS access to MC registers */
-	tmp = read32(PHY_2_VIR(MC_SCR_REGISTER));
+	tmp = io_read32(PHY_2_VIR(MC_SCR_REGISTER));
 	tmp |= 0x1;
-	write32(tmp, PHY_2_VIR(MC_SCR_REGISTER));
+	io_write32(PHY_2_VIR(MC_SCR_REGISTER), tmp);
 
 	/* Set Secure Memory Region */
 	DMSG("sec-rgn size: ra = 0x%08" PRIx32 ", size = 0x%" PRIx32,

--- a/core/arch/arm/plat-rockchip/platform.c
+++ b/core/arch/arm/plat-rockchip/platform.c
@@ -45,13 +45,13 @@ static TEE_Result platform_init(void)
 	vaddr_t ddrsgrf_base = (vaddr_t)phys_to_virt_io(DDRSGRF_BASE);
 
 	/* Set rgn0 non-secure */
-	write32(DDR_RGN0_NS, ddrsgrf_base + DDR_SGRF_DDR_CON(0));
+	io_write32(ddrsgrf_base + DDR_SGRF_DDR_CON(0), DDR_RGN0_NS);
 
 	/* Initialize all slave non-secure */
-	write32(SLAVE_ALL_NS, sgrf_base + SGRF_SOC_CON(7));
-	write32(SLAVE_ALL_NS, sgrf_base + SGRF_SOC_CON(8));
-	write32(SLAVE_ALL_NS, sgrf_base + SGRF_SOC_CON(9));
-	write32(SLAVE_ALL_NS, sgrf_base + SGRF_SOC_CON(10));
+	io_write32(sgrf_base + SGRF_SOC_CON(7), SLAVE_ALL_NS);
+	io_write32(sgrf_base + SGRF_SOC_CON(8), SLAVE_ALL_NS);
+	io_write32(sgrf_base + SGRF_SOC_CON(9), SLAVE_ALL_NS);
+	io_write32(sgrf_base + SGRF_SOC_CON(10), SLAVE_ALL_NS);
 
 	return TEE_SUCCESS;
 }

--- a/core/arch/arm/plat-sam/main.c
+++ b/core/arch/arm/plat-sam/main.c
@@ -99,9 +99,9 @@ enum ram_config {RAMC_SRAM = 0, RAMC_L2CC};
 static void l2_sram_config(enum ram_config setting)
 {
 	if (setting == RAMC_L2CC)
-		write32(0x1, sfr_base() + SFR_L2CC_HRAMC);
+		io_write32(sfr_base() + SFR_L2CC_HRAMC, 0x1);
 	else
-		write32(0x0, sfr_base() + SFR_L2CC_HRAMC);
+		io_write32(sfr_base() + SFR_L2CC_HRAMC, 0x0);
 }
 
 vaddr_t pl310_base(void)
@@ -118,11 +118,11 @@ vaddr_t pl310_base(void)
 
 void arm_cl2_config(vaddr_t pl310_base)
 {
-	write32(0, pl310_base + PL310_CTRL);
+	io_write32(pl310_base + PL310_CTRL, 0);
 	l2_sram_config(RAMC_L2CC);
-	write32(PL310_AUX_CTRL_INIT, pl310_base + PL310_AUX_CTRL);
-	write32(PL310_PREFETCH_CTRL_INIT, pl310_base + PL310_PREFETCH_CTRL);
-	write32(PL310_POWER_CTRL_INIT, pl310_base + PL310_POWER_CTRL);
+	io_write32(pl310_base + PL310_AUX_CTRL, PL310_AUX_CTRL_INIT);
+	io_write32(pl310_base + PL310_PREFETCH_CTRL, PL310_PREFETCH_CTRL_INIT);
+	io_write32(pl310_base + PL310_POWER_CTRL, PL310_POWER_CTRL_INIT);
 
 	/* invalidate all cache ways */
 	arm_cl2_invbyway(pl310_base);
@@ -131,7 +131,7 @@ void arm_cl2_config(vaddr_t pl310_base)
 void arm_cl2_enable(vaddr_t pl310_base)
 {
 	/* Enable PL310 ctrl -> only set lsb bit */
-	write32(1, pl310_base + PL310_CTRL);
+	io_write32(pl310_base + PL310_CTRL, 1);
 }
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, AT91C_BASE_MATRIX32,

--- a/core/arch/arm/plat-sam/matrix.c
+++ b/core/arch/arm/plat-sam/matrix.c
@@ -429,12 +429,12 @@ static void matrix_write(unsigned int base,
 			 unsigned int offset,
 			 const unsigned int value)
 {
-	write32(value, offset + base);
+	io_write32(offset + base, value);
 }
 
 static unsigned int matrix_read(int base, unsigned int offset)
 {
-	return read32(offset + base);
+	return io_read32(offset + base);
 }
 
 void matrix_write_protect_enable(unsigned int matrix_base)

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -116,14 +116,14 @@ vaddr_t pl310_base(void)
 void arm_cl2_config(vaddr_t pl310)
 {
 	/* pl310 off */
-	write32(0, pl310 + PL310_CTRL);
+	io_write32(pl310 + PL310_CTRL, 0);
 
 	/* config PL310 */
-	write32(PL310_TAG_RAM_CTRL_INIT, pl310 + PL310_TAG_RAM_CTRL);
-	write32(PL310_DATA_RAM_CTRL_INIT, pl310 + PL310_DATA_RAM_CTRL);
-	write32(PL310_AUX_CTRL_INIT, pl310 + PL310_AUX_CTRL);
-	write32(PL310_PREFETCH_CTRL_INIT, pl310 + PL310_PREFETCH_CTRL);
-	write32(PL310_POWER_CTRL_INIT, pl310 + PL310_POWER_CTRL);
+	io_write32(pl310 + PL310_TAG_RAM_CTRL, PL310_TAG_RAM_CTRL_INIT);
+	io_write32(pl310 + PL310_DATA_RAM_CTRL, PL310_DATA_RAM_CTRL_INIT);
+	io_write32(pl310 + PL310_AUX_CTRL, PL310_AUX_CTRL_INIT);
+	io_write32(pl310 + PL310_PREFETCH_CTRL, PL310_PREFETCH_CTRL_INIT);
+	io_write32(pl310 + PL310_POWER_CTRL, PL310_POWER_CTRL_INIT);
 
 	/* invalidate all pl310 cache ways */
 	arm_cl2_invbyway(pl310);
@@ -141,19 +141,19 @@ void plat_cpu_reset_late(void)
 	if (get_core_pos())
 		return;
 
-	write32(SCU_SAC_INIT, SCU_BASE + SCU_SAC);
-	write32(SCU_NSAC_INIT, SCU_BASE + SCU_NSAC);
-	write32(CPU_PORT_FILT_END, SCU_BASE + SCU_FILT_EA);
-	write32(CPU_PORT_FILT_START, SCU_BASE + SCU_FILT_SA);
-	write32(SCU_CTRL_INIT, SCU_BASE + SCU_CTRL);
+	io_write32(SCU_BASE + SCU_SAC, SCU_SAC_INIT);
+	io_write32(SCU_BASE + SCU_NSAC, SCU_NSAC_INIT);
+	io_write32(SCU_BASE + SCU_FILT_EA, CPU_PORT_FILT_END);
+	io_write32(SCU_BASE + SCU_FILT_SA, CPU_PORT_FILT_START);
+	io_write32(SCU_BASE + SCU_CTRL, SCU_CTRL_INIT);
 
-	write32(CPU_PORT_FILT_END, pl310_base() + PL310_ADDR_FILT_END);
-	write32(CPU_PORT_FILT_START | PL310_CTRL_ENABLE_BIT,
-				   pl310_base() + PL310_ADDR_FILT_START);
+	io_write32(pl310_base() + PL310_ADDR_FILT_END, CPU_PORT_FILT_END);
+	io_write32(pl310_base() + PL310_ADDR_FILT_START,
+		CPU_PORT_FILT_START | PL310_CTRL_ENABLE_BIT);
 
 	/* TODO: gic_init scan fails, pre-init all SPIs are nonsecure */
 	for (i = 0; i < (31 * 4); i += 4)
-		write32(0xFFFFFFFF, GIC_DIST_BASE + GIC_DIST_ISR1 + i);
+		io_write32(GIC_DIST_BASE + GIC_DIST_ISR1 + i, 0xFFFFFFFF);
 }
 
 void main_init_gic(void)

--- a/core/arch/arm/plat-stm/rng_support.c
+++ b/core/arch/arm/plat-stm/rng_support.c
@@ -37,7 +37,7 @@ static inline int hwrng_waithost_fifo_full(void)
 	uint32_t status;
 
 	do {
-		status = read32(rng_base() + RNG_STATUS_OFFSET);
+		status = io_read32(rng_base() + RNG_STATUS_OFFSET);
 	} while (!(status & RNG_STATUS_FULL));
 
 	if (status & (RNG_STATUS_ERR0 | RNG_STATUS_ERR1))
@@ -109,7 +109,7 @@ uint8_t hw_get_random_byte(void)
 
 	/* Read the FIFO according the number of expected element */
 	for (i = 0; i < _LOCAL_FIFO_SIZE / 2; i++)
-		tmpval[i] = read32(rng_base() + RNG_VAL_OFFSET) & 0xFFFF;
+		tmpval[i] = io_read32(rng_base() + RNG_VAL_OFFSET) & 0xFFFF;
 
 	/* Update the local SW fifo for next request */
 	pos = 0;

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
@@ -28,7 +28,7 @@
 			panic(); \
 	} while (!(_condition))
 
-uintptr_t stm32_rcc_base(void)
+vaddr_t stm32_rcc_base(void)
 {
 	static struct io_pa_va base = { .pa = RCC_BASE };
 
@@ -50,11 +50,11 @@ void stm32_reset_assert(unsigned int id)
 	size_t offset = reset_id2reg_offset(id);
 	uint32_t bitmsk = BIT(reset_id2reg_bit_pos(id));
 	uint64_t timeout_ref = timeout_init_us(RESET_TIMEOUT_US);
-	uintptr_t rcc_base = stm32_rcc_base();
+	vaddr_t rcc_base = stm32_rcc_base();
 
-	write32(bitmsk, rcc_base + offset);
+	io_write32(rcc_base + offset, bitmsk);
 
-	WAIT_COND_OR_PANIC(read32(rcc_base + offset) & bitmsk,
+	WAIT_COND_OR_PANIC(io_read32(rcc_base + offset) & bitmsk,
 			   timeout_ref);
 }
 
@@ -63,10 +63,10 @@ void stm32_reset_deassert(unsigned int id)
 	size_t offset = reset_id2reg_offset(id) + RCC_MP_RSTCLRR_OFFSET;
 	uint32_t bitmsk = BIT(reset_id2reg_bit_pos(id));
 	uint64_t timeout_ref = timeout_init_us(RESET_TIMEOUT_US);
-	uintptr_t rcc_base = stm32_rcc_base();
+	vaddr_t rcc_base = stm32_rcc_base();
 
-	write32(bitmsk, rcc_base + offset);
+	io_write32(rcc_base + offset, bitmsk);
 
-	WAIT_COND_OR_PANIC(!(read32(rcc_base + offset) & bitmsk),
+	WAIT_COND_OR_PANIC(!(io_read32(rcc_base + offset) & bitmsk),
 			   timeout_ref);
 }

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -538,12 +538,12 @@ vaddr_t stm32_rcc_base(void);
 
 static inline bool stm32_rcc_is_secure(void)
 {
-	return read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN;
+	return io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN;
 }
 
 static inline bool stm32_rcc_is_mckprot(void)
 {
-	return read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_MCKPROT;
+	return io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_MCKPROT;
 }
 #endif /*ASM*/
 

--- a/core/arch/arm/plat-stm32mp1/pm/psci.c
+++ b/core/arch/arm/plat-stm32mp1/pm/psci.c
@@ -83,7 +83,8 @@ static void __noreturn stm32_pm_cpu_power_down_wfi(void)
 {
 	dcache_op_level1(DCACHE_OP_CLEAN);
 
-	write32(RCC_MP_GRSTCSETR_MPUP1RST, stm32_rcc_base() + RCC_MP_GRSTCSETR);
+	io_write32(stm32_rcc_base() + RCC_MP_GRSTCSETR,
+		   RCC_MP_GRSTCSETR_MPUP1RST);
 
 	dsb();
 	isb();
@@ -115,8 +116,8 @@ void stm32mp_register_online_cpu(void)
 static void raise_sgi0_as_secure(void)
 {
 	dsb_ishst();
-	write32(GIC_NON_SEC_SGI_0 | SHIFT_U32(TARGET_CPU1_GIC_MASK, 16),
-		get_gicd_base() + GICD_SGIR);
+	io_write32(get_gicd_base() + GICD_SGIR,
+		   GIC_NON_SEC_SGI_0 | SHIFT_U32(TARGET_CPU1_GIC_MASK, 16));
 }
 
 static void release_secondary_early_hpen(size_t __unused pos)
@@ -125,10 +126,10 @@ static void release_secondary_early_hpen(size_t __unused pos)
 	raise_sgi0_as_secure();
 	udelay(20);
 
-	write32(TEE_LOAD_ADDR,
-		stm32mp_bkpreg(BCKR_CORE1_BRANCH_ADDRESS));
-	write32(BOOT_API_A7_CORE1_MAGIC_NUMBER,
-		stm32mp_bkpreg(BCKR_CORE1_MAGIC_NUMBER));
+	io_write32(stm32mp_bkpreg(BCKR_CORE1_BRANCH_ADDRESS),
+		   TEE_LOAD_ADDR);
+	io_write32(stm32mp_bkpreg(BCKR_CORE1_MAGIC_NUMBER),
+		   BOOT_API_A7_CORE1_MAGIC_NUMBER);
 
 	dsb_ishst();
 	itr_raise_sgi(GIC_SEC_SGI_0, TARGET_CPU1_GIC_MASK);

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -138,22 +138,20 @@ void console_init(void)
 #ifdef SUNXI_TZPC_BASE
 static void tzpc_init(void)
 {
-	vaddr_t tzpc;
+	vaddr_t v = (vaddr_t)phys_to_virt(SUNXI_TZPC_BASE, MEM_AREA_IO_SEC);
 
-	tzpc = (vaddr_t)phys_to_virt(SUNXI_TZPC_BASE, MEM_AREA_IO_SEC);
-
-	DMSG("SMTA_DECPORT0=%x", read32(tzpc + REG_TZPC_SMTA_DECPORT0_STA_REG));
-	DMSG("SMTA_DECPORT1=%x", read32(tzpc + REG_TZPC_SMTA_DECPORT1_STA_REG));
-	DMSG("SMTA_DECPORT2=%x", read32(tzpc + REG_TZPC_SMTA_DECPORT2_STA_REG));
+	DMSG("SMTA_DECPORT0=%x", io_read32(v + REG_TZPC_SMTA_DECPORT0_STA_REG));
+	DMSG("SMTA_DECPORT1=%x", io_read32(v + REG_TZPC_SMTA_DECPORT1_STA_REG));
+	DMSG("SMTA_DECPORT2=%x", io_read32(v + REG_TZPC_SMTA_DECPORT2_STA_REG));
 
 	/* Allow all peripherals for normal world */
-	write32(0xbe, tzpc + REG_TZPC_SMTA_DECPORT0_SET_REG);
-	write32(0xff, tzpc + REG_TZPC_SMTA_DECPORT1_SET_REG);
-	write32(0x7f, tzpc + REG_TZPC_SMTA_DECPORT2_SET_REG);
+	io_write32(v + REG_TZPC_SMTA_DECPORT0_SET_REG, 0xbe);
+	io_write32(v + REG_TZPC_SMTA_DECPORT1_SET_REG, 0xff);
+	io_write32(v + REG_TZPC_SMTA_DECPORT2_SET_REG, 0x7f);
 
-	DMSG("SMTA_DECPORT0=%x", read32(tzpc + REG_TZPC_SMTA_DECPORT0_STA_REG));
-	DMSG("SMTA_DECPORT1=%x", read32(tzpc + REG_TZPC_SMTA_DECPORT1_STA_REG));
-	DMSG("SMTA_DECPORT2=%x", read32(tzpc + REG_TZPC_SMTA_DECPORT2_STA_REG));
+	DMSG("SMTA_DECPORT0=%x", io_read32(v + REG_TZPC_SMTA_DECPORT0_STA_REG));
+	DMSG("SMTA_DECPORT1=%x", io_read32(v + REG_TZPC_SMTA_DECPORT1_STA_REG));
+	DMSG("SMTA_DECPORT2=%x", io_read32(v + REG_TZPC_SMTA_DECPORT2_STA_REG));
 }
 #else
 static inline void tzpc_init(void)
@@ -208,7 +206,6 @@ vaddr_t smc_base(void)
 
 static TEE_Result smc_init(void)
 {
-	uint32_t val = 0;
 	vaddr_t base = smc_base();
 
 	if (!base) {
@@ -222,11 +219,8 @@ static TEE_Result smc_init(void)
 	tzc_configure_region(1, 0x0, TZC_ATTR_REGION_SIZE(TZC_REGION_SIZE_32M) |
 			     TZC_ATTR_REGION_EN_MASK | TZC_ATTR_SP_S_RW);
 
-
 	/* SoC specific bits */
-	val = read32(base + SMC_MASTER_BYPASS);
-	val = val & ~(SMC_MASTER_BYPASS_EN_MASK);
-	write32(val, base + SMC_MASTER_BYPASS);
+	io_clrbits32(base + SMC_MASTER_BYPASS, SMC_MASTER_BYPASS_EN_MASK);
 
 	return TEE_SUCCESS;
 }

--- a/core/arch/arm/plat-synquacer/rng_pta.c
+++ b/core/arch/arm/plat-synquacer/rng_pta.c
@@ -232,7 +232,7 @@ void rng_collect_entropy(void)
 					(THERMAL_SENSOR_OFFSET * i) +
 					TEMP_DATA_REG_OFFSET);
 		sensors_data[sensors_data_slot_idx + i][sensors_data_idx] =
-					(uint8_t)read32((vaddr_t)vaddr);
+					(uint8_t)io_read32((vaddr_t)vaddr);
 	}
 
 	sensors_data_idx++;

--- a/core/arch/arm/plat-ti/sm_platform_handler_a9.c
+++ b/core/arch/arm/plat-ti/sm_platform_handler_a9.c
@@ -63,29 +63,29 @@ bool sm_platform_handler(struct sm_ctx *ctx)
 		}
 		break;
 	case API_MONITOR_L2CACHE_SETDEBUG_INDEX:
-		write32(ctx->nsec.r0, pl310_base() + PL310_DEBUG_CTRL);
+		io_write32(pl310_base() + PL310_DEBUG_CTRL, ctx->nsec.r0);
 		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
 		break;
 	case API_MONITOR_L2CACHE_CLEANINVBYPA_INDEX:
 		arm_cl2_cleaninvbypa(pl310_base(), ctx->nsec.r0,
-				     (ctx->nsec.r0 + ctx->nsec.r1));
+				     ctx->nsec.r0 + ctx->nsec.r1);
 		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
 		break;
 	case API_MONITOR_L2CACHE_SETCONTROL_INDEX:
-		write32(ctx->nsec.r0, pl310_base() + PL310_CTRL);
+		io_write32(pl310_base() + PL310_CTRL, ctx->nsec.r0);
 		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
 		break;
 	case API_MONITOR_L2CACHE_SETAUXILIARYCONTROL_INDEX:
-		write32(ctx->nsec.r0, pl310_base() + PL310_AUX_CTRL);
+		io_write32(pl310_base() + PL310_AUX_CTRL, ctx->nsec.r0);
 		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
 		break;
 	case API_MONITOR_L2CACHE_SETLATENCY_INDEX:
-		write32(ctx->nsec.r0, pl310_base() + PL310_TAG_RAM_CTRL);
-		write32(ctx->nsec.r1, pl310_base() + PL310_DATA_RAM_CTRL);
+		io_write32(pl310_base() + PL310_TAG_RAM_CTRL, ctx->nsec.r0);
+		io_write32(pl310_base() + PL310_DATA_RAM_CTRL, ctx->nsec.r1);
 		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
 		break;
 	case API_MONITOR_L2CACHE_SETPREFETCHCONTROL_INDEX:
-		write32(ctx->nsec.r0, pl310_base() + PL310_PREFETCH_CTRL);
+		io_write32(pl310_base() + PL310_PREFETCH_CTRL, ctx->nsec.r0);
 		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
 		break;
 	default:

--- a/core/drivers/atmel_uart.c
+++ b/core/drivers/atmel_uart.c
@@ -61,7 +61,7 @@ static void atmel_uart_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (!(read32(base + ATMEL_UART_SR) & ATMEL_SR_TXEMPTY))
+	while (!(io_read32(base + ATMEL_UART_SR) & ATMEL_SR_TXEMPTY))
 		;
 }
 
@@ -69,20 +69,20 @@ static int atmel_uart_getchar(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (read32(base + ATMEL_UART_SR) & ATMEL_SR_RXRDY)
+	while (io_read32(base + ATMEL_UART_SR) & ATMEL_SR_RXRDY)
 		;
 
-	return read32(base + ATMEL_UART_RHR);
+	return io_read32(base + ATMEL_UART_RHR);
 }
 
 static void atmel_uart_putc(struct serial_chip *chip, int ch)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (!(read32(base + ATMEL_UART_SR) & ATMEL_SR_TXRDY))
+	while (!(io_read32(base + ATMEL_UART_SR) & ATMEL_SR_TXRDY))
 		;
 
-	write32(ch, base + ATMEL_UART_THR);
+	io_write32(base + ATMEL_UART_THR, ch);
 }
 
 static const struct serial_ops atmel_uart_ops = {

--- a/core/drivers/cdns_uart.c
+++ b/core/drivers/cdns_uart.c
@@ -67,7 +67,7 @@ static void cdns_uart_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (!(read32(base + CDNS_UART_CHANNEL_STATUS) &
+	while (!(io_read32(base + CDNS_UART_CHANNEL_STATUS) &
 		 CDNS_UART_CHANNEL_STATUS_TEMPTY))
 		;
 }
@@ -76,8 +76,8 @@ static bool cdns_uart_have_rx_data(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	return !(read32(base + CDNS_UART_CHANNEL_STATUS) &
-			CDNS_UART_CHANNEL_STATUS_REMPTY);
+	return !(io_read32(base + CDNS_UART_CHANNEL_STATUS) &
+		 CDNS_UART_CHANNEL_STATUS_REMPTY);
 }
 
 static int cdns_uart_getchar(struct serial_chip *chip)
@@ -86,7 +86,7 @@ static int cdns_uart_getchar(struct serial_chip *chip)
 
 	while (!cdns_uart_have_rx_data(chip))
 		;
-	return read32(base + CDNS_UART_FIFO) & 0xff;
+	return io_read32(base + CDNS_UART_FIFO) & 0xff;
 }
 
 static void cdns_uart_putc(struct serial_chip *chip, int ch)
@@ -94,12 +94,12 @@ static void cdns_uart_putc(struct serial_chip *chip, int ch)
 	vaddr_t base = chip_to_base(chip);
 
 	/* Wait until there is space in the FIFO */
-	while (read32(base + CDNS_UART_CHANNEL_STATUS) &
-			CDNS_UART_CHANNEL_STATUS_TFUL)
+	while (io_read32(base + CDNS_UART_CHANNEL_STATUS) &
+	       CDNS_UART_CHANNEL_STATUS_TFUL)
 		;
 
 	/* Send the character */
-	write32(ch, base + CDNS_UART_FIFO);
+	io_write32(base + CDNS_UART_FIFO, ch);
 }
 
 
@@ -125,8 +125,8 @@ void cdns_uart_init(struct cdns_uart_data *pd, paddr_t base, uint32_t uart_clk,
 		return;
 
 	/* Enable UART and RX/TX */
-	write32(CDNS_UART_CONTROL_RXEN | CDNS_UART_CONTROL_TXEN,
-		base + CDNS_UART_CONTROL);
+	io_write32(base + CDNS_UART_CONTROL,
+		   CDNS_UART_CONTROL_RXEN | CDNS_UART_CONTROL_TXEN);
 
 	cdns_uart_flush(&pd->chip);
 }

--- a/core/drivers/hi16xx_rng.c
+++ b/core/drivers/hi16xx_rng.c
@@ -44,17 +44,17 @@ static TEE_Result hi16xx_rng_init(void)
 	TEE_Time time;
 
 	/* ALG sub-controller must allow RNG out of reset */
-	write32(ALG_SC_SRST_DREQ_RNG, alg + ALG_SC_RNG_RESET_DREQ);
+	io_write32(alg + ALG_SC_RNG_RESET_DREQ, ALG_SC_SRST_DREQ_RNG);
 
 	/* Set initial seed */
 	tee_time_get_sys_time(&time);
-	write32(time.seconds * 1000 + time.millis, rng + RNG_SEED);
+	io_write32(rng + RNG_SEED, time.seconds * 1000 + time.millis);
 
 	/*
 	 * Enable RNG and configure it to re-seed automatically from the
 	 * internal ring oscillator
 	 */
-	write32(RNG_EN | RNG_RING_EN | RNG_SEED_SEL, rng + RNG_CTRL);
+	io_write32(rng + RNG_CTRL, RNG_EN | RNG_RING_EN | RNG_SEED_SEL);
 
 	IMSG("Hi16xx RNG initialized");
 	return TEE_SUCCESS;
@@ -77,7 +77,7 @@ uint8_t hw_get_random_byte(void)
 		r = (vaddr_t)phys_to_virt(RNG_BASE, MEM_AREA_IO_SEC) + RNG_NUM;
 
 	if (!pos)
-		random.val = read32(r);
+		random.val = io_read32(r);
 
 	ret = random.byte[pos++];
 

--- a/core/drivers/imx_snvs.c
+++ b/core/drivers/imx_snvs.c
@@ -93,16 +93,16 @@ static uint64_t snvs_srtc_read_lp_counter(void)
 	uint32_t val;
 
 	do {
-		val = read32(snvs + SNVS_LPSRTCMR);
+		val = io_read32(snvs + SNVS_LPSRTCMR);
 		val1 = val;
 		val1 <<= 32;
-		val = read32(snvs + SNVS_LPSRTCLR);
+		val = io_read32(snvs + SNVS_LPSRTCLR);
 		val1 |= val;
 
-		val = read32(snvs + SNVS_LPSRTCMR);
+		val = io_read32(snvs + SNVS_LPSRTCMR);
 		val2 = val;
 		val2 <<= 32;
-		val = read32(snvs + SNVS_LPSRTCLR);
+		val = io_read32(snvs + SNVS_LPSRTCLR);
 		val2 |= val;
 
 	/*
@@ -140,12 +140,12 @@ TEE_Result snvs_srtc_enable(void)
 	int timeout = 2000;
 	uint32_t val;
 
-	val = read32(snvs + SNVS_LPCR);
+	val = io_read32(snvs + SNVS_LPCR);
 	val |= SNVS_LPCR_SRTC_ENV_MASK;
-	write32(val, snvs + SNVS_LPCR);
+	io_write32(snvs + SNVS_LPCR, val);
 
 	do {
-		val = read32(snvs + SNVS_LPCR);
+		val = io_read32(snvs + SNVS_LPCR);
 		if (val & SNVS_LPCR_SRTC_ENV_MASK)
 			break;
 	} while (--timeout);

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -93,8 +93,8 @@ static void imx_uart_flush(struct serial_chip *chip)
 	vaddr_t base = chip_to_base(chip);
 
 
-	while (!(read32(base + UTS) & UTS_TXEMPTY))
-		if (!(read32(base + UCR1) & UCR1_UARTEN))
+	while (!(io_read32(base + UTS) & UTS_TXEMPTY))
+		if (!(io_read32(base + UCR1) & UCR1_UARTEN))
 			return;
 }
 
@@ -102,10 +102,10 @@ static int imx_uart_getchar(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (read32(base + UTS) & UTS_RXEMPTY)
+	while (io_read32(base + UTS) & UTS_RXEMPTY)
 		;
 
-	return (read32(base + URXD) & URXD_RX_DATA);
+	return (io_read32(base + URXD) & URXD_RX_DATA);
 }
 
 static void imx_uart_putc(struct serial_chip *chip, int ch)
@@ -113,11 +113,11 @@ static void imx_uart_putc(struct serial_chip *chip, int ch)
 	vaddr_t base = chip_to_base(chip);
 
 	/* Wait until there's space in the TX FIFO */
-	while (read32(base + UTS) & UTS_TXFULL)
-		if (!(read32(base + UCR1) & UCR1_UARTEN))
+	while (io_read32(base + UTS) & UTS_TXFULL)
+		if (!(io_read32(base + UCR1) & UCR1_UARTEN))
 			return;
 
-	write32(ch, base + UTXD);
+	io_write32(base + UTXD, ch);
 }
 
 static const struct serial_ops imx_uart_ops = {

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -60,16 +60,16 @@ void imx_wdog_restart(void)
 
 	DMSG("val %x\n", val);
 
-	write16(val, wdog_base + WDT_WCR);
+	io_write16(wdog_base + WDT_WCR, val);
 	dsb();
 
-	if (read16(wdog_base + WDT_WCR) & WDT_WCR_WDE) {
-		write16(WDT_SEQ1, wdog_base + WDT_WSR);
-		write16(WDT_SEQ2, wdog_base + WDT_WSR);
+	if (io_read16(wdog_base + WDT_WCR) & WDT_WCR_WDE) {
+		io_write16(wdog_base + WDT_WSR, WDT_SEQ1);
+		io_write16(wdog_base + WDT_WSR, WDT_SEQ2);
 	}
 
-	write16(val, wdog_base + WDT_WCR);
-	write16(val, wdog_base + WDT_WCR);
+	io_write16(wdog_base + WDT_WCR, val);
+	io_write16(wdog_base + WDT_WCR, val);
 
 	while (1)
 		;

--- a/core/drivers/ns16550.c
+++ b/core/drivers/ns16550.c
@@ -58,7 +58,7 @@ static void ns16550_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while ((read8(base + UART_LSR) & UART_LSR_THRE) == 0)
+	while ((io_read8(base + UART_LSR) & UART_LSR_THRE) == 0)
 		;
 }
 
@@ -69,7 +69,7 @@ static void ns16550_putc(struct serial_chip *chip, int ch)
 	ns16550_flush(chip);
 
 	/* write out charset to Transmit-hold-register */
-	write8(ch, base + UART_THR);
+	io_write8(base + UART_THR, ch);
 }
 
 static const struct serial_ops ns16550_ops = {

--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -151,25 +151,25 @@ static enum spi_result pl022_txrx8(struct spi_chip *chip, uint8_t *wdat,
 
 	if (wdat)
 		while (i < num_pkts) {
-			if (read8(pd->base + SSPSR) & SSPSR_TNF) {
+			if (io_read8(pd->base + SSPSR) & SSPSR_TNF) {
 				/* tx 1 packet */
-				write8(wdat[i++], pd->base + SSPDR);
+				io_write8(pd->base + SSPDR, wdat[i++]);
 			}
 
 			if (rdat)
-				if (read8(pd->base + SSPSR) & SSPSR_RNE) {
+				if (io_read8(pd->base + SSPSR) & SSPSR_RNE) {
 					/* rx 1 packet */
-					rdat[j++] = read8(pd->base + SSPDR);
+					rdat[j++] = io_read8(pd->base + SSPDR);
 				}
 		}
 
 	/* Capture remaining rdat not read above */
 	if (rdat) {
 		while ((j < num_pkts) &&
-			(read8(pd->base + SSPSR) & SSPSR_BSY))
-			if (read8(pd->base + SSPSR) & SSPSR_RNE) {
+			(io_read8(pd->base + SSPSR) & SSPSR_BSY))
+			if (io_read8(pd->base + SSPSR) & SSPSR_RNE) {
 				/* rx 1 packet */
-				rdat[j++] = read8(pd->base + SSPDR);
+				rdat[j++] = io_read8(pd->base + SSPDR);
 			}
 
 		if (j < num_pkts) {
@@ -197,25 +197,25 @@ static enum spi_result pl022_txrx16(struct spi_chip *chip, uint16_t *wdat,
 
 	if (wdat)
 		while (i < num_pkts) {
-			if (read8(pd->base + SSPSR) & SSPSR_TNF) {
+			if (io_read8(pd->base + SSPSR) & SSPSR_TNF) {
 				/* tx 1 packet */
-				write16(wdat[i++], pd->base + SSPDR);
+				io_write16(pd->base + SSPDR, wdat[i++]);
 			}
 
 			if (rdat)
-				if (read8(pd->base + SSPSR) & SSPSR_RNE) {
+				if (io_read8(pd->base + SSPSR) & SSPSR_RNE) {
 					/* rx 1 packet */
-					rdat[j++] = read16(pd->base + SSPDR);
+					rdat[j++] = io_read8(pd->base + SSPDR);
 				}
 		}
 
 	/* Capture remaining rdat not read above */
 	if (rdat) {
 		while ((j < num_pkts) &&
-			(read8(pd->base + SSPSR) & SSPSR_BSY))
-			if (read8(pd->base + SSPSR) & SSPSR_RNE) {
+			(io_read8(pd->base + SSPSR) & SSPSR_BSY))
+			if (io_read8(pd->base + SSPSR) & SSPSR_RNE) {
 				/* rx 1 packet */
-				rdat[j++] = read16(pd->base + SSPDR);
+				rdat[j++] = io_read8(pd->base + SSPDR);
 			}
 
 		if (j < num_pkts) {
@@ -232,20 +232,20 @@ static void pl022_print_peri_id(struct pl022_data *pd __maybe_unused)
 {
 	DMSG("Expected: 0x 22 10 ?4 00");
 	DMSG("Read: 0x %02x %02x %02x %02x",
-		read32(pd->base + SSPPeriphID0),
-		read32(pd->base + SSPPeriphID1),
-		read32(pd->base + SSPPeriphID2),
-		read32(pd->base + SSPPeriphID3));
+		io_read8(pd->base + SSPPeriphID0),
+		io_read8(pd->base + SSPPeriphID1),
+		io_read8(pd->base + SSPPeriphID2),
+		io_read8(pd->base + SSPPeriphID3));
 }
 
 static void pl022_print_cell_id(struct pl022_data *pd __maybe_unused)
 {
 	DMSG("Expected: 0x 0d f0 05 b1");
 	DMSG("Read: 0x %02x %02x %02x %02x",
-		read32(pd->base + SSPPCellID0),
-		read32(pd->base + SSPPCellID1),
-		read32(pd->base + SSPPCellID2),
-		read32(pd->base + SSPPCellID3));
+		io_read8(pd->base + SSPPCellID0),
+		io_read8(pd->base + SSPPCellID1),
+		io_read8(pd->base + SSPPCellID2),
+		io_read8(pd->base + SSPPCellID3));
 }
 
 static void pl022_sanity_check(struct pl022_data *pd)
@@ -271,7 +271,7 @@ static void pl022_sanity_check(struct pl022_data *pd)
 
 	#ifdef PLATFORM_hikey
 	DMSG("SSPB2BTRANS: Expected: 0x2. Read: 0x%x",
-		read32(pd->base + SSPB2BTRANS));
+		io_read8(pd->base + SSPB2BTRANS));
 	#endif
 	pl022_print_peri_id(pd);
 	pl022_print_cell_id(pd);
@@ -289,9 +289,9 @@ static void pl022_control_cs(struct spi_chip *chip, enum gpio_level value)
 
 	switch (pd->cs_control) {
 	case PL022_CS_CTRL_AUTO_GPIO:
-		if (read8(pd->base + SSPSR) & SSPSR_BSY)
+		if (io_read8(pd->base + SSPSR) & SSPSR_BSY)
 			DMSG("pl022 busy - do NOT set CS!");
-		while (read8(pd->base + SSPSR) & SSPSR_BSY)
+		while (io_read8(pd->base + SSPSR) & SSPSR_BSY)
 			;
 		DMSG("pl022 done - set CS!");
 
@@ -359,11 +359,11 @@ static void pl022_flush_fifo(struct pl022_data *pd)
 	uint32_t __maybe_unused rdat;
 
 	do {
-		while (read32(pd->base + SSPSR) & SSPSR_RNE) {
-			rdat = read32(pd->base + SSPDR);
+		while (io_read32(pd->base + SSPSR) & SSPSR_RNE) {
+			rdat = io_read32(pd->base + SSPDR);
 			DMSG("rdat: 0x%x", rdat);
 		}
-	} while (read32(pd->base + SSPSR) & SSPSR_BSY);
+	} while (io_read32(pd->base + SSPSR) & SSPSR_BSY);
 }
 
 static void pl022_configure(struct spi_chip *chip)

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -49,7 +49,7 @@ static enum gpio_dir pl061_get_direction(unsigned int gpio_pin)
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
-	data = read8(base_addr + GPIODIR);
+	data = io_read8(base_addr + GPIODIR);
 	if (data & BIT(offset))
 		return GPIO_DIR_OUT;
 	return GPIO_DIR_IN;
@@ -58,20 +58,16 @@ static enum gpio_dir pl061_get_direction(unsigned int gpio_pin)
 static void pl061_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
 {
 	vaddr_t base_addr;
-	uint8_t data;
 	unsigned int offset;
 
 	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
-	if (direction == GPIO_DIR_OUT) {
-		data = read8(base_addr + GPIODIR) | BIT(offset);
-		write8(data, base_addr + GPIODIR);
-	} else {
-		data = read8(base_addr + GPIODIR) & ~BIT(offset);
-		write8(data, base_addr + GPIODIR);
-	}
+	if (direction == GPIO_DIR_OUT)
+		io_setbits8(base_addr + GPIODIR, BIT(offset));
+	else
+		io_clrbits8(base_addr + GPIODIR, BIT(offset));
 }
 
 /*
@@ -91,7 +87,7 @@ static enum gpio_level pl061_get_value(unsigned int gpio_pin)
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
-	if (read8(base_addr + BIT(offset + 2)))
+	if (io_read8(base_addr + BIT(offset + 2)))
 		return GPIO_LEVEL_HIGH;
 	return GPIO_LEVEL_LOW;
 }
@@ -111,9 +107,9 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
 	if (value == GPIO_LEVEL_HIGH)
-		write8(BIT(offset), base_addr + BIT(offset + 2));
+		io_write8(base_addr + BIT(offset + 2), BIT(offset));
 	else
-		write8(0, base_addr + BIT(offset + 2));
+		io_write8(base_addr + BIT(offset + 2), 0);
 }
 
 static enum gpio_interrupt pl061_get_interrupt(unsigned int gpio_pin)
@@ -126,7 +122,7 @@ static enum gpio_interrupt pl061_get_interrupt(unsigned int gpio_pin)
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
-	data = read8(base_addr + GPIOIE);
+	data = io_read8(base_addr + GPIOIE);
 	if (data & BIT(offset))
 		return GPIO_INTERRUPT_ENABLE;
 	return GPIO_INTERRUPT_DISABLE;
@@ -136,20 +132,16 @@ static void pl061_set_interrupt(unsigned int gpio_pin,
 	enum gpio_interrupt ena_dis)
 {
 	vaddr_t base_addr;
-	uint8_t data;
 	unsigned int offset;
 
 	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
-	if (ena_dis == GPIO_INTERRUPT_ENABLE) {
-		data = read8(base_addr + GPIOIE) | BIT(offset);
-		write8(data, base_addr + GPIOIE);
-	} else {
-		data = read8(base_addr + GPIOIE) & ~BIT(offset);
-		write8(data, base_addr + GPIOIE);
-	}
+	if (ena_dis == GPIO_INTERRUPT_ENABLE)
+		io_setbits8(base_addr + GPIOIE, BIT(offset));
+	else
+		io_clrbits8(base_addr + GPIOIE, BIT(offset));
 }
 
 /*
@@ -194,7 +186,7 @@ enum pl061_mode_control pl061_get_mode_control(unsigned int gpio_pin)
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
-	data = read8(base_addr + GPIOAFSEL);
+	data = io_read8(base_addr + GPIOAFSEL);
 	if (data & BIT(offset))
 		return PL061_MC_HW;
 	return PL061_MC_SW;
@@ -204,18 +196,14 @@ void pl061_set_mode_control(unsigned int gpio_pin,
 	enum pl061_mode_control hw_sw)
 {
 	vaddr_t base_addr;
-	uint8_t data;
 	unsigned int offset;
 
 	assert(gpio_pin < PLAT_PL061_MAX_GPIOS);
 
 	base_addr = pl061_reg_base[gpio_pin / GPIOS_PER_PL061];
 	offset = gpio_pin % GPIOS_PER_PL061;
-	if (hw_sw == PL061_MC_HW) {
-		data = read8(base_addr + GPIOAFSEL) | BIT(offset);
-		write8(data, base_addr + GPIOAFSEL);
-	} else {
-		data = read8(base_addr + GPIOAFSEL) & ~BIT(offset);
-		write8(data, base_addr + GPIOAFSEL);
-	}
+	if (hw_sw == PL061_MC_HW)
+		io_setbits8(base_addr + GPIOAFSEL, BIT(offset));
+	else
+		io_clrbits8(base_addr + GPIOAFSEL, BIT(offset));
 }

--- a/core/drivers/scif.c
+++ b/core/drivers/scif.c
@@ -57,7 +57,7 @@ static void scif_uart_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (!(read16(base + SCIF_SCFSR) & SCFSR_TEND))
+	while (!(io_read16(base + SCIF_SCFSR) & SCFSR_TEND))
 		;
 }
 
@@ -66,12 +66,11 @@ static void scif_uart_putc(struct serial_chip *chip, int ch)
 	vaddr_t base = chip_to_base(chip);
 
 	/* Wait until there is space in the FIFO */
-	while ((read16(base + SCIF_SCFDR) >> SCFDR_T_SHIFT) >=
+	while ((io_read16(base + SCIF_SCFDR) >> SCFDR_T_SHIFT) >=
 		SCIF_TX_FIFO_SIZE)
 		;
-	write8(ch, base + SCIF_SCFTDR);
-	write16(read16(base + SCIF_SCFSR) & ~(SCFSR_TEND | SCFSR_TDFE),
-		base + SCIF_SCFSR);
+	io_write8(base + SCIF_SCFTDR, ch);
+	io_clrbits16(base + SCIF_SCFSR, SCFSR_TEND | SCFSR_TDFE);
 }
 
 static const struct serial_ops scif_uart_ops = {
@@ -86,7 +85,7 @@ void scif_uart_init(struct scif_uart_data *pd, paddr_t base)
 	pd->chip.ops = &scif_uart_ops;
 
 	/* Set Transmit Enable in Control register */
-	write16(read16(base + SCIF_SCSCR) | SCSCR_TE, base + SCIF_SCSCR);
+	io_setbits16(base + SCIF_SCSCR, SCSCR_TE);
 
 	scif_uart_flush(&pd->chip);
 }

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -42,7 +42,7 @@ static void serial8250_uart_flush(struct serial_chip *chip)
 	vaddr_t base = chip_to_base(chip);
 
 	while (1) {
-		uint32_t state = read32(base + UART_LSR);
+		uint32_t state = io_read32(base + UART_LSR);
 
 		/* Wait until transmit FIFO is empty */
 		if ((state & LSR_EMPTY) == LSR_EMPTY)
@@ -54,7 +54,7 @@ static bool serial8250_uart_have_rx_data(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	return (read32(base + UART_LSR) & LSR_DR);
+	return (io_read32(base + UART_LSR) & LSR_DR);
 }
 
 static int serial8250_uart_getchar(struct serial_chip *chip)
@@ -65,7 +65,7 @@ static int serial8250_uart_getchar(struct serial_chip *chip)
 		/* Transmit FIFO is empty, waiting again */
 		;
 	}
-	return read32(base + UART_RHR) & 0xff;
+	return io_read32(base + UART_RHR) & 0xff;
 }
 
 static void serial8250_uart_putc(struct serial_chip *chip, int ch)
@@ -75,7 +75,7 @@ static void serial8250_uart_putc(struct serial_chip *chip, int ch)
 	serial8250_uart_flush(chip);
 
 	/* Write out character to transmit FIFO */
-	write32(ch, base + UART_THR);
+	io_write32(base + UART_THR, ch);
 }
 
 static const struct serial_ops serial8250_uart_ops = {

--- a/core/drivers/sprd_uart.c
+++ b/core/drivers/sprd_uart.c
@@ -52,7 +52,7 @@ static void sprd_uart_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (read32(base + UART_STS1) & STS1_TXF_CNT_MASK)
+	while (io_read32(base + UART_STS1) & STS1_TXF_CNT_MASK)
 		;
 }
 
@@ -60,7 +60,7 @@ static bool sprd_uart_have_rx_data(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	return !!(read32(base + UART_STS1) & STS1_RXF_CNT_MASK);
+	return !!(io_read32(base + UART_STS1) & STS1_RXF_CNT_MASK);
 }
 
 static void sprd_uart_putc(struct serial_chip *chip, int ch)
@@ -68,7 +68,7 @@ static void sprd_uart_putc(struct serial_chip *chip, int ch)
 	vaddr_t base = chip_to_base(chip);
 
 	sprd_uart_flush(chip);
-	write32(base + UART_TXD, ch);
+	io_write32(base + UART_TXD, ch);
 }
 
 static int sprd_uart_getchar(struct serial_chip *chip)
@@ -78,7 +78,7 @@ static int sprd_uart_getchar(struct serial_chip *chip)
 	while (!sprd_uart_have_rx_data(chip))
 		;
 
-	return read32(base + UART_RXD) & 0xff;
+	return io_read32(base + UART_RXD) & 0xff;
 }
 
 static const struct serial_ops sprd_uart_ops = {

--- a/core/drivers/stih_asc.c
+++ b/core/drivers/stih_asc.c
@@ -26,7 +26,7 @@ static void stih_asc_flush(struct serial_chip *chip)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (!(read32(base + ASC_STATUS) & ASC_STATUS_TX_EMPTY))
+	while (!(io_read32(base + ASC_STATUS) & ASC_STATUS_TX_EMPTY))
 		;
 }
 
@@ -34,10 +34,10 @@ static void stih_asc_putc(struct serial_chip *chip, int ch)
 {
 	vaddr_t base = chip_to_base(chip);
 
-	while (!(read32(base + ASC_STATUS) & ASC_STATUS_TX_HALF_EMPTY))
+	while (!(io_read32(base + ASC_STATUS) & ASC_STATUS_TX_HALF_EMPTY))
 		;
 
-	write32(ch, base + ASC_TXBUFFER);
+	io_write32(base + ASC_TXBUFFER, ch);
 }
 
 static const struct serial_ops stih_asc_ops = {

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -133,7 +133,7 @@ enum etzpc_decprot_attributes etzpc_get_decprot(uint32_t decprot_id)
 
 	assert(valid_decprot_id(decprot_id));
 
-	value = (read32(base + ETZPC_DECPROT0 + offset) >> shift) &
+	value = (io_read32(base + ETZPC_DECPROT0 + offset) >> shift) &
 		ETZPC_DECPROT0_MASK;
 
 	return (enum etzpc_decprot_attributes)value;
@@ -147,7 +147,7 @@ void etzpc_lock_decprot(uint32_t decprot_id)
 
 	assert(valid_decprot_id(decprot_id));
 
-	write32(mask, base + offset + ETZPC_DECPROT_LOCK0);
+	io_write32(base + offset + ETZPC_DECPROT_LOCK0, mask);
 
 	/* Save for PM */
 	etzpc_dev.periph_cfg[decprot_id] |= PERIPH_PM_LOCK_BIT;
@@ -161,7 +161,7 @@ bool etzpc_get_lock_decprot(uint32_t decprot_id)
 
 	assert(valid_decprot_id(decprot_id));
 
-	return read32(base + offset + ETZPC_DECPROT_LOCK0) & mask;
+	return io_read32(base + offset + ETZPC_DECPROT_LOCK0) & mask;
 }
 
 void etzpc_configure_tzma(uint32_t tzma_id, uint16_t tzma_value)
@@ -171,7 +171,7 @@ void etzpc_configure_tzma(uint32_t tzma_id, uint16_t tzma_value)
 
 	assert(valid_tzma_id(tzma_id));
 
-	write32(tzma_value, base + ETZPC_TZMA0_SIZE + offset);
+	io_write32(base + ETZPC_TZMA0_SIZE + offset, tzma_value);
 
 	/* Save for PM */
 	assert((tzma_value & ~TZMA_PM_VALUE_MASK) == 0);
@@ -186,7 +186,7 @@ uint16_t etzpc_get_tzma(uint32_t tzma_id)
 
 	assert(valid_tzma_id(tzma_id));
 
-	return read32(base + ETZPC_TZMA0_SIZE + offset);
+	return io_read32(base + ETZPC_TZMA0_SIZE + offset);
 }
 
 void etzpc_lock_tzma(uint32_t tzma_id)
@@ -209,7 +209,8 @@ bool etzpc_get_lock_tzma(uint32_t tzma_id)
 
 	assert(valid_tzma_id(tzma_id));
 
-	return read32(base + ETZPC_TZMA0_SIZE + offset) & ETZPC_TZMA0_SIZE_LOCK;
+	return io_read32(base + ETZPC_TZMA0_SIZE + offset) &
+	       ETZPC_TZMA0_SIZE_LOCK;
 }
 
 static TEE_Result etzpc_pm(enum pm_op op, unsigned int pm_hint __unused,
@@ -278,7 +279,7 @@ struct etzpc_hwcfg {
 
 static void get_hwcfg(struct etzpc_hwcfg *hwcfg)
 {
-	uint32_t reg = read32(etzpc_base() + ETZPC_HWCFGR);
+	uint32_t reg = io_read32(etzpc_base() + ETZPC_HWCFGR);
 
 	hwcfg->num_tzma = (reg & ETZPC_HWCFGR_NUM_TZMA_MASK) >>
 			  ETZPC_HWCFGR_NUM_TZMA_SHIFT;
@@ -306,7 +307,7 @@ static void init_devive_from_hw_config(struct etzpc_instance *dev,
 	dev->num_ahb_sec = hwcfg.num_ahb_sec;
 
 	DMSG("ETZPC revison 0x02%" PRIu8 ", per_sec %u, ahb_sec %u, tzma %u",
-	     read8(etzpc_base() + ETZPC_VERR),
+	     io_read8(etzpc_base() + ETZPC_VERR),
 	     hwcfg.num_per_sec, hwcfg.num_ahb_sec, hwcfg.num_tzma);
 
 	init_pm(dev);

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -66,24 +66,24 @@ static void get_gpio_cfg(uint32_t bank, uint32_t pin, struct gpio_cfg *cfg)
 	 * 4bit fields are accessed at bit position being fourth the pin index
 	 * but accessed from 2 32bit registers at incremental addresses.
 	 */
-	cfg->mode = (read32(base + GPIO_MODER_OFFSET) >> (pin << 1)) &
+	cfg->mode = (io_read32(base + GPIO_MODER_OFFSET) >> (pin << 1)) &
 		     GPIO_MODE_MASK;
 
-	cfg->otype = (read32(base + GPIO_OTYPER_OFFSET) >> pin) & 1;
+	cfg->otype = (io_read32(base + GPIO_OTYPER_OFFSET) >> pin) & 1;
 
-	cfg->ospeed = (read32(base +  GPIO_OSPEEDR_OFFSET) >> (pin << 1)) &
+	cfg->ospeed = (io_read32(base +  GPIO_OSPEEDR_OFFSET) >> (pin << 1)) &
 		       GPIO_OSPEED_MASK;
 
-	cfg->pupd = (read32(base +  GPIO_PUPDR_OFFSET) >> (pin << 1)) &
+	cfg->pupd = (io_read32(base +  GPIO_PUPDR_OFFSET) >> (pin << 1)) &
 		     GPIO_PUPD_PULL_MASK;
 
-	cfg->od = (read32(base + GPIO_ODR_OFFSET) >> (pin << 1)) & 1;
+	cfg->od = (io_read32(base + GPIO_ODR_OFFSET) >> (pin << 1)) & 1;
 
 	if (pin < GPIO_ALT_LOWER_LIMIT)
-		cfg->af = (read32(base + GPIO_AFRL_OFFSET) >> (pin << 2)) &
+		cfg->af = (io_read32(base + GPIO_AFRL_OFFSET) >> (pin << 2)) &
 			   GPIO_ALTERNATE_MASK;
 	else
-		cfg->af = (read32(base + GPIO_AFRH_OFFSET) >>
+		cfg->af = (io_read32(base + GPIO_AFRH_OFFSET) >>
 			    ((pin - GPIO_ALT_LOWER_LIMIT) << 2)) &
 			   GPIO_ALTERNATE_MASK;
 
@@ -354,7 +354,7 @@ static __maybe_unused bool valid_gpio_config(unsigned int bank,
 					     unsigned int pin, bool input)
 {
 	vaddr_t base = stm32_get_gpio_bank_base(bank);
-	uint32_t mode = (read32(base + GPIO_MODER_OFFSET) >> (pin << 1)) &
+	uint32_t mode = (io_read32(base + GPIO_MODER_OFFSET) >> (pin << 1)) &
 			GPIO_MODE_MASK;
 
 	if (pin > GPIO_PIN_MAX)
@@ -376,7 +376,7 @@ int stm32_gpio_get_input_level(unsigned int bank, unsigned int pin)
 
 	stm32_clock_enable(clock);
 
-	if (read32(base + GPIO_IDR_OFFSET) == BIT(pin))
+	if (io_read32(base + GPIO_IDR_OFFSET) == BIT(pin))
 		rc = 1;
 
 	stm32_clock_disable(clock);
@@ -394,9 +394,9 @@ void stm32_gpio_set_output_level(unsigned int bank, unsigned int pin, int level)
 	stm32_clock_enable(clock);
 
 	if (level)
-		write32(BIT(pin), base + GPIO_BSRR_OFFSET);
+		io_write32(base + GPIO_BSRR_OFFSET, BIT(pin));
 	else
-		write32(BIT(pin + 16), base + GPIO_BSRR_OFFSET);
+		io_write32(base + GPIO_BSRR_OFFSET, BIT(pin + 16));
 
 	stm32_clock_disable(clock);
 }

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -55,7 +55,7 @@ static void loc_flush(struct serial_chip *chip)
 	vaddr_t base = loc_chip_to_base(chip);
 	uint64_t timeout = timeout_init_us(FLUSH_TIMEOUT_US);
 
-	while (!(read32(base + UART_REG_ISR) & USART_ISR_TXFE))
+	while (!(io_read32(base + UART_REG_ISR) & USART_ISR_TXFE))
 		if (timeout_elapsed(timeout))
 			return;
 }
@@ -65,18 +65,18 @@ static void loc_putc(struct serial_chip *chip, int ch)
 	vaddr_t base = loc_chip_to_base(chip);
 	uint64_t timeout = timeout_init_us(PUTC_TIMEOUT_US);
 
-	while (!(read32(base + UART_REG_ISR) & USART_ISR_TXE_TXFNF))
+	while (!(io_read32(base + UART_REG_ISR) & USART_ISR_TXE_TXFNF))
 		if (timeout_elapsed(timeout))
 			return;
 
-	write32(ch, base + UART_REG_TDR);
+	io_write32(base + UART_REG_TDR, ch);
 }
 
 static bool loc_have_rx_data(struct serial_chip *chip)
 {
 	vaddr_t base = loc_chip_to_base(chip);
 
-	return read32(base + UART_REG_ISR) & USART_ISR_RXNE_RXFNE;
+	return io_read32(base + UART_REG_ISR) & USART_ISR_RXNE_RXFNE;
 }
 
 static int loc_getchar(struct serial_chip *chip)
@@ -86,7 +86,7 @@ static int loc_getchar(struct serial_chip *chip)
 	while (!loc_have_rx_data(chip))
 		;
 
-	return read32(base + UART_REG_RDR) & 0xff;
+	return io_read32(base + UART_REG_RDR) & 0xff;
 }
 
 static const struct serial_ops stm32_uart_serial_ops = {

--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -54,35 +54,35 @@ static struct tzc_instance tzc;
 
 static uint32_t tzc_read_build_config(vaddr_t base)
 {
-	return read32(base + BUILD_CONFIG_OFF);
+	return io_read32(base + BUILD_CONFIG_OFF);
 }
 
 static void tzc_write_action(vaddr_t base, enum tzc_action action)
 {
-	write32(action, base + ACTION_OFF);
+	io_write32(base + ACTION_OFF, action);
 }
 
 static void tzc_write_region_base_low(vaddr_t base, uint32_t region,
 				      uint32_t val)
 {
-	write32(val, base + REGION_SETUP_LOW_OFF(region));
+	io_write32(base + REGION_SETUP_LOW_OFF(region), val);
 }
 
 static void tzc_write_region_base_high(vaddr_t base, uint32_t region,
 				       uint32_t val)
 {
-	write32(val, base + REGION_SETUP_HIGH_OFF(region));
+	io_write32(base + REGION_SETUP_HIGH_OFF(region), val);
 }
 
 static uint32_t tzc_read_region_attributes(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_ATTRIBUTES_OFF(region));
+	return io_read32(base + REGION_ATTRIBUTES_OFF(region));
 }
 
 static void tzc_write_region_attributes(vaddr_t base, uint32_t region,
 					uint32_t val)
 {
-	write32(val, base + REGION_ATTRIBUTES_OFF(region));
+	io_write32(base + REGION_ATTRIBUTES_OFF(region), val);
 }
 
 void tzc_init(vaddr_t base)
@@ -108,7 +108,7 @@ void tzc_init(vaddr_t base)
  */
 void tzc_security_inversion_en(vaddr_t base)
 {
-	write32(1, base + SECURITY_INV_EN_OFF);
+	io_write32(base + SECURITY_INV_EN_OFF, 1);
 }
 
 /*
@@ -137,18 +137,18 @@ void tzc_fail_dump(void)
 						      MEM_AREA_IO_SEC);
 
 	EMSG("Fail address Low 0x%" PRIx32,
-	     read32(base + FAIL_ADDRESS_LOW_OFF));
+	     io_read32(base + FAIL_ADDRESS_LOW_OFF));
 	EMSG("Fail address High 0x%" PRIx32,
-	     read32(base + FAIL_ADDRESS_HIGH_OFF));
-	EMSG("Fail Control 0x%" PRIx32, read32(base + FAIL_CONTROL_OFF));
-	EMSG("Fail Id 0x%" PRIx32, read32(base + FAIL_ID));
+	     io_read32(base + FAIL_ADDRESS_HIGH_OFF));
+	EMSG("Fail Control 0x%" PRIx32, io_read32(base + FAIL_CONTROL_OFF));
+	EMSG("Fail Id 0x%" PRIx32, io_read32(base + FAIL_ID));
 }
 
 void tzc_int_clear(void)
 {
 	vaddr_t base = core_mmu_get_va(tzc.base, MEM_AREA_IO_SEC);
 
-	write32(0, base + INT_CLEAR);
+	io_write32(base + INT_CLEAR, 0);
 }
 
 static uint32_t addr_low(vaddr_t addr)
@@ -208,12 +208,12 @@ void tzc_set_action(enum tzc_action action)
 
 static uint32_t tzc_read_region_base_low(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_SETUP_LOW_OFF(region));
+	return io_read32(base + REGION_SETUP_LOW_OFF(region));
 }
 
 static uint32_t tzc_read_region_base_high(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_SETUP_HIGH_OFF(region));
+	return io_read32(base + REGION_SETUP_HIGH_OFF(region));
 }
 
 #define	REGION_MAX	16
@@ -224,7 +224,7 @@ void tzc_dump_state(void)
 
 	DMSG("enter");
 	DMSG("security_inversion_en %x\n",
-	     read32(tzc.base + SECURITY_INV_EN_OFF));
+	     io_read32(tzc.base + SECURITY_INV_EN_OFF));
 	for (n = 0; n <= REGION_MAX; n++) {
 		temp_32reg = tzc_read_region_attributes(tzc.base, n);
 		if (!(temp_32reg & TZC_ATTR_REGION_EN_MASK))

--- a/core/drivers/tzc400.c
+++ b/core/drivers/tzc400.c
@@ -81,74 +81,68 @@ static struct tzc_instance tzc;
 
 static uint32_t tzc_read_build_config(vaddr_t base)
 {
-	return read32(base + BUILD_CONFIG_OFF);
+	return io_read32(base + BUILD_CONFIG_OFF);
 }
 
 static uint32_t tzc_read_gate_keeper(vaddr_t base)
 {
-	return read32(base + GATE_KEEPER_OFF);
+	return io_read32(base + GATE_KEEPER_OFF);
 }
 
 static void tzc_write_gate_keeper(vaddr_t base, uint32_t val)
 {
-	write32(val, base + GATE_KEEPER_OFF);
+	io_write32(base + GATE_KEEPER_OFF, val);
 }
 
 static void tzc_write_action(vaddr_t base, enum tzc_action action)
 {
-	write32(action, base + ACTION_OFF);
+	io_write32(base + ACTION_OFF, action);
 }
 
 static void tzc_write_region_base_low(vaddr_t base, uint32_t region,
 				      uint32_t val)
 {
-	write32(val, base + REGION_BASE_LOW_OFF +
-		REGION_NUM_OFF(region));
+	io_write32(base + REGION_BASE_LOW_OFF + REGION_NUM_OFF(region), val);
 }
 
 static void tzc_write_region_base_high(vaddr_t base, uint32_t region,
 				       uint32_t val)
 {
-	write32(val, base + REGION_BASE_HIGH_OFF +
-		REGION_NUM_OFF(region));
+	io_write32(base + REGION_BASE_HIGH_OFF + REGION_NUM_OFF(region), val);
 }
 
 static void tzc_write_region_top_low(vaddr_t base, uint32_t region,
 				     uint32_t val)
 {
-	write32(val, base + REGION_TOP_LOW_OFF +
-		REGION_NUM_OFF(region));
+	io_write32(base + REGION_TOP_LOW_OFF + REGION_NUM_OFF(region), val);
 }
 
 static void tzc_write_region_top_high(vaddr_t base, uint32_t region,
 				      uint32_t val)
 {
-	write32(val, base + REGION_TOP_HIGH_OFF +
-		REGION_NUM_OFF(region));
+	io_write32(base + REGION_TOP_HIGH_OFF +	REGION_NUM_OFF(region), val);
 }
 
 static void tzc_write_region_attributes(vaddr_t base, uint32_t region,
 					uint32_t val)
 {
-	write32(val, base + REGION_ATTRIBUTES_OFF +
-		REGION_NUM_OFF(region));
+	io_write32(base + REGION_ATTRIBUTES_OFF + REGION_NUM_OFF(region), val);
 }
 
 static void tzc_write_region_id_access(vaddr_t base, uint32_t region,
 				       uint32_t val)
 {
-	write32(val, base + REGION_ID_ACCESS_OFF +
-		REGION_NUM_OFF(region));
+	io_write32(base + REGION_ID_ACCESS_OFF + REGION_NUM_OFF(region), val);
 }
 
 static uint32_t tzc_read_component_id(vaddr_t base)
 {
 	uint32_t id;
 
-	id = read8(base + CID0_OFF);
-	id |= SHIFT_U32(read8(base + CID1_OFF), 8);
-	id |= SHIFT_U32(read8(base + CID2_OFF), 16);
-	id |= SHIFT_U32(read8(base + CID3_OFF), 24);
+	id = io_read8(base + CID0_OFF);
+	id |= SHIFT_U32(io_read8(base + CID1_OFF), 8);
+	id |= SHIFT_U32(io_read8(base + CID2_OFF), 16);
+	id |= SHIFT_U32(io_read8(base + CID3_OFF), 24);
 
 	return id;
 }
@@ -350,27 +344,27 @@ void tzc_disable_filters(void)
 
 static uint32_t tzc_read_region_attributes(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_ATTRIBUTES_OFF + REGION_NUM_OFF(region));
+	return io_read32(base + REGION_ATTRIBUTES_OFF + REGION_NUM_OFF(region));
 }
 
 static uint32_t tzc_read_region_base_low(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_BASE_LOW_OFF + REGION_NUM_OFF(region));
+	return io_read32(base + REGION_BASE_LOW_OFF + REGION_NUM_OFF(region));
 }
 
 static uint32_t tzc_read_region_base_high(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_BASE_HIGH_OFF + REGION_NUM_OFF(region));
+	return io_read32(base + REGION_BASE_HIGH_OFF + REGION_NUM_OFF(region));
 }
 
 static uint32_t tzc_read_region_top_low(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_TOP_LOW_OFF + REGION_NUM_OFF(region));
+	return io_read32(base + REGION_TOP_LOW_OFF + REGION_NUM_OFF(region));
 }
 
 static uint32_t tzc_read_region_top_high(vaddr_t base, uint32_t region)
 {
-	return read32(base + REGION_TOP_HIGH_OFF + REGION_NUM_OFF(region));
+	return io_read32(base + REGION_TOP_HIGH_OFF + REGION_NUM_OFF(region));
 }
 
 #define	REGION_MAX		8

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2014-2019, Linaro Limited
  */
 #ifndef IO_H
 #define IO_H
@@ -19,49 +19,49 @@
  */
 #define READ_ONCE(p) __compiler_atomic_load(&(p))
 
-static inline void write8(uint8_t val, vaddr_t addr)
+static inline void io_write8(vaddr_t addr, uint8_t val)
 {
 	*(volatile uint8_t *)addr = val;
 }
 
-static inline void write16(uint16_t val, vaddr_t addr)
+static inline void io_write16(vaddr_t addr, uint16_t val)
 {
 	*(volatile uint16_t *)addr = val;
 }
 
-static inline void write32(uint32_t val, vaddr_t addr)
+static inline void io_write32(vaddr_t addr, uint32_t val)
 {
 	*(volatile uint32_t *)addr = val;
 }
 
-static inline uint8_t read8(vaddr_t addr)
+static inline uint8_t io_read8(vaddr_t addr)
 {
 	return *(volatile uint8_t *)addr;
 }
 
-static inline uint16_t read16(vaddr_t addr)
+static inline uint16_t io_read16(vaddr_t addr)
 {
 	return *(volatile uint16_t *)addr;
 }
 
-static inline uint32_t read32(vaddr_t addr)
+static inline uint32_t io_read32(vaddr_t addr)
 {
 	return *(volatile uint32_t *)addr;
 }
 
 static inline void io_mask8(vaddr_t addr, uint8_t val, uint8_t mask)
 {
-	write8((read8(addr) & ~mask) | (val & mask), addr);
+	io_write8(addr, (io_read8(addr) & ~mask) | (val & mask));
 }
 
 static inline void io_mask16(vaddr_t addr, uint16_t val, uint16_t mask)
 {
-	write16((read16(addr) & ~mask) | (val & mask), addr);
+	io_write16(addr, (io_read16(addr) & ~mask) | (val & mask));
 }
 
 static inline void io_mask32(vaddr_t addr, uint32_t val, uint32_t mask)
 {
-	write32((read32(addr) & ~mask) | (val & mask), addr);
+	io_write32(addr, (io_read32(addr) & ~mask) | (val & mask));
 }
 
 static inline uint64_t get_be64(const void *p)
@@ -106,18 +106,56 @@ static inline void put_be16(void *p, uint16_t val)
  */
 static inline void io_setbits32(vaddr_t addr, uint32_t set_mask)
 {
-	write32(read32(addr) | set_mask, addr);
+	io_write32(addr, io_read32(addr) | set_mask);
 }
 
 static inline void io_clrbits32(vaddr_t addr, uint32_t clear_mask)
 {
-	write32(read32(addr) & ~clear_mask, addr);
+	io_write32(addr, io_read32(addr) & ~clear_mask);
 }
 
 static inline void io_clrsetbits32(vaddr_t addr, uint32_t clear_mask,
 				   uint32_t set_mask)
 {
-	write32((read32(addr) & ~clear_mask) | set_mask, addr);
+	io_write32(addr, (io_read32(addr) & ~clear_mask) | set_mask);
+}
+
+/*
+ * Functions write8(), write16(), write32(), read8(), read16() and read32()
+ * will be deprecated in OP-TEE release 3.5.0.
+ *
+ * Main issue is the swapping position of address and value arguments
+ * of write{8|16|32}() regarding other util functions io_mask*(),
+ * io_*bits32() and put_be*().
+ */
+static inline void write8(uint8_t val, vaddr_t addr)
+{
+	io_write8(addr, val);
+}
+
+static inline void write16(uint16_t val, vaddr_t addr)
+{
+	io_write16(addr, val);
+}
+
+static inline void write32(uint32_t val, vaddr_t addr)
+{
+	io_write32(addr, val);
+}
+
+static inline uint8_t read8(vaddr_t addr)
+{
+	return io_read8(addr);
+}
+
+static inline uint16_t read16(vaddr_t addr)
+{
+	return io_read16(addr);
+}
+
+static inline uint32_t read32(vaddr_t addr)
+{
+	return io_read32(addr);
 }
 
 #endif /*IO_H*/

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -120,6 +120,38 @@ static inline void io_clrsetbits32(vaddr_t addr, uint32_t clear_mask,
 	io_write32(addr, (io_read32(addr) & ~clear_mask) | set_mask);
 }
 
+static inline void io_setbits16(vaddr_t addr, uint16_t set_mask)
+{
+	io_write16(addr, io_read16(addr) | set_mask);
+}
+
+static inline void io_clrbits16(vaddr_t addr, uint16_t clear_mask)
+{
+	io_write16(addr, io_read16(addr) & ~clear_mask);
+}
+
+static inline void io_clrsetbits16(vaddr_t addr, uint16_t clear_mask,
+				   uint16_t set_mask)
+{
+	io_write16(addr, (io_read16(addr) & ~clear_mask) | set_mask);
+}
+
+static inline void io_setbits8(vaddr_t addr, uint8_t set_mask)
+{
+	io_write8(addr, io_read8(addr) | set_mask);
+}
+
+static inline void io_clrbits8(vaddr_t addr, uint8_t clear_mask)
+{
+	io_write8(addr, io_read8(addr) & ~clear_mask);
+}
+
+static inline void io_clrsetbits8(vaddr_t addr, uint8_t clear_mask,
+				  uint8_t set_mask)
+{
+	io_write8(addr, (io_read8(addr) & ~clear_mask) | set_mask);
+}
+
 /*
  * Functions write8(), write16(), write32(), read8(), read16() and read32()
  * will be deprecated in OP-TEE release 3.5.0.

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -152,42 +152,4 @@ static inline void io_clrsetbits8(vaddr_t addr, uint8_t clear_mask,
 	io_write8(addr, (io_read8(addr) & ~clear_mask) | set_mask);
 }
 
-/*
- * Functions write8(), write16(), write32(), read8(), read16() and read32()
- * will be deprecated in OP-TEE release 3.5.0.
- *
- * Main issue is the swapping position of address and value arguments
- * of write{8|16|32}() regarding other util functions io_mask*(),
- * io_*bits32() and put_be*().
- */
-static inline void write8(uint8_t val, vaddr_t addr)
-{
-	io_write8(addr, val);
-}
-
-static inline void write16(uint16_t val, vaddr_t addr)
-{
-	io_write16(addr, val);
-}
-
-static inline void write32(uint32_t val, vaddr_t addr)
-{
-	io_write32(addr, val);
-}
-
-static inline uint8_t read8(vaddr_t addr)
-{
-	return io_read8(addr);
-}
-
-static inline uint16_t read16(vaddr_t addr)
-{
-	return io_read16(addr);
-}
-
-static inline uint32_t read32(vaddr_t addr)
-{
-	return io_read32(addr);
-}
-
 #endif /*IO_H*/


### PR DESCRIPTION
`write8()`, `write16()` and `write32()` expect the target written address as 1st argument and the written value as 2nd argument. This is confusing as `put_be32()`, `put_be64()`, `io_mask32()`, and the `io_*bits32()` functions expect the opposite: 1st argument is the address and 2nd argument is the written value.

This change introduces functions `io_write8()`, `io_write16()` and `io_write32()` with `io_mask32()` like APIs. This change introduces `io_read*()` for consistency: all prefixed with `io_`.

This change preserve the `write8()`/`write16()`/`write32()` functions for compatibility. These will be deprecated in the next OP-TEE release to lower confusion around these.

If one agrees with this RFC, i can push an update for the supported platforms and drivers (and generic code) to move to `io_read*()` and `io_write*()`.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
