### PR TITLE
der_decode_utf8_string: Fix output buffer overflow

### DIFF
--- a/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
@@ -121,7 +121,7 @@ int der_decode_utf8_string(const unsigned char *in,  unsigned long inlen,
          tmp = (tmp << 6) | ((wchar_t)in[x++] & 0x3F);
       }
 
-      if (y > *outlen) {
+      if (y >= *outlen) {
          *outlen = y;
          return CRYPT_BUFFER_OVERFLOW;
       }


### PR DESCRIPTION
Return CRYPT_BUFFER_OVERFLOW if "y >= *outlen" to prevent overflow
of the output buffer.

Signed-off-by: Peikan Tsai <mark1990301@gmail.com>
