### PR TITLE
Revert "core_mmu: phys_to_virt_io(): warn if PA has both S and NS map…

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1946,22 +1946,12 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m)
 
 void *phys_to_virt_io(paddr_t pa)
 {
-	struct tee_mmap_region *map = NULL;
-	struct tee_mmap_region *smap = NULL;
-	struct tee_mmap_region *nsmap = NULL;
-	void *va = NULL;
+	struct tee_mmap_region *map;
+	void *va;
 
-	smap = find_map_by_type_and_pa(MEM_AREA_IO_SEC, pa);
-	nsmap = find_map_by_type_and_pa(MEM_AREA_IO_NSEC, pa);
-	if (smap && nsmap) {
-		EMSG("pa %" PRIxPA " mapped IO_SEC and IO_NSEC!", pa);
-		map = smap;
-	} else {
-		if (smap)
-			map = smap;
-		else
-			map = nsmap;
-	}
+	map = find_map_by_type_and_pa(MEM_AREA_IO_SEC, pa);
+	if (!map)
+		map = find_map_by_type_and_pa(MEM_AREA_IO_NSEC, pa);
 	if (!map)
 		return NULL;
 	va = map_pa2va(map, pa);


### PR DESCRIPTION
…pings"

This reverts commit 53c1131c3dee546d6d618a0f7f20586598ca032c. The
original change breaks platforms that map their console UART in both
security domains [1]. In this case, the platform won't boot because the
error message causes infinite recursion.

Since add_phys_mem() warns about overlaps already, there is really no
need for more checks.

Link: [1] https://github.com/OP-TEE/optee_os/issues/2821
Reported-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
