### PR TITLE
libutee: fix TEE_OpenPersistentObject error behavior

### DIFF
--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -418,6 +418,9 @@ out:
 	    res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
 		TEE_Panic(res);
 
+	if (res != TEE_SUCCESS && object)
+		*object = TEE_HANDLE_NULL;
+
 	return res;
 }
 


### PR DESCRIPTION
The TEE spec says about  TEE_OpenPersistentObject:
> If this function fails for any reason, the value pointed to by object is set to TEE_HANDLE_NULL.

The diff looks a bit confusing. All I did was to move the `if (!object)` block to the top and set `*object` to `TEE_HANDLE_NULL` directly afterwards.