### PR TITLE
support offline signing of TAs

### DIFF
--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
+import sys
+
 
 def uuid_parse(s):
     from uuid import UUID
@@ -14,65 +16,200 @@ def int_parse(str):
     return int(str, 0)
 
 
-def get_args():
-    from argparse import ArgumentParser
+def get_args(logger):
+    from argparse import ArgumentParser, RawDescriptionHelpFormatter
+    import textwrap
+    command_base = ['sign', 'digest', 'stitch']
+    command_aliases_digest = ['generate-digest']
+    command_aliases_stitch = ['stitch-ta']
+    command_aliases = command_aliases_digest + command_aliases_stitch
+    command_choices = command_base + command_aliases
 
-    parser = ArgumentParser()
+    dat = '[' + ', '.join(command_aliases_digest) + ']'
+    sat = '[' + ', '.join(command_aliases_stitch) + ']'
+
+    parser = ArgumentParser(
+        description='Sign a Tusted Application for OP-TEE.',
+        usage='\n   %(prog)s command [ arguments ]\n\n'
+
+        '   command:\n' +
+        '     sign        Generate signed loadable TA image file.\n' +
+        '                 Takes arguments --uuid, --in, --out' +
+        ' and --key.\n' +
+        '     digest      Generate loadable TA binary image digest' +
+        ' for offline\n' +
+        '                 signing. Takes arguments  --uuid, --in and' +
+        ' --dig.\n' +
+        '     stitch      Generate loadable signed TA binary image' +
+        ' file from\n' +
+        '                 TA raw image and its signature. Takes' +
+        ' arguments\n' +
+        '                 --uuid, --in, --out, and --sig.\n\n' +
+        '   %(prog)s --help  show available commands and arguments\n\n',
+        formatter_class=RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent('''\
+            If no command is given, the script will default to "sign".
+
+            command aliases:
+              The command \'digest\' can be aliased by ''' + dat + '''
+              The command \'stitch\' can be aliased by ''' + sat + '\n' + '''
+            example offline signing command using OpenSSL:
+              base64 -d <UUID>.dig | \\
+              openssl pkeyutl -sign -inkey <KEYFILE>.pem \\
+                  -pkeyopt digest:sha256 \\
+                  -pkeyopt rsa_padding_mode:pkcs1 | \\
+              base64 > <UUID>.sig
+            '''))
+
+    parser.add_argument(
+        'command', choices=command_choices, nargs='?',
+        default='sign',
+        help='Command, one of [' + ', '.join(command_base) + ']')
     parser.add_argument('--uuid', required=True,
-                        type=uuid_parse, help='UUID of TA')
-    parser.add_argument('--version', type=int_parse, default=0, help='Version')
-    parser.add_argument('--key', required=True, help='Name of key file')
-    parser.add_argument('--in', required=True, dest='inf',
-                        help='Name of in file')
-    parser.add_argument('--out', required=True, help='Name of out file')
-    return parser.parse_args()
+                        type=uuid_parse, help='String UUID of the TA')
+    parser.add_argument('--key', required=True,
+                        help='Name of key file (PEM format)')
+    parser.add_argument(
+        '--sig', required=False, dest='sigf',
+        help='Name of signature input file, defaults to <UUID>.sig')
+    parser.add_argument(
+        '--dig', required=False, dest='digf',
+        help='Name of digest output file, defaults to <UUID>.dig')
+    parser.add_argument(
+        '--in', required=False, dest='inf',
+        help='Name of application input file, defaults to <UUID>.stripped.elf')
+    parser.add_argument(
+        '--out', required=False, dest='outf',
+        help='Name of application output file, defaults to <UUID>.ta')
+
+    parsed = parser.parse_args()
+
+    # Check parameter combinations
+
+    if parsed.digf is None and \
+       parsed.outf is not None and \
+       parsed.command in ['digest'] + command_aliases_digest:
+        logger.error('A digest was requested, but argument --out was given.' +
+                     '  Did you mean:\n  ' +
+                     parser.prog+' --dig ' + parsed.outf + ' ...')
+        sys.exit(1)
+
+    if parsed.digf is not None \
+       and parsed.outf is not None \
+       and parsed.command in ['digest'] + command_aliases_digest:
+        logger.warn('A digest was requested, but arguments --dig and ' +
+                    '--out were given.\n' +
+                    '  --out will be ignored.')
+
+    # Set defaults for optional arguments.
+
+    if parsed.sigf is None:
+        parsed.sigf = str(parsed.uuid)+'.sig'
+    if parsed.digf is None:
+        parsed.digf = str(parsed.uuid)+'.dig'
+    if parsed.inf is None:
+        parsed.inf = str(parsed.uuid)+'.stripped.elf'
+    if parsed.outf is None:
+        parsed.outf = str(parsed.uuid)+'.ta'
+
+    return parsed
 
 
 def main():
     from Crypto.Signature import PKCS1_v1_5
     from Crypto.Hash import SHA256
     from Crypto.PublicKey import RSA
+    from Crypto.Util.number import ceil_div
+    import base64
+    import logging
+    import os
     import struct
 
-    args = get_args()
+    logging.basicConfig()
+    logger = logging.getLogger(os.path.basename(__file__))
 
-    f = open(args.key, 'rb')
-    key = RSA.importKey(f.read())
-    f.close()
+    args = get_args(logger)
 
-    f = open(args.inf, 'rb')
-    img = f.read()
-    f.close()
+    with open(args.key, 'rb') as f:
+        key = RSA.importKey(f.read())
 
-    signer = PKCS1_v1_5.new(key)
+    with open(args.inf, 'rb') as f:
+        img = f.read()
+
     h = SHA256.new()
 
     digest_len = h.digest_size
-    sig_len = len(signer.sign(h))
+    sig_len = ceil_div(key.size() + 1, 8)
     img_size = len(img)
 
-    magic = 0x4f545348    # SHDR_MAGIC
-    img_type = 1        # SHDR_BOOTSTRAP_TA
+    hdr_version = 0      # SHDR_VERSION (always 0)
+    magic = 0x4f545348   # SHDR_MAGIC
+    img_type = 1         # SHDR_BOOTSTRAP_TA
     algo = 0x70004830    # TEE_ALG_RSASSA_PKCS1_V1_5_SHA256
     shdr = struct.pack('<IIIIHH',
                        magic, img_type, img_size, algo, digest_len, sig_len)
     shdr_uuid = args.uuid.bytes
-    shdr_version = struct.pack('<I', args.version)
+    shdr_version = struct.pack('<I', hdr_version)
 
     h.update(shdr)
     h.update(shdr_uuid)
     h.update(shdr_version)
     h.update(img)
-    sig = signer.sign(h)
+    img_digest = h.digest()
 
-    f = open(args.out, 'wb')
-    f.write(shdr)
-    f.write(h.digest())
-    f.write(sig)
-    f.write(shdr_uuid)
-    f.write(shdr_version)
-    f.write(img)
-    f.close()
+    def write_image_with_signature(sig):
+        with open(args.outf, 'wb') as f:
+            f.write(shdr)
+            f.write(img_digest)
+            f.write(sig)
+            f.write(shdr_uuid)
+            f.write(shdr_version)
+            f.write(img)
+
+    def sign_ta():
+        if not key.has_private():
+            logger.error('Provided key cannot be used for signing, ' +
+                         'please use offline-signing mode.')
+        else:
+            signer = PKCS1_v1_5.new(key)
+            sig = signer.sign(h)
+            write_image_with_signature(sig)
+            logger.info('Successfully signed application.')
+
+    def generate_digest():
+        with open(args.digf, 'wb+') as digfile:
+            digfile.write(base64.b64encode(img_digest))
+
+    def stitch_ta():
+        try:
+            with open(args.sigf, 'r') as sigfile:
+                sig = base64.b64decode(sigfile.read())
+        except IOError:
+            if not os.path.exits(args.digf):
+                generate_digest()
+            logger.error('No signature file found. Please sign\n %s\n' +
+                         'offline and place the signature at \n %s\n' +
+                         'or pass a different location ' +
+                         'using the --sig argument.\n',
+                         args.digf, args.sigf)
+        else:
+            verifier = PKCS1_v1_5.new(key)
+            if verifier.verify(h, sig):
+                write_image_with_signature(sig)
+                logger.info('Successfully applied signature.')
+            else:
+                logger.error('Verification failed, ignoring given signature.')
+
+    command_dict = {
+        'sign': sign_ta,
+        'digest': generate_digest,
+        'generate-digest': generate_digest,
+        'stitch': stitch_ta,
+        'stitch-ta': stitch_ta
+    }
+
+    fun = command_dict.get(args.command, 'sign_ta')
+    fun()
 
 
 if __name__ == "__main__":

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -75,7 +75,7 @@ $(link-out-dir$(sm))/$(user-ta-uuid).ta: \
 			$(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf \
 			$(TA_SIGN_KEY)
 	@$(cmd-echo-silent) '  SIGN    $$@'
-	$(q)$(SIGN) --key $(TA_SIGN_KEY) --uuid $(user-ta-uuid) --version 0 \
+	$(q)$(SIGN) --key $(TA_SIGN_KEY) --uuid $(user-ta-uuid) \
 		--in $$< --out $$@
 endef
 

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -46,5 +46,5 @@ $(link-out-dir)/$(shlibuuid).elf: $(link-out-dir)/$(shlibname).so
 $(link-out-dir)/$(shlibuuid).ta: $(link-out-dir)/$(shlibname).stripped.so \
 				$(TA_SIGN_KEY)
 	@$(cmd-echo-silent) '  SIGN    $@'
-	$(q)$(SIGN) --key $(TA_SIGN_KEY) --uuid $(shlibuuid) --version 0 \
+	$(q)$(SIGN) --key $(TA_SIGN_KEY) --uuid $(shlibuuid) \
 		--in $< --out $@


### PR DESCRIPTION
Signed-off-by: Markus S. Wamser <markus.wamser@mixed-mode.de>

This modifies `scripts/sign.py` to support offline signing.

The behaviour should not change for users that provide the private key in `keys/default_ta.pem`.

In case no privat key is found, the digest is written to a file and a notice is printed. If a matching file containing a signature is found, the signature is verified against the current digest of the TA and the public key and applied only if verification succeds.
Naming of files and encoding of contents follows https://github.com/Microsoft/ms-tpm-20-ref/tree/master/Samples/ARM32-FirmwareTPM/ta_prod_signing_scripts. While not explicitly tested, the workflows should be compatible.

To produce an ofline signature with OpenSSL (1.1.0):
```
DIGFILE=some-U-U-I-D.dig # as printed by sign.py
KEYFILE=/path/to/default_ta_private.pem
base64 -d $DIGFILE | openssl pkeyutl -sign -inkey $KEYFILE -pkeyopt digest:sha256 -pkeyopt rsa_padding_mode:pkcs1 | base64 > $DIGFILE.signed
```

Proper documentation is still pending. Also maybe a test case (in optee_test?)


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
