### PR TITLE
README.md: remove mention of mixed code and declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ Please see [build] for instructions how to run OP-TEE on various devices.
 ## 5. Coding standards
 In this project we are trying to adhere to the same coding convention as used in
 the Linux kernel (see [CodingStyle]). We achieve this by running [checkpatch]
-from Linux kernel. However there are a few exceptions that we had to make since
-the code also follows GlobalPlatform standards. The exceptions are as follows:
+from Linux kernel. However there are a few exceptions:
 
 -	CamelCase for GlobalPlatform types are allowed.
 -	And we also exclude checking third party code that we might use in this
@@ -125,9 +124,7 @@ the code also follows GlobalPlatform standards. The exceptions are as follows:
 	deviate too much from upstream and therefore it would be hard to rebase
 	against those projects later on and we don't expect that it is easy to
 	convince other software projects to change coding style.
-	Automatic variables should always be initialized. Mixed declarations
-	and statements are allowed, and may be used to avoid assigning useless
-	values. Please leave one blank line before and after such declarations.
+-	Automatic variables should always be initialized.
 
 Regarding the checkpatch tool, it is not included directly into this project.
 Please use checkpatch.pl from the Linux kernel git in combination with the


### PR DESCRIPTION
Back when we decided that new code should always initialize local
variables [1], we allowed mixed declarations and code in order to reduce
"useless" initializations. It turns out that this makes the code harder
to read (prevents seeing all declarations at a glance, introduces too
much extra spacing). Therefore, remove this recommendation.

[1] commit 439203cb04ce ("Allow mixed declaration and code")

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
