### PR TITLE
core/generic-boot: level up missing external DTB trace

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -601,7 +601,7 @@ static int add_optee_dt_node(struct dt_descriptor *dt)
 	int ret;
 
 	if (fdt_path_offset(dt->blob, "/firmware/optee") >= 0) {
-		DMSG("OP-TEE Device Tree node already exists!\n");
+		DMSG("OP-TEE Device Tree node already exists!");
 		return 0;
 	}
 
@@ -637,7 +637,7 @@ static int dt_add_psci_node(struct dt_descriptor *dt)
 	int offs;
 
 	if (fdt_path_offset(dt->blob, "/psci") >= 0) {
-		DMSG("PSCI Device Tree node already exists!\n");
+		DMSG("PSCI Device Tree node already exists!");
 		return 0;
 	}
 
@@ -1057,10 +1057,10 @@ static void init_primary_helper(unsigned long pageable_part,
 #endif
 	release_external_dt();
 #ifdef CFG_VIRTUALIZATION
-	IMSG("Initializing virtualization support\n");
+	IMSG("Initializing virtualization support");
 	core_mmu_init_virtualization();
 #endif
-	DMSG("Primary CPU switching to normal world boot\n");
+	DMSG("Primary CPU switching to normal world boot");
 }
 
 /* What this function is using is needed each time another CPU is started */
@@ -1084,7 +1084,7 @@ static void init_secondary_helper(unsigned long nsec_entry)
 	init_vfp_sec();
 	init_vfp_nsec();
 
-	DMSG("Secondary CPU Switching to normal world boot\n");
+	DMSG("Secondary CPU Switching to normal world boot");
 }
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -888,7 +888,6 @@ static void init_external_dt(unsigned long phys_dt)
 	int ret;
 
 	if (!phys_dt) {
-		EMSG("Device Tree missing");
 		/*
 		 * No need to panic as we're not using the DT in OP-TEE
 		 * yet, we're only adding some nodes for normal world use.
@@ -897,6 +896,7 @@ static void init_external_dt(unsigned long phys_dt)
 		 * initialize devices based on DT we'll likely panic
 		 * instead of returning here.
 		 */
+		DMSG("No non-secure external DT");
 		return;
 	}
 

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -503,6 +503,7 @@ void *get_embedded_dt(void)
 		checked = true;
 	}
 
+	IMSG("Embedded DTB found");
 	return embedded_secure_dtb;
 }
 #else
@@ -896,7 +897,7 @@ static void init_external_dt(unsigned long phys_dt)
 		 * initialize devices based on DT we'll likely panic
 		 * instead of returning here.
 		 */
-		DMSG("No non-secure external DT");
+		IMSG("No non-secure external DT");
 		return;
 	}
 
@@ -922,6 +923,8 @@ static void init_external_dt(unsigned long phys_dt)
 		     phys_dt, ret);
 		panic();
 	}
+
+	IMSG("Non-secure external DT found");
 }
 
 static void update_external_dt(void)

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -69,8 +69,7 @@ void plat_prng_add_jitter_entropy(enum crypto_rng_src sid, unsigned int *pnum)
 		}
 	}
 	if (bytes) {
-		FMSG("%s: 0x%02X\n", __func__,
-		     (int)acc & ((1 << (bytes * 8)) - 1));
+		FMSG("0x%02X", (int)acc & ((1 << (bytes * 8)) - 1));
 		crypto_rng_add_event(sid, pnum, (uint8_t *)&acc, bytes);
 	}
 }

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -164,9 +164,9 @@ static void init_canaries(void)
 									\
 		*start_canary = START_CANARY_VALUE;			\
 		*end_canary = END_CANARY_VALUE;				\
-		DMSG("#Stack canaries for %s[%zu] with top at %p\n",	\
+		DMSG("#Stack canaries for %s[%zu] with top at %p",	\
 			#name, n, (void *)(end_canary - 1));		\
-		DMSG("watch *%p\n", (void *)end_canary);		\
+		DMSG("watch *%p", (void *)end_canary);			\
 	}
 
 	INIT_CANARY(stack_tmp);

--- a/core/arch/arm/kernel/unwind_arm32.c
+++ b/core/arch/arm/kernel/unwind_arm32.c
@@ -309,7 +309,7 @@ static bool unwind_exec_insn(struct unwind_state_arm32 *state,
 
 	} else {
 		/* We hit a new instruction that needs to be implemented */
-		DMSG("Unhandled instruction %.2x\n", insn);
+		DMSG("Unhandled instruction %.2x", insn);
 		return false;
 	}
 
@@ -344,7 +344,7 @@ static bool unwind_tab(struct unwind_state_arm32 *state, bool kernel_stack,
 		state->byte = 1;
 		state->entries = ((insn >> 16) & 0xFF) + 1;
 	} else {
-		DMSG("Unknown entry: %x\n", entry);
+		DMSG("Unknown entry: %x", entry);
 		return true;
 	}
 

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -312,7 +312,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	serr = TEE_ORIGIN_TRUSTED_APP;
 
 	if (utc->ctx.panicked) {
-		DMSG("tee_user_ta_enter: TA panicked with code 0x%x\n",
+		DMSG("tee_user_ta_enter: TA panicked with code 0x%x",
 		     utc->ctx.panic_code);
 		serr = TEE_ORIGIN_TEE;
 		res = TEE_ERROR_TARGET_DEAD;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -804,7 +804,8 @@ bool core_mmu_entry_to_finer_grained(struct core_mmu_table_info *tbl_info,
 
 	new_table = prtn->xlat_tables[prtn->xlat_tables_used++];
 
-	DMSG("xlat tables used %d / %d\n", prtn->xlat_tables_used, MAX_XLAT_TABLES);
+	DMSG("xlat tables used %d / %d",
+	     prtn->xlat_tables_used, MAX_XLAT_TABLES);
 
 	if (*entry) {
 		pa = *entry & OUTPUT_ADDRESS_MASK;

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -529,7 +529,7 @@ void __weak tee_entry_std(struct thread_smc_args *smc_args)
 
 	if (smc_args->a0 != OPTEE_SMC_CALL_WITH_ARG) {
 		EMSG("Unknown SMC 0x%" PRIx64, (uint64_t)smc_args->a0);
-		DMSG("Expected 0x%x\n", OPTEE_SMC_CALL_WITH_ARG);
+		DMSG("Expected 0x%x", OPTEE_SMC_CALL_WITH_ARG);
 		smc_args->a0 = OPTEE_SMC_RETURN_EBADCMD;
 		return;
 	}
@@ -580,7 +580,7 @@ void __weak tee_entry_std(struct thread_smc_args *smc_args)
 		break;
 
 	default:
-		EMSG("Unknown cmd 0x%x\n", arg->cmd);
+		EMSG("Unknown cmd 0x%x", arg->cmd);
 		smc_args->a0 = OPTEE_SMC_RETURN_EBADCMD;
 	}
 	mobj_free(mobj);

--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -223,21 +223,21 @@ void tzc_dump_state(void)
 	uint32_t temp_32reg, temp_32reg_h;
 
 	DMSG("enter");
-	DMSG("security_inversion_en %x\n",
+	DMSG("security_inversion_en %x",
 	     io_read32(tzc.base + SECURITY_INV_EN_OFF));
 	for (n = 0; n <= REGION_MAX; n++) {
 		temp_32reg = tzc_read_region_attributes(tzc.base, n);
 		if (!(temp_32reg & TZC_ATTR_REGION_EN_MASK))
 			continue;
 
-		DMSG("\n");
+		DMSG("");
 		DMSG("region %d", n);
 		temp_32reg = tzc_read_region_base_low(tzc.base, n);
 		temp_32reg_h = tzc_read_region_base_high(tzc.base, n);
 		DMSG("region_base: 0x%08x%08x", temp_32reg_h, temp_32reg);
 		temp_32reg = tzc_read_region_attributes(tzc.base, n);
 		DMSG("region sp: %x", temp_32reg >> TZC_ATTR_SP_SHIFT);
-		DMSG("region size: %x\n", (temp_32reg & TZC_REGION_SIZE_MASK) >>
+		DMSG("region size: %x", (temp_32reg & TZC_REGION_SIZE_MASK) >>
 				TZC_REGION_SIZE_SHIFT);
 	}
 	DMSG("exit");

--- a/core/drivers/tzc400.c
+++ b/core/drivers/tzc400.c
@@ -194,7 +194,7 @@ void tzc_init(vaddr_t base)
 	 */
 	tzc_id = tzc_read_component_id(tzc.base);
 	if (tzc_id != TZC400_COMPONENT_ID) {
-		EMSG("TZC : Wrong device ID (0x%x).\n", tzc_id);
+		EMSG("TZC : Wrong device ID (0x%" PRIx32 ")", tzc_id);
 		panic();
 	}
 
@@ -317,8 +317,8 @@ void tzc_enable_filters(void)
 			 * http://infocenter.arm.com/help/index.jsp?\
 			 * topic=/com.arm.doc.ddi0504c/CJHHECBF.html
 			 */
-			EMSG("TZC : Filter %d Gatekeeper already enabled.\n",
-				filter);
+			EMSG("TZC : Filter %d Gatekeeper already enabled",
+			     filter);
 			panic();
 		}
 		tzc_set_gate_keeper(tzc.base, filter, 1);

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -622,7 +622,7 @@ TEE_Result tee_ta_invoke_command(TEE_ErrorOrigin *err,
 
 	/* Short buffer is not an effective error case */
 	if (res != TEE_SUCCESS && res != TEE_ERROR_SHORT_BUFFER)
-		DMSG("Error: %x of %d\n", res, *err);
+		DMSG("Error: %x of %d", res, *err);
 
 	return res;
 }

--- a/core/lib/libtomcrypt/src/tee_ltc_provider.c
+++ b/core/lib/libtomcrypt/src/tee_ltc_provider.c
@@ -567,14 +567,14 @@ static TEE_Result rsadorep(rsa_key *ltc_key, const uint8_t *src,
 	case CRYPT_PK_INVALID_TYPE:
 	case CRYPT_PK_INVALID_SIZE:
 	case CRYPT_INVALID_PACKET:
-		EMSG("rsa_exptmod() returned %d\n", ltc_res);
+		EMSG("rsa_exptmod() returned %d", ltc_res);
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	case CRYPT_OK:
 		break;
 	default:
 		/* This will result in a panic */
-		EMSG("rsa_exptmod() returned %d\n", ltc_res);
+		EMSG("rsa_exptmod() returned %d", ltc_res);
 		res = TEE_ERROR_GENERIC;
 		goto out;
 	}
@@ -666,7 +666,7 @@ TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
 	/* Get the algorithm */
 	res = tee_algo_to_ltc_hashindex(algo, &ltc_hashindex);
 	if (res != TEE_SUCCESS) {
-		EMSG("tee_algo_to_ltc_hashindex() returned %d\n", (int)res);
+		EMSG("tee_algo_to_ltc_hashindex() returned %d", (int)res);
 		goto out;
 	}
 
@@ -699,20 +699,20 @@ TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
 	case CRYPT_PK_INVALID_PADDING:
 	case CRYPT_INVALID_PACKET:
 	case CRYPT_PK_INVALID_SIZE:
-		EMSG("rsa_decrypt_key_ex() returned %d\n", ltc_res);
+		EMSG("rsa_decrypt_key_ex() returned %d", ltc_res);
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	case CRYPT_OK:
 		break;
 	default:
 		/* This will result in a panic */
-		EMSG("rsa_decrypt_key_ex() returned %d\n", ltc_res);
+		EMSG("rsa_decrypt_key_ex() returned %d", ltc_res);
 		res = TEE_ERROR_GENERIC;
 		goto out;
 	}
 	if (ltc_stat != 1) {
 		/* This will result in a panic */
-		EMSG("rsa_decrypt_key_ex() returned %d and %d\n",
+		EMSG("rsa_decrypt_key_ex() returned %d and %d",
 		     ltc_res, ltc_stat);
 		res = TEE_ERROR_GENERIC;
 		goto out;
@@ -776,7 +776,7 @@ TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
 	case CRYPT_PK_INVALID_PADDING:
 	case CRYPT_INVALID_PACKET:
 	case CRYPT_PK_INVALID_SIZE:
-		EMSG("rsa_encrypt_key_ex() returned %d\n", ltc_res);
+		EMSG("rsa_encrypt_key_ex() returned %d", ltc_res);
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	case CRYPT_OK:

--- a/core/tee/tee_obj.c
+++ b/core/tee/tee_obj.c
@@ -64,7 +64,7 @@ TEE_Result tee_obj_verify(struct tee_ta_session *sess, struct tee_obj *o)
 
 	res = fops->open(o->pobj, NULL, &fh);
 	if (res == TEE_ERROR_CORRUPT_OBJECT) {
-		EMSG("Object corrupt\n");
+		EMSG("Object corrupt");
 		fops->remove(o->pobj);
 		tee_obj_close(to_user_ta_ctx(sess->ctx), o);
 	}

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1011,7 +1011,7 @@ static TEE_Result tee_rpmb_verify_key_sync_counter(uint16_t dev_id)
 		rpmb_ctx->wr_cnt_synced = true;
 	}
 
-	DMSG("Verify key returning 0x%x\n", res);
+	DMSG("Verify key returning 0x%x", res);
 	return res;
 }
 

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -192,7 +192,7 @@ static TEE_Result tee_svc_storage_read_head(struct tee_obj *o)
 	res = fops->read(o->fh, 0, &head, &bytes);
 	if (res != TEE_SUCCESS) {
 		if (res == TEE_ERROR_CORRUPT_OBJECT)
-			EMSG("Head corrupt\n");
+			EMSG("Head corrupt");
 		goto exit;
 	}
 
@@ -830,9 +830,8 @@ TEE_Result syscall_storage_obj_read(unsigned long obj, void *data, size_t len,
 	res = o->pobj->fops->read(o->fh, o->ds_pos + o->info.dataPosition,
 				  data, &bytes);
 	if (res != TEE_SUCCESS) {
-		EMSG("Error code=%x\n", (uint32_t)res);
 		if (res == TEE_ERROR_CORRUPT_OBJECT) {
-			EMSG("Object corrupt\n");
+			EMSG("Object corrupt");
 			tee_svc_storage_remove_corrupt_obj(sess, o);
 		}
 		goto exit;
@@ -928,7 +927,7 @@ TEE_Result syscall_storage_obj_trunc(unsigned long obj, size_t len)
 	res = o->pobj->fops->truncate(o->fh, len + off);
 	if (res != TEE_SUCCESS) {
 		if (res == TEE_ERROR_CORRUPT_OBJECT) {
-			EMSG("Object corrupt\n");
+			EMSG("Object corrupt");
 			res = tee_svc_storage_remove_corrupt_obj(sess, o);
 			if (res != TEE_SUCCESS)
 				goto exit;


### PR DESCRIPTION
Change trace message indicating absence of external DTB
from error level to debug level. Implementation and comment
clearly state the configuration is fully legitimate.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
