### PR TITLE
core: add inline description of TEE session field user_ctx

### DIFF
--- a/core/arch/arm/kernel/pseudo_ta.c
+++ b/core/arch/arm/kernel/pseudo_ta.c
@@ -36,7 +36,7 @@ static bool validate_in_param(struct tee_ta_session *s, struct mobj *mobj)
 	if (client_is_secure(s))
 		return true;
 
-	/* all non-secure memory references are hanlded by pTAs */
+	/* all non-secure memory references are hanlded by PTAs */
 	if (mobj_is_nonsec(mobj))
 		return true;
 
@@ -261,7 +261,7 @@ static TEE_Result verify_pseudo_tas_conformance(void)
 	return TEE_SUCCESS;
 err:
 	DMSG("pseudo TA error at %p", (void *)pta);
-	panic("pta");
+	panic("PTA");
 }
 
 service_init(verify_pseudo_tas_conformance);

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -92,9 +92,9 @@ struct tee_ta_session {
 	TAILQ_ENTRY(tee_ta_session) link_tsd;
 	struct tee_ta_ctx *ctx;	/* TA context */
 	TEE_Identity clnt_id;	/* Identify of client */
-	bool cancel;		/* True if TAF is cancelled */
+	bool cancel;		/* True if TA invocation is cancelled */
 	bool cancel_mask;	/* True if cancel is masked */
-	TEE_Time cancel_time;	/* Time when to cancel the TAF */
+	TEE_Time cancel_time;	/* Time when to cancel the TA invocation */
 	void *user_ctx;		/* Opaque session handle assigned by PTA */
 	uint32_t ref_count;	/* reference counter */
 	struct condvar refc_cv;	/* CV used to wait for ref_count to be 0 */

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -95,7 +95,7 @@ struct tee_ta_session {
 	bool cancel;		/* True if TAF is cancelled */
 	bool cancel_mask;	/* True if cancel is masked */
 	TEE_Time cancel_time;	/* Time when to cancel the TAF */
-	void *user_ctx;		/* Opaque session handle assigned by pTA */
+	void *user_ctx;		/* Opaque session handle assigned by PTA */
 	uint32_t ref_count;	/* reference counter */
 	struct condvar refc_cv;	/* CV used to wait for ref_count to be 0 */
 	struct condvar lock_cv;	/* CV used to wait for lock */

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -95,7 +95,7 @@ struct tee_ta_session {
 	bool cancel;		/* True if TAF is cancelled */
 	bool cancel_mask;	/* True if cancel is masked */
 	TEE_Time cancel_time;	/* Time when to cancel the TAF */
-	void *user_ctx;		/* ??? */
+	void *user_ctx;		/* Opaque session handle assigned by pTA */
 	uint32_t ref_count;	/* reference counter */
 	struct condvar refc_cv;	/* CV used to wait for ref_count to be 0 */
 	struct condvar lock_cv;	/* CV used to wait for lock */

--- a/lib/libutee/include/pta_invoke_tests.h
+++ b/lib/libutee/include/pta_invoke_tests.h
@@ -25,7 +25,7 @@
 #define PTA_INVOKE_TESTS_CMD_SELF_TESTS		2
 
 /*
- * Secure data path: check that pTA can copy data from non-secure shared memory
+ * Secure data path: check that PTA can copy data from non-secure shared memory
  * to SDP secure memory
  *
  * [in]     memref[0]        source (non-secure shared memory)
@@ -34,7 +34,7 @@
 #define PTA_INVOKE_TESTS_CMD_COPY_NSEC_TO_SEC	3
 
 /*
- * Secure data path: check that pTA can read data from SDP secure memory and
+ * Secure data path: check that PTA can read data from SDP secure memory and
  * write it back. Data are processed so that client check the expected
  * read/write sequence succeed.
  *
@@ -43,7 +43,7 @@
 #define PTA_INVOKE_TESTS_CMD_READ_MODIFY_SEC	4
 
 /*
- * Secure data path: check that pTA can copy data from SDP secure memory to
+ * Secure data path: check that PTA can copy data from SDP secure memory to
  * non-secure shared memory
  *
  * [in]     memref[0]        source (SDP secure memory)


### PR DESCRIPTION
Replace inline comment ??? with an appropriate description of
the user_ctx field which points the the caller user TA context
in case a pseudo TA is invoked from the user TA client.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
