### PR TITLE
python scripts: use host python explicitly for android builds

### DIFF
--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2015, Linaro Limited

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # Copyright (c) 2015, 2017, Linaro Limited
 #


### PR DESCRIPTION
This is the workaround for the aosp master change[1],
which makes android build system to use the AOSP prebuilt python
binarys with its libraries. But the prebuilt python libraries
do not have the Crypto module yet, which is required by the
optee_os python scripts.

So this is just a workaround to make the scripts that use Crypto library
to use the host side python script.
Some other workarounds could be considered as well, like:
1. Update the AOSP master prebuilt python to include Crypto module
   might be not easy to persuade upstream to accept
2. Copy the Crypto python files to optee_os repository
   and make the scripts to call from there directly
   This will make optee_os not depend on host side Crypto implementation.
3. Change to use python3 which is still not limitted by AOSP master yet.
   but would get the problem again in the future.

No.2 seems to be a better one, not sure if there is any similar cases
for third party libraries in optee_os already.

[1]: https://android.googlesource.com/platform/build/soong/+/ac0f5d3643029e8af537c551a0957199c166d6ee

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
