### PR TITLE
core: user_ta: load_elf(): return meaningful error code

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -869,7 +869,7 @@ out:
 /* Loads a single ELF file (main executable or library) */
 static TEE_Result load_elf(const TEE_UUID *uuid, struct user_ta_ctx *utc)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_ITEM_NOT_FOUND;
 	const struct user_ta_store_ops *op = NULL;
 
 	SCATTERED_ARRAY_FOREACH(op, ta_stores, struct user_ta_store_ops) {
@@ -877,13 +877,10 @@ static TEE_Result load_elf(const TEE_UUID *uuid, struct user_ta_ctx *utc)
 		     op->description);
 
 		res = load_elf_from_store(uuid, op, utc);
-		if (res == TEE_ERROR_ITEM_NOT_FOUND)
+		DMSG("res=0x%x", res);
+		if (res == TEE_ERROR_ITEM_NOT_FOUND ||
+		    res == TEE_ERROR_STORAGE_NOT_AVAILABLE)
 			continue;
-		if (res) {
-			DMSG("res=0x%x", res);
-			continue;
-		}
-
 		return res;
 	}
 


### PR DESCRIPTION
If any error is encountered when the TEE core attempts to load a TA from
TA storage, the next storage is tried and so on until the TA is
successfully loaded or there is no more storage to try. In this case, a
generic error code (TEE_ERROR_ITEM_NOT_FOUND) is returned to the caller
of load_elf() and ultimately to the client. This is not super useful,
especially when debug traces are disabled, because the user has no way
to differentiate a true "not found" situation (which might be a
configuration or deployement issue) from an issue with the TA file
itself or an out-of-memory condition etc.

This commit changes the return code of load_elf() to better reflect the
errors. Here are some examples (assuming we have two TA stores: 1 and 2,
1 is tried first):

 Partial results                 Final result

 TA store 1: NOT_FOUND
 TA store 2: SUCCESS         => SUCCESS

 TA store 1: SUCCESS         => SUCCESS

 TA store 1: OUT_OF_MEMORY
 TA store 2: NOT_FOUND       => OUT_OF_MEMORY

 TA store 1: OUT_OF_MEMORY
 TA store 2: SUCCESS         => SUCCESS

 TA store 1: NOT_FOUND
 TA store 2: NOT_FOUND       => NOT_FOUND

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
