### PR TITLE
RFC: libutils libutee etc. as shared libraries

### DIFF
--- a/core/arch/arm/kernel/elf_load.c
+++ b/core/arch/arm/kernel/elf_load.c
@@ -403,8 +403,14 @@ static TEE_Result e32_process_rel(struct elf_load_state *state, size_t rel_sidx,
 			sym_idx = ELF32_R_SYM(rel->r_info);
 			if (sym_idx >= num_syms)
 				return TEE_ERROR_BAD_FORMAT;
-
-			*where += vabase + sym_tab[sym_idx].st_value;
+			if (sym_tab[sym_idx].st_shndx == SHN_UNDEF) {
+				/* Symbol is external */
+				res = e32_process_dyn_rel(state, rel, where);
+				if (res)
+					return res;
+			} else {
+				*where += vabase + sym_tab[sym_idx].st_value;
+			}
 			break;
 		case R_ARM_REL32:
 			sym_idx = ELF32_R_SYM(rel->r_info);
@@ -503,8 +509,15 @@ static TEE_Result e64_process_rel(struct elf_load_state *state,
 			sym_idx = ELF64_R_SYM(rela->r_info);
 			if (sym_idx > num_syms)
 				return TEE_ERROR_BAD_FORMAT;
-			*where = rela->r_addend + sym_tab[sym_idx].st_value +
-				 vabase;
+			if (sym_tab[sym_idx].st_shndx == SHN_UNDEF) {
+				/* Symbol is external */
+				res = e64_process_dyn_rela(state, rela, where);
+				if (res)
+					return res;
+			} else {
+				*where = rela->r_addend +
+					sym_tab[sym_idx].st_value + vabase;
+			}
 			break;
 		case R_AARCH64_RELATIVE:
 			*where = rela->r_addend + vabase;

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -425,8 +425,8 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 
 		mattr_perm_to_str(flags, sizeof(flags), r->attr);
 		describe_region(utc, r->va, r->size, desc, sizeof(desc));
-		EMSG_RAW(" region %zu: va %#" PRIxVA " pa %#" PRIxPA
-			 " size %#zx flags %s %s",
+		EMSG_RAW(" region %2zu: va %#" PRIxVA " pa %#" PRIxPA
+			 " size 0x%06zx flags %s %s",
 			 n, r->va, pa, r->size, flags, desc);
 		n++;
 	}

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -346,6 +346,16 @@ $(error Cannot instrument user libraries if user mode profiling is disabled)
 endif
 endif
 
+# Build libutee, libutils, libmpa/libmbedtls as shared libraries.
+# - Static libraries are still generated when this is enabled, but TAs will use
+# the shared libraries unless explicitly linked with the -static flag.
+# - Shared libraries are made of two files: for example, libutee is
+#   libutee.so and 527f1a47-b92c-4a74-95bd-72f19f4a6f74.ta. The '.so' file
+#   is a totally standard shared object, and should be used to link against.
+#   The '.ta' file is a signed version of the '.so' and should be installed
+#   in the same way as TAs so that they can be found at runtime.
+CFG_ULIBS_SHARED ?= n
+
 # CFG_GP_SOCKETS
 # Enable Global Platform Sockets support
 CFG_GP_SOCKETS ?= y

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -1,9 +1,15 @@
 # Input
 #
-# libname	tells the name of the lib and
-# libdir	tells directory of lib which also is used as input to
+# libname	the name of the lib
+# libdir	directory of lib which also is used as input to
 #		mk/subdir.mk
 # conf-file     [optional] if set, all objects will depend on $(conf-file)
+# [if CFG_ULIBS_SHARED==y]
+#   libuuid	the UUID of the shared lib
+#   libl	other libraries this library depends on; used to generate the
+#               proper link arguments (-Lxxx -lyyy) and to add dependencies
+#               on the needed .so files
+# [endif]
 #
 # Output
 #
@@ -20,12 +26,25 @@ endif
 endif
 include mk/compile.mk
 
-lib-libfile	 = $(out-dir)/$(base-prefix)$(libdir)/lib$(libname).a
-cleanfiles	:= $(cleanfiles) $(lib-libfile)
-libfiles	:= $(lib-libfile) $(libfiles)
+lib-libfile	:= $(out-dir)/$(base-prefix)$(libdir)/lib$(libname).a
+ifeq ($(CFG_ULIBS_SHARED),y)
+lib-shlibfile	:= $(out-dir)/$(base-prefix)$(libdir)/lib$(libname).so
+lib-shlibstrippedfile := $(out-dir)/$(base-prefix)$(libdir)/lib$(libname).stripped.so
+lib-shlibtafile	:= $(out-dir)/$(base-prefix)$(libdir)/$(libuuid).ta
+lib-libuuidln	:= $(out-dir)/$(base-prefix)$(libdir)/$(libuuid).elf
+lib-shlibfile-$(libname)-$(sm) := $(lib-shlibfile)
+lib-libdir-$(libname)-$(sm) := $(out-dir)/$(base-prefix)$(libdir)
+lib-needed-so-files := $(foreach l,$(libl),$(lib-shlibfile-$(l)-$(sm)))
+lib-Ll-args := $(foreach l,$(libl),-L$(lib-libdir-$(l)-$(sm)) -l$(l))
+endif
+cleanfiles	:= $(lib-libfile) $(lib-shlibfile) $(lib-shlibstrippedfile) $(lib-shlibtafile) $(lib-libuuidln) $(cleanfiles)
+libfiles	:= $(lib-libfile) $(lib-shlibfile) $(lib-shlibstrippedfile) $(lib-shlibtafile) $(lib-libuuidln) $(libfiles)
 libdirs 	:= $(out-dir)/$(base-prefix)$(libdir) $(libdirs)
 libnames	:= $(libname) $(libnames)
 libdeps		:= $(lib-libfile) $(libdeps)
+
+SIGN = scripts/sign.py
+TA_SIGN_KEY ?= keys/default_ta.pem
 
 define process-lib
 ifeq ($(lib-use-ld), y)
@@ -39,6 +58,26 @@ $(lib-libfile): $(objs)
 	@mkdir -p $$(dir $$@)
 	$$(q)rm -f $$@ && $$(AR$(sm)) rcs $$@ $$^
 endif
+ifeq ($(CFG_ULIBS_SHARED),y)
+$(lib-shlibfile): $(objs) $(lib-needed-so-files)
+	@$(cmd-echo-silent) '  LD      $$@'
+	@mkdir -p $$(dir $$@)
+	$$(q)$$(LD$(sm)) $(lib-ldflags) $(lib-Ll-args) -shared \
+		--soname=$(libuuid) -o $$@ $$^
+
+$(lib-shlibstrippedfile): $(lib-shlibfile)
+	@$(cmd-echo-silent) '  OBJCOPY $$@'
+	$$(q)$$(OBJCOPY$(sm)) --strip-unneeded $$< $$@
+
+$(lib-shlibtafile): $(lib-shlibstrippedfile) $(TA_SIGN_KEY)
+	@$(cmd-echo-silent) '  SIGN    $$@'
+	$$(q)$$(SIGN) --key $(TA_SIGN_KEY) --uuid $(libuuid) --version 0 \
+		--in $$< --out $$@
+
+$(lib-libuuidln): $(lib-shlibfile)
+	@$(cmd-echo-silent) '  LN      $$@'
+	$$(q)ln -sf lib$(libname).so $$@
+endif
 endef #process-lib
 
 $(eval $(call process-lib))
@@ -48,4 +87,11 @@ $(objs): $(conf-file)
 # Clean residues from processing
 objs		:=
 libname		:=
+libuuid		:=
 lib-use-ld	:=
+lib-shlibfile	:=
+lib-shlibstrippedfile :=
+lib-shlibtafile	:=
+lib-libuuidln	:=
+lib-needed-so-files :=
+libl :=

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -21,6 +21,7 @@ link-ldflags += -Map=$(link-out-dir$(sm))/$(user-ta-uuid).map
 link-ldflags += --sort-section=alignment
 link-ldflags += -z max-page-size=4096 # OP-TEE always uses 4K alignment
 link-ldflags += --as-needed # Do not add dependency on unused shlib
+link-ldflags += $(link-ldflags$(sm))
 
 link-ldadd  = $(user-ta-ldadd) $(addprefix -L,$(libdirs))
 link-ldadd += --start-group $(addprefix -l,$(libnames)) --end-group

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -20,6 +20,7 @@ link-ldflags += -T $(link-script-pp$(sm))
 link-ldflags += -Map=$(link-out-dir$(sm))/$(user-ta-uuid).map
 link-ldflags += --sort-section=alignment
 link-ldflags += -z max-page-size=4096 # OP-TEE always uses 4K alignment
+link-ldflags += --as-needed # Do not add dependency on unused shlib
 
 link-ldadd  = $(user-ta-ldadd) $(addprefix -L,$(libdirs))
 link-ldadd += --start-group $(addprefix -l,$(libnames)) --end-group

--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -24,6 +24,11 @@ cppflags$(sm)	:= $(cppflags$(ta-target)) -I$(ta-dev-kit-dir$(sm))/include
 cflags$(sm)	:= $(cflags$(ta-target))
 aflags$(sm)	:= $(aflags$(ta-target))
 
+ifeq ($(CFG_ULIBS_SHARED),y)
+# For now, do not link in-tree TAs against shared libraries
+link-ldflags$(sm) := -static
+endif
+
 libdirs  = $(ta-dev-kit-dir$(sm))/lib
 libnames = utils utee
 ifneq ($(CFG_TA_MBEDTLS_MPI),y)

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -48,27 +48,36 @@ base-prefix := $(sm)-
 
 libname = utils
 libdir = lib/libutils
+libuuid = 71855bba-6055-4293-a63f-b0963a737360
 include mk/lib.mk
 
 CFG_TA_MBEDTLS_MPI ?= y
 ifeq ($(CFG_TA_MBEDTLS_MPI),y)
+mplib-for-utee = mbedtls
 $(call force,CFG_TA_MBEDTLS,y)
 else
+mplib-for-utee = mpa
 libname = mpa
 libdir = lib/libmpa
+libuuid = 39b498d9-1e1f-4ae0-a9e1-6d1caf8ec731
+libl = utils
 include mk/lib.mk
 endif
-
-libname = utee
-libdir = lib/libutee
-include mk/lib.mk
 
 ifeq ($(CFG_TA_MBEDTLS),y)
 libname = mbedtls
 libdir = lib/libmbedtls
+libuuid = 87bb6ae8-4b1d-49fe-9986-2b966132c309
+libl = utils
 include mk/lib.mk
 ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS
 endif
+
+libname = utee
+libdir = lib/libutee
+libuuid = 527f1a47-b92c-4a74-95bd-72f19f4a6f74
+libl = $(mplib-for-utee) utils
+include mk/lib.mk
 
 base-prefix :=
 
@@ -92,7 +101,7 @@ $2/$$(notdir $1): $1
 	@set -e; \
 	mkdir -p $$(dir $$@) ; \
 	$(cmd-echo-silent) '  INSTALL $$@' ; \
-	cp $$< $$@
+	cp -P $$< $$@
 
 cleanfiles += $2/$$(notdir $1)
 ta_dev_kit: $2/$$(notdir $1)


### PR DESCRIPTION
This RFC introduces a config flag to build user-mode libraries (libutee, libutils etc.) as shared objects.
I wrote this patch set when I was implementing the dynamic link support in the ELF loader, because it was quite convenient to test the feature. But, without the ability to share code and RO data between TAs, it was quite useless in practice.

Now that @jenswi-linaro has proposed #2801 "Shared read-only pages between TAs", things are different and thus I'm pushing this as an RFC. With both features combined we can probably save significant amounts of memory and load many more TAs simultaneously. 

FYI, here is the output of `xtest 1019` (calling `TEE_Panic()` in a library) filtered through `symbolize.py`, with all libraries built as shared objects. Pretty cool, no? ;-)

```
E/TC:? 0 TA panicked with code 0x0
E/TC:? 0 Status of TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b (0xe171b10) (active)
E/TC:? 0  arch: arm  load address: 0x105000 ctx-idr: 2
E/TC:? 0  stack: 0x102000 10240
E/TC:? 0  region 0: va 0x100000 pa 0xe100000 size 0x1000 flags ---R-X
E/TC:? 0  region 1: va 0x102000 pa 0xe3f0000 size 0x3000 flags rw-RW-
E/TC:? 0  region 2: va 0x105000 pa 0xe308000 size 0x6000 flags r-x--- [0] .ta_head .text .plt .rodata .ARM.extab .ARM.exidx .got .dynsym .rel.plt .dynamic .dynstr .hash .rel.dyn
E/TC:? 0  region 3: va 0x10b000 pa 0xe30e000 size 0xe2000 flags rw---- [0] .data .bss
E/TC:? 0  region 4: va 0x1ed000 pa 0xe3f3000 size 0x1000 flags r-x--- [1] .hash .dynsym .dynstr .rel.plt .plt .text .ARM.extab .ARM.exidx
E/TC:? 0  region 5: va 0x1fd000 pa 0xe403000 size 0x1000 flags rw---- [1] .dynamic .got
E/TC:? 0  region 6: va 0x1fe000 pa 0xe482000 size 0xe000 flags r-x--- [2] .hash .dynsym .dynstr .rel.dyn .rel.plt .plt .text .rodata .ARM.extab .ARM.exidx
E/TC:? 0  region 7: va 0x21b000 pa 0xe49f000 size 0x1000 flags rw---- [2] .dynamic .got .data .bss
E/TC:? 0  region 8: va 0x21c000 pa 0xe43f000 size 0xd000 flags r-x--- [3] .hash .dynsym .dynstr .rel.dyn .rel.plt .plt .text .rodata .ARM.extab .ARM.exidx
E/TC:? 0  region 9: va 0x239000 pa 0xe45c000 size 0x3000 flags rw---- [3] .data.rel.ro .dynamic .got .data .bss
E/TC:? 0  region 10: va 0x23c000 pa 0xe54f000 size 0x38000 flags r-x--- [4] .hash .dynsym .dynstr .rel.dyn .rel.plt .plt .text .rodata .ARM.extab .ARM.exidx
E/TC:? 0  region 11: va 0x283000 pa 0xe596000 size 0x4000 flags rw---- [4] .data.rel.ro .dynamic .got .data .bss
E/TC:? 0  region 12: va 0x287000 pa 0xe300000 size 0x3000 flags r-----
E/TC:? 0  [0] 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b @ 0x105000 (optee_test/out/ta/os_test/5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf)
E/TC:? 0  [1] ffd2bded-ab7d-4988-95ee-e4962fff7154 @ 0x1ed000 (optee_test/out/ta/os_test_lib/libos_test.so)
E/TC:? 0  [2] 71855bba-6055-4293-a63f-b0963a737360 @ 0x1fe000 (optee_os/out/arm/ta_arm32-lib/libutils/libutils.so)
E/TC:? 0  [3] 527f1a47-b92c-4a74-95bd-72f19f4a6f74 @ 0x21c000 (optee_os/out/arm/ta_arm32-lib/libutee/libutee.so)
E/TC:? 0  [4] 87bb6ae8-4b1d-49fe-9986-2b966132c309 @ 0x23c000 (optee_os/out/arm/ta_arm32-lib/libmbedtls/libmbedtls.so)
E/TC:? 0 Call stack:
E/TC:? 0  0x00227760 utee_panic at optee_os/lib/libutee/arch/arm/utee_syscalls_a32.S:52
E/TC:? 0  0x00225105 TEE_Panic at optee_os/lib/libutee/tee_api_panic.c:13
E/TC:? 0  0x001ed317 os_test_shlib_panic at optee_test/ta/os_test_lib/os_test_lib.c:17
E/TC:? 0  0x00107c8b ta_entry_call_lib_panic at optee_test/ta/os_test/os_test.c:1089
E/TC:? 0  0x00107df1 TA_InvokeCommandEntryPoint at optee_test/ta/os_test/ta_entry.c:116
E/TC:? 0  0x002276bf entry_invoke_command at optee_os/lib/libutee/arch/arm/user_ta_entry.c:191
E/TC:? 0  0x0022771b __utee_entry at optee_os/lib/libutee/arch/arm/user_ta_entry.c:219
```