### PR TITLE
[RFC] change PTA API regarding client indentification (and add embedded tests)

### DIFF
--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -33,9 +33,9 @@ struct pseudo_ta_head {
 	void (*destroy_entry_point)(void);
 	TEE_Result (*open_session_entry_point)(uint32_t nParamTypes,
 			TEE_Param pParams[TEE_NUM_PARAMS],
-			void **ppSessionContext);
-	void (*close_session_entry_point)(void *pSessionContext);
-	TEE_Result (*invoke_command_entry_point)(void *pSessionContext,
+			uint32_t session_id);
+	void (*close_session_entry_point)(uint32_t session_id);
+	TEE_Result (*invoke_command_entry_point)(uint32_t session_id,
 			uint32_t nCommandID, uint32_t nParamTypes,
 			TEE_Param pParams[TEE_NUM_PARAMS]);
 };

--- a/core/arch/arm/kernel/pseudo_ta.c
+++ b/core/arch/arm/kernel/pseudo_ta.c
@@ -163,8 +163,9 @@ static TEE_Result pseudo_ta_enter_open_session(struct tee_ta_session *s,
 		}
 
 		res = stc->pseudo_ta->open_session_entry_point(param->types,
-								tee_param,
-								&s->user_ctx);
+							       tee_param,
+							       s->id);
+
 		update_out_param(tee_param, param);
 		unmap_mapped_param(param, did_map);
 	}
@@ -192,7 +193,7 @@ static TEE_Result pseudo_ta_enter_invoke_cmd(struct tee_ta_session *s,
 	}
 
 	*eo = TEE_ORIGIN_TRUSTED_APP;
-	res = stc->pseudo_ta->invoke_command_entry_point(s->user_ctx, cmd,
+	res = stc->pseudo_ta->invoke_command_entry_point(s->id, cmd,
 							 param->types,
 							 tee_param);
 	update_out_param(tee_param, param);
@@ -209,7 +210,7 @@ static void pseudo_ta_enter_close_session(struct tee_ta_session *s)
 	tee_ta_push_current_session(s);
 
 	if (stc->pseudo_ta->close_session_entry_point)
-		stc->pseudo_ta->close_session_entry_point(s->user_ctx);
+		stc->pseudo_ta->close_session_entry_point(s->id);
 
 	if ((s->ctx->ref_count == 1) && stc->pseudo_ta->destroy_entry_point)
 		stc->pseudo_ta->destroy_entry_point();

--- a/core/arch/arm/plat-synquacer/rng_pta.c
+++ b/core/arch/arm/plat-synquacer/rng_pta.c
@@ -334,7 +334,7 @@ static TEE_Result rng_get_info(uint32_t types,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result invoke_command(void *pSessionContext __unused,
+static TEE_Result invoke_command(uint32_t session_id __unused,
 				 uint32_t nCommandID, uint32_t nParamTypes,
 				 TEE_Param pParams[TEE_NUM_PARAMS])
 {

--- a/core/arch/arm/pta/benchmark.c
+++ b/core/arch/arm/pta/benchmark.c
@@ -159,7 +159,7 @@ static TEE_Result unregister_benchmark(uint32_t type,
 	return res;
 }
 
-static TEE_Result invoke_command(void *session_ctx __unused,
+static TEE_Result invoke_command(uint32_t session_id __unused,
 		uint32_t cmd_id, uint32_t param_types,
 		TEE_Param params[TEE_NUM_PARAMS])
 {

--- a/core/arch/arm/pta/core_self_tests.c
+++ b/core/arch/arm/pta/core_self_tests.c
@@ -466,8 +466,8 @@ static int self_test_nex_malloc(void)
 }
 #endif
 /* exported entry points for some basic test */
-TEE_Result core_self_tests(uint32_t nParamTypes __unused,
-		TEE_Param pParams[TEE_NUM_PARAMS] __unused)
+TEE_Result core_self_tests(uint32_t param_types __unused,
+			   TEE_Param params[TEE_NUM_PARAMS] __unused)
 {
 	if (self_test_mul_signed_overflow() || self_test_add_overflow() ||
 	    self_test_sub_overflow() || self_test_mul_unsigned_overflow() ||

--- a/core/arch/arm/pta/device.c
+++ b/core/arch/arm/pta/device.c
@@ -58,13 +58,14 @@ static TEE_Result get_devices(uint32_t types,
 	return res;
 }
 
-static TEE_Result invoke_command(void *pSessionContext __unused,
-				 uint32_t nCommandID, uint32_t nParamTypes,
-				 TEE_Param pParams[TEE_NUM_PARAMS])
+static TEE_Result invoke_command(uint32_t session_id __unused,
+				 uint32_t command_id,
+				 uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
 {
-	switch (nCommandID) {
+	switch (command_id) {
 	case PTA_CMD_GET_DEVICES:
-		return get_devices(nParamTypes, pParams);
+		return get_devices(param_types, params);
 	default:
 		break;
 	}

--- a/core/arch/arm/pta/gprof.c
+++ b/core/arch/arm/pta/gprof.c
@@ -145,7 +145,7 @@ static TEE_Result gprof_stop_pc_sampling(struct tee_ta_session *s,
 
 static TEE_Result open_session(uint32_t param_types __unused,
 			       TEE_Param params[TEE_NUM_PARAMS] __unused,
-			       void **sess_ctx __unused)
+			       uint32_t session_id __unused)
 {
 	struct tee_ta_session *s;
 
@@ -159,7 +159,7 @@ static TEE_Result open_session(uint32_t param_types __unused,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+static TEE_Result invoke_command(uint32_t session_id __unused, uint32_t cmd_id,
 				 uint32_t param_types,
 				 TEE_Param params[TEE_NUM_PARAMS])
 {

--- a/core/arch/arm/pta/interrupt_tests.c
+++ b/core/arch/arm/pta/interrupt_tests.c
@@ -183,9 +183,9 @@ static TEE_Result interrupt_tests(uint32_t nParamTypes __unused,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result invoke_command(void *psess __unused,
+static TEE_Result invoke_command(uint32_t session_id __unused,
 				 uint32_t cmd, uint32_t ptypes,
-				 TEE_Param params[4])
+				 TEE_Param params[TEE_NUM_PARAMS])
 {
 	TEE_Result res;
 	uint8_t i;

--- a/core/arch/arm/pta/pta_invoke_tests.c
+++ b/core/arch/arm/pta/pta_invoke_tests.c
@@ -370,46 +370,46 @@ static void destroy_ta(void)
 	DMSG("destroy entry point for pseudo ta \"%s\"", TA_NAME);
 }
 
-static TEE_Result open_session(uint32_t nParamTypes __unused,
-		TEE_Param pParams[TEE_NUM_PARAMS] __unused,
-		void **ppSessionContext __unused)
+static TEE_Result open_session(uint32_t param_type __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
+			       void **session __unused)
 {
 	DMSG("open entry point for pseudo ta \"%s\"", TA_NAME);
 	return TEE_SUCCESS;
 }
 
-static void close_session(void *pSessionContext __unused)
+static void close_session(void *session __unused)
 {
 	DMSG("close entry point for pseudo ta \"%s\"", TA_NAME);
 }
 
-static TEE_Result invoke_command(void *pSessionContext __unused,
-		uint32_t nCommandID, uint32_t nParamTypes,
-		TEE_Param pParams[TEE_NUM_PARAMS])
+static TEE_Result invoke_command(void *session __unused,
+				 uint32_t command_id, uint32_t params_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
 {
 	FMSG("command entry point for pseudo ta \"%s\"", TA_NAME);
 
-	switch (nCommandID) {
+	switch (command_id) {
 	case PTA_INVOKE_TESTS_CMD_TRACE:
-		return test_trace(nParamTypes, pParams);
+		return test_trace(params_types, params);
 	case PTA_INVOKE_TESTS_CMD_PARAMS:
-		return test_entry_params(nParamTypes, pParams);
+		return test_entry_params(params_types, params);
 	case PTA_INVOKE_TESTS_CMD_COPY_NSEC_TO_SEC:
-		return test_inject_sdp(nParamTypes, pParams);
+		return test_inject_sdp(params_types, params);
 	case PTA_INVOKE_TESTS_CMD_READ_MODIFY_SEC:
-		return test_transform_sdp(nParamTypes, pParams);
+		return test_transform_sdp(params_types, params);
 	case PTA_INVOKE_TESTS_CMD_COPY_SEC_TO_NSEC:
-		return test_dump_sdp(nParamTypes, pParams);
+		return test_dump_sdp(params_types, params);
 	case PTA_INVOKE_TESTS_CMD_SELF_TESTS:
-		return core_self_tests(nParamTypes, pParams);
+		return core_self_tests(params_types, params);
 #if defined(CFG_WITH_USER_TA)
 	case PTA_INVOKE_TESTS_CMD_FS_HTREE:
-		return core_fs_htree_tests(nParamTypes, pParams);
+		return core_fs_htree_tests(params_types, params);
 #endif
 	case PTA_INVOKE_TESTS_CMD_MUTEX:
-		return core_mutex_tests(nParamTypes, pParams);
+		return core_mutex_tests(params_types, params);
 	case PTA_INVOKE_TESTS_CMD_LOCKDEP:
-		return core_lockdep_tests(nParamTypes, pParams);
+		return core_lockdep_tests(params_types, params);
 	default:
 		break;
 	}

--- a/core/arch/arm/pta/sdp_pta.c
+++ b/core/arch/arm/pta/sdp_pta.c
@@ -54,9 +54,9 @@ static TEE_Result sdp_pa_cmd_virt_to_phys(uint32_t types,
 /*
  * Trusted Application Entry Points
  */
-static TEE_Result open_session(uint32_t nParamTypes __unused,
-			       TEE_Param pParams[TEE_NUM_PARAMS] __unused,
-			       void **ppSessionContext __unused)
+static TEE_Result open_session(uint32_t param_types __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
+			       uint32_t session_id __unused)
 {
 	struct tee_ta_session *s = tee_ta_get_calling_session();
 
@@ -71,15 +71,15 @@ static TEE_Result open_session(uint32_t nParamTypes __unused,
 	return TEE_ERROR_ACCESS_DENIED;
 }
 
-static TEE_Result invoke_command(void *pSessionContext __unused,
-				 uint32_t nCommandID, uint32_t nParamTypes,
-				 TEE_Param pParams[TEE_NUM_PARAMS])
+static TEE_Result invoke_command(uint32_t session_id __unused,
+				 uint32_t command_id, uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
 {
 	FMSG("command entry point for pseudo-TA \"%s\"", PTA_NAME);
 
-	switch (nCommandID) {
+	switch (command_id) {
 	case PTA_CMD_SDP_VIRT_TO_PHYS:
-		return sdp_pa_cmd_virt_to_phys(nParamTypes, pParams);
+		return sdp_pa_cmd_virt_to_phys(param_types, params);
 	default:
 		break;
 	}

--- a/core/arch/arm/pta/secstor_ta_mgmt.c
+++ b/core/arch/arm/pta/secstor_ta_mgmt.c
@@ -166,7 +166,7 @@ out:
 	return res;
 }
 
-static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+static TEE_Result invoke_command(uint32_t client_id __unused, uint32_t cmd_id,
 				 uint32_t param_types,
 				 TEE_Param params[TEE_NUM_PARAMS])
 {

--- a/core/arch/arm/pta/stats.c
+++ b/core/arch/arm/pta/stats.c
@@ -141,7 +141,7 @@ static TEE_Result get_memleak_stats(uint32_t type,
  * Trusted Application Entry Points
  */
 
-static TEE_Result invoke_command(void *psess __unused,
+static TEE_Result invoke_command(uint32_t client_id __unused,
 				 uint32_t cmd, uint32_t ptypes,
 				 TEE_Param params[TEE_NUM_PARAMS])
 {

--- a/core/arch/arm/pta/system.c
+++ b/core/arch/arm/pta/system.c
@@ -42,7 +42,7 @@ static TEE_Result system_rng_reseed(struct tee_ta_session *s __unused,
 
 static TEE_Result open_session(uint32_t param_types __unused,
 			       TEE_Param params[TEE_NUM_PARAMS] __unused,
-			       void **sess_ctx __unused)
+			       uint32_t client_id __unused)
 {
 	struct tee_ta_session *s;
 
@@ -56,7 +56,7 @@ static TEE_Result open_session(uint32_t param_types __unused,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+static TEE_Result invoke_command(uint32_t client_id __unused, uint32_t cmd_id,
 				 uint32_t param_types,
 				 TEE_Param params[TEE_NUM_PARAMS])
 {

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -96,7 +96,6 @@ struct tee_ta_session {
 	bool cancel;		/* True if TA invocation is cancelled */
 	bool cancel_mask;	/* True if cancel is masked */
 	TEE_Time cancel_time;	/* Time when to cancel the TA invocation */
-	void *user_ctx;		/* Opaque session handle assigned by PTA */
 	uint32_t ref_count;	/* reference counter */
 	struct condvar refc_cv;	/* CV used to wait for ref_count to be 0 */
 	struct condvar lock_cv;	/* CV used to wait for lock */


### PR DESCRIPTION
While reviewing https://github.com/OP-TEE/optee_os/pull/2843, a question raised whether field `user_ctx` from `struct tee_ta_session` should be removed, as very specific of PTA contexts [1].

This RFC proposes a change in the PTA API. Instead of producing client context references from open_session sequence, as standard TA (as specified by the GPD TEE spec), PTA would get the session ID from the core, assumed unique, and use it to distinguish between sessions.

Main change is in `pseudo_ta.c` and `pseudo_ta.h`:
```patch
@@ -33,9 +33,9 @@ struct pseudo_ta_head {
 	void (*destroy_entry_point)(void);
 	TEE_Result (*open_session_entry_point)(uint32_t nParamTypes,
 			TEE_Param pParams[TEE_NUM_PARAMS],
-			void **ppSessionContext);
-	void (*close_session_entry_point)(void *pSessionContext);
-	TEE_Result (*invoke_command_entry_point)(void *pSessionContext,
+			uint32_t session_id);
+	void (*close_session_entry_point)(uint32_t session_id);
+	TEE_Result (*invoke_command_entry_point)(uint32_t session_id,
 			uint32_t nCommandID, uint32_t nParamTypes,
 			TEE_Param pParams[TEE_NUM_PARAMS]);
 };
```

This P-R also adds session context (IDs) tests in the invocation test PTA, before API change and adapted to the proposed API change.

[1] https://github.com/OP-TEE/optee_os/pull/2843#discussion_r259737076