### PR TITLE
core: arch: arm: Allow memrefs with size 0

### DIFF
--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -276,7 +276,8 @@
 #define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM		(1 << 2)
 /* Secure world is built with virtualization support */
 #define OPTEE_SMC_SEC_CAP_VIRTUALIZATION	(1 << 3)
-
+/* Secure world supports Shared Memory with a NULL reference */
+#define OPTEE_SMC_SEC_CAP_MEMREF_NULL		(1 << 4)
 
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -91,6 +91,7 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 #ifdef CFG_VIRTUALIZATION
 	args->a1 |= OPTEE_SMC_SEC_CAP_VIRTUALIZATION;
 #endif
+	args->a1 |= OPTEE_SMC_SEC_CAP_MEMREF_NULL;
 
 #if defined(CFG_CORE_DYN_SHM)
 	dyn_shm_en = core_mmu_nsec_ddr_is_defined();

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -67,8 +67,10 @@ static TEE_Result set_tmem_param(const struct optee_msg_param_tmem *tmem,
 	paddr_t pa = READ_ONCE(tmem->buf_ptr);
 	size_t sz = READ_ONCE(tmem->size);
 
-	/* Handle NULL memory reference */
-	if (!pa && !sz) {
+	/*
+	 * Handle NULL memory reference
+	 */
+	if (!pa) {
 		mem->mobj = NULL;
 		mem->offs = 0;
 		mem->size = 0;


### PR DESCRIPTION
Refering to GPTS test suite v2.0.0.1-2016-11-09 id de-14-33

Refer to the TEEC_RegisterSharedMemory function for error conditions
which can be triggered during temporary registration of a memory region.

When a CA passes a memref with size 0, a valid pointer must be passed to
the TA.  An example use is passing a read pointer for a shared buffer.
This is tested by GPTS, case de-14-33 for example.
To allow passing a memref with size 0, memref validity is based on pointer
non NULL, not on size non-zero.  For the size 0 case, the minimum
size memory allocation is done to allow a correct virtual address to be
passed.

Signed-off-by: Michael Whitfield <michael.whitfield@nxp.com>
Signed-off-by: Cedric Neveux <cedric.neveux@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
