### PR TITLE
Compile user TAs with -fpic rather than -fpie

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -165,7 +165,7 @@ ta_arm32-platform-cppflags += $(arm32-platform-cppflags)
 ta_arm32-platform-cflags += $(arm32-platform-cflags)
 ta_arm32-platform-cflags += $(platform-cflags-optimization)
 ta_arm32-platform-cflags += $(platform-cflags-debug-info)
-ta_arm32-platform-cflags += -fpie
+ta_arm32-platform-cflags += -fpic
 ta_arm32-platform-cflags += $(arm32-platform-cflags-generic)
 ifeq ($(arm32-platform-hard-float-enabled),y)
 ta_arm32-platform-cflags += $(arm32-platform-cflags-hard-float)
@@ -197,7 +197,7 @@ ta_arm64-platform-cppflags += $(arm64-platform-cppflags)
 ta_arm64-platform-cflags += $(arm64-platform-cflags)
 ta_arm64-platform-cflags += $(platform-cflags-optimization)
 ta_arm64-platform-cflags += $(platform-cflags-debug-info)
-ta_arm64-platform-cflags += -fpie
+ta_arm64-platform-cflags += -fpic
 ta_arm64-platform-cflags += $(arm64-platform-cflags-generic)
 ifeq ($(arm64-platform-hard-float-enabled),y)
 ta_arm64-platform-cflags += $(arm64-platform-cflags-hard-float)


### PR DESCRIPTION
TA source files are compiled with the -fpie GCC flag in order to
generate a Position Independant Executable. This is not suitable to
produce a shared library as introduced by commit f8896d1301fc ("TA dev
kit: add support for creating shared libraries"). -fpic should be used
instead. Here is what the GCC man page has to say on these flags:

  -fpic
      Generate position-independent code (PIC) suitable for use in a
      shared library [...]

  -fpie
  -fPIE
      These options are similar to -fpic and -fPIC, but generated
      position independent code can be only linked into executables.

So, it is quite clear that -fpie is wrong for a shared library. It is
not very clear however if -fpic can be used when generating code for an
executable. I think it can, and there is a bug report against the GCC
documentation that would confirm this [1]. Therefore we can simply use
-fpic in all cases. This is quite convenient because we currently make
no difference in the compile flags when we are building an executable,
a static library or a shared library.

The difference between -fpie and -fpic has to do with the kinds of
relocations that the compiler is allowed to emit. I stumbled upon this
issue when experimenting with shared libraries and the code proposed
by Jens to share read-only pages between TAs [2]. In my test case, a
shared library already loaded by one TA, is used by another TA. During
the load phase of the second TA, the TEE core crashed with a data-abort
(write permission fault) when trying to apply an R_ARM_REL32 relocation
to some literal pool data in the .text section of the library. The
whole .text being mapped read-only, there should be no relocation to do
here. And indeed the cause was the wrong flag (-fpie) used when
compiling the shared library.

Link: [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70419
Link: [2] https://github.com/OP-TEE/optee_os/pull/2801
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
CC: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (QEMU)
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (HiKey960 32 & 64-bit TA)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
