### PR TITLE
    Allow to set the sysroot for libgcc lookup

### DIFF
--- a/mk/gcc.mk
+++ b/mk/gcc.mk
@@ -12,7 +12,7 @@ nostdinc$(sm)	:= -nostdinc -isystem $(shell $(CC$(sm)) \
 			-print-file-name=include 2> /dev/null)
 
 # Get location of libgcc from gcc
-libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) $(comp-cflags$(sm)) \
+libgcc$(sm)  	:= $(shell $(CC$(sm)) $(LIBGCC_LOCATE_CFLAGS) $(CFLAGS$(arch-bits-$(sm))) $(comp-cflags$(sm)) \
 			-print-libgcc-file-name 2> /dev/null)
 
 # Define these to something to discover accidental use


### PR DESCRIPTION
    OP-TEE compilation fails when OE/bb is used:
    libgcc.a cannot be find when gcc.mk is executed.
    This commit allows to set the sysroot to solve this problem.
    Sysroot can be defined using the variable LIBGCC_LOCATE_CFLAGS.
    e.g. LIBGCC_LOCATE_CFLAGS=--sysroot=<new_sysroot>

    This patch originally come from https://git.linaro.org/openembedded/meta-linaro.git/

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
