### PR TITLE
core: ignore deprecated TA flags EXEC_DDR and USER_MODE

### DIFF
--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -10,6 +10,8 @@
 #include <tee_api_types.h>
 #include <util.h>
 
+#define TA_FLAG_USER_MODE		0	 /* Deprecated, was (1 << 0) */
+#define TA_FLAG_EXEC_DDR		0	 /* Deprecated, was (1 << 1) */
 #define TA_FLAG_SINGLE_INSTANCE		(1 << 2)
 #define TA_FLAG_MULTI_SESSION		(1 << 3)
 #define TA_FLAG_INSTANCE_KEEP_ALIVE	(1 << 4) /* remains after last close */
@@ -23,11 +25,7 @@
 #define TA_FLAG_CONCURRENT		(1 << 8)
 #define TA_FLAG_DEVICE_ENUM		(1 << 9) /* device enumeration */
 
-#define TA_FLAGS_MASK			GENMASK_32(9, 2)
-
-/* Deprecated macros that will be removed in the 3.2 release */
-#define TA_FLAG_USER_MODE		0
-#define TA_FLAG_EXEC_DDR		0
+#define TA_FLAGS_MASK			GENMASK_32(9, 0)
 
 union ta_head_func_ptr {
 	uint64_t ptr64;


### PR DESCRIPTION
Commit 387b0ee39b1b ("core: deprecate TA property flags EXEC_DDR and
USER_MODE") removes the requirement for user TAs to set the flags
TA_FLAG_EXEC_DDR (bit 0) and TA_FLAG_USER_MODE (bit 1), the rationale
being that they are meaningless in the current implementation.
The macros are re-defined to be zero to reflect the fact that they have
no use. But, instead of ignoring the previous values, the TEE core now
requires that bits 0 and 1 must *not* be set. This is a problem because
it needlessly breaks backward compatibility. A TA built against OP-TEE
3.0.0 will not work with 3.1.0 or later:

 E/TC:? 0 tee_ta_init_user_ta_session:1040 Invalid TA flag(s) 0x3

This commit changes the acceptable flags mask (TA_FLAGS_MASK) to
include the previous EXEC_DDR and USER_MODE bits, thus restoring
backward compatibility.

Fixes: 387b0ee39b1b ("core: deprecate TA property flags EXEC_DDR and USER_MODE")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
