### PR TITLE
core: Initialize the chip_id array when generating the SSK

### DIFF
--- a/core/tee/tee_fs_key_manager.c
+++ b/core/tee/tee_fs_key_manager.c
@@ -148,6 +148,7 @@ static TEE_Result tee_fs_init_key_manager(void)
 	 *     message := concatenate(chip_id, static string)
 	 * */
 	tee_otp_get_hw_unique_key(&huk);
+	memset(chip_id, 0, sizeof(chip_id));
 	if (tee_otp_get_die_id(chip_id, sizeof(chip_id)))
 		return TEE_ERROR_BAD_STATE;
 


### PR DESCRIPTION
In tee_fs_init_key_manager(), Secure Storage Key (SSK) is computed as
follow:

    SSK = HMAC(HUK, message)
    message := concatenate(chip_id, static string)

chip_id is a 32-byte array but some tee_otp_get_die_id() implementation
may provide a smaller chip ID. Initialize the chip_id array to make
sure the remaining bytes do not contain garbage data. Without this
initialization, SSK may be inconsistent across power cycles generating
failures when reading back data from the secure storage.

Signed-off-by: Alexandre Jutras <alexandre.jutras@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
