### PR TITLE
Add support for ultra96 ZynqMP board

### DIFF
--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -66,6 +66,34 @@
 #define GICD_OFFSET		0
 #define GICC_OFFSET		0x20000
 
+#elif defined(PLATFORM_FLAVOR_ultra96)
+
+#define GIC_BASE		0xF9010000
+#define UART0_BASE		0xFF000000
+#define UART1_BASE		0xFF010000
+
+#define IT_UART0		53
+#define IT_UART1		54
+
+#define UART0_CLK_IN_HZ		100000000
+#define UART1_CLK_IN_HZ		100000000
+#define CONSOLE_UART_BASE	UART1_BASE
+#define IT_CONSOLE_UART		IT_UART1
+#define CONSOLE_UART_CLK_IN_HZ	UART1_CLK_IN_HZ
+
+#define DRAM0_BASE		0
+#define DRAM0_SIZE		0x80000000
+
+/* Location of trusted dram */
+#define TZDRAM_BASE		0x60000000
+#define TZDRAM_SIZE		0x10000000
+
+#define TEE_SHMEM_START		0x70000000
+#define TEE_SHMEM_SIZE		0x10000000
+
+#define GICD_OFFSET		0
+#define GICC_OFFSET		0x20000
+
 #else
 #error "Unknown platform flavor"
 #endif


### PR DESCRIPTION
Add flavor 'ultra96' to platform 'zynqmp'.
Redirect TEE console output to UART1.
Fix UART1 base address which is wrong.
Successfully tested on Ultra96 board.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
