### PR TITLE
zynqmp: fix UART1 base for zcu102, zc1751_dc1 and zc1751_dc2 flavors

### DIFF
--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -42,7 +42,7 @@
 
 #define GIC_BASE		0xF9010000
 #define UART0_BASE		0xFF000000
-#define UART1_BASE		0xFF001000
+#define UART1_BASE		0xFF010000
 
 #define IT_UART0		53
 #define IT_UART1		54


### PR DESCRIPTION
Fix UART1 base address in zcu102 flavor

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
