### PR TITLE
[rfc] core: Introduce OPTEE_SMC_GET_CONFIG SMC

### DIFF
--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -423,6 +423,31 @@
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_VM_DESTROYED)
 
 /*
+ * Query OP-TEE about number of supported threads
+ *
+ * Normal World OS or Hypervisor issues this call to find out how many
+ * threads OP-TEE supports. That is how many standard calls can be issued
+ * in parallel before OP-TEE will return OPTEE_SMC_RETURN_ETHREAD_LIMIT.
+ *
+ * Call requests usage:
+ * a0	SMC Function ID, OPTEE_SMC_GET_THREAD_COUNT
+ * a1-6 Not used
+ * a7	Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1	Number of threads
+ * a2-7 Preserved
+ *
+ * Error return:
+ * a0	OPTEE_SMC_RETURN_UNKNOWN_FUNCTION   Requested call is not implemented
+ * a1-7	Preserved
+ */
+#define OPTEE_SMC_FUNCID_GET_THREAD_COUNT	15
+#define OPTEE_SMC_GET_THREAD_COUNT \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_THREAD_COUNT)
+
+/*
  * Resume from RPC (for example after processing a foreign interrupt)
  *
  * Call register usage:

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -132,6 +132,12 @@ static void tee_entry_boot_secondary(struct thread_smc_args *args)
 #endif
 }
 
+static void tee_entry_get_thread_count(struct thread_smc_args *args)
+{
+	args->a0 = OPTEE_SMC_RETURN_OK;
+	args->a1 = CFG_NUM_THREADS;
+}
+
 #if defined(CFG_VIRTUALIZATION)
 static void tee_entry_vm_created(struct thread_smc_args *args)
 {
@@ -200,6 +206,9 @@ void tee_entry_fast(struct thread_smc_args *args)
 	case OPTEE_SMC_BOOT_SECONDARY:
 		tee_entry_boot_secondary(args);
 		break;
+	case OPTEE_SMC_GET_THREAD_COUNT:
+		tee_entry_get_thread_count(args);
+		break;
 
 #if defined(CFG_VIRTUALIZATION)
 	case OPTEE_SMC_VM_CREATED:
@@ -223,7 +232,7 @@ size_t tee_entry_generic_get_api_call_count(void)
 	 * target has additional calls it will call this function and
 	 * add the number of calls the target has added.
 	 */
-	size_t ret = 11;
+	size_t ret = 12;
 
 #if defined(CFG_VIRTUALIZATION)
 	ret += 2;


### PR DESCRIPTION
This call can be used to query OP-TEE about different configuration
options.

It is introduced after discussion at [1] about possibility to read
number of supported threads. It is needed for XEN OP-TEE mediator to
mitigate possible DoS from virtual guest. If XEN knows number of
OP-TEE threads, it can limit number of standard calls from the guest
on own side.

I tried to implement OPTEE_SMC_GET_CONFIG in flexible way, so more
options can be added later.

[1] https://lists.xenproject.org/archives/html/xen-devel/2019-01/msg01460.html

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

---

This isn't strictly required change. I can limit number of threads from XEN side using arbitrary number. Hence, [rfc] tag.
But anyways, it is a nice feature to have.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
