### PR TITLE
generic_boot: map device tree as MEM_AREA_IO_SEC

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -901,10 +901,10 @@ static void init_external_dt(unsigned long phys_dt)
 		return;
 	}
 
-	if (!core_mmu_add_mapping(MEM_AREA_IO_NSEC, phys_dt, CFG_DTB_MAX_SIZE))
+	if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, phys_dt, CFG_DTB_MAX_SIZE))
 		panic("Failed to map external DTB");
 
-	fdt = phys_to_virt(phys_dt, MEM_AREA_IO_NSEC);
+	fdt = phys_to_virt(phys_dt, MEM_AREA_IO_SEC);
 	if (!fdt)
 		panic();
 


### PR DESCRIPTION
If the device starts with an active TZASC, the default configuration allows only
secure access. Use a secure access for the early device tree.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>
