### PR TITLE
scripts/symbolize.py: accept several spaces after "region"

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -18,7 +18,7 @@ CALL_STACK_RE = re.compile('Call stack:')
 STACK_ADDR_RE = re.compile(
     r'[UEIDFM]/T[AC]:(\?+|[0-9]+) [0-9]* +(?P<addr>0x[0-9a-f]+)')
 ABORT_ADDR_RE = re.compile(r'-abort at address (?P<addr>0x[0-9a-f]+)')
-REGION_RE = re.compile(r'region [0-9]+: va (?P<addr>0x[0-9a-f]+) '
+REGION_RE = re.compile(r'region +[0-9]+: va (?P<addr>0x[0-9a-f]+) '
                        r'pa 0x[0-9a-f]+ size (?P<size>0x[0-9a-f]+)'
                        r'( flags .{6} (\[(?P<elf_idx>[0-9]+)\])?)?')
 ELF_LIST_RE = re.compile(r'\[(?P<idx>[0-9]+)\] (?P<uuid>[0-9a-f\-]+)'


### PR DESCRIPTION
User TA crash dumps were slightly modified to better align region
numbers. scripts/symbolize.py needs to be updated accordingly.

Fixes: dba5a1eab8af1 ("core: better align output of TA dump with many or big regions")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
