### PR TITLE
libutee: fix off-by-one errors in base64_dec()

### DIFF
--- a/lib/libutee/base64.c
+++ b/lib/libutee/base64.c
@@ -84,7 +84,7 @@ bool base64_dec(const char *data, size_t size, void *buf, size_t *blen)
 		if (!get_idx(data[n], &idx))
 			continue;
 
-		if (m > *blen)
+		if (m >= *blen)
 			b = NULL;
 
 		switch (s) {
@@ -97,7 +97,7 @@ bool base64_dec(const char *data, size_t size, void *buf, size_t *blen)
 			if (b)
 				b[m] |= idx >> 4;
 			m++;
-			if (m > *blen)
+			if (m >= *blen)
 				b = NULL;
 			if (b)
 				b[m] = (idx & 0xf) << 4;
@@ -107,7 +107,7 @@ bool base64_dec(const char *data, size_t size, void *buf, size_t *blen)
 			if (b)
 				b[m] |= idx >> 2;
 			m++;
-			if (m > *blen)
+			if (m >= *blen)
 				b = NULL;
 			if (b)
 				b[m] = (idx & 0x3) << 6;


### PR DESCRIPTION
There is a possible buffer overflow in base64_dec(). Since the output
buffer size is *blen, the last byte of the buffer is buf[*blen - 1] and
therefore the buffer must not be written to when the current index m is
such that (m >= *blen), not (m > *blen).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
