### PR TITLE
Add sanity check for public exponent of TA signing key.

### DIFF
--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -33,6 +33,15 @@ def main():
     key = RSA.importKey(f.read())
     f.close
 
+    # Refuse public exponent with more than 32 bits. Otherwise the C
+    # compiler may simply truncate the value and proceed.
+    # This will lead to TAs seemingly having invalid signatures with a
+    # possible security issue for any e = k*2^32 + 1 (for any integer k).
+    if key.publickey().e > 0xffffffff:
+        raise ValueError(
+            'Unsupported large public exponent detected. ' +
+            'OP-TEE handles only public exponents up to 2^32 - 1.')
+
     f = open(args.out, 'w')
 
     f.write("#include <stdint.h>\n")

--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2015, Linaro Limited
-#
 
 
 def get_args():
@@ -10,13 +9,11 @@ def get_args():
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--prefix',
-        required=True,
+        '--prefix', required=True,
         help='Prefix for the public key exponent and modulus in c file')
-
-    parser.add_argument('--out', required=True,
-                        help='Name of c file for the public key')
-
+    parser.add_argument(
+        '--out', required=True,
+        help='Name of c file for the public key')
     parser.add_argument('--key', required=True, help='Name of key file')
 
     return parser.parse_args()
@@ -29,9 +26,8 @@ def main():
 
     args = get_args()
 
-    f = open(args.key, 'r')
-    key = RSA.importKey(f.read())
-    f.close
+    with open(args.key, 'r') as f:
+        key = RSA.importKey(f.read())
 
     # Refuse public exponent with more than 32 bits. Otherwise the C
     # compiler may simply truncate the value and proceed.
@@ -42,29 +38,23 @@ def main():
             'Unsupported large public exponent detected. ' +
             'OP-TEE handles only public exponents up to 2^32 - 1.')
 
-    f = open(args.out, 'w')
-
-    f.write("#include <stdint.h>\n")
-    f.write("#include <stddef.h>\n\n")
-
-    f.write("const uint32_t " + args.prefix + "_exponent = " +
-            str(key.publickey().e) + ";\n\n")
-
-    f.write("const uint8_t " + args.prefix + "_modulus[] = {\n")
-    i = 0
-    for x in array.array("B", long_to_bytes(key.publickey().n)):
-        f.write("0x" + '{0:02x}'.format(x) + ",")
-        i = i + 1
-        if i % 8 == 0:
-            f.write("\n")
-        else:
-            f.write(" ")
-    f.write("};\n")
-
-    f.write("const size_t " + args.prefix + "_modulus_size = sizeof(" +
-            args.prefix + "_modulus);\n")
-
-    f.close()
+    with open(args.out, 'w') as f:
+        f.write("#include <stdint.h>\n")
+        f.write("#include <stddef.h>\n\n")
+        f.write("const uint32_t " + args.prefix + "_exponent = " +
+                str(key.publickey().e) + ";\n\n")
+        f.write("const uint8_t " + args.prefix + "_modulus[] = {\n")
+        i = 0
+        for x in array.array("B", long_to_bytes(key.publickey().n)):
+            f.write("0x" + '{0:02x}'.format(x) + ",")
+            i = i + 1
+            if i % 8 == 0:
+                f.write("\n")
+            else:
+                f.write(" ")
+        f.write("};\n")
+        f.write("const size_t " + args.prefix + "_modulus_size = sizeof(" +
+                args.prefix + "_modulus);\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This also fixes a potential security vulnerability (see below).

The public exponent of the TA signing key is stored by OP-TEE OS as an
unsigned 32-bit integer. While rarely seen in the wild, public exponents
that overflow this storage field exist. Although the C compiler usually
generates an overflow warning when such an exponent would be set, this
is happens only once after the key was changed and is easily overlooked.
The script therefore throws an exception, notifying the user of the
unsuitable key.

Without the sanity check, such an unsuitable key would simply lead to
TA signature verification failures. However, if the public exponent e
is close to a multiple of 2^32, a small exponent attack to forge a
signature might be feasible.

Code was also reworked to be pep8 clean.

Signed-off-by: Markus S. Wamser <markus.wamser@mixed-mode.de>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
