### PR TITLE
TZC380 autoconfiguration (search correct region size) and support for i.MX6Q/D

### DIFF
--- a/core/arch/arm/plat-imx/drivers/sub.mk
+++ b/core/arch/arm/plat-imx/drivers/sub.mk
@@ -1,0 +1,1 @@
+srcs-$(CFG_TZC380) 	+= tzc380.c

--- a/core/arch/arm/plat-imx/drivers/tzc380.c
+++ b/core/arch/arm/plat-imx/drivers/tzc380.c
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2019 Pengutronix
+ * All rights reserved.
+ *
+ * Rouven Czerwinski <entwicklung@pengutronix.de>
+ */
+
+#include <drivers/tzc380.h>
+#include <imx-regs.h>
+#include <imx.h>
+#include <mm/core_memprot.h>
+#include <mm/generic_ram_layout.h>
+
+void imx_configure_tzasc(void)
+{
+
+	int i;
+	vaddr_t addr[2] = {0};
+
+	addr[0] = core_mmu_get_va(TZASC_BASE, MEM_AREA_IO_SEC);
+	addr[1] = core_mmu_get_va(TZASC2_BASE, MEM_AREA_IO_SEC);
+
+	for (i = 0; i < 2; i++) {
+		uint8_t region = 1;
+
+		tzc_init(addr[i]);
+
+		region = tzc_auto_configure(CFG_DRAM_BASE, CFG_DDR_SIZE,
+			     TZC_ATTR_SP_NS_RW, region);
+		region = tzc_auto_configure(CFG_TZDRAM_START, CFG_TZDRAM_SIZE,
+			     TZC_ATTR_SP_S_RW, region);
+		region = tzc_auto_configure(CFG_SHMEM_START, CFG_SHMEM_SIZE,
+			     TZC_ATTR_SP_ALL, region);
+		DMSG("Action register: %xl", tzc_get_action());
+	}
+}

--- a/core/arch/arm/plat-imx/imx.h
+++ b/core/arch/arm/plat-imx/imx.h
@@ -33,4 +33,10 @@ uint32_t imx_soc_type(void);
 void imx_gpcv2_set_core1_pdn_by_software(void);
 void imx_gpcv2_set_core1_pup_by_software(void);
 void imx_gpcv2_set_core_pgc(bool enable, uint32_t offset);
+
+#ifdef CFG_TZC380
+void imx_configure_tzasc(void);
+#else
+static inline void imx_configure_tzasc(void) {}
+#endif /* CFG_TZC380 */
 #endif

--- a/core/arch/arm/plat-imx/imx6.c
+++ b/core/arch/arm/plat-imx/imx6.c
@@ -26,6 +26,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include <imx.h>
 
 #include <compiler.h>
 #include <drivers/gic.h>
@@ -77,5 +78,6 @@ void plat_cpu_reset_late(void)
 		     addr != CSU_BASE + CSU_CSL_END;
 		     addr += 4)
 			io_setbits32(addr, CSU_SETTING_LOCK);
+		imx_configure_tzasc();
 	}
 }

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -23,3 +23,5 @@ endif
 srcs-$(CFG_MX7) += imx7.c a7_plat_init.S
 
 subdirs-$(CFG_PSCI_ARM32) += pm
+
+subdirs-y += drivers

--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -62,6 +62,11 @@ static void tzc_write_action(vaddr_t base, enum tzc_action action)
 	io_write32(base + ACTION_OFF, action);
 }
 
+static uint32_t tzc_read_action(vaddr_t base)
+{
+	return io_read32(base + ACTION_OFF);
+}
+
 static void tzc_write_region_base_low(vaddr_t base, uint32_t region,
 				      uint32_t val)
 {
@@ -202,6 +207,13 @@ void tzc_set_action(enum tzc_action action)
 	 * - The interrupt action has not been tested.
 	 */
 	tzc_write_action(tzc.base, action);
+}
+
+uint32_t tzc_get_action(void)
+{
+	assert(tzc.base);
+
+	return tzc_read_action(tzc.base);
 }
 
 #if TRACE_LEVEL >= TRACE_DEBUG

--- a/core/include/drivers/tzc380.h
+++ b/core/include/drivers/tzc380.h
@@ -189,12 +189,24 @@ enum tzc_action {
 #define TZC_REGION_SIZE_MASK	GENMASK_32(6, 1)
 #define TZC_ATTR_REGION_SIZE(s)	((s) << TZC_REGION_SIZE_SHIFT)
 
+#define TZC_SUBREGION_DIS_SHIFT	8
+#define TZC_SUBREGION_DIS_MASK	GENMASK_32(15, 8)
+#define TZC_ATTR_SUBREGION_DIS(subreg) \
+	(BIT((subreg) + TZC_SUBREGION_DIS_SHIFT) & \
+	 TZC_SUBREGION_DIS_MASK)
+
 #define TZC_ATTR_REGION_EN_SHIFT	0x0
 #define TZC_ATTR_REGION_EN_MASK		0x1
 
 #define TZC_ATTR_REGION_EN
 #define TZC_ATTR_REGION_ENABLE	0x1
 #define TZC_ATTR_REGION_DISABLE	0x0
+
+#ifdef CFG_WITH_LPAE
+#define TZC380_POW	48
+#else
+#define TZC380_POW	34
+#endif
 
 void tzc_init(vaddr_t base);
 void tzc_configure_region(uint8_t region, vaddr_t region_base, uint32_t attr);
@@ -204,6 +216,8 @@ void tzc_set_action(enum tzc_action action);
 uint32_t tzc_get_action(void);
 void tzc_fail_dump(void);
 void tzc_int_clear(void);
+int tzc_auto_configure(vaddr_t addr, vaddr_t rsize, uint32_t attr,
+		       uint8_t region);
 
 #if TRACE_LEVEL >= TRACE_DEBUG
 void tzc_dump_state(void);

--- a/core/include/drivers/tzc380.h
+++ b/core/include/drivers/tzc380.h
@@ -201,6 +201,7 @@ void tzc_configure_region(uint8_t region, vaddr_t region_base, uint32_t attr);
 void tzc_region_enable(uint8_t region);
 void tzc_security_inversion_en(vaddr_t base);
 void tzc_set_action(enum tzc_action action);
+uint32_t tzc_get_action(void);
 void tzc_fail_dump(void);
 void tzc_int_clear(void);
 


### PR DESCRIPTION
Hello,

this PR adds a new function called `tzc380_auto_configure` which searches for the matching configuration for a given start address and size. This configuration is then applied with the given permissions to the controller.
This vastly simplifies configurations for devices with a generic RAM layout, since the necessary information is already available from the header file.
Support for i.MX6QD devices is added as a user of the new function.
