### PR TITLE
plat-rpi3: Use generic memory layout

### DIFF
--- a/core/arch/arm/plat-rpi3/conf.mk
+++ b/core/arch/arm/plat-rpi3/conf.mk
@@ -2,6 +2,12 @@ include core/arch/arm/cpu/cortex-armv8-0.mk
 
 $(call force,CFG_TEE_CORE_NB_CORE,4)
 
+CFG_SHMEM_START ?= 0x08000000
+CFG_SHMEM_SIZE ?= 0x00400000
+CFG_TZDRAM_START ?= 0x10100000
+CFG_TZDRAM_SIZE ?= 0x00F00000
+CFG_TEE_RAM_VA_SIZE ?= 0x00700000
+
 $(call force,CFG_8250_UART,y)
 $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_PM_STUBS,y)

--- a/core/arch/arm/plat-rpi3/platform_config.h
+++ b/core/arch/arm/plat-rpi3/platform_config.h
@@ -29,6 +29,8 @@
 #ifndef PLATFORM_CONFIG_H
 #define PLATFORM_CONFIG_H
 
+#include <mm/generic_ram_layout.h>
+
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		64
 
@@ -65,24 +67,5 @@
 
 #define DRAM0_BASE		0x00000000
 #define DRAM0_SIZE		0x40000000
-
-/* Below ARM-TF */
-#define TEE_SHMEM_START		(0x08000000)
-#define TEE_SHMEM_SIZE		(4 * 1024 * 1024)
-
-#define TZDRAM_BASE		(0x10100000)
-#define TZDRAM_SIZE		(15 * 1024 * 1024)
-
-#define TEE_RAM_VA_SIZE		(7 * 1024 * 1024)
-
-#define TEE_LOAD_ADDR		TZDRAM_BASE
-
-#define TEE_RAM_PH_SIZE		TEE_RAM_VA_SIZE
-#define TEE_RAM_START		TZDRAM_BASE
-
-#define TA_RAM_START		ROUNDUP((TZDRAM_BASE + TEE_RAM_VA_SIZE), \
-					CORE_MMU_PGDIR_SIZE)
-
-# define TA_RAM_SIZE		(8 * 1024 * 1024)
 
 #endif /* PLATFORM_CONFIG_H */


### PR DESCRIPTION
plat-rpi3 have quite standard memory layout, so there is no sense
to maintain separate configuration if it possible to use generic
one.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
