### PR TITLE
tee: entry_fast: reduce verbosity of dynamic shared memory message

### DIFF
--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -95,7 +95,7 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 		args->a1 |= OPTEE_SMC_SEC_CAP_DYNAMIC_SHM;
 #endif
 
-	IMSG("Dynamic shared memory is %sabled", dyn_shm_en ? "en" : "dis");
+	DMSG("Dynamic shared memory is %sabled", dyn_shm_en ? "en" : "dis");
 }
 
 static void tee_entry_disable_shm_cache(struct thread_smc_args *args)


### PR DESCRIPTION
Outside of the initial boot or error cases OP-TEE is quiet, this
is a notable exception that dirties up the boot log and has caused
confusion during kernel boot by users. It is only needed for
debug purposes.

Reduce this message to only debug verbosity.

`Signed-off-by: Andrew F. Davis <afd@ti.com>`