### PR TITLE
plat/rcar: set 8 cpu cores for all flavors

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -16,7 +16,12 @@ ifeq ($(PLATFORM_FLAVOR),salvator_h3_4x2g)
 $(call force,CFG_TEE_CORE_NB_CORE,8)
 endif
 ifeq ($(PLATFORM_FLAVOR),salvator_m3)
-$(call force,CFG_TEE_CORE_NB_CORE,4)
+$(call force,CFG_TEE_CORE_NB_CORE,6)
+# This somewhat abuses implementation of get_core_pos_mpidr()
+# M3 have 6 cores, but internaly they have ids 0, 1, 4, 5, 6, 7.
+# By setting CFG_CORE_CLUSTER_SHIFT to 1, get_core_pos_mpidr()
+# will produce correct numbers: 0, 1, 2, 3, 4, 5
+$(call force,CFG_CORE_CLUSTER_SHIFT,1)
 endif
 
 CFG_TZDRAM_START ?= 0x44100000


### PR DESCRIPTION
R-car Gen3 SoCs have consistent core numbering across all
variations: CA57 cluster have core numbers 0-3 and CA53 have
numbers 4-7.

Also M3 flavor have 6 cores: two CA57s and four CA53s. Taking
into account consistent numbering, M3 will have the following
core ids: 0, 1, 3, 5, 6, 7. So, it is natural to set
CFG_TEE_CORE_NB_CORE = 8 for M3 flavor.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
