### PR TITLE
stm32mp1: seed PRNG with STM32 RNG

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -545,6 +545,9 @@ static inline bool stm32_rcc_is_mckprot(void)
 {
 	return io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_MCKPROT;
 }
+
+/* Clock and reset RNG1 from RCC raw access aside clock/reset drviers */
+void stm32mp_rcc_raw_setup_rng1(void);
 #endif /*ASM*/
 
 #endif /*__STM32MP1_RCC_H__*/

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -11,8 +11,12 @@
 #include <drivers/stm32_uart.h>
 #include <drivers/stm32mp1_etzpc.h>
 #include <dt-bindings/clock/stm32mp1-clks.h>
+#include <drivers/stm32_rng.h>
+#include <drivers/stm32mp1_rcc.h>
+#include <io.h>
 #include <kernel/generic_boot.h>
 #include <kernel/dt.h>
+#include <kernel/delay.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
@@ -23,6 +27,7 @@
 #include <stm32_util.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
+#include <tee/tee_cryp_utl.h>
 #include <trace.h>
 
 #ifdef CFG_WITH_NSEC_GPIOS
@@ -329,3 +334,40 @@ unsigned int stm32_get_gpio_bank_clock(unsigned int bank)
 	assert(bank <= GPIO_BANK_K);
 	return GPIOA + bank;
 }
+
+#ifdef CFG_STM32_RNG
+#define RNG1_RESET_TIMEOUT_US		1000
+#define PRNG_SEED_SIZE			16
+
+void plat_rng_init(void)
+{
+	vaddr_t rng = (vaddr_t)phys_to_virt(RNG1_BASE, MEM_AREA_IO_SEC);
+	vaddr_t rcc = stm32_rcc_base();
+	uint64_t timeout_ref = timeout_init_us(RNG1_RESET_TIMEOUT_US);
+	uint8_t seed[PRNG_SEED_SIZE] = { };
+	size_t size = 0;
+
+	assert(cpu_mmu_enabled());
+
+	/* Clock/reset drivers are not probed yet: prepare RNG1 */
+	io_setbits32(rcc + RCC_MP_AHB5ENSETR, RCC_MP_AHB5ENSETR_RNG1EN);
+	io_setbits32(rcc + RCC_MP_AHB5LPENCLRR, RCC_MP_AHB5LPENSETR_RNG1LPEN);
+	io_setbits32(rcc + RCC_AHB5RSTSETR, RCC_AHB5RSTSETR_RNG1RST);
+	while (!(io_read32(rcc + RCC_AHB5RSTSETR) & RCC_AHB5RSTSETR_RNG1RST))
+		if (timeout_elapsed(timeout_ref))
+			panic();
+	io_setbits32(rcc + RCC_AHB5RSTCLRR, RCC_AHB5RSTSETR_RNG1RST);
+	while (io_read32(rcc + RCC_AHB5RSTSETR) & RCC_AHB5RSTSETR_RNG1RST)
+		if (timeout_elapsed(timeout_ref))
+			panic();
+
+	size = sizeof(seed);
+	if (stm32_rng_read_raw(rng, seed, &size))
+		panic();
+	if (size != sizeof(seed))
+		panic();
+
+	if (crypto_rng_init(seed, sizeof(seed)))
+		panic();
+}
+#endif

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -336,37 +336,20 @@ unsigned int stm32_get_gpio_bank_clock(unsigned int bank)
 }
 
 #ifdef CFG_STM32_RNG
-#define RNG1_RESET_TIMEOUT_US		1000
 #define PRNG_SEED_SIZE			16
-
 void plat_rng_init(void)
 {
 	vaddr_t rng = (vaddr_t)phys_to_virt(RNG1_BASE, MEM_AREA_IO_SEC);
-	vaddr_t rcc = stm32_rcc_base();
-	uint64_t timeout_ref = timeout_init_us(RNG1_RESET_TIMEOUT_US);
 	uint8_t seed[PRNG_SEED_SIZE] = { };
-	size_t size = 0;
+	size_t size = sizeof(seed);
 
-	assert(cpu_mmu_enabled());
+	/* Cannot use clock/reset drivers: these are not initialized yet */
+	stm32mp_rcc_raw_setup_rng1();
 
-	/* Clock/reset drivers are not probed yet: prepare RNG1 */
-	io_setbits32(rcc + RCC_MP_AHB5ENSETR, RCC_MP_AHB5ENSETR_RNG1EN);
-	io_setbits32(rcc + RCC_MP_AHB5LPENCLRR, RCC_MP_AHB5LPENSETR_RNG1LPEN);
-	io_setbits32(rcc + RCC_AHB5RSTSETR, RCC_AHB5RSTSETR_RNG1RST);
-	while (!(io_read32(rcc + RCC_AHB5RSTSETR) & RCC_AHB5RSTSETR_RNG1RST))
-		if (timeout_elapsed(timeout_ref))
-			panic();
-	io_setbits32(rcc + RCC_AHB5RSTCLRR, RCC_AHB5RSTSETR_RNG1RST);
-	while (io_read32(rcc + RCC_AHB5RSTSETR) & RCC_AHB5RSTSETR_RNG1RST)
-		if (timeout_elapsed(timeout_ref))
-			panic();
-
-	size = sizeof(seed);
 	if (stm32_rng_read_raw(rng, seed, &size))
 		panic();
 	if (size != sizeof(seed))
 		panic();
-
 	if (crypto_rng_init(seed, sizeof(seed)))
 		panic();
 }


### PR DESCRIPTION
Initialize the core PRNG with samples from the SoC RNG during early
initialization. PRNG is used to generate random samples used early
before all services and obviously device and peripheral drivers
are initialized. Therefore the platform sequence to initialize the
PRNG locally handles RNG clock and reset without relying on clock
and reset device drivers as these are not yet initialized.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
