### PR TITLE
plat-bcm: add sotp and hwrng low lever drivers

### DIFF
--- a/core/drivers/bcm_hwrng.c
+++ b/core/drivers/bcm_hwrng.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2019 Broadcom.
+ */
+
+#include <drivers/bcm_hwrng.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <trace.h>
+
+/* Registers */
+#define RNG_CTRL_OFFSET         0x00
+#define RNG_CTRL_MASK           0x00001fff
+#define RNG_CTRL_DISABLE        0x00000000
+#define RNG_CTRL_ENABLE         0x00000001
+
+#define RNG_SOFT_RESET_OFFSET   0x04
+#define RNG_SOFT_RESET_MASK     0x00000001
+
+#define RNG_FIFO_DATA_OFFSET    0x20
+
+#define RNG_FIFO_COUNT_OFFSET   0x24
+
+#define RNG_FIFO_COUNT_MASK     0x000000ff
+#define RNG_TIMEOUT_US		10000
+
+static vaddr_t bcm_hwrng_base;
+
+static void bcm_hwrng_reset(void)
+{
+	/* Disable RBG */
+	io_clrsetbits32(bcm_hwrng_base + RNG_CTRL_OFFSET,
+			RNG_CTRL_MASK, RNG_CTRL_DISABLE);
+	/* Reset RNG and RBG */
+	io_setbits32(bcm_hwrng_base +
+		     RNG_SOFT_RESET_OFFSET, RNG_SOFT_RESET_MASK);
+	io_clrbits32(bcm_hwrng_base +
+		     RNG_SOFT_RESET_OFFSET, RNG_SOFT_RESET_MASK);
+	/* Enable RBG */
+	io_clrsetbits32(bcm_hwrng_base + RNG_CTRL_OFFSET,
+			RNG_CTRL_MASK, RNG_CTRL_ENABLE);
+}
+
+uint32_t bcm_hwrng_read_rng(uint32_t *p_out, uint32_t words_to_read)
+{
+	uint32_t available_words = 0;
+	uint32_t num_words = 0;
+	uint32_t i = 0;
+	uint64_t timeout = timeout_init_us(RNG_TIMEOUT_US);
+
+	assert(bcm_hwrng_base);
+
+	do {
+		available_words = io_read32(bcm_hwrng_base +
+					    RNG_FIFO_COUNT_OFFSET);
+		available_words = available_words & RNG_FIFO_COUNT_MASK;
+	} while (!available_words && !timeout_elapsed(timeout));
+
+	if ((available_words > 0) && (words_to_read > 0)) {
+		num_words =  MIN(available_words, words_to_read);
+		for (i = 0; i < num_words; i++)
+			p_out[i] = io_read32(bcm_hwrng_base +
+					     RNG_FIFO_DATA_OFFSET);
+	}
+
+	return num_words;
+}
+
+static TEE_Result bcm_hwrng_init(void)
+{
+	bcm_hwrng_base = (vaddr_t)phys_to_virt(HWRNG_BASE, MEM_AREA_IO_SEC);
+
+	bcm_hwrng_reset();
+
+	DMSG("bcm_hwrng init done\n");
+	return TEE_SUCCESS;
+}
+
+driver_init(bcm_hwrng_init);

--- a/core/drivers/bcm_sotp.c
+++ b/core/drivers/bcm_sotp.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2019 Broadcom.
+ */
+
+#include <assert.h>
+#include <drivers/bcm_sotp.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <util.h>
+
+#define SOTP_PROG_CONTROL			0x0
+#define SOTP_PROG_CONTROL__OTP_CPU_MODE_EN	BIT(15)
+#define SOTP_PROG_CONTROL__OTP_DISABLE_ECC	BIT(9)
+#define SOTP_ADDR__OTP_ROW_ADDR_R		6
+
+#define SOTP_ADDR				0xc
+
+#define SOTP_CTRL_0				0x10
+#define SOTP_CTRL_0__START			1
+#define SOTP_READ				0
+
+#define SOTP_STAT_0				0x18
+#define SOTP_STATUS_0__FDONE			BIT(3)
+
+#define SOTP_STATUS_1				0x1c
+#define SOTP_STATUS_1__CMD_DONE			BIT(1)
+#define SOTP_STATUS_1__ECC_DET			BIT(17)
+
+#define SOTP_RDDATA_0				0x20
+#define SOTP_RDDATA_1				0x24
+#define SOTP_ADDR_MASK				0x3ff
+
+#define SOTP_ECC_ERR_DETECT			BIT64(63)
+
+#define SOTP_TIMEOUT_US				300
+
+static vaddr_t bcm_sotp_base;
+
+static TEE_Result otp_status_done_wait(vaddr_t addr, uint32_t bit)
+{
+	uint64_t timeout = timeout_init_us(SOTP_TIMEOUT_US);
+
+	while (!(io_read32(addr) & bit))
+		if (timeout_elapsed(timeout))
+			return TEE_ERROR_BUSY;
+	return TEE_SUCCESS;
+}
+
+TEE_Result bcm_iproc_sotp_mem_read(uint32_t row_addr, uint32_t sotp_add_ecc,
+				uint64_t *rdata)
+{
+	uint64_t read_data = 0;
+	uint32_t reg_val = 0;
+	TEE_Result ret = TEE_SUCCESS;
+
+	assert(bcm_sotp_base);
+	/* Check for FDONE status */
+	ret = otp_status_done_wait((bcm_sotp_base + SOTP_STAT_0),
+				   SOTP_STATUS_0__FDONE);
+	if (ret) {
+		EMSG("FDONE status done wait failed");
+		return ret;
+	}
+
+	/* Enable OTP access by CPU */
+	io_setbits32((bcm_sotp_base + SOTP_PROG_CONTROL),
+		     SOTP_PROG_CONTROL__OTP_CPU_MODE_EN);
+
+	if (sotp_add_ecc == 1) {
+		io_clrbits32((bcm_sotp_base + SOTP_PROG_CONTROL),
+			     SOTP_PROG_CONTROL__OTP_DISABLE_ECC);
+	} else {
+		io_setbits32((bcm_sotp_base + SOTP_PROG_CONTROL),
+			     SOTP_PROG_CONTROL__OTP_DISABLE_ECC);
+	}
+
+	/* 10 bit row address */
+	reg_val = (row_addr & SOTP_ADDR_MASK) << SOTP_ADDR__OTP_ROW_ADDR_R;
+	io_write32((bcm_sotp_base + SOTP_ADDR), reg_val);
+	reg_val = SOTP_READ;
+	io_write32((bcm_sotp_base + SOTP_CTRL_0), reg_val);
+
+	/* Start bit to tell SOTP to send command to the OTP controller */
+	io_setbits32((bcm_sotp_base + SOTP_CTRL_0), SOTP_CTRL_0__START);
+
+	/* Wait for SOTP command done to be set */
+	ret = otp_status_done_wait((bcm_sotp_base + SOTP_STAT_0),
+				   SOTP_STATUS_1__CMD_DONE);
+	if (ret) {
+		EMSG("FDONE cmd done wait failed\n");
+		return ret;
+	}
+
+	DMSG("CMD Done\n");
+
+	/* Clr Start bit after command done */
+	io_clrbits32((bcm_sotp_base + SOTP_CTRL_0), SOTP_CTRL_0__START);
+	read_data = io_read32(bcm_sotp_base + SOTP_RDDATA_1);
+	read_data = ((read_data & 0x1ff) << 32);
+	read_data |= io_read32(bcm_sotp_base + SOTP_RDDATA_0);
+
+	reg_val = io_read32(bcm_sotp_base + SOTP_STATUS_1);
+	/* no ECC check till row 15 */
+	if ((row_addr > 15) && (reg_val & SOTP_STATUS_1__ECC_DET)) {
+		EMSG("SOTP ECC ERROR Detected ROW %d\n", row_addr);
+		read_data = SOTP_ECC_ERR_DETECT;
+	}
+
+	/* Command done is cleared */
+	io_setbits32((bcm_sotp_base + SOTP_STATUS_1), SOTP_STATUS_1__CMD_DONE);
+	io_clrbits32((bcm_sotp_base + SOTP_PROG_CONTROL),
+		     SOTP_PROG_CONTROL__OTP_CPU_MODE_EN);
+	DMSG("read done\n");
+
+	*rdata = read_data;
+	return ret;
+}
+
+static TEE_Result bcm_sotp_init(void)
+{
+	bcm_sotp_base = (vaddr_t)phys_to_virt(SOTP_BASE, MEM_AREA_IO_SEC);
+
+	DMSG("bcm_sotp init done\n");
+	return TEE_SUCCESS;
+}
+
+driver_init(bcm_sotp_init);

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -24,3 +24,4 @@ srcs-$(CFG_STM32_ETZPC) += stm32_etzpc.c
 srcs-$(CFG_STM32_GPIO) += stm32_gpio.c
 srcs-$(CFG_STM32_UART) += stm32_uart.c
 srcs-$(CFG_STM32_I2C) += stm32_i2c.c
+srcs-$(CFG_BCM_HWRNG) += bcm_hwrng.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -25,3 +25,4 @@ srcs-$(CFG_STM32_GPIO) += stm32_gpio.c
 srcs-$(CFG_STM32_UART) += stm32_uart.c
 srcs-$(CFG_STM32_I2C) += stm32_i2c.c
 srcs-$(CFG_BCM_HWRNG) += bcm_hwrng.c
+srcs-$(CFG_BCM_SOTP) += bcm_sotp.c

--- a/core/include/drivers/bcm_hwrng.h
+++ b/core/include/drivers/bcm_hwrng.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2019 Broadcom.
+ */
+
+#ifndef BCM_HWRNG_H
+#define BCM_HWRNG_H
+
+#include <stdlib.h>
+
+uint32_t bcm_hwrng_read_rng(uint32_t *p_out, uint32_t words_to_read);
+
+#endif /* BCM_HWRNG_H */

--- a/core/include/drivers/bcm_sotp.h
+++ b/core/include/drivers/bcm_sotp.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2019 Broadcom.
+ */
+
+#ifndef BCM_SOTP_H
+#define BCM_SOTP_H
+
+#include <stdint.h>
+#include <tee_api.h>
+
+TEE_Result bcm_iproc_sotp_mem_read(uint32_t row_addr, uint32_t sotp_add_ecc,
+				   uint64_t *rdata);
+
+#endif


### PR DESCRIPTION
Add low level sequences for sotp and hwrng ip.
TODO: use dt to populate the base address , enable disable for these devices.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
