### PR TITLE
stm32mp1: introduce shared resource support

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -44,7 +44,9 @@ CFG_STM32_UART ?= y
 # Default enable some test facitilites
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STATS ?= y
-# Non-secure UART for the output console
+
+# Non-secure UART and GPIO/pinctrl for the output console
+CFG_WITH_NSEC_GPIOS ?= y
 CFG_WITH_NSEC_UARTS ?= y
 # UART instance used for early console (0 disables early console)
 CFG_STM32_EARLY_CONSOLE_UART ?= 4

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -14,6 +14,7 @@
 /* SoC interface registers base address */
 #define BSEC_BASE			0x5c005000
 #define ETZPC_BASE			0x5c007000
+#define CRYP1_BASE			0x54001000
 #define GIC_BASE			0xa0021000ul
 #define GPIOA_BASE			0x50002000
 #define GPIOB_BASE			0x50003000
@@ -27,9 +28,16 @@
 #define GPIOJ_BASE			0x5000b000
 #define GPIOK_BASE			0x5000c000
 #define GPIOZ_BASE			0x54004000
+#define HASH1_BASE			0x54002000
+#define I2C4_BASE			0x5c002000
+#define I2C6_BASE			0x5c009000
+#define IWDG1_BASE			0x5c003000
+#define IWDG2_BASE			0x5a002000
 #define PWR_BASE			0x50001000
 #define RCC_BASE			0x50000000
 #define RNG1_BASE			0x54003000
+#define RTC_BASE			0x5c004000
+#define SPI6_BASE			0x5c001000
 #define TAMP_BASE			0x5c00a000
 #define UART1_BASE			0x5c000000
 #define UART2_BASE			0x4000e000

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -4,6 +4,7 @@
  */
 
 #include <drivers/stm32_etzpc.h>
+#include <drivers/stm32_gpio.h>
 #include <drivers/stm32mp1_etzpc.h>
 #include <drivers/stm32mp1_rcc.h>
 #include <dt-bindings/clock/stm32mp1-clks.h>
@@ -635,7 +636,19 @@ static void check_rcc_secure_configuration(void)
 		panic();
 }
 
-static TEE_Result stm32mp1_lock_shared_resources(void)
+static void set_gpio_secure_configuration(void)
+{
+	unsigned int pin = 0;
+
+	for (pin = 0; pin < get_gpioz_nbpin(); pin++) {
+		enum stm32mp_shres shres = STM32MP1_SHRES_GPIOZ(pin);
+		bool secure = stm32mp_periph_is_secure(shres);
+
+		stm32_gpio_set_secure_cfg(GPIO_BANK_Z, pin, secure);
+	}
+}
+
+static TEE_Result stm32mp1_init_shres(void)
 {
 	enum stm32mp_shres id = STM32MP1_SHRES_COUNT;
 
@@ -655,8 +668,9 @@ static TEE_Result stm32mp1_lock_shared_resources(void)
 	}
 
 	set_etzpc_secure_configuration();
+	set_gpio_secure_configuration();
 	check_rcc_secure_configuration();
 
 	return TEE_SUCCESS;
 }
-driver_init_late(stm32mp1_lock_shared_resources);
+driver_init_late(stm32mp1_init_shres);

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -1,0 +1,528 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2017-2019, STMicroelectronics
+ */
+
+#include <drivers/stm32mp1_rcc.h>
+#include <dt-bindings/clock/stm32mp1-clks.h>
+#include <initcall.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stm32_util.h>
+#include <stdbool.h>
+#include <string.h>
+
+/*
+ * Once one starts to get the resource registering state, one cannot register
+ * new resources. This ensures resource state cannot change.
+ */
+static bool registering_locked;
+
+/*
+ * Shared peripherals and resources registration
+ *
+ * Each resource assignation is stored in a table. The state defaults
+ * to PERIPH_UNREGISTERED if the resource is not explicitly assigned.
+ *
+ * Resource driver that as not embedded (a.k.a their related CFG_xxx build
+ * directive is disabled) are assigned to the non-secure world.
+ *
+ * Each IO of the GPIOZ IO can be secure or non-secure.
+ *
+ * It is the platform responsibility the ensure resource assignation
+ * matches the access permission firewalls configuration.
+ */
+enum shres_state {
+	SHRES_UNREGISTERED = 0,
+	SHRES_SECURE,
+	SHRES_NON_SECURE,
+};
+
+/* Use a byte array to store each resource state */
+static uint8_t shres_state[STM32MP1_SHRES_COUNT] = {
+#if !defined(CFG_STM32_IWDG)
+	[STM32MP1_SHRES_IWDG1] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_UART)
+	[STM32MP1_SHRES_USART1] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_SPI)
+	[STM32MP1_SHRES_SPI6] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_I2C)
+	[STM32MP1_SHRES_I2C4] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_I2C6] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_GPIO)
+	[STM32MP1_SHRES_GPIOZ(0)] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_GPIOZ(1)] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_GPIOZ(2)] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_GPIOZ(3)] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_GPIOZ(4)] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_GPIOZ(5)] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_GPIOZ(6)] = SHRES_NON_SECURE,
+	[STM32MP1_SHRES_GPIOZ(7)] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_RNG)
+	[STM32MP1_SHRES_RNG1] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_HASH)
+	[STM32MP1_SHRES_HASH1] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_CRYP)
+	[STM32MP1_SHRES_CRYP1] = SHRES_NON_SECURE,
+#endif
+#if !defined(CFG_STM32_RTC)
+	[STM32MP1_SHRES_RTC] = SHRES_NON_SECURE,
+#endif
+};
+
+static const char __maybe_unused *shres2str_id_tbl[STM32MP1_SHRES_COUNT] = {
+	[STM32MP1_SHRES_GPIOZ(0)] = "GPIOZ0",
+	[STM32MP1_SHRES_GPIOZ(1)] = "GPIOZ1",
+	[STM32MP1_SHRES_GPIOZ(2)] = "GPIOZ2",
+	[STM32MP1_SHRES_GPIOZ(3)] = "GPIOZ3",
+	[STM32MP1_SHRES_GPIOZ(4)] = "GPIOZ4",
+	[STM32MP1_SHRES_GPIOZ(5)] = "GPIOZ5",
+	[STM32MP1_SHRES_GPIOZ(6)] = "GPIOZ6",
+	[STM32MP1_SHRES_GPIOZ(7)] = "GPIOZ7",
+	[STM32MP1_SHRES_IWDG1] = "IWDG1",
+	[STM32MP1_SHRES_USART1] = "USART1",
+	[STM32MP1_SHRES_SPI6] = "SPI6",
+	[STM32MP1_SHRES_I2C4] = "I2C4",
+	[STM32MP1_SHRES_RNG1] = "RNG1",
+	[STM32MP1_SHRES_HASH1] = "HASH1",
+	[STM32MP1_SHRES_CRYP1] = "CRYP1",
+	[STM32MP1_SHRES_I2C6] = "I2C6",
+	[STM32MP1_SHRES_RTC] = "RTC",
+	[STM32MP1_SHRES_MCU] = "MCU",
+	[STM32MP1_SHRES_HSI] = "HSI",
+	[STM32MP1_SHRES_LSI] = "LSI",
+	[STM32MP1_SHRES_HSE] = "HSE",
+	[STM32MP1_SHRES_LSE] = "LSE",
+	[STM32MP1_SHRES_CSI] = "CSI",
+	[STM32MP1_SHRES_PLL1] = "PLL1",
+	[STM32MP1_SHRES_PLL1_P] = "PLL1_P",
+	[STM32MP1_SHRES_PLL1_Q] = "PLL1_Q",
+	[STM32MP1_SHRES_PLL1_R] = "PLL1_R",
+	[STM32MP1_SHRES_PLL2] = "PLL2",
+	[STM32MP1_SHRES_PLL2_P] = "PLL2_P",
+	[STM32MP1_SHRES_PLL2_Q] = "PLL2_Q",
+	[STM32MP1_SHRES_PLL2_R] = "PLL2_R",
+	[STM32MP1_SHRES_PLL3] = "PLL3",
+	[STM32MP1_SHRES_PLL3_P] = "PLL3_P",
+	[STM32MP1_SHRES_PLL3_Q] = "PLL3_Q",
+	[STM32MP1_SHRES_PLL3_R] = "PLL3_R",
+};
+
+static __maybe_unused const char *shres2str_id(enum stm32mp_shres id)
+{
+	return shres2str_id_tbl[id];
+}
+
+static const char *shres2str_state_tbl[4] __maybe_unused = {
+	[SHRES_UNREGISTERED] = "unregistered",
+	[SHRES_NON_SECURE] = "non-secure",
+	[SHRES_SECURE] = "secure",
+};
+
+static __maybe_unused const char *shres2str_state(enum stm32mp_shres id)
+{
+	return shres2str_state_tbl[id];
+}
+
+static unsigned int get_gpioz_nbpin(void)
+{
+	return STM32MP1_GPIOZ_PIN_MAX_COUNT;
+}
+
+static void register_periph(enum stm32mp_shres id, enum shres_state state)
+{
+	assert(id < STM32MP1_SHRES_COUNT &&
+	       (state == SHRES_SECURE || state == SHRES_NON_SECURE));
+
+	if (registering_locked)
+		panic();
+
+	if (shres_state[id] != SHRES_UNREGISTERED &&
+	    shres_state[id] != state) {
+		DMSG("Cannot change %s from %s to %s",
+		     shres2str_id(id),
+		     shres2str_state(shres_state[id]),
+		     shres2str_state(state));
+		panic();
+	}
+
+	if (shres_state[id] == SHRES_UNREGISTERED)
+		DMSG("Register %s as %s",
+		     shres2str_id(id), shres2str_state(state));
+
+	switch (id) {
+	case STM32MP1_SHRES_GPIOZ(0):
+	case STM32MP1_SHRES_GPIOZ(1):
+	case STM32MP1_SHRES_GPIOZ(2):
+	case STM32MP1_SHRES_GPIOZ(3):
+	case STM32MP1_SHRES_GPIOZ(4):
+	case STM32MP1_SHRES_GPIOZ(5):
+	case STM32MP1_SHRES_GPIOZ(6):
+	case STM32MP1_SHRES_GPIOZ(7):
+		if ((id - STM32MP1_SHRES_GPIOZ(0)) >= get_gpioz_nbpin()) {
+			EMSG("Invalid GPIO %u >= %u",
+			     id - STM32MP1_SHRES_GPIOZ(0), get_gpioz_nbpin());
+			panic();
+		}
+		break;
+	default:
+		break;
+	}
+
+	shres_state[id] = state;
+
+	/* Explore clock tree to lock dependencies */
+	if (state == SHRES_SECURE) {
+		switch (id) {
+		case STM32MP1_SHRES_PLL1_P:
+		case STM32MP1_SHRES_PLL1_Q:
+		case STM32MP1_SHRES_PLL1_R:
+			register_periph(STM32MP1_SHRES_PLL1, SHRES_SECURE);
+			break;
+		case STM32MP1_SHRES_PLL2_P:
+		case STM32MP1_SHRES_PLL2_Q:
+		case STM32MP1_SHRES_PLL2_R:
+			register_periph(STM32MP1_SHRES_PLL2, SHRES_SECURE);
+			break;
+		case STM32MP1_SHRES_PLL3_P:
+		case STM32MP1_SHRES_PLL3_Q:
+		case STM32MP1_SHRES_PLL3_R:
+			register_periph(STM32MP1_SHRES_PLL3, SHRES_SECURE);
+			break;
+		default:
+			/* No expected resource dependency */
+			break;
+		}
+	}
+}
+
+/* Register resource by ID */
+void stm32mp_register_secure_periph(enum stm32mp_shres id)
+{
+	register_periph(id, SHRES_SECURE);
+}
+
+void stm32mp_register_non_secure_periph(enum stm32mp_shres id)
+{
+	register_periph(id, SHRES_NON_SECURE);
+}
+
+/* Register resource by IO memory base address */
+static void register_periph_iomem(uintptr_t base, enum shres_state state)
+{
+	enum stm32mp_shres id = STM32MP1_SHRES_COUNT;
+
+	switch (base) {
+	case IWDG1_BASE:
+		id = STM32MP1_SHRES_IWDG1;
+		break;
+	case USART1_BASE:
+		id = STM32MP1_SHRES_USART1;
+		break;
+	case SPI6_BASE:
+		id = STM32MP1_SHRES_SPI6;
+		break;
+	case I2C4_BASE:
+		id = STM32MP1_SHRES_I2C4;
+		break;
+	case I2C6_BASE:
+		id = STM32MP1_SHRES_I2C6;
+		break;
+	case RTC_BASE:
+		id = STM32MP1_SHRES_RTC;
+		break;
+	case RNG1_BASE:
+		id = STM32MP1_SHRES_RNG1;
+		break;
+	case CRYP1_BASE:
+		id = STM32MP1_SHRES_CRYP1;
+		break;
+	case HASH1_BASE:
+		id = STM32MP1_SHRES_HASH1;
+		break;
+
+	/* Always non-secure resource cases */
+#ifdef CFG_WITH_NSEC_GPIOS
+	case GPIOA_BASE:
+	case GPIOB_BASE:
+	case GPIOC_BASE:
+	case GPIOD_BASE:
+	case GPIOE_BASE:
+	case GPIOF_BASE:
+	case GPIOG_BASE:
+	case GPIOH_BASE:
+	case GPIOI_BASE:
+	case GPIOJ_BASE:
+	case GPIOK_BASE:
+	/* Fall through */
+#endif
+#ifdef CFG_WITH_NSEC_UARTS
+	case USART2_BASE:
+	case USART3_BASE:
+	case UART4_BASE:
+	case UART5_BASE:
+	case USART6_BASE:
+	case UART7_BASE:
+	case UART8_BASE:
+	/* Fall through */
+#endif
+	case IWDG2_BASE:
+		/* Allow drivers to register some non-secure resources */
+		DMSG("IO for non-secure resource 0x%lx", base);
+		if (state != SHRES_NON_SECURE)
+			panic();
+
+		return;
+
+	default:
+		panic();
+		break;
+	}
+
+	register_periph(id, state);
+}
+
+void stm32mp_register_secure_periph_iomem(uintptr_t base)
+{
+	register_periph_iomem(base, SHRES_SECURE);
+}
+
+void stm32mp_register_non_secure_periph_iomem(uintptr_t base)
+{
+	register_periph_iomem(base, SHRES_NON_SECURE);
+}
+
+/* Register GPIO resource */
+void stm32mp_register_secure_gpio(unsigned int bank, unsigned int pin)
+{
+	switch (bank) {
+	case GPIO_BANK_Z:
+		assert(pin < get_gpioz_nbpin());
+		register_periph(STM32MP1_SHRES_GPIOZ(pin), SHRES_SECURE);
+		break;
+	default:
+		EMSG("GPIO bank %u cannot be secured", bank);
+		panic();
+	}
+}
+
+void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin)
+{
+	switch (bank) {
+	case GPIO_BANK_Z:
+		assert(pin < get_gpioz_nbpin());
+		register_periph(STM32MP1_SHRES_GPIOZ(pin), SHRES_NON_SECURE);
+		break;
+	default:
+		break;
+	}
+}
+
+static void lock_registering(void)
+{
+	registering_locked = true;
+}
+
+bool stm32mp_periph_is_non_secure(enum stm32mp_shres id)
+{
+	lock_registering();
+
+	return shres_state[id] == SHRES_NON_SECURE;
+}
+
+bool stm32mp_periph_is_secure(enum stm32mp_shres id)
+{
+	lock_registering();
+
+	return shres_state[id] == SHRES_SECURE;
+}
+
+bool stm32mp_periph_is_unregistered(enum stm32mp_shres id)
+{
+	lock_registering();
+
+	return shres_state[id] == SHRES_UNREGISTERED;
+}
+
+bool stm32mp_gpio_bank_is_shared(unsigned int bank)
+{
+	unsigned int non_secure = 0;
+	unsigned int pin = 0;
+
+	lock_registering();
+
+	if (bank != GPIO_BANK_Z)
+		return false;
+
+	for (pin = 0; pin < get_gpioz_nbpin(); pin++)
+		if (stm32mp_periph_is_non_secure(STM32MP1_SHRES_GPIOZ(pin)) ||
+		    stm32mp_periph_is_unregistered(STM32MP1_SHRES_GPIOZ(pin)))
+			non_secure++;
+
+	return non_secure > 0 && non_secure < get_gpioz_nbpin();
+}
+
+bool stm32mp_gpio_bank_is_non_secure(unsigned int bank)
+{
+	unsigned int non_secure = 0;
+	unsigned int pin = 0;
+
+	lock_registering();
+
+	if (bank != GPIO_BANK_Z)
+		return true;
+
+	for (pin = 0; pin < get_gpioz_nbpin(); pin++)
+		if (stm32mp_periph_is_non_secure(STM32MP1_SHRES_GPIOZ(pin)) ||
+		    stm32mp_periph_is_unregistered(STM32MP1_SHRES_GPIOZ(pin)))
+			non_secure++;
+
+	return non_secure > 0 && non_secure == get_gpioz_nbpin();
+}
+
+bool stm32mp_gpio_bank_is_secure(unsigned int bank)
+{
+	unsigned int secure = 0;
+	unsigned int pin = 0;
+
+	lock_registering();
+
+	if (bank != GPIO_BANK_Z)
+		return false;
+
+	for (pin = 0; pin < get_gpioz_nbpin(); pin++)
+		if (stm32mp_periph_is_secure(STM32MP1_SHRES_GPIOZ(pin)))
+			secure++;
+
+	return secure > 0 && secure == get_gpioz_nbpin();
+}
+
+bool stm32mp_clock_is_shareable(unsigned long clock_id)
+{
+	switch (clock_id) {
+	case GPIOZ:
+		/* GPIOZ clocking may be shared */
+		return get_gpioz_nbpin() > 0;
+	case RTCAPB:
+		/* RTCAPB clock is shared: non-secure backup registers */
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool stm32mp_clock_is_shared(unsigned long clock_id)
+{
+	lock_registering();
+
+	switch (clock_id) {
+	case GPIOZ:
+		/* GPIOZ clocking may be shared */
+		if (get_gpioz_nbpin() > 0)
+			return stm32mp_gpio_bank_is_shared(GPIO_BANK_Z);
+		else
+			return false;
+	case RTCAPB:
+		/* RTCAPB clock must be shared: non-secure backup registers */
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool stm32mp_clock_is_non_secure(unsigned long clock_id)
+{
+	enum stm32mp_shres shres_id = STM32MP1_SHRES_COUNT;
+
+	lock_registering();
+
+	if (stm32mp_clock_is_shared(clock_id))
+		return false;
+
+	switch (clock_id) {
+	case BSEC:
+	case BKPSRAM:
+	case TZPC:
+	case TZC1:
+	case TZC2:
+	case STGEN_K:
+	case DDRC1:
+	case DDRC1LP:
+	case DDRC2:
+	case DDRC2LP:
+	case DDRPHYC:
+	case DDRPHYCLP:
+	case DDRCAPB:
+	case DDRCAPBLP:
+	case AXIDCG:
+	case DDRPHYCAPB:
+	case DDRPHYCAPBLP:
+		return false;
+	case IWDG1:
+		shres_id = STM32MP1_SHRES_IWDG1;
+		break;
+	case USART1_K:
+		shres_id = STM32MP1_SHRES_USART1;
+		break;
+	case SPI6_K:
+		shres_id = STM32MP1_SHRES_SPI6;
+		break;
+	case I2C4_K:
+		shres_id = STM32MP1_SHRES_I2C4;
+		break;
+	case RNG1_K:
+		shres_id = STM32MP1_SHRES_RNG1;
+		break;
+	case HASH1:
+		shres_id = STM32MP1_SHRES_HASH1;
+		break;
+	case CRYP1:
+		shres_id = STM32MP1_SHRES_CRYP1;
+		break;
+	case I2C6_K:
+		shres_id = STM32MP1_SHRES_I2C6;
+		break;
+	case RTC:
+		shres_id = STM32MP1_SHRES_RTC;
+		break;
+	default:
+		return true;
+	}
+
+	return stm32mp_periph_is_non_secure(shres_id);
+}
+
+static TEE_Result stm32mp1_lock_shared_resources(void)
+{
+	enum stm32mp_shres id = STM32MP1_SHRES_COUNT;
+
+	lock_registering();
+
+	for (id = (enum stm32mp_shres)0; id < STM32MP1_SHRES_COUNT; id++) {
+		uint8_t __maybe_unused *state = &shres_state[id];
+
+#if TRACE_LEVEL == TRACE_INFO
+		/* Print only the secure and shared resources */
+		if (*state == SHRES_NON_SECURE || *state == SHRES_UNREGISTERED)
+			continue;
+#endif
+
+		IMSG("stm32mp %-8s (%2u): %-14s",
+		     shres2str_id(id), id, shres2str_state(*state));
+	}
+
+	return TEE_SUCCESS;
+}
+driver_init_late(stm32mp1_lock_shared_resources);

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -183,23 +183,69 @@ static void register_periph(enum stm32mp_shres id, enum shres_state state)
 
 	shres_state[id] = state;
 
-	/* Explore clock tree to lock dependencies */
+	/* Explore clock tree to lock secure clock dependencies */
 	if (state == SHRES_SECURE) {
 		switch (id) {
+		case STM32MP1_SHRES_GPIOZ(0):
+		case STM32MP1_SHRES_GPIOZ(1):
+		case STM32MP1_SHRES_GPIOZ(2):
+		case STM32MP1_SHRES_GPIOZ(3):
+		case STM32MP1_SHRES_GPIOZ(4):
+		case STM32MP1_SHRES_GPIOZ(5):
+		case STM32MP1_SHRES_GPIOZ(6):
+		case STM32MP1_SHRES_GPIOZ(7):
+			stm32mp_register_clock_parents_secure(GPIOZ);
+			break;
+		case STM32MP1_SHRES_IWDG1:
+			stm32mp_register_clock_parents_secure(IWDG1);
+			break;
+		case STM32MP1_SHRES_USART1:
+			stm32mp_register_clock_parents_secure(USART1_K);
+			break;
+		case STM32MP1_SHRES_SPI6:
+			stm32mp_register_clock_parents_secure(SPI6_K);
+			break;
+		case STM32MP1_SHRES_I2C4:
+			stm32mp_register_clock_parents_secure(I2C4_K);
+			break;
+		case STM32MP1_SHRES_RNG1:
+			stm32mp_register_clock_parents_secure(RNG1_K);
+			break;
+		case STM32MP1_SHRES_HASH1:
+			stm32mp_register_clock_parents_secure(HASH1);
+			break;
+		case STM32MP1_SHRES_CRYP1:
+			stm32mp_register_clock_parents_secure(CRYP1);
+			break;
+		case STM32MP1_SHRES_I2C6:
+			stm32mp_register_clock_parents_secure(I2C6_K);
+			break;
+		case STM32MP1_SHRES_RTC:
+			stm32mp_register_clock_parents_secure(RTC);
+			break;
 		case STM32MP1_SHRES_PLL1_P:
 		case STM32MP1_SHRES_PLL1_Q:
 		case STM32MP1_SHRES_PLL1_R:
 			register_periph(STM32MP1_SHRES_PLL1, SHRES_SECURE);
+			break;
+		case STM32MP1_SHRES_PLL1:
+			stm32mp_register_clock_parents_secure(PLL1);
 			break;
 		case STM32MP1_SHRES_PLL2_P:
 		case STM32MP1_SHRES_PLL2_Q:
 		case STM32MP1_SHRES_PLL2_R:
 			register_periph(STM32MP1_SHRES_PLL2, SHRES_SECURE);
 			break;
+		case STM32MP1_SHRES_PLL2:
+			stm32mp_register_clock_parents_secure(PLL2);
+			break;
 		case STM32MP1_SHRES_PLL3_P:
 		case STM32MP1_SHRES_PLL3_Q:
 		case STM32MP1_SHRES_PLL3_R:
 			register_periph(STM32MP1_SHRES_PLL3, SHRES_SECURE);
+			break;
+		case STM32MP1_SHRES_PLL3:
+			stm32mp_register_clock_parents_secure(PLL3);
 			break;
 		default:
 			/* No expected resource dependency */

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -260,4 +260,7 @@ bool stm32mp_clock_is_shared(unsigned long clock_id);
 /* Return true if and only if @clock_id is assigned to non-secure world */
 bool stm32mp_clock_is_non_secure(unsigned long clock_id);
 
+/* Register parent clocks of @clock (ID used in clock DT bindings) as secure */
+void stm32mp_register_clock_parents_secure(unsigned long clock_id);
+
 #endif /*__STM32_UTIL_H__*/

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -146,4 +146,118 @@ static inline int decr_refcnt(unsigned int *refcnt)
 	return decr_shrefcnt(refcnt, true);
 }
 
+/*
+ * Shared peripherals and resources registration
+ *
+ * Resources listed in enum stm32mp_shres assigned at run-time to the
+ * non-secure world, to the secure world or shared by both worlds.
+ * In the later case, there must exist a secure service in OP-TEE
+ * for the non-secure world to access the resource.
+ *
+ * Resources may be a peripheral, a bus, a clock or a memory.
+ *
+ * Shared resources driver API functions allows drivers to register the
+ * resource as secure, non-secure or shared and to get the resource
+ * assignation state.
+ */
+#define STM32MP1_SHRES_GPIOZ(i)		(STM32MP1_SHRES_GPIOZ_0 + i)
+
+enum stm32mp_shres {
+	STM32MP1_SHRES_GPIOZ_0 = 0,
+	STM32MP1_SHRES_GPIOZ_1,
+	STM32MP1_SHRES_GPIOZ_2,
+	STM32MP1_SHRES_GPIOZ_3,
+	STM32MP1_SHRES_GPIOZ_4,
+	STM32MP1_SHRES_GPIOZ_5,
+	STM32MP1_SHRES_GPIOZ_6,
+	STM32MP1_SHRES_GPIOZ_7,
+	STM32MP1_SHRES_IWDG1,
+	STM32MP1_SHRES_USART1,
+	STM32MP1_SHRES_SPI6,
+	STM32MP1_SHRES_I2C4,
+	STM32MP1_SHRES_RNG1,
+	STM32MP1_SHRES_HASH1,
+	STM32MP1_SHRES_CRYP1,
+	STM32MP1_SHRES_I2C6,
+	STM32MP1_SHRES_RTC,
+	STM32MP1_SHRES_MCU,
+	STM32MP1_SHRES_HSI,
+	STM32MP1_SHRES_LSI,
+	STM32MP1_SHRES_HSE,
+	STM32MP1_SHRES_LSE,
+	STM32MP1_SHRES_CSI,
+	STM32MP1_SHRES_PLL1,
+	STM32MP1_SHRES_PLL1_P,
+	STM32MP1_SHRES_PLL1_Q,
+	STM32MP1_SHRES_PLL1_R,
+	STM32MP1_SHRES_PLL2,
+	STM32MP1_SHRES_PLL2_P,
+	STM32MP1_SHRES_PLL2_Q,
+	STM32MP1_SHRES_PLL2_R,
+	STM32MP1_SHRES_PLL3,
+	STM32MP1_SHRES_PLL3_P,
+	STM32MP1_SHRES_PLL3_Q,
+	STM32MP1_SHRES_PLL3_R,
+	STM32MP1_SHRES_COUNT
+};
+
+/* Register resource @id as a secure peripheral */
+void stm32mp_register_secure_periph(enum stm32mp_shres id);
+
+/* Register resource @id as a non-secure peripheral */
+void stm32mp_register_non_secure_periph(enum stm32mp_shres id);
+
+/*
+ * Register resource identified by @base as a secure peripheral
+ * @base: IOMEM physical base address of the resource
+ */
+void stm32mp_register_secure_periph_iomem(uintptr_t base);
+
+/*
+ * Register resource identified by @base as a non-secure peripheral
+ * @base: IOMEM physical base address of the resource
+ */
+void stm32mp_register_non_secure_periph_iomem(uintptr_t base);
+
+/*
+ * Register GPIO resource as a secure peripheral
+ * @bank: Bank of the target GPIO
+ * @pin: Bit position of the target GPIO in the bank
+ */
+void stm32mp_register_secure_gpio(unsigned int bank, unsigned int pin);
+
+/*
+ * Register GPIO resource as a non-secure peripheral
+ * @bank: Bank of the target GPIO
+ * @pin: Bit position of the target GPIO in the bank
+ */
+void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin);
+
+/* Return true if and only if resource @id is registered as secure */
+bool stm32mp_periph_is_secure(enum stm32mp_shres id);
+
+/* Return true if and only if the resource @id is registered as non-secure */
+bool stm32mp_periph_is_non_secure(enum stm32mp_shres id);
+
+/* Return true if and only if the resource @id is not registered */
+bool stm32mp_periph_is_unregistered(enum stm32mp_shres id);
+
+/* Return true if and only if GPIO bank @bank is registered as secure */
+bool stm32mp_gpio_bank_is_secure(unsigned int bank);
+
+/* Return true if and only if GPIO bank @bank is registered as shared */
+bool stm32mp_gpio_bank_is_shared(unsigned int bank);
+
+/* Return true if and only if GPIO bank @bank is registered as non-secure */
+bool stm32mp_gpio_bank_is_non_secure(unsigned int bank);
+
+/* Return true if and only if @clock_id is shareable */
+bool stm32mp_clock_is_shareable(unsigned long clock_id);
+
+/* Return true if and only if @clock_id is shared by secure and non-secure */
+bool stm32mp_clock_is_shared(unsigned long clock_id);
+
+/* Return true if and only if @clock_id is assigned to non-secure world */
+bool stm32mp_clock_is_non_secure(unsigned long clock_id);
+
 #endif /*__STM32_UTIL_H__*/

--- a/core/arch/arm/plat-stm32mp1/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/sub.mk
@@ -2,6 +2,7 @@ global-incdirs-y += .
 
 srcs-y += main.c
 srcs-y += reset.S
+srcs-y += shared_resources.c
 
 subdirs-y += drivers
 subdirs-y += pm


### PR DESCRIPTION
This series introduces shared resources for stm32mp1. Some platform resources can be assigned to the secure or the non-secure world according to platform configuration. As platform is configured at boot time thanks to device tree technology, assignation of resource is done during the core inits. Note some resource cannot be assigned to secure world.

Each driver is responsible for registering itself as secure or non-secure during its initialization. Note that core may register non-secure resource in secure world, for example when shared a UART console with the non-secure world and its related pin muxing (GPIO driver controls stm32mp1 pin control)

1st commit "stm32mp1: shres: registering shared resources" introduces the drivers used to saves the resources assignation. Shared peripherals that are not embedded or not registered by core are de-facto assign to the non-secure world.

2nd commit "stm32mp1: shres: secure clock parents" propagates secure assignation to parent clocks for clocks assigned to the secure world.

3rd commit "stm32mp1: shres: check RCC secure hardening" ensures RCC configuration matches clock secure states.

4th commit "stm32mp1: shres: configure ETZPC protection" configures the platform ETZPC access control according to resource assignation.

5th commit "stm32mp1: shres: set GPIO secure hardening" configures platform GPIO access control according to resource assignation.

Further related change will follow since the P-R is finalized, as restoration of harden configuration when resuming from a low power state where RCC/ETZPC/GPIO HW state is lost.