### PR TITLE
Error out if CFG_ULIBS_GPROF and CFG_ULIBS_SHARED are both enabled

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -370,6 +370,17 @@ endif
 #   in the same way as TAs so that they can be found at runtime.
 CFG_ULIBS_SHARED ?= n
 
+ifeq (yy,$(CFG_ULIBS_GPROF)$(CFG_ULIBS_SHARED))
+# FIXME:
+# If both are enabled, the linker will report an error when linking a TA:
+#  ta.lds:19: unresolvable symbol `__utee_mcount' referenced in expression
+# The allocation of the profiling buffer should probably be done at runtime
+# via a new syscall/PTA call instead of having it pre-allocated in .bss by the
+# linker, which is hackish. When the TA link script is processed, there is no
+# way the linker can tell if some file in some shared library uses -pg anyway.
+$(error CFG_ULIBS_GPROF and CFG_ULIBS_SHARED are incompatible)
+endif
+
 # CFG_GP_SOCKETS
 # Enable Global Platform Sockets support
 CFG_GP_SOCKETS ?= y


### PR DESCRIPTION
When CFG_ULIBS_GPROF=y, the TA linker script references the
__utee_mcount symbol, which is external to the TA if libutee is built
as a shared library. This causes the following link error:

 ta.lds:19: unresolvable symbol `__utee_mcount' referenced in expression

It should quite easy to get rid of the allocation of the profiling
buffer in the TA's .bss segment, once we have a syscall (or a PTA
command) to allocate and map TA memory from the TEE core. Until then,
let's just prvent the incompatible configuration. Profiling is just a
debugging tool, so it should not be a problem to force static linking in
that case.

Fixes: 64718c936163 ("Allow building libutils etc. as shared libraries")
Reported-by: Sumit Garg <sumit.garg@linaro.org>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
