### PR TITLE
gprof: define original mcount APIs inserted by compiler

### DIFF
--- a/lib/libutee/arch/arm/gprof/gprof_a32.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a32.S
@@ -23,11 +23,8 @@
  * stored on the top of the stack. The callee, i.e. the instrumented function
  * itself, is determined from the current value of lr. Then we call:
  *   void __mcount_internal(void *frompc, void *selfpc);
- *
- * __gnu_mcount_nc is defined and set to the value of this function by the
- * TA linker script, only if__gnu_mcount_nc is referenced
  */
-FUNC __utee_mcount, :
+FUNC __gnu_mcount_nc, :
 	stmdb		sp!, {r0-r3, lr}
 	ldr		r0, [sp, #20]		/* lr of instrumented func */
 	mcount_adj_pc	r0, r0
@@ -35,20 +32,6 @@ FUNC __utee_mcount, :
 	bl		__mcount_internal
 	ldmia		sp!, {r0-r3, ip, lr}
 	bx		ip
-END_FUNC __utee_mcount
-
-#else /* !CFG_TA_GPROF_SUPPORT */
-
-/*
- * The TA linker script always references __utee_mcount so provide a version
- * that just pops one register (lr) off the stack, since that's the ABI we must
- * follow.
- */
-	.weak __utee_mcount
-FUNC __utee_mcount, :
-	push		{lr}
-	pop		{ip, lr}
-	bx		ip
-END_FUNC __utee_mcount
+END_FUNC __gnu_mcount_nc
 
 #endif /* CFG_TA_GPROF_SUPPORT */

--- a/lib/libutee/arch/arm/gprof/gprof_a64.S
+++ b/lib/libutee/arch/arm/gprof/gprof_a64.S
@@ -17,7 +17,7 @@
 .endm
 
 /*
- * void __utee_mcount(void *return_address)
+ * void _mcount(void *return_address)
  * @return_address: return address to instrumented function
  *
  * With the -pg option, the compiler inserts a call to _mcount into
@@ -27,11 +27,8 @@
  * instrumented function itself, is determined from the current value of x30.
  * Then we call:
  *   void __mcount_internal(void *frompc, void *selfpc);
- *
- * _mcount is defined and set to the value of this function by the linker
- * script if the TA is instrumented, i.e., if _mcount is referenced
  */
-FUNC __utee_mcount, :
+FUNC _mcount, :
 	stp		x29, x30, [sp, #-16]!
 	mov		x29, sp
 	adjust_pc	x0, x0
@@ -39,17 +36,6 @@ FUNC __utee_mcount, :
 	bl		__mcount_internal
 	ldp		x29, x30, [sp], #16
 	ret
-END_FUNC __utee_mcount
-
-#else /* !CFG_TA_GPROF_SUPPORT */
-
-/*
- * The TA linker script always references __utee_mcount so provide a version
- * that does nothing
- */
-	.weak __utee_mcount
-FUNC __utee_mcount, :
-	ret
-END_FUNC __utee_mcount
+END_FUNC _mcount
 
 #endif /* CFG_TA_GPROF_SUPPORT */

--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -16,19 +16,6 @@
 #include <malloc.h>
 #include "tee_api_private.h"
 
-/*
- * Pull in symbol __utee_mcount.
- * This symbol is implemented in assembly in its own compilation unit, and is
- * never referenced except by the linker script (in a PROVIDE() command).
- * Because the compilation units are packed into an archive (libutee.a), the
- * linker will discard the compilation units that are not explicitly
- * referenced. AFAICT this occurs *before* the linker processes the PROVIDE()
- * command, resulting in an "undefined symbol" error. We avoid this by
- * adding an explicit reference here.
- */
-extern uint8_t __utee_mcount[];
-void *_ref__utee_mcount __unused = &__utee_mcount;
-
 struct ta_session {
 	uint32_t session_id;
 	void *session_ctx;

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -39,7 +39,6 @@ SECTIONS {
 		*(.gnu.linkonce.t.*)
 		/* Workaround for an erratum in ARM's VFP11 coprocessor */
 		*(.vfp11_veneer)
-		PROVIDE(MCOUNT_SYM = __utee_mcount);
 		__text_end = .;
 	}
         .plt : { *(.plt) }
@@ -91,8 +90,6 @@ SECTIONS {
 		 * TA profiling with gprof
 		 * Reserve some space for the profiling buffer, only if the
 		 * TA is instrumented (i.e., some files were built with -pg).
-		 * Note that PROVIDE() above defines a symbol only if it is
-		 * referenced in the object files.
 		 * This also provides a way to detect at runtime if the TA is
 		 * instrumented or not.
 		 */


### PR DESCRIPTION
Define original mcount APIs: _mcount (for aarch64) and __gnu_mcount_nc
(for arm) inserted by compiler instead of providing them via
__utee_mcount API.

As linker treats __utee_mcount as normal symbol which may be discarded
(in case its defined in static library) or undetected (in case its
defined in shared library) leading unresolvable symbol linker error.

Fixes: 64718c9 ("Allow building libutils etc. as shared libraries")
Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
