### PR TITLE
core: kernel_generic_entry_a64.S: support CFG_DT_ADDR

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -54,7 +54,11 @@
 
 FUNC _start , :
 	mov	x19, x0		/* Save pagable part address */
+#if defined(CFG_DT_ADDR)
+	ldr     x20, =CFG_DT_ADDR
+#else
 	mov	x20, x2		/* Save DT address */
+#endif
 
 	adr	x0, reset_vect_table
 	msr	vbar_el1, x0


### PR DESCRIPTION
Add CFG_DT_ADDR for a64 to override the DT address passing
through arg2.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
