### PR TITLE
Add TAILQ_ENTRY() to typedefs.checkpatch

### DIFF
--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -29,5 +29,6 @@ TEE_BigIntFMMContext
 TEE_BigIntFMM
 TEE_BigInt
 TEE_Attribute
+TAILQ_ENTRY\(.*\)
 mbedtls_mpi_uint
 mbedtls_mpi


### PR DESCRIPTION
When using BSD queues from <sys/queues.h>, a queue entry is declared
with a macro:

 TAILQ_ENTRY(type) var;

This makes checkpatch.pl unhappy because the type is unknown:

 WARNING: Missing a blank line after declarations
 #52: FILE: core/arch/arm/include/mm/tee_pager.h:32:
 +	struct pgt *pgt;
 +	TAILQ_ENTRY(tee_pager_area) link;

This patch adds a regular expression to typedefs.chackpatch that
matches the macro part, thus fixing the warning.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
