### PR TITLE
core: add CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -44,6 +44,15 @@ CFG_CORE_WORKAROUND_SPECTRE_BP ?= y
 # secure EL0 instead of non-secure world.
 CFG_CORE_WORKAROUND_SPECTRE_BP_SEC ?= $(CFG_CORE_WORKAROUND_SPECTRE_BP)
 
+# Adds protection against a tool like Cachegrab
+# (https://github.com/nccgroup/cachegrab), which uses non-secure interrupts
+# to prime and later analyze the L1D, L1I and BTB caches to gain
+# information from secure world execution.
+CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME ?= y
+ifeq ($(CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME),y)
+$(call force,CFG_CORE_WORKAROUND_SPECTRE_BP,y,Required by CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME)
+endif
+
 CFG_CORE_RWDATA_NOEXEC ?= y
 CFG_CORE_RODATA_NOEXEC ?= n
 ifeq ($(CFG_CORE_RODATA_NOEXEC),y)

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -10,6 +10,7 @@
 #include <generated/asm-defines.h>
 #include <keep.h>
 #include <kernel/abort.h>
+#include <kernel/cache_helpers.h>
 #include <kernel/thread_defs.h>
 #include <kernel/unwind.h>
 #include <mm/core_mmu.h>
@@ -750,6 +751,17 @@ END_FUNC thread_unwind_user_mode
 	mov	r0, sp
 	cps	#CPSR_MODE_SVC
 	mov	sp, r0
+
+#ifdef CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME
+	/*
+	 * Prevent leaking information about which entries has been used in
+	 * cache. We're relying on the secure monitor/dispatcher to take
+	 * care of the BTB.
+	 */
+	mov	r0, #DCACHE_OP_CLEAN_INV
+	bl	dcache_op_louis
+	write_iciallu
+#endif
 
 	ldr	r0, =TEESMC_OPTEED_RETURN_CALL_DONE
 	ldr	r1, =OPTEE_SMC_RETURN_RPC_FOREIGN_INTR

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -8,6 +8,7 @@
 #include <asm.S>
 #include <generated/asm-defines.h>
 #include <keep.h>
+#include <kernel/cache_helpers.h>
 #include <kernel/thread_defs.h>
 #include <mm/core_mmu.h>
 #include <smccc.h>
@@ -1072,6 +1073,16 @@ END_FUNC el0_sync_abort
 	msr	spsel, #0
 	mov	sp, x1
 
+#ifdef CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME
+	/*
+	 * Prevent leaking information about which entries has been used in
+	 * cache. We're relying on the dispatcher in TF-A to take care of
+	 * the BTB.
+	 */
+	mov	x0, #DCACHE_OP_CLEAN_INV
+	bl	dcache_op_louis
+	ic	iallu
+#endif
 	/*
 	 * Mark current thread as suspended
 	 */

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -135,6 +135,21 @@ UNWIND(	.cantunwind)
 	add     r0, sp, #(SM_CTX_NSEC + SM_NSEC_CTX_R8)
 	ldm	r0, {r8-r12}
 
+#ifdef CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME
+	/*
+	 * Prevent leaking information about which code has been executed.
+	 * This is required to be used together with
+	 * CFG_CORE_WORKAROUND_SPECTRE_BP to protect Cortex A15 CPUs too.
+	 *
+	 * CFG_CORE_WORKAROUND_SPECTRE_BP also invalidates the branch
+	 * predictor on affected CPUs. In the cases where an alternative
+	 * vector has been installed the branch predictor is already
+	 * invalidated so invalidating here again would be redundant, but
+	 * testing for that is more trouble than it's worth.
+	 */
+	write_bpiall
+#endif
+
 	/* Update SCR */
 	read_scr r0
 	orr	r0, r0, #(SCR_NS | SCR_FIQ) /* Set NS and FIQ bit in SCR */


### PR DESCRIPTION
Adds CFG_CORE_WORKAROUND_NSITR_CACHE_PRIME which if 'y' enables
protection against a tool like Cachegrab
(https://github.com/nccgroup/cachegrab), which uses non-secure
interrupts to prime and later analyze the L1D, L1I and BTB caches to
gain information from secure world execution.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
