### PR TITLE
Error out if CFG_TA_GPROF_SUPPORT and CFG_ULIBS_SHARED are both enabled

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -370,6 +370,19 @@ endif
 #   in the same way as TAs so that they can be found at runtime.
 CFG_ULIBS_SHARED ?= n
 
+ifeq (yy,$(CFG_TA_GPROF_SUPPORT)$(CFG_ULIBS_SHARED))
+# FIXME:
+# TA profiling with gprof does not work well with shared libraries (not limited
+# to CFG_ULIBS_SHARED=y actually), because the total .text size is not known at
+# link time. The symptom is an error trace when the TA starts (and no gprof
+# output is produced):
+#  E/TA: __utee_gprof_init:159 gprof: could not allocate profiling buffer
+# The allocation of the profiling buffer should probably be done at runtime
+# via a new syscall/PTA call instead of having it pre-allocated in .bss by the
+# linker.
+$(error CFG_TA_GPROF_SUPPORT and CFG_ULIBS_SHARED are currently incompatible)
+endif
+
 # CFG_GP_SOCKETS
 # Enable Global Platform Sockets support
 CFG_GP_SOCKETS ?= y


### PR DESCRIPTION
The gprof sample buffer is currently allocated at link time by the TA
linker script: ta/arch/arm/ta.ld.S. The size of the buffer is a
function of the total TA code size (.text segment). While this works
fine for statically linked TAs, it is problematic when shared libraries
are used, because in this case the total .text size is not known at
link time. As a result, the pre-allocated buffer may be too small,
resulting in the following error when the TA is initialized:

 E/TA:  __utee_gprof_init:159 gprof: could not allocate profiling buffer

One way to fix this problem is to allocate the buffer at run time, once
all the shared libraries have been loaded. Since the TA loader is about
to be reworked and moved to user space, let's wait for this to occur
before implementing a long term solution. This commit just prohibits the
problematic configuration in mk/config.mk.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
