### PR TITLE
Master+imx caam fix

### DIFF
--- a/core/arch/arm/plat-imx/imx6.c
+++ b/core/arch/arm/plat-imx/imx6.c
@@ -79,5 +79,6 @@ void plat_cpu_reset_late(void)
 		     addr += 4)
 			io_setbits32(addr, CSU_SETTING_LOCK);
 		imx_configure_tzasc();
+		init_caam();
 	}
 }

--- a/core/arch/arm/plat-imx/imx6ul.c
+++ b/core/arch/arm/plat-imx/imx6ul.c
@@ -7,6 +7,7 @@
 
 #include <arm32.h>
 #include <io.h>
+#include <imx_caam.h>
 #include <kernel/generic_boot.h>
 #include <platform_config.h>
 #include <stdint.h>
@@ -32,4 +33,5 @@ static void init_csu(void)
 void plat_cpu_reset_late(void)
 {
 	init_csu();
+	init_caam();
 }

--- a/core/arch/arm/plat-imx/imx7.c
+++ b/core/arch/arm/plat-imx/imx7.c
@@ -9,6 +9,7 @@
 #include <console.h>
 #include <drivers/imx_uart.h>
 #include <drivers/tzc380.h>
+#include <imx_caam.h>
 #include <io.h>
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
@@ -61,4 +62,7 @@ void plat_cpu_reset_late(void)
 	for (addr = CSU_CSL_START; addr != CSU_CSL_END; addr += 4)
 		io_setbits32(core_mmu_get_va(addr, MEM_AREA_IO_SEC),
 			     CSU_SETTING_LOCK);
+
+	/* Set CAAM job-ring permissions to non-secure by default */
+	init_caam();
 }

--- a/core/arch/arm/plat-imx/imx_caam.c
+++ b/core/arch/arm/plat-imx/imx_caam.c
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2019 Bryan O'Donoghue
+ *
+ * Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+ */
+
+#include <io.h>
+#include <imx_caam.h>
+#include <kernel/generic_boot.h>
+#include <platform_config.h>
+#include <stdint.h>
+
+void init_caam(void)
+{
+	struct imx_caam_ctrl *caam = (struct caam_ctrl *)CAAM_BASE;
+	uint32_t reg;
+	int i;
+
+	/*
+	 * Set job-ring ownership to non-secure by default.
+	 * A Linux kernel that runs after OP-TEE will run in normal-world
+	 * so we want to enable that kernel to have total ownership of the
+	 * CAAM job-rings.
+	 *
+	 * It is possible to use CAAM job-rings inside of OP-TEE i.e. in
+	 * secure world code but, to do that OP-TEE and kernel should agree
+	 * via a DTB which job-rings are owned by OP-TEE and which are
+	 * owned by Kernel, something that the OP-TEE CAAM driver should
+	 * set up.
+	 *
+	 * This code below simply sets a default for the case where no
+	 * runtime OP-TEE CAAM code will be run
+	 */
+	for (i = 0; i < CAAM_NUM_JOB_RINGS; i++) {
+		reg = io_read32((vaddr_t)&caam->jr[i].jrmidr_ms);
+		reg |= JROWN_NS | JROWN_MID;
+		io_write32((vaddr_t)&caam->jr[i].jrmidr_ms, reg);
+	}
+}

--- a/core/arch/arm/plat-imx/imx_caam.h
+++ b/core/arch/arm/plat-imx/imx_caam.h
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2019 Bryan O'Donoghue
+ *
+ * Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+ */
+
+#ifndef __IMX_CAAM_H__
+#define __IMX_CAAM_H__
+
+#include <imx-regs.h>
+#include <stdint.h>
+
+struct imx_caam_job_ring {
+	uint32_t			jrmidr_ms;
+	uint32_t			jrmidr_ls;
+};
+
+#define CAAM_NUM_JOB_RINGS		4
+
+/* CAAM ownersip definition bits */
+#define JROWN_NS			BIT(3)
+#define JROWN_MID			0x01
+
+/* A basic sub-set of the CAAM */
+struct imx_caam_ctrl {
+	uint32_t			res0;
+	uint32_t			mcfgr;
+	uint32_t			res1;
+	uint32_t			scfgr;
+	struct imx_caam_job_ring	jr[CAAM_NUM_JOB_RINGS];
+};
+
+void init_caam(void);
+
+#endif /* __IMX_CAAM_H__ */

--- a/core/arch/arm/plat-imx/sub.mk
+++ b/core/arch/arm/plat-imx/sub.mk
@@ -1,7 +1,7 @@
 global-incdirs-y += .
 srcs-y += main.c
 
-srcs-$(CFG_MX6)$(CFG_MX7) += mmdc.c imx-common.c
+srcs-$(CFG_MX6)$(CFG_MX7) += mmdc.c imx-common.c imx_caam.c
 
 srcs-$(CFG_PL310) += imx_pl310.c
 ifeq ($(CFG_PSCI_ARM32),y)


### PR DESCRIPTION
This series 

1. Adds a simple set of routines to set the CAAM job-rings to normal world
2. Calls that routine for i.MX6 and i.MX7 processors.

This is not a full fledged CAAM driver, which both NXP and Microsoft have written but, not thus far upstreamed code for. This is simply about setting the default permissions of the CAAM.

The expectation is that a full CAAM driver will assign some job-rings to secure and some job-rings to normal world and will communicate job-ring ownership via DTB settings.

Setting job-ring ownership when transitioning from secure to non-secure world is best done in OPTEE rather than u-boot and so if this code is applied in OP-TEE the next step is to stop setting job-ring permissions in u-boot.