### PR TITLE
stm32mp1: remove stm32mp_periph_is_unregistered()

### DIFF
--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -657,13 +657,7 @@ static TEE_Result stm32mp1_init_shres(void)
 	for (id = (enum stm32mp_shres)0; id < STM32MP1_SHRES_COUNT; id++) {
 		uint8_t __maybe_unused *state = &shres_state[id];
 
-#if TRACE_LEVEL == TRACE_INFO
-		/* Print only the secure and shared resources */
-		if (*state == SHRES_NON_SECURE || *state == SHRES_UNREGISTERED)
-			continue;
-#endif
-
-		IMSG("stm32mp %-8s (%2u): %-14s",
+		DMSG("stm32mp %-8s (%2u): %-14s",
 		     shres2str_id(id), id, shres2str_state(*state));
 	}
 

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -236,12 +236,6 @@ void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin);
 /* Return true if and only if resource @id is registered as secure */
 bool stm32mp_periph_is_secure(enum stm32mp_shres id);
 
-/* Return true if and only if the resource @id is registered as non-secure */
-bool stm32mp_periph_is_non_secure(enum stm32mp_shres id);
-
-/* Return true if and only if the resource @id is not registered */
-bool stm32mp_periph_is_unregistered(enum stm32mp_shres id);
-
 /* Return true if and only if GPIO bank @bank is registered as secure */
 bool stm32mp_gpio_bank_is_secure(unsigned int bank);
 


### PR DESCRIPTION
Change `stm32mp_periph_is_non_secure()` to cover unregistered and non-secure registered resources. This allows to remove `stm32mp_periph_is_unregistered()` that also relates to non-secure
resources.

This change also lowers verbosity of shared resource registration trace from info to debug log level.