### PR TITLE
stm32mp1: clean shared resource to use vaddr_t

### DIFF
--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -269,7 +269,7 @@ void stm32mp_register_non_secure_periph(enum stm32mp_shres id)
 }
 
 /* Register resource by IO memory base address */
-static void register_periph_iomem(uintptr_t base, enum shres_state state)
+static void register_periph_iomem(vaddr_t base, enum shres_state state)
 {
 	enum stm32mp_shres id = STM32MP1_SHRES_COUNT;
 
@@ -343,12 +343,12 @@ static void register_periph_iomem(uintptr_t base, enum shres_state state)
 	register_periph(id, state);
 }
 
-void stm32mp_register_secure_periph_iomem(uintptr_t base)
+void stm32mp_register_secure_periph_iomem(vaddr_t base)
 {
 	register_periph_iomem(base, SHRES_SECURE);
 }
 
-void stm32mp_register_non_secure_periph_iomem(uintptr_t base)
+void stm32mp_register_non_secure_periph_iomem(vaddr_t base)
 {
 	register_periph_iomem(base, SHRES_NON_SECURE);
 }

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -10,6 +10,7 @@
 #include <drivers/stm32_bsec.h>
 #include <kernel/panic.h>
 #include <stdint.h>
+#include <types_ext.h>
 
 /* Backup registers and RAM utils */
 vaddr_t stm32mp_bkpreg(unsigned int idx);
@@ -211,13 +212,13 @@ void stm32mp_register_non_secure_periph(enum stm32mp_shres id);
  * Register resource identified by @base as a secure peripheral
  * @base: IOMEM physical base address of the resource
  */
-void stm32mp_register_secure_periph_iomem(uintptr_t base);
+void stm32mp_register_secure_periph_iomem(vaddr_t base);
 
 /*
  * Register resource identified by @base as a non-secure peripheral
  * @base: IOMEM physical base address of the resource
  */
-void stm32mp_register_non_secure_periph_iomem(uintptr_t base);
+void stm32mp_register_non_secure_periph_iomem(vaddr_t base);
 
 /*
  * Register GPIO resource as a secure peripheral


### PR DESCRIPTION
Replace type uintptr_t with type vaddr_t when applicable for consistency
with other resources.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
