### PR TITLE
Release resources in case of panicked instance #2

### DIFF
--- a/core/arch/arm/include/tee/entry_std.h
+++ b/core/arch/arm/include/tee/entry_std.h
@@ -12,4 +12,7 @@
 /* Standard call entry */
 void tee_entry_std(struct thread_smc_args *args);
 
+/* Get list head for sessions opened from non-secure */
+void nsec_sessions_list_head(struct tee_ta_session_head **open_sessions);
+
 #endif /* TEE_ENTRY_STD_H */

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -525,7 +525,7 @@ static void set_ta_ctx_ops(struct tee_ta_ctx *ctx)
 
 bool is_user_ta_ctx(struct tee_ta_ctx *ctx)
 {
-	return ctx->ops == _user_ta_ops;
+	return ctx && ctx->ops == _user_ta_ops;
 }
 
 static TEE_Result check_ta_store(void)

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -817,9 +817,9 @@ void tee_mmu_set_ctx(struct tee_ta_ctx *ctx)
 	 *
 	 * Save translation tables in a cache if it's a user TA.
 	 */
-	pgt_free(&tsd->pgt_cache, tsd->ctx && is_user_ta_ctx(tsd->ctx));
+	pgt_free(&tsd->pgt_cache, is_user_ta_ctx(tsd->ctx));
 
-	if (ctx && is_user_ta_ctx(ctx)) {
+	if (is_user_ta_ctx(ctx)) {
 		struct core_mmu_user_map map;
 		struct user_ta_ctx *utc = to_user_ta_ctx(ctx);
 

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -581,7 +581,7 @@ static struct tee_pager_area *find_uta_area(vaddr_t va)
 {
 	struct tee_ta_ctx *ctx = thread_get_tsd()->ctx;
 
-	if (!ctx || !is_user_ta_ctx(ctx))
+	if (!is_user_ta_ctx(ctx))
 		return NULL;
 	return find_area(to_user_ta_ctx(ctx)->areas, va);
 }

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -529,6 +529,11 @@ static struct mobj *get_cmd_buffer(paddr_t parg, uint32_t *num_params)
 	return mobj_shm_alloc(parg, args_size, 0);
 }
 
+void nsec_sessions_list_head(struct tee_ta_session_head **open_sessions)
+{
+	*open_sessions = &tee_open_sessions;
+}
+
 /*
  * Note: this function is weak just to make it possible to exclude it from
  * the unpaged area.

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -23,6 +23,7 @@
 #include <mm/core_memprot.h>
 #include <mm/mobj.h>
 #include <mm/tee_mmu.h>
+#include <tee/entry_std.h>
 #include <tee/tee_svc_cryp.h>
 #include <tee/tee_obj.h>
 #include <tee/tee_svc_storage.h>
@@ -261,6 +262,84 @@ static void tee_ta_unlink_session(struct tee_ta_session *s,
 	mutex_unlock(&tee_ta_mutex);
 }
 
+static void destroy_session(struct tee_ta_session *s,
+			    struct tee_ta_session_head *open_sessions)
+{
+	tee_ta_unlink_session(s, open_sessions);
+#if defined(CFG_TA_GPROF_SUPPORT)
+	free(s->sbuf);
+#endif
+	free(s);
+}
+
+static void destroy_context(struct tee_ta_ctx *ctx)
+{
+	DMSG("Destroy TA ctx (0x%" PRIxVA ")",  (vaddr_t)ctx);
+
+	condvar_destroy(&ctx->busy_cv);
+	pgt_flush_ctx(ctx);
+	ctx->ops->destroy(ctx);
+}
+
+static void destroy_ta_ctx_from_session(struct tee_ta_session *s)
+{
+	struct tee_ta_session *sess = NULL;
+	struct tee_ta_session_head *open_sessions = NULL;
+	struct tee_ta_ctx *ctx = NULL;
+	struct user_ta_ctx *utc = NULL;
+	size_t count = 1; /* start counting the references to the context */
+
+	DMSG("Remove references to context (0x%" PRIxVA ")", (vaddr_t)s->ctx);
+
+	mutex_lock(&tee_ta_mutex);
+	nsec_sessions_list_head(&open_sessions);
+
+	/*
+	 * Next two loops will remove all references to the context which is
+	 * about to be destroyed, but avoiding such operation to the current
+	 * session. That will be done later in this function, only after
+	 * the context will be properly destroyed.
+	 */
+
+	/*
+	 * Scan the entire list of opened sessions by the clients from
+	 * non-secure world.
+	 */
+	TAILQ_FOREACH(sess, open_sessions, link) {
+		if (sess->ctx == s->ctx && sess != s) {
+			sess->ctx = NULL;
+			count++;
+		}
+	}
+
+	/*
+	 * Scan all sessions opened from secure side by searching through
+	 * all available TA instances and for each context, scan all opened
+	 * sessions.
+	 */
+	TAILQ_FOREACH(ctx, &tee_ctxes, link) {
+		if (is_user_ta_ctx(ctx)) {
+			utc = to_user_ta_ctx(ctx);
+
+			TAILQ_FOREACH(sess, &utc->open_sessions, link) {
+				if (sess->ctx == s->ctx && sess != s) {
+					sess->ctx = NULL;
+					count++;
+				}
+			}
+		}
+	}
+
+	assert(count == s->ctx->ref_count);
+
+	TAILQ_REMOVE(&tee_ctxes, s->ctx, link);
+	mutex_unlock(&tee_ta_mutex);
+
+	destroy_context(s->ctx);
+
+	s->ctx = NULL;
+}
+
 /*
  * tee_ta_context_find - Find TA in session list based on a UUID (input)
  * Returns a pointer to the session
@@ -416,18 +495,19 @@ TEE_Result tee_ta_close_session(struct tee_ta_session *csess,
 	ctx = sess->ctx;
 	DMSG("Destroy session");
 
-	tee_ta_set_busy(ctx);
-
-	if (!ctx->panicked) {
-		set_invoke_timeout(sess, TEE_TIMEOUT_INFINITE);
-		ctx->ops->enter_close_session(sess);
+	if (!ctx) {
+		destroy_session(sess, open_sessions);
+		return TEE_SUCCESS;
 	}
 
-	tee_ta_unlink_session(sess, open_sessions);
-#if defined(CFG_TA_GPROF_SUPPORT)
-	free(sess->sbuf);
-#endif
-	free(sess);
+	assert(!ctx->panicked);
+
+	tee_ta_set_busy(ctx);
+
+	set_invoke_timeout(sess, TEE_TIMEOUT_INFINITE);
+	ctx->ops->enter_close_session(sess);
+
+	destroy_session(sess, open_sessions);
 
 	tee_ta_clear_busy(ctx);
 
@@ -440,15 +520,10 @@ TEE_Result tee_ta_close_session(struct tee_ta_session *csess,
 	keep_alive = (ctx->flags & TA_FLAG_INSTANCE_KEEP_ALIVE) &&
 			(ctx->flags & TA_FLAG_SINGLE_INSTANCE);
 	if (!ctx->ref_count && !keep_alive) {
-		DMSG("Destroy TA ctx");
-
 		TAILQ_REMOVE(&tee_ctxes, ctx, link);
 		mutex_unlock(&tee_ta_mutex);
 
-		condvar_destroy(&ctx->busy_cv);
-
-		pgt_flush_ctx(ctx);
-		ctx->ops->destroy(ctx);
+		destroy_context(ctx);
 	} else
 		mutex_unlock(&tee_ta_mutex);
 
@@ -594,7 +669,7 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 
 	ctx = s->ctx;
 
-	if (ctx->panicked) {
+	if (!ctx || ctx->panicked) {
 		DMSG("panicked, call tee_ta_close_session()");
 		tee_ta_close_session(s, open_sessions, KERN_IDENTITY);
 		*err = TEE_ORIGIN_TEE;
@@ -650,8 +725,13 @@ TEE_Result tee_ta_invoke_command(TEE_ErrorOrigin *err,
 	if (!check_params(sess, param))
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (sess->ctx->panicked) {
+	if (!sess->ctx) {
+		/* The context has been already destroyed */
+		*err = TEE_ORIGIN_TEE;
+		return TEE_ERROR_TARGET_DEAD;
+	} else if (sess->ctx->panicked) {
 		DMSG("Panicked !");
+		destroy_ta_ctx_from_session(sess);
 		*err = TEE_ORIGIN_TEE;
 		return TEE_ERROR_TARGET_DEAD;
 	}
@@ -661,12 +741,13 @@ TEE_Result tee_ta_invoke_command(TEE_ErrorOrigin *err,
 	set_invoke_timeout(sess, cancel_req_to);
 	res = sess->ctx->ops->enter_invoke_cmd(sess, cmd, param, err);
 
-	if (sess->ctx->panicked) {
-		*err = TEE_ORIGIN_TEE;
-		res = TEE_ERROR_TARGET_DEAD;
-	}
-
 	tee_ta_clear_busy(sess->ctx);
+
+	if (sess->ctx->panicked) {
+		destroy_ta_ctx_from_session(sess);
+		*err = TEE_ORIGIN_TEE;
+		return TEE_ERROR_TARGET_DEAD;
+	}
 
 	/* Short buffer is not an effective error case */
 	if (res != TEE_SUCCESS && res != TEE_ERROR_SHORT_BUFFER)

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -330,7 +330,7 @@ static bool check_params(struct tee_ta_session *sess,
 	 * When CFG_SECURE_DATA_PATH is enabled, OP-TEE entry allows SHM and
 	 * SDP memory references. Only TAs flagged SDP can access SDP memory.
 	 */
-	if (sess->ctx->flags & TA_FLAG_SECURE_DATA_PATH)
+	if (sess->ctx && sess->ctx->flags & TA_FLAG_SECURE_DATA_PATH)
 		return true;
 
 	for (n = 0; n < TEE_NUM_PARAMS; n++) {
@@ -734,7 +734,7 @@ static void update_current_ctx(struct thread_specific_data *tsd)
 	 * If ctx->mmu == NULL we must not have user mapping active,
 	 * if ctx->mmu != NULL we must have user mapping active.
 	 */
-	if (((ctx && is_user_ta_ctx(ctx) ?
+	if (((is_user_ta_ctx(ctx) ?
 			to_user_ta_ctx(ctx)->vm_info : NULL) == NULL) ==
 					core_mmu_user_mapping_is_active())
 		panic("unexpected active mapping");
@@ -786,6 +786,11 @@ static void dump_state(struct tee_ta_ctx *ctx)
 {
 	struct tee_ta_session *s = NULL;
 	bool active __maybe_unused;
+
+	if (!ctx) {
+		EMSG("No TA status: null context reference");
+		return;
+	}
 
 	active = ((tee_ta_get_current_session(&s) == TEE_SUCCESS) &&
 		  s && s->ctx == ctx);

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -854,6 +854,8 @@ TEE_Result syscall_invoke_ta_command(unsigned long ta_sess,
 
 	res = tee_ta_invoke_command(&ret_o, called_sess, &clnt_id,
 				    cancel_req_to, cmd_id, &param);
+	if (res == TEE_ERROR_TARGET_DEAD)
+		goto function_exit;
 
 	res2 = tee_svc_update_out_param(&param, tmp_buf_va, usr_param);
 	if (res2 != TEE_SUCCESS) {


### PR DESCRIPTION
This change include change commit from https://github.com/OP-TEE/optee_os/pull/2838 prepended with a preparatory change to not crash on release context reference in TEE session instances:
* "core: handle user TA context released from session": to be reviewed.
* "core: keep alive TA context can be created after TA has panicked": https://github.com/OP-TEE/optee_os/pull/2838 incluing review tags.