### PR TITLE
stm32mp1: common SoC registers protections

### DIFF
--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -27,6 +27,40 @@
 static bool registering_locked;
 
 /*
+ * Shared register access: upon shared resource lock
+ */
+static unsigned int shregs_lock = SPINLOCK_UNLOCK;
+
+/* Shared resource lock: assume not required if MMU is disabled */
+static uint32_t lock_stm32shregs(void)
+{
+	return may_spin_lock(&shregs_lock);
+}
+
+static void unlock_stm32shregs(uint32_t exceptions)
+{
+	may_spin_unlock(&shregs_lock, exceptions);
+}
+
+void io_mask32_stm32shregs(vaddr_t va, uint32_t value, uint32_t mask)
+{
+	uint32_t exceptions = lock_stm32shregs();
+
+	io_mask32(va, value, mask);
+
+	unlock_stm32shregs(exceptions);
+}
+
+void io_clrsetbits32_stm32shregs(vaddr_t va, uint32_t clr, uint32_t set)
+{
+	uint32_t exceptions = lock_stm32shregs();
+
+	io_clrsetbits32(va, clr, set);
+
+	unlock_stm32shregs(exceptions);
+}
+
+/*
  * Shared peripherals and resources registration
  *
  * Each resource assignation is stored in a table. The state defaults

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -88,6 +88,24 @@ struct stm32_bsec_static_cfg {
 void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg);
 
 /*
+ * Shared registers support: common lock for accessing SoC registers
+ * shared between several drivers.
+ */
+void io_mask32_stm32shregs(vaddr_t va, uint32_t value, uint32_t mask);
+
+static inline void io_setbits32_stm32shregs(vaddr_t va, uint32_t value)
+{
+	io_mask32_stm32shregs(va, value, value);
+}
+
+static inline void io_clrbits32_stm32shregs(vaddr_t va, uint32_t value)
+{
+	io_mask32_stm32shregs(va, 0, value);
+}
+
+void io_clrsetbits32_stm32shregs(vaddr_t va, uint32_t clr, uint32_t set);
+
+/*
  * Shared reference counter: increments by 2 on secure increment
  * request, decrements by 2 on secure decrement request. Bit #0
  * is set to 1 on non-secure increment request and reset to 0 on


### PR DESCRIPTION
Helper functions for stm32mp1 platform to access a SoC interface
register that can be accessed from several drivers and services.
They all use a common spinlock to ensure atomic update of the
register content.

Helpers: io_mask32_stm32shregs(), io_setbits32_stm32shregs(),
io_clrbits32_stm32shregs() and io_clrsetbits32_stm32shregs().

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
