### PR TITLE
stm32mp1 clocks: non-secure & shared clocks and PM

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1174,8 +1174,6 @@ void stm32mp_register_clock_parents_secure(unsigned long clock_id)
 }
 
 #ifdef CFG_EMBED_DTB
-#define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"
-
 static const char *stm32mp_osc_node_label[NB_OSC] = {
 	[_LSI] = "clk-lsi",
 	[_LSE] = "clk-lse",

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1289,6 +1289,16 @@ static void stm32mp1_clk_early_init(void)
 	if (ignored != 0)
 		IMSG("DT clock tree configurations were ignored");
 }
+#else
+static void stm32mp1_clk_early_init(void)
+{
+	vaddr_t rcc_base = stm32_rcc_base();
+
+	/* Expect booting from a secure setup */
+	if ((io_read32(rcc_base + RCC_TZCR) & RCC_TZCR_TZEN) == 0)
+		panic("RCC TZC[TZEN]");
+}
+#endif /*CFG_EMBED_DTB*/
 
 /*
  * Sync secure clock refcount after all drivers initializations.
@@ -1395,4 +1405,3 @@ static TEE_Result stm32_clk_probe(void)
 /* Setup clock support before driver initialization */
 service_init(stm32_clk_probe);
 
-#endif /*CFG_EMBED_DTB*/

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -6,9 +6,13 @@
 #ifndef __STM32MP1_RCC_H__
 #define __STM32MP1_RCC_H__
 
+#ifndef ASM
 #include <io.h>
 #include <stdbool.h>
 #include <util.h>
+#endif
+
+#define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"
 
 #define RCC_TZCR			0x00
 #define RCC_OCENSETR			0x0C

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -667,6 +667,8 @@ static TEE_Result stm32mp1_init_shres(void)
 		     shres2str_id(id), id, shres2str_state(*state));
 	}
 
+	stm32mp_update_earlyboot_clocks_state();
+
 	set_etzpc_secure_configuration();
 	set_gpio_secure_configuration();
 	check_rcc_secure_configuration();

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -67,6 +67,9 @@ bool stm32_clock_is_enabled(unsigned long id);
 void stm32_nsec_clock_enable(unsigned long id);
 void stm32_nsec_clock_disable(unsigned long id);
 
+/* Synchronise clock states after drivers initialization */
+void stm32mp_update_earlyboot_clocks_state(void);
+
 /*
  * Util for reset signal assertion/desassertion for stm32 and platform drivers
  * @id: Target peripheral ID, ID used in reset DT bindings

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -55,11 +55,17 @@ void may_spin_unlock(unsigned int *lock, uint32_t exceptions);
 /*
  * Util for clock gating and to get clock rate for stm32 and platform drivers
  * @id: Target clock ID, ID used in clock DT bindings
+ *
+ * stm32_clock_enable()/stm32_clock_disable() implicitly refer to secure
+ * clocks.
+ *
  */
 void stm32_clock_enable(unsigned long id);
 void stm32_clock_disable(unsigned long id);
 unsigned long stm32_clock_get_rate(unsigned long id);
 bool stm32_clock_is_enabled(unsigned long id);
+void stm32_nsec_clock_enable(unsigned long id);
+void stm32_nsec_clock_disable(unsigned long id);
 
 /*
  * Util for reset signal assertion/desassertion for stm32 and platform drivers

--- a/core/include/kernel/pm.h
+++ b/core/include/kernel/pm.h
@@ -134,6 +134,24 @@ static inline void register_pm_driver_cb(
 }
 
 /*
+ * Register a core service callback for generic suspend/resume.
+ * Refer to struct pm_callback_handle for description of the callbacks
+ * API.
+ *
+ * @callback: Registered callback function
+ * @handle: Registered private handle argument for the callback
+ */
+static inline void register_pm_core_service_cb(
+		TEE_Result (*callback)(
+				enum pm_op op, uint32_t pm_hint,
+				const struct pm_callback_handle *pm_handle),
+		void *handle)
+{
+	register_pm_cb(&PM_CALLBACK_HANDLE_INITIALIZER(callback, handle,
+						PM_CB_ORDER_CORE_SERVICE));
+}
+
+/*
  * Request call to registered PM callbacks
  *
  * @op: Either PM_OP_SUSPEND or PM_OP_RESUME


### PR DESCRIPTION
Note in this series that commit `core: pm: helper register_pm_core_service_cb()` is a generic change also found in #2709 and #3000.