### PR TITLE
core: fix session closure when open panicked

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -500,16 +500,15 @@ TEE_Result tee_ta_close_session(struct tee_ta_session *csess,
 		return TEE_SUCCESS;
 	}
 
-	assert(!ctx->panicked);
-
-	tee_ta_set_busy(ctx);
-
-	set_invoke_timeout(sess, TEE_TIMEOUT_INFINITE);
-	ctx->ops->enter_close_session(sess);
-
-	destroy_session(sess, open_sessions);
-
-	tee_ta_clear_busy(ctx);
+	if (ctx->panicked) {
+		destroy_session(sess, open_sessions);
+	} else {
+		tee_ta_set_busy(ctx);
+		set_invoke_timeout(sess, TEE_TIMEOUT_INFINITE);
+		ctx->ops->enter_close_session(sess);
+		destroy_session(sess, open_sessions);
+		tee_ta_clear_busy(ctx);
+	}
 
 	mutex_lock(&tee_ta_mutex);
 


### PR DESCRIPTION
Change tee_ta_close_session() function to support panicked TA contexts.
Prior this change, the function did not expect referenced context
had previously panicked. Since recent changes for reloadable keep alive
TAs, referenced below, Panic on open session does completely release
context which session closure is expected to proceed to.

Fixes: fd10f62b8210 ("core: keep alive TA context can be created after TA has panicked")

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
