### PR TITLE
core:tee: remove redundant tee_obj_attr_to_binary() calls

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -262,7 +262,6 @@ TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,
 	char *file = NULL;
 	struct tee_pobj *po = NULL;
 	struct user_ta_ctx *utc;
-	size_t attr_size;
 	const struct tee_file_operations *fops =
 			tee_svc_storage_file_ops(storage_id);
 
@@ -316,10 +315,6 @@ TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,
 	}
 
 	res = tee_svc_copy_kaddr_to_uref(obj, o);
-	if (res != TEE_SUCCESS)
-		goto oclose;
-
-	res = tee_obj_attr_to_binary(o, NULL, &attr_size);
 	if (res != TEE_SUCCESS)
 		goto oclose;
 
@@ -995,7 +990,6 @@ TEE_Result syscall_storage_obj_seek(unsigned long obj, int32_t offset,
 	TEE_Result res;
 	struct tee_ta_session *sess;
 	struct tee_obj *o;
-	size_t attr_size;
 	tee_fs_off_t new_pos;
 
 	res = tee_ta_get_current_session(&sess);
@@ -1009,10 +1003,6 @@ TEE_Result syscall_storage_obj_seek(unsigned long obj, int32_t offset,
 
 	if (!(o->info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT))
 		return TEE_ERROR_BAD_STATE;
-
-	res = tee_obj_attr_to_binary(o, NULL, &attr_size);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	switch (whence) {
 	case TEE_DATA_SEEK_SET:


### PR DESCRIPTION
Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Fixes: https://github.com/OP-TEE/optee_os/issues/3004

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
