### PR TITLE
core: fix missing unpaged constraint on mobj_with_fobj_get_pa()

### DIFF
--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -606,6 +606,7 @@ static TEE_Result mobj_with_fobj_get_pa(struct mobj *mobj, size_t offs,
 
 	return TEE_SUCCESS;
 }
+KEEP_PAGER(mobj_with_fobj_get_pa);
 
 static const struct mobj_ops mobj_with_fobj_ops __rodata_unpaged = {
 	.matches = mobj_with_fobj_matches,


### PR DESCRIPTION
`mobj_with_fobj_get_pa()` gets called when a TA crashed and core prints some information about the TA. This change ensures the function belongs to an unpaged section.
