### PR TITLE
Checkpatch fixes

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -19,12 +19,19 @@ function _checkpatch() {
 		    [ -r typedefs.checkpatch ]; then
 			typedefs_opt="--typedefsfile typedefs.checkpatch"
 		fi
+		# Use --root if supported by the checkpatch tool.
+		rootdir_opt=""
+		if $CHECKPATCH --help 2>&1 | grep -q -- --root; then
+		    local rootdir="${KERNEL_SRC_ROOT:-'.'}"
+		    rootdir_opt="--root=${rootdir}"
+		fi
 		# Ignore NOT_UNIFIED_DIFF in case patch has no diff
 		# (e.g., all paths filtered out)
 		$CHECKPATCH --quiet --ignore FILE_PATH_CHANGES \
 				--ignore GERRIT_CHANGE_ID \
 				--ignore NOT_UNIFIED_DIFF \
 				--no-tree \
+				$rootdir_opt \
 				$typedefs_opt \
 				-
 }

--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -13,9 +13,12 @@ _CP_EXCL=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
 
 function _checkpatch() {
 		# Use --typedefsfile if supported by the checkpatch tool
-		typedefs_opt="--typedefsfile typedefs.checkpatch"
-		$CHECKPATCH --help 2>&1 | grep -q -- --typedefsfile || \
-				typedefs_opt="";
+		# AND this file is present
+		typedefs_opt="";
+		if $CHECKPATCH --help 2>&1 | grep -q -- --typedefsfile &&
+		    [ -r typedefs.checkpatch ]; then
+			typedefs_opt="--typedefsfile typedefs.checkpatch"
+		fi
 		# Ignore NOT_UNIFIED_DIFF in case patch has no diff
 		# (e.g., all paths filtered out)
 		$CHECKPATCH --quiet --ignore FILE_PATH_CHANGES \


### PR DESCRIPTION
Fix 2 bugs in checkpatch.sh tool:

Fix an error if no file 'typedefs.checkpatch' present:
            No additional types will be considered - file 'typedefs.checkpatch': No such file or directory

Fix running checkpatch.pl versions, that require --root option.
