### PR TITLE
TZC380 support for MX6UL/ULL

### DIFF
--- a/core/arch/arm/plat-imx/drivers/tzc380.c
+++ b/core/arch/arm/plat-imx/drivers/tzc380.c
@@ -6,22 +6,39 @@
  * Rouven Czerwinski <entwicklung@pengutronix.de>
  */
 
+#include <config.h>
 #include <drivers/tzc380.h>
 #include <imx-regs.h>
 #include <imx.h>
 #include <mm/core_memprot.h>
 #include <mm/generic_ram_layout.h>
 
+/*
+ * TZASC2_BASE is asserted non null when used.
+ * This is needed to compile the code for i.MX6UL/L
+ * and i.MX8MQ.
+ */
+#ifndef TZASC2_BASE
+#define TZASC2_BASE			0
+#endif
+
 void imx_configure_tzasc(void)
 {
 
-	int i;
+	int i = 0;
+	int end = 1;
 	vaddr_t addr[2] = {0};
 
 	addr[0] = core_mmu_get_va(TZASC_BASE, MEM_AREA_IO_SEC);
-	addr[1] = core_mmu_get_va(TZASC2_BASE, MEM_AREA_IO_SEC);
 
-	for (i = 0; i < 2; i++) {
+	if (IS_ENABLED(CFG_MX6Q) || IS_ENABLED(CFG_MX6D) ||
+	    IS_ENABLED(CFG_MX6DL)) {
+		assert(TZASC2_BASE != 0);
+		addr[1] = core_mmu_get_va(TZASC2_BASE, MEM_AREA_IO_SEC);
+		end = 2;
+	}
+
+	for (i = 0; i < end; i++) {
 		uint8_t region = 1;
 
 		tzc_init(addr[i]);


### PR DESCRIPTION
Add support for the TZC380 found on the MX6UL.
On the MX6UL/ULL only one instance of the TZC380 can be found, add a check for this in the driver and use only one if either of the SoCs is detected.
Add the tzasc autoconfiguration for the i.MX6UL.

Tested on a Nitrogen6x and a Digi CCIMX6UL SBC Pro.