### PR TITLE
Add plat-imx flavour: digi ccimx6ulsbcpro

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -3,6 +3,7 @@ PLATFORM_FLAVOR ?= mx6ulevk
 # Get SoC associated with the PLATFORM_FLAVOR
 mx6ul-flavorlist = \
 	mx6ulevk \
+	mx6ulccimx6ulsbcpro \
 
 mx6ull-flavorlist = \
 	mx6ullevk \
@@ -163,6 +164,12 @@ endif
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx6ulevk mx6ullevk))
 CFG_DDR_SIZE ?= 0x20000000
 CFG_NS_ENTRY_ADDR ?= 0x80800000
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx6ulccimx6ulsbcpro))
+CFG_DDR_SIZE ?= 0x10000000
+CFG_NS_ENTRY_ADDR ?= 0x80800000
+CFG_UART_BASE ?= UART5_BASE
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),imx8mqevk))


### PR DESCRIPTION
The Digi CCIMX6UL SBC Pro does not fit any of the existing flavours, add a new flavour for it.
The board ships with 256MB of RAM and the default console of the SoM is Uart5.