### PR TITLE
core: RPMB FS: fix panic when RPMB partition size is 16 MiB

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1041,6 +1041,7 @@ static TEE_Result tee_rpmb_init(uint16_t dev_id)
 {
 	TEE_Result res = TEE_SUCCESS;
 	struct rpmb_dev_info dev_info;
+	uint32_t nblocks = 0;
 
 	if (!rpmb_ctx) {
 		rpmb_ctx = calloc(1, sizeof(struct tee_rpmb_ctx));
@@ -1071,12 +1072,11 @@ static TEE_Result tee_rpmb_init(uint16_t dev_id)
 		}
 
 		if (MUL_OVERFLOW(dev_info.rpmb_size_mult,
-				 RPMB_SIZE_SINGLE / RPMB_DATA_SIZE,
-				 &rpmb_ctx->max_blk_idx)) {
+				 RPMB_SIZE_SINGLE / RPMB_DATA_SIZE, &nblocks) ||
+		    SUB_OVERFLOW(nblocks, 1, &rpmb_ctx->max_blk_idx)) {
 			res = TEE_ERROR_BAD_PARAMETERS;
 			goto func_exit;
 		}
-		rpmb_ctx->max_blk_idx--;
 
 		memcpy(rpmb_ctx->cid, dev_info.cid, RPMB_EMMC_CID_SIZE);
 


### PR DESCRIPTION
The overflow check used when computing the number of the last block in
the RPMB parition is incorrect. It causes an overflow when
rpmb_size_mult is 128, that is, when the partition size is 16 MiB.
Indeed, max_blk_idx is a uint16_t and we are trying to store 65536
(= 128 * (128 * 1024) / 256).

Fix this by using a 32-bit temporary variable to hold the result of the
multiplication (the number of blocks), then subtract 1 to get the last
block number using SUB_OVERFLOW().

Fixes: ea81076f7896 ("core: RPMB FS: check for potential overflows")
Fixes: https://github.com/OP-TEE/optee_os/issues/3012
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
