### PR TITLE
core: new io_pa_or_va_secure() and io_pa_or_va_nsec()

### DIFF
--- a/core/arch/arm/include/mm/core_memprot.h
+++ b/core/arch/arm/include/mm/core_memprot.h
@@ -102,17 +102,11 @@ struct io_pa_va {
 /*
  * Helper function to return a physical or virtual address for a device,
  * depending on whether the MMU is enabled or not
+ * io_pa_or_va() uses secure mapped IO memory if found or fallback to
+ * non-secure mapped IO memory.
  */
-static inline vaddr_t io_pa_or_va(struct io_pa_va *p)
-{
-	assert(p->pa);
-	if (cpu_mmu_enabled()) {
-		if (!p->va)
-			p->va = (vaddr_t)phys_to_virt_io(p->pa);
-		assert(p->va);
-		return p->va;
-	}
-	return p->pa;
-}
+vaddr_t io_pa_or_va_secure(struct io_pa_va *p);
+vaddr_t io_pa_or_va_nsec(struct io_pa_va *p);
+vaddr_t io_pa_or_va(struct io_pa_va *p);
 
 #endif /* CORE_MEMPROT_H */

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -2022,3 +2022,39 @@ void core_mmu_init_virtualization(void)
 	virt_init_memory(static_memory_map);
 }
 #endif
+
+vaddr_t io_pa_or_va(struct io_pa_va *p)
+{
+	assert(p->pa);
+	if (cpu_mmu_enabled()) {
+		if (!p->va)
+			p->va = (vaddr_t)phys_to_virt_io(p->pa);
+		assert(p->va);
+		return p->va;
+	}
+	return p->pa;
+}
+
+vaddr_t io_pa_or_va_secure(struct io_pa_va *p)
+{
+	assert(p->pa);
+	if (cpu_mmu_enabled()) {
+		if (!p->va)
+			p->va = (vaddr_t)phys_to_virt(p->pa, MEM_AREA_IO_SEC);
+		assert(p->va);
+		return p->va;
+	}
+	return p->pa;
+}
+
+vaddr_t io_pa_or_va_nsec(struct io_pa_va *p)
+{
+	assert(p->pa);
+	if (cpu_mmu_enabled()) {
+		if (!p->va)
+			p->va = (vaddr_t)phys_to_virt(p->pa, MEM_AREA_IO_NSEC);
+		assert(p->va);
+		return p->va;
+	}
+	return p->pa;
+}

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.c
@@ -11,5 +11,5 @@ vaddr_t stm32_pwr_base(void)
 {
 	static struct io_pa_va base = { .pa = PWR_BASE };
 
-	return io_pa_or_va(&base);
+	return io_pa_or_va_secure(&base);
 }

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
@@ -32,7 +32,7 @@ vaddr_t stm32_rcc_base(void)
 {
 	static struct io_pa_va base = { .pa = RCC_BASE };
 
-	return io_pa_or_va(&base);
+	return io_pa_or_va_secure(&base);
 }
 
 static size_t reset_id2reg_offset(unsigned int id)

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -245,14 +245,14 @@ vaddr_t get_gicc_base(void)
 {
 	struct io_pa_va base = { .pa = GIC_BASE + GICC_OFFSET };
 
-	return io_pa_or_va(&base);
+	return io_pa_or_va_secure(&base);
 }
 
 vaddr_t get_gicd_base(void)
 {
 	struct io_pa_va base = { .pa = GIC_BASE + GICD_OFFSET };
 
-	return io_pa_or_va(&base);
+	return io_pa_or_va_secure(&base);
 }
 
 void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg)
@@ -284,7 +284,7 @@ static vaddr_t stm32_tamp_base(void)
 {
 	static struct io_pa_va base = { .pa = TAMP_BASE };
 
-	return io_pa_or_va(&base);
+	return io_pa_or_va_secure(&base);
 }
 
 static vaddr_t bkpreg_base(void)
@@ -302,13 +302,14 @@ vaddr_t stm32_get_gpio_bank_base(unsigned int bank)
 	static struct io_pa_va gpios_nsec_base = { .pa = GPIOS_NSEC_BASE };
 	static struct io_pa_va gpioz_base = { .pa = GPIOZ_BASE };
 
+	/* Get non-secure mapping address for GPIOZ */
 	if (bank == GPIO_BANK_Z)
-		return io_pa_or_va(&gpioz_base);
+		io_pa_or_va_nsec(&gpioz_base);
 
 	COMPILE_TIME_ASSERT(GPIO_BANK_A == 0);
 	assert(bank <= GPIO_BANK_K);
 
-	return io_pa_or_va(&gpios_nsec_base) + (bank * GPIO_BANK_OFFSET);
+	return io_pa_or_va_nsec(&gpios_nsec_base) + (bank * GPIO_BANK_OFFSET);
 }
 
 unsigned int stm32_get_gpio_bank_offset(unsigned int bank)

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -141,7 +141,7 @@ static uint32_t otp_bank_offset(uint32_t otp_id)
 
 static vaddr_t bsec_base(void)
 {
-	return io_pa_or_va(&bsec_dev.base);
+	return io_pa_or_va_secure(&bsec_dev.base);
 }
 
 static uint32_t bsec_status(void)

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -89,7 +89,7 @@ static struct etzpc_instance etzpc_dev;
 
 static vaddr_t etzpc_base(void)
 {
-	return io_pa_or_va(&etzpc_dev.base);
+	return io_pa_or_va_secure(&etzpc_dev.base);
 }
 
 static bool __maybe_unused valid_decprot_id(unsigned int id)

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -291,7 +291,7 @@ struct i2c_request {
 
 static vaddr_t get_base(struct i2c_handle_s *hi2c)
 {
-	return io_pa_or_va(&hi2c->base);
+	return io_pa_or_va_secure(&hi2c->base);
 }
 
 static void notif_i2c_timeout(struct i2c_handle_s *hi2c)

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -193,6 +193,7 @@ static TEE_Result stm32_rng_init(void)
 	void *fdt = NULL;
 	int node = -1;
 	struct dt_node_info dt_info;
+	enum teecore_memtypes mtype = MEM_AREA_END;
 
 	memset(&dt_info, 0, sizeof(dt_info));
 
@@ -220,7 +221,13 @@ static TEE_Result stm32_rng_init(void)
 		assert(dt_info.clock != DT_INFO_INVALID_CLOCK &&
 		       dt_info.reg != DT_INFO_INVALID_REG);
 
+		if (dt_info.status & DT_STATUS_OK_NSEC)
+			mtype = MEM_AREA_IO_NSEC;
+		else
+			mtype = MEM_AREA_IO_SEC;
 		stm32_rng->base.pa = dt_info.reg;
+		stm32_rng->base.va = (vaddr_t)phys_to_virt(dt_info.reg, mtype);
+
 		stm32_rng->clock = (unsigned long)dt_info.clock;
 
 		DMSG("RNG init");


### PR DESCRIPTION
When MMU is ON, `io_pa_or_va()` returns a secure mapped virtual address if found, or falls back to a non-secure mapped address if found, or returns `NULL`.

This P-R introduces `io_pa_or_va_secure()` to get an address for a secure only interface
and  `io_pa_or_va_nsec()` to get an address for a non-secure only interface.

This P-R updates the drivers accordingly. However, most drivers calling  `io_pa_or_va()` are UART console drivers for which interface maybe secure or not, according to the platform. Therefore, all these drivers are not modified. There are stm32 drivers where `io_pa_or_va()` is repalced appropriate the new function.