### PR TITLE
core: print TA stack dump from thread context

### DIFF
--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -33,6 +33,9 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs);
 
 bool abort_is_user_exception(struct abort_info *ai);
 
+/* Called from a normal thread */
+void abort_print_current_ta(void);
+
 #endif /*ASM*/
 #endif /*KERNEL_ABORT_H*/
 

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -63,15 +63,6 @@ struct thread_vector_table {
 };
 extern struct thread_vector_table thread_vector_table;
 
-struct thread_specific_data {
-	TAILQ_HEAD(, tee_ta_session) sess_stack;
-	struct tee_ta_ctx *ctx;
-	struct pgt_cache pgt_cache;
-	void *rpc_fs_payload;
-	struct mobj *rpc_fs_payload_mobj;
-	size_t rpc_fs_payload_size;
-};
-
 struct thread_user_vfp_state {
 	struct vfp_state vfp;
 	bool lazy_saved;
@@ -202,6 +193,22 @@ struct thread_svc_regs {
 	uint64_t pad;
 } __aligned(16);
 #endif /*ARM64*/
+
+struct thread_specific_data {
+	TAILQ_HEAD(, tee_ta_session) sess_stack;
+	struct tee_ta_ctx *ctx;
+	struct pgt_cache pgt_cache;
+	void *rpc_fs_payload;
+	struct mobj *rpc_fs_payload_mobj;
+	size_t rpc_fs_payload_size;
+
+	uint32_t abort_type;
+	uint32_t abort_descr;
+	vaddr_t abort_va;
+	unsigned int abort_core;
+	struct thread_abort_regs abort_regs;
+};
+
 #endif /*ASM*/
 
 #ifndef ASM

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -359,6 +359,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	serr = TEE_ORIGIN_TRUSTED_APP;
 
 	if (utc->ctx.panicked) {
+		abort_print_current_ta();
 		DMSG("tee_user_ta_enter: TA panicked with code 0x%x",
 		     utc->ctx.panic_code);
 		serr = TEE_ORIGIN_TEE;
@@ -486,7 +487,6 @@ static void user_ta_dump_state(struct tee_ta_ctx *ctx)
 	}
 	show_elfs(utc);
 }
-KEEP_PAGER(user_ta_dump_state);
 
 static void release_ta_memory_by_mobj(struct mobj *mobj)
 {

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -1252,7 +1252,8 @@ bool tee_pager_handle_fault(struct abort_info *ai)
 	bool ret;
 
 #ifdef TEE_PAGER_DEBUG_PRINT
-	abort_print(ai);
+	if (!abort_is_user_exception(ai))
+		abort_print(ai);
 #endif
 
 	/*


### PR DESCRIPTION
Instead of printing TA stack dump in abort mode, save the required
information and print it from user_ta_enter() in thread context. This
allows dumping the stack also for paged TAs.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
