### PR TITLE
stm32mp1: fix stm32_get_gpio_bank_base()

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -304,7 +304,7 @@ vaddr_t stm32_get_gpio_bank_base(unsigned int bank)
 
 	/* Get non-secure mapping address for GPIOZ */
 	if (bank == GPIO_BANK_Z)
-		io_pa_or_va_nsec(&gpioz_base);
+		return io_pa_or_va_nsec(&gpioz_base);
 
 	COMPILE_TIME_ASSERT(GPIO_BANK_A == 0);
 	assert(bank <= GPIO_BANK_K);


### PR DESCRIPTION
Correct missing return in function stm32_get_gpio_bank_base(). Prior
this change, platform may fail to boot and with debug trace:

E/TC:0 0 assertion 'bank <= GPIO_BANK_K' failed at core/arch/arm/plat-stm32mp1/main.c:311 <stm32_get_gpio_bank_base>

Fixes: 68c4a16b37c7 ("stm32mp1: use phys_to_virt_io_secure() where expected")

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
