### PR TITLE
Remove redundant __noreturn from __utee_entry()

### DIFF
--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -182,7 +182,7 @@ static TEE_Result entry_invoke_command(unsigned long session_id,
 	return res;
 }
 
-void __noreturn __utee_entry(unsigned long func, unsigned long session_id,
+TEE_Result __utee_entry(unsigned long func, unsigned long session_id,
 			struct utee_params *up, unsigned long cmd_id)
 {
 	TEE_Result res;
@@ -211,5 +211,6 @@ void __noreturn __utee_entry(unsigned long func, unsigned long session_id,
 		break;
 	}
 	ta_header_save_params(0, NULL);
-	utee_return(res);
+
+	return res;
 }

--- a/lib/libutee/tee_api_private.h
+++ b/lib/libutee/tee_api_private.h
@@ -18,7 +18,7 @@ void __utee_from_param(struct utee_params *up, uint32_t param_types,
 void __utee_to_param(TEE_Param params[TEE_NUM_PARAMS],
 			uint32_t *param_types, const struct utee_params *up);
 
-void __utee_entry(unsigned long func, unsigned long session_id,
+TEE_Result __utee_entry(unsigned long func, unsigned long session_id,
 			struct utee_params *up, unsigned long cmd_id);
 
 

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -5,9 +5,10 @@
 #include <compiler.h>
 #include <tee_ta_api.h>
 #include <tee_internal_api_extensions.h>
+#include <trace.h>
 #include <user_ta_header.h>
 #include <user_ta_header_defines.h>
-#include <trace.h>
+#include <utee_syscalls.h>
 
 int trace_level = TRACE_LEVEL;
 
@@ -24,9 +25,8 @@ const char trace_ext_prefix[]  = "TA";
 /* exprted to user_ta_header.c, built within TA */
 struct utee_params;
 
-void __utee_entry(unsigned long func, unsigned long session_id,
-			struct utee_params *up, unsigned long cmd_id)
-			__noreturn;
+TEE_Result __utee_entry(unsigned long func, unsigned long session_id,
+			struct utee_params *up, unsigned long cmd_id);
 
 void __noreturn __ta_entry(unsigned long func, unsigned long session_id,
 			   struct utee_params *up, unsigned long cmd_id);
@@ -34,7 +34,11 @@ void __noreturn __ta_entry(unsigned long func, unsigned long session_id,
 void __noreturn __ta_entry(unsigned long func, unsigned long session_id,
 			   struct utee_params *up, unsigned long cmd_id)
 {
-	__utee_entry(func, session_id, up, cmd_id);
+	TEE_Result res = TEE_SUCCESS;
+
+	res = __utee_entry(func, session_id, up, cmd_id);
+
+	utee_return(res);
 }
 
 /*


### PR DESCRIPTION
As __ta_entry() acts as function entry point, it makes sense to
logically return from this api only via utee_return(). So remove
redundant __noreturn from __utee_entry().

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
