### PR TITLE
config.mk: fix CFG_OPTEE_REVISION_MINOR

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -116,7 +116,7 @@ endif
 # with limited depth not including any tag, so there is really no guarantee
 # that TEE_IMPL_VERSION contains the major and minor revision numbers.
 CFG_OPTEE_REVISION_MAJOR ?= 3
-CFG_OPTEE_REVISION_MINOR ?= 4
+CFG_OPTEE_REVISION_MINOR ?= 5
 
 # Trusted OS implementation manufacturer name
 CFG_TEE_MANUFACTURER ?= LINARO


### PR DESCRIPTION
The current release is 3.5.0, change the revision to match.

Fixes https://github.com/OP-TEE/optee_os/issues/3028