### PR TITLE
libmbedtls: mbedtls_mpi_exp_mod(): reduce stack usage

### DIFF
--- a/lib/libmbedtls/mbedtls/library/bignum.c
+++ b/lib/libmbedtls/mbedtls/library/bignum.c
@@ -1788,7 +1788,9 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     size_t i, j, nblimbs;
     size_t bufsize, nbits;
     mbedtls_mpi_uint ei, mm, state;
-    mbedtls_mpi RR, T, W[ 2 << MBEDTLS_MPI_WINDOW_SIZE ], Apos;
+    mbedtls_mpi RR, T, Apos;
+    mbedtls_mpi *W;
+    const size_t array_size_W = 2 << MBEDTLS_MPI_WINDOW_SIZE;
     int neg;
 
     MPI_VALIDATE_RET( X != NULL );
@@ -1802,13 +1804,18 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     if( mbedtls_mpi_cmp_int( E, 0 ) < 0 )
         return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
 
+    W = mempool_alloc( mbedtls_mpi_mempool,
+                       sizeof( mbedtls_mpi ) * array_size_W );
+    if( W == NULL )
+        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
+
     /*
      * Init temps and window size
      */
     mbedtls_mpi_montg_init( &mm, N );
     mbedtls_mpi_init_mempool( &RR ); mbedtls_mpi_init_mempool( &T );
     mbedtls_mpi_init_mempool( &Apos );
-    for( i = 0; i < ARRAY_SIZE(W); i++ )
+    for( i = 0; i < array_size_W; i++ )
         mbedtls_mpi_init_mempool( W + i );
 
     i = mbedtls_mpi_bitlen( E );
@@ -1981,8 +1988,9 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
 
 cleanup:
 
-    for( i = 0; i < ARRAY_SIZE(W); i++ )
+    for( i = 0; i < array_size_W; i++ )
         mbedtls_mpi_free( W + i );
+    mempool_free( mbedtls_mpi_mempool , W );
 
     mbedtls_mpi_free( &T ); mbedtls_mpi_free( &Apos );
 

--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -13,7 +13,7 @@
 #include <utee_syscalls.h>
 #include <util.h>
 
-#define MPI_MEMPOOL_SIZE	(8 * 1024)
+#define MPI_MEMPOOL_SIZE	(12 * 1024)
 
 static void __noreturn api_panic(const char *func, int line, const char *msg)
 {


### PR DESCRIPTION
The W variable is 3072 on AArch64 with MBEDTLS_MPI_WINDOW_SIZE set to 6
for maximum performance. Instead of allocating such a large variable on
the stack use mempool_alloc().

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
