### PR TITLE
virt: kern.ld.S: remove PROVIDE() keyword

### DIFF
--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -463,8 +463,8 @@ __vcore_unpg_rw_size = __flatmap_unpg_rw_size;
 
 #ifdef CFG_VIRTUALIZATION
 /* Nexus read-write memory */
-PROVIDE(__vcore_nex_rw_start = __flatmap_nex_rw_start);
-PROVIDE(__vcore_nex_rw_size = __flatmap_nex_rw_size);
+__vcore_nex_rw_start = __flatmap_nex_rw_start;
+__vcore_nex_rw_size = __flatmap_nex_rw_size;
 #endif
 
 #ifdef CFG_WITH_PAGER


### PR DESCRIPTION
The linker script for the TEE core exports two symbols using the
PROVIDE() keyword. This keyword is not needed; it makes no difference
because when CFG_VIRTUALIZATION=y the symbols are *not* defined
elsewhere, and they *are* used by a C file, so that a normal symbol will
do the same. Therefore, remove the keyword.

[1]: https://sourceware.org/binutils/docs/ld/PROVIDE.html#PROVIDE
"The PROVIDE keyword may be used to define a symbol [...] only if it is
 referenced but not defined."

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
