### PR TITLE
mk/cleandirs.mk: avoid print spurious empty lines

### DIFF
--- a/mk/cleandirs.mk
+++ b/mk/cleandirs.mk
@@ -32,7 +32,7 @@ RMDIR := rmdir --ignore-fail-on-non-empty
 # (200 files at a time), to minimize the odds of having:
 # "/bin/bash: Argument list too long"
 define do-rm-f
-        $(call _do-rm-f, $(wordlist 1, 200, $(1)))
+        $(call _do-rm-f, $(wordlist 1, 200, $(1))) \
         $(eval _tail := $(wordlist 201, $(words $(1)), $(1)))
         $(if $(_tail), $(call do-rm-f, $(_tail)))
 endef


### PR DESCRIPTION
Fixes the macro do-rm-f from outputting spurious empty lines if supplied
a large list of files.

Reviewed-by: Jerome Forissier <jerome@forissier.org>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
