### PR TITLE
libmbedtls: mbedtls_mpi_exp_mod(): optimize mempool usage

### DIFF
--- a/lib/libmbedtls/mbedtls/library/bignum.c
+++ b/lib/libmbedtls/mbedtls/library/bignum.c
@@ -1789,7 +1789,7 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     size_t bufsize, nbits;
     mbedtls_mpi_uint ei, mm, state;
     mbedtls_mpi RR, T, Apos;
-    mbedtls_mpi *W;
+    mbedtls_mpi *W = NULL;
     const size_t array_size_W = 2 << MBEDTLS_MPI_WINDOW_SIZE;
     int neg;
 
@@ -1804,19 +1804,12 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     if( mbedtls_mpi_cmp_int( E, 0 ) < 0 )
         return( MBEDTLS_ERR_MPI_BAD_INPUT_DATA );
 
-    W = mempool_alloc( mbedtls_mpi_mempool,
-                       sizeof( mbedtls_mpi ) * array_size_W );
-    if( W == NULL )
-        return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
-
     /*
      * Init temps and window size
      */
     mbedtls_mpi_montg_init( &mm, N );
     mbedtls_mpi_init_mempool( &RR ); mbedtls_mpi_init_mempool( &T );
     mbedtls_mpi_init_mempool( &Apos );
-    for( i = 0; i < array_size_W; i++ )
-        mbedtls_mpi_init_mempool( W + i );
 
     i = mbedtls_mpi_bitlen( E );
 
@@ -1828,7 +1821,7 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
 
     j = N->n + 1;
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, j ) );
-    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &W[1],  j ) );
+
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &T, j * 2 ) );
 
     /*
@@ -1856,6 +1849,16 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
     }
     else
         memcpy( &RR, _RR, sizeof( mbedtls_mpi ) );
+
+    W = mempool_alloc( mbedtls_mpi_mempool,
+                       sizeof( mbedtls_mpi ) * array_size_W );
+    if( W == NULL ) {
+        ret = MBEDTLS_ERR_MPI_ALLOC_FAILED;
+        goto cleanup;
+    }
+    for( i = 0; i < array_size_W; i++ )
+        mbedtls_mpi_init_mempool( W + i );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow( &W[1],  j ) );
 
     /*
      * W[1] = A * R^2 * R^-1 mod N = A * R mod N
@@ -1988,8 +1991,9 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
 
 cleanup:
 
-    for( i = 0; i < array_size_W; i++ )
-        mbedtls_mpi_free( W + i );
+    if( W )
+        for( i = 0; i < array_size_W; i++ )
+            mbedtls_mpi_free( W + i );
     mempool_free( mbedtls_mpi_mempool , W );
 
     mbedtls_mpi_free( &T ); mbedtls_mpi_free( &Apos );


### PR DESCRIPTION
With W allocated in the mempool instead of the stack it more important
to utilize the mempool in a stack like way.

With this patch allocation and initialization of W is moved to a point
where all following mempool allocations are free before the function
returns.

This reduces maximum memory consumption of mempool in regression case
8101 for an AArch64 TA in from 17280 to 7640 bytes. Figures for an
AArch32 TA are 12040 to 5288 bytes.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
