### PR TITLE
core: fix AArch64 user TA stack dump

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -160,10 +160,16 @@ static void __print_stack_unwind_arm64(struct abort_info *ai)
 	size_t stack_size = 0;
 
 	if (abort_is_user_exception(ai)) {
+		struct tee_ta_session *s = NULL;
+		struct user_ta_ctx *utc = NULL;
+
+		if (tee_ta_get_current_session(&s) != TEE_SUCCESS)
+			panic();
+
+		utc = to_user_ta_ctx(s->ctx);
 		/* User stack */
-		stack = 0;
-		stack_size = 0;
-		kernel_stack = false;
+		stack = utc->stack_addr;
+		stack_size = utc->mobj_stack->size;
 	} else {
 		/* Kernel stack */
 		stack = thread_stack_start();


### PR DESCRIPTION
Restores user TA stack base and size __print_stack_unwind_arm64() to be able
to dump the user TA stack.

Fixes: c0bc8d0e7d72 ("core: print TA stack dump from thread context")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
