### PR TITLE
pta: add support for deriving device and TA unique keys

### DIFF
--- a/core/arch/arm/pta/system.c
+++ b/core/arch/arm/pta/system.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2018, Linaro Limited
  */
+#include <kernel/huk_subkey.h>
 #include <kernel/msg_param.h>
 #include <kernel/pseudo_ta.h>
 #include <kernel/user_ta.h>
@@ -40,6 +41,52 @@ static TEE_Result system_rng_reseed(struct tee_ta_session *s __unused,
 	return TEE_SUCCESS;
 }
 
+static TEE_Result system_derive_ta_unique_key(struct tee_ta_session *s,
+					      uint32_t param_types,
+					      TEE_Param params[TEE_NUM_PARAMS])
+{
+	size_t data_len = sizeof(TEE_UUID);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *data = NULL;
+	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					  TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					  TEE_PARAM_TYPE_NONE,
+					  TEE_PARAM_TYPE_NONE);
+
+	if (exp_pt != param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (params[0].memref.size > TA_DERIVED_EXTRA_DATA_MAX_SIZE ||
+	    params[1].memref.size < TA_DERIVED_KEY_MIN_SIZE ||
+	    params[1].memref.size > TA_DERIVED_KEY_MAX_SIZE)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* The derived key shall not end up in non-secure memory by mistake */
+	if (!tee_vbuf_is_sec(params[1].memref.buffer, params[1].memref.size))
+		return TEE_ERROR_SECURITY;
+
+	/* Take extra data into account. */
+	if (ADD_OVERFLOW(data_len, params[0].memref.size, &data_len))
+		return TEE_ERROR_SECURITY;
+
+	data = calloc(data_len, 1);
+	if (!data)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	memcpy(data, &s->ctx->uuid, sizeof(TEE_UUID));
+
+	/* Append the user provided data */
+	memcpy(data + sizeof(TEE_UUID), params[0].memref.buffer,
+	       params[0].memref.size);
+
+	res = huk_subkey_derive(HUK_SUBKEY_UNIQUE_TA, data, data_len,
+				params[1].memref.buffer,
+				params[1].memref.size);
+	free(data);
+
+	return res;
+}
+
 static TEE_Result open_session(uint32_t param_types __unused,
 			       TEE_Param params[TEE_NUM_PARAMS] __unused,
 			       void **sess_ctx __unused)
@@ -65,6 +112,10 @@ static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
 	switch (cmd_id) {
 	case PTA_SYSTEM_ADD_RNG_ENTROPY:
 		return system_rng_reseed(s, param_types, params);
+
+	case PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY:
+		return system_derive_ta_unique_key(s, param_types, params);
+
 	default:
 		break;
 	}

--- a/core/include/kernel/huk_subkey.h
+++ b/core/include/kernel/huk_subkey.h
@@ -12,9 +12,10 @@
 
 /*
  * enum huk_subkey_usage - subkey usage identifier
- * @HUK_SUBKEY_RPMB:	RPMB key
- * @HUK_SUBKEY_SSK:	Secure Storage key
- * @HUK_SUBKEY_DIE_ID:	Representing the die ID
+ * @HUK_SUBKEY_RPMB:	  RPMB key
+ * @HUK_SUBKEY_SSK:	  Secure Storage key
+ * @HUK_SUBKEY_DIE_ID:	  Representing the die ID
+ * @HUK_SUBKEY_UNIQUE_TA: TA unique key
  *
  * Add more identifiers as needed, be careful to not change the already
  * assigned numbers as that will affect the derived subkey.
@@ -27,6 +28,7 @@ enum huk_subkey_usage {
 	HUK_SUBKEY_RPMB = 0,
 	HUK_SUBKEY_SSK = 1,
 	HUK_SUBKEY_DIE_ID = 2,
+	HUK_SUBKEY_UNIQUE_TA = 3,
 };
 
 #define HUK_SUBKEY_MAX_LEN	TEE_SHA256_HASH_SIZE

--- a/lib/libutee/include/pta_system.h
+++ b/lib/libutee/include/pta_system.h
@@ -14,6 +14,17 @@
 			 0x9c, 0x2d, 0xfa, 0x7a, 0xe0, 0x1b, 0xbe, 0xbc } }
 
 /*
+ * Having keys with too few bits impose a potential security risk, hence set a
+ * lower bound of 128 bits.
+ */
+#define TA_DERIVED_KEY_MIN_SIZE		16
+
+/* Same value as max in huk_subkey_derive */
+#define TA_DERIVED_KEY_MAX_SIZE		32
+
+#define TA_DERIVED_EXTRA_DATA_MAX_SIZE	1024
+
+/*
  * Add (re-seed) caller-provided entropy to the RNG pool. Keymaster
  * implementations need to securely mix the provided entropy into their pool,
  * which also must contain internally-generated entropy from a hardware random
@@ -22,5 +33,18 @@
  * [in]     memref[0]: entropy input data
  */
 #define PTA_SYSTEM_ADD_RNG_ENTROPY	0
+
+/*
+ * Derives a device and TA unique key. The caller can also provide extra data
+ * that will be mixed together with existing device unique properties. If no
+ * extra data is provided, then the derived key will only use device unique
+ * properties and caller TA UUID.
+ *
+ * [in]  params[0].memref.buffer     Buffer for extra data
+ * [in]  params[0].memref.size       Size of extra data (max 1024 bytes)
+ * [out] params[1].memref.buffer     Buffer for the derived key
+ * [out] params[1].memref.size       Size of the derived key (16 to 32 bytes)
+ */
+#define PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY 1
 
 #endif /* __PTA_SYSTEM_H */


### PR DESCRIPTION
Enable derivation of device and Trusted Application unique keys that can
be used by different Trusted Applications directly. An example of use
case could be when you need to encrypt some data in a Trusted App and
then give it back to normal world.

By default device unique properties (HUK and TA UUID) will be used when
deriving a key. However, the one calling the pTA derive key function
also have the ability to provide some extra data that will be mixed in
together with existing device unique properties. That gives the ability
to derive keys that are not only device and Trusted Application unique,
but also tied to some additional data, it could for example be a
password or something similar.

I have test cases in xtest ready for this also, I'll send that PR right after this one has been sent.