### PR TITLE
core: correct _fdt_get_status() description

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -113,7 +113,7 @@ ssize_t _fdt_reg_size(const void *fdt, int offs);
  * Read the status and secure-status properties into a bitfield.
  * @status is set to DT_STATUS_DISABLED or a combination of DT_STATUS_OK_NSEC
  * and DT_STATUS_OK_SEC
- * Returns 0 on success or -1 in case of error.
+ * Returns positive or null status value on success or -1 in case of error.
  */
 int _fdt_get_status(const void *fdt, int offs);
 


### PR DESCRIPTION
Correct _fdt_get_status() function description since it returns a
positive or null value on success and -1 on error.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
