### PR TITLE
core: ensure embedded DTB found trace is output once

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -508,13 +508,14 @@ void *get_embedded_dt(void)
 	assert(cpu_mmu_enabled());
 
 	if (!checked) {
+		IMSG("Embedded DTB found");
+
 		if (fdt_check_header(embedded_secure_dtb))
 			panic("Invalid embedded DTB");
 
 		checked = true;
 	}
 
-	IMSG("Embedded DTB found");
 	return embedded_secure_dtb;
 }
 #else


### PR DESCRIPTION
Move info trace "Embedded DTB found" so that it is output only once
even when get_embedded_dt() is called several times.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
