### PR TITLE
core: move embedded DTB out of init sections

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -1016,7 +1016,7 @@ static void discover_nsec_memory(void)
 {
 	struct core_mmu_phys_mem *mem;
 	size_t nelems;
-	void *fdt = get_dt();
+	void *fdt = get_external_dt();
 
 	if (fdt) {
 		mem = get_memory(fdt, &nelems);

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -144,9 +144,18 @@ static TEE_Result init_console_from_dt(void)
 	struct stm32_uart_pdata *pd = NULL;
 	void *fdt = NULL;
 	int node = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
-	if (get_console_node_from_dt(&fdt, &node, NULL, NULL))
-		return TEE_SUCCESS;
+	fdt = get_embedded_dt();
+	res = get_console_node_from_dt(fdt, &node, NULL, NULL);
+	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+		fdt = get_external_dt();
+		res = get_console_node_from_dt(fdt, &node, NULL, NULL);
+		if (res == TEE_ERROR_ITEM_NOT_FOUND)
+			return TEE_SUCCESS;
+		if (res != TEE_SUCCESS)
+			return res;
+	}
 
 	pd = stm32_uart_init_from_dt_node(fdt, node);
 	if (!pd) {

--- a/core/include/console.h
+++ b/core/include/console.h
@@ -35,7 +35,7 @@ void register_serial_console(struct serial_chip *chip);
  * Return a TEE_Result compliant return value
  *
  */
-TEE_Result get_console_node_from_dt(void **fdt_out, int *offs_out,
+TEE_Result get_console_node_from_dt(void *fdt, int *offs_out,
 				    const char **path_out,
 				    const char **params_out);
 


### PR DESCRIPTION
This change makes generic boot to discover non-secure memory and
console configuration from the external DTB only, no more from the
embedded DTB as prior this change. When generic boot attempts to access
embedded DTB, the embedded DTB gets located in init read-only data
section become unnecessary too big. With this change, embedded DTB now
lies in the standard pageable read-only data section, relaxing memory
footprint constraint.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
