### PR TITLE
stmp32mp1: support STPMIC1 device

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -38,6 +38,7 @@ CFG_MMAP_REGIONS ?= 23
 ifeq ($(CFG_EMBED_DTB_SOURCE_FILE),)
 # Some drivers mandate DT support
 $(call force,CFG_STM32_I2C,n)
+$(call force,CFG_STPMIC1,n)
 endif
 
 CFG_STM32_BSEC ?= y
@@ -47,6 +48,13 @@ CFG_STM32_I2C ?= y
 CFG_STM32_RNG ?= y
 CFG_STM32_RNG ?= y
 CFG_STM32_UART ?= y
+
+CFG_STPMIC1 ?= y
+
+ifeq ($(CFG_STPMIC1),y)
+$(call force,CFG_STM32_I2C,y)
+$(call force,CFG_STM32_GPIO,y)
+endif
 
 # Default enable some test facitilites
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics - All Rights Reserved
+ */
+
+#include <drivers/stm32_i2c.h>
+#include <drivers/stm32mp1_pmic.h>
+#include <drivers/stpmic1.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm.h>
+#include <libfdt.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stdbool.h>
+#include <stm32_util.h>
+#include <trace.h>
+#include <util.h>
+
+#define MODE_STANDBY                    8
+
+#define PMIC_I2C_TRIALS			1
+#define PMIC_I2C_TIMEOUT_BUSY_MS	5
+
+/* Expect a single PMIC instance */
+static struct i2c_handle_s i2c_handle;
+static uint32_t pmic_i2c_addr;
+
+bool stm32mp_with_pmic(void)
+{
+	return i2c_handle.dt_status & DT_STATUS_OK_SEC;
+}
+
+static int dt_get_pmic_node(void *fdt)
+{
+	return fdt_node_offset_by_compatible(fdt, -1, "st,stpmic1");
+}
+
+static int dt_pmic_status(void)
+{
+	void *fdt = get_embedded_dt();
+
+	if (fdt) {
+		int node = dt_get_pmic_node(fdt);
+
+		if (node > 0)
+			return _fdt_get_status(fdt, node);
+	}
+
+	return -1;
+}
+
+static bool dt_pmic_is_secure(void)
+{
+	int status = dt_pmic_status();
+
+	return status == DT_STATUS_OK_SEC &&
+	       i2c_handle.dt_status == DT_STATUS_OK_SEC;
+}
+
+/*
+ * @idx: Private identifier provided by the target PMIC driver
+ * @flags: Operations expected when entering a low power sequence
+ * @voltage: Target voltage to apply during low power sequences
+ */
+struct regu_bo_config {
+	uint8_t flags;
+	struct stpmic1_bo_cfg cfg;
+};
+
+#define REGU_BO_FLAG_ENABLE_REGU		BIT(0)
+#define REGU_BO_FLAG_SET_VOLTAGE		BIT(1)
+#define REGU_BO_FLAG_PULL_DOWN			BIT(2)
+#define REGU_BO_FLAG_MASK_RESET			BIT(3)
+
+static struct regu_bo_config *regu_bo_config;
+static size_t regu_bo_count;
+
+static int save_boot_on_config(void)
+{
+	int pmic_node = 0;
+	int regulators_node = 0;
+	int regu_node = 0;
+	void *fdt = NULL;
+
+	assert(!regu_bo_config && !regu_bo_count);
+
+	fdt = get_embedded_dt();
+	if (!fdt)
+		panic();
+
+	pmic_node = dt_get_pmic_node(fdt);
+	if (pmic_node < 0)
+		panic();
+
+	regulators_node = fdt_subnode_offset(fdt, pmic_node, "regulators");
+
+	fdt_for_each_subnode(regu_node, fdt, regulators_node) {
+		const fdt32_t *cuint = NULL;
+		const char *name = NULL;
+		struct regu_bo_config regu_cfg = { };
+		uint16_t mv = 0;
+
+		if (_fdt_get_status(fdt, regu_node) == DT_STATUS_DISABLED)
+			continue;
+
+		if (!fdt_getprop(fdt, regu_node, "regulator-boot-on", NULL))
+			continue;
+
+		memset(&regu_cfg, 0, sizeof(regu_cfg));
+		name = fdt_get_name(fdt, regu_node, NULL);
+
+		regu_cfg.flags |= REGU_BO_FLAG_ENABLE_REGU;
+
+		if (fdt_getprop(fdt, regu_node, "regulator-pull-down", NULL)) {
+			stpmic1_bo_pull_down_cfg(name, &regu_cfg.cfg);
+			regu_cfg.flags |= REGU_BO_FLAG_PULL_DOWN;
+		}
+
+		if (fdt_getprop(fdt, regu_node, "st,mask-reset", NULL)) {
+			stpmic1_bo_mask_reset_cfg(name, &regu_cfg.cfg);
+			regu_cfg.flags |= REGU_BO_FLAG_MASK_RESET;
+		}
+
+		cuint = fdt_getprop(fdt, regu_node,
+				    "regulator-min-microvolt", NULL);
+		if (cuint) {
+			/* DT uses microvolts and driver awaits millivolts */
+			mv = (uint16_t)(fdt32_to_cpu(*cuint) / 1000U);
+
+			if (!stpmic1_bo_voltage_cfg(name, mv, &regu_cfg.cfg))
+				regu_cfg.flags |= REGU_BO_FLAG_SET_VOLTAGE;
+		}
+
+		/* Save config in the Boot On configuration list */
+		regu_bo_count++;
+		regu_bo_config = realloc(regu_bo_config,
+					 regu_bo_count * sizeof(regu_cfg));
+		if (!regu_bo_config)
+			panic();
+
+		memcpy(&regu_bo_config[regu_bo_count - 1], &regu_cfg,
+		       sizeof(regu_cfg));
+	}
+
+	return 0;
+}
+
+void stm32mp_pmic_apply_boot_on_config(void)
+{
+	size_t i = 0;
+
+	for (i = 0; i < regu_bo_count; i++) {
+		struct regu_bo_config *regu_cfg = &regu_bo_config[i];
+
+		if (regu_cfg->flags & REGU_BO_FLAG_SET_VOLTAGE)
+			if (stpmic1_bo_voltage_unpg(&regu_cfg->cfg))
+				panic();
+
+		if (regu_cfg->flags & REGU_BO_FLAG_ENABLE_REGU)
+			if (stpmic1_bo_enable_unpg(&regu_cfg->cfg))
+				panic();
+
+		if (regu_cfg->flags & REGU_BO_FLAG_PULL_DOWN)
+			if (stpmic1_bo_pull_down_unpg(&regu_cfg->cfg))
+				panic();
+
+		if (regu_cfg->flags & REGU_BO_FLAG_MASK_RESET)
+			if (stpmic1_bo_mask_reset_unpg(&regu_cfg->cfg))
+				panic();
+	}
+}
+
+/*
+ * @idx: Private identifier provided by the target PMIC driver
+ * @flags: Operations expected when entering a low power sequence
+ * @voltage: Target voltage to apply during low power sequences
+ */
+struct regu_lp_config {
+	uint8_t flags;
+	struct stpmic1_lp_cfg cfg;
+};
+
+#define REGU_LP_FLAG_LOAD_PWRCTRL	BIT(0)
+#define REGU_LP_FLAG_ON_IN_SUSPEND	BIT(1)
+#define REGU_LP_FLAG_OFF_IN_SUSPEND	BIT(2)
+#define REGU_LP_FLAG_SET_VOLTAGE	BIT(3)
+#define REGU_LP_FLAG_MODE_STANDBY	BIT(4)
+
+struct regu_lp_state {
+	const char *name;
+	size_t cfg_count;
+	struct regu_lp_config *cfg;
+};
+
+enum regu_lp_state_id {
+	REGU_LP_STATE_DISK = 0,
+	REGU_LP_STATE_STANDBY,
+	REGU_LP_STATE_MEM,
+	REGU_LP_STATE_COUNT
+};
+
+static struct regu_lp_state regu_lp_state[REGU_LP_STATE_COUNT] = {
+	[REGU_LP_STATE_DISK] = { .name = "standby-ddr-off", },
+	[REGU_LP_STATE_STANDBY] = { .name = "standby-ddr-sr", },
+	[REGU_LP_STATE_MEM] = { .name = "lp-stop", },
+};
+
+static unsigned int regu_lp_state2idx(const char *name)
+{
+	unsigned int i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(regu_lp_state); i++) {
+		struct regu_lp_state *state = &regu_lp_state[i];
+
+		if (!strncmp(name, state->name, strlen(state->name)))
+			return i;
+	}
+
+	panic();
+}
+
+static int save_low_power_config(const char *lp_state)
+{
+	int pmic_node = 0;
+	int regulators_node = 0;
+	int regu_node = 0;
+	void *fdt = NULL;
+	unsigned int state_idx = regu_lp_state2idx(lp_state);
+	struct regu_lp_state *state = &regu_lp_state[state_idx];
+
+	assert(!state->cfg && !state->cfg_count);
+
+	fdt = get_embedded_dt();
+	if (!fdt)
+		panic();
+
+	pmic_node = dt_get_pmic_node(fdt);
+	if (pmic_node < 0)
+		return -FDT_ERR_NOTFOUND;
+
+	regulators_node = fdt_subnode_offset(fdt, pmic_node, "regulators");
+
+	fdt_for_each_subnode(regu_node, fdt, regulators_node) {
+		const fdt32_t *cuint = NULL;
+		const char *reg_name = NULL;
+		int regu_state_node = 0;
+		struct regu_lp_config *regu_cfg = NULL;
+
+		if (_fdt_get_status(fdt, regu_node) == DT_STATUS_DISABLED)
+			continue;
+
+		state->cfg_count++;
+		state->cfg = realloc(state->cfg,
+				     state->cfg_count * sizeof(*state->cfg));
+		if (!state->cfg)
+			panic();
+
+		regu_cfg = &state->cfg[state->cfg_count - 1];
+
+		memset(regu_cfg, 0, sizeof(*regu_cfg));
+
+		reg_name = fdt_get_name(fdt, regu_node, NULL);
+
+		if (stpmic1_lp_cfg(reg_name, &regu_cfg->cfg)) {
+			EMSG("Invalid regu name %s", reg_name);
+			return -1;
+		}
+
+		/*
+		 * Always copy active configuration (Control register) to
+		 * PWRCTRL Control register, even if regu_state_node
+		 * does not exist.
+		 */
+		regu_cfg->flags |= REGU_LP_FLAG_LOAD_PWRCTRL;
+
+		/* Then apply configs from regu_state_node */
+		regu_state_node = fdt_subnode_offset(fdt, regu_node, lp_state);
+		if (regu_state_node <= 0)
+			continue;
+
+		if (fdt_getprop(fdt, regu_state_node,
+				"regulator-on-in-suspend", NULL))
+			regu_cfg->flags |= REGU_LP_FLAG_ON_IN_SUSPEND;
+
+		if (fdt_getprop(fdt, regu_state_node,
+				"regulator-off-in-suspend", NULL))
+			regu_cfg->flags |= REGU_LP_FLAG_OFF_IN_SUSPEND;
+
+		cuint = fdt_getprop(fdt, regu_state_node,
+				    "regulator-suspend-microvolt", NULL);
+		if (cuint) {
+			uint32_t mv = fdt32_to_cpu(*cuint) / 1000U;
+
+			if (!stpmic1_lp_voltage_cfg(reg_name, mv,
+						    &regu_cfg->cfg))
+				regu_cfg->flags |= REGU_LP_FLAG_SET_VOLTAGE;
+		}
+
+		cuint = fdt_getprop(fdt, regu_state_node,
+				    "regulator-mode", NULL);
+		if (cuint && fdt32_to_cpu(*cuint) == MODE_STANDBY)
+			regu_cfg->flags |= REGU_LP_FLAG_MODE_STANDBY;
+	}
+
+	return 0;
+}
+
+/*
+ * int stm32mp_pmic_set_lp_config(char *lp_state)
+ *
+ * Load the low power configuration stored in regu_lp_state[].
+ */
+void stm32mp_pmic_apply_lp_config(const char *lp_state)
+{
+	unsigned int state_idx = regu_lp_state2idx(lp_state);
+	struct regu_lp_state *state = &regu_lp_state[state_idx];
+	size_t i = 0;
+
+	if (stpmic1_powerctrl_on())
+		panic();
+
+	for (i = 0; i < state->cfg_count; i++) {
+		struct stpmic1_lp_cfg *cfg = &state->cfg[i].cfg;
+
+		if ((state->cfg[i].flags & REGU_LP_FLAG_LOAD_PWRCTRL) &&
+		    stpmic1_lp_load_unpg(cfg))
+			panic();
+
+		if ((state->cfg[i].flags & REGU_LP_FLAG_ON_IN_SUSPEND) &&
+		    stpmic1_lp_on_off_unpg(cfg, 1))
+			panic();
+
+		if ((state->cfg[i].flags & REGU_LP_FLAG_OFF_IN_SUSPEND) &&
+		    stpmic1_lp_on_off_unpg(cfg, 0))
+			panic();
+
+		if ((state->cfg[i].flags & REGU_LP_FLAG_SET_VOLTAGE) &&
+		    stpmic1_lp_voltage_unpg(cfg))
+			panic();
+
+		if ((state->cfg[i].flags & REGU_LP_FLAG_MODE_STANDBY) &&
+		    stpmic1_lp_mode_unpg(cfg, 1))
+			panic();
+	}
+}
+
+static int save_power_configurations(void)
+{
+	unsigned int i = 0;
+
+	if (save_boot_on_config())
+		return 1;
+
+	for (i = 0; i < ARRAY_SIZE(regu_lp_state); i++)
+		if (save_low_power_config(regu_lp_state[i].name))
+			return 1;
+
+	return 0;
+}
+
+/*
+ * Get PMIC and its I2C bus configuration from the device tree.
+ * Return 0 on success, negative on error, 1 if no PMIC node is found.
+ */
+static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
+			      struct stm32_pinctrl **pinctrl,
+			      size_t *pinctrl_count,
+			      struct stm32_i2c_init_s *init)
+{
+	int pmic_node = 0;
+	int i2c_node = 0;
+	void *fdt = NULL;
+	const fdt32_t *cuint = NULL;
+
+	fdt = get_embedded_dt();
+	if (!fdt)
+		return -1;
+
+	pmic_node = dt_get_pmic_node(fdt);
+	if (pmic_node < 0)
+		return 1;
+
+	cuint = fdt_getprop(fdt, pmic_node, "reg", NULL);
+	if (cuint == NULL)
+		return -FDT_ERR_NOTFOUND;
+
+	pmic_i2c_addr = fdt32_to_cpu(*cuint) << 1;
+	if (pmic_i2c_addr > UINT16_MAX)
+		return -1;
+
+	i2c_node = fdt_parent_offset(fdt, pmic_node);
+	if (i2c_node < 0)
+		return -FDT_ERR_NOTFOUND;
+
+	_fdt_fill_device_info(fdt, i2c_info, i2c_node);
+	if (i2c_info->reg == 0U)
+		return -FDT_ERR_NOTFOUND;
+
+	return stm32_i2c_get_setup_from_fdt(fdt, i2c_node, init,
+					    pinctrl, pinctrl_count);
+}
+
+/*
+ * PMIC and resource initialization
+ */
+
+/* Return true if PMIC is available, false if not found, panics on errors */
+static bool initialize_pmic_i2c(void)
+{
+	int ret = 0;
+	struct dt_node_info i2c_info = { };
+	struct i2c_handle_s *i2c = &i2c_handle;
+	struct stm32_pinctrl *pinctrl = NULL;
+	size_t pin_count = 0;
+	struct stm32_i2c_init_s i2c_init = { };
+
+	ret = dt_pmic_i2c_config(&i2c_info, &pinctrl, &pin_count, &i2c_init);
+	if (ret < 0) {
+		EMSG("I2C configuration failed %d", ret);
+		panic();
+	}
+	if (ret)
+		return false;
+
+	/* Initialize PMIC I2C */
+	i2c->base.pa = i2c_info.reg;
+	i2c->base.va = (vaddr_t)phys_to_virt(i2c->base.pa, MEM_AREA_IO_SEC);
+	assert(i2c->base.va);
+	i2c->dt_status = i2c_info.status;
+	i2c->clock = i2c_info.clock;
+	i2c_init.own_address1 = pmic_i2c_addr;
+	i2c_init.analog_filter = true;
+	i2c_init.digital_filter_coef = 0;
+
+	i2c->pinctrl = pinctrl;
+	i2c->pinctrl_count = pin_count;
+
+	stm32mp_get_pmic();
+
+	ret = stm32_i2c_init(i2c, &i2c_init);
+	if (ret) {
+		EMSG("I2C init 0x%" PRIxPA ": %d", i2c_info.reg, ret);
+		panic();
+	}
+
+	if (!stm32_i2c_is_device_ready(i2c, pmic_i2c_addr,
+				       PMIC_I2C_TRIALS,
+				       PMIC_I2C_TIMEOUT_BUSY_MS))
+		panic();
+
+	stpmic1_bind_i2c(i2c, pmic_i2c_addr);
+
+	stm32mp_put_pmic();
+
+	return true;
+}
+
+/*
+ * Automated suspend/resume at system suspend/resume is expected
+ * only when the PMIC is secure. If it is non secure, only atomic
+ * execution context acn get/put the PMIC resources.
+ */
+static TEE_Result pmic_pm(enum pm_op op, uint32_t pm_hint __unused,
+			  const struct pm_callback_handle *pm_handle __unused)
+{
+	if (op == PM_OP_SUSPEND)
+		stm32_i2c_suspend(&i2c_handle);
+	else
+		stm32_i2c_resume(&i2c_handle);
+
+	return TEE_SUCCESS;
+}
+KEEP_PAGER(pmic_pm);
+
+/* stm32mp_get/put_pmic allows secure atomic sequences to use non secure PMIC */
+void stm32mp_get_pmic(void)
+{
+	stm32_i2c_resume(&i2c_handle);
+}
+
+void stm32mp_put_pmic(void)
+{
+	stm32_i2c_suspend(&i2c_handle);
+}
+
+static void register_non_secure_pmic(void)
+{
+	size_t n = 0;
+
+	/* Allow this function to be called when STPMIC1 not used */
+	if (!i2c_handle.base.pa)
+		return;
+
+	for (n = 0; n < i2c_handle.pinctrl_count; n++)
+		stm32mp_register_non_secure_gpio(i2c_handle.pinctrl[n].bank,
+						 i2c_handle.pinctrl[n].pin);
+
+	stm32mp_register_non_secure_periph_iomem(i2c_handle.base.pa);
+
+	/*
+	 * Non secure PMIC can be used by secure world during power state
+	 * transition when non-secure world is suspended. Therefore secure
+	 * the I2C clock parents, if not specifically the I2C clock itself.
+	 */
+	stm32mp_register_clock_parents_secure(i2c_handle.clock);
+}
+
+static void register_secure_pmic(void)
+{
+	size_t n = 0;
+
+	for (n = 0; n < i2c_handle.pinctrl_count; n++)
+		stm32mp_register_secure_gpio(i2c_handle.pinctrl[n].bank,
+					     i2c_handle.pinctrl[n].pin);
+
+	stm32mp_register_secure_periph_iomem(i2c_handle.base.pa);
+	register_pm_driver_cb(pmic_pm, NULL);
+}
+
+static TEE_Result initialize_pmic(void)
+{
+	unsigned long pmic_version = 0;
+
+	if (!initialize_pmic_i2c()) {
+		DMSG("No PMIC");
+		register_non_secure_pmic();
+		return TEE_SUCCESS;
+	}
+
+	stm32mp_get_pmic();
+
+	if (stpmic1_get_version(&pmic_version))
+		panic("Failed to access PMIC");
+
+	DMSG("PMIC version = 0x%02lx", pmic_version);
+	stpmic1_dump_regulators();
+
+	if (save_power_configurations())
+		panic();
+
+	if (dt_pmic_is_secure())
+		register_secure_pmic();
+	else
+		register_non_secure_pmic();
+
+	stm32mp_put_pmic();
+
+	return TEE_SUCCESS;
+}
+driver_init(initialize_pmic);
+

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2017-2018, STMicroelectronics - All Rights Reserved
+ * Copyright (c) 2017-2019, STMicroelectronics
  */
 
 #ifndef __STM32MP1_PMIC_H__

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics - All Rights Reserved
+ */
+
+#ifndef __STM32MP1_PMIC_H__
+#define __STM32MP1_PMIC_H__
+
+#include <kernel/panic.h>
+
+#ifdef CFG_STPMIC1
+void stm32mp_pmic_apply_boot_on_config(void);
+void stm32mp_pmic_apply_lp_config(const char *lp_state);
+void stm32mp_get_pmic(void);
+void stm32mp_put_pmic(void);
+#else
+static inline void stm32mp_pmic_apply_boot_on_config(void)
+{
+}
+static inline void stm32mp_pmic_apply_lp_config(const char *lp_state __unused)
+{
+}
+static inline void stm32mp_get_pmic(void)
+{
+	panic();
+}
+static inline void stm32mp_put_pmic(void)
+{
+	panic();
+}
+#endif
+
+#endif /*__STM32MP1_PMIC_H__*/

--- a/core/arch/arm/plat-stm32mp1/drivers/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/drivers/sub.mk
@@ -1,3 +1,4 @@
 srcs-y 	+= stm32mp1_clk.c
+srcs-$(CFG_STPMIC1) += stm32mp1_pmic.c
 srcs-y 	+= stm32mp1_pwr.c
 srcs-y 	+= stm32mp1_rcc.c

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -264,6 +264,11 @@ void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg)
 	cfg->closed_device_position = DATA0_OTP_SECURED_POS;
 }
 
+bool __weak stm32mp_with_pmic(void)
+{
+	return false;
+}
+
 uint32_t may_spin_lock(unsigned int *lock)
 {
 	if (!lock || !cpu_mmu_enabled())

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -36,6 +36,9 @@ vaddr_t stm32_get_gpio_bank_base(unsigned int bank);
 unsigned int stm32_get_gpio_bank_offset(unsigned int bank);
 unsigned int stm32_get_gpio_bank_clock(unsigned int bank);
 
+/* Platform util for PMIC support */
+bool stm32mp_with_pmic(void);
+
 /* Power management service */
 #ifdef CFG_PSCI_ARM32
 void stm32mp_register_online_cpu(void);


### PR DESCRIPTION
Implement a power management device driver for the platform to handle
STPMIC1 as external regulator control device. This driver is embedded upon
CFG_STPMIC1=y and get the regulator definition and configuration from the
device tree.

Platform implements stm32mp_with_pmic() which returns whether or not a
PMIC device is used to control external regulators.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
