### PR TITLE
stm32mp1: SiP SMCs for BSEC access

### DIFF
--- a/core/arch/arm/dts/stm32mp157a-dk1.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1.dts
@@ -253,3 +253,16 @@
 	status = "okay";
 	secure-status = "disable";
 };
+
+&bsec {
+	/*
+	 * Board ID occupies 4 bytes in BSEC upper secure words.
+	 * status = "okay" states non-secure can access the fuse
+	 * through BSEC service.
+	 */
+	board_id: board_id@ec {
+		reg = <0xec 0x4>;
+		status = "okay";
+		secure-status = "okay";
+	};
+};

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -272,3 +272,16 @@
 	status = "okay";
 	secure-status = "disable";
 };
+
+&bsec {
+	/*
+	 * Board ID occupies 4 bytes in BSEC upper secure words.
+	 * status = "okay" states non-secure can access the fuse
+	 * through BSEC service.
+	 */
+	board_id: board_id@ec {
+		reg = <0xec 0x4>;
+		status = "okay";
+		secure-status = "okay";
+	};
+};

--- a/core/arch/arm/dts/stm32mp157c.dtsi
+++ b/core/arch/arm/dts/stm32mp157c.dtsi
@@ -1247,11 +1247,58 @@
 			reg = <0x5c005000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ts_cal1: calib@5c {
+			/* Lower OTPs: implicitly non-secure in BSEC */
+			otp_cfg: cfg {
+				reg = <0x0 0x34>;
+			};
+			otp_id: id {
+				reg = <0x34 0xc>;
+			};
+			otp_hw: hw {
+				reg = <0x40 0x1c>;
+			};
+			otp_ts_cal1: calib@5c {
 				reg = <0x5c 0x2>;
 			};
-			ts_cal2: calib@5e {
+			otp_ts_cal2: calib@5e {
 				reg = <0x5e 0x2>;
+			};
+			otp_pkh: pkh {
+				reg = <0x60 0x20>;
+			};
+			/*
+			 * Upper OTPs: secure but may be accessed by non-secure
+			 * through BSEC SiP SMC service.
+			 *
+			 * NVMEM locations defined in BSEC DT node are
+			 * accessible to the non-secure world unless the node
+			 * explicity states:
+			 *	status = "disabled";
+			 *
+			 * NVMEM words not defined in BSEC DT node are
+			 * implicilty not accessible non-secure world.
+			 *
+			 * BSEC words have a 32bit access granularity.
+			 */
+			otp_ecdsa_for_ssp: ecdsa_for_ssp {
+				reg = <0x80 0x60>;
+				status = "disabled";
+				secure-status = "okay";
+			};
+			otp_rma: rma {
+				reg = <0xe0 0x4>;
+				status = "disabled";
+				secure-status = "okay";
+			};
+			/*
+			 * MAC access can be access from non-secure.
+			 * Enable access for the 2 32bit BSEC words (8 NVMEM bytes).
+			 * MAC address occupies the 6 first bytes.
+			 */
+			mac_addr: mac_addr@e4 {
+				reg = <0xe4 0x8>;
+				status = "okay";
+				secure-status = "okay";
 			};
 		};
 

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -49,6 +49,9 @@ CFG_STM32_RNG ?= y
 CFG_STM32_RNG ?= y
 CFG_STM32_UART ?= y
 
+# SiP/OEM service for non-secure world
+CFG_STM32_BSEC_SIP ?= y
+
 # Default enable some test facitilites
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STATS ?= y

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -15,6 +15,7 @@ $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_PSCI_ARM32,y)
 $(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_SM_PLATFORM_HANDLER,y)
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
 
 ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-512M)),)

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -269,8 +269,6 @@ void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg)
 	cfg->base = BSEC_BASE;
 	cfg->upper_start = STM32MP1_UPPER_OTP_START;
 	cfg->max_id = STM32MP1_OTP_MAX_ID;
-	cfg->closed_device_id = DATA0_OTP;
-	cfg->closed_device_position = DATA0_OTP_SECURED_POS;
 }
 
 bool stm32mp_is_closed_device(void)

--- a/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.c
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2016-2019, STMicroelectronics
+ */
+
+#include <drivers/stm32_bsec.h>
+#include <tee_api_types.h>
+#include <trace.h>
+
+#include "bsec_svc.h"
+#include "stm32mp1_smc.h"
+
+uint32_t bsec_main(uint32_t cmd, uint32_t otp_id, uint32_t in_value,
+		   uint32_t *out_value)
+{
+	TEE_Result result = TEE_ERROR_GENERIC;
+	uint32_t tmp = 0;
+
+	if (!stm32_bsec_nsec_can_access_otp(otp_id))
+		return STM32_SIP_SVC_INVALID_PARAMS;
+
+	switch (cmd) {
+	case STM32_SIP_SVC_BSEC_READ_SHADOW:
+		result = stm32_bsec_read_otp(out_value, otp_id);
+		FMSG("read shadow @%" PRIx32 " = %" PRIx32, otp_id, *out_value);
+		break;
+	case STM32_SIP_SVC_BSEC_PROG_OTP:
+		FMSG("program @%" PRIx32, otp_id);
+		result = stm32_bsec_program_otp(in_value, otp_id);
+		break;
+	case STM32_SIP_SVC_BSEC_WRITE_SHADOW:
+		FMSG("write shadow @%" PRIx32, otp_id);
+		result = stm32_bsec_write_otp(in_value, otp_id);
+		break;
+	case STM32_SIP_SVC_BSEC_READ_OTP:
+		result = stm32_bsec_read_otp(&tmp, otp_id);
+		if (result != TEE_SUCCESS)
+			break;
+
+		result = stm32_bsec_shadow_register(otp_id);
+		if (result != TEE_SUCCESS)
+			break;
+
+		result = stm32_bsec_read_otp(out_value, otp_id);
+		if (result != TEE_SUCCESS)
+			break;
+
+		result = stm32_bsec_write_otp(tmp, otp_id);
+		FMSG("read @%" PRIx32 " = %" PRIx32, otp_id, *out_value);
+		break;
+	default:
+		EMSG("Invalid 0x%" PRIx32, cmd);
+		result = TEE_ERROR_BAD_PARAMETERS;
+		break;
+	}
+
+	switch (result) {
+	case TEE_SUCCESS:
+		return STM32_SIP_SVC_OK;
+	case TEE_ERROR_BAD_PARAMETERS:
+		return STM32_SIP_SVC_INVALID_PARAMS;
+	default:
+		return STM32_SIP_SVC_FAILED;
+	}
+}

--- a/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.h
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2016-2018, STMicroelectronics
+ */
+
+#ifndef __STM32MP1_BSEC_SVC_H__
+#define __STM32MP1_BSEC_SVC_H__
+
+#include <stdint.h>
+#include <stm32mp1_smc.h>
+
+#ifdef CFG_STM32_BSEC_SIP
+uint32_t bsec_main(uint32_t cmd, uint32_t otp_id, uint32_t in_value,
+		   uint32_t *out_value);
+#else
+static inline uint32_t bsec_main(uint32_t cmd __unused,
+				 uint32_t otp_id __unused,
+				 uint32_t in_value __unused,
+				 uint32_t *out_value __unused)
+{
+	return STM32_SIP_SVC_FAILED;
+}
+#endif
+
+#endif /*__STM32MP1_BSEC_SVC_H__*/

--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_smc.h
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_smc.h
@@ -12,7 +12,7 @@
 #define STM32_SIP_SVC_VERSION_MAJOR	0x0
 #define STM32_SIP_SVC_VERSION_MINOR	0x1
 
-#define STM32_SIP_SVC_FUNCTION_COUNT	0x0
+#define STM32_SIP_SVC_FUNCTION_COUNT	0x1
 
 /* SIP service generic return codes */
 #define STM32_SIP_SVC_OK		0x0
@@ -69,6 +69,24 @@
  * Argument a1: (output) STM32 SIP service minor
  */
 #define STM32_SIP_SVC_FUNC_VERSION		0xff03
+
+/*
+ * SIP functions STM32_SIP_SVC_FUNC_BSEC
+ *
+ * Argument a0: (input) SMCC ID
+ *		(output) status return code
+ * Argument a1: (input) Service ID (STM32_SIP_BSEC_xxx)
+ * Argument a2: (input) OTP index
+ *		(output) OTP read value, if applicable
+ * Argument a3: (input) OTP value if applicable
+ */
+#define STM32_SIP_SVC_FUNC_BSEC			0x1003
+
+/* Service ID for STM32_SIP_FUNC_BSEC */
+#define STM32_SIP_SVC_BSEC_READ_SHADOW		0x1
+#define STM32_SIP_SVC_BSEC_PROG_OTP		0x2
+#define STM32_SIP_SVC_BSEC_WRITE_SHADOW		0x3
+#define STM32_SIP_SVC_BSEC_READ_OTP		0x4
 
 /* Generic input/output arguments for an SMC */
 struct smc_args {

--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_smc.h
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_smc.h
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2016-2018, STMicroelectronics
+ * Copyright (c) 2018, Linaro Limited
+ */
+#ifndef __STM32MP1_SMC_H__
+#define __STM32MP1_SMC_H__
+
+/*
+ * SIP Functions
+ */
+#define STM32_SIP_SVC_VERSION_MAJOR	0x0
+#define STM32_SIP_SVC_VERSION_MINOR	0x1
+
+#define STM32_SIP_SVC_FUNCTION_COUNT	0x0
+
+/* SIP service generic return codes */
+#define STM32_SIP_SVC_OK		0x0
+#define STM32_SIP_SVC_UNKNOWN_FUNCTION	OPTEE_SMC_RETURN_UNKNOWN_FUNCTION
+#define STM32_SIP_SVC_FAILED		0xfffffffeU
+#define STM32_SIP_SVC_INVALID_PARAMS	0xfffffffdU
+
+/*
+ * SMC function IDs for STM32 Service queries
+ * STM32 SMC services use the space between 0x82000000 and 0x8200FFFF
+ * like this is defined in SMC calling Convention by ARM
+ * for SiP (Silicon Partner)
+ * http://infocenter.arm.com/help/topic/com.arm.doc.den0028a/index.html
+ */
+
+/*
+ * SIP function STM32_SIP_FUNC_CALL_COUNT
+ *
+ * Argument a0: (input) SMCC ID
+ *		(output) dummy value 0
+ */
+#define STM32_SIP_SVC_FUNC_CALL_COUNT		0xff00
+
+
+/*
+ * Return the following UID if using API specified in this file without
+ * further extensions:
+ * 50aa78a7-9bf4-4a14-8a5e-264d5994c214.
+ *
+ * Represented in 4 32-bit words in STM32_SIP_UID_0, STM32_SIP_UID_1,
+ * STM32_SIP_UID_2, STM32_SIP_UID_3.
+ */
+#define STM32_SIP_SVC_UID_0			0x50aa78a7
+#define STM32_SIP_SVC_UID_1			0x9bf44a14
+#define STM32_SIP_SVC_UID_2			0x8a5e264d
+#define STM32_SIP_SVC_UID_3			0x5994c214
+
+/*
+ * SIP function STM32_SIP_SVC_FUNC_UID
+ *
+ * Argument a0: (input) SMCC ID
+ *		(output) Lowest 32bit of the stm32mp1 SIP service UUID
+ * Argument a1: (output) Next 32bit of the stm32mp1 SIP service UUID
+ * Argument a2: (output) Next 32bit of the stm32mp1 SIP service UUID
+ * Argument a3: (output) Last 32bit of the stm32mp1 SIP service UUID
+ */
+#define STM32_SIP_SVC_FUNC_UID			0xff01
+
+/*
+ * SIP function STM32_SIP_FUNC_VERSION
+ *
+ * Argument a0: (input) SMCC ID
+ *		(output) STM32 SIP service major
+ * Argument a1: (output) STM32 SIP service minor
+ */
+#define STM32_SIP_SVC_FUNC_VERSION		0xff03
+
+/* Generic input/output arguments for an SMC */
+struct smc_args {
+	uint32_t a0;
+	uint32_t a1;
+	uint32_t a2;
+	uint32_t a3;
+	uint32_t a4;
+	uint32_t a5;
+	uint32_t a6;
+	uint32_t a7;
+};
+
+#endif /* __STM32MP1_SMC_H__*/

--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stm32_util.h>
 
+#include "bsec_svc.h"
 #include "stm32mp1_smc.h"
 
 #define SM_NSEC_CTX_OFFSET(_reg)	(offsetof(struct sm_nsec_ctx, _reg) - \
@@ -31,6 +32,9 @@ static enum sm_handler_ret sip_service(struct sm_ctx *ctx __unused,
 		args->a1 = STM32_SIP_SVC_UID_1;
 		args->a2 = STM32_SIP_SVC_UID_2;
 		args->a3 = STM32_SIP_SVC_UID_3;
+		break;
+	case STM32_SIP_SVC_FUNC_BSEC:
+		args->a0 = bsec_main(args->a1, args->a2, args->a3, &args->a1);
 		break;
 	default:
 		return SM_HANDLER_PENDING_SMC;

--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
@@ -43,7 +43,6 @@ static enum sm_handler_ret sip_service(struct sm_ctx *ctx __unused,
 	return SM_HANDLER_SMC_HANDLED;
 }
 
-/* Override default sm_platform_handler() with paltform specific function */
 enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx)
 {
 	struct smc_args *args = (void *)&ctx->nsec.r0;

--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2017-2018, STMicroelectronics
+ */
+
+#include <arm.h>
+#include <sm/optee_smc.h>
+#include <sm/sm.h>
+#include <string.h>
+#include <stm32_util.h>
+
+#include "stm32mp1_smc.h"
+
+#define SM_NSEC_CTX_OFFSET(_reg)	(offsetof(struct sm_nsec_ctx, _reg) - \
+					 offsetof(struct sm_nsec_ctx, r0))
+#define SMC_ARGS_OFFSET(_reg)		offsetof(struct smc_args, _reg)
+
+static enum sm_handler_ret sip_service(struct sm_ctx *ctx __unused,
+				       struct smc_args *args)
+{
+	switch (OPTEE_SMC_FUNC_NUM(args->a0)) {
+	case STM32_SIP_SVC_FUNC_CALL_COUNT:
+		args->a0 = STM32_SIP_SVC_FUNCTION_COUNT;
+		break;
+	case STM32_SIP_SVC_FUNC_VERSION:
+		args->a0 = STM32_SIP_SVC_VERSION_MAJOR;
+		args->a1 = STM32_SIP_SVC_VERSION_MINOR;
+		break;
+	case STM32_SIP_SVC_FUNC_UID:
+		args->a0 = STM32_SIP_SVC_UID_0;
+		args->a1 = STM32_SIP_SVC_UID_1;
+		args->a2 = STM32_SIP_SVC_UID_2;
+		args->a3 = STM32_SIP_SVC_UID_3;
+		break;
+	default:
+		return SM_HANDLER_PENDING_SMC;
+	}
+
+	return SM_HANDLER_SMC_HANDLED;
+}
+
+/* Override default sm_platform_handler() with paltform specific function */
+enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx)
+{
+	struct smc_args *args = (void *)&ctx->nsec.r0;
+
+	COMPILE_TIME_ASSERT(SM_NSEC_CTX_OFFSET(r0) == SMC_ARGS_OFFSET(a0) &&
+			    SM_NSEC_CTX_OFFSET(r1) == SMC_ARGS_OFFSET(a1) &&
+			    SM_NSEC_CTX_OFFSET(r2) == SMC_ARGS_OFFSET(a2) &&
+			    SM_NSEC_CTX_OFFSET(r3) == SMC_ARGS_OFFSET(a3) &&
+			    SM_NSEC_CTX_OFFSET(r4) == SMC_ARGS_OFFSET(a4) &&
+			    SM_NSEC_CTX_OFFSET(r5) == SMC_ARGS_OFFSET(a5) &&
+			    SM_NSEC_CTX_OFFSET(r6) == SMC_ARGS_OFFSET(a6) &&
+			    SM_NSEC_CTX_OFFSET(r7) == SMC_ARGS_OFFSET(a7));
+
+	if (!OPTEE_SMC_IS_FAST_CALL(args->a0))
+		return SM_HANDLER_PENDING_SMC;
+
+	switch (OPTEE_SMC_OWNER_NUM(args->a0)) {
+	case OPTEE_SMC_OWNER_SIP:
+		return sip_service(ctx, args);
+	default:
+		return SM_HANDLER_PENDING_SMC;
+	}
+}

--- a/core/arch/arm/plat-stm32mp1/nsec-service/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/sub.mk
@@ -1,3 +1,4 @@
 global-incdirs-y += .
 
 srcs-y += stm32mp1_svc_setup.c
+srcs-$(CFG_STM32_BSEC_SIP) += bsec_svc.c

--- a/core/arch/arm/plat-stm32mp1/nsec-service/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/sub.mk
@@ -1,0 +1,3 @@
+global-incdirs-y += .
+
+srcs-y += stm32mp1_svc_setup.c

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -74,15 +74,11 @@ void stm32_reset_deassert(unsigned int id);
  * @base: BSEC interface registers physical base address
  * @upper_start: Base ID for the BSEC upper words in the platform
  * @max_id: Max value for BSEC word ID for the platform
- * @closed_device_id: BSEC word ID storing the "closed_device" OTP bit
- * @closed_device_position: Bit position of "closed_device" bit in the OTP word
  */
 struct stm32_bsec_static_cfg {
 	paddr_t base;
 	unsigned int upper_start;
 	unsigned int max_id;
-	unsigned int closed_device_id;
-	unsigned int closed_device_position;
 };
 
 void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg);

--- a/core/arch/arm/plat-stm32mp1/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/sub.mk
@@ -5,4 +5,5 @@ srcs-y += reset.S
 srcs-y += shared_resources.c
 
 subdirs-y += drivers
+subdirs-y += nsec-service
 subdirs-y += pm

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -113,7 +113,6 @@ struct bsec_dev {
 	struct io_pa_va base;
 	unsigned int upper_base;
 	unsigned int max_id;
-	bool closed_device;
 	uint32_t *nsec_access;
 };
 
@@ -651,20 +650,12 @@ static void initialize_bsec_from_dt(void)
 static TEE_Result initialize_bsec(void)
 {
 	struct stm32_bsec_static_cfg cfg = { };
-	uint32_t otp = 0;
-	TEE_Result result = TEE_ERROR_GENERIC;
 
 	stm32mp_get_bsec_static_cfg(&cfg);
 
 	bsec_dev.base.pa = cfg.base;
 	bsec_dev.upper_base = cfg.upper_start;
 	bsec_dev.max_id = cfg.max_id;
-	bsec_dev.closed_device = true;
-
-	/* Disable closed device mode upon platform closed device OTP value */
-	result = stm32_bsec_shadow_read_otp(&otp, cfg.closed_device_id);
-	if (!result && !(otp & BIT(cfg.closed_device_position)))
-		bsec_dev.closed_device = false;
 
 	initialize_bsec_from_dt();
 


### PR DESCRIPTION
This P-R implements management of SiP SMCs alllowing non-secure world to access platform secure fuses that platform secure device tree defines as accessible from non-secure world.

This service is used by U-boot package since its release v2019.07-rc1 [1] to retrieve information such as the device MAC address [2].

[1] https://github.com/u-boot/u-boot/blob/v2019.07-rc1/arch/arm/mach-stm32mp/include/mach/stm32mp1_smc.h
[2] https://github.com/u-boot/u-boot/blob/v2019.07-rc1/arch/arm/mach-stm32mp/cpu.c#L475