### PR TITLE
core: fix core panic when CFG_UNWIND=n

### DIFF
--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -276,6 +276,9 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 #else /* CFG_UNWIND */
 static void save_panic_stack(struct thread_svc_regs *regs __unused)
 {
+	struct thread_specific_data *tsd = thread_get_tsd();
+
+	tsd->abort_type = ABORT_TYPE_TA_PANIC;
 }
 #endif
 
@@ -367,6 +370,9 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 #else /* CFG_UNWIND */
 static void save_panic_stack(struct thread_svc_regs *regs __unused)
 {
+	struct thread_specific_data *tsd = thread_get_tsd();
+
+	tsd->abort_type = ABORT_TYPE_TA_PANIC;
 }
 #endif /* CFG_UNWIND */
 


### PR DESCRIPTION
This change fixes a core panic occurrence when a TA panics while core
is built with `CFG_TEE_CORE_DEBUG=y` and `CFG_UNWIND=n`.

When a TA panics while `CFG_UNWIND=n,` the thread specific data holding
`abort_type` was not loaded prior this change. The abort sequence that
print information to the console dumps now does not attemp to dump
un-relevant CPU register content.

Prior this change, ARM32 code could panic since reading an invalid SPSR
value when printing CPU state to the console, with an error trace like:
```
E/TC:? 0 TA panicked with code 0xbeef
E/TC:? 0 assertion 'thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR' failed at core/arch/arm/include/kernel/misc.h:22 <get_core_pos>
E/TC:0 0 Panic at core/kernel/assert.c:28 <_assert_break>
```

Prior this change ARM64 code printed irrelevant CPU state information
as below:
```
E/TC:? 0 TA panicked with code 0xbeef
E/TC:? 0
E/TC:? 0 User TA undef-abort at address 0x0
E/TC:? 0  esr 0x00000000  ttbr0 0x200000e173020   ttbr1 0x00000000   cidr 0x0
E/TC:? 0  cpu #0          cpsr 0x00000000
E/TC:? 0  x0  0000000000000000 x1  0000000000000000
(...)
E/TC:? 0  x30 0000000000000000 elr 0000000000000000
E/TC:? 0  sp_el0 0000000000000000
```

Fixes: c0bc8d0e7d72 ("core: print TA stack dump from thread context")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
