### PR TITLE
ref_count : panicked occurs in tee_ta_open_session

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -441,10 +441,7 @@ static void thread_alloc_and_run(struct thread_smc_args *args)
 
 	threads[n].flags = 0;
 	init_regs(threads + n, args);
-
-	/* Save Hypervisor Client ID */
-	threads[n].hyp_clnt_id = args->a7;
-
+	
 	thread_lazy_save_ns_vfp();
 	thread_resume(&threads[n].regs);
 }
@@ -517,9 +514,7 @@ static void thread_resume_from_rpc(struct thread_smc_args *args)
 
 	lock_global();
 
-	if (n < CFG_NUM_THREADS &&
-	    threads[n].state == THREAD_STATE_SUSPENDED &&
-	    args->a7 == threads[n].hyp_clnt_id)
+	if (n < CFG_NUM_THREADS && threads[n].state == THREAD_STATE_SUSPENDED)
 		threads[n].state = THREAD_STATE_ACTIVE;
 	else
 		rv = OPTEE_SMC_RETURN_ERESUME;


### PR DESCRIPTION
When panicked occurs in tee_ta_open_session(),
Thread will sleep in tee_ta_unlink_session,
The value of ref_count is initialized to 1 in tee_ta_init_session() and incremented by 1 in tee_ta_close_session(),
 then the value is 2, so the will loop will continue

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
