### PR TITLE
Explicit return values for `sm_platform_handler()` and `smc_std_handler()`

### DIFF
--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -7,6 +7,8 @@
 #ifndef SM_SM_H
 #define SM_SM_H
 
+#ifndef ASM
+
 #include <compiler.h>
 #include <types_ext.h>
 
@@ -122,4 +124,11 @@ enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx);
 
 void sm_save_unbanked_regs(struct sm_unbanked_regs *regs);
 void sm_restore_unbanked_regs(struct sm_unbanked_regs *regs);
+
+#endif /*!ASM*/
+
+/* 32 bit return value for sm_from_nsec() */
+#define SM_EXIT_TO_NON_SECURE		0
+#define SM_EXIT_TO_SECURE		1
+
 #endif /*SM_SM_H*/

--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -107,17 +107,23 @@ void *sm_get_sp(void);
  */
 void sm_init(vaddr_t stack_pointer);
 
+enum sm_handler_ret {
+	SM_HANDLER_SMC_HANDLED = 0,
+	SM_HANDLER_PENDING_SMC,
+};
+
 #ifndef CFG_SM_PLATFORM_HANDLER
-/*
- * Returns false if we handled the monitor service and should now return
- * back to the non-secure state
- */
-static inline bool sm_platform_handler(__unused struct sm_ctx *ctx)
+/* No platform handler in secure monitor, SMC shall reach OP-TEE core */
+static inline enum sm_handler_ret sm_platform_handler(__unused struct sm_ctx *c)
 {
-	return true;
+	return SM_HANDLER_PENDING_SMC;
 }
 #else
-bool sm_platform_handler(struct sm_ctx *ctx);
+/*
+ * Returns whether SMC was handled from platform handler in secure monitor
+ * or if it shall reach OP-TEE core .
+ */
+enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx);
 #endif
 
 void sm_save_unbanked_regs(struct sm_unbanked_regs *regs);

--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -112,13 +112,7 @@ enum sm_handler_ret {
 	SM_HANDLER_PENDING_SMC,
 };
 
-#ifndef CFG_SM_PLATFORM_HANDLER
-/* No platform handler in secure monitor, SMC shall reach OP-TEE core */
-static inline enum sm_handler_ret sm_platform_handler(__unused struct sm_ctx *c)
-{
-	return SM_HANDLER_PENDING_SMC;
-}
-#else
+#ifdef CFG_SM_PLATFORM_HANDLER
 /*
  * Returns whether SMC was handled from platform handler in secure monitor
  * or if it shall reach OP-TEE core .

--- a/core/arch/arm/plat-imx/sm_platform_handler.c
+++ b/core/arch/arm/plat-imx/sm_platform_handler.c
@@ -10,7 +10,7 @@
 #include "imx_sip.h"
 #include "imx_pl310.h"
 
-static bool imx_sip_handler(struct thread_smc_args *smc_args)
+static enum sm_handler_ret imx_sip_handler(struct thread_smc_args *smc_args)
 {
 	uint16_t sip_func = OPTEE_SMC_FUNC_NUM(smc_args->a0);
 
@@ -38,10 +38,10 @@ static bool imx_sip_handler(struct thread_smc_args *smc_args)
 		break;
 	}
 
-	return false;
+	return SM_HANDLER_SMC_HANDLED;
 }
 
-bool sm_platform_handler(struct sm_ctx *ctx)
+enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx)
 {
 	uint32_t *nsec_r0 = (uint32_t *)(&ctx->nsec.r0);
 	uint16_t smc_owner = OPTEE_SMC_OWNER_NUM(*nsec_r0);
@@ -50,6 +50,6 @@ bool sm_platform_handler(struct sm_ctx *ctx)
 	case OPTEE_SMC_OWNER_SIP:
 		return imx_sip_handler((struct thread_smc_args *)nsec_r0);
 	default:
-		return true;
+		return SM_HANDLER_PENDING_SMC;
 	}
 }

--- a/core/arch/arm/plat-ti/sm_platform_handler_a15.c
+++ b/core/arch/arm/plat-ti/sm_platform_handler_a15.c
@@ -33,7 +33,7 @@
 bool sm_platform_handler(struct sm_ctx *ctx)
 {
 	if (ctx->nsec.r12 == 0x200)
-		return true;
+		return SM_HANDLER_PENDING_SMC;
 
 	switch (ctx->nsec.r12) {
 	case API_MONITOR_ACTLR_SETREGISTER_INDEX:
@@ -51,5 +51,5 @@ bool sm_platform_handler(struct sm_ctx *ctx)
 		break;
 	}
 
-	return false;
+	return SM_HANDLER_SMC_HANDLED;
 }

--- a/core/arch/arm/plat-ti/sm_platform_handler_a9.c
+++ b/core/arch/arm/plat-ti/sm_platform_handler_a9.c
@@ -42,7 +42,7 @@ uint32_t suspend_regs[16];
 bool sm_platform_handler(struct sm_ctx *ctx)
 {
 	if (ctx->nsec.r12 == 0x200)
-		return true;
+		return SM_HANDLER_PENDING_SMC;
 
 	switch (ctx->nsec.r12) {
 	case 0x0:
@@ -93,5 +93,5 @@ bool sm_platform_handler(struct sm_ctx *ctx)
 		break;
 	}
 
-	return false;
+	return SM_HANDLER_SMC_HANDLED;
 }

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -31,8 +31,10 @@ bool sm_from_nsec(struct sm_ctx *ctx)
 	COMPILE_TIME_ASSERT(!(offsetof(struct sm_ctx, nsec.r0) % 8));
 	COMPILE_TIME_ASSERT(!(sizeof(struct sm_ctx) % 8));
 
+#ifdef CFG_SM_PLATFORM_HANDLER
 	if (sm_platform_handler(ctx) == SM_HANDLER_SMC_HANDLED)
 		return false;
+#endif
 
 #ifdef CFG_PSCI_ARM32
 	if (OPTEE_SMC_OWNER_NUM(*nsec_r0) == OPTEE_SMC_OWNER_STANDARD) {

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -13,6 +13,11 @@
 #include <string.h>
 #include "sm_private.h"
 
+/*
+ * Return false/0 if secure monitor shall retrun to non-secure and
+ * true/1 if secure monitor shall enter OP-TEE core to proceed
+ * invocation.
+ */
 bool sm_from_nsec(struct sm_ctx *ctx)
 {
 	uint32_t *nsec_r0 = (uint32_t *)(&ctx->nsec.r0);
@@ -26,7 +31,7 @@ bool sm_from_nsec(struct sm_ctx *ctx)
 	COMPILE_TIME_ASSERT(!(offsetof(struct sm_ctx, nsec.r0) % 8));
 	COMPILE_TIME_ASSERT(!(sizeof(struct sm_ctx) % 8));
 
-	if (!sm_platform_handler(ctx))
+	if (sm_platform_handler(ctx) == SM_HANDLER_SMC_HANDLED)
 		return false;
 
 #ifdef CFG_PSCI_ARM32

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -11,6 +11,7 @@
 #include <keep.h>
 #include <kernel/unwind.h>
 #include <sm/optee_smc.h>
+#include <sm/sm.h>
 #include <sm/teesmc_opteed.h>
 #include <sm/teesmc_opteed_macros.h>
 #include <util.h>
@@ -175,7 +176,7 @@ UNWIND(	.cantunwind)
 
 	mov	r0, sp
 	bl	sm_from_nsec
-	cmp	r0, #0
+	cmp	r0, #SM_EXIT_TO_NON_SECURE
 	beq	.sm_ret_to_nsec
 
 	/*

--- a/core/arch/arm/sm/sm_private.h
+++ b/core/arch/arm/sm/sm_private.h
@@ -6,7 +6,7 @@
 #ifndef SM_PRIVATE_H
 #define SM_PRIVATE_H
 
-/* Returns true if returning to sec, false if returning to nsec */
-bool sm_from_nsec(struct sm_ctx *ctx);
+/* Returns one of SM_EXIT_TO_* exit monitor in secure or non-secure world */
+uint32_t sm_from_nsec(struct sm_ctx *ctx);
 #endif /*SM_PRIVATE_H*/
 


### PR DESCRIPTION
Explicit return values for `sm_platform_handler()` and `smc_std_handler()` to state whether the SMC was handled or shall be relayed to another layer.
