### PR TITLE
drivers: wdt: Add arm SP805 watchdog driver

### DIFF
--- a/core/arch/arm/plat-bcm/conf.mk
+++ b/core/arch/arm/plat-bcm/conf.mk
@@ -23,6 +23,7 @@ $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 
 ifeq ($(PLATFORM_FLAVOR),ns3)
 $(call force,CFG_PL022,y)
+$(call force,CFG_SP805_WDT,y)
 $(call force,CFG_BCM_HWRNG,y)
 $(call force,CFG_BCM_SOTP,y)
 $(call force,CFG_BCM_GPIO,y)

--- a/core/drivers/sp805_wdt.c
+++ b/core/drivers/sp805_wdt.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019, Broadcom
+ *
+ */
+
+#include <drivers/sp805_wdt.h>
+#include <initcall.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/interrupt.h>
+#include <mm/core_memprot.h>
+#include <stdint.h>
+#include <trace.h>
+
+static vaddr_t chip_to_base(struct wdt_chip *chip)
+{
+	struct sp805_wdt_data *pd =
+		container_of(chip, struct sp805_wdt_data, chip);
+
+	return io_pa_or_va(&pd->base);
+}
+
+/* This routine finds load value that will reset system in required timeout */
+static void sp805_setload(struct wdt_chip *chip, unsigned long timeout)
+{
+	struct sp805_wdt_data *pd =
+		container_of(chip, struct sp805_wdt_data, chip);
+	uint32_t load;
+
+	/*
+	 * sp805 runs counter with given value twice, after the end of first
+	 * counter it gives an interrupt and then starts counter again. If
+	 * interrupt already occurred then it resets the system. This is why
+	 * load is half of what should be required.
+	 */
+	load = (pd->clk_rate / 2) * (timeout) - 1;
+
+	load = (load > WDT_LOAD_MAX) ? WDT_LOAD_MAX : load;
+	load = (load < WDT_LOAD_MIN) ? WDT_LOAD_MIN : load;
+
+	pd->load_val = load;
+}
+
+static void sp805_config(struct wdt_chip *chip, bool ping)
+{
+	struct sp805_wdt_data *pd =
+		container_of(chip, struct sp805_wdt_data, chip);
+	vaddr_t base = chip_to_base(chip);
+
+	io_write32(base + WDT_LOCK_OFFSET, WDT_UNLOCK_KEY);
+	io_write32(base + WDT_LOAD_OFFSET, pd->load_val);
+	io_write32(base + WDT_INTCLR_OFFSET, WDT_INT_CLR);
+
+	if (!ping)
+		io_write32(base + WDT_CONTROL_OFFSET,
+			   WDT_INT_EN | WDT_RESET_EN);
+
+	io_write32(base + WDT_LOCK_OFFSET, WDT_LOCK_KEY);
+
+	/* Flush posted writes. */
+	io_read32(base + WDT_LOCK_OFFSET);
+}
+
+static void sp805_ping(struct wdt_chip *chip)
+{
+	sp805_config(chip, true);
+}
+
+/* enables watchdog timers reset */
+static void sp805_enable(struct wdt_chip *chip)
+{
+	sp805_config(chip, false);
+}
+
+/* disables watchdog timers reset */
+static void sp805_disable(struct wdt_chip *chip)
+{
+	vaddr_t base = chip_to_base(chip);
+
+	io_write32(base + WDT_LOCK_OFFSET, WDT_UNLOCK_KEY);
+	io_write32(base + WDT_CONTROL_OFFSET, 0);
+	io_write32(base + WDT_LOCK_OFFSET, WDT_LOCK_KEY);
+
+	/* Flush posted writes. */
+	io_read32(base + WDT_LOCK_OFFSET);
+}
+
+static enum itr_return wdt_irq_cb(struct itr_handler *h __unused)
+{
+	struct wdt_chip *chip = h->data;
+	struct sp805_wdt_data *pd =
+		container_of(chip, struct sp805_wdt_data, chip);
+
+	if (pd->irq_handler)
+		pd->irq_handler(h);
+
+	return ITRR_HANDLED;
+}
+
+TEE_Result sp805_register_irq_handler(struct sp805_wdt_data *pd,
+				      uint32_t irq_num, uint32_t irq_flags,
+				      irq_handler_t irq_handler)
+{
+	struct itr_handler *wdt_irq = &pd->chip.wdt_irq;
+
+	wdt_irq->it = irq_num;
+	wdt_irq->flags = irq_flags;
+	wdt_irq->handler = wdt_irq_cb;
+	wdt_irq->data = &pd->chip;
+	pd->irq_handler = irq_handler;
+
+	itr_add(wdt_irq);
+	itr_enable(wdt_irq->it);
+
+	return TEE_SUCCESS;
+}
+
+static struct wdt_ops sp805_wdt_ops = {
+	.start = sp805_enable,
+	.stop = sp805_disable,
+	.ping = sp805_ping,
+	.set_timeout = sp805_setload,
+};
+KEEP_PAGER(sp805_wdt_ops);
+
+void sp805_wdt_init(struct sp805_wdt_data *pd, paddr_t base,
+		    uint32_t clk_rate, uint32_t timeout)
+{
+	assert(pd);
+	pd->base.pa = base;
+	pd->clk_rate = clk_rate;
+	pd->chip.ops = &sp805_wdt_ops;
+	sp805_setload(&pd->chip, timeout);
+}

--- a/core/drivers/sp805_wdt.c
+++ b/core/drivers/sp805_wdt.c
@@ -43,7 +43,7 @@ static TEE_Result sp805_setload(struct wdt_chip *chip, unsigned long timeout)
 	return TEE_SUCCESS;
 }
 
-static void sp805_config(struct wdt_chip *chip, bool ping)
+static void sp805_config(struct wdt_chip *chip, bool enable)
 {
 	struct sp805_wdt_data *pd =
 		container_of(chip, struct sp805_wdt_data, chip);
@@ -53,7 +53,7 @@ static void sp805_config(struct wdt_chip *chip, bool ping)
 	io_write32(base + WDT_LOAD_OFFSET, pd->load_val);
 	io_write32(base + WDT_INTCLR_OFFSET, WDT_INT_CLR);
 
-	if (!ping)
+	if (enable)
 		io_write32(base + WDT_CONTROL_OFFSET,
 			   WDT_INT_EN | WDT_RESET_EN);
 
@@ -65,12 +65,12 @@ static void sp805_config(struct wdt_chip *chip, bool ping)
 
 static void sp805_ping(struct wdt_chip *chip)
 {
-	sp805_config(chip, true);
+	sp805_config(chip, false);
 }
 
 static void sp805_enable(struct wdt_chip *chip)
 {
-	sp805_config(chip, false);
+	sp805_config(chip, true);
 }
 
 static void sp805_disable(struct wdt_chip *chip)

--- a/core/drivers/sp805_wdt.c
+++ b/core/drivers/sp805_wdt.c
@@ -106,7 +106,7 @@ TEE_Result sp805_register_itr_handler(struct sp805_wdt_data *pd,
 
 	assert(!pd->chip.wdt_itr);
 
-	wdt_itr = malloc(sizeof(*wdt_itr));
+	wdt_itr = calloc(1, sizeof(*wdt_itr));
 	if (!wdt_itr)
 		return TEE_ERROR_OUT_OF_MEMORY;
 

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -5,6 +5,7 @@ srcs-$(CFG_TZC380) += tzc380.c
 srcs-$(CFG_GIC) += gic.c
 srcs-$(CFG_PL061) += pl061_gpio.c
 srcs-$(CFG_PL022) += pl022_spi.c
+srcs-$(CFG_SP805_WDT) += sp805_wdt.c
 srcs-$(CFG_8250_UART) += serial8250_uart.c
 srcs-$(CFG_16550_UART) += ns16550.c
 srcs-$(CFG_IMX_SNVS) += imx_snvs.c

--- a/core/include/drivers/sp805_wdt.h
+++ b/core/include/drivers/sp805_wdt.h
@@ -3,11 +3,12 @@
  * Copyright 2019 Broadcom.
  */
 
-#ifndef SP805_H
-#define SP805_H
+#ifndef SP805_WDT_H
+#define SP805_WDT_H
 
 #include <drivers/wdt.h>
 #include <kernel/interrupt.h>
+#include <mm/core_memprot.h>
 #include <types_ext.h>
 
 /* SP805 register offset */
@@ -26,17 +27,16 @@
 #define WDT_INT_CLR		BIT(0)
 
 #define WDT_LOAD_MIN		0x1
-#define WDT_LOAD_MAX		0xffffffff
 
-typedef enum itr_return (*irq_handler_t)(struct itr_handler *h __unused);
+typedef void (*sp805_itr_handler_func_t)(struct wdt_chip *chip);
 
 struct sp805_wdt_data {
 	struct io_pa_va base;
 	struct wdt_chip chip;
 	uint32_t clk_rate;
 	uint32_t load_val;
-	uint32_t irq_num;
-	irq_handler_t irq_handler;
+	uint32_t itr_num;
+	sp805_itr_handler_func_t itr_handler;
 };
 
 /*
@@ -46,22 +46,23 @@ struct sp805_wdt_data {
  * @base: physical base address of sp805 watchdog timer
  * @clk_rate: rate of the clock driving the watchdog timer hardware
  * @timeout: watchdog timer timeout in seconds
+ * Return a TEE_Result compliant status
  */
-void sp805_wdt_init(struct sp805_wdt_data *pd, paddr_t base,
-			  uint32_t clk_rate, uint32_t timeout);
+TEE_Result sp805_wdt_init(struct sp805_wdt_data *pd, paddr_t base,
+		    uint32_t clk_rate, uint32_t timeout);
 
 /*
  * Optionally register sp805 watchdog timer interrupt handler
  *
  * @pd: platform data of sp805 watchdog timer for which interrupt handler
  * is to be registered
- * @irq_num: sp805 watchdog timer interrupt id
- * @irq_flag: interrupt attributes
- * @irq_handler: interrupt handler callback
+ * @itr_num: sp805 watchdog timer interrupt id
+ * @itr_flag: interrupt attributes
+ * @itr_handler: Optional interrupt handler callback
  * Return a TEE_Result compliant status
  */
-TEE_Result sp805_register_irq_handler(struct sp805_wdt_data *pd,
-				      uint32_t irq_num, uint32_t irq_flag,
-				      irq_handler_t irq_handler);
+TEE_Result sp805_register_itr_handler(struct sp805_wdt_data *pd,
+				      uint32_t itr_num, uint32_t itr_flag,
+				      sp805_itr_handler_func_t itr_handler);
 
-#endif /* SP805_H */
+#endif /* SP805_WDT_H */

--- a/core/include/drivers/sp805_wdt.h
+++ b/core/include/drivers/sp805_wdt.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2019 Broadcom.
+ */
+
+#ifndef SP805_H
+#define SP805_H
+
+#include <drivers/wdt.h>
+#include <kernel/interrupt.h>
+#include <types_ext.h>
+
+/* SP805 register offset */
+#define WDT_LOAD_OFFSET		0x000
+#define WDT_CONTROL_OFFSET	0x008
+#define WDT_INTCLR_OFFSET	0x00c
+#define WDT_LOCK_OFFSET		0xc00
+
+/* Magic word to unlock the wd registers */
+#define WDT_UNLOCK_KEY		0x1ACCE551
+#define WDT_LOCK_KEY		0x1
+
+/* Register field definitions */
+#define WDT_INT_EN		BIT(0)
+#define WDT_RESET_EN		BIT(1)
+#define WDT_INT_CLR		BIT(0)
+
+#define WDT_LOAD_MIN		0x1
+#define WDT_LOAD_MAX		0xffffffff
+
+typedef enum itr_return (*irq_handler_t)(struct itr_handler *h __unused);
+
+struct sp805_wdt_data {
+	struct io_pa_va base;
+	struct wdt_chip chip;
+	uint32_t clk_rate;
+	uint32_t load_val;
+	uint32_t irq_num;
+	irq_handler_t irq_handler;
+};
+
+/*
+ * Initialize sp805 watchdog timer
+ *
+ * @pd: allocated sp805 watchdog timer platform data
+ * @base: physical base address of sp805 watchdog timer
+ * @clk_rate: rate of the clock driving the watchdog timer hardware
+ * @timeout: watchdog timer timeout in seconds
+ */
+void sp805_wdt_init(struct sp805_wdt_data *pd, paddr_t base,
+			  uint32_t clk_rate, uint32_t timeout);
+
+/*
+ * Optionally register sp805 watchdog timer interrupt handler
+ *
+ * @pd: platform data of sp805 watchdog timer for which interrupt handler
+ * is to be registered
+ * @irq_num: sp805 watchdog timer interrupt id
+ * @irq_flag: interrupt attributes
+ * @irq_handler: interrupt handler callback
+ * Return a TEE_Result compliant status
+ */
+TEE_Result sp805_register_irq_handler(struct sp805_wdt_data *pd,
+				      uint32_t irq_num, uint32_t irq_flag,
+				      irq_handler_t irq_handler);
+
+#endif /* SP805_H */

--- a/core/include/drivers/wdt.h
+++ b/core/include/drivers/wdt.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2019 Broadcom.
+ */
+
+#ifndef DRIVERS_WDT_H
+#define DRIVERS_WDT_H
+
+#include <kernel/interrupt.h>
+#include <mm/core_memprot.h>
+
+struct wdt_chip {
+	struct wdt_ops *ops;
+	struct itr_handler wdt_irq;
+};
+
+struct wdt_ops {
+	void (*start)(struct wdt_chip *chip);
+	void (*stop)(struct wdt_chip *chip);
+	void (*ping)(struct wdt_chip *chip);
+	void (*set_timeout)(struct wdt_chip *chip, unsigned long timeout);
+};
+
+#endif /* DRIVERS_WDT_H */

--- a/core/include/drivers/wdt.h
+++ b/core/include/drivers/wdt.h
@@ -11,7 +11,7 @@
 
 struct wdt_chip {
 	const struct wdt_ops *ops;
-	struct itr_handler wdt_itr;
+	struct itr_handler *wdt_itr;
 };
 
 /*

--- a/core/include/drivers/wdt.h
+++ b/core/include/drivers/wdt.h
@@ -7,18 +7,30 @@
 #define DRIVERS_WDT_H
 
 #include <kernel/interrupt.h>
-#include <mm/core_memprot.h>
+#include <tee_api_types.h>
 
 struct wdt_chip {
-	struct wdt_ops *ops;
-	struct itr_handler wdt_irq;
+	const struct wdt_ops *ops;
+	struct itr_handler wdt_itr;
 };
 
+/*
+ * struct wdt_ops - The watchdog device operations
+ *
+ * @start:	The routine for starting the watchdog device.
+ * @stop:	The routine for stopping the watchdog device.
+ * @ping:	The routine that sends a keepalive ping to the watchdog device.
+ * @set_timeout:The routine that finds the load value that will reset system in
+ * required timeout (in seconds).
+ *
+ * The wdt_ops structure contains a list of low-level operations
+ * that control a watchdog device.
+ */
 struct wdt_ops {
 	void (*start)(struct wdt_chip *chip);
 	void (*stop)(struct wdt_chip *chip);
 	void (*ping)(struct wdt_chip *chip);
-	void (*set_timeout)(struct wdt_chip *chip, unsigned long timeout);
+	TEE_Result (*set_timeout)(struct wdt_chip *chip, unsigned long timeout);
 };
 
 #endif /* DRIVERS_WDT_H */


### PR DESCRIPTION
Add sp805 watchdog driver with following functionality:
- start/reload watchdog with specified timeout
- stop watchdog
- ping watchdog (clear watchdog interrupt and reload it)
- register watchdog interrupt handler

Signed-off-by: Abhishek Shah <abhishek.shah@broadcom.com>
Reviewed-by: Sandeep Tripathy <sandeep.tripathy@broadcom.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
