### PR TITLE
plat-k3: Add J721E device support

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -68,6 +68,8 @@ build:
     - _make PLATFORM=imx-mx7dsabresd
     - _make PLATFORM=imx-imx8mmevk
     - _make PLATFORM=imx-imx8mqevk
+    - _make PLATFORM=k3-j721e
+    - _make PLATFORM=k3-j721e CFG_ARM64_core=y
     - _make PLATFORM=k3-am65x
     - _make PLATFORM=k3-am65x CFG_ARM64_core=y
     - _make PLATFORM=ti-dra7xx

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -148,7 +148,7 @@ R:	Etienne Carriere <etienne.carriere@st.com>
 S:	Maintained
 F:	core/arch/arm/plat-stm32mp1/
 
-Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x
+Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x, J721E
 R:	Andrew F. Davis <afd@ti.com>
 S:	Maintained
 F:	core/arch/arm/plat-ti/

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -19,10 +19,17 @@
 #define CONSOLE_UART_CLK_IN_HZ  48000000
 
 #define SCU_BASE        0x01800000
+#if defined(PLATFORM_FLAVOR_j721e)
+#define GICC_OFFSET     0x100000
+#define GICC_SIZE       0x100000
+#define GICD_OFFSET     0x0
+#define GICD_SIZE       0x10000
+#else
 #define GICC_OFFSET     0x80000
 #define GICC_SIZE       0x90000
 #define GICD_OFFSET     0x0
 #define GICD_SIZE       0x10000
+#endif
 #define GICC_BASE       (SCU_BASE + GICC_OFFSET)
 #define GICD_BASE       (SCU_BASE + GICD_OFFSET)
 


### PR DESCRIPTION
The only difference from AM65x that OP-TEE cares about currently is the
GICC offset and size. Update the same.

Signed-off-by: Andrew F. Davis <afd@ti.com>
