### PR TITLE
ref_count : panicked occurs in tee_ta_open_session

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -670,6 +670,7 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 
 	if (!ctx || ctx->panicked) {
 		DMSG("panicked, call tee_ta_close_session()");
+		tee_ta_put_session(s);
 		tee_ta_close_session(s, open_sessions, KERN_IDENTITY);
 		*err = TEE_ORIGIN_TEE;
 		return TEE_ERROR_TARGET_DEAD;


### PR DESCRIPTION
When panicked happens in tee_ta_open_session(),
The tee_ta_close_session() function calls the tee_ta_get_session() function.
Increase the value of ref_count by 1, then the value of ref_count is 2, then the tee_ta_unlink_session() function
Will be called, this function will check if ref_count is 1, and thus continue to loop

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
