### PR TITLE
core: imx: Fix compilation warning leading to build breakage

### DIFF
--- a/core/arch/arm/plat-imx/imx6.c
+++ b/core/arch/arm/plat-imx/imx6.c
@@ -31,6 +31,7 @@
 #include <compiler.h>
 #include <drivers/gic.h>
 #include <io.h>
+#include <imx_caam.h>
 #include <kernel/generic_boot.h>
 #include <kernel/misc.h>
 #include <kernel/tz_ssvce_pl310.h>

--- a/core/arch/arm/plat-imx/imx_caam.c
+++ b/core/arch/arm/plat-imx/imx_caam.c
@@ -13,7 +13,7 @@
 
 void init_caam(void)
 {
-	struct imx_caam_ctrl *caam = (struct caam_ctrl *)CAAM_BASE;
+	struct imx_caam_ctrl *caam = (struct imx_caam_ctrl *)(vaddr_t)CAAM_BASE;
 	uint32_t reg;
 	int i;
 


### PR DESCRIPTION
Commit 4cb61ae7d98e ("core: imx: Add simple CAAM permissions set routine")
has the following cast, which has a typo resulting in a forward declaration
of "struct caam_ctrl" which is not in fact a structure defined anywhere.

struct imx_caam_ctrl *caam = (struct caam_ctrl *)CAAM_BASE;

It looks like it shouldn't compile but, it does.

Fixes: 4cb61ae7d98e ("core: imx: Add simple CAAM permissions set routine")

Signed-off-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
Reported-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
