### PR TITLE
TA dev kit: always link shared libraries against OP-TEE libraries

### DIFF
--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -19,8 +19,11 @@ cleanfiles += $(link-out-dir)/$(shlibuuid).ta
 
 shlink-ldflags  = $(LDFLAGS)
 shlink-ldflags += -shared -z max-page-size=4096
+shlink-ldflags += --as-needed # Do not add dependency on unused shlib
 
 shlink-ldadd  = $(LDADD)
+shlink-ldadd += $(addprefix -L,$(libdirs))
+shlink-ldadd += --start-group $(addprefix -l,$(libnames)) --end-group
 ldargs-$(shlibname).so := $(shlink-ldflags) $(objs) $(shlink-ldadd)
 
 


### PR DESCRIPTION
If a TA shared library is created, and needs to call OP-TEE functions,
it needs to link against the TEE libraries (libutee, libutils etc.) in
a similar way to TAs.

This patch adds the proper flags.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
