### PR TITLE
ftrace: Add 32 bit apps and function execution time support

### DIFF
--- a/ldelf/ftrace.c
+++ b/ldelf/ftrace.c
@@ -35,7 +35,8 @@ bool ftrace_init(void)
 
 	assert(elf && elf->is_main);
 
-	if (SUB_OVERFLOW(finfo->buf_end, finfo->buf_start, &fbuf_size))
+	if (SUB_OVERFLOW(finfo->buf_end.ptr64, finfo->buf_start.ptr64,
+			 &fbuf_size))
 		return false;
 
 	if (fbuf_size < MIN_FTRACE_BUF_SIZE) {
@@ -43,14 +44,14 @@ bool ftrace_init(void)
 		return false;
 	}
 
-	fbuf = (struct ftrace_buf *)finfo->buf_start;
+	fbuf = (struct ftrace_buf *)finfo->buf_start.ptr64;
 	fbuf->head_off = sizeof(struct ftrace_buf);
 	count = snprintk((char *)fbuf + fbuf->head_off, MAX_HEADER_STRLEN,
 			 "Function graph for TA: %pUl @ %lx\n",
 			 (void *)&elf->uuid, elf->load_addr);
 	assert(count < MAX_HEADER_STRLEN);
 
-	fbuf->ret_func_ptr = finfo->ret_ptr;
+	fbuf->ret_func_ptr = finfo->ret_ptr.ptr64;
 	fbuf->ret_idx = 0;
 	fbuf->lr_idx = 0;
 	fbuf->buf_off = fbuf->head_off + count;

--- a/lib/libutee/arch/arm/utee_mcount_a32.S
+++ b/lib/libutee/arch/arm/utee_mcount_a32.S
@@ -26,25 +26,36 @@
  */
 FUNC __gnu_mcount_nc, :
 	stmdb		sp!, {r0-r3, lr}
-	ldr		r0, [sp, #20]		/* lr of instrumented func */
 #ifdef CFG_TA_GPROF_SUPPORT
+	ldr		r0, [sp, #20]		/* lr of instrumented func */
 	mcount_adj_pc	r0, r0
 	mcount_adj_pc	r1, lr			/* instrumented func */
 	bl		__mcount_internal
+#endif
+#ifdef CFG_TA_FTRACE_SUPPORT
+	/* Get instrumented function's pc value */
+	ldr		r0, [sp, #16]
+	mcount_adj_pc	r0, r0
+	/* Get instrumented function's lr address pointer */
+	sub		r1, fp, #4
+	bl		ftrace_enter
 #endif
 	ldmia		sp!, {r0-r3, ip, lr}
 	bx		ip
 END_FUNC __gnu_mcount_nc
 
 #ifdef CFG_TA_FTRACE_SUPPORT
-/*
- * ftrace is not yet supported in 32bit mode. Currently this is just a
- * placeholder to avoid linking error.
- */
 FUNC __ftrace_return, :
-	push		{lr}
-	pop		{ip, lr}
-	bx		ip
+	/* save return value regs */
+	stmdb		sp!, {r0-r3}
+
+	/* get return address of parent func */
+	bl		ftrace_return
+	mov		lr, r0
+
+	/* restore return value regs */
+	ldmia		sp!, {r0-r3}
+	bx		lr
 END_FUNC __ftrace_return
 #endif
 

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -36,10 +36,18 @@ struct ta_head {
 
 #if defined(CFG_TA_FTRACE_SUPPORT)
 #define FTRACE_RETFUNC_DEPTH		50
+union compat_ptr {
+	uint64_t ptr64;
+	struct {
+		uint32_t lo;
+		uint32_t hi;
+	} ptr32;
+};
+
 struct __ftrace_info {
-	uintptr_t buf_start;
-	uintptr_t buf_end;
-	uintptr_t ret_ptr;
+	union compat_ptr buf_start;
+	union compat_ptr buf_end;
+	union compat_ptr ret_ptr;
 };
 
 struct ftrace_buf {

--- a/lib/libutils/isoc/arch/arm/setjmp_a32.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a32.S
@@ -213,6 +213,18 @@ SYM (\name):
 	sfmea		f4, 4, [a1]
 #endif
 #endif		
+
+#ifdef CFG_TA_FTRACE_SUPPORT
+	stmdb		sp!, { lr }
+	/*
+	 * As ftrace is supported in ARM mode only, so hardcode jmp_buf
+	 * offset used to save ftrace return index.
+	 */
+	add		a1, a1, #48
+	bl		ftrace_setjmp
+	ldmia		sp!, { lr }
+#endif
+
 	/* When setting up the jump buffer return 0.  */
 	mov		a1, #0
 
@@ -226,6 +238,17 @@ SYM (\name):
 
 	/* If we have stack extension code it ought to be handled here.  */
 	
+#ifdef CFG_TA_FTRACE_SUPPORT
+	stmdb		sp!, { a1, a2, lr }
+	/*
+	 * As ftrace is supported in ARM mode only, so hardcode jmp_buf
+	 * offset used to restore ftrace return stack.
+	 */
+	add		a1, a1, #92
+	bl		ftrace_longjmp
+	ldmia		sp!, { a1, a2, lr }
+#endif
+
 	/* Restore the registers, retrieving the state when setjmp() was called.  */
 #ifdef __thumb2__
 	ldmfd		a1!, { v1-v7, fp, ip, lr }

--- a/lib/libutils/isoc/arch/arm/sub.mk
+++ b/lib/libutils/isoc/arch/arm/sub.mk
@@ -7,6 +7,16 @@ srcs-$(CFG_ARM32_$(sm)) += arm32_aeabi_ldivmod_a32.S
 srcs-$(CFG_ARM32_$(sm)) += arm32_aeabi_ldivmod.c
 srcs-$(CFG_ARM32_$(sm)) += arm32_aeabi_shift.c
 
+ifeq ($(CFG_ULIBS_MCOUNT),y)
+# We would not like to profile __aeabi functions as these provide
+# internal implementations for "/ %" operations. Also, "/ %" operations
+# could be used inside profiling code which could create an incorrect
+# cyclic behaviour.
+cflags-remove-arm32_aeabi_divmod.c-y += -pg
+cflags-remove-arm32_aeabi_ldivmod.c-y += -pg
+cflags-remove-arm32_aeabi_shift.c-y += -pg
+endif
+
 srcs-$(CFG_ARM32_$(sm)) += setjmp_a32.S
 srcs-$(CFG_ARM64_$(sm)) += setjmp_a64.S
 

--- a/lib/libutils/isoc/include/setjmp.h
+++ b/lib/libutils/isoc/include/setjmp.h
@@ -38,8 +38,10 @@
 /*
  * All callee preserved registers:
  * v1 - v7, fp, ip, sp, lr, f4, f5, f6, f7
+ * One additional 32-bit value used in case ftrace
+ * is enabled to restore ftrace return stack.
  */
-#define _JBLEN 23
+#define _JBLEN 24
 #define _JBTYPE int
 #endif
 

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -127,9 +127,15 @@ const size_t ta_num_props = sizeof(ta_props) / sizeof(ta_props[0]);
 
 #ifdef CFG_TA_FTRACE_SUPPORT
 struct __ftrace_info __ftrace_info = {
-	.buf_start = (uintptr_t)&__ftrace_buf_start,
-	.buf_end = (uintptr_t)__ftrace_buf_end,
-	.ret_ptr = (uintptr_t)&__ftrace_return,
+#ifdef __ILP32__
+	.buf_start.ptr32 = { .lo = (uint32_t)&__ftrace_buf_start },
+	.buf_end.ptr32 = { .lo = (uint32_t)__ftrace_buf_end },
+	.ret_ptr.ptr32 = { .lo = (uint32_t)&__ftrace_return },
+#else
+	.buf_start.ptr64 = (uint64_t)&__ftrace_buf_start,
+	.buf_end.ptr64 = (uint64_t)__ftrace_buf_end,
+	.ret_ptr.ptr64 = (uint64_t)&__ftrace_return,
+#endif
 };
 #endif
 


### PR DESCRIPTION
This patch-set adds ftrace support for 32 bit apps as well as function execution time. So after this patch-set function graph would look something like:

```
              | __ta_entry() {
              |  __utee_entry() {
     1.168 us |   ta_header_get_session();
     1.392 us |   __utee_to_param();
              |   TA_InvokeCommandEntryPoint() {
              |    ta_entry_params_access_rights() {
    31.392 us |     TEE_CheckMemoryAccessRights();
    28.176 us |     TEE_CheckMemoryAccessRights();
   173.984 us |    }
   202.448 us |   }
     1.152 us |   __utee_from_param();
              |   ta_header_save_params() {
      .656 us |    memset();
     5.488 us |   }
   275.824 us |  }
   281.424 us | }
```

Looking forward to your valuable feedback/comments.

Regards,
Sumit