### PR TITLE
arm32: prevent unwinding of __ta_entry()

### DIFF
--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -187,14 +187,6 @@ TEE_Result __utee_entry(unsigned long func, unsigned long session_id,
 {
 	TEE_Result res;
 
-#if defined(ARM32) && defined(CFG_UNWIND)
-	/*
-	 * This function is the bottom of the user call stack: mark it as such
-	 * so that the unwinding code won't try to go further down.
-	 */
-	asm(".cantunwind");
-#endif
-
 	switch (func) {
 	case UTEE_ENTRY_FUNC_OPEN_SESSION:
 		res = entry_open_session(session_id, up);

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -36,6 +36,14 @@ void __noreturn __ta_entry(unsigned long func, unsigned long session_id,
 {
 	TEE_Result res = TEE_SUCCESS;
 
+#if defined(ARM32) && defined(CFG_UNWIND)
+	/*
+	 * This function is the bottom of the user call stack: mark it as such
+	 * so that the unwinding code won't try to go further down.
+	 */
+	asm(".cantunwind");
+#endif
+
 	res = __utee_entry(func, session_id, up, cmd_id);
 
 #if defined(CFG_TA_FTRACE_SUPPORT)

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -33,6 +33,7 @@ ta-mk-file-export-vars-$(sm) += CFG_SYSTEM_PTA
 ta-mk-file-export-vars-$(sm) += CFG_TA_DYNLINK
 ta-mk-file-export-vars-$(sm) += CFG_TEE_TA_LOG_LEVEL
 ta-mk-file-export-vars-$(sm) += CFG_TA_FTRACE_SUPPORT
+ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.


### PR DESCRIPTION
Since commit eeb866c431db ("Add TA entry point function: __ta_entry()"),
__ta_entry() is the first function in the user space call stack, not
__utee_entry(). Therefore, the asm(".cantunwind") declaration should be
moved from __utee_entry() to __ta_entry().

When utee_return() was moved from __utee_entry() to __ta_entry() by
commit fde3a7f212f8 ("Remove redundant __noreturn from __utee_entry()"),
it caused a regression in xtest 1010.3. The stack unwinding would enter
an infinite loop as follows:

 E/TC:? 0 User TA prefetch-abort at address 0x0 (translation fault)
 E/TC:? 0  fsr 0x00000005  ttbr0 0x3f07906a  ttbr1 0x3f06c06a  cidr 0x2
 E/TC:? 0  cpu #7          cpsr 0x80000110
 E/TC:? 0  r0 0x00000001      r4 0x00161448    r8 0x00161438   r12 0x00152f80
 E/TC:? 0  r1 0x00000002      r5 0x00152f40    r9 0x00152f30    sp 0x00152f10
 E/TC:? 0  r2 0x00000000      r6 0x00152f80   r10 0x0000000a    lr 0x0015498d
 E/TC:? 0  r3 0x00152f14      r7 0x00161458   r11 0x00245420    pc 0x00000000
 E/TC:? 0 Status of TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b (0x3f069c30) (active)
 E/TC:? 0  arch: arm  load address: 0x00153000 ctx-idr: 2
 E/TC:? 0  stack: 0x00150000 12288
 E/TC:? 0  region  0: va 0x00100000 pa 0x3f000000 size 0x002000 flags ---R-X
 E/TC:? 0  region  1: va 0x00150000 pa 0x3f110000 size 0x003000 flags rw-RW-
 E/TC:? 0  region  2: va 0x00153000 pa 0x3f113000 size 0x00e000 flags r-xR-- [0] .ta_head .text .plt .rodata .ARM.extab .ARM.extab.text.unlikely .ARM.extab.text.__aeabi_ldivmod .ARM.extab.text.__aeabi_uldivmod .ARM.extab.text.utee_panic .ARM.exidx .dynsym .dynstr .hash
 E/TC:? 0  region  3: va 0x00161000 pa 0x3f121000 size 0x0e5000 flags rw-RW- [0] .got .rel.got .rel.plt .dynamic .data .bss .rel.dyn
 E/TC:? 0  region  4: va 0x00246000 pa 0x3f101000 size 0x001000 flags r-xR-- [1] .hash .dynsym .dynstr .rel.plt .plt .text .ARM.exidx
 E/TC:? 0  region  5: va 0x00247000 pa 0x3f102000 size 0x001000 flags rw-RW- [1] .dynamic .got
 E/TC:? 0  region  6: va 0x00248000 pa 0x3f100000 size 0x001000 flags r-----
 E/TC:? 0  [0] 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b @ 0x00153000 (optee_test/out/ta/os_test/5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf)
 E/TC:? 0  [1] ffd2bded-ab7d-4988-95ee-e4962fff7154 @ 0x00246000 (optee_test/out/ta/os_test_lib/libos_test.so)
 E/TC:? 0 Call stack:
 E/TC:? 0  0x00000000 ???
 E/TC:? 0  0x0015c629 __ta_entry at optee_os/out/arm/export-ta_arm32/src/user_ta_header.c:41
 E/TC:? 0  0x0015c62d tahead_get_trace_level at optee_os/out/arm/export-ta_arm32/src/user_ta_header.c:117
 E/TC:? 0  0x0015c62d tahead_get_trace_level at optee_os/out/arm/export-ta_arm32/src/user_ta_header.c:117
 ...

Moving the .cantunwind directive fixes the issue.

Fixes: fde3a7f212f8 ("Remove redundant __noreturn from __utee_entry()")
Fixes: eeb866c431db ("Add TA entry point function: __ta_entry()")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
