### PR TITLE
svc: fix behavior of TEE_StartPersistentObjectEnumerator

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -706,11 +706,16 @@ TEE_Result syscall_storage_start_enum(unsigned long obj_enum,
 	if (res != TEE_SUCCESS)
 		return res;
 
+	if (e->dir) {
+		e->fops->closedir(e->dir);
+		e->dir = NULL;
+	}
+
 	if (!fops)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	e->fops = fops;
-	assert(!e->dir);
+
 	return fops->opendir(&sess->ctx->uuid, &e->dir);
 }
 


### PR DESCRIPTION
According to the GlobalPlatform specification it should be possible to
call TEE_StartPersistentObjectEnumerator(..) on an enumerator that
already has been started. When doing that we trigged an assert and ended
up with a panic. This patch fixes that issue by ensuring that we are
closing the currently open directory before re-opening or opening
another directory in those cases where
TEE_StartPersistentObjectEnumerator(..) are called again and again with
no reset done in-between.

Fixes: https://github.com/OP-TEE/optee_os/issues/3093

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Reported-by: Daniel McIlvaney <damcilva@microsoft.com>

(I'll see if I can add a couple of test to xtest for this also).