### PR TITLE
core: introduce OPTEE_SMC_SEC_CAP_VIRTUALIZATION

### DIFF
--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -269,6 +269,8 @@
 #define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	(1 << 0)
 /* Secure world can communicate via previously unregistered shared memory */
 #define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	(1 << 1)
+/* Secure world is built with virtualization support */
+#define OPTEE_SMC_SEC_CAP_VIRTUALIZATION	(1 << 2)
 
 /*
  * Secure world supports commands "register/unregister shared memory",

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -88,6 +88,9 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 #ifdef CFG_CORE_RESERVED_SHM
 	args->a1 |= OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM;
 #endif
+#ifdef CFG_VIRTUALIZATION
+	args->a1 |= OPTEE_SMC_SEC_CAP_VIRTUALIZATION;
+#endif
 
 #if defined(CFG_CORE_DYN_SHM)
 	dyn_shm_en = core_mmu_nsec_ddr_is_defined();


### PR DESCRIPTION
We need some way to tell normal world if OP-TEE does support
virtualization. Prior to this patch NW had to probe for virtualization by
calling OPTEE_SMC_VM_DESTROYED which is not reliable.

New capability flag OPTEE_SMC_SEC_CAP_VIRTUALIZATION solves this issue.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
