### PR TITLE
core: pager: fix NULL deref in tee_pager_pgt_save_and_release_entries()

### DIFF
--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -1496,8 +1496,9 @@ void tee_pager_assign_uta_tables(struct user_ta_ctx *utc)
 
 void tee_pager_pgt_save_and_release_entries(struct pgt *pgt)
 {
-	struct tee_pager_pmem *pmem;
-	struct tee_pager_area *area;
+	struct tee_pager_pmem *pmem = NULL;
+	struct tee_pager_area *area = NULL;
+	struct tee_pager_area_head *areas = NULL;
 	uint32_t exceptions = pager_lock_check_stack(SMALL_PAGE_SIZE);
 
 	if (!pgt->num_used_entries)
@@ -1510,9 +1511,12 @@ void tee_pager_pgt_save_and_release_entries(struct pgt *pgt)
 	assert(!pgt->num_used_entries);
 
 out:
-	TAILQ_FOREACH(area, to_user_ta_ctx(pgt->ctx)->areas, link) {
-		if (area->pgt == pgt)
-			area->pgt = NULL;
+	areas = to_user_ta_ctx(pgt->ctx)->areas;
+	if (areas) {
+		TAILQ_FOREACH(area, areas, link) {
+			if (area->pgt == pgt)
+				area->pgt = NULL;
+		}
 	}
 
 	pager_unlock(exceptions);


### PR DESCRIPTION
Fixes a potential NULL dereference in
tee_pager_pgt_save_and_release_entries() in case a struct user_ta_ctx
doesn't have an areas pointer allocated yet.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
