### PR TITLE
core: crypto: libtomcrypt: fix LTC_CLEAN_STACK bug

### DIFF
--- a/core/lib/libtomcrypt/src/misc/burn_stack.c
+++ b/core/lib/libtomcrypt/src/misc/burn_stack.c
@@ -49,10 +49,8 @@
 */
 void burn_stack(unsigned long len)
 {
-   unsigned char buf[32];
+   unsigned char buf[len];
    zeromem(buf, sizeof(buf));
-   if (len > (unsigned long)sizeof(buf))
-      burn_stack(len - sizeof(buf));
 }
 
 

--- a/core/lib/libtomcrypt/src/misc/zeromem.c
+++ b/core/lib/libtomcrypt/src/misc/zeromem.c
@@ -37,6 +37,7 @@
  * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
  */
 #include "tomcrypt.h"
+#include <string_ext.h>
 
 /**
    @file zeromem.c
@@ -50,11 +51,8 @@
 */
 void zeromem(volatile void *out, size_t outlen)
 {
-   volatile char *mem = out;
    LTC_ARGCHKVD(out != NULL);
-   while (outlen-- > 0) {
-      *mem++ = 0;
-   }
+   memzero_explicit((void *)out, outlen);
 }
 
 /* $Source: /cvs/libtom/libtomcrypt/src/misc/zeromem.c,v $ */


### PR DESCRIPTION
LTC_CLEAN_STACK uses burn_stack() API that uses a recursive call which
leads to approx. double the size of stack cleaned than expected on ARM64.
So this causes stack overflow corrupting canaries in case we perform a
SHA512 hash operation which utilizes maximum stack as compared to other
libtomcrypt APIs. So get rid of this recursive call via using variable
length array to clean stack.

Also, convert zeromem() API as a wrapper to call memzero_explicit().

Fixes: ad565116a0d7 ("core: crypto: libtomcrypt: enable LTC_CLEAN_STACK")
Suggested-by: Daniel Thompson <daniel.thompson@linaro.org>
Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
