### PR TITLE
stm32mp1: disable RCC security in ST boards

### DIFF
--- a/core/arch/arm/dts/stm32mp157a-dk1.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1.dts
@@ -248,3 +248,8 @@
 	pinctrl-0 = <&uart4_pins_a>;
 	status = "okay";
 };
+
+&rcc {
+	status = "okay";
+	secure-status = "disable";
+};

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -267,3 +267,8 @@
 	vdda1v1-supply = <&reg11>;
 	vdda1v8-supply = <&reg18>;
 };
+
+&rcc {
+	status = "okay";
+	secure-status = "disable";
+};

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1232,7 +1232,9 @@ static TEE_Result stm32mp1_clk_early_init(void)
 	if (_fdt_get_status(fdt, node) & DT_STATUS_OK_SEC) {
 		io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
 	} else {
-		io_clrbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
+		if (io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN)
+			panic("Refuse to release RCC[TZEN]");
+
 		IMSG("RCC is non-secure");
 	}
 

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -273,6 +273,19 @@ void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg)
 	cfg->closed_device_position = DATA0_OTP_SECURED_POS;
 }
 
+bool stm32mp_is_closed_device(void)
+{
+	uint32_t otp = 0;
+	TEE_Result result = TEE_ERROR_GENERIC;
+
+	/* Non closed_device platform expects fuse well programmed to 0 */
+	result = stm32_bsec_shadow_read_otp(&otp, DATA0_OTP);
+	if (!result && !(otp & BIT(DATA0_OTP_SECURED_POS)))
+		return false;
+
+	return true;
+}
+
 uint32_t may_spin_lock(unsigned int *lock)
 {
 	if (!lock || !cpu_mmu_enabled())

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -672,6 +672,9 @@ static void check_rcc_secure_configuration(void)
 	enum stm32mp_shres id = STM32MP1_SHRES_COUNT;
 	bool have_error = false;
 
+	if (stm32mp_is_closed_device() && !secure)
+		panic();
+
 	for (id = 0; id < STM32MP1_SHRES_COUNT; id++) {
 		if  (shres_state[id] != SHRES_SECURE)
 			continue;

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -88,6 +88,11 @@ struct stm32_bsec_static_cfg {
 void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg);
 
 /*
+ * Return true if platform is in closed_device mode
+ */
+bool stm32mp_is_closed_device(void);
+
+/*
  * Shared registers support: common lock for accessing SoC registers
  * shared between several drivers.
  */


### PR DESCRIPTION
This series aims at allowing one to use upstream OP-TEE next 3.6.0 together with upstream Linux kernel (release 5.2) which support stm32mp1 ST boards but not yet with a secure hardened RCC SoC interface.

Once upstream Linux kernel will support fully secured stm32mp1, the ST board DTS files will be updated to enable back RCC secure hardening.

With this series, RCC secure hardening mandates secure bootloader also disabled RCC secure hardening which also complies with stm32mp1 support in upstream TF-A package.