### PR TITLE
ecc_sign_hash blinding CVE-2018-12437

### DIFF
--- a/core/lib/libtomcrypt/src/math/rand_bn.c
+++ b/core/lib/libtomcrypt/src/math/rand_bn.c
@@ -9,7 +9,6 @@
  */
 #include "tomcrypt.h"
 
-#ifdef LTC_MDSA
 /**
   Generate a random number N with given bitlength (note: MSB can be 0)
 */
@@ -68,4 +67,3 @@ int rand_bn_range(void *N, void *limit, prng_state *prng, int wprng)
 
    return CRYPT_OK;
 }
-#endif


### PR DESCRIPTION
This is originates from the LibTomCrypt upstream mitigation patch:
 f0a51bbdbd ("ecc_sign_hash blinding CVE-2018-12437") [1]

but with modifications to fit into the current LibTomCrypt version used
by OP-TEE (use the old function name rand_bn_range(..) instead of the
new name rand_bn_upto(..)).

[1] https://github.com/libtom/libtomcrypt/commit/f0a51bbdbd50e03a43914c9ee912c451b6ad82e5

Fixes: OP-TEE-2019-0018

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (QEMU-v7)
Reported-by: Santos Merino del Pozo <santos.research@gmail.com>
Suggested-by: Santos Merino del Pozo <santos.research@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
