### PR TITLE
core: fix icache_inv_user_range in AArch64

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -742,7 +742,7 @@ icache_inv_user_range:
 
 #else
 	mrs	x5, ttbr0_el1	/* this register must be preserved */
-	orr	x2, x2, #BIT(TTBR_ASID_SHIFT) /* switch to user mode ASID */
+	orr	x2, x5, #BIT(TTBR_ASID_SHIFT) /* switch to user mode ASID */
 	msr	ttbr0_el1, x2
 	isb
 #endif /*CFG_CORE_UNMAP_CORE_AT_EL0*/


### PR DESCRIPTION
Prior to this patch in the AArch64 version of icache_inv_user_range()
ttbr0_el1 was overwritten with garbage if CFG_CORE_UNMAP_CORE_AT_EL0=n.
This patch fixes this by instead modifying previously read value.

Fixes: 79083642a114 ("core: add icache_inv_user_range()")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

I stumbled over this, I'm pretty sure we'd like to have it included in the release.