### PR TITLE
core: console: fix use after free when CFG_DT=y

### DIFF
--- a/core/include/console.h
+++ b/core/include/console.h
@@ -29,15 +29,16 @@ void register_serial_console(struct serial_chip *chip);
  *
  * @fdt_out: Output DTB address where console directive is found
  * @offs_out: Output offset in the DTB where console directive is found
- * @path_out: Output string configuration of the console from in the DTB
- * @params_out: Output console parameters found from the DTB
+ * @path_out: Output string configuration of the console from the DTB.
+ * (*path_out) shall be freed using nex_free().
+ * @params_out: Output console parameters found from the DTB.
+ * (*params_out) shall be freed using nex_free().
  *
  * Return a TEE_Result compliant return value
  *
  */
 TEE_Result get_console_node_from_dt(void *fdt, int *offs_out,
-				    const char **path_out,
-				    const char **params_out);
+				    char **path_out, char **params_out);
 
 /*
  * Check if the /secure-chosen or /chosen node in the DT contains an


### PR DESCRIPTION
Commit 770b2afacf33 ("core: more flexible console init from DT") has
split configure_console_from_dt() in two parts, the first one being
moved to a new function: get_console_node_from_dt(). Unfortunately,
this function may return pointers to a freed buffer.

Fix the problem by allocating each output string on the heap and letting
the caller clean on return.

Fixes: 770b2afacf33 ("core: more flexible console init from DT")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
