### PR TITLE
ta: avb: solve an issue to write the AVB lock state in secure storage

### DIFF
--- a/ta/avb/entry.c
+++ b/ta/avb/entry.c
@@ -239,7 +239,12 @@ static TEE_Result write_lock_state(uint32_t pt,
 	if (count == sizeof(lock_state) && lock_state == wlock_state)
 		goto out;
 
-	res = create_rb_state(wlock_state, &h);
+	res = TEE_SeekObjectData(h, 0, TEE_DATA_SEEK_SET);
+	if (res)
+		goto out;
+
+	res = TEE_WriteObjectData(h, &wlock_state, sizeof(wlock_state));
+
 out:
 	TEE_CloseObject(h);
 	return res;

--- a/ta/avb/include/ta_avb.h
+++ b/ta/avb/include/ta_avb.h
@@ -39,7 +39,7 @@
 /*
  * Sets the lock state of the device.
  *
- * If the lock state is changed all rollback slots will be reset to 0
+ * The rollback slots are preserved.
  *
  * in	params[0].value.a:	lock state
  */


### PR DESCRIPTION
When writing the lock state, write_lock_state() returns
TEE_ERROR_ACCESS_CONFLICT. This error occurs because
TEE_CreatePersistentObject() tries to overwrite the file
but the file was already opened by TEE_OpenPersistentObject().
Use TEE_SeekObjectData() and TEE_WriteObjectData() instead.

Note that, when the lock state is updated, the rollback
indexes are preserved.

Signed-off-by: Alexandre Jutras <alexandre.jutras@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
