### PR TITLE
ftrace:  Add function execution time support

### DIFF
--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -37,6 +37,10 @@ struct sm_unbanked_regs {
 #ifdef CFG_SM_NO_CYCLE_COUNTING
 	uint32_t pmcr;
 #endif
+#ifdef CFG_TA_FTRACE_SUPPORT
+	uint32_t cntkctl;
+	uint32_t pad;
+#endif
 };
 
 struct sm_nsec_ctx {

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -533,11 +533,11 @@ static void thread_resume_from_rpc(struct thread_smc_args *args)
 
 	l->curr_thread = n;
 
-	if (is_user_mode(&threads[n].regs))
-		tee_ta_update_session_utime_resume();
-
 	if (threads[n].have_user_map)
 		core_mmu_set_user_map(&threads[n].user_map);
+
+	if (is_user_mode(&threads[n].regs))
+		tee_ta_update_session_utime_resume();
 
 	/*
 	 * Return from RPC to request service of a foreign interrupt must not

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1075,6 +1075,15 @@ void thread_init_per_cpu(void)
 	set_abt_stack(l, GET_STACK(stack_abt[pos]));
 
 	thread_init_vbar(get_excp_vect());
+
+#ifdef CFG_TA_FTRACE_SUPPORT
+	/*
+	 * Enable accesses to frequency register and physical counter
+	 * register in EL0/PL0 required for timestamping during
+	 * function tracing.
+	 */
+	write_cntkctl(read_cntkctl() | CNTKCTL_PL0PCTEN);
+#endif
 }
 
 struct thread_specific_data *thread_get_tsd(void)

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -252,6 +252,7 @@ static TEE_Result init_with_ldelf(struct tee_ta_session *sess,
 	utc->dump_entry_func = arg->dump_entry;
 #ifdef CFG_TA_FTRACE_SUPPORT
 	utc->ftrace_entry_func = arg->ftrace_entry;
+	sess->fbuf = arg->fbuf;
 #endif
 
 out:

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -44,6 +44,11 @@ UNWIND(	.cantunwind)
 	read_pmcr r2
 	stm	r0!, {r2}
 #endif
+
+#ifdef CFG_TA_FTRACE_SUPPORT
+	read_cntkctl r2
+	stm	r0!, {r2}
+#endif
 	cps	#CPSR_MODE_MON
 	bx	lr
 UNWIND(	.fnend)
@@ -75,6 +80,11 @@ UNWIND(	.cantunwind)
 #ifdef CFG_SM_NO_CYCLE_COUNTING
 	ldm	r0!, {r2}
 	write_pmcr r2
+#endif
+
+#ifdef CFG_TA_FTRACE_SUPPORT
+	ldm	r0!, {r2}
+	write_cntkctl r2
 #endif
 	cps	#CPSR_MODE_MON
 	bx	lr

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -107,6 +107,9 @@ struct tee_ta_session {
 #if defined(CFG_TA_GPROF_SUPPORT)
 	struct sample_buf *sbuf; /* Profiling data (PC sampling) */
 #endif
+#if defined(CFG_TA_FTRACE_SUPPORT)
+	struct ftrace_buf *fbuf; /* ftrace buffer */
+#endif
 };
 
 /* Registered contexts */
@@ -160,14 +163,17 @@ struct tee_ta_session *tee_ta_get_session(uint32_t id, bool exclusive,
 
 void tee_ta_put_session(struct tee_ta_session *sess);
 
-#if defined(CFG_TA_GPROF_SUPPORT)
-void tee_ta_gprof_sample_pc(vaddr_t pc);
+#if defined(CFG_TA_GPROF_SUPPORT) || defined(CFG_TA_FTRACE_SUPPORT)
 void tee_ta_update_session_utime_suspend(void);
 void tee_ta_update_session_utime_resume(void);
 #else
-static inline void tee_ta_gprof_sample_pc(vaddr_t pc __unused) {}
 static inline void tee_ta_update_session_utime_suspend(void) {}
 static inline void tee_ta_update_session_utime_resume(void) {}
+#endif
+#if defined(CFG_TA_GPROF_SUPPORT)
+void tee_ta_gprof_sample_pc(vaddr_t pc);
+#else
+static inline void tee_ta_gprof_sample_pc(vaddr_t pc __unused) {}
 #endif
 
 #endif

--- a/ldelf/ftrace.c
+++ b/ldelf/ftrace.c
@@ -53,6 +53,7 @@ bool ftrace_init(struct ftrace_buf **fbuf_ptr)
 	fbuf->ret_func_ptr = finfo->ret_ptr.ptr64;
 	fbuf->ret_idx = 0;
 	fbuf->lr_idx = 0;
+	fbuf->suspend_time = 0;
 	fbuf->buf_off = fbuf->head_off + count;
 	fbuf->curr_size = 0;
 	fbuf->max_size = fbuf_size - sizeof(struct ftrace_buf) - count;

--- a/ldelf/ftrace.c
+++ b/ldelf/ftrace.c
@@ -8,7 +8,6 @@
 #include <sys/queue.h>
 #include <types_ext.h>
 #include <util.h>
-#include <user_ta_header.h>
 
 #include "ftrace.h"
 #include "ta_elf.h"
@@ -16,11 +15,11 @@
 #define MIN_FTRACE_BUF_SIZE	1024
 #define MAX_HEADER_STRLEN	128
 
-static struct __ftrace_info *finfo;
 static struct ftrace_buf *fbuf;
 
-bool ftrace_init(void)
+bool ftrace_init(struct ftrace_buf **fbuf_ptr)
 {
+	struct __ftrace_info *finfo = NULL;
 	struct ta_elf *elf = TAILQ_FIRST(&main_elf_queue);
 	TEE_Result res = TEE_SUCCESS;
 	vaddr_t val = 0;
@@ -57,6 +56,8 @@ bool ftrace_init(void)
 	fbuf->buf_off = fbuf->head_off + count;
 	fbuf->curr_size = 0;
 	fbuf->max_size = fbuf_size - sizeof(struct ftrace_buf) - count;
+
+	*fbuf_ptr = fbuf;
 
 	return true;
 }

--- a/ldelf/ftrace.h
+++ b/ldelf/ftrace.h
@@ -7,11 +7,12 @@
 #define FTRACE_H
 
 #include <types_ext.h>
+#include <user_ta_header.h>
 
-bool ftrace_init(void);
+#ifdef CFG_TA_FTRACE_SUPPORT
+bool ftrace_init(struct ftrace_buf **fbuf_ptr);
 void ftrace_copy_buf(void *pctx, void (*copy_func)(void *pctx, void *b,
 						   size_t bl));
-#ifdef CFG_TA_FTRACE_SUPPORT
 void ftrace_map_lr(uint64_t *lr);
 #else
 static inline void ftrace_map_lr(uint64_t *lr __unused)

--- a/ldelf/include/ldelf.h
+++ b/ldelf/include/ldelf.h
@@ -8,6 +8,7 @@
 
 #include <types_ext.h>
 #include <tee_api_types.h>
+#include <user_ta_header.h>
 
 /* Size of stack for TEE Core to allocate */
 #define LDELF_STACK_SIZE	(4096 * 2)
@@ -21,6 +22,7 @@
  * @stack_ptr:	  [out] TA stack pointer
  * @dump_entry:	  [out] Dump TA mappings and stack trace
  * @ftrace_entry: [out] Dump TA mappings and ftrace buffer
+ * @fbuf:         [out] ftrace buffer pointer
  */
 struct ldelf_arg {
 	TEE_UUID uuid;
@@ -30,6 +32,7 @@ struct ldelf_arg {
 	uint64_t stack_ptr;
 	uint64_t dump_entry;
 	uint64_t ftrace_entry;
+	struct ftrace_buf *fbuf;
 };
 
 #define DUMP_MAP_READ	BIT(0)

--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -143,7 +143,7 @@ void ldelf(struct ldelf_arg *arg)
 
 	arg->ftrace_entry = 0;
 #ifdef CFG_TA_FTRACE_SUPPORT
-	if (ftrace_init())
+	if (ftrace_init(&arg->fbuf))
 		arg->ftrace_entry = (vaddr_t)(void *)ftrace_dump;
 #endif
 

--- a/lib/libutee/arch/arm/arm32_user_sysreg.txt
+++ b/lib/libutee/arch/arm/arm32_user_sysreg.txt
@@ -1,0 +1,13 @@
+# Format of file
+# <reg-name> <CRn> <opc1> <CRm> <opc2> <Type> <Description>
+# lines beginning with '@' will be printed as additional comments
+
+@ Based on register description in
+@ ARM Architecture Reference Manual
+@ ARMv7-A and ARMv7-R edition
+@ Issue C.c
+@
+
+@ B8.2 Generic Timer registers summary
+CNTFRQ    c14 0 c0  0 RW Counter Frequency register
+CNTPCT    -   0 c14 - RO Physical Count register

--- a/lib/libutee/include/arm64_user_sysreg.h
+++ b/lib/libutee/include/arm64_user_sysreg.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+#ifndef ARM64_USER_SYSREG_H
+#define ARM64_USER_SYSREG_H
+
+#include <compiler.h>
+#include <stdint.h>
+
+/*
+ * Templates for register read/write functions based on mrs/msr
+ */
+
+#define DEFINE_REG_READ_FUNC_(reg, type, asmreg)	\
+static inline __noprof type read_##reg(void)		\
+{							\
+	type val;					\
+							\
+	asm volatile("mrs %0, " #asmreg : "=r" (val));	\
+	return val;					\
+}
+
+#define DEFINE_REG_WRITE_FUNC_(reg, type, asmreg)		\
+static inline __noprof void write_##reg(type val)		\
+{								\
+	asm volatile("msr " #asmreg ", %0" : : "r" (val));	\
+}
+
+/* ARM Generic timer functions */
+DEFINE_REG_READ_FUNC_(cntfrq, uint32_t, cntfrq_el0)
+DEFINE_REG_READ_FUNC_(cntpct, uint64_t, cntpct_el0)
+
+#endif /*ARM64_USER_SYSREG_H*/

--- a/lib/libutee/include/arm_user_sysreg.h
+++ b/lib/libutee/include/arm_user_sysreg.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+#ifndef ARM_USER_SYSREG_H
+#define ARM_USER_SYSREG_H
+
+#include <util.h>
+
+#ifdef ARM32
+#include <arm32_user_sysreg.h>
+#endif
+
+#ifdef ARM64
+#include <arm64_user_sysreg.h>
+#endif
+
+#endif /*ARM_USER_SYSREG_H*/

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -55,6 +55,8 @@ struct ftrace_buf {
 	uint64_t ret_stack[FTRACE_RETFUNC_DEPTH]; /* Return stack */
 	uint32_t ret_idx;	/* Return stack index */
 	uint32_t lr_idx;	/* lr index used for stack unwinding */
+	uint64_t begin_time[FTRACE_RETFUNC_DEPTH]; /* Timestamp */
+	uint64_t suspend_time;	/* Suspend timestamp */
 	uint32_t curr_size;	/* Size of ftrace buffer */
 	uint32_t max_size;	/* Max allowed size of ftrace buffer */
 	uint32_t head_off;	/* Ftrace buffer header offset */

--- a/scripts/arm32_sysreg.py
+++ b/scripts/arm32_sysreg.py
@@ -69,7 +69,7 @@ def gen_read64_func(reg_name, opc1, crm, descr):
     print('')
     if len(descr):
         print('/* ' + descr + ' */')
-    print('static inline uint64_t read_' + reg_name.lower() + '(void)')
+    print('static inline __noprof uint64_t read_' + reg_name.lower() + '(void)')
     print('{')
     print('\tuint64_t v;')
     print('')
@@ -84,7 +84,8 @@ def gen_write64_func(reg_name, opc1, crm, descr):
     print('')
     if len(descr):
         print('/* ' + descr + ' */')
-    print('static inline void write_' + reg_name.lower() + '(uint64_t v)')
+    print('static inline __noprof void write_' + reg_name.lower() +
+          '(uint64_t v)')
     print('{')
     print('\tasm volatile ("mcrr p15, ' + opc1 + ', %Q0, %R0, ' +
           crm + '"' + ' : : "r"  (v));')
@@ -95,7 +96,7 @@ def gen_read32_func(reg_name, crn, opc1, crm, opc2, descr):
     print('')
     if len(descr):
         print('/* ' + descr + ' */')
-    print('static inline uint32_t read_' + reg_name.lower() + '(void)')
+    print('static inline __noprof uint32_t read_' + reg_name.lower() + '(void)')
     print('{')
     print('\tuint32_t v;')
     print('')
@@ -110,7 +111,8 @@ def gen_write32_func(reg_name, crn, opc1, crm, opc2, descr):
     print('')
     if len(descr):
         print('/* ' + descr + ' */')
-    print('static inline void write_' + reg_name.lower() + '(uint32_t v)')
+    print('static inline __noprof void write_' + reg_name.lower() +
+          '(uint32_t v)')
     print('{')
     print('\tasm volatile ("mcr p15, ' + opc1 + ', %0, ' + crn + ', ' +
           crm + ', ' + opc2 + '"' + ' : : "r"  (v));')
@@ -225,6 +227,7 @@ def main():
         if args.guard is not None:
             print('#ifndef ' + args.guard.upper().replace('.', '_'))
             print('#define ' + args.guard.upper().replace('.', '_'))
+        print('#include <compiler.h>')
 
     line_number = 0
     for line in sys.stdin:


### PR DESCRIPTION
This patch-set adds function execution time support and is in continuation of PR: https://github.com/OP-TEE/optee_os/pull/3080 with comments incorporated. So after this patch-set function graph would look something like:

```
              | __ta_entry() {
              |  __utee_entry() {
     1.168 us |   ta_header_get_session();
     1.392 us |   __utee_to_param();
              |   TA_InvokeCommandEntryPoint() {
              |    ta_entry_params_access_rights() {
    31.392 us |     TEE_CheckMemoryAccessRights();
    28.176 us |     TEE_CheckMemoryAccessRights();
   173.984 us |    }
   202.448 us |   }
     1.152 us |   __utee_from_param();
              |   ta_header_save_params() {
      .656 us |    memset();
     5.488 us |   }
   275.824 us |  }
   281.424 us | }
```
Looking forward to your valuable feedback/comments.

Regards,
Sumit