### PR TITLE
core_mmu: fix "outside of array bounds" warning

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -520,7 +520,7 @@ static void verify_special_mem_areas(struct tee_mmap_region *mem_map,
 		     area_name, mem->addr, (uint64_t)mem->addr + mem->size);
 
 	/* Check memories do not intersect each other */
-	for (mem = start; mem < end - 1; mem++) {
+	for (mem = start; mem + 1 < end; mem++) {
 		for (mem2 = mem + 1; mem2 < end; mem2++) {
 			if (core_is_buffer_intersect(mem2->addr, mem2->size,
 						     mem->addr, mem->size)) {


### PR DESCRIPTION
Newest versions of GCC (v9.1.0 at least) are unhappy about subtraction
from array pointer:

core/arch/arm/mm/core_mmu.c: In function 'core_init_mmu_map':
core/arch/arm/mm/core_mmu.c:523:30: warning: array subscript -1 is outside array bounds of 'const struct core_mmu_phys_mem[]' [-Warray-bounds]
  523 |  for (mem = start; mem < end - 1; mem++) {
      |                          ~~~~^~~
In file included from core/include/initcall.h:9,
                 from core/arch/arm/include/kernel/generic_boot.h:8,
                 from core/arch/arm/mm/core_mmu.c:11:
core/include/scattered_array.h:100:29: note: while referencing '__scattered_array_end'
  100 |   static const element_type __scattered_array_end[0] __unused \
      |                             ^~~~~~~~~~~~~~~~~~~~~

This is valid warning, as such pointer arithmetic produces undefined
behavior according to paragraph 5.6.5.8 of C99 standard. On other hand
the standard allows pointers that point past the last element of
array, so expression "mem + 1" is valid.

Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
