### PR TITLE
ldelf: fix warning in ftrace_init()

### DIFF
--- a/ldelf/ftrace.c
+++ b/ldelf/ftrace.c
@@ -44,7 +44,7 @@ bool ftrace_init(void)
 		return false;
 	}
 
-	fbuf = (struct ftrace_buf *)finfo->buf_start.ptr64;
+	fbuf = (struct ftrace_buf *)(vaddr_t)finfo->buf_start.ptr64;
 	fbuf->head_off = sizeof(struct ftrace_buf);
 	count = snprintk((char *)fbuf + fbuf->head_off, MAX_HEADER_STRLEN,
 			 "Function graph for TA: %pUl @ %lx\n",


### PR DESCRIPTION
Fixes warning in ftrace_init():

ldelf/ftrace.c: In function ‘ftrace_init’:
ldelf/ftrace.c:47:9: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  fbuf = (struct ftrace_buf *)finfo->buf_start.ptr64;
         ^
Fixes: c96d7091b566 ("ftrace: Enable support for 32 bit apps")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
