### PR TITLE
core: mmu: Update TCR_EL1 register when new physical address added

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1699,6 +1699,9 @@ bool core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len)
 	map->attr = core_mmu_type_to_attr(type);
 	map->pa = p;
 
+	/* Update TCR_EL1 with possiable maximum physical address change */
+	core_mmu_set_max_pa(map->pa + map->size);
+
 	set_region(&tbl_info, map);
 
 	/* Make sure the new entry is visible before continuing. */


### PR DESCRIPTION
Suppose in init stage all physical memory registered is in 0~4G,
the IPS bits (bit34~32) is set 0. Later a physical address 0x100000000
is dynamically mapping with core_mmu_add_mapping, since 0x100000000
is higher than 4G, the IPS bits of TCR_EL1 register should be updated
to 0x1. Otherwise the below panic occurs:

E/TC:00 check_pa_matches_va:1805 va 0x82a00000 maps 0x100000000, expect 0x0

As currently TCR_EL1 register is only set in init stage, this patch
also updates the register in core_mmu_add_mapping.

Signed-off-by: Fangsuo Wu <fangsuowu@asrmicro.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
