### PR TITLE
ta_bin_to_c.py: fix hex string conversion in python3

### DIFF
--- a/scripts/ta_bin_to_c.py
+++ b/scripts/ta_bin_to_c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2017, Linaro Limited
@@ -79,7 +79,7 @@ def main():
     while i < size:
         if i % 8 == 0:
             f.write('\t\t')
-        f.write('0x' + '{:02x}'.format(ord(bytes[i])) + ',')
+        f.write(hex(bytes[i]) + ',')
         i = i + 1
         if i % 8 == 0 or i == size:
             f.write('\n')


### PR DESCRIPTION
`zlib.compress()` behaves differently in python2 and python3.
It returns a string in python2, and it returns bytes object in python3.
Hence, the script fails during `ord()` conversion in python3.

This commit fixes by checking python version to perform proper
conversion before writing to a file.

Signed-off-by: Pipat Methavanitpong <pipat.methavanitpong@linaro.org>