### PR TITLE
Minimal HUK implementation without full CAAM driver

### DIFF
--- a/core/arch/arm/plat-imx/drivers/imx_caam.c
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.c
@@ -63,15 +63,15 @@ static void imx_caam_reset_jr(struct imx_caam_ctrl *ctrl)
 	uint32_t reg_val = 0;
 	uint32_t timeout = 1000;
 
-	io_write32((vaddr_t)&ctrl->jrcfg[0].jrcr, 1);
+	io_write32((vaddr_t)&ctrl->jrcfg[1].jrcr, 1);
 	do {
-		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[0].jrintr);
+		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[1].jrintr);
 		reg_val &= 0xc;
 	} while ((reg_val == 0x4) && --timeout);
 
-	io_write32((vaddr_t)&ctrl->jrcfg[0].jrcr, 1);
+	io_write32((vaddr_t)&ctrl->jrcfg[1].jrcr, 1);
 	do {
-		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[0].jrintr);
+		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[1].jrintr);
 		reg_val &= 0xc;
 	} while ((reg_val & 0x1) && --timeout);
 }
@@ -83,12 +83,12 @@ static void mkvb_init_jr(struct imx_mkvb *mkvb)
 	imx_caam_reset_jr(ctrl);
 	mkvb->njobs = 4;
 	io_write32((vaddr_t)&ctrl->jrstartr, 1);
-	io_write32((vaddr_t)&ctrl->jrcfg[0].irbar_ls,
+	io_write32((vaddr_t)&ctrl->jrcfg[1].irbar_ls,
 		   virt_to_phys(&mkvb->jr.inring));
-	io_write32((vaddr_t)&ctrl->jrcfg[0].irsr, mkvb->njobs);
-	io_write32((vaddr_t)&ctrl->jrcfg[0].orbar_ls,
+	io_write32((vaddr_t)&ctrl->jrcfg[1].irsr, mkvb->njobs);
+	io_write32((vaddr_t)&ctrl->jrcfg[1].orbar_ls,
 		   virt_to_phys(&mkvb->jr.outring));
-	io_write32((vaddr_t)&ctrl->jrcfg[0].orsr, mkvb->njobs);
+	io_write32((vaddr_t)&ctrl->jrcfg[1].orsr, mkvb->njobs);
 }
 
 static TEE_Result caam_get_mkvb(uint8_t *dest)
@@ -118,10 +118,10 @@ static TEE_Result caam_get_mkvb(uint8_t *dest)
 			sizeof(mkvb.jr.inring[0]));
 
 	/*  Tell CAAM that one job is available */
-	io_write32((vaddr_t)&mkvb.ctrl->jrcfg[0].irjar, 1);
+	io_write32((vaddr_t)&mkvb.ctrl->jrcfg[1].irjar, 1);
 
 	/*  Busy loop until job is completed */
-	while (io_read32((vaddr_t)&mkvb.ctrl->jrcfg[0].orsfr) != 1) {
+	while (io_read32((vaddr_t)&mkvb.ctrl->jrcfg[1].orsfr) != 1) {
 		counter++;
 		if (counter > 10000)
 			goto out;

--- a/core/arch/arm/plat-imx/drivers/imx_caam.c
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.c
@@ -21,8 +21,8 @@
 
 #include "imx_caam.h"
 
-uint8_t stored_key[32] = { 0 };
-bool mkvb_retrieved;
+static uint8_t stored_key[32] = { 0 };
+static bool mkvb_retrieved;
 
 static void caam_enable_clocks(bool enable)
 {
@@ -41,9 +41,9 @@ static void caam_enable_clocks(bool enable)
 	else
 		reg &= ~mask;
 
-	io_write32((ccm_base + CCM_CCGR0), reg);
+	io_write32(ccm_base + CCM_CCGR0, reg);
 
-	if ((soc_is_imx6dqp() || soc_is_imx6sdl() || soc_is_imx6dq())) {
+	if (soc_is_imx6dqp() || soc_is_imx6sdl() || soc_is_imx6dq()) {
 		/* EMI slow clk */
 		reg  = io_read32(ccm_base + CCM_CCGR6);
 		mask = CCM_CCGR6_EMI_SLOW;
@@ -124,7 +124,7 @@ static TEE_Result caam_get_mkvb(uint8_t *dest)
 	while (io_read32((vaddr_t)&mkvb.ctrl->jrcfg[0].orsfr) != 1) {
 		counter++;
 		if (counter > 10000)
-			break;
+			goto out;
 	}
 
 	cache_operation(TEE_CACHEINVALIDATE, &mkvb.jr, sizeof(mkvb.jr));

--- a/core/arch/arm/plat-imx/drivers/imx_caam.c
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.c
@@ -56,18 +56,18 @@ static TEE_Result imx_caam_reset_jr(struct imx_caam_ctrl *ctrl)
 	uint32_t reg_val = 0;
 	uint32_t timeout = 1000;
 
-	io_write32((vaddr_t)&ctrl->jrcfg[1].jrcr, 1);
+	io_write32((vaddr_t)&ctrl->jrcfg[MKVB_JR].jrcr, 1);
 	do {
-		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[1].jrintr);
+		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[MKVB_JR].jrintr);
 		reg_val &= 0xc;
 	} while ((reg_val == 0x4) && --timeout);
 
 	if (!timeout)
 		return TEE_ERROR_SECURITY;
 
-	io_write32((vaddr_t)&ctrl->jrcfg[1].jrcr, 1);
+	io_write32((vaddr_t)&ctrl->jrcfg[MKVB_JR].jrcr, 1);
 	do {
-		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[1].jrintr);
+		reg_val = io_read32((vaddr_t)&ctrl->jrcfg[MKVB_JR].jrintr);
 		reg_val &= 0xc;
 	} while ((reg_val & 0x1) && --timeout);
 

--- a/core/arch/arm/plat-imx/drivers/imx_caam.c
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.c
@@ -9,8 +9,49 @@
 #include <initcall.h>
 #include <io.h>
 #include <mm/core_memprot.h>
+#include <imx.h>
+#include <imx-regs.h>
+#include <io.h>
+#include <kernel/generic_boot.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stdint.h>
 
 #include "imx_caam.h"
+
+static void caam_enable_clocks(bool enable)
+{
+	vaddr_t ccm_base = core_mmu_get_va(CCM_BASE, MEM_AREA_IO_SEC);
+	uint32_t reg = 0;
+	uint32_t mask = 0;
+
+	reg = io_read32(ccm_base + CCM_CCGR0);
+
+	mask = CCM_CCGR0_CAAM_WRAPPER_IPG  |
+		CCM_CCGR0_CAAM_WRAPPER_ACLK |
+		CCM_CCGR0_CAAM_SECURE_MEM;
+
+	if (enable)
+		reg |= mask;
+	else
+		reg &= ~mask;
+
+	io_write32((ccm_base + CCM_CCGR0), reg);
+
+	if ((soc_is_imx6dqp() || soc_is_imx6sdl() || soc_is_imx6dq())) {
+		/* EMI slow clk */
+		reg  = io_read32(ccm_base + CCM_CCGR6);
+		mask = CCM_CCGR6_EMI_SLOW;
+
+		if (enable)
+			reg |= mask;
+		else
+			reg &= ~mask;
+
+		io_write32(ccm_base + CCM_CCGR6, reg);
+	}
+
+}
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CAAM_BASE, CORE_MMU_PGDIR_SIZE);
 
@@ -25,6 +66,7 @@ static TEE_Result init_caam(void)
 	if (!caam)
 		return TEE_ERROR_GENERIC;
 
+	caam_enable_clocks(true);
 	/*
 	 * Set job-ring ownership to non-secure by default.
 	 * A Linux kernel that runs after OP-TEE will run in normal-world

--- a/core/arch/arm/plat-imx/drivers/imx_caam.h
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.h
@@ -9,13 +9,15 @@
 #ifndef __IMX_CAAM_H__
 #define __IMX_CAAM_H__
 
+#include <compiler.h>
 #include <imx-regs.h>
 #include <stdint.h>
+#include <types_ext.h>
 
 struct imx_caam_job_ring {
 	uint32_t			jrmidr_ms;
 	uint32_t			jrmidr_ls;
-};
+} __packed;
 
 #define CAAM_NUM_JOB_RINGS		4
 
@@ -39,6 +41,6 @@ struct imx_caam_ctrl {
 	uint32_t			res1;
 	uint32_t			scfgr;
 	struct imx_caam_job_ring	jr[CAAM_NUM_JOB_RINGS];
-};
+} __packed;
 
 #endif /* __IMX_CAAM_H__ */

--- a/core/arch/arm/plat-imx/drivers/imx_caam.h
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.h
@@ -23,6 +23,15 @@ struct imx_caam_job_ring {
 #define JROWN_NS			BIT(3)
 #define JROWN_MID			0x01
 
+/* i.MX6 CAAM clocks bits  */
+#define CCM_CCGR0		0x0068
+#define CCM_CCGR6		0x0080
+
+#define CCM_CCGR0_CAAM_WRAPPER_IPG	SHIFT_U32(3, 12)
+#define CCM_CCGR0_CAAM_SECURE_MEM	SHIFT_U32(3, 8)
+#define CCM_CCGR0_CAAM_WRAPPER_ACLK	SHIFT_U32(3, 10)
+#define CCM_CCGR6_EMI_SLOW		SHIFT_U32(3, 10)
+
 /* A basic sub-set of the CAAM */
 struct imx_caam_ctrl {
 	uint32_t			res0;

--- a/core/arch/arm/plat-imx/drivers/imx_caam.h
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.h
@@ -34,6 +34,14 @@ struct imx_caam_job_ring {
 #define CCM_CCGR0_CAAM_WRAPPER_ACLK	SHIFT_U32(3, 10)
 #define CCM_CCGR6_EMI_SLOW		SHIFT_U32(3, 10)
 
+/* Descriptor and MKVB Definitions */
+#define MKVB_SIZE			32
+#define MKVB_DESC_SEQ_OUT		0xf8000020
+#define MKVB_DESC_HEADER		0xb0800004
+#define MKVB_DESC_BLOB			0x870d0002
+
+/* PRIBLOB Bits */
+#define PRIBLOB_11			3
 /* jr configuration registers */
 struct imx_caam_jr_ctrl {
 	uint32_t	irbar;
@@ -82,5 +90,23 @@ struct imx_caam_ctrl {
 	uint8_t				padding2[4004];
 	struct imx_caam_jr_ctrl		jrcfg[CAAM_NUM_JOB_RINGS];
 } __packed;
+
+#define MKVB_CL_SIZE	64
+
+struct imx_mkvb {
+	struct {
+		struct {
+			uint32_t desc;
+		} inring[8];
+		struct {
+			uint32_t desc;
+			uint32_t status;
+		} __packed outring[4];
+	} __packed __aligned(MKVB_CL_SIZE) jr;
+	uint32_t descriptor[16] __aligned(MKVB_CL_SIZE);
+	char outbuf[MKVB_CL_SIZE] __aligned(MKVB_CL_SIZE);
+	size_t njobs;
+	struct imx_caam_ctrl *ctrl;
+};
 
 #endif /* __IMX_CAAM_H__ */

--- a/core/arch/arm/plat-imx/drivers/imx_caam.h
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.h
@@ -42,6 +42,10 @@ struct imx_caam_job_ring {
 
 /* PRIBLOB Bits */
 #define PRIBLOB_11			3
+
+/* PRIBLOB Bits */
+#define MKVB_JR				1
+
 /* jr configuration registers */
 struct imx_caam_jr_ctrl {
 	uint32_t	irbar;

--- a/core/arch/arm/plat-imx/drivers/imx_caam.h
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.h
@@ -34,6 +34,41 @@ struct imx_caam_job_ring {
 #define CCM_CCGR0_CAAM_WRAPPER_ACLK	SHIFT_U32(3, 10)
 #define CCM_CCGR6_EMI_SLOW		SHIFT_U32(3, 10)
 
+/* jr configuration registers */
+struct imx_caam_jr_ctrl {
+	uint32_t	irbar;
+	uint32_t	irbar_ls;
+	uint8_t		padding[4];
+	uint32_t	irsr;
+	uint8_t		padding2[4];
+	uint32_t	irsar;
+	uint8_t		padding3[4];
+	uint32_t	irjar;
+	uint32_t	orbar;
+	uint32_t	orbar_ls;
+	uint8_t		padding4[4];
+	uint32_t	orsr;
+	uint8_t		padding5[4];
+	uint32_t	orjrr;
+	uint8_t		padding6[4];
+	uint32_t	orsfr;
+	uint8_t		padding7[4];
+	uint32_t	jrstar;
+	uint8_t		padding8[4];
+	uint32_t	jrintr;
+	uint32_t	jrcfgr_ms;
+	uint32_t	jrcfgr_ls;
+	uint8_t		padding9[4];
+	uint32_t	irrir;
+	uint8_t		padding10[4];
+	uint32_t	orwir;
+	uint8_t		padding11[4];
+	uint32_t	jrcr;
+	uint8_t		padding12[1688];
+	uint32_t	jraav;
+	uint8_t		padding13[2292];
+} __packed;
+
 /* A basic sub-set of the CAAM */
 struct imx_caam_ctrl {
 	uint32_t			res0;
@@ -41,6 +76,11 @@ struct imx_caam_ctrl {
 	uint32_t			res1;
 	uint32_t			scfgr;
 	struct imx_caam_job_ring	jr[CAAM_NUM_JOB_RINGS];
+	uint8_t				padding[36];
+	uint32_t			debugctl;
+	uint32_t			jrstartr;
+	uint8_t				padding2[4004];
+	struct imx_caam_jr_ctrl		jrcfg[CAAM_NUM_JOB_RINGS];
 } __packed;
 
 #endif /* __IMX_CAAM_H__ */

--- a/core/arch/arm/plat-imx/drivers/imx_caam.h
+++ b/core/arch/arm/plat-imx/drivers/imx_caam.h
@@ -43,8 +43,9 @@ struct imx_caam_job_ring {
 /* PRIBLOB Bits */
 #define PRIBLOB_11			3
 
-/* PRIBLOB Bits */
+/* JR Bits */
 #define MKVB_JR				1
+#define MKVB_JR1_START			2
 
 /* jr configuration registers */
 struct imx_caam_jr_ctrl {


### PR DESCRIPTION
This PR implements a minimal implementation to retrieve a Master Key Verification Blob (MKVB) from the CAAM inside of i.MX processors for use as a Hardware Unique Key (HUK). In contrast to the full CAAM implementation offered by NXP, this only implements the necessary bits to retrieve MKVB once, does not allocate job rings to the secure world and has no conflicts with the linux kernel CAAM driver, since the CAAM is not accessed after the MKVB is retrieved.
Things I'm not sure about:
- Access through the structs to the registers:
I followed the style implemented by @bryanodonoghue, it may be more readable to switch to a normal `#define` based register access model

Related:
#2892 - initial i.MX HUK issue
#3149 - full NXP CAAM driver