### PR TITLE
core: arm: core_mmu_lpae.c: fix page table level issue

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -767,8 +767,8 @@ bool core_mmu_entry_to_finer_grained(struct core_mmu_table_info *tbl_info,
 	int i;
 	paddr_t pa;
 	uint64_t attr;
-	paddr_t block_size_on_next_lvl = L1_XLAT_ADDRESS_SHIFT -
-		tbl_info->level * XLAT_TABLE_ENTRIES_SHIFT;
+	paddr_t block_size_on_next_lvl = 1 << (L1_XLAT_ADDRESS_SHIFT -
+		tbl_info->level * XLAT_TABLE_ENTRIES_SHIFT);
 	struct mmu_partition *prtn;
 
 #ifdef CFG_VIRTUALIZATION
@@ -798,7 +798,7 @@ bool core_mmu_entry_to_finer_grained(struct core_mmu_table_info *tbl_info,
 		pa = *entry & OUTPUT_ADDRESS_MASK;
 		attr = *entry & ~(OUTPUT_ADDRESS_MASK | DESC_ENTRY_TYPE_MASK);
 		for (i = 0; i < XLAT_TABLE_ENTRIES; i++) {
-			new_table[i] = pa | attr | TABLE_DESC;
+			new_table[i] = pa | attr | BLOCK_DESC;
 			pa += block_size_on_next_lvl;
 		}
 	} else {


### PR DESCRIPTION
Declare block_size_on_next_lvl as
    1 << (L1_XLAT_ADDRESS_SHIFT -
	tbl_info->level * XLAT_TABLE_ENTRIES_SHIFT));
Change new_table to BLOCK_DESC

Signed-off-by: jeffrey <363929442@qq.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
