### PR TITLE
core: imx: add TZASC configuration

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -77,6 +77,7 @@ else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6qp-flavorlist)))
 $(call force,CFG_MX6,y)
 $(call force,CFG_MX6QP,y)
 $(call force,CFG_TEE_CORE_NB_CORE,4)
+$(call force,CFG_TZC380,n)
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6d-flavorlist)))
 $(call force,CFG_MX6,y)
 $(call force,CFG_MX6D,y)
@@ -306,10 +307,22 @@ CFG_PM_STUBS ?= y
 supported-ta-targets = ta_arm64
 endif
 
+CFG_TZC380 ?= y
+
+ifneq (,$(filter y, $(CFG_IMX8MM) $(CFG_IMX8MQ)))
+CFG_TZC_NSEC_START = 0x0
+CFG_TZC_SEC_START = CFG_TZDRAM_START - CFG_DRAM_BASE
+CFG_TZC_SHMEM_START = CFG_SHMEM_START - CFG_DRAM_BASE
+endif
+
 CFG_TZDRAM_START ?= ($(CFG_DRAM_BASE) - 0x02000000 + $(CFG_DDR_SIZE))
 CFG_TZDRAM_SIZE ?= 0x01e00000
 CFG_SHMEM_START ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))
 CFG_SHMEM_SIZE ?= 0x00200000
+
+CFG_TZC_NSEC_START ?= CFG_DRAM_BASE
+CFG_TZC_SEC_START ?= CFG_TZDRAM_START
+CFG_TZC_SHMEM_START ?= CFG_SHMEM_START
 
 CFG_CRYPTO_SIZE_OPTIMIZATION ?= n
 CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-imx/drivers/tzc380.c
+++ b/core/arch/arm/plat-imx/drivers/tzc380.c
@@ -2,6 +2,7 @@
 /*
  * Copyright 2019 Pengutronix
  * All rights reserved.
+ * Copyright 2019 NXP
  *
  * Rouven Czerwinski <entwicklung@pengutronix.de>
  */
@@ -9,29 +10,43 @@
 #include <drivers/tzc380.h>
 #include <imx-regs.h>
 #include <imx.h>
+#include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <mm/generic_ram_layout.h>
 
 void imx_configure_tzasc(void)
 {
-
-	int i;
-	vaddr_t addr[2] = {0};
+	uint8_t region;
+	vaddr_t addr[2] = { 0 };
+	uint8_t tzc_controllers = 1;
+	uint8_t i;
 
 	addr[0] = core_mmu_get_va(TZASC_BASE, MEM_AREA_IO_SEC);
+
+	if (!addr[0])
+		panic("Cannot get TZASC1 base address");
+
+#ifdef TZASC2_BASE
 	addr[1] = core_mmu_get_va(TZASC2_BASE, MEM_AREA_IO_SEC);
 
-	for (i = 0; i < 2; i++) {
-		uint8_t region = 1;
+	if (!addr[1])
+		panic("Cannot get TZASC2 base address");
+
+	tzc_controllers = 2;
+#endif
+
+	for (i = 0; i < tzc_controllers; i++) {
+		region = 1;
 
 		tzc_init(addr[i]);
 
-		region = tzc_auto_configure(CFG_DRAM_BASE, CFG_DDR_SIZE,
-			     TZC_ATTR_SP_NS_RW, region);
-		region = tzc_auto_configure(CFG_TZDRAM_START, CFG_TZDRAM_SIZE,
-			     TZC_ATTR_SP_S_RW, region);
-		region = tzc_auto_configure(CFG_SHMEM_START, CFG_SHMEM_SIZE,
-			     TZC_ATTR_SP_ALL, region);
-		DMSG("Action register: %xl", tzc_get_action());
+		region = tzc_auto_configure(CFG_TZC_NSEC_START, CFG_DDR_SIZE,
+					    TZC_ATTR_SP_NS_RW, region);
+		region = tzc_auto_configure(CFG_TZC_SEC_START, CFG_TZDRAM_SIZE,
+					    TZC_ATTR_SP_S_RW, region);
+		region = tzc_auto_configure(CFG_TZC_SHMEM_START, CFG_SHMEM_SIZE,
+					    TZC_ATTR_SP_ALL, region);
+
+		DMSG("Action register: 0x%" PRIx32, tzc_get_action());
 	}
 }

--- a/core/arch/arm/plat-imx/imx.h
+++ b/core/arch/arm/plat-imx/imx.h
@@ -39,7 +39,5 @@ void imx_gpcv2_set_core_pgc(bool enable, uint32_t offset);
 
 #ifdef CFG_TZC380
 void imx_configure_tzasc(void);
-#else
-static inline void imx_configure_tzasc(void) {}
 #endif /* CFG_TZC380 */
 #endif

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -189,6 +189,8 @@ void plat_cpu_reset_late(void)
 #if defined(CFG_BOOT_SYNC_CPU)
 		psci_boot_allcpus()
 #endif
+#if defined(CFG_TZC380)
 		imx_configure_tzasc();
+#endif
 	}
 }

--- a/core/arch/arm/plat-imx/registers/imx6.h
+++ b/core/arch/arm/plat-imx/registers/imx6.h
@@ -52,7 +52,9 @@
 #define MMDC_P1_BASE			0x021B4000
 #define MMDC_P1_SIZE			0x4000
 #define TZASC_BASE			0x21D0000
+#if defined(CFG_MX6QP) || defined(CFG_MX6Q) || defined(CFG_MX6DL)
 #define TZASC2_BASE			0x21D4000
+#endif
 #define UART2_BASE			0x021E8000
 #define UART3_BASE			0x021EC000
 #define UART4_BASE			0x021F0000


### PR DESCRIPTION
Hello,

This PR is a follow up of my last [PR](https://github.com/OP-TEE/optee_os/pull/3169) where I wanted to add TZASC configurations.
Since the TZASC was matter of debate, I preferred removing the TZASC commit from the PR and do this PR where I re-worked the code a bit.

Commit message:

Add TZASC configuration for all boards.
Disable TZASC for imx6QP.
Introduce CFG_TZC_NSEC_START, CFG_TZC_SEC_START and CFG_TZC_SHMEM_START
addresses for TZASC configuration.
Define TZASC2_BASE only for boards featuring a second TZASC controller.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
