### PR TITLE
Fix signing in-tree TAs and libraries

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -71,8 +71,7 @@ $(lib-shlibstrippedfile): $(lib-shlibfile)
 
 $(lib-shlibtafile): $(lib-shlibstrippedfile) $(TA_SIGN_KEY)
 	@$(cmd-echo-silent) '  SIGN    $$@'
-	$$(q)$$(SIGN) --key $(TA_SIGN_KEY) --uuid $(libuuid) --version 0 \
-		--in $$< --out $$@
+	$$(q)$$(SIGN) --key $(TA_SIGN_KEY) --uuid $(libuuid) --in $$< --out $$@
 
 $(lib-libuuidln): $(lib-shlibfile)
 	@$(cmd-echo-silent) '  LN      $$@'


### PR DESCRIPTION
```
With 1cdd95a2a46d ("Support offline signing of TAs.") the sign.py script
now expects the token "sign" first in the arguments in order to do its
original purpose. So effectively to sign a TA or a library the script
now has to be called as "./scripts/sign.py sign ..." or there's to be
errors like:
  SIGN    ../out-os-qemu/ta_arm32-lib/libutee/527f1a47-b92c-4a74-95bd-72f19f4a6f74.ta
usage:
   sign.py command [ arguments ]

   command:
     sign        Generate signed loadable TA image file.
                 Takes arguments --uuid, --in, --out and --key.
     digest      Generate loadable TA binary image digest for offline
                 signing. Takes arguments  --uuid, --in and --dig.
     stitch      Generate loadable signed TA binary image file from
                 TA raw image and its signature. Takes arguments
                 --uuid, --in, --out, and --sig.

   sign.py --help  show available commands and arguments
sign.py: error: argument command: invalid choice: '0' (choose from 'sign', 'digest', 'stitch', 'generate-digest', 'stitch-ta')
mk/lib.mk:83: recipe for target '../out-os-qemu/ta_arm32-lib/libutee/527f1a47-b92c-4a74-95bd-72f19f4a6f74.ta' failed
make: *** [../out-os-qemu/ta_arm32-lib/libutee/527f1a47-b92c-4a74-95bd-72f19f4a6f74.ta] Error 2

With this patch "sign" is added as needed in the different make files.
Also the "--version 0" argument is removed since it doesn't seem to be
supported any longer.

Fixes: 1cdd95a2a46d ("Support offline signing of TAs.")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
```

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
