### PR TITLE
restore TA version arguement in sign.py

### DIFF
--- a/core/arch/arm/pta/secstor_ta_mgmt.c
+++ b/core/arch/arm/pta/secstor_ta_mgmt.c
@@ -30,7 +30,7 @@ static TEE_Result check_install_conflict(const struct shdr_bootstrap_ta *bs_ta)
 		return res;
 
 	prop = tee_tadb_ta_get_property(ta);
-	if (prop->version > bs_ta->version)
+	if (prop->version > bs_ta->ta_version)
 		res = TEE_ERROR_ACCESS_CONFLICT;
 
 	tee_tadb_ta_close(ta);
@@ -96,7 +96,7 @@ static TEE_Result install_ta(struct shdr *shdr, const uint8_t *nw,
 	memset(&property, 0, sizeof(property));
 	COMPILE_TIME_ASSERT(sizeof(property.uuid) == sizeof(bs_ta.uuid));
 	tee_uuid_from_octets(&property.uuid, bs_ta.uuid);
-	property.version = bs_ta.version;
+	property.version = bs_ta.ta_version;
 	property.custom_size = 0;
 	property.bin_size = nw_size - offs;
 	DMSG("Installing %pUl", (void *)&property.uuid);

--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -54,7 +54,7 @@ struct shdr {
 
 struct shdr_bootstrap_ta {
 	uint8_t uuid[sizeof(TEE_UUID)];
-	uint32_t version;
+	uint32_t ta_version;
 };
 
 /*

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -34,12 +34,12 @@ def get_args(logger):
 
         '   command:\n' +
         '     sign        Generate signed loadable TA image file.\n' +
-        '                 Takes arguments --uuid, --in, --out' +
+        '                 Takes arguments --uuid, --ta-version, --in, --out' +
         ' and --key.\n' +
         '     digest      Generate loadable TA binary image digest' +
         ' for offline\n' +
-        '                 signing. Takes arguments  --uuid, --in and' +
-        ' --dig.\n' +
+        '                 signing. Takes arguments  --uuid, --ta-version,' +
+        ' --in and --dig.\n' +
         '     stitch      Generate loadable signed TA binary image' +
         ' file from\n' +
         '                 TA raw image and its signature. Takes' +
@@ -69,6 +69,11 @@ def get_args(logger):
                         type=uuid_parse, help='String UUID of the TA')
     parser.add_argument('--key', required=True,
                         help='Name of key file (PEM format)')
+    parser.add_argument(
+        '--ta-version', required=False, type=int_parse, default=0,
+        help='TA version stored as a 32-bit unsigned integer and used for\n' +
+        'rollback protection of TA install in the secure database.\n' +
+        'Defaults to 0.')
     parser.add_argument(
         '--sig', required=False, dest='sigf',
         help='Name of signature input file, defaults to <UUID>.sig')
@@ -142,10 +147,12 @@ def main():
     sig_len = ceil_div(key.size() + 1, 8)
     img_size = len(img)
 
-    hdr_version = 0      # SHDR_VERSION (always 0)
+    hdr_version = args.ta_version  # struct shdr_bootstrap_ta::ta_version
+
     magic = 0x4f545348   # SHDR_MAGIC
     img_type = 1         # SHDR_BOOTSTRAP_TA
     algo = 0x70004830    # TEE_ALG_RSASSA_PKCS1_V1_5_SHA256
+
     shdr = struct.pack('<IIIIHH',
                        magic, img_type, img_size, algo, digest_len, sig_len)
     shdr_uuid = args.uuid.bytes

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -39,12 +39,12 @@ def get_args(logger):
         '     digest      Generate loadable TA binary image digest' +
         ' for offline\n' +
         '                 signing. Takes arguments  --uuid, --ta-version,' +
-        ' --in and --dig.\n' +
+        ' --in, --key and --dig.\n' +
         '     stitch      Generate loadable signed TA binary image' +
         ' file from\n' +
         '                 TA raw image and its signature. Takes' +
         ' arguments\n' +
-        '                 --uuid, --in, --out, and --sig.\n\n' +
+        '                 --uuid, --in, --key, --out, and --sig.\n\n' +
         '   %(prog)s --help  show available commands and arguments\n\n',
         formatter_class=RawDescriptionHelpFormatter,
         epilog=textwrap.dedent('''\
@@ -81,7 +81,7 @@ def get_args(logger):
         '--dig', required=False, dest='digf',
         help='Name of digest output file, defaults to <UUID>.dig')
     parser.add_argument(
-        '--in', required=False, dest='inf',
+        '--in', required=True, dest='inf',
         help='Name of application input file, defaults to <UUID>.stripped.elf')
     parser.add_argument(
         '--out', required=False, dest='outf',


### PR DESCRIPTION
build: restore TA --version argument to signing script
    
Restores argument --version to script sign.py to allow user to
set the trusted application version identifier in the signed
header of the TA binary image. This argument was wrongly removed
while review fixed referred to below.
    
Fixes: 1cdd95a2a46d ("Support offline signing of TAs.")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>


...followed by a minor fixup in `sign.py`