### PR TITLE
stm32mp1: codestyle fixup in stm32image.py

### DIFF
--- a/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
+++ b/core/arch/arm/plat-stm32mp1/scripts/stm32image.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2017-2018, STMicroelectronics
 #
+# SPDX-License-Identifier: BSD-2-Clause
+
 import argparse
 import struct
 import mmap
+
 
 header_size = 256
 hdr_magic_number = 0x324D5453  # magic ='S' 'T' 'M' 0x32


### PR DESCRIPTION
Fix minor code style issues in platform python script stm32image.py.

Issue found by [travis](https://travis-ci.org/OP-TEE/optee_os/builds/570870530?utm_source=github_status&utm_medium=notification) for an unrelated P-R:
```
$ pycodestyle scripts/*.py core/arch/arm/plat-stm32mp1/scripts/stm32image.py
scripts/sign.py:150:34: E261 at least two spaces before inline comment
The command "pycodestyle scripts/*.py core/arch/arm/plat-stm32mp1/scripts/stm32image.py" exited with 1.
