### PR TITLE
core: unwind: fix function args for print_stack_arm64

### DIFF
--- a/core/arch/arm/include/kernel/unwind.h
+++ b/core/arch/arm/include/kernel/unwind.h
@@ -89,7 +89,6 @@ void print_kernel_stack(int level);
 #ifdef ARM64
 static inline void print_stack_arm64(int level __unused,
 				     struct unwind_state_arm64 *state __unused,
-				     bool kernel_stack __unused,
 				     vaddr_t stack __unused,
 				     size_t stack_size __unused)
 {


### PR DESCRIPTION
Fix a build failure when CFG_TEE_CORE_LOG_LEVEL=0,

core/arch/arm/kernel/abort.c: In function ‘__print_stack_unwind’:
core/arch/arm/kernel/abort.c:85:2: error: too few arguments to function
‘print_stack_arm64’
  print_stack_arm64(TRACE_ERROR, &state, thread_stack_start(),
  ^~~~~~~~~~~~~~~~~

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
