### PR TITLE
arm32_sysreg.py: shorten lines to <= 79 characters

### DIFF
--- a/scripts/arm32_sysreg.py
+++ b/scripts/arm32_sysreg.py
@@ -69,7 +69,8 @@ def gen_read64_func(reg_name, opc1, crm, descr):
     print('')
     if len(descr):
         print('/* ' + descr + ' */')
-    print('static inline __noprof uint64_t read_' + reg_name.lower() + '(void)')
+    print('static inline __noprof uint64_t read_' + reg_name.lower() +
+          '(void)')
     print('{')
     print('\tuint64_t v;')
     print('')
@@ -96,7 +97,8 @@ def gen_read32_func(reg_name, crn, opc1, crm, opc2, descr):
     print('')
     if len(descr):
         print('/* ' + descr + ' */')
-    print('static inline __noprof uint32_t read_' + reg_name.lower() + '(void)')
+    print('static inline __noprof uint32_t read_' + reg_name.lower() +
+          '(void)')
     print('{')
     print('\tuint32_t v;')
     print('')


### PR DESCRIPTION
pycodestyle v2.4.0 complains:

$ pycodestyle scripts/arm32_sysreg.py
scripts/arm32_sysreg.py:72:80: E501 line too long (80 > 79 characters)
scripts/arm32_sysreg.py:99:80: E501 line too long (80 > 79 characters)

Break those two lines before the 79 character limit.

Fixes: 4486d5866e238 ("libutee: add headers for user-space to access sysregs")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
