### PR TITLE
core: ftrace: fix incorrect usage of ROUNDUP

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -516,7 +516,7 @@ static void user_ta_dump_ftrace(struct tee_ta_ctx *ctx)
 	if (res != TEE_ERROR_SHORT_BUFFER)
 		return;
 
-	pl_sz = ROUNDUP(SMALL_PAGE_SIZE, blen + sizeof(TEE_UUID));
+	pl_sz = ROUNDUP(blen + sizeof(TEE_UUID), SMALL_PAGE_SIZE);
 
 	mobj = thread_rpc_alloc_payload(pl_sz);
 	if (!mobj) {


### PR DESCRIPTION
Fix incorrect usage of ROUNDUP macro during ftrace data dump to normal
world. It leads to random crashes dependent on ftrace buffer size.

Fixes: 153479acb74e ("core: dump ftrace data with ldelf")
Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
