### PR TITLE
ftrace: enable trace for utee_* assembly APIs

### DIFF
--- a/ldelf/ldelf.mk
+++ b/ldelf/ldelf.mk
@@ -20,6 +20,7 @@ endif
 
 cppflags$(sm)	+= -include $(conf-file)
 cppflags$(sm)	+= -DTRACE_LEVEL=$(CFG_TEE_CORE_LOG_LEVEL)
+cppflags$(sm)	+= -D__LDELF__
 
 # Use same compiler as for core
 CROSS_COMPILE_$(sm)	:= $(CROSS_COMPILE_core)

--- a/lib/libutee/arch/arm/utee_syscalls_a32.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a32.S
@@ -23,6 +23,17 @@
 UNWIND( .fnstart)
         push    {r5-r7,lr}
 UNWIND( .save   {r5-r7,lr})
+#if defined(CFG_ULIBS_MCOUNT) && !defined(__LDELF__)
+	.if \scn != TEE_SCN_RETURN
+	mov	ip, sp
+	push	{r0-r4, fp, ip}
+	add	fp, ip, #16
+	push	{lr}
+	bl	__gnu_mcount_nc
+	pop	{r0-r4, fp, ip}
+	mov	sp, ip
+	.endif
+#endif
         mov     r7, #(\scn)
 	.if \num_args > TEE_SVC_MAX_ARGS
 	.error "Too many arguments for syscall"

--- a/lib/libutee/arch/arm/utee_syscalls_a64.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a64.S
@@ -14,6 +14,23 @@
 	.if \num_args > TEE_SVC_MAX_ARGS || \num_args > 8
 	.error "Too many arguments for syscall"
 	.endif
+#if defined(CFG_ULIBS_MCOUNT) && !defined(__LDELF__)
+	.if \scn != TEE_SCN_RETURN
+	stp	x29, x30, [sp, #-80]!
+	mov	x29, sp
+	stp	x0, x1, [sp, #16]
+	stp	x2, x3, [sp, #32]
+	stp	x4, x5, [sp, #48]
+	stp	x6, x7, [sp, #64]
+	mov	x0, x30
+	bl	_mcount
+	ldp	x0, x1, [sp, #16]
+	ldp	x2, x3, [sp, #32]
+	ldp	x4, x5, [sp, #48]
+	ldp	x6, x7, [sp, #64]
+	ldp	x29, x30, [sp], #80
+	.endif
+#endif
         mov     x8, #(\scn)
         svc #0
         ret


### PR DESCRIPTION
Enable function trace for utee_* syscall assembly APIs for better view
of user-space to kernel switching.

Suggested-by: Jerome Forissier <jerome.forissier@linaro.org>
Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
