### PR TITLE
checkpatch: use --strict option

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -21,7 +21,10 @@ function _checkpatch() {
 		$CHECKPATCH --quiet --ignore FILE_PATH_CHANGES \
 				--ignore GERRIT_CHANGE_ID \
 				--ignore NOT_UNIFIED_DIFF \
+				--ignore CAMELCASE \
+				--ignore PREFER_KERNEL_TYPES \
 				--no-tree \
+				--strict \
 				$typedefs_opt \
 				-
 }


### PR DESCRIPTION
Uses the --strict option with checkpatch to catch more of the common style
issues. Ignoring the PREFER_KERNEL_TYPES since we are normally not using
those types. CAMELCASE is also ignored for now since it triggers many false
positives due to the TEE_Result type.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
