### PR TITLE
checkpatch: allow string concatenation without space

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -23,6 +23,7 @@ function _checkpatch() {
 				--ignore NOT_UNIFIED_DIFF \
 				--ignore CAMELCASE \
 				--ignore PREFER_KERNEL_TYPES \
+				--ignore CONCATENATED_STRING \
 				--no-tree \
 				--strict \
 				$typedefs_opt \


### PR DESCRIPTION
Adds --ignore CONCATENATED_STRING to checkpatch to allow constructs
like:
DMESG("value1 %"PRIX32" value2 %"PRIX32, v1, v2);

Without this we're force to use:
DMESG("value1 %" PRIX32 " value2 %" PRIX32, v1, v2);

Which is a bit harder to read, especially for more complicated cases.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
