### PR TITLE
core: link.mk: support reproducible builds via SOURCE_DATE_EPOCH

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -117,7 +117,12 @@ endef
 # filter-out to workaround objdump warning
 version-o-cflags = $(filter-out -g3,$(core-platform-cflags) \
 			$(platform-cflags) $(cflagscore))
+# SOURCE_DATE_EPOCH defined for reproducible builds
+ifneq ($(SOURCE_DATE_EPOCH),)
+DATE_STR = `date -u -d @$(SOURCE_DATE_EPOCH)`
+else
 DATE_STR = `date -u`
+endif
 BUILD_COUNT_STR = `cat $(link-out-dir)/.buildcount`
 CORE_CC_VERSION = `$(CCcore) -v 2>&1 | grep "version " | sed 's/ *$$//'`
 define gen-version-o


### PR DESCRIPTION
Allow using SOURCE_DATE_EPOCH when defining DATE_STR in order to support
reproducible builds.

See https://reproducible-builds.org/specs/source-date-epoch/

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>