### PR TITLE
Force CFG_CRYPTO_SIZE_OPTIMIZATION=n when DEBUG=1

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -111,6 +111,7 @@ arm64-platform-cflags-generic ?= -mstrict-align
 ifeq ($(DEBUG),1)
 # For backwards compatibility
 $(call force,CFG_CC_OPTIMIZE_FOR_SIZE,n)
+$(call force,CFG_CRYPTO_SIZE_OPTIMIZATION,n)
 $(call force,CFG_DEBUG_INFO,y)
 endif
 


### PR DESCRIPTION
"make DEBUBG=1" builds most of the code with -O0 instead of -Os,
because it sets CFG_CC_OPTIMIZE_FOR_SIZE=n. The problem is, the crypto
code depends on a different configuration variable to select its -O flag:
CFG_CRYPTO_SIZE_OPTIMIZATION.

For consistency, make sure that DEBUG=1 also sets the crypto flag.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
