### PR TITLE
Do not let CFG_CRYPTO_SIZE_OPTIMIZATION set -Os

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -1,4 +1,7 @@
 CFG_CRYPTO ?= y
+# Select small code size in the crypto library if applicable (for instance
+# LibTomCrypt has -DLTC_SMALL_CODE)
+# Note: the compiler flag -Os is not set here but by CFG_CC_OPTIMIZE_FOR_SIZE
 CFG_CRYPTO_SIZE_OPTIMIZATION ?= y
 
 ifeq (y,$(CFG_CRYPTO))

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -1,6 +1,5 @@
 cppflags-lib-$(_CFG_CORE_LTC_SIZE_OPTIMIZATION) += -DLTC_SMALL_CODE
 cppflags-lib-y += -DLTC_RSA_CRT_HARDENING -DLTC_RSA_BLINDING -DLTC_CLEAN_STACK
-cflags-lib-$(_CFG_CORE_LTC_SIZE_OPTIMIZATION) += -Os
 
 global-incdirs-y += include
 

--- a/lib/libmbedtls/core/sub.mk
+++ b/lib/libmbedtls/core/sub.mk
@@ -1,5 +1,3 @@
-cflags-lib-$(CFG_CRYPTO_SIZE_OPTIMIZATION) += -Os
-
 srcs-y += tomcrypt.c
 srcs-$(call cfg-one-enabled, CFG_CRYPTO_MD5 CFG_CRYPTO_SHA1 CFG_CRYPTO_SHA224 \
 			     CFG_CRYPTO_SHA256 CFG_CRYPTO_SHA384 \


### PR DESCRIPTION
Compiler optimization flags -O0 or -Os are selected globally by the
config variable CFG_CC_OPTIMIZE_FOR_SIZE, but crypto code
(lib/libmbedtls and core/lib/libtomcrypt) is always built with -Os
when CFG_CRYPTO_SIZE_OPTIMIZATION=y. This is a bit inconvenient
when debugging crypto code because two flags have to be set, and it
is not obvious why CFG_CC_OPTIMIZE_FOR_SIZE would not influence crypto.

Since performance does not matter much when debugging, and -Os/-O0
does not make a huge difference anyway, it is wiser to keep the purpose
of the two CFG_ variables separated: CFG_CC_OPTIMIZE_FOR_SIZE should
control the -O flag for all sources, while CFG_CRYPTO_SIZE_OPTIMIZATION
should deal with other size-related settings in the crypto code
(namely: set -DLTC_SMALL_CODE for LibTomCrypt).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
