### PR TITLE
core: add missing arch_extension to thread assembly

### DIFF
--- a/core/arch/arm/kernel/thread_optee_smc_a32.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a32.S
@@ -12,6 +12,8 @@
 #include <sm/teesmc_opteed.h>
 #include <sm/teesmc_opteed_macros.h>
 
+.arch_extension sec
+
 LOCAL_FUNC vector_std_smc_entry , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)


### PR DESCRIPTION
Compilation with newer gcc versions fails:

core/arch/arm/kernel/thread_optee_smc_a32.S: Assembler messages:
core/arch/arm/kernel/thread_optee_smc_a32.S:29: Error: selected processor does not support `smc #0' in ARM mode

add the required .arch_extension sec to the recently added assembly
file.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>
