### PR TITLE
ftrace: exclude only foreign interrupt time

### DIFF
--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -163,17 +163,21 @@ struct tee_ta_session *tee_ta_get_session(uint32_t id, bool exclusive,
 
 void tee_ta_put_session(struct tee_ta_session *sess);
 
-#if defined(CFG_TA_GPROF_SUPPORT) || defined(CFG_TA_FTRACE_SUPPORT)
+#if defined(CFG_TA_GPROF_SUPPORT)
 void tee_ta_update_session_utime_suspend(void);
 void tee_ta_update_session_utime_resume(void);
+void tee_ta_gprof_sample_pc(vaddr_t pc);
 #else
 static inline void tee_ta_update_session_utime_suspend(void) {}
 static inline void tee_ta_update_session_utime_resume(void) {}
-#endif
-#if defined(CFG_TA_GPROF_SUPPORT)
-void tee_ta_gprof_sample_pc(vaddr_t pc);
-#else
 static inline void tee_ta_gprof_sample_pc(vaddr_t pc __unused) {}
+#endif
+#if defined(CFG_TA_FTRACE_SUPPORT)
+void tee_ta_ftrace_update_times_suspend(void);
+void tee_ta_ftrace_update_times_resume(void);
+#else
+static inline void tee_ta_ftrace_update_times_suspend(void) {}
+static inline void tee_ta_ftrace_update_times_resume(void) {}
 #endif
 
 #endif


### PR DESCRIPTION
Current TA function execution time feature only reports user mode
execution time and exclude any non-user mode execution time. But in
case of syscalls which are essentially function invocations from TA
into the kernel, we shouldn't exclude syscall execution time in order
to account for actual function execution time.

So changes in this patch allows to incorporate syscall execution time
in the function graph output.

Fixes: f5df167c2ffb ("ftrace: Add function execution time support")
Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
