### PR TITLE
build: do not use -Wp with the preprocessor and use -o instead of a redirection

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -101,8 +101,8 @@ cleanfiles += $(link-script-pp) $(link-script-dep)
 $(link-script-pp): $(link-script) $(link-script-extra-deps)
 	@$(cmd-echo-silent) '  CPP     $@'
 	@mkdir -p $(dir $@)
-	$(q)$(CPPcore) -Wp,-P,-MT,$@,-MD,$(link-script-dep) \
-		$(link-script-cppflags) $< > $@
+	$(q)$(CPPcore) -P -MT $@ -MD -MF $(link-script-dep) \
+		$(link-script-cppflags) $< -o $@
 
 define update-buildcount
 	@$(cmd-echo-silent) '  UPD     $(1)'

--- a/ldelf/link.mk
+++ b/ldelf/link.mk
@@ -37,8 +37,8 @@ $(link-script-pp$(sm)): $(link-script$(sm)) $(conf-file) \
 			$(link-script-pp-makefiles$(sm))
 	@$(cmd-echo-silent) '  CPP     $$@'
 	$(q)mkdir -p $$(dir $$@)
-	$(q)$(CPP$(sm)) -Wp,-P,-MT,$$@,-MD,$(link-script-dep$(sm)) \
-		$(link-script-cppflags-$(sm)) $$< > $$@
+	$(q)$(CPP$(sm)) -P -MT $$@ -MD -MF $(link-script-dep$(sm)) \
+		$(link-script-cppflags-$(sm)) $$< -o $$@
 
 $(link-out-dir$(sm))/ldelf.elf: $(objs) $(libdeps) $(link-script-pp$(sm))
 	@$(cmd-echo-silent) '  LD      $$@'

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -52,8 +52,8 @@ define gen-link-t
 $(link-script-pp$(sm)): $(link-script$(sm)) $(conf-file) $(link-script-pp-makefiles$(sm))
 	@$(cmd-echo-silent) '  CPP     $$@'
 	$(q)mkdir -p $$(dir $$@)
-	$(q)$(CPP$(sm)) -Wp,-P,-MT,$$@,-MD,$(link-script-dep$(sm)) \
-		$(link-script-cppflags-$(sm)) $$< > $$@
+	$(q)$(CPP$(sm)) -P -MT $$@ -MD -MF $(link-script-dep$(sm)) \
+		$(link-script-cppflags-$(sm)) $$< -o $$@
 
 $(link-out-dir$(sm))/$(user-ta-uuid).elf: $(objs) $(libdeps) \
 					  $(link-script-pp$(sm)) \


### PR DESCRIPTION
This patch cleans up the command line where we use the C preprocessor
to better reflect the documented usage in the GCC man page, thus
preparing for Clang support.

1. When invoking the C preprocessor, there is no need for -Wp to pass
arguments, so remove it.

2. -MD is not supposed to take a file name when passed to cpp. The
dependency output file name is overridden with -MF.

3. Lastly, it is better to use -o to specify the output file instead
of redirecting standard output, because if an error occurs during
preprocessing we don't want the output file to be created.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
