### PR TITLE
core: imx: add mx6dapalis/mx6qapalis platform flavor

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -76,6 +76,8 @@ build:
     - _make PLATFORM=imx-mx6qpsabresd
     - _make PLATFORM=imx-mx6dlsabresd
     - _make PLATFORM=imx-mx6dlsabreauto
+    - _make PLATFORM=imx-mx6dapalis
+    - _make PLATFORM=imx-mx6qapalis
     - _make PLATFORM=imx-mx7dsabresd
     - _make PLATFORM=imx-mx7ulpevk
     - _make PLATFORM=imx-imx8mmevk

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -14,6 +14,7 @@ mx6q-flavorlist = \
 	mx6qsabreauto \
 	mx6qsabresd \
 	mx6qhmbedge \
+	mx6qapalis \
 
 mx6qp-flavorlist = \
 	mx6qpsabreauto \
@@ -32,6 +33,7 @@ mx6sx-flavorlist = \
 
 mx6d-flavorlist = \
 	mx6dhmbedge \
+	mx6dapalis \
 
 mx6dl-flavorlist = \
 	mx6dlsabreauto \
@@ -178,7 +180,8 @@ CFG_UART_BASE ?= UART4_BASE
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx6qpsabresd mx6qsabresd mx6dlsabresd \
-	mx6dlsabrelite mx6dhmbedge mx6dlhmbedge mx6solosabresd))
+	mx6dlsabrelite mx6dhmbedge mx6dlhmbedge mx6solosabresd \
+	mx6dapalis mx6qapalis))
 CFG_DDR_SIZE ?= 0x40000000
 CFG_NS_ENTRY_ADDR ?= 0x12000000
 endif


### PR DESCRIPTION
Add Toradex Apalis iMX6D and iMX6Q platform flavors.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>