### PR TITLE
get_maintainer.py: fix spelling mistake

### DIFF
--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -100,7 +100,7 @@ def split_patchset(patchset):
     f = None
     try:
         f = open(patchset, "r")
-    except OsError:
+    except OSError:
         return []
     for line in f:
         match = re.search(PATCH_START, line)


### PR DESCRIPTION
OSError is spelled incorrectly, causing the following error:

 $ ./scripts/get_maintainer.py core/arch/arm/plat-imx/
 Traceback (most recent call last):
   File "./scripts/get_maintainer.py", line 102, in split_patchset
     f = open(patchset, "r")
 IsADirectoryError: [Errno 21] Is a directory: 'core/arch/arm/plat-imx/'

 During handling of the above exception, another exception occurred:

 Traceback (most recent call last):
   File "./scripts/get_maintainer.py", line 292, in <module>
     main()
   File "./scripts/get_maintainer.py", line 242, in main
     patches = split_patchset(arg)
   File "./scripts/get_maintainer.py", line 103, in split_patchset
     except OsError:
 NameError: name 'OsError' is not defined

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
