### PR TITLE
core: don't use __bss and __data attributes

### DIFF
--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -54,8 +54,8 @@
 #define __nex_bss		__section(".nex_bss")
 #define __nex_data		__section(".nex_data")
 #else  /* CFG_VIRTUALIZATION */
-#define __nex_bss		__bss
-#define __nex_data		__data
+#define __nex_bss
+#define __nex_data
 #endif	/* CFG_VIRTUALIZATION */
 #define __noprof	__attribute__((no_instrument_function))
 


### PR DESCRIPTION
This breaks GCC Address Sanitizer, because it refuses to track
variables, that are stored in user sections. Even if those
sections are actually .bss and .data.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

---

This should fix #3235

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
