### PR TITLE
libutils: replace memcpy() with plain struct assignment

### DIFF
--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -108,6 +108,12 @@ static void *memset_unchecked(void *s, int c, size_t n)
 	return asan_memset_unchecked(s, c, n);
 }
 
+static __maybe_unused void *memcpy_unchecked(void *dst, const void *src,
+					     size_t n)
+{
+	return asan_memcpy_unchecked(dst, src, n);
+}
+
 #else /*__KERNEL__*/
 /* Compiling for TA */
 
@@ -122,6 +128,12 @@ static void tag_asan_alloced(void *buf __unused, size_t len __unused)
 static void *memset_unchecked(void *s, int c, size_t n)
 {
 	return memset(s, c, n);
+}
+
+static __maybe_unused void *memcpy_unchecked(void *dst, const void *src,
+					     size_t n)
+{
+	return memcpy(dst, src, n);
 }
 
 #endif /*__KERNEL__*/
@@ -230,7 +242,7 @@ static void gen_malloc_get_stats(struct malloc_ctx *ctx,
 {
 	uint32_t exceptions = malloc_lock(ctx);
 
-	memcpy(stats, &ctx->mstats, sizeof(*stats));
+	memcpy_unchecked(stats, &ctx->mstats, sizeof(*stats));
 	stats->allocated = ctx->poolset.totalloc;
 	malloc_unlock(ctx, exceptions);
 }


### PR DESCRIPTION
When CFG_CORE_SANITIZE_KADDRESS=y, most OP-TEE files are built with
address sanitizer flags except bget_malloc.c. As a result, the memcpy()
function in memcpy.c is instrumented, whereas the malloc context
structure (malloc_ctx) in bget_malloc.c is not. This causes the
following panic:

 $ xtest --stats --alloc

 E/TC:0 0 Panic at core/kernel/asan.c:189 <check_access>
 E/TC:0 0 Call stack:
 E/TC:0 0  0x0e125c3d print_kernel_stack at optee_os/core/arch/arm/kernel/unwind_arm32.c:450
 E/TC:0 0  0x0e13fcfb __do_panic at optee_os/core/kernel/panic.c:32 (discriminator 1)
 E/TC:0 0  0x0e13e099 check_access at optee_os/core/kernel/asan.c:187 (discriminator 2)
 E/TC:0 0  0x0e13e10f check_load at optee_os/core/kernel/asan.c:199
 E/TC:0 0  0x0e13e187 __asan_load4_noabort at optee_os/core/kernel/asan.c:231
 E/TC:0 0  0x0e185d15 memcpy at optee_os/lib/libutils/isoc/newlib/memcpy.c:112
 E/TC:0 0  0x0e184a3f gen_malloc_get_stats at optee_os/lib/libutils/isoc/bget_malloc.c:234
 [...]

Replace memcpy() with a plain structure assignment to fix the issue.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
