### PR TITLE
util.h: add the macro ROUNDUP_OVERFLOW()

### DIFF
--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -47,6 +47,14 @@
 #define ROUNDUP(v, size) (((v) + ((__typeof__(v))(size) - 1)) & \
 			  ~((__typeof__(v))(size) - 1))
 
+#define ROUNDUP_OVERFLOW(v, size, res) (__extension__({ \
+	typeof(*(res)) __roundup_tmp = 0; \
+	typeof(v) __roundup_mask = (typeof(v))(size) - 1; \
+	\
+	ADD_OVERFLOW((v), __roundup_mask, &__roundup_tmp) ? 1 : \
+		(void)(*(res) = __roundup_tmp & ~__roundup_mask), 0; \
+}))
+
 /* Round down the even multiple of size, size has to be a multiple of 2 */
 #define ROUNDDOWN(v, size) ((v) & ~((__typeof__(v))(size) - 1))
 


### PR DESCRIPTION
Adds the macro ROUNDUP_OVERFLOW() which rounds up like ROUNDUP() but also
checks the result for overflow and returns true on overflow.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
