### PR TITLE
ta: ldelf.ld.S: align __reloc_begin on 8 bytes

### DIFF
--- a/ldelf/ldelf.ld.S
+++ b/ldelf/ldelf.ld.S
@@ -42,6 +42,11 @@ SECTIONS {
 	.dynstr : { *(.dynstr) }
 	.hash : { *(.hash) }
 
+	/*
+	 * Relocation sections may be aligned on 4 or 8 bytes. With ALIGN(8)
+	 * we avoid any padding between __reloc_begin and the first relocation.
+	 */
+	. = ALIGN(8);
 	__reloc_begin = .;
 	.rel.got : { *(.rel.got) }
 	.rela.got : { *(.rela.got) }


### PR DESCRIPTION
__reloc_begin is currently defined as "__reloc_begin = ." just before
the various .rel.* output sections. The problem is, there is no
guarantee that the symbol will actually point to the first relocation
entry due to the alignment constraints on relocation sections. For
instance for Aarch64 relocations, alignment is 8 bytes, but
__reloc_begin has no alignment constraint, so it might end before the
first relocation (this issue was observed with the Clang linker,
ld.lld).

The patch forces the alignment of __reloc_begin on 8 bytes so that
there can be no unwanted padding.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
