### PR TITLE
core: dt: add __noreturn to _fdt_fill_device_info() stub

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -203,6 +203,7 @@ static inline int _fdt_get_status(const void *fdt __unused, int offs __unused)
 	return -1;
 }
 
+__noreturn
 static inline void _fdt_fill_device_info(void *fdt __unused,
 					 struct dt_node_info *info __unused,
 					 int node __unused)


### PR DESCRIPTION
When CFG_DT != y, the stub function _fdt_fill_device_info() just
panics. Therefore it deserves the __noreturn attribute. Adding it makes
a Clang warning go away.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
