### PR TITLE
Get rid of option -Wno-suggest-attribute=noreturn

### DIFF
--- a/core/arch/arm/kernel/pm_stubs.c
+++ b/core/arch/arm/kernel/pm_stubs.c
@@ -7,7 +7,8 @@
 #include <kernel/panic.h>
 #include <kernel/pm_stubs.h>
 
-unsigned long pm_panic(unsigned long a0 __unused, unsigned long a1 __unused)
+unsigned long __noreturn pm_panic(unsigned long a0 __unused,
+				  unsigned long a1 __unused)
 {
 	panic();
 }

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -44,7 +44,6 @@ srcs-y += mutex.c
 srcs-$(CFG_LOCKDEP) += mutex_lockdep.c
 srcs-y += wait_queue.c
 srcs-$(CFG_PM_STUBS) += pm_stubs.c
-cflags-pm_stubs.c-y += -Wno-suggest-attribute=noreturn
 
 srcs-$(CFG_GENERIC_BOOT) += generic_boot.c
 ifeq ($(CFG_GENERIC_BOOT),y)

--- a/core/arch/arm/plat-imx/pm/psci.c
+++ b/core/arch/arm/plat-imx/pm/psci.c
@@ -93,7 +93,7 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	return PSCI_RET_SUCCESS;
 }
 
-int psci_cpu_off(void)
+int __noreturn psci_cpu_off(void)
 {
 	uint32_t core_id;
 
@@ -109,8 +109,6 @@ int psci_cpu_off(void)
 
 	while (true)
 		wfi();
-
-	return PSCI_RET_INTERNAL_FAILURE;
 }
 
 int psci_affinity_info(uint32_t affinity,
@@ -235,7 +233,7 @@ int psci_cpu_suspend(uint32_t power_state,
 	return ret;
 }
 
-void psci_system_reset(void)
+void __noreturn psci_system_reset(void)
 {
 	imx_wdog_restart();
 }

--- a/core/arch/arm/plat-imx/pm/sub.mk
+++ b/core/arch/arm/plat-imx/pm/sub.mk
@@ -2,5 +2,3 @@ global-incdirs-y += .
 srcs-y += psci.c
 srcs-$(CFG_MX7) += pm-imx7.c psci-suspend-imx7.S imx7_suspend.c \
 	cpuidle-imx7d.c psci-cpuidle-imx7.S gpcv2.c
-
-cflags-psci.c-y += -Wno-suggest-attribute=noreturn

--- a/core/arch/arm/plat-sunxi/psci.c
+++ b/core/arch/arm/plat-sunxi/psci.c
@@ -28,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <compiler.h>
 #include <console.h>
 #include <io.h>
 #include <stdint.h>
@@ -128,7 +129,7 @@ int psci_cpu_on(uint32_t core_idx, uint32_t entry,
 	return PSCI_RET_SUCCESS;
 }
 
-int psci_cpu_off(void)
+int __noreturn psci_cpu_off(void)
 {
 	uint32_t core_id;
 	vaddr_t base = (vaddr_t)phys_to_virt(SUNXI_PRCM_BASE, MEM_AREA_IO_SEC);
@@ -156,7 +157,5 @@ int psci_cpu_off(void)
 
 	while (true)
 		wfi();
-
-	return PSCI_RET_INTERNAL_FAILURE;
 }
 #endif

--- a/core/arch/arm/plat-sunxi/sub.mk
+++ b/core/arch/arm/plat-sunxi/sub.mk
@@ -2,4 +2,3 @@ global-incdirs-y += .
 srcs-y += main.c
 srcs-$(CFG_ARM32_core) += plat_init.S
 srcs-$(CFG_ARM32_core) += psci.c
-cflags-psci.c-y += -Wno-suggest-attribute=noreturn

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -12,7 +12,6 @@ srcs-$(CFG_IMX_SNVS) += imx_snvs.c
 srcs-$(CFG_IMX_UART) += imx_uart.c
 srcs-$(CFG_IMX_LPUART) += imx_lpuart.c
 srcs-$(CFG_IMX_WDOG) += imx_wdog.c
-cflags-imx_wdog.c-y += -Wno-suggest-attribute=noreturn
 srcs-$(CFG_SPRD_UART) += sprd_uart.c
 srcs-$(CFG_HI16XX_UART) += hi16xx_uart.c
 srcs-$(CFG_HI16XX_RNG) += hi16xx_rng.c

--- a/core/include/drivers/imx_wdog.h
+++ b/core/include/drivers/imx_wdog.h
@@ -28,6 +28,8 @@
 #ifndef __IMX_WDOG_H
 #define __IMX_WDOG_H
 
+#include <compiler.h>
+
 /* i.MX6/7D */
 #define WDT_WCR		0x00
 #define WDT_WCR_WDA	BIT(5)
@@ -60,5 +62,5 @@
 #define WDOG_CS_UPDATE		BIT(5)
 
 /* Exposed for psci reset */
-void imx_wdog_restart(void);
+void __noreturn imx_wdog_restart(void);
 #endif


### PR DESCRIPTION
The GCC option -Wno-suggest-attribute=noreturn is not supported by
Clang. Instead of playing with compiler options, let's fix the code
according to the following rules:
 - If a function is know to never return, it should have the __noreturn
attribute in the header file.
 - If only some implementation of a function never returns, __noreturn
shall be applied to that particular implementation in the .c file.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
