### PR TITLE
libutee,libdl: remove 0ms timeouts in TA invocations

### DIFF
--- a/lib/libdl/dlfcn.c
+++ b/lib/libdl/dlfcn.c
@@ -21,11 +21,13 @@ static TEE_Result invoke_system_pta(uint32_t cmd_id, uint32_t param_types,
 	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (sess == TEE_HANDLE_NULL) {
-		res = TEE_OpenTASession(&core_uuid, 0, 0, NULL, &sess, NULL);
+		res = TEE_OpenTASession(&core_uuid, TEE_TIMEOUT_INFINITE,
+					0, NULL, &sess, NULL);
 		if (res)
 			return res;
 	}
-	return TEE_InvokeTACommand(sess, 0, cmd_id, param_types, params, NULL);
+	return TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE,
+				   cmd_id, param_types, params, NULL);
 }
 
 struct dl_handle {

--- a/lib/libutee/arch/arm/gprof/gprof_pta.c
+++ b/lib/libutee/arch/arm/gprof/gprof_pta.c
@@ -17,11 +17,13 @@ static TEE_Result invoke_gprof_pta(uint32_t cmd_id, uint32_t param_types,
 	TEE_Result res;
 
 	if (!sess) {
-		res = TEE_OpenTASession(&core_uuid, 0, 0, NULL, &sess, NULL);
+		res = TEE_OpenTASession(&core_uuid, TEE_TIMEOUT_INFINITE,
+					0, NULL, &sess, NULL);
 		if (res != TEE_SUCCESS)
 			return res;
 	}
-	res = TEE_InvokeTACommand(sess, 0, cmd_id, param_types, params, NULL);
+	res = TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE, cmd_id,
+				  param_types, params, NULL);
 	return res;
 }
 

--- a/lib/libutee/tee_socket_pta.c
+++ b/lib/libutee/tee_socket_pta.c
@@ -18,14 +18,16 @@ static TEE_Result invoke_socket_pta(uint32_t cmd_id, uint32_t param_types,
 	static const TEE_UUID socket_uuid = PTA_SOCKET_UUID;
 
 	if (sess == TEE_HANDLE_NULL) {
-		TEE_Result res = TEE_OpenTASession(&socket_uuid, 0, 0, NULL,
-						   &sess, NULL);
+		TEE_Result res = TEE_OpenTASession(&socket_uuid,
+						   TEE_TIMEOUT_INFINITE,
+						   0, NULL, &sess, NULL);
 
 		if (res != TEE_SUCCESS)
 			return res;
 	}
 
-	return TEE_InvokeTACommand(sess, 0, cmd_id, param_types, params, NULL);
+	return TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE, cmd_id,
+				   param_types, params, NULL);
 }
 
 TEE_Result __tee_socket_pta_open(TEE_ipSocket_ipVersion ip_vers,

--- a/lib/libutee/tee_system_pta.c
+++ b/lib/libutee/tee_system_pta.c
@@ -17,14 +17,15 @@ static TEE_Result invoke_system_pta(uint32_t cmd_id, uint32_t param_types,
 	static const TEE_UUID uuid = PTA_SYSTEM_UUID;
 
 	if (sess == TEE_HANDLE_NULL) {
-		TEE_Result res = TEE_OpenTASession(&uuid, 0, 0, NULL,
-						   &sess, NULL);
+		TEE_Result res = TEE_OpenTASession(&uuid, TEE_TIMEOUT_INFINITE,
+						   0, NULL, &sess, NULL);
 
 		if (res)
 			return res;
 	}
 
-	return TEE_InvokeTACommand(sess, 0, cmd_id, param_types, params, NULL);
+	return TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE, cmd_id,
+				   param_types, params, NULL);
 }
 
 void *tee_map_zi(size_t len, uint32_t flags)


### PR DESCRIPTION
TEE_OpenTASession(), TEE_InvokeTACommand() calls using 0ms timeout
are replaced with TEE_INFINITE_TIMEOUT to avoid risk of being cancelled.

Signed-off-by: Cedric Auger <cauger@provenrun.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
