### PR TITLE
libutils: relax noreturn label

### DIFF
--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -21,7 +21,7 @@
 #endif
 #define __weak		__attribute__((weak))
 #ifndef __noreturn
-#define __noreturn	__attribute__((noreturn))
+#define __noreturn	__attribute__((__noreturn__))
 #endif
 #define __pure		__attribute__((pure))
 #define __aligned(x)	__attribute__((aligned(x)))


### PR DESCRIPTION
Replaces attribute label identifier noreturn with __noreturn__ to
prevent conflicts when importing code which defines label noreturn
itself as a macro. This change applies suggestion from the GCC
documentation [1], applicable even prio GCC 4.x.x, cited below.

> You may optionally specify attribute names with ‘__’ preceding
> and following the name. This allows you to use them in header
> files without being concerned about a possible macro of the same
> name. For example, you may use the attribute name __noreturn__
> instead of noreturn.

[1] https://gcc.gnu.org/onlinedocs/gcc-8.3.0/gcc/Attribute-Syntax.html#Attribute-Syntax

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
