### PR TITLE
core: no need to set the default partition again

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -619,9 +619,6 @@ void thread_state_free(void)
 	threads[ct].flags = 0;
 	l->curr_thread = -1;
 
-#ifdef CFG_VIRTUALIZATION
-	virt_unset_guest();
-#endif
 	thread_unlock_global();
 }
 


### PR DESCRIPTION
Run here, the program is already in the default partition,no need to set it again

