### PR TITLE
[RFC] Dump configuration on boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ SHELL = /bin/bash
 # (we include many *.cmd and *.d files).
 unexport MAKEFILE_LIST
 
+# Automatically delete corrupt targets (file updated but recipe exits with a
+# nonzero status). Useful since a few recipes use shell redirection.
+.DELETE_ON_ERROR:
+
 include mk/checkconf.mk
 
 .PHONY: all

--- a/core/kernel/show_conf.c
+++ b/core/kernel/show_conf.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 1019 Huawei Technologies Co., Ltd
+ */
+
+#include <initcall.h>
+#include <trace.h>
+
+extern const char conf_str[];
+
+static TEE_Result show_conf(void)
+{
+#if (TRACE_LEVEL >= TRACE_INFO)
+	IMSG("Contents of conf.mk (decode with 'base64 -d | xz -d'):");
+	trace_ext_puts(conf_str);
+#endif
+	return TEE_SUCCESS;
+}
+service_init(show_conf);

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -15,3 +15,4 @@ srcs-y += tee_ta_manager.c
 srcs-$(CFG_CORE_SANITIZE_UNDEFINED) += ubsan.c
 srcs-y += scattered_array.c
 srcs-y += huk_subkey.c
+srcs-$(CFG_SHOW_CONF_ON_BOOT) += show_conf.c

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -50,3 +50,20 @@ recipe-embedded_secure_dtb = scripts/bin_to_c.py \
 				--out $(core-embed-fdt-c)
 $(eval $(call gen-dtb-file,$(core-embed-fdt-dts),$(core-embed-fdt-dtb)))
 endif
+
+ifeq ($(CFG_SHOW_CONF_ON_BOOT),y)
+conf-mk-xz-base64 := $(sub-dir-out)/conf.mk.xz.base64
+cleanfiles += $(conf-mk-xz-base64)
+
+$(conf-mk-xz-base64): $(conf-mk-file)
+	@$(cmd-echo-silent) '  GEN     $@'
+	$(q)tail +3 $< | xz | base64 -w 100 >$@
+
+gensrcs-y += conf_str
+produce-conf_str = conf.mk.xz.base64.c
+depends-conf_str = $(conf-mk-xz-base64)
+recipe-conf_str = scripts/bin_to_c.py --text --bin $(conf-mk-xz-base64) \
+			--out $(sub-dir-out)/conf.mk.xz.base64.c \
+			--vname conf_str
+cleanfiles += $(sub-dir-out)/conf.mk.xz.base64.c
+endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -494,3 +494,7 @@ endif
 
 # Enables backwards compatible derivation of RPMB and SSK keys
 CFG_CORE_HUK_SUBKEY_COMPAT ?= y
+
+# Compress and encode conf.mk into the TEE core, and show the encoded string on
+# boot (with severity TRACE_INFO).
+CFG_SHOW_CONF_ON_BOOT ?= n


### PR DESCRIPTION
This RFC PR introduces `CFG_SHOW_CONF_ON_BOOT` which I think would have come handy to know more about an IBART failure (see [here](https://github.com/OP-TEE/optee_os/pull/3268#issuecomment-532598986)).

FYI, here is what it looks like when booting QEMU OP-TEE with `CFG_SHOW_CONF_ON_BOOT=y`.

```
I/TC:
I/TC: Non-secure external DT found
I/TC: Switching console to device: /pl011@9040000
I/TC: OP-TEE version: 3.6.0-163-ga33f0c8924-dev (gcc version 6.2.1 20161016 (Linaro GCC 6.2-2016.11)) #2 Wed 18 Sep 2019 04:00:30 PM UTC arm
I/TC: Contents of conf.mk (decode with 'ascii85 -d | xz -d'):
<~rAT%)=o\O*k16n/!WXAE('"=7F>)aNi!pD(<a>\JP_<`1%r^hlZdit2!d[9Aa#s*r4r)8kZPS@2Eq3(:S]prR4BtVp2B1V\@]R
<"F9oC1/tCgM,2KTlf&:^$o5*^;d4.DYlrhS;IbLES'#u[":p'=qq\p5b+6jVdOlSX0'SDf++.nD#8i&gi%&NZ/#Bo%n6cGB"Z-9
X?;<i'p4h%D.KpSO1\FQ*D+YM2Dhar0]&klsBH5?B8C.L_N=Y'+$hfTn)m*dB05"AG1RMG5#J"gi5+\XstCbm3TH4PPMjR$2_#/$
7)qZgD0g)g^>"Y[p\3\j<*VnHgd'RKZPMVYUor$:&uh&`!DXY"054u$Lg4'E->^PI/RT)aWZg0c&;`R3o+R`_DV\H?C!>u#hNi7#
0XXAk*f$L)kITo4q627'm*^e?:YO<$odS>_-5U46,#cdW4#.BX]JRr[V2<2N^k'Jl:Ji*g^i/+eHccW_AA$3.#;JC@HX@Z^0@.3F
^mc5ElE9C4tb!#)uXTZt=Ue<VQnU_+/\aRQ3*r08)Pn1uf-=mj'1^Gn\*?l8J02VkUOK$7V^rr7E4G)3oifNOeQ\dA*6%;;Zl5cA
YJY_q?o0`c'BY[WJ;m+Lo]U\)49:4,m,30U0V_u3!QQp>u*'K'5;2g/)'<VBL+8@3,n)L94Co%&5K*gJuhdZmRS#n&P/]3u"5%m;
Ae.'6pjLt483D[`LqF$X;&+P37)hpj3>"G+:k`uJW<_tA"F'lrt*2RTH/O7s:(URO--Mgk91@lIOsV1bmla#g2p<m.k4H7(CQ9Tn
aAW;!$4^c"J%S>0Xs[8c.(WCSoaWYW2<,)T<N]@/l(Q+jd5[)^4DK<IRKkY(3mjn_%F@Z)>N@u8(u;/))$,k_hCJj^PM@t:=W*(b
<*_+=rZ*p1oT7(pI:'gWJlH5le@g-)33c!_gR(\X_aS_#`r=cf?2k..A&^T,,SG<q$A84r=Q$_t\>3[g6E2Q;C]!hVluF+<NK::"
8gM3^u!q(*]7':_%*i[@QW`43f[mm[m,aZtAoXQ?d!GHX1n>b[cD"D&BHG$=!&e<q':jkB;'Whi5<+*>T\X!\YJk`D2%qSQrj30m
PEZl'S<n(Qn5:'_hO>?Pb6L5'X7AATJ,&N$75^d69o-.Dr<]%9hiGA7+e^EJ$k\-s9HL-kAAG-"=f!AIbB^IgAP[@c`5%T-t[`*@
_6/C`g!/mKq+nN%tImNWp)d#TWaN&Y2mN/"R2`OLh#C'r3s=TXMtV`c?6haiPjE[/#tl;PY:$IH)l\*8aj(`<>.8+(]&P>)P?;VK
VTU8sj3B=F(V*\=:oEA=rG3t#O$]JH"Qm6+8iG8K?Yq1jk`4<AZ^K6rXPI_DEr2"3aIQOFd'F_\&ZQLAm2jL[nNH+5r<>niD5k,T
64C1o:C3k[(Z$8L`r_.D`(GuF1m"^78A'5>Rp]ULZ\ctr$d'o8E]=UZ)B71=+[SjsOOcq:(A5F;u4/r2$"nJ,P(mSn8P>K;ds'Im
YBK4fe"?R05+/*:Q#l@[IE+4u*f*X?nmXWedL5C#is;/1[#$&pS,pJ:PeGXi6MRH$2TWfs/+&'2IVB#Q>e*l4%t9Rj^NK-*S-E%X
_8heWAR'<Uu\'$;<ahq(op,4]4b"W=kq[,'_GSYYLAlL]"5NX%lNeWJ5\\($/Y:[h[)5oK95+,GH=^'m@WB2EGf0I&sp$1Sl$ig.
#"e.?%/Fc\`Q[$LHm>d]nna^a[CjTb,I^kl==L&GJ%?Ur)/kPtS_m(^b&FOHa:!!2WtPT0Z'M--JFZ,C;P!WW3#!!HG.~>
I/TC: Initialized
```
