### PR TITLE
core: REE FS TAs: disable CFG_REE_FS_TA_BUFFERED by default

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -232,7 +232,7 @@ CFG_REE_FS_TA ?= y
 #   valid.
 # - If disabled: hash the binaries as they are being processed and verify the
 #   signature as a last step.
-CFG_REE_FS_TA_BUFFERED ?= $(CFG_REE_FS_TA)
+CFG_REE_FS_TA_BUFFERED ?= n
 $(eval $(call cfg-depends-all,CFG_REE_FS_TA_BUFFERED,CFG_REE_FS_TA))
 
 # Support for loading user TAs from a special section in the TEE binary.


### PR DESCRIPTION
Now that the TA loader is in user space [1], the main reason why we had
introduced CFG_REE_FS_TA_BUFFERED [2] does not exist anymore. Therefore
we can set it to 'n' by default, thus saving some time and memory.

[1] commit d1911a85142d ("core: load TAs using ldelf")
[2] commit 7db24ad625b9 ("core: REE FS TAs: add option to verify
    signature before processing")

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
