### PR TITLE
symbolize.py: disable terminal local echo

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+import termios
 
 CALL_STACK_RE = re.compile('Call stack:')
 # This gets the address from lines looking like this:
@@ -477,9 +478,17 @@ def main():
         args.dirs = []
     symbolizer = Symbolizer(sys.stdout, args.dirs, args.strip_path)
 
-    for line in sys.stdin:
-        symbolizer.write(line)
-    symbolizer.flush()
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    new = termios.tcgetattr(fd)
+    new[3] = new[3] & ~termios.ECHO  # lflags
+    try:
+        termios.tcsetattr(fd, termios.TCSADRAIN, new)
+        for line in sys.stdin:
+            symbolizer.write(line)
+    finally:
+        symbolizer.flush()
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When scripts/symbolize.py is used interactively and the input data is
copied and pasted into the terminal, both the input and output text are
displayed on the same screen. There is nothing preventing both text
streams from mixing up because it depends on buffering and how Python
reads and flushes its buffers.

Things usually go well with Python 2, but I have observed that Python 3
is more problematic. So the issue needs to be properly addressed. This
patch temporarily disables local echo so that only the processed text is
shown.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
