### PR TITLE
Generic RPC Support

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -45,6 +45,7 @@ build:
     - _make CFG_TA_GPROF_SUPPORT=y CFG_ULIBS_MCOUNT=y
     - _make CFG_SECURE_DATA_PATH=y
     - _make CFG_REE_FS_TA_BUFFERED=n
+    - _make CFG_GRPC=y
     - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y
     - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_WITH_PAGER=y
     - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_TA_GPROF_SUPPORT=y CFG_ULIBS_MCOUNT=y

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2016-2017, Linaro Limited
+ * Copyright (c) 2019, Microsoft Corporation
  */
 
 #ifndef KERNEL_THREAD_H

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -562,6 +562,22 @@ struct mobj *thread_rpc_alloc_payload(size_t size);
  */
 void thread_rpc_free_payload(struct mobj *mobj);
 
+/**
+ * Allocates data for host application payload buffers.
+ *
+ * @size:	size in bytes of payload buffer
+ *
+ * @returns	mobj that describes allocated buffer or NULL on error
+ */
+struct mobj *thread_rpc_alloc_host_payload(size_t size);
+
+/**
+ * Free physical memory previously allocated with
+ * thread_rpc_alloc_host_payload()
+ *
+ * @mobj:	mobj that describes the buffer
+ */
+void thread_rpc_free_host_payload(struct mobj *mobj);
 
 struct thread_param_memref {
 	size_t offs;

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -601,3 +601,13 @@ void thread_rpc_free_global_payload(struct mobj *mobj)
 	thread_rpc_free(OPTEE_RPC_SHM_TYPE_GLOBAL, mobj_get_cookie(mobj),
 			mobj);
 }
+
+struct mobj *thread_rpc_alloc_host_payload(size_t size)
+{
+	return thread_rpc_alloc(size, 8, OPTEE_RPC_SHM_TYPE_APPL);
+}
+
+void thread_rpc_free_host_payload(struct mobj *mobj)
+{
+	thread_rpc_free(OPTEE_RPC_SHM_TYPE_APPL, mobj_get_cookie(mobj), mobj);
+}

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -604,10 +604,10 @@ void thread_rpc_free_global_payload(struct mobj *mobj)
 
 struct mobj *thread_rpc_alloc_host_payload(size_t size)
 {
-	return thread_rpc_alloc(size, 8, OPTEE_RPC_SHM_TYPE_APPL);
+	return thread_rpc_alloc(size, 8, OPTEE_RPC_SHM_TYPE_HOST);
 }
 
 void thread_rpc_free_host_payload(struct mobj *mobj)
 {
-	thread_rpc_free(OPTEE_RPC_SHM_TYPE_APPL, mobj_get_cookie(mobj), mobj);
+	thread_rpc_free(OPTEE_RPC_SHM_TYPE_HOST, mobj_get_cookie(mobj), mobj);
 }

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2019, Microsoft Corporation
  */
 
 #include <assert.h>

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2016-2017, Linaro Limited
+ * Copyright (c) 2019, Microsoft Corporation
  */
 
 #ifndef __OPTEE_RPC_CMD_H

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -97,6 +97,11 @@
  * space application
  */
 #define OPTEE_RPC_SHM_TYPE_GLOBAL	2
+/*
+ * Memory shared with the non-secure user space application that owns the
+ * current session
+ */
+#define OPTEE_MSG_RPC_SHM_TYPE_HOST	3
 
 /*
  * Free shared memory previously allocated with OPTEE_RPC_CMD_SHM_ALLOC
@@ -326,5 +331,10 @@
 #define OPTEE_RPC_SOCKET_IOCTL	5
 
 /* End of definition of protocol for command OPTEE_RPC_CMD_SOCKET */
+
+/*
+ * Request a generic service from the host application.
+ */
+#define OPTEE_MSG_RPC_CMD_GENERIC	8
 
 #endif /*__OPTEE_RPC_CMD_H*/

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -332,9 +332,4 @@
 
 /* End of definition of protocol for command OPTEE_RPC_CMD_SOCKET */
 
-/*
- * Request a generic service from the host application.
- */
-#define OPTEE_MSG_RPC_CMD_GENERIC	8
-
 #endif /*__OPTEE_RPC_CMD_H*/

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -101,7 +101,7 @@
  * Memory shared with the non-secure user space application that owns the
  * current session
  */
-#define OPTEE_MSG_RPC_SHM_TYPE_HOST	3
+#define OPTEE_RPC_SHM_TYPE_HOST 	3
 
 /*
  * Free shared memory previously allocated with OPTEE_RPC_CMD_SHM_ALLOC

--- a/core/pta/grpc.c
+++ b/core/pta/grpc.c
@@ -69,7 +69,7 @@ static TEE_Result rpc_preprocess_param(struct thread_param *rpc_msg_param,
 			param->memref.size);
 		break;
 	default:
-		break;
+		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	/* Perform copies into shared memory, if necessary */
@@ -102,8 +102,12 @@ static TEE_Result rpc_postprocess_param(struct thread_param *rpc_msg_param,
 		return TEE_ERROR_BAD_PARAMETERS;
 	case TEE_PARAM_TYPE_VALUE_OUTPUT:
 	case TEE_PARAM_TYPE_VALUE_INOUT:
-		param->value.a = rpc_msg_param->u.value.a;
-		param->value.b = rpc_msg_param->u.value.b;
+		if (rpc_msg_param->u.value.a > UINT32_MAX ||
+		    rpc_msg_param->u.value.b > UINT32_MAX)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		param->value.a = (uint32_t)rpc_msg_param->u.value.a;
+		param->value.b = (uint32_t)rpc_msg_param->u.value.b;
 		break;
 	case TEE_PARAM_TYPE_MEMREF_INPUT:
 		return TEE_ERROR_BAD_PARAMETERS;

--- a/core/pta/grpc.c
+++ b/core/pta/grpc.c
@@ -98,8 +98,6 @@ static TEE_Result rpc_postprocess_param(struct thread_param *rpc_msg_param,
 					TEE_Param *param)
 {
 	switch (param_type) {
-	case TEE_PARAM_TYPE_VALUE_INPUT:
-		return TEE_ERROR_BAD_PARAMETERS;
 	case TEE_PARAM_TYPE_VALUE_OUTPUT:
 	case TEE_PARAM_TYPE_VALUE_INOUT:
 		if (rpc_msg_param->u.value.a > UINT32_MAX ||
@@ -109,8 +107,6 @@ static TEE_Result rpc_postprocess_param(struct thread_param *rpc_msg_param,
 		param->value.a = (uint32_t)rpc_msg_param->u.value.a;
 		param->value.b = (uint32_t)rpc_msg_param->u.value.b;
 		break;
-	case TEE_PARAM_TYPE_MEMREF_INPUT:
-		return TEE_ERROR_BAD_PARAMETERS;
 	case TEE_PARAM_TYPE_MEMREF_OUTPUT:
 	case TEE_PARAM_TYPE_MEMREF_INOUT:
 		if (!mobj_va ||

--- a/core/pta/grpc.c
+++ b/core/pta/grpc.c
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019, Microsoft Corporation
+ */
+
+#include <kernel/msg_param.h>
+#include <kernel/pseudo_ta.h>
+#include <optee_rpc_cmd.h>
+#include <pta_grpc.h>
+#include <string.h>
+#include <util.h>
+
+static TEE_Result rpc_calc_param_size(uint32_t param_type, TEE_Param *param,
+				      uint32_t *size)
+{
+	switch (param_type) {
+	case TEE_PARAM_TYPE_NONE:
+	case TEE_PARAM_TYPE_VALUE_INPUT:
+	case TEE_PARAM_TYPE_VALUE_OUTPUT:
+	case TEE_PARAM_TYPE_VALUE_INOUT:
+		*size = 0;
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INPUT:
+	case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+	case TEE_PARAM_TYPE_MEMREF_INOUT:
+		*size = param->memref.size;
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result rpc_preprocess_param(struct thread_param *rpc_msg_param,
+				       struct mobj *mobj,
+				       uint8_t *mobj_va,
+				       uint32_t *mobj_offset,
+				       uint32_t param_type,
+				       TEE_Param *param)
+{
+	/* Fill the thread_param struct */
+	switch (param_type) {
+	case TEE_PARAM_TYPE_NONE:
+		rpc_msg_param->attr = THREAD_PARAM_ATTR_NONE;
+		break;
+	case TEE_PARAM_TYPE_VALUE_INPUT:
+		*rpc_msg_param = THREAD_PARAM_VALUE(IN, param->value.a,
+			param->value.b, 0);
+		break;
+	case TEE_PARAM_TYPE_VALUE_OUTPUT:
+		*rpc_msg_param = THREAD_PARAM_VALUE(OUT, param->value.a,
+			param->value.b, 0);
+		break;
+	case TEE_PARAM_TYPE_VALUE_INOUT:
+		*rpc_msg_param = THREAD_PARAM_VALUE(INOUT, param->value.a,
+			param->value.b, 0);
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INPUT:
+		*rpc_msg_param = THREAD_PARAM_MEMREF(IN, mobj, *mobj_offset,
+			param->memref.size);
+		break;
+	case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+		*rpc_msg_param = THREAD_PARAM_MEMREF(OUT, mobj, *mobj_offset,
+			param->memref.size);
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INOUT:
+		*rpc_msg_param = THREAD_PARAM_MEMREF(INOUT, mobj, *mobj_offset,
+			param->memref.size);
+		break;
+	default:
+		break;
+	}
+
+	/* Perform copies into shared memory, if necessary */
+	switch (param_type) {
+	case TEE_PARAM_TYPE_MEMREF_INPUT:
+	case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+	case TEE_PARAM_TYPE_MEMREF_INOUT:
+		if (!mobj)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		memcpy(mobj_va + *mobj_offset, param->memref.buffer,
+			param->memref.size);
+		*mobj_offset += param->memref.size;
+		break;
+	default:
+		break;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result rpc_postprocess_param(struct thread_param *rpc_msg_param,
+					uint8_t *mobj_va,
+					uint32_t *mobj_offset,
+					uint32_t param_type,
+					TEE_Param *param)
+{
+	switch (param_type) {
+	case TEE_PARAM_TYPE_VALUE_INPUT:
+		return TEE_ERROR_BAD_PARAMETERS;
+	case TEE_PARAM_TYPE_VALUE_OUTPUT:
+	case TEE_PARAM_TYPE_VALUE_INOUT:
+		param->value.a = rpc_msg_param->u.value.a;
+		param->value.b = rpc_msg_param->u.value.b;
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INPUT:
+		return TEE_ERROR_BAD_PARAMETERS;
+	case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+	case TEE_PARAM_TYPE_MEMREF_INOUT:
+		if (!mobj_va ||
+		    (rpc_msg_param->u.memref.size > param->memref.size))
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		memcpy(param->memref.buffer, mobj_va + *mobj_offset,
+			rpc_msg_param->u.memref.size);
+		*mobj_offset += rpc_msg_param->u.memref.size;
+	default:
+		break;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result rpc_execute(uint32_t param_types,
+			      TEE_Param params[TEE_NUM_PARAMS])
+{
+	TEE_Result res;
+
+	struct mobj *mobj = NULL;
+	uint8_t *mobj_va = NULL;
+
+	uint32_t mobj_size = 0;
+	uint32_t mobj_offset = 0;
+
+	struct thread_param rpc_msg_params[TEE_NUM_PARAMS] = { 0 };
+
+	uint8_t i;
+	uint32_t param_type;
+	uint32_t param_size;
+
+	/* Compute RPC payload size */
+	for (i = 0; i < TEE_NUM_PARAMS; i++) {
+		param_type = TEE_PARAM_TYPE_GET(param_types, i);
+		res = rpc_calc_param_size(param_type, &params[i], &param_size);
+		if (res != TEE_SUCCESS)
+			goto exit;
+
+		if (ADD_OVERFLOW(mobj_size, param_size, &mobj_size)) {
+			res = TEE_ERROR_SECURITY;
+			goto exit;
+		}
+	}
+
+	/* Allocate RPC payload with host, if necessary */
+	if (mobj_size) {
+		mobj = thread_rpc_alloc_host_payload(mobj_size);
+		if (!mobj) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto exit;
+		}
+
+		mobj_va = mobj_get_va(mobj, 0);
+		if (!mobj_va) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto exit;
+		}
+	}
+
+	/* Prepare parameters for the RPC */
+	for (i = 0; i < TEE_NUM_PARAMS; i++) {
+		param_type = TEE_PARAM_TYPE_GET(param_types, i);
+		res = rpc_preprocess_param(&rpc_msg_params[i], mobj, mobj_va,
+			&mobj_offset, param_type, &params[i]);
+	}
+
+	/* Send RPC message to the host */
+	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_GENERIC,
+		ARRAY_SIZE(rpc_msg_params), rpc_msg_params);
+	if (res != TEE_SUCCESS)
+		goto exit;
+
+	/* Process output parameters from the RPC */
+	mobj_offset = 0;
+	for (i = 0; i < TEE_NUM_PARAMS; i++) {
+		param_type = TEE_PARAM_TYPE_GET(param_types, i);
+		res = rpc_postprocess_param(&rpc_msg_params[i], mobj_va,
+			&mobj_offset, param_type, &params[i]);
+		if (res != TEE_SUCCESS)
+			goto exit;
+	}
+
+exit:
+	if (mobj)
+		thread_rpc_free_host_payload(mobj);
+
+	return res;
+}
+
+static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+				 uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	switch (cmd_id) {
+	case PTA_GRPC_EXECUTE:
+		return rpc_execute(param_types, params);
+	default:
+		break;
+	}
+
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static TEE_Result open_session(uint32_t param_types __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
+			       void **sess_ctx __unused)
+{
+	struct tee_ta_session *sess = NULL;
+
+	sess = tee_ta_get_calling_session();
+	if (!sess)
+		return TEE_ERROR_ACCESS_DENIED;
+
+	if (!is_user_ta_ctx(sess->ctx))
+		return TEE_ERROR_ACCESS_DENIED;
+
+	return TEE_SUCCESS;
+}
+
+static void close_session(void *sess_ctx __unused)
+{
+	/* Nothing */
+}
+
+pseudo_ta_register(.uuid = PTA_RPC_UUID, .name = "system.rpc",
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_CONCURRENT,
+		   .open_session_entry_point = open_session,
+		   .close_session_entry_point = close_session,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/pta/grpc.c
+++ b/core/pta/grpc.c
@@ -127,7 +127,7 @@ static TEE_Result rpc_postprocess_param(struct thread_param *rpc_msg_param,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result rpc_execute(uint32_t param_types,
+static TEE_Result rpc_execute(uint32_t cmd_id, uint32_t param_types,
 			      TEE_Param params[TEE_NUM_PARAMS])
 {
 	TEE_Result res;
@@ -180,8 +180,8 @@ static TEE_Result rpc_execute(uint32_t param_types,
 	}
 
 	/* Send RPC message to the host */
-	res = thread_rpc_cmd(OPTEE_MSG_RPC_CMD_GENERIC,
-		ARRAY_SIZE(rpc_msg_params), rpc_msg_params);
+	res = thread_rpc_cmd(cmd_id, ARRAY_SIZE(rpc_msg_params),
+		rpc_msg_params);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
@@ -206,9 +206,9 @@ static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
 				 uint32_t param_types,
 				 TEE_Param params[TEE_NUM_PARAMS])
 {
-	switch (cmd_id) {
+	switch (PTA_GRPC_GET_CMD_ID(cmd_id)) {
 	case PTA_GRPC_EXECUTE:
-		return rpc_execute(param_types, params);
+		return rpc_execute(cmd_id, param_types, params);
 	default:
 		break;
 	}

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -2,6 +2,7 @@ subdirs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += tests
 
 srcs-$(CFG_TEE_BENCHMARK) += benchmark.c
 srcs-$(CFG_DEVICE_ENUM_PTA) += device.c
+srcs-$(CFG_GENERIC_RPC) += grpc.c
 srcs-$(CFG_TA_GPROF_SUPPORT) += gprof.c
 srcs-$(CFG_SDP_PTA) += sdp.c
 ifeq ($(CFG_WITH_USER_TA),y)

--- a/lib/libutee/include/pta_grpc.h
+++ b/lib/libutee/include/pta_grpc.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019, Microsoft Corporation
+ */
+
+#ifndef __PTA_GRPC_H
+#define __PTA_GRPC_H
+
+/* PTA UUID: {ad0fd0ae-09e1-464b-98ed-0607ec9ebd8b} */
+#define PTA_RPC_UUID { 0xad0fd0ae, 0x09e1, 0x464b, { \
+		      0x98, 0xed, 0x06, 0x07, 0xec, 0x9e, 0xbd, 0x8b } }
+
+/*
+ * Send a Generic RPC request to the host application associated with the 
+ * session of the calling TA.
+ * 
+ * Up to four TEE_Param structs are passed as-is to the REE based on the TA's
+ * request.
+ */
+#define PTA_GRPC_EXECUTE		1
+
+#endif /* __PTA_GRPC_H */

--- a/lib/libutee/include/pta_grpc.h
+++ b/lib/libutee/include/pta_grpc.h
@@ -28,7 +28,7 @@
  * This means "send a generic RPC request to my host application with function
  * ID 3."
  * 
- * The reason for using 0xF is that the entire value is passed to the REE. When
+ * The reason for using 0x1 is that the entire value is passed to the REE. When
  * the REE sees an RPC request, if can determine that it is a generic RPC
  * request by examining the upper four bits while the bottom ones are used for
  * data transfer. This way, it is not necessary to reserve one of the four

--- a/lib/libutee/include/pta_grpc.h
+++ b/lib/libutee/include/pta_grpc.h
@@ -11,12 +11,64 @@
 		      0x98, 0xed, 0x06, 0x07, 0xec, 0x9e, 0xbd, 0x8b } }
 
 /*
- * Send a Generic RPC request to the host application associated with the 
- * session of the calling TA.
+ * The GRPC PTA accepts 32-bit commands whose bits are interpreted as follows:
  * 
- * Up to four TEE_Param structs are passed as-is to the REE based on the TA's
- * request.
+ * | xxxx | xxxx xxxx xxxx xxxx xxxx xxxx xxxx |
+ *  CMD ID             FUNC ID
+ * 
+ * The CMD ID part is interpreted by the GRPC PTA. If the CMD ID is 0x1, this
+ * indicates that the caller wishes to send a generic RPC request to its host
+ * application. The FUNC ID indicates the function ID that the host application
+ * knows how to interpret and handle.
+ * 
+ * For example, if the GRPC PTA receives the following bitmap as its command:
+ * 
+ * | 0001 | 0000 0000 0000 0000 0000 0000 0011 |
+ * 
+ * This means "send a generic RPC request to my host application with function
+ * ID 3."
+ * 
+ * The reason for using 0xF is that the entire value is passed to the REE. When
+ * the REE sees an RPC request, if can determine that it is a generic RPC
+ * request by examining the upper four bits while the bottom ones are used for
+ * data transfer. This way, it is not necessary to reserve one of the four
+ * TEE_Param structs to pass the host function ID.
+ * 
+ * In the future, if the GRPC PTA must perform other tasks, the upper four bits
+ * can be used to indicate which of these other tasks to execute.
+ */
+
+/* Reserve the upper four bits */
+#define PTA_GRPC_CMD_ID_MASK 		0xF0000000
+#define PTA_GRPC_CMD_ID_SHIFT		(32 - 4)
+
+/*
+ * Send a generic RPC to the host application of the calling TA.
+ * 
+ * The four TEE_Param structs are marshalled to the REE as requested by the
+ * caller. That is, the structs carry no special meaning as far as the GRPC PTA
+ * is concerned.
  */
 #define PTA_GRPC_EXECUTE		1
+
+/*
+ * Verify that the host function ID is not so large that it overlaps with the
+ * reserved bits. TA's can use this to assert that their function ID's are OK.
+ */
+#define PTA_GRPC_IS_FUNC_ID_VALID(func_id) \
+	(!((func_id) & PTA_GRPC_CMD_ID_MASK))
+
+/*
+ * Create a composite command with the GRPC PTA command ID and the host function
+ * ID
+ */
+#define PTA_GRPC_ENCODE_CMD(cmd, func_id) \
+	(((cmd) << PTA_GRPC_CMD_ID_SHIFT) | (func_id))
+
+/* Retrieve the GRPC PTA command ID from a composite command */
+#define PTA_GRPC_GET_CMD_ID(cmd)	((cmd) >> PTA_GRPC_CMD_ID_SHIFT)
+
+/* Retrieve the host function ID from a composite command */
+#define PTA_GRPC_GET_FUNC_ID(cmd)	((cmd) & ~PTA_GRPC_CMD_ID_MASK)
 
 #endif /* __PTA_GRPC_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -369,6 +369,10 @@ CFG_ULIBS_MCOUNT ?= n
 # Profiling/tracing of syscall wrapper (utee_*)
 CFG_SYSCALL_WRAPPERS_MCOUNT ?= $(CFG_ULIBS_MCOUNT)
 
+# Enable Generic RPC's to allow TA's to request services from their host
+# application running in the rich OS on a per-session basis.
+CFG_GENERIC_RPC ?= y
+
 ifeq (y,$(filter y,$(CFG_ULIBS_MCOUNT) $(CFG_SYSCALL_WRAPPERS_MCOUNT)))
 ifeq (,$(filter y,$(CFG_TA_GPROF_SUPPORT) $(CFG_TA_FTRACE_SUPPORT)))
 $(error Cannot instrument user libraries if user mode profiling is disabled)


### PR DESCRIPTION
This PR adds a new PTA, the Generic RPC (GRPC) PTA, that allows user-mode TA's to perform calls out to their corresponding host application running in the REE on a session-by-session basis. The logic behind this feature mirrors that utilized to communicate with the TEE supplicant. In this sense, a TA's host application effectively becomes its own little supplicant.

This mechanism was originally developed for the [Open Enclave SDK](https://github.com/openenclave/openenclave). This SDK provides developers with an abstraction layer on top of multiple TEE technologies, allowing them to write hosts and enclaves once which can run anywhere. Currently, it supports Intel SGX and work is underway to support OP-TEE, too. The SDK's master branch has preliminary support for OP-TEE and allows one to build and load TA's, to invoke commands (aka. "enclave calls", or "ECALLs") and for TA's to invoke commands on their host (aka. "out calls" or "OCALLs"), for parity with SGX.

In the SDK, a code generator produces stubs that serialize function parameters into known structures (one for input, one for output, and a control structure), then passes that to the enclave or host, depending on the direction of the call. On the other side of the call, the structure is deserialized and the underlying function is invoked automatically. In this sense, the developer merely executes a function call on either side and the complexities of performing an ECALL or an OCALL are completely hidden by the SDK.

The flow for an OCALL is exactly the same as for an RPC to the TEE supplicant; this method just allows for arbitrary parameters and for routing the request to the host application.

To support this functionality, changes were made to the Linux TEE and OP-TEE drivers. These may be viewed [here](https://github.com/torvalds/linux/compare/master...ms-iot:optee-generic-rpc-support).

Open questions:
1. API offered to TA's (besides the raw GRPC PTA API);
2. Is there a way to minimize copies?
3. How would you like me to submit the changes to Linux?

Associated PR's:
1. [OP-TEE Client](https://github.com/OP-TEE/optee_client/pull/171)
2. [OP-TEE Examples](https://github.com/linaro-swg/optee_examples/pull/64)