### PR TITLE
build: prevent empty config from cfg-one-enabled

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -95,12 +95,12 @@ define cfg-cmake-set
 		  set($1 $($1))_nl_))
 endef
 
-# Returns 'y' if at least one variable is 'y', empty otherwise
+# Returns 'y' if at least one variable is 'y', 'n' otherwise
 # Example:
 # FOO_OR_BAR := $(call cfg-one-enabled, FOO BAR)
-cfg-one-enabled = $(if $(filter y, $(foreach var,$(1),$($(var)))),y,)
+cfg-one-enabled = $(if $(filter y, $(foreach var,$(1),$($(var)))),y,n)
 
-# Returns 'y' if all variables are 'y', empty otherwise
+# Returns 'y' if all variables are 'y', 'n' otherwise
 # Example:
 # FOO_AND_BAR := $(call cfg-all-enabled, FOO BAR)
 cfg-all-enabled =                                                             \
@@ -108,6 +108,7 @@ cfg-all-enabled =                                                             \
         $(if $(1),                                                            \
             $(if $(filter y,$($(firstword $(1)))),                            \
                 $(call cfg-all-enabled,$(filter-out $(firstword $(1)),$(1))), \
+		n                                                             \
              ),                                                               \
             y                                                                 \
          )                                                                    \


### PR DESCRIPTION
Changes makefile macro cfg-one-enabled to set return value
to 'n' rather than an empty string when condition is not
fulfilled.

This change prevents configuration switches to be set
to empty values when set though use of macro cfg-one-enabled.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
