### PR TITLE
symbolize.py: fix exception when stdin is not a terminal

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -481,16 +481,20 @@ def main():
     symbolizer = Symbolizer(sys.stdout, args.dirs, args.strip_path)
 
     fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
-    new = termios.tcgetattr(fd)
-    new[3] = new[3] & ~termios.ECHO  # lflags
+    isatty = os.isatty(fd)
+    if isatty:
+        old = termios.tcgetattr(fd)
+        new = termios.tcgetattr(fd)
+        new[3] = new[3] & ~termios.ECHO  # lflags
     try:
-        termios.tcsetattr(fd, termios.TCSADRAIN, new)
+        if isatty:
+            termios.tcsetattr(fd, termios.TCSADRAIN, new)
         for line in sys.stdin:
             symbolizer.write(line)
     finally:
         symbolizer.flush()
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        if isatty:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Commit 6b4fc6752b3c ("symbolize.py: disable terminal local echo") uses
termios functions on stdin unconditionally. Unfortunately, this will
cause an exception when stdin is not a terminal, for instance:

 $ echo Hello | ./script/symbolize.py
 Traceback (most recent call last):
   File "./scripts/symbolize.py", line 497, in <module>
     main()
   File "./scripts/symbolize.py", line 484, in main
     old = termios.tcgetattr(fd)
 termios.error: (25, 'Inappropriate ioctl for device')

Add a try/except block and test 'old' and 'new' to deal with this
situation.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
