### PR TITLE
Revert "hikey: increase core heap size to 192 kB"

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -19,9 +19,6 @@ CFG_NUM_THREADS ?= 8
 CFG_CRYPTO_WITH_CE ?= y
 CFG_WITH_STACK_CANARIES ?= y
 
-# Override 64 kB default in mk/config.mk with 192 kB
-CFG_CORE_HEAP_SIZE ?= 196608
-
 ifeq ($(PLATFORM_FLAVOR),hikey)
 CFG_PL061 ?= y
 CFG_PL022 ?= y


### PR DESCRIPTION
This reverts commit 28c75dbebc49 ("hikey: increase core heap size to
192 kB") which increased the core heap size in order to pass the AOSP
VTS. Unfortunately, this bigger value does not work well when the pager
is enabled: it causes lots of page faults and a massive slowdown (for
instance, 'xtest 1013' on HiKey620 completes in ~ 1.7 s with the
default heap size of 64 kB but takes ~ 53 s with 192 kB).

Therefore, revert to the previous configuration. A bigger value can
always be set on the command line or by other means when building for
AOSP.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
