### PR TITLE
Update CHANGELOG for 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# OP-TEE - version 3.7.0 (2019-10-18)
+
+- Links to the release pages, commits and pull requests merged into this release for:
+  - OP-TEE/optee_os: [release page][OP_TEE_optee_os_release_3_7_0], [commits][OP_TEE_optee_os_commits_3_7_0] and [pull requests][OP_TEE_optee_os_pr_3_7_0]
+  - OP-TEE/optee_client: [release page][OP_TEE_optee_client_release_3_7_0], [commits][OP_TEE_optee_client_commits_3_7_0] and [pull requests][OP_TEE_optee_client_pr_3_7_0]
+  - OP-TEE/optee_test: [release page][OP_TEE_optee_test_release_3_7_0], [commits][OP_TEE_optee_test_commits_3_7_0] and [pull requests][OP_TEE_optee_test_pr_3_7_0]
+  - OP-TEE/build: [release page][OP_TEE_build_release_3_7_0], [commits][OP_TEE_build_commits_3_7_0] and [pull requests][OP_TEE_build_pr_3_7_0]
+  - linaro-swg/optee_examples: [release page][linaro_swg_optee_examples_release_3_7_0], [commits][linaro_swg_optee_examples_commits_3_7_0] and [pull requests][linaro_swg_optee_examples_pr_3_7_0]
+
+
+[OP_TEE_optee_os_release_3_7_0]: https://github.com/OP-TEE/optee_os/releases/tag/3.7.0
+[OP_TEE_optee_os_commits_3_7_0]: https://github.com/OP-TEE/optee_os/compare/3.6.0...3.7.0
+[OP_TEE_optee_os_pr_3_7_0]: https://github.com/OP-TEE/optee_os/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2019-07-05..2019-10-18
+
+[OP_TEE_optee_client_release_3_7_0]: https://github.com/OP-TEE/optee_client/releases/tag/3.7.0
+[OP_TEE_optee_client_commits_3_7_0]: https://github.com/OP-TEE/optee_client/compare/3.6.0...3.7.0
+[OP_TEE_optee_client_pr_3_7_0]: https://github.com/OP-TEE/optee_client/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2019-07-05..2019-10-18
+
+[OP_TEE_optee_test_release_3_7_0]: https://github.com/OP-TEE/optee_test/releases/tag/3.7.0
+[OP_TEE_optee_test_commits_3_7_0]: https://github.com/OP-TEE/optee_test/compare/3.6.0...3.7.0
+[OP_TEE_optee_test_pr_3_7_0]: https://github.com/OP-TEE/optee_test/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2019-07-05..2019-10-18
+
+[OP_TEE_build_release_3_7_0]: https://github.com/OP-TEE/build/releases/tag/3.7.0
+[OP_TEE_build_commits_3_7_0]: https://github.com/OP-TEE/build/compare/3.6.0...3.7.0
+[OP_TEE_build_pr_3_7_0]: https://github.com/OP-TEE/build/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2019-07-05..2019-10-18
+
+[linaro_swg_optee_examples_release_3_7_0]: https://github.com/linaro-swg/optee_examples/releases/tag/3.7.0
+[linaro_swg_optee_examples_commits_3_7_0]: https://github.com/linaro-swg/optee_examples/compare/3.6.0...3.7.0
+[linaro_swg_optee_examples_pr_3_7_0]: https://github.com/linaro-swg/optee_examples/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2019-07-05..2019-10-18
+
 # OP-TEE - version 3.6.0 (2019-07-05)
 
 - Link to the GitHub [release page][github_release_3_6_0].

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -116,7 +116,7 @@ endif
 # with limited depth not including any tag, so there is really no guarantee
 # that TEE_IMPL_VERSION contains the major and minor revision numbers.
 CFG_OPTEE_REVISION_MAJOR ?= 3
-CFG_OPTEE_REVISION_MINOR ?= 6
+CFG_OPTEE_REVISION_MINOR ?= 7
 
 # Trusted OS implementation manufacturer name
 CFG_TEE_MANUFACTURER ?= LINARO

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2019, Linaro Limited
+#
+
+from subprocess import Popen, PIPE
+import argparse
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Helper script that updates '
+                                     'the CHANGELOG.md file.\n'
+                                     'Usage example:\n'
+                                     '  ./update_changelog.py '
+                                     ' --changelog-file CHANGELOG.md'
+                                     ' --release-version 3.7.0'
+                                     ' --previous-release-version 3.6.0'
+                                     ' --release-date 2019-10-11')
+
+    parser.add_argument('--changelog-file', action='store', required=False,
+                        default='CHANGELOG.md',
+                        help='Changelog file to be updated.')
+
+    parser.add_argument('--release-date', action='store', required=True,
+                        help='The release date (yyyy-mm-dd).')
+
+    parser.add_argument('--release-version', action='store', required=True,
+                        help='Release version (MAJOR.MINOR.PATCH).')
+
+    parser.add_argument('--previous-release-version', action='store',
+                        required=True,
+                        help='Previous release version (MAJOR.MINOR.PATCH).')
+
+    return parser.parse_args()
+
+
+def prepend_write(filename, text):
+    with open(filename, 'r+') as f:
+        current_content = f.read()
+        f.seek(0, 0)
+        f.write(text + '\n' + current_content)
+        f.flush()
+
+
+def get_previous_release_date(tag):
+    cmd = "git log -1 --date=format:%Y-%m-%d --format=format:%cd " \
+          "{}".format(tag)
+    process = Popen(cmd.split(), stdout=PIPE)
+    (output, err) = process.communicate()
+    return output.decode("utf-8")
+
+
+def main():
+    global args
+
+    args = get_args()
+
+    gits = ["OP-TEE/optee_os", "OP-TEE/optee_client", "OP-TEE/optee_test",
+            "OP-TEE/build", "linaro-swg/optee_examples"]
+
+    # Shorten name
+    clf = args.changelog_file
+    rv = args.release_version
+    prv = args.previous_release_version
+    rd = args.release_date
+    prd = get_previous_release_date(prv)
+
+    # In some cases we need underscore in string
+    rvu = rv.replace('.', '_')
+
+    text = "# OP-TEE - version {} ({})\n".format(rv, rd)
+    text += "\n"
+    text += "- Links to the release pages, commits and pull requests merged " \
+            "into this release for:\n"
+
+    for g in gits:
+        gu = g.replace('/', '_')
+        gu = gu.replace('-', '_')
+        text += "  - {}: [release page][{}_release_{}], " \
+                "[commits][{}_commits_{}] and [pull requests]" \
+                "[{}_pr_{}]\n".format(g, gu, rvu, gu, rvu, gu, rvu)
+
+    text += "\n"
+
+    for g in gits:
+        gu = g.replace('/', '_')
+        gu = gu.replace('-', '_')
+        text += "\n[{}_release_{}]: https://github.com/{}/releases/tag/" \
+                "{}\n".format(gu, rvu, g, rv)
+        text += "[{}_commits_{}]: https://github.com/{}/compare/" \
+                "{}...{}\n".format(gu, rvu, g, prv, rv)
+        text += "[{}_pr_{}]: https://github.com/{}/pulls?q=is%3Apr+is%3A" \
+                "merged+base%3Amaster+merged%3A{}..{}\n".format(
+                        gu, rvu, g, prd, rd)
+
+    prepend_write(args.changelog_file, text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@OP-TEE/maintainers please start testing your devices/platforms and add `Tested-by: ...` in the comments. Release candidate tag will be sent out shortly.

I've also written a python script that makes it quick and easy to create/update the `CHANGELOG.md`. The changelog updates in this commit has been generated by that script. Another change is that it also lists the other gits that makes up the core of the OP-TEE project.

// Joakim