### PR TITLE
core: Add support for multi-threaded MPIDR values

### DIFF
--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
  */
 #ifndef ARM_H
 #define ARM_H
@@ -28,9 +29,21 @@
 #define CORTEX_A75_PART_NUM		0xD0A
 
 /* MPIDR definitions */
-#define MPIDR_CPU_MASK		0xff
-#define MPIDR_CLUSTER_SHIFT	8
-#define MPIDR_CLUSTER_MASK	(0xff << MPIDR_CLUSTER_SHIFT)
+#define MPIDR_AFFINITY_BITS	8
+#define MPIDR_AFFLVL_MASK	0xff
+#define MPIDR_AFF0_SHIFT	0
+#define MPIDR_AFF0_MASK		(MPIDR_AFFLVL_MASK << MPIDR_AFF0_SHIFT)
+#define MPIDR_AFF1_SHIFT	8
+#define MPIDR_AFF1_MASK		(MPIDR_AFFLVL_MASK << MPIDR_AFF1_SHIFT)
+#define MPIDR_AFF2_SHIFT	16
+#define MPIDR_AFF2_MASK		(MPIDR_AFFLVL_MASK << MPIDR_AFF2_SHIFT)
+
+#define MPIDR_MT_SHIFT		24
+#define MPIDR_MT_MASK		BIT(MPIDR_MT_SHIFT)
+
+#define MPIDR_CPU_MASK		MPIDR_AFF0_MASK
+#define MPIDR_CLUSTER_SHIFT	MPIDR_AFF1_SHIFT
+#define MPIDR_CLUSTER_MASK	MPIDR_AFF1_MASK
 
 /* CLIDR definitions */
 #define CLIDR_LOUIS_SHIFT	21

--- a/core/arch/arm/kernel/misc_a32.S
+++ b/core/arch/arm/kernel/misc_a32.S
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
  */
 
 #include <asm.S>
@@ -21,10 +22,39 @@ END_FUNC __get_core_pos
 /* size_t get_core_pos_mpidr(uint32_t mpidr); */
 FUNC get_core_pos_mpidr , :
 UNWIND(	.fnstart)
+	mov	r3, r0
+
+	/*
+	 * Shift MPIDR value if it's not already shifted.
+	 * Using logical shift ensures AFF0 to be filled with zeroes.
+	 * This part is necessary even if CFG_CORE_THREAD_SHIFT is 0 because
+	 * MT bit can be set on single threaded systems where all the AFF0
+	 * values are zeroes.
+	 */
+	tst	r0, #MPIDR_MT_MASK
+	lsleq	r3, r0, #MPIDR_AFFINITY_BITS
+
+	/*
+	 * At this point the MPIDR layout is always shifted so it looks
+	 * as follows AFF2 -> cluster, AFF1 -> core, AFF0 -> thread
+	 */
+#if CFG_CORE_THREAD_SHIFT == 0
 	/* Calculate CorePos = (ClusterId * (cores/cluster)) + CoreId */
-	and	r1, r0, #MPIDR_CPU_MASK
-	and	r0, r0, #MPIDR_CLUSTER_MASK
-	add	r0, r1, r0, LSR #(MPIDR_CLUSTER_SHIFT - CFG_CORE_CLUSTER_SHIFT)
+	ubfx	r0, r3, #MPIDR_AFF1_SHIFT, #MPIDR_AFFINITY_BITS
+	ubfx	r1, r3, #MPIDR_AFF2_SHIFT, #MPIDR_AFFINITY_BITS
+	add	r0, r0, r1, LSL #(CFG_CORE_CLUSTER_SHIFT)
+#else
+	/*
+	 * Calculate CorePos =
+	 * ((ClusterId * (cores/cluster)) + CoreId) * (threads/core) + ThreadId
+	 */
+	ubfx	r0, r3, #MPIDR_AFF0_SHIFT, #MPIDR_AFFINITY_BITS
+	ubfx	r1, r3, #MPIDR_AFF1_SHIFT, #MPIDR_AFFINITY_BITS
+	ubfx	r2, r3, #MPIDR_AFF2_SHIFT, #MPIDR_AFFINITY_BITS
+	add	r1, r1, r2, LSL #(CFG_CORE_CLUSTER_SHIFT)
+	add	r0, r0, r1, LSL #(CFG_CORE_THREAD_SHIFT)
+#endif
+
 	bx	lr
 UNWIND(	.fnend)
 END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
  */
 
 #include <asm.S>
@@ -15,10 +16,38 @@ END_FUNC __get_core_pos
 
 /* size_t get_core_pos_mpidr(uint32_t mpidr); */
 FUNC get_core_pos_mpidr , :
+	/*
+	 * Shift MPIDR value if it's not already shifted.
+	 * Using logical shift ensures AFF0 to be filled with zeroes.
+	 * This part is necessary even if CFG_CORE_THREAD_SHIFT is 0 because
+	 * MT bit can be set on single threaded systems where all the AFF0
+	 * values are zeroes.
+	 */
+	tst	x0, #MPIDR_MT_MASK
+	lsl	x3, x0, #MPIDR_AFFINITY_BITS
+	csel	x3, x3, x0, eq
+
+	/*
+	 * At this point the MPIDR layout is always shifted so it looks
+	 * as follows AFF2 -> cluster, AFF1 -> core, AFF0 -> thread
+	 */
+#if CFG_CORE_THREAD_SHIFT == 0
 	/* Calculate CorePos = (ClusterId * (cores/cluster)) + CoreId */
-	and	x1, x0, #MPIDR_CPU_MASK
-	and	x0, x0, #MPIDR_CLUSTER_MASK
-	add	x0, x1, x0, LSR #(MPIDR_CLUSTER_SHIFT - CFG_CORE_CLUSTER_SHIFT)
+	ubfx	x0, x3, #MPIDR_AFF1_SHIFT, #MPIDR_AFFINITY_BITS
+	ubfx	x1, x3, #MPIDR_AFF2_SHIFT, #MPIDR_AFFINITY_BITS
+	add	x0, x0, x1, LSL #(CFG_CORE_CLUSTER_SHIFT)
+#else
+	/*
+	 * Calculate CorePos =
+	 * ((ClusterId * (cores/cluster)) + CoreId) * (threads/core) + ThreadId
+	 */
+	ubfx	x0, x3, #MPIDR_AFF0_SHIFT, #MPIDR_AFFINITY_BITS
+	ubfx	x1, x3, #MPIDR_AFF1_SHIFT, #MPIDR_AFFINITY_BITS
+	ubfx	x2, x3, #MPIDR_AFF2_SHIFT, #MPIDR_AFFINITY_BITS
+	add	x1, x1, x2, LSL #(CFG_CORE_CLUSTER_SHIFT)
+	add	x0, x0, x1, LSL #(CFG_CORE_THREAD_SHIFT)
+#endif
+
 	ret
 END_FUNC get_core_pos_mpidr
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -430,6 +430,12 @@ CFG_DEVICE_ENUM_PTA ?= y
 # Default is 2**(2) = 4 cores per cluster.
 CFG_CORE_CLUSTER_SHIFT ?= 2
 
+# Define the number of threads per core used in calculating processing
+# element's position. The core number is shifted by this value and added to
+# the thread ID, so its value represents log2(threads/core).
+# Default is 2**(0) = 1 threads per core.
+CFG_CORE_THREAD_SHIFT ?= 0
+
 # Enable support for dynamic shared memory (shared memory anywhere in
 # non-secure memory).
 CFG_CORE_DYN_SHM ?= y


### PR DESCRIPTION
If the MT bit is set the affinities are shifted in the MPIDR register
so the get_core_pos_mpidr functions needs to be modified accordingly.
This is necessary to make OP-TEE to be able to run on multi-threaded
systems. The number of threads/core can be modified by the
CFG_THREAD_CORE_SHIFT makefile parameter. The default value is the
existing single threaded mode.

Change-Id: Ibfacad34ac2bc67b1d0b7929f731da6406a97b5a
Signed-off-by: Imre Kis <imre.kis@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
