### PR TITLE
Riscure fuzzer vuln

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -3010,6 +3010,9 @@ TEE_Result syscall_authenc_update_aad(unsigned long state,
 	if (res != TEE_SUCCESS)
 		return res;
 
+	if (TEE_ALG_GET_CLASS(cs->algo) != TEE_OPERATION_AE)
+		return TEE_ERROR_BAD_STATE;
+
 	res = crypto_authenc_update_aad(cs->ctx, cs->algo, cs->mode,
 					aad_data, aad_data_len);
 	if (res != TEE_SUCCESS)
@@ -3034,6 +3037,9 @@ TEE_Result syscall_authenc_update_payload(unsigned long state,
 	res = tee_svc_cryp_get_state(sess, tee_svc_uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
 		return res;
+
+	if (TEE_ALG_GET_CLASS(cs->algo) != TEE_OPERATION_AE)
+		return TEE_ERROR_BAD_STATE;
 
 	res = tee_mmu_check_access_rights(to_user_ta_ctx(sess->ctx),
 					  TEE_MEMORY_ACCESS_READ |
@@ -3093,6 +3099,9 @@ TEE_Result syscall_authenc_enc_final(unsigned long state,
 
 	if (cs->mode != TEE_MODE_ENCRYPT)
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (TEE_ALG_GET_CLASS(cs->algo) != TEE_OPERATION_AE)
+		return TEE_ERROR_BAD_STATE;
 
 	res = tee_mmu_check_access_rights(to_user_ta_ctx(sess->ctx),
 					  TEE_MEMORY_ACCESS_READ |
@@ -3174,6 +3183,9 @@ TEE_Result syscall_authenc_dec_final(unsigned long state,
 
 	if (cs->mode != TEE_MODE_DECRYPT)
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (TEE_ALG_GET_CLASS(cs->algo) != TEE_OPERATION_AE)
+		return TEE_ERROR_BAD_STATE;
 
 	res = tee_mmu_check_access_rights(to_user_ta_ctx(sess->ctx),
 					  TEE_MEMORY_ACCESS_READ |

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2416,6 +2416,9 @@ TEE_Result syscall_cipher_init(unsigned long state, const void *iv,
 	if (res != TEE_SUCCESS)
 		return res;
 
+	if (TEE_ALG_GET_CLASS(cs->algo) != TEE_OPERATION_CIPHER)
+		return TEE_ERROR_BAD_STATE;
+
 	res = tee_mmu_check_access_rights(utc,
 					  TEE_MEMORY_ACCESS_READ |
 					  TEE_MEMORY_ACCESS_ANY_OWNER,


### PR DESCRIPTION
Fixes for potential security issues found by Riscure's fuzzer tool.

I've tested this in QEMU v7, no regressions seen.
```bash
24105 subtests of which 0 failed
96 test cases of which 0 failed
0 test cases were skipped
TEE test application done!
```