### PR TITLE
ldelf: increase heap size from 8 to 12 KiB

### DIFF
--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -19,7 +19,7 @@
 #include "sys.h"
 #include "ta_elf.h"
 
-static size_t mpool_size = 2 * SMALL_PAGE_SIZE;
+static size_t mpool_size = 3 * SMALL_PAGE_SIZE;
 static vaddr_t mpool_base;
 
 static void __printf(2, 0) print_to_console(void *pctx __unused,


### PR DESCRIPTION
The ldelf heap is not big enough to load some 64-bit TAs with several
shared libraries such as xtest 1006 when CFG_ULIBS_SHARED=y:

 * regression_1006 Test Basic OS features
 E/LD:  copy_section_headers:766 malloc
 E/TC:? 0 init_with_ldelf:229 ldelf failed with res: 0xffff000c
 E/TC:? 0 tee_ta_open_session:727 Failed. Return error 0xffff000c
   regression_1006 FAILED

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
