### PR TITLE
Fix tag hash calculation for early TAs

### DIFF
--- a/core/arch/arm/kernel/early_ta.c
+++ b/core/arch/arm/kernel/early_ta.c
@@ -126,11 +126,11 @@ static TEE_Result early_ta_get_tag(const struct user_ta_store_handle *h,
 	res = crypto_hash_init(ctx, TEE_ALG_SHA256);
 	if (res)
 		goto out;
-	res = crypto_hash_update(ctx, TEE_ALG_SHA256, h->early_ta->ta + h->offs,
+	res = crypto_hash_update(ctx, TEE_ALG_SHA256, h->early_ta->ta,
 				 h->early_ta->size);
 	if (res)
 		goto out;
-	res = crypto_hash_final(ctx, TEE_ALG_SHA256, tag, h->early_ta->size);
+	res = crypto_hash_final(ctx, TEE_ALG_SHA256, tag, *tag_len);
 out:
 	crypto_hash_free_ctx(ctx, TEE_ALG_SHA256);
 	return res;


### PR DESCRIPTION
I found what appears to be a flaw with early_ta_get_tag() while working
on some code measurement features.

I believe this has been working correctly due to the order of execution
(tag is calculated before any reads) and crypto_hash_final taking the 
minimum of digest length and buffer length, but this will be more
reliable.

Signed-off-by: Daniel McIlvaney <damcilva@microsoft.com>