### PR TITLE
Fixes #507 in LibTomCrypt

### DIFF
--- a/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
@@ -66,7 +66,7 @@ int der_decode_utf8_string(const unsigned char *in,  unsigned long inlen,
       /* count number of bytes */
       for (z = 0; (tmp & 0x80) && (z <= 4); z++, tmp = (tmp << 1) & 0xFF);
 
-      if (z > 4 || (x + (z - 1) > inlen)) {
+      if (z == 1 || z > 4 || (x + (z - 1) > inlen)) {
          return CRYPT_INVALID_PACKET;
       }
 


### PR DESCRIPTION
@werew FYI and btw, we tend to use "Signed-off-by" tags in patches in our tree, so I wonder, is it OK if I add the following to the commit message?
```
Signed-off-by: Luigi Coniglio <werew@ret2libc.com>>
```

Fix a vulnerability in der_decode_utf8_string as specified here:
https://github.com/libtom/libtomcrypt/issues/507

Patch created by @werew and manually picked from:
  https://github.com/libtom/libtomcrypt/commit/25c26a3b7a9ad8192ccc923e15cf62bf0108ef94