### PR TITLE
Fixes #507 in LTC - vulnerability in der_decode_utf8_string

### DIFF
--- a/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
@@ -66,7 +66,7 @@ int der_decode_utf8_string(const unsigned char *in,  unsigned long inlen,
       /* count number of bytes */
       for (z = 0; (tmp & 0x80) && (z <= 4); z++, tmp = (tmp << 1) & 0xFF);
 
-      if (z > 4 || (x + (z - 1) > inlen)) {
+      if (z == 1 || z > 4 || (x + (z - 1) > inlen)) {
          return CRYPT_INVALID_PACKET;
       }
 


### PR DESCRIPTION
Fix a vulnerability in der_decode_utf8_string as specified here:
https://github.com/libtom/libtomcrypt/issues/507

Patch manually picked from:
  https://github.com/libtom/libtomcrypt/commit/25c26a3b7a9ad8192ccc923e15cf62bf0108ef94

[Joakim Bech: Extended commmit message]
Signed-off-by: Luigi Coniglio <werew@ret2libc.com>
Acked-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (QEMU v7)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
