### PR TITLE
check range in _rijndael_ecb_ functions

### DIFF
--- a/core/lib/libtomcrypt/src/ciphers/aes/aes.c
+++ b/core/lib/libtomcrypt/src/ciphers/aes/aes.c
@@ -296,6 +296,10 @@ int ECB_ENC(const unsigned char *pt, unsigned char *ct, const symmetric_key *ske
     LTC_ARGCHK(skey != NULL);
 
     Nr = skey->rijndael.Nr;
+
+    if (Nr < 2 || Nr > 16)
+        return CRYPT_INVALID_ROUNDS;
+
     rk = skey->rijndael.eK;
 
     /*
@@ -476,6 +480,10 @@ int ECB_DEC(const unsigned char *ct, unsigned char *pt, const symmetric_key *ske
     LTC_ARGCHK(skey != NULL);
 
     Nr = skey->rijndael.Nr;
+
+    if (Nr < 2 || Nr > 16)
+        return CRYPT_INVALID_ROUNDS;
+
     rk = skey->rijndael.dK;
 
     /*


### PR DESCRIPTION
There is no check that the 'skey' structure has been properly
initialized. For example, the skey->rijndael.Nr is assumed to contain a
positive number corresponding to the number of AES rounds to perform. In
_rijndael_ecb_encrypt the skey->rijndael.Nr is subtracted by two, which
can result in an integer underflow if the structure hasn't been
initialized correctly.

By clamping the value for skey->rijndael.Nr into the valid rounds for
AES we can return an error instead of ending up reading outside the
boundaries (of skey->rijndael.eK).

Patch manually picked from:
  https://github.com/libtom/libtomcrypt/commit/7b4a5c1dcf2803e9c6cbcbc2458db9317e6fb8ca

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-off-by: Joakim Bech <joakim.bech@linaro.org> (QEMU v7)
Reported-by: Martijn Bogaard <bogaard@riscure.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
