### PR TITLE
[RFC] core: print version reported to non-secure

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -129,7 +129,8 @@ define gen-version-o
 	$(call update-buildcount,$(link-out-dir)/.buildcount)
 	@$(cmd-echo-silent) '  GEN     $(link-out-dir)/version.o'
 	$(q)echo -e "const char core_v_str[] =" \
-		"\"$(TEE_IMPL_VERSION) \"" \
+		"\"$(CFG_OPTEE_REVISION_MAJOR).$(CFG_OPTEE_REVISION_MINOR) \"" \
+		"\"(git $(TEE_IMPL_VERSION)) \"" \
 		"\"($(CORE_CC_VERSION)) \"" \
 		"\"#$(BUILD_COUNT_STR) \"" \
 		"\"$(DATE_STR) \"" \


### PR DESCRIPTION
This is a proposal to get some feedback about the versionning info reported by OP-TEE core.

Core prints version info at boot and provides version info to non-secure world but both are not alwyas consistent.

This is not a hot topic (not mandated for 3.7.0)