### PR TITLE
core: fix terminal char in pta dlsym

### DIFF
--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -682,7 +682,7 @@ static TEE_Result call_ldelf_dlsym(struct user_ta_ctx *utc, TEE_UUID *uuid,
 	arg->cmd = LDELF_DL_ENTRY_DLSYM;
 	arg->dlsym.uuid = *uuid;
 	memcpy(arg->dlsym.symbol, sym, len);
-	arg->dlsym.symbol[len + 1] = '\0';
+	arg->dlsym.symbol[len] = '\0';
 
 	res = thread_enter_user_mode((vaddr_t)arg, 0, 0, 0,
 				     usr_stack, utc->dl_entry_func,


### PR DESCRIPTION
Correct misplaced terminal null character in PTA system when invoking
ldelf entry to look for a target symbol.

Fixes: ebef121c1f5c ("core, ldelf: add support for runtime loading of shared libraries")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
