### PR TITLE
[RFC] Add framework to support REE-FS encrypted TAs

### DIFF
--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2015, 2019, Linaro Limited
  */
 
+#include <assert.h>
 #include <inttypes.h>
 #include <kernel/tee_common_otp.h>
 #include <kernel/huk_subkey.h>
+#include <signed_hdr.h>
+#include <ta_pub_key.h>
 
 /*
  * Override these in your platform code to really fetch device-unique
@@ -26,4 +29,25 @@ __weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 		return -1;
 
 	return 0;
+}
+
+/*
+ * Override this API on your platform to provide TA encryption key as
+ * per your security requirements. There can be two options for this key:
+ *
+ * 1) Unique per device encryption key.
+ * 2) Class wide encryption key.
+ *
+ * The default implementation chooses option (1).
+ */
+__weak TEE_Result tee_otp_get_ta_enc_key(uint32_t key_type __maybe_unused,
+					 uint8_t *buffer, size_t len)
+{
+	assert(key_type == SHDR_ENC_KEY_DEV_SPECIFIC);
+
+	if (huk_subkey_derive(HUK_SUBKEY_TA_ENC, ta_pub_key_modulus,
+			      ta_pub_key_modulus_size, buffer, len))
+		return TEE_ERROR_SECURITY;
+
+	return TEE_SUCCESS;
 }

--- a/core/include/kernel/huk_subkey.h
+++ b/core/include/kernel/huk_subkey.h
@@ -16,6 +16,7 @@
  * @HUK_SUBKEY_SSK:	  Secure Storage key
  * @HUK_SUBKEY_DIE_ID:	  Representing the die ID
  * @HUK_SUBKEY_UNIQUE_TA: TA unique key
+ * @HUK_SUBKEY_TA_ENC:    TA encryption key
  *
  * Add more identifiers as needed, be careful to not change the already
  * assigned numbers as that will affect the derived subkey.
@@ -29,6 +30,7 @@ enum huk_subkey_usage {
 	HUK_SUBKEY_SSK = 1,
 	HUK_SUBKEY_DIE_ID = 2,
 	HUK_SUBKEY_UNIQUE_TA = 3,
+	HUK_SUBKEY_TA_ENC = 4,
 };
 
 #define HUK_SUBKEY_MAX_LEN	TEE_SHA256_HASH_SIZE

--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -17,5 +17,7 @@ struct tee_hw_unique_key {
 
 TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);
 int tee_otp_get_die_id(uint8_t *buffer, size_t len);
+TEE_Result tee_otp_get_ta_enc_key(uint32_t key_type, uint8_t *buffer,
+				  size_t len);
 
 #endif /* TEE_COMMON_OTP_H */

--- a/core/include/tee/tee_ta_enc_manager.h
+++ b/core/include/tee/tee_ta_enc_manager.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef TEE_TA_ENC_MANAGER_H
+#define TEE_TA_ENC_MANAGER_H
+
+#include <signed_hdr.h>
+#include <tee_api_types.h>
+#include <utee_defines.h>
+
+#define TEE_TA_ENC_KEY_SIZE		TEE_SHA256_HASH_SIZE
+
+TEE_Result tee_ta_decrypt_init(void **enc_ctx, struct shdr_encrypted_ta *ehdr,
+			       size_t len);
+TEE_Result tee_ta_decrypt_update(void *enc_ctx, uint8_t *dst, uint8_t *src,
+				 size_t len);
+TEE_Result tee_ta_decrypt_final(void *enc_ctx, struct shdr_encrypted_ta *ehdr,
+				uint8_t *dst, uint8_t *src, size_t len);
+
+#endif

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -45,3 +45,4 @@ srcs-$(CFG_GP_SOCKETS) += socket.c
 endif #CFG_WITH_USER_TA,y
 
 srcs-y += uuid.c
+srcs-y += tee_ta_enc_manager.c

--- a/core/tee/tee_ta_enc_manager.c
+++ b/core/tee/tee_ta_enc_manager.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#include <crypto/crypto.h>
+#include <kernel/tee_common_otp.h>
+#include <string_ext.h>
+#include <tee/tee_ta_enc_manager.h>
+#include <trace.h>
+
+TEE_Result tee_ta_decrypt_init(void **enc_ctx, struct shdr_encrypted_ta *ehdr,
+			       size_t len)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint8_t key[TEE_TA_ENC_KEY_SIZE] = {0};
+
+	res = crypto_authenc_alloc_ctx(enc_ctx, ehdr->enc_algo);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = tee_otp_get_ta_enc_key(ehdr->flags & SHDR_ENC_KEY_TYPE_MASK,
+				     key, sizeof(key));
+	if (res != TEE_SUCCESS)
+		goto out_init;
+
+	res = crypto_authenc_init(*enc_ctx, TEE_MODE_DECRYPT, key, sizeof(key),
+				  SHDR_ENC_GET_IV(ehdr), ehdr->iv_size,
+				  ehdr->tag_size, 0, len);
+
+out_init:
+	if (res != TEE_SUCCESS)
+		crypto_authenc_free_ctx(*enc_ctx);
+
+	memzero_explicit(key, sizeof(key));
+	return res;
+}
+
+TEE_Result tee_ta_decrypt_update(void *enc_ctx, uint8_t *dst, uint8_t *src,
+				 size_t len)
+{
+	TEE_Result res = TEE_SUCCESS;
+	size_t dlen = len;
+
+	res = crypto_authenc_update_payload(enc_ctx, TEE_MODE_DECRYPT, src, len,
+					    dst, &dlen);
+	if (res != TEE_SUCCESS)
+		crypto_authenc_free_ctx(enc_ctx);
+
+	return res;
+}
+
+TEE_Result tee_ta_decrypt_final(void *enc_ctx, struct shdr_encrypted_ta *ehdr,
+				uint8_t *dst, uint8_t *src, size_t len)
+{
+	TEE_Result res = TEE_SUCCESS;
+	size_t dlen = len;
+
+	res = crypto_authenc_dec_final(enc_ctx, src, len, dst, &dlen,
+				       SHDR_ENC_GET_TAG(ehdr), ehdr->tag_size);
+
+	crypto_authenc_free_ctx(enc_ctx);
+
+	return res;
+}

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -43,7 +43,7 @@ libdirs 	:= $(out-dir)/$(base-prefix)$(libdir) $(libdirs)
 libnames	:= $(libname) $(libnames)
 libdeps		:= $(lib-libfile) $(libdeps)
 
-SIGN = scripts/sign.py
+SIGN = scripts/sign_encrypt.py
 TA_SIGN_KEY ?= keys/default_ta.pem
 
 define process-lib

--- a/scripts/sign_encrypt.py
+++ b/scripts/sign_encrypt.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-#
-# Copyright (c) 2015, 2017, Linaro Limited
-#
 # SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2015, 2017, 2019, Linaro Limited
+#
 
 import sys
 
@@ -19,7 +19,7 @@ def int_parse(str):
 def get_args(logger):
     from argparse import ArgumentParser, RawDescriptionHelpFormatter
     import textwrap
-    command_base = ['sign', 'digest', 'stitch']
+    command_base = ['sign-enc', 'digest', 'stitch']
     command_aliases_digest = ['generate-digest']
     command_aliases_stitch = ['stitch-ta']
     command_aliases = command_aliases_digest + command_aliases_stitch
@@ -29,26 +29,31 @@ def get_args(logger):
     sat = '[' + ', '.join(command_aliases_stitch) + ']'
 
     parser = ArgumentParser(
-        description='Sign a Tusted Application for OP-TEE.',
+        description='Sign and encrypt (optional) a Tusted Application for' +
+        ' OP-TEE.',
         usage='\n   %(prog)s command [ arguments ]\n\n'
 
         '   command:\n' +
-        '     sign        Generate signed loadable TA image file.\n' +
-        '                 Takes arguments --uuid, --ta-version, --in, --out' +
-        ' and --key.\n' +
+        '     sign-enc    Generate signed and optionally encrypted loadable' +
+        ' TA image file.\n' +
+        '                 Takes arguments --uuid, --ta-version, --in, --out,' +
+        ' --key\n' +
+        '                 and --enc-key (optional).\n' +
         '     digest      Generate loadable TA binary image digest' +
         ' for offline\n' +
-        '                 signing. Takes arguments  --uuid, --ta-version,' +
-        ' --in, --key and --dig.\n' +
-        '     stitch      Generate loadable signed TA binary image' +
-        ' file from\n' +
+        '                 signing. Takes arguments --uuid, --ta-version,' +
+        ' --in, --key,\n'
+        '                 --enc-key (optional) and --dig.\n' +
+        '     stitch      Generate loadable signed and encrypted TA binary' +
+        ' image file from\n' +
         '                 TA raw image and its signature. Takes' +
         ' arguments\n' +
-        '                 --uuid, --in, --key, --out, and --sig.\n\n' +
+        '                 --uuid, --in, --key, --enc-key (optional), --out,' +
+        ' and --sig.\n\n' +
         '   %(prog)s --help  show available commands and arguments\n\n',
         formatter_class=RawDescriptionHelpFormatter,
         epilog=textwrap.dedent('''\
-            If no command is given, the script will default to "sign".
+            If no command is given, the script will default to "sign-enc".
 
             command aliases:
               The command \'digest\' can be aliased by ''' + dat + '''
@@ -63,12 +68,14 @@ def get_args(logger):
 
     parser.add_argument(
         'command', choices=command_choices, nargs='?',
-        default='sign',
+        default='sign-enc',
         help='Command, one of [' + ', '.join(command_base) + ']')
     parser.add_argument('--uuid', required=True,
                         type=uuid_parse, help='String UUID of the TA')
     parser.add_argument('--key', required=True,
-                        help='Name of key file (PEM format)')
+                        help='Name of signing key file (PEM format)')
+    parser.add_argument('--enc-key', required=False,
+                        help='Encryption key string')
     parser.add_argument(
         '--ta-version', required=False, type=int_parse, default=0,
         help='TA version stored as a 32-bit unsigned integer and used for\n' +
@@ -156,7 +163,10 @@ def main():
     hdr_version = args.ta_version  # struct shdr_bootstrap_ta::ta_version
 
     magic = 0x4f545348   # SHDR_MAGIC
-    img_type = 1         # SHDR_BOOTSTRAP_TA
+    if args.enc_key:
+        img_type = 2         # SHDR_ENCRYPTED_TA
+    else:
+        img_type = 1         # SHDR_BOOTSTRAP_TA
     algo = 0x70004830    # TEE_ALG_RSASSA_PKCS1_V1_5_SHA256
 
     shdr = struct.pack('<IIIIHH',
@@ -164,9 +174,23 @@ def main():
     shdr_uuid = args.uuid.bytes
     shdr_version = struct.pack('<I', hdr_version)
 
+    if args.enc_key:
+        from Cryptodome.Cipher import AES
+        cipher = AES.new(bytearray.fromhex(args.enc_key), AES.MODE_GCM)
+        ciphertext, tag = cipher.encrypt_and_digest(img)
+
+        enc_algo = 0x40000810  # TEE_ALG_AES_GCM
+        flags = 0              # SHDR_ENC_KEY_DEV_SPECIFIC
+        ehdr = struct.pack('<IIHH',
+                           enc_algo, flags, len(cipher.nonce), len(tag))
+
     h.update(shdr)
     h.update(shdr_uuid)
     h.update(shdr_version)
+    if args.enc_key:
+        h.update(ehdr)
+        h.update(cipher.nonce)
+        h.update(tag)
     h.update(img)
     img_digest = h.digest()
 
@@ -177,9 +201,15 @@ def main():
             f.write(sig)
             f.write(shdr_uuid)
             f.write(shdr_version)
-            f.write(img)
+            if args.enc_key:
+                f.write(ehdr)
+                f.write(cipher.nonce)
+                f.write(tag)
+                f.write(ciphertext)
+            else:
+                f.write(img)
 
-    def sign_ta():
+    def sign_encrypt_ta():
         if not key.has_private():
             logger.error('Provided key cannot be used for signing, ' +
                          'please use offline-signing mode.')
@@ -222,12 +252,12 @@ def main():
 
     # dispatch command
     {
-        'sign': sign_ta,
+        'sign-enc': sign_encrypt_ta,
         'digest': generate_digest,
         'generate-digest': generate_digest,
         'stitch': stitch_ta,
         'stitch-ta': stitch_ta
-    }.get(args.command, 'sign_ta')()
+    }.get(args.command, 'sign_encrypt_ta')()
 
 
 if __name__ == "__main__":

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -3,7 +3,7 @@ $(error SHLIBUUID not set)
 endif
 link-out-dir = $(out-dir)
 
-SIGN ?= $(TA_DEV_KIT_DIR)/scripts/sign.py
+SIGN ?= $(TA_DEV_KIT_DIR)/scripts/sign_encrypt.py
 TA_SIGN_KEY ?= $(TA_DEV_KIT_DIR)/keys/default_ta.pem
 
 all: $(link-out-dir)/$(shlibname).so $(link-out-dir)/$(shlibname).dmp \

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -192,7 +192,8 @@ $(foreach f, $(ta-keys), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/keys)))
 
 # Copy the scripts
-ta-scripts = scripts/sign.py scripts/symbolize.py scripts/llvm-objcopy-wrapper
+ta-scripts = scripts/sign_encrypt.py scripts/symbolize.py \
+	scripts/llvm-objcopy-wrapper
 $(foreach f, $(ta-scripts), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/scripts)))
 


### PR DESCRIPTION
Add framework to support loading of encrypted TAs from REE-FS using symmetric authenticated encryption scheme supported by OP-TEE.

This framework only support buffered REE-FS TAs as encrypted TA needs to be read at once and decrypted into temporary secure memory buffer.

The default encryption key is derived from hardware unique key which can be overridden via platform specific encryption key.

Also it adds support in TA dev kit to encrypt as well as sign TA in case corresponding TA build time configuration option `CFG_ENCRYPT_TA=y` is enabled.

Looking forward to your feedback/comments.

-Sumit