### PR TITLE
[RFC] Add option to restrict loading of shared libraries by TAs

### DIFF
--- a/core/include/dl_policy.h
+++ b/core/include/dl_policy.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019, Huawei Technologies Co., Ltd
+ */
+#ifndef DL_POLICY_H
+#define DL_POLICY_H
+
+#include <tee_api_types.h>
+
+struct dl_policy {
+	const TEE_UUID lib_uuid;
+	const TEE_UUID *allowed_tas;
+};
+
+#define ANY_UUID { 0xffffffff, 0xffff, 0xffff, { 0xff, 0xff, 0xff, 0xff, \
+						 0xff, 0xff, 0xff, 0xff } }
+
+extern struct dl_policy dl_policies[];
+
+#endif /* DL_POLICY_H */

--- a/core/pta/dl_policy.ini
+++ b/core/pta/dl_policy.ini
@@ -1,0 +1,41 @@
+; This file defines the dynamic link policies for user TAs, in other words:
+; which libraries can be loaded at runtime by which user space Trusted
+; Applications.
+;
+; - If CFG_RESTRICT_TA_DL = y, this file is used. By default, the TEE core will
+; deny all access requests unless explicitly allowed in this file.
+; Each shared library that needs to be opened by a TA needs to be listed below.
+;   - The section name is the UUID of the library.
+;   - The "allowed" key is a coma-separated list of TA UUIDs that are allowed
+;     to open that specific library.
+;   - An empty "allowed" list prevents the library from being loaded by any TA.
+;   - '*' is a wildcard for any TA or library.
+; - IF CFG_RESTRICT_TA_DL != y, this file is not used and all access requests
+; are granted.
+
+#ifdef CFG_ULIBS_SHARED
+[71855bba-6055-4293-a63f-b0963a737360]  ; libutils
+allowed = *
+
+[39b498d9-1e1f-4ae0-a9e1-6d1caf8ec731]  ; libmpa
+allowed = *
+
+[87bb6ae8-4b1d-49fe-9986-2b966132c309]  ; libmbedtls
+allowed = *
+
+[527f1a47-b92c-4a74-95bd-72f19f4a6f74]  ; libutee
+allowed = *
+
+[be807bbd-81e1-4dc4-bd99-3d363f240ece]  ; libdl
+allowed = *
+#endif
+
+#ifdef CFG_XTEST
+; Libraries used by xtest (optee_test)
+
+[ffd2bded-ab7d-4988-95ee-e4962fff7154]  ; libos_test
+allowed = 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b  ; os_test TA
+
+[b3091a65-9751-4784-abf7-0298a7cc35ba]  ; libos_test_dl
+allowed = 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b  ; os_test TA
+#endif

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -67,3 +67,9 @@ recipe-conf_str = scripts/bin_to_c.py --text --bin $(conf-mk-xz-base64) \
 			--vname conf_str
 cleanfiles += $(sub-dir-out)/conf.mk.xz.base64.c
 endif
+
+gensrcs-$(CFG_RESTRICT_TA_DL) += dl_policy
+produce-dl_policy = dl_policy.c
+depends-dl_policy = $(CFG_DL_POLICY_FILE) scripts/gen_dl_policy.py $(conf-file)
+recipe-dl_policy = $(CPP$(sm)) $(cppflags$(sm)) $(CFG_DL_POLICY_FILE) | \
+			scripts/gen_dl_policy.py -o $(sub-dir-out)/dl_policy.c

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -511,3 +511,8 @@ CFG_CORE_HUK_SUBKEY_COMPAT ?= y
 # Compress and encode conf.mk into the TEE core, and show the encoded string on
 # boot (with severity TRACE_INFO).
 CFG_SHOW_CONF_ON_BOOT ?= n
+
+# Restricts which dynamic libraries may be loaded by user TAs.
+CFG_RESTRICT_TA_DL ?= y
+CFG_DL_POLICY_FILE ?= core/pta/dl_policy.ini
+CFG_XTEST ?= y

--- a/scripts/gen_dl_policy.py
+++ b/scripts/gen_dl_policy.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2019, Huawei Technologies Co., Ltd
+
+import argparse
+import configparser
+import os
+import sys
+import uuid
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        description='Generates a C source file from a text file defining the '
+                    'dynamic library loading policy for user TAs')
+    parser.add_argument('input', nargs='?', help='Input text file')
+    parser.add_argument('-o', '--output', help='Output C file')
+    return parser.parse_args()
+
+
+def uuid_to_c(uuid_s):
+    if uuid_s == '*':
+        return 'ANY_UUID'
+    u = uuid.UUID(uuid_s)
+    s = (f'{{ 0x{u.time_low:08x}, 0x{u.time_mid:04x}, '
+         f'0x{u.time_hi_version:04x}, {{ ')
+    csn = f'{u.clock_seq_hi_variant:02x}{u.clock_seq_low:02x}{u.node:012x}'
+    s += ', '.join('0x' + csn[i:i + 2] for i in range(0, len(csn), 2))
+    s += ' } }'
+    return s
+
+
+def main():
+    args = get_args()
+
+    inf = sys.stdin
+    if args.input:
+        inf = open(args.input, 'r')
+    else:
+        args.input = '(stdin)'
+
+    config = configparser.ConfigParser(inline_comment_prefixes=';')
+    config.read_file(inf)
+
+    policies = {}
+    num = 0
+    for section in config.sections():
+        allowed_c = []
+        allowed = config[section]['allowed']
+        for a in allowed.split(','):
+            a = a.strip()
+            if a == '':
+                continue
+            allowed_c.append(uuid_to_c(a))
+        allowed_c.append('{ }')
+        if allowed not in policies:
+            num = num + 1
+            policies[allowed] = {'C': allowed_c, 'varname': f'policy{num}'}
+
+    outf = sys.stdout
+    if args.output:
+        outf = open(args.output, 'w')
+    outf.write('/* Generated from ' + args.input + ' by '
+               + os.path.basename(__file__) + ' */\n')
+    outf.write('#include <dl_policy.h>\n#include <tee_api_types.h>\n\n')
+
+    for pol in policies:
+        varname = policies[pol]["varname"]
+        outf.write(f'static const TEE_UUID {varname}[] = {{ ')
+        outf.write(', '.join(policies[pol]['C']))
+        outf.write(' };\n')
+
+    outf.write('\nstruct dl_policy dl_policies[] = {\n')
+    for section in config.sections():
+        if section == '*':
+            uuid_c = 'ANY_UUID'
+        else:
+            uuid_c = uuid_to_c(section)
+        allowed = config[section]['allowed']
+        varname = policies[allowed]['varname']
+        outf.write(f'\t{{ {uuid_c}, {varname} }},\n')
+    outf.write('\t{ }\n};\n')
+    outf.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Since commit c27907e1bc5a ("core: arm32: add support for dynamically
linked TAs") and commit d3aa2143a9aa ("core: arm64: add support for
dynamically linked TAs"), Trusted Applications may open additional
libraries at load time. Any UUID listed in a DT_NEEDED entry of the
dynamic table will caused the TEE core to load the corresponding ELF
file into the TA's address space.

With the introduction of the user space loader (ldelf) and especially
commit 0b414d3f9128 ("core: pta_system: ta binary handling"), a TA can
invoke the 'system' PTA to open a library at any time.
Commit ebef121c1f5c ("core, ldelf: add support for runtime loading of
shared libraries") makes it even easier by providing the dlopen() API.

This situation may raise confidentiality and security concerns. To
address them, this commit introduces a new configuration flag:
CFG_RESTRICT_TA_DL (default y). When enabled, a static table is
compiled into the TEE core which defines load permissions; requests
are denied by default. The source file for the table is
$(CFG_DL_POLICY_FILE) (default: core/pta/dl_policy.ini).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
