### PR TITLE
core: imx: disable CAAM for all i.MX6/7 flavors

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -386,7 +386,7 @@ CFG_MMAP_REGIONS ?= 24
 
 # Almost all platforms include CAAM HW Modules, except the
 # ones forced to be disabled
-CFG_NXP_CAAM ?= y
+CFG_NXP_CAAM ?= n
 
 ifeq ($(CFG_NXP_CAAM),y)
 # As NXP CAAM Driver is enabled, disable the small local CAAM driver


### PR DESCRIPTION
Currently, using an upstream kernel with i.MX6/7 devices and OP-TEE
results in OP-TEE stalling during the loading of trusted applications.
OP-TEE tries to use the CAAM for verification, unfortunately the
upstream kernel will turn off the clocks for the CAAM, resulting in the
bus transaction stalling on the bus and the processors requiring a hard
reset. Disable the NXP CAAM driver until the clocks issues are resolved.

This is the same problem I already reported in the initial CAAM pull requests.
One could argue that this is about platform configuration, but my expectation
is that upstream OP-TEE works with an upstream kernel without required
additional configuration. 