### PR TITLE
virt: Initialize the TEE runtime on guest creation

### DIFF
--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -207,9 +207,6 @@ uint32_t __weak __thread_std_smc_entry(uint32_t a0, uint32_t a1, uint32_t a2,
 {
 	uint32_t rv = 0;
 
-#ifdef CFG_VIRTUALIZATION
-	virt_on_stdcall();
-#endif
 	rv = std_smc_entry(a0, a1, a2, a3);
 
 	if (rv == OPTEE_SMC_RETURN_OK) {

--- a/core/include/kernel/virtualization.h
+++ b/core/include/kernel/virtualization.h
@@ -57,14 +57,6 @@ bool virt_set_guest(uint16_t guest_id);
  */
 void virt_unset_guest(void);
 
-/**
- * virt_on_stdcall() - std call hook
- *
- * This hook is called on every std call, but really is needed
- * only once: to initialize TEE runtime for current guest VM
- */
-void virt_on_stdcall(void);
-
 /*
  * Next function are needed because virtualization subsystem manages
  * memory in own way. There is no one static memory map, instead


### PR DESCRIPTION
Under the current scheme, a new guest's environment is initialized in two steps:
1. virt_guest_created(): Guest partition and threads
2. virt_on_std_call(): TEE runtime and services

When a service needs to be initialized by a single guest and be available to the rest of the guests, the above scheme suffers from a race condition, as it is not known which guest the first std call will be received from.

This patch eliminates this requirement by performing the full initialization of a new guest during virt_on_guest_created().

CC: @lorc 