### PR TITLE
ftrace: arm32: make sure assembler code is compiled in arm mode

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -96,6 +96,8 @@ arm32-platform-cppflags += -DARM32=1 -D__ILP32__=1
 platform-cflags-generic ?= -ffunction-sections -fdata-sections -pipe
 platform-aflags-generic ?= -pipe
 
+arm32-platform-aflags += -marm
+
 arm32-platform-cflags-no-hard-float ?= -mfloat-abi=soft
 arm32-platform-cflags-hard-float ?= -mfloat-abi=hard -funsafe-math-optimizations
 arm32-platform-cflags-generic-thumb ?= -mthumb \


### PR DESCRIPTION
When CFG_FTRACE_SUPPORT=y, thumb mode should not be used in TA code,
because the ftrace code assumes arm instructions. Therefore we have to
pass the -marm flag to the compiler and assembler. This is correctrly
done for the C compiler but not for the assembler -- fix that.

The same fix applies for assembler files in the TEE core when
CFG_SYSCALL_FTRACE=y.

Fixes a crash in the setjmp()/longjmp() test of xtest 1006 when GCC 6.2
is used to build the user space libutils.a (more precisely:
lib/libutils/isoc/arch/arm/setjmp_a32.S):

 E/TC:? 0 User TA prefetch-abort at address 0x0 (translation fault)
 E/TC:? 0  fsr 0x00000005  ttbr0 0x0e19206a  ttbr1 0x0e18806a  cidr 0x2
 E/TC:? 0  cpu #1          cpsr 0x60000110
 E/TC:? 0  r0 0x00000000      r4 0x00115780    r8 0x00000000   r12 0x00115658
 E/TC:? 0  r1 0x00000001      r5 0x0011fb8c    r9 0x00000000    sp 0x001156a0
 E/TC:? 0  r2 0x00000000      r6 0x60000110   r10 0x00000000    lr 0x00000000
 E/TC:? 0  r3 0x00000000      r7 0x00000000   r11 0x001156bc    pc 0x00000000
 E/LD:  Status of TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b
 E/LD:   arch: arm
 E/LD:  region  0: va 0x00102000 pa 0x0e300000 size 0x002000 flags rw-s (ldelf)
 E/LD:  region  1: va 0x00104000 pa 0x0e302000 size 0x00a000 flags r-xs (ldelf)
 E/LD:  region  2: va 0x0010e000 pa 0x0e30c000 size 0x001000 flags rw-s (ldelf)
 E/LD:  region  3: va 0x0010f000 pa 0x0e30d000 size 0x003000 flags rw-s (ldelf)
 E/LD:  region  4: va 0x00112000 pa 0x0e310000 size 0x001000 flags r--s
 E/LD:  region  5: va 0x00113000 pa 0x0e444000 size 0x003000 flags rw-s (stack)
 E/LD:  region  6: va 0x0011b000 pa 0x00001000 size 0x024000 flags r-xs [0]
 E/LD:  region  7: va 0x0013f000 pa 0x00025000 size 0x10f000 flags rw-s [0]
 E/LD:  region  8: va 0x00266000 pa 0x00000000 size 0x003000 flags r-xs [1]
 E/LD:  region  9: va 0x00269000 pa 0x00002000 size 0x002000 flags rw-s [1]
 E/LD:  region 10: va 0x00300000 pa 0x40a67570 size 0x001000 flags rw-- (param)
 E/LD:   [0] 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b @ 0x0011b000
 E/LD:   [1] ffd2bded-ab7d-4988-95ee-e4962fff7154 @ 0x00266000
 E/LD:  Call stack:
 E/LD:   0x00000000

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
