### PR TITLE
plat-imx: add UART6 & 7 for i.MX6UL/L

### DIFF
--- a/core/arch/arm/plat-imx/registers/imx6.h
+++ b/core/arch/arm/plat-imx/registers/imx6.h
@@ -78,6 +78,8 @@
 
 #if defined(CFG_MX6UL) || defined(CFG_MX6ULL)
 #define GICC_OFFSET			0x2000
+#define UART6_BASE			0x021FC000
+#define UART7_BASE			0x02018000
 /* No CAAM on i.MX6ULL */
 #define CAAM_BASE			0x02140000
 #else


### PR DESCRIPTION
The i.MX6UL/L variants contains additional UARTs which are not present
on the Cortex A9 variants. Add them to register file so they can be used
for new board definitions.

cc @clementfaure 
