### PR TITLE
core: arm32: disable interrupt in thread_excp_vect_workaround

### DIFF
--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -560,13 +560,14 @@ UNWIND(	.cantunwind)
 		add	sp, sp, #1	/* 3:011 Data abort		*/
 		add	sp, sp, #1	/* 2:010 Reserved		*/
 		add	sp, sp, #1	/* 1:001 IRQ			*/
-		write_tpidrprw r0	/* 0:000 FIQ			*/
+		cpsid   aif		/* 0:000 FIQ			*/
 	.endm
 
         .align	5
 	.global thread_excp_vect_workaround_a15
 thread_excp_vect_workaround_a15:
 	vector_prologue_spectre
+	write_tpidrprw r0
 	mrs	r0, spsr
 	cmp_spsr_user_mode r0
 	bne	1f
@@ -589,6 +590,7 @@ thread_excp_vect_workaround_a15:
 	.global thread_excp_vect_workaround
 thread_excp_vect_workaround:
 	vector_prologue_spectre
+	write_tpidrprw r0
 	mrs	r0, spsr
 	cmp_spsr_user_mode r0
 	bne	1f


### PR DESCRIPTION
thread_excp_vect_workaround isn't reentrant because it use the tpidr
as a temporary register to save value of r0. That means if a fiq
happend when optee is processing a syscall, the syscall argument r0
will be changed to unexpected value.

Move `write_tpidrprw r0` out of `vector_prologue_spectre` and add
`cpsid aif` before it to fix this issue.

Signed-off-by: Mark-PK Tsai <mark-pk.tsai@mediatek.com>

#3371 