### PR TITLE
core: add invoke_tests.pta to enumerated TAs

### DIFF
--- a/core/pta/tests/invoke.c
+++ b/core/pta/tests/invoke.c
@@ -418,7 +418,7 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 
 pseudo_ta_register(.uuid = PTA_INVOKE_TESTS_UUID, .name = TA_NAME,
 		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_SECURE_DATA_PATH |
-			    TA_FLAG_CONCURRENT,
+			    TA_FLAG_CONCURRENT | TA_FLAG_DEVICE_ENUM,
 		   .create_entry_point = create_ta,
 		   .destroy_entry_point = destroy_ta,
 		   .open_session_entry_point = open_session,


### PR DESCRIPTION
For testing purposes Add invoke_tests.pta to enumerated TAs. This gives
optee_enumerate_devices() in the OP-TEE kernel driver something to
iterate over in case there's no other TAs to enumerate.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
