### PR TITLE
 gprof: fix TEE core crash by allocating sample buffer dynamically

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -348,6 +348,11 @@ CFG_CORE_NEX_HEAP_SIZE ?= 16384
 # instrumented with GCC's -pg flag and will output profiling information
 # in gmon.out format to /tmp/gmon-<ta_uuid>.out (path is defined in
 # tee-supplicant)
+# Note: this does not work well with shared libraries at the moment for a
+# couple of reasons:
+# 1. The profiling code assumes a unique executable section in the TA VA space.
+# 2. The code used to detect at run time if the TA is intrumented assumes that
+# the TA is linked statically.
 CFG_TA_GPROF_SUPPORT ?= n
 
 # TA function tracing.
@@ -393,15 +398,6 @@ endif
 CFG_ULIBS_SHARED ?= n
 
 ifeq (yy,$(CFG_TA_GPROF_SUPPORT)$(CFG_ULIBS_SHARED))
-# FIXME:
-# TA profiling with gprof does not work well with shared libraries (not limited
-# to CFG_ULIBS_SHARED=y actually), because the total .text size is not known at
-# link time. The symptom is an error trace when the TA starts (and no gprof
-# output is produced):
-#  E/TA: __utee_gprof_init:159 gprof: could not allocate profiling buffer
-# The allocation of the profiling buffer should probably be done at runtime
-# via a new syscall/PTA call instead of having it pre-allocated in .bss by the
-# linker.
 $(error CFG_TA_GPROF_SUPPORT and CFG_ULIBS_SHARED are currently incompatible)
 endif
 

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -2,17 +2,11 @@
 OUTPUT_FORMAT("elf32-littlearm")
 OUTPUT_ARCH(arm)
 #define MCOUNT_SYM __gnu_mcount_nc
-/*
- * This magic value corresponds to the size requested by
- * libutee/arch/arm/gprof/gprof.c
- */
-#define GPROF_BUF_MULT(x) ((x) * 136) / 100
 #endif
 #ifdef ARM64
 OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 #define MCOUNT_SYM _mcount
-#define GPROF_BUF_MULT(x) ((x) * 177) / 100
 #endif
 
 #ifndef CFG_FTRACE_BUF_SIZE
@@ -77,19 +71,6 @@ SECTIONS {
 	.data : { *(.data .data.* .gnu.linkonce.d.*) }
 	.bss : {
 		*(.bss .bss.* .gnu.linkonce.b.* COMMON)
-
-		/*
-		 * TA profiling with gprof
-		 * Reserve some space for the profiling buffer, only if the
-		 * TA is instrumented (i.e., some files were built with -pg).
-		 * This also provides a way to detect at runtime if the TA is
-		 * instrumented or not.
-		 */
-		. = ALIGN(8);
-		__gprof_buf_start = .;
-		. += DEFINED(MCOUNT_SYM) ?
-			GPROF_BUF_MULT(__text_end - __text_start) : 0;
-		__gprof_buf_end = .;
 
 		/*
 		 * TA tracing using ftrace


### PR DESCRIPTION
The gprof sample buffer is in user space memory but is also accessed by
the TEE core. Currently, space is reserved by the TA linker script. The
address and size of the buffer is passed to the TEE core via a call to
the gprof PTA. After this call, the TEE core accesses the buffer
periodically, such as when the TA is interrupted by a timer interrupt.

Commit ef305e5 ("libutee: allocate temp secmem for invoke")
modified the way that private TA memory is mapped in TA to TA
invocations, so that memory is mapped only for the duration of the
call. After this point, the memory is unmapped so the gprof sample
buffer becomes inaccessible, resulting in a crash:

 E/TC:0 0 Core data-abort at address 0x121356 (translation fault)
 E/TC:0 0  fsr 0x00000007  ttbr0 0x0e19206a  ttbr1 0x0e18806a  cidr 0x2
 E/TC:0 0  cpu #0          cpsr 0x800001f2
 E/TC:0 0  r0 0x00000000      r4 0x00000000    r8 0x00000000   r12 0x0017bb4b
 E/TC:0 0  r1 0x000021ab      r5 0x00000000    r9 0x00000000    sp 0x0e1928f0
 E/TC:0 0  r2 0x0011d000      r6 0x00000000   r10 0x00000000    lr 0x0e112763
 E/TC:0 0  r3 0x00121356      r7 0x0e1928f0   r11 0x00000000    pc 0x0e12958e
 E/TC:0 0 Core data-abort at address 0x121356 .debug_info+1184598 (translation fault)
 E/TC:0 0 Call stack:
 E/TC:0 0  0x0e12958e tee_ta_gprof_sample_pc at optee_os/core/kernel/tee_ta_manager.c:897

The solution is to allocate and map the sample buffer explicitly in
user space when profiling is initialized, and at the same time get rid
of the reserved area in the TA linker script. The TEE core also needs
to check that the sample buffer is valid before writing to it,
otherwise a malicious TA could crash the core by unmapping that memory.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
