### PR TITLE
Fix Broadcom SOTP driver

### DIFF
--- a/core/arch/arm/plat-bcm/platform_config.h
+++ b/core/arch/arm/plat-bcm/platform_config.h
@@ -34,6 +34,9 @@
 
 #define SOTP_BASE		0x68b50000
 
+/* NO ECC bits are present from ROW_0 to ROW_20, i.e Section 0 to Section 3 */
+#define SOTP_NO_ECC_ROWS	20
+
 /* Secure Watch Dog */
 #define SEC_WDT_BASE		0x68B30000
 #define SEC_WDT_END		(SEC_WDT_BASE + 0x1000)

--- a/core/drivers/bcm_sotp.c
+++ b/core/drivers/bcm_sotp.c
@@ -70,6 +70,10 @@ TEE_Result bcm_iproc_sotp_mem_read(uint32_t row_addr, uint32_t sotp_add_ecc,
 	io_setbits32((bcm_sotp_base + SOTP_PROG_CONTROL),
 		     SOTP_PROG_CONTROL__OTP_CPU_MODE_EN);
 
+	/* ROWS does not support ECC */
+	if (row_addr <= SOTP_NO_ECC_ROWS)
+		sotp_add_ecc = 0;
+
 	if (sotp_add_ecc == 1) {
 		io_clrbits32((bcm_sotp_base + SOTP_PROG_CONTROL),
 			     SOTP_PROG_CONTROL__OTP_DISABLE_ECC);
@@ -104,8 +108,9 @@ TEE_Result bcm_iproc_sotp_mem_read(uint32_t row_addr, uint32_t sotp_add_ecc,
 	read_data |= io_read32(bcm_sotp_base + SOTP_RDDATA_0);
 
 	reg_val = io_read32(bcm_sotp_base + SOTP_STATUS_1);
-	/* no ECC check till row 15 */
-	if ((row_addr > 15) && (reg_val & SOTP_STATUS_1__ECC_DET)) {
+	/* No ECC check till SOTP_NO_ECC_ROWS */
+	if (row_addr > SOTP_NO_ECC_ROWS &&
+	    reg_val & SOTP_STATUS_1__ECC_DET) {
 		EMSG("SOTP ECC ERROR Detected ROW %d\n", row_addr);
 		read_data = SOTP_ECC_ERR_DETECT;
 	}


### PR DESCRIPTION
- Hardware does not support ECC bits for SOTP section_0 to
  section_3, i.e ROWS_0 to ROWS_20.
- Remove magic number and use platform provided
  SOTP_NO_ECC_ROWS macro.

Signed-off-by: Bharat Kumar Reddy Gooty <bharat.gooty@broadcom.com>
Signed-off-by: Raveendra Padasalagi <raveendra.padasalagi@broadcom.com>
Signed-off-by: Sheetal Tigadoli <sheetal.tigadoli@broadcom.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
