### PR TITLE
core: reference count struct mobj

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -653,9 +653,8 @@ static TEE_Result alloc_and_map_ldelf_fobj(struct user_ta_ctx *utc, size_t sz,
 	if (!mobj)
 		return TEE_ERROR_OUT_OF_MEMORY;
 	res = vm_map(utc, va, num_pgs * SMALL_PAGE_SIZE,
-		     prot, VM_FLAG_LDELF | VM_FLAG_EXCLUSIVE_MOBJ, mobj, 0);
-	if (res)
-		mobj_free(mobj);
+		     prot, VM_FLAG_LDELF, mobj, 0);
+	mobj_put(mobj);
 
 	return res;
 }

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -173,6 +173,7 @@ struct mobj *mobj_phys_alloc(paddr_t pa, size_t size, uint32_t cattr,
 	moph->cattr = cattr;
 	moph->mobj.size = size;
 	moph->mobj.ops = &mobj_phys_ops;
+	refcount_set(&moph->mobj.refc, 1);
 	moph->pa = pa;
 	moph->va = (vaddr_t)va;
 
@@ -292,6 +293,7 @@ struct mobj *mobj_mm_alloc(struct mobj *mobj_parent, size_t size,
 	m->parent_mobj = mobj_parent;
 	m->mobj.size = size;
 	m->mobj.ops = &mobj_mm_ops;
+	refcount_set(&m->mobj.refc, 1);
 
 	return &m->mobj;
 }
@@ -397,6 +399,7 @@ struct mobj *mobj_shm_alloc(paddr_t pa, size_t size, uint64_t cookie)
 
 	m->mobj.size = size;
 	m->mobj.ops = &mobj_shm_ops;
+	refcount_set(&m->mobj.refc, 1);
 	m->pa = pa;
 	m->cookie = cookie;
 
@@ -487,6 +490,7 @@ struct mobj *mobj_seccpy_shm_alloc(size_t size)
 
 	m->mobj.size = size;
 	m->mobj.ops = &mobj_seccpy_shm_ops;
+	refcount_set(&m->mobj.refc, 1);
 
 	if (tee_mmu_add_rwmem(utc, &m->mobj, &va) != TEE_SUCCESS)
 		goto bad;
@@ -531,6 +535,7 @@ struct mobj *mobj_with_fobj_alloc(struct fobj *fobj, struct file *file)
 		return NULL;
 
 	m->mobj.ops = &mobj_with_fobj_ops;
+	refcount_set(&m->mobj.refc, 1);
 	m->mobj.size = fobj->num_pages * SMALL_PAGE_SIZE;
 	m->mobj.phys_granule = SMALL_PAGE_SIZE;
 	m->fobj = fobj_get(fobj);

--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -37,10 +37,11 @@ struct mobj_reg_shm {
 	uint64_t cookie;
 	tee_mm_entry_t *mm;
 	paddr_t page_offset;
-	struct refcount refcount;
 	struct refcount mapcount;
 	int num_pages;
 	bool guarded;
+	bool releasing;
+	bool release_frees;
 	paddr_t pages[];
 };
 
@@ -135,7 +136,34 @@ static void reg_shm_free_helper(struct mobj_reg_shm *mobj_reg_shm)
 
 static void mobj_reg_shm_free(struct mobj *mobj)
 {
-	mobj_reg_shm_put(mobj);
+	struct mobj_reg_shm *r = to_mobj_reg_shm(mobj);
+	uint32_t exceptions = 0;
+
+	if (r->guarded && !r->releasing) {
+		/*
+		 * Guarded registersted shared memory can't be released
+		 * by cookie, only by mobj_put(). However, unguarded
+		 * registered shared memory can also be freed by mobj_put()
+		 * unless mobj_reg_shm_release_by_cookie() is waiting for
+		 * the mobj to be released.
+		 */
+		exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+		reg_shm_free_helper(r);
+		cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+	} else {
+		/*
+		 * We've reached the point where an unguarded reg shm can
+		 * be released by cookie. Notify eventual waiters.
+		 */
+		exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+		r->release_frees = true;
+		cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+		mutex_lock(&shm_mu);
+		if (shm_release_waiters)
+			condvar_broadcast(&shm_cv);
+		mutex_unlock(&shm_mu);
+	}
 }
 
 static TEE_Result mobj_reg_shm_get_cattr(struct mobj *mobj __unused,
@@ -209,12 +237,12 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 	mobj_reg_shm->mobj.ops = &mobj_reg_shm_ops;
 	mobj_reg_shm->mobj.size = num_pages * SMALL_PAGE_SIZE;
 	mobj_reg_shm->mobj.phys_granule = SMALL_PAGE_SIZE;
+	refcount_set(&mobj_reg_shm->mobj.refc, 1);
 	mobj_reg_shm->cookie = cookie;
 	mobj_reg_shm->guarded = true;
 	mobj_reg_shm->num_pages = num_pages;
 	mobj_reg_shm->page_offset = page_offset;
 	memcpy(mobj_reg_shm->pages, pages, sizeof(*pages) * num_pages);
-	refcount_set(&mobj_reg_shm->refcount, 1);
 
 	/* Ensure loaded references match format and security constraints */
 	for (i = 0; i < num_pages; i++) {
@@ -261,85 +289,60 @@ struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie)
 	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
 	struct mobj_reg_shm *r = reg_shm_find_unlocked(cookie);
 
-	if (r) {
-		/*
-		 * Counter is supposed to be larger than 0, if it isn't
-		 * we're in trouble.
-		 */
-		if (!refcount_inc(&r->refcount))
-			panic();
-	}
-
 	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+	if (!r)
+		return NULL;
 
-	if (r)
-		return &r->mobj;
-
-	return NULL;
-}
-
-void mobj_reg_shm_put(struct mobj *mobj)
-{
-	struct mobj_reg_shm *r = to_mobj_reg_shm(mobj);
-	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
-
-	/*
-	 * A put is supposed to match a get or the initial alloc, once
-	 * we're at zero there's no more user and the original allocator is
-	 * done too.
-	 */
-	if (refcount_dec(&r->refcount))
-		reg_shm_free_helper(r);
-
-	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
-
-	/*
-	 * Note that we're reading this mutex protected variable without the
-	 * mutex acquired. This isn't a problem since an eventually missed
-	 * waiter who is waiting for this MOBJ will try again before hanging
-	 * in condvar_wait().
-	 */
-	if (shm_release_waiters) {
-		mutex_lock(&shm_mu);
-		condvar_broadcast(&shm_cv);
-		mutex_unlock(&shm_mu);
-	}
-}
-
-static TEE_Result try_release_reg_shm(uint64_t cookie)
-{
-	TEE_Result res = TEE_ERROR_BAD_PARAMETERS;
-	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
-	struct mobj_reg_shm *r = reg_shm_find_unlocked(cookie);
-
-	if (!r || r->guarded)
-		goto out;
-
-	res = TEE_ERROR_BUSY;
-	if (refcount_val(&r->refcount) == 1) {
-		reg_shm_free_helper(r);
-		res = TEE_SUCCESS;
-	}
-out:
-	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
-
-	return res;
+	return mobj_get(&r->mobj);
 }
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie)
 {
-	TEE_Result res = try_release_reg_shm(cookie);
+	uint32_t exceptions = 0;
+	struct mobj_reg_shm *r = NULL;
 
-	if (res != TEE_ERROR_BUSY)
-		return res;
+	/*
+	 * Try to find r and see can be released by this function, if so
+	 * call mobj_put(). Otherwise this function is called either by
+	 * wrong cookie and perhaps a second time, regardless return
+	 * TEE_ERROR_BAD_PARAMETERS.
+	 */
+	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+	r = reg_shm_find_unlocked(cookie);
+	if (!r || r->guarded || r->releasing)
+		r = NULL;
+	else
+		r->releasing = true;
 
+	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+	if (!r)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mobj_put(&r->mobj);
+
+	/*
+	 * We've established that this function can release the cookie.
+	 * Now we wait until mobj_reg_shm_free() is called by the last
+	 * mobj_put() needed to free this mobj. Note that the call to
+	 * mobj_put() above could very well be that call.
+	 *
+	 * Once mobj_reg_shm_free() is called it will set r->release_frees
+	 * to true and we can free the mobj here.
+	 */
 	mutex_lock(&shm_mu);
 	shm_release_waiters++;
 	assert(shm_release_waiters);
 
 	while (true) {
-		res = try_release_reg_shm(cookie);
-		if (res != TEE_ERROR_BUSY)
+		exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+		if (r->release_frees) {
+			reg_shm_free_helper(r);
+			r = NULL;
+		}
+		cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+		if (!r)
 			break;
 		condvar_wait(&shm_cv, &shm_mu);
 	}
@@ -348,7 +351,7 @@ TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie)
 	shm_release_waiters--;
 	mutex_unlock(&shm_mu);
 
-	return res;
+	return TEE_SUCCESS;
 }
 
 TEE_Result mobj_reg_shm_inc_map(struct mobj *mobj)
@@ -423,7 +426,7 @@ struct mobj *mobj_mapped_shm_alloc(paddr_t *pages, size_t num_pages,
 		return NULL;
 
 	if (mobj_reg_shm_inc_map(mobj)) {
-		mobj_free(mobj);
+		mobj_put(mobj);
 		return NULL;
 	}
 

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -258,7 +258,7 @@ TEE_Result vm_map_pad(struct user_ta_ctx *utc, vaddr_t *va, size_t len,
 	if (mobj_is_secure(mobj))
 		attr |= TEE_MATTR_SECURE;
 
-	reg->mobj = mobj;
+	reg->mobj = mobj_get(mobj);
 	reg->offset = offs;
 	reg->va = *va;
 	reg->size = ROUNDUP(len, SMALL_PAGE_SIZE);
@@ -301,6 +301,7 @@ TEE_Result vm_map_pad(struct user_ta_ctx *utc, vaddr_t *va, size_t len,
 err_rem_reg:
 	TAILQ_REMOVE(&utc->vm_info->regions, reg, link);
 err_free_reg:
+	mobj_put(reg->mobj);
 	free(reg);
 	return res;
 }
@@ -452,8 +453,7 @@ TEE_Result vm_set_prot(struct user_ta_ctx *utc, vaddr_t va, size_t len,
 static void umap_remove_region(struct vm_info *vmi, struct vm_region *reg)
 {
 	TAILQ_REMOVE(&vmi->regions, reg, link);
-	if (reg->flags & VM_FLAG_EXCLUSIVE_MOBJ)
-		mobj_free(reg->mobj);
+	mobj_put(reg->mobj);
 	free(reg);
 }
 

--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -53,7 +53,7 @@ static bool __maybe_unused param_mem_from_mobj(struct param_mem *mem,
 	if (!core_is_buffer_inside(pa, MAX(sz, 1UL), b, mobj->size))
 		return false;
 
-	mem->mobj = mobj;
+	mem->mobj = mobj_get(mobj);
 	mem->offs = pa - b;
 	mem->size = sz;
 	return true;
@@ -207,16 +207,13 @@ static void cleanup_shm_refs(const uint64_t *saved_attr,
 		case OPTEE_MSG_ATTR_TYPE_TMEM_INPUT:
 		case OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT:
 		case OPTEE_MSG_ATTR_TYPE_TMEM_INOUT:
-			if (saved_attr[n] & OPTEE_MSG_ATTR_NONCONTIG)
-				mobj_free(param->u[n].mem.mobj);
-			break;
 #ifdef CFG_CORE_DYN_SHM
 		case OPTEE_MSG_ATTR_TYPE_RMEM_INPUT:
 		case OPTEE_MSG_ATTR_TYPE_RMEM_OUTPUT:
 		case OPTEE_MSG_ATTR_TYPE_RMEM_INOUT:
-			mobj_reg_shm_put(param->u[n].mem.mobj);
-			break;
 #endif
+			mobj_put(param->u[n].mem.mobj);
+			break;
 		default:
 			break;
 		}

--- a/core/include/mm/tee_mmu_types.h
+++ b/core/include/mm/tee_mmu_types.h
@@ -53,11 +53,6 @@
  * functions.
  */
 #define VM_FLAG_READONLY		BIT(4)
-/*
- * The mobj in the region is exclusive, that is, it's the last pointer to
- * that mobj and has to be freed when the region is removed.
- */
-#define VM_FLAG_EXCLUSIVE_MOBJ		BIT(5)
 
 /*
  * Set of flags used by tee_mmu_is_vbuf_inside_ta_private() and

--- a/core/kernel/msg_param.c
+++ b/core/kernel/msg_param.c
@@ -93,7 +93,7 @@ static bool msg_param_extract_pages(paddr_t buffer, paddr_t *pages,
 			if (page & SMALL_PAGE_MASK)
 				goto out;
 
-			mobj_free(mobj);
+			mobj_put(mobj);
 			mobj = mobj_mapped_shm_alloc(&page, 1, 0, 0);
 			if (!mobj)
 				goto out;
@@ -108,7 +108,7 @@ static bool msg_param_extract_pages(paddr_t buffer, paddr_t *pages,
 
 	ret = true;
 out:
-	mobj_free(mobj);
+	mobj_put(mobj);
 	return ret;
 }
 

--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -137,10 +137,10 @@ static TEE_Result system_map_zi(struct tee_ta_session *s, uint32_t param_types,
 					  TEE_PARAM_TYPE_NONE);
 	struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
 	uint32_t prot = TEE_MATTR_URW | TEE_MATTR_PRW;
-	uint32_t vm_flags = VM_FLAG_EXCLUSIVE_MOBJ;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct mobj *mobj = NULL;
 	uint32_t pad_begin = 0;
+	uint32_t vm_flags = 0;
 	struct fobj *f = NULL;
 	uint32_t pad_end = 0;
 	size_t num_bytes = 0;
@@ -169,9 +169,8 @@ static TEE_Result system_map_zi(struct tee_ta_session *s, uint32_t param_types,
 		return TEE_ERROR_OUT_OF_MEMORY;
 	res = vm_map_pad(utc, &va, num_bytes, prot, vm_flags,
 			 mobj, 0, pad_begin, pad_end);
-	if (res)
-		mobj_free(mobj);
-	else
+	mobj_put(mobj);
+	if (!res)
 		reg_pair_from_64(va, &params[1].value.a, &params[1].value.b);
 
 	return res;
@@ -428,15 +427,16 @@ static TEE_Result system_map_ta_binary(struct system_ctx *ctx,
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto err;
 		}
-		res = vm_map_pad(utc, &va, num_pages * SMALL_PAGE_SIZE, prot,
-				 VM_FLAG_READONLY | VM_FLAG_EXCLUSIVE_MOBJ,
+		res = vm_map_pad(utc, &va, num_pages * SMALL_PAGE_SIZE,
+				 prot, VM_FLAG_READONLY,
 				 mobj, 0, pad_begin, pad_end);
+		mobj_put(mobj);
 		if (res)
 			goto err;
 	} else {
 		struct fobj *f = fobj_ta_mem_alloc(num_pages);
 		struct file *file = NULL;
-		uint32_t vm_flags = VM_FLAG_EXCLUSIVE_MOBJ;
+		uint32_t vm_flags = 0;
 
 		if (!f) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
@@ -456,6 +456,7 @@ static TEE_Result system_map_ta_binary(struct system_ctx *ctx,
 		res = vm_map_pad(utc, &va, num_pages * SMALL_PAGE_SIZE,
 				 TEE_MATTR_PRW, vm_flags, mobj, 0,
 				 pad_begin, pad_end);
+		mobj_put(mobj);
 		if (res)
 			goto err;
 		res = binh_copy_to(binh, va, offs_bytes, num_bytes);
@@ -494,7 +495,6 @@ err_unmap_va:
 	tee_mmu_set_ctx(s->ctx);
 
 err:
-	mobj_free(mobj);
 	if (file_is_locked)
 		file_unlock(binh->f);
 

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -800,7 +800,7 @@ TEE_Result syscall_open_ta_session(const TEE_UUID *dest,
 				       usr_param);
 
 function_exit:
-	mobj_free_wipe(mobj_param);
+	mobj_put_wipe(mobj_param);
 	if (res == TEE_SUCCESS)
 		tee_svc_copy_to_user(ta_sess, &s->id, sizeof(s->id));
 	tee_svc_copy_to_user(ret_orig, &ret_o, sizeof(ret_o));
@@ -891,7 +891,7 @@ TEE_Result syscall_invoke_ta_command(unsigned long ta_sess,
 
 function_exit:
 	tee_ta_put_session(called_sess);
-	mobj_free_wipe(mobj_param);
+	mobj_put_wipe(mobj_param);
 	if (ret_orig)
 		tee_svc_copy_to_user(ret_orig, &ret_o, sizeof(ret_o));
 	return res;


### PR DESCRIPTION
The mobj interface is changed to use reference counting of mobjs, the
direct mobj_free() call is replaced by mobj_put(). As expected a
mobj_get() is also added to handle multiple references to the same mobj.

This also changes already present reference counting in struct
mobj_reg_shm to use the reference counting mechanism now available in
struct mobj.

The VM_FLAG_EXCLUSIVE_MOBJ flag is removed since the referenced mobj is
put instead when a struct vm_region is removed.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
