### PR TITLE
core: fix check_mem_map() vs MEM_AREA_IDENTITY_MAP_RX

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1140,6 +1140,7 @@ static void check_mem_map(struct tee_mmap_region *map)
 		case MEM_AREA_TEE_RAM_RO:
 		case MEM_AREA_TEE_RAM_RW:
 		case MEM_AREA_NEX_RAM_RW:
+		case MEM_AREA_IDENTITY_MAP_RX:
 			if (!pbuf_is_inside(secure_only, m->pa, m->size))
 				panic("TEE_RAM can't fit in secure_only");
 			break;


### PR DESCRIPTION
This patch updates check_mem_map() to recognize MEM_AREA_IDENTITY_MAP_RX
as part of secure only memory.

This fix is only needed with CFG_CORE_ASLR= and prevents an error like:
E/TC:0 0 check_mem_map:1166 Uhandled memtype 8
E/TC:0 0 Panic at core/arch/arm/mm/core_mmu.c:1167 <check_mem_map>

Fixes: 1385854b72c9 ("core: Add core memory type MEM_AREA_IDENTITY_MAP_RX")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
