### PR TITLE
core: generic_boot: extend dts while supporting overlay generation.

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -78,6 +78,9 @@ KEEP_PAGER(sem_cpu_sync);
 struct dt_descriptor {
 	void *blob;
 	int frag_id;
+#ifdef CFG_OVERLAY_ADDR
+	int is_overlay;
+#endif
 };
 
 static struct dt_descriptor external_dt __nex_bss;
@@ -550,13 +553,17 @@ static void release_external_dt(void)
 	external_dt.blob = NULL;
 }
 
-#ifdef CFG_EXTERNAL_DTB_OVERLAY
+#if defined(CFG_EXTERNAL_DTB_OVERLAY) || defined(CFG_OVERLAY_ADDR)
 static int add_dt_overlay_fragment(struct dt_descriptor *dt, int ioffs)
 {
 	char frag[32];
 	int offs;
 	int ret;
 
+#ifdef CFG_OVERLAY_ADDR
+	if (!dt->is_overlay)
+		return ioffs;
+#endif
 	snprintf(frag, sizeof(frag), "fragment@%d", dt->frag_id);
 	offs = fdt_add_subnode(dt->blob, ioffs, frag);
 	if (offs < 0)
@@ -576,6 +583,9 @@ static int init_dt_overlay(struct dt_descriptor *dt, int __maybe_unused dt_size)
 	int fragment;
 	int ret;
 
+#ifdef CFG_OVERLAY_ADDR
+	return fdt_create_empty_tree(dt->blob, dt_size);
+#endif
 	ret = fdt_check_header(dt->blob);
 	if (!ret) {
 		fdt_for_each_subnode(fragment, dt->blob, 0)
@@ -600,7 +610,7 @@ static int init_dt_overlay(struct dt_descriptor *dt __unused,
 {
 	return 0;
 }
-#endif /* CFG_EXTERNAL_DTB_OVERLAY */
+#endif /* CFG_EXTERNAL_DTB_OVERLAY || CFG_OVERLAY_ADDR */
 
 static int add_dt_path_subnode(struct dt_descriptor *dt, const char *path,
 			       const char *subnode)
@@ -945,6 +955,11 @@ static void init_external_dt(unsigned long phys_dt)
 
 	dt->blob = fdt;
 
+#ifdef CFG_OVERLAY_ADDR
+	/* use goto to work around Travis-CI indent warning */
+	if (!dt->is_overlay)
+		goto open_into;
+#endif
 	ret = init_dt_overlay(dt, CFG_DTB_MAX_SIZE);
 	if (ret < 0) {
 		EMSG("Device Tree Overlay init fail @ 0x%" PRIxPA ": error %d",
@@ -952,6 +967,9 @@ static void init_external_dt(unsigned long phys_dt)
 		panic();
 	}
 
+#ifdef CFG_OVERLAY_ADDR
+open_into:
+#endif
 	ret = fdt_open_into(fdt, fdt, CFG_DTB_MAX_SIZE);
 	if (ret < 0) {
 		EMSG("Invalid Device Tree at 0x%" PRIxPA ": error %d",
@@ -1071,6 +1089,9 @@ void init_tee_runtime(void)
 static void init_primary_helper(unsigned long pageable_part,
 				unsigned long nsec_entry, unsigned long fdt)
 {
+#ifdef CFG_OVERLAY_ADDR
+	struct dt_descriptor *dt = &external_dt;
+#endif
 	/*
 	 * Mask asynchronous exceptions before switch to the thread vector
 	 * as the thread handler requires those to be masked while
@@ -1089,6 +1110,9 @@ static void init_primary_helper(unsigned long pageable_part,
 	thread_init_primary(generic_boot_get_handlers());
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
+#ifdef CFG_OVERLAY_ADDR
+	dt->is_overlay = 0;
+#endif
 	init_external_dt(fdt);
 	discover_nsec_memory();
 	update_external_dt();
@@ -1106,6 +1130,13 @@ static void init_primary_helper(unsigned long pageable_part,
 	init_tee_runtime();
 #endif
 	release_external_dt();
+#ifdef CFG_OVERLAY_ADDR
+	dt->is_overlay = 1;
+	init_external_dt(CFG_OVERLAY_ADDR);
+	discover_nsec_memory();
+	update_external_dt();
+	release_external_dt();
+#endif
 #ifdef CFG_VIRTUALIZATION
 	IMSG("Initializing virtualization support");
 	core_mmu_init_virtualization();

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -329,6 +329,8 @@ CFG_DT ?= n
 CFG_DTB_MAX_SIZE ?= 0x10000
 
 # Device Tree Overlay support.
+#
+# option a)
 # This define enables support for an OP-TEE provided DTB overlay.
 # One of two modes is supported in this case:
 # 1. Append OP-TEE nodes to an existing DTB overlay located at CFG_DT_ADDR or
@@ -337,6 +339,21 @@ CFG_DTB_MAX_SIZE ?= 0x10000
 # A subsequent boot stage must then merge the generated overlay DTB into a main
 # DTB using the standard fdt_overlay_apply() method.
 CFG_EXTERNAL_DTB_OVERLAY ?= n
+#
+# option b)
+# This define enables support for an OP-TEE provided DTB overlay as well as
+# extending a device tree that must be passed as an input parameter.
+# This define is not compatible with CFG_EXTERNAL_DTB_OVERLAY nor
+# CFG_DT_ADDR and a build error should trigger if either of those are enabled
+ifneq ($(strip $(CFG_OVERLAY_ADDR)),)
+ifeq ($(CFG_EXTERNAL_DTB_OVERLAY),y)
+$(error Cannot implement OVERLAY_ADDR and EXTERNAL_DTB_OVERLAY)
+else
+ifneq ($(strip $(CFG_DT_ADDR)),)
+$(error Cannot implement OVERLAY_ADDR and CFG_DT_ADDR)
+endif
+endif
+endif
 
 # Enable core self tests and related pseudo TAs
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y


### PR DESCRIPTION
The following commit will insert the OP-TEE node in a device tree
passed as an input parameter during boot while it will also generate
an OP-TEE specific overlay at a build specific address (CFG_OVERLAY_ADDR).

This functionality is useful when it is SPL that boots OP-TEE which in turns boots
U-boot; then U-Boot will contain the correct OP-TEE node plus an
overlay which U-boot can then apply to the linux dtb before starting it.

When this feature is enabled, CFG_DT_ADDR and CFG_EXTERNAL_DTB_OVERLAY
are not required.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

