### PR TITLE
core: remove unused user_ta_ctx::load_addr

### DIFF
--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -35,7 +35,6 @@ SLIST_HEAD(load_seg_head, load_seg);
  * @objects:		List of storage objects opened by this TA
  * @storage_enums:	List of storage enumerators opened by this TA
  * @stack_ptr:		Stack pointer
- * @load_addr:		ELF load addr (from TA address space)
  * @vm_info:		Virtual memory map of this context
  * @ta_time_offs:	Time reference used by the TA
  * @areas:		Memory areas registered by pager
@@ -57,7 +56,6 @@ struct user_ta_ctx {
 	struct tee_obj_head objects;
 	struct tee_storage_enum_head storage_enums;
 	vaddr_t stack_ptr;
-	vaddr_t load_addr;
 	struct vm_info *vm_info;
 	void *ta_time_offs;
 	struct tee_pager_area_head *areas;


### PR DESCRIPTION
Since commit d1911a85142d ("core: load TAs using ldelf"), the load_addr
field in struct user_ta_ctx is not used anymore. Remove it.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
