### PR TITLE
core: fix gen_tee_bin.py to handle STB_LOCAL symbols

### DIFF
--- a/scripts/gen_tee_bin.py
+++ b/scripts/gen_tee_bin.py
@@ -64,20 +64,32 @@ def get_arch_id(elffile):
 
 def get_symbol(elffile, name):
     global elffile_symbols
+    global lsyms_def
     if elffile_symbols is None:
         elffile_symbols = dict()
+        lsyms_def = dict()
         symbol_tables = [s for s in elffile.iter_sections()
                          if isinstance(s, SymbolTableSection)]
         for section in symbol_tables:
             for symbol in section.iter_symbols():
                 if symbol['st_info']['bind'] == 'STB_GLOBAL':
                     elffile_symbols[symbol.name] = symbol
+                elif symbol['st_info']['bind'] == 'STB_LOCAL':
+                    if symbol.name not in elffile_symbols.keys():
+                        elffile_symbols[symbol.name] = symbol;
+                        if symbol.name not in lsyms_def.keys():
+                            lsyms_def[symbol.name] = 1
+                        else:
+                            lsyms_def[symbol.name] += 1
 
-    try:
-        return elffile_symbols[name]
-    except (KeyError):
+    if name in lsyms_def.keys() and lsyms_def[name] > 1:
+        eprint("Multiple definitions of local symbol %s" % name)
+        sys.exit(1)
+    if name not in elffile_symbols.keys():
         eprint("Cannot find symbol %s" % name)
         sys.exit(1)
+
+    return elffile_symbols[name]
 
 
 def get_sections(elffile, pad_to, dump_names):


### PR DESCRIPTION
Prior to this patch scripts/gen_tee_bin.py only looked for global
symbols (STB_GLOBAL). The linker in some older versions of the gcc
toolchain makes some of the symbols local (STB_LOCAL) instead. This
patch fixes that by falling back to a local symbol in case a global
cannot be found.

Reported-by: Victor Chong <victor.chong@linaro.org>
Fixes: 3c51966baa03 ("core: add scripts/gen_tee_bin.py for boot binaries")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
