### PR TITLE
[rfc] Sign TAs using pss

### DIFF
--- a/core/crypto/signed_hdr.c
+++ b/core/crypto/signed_hdr.c
@@ -76,7 +76,7 @@ TEE_Result shdr_verify_signature(const struct shdr *shdr)
 	if (res)
 		goto out;
 
-	res = crypto_acipher_rsassa_verify(shdr->algo, &key, -1,
+	res = crypto_acipher_rsassa_verify(shdr->algo, &key, shdr->hash_size,
 					   SHDR_GET_HASH(shdr), shdr->hash_size,
 					   SHDR_GET_SIG(shdr), shdr->sig_size);
 out:

--- a/scripts/sign_encrypt.py
+++ b/scripts/sign_encrypt.py
@@ -131,7 +131,6 @@ def main():
     from Cryptodome.Signature import pss
     from Cryptodome.Hash import SHA256
     from Cryptodome.PublicKey import RSA
-    from Cryptodome.Util.number import ceil_div
     import base64
     import logging
     import os
@@ -151,12 +150,7 @@ def main():
     h = SHA256.new()
 
     digest_len = h.digest_size
-    try:
-        # This works in pycrypto
-        sig_len = ceil_div(key.size() + 1, 8)
-    except NotImplementedError:
-        # ... and this one - in pycryptodome
-        sig_len = key.size_in_bytes()
+    sig_len = key.size_in_bytes()
 
     img_size = len(img)
 

--- a/scripts/sign_encrypt.py
+++ b/scripts/sign_encrypt.py
@@ -128,10 +128,10 @@ def get_args(logger):
 
 
 def main():
-    from Crypto.Signature import PKCS1_v1_5
-    from Crypto.Hash import SHA256
-    from Crypto.PublicKey import RSA
-    from Crypto.Util.number import ceil_div
+    from Cryptodome.Signature import pss
+    from Cryptodome.Hash import SHA256
+    from Cryptodome.PublicKey import RSA
+    from Cryptodome.Util.number import ceil_div
     import base64
     import logging
     import os
@@ -167,7 +167,7 @@ def main():
         img_type = 2         # SHDR_ENCRYPTED_TA
     else:
         img_type = 1         # SHDR_BOOTSTRAP_TA
-    algo = 0x70004830    # TEE_ALG_RSASSA_PKCS1_V1_5_SHA256
+    algo = 0x70414930    # TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256
 
     shdr = struct.pack('<IIIIHH',
                        magic, img_type, img_size, algo, digest_len, sig_len)
@@ -215,7 +215,7 @@ def main():
                          'please use offline-signing mode.')
             sys.exit(1)
         else:
-            signer = PKCS1_v1_5.new(key)
+            signer = pss.new(key)
             sig = signer.sign(h)
             if len(sig) != sig_len:
                 raise Exception(("Actual signature length is not equal to ",
@@ -242,7 +242,7 @@ def main():
                          args.digf, args.sigf)
             sys.exit(1)
         else:
-            verifier = PKCS1_v1_5.new(key)
+            verifier = pss.new(key)
             if verifier.verify(h, sig):
                 write_image_with_signature(sig)
                 logger.info('Successfully applied signature.')


### PR DESCRIPTION
PKCS#1 v1.5 has some security issues, https://cryptosense.com/blog/why-pkcs1v1-5-encryption-should-be-put-out-of-our-misery/

In this PR I propose to switch to sign TAs using TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256. However, it's not completely without issues. In the scripts/sign_encrypt.py script we'll add dependency to Cryptodome. Before this the was dependency to Cryptodome only if TAs where to be encrypted.

Perhaps we should have a way of passing the algorithm to the script instead of using a hard coded algorithm.