### PR TITLE
Enable rollback protection for REE-FS TAs

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -93,7 +93,8 @@ $(link-out-dir$(sm))/$(user-ta-uuid).ta: \
 			$(TA_SIGN_KEY)
 	@$(cmd-echo-silent) '  $$(cmd-echo$(user-ta-uuid)) $$@'
 	$(q)$(SIGN_ENC) --key $(TA_SIGN_KEY) $$(crypt-args$(user-ta-uuid)) \
-		--uuid $(user-ta-uuid) --in $$< --out $$@
+		--uuid $(user-ta-uuid) --ta-version $(user-ta-version) \
+		--in $$< --out $$@
 endef
 
 $(eval $(call gen-link-t))

--- a/ta/avb/user_ta.mk
+++ b/ta/avb/user_ta.mk
@@ -1,1 +1,2 @@
 user-ta-uuid := 023f8f1a-292a-432b-8fc4-de8471358067
+user-ta-version := 0

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -20,6 +20,7 @@ link-out-dir := $(out-dir)	# backward compat
 link-out-dir$(sm) := $(out-dir)
 
 user-ta-uuid := $(BINARY)
+user-ta-version := $(if $(CFG_TA_VERSION),$(CFG_TA_VERSION),0)
 user-ta-ldadd := $(LDADD)
 libname := $(LIBNAME)
 shlibname := $(SHLIBNAME)


### PR DESCRIPTION
Add check for TA version while loading TA from REE-FS and compare against secure storage based TA version database to prevent against any TA version downgrades.

We should normally keep TA version database in RPMB filesystem for more robustness. That's the reason for default selection being RPMB based secure storage if present otherwise fallback to REE-FS based secure storage.

Looking forward to your comments.

-Sumit