### PR TITLE
symbolize.py: fix decoding of ftrace dumps containing syscalls

### DIFF
--- a/core/arch/arm/kernel/unwind_arm32.c
+++ b/core/arch/arm/kernel/unwind_arm32.c
@@ -435,7 +435,7 @@ void print_stack_arm32(int level, struct unwind_state_arm32 *state,
 		       vaddr_t exidx, size_t exidx_sz,
 		       vaddr_t stack, size_t stack_size)
 {
-	trace_printf_helper_raw(level, true, "Load address @ %#"PRIxVA,
+	trace_printf_helper_raw(level, true, "TEE load address @ %#"PRIxVA,
 				VCORE_START_VA);
 	trace_printf_helper_raw(level, true, "Call stack:");
 	do {

--- a/core/arch/arm/kernel/unwind_arm64.c
+++ b/core/arch/arm/kernel/unwind_arm64.c
@@ -110,7 +110,7 @@ bool unwind_stack_arm64(struct unwind_state_arm64 *frame,
 void print_stack_arm64(int level, struct unwind_state_arm64 *state,
 		       vaddr_t stack, size_t stack_size)
 {
-	trace_printf_helper_raw(level, true, "Load address @ %#"PRIxVA,
+	trace_printf_helper_raw(level, true, "TEE load address @ %#"PRIxVA,
 				VCORE_START_VA);
 	trace_printf_helper_raw(level, true, "Call stack:");
 

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -15,7 +15,7 @@ import sys
 import termios
 
 CALL_STACK_RE = re.compile('Call stack:')
-TEE_LOAD_ADDR_RE = re.compile(r'Load address @ (?P<load_addr>0x[0-9a-f]+)')
+TEE_LOAD_ADDR_RE = re.compile(r'TEE load address @ (?P<load_addr>0x[0-9a-f]+)')
 # This gets the address from lines looking like this:
 # E/TC:0  0x001044a8
 STACK_ADDR_RE = re.compile(

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -186,17 +186,15 @@ class Symbolizer(object):
             # especially to symbolize mixed (user-space and kernel) addresses
             # which is true when syscall ftrace is enabled along with TA
             # ftrace.
-            return '0x0'
+            return self._tee_load_addr
         else:
             # tee.elf
             return self._tee_load_addr
 
     def elf_for_addr(self, addr):
-        if not self._regions:
-            return 'tee.elf'
         l_addr = self.elf_load_addr(addr)
-        if l_addr is None:
-            return None
+        if l_addr == self._tee_load_addr:
+            return 'tee.elf'
         for k in self._elfs:
             e = self._elfs[k]
             if int(e[1], 16) == int(l_addr, 16):
@@ -369,7 +367,7 @@ class Symbolizer(object):
         self._sections = {}  # {elf_name: [[name, addr, size], ...], ...}
         self._regions = []   # [[addr, size, elf_idx, saved line], ...]
         self._elfs = {0: ["tee.elf", 0]}  # {idx: [uuid, load_addr], ...}
-        self._tee_load_addr = 0x0
+        self._tee_load_addr = '0x0'
         self._func_graph_found = False
         self._func_graph_skip_line = True
 


### PR DESCRIPTION
When decoding an ftrace file with syscall tracing enabled [1], the
kernel functions are not resolved and show question marks instead.

[1] $ make CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y \
           CFLAGS_ta_arm32=-pg
    [run test and copy content of /tmp/ftrace*]
    $ optee_os/scripts/symbolize.py -d optee_os/out/arm/core \
           -d out-br/build/optee_test-1.0/ta/*/out
    [paste ftrace log here]

Fixes: 105e09c24479 ("symbolize.py: add support for TEE core ASLR")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
