### PR TITLE
pl022_spi: Add check for busy flag during SPI transfer

### DIFF
--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -150,7 +150,7 @@ static enum spi_result pl022_txrx8(struct spi_chip *chip, uint8_t *wdat,
 		return SPI_ERR_CFG;
 	}
 
-	if (wdat)
+	if (wdat) {
 		while (i < num_pkts) {
 			if (io_read8(pd->base + SSPSR) & SSPSR_TNF) {
 				/* tx 1 packet */
@@ -163,6 +163,16 @@ static enum spi_result pl022_txrx8(struct spi_chip *chip, uint8_t *wdat,
 					rdat[j++] = io_read8(pd->base + SSPDR);
 				}
 		}
+
+		/* Wait until tx fifo is empty */
+		while (io_read32(pd->base + SSPSR) & SSPSR_BSY) {
+			if (rdat)
+				if (io_read8(pd->base + SSPSR) & SSPSR_RNE) {
+					/* rx 1 packet */
+					rdat[j++] = io_read8(pd->base + SSPDR);
+				}
+		}
+	}
 
 	/* Capture remaining rdat not read above */
 	if (rdat) {
@@ -195,7 +205,7 @@ static enum spi_result pl022_txrx16(struct spi_chip *chip, uint16_t *wdat,
 		return SPI_ERR_CFG;
 	}
 
-	if (wdat)
+	if (wdat) {
 		while (i < num_pkts) {
 			if (io_read8(pd->base + SSPSR) & SSPSR_TNF) {
 				/* tx 1 packet */
@@ -208,6 +218,16 @@ static enum spi_result pl022_txrx16(struct spi_chip *chip, uint16_t *wdat,
 					rdat[j++] = io_read16(pd->base + SSPDR);
 				}
 		}
+
+		/* Wait until tx fifo is empty */
+		while (io_read32(pd->base + SSPSR) & SSPSR_BSY) {
+			if (rdat)
+				if (io_read8(pd->base + SSPSR) & SSPSR_RNE) {
+					/* rx 1 packet */
+					rdat[j++] = io_read16(pd->base + SSPDR);
+				}
+		}
+	}
 
 	/* Capture remaining rdat not read above */
 	if (rdat) {


### PR DESCRIPTION
This check allows for data transmission to be complete prior to
return from SPI data transfer API. It also fixes loopback case wherein
data hasn't been transmitted yet prior to receive.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
