### PR TITLE
drivers: imx_wdog: set functional state prior restart.

### DIFF
--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -44,6 +44,24 @@
 static bool ext_reset;
 static vaddr_t wdog_base;
 
+#ifdef CFG_MX7ULP
+static void imx_wdt_reinit(void)
+{
+	uint32_t val;
+
+	/* unlock the wdog for reconfiguration */
+	io_write32(wdog_base + WDOG_CNT, UNLOCK_SEQ0);
+	io_write32(wdog_base + WDOG_CNT, UNLOCK_SEQ1);
+
+	/* set an initial timeout value in TOVAL */
+	io_write32(wdog_base + WDOG_TOVAL, 1000);
+
+	/* enable 32bit command sequence and reconfigure */
+	val = (1 << 13) | (1 << 8) | (1 << 5);
+	io_write32(wdog_base + WDOG_CS, val);
+}
+#endif
+
 void imx_wdog_restart(void)
 {
 	uint32_t val;
@@ -54,6 +72,9 @@ void imx_wdog_restart(void)
 	}
 
 #ifdef CFG_MX7ULP
+	/* make sure the wdt is in the ready state */
+	imx_wdt_reinit();
+
 	val = io_read32(wdog_base + WDOG_CS);
 
 	io_write32(wdog_base + WDOG_CNT, UNLOCK);


### PR DESCRIPTION
The linux kernel is responsible for probing and initializing the
imx watchdog. It is therefore possible for any subsystem -ie
systemd- to stop and disable the watchdog as part of the reboot
house-keeping tasks.
If this happens and the kernel calls OP-TEE's psci to reboot, the
watchdog will be in the wrong state to perform the requested reset and
the system will hang in a zombie state.

This commit re-initializes the watchdog to a ready state before
requesting reset.

This use case has been tested on imx7ulp.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
