### PR TITLE
Un-deprecate v1 OP-TEE header

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -178,9 +178,9 @@ $(link-out-dir)/tee-pageable.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)scripts/gen_tee_bin.py --input $< --out_tee_pageable_bin $@
 
+all: $(link-out-dir)/tee.bin
 cleanfiles += $(link-out-dir)/tee.bin
 $(link-out-dir)/tee.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
-	@echo Warning: $@ is deprecated
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)scripts/gen_tee_bin.py --input $< --out_tee_bin $@
 


### PR DESCRIPTION
The OP-TEE v1 header is the only version supported by U-Boot[0] and several other projects, including non-modifiable device code. Community and device support for v2 should be in better shape before marking the format as deprecated (if it ever has to be deprecated).

Removing the images from the 'all' build causes automatic testing to miss issues with the v1 format like [here](https://github.com/OP-TEE/optee_os/issues/3459).

Restore v1 as a supported format.

Andrew

[0] https://gitlab.denx.de/u-boot/u-boot/blob/master/include/tee/optee.h




<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
