### PR TITLE
Add libsm implementing the Chinese SM2/SM3/SM4 algorithms for TAs

### DIFF
--- a/lib/libsm/include/sm2.h
+++ b/lib/libsm/include/sm2.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019 Huawei Technologies Co., Ltd
+ */
+/*
+ *  sm2_signature.h
+ *  mbedtlsSM2
+ *
+ *  Created by mac on 2018/4/18.
+ *  Copyright © 2018年 mac. All rights reserved.
+ */
+
+#ifndef LIBSM_SM2_H
+#define LIBSM_SM2_H
+
+#include <mbedtls/ecp.h>
+
+#define MAX_POINT_BYTE_LENGTH 64
+#define HASH_BYTE_LENGTH 32
+
+struct sm2_sign_ctx {
+	uint8_t *message;
+	size_t message_size;
+
+	uint8_t *ID;
+	size_t ENTL;
+
+	mbedtls_ecp_keypair *key_pair;
+
+	uint8_t Z[HASH_BYTE_LENGTH];
+	uint8_t k[MAX_POINT_BYTE_LENGTH];
+	uint8_t r[MAX_POINT_BYTE_LENGTH];
+	uint8_t s[MAX_POINT_BYTE_LENGTH];
+	uint8_t R[MAX_POINT_BYTE_LENGTH];
+};
+
+struct sm2_hash {
+	uint8_t buffer[1024];
+	int position;
+	uint8_t hash[HASH_BYTE_LENGTH];
+};
+
+int sm2_sign(mbedtls_ecp_group *ecp, struct sm2_sign_ctx *ctx);
+int sm2_verify(mbedtls_ecp_group *ecp, struct sm2_sign_ctx *ctx);
+
+#endif /* LIBSM_SM2_H */

--- a/lib/libsm/include/sm2.h
+++ b/lib/libsm/include/sm2.h
@@ -3,11 +3,10 @@
  * Copyright (c) 2019 Huawei Technologies Co., Ltd
  */
 /*
- *  sm2_signature.h
  *  mbedtlsSM2
  *
  *  Created by mac on 2018/4/18.
- *  Copyright © 2018年 mac. All rights reserved.
+ *  Copyright 2018 mac. All rights reserved.
  */
 
 #ifndef LIBSM_SM2_H
@@ -15,8 +14,8 @@
 
 #include <mbedtls/ecp.h>
 
-#define MAX_POINT_BYTE_LENGTH 64
-#define HASH_BYTE_LENGTH 32
+#define MAX_POINT_BYTE_LENGTH	64
+#define HASH_BYTE_LENGTH	32
 
 struct sm2_sign_ctx {
 	uint8_t *message;

--- a/lib/libsm/include/sm3.h
+++ b/lib/libsm/include/sm3.h
@@ -5,7 +5,6 @@
 /**
  * \file sm3.h
  * thanks to Xyssl
- * SM3 standards:http://www.oscca.gov.cn/News/201012/News_1199.htm
  * author:goldboar
  * email:goldboar@163.com
  * 2011-10-26

--- a/lib/libsm/include/sm3.h
+++ b/lib/libsm/include/sm3.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019 Huawei Technologies Co., Ltd
+ */
+/**
+ * \file sm3.h
+ * thanks to Xyssl
+ * SM3 standards:http://www.oscca.gov.cn/News/201012/News_1199.htm
+ * author:goldboar
+ * email:goldboar@163.com
+ * 2011-10-26
+ */
+#ifndef LIBSM_SM3_H
+#define LIBSM_SM3_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct sm3_context {
+	uint32_t total[2];   /* number of bytes processed */
+	uint32_t state[8];   /* intermediate digest state */
+	uint8_t buffer[64];  /* data block being processed */
+	uint8_t ipad[64];    /* HMAC: inner padding */
+	uint8_t opad[64];    /* HMAC: outer padding */
+};
+
+void sm3_init(struct sm3_context *ctx);
+void sm3_update(struct sm3_context *ctx, const uint8_t *input, size_t ilen);
+void sm3_final(struct sm3_context *ctx, uint8_t output[32]);
+void sm3(uint8_t *input, size_t ilen, uint8_t output[32]);
+
+void sm3_hmac_init(struct sm3_context *ctx, uint8_t *key, size_t keylen);
+void sm3_hmac_update(struct sm3_context *ctx, const uint8_t *input,
+		     size_t ilen);
+void sm3_hmac_final(struct sm3_context *ctx, uint8_t output[32]);
+void sm3_hmac(uint8_t *key, size_t keylen, uint8_t *input, size_t ilen,
+	      uint8_t output[32]);
+
+#endif /* LIBSM_SM3_H */

--- a/lib/libsm/include/sm4.h
+++ b/lib/libsm/include/sm4.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 1019 Huawei Technologies Co., Ltd
+ */
+#ifndef LIBSM_SM4_H
+#define LIBSM_SM4_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SM4_ENCRYPT     1
+#define SM4_DECRYPT     0
+
+struct sm4_context {
+	int mode;         /* encrypt/decrypt */
+	uint32_t sk[32];  /* SM4 subkeys */
+};
+
+void sm4_setkey_enc(struct sm4_context *ctx, unsigned char key[16]);
+void sm4_setkey_dec(struct sm4_context *ctx, unsigned char key[16]);
+void sm4_crypt_ecb(struct sm4_context *ctx, size_t length, uint8_t *input,
+		   uint8_t *output);
+void sm4_crypt_cbc(struct sm4_context *ctx, int mode, size_t length,
+		   uint8_t iv[16], uint8_t *input, uint8_t *output);
+
+#endif /* LIBSM_SM4_H */

--- a/lib/libsm/include/sm4.h
+++ b/lib/libsm/include/sm4.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 1019 Huawei Technologies Co., Ltd
+ * Copyright (c) 2019 Huawei Technologies Co., Ltd
  */
 #ifndef LIBSM_SM4_H
 #define LIBSM_SM4_H

--- a/lib/libsm/sm2.c
+++ b/lib/libsm/sm2.c
@@ -3,24 +3,26 @@
  * Copyright (c) 2019 Huawei Technologies Co., Ltd
  */
 /*
- *  sm2_signature.c
  *  mbedtlsSM2
  *
  *  Created by mac on 2018/4/18.
- *  Copyright © 2018年 mac. All rights reserved.
+ *  Copyright 2018 mac. All rights reserved.
  */
 
+#include <assert.h>
 #include <mbedtls/bignum.h>
 #include <mbedtls/ecp.h>
 #include <sm2.h>
 #include <string.h>
 #include <tee_internal_api.h>
+#include <util.h>
 
 #define BN2BIN_SIZE 512
 uint8_t bn2binbuffer[BN2BIN_SIZE];
 
 static void append_bin(struct sm2_hash *h, size_t size)
 {
+	assert(h->position + size <= ARRAY_SIZE(bn2binbuffer));
 	memcpy(h->buffer + h->position, &bn2binbuffer[BN2BIN_SIZE - size],
 	       size);
 	h->position += size;
@@ -28,6 +30,7 @@ static void append_bin(struct sm2_hash *h, size_t size)
 
 static void append_str(struct sm2_hash *h, uint8_t *buf, size_t size)
 {
+	assert(h->position + size <= ARRAY_SIZE(bn2binbuffer));
 	memcpy(h->buffer + h->position, buf, size);
 	h->position += size;
 }
@@ -58,7 +61,10 @@ static int hash256(uint8_t *in, size_t size, uint8_t *out)
 	return ret;
 }
 
-/* Return random number @a < @b */
+/*
+ * Generates a random number @a such that @a < @b.
+ * Returns an Mbed TLS status code.
+ */
 static int random_num(mbedtls_mpi *a, size_t bytes, mbedtls_mpi *b)
 {
 	uint8_t *rnd = NULL;

--- a/lib/libsm/sm2.c
+++ b/lib/libsm/sm2.c
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019 Huawei Technologies Co., Ltd
+ */
+/*
+ *  sm2_signature.c
+ *  mbedtlsSM2
+ *
+ *  Created by mac on 2018/4/18.
+ *  Copyright © 2018年 mac. All rights reserved.
+ */
+
+#include <mbedtls/bignum.h>
+#include <mbedtls/ecp.h>
+#include <sm2.h>
+#include <string.h>
+#include <tee_internal_api.h>
+
+#define BN2BIN_SIZE 512
+uint8_t bn2binbuffer[BN2BIN_SIZE];
+
+static void append_bin(struct sm2_hash *h, size_t size)
+{
+	memcpy(h->buffer + h->position, &bn2binbuffer[BN2BIN_SIZE - size],
+	       size);
+	h->position += size;
+}
+
+static void append_str(struct sm2_hash *h, uint8_t *buf, size_t size)
+{
+	memcpy(h->buffer + h->position, buf, size);
+	h->position += size;
+}
+
+static size_t byte_length(size_t bit_length)
+{
+	return (bit_length + 7) / 8;
+}
+
+static int hash256(uint8_t *in, size_t size, uint8_t *out)
+{
+	size_t out_size = size;
+	TEE_OperationHandle op = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int ret = 0;
+
+	res = TEE_AllocateOperation(&op, TEE_ALG_SHA256, TEE_MODE_DIGEST, 0);
+	if (res)
+		return MBEDTLS_ERR_MPI_ALLOC_FAILED;
+	res = TEE_DigestDoFinal(op, in, size, out, &out_size);
+	if (res)
+		ret = MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+
+	TEE_FreeOperation(op);
+
+	return ret;
+}
+
+/* Return random number @a < @b */
+static int random_num(mbedtls_mpi *a, size_t bytes, mbedtls_mpi *b)
+{
+	uint8_t *rnd = NULL;
+	int res = 0;
+
+	rnd = TEE_Malloc(bytes, 0);
+	if (!rnd)
+		return MBEDTLS_ERR_MPI_ALLOC_FAILED;
+	TEE_GenerateRandom(rnd, bytes);
+	res = mbedtls_mpi_read_binary(a, rnd, bytes);
+	if (res)
+		goto cleanup;
+	while (mbedtls_mpi_cmp_mpi(a, b) >= 0) {
+		res = mbedtls_mpi_shift_r(a, 1);
+		if (res)
+			goto cleanup;
+	}
+cleanup:
+	TEE_Free(rnd);
+	return res;
+}
+
+int sm2_sign(mbedtls_ecp_group *ecp, struct sm2_sign_ctx *ctx)
+{
+	int res = 0;
+	size_t num_size;
+	struct sm2_hash e;
+	struct sm2_hash Z_A;
+	mbedtls_ecp_point kG;
+	mbedtls_mpi e_n, k_n, r_n, s_n, temp;
+
+	mbedtls_mpi_init(&s_n);
+	mbedtls_mpi_init(&e_n);
+	mbedtls_mpi_init(&k_n);
+	mbedtls_mpi_init(&r_n);
+	mbedtls_mpi_init(&temp);
+	mbedtls_ecp_point_init(&kG);
+
+	/* step 1 */
+
+	/* Z = H(ENTL || ID A || a || b || x G || y G || x A || y A) */
+	memset(&Z_A, 0, sizeof(Z_A));
+	Z_A.buffer[0] = ((ctx->ENTL * 8) >> 8) & 0xff;
+	Z_A.buffer[1] = (ctx->ENTL * 8) & 0xff;
+	Z_A.position += 2;
+
+	append_str(&Z_A, ctx->ID, ctx->ENTL);
+
+	res = mbedtls_mpi_write_binary(&ecp->A, bn2binbuffer, BN2BIN_SIZE);
+	if (res)
+		goto cleanup;
+	num_size = mbedtls_mpi_size(&ecp->A);
+	append_bin(&Z_A, num_size);
+
+	res = mbedtls_mpi_write_binary(&ecp->B, bn2binbuffer, BN2BIN_SIZE);
+	if (res)
+		goto cleanup;
+	num_size = mbedtls_mpi_size(&ecp->B);
+	append_bin(&Z_A, num_size);
+
+	res = mbedtls_mpi_write_binary(&ecp->G.X, bn2binbuffer, BN2BIN_SIZE);
+	if (res)
+		goto cleanup;
+	num_size = mbedtls_mpi_size(&ecp->G.X);
+	append_bin(&Z_A, num_size);
+
+	res = mbedtls_mpi_write_binary(&ecp->G.Y, bn2binbuffer, BN2BIN_SIZE);
+	if (res)
+		goto cleanup;
+	num_size = mbedtls_mpi_size(&ecp->G.Y);
+	append_bin(&Z_A, num_size);
+
+	res = mbedtls_mpi_write_binary(&ctx->key_pair->Q.X, bn2binbuffer,
+				       BN2BIN_SIZE);
+	if (res)
+		goto cleanup;
+	num_size = mbedtls_mpi_size(&ctx->key_pair->Q.X);
+	append_bin(&Z_A, num_size);
+
+	res = mbedtls_mpi_write_binary(&ctx->key_pair->Q.Y, bn2binbuffer,
+				       BN2BIN_SIZE);
+	if (res)
+		goto cleanup;
+	num_size = mbedtls_mpi_size(&ctx->key_pair->Q.Y);
+	append_bin(&Z_A, num_size);
+
+	res = hash256(Z_A.buffer, Z_A.position, Z_A.hash);
+	if (res)
+		goto cleanup;
+	memcpy(ctx->Z, Z_A.hash, HASH_BYTE_LENGTH);
+
+	/* step 2 */
+
+	memset(&e, 0, sizeof(e));
+	append_str(&e, ctx->Z, HASH_BYTE_LENGTH);
+	append_str(&e, ctx->message, ctx->message_size);
+
+	res = hash256(e.buffer, e.position, e.hash);
+	if (res)
+		goto cleanup;
+
+	res = mbedtls_mpi_read_binary(&e_n, e.hash, HASH_BYTE_LENGTH);
+	if (res)
+		goto cleanup;
+
+	/* step 3 */
+
+	res = random_num(&k_n, byte_length(ecp->nbits), &ecp->N);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_write_binary(&k_n, ctx->k, byte_length(ecp->nbits));
+	if (res)
+		goto cleanup;
+
+	/* step 4 */
+
+	res = mbedtls_ecp_mul(ecp,  &kG, &k_n, &ecp->G, NULL, NULL);
+	if (res)
+		goto cleanup;
+
+	/* step 5 */
+
+	res = mbedtls_mpi_add_mpi(&r_n, &e_n, &kG.X);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_mod_mpi(&r_n, &r_n, &ecp->N);
+	if (res)
+		goto cleanup;
+
+	/* step 6 */
+
+	res = mbedtls_mpi_add_int(&temp, &ctx->key_pair->d, 1);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_inv_mod(&temp, &temp, &ecp->N);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_mul_mpi(&s_n, &r_n, &ctx->key_pair->d);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_sub_mpi(&s_n, &k_n, &s_n);
+	if (res)
+		goto cleanup;
+
+	res = mbedtls_mpi_mul_mpi(&s_n, &temp, &s_n);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_mod_mpi(&s_n, &s_n, &ecp->N);
+	if (res)
+		goto cleanup;
+
+	res = mbedtls_mpi_write_binary(&r_n, ctx->r, byte_length(ecp->nbits));
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_write_binary(&s_n, ctx->s, byte_length(ecp->nbits));
+	if (res)
+		goto cleanup;
+
+cleanup:
+	mbedtls_mpi_free(&e_n);
+	mbedtls_mpi_free(&k_n);
+	mbedtls_mpi_free(&r_n);
+	mbedtls_mpi_free(&s_n);
+	mbedtls_mpi_free(&temp);
+	mbedtls_ecp_point_free(&kG);
+	return res;
+}
+
+int sm2_verify(mbedtls_ecp_group *ecp, struct sm2_sign_ctx *ctx)
+{
+	int res = 0;
+	struct sm2_hash e;
+	mbedtls_ecp_point sGtP;
+	mbedtls_mpi e_n, r_n, s_n, t_n, R_n;
+
+	memset(&e, 0, sizeof(e));
+	mbedtls_ecp_point_init(&sGtP);
+	mbedtls_mpi_init(&e_n);
+	mbedtls_mpi_init(&r_n);
+	mbedtls_mpi_init(&s_n);
+	mbedtls_mpi_init(&t_n);
+	mbedtls_mpi_init(&R_n);
+
+	/* step 3 4 */
+
+	append_str(&e, ctx->Z, HASH_BYTE_LENGTH);
+	append_str(&e, ctx->message, ctx->message_size);
+	res = hash256(e.buffer, e.position, e.hash);
+	if (res)
+		goto cleanup;
+
+	res = mbedtls_mpi_read_binary(&e_n, e.hash, HASH_BYTE_LENGTH);
+	if (res)
+		goto cleanup;
+
+	/* step 5 */
+	res = mbedtls_mpi_read_binary(&r_n, ctx->r, byte_length(ecp->nbits));
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_read_binary(&s_n, ctx->s, byte_length(ecp->nbits));
+	if (res)
+		goto cleanup;
+
+	res = mbedtls_mpi_add_mpi(&t_n, &r_n, &s_n);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_mod_mpi(&t_n, &t_n, &ecp->N);
+	if (res)
+		goto cleanup;
+
+	/* step 6 */
+	res = mbedtls_ecp_muladd(ecp, &sGtP, &s_n, &ecp->G, &t_n,
+				 &ctx->key_pair->Q);
+	if (res)
+		goto cleanup;
+
+	/* step 7 */
+	res = mbedtls_mpi_add_mpi(&R_n, &e_n, &sGtP.X);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_mod_mpi(&R_n, &R_n, &ecp->N);
+	if (res)
+		goto cleanup;
+	res = mbedtls_mpi_cmp_mpi(&R_n, &r_n);
+	if (res)
+		goto cleanup;
+
+cleanup:
+	mbedtls_ecp_point_free(&sGtP);
+	mbedtls_mpi_free(&e_n);
+	mbedtls_mpi_free(&r_n);
+	mbedtls_mpi_free(&s_n);
+	mbedtls_mpi_free(&t_n);
+	mbedtls_mpi_free(&R_n);
+	return res;
+}

--- a/lib/libsm/sm2.c
+++ b/lib/libsm/sm2.c
@@ -39,11 +39,13 @@ static size_t byte_length(size_t bit_length)
 
 static int hash256(uint8_t *in, size_t size, uint8_t *out)
 {
-	size_t out_size = size;
+	uint32_t out_size = size;
 	TEE_OperationHandle op = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	int ret = 0;
 
+	if (size > out_size)
+		return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
 	res = TEE_AllocateOperation(&op, TEE_ALG_SHA256, TEE_MODE_DIGEST, 0);
 	if (res)
 		return MBEDTLS_ERR_MPI_ALLOC_FAILED;

--- a/lib/libsm/sm3.c
+++ b/lib/libsm/sm3.c
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright Copyright (c) 2019 Huawei Technologies Co., Ltd
+ */
+/*
+ * SM3 Hash algorithm
+ * thanks to Xyssl
+ * author:goldboar
+ * email:goldboar@163.com
+ * 2011-10-26
+ */
+
+#include <sm3.h>
+#include <string.h>
+#include <string_ext.h>
+
+#define GET_UINT32_BE(n, b, i)			\
+{						\
+	(n) = ((uint32_t)(b)[(i)] << 24)	\
+	    | ((uint32_t)(b)[(i) + 1] << 16)	\
+	    | ((uint32_t)(b)[(i) + 2] <<  8)	\
+	    | ((uint32_t)(b)[(i) + 3]);		\
+}
+
+#define PUT_UINT32_BE(n, b, i)			\
+{						\
+	(b)[(i)] = (uint8_t)((n) >> 24);	\
+	(b)[(i) + 1] = (uint8_t)((n) >> 16);	\
+	(b)[(i) + 2] = (uint8_t)((n) >>  8);	\
+	(b)[(i) + 3] = (uint8_t)((n));		\
+}
+
+void sm3_init(struct sm3_context *ctx)
+{
+	ctx->total[0] = 0;
+	ctx->total[1] = 0;
+
+	ctx->state[0] = 0x7380166F;
+	ctx->state[1] = 0x4914B2B9;
+	ctx->state[2] = 0x172442D7;
+	ctx->state[3] = 0xDA8A0600;
+	ctx->state[4] = 0xA96F30BC;
+	ctx->state[5] = 0x163138AA;
+	ctx->state[6] = 0xE38DEE4D;
+	ctx->state[7] = 0xB0FB0E4E;
+}
+
+static void sm3_process(struct sm3_context *ctx, const uint8_t data[64])
+{
+	uint32_t SS1, SS2, TT1, TT2, W[68], W1[64];
+	uint32_t A, B, C, D, E, F, G, H;
+	uint32_t T[64];
+	uint32_t Temp1, Temp2, Temp3, Temp4, Temp5;
+	int j;
+
+	for (j = 0; j < 16; j++)
+		T[j] = 0x79CC4519;
+	for (j = 16; j < 64; j++)
+		T[j] = 0x7A879D8A;
+
+	GET_UINT32_BE(W[0], data,  0);
+	GET_UINT32_BE(W[1], data,  4);
+	GET_UINT32_BE(W[2], data,  8);
+	GET_UINT32_BE(W[3], data, 12);
+	GET_UINT32_BE(W[4], data, 16);
+	GET_UINT32_BE(W[5], data, 20);
+	GET_UINT32_BE(W[6], data, 24);
+	GET_UINT32_BE(W[7], data, 28);
+	GET_UINT32_BE(W[8], data, 32);
+	GET_UINT32_BE(W[9], data, 36);
+	GET_UINT32_BE(W[10], data, 40);
+	GET_UINT32_BE(W[11], data, 44);
+	GET_UINT32_BE(W[12], data, 48);
+	GET_UINT32_BE(W[13], data, 52);
+	GET_UINT32_BE(W[14], data, 56);
+	GET_UINT32_BE(W[15], data, 60);
+
+#define FF0(x, y, z) ((x) ^ (y) ^ (z))
+#define FF1(x, y, z) (((x) & (y)) | ((x) & (z)) | ((y) & (z)))
+
+#define GG0(x, y, z) ((x) ^ (y) ^ (z))
+#define GG1(x, y, z) (((x) & (y)) | ((~(x)) & (z)))
+
+#define SHL(x, n)  (((x) & 0xFFFFFFFF) << (n))
+#define ROTL(x, n) (SHL((x), n) | ((x) >> (32 - n)))
+
+#define P0(x) ((x) ^ ROTL((x), 9) ^ ROTL((x), 17))
+#define P1(x) ((x) ^ ROTL((x), 15) ^ ROTL((x), 23))
+
+	for (j = 16; j < 68; j++) {
+		/*
+		 * W[j] = P1( W[j-16] ^ W[j-9] ^ ROTL(W[j-3],15)) ^
+		 *        ROTL(W[j - 13],7 ) ^ W[j-6];
+		 */
+
+		Temp1 = W[j - 16] ^ W[j - 9];
+		Temp2 = ROTL(W[j - 3], 15);
+		Temp3 = Temp1 ^ Temp2;
+		Temp4 = P1(Temp3);
+		Temp5 =  ROTL(W[j - 13], 7) ^ W[j - 6];
+		W[j] = Temp4 ^ Temp5;
+	}
+
+	for (j =  0; j < 64; j++)
+		W1[j] = W[j] ^ W[j + 4];
+
+	A = ctx->state[0];
+	B = ctx->state[1];
+	C = ctx->state[2];
+	D = ctx->state[3];
+	E = ctx->state[4];
+	F = ctx->state[5];
+	G = ctx->state[6];
+	H = ctx->state[7];
+
+	for (j = 0; j < 16; j++) {
+		SS1 = ROTL((ROTL(A, 12) + E + ROTL(T[j], j)), 7);
+		SS2 = SS1 ^ ROTL(A, 12);
+		TT1 = FF0(A, B, C) + D + SS2 + W1[j];
+		TT2 = GG0(E, F, G) + H + SS1 + W[j];
+		D = C;
+		C = ROTL(B, 9);
+		B = A;
+		A = TT1;
+		H = G;
+		G = ROTL(F, 19);
+		F = E;
+		E = P0(TT2);
+	}
+
+	for (j = 16; j < 64; j++) {
+		SS1 = ROTL((ROTL(A, 12) + E + ROTL(T[j], j)), 7);
+		SS2 = SS1 ^ ROTL(A, 12);
+		TT1 = FF1(A, B, C) + D + SS2 + W1[j];
+		TT2 = GG1(E, F, G) + H + SS1 + W[j];
+		D = C;
+		C = ROTL(B, 9);
+		B = A;
+		A = TT1;
+		H = G;
+		G = ROTL(F, 19);
+		F = E;
+		E = P0(TT2);
+	}
+
+	ctx->state[0] ^= A;
+	ctx->state[1] ^= B;
+	ctx->state[2] ^= C;
+	ctx->state[3] ^= D;
+	ctx->state[4] ^= E;
+	ctx->state[5] ^= F;
+	ctx->state[6] ^= G;
+	ctx->state[7] ^= H;
+}
+
+void sm3_update(struct sm3_context *ctx, const uint8_t *input, size_t ilen)
+{
+	size_t fill;
+	size_t left;
+
+	if (ilen <= 0)
+		return;
+
+	left = ctx->total[0] & 0x3F;
+	fill = 64 - left;
+
+	ctx->total[0] += ilen;
+	ctx->total[0] &= 0xFFFFFFFF;
+
+	if (ctx->total[0] < ilen)
+		ctx->total[1]++;
+
+	if (left && ilen >= fill) {
+		memcpy(ctx->buffer + left, input, fill);
+		sm3_process(ctx, ctx->buffer);
+		input += fill;
+		ilen -= fill;
+		left = 0;
+	}
+
+	while (ilen >= 64) {
+		sm3_process(ctx, input);
+		input += 64;
+		ilen -= 64;
+	}
+
+	if (ilen > 0)
+		memcpy(ctx->buffer + left, input, ilen);
+}
+
+static const uint8_t sm3_padding[64] = {
+	0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+void sm3_final(struct sm3_context *ctx, uint8_t output[32])
+{
+	uint32_t last, padn;
+	uint32_t high, low;
+	uint8_t msglen[8];
+
+	high = (ctx->total[0] >> 29) | (ctx->total[1] <<  3);
+	low  = (ctx->total[0] <<  3);
+
+	PUT_UINT32_BE(high, msglen, 0);
+	PUT_UINT32_BE(low,  msglen, 4);
+
+	last = ctx->total[0] & 0x3F;
+	padn = (last < 56) ? (56 - last) : (120 - last);
+
+	sm3_update(ctx, sm3_padding, padn);
+	sm3_update(ctx, msglen, 8);
+
+	PUT_UINT32_BE(ctx->state[0], output,  0);
+	PUT_UINT32_BE(ctx->state[1], output,  4);
+	PUT_UINT32_BE(ctx->state[2], output,  8);
+	PUT_UINT32_BE(ctx->state[3], output, 12);
+	PUT_UINT32_BE(ctx->state[4], output, 16);
+	PUT_UINT32_BE(ctx->state[5], output, 20);
+	PUT_UINT32_BE(ctx->state[6], output, 24);
+	PUT_UINT32_BE(ctx->state[7], output, 28);
+}
+
+void sm3(uint8_t *input, size_t ilen, uint8_t output[32])
+{
+	struct sm3_context ctx;
+
+	sm3_init(&ctx);
+	sm3_update(&ctx, input, ilen);
+	sm3_final(&ctx, output);
+
+	memzero_explicit(&ctx, sizeof(ctx));
+}
+
+void sm3_hmac_init(struct sm3_context *ctx, uint8_t *key, size_t keylen)
+{
+	size_t i;
+	uint8_t sum[32];
+
+	if (keylen > 64) {
+		sm3(key, keylen, sum);
+		keylen = 32;
+		key = sum;
+	}
+
+	memset(ctx->ipad, 0x36, 64);
+	memset(ctx->opad, 0x5C, 64);
+
+	for (i = 0; i < keylen; i++) {
+		ctx->ipad[i] = (uint8_t)(ctx->ipad[i] ^ key[i]);
+		ctx->opad[i] = (uint8_t)(ctx->opad[i] ^ key[i]);
+	}
+
+	sm3_init(ctx);
+	sm3_update(ctx, ctx->ipad, 64);
+
+	memzero_explicit(sum, sizeof(sum));
+}
+
+void sm3_hmac_update(struct sm3_context *ctx, const uint8_t *input, size_t ilen)
+{
+	sm3_update(ctx, input, ilen);
+}
+
+void sm3_hmac_final(struct sm3_context *ctx, uint8_t output[32])
+{
+	uint8_t tmpbuf[32];
+
+	sm3_final(ctx, tmpbuf);
+	sm3_init(ctx);
+	sm3_update(ctx, ctx->opad, 64);
+	sm3_update(ctx, tmpbuf, 32);
+	sm3_final(ctx, output);
+
+	memzero_explicit(tmpbuf, sizeof(tmpbuf));
+}
+
+void sm3_hmac(uint8_t *key, size_t keylen, uint8_t *input, size_t ilen,
+	      uint8_t output[32])
+{
+	struct sm3_context ctx;
+
+	sm3_hmac_init(&ctx, key, keylen);
+	sm3_hmac_update(&ctx, input, ilen);
+	sm3_hmac_final(&ctx, output);
+
+	memzero_explicit(&ctx, sizeof(ctx));
+}

--- a/lib/libsm/sm3.c
+++ b/lib/libsm/sm3.c
@@ -75,17 +75,17 @@ static void sm3_process(struct sm3_context *ctx, const uint8_t data[64])
 	GET_UINT32_BE(W[14], data, 56);
 	GET_UINT32_BE(W[15], data, 60);
 
-#define FF0(x, y, z) ((x) ^ (y) ^ (z))
-#define FF1(x, y, z) (((x) & (y)) | ((x) & (z)) | ((y) & (z)))
+#define FF0(x, y, z)	((x) ^ (y) ^ (z))
+#define FF1(x, y, z)	(((x) & (y)) | ((x) & (z)) | ((y) & (z)))
 
-#define GG0(x, y, z) ((x) ^ (y) ^ (z))
-#define GG1(x, y, z) (((x) & (y)) | ((~(x)) & (z)))
+#define GG0(x, y, z)	((x) ^ (y) ^ (z))
+#define GG1(x, y, z)	(((x) & (y)) | ((~(x)) & (z)))
 
-#define SHL(x, n)  (((x) & 0xFFFFFFFF) << (n))
-#define ROTL(x, n) (SHL((x), n) | ((x) >> (32 - n)))
+#define SHL(x, n)	(((x) & 0xFFFFFFFF) << (n))
+#define ROTL(x, n)	(SHL((x), (n)) | ((x) >> (32 - (n))))
 
-#define P0(x) ((x) ^ ROTL((x), 9) ^ ROTL((x), 17))
-#define P1(x) ((x) ^ ROTL((x), 15) ^ ROTL((x), 23))
+#define P0(x)	((x) ^ ROTL((x), 9) ^ ROTL((x), 17))
+#define P1(x)	((x) ^ ROTL((x), 15) ^ ROTL((x), 23))
 
 	for (j = 16; j < 68; j++) {
 		/*
@@ -158,7 +158,7 @@ void sm3_update(struct sm3_context *ctx, const uint8_t *input, size_t ilen)
 	size_t fill;
 	size_t left;
 
-	if (ilen <= 0)
+	if (!ilen)
 		return;
 
 	left = ctx->total[0] & 0x3F;

--- a/lib/libsm/sm4.c
+++ b/lib/libsm/sm4.c
@@ -31,10 +31,10 @@
 	(b)[(i) + 3] = (uint8_t)((n));		\
 }
 
-#define  SHL(x, n) (((x) & 0xFFFFFFFF) << (n))
-#define ROTL(x, n) (SHL((x), n) | ((x) >> (32 - n)))
+#define SHL(x, n)	(((x) & 0xFFFFFFFF) << (n))
+#define ROTL(x, n)	(SHL((x), (n)) | ((x) >> (32 - (n))))
 
-#define SWAP(a, b) { uint32_t t = a; a = b; b = t; t = 0; }
+#define SWAP(a, b)	{ uint32_t t = a; a = b; b = t; t = 0; }
 
 /*
  * Expanded SM4 S-boxes
@@ -79,7 +79,7 @@ static const uint32_t FK[4] = {
 	0xa3b1bac6, 0x56aa3350, 0x677d9197, 0xb27022dc
 };
 
-/* fixed parameter */
+/* Fixed parameter */
 static const uint32_t CK[32] = {
 	0x00070e15, 0x1c232a31, 0x383f464d, 0x545b6269,
 	0x70777e85, 0x8c939aa1, 0xa8afb6bd, 0xc4cbd2d9,

--- a/lib/libsm/sm4.c
+++ b/lib/libsm/sm4.c
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright Copyright (c) 2019 Huawei Technologies Co., Ltd
+ */
+/*
+ * SM4 Encryption algorithm (SMS4 algorithm)
+ * GM/T 0002-2012 Chinese National Standard ref:http://www.oscca.gov.cn/
+ * thanks to Xyssl
+ * thnaks and refers to http://hi.baidu.com/numax/blog/item/80addfefddfb93e4cf1b3e61.html
+ * author:goldboar
+ * email:goldboar@163.com
+ * 2012-4-20
+ */
+
+#include <sm4.h>
+#include <string.h>
+
+#define GET_UINT32_BE(n, b, i)			\
+{						\
+	(n) = ((uint32_t)(b)[(i)] << 24)	\
+	| ((uint32_t)(b)[(i) + 1] << 16)	\
+	| ((uint32_t)(b)[(i) + 2] <<  8)	\
+	| ((uint32_t)(b)[(i) + 3]);		\
+}
+
+#define PUT_UINT32_BE(n, b, i)			\
+{						\
+	(b)[(i)]     = (uint8_t)((n) >> 24);	\
+	(b)[(i) + 1] = (uint8_t)((n) >> 16);	\
+	(b)[(i) + 2] = (uint8_t)((n) >>  8);	\
+	(b)[(i) + 3] = (uint8_t)((n));		\
+}
+
+#define  SHL(x, n) (((x) & 0xFFFFFFFF) << (n))
+#define ROTL(x, n) (SHL((x), n) | ((x) >> (32 - n)))
+
+#define SWAP(a, b) { uint32_t t = a; a = b; b = t; t = 0; }
+
+/*
+ * Expanded SM4 S-boxes
+ */
+static const uint8_t SboxTable[16][16] =  {
+	{0xd6, 0x90, 0xe9, 0xfe, 0xcc, 0xe1, 0x3d, 0xb7,
+	 0x16, 0xb6, 0x14, 0xc2, 0x28, 0xfb, 0x2c, 0x05},
+	{0x2b, 0x67, 0x9a, 0x76, 0x2a, 0xbe, 0x04, 0xc3,
+	 0xaa, 0x44, 0x13, 0x26, 0x49, 0x86, 0x06, 0x99},
+	{0x9c, 0x42, 0x50, 0xf4, 0x91, 0xef, 0x98, 0x7a,
+	 0x33, 0x54, 0x0b, 0x43, 0xed, 0xcf, 0xac, 0x62},
+	{0xe4, 0xb3, 0x1c, 0xa9, 0xc9, 0x08, 0xe8, 0x95,
+	 0x80, 0xdf, 0x94, 0xfa, 0x75, 0x8f, 0x3f, 0xa6},
+	{0x47, 0x07, 0xa7, 0xfc, 0xf3, 0x73, 0x17, 0xba,
+	 0x83, 0x59, 0x3c, 0x19, 0xe6, 0x85, 0x4f, 0xa8},
+	{0x68, 0x6b, 0x81, 0xb2, 0x71, 0x64, 0xda, 0x8b,
+	 0xf8, 0xeb, 0x0f, 0x4b, 0x70, 0x56, 0x9d, 0x35},
+	{0x1e, 0x24, 0x0e, 0x5e, 0x63, 0x58, 0xd1, 0xa2,
+	 0x25, 0x22, 0x7c, 0x3b, 0x01, 0x21, 0x78, 0x87},
+	{0xd4, 0x00, 0x46, 0x57, 0x9f, 0xd3, 0x27, 0x52,
+	 0x4c, 0x36, 0x02, 0xe7, 0xa0, 0xc4, 0xc8, 0x9e},
+	{0xea, 0xbf, 0x8a, 0xd2, 0x40, 0xc7, 0x38, 0xb5,
+	 0xa3, 0xf7, 0xf2, 0xce, 0xf9, 0x61, 0x15, 0xa1},
+	{0xe0, 0xae, 0x5d, 0xa4, 0x9b, 0x34, 0x1a, 0x55,
+	 0xad, 0x93, 0x32, 0x30, 0xf5, 0x8c, 0xb1, 0xe3},
+	{0x1d, 0xf6, 0xe2, 0x2e, 0x82, 0x66, 0xca, 0x60,
+	 0xc0, 0x29, 0x23, 0xab, 0x0d, 0x53, 0x4e, 0x6f},
+	{0xd5, 0xdb, 0x37, 0x45, 0xde, 0xfd, 0x8e, 0x2f,
+	 0x03, 0xff, 0x6a, 0x72, 0x6d, 0x6c, 0x5b, 0x51},
+	{0x8d, 0x1b, 0xaf, 0x92, 0xbb, 0xdd, 0xbc, 0x7f,
+	 0x11, 0xd9, 0x5c, 0x41, 0x1f, 0x10, 0x5a, 0xd8},
+	{0x0a, 0xc1, 0x31, 0x88, 0xa5, 0xcd, 0x7b, 0xbd,
+	 0x2d, 0x74, 0xd0, 0x12, 0xb8, 0xe5, 0xb4, 0xb0},
+	{0x89, 0x69, 0x97, 0x4a, 0x0c, 0x96, 0x77, 0x7e,
+	 0x65, 0xb9, 0xf1, 0x09, 0xc5, 0x6e, 0xc6, 0x84},
+	{0x18, 0xf0, 0x7d, 0xec, 0x3a, 0xdc, 0x4d, 0x20,
+	 0x79, 0xee, 0x5f, 0x3e, 0xd7, 0xcb, 0x39, 0x48}
+};
+
+/* System parameter */
+static const uint32_t FK[4] = {
+	0xa3b1bac6, 0x56aa3350, 0x677d9197, 0xb27022dc
+};
+
+/* fixed parameter */
+static const uint32_t CK[32] = {
+	0x00070e15, 0x1c232a31, 0x383f464d, 0x545b6269,
+	0x70777e85, 0x8c939aa1, 0xa8afb6bd, 0xc4cbd2d9,
+	0xe0e7eef5, 0xfc030a11, 0x181f262d, 0x343b4249,
+	0x50575e65, 0x6c737a81, 0x888f969d, 0xa4abb2b9,
+	0xc0c7ced5, 0xdce3eaf1, 0xf8ff060d, 0x141b2229,
+	0x30373e45, 0x4c535a61, 0x686f767d, 0x848b9299,
+	0xa0a7aeb5, 0xbcc3cad1, 0xd8dfe6ed, 0xf4fb0209,
+	0x10171e25, 0x2c333a41, 0x484f565d, 0x646b7279
+};
+
+static uint8_t sm4Sbox(uint8_t inch)
+{
+	uint8_t *tab = (uint8_t *)SboxTable;
+
+	return tab[inch];
+}
+
+static uint32_t sm4Lt(uint32_t ka)
+{
+	uint32_t bb = 0;
+	uint8_t a[4];
+	uint8_t b[4];
+
+	PUT_UINT32_BE(ka, a, 0);
+	b[0] = sm4Sbox(a[0]);
+	b[1] = sm4Sbox(a[1]);
+	b[2] = sm4Sbox(a[2]);
+	b[3] = sm4Sbox(a[3]);
+	GET_UINT32_BE(bb, b, 0);
+
+	return bb ^ ROTL(bb, 2) ^ ROTL(bb, 10) ^ ROTL(bb, 18) ^ ROTL(bb, 24);
+}
+
+static uint32_t sm4F(uint32_t x0, uint32_t x1, uint32_t x2, uint32_t x3,
+		     uint32_t rk)
+{
+	return x0 ^ sm4Lt(x1 ^ x2 ^ x3 ^ rk);
+}
+
+static uint32_t sm4CalciRK(uint32_t ka)
+{
+	uint32_t bb = 0;
+	uint8_t a[4];
+	uint8_t b[4];
+
+	PUT_UINT32_BE(ka, a, 0);
+	b[0] = sm4Sbox(a[0]);
+	b[1] = sm4Sbox(a[1]);
+	b[2] = sm4Sbox(a[2]);
+	b[3] = sm4Sbox(a[3]);
+	GET_UINT32_BE(bb, b, 0);
+
+	return bb ^ ROTL(bb, 13) ^ ROTL(bb, 23);
+}
+
+static void sm4_setkey(uint32_t SK[32], uint8_t key[16])
+{
+	uint32_t MK[4];
+	uint32_t k[36];
+	uint32_t i = 0;
+
+	GET_UINT32_BE(MK[0], key, 0);
+	GET_UINT32_BE(MK[1], key, 4);
+	GET_UINT32_BE(MK[2], key, 8);
+	GET_UINT32_BE(MK[3], key, 12);
+
+	k[0] = MK[0] ^ FK[0];
+	k[1] = MK[1] ^ FK[1];
+	k[2] = MK[2] ^ FK[2];
+	k[3] = MK[3] ^ FK[3];
+
+	for (i = 0; i < 32; i++) {
+		k[i + 4] = k[i] ^ sm4CalciRK(k[i + 1] ^ k[i + 2] ^ k[i + 3] ^
+					     CK[i]);
+		SK[i] = k[i + 4];
+	}
+}
+
+static void sm4_one_round(uint32_t sk[32], uint8_t input[16],
+			  uint8_t output[16])
+{
+	uint32_t i = 0;
+	uint32_t ulbuf[36];
+
+	memset(ulbuf, 0, sizeof(ulbuf));
+
+	GET_UINT32_BE(ulbuf[0], input, 0);
+	GET_UINT32_BE(ulbuf[1], input, 4);
+	GET_UINT32_BE(ulbuf[2], input, 8);
+	GET_UINT32_BE(ulbuf[3], input, 12);
+
+	for (i = 0; i < 32; i++)
+		ulbuf[i + 4] = sm4F(ulbuf[i], ulbuf[i + 1], ulbuf[i + 2],
+				    ulbuf[i + 3], sk[i]);
+
+	PUT_UINT32_BE(ulbuf[35], output, 0);
+	PUT_UINT32_BE(ulbuf[34], output, 4);
+	PUT_UINT32_BE(ulbuf[33], output, 8);
+	PUT_UINT32_BE(ulbuf[32], output, 12);
+}
+
+void sm4_setkey_enc(struct sm4_context *ctx, uint8_t key[16])
+{
+	ctx->mode = SM4_ENCRYPT;
+	sm4_setkey(ctx->sk, key);
+}
+
+void sm4_setkey_dec(struct sm4_context *ctx, uint8_t key[16])
+{
+	int i;
+
+	ctx->mode = SM4_ENCRYPT;
+	sm4_setkey(ctx->sk, key);
+
+	for (i = 0; i < 16; i++)
+		SWAP(ctx->sk[i], ctx->sk[31 - i]);
+}
+
+void sm4_crypt_ecb(struct sm4_context *ctx, size_t length, uint8_t *input,
+		   uint8_t *output)
+{
+	while (length > 0) {
+		sm4_one_round(ctx->sk, input, output);
+		input  += 16;
+		output += 16;
+		length -= 16;
+	}
+}
+
+void sm4_crypt_cbc(struct sm4_context *ctx, int mode, size_t length,
+		   uint8_t iv[16], uint8_t *input, uint8_t *output)
+{
+	int i;
+	uint8_t temp[16];
+
+	if (mode == SM4_ENCRYPT) {
+		while (length > 0) {
+			for (i = 0; i < 16; i++)
+				output[i] = (uint8_t)(input[i] ^ iv[i]);
+			sm4_one_round(ctx->sk, output, output);
+			memcpy(iv, output, 16);
+
+			input  += 16;
+			output += 16;
+			length -= 16;
+		}
+	} else {
+		/* SM4_DECRYPT */
+		while (length > 0) {
+			memcpy(temp, input, 16);
+			sm4_one_round(ctx->sk, input, output);
+			for (i = 0; i < 16; i++)
+				output[i] = (uint8_t)(output[i] ^ iv[i]);
+			memcpy(iv, temp, 16);
+
+			input  += 16;
+			output += 16;
+			length -= 16;
+		}
+	}
+}

--- a/lib/libsm/sub.mk
+++ b/lib/libsm/sub.mk
@@ -1,0 +1,5 @@
+global-incdirs-y += include
+
+srcs-y += sm2.c
+srcs-y += sm3.c
+srcs-y += sm4.c

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -517,3 +517,8 @@ CFG_CORE_HUK_SUBKEY_COMPAT ?= y
 # Compress and encode conf.mk into the TEE core, and show the encoded string on
 # boot (with severity TRACE_INFO).
 CFG_SHOW_CONF_ON_BOOT ?= n
+
+# User space library implementing the SM2/SM3/SM4 Chinese algorithms
+# SM2 depends on MbedTLS
+CFG_TA_LIBSM ?= $(CFG_TA_MBEDTLS)
+$(eval $(call cfg-depends-all,CFG_TA_LIBSM,CFG_TA_MBEDTLS))

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -518,7 +518,10 @@ CFG_CORE_HUK_SUBKEY_COMPAT ?= y
 # boot (with severity TRACE_INFO).
 CFG_SHOW_CONF_ON_BOOT ?= n
 
+# EXPERIMENTAL
 # User space library implementing the SM2/SM3/SM4 Chinese algorithms
-# SM2 depends on MbedTLS
+# (note that SM2 depends on MbedTLS).
+# This may become deprecated once the GP TEE Internal Core API supports
+# these algorithms, which is expected to happen in version 1.3.
 CFG_TA_LIBSM ?= $(CFG_TA_MBEDTLS)
 $(eval $(call cfg-depends-all,CFG_TA_LIBSM,CFG_TA_MBEDTLS))

--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -37,6 +37,9 @@ endif
 ifeq ($(CFG_TA_MBEDTLS),y)
 libnames += mbedtls
 endif
+ifeq ($(CFG_TA_LIBSM),y)
+libnames += sm
+endif
 libdeps = $(addsuffix .a, $(addprefix $(libdirs)/lib, $(libnames)))
 
 subdirs = $(patsubst %/,%,$(dir $(ta-mk-file)))

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -74,6 +74,10 @@ libdeps += $(ta-dev-kit-dir$(sm))/lib/libmbedtls.a
 endif
 libnames += dl
 libdeps += $(ta-dev-kit-dir$(sm))/lib/libdl.a
+ifeq ($(CFG_TA_LIBSM),y)
+libnames += sm
+libdeps += $(ta-dev-kit-dir$(sm))/lib/libsm.a
+endif
 
 # Pass config variable (CFG_) from conf.mk on the command line
 cppflags$(sm) += $(strip \

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -38,6 +38,7 @@ ta-mk-file-export-vars-$(sm) += CFG_TEE_TA_LOG_LEVEL
 ta-mk-file-export-vars-$(sm) += CFG_FTRACE_SUPPORT
 ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
+ta-mk-file-export-vars-$(sm) += CFG_TA_LIBSM
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.
@@ -117,6 +118,14 @@ libdir = lib/libdl
 libuuid = be807bbd-81e1-4dc4-bd99-3d363f240ece
 libl = utee utils
 include mk/lib.mk
+
+ifeq ($(CFG_TA_LIBSM),y)
+libname = sm
+libdir = lib/libsm
+libuuid = b124dfd6-302c-4d9a-acec-fac35ec9b1b8
+libl = mbedtls  # SM2 algorithm depends on libmbedtls
+include mk/lib.mk
+endif
 
 base-prefix :=
 


### PR DESCRIPTION
Adds a new library called libsm to implement the following
cryptographic algorithms:
- SM2, a public key cryptographic algorithm based on elliptic curves
  [3]. We implement the digital signature algorithm only. The code
  depends on the MbedTLS library for the ECC operations.
- SM3, a cryptographic hash function [4].
- SM4, a block cipher [5] (initially called SMS4 then renamed).

Source code is imported from [1] and [2] and modified as per the OP-TEE
coding rules. The library is built when CFG_TA_LIBSM = y (default unless
CFG_TA_MBEDTLS != y).

Note that the GlobalPlatform Internal Core API does not yet contain
these algorithms, but v1.3 (which is in the works) will have them.

[1] https://github.com/siddontang/pygmcrypto
[2] https://github.com/LJNL/SM2-mbedtls
[3] https://tools.ietf.org/id/draft-shen-sm2-ecdsa-02.txt
[4] https://tools.ietf.org/id/draft-oscca-cfrg-sm3-02.txt
[5] https://eprint.iacr.org/2008/329.pdf

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
