### PR TITLE
plat-ti: Switch to using SMCCC compatible calls

### DIFF
--- a/core/arch/arm/plat-ti/sm_platform_handler_a15.c
+++ b/core/arch/arm/plat-ti/sm_platform_handler_a15.c
@@ -27,29 +27,46 @@
  */
 
 #include <arm32.h>
+#include <kernel/thread.h>
+#include <sm/optee_smc.h>
 #include <sm/sm.h>
+#include <trace.h>
+
 #include "api_monitor_index_a15.h"
 
-enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx)
+static enum sm_handler_ret ti_sip_handler(struct thread_smc_args *smc_args)
 {
-	if (ctx->nsec.r12 == 0x200)
-		return SM_HANDLER_PENDING_SMC;
+	uint16_t sip_func = OPTEE_SMC_FUNC_NUM(smc_args->a0);
 
-	switch (ctx->nsec.r12) {
+	switch (sip_func) {
 	case API_MONITOR_ACTLR_SETREGISTER_INDEX:
-		write_actlr(ctx->nsec.r0);
+		write_actlr(smc_args->a1);
 		isb();
-		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
+		smc_args->a0 = OPTEE_SMC_RETURN_OK;
 		break;
 	case API_MONITOR_TIMER_SETCNTFRQ_INDEX:
-		write_cntfrq(ctx->nsec.r0);
+		write_cntfrq(smc_args->a1);
 		isb();
-		ctx->nsec.r0 = API_HAL_RET_VALUE_OK;
+		smc_args->a0 = OPTEE_SMC_RETURN_OK;
 		break;
 	default:
-		ctx->nsec.r0 = API_HAL_RET_VALUE_SERVICE_UNKNWON;
+		EMSG("Invalid SIP function code: 0x%04"PRIx16, sip_func);
+		smc_args->a0 = OPTEE_SMC_RETURN_EBADCMD;
 		break;
 	}
 
 	return SM_HANDLER_SMC_HANDLED;
+}
+
+enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx)
+{
+	uint32_t *nsec_r0 = (uint32_t *)(&ctx->nsec.r0);
+	uint16_t smc_owner = OPTEE_SMC_OWNER_NUM(*nsec_r0);
+
+	switch (smc_owner) {
+	case OPTEE_SMC_OWNER_SIP:
+		return ti_sip_handler((struct thread_smc_args *)nsec_r0);
+	default:
+		return SM_HANDLER_PENDING_SMC;
+	}
 }


### PR DESCRIPTION
Previously on our TI evil vendor Linux tree we would use a sentinel value
in r12 to signal if a call was meant for OP-TEE or the legacy ROM. A path
to using SMCCC compatible calls from Linux is being implemented.
Switch the OP-TEE side over.

Signed-off-by: Andrew F. Davis <afd@ti.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
