### PR TITLE
plat-ti: Restore non-secure entry address from saved copy in r5

### DIFF
--- a/core/arch/arm/plat-ti/a9_plat_init.S
+++ b/core/arch/arm/plat-ti/a9_plat_init.S
@@ -75,8 +75,6 @@ END_FUNC plat_cpu_reset_early
 LOCAL_FUNC resume_springboard , :
 UNWIND(	.fnstart)
 UNWIND(	.cantunwind)
-	mov	r3, r5
-
 	/* Setup tmp stack */
 	bl	__get_core_pos
 	cmp	r0, #CFG_TEE_CORE_NB_CORE
@@ -100,10 +98,10 @@ unhandled_cpu:
 	bl	sm_pm_cpu_do_resume
 
 after_resume:
-	mov	r4, r3
 	bl	thread_init_per_cpu
 
-	mov	r0, r4
+	/* r5 contains the non-secure entry address (ARMv7 bootarg #0) */
+	mov	r0, r5
 	bl	init_sec_mon
 
 	bl	main_init_gic


### PR DESCRIPTION
When resuming the only value we need to work with a new version of is the
non-secure context as it will have changed since boot. This value is
stored on OP-TEE entry in r5, previously we saved this value by moving
r5 to r3 then r3 to r4 basically just dodging getting overwritten by
functions we call. This can be simplified now as nothing clobbers r5,
so we can use it directly as the source for the non-secure context
pointer feed into init_sec_mon().

Signed-off-by: Andrew F. Davis <afd@ti.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
