### PR TITLE
core: fix generation of tee.bin

### DIFF
--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -334,6 +334,7 @@ SECTIONS
 	__rodata_init_end = .;
 
 	__init_end = ROUNDUP(__rodata_init_end, SMALL_PAGE_SIZE);
+	__get_tee_init_end = __init_end;
 	__init_size = __init_end - __init_start;
 
 	/* vcore flat map stops here. No need to page align, rodata follows. */
@@ -406,6 +407,7 @@ SECTIONS
 
 #ifndef CFG_WITH_PAGER
 	__flatmap_unpg_rw_size = _end_of_ram - __flatmap_unpg_rw_start;
+	__get_tee_init_end = .;
 #endif
 
 	/*

--- a/scripts/gen_tee_bin.py
+++ b/scripts/gen_tee_bin.py
@@ -270,7 +270,7 @@ def output_header_v1(elffile, outf):
     pager_bin_size = len(pager_bin)
     paged_area_size = len(pageable_bin)
 
-    init_mem_usage = (get_symbol(elffile, '__init_end')['st_value'] -
+    init_mem_usage = (get_symbol(elffile, '__get_tee_init_end')['st_value'] -
                       get_symbol(elffile, '__text_start')['st_value'] +
                       len(embdata_bin))
 


### PR DESCRIPTION
Prior to this patch generation of tee.bin (CFG_WITH_PAGER=n) fails with:
  GEN     out/core/tee.bin
Cannot find symbol __init_end
core/arch/arm/kernel/link.mk:183: recipe for target 'out/core/tee.bin' failed

Introduce a special __get_tee_init_end to fix this and also avoid
confusion with __init_end used in the code for the pager case.

Fixes: 5dd1570ac5b0 ("core: add embedded data region")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
