### PR TITLE
core: imx: fix CFG_DRAM_BASE for imx8qm/qxp

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -158,14 +158,14 @@ $(call force,CFG_MX8QM,y)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_IMX_SNVS,n)
 CFG_IMX_LPUART ?= y
-CFG_DRAM_BASE ?= 0x40000000
+CFG_DRAM_BASE ?= 0x80000000
 CFG_TEE_CORE_NB_CORE ?= 6
 $(call force,CFG_NXP_CAAM,n)
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8qx-flavorlist)))
 $(call force,CFG_MX8QX,y)
 $(call force,CFG_ARM64_core,y)
 CFG_IMX_LPUART ?= y
-CFG_DRAM_BASE ?= 0x40000000
+CFG_DRAM_BASE ?= 0x80000000
 CFG_TEE_CORE_NB_CORE ?= 4
 $(call force,CFG_NXP_CAAM,n)
 else


### PR DESCRIPTION
The CFG_DRAM_BASE on imx8qm and imx8qxp is 0x80000000

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
