### PR TITLE
[i.MX CAAM] SGT + Hash Fix

### DIFF
--- a/core/arch/arm/plat-imx/crypto_conf.mk
+++ b/core/arch/arm/plat-imx/crypto_conf.mk
@@ -16,6 +16,7 @@
 # DBG_TRACE_HASH BIT32(8)  // Hash trace
 # DBG_DESC_HASH  BIT32(9)  // Hash dump descriptor
 # DBG_BUF_HASH   BIT32(10) // Hash dump Buffer
+# DBG_TRACE_SGT  BIT32(11) // Scatter Gather trace
 CFG_CAAM_DBG ?= 0x2
 
 #

--- a/core/drivers/crypto/caam/include/caam_common.h
+++ b/core/drivers/crypto/caam/include/caam_common.h
@@ -74,29 +74,26 @@ struct caamdefkey {
  */
 struct caamsgt {
 	/* Word 0 */
-	uint32_t ptr_ms : 8;  /* Address pointer (MS 8 bits) */
-	uint32_t res_w0 : 24; /* Not used */
+	uint32_t ptr_ms;   /* Address pointer (MS 8 LSBs) */
 
 	/* Word 1 */
-	uint32_t ptr_ls;      /* Address pointer (LS 32 bits) */
+	uint32_t ptr_ls;   /* Address pointer (LS 32 bits) */
 
 	/* Word 2 */
-	uint32_t length : 30; /* Length (30 bits) */
-	uint32_t final : 1;   /* Last entry in the table */
-	uint32_t ext : 1;     /* Extension bit (if set, point to sgt table) */
+	uint32_t len_f_e;  /* Length 30bits + 1bit Final + 1bit Extension) */
 
 	/* Word 3 */
-	uint32_t offset : 13; /* Offset in memory buffer */
-	uint32_t res_w3 : 19; /* Not used */
+	uint32_t offset;   /* Offset in memory buffer (13 LSBs) */
 };
 
 /*
  * Data buffer encoded in SGT format
  */
 struct caamsgtbuf {
-	struct cammsgt *sgt; /* SGT Array */
+	struct caamsgt *sgt; /* SGT Array */
 	struct caambuf *buf; /* Buffer Array */
-	uint8_t number;      /* Number of SGT/Buf */
+	unsigned int number; /* Number of SGT/Buf */
+	size_t length;       /* Total length of the data encoded */
 	bool sgt_type;       /* Define the data format */
 };
 

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -137,11 +137,20 @@ static inline void dump_desc(uint32_t *desc)
 
 /*
  * FIFO Load to register dst class cla with action act.
- * Pointer is a Scatter/Gatter Table
+ * Pointer is a Scatter/Gather Table
  */
 #define FIFO_LD_SGT(cla, dst, act, len)                                        \
 	(CMD_FIFO_LOAD_TYPE | CMD_CLASS(cla) | CMD_SGT |                       \
 	 FIFO_LOAD_INPUT(dst) | FIFO_LOAD_ACTION(act) | FIFO_LOAD_LENGTH(len))
+
+/*
+ * FIFO Load to register dst class cla with action act.
+ * Pointer is a Scatter/Gather Table
+ * The length is externally defined
+ */
+#define FIFO_LD_SGT_EXT(cla, dst, act)                                         \
+	(CMD_FIFO_LOAD_TYPE | CMD_CLASS(cla) | CMD_SGT | FIFO_LOAD_EXT |       \
+	 FIFO_LOAD_INPUT(dst) | FIFO_LOAD_ACTION(act))
 
 /*
  * FIFO Load to register dst class cla with action act.
@@ -166,6 +175,14 @@ static inline void dump_desc(uint32_t *desc)
 	(CMD_STORE_TYPE | CMD_CLASS(cla) | STORE_SRC(src) | STORE_LENGTH(len))
 
 /*
+ * Store value of length len from register src of class cla
+ * Pointer is a Scatter/Gather Table
+ */
+#define ST_SGT_NOIMM(cla, src, len)                                            \
+	(CMD_STORE_TYPE | CMD_CLASS(cla) | CMD_SGT | STORE_SRC(src) |          \
+	 STORE_LENGTH(len))
+
+/*
  * Store value of length len from register src of class cla starting
  * at register offset off
  */
@@ -184,15 +201,24 @@ static inline void dump_desc(uint32_t *desc)
  * The length is externally defined
  */
 #define FIFO_ST_EXT(src)                                                       \
-	(CMD_FIFO_STORE_TYPE | FIFO_LOAD_EXT | FIFO_STORE_OUTPUT(src))
+	(CMD_FIFO_STORE_TYPE | FIFO_STORE_EXT | FIFO_STORE_OUTPUT(src))
 
 /*
  * FIFO Store from register src of length len.
- * Pointer is a Scatter/Gatter Table
+ * Pointer is a Scatter/Gather Table
  */
 #define FIFO_ST_SGT(src, len)                                                  \
 	(CMD_FIFO_STORE_TYPE | CMD_SGT | FIFO_STORE_OUTPUT(src) |              \
 	 FIFO_STORE_LENGTH(len))
+
+/*
+ * FIFO Store from register src.
+ * Pointer is a Scatter/Gather Table
+ * The length is externally defined
+ */
+#define FIFO_ST_SGT_EXT(src)                                                   \
+	(CMD_FIFO_STORE_TYPE | CMD_SGT | FIFO_STORE_EXT |                      \
+	 FIFO_STORE_OUTPUT(src))
 
 /*
  * RNG State Handle instantation operation for sh ID

--- a/core/drivers/crypto/caam/include/caam_trace.h
+++ b/core/drivers/crypto/caam/include/caam_trace.h
@@ -28,6 +28,7 @@
 #define DBG_TRACE_HASH   BIT32(8)  /* Hash trace */
 #define DBG_DESC_HASH    BIT32(9)  /* Hash dump descriptor */
 #define DBG_BUF_HASH     BIT32(10) /* Hash dump Buffer */
+#define DBG_TRACE_SGT    BIT32(11) /* Scatter Gather trace */
 
 /* HAL */
 #if (CFG_CAAM_DBG & DBG_TRACE_HAL)
@@ -48,6 +49,13 @@
 #define MEM_TRACE DRV_TRACE
 #else
 #define MEM_TRACE(...)
+#endif
+
+/* Scatter Gether Table */
+#if (CFG_CAAM_DBG & DBG_TRACE_SGT)
+#define SGT_TRACE DRV_TRACE
+#else
+#define SGT_TRACE(...)
 #endif
 
 /* Power */

--- a/core/drivers/crypto/caam/include/caam_utils_mem.h
+++ b/core/drivers/crypto/caam/include/caam_utils_mem.h
@@ -118,4 +118,25 @@ int caam_set_or_alloc_align_buf(void *orig, struct caambuf *dst, size_t size);
 enum caam_status caam_cpy_block_src(struct caamblock *block,
 				    struct caambuf *src, size_t offset);
 
+/*
+ * Return the number of Physical Areas used by the buffer @buf.
+ * If @pabufs is not NULL, function fills it with the Physical Areas used
+ * to map the buffer @buf.
+ *
+ * @buf         Data buffer to analyze
+ * @pabufs[out] If not NULL, list the Physical Areas of the @buf
+ *
+ * Returns:
+ * Number of physical area used
+ * (-1) if error
+ */
+int caam_mem_get_pa_area(struct caambuf *buf, struct caambuf **pabufs);
+
+/*
+ * Return if the buffer @buf is cacheable or not
+ *
+ * @buf  Buffer address
+ * @size Buffer size
+ */
+bool caam_mem_is_cached_buf(void *buf, size_t size);
 #endif /* __CAAM_UTILS_MEM_H__ */

--- a/core/drivers/crypto/caam/include/caam_utils_sgt.h
+++ b/core/drivers/crypto/caam/include/caam_utils_sgt.h
@@ -16,6 +16,41 @@
  * @op     Cache operation
  * @insgt  SGT table
  */
-void caam_cache_op_sgt(enum utee_cache_operation op, struct caamsgtbuf *insgt);
+void caam_sgt_cache_op(enum utee_cache_operation op, struct caamsgtbuf *insgt);
+
+/*
+ * Set a Scatter Gather Table Entry
+ *
+ * @sgt      SGT entry
+ * @paddr    Data's physical address
+ * @len      Data's length
+ * @offset   Offset to start in data buffer
+ * @final_e  Final entry in the table if true
+ * @ext_e    Entry is a SGT table extension
+ */
+void caam_sgt_set_entry(struct caamsgt *sgt, vaddr_t paddr, size_t len,
+			unsigned int offset, bool final_e, bool ext_e);
+
+#define CAAM_SGT_ENTRY(sgt, paddr, len)                                        \
+	caam_sgt_set_entry(sgt, paddr, len, 0, false, false)
+#define CAAM_SGT_ENTRY_FINAL(sgt, paddr, len)                                  \
+	caam_sgt_set_entry(sgt, paddr, len, 0, true, false)
+#define CAAM_SGT_ENTRY_EXT(sgt, paddr, len)                                    \
+	caam_sgt_set_entry(sgt, paddr, len, 0, false, true)
+
+/*
+ * Build a SGT object with @block and @data buffer.
+ * If @block is not null, create a SGT with block buffer as first SGT entry
+ * and then the @data.
+ * If the @data buffer is a User buffer mapped on multiple Small Page,
+ * convert it in SGT entries corresponding to physical Small Page.
+ *
+ * @sgtbuf [out] SGT object built
+ * @block  If not NULL, data block to be handled first
+ * @data   Operation data
+ */
+enum caam_status caam_sgt_build_block_data(struct caamsgtbuf *sgtbuf,
+					   struct caamblock *block,
+					   struct caambuf *data);
 
 #endif /* __CAAM_UTILS_SGT_H__ */

--- a/core/drivers/crypto/caam/utils/utils_sgt.c
+++ b/core/drivers/crypto/caam/utils/utils_sgt.c
@@ -5,10 +5,20 @@
  * Brief   Scatter-Gatter Table management utilities.
  */
 #include <caam_common.h>
+#include <caam_io.h>
+#include <caam_utils_mem.h>
 #include <caam_utils_sgt.h>
+#include <caam_trace.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
 #include <tee/cache.h>
+#include <util.h>
 
-void caam_cache_op_sgt(enum utee_cache_operation op, struct caamsgtbuf *insgt)
+#define ENTRY_LEN(len)	((len) & GENMASK_32(29, 0))
+#define BS_ENTRY_EXT	BIT32(31)
+#define BS_ENTRY_FINAL	BIT32(30)
+
+void caam_sgt_cache_op(enum utee_cache_operation op, struct caamsgtbuf *insgt)
 {
 	unsigned int idx = 0;
 
@@ -16,7 +26,153 @@ void caam_cache_op_sgt(enum utee_cache_operation op, struct caamsgtbuf *insgt)
 			insgt->number * sizeof(struct caamsgt));
 	for (idx = 0; idx < insgt->number; idx++) {
 		if (!insgt->buf[idx].nocache)
-			cache_operation(op, (void *)(insgt->buf[idx].data),
+			cache_operation(op, (void *)insgt->buf[idx].data,
 					insgt->buf[idx].length);
 	}
+}
+
+void caam_sgt_set_entry(struct caamsgt *sgt, paddr_t paddr, size_t len,
+			unsigned int offset, bool final_e, bool ext_e)
+{
+	unsigned int len_f_e = 0;
+
+	caam_write_val32(&sgt->ptr_ls, paddr);
+#ifdef CFG_CAAM_64BIT
+	caam_write_val32(&sgt->ptr_ms, paddr >> 32);
+#else
+	caam_write_val32(&sgt->ptr_ms, 0);
+#endif
+
+	len_f_e = ENTRY_LEN(len);
+	if (final_e)
+		len_f_e |= BS_ENTRY_FINAL;
+	else if (ext_e)
+		len_f_e |= BS_ENTRY_EXT;
+
+	caam_write_val32(&sgt->len_f_e, len_f_e);
+	caam_write_val32(&sgt->offset, offset);
+}
+
+static void caam_sgt_fill_table(struct caambuf *buf, struct caamsgtbuf *sgt,
+				int start_idx, int nb_pa)
+{
+	int idx = 0;
+
+	SGT_TRACE("Create %d SGT entries", nb_pa);
+
+	for (idx = 0; idx < nb_pa; idx++) {
+		sgt->buf[idx + start_idx].data = buf[idx].data;
+		sgt->buf[idx + start_idx].length = buf[idx].length;
+		sgt->buf[idx + start_idx].paddr = buf[idx].paddr;
+		sgt->buf[idx + start_idx].nocache = buf[idx].nocache;
+		sgt->length += buf[idx].length;
+		if (idx < nb_pa - 1)
+			CAAM_SGT_ENTRY(&sgt->sgt[idx + start_idx],
+				       sgt->buf[idx + start_idx].paddr,
+				       sgt->buf[idx + start_idx].length);
+		else
+			CAAM_SGT_ENTRY_FINAL(&sgt->sgt[idx + start_idx],
+					     sgt->buf[idx + start_idx].paddr,
+					     sgt->buf[idx + start_idx].length);
+
+		SGT_TRACE("SGT[%d]->data   = %p", idx + start_idx,
+			  sgt->buf[idx + start_idx].data);
+		SGT_TRACE("SGT[%d]->length = %zu", idx + start_idx,
+			  sgt->buf[idx + start_idx].length);
+		SGT_TRACE("SGT[%d]->paddr  = 0x%" PRIxPA, idx + start_idx,
+			  sgt->buf[idx + start_idx].paddr);
+		SGT_TRACE("SGT[%d]->ptr_ms   = %" PRIx32, idx + start_idx,
+			  sgt->sgt[idx + start_idx].ptr_ms);
+		SGT_TRACE("SGT[%d]->ptr_ls   = %" PRIx32, idx + start_idx,
+			  sgt->sgt[idx + start_idx].ptr_ls);
+		SGT_TRACE("SGT[%d]->len_f_e  = %" PRIx32, idx + start_idx,
+			  sgt->sgt[idx + start_idx].len_f_e);
+		SGT_TRACE("SGT[%d]->offset   = %" PRIx32, idx + start_idx,
+			  sgt->sgt[idx + start_idx].offset);
+	}
+}
+
+enum caam_status caam_sgt_build_block_data(struct caamsgtbuf *sgtbuf,
+					   struct caamblock *block,
+					   struct caambuf *data)
+{
+	enum caam_status retstatus = CAAM_FAILURE;
+	int nb_pa_area = 0;
+	unsigned int sgtidx = 0;
+	struct caambuf *pabufs = NULL;
+
+	/* Get the number of physical pages used by the input buffer @data */
+	nb_pa_area = caam_mem_get_pa_area(data, &pabufs);
+	if (nb_pa_area == -1)
+		return CAAM_FAILURE;
+
+	/*
+	 * If caller provided a block buffer reference, we need a SGT object
+	 * with a minimum of 2 entries. Moreover, if the data is mapped
+	 * on non-contiguous physical pages, we need a SGT object with
+	 * the number of physical pages + one entry for the block buffer.
+	 *
+	 * If caller provided a block buffer reference and data is mapped
+	 * on non-contiguous physical pages, a SGT object of the
+	 * number of physical page is needed.
+	 *
+	 * Otherwise no SGT object is needed.
+	 */
+	if (nb_pa_area > 1)
+		sgtbuf->number = nb_pa_area;
+
+	if (block) {
+		if (nb_pa_area > 1)
+			sgtbuf->number += 1;
+		else
+			sgtbuf->number = 2;
+	}
+
+	if (sgtbuf->number) {
+		sgtbuf->sgt_type = true;
+		sgtbuf->length = 0;
+
+		SGT_TRACE("Allocate %d SGT entries", sgtbuf->number);
+		retstatus = caam_sgtbuf_alloc(sgtbuf);
+
+		if (retstatus != CAAM_NO_ERROR)
+			goto exit_build_block;
+
+		/*
+		 * The first entry to create in the SGT is the
+		 * block buffer if provided.
+		 */
+		if (block) {
+			sgtbuf->buf[0].data = block->buf.data;
+			sgtbuf->buf[0].length = block->filled;
+			sgtbuf->buf[0].paddr = block->buf.paddr;
+			sgtbuf->buf[0].nocache = block->buf.nocache;
+			sgtbuf->length = sgtbuf->buf[0].length;
+
+			CAAM_SGT_ENTRY(&sgtbuf->sgt[0], sgtbuf->buf[0].paddr,
+				       sgtbuf->buf[0].length);
+
+			sgtidx++;
+		}
+
+		/* Add the data in the SGT table */
+		caam_sgt_fill_table(pabufs, sgtbuf, sgtidx, nb_pa_area);
+	} else {
+		/*
+		 * Only the data buffer is to be used and it's not
+		 * split on User Pages
+		 */
+		sgtbuf->sgt_type = false;
+		sgtbuf->number = 1;
+		sgtbuf->buf = data;
+		sgtbuf->length = data->length;
+	}
+
+	retstatus = CAAM_NO_ERROR;
+
+exit_build_block:
+	if (pabufs)
+		caam_free(pabufs);
+
+	return retstatus;
 }


### PR DESCRIPTION
Hi everyone,

This PR introduces the scatter gather for CAAM driver. CAAM uses DMA to load/store data in memory. In case of a user buffer, if the buffer is crossing multiple Small Page, a CAAM Scatter Gather Table needs to be created to rebuild the physical memory chunks used by the User virtual buffer.

This PR also add the use of SGT for the Hash driver.

Thanks!