### PR TITLE
shippable: generate deprecated v1 images

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -34,7 +34,7 @@ build:
     - _make CFG_CRYPTO_{H,C,CBC_}MAC=n
     - _make CFG_CRYPTO_{G,C}CM=n
     - _make CFG_CRYPTO_{MD5,SHA{1,224,256,384,512,512_256}}=n
-    - _make CFG_WITH_PAGER=y
+    - _make CFG_WITH_PAGER=y out/core/tee{,-pager,-pageable}.bin
     - _make CFG_WITH_PAGER=y CFG_CRYPTOLIB_NAME=mbedtls CFG_CRYPTOLIB_DIR=lib/libmbedtls
     - _make CFG_WITH_PAGER=y CFG_WITH_LPAE=y
     - _make CFG_WITH_LPAE=y CFG_CORE_ASLR=y
@@ -94,7 +94,7 @@ build:
     - _make PLATFORM=k3-j721e CFG_ARM64_core=y
     - _make PLATFORM=k3-am65x
     - _make PLATFORM=k3-am65x CFG_ARM64_core=y
-    - _make PLATFORM=ti-dra7xx
+    - _make PLATFORM=ti-dra7xx out/core/tee{,-pager,-pageable}.bin
     - _make PLATFORM=ti-am57xx
     - _make PLATFORM=ti-am43xx
     - _make PLATFORM=sprd-sc9860


### PR DESCRIPTION
Modifies two targets to also generate the deprecated v1 images.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
