### PR TITLE
arm: kernel: generic: reserved-memory overlay properties

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -775,6 +775,8 @@ static int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
 	int len_size = -1;
 	bool found = true;
 	char subnode_name[80] = { 0 };
+	const fdt32_t *c;
+	int len;
 
 	offs = fdt_path_offset(dt->blob, "/reserved-memory");
 
@@ -783,12 +785,23 @@ static int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
 		offs = 0;
 	}
 
-	len_size = fdt_size_cells(dt->blob, offs);
-	if (len_size < 0)
-		return -1;
-	addr_size = fdt_address_cells(dt->blob, offs);
-	if (addr_size < 0)
-		return -1;
+	c = fdt_getprop(dt->blob, offs, "#size-cells", &len);
+	if (!c) {
+		len_size = sizeof(paddr_t) / sizeof(uint32_t);
+	} else {
+		len_size = fdt_size_cells(dt->blob, offs);
+		if (len_size < 0)
+			return -1;
+	}
+
+	c = fdt_getprop(dt->blob, offs, "#address-cells", &len);
+	if (!c) {
+		addr_size = sizeof(paddr_t) / sizeof(uint32_t);
+	} else {
+		addr_size = fdt_address_cells(dt->blob, offs);
+		if (addr_size < 0)
+			return -1;
+	}
 
 	if (!found) {
 		offs = add_dt_path_subnode(dt, "/", "reserved-memory");


### PR DESCRIPTION
When CFG_EXTERNAL_DTB_OVERLAY is enabled, OP-TEE is capable of
appending but also generating new overlays containing psci and
reserved-memory fragments.
Appending occurs when OP-TEE is provided a DTB overlay at CFG_DT_ADDR
or passed in arg2. Otherwise it defaults to generation.

Currently the reserved-memory fragments on any newly generated overlay
defaults the node's #address-cells and #size-cells to 2 (ie 64 bit
fields for address and size)

Systems running on 32 bits do not need 64 bit addresses; therefore on
such systems (arm) an overlay that describes reserved-memory fragments
using 64 bit addresses would not be correct (certainly is not
standard, not sure if there can be some weird scenario that justifies
this).

Make the default settings for these properties configurable via CFG_
so those values can be overloaded.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
