### PR TITLE
Allow the platform to add drivers to the dts/overlay for TEE exclusive access

### DIFF
--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -57,6 +57,7 @@ void generic_boot_init_secondary(unsigned long nsec_entry);
 void main_init_gic(void);
 void main_secondary_init_gic(void);
 
+const char *main_get_optee_exclusive_node_name(unsigned int i);
 void init_sec_mon(unsigned long nsec_entry);
 void init_tee_runtime(void);
 

--- a/lib/libutils/isoc/include/string.h
+++ b/lib/libutils/isoc/include/string.h
@@ -30,6 +30,7 @@ char *strstr(const char *big, const char *little);
 char *strcpy(char *dest, const char *src);
 char *strncpy(char *dest, const char *src, size_t n);
 char *strrchr(const char *s, int i);
+char *strtok(char *str, const char *delims);
 
 void *memchr(const void *buf, int c, size_t length);
 

--- a/lib/libutils/isoc/strtok.c
+++ b/lib/libutils/isoc/strtok.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-2-Clause
+#include <stdlib.h>
+#include <string.h>
+
+char *strtok(char *str, const char *delims)
+{
+	static char *pos = NULL;
+	char *start = NULL;
+
+	if (str)
+		pos = str;
+
+	if (pos) {
+		while (*pos && strchr(delims, *pos)) {
+                    pos++;
+		}
+
+		if (*pos) {
+			start = pos;
+			while (*pos && !strchr(delims, *pos)) {
+				pos++;
+			}
+
+			if (*pos)
+				*pos++ = '\0';
+		}
+	}
+
+	return start;
+}

--- a/lib/libutils/isoc/sub.mk
+++ b/lib/libutils/isoc/sub.mk
@@ -15,6 +15,7 @@ srcs-y += snprintf.c
 srcs-y += stack_check.c
 srcs-y += strdup.c
 srcs-y += strndup.c
+srcs-y += strtok.c
 srcs-y += tolower.c
 srcs-y += isalpha.c
 srcs-y += isspace.c


### PR DESCRIPTION
Drivers defined in the platform specific main.c module will be added
to the dts and to the generated overlay (if overlay generation is
requested)

In order to do that, the platforms need to define an interface in
their main.c module through which the generic code can retrieve the
driver names.

An example for such an interface can be seen below:

```
const char *main_get_optee_exclusive_node_name(unsigned int i)
{
	static const char *exclusive_drivers[] = {
		"/ahb-bridge0@40000000/wdog@403D0000",
		NULL,
	};

	if (i < ARRAY_SIZE(exclusive_drivers))
		return exclusive_drivers[i];

	return NULL;
}
```

