### PR TITLE
mk/compile.mk: add cc-option macro

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -17,6 +17,15 @@ objs		:=
 # Disable all builtin rules
 .SUFFIXES:
 
+__cc-option = $(if $(shell $(CC$(sm)) $(1) -c -x c /dev/null -o /dev/null 2>&1 >/dev/null),$(2),$(1))
+_cc-opt-cached-var-name = cached-cc-option$(subst =,~,$(strip $(1)))$(subst $(empty) $(empty),,$(CC$(sm)))
+define _cc-option
+$(eval _cached := $(call _cc-opt-cached-var-name,$1))
+$(eval $(_cached) := $(if $(filter $(origin $(_cached)),undefined),$(call __cc-option,$(1),$(2)),$($(_cached))))
+$($(_cached))
+endef
+cc-option = $(strip $(call _cc-option,$(1),$(2)))
+
 comp-cflags$(sm) = -std=gnu99
 comp-aflags$(sm) =
 comp-cppflags$(sm) =


### PR DESCRIPTION
Adds a macro to test the availability of a compiler option. For example:

 $(call cc-option,-opt1,-opt2)

...will evaluate to '-opt1' if the C compiler supports option -opt1, or
'-opt2' otherwise. The second argument (-opt2) is optional.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
