### PR TITLE
core: crypto: sm3: remove unused header

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -26,6 +26,7 @@ build:
     - _make CFG_TEE_CORE_MALLOC_DEBUG=y
     - _make CFG_CORE_SANITIZE_UNDEFINED=y
     - _make CFG_CORE_SANITIZE_KADDRESS=y
+    - _make CFG_CORE_MBEDTLS_MPI=n
     - _make CFG_LOCKDEP=y
     - _make CFG_CRYPTO=n
     - _make CFG_CRYPTO_{AES,DES}=n

--- a/core/crypto/sm3-hmac.c
+++ b/core/crypto/sm3-hmac.c
@@ -9,7 +9,6 @@
 #include <crypto/crypto.h>
 #include <crypto/crypto_impl.h>
 #include <kernel/panic.h>
-#include <mbedtls/md.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string_ext.h>


### PR DESCRIPTION
Remove unused mbedtls/md.h header file to fix error:

 core/crypto/sm3-hmac.c:12:10: fatal error: mbedtls/md.h: No such file or directory

when building with CFG_CORE_MBEDTLS_MPI=n. To prevent future similar
regression, also add a test case to Shippable.

Fixes: https://github.com/OP-TEE/optee_os/issues/3487
Fixes: 47645577c806 ("core: crypto: add support for SM3")
Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
