### PR TITLE
ci: shippable: remove CCACHE_UNIFY=true

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -13,7 +13,7 @@ build:
     - export PATH=/usr/local/bin:$PATH  # clang
     - export CROSS_COMPILE32="ccache arm-linux-gnueabihf-"
     - export CROSS_COMPILE64="ccache aarch64-linux-gnu-"
-    - export CFG_DEBUG_INFO=n; export CCACHE_UNIFY=true
+    - export CFG_DEBUG_INFO=n
     - export CFG_WERROR=y
     - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && ccache -s && ccache -z; }
     - ccache -z


### PR DESCRIPTION
The ccache unify mode does not increase cache hits in the Shippable
build, contrary to what is claimed in commit a2a52e198719 ("ci:
shippable: enable ccache's 'unify' option"). Disable this mode,
because it is slower than the default mode [1] and might cause
corrupted builds [2].

Unify mode was enabled in the above commit, but that commit also set
CFG_DEBUG_INFO=n. It was in fact this configuration flag that allowed
better caching, by preventing -g3 from being added to the C flags.
With -g3, the preprocessor output contains all the macro definitions
(such as the configuration variables from config.h). Without it (or
with -g), those defines are not visible after the preprocessing stage
and therefore adding defines that do not change the actual code has no
impact and cached objects can be re-used.

 $ echo '#define FOO 1' | gcc -x c -E - | grep '#define FOO 1'
 $ echo '#define FOO 1' | gcc -x c -g3 -E - | grep '#define FOO 1'
 #define FOO 1

 [1] ccache(1) man page
 [2] .incbin directive bug: https://github.com/ccache/ccache/issues/497

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
