### PR TITLE
Enhancements for ARMv8 crypto extensions specific to AES-CTR mode [v2]

### DIFF
--- a/core/lib/libtomcrypt/src/ciphers/aes/aes_modes_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes/aes_modes_armv8a_ce_a64.S
@@ -485,8 +485,7 @@ ENTRY(ce_aes_ctr_encrypt)
 
 .Lctrtailblock:
 	st1             {v0.16b}, [x0]
-	ldp             x29, x30, [sp], #16
-	ret
+	b		.Lctrout
 
 .Lctrcarry:
 	umov            x7, v4.d[0]             /* load upper word of ctr  */

--- a/core/lib/libtomcrypt/src/ciphers/aes/aes_modes_armv8a_ce_a64.S
+++ b/core/lib/libtomcrypt/src/ciphers/aes/aes_modes_armv8a_ce_a64.S
@@ -413,14 +413,15 @@ ENDPROC(ce_aes_cbc_decrypt)
 
 	/*
 	 * aes_ctr_encrypt(u8 out[], u8 const in[], u8 const rk[], int rounds,
-	 *		   int blocks, u8 ctr[], int first)
+	 *		   int blocks, u8 ctr[], int ctrlen, int first)
 	 */
 
 ENTRY(ce_aes_ctr_encrypt)
 	stp             x29, x30, [sp, #-16]!
 	mov             x29, sp
 
-	enc_prepare     w3, x2, x6
+	enc_prepare     w3, x2, x7
+	mov             x9, x6                  /* save ctrlen */
 	ld1             {v4.16b}, [x5]
 
 	umov            x6, v4.d[1]             /* keep swabbed ctr in reg */
@@ -466,6 +467,7 @@ ENTRY(ce_aes_ctr_encrypt)
 	adds            x6, x6, #1              /* increment BE ctr */
 	rev             x7, x6
 	ins             v4.d[1], x7
+	cbnz            x9, .Lctrcarrydone      /* ignore overflow 64-bit ctr */
 	bcs             .Lctrcarry              /* overflow? */
 
 .Lctrcarrydone:

--- a/core/lib/libtomcrypt/src/headers/tomcrypt_cipher.h
+++ b/core/lib/libtomcrypt/src/headers/tomcrypt_cipher.h
@@ -466,11 +466,15 @@ extern const struct ltc_cipher_descriptor {
        @param ct      Ciphertext
        @param blocks  The number of complete blocks to process
        @param IV      The initial value (input/output)
+       @param IV_size The initial value size identifier. Following is mode
+                      specific identifier mapping:
+                      - LE mode (normal): 0: NULL, ..., 8: 8 bytes, ..., 16: 16 bytes
+                      - BE mode (reverse): 0: 16 bytes, ..., 8: 8 bytes, ..., 16: NULL
        @param mode    little or big endian counter (mode=0 or mode=1)
        @param skey    The scheduled key context
        @return CRYPT_OK if successful
    */
-   int (*accel_ctr_encrypt)(const unsigned char *pt, unsigned char *ct, unsigned long blocks, unsigned char *IV, int mode, symmetric_key *skey);
+   int (*accel_ctr_encrypt)(const unsigned char *pt, unsigned char *ct, unsigned long blocks, unsigned char *IV, int IV_size, int mode, symmetric_key *skey);
 
    /** Accelerated LRW
        @param pt      Plaintext

--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
@@ -118,7 +118,8 @@ int ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned long len, s
    if (cipher_descriptor[ctr->cipher]->accel_ctr_encrypt != NULL ) {
      /* handle acceleration only if not in the middle of a block, accelerator is present and length is >= a block size */
      if ((ctr->padlen == 0 || ctr->padlen == ctr->blocklen) && len >= (unsigned long)ctr->blocklen) {
-       if ((err = cipher_descriptor[ctr->cipher]->accel_ctr_encrypt(pt, ct, len/ctr->blocklen, ctr->ctr, ctr->mode, &ctr->key)) != CRYPT_OK) {
+       if ((err = cipher_descriptor[ctr->cipher]->accel_ctr_encrypt(pt, ct, len/ctr->blocklen, ctr->ctr,
+           ctr->ctrlen, ctr->mode, &ctr->key)) != CRYPT_OK) {
          return err;
        }
        pt += (len / ctr->blocklen) * ctr->blocklen;


### PR DESCRIPTION
Enhancements:

- arm64: CE: AES-CTR: Add support for 64 bit IV
- arm64: CE: AES-CTR: update IV after partial final CTR block