### PR TITLE
core: ltc: add implementations for .addmod and .submod

### DIFF
--- a/core/lib/libtomcrypt/mpa_desc.c
+++ b/core/lib/libtomcrypt/mpa_desc.c
@@ -457,6 +457,26 @@ static int mod(void *a, void *b, void *c)
 	return CRYPT_OK;
 }
 
+static int addmod(void *a, void *b, void *c, void *d)
+{
+	int res = add(a, b, d);
+
+	if (res != CRYPT_OK)
+		return res;
+
+	return mod(d, c, d);
+}
+
+static int submod(void *a, void *b, void *c, void *d)
+{
+	int res = sub(a, b, d);
+
+	if (res != CRYPT_OK)
+		return res;
+
+	return mod(d, c, d);
+}
+
 static int mulmod(void *a, void *b, void *c, void *d)
 {
 	LTC_ARGCHK(a != NULL);
@@ -713,6 +733,8 @@ ltc_math_descriptor ltc_mp = {
 	.rsa_keygen = &rsa_make_key,
 	.rsa_me = &rsa_exptmod,
 #endif
+	.addmod = addmod,
+	.submod = submod,
 	.rand = &mpa_rand,
 
 };

--- a/core/lib/libtomcrypt/mpi_desc.c
+++ b/core/lib/libtomcrypt/mpi_desc.c
@@ -428,6 +428,26 @@ static int mod(void *a, void *b, void *c)
 	return CRYPT_OK;
 }
 
+static int addmod(void *a, void *b, void *c, void *d)
+{
+	int res = add(a, b, d);
+
+	if (res)
+		return res;
+
+	return mod(d, c, d);
+}
+
+static int submod(void *a, void *b, void *c, void *d)
+{
+	int res = sub(a, b, d);
+
+	if (res)
+		return res;
+
+	return mod(d, c, d);
+}
+
 static int mulmod(void *a, void *b, void *c, void *d)
 {
 	int res;
@@ -681,6 +701,8 @@ ltc_math_descriptor ltc_mp = {
 	.rsa_keygen = &rsa_make_key,
 	.rsa_me = &rsa_exptmod,
 #endif
+	.addmod = addmod,
+	.submod = submod,
 	.rand = &mpa_rand,
 
 };


### PR DESCRIPTION
Adds the addmod() and subkod() functions which will be useful for
Elliptic Curve Cryptography (they are used by ltc_ecc_is_point()).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
