### PR TITLE
GitHub: use GitHub actions to close stale issues and PRs

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -1,0 +1,15 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "15 00 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'
+        days-before-stale: 30
+        days-before-close: 5

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,0 +1,15 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+  - cron: "16 00 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 5 days. Note, that you can always re-open a closed pull request at any time.'
+        days-before-stale: 30
+        days-before-close: 5


### PR DESCRIPTION
It's not uncommon that people ask questions or send pull requests that
becomes stale for various reasons. Some examples can be:
 - Original Poster (OP) doesn't close the ticket.
 - OP doesn't get back when maintainers asked for more information.
 - OP gets busy with other things and have to put the work a side.

Having lots of open issues and pull request makes it almost impossible
to figure out where help and input is needed, since things simply
becomes overwhelming. By using GitHub actions [1] we enable a tool that
can:
  - Automatically close issues that no one cares about.
  - Help us bring attention back to issues that are of importance.
  - Push patch creators to not drop their proposed patches.
  - Remind maintainers and other OP-TEE users that reviews are needed.

This patch set propose actions that will warn after 30 days of no
activity, together with that warning the GitHub bot will add a "stale"
label. If that label isn't removed within 5 days, then the GitHub bot
will close the issue or pull request.

People who are admins in the OP-TEE project can remove the label by
themselves, other people have to add a comment telling that their issue
is still relevant and that they would like to have the stale label
removed.

When we first enable this, hundreds of issues and pull requests will be
affected, but after a first round the list of open issues and pull
request should be much smaller and should only contain things that are
or relevance to continue working with.

[1] https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-github-actions

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>