### PR TITLE
fix bugs in dynamic shared ddr support

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -100,6 +100,7 @@
  * MEM_AREA_RAM_SEC:  Secure RAM storing some secrets
  * MEM_AREA_IO_NSEC:  NonSecure HW mapped registers
  * MEM_AREA_IO_SEC:   Secure HW mapped registers
+ * MEM_AREA_EXT_DT:   Memory loads external device tree
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_SHM_VASPACE: Virtual memory space for dynamic shared memory buffers
  * MEM_AREA_TA_VASPACE: TA va space, only used with phys_to_virt()
@@ -123,6 +124,7 @@ enum teecore_memtypes {
 	MEM_AREA_RAM_SEC,
 	MEM_AREA_IO_NSEC,
 	MEM_AREA_IO_SEC,
+	MEM_AREA_EXT_DT,
 	MEM_AREA_RES_VASPACE,
 	MEM_AREA_SHM_VASPACE,
 	MEM_AREA_TA_VASPACE,
@@ -151,6 +153,7 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 		[MEM_AREA_RAM_SEC] = "RAM_SEC",
 		[MEM_AREA_IO_NSEC] = "IO_NSEC",
 		[MEM_AREA_IO_SEC] = "IO_SEC",
+		[MEM_AREA_EXT_DT] = "EXT_DT",
 		[MEM_AREA_RES_VASPACE] = "RES_VASPACE",
 		[MEM_AREA_SHM_VASPACE] = "SHM_VASPACE",
 		[MEM_AREA_TA_VASPACE] = "TA_VASPACE",

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -999,10 +999,10 @@ static void init_external_dt(unsigned long phys_dt)
 		return;
 	}
 
-	if (!core_mmu_add_mapping(MEM_AREA_IO_NSEC, phys_dt, CFG_DTB_MAX_SIZE))
+	if (!core_mmu_add_mapping(MEM_AREA_EXT_DT, phys_dt, CFG_DTB_MAX_SIZE))
 		panic("Failed to map external DTB");
 
-	fdt = phys_to_virt(phys_dt, MEM_AREA_IO_NSEC);
+	fdt = phys_to_virt(phys_dt, MEM_AREA_EXT_DT);
 	if (!fdt)
 		panic();
 

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -381,7 +381,7 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 	for (map = static_memory_map; core_mmap_is_end_of_table(map); map++) {
 		if (map->type == MEM_AREA_NSEC_SHM)
 			carve_out_phys_mem(&m, &num_elems, map->pa, map->size);
-		else
+		else if (map->type != MEM_AREA_EXT_DT)
 			check_phys_mem_is_outside(m, num_elems, map);
 	}
 
@@ -664,6 +664,7 @@ uint32_t core_mmu_type_to_attr(enum teecore_memtypes t)
 		return attr | TEE_MATTR_SECURE | TEE_MATTR_PRW | cached;
 	case MEM_AREA_NSEC_SHM:
 		return attr | TEE_MATTR_PRW | cached;
+	case MEM_AREA_EXT_DT:
 	case MEM_AREA_IO_NSEC:
 		return attr | TEE_MATTR_PRW | noncache;
 	case MEM_AREA_IO_SEC:
@@ -1166,6 +1167,7 @@ static void check_mem_map(struct tee_mmap_region *map)
 		case MEM_AREA_TEE_ASAN:
 		case MEM_AREA_IO_SEC:
 		case MEM_AREA_IO_NSEC:
+		case MEM_AREA_EXT_DT:
 		case MEM_AREA_RAM_SEC:
 		case MEM_AREA_RAM_NSEC:
 		case MEM_AREA_RES_VASPACE:

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -378,7 +378,7 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 		carve_out_phys_mem(&m, &num_elems, pmem->addr, pmem->size);
 #endif
 
-	for (map = static_memory_map; core_mmap_is_end_of_table(map); map++) {
+	for (map = static_memory_map; !core_mmap_is_end_of_table(map); map++) {
 		if (map->type == MEM_AREA_NSEC_SHM)
 			carve_out_phys_mem(&m, &num_elems, map->pa, map->size);
 		else if (map->type != MEM_AREA_EXT_DT)

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -301,6 +301,7 @@ static void carve_out_phys_mem(struct core_mmu_phys_mem **mem, size_t *nelems,
 		*mem = m;
 	} else if (pa == m[n].addr) {
 		m[n].addr += size;
+		m[n].size -= size;
 	} else if ((pa + size) == (m[n].addr + m[n].size)) {
 		m[n].size -= size;
 	} else {

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1277,9 +1277,11 @@ bool core_pbuf_is(uint32_t attr, paddr_t pbuf, size_t len)
 	case CORE_MEM_TA_RAM:
 		return core_is_buffer_inside(pbuf, len, TA_RAM_START,
 							TA_RAM_SIZE);
+#ifdef CFG_CORE_RESERVED_SHM
 	case CORE_MEM_NSEC_SHM:
 		return core_is_buffer_inside(pbuf, len, TEE_SHMEM_START,
 							TEE_SHMEM_SIZE);
+#endif
 	case CORE_MEM_SDP_MEM:
 		return pbuf_is_sdp_mem(pbuf, len);
 	case CORE_MEM_CACHED:


### PR DESCRIPTION
In core_mmu_set_discovered_nsec_ddr(), core_mmap_is_end_of_table
always returns false and the loop body cannot be executed, which
is unexpected.

In carve_out_phys_mem(), when pa has the same address
with m[n].addr, the m[n].size should also be adjusted.

also submitted a patch to fix compiling errors when only use dynamic shared memory
(i.e: CFG_CORE_DYN_SHM=y && CFG_CORE_RESERVED_SHM=n), with
CFG_SHMEM_START and CFG_SHMEM_SIZE not defined.

Totally, I submitted 3 patches to fix the bugs. Pls help to review. thanks. 

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
