### PR TITLE
core: generic_entry_a64.S: use CIVAC over IVAC to clean cache data

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -154,7 +154,7 @@ clear_nex_bss:
 	adr_l	x0, __text_start
 	ldr	x1, cached_mem_end
 	sub	x1, x1, x0
-	bl	dcache_inv_range
+	bl	dcache_cleaninv_range
 
 	/* Enable Console */
 	bl	console_init


### PR DESCRIPTION
After moving some initial sections around in memory we clean out the new
data and invalidate the cache so it can be seen by other cores when they
enable caches. The instruction used was invalidate; on most systems this
will behave the same as clean/invalidate, but on some with L3 caches this
can cause the just written data to be invalidated. Use the
clean+invalidate to prevent this on such systems.

Signed-off-by: Andrew F. Davis <afd@ti.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
