### PR TITLE
core: make SMALL_PAGE_MASK and friends of type paddr_t

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -20,7 +20,7 @@
 /* A small page is the smallest unit of memory that can be mapped */
 #define SMALL_PAGE_SHIFT	12
 #define SMALL_PAGE_SIZE		BIT(SMALL_PAGE_SHIFT)
-#define SMALL_PAGE_MASK		((paddr_t)(SMALL_PAGE_SIZE - 1))
+#define SMALL_PAGE_MASK		((paddr_t)SMALL_PAGE_SIZE - 1)
 
 /*
  * PGDIR is the translation table above the translation table that holds

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -19,8 +19,8 @@
 
 /* A small page is the smallest unit of memory that can be mapped */
 #define SMALL_PAGE_SHIFT	12
-#define SMALL_PAGE_MASK		(SMALL_PAGE_SIZE - 1)
 #define SMALL_PAGE_SIZE		BIT(SMALL_PAGE_SHIFT)
+#define SMALL_PAGE_MASK		((paddr_t)(SMALL_PAGE_SIZE - 1))
 
 /*
  * PGDIR is the translation table above the translation table that holds
@@ -34,17 +34,17 @@
 #define CORE_MMU_PGDIR_LEVEL	2
 #endif
 #define CORE_MMU_PGDIR_SIZE		BIT(CORE_MMU_PGDIR_SHIFT)
-#define CORE_MMU_PGDIR_MASK		(CORE_MMU_PGDIR_SIZE - 1)
+#define CORE_MMU_PGDIR_MASK		((paddr_t)CORE_MMU_PGDIR_SIZE - 1)
 
 /* TA user space code, data, stack and heap are mapped using this granularity */
 #define CORE_MMU_USER_CODE_SHIFT	SMALL_PAGE_SHIFT
 #define CORE_MMU_USER_CODE_SIZE		BIT(CORE_MMU_USER_CODE_SHIFT)
-#define CORE_MMU_USER_CODE_MASK		(CORE_MMU_USER_CODE_SIZE - 1)
+#define CORE_MMU_USER_CODE_MASK		((paddr_t)CORE_MMU_USER_CODE_SIZE - 1)
 
 /* TA user space parameters are mapped using this granularity */
 #define CORE_MMU_USER_PARAM_SHIFT	SMALL_PAGE_SHIFT
 #define CORE_MMU_USER_PARAM_SIZE	BIT(CORE_MMU_USER_PARAM_SHIFT)
-#define CORE_MMU_USER_PARAM_MASK	(CORE_MMU_USER_PARAM_SIZE - 1)
+#define CORE_MMU_USER_PARAM_MASK	((paddr_t)CORE_MMU_USER_PARAM_SIZE - 1)
 
 /*
  * CORE_MMU_L1_TBL_OFFSET is used when switching to/from reduced kernel


### PR DESCRIPTION
Makes SMALL_PAGE_MASK, CORE_MMU_PGDIR_MASK, CORE_MMU_USER_CODE_MASK and
CORE_MMU_USER_PARAM_MASK of type paddr_t to allow correct masking of
significant bits.

Example:
	extern paddr_t addr;
	paddr_t page_addr = addr & ~SMALL_PAGE_MASK

If paddr_t is a 64-bit type SMALL_PAGE_MASK must also be 64-bit wide or
the ~ operation will not set all the higher bits.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
