### PR TITLE
core: arm64: introduce CFG_CORE_ARM64_PA_BITS

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -10,6 +10,13 @@ CFG_RESERVED_VASPACE_SIZE ?= (1024 * 1024 * 10)
 ifeq ($(CFG_ARM64_core),y)
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64
 CFG_KERN_LINKER_ARCH ?= aarch64
+# TCR_EL1.IPS needs to be initialized according to the largest physical
+# address that we need to map.
+# Physical address size
+# 32 bits, 4GB.
+# 36 bits, 64GB.
+# (etc.)
+CFG_CORE_ARM64_PA_BITS ?= 32
 else
 ifeq ($(CFG_ARM32_core),y)
 CFG_KERN_LINKER_FORMAT ?= elf32-littlearm

--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -8,6 +8,7 @@ $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_SCIF,y)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
 
 ifeq ($(PLATFORM_FLAVOR),salvator_h3)
 $(call force,CFG_TEE_CORE_NB_CORE,8)

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -52,6 +52,7 @@ CFG_SHMEM_START  ?= 0x83000000
 CFG_SHMEM_SIZE   ?= 0x00200000
 # DRAM1 is defined above 4G
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
 endif
 
 ifeq ($(PLATFORM_FLAVOR),juno)
@@ -62,6 +63,7 @@ CFG_SHMEM_START  ?= 0xfee00000
 CFG_SHMEM_SIZE   ?= 0x00200000
 # DRAM1 is defined above 4G
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
 CFG_CRYPTO_WITH_CE ?= y
 endif
 


### PR DESCRIPTION
Introduces CFG_CORE_ARM64_PA_BITS which replaces the max_pa global
variable which was used to configure TCR_EL1.IPS.

Prior to 520860f ("core: generic_entry: add enable_mmu()") TCR_EL1.IPS
was calculated and even updated later in the boot flow to automatically
cover the needed physical address space. But now it's calculated before
MMU is enabled and once MMU it's kept in read only memory.

With CFG_CORE_ARM64_PA_BITS TCR_EL1.IPS can be determined early and
later it is enough to check that physical addresses to be mapped are
covered by CFG_CORE_ARM64_PA_BITS.

Fixes: 520860f658be ("core: generic_entry: add enable_mmu()")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
