### PR TITLE
SM2 KEP (Key Exchange Protocol)

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -42,12 +42,16 @@ CFG_CRYPTO_ECC ?= y
 ifeq ($(CFG_CRYPTOLIB_NAME),tomcrypt)
 CFG_CRYPTO_SM2_PKE ?= y
 CFG_CRYPTO_SM2_DSA ?= y
+CFG_CRYPTO_SM2_KEP ?= y
 endif
 ifeq ($(CFG_CRYPTOLIB_NAME)-$(CFG_CRYPTO_SM2_PKE),mbedtls-y)
 $(error Error: CFG_CRYPTO_SM2_PKE=y requires CFG_CRYPTOLIB_NAME=tomcrypt)
 endif
 ifeq ($(CFG_CRYPTOLIB_NAME)-$(CFG_CRYPTO_SM2_DSA),mbedtls-y)
 $(error Error: CFG_CRYPTO_SM2_DSA=y requires CFG_CRYPTOLIB_NAME=tomcrypt)
+endif
+ifeq ($(CFG_CRYPTOLIB_NAME)-$(CFG_CRYPTO_SM2_KEP),mbedtls-y)
+$(error Error: CFG_CRYPTO_SM2_KEP=y requires CFG_CRYPTOLIB_NAME=tomcrypt)
 endif
 
 # Authenticated encryption
@@ -142,6 +146,7 @@ $(eval $(call cryp-dep-one, DES, ECB CBC))
 # SM2 is Elliptic Curve Cryptography, it uses some generic ECC functions
 $(eval $(call cryp-dep-one, SM2_PKE, ECC))
 $(eval $(call cryp-dep-one, SM2_DSA, ECC))
+$(eval $(call cryp-dep-one, SM2_KEP, ECC))
 
 ###############################################################
 # libtomcrypt (LTC) specifics, phase #1
@@ -174,6 +179,7 @@ core-ltc-vars += SHA256_ARM32_CE SHA256_ARM64_CE
 core-ltc-vars += SIZE_OPTIMIZATION
 core-ltc-vars += SM2_PKE
 core-ltc-vars += SM2_DSA
+core-ltc-vars += SM2_KEP
 # Assigned selected CFG_CRYPTO_xxx as _CFG_CORE_LTC_xxx
 $(foreach v, $(core-ltc-vars), $(eval _CFG_CORE_LTC_$(v) := $(CFG_CRYPTO_$(v))))
 _CFG_CORE_LTC_MPI := $(CFG_CORE_MBEDTLS_MPI)

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -733,3 +733,16 @@ TEE_Result crypto_acipher_sm2_dsa_verify(uint32_t algo __unused,
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 #endif /* !CFG_CRYPTO_SM2_DSA */
+#if !defined(CFG_CRYPTO_SM2_KEP)
+TEE_Result crypto_acipher_sm2_kep_derive(struct ecc_keypair *my_key __unused,
+					 struct ecc_keypair *my_eph_key
+								__unused,
+					 struct ecc_public_key *peer_key
+								__unused,
+					 struct ecc_public_key *peer_eph_key
+								__unused,
+					 struct sm2_kep_parms *p __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -252,6 +252,26 @@ TEE_Result crypto_acipher_sm2_dsa_verify(uint32_t algo,
 					 const uint8_t *msg, size_t msg_len,
 					 const uint8_t *sig, size_t sig_len);
 
+struct sm2_kep_parms {
+	uint8_t *out;
+	size_t out_len;
+	bool is_initiator;
+	const uint8_t *initiator_id;
+	size_t initiator_id_len;
+	const uint8_t *responder_id;
+	size_t responder_id_len;
+	const uint8_t *conf_in;
+	size_t conf_in_len;
+	uint8_t *conf_out;
+	size_t conf_out_len;
+};
+
+TEE_Result crypto_acipher_sm2_kep_derive(struct ecc_keypair *my_key,
+					 struct ecc_keypair *my_eph_key,
+					 struct ecc_public_key *peer_key,
+					 struct ecc_public_key *peer_eph_key,
+					 struct sm2_kep_parms *p);
+
 /*
  * Verifies a SHA-256 hash, doesn't require crypto_init() to be called in
  * advance and has as few dependencies as possible.

--- a/core/lib/libtomcrypt/acipher_helpers.h
+++ b/core/lib/libtomcrypt/acipher_helpers.h
@@ -50,4 +50,6 @@ TEE_Result ecc_populate_ltc_public_key(ecc_key *ltc_key,
                 mp_to_unsigned_bin(_a, (b) + (c) - mp_unsigned_bin_size(_a)); \
         } while(0)
 
+TEE_Result sm2_kdf(const uint8_t *Z, size_t Z_len, uint8_t *t, size_t tlen);
+
 #endif /* ACIPHER_HELPERS_H */

--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -129,7 +129,8 @@ static TEE_Result ecc_get_curve_info(uint32_t curve, uint32_t algo,
 		size_bytes = 32;
 		name = "SM2";
 		if ((algo != 0) && (algo != TEE_ALG_SM2_PKE) &&
-		    (algo != TEE_ALG_SM2_DSA_SM3))
+		    (algo != TEE_ALG_SM2_DSA_SM3) &&
+		    (algo != TEE_ALG_SM2_KEP))
 			return TEE_ERROR_BAD_PARAMETERS;
 		break;
 	default:

--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -231,6 +231,9 @@ TEE_Result ecc_populate_ltc_private_key(ecc_key *ltc_key,
 
 	ltc_key->type = PK_PRIVATE;
 	mp_copy(key->d, ltc_key->k);
+	mp_copy(key->x, ltc_key->pubkey.x);
+	mp_copy(key->y, ltc_key->pubkey.y);
+	mp_set_int(ltc_key->pubkey.z, 1);
 
 	return TEE_SUCCESS;
 }

--- a/core/lib/libtomcrypt/sm2-kep.c
+++ b/core/lib/libtomcrypt/sm2-kep.c
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020 Huawei Technologies Co., Ltd
+ */
+
+#include <crypto/crypto.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee_api_types.h>
+#include <tee/tee_cryp_utl.h>
+#include <util.h>
+#include <utee_defines.h>
+
+#include "acipher_helpers.h"
+
+/* SM2 uses 256 bit unsigned integers in big endian format */
+#define SM2_INT_SIZE_BYTES 32
+
+/*
+ * Compute a hash of a user's identity and public key
+ * For user A: ZA = SM3(ENTLA || IDA || a || b || xG || yG || xA || yA)
+ */
+static TEE_Result sm2_kep_compute_Z(uint8_t *Z, size_t Zlen, const uint8_t *id,
+				    size_t idlen, const ecc_key *key)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t ENTLEN[2] = { };
+	uint8_t buf[SM2_INT_SIZE_BYTES];
+	void *ctx = NULL;
+
+	if (Zlen < TEE_SM3_HASH_SIZE)
+		return TEE_ERROR_SHORT_BUFFER;
+
+	/*
+	 * ENTLEN is the length in bits if the user's distinguished identifier
+	 * encoded over 16 bits in big endian format.
+	 */
+	ENTLEN[0] = (idlen * 8) >> 8;
+	ENTLEN[1] = idlen * 8;
+
+	res = crypto_hash_alloc_ctx(&ctx, TEE_ALG_SM3);
+	if (res)
+		goto out;
+
+	res = crypto_hash_init(ctx);
+	if (res)
+		goto out;
+
+	res = crypto_hash_update(ctx, ENTLEN, sizeof(ENTLEN));
+	if (res)
+		goto out;
+
+	res = crypto_hash_update(ctx, id, idlen);
+	if (res)
+		goto out;
+
+	mp_to_unsigned_bin2(key->dp.A, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	mp_to_unsigned_bin2(key->dp.B, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	mp_to_unsigned_bin2(key->dp.base.x, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	mp_to_unsigned_bin2(key->dp.base.y, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	mp_to_unsigned_bin2(key->pubkey.x, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	mp_to_unsigned_bin2(key->pubkey.y, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	res = crypto_hash_final(ctx, Z, TEE_SM3_HASH_SIZE);
+out:
+	crypto_hash_free_ctx(ctx);
+	return res;
+}
+
+/*
+ * Compute a verification value, to be checked against the value sent by the
+ * peer.
+ * On the initiator's side:
+ *   S1 = SM3(0x02 || yU || SM3(xU || ZA || ZB || x1 || y1 || x2 || y2))
+ * On the responder's side:
+ *   S2 = SM3(0x03 || yV || SM3(xV || ZA || ZB || x1 || y1 || x2 || y2))
+ */
+static TEE_Result sm2_kep_compute_S(uint8_t *S, size_t S_len, uint8_t flag,
+				    ecc_point *UV, const uint8_t *ZAZB,
+				    size_t ZAZB_len, ecc_key *initiator_eph_key,
+				    ecc_key *responder_eph_key)
+{
+	uint8_t hash[TEE_SM3_HASH_SIZE] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t buf[SM2_INT_SIZE_BYTES];
+	void *ctx = NULL;
+
+	if (S_len < TEE_SM3_HASH_SIZE)
+		return TEE_ERROR_SHORT_BUFFER;
+
+	res = crypto_hash_alloc_ctx(&ctx, TEE_ALG_SM3);
+	if (res)
+		goto out;
+
+	/* Compute the inner hash */
+
+	res = crypto_hash_init(ctx);
+	if (res)
+		goto out;
+
+	/* xU or xV */
+	mp_to_unsigned_bin2(UV->x, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	/* ZA || ZB */
+	res = crypto_hash_update(ctx, ZAZB, ZAZB_len);
+	if (res)
+		goto out;
+
+	/* x1 */
+	mp_to_unsigned_bin2(initiator_eph_key->pubkey.x, buf,
+			    SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	/* y1 */
+	mp_to_unsigned_bin2(initiator_eph_key->pubkey.y, buf,
+			    SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	/* x2 */
+	mp_to_unsigned_bin2(responder_eph_key->pubkey.x, buf,
+			    SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	/* y2 */
+	mp_to_unsigned_bin2(responder_eph_key->pubkey.y, buf,
+			   SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	res = crypto_hash_final(ctx, hash, sizeof(hash));
+	if (res)
+		goto out;
+
+	/* Now compute S */
+
+	res = crypto_hash_init(ctx);
+	if (res)
+		goto out;
+
+	/* 0x02 or 0x03  */
+	res = crypto_hash_update(ctx, &flag, sizeof(flag));
+	if (res)
+		goto out;
+
+	/* yU or yV */
+	mp_to_unsigned_bin2(UV->y, buf, SM2_INT_SIZE_BYTES);
+	res = crypto_hash_update(ctx, buf, sizeof(buf));
+	if (res)
+		goto out;
+
+	/* Inner SM3(...) */
+	res = crypto_hash_update(ctx, hash, sizeof(hash));
+	if (res)
+		goto out;
+
+	res = crypto_hash_final(ctx, S, TEE_SM3_HASH_SIZE);
+
+out:
+	crypto_hash_free_ctx(ctx);
+	return res;
+
+}
+
+/*
+ * GM/T 0003.1‒2012 Part 3 Section 6.1
+ * Key exchange protocol
+ */
+static TEE_Result sm2_kep_derive(ecc_key *my_key, ecc_key *my_eph_key,
+				 ecc_key *peer_key, ecc_key *peer_eph_key,
+				 struct sm2_kep_parms *p)
+{
+	/*
+	 * Variable names and documented steps reflect the initator side (user A
+	 * in the spec), but the other side is quite similar hence only one
+	 * function.
+	 */
+	uint8_t xUyUZAZB[2 * SM2_INT_SIZE_BYTES + 2 * TEE_SM3_HASH_SIZE] = { };
+	ecc_key *initiator_eph_key = p->is_initiator ? my_eph_key :
+						       peer_eph_key;
+	ecc_key *responder_eph_key = p->is_initiator ? peer_eph_key :
+						       my_eph_key;
+	ecc_key *initiator_key = p->is_initiator ? my_key : peer_key;
+	ecc_key *responder_key = p->is_initiator ? peer_key : my_key;
+	TEE_Result res = TEE_ERROR_BAD_STATE;
+	uint8_t tmp[SM2_INT_SIZE_BYTES];
+	void *n = my_key->dp.order;
+	ecc_point *U = NULL;
+	void *x1bar = NULL;
+	void *x2bar = NULL;
+	void *tA = NULL;
+	void *h = NULL;
+	void *htA = NULL;
+	void *mp = NULL;
+	void *mu = NULL;
+	void *ma = NULL;
+	void *one = NULL;
+	int ltc_res = 0;
+	int inf = 0;
+
+	ltc_res = mp_init_multi(&x1bar, &x2bar, &tA, &h, &htA, &mu, &ma, &one,
+				NULL);
+	if (ltc_res != CRYPT_OK) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	U = ltc_ecc_new_point();
+	if (!U) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	/*
+	 * Steps A1-A3 are supposedly done already (generate ephemeral key, send
+	 * it to peer).
+	 * Step A4: (x1, y1) = RA; x1bar = 2^w + (x1 & (2^w - 1))
+	 */
+
+	mp_to_unsigned_bin2(my_eph_key->pubkey.x, tmp, SM2_INT_SIZE_BYTES);
+	tmp[SM2_INT_SIZE_BYTES / 2] |= 0x80;
+	mp_read_unsigned_bin(x1bar, tmp + SM2_INT_SIZE_BYTES / 2,
+			     SM2_INT_SIZE_BYTES / 2);
+
+	/* Step A5: tA = (dA + x1bar * rA) mod n */
+
+	ltc_res = mp_mulmod(x1bar, my_eph_key->k, n, tA);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = mp_addmod(tA, my_key->k, n, tA);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	/* Step A6: verify whether RB verifies the curve equation */
+
+	ltc_res = ltc_ecc_is_point(&peer_eph_key->dp, peer_eph_key->pubkey.x,
+				   peer_eph_key->pubkey.y);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	/* Step A6 (continued): (x2, y2) = RB; x2bar = 2^w + (x2 & (2^w - 1)) */
+
+	mp_to_unsigned_bin2(peer_eph_key->pubkey.x, tmp, SM2_INT_SIZE_BYTES);
+	tmp[SM2_INT_SIZE_BYTES / 2] |= 0x80;
+	mp_read_unsigned_bin(x2bar, tmp + SM2_INT_SIZE_BYTES / 2,
+			     SM2_INT_SIZE_BYTES / 2);
+
+
+	/* Step A7: compute U = [h.tA](PB + [x2bar]RB) and check for infinity */
+
+	ltc_res = mp_montgomery_setup(peer_key->dp.prime, &mp);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = mp_montgomery_normalization(mu, peer_key->dp.prime);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = mp_mulmod(peer_key->dp.A, mu, peer_key->dp.prime, ma);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = mp_set_int(one, 1);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = ltc_ecc_mul2add(&peer_key->pubkey, one, &peer_eph_key->pubkey,
+				  x2bar, U, ma, peer_key->dp.prime);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = mp_set_int(h, peer_key->dp.cofactor);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = mp_mul(h, tA, htA);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = ltc_ecc_mulmod(htA, U, U, peer_key->dp.A, peer_key->dp.prime,
+				 1);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	ltc_res = ltc_ecc_is_point_at_infinity(U, peer_key->dp.prime, &inf);
+	if (ltc_res != CRYPT_OK)
+		goto out;
+
+	if (inf)
+		goto out;
+
+	/* Step A8: compute KA = KDF(xU || yU || ZA || ZB, klen) */
+
+	/* xU */
+	mp_to_unsigned_bin2(U->x, xUyUZAZB, SM2_INT_SIZE_BYTES);
+
+	/* yU */
+	mp_to_unsigned_bin2(U->y, xUyUZAZB + SM2_INT_SIZE_BYTES,
+			    SM2_INT_SIZE_BYTES);
+
+	/* ZA */
+	res = sm2_kep_compute_Z(xUyUZAZB + 2 * SM2_INT_SIZE_BYTES,
+				TEE_SM3_HASH_SIZE, p->initiator_id,
+				p->initiator_id_len, initiator_key);
+	if (res)
+		goto out;
+
+	/* ZB */
+	res = sm2_kep_compute_Z(xUyUZAZB + 2 * SM2_INT_SIZE_BYTES +
+					TEE_SM3_HASH_SIZE,
+				TEE_SM3_HASH_SIZE, p->responder_id,
+				p->responder_id_len, responder_key);
+	if (res)
+		goto out;
+
+	res = sm2_kdf(xUyUZAZB, sizeof(xUyUZAZB), p->out, p->out_len);
+	if (res)
+		goto out;
+
+	/* Step A9: compute S1 and check S1 == SB */
+
+	if (p->conf_in) {
+		uint8_t S1[TEE_SM3_HASH_SIZE];
+		uint8_t flag = p->is_initiator ? 0x02 : 0x03;
+
+		if (p->conf_in_len < TEE_SM3_HASH_SIZE) {
+			res = TEE_ERROR_BAD_PARAMETERS;
+			goto out;
+		}
+		res = sm2_kep_compute_S(S1, sizeof(S1), flag, U,
+					xUyUZAZB + 2 * SM2_INT_SIZE_BYTES,
+					2 * SM2_INT_SIZE_BYTES,
+					initiator_eph_key, responder_eph_key);
+		if (res)
+			goto out;
+
+		if (consttime_memcmp(S1, p->conf_in, sizeof(S1))) {
+			/* Verification failed */
+			res = TEE_ERROR_BAD_STATE;
+			goto out;
+		}
+	}
+
+	/* Step A10: compute SA */
+
+	if (p->conf_out) {
+		uint8_t flag = p->is_initiator ? 0x03 : 0x02;
+
+		if (p->conf_out_len < TEE_SM3_HASH_SIZE) {
+			res = TEE_ERROR_BAD_PARAMETERS;
+			goto out;
+		}
+
+		res = sm2_kep_compute_S(p->conf_out, TEE_SM3_HASH_SIZE, flag, U,
+					xUyUZAZB + 2 * SM2_INT_SIZE_BYTES,
+					2 * SM2_INT_SIZE_BYTES,
+					initiator_eph_key, responder_eph_key);
+		if (res)
+			goto out;
+	}
+out:
+	mp_montgomery_free(mp);
+	ltc_ecc_del_point(U);
+	mp_clear_multi(x1bar, x2bar, tA, h, htA, mu, ma, one, NULL);
+	return res;
+}
+
+TEE_Result crypto_acipher_sm2_kep_derive(struct ecc_keypair *my_key,
+					 struct ecc_keypair *my_eph_key,
+					 struct ecc_public_key *peer_key,
+					 struct ecc_public_key *peer_eph_key,
+					 struct sm2_kep_parms *p)
+{
+	TEE_Result res = TEE_SUCCESS;
+	ecc_key ltc_my_key = { };
+	ecc_key ltc_my_eph_key = { };
+	ecc_key ltc_peer_key = { };
+	ecc_key ltc_peer_eph_key = { };
+
+	res = ecc_populate_ltc_private_key(&ltc_my_key, my_key,
+					   TEE_ALG_SM2_KEP, NULL);
+	if (res)
+		goto out;
+
+	res = ecc_populate_ltc_private_key(&ltc_my_eph_key, my_eph_key,
+					   TEE_ALG_SM2_KEP, NULL);
+	if (res)
+		goto out;
+
+	res = ecc_populate_ltc_public_key(&ltc_peer_key, peer_key,
+					  TEE_ALG_SM2_KEP, NULL);
+	if (res)
+		goto out;
+
+	res = ecc_populate_ltc_public_key(&ltc_peer_eph_key, peer_eph_key,
+					  TEE_ALG_SM2_KEP, NULL);
+	if (res)
+		goto out;
+
+	res = sm2_kep_derive(&ltc_my_key, &ltc_my_eph_key, &ltc_peer_key,
+			     &ltc_peer_eph_key, p);
+out:
+	ecc_free(&ltc_peer_eph_key);
+	ecc_free(&ltc_peer_key);
+	ecc_free(&ltc_my_eph_key);
+	ecc_free(&ltc_my_key);
+	return res;
+}
+

--- a/core/lib/libtomcrypt/sm2-kep.c
+++ b/core/lib/libtomcrypt/sm2-kep.c
@@ -440,4 +440,3 @@ out:
 	ecc_free(&ltc_my_key);
 	return res;
 }
-

--- a/core/lib/libtomcrypt/sm2-pke.c
+++ b/core/lib/libtomcrypt/sm2-pke.c
@@ -89,62 +89,6 @@ static TEE_Result sm2_bytes_to_point(ecc_point *p, const ltc_ecc_dp *dp,
 	return TEE_ERROR_GENERIC;
 }
 
-/*
- * GM/T 0003.1‒2012 Part 4 Sections 5.4.2 and 5.4.3
- * Key derivation function based on the SM3 hash function
- */
-static TEE_Result sm2_kdf(const uint8_t *Z, size_t Z_len, uint8_t *t,
-			  size_t tlen)
-{
-	TEE_Result res = TEE_SUCCESS;
-	size_t remain = tlen;
-	uint32_t count = 1;
-	uint32_t be_count = 0;
-	void *ctx = NULL;
-	uint8_t *out = t;
-
-	res = crypto_hash_alloc_ctx(&ctx, TEE_ALG_SM3);
-	if (res)
-		return res;
-
-	while (remain) {
-		uint8_t tmp[TEE_SM3_HASH_SIZE] = { };
-		uint8_t *buf = NULL;
-
-		if (remain >= TEE_SM3_HASH_SIZE)
-			buf = out;
-		else
-			buf = tmp;
-
-		put_be32(&be_count, count);
-		res = crypto_hash_init(ctx);
-		if (res)
-			goto out;
-		res = crypto_hash_update(ctx, Z, Z_len);
-		if (res)
-			goto out;
-		res = crypto_hash_update(ctx, (const uint8_t *)&be_count,
-					 sizeof(be_count));
-		if (res)
-			goto out;
-		res = crypto_hash_final(ctx, buf, TEE_SM3_HASH_SIZE);
-		if (res)
-			goto out;
-
-		if (remain < TEE_SM3_HASH_SIZE) {
-			memcpy(out, tmp, remain);
-			break;
-		}
-
-		out += TEE_SM3_HASH_SIZE;
-		remain -= TEE_SM3_HASH_SIZE;
-		count++;
-	}
-out:
-	crypto_hash_free_ctx(ctx);
-	return res;
-}
-
 static bool is_zero(const uint8_t *buf, size_t size)
 {
 	uint8_t v = 0;

--- a/core/lib/libtomcrypt/sm2_kdf.c
+++ b/core/lib/libtomcrypt/sm2_kdf.c
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020 Huawei Technologies Co., Ltd
+ */
+
+#include <crypto/crypto.h>
+#include <io.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+#include <unistd.h>
+#include <utee_defines.h>
+
+#include "acipher_helpers.h"
+
+/*
+ * GM/T 0003.1‒2012 Part 4 Sections 5.4.2 and 5.4.3
+ * GM/T 0003.1‒2012 Part 5 Sections 5.4.2 and 5.4.3
+ * Key derivation function based on the SM3 hash function
+ */
+TEE_Result sm2_kdf(const uint8_t *Z, size_t Z_len, uint8_t *t, size_t tlen)
+{
+	TEE_Result res = TEE_SUCCESS;
+	size_t remain = tlen;
+	uint32_t count = 1;
+	uint32_t be_count = 0;
+	void *ctx = NULL;
+	uint8_t *out = t;
+
+	res = crypto_hash_alloc_ctx(&ctx, TEE_ALG_SM3);
+	if (res)
+		return res;
+
+	while (remain) {
+		uint8_t tmp[TEE_SM3_HASH_SIZE] = { };
+		uint8_t *buf = NULL;
+
+		if (remain >= TEE_SM3_HASH_SIZE)
+			buf = out;
+		else
+			buf = tmp;
+
+		put_be32(&be_count, count);
+		res = crypto_hash_init(ctx);
+		if (res)
+			goto out;
+		res = crypto_hash_update(ctx, Z, Z_len);
+		if (res)
+			goto out;
+		res = crypto_hash_update(ctx, (const uint8_t *)&be_count,
+					 sizeof(be_count));
+		if (res)
+			goto out;
+		res = crypto_hash_final(ctx, buf, TEE_SM3_HASH_SIZE);
+		if (res)
+			goto out;
+
+		if (remain < TEE_SM3_HASH_SIZE) {
+			memcpy(out, tmp, remain);
+			break;
+		}
+
+		out += TEE_SM3_HASH_SIZE;
+		remain -= TEE_SM3_HASH_SIZE;
+		count++;
+	}
+out:
+	crypto_hash_free_ctx(ctx);
+	return res;
+}
+

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -107,7 +107,7 @@ ifeq ($(_CFG_CORE_LTC_ECC),y)
    # ECC 521 bits is the max supported key size
    cppflags-lib-y += -DLTC_MAX_ECC=521
 endif
-ifeq ($(filter y,$(_CFG_CORE_LTC_SM2_DSA_SM3) $(_CFG_CORE_LTC_SM2_PKE)),y)
+ifneq (,$(filter y,$(_CFG_CORE_LTC_SM2_DSA) $(_CFG_CORE_LTC_SM2_PKE)))
    cppflags-lib-y += -DLTC_ECC_SM2
 endif
 

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -139,7 +139,8 @@ srcs-$(_CFG_CORE_LTC_DH) += dh.c
 srcs-$(_CFG_CORE_LTC_AES) += aes.c
 srcs-$(_CFG_CORE_LTC_SM2_DSA) += sm2-dsa.c
 srcs-$(_CFG_CORE_LTC_SM2_PKE) += sm2-pke.c
-srcs-$(_CFG_CORE_LTC_SM2_PKE) += sm2_kdf.c
+srcs-$(_CFG_CORE_LTC_SM2_KEP) += sm2-kep.c
+srcs-$(if $(filter y,$(_CFG_CORE_LTC_SM2_PKE) $(_CFG_CORE_LTC_SM2_KEP),y),y) += sm2_kdf.c
 
 ifeq ($(_CFG_CORE_LTC_ACIPHER),y)
 ifeq ($(_CFG_CORE_LTC_MPI),y)

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -139,6 +139,7 @@ srcs-$(_CFG_CORE_LTC_DH) += dh.c
 srcs-$(_CFG_CORE_LTC_AES) += aes.c
 srcs-$(_CFG_CORE_LTC_SM2_DSA) += sm2-dsa.c
 srcs-$(_CFG_CORE_LTC_SM2_PKE) += sm2-pke.c
+srcs-$(_CFG_CORE_LTC_SM2_PKE) += sm2_kdf.c
 
 ifeq ($(_CFG_CORE_LTC_ACIPHER),y)
 ifeq ($(_CFG_CORE_LTC_MPI),y)

--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -163,6 +163,7 @@
 #define TEE_ALG_DSA_SHA256                      0x70004131
 #define TEE_ALG_SM2_DSA_SM3                     0x70006045
 #define TEE_ALG_DH_DERIVE_SHARED_SECRET         0x80000032
+#define TEE_ALG_SM2_KEP                         0x60000045
 #define TEE_ALG_MD5                             0x50000001
 #define TEE_ALG_SHA1                            0x50000002
 #define TEE_ALG_SHA224                          0x50000003
@@ -224,6 +225,8 @@
 #define TEE_TYPE_ECDH_KEYPAIR               0xA1000042
 #define TEE_TYPE_SM2_DSA_PUBLIC_KEY         0xA0000045
 #define TEE_TYPE_SM2_DSA_KEYPAIR            0xA1000045
+#define TEE_TYPE_SM2_KEP_PUBLIC_KEY         0xA0000046
+#define TEE_TYPE_SM2_KEP_KEYPAIR            0xA1000046
 #define TEE_TYPE_SM2_PKE_PUBLIC_KEY         0xA0000047
 #define TEE_TYPE_SM2_PKE_KEYPAIR            0xA1000047
 #define TEE_TYPE_GENERIC_SECRET             0xA0000000
@@ -258,6 +261,13 @@
 #define TEE_ATTR_ECC_PUBLIC_VALUE_Y         0xD0000241
 #define TEE_ATTR_ECC_PRIVATE_VALUE          0xC0000341
 #define TEE_ATTR_ECC_CURVE                  0xF0000441
+#define TEE_ATTR_SM2_ID_INITIATOR           0xD0000446
+#define TEE_ATTR_SM2_ID_RESPONDER           0xD0000546
+#define TEE_ATTR_SM2_KEP_USER               0xF0000646
+#define TEE_ATTR_SM2_KEP_CONFIRMATION_IN    0xD0000746
+#define TEE_ATTR_SM2_KEP_CONFIRMATION_OUT   0xD0000846
+#define TEE_ATTR_ECC_EPHEMERAL_PUBLIC_VALUE_X 0xD0000946 /* Missing in 1.2.1 */
+#define TEE_ATTR_ECC_EPHEMERAL_PUBLIC_VALUE_Y 0xD0000A46 /* Missing in 1.2.1 */
 
 #define TEE_ATTR_BIT_PROTECTED		(1 << 28)
 #define TEE_ATTR_BIT_VALUE		(1 << 29)

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -31,6 +31,7 @@
 #define TEE_MAIN_ALGO_ECDSA      0x41
 #define TEE_MAIN_ALGO_ECDH       0x42
 #define TEE_MAIN_ALGO_SM2_DSA_SM3 0x45 /* Not in v1.2 spec */
+#define TEE_MAIN_ALGO_SM2_KEP    0x46 /* Not in v1.2 spec */
 #define TEE_MAIN_ALGO_SM2_PKE    0x47 /* Not in v1.2 spec */
 #define TEE_MAIN_ALGO_HKDF       0xC0 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_CONCAT_KDF 0xC1 /* OP-TEE extension */
@@ -53,6 +54,8 @@ static inline uint32_t __tee_alg_get_class(uint32_t algo)
 {
 	if (algo == TEE_ALG_SM2_PKE)
 		return TEE_OPERATION_ASYMMETRIC_CIPHER;
+	if (algo == TEE_ALG_SM2_KEP)
+		return TEE_OPERATION_KEY_DERIVATION;
 
 	return (algo >> 28) & 0xF; /* Bits [31:28] */
 }
@@ -64,6 +67,8 @@ static inline uint32_t __tee_alg_get_main_alg(uint32_t algo)
 	switch (algo) {
 	case TEE_ALG_SM2_PKE:
 		return TEE_MAIN_ALGO_SM2_PKE;
+	case TEE_ALG_SM2_KEP:
+		return TEE_MAIN_ALGO_SM2_KEP;
 	default:
 		break;
 	}

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -46,7 +46,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	if (!operation)
 		TEE_Panic(0);
 
-	if (algorithm == TEE_ALG_AES_XTS)
+	if (algorithm == TEE_ALG_AES_XTS || algorithm == TEE_ALG_SM2_KEP)
 		handle_state = TEE_HANDLE_FLAG_EXPECT_TWO_KEYS;
 
 	/* Check algorithm max key size */
@@ -87,6 +87,12 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_SM2_PKE:
 	case TEE_ALG_SM2_DSA_SM3:
 		if (maxKeySize != 256)
+			return TEE_ERROR_NOT_SUPPORTED;
+		break;
+
+	case TEE_ALG_SM2_KEP:
+		/* Two 256-bit keys */
+		if (maxKeySize != 512)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
@@ -218,6 +224,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_CONCAT_KDF_SHA384_DERIVE_KEY:
 	case TEE_ALG_CONCAT_KDF_SHA512_DERIVE_KEY:
 	case TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY:
+	case TEE_ALG_SM2_KEP:
 		if (mode != TEE_MODE_DERIVE)
 			return TEE_ERROR_NOT_SUPPORTED;
 		with_private_key = true;
@@ -623,7 +630,7 @@ TEE_Result TEE_SetOperationKey2(TEE_OperationHandle operation,
 		goto out;
 	}
 
-	/* Two keys flag expected (TEE_ALG_AES_XTS only) */
+	/* Two keys flag expected (TEE_ALG_AES_XTS and TEE_ALG_SM2_KEP only) */
 	if ((operation->info.handleState & TEE_HANDLE_FLAG_EXPECT_TWO_KEYS) ==
 	    0) {
 		res = TEE_ERROR_BAD_PARAMETERS;
@@ -658,11 +665,10 @@ TEE_Result TEE_SetOperationKey2(TEE_OperationHandle operation,
 	}
 
 	/*
-	 * AES-XTS (the only multi key algorithm supported, requires the
-	 * keys to be of equal size.
+	 * All the multi key algorithm currently supported requires the keys to
+	 * be of equal size.
 	 */
-	if (operation->info.algorithm == TEE_ALG_AES_XTS &&
-	    key_info1.keySize != key_info2.keySize) {
+	if (key_info1.keySize != key_info2.keySize) {
 		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 
@@ -686,7 +692,6 @@ TEE_Result TEE_SetOperationKey2(TEE_OperationHandle operation,
 	res = TEE_CopyObjectAttributes1(operation->key1, key1);
 	if (res != TEE_SUCCESS)
 		goto out;
-
 	res = TEE_CopyObjectAttributes1(operation->key2, key2);
 	if (res != TEE_SUCCESS) {
 		if (res == TEE_ERROR_CORRUPT_OBJECT)


### PR DESCRIPTION
This is the last bit of my Chinese crypto series: the key exchange protocol (key derivation).

The first 3 commits are small fixes and improvement required by the two main ones: "core: ltc: add support for SM2 KEP" and "core: crypto: add support for SM2 KEP".

Note that the commits prefixed with "core: ltc:" will need to eventually go into the LTC import branch. I'll take care of that later for simplicity (well, I think it is simpler to review everything here).