### PR TITLE
core: ltc: sm2: add missing status check

### DIFF
--- a/core/lib/libtomcrypt/sm2-pke.c
+++ b/core/lib/libtomcrypt/sm2-pke.c
@@ -182,7 +182,7 @@ TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key,
 		ltc_res = ltc_ecc_is_point_at_infinity(C1, ltc_key.dp.prime,
 						       &inf);
 	}
-	if (inf) {
+	if (ltc_res != CRYPT_OK || inf) {
 		res = TEE_ERROR_BAD_STATE;
 		goto out;
 	}


### PR DESCRIPTION
crypto_acipher_sm2_pke_decrypt() fails to check a return status from
LibTomCrypt. Add the missing check.

Fixes: f9a78287dd12 ("core: ltc: add support for SM2 PKE")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
