### PR TITLE
Add TEE_IsAlgorithmSupported()

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -144,9 +144,10 @@ $(eval $(call cryp-dep-one, AES, ECB CBC CTR CTS XTS))
 # If no DES cipher mode is left, disable DES
 $(eval $(call cryp-dep-one, DES, ECB CBC))
 # SM2 is Elliptic Curve Cryptography, it uses some generic ECC functions
-$(eval $(call cryp-dep-one, SM2_PKE, ECC))
-$(eval $(call cryp-dep-one, SM2_DSA, ECC))
-$(eval $(call cryp-dep-one, SM2_KEP, ECC))
+# All SM2 algorithms also use the SM3 hash
+$(eval $(call cryp-dep-all, SM2_PKE, ECC SM3))
+$(eval $(call cryp-dep-all, SM2_DSA, ECC SM3))
+$(eval $(call cryp-dep-all, SM2_KEP, ECC SM3))
 
 ###############################################################
 # libtomcrypt (LTC) specifics, phase #1

--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -795,6 +795,138 @@ static TEE_Result system_dlsym(struct tee_ta_session *cs, uint32_t param_types,
 	return res;
 }
 
+static TEE_Result system_is_algo_supported(uint32_t param_types,
+					   TEE_Param params[TEE_NUM_PARAMS])
+{
+	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+					  TEE_PARAM_TYPE_VALUE_OUTPUT,
+					  TEE_PARAM_TYPE_NONE,
+					  TEE_PARAM_TYPE_NONE);
+	TEE_Result st = TEE_ERROR_NOT_SUPPORTED;
+	uint32_t element = 0;
+	uint32_t alg = 0;
+
+	if (exp_pt != param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	alg = params[0].value.a;
+	element = params[0].value.b;
+
+	switch (alg) {
+	case TEE_ALG_AES_ECB_NOPAD:
+	case TEE_ALG_AES_CBC_NOPAD:
+	case TEE_ALG_AES_CTR:
+	case TEE_ALG_AES_CTS:
+	case TEE_ALG_AES_XTS:
+	case TEE_ALG_AES_CBC_MAC_NOPAD:
+	case TEE_ALG_AES_CBC_MAC_PKCS5:
+	case TEE_ALG_AES_CMAC:
+	case TEE_ALG_AES_CCM:
+	case TEE_ALG_AES_GCM:
+	case TEE_ALG_DES_ECB_NOPAD:
+	case TEE_ALG_DES_CBC_NOPAD:
+	case TEE_ALG_DES_CBC_MAC_NOPAD:
+	case TEE_ALG_DES_CBC_MAC_PKCS5:
+	case TEE_ALG_DES3_ECB_NOPAD:
+	case TEE_ALG_DES3_CBC_NOPAD:
+	case TEE_ALG_DES3_CBC_MAC_NOPAD:
+	case TEE_ALG_DES3_CBC_MAC_PKCS5:
+	case TEE_ALG_RSASSA_PKCS1_V1_5_MD5:
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA1:
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA224:
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA256:
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA384:
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA512:
+	case TEE_ALG_RSASSA_PKCS1_V1_5_MD5SHA1:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA1:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA224:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA384:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA512:
+	case TEE_ALG_RSAES_PKCS1_V1_5:
+	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA1:
+	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA224:
+	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA256:
+	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA384:
+	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA512:
+	case TEE_ALG_RSA_NOPAD:
+	case TEE_ALG_DSA_SHA1:
+	case TEE_ALG_DSA_SHA224:
+	case TEE_ALG_DSA_SHA256:
+	case TEE_ALG_DH_DERIVE_SHARED_SECRET:
+	case TEE_ALG_MD5:
+	case TEE_ALG_SHA1:
+	case TEE_ALG_SHA224:
+	case TEE_ALG_SHA256:
+	case TEE_ALG_SHA384:
+	case TEE_ALG_SHA512:
+	case TEE_ALG_MD5SHA1:
+	case TEE_ALG_HMAC_MD5:
+	case TEE_ALG_HMAC_SHA1:
+	case TEE_ALG_HMAC_SHA224:
+	case TEE_ALG_HMAC_SHA256:
+	case TEE_ALG_HMAC_SHA384:
+	case TEE_ALG_HMAC_SHA512:
+#ifdef CFG_CRYPTO_SM3
+	case TEE_ALG_SM3:
+	case TEE_ALG_HMAC_SM3:
+#endif
+#ifdef CFG_CRYPTO_SM4
+	case TEE_ALG_SM4_ECB_NOPAD:
+	case TEE_ALG_SM4_CBC_NOPAD:
+	case TEE_ALG_SM4_CTR:
+#endif
+		if (element == TEE_CRYPTO_ELEMENT_NONE)
+			st = TEE_SUCCESS;
+		break;
+
+	case TEE_ALG_ECDSA_P192:
+	case TEE_ALG_ECDSA_P224:
+	case TEE_ALG_ECDSA_P256:
+	case TEE_ALG_ECDSA_P384:
+	case TEE_ALG_ECDSA_P521:
+	case TEE_ALG_ECDH_P192:
+	case TEE_ALG_ECDH_P224:
+	case TEE_ALG_ECDH_P256:
+	case TEE_ALG_ECDH_P384:
+	case TEE_ALG_ECDH_P521:
+		switch (element) {
+		case TEE_ECC_CURVE_NIST_P192:
+		case TEE_ECC_CURVE_NIST_P224:
+		case TEE_ECC_CURVE_NIST_P256:
+		case TEE_ECC_CURVE_NIST_P384:
+		case TEE_ECC_CURVE_NIST_P521:
+			st = TEE_SUCCESS;
+		default:
+			break;
+		}
+		break;
+
+#ifdef CFG_CRYPTO_SM2_DSA
+	case TEE_ALG_SM2_DSA_SM3:
+#endif
+#ifdef CFG_CRYPTO_SM2_KEP
+	case TEE_ALG_SM2_KEP:
+#endif
+#ifdef CFG_CRYPTO_SM2_PKE
+	case TEE_ALG_SM2_PKE:
+#endif
+#if defined(CFG_CRYPTO_SM2_DSA) || defined(CFG_CRYPTO_SM2_PKE) || \
+	defined(CFG_CRYPTO_SM2_KEP)
+		if (element == TEE_ECC_CURVE_SM2)
+			st = TEE_SUCCESS;
+		break;
+#endif
+
+	default:
+		break;
+	}
+
+	params[1].value.a = st;
+
+	return TEE_SUCCESS;
+}
+
 static TEE_Result open_session(uint32_t param_types __unused,
 			       TEE_Param params[TEE_NUM_PARAMS] __unused,
 			       void **sess_ctx)
@@ -858,6 +990,8 @@ static TEE_Result invoke_command(void *sess_ctx, uint32_t cmd_id,
 		return system_dlopen(s, param_types, params);
 	case PTA_SYSTEM_DLSYM:
 		return system_dlsym(s, param_types, params);
+	case PTA_SYSTEM_IS_ALGO_SUPPORTED:
+		return system_is_algo_supported(param_types, params);
 	default:
 		break;
 	}

--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -812,74 +812,174 @@ static TEE_Result system_is_algo_supported(uint32_t param_types,
 	alg = params[0].value.a;
 	element = params[0].value.b;
 
+	if (alg == TEE_ALG_ILLEGAL_VALUE)
+		return TEE_ERROR_NOT_SUPPORTED;
+
 	switch (alg) {
+#ifdef CFG_CRYPTO_AES
+#ifdef CFG_CRYPTO_ECB
 	case TEE_ALG_AES_ECB_NOPAD:
+#endif
+#ifdef CFG_CRYPTO_CBC
 	case TEE_ALG_AES_CBC_NOPAD:
+#endif
+#ifdef CFG_CRYPTO_CTR
 	case TEE_ALG_AES_CTR:
+#endif
+#ifdef CFG_CRYPTO_CTS
 	case TEE_ALG_AES_CTS:
+#endif
+#ifdef CFG_CRYPTO_XTS
 	case TEE_ALG_AES_XTS:
+#endif
+#ifdef CFG_CRYPTO_CBC_MAC
 	case TEE_ALG_AES_CBC_MAC_NOPAD:
 	case TEE_ALG_AES_CBC_MAC_PKCS5:
+#endif
+#ifdef CFG_CRYPTO_CMAC
 	case TEE_ALG_AES_CMAC:
+#endif
+#ifdef CFG_CRYPTO_CCM
 	case TEE_ALG_AES_CCM:
+#endif
+#ifdef CFG_CRYPTO_GCM
 	case TEE_ALG_AES_GCM:
+#endif
+#endif /* CFG_CRYPTO_AES */
+#ifdef CFG_CRYPTO_DES
+#ifdef CFG_CRYPTO_ECB
 	case TEE_ALG_DES_ECB_NOPAD:
+	case TEE_ALG_DES3_ECB_NOPAD:
+#endif
+#ifdef CFG_CRYPTO_CBC
 	case TEE_ALG_DES_CBC_NOPAD:
+	case TEE_ALG_DES3_CBC_NOPAD:
+#endif
+#ifdef CFG_CRYPTO_CBC_MAC
 	case TEE_ALG_DES_CBC_MAC_NOPAD:
 	case TEE_ALG_DES_CBC_MAC_PKCS5:
-	case TEE_ALG_DES3_ECB_NOPAD:
-	case TEE_ALG_DES3_CBC_NOPAD:
 	case TEE_ALG_DES3_CBC_MAC_NOPAD:
 	case TEE_ALG_DES3_CBC_MAC_PKCS5:
+#endif
+#endif /* CFG_CRYPTO_DES */
+#ifdef CFG_CRYPTO_RSA
+#ifdef CFG_CRYPTO_MD5
 	case TEE_ALG_RSASSA_PKCS1_V1_5_MD5:
+#endif
+#ifdef CFG_CRYPTO_SHA1
 	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA1:
-	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA224:
-	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA256:
-	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA384:
-	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA512:
-	case TEE_ALG_RSASSA_PKCS1_V1_5_MD5SHA1:
 	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA1:
-	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA224:
-	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256:
-	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA384:
-	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA512:
-	case TEE_ALG_RSAES_PKCS1_V1_5:
 	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA1:
+#endif
+#ifdef CFG_CRYPTO_SHA224
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA224:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA224:
 	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA224:
+#endif
+#ifdef CFG_CRYPTO_SHA256
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA256:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256:
 	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA256:
+#endif
+#ifdef CFG_CRYPTO_SHA384
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA384:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA384:
 	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA384:
+#endif
+#ifdef CFG_CRYPTO_SHA512
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA512:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA512:
 	case TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA512:
+#endif
+#if defined(CFG_CRYPTO_MD5) && defined(CFG_CRYPTO_SHA1)
+	case TEE_ALG_RSASSA_PKCS1_V1_5_MD5SHA1:
+#endif
+	case TEE_ALG_RSAES_PKCS1_V1_5:
 	case TEE_ALG_RSA_NOPAD:
+#endif /* CFG_CRYPTO_RSA */
+#ifdef CFG_CRYPTO_DSA
+#ifdef CFG_CRYPTO_SHA1
 	case TEE_ALG_DSA_SHA1:
+#endif
+#ifdef CFG_CRYPTO_SHA224
 	case TEE_ALG_DSA_SHA224:
+#endif
+#ifdef CFG_CRYPTO_SHA256
 	case TEE_ALG_DSA_SHA256:
+#endif
+#endif /* CFG_CRYPTO_DSA */
+#ifdef CFG_CRYPTO_DH
 	case TEE_ALG_DH_DERIVE_SHARED_SECRET:
+#endif
+#ifdef CFG_CRYPTO_MD5
 	case TEE_ALG_MD5:
+#endif
+#ifdef CFG_CRYPTO_SHA1
 	case TEE_ALG_SHA1:
+#endif
+#ifdef CFG_CRYPTO_SHA224
 	case TEE_ALG_SHA224:
+#endif
+#ifdef CFG_CRYPTO_SHA256
 	case TEE_ALG_SHA256:
+#endif
+#ifdef CFG_CRYPTO_SHA384
 	case TEE_ALG_SHA384:
+#endif
+#ifdef CFG_CRYPTO_SHA512
 	case TEE_ALG_SHA512:
+#endif
+#if defined(CFG_CRYPTO_MD5) && defined(CFG_CRYPTO_SHA1)
 	case TEE_ALG_MD5SHA1:
+#endif
+#ifdef CFG_CRYPTO_HMAC
+#ifdef CFG_CRYPTO_MD5
 	case TEE_ALG_HMAC_MD5:
+#endif
+#ifdef CFG_CRYPTO_SHA1
 	case TEE_ALG_HMAC_SHA1:
+#endif
+#ifdef CFG_CRYPTO_SHA224
 	case TEE_ALG_HMAC_SHA224:
+#endif
+#ifdef CFG_CRYPTO_SHA256
 	case TEE_ALG_HMAC_SHA256:
+#endif
+#ifdef CFG_CRYPTO_SHA384
 	case TEE_ALG_HMAC_SHA384:
+#endif
+#ifdef CFG_CRYPTO_SHA512
 	case TEE_ALG_HMAC_SHA512:
+#endif
 #ifdef CFG_CRYPTO_SM3
-	case TEE_ALG_SM3:
 	case TEE_ALG_HMAC_SM3:
 #endif
+#endif /* CFG_CRYPTO_HMAC */
+#ifdef CFG_CRYPTO_SM3
+	case TEE_ALG_SM3:
+#endif
 #ifdef CFG_CRYPTO_SM4
+#ifdef CFG_CRYPTO_ECB
 	case TEE_ALG_SM4_ECB_NOPAD:
+#endif
+#ifdef CFG_CRYPTO_CBC
 	case TEE_ALG_SM4_CBC_NOPAD:
+#endif
+#ifdef CFG_CRYPTO_CTR
 	case TEE_ALG_SM4_CTR:
 #endif
+#endif /* CFG_CRYPTO_SM4 */
+	case TEE_ALG_ILLEGAL_VALUE: /* this value to prevent empty case list */
 		if (element == TEE_CRYPTO_ELEMENT_NONE)
 			st = TEE_SUCCESS;
 		break;
 
+	default:
+		break;
+	}
+
+	switch(alg) {
+#ifdef CFG_CRYPTO_DESO_ECC
 	case TEE_ALG_ECDSA_P192:
 	case TEE_ALG_ECDSA_P224:
 	case TEE_ALG_ECDSA_P256:
@@ -901,7 +1001,7 @@ static TEE_Result system_is_algo_supported(uint32_t param_types,
 			break;
 		}
 		break;
-
+#endif /* CFG_CRYPTO_ECC */
 #ifdef CFG_CRYPTO_SM2_DSA
 	case TEE_ALG_SM2_DSA_SM3:
 #endif
@@ -911,12 +1011,10 @@ static TEE_Result system_is_algo_supported(uint32_t param_types,
 #ifdef CFG_CRYPTO_SM2_PKE
 	case TEE_ALG_SM2_PKE:
 #endif
-#if defined(CFG_CRYPTO_SM2_DSA) || defined(CFG_CRYPTO_SM2_PKE) || \
-	defined(CFG_CRYPTO_SM2_KEP)
+	case TEE_ALG_ILLEGAL_VALUE: /* this value to prevent empty case list */
 		if (element == TEE_ECC_CURVE_SM2)
 			st = TEE_SUCCESS;
 		break;
-#endif
 
 	default:
 		break;

--- a/lib/libutee/include/pta_system.h
+++ b/lib/libutee/include/pta_system.h
@@ -182,4 +182,14 @@
  */
 #define PTA_SYSTEM_DLSYM                11
 
+/*
+ * Check if a cryptographic algorithm is supported by the TEE core
+ *
+ * [in]     value[0].a: algId
+ * [in]     value[0].b: element
+ * [out]    value[1].a: TEE_SUCCESS or TEE_ERROR_NOT_SUPPORTED
+ *
+ * Used by: TEE_IsAlgorithmSupported()
+ */
+#define PTA_SYSTEM_IS_ALGO_SUPPORTED    12
 #endif /* __PTA_SYSTEM_H */

--- a/lib/libutee/include/tee_api.h
+++ b/lib/libutee/include/tee_api.h
@@ -226,6 +226,8 @@ TEE_Result TEE_SetOperationKey2(TEE_OperationHandle operation,
 void TEE_CopyOperation(TEE_OperationHandle dstOperation,
 		       TEE_OperationHandle srcOperation);
 
+TEE_Result TEE_IsAlgorithmSupported(uint32_t algId, uint32_t element);
+
 /* Cryptographic Operations API - Message Digest Functions */
 
 void TEE_DigestUpdate(TEE_OperationHandle operation,

--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -200,6 +200,7 @@
 #define TEE_ALG_ECDH_P521                       0x80005042
 #define TEE_ALG_SM2_PKE                         0x80000045
 #define TEE_ALG_SM3                             0x50000007
+#define TEE_ALG_ILLEGAL_VALUE                   0xEFFFFFFF
 
 /* Object Types */
 

--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -273,6 +273,7 @@
 #define TEE_ATTR_BIT_VALUE		(1 << 29)
 
 /* List of Supported ECC Curves */
+#define TEE_CRYPTO_ELEMENT_NONE             0x00000000
 #define TEE_ECC_CURVE_NIST_P192             0x00000001
 #define TEE_ECC_CURVE_NIST_P224             0x00000002
 #define TEE_ECC_CURVE_NIST_P256             0x00000003

--- a/lib/libutee/tee_system_pta.c
+++ b/lib/libutee/tee_system_pta.c
@@ -76,3 +76,23 @@ TEE_Result tee_unmap(void *buf, size_t len)
 
 	return res;
 }
+
+TEE_Result TEE_IsAlgorithmSupported(uint32_t algId, uint32_t element)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+					       TEE_PARAM_TYPE_VALUE_OUTPUT,
+					       TEE_PARAM_TYPE_NONE,
+					       TEE_PARAM_TYPE_NONE);
+	TEE_Param params[TEE_NUM_PARAMS] = { };
+
+	params[0].value.a = algId;
+	params[0].value.b = element;
+
+	res = invoke_system_pta(PTA_SYSTEM_IS_ALGO_SUPPORTED, param_types,
+				params);
+	if (res)
+		return res;
+
+	return params[1].value.a;
+}


### PR DESCRIPTION
Fixes some dependency issues (SM2 needs SM3) and implements `TEE_IsAlgorithmSupported()` so that TAs can detect at run time which algorithms are supported.