### PR TITLE
Fix Rcar Gen3 platform boot

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -10,6 +10,14 @@ $(call force,CFG_SCIF,y)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 
+# Disable core ASLR for two reasons:
+# 1. There is no source for ALSR seed, as Rcar platform
+#    does not provide DTB to OP-TEE. Also, there is no
+#    publically available documentation on integrated
+#    hardware RNG, so we can't use it either.
+# 2. OP-TEE crashes during boot with enabled CFG_CORE_ASLR.
+$(call force,CFG_CORE_ASLR,n)
+
 ifeq ($(PLATFORM_FLAVOR),salvator_h3)
 $(call force,CFG_TEE_CORE_NB_CORE,8)
 endif

--- a/core/arch/arm/plat-rcar/link.mk
+++ b/core/arch/arm/plat-rcar/link.mk
@@ -2,6 +2,14 @@ include core/arch/arm/kernel/link.mk
 
 all: $(link-out-dir)/tee.srec
 cleanfiles += $(link-out-dir)/tee.srec
-$(link-out-dir)/tee.srec: $(link-out-dir)/tee.elf
+
+cleanfiles += $(link-out-dir)/tee-raw.bin
+$(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)$(OBJCOPYcore) -O srec $< $@
+	$(q)scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@
+
+cleanfiles += $(link-out-dir)/tee.srec
+$(link-out-dir)/tee.srec: $(link-out-dir)/tee-raw.bin
+	@$(cmd-echo-silent) '  GEN     $@'
+	$(q)$(OBJCOPYcore) -I binary -O srec $< $@
+

--- a/scripts/gen_tee_bin.py
+++ b/scripts/gen_tee_bin.py
@@ -260,6 +260,18 @@ def get_init_load_addr(elffile):
     return init_load_addr_hi, init_load_addr_lo
 
 
+def output_raw_bin(elffile, outf):
+    pager_bin = get_pager_bin(elffile)
+    pageable_bin = get_pageable_bin(elffile)
+    embdata_bin = get_embdata_bin(elffile)
+    init_bin_size = get_symbol(elffile, '__init_size')['st_value']
+
+    outf.write(pager_bin)
+    outf.write(pageable_bin[:init_bin_size])
+    outf.write(embdata_bin)
+    outf.write(pageable_bin[init_bin_size:])
+
+
 def output_header_v1(elffile, outf):
     arch_id = get_arch_id(elffile)
     pager_bin = get_pager_bin(elffile)
@@ -341,6 +353,10 @@ def get_args():
                         required=False, type=argparse.FileType('wb'),
                         help='The output tee.bin')
 
+    parser.add_argument('--out_tee_raw_bin',
+                        required=False, type=argparse.FileType('wb'),
+                        help='The output tee_raw.bin')
+
     parser.add_argument('--out_tee_pager_bin',
                         required=False, type=argparse.FileType('wb'),
                         help='The output tee_pager.bin')
@@ -368,6 +384,9 @@ def main():
     args = get_args()
 
     elffile = ELFFile(args.input)
+
+    if args.out_tee_raw_bin:
+        output_raw_bin(elffile, args.out_tee_raw_bin)
 
     if args.out_tee_bin:
         output_header_v1(elffile, args.out_tee_bin)


### PR DESCRIPTION
Rcar Gen3 uses quite old ARM-TF which does not support OP-TEE image with headers. This wasn't problem until now. We just used objdump to generate raw binary (or srec) file to flash it to a board.

But with recent changes, it is not working anymore, as OP-TEE expects some additional data right after its image. This set of patches uses gen_tee_bin script to generate image in the correct way.

Also I'm disabling core ASLR for reasons described in the patch.