### PR TITLE
Fix virtualization mode

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1202,7 +1202,12 @@ static struct tee_mmap_region *get_tmp_mmap(void)
  */
 void core_init_mmu_map(unsigned long seed, struct core_mmu_config *cfg)
 {
+#ifndef CFG_VIRTUALIZATION
 	vaddr_t start = ROUNDDOWN((vaddr_t)__nozi_start, SMALL_PAGE_SIZE);
+#else
+	vaddr_t start = ROUNDDOWN((vaddr_t)__vcore_nex_rw_start,
+				  SMALL_PAGE_SIZE);
+#endif
 	vaddr_t len = ROUNDUP((vaddr_t)__nozi_end, SMALL_PAGE_SIZE) - start;
 	struct tee_mmap_region *tmp_mmap = get_tmp_mmap();
 	unsigned long offs = 0;

--- a/scripts/gen_tee_bin.py
+++ b/scripts/gen_tee_bin.py
@@ -144,7 +144,7 @@ def get_pager_bin(elffile):
     if tee_pager_bin is None:
         pad_to = get_symbol(elffile, '__data_end')['st_value']
         dump_names = re.compile(
-            r'^\.(text|rodata|got|data|ARM\.exidx|ARM\.extab)$')
+            r'^\.(text|nex_data|rodata|got|data|ARM\.exidx|ARM\.extab)$')
         tee_pager_bin = get_sections(elffile, pad_to, dump_names)
 
     return tee_pager_bin


### PR DESCRIPTION
There are two changes:

1. It appeared that gen_tee_bin.py didn't include nexus section in the resulting image. That can explain unsuccessful attempts to bring up virtualization support on some other platforms.

2.  Initial temporary mapping should include nexus sections, to ensure that table allocator will be able to use them.

This completely fixes #3543. 