### PR TITLE
core: calculate size/address cells with overlay

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -6,6 +6,7 @@
 #include <arm.h>
 #include <assert.h>
 #include <compiler.h>
+#include <config.h>
 #include <console.h>
 #include <crypto/crypto.h>
 #include <inttypes.h>
@@ -839,12 +840,17 @@ static int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
 		offs = 0;
 	}
 
-	len_size = fdt_size_cells(dt->blob, offs);
-	if (len_size < 0)
-		return -1;
-	addr_size = fdt_address_cells(dt->blob, offs);
-	if (addr_size < 0)
-		return -1;
+	if (IS_ENABLED(CFG_EXTERNAL_DTB_OVERLAY)) {
+		len_size = sizeof(paddr_t) / sizeof(uint32_t);
+		addr_size = sizeof(paddr_t) / sizeof(uint32_t);
+	} else {
+		len_size = fdt_size_cells(dt->blob, offs);
+		if (len_size < 0)
+			return -1;
+		addr_size = fdt_address_cells(dt->blob, offs);
+		if (addr_size < 0)
+			return -1;
+	}
 
 	if (!found) {
 		offs = add_dt_path_subnode(dt, "/", "reserved-memory");


### PR DESCRIPTION
In case an external device tree overlay is configured within OP-TEE,
fdt_{size,address}_cells will return the defaults from the device tree
specification. These will be wrong for 32-bit ARM platforms, instead
calculate them from the paddr_t size instead.

Fixes https://github.com/OP-TEE/optee_os/issues/3470

Alternative to https://github.com/OP-TEE/optee_os/pull/3481