### PR TITLE
.shippable.yml: build with CFG_REE_FS_TA_BUFFERED=y

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -48,7 +48,7 @@ build:
     - _make CFG_FTRACE_SUPPORT=y CFG_ULIBS_MCOUNT=y CFG_ULIBS_SHARED=y
     - _make CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
     - _make CFG_SECURE_DATA_PATH=y
-    - _make CFG_REE_FS_TA_BUFFERED=n
+    - _make CFG_REE_FS_TA_BUFFERED=y
     - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_CORE_ASLR=y
     - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y COMPILER=clang
     - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_WITH_PAGER=y


### PR DESCRIPTION
Since commit e6e68745589b ("core: REE FS TAs: disable
CFG_REE_FS_TA_BUFFERED by default"), there is no need for an entry with
CFG_REE_FS_TA_BUFFERED=n in .shippable.yml. Instead, we should test
with =y.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
