### PR TITLE
plat-amlogic: Add initial support for Amlogic platforms

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -135,3 +135,4 @@ build:
     - _make PLATFORM=sunxi-sun50i_a64
     - _make PLATFORM=bcm-ns3 CFG_ARM64_core=y
     - _make PLATFORM=hisilicon-hi3519av100_demo
+    - _make PLATFORM=amlogic

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -54,6 +54,11 @@ R:	Amit Singh Tomar <amittomer25@gmail.com> [@Amit-Radur]
 S:	Maintained
 F:	core/arch/arm/plat-sunxi/
 
+AmLogic AXG (A113D)
+R:	Carlo Caione <ccaione@baylibre.com> [@carlocaione]
+S:	Maintained
+F:	core/arch/arm/plat-amlogic/
+
 Atmel ATSAMA5D2-XULT
 R:	Akshay Bhat <akshay.bhat@timesys.com> [@nodeax]
 R:	[@OP-TEE/plat-sam]

--- a/core/arch/arm/plat-amlogic/conf.mk
+++ b/core/arch/arm/plat-amlogic/conf.mk
@@ -1,0 +1,22 @@
+PLATFORM_FLAVOR ?= axg
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+
+CFG_TZDRAM_START ?= 0x05300000
+CFG_TZDRAM_SIZE ?= 0x00c00000
+CFG_SHMEM_START ?= 0x05000000
+CFG_SHMEM_SIZE ?= 0x00100000
+
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_AMLOGIC_UART,y)
+
+$(call force,CFG_WITH_PAGER,n)
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_WITH_LPAE,y)
+
+CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-amlogic/link.mk
+++ b/core/arch/arm/plat-amlogic/link.mk
@@ -1,0 +1,17 @@
+include core/arch/arm/kernel/link.mk
+
+# Create BL32 image from the native binary images
+
+define aml_bin2img_cmd
+	@$(cmd-echo-silent) '  GEN     $@'
+	$(q)./core/arch/arm/plat-amlogic/scripts/aml_bin2img.py
+endef
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),axg))
+all: $(link-out-dir)/bl32.img
+cleanfiles += $(link-out-dir)/bl32.img
+$(link-out-dir)/bl32.img: $(link-out-dir)/tee-pager_v2.bin
+	$(aml_bin2img_cmd) --source $< --dest $@ --entry 0x5300000 \
+			   --res_mem_start 0x5300000 --res_mem_size 0x1000000 \
+			   --sec_mem_start 0x5300000 --sec_mem_size 0xc00000
+endif

--- a/core/arch/arm/plat-amlogic/main.c
+++ b/core/arch/arm/plat-amlogic/main.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020 Carlo Caione <ccaione@baylibre.com>
+ */
+
+#include <console.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/entry_std.h>
+#include <tee/entry_fast.h>
+#include <drivers/amlogic_uart.h>
+
+static const struct thread_handlers handlers = {
+	.cpu_on = cpu_on_handler,
+	.cpu_off = pm_do_nothing,
+	.cpu_suspend = pm_do_nothing,
+	.cpu_resume = pm_do_nothing,
+	.system_off = pm_do_nothing,
+	.system_reset = pm_do_nothing,
+};
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+static struct amlogic_uart_data console_data;
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE,
+			CORE_MMU_PGDIR_SIZE);
+
+void console_init(void)
+{
+	amlogic_uart_init(&console_data, CONSOLE_UART_BASE);
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-amlogic/platform_config.h
+++ b/core/arch/arm/plat-amlogic/platform_config.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020 Carlo Caione <ccaione@baylibre.com>
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#define GIC_BASE		0xFFC01000
+#define GICC_OFFSET		0x2000
+#define GICD_OFFSET		0x1000
+
+#define CONSOLE_UART_BASE	0xFF803000
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-amlogic/scripts/aml_bin2img.py
+++ b/core/arch/arm/plat-amlogic/scripts/aml_bin2img.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2020 Carlo Caione <ccaione@baylibre.com>
+#
+# Derived from plat-stm32mp1/scripts/stm32image.py
+#
+
+import argparse
+import struct
+import mmap
+
+header_size = 0x200
+ext_magic_number = 0x12348765
+version = 0x00002710
+
+
+def get_size(file):
+    file.seek(0, 2)        # End of the file
+    size = file.tell()
+    return size
+
+
+def aml_set_header(dest_fd, entry, res_mem_start, res_mem_size, sec_mem_start,
+                   sec_mem_size):
+    dest_fd.seek(0, 0)
+
+    dest_fd.write(struct.pack('<IIQQQQQ',
+                  ext_magic_number,
+                  version,
+                  entry,
+                  res_mem_start,
+                  res_mem_size,
+                  sec_mem_start,
+                  sec_mem_size))
+
+    # Padding
+    dest_fd.write(b'\x00' * 464)
+    dest_fd.close()
+
+
+def aml_create_header_file(source, dest, entry, res_mem_start, res_mem_size,
+                           sec_mem_start, sec_mem_size):
+    dest_fd = open(dest, 'w+b')
+    src_fd = open(source, 'rb')
+
+    dest_fd.write(b'\x00' * header_size)
+
+    sizesrc = get_size(src_fd)
+    if sizesrc > 0:
+        mmsrc = mmap.mmap(src_fd.fileno(), 0, access=mmap.ACCESS_READ)
+        dest_fd.write(mmsrc[:sizesrc])
+        mmsrc.close()
+
+    src_fd.close()
+
+    aml_set_header(dest_fd, entry, res_mem_start, res_mem_size, sec_mem_start,
+                   sec_mem_size)
+
+    dest_fd.close()
+
+
+def auto_int(x):
+    return int(x, 0)
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--source',
+                        required=True,
+                        help='Source file')
+
+    parser.add_argument('--dest',
+                        required=True,
+                        help='Destination file')
+
+    parser.add_argument('--entry',
+                        required=True,
+                        type=auto_int,
+                        help='Entry point')
+
+    parser.add_argument('--res_mem_start',
+                        required=True,
+                        type=auto_int,
+                        help='Reserved memory start')
+
+    parser.add_argument('--res_mem_size',
+                        required=True,
+                        type=auto_int,
+                        help='Reserved memory size')
+
+    parser.add_argument('--sec_mem_start',
+                        required=True,
+                        type=auto_int,
+                        help='Secure memory start')
+
+    parser.add_argument('--sec_mem_size',
+                        required=True,
+                        type=auto_int,
+                        help='Secure memory size')
+
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+
+    source_file = args.source
+    destination_file = args.dest
+    entry_point = args.entry
+    res_mem_start = args.res_mem_start
+    res_mem_size = args.res_mem_size
+    sec_mem_start = args.sec_mem_start
+    sec_mem_size = args.sec_mem_size
+
+    aml_create_header_file(source_file,
+                           destination_file,
+                           entry_point,
+                           res_mem_start,
+                           res_mem_size,
+                           sec_mem_start,
+                           sec_mem_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/arch/arm/plat-amlogic/sub.mk
+++ b/core/arch/arm/plat-amlogic/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c

--- a/core/drivers/amlogic_uart.c
+++ b/core/drivers/amlogic_uart.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020 Carlo Caione <ccaione@baylibre.com>
+ */
+
+#include <assert.h>
+#include <drivers/amlogic_uart.h>
+#include <io.h>
+#include <keep.h>
+#include <util.h>
+
+/* Registers */
+#define AML_UART_WFIFO		0x0000
+#define AML_UART_RFIFO		0x0004
+#define AML_UART_CONTROL	0x0008
+#define AML_UART_STATUS		0x000C
+#define AML_UART_MISC		0x0010
+
+/* AML_UART_STATUS bits */
+#define AML_UART_RX_EMPTY	BIT(20)
+#define AML_UART_TX_FULL	BIT(21)
+#define AML_UART_TX_EMPTY	BIT(22)
+
+static vaddr_t chip_to_base(struct serial_chip *chip)
+{
+	struct amlogic_uart_data *pd =
+		container_of(chip, struct amlogic_uart_data, chip);
+
+	return io_pa_or_va(&pd->base);
+}
+
+static void amlogic_uart_flush(struct serial_chip *chip)
+{
+	vaddr_t base = chip_to_base(chip);
+
+	while (!(io_read32(base + AML_UART_STATUS) & AML_UART_TX_EMPTY))
+		;
+}
+
+static int amlogic_uart_getchar(struct serial_chip *chip)
+{
+	vaddr_t base = chip_to_base(chip);
+
+	if (io_read32(base + AML_UART_STATUS) & AML_UART_RX_EMPTY)
+		return -1;
+
+	return io_read32(base + AML_UART_RFIFO) & 0xff;
+}
+
+static void amlogic_uart_putc(struct serial_chip *chip, int ch)
+{
+	vaddr_t base = chip_to_base(chip);
+
+	while (io_read32(base + AML_UART_STATUS) & AML_UART_TX_FULL)
+		;
+
+	io_write32(base + AML_UART_WFIFO, ch);
+}
+
+static const struct serial_ops amlogic_uart_ops = {
+	.flush = amlogic_uart_flush,
+	.getchar = amlogic_uart_getchar,
+	.putc = amlogic_uart_putc,
+};
+
+void amlogic_uart_init(struct amlogic_uart_data *pd, paddr_t base)
+{
+	pd->base.pa = base;
+	pd->chip.ops = &amlogic_uart_ops;
+
+	/*
+	 * Do nothing, debug uart (AO) shared with normal world, everything for
+	 * uart initialization is done in bootloader.
+	 */
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -19,6 +19,7 @@ srcs-$(CFG_SCIF) += scif.c
 srcs-$(CFG_DRA7_RNG) += dra7_rng.c
 srcs-$(CFG_STIH_UART) += stih_asc.c
 srcs-$(CFG_ATMEL_UART) += atmel_uart.c
+srcs-$(CFG_AMLOGIC_UART) += amlogic_uart.c
 srcs-$(CFG_MVEBU_UART) += mvebu_uart.c
 srcs-$(CFG_STM32_BSEC) += stm32_bsec.c
 srcs-$(CFG_STM32_ETZPC) += stm32_etzpc.c

--- a/core/include/drivers/amlogic_uart.h
+++ b/core/include/drivers/amlogic_uart.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+#ifndef AMLOGIC_UART_H
+#define AMLOGIC_UART_H
+
+#include <types_ext.h>
+#include <drivers/serial.h>
+
+struct amlogic_uart_data {
+	struct io_pa_va base;
+	struct serial_chip chip;
+};
+
+void amlogic_uart_init(struct amlogic_uart_data *pd, paddr_t base);
+
+#endif /* AMLOGIC_UART_H */


### PR DESCRIPTION
This is the initial support for the Amlogic platforms.

Tested 64-bin mode on A113D (AXG) board using upstream BL31.

* xtest results (-l 15):
| 44074 subtests of which 0 failed
| 96 test cases of which 0 failed
| 0 test cases were skipped
| TEE test application done!

* Compiled with:
| make PLATFORM=amlogic

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
