### PR TITLE
symbolize.py: Python < 3.7 compatibility

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -106,7 +106,8 @@ class Symbolizer(object):
     def my_Popen(self, cmd):
         try:
             return subprocess.Popen(cmd, stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE, text=True,
+                                    stdout=subprocess.PIPE,
+                                    universal_newlines=True,
                                     bufsize=1)
         except OSError as e:
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
The documentation for the Python 3 subprocess module [1] has the
following note related to the Popen() constructor:

 Changed in version 3.7: Added the text parameter, as a more
 understandable alias of universal_newlines.

In order to avoid a runtime error with versions of Python prior to 3.7,
replace the 'text' parameter with 'universal_newlines'.

Link: [1] https://docs.python.org/3/library/subprocess.html
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
