### PR TITLE
libmbedtls: Fix Diffie-Helman operation wrong public key size

### DIFF
--- a/lib/libmbedtls/core/dh.c
+++ b/lib/libmbedtls/core/dh.c
@@ -50,6 +50,7 @@ TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key,
 	int lmd_res = 0;
 	mbedtls_dhm_context dhm;
 	unsigned char *buf = NULL;
+	size_t xbytes = 0;
 
 	memset(&dhm, 0, sizeof(dhm));
 	mbedtls_dhm_init(&dhm);
@@ -60,22 +61,22 @@ TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key,
 	dhm.len = crypto_bignum_num_bytes(key->p);
 
 	if (xbits == 0)
-		xbits = dhm.len;
+		xbytes = dhm.len;
 	else
-		xbits = xbits / 8;
+		xbytes = xbits / 8;
 
 	buf = malloc(dhm.len);
 	if (!buf) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto out;
 	}
-	lmd_res = mbedtls_dhm_make_public(&dhm, (int)xbits, buf,
+	lmd_res = mbedtls_dhm_make_public(&dhm, (int)xbytes, buf,
 					  dhm.len, mbd_rand, NULL);
 	if (lmd_res != 0) {
 		FMSG("mbedtls_dhm_make_public err, return is 0x%x", -lmd_res);
 		res = TEE_ERROR_BAD_PARAMETERS;
 	} else {
-		crypto_bignum_bin2bn(buf, xbits / 8, key->y);
+		crypto_bignum_bin2bn(buf, xbytes, key->y);
 		crypto_bignum_copy(key->x, (void *)&dhm.X);
 		res = TEE_SUCCESS;
 	}


### PR DESCRIPTION
GP wrapper of mbedtls DH operation generate key function wrongly
calculates the number of bytes from bits, leading to incorrect public
key generated and returned.

Change-Id: I3ea4e5a551b3af3b740b0f75cff1457bce68b866
Signed-off-by: Cao, Vincent T <vincent.t.cao@intel.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
