### PR TITLE
Fix ASLR bug: update cached_mem_end after relocation and switch tee_svc_uref_base to use VCORE_START_VA

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -500,6 +500,13 @@ shadow_stack_access_ok:
 	 */
 	ldr	r0, =boot_mmu_config
 	ldr	r0, [r0, #CORE_MMU_CONFIG_LOAD_OFFSET]
+	/*
+	 * Update cached_mem_end address with load offset since it was
+	 * calculated before relocation.
+	 */
+	ldr	r4, cached_mem_end
+	add	r4, r4, r0
+	str	r4, cached_mem_end
 	bl	relocate
 #endif
 

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -182,6 +182,14 @@ clear_nex_bss:
 	 * the memory will become write protected.
 	 */
 	ldr	x0, boot_mmu_config + CORE_MMU_CONFIG_LOAD_OFFSET
+	/*
+	 * Update cached_mem_end address with load offset since it was
+	 * calculated before relocation.
+	 */
+	adr	x5, cached_mem_end
+	ldr	x6, [x5]
+	add	x6, x6, x0
+	str	x6, [x5]
 	bl	relocate
 #endif
 

--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -49,7 +49,7 @@ TEE_Result __weak init_teecore(void)
 	is_first = 0;
 
 #ifdef CFG_WITH_USER_TA
-	tee_svc_uref_base = TEE_TEXT_VA_START;
+	tee_svc_uref_base = VCORE_START_VA;
 #endif
 
 #ifdef CFG_CORE_RESERVED_SHM


### PR DESCRIPTION
cached_mem_end was calculated before relocation. Add code to update cached_mem_end with ASLR load offset.

tee_svc_uref_base was using hardcoded TEE_TEXT_VA_START define value. This value no longer valid after TEE core relocation. Switch to use VCORE_START_VA which is linker variable that should get update after relocation code executed.

Signed-off-by: Khoa Hoang <admin@khoahoang.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
