### PR TITLE
hikey960: fix support for 4G & 6G boards

### DIFF
--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -55,6 +55,10 @@ CFG_CORE_BGET_BESTFIT ?= y
 ifeq ($(CFG_ARM32_core),y)
 CFG_ASAN_SHADOW_OFFSET ?= 0x372E38E0
 endif
+# Hikey960 4G/6G versions have physical addresses above 4G range
+ifneq (,$(filter 4 6,$(CFG_DRAM_SIZE_GB)))
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+endif
 endif
 
 CFG_TZDRAM_START ?= 0x3F000000


### PR DESCRIPTION
Since commit 4518cdc1ff64 ("core: arm64: introduce CFG_CORE_ARM64_PA_BITS")
platforms are required to define CFG_CORE_ARM64_PA_BITS if their physical
address space extends beyond 4G. This was missing for HiKey960 4G & 6G versions,
which indeed have addresses beyond 4G.
    
Signed-off-by: Henrik Uhrenfeldt <henrik.uhrenfeldt@huawei.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
