### PR TITLE
generic_boot: don't add fdt memory as NSEC memory

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -678,6 +678,10 @@ void core_mmu_set_prtn(struct mmu_partition *prtn);
 void core_mmu_set_default_prtn(void);
 
 void core_mmu_init_virtualization(void);
+#else
+static inline void core_mmu_init_virtualization(void)
+{
+}
 #endif
 
 #endif /*__ASSEMBLER__*/

--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -1054,9 +1054,9 @@ static void init_primary_helper(unsigned long pageable_part,
 	init_vfp_sec();
 	init_runtime(pageable_part);
 
-#ifndef CFG_VIRTUALIZATION
-	thread_init_boot_thread();
-#endif
+	if (!IS_ENABLED(CFG_VRTUALIZATION))
+		thread_init_boot_thread();
+
 	thread_init_primary(generic_boot_get_handlers());
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
@@ -1069,21 +1069,22 @@ static void init_primary_helper(unsigned long pageable_part,
 	configure_console_from_dt();
 
 	IMSG("OP-TEE version: %s", core_v_str);
-#ifdef CFG_CORE_ASLR
-	DMSG("Executing at offset %#lx with virtual load address %#"PRIxVA,
-	     (unsigned long)boot_mmu_config.load_offset, VCORE_START_VA);
-#endif
+	if (IS_ENABLED(CFG_CORE_ASLR))
+		DMSG("Executing at offset %#lx with virtual load address %#"PRIxVA,
+		     (unsigned long)boot_mmu_config.load_offset, VCORE_START_VA);
 
 	main_init_gic();
 	init_vfp_nsec();
-#ifndef CFG_VIRTUALIZATION
-	init_tee_runtime();
-#endif
+
+	if (!IS_ENABLED(CFG_VRTUALIZATION))
+		init_tee_runtime();
+
 	release_external_dt();
-#ifdef CFG_VIRTUALIZATION
-	IMSG("Initializing virtualization support");
-	core_mmu_init_virtualization();
-#endif
+
+	if (!IS_ENABLED(CFG_VRTUALIZATION)) {
+		IMSG("Initializing virtualization support");
+		core_mmu_init_virtualization();
+	}
 	DMSG("Primary CPU switching to normal world boot");
 }
 


### PR DESCRIPTION
If the memory is probed from DT, it will include all memory with the
TZRAM. This can lead to the following trace:
```
  I/TC: Non-secure external DT found
  E/TC:0 0 check_phys_mem_is_outside:330 Non-sec mem (0x10000000:0x40000000) overlaps map (type 2 0x4e000000:0x5d000)
  E/TC:0 0 Panic at core/arch/arm/mm/core_mmu.c:334 <check_phys_mem_is_outside>
  E/TC:0 0 TEE load address @ 0x4e000000
  E/TC:0 0 Call stack:
  E/TC:0 0  0x4e006fd1
```
Which rightfully complains that the TZRAM lies within the wrongly handed
over overall memory. To really hand-over only the non-secure memory,
lift the carve_out_phys_mem() function into the header and remove the
TZRAM area from overall memory.

Fixes https://github.com/OP-TEE/optee_os/issues/3567

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>