### PR TITLE
core: arm32: derive spsr from cpsr

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1210,7 +1210,7 @@ static bool get_spsr(bool is_32bit, unsigned long entry_func, uint32_t *spsr)
 	if (!is_32bit)
 		return false;
 
-	s = read_spsr();
+	s = read_cpsr();
 	s &= ~(CPSR_MODE_MASK | CPSR_T | CPSR_IT_MASK1 | CPSR_IT_MASK2);
 	s |= CPSR_MODE_USR;
 	if (entry_func & 1)
@@ -1284,6 +1284,7 @@ uint32_t thread_enter_user_mode(unsigned long a0, unsigned long a1,
 
 	tee_ta_update_session_utime_resume();
 
+	/* Derive SPSR from current CPSR/PSTATE readout. */
 	if (!get_spsr(is_32bit, entry_func, &spsr)) {
 		*exit_status0 = 1; /* panic */
 		*exit_status1 = 0xbadbadba;


### PR DESCRIPTION
When entering user mode, the bits of SPSR should be derived from CPSR.

Fixes: a702f5e71e79 "core: split thread_enter_user_mode"
Signed-off-by: Ali Zhang <alizhang@google.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
