### PR TITLE
core: huk_subkey: ISO C forbids empty initializer braces

### DIFF
--- a/core/kernel/huk_subkey.c
+++ b/core/kernel/huk_subkey.c
@@ -59,7 +59,7 @@ TEE_Result huk_subkey_derive(enum huk_subkey_usage usage,
 			     uint8_t *subkey, size_t subkey_len)
 {
 	void *ctx = NULL;
-	struct tee_hw_unique_key huk = { };
+	struct tee_hw_unique_key huk = { 0 };
 	TEE_Result res = TEE_SUCCESS;
 
 	if (subkey_len > HUK_SUBKEY_MAX_LEN)


### PR DESCRIPTION
Avoids following compiler warning.

| core/kernel/huk_subkey.c: In function 'huk_subkey_derive':
| core/kernel/huk_subkey.c:64:33: warning: ISO C forbids empty initializer braces [-Wpedantic]
|    64 |  struct tee_hw_unique_key huk = { };

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
