### PR TITLE
ci: travis: Use proper construct for full clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   - email: true
 
 git:
-  depth: 1000000
+  depth: false
 
 before_script:
   - export OPTEE_OS=$PWD


### PR DESCRIPTION
As per the Travis docs at
https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth to
avoid performing git clones with limited depth, the depth should be set
to "false", not to a large magic number.

Signed-off-by: David Brown <david.brown@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
