### PR TITLE
drivers: CAAM: Update caam_desc_pop() function for 64bit platforms

### DIFF
--- a/core/drivers/crypto/caam/caam_desc.c
+++ b/core/drivers/crypto/caam/caam_desc.c
@@ -80,10 +80,11 @@ void caam_desc_push(uint64_t *in_entry, paddr_t paddr)
 
 paddr_t caam_desc_pop(uint64_t *out_entry)
 {
+	const uint32_t *a32 = (const uint32_t *)out_entry;
 #ifdef CFG_CAAM_BIG_ENDIAN
-	return get_be64(out_entry);
+	return SHIFT_U64(get_be32(&a32[0]), 32) | get_be32(&a32[1]);
 #else
-	return get_le64(out_entry);
+	return SHIFT_U64(get_be32(&a32[1]), 32) | get_be32(&a32[0]);
 #endif /* CFG_CAAM_BIG_ENDIAN */
 }
 #else /* CFG_CAAM_64BIT */


### PR DESCRIPTION
Updated caam_desc_pop() for reading the output CAAM job ring
entry for 64-bit platforms

Signed-off-by: Priyanka Singh <priyanka.singh@nxp.com>
Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>