### PR TITLE
drivers: tzc: set maximum region size for tzc_auto_configure()

### DIFF
--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2017 NXP
+ * Copyright 2017-2020 NXP
  * All rights reserved.
  *
  * Peng Fan <peng.fan@nxp.com>
@@ -228,7 +228,17 @@ int tzc_auto_configure(vaddr_t addr, vaddr_t size, uint32_t attr,
 	uint64_t lsize = size;
 	uint32_t mask = 0;
 	int i = 0;
-	uint8_t pow = TZC380_POW;
+	uint8_t pow = 0;
+
+	assert(tzc.base);
+
+	/*
+	 * TZC380 RM
+	 * For region_attributes_<n> registers, region_size:
+	 * Note: The AXI address width, that is AXI_ADDRESS_MSB+1, controls the
+	 * upper limit value of the field.
+	 */
+	pow = tzc.addr_width;
 
 	while (lsize != 0 && pow > 15) {
 		region_size = 1ULL << pow;

--- a/core/include/drivers/tzc380.h
+++ b/core/include/drivers/tzc380.h
@@ -202,12 +202,6 @@ enum tzc_action {
 #define TZC_ATTR_REGION_ENABLE	0x1
 #define TZC_ATTR_REGION_DISABLE	0x0
 
-#ifdef CFG_WITH_LPAE
-#define TZC380_POW	48
-#else
-#define TZC380_POW	34
-#endif
-
 void tzc_init(vaddr_t base);
 void tzc_configure_region(uint8_t region, vaddr_t region_base, uint32_t attr);
 void tzc_region_enable(uint8_t region);


### PR DESCRIPTION
Hello,

Here is a small fix for `tzc_auto_configure()` function.

We met an error on a i.MX platform where this function creates a region of 8G when the AXI bus width is 32bits. This causes the newly created region to be ineffective.

According to the TZASC RM,

> Size of region <n>. See Table 3-16.
> Note
> The AXI address width, that is AXI_ADDRESS_MSB+1, controls the upper limit value of this field.

The ARM supports confirms this case is outside of the restrictions and the tzasc behavior would be unpredictable.

Thanks!
