### PR TITLE
core: imx: add default UART for sabreauto boards

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -224,6 +224,7 @@ ifneq (,$(filter $(PLATFORM_FLAVOR),mx6qpsabreauto mx6qsabreauto \
 	mx6dlsabreauto mx6solosabreauto))
 CFG_DDR_SIZE ?= 0x80000000
 CFG_NS_ENTRY_ADDR ?= 0x12000000
+CFG_UART_BASE ?= UART4_BASE
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx6qhmbedge))


### PR DESCRIPTION
Board imx6*sabreauto default UART is UART4 and not UART1.

Signed-off-by: Clement Faure <clement.faure@nxp.com>