### PR TITLE
Empty body for dump_fat() unless log level set to TRACE_FLOW

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1469,6 +1469,7 @@ func_exit:
 
 static TEE_Result get_fat_start_address(uint32_t *addr);
 
+#if (TRACE_LEVEL >= TRACE_FLOW)
 static void dump_fat(void)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
@@ -1516,6 +1517,11 @@ static void dump_fat(void)
 out:
 	free(fat_entries);
 }
+#else
+static void dump_fat(void)
+{
+}
+#endif
 
 #if (TRACE_LEVEL >= TRACE_DEBUG)
 static void dump_fh(struct rpmb_file_handle *fh)


### PR DESCRIPTION
Improves RPMB performance as dump_fat has various callers (write_fat_entry(), rpmb_fs_setup()).
When called, dump_fat traverses the whole list of FAT entries and prints out using FMSG().
dump_fat() should be used for debugging/tracing, but not for productive builds.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
