### PR TITLE
Jas/tpm system pta

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -30,6 +30,7 @@
 #include <trace.h>
 #include <utee_defines.h>
 #include <util.h>
+#include <kernel/tpm.h>
 
 #include <platform_config.h>
 
@@ -1153,6 +1154,7 @@ static void init_primary_helper(unsigned long pageable_part,
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
 	init_external_dt(fdt);
+	tpm_map_log_area(get_external_dt());
 	discover_nsec_memory();
 	update_external_dt();
 	configure_console_from_dt();

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -35,6 +35,14 @@ $(call force,CFG_PL011,y)
 $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 
+ifeq ($(CFG_CORE_TPM_EVENT_LOG),y)
+# NOTE: Below values for the TPM event log are implementation
+# dependent and used mostly for debugging purposes.
+# Care must be taken to properly configure them if used.
+CFG_TPM_LOG_BASE_ADDR ?= 0x402c951
+CFG_TPM_MAX_LOG_SIZE ?= 0x200
+endif
+
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_WITH_LPAE,y)
 else

--- a/core/include/kernel/tpm.h
+++ b/core/include/kernel/tpm.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2020, ARM Limited. All rights reserved.
+ */
+
+#ifndef __KERNEL_TPM_H__
+#define __KERNEL_TPM_H__
+
+#include <tee_api_types.h>
+
+#ifdef CFG_CORE_TPM_EVENT_LOG
+
+/*
+ * Returns the TPM Event Log information previously retrieved
+ * by @tpm_map_log_area.
+ *
+ * @buf Pointer to a buffer where to store a copy of the TPM Event log.
+ */
+TEE_Result tpm_get_event_log(void *buf, size_t *size);
+
+/*
+ * Reads the TPM Event log information and store it internally.
+ * If support for DTB is enabled, it will read the parameters there.
+ * Otherwise, it will use the constant parameters hardcoded in conf.mk.
+ *
+ * @fdt Pointer to the DTB blob where the TPM Event log information
+ * is expected to be.
+ */
+void tpm_map_log_area(void *fdt);
+
+#else
+
+static inline TEE_Result tpm_get_event_log(void *buf __unused,
+					   size_t *size __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline void tpm_map_log_area(void *fdt __unused)
+{}
+
+#endif /* CFG_CORE_TPM_EVENT_LOG */
+
+#endif /* __KERNEL_TPM_H__ */

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -17,3 +17,4 @@ srcs-y += scattered_array.c
 srcs-y += huk_subkey.c
 srcs-$(CFG_SHOW_CONF_ON_BOOT) += show_conf.c
 srcs-y += user_mode_ctx.c
+srcs-$(CFG_CORE_TPM_EVENT_LOG) += tpm.c

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2020, ARM Limited. All rights reserved.
+ */
+
+#include <mm/core_memprot.h>
+#include <kernel/tpm.h>
+#include <compiler.h>
+#include <string.h>
+#ifdef CFG_DT
+#include <kernel/dt.h>
+#include <libfdt.h>
+#endif
+
+static void *tpm_log_addr;
+static size_t tpm_log_size;
+
+/*
+ * Check whether the node at @offs contains TPM Event Log information or not.
+ *
+ * @offs is the offset of the node that describes the device in @fdt.
+ * @buf will contain the phy address of the TPM Event log.
+ * @size will contain the size of the mapped area.
+ *
+ * Returns the size of the mapped area or < 0 on failure.
+ */
+#ifdef CFG_DT
+static int read_dt_tpm_log_info(void *fdt, int node, paddr_t *buf,
+				size_t *size)
+{
+	const uint32_t *property = NULL;
+	const uint64_t zero_addr = 0;
+	int len_prop = 0;
+	paddr_t log_addr = 0;
+	int err = 0;
+
+	/*
+	 * Get the TPM Log address.
+	 */
+	property = fdt_getprop(fdt, node, "tpm_event_log_sm_addr", &len_prop);
+
+	if (!property  || len_prop != sizeof(uint32_t) * 2)
+		return -1;
+
+	log_addr = fdt32_to_cpu(property[1]);
+
+	err = fdt_setprop(fdt, node, "tpm_event_log_sm_addr", &zero_addr,
+			  sizeof(uint32_t) * 2);
+	if (err < 0) {
+		EMSG("Error setting property DTB to zero\n");
+		return err;
+	}
+
+	/*
+	 * Get the TPM Log size.
+	 */
+	property = fdt_getprop(fdt, node, "tpm_event_log_size", &len_prop);
+
+	if (!property || len_prop != sizeof(uint32_t))
+		return -1;
+
+	*size = fdt32_to_cpu(property[0]);
+	*buf = log_addr;
+
+	return *size;
+}
+#endif
+
+static void get_tpm_phys_params(void *fdt __maybe_unused,
+				paddr_t *addr, size_t *size)
+{
+#ifdef CFG_DT
+	int node = 0;
+	const char *dt_tpm_match_table = {
+		"arm,nt_fw",
+	};
+
+	if (!fdt) {
+		EMSG("TPM: No DTB found");
+		return;
+	}
+
+	node = fdt_node_offset_by_compatible(fdt, -1, dt_tpm_match_table);
+
+	if (node < 0) {
+		EMSG("TPM: Fail to find TPM node %i", node);
+		return;
+	}
+
+	if (read_dt_tpm_log_info((void *)fdt, node, addr, size) < 0) {
+		EMSG("TPM: Fail to retrieve DTB properties from node %i",
+		     node);
+		return;
+	}
+#else
+	*size = CFG_TPM_MAX_LOG_SIZE;
+	*addr = CFG_TPM_LOG_BASE_ADDR;
+#endif /* CFG_DT */
+}
+
+TEE_Result tpm_get_event_log(void *buf, size_t *size)
+{
+	const size_t buf_size = *size;
+
+	*size = tpm_log_size;
+	if (!buf) {
+		EMSG("TPM: Invalid buffer");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (buf_size < tpm_log_size) {
+		EMSG("TPM: Not enough space for the log: %zu, %lu",
+		     buf_size, tpm_log_size);
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	memcpy(buf, tpm_log_addr, tpm_log_size);
+
+	return TEE_SUCCESS;
+}
+
+void tpm_map_log_area(void *fdt)
+{
+	paddr_t log_addr = 0;
+	unsigned int rounded_size = 0;
+
+	get_tpm_phys_params(fdt, &log_addr, &tpm_log_size);
+
+	DMSG("TPM Event log PA: %#" PRIxPA, log_addr);
+	DMSG("TPM Event log size: %zu Bytes", tpm_log_size);
+
+	rounded_size = ROUNDUP(tpm_log_size, SMALL_PAGE_SIZE);
+
+	if (!core_mmu_add_mapping(MEM_AREA_RAM_SEC, log_addr, rounded_size)) {
+		EMSG("TPM: Failed to map TPM log memory");
+		return;
+	}
+
+	tpm_log_addr = phys_to_virt(log_addr, MEM_AREA_RAM_SEC);
+
+	if (!tpm_log_addr)
+		EMSG("TPM: Error mapping phys mem to va space");
+}

--- a/lib/libutee/include/pta_system.h
+++ b/lib/libutee/include/pta_system.h
@@ -182,4 +182,11 @@
  */
 #define PTA_SYSTEM_DLSYM                11
 
+/*
+ * Retrieves a copy of the TPM Event log held in secure memory.
+ *
+ * [out]    memref[0]: Pointer to the buffer where to store the event log.
+ */
+#define PTA_SYSTEM_GET_TPM_EVENT_LOG	12
+
 #endif /* __PTA_SYSTEM_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -514,3 +514,8 @@ CFG_CORE_HUK_SUBKEY_COMPAT ?= y
 # Compress and encode conf.mk into the TEE core, and show the encoded string on
 # boot (with severity TRACE_INFO).
 CFG_SHOW_CONF_ON_BOOT ?= n
+
+# Enables support for passing a TPM Event Log stored in secure memory
+# to a TA, so a TPM Service could use it to extend any measurement
+# taken before the service was up and running.
+CFG_CORE_TPM_EVENT_LOG ?= n

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -38,6 +38,7 @@ ta-mk-file-export-vars-$(sm) += CFG_TEE_TA_LOG_LEVEL
 ta-mk-file-export-vars-$(sm) += CFG_FTRACE_SUPPORT
 ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
+ta-mk-file-export-vars-$(sm) += CFG_CORE_TPM_EVENT_LOG
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.


### PR DESCRIPTION
Support to allow a TPM service to be able to retrieve an event log from secure memory maintained by early bootloaders in order to extend them once the TPM service is ready.

Refer to RFC #3596 
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
