### PR TITLE
core: RPMB FS: Make N_ENTRIES a config variable

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -37,7 +37,6 @@
 
 #define RPMB_FS_MAGIC                   0x52504D42
 #define FS_VERSION                      2
-#define N_ENTRIES                       8
 
 #define FILE_IS_ACTIVE                  (1u << 0)
 #define FILE_IS_LAST_ENTRY              (1u << 1)
@@ -1483,7 +1482,7 @@ static void dump_fat(void)
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
+	size = CFG_RPMB_FS_RD_ENTRIES * sizeof(struct rpmb_fat_entry);
 	fat_entries = malloc(size);
 	if (!fat_entries) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
@@ -1496,7 +1495,7 @@ static void dump_fat(void)
 		if (res != TEE_SUCCESS)
 			goto out;
 
-		for (i = 0; i < N_ENTRIES; i++) {
+		for (i = 0; i < CFG_RPMB_FS_RD_ENTRIES; i++) {
 
 			FMSG("flags 0x%x, size %d, address 0x%x, filename '%s'",
 				fat_entries[i].flags,
@@ -1731,7 +1730,7 @@ static TEE_Result read_fat(struct rpmb_file_handle *fh, tee_mm_pool_t *p)
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
+	size = CFG_RPMB_FS_RD_ENTRIES * sizeof(struct rpmb_fat_entry);
 	fat_entries = malloc(size);
 	if (!fat_entries) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
@@ -1750,7 +1749,7 @@ static TEE_Result read_fat(struct rpmb_file_handle *fh, tee_mm_pool_t *p)
 		if (res != TEE_SUCCESS)
 			goto out;
 
-		for (i = 0; i < N_ENTRIES; i++) {
+		for (i = 0; i < CFG_RPMB_FS_RD_ENTRIES; i++) {
 			/*
 			 * Look for an entry, matching filenames. (read, rm,
 			 * rename and stat.). Only store first filename match.
@@ -2334,7 +2333,7 @@ static TEE_Result rpmb_fs_dir_populate(const char *path,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	size = N_ENTRIES * sizeof(struct rpmb_fat_entry);
+	size = CFG_RPMB_FS_RD_ENTRIES * sizeof(struct rpmb_fat_entry);
 	fat_entries = malloc(size);
 	if (!fat_entries) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
@@ -2348,7 +2347,7 @@ static TEE_Result rpmb_fs_dir_populate(const char *path,
 		if (res != TEE_SUCCESS)
 			goto out;
 
-		for (i = 0; i < N_ENTRIES; i++) {
+		for (i = 0; i < CFG_RPMB_FS_RD_ENTRIES; i++) {
 			filename = fat_entries[i].filename;
 			if (fat_entries[i].flags & FILE_IS_ACTIVE) {
 				matched = false;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -141,6 +141,19 @@ CFG_RPMB_FS ?= n
 # tee-supplicant process will open /dev/mmcblk<id>rpmb
 CFG_RPMB_FS_DEV_ID ?= 0
 
+# This config variable determines the number of entries read in from RPMB at
+# once whenever a function traverses the RPMB FS. Increasing the default value
+# has the following consequences:
+# - More memory required on heap. A single FAT entry currently has a size of
+#   256 bytes.
+# - Potentially significant speed-ups for RPMB I/O. Depending on how many
+#   entries a function needs to traverse, the number of time-consuming RPMB
+#   read-in operations can be reduced.
+# Chosing a proper value is both platform- (available memory) and use-case-
+# dependent (potential number of FAT fs entries), so overwrite in platform
+# config files
+CFG_RPMB_FS_RD_ENTRIES ?= 8
+
 # Enables RPMB key programming by the TEE, in case the RPMB partition has not
 # been configured yet.
 # !!! Security warning !!!


### PR DESCRIPTION
Allows to configure the number of FAT fs entries to be read from RPMB
storage in one chunk. Increasing this number makes functions that
traverse the FAT fs read in more entries within a single RPMB read
operation. While this potentially improves RPMB I/O, it comes at the
cost of additional memory required to be allocated on the heap.
Determining an optimal size is platform- and use-case-dependent.

Signed-off-by: Manuel Huber <manuel.huber@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
