### PR TITLE
Hardware Unique Key (HUK) generation using the CAAM Master Key Verification Blob (MKVB) for i.MX platforms.

### DIFF
--- a/core/arch/arm/plat-imx/crypto_conf.mk
+++ b/core/arch/arm/plat-imx/crypto_conf.mk
@@ -18,9 +18,13 @@
 # DBG_HASH   BIT32(7)  // Hash trace
 # DBG_RSA    BIT32(8)  // RSA trace
 # DBG_CIPHER BIT32(9)  // Cipher trace
+# DBG_BLOB   BIT32(10) // BLOB trace
 CFG_DBG_CAAM_TRACE ?= 0x2
 CFG_DBG_CAAM_DESC ?= 0x0
 CFG_DBG_CAAM_BUF ?= 0x0
+
+# Enable the BLOB module used for the hardware unique key
+CFG_NXP_CAAM_BLOB_DRV ?= y
 
 #
 # CAAM Job Ring configuration

--- a/core/drivers/crypto/caam/blob/caam_blob.c
+++ b/core/drivers/crypto/caam/blob/caam_blob.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2020 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
+ */
+
+#include <caam_blob.h>
+#include <caam_common.h>
+#include <caam_hal_ctrl.h>
+#include <caam_jr.h>
+#include <caam_trace.h>
+#include <caam_utils_mem.h>
+#include <kernel/tee_common_otp.h>
+#include <mm/core_memprot.h>
+#include <stdint.h>
+#include <string.h>
+#include <tee/cache.h>
+
+#define MKVB_SIZE	32
+
+static uint8_t stored_key[MKVB_SIZE];
+static bool mkvb_retrieved;
+
+enum caam_status caam_blob_mkvb_init(vaddr_t baseaddr)
+{
+	struct caam_jobctx jobctx = { };
+	enum caam_status res = CAAM_NO_ERROR;
+	struct caambuf buf = { };
+	uint32_t *desc = NULL;
+
+	assert(!mkvb_retrieved);
+
+	res = caam_calloc_align_buf(&buf, MKVB_SIZE);
+	if (res != CAAM_NO_ERROR)
+		goto out;
+
+	desc = caam_calloc_desc(8);
+	if (!desc) {
+		res = CAAM_OUT_MEMORY;
+		goto out_buf;
+	}
+
+	caam_desc_init(desc);
+	caam_desc_add_word(desc, DESC_HEADER(0));
+	caam_desc_add_word(desc, SEQ_OUT_PTR(32));
+	caam_desc_add_ptr(desc, buf.paddr);
+	caam_desc_add_word(desc, BLOB_MSTR_KEY);
+	BLOB_DUMPDESC(desc);
+
+	cache_operation(TEE_CACHEFLUSH, buf.data, buf.length);
+
+	jobctx.desc = desc;
+	res = caam_jr_enqueue(&jobctx, NULL);
+
+	if (res != CAAM_NO_ERROR) {
+		BLOB_TRACE("JR return code: %#"PRIx32, res);
+		BLOB_TRACE("MKVB failed: Job status %#"PRIx32, jobctx.status);
+	} else {
+		cache_operation(TEE_CACHEINVALIDATE, buf.data, MKVB_SIZE);
+		BLOB_DUMPBUF("MKVB", buf.data, buf.length);
+		memcpy(&stored_key, buf.data, buf.length);
+		mkvb_retrieved = true;
+	}
+
+out_buf:
+	caam_free_desc(&desc);
+	caam_free_buf(&buf);
+out:
+	caam_hal_ctrl_inc_priblob(baseaddr);
+
+	return res;
+}
+
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+{
+	COMPILE_TIME_ASSERT(sizeof(hwkey->data) <= sizeof(stored_key));
+
+	if (!mkvb_retrieved)
+		return TEE_ERROR_SECURITY;
+
+	memcpy(&hwkey->data, &stored_key, sizeof(hwkey->data));
+	return TEE_SUCCESS;
+}

--- a/core/drivers/crypto/caam/blob/sub.mk
+++ b/core/drivers/crypto/caam/blob/sub.mk
@@ -1,0 +1,3 @@
+srcs-y += caam_blob.c
+
+incdirs-y += ../include

--- a/core/drivers/crypto/caam/caam_ctrl.c
+++ b/core/drivers/crypto/caam/caam_ctrl.c
@@ -109,7 +109,7 @@ exit_init:
 	return retresult;
 }
 
-driver_init(crypto_driver_init);
+early_init(crypto_driver_init);
 
 /* Crypto driver late initialization to complete on-going CAAM operations */
 static TEE_Result init_caam_late(void)
@@ -126,4 +126,4 @@ static TEE_Result init_caam_late(void)
 	return TEE_SUCCESS;
 }
 
-driver_init_late(init_caam_late);
+early_init_late(init_caam_late);

--- a/core/drivers/crypto/caam/caam_ctrl.c
+++ b/core/drivers/crypto/caam/caam_ctrl.c
@@ -12,6 +12,7 @@
 #include <caam_hal_ctrl.h>
 #include <caam_hash.h>
 #include <caam_jr.h>
+#include <caam_blob.h>
 #include <caam_pwr.h>
 #include <caam_rng.h>
 #include <caam_utils_mem.h>
@@ -82,6 +83,13 @@ static TEE_Result crypto_driver_init(void)
 
 	/* Initialize the HMAC Module */
 	retstatus = caam_hmac_init(jrcfg.base);
+	if (retstatus != CAAM_NO_ERROR) {
+		retresult = TEE_ERROR_GENERIC;
+		goto exit_init;
+	}
+
+	/* Initialize the BLOB Module */
+	retstatus = caam_blob_mkvb_init(jrcfg.base);
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;

--- a/core/drivers/crypto/caam/hal/common/hal_ctrl.c
+++ b/core/drivers/crypto/caam/hal/common/hal_ctrl.c
@@ -7,8 +7,11 @@
  */
 #include <caam_hal_ctrl.h>
 #include <caam_io.h>
+#include <caam_trace.h>
+#include <config.h>
 #include <registers/ctrl_regs.h>
 #include <registers/version_regs.h>
+#include <kernel/panic.h>
 
 uint8_t caam_hal_ctrl_jrnum(vaddr_t baseaddr)
 {
@@ -63,4 +66,39 @@ uint8_t caam_hal_ctrl_era(vaddr_t baseaddr)
 	val = io_caam_read32(baseaddr + CCBVID);
 
 	return GET_CCBVID_CAAM_ERA(val);
+}
+
+#define PRIBLOB_MASK	GENMASK_32(1, 0)
+
+void caam_hal_ctrl_inc_priblob(vaddr_t baseaddr)
+{
+	uint32_t val = 0;
+	uint32_t blob = 0;
+
+	if (!IS_ENABLED(CFG_CAAM_INC_PRIBLOB))
+		return;
+
+	val = io_caam_read32(baseaddr + SCFGR);
+	val &= PRIBLOB_MASK;
+	CTRL_TRACE("Reading CAAM PRIBLOB: 0x%"PRIx32, val);
+
+	if (val == 0 || val == 2)
+		blob = val + 1;
+	else if (val == 1)
+		blob = val + 2;
+	else
+		panic("Error locking PRIBLOB, PRIBLOB =3");
+
+	CTRL_TRACE("New CAAM PRIBLOB value: 0x%"PRIx32, blob);
+
+	val = io_caam_read32(baseaddr + SCFGR);
+	val |= blob;
+	io_caam_write32(baseaddr + SCFGR, val);
+
+	val = io_caam_read32(baseaddr + SCFGR);
+	val &= PRIBLOB_MASK;
+	CTRL_TRACE("Checking: CAAM PRIBLOB: 0x%"PRIx32 " want: 0x%"PRIx32, val,
+		   blob);
+	if (val != blob)
+		panic("Written PRIBLOB and read PRIBLOB do not match!");
 }

--- a/core/drivers/crypto/caam/include/caam_blob.h
+++ b/core/drivers/crypto/caam/include/caam_blob.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
+ */
+#ifndef __CAAM_BLOB_H__
+#define __CAAM_BLOB_H__
+
+#include <caam_common.h>
+
+#ifdef CFG_NXP_CAAM_BLOB_DRV
+/*
+ * Initialize the BLOB module
+ *
+ * @ctrl_addr   Controller base address
+ */
+enum caam_status caam_blob_mkvb_init(vaddr_t baseaddr);
+#else
+static inline enum caam_status caam_blob_mkvb_init(vaddr_t baseaddr __unused)
+{
+	return CAAM_NO_ERROR;
+}
+#endif /* CFG_NXP_CAAM_BLOB_DRV */
+
+#endif /* __CAAM_BLOB_H__ */

--- a/core/drivers/crypto/caam/include/caam_hal_ctrl.h
+++ b/core/drivers/crypto/caam/include/caam_hal_ctrl.h
@@ -51,4 +51,11 @@ bool caam_hal_ctrl_splitkey_support(vaddr_t baseaddr);
  * @baseaddr  Controller base address
  */
 uint8_t caam_hal_ctrl_era(vaddr_t baseaddr);
+
+/*
+ * Increment the CAAM PRIBLOB field
+ *
+ * @baseaddr  Controller base address
+ */
+void caam_hal_ctrl_inc_priblob(vaddr_t baseaddr);
 #endif /* __CAAM_HAL_CTRL_H__ */

--- a/core/drivers/crypto/caam/include/caam_trace.h
+++ b/core/drivers/crypto/caam/include/caam_trace.h
@@ -35,6 +35,7 @@
 #define DBG_TRACE_HASH	 BIT32(7)  /* Hash trace */
 #define DBG_TRACE_RSA	 BIT32(8)  /* RSA trace */
 #define DBG_TRACE_CIPHER BIT32(9)  /* Cipher dump Buffer */
+#define DBG_TRACE_BLOB   BIT32(10) /* BLOB trace */
 
 /* HAL */
 #if CAAM_DBG_TRACE(HAL)
@@ -192,6 +193,29 @@
 #define DRV_TRACE(...)
 #define DRV_DUMPDESC(...)
 #define DRV_DUMPBUF(...)
+#endif
+
+/* BLOB */
+#if CAAM_DBG_TRACE(BLOB)
+#define BLOB_TRACE DRV_TRACE
+#if CAAM_DBG_DESC(BLOB)
+#define BLOB_DUMPDESC(desc)                                                    \
+	do {                                                                   \
+		BLOB_TRACE("BLOB Descriptor");                                 \
+		DRV_DUMPDESC(desc);                                            \
+	} while (0)
+#else
+#define BLOB_DUMPDESC(desc)
+#endif
+#if CAAM_DBG_BUF(BLOB)
+#define BLOB_DUMPBUF DRV_DUMPBUF
+#else
+#define BLOB_DUMPBUF(...)
+#endif
+#else
+#define BLOB_TRACE(...)
+#define BLOB_DUMPDESC(desc)
+#define BLOB_DUMPBUF(...)
 #endif
 
 #endif /* CAAM_TRACE_H__ */

--- a/core/drivers/crypto/caam/sub.mk
+++ b/core/drivers/crypto/caam/sub.mk
@@ -11,3 +11,4 @@ srcs-y += caam_desc.c
 subdirs-$(call cfg-one-enabled, CFG_NXP_CAAM_HASH_DRV CFG_NXP_CAAM_HMAC_DRV) += hash
 subdirs-$(CFG_NXP_CAAM_CIPHER_DRV) += cipher
 subdirs-$(CFG_NXP_CAAM_ACIPHER_DRV) += acipher
+subdirs-$(CFG_NXP_CAAM_BLOB_DRV) += blob

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -18,10 +18,12 @@ typedef TEE_Result (*initcall_t)(void);
 #define initcall_begin	SCATTERED_ARRAY_BEGIN(initcall, initcall_t)
 #define initcall_end	SCATTERED_ARRAY_END(initcall, initcall_t)
 
-#define service_init(fn)	__define_initcall(1, fn)
-#define service_init_late(fn)	__define_initcall(2, fn)
-#define driver_init(fn)		__define_initcall(3, fn)
-#define driver_init_late(fn)	__define_initcall(4, fn)
+#define early_init(fn)			__define_initcall(1, fn)
+#define early_init_late(fn)		__define_initcall(2, fn)
+#define service_init(fn)		__define_initcall(3, fn)
+#define service_init_late(fn)		__define_initcall(4, fn)
+#define driver_init(fn)			__define_initcall(5, fn)
+#define driver_init_late(fn)		__define_initcall(6, fn)
 
 
 #endif


### PR DESCRIPTION
This is a port of PR #3160 to the NXP CAAM driver. The i.MX platform configuration is also modified to enable the MKVB generation for all possible platforms.
This PR:
1. introduces a early_driver initcall which runs before the service initcalls
2. moves the CAAM initialization there
3. implements a MKVB module which retrieves the MKVB
4. implements the platform implementation to retrieve a HUK using the MKVB
5. moves the jobring handoff into the driver_late initcall

This way there is always a jobring available during OP-TEE initialization which is used to retrieve the MKVB. Instead of disabling the complete CAAM driver, the default configuration now disables the crypto driver and runtime jobring access to prevent the SoC hang if clocks are disabled.

cc @clementfaure 