### PR TITLE
core: panic(): don't lose the message in non-debug mode

### DIFF
--- a/core/include/kernel/panic.h
+++ b/core/include/kernel/panic.h
@@ -12,7 +12,7 @@
 #if defined(CFG_TEE_CORE_DEBUG)
 #define __panic(str)	__do_panic(__FILE__, __LINE__, __func__, str)
 #else
-#define __panic(str)	__do_panic((void *)0, 0, (void *)0, (void *)0)
+#define __panic(str)	__do_panic((void *)0, 0, (void *)0, str)
 #endif
 
 void __do_panic(const char *file, const int line, const char *func,


### PR DESCRIPTION
When CFG_TEE_CORE_DEBUG != y, panic("Some text") prints no file/line/
function information (which is expected in non-debug mode) but it also
ignores its parameter. As a result, the console simply shows "Panic"
which is not very helpful.

There is no reason not to print the panic message, so add it.
Note that it is still possible to build a fully silent OP-TEE by
setting the log level to zero.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
