### PR TITLE
core: crypto: caam: hash: fix core data-abort

### DIFF
--- a/core/drivers/crypto/caam/hash/caam_hash.c
+++ b/core/drivers/crypto/caam/hash/caam_hash.c
@@ -562,7 +562,7 @@ static TEE_Result do_final(struct crypto_hash_ctx *ctx, uint8_t *digest,
 					alg->size_digest);
 
 		if (realloc)
-			memcpy(digest, digest_align.data, len);
+			memcpy(digest, digest_align.data, alg->size_digest);
 
 		HASH_DUMPBUF("Digest", digest_align.data,
 			     (size_t)alg->size_digest);


### PR DESCRIPTION
Fix memory corruption caused by writing beyond the buffer limits (ie using TA length instead of size_digest).

Tested on iMX7ulp.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
