### PR TITLE
ta: pkcs11: add TA version property mandated by GPD

### DIFF
--- a/ta/pkcs11/src/user_ta_header_defines.h
+++ b/ta/pkcs11/src/user_ta_header_defines.h
@@ -17,4 +17,9 @@
 #define TA_STACK_SIZE			(4 * 1024)
 #define TA_DATA_SIZE			(16 * 1024)
 
+#define TA_DESCRIPTION			"PKCS#11 trusted application"
+#define TA_VERSION			TO_STR(PKCS11_TA_VERSION_MAJOR) "." \
+					TO_STR(PKCS11_TA_VERSION_MINOR) "." \
+					TO_STR(PKCS11_TA_VERSION_PATCH)
+
 #endif /*USER_TA_HEADER_DEFINES_H*/


### PR DESCRIPTION
GPD TEE specification mandates that trusted applications provide
a  version information through TA property "gpd.ta.version". This
change implement this propoerty for the PKCS11 TA. The version number
is defined by PKCS11_TA_VERSION_MAJOR/PKCS11_TA_VERSION_MINOR in TA
API header file.

This change also adds a short description in "gpd.ta.description".

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
