### PR TITLE
ta: pkcs11: persistent database for the pkcs11 tokens

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -54,18 +54,20 @@
  * Param#3 is currently unused and reserved for evolution of the API.
  */
 
-/*
- * PKCS11_CMD_PING		Acknowledge TA presence and return version info
- *
- * [in]         memref[0] = 32bit, unused, must be 0
- * [out]        memref[0] = 32bit return code, enum pkcs11_rc
- * [out]        memref[2] = [
- *                      32bit version major value,
- *                      32bit version minor value
- *                      32bit version patch value
- *              ]
- */
-#define PKCS11_CMD_PING				0
+enum pkcs11_ta_cmd {
+	/*
+	 * PKCS11_CMD_PING		Ack TA presence and return version info
+	 *
+	 * [in]  memref[0] = 32bit, unused, must be 0
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = [
+	 *              32bit version major value,
+	 *              32bit version minor value
+	 *              32bit version patch value
+	 *       ]
+	 */
+	PKCS11_CMD_PING = 0,
+};
 
 /*
  * Command return codes

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -11,14 +11,16 @@
 #include <util.h>
 
 #include "pkcs11_helpers.h"
+#include "pkcs11_token.h"
 
 TEE_Result TA_CreateEntryPoint(void)
 {
-	return TEE_SUCCESS;
+	return pkcs11_init();
 }
 
 void TA_DestroyEntryPoint(void)
 {
+	pkcs11_deinit();
 }
 
 TEE_Result TA_OpenSessionEntryPoint(uint32_t __unused param_types,

--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2018-2020, Linaro Limited
+ */
+
+#include <assert.h>
+#include <pkcs11_ta.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee_internal_api_extensions.h>
+#include <util.h>
+
+#include "pkcs11_token.h"
+#include "pkcs11_helpers.h"
+
+void close_persistent_db(struct ck_token *token __unused)
+{
+}
+
+static void init_pin_keys(struct ck_token *token, unsigned int uid)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	unsigned int token_id = get_token_id(token);
+	TEE_ObjectHandle key_hdl = TEE_HANDLE_NULL;
+	char file[32] = { 0 };
+
+	assert(token_id < 10 && uid < 10);
+
+	if (snprintf(file, 32, "token.db.%1d-pin%1d", token_id, uid) >= 32)
+		TEE_Panic(0);
+
+	res = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
+				       file, sizeof(file), 0, &key_hdl);
+
+	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+		TEE_Attribute attr = { };
+		TEE_ObjectHandle hdl = TEE_HANDLE_NULL;
+		uint8_t pin_key[16] = { 0 };
+
+		TEE_MemFill(&attr, 0, sizeof(attr));
+
+		TEE_GenerateRandom(pin_key, sizeof(pin_key));
+		TEE_InitRefAttribute(&attr, TEE_ATTR_SECRET_VALUE,
+				     pin_key, sizeof(pin_key));
+
+		res = TEE_AllocateTransientObject(TEE_TYPE_AES, 128, &hdl);
+		if (res)
+			TEE_Panic(0);
+
+		res = TEE_PopulateTransientObject(hdl, &attr, 1);
+		if (res)
+			TEE_Panic(0);
+
+		res = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
+						 file, sizeof(file), 0, hdl,
+						 pin_key, sizeof(pin_key),
+						 &key_hdl);
+		TEE_CloseObject(hdl);
+
+		if (res == TEE_SUCCESS)
+			DMSG("Token %u: PIN key created", token_id);
+	}
+
+	if (res)
+		TEE_Panic(res);
+
+	TEE_CloseObject(key_hdl);
+}
+
+/*
+ * Return the token instance, either initialized from reset or initialized
+ * from the token persistent state if found.
+ */
+struct ck_token *init_persistent_db(unsigned int token_id)
+{
+	struct ck_token *token = get_token(token_id);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	char db_file[32] = { 0 };
+	TEE_ObjectHandle db_hdl = TEE_HANDLE_NULL;
+	struct token_persistent_main *db_main = NULL;
+	int n = 0;
+
+	if (!token)
+		return NULL;
+
+	for (n = 0; n < PKCS11_MAX_USERS; n++)
+		init_pin_keys(token, n);
+
+	db_main = TEE_Malloc(sizeof(*db_main), TEE_MALLOC_FILL_ZERO);
+	if (!db_main)
+		goto error;
+
+	if (snprintf(db_file, 32, "token.db.%1d", token_id) >= 32)
+		TEE_Panic(0);
+
+	res = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
+				       db_file, sizeof(db_file),
+				       TEE_DATA_FLAG_ACCESS_READ |
+				       TEE_DATA_FLAG_ACCESS_WRITE,
+				       &db_hdl);
+	if (res == TEE_SUCCESS) {
+		uint32_t size = 0;
+
+		IMSG("PKCS11 token %u: load db", token_id);
+
+		size = sizeof(*db_main);
+		res = TEE_ReadObjectData(db_hdl, db_main, size, &size);
+		if (res || size != sizeof(*db_main))
+			TEE_Panic(0);
+	} else if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+		IMSG("PKCS11 token %u: init db", token_id);
+
+		TEE_MemFill(db_main, 0, sizeof(*db_main));
+		TEE_MemFill(db_main->label, '*', sizeof(db_main->label));
+
+		db_main->flags = PKCS11_CKFT_SO_PIN_TO_BE_CHANGED |
+				 PKCS11_CKFT_USER_PIN_TO_BE_CHANGED |
+				 PKCS11_CKFT_RNG |
+				 PKCS11_CKFT_DUAL_CRYPTO_OPERATIONS |
+				 PKCS11_CKFT_LOGIN_REQUIRED;
+
+		res = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
+						 db_file, sizeof(db_file),
+						 TEE_DATA_FLAG_ACCESS_READ |
+						 TEE_DATA_FLAG_ACCESS_WRITE,
+						 TEE_HANDLE_NULL,
+						 db_main, sizeof(*db_main),
+						 &db_hdl);
+		if (res) {
+			EMSG("Failed to create db: %"PRIx32, res);
+			goto error;
+		}
+	} else {
+		goto error;
+	}
+
+	token->db_main = db_main;
+	TEE_CloseObject(db_hdl);
+
+	return token;
+
+error:
+	TEE_Free(db_main);
+	if (db_hdl != TEE_HANDLE_NULL)
+		TEE_CloseObject(db_hdl);
+
+	return NULL;
+}

--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -62,6 +62,36 @@ static const char *id2str(uint32_t id, const struct any_id *table,
  */
 static const struct any_id __maybe_unused string_ta_cmd[] = {
 	PKCS11_ID(PKCS11_CMD_PING),
+	PKCS11_ID(PKCS11_CMD_SLOT_LIST),
+	PKCS11_ID(PKCS11_CMD_SLOT_INFO),
+	PKCS11_ID(PKCS11_CMD_TOKEN_INFO),
+};
+
+static const struct any_id __maybe_unused string_slot_flags[] = {
+	PKCS11_ID(PKCS11_CKFS_TOKEN_PRESENT),
+	PKCS11_ID(PKCS11_CKFS_REMOVABLE_DEVICE),
+	PKCS11_ID(PKCS11_CKFS_HW_SLOT),
+};
+
+static const struct any_id __maybe_unused string_token_flags[] = {
+	PKCS11_ID(PKCS11_CKFT_RNG),
+	PKCS11_ID(PKCS11_CKFT_WRITE_PROTECTED),
+	PKCS11_ID(PKCS11_CKFT_LOGIN_REQUIRED),
+	PKCS11_ID(PKCS11_CKFT_USER_PIN_INITIALIZED),
+	PKCS11_ID(PKCS11_CKFT_RESTORE_KEY_NOT_NEEDED),
+	PKCS11_ID(PKCS11_CKFT_CLOCK_ON_TOKEN),
+	PKCS11_ID(PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH),
+	PKCS11_ID(PKCS11_CKFT_DUAL_CRYPTO_OPERATIONS),
+	PKCS11_ID(PKCS11_CKFT_TOKEN_INITIALIZED),
+	PKCS11_ID(PKCS11_CKFT_USER_PIN_COUNT_LOW),
+	PKCS11_ID(PKCS11_CKFT_USER_PIN_FINAL_TRY),
+	PKCS11_ID(PKCS11_CKFT_USER_PIN_LOCKED),
+	PKCS11_ID(PKCS11_CKFT_USER_PIN_TO_BE_CHANGED),
+	PKCS11_ID(PKCS11_CKFT_SO_PIN_COUNT_LOW),
+	PKCS11_ID(PKCS11_CKFT_SO_PIN_FINAL_TRY),
+	PKCS11_ID(PKCS11_CKFT_SO_PIN_LOCKED),
+	PKCS11_ID(PKCS11_CKFT_SO_PIN_TO_BE_CHANGED),
+	PKCS11_ID(PKCS11_CKFT_ERROR_STATE),
 };
 
 static const struct any_id __maybe_unused string_rc[] = {
@@ -121,5 +151,15 @@ const char *id2str_rc(uint32_t id)
 const char *id2str_ta_cmd(uint32_t id)
 {
 	return ID2STR(id, string_ta_cmd, NULL);
+}
+
+const char *id2str_slot_flag(uint32_t id)
+{
+	return ID2STR(id, string_slot_flags, "PKCS11_CKFS_");
+}
+
+const char *id2str_token_flag(uint32_t id)
+{
+	return ID2STR(id, string_token_flags, "PKCS11_CKFT_");
 }
 #endif /*CFG_TEE_TA_LOG_LEVEL*/

--- a/ta/pkcs11/src/pkcs11_helpers.h
+++ b/ta/pkcs11/src/pkcs11_helpers.h
@@ -19,5 +19,7 @@
 /* Id-to-string conversions only for trace support */
 const char *id2str_ta_cmd(uint32_t id);
 const char *id2str_rc(uint32_t id);
-#endif
+const char *id2str_slot_flag(uint32_t id);
+const char *id2str_token_flag(uint32_t id);
+#endif /* CFG_TEE_TA_LOG_LEVEL > 0 */
 #endif /*PKCS11_HELPERS_H*/

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017-2020, Linaro Limited
+ */
+
+#include <assert.h>
+#include <pkcs11_ta.h>
+#include <string.h>
+#include <string_ext.h>
+#include <sys/queue.h>
+#include <tee_api_types.h>
+#include <tee_internal_api_extensions.h>
+#include <util.h>
+
+#include "pkcs11_token.h"
+#include "pkcs11_helpers.h"
+
+/* Provide 3 slots/tokens, ID is token index */
+#ifndef CFG_PKCS11_TA_TOKEN_COUNT
+#define TOKEN_COUNT		3
+#else
+#define TOKEN_COUNT		CFG_PKCS11_TA_TOKEN_COUNT
+#endif
+
+/* Static allocation of tokens runtime instances (reset to 0 at load) */
+struct ck_token ck_token[TOKEN_COUNT];
+
+/* Static allocation of tokens runtime instances */
+struct ck_token *get_token(unsigned int token_id)
+{
+	if (token_id > TOKEN_COUNT)
+		return NULL;
+
+	return &ck_token[token_id];
+}
+
+unsigned int get_token_id(struct ck_token *token)
+{
+	ptrdiff_t id = token - ck_token;
+
+	assert(id >= 0 && id < TOKEN_COUNT);
+	return id;
+}
+
+static TEE_Result pkcs11_token_init(unsigned int id)
+{
+	struct ck_token *token = init_persistent_db(id);
+
+	if (!token)
+		return TEE_ERROR_SECURITY;
+
+	if (token->state == PKCS11_TOKEN_RESET) {
+		/* As per PKCS#11 spec, token resets to read/write state */
+		token->state = PKCS11_TOKEN_READ_WRITE;
+		token->session_count = 0;
+		token->rw_session_count = 0;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pkcs11_init(void)
+{
+	unsigned int id = 0;
+	TEE_Result ret = TEE_ERROR_GENERIC;
+
+	for (id = 0; id < TOKEN_COUNT; id++) {
+		ret = pkcs11_token_init(id);
+		if (ret)
+			return ret;
+	}
+
+	return ret;
+}
+
+void pkcs11_deinit(void)
+{
+	unsigned int id = 0;
+
+	for (id = 0; id < TOKEN_COUNT; id++)
+		close_persistent_db(get_token(id));
+}

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017-2020, Linaro Limited
+ */
+#ifndef PKCS11_TA_PKCS11_TOKEN_H
+#define PKCS11_TA_PKCS11_TOKEN_H
+
+#include <sys/queue.h>
+#include <tee_api_types.h>
+#include <tee_internal_api.h>
+
+enum pkcs11_token_state {
+	PKCS11_TOKEN_RESET = 0,
+	PKCS11_TOKEN_READ_WRITE,
+	PKCS11_TOKEN_READ_ONLY,
+};
+
+#define PKCS11_MAX_USERS		2
+#define PKCS11_TOKEN_PIN_SIZE		128
+
+/*
+ * Persistent state of the token
+ *
+ * @version - currently unused...
+ * @label - pkcs11 formatted token label, set by client
+ * @flags - pkcs11 token flags
+ * @so_pin_count - counter on security officer login failure
+ * @so_pin_size - byte size of the provisioned SO PIN
+ * @so_pin - stores the SO PIN
+ * @user_pin_count - counter on user login failure
+ * @user_pin_size - byte size of the provisioned user PIN
+ * @user_pin - stores the user PIN
+ */
+struct token_persistent_main {
+	uint32_t version;
+	uint8_t label[PKCS11_TOKEN_LABEL_SIZE];
+	uint32_t flags;
+	uint32_t so_pin_count;
+	uint32_t so_pin_size;
+	uint8_t so_pin[PKCS11_TOKEN_PIN_SIZE];
+	uint32_t user_pin_count;
+	uint32_t user_pin_size;
+	uint8_t user_pin[PKCS11_TOKEN_PIN_SIZE];
+};
+
+/*
+ * Runtime state of the token, complies with pkcs11
+ *
+ * @state - Pkcs11 login is public, user, SO or custom
+ * @session_count - Counter for opened Pkcs11 sessions
+ * @rw_session_count - Count for opened Pkcs11 read/write sessions
+ * @db_main - Volatile copy of the persistent main database
+ */
+struct ck_token {
+	enum pkcs11_token_state state;
+	uint32_t session_count;
+	uint32_t rw_session_count;
+	/* Copy in RAM of the persistent database */
+	struct token_persistent_main *db_main;
+};
+
+/* Initialize static token instance(s) from default/persistent database */
+TEE_Result pkcs11_init(void);
+void pkcs11_deinit(void);
+
+/* Return token instance from token identifier */
+struct ck_token *get_token(unsigned int token_id);
+
+/* Return token identified from token instance address */
+unsigned int get_token_id(struct ck_token *token);
+
+/* Access to persistent database */
+struct ck_token *init_persistent_db(unsigned int token_id);
+void close_persistent_db(struct ck_token *token);
+
+#endif /*PKCS11_TA_PKCS11_TOKEN_H*/

--- a/ta/pkcs11/src/sub.mk
+++ b/ta/pkcs11/src/sub.mk
@@ -1,2 +1,4 @@
 srcs-y += entry.c
+srcs-y += persistent_token.c
 srcs-y += pkcs11_helpers.c
+srcs-y += pkcs11_token.c


### PR DESCRIPTION
Initialize token(s) state from a persistent database. If no
persistent database is found in the secure storage, initialize
it to a default state and save the database in secure storage.

PKCS11 TA may implement several tokens each related to its own
database.

A token persistent database is stored in several part in TEE secure
storage. The main database stores token label, flags and PINs status.
Another database stores the UUIDs of the TEE persistent objects
used to store the token PKCS11 objects allowing the token to find
back PKCS11 persistent objects. This object database is out of the
scope of this change.

At runtime, a token instance is reference by a struct ck_token instance
in RAM which stores the state of the token and references to the
resources the token as loaded as PIN cipher keys (see paragraph below),
session states and the volatile copy of the persistent databases.

Among data saved in persistent database is the reference to
the keys used to cipher the PINs that will be used. A symmetric
encryption scheme is used using keys PKCS11 TA does not have access
to. This allows PKCS11 TA to save in RAM an encryption value of
the owners PINs.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
