### PR TITLE
Revert "ftrace: define CFG_FTRACE_BUF_SIZE in mk/config.mk"

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -382,10 +382,6 @@ CFG_TA_GPROF_SUPPORT ?= n
 # defined in tee-supplicant)
 CFG_FTRACE_SUPPORT ?= n
 
-# Size of the function tracing buffer in bytes. The memory size required to
-# map the TA is increased by this value compared to when ftrace is disabled.
-CFG_FTRACE_BUF_SIZE ?= 2048
-
 # How to make room when the function tracing buffer is full?
 # 'shift': shift the previously stored data by the amount needed in order
 #    to always keep the latest logs (slower, especially with big buffer sizes)

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -9,6 +9,10 @@ OUTPUT_ARCH(aarch64)
 #define MCOUNT_SYM _mcount
 #endif
 
+#ifndef CFG_FTRACE_BUF_SIZE
+#define CFG_FTRACE_BUF_SIZE 2048
+#endif
+
 SECTIONS {
 	.ta_head : {*(.ta_head)}
 	.text : {


### PR DESCRIPTION
This reverts commit 59e8ef0dcb3773964fd133d0a9360989cb86108f.

The default value for CFG_FTRACE_BUF_SIZE needs to be in the TA link
script ta.ld.S, because this file is *not* pre-processed before being
added to the TA dev kit. Replacement of CFG_* values only happens when
the TA is built, at which point mk/config.mk is irrelevant. It makes
sense of course, since it allows to change TA settings and re-build
only the TA.

Fixes the following TA link error:

 $ make CFLAGS_ta_arm32=-pg
 [...]
 bin/arm-linux-gnueabihf-ld.bfd:out/ta.lds:57: undefined symbol `CFG_FTRACE_BUF_SIZE' referenced in expression

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
