### PR TITLE
symbolize.py: add -L option to the "file" command

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -129,7 +129,7 @@ class Symbolizer(object):
         self._arch = os.getenv('CROSS_COMPILE')
         if self._arch:
             return
-        p = subprocess.Popen(['file', elf], stdout=subprocess.PIPE)
+        p = subprocess.Popen(['file', '-L', elf], stdout=subprocess.PIPE)
         output = p.stdout.readlines()
         p.terminate()
         if b'ARM aarch64,' in output[0]:


### PR DESCRIPTION
```
The symbolize script uses the "file" command to identify the
architecture of ELF binaries. If the file is a symbolic link (which can
happen with shared libraries typically), the command may fail to return
the expected output and print "symbolic link to <some path>" instead.

This behavior of the "file" command depends on the environment variable
POSIXLY_CORRECT. In order to not depend on this, this commit adds the
-L option (follow symlinks).

Signed-off-by: Jerome Forissier <jerome@forissier.org>
```