### PR TITLE
clang: use llvm-objdump

### DIFF
--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -24,19 +24,7 @@ endif
 AR$(sm)		:= $(ccache-cmd)llvm-ar
 NM$(sm)		:= llvm-nm
 OBJCOPY$(sm)	:= llvm-objcopy
-
-# llvm-objdump:
-# - Does not support mixed 32-bit ARM and Thumb instructions
-# - Has a poorer output than the binutils version (static functions not shown,
-#   for instance).
-# Rely on the GNU binutils version instead (if available).
-binutils-objdump = $(CROSS_COMPILE_$(sm))objdump
-ifneq (,$(filter GNU,$(shell $(binutils-objdump) -v 2>&1)))
-OBJDUMP$(sm)	:= $(binutils-objdump)
-else
-OBJDUMP$(sm)	:= echo "Warning: binutils objdump not found, file will be empty" >&2; true
-endif
-
+OBJDUMP$(sm)	:= llvm-objdump
 READELF$(sm)	:= llvm-readelf
 
 nostdinc$(sm)	:= -nostdinc -isystem $(shell $(CC$(sm)) \


### PR DESCRIPTION
Clang version 9.0.0 has a llvm-objdump tool that provides equivalent
output to the binutils version. Let's use it and remove the hack in
mk/clang.mk.

With this, it is possible to build OP-TEE with Clang and without a GCC
toolchain.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
