### PR TITLE
core: mmu: fix secure memory end address

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -390,7 +390,7 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 	discovered_nsec_ddr_nelems = num_elems;
 
 	if (!core_mmu_check_end_pa(m[num_elems - 1].addr,
-				   m[num_elems - 1].size - 1))
+				   m[num_elems - 1].size))
 		panic();
 }
 

--- a/core/arch/arm/mm/core_mmu_private.h
+++ b/core/arch/arm/mm/core_mmu_private.h
@@ -39,7 +39,7 @@ static inline bool core_mmu_check_end_pa(paddr_t pa, size_t len)
 {
 	paddr_t end_pa = 0;
 
-	if (ADD_OVERFLOW(pa, len, &end_pa))
+	if (ADD_OVERFLOW(pa, len - 1, &end_pa))
 		return false;
 	return core_mmu_check_max_pa(end_pa);
 }


### PR DESCRIPTION
Correct test on memory physical end address that was not consistent
in use of `core_mmu_check_end_pa()`.

This change fixes `core_mmu_set_discovered_nsec_ddr()` where
`core_mmu_check_end_pa()` was called with a byte length argument
decreased by one whereas it should provide the effective byte size
 of the memory area.

This change fixes `core_mmu_check_end_pa()` so that it computes
the end address as start address plus byte size minus one to
obtain the inclusive end address `core_mmu_check_max_pa()` expects
as input argument.

Fixes: 4518cdc1ff64 ("core: arm64: introduce CFG_CORE_ARM64_PA_BITS")
