### PR TITLE
core: ree_fs_ta: fix bootstrap header size check

### DIFF
--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -184,7 +184,7 @@ static TEE_Result ree_fs_ta_open(const TEE_UUID *uuid,
 	    shdr->img_type == SHDR_ENCRYPTED_TA) {
 		TEE_UUID bs_uuid;
 
-		if (ta_size < SHDR_GET_SIZE(shdr) + sizeof(bs_hdr)) {
+		if (ta_size < SHDR_GET_SIZE(shdr) + sizeof(*bs_hdr)) {
 			res = TEE_ERROR_SECURITY;
 			goto error_free_hash;
 		}


### PR DESCRIPTION
This change fix bootstrap header size check. Before it use sizeof(bs_hdr) but bs_hdr is a struct pointer. Correct it to sizeof(*bs_hdr)