### PR TITLE
drivers: caam: RNG: provide plat_rng_init symbol

### DIFF
--- a/core/drivers/crypto/caam/caam_rng.c
+++ b/core/drivers/crypto/caam/caam_rng.c
@@ -16,6 +16,7 @@
 #include <mm/core_memprot.h>
 #include <rng_support.h>
 #include <tee/cache.h>
+#include <tee/tee_cryp_utl.h>
 #include <string.h>
 
 /*
@@ -568,5 +569,9 @@ uint8_t hw_get_random_byte(void)
 		panic();
 
 	return data;
+}
+
+void plat_rng_init(void)
+{
 }
 #endif


### PR DESCRIPTION
Not doing so calls the default implementation which generates
misleading rng trace information.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

``
> D/TC:0 0 caam_rng_init:536 Initialization
> D/TC:0 0 caam_rng_instantiation:428 RNG Instantation
> D/TC:0 0 caam_rng_instantiation:492 RNG Kick (inc=0) ret 0x00000000
> D/TC:0 0 prepare_inst_desc:367 RNG SH Status 0x00000000 - Key Status 0
> D/TC:0 0 prepare_inst_desc:373 Instantiation start at SH0 (2)
> D/TC:0 0 caam_rng_instantiation:504 RNG Job returned 0x00000000
> D/TC:0 0 caam_rng_instantiation:482 RNG All SH are instantiated (0x00000003)
> D/TC:0 0 caam_rng_instantiation:527 RNG Instantiation return 0x00000000
> D/TC:0 0 check_ta_store:638 TA store: "early TA"
> D/TC:0 0 check_ta_store:638 TA store: "Secure Storage TA"
> D/TC:0 0 check_ta_store:638 TA store: "REE [buffered]"
> D/TC:0 0 early_ta_init:254 Early TA 22250a54-0bf1-48fe-8002-7b20f1c9c9b1 size 22247 (compressed, uncompressed 38704)
> D/TC:0 0 mobj_mapped_shm_init:446 Shared memory address range: 9bf00000, 9df00000
**> E/TC:0 0 plat_rng_init:354 Warning: seeding RNG with zeroes**
``

