### PR TITLE
core: use adr_l to allow bigger data sections

### DIFF
--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -105,15 +105,15 @@ copy_init:
 	 * [struct boot_embdata + data] : Should be moved to __end, first
 	 * uint32_t tells the length of the struct + data
 	 */
-	adr	x0, __end		/* dst */
-	adr	x1, __data_end		/* src */
+	adr_l	x0, __end		/* dst */
+	adr_l	x1, __data_end		/* src */
 	ldr	w2, [x1]		/* struct boot_embdata::total_len */
 	/* Copy backwards (as memmove) in case we're overlapping */
 	add	x0, x0, x2
 	add	x1, x1, x2
 	adr	x3, cached_mem_end
 	str	x0, [x3]
-	adr	x2, __end
+	adr_l	x2, __end
 
 copy_init:
 	ldp	x3, x4, [x1, #-16]!
@@ -253,9 +253,9 @@ END_DATA cached_mem_end
 LOCAL_FUNC relocate , :
 	/* x0 holds load offset */
 #ifdef CFG_WITH_PAGER
-	adr	x6, __init_end
+	adr_l	x6, __init_end
 #else
-	adr	x6, __end
+	adr_l	x6, __end
 #endif
 	ldp	w2, w3, [x6, #BOOT_EMBDATA_RELOC_OFFSET]
 

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -176,7 +176,7 @@ END_FUNC thread_unwind_user_mode
 	1:
 
 		/* Point to the vector into the full mapping */
-		adr	x0, thread_user_kcode_offset
+		adr_l	x0, thread_user_kcode_offset
 		ldr	x0, [x0]
 		mrs	x1, vbar_el1
 		add	x1, x1, x0
@@ -188,7 +188,7 @@ END_FUNC thread_unwind_user_mode
 		 * Update the SP with thread_user_kdata_sp_offset as
 		 * described in init_user_kcode().
 		 */
-		adr	x0, thread_user_kdata_sp_offset
+		adr_l	x0, thread_user_kdata_sp_offset
 		ldr	x0, [x0]
 		add	sp, sp, x0
 #endif
@@ -454,7 +454,7 @@ eret_to_el0:
 
 #ifdef CFG_CORE_UNMAP_CORE_AT_EL0
 	/* Point to the vector into the reduced mapping */
-	adr	x0, thread_user_kcode_offset
+	adr_l	x0, thread_user_kcode_offset
 	ldr	x0, [x0]
 	mrs	x1, vbar_el1
 	sub	x1, x1, x0
@@ -463,7 +463,7 @@ eret_to_el0:
 
 #ifdef CFG_CORE_WORKAROUND_SPECTRE_BP_SEC
 	/* Store the SP offset in tpidr_el1 to be used below to update SP */
-	adr	x1, thread_user_kdata_sp_offset
+	adr_l	x1, thread_user_kdata_sp_offset
 	ldr	x1, [x1]
 	msr	tpidr_el1, x1
 #endif
@@ -520,7 +520,7 @@ icache_inv_user_range:
 
 #ifdef CFG_CORE_UNMAP_CORE_AT_EL0
 	/* Point to the vector into the reduced mapping */
-	adr	x2, thread_user_kcode_offset
+	adr_l	x2, thread_user_kcode_offset
 	ldr	x2, [x2]
 	mrs	x4, vbar_el1	/* this register must be preserved */
 	sub	x3, x4, x2

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -72,7 +72,7 @@ LOCAL_FUNC vector_fiq_entry , : , .identity_map
 END_FUNC vector_fiq_entry
 
 LOCAL_FUNC vector_cpu_on_entry , : , .identity_map
-	adr	x16, thread_cpu_on_handler_ptr
+	adr_l	x16, thread_cpu_on_handler_ptr
 	ldr	x16, [x16]
 	ldr	x17, boot_mmu_config + CORE_MMU_CONFIG_LOAD_OFFSET
 	sub	x16, x16, x17
@@ -85,7 +85,7 @@ END_FUNC vector_cpu_on_entry
 
 LOCAL_FUNC vector_cpu_off_entry , : , .identity_map
 	readjust_pc
-	adr	x16, thread_cpu_off_handler_ptr
+	adr_l	x16, thread_cpu_off_handler_ptr
 	ldr	x16, [x16]
 	blr	x16
 	mov	x1, x0
@@ -96,7 +96,7 @@ END_FUNC vector_cpu_off_entry
 
 LOCAL_FUNC vector_cpu_suspend_entry , : , .identity_map
 	readjust_pc
-	adr	x16, thread_cpu_suspend_handler_ptr
+	adr_l	x16, thread_cpu_suspend_handler_ptr
 	ldr	x16, [x16]
 	blr	x16
 	mov	x1, x0
@@ -107,7 +107,7 @@ END_FUNC vector_cpu_suspend_entry
 
 LOCAL_FUNC vector_cpu_resume_entry , : , .identity_map
 	readjust_pc
-	adr	x16, thread_cpu_resume_handler_ptr
+	adr_l	x16, thread_cpu_resume_handler_ptr
 	ldr	x16, [x16]
 	blr	x16
 	mov	x1, x0
@@ -118,7 +118,7 @@ END_FUNC vector_cpu_resume_entry
 
 LOCAL_FUNC vector_system_off_entry , : , .identity_map
 	readjust_pc
-	adr	x16, thread_system_off_handler_ptr
+	adr_l	x16, thread_system_off_handler_ptr
 	ldr	x16, [x16]
 	blr	x16
 	mov	x1, x0
@@ -129,7 +129,7 @@ END_FUNC vector_system_off_entry
 
 LOCAL_FUNC vector_system_reset_entry , : , .identity_map
 	readjust_pc
-	adr	x16, thread_system_reset_handler_ptr
+	adr_l	x16, thread_system_reset_handler_ptr
 	ldr	x16, [x16]
 	blr	x16
 	mov	x1, x0


### PR DESCRIPTION
Compiling for nxp lx2160ardb with debug enabled fails with:
make -j32 CFG_ARM64_core=y PLATFORM=ls-lx2160ardb DEBUG=1

out/arm-plat-ls/core/arch/arm/kernel/thread_a64.o: In function `el0_sync_a64':
optee_os/core/arch/arm/kernel/thread_a64.S:271:(.text.thread_excp_vect+0x424): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kcode_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
/optee_os/core/arch/arm/kernel/thread_a64.S:271:(.text.thread_excp_vect+0x43c): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kdata_sp_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
out/arm-plat-ls/core/arch/arm/kernel/thread_a64.o: In function `el0_irq_a64':
work/optee_os/core/arch/arm/kernel/thread_a64.S:283:(.text.thread_excp_vect+0x4a4): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kcode_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
optee_os/core/arch/arm/kernel/thread_a64.S:283:(.text.thread_excp_vect+0x4bc): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kdata_sp_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
out/arm-plat-ls/core/arch/arm/kernel/thread_a64.o: In function `el0_fiq_a64':
optee_os/core/arch/arm/kernel/thread_a64.S:290:(.text.thread_excp_vect+0x524): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kcode_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
optee_os/core/arch/arm/kernel/thread_a64.S:290:(.text.thread_excp_vect+0x53c): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kdata_sp_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
out/arm-plat-ls/core/arch/arm/kernel/thread_a64.o: In function `el0_sync_a32':
optee_os/core/arch/arm/kernel/thread_a64.S:306:(.text.thread_excp_vect+0x624): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kcode_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
optee_os/core/arch/arm/kernel/thread_a64.S:306:(.text.thread_excp_vect+0x63c): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kdata_sp_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
out/arm-plat-ls/core/arch/arm/kernel/thread_a64.o: In function `el0_irq_a32':
optee_os/core/arch/arm/kernel/thread_a64.S:318:(.text.thread_excp_vect+0x6a4): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kcode_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
optee_os/core/arch/arm/kernel/thread_a64.S:318:(.text.thread_excp_vect+0x6bc): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `thread_user_kdata_sp_offset' defined in COMMON section in out/arm-plat-ls/core/arch/arm/kernel/thread.o
out/arm-plat-ls/core/arch/arm/kernel/thread_a64.o: In function `el0_fiq_a32':
optee_os/core/arch/arm/kernel/thread_a64.S:325:(.text.thread_excp_vect+0x724): additional relocation overflows omitted from the output
make: *** [core/arch/arm/kernel/link.mk:39: out/arm-plat-ls/core/all_objs.o] Error 1

So let's replace that with adr_l and apply a similar fix of what
commit 82d398c0e05c ("core: generic_entry_a64.S: use adr_l to allow bigger data sections")
suggests

Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
