### PR TITLE
core: save_panic_stack(): make sure tsd is initialized

### DIFF
--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -297,6 +297,10 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 	if (tee_ta_get_current_session(&s))
 		panic("No current session");
 
+	tsd->abort_type = ABORT_TYPE_TA_PANIC;
+	tsd->abort_descr = 0;
+	tsd->abort_va = 0;
+
 	if (tee_mmu_check_access_rights(&to_user_ta_ctx(s->ctx)->uctx,
 					TEE_MEMORY_ACCESS_READ |
 					TEE_MEMORY_ACCESS_WRITE,
@@ -307,10 +311,6 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 				(uaddr_t)regs->r1);
 		return;
 	}
-
-	tsd->abort_type = ABORT_TYPE_TA_PANIC;
-	tsd->abort_descr = 0;
-	tsd->abort_va = 0;
 
 	save_panic_regs_a32_ta(tsd, (uint32_t *)regs->r1);
 }


### PR DESCRIPTION
If a TA fails to load due to an assertion failure in ldelf, the user
stack might be inaccessible. save_panic_stack() detects this situation
but fails to set abort information in the thread specific data (tsd).
As a result, the stack unwinding code can erroneously execute kernel
unwinding code and trigger an assertion:

 E/TC:? 0 assertion 'thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR' failed at core/arch/arm/include/kernel/misc.h:22 <get_core_pos>

The fix consists in moving the tsd initialization above the user stack
accessibility check.

Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
