### PR TITLE
core: system.pta: block access to user TA binary after initialize

### DIFF
--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -852,6 +852,11 @@ static TEE_Result invoke_command(void *sess_ctx, uint32_t cmd_id,
 				 TEE_Param params[TEE_NUM_PARAMS])
 {
 	struct tee_ta_session *s = tee_ta_get_calling_session();
+	bool ta_initializing = false;
+
+	if (s && is_user_ta_ctx(s->ctx)) {
+		ta_initializing = to_user_ta_ctx(s->ctx)->is_initializing;
+	}
 
 	switch (cmd_id) {
 	case PTA_SYSTEM_ADD_RNG_ENTROPY:
@@ -863,12 +868,20 @@ static TEE_Result invoke_command(void *sess_ctx, uint32_t cmd_id,
 	case PTA_SYSTEM_UNMAP:
 		return system_unmap(s, param_types, params);
 	case PTA_SYSTEM_OPEN_TA_BINARY:
+		if (!ta_initializing)
+			return TEE_ERROR_ACCESS_DENIED;
 		return system_open_ta_binary(sess_ctx, param_types, params);
 	case PTA_SYSTEM_CLOSE_TA_BINARY:
+		if (!ta_initializing)
+			return TEE_ERROR_ACCESS_DENIED;
 		return system_close_ta_binary(sess_ctx, param_types, params);
 	case PTA_SYSTEM_MAP_TA_BINARY:
+		if (!ta_initializing)
+			return TEE_ERROR_ACCESS_DENIED;
 		return system_map_ta_binary(sess_ctx, s, param_types, params);
 	case PTA_SYSTEM_COPY_FROM_TA_BINARY:
+		if (!ta_initializing)
+			return TEE_ERROR_ACCESS_DENIED;
 		return system_copy_from_ta_binary(sess_ctx, param_types,
 						  params);
 	case PTA_SYSTEM_SET_PROT:


### PR DESCRIPTION
This change block access to user TA binary after TA initialized to
prevent bad behaving user TA from extracting decrypted binary of
other TAs in system.

Signed-off-by: Khoa Hoang <admin@khoahoang.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
