### PR TITLE
ta: pkcs11: get list of slots and related info implemented in TA

### DIFF
--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -146,6 +146,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session __unused, uint32_t cmd,
 	case PKCS11_CMD_SLOT_LIST:
 		rc = entry_ck_slot_list(ptypes, params);
 		break;
+	case PKCS11_CMD_SLOT_INFO:
+		rc = entry_ck_slot_info(ptypes, params);
+		break;
 	default:
 		EMSG("Command 0x%"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -143,6 +143,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session __unused, uint32_t cmd,
 		rc = entry_ping(ptypes, params);
 		break;
 
+	case PKCS11_CMD_SLOT_LIST:
+		rc = entry_ck_slot_list(ptypes, params);
+		break;
 	default:
 		EMSG("Command 0x%"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <confine_array_index.h>
 #include <pkcs11_ta.h>
 #include <string.h>
 #include <string_ext.h>
@@ -26,13 +27,12 @@
 /* Static allocation of tokens runtime instances (reset to 0 at load) */
 struct ck_token ck_token[TOKEN_COUNT];
 
-/* Static allocation of tokens runtime instances */
 struct ck_token *get_token(unsigned int token_id)
 {
-	if (token_id > TOKEN_COUNT)
-		return NULL;
+	if (token_id < TOKEN_COUNT)
+		return &ck_token[confine_array_index(token_id, TOKEN_COUNT)];
 
-	return &ck_token[token_id];
+	return NULL;
 }
 
 unsigned int get_token_id(struct ck_token *token)

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -14,6 +14,7 @@
 
 #include "pkcs11_token.h"
 #include "pkcs11_helpers.h"
+#include "serializer.h"
 
 /* Provide 3 slots/tokens, ID is token index */
 #ifndef CFG_PKCS11_TA_TOKEN_COUNT
@@ -79,4 +80,37 @@ void pkcs11_deinit(void)
 
 	for (id = 0; id < TOKEN_COUNT; id++)
 		close_persistent_db(get_token(id));
+}
+
+uint32_t entry_ck_slot_list(uint32_t ptypes, TEE_Param *params)
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_MEMREF_OUTPUT,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Param *out = &params[2];
+	uint32_t token_id = 0;
+	const size_t out_size = sizeof(token_id) * TOKEN_COUNT;
+	uint8_t *id = NULL;
+
+	if (ptypes != exp_pt ||
+	    params[0].memref.size != TEE_PARAM0_SIZE_MIN)
+		return PKCS11_CKR_ARGUMENTS_BAD;
+
+	if (out->memref.size < out_size) {
+		out->memref.size = out_size;
+
+		if (out->memref.buffer)
+			return PKCS11_CKR_BUFFER_TOO_SMALL;
+		else
+			return PKCS11_CKR_OK;
+	}
+
+	for (token_id = 0, id = out->memref.buffer; token_id < TOKEN_COUNT;
+	     token_id++, id += sizeof(token_id))
+		TEE_MemMove(id, &token_id, sizeof(token_id));
+
+	out->memref.size = out_size;
+
+	return PKCS11_CKR_OK;
 }

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -73,4 +73,7 @@ unsigned int get_token_id(struct ck_token *token);
 struct ck_token *init_persistent_db(unsigned int token_id);
 void close_persistent_db(struct ck_token *token);
 
+/* Entry point for the TA commands */
+uint32_t entry_ck_slot_list(uint32_t ptypes, TEE_Param *params);
+
 #endif /*PKCS11_TA_PKCS11_TOKEN_H*/

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -9,6 +9,13 @@
 #include <tee_api_types.h>
 #include <tee_internal_api.h>
 
+/* Hard coded description */
+#define PKCS11_SLOT_DESCRIPTION		"OP-TEE PKCS11 TA"
+#define PKCS11_SLOT_MANUFACTURER	"Linaro"
+#define PKCS11_SLOT_HW_VERSION		{ 0, 0 }
+#define PKCS11_SLOT_FW_VERSION		{ PKCS11_TA_VERSION_MAJOR, \
+					  PKCS11_TA_VERSION_MINOR }
+
 enum pkcs11_token_state {
 	PKCS11_TOKEN_RESET = 0,
 	PKCS11_TOKEN_READ_WRITE,
@@ -75,5 +82,6 @@ void close_persistent_db(struct ck_token *token);
 
 /* Entry point for the TA commands */
 uint32_t entry_ck_slot_list(uint32_t ptypes, TEE_Param *params);
+uint32_t entry_ck_slot_info(uint32_t ptypes, TEE_Param *params);
 
 #endif /*PKCS11_TA_PKCS11_TOKEN_H*/

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -63,7 +63,7 @@ struct ck_token {
 TEE_Result pkcs11_init(void);
 void pkcs11_deinit(void);
 
-/* Return token instance from token identifier */
+/* Speculation safe lookup of token instance from token identifier */
 struct ck_token *get_token(unsigned int token_id);
 
 /* Return token identified from token instance address */

--- a/ta/pkcs11/src/serializer.c
+++ b/ta/pkcs11/src/serializer.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017-2020, Linaro Limited
+ */
+
+#include <pkcs11_ta.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <tee_internal_api.h>
+#include <trace.h>
+
+#include "serializer.h"
+
+/*
+ * Util routines for serializes unformatted arguments in a client memref
+ */
+void serialargs_init(struct serialargs *args, void *in, size_t size)
+{
+	args->start = in;
+	args->next = in;
+	args->size = size;
+}
+
+uint32_t serialargs_get(struct serialargs *args, void *out, size_t size)
+{
+	if (args->next + size > args->start + args->size) {
+		EMSG("arg too short: full %zd, remain %zd, expect %zd",
+		     args->size, args->size - (args->next - args->start), size);
+		return PKCS11_CKR_ARGUMENTS_BAD;
+	}
+
+	TEE_MemMove(out, args->next, size);
+
+	args->next += size;
+
+	return PKCS11_CKR_OK;
+}
+
+uint32_t serialargs_alloc_and_get(struct serialargs *args,
+				  void **out, size_t size)
+{
+	void *ptr = NULL;
+
+	if (!size) {
+		*out = NULL;
+		return PKCS11_CKR_OK;
+	}
+
+	if (args->next + size > args->start + args->size) {
+		EMSG("arg too short: full %zd, remain %zd, expect %zd",
+		     args->size, args->size - (args->next - args->start), size);
+		return PKCS11_CKR_ARGUMENTS_BAD;
+	}
+
+	ptr = TEE_Malloc(size, TEE_MALLOC_FILL_ZERO);
+	if (!ptr)
+		return PKCS11_CKR_DEVICE_MEMORY;
+
+	TEE_MemMove(ptr, args->next, size);
+
+	args->next += size;
+	*out = ptr;
+
+	return PKCS11_CKR_OK;
+}
+
+uint32_t serialargs_get_ptr(struct serialargs *args, void **out, size_t size)
+{
+	void *ptr = args->next;
+
+	if (!size) {
+		*out = NULL;
+		return PKCS11_CKR_OK;
+	}
+
+	if (args->next + size > args->start + args->size) {
+		EMSG("arg too short: full %zd, remain %zd, expect %zd",
+		     args->size, args->size - (args->next - args->start), size);
+		return PKCS11_CKR_ARGUMENTS_BAD;
+	}
+
+	args->next += size;
+	*out = ptr;
+
+	return PKCS11_CKR_OK;
+}
+
+bool serialargs_remaining_bytes(struct serialargs *args)
+{
+	return args->next < args->start + args->size;
+}

--- a/ta/pkcs11/src/serializer.h
+++ b/ta/pkcs11/src/serializer.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017-2020, Linaro Limited
+ */
+
+#ifndef PKCS11_TA_SERIALIZER_H
+#define PKCS11_TA_SERIALIZER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * Util routines for serializes unformated arguments in a client memref
+ */
+struct serialargs {
+	char *start;
+	char *next;
+	size_t size;
+};
+
+void serialargs_init(struct serialargs *args, void *in, size_t size);
+
+uint32_t serialargs_get(struct serialargs *args, void *out, size_t sz);
+
+uint32_t serialargs_get_ptr(struct serialargs *args, void **out, size_t size);
+
+uint32_t serialargs_alloc_and_get(struct serialargs *args,
+				  void **out, size_t size);
+
+bool serialargs_remaining_bytes(struct serialargs *args);
+
+#endif /*PKCS11_TA_SERIALIZER_H*/

--- a/ta/pkcs11/src/sub.mk
+++ b/ta/pkcs11/src/sub.mk
@@ -2,3 +2,4 @@ srcs-y += entry.c
 srcs-y += persistent_token.c
 srcs-y += pkcs11_helpers.c
 srcs-y += pkcs11_token.c
+srcs-y += serializer.c


### PR DESCRIPTION
Implement TA commands for PKCS#11 API functions `C_GetSlotList()` and `C_GetSlotInfo()`.