### PR TITLE
ta: ta.ld.S: merge .ARM.extab* sections

### DIFF
--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -33,6 +33,7 @@ SECTIONS {
 		*(.gnu.linkonce.r.*)
 		*(.rodata .rodata.*)
 	}
+	.ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) }
 	/* .ARM.exidx is sorted, so has to go in its own output section.  */
 	.ARM.exidx : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) }
         .ctors : { *(.ctors) }


### PR DESCRIPTION
Contrary to .ARM.exidx, we have no .ARM.extab entry in the TA linker
script. As a result, the multiple .ARM.extab* sections [1] gathered
from the object files will remain in the TA. While this is perfectly
valid and does not cause any functional issue, it uselessly pollutes
the readelf/symbolize.py/etc. dumps.

This commit merges all the .ARM.extab* into a unique .ARM.extab.

[1] Due to -ffunction-sections, each function that generates exception
table information will create its own section.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
