### PR TITLE
ta: pkcs11: better test object ids generation

### DIFF
--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -23,10 +23,12 @@ static void init_pin_keys(struct ck_token *token, unsigned int uid)
 	unsigned int token_id = get_token_id(token);
 	TEE_ObjectHandle key_hdl = TEE_HANDLE_NULL;
 	char file[32] = { 0 };
+	int n = 0;
 
 	assert(token_id < 10 && uid < 10);
 
-	if (snprintf(file, 32, "token.db.%1d-pin%1d", token_id, uid) >= 32)
+	n = snprintf(file, sizeof(file), "token.db.%1d-pin%1d", token_id, uid);
+	if (n < 0 || (size_t)n >= sizeof(file))
 		TEE_Panic(0);
 
 	res = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
@@ -90,7 +92,8 @@ struct ck_token *init_persistent_db(unsigned int token_id)
 	if (!db_main)
 		goto error;
 
-	if (snprintf(db_file, 32, "token.db.%1d", token_id) >= 32)
+	n = snprintf(db_file, sizeof(db_file), "token.db.%1d", token_id);
+	if (n < 0 || (size_t)n >= sizeof(db_file))
 		TEE_Panic(0);
 
 	res = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,


### PR DESCRIPTION
Change init_pin_keys() and init_persistent_db() to rely on the
strict byte size of the object ID reference rather than using hard
coded value 32.

Fixes: c84ccd0a805e ("ta: pkcs11: persistent database for the pkcs11 tokens")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
