### PR TITLE
core: init: aslr offset leak in initcall error message

### DIFF
--- a/core/arch/arm/tee/init.c
+++ b/core/arch/arm/tee/init.c
@@ -29,8 +29,8 @@ static void call_initcalls(void)
 		TEE_Result ret;
 		ret = (*call)();
 		if (ret != TEE_SUCCESS) {
-			EMSG("Initial call 0x%08" PRIxVA " failed",
-			     (vaddr_t)call);
+			EMSG("Initial call __text_start + 0x%08" PRIxVA " failed",
+			     (vaddr_t)call - VCORE_START_VA);
 		}
 	}
 }


### PR DESCRIPTION
Initial call error message print out call pointer. This leak the ASLR offset. Subtract VA start address to hide ASLR offset.