### PR TITLE
ta: pkcs11: get token information

### DIFF
--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -149,6 +149,10 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session __unused, uint32_t cmd,
 	case PKCS11_CMD_SLOT_INFO:
 		rc = entry_ck_slot_info(ptypes, params);
 		break;
+	case PKCS11_CMD_TOKEN_INFO:
+		rc = entry_ck_token_info(ptypes, params);
+		break;
+
 	default:
 		EMSG("Command 0x%"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -115,6 +115,13 @@ uint32_t entry_ck_slot_list(uint32_t ptypes, TEE_Param *params)
 	return PKCS11_CKR_OK;
 }
 
+static void pad_str(uint8_t *str, size_t size)
+{
+	int n = strnlen((char *)str, size);
+
+	TEE_MemFill(str + n, ' ', size - n);
+}
+
 uint32_t entry_ck_slot_info(uint32_t ptypes, TEE_Param *params)
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
@@ -134,7 +141,6 @@ uint32_t entry_ck_slot_info(uint32_t ptypes, TEE_Param *params)
 		.hardware_version = PKCS11_SLOT_HW_VERSION,
 		.firmware_version = PKCS11_SLOT_FW_VERSION,
 	};
-	int n = 0;
 
 	COMPILE_TIME_ASSERT(sizeof(PKCS11_SLOT_DESCRIPTION) <=
 			    sizeof(info.slot_description));
@@ -157,16 +163,8 @@ uint32_t entry_ck_slot_info(uint32_t ptypes, TEE_Param *params)
 	if (!token)
 		return PKCS11_CKR_SLOT_ID_INVALID;
 
-	/* Pad string identifiers with blank characters */
-	n = strnlen((char *)info.slot_description,
-		    sizeof(info.slot_description));
-	TEE_MemFill(&info.slot_description[n], ' ',
-		    sizeof(info.slot_description) - n);
-
-	n = strnlen((char *)info.manufacturer_id,
-		    sizeof(info.manufacturer_id));
-	TEE_MemFill(&info.manufacturer_id[n], ' ',
-		    sizeof(info.manufacturer_id) - n);
+	pad_str(info.slot_description, sizeof(info.slot_description));
+	pad_str(info.manufacturer_id, sizeof(info.manufacturer_id));
 
 	out->memref.size = sizeof(info);
 	TEE_MemMove(out->memref.buffer, &info, out->memref.size);

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -16,6 +16,13 @@
 #define PKCS11_SLOT_FW_VERSION		{ PKCS11_TA_VERSION_MAJOR, \
 					  PKCS11_TA_VERSION_MINOR }
 
+#define PKCS11_TOKEN_LABEL		"OP-TEE PKCS#11 TA token"
+#define PKCS11_TOKEN_MANUFACTURER	PKCS11_SLOT_MANUFACTURER
+#define PKCS11_TOKEN_MODEL		"OP-TEE TA"
+#define PKCS11_TOKEN_SERIAL_NUMBER	"0000000000000000"
+#define PKCS11_TOKEN_HW_VERSION		PKCS11_SLOT_HW_VERSION
+#define PKCS11_TOKEN_FW_VERSION		PKCS11_SLOT_FW_VERSION
+
 enum pkcs11_token_state {
 	PKCS11_TOKEN_RESET = 0,
 	PKCS11_TOKEN_READ_WRITE,
@@ -23,7 +30,8 @@ enum pkcs11_token_state {
 };
 
 #define PKCS11_MAX_USERS		2
-#define PKCS11_TOKEN_PIN_SIZE		128
+#define PKCS11_TOKEN_PIN_SIZE_MAX	128
+#define PKCS11_TOKEN_PIN_SIZE_MIN	10
 
 /*
  * Persistent state of the token
@@ -44,10 +52,10 @@ struct token_persistent_main {
 	uint32_t flags;
 	uint32_t so_pin_count;
 	uint32_t so_pin_size;
-	uint8_t so_pin[PKCS11_TOKEN_PIN_SIZE];
+	uint8_t so_pin[PKCS11_TOKEN_PIN_SIZE_MAX];
 	uint32_t user_pin_count;
 	uint32_t user_pin_size;
-	uint8_t user_pin[PKCS11_TOKEN_PIN_SIZE];
+	uint8_t user_pin[PKCS11_TOKEN_PIN_SIZE_MAX];
 };
 
 /*
@@ -83,5 +91,6 @@ void close_persistent_db(struct ck_token *token);
 /* Entry point for the TA commands */
 uint32_t entry_ck_slot_list(uint32_t ptypes, TEE_Param *params);
 uint32_t entry_ck_slot_info(uint32_t ptypes, TEE_Param *params);
+uint32_t entry_ck_token_info(uint32_t ptypes, TEE_Param *params);
 
 #endif /*PKCS11_TA_PKCS11_TOKEN_H*/


### PR DESCRIPTION
* ta: pkcs11: add pad_str() helper in token info wrapper
Add pad_str() to pad a string ('\0' terminated) with blank characters (' '), removing the '\0' termination as per PKCS#11 specification. This will factorize other padding needed in other function/command wrappers.

* ta: pkcs11: implement command to get token information
Implement TA command PKCS11_CMD_TOKEN_INFO for client to get information on a token embedded in the PKCS11 TA.