### PR TITLE
Ldelf nospec

### DIFF
--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -400,6 +400,9 @@ static void add_segment(struct ta_elf *elf, size_t offset, size_t vaddr,
 	if (!seg)
 		err(TEE_ERROR_OUT_OF_MEMORY, "calloc");
 
+	if (memsz < filesz)
+		err(TEE_ERROR_BAD_FORMAT, "Memsz smaller than filesz");
+
 	seg->offset = offset;
 	seg->vaddr = vaddr;
 	seg->filesz = filesz;
@@ -733,6 +736,9 @@ static void populate_segments(struct ta_elf *elf)
 				if (res)
 					err(res, "sys_copy_from_ta_bin");
 			} else {
+				if (filesz != memsz)
+					err(TEE_ERROR_BAD_FORMAT,
+					    "Filesz and memsz mismatch");
 				res = sys_map_ta_bin(&va, filesz, flags,
 						     elf->handle, offset,
 						     pad_begin, pad_end);
@@ -747,7 +753,7 @@ static void populate_segments(struct ta_elf *elf)
 
 			if (!elf->load_addr)
 				elf->load_addr = va;
-			elf->max_addr = roundup(va + filesz);
+			elf->max_addr = roundup(va + memsz);
 			elf->max_offs += filesz;
 		}
 	}


### PR DESCRIPTION
"ldelf: use confine_array_index() to cap speculation" brings protection against Spectre V1 speculations.

When parsing the ELF there's indexes and offsets used to load data which in turn is used to load other data and so on, a growing ground for Spectre V1. I think `confine_array_index()` should only be used when needed or sometimes needed. It is however not so easy to tell since it's with the second data load there's danger. This ELF parsing is a bit of a special case so perhaps we should try to annotate the code in a way to assist someone reviewing the code to see if another call to `confine_array_index()` might be needed or not.