### PR TITLE
libutils: add __noreturn to longjmp() prototype

### DIFF
--- a/lib/libutils/isoc/include/setjmp.h
+++ b/lib/libutils/isoc/include/setjmp.h
@@ -34,6 +34,8 @@
 #ifndef __SETJMP_H
 #define __SETJMP_H
 
+#include <compiler.h>
+
 #if defined(ARM32)
 /*
  * All callee preserved registers:
@@ -54,7 +56,7 @@
 typedef	_JBTYPE jmp_buf[_JBLEN];
 #endif
 
-void longjmp(jmp_buf env, int val);
+void __noreturn longjmp(jmp_buf env, int val);
 int setjmp(jmp_buf env);
 
 #ifdef CFG_FTRACE_SUPPORT


### PR DESCRIPTION
The longjmp() function does not return, therefore it should have the
__noreturn attribute. Avoids compiler warnings.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
