### PR TITLE
ta: pkcs11: identify user as per define user types

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -281,4 +281,11 @@ struct pkcs11_token_info {
 #define PKCS11_CKFT_SO_PIN_TO_BE_CHANGED		(1U << 16)
 #define PKCS11_CKFT_ERROR_STATE				(1U << 17)
 
+/* Values for user identity */
+enum pkcs11_user_type {
+	PKCS11_CKU_SO = 0x000,
+	PKCS11_CKU_USER = 0x001,
+	PKCS11_CKU_CONTEXT_SPECIFIC = 0x002,
+};
+
 #endif /*PKCS11_TA_H*/

--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -85,8 +85,10 @@ struct ck_token *init_persistent_db(unsigned int token_id)
 	if (!token)
 		return NULL;
 
-	for (n = 0; n < PKCS11_MAX_USERS; n++)
-		init_pin_keys(token, n);
+	init_pin_keys(token, PKCS11_CKU_SO);
+	init_pin_keys(token, PKCS11_CKU_USER);
+	COMPILE_TIME_ASSERT(PKCS11_CKU_SO == 0 && PKCS11_CKU_USER == 1 &&
+			    PKCS11_MAX_USERS >= 2);
 
 	db_main = TEE_Malloc(sizeof(*db_main), TEE_MALLOC_FILL_ZERO);
 	if (!db_main)


### PR DESCRIPTION
Define users  with CKU User Type in Cryptoki API:
PKCS11_CKU_SO and PKCS11_CKU_USER. They will be used as identifiers
for login and related PKCS#11 API functions.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
