### PR TITLE
mk/lib.mk: cleanup shared library link command

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -62,8 +62,8 @@ ifeq ($(CFG_ULIBS_SHARED),y)
 $(lib-shlibfile): $(objs) $(lib-needed-so-files)
 	@$(cmd-echo-silent) '  LD      $$@'
 	@mkdir -p $$(dir $$@)
-	$$(q)$$(LD$(sm)) $(lib-ldflags) $(lib-Ll-args) -shared \
-		-z max-page-size=4096 --soname=$(libuuid) -o $$@ $$^
+	$$(q)$$(LD$(sm)) $(lib-ldflags) -shared -z max-page-size=4096 \
+		--soname=$(libuuid) -o $$@ $$(filter-out %.so,$$^) $(lib-Ll-args)
 
 $(lib-shlibstrippedfile): $(lib-shlibfile)
 	@$(cmd-echo-silent) '  OBJCOPY $$@'


### PR DESCRIPTION
The command used to link shared libraries when CFG_ULIBS_SHARED=y is
slightly incorrect for two reasons:

1. The -L/-l arguments are passed before the object files, when they
should normally be added after;

2. The shared libraries needed during the link are passed as files in
addition to being supplied with -L/-l. This is redundant, and is a
consequence of having the shared libraries in the prerequisites and
using $^. Order-only prerequisites should be used instead.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
