### PR TITLE
SCMI message drivers

### DIFF
--- a/core/drivers/scmi-msg/base.c
+++ b/core/drivers/scmi-msg/base.c
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+#include <assert.h>
+#include <confine_array_index.h>
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <string.h>
+#include <trace.h>
+#include <util.h>
+
+#include "base.h"
+#include "common.h"
+
+static bool message_id_is_supported(unsigned int message_id);
+
+static void report_version(struct scmi_msg *msg)
+{
+	struct scmi_protocol_version_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.version = SCMI_PROTOCOL_VERSION_BASE,
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_attributes(struct scmi_msg *msg)
+{
+	size_t protocol_count = plat_scmi_protocol_count();
+	struct scmi_protocol_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		/* Null agent count since agent discovery is not supported */
+		.attributes = SCMI_BASE_PROTOCOL_ATTRIBUTES(protocol_count, 0),
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_message_attributes(struct scmi_msg *msg)
+{
+	struct scmi_protocol_message_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_protocol_message_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		/* For this protocol, attributes shall be zero */
+		.attributes = 0,
+	};
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (!message_id_is_supported(in_args->message_id)) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void discover_vendor(struct scmi_msg *msg)
+{
+	const char *name = plat_scmi_vendor_name();
+	struct scmi_base_discover_vendor_p2a return_values = {
+		.status = SCMI_SUCCESS,
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	COPY_NAME_IDENTIFIER(return_values.vendor_identifier, name);
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void discover_sub_vendor(struct scmi_msg *msg)
+{
+	const char *name = plat_scmi_sub_vendor_name();
+	struct scmi_base_discover_sub_vendor_p2a return_values = {
+		.status = SCMI_SUCCESS,
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	COPY_NAME_IDENTIFIER(return_values.sub_vendor_identifier, name);
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void discover_implementation_version(struct scmi_msg *msg)
+{
+	struct scmi_protocol_version_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.version = SCMI_IMPL_VERSION,
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static unsigned int count_protocols_in_list(const uint8_t *protocol_list)
+{
+	unsigned int count = 0;
+
+	if (protocol_list)
+		while (protocol_list[count])
+			count++;
+
+	return count;
+}
+
+#define MAX_PROTOCOL_IN_LIST		8u
+
+static void discover_list_protocols(struct scmi_msg *msg)
+{
+	const struct scmi_base_discover_list_protocols_a2p *a2p = NULL;
+	struct scmi_base_discover_list_protocols_p2a p2a = {
+		.status = SCMI_SUCCESS,
+	};
+	uint8_t outargs[sizeof(p2a) + MAX_PROTOCOL_IN_LIST] = { };
+	const uint8_t *list = NULL;
+	unsigned int count = 0;
+
+	if (msg->in_size != sizeof(*a2p)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	assert(msg->out_size > sizeof(outargs));
+
+	a2p = (void *)msg->in;
+
+	list = plat_scmi_protocol_list(msg->agent_id);
+	count = count_protocols_in_list(list);
+	if (count > a2p->skip)
+		count = MIN(count - a2p->skip, MAX_PROTOCOL_IN_LIST);
+	else
+		count = 0;
+
+	p2a.num_protocols = count;
+
+	memcpy(outargs, &p2a, sizeof(p2a));
+	memcpy(outargs + sizeof(p2a), list + a2p->skip, count);
+
+	scmi_write_response(msg, outargs, sizeof(outargs));
+}
+
+static const scmi_msg_handler_t scmi_base_handler_table[] = {
+	[SCMI_PROTOCOL_VERSION] = report_version,
+	[SCMI_PROTOCOL_ATTRIBUTES] = report_attributes,
+	[SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] = report_message_attributes,
+	[SCMI_BASE_DISCOVER_VENDOR] = discover_vendor,
+	[SCMI_BASE_DISCOVER_SUB_VENDOR] = discover_sub_vendor,
+	[SCMI_BASE_DISCOVER_IMPLEMENTATION_VERSION] =
+					discover_implementation_version,
+	[SCMI_BASE_DISCOVER_LIST_PROTOCOLS] = discover_list_protocols,
+};
+
+static bool message_id_is_supported(unsigned int message_id)
+{
+	return message_id < ARRAY_SIZE(scmi_base_handler_table) &&
+	       scmi_base_handler_table[message_id];
+}
+
+scmi_msg_handler_t scmi_msg_get_base_handler(struct scmi_msg *msg)
+{
+	const size_t array_size = ARRAY_SIZE(scmi_base_handler_table);
+	unsigned int message_id = 0;
+
+	if (msg->message_id >= array_size) {
+		DMSG("Base handle not found %u", msg->message_id);
+		return NULL;
+	}
+
+	message_id = confine_array_index(msg->message_id, array_size);
+
+	return scmi_base_handler_table[message_id];
+}

--- a/core/drivers/scmi-msg/base.h
+++ b/core/drivers/scmi-msg/base.h
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef SCMI_MSG_BASE_H
+#define SCMI_MSG_BASE_H
+
+#include <stdint.h>
+#include <types_ext.h>
+
+#define SCMI_PROTOCOL_VERSION_BASE	0x20000
+
+#define SCMI_DEFAULT_STRING_LENGTH	16
+
+enum scmi_base_message_id {
+	SCMI_BASE_DISCOVER_VENDOR		= 0x003,
+	SCMI_BASE_DISCOVER_SUB_VENDOR		= 0x004,
+	SCMI_BASE_DISCOVER_IMPLEMENTATION_VERSION = 0x005,
+	SCMI_BASE_DISCOVER_LIST_PROTOCOLS	= 0x006,
+	SCMI_BASE_DISCOVER_AGENT		= 0x007,
+	SCMI_BASE_NOTIFY_ERRORS			= 0x008,
+};
+
+/*
+ * PROTOCOL_ATTRIBUTES
+ */
+
+#define SCMI_BASE_PROTOCOL_ATTRS_NUM_PROTOCOLS_POS	0
+#define SCMI_BASE_PROTOCOL_ATTRS_NUM_AGENTS_POS		8
+
+#define SCMI_BASE_PROTOCOL_ATTRS_NUM_PROTOCOLS_MASK	0xFF
+#define SCMI_BASE_PROTOCOL_ATTRS_NUM_AGENTS_MASK	0xFF00
+
+#define SCMI_BASE_PROTOCOL_ATTRIBUTES(NUM_PROTOCOLS, NUM_AGENTS) \
+	((((NUM_PROTOCOLS) << SCMI_BASE_PROTOCOL_ATTRS_NUM_PROTOCOLS_POS) & \
+	  SCMI_BASE_PROTOCOL_ATTRS_NUM_PROTOCOLS_MASK) | \
+	(((NUM_AGENTS) << SCMI_BASE_PROTOCOL_ATTRS_NUM_AGENTS_POS) & \
+	 SCMI_BASE_PROTOCOL_ATTRS_NUM_AGENTS_MASK))
+
+/*
+ * BASE_DISCOVER_VENDOR
+ */
+struct scmi_base_discover_vendor_p2a {
+	int32_t status;
+	char vendor_identifier[SCMI_DEFAULT_STRING_LENGTH];
+};
+
+/*
+ * BASE_DISCOVER_SUB_VENDOR
+ */
+struct scmi_base_discover_sub_vendor_p2a {
+	int32_t status;
+	char sub_vendor_identifier[SCMI_DEFAULT_STRING_LENGTH];
+};
+
+/*
+ * BASE_DISCOVER_IMPLEMENTATION_VERSION
+ * No special structure right now, see protocol_version.
+ */
+
+/*
+ * BASE_DISCOVER_LIST_PROTOCOLS
+ */
+struct scmi_base_discover_list_protocols_a2p {
+	uint32_t skip;
+};
+
+struct scmi_base_discover_list_protocols_p2a {
+	int32_t status;
+	uint32_t num_protocols;
+	uint32_t protocols[];
+};
+
+#endif /* SCMI_MSG_BASE_H */

--- a/core/drivers/scmi-msg/clock.c
+++ b/core/drivers/scmi-msg/clock.c
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+#include <assert.h>
+#include <confine_array_index.h>
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <string.h>
+#include <util.h>
+
+#include "clock.h"
+#include "common.h"
+
+static bool message_id_is_supported(unsigned int message_id);
+
+size_t __weak plat_scmi_clock_count(unsigned int agent_id __unused)
+{
+	return 0;
+}
+
+const char __weak *plat_scmi_clock_get_name(unsigned int agent_id __unused,
+					    unsigned int scmi_id __unused)
+{
+	return NULL;
+}
+
+int32_t __weak plat_scmi_clock_rates_array(unsigned int agent_id __unused,
+					   unsigned int scmi_id __unused,
+					   unsigned long *rates __unused,
+					   size_t *nb_elts __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t __weak plat_scmi_clock_rates_by_step(unsigned int agent_id __unused,
+					     unsigned int scmi_id __unused,
+					     unsigned long *steps __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+unsigned long __weak plat_scmi_clock_get_rate(unsigned int agent_id __unused,
+					      unsigned int scmi_id __unused)
+{
+	return 0;
+}
+
+int32_t __weak plat_scmi_clock_set_rate(unsigned int agent_id __unused,
+					unsigned int scmi_id __unused,
+					unsigned long rate __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t __weak plat_scmi_clock_get_state(unsigned int agent_id __unused,
+					 unsigned int scmi_id __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t __weak plat_scmi_clock_set_state(unsigned int agent_id __unused,
+					 unsigned int scmi_id __unused,
+					 bool enable_not_disable __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+static void report_version(struct scmi_msg *msg)
+{
+	struct scmi_protocol_version_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.version = SCMI_PROTOCOL_VERSION_CLOCK,
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_attributes(struct scmi_msg *msg)
+{
+	size_t agent_count = plat_scmi_clock_count(msg->agent_id);
+	struct scmi_protocol_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.attributes = SCMI_CLOCK_PROTOCOL_ATTRIBUTES(1, agent_count),
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_message_attributes(struct scmi_msg *msg)
+{
+	struct scmi_protocol_message_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_protocol_message_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		/* For this protocol, attributes shall be zero */
+		.attributes = 0,
+	};
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (!message_id_is_supported(in_args->message_id)) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void scmi_clock_attributes(struct scmi_msg *msg)
+{
+	const struct scmi_clock_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_clock_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+	};
+	const char *name = NULL;
+	unsigned int clock_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->clock_id >= plat_scmi_clock_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	clock_id = confine_array_index(in_args->clock_id,
+				       plat_scmi_clock_count(msg->agent_id));
+
+	name = plat_scmi_clock_get_name(msg->agent_id, clock_id);
+	if (!name) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	COPY_NAME_IDENTIFIER(return_values.clock_name, name);
+
+	return_values.attributes = plat_scmi_clock_get_state(msg->agent_id,
+							     clock_id);
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void scmi_clock_rate_get(struct scmi_msg *msg)
+{
+	const struct scmi_clock_rate_get_a2p *in_args = (void *)msg->in;
+	unsigned long rate = 0;
+	struct scmi_clock_rate_get_p2a return_values = { };
+	unsigned int clock_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->clock_id >= plat_scmi_clock_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	clock_id = confine_array_index(in_args->clock_id,
+				       plat_scmi_clock_count(msg->agent_id));
+
+	rate = plat_scmi_clock_get_rate(msg->agent_id, clock_id);
+
+	reg_pair_from_64(rate, return_values.rate + 1, return_values.rate);
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void scmi_clock_rate_set(struct scmi_msg *msg)
+{
+	const struct scmi_clock_rate_set_a2p *in_args = (void *)msg->in;
+	uint64_t rate_64 = 0;
+	unsigned long rate = 0;
+	int32_t status = 0;
+	unsigned int clock_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->clock_id >= plat_scmi_clock_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	clock_id = confine_array_index(in_args->clock_id,
+				       plat_scmi_clock_count(msg->agent_id));
+
+	rate_64 = reg_pair_to_64(in_args->rate[1], in_args->rate[0]);
+	rate = rate_64;
+
+	status = plat_scmi_clock_set_rate(msg->agent_id, clock_id, rate);
+
+	scmi_status_response(msg, status);
+}
+
+static void scmi_clock_config_set(struct scmi_msg *msg)
+{
+	const struct scmi_clock_config_set_a2p *in_args = (void *)msg->in;
+	int32_t status = SCMI_GENERIC_ERROR;
+	bool enable = false;
+	unsigned int clock_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->clock_id >= plat_scmi_clock_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	clock_id = confine_array_index(in_args->clock_id,
+				       plat_scmi_clock_count(msg->agent_id));
+
+	enable = in_args->attributes & SCMI_CLOCK_CONFIG_SET_ENABLE_MASK;
+
+	status = plat_scmi_clock_set_state(msg->agent_id, clock_id, enable);
+
+	scmi_status_response(msg, status);
+}
+
+#define RATES_ARRAY_SIZE_MAX	(SCMI_PLAYLOAD_MAX - \
+				 sizeof(struct scmi_clock_describe_rates_p2a))
+
+#define SCMI_RATES_BY_ARRAY(_nb_rates, _rem_rates) \
+	SCMI_CLOCK_DESCRIBE_RATES_NUM_RATES_FLAGS((_nb_rates), \
+						SCMI_CLOCK_RATE_FORMAT_LIST, \
+						(_rem_rates))
+#define SCMI_RATES_BY_STEP \
+	SCMI_CLOCK_DESCRIBE_RATES_NUM_RATES_FLAGS(3, \
+						SCMI_CLOCK_RATE_FORMAT_RANGE, \
+						0)
+
+#define RATE_DESC_SIZE		sizeof(struct scmi_clock_rate)
+
+static void write_rate_desc_array_in_buffer(char *dest, unsigned long *rates,
+					    size_t nb_elt)
+{
+	uint32_t *out = NULL;
+	size_t n = 0;
+
+	assert(ALIGNMENT_IS_OK(dest, uint32_t));
+	out = (uint32_t *)(uintptr_t)dest;
+
+	for (n = 0; n < nb_elt; n++) {
+		uint64_t rate = rates[n];
+
+		reg_pair_from_64(rate, out + 2 * n + 1, out + 2 * n);
+	}
+}
+
+static void scmi_clock_describe_rates(struct scmi_msg *msg)
+{
+	const struct scmi_clock_describe_rates_a2p *in_args = (void *)msg->in;
+	struct scmi_clock_describe_rates_p2a p2a = { };
+	size_t nb_rates = 0;
+	int32_t status = SCMI_GENERIC_ERROR;
+	unsigned int clock_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->clock_id >= plat_scmi_clock_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	clock_id = confine_array_index(in_args->clock_id,
+				       plat_scmi_clock_count(msg->agent_id));
+
+	/* Platform may support array rate description */
+	status = plat_scmi_clock_rates_array(msg->agent_id, clock_id, NULL,
+					     &nb_rates);
+	if (status == SCMI_SUCCESS) {
+		/* Currently 12 cells mex, so it's affordable for the stack */
+		unsigned long plat_rates[RATES_ARRAY_SIZE_MAX / RATE_DESC_SIZE];
+		size_t max_nb = RATES_ARRAY_SIZE_MAX / RATE_DESC_SIZE;
+		size_t ret_nb = MIN(nb_rates - in_args->rate_index, max_nb);
+		size_t rem_nb = nb_rates - in_args->rate_index - ret_nb;
+
+		status =  plat_scmi_clock_rates_array(msg->agent_id, clock_id,
+						      plat_rates, &ret_nb);
+		if (status == SCMI_SUCCESS) {
+			write_rate_desc_array_in_buffer(msg->out + sizeof(p2a),
+							plat_rates, ret_nb);
+
+			p2a.num_rates_flags = SCMI_RATES_BY_ARRAY(ret_nb,
+								  rem_nb);
+			p2a.status = SCMI_SUCCESS;
+
+			memcpy(msg->out, &p2a, sizeof(p2a));
+			msg->out_size_out = sizeof(p2a) +
+					    ret_nb * RATE_DESC_SIZE;
+		}
+	} else if (status == SCMI_NOT_SUPPORTED) {
+		unsigned long triplet[3] = { 0, 0, 0 };
+
+		/* Platform may support min§max/step triplet description */
+		status =  plat_scmi_clock_rates_by_step(msg->agent_id, clock_id,
+							triplet);
+		if (status == SCMI_SUCCESS) {
+			write_rate_desc_array_in_buffer(msg->out + sizeof(p2a),
+							triplet, 3);
+
+			p2a.num_rates_flags = SCMI_RATES_BY_STEP;
+			p2a.status = SCMI_SUCCESS;
+
+			memcpy(msg->out, &p2a, sizeof(p2a));
+			msg->out_size_out = sizeof(p2a) + (3 * RATE_DESC_SIZE);
+		}
+	} else {
+		/* Fallthrough generic exit sequence below with error status */
+	}
+
+	if (status) {
+		scmi_status_response(msg, status);
+	} else {
+		/*
+		 * Message payload is already writen to msg->out, and
+		 * msg->out_size_out updated.
+		 */
+	}
+}
+
+static const scmi_msg_handler_t scmi_clock_handler_table[] = {
+	[SCMI_PROTOCOL_VERSION] = report_version,
+	[SCMI_PROTOCOL_ATTRIBUTES] = report_attributes,
+	[SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] = report_message_attributes,
+	[SCMI_CLOCK_ATTRIBUTES] = scmi_clock_attributes,
+	[SCMI_CLOCK_DESCRIBE_RATES] = scmi_clock_describe_rates,
+	[SCMI_CLOCK_RATE_SET] = scmi_clock_rate_set,
+	[SCMI_CLOCK_RATE_GET] = scmi_clock_rate_get,
+	[SCMI_CLOCK_CONFIG_SET] = scmi_clock_config_set,
+};
+
+static bool message_id_is_supported(size_t message_id)
+{
+	return message_id < ARRAY_SIZE(scmi_clock_handler_table) &&
+	       scmi_clock_handler_table[message_id];
+}
+
+scmi_msg_handler_t scmi_msg_get_clock_handler(struct scmi_msg *msg)
+{
+	const size_t array_size = ARRAY_SIZE(scmi_clock_handler_table);
+	unsigned int message_id = 0;
+
+	if (msg->message_id >= array_size) {
+		DMSG("Clock handle not found %u", msg->message_id);
+		return NULL;
+	}
+
+	message_id = confine_array_index(msg->message_id, array_size);
+
+	return scmi_clock_handler_table[message_id];
+}

--- a/core/drivers/scmi-msg/clock.h
+++ b/core/drivers/scmi-msg/clock.h
@@ -1,0 +1,149 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef SCMI_MSG_CLOCK_H
+#define SCMI_MSG_CLOCK_H
+
+#include <stdint.h>
+#include <util.h>
+
+#define SCMI_PROTOCOL_VERSION_CLOCK	0x20000
+
+/*
+ * Identifiers of the SCMI Clock Management Protocol commands
+ */
+enum scmi_clock_command_id {
+	SCMI_CLOCK_ATTRIBUTES = 0x003,
+	SCMI_CLOCK_DESCRIBE_RATES = 0x004,
+	SCMI_CLOCK_RATE_SET = 0x005,
+	SCMI_CLOCK_RATE_GET = 0x006,
+	SCMI_CLOCK_CONFIG_SET = 0x007,
+};
+
+/* Protocol attributes */
+#define SCMI_CLOCK_CLOCK_COUNT_MASK			GENMASK_32(15, 0)
+#define SCMI_CLOCK_MAX_PENDING_TRANSITIONS_MASK		GENMASK_32(23, 16)
+
+#define SCMI_CLOCK_PROTOCOL_ATTRIBUTES(_max_pending, _clk_count) \
+	((((_max_pending) << 16) & SCMI_CLOCK_MAX_PENDING_TRANSITIONS_MASK) | \
+	 (((_clk_count) & SCMI_CLOCK_CLOCK_COUNT_MASK)))
+
+struct scmi_clock_attributes_a2p {
+	uint32_t clock_id;
+};
+
+#define SCMI_CLOCK_NAME_LENGTH_MAX	16
+
+struct scmi_clock_attributes_p2a {
+	int32_t status;
+	uint32_t attributes;
+	char clock_name[SCMI_CLOCK_NAME_LENGTH_MAX];
+};
+
+/*
+ * Clock Rate Get
+ */
+
+struct scmi_clock_rate_get_a2p {
+	uint32_t clock_id;
+};
+
+struct scmi_clock_rate_get_p2a {
+	int32_t status;
+	uint32_t rate[2];
+};
+
+/*
+ * Clock Rate Set
+ */
+
+/* If set, set the new clock rate asynchronously */
+#define SCMI_CLOCK_RATE_SET_ASYNC_POS			0
+/* If set, do not send a delayed asynchronous response */
+#define SCMI_CLOCK_RATE_SET_NO_DELAYED_RESPONSE_POS	1
+/* Round up, if set, otherwise round down */
+#define SCMI_CLOCK_RATE_SET_ROUND_UP_POS		2
+/* If set, the platform chooses the appropriate rounding mode */
+#define SCMI_CLOCK_RATE_SET_ROUND_AUTO_POS		3
+
+#define SCMI_CLOCK_RATE_SET_ASYNC_MASK \
+		BIT(SCMI_CLOCK_RATE_SET_ASYNC_POS)
+#define SCMI_CLOCK_RATE_SET_NO_DELAYED_RESPONSE_MASK \
+		BIT(SCMI_CLOCK_RATE_SET_NO_DELAYED_RESPONSE_POS)
+#define SCMI_CLOCK_RATE_SET_ROUND_UP_MASK \
+		BIT(SCMI_CLOCK_RATE_SET_ROUND_UP_POS)
+#define SCMI_CLOCK_RATE_SET_ROUND_AUTO_MASK \
+		BIT(SCMI_CLOCK_RATE_SET_ROUND_AUTO_POS)
+
+struct scmi_clock_rate_set_a2p {
+	uint32_t flags;
+	uint32_t clock_id;
+	uint32_t rate[2];
+};
+
+struct scmi_clock_rate_set_p2a {
+	int32_t status;
+};
+
+/*
+ * Clock Config Set
+ */
+
+#define SCMI_CLOCK_CONFIG_SET_ENABLE_POS	0
+
+#define SCMI_CLOCK_CONFIG_SET_ENABLE_MASK \
+	(0x1 << SCMI_CLOCK_CONFIG_SET_ENABLE_POS)
+
+struct scmi_clock_config_set_a2p {
+	uint32_t clock_id;
+	uint32_t attributes;
+};
+
+struct scmi_clock_config_set_p2a {
+	int32_t status;
+};
+
+/*
+ * Clock Describe Rates
+ */
+
+#define SCMI_CLOCK_RATE_FORMAT_RANGE 1
+#define SCMI_CLOCK_RATE_FORMAT_LIST  0
+
+#define SCMI_CLOCK_DESCRIBE_RATES_REMAINING_MASK	GENMASK_32(31, 16)
+#define SCMI_CLOCK_DESCRIBE_RATES_REMAINING_POS		16
+
+#define SCMI_CLOCK_DESCRIBE_RATES_FORMAT_MASK		BIT(12)
+#define SCMI_CLOCK_DESCRIBE_RATES_FORMAT_POS		12
+
+#define SCMI_CLOCK_DESCRIBE_RATES_COUNT_MASK		GENMASK_32(11, 0)
+
+#define SCMI_CLOCK_DESCRIBE_RATES_NUM_RATES_FLAGS(_count, _fmt, _rem_rates) \
+	( \
+		((_count) & SCMI_CLOCK_DESCRIBE_RATES_COUNT_MASK) | \
+		(((_rem_rates) << SCMI_CLOCK_DESCRIBE_RATES_REMAINING_POS) & \
+		 SCMI_CLOCK_DESCRIBE_RATES_REMAINING_MASK) | \
+		(((_fmt) << SCMI_CLOCK_DESCRIBE_RATES_FORMAT_POS) & \
+		 SCMI_CLOCK_DESCRIBE_RATES_FORMAT_MASK) \
+	)
+
+struct scmi_clock_rate {
+	uint32_t low;
+	uint32_t high;
+};
+
+struct scmi_clock_describe_rates_a2p {
+	uint32_t clock_id;
+	uint32_t rate_index;
+};
+
+struct scmi_clock_describe_rates_p2a {
+	int32_t status;
+	uint32_t num_rates_flags;
+	struct scmi_clock_rate rates[];
+};
+
+#endif /* SCMI_MSG_CLOCK_H */

--- a/core/drivers/scmi-msg/common.h
+++ b/core/drivers/scmi-msg/common.h
@@ -1,0 +1,121 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+#ifndef SCMI_MSG_COMMON_H
+#define SCMI_MSG_COMMON_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <types_ext.h>
+
+#include "base.h"
+
+#define SCMI_VERSION			0x20000
+#define SCMI_IMPL_VERSION		0
+
+#define SCMI_PLAYLOAD_MAX		92
+
+/*
+ * Copy name identifier in target buffer following the SCMI specification
+ * that state name identifier shall be a null terminated string.
+ */
+#define COPY_NAME_IDENTIFIER(_dst_array, _name)				\
+	do {								\
+		assert(strlen(_name) < sizeof(_dst_array));		\
+		strncpy((_dst_array), (_name), sizeof(_dst_array));	\
+	} while (0)
+
+/* Common command identifiers shared by all procotols */
+enum scmi_common_message_id {
+	SCMI_PROTOCOL_VERSION = 0x000,
+	SCMI_PROTOCOL_ATTRIBUTES = 0x001,
+	SCMI_PROTOCOL_MESSAGE_ATTRIBUTES = 0x002
+};
+
+/* Common platform-to-agent (p2a) PROTOCOL_VERSION structure */
+struct scmi_protocol_version_p2a {
+	int32_t status;
+	uint32_t version;
+};
+
+/* Generic platform-to-agent (p2a) PROTOCOL_ATTRIBUTES structure */
+struct scmi_protocol_attributes_p2a {
+	int32_t status;
+	uint32_t attributes;
+};
+
+/* Generic agent-to-platform (a2p) PROTOCOL_MESSAGE_ATTRIBUTES structure */
+struct scmi_protocol_message_attributes_a2p {
+	uint32_t message_id;
+};
+
+/* Generic platform-to-agent (p2a) PROTOCOL_MESSAGE_ATTRIBUTES structure */
+struct scmi_protocol_message_attributes_p2a {
+	int32_t status;
+	uint32_t attributes;
+};
+
+/*
+ * struct scmi_msg - SCMI message context
+ *
+ * @agent_id: SCMI agent ID, safely set from secure world
+ * @protocol_id: SCMI protocol ID for the related message, set by caller agent
+ * @message_id: SCMI message ID for the related message, set by caller agent
+ * @in: Address of the incoming message payload copied in secure memory
+ * @in_size: Byte length of the incoming message payload, set by caller agent
+ * @out: Address of of the output message payload message in non-secure memory
+ * @out_size: Byte length of the provisionned output buffer
+ * @out_size_out: Byte length of the output message payload
+ */
+struct scmi_msg {
+	unsigned int agent_id;
+	unsigned int protocol_id;
+	unsigned int message_id;
+	char *in;
+	size_t in_size;
+	char *out;
+	size_t out_size;
+	size_t out_size_out;
+};
+
+/*
+ * Type scmi_msg_handler_t is used by procotol drivers to safely find
+ * the handler function for the incoming message ID.
+ */
+typedef void (*scmi_msg_handler_t)(struct scmi_msg *msg);
+
+/*
+ * scmi_msg_get_base_handler - Return a handler for a base message
+ * @msg - message to process
+ * Return a function handler for the message or NULL
+ */
+scmi_msg_handler_t scmi_msg_get_base_handler(struct scmi_msg *msg);
+
+/*
+ * Process Read, process and write response for input SCMI message
+ *
+ * @msg: SCMI message context
+ */
+void scmi_process_message(struct scmi_msg *msg);
+
+/*
+ * Write SCMI response payload to output message shared memory
+ *
+ * @msg: SCMI message context
+ * @payload: Output message payload
+ * @size: Byte size of output message payload
+ */
+void scmi_write_response(struct scmi_msg *msg, void *payload, size_t size);
+
+/*
+ * Write status only SCMI response payload to output message shared memory
+ *
+ * @msg: SCMI message context
+ * @status: SCMI status value returned to caller
+ */
+void scmi_status_response(struct scmi_msg *msg, int32_t status);
+#endif /* SCMI_MSG_COMMON_H */

--- a/core/drivers/scmi-msg/common.h
+++ b/core/drivers/scmi-msg/common.h
@@ -13,6 +13,7 @@
 #include <types_ext.h>
 
 #include "base.h"
+#include "clock.h"
 
 #define SCMI_VERSION			0x20000
 #define SCMI_IMPL_VERSION		0
@@ -94,6 +95,15 @@ typedef void (*scmi_msg_handler_t)(struct scmi_msg *msg);
  * Return a function handler for the message or NULL
  */
 scmi_msg_handler_t scmi_msg_get_base_handler(struct scmi_msg *msg);
+
+#ifdef CFG_SCMI_MSG_CLOCK
+/*
+ * scmi_msg_get_clock_handler - Return a handler for a clock message
+ * @msg - message to process
+ * Return a function handler for the message or NULL
+ */
+scmi_msg_handler_t scmi_msg_get_clock_handler(struct scmi_msg *msg);
+#endif
 
 /*
  * Process Read, process and write response for input SCMI message

--- a/core/drivers/scmi-msg/common.h
+++ b/core/drivers/scmi-msg/common.h
@@ -14,6 +14,7 @@
 
 #include "base.h"
 #include "clock.h"
+#include "reset_domain.h"
 
 #define SCMI_VERSION			0x20000
 #define SCMI_IMPL_VERSION		0
@@ -103,6 +104,15 @@ scmi_msg_handler_t scmi_msg_get_base_handler(struct scmi_msg *msg);
  * Return a function handler for the message or NULL
  */
 scmi_msg_handler_t scmi_msg_get_clock_handler(struct scmi_msg *msg);
+#endif
+
+#ifdef CFG_SCMI_MSG_RESET_DOMAIN
+/*
+ * scmi_msg_get_rd_handler - Return a handler for a reset domain message
+ * @msg - message to process
+ * Return a function handler for the message or NULL
+ */
+scmi_msg_handler_t scmi_msg_get_rd_handler(struct scmi_msg *msg);
 #endif
 
 /*

--- a/core/drivers/scmi-msg/entry.c
+++ b/core/drivers/scmi-msg/entry.c
@@ -9,6 +9,7 @@
 #include <trace.h>
 
 #include "base.h"
+#include "clock.h"
 #include "common.h"
 
 void scmi_status_response(struct scmi_msg *msg, int32_t status)
@@ -41,6 +42,11 @@ void scmi_process_message(struct scmi_msg *msg)
 	case SCMI_PROTOCOL_ID_BASE:
 		handler = scmi_msg_get_base_handler(msg);
 		break;
+#ifdef CFG_SCMI_MSG_CLOCK
+	case SCMI_PROTOCOL_ID_CLOCK:
+		handler = scmi_msg_get_clock_handler(msg);
+		break;
+#endif
 	default:
 		break;
 	}

--- a/core/drivers/scmi-msg/entry.c
+++ b/core/drivers/scmi-msg/entry.c
@@ -11,6 +11,7 @@
 #include "base.h"
 #include "clock.h"
 #include "common.h"
+#include "reset_domain.h"
 
 void scmi_status_response(struct scmi_msg *msg, int32_t status)
 {
@@ -45,6 +46,11 @@ void scmi_process_message(struct scmi_msg *msg)
 #ifdef CFG_SCMI_MSG_CLOCK
 	case SCMI_PROTOCOL_ID_CLOCK:
 		handler = scmi_msg_get_clock_handler(msg);
+		break;
+#endif
+#ifdef CFG_SCMI_MSG_RESET_DOMAIN
+	case SCMI_PROTOCOL_ID_RESET_DOMAIN:
+		handler = scmi_msg_get_rd_handler(msg);
 		break;
 #endif
 	default:

--- a/core/drivers/scmi-msg/entry.c
+++ b/core/drivers/scmi-msg/entry.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+#include <speculation_barrier.h>
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <trace.h>
+
+#include "base.h"
+#include "common.h"
+
+void scmi_status_response(struct scmi_msg *msg, int32_t status)
+{
+	assert(msg->out && msg->out_size >= sizeof(int32_t));
+
+	memcpy(msg->out, &status, sizeof(int32_t));
+	msg->out_size_out = sizeof(int32_t);
+}
+
+void scmi_write_response(struct scmi_msg *msg, void *payload, size_t size)
+{
+	/*
+	 * Output payload shall be at least the size of the status
+	 * Output buffer shall be at least be the size of the status
+	 * Output paylaod shall fit in output buffer
+	 */
+	assert(payload && size >= sizeof(int32_t) && size <= msg->out_size &&
+	       msg->out && msg->out_size >= sizeof(int32_t));
+
+	memcpy(msg->out, payload, size);
+	msg->out_size_out = size;
+}
+
+void scmi_process_message(struct scmi_msg *msg)
+{
+	scmi_msg_handler_t handler = NULL;
+
+	switch (msg->protocol_id) {
+	case SCMI_PROTOCOL_ID_BASE:
+		handler = scmi_msg_get_base_handler(msg);
+		break;
+	default:
+		break;
+	}
+
+	if (handler) {
+		handler(msg);
+		return;
+	}
+
+	DMSG("Agent %u Protocol %#x Message %#x: not supported",
+	     msg->agent_id, msg->protocol_id, msg->message_id);
+
+	scmi_status_response(msg, SCMI_NOT_SUPPORTED);
+}

--- a/core/drivers/scmi-msg/reset_domain.c
+++ b/core/drivers/scmi-msg/reset_domain.c
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+#include <assert.h>
+#include <confine_array_index.h>
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <string.h>
+#include <util.h>
+
+#include "common.h"
+#include "reset_domain.h"
+
+static bool message_id_is_supported(unsigned int message_id);
+
+size_t __weak plat_scmi_rd_count(unsigned int agent_id __unused)
+{
+	return 0;
+}
+
+const char __weak *plat_scmi_rd_get_name(unsigned int agent_id __unused,
+					 unsigned int scmi_id __unused)
+{
+	return NULL;
+}
+
+int32_t __weak plat_scmi_rd_autonomous(unsigned int agent_id __unused,
+				       unsigned int scmi_id __unused,
+				       unsigned int state __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t __weak plat_scmi_rd_set_state(unsigned int agent_id __unused,
+				      unsigned int scmi_id __unused,
+				      bool assert_not_deassert __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+static void report_version(struct scmi_msg *msg)
+{
+	struct scmi_protocol_version_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.version = SCMI_PROTOCOL_VERSION_RESET_DOMAIN,
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_attributes(struct scmi_msg *msg)
+{
+	struct scmi_protocol_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.attributes = plat_scmi_rd_count(msg->agent_id),
+	};
+
+	if (msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_message_attributes(struct scmi_msg *msg)
+{
+	struct scmi_protocol_message_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_protocol_message_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		/* For this protocol, attributes shall be zero */
+		.attributes = 0,
+	};
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (!message_id_is_supported(in_args->message_id)) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void reset_domain_attributes(struct scmi_msg *msg)
+{
+	struct scmi_reset_domain_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_reset_domain_attributes_p2a return_values = { };
+	const char *name = NULL;
+	unsigned int domain_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->domain_id >= plat_scmi_rd_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_rd_count(msg->agent_id));
+
+	name = plat_scmi_rd_get_name(msg->agent_id, domain_id);
+	if (!name) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	COPY_NAME_IDENTIFIER(return_values.name, name);
+	return_values.status = SCMI_SUCCESS;
+	return_values.flags = 0; /* Async and Notif are not supported */
+	return_values.latency = SCMI_RESET_DOMAIN_ATTR_UNK_LAT;
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void reset_request(struct scmi_msg *msg)
+{
+	struct scmi_reset_domain_request_a2p *in_args = (void *)msg->in;
+	struct scmi_reset_domain_request_p2a out_args = {
+		.status = SCMI_SUCCESS,
+	};
+	unsigned int domain_id = 0;
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_rd_count(msg->agent_id));
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->domain_id >= plat_scmi_rd_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	if (in_args->flags & SCMI_RESET_DOMAIN_AUTO)
+		out_args.status = plat_scmi_rd_autonomous(msg->agent_id,
+							  domain_id,
+							  in_args->reset_state);
+	else if (in_args->flags & SCMI_RESET_DOMAIN_EXPLICIT)
+		out_args.status = plat_scmi_rd_set_state(msg->agent_id,
+							 domain_id, true);
+	else
+		out_args.status = plat_scmi_rd_set_state(msg->agent_id,
+							 domain_id, false);
+
+	if (out_args.status)
+		scmi_status_response(msg, out_args.status);
+	else
+		scmi_write_response(msg, &out_args, sizeof(out_args));
+}
+
+static const scmi_msg_handler_t scmi_rd_handler_table[] = {
+	[SCMI_PROTOCOL_VERSION] = report_version,
+	[SCMI_PROTOCOL_ATTRIBUTES] = report_attributes,
+	[SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] = report_message_attributes,
+	[SCMI_RESET_DOMAIN_ATTRIBUTES] = reset_domain_attributes,
+	[SCMI_RESET_DOMAIN_REQUEST] = reset_request,
+};
+
+static bool message_id_is_supported(unsigned int message_id)
+{
+	return message_id < ARRAY_SIZE(scmi_rd_handler_table) &&
+	       scmi_rd_handler_table[message_id];
+}
+
+scmi_msg_handler_t scmi_msg_get_rd_handler(struct scmi_msg *msg)
+{
+	const size_t array_size = ARRAY_SIZE(scmi_rd_handler_table);
+	unsigned int message_id = 0;
+
+	if (msg->message_id >= array_size) {
+		DMSG("Reset domain handle not found %u", msg->message_id);
+		return NULL;
+	}
+
+	message_id = confine_array_index(msg->message_id, array_size);
+
+	return scmi_rd_handler_table[message_id];
+}

--- a/core/drivers/scmi-msg/reset_domain.h
+++ b/core/drivers/scmi-msg/reset_domain.h
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+#ifndef SCMI_MSG_RESET_DOMAIN_H
+#define SCMI_MSG_RESET_DOMAIN_H
+
+#include <compiler.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <types_ext.h>
+#include <util.h>
+
+#define SCMI_PROTOCOL_VERSION_RESET_DOMAIN	0x10000
+
+#define SCMI_RESET_STATE_ARCH			BIT(31)
+#define SCMI_RESET_STATE_IMPL			0
+
+/*
+ * Identifiers of the SCMI Reset Domain Management Protocol commands
+ */
+enum scmi_reset_domain_command_id {
+	SCMI_RESET_DOMAIN_ATTRIBUTES = 0x03,
+	SCMI_RESET_DOMAIN_REQUEST = 0x04,
+	SCMI_RESET_DOMAIN_NOTIFY = 0x05,
+};
+
+/*
+ * Identifiers of the SCMI Reset Domain Management Protocol responses
+ */
+enum scmi_reset_domain_response_id {
+	SCMI_RESET_ISSUED = 0x00,
+	SCMI_RESET_COMPLETE = 0x04,
+};
+
+/*
+ * PROTOCOL_ATTRIBUTES
+ */
+
+#define SCMI_RESET_DOMAIN_COUNT_MASK		GENMASK_32(15, 0)
+
+struct scmi_reset_domain_protocol_attributes_p2a {
+	int32_t status;
+	uint32_t attributes;
+};
+
+/* Value for scmi_reset_domain_attributes_p2a:flags */
+#define SCMI_RESET_DOMAIN_ATTR_ASYNC		BIT(31)
+#define SCMI_RESET_DOMAIN_ATTR_NOTIF		BIT(30)
+
+/* Value for scmi_reset_domain_attributes_p2a:latency */
+#define SCMI_RESET_DOMAIN_ATTR_UNK_LAT		0x7fffffff
+#define SCMI_RESET_DOMAIN_ATTR_MAX_LAT		0x7ffffffe
+
+/* Macro for scmi_reset_domain_attributes_p2a:name */
+#define SCMI_RESET_DOMAIN_ATTR_NAME_SZ		16
+
+struct scmi_reset_domain_attributes_a2p {
+	uint32_t domain_id;
+};
+
+struct scmi_reset_domain_attributes_p2a {
+	int32_t status;
+	uint32_t flags;
+	uint32_t latency;
+	char name[SCMI_RESET_DOMAIN_ATTR_NAME_SZ];
+};
+
+/*
+ * RESET
+ */
+
+/* Values for scmi_reset_domain_request_a2p:flags */
+#define SCMI_RESET_DOMAIN_ASYNC			BIT(2)
+#define SCMI_RESET_DOMAIN_EXPLICIT		BIT(1)
+#define SCMI_RESET_DOMAIN_AUTO			BIT(0)
+
+struct scmi_reset_domain_request_a2p {
+	uint32_t domain_id;
+	uint32_t flags;
+	uint32_t reset_state;
+};
+
+struct scmi_reset_domain_request_p2a {
+	int32_t status;
+};
+
+/*
+ * RESET_NOTIFY
+ */
+
+/* Values for scmi_reset_notify_p2a:flags */
+#define SCMI_RESET_DOMAIN_DO_NOTIFY		BIT(0)
+
+struct scmi_reset_domain_notify_a2p {
+	uint32_t domain_id;
+	uint32_t notify_enable;
+};
+
+struct scmi_reset_domain_notify_p2a {
+	int32_t status;
+};
+
+/*
+ * RESET_COMPLETE
+ */
+
+struct scmi_reset_domain_complete_p2a {
+	int32_t status;
+	uint32_t domain_id;
+};
+
+/*
+ * RESET_ISSUED
+ */
+
+struct scmi_reset_domain_issued_p2a {
+	uint32_t domain_id;
+	uint32_t reset_state;
+};
+
+#endif /* SCMI_MSG_RESET_DOMAIN_H */

--- a/core/drivers/scmi-msg/smt.c
+++ b/core/drivers/scmi-msg/smt.c
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Linaro Limited
+ */
+#include <assert.h>
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <io.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <trace.h>
+#include <util.h>
+
+#include "common.h"
+
+/* Legacy SMT/SCMI messages are 128 bytes at most including SMT header */
+#define SCMI_PLAYLOAD_MAX		92
+#define SCMI_PLAYLOAD_U32_MAX		(SCMI_PLAYLOAD_MAX / sizeof(uint32_t))
+
+/**
+ * struct smt_header - SMT formatted header for SMT base shared memory transfer
+ *
+ * @status: Bit flags, see SMT_STATUS_*
+ * @flags: Bit flags, see SMT_FLAG_*
+ * @length: Byte size of message payload (variable) + ::message_header (32bit)
+ * payload: SCMI message payload data
+ */
+struct smt_header {
+	uint32_t reserved0;
+	uint32_t status;
+	uint64_t reserved1;
+	uint32_t flags;
+	uint32_t length; /* message_header + payload */
+	uint32_t message_header;
+	uint32_t payload[];
+};
+
+/* Flag set in smt_header::status when SMT does not contain pending message */
+#define SMT_STATUS_FREE			BIT(0)
+/* Flag set in smt_header::status when SMT reports an error */
+#define SMT_STATUS_ERROR		BIT(1)
+
+/* Flag set in smt_header::flags when SMT uses interrupts */
+#define SMT_FLAG_INTR_ENABLED		BIT(1)
+
+/* Bit fields packed in smt_header::message_header */
+#define SMT_MSG_ID_MASK			GENMASK_32(7, 0)
+#define SMT_HDR_MSG_ID(_hdr)		((_hdr) & SMT_MSG_ID_MASK)
+
+#define SMT_MSG_TYPE_MASK		GENMASK_32(9, 8)
+#define SMT_HDR_TYPE_ID(_hdr)		(((_hdr) & SMT_MSG_TYPE_MASK) >> 8)
+
+#define SMT_MSG_PROT_ID_MASK		GENMASK_32(17, 10)
+#define SMT_HDR_PROT_ID(_hdr)		(((_hdr) & SMT_MSG_PROT_ID_MASK) >> 10)
+
+/* SMP protection on channel access */
+static unsigned int smt_channels_lock;
+
+/* If channel is not busy, set busy and return true, otherwise return false */
+static bool channel_set_busy(struct scmi_msg_channel *chan)
+{
+	uint32_t exceptions = cpu_spin_lock_xsave(&smt_channels_lock);
+	bool channel_is_busy = chan->busy;
+
+	if (!channel_is_busy)
+		chan->busy = true;
+
+	cpu_spin_unlock_xrestore(&smt_channels_lock, exceptions);
+
+	return !channel_is_busy;
+}
+
+static void channel_release_busy(struct scmi_msg_channel *chan)
+{
+	chan->busy = false;
+}
+
+static struct smt_header *channel_to_smt_hdr(struct scmi_msg_channel *chan)
+{
+	return (struct smt_header *)io_pa_or_va(&chan->shm_addr);
+}
+
+/*
+ * Creates a SCMI message instance in secure memory and push it in the SCMI
+ * message drivers. Message structure contains SCMI protocol meta-data and
+ * references to input payload in secure memory and output message buffer
+ * in shared memory.
+ */
+static void scmi_proccess_smt(unsigned int agent_id, uint32_t *payload_buf)
+{
+	struct scmi_msg_channel *chan = NULL;
+	struct smt_header *smt_hdr = NULL;
+	size_t in_payload_size = 0;
+	uint32_t smt_status = 0;
+	struct scmi_msg msg = { };
+	bool error = true;
+
+	chan = plat_scmi_get_channel(agent_id);
+	if (!chan)
+		return;
+
+	smt_hdr = channel_to_smt_hdr(chan);
+	assert(smt_hdr);
+
+	smt_status = READ_ONCE(smt_hdr->status);
+
+	if (!channel_set_busy(chan)) {
+		DMSG("SCMI channel %u busy", agent_id);
+		goto out;
+	}
+
+	in_payload_size = READ_ONCE(smt_hdr->length) -
+			  sizeof(smt_hdr->message_header);
+
+	if (in_payload_size > SCMI_PLAYLOAD_MAX) {
+		DMSG("SCMI payload too big %u", in_payload_size);
+		goto out;
+	}
+
+	if (smt_status & (SMT_STATUS_ERROR | SMT_STATUS_FREE)) {
+		DMSG("SCMI channel bad status 0x%x",
+		     smt_hdr->status & (SMT_STATUS_ERROR | SMT_STATUS_FREE));
+		goto out;
+	}
+
+	/* Fill message */
+	msg.in = (char *)payload_buf;
+	msg.in_size = in_payload_size;
+	msg.out = (char *)smt_hdr->payload;
+	msg.out_size = chan->shm_size - sizeof(*smt_hdr);
+
+	assert(msg.out && msg.out_size >= sizeof(int32_t));
+
+	/* Here the payload is copied in secure memory */
+	memcpy(msg.in, smt_hdr->payload, in_payload_size);
+
+	msg.protocol_id = SMT_HDR_PROT_ID(smt_hdr->message_header);
+	msg.message_id = SMT_HDR_MSG_ID(smt_hdr->message_header);
+	msg.agent_id = agent_id;
+
+	scmi_process_message(&msg);
+
+	/* Update message length with the length of the response message */
+	smt_hdr->length = msg.out_size_out + sizeof(smt_hdr->message_header);
+
+	channel_release_busy(chan);
+	error = false;
+
+out:
+	if (error) {
+		DMSG("SCMI error");
+		smt_hdr->status |= SMT_STATUS_ERROR | SMT_STATUS_FREE;
+	} else {
+		smt_hdr->status |= SMT_STATUS_FREE;
+	}
+}
+
+#ifdef CFG_SCMI_MSG_SMT_FASTCALL_ENTRY
+/* Provision input message payload buffers for fastcall SMC context entries */
+static uint32_t fast_smc_payload[CFG_TEE_CORE_NB_CORE][SCMI_PLAYLOAD_U32_MAX];
+
+void scmi_smt_fastcall_smc_entry(unsigned int agent_id)
+{
+	scmi_proccess_smt(agent_id, fast_smc_payload[get_core_pos()]);
+}
+#endif
+
+#ifdef CFG_SCMI_MSG_SMT_INTERRUPT_ENTRY
+/* Provision input message payload buffers for fastcall SMC context entries */
+static uint32_t interrupt_payload[CFG_TEE_CORE_NB_CORE][SCMI_PLAYLOAD_U32_MAX];
+
+void scmi_smt_interrupt_entry(unsigned int agent_id)
+{
+	scmi_proccess_smt(agent_id, interrupt_payload[get_core_pos()]);
+}
+#endif
+
+#ifdef CFG_SCMI_MSG_SMT_THREAD_ENTRY
+/* Provision input message payload buffers for fastcall SMC context entries */
+static uint32_t threaded_payload[CFG_NUM_THREADS][SCMI_PLAYLOAD_U32_MAX];
+
+void scmi_smt_threaded_entry(unsigned int agent_id)
+{
+	assert(plat_scmi_get_channel(agent_id)->threaded);
+
+	scmi_proccess_smt(agent_id, threaded_payload[thread_get_id()]);
+}
+#endif
+
+/* Init a SMT header for a shared memory buffer: state it a free/no-error */
+void scmi_smt_init_agent_channel(struct scmi_msg_channel *chan)
+{
+	COMPILE_TIME_ASSERT(SCMI_PLAYLOAD_MAX + sizeof(struct smt_header) <=
+			    SMT_BUF_SLOT_SIZE);
+
+	if (chan) {
+		struct smt_header *smt_header = channel_to_smt_hdr(chan);
+
+		if (smt_header) {
+			memset(smt_header, 0, sizeof(*smt_header));
+			smt_header->status = SMT_STATUS_FREE;
+
+			return;
+		}
+	}
+
+	panic();
+}

--- a/core/drivers/scmi-msg/sub.mk
+++ b/core/drivers/scmi-msg/sub.mk
@@ -1,3 +1,4 @@
 srcs-y += base.c
 srcs-$(CFG_SCMI_MSG_CLOCK) += clock.c
 srcs-y += entry.c
+srcs-$(CFG_SCMI_MSG_RESET_DOMAIN) += reset_domain.c

--- a/core/drivers/scmi-msg/sub.mk
+++ b/core/drivers/scmi-msg/sub.mk
@@ -1,0 +1,2 @@
+srcs-y += base.c
+srcs-y += entry.c

--- a/core/drivers/scmi-msg/sub.mk
+++ b/core/drivers/scmi-msg/sub.mk
@@ -1,2 +1,3 @@
 srcs-y += base.c
+srcs-$(CFG_SCMI_MSG_CLOCK) += clock.c
 srcs-y += entry.c

--- a/core/drivers/scmi-msg/sub.mk
+++ b/core/drivers/scmi-msg/sub.mk
@@ -2,3 +2,4 @@ srcs-y += base.c
 srcs-$(CFG_SCMI_MSG_CLOCK) += clock.c
 srcs-y += entry.c
 srcs-$(CFG_SCMI_MSG_RESET_DOMAIN) += reset_domain.c
+srcs-$(CFG_SCMI_MSG_SMT) += smt.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -34,3 +34,4 @@ srcs-$(CFG_BCM_GPIO) += bcm_gpio.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt
+subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg

--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef SCMI_MSG_H
+#define SCMI_MSG_H
+
+#include <compiler.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Minimum size expected for SMT based shared memory message buffers */
+#define SMT_BUF_SLOT_SIZE	128
+
+/* A channel abstract a communication path between agent and server */
+struct scmi_msg_channel;
+
+/*
+ * struct scmi_msg_channel - Shared memory buffer for a agent-to-server channel
+ *
+ * @shm_addr: Address of the shared memory for the SCMI channel
+ * @shm_size: Byte size of the shared memory for the SCMI channel
+ * @busy: True when channel is busy, flase when channel is free
+ * @threaded: True is executed in a threaded context, false otherwise
+ * @agent_name: Optional agent name, SCMI protocol exposes 16 bytes max
+ */
+struct scmi_msg_channel {
+	struct io_pa_va shm_addr;
+	size_t shm_size;
+	bool busy;
+	bool threaded;
+	const char *agent_name;
+};
+
+/* Platform callback functions */
+
+/*
+ * Return the SCMI channel related to an agent
+ * @agent_id: SCMI agent ID
+ * Return a pointer to channel on success, NULL otherwise
+ */
+struct scmi_msg_channel *plat_scmi_get_channel(unsigned int agent_id);
+
+/*
+ * Return how many SCMI protocols supported by the platform
+ * According to the SCMI specification, this function does not target
+ * a specific agent ID and shall return all platform known capabilities.
+ */
+size_t plat_scmi_protocol_count(void);
+
+/*
+ * Get the count and list of SCMI protocols (but base) supported for an agent
+ *
+ * @agent_id: SCMI agent ID
+ * Return a pointer to a null terminated array supported protocol IDs.
+ */
+const uint8_t *plat_scmi_protocol_list(unsigned int agent_id);
+
+/* Get the name of the SCMI vendor for the platform */
+const char *plat_scmi_vendor_name(void);
+
+/* Get the name of the SCMI sub-vendor for the platform */
+const char *plat_scmi_sub_vendor_name(void);
+
+#endif /* SCMI_MSG_H */

--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -145,4 +145,42 @@ int32_t plat_scmi_clock_get_state(unsigned int agent_id, unsigned int scmi_id);
  */
 int32_t plat_scmi_clock_set_state(unsigned int agent_id, unsigned int scmi_id,
 				  bool enable_not_disable);
+
+/* Handlers for SCMI Reset Domain protocol services */
+
+/*
+ * Return number of reset domains for the agent
+ * @agent_id: SCMI agent ID
+ * Return number of reset domains
+ */
+size_t plat_scmi_rd_count(unsigned int agent_id);
+
+/*
+ * Get reset domain string ID (aka name)
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI reset domain ID
+ * Return pointer to name or NULL
+ */
+const char *plat_scmi_rd_get_name(unsigned int agent_id, unsigned int scmi_id);
+
+/*
+ * Perform a reset cycle on a target reset domain
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI reset domain ID
+ * @state: Target reset state (see SCMI specification, 0 means context loss)
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_rd_autonomous(unsigned int agent_id, unsigned int scmi_id,
+				unsigned int state);
+
+/*
+ * Assert or deassert target reset domain
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI reset domain ID
+ * @assert_not_deassert: Assert domain if true, otherwise deassert domain
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_rd_set_state(unsigned int agent_id, unsigned int scmi_id,
+			       bool assert_not_deassert);
+
 #endif /* SCMI_MSG_H */

--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -37,6 +37,45 @@ struct scmi_msg_channel {
 	const char *agent_name;
 };
 
+/*
+ * Initialize SMT memory buffer, called by platform at init for each
+ * agent channel using the SMT header format.
+ * This function depends on CFG_SCMI_MSG_SMT.
+ *
+ * @chan: Pointer to the channel shared memory to be initialized
+ */
+void scmi_smt_init_agent_channel(struct scmi_msg_channel *chan);
+
+/*
+ * Process SMT formatted message in a fastcall SMC cexecution ontext.
+ * Called by platform on SMC entry. When returning, output message is
+ * available in shared memory for agent to read the response.
+ * This function depends on CFG_SCMI_MSG_SMT_FASTCALL_ENTRY.
+ *
+ * @agent_id: SCMI agent ID the SMT belongs to
+ */
+void scmi_smt_fastcall_smc_entry(unsigned int agent_id);
+
+/*
+ * Process SMT formatted message in a secure interrupt execution context.
+ * Called by platform interrupt handler. When returning, output message is
+ * available in shared memory for agent to read the response.
+ * This function depends on CFG_SCMI_MSG_SMT_INTERRUPT_ENTRY.
+ *
+ * @agent_id: SCMI agent ID the SMT belongs to
+ */
+void scmi_smt_interrupt_entry(unsigned int agent_id);
+
+/*
+ * Process SMT formatted message in a TEE thread execution context.
+ * When returning, output message is available in shared memory for
+ * agent to read the response.
+ * This function depends on CFG_SCMI_MSG_SMT_THREAD_ENTRY.
+ *
+ * @agent_id: SCMI agent ID the SMT belongs to
+ */
+void scmi_smt_threaded_entry(unsigned int agent_id);
+
 /* Platform callback functions */
 
 /*

--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -67,4 +67,82 @@ const char *plat_scmi_vendor_name(void);
 /* Get the name of the SCMI sub-vendor for the platform */
 const char *plat_scmi_sub_vendor_name(void);
 
+/* Handlers for SCMI Clock protocol services */
+
+/*
+ * Return number of clock controllers for an agent
+ * @agent_id: SCMI agent ID
+ * Return number of clock controllers
+ */
+size_t plat_scmi_clock_count(unsigned int agent_id);
+
+/*
+ * Get clock controller string ID (aka name)
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * Return pointer to name or NULL
+ */
+const char *plat_scmi_clock_get_name(unsigned int agent_id,
+				     unsigned int scmi_id);
+
+/*
+ * Get clock possible rate as an array of frequencies in Hertz.
+ *
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * @rates: If NULL, function returns, else output rates array
+ * @nb_elts: Array size of @rates.
+ * Return an SCMI compliant error code
+ */
+int32_t plat_scmi_clock_rates_array(unsigned int agent_id, unsigned int scmi_id,
+				    unsigned long *rates, size_t *nb_elts);
+
+/*
+ * Get clock possible rate as range with regular steps in Hertz
+ *
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * @min_max_step: 3 cell array for min, max and step rate data
+ * Return an SCMI compliant error code
+ */
+int32_t plat_scmi_clock_rates_by_step(unsigned int agent_id,
+				      unsigned int scmi_id,
+				      unsigned long *min_max_step);
+
+/*
+ * Get clock rate in Hertz
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * Return clock rate or 0 if not supported
+ */
+unsigned long plat_scmi_clock_get_rate(unsigned int agent_id,
+				       unsigned int scmi_id);
+
+/*
+ * Set clock rate in Hertz
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * @rate: Target clock frequency in Hertz
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_clock_set_rate(unsigned int agent_id, unsigned int scmi_id,
+				 unsigned long rate);
+
+/*
+ * Get clock state (enabled or disabled)
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * Return 1 if clock is enabled, 0 if disables, or a negative SCMI error code
+ */
+int32_t plat_scmi_clock_get_state(unsigned int agent_id, unsigned int scmi_id);
+
+/*
+ * Get clock state (enabled or disabled)
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * @enable_not_disable: Enable clock if true, disable clock otherwise
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_clock_set_state(unsigned int agent_id, unsigned int scmi_id,
+				  bool enable_not_disable);
 #endif /* SCMI_MSG_H */

--- a/core/include/drivers/scmi.h
+++ b/core/include/drivers/scmi.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ */
+#ifndef SCMI_MSG_SCMI_H
+#define SCMI_MSG_SCMI_H
+
+#define SCMI_PROTOCOL_ID_BASE			0x10
+#define SCMI_PROTOCOL_ID_POWER_DOMAIN		0x11
+#define SCMI_PROTOCOL_ID_SYS_POWER		0x12
+#define SCMI_PROTOCOL_ID_PERF			0x13
+#define SCMI_PROTOCOL_ID_CLOCK			0x14
+#define SCMI_PROTOCOL_ID_SENSOR			0x15
+#define SCMI_PROTOCOL_ID_RESET_DOMAIN		0x16
+
+/* SCMI error codes reported to agent through server-to-agent messages */
+#define SCMI_SUCCESS			0
+#define SCMI_NOT_SUPPORTED		(-1)
+#define SCMI_INVALID_PARAMETERS		(-2)
+#define SCMI_DENIED			(-3)
+#define SCMI_NOT_FOUND			(-4)
+#define SCMI_OUT_OF_RANGE		(-5)
+#define SCMI_BUSY			(-6)
+#define SCMI_COMMS_ERROR		(-7)
+#define SCMI_GENERIC_ERROR		(-8)
+#define SCMI_HARDWARE_ERROR		(-9)
+#define SCMI_PROTOCOL_ERROR		(-10)
+
+#endif /* SCMI_MSG_SCMI_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -552,6 +552,8 @@ CFG_CORE_TPM_EVENT_LOG ?= n
 # Refer to the supported SCMI features embedded upon CFG_SCMI_MSG_*
 # CFG_SCMI_MSG_CLOCK embeds SCMI clock protocol support.
 # CFG_SCMI_MSG_RESET_DOMAIN embeds SCMI reset domain protocol support.
+# CFG_SCMI_MSG_SMT embeds SMT based message buffer of communication channel
 CFG_SCMI_MSG_DRIVERS ?= n
 CFG_SCMI_MSG_CLOCK ?= n
 CFG_SCMI_MSG_RESET_DOMAIN ?= n
+CFG_SCMI_MSG_SMT ?= n

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -550,4 +550,6 @@ CFG_CORE_TPM_EVENT_LOG ?= n
 
 # When enabled, CFG_SCMI_MSG_DRIVERS embeds SCMI message drivers in the core.
 # Refer to the supported SCMI features embedded upon CFG_SCMI_MSG_*
+# CFG_SCMI_MSG_CLOCK embeds SCMI clock protocol support.
 CFG_SCMI_MSG_DRIVERS ?= n
+CFG_SCMI_MSG_CLOCK ?= n

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -551,5 +551,7 @@ CFG_CORE_TPM_EVENT_LOG ?= n
 # When enabled, CFG_SCMI_MSG_DRIVERS embeds SCMI message drivers in the core.
 # Refer to the supported SCMI features embedded upon CFG_SCMI_MSG_*
 # CFG_SCMI_MSG_CLOCK embeds SCMI clock protocol support.
+# CFG_SCMI_MSG_RESET_DOMAIN embeds SCMI reset domain protocol support.
 CFG_SCMI_MSG_DRIVERS ?= n
 CFG_SCMI_MSG_CLOCK ?= n
+CFG_SCMI_MSG_RESET_DOMAIN ?= n

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -547,3 +547,7 @@ CFG_SHOW_CONF_ON_BOOT ?= n
 # to a TA, so a TPM Service could use it to extend any measurement
 # taken before the service was up and running.
 CFG_CORE_TPM_EVENT_LOG ?= n
+
+# When enabled, CFG_SCMI_MSG_DRIVERS embeds SCMI message drivers in the core.
+# Refer to the supported SCMI features embedded upon CFG_SCMI_MSG_*
+CFG_SCMI_MSG_DRIVERS ?= n


### PR DESCRIPTION
These changes propose a set of drivers to help a platform to embed an SCMI server in OP-TEE.

This P-R proposes support for SCMI base, clock and reset domain protocols. More protocols can easily be added.

SCMI message drivers offers API functions to read an SCMI message received by Core. The drivers call one or more platform handlers to get the message handled. For example a clock STATE_SET message ends in platform clock driver interface to enable/disable the clock. The drivers only carry the messages to the right platform handler.

SCMI message drivers use the SMT header format to manage the shared memory area used for SCMI message exchanges. SCMI message notification channel can be:
* an interrupt: if so, SCMI message drivers execute in interrupt context up to handlers completion.
Interrupt handler calls  `scmi_smt_interrupt_entry()` to get the SCMI message processed and response forged before interrupt completion.
* a fast call SMC: if so, SCMI message drivers execute in fastcall context up.
Core handler calls `scmi_smt_fastcall_entry()` to get the message processed and response forged upon completion of the fastcall service.
* a yield (standard) call: in such context, SCMI message drivers execute in a TEE thread context.
Core (i.e. a PTA) calls `scmi_smt_thread_entry()` to get the message processed and response forged upon completion of the SMC.

Source files related to the SCMI specification are based on SCP-firmware source tree as mentioned in related commit messages.

P-R https://github.com/OP-TEE/optee_os/pull/3480 (to update) shows how a platform can hook message channel with platform resources for plat-stm32mp1/.

Supersedes https://github.com/OP-TEE/optee_os/pull/3447.