### PR TITLE
drivers/stm32_etzpc: initialize etzpc driver early

### DIFF
--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -345,5 +345,5 @@ static TEE_Result init_etzpc_from_dt(void)
 	return TEE_SUCCESS;
 }
 
-driver_init(init_etzpc_from_dt);
+service_init(init_etzpc_from_dt);
 #endif /*CFG_DT*/


### PR DESCRIPTION
Changes initcall level for STM32 ETZPC driver so that in initializes
early, at service_init level. The driver does not depends on other
SoC drivers and can be initialize early. This change allows other
driver_init level initialization sequence to use ETZPC resources.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
