### PR TITLE
plat-stm32mp1: change reset functions to get a timeout argument

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
@@ -10,23 +10,11 @@
 #include <mm/core_memprot.h>
 #include <platform_config.h>
 #include <stm32_util.h>
+#include <tee_api_defines.h>
 
 #define RESET_ID_MASK		GENMASK_32(31, 5)
 #define RESET_ID_SHIFT		5
 #define RESET_BIT_POS_MASK	GENMASK_32(4, 0)
-
-#define RESET_TIMEOUT_US	1000
-
-/*
- * Loop until condition is reached or timeout elapsed. We test the condition
- * again after timeout is detected and panic only if it is still false since
- * TEE thread might have been suspended hence timing out when resumed.
- */
-#define WAIT_COND_OR_PANIC(_condition, _timeout_ref) \
-	do { \
-		if (timeout_elapsed(_timeout_ref) && !(_condition)) \
-			panic(); \
-	} while (!(_condition))
 
 vaddr_t stm32_rcc_base(void)
 {
@@ -45,28 +33,46 @@ static uint8_t reset_id2reg_bit_pos(unsigned int reset_id)
 	return reset_id & RESET_BIT_POS_MASK;
 }
 
-void stm32_reset_assert(unsigned int id)
+TEE_Result stm32_reset_assert(unsigned int id, unsigned int to_us)
 {
 	size_t offset = reset_id2reg_offset(id);
 	uint32_t bitmsk = BIT(reset_id2reg_bit_pos(id));
-	uint64_t timeout_ref = timeout_init_us(RESET_TIMEOUT_US);
 	vaddr_t rcc_base = stm32_rcc_base();
 
 	io_write32(rcc_base + offset, bitmsk);
 
-	WAIT_COND_OR_PANIC(io_read32(rcc_base + offset) & bitmsk,
-			   timeout_ref);
+	if (to_us) {
+		uint64_t timeout_ref = timeout_init_us(to_us);
+
+		while (!(io_read32(rcc_base + offset) & bitmsk))
+			if (timeout_elapsed(timeout_ref))
+				break;
+
+		if (!(io_read32(rcc_base + offset) & bitmsk))
+			return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
 }
 
-void stm32_reset_deassert(unsigned int id)
+TEE_Result stm32_reset_deassert(unsigned int id, unsigned int to_us)
 {
 	size_t offset = reset_id2reg_offset(id) + RCC_MP_RSTCLRR_OFFSET;
 	uint32_t bitmsk = BIT(reset_id2reg_bit_pos(id));
-	uint64_t timeout_ref = timeout_init_us(RESET_TIMEOUT_US);
 	vaddr_t rcc_base = stm32_rcc_base();
 
 	io_write32(rcc_base + offset, bitmsk);
 
-	WAIT_COND_OR_PANIC(!(io_read32(rcc_base + offset) & bitmsk),
-			   timeout_ref);
+	if (to_us) {
+		uint64_t timeout_ref = timeout_init_us(to_us);
+
+		while ((io_read32(rcc_base + offset) & bitmsk))
+			if (timeout_elapsed(timeout_ref))
+				break;
+
+		if (io_read32(rcc_base + offset) & bitmsk)
+			return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
 }

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -64,9 +64,20 @@ bool stm32_clock_is_enabled(unsigned long id);
 /*
  * Util for reset signal assertion/desassertion for stm32 and platform drivers
  * @id: Target peripheral ID, ID used in reset DT bindings
+ * @to_us: Timeout out in microsecond, or 0 if not waiting signal state
  */
-void stm32_reset_assert(unsigned int id);
-void stm32_reset_deassert(unsigned int id);
+TEE_Result stm32_reset_assert(unsigned int id, unsigned int timeout_us);
+TEE_Result stm32_reset_deassert(unsigned int id, unsigned int timeout_us);
+
+static inline void stm32_reset_set(unsigned int id)
+{
+	(void)stm32_reset_assert(id, 0);
+}
+
+static inline void stm32_reset_release(unsigned int id)
+{
+	(void)stm32_reset_deassert(id, 0);
+}
 
 /*
  * Structure and API function for BSEC driver to get some platform data.


### PR DESCRIPTION
Stm32mp1 reset function APIs now get a timeout argument and return
an error if reset domain has not effectively reset when timeout has
expired. A null timeout means the driver loads target reset state
and return without waiting request domain reset state is reached.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
