### PR TITLE
driver/gic: remove SPI security checking

### DIFF
--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -306,8 +306,6 @@ static void gic_it_set_pending(struct gic_data *gd, size_t it)
 
 	/* Should be Peripheral Interrupt */
 	assert(it >= NUM_SGI);
-	/* Assigned to group0 */
-	assert(!(io_read32(gd->gicd_base + GICD_IGROUPR(idx)) & mask));
 
 	/* Raise the interrupt */
 	io_write32(gd->gicd_base + GICD_ISPENDR(idx), mask);


### PR DESCRIPTION
Current SPI raised by gic_it_set_pending is limited
to secure interrupt. Remove this limitation to let
it be handled by REE.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
