### PR TITLE
core: add TEE_LOGIN_REE_KERNEL login method

### DIFF
--- a/core/arch/arm/tee/entry_std.c
+++ b/core/arch/arm/tee/entry_std.c
@@ -278,6 +278,7 @@ static TEE_Result get_open_session_meta(size_t num_params,
 	clnt_id->login = params[1].u.value.c;
 	switch (clnt_id->login) {
 	case TEE_LOGIN_PUBLIC:
+	case TEE_LOGIN_REE_KERNEL:
 		memset(&clnt_id->uuid, 0, sizeof(clnt_id->uuid));
 		break;
 	case TEE_LOGIN_USER:

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -89,4 +89,11 @@
 #define TEE_MEMORY_ACCESS_NONSECURE          0x10000000
 #define TEE_MEMORY_ACCESS_SECURE             0x20000000
 
+/*
+ * Implementation-specific login types
+ */
+
+/* Private login method for REE kernel clients */
+#define TEE_LOGIN_REE_KERNEL		0x80000000
+
 #endif /* TEE_API_DEFINES_EXTENSIONS_H */


### PR DESCRIPTION
Add private login method for REE kernel clients to invoke TAs. It allows
a TA to distinguish among normal world clients whether its a REE kernel
client or a REE user-space client.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
