### PR TITLE
ta: pkcs11: session support related commands

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -131,6 +131,52 @@ enum pkcs11_ta_cmd {
 	 * C_GetMechanismInfo().
 	 */
 	PKCS11_CMD_MECHANISM_INFO = 5,
+
+	/*
+	 * PKCS11_CMD_OPEN_SESSION - Open a session
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit slot ID,
+	 *              32bit session flags,
+	 *       ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = 32bit session handle
+	 *
+	 * This command relates to the PKCS#11 API function C_OpenSession().
+	 */
+	PKCS11_CMD_OPEN_SESSION = 6,
+
+	/*
+	 * PKCS11_CMD_CLOSE_SESSION - Close an opened session
+	 *
+	 * [in]  memref[0] = 32bit session handle
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 *
+	 * This command relates to the PKCS#11 API function C_CloseSession().
+	 */
+	PKCS11_CMD_CLOSE_SESSION = 7,
+
+	/*
+	 * PKCS11_CMD_CLOSE_ALL_SESSIONS - Close all client sessions on token
+	 *
+	 * [in]	 memref[0] = 32bit slot ID
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 *
+	 * This command relates to the PKCS#11 API function
+	 * C_CloseAllSessions().
+	 */
+	PKCS11_CMD_CLOSE_ALL_SESSIONS = 8,
+
+	/*
+	 * PKCS11_CMD_SESSION_INFO - Get Cryptoki information on a session
+	 *
+	 * [in]  memref[0] = 32bit session handle
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = (struct pkcs11_session_info)info
+	 *
+	 * This command relates to the PKCS#11 API function C_GetSessionInfo().
+	 */
+	PKCS11_CMD_SESSION_INFO = 9,
 };
 
 /*
@@ -287,6 +333,34 @@ enum pkcs11_user_type {
 	PKCS11_CKU_SO = 0x000,
 	PKCS11_CKU_USER = 0x001,
 	PKCS11_CKU_CONTEXT_SPECIFIC = 0x002,
+};
+
+/*
+ * Values for 32bit session flags argument to PKCS11_CMD_OPEN_SESSION
+ * and pkcs11_session_info::flags.
+ * PKCS11_CKFSS_<x> reflects CryptoKi client API session flags CKF_<x>.
+ */
+#define PKCS11_CKFSS_RW_SESSION				(1U << 1)
+#define PKCS11_CKFSS_SERIAL_SESSION			(1U << 2)
+
+/*
+ * Arguments for PKCS11_CMD_SESSION_INFO
+ */
+
+struct pkcs11_session_info {
+	uint32_t slot_id;
+	uint32_t state;
+	uint32_t flags;
+	uint32_t device_error;
+};
+
+/* Valid values for pkcs11_session_info::state */
+enum pkcs11_session_state {
+	PKCS11_CKS_RO_PUBLIC_SESSION = 0,
+	PKCS11_CKS_RO_USER_FUNCTIONS = 1,
+	PKCS11_CKS_RW_PUBLIC_SESSION = 2,
+	PKCS11_CKS_RW_USER_FUNCTIONS = 3,
+	PKCS11_CKS_RW_SO_FUNCTIONS = 4,
 };
 
 /*

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -171,6 +171,19 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 		rc = entry_ck_token_mecha_info(ptypes, params);
 		break;
 
+	case PKCS11_CMD_OPEN_SESSION:
+		rc = entry_ck_open_session(client, ptypes, params);
+		break;
+	case PKCS11_CMD_CLOSE_SESSION:
+		rc = entry_ck_close_session(client, ptypes, params);
+		break;
+	case PKCS11_CMD_CLOSE_ALL_SESSIONS:
+		rc = entry_ck_close_all_sessions(client, ptypes, params);
+		break;
+	case PKCS11_CMD_SESSION_INFO:
+		rc = entry_ck_session_info(client, ptypes, params);
+		break;
+
 	default:
 		EMSG("Command 0x%"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/handle.c
+++ b/ta/pkcs11/src/handle.c
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2014-2020, Linaro Limited
+ */
+
+#include <stdlib.h>
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
+
+#include "handle.h"
+
+/*
+ * Define the initial capacity of the database. It should be a low number
+ * multiple of 2 since some databases a likely to only use a few handles.
+ * Since the algorithm is to doubles up when growing it shouldn't cause a
+ * noticeable overhead on large databases.
+ */
+#define HANDLE_DB_INITIAL_MAX_PTRS	4
+
+void handle_db_init(struct handle_db *db)
+{
+	TEE_MemFill(db, 0, sizeof(*db));
+}
+
+void handle_db_destroy(struct handle_db *db)
+{
+	if (db) {
+		TEE_Free(db->ptrs);
+		db->ptrs = NULL;
+		db->max_ptrs = 0;
+	}
+}
+
+uint32_t handle_get(struct handle_db *db, void *ptr)
+{
+	uint32_t n = 0;
+	void *p = NULL;
+	uint32_t new_max_ptrs = 0;
+
+	if (!db || !ptr)
+		return 0;
+
+	/* Try to find an empty location (index 0 is reserved as invalid) */
+	for (n = 1; n < db->max_ptrs; n++) {
+		if (!db->ptrs[n]) {
+			db->ptrs[n] = ptr;
+			return n;
+		}
+	}
+
+	/* No location available, grow the ptrs array */
+	if (db->max_ptrs)
+		new_max_ptrs = db->max_ptrs * 2;
+	else
+		new_max_ptrs = HANDLE_DB_INITIAL_MAX_PTRS;
+
+	p = TEE_Realloc(db->ptrs, new_max_ptrs * sizeof(void *));
+	if (!p)
+		return 0;
+	db->ptrs = p;
+	TEE_MemFill(db->ptrs + db->max_ptrs, 0,
+		    (new_max_ptrs - db->max_ptrs) * sizeof(void *));
+	db->max_ptrs = new_max_ptrs;
+
+	/* Since n stopped at db->max_ptrs there is an empty location there */
+	db->ptrs[n] = ptr;
+	return n;
+}
+
+void *handle_put(struct handle_db *db, uint32_t handle)
+{
+	void *p = NULL;
+
+	if (!db || !handle || handle >= db->max_ptrs)
+		return NULL;
+
+	p = db->ptrs[handle];
+	db->ptrs[handle] = NULL;
+	return p;
+}
+
+void *handle_lookup(struct handle_db *db, uint32_t handle)
+{
+	if (!db || !handle || handle >= db->max_ptrs)
+		return NULL;
+
+	return db->ptrs[handle];
+}
+
+uint32_t handle_lookup_handle(struct handle_db *db, void *ptr)
+{
+	uint32_t n = 0;
+
+	if (ptr) {
+		for (n = 1; n < db->max_ptrs; n++)
+			if (db->ptrs[n] == ptr)
+				return n;
+	}
+
+	return 0;
+}

--- a/ta/pkcs11/src/handle.h
+++ b/ta/pkcs11/src/handle.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2014-2020, Linaro Limited
+ */
+
+#ifndef PKCS11_TA_HANDLE_H
+#define PKCS11_TA_HANDLE_H
+
+#include <stddef.h>
+
+struct handle_db {
+	void **ptrs;
+	uint32_t max_ptrs;
+};
+
+/*
+ * Initialize the handle database
+ */
+void handle_db_init(struct handle_db *db);
+
+/*
+ * Free all internal data structures of the database, but does not free
+ * the db pointer. The database is safe to reuse after it's destroyed, it
+ * just be empty again.
+ */
+void handle_db_destroy(struct handle_db *db);
+
+/*
+ * Allocate a new handle ID and assigns the supplied pointer to it,
+ * The function returns > 0 on success and 0 on failure.
+ */
+uint32_t handle_get(struct handle_db *db, void *ptr);
+
+/*
+ * Deallocate a handle. Returns the associated pointer of the handle
+ * the the handle was valid or NULL if it's invalid.
+ */
+void *handle_put(struct handle_db *db, uint32_t handle);
+
+/*
+ * Return the associated pointer of the handle if the handle is a valid
+ * handle.
+ * Returns NULL on failure.
+ */
+void *handle_lookup(struct handle_db *db, uint32_t handle);
+
+/* Return the handle associated to a pointer if found, else return 0 */
+uint32_t handle_lookup_handle(struct handle_db *db, void *ptr);
+
+#endif /*PKCS11_TA_HANDLE_H*/

--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -65,6 +65,12 @@ static const struct any_id __maybe_unused string_ta_cmd[] = {
 	PKCS11_ID(PKCS11_CMD_SLOT_LIST),
 	PKCS11_ID(PKCS11_CMD_SLOT_INFO),
 	PKCS11_ID(PKCS11_CMD_TOKEN_INFO),
+	PKCS11_ID(PKCS11_CMD_MECHANISM_IDS),
+	PKCS11_ID(PKCS11_CMD_MECHANISM_INFO),
+	PKCS11_ID(PKCS11_CMD_OPEN_SESSION),
+	PKCS11_ID(PKCS11_CMD_SESSION_INFO),
+	PKCS11_ID(PKCS11_CMD_CLOSE_SESSION),
+	PKCS11_ID(PKCS11_CMD_CLOSE_ALL_SESSIONS),
 };
 
 static const struct any_id __maybe_unused string_slot_flags[] = {
@@ -92,6 +98,19 @@ static const struct any_id __maybe_unused string_token_flags[] = {
 	PKCS11_ID(PKCS11_CKFT_SO_PIN_LOCKED),
 	PKCS11_ID(PKCS11_CKFT_SO_PIN_TO_BE_CHANGED),
 	PKCS11_ID(PKCS11_CKFT_ERROR_STATE),
+};
+
+static const struct any_id __maybe_unused string_session_flags[] = {
+	PKCS11_ID(PKCS11_CKFSS_RW_SESSION),
+	PKCS11_ID(PKCS11_CKFSS_SERIAL_SESSION),
+};
+
+static const struct any_id __maybe_unused string_session_state[] = {
+	PKCS11_ID(PKCS11_CKS_RO_PUBLIC_SESSION),
+	PKCS11_ID(PKCS11_CKS_RO_USER_FUNCTIONS),
+	PKCS11_ID(PKCS11_CKS_RW_PUBLIC_SESSION),
+	PKCS11_ID(PKCS11_CKS_RW_USER_FUNCTIONS),
+	PKCS11_ID(PKCS11_CKS_RW_SO_FUNCTIONS),
 };
 
 static const struct any_id __maybe_unused string_rc[] = {
@@ -161,5 +180,15 @@ const char *id2str_slot_flag(uint32_t id)
 const char *id2str_token_flag(uint32_t id)
 {
 	return ID2STR(id, string_token_flags, "PKCS11_CKFT_");
+}
+
+const char *id2str_session_flag(uint32_t id)
+{
+	return ID2STR(id, string_session_flags, "PKCS11_CKFSS_");
+}
+
+const char *id2str_session_state(uint32_t id)
+{
+	return ID2STR(id, string_session_state, "PKCS11_CKS_");
 }
 #endif /*CFG_TEE_TA_LOG_LEVEL*/

--- a/ta/pkcs11/src/pkcs11_helpers.h
+++ b/ta/pkcs11/src/pkcs11_helpers.h
@@ -23,6 +23,9 @@ const char *id2str_ta_cmd(uint32_t id);
 const char *id2str_rc(uint32_t id);
 const char *id2str_slot_flag(uint32_t id);
 const char *id2str_token_flag(uint32_t id);
+const char *id2str_session_flag(uint32_t id);
+const char *id2str_session_state(uint32_t id);
+
 static inline const char *id2str_mechanism(enum pkcs11_mechanism_id id)
 {
 	return mechanism_string_id(id);

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -119,11 +119,52 @@ struct pkcs11_client *tee_session2client(void *tee_session);
 struct pkcs11_client *register_client(void);
 void unregister_client(struct pkcs11_client *client);
 
+struct pkcs11_session *pkcs11_handle2session(uint32_t handle,
+					     struct pkcs11_client *client);
+
+static inline bool pkcs11_session_is_read_write(struct pkcs11_session *session)
+{
+	return session->state == PKCS11_CKS_RW_PUBLIC_SESSION ||
+	       session->state == PKCS11_CKS_RW_USER_FUNCTIONS ||
+	       session->state == PKCS11_CKS_RW_SO_FUNCTIONS;
+}
+
+static inline bool pkcs11_session_is_public(struct pkcs11_session *session)
+{
+	return session->state == PKCS11_CKS_RO_PUBLIC_SESSION ||
+	       session->state == PKCS11_CKS_RW_PUBLIC_SESSION;
+}
+
+static inline bool pkcs11_session_is_user(struct pkcs11_session *session)
+{
+	return session->state == PKCS11_CKS_RO_USER_FUNCTIONS ||
+	       session->state == PKCS11_CKS_RW_USER_FUNCTIONS;
+}
+
+static inline bool pkcs11_session_is_so(struct pkcs11_session *session)
+{
+	return session->state == PKCS11_CKS_RW_SO_FUNCTIONS;
+}
+
+static inline
+struct ck_token *pkcs11_session2token(struct pkcs11_session *session)
+{
+	return session->token;
+}
+
 /* Entry point for the TA commands */
 uint32_t entry_ck_slot_list(uint32_t ptypes, TEE_Param *params);
 uint32_t entry_ck_slot_info(uint32_t ptypes, TEE_Param *params);
 uint32_t entry_ck_token_info(uint32_t ptypes, TEE_Param *params);
 uint32_t entry_ck_token_mecha_ids(uint32_t ptypes, TEE_Param *params);
 uint32_t entry_ck_token_mecha_info(uint32_t ptypes, TEE_Param *params);
+uint32_t entry_ck_open_session(struct pkcs11_client *client,
+			       uint32_t ptypes, TEE_Param *params);
+uint32_t entry_ck_close_session(struct pkcs11_client *client,
+				uint32_t ptypes, TEE_Param *params);
+uint32_t entry_ck_close_all_sessions(struct pkcs11_client *client,
+				     uint32_t ptypes, TEE_Param *params);
+uint32_t entry_ck_session_info(struct pkcs11_client *client,
+			       uint32_t ptypes, TEE_Param *params);
 
 #endif /*PKCS11_TA_PKCS11_TOKEN_H*/

--- a/ta/pkcs11/src/sub.mk
+++ b/ta/pkcs11/src/sub.mk
@@ -1,4 +1,5 @@
 srcs-y += entry.c
+srcs-y += handle.c
 srcs-y += persistent_token.c
 srcs-y += pkcs11_helpers.c
 srcs-y += pkcs11_token.c


### PR DESCRIPTION
This P-R implements support for PKCS11 session commands: open session, close session, close all sessions, get session info. It is spread into a 5 commit series:

* ta: pkcs11: define TA commands related to session management
* ta: pkcs11: add mechanism info and session command to helpers
* ta: pkcs11: handle database for various client references
* ta: pkcs11: register a client instance for each opened TEE session
* ta: pkcs11: session commands support

(If too many commits in the series, tell me, I can split into smaller P-Rs)

This P-R is related to https://github.com/OP-TEE/optee_client/pull/194 and https://github.com/OP-TEE/optee_test/pull/404.


Note that commit "ta: pkcs11: define TA commands related to session management" hurts checkpatch for macro `BIT()` being intentionally not used in TA API header file:
```bash
a94bf0fa ta: pkcs11: define TA commands related to session management
CHECK: Prefer using the BIT macro
#81: FILE: ta/pkcs11/include/pkcs11_ta.h:343:
+#define PKCS11_CKFSS_RW_SESSION				(1U << 1)

CHECK: Prefer using the BIT macro
#82: FILE: ta/pkcs11/include/pkcs11_ta.h:344:
+#define PKCS11_CKFSS_SERIAL_SESSION			(1U << 2)

total: 0 errors, 0 warnings, 2 checks, 86 lines checked
```