### PR TITLE
core: check writeable in tee_svc_copy_param()

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -583,6 +583,7 @@ static TEE_Result tee_svc_copy_param(struct tee_ta_session *sess,
 		memset(param, 0, sizeof(*param));
 	} else {
 		uint32_t flags = TEE_MEMORY_ACCESS_READ |
+				 TEE_MEMORY_ACCESS_WRITE |
 				 TEE_MEMORY_ACCESS_ANY_OWNER;
 
 		res = tee_mmu_check_access_rights(&utc->uctx, flags,


### PR DESCRIPTION
Check that the callee_params are writeable too in tee_svc_copy_param()
as they will be updated in tee_svc_update_out_param() in case one of the
parameters is an "out" parameter. To keep it simple always require
callee_params to be writeable.

Reported-by: Bastien Simondi <bsimondi@netflix.com>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
