### PR TITLE
rpmb: fix call to plat_rpmb_key_is_ready()

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1020,7 +1020,7 @@ static TEE_Result tee_rpmb_write_and_verify_key(uint16_t dev_id)
 {
 	TEE_Result res;
 
-	if (!plat_rpmb_key_is_ready) {
+	if (!plat_rpmb_key_is_ready()) {
 		DMSG("RPMB INIT: platform indicates RPMB key is not ready");
 		return TEE_ERROR_BAD_STATE;
 	}


### PR DESCRIPTION
In tee_rpmb_write_and_verify_key() a call was recently added to check if
the RPMB key was ready to be retrieved. But the function wasn't called
in the new if statement, instead was just the address of the function
tested to be non-NULL. So with this patch add the missing () to make it
a function call.

Fixes: b1042535dc3e ("rpmb: function to block rpmb write per platform")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
