### PR TITLE
i.MX: fix RPMB ready check function name

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -79,6 +79,7 @@ build:
     - _make PLATFORM=imx-mx6sxsabreauto
     - _make PLATFORM=imx-mx6qsabrelite
     - _make PLATFORM=imx-mx6qsabresd
+    - _make PLATFORM=imx-mx6qsabresd CFG_RPMB_FS=y
     - _make PLATFORM=imx-mx6qsabreauto
     - _make PLATFORM=imx-mx6qsabreauto CFG_NXP_CAAM=y
     - _make PLATFORM=imx-mx6qpsabreauto

--- a/core/arch/arm/plat-imx/drivers/imx_snvs.c
+++ b/core/arch/arm/plat-imx/drivers/imx_snvs.c
@@ -5,7 +5,7 @@
 #include <drivers/imx_snvs.h>
 #include <tee/tee_fs.h>
 
-bool plat_rpmb_ready(void)
+bool plat_rpmb_key_is_ready(void)
 {
 	enum snvs_ssm_mode mode = SNVS_SSM_MODE_INIT;
 	enum snvs_security_cfg security = SNVS_SECURITY_CFG_OPEN;


### PR DESCRIPTION
RPMB ready check keeps on giving. I'll keep this in mind to be more careful when making changes next time. Also add a shippable configuration to catch these kinds of errors. Thanks @ldts for the report.