### PR TITLE
crypto: add CFG_CRYPTO_RSA_NOPAD_SIGNATURE

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -3589,11 +3589,20 @@ TEE_Result syscall_asymm_operate(unsigned long state,
 
 	switch (cs->algo) {
 	case TEE_ALG_RSA_NOPAD:
-		if (cs->mode == TEE_MODE_ENCRYPT) {
+		if (!IS_ENABLED(CFG_CRYPTO_RSA_NOPAD_SIGNATURE) &&
+		    (cs->mode == TEE_MODE_VERIFY ||
+		     cs->mode == TEE_MODE_SIGN)) {
+			res = TEE_ERROR_GENERIC;
+			break;
+		}
+
+		if (cs->mode == TEE_MODE_ENCRYPT ||
+		    cs->mode == TEE_MODE_VERIFY) {
 			res = crypto_acipher_rsanopad_encrypt(o->attr, src_data,
 							      src_len, dst_data,
 							      &dlen);
-		} else if (cs->mode == TEE_MODE_DECRYPT) {
+		} else if (cs->mode == TEE_MODE_DECRYPT ||
+			   cs->mode == TEE_MODE_SIGN) {
 			res = crypto_acipher_rsanopad_decrypt(o->attr, src_data,
 							      src_len, dst_data,
 							      &dlen);

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -196,6 +196,10 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		break;
 
 	case TEE_ALG_RSA_NOPAD:
+		if (!IS_ENABLED(CFG_CRYPTO_RSA_NOPAD_SIGNATURE) &&
+		    (mode == TEE_MODE_VERIFY || mode == TEE_MODE_SIGN))
+			return TEE_ERROR_NOT_SUPPORTED;
+
 		if (mode == TEE_MODE_ENCRYPT) {
 			req_key_usage = TEE_USAGE_ENCRYPT | TEE_USAGE_VERIFY;
 		} else if (mode == TEE_MODE_DECRYPT) {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -547,3 +547,6 @@ CFG_SHOW_CONF_ON_BOOT ?= n
 # to a TA, so a TPM Service could use it to extend any measurement
 # taken before the service was up and running.
 CFG_CORE_TPM_EVENT_LOG ?= n
+
+# Enable TEE_ALG_RSA_NOPAD_SIGNATURE for sign/verify without padding
+CFG_CRYPTO_RSA_NOPAD_SIGNATURE ?= y


### PR DESCRIPTION
This extends the TEE API to support RSA with no padding in sign and
verify mode. An example where this is used is the pkcs11 TA, where
together with an openssl pkcs11 engine and TLS connection, this is
required to support client certificate authentication.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>