### PR TITLE
drivers/stm32_rng: register device as secure or non-secure

### DIFF
--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -221,10 +221,14 @@ static TEE_Result stm32_rng_init(void)
 		assert(dt_info.clock != DT_INFO_INVALID_CLOCK &&
 		       dt_info.reg != DT_INFO_INVALID_REG);
 
-		if (dt_info.status & DT_STATUS_OK_NSEC)
+		if (dt_info.status & DT_STATUS_OK_NSEC) {
+			stm32mp_register_non_secure_periph_iomem(dt_info.reg);
 			mtype = MEM_AREA_IO_NSEC;
-		else
+		} else {
+			stm32mp_register_secure_periph_iomem(dt_info.reg);
 			mtype = MEM_AREA_IO_SEC;
+		}
+
 		stm32_rng->base.pa = dt_info.reg;
 		stm32_rng->base.va = (vaddr_t)phys_to_virt(dt_info.reg, mtype);
 


### PR DESCRIPTION
FDT data defines through the status/secure-status property whether
RNG device is assigned to the secure world or to the non-secure
world. This change makes the device driver to register the
peripheral assignation at boot time.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
