### PR TITLE
libutee: Set digestLength value in TEE_OperationInfo structure

### DIFF
--- a/core/crypto/signed_hdr.c
+++ b/core/crypto/signed_hdr.c
@@ -57,8 +57,8 @@ TEE_Result shdr_verify_signature(const struct shdr *shdr)
 	if (TEE_ALG_GET_MAIN_ALG(shdr->algo) != TEE_MAIN_ALGO_RSA)
 		return TEE_ERROR_SECURITY;
 
-	res = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(shdr->algo),
-				       &hash_size);
+	res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(shdr->algo),
+				      &hash_size);
 	if (res)
 		return TEE_ERROR_SECURITY;
 	if (hash_size != shdr->hash_size)

--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
@@ -204,8 +204,8 @@ TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
 			rsa_data.rsa_id = DRVCRYPT_RSA_OAEP;
 			rsa_data.hash_algo = TEE_INTERNAL_HASH_TO_ALGO(algo);
 
-			ret = tee_hash_get_digest_size(rsa_data.hash_algo,
-						       &rsa_data.digest_size);
+			ret = tee_alg_get_digest_size(rsa_data.hash_algo,
+						      &rsa_data.digest_size);
 			if (ret != TEE_SUCCESS)
 				return ret;
 
@@ -281,8 +281,8 @@ TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
 			rsa_data.hash_algo = TEE_INTERNAL_HASH_TO_ALGO(algo);
 
 			/* Message length <= (modulus_size - 2 * hLength - 2) */
-			ret = tee_hash_get_digest_size(rsa_data.hash_algo,
-						       &rsa_data.digest_size);
+			ret = tee_alg_get_digest_size(rsa_data.hash_algo,
+						      &rsa_data.digest_size);
 			if (ret != TEE_SUCCESS)
 				return ret;
 
@@ -330,8 +330,8 @@ TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 		rsa_ssa.hash_algo = TEE_DIGEST_HASH_TO_ALGO(algo);
 
 		/* Check if the message length is digest hash size */
-		ret = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
-					       &rsa_ssa.digest_size);
+		ret = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
+					      &rsa_ssa.digest_size);
 		if (ret != TEE_SUCCESS)
 			return ret;
 
@@ -405,8 +405,8 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 		rsa_ssa.hash_algo = TEE_DIGEST_HASH_TO_ALGO(algo);
 
 		/* Check if the message length is digest hash size */
-		ret = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
-					       &rsa_ssa.digest_size);
+		ret = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
+					      &rsa_ssa.digest_size);
 		if (ret != TEE_SUCCESS)
 			return ret;
 

--- a/core/include/tee/tee_cryp_utl.h
+++ b/core/include/tee/tee_cryp_utl.h
@@ -9,11 +9,10 @@
 #include <tee_api_types.h>
 #include <crypto/crypto.h>
 
-TEE_Result tee_hash_get_digest_size(uint32_t algo, size_t *size);
+TEE_Result tee_alg_get_digest_size(uint32_t algo, size_t *size);
 TEE_Result tee_hash_createdigest(uint32_t algo, const uint8_t *data,
 				 size_t datalen, uint8_t *digest,
 				 size_t digestlen);
-TEE_Result tee_mac_get_digest_size(uint32_t algo, size_t *size);
 TEE_Result tee_cipher_get_block_size(uint32_t algo, size_t *size);
 TEE_Result tee_do_cipher_update(void *ctx, uint32_t algo,
 				TEE_OperationMode mode, bool last_block,

--- a/core/lib/libtomcrypt/dsa.c
+++ b/core/lib/libtomcrypt/dsa.c
@@ -122,8 +122,8 @@ TEE_Result crypto_acipher_dsa_sign(uint32_t algo, struct dsa_keypair *key,
 		goto err;
 	}
 
-	res = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
-				       &hash_size);
+	res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
+				      &hash_size);
 	if (res != TEE_SUCCESS)
 		goto err;
 	if (mp_unsigned_bin_size(ltc_key.q) < hash_size)

--- a/core/lib/libtomcrypt/rsa.c
+++ b/core/lib/libtomcrypt/rsa.c
@@ -481,8 +481,8 @@ TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 			goto err;
 		}
 
-		res = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
-					       &hash_size);
+		res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
+					      &hash_size);
 		if (res != TEE_SUCCESS)
 			goto err;
 
@@ -535,8 +535,8 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 	};
 
 	if (algo != TEE_ALG_RSASSA_PKCS1_V1_5) {
-		res = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
-					       &hash_size);
+		res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
+					      &hash_size);
 		if (res != TEE_SUCCESS)
 			goto err;
 

--- a/core/tee/tee_cryp_concat_kdf.c
+++ b/core/tee/tee_cryp_concat_kdf.c
@@ -28,7 +28,7 @@ TEE_Result tee_cryp_concat_kdf(uint32_t hash_id, const uint8_t *shared_secret,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	res = tee_hash_get_digest_size(hash_algo, &hash_len);
+	res = tee_alg_get_digest_size(hash_algo, &hash_len);
 	if (res != TEE_SUCCESS)
 		goto out;
 

--- a/core/tee/tee_cryp_hkdf.c
+++ b/core/tee/tee_cryp_hkdf.c
@@ -29,7 +29,7 @@ static TEE_Result hkdf_extract(uint32_t hash_id, const uint8_t *ikm,
 		 * zeros
 		 */
 		salt = zero_salt;
-		res = tee_hash_get_digest_size(hash_algo, &salt_len);
+		res = tee_alg_get_digest_size(hash_algo, &salt_len);
 		if (res != TEE_SUCCESS)
 			goto out;
 	}
@@ -56,7 +56,7 @@ static TEE_Result hkdf_extract(uint32_t hash_id, const uint8_t *ikm,
 	if (res != TEE_SUCCESS)
 		goto out;
 
-	res = tee_hash_get_digest_size(hash_algo, prk_len);
+	res = tee_alg_get_digest_size(hash_algo, prk_len);
 out:
 	crypto_mac_free_ctx(ctx);
 	return res;
@@ -73,7 +73,7 @@ static TEE_Result hkdf_expand(uint32_t hash_id, const uint8_t *prk,
 	uint32_t hash_algo = TEE_ALG_HASH_ALGO(hash_id);
 	uint32_t hmac_algo = TEE_ALG_HMAC_ALGO(hash_id);
 
-	res = tee_hash_get_digest_size(hash_algo, &hash_len);
+	res = tee_alg_get_digest_size(hash_algo, &hash_len);
 	if (res != TEE_SUCCESS)
 		goto out;
 

--- a/core/tee/tee_cryp_pbkdf2.c
+++ b/core/tee/tee_cryp_pbkdf2.c
@@ -81,7 +81,7 @@ TEE_Result tee_cryp_pbkdf2(uint32_t hash_id, const uint8_t *password,
 
 	hmac_parms.algo = TEE_ALG_HMAC_ALGO(hash_id);
 
-	res = tee_mac_get_digest_size(hmac_parms.algo, &hmac_parms.hash_len);
+	res = tee_alg_get_digest_size(hmac_parms.algo, &hmac_parms.hash_len);
 	if (res != TEE_SUCCESS)
 		return res;
 

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -15,43 +15,14 @@
 #include <trace.h>
 #include <utee_defines.h>
 
-TEE_Result tee_hash_get_digest_size(uint32_t algo, size_t *size)
+TEE_Result tee_alg_get_digest_size(uint32_t algo, size_t *size)
 {
-	switch (algo) {
-	case TEE_ALG_MD5:
-	case TEE_ALG_HMAC_MD5:
-		*size = TEE_MD5_HASH_SIZE;
-		break;
-	case TEE_ALG_SHA1:
-	case TEE_ALG_HMAC_SHA1:
-	case TEE_ALG_DSA_SHA1:
-		*size = TEE_SHA1_HASH_SIZE;
-		break;
-	case TEE_ALG_SHA224:
-	case TEE_ALG_HMAC_SHA224:
-	case TEE_ALG_DSA_SHA224:
-		*size = TEE_SHA224_HASH_SIZE;
-		break;
-	case TEE_ALG_SHA256:
-	case TEE_ALG_HMAC_SHA256:
-	case TEE_ALG_DSA_SHA256:
-		*size = TEE_SHA256_HASH_SIZE;
-		break;
-	case TEE_ALG_SHA384:
-	case TEE_ALG_HMAC_SHA384:
-		*size = TEE_SHA384_HASH_SIZE;
-		break;
-	case TEE_ALG_SHA512:
-	case TEE_ALG_HMAC_SHA512:
-		*size = TEE_SHA512_HASH_SIZE;
-		break;
-	case TEE_ALG_SM3:
-	case TEE_ALG_HMAC_SM3:
-		*size = TEE_SM3_HASH_SIZE;
-		break;
-	default:
+	size_t digest_size = TEE_ALG_GET_DIGEST_SIZE(algo);
+
+	if (!digest_size)
 		return TEE_ERROR_NOT_SUPPORTED;
-	}
+
+	*size = digest_size;
 
 	return TEE_SUCCESS;
 }
@@ -82,33 +53,6 @@ out:
 	crypto_hash_free_ctx(ctx);
 
 	return res;
-}
-
-TEE_Result tee_mac_get_digest_size(uint32_t algo, size_t *size)
-{
-	switch (algo) {
-	case TEE_ALG_HMAC_MD5:
-	case TEE_ALG_HMAC_SHA224:
-	case TEE_ALG_HMAC_SHA1:
-	case TEE_ALG_HMAC_SHA256:
-	case TEE_ALG_HMAC_SHA384:
-	case TEE_ALG_HMAC_SHA512:
-	case TEE_ALG_HMAC_SM3:
-		return tee_hash_get_digest_size(algo, size);
-	case TEE_ALG_AES_CBC_MAC_NOPAD:
-	case TEE_ALG_AES_CBC_MAC_PKCS5:
-	case TEE_ALG_AES_CMAC:
-		*size = TEE_AES_BLOCK_SIZE;
-		return TEE_SUCCESS;
-	case TEE_ALG_DES_CBC_MAC_NOPAD:
-	case TEE_ALG_DES_CBC_MAC_PKCS5:
-	case TEE_ALG_DES3_CBC_MAC_NOPAD:
-	case TEE_ALG_DES3_CBC_MAC_PKCS5:
-		*size = TEE_DES_BLOCK_SIZE;
-		return TEE_SUCCESS;
-	default:
-		return TEE_ERROR_NOT_SUPPORTED;
-	}
 }
 
 TEE_Result tee_cipher_get_block_size(uint32_t algo, size_t *size)

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2442,7 +2442,7 @@ TEE_Result syscall_hash_final(unsigned long state, const void *chunk,
 
 	switch (TEE_ALG_GET_CLASS(cs->algo)) {
 	case TEE_OPERATION_DIGEST:
-		res = tee_hash_get_digest_size(cs->algo, &hash_size);
+		res = tee_alg_get_digest_size(cs->algo, &hash_size);
 		if (res != TEE_SUCCESS)
 			return res;
 		if (hlen < hash_size) {
@@ -2462,7 +2462,7 @@ TEE_Result syscall_hash_final(unsigned long state, const void *chunk,
 		break;
 
 	case TEE_OPERATION_MAC:
-		res = tee_mac_get_digest_size(cs->algo, &hash_size);
+		res = tee_alg_get_digest_size(cs->algo, &hash_size);
 		if (res != TEE_SUCCESS)
 			return res;
 		if (hlen < hash_size) {
@@ -3774,7 +3774,7 @@ TEE_Result syscall_asymm_verify(unsigned long state,
 	case TEE_MAIN_ALGO_RSA:
 		if (cs->algo != TEE_ALG_RSASSA_PKCS1_V1_5) {
 			hash_algo = TEE_DIGEST_HASH_TO_ALGO(cs->algo);
-			res = tee_hash_get_digest_size(hash_algo, &hash_size);
+			res = tee_alg_get_digest_size(hash_algo, &hash_size);
 			if (res != TEE_SUCCESS)
 				break;
 			if (data_len != hash_size) {
@@ -3791,7 +3791,7 @@ TEE_Result syscall_asymm_verify(unsigned long state,
 
 	case TEE_MAIN_ALGO_DSA:
 		hash_algo = TEE_DIGEST_HASH_TO_ALGO(cs->algo);
-		res = tee_hash_get_digest_size(hash_algo, &hash_size);
+		res = tee_alg_get_digest_size(hash_algo, &hash_size);
 		if (res != TEE_SUCCESS)
 			break;
 		/*

--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -535,8 +535,8 @@ TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 		goto err;
 	}
 
-	res = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
-				       &hash_size);
+	res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
+				      &hash_size);
 	if (res != TEE_SUCCESS)
 		goto err;
 
@@ -606,8 +606,8 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 	rsa.E = *(mbedtls_mpi *)key->e;
 	rsa.N = *(mbedtls_mpi *)key->n;
 
-	res = tee_hash_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
-				       &hash_size);
+	res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
+				      &hash_size);
 	if (res != TEE_SUCCESS)
 		goto err;
 

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -168,6 +168,50 @@ typedef enum {
 #define TEE_MAC_SIZE_AES_CMAC
 #define TEE_MAC_SIZE_DES_CBC_MAC_PKCS5
 
+static inline size_t __tee_alg_get_digest_size(uint32_t algo)
+{
+	switch (algo) {
+	case TEE_ALG_MD5:
+	case TEE_ALG_HMAC_MD5:
+		return TEE_MD5_HASH_SIZE;
+	case TEE_ALG_SHA1:
+	case TEE_ALG_HMAC_SHA1:
+	case TEE_ALG_DSA_SHA1:
+		return TEE_SHA1_HASH_SIZE;
+	case TEE_ALG_SHA224:
+	case TEE_ALG_HMAC_SHA224:
+	case TEE_ALG_DSA_SHA224:
+		return TEE_SHA224_HASH_SIZE;
+	case TEE_ALG_SHA256:
+	case TEE_ALG_HMAC_SHA256:
+	case TEE_ALG_DSA_SHA256:
+		return TEE_SHA256_HASH_SIZE;
+	case TEE_ALG_SHA384:
+	case TEE_ALG_HMAC_SHA384:
+		return TEE_SHA384_HASH_SIZE;
+	case TEE_ALG_SHA512:
+	case TEE_ALG_HMAC_SHA512:
+		return TEE_SHA512_HASH_SIZE;
+	case TEE_ALG_SM3:
+	case TEE_ALG_HMAC_SM3:
+		return TEE_SM3_HASH_SIZE;
+	case TEE_ALG_AES_CBC_MAC_NOPAD:
+	case TEE_ALG_AES_CBC_MAC_PKCS5:
+	case TEE_ALG_AES_CMAC:
+		return TEE_AES_BLOCK_SIZE;
+	case TEE_ALG_DES_CBC_MAC_NOPAD:
+	case TEE_ALG_DES_CBC_MAC_PKCS5:
+	case TEE_ALG_DES3_CBC_MAC_NOPAD:
+	case TEE_ALG_DES3_CBC_MAC_PKCS5:
+		return TEE_DES_BLOCK_SIZE;
+	default:
+		return 0;
+	}
+}
+
+	/* Return algorithm digest size */
+#define TEE_ALG_GET_DIGEST_SIZE(algo) __tee_alg_get_digest_size(algo)
+
 /*
  * Bit indicating that the attribute is a value attribute
  * See TEE Internal API specificaion v1.0 table 6-12 "Partial Structure of

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -279,6 +279,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		op->info.operationClass = TEE_OPERATION_ASYMMETRIC_SIGNATURE;
 #endif
 	op->info.mode = mode;
+	op->info.digestLength = TEE_ALG_GET_DIGEST_SIZE(algorithm);
 	op->info.maxKeySize = maxKeySize;
 	op->info.requiredKeyUsage = req_key_usage;
 	op->info.handleState = handle_state;
@@ -1328,6 +1329,7 @@ TEE_Result TEE_AEInit(TEE_OperationHandle operation, const void *nonce,
 		goto out;
 
 	operation->ae_tag_len = tagLen / 8;
+	operation->info.digestLength = operation->ae_tag_len;
 	operation->info.handleState |= TEE_HANDLE_FLAG_INITIALIZED;
 
 out:


### PR DESCRIPTION
Set digestLength as specified in the TEE Internal Core API, section 6.2.3. Previously, this value was always 0. Fixes #3471. 

Not sure this is the best approach to reuse `tee_hash_get_digest_size`, but those are at this moment core functions that I could not access from libutee. Perhaps moving `tee_hash_get_digest_size` etc. to a new file like core/tee/tee_cryp_utl_size.c and including that file in the build of utee would make  sense.  But I experienced build problems that way, in particular when building 32bit and 64bit together. Maybe I am just not familiar enough with the build system to make it work properly. Either way, having those functions in utee doesn't seem particularly wrong on the other hand, since they don't depend really on core functionality. I think the approach taken here should be among those with the least changes.  




