### PR TITLE
drivers: caam: fix GCC9 warnings with CAAM structure alignment

### DIFF
--- a/core/drivers/crypto/caam/caam_jr.c
+++ b/core/drivers/crypto/caam/caam_jr.c
@@ -36,7 +36,7 @@ struct inring_entry {
 struct __packed outring_entry {
 	uint64_t desc;   /* Physical address of the descriptor */
 	uint32_t status; /* Status of the executed job */
-};
+} __aligned(__alignof__(void *));
 #else
 struct inring_entry {
 	uint32_t desc;   /* Physical address of the descriptor */
@@ -45,7 +45,7 @@ struct inring_entry {
 struct __packed outring_entry {
 	uint32_t desc;   /* Physical address of the descriptor */
 	uint32_t status; /* Status of the executed job */
-};
+} __aligned(__alignof__(void *));
 #endif /* CFG_CAAM_64BIT */
 
 /*


### PR DESCRIPTION
Hello all,

A small patch to fix two warnings we got in the CAAM driver with GCC9 and its new rule Waddress-of-packed-member.

Thanks!