### PR TITLE
Remove '.section .text.<name>' and use function macros instead

### DIFF
--- a/core/arch/arm/crypto/ghash-ce-core_a32.S
+++ b/core/arch/arm/crypto/ghash-ce-core_a32.S
@@ -6,15 +6,7 @@
  */
 
 #include <arm32_macros.S>
-
-#define ENTRY(func) \
-	.global func ; \
-	.type func , %function ; \
-	.balign 4 ; \
-	func :
-
-#define ENDPROC(func) \
-	.size func , .-func
+#include <asm.S>
 
 #define CPU_LE(x...)	x
 
@@ -218,8 +210,7 @@
 	 * void pmull_ghash_update(int blocks, u64 dg[], const char *src,
 	 *			   struct ghash_key const *k, const char *head)
 	 */
-	.section .text.pmull_ghash_update_p64
-ENTRY(pmull_ghash_update_p64)
+FUNC pmull_ghash_update_p64 , :
 	vld1.64		{SHASH}, [r3]
 	veor		SHASH2_p64, SHASH_L, SHASH_H
 
@@ -227,10 +218,9 @@ ENTRY(pmull_ghash_update_p64)
 	vshl.u64	MASK, MASK, #57
 
 	ghash_update	p64
-ENDPROC(pmull_ghash_update_p64)
+END_FUNC pmull_ghash_update_p64
 
-	.section .text.pmull_ghash_update_p8
-ENTRY(pmull_ghash_update_p8)
+FUNC pmull_ghash_update_p8 , :
 	vld1.64		{SHASH}, [r3]
 	veor		SHASH2_p8, SHASH_L, SHASH_H
 
@@ -248,4 +238,4 @@ ENTRY(pmull_ghash_update_p8)
 	vmov.i64	k48, #0xffffffffffff
 
 	ghash_update	p8
-ENDPROC(pmull_ghash_update_p8)
+END_FUNC pmull_ghash_update_p8

--- a/core/arch/arm/crypto/ghash-ce-core_a64.S
+++ b/core/arch/arm/crypto/ghash-ce-core_a64.S
@@ -6,15 +6,7 @@
  */
 
 #include <arm64_macros.S>
-
-#define ENTRY(func) \
-	.global func ; \
-	.type func , %function ; \
-	.balign 4 ; \
-	func :
-
-#define ENDPROC(func) \
-	.size func , .-func
+#include <asm.S>
 
 #define CPU_LE(x...)	x
 
@@ -267,15 +259,13 @@ CPU_LE(	rev64		T1.16b, T1.16b	)
 	 * void pmull_ghash_update(int blocks, u64 dg[], const char *src,
 	 *			   struct ghash_key const *k, const char *head)
 	 */
-	.section .text.pmull_ghash_update_p64
-ENTRY(pmull_ghash_update_p64)
+FUNC pmull_ghash_update_p64 , :
 	__pmull_ghash	p64
-ENDPROC(pmull_ghash_update_p64)
+END_FUNC pmull_ghash_update_p64
 
-	.section .text.pmull_ghash_update_p8
-ENTRY(pmull_ghash_update_p8)
+FUNC pmull_ghash_update_p8 , :
 	__pmull_ghash	p8
-ENDPROC(pmull_ghash_update_p8)
+END_FUNC pmull_ghash_update_p8
 
 	KS		.req	v8
 	CTR		.req	v9
@@ -431,39 +421,36 @@ CPU_LE(	rev64		CTR.16b, CTR.16b)
 	 *			  const u8 src[], struct ghash_key const *k,
 	 *			  u64 ctr[2], int rounds, u8 ks[])
 	 */
-	.section .text.pmull_gcm_encrypt
-ENTRY(pmull_gcm_encrypt)
+FUNC pmull_gcm_encrypt , :
 	pmull_gcm_do_crypt	1
-ENDPROC(pmull_gcm_encrypt)
+END_FUNC pmull_gcm_encrypt
 
 	/*
 	 * void pmull_gcm_decrypt(int blocks, u64 dg[], u8 dst[],
 	 *			  const u8 src[], struct ghash_key const *k,
 	 *			  u64 ctr[2], int rounds)
 	 */
-	.section .text.pmull_gcm_decrypt
-ENTRY(pmull_gcm_decrypt)
+FUNC pmull_gcm_decrypt , :
 	pmull_gcm_do_crypt	0
-ENDPROC(pmull_gcm_decrypt)
+END_FUNC pmull_gcm_decrypt
 
 	/*
 	 * void pmull_gcm_encrypt_block(u8 dst[], u8 src[], int rounds)
 	 */
-	.section .text.pmull_gcm_encrypt_block
-ENTRY(pmull_gcm_encrypt_block)
+FUNC pmull_gcm_encrypt_block , :
 	ld1		{v0.16b}, [x1]
 	enc_block	v0, w2
 	st1		{v0.16b}, [x0]
 	ret
-ENDPROC(pmull_gcm_encrypt_block)
+END_FUNC pmull_gcm_encrypt_block
 
 	/*
 	 * pmull_gcm_load_round_keys(uint64_t rk[2], int rounds)
 	 */
-ENTRY(pmull_gcm_load_round_keys)
+FUNC pmull_gcm_load_round_keys , :
 	load_round_keys	w1, x0
 	ret
-ENDPROC(pmull_gcm_load_round_keys)
+END_FUNC pmull_gcm_load_round_keys
 
 	/*
 	 * uint32_t pmull_gcm_aes_sub(uint32_t input)
@@ -471,10 +458,10 @@ ENDPROC(pmull_gcm_load_round_keys)
 	 * use the aese instruction to perform the AES sbox substitution
 	 * on each byte in 'input'
 	 */
-ENTRY(pmull_gcm_aes_sub)
+FUNC pmull_gcm_aes_sub , :
 	dup	v1.4s, w0
 	movi	v0.16b, #0
 	aese	v0.16b, v1.16b
 	umov	w0, v0.s[0]
 	ret
-ENDPROC(pmull_gcm_aes_sub)
+END_FUNC pmull_gcm_aes_sub

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -523,7 +523,6 @@ END_FUNC thread_unwind_user_mode
 	b	thread_foreign_intr_exit
 .endm
 
-	.section .text.thread_excp_vect
         .align	5
 FUNC thread_excp_vect , :
 UNWIND(	.fnstart)

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -208,7 +208,6 @@ END_FUNC thread_unwind_user_mode
 	.endm
 
 #define INV_INSN	0
-	.section .text.thread_excp_vect
 	.align	11, INV_INSN
 FUNC thread_excp_vect , :
 	/* -----------------------------------------------------

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -254,7 +254,6 @@ UNWIND(	.cantunwind)
 UNWIND(	.fnend)
 END_FUNC sm_fiq_entry
 
-	.section .text.sm_vect_table
         .align	5
 LOCAL_FUNC sm_vect_table , :
 UNWIND(	.fnstart)

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
@@ -19,7 +19,6 @@
  * signed ret_idivmod_values(signed quot, signed rem);
  * return quotient and remaining the EABI way (regs r0,r1)
  */
-.section .text.ret_idivmod_values
 FUNC ret_idivmod_values , :
 LOCAL_UNWIND(.fnstart)
         bx lr
@@ -30,7 +29,6 @@ END_FUNC ret_idivmod_values
  * unsigned ret_uidivmod_values(unsigned quot, unsigned rem);
  * return quotient and remaining the EABI way (regs r0,r1)
  */
-.section .text.ret_uidivmod_values
 FUNC ret_uidivmod_values , :
 LOCAL_UNWIND(.fnstart)
         bx      lr

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
@@ -18,7 +18,6 @@
 /*
  * __value_in_regs lldiv_t __aeabi_ldivmod( long long n, long long d)
  */
-.section .text.__aeabi_ldivmod
 FUNC __aeabi_ldivmod , :
 LOCAL_UNWIND(.fnstart)
 	push	{ip, lr}
@@ -36,7 +35,6 @@ END_FUNC __aeabi_ldivmod
  * __value_in_regs ulldiv_t __aeabi_uldivmod(
  *		unsigned long long n, unsigned long long d)
  */
-.section .text.__aeabi_uldivmod
 FUNC __aeabi_uldivmod , :
 LOCAL_UNWIND(.fnstart)
 	push	{ip, lr}


### PR DESCRIPTION
Assembler functions are normally defined using the FUNC/LOCAL_FUNC
macros from <asm.S>. The macros takes care of several things, including
putting the function in a specific section for later garbage collection
by the linker (--gc-sections).

A few files do not follow this convention, let's fix them. Two
functions in ghash-ce-core_a64.S (pmull_gcm_load_round_keys() and
pmull_gcm_aes_sub()) totally lack a .section directive, which I think
is a mistake. Fix them at the same time.

No functional change is expected.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
