### PR TITLE
plat-stm32mp1: allow fdt to disable root clocks

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1127,9 +1127,14 @@ static const char *stm32mp_osc_node_label[NB_OSC] = {
 
 static unsigned int clk_freq_prop(void *fdt, int node)
 {
+	const fdt32_t *cuint = NULL;
 	int ret = 0;
-	const fdt32_t *cuint = fdt_getprop(fdt, node, "clock-frequency", &ret);
 
+	/* Disabled clocks report null rate */
+	if (_fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
+		return 0;
+
+	cuint = fdt_getprop(fdt, node, "clock-frequency", &ret);
 	if (!cuint)
 		panic();
 


### PR DESCRIPTION
Assign a null frequency value to root clocks when FDT defines them
as disabled.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
