### PR TITLE
plat-stm32mp1: clock: handle always-on clocks

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -879,10 +879,44 @@ static bool __clk_is_enabled(struct stm32mp1_clk_gate const *gate)
 	return io_read32(base + gate->offset) & BIT(gate->bit);
 }
 
+static bool clock_is_always_on(unsigned long id)
+{
+	COMPILE_TIME_ASSERT(CK_HSE == 0 &&
+			    (CK_HSE + 1) == CK_CSI &&
+			    (CK_HSE + 2) == CK_LSI &&
+			    (CK_HSE + 3) == CK_LSE &&
+			    (CK_HSE + 4) == CK_HSI &&
+			    (CK_HSE + 5) == CK_HSE_DIV2 &&
+			    (PLL1_P + 1) == PLL1_Q &&
+			    (PLL1_P + 2) == PLL1_R &&
+			    (PLL1_P + 3) == PLL2_P &&
+			    (PLL1_P + 4) == PLL2_Q &&
+			    (PLL1_P + 5) == PLL2_R &&
+			    (PLL1_P + 6) == PLL3_P &&
+			    (PLL1_P + 7) == PLL3_Q &&
+			    (PLL1_P + 8) == PLL3_R);
+
+	if (id <= CK_HSE_DIV2 || (id >= PLL1_P && id <= PLL3_R))
+		return true;
+
+	switch (id) {
+	case CK_AXI:
+	case CK_MPU:
+	case CK_MCU:
+		return true;
+	default:
+		return false;
+	}
+}
+
 bool stm32_clock_is_enabled(unsigned long id)
 {
-	int i = stm32mp1_clk_get_gated_id(id);
+	int i = 0;
 
+	if (clock_is_always_on(id))
+		return true;
+
+	i = stm32mp1_clk_get_gated_id(id);
 	if (i < 0)
 		return false;
 
@@ -891,9 +925,13 @@ bool stm32_clock_is_enabled(unsigned long id)
 
 void stm32_clock_enable(unsigned long id)
 {
-	int i = stm32mp1_clk_get_gated_id(id);
+	int i = 0;
 	uint32_t exceptions = 0;
 
+	if (clock_is_always_on(id))
+		return;
+
+	i = stm32mp1_clk_get_gated_id(id);
 	if (i < 0) {
 		DMSG("Invalid clock %lu: %d", id, i);
 		panic();
@@ -911,9 +949,13 @@ void stm32_clock_enable(unsigned long id)
 
 void stm32_clock_disable(unsigned long id)
 {
-	int i = stm32mp1_clk_get_gated_id(id);
+	int i = 0;
 	uint32_t exceptions = 0;
 
+	if (clock_is_always_on(id))
+		return;
+
+	i = stm32mp1_clk_get_gated_id(id);
 	if (i < 0) {
 		DMSG("Invalid clock %lu: %d", id, i);
 		panic();


### PR DESCRIPTION
Oscillators, PLLs and AXI/MPU/MCU clocks are not gated from
functions stm32_clock_enable() and stm32_clock_disable(). This change
allows these functions and stm32_clock_is_enabled() to blindly handle
clock gating for such always-on clocks. Gating these clocks is out of
the scope of this change even if preferred for power consumption
optimization considerations.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
