### PR TITLE
plat-stm32mp1: clock: allow tree lookup for several system clocks

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -96,6 +96,56 @@ enum stm32mp1_parent_sel {
 	_UNKNOWN_SEL = 0xff,
 };
 
+static const uint8_t parent_id_clock_id[_PARENT_NB] = {
+	[_HSE] = CK_HSE,
+	[_HSI] = CK_HSI,
+	[_CSI] = CK_CSI,
+	[_LSE] = CK_LSE,
+	[_LSI] = CK_LSI,
+	[_I2S_CKIN] = _UNKNOWN_ID,
+	[_USB_PHY_48] = _UNKNOWN_ID,
+	[_HSI_KER] = CK_HSI,
+	[_HSE_KER] = CK_HSE,
+	[_HSE_KER_DIV2] = CK_HSE_DIV2,
+	[_CSI_KER] = CK_CSI,
+	[_PLL1_P] = PLL1_P,
+	[_PLL1_Q] = PLL1_Q,
+	[_PLL1_R] = PLL1_R,
+	[_PLL2_P] = PLL2_P,
+	[_PLL2_Q] = PLL2_Q,
+	[_PLL2_R] = PLL2_R,
+	[_PLL3_P] = PLL3_P,
+	[_PLL3_Q] = PLL3_Q,
+	[_PLL3_R] = PLL3_R,
+	[_PLL4_P] = PLL4_P,
+	[_PLL4_Q] = PLL4_Q,
+	[_PLL4_R] = PLL4_R,
+	[_ACLK] = CK_AXI,
+	[_PCLK1] = CK_AXI,
+	[_PCLK2] = CK_AXI,
+	[_PCLK3] = CK_AXI,
+	[_PCLK4] = CK_AXI,
+	[_PCLK5] = CK_AXI,
+	[_HCLK6] = CK_AXI,
+	[_HCLK2] = CK_AXI,
+	[_CK_PER] = CK_PER,
+	[_CK_MPU] = CK_MPU,
+	[_CK_MCU] = CK_MCU,
+};
+
+static enum stm32mp1_parent_id clock_id2parent_id(unsigned long id)
+{
+	size_t n = 0;
+
+	COMPILE_TIME_ASSERT(STM32MP1_LAST_CLK < _UNKNOWN_ID);
+
+	for (n = 0; n < ARRAY_SIZE(parent_id_clock_id); n++)
+		if (parent_id_clock_id[n] == id)
+			return (enum stm32mp1_parent_id)n;
+
+	return _UNKNOWN_ID;
+}
+
 /* Identifiers for PLLs and their configuration resources */
 enum stm32mp1_pll_id {
 	_PLL1,
@@ -253,19 +303,6 @@ struct stm32mp1_clk_pll {
 		.refclk[2] = (_p3),				\
 		.refclk[3] = (_p4),				\
 	}
-
-static const uint8_t stm32mp1_clks[][2] = {
-	{ CK_PER, _CK_PER },
-	{ CK_MPU, _CK_MPU },
-	{ CK_AXI, _ACLK },
-	{ CK_MCU, _CK_MCU },
-	{ CK_HSE, _HSE },
-	{ CK_CSI, _CSI },
-	{ CK_LSI, _LSI },
-	{ CK_LSE, _LSE },
-	{ CK_HSI, _HSI },
-	{ CK_HSE_DIV2, _HSE_KER_DIV2 },
-};
 
 #define NB_GATES	ARRAY_SIZE(stm32mp1_clk_gate)
 
@@ -538,16 +575,16 @@ static enum stm32mp1_parent_id stm32mp1_clk_get_fixed_parent(int i)
 static int stm32mp1_clk_get_parent(unsigned long id)
 {
 	const struct stm32mp1_clk_sel *sel = NULL;
-	unsigned int j = 0;
+	enum stm32mp1_parent_id parent_id = 0;
 	uint32_t p_sel = 0;
 	int i = 0;
 	enum stm32mp1_parent_id p = _UNKNOWN_ID;
 	enum stm32mp1_parent_sel s = _UNKNOWN_SEL;
 	vaddr_t rcc_base = stm32_rcc_base();
 
-	for (j = 0U; j < ARRAY_SIZE(stm32mp1_clks); j++)
-		if (stm32mp1_clks[j][0] == id)
-			return (int)stm32mp1_clks[j][1];
+	parent_id = clock_id2parent_id(id);
+	if (parent_id != _UNKNOWN_ID)
+		return (int)parent_id;
 
 	i = stm32mp1_clk_get_gated_id(id);
 	if (i < 0)


### PR DESCRIPTION
Oscillators, PLLs and some system clocks can be related straight to
a parent clock identifier. Prior this change were only oscillators
and few clocks supported by this look up scheme. This changes makes all
parent IDs covered supported. This enables for flexible use of clock
tree exploration when computing a clock frequency value.

Introduces helper function clock_id2parent_id() for clock ID
to parent ID conversion and defines helper right above parent clock
resources for consistency.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
