### PR TITLE
[Don't merge] imx: Enable prediction resistance for CAAM RNG

### DIFF
--- a/core/drivers/crypto/caam/include/caam_desc_defines.h
+++ b/core/drivers/crypto/caam/include/caam_desc_defines.h
@@ -404,6 +404,8 @@
  */
 /* Secure Key */
 #define ALGO_RNG_SK		BIT32(12)
+/* Prediction Resistance */
+#define ALGO_RNG_PR		BIT32(1)
 
 /* State Handle */
 #define ALGO_RNG_SH(sh)		SHIFT_U32((sh) & 0x3, 4)

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -225,7 +225,7 @@ static inline void dump_desc(uint32_t *desc)
  */
 #define RNG_SH_INST(sh)                                                        \
 	(CMD_OP_TYPE | OP_TYPE(CLASS1) | OP_ALGO(RNG) | ALGO_RNG_SH(sh) |      \
-	 ALGO_AS(RNG_INSTANTIATE))
+	 ALGO_AS(RNG_INSTANTIATE) | ALGO_RNG_PR)
 
 /*
  * RNG Generates Secure Keys
@@ -238,7 +238,8 @@ static inline void dump_desc(uint32_t *desc)
  * RNG Generates Data
  */
 #define RNG_GEN_DATA                                                           \
-	(CMD_OP_TYPE | OP_TYPE(CLASS1) | OP_ALGO(RNG) | ALGO_AS(RNG_GENERATE))
+	(CMD_OP_TYPE | OP_TYPE(CLASS1) | OP_ALGO(RNG) | ALGO_AS(RNG_GENERATE) |\
+	 ALGO_RNG_PR)
 
 /*
  * Hash Init Operation of algorithm algo


### PR DESCRIPTION
The [upstream kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/crypto/caam?id=358ba762d9f1d4ba99ab31ef12bc28014b22f4c9) merged a patch series to enable prediction resistance for all RNG state handles. Enable prediction resistance for the OP-TEE CAAM RNG handling as well.