### PR TITLE
[fix] core: TEE capability for null sized memrefs support

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -514,9 +514,19 @@ static TEE_Result utee_param_to_param(struct user_ta_ctx *utc,
 			flags |= TEE_MEMORY_ACCESS_WRITE;
 			/*FALLTHROUGH*/
 		case TEE_PARAM_TYPE_MEMREF_INPUT:
-			p->u[n].mem.mobj = &mobj_virt;
 			p->u[n].mem.offs = a;
 			p->u[n].mem.size = b;
+
+			if (!p->u[n].mem.offs) {
+				/* Allow NULL memrefs if of size 0 */
+				if (p->u[n].mem.size)
+					return TEE_ERROR_BAD_PARAMETERS;
+				p->u[n].mem.mobj = NULL;
+				break;
+			}
+
+			p->u[n].mem.mobj = &mobj_virt;
+
 			if (tee_mmu_check_access_rights(&utc->uctx, flags, a,
 							b))
 				return TEE_ERROR_ACCESS_DENIED;


### PR DESCRIPTION
Ensure that TA param mobj is set to NULL, in case User Parameter of
type IN/OUT memref is NULL with a size=0 is handled.

Signed-off-by: Cedric Neveux <cedric.neveux@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
