### PR TITLE
ta: pkcs11: fix MECHANISM_IDS to return OK when no output buffer

### DIFF
--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -349,7 +349,10 @@ uint32_t entry_ck_token_mecha_ids(uint32_t ptypes, TEE_Param *params)
 	if (out->memref.size < count * sizeof(*array)) {
 		assert(!array);
 		out->memref.size = count * sizeof(*array);
-		return PKCS11_CKR_BUFFER_TOO_SMALL;
+		if (out->memref.buffer)
+			return PKCS11_CKR_BUFFER_TOO_SMALL;
+		else
+			return PKCS11_CKR_OK;
 	}
 
 	if (!array)


### PR DESCRIPTION
Fix PKCS11 TA command PKCS11_CMD_MECHANISM_IDS to handle case
where client provides a NULL buffer reference when querying the
list of supported mechanism IDs. In such case TA should return OK,
not PKCS11_CKR_BUFFER_TOO_SMALL.

This change is needed since commit [1] that makes an OP-TEE TA able
to receive memref parameters with a NULL buffer reference.

Link: [1] 20b567068a37 ("libutee: flag NULL pointer using invalid shm id")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
