### PR TITLE
ta: sks: drop derive from AES_ECB

### DIFF
--- a/ta/pkcs11/src/token_capabilities.c
+++ b/ta/pkcs11/src/token_capabilities.c
@@ -61,7 +61,6 @@ struct pkcs11_mechachism_modes {
 static const struct pkcs11_mechachism_modes pkcs11_modes[] = {
 	MECHANISM(PKCS11_CKM_AES_ECB,
 		  PKCS11_CKFM_ENCRYPT | PKCS11_CKFM_DECRYPT |
-		  PKCS11_CKFM_DERIVE |
 		  PKCS11_CKFM_WRAP | PKCS11_CKFM_UNWRAP,
 		  ANY_PART),
 };


### PR DESCRIPTION
Drop key derivation as a capability of mechanisms AES_ECB as not part
of the PKCS#11 specification.

Reported-by: Ricardo Salveti <ricardo@foundries.io>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
