### PR TITLE
pta: invoke_test.pta: add test on null memref parameter

### DIFF
--- a/core/pta/tests/invoke.c
+++ b/core/pta/tests/invoke.c
@@ -71,6 +71,26 @@ static int test_v2p2v(void *va)
 }
 
 /*
+ * Check PTA can be invoked with a memory reference on a NULL buffer
+ */
+static TEE_Result test_entry_memref_null(uint32_t type,
+					 TEE_Param p[TEE_NUM_PARAMS])
+{
+	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
+					  TEE_PARAM_TYPE_NONE,
+					  TEE_PARAM_TYPE_NONE,
+					  TEE_PARAM_TYPE_NONE);
+
+	if (exp_pt != type)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (p[0].memref.buffer || p[0].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return TEE_SUCCESS;
+}
+
+/*
  * Supported tests on parameters
  * (I, J, K, L refer to param index)
  *
@@ -394,6 +414,8 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 		return test_trace(nParamTypes, pParams);
 	case PTA_INVOKE_TESTS_CMD_PARAMS:
 		return test_entry_params(nParamTypes, pParams);
+	case PTA_INVOKE_TESTS_CMD_MEMREF_NULL:
+		return test_entry_memref_null(nParamTypes, pParams);
 	case PTA_INVOKE_TESTS_CMD_COPY_NSEC_TO_SEC:
 		return test_inject_sdp(nParamTypes, pParams);
 	case PTA_INVOKE_TESTS_CMD_READ_MODIFY_SEC:

--- a/lib/libutee/include/pta_invoke_tests.h
+++ b/lib/libutee/include/pta_invoke_tests.h
@@ -96,5 +96,12 @@
  */
 #define PTA_INVOKE_TEST_CMD_AES_PERF		9
 
+/*
+ * NULL memory reference parameter
+ *
+ * [in/out] memref[0]	NULL memory reference of size zero
+ */
+#define PTA_INVOKE_TESTS_CMD_MEMREF_NULL	10
+
 #endif /*__PTA_INVOKE_TESTS_H*/
 


### PR DESCRIPTION
Add command PTA_INVOKE_TESTS_CMD_MEMREF_NULL to test invocation
of a PTA with a memref parameter with a NULL buffer reference.
The PTA should successfully be invoked with a valid memref
parameter yet referring to a NULL buffer pointer.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
