### PR TITLE
core: rcar: Enable parsing of /memory nodes from DT from TFA

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -44,3 +44,4 @@ $(call force,CFG_ARM32_core,y)
 endif
 
 CFG_WITH_STACK_CANARIES ?= y
+CFG_DT ?= y


### PR DESCRIPTION
The TFA can pass DT to the optee-os, however the optee-os cannot parse all possible /memory node formats correctly, e.g. the following does not work:
/ {
      memory@480000000 {
        reg = <0x00000000 0x48000000 0x00000000 0x78000000>;
        device_type = "memory";
      };
      memory@600000000 {
        reg = <0x00000006 0x00000000 0x00000000 0x80000000>;
        device_type = "memory";
      };
    };
Optee-os can only parse the most simple plain /memory node. The above sample is correct per DT specification and rcar gen3 uses it in Linux, so it should be supported by other components too.

This patchset fixes it so that optee-os can handle all possible /memory nodes and enables parsing of memory nodes on rcar gen3.