### PR TITLE
rcar: Print SREC when generating the SREC file

### DIFF
--- a/core/arch/arm/plat-rcar/link.mk
+++ b/core/arch/arm/plat-rcar/link.mk
@@ -10,6 +10,6 @@ $(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 
 cleanfiles += $(link-out-dir)/tee.srec
 $(link-out-dir)/tee.srec: $(link-out-dir)/tee-raw.bin
-	@$(cmd-echo-silent) '  GEN     $@'
+	@$(cmd-echo-silent) '  SREC    $@'
 	$(q)$(OBJCOPYcore) -I binary -O srec $< $@
 


### PR DESCRIPTION
Fix likely copy-paste error, print SREC when generating the SREC
file instead of GEN, which is likely copied from neighboring entry
in the same Makefile.