### PR TITLE
Makefile: use plain bash for SHELL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL = /bin/bash
+SHELL = bash
 
 # It can happen that a makefile calls us, which contains an 'export' directive
 # or the '.EXPORT_ALL_VARIABLES:' special target. In this case, all the make


### PR DESCRIPTION
Some linux distributions do not provide bash at the /bin/bash location,
use the /usr/bin/env wrapper which is guaranteed to exist instead.