### PR TITLE
drivers: caam: use pointers to out/inring_entry for CAAM

### DIFF
--- a/core/drivers/crypto/caam/caam_desc.c
+++ b/core/drivers/crypto/caam/caam_desc.c
@@ -69,37 +69,36 @@ void caam_desc_add_ptr(uint32_t *desc, paddr_t ptr)
 }
 
 #ifdef CFG_CAAM_64BIT
-void caam_desc_push(uint64_t *in_entry, paddr_t paddr)
+void caam_desc_push(struct caam_inring_entry *in_entry, paddr_t paddr)
 {
 #ifdef CFG_CAAM_BIG_ENDIAN
-	put_be64(in_entry, paddr);
+	put_be64(&in_entry->desc, paddr);
 #else
-	put_le64(in_entry, paddr);
+	put_le64(&in_entry->desc, paddr);
 #endif /* CFG_CAAM_BIG_ENDIAN */
 }
 
-paddr_t caam_desc_pop(uint64_t *out_entry)
+paddr_t caam_desc_pop(struct caam_outring_entry *out_entry)
 {
-	const uint32_t *a32 = (const uint32_t *)out_entry;
 #ifdef CFG_CAAM_BIG_ENDIAN
-	return SHIFT_U64(get_be32(&a32[0]), 32) | get_be32(&a32[1]);
+	return get_be64(&out_entry->desc);
 #else
-	return SHIFT_U64(get_be32(&a32[1]), 32) | get_be32(&a32[0]);
+	return get_le64(&out_entry->desc);
 #endif /* CFG_CAAM_BIG_ENDIAN */
 }
 #else /* CFG_CAAM_64BIT */
-void caam_desc_push(uint32_t *in_entry, paddr_t paddr)
+void caam_desc_push(struct caam_inring_entry *in_entry, paddr_t paddr)
 {
-	caam_write_val32(in_entry, paddr);
+	caam_write_val32(&in_entry->desc, paddr);
 }
 
-paddr_t caam_desc_pop(uint32_t *out_entry)
+paddr_t caam_desc_pop(struct caam_outring_entry *out_entry)
 {
-	return caam_read_val32(out_entry);
+	return caam_read_val32(&out_entry->desc);
 }
 #endif /* CFG_CAAM_64BIT */
 
-uint32_t caam_read_jobstatus(uint32_t *addr)
+uint32_t caam_read_jobstatus(struct caam_outring_entry *out)
 {
-	return caam_read_val32(addr);
+	return caam_read_val32(&out->status);
 }

--- a/core/drivers/crypto/caam/caam_jr.c
+++ b/core/drivers/crypto/caam/caam_jr.c
@@ -21,34 +21,6 @@
 #include <tee/cache.h>
 
 /*
- * The CAAM physical address is decorrelated from the CPU addressing mode.
- * CAAM can manage 32 or 64 bits address depending on its version and the
- * device.
- */
-/*
- * Definition of input and output ring object
- */
-#ifdef CFG_CAAM_64BIT
-struct inring_entry {
-	uint64_t desc;   /* Physical address of the descriptor */
-};
-
-struct __packed outring_entry {
-	uint64_t desc;   /* Physical address of the descriptor */
-	uint32_t status; /* Status of the executed job */
-};
-#else
-struct inring_entry {
-	uint32_t desc;   /* Physical address of the descriptor */
-};
-
-struct __packed outring_entry {
-	uint32_t desc;   /* Physical address of the descriptor */
-	uint32_t status; /* Status of the executed job */
-};
-#endif /* CFG_CAAM_64BIT */
-
-/*
  * Job Free define
  */
 #define JR_JOB_FREE	0
@@ -76,12 +48,12 @@ struct jr_privdata {
 	uint8_t nb_jobs;         /* Number of Job ring entries managed */
 
 	/* Input Job Ring Variables */
-	struct inring_entry *inrings; /* Input JR HW queue */
+	struct caam_inring_entry *inrings; /* Input JR HW queue */
 	unsigned int inlock;          /* Input JR spin lock */
 	uint16_t inwrite_index;       /* SW Index - next JR entry free */
 
 	/* Output Job Ring Variables */
-	struct outring_entry *outrings; /* Output JR HW queue */
+	struct caam_outring_entry *outrings; /* Output JR HW queue */
 	unsigned int outlock;           /* Output JR spin lock */
 	uint16_t outread_index;         /* SW Index - next JR output done */
 
@@ -137,9 +109,9 @@ static enum caam_status do_jr_alloc(struct jr_privdata **privdata,
 
 	/* Allocate the input and output job ring queues */
 	jr_priv->inrings =
-		caam_calloc_align(nb_jobs * sizeof(struct inring_entry));
+		caam_calloc_align(nb_jobs * sizeof(struct caam_inring_entry));
 	jr_priv->outrings =
-		caam_calloc_align(nb_jobs * sizeof(struct outring_entry));
+		caam_calloc_align(nb_jobs * sizeof(struct caam_outring_entry));
 
 	/* Allocate the callers information */
 	jr_priv->callers = caam_calloc(nb_jobs * sizeof(struct caller_info));
@@ -163,9 +135,9 @@ static enum caam_status do_jr_alloc(struct jr_privdata **privdata,
 	 * memory
 	 */
 	cache_operation(TEE_CACHEFLUSH, jr_priv->inrings,
-			nb_jobs * sizeof(struct inring_entry));
+			nb_jobs * sizeof(struct caam_inring_entry));
 	cache_operation(TEE_CACHEFLUSH, jr_priv->outrings,
-			nb_jobs * sizeof(struct outring_entry));
+			nb_jobs * sizeof(struct caam_outring_entry));
 
 	retstatus = CAAM_NO_ERROR;
 end_alloc:
@@ -206,7 +178,7 @@ static uint32_t do_jr_dequeue(uint32_t wait_job_ids)
 {
 	uint32_t ret_job_id = 0;
 	struct caller_info *caller = NULL;
-	struct outring_entry *jr_out = NULL;
+	struct caam_outring_entry *jr_out = NULL;
 	struct caam_jobctx *jobctx = NULL;
 	uint32_t exceptions = 0;
 	bool found = false;
@@ -239,7 +211,7 @@ static uint32_t do_jr_dequeue(uint32_t wait_job_ids)
 	}
 
 	cache_operation(TEE_CACHEINVALIDATE, jr_out,
-			sizeof(struct outring_entry) * nb_jobs_inv);
+			sizeof(struct caam_outring_entry) * nb_jobs_inv);
 
 	for (; nb_jobs_done; nb_jobs_done--) {
 		jr_out = &jr_privdata->outrings[jr_privdata->outread_index];
@@ -259,10 +231,9 @@ static uint32_t do_jr_dequeue(uint32_t wait_job_ids)
 			 * buffer
 			 */
 			caller = &jr_privdata->callers[idx_jr];
-			if (caam_desc_pop(&jr_out->desc) == caller->pdesc) {
+			if (caam_desc_pop(jr_out) == caller->pdesc) {
 				jobctx = caller->jobctx;
-				jobctx->status =
-					caam_read_jobstatus(&jr_out->status);
+				jobctx->status = caam_read_jobstatus(jr_out);
 
 				/* Update return Job IDs mask */
 				if (caller->job_id & wait_job_ids)
@@ -318,7 +289,7 @@ static enum caam_status do_jr_enqueue(struct caam_jobctx *jobctx,
 				      uint32_t *job_id)
 {
 	enum caam_status retstatus = CAAM_BUSY;
-	struct inring_entry *cur_inrings = NULL;
+	struct caam_inring_entry *cur_inrings = NULL;
 	struct caller_info *caller = NULL;
 	uint32_t exceptions = 0;
 	uint32_t job_mask = 0;
@@ -380,11 +351,11 @@ static enum caam_status do_jr_enqueue(struct caam_jobctx *jobctx,
 	cur_inrings = &jr_privdata->inrings[jr_privdata->inwrite_index];
 
 	/* Push the descriptor into the JR HW list */
-	caam_desc_push(&cur_inrings->desc, caller->pdesc);
+	caam_desc_push(cur_inrings, caller->pdesc);
 
 	/* Ensure that physical memory is up to date */
 	cache_operation(TEE_CACHECLEAN, cur_inrings,
-			sizeof(struct inring_entry));
+			sizeof(struct caam_inring_entry));
 
 	/*
 	 * Increment index to next JR input entry taking care that

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -8,6 +8,7 @@
 #define __CAAM_DESC_HELPER_H__
 
 #include <caam_desc_defines.h>
+#include <caam_jr.h>
 #include <trace.h>
 
 /*
@@ -22,15 +23,10 @@ void caam_desc_add_ptr(uint32_t *desc, paddr_t ptr);
 void caam_desc_add_word(uint32_t *desc, uint32_t word);
 
 /* Push/Pop descriptor rings queue */
-#ifdef CFG_CAAM_64BIT
-void caam_desc_push(uint64_t *in_entry, paddr_t paddr);
-paddr_t caam_desc_pop(uint64_t *out_entry);
-#else
-void caam_desc_push(uint32_t *in_entry, paddr_t paddr);
-paddr_t caam_desc_pop(uint32_t *out_entry);
-#endif /* CFG_CAAM_64BIT */
+void caam_desc_push(struct caam_inring_entry *in_entry, paddr_t paddr);
+paddr_t caam_desc_pop(struct caam_outring_entry *out_entry);
 
-uint32_t caam_read_jobstatus(uint32_t *addr);
+uint32_t caam_read_jobstatus(struct caam_outring_entry *out);
 
 /* Debug print function to dump a Descriptor in hex */
 static inline void dump_desc(uint32_t *desc)

--- a/core/drivers/crypto/caam/include/caam_jr.h
+++ b/core/drivers/crypto/caam/include/caam_jr.h
@@ -8,6 +8,7 @@
 #define __CAAM_JR_H__
 
 #include <caam_jr_status.h>
+#include <types_ext.h>
 
 /*
  * Job context to enqueue/dequeue
@@ -30,6 +31,34 @@ struct caam_jrcfg {
 	int it_num;      /* Job Ring interrupt number */
 	uint8_t nb_jobs; /* Number of Jobs to managed */
 };
+
+/*
+ * The CAAM physical address is decorrelated from the CPU addressing mode.
+ * CAAM can manage 32 or 64 bits address depending on its version and the
+ * device.
+ */
+/*
+ * Definition of input and output ring object
+ */
+#ifdef CFG_CAAM_64BIT
+struct caam_inring_entry {
+	uint64_t desc; /* Physical address of the descriptor */
+};
+
+struct caam_outring_entry {
+	uint64_t desc;	 /* Physical address of the descriptor */
+	uint32_t status; /* Status of the executed job */
+} __packed;
+#else
+struct caam_inring_entry {
+	uint32_t desc; /* Physical address of the descriptor */
+};
+
+struct caam_outring_entry {
+	uint32_t desc;	 /* Physical address of the descriptor */
+	uint32_t status; /* Status of the executed job */
+} __packed;
+#endif /* CFG_CAAM_64BIT */
 
 /*
  * Initialization of the CAAM Job Ring module


### PR DESCRIPTION
Hello,

This PR is a follow-up of this previous PR : https://github.com/OP-TEE/optee_os/pull/3713
I took the suggestion from @jenswi-linaro where we should supply the function with a pointer to ```struct outring_entry``` instead of a ```void *```.

Thanks