### PR TITLE
enum early TAs

### DIFF
--- a/core/arch/arm/include/kernel/early_ta.h
+++ b/core/arch/arm/include/kernel/early_ta.h
@@ -10,6 +10,7 @@
 #include <tee_api_types.h>
 
 struct early_ta {
+	uint32_t flags;
 	TEE_UUID uuid;
 	uint32_t size;
 	uint32_t uncompressed_size; /* 0: not compressed */

--- a/core/pta/device.c
+++ b/core/pta/device.c
@@ -20,14 +20,24 @@
 
 #define PTA_NAME "device.pta"
 
+static void add_ta(uint32_t flags, const TEE_UUID *uuid, uint8_t *buf,
+		   uint32_t blen, uint32_t *pos)
+{
+	if (flags & TA_FLAG_DEVICE_ENUM) {
+		if (*pos + sizeof(*uuid) <= blen)
+			tee_uuid_to_octets(buf + *pos, uuid);
+
+		(*pos) += sizeof(*uuid);
+	}
+}
+
 static TEE_Result get_devices(uint32_t types,
 			      TEE_Param params[TEE_NUM_PARAMS])
 {
-	const struct pseudo_ta_head *ta;
-	TEE_UUID *device_uuid = NULL;
-	uint8_t uuid_octet[sizeof(TEE_UUID)];
-	size_t ip_size, op_size = 0;
-	TEE_Result res = TEE_SUCCESS;
+	const struct pseudo_ta_head *ta = NULL;
+	void *buf = NULL;
+	uint32_t blen = 0;
+	uint32_t pos = 0;
 
 	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_OUTPUT,
 				     TEE_PARAM_TYPE_NONE,
@@ -38,46 +48,24 @@ static TEE_Result get_devices(uint32_t types,
 	if (!params[0].memref.buffer && (params[0].memref.size > 0))
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	device_uuid = (TEE_UUID *)params[0].memref.buffer;
-	ip_size = params[0].memref.size;
+	buf =  params[0].memref.buffer;
+	blen = params[0].memref.size;
 
-	SCATTERED_ARRAY_FOREACH(ta, pseudo_tas, struct pseudo_ta_head) {
-		if (ta->flags & TA_FLAG_DEVICE_ENUM) {
-			if (ip_size < sizeof(TEE_UUID)) {
-				res = TEE_ERROR_SHORT_BUFFER;
-			} else {
-				tee_uuid_to_octets(uuid_octet, &ta->uuid);
-				memcpy(device_uuid, uuid_octet,
-				       sizeof(TEE_UUID));
-				device_uuid++;
-				ip_size -= sizeof(TEE_UUID);
-			}
-			op_size += sizeof(TEE_UUID);
-		}
-	}
+	SCATTERED_ARRAY_FOREACH(ta, pseudo_tas, struct pseudo_ta_head)
+		add_ta(ta->flags, &ta->uuid, buf, blen, &pos);
 
 	if (IS_ENABLED(CFG_EARLY_TA)) {
 		const struct early_ta *eta = NULL;
 
-		for_each_early_ta(eta) {
-			if (!(eta->flags & TA_FLAG_DEVICE_ENUM))
-				continue;
-			if (ip_size < sizeof(TEE_UUID)) {
-				res = TEE_ERROR_SHORT_BUFFER;
-			} else {
-				tee_uuid_to_octets(uuid_octet, &eta->uuid);
-				memcpy(device_uuid, uuid_octet,
-				       sizeof(TEE_UUID));
-				device_uuid++;
-				ip_size -= sizeof(TEE_UUID);
-			}
-			op_size += sizeof(TEE_UUID);
-		}
+		for_each_early_ta(eta)
+			add_ta(eta->flags, &eta->uuid, buf, blen, &pos);
 	}
 
-	params[0].memref.size = op_size;
+	params[0].memref.size = pos;
+	if (pos > blen)
+		return TEE_ERROR_SHORT_BUFFER;
 
-	return res;
+	return TEE_SUCCESS;
 }
 
 static TEE_Result invoke_command(void *pSessionContext __unused,

--- a/scripts/ta_bin_to_c.py
+++ b/scripts/ta_bin_to_c.py
@@ -15,7 +15,6 @@ import zlib
 
 
 def get_args():
-
     parser = argparse.ArgumentParser(
         description='Converts a Trusted '
         'Application ELF file into a C source file, ready for '
@@ -39,6 +38,7 @@ def get_args():
 
     return parser.parse_args()
 
+
 def get_name(obj):
     # Symbol or section .name might be a byte array or a string, we want a
     # string
@@ -48,8 +48,8 @@ def get_name(obj):
         name = obj.name
     return name
 
-def ta_get_flags(ta_f):
 
+def ta_get_flags(ta_f):
     with open(ta_f, 'rb') as f:
         elffile = ELFFile(f)
 
@@ -59,8 +59,8 @@ def ta_get_flags(ta_f):
 
         raise Exception('.ta_head section not found')
 
-def main():
 
+def main():
     args = get_args()
 
     ta_uuid = uuid.UUID(re.sub(r'\..*', '', os.path.basename(args.ta)))


### PR DESCRIPTION
This patches add enumeration of early TAs. I.e. linux kernel is able to see TAs built into optee os.

For reference how it works together with kernel and qemu you can take a look at my dev PR: https://github.com/Linaro/meta-ledge/pull/203

p.s.
On pull request creation message template cames with broken link:
         https://optee.readthedocs.io/general/contribute.html
