### PR TITLE
github: update links in issue/pr templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -8,13 +8,13 @@
        the question is about build issues.
 
     3. Try to use GitHub markdown formatting to make your issue more readable:
-         https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code
+         https://help.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax#quoting-code
 
     4. Try to search for the issue before posting the question:
          -> Issues tab -> Filters
 
     5. Check the FAQ before posting a question:
-         https://optee.readthedocs.io/faq/faq.html
+         https://optee.readthedocs.io/en/latest/faq/faq.html
 
     NOTE: This comment will not be shown in the issue, so no harm keeping it,
     but feel free to remove it if you like.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
     look at the list below and tick them off before submitting the pull request.
 
     1. Read our contribution guidelines:
-         https://optee.readthedocs.io/general/contribute.html
+         https://optee.readthedocs.io/en/latest/general/contribute.html
 
     2. Read the contribution section in Notice.md and pay extra attention to the
        "Developer Certificate of Origin" in the contribution guidelines.


### PR DESCRIPTION
Auto-generated URLs from readthedoc.io has changed since we started
using it. This fixes broken links in our GitHub template files.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
