### PR TITLE
core: mmu: remove TEE/TA RAM from passed in total RAM

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -379,6 +379,9 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 		carve_out_phys_mem(&m, &num_elems, pmem->addr, pmem->size);
 #endif
 
+	carve_out_phys_mem(&m, &num_elems, TEE_RAM_START, TEE_RAM_PH_SIZE);
+	carve_out_phys_mem(&m, &num_elems, TA_RAM_START, TA_RAM_SIZE);
+
 	for (map = static_memory_map; !core_mmap_is_end_of_table(map); map++) {
 		if (map->type == MEM_AREA_NSEC_SHM)
 			carve_out_phys_mem(&m, &num_elems, map->pa, map->size);


### PR DESCRIPTION
On platforms where the DT is parsed from the device tree, devices can
pass in the complete available memory. This is in accordance with the
device tree specification which mandates that the total physical memory
should be passed in the memory nodes.
Remove the TZDRAM from the passed in memory on platforms with CFG_DT,
here reserved-memory nodes are used to indicate that part of the RAM is
not accessible to Linux. Fixes the following warning on some i.MX
platforms:

  I/TC: Non-secure external DT found
  E/TC:0 0 check_phys_mem_is_outside:330 Non-sec mem (0x10000000:0x40000000) overlaps map (type 2 0x4e000000:0x5d000)
  E/TC:0 0 Panic at core/arch/arm/mm/core_mmu.c:334 <check_phys_mem_is_outside>
  E/TC:0 0 TEE load address @ 0x4e000000
  E/TC:0 0 Call stack:
  E/TC:0 0  0x4e006fd1

Fixes https://github.com/OP-TEE/optee_os/issues/3567
Fixes https://github.com/OP-TEE/optee_os/issues/3710

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

Lets see if this passes shippable. This is an update to #3569. I'm getting tired of cherry-picking this onto my topic branches and since #3710 revealed that U-Boot has the same problem and fixing barebox is not the correct way, lets try this again.