### PR TITLE
Add initial UniPhier platform support

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -170,6 +170,12 @@ R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
 S:	Maintained
 F:	core/arch/arm/plat-synquacer/
 
+Socionext UniPhier
+R:	Kunihiko Hayashi <hayashi.kunihiko@socionext.com>
+R:	[@96boards-akebi96/optee]
+S:	Maintained
+F:	core/arch/arm/plat-uniphier/
+
 Spreadtrum SC9860
 R:	Aijun Sun <aijun.sun@unisoc.com>
 R:	[@OP-TEE/plat-sprd]

--- a/core/arch/arm/plat-uniphier/conf.mk
+++ b/core/arch/arm/plat-uniphier/conf.mk
@@ -1,0 +1,50 @@
+PLATFORM_FLAVOR ?= ld20
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+ifeq ($(PLATFORM_FLAVOR),ld20)
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+CFG_DRAM0_BASE      ?= 0x80000000
+CFG_DRAM0_SIZE      ?= 0xc0000000
+CFG_DRAM0_RSV_SIZE  ?= 0x02000000
+endif
+
+ifeq ($(PLATFORM_FLAVOR),ld11)
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+CFG_DRAM0_BASE      ?= 0x80000000
+CFG_DRAM0_SIZE      ?= 0x40000000
+CFG_DRAM0_RSV_SIZE  ?= 0x02000000
+endif
+
+CFG_TZDRAM_START    ?= (CFG_DRAM0_BASE + 0x01080000)
+CFG_TZDRAM_SIZE     ?= 0x00E00000
+CFG_SHMEM_START     ?= (CFG_DRAM0_BASE + 0x00E00000)
+CFG_SHMEM_SIZE      ?= 0x00200000
+CFG_TEE_RAM_VA_SIZE ?= 0x00100000
+
+# 32-bit flags
+core_arm32-platform-aflags	+= -mfpu=neon
+
+$(call force,CFG_GENERIC_BOOT,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_GIC,y)
+$(call force,CFG_ARM_GICV3,y)
+$(call force,CFG_8250_UART,y)
+$(call force,CFG_PM_STUBS,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_CORE_CLUSTER_SHIFT,1)
+
+ta-targets = ta_arm32
+
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+ta-targets += ta_arm64
+else
+$(call force,CFG_ARM32_core,y)
+endif
+
+CFG_NUM_THREADS ?= 4
+CFG_CRYPTO_WITH_CE ?= y
+CFG_WITH_STACK_CANARIES ?= y

--- a/core/arch/arm/plat-uniphier/kern.ld.S
+++ b/core/arch/arm/plat-uniphier/kern.ld.S
@@ -1,0 +1,2 @@
+/* SPDX-License-Identifier: (BSD-2-Clause AND MIT) */
+#include "../kernel/kern.ld.S"

--- a/core/arch/arm/plat-uniphier/link.mk
+++ b/core/arch/arm/plat-uniphier/link.mk
@@ -1,0 +1,1 @@
+include core/arch/arm/kernel/link.mk

--- a/core/arch/arm/plat-uniphier/main.c
+++ b/core/arch/arm/plat-uniphier/main.c
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2017, Socionext Inc.
+ */
+
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/serial8250_uart.h>
+#include <io.h>
+#include <kernel/generic_boot.h>
+#include <kernel/panic.h>
+#include <kernel/pm_stubs.h>
+#include <mm/tee_pager.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/entry_std.h>
+#include <tee/entry_fast.h>
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(CONSOLE_UART_BASE, CORE_MMU_PGDIR_SIZE),
+			CORE_MMU_PGDIR_SIZE);
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(GIC_BASE, CORE_MMU_PGDIR_SIZE),
+			CORE_MMU_PGDIR_SIZE);
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(GIC_BASE + GICD_OFFSET, CORE_MMU_PGDIR_SIZE),
+			CORE_MMU_PGDIR_SIZE);
+
+#ifdef DRAM0_BASE
+register_ddr(DRAM0_BASE, DRAM0_SIZE);
+#endif
+#ifdef DRAM1_BASE
+register_ddr(DRAM1_BASE, DRAM1_SIZE);
+#endif
+
+static struct gic_data gic_data;
+
+static const struct thread_handlers handlers = {
+	.cpu_on = cpu_on_handler,
+	.cpu_off = pm_do_nothing,
+	.cpu_suspend = pm_do_nothing,
+	.cpu_resume = pm_do_nothing,
+	.system_off = pm_do_nothing,
+	.system_reset = pm_do_nothing,
+};
+
+static struct serial8250_uart_data console_data;
+
+const struct thread_handlers *generic_boot_get_handlers(void)
+{
+	return &handlers;
+}
+
+void main_init_gic(void)
+{
+	vaddr_t gicc_base, gicd_base;
+
+	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
+					  MEM_AREA_IO_SEC);
+	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
+					  MEM_AREA_IO_SEC);
+
+	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	itr_init(&gic_data.chip);
+}
+
+void itr_core_handler(void)
+{
+	gic_it_handle(&gic_data);
+}
+
+void console_init(void)
+{
+	/* Init UART */
+	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+
+	/* Register console */
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-uniphier/platform_config.h
+++ b/core/arch/arm/plat-uniphier/platform_config.h
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2017, Socionext Inc.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+/* GIC */
+#define GIC_BASE		0x5FE00000
+#define GICD_OFFSET		0
+#define GICC_OFFSET		0x80000
+
+/* UART */
+#define UART_CH			0
+#define UART_BASE		0x54006800
+#define CONSOLE_UART_BASE	(UART_BASE + 0x100 * UART_CH)
+#define CONSOLE_BAUDRATE	115200
+#define CONSOLE_UART_CLK_IN_HZ	58820000
+
+/*
+ * UniPhier memory map
+ *
+ *  0xXXXX_XXXX
+ *    Linux kernel and user space             | DRAM#0-#x | Normal memory
+ *  0x8200_0000 [DRAM0_BASE]                  -           -
+ *    unused                                  |           |
+ *  0x81E8_0000                               |           |
+ *    TA RAM: 13 MiB                          | TZDRAM    |
+ *  0x8118_0000                               |           | Secure memory
+ *    TEE RAM: 1 MiB (CFG_TEE_RAM_VA_SIZE)    |           |
+ *  0x8108_0000 [CFG_TZDRAM_START]            -           |
+ *    BL31 runtime: 512 KiB                   |           |
+ *  0x8100_0000                               |           -
+ *    Shared memory: 2 MiB (CFG_SHMEM_SIZE)   |           |
+ *  0x80E0_0000 [CFG_SHMEM_START]             | DRAM#0    | Normal memory
+ *    reserved                                |           |
+ *  0x8008_0000                               |           |
+ *    BL2: 512 KiB                            |           |
+ *  0x8000_0000 [CFG_DRAM0_BASE]              -           -
+ */
+
+#define DRAM0_BASE		(CFG_DRAM0_BASE + CFG_DRAM0_RSV_SIZE)
+#define DRAM0_SIZE		(CFG_DRAM0_SIZE - CFG_DRAM0_RSV_SIZE)
+
+#define CFG_TEE_LOAD_ADDR	CFG_TZDRAM_START
+
+#endif /* PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-uniphier/sub.mk
+++ b/core/arch/arm/plat-uniphier/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
This introduces support for Socionext UniPhier SoCs in 64-bit mode,
that include LD11 and LD20. Tested with Akebi96 board[1].

[1] https://www.96boards.org/product/akebi96/

Signed-off-by: Tetsuya Yoshizaki <yoshizaki.tetsuya@socionext.com>
Signed-off-by: Kunihiko Hayashi <hayashi.kunihiko@socionext.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
