### PR TITLE
core: crypto: DH: make sure key_size is consistent with attributes

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -634,7 +634,8 @@ TEE_Result crypto_acipher_alloc_dh_keypair(struct dh_keypair *s __unused,
 
 TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key __unused,
 				     struct bignum *q __unused,
-				     size_t xbits __unused)
+				     size_t xbits __unused,
+				     size_t key_size __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -190,7 +190,7 @@ void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s);
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size);
 TEE_Result crypto_acipher_gen_dsa_key(struct dsa_keypair *key, size_t key_size);
 TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
-				     size_t xbits);
+				     size_t xbits, size_t key_size);
 TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key);
 
 TEE_Result crypto_acipher_dh_shared_secret(struct dh_keypair *private_key,

--- a/core/lib/libtomcrypt/dh.c
+++ b/core/lib/libtomcrypt/dh.c
@@ -36,11 +36,14 @@ err:
 }
 
 TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
-				     size_t xbits)
+				     size_t xbits, size_t key_size)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	dh_key ltc_tmp_key = { };
 	int ltc_res = 0;
+
+	if (key_size != 8 * mp_unsigned_bin_size(key->p))
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	ltc_res = mp_init_multi(&ltc_tmp_key.base, &ltc_tmp_key.prime, NULL);
 	if (ltc_res != CRYPT_OK)

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1741,8 +1741,7 @@ static TEE_Result tee_svc_obj_generate_key_dsa(
 
 static TEE_Result tee_svc_obj_generate_key_dh(
 	struct tee_obj *o, const struct tee_cryp_obj_type_props *type_props,
-	uint32_t key_size __unused,
-	const TEE_Attribute *params, uint32_t param_count)
+	uint32_t key_size, const TEE_Attribute *params, uint32_t param_count)
 {
 	TEE_Result res;
 	struct dh_keypair *tee_dh_key;
@@ -1761,7 +1760,7 @@ static TEE_Result tee_svc_obj_generate_key_dh(
 		dh_q = tee_dh_key->q;
 	if (get_attribute(o, type_props, TEE_ATTR_DH_X_BITS))
 		dh_xbits = tee_dh_key->xbits;
-	res = crypto_acipher_gen_dh_key(tee_dh_key, dh_q, dh_xbits);
+	res = crypto_acipher_gen_dh_key(tee_dh_key, dh_q, dh_xbits, key_size);
 	if (res != TEE_SUCCESS)
 		return res;
 

--- a/lib/libmbedtls/core/dh.c
+++ b/lib/libmbedtls/core/dh.c
@@ -44,7 +44,7 @@ err:
 
 TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key,
 				     struct bignum *q __unused,
-				     size_t xbits)
+				     size_t xbits, size_t key_size)
 {
 	TEE_Result res = TEE_SUCCESS;
 	int lmd_res = 0;
@@ -59,6 +59,10 @@ TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key,
 	dhm.P = *(mbedtls_mpi *)key->p;
 
 	dhm.len = crypto_bignum_num_bytes(key->p);
+	if (key_size != 8 * dhm.len) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
 
 	if (xbits == 0)
 		xbytes = dhm.len;


### PR DESCRIPTION
TEE_GenerateKey() takes a key_size argument and various attributes. For
Diffie-Hellman, if the size of the prime number (TEE_ATTR_DH_PRIME) is
not key_size, we should return TEE_ERROR_BAD_PARAMETERS as per the GP
TEE Internal Core API specification v1.2.1: "If an incorrect or
inconsistent attribute is detected. The checks that are performed
depend on the implementation.".

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
