### PR TITLE
core: crypto: ECC: make sure key_size is consistent with attributes

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -667,7 +667,8 @@ void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s __unused)
 {
 }
 
-TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key __unused)
+TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key __unused,
+				      size_t key_size __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -191,7 +191,7 @@ TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size);
 TEE_Result crypto_acipher_gen_dsa_key(struct dsa_keypair *key, size_t key_size);
 TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
 				     size_t xbits, size_t key_size);
-TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key);
+TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key, size_t key_size);
 
 TEE_Result crypto_acipher_dh_shared_secret(struct dh_keypair *private_key,
 					   struct bignum *public_key,

--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -146,7 +146,7 @@ static TEE_Result ecc_get_curve_info(uint32_t curve, uint32_t algo,
 	return TEE_SUCCESS;
 }
 
-TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key)
+TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key, size_t key_size)
 {
 	TEE_Result res;
 	ecc_key ltc_tmp_key;
@@ -158,6 +158,9 @@ TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key)
 				 NULL);
 	if (res != TEE_SUCCESS)
 		return res;
+
+	if (key_size != key_size_bits)
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	/* Generate the ECC key */
 	ltc_res = ecc_make_key(NULL, find_prng("prng_crypto"),

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1779,8 +1779,7 @@ static TEE_Result tee_svc_obj_generate_key_dh(
 
 static TEE_Result tee_svc_obj_generate_key_ecc(
 	struct tee_obj *o, const struct tee_cryp_obj_type_props *type_props,
-	uint32_t key_size __unused,
-	const TEE_Attribute *params, uint32_t param_count)
+	uint32_t key_size, const TEE_Attribute *params, uint32_t param_count)
 {
 	TEE_Result res;
 	struct ecc_keypair *tee_ecc_key;
@@ -1793,7 +1792,7 @@ static TEE_Result tee_svc_obj_generate_key_ecc(
 
 	tee_ecc_key = (struct ecc_keypair *)o->attr;
 
-	res = crypto_acipher_gen_ecc_key(tee_ecc_key);
+	res = crypto_acipher_gen_ecc_key(tee_ecc_key, key_size);
 	if (res != TEE_SUCCESS)
 		return res;
 

--- a/lib/libmbedtls/core/ecc.c
+++ b/lib/libmbedtls/core/ecc.c
@@ -150,7 +150,7 @@ static void ecc_clear_precomputed(mbedtls_ecp_group *grp)
 	grp->T_size = 0;
 }
 
-TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key)
+TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key, size_t key_size)
 {
 	TEE_Result res = TEE_SUCCESS;
 	int lmd_res = 0;
@@ -163,6 +163,9 @@ TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key)
 	res = ecc_get_keysize(key->curve, 0, &key_size_bytes, &key_size_bits);
 	if (res != TEE_SUCCESS)
 		return res;
+
+	if (key_size != key_size_bits)
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	mbedtls_ecdsa_init(&ecdsa);
 


### PR DESCRIPTION
TEE_GenerateKey() takes a key_size argument and various attributes. If
the size derived from the attributes is not key_size, we should return
TEE_ERROR_BAD_PARAMETERS as per the GP TEE Internal Core API
specification v1.2.1: "If an incorrect or inconsistent attribute is
detected. The checks that are performed depend on the implementation.".

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
