### PR TITLE
mk/clang.mk: define libgcc$(sm)

### DIFF
--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -33,7 +33,10 @@ nostdinc$(sm)	:= -nostdinc -isystem $(shell $(CC$(sm)) \
 comp-cflags-warns-clang := -Wno-language-extension-token \
 			 -Wno-gnu-zero-variadic-macro-arguments
 
-libgcc$(sm)  	:=
+# Note, the currently used compiler runtime library may be libgcc.a or
+# libclang_rt.builtins.*.a depending on the compiler build-time configuration.
+libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) $(comp-cflags$(sm)) \
+			-print-libgcc-file-name 2> /dev/null)
 
 # Define these to something to discover accidental use
 CC		:= false


### PR DESCRIPTION
Adds missing definition for libgcc$(sm) (the compiler runtime library)
to mk/clang.mk.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
