### PR TITLE
mk: clang.mk: use 'clang -E' instead of clang-cpp

### DIFF
--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -7,7 +7,9 @@ clang-target	:= $(patsubst %-,%,$(notdir $(lastword $(CROSS_COMPILE_$(sm)))))
 ccache-cmd	:= $(if $(findstring ccache,$(CROSS_COMPILE_$(sm))),$(firstword $(CROSS_COMPILE_$(sm))) ,)
 
 CC$(sm)		:= $(ccache-cmd)clang --target=$(clang-target)
-CPP$(sm)	:= $(ccache-cmd)clang-cpp --target=$(clang-target)
+# Due to the absence of clang-cpp in AOSP's prebuilt version of clang,
+# use the equivalent command of 'clang -E'
+CPP$(sm)	:= $(ccache-cmd)clang --target=$(clang-target) -E
 LD$(sm)		:= $(ccache-cmd)ld.lld
 
 ifeq ($(sm)-$(CFG_WITH_PAGER),core-y)


### PR DESCRIPTION
AOSP's prebuilt versions of Clang [1] don't contain the clang-cpp
symlink to clang, so use the equivalent command of 'clang -E' instead.

LINK: [1] https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/heads/master
LINK: [2] https://github.com/llvm/llvm-project/tree/llvmorg-9.0.1
LINK: [3] https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/heads/master/clang-r370808/bin/clang

Suggested by: Jerome Forissier <jerome@forissier.org>
Signed-off-by: Victor Chong <victor.chong@linaro.org>
Tested-by: Victor Chong <victor.chong@linaro.org> (builds only with
clang-v9.0.1 [2] and AOSP clang v10.0.1 [3])

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
