### PR TITLE
core: ree_fs_ta.c: initialize structs with '= { };'

### DIFF
--- a/core/arch/arm/kernel/ree_fs_ta.c
+++ b/core/arch/arm/kernel/ree_fs_ta.c
@@ -322,14 +322,14 @@ out:
 
 static TEE_Result check_update_version(struct shdr_bootstrap_ta *hdr)
 {
-	struct shdr_bootstrap_ta hdr_entry = {0};
+	struct shdr_bootstrap_ta hdr_entry = { };
 	const struct tee_file_operations *ops = NULL;
 	struct tee_file_handle *fh = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	bool entry_found = false;
 	size_t len = 0;
 	unsigned int i = 0;
-	struct ta_ver_db_hdr db_hdr = {0};
+	struct ta_ver_db_hdr db_hdr = { };
 	struct tee_pobj pobj = {
 		.obj_id = (void *)ta_ver_db_obj_id,
 		.obj_id_len = sizeof(ta_ver_db_obj_id)


### PR DESCRIPTION
Initialize structs with '= { };' rather than '= {0};' because (1) it is
the recommended style and (2) it fixes the following warning with Clang
9:

   CC      out/arm/core/arch/arm/kernel/ree_fs_ta.o
 core/arch/arm/kernel/ree_fs_ta.c:325:40: warning: suggest braces around initialization of subobject [-Wmissing-braces]
         struct shdr_bootstrap_ta hdr_entry = {0};
                                               ^
                                               {}

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
