### PR TITLE
stm32mp1: seed PRNG with STM32 RNG

### DIFF
--- a/core/arch/arm/plat-stm32mp1/rng_seed.c
+++ b/core/arch/arm/plat-stm32mp1/rng_seed.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#include <assert.h>
+#include <drivers/stm32_rng.h>
+#include <drivers/stm32mp1_rcc.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stm32_util.h>
+#include <tee/tee_cryp_utl.h>
+#include <trace.h>
+
+#define RNG1_RESET_TIMEOUT_US		1000
+#define PRNG_SEED_SIZE			16
+
+/* Override weak plat_rng_init with platform handler to seed PRNG */
+void plat_rng_init(void)
+{
+	vaddr_t rng = (vaddr_t)phys_to_virt(RNG1_BASE, MEM_AREA_IO_SEC);
+	vaddr_t rcc = stm32_rcc_base();
+	uint64_t timeout_ref = timeout_init_us(RNG1_RESET_TIMEOUT_US);
+	uint8_t seed[PRNG_SEED_SIZE] = { };
+	size_t size = 0;
+
+	assert(cpu_mmu_enabled());
+
+	/* Setup RNG1 without clock/reset driver support, not yet initialized */
+	io_setbits32(rcc + RCC_MP_AHB5ENSETR, RCC_MP_AHB5ENSETR_RNG1EN);
+	io_setbits32(rcc + RCC_MP_AHB5LPENCLRR, RCC_MP_AHB5LPENSETR_RNG1LPEN);
+	io_setbits32(rcc + RCC_AHB5RSTSETR, RCC_AHB5RSTSETR_RNG1RST);
+	while (!(io_read32(rcc + RCC_AHB5RSTSETR) & RCC_AHB5RSTSETR_RNG1RST))
+		if (timeout_elapsed(timeout_ref))
+			panic();
+	io_setbits32(rcc + RCC_AHB5RSTCLRR, RCC_AHB5RSTSETR_RNG1RST);
+	while (io_read32(rcc + RCC_AHB5RSTSETR) & RCC_AHB5RSTSETR_RNG1RST)
+		if (timeout_elapsed(timeout_ref))
+			panic();
+
+	size = sizeof(seed);
+	if (stm32_rng_read_raw(rng, seed, &size))
+		panic();
+	if (size != sizeof(seed))
+		panic();
+
+	if (crypto_rng_init(seed, sizeof(seed)))
+		panic();
+
+	DMSG("PRNG seeded with RNG1");
+}

--- a/core/arch/arm/plat-stm32mp1/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/sub.mk
@@ -2,6 +2,7 @@ global-incdirs-y += .
 
 srcs-y += main.c
 srcs-y += reset.S
+srcs-$(CFG_STM32_RNG) += rng_seed.c
 srcs-y += scmi_server.c
 srcs-y += shared_resources.c
 


### PR DESCRIPTION
Initialize the core PRNG with samples from the SoC RNG during early
initialization. PRNG is used to generate random samples used early
before all services and obviously device and peripheral drivers
are initialized. Therefore the platform sequence to initialize the
PRNG locally handles RNG clock and reset without relying on clock
and reset device drivers as these are not yet initialized.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
