### PR TITLE
[RFC] Using "secure-" property prefix in DTS for clocks/resets/...

### DIFF
--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -167,22 +167,22 @@ void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt)
 /* Panic if GPIO bank information from platform do not match DTB description */
 static void ckeck_gpio_bank(void *fdt, uint32_t bank, int pinctrl_node)
 {
-	int pinctrl_subnode = 0;
+	int subnode = 0;
 
-	fdt_for_each_subnode(pinctrl_subnode, fdt, pinctrl_node) {
+	fdt_for_each_subnode(subnode, fdt, pinctrl_node) {
 		const fdt32_t *cuint = NULL;
 
-		if (fdt_getprop(fdt, pinctrl_subnode,
-				"gpio-controller", NULL) == NULL)
+		if (!fdt_getprop(fdt, subnode, "gpio-controller", NULL))
 			continue;
 
 		/* Check bank register offset matches platform assumptions */
-		cuint = fdt_getprop(fdt, pinctrl_subnode, "reg", NULL);
+		cuint = _fdt_get_secure_prop(fdt, subnode, "reg", NULL);
+		assert(cuint);
 		if (fdt32_to_cpu(*cuint) != stm32_get_gpio_bank_offset(bank))
 			continue;
 
 		/* Check bank clock matches platform assumptions */
-		cuint = fdt_getprop(fdt, pinctrl_subnode, "clocks", NULL);
+		cuint = _fdt_get_secure_prop(fdt, subnode, "clocks", NULL);
 		if (!cuint)
 			panic();
 		cuint++;
@@ -190,7 +190,7 @@ static void ckeck_gpio_bank(void *fdt, uint32_t bank, int pinctrl_node)
 			panic();
 
 		/* Check controller is enabled */
-		if (_fdt_get_status(fdt, pinctrl_subnode) == DT_STATUS_DISABLED)
+		if (_fdt_get_status(fdt, subnode) == DT_STATUS_DISABLED)
 			panic();
 
 		return;

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -161,6 +161,20 @@ int _fdt_get_status(const void *fdt, int offs);
  */
 void _fdt_fill_device_info(void *fdt, struct dt_node_info *info, int node);
 
+/*
+ * fdt_get_secure_prop - like fdt_getprop for a the secure world
+ * @fdt: pointer to the device tree blob
+ * @nodeoffset: offset of the node whose property to find
+ * @name: name of the property to find
+ * @lenp: pointer to an integer variable (will be overwritten) or NULL
+ *
+ * Attempts to get property "secure-"@name and fallback to property @name
+ * if not found. Length of name shall be is expect 24 chars max excluding
+ * null termination unless what this function panics.
+ */
+const void *_fdt_get_secure_prop(const void *fdt, int nodeoffset,
+				 const char *name, int *lenp);
+
 #else /* !CFG_DT */
 
 static inline const struct dt_driver *__dt_driver_start(void)
@@ -209,6 +223,14 @@ static inline void _fdt_fill_device_info(void *fdt __unused,
 					 int node __unused)
 {
 	panic();
+}
+
+static inline const void *_fdt_get_secure_prop(const void *fdt __unused,
+					       int nodeoffset __unused,
+					       const char *name __unused,
+					       int *lenp __unused)
+{
+	return NULL;
 }
 #endif /* !CFG_DT */
 

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -63,7 +63,7 @@ int dt_get_irq(void *fdt, int node)
 	 *  - Type of interrupt
 	 *  - Interrupt Number
 	 */
-	int_prop = fdt_getprop(fdt, node, "interrupts", &len_prop);
+	int_prop = _fdt_get_secure_prop(fdt, node, "interrupts", &len_prop);
 
 	if (!int_prop || len_prop < 2)
 		return it_num;
@@ -202,7 +202,7 @@ paddr_t _fdt_reg_base_address(const void *fdt, int offs)
 	if (parent < 0)
 		return DT_INFO_INVALID_REG;
 
-	reg = fdt_getprop(fdt, offs, "reg", &len);
+	reg = _fdt_get_secure_prop(fdt, offs, "reg", &len);
 	if (!reg)
 		return DT_INFO_INVALID_REG;
 
@@ -225,7 +225,7 @@ ssize_t _fdt_reg_size(const void *fdt, int offs)
 	if (parent < 0)
 		return DT_INFO_INVALID_REG;
 
-	reg = (const uint32_t *)fdt_getprop(fdt, offs, "reg", &len);
+	reg = (const uint32_t *)_fdt_get_secure_prop(fdt, offs, "reg", &len);
 	if (!reg)
 		return -1;
 
@@ -294,13 +294,13 @@ void _fdt_fill_device_info(void *fdt, struct dt_node_info *info, int offs)
 
 	dinfo.reg = _fdt_reg_base_address(fdt, offs);
 
-	cuint = fdt_getprop(fdt, offs, "clocks", NULL);
+	cuint = _fdt_get_secure_prop(fdt, offs, "clocks", NULL);
 	if (cuint) {
 		cuint++;
 		dinfo.clock = (int)fdt32_to_cpu(*cuint);
 	}
 
-	cuint = fdt_getprop(fdt, offs, "resets", NULL);
+	cuint = _fdt_get_secure_prop(fdt, offs, "resets", NULL);
 	if (cuint) {
 		cuint++;
 		dinfo.reset = (int)fdt32_to_cpu(*cuint);

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -9,6 +9,7 @@
 #include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <stdio.h>
 #include <string.h>
 #include <trace.h>
 
@@ -308,4 +309,24 @@ void _fdt_fill_device_info(void *fdt, struct dt_node_info *info, int offs)
 	dinfo.status = _fdt_get_status(fdt, offs);
 
 	*info = dinfo;
+}
+
+const void *_fdt_get_secure_prop(const void *fdt, int nodeoffset,
+				 const char *name, int *lenp)
+{
+	const fdt32_t *cuint;
+	char sec_prop[32] = { 0 };
+	int rc = 0;
+
+	rc = snprintf(sec_prop, sizeof(sec_prop), "secure-%s", name);
+	if (rc < 0 || (size_t) rc >= sizeof(sec_prop)) {
+		DMSG("Property name \"%s\"too long, panicking!", name);
+		panic();
+	}
+
+	cuint = fdt_getprop(fdt, nodeoffset, sec_prop, lenp);
+	if (!cuint)
+		cuint = fdt_getprop(fdt, nodeoffset, name, lenp);
+
+	return cuint;
 }


### PR DESCRIPTION
**(edited: text added, P-R moved to [RFC])**
Proposal to use precedence of `secure-` prefix in FDT property name for various resources.

As in this first P-R version: update helper functions to apply on:
`clocks`, `interrupt`, `reg`, `resets`.