### PR TITLE
stm32_bsec: fixes

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -273,8 +273,6 @@ void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg)
 	cfg->base = BSEC_BASE;
 	cfg->upper_start = STM32MP1_UPPER_OTP_START;
 	cfg->max_id = STM32MP1_OTP_MAX_ID;
-	cfg->closed_device_id = DATA0_OTP;
-	cfg->closed_device_position = DATA0_OTP_SECURED_POS;
 }
 
 bool stm32mp_is_closed_device(void)

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -91,15 +91,11 @@ bool stm32mp_nsec_can_access_reset(unsigned int reset_id);
  * @base: BSEC interface registers physical base address
  * @upper_start: Base ID for the BSEC upper words in the platform
  * @max_id: Max value for BSEC word ID for the platform
- * @closed_device_id: BSEC word ID storing the "closed_device" OTP bit
- * @closed_device_position: Bit position of "closed_device" bit in the OTP word
  */
 struct stm32_bsec_static_cfg {
 	paddr_t base;
 	unsigned int upper_start;
 	unsigned int max_id;
-	unsigned int closed_device_id;
-	unsigned int closed_device_position;
 };
 
 void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg);

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -98,7 +98,7 @@
  */
 #define BSEC_LOCK_UPPER_OTP		0x00
 #define BSEC_LOCK_DEBUG			0x02
-#define BSEC_LOCK_PROGRAM		0x03
+#define BSEC_LOCK_PROGRAM		0x04
 
 /* Timeout when polling on status */
 #define BSEC_TIMEOUT_US			1000

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -109,7 +109,6 @@ struct bsec_dev {
 	struct io_pa_va base;
 	unsigned int upper_base;
 	unsigned int max_id;
-	bool closed_device;
 };
 
 /* Only 1 instance of BSEC is expected per platform */
@@ -519,26 +518,18 @@ bool stm32_bsec_nsec_can_access_otp(uint32_t otp_id)
 	if (otp_id > otp_max_id())
 		return false;
 
-	return otp_id < bsec_dev.upper_base || !bsec_dev.closed_device;
+	return otp_id < bsec_dev.upper_base;
 }
 
 static TEE_Result initialize_bsec(void)
 {
-	struct stm32_bsec_static_cfg cfg = { 0 };
-	uint32_t otp = 0;
-	TEE_Result result = 0;
+	struct stm32_bsec_static_cfg cfg = { };
 
 	stm32mp_get_bsec_static_cfg(&cfg);
 
 	bsec_dev.base.pa = cfg.base;
 	bsec_dev.upper_base = cfg.upper_start;
 	bsec_dev.max_id = cfg.max_id;
-	bsec_dev.closed_device = true;
-
-	/* Disable closed device mode upon platform closed device OTP value */
-	result = stm32_bsec_shadow_read_otp(&otp, cfg.closed_device_id);
-	if (!result && !(otp & BIT(cfg.closed_device_position)))
-		bsec_dev.closed_device = false;
 
 	return TEE_SUCCESS;
 }

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -281,6 +281,7 @@ TEE_Result stm32_bsec_shadow_read_otp(uint32_t *otp_value, uint32_t otp_id)
 	return result;
 }
 
+#ifdef CFG_STM32_BSEC_WRITE
 TEE_Result stm32_bsec_write_otp(uint32_t value, uint32_t otp_id)
 {
 	TEE_Result result = 0;
@@ -348,6 +349,7 @@ TEE_Result stm32_bsec_program_otp(uint32_t value, uint32_t otp_id)
 
 	return result;
 }
+#endif /*CFG_STM32_BSEC_WRITE*/
 
 TEE_Result stm32_bsec_permanent_lock_otp(uint32_t otp_id)
 {
@@ -397,6 +399,7 @@ TEE_Result stm32_bsec_permanent_lock_otp(uint32_t otp_id)
 	return result;
 }
 
+#ifdef CFG_STM32_BSEC_WRITE
 TEE_Result stm32_bsec_write_debug_conf(uint32_t value)
 {
 	TEE_Result result = TEE_ERROR_GENERIC;
@@ -414,6 +417,7 @@ TEE_Result stm32_bsec_write_debug_conf(uint32_t value)
 
 	return result;
 }
+#endif /*CFG_STM32_BSEC_WRITE*/
 
 uint32_t stm32_bsec_read_debug_conf(void)
 {

--- a/core/include/drivers/stm32_bsec.h
+++ b/core/include/drivers/stm32_bsec.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2017-2019, STMicroelectronics
+ * Copyright (c) 2017-2020, STMicroelectronics
  */
 
 #ifndef __STM32_BSEC_H
@@ -68,62 +68,62 @@ uint32_t stm32_bsec_read_debug_conf(void);
 /*
  * Write shadow-read lock
  * @otp_id: OTP number
- * @value: Value to write in the register, must be non null
- * Return true if OTP is locked, else false
+ * Return a TEE_Result compliant return value
  */
-bool stm32_bsec_write_sr_lock(uint32_t otp_id, uint32_t value);
+TEE_Result stm32_bsec_set_sr_lock(uint32_t otp_id);
 
 /*
  * Read shadow-read lock
  * @otp_id: OTP number
- * Return true if OTP is locked, else false
+ * @locked: (out) true if shadow-read is locked, false if not locked.
+ * Return a TEE_Result compliant return value
  */
-bool stm32_bsec_read_sr_lock(uint32_t otp_id);
+TEE_Result stm32_bsec_read_sr_lock(uint32_t otp_id, bool *locked);
 
 /*
  * Write shadow-write lock
  * @otp_id: OTP number
- * @value: Value to write in the register, must be non null
- * Return true if OTP is locked, else false
+ * Return a TEE_Result compliant return value
  */
-bool stm32_bsec_write_sw_lock(uint32_t otp_id, uint32_t value);
+TEE_Result stm32_bsec_set_sw_lock(uint32_t otp_id);
 
 /*
  * Read shadow-write lock
  * @otp_id: OTP number
- * Return true if OTP is locked, else false
+ * @locked: (out) true if shadow-write is locked, false if not locked.
+ * Return a TEE_Result compliant return value
  */
-bool stm32_bsec_read_sw_lock(uint32_t otp_id);
+TEE_Result stm32_bsec_read_sw_lock(uint32_t otp_id, bool *locked);
 
 /*
  * Write shadow-program lock
  * @otp_id: OTP number
- * @value: Value to write in the register, must be non null
- * Return true if OTP is locked, else false
+ * Return a TEE_Result compliant return value
  */
-bool stm32_bsec_write_sp_lock(uint32_t otp_id, uint32_t value);
+TEE_Result stm32_bsec_set_sp_lock(uint32_t otp_id);
 
 /*
  * Read shadow-program lock
  * @otp_id: OTP number
- * Return true if OTP is locked, else false
+ * @locked: (out) true if shadow-program is locked, false if not locked.
+ * Return a TEE_Result compliant return value
  */
-bool stm32_bsec_read_sp_lock(uint32_t otp_id);
+TEE_Result stm32_bsec_read_sp_lock(uint32_t otp_id, bool *locked);
 
 /*
  * Read permanent lock status
  * @otp_id: OTP number
- * Return true if OTP is locked, else false
+ * @locked: (out) true if permanent lock is locked, false if not locked.
+ * Return a TEE_Result compliant return value
  */
-bool stm32_bsec_wr_lock(uint32_t otp_id);
+TEE_Result stm32_bsec_read_permanent_lock(uint32_t otp_id, bool *locked);
 
 /*
  * Lock Upper OTP or Global programming or debug enable
  * @service: Service to lock, see header file
- * @value: Value to write must always set to 1 (only use for debug purpose)
  * Return a TEE_Result compliant return value
  */
-TEE_Result stm32_bsec_otp_lock(uint32_t service, uint32_t value);
+TEE_Result stm32_bsec_otp_lock(uint32_t service);
 
 /*
  * Return true if non-secure world is allowed to read the target OTP

--- a/core/include/drivers/stm32_bsec.h
+++ b/core/include/drivers/stm32_bsec.h
@@ -6,6 +6,7 @@
 #ifndef __STM32_BSEC_H
 #define __STM32_BSEC_H
 
+#include <compiler.h>
 #include <stdint.h>
 #include <tee_api.h>
 
@@ -38,7 +39,15 @@ TEE_Result stm32_bsec_read_otp(uint32_t *value, uint32_t otp_id);
  * @otp_id: OTP number
  * Return a TEE_Result compliant return value
  */
+#ifdef CFG_STM32_BSEC_WRITE
 TEE_Result stm32_bsec_write_otp(uint32_t value, uint32_t otp_id);
+#else
+static inline TEE_Result stm32_bsec_write_otp(uint32_t value __unused,
+					      uint32_t otp_id __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif
 
 /*
  * Program a bit in SAFMEM without BSEC data refresh
@@ -46,7 +55,15 @@ TEE_Result stm32_bsec_write_otp(uint32_t value, uint32_t otp_id);
  * @otp_id: OTP number.
  * Return a TEE_Result compliant return value
  */
+#ifdef CFG_STM32_BSEC_WRITE
 TEE_Result stm32_bsec_program_otp(uint32_t value, uint32_t otp_id);
+#else
+static inline TEE_Result stm32_bsec_program_otp(uint32_t value __unused,
+						uint32_t otp_id __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif
 
 /*
  * Permanent lock of OTP in SAFMEM
@@ -60,7 +77,14 @@ TEE_Result stm32_bsec_permanent_lock_otp(uint32_t otp_id);
  * @value: Value to write
  * Return a TEE_Result compliant return value
  */
+#ifdef CFG_STM32_BSEC_WRITE
 TEE_Result stm32_bsec_write_debug_conf(uint32_t value);
+#else
+static inline TEE_Result stm32_bsec_write_debug_conf(uint32_t value __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif
 
 /* Return debug configuration read from BSEC */
 uint32_t stm32_bsec_read_debug_conf(void);


### PR DESCRIPTION
A series of fixes in stm32_bsec driver.

This P-R is a preparation for BSEC SiP service in platform stm32mp1 that were introduced in stalled P-R https://github.com/OP-TEE/optee_os/pull/3063. I'll create a new P-R for this on top of these fixes.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
