### PR TITLE
plat-stm32mp1: remove static ETZPC configuration

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -229,27 +229,6 @@ static TEE_Result init_stm32mp1_drivers(void)
 	etzpc_configure_tzma(1, SYSRAM_SEC_SIZE >> SMALL_PAGE_SHIFT);
 	etzpc_lock_tzma(1);
 
-	/* Static secure DECPROT configuration */
-	etzpc_configure_decprot(STM32MP1_ETZPC_STGENC_ID, ETZPC_DECPROT_S_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_BKPSRAM_ID, ETZPC_DECPROT_S_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_IWDG1_ID, ETZPC_DECPROT_S_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_DDRCTRL_ID, ETZPC_DECPROT_S_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_DDRPHYC_ID, ETZPC_DECPROT_S_RW);
-	etzpc_lock_decprot(STM32MP1_ETZPC_STGENC_ID);
-	etzpc_lock_decprot(STM32MP1_ETZPC_BKPSRAM_ID);
-	etzpc_lock_decprot(STM32MP1_ETZPC_IWDG1_ID);
-	etzpc_lock_decprot(STM32MP1_ETZPC_DDRCTRL_ID);
-	etzpc_lock_decprot(STM32MP1_ETZPC_DDRPHYC_ID);
-	/* Static non-secure DECPROT configuration */
-	etzpc_configure_decprot(STM32MP1_ETZPC_I2C4_ID, ETZPC_DECPROT_NS_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_RNG1_ID, ETZPC_DECPROT_NS_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_HASH1_ID, ETZPC_DECPROT_NS_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_CRYP1_ID, ETZPC_DECPROT_NS_RW);
-	/* Release few resource to the non-secure world */
-	etzpc_configure_decprot(STM32MP1_ETZPC_USART1_ID, ETZPC_DECPROT_NS_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_SPI6_ID, ETZPC_DECPROT_NS_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_I2C6_ID, ETZPC_DECPROT_NS_RW);
-
 	return TEE_SUCCESS;
 }
 service_init_late(init_stm32mp1_drivers);

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -606,31 +606,41 @@ static enum etzpc_decprot_attributes shres2decprot_attr(enum stm32mp_shres id)
 	return ETZPC_DECPROT_S_RW;
 }
 
+/* Configure ETZPC cell and lock it when resource is secure */
+static void config_lock_decprot(uint32_t decprot_id,
+				enum etzpc_decprot_attributes decprot_attr)
+{
+	etzpc_configure_decprot(decprot_id, decprot_attr);
+
+	if (decprot_attr == ETZPC_DECPROT_S_RW)
+		etzpc_lock_decprot(decprot_id);
+}
+
 static void set_etzpc_secure_configuration(void)
 {
 	/* Some peripherals shall be secure */
-	etzpc_configure_decprot(STM32MP1_ETZPC_STGENC_ID, ETZPC_DECPROT_S_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_BKPSRAM_ID, ETZPC_DECPROT_S_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_DDRCTRL_ID, ETZPC_DECPROT_S_RW);
-	etzpc_configure_decprot(STM32MP1_ETZPC_DDRPHYC_ID, ETZPC_DECPROT_S_RW);
+	config_lock_decprot(STM32MP1_ETZPC_STGENC_ID, ETZPC_DECPROT_S_RW);
+	config_lock_decprot(STM32MP1_ETZPC_BKPSRAM_ID, ETZPC_DECPROT_S_RW);
+	config_lock_decprot(STM32MP1_ETZPC_DDRCTRL_ID, ETZPC_DECPROT_S_RW);
+	config_lock_decprot(STM32MP1_ETZPC_DDRPHYC_ID, ETZPC_DECPROT_S_RW);
 
 	/* Configure ETZPC with peripheral registering */
-	etzpc_configure_decprot(STM32MP1_ETZPC_IWDG1_ID,
-				shres2decprot_attr(STM32MP1_SHRES_IWDG1));
-	etzpc_configure_decprot(STM32MP1_ETZPC_USART1_ID,
-				shres2decprot_attr(STM32MP1_SHRES_USART1));
-	etzpc_configure_decprot(STM32MP1_ETZPC_SPI6_ID,
-				shres2decprot_attr(STM32MP1_SHRES_SPI6));
-	etzpc_configure_decprot(STM32MP1_ETZPC_I2C4_ID,
-				shres2decprot_attr(STM32MP1_SHRES_I2C4));
-	etzpc_configure_decprot(STM32MP1_ETZPC_RNG1_ID,
-				shres2decprot_attr(STM32MP1_SHRES_RNG1));
-	etzpc_configure_decprot(STM32MP1_ETZPC_HASH1_ID,
-				shres2decprot_attr(STM32MP1_SHRES_HASH1));
-	etzpc_configure_decprot(STM32MP1_ETZPC_CRYP1_ID,
-				shres2decprot_attr(STM32MP1_SHRES_CRYP1));
-	etzpc_configure_decprot(STM32MP1_ETZPC_I2C6_ID,
-				shres2decprot_attr(STM32MP1_SHRES_I2C6));
+	config_lock_decprot(STM32MP1_ETZPC_IWDG1_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_IWDG1));
+	config_lock_decprot(STM32MP1_ETZPC_USART1_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_USART1));
+	config_lock_decprot(STM32MP1_ETZPC_SPI6_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_SPI6));
+	config_lock_decprot(STM32MP1_ETZPC_I2C4_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_I2C4));
+	config_lock_decprot(STM32MP1_ETZPC_RNG1_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_RNG1));
+	config_lock_decprot(STM32MP1_ETZPC_HASH1_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_HASH1));
+	config_lock_decprot(STM32MP1_ETZPC_CRYP1_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_CRYP1));
+	config_lock_decprot(STM32MP1_ETZPC_I2C6_ID,
+			    shres2decprot_attr(STM32MP1_SHRES_I2C6));
 }
 #else
 static void set_etzpc_secure_configuration(void)


### PR DESCRIPTION
Remove static ETZPC configuration and rely on shared_resources
driver to dynamically configure secure aware resources.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
