### PR TITLE
plat-stm32mp1: map GPIOZ bank registers as secure

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -328,9 +328,9 @@ vaddr_t stm32_get_gpio_bank_base(unsigned int bank)
 	static struct io_pa_va gpios_nsec_base = { .pa = GPIOS_NSEC_BASE };
 	static struct io_pa_va gpioz_base = { .pa = GPIOZ_BASE };
 
-	/* Get non-secure mapping address for GPIOZ */
+	/* Get secure mapping address for GPIOZ */
 	if (bank == GPIO_BANK_Z)
-		return io_pa_or_va_nsec(&gpioz_base);
+		return io_pa_or_va_secure(&gpioz_base);
 
 	COMPILE_TIME_ASSERT(GPIO_BANK_A == 0);
 	assert(bank <= GPIO_BANK_K);


### PR DESCRIPTION
Fix GPZIOZ registers memory mapping that shall be mapped secure
for secure world to safely access the secure hardening configuration
registers of the bank.

Fixes: 68c4a16b37c7 ("stm32mp1: use phys_to_virt_io_secure() where expected")
Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
