### PR TITLE
core: libtomcrypt: fix return code in convert_ltc_verify_status()

### DIFF
--- a/core/lib/libtomcrypt/acipher_helpers.h
+++ b/core/lib/libtomcrypt/acipher_helpers.h
@@ -28,6 +28,7 @@ static inline TEE_Result convert_ltc_verify_status(int ltc_res, int ltc_stat)
 		else
 			return TEE_ERROR_SIGNATURE_INVALID;
 	case CRYPT_INVALID_PACKET:
+	case CRYPT_PK_INVALID_SIZE:
 		return TEE_ERROR_SIGNATURE_INVALID;
 	default:
 		return TEE_ERROR_GENERIC;


### PR DESCRIPTION
Calling TEE_AsymmetricVerifyDigest() with lnvalid RSA signature
length cause TA to panic. Introduced by commit:
a3f5668a0cae797a8eee1c0f3287983c5eb749eb

By GP TEE Internal Core specs, TEE_AsymmetricVerifyDigest()
shouldn't cause panic when call with invalid signature length.

Signed-off-by: Khoa Hoang <admin@khoahoang.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
