### PR TITLE
core: clang: add --apply-dynamic-relocs linker flag

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -11,7 +11,7 @@ AWK	 = awk
 
 link-ldflags  = $(LDFLAGS)
 ifeq ($(CFG_CORE_ASLR),y)
-link-ldflags += -pie -z notext -z norelro
+link-ldflags += -pie -z notext -z norelro $(ldflag-apply-dynamic-relocs)
 endif
 link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
 link-ldflags += --sort-section=alignment

--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -40,6 +40,11 @@ comp-cflags-warns-clang := -Wno-language-extension-token \
 libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) $(comp-cflags$(sm)) \
 			-print-libgcc-file-name 2> /dev/null)
 
+# Core ASLR relies on the executable being ready to run from its preferred load
+# address, because some symbols are used before the MMU is enabled and the
+# relocations are applied.
+ldflag-apply-dynamic-relocs := --apply-dynamic-relocs
+
 # Define these to something to discover accidental use
 CC		:= false
 CPP		:= false


### PR DESCRIPTION
Core ASLR relies on the executable being ready to run from its
preferred load address, because some symbols are used before the MMU is
enabled and relocations are applied. Clang (ld.lld) on Aarch64 needs a
special flag for this: --apply-dynamic-relocs. Without the flag the
R_AARCH64_RELATIVE places are initially filled with zeros.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
