### PR TITLE
lib: fix confine_array_index() for 32bit modes

### DIFF
--- a/lib/libutils/ext/include/confine_array_index.h
+++ b/lib/libutils/ext/include/confine_array_index.h
@@ -99,7 +99,15 @@ static inline size_t confine_array_index(size_t index, size_t size)
 	".syntax unified\n"
 	"cmp	%0, %1\n"
 	"it	cs\n"
+#ifdef __clang__
+#pragma clang diagnostic push
+	/* Avoid 'deprecated instruction in IT block [-Werror,-Winline-asm]' */
+#pragma clang diagnostic ignored "-Winline-asm"
+#endif
 	"movcs	%0, #0\n"
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 	".inst.n 0xf3af\t@ CSDB\n"
 	".inst.n 0x8014\t@ CSDB"
 	: "+r" (ret_val) : "r" (size) : "cc");

--- a/lib/libutils/ext/include/confine_array_index.h
+++ b/lib/libutils/ext/include/confine_array_index.h
@@ -86,7 +86,7 @@ static inline size_t confine_array_index(size_t index, size_t size) {
 #ifdef __arm__
 static inline size_t confine_array_index(size_t index, size_t size)
 {
-	size_t safe_index = 0;
+	size_t ret_val = index;
 
 	/*
 	 * For the ARMv7/AArch32 case we're basing the select and barrier
@@ -97,22 +97,22 @@ static inline size_t confine_array_index(size_t index, size_t size)
 #ifdef __thumb2__
       asm volatile (
 	".syntax unified\n"
-	"cmp	%1, %2\n" /* %1 holds the unsanitized index */
+	"cmp	%0, %1\n"
 	"it	cs\n"
-	"movcs	%1, #0\n"
+	"movcs	%0, #0\n"
 	".inst.n 0xf3af\t@ CSDB\n"
 	".inst.n 0x8014\t@ CSDB"
-	: "=r" (safe_index) : "r" (index), "r" (size) : "cc");
+	: "+r" (ret_val) : "r" (size) : "cc");
 #else
       asm volatile (
 	".syntax unified\n"
-	"cmp	%1, %2\n" /* %1 holds the unsanitized index */
-	"movcs	%1, #0\n"
+	"cmp	%0, %1\n" /* %0 holds the unsanitized index */
+	"movcs	%0, #0\n"
 	".inst	0xe320f014\t@ CSDB"
-	: "=r" (safe_index) : "r" (index), "r" (size) : "cc");
+	: "+r" (ret_val) : "r" (size) : "cc");
 #endif
 
-	return safe_index;
+	return ret_val;
 }
 #endif /* __arm__ */
 


### PR DESCRIPTION
Fix implementation of confine_array_index() for 32bit Arm and Thumb2
modes as previous implementation does not explicit the return value
and show issues with GCC 8.3 compiler.

Fixes: https://github.com/OP-TEE/optee_os/issues/3799
Fixes: 2b6dd0df52b4 ("confine_array_index.h: add A32 and T32 versions of confine_array_index()")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
Tested-by: Etienne Carriere <etienne.carriere@linaro.org> (qemu,qemu_v8)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
