### PR TITLE
core: clang: pager: use the normal linker (ld.lld)

### DIFF
--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -12,17 +12,6 @@ CC$(sm)		:= $(ccache-cmd)clang --target=$(clang-target)
 CPP$(sm)	:= $(ccache-cmd)clang --target=$(clang-target) -E
 LD$(sm)		:= $(ccache-cmd)ld.lld
 
-ifeq ($(sm)-$(CFG_WITH_PAGER),core-y)
-# Workaround an issue with all_objs.o and unpaged.o when CFG_WITH_PAGER=y:
-# ld.ldd merges .text.* sections into .text, even though the linker script does
-# not tell to do so. --relocatable would avoid that, but is not compatible with
-# --gc-sections. A trivial patch to ld.lld can fix the issue (in
-# lld/ELF/Writer.cpp, change elf::getOutputSectionName() to always return
-# s->name) so perhaps a new command line option could be proposed upstream?
-# Anyway, use GNU.ld for the moment.
-LDcore		:= $(CROSS_COMPILE_$(sm))ld
-endif
-
 AR$(sm)		:= $(ccache-cmd)llvm-ar
 NM$(sm)		:= llvm-nm
 OBJCOPY$(sm)	:= llvm-objcopy


### PR DESCRIPTION
Since LLVM commit [1] ("[ELF] Keep orphan section names (.rodata.foo
.text.foo) unchanged if !hasSectionsCommand"), ld.lld behaves like GNU
ld regarding output section names. So, we can remove our temporary hack.

This also fixes a build issue when a newer Clang (v11 master) is used
together with an older GNU ld (8.3 for instance) due to the latter not
supporting some GNU_PROPERTY_* values generated by the Clang compiler:

   LD      out/arm/core/tee.elf
 bin/aarch64-linux-gnu-ld: warning: out/arm/core/ta_pub_key.o: unsupported GNU_PROPERTY_TYPE (5) type: 0xc0000000
 ...

Link: [1] https://github.com/llvm/llvm-project/commit/9e33c096476a
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
