### PR TITLE
rpmb: remove unnecessary check

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2048,7 +2048,7 @@ static TEE_Result read_fat(struct rpmb_file_handle *fh, tee_mm_pool_t *p)
 		 * Look for an entry, matching filenames. (read, rm,
 		 * rename and stat.). Only store first filename match.
 		 */
-		if (fh->filename && (!strcmp(fh->filename, fe->filename)) &&
+		if ((!strcmp(fh->filename, fe->filename)) &&
 		    (fe->flags & FILE_IS_ACTIVE) && !entry_found) {
 			entry_found = true;
 			fh->rpmb_fat_address = fat_address;
@@ -2131,7 +2131,7 @@ static TEE_Result read_fat(struct rpmb_file_handle *fh, tee_mm_pool_t *p)
 		}
 	}
 
-	if (fh->filename && !fh->rpmb_fat_address)
+	if (!fh->rpmb_fat_address)
 		res = TEE_ERROR_ITEM_NOT_FOUND;
 
 out:


### PR DESCRIPTION
Remove unnecessary check to fix compile warning reported
by clang as following:

core/tee/tee_rpmb_fs.c:2051:11: warning: address of array 'fh->filename'
will always evaluate to 'true' [-Wpointer-bool-conversion]
                if (fh->filename && (!strcmp(fh->filename,
fe->filename)) &&
                    ~~~~^~~~~~~~ ~~
core/tee/tee_rpmb_fs.c:2134:10: warning: address of array 'fh->filename'
will always evaluate to 'true' [-Wpointer-bool-conversion]
        if (fh->filename && !fh->rpmb_fat_address)
            ~~~~^~~~~~~~ ~~
