### PR TITLE
plat-stm32mp1: fix timeout when seeding PRNG

### DIFF
--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -34,7 +34,7 @@
 #define RNG_SR_CEIS		BIT(5)
 #define RNG_SR_SEIS		BIT(6)
 
-#define RNG_TIMEOUT_US		1000
+#define RNG_TIMEOUT_US		10000
 
 struct stm32_rng_instance {
 	struct io_pa_va base;


### PR DESCRIPTION
When enabling STM32 RNG from reset state, it may take few milliseconds
for the RNG to be ready. Use a longer timeout to warm up RNG when it
is enabled.

Fixes panic at platform boot with trace:
E/TC:0 0 Panic at core/arch/arm/plat-stm32mp1/rng_seed.c:48 <plat_rng_init>

Fixes: 4e0397eed2e5 ("stm32mp1: seed PRNG with STM32 RNG")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
