### PR TITLE
core: sm: support SMCCC v1.1 specification

### DIFF
--- a/core/arch/arm/include/sm/sm.h
+++ b/core/arch/arm/include/sm/sm.h
@@ -118,13 +118,11 @@ enum sm_handler_ret {
 	SM_HANDLER_PENDING_SMC,
 };
 
-#ifdef CFG_SM_PLATFORM_HANDLER
 /*
  * Returns whether SMC was handled from platform handler in secure monitor
  * or if it shall reach OP-TEE core .
  */
 enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx);
-#endif
 
 void sm_save_unbanked_regs(struct sm_unbanked_regs *regs);
 void sm_restore_unbanked_regs(struct sm_unbanked_regs *regs);

--- a/core/arch/arm/include/sm/std_smc.h
+++ b/core/arch/arm/include/sm/std_smc.h
@@ -10,6 +10,21 @@
 /*                                      0x8400ff02 is reserved */
 #define ARM_STD_SVC_VERSION		0x8400ff03
 
+#define ARM_SMCCC_VERSION		0x80000000
+#define ARM_SMCCC_ARCH_FEATURES		0x80000001
+#define ARM_SMCCC_ARCH_SOC_ID		0x80000002
+#define ARM_SMCCC_ARCH_WORKAROUND_1	0x80008000
+#define ARM_SMCCC_ARCH_WORKAROUND_2	0x80007fff
+
+#define ARM_SMCCC_RET_SUCCESS		0
+#define ARM_SMCCC_RET_NOT_SUPPORTED	0xffffffff
+#define ARM_SMCCC_RET_NOT_REQUIRED	0xfffffffe
+#define ARM_SMCCC_RET_INVALID_PARAMETER	0xfffffffd
+
+#define SMCCC_V_1_0			0x10000
+#define SMCCC_V_1_1			0x10001
+#define SMCCC_V_1_2			0x10002
+
 /* ARM Standard Service Calls version numbers */
 #define STD_SVC_VERSION_MAJOR		0x0
 #define STD_SVC_VERSION_MINOR		0x1

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -15,6 +15,11 @@
 #include <string.h>
 #include "sm_private.h"
 
+enum sm_handler_ret __weak sm_platform_handler(struct sm_ctx *ctx __unused)
+{
+	return SM_HANDLER_PENDING_SMC;
+}
+
 static void smc_arch_handler(struct thread_smc_args *args)
 {
 	uint32_t smc_fid = args->a0;
@@ -62,10 +67,9 @@ uint32_t sm_from_nsec(struct sm_ctx *ctx)
 	COMPILE_TIME_ASSERT(!(offsetof(struct sm_ctx, nsec.r0) % 8));
 	COMPILE_TIME_ASSERT(!(sizeof(struct sm_ctx) % 8));
 
-#ifdef CFG_SM_PLATFORM_HANDLER
-	if (sm_platform_handler(ctx) == SM_HANDLER_SMC_HANDLED)
+	if (IS_ENABLED(CFG_SM_PLATFORM_HANDLER) &&
+	    sm_platform_handler(ctx) == SM_HANDLER_SMC_HANDLED)
 		return SM_EXIT_TO_NON_SECURE;
-#endif
 
 	switch (OPTEE_SMC_OWNER_NUM(args->a0)) {
 	case OPTEE_SMC_OWNER_STANDARD:

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2016, Linaro Limited
+ * Copyright (c) 2016-2020, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  */
 #include <arm.h>
 #include <compiler.h>
+#include <config.h>
 #include <kernel/misc.h>
+#include <kernel/thread.h>
 #include <platform_config.h>
 #include <sm/optee_smc.h>
 #include <sm/sm.h>
@@ -13,9 +15,43 @@
 #include <string.h>
 #include "sm_private.h"
 
+static void smc_arch_handler(struct thread_smc_args *args)
+{
+	uint32_t smc_fid = args->a0;
+	uint32_t feature_fid = args->a1;
+
+	switch (smc_fid) {
+	case ARM_SMCCC_VERSION:
+		args->a0 = SMCCC_V_1_1;
+		break;
+	case ARM_SMCCC_ARCH_FEATURES:
+		switch (feature_fid) {
+		case ARM_SMCCC_VERSION:
+		case ARM_SMCCC_ARCH_SOC_ID:
+			args->a0 = ARM_SMCCC_RET_SUCCESS;
+			break;
+		default:
+			args->a0 = ARM_SMCCC_RET_NOT_SUPPORTED;
+			break;
+		}
+		break;
+	case ARM_SMCCC_ARCH_SOC_ID:
+		args->a0 = ARM_SMCCC_RET_NOT_SUPPORTED;
+		break;
+	case ARM_SMCCC_ARCH_WORKAROUND_1:
+	case ARM_SMCCC_ARCH_WORKAROUND_2:
+		args->a0 = ARM_SMCCC_RET_NOT_REQUIRED;
+		break;
+	default:
+		args->a0 = OPTEE_SMC_RETURN_UNKNOWN_FUNCTION;
+		break;
+	}
+}
+
 uint32_t sm_from_nsec(struct sm_ctx *ctx)
 {
 	uint32_t *nsec_r0 = (uint32_t *)(&ctx->nsec.r0);
+	struct thread_smc_args *args = (struct thread_smc_args *)nsec_r0;
 
 	/*
 	 * Check that struct sm_ctx has the different parts properly
@@ -31,17 +67,24 @@ uint32_t sm_from_nsec(struct sm_ctx *ctx)
 		return SM_EXIT_TO_NON_SECURE;
 #endif
 
-#ifdef CFG_PSCI_ARM32
-	if (OPTEE_SMC_OWNER_NUM(*nsec_r0) == OPTEE_SMC_OWNER_STANDARD) {
-		smc_std_handler((struct thread_smc_args *)nsec_r0, &ctx->nsec);
+	switch (OPTEE_SMC_OWNER_NUM(args->a0)) {
+	case OPTEE_SMC_OWNER_STANDARD:
+		if (IS_ENABLED(CFG_PSCI_ARM32)) {
+			smc_std_handler(args, &ctx->nsec);
+			return SM_EXIT_TO_NON_SECURE;
+		}
+		break;
+	case OPTEE_SMC_OWNER_ARCH:
+		smc_arch_handler(args);
 		return SM_EXIT_TO_NON_SECURE;
+	default:
+		break;
 	}
-#endif
 
 	sm_save_unbanked_regs(&ctx->nsec.ub_regs);
 	sm_restore_unbanked_regs(&ctx->sec.ub_regs);
 
-	memcpy(&ctx->sec.r0, nsec_r0, sizeof(uint32_t) * 8);
+	memcpy(&ctx->sec.r0, args, sizeof(*args));
 	if (OPTEE_SMC_IS_FAST_CALL(ctx->sec.r0))
 		ctx->sec.mon_lr = (uint32_t)&thread_vector_table.fast_smc_entry;
 	else


### PR DESCRIPTION
SMCCC v1.1 specification: support defined function IDs with weak
handlers platform can override, as other PSCI function handler.

* `unsigned long arm_arch_version(void);`
    returns SMCCC_V_1_1

* `unsigned long arm_arch_feature(unsigned long a1);`
default supports version only

* `unsigned long arm_arch_soc_id(void);`
`unsigned long arm_arch_workaround_1(void);`
`unsigned long arm_arch_workaround_2(void);`
default return ARM_SMCCC_RET_NOT_SUPPORTED

This support is needed by Linux kernel (maybe U-Boot one day) drivers that rely on `arm_smccc_1_1()` supports. Linux kernel probes SMCCC v1.1 support to establish SMC/HVC conduit. Caller driver don't need to select smc/hvc.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
