### PR TITLE
libmbedtls: mbedtls_mpi_shrink(): fix possible unwanted truncation

### DIFF
--- a/lib/libmbedtls/mbedtls/library/bignum.c
+++ b/lib/libmbedtls/mbedtls/library/bignum.c
@@ -206,14 +206,14 @@ int mbedtls_mpi_shrink( mbedtls_mpi *X, size_t nblimbs )
 
     if( X->use_mempool )
     {
-        p = mempool_alloc( mbedtls_mpi_mempool, nblimbs * ciL );
+        p = mempool_alloc( mbedtls_mpi_mempool, i * ciL );
         if( p == NULL )
             return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
-        memset( p, 0, nblimbs * ciL );
+        memset( p, 0, i * ciL );
     }
     else
     {
-        p = (mbedtls_mpi_uint*)mbedtls_calloc( nblimbs, ciL );
+        p = (mbedtls_mpi_uint*)mbedtls_calloc( i, ciL );
         if( p == NULL )
             return( MBEDTLS_ERR_MPI_ALLOC_FAILED );
     }


### PR DESCRIPTION
If mbedtls_mpi_shrink() is passed a value for nblimbs that is smaller
than the minimum number of limbs required to store the big number, the
current implementation will unexpectedly truncate the number to the
requested size. It should use the minimal size instead in order not to
corrupt the bigum value.

This issue was introduced in [1] probably as a result of a bad copy
and paste from mbedtls_mpi_grow().

Fixes: [1] commit 98bd5fe350be ("libmbedtls: add mbedtls_mpi_init_mempool()")
Reported-by: Zhenke Ma <zhenke.ma@armchina.com>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
