### PR TITLE
stpmic1: fix missing parentheses in boot-on config

### DIFF
--- a/core/drivers/stpmic1.c
+++ b/core/drivers/stpmic1.c
@@ -721,7 +721,7 @@ int stpmic1_bo_voltage_unpg(struct stpmic1_bo_cfg *cfg)
 	if (stpmic1_register_read(cfg->ctrl_reg, &value))
 		return -1;
 
-	if (value & cfg->mask >= cfg->min_value)
+	if ((value & cfg->mask) >= cfg->min_value)
 		return 0;
 
 	return stpmic1_register_update(cfg->ctrl_reg, cfg->min_value,


### PR DESCRIPTION
Fix error reported by GCC [1]:

core/drivers/stpmic1.c: In function ‘stpmic1_bo_voltage_unpg’:
core/drivers/stpmic1.c:720:24: error: suggest parentheses around comparison in operand of ‘&’ [-Werror=parentheses]
  if (value & cfg->mask >= cfg->min_value)
              ~~~~~~~~~~^~~~~~~~~~~~~~~~~

Link: [1] arm-buildroot-linux-uclibcgnueabihf-gcc.br_real (Buildroot 2019.11-git-01409-gab8f872d0e-dirty) 8.3.0
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
