### PR TITLE
plat-stm32mp1: clock: fix MPUDIV support

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -483,8 +483,8 @@ static const uint8_t stm32mp1_mcu_div[16] = {
 };
 
 /* div = /1 /2 /4 /8 /16 : same divider for PMU and APBX */
-#define stm32mp1_mpu_div stm32mp1_mpu_apbx_div
-#define stm32mp1_apbx_div stm32mp1_mpu_apbx_div
+#define stm32mp1_mpu_div	stm32mp1_mpu_apbx_div
+#define stm32mp1_apbx_div	stm32mp1_mpu_apbx_div
 static const uint8_t stm32mp1_mpu_apbx_div[8] = {
 	0, 1, 2, 3, 4, 4, 4, 4
 };
@@ -706,7 +706,6 @@ static unsigned long stm32mp1_read_pll_freq(enum stm32mp1_pll_id pll_id,
 static unsigned long get_clock_rate(int p)
 {
 	uint32_t reg = 0;
-	uint32_t clkdiv = 0;
 	unsigned long clock = 0;
 	vaddr_t rcc_base = stm32_rcc_base();
 
@@ -725,12 +724,12 @@ static unsigned long get_clock_rate(int p)
 			clock = stm32mp1_read_pll_freq(_PLL1, _DIV_P);
 			break;
 		case RCC_MPCKSELR_PLL_MPUDIV:
-			clock = stm32mp1_read_pll_freq(_PLL1, _DIV_P);
-
 			reg = io_read32(rcc_base + RCC_MPCKDIVR);
-			clkdiv = reg & RCC_MPUDIV_MASK;
-			if (clkdiv)
-				clock /= stm32mp1_mpu_div[clkdiv];
+			if (reg & RCC_MPUDIV_MASK)
+				clock = stm32mp1_read_pll_freq(_PLL1, _DIV_P) >>
+					stm32mp1_mpu_div[reg & RCC_MPUDIV_MASK];
+			else
+				clock = 0;
 			break;
 		default:
 			break;


### PR DESCRIPTION
Fix implementation that divides clock with a value that in fact is
a bit shift value.

Fix implementation for getting MPU clock: when PMUDIV is zero,
MPU clock is disabled.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
