### PR TITLE
plat-stm32mp1: clock: enable some secure clocks at initialization

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1286,6 +1286,24 @@ static void get_osc_freq_from_dt(void *fdt)
 	}
 }
 
+static void enable_static_secure_clocks(void)
+{
+	unsigned int idx = 0;
+	static const unsigned long secure_enable[] = {
+		DDRC1, DDRC1LP, DDRC2, DDRC2LP, DDRPHYC, DDRPHYCLP, DDRCAPB,
+		AXIDCG, DDRPHYCAPB, DDRPHYCAPBLP, TZPC, TZC1, TZC2, STGEN_K,
+		BSEC,
+	};
+
+	for (idx = 0; idx < ARRAY_SIZE(secure_enable); idx++) {
+		stm32_clock_enable(secure_enable[idx]);
+		stm32mp_register_clock_parents_secure(secure_enable[idx]);
+	}
+
+	if (CFG_TEE_CORE_NB_CORE > 1)
+		stm32_clock_enable(RTCAPB);
+}
+
 static TEE_Result stm32mp1_clk_early_init(void)
 {
 	void *fdt = NULL;
@@ -1347,6 +1365,8 @@ static TEE_Result stm32mp1_clk_early_init(void)
 
 	if (ignored != 0)
 		IMSG("DT clock tree configurations were ignored");
+
+	enable_static_secure_clocks();
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
With this change some system clocks are enabled by Core at
boot time and have a reference counter synchronized with
the clock hardware state. RTCAPB must be enabled for secondary
cores to boot, if any.

This change also ensures these secure clocks are derived from
secure clocks.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
