### PR TITLE
plat-stm32mp1: enable IO compensation at boot time

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -380,6 +380,7 @@ static const struct stm32mp1_clk_gate stm32mp1_clk_gate[] = {
 #ifdef CFG_WITH_NSEC_UARTS
 	_CLK_SC_SELEC(N_S, RCC_MP_APB2ENSETR, 13, USART6_K, _UART6_SEL),
 #endif
+	_CLK_SC_FIXED(N_S, RCC_MP_APB3ENSETR, 11, SYSCFG, _UNKNOWN_ID),
 	_CLK_SC_SELEC(N_S, RCC_MP_APB4ENSETR, 8, DDRPERFM, _UNKNOWN_SEL),
 	_CLK_SC_SELEC(N_S, RCC_MP_APB4ENSETR, 15, IWDG2, _UNKNOWN_SEL),
 
@@ -1224,8 +1225,6 @@ void stm32mp_register_clock_parents_secure(unsigned long clock_id)
 }
 
 #ifdef CFG_EMBED_DTB
-#define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"
-
 static const char *stm32mp_osc_node_label[NB_OSC] = {
 	[_LSI] = "clk-lsi",
 	[_LSE] = "clk-lse",

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -538,6 +538,8 @@
 #define RCC_MP_IWDGFZSETR_IWDG1			BIT(0)
 #define RCC_MP_IWDGFZSETR_IWDG2			BIT(1)
 
+#define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"
+
 #ifndef __ASSEMBLER__
 vaddr_t stm32_rcc_base(void);
 

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019-2020, STMicroelectronics
+ */
+
+#include <dt-bindings/clock/stm32mp1-clks.h>
+#include <initcall.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <stm32_util.h>
+#include <io.h>
+#include <trace.h>
+#include <types_ext.h>
+
+/*
+ * SYSCFG register offsets (base relative)
+ */
+#define SYSCFG_CMPCR				0x20U
+#define SYSCFG_CMPENSETR			0x24U
+
+/*
+ * SYSCFG_CMPCR Register
+ */
+#define SYSCFG_CMPCR_SW_CTRL			BIT(1)
+#define SYSCFG_CMPCR_READY			BIT(8)
+#define SYSCFG_CMPCR_RANSRC			GENMASK_32(19, 16)
+#define SYSCFG_CMPCR_RANSRC_SHIFT		16
+#define SYSCFG_CMPCR_RAPSRC			GENMASK_32(23, 20)
+#define SYSCFG_CMPCR_ANSRC_SHIFT		24
+
+#define SYSCFG_CMPCR_READY_TIMEOUT_US		1000U
+
+/*
+ * SYSCFG_CMPENSETR Register
+ */
+#define SYSCFG_CMPENSETR_MPU_EN			BIT(0)
+
+static vaddr_t get_syscfg_base(void)
+{
+	struct io_pa_va base = { .pa = SYSCFG_BASE };
+
+	return io_pa_or_va(&base);
+}
+
+void stm32mp_syscfg_enable_io_compensation(void)
+{
+	vaddr_t syscfg_base = get_syscfg_base();
+	uint64_t timeout_ref = 0;
+
+	stm32_clock_enable(CK_CSI);
+	stm32_clock_enable(SYSCFG);
+
+	io_setbits32(syscfg_base + SYSCFG_CMPENSETR, SYSCFG_CMPENSETR_MPU_EN);
+
+	timeout_ref = timeout_init_us(SYSCFG_CMPCR_READY_TIMEOUT_US);
+
+	while (!(io_read32(syscfg_base + SYSCFG_CMPCR) & SYSCFG_CMPCR_READY))
+		if (timeout_elapsed(timeout_ref)) {
+			EMSG("IO compensation cell not ready");
+			/* Allow an almost silent failure here */
+			break;
+		}
+
+	io_clrbits32(syscfg_base + SYSCFG_CMPCR, SYSCFG_CMPCR_SW_CTRL);
+
+	DMSG("SYSCFG.cmpcr = %#"PRIx32, io_read32(syscfg_base + SYSCFG_CMPCR));
+}
+
+void stm32mp_syscfg_disable_io_compensation(void)
+{
+	vaddr_t syscfg_base = get_syscfg_base();
+	uint32_t value = 0;
+
+	value = io_read32(syscfg_base + SYSCFG_CMPCR) >>
+		SYSCFG_CMPCR_ANSRC_SHIFT;
+
+	io_clrbits32(syscfg_base + SYSCFG_CMPCR,
+		     SYSCFG_CMPCR_RANSRC | SYSCFG_CMPCR_RAPSRC);
+
+	value = io_read32(syscfg_base + SYSCFG_CMPCR) |
+		(value << SYSCFG_CMPCR_RANSRC_SHIFT);
+
+	io_write32(syscfg_base + SYSCFG_CMPCR, value | SYSCFG_CMPCR_SW_CTRL);
+
+	DMSG("SYSCFG.cmpcr = %#"PRIx32, io_read32(syscfg_base + SYSCFG_CMPCR));
+
+	io_clrbits32(syscfg_base + SYSCFG_CMPENSETR, SYSCFG_CMPENSETR_MPU_EN);
+
+	stm32_clock_disable(SYSCFG);
+	stm32_clock_disable(CK_CSI);
+}
+
+static TEE_Result stm32mp1_iocomp(void)
+{
+	stm32mp_syscfg_enable_io_compensation();
+
+	return TEE_SUCCESS;
+}
+driver_init(stm32mp1_iocomp);

--- a/core/arch/arm/plat-stm32mp1/drivers/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/drivers/sub.mk
@@ -1,3 +1,4 @@
 srcs-y 	+= stm32mp1_clk.c
 srcs-y 	+= stm32mp1_pwr.c
 srcs-y 	+= stm32mp1_rcc.c
+srcs-y 	+= stm32mp1_syscfg.c

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -53,6 +53,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, I2C6_BASE, SMALL_PAGE_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, PWR_BASE, SMALL_PAGE_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, RCC_BASE, SMALL_PAGE_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, RNG1_BASE, SMALL_PAGE_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SYSCFG_BASE, SMALL_PAGE_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, TAMP_BASE, SMALL_PAGE_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, USART1_BASE, SMALL_PAGE_SIZE);
 

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -39,6 +39,7 @@
 #define RNG1_BASE			0x54003000
 #define RTC_BASE			0x5c004000
 #define SPI6_BASE			0x5c001000
+#define SYSCFG_BASE			0x50020000
 #define SYSRAM_BASE			0x2ffc0000
 #define TAMP_BASE			0x5c00a000
 #define UART1_BASE			0x5c000000

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -15,6 +15,13 @@
 /* Backup registers and RAM utils */
 vaddr_t stm32mp_bkpreg(unsigned int idx);
 
+/*
+ * SYSCFG IO compensation.
+ * These functions assume non-secure world is suspended.
+ */
+void stm32mp_syscfg_enable_io_compensation(void);
+void stm32mp_syscfg_disable_io_compensation(void);
+
 /* Platform util for the GIC */
 vaddr_t get_gicc_base(void);
 vaddr_t get_gicd_base(void);


### PR DESCRIPTION
Implement platform functions stm32mp_syscfg_enable_io_compensation()
and stm32mp_syscfg_disable_io_compensation() to enable/disable
STM23MP1 IO compensation. Enable IO compensation when platform boots.

This change defines SYSCFG clock that is needed and moves definition
of the RCC compatible string DT_RCC_CLK_COMPAT to RCC header file so
that it can be shared with stm32mp1_syscfg.c.

Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
