### PR TITLE
[RFC] Rename KEEP_INIT() and KEEP_PAGER()

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -73,7 +73,7 @@ static uint32_t spin_table[CFG_TEE_CORE_NB_CORE];
  * When 1, it has started
  */
 uint32_t sem_cpu_sync[CFG_TEE_CORE_NB_CORE];
-KEEP_PAGER(sem_cpu_sync);
+DECLARE_KEEP_PAGER(sem_cpu_sync);
 #endif
 
 #ifdef CFG_DT
@@ -93,7 +93,7 @@ static uint32_t cntfrq;
 __weak void plat_primary_init_early(void)
 {
 }
-KEEP_PAGER(plat_primary_init_early);
+DECLARE_KEEP_PAGER(plat_primary_init_early);
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
 __weak void main_init_gic(void)
@@ -1185,7 +1185,7 @@ static void init_primary_helper(unsigned long pageable_part,
 }
 
 /* What this function is using is needed each time another CPU is started */
-KEEP_PAGER(generic_boot_get_handlers);
+DECLARE_KEEP_PAGER(generic_boot_get_handlers);
 
 static void init_secondary_helper(unsigned long nsec_entry)
 {

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -73,7 +73,7 @@ UNWIND(	.fnstart)
 	bx	lr
 UNWIND(	.fnend)
 END_FUNC plat_cpu_reset_early
-KEEP_PAGER plat_cpu_reset_early
+DECLARE_KEEP_PAGER plat_cpu_reset_early
 .weak plat_cpu_reset_early
 
 	.section .identity_map, "ax"
@@ -253,7 +253,7 @@ UNWIND(	.cantunwind)
 #endif
 UNWIND(	.fnend)
 END_FUNC _start
-KEEP_INIT _start
+DECLARE_KEEP_INIT _start
 
 	/*
 	 * Setup sp to point to the top of the tmp stack for the current CPU:
@@ -812,7 +812,7 @@ UNWIND(	.cantunwind)
 	bx	r6
 UNWIND(	.fnend)
 END_FUNC cpu_on_handler
-KEEP_PAGER cpu_on_handler
+DECLARE_KEEP_PAGER cpu_on_handler
 
 #else /* defined(CFG_WITH_ARM_TRUSTED_FW) */
 
@@ -870,5 +870,5 @@ UNWIND(	.cantunwind)
 	b	.	/* SMC should not return */
 UNWIND(	.fnend)
 END_FUNC reset_secondary
-KEEP_PAGER reset_secondary
+DECLARE_KEEP_PAGER reset_secondary
 #endif /* defined(CFG_WITH_ARM_TRUSTED_FW) */

--- a/core/arch/arm/kernel/generic_entry_a64.S
+++ b/core/arch/arm/kernel/generic_entry_a64.S
@@ -241,7 +241,7 @@ clear_nex_bss:
 	smc	#0
 	b	.	/* SMC should not return */
 END_FUNC _start
-KEEP_INIT _start
+DECLARE_KEEP_INIT _start
 
 	.balign	8
 LOCAL_DATA cached_mem_end , :
@@ -404,7 +404,7 @@ FUNC cpu_on_handler , :
 	mov	x30, x21
 	b	generic_boot_cpu_on_handler
 END_FUNC cpu_on_handler
-KEEP_PAGER cpu_on_handler
+DECLARE_KEEP_PAGER cpu_on_handler
 
 LOCAL_FUNC unhandled_cpu , :
 	wfi

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -114,8 +114,8 @@ const uint32_t stack_tmp_stride __section(".identity_map.stack_tmp_stride") =
  * These stack setup info are required by secondary boot cores before they
  * each locally enable the pager (the mmu). Hence kept in pager sections.
  */
-KEEP_PAGER(stack_tmp_export);
-KEEP_PAGER(stack_tmp_stride);
+DECLARE_KEEP_PAGER(stack_tmp_export);
+DECLARE_KEEP_PAGER(stack_tmp_stride);
 
 thread_pm_handler_t thread_cpu_on_handler_ptr __nex_bss;
 thread_pm_handler_t thread_cpu_off_handler_ptr __nex_bss;

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -225,7 +225,7 @@ UNWIND(	.fnstart)
 	bx	lr
 UNWIND(	.fnend)
 END_FUNC thread_init_vbar
-KEEP_PAGER thread_init_vbar
+DECLARE_KEEP_PAGER thread_init_vbar
 
 /*
  * Below are low level routines handling entry and return from user mode.

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -67,7 +67,7 @@ FUNC thread_init_vbar , :
 	msr	vbar_el1, x0
 	ret
 END_FUNC thread_init_vbar
-KEEP_PAGER thread_init_vbar
+DECLARE_KEEP_PAGER thread_init_vbar
 
 /*
  * uint32_t __thread_enter_user_mode(struct thread_ctx_regs *regs,
@@ -123,7 +123,7 @@ FUNC __thread_enter_user_mode , :
 	/* Jump into user mode */
 	b eret_to_el0
 END_FUNC __thread_enter_user_mode
-KEEP_PAGER __thread_enter_user_mode
+DECLARE_KEEP_PAGER __thread_enter_user_mode
 
 /*
  * void thread_unwind_user_mode(uint32_t ret, uint32_t exit_status0,

--- a/core/arch/arm/kernel/thread_optee_smc_a32.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a32.S
@@ -204,7 +204,7 @@ UNWIND(	.cantunwind)
 	b	vector_system_reset_entry
 UNWIND(	.fnend)
 END_FUNC thread_vector_table
-KEEP_PAGER thread_vector_table
+DECLARE_KEEP_PAGER thread_vector_table
 
 FUNC thread_std_smc_entry , :
 UNWIND(	.fnstart)
@@ -270,7 +270,7 @@ UNWIND(	.save	{r0, lr})
 	bx	lr
 UNWIND(	.fnend)
 END_FUNC thread_rpc
-KEEP_PAGER thread_rpc
+DECLARE_KEEP_PAGER thread_rpc
 
 /*
  * void thread_foreign_intr_exit(uint32_t thread_index)

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -156,7 +156,7 @@ FUNC thread_vector_table , : , .identity_map
 	b	vector_system_off_entry
 	b	vector_system_reset_entry
 END_FUNC thread_vector_table
-KEEP_PAGER thread_vector_table
+DECLARE_KEEP_PAGER thread_vector_table
 
 FUNC thread_std_smc_entry , :
 	bl	__thread_std_smc_entry
@@ -230,7 +230,7 @@ FUNC thread_rpc , :
 	store_wregs x16, 0, 0, 3	/* Store w0-w3 into rv[] */
 	ret
 END_FUNC thread_rpc
-KEEP_PAGER thread_rpc
+DECLARE_KEEP_PAGER thread_rpc
 
 /*
  * void thread_foreign_intr_exit(uint32_t thread_index)

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -777,7 +777,7 @@ void core_init_mmu_regs(struct core_mmu_config *cfg)
 	 */
 	cfg->ttbcr = TTBCR_N_VALUE;
 }
-KEEP_PAGER(core_init_mmu_regs);
+DECLARE_KEEP_PAGER(core_init_mmu_regs);
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fsr)
 {

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -71,7 +71,7 @@ static TEE_Result mobj_phys_get_pa(struct mobj *mobj, size_t offs,
 	*pa = p;
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(mobj_phys_get_pa);
+DECLARE_KEEP_PAGER(mobj_phys_get_pa);
 
 static TEE_Result mobj_phys_get_cattr(struct mobj *mobj, uint32_t *cattr)
 {
@@ -236,7 +236,7 @@ static TEE_Result mobj_mm_get_pa(struct mobj *mobj, size_t offs,
 	return mobj_get_pa(to_mobj_mm(mobj)->parent_mobj,
 			   mobj_mm_offs(mobj, offs), granule, pa);
 }
-KEEP_PAGER(mobj_mm_get_pa);
+DECLARE_KEEP_PAGER(mobj_mm_get_pa);
 
 static size_t mobj_mm_get_phys_offs(struct mobj *mobj, size_t granule)
 {
@@ -346,7 +346,7 @@ static TEE_Result mobj_shm_get_pa(struct mobj *mobj, size_t offs,
 	*pa = p;
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(mobj_shm_get_pa);
+DECLARE_KEEP_PAGER(mobj_shm_get_pa);
 
 static size_t mobj_shm_get_phys_offs(struct mobj *mobj, size_t granule)
 {
@@ -614,7 +614,7 @@ static TEE_Result mobj_with_fobj_get_pa(struct mobj *mobj, size_t offs,
 
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(mobj_with_fobj_get_pa);
+DECLARE_KEEP_PAGER(mobj_with_fobj_get_pa);
 
 static const struct mobj_ops mobj_with_fobj_ops __rodata_unpaged = {
 	.matches = mobj_with_fobj_matches,

--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -92,7 +92,7 @@ static TEE_Result mobj_reg_shm_get_pa(struct mobj *mobj, size_t offst,
 
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(mobj_reg_shm_get_pa);
+DECLARE_KEEP_PAGER(mobj_reg_shm_get_pa);
 
 static size_t mobj_reg_shm_get_phys_offs(struct mobj *mobj,
 					 size_t granule __maybe_unused)

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -523,7 +523,7 @@ static void area_insert(struct tee_pager_area_head *head,
 
 	pager_unlock(exceptions);
 }
-KEEP_PAGER(area_insert);
+DECLARE_KEEP_PAGER(area_insert);
 
 void tee_pager_add_core_area(vaddr_t base, enum tee_pager_area_type type,
 			     struct fobj *fobj)
@@ -699,7 +699,7 @@ static void unlink_area(struct tee_pager_area_head *area_head,
 
 	pager_unlock(exceptions);
 }
-KEEP_PAGER(unlink_area);
+DECLARE_KEEP_PAGER(unlink_area);
 
 static void free_area(struct tee_pager_area *area)
 {
@@ -854,7 +854,7 @@ static void split_area(struct tee_pager_area_head *area_head,
 
 	pager_unlock(exceptions);
 }
-KEEP_PAGER(split_area);
+DECLARE_KEEP_PAGER(split_area);
 
 TEE_Result tee_pager_split_um_region(struct user_mode_ctx *uctx, vaddr_t va)
 {
@@ -891,7 +891,7 @@ static void merge_area_with_next(struct tee_pager_area_head *area_head,
 
 	pager_unlock(exceptions);
 }
-KEEP_PAGER(merge_area_with_next);
+DECLARE_KEEP_PAGER(merge_area_with_next);
 
 void tee_pager_merge_um_region(struct user_mode_ctx *uctx, vaddr_t va,
 			       size_t len)
@@ -972,7 +972,7 @@ static void rem_area(struct tee_pager_area_head *area_head,
 
 	free_area(area);
 }
-KEEP_PAGER(rem_area);
+DECLARE_KEEP_PAGER(rem_area);
 
 void tee_pager_rem_um_region(struct user_mode_ctx *uctx, vaddr_t base,
 			     size_t size)
@@ -1108,7 +1108,7 @@ out:
 	return ret;
 }
 
-KEEP_PAGER(tee_pager_set_um_area_attr);
+DECLARE_KEEP_PAGER(tee_pager_set_um_area_attr);
 #endif /*CFG_PAGED_USER_TA*/
 
 void tee_pager_invalidate_fobj(struct fobj *fobj)
@@ -1127,7 +1127,7 @@ void tee_pager_invalidate_fobj(struct fobj *fobj)
 
 	pager_unlock(exceptions);
 }
-KEEP_PAGER(tee_pager_invalidate_fobj);
+DECLARE_KEEP_PAGER(tee_pager_invalidate_fobj);
 
 static struct tee_pager_pmem *pmem_find(struct tee_pager_area *area,
 					unsigned int tblidx)
@@ -1713,7 +1713,7 @@ out:
 
 	pager_unlock(exceptions);
 }
-KEEP_PAGER(tee_pager_pgt_save_and_release_entries);
+DECLARE_KEEP_PAGER(tee_pager_pgt_save_and_release_entries);
 #endif /*CFG_PAGED_USER_TA*/
 
 void tee_pager_release_phys(void *addr, size_t size)
@@ -1742,7 +1742,7 @@ void tee_pager_release_phys(void *addr, size_t size)
 
 	pager_unlock(exceptions);
 }
-KEEP_PAGER(tee_pager_release_phys);
+DECLARE_KEEP_PAGER(tee_pager_release_phys);
 
 void *tee_pager_alloc(size_t size)
 {

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -385,7 +385,7 @@ static const struct stm32mp1_clk_gate stm32mp1_clk_gate[] = {
 
 	_CLK_SELEC(N_S, RCC_DBGCFGR, 8, CK_DBG, _UNKNOWN_SEL),
 };
-KEEP_PAGER(stm32mp1_clk_gate);
+DECLARE_KEEP_PAGER(stm32mp1_clk_gate);
 
 /* Parents for secure aware clocks in the xxxSELR value ordering */
 static const uint8_t stgen_parents[] = {

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -696,7 +696,7 @@ static TEE_Result gpioz_pm(enum pm_op op, uint32_t pm_hint __unused,
 
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(gpioz_pm);
+DECLARE_KEEP_PAGER(gpioz_pm);
 
 static TEE_Result stm32mp1_init_final_shres(void)
 {

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -142,7 +142,7 @@ static struct itr_handler console_itr = {
 	.flags = ITRF_TRIGGER_LEVEL,
 	.handler = console_itr_cb,
 };
-KEEP_PAGER(console_itr);
+DECLARE_KEEP_PAGER(console_itr);
 
 static TEE_Result init_console_itr(void)
 {

--- a/core/arch/arm/sm/sm_a32.S
+++ b/core/arch/arm/sm/sm_a32.S
@@ -416,7 +416,7 @@ UNWIND(	.fnstart)
 
 	bx	lr
 END_FUNC sm_init
-KEEP_PAGER sm_init
+DECLARE_KEEP_PAGER sm_init
 
 
 /* struct sm_nsec_ctx *sm_get_nsec_ctx(void); */

--- a/core/drivers/bcm_gpio.c
+++ b/core/drivers/bcm_gpio.c
@@ -149,7 +149,7 @@ static const struct gpio_ops bcm_gpio_ops = {
 	.get_interrupt = iproc_gpio_get_itr,
 	.set_interrupt = iproc_gpio_set_itr,
 };
-KEEP_PAGER(bcm_gpio_ops);
+DECLARE_KEEP_PAGER(bcm_gpio_ops);
 
 void iproc_gpio_set_secure(int gpiopin)
 {

--- a/core/drivers/cdns_uart.c
+++ b/core/drivers/cdns_uart.c
@@ -109,7 +109,7 @@ static const struct serial_ops cdns_uart_ops = {
 	.have_rx_data = cdns_uart_have_rx_data,
 	.putc = cdns_uart_putc,
 };
-KEEP_PAGER(cdns_uart_ops);
+DECLARE_KEEP_PAGER(cdns_uart_ops);
 
 /*
  * we rely on the bootloader having set up the HW correctly, we just enable

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -84,7 +84,7 @@ static const struct itr_ops gic_ops = {
 	.raise_sgi = gic_op_raise_sgi,
 	.set_affinity = gic_op_set_affinity,
 };
-KEEP_PAGER(gic_ops);
+DECLARE_KEEP_PAGER(gic_ops);
 
 static size_t probe_max_it(vaddr_t gicc_base __maybe_unused, vaddr_t gicd_base)
 {

--- a/core/drivers/hi16xx_uart.c
+++ b/core/drivers/hi16xx_uart.c
@@ -108,7 +108,7 @@ static const struct serial_ops hi16xx_uart_ops = {
 	.have_rx_data = hi16xx_uart_have_rx_data,
 	.putc = hi16xx_uart_putc,
 };
-KEEP_PAGER(hi16xx_uart_ops);
+DECLARE_KEEP_PAGER(hi16xx_uart_ops);
 
 void hi16xx_uart_init(struct hi16xx_uart_data *pd, paddr_t base,
 		      uint32_t uart_clk, uint32_t baud_rate)

--- a/core/drivers/imx_lpuart.c
+++ b/core/drivers/imx_lpuart.c
@@ -59,7 +59,7 @@ static const struct serial_ops imx_lpuart_ops = {
 	.getchar = imx_lpuart_getchar,
 	.putc = imx_lpuart_putc,
 };
-KEEP_PAGER(imx_lpuart_ops);
+DECLARE_KEEP_PAGER(imx_lpuart_ops);
 
 void imx_uart_init(struct imx_uart_data *pd, paddr_t base)
 {

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -127,7 +127,7 @@ static const struct serial_ops imx_uart_ops = {
 	.getchar = imx_uart_getchar,
 	.putc = imx_uart_putc,
 };
-KEEP_PAGER(imx_uart_ops);
+DECLARE_KEEP_PAGER(imx_uart_ops);
 
 void imx_uart_init(struct imx_uart_data *pd, paddr_t base)
 {

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -86,7 +86,7 @@ void imx_wdog_restart(void)
 	while (1)
 		;
 }
-KEEP_PAGER(imx_wdog_restart);
+DECLARE_KEEP_PAGER(imx_wdog_restart);
 
 #if defined(CFG_DT) && !defined(CFG_EXTERNAL_DTB_OVERLAY)
 static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)

--- a/core/drivers/mvebu_uart.c
+++ b/core/drivers/mvebu_uart.c
@@ -112,7 +112,7 @@ static const struct serial_ops mvebu_uart_ops = {
 	.have_rx_data = mvebu_uart_have_rx_data,
 	.putc = mvebu_uart_putc,
 };
-KEEP_PAGER(mvebu_uart_ops);
+DECLARE_KEEP_PAGER(mvebu_uart_ops);
 
 void mvebu_uart_init(struct mvebu_uart_data *pd, paddr_t pbase,
 		uint32_t uart_clk, uint32_t baud_rate)

--- a/core/drivers/ns16550.c
+++ b/core/drivers/ns16550.c
@@ -76,7 +76,7 @@ static const struct serial_ops ns16550_ops = {
 	.flush = ns16550_flush,
 	.putc = ns16550_putc,
 };
-KEEP_PAGER(ns16550_ops);
+DECLARE_KEEP_PAGER(ns16550_ops);
 
 void ns16550_init(struct ns16550_data *pd, paddr_t base)
 {

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -132,7 +132,7 @@ static const struct serial_ops pl011_ops = {
 	.have_rx_data = pl011_have_rx_data,
 	.putc = pl011_putc,
 };
-KEEP_PAGER(pl011_ops);
+DECLARE_KEEP_PAGER(pl011_ops);
 
 void pl011_init(struct pl011_data *pd, paddr_t pbase, uint32_t uart_clk,
 		uint32_t baud_rate)

--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -499,7 +499,7 @@ static const struct spi_ops pl022_ops = {
 	.txrx16 = pl022_txrx16,
 	.end = pl022_end,
 };
-KEEP_PAGER(pl022_ops);
+DECLARE_KEEP_PAGER(pl022_ops);
 
 void pl022_init(struct pl022_data *pd)
 {

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -165,7 +165,7 @@ static const struct gpio_ops pl061_ops = {
 	.get_interrupt = pl061_get_interrupt,
 	.set_interrupt = pl061_set_interrupt,
 };
-KEEP_PAGER(pl061_ops);
+DECLARE_KEEP_PAGER(pl061_ops);
 
 /*
  * Initialize PL061 GPIO controller

--- a/core/drivers/scif.c
+++ b/core/drivers/scif.c
@@ -77,7 +77,7 @@ static const struct serial_ops scif_uart_ops = {
 	.flush = scif_uart_flush,
 	.putc = scif_uart_putc,
 };
-KEEP_PAGER(scif_uart_ops);
+DECLARE_KEEP_PAGER(scif_uart_ops);
 
 void scif_uart_init(struct scif_uart_data *pd, paddr_t base)
 {

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -84,7 +84,7 @@ static const struct serial_ops serial8250_uart_ops = {
 	.have_rx_data = serial8250_uart_have_rx_data,
 	.putc = serial8250_uart_putc,
 };
-KEEP_PAGER(serial8250_uart_ops);
+DECLARE_KEEP_PAGER(serial8250_uart_ops);
 
 void serial8250_uart_init(struct serial8250_uart_data *pd, paddr_t base,
 			  uint32_t __unused uart_clk,

--- a/core/drivers/sp805_wdt.c
+++ b/core/drivers/sp805_wdt.c
@@ -96,7 +96,7 @@ static enum itr_return wdt_itr_cb(struct itr_handler *h)
 
 	return ITRR_HANDLED;
 }
-KEEP_PAGER(wdt_itr_cb);
+DECLARE_KEEP_PAGER(wdt_itr_cb);
 
 TEE_Result sp805_register_itr_handler(struct sp805_wdt_data *pd,
 				      uint32_t itr_num, uint32_t itr_flags,
@@ -129,7 +129,7 @@ static const struct wdt_ops sp805_wdt_ops = {
 	.ping = sp805_ping,
 	.set_timeout = sp805_setload,
 };
-KEEP_PAGER(sp805_wdt_ops);
+DECLARE_KEEP_PAGER(sp805_wdt_ops);
 
 TEE_Result sp805_wdt_init(struct sp805_wdt_data *pd, paddr_t base,
 		    uint32_t clk_rate, uint32_t timeout)

--- a/core/drivers/sprd_uart.c
+++ b/core/drivers/sprd_uart.c
@@ -87,7 +87,7 @@ static const struct serial_ops sprd_uart_ops = {
 	.have_rx_data = sprd_uart_have_rx_data,
 	.putc = sprd_uart_putc,
 };
-KEEP_PAGER(sprd_uart_ops);
+DECLARE_KEEP_PAGER(sprd_uart_ops);
 
 void sprd_uart_init(struct sprd_uart_data *pd, paddr_t base)
 {

--- a/core/drivers/stih_asc.c
+++ b/core/drivers/stih_asc.c
@@ -44,7 +44,7 @@ static const struct serial_ops stih_asc_ops = {
 	.flush = stih_asc_flush,
 	.putc = stih_asc_putc,
 };
-KEEP_PAGER(stih_asc_ops);
+DECLARE_KEEP_PAGER(stih_asc_ops);
 
 void stih_asc_init(struct stih_asc_pd *pd, vaddr_t base)
 {

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -244,7 +244,7 @@ static TEE_Result etzpc_pm(enum pm_op op, unsigned int pm_hint __unused,
 
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(etzpc_pm);
+DECLARE_KEEP_PAGER(etzpc_pm);
 
 static void init_pm(struct etzpc_instance *dev)
 {

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -97,7 +97,7 @@ static const struct serial_ops stm32_uart_serial_ops = {
 	.getchar = loc_getchar,
 
 };
-KEEP_PAGER(stm32_uart_serial_ops);
+DECLARE_KEEP_PAGER(stm32_uart_serial_ops);
 
 void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base)
 {

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -7,7 +7,7 @@
 
 #ifdef __ASSEMBLER__
 
-	.macro KEEP_PAGER sym
+	.macro DECLARE_KEEP_PAGER sym
 	.pushsection __keep_meta_vars_pager
 	.global ____keep_pager_\sym
 	____keep_pager_\sym:
@@ -15,7 +15,7 @@
 	.popsection
 	.endm
 
-	.macro KEEP_INIT sym
+	.macro DECLARE_KEEP_INIT sym
 	.pushsection __keep_meta_vars_init
 	.global ____keep_init_\sym
 	____keep_init_\sym:
@@ -27,21 +27,21 @@
 
 #include <compiler.h>
 
-#define __KEEP_PAGER2(sym, file_id) \
+#define __DECLARE_KEEP_PAGER2(sym, file_id) \
 	extern const unsigned long ____keep_pager_##sym; \
 	const unsigned long ____keep_pager_##sym##_##file_id  \
 		__section("__keep_meta_vars_pager") = (unsigned long)&(sym)
 
-#define __KEEP_PAGER1(sym, file_id)	__KEEP_PAGER2(sym, file_id)
-#define KEEP_PAGER(sym)			__KEEP_PAGER1(sym, __FILE_ID__)
+#define __DECLARE_KEEP_PAGER1(sym, file_id) __DECLARE_KEEP_PAGER2(sym, file_id)
+#define DECLARE_KEEP_PAGER(sym) __DECLARE_KEEP_PAGER1(sym, __FILE_ID__)
 
-#define __KEEP_INIT2(sym, file_id) \
+#define __DECLARE_KEEP_INIT2(sym, file_id) \
 	extern const unsigned long ____keep_init_##sym##file_id; \
 	const unsigned long ____keep_init_##sym##_##file_id  \
 		__section("__keep_meta_vars_init") = (unsigned long)&(sym)
 
-#define __KEEP_INIT1(sym, file_id)	__KEEP_INIT2(sym, file_id)
-#define KEEP_INIT(sym)			__KEEP_INIT1(sym, __FILE_ID__)
+#define __DECLARE_KEEP_INIT1(sym, file_id) __DECLARE_KEEP_INIT2(sym, file_id)
+#define DECLARE_KEEP_INIT(sym) __DECLARE_KEEP_INIT1(sym, __FILE_ID__)
 
 #endif /* __ASSEMBLER__ */
 

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -30,7 +30,7 @@
 #define __KEEP_PAGER2(sym, file_id) \
 	extern const unsigned long ____keep_pager_##sym; \
 	const unsigned long ____keep_pager_##sym##_##file_id  \
-		__section("__keep_meta_vars_pager") = (unsigned long)&sym
+		__section("__keep_meta_vars_pager") = (unsigned long)&(sym)
 
 #define __KEEP_PAGER1(sym, file_id)	__KEEP_PAGER2(sym, file_id)
 #define KEEP_PAGER(sym)			__KEEP_PAGER1(sym, __FILE_ID__)
@@ -38,7 +38,7 @@
 #define __KEEP_INIT2(sym, file_id) \
 	extern const unsigned long ____keep_init_##sym##file_id; \
 	const unsigned long ____keep_init_##sym##_##file_id  \
-		__section("__keep_meta_vars_init") = (unsigned long)&sym
+		__section("__keep_meta_vars_init") = (unsigned long)&(sym)
 
 #define __KEEP_INIT1(sym, file_id)	__KEEP_INIT2(sym, file_id)
 #define KEEP_INIT(sym)			__KEEP_INIT1(sym, __FILE_ID__)

--- a/core/include/kernel/pm.h
+++ b/core/include/kernel/pm.h
@@ -75,8 +75,8 @@ typedef TEE_Result (*pm_callback)(enum pm_op op, uint32_t pm_hint,
  * non-fatal failure to suspend.
  *
  * Callback implementations should ensure their functions belong to unpaged
- * memory sections (see KEEP_PAGER()) since the callback is likely to be
- * called from an unpaged execution context.
+ * memory sections (see DECLARE_KEEP_PAGER()) since the callback is likely to
+ * be called from an unpaged execution context.
  *
  * Power Mamagement callback functions API:
  *

--- a/core/include/scattered_array.h
+++ b/core/include/scattered_array.h
@@ -19,7 +19,7 @@
 
 #define __SCT_ARRAY_DEF_ITEM3(element_type, element_name, section_name) \
 	static const element_type element_name; \
-	KEEP_INIT(element_name); \
+	DECLARE_KEEP_INIT(element_name); \
 	static const element_type element_name __used \
 		__section(section_name __SECTION_FLAGS_RODATA)
 

--- a/core/kernel/asan.c
+++ b/core/kernel/asan.c
@@ -275,7 +275,7 @@ void __asan_register_globals(struct asan_global *globals, size_t size)
 		asan_tag_access((void *)globals[n].beg,
 				(void *)(globals[n].beg + globals[n].size));
 }
-KEEP_INIT(__asan_register_globals);
+DECLARE_KEEP_INIT(__asan_register_globals);
 
 void __asan_unregister_globals(struct asan_global *globals, size_t size);
 void __asan_unregister_globals(struct asan_global *globals __unused,

--- a/core/mm/fobj.c
+++ b/core/mm/fobj.c
@@ -151,7 +151,7 @@ static TEE_Result rwp_load_page(struct fobj *fobj, unsigned int page_idx,
 				    NULL, 0, src, SMALL_PAGE_SIZE, va,
 				    state->tag, sizeof(state->tag));
 }
-KEEP_PAGER(rwp_load_page);
+DECLARE_KEEP_PAGER(rwp_load_page);
 
 static TEE_Result rwp_save_page(struct fobj *fobj, unsigned int page_idx,
 				const void *va)
@@ -192,7 +192,7 @@ static TEE_Result rwp_save_page(struct fobj *fobj, unsigned int page_idx,
 				    NULL, 0, va, SMALL_PAGE_SIZE, dst,
 				    state->tag, &tag_len);
 }
-KEEP_PAGER(rwp_save_page);
+DECLARE_KEEP_PAGER(rwp_save_page);
 
 static const struct fobj_ops ops_rw_paged __rodata_unpaged = {
 	.free = rwp_free,
@@ -272,7 +272,7 @@ static TEE_Result rop_load_page(struct fobj *fobj, unsigned int page_idx,
 {
 	return rop_load_page_helper(to_rop(fobj), page_idx, va);
 }
-KEEP_PAGER(rop_load_page);
+DECLARE_KEEP_PAGER(rop_load_page);
 
 static TEE_Result rop_save_page(struct fobj *fobj __unused,
 				unsigned int page_idx __unused,
@@ -280,7 +280,7 @@ static TEE_Result rop_save_page(struct fobj *fobj __unused,
 {
 	return TEE_ERROR_GENERIC;
 }
-KEEP_PAGER(rop_save_page);
+DECLARE_KEEP_PAGER(rop_save_page);
 
 static const struct fobj_ops ops_ro_paged __rodata_unpaged = {
 	.free = rop_free,
@@ -452,7 +452,7 @@ static TEE_Result rrp_load_page(struct fobj *fobj, unsigned int page_idx,
 
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(rrp_load_page);
+DECLARE_KEEP_PAGER(rrp_load_page);
 
 static const struct fobj_ops ops_ro_reloc_paged __rodata_unpaged = {
 	.free = rrp_free,
@@ -497,7 +497,7 @@ static TEE_Result lop_load_page(struct fobj *fobj __maybe_unused,
 
 	return TEE_SUCCESS;
 }
-KEEP_PAGER(lop_load_page);
+DECLARE_KEEP_PAGER(lop_load_page);
 
 static TEE_Result lop_save_page(struct fobj *fobj __unused,
 				unsigned int page_idx __unused,
@@ -505,7 +505,7 @@ static TEE_Result lop_save_page(struct fobj *fobj __unused,
 {
 	return TEE_ERROR_GENERIC;
 }
-KEEP_PAGER(lop_save_page);
+DECLARE_KEEP_PAGER(lop_save_page);
 
 static const struct fobj_ops ops_locked_paged __rodata_unpaged = {
 	.free = lop_free,

--- a/core/pta/tests/interrupt.c
+++ b/core/pta/tests/interrupt.c
@@ -63,7 +63,7 @@ static enum itr_return __maybe_unused ihandler_ok(struct itr_handler *handler)
 
 	return ITRR_HANDLED;
 }
-KEEP_PAGER(ihandler_ok);
+DECLARE_KEEP_PAGER(ihandler_ok);
 
 struct itr_handler sgi_handler = {
 	.it = TEST_SGI_ID,


### PR DESCRIPTION
RFC.

As mentioned in https://github.com/OP-TEE/optee_os/pull/3818#discussion_r419403124 and earlier in  https://github.com/OP-TEE/optee_os/pull/3377#issuecomment-564929705.

`DEFINE_KEEP_INIT()` and `DEFINE_KEEP_PAGER()` would also work and would be more correct considering that the macros define symbols (they are not simple C declarations), but perhaps "declare" sounds better for this usage?