### PR TITLE
scripts/gen_ldelf_hex.py: do not use f-strings

### DIFF
--- a/scripts/gen_ldelf_hex.py
+++ b/scripts/gen_ldelf_hex.py
@@ -65,7 +65,7 @@ def emit_load_segments(elffile, outf):
                 w_found = True
         else:
             if w_found:
-                print(f'RO load segment found after RW one(s) (m={n})')
+                print('RO load segment found after RW one(s) (m={})'.format(n))
                 sys.exit(1)
         if prev_segment:
             if pad > 31:
@@ -73,8 +73,8 @@ def emit_load_segments(elffile, outf):
                 # efficiency. 31 is an arbitrary, "sounds reasonable" value
                 # which might need to be adjusted -- who knows what the
                 # compiler/linker can do.
-                print(f'Warning: suspiciously large padding ({pad}) after '
-                      f'load segment {n-1}, please check')
+                print('Warning: suspiciously large padding ({}) after load '
+                      'segment {}, please check'.format(pad, n-1))
             pad_size.append(pad)
         prev_segment = segment
         n = n + 1


### PR DESCRIPTION
f-strings were introduced in Python 3.6 [1] and will therefore
cause an error with prior versions:

 | File "scripts/gen_ldelf_hex.py", line 68
 | print(f'RO load segment found after RW one(s) (m={n})')
 | ^
 | SyntaxError: invalid syntax

For better compatibility use .format() instead.

Link: [1] https://docs.python.org/3/whatsnew/3.6.html#pep-498-formatted-string-literals
Fixes: c706c2449b50 ("scripts/gen_ldelf_hex.py: relax rules for PT_LOAD segments")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
