### PR TITLE
core: try to get embedded dt when external dt not found (2nd try)

### DIFF
--- a/core/arch/arm/include/kernel/generic_boot.h
+++ b/core/arch/arm/include/kernel/generic_boot.h
@@ -45,6 +45,9 @@ extern const struct core_mmu_config boot_mmu_config;
 /* @nsec_entry is unused if using CFG_WITH_ARM_TRUSTED_FW */
 void generic_boot_init_primary(unsigned long pageable_part,
 			       unsigned long nsec_entry, unsigned long fdt);
+
+void paged_init_primary(unsigned long fdt);
+
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 unsigned long cpu_on_handler(unsigned long a0, unsigned long a1);
 unsigned long generic_boot_cpu_on_handler(unsigned long a0, unsigned long a1);

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2017, Linaro Limited
  */
 #include <compiler.h>
+#include <kernel/generic_boot.h>
 #include <kernel/thread.h>
 #include <kernel/wait_queue.h>
 #include <sm/tee_mon.h>
@@ -20,6 +21,11 @@ thread_svc_handler(struct thread_svc_regs *regs __unused)
 TEE_Result __section(".text.dummy.init_teecore") init_teecore(void)
 {
 	return TEE_SUCCESS;
+}
+
+void __section(".text.dummy.paged_init_primary")
+paged_init_primary(unsigned long fdt __unused)
+{
 }
 
 uint32_t __section(".text.dummy.__thread_std_smc_entry")

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -127,7 +127,7 @@ void configure_console_from_dt(void)
 	void *fdt;
 	int offs;
 
-	fdt = get_external_dt();
+	fdt = get_dt();
 	if (get_console_node_from_dt(fdt, &offs, &uart, &parms))
 		return;
 


### PR DESCRIPTION
This P-R supersedes  https://github.com/OP-TEE/optee_os/pull/3827.

Initial purpose is to allow console generic initialization to use the embedded DTB instead of the external DTB.

However this simple change makes the embedded DTB to move from a pageable section to an _init_ section (pageable sections pre-loaded/mapped at Core early boot time) since embedded DTB would be accessed from `init_primary_helper()`. This can be a issue from some platforms.

This P-R proposes to relax a part of the Core initialization sequence from the pager _init_ section constraints. See 1st commit of this series. **(still a draft, deserves some cleaning)**

The 2nd commit implements https://github.com/OP-TEE/optee_os/pull/3827 proposal.

Few numbers to illustrate, based on **plat-stm32mp1** (enables pager) builds with an embedded DTB:
`make PLATFORM=stm32mp1 CFG_EMBED_DTB_SOURCE_FILE=stm32mp157c-dk2.dts`

Prior these changes (from a8f0bfcf326):
```bash
$ ./scripts/mem_usage.py out/arm-plat-stm32mp1/core/tee.elf 
RAM Usage        2FFC0000 - 30022000 size 00062000 392 KiB 98 pages
.text            2FFC0000 - 2FFC73C0 size 000073C0  28 KiB
.rodata          2FFC73C0 - 2FFC8A88 size 000016C8   5 KiB
*hole*           2FFC8A88 - 2FFC9000 size 00000578   1 KiB
.data            2FFC9000 - 2FFC9430 size 00000430   1 KiB
.bss             2FFC9430 - 2FFCA5C0 size 00001190   4 KiB
.heap1           2FFCA5C0 - 2FFCB000 size 00000A40   2 KiB
.nozi            2FFCB000 - 2FFD4300 size 00009300  36 KiB
.heap2           2FFD4300 - 2FFE4000 size 0000FD00  63 KiB
.text_init       2FFE4000 - 2FFE7BA0 size 00003BA0  14 KiB
.rodata_init     2FFE7BA0 - 2FFE8918 size 00000D78   3 KiB
*hole*           2FFE8918 - 2FFE9000 size 000006E8   1 KiB
.rodata_pageable 2FFE9000 - 2FFFE32E size 0001532E  84 KiB  <- embedded DTB is here
*hole*           2FFFE32E - 2FFFE330 size 00000002   0 KiB
.text_pageable   2FFFE330 - 30022000 size 00023CD0 143 KiB
```

With only the 2nd change applied:
```bash
$ ./scripts/mem_usage.py out/arm-plat-stm32mp1/core/tee.elf 
RAM Usage        2FFC0000 - 30021000 size 00061000 388 KiB 97 pages
.text            2FFC0000 - 2FFC73C0 size 000073C0  28 KiB
.rodata          2FFC73C0 - 2FFC8A88 size 000016C8   5 KiB
*hole*           2FFC8A88 - 2FFC9000 size 00000578   1 KiB
.data            2FFC9000 - 2FFC9430 size 00000430   1 KiB
.bss             2FFC9430 - 2FFCA5C0 size 00001190   4 KiB
.heap1           2FFCA5C0 - 2FFCB000 size 00000A40   2 KiB
.nozi            2FFCB000 - 2FFD4300 size 00009300  36 KiB
.heap2           2FFD4300 - 2FFE4000 size 0000FD00  63 KiB
.text_init       2FFE4000 - 2FFE7CB8 size 00003CB8  15 KiB
.rodata_init     2FFE7CB8 - 2FFF0BA8 size 00008EF0  35 KiB  <- embedded DTB is here :(
*hole*           2FFF0BA8 - 2FFF1000 size 00000458   1 KiB
.rodata_pageable 2FFF1000 - 2FFFE1B9 size 0000D1B9  52 KiB
*hole*           2FFFE1B9 - 2FFFE1C0 size 00000007   0 KiB
.text_pageable   2FFFE1C0 - 30021000 size 00022E40 139 KiB
```

With both patches applied:
```bash
$ ./scripts/mem_usage.py out/arm-plat-stm32mp1/core/tee.elf 
RAM Usage        2FFC0000 - 30021000 size 00061000 388 KiB 97 pages
.text            2FFC0000 - 2FFC73C0 size 000073C0  28 KiB
.rodata          2FFC73C0 - 2FFC8A88 size 000016C8   5 KiB
*hole*           2FFC8A88 - 2FFC9000 size 00000578   1 KiB
.data            2FFC9000 - 2FFC9430 size 00000430   1 KiB
.bss             2FFC9430 - 2FFCA5C0 size 00001190   4 KiB
.heap1           2FFCA5C0 - 2FFCB000 size 00000A40   2 KiB
.nozi            2FFCB000 - 2FFD4300 size 00009300  36 KiB
.heap2           2FFD4300 - 2FFE4000 size 0000FD00  63 KiB
.text_init       2FFE4000 - 2FFE6008 size 00002008   8 KiB
.rodata_init     2FFE6008 - 2FFE6AF8 size 00000AF0   2 KiB
*hole*           2FFE6AF8 - 2FFE7000 size 00000508   1 KiB
.rodata_pageable 2FFE7000 - 2FFFC5B4 size 000155B4  85 KiB  <- embedded DTB is back here
*hole*           2FFFC5B4 - 2FFFC5B8 size 00000004   0 KiB
.text_pageable   2FFFC5B8 - 30021000 size 00024A48 146 KiB
```

