### PR TITLE
libutee: crypto: AE: Explicitly initialize buffer_offs

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1326,6 +1326,7 @@ TEE_Result TEE_AEInit(TEE_OperationHandle operation, const void *nonce,
 		goto out;
 
 	operation->info.digestLength = tagLen / 8;
+	operation->buffer_offs = 0;
 	operation->info.handleState |= TEE_HANDLE_FLAG_INITIALIZED;
 
 out:


### PR DESCRIPTION
Explicitly initialize operation param buffer_offs in TEE_AEInit() instead
of relying on TEE_AllocateOperation() as it may cause issues while using
operation handle allocated once and used in subsequent authenticated
encryption operations.

It is quite similar to how TEE_CipherInit() and init_hash_operation()
initializes buffer_offs.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
