### PR TITLE
shippable: build stm32mp1-157C_DK2

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -57,6 +57,7 @@ build:
     - _make PLATFORM=stm-b2260
     - _make PLATFORM=stm-cannes
     - _make PLATFORM=stm32mp1
+    - _make PLATFORM=stm32mp1-157C_DK2
     - _make PLATFORM=vexpress-fvp
     - _make PLATFORM=vexpress-fvp CFG_ARM64_core=y
     - _make PLATFORM=vexpress-juno


### PR DESCRIPTION
Add build test for platform flavor stm32mp1-157C_DK2 to build stm32mp1
with an embedded DTB.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
