### PR TITLE
core: device pta: add flag to watch for running tee-supplicant

### DIFF
--- a/lib/libutee/include/pta_device.h
+++ b/lib/libutee/include/pta_device.h
@@ -23,6 +23,7 @@
  * TEE_ERROR_BAD_PARAMETERS - Incorrect input param
  * TEE_ERROR_SHORT_BUFFER - Output buffer size less than required
  */
-#define PTA_CMD_GET_DEVICES		0x0
+#define PTA_CMD_GET_DEVICES		0x0 /* before tee-supplicant run */
+#define PTA_CMD_GET_DEVICES_SUPP	0x1 /* after tee-supplicant run */
 
 #endif /* __PTA_DEVICE_H */

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -23,9 +23,16 @@
 	 * (pseudo-TAs only).
 	 */
 #define TA_FLAG_CONCURRENT		(1 << 8)
-#define TA_FLAG_DEVICE_ENUM		(1 << 9) /* device enumeration */
+	/*
+	 * Device enumeration is done in two stages by the normal world, first
+	 * before the tee-supplicant has started and then once more when the
+	 * tee-supplicant is started. The flags below control if the TA should
+	 * be reported in the first or second or case.
+	 */
+#define TA_FLAG_DEVICE_ENUM		(1 << 9)  /* without tee-supplicant */
+#define TA_FLAG_DEVICE_ENUM_SUPP	(1 << 10) /* with tee-supplicant */
 
-#define TA_FLAGS_MASK			GENMASK_32(9, 0)
+#define TA_FLAGS_MASK			GENMASK_32(10, 0)
 
 struct ta_head {
 	TEE_UUID uuid;


### PR DESCRIPTION
Some TAs require tee-supplicant to be run. For example fTPM requires
storage services provided by tee-supplicant. When scanning and
probe() devices on tee bus we can initialize early drivers which
do not require tee-supplicant and after mount fs and tee-supplicant
run do probe() drivers witch require tee-supplicant.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
