### PR TITLE
core: generic_boot: use "%#lx" to print unsigned long, not "0x%"PRIxPA

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -1017,15 +1017,14 @@ static void init_external_dt(unsigned long phys_dt)
 
 	ret = init_dt_overlay(dt, CFG_DTB_MAX_SIZE);
 	if (ret < 0) {
-		EMSG("Device Tree Overlay init fail @ 0x%" PRIxPA ": error %d",
-		     phys_dt, ret);
+		EMSG("Device Tree Overlay init fail @ %#lx: error %d", phys_dt,
+		     ret);
 		panic();
 	}
 
 	ret = fdt_open_into(fdt, fdt, CFG_DTB_MAX_SIZE);
 	if (ret < 0) {
-		EMSG("Invalid Device Tree at 0x%" PRIxPA ": error %d",
-		     phys_dt, ret);
+		EMSG("Invalid Device Tree at %#lx: error %d", phys_dt, ret);
 		panic();
 	}
 


### PR DESCRIPTION
In 32-bit builds with CFG_CORE_LARGE_PHYS_ADDR=y, PRIxPA is "llx"
which is not the recommended format to print an unsigned long int.
Use "lx" instead to avoid warnings with some compilers.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
