### PR TITLE
stm32mp1: SiP SMCs for BSEC access (take 2)

### DIFF
--- a/core/arch/arm/dts/stm32mp151.dtsi
+++ b/core/arch/arm/dts/stm32mp151.dtsi
@@ -1494,6 +1494,10 @@
 			ts_cal2: calib@5e {
 				reg = <0x5e 0x2>;
 			};
+			mac_addr: mac_addr@e4 {
+				reg = <0xe4 0x8>;
+				st,non-secure-otp;
+			};
 		};
 
 		etzpc: etzpc@5c007000 {

--- a/core/arch/arm/dts/stm32mp157a-dk1.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1.dts
@@ -29,3 +29,10 @@
 	status = "okay";
 	secure-status = "disable";
 };
+
+&bsec {
+	board_id: board_id@ec {
+		reg = <0xec 0x4>;
+		st,non-secure-otp;
+	};
+};

--- a/core/arch/arm/dts/stm32mp157c-dk2.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2.dts
@@ -97,3 +97,10 @@
 	status = "okay";
 	secure-status = "disable";
 };
+
+&bsec {
+	board_id: board_id@ec {
+		reg = <0xec 0x4>;
+		st,non-secure-otp;
+	};
+};

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -371,3 +371,10 @@
 	status = "okay";
 	secure-status = "disable";
 };
+
+&bsec {
+	board_id: board_id@ec {
+		reg = <0xec 0x4>;
+		st,non-secure-otp;
+	};
+};

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -93,6 +93,9 @@ endif
 # Platform specific configuration
 CFG_STM32MP_PANIC_ON_TZC_PERM_VIOLATION ?= y
 
+# SiP/OEM service for non-secure world
+CFG_STM32_BSEC_SIP ?= y
+
 # Default enable some test facitilites
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STATS ?= y

--- a/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.c
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2016-2020, STMicroelectronics
+ */
+
+#include <drivers/stm32_bsec.h>
+#include <kernel/thread.h>
+#include <tee_api_types.h>
+#include <trace.h>
+
+#include "bsec_svc.h"
+#include "stm32mp1_smc.h"
+
+void bsec_main(struct thread_smc_args *args)
+{
+	TEE_Result result = TEE_ERROR_GENERIC;
+	uint32_t cmd = args->a1;
+	uint32_t otp_id = args->a2;
+	uint32_t in_value = args->a3;
+	uint32_t *out_value = &args->a1;
+	uint32_t tmp = 0;
+
+	if (!stm32_bsec_nsec_can_access_otp(otp_id)) {
+		args->a0 = STM32_SIP_SVC_INVALID_PARAMS;
+		return;
+	}
+
+	switch (cmd) {
+	case STM32_SIP_SVC_BSEC_READ_SHADOW:
+		FMSG("read shadow @%#"PRIx32, otp_id);
+		result = stm32_bsec_read_otp(out_value, otp_id);
+		break;
+	case STM32_SIP_SVC_BSEC_PROG_OTP:
+		FMSG("program @%#"PRIx32, otp_id);
+		result = stm32_bsec_program_otp(in_value, otp_id);
+		break;
+	case STM32_SIP_SVC_BSEC_WRITE_SHADOW:
+		FMSG("write shadow @%#"PRIx32, otp_id);
+		result = stm32_bsec_write_otp(in_value, otp_id);
+		break;
+	case STM32_SIP_SVC_BSEC_READ_OTP:
+		FMSG("read @%#"PRIx32, otp_id);
+		result = stm32_bsec_read_otp(&tmp, otp_id);
+		if (!result)
+			result = stm32_bsec_shadow_register(otp_id);
+		if (!result)
+			result = stm32_bsec_read_otp(out_value, otp_id);
+		if (!result)
+			result = stm32_bsec_write_otp(tmp, otp_id);
+		break;
+	case STM32_SIP_SVC_BSEC_WRLOCK_OTP:
+		FMSG("permanent write lock @%#"PRIx32, otp_id);
+		result = stm32_bsec_permanent_lock_otp(otp_id);
+		break;
+	default:
+		DMSG("Invalid command %#"PRIx32, cmd);
+		result = TEE_ERROR_BAD_PARAMETERS;
+		break;
+	}
+
+	if (!result)
+		args->a0 = STM32_SIP_SVC_OK;
+	else if (result == TEE_ERROR_BAD_PARAMETERS)
+		args->a0 = STM32_SIP_SVC_INVALID_PARAMS;
+	else
+		args->a0 = STM32_SIP_SVC_FAILED;
+}

--- a/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.h
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/bsec_svc.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2016-2020, STMicroelectronics
+ */
+
+#ifndef __STM32MP1_BSEC_SVC_H__
+#define __STM32MP1_BSEC_SVC_H__
+
+#include <kernel/thread.h>
+#include <stdint.h>
+#include <stm32mp1_smc.h>
+
+#ifdef CFG_STM32_BSEC_SIP
+void bsec_main(struct thread_smc_args *args);
+#else
+static inline void bsec_main(struct thread_smc_args *args)
+{
+	args->a0 = STM32_SIP_SVC_UNKNOWN_FUNCTION;
+}
+#endif
+#endif /*__STM32MP1_BSEC_SVC_H__*/

--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_smc.h
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_smc.h
@@ -1,10 +1,12 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2016-2018, STMicroelectronics
+ * Copyright (c) 2016-2020, STMicroelectronics
  * Copyright (c) 2018, Linaro Limited
  */
 #ifndef __STM32MP1_SMC_H__
 #define __STM32MP1_SMC_H__
+
+#include <sm/optee_smc.h>
 
 /*
  * SIP Functions
@@ -12,7 +14,13 @@
 #define STM32_SIP_SVC_VERSION_MAJOR	0x0
 #define STM32_SIP_SVC_VERSION_MINOR	0x1
 
-#define STM32_SIP_SVC_FUNCTION_COUNT	0x2
+#define STM32_SIP_SVC_FUNCTION_COUNT	0x3
+
+/* STM32 SIP service generic return codes */
+#define STM32_SIP_SVC_OK		0x0
+#define STM32_SIP_SVC_UNKNOWN_FUNCTION	OPTEE_SMC_RETURN_UNKNOWN_FUNCTION
+#define STM32_SIP_SVC_FAILED		0xfffffffeU
+#define STM32_SIP_SVC_INVALID_PARAMS	0xfffffffdU
 
 /*
  * SMC function IDs for STM32 Service queries
@@ -62,6 +70,25 @@
  * Argument a1: (output) STM32 SIP service minor
  */
 #define STM32_SIP_SVC_FUNC_VERSION		0xff03
+
+/*
+ * SIP functions STM32_SIP_SVC_FUNC_BSEC
+ *
+ * Argument a0: (input) SMCCC function ID
+ *		(output) status return code
+ * Argument a1: (input) Service ID (STM32_SIP_BSEC_xxx)
+ * Argument a2: (input) OTP index
+ *		(output) OTP read value, if applicable
+ * Argument a3: (input) OTP value if applicable
+ */
+#define STM32_SIP_SVC_FUNC_BSEC			0x1003
+
+/* Service ID for function ID STM32_SIP_FUNC_BSEC */
+#define STM32_SIP_SVC_BSEC_READ_SHADOW		0x1
+#define STM32_SIP_SVC_BSEC_PROG_OTP		0x2
+#define STM32_SIP_SVC_BSEC_WRITE_SHADOW		0x3
+#define STM32_SIP_SVC_BSEC_READ_OTP		0x4
+#define STM32_SIP_SVC_BSEC_WRLOCK_OTP		0x5
 
 /*
  * SIP function STM32_SIP_SVC_FUNC_SCMI_AGENT0

--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2017-2018, STMicroelectronics
+ * Copyright (c) 2017-2020, STMicroelectronics
  */
 
 #include <kernel/thread.h>
@@ -8,6 +8,7 @@
 #include <sm/optee_smc.h>
 #include <sm/sm.h>
 
+#include "bsec_svc.h"
 #include "stm32mp1_smc.h"
 
 static enum sm_handler_ret sip_service(struct sm_ctx *ctx __unused,
@@ -32,6 +33,9 @@ static enum sm_handler_ret sip_service(struct sm_ctx *ctx __unused,
 		break;
 	case STM32_SIP_SVC_FUNC_SCMI_AGENT1:
 		scmi_smt_fastcall_smc_entry(1);
+		break;
+	case STM32_SIP_SVC_FUNC_BSEC:
+		bsec_main(args);
 		break;
 	default:
 		return SM_HANDLER_PENDING_SMC;

--- a/core/arch/arm/plat-stm32mp1/nsec-service/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/sub.mk
@@ -1,3 +1,4 @@
 global-incdirs-y += .
 
 srcs-y += stm32mp1_svc_setup.c
+srcs-$(CFG_STM32_BSEC_SIP) += bsec_svc.c


### PR DESCRIPTION
This P-R supersedes https://github.com/OP-TEE/optee_os/pull/3063/files.

This P-R implements management of SiP SMCs allowing non-secure world to access platform secure fuses that platform secure device tree defines as accessible from non-secure world.