### PR TITLE
plat-stm32mp1: psci: support Arm SMCCC_VERSION function ID

### DIFF
--- a/core/arch/arm/plat-stm32mp1/pm/psci.c
+++ b/core/arch/arm/plat-stm32mp1/pm/psci.c
@@ -20,6 +20,7 @@
 #include <mm/core_memprot.h>
 #include <platform_config.h>
 #include <sm/psci.h>
+#include <sm/std_smc.h>
 #include <stm32_util.h>
 #include <trace.h>
 
@@ -244,6 +245,7 @@ void __noreturn psci_system_reset(void)
 int psci_features(uint32_t psci_fid)
 {
 	switch (psci_fid) {
+	case ARM_SMCCC_VERSION:
 	case PSCI_PSCI_FEATURES:
 	case PSCI_SYSTEM_RESET:
 	case PSCI_VERSION:


### PR DESCRIPTION
As per Arm SMCCC v1.1 specification [1], PSCI PSCI_FEATURES function ID
should report Arm Architecture Call SMCCC_VERSION as supported when
the secure firmware supports both PSCI PSCI_FEATURE function ID and
Arm SMCCC_VERSION function ID.

Link: [1] https://developer.arm.com/docs/den0028/latest
Signed-off-by: Etienne Carriere <etienne.carriere@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
