### PR TITLE
rpmb: fix building when TRACE_LEVEL >= TRACE_FLOW

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1803,7 +1803,7 @@ post_read_in:
 #if (TRACE_LEVEL >= TRACE_FLOW)
 static void dump_fat(void)
 {
-	TEE_RESULT res;
+	TEE_Result res = TEE_ERROR_SECURITY;
 	struct rpmb_fat_entry *fe = NULL;
 
 	if (fat_entry_dir_init())


### PR DESCRIPTION
Building with CFG_RPMB_FS=y and CFG_TEE_CORE_LOG_LEVEL=4 yields a
compile-time error due to a typo.

Replacing TEE_RESULT with TEE_Result fixes the issue.

Signed-off-by: Gianguido Sorà <me@gsora.xyz>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
