### PR TITLE
plat-sunxi: psci: support Arm SMCCC_VERSION function ID

### DIFF
--- a/core/arch/arm/plat-sunxi/psci.c
+++ b/core/arch/arm/plat-sunxi/psci.c
@@ -44,6 +44,7 @@
 #include <sm/tee_mon.h>
 #include <sm/optee_smc.h>
 #include <sm/psci.h>
+#include <sm/std_smc.h>
 #include <arm32.h>
 
 #define REG_CPUCFG_RES0             (0x0000)
@@ -57,11 +58,11 @@
 int psci_features(uint32_t psci_fid)
 {
 	switch (psci_fid) {
+	case ARM_SMCCC_VERSION:
 #ifdef CFG_BOOT_SECONDARY_REQUEST
 	case PSCI_CPU_ON:
-		return 0;
 #endif
-
+		return PSCI_RET_SUCCESS;
 	default:
 		return PSCI_RET_NOT_SUPPORTED;
 	}


### PR DESCRIPTION
As per Arm SMCCC v1.1 specification [1], PSCI PSCI_FEATURES function ID
should report Arm Architecture Call SMCCC_VERSION as supported when
the secure firmware supports both PSCI PSCI_FEATURES function ID and
Arm SMCCC_VERSION function ID.

Link: [1] https://developer.arm.com/docs/den0028/latest
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
