### PR TITLE
plat-imx: psci: support Arm SMCCC_VERSION function ID

### DIFF
--- a/core/arch/arm/plat-imx/pm/psci.c
+++ b/core/arch/arm/plat-imx/pm/psci.c
@@ -22,12 +22,14 @@
 #include <stdint.h>
 #include <sm/optee_smc.h>
 #include <sm/psci.h>
+#include <sm/std_smc.h>
 #include <tee/entry_std.h>
 #include <tee/entry_fast.h>
 
 int psci_features(uint32_t psci_fid)
 {
 	switch (psci_fid) {
+	case ARM_SMCCC_VERSION:
 	case PSCI_PSCI_FEATURES:
 	case PSCI_VERSION:
 	case PSCI_CPU_SUSPEND:


### PR DESCRIPTION
As per Arm SMCCC v1.1 specification [1], PSCI PSCI_FEATURES function ID
should report Arm Architecture Call SMCCC_VERSION as supported when
the secure firmware supports both PSCI PSCI_FEATURES function ID and
Arm SMCCC_VERSION function ID.

Link: [1] https://developer.arm.com/docs/den0028/latest
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
