### PR TITLE
[RFC] core: always build libfdt

### DIFF
--- a/core/arch/arm/kernel/generic_boot.c
+++ b/core/arch/arm/kernel/generic_boot.c
@@ -18,6 +18,8 @@
 #include <kernel/panic.h>
 #include <kernel/tee_misc.h>
 #include <kernel/thread.h>
+#include <kernel/tpm.h>
+#include <libfdt.h>
 #include <malloc.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
@@ -31,7 +33,6 @@
 #include <trace.h>
 #include <utee_defines.h>
 #include <util.h>
-#include <kernel/tpm.h>
 
 #include <platform_config.h>
 
@@ -41,10 +42,6 @@
 
 #if defined(CFG_WITH_VFP)
 #include <kernel/vfp.h>
-#endif
-
-#if defined(CFG_DT)
-#include <libfdt.h>
 #endif
 
 /*

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -13,15 +13,12 @@
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
 #include <kernel/spinlock.h>
+#include <libfdt.h>
 #include <platform_config.h>
-#include <stm32_util.h>
 #include <stdio.h>
+#include <stm32_util.h>
 #include <trace.h>
 #include <util.h>
-
-#ifdef CFG_DT
-#include <libfdt.h>
-#endif
 
 /* Identifiers for root oscillators */
 enum stm32mp_osc_id {

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -16,15 +16,12 @@
 #include <kernel/panic.h>
 #include <kernel/pm.h>
 #include <kernel/spinlock.h>
+#include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
-#include <stm32_util.h>
 #include <stdbool.h>
+#include <stm32_util.h>
 #include <string.h>
-
-#ifdef CFG_DT
-#include <libfdt.h>
-#endif
 
 /*
  * Once one starts to get the resource registering state, one cannot register

--- a/core/core.mk
+++ b/core/core.mk
@@ -128,11 +128,9 @@ include mk/lib.mk
 
 base-prefix :=
 
-ifeq ($(CFG_DT),y)
 libname = fdt
 libdir = core/lib/libfdt
 include mk/lib.mk
-endif
 
 ifeq ($(CFG_ZLIB),y)
 libname = zlib

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -34,11 +34,9 @@
 #include <kernel/dt.h>
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
-#ifdef CFG_DT
 #include <libfdt.h>
-#endif
-#include <mm/core_mmu.h>
 #include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
 #include <util.h>
 
 static bool ext_reset;

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -11,6 +11,7 @@
 #include <kernel/dt.h>
 #include <kernel/generic_boot.h>
 #include <kernel/spinlock.h>
+#include <libfdt.h>
 #include <limits.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
@@ -19,10 +20,6 @@
 #include <tee_api_defines.h>
 #include <types_ext.h>
 #include <util.h>
-
-#ifdef CFG_DT
-#include <libfdt.h>
-#endif
 
 #define BSEC_OTP_MASK			GENMASK_32(4, 0)
 #define BSEC_OTP_BANK_SHIFT		5

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -17,19 +17,16 @@
 
 #include <assert.h>
 #include <drivers/stm32_etzpc.h>
-#include <kernel/dt.h>
-#include <kernel/generic_boot.h>
 #include <initcall.h>
 #include <io.h>
 #include <keep.h>
+#include <kernel/dt.h>
+#include <kernel/generic_boot.h>
 #include <kernel/panic.h>
 #include <kernel/pm.h>
+#include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <util.h>
-
-#ifdef CFG_DT
-#include <libfdt.h>
-#endif
 
 /* Devicetree compatibulity */
 #define ETZPC_COMPAT			"st,stm32-etzpc"

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -13,15 +13,12 @@
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
 #include <kernel/spinlock.h>
+#include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <stdbool.h>
 #include <stm32_util.h>
 #include <trace.h>
 #include <util.h>
-
-#ifdef CFG_DT
-#include <libfdt.h>
-#endif
 
 #define GPIO_PIN_MAX		15
 

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -6,18 +6,15 @@
 #include <assert.h>
 #include <drivers/stm32_rng.h>
 #include <io.h>
-#include <kernel/dt.h>
 #include <kernel/delay.h>
+#include <kernel/dt.h>
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
+#include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <stdbool.h>
 #include <stm32_util.h>
 #include <string.h>
-
-#ifdef CFG_DT
-#include <libfdt.h>
-#endif
 
 #define DT_RNG_COMPAT		"st,stm32-rng"
 #define RNG_CR			0x00U

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -3,19 +3,16 @@
  * Copyright (c) 2017, Linaro Limited
  */
 
-#include <console.h>
 #include <compiler.h>
+#include <console.h>
 #include <drivers/serial.h>
+#include <kernel/dt.h>
 #include <kernel/generic_boot.h>
 #include <kernel/panic.h>
+#include <libfdt.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string_ext.h>
-
-#ifdef CFG_DT
-#include <kernel/dt.h>
-#include <libfdt.h>
-#endif
 
 static struct serial_chip *serial_console __nex_bss;
 

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -3,14 +3,12 @@
  * Copyright (c) 2020, ARM Limited. All rights reserved.
  */
 
-#include <mm/core_memprot.h>
-#include <kernel/tpm.h>
 #include <compiler.h>
-#include <string.h>
-#ifdef CFG_DT
 #include <kernel/dt.h>
+#include <kernel/tpm.h>
 #include <libfdt.h>
-#endif
+#include <mm/core_memprot.h>
+#include <string.h>
 
 static void *tpm_log_addr;
 static size_t tpm_log_size;


### PR DESCRIPTION
libfdt is built only when CFG_DT=y. As a result, the libfdt header
files are only available when CFG_DT=y and any source file that makes
optional use of the library has to guard the #include <libfdt.h> with
a #ifdef CFG_DT ... #endif block. This contrasts with other features
which don't require such guards.

This patch builds libfdt unconditionally and removes the include
guards. No change is expected in the binaries.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
