### PR TITLE
batch typo fixes in documentation/comments

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -320,7 +320,7 @@ void thread_set_foreign_intr(bool enable);
 void thread_restore_foreign_intr(void);
 
 /*
- * Defines the bits for the exception mask used the the
+ * Defines the bits for the exception mask used by the
  * thread_*_exceptions() functions below.
  * These definitions are compatible with both ARM32 and ARM64.
  */

--- a/core/arch/arm/kernel/generic_entry_a32.S
+++ b/core/arch/arm/kernel/generic_entry_a32.S
@@ -141,8 +141,8 @@ END_FUNC reset_vect_table
 	 * - Disable data and instruction cache.
 	 * - MMU is expected off and exceptions trapped in ARM mode.
 	 * - Enable or disable alignment checks upon platform configuration.
-	 * - Optinally enable write-implies-execute-never.
-	 * - Optinally enable round robin strategy for cache replacement.
+	 * - Optionally enable write-implies-execute-never.
+	 * - Optionally enable round robin strategy for cache replacement.
 	 *
 	 * Clobbers r0.
 	 */

--- a/core/arch/arm/kernel/wait_queue.c
+++ b/core/arch/arm/kernel/wait_queue.c
@@ -160,7 +160,7 @@ void wq_promote_condvar(struct wait_queue *wq, struct condvar *cv,
 	/*
 	 * Find condvar waiter(s) and promote each to an active waiter.
 	 * This is a bit unfair to eventual other active waiters as a
-	 * condvar waiter is added the the queue when waiting for the
+	 * condvar waiter is added to the queue when waiting for the
 	 * condvar.
 	 */
 	SLIST_FOREACH(wqe, wq, link) {

--- a/core/drivers/crypto/crypto_api/acipher/local.h
+++ b/core/drivers/crypto/crypto_api/acipher/local.h
@@ -11,7 +11,7 @@
 
 /*
  * Mask Generation function. Use a Hash operation
- * to generate an output @mask from a input @seed
+ * to generate an output @mask from an input @seed
  *
  * @mgf_data  [in/out] MGF data
  */

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -345,7 +345,7 @@ TEE_Result crypto_rng_read(void *buf, size_t len);
 /*
  * crypto_aes_expand_enc_key() - Expand an AES key
  * @key:	AES key buffer
- * @key_len:	Size of the the @key buffer in bytes
+ * @key_len:	Size of the @key buffer in bytes
  * @enc_key:	Expanded AES encryption key buffer
  * @enc_keylen: Size of the @enc_key buffer in bytes
  * @rounds:	Number of rounds to be used during encryption

--- a/core/include/kernel/handle.h
+++ b/core/include/kernel/handle.h
@@ -33,7 +33,7 @@ int handle_get(struct handle_db *db, void *ptr);
 
 /*
  * Deallocates a handle. Returns the assiciated pointer of the handle
- * the the handle was valid or NULL if it's invalid.
+ * if the handle was valid or NULL if it's invalid.
  */
 void *handle_put(struct handle_db *db, int handle);
 

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -43,13 +43,13 @@
  * return code for the invoked command.
  *
  * Param#1 can be used for input data arguments of the invoked command.
- * It is unused or is a input memory reference, aka memref[1].
+ * It is unused or is an input memory reference, aka memref[1].
  * Evolution of the API may use memref[1] for output data as well.
  *
  * Param#2 is mostly used for output data arguments of the invoked command
  * and for output handles generated from invoked commands.
  * Few commands uses it for a secondary input data buffer argument.
- * It is unused or is a input/output/in-out memory reference, aka memref[2].
+ * It is unused or is an input/output/in-out memory reference, aka memref[2].
  *
  * Param#3 is currently unused and reserved for evolution of the API.
  */

--- a/ta/pkcs11/src/handle.h
+++ b/ta/pkcs11/src/handle.h
@@ -33,7 +33,7 @@ uint32_t handle_get(struct handle_db *db, void *ptr);
 
 /*
  * Deallocate a handle. Returns the associated pointer of the handle
- * the the handle was valid or NULL if it's invalid.
+ * if the handle was valid or NULL if it's invalid.
  */
 void *handle_put(struct handle_db *db, uint32_t handle);
 


### PR DESCRIPTION
a input -> an input
Optinally -> Optionally
the the -> if the, the, by the, to the (guessed from context)

(typos inherited from upstream are kept)

Signed-off-by: Markus S. Wamser <github-dev@mail2013.wamser.eu>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
