### PR TITLE
mk/subdir.mk: avoid trailing slash in $(sub-dir-out)

### DIFF
--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -117,7 +117,7 @@ endef #process-subdir-asm-defines-y
 define process-subdir
 sub-dir := $1
 ifeq ($1,.)
-sub-dir-out := $(out-dir)/$(base-prefix)
+sub-dir-out := $(patsubst %/,%,$(out-dir)/$(base-prefix))
 else
 sub-dir-out := $(out-dir)/$(base-prefix)$1
 endif


### PR DESCRIPTION
As a general rule, paths to directories should not end with a slash
[1]. In some cases, $(sub-dir-out) does not meet this requirement. For
example when building the 'crypt' TA in the optee_test project:
```
  GEN     /tmp/optee/optee_test/out/ta/crypt//ca_crt.c
  CC      /tmp/optee/optee_test/out/ta/crypt//ca_crt.o
  GEN     /tmp/optee/optee_test/out/ta/crypt//mid_crt.c
  CC      /tmp/optee/optee_test/out/ta/crypt//mid_crt.o
  GEN     /tmp/optee/optee_test/out/ta/crypt//mid_key.c
  CC      /tmp/optee/optee_test/out/ta/crypt//mid_key.o
```
In this example, $(sub-dir-out) is /tmp/optee/optee_test/out/ta/crypt/.

This patch removes the trailing slash.

[1] commit 4334e8d79fa3 ("Makefile variables $(*-dir) should not have a
    trailing slash")

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
