### PR TITLE
plat-stm32mp1: ack SCMI SiP SMC entry with 0 return code

### DIFF
--- a/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
+++ b/core/arch/arm/plat-stm32mp1/nsec-service/stm32mp1_svc_setup.c
@@ -30,9 +30,11 @@ static enum sm_handler_ret sip_service(struct sm_ctx *ctx __unused,
 		break;
 	case STM32_SIP_SVC_FUNC_SCMI_AGENT0:
 		scmi_smt_fastcall_smc_entry(0);
+		args->a0 = STM32_SIP_SVC_OK;
 		break;
 	case STM32_SIP_SVC_FUNC_SCMI_AGENT1:
 		scmi_smt_fastcall_smc_entry(1);
+		args->a0 = STM32_SIP_SVC_OK;
 		break;
 	case STM32_SIP_SVC_FUNC_BSEC:
 		bsec_main(args);


### PR DESCRIPTION
Load STM32_SIP_SVC_OK in output argument a0 on return from
SCMI message notification from SiP SMC function IDs. It simplifies
non-secure world to consider any non-zero values,
including standard unknown function error code (-1), as
reporting a failure.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
