### PR TITLE
core: make core_is_buffer_*() paddr_t compatible

### DIFF
--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -1048,7 +1048,7 @@ bool tee_mmu_is_vbuf_inside_um_private(const struct user_mode_ctx *uctx,
 	TAILQ_FOREACH(r, &uctx->vm_info.regions, link) {
 		if (r->flags & VM_FLAGS_NONPRIV)
 			continue;
-		if (core_is_buffer_inside(va, size, r->va, r->size))
+		if (core_is_buffer_inside((vaddr_t)va, size, r->va, r->size))
 			return true;
 	}
 
@@ -1064,7 +1064,7 @@ bool tee_mmu_is_vbuf_intersect_um_private(const struct user_mode_ctx *uctx,
 	TAILQ_FOREACH(r, &uctx->vm_info.regions, link) {
 		if (r->attr & VM_FLAGS_NONPRIV)
 			continue;
-		if (core_is_buffer_intersect(va, size, r->va, r->size))
+		if (core_is_buffer_intersect((vaddr_t)va, size, r->va, r->size))
 			return true;
 	}
 
@@ -1080,7 +1080,7 @@ TEE_Result tee_mmu_vbuf_to_mobj_offs(const struct user_mode_ctx *uctx,
 	TAILQ_FOREACH(r, &uctx->vm_info.regions, link) {
 		if (!r->mobj)
 			continue;
-		if (core_is_buffer_inside(va, size, r->va, r->size)) {
+		if (core_is_buffer_inside((vaddr_t)va, size, r->va, r->size)) {
 			size_t poffs;
 
 			poffs = mobj_get_phys_offs(r->mobj,
@@ -1100,7 +1100,8 @@ static TEE_Result tee_mmu_user_va2pa_attr(const struct user_mode_ctx *uctx,
 	struct vm_region *region = NULL;
 
 	TAILQ_FOREACH(region, &uctx->vm_info.regions, link) {
-		if (!core_is_buffer_inside(ua, 1, region->va, region->size))
+		if (!core_is_buffer_inside((vaddr_t)ua, 1, region->va,
+					   region->size))
 			continue;
 
 		if (pa) {

--- a/core/include/kernel/tee_misc.h
+++ b/core/include/kernel/tee_misc.h
@@ -42,20 +42,11 @@ uint32_t tee_hs2b(uint8_t *hs, uint8_t *b, uint32_t hslen, uint32_t blen);
  * @a - memory area start address (handled has an unsigned offset)
  * @al - memory area length (in byte)
  */
-#define core_is_buffer_inside(b, bl, a, al) \
-	_core_is_buffer_inside((vaddr_t)(b), (size_t)(bl), \
-				(vaddr_t)(a), (size_t)(al))
-
-#define core_is_buffer_outside(b, bl, a, al) \
-	_core_is_buffer_outside((vaddr_t)(b), (size_t)(bl), \
-				(vaddr_t)(a), (size_t)(al))
-
-#define core_is_buffer_intersect(b, bl, a, al) \
-	_core_is_buffer_intersect((vaddr_t)(b), (size_t)(bl), \
-				(vaddr_t)(a), (size_t)(al))
-
-bool _core_is_buffer_inside(vaddr_t b, size_t bl, vaddr_t a, size_t al);
-bool _core_is_buffer_outside(vaddr_t b, size_t bl, vaddr_t a, size_t al);
-bool _core_is_buffer_intersect(vaddr_t b, size_t bl, vaddr_t a, size_t al);
+bool core_is_buffer_inside(paddr_t b, paddr_size_t bl,
+			   paddr_t a, paddr_size_t al);
+bool core_is_buffer_outside(paddr_t b, paddr_size_t bl,
+			    paddr_t a, paddr_size_t al);
+bool core_is_buffer_intersect(paddr_t b, paddr_size_t bl,
+			      paddr_t a, paddr_size_t al);
 
 #endif /* TEE_MISC_H */

--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -68,8 +68,8 @@ uint32_t tee_hs2b(uint8_t *hs, uint8_t *b, uint32_t hslen, uint32_t blen)
 	return len;
 }
 
-static bool is_valid_conf_and_notnull_size(
-		vaddr_t b, size_t bl, vaddr_t a, size_t al)
+static bool is_valid_conf_and_notnull_size(paddr_t b, paddr_size_t bl,
+					   paddr_t a, paddr_size_t al)
 {
 	/* invalid config return false */
 	if ((b - 1 + bl < b) || (a - 1 + al < a))
@@ -81,7 +81,8 @@ static bool is_valid_conf_and_notnull_size(
 }
 
 /* Returns true when buffer 'b' is fully contained in area 'a' */
-bool _core_is_buffer_inside(vaddr_t b, size_t bl, vaddr_t a, size_t al)
+bool core_is_buffer_inside(paddr_t b, paddr_size_t bl,
+			   paddr_t a, paddr_size_t al)
 {
 	/* invalid config or "null size" return false */
 	if (!is_valid_conf_and_notnull_size(b, bl, a, al))
@@ -93,7 +94,8 @@ bool _core_is_buffer_inside(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 }
 
 /* Returns true when buffer 'b' is fully contained in area 'a' */
-bool _core_is_buffer_outside(vaddr_t b, size_t bl, vaddr_t a, size_t al)
+bool core_is_buffer_outside(paddr_t b, paddr_size_t bl,
+			    paddr_t a, paddr_size_t al)
 {
 	/* invalid config or "null size" return false */
 	if (!is_valid_conf_and_notnull_size(b, bl, a, al))
@@ -105,7 +107,8 @@ bool _core_is_buffer_outside(vaddr_t b, size_t bl, vaddr_t a, size_t al)
 }
 
 /* Returns true when buffer 'b' intersects area 'a' */
-bool _core_is_buffer_intersect(vaddr_t b, size_t bl, vaddr_t a, size_t al)
+bool core_is_buffer_intersect(paddr_t b, paddr_size_t bl,
+			      paddr_t a, paddr_size_t al)
 {
 	/* invalid config or "null size" return false */
 	if (!is_valid_conf_and_notnull_size(b, bl, a, al))


### PR DESCRIPTION
The core_is_buffer_*() helpers are sometimes used with physical
addresses (type paddr_t). This can cause problem on platforms where
sizeof(paddr_t) > sizeof(vaddr_t), that is on ARM32 systems with
CFG_CORE_LARGE_PHYS_ADDR=y. The FVP platform compiled for AArch32 is one
such system which as a consequence fails with:
E/TC:0 0 check_phys_mem_is_outside:335 Non-sec mem (0x880000000:0x180000000) ove
rlaps map (type 12 0xff000000:0x1000000)
E/TC:0 0 Panic at core/arch/arm/mm/core_mmu.c:336 <check_phys_mem_is_outside>

This patch fixes this problem by taking input addresses as paddr_t and
sizes as paddr_ssize_t instead. The wrapper macros which did some
automatic casting removed. The requires updates at some of the places
where these functions are called.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
