### PR TITLE
plat-imx: fix build when CFG_BOOT_SYNC_CPU=y

### DIFF
--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -183,7 +183,7 @@ static void psci_boot_allcpus(void)
 	io_write32(src_base + SRC_GPR1 + 16, pa);
 	io_write32(src_base + SRC_GPR1 + 24, pa);
 
-	io_write32(src_base + SRC_SCR, BM_SRC_SCR_CPU_ENABLE_ALL);
+	io_write32(src_base + SRC_SCR, SRC_SCR_CPU_ENABLE_ALL);
 }
 #endif
 
@@ -191,6 +191,6 @@ void plat_primary_init_early(void)
 {
 	/* primary core */
 #if defined(CFG_BOOT_SYNC_CPU)
-	psci_boot_allcpus()
+	psci_boot_allcpus();
 #endif
 }


### PR DESCRIPTION
Added a missing semicolon, removed an unknown macro prefix.

Just doing some cleaning 😄

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
