### PR TITLE
ta: Add missing default user-ta-version settings

### DIFF
--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -10,6 +10,9 @@ ta-target := $(strip $(if $(CFG_USER_TA_TARGET_$(sm)), \
 ta-dev-kit-dir$(sm) := $(out-dir)/export-$(ta-target)
 link-out-dir$(sm) := $(out-dir)/$(patsubst %/,%, $(dir $(ta-mk-file)))
 
+# Default if ta-mk-file defines none
+user-ta-version := 0
+
 include $(ta-mk-file)
 ifeq ($(user-ta-uuid),)
 $(error user-ta-uuid missing in $(ta-mk-file))


### PR DESCRIPTION
Unbreaks building of vexpress-qemu_armv8a and k3-am65x, e.g.

Fixes: 682f256 ("TA dev kit: expose CFG_TA_VERSION build option")
Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>