### PR TITLE
core: Disable outline-atomics when compiling

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -115,7 +115,7 @@ arm32-platform-aflags-no-hard-float ?=
 
 arm64-platform-cflags-no-hard-float ?= -mgeneral-regs-only
 arm64-platform-cflags-hard-float ?=
-arm64-platform-cflags-generic ?= -mstrict-align
+arm64-platform-cflags-generic ?= -mstrict-align $(call cc-option,-mno-outline-atomics,)
 
 ifeq ($(DEBUG),1)
 # For backwards compatibility


### PR DESCRIPTION
Disables the automatic detection of LSE (Large System Extension)
instructions when compiling AArch64 code. GCC 10 implements this
detection in libgcc using __getauxval(), which optee doesn't implement.
This requires that the proper -mcpu is passed to GCC so that the code
can be correctly compiled to use either LSE or load-store-exclusive.

Fixes linker errors like the following when compiling with GCC 10:

 aarch64-linux-ld.bfd: libgcc.a(lse-init.o): in function `init_have_lse_atomics':
 lse-init.c:44: undefined reference to `__getauxval'
 core/arch/arm/kernel/link.mk:38: recipe for target 'build/core/all_objs.o' failed

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
