### PR TITLE
core: aslr: suppress R_AARCH64_ABS64 and R_ARM_ABS32 relocations

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -11,7 +11,7 @@ AWK	 = awk
 
 link-ldflags  = $(LDFLAGS)
 ifeq ($(CFG_CORE_ASLR),y)
-link-ldflags += -pie -z notext -z norelro $(ldflag-apply-dynamic-relocs)
+link-ldflags += -pie -Bsymbolic -z notext -z norelro $(ldflag-apply-dynamic-relocs)
 endif
 link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
 link-ldflags += --sort-section=alignment


### PR DESCRIPTION
The following errors were observed when building with GCC 6.2.1:

- 64 bits:
   GEN     out/arm/core/tee.bin
 Unexpected relocation type 0x101

- 32 bits:
   GEN     out/arm/core/tee.bin
 Unexpected relocation type 0x2

Relocation type 0x101 is R_AARCH64_ABS64 and 0x2 is R_ARM_ABS32. The
errors are output by scripts/gen_tee_bin.py which expects only relative
relocations (the ones that are necessary for ASLR).

This patch adds the -Bsymbolic linker option to avoid these
relocations. More information can be found in Linux commit [1].

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=08cc55b2afd97a654f71b3bebf8bb0ec89fdc498
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
