### PR TITLE
core: tee_mmu: fix use after free bug in vm_unmap()

### DIFF
--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -715,6 +715,7 @@ TEE_Result vm_unmap(struct user_mode_ctx *uctx, vaddr_t va, size_t len)
 	struct vm_region *r = NULL;
 	struct vm_region *r_next = NULL;
 	size_t end_va = 0;
+	size_t unmap_end_va = 0;
 	size_t l = 0;
 
 	assert(thread_get_tsd()->ctx == &uctx->ctx);
@@ -734,11 +735,12 @@ TEE_Result vm_unmap(struct user_mode_ctx *uctx, vaddr_t va, size_t len)
 
 	while (true) {
 		r_next = TAILQ_NEXT(r, link);
+		unmap_end_va = r->va + r->size;
 		if (mobj_is_paged(r->mobj))
 			tee_pager_rem_um_region(uctx, r->va, r->size);
 		maybe_free_pgt(uctx, r);
 		umap_remove_region(&uctx->vm_info, r);
-		if (!r_next || r->va + r->size == end_va)
+		if (!r_next || unmap_end_va == end_va)
 			break;
 		r = r_next;
 	}


### PR DESCRIPTION
vm_unmap() use r->va and r->size after it already freed cause the
end VA address calulation to be wrong and the while loop keep going
till it unmap rest of the regions. This bug usually cause TA to
crash with translation fault since vm_unmap() removed text and data
regions.

Signed-off-by: Khoa Hoang <admin@khoahoang.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
