### PR TITLE
mk/compile.mk: fix cc-option macro with Clang

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -17,8 +17,8 @@ objs		:=
 # Disable all builtin rules
 .SUFFIXES:
 
-__cc-option = $(if $(shell $(CC$(sm)) $(1) -c -x c /dev/null -o /dev/null 2>&1 >/dev/null),$(2),$(1))
-_cc-opt-cached-var-name = cached-cc-option$(subst =,~,$(strip $(1)))$(subst $(empty) $(empty),,$(CC$(sm)))
+__cc-option = $(if $(shell $(CC$(sm)) $(1) -c -x c /dev/null -o /dev/null 2>/dev/null >/dev/null || echo "Not supported"),$(2),$(1))
+_cc-opt-cached-var-name = $(subst =,~,$(strip cached-cc-option-$(1)-$(subst $(empty) $(empty),,$(CC$(sm)))))
 define _cc-option
 $(eval _cached := $(call _cc-opt-cached-var-name,$1))
 $(eval $(_cached) := $(if $(filter $(origin $(_cached)),undefined),$(call __cc-option,$(1),$(2)),$($(_cached))))


### PR DESCRIPTION
The cc-option macro has two issues that make it behave incorrectly
when COMPILER=clang (it always returns an empty string):

1. When presented with a supported but unused option, Clang emits a
   warning to stderr (and returns a success code of 0). Therefore it is
   incorrect to check stderr to determine if an option is supported or
   not; we should rely on the return status instead.
2. When COMPILER=clang, the compile command $(CC$(sm)) contains an
   equal sign (e.g., clang --target=arm-linux-gnueabihf). This is not
   expected in the cc-option macro, currently only flags are supposed
   to potentially contain an equal sign.

This commit fixes both issues so that cc-option works with Clang as
well as GCC.

Fixes: 989ac108b0ef ("mk/compile.mk: add cc-option macro")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
