### PR TITLE
ci: travis: install codespell package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ notifications:
 git:
   depth: false
 
+before_install:
+  - sudo apt-get -y install codespell
+
 before_script:
   - export OPTEE_OS=$PWD
 


### PR DESCRIPTION
Since commit e7e3142343c2 ("checkpatch: add codespell support"),
checkpatch.pl expects to find the codespell dictionary at
/usr/share/codespell/dictionary.txt. This patch adds the missing
package.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
