### PR TITLE
scripts/pem_to_pub.py: use Cryptodome module instead of Crypto

### DIFF
--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -21,8 +21,8 @@ def get_args():
 
 def main():
     import array
-    from Crypto.PublicKey import RSA
-    from Crypto.Util.number import long_to_bytes
+    from Cryptodome.PublicKey import RSA
+    from Cryptodome.Util.number import long_to_bytes
 
     args = get_args()
 


### PR DESCRIPTION
Upgrade scripts/pem_to_pub.py to use module Cryptodome instead of
module Crypto for consistency with the other helper Python scripts
of OP-TEE OS package.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
