### PR TITLE
Fix cc-option and disable outline-atomics when applicable

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -128,7 +128,7 @@ arm32-platform-aflags-no-hard-float ?=
 
 arm64-platform-cflags-no-hard-float ?= -mgeneral-regs-only
 arm64-platform-cflags-hard-float ?=
-arm64-platform-cflags-generic ?= -mstrict-align
+arm64-platform-cflags-generic := -mstrict-align $(call cc-option,-mno-outline-atomics,)
 
 ifeq ($(DEBUG),1)
 # For backwards compatibility

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -1,3 +1,16 @@
+# Setup compiler for the core module
+ifeq ($(CFG_ARM64_core),y)
+arch-bits-core := 64
+else
+arch-bits-core := 32
+endif
+CROSS_COMPILE_core := $(CROSS_COMPILE$(arch-bits-core))
+COMPILER_core := $(COMPILER)
+include mk/$(COMPILER_core).mk
+
+# Defines the cc-option macro using the compiler set for the core module
+include mk/cc-option.mk
+
 CFG_LTC_OPTEE_THREAD ?= y
 # Size of emulated TrustZone protected SRAM, 448 kB.
 # Only applicable when paging is enabled.
@@ -148,14 +161,12 @@ core-platform-cflags += -fpie
 endif
 
 ifeq ($(CFG_ARM64_core),y)
-arch-bits-core := 64
 core-platform-cppflags += $(arm64-platform-cppflags)
 core-platform-cflags += $(arm64-platform-cflags)
 core-platform-cflags += $(arm64-platform-cflags-generic)
 core-platform-cflags += $(arm64-platform-cflags-no-hard-float)
 core-platform-aflags += $(arm64-platform-aflags)
 else
-arch-bits-core := 32
 core-platform-cppflags += $(arm32-platform-cppflags)
 core-platform-cflags += $(arm32-platform-cflags)
 core-platform-cflags += $(arm32-platform-cflags-no-hard-float)
@@ -258,8 +269,8 @@ ta-mk-file-export-add-ta_arm64 += COMPILER ?= gcc_nl_
 ta-mk-file-export-add-ta_arm64 += COMPILER_ta_arm64 ?= $$(COMPILER)_nl_
 endif
 
-# Set cross compiler prefix for each submodule
-$(foreach sm, core $(ta-targets), $(eval CROSS_COMPILE_$(sm) ?= $(CROSS_COMPILE$(arch-bits-$(sm)))))
+# Set cross compiler prefix for each TA target
+$(foreach sm, $(ta-targets), $(eval CROSS_COMPILE_$(sm) ?= $(CROSS_COMPILE$(arch-bits-$(sm)))))
 
 arm32-sysreg-txt = core/arch/arm/kernel/arm32_sysreg.txt
 arm32-sysregs-$(arm32-sysreg-txt)-h := arm32_sysreg.h

--- a/core/core.mk
+++ b/core/core.mk
@@ -8,6 +8,7 @@ arch-dir	:= core/arch/$(ARCH)
 platform-dir	:= $(arch-dir)/plat-$(PLATFORM)
 include $(platform-dir)/conf.mk
 include mk/config.mk
+# $(ARCH).mk also sets the compiler for the core module
 include core/arch/$(ARCH)/$(ARCH).mk
 
 PLATFORM_$(PLATFORM) := y
@@ -15,10 +16,6 @@ PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
 
 $(eval $(call cfg-depends-all,CFG_PAGED_USER_TA,CFG_WITH_PAGER CFG_WITH_USER_TA))
 include core/crypto.mk
-
-# Setup compiler for this sub module
-COMPILER_$(sm)		?= $(COMPILER)
-include mk/$(COMPILER_$(sm)).mk
 
 cppflags$(sm)	+= -D__KERNEL__
 

--- a/mk/cc-option.mk
+++ b/mk/cc-option.mk
@@ -1,0 +1,9 @@
+_cc-option-supported = $(if $(shell $(CC$(sm)) $(1) -c -x c /dev/null -o /dev/null 2>/dev/null >/dev/null || echo "Not supported"),,1)
+_cc-opt-cached-var-name = $(subst =,~,$(strip cached-cc-option-$(1)-$(subst $(empty) $(empty),,$(CC$(sm)))))
+define _cc-option
+$(eval _var_name := $(call _cc-opt-cached-var-name,$(1)))
+$(eval $(_var_name) := $(if $(filter $(origin $(_var_name)),undefined),$(call _cc-option-supported,$(1)),$($(_var_name))))
+$(if $($(_var_name)),$(1),$(2))
+endef
+cc-option = $(strip $(call _cc-option,$(1),$(2)))
+

--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -26,7 +26,7 @@ comp-cflags-warns-clang := -Wno-language-extension-token \
 
 # Note, use the compiler runtime library (libclang_rt.builtins.*.a) instead of
 # libgcc for clang
-libgcc$(sm)	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) $(comp-cflags$(sm)) \
+libgcc$(sm)	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) \
 			-rtlib=compiler-rt -print-libgcc-file-name 2> /dev/null)
 
 # Core ASLR relies on the executable being ready to run from its preferred load

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -17,12 +17,12 @@ objs		:=
 # Disable all builtin rules
 .SUFFIXES:
 
-__cc-option = $(if $(shell $(CC$(sm)) $(1) -c -x c /dev/null -o /dev/null 2>&1 >/dev/null),$(2),$(1))
-_cc-opt-cached-var-name = cached-cc-option$(subst =,~,$(strip $(1)))$(subst $(empty) $(empty),,$(CC$(sm)))
+_cc-option-supported = $(if $(shell $(CC$(sm)) $(1) -c -x c /dev/null -o /dev/null 2>/dev/null >/dev/null || echo "Not supported"),,1)
+_cc-opt-cached-var-name = $(subst =,~,$(strip cached-cc-option-$(1)-$(subst $(empty) $(empty),,$(CC$(sm)))))
 define _cc-option
-$(eval _cached := $(call _cc-opt-cached-var-name,$1))
-$(eval $(_cached) := $(if $(filter $(origin $(_cached)),undefined),$(call __cc-option,$(1),$(2)),$($(_cached))))
-$($(_cached))
+$(eval _var_name := $(call _cc-opt-cached-var-name,$(1)))
+$(eval $(_var_name) := $(if $(filter $(origin $(_var_name)),undefined),$(call _cc-option-supported,$(1)),$($(_var_name))))
+$(if $($(_var_name)),$(1),$(2))
 endef
 cc-option = $(strip $(call _cc-option,$(1),$(2)))
 

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -17,15 +17,6 @@ objs		:=
 # Disable all builtin rules
 .SUFFIXES:
 
-_cc-option-supported = $(if $(shell $(CC$(sm)) $(1) -c -x c /dev/null -o /dev/null 2>/dev/null >/dev/null || echo "Not supported"),,1)
-_cc-opt-cached-var-name = $(subst =,~,$(strip cached-cc-option-$(1)-$(subst $(empty) $(empty),,$(CC$(sm)))))
-define _cc-option
-$(eval _var_name := $(call _cc-opt-cached-var-name,$(1)))
-$(eval $(_var_name) := $(if $(filter $(origin $(_var_name)),undefined),$(call _cc-option-supported,$(1)),$($(_var_name))))
-$(if $($(_var_name)),$(1),$(2))
-endef
-cc-option = $(strip $(call _cc-option,$(1),$(2)))
-
 comp-cflags$(sm) = -std=gnu99
 comp-aflags$(sm) =
 comp-cppflags$(sm) =

--- a/mk/gcc.mk
+++ b/mk/gcc.mk
@@ -12,7 +12,7 @@ nostdinc$(sm)	:= -nostdinc -isystem $(shell $(CC$(sm)) \
 			-print-file-name=include 2> /dev/null)
 
 # Get location of libgcc from gcc
-libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) $(comp-cflags$(sm)) \
+libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) \
 			-print-libgcc-file-name 2> /dev/null)
 
 # Define these to something to discover accidental use

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -89,6 +89,9 @@ clean:
 	@$(cmd-echo-silent) '  CLEAN   $(O)'
 	${q}if [ -d "$(O)" ]; then $(RMDIR) $(O); fi
 
+include  $(ta-dev-kit-dir$(sm))/mk/$(COMPILER_$(sm)).mk
+include  $(ta-dev-kit-dir$(sm))/mk/cc-option.mk
+
 subdirs = .
 include  $(ta-dev-kit-dir$(sm))/mk/subdir.mk
 
@@ -103,7 +106,6 @@ endif
 endif
 
 SCRIPTS_DIR := $(ta-dev-kit-dir)/scripts
-include  $(ta-dev-kit-dir$(sm))/mk/$(COMPILER_$(sm)).mk
 include  $(ta-dev-kit-dir$(sm))/mk/compile.mk
 
 ifneq ($(user-ta-uuid),)

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -143,6 +143,7 @@ $(foreach f, $(libfiles), \
 
 # Copy .mk files
 ta-mkfiles = mk/compile.mk mk/subdir.mk mk/gcc.mk mk/clang.mk mk/cleandirs.mk \
+	mk/cc-option.mk \
 	ta/arch/$(ARCH)/link.mk ta/arch/$(ARCH)/link_shlib.mk \
 	ta/mk/ta_dev_kit.mk
 


### PR DESCRIPTION
This is a follow-up to https://github.com/OP-TEE/optee_os/pull/3874 which I unfortunately had to revert until I could investigate a few issues.

Well there it is, I have now fixed the cc-option macro and (hopefully) dealt with circular dependencies so that it can finally be used as intended.

I spent quite some time figuring out the root cause of the `bash: --: invalid option` [error](https://github.com/OP-TEE/optee_os/pull/3874#issuecomment-633617767), the reason is we were using `?=` instead of `:=` when defining the platform flags but the latter form is needed for immediate evaluation of `$(call cc-option...)`, i.e., with the current value of `$(CC$(sm))`.

Perhaps a global replace of `?=` with `:=` would be in order for everything but the `CFG_` flags (which have a [good reason](https://optee.readthedocs.io/en/latest/building/gits/optee_os.html#configuration-variables) for using `?=`, and they do not get changing values anyways).

@JPEWdev please let me know if this works for you with GCC 10. Thanks!