### PR TITLE
plat-imx: remove CFG_BOOT_SYNC_CPU

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -350,7 +350,6 @@ $(call force,CFG_GENERIC_BOOT,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_PM_STUBS,y)
 
-CFG_BOOT_SYNC_CPU ?= n
 CFG_BOOT_SECONDARY_REQUEST ?= y
 CFG_DT ?= y
 CFG_PAGEABLE_ADDR ?= 0

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -176,26 +176,3 @@ void main_secondary_init_gic(void)
 	gic_cpu_init(&gic_data);
 }
 #endif
-
-#if defined(CFG_BOOT_SYNC_CPU)
-static void psci_boot_allcpus(void)
-{
-	vaddr_t src_base = core_mmu_get_va(SRC_BASE, MEM_AREA_TEE_COHERENT);
-	uint32_t pa = virt_to_phys((void *)TEE_TEXT_VA_START);
-
-	/* set secondary entry address and release core */
-	io_write32(src_base + SRC_GPR1 + 8, pa);
-	io_write32(src_base + SRC_GPR1 + 16, pa);
-	io_write32(src_base + SRC_GPR1 + 24, pa);
-
-	io_write32(src_base + SRC_SCR, BM_SRC_SCR_CPU_ENABLE_ALL);
-}
-#endif
-
-void plat_primary_init_early(void)
-{
-	/* primary core */
-#if defined(CFG_BOOT_SYNC_CPU)
-	psci_boot_allcpus()
-#endif
-}


### PR DESCRIPTION
Following up on @clementfaure suggestion (#3869), remove
CFG_BOOT_SYNC_CPU.

It was disabled by default, and no i.MX platform was enabling it anyway.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
