### PR TITLE
drivers: imx_i2c: add i2c support

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -71,6 +71,11 @@ L:	Broadcom <bcm-optee-feedback-list.pdl@broadcom.com>
 S:	Maintained
 F:	core/arch/arm/plat-bcm/
 
+Core Drivers I2C
+R:	Jorge Ramirez <jorge@foundries.io>
+S:	Maintained
+F:	core/drivers/imx_i2c.c
+
 Function Graph Tracer (ftrace) support
 R:	Sumit Garg <sumit.garg@linaro.org> [@b49020]
 S:	Maintained

--- a/core/arch/arm/plat-imx/registers/imx8m-crm.h
+++ b/core/arch/arm/plat-imx/registers/imx8m-crm.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 Foundries Ltd
+ */
+
+#ifndef __IMX8M_CRM_H
+#define __IMX8M_CRM_H
+
+/* CCGRx Registers (Clock Gating) */
+#define CCM_CCGR0		0x4000
+#define CCM_CCGRx_OFFSET	0x10
+#define CCM_CCGRx(idx)		(((idx) * CCM_CCGRx_OFFSET) + CCM_CCGR0)
+#define CCM_CCGRx_SET(idx)	(CCM_CCGRx(idx) + 0x4)
+#define CCM_CCGRx_CLR(idx)	(CCM_CCGRx(idx) + 0x8)
+#define CCM_CCGRx_TOG(idx)	(CCM_CCGRx(idx) + 0xC)
+
+#define BS_CCM_CCGRx_SETTING(idx)	((idx) * 4)
+#define BM_CCM_CCGRx_SETTING(idx)	\
+			SHIFT_U32(0x3, BS_CCM_CCGRx_SETTING(idx))
+#define CCM_CCGRx_DISABLE(idx)		\
+			SHIFT_U32(0, BS_CCM_CCGRx_SETTING(idx))
+#define CCM_CCGRx_RUN(idx)		\
+			BIT32(BS_CCM_CCGRx_SETTING(idx))
+#define CCM_CCGRx_RUN_WAIT(idx)		\
+			SHIFT_U32(0x2, BS_CCM_CCGRx_SETTING(idx))
+#define CCM_CCGRx_ALWAYS_ON(idx)	\
+			SHIFT_U32(0x3, BS_CCM_CCGRx_SETTING(idx))
+
+#define CCM_CCRG_I2C1		23
+#define CCM_CCRG_I2C2		24
+#define CCM_CCRG_I2C3		25
+#define I2C_CLK_CGR(__x)	CCM_CCRG_I2C##__x
+
+#endif  /* __IMX8M_CRM_H */

--- a/core/arch/arm/plat-imx/registers/imx8m.h
+++ b/core/arch/arm/plat-imx/registers/imx8m.h
@@ -6,6 +6,8 @@
 #ifndef __IMX8M_H__
 #define __IMX8M_H__
 
+#include <registers/imx8m-crm.h>
+
 #define GICD_BASE	0x38800000
 #define GICR_BASE	0x38880000
 #define UART1_BASE	0x30860000
@@ -14,13 +16,36 @@
 #define UART4_BASE	0x30A60000
 #define TZASC_BASE	0x32F80000
 #define CAAM_BASE	0x30900000
+#define CCM_BASE	0x30380000
 #define ANATOP_BASE	0x30360000
+#define IOMUXC_BASE	0x30330000
 
 #ifdef CFG_MX8MQ
 #define DIGPROG_OFFSET	0x06c
 #endif
 #if defined(CFG_MX8MM) || defined(CFG_MX8MN)
 #define DIGPROG_OFFSET	0x800
+#endif
+
+#if defined(CFG_MX8MM)
+#define I2C1_BASE		0x30a20000
+#define I2C2_BASE		0x30a30000
+#define I2C3_BASE		0x30a40000
+
+#define IOMUXC_I2C1_SCL_CFG	0x47C
+#define IOMUXC_I2C1_SDA_CFG	0x480
+#define I2C_CFG_SCL(__x)	(IOMUXC_I2C1_SCL_CFG + ((__x) - 1) * 0x8)
+#define I2C_CFG_SDA(__x)	(IOMUXC_I2C1_SDA_CFG + ((__x) - 1) * 0x8)
+
+#define IOMUXC_I2C1_SCL_MUX	0x214
+#define IOMUXC_I2C1_SDA_MUX	0x218
+#define I2C_MUX_SCL(__x)	(IOMUXC_I2C1_SCL_MUX + ((__x) - 1) * 0x8)
+#define I2C_MUX_SDA(__x)	(IOMUXC_I2C1_SDA_MUX + ((__x) - 1) * 0x8)
+
+#define IOMUXC_I2C_MUX_VAL	0x010
+#define IOMUXC_I2C_CFG_VAL	0x1c3
+#define I2C_MUX_VAL(__x)	IOMUXC_I2C_MUX_VAL
+#define I2C_CFG_VAL(__x)	IOMUXC_I2C_CFG_VAL
 #endif
 
 #endif /* __IMX8M_H__ */

--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * (c) 2020 Jorge Ramirez <jorge@foundries.io>, Foundries Ltd.
+ */
+#include <arm.h>
+#include <drivers/imx_i2c.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <stdlib.h>
+#include <trace.h>
+#include <util.h>
+
+#define I2C_CLK_RATE	24000000 /* Bits per second */
+
+static struct io_pa_va i2c_bus[] = {
+	{ .pa = I2C1_BASE, },
+	{ .pa = I2C2_BASE, },
+	{ .pa = I2C3_BASE, },
+};
+
+static struct imx_i2c_clk {
+	struct io_pa_va base;
+	uint32_t i2c[ARRAY_SIZE(i2c_bus)];
+} i2c_clk = {
+	.base.pa = CCM_BASE,
+	.i2c = { I2C_CLK_CGR(1), I2C_CLK_CGR(2), I2C_CLK_CGR(3), },
+};
+
+static struct imx_i2c_mux {
+	struct io_pa_va base;
+	struct imx_i2c_mux_regs {
+		uint32_t scl_mux;
+		uint32_t scl_cfg;
+		uint32_t sda_mux;
+		uint32_t sda_cfg;
+	} i2c[ARRAY_SIZE(i2c_bus)];
+} i2c_mux = {
+	.base.pa = IOMUXC_BASE,
+	.i2c = {{ .scl_mux = I2C_MUX_SCL(1), .scl_cfg = I2C_CFG_SCL(1),
+		.sda_mux = I2C_MUX_SDA(1), .sda_cfg = I2C_CFG_SDA(1), },
+	       { .scl_mux = I2C_MUX_SCL(2), .scl_cfg = I2C_CFG_SCL(2),
+		.sda_mux = I2C_MUX_SDA(2), .sda_cfg = I2C_CFG_SDA(2), },
+	       { .scl_mux = I2C_MUX_SCL(3), .scl_cfg = I2C_CFG_SCL(3),
+		.sda_mux = I2C_MUX_SDA(3), .sda_cfg = I2C_CFG_SDA(3), },},
+};
+
+#define I2DR				0x10
+#define I2SR				0x0C
+#define I2CR				0x08
+#define IFDR				0x04
+
+#define I2CR_IEN			BIT(7)
+#define I2CR_IIEN			BIT(6)
+#define I2CR_MSTA			BIT(5)
+#define I2CR_MTX			BIT(4)
+#define I2CR_TX_NO_AK			BIT(3)
+#define I2CR_RSTA			BIT(2)
+
+#define I2SR_ICF			BIT(7)
+#define I2SR_IBB			BIT(5)
+#define I2SR_IAL			BIT(4)
+#define I2SR_IIF			BIT(1)
+#define I2SR_RX_NO_AK			BIT(0)
+
+static uint8_t i2c_io_read8(uint8_t bid, uint32_t address)
+{
+	return io_read8(i2c_bus[bid].va + address);
+}
+
+static void i2c_io_write8(uint8_t bid, uint32_t address, uint8_t data)
+{
+	return io_write8(i2c_bus[bid].va + address, data);
+}
+
+static bool bus_is_idle(uint32_t sr)
+{
+	return (sr & I2SR_IBB) == 0;
+}
+
+static bool bus_is_busy(uint32_t sr)
+{
+	return !bus_is_idle(sr);
+}
+
+static bool isr_active(uint32_t sr)
+{
+	return (sr & I2SR_IIF) == I2SR_IIF;
+}
+
+static struct ifdr_pair {
+	uint32_t divider;
+	uint8_t prescaler;
+} ifdr_table[] = {
+	{ 22,	0x20 }, { 24,	0x21 }, { 26,	0x22 }, { 28,	0x23 },
+	{ 30,	0x00 }, { 32,	0x24 }, { 36,	0x25 }, { 40,	0x26 },
+	{ 42,	0x03 }, { 44,	0x27 }, { 48,	0x28 }, { 52,	0x05 },
+	{ 56,	0x29 }, { 60,	0x06 }, { 64,	0x2A }, { 72,	0x2B },
+	{ 80,	0x2C }, { 88,	0x09 }, { 96,	0x2D }, { 104,	0x0A },
+	{ 112,	0x2E }, { 128,	0x2F }, { 144,	0x0C }, { 160,	0x30 },
+	{ 192,	0x31 }, { 224,	0x32 }, { 240,	0x0F }, { 256,	0x33 },
+	{ 288,	0x10 }, { 320,	0x34 }, { 384,	0x35 }, { 448,	0x36 },
+	{ 480,	0x13 }, { 512,	0x37 }, { 576,	0x14 }, { 640,	0x38 },
+	{ 768,	0x39 }, { 896,	0x3A }, { 960,	0x17 }, { 1024,	0x3B },
+	{ 1152,	0x18 }, { 1280,	0x3C }, { 1536,	0x3D }, { 1792,	0x3E },
+	{ 1920,	0x1B }, { 2048,	0x3F }, { 2304,	0x1C }, { 2560,	0x1D },
+	{ 3072,	0x1E }, { 3840,	0x1F }
+};
+
+static void i2c_set_prescaler(uint8_t bid, uint32_t bps)
+{
+	struct ifdr_pair *p = ifdr_table;
+	struct ifdr_pair *q = p + ARRAY_SIZE(ifdr_table) - 1;
+	uint32_t div = (I2C_CLK_RATE + bps - 1) / bps;
+
+	if (div < p->divider)
+		q = p;
+	else if (div > q->divider)
+		p = q;
+
+	while (p != q) {
+		if (div <= p->divider)
+			break;
+		p++;
+	}
+
+	i2c_io_write8(bid, IFDR, p->prescaler);
+}
+
+static void i2c_set_bus_speed(uint8_t bid, int bps)
+{
+	/* Enable the clock */
+	io_write32(i2c_clk.base.va + CCM_CCGRx_SET(i2c_clk.i2c[bid]),
+		   CCM_CCGRx_ALWAYS_ON(0));
+
+	i2c_set_prescaler(bid, bps);
+}
+
+static TEE_Result i2c_sync_bus(uint8_t bid, bool (*match)(uint32_t),
+			       uint32_t *status)
+{
+	uint64_t tref = timeout_init_us(100000);
+	uint32_t sr = 0;
+
+	while (!timeout_elapsed(tref)) {
+		sr = i2c_io_read8(bid, I2SR);
+		if (sr & I2SR_IAL) {
+			EMSG("bus arbitration lost");
+			i2c_io_write8(bid, I2SR, sr & ~I2SR_IAL);
+			return TEE_ERROR_COMMUNICATION;
+		}
+		if ((*match)(sr)) {
+			if (status)
+				*status = sr;
+			return TEE_SUCCESS;
+		}
+	}
+
+	return TEE_ERROR_BUSY;
+}
+
+static TEE_Result i2c_idle_bus(uint8_t bid)
+{
+	uint8_t tmp = i2c_io_read8(bid, I2CR) & ~I2CR_MSTA;
+	TEE_Result ret = TEE_SUCCESS;
+
+	i2c_io_write8(bid, I2CR, tmp);
+	ret = i2c_sync_bus(bid, &bus_is_idle, NULL);
+	i2c_io_write8(bid, I2SR, 0);
+
+	return ret;
+}
+
+static TEE_Result i2c_write_byte(uint8_t bid, uint8_t byte)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	uint32_t status = 0;
+
+	i2c_io_write8(bid, I2DR, byte);
+	ret = i2c_sync_bus(bid, &isr_active, &status);
+	i2c_io_write8(bid, I2SR, 0);
+
+	if (ret == TEE_SUCCESS && (status & I2SR_RX_NO_AK))
+		return TEE_ERROR_BAD_STATE;
+
+	return ret;
+}
+
+static TEE_Result i2c_read_byte(uint8_t bid, uint8_t *p)
+{
+	TEE_Result ret = TEE_SUCCESS;
+
+	*p = i2c_io_read8(bid, I2DR);
+	ret = i2c_sync_bus(bid, &isr_active, NULL);
+	i2c_io_write8(bid, I2SR, 0);
+
+	return ret;
+}
+
+static TEE_Result i2c_write_data(uint8_t bid, const uint8_t *buf, int len)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	uint32_t tmp = 0;
+
+	if (!len)
+		return TEE_SUCCESS;
+
+	tmp = i2c_io_read8(bid, I2CR) | I2CR_MTX | I2CR_TX_NO_AK;
+	i2c_io_write8(bid, I2CR, tmp);
+
+	while (len--) {
+		ret = i2c_write_byte(bid, *buf++);
+		if (ret != TEE_SUCCESS)
+			return ret;
+	}
+
+	return ret;
+}
+
+static TEE_Result i2c_read_data(uint8_t bid, uint8_t *buf, int len)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	uint8_t dummy = 0;
+	uint32_t tmp = 0;
+
+	if (!len)
+		return TEE_SUCCESS;
+
+	tmp = i2c_io_read8(bid, I2CR) & ~I2CR_MTX;
+	tmp = (len == 1) ? tmp | I2CR_TX_NO_AK : tmp & ~I2CR_TX_NO_AK;
+	i2c_io_write8(bid, I2CR, tmp);
+	i2c_io_read8(bid, I2DR);
+
+	ret = i2c_read_byte(bid, &dummy);
+	if (ret != TEE_SUCCESS)
+		return ret;
+
+	/*
+	 * A data transfer ends when the master signals a stop; for a master
+	 * receiver to terminate a transfer it must inform the slave transmiter
+	 * by not acknowledging the last data byte. This is done by setting the
+	 * transmit acknowledge bit before reading the next-to-last byte.
+	 */
+	do {
+		if (len == 2) {
+			tmp = i2c_io_read8(bid, I2CR) | I2CR_TX_NO_AK;
+			i2c_io_write8(bid, I2CR, tmp);
+		}
+
+		ret = i2c_read_byte(bid, buf++);
+		if (ret != TEE_SUCCESS)
+			return ret;
+	} while (len--);
+
+	return ret;
+}
+
+static TEE_Result i2c_init_transfer(uint8_t bid, uint8_t chip)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	uint32_t tmp = 0;
+
+	ret = i2c_idle_bus(bid);
+	if (ret != TEE_SUCCESS)
+		return ret;
+
+	/* Enable the interface */
+	i2c_io_write8(bid, I2CR, I2CR_IEN);
+
+	tmp = i2c_io_read8(bid, I2CR) | I2CR_MSTA;
+	i2c_io_write8(bid, I2CR, tmp);
+
+	/* Wait until the bus is active */
+	ret = i2c_sync_bus(bid, &bus_is_busy, NULL);
+	if (ret != TEE_SUCCESS)
+		return ret;
+
+	/* Slave address on the bus */
+	return i2c_write_data(bid, &chip, 1);
+}
+
+TEE_Result imx_i2c_read(uint8_t bid, uint8_t chip, uint8_t *buf, int len)
+{
+	TEE_Result ret = TEE_SUCCESS;
+
+	if (bid >= ARRAY_SIZE(i2c_bus))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if ((len && !buf) || chip > 0x7F)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	ret = i2c_init_transfer(bid, chip << 1 | BIT(0));
+	if (ret == TEE_SUCCESS)
+		ret = i2c_read_data(bid, buf, len);
+
+	if (i2c_idle_bus(bid) != TEE_SUCCESS)
+		IMSG("bus not idle");
+
+	return ret;
+}
+
+TEE_Result imx_i2c_write(uint8_t bid, uint8_t chip, const uint8_t *buf, int len)
+{
+	TEE_Result ret = TEE_SUCCESS;
+
+	if (bid >= ARRAY_SIZE(i2c_bus))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if ((len && !buf) || chip > 0x7F)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	ret = i2c_init_transfer(bid, chip << 1);
+	if (ret == TEE_SUCCESS)
+		ret = i2c_write_data(bid, buf, len);
+
+	if (i2c_idle_bus(bid) != TEE_SUCCESS)
+		IMSG("bus not idle");
+
+	return ret;
+}
+
+TEE_Result imx_i2c_probe(uint8_t bid, uint8_t chip)
+{
+	if (bid >= ARRAY_SIZE(i2c_bus))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (chip > 0x7F)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return imx_i2c_write(bid, chip, NULL, 0);
+}
+
+/*
+ * I2C bus initialization: configure the IOMUX and enable the clock.
+ * @bid: Bus ID: (0=I2C1), (1=I2C2), (2=I2C3).
+ * @bps: Bus baud rate, in bits per second.
+ */
+TEE_Result imx_i2c_init(uint8_t bid, int bps)
+{
+	struct imx_i2c_mux *mux = &i2c_mux;
+
+	if (bid >= ARRAY_SIZE(i2c_bus))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!bps)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	io_write32(mux->base.va + mux->i2c[bid].scl_mux, I2C_MUX_VAL(bid));
+	io_write32(mux->base.va + mux->i2c[bid].scl_cfg, I2C_CFG_VAL(bid));
+	io_write32(mux->base.va + mux->i2c[bid].sda_mux, I2C_MUX_VAL(bid));
+	io_write32(mux->base.va + mux->i2c[bid].sda_cfg, I2C_CFG_VAL(bid));
+
+	/* Baud rate in bits per second */
+	i2c_set_bus_speed(bid, bps);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result get_va(paddr_t pa, vaddr_t *va)
+{
+	if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, pa, 0x10000))
+		return TEE_ERROR_GENERIC;
+
+	*va = (vaddr_t)phys_to_virt(pa, MEM_AREA_IO_SEC);
+	if (*va)
+		return TEE_SUCCESS;
+
+	return TEE_ERROR_GENERIC;
+}
+
+static TEE_Result i2c_init(void)
+{
+	size_t n = 0;
+
+	if (get_va(i2c_clk.base.pa, &i2c_clk.base.va) != TEE_SUCCESS)
+		return TEE_ERROR_GENERIC;
+
+	if (get_va(i2c_mux.base.pa, &i2c_mux.base.va) != TEE_SUCCESS)
+		return TEE_ERROR_GENERIC;
+
+	for (n = 0; n < ARRAY_SIZE(i2c_bus); n++) {
+		if (get_va(i2c_bus[n].pa, &i2c_bus[n].va) != TEE_SUCCESS)
+			return TEE_ERROR_GENERIC;
+	}
+
+	return TEE_SUCCESS;
+}
+
+driver_init(i2c_init);

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -10,6 +10,7 @@ srcs-$(CFG_8250_UART) += serial8250_uart.c
 srcs-$(CFG_16550_UART) += ns16550.c
 srcs-$(CFG_IMX_SNVS) += imx_snvs.c
 srcs-$(CFG_IMX_UART) += imx_uart.c
+srcs-$(CFG_IMX_I2C) += imx_i2c.c
 srcs-$(CFG_IMX_LPUART) += imx_lpuart.c
 srcs-$(CFG_IMX_WDOG) += imx_wdog.c
 srcs-$(CFG_SPRD_UART) += sprd_uart.c

--- a/core/include/drivers/imx_i2c.h
+++ b/core/include/drivers/imx_i2c.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2020 Foundries.io
+ * Jorge Ramirez-Ortiz <jorge@foundries.io>
+ */
+#ifndef __DRIVERS_IMX_I2C_H
+#define __DRIVERS_IMX_I2C_H
+
+#include <stdint.h>
+#include <tee_api_types.h>
+
+TEE_Result imx_i2c_write(uint8_t bid, uint8_t chip, const uint8_t *p, int l);
+TEE_Result imx_i2c_read(uint8_t bid, uint8_t chip, uint8_t *p, int l);
+TEE_Result imx_i2c_probe(uint8_t bid, uint8_t chip);
+TEE_Result imx_i2c_init(uint8_t bid, int bps);
+
+#endif /*__DRIVERS_IMX_I2C_H*/


### PR DESCRIPTION
    This driver provides native access to the I2C bus on iMX.
    
    The driver will not query the clock hierarchy - to find the base clock
    rate - because it overcomplicates the deliverable for not much added
    value (this can be done at a later time if required).
    
    The U-Boot and Linux GPL code was initially used as a reference;
    however due to the simpler OP-TEE use case requirements, the code was
    later re-written following the reference manual [1].
    
    This driver will not access addresses within a I2C slave map.
    
    This driver must not be used while the Linux kernel is running unless
    the following is guaranteed:
     - that the I2C bus will not be suspended.
     - that there will not be collisions with other bus masters.
    
    Without those guarantees, please use a trampoline driver to route the
    I2C requests to Linux.
    
    Tested on imx8mm-lpddr4.
    
    [1] i.MX 8M Mini Applications Processor Reference Manual
        Document Number: IMX8MMMRM
        Rev.2 08/2019
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
