### PR TITLE
Clang 10 support

### DIFF
--- a/mk/cc-option.mk
+++ b/mk/cc-option.mk
@@ -7,3 +7,11 @@ $(if $($(_var_name)),$(1),$(2))
 endef
 cc-option = $(strip $(call _cc-option,$(1),$(2)))
 
+_ld-option-supported = $(if $(shell $(LD$(sm)) -v $(1) 2>/dev/null >/dev/null || echo "Not supported"),,1)
+_ld-opt-cached-var-name = $(subst =,~,$(subst $(empty) $(empty),,$(strip cached-ld-option-$(1)-$(LD$(sm)))))
+define _ld-option
+$(eval _var_name := $(call _ld-opt-cached-var-name,$(1)))
+$(eval $(_var_name) := $(if $(filter $(origin $(_var_name)),undefined),$(call _ld-option-supported,$(1)),$($(_var_name))))
+$(if $($(_var_name)),$(1),$(2))
+endef
+ld-option = $(strip $(call _ld-option,$(1),$(2)))

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -19,6 +19,7 @@ cleanfiles += $(link-out-dir)/$(shlibuuid).ta
 
 shlink-ldflags  = $(LDFLAGS)
 shlink-ldflags += -shared -z max-page-size=4096
+shlink-ldflags += $(call ld-option,-z separate-loadable-segments)
 shlink-ldflags += --as-needed # Do not add dependency on unused shlib
 
 shlink-ldadd  = $(LDADD)


### PR DESCRIPTION
Link shared libraries with the LLVM linker option `-z separate-loadable-segments` (when supported) so that the `PT_LOAD` segments are laid out as expected by `ldelf`.