### PR TITLE
core: arm: tee to linux i2c trampoline driver

### DIFF
--- a/core/arch/arm/kernel/rpc_io_i2c.c
+++ b/core/arch/arm/kernel/rpc_io_i2c.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2020 Foundries Ltd <jorge@foundries.io>
+ */
+#include <kernel/rpc_io_i2c.h>
+#include <kernel/thread.h>
+#include <mm/mobj.h>
+#include <optee_rpc_cmd.h>
+#include <string.h>
+
+/*
+ * @brief: i2c transfer request (read/write) via an adaptor from/to a device
+ * for a given length. It is the responsibility of the caller of this function
+ * to validate the number of bytes processed by the call.
+ *
+ * @param req:	mode: transfer mode is either read or write,
+ *		chip: the i2c device address (0..0x7F)
+ *		bus: the i2c adapter (REE bus ID where the chip sits)
+ *		buffer: the memory to access during the transfer,
+ *		buffer_len: the number of bytes to be processed,
+ * @param len: the number of bytes processed by the driver
+ * @returns: TEE_SUCCESS on success, TEE_ERROR_XXX on error
+ */
+TEE_Result rpc_io_i2c_transfer(struct rpc_i2c_request *req, size_t *len)
+{
+	struct thread_param p[3] = { };
+	TEE_Result res = TEE_SUCCESS;
+	struct mobj *mobj = NULL;
+	uint8_t *va = NULL;
+
+	assert(req);
+
+	if (!len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_KERNEL_PRIVATE,
+					req->buffer_len, &mobj);
+	if (!va)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	if (req->mode == RPC_I2C_MODE_WRITE)
+		memcpy(va, req->buffer, req->buffer_len);
+
+	p[0] = THREAD_PARAM_VALUE(IN, req->mode, req->bus, req->chip),
+	p[1] = THREAD_PARAM_MEMREF(INOUT, mobj, 0, req->buffer_len),
+	p[2] = THREAD_PARAM_VALUE(OUT, 0, 0, 0),
+
+	res = thread_rpc_cmd(OPTEE_RPC_CMD_I2C_TRANSFER, ARRAY_SIZE(p), p);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	/*
+	 * It's an error by normal world to report more processed bytes
+	 * than supplied, regardless of direction.
+	 */
+	if (p[2].u.value.a > req->buffer_len)
+		return TEE_ERROR_EXCESS_DATA;
+
+	*len = p[2].u.value.a;
+
+	if (req->mode == RPC_I2C_MODE_READ)
+		memcpy(req->buffer, va, *len);
+
+	return TEE_SUCCESS;
+}

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -6,6 +6,7 @@ srcs-$(CFG_SECSTOR_TA) += secstor_ta.c
 endif
 srcs-y += pseudo_ta.c
 srcs-y += tee_time.c
+srcs-y += rpc_io_i2c.c
 srcs-y += otp_stubs.c
 srcs-y += delay.c
 

--- a/core/include/kernel/rpc_io_i2c.h
+++ b/core/include/kernel/rpc_io_i2c.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020 Foundries Ltd <jorge@foundries.io>
+ */
+
+#ifndef __RPC_IO_I2C_H
+#define __RPC_IO_I2C_H
+
+#include <tee_api_types.h>
+
+enum rpc_i2c_mode {
+	RPC_I2C_MODE_WRITE = 0,
+	RPC_I2C_MODE_READ = 1,
+};
+
+/*
+ * The bus identifier defines an implicit ABI with the REE.
+ * Using this service to access i2c chips on REE dynamically assigned buses is
+ * not recommended due to the lack of guarantees that the REE will reuse the
+ * same bus identifier over reboots.
+ */
+struct rpc_i2c_request {
+	enum rpc_i2c_mode mode;
+	uint8_t bus; /* bus identifier used by the REE [0..n] */
+	uint8_t chip; /* chip identifier from the device data sheet [0..0x7f] */
+	uint8_t *buffer;
+	size_t buffer_len;
+};
+
+TEE_Result rpc_io_i2c_transfer(struct rpc_i2c_request *p, size_t *bytes);
+
+#endif /* __RPC_IO_I2C_H */

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -149,6 +149,18 @@
 #define OPTEE_RPC_CMD_BENCH_REG		20
 
 /*
+ * Transfer data in/out via I2C in master mode with a 7-bit address
+ *
+ * [in]     value[0].a	    Transfer mode (check enum rpc_i2c_mode for modes)
+ * [in]     value[0].b	    The I2C bus (a.k.a adapter)
+ * [in]     value[0].c	    The I2C chip to transfer from/to (a.k.a address)
+ *
+ * [in/out] memref[1]	    Buffer used to transfer the data
+ * [out]    value[2].a	    Number of bytes transferred by the actual driver
+ */
+#define OPTEE_RPC_CMD_I2C_TRANSFER	21
+
+/*
  * Definition of protocol for command OPTEE_RPC_CMD_FS
  */
 


### PR DESCRIPTION
core: arm: tee to linux i2c trampoline driver

Gives OP-TEE access to the i2c buses initialized and controlled by the
REE kernel. This is done by memory mapping a buffer from the thread's
cache where the input or output data is transferred.

Using this mechanism, OP-TEE clients do not have to worry about REE
RUNTIME_PM features switching off clocks from the controllers or
collisions with other bus masters.

This driver assumes that the I2C chip is on a REE statically assigned
bus which value is known to OP-TEE (it will not query/probe the REE).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
