### PR TITLE
Disable CFG_SCTLR_ALIGNMENT_CHECK (SCTLR.A) by default

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -79,7 +79,7 @@ ifeq ($(CFG_CORE_RODATA_NOEXEC),y)
 $(call force,CFG_CORE_RWDATA_NOEXEC,y)
 endif
 # 'y' to set the Alignment Check Enable bit in SCTLR/SCTLR_EL1, 'n' to clear it
-CFG_SCTLR_ALIGNMENT_CHECK ?= y
+CFG_SCTLR_ALIGNMENT_CHECK ?= n
 
 ifeq ($(CFG_CORE_LARGE_PHYS_ADDR),y)
 $(call force,CFG_WITH_LPAE,y)


### PR DESCRIPTION
With ARM CPUs, unaligned accesses are forbidden in a number of cases
such as when the MMU is disabled, or when device memory is concerned,
or with atomic instructions. However in the general case [1] and for
all modern ARMv7-A and ARMv8-A processors, they do not really matter.
Compilers such as GCC and Clang will generate unaligned accesses by
default; a specific flag (-mstrict-align or --mno-unaligned-access) has
to be supplied to prevent such code from being output.

[1] Roughly speaking: LDR/STR instructions operating on normal cached
memory.

The SCTLR.A bit ("Alignment check enable") defines whether the CPU
should allow these unaligned accesses (when set to 0) or should trap
(when set to 1). Having SCTLR.A enabled by default can be annoying for
a couple of reasons that we have met in practice:

 1. TAs linked against a third-party library. Since strict alignment
is not a compiler default, it is likely that a third party library does
not enforce it. With SCTLR.A == 1, such a library would have to be
recompiled in order to be used by a TA. Recompiling may or may not be
an easy task. Concrete example: libgcc_eh.a (the C++ exception handling
support library, part of the arm-linux-gnueabihf and aarch64-linux-gnu
toolchains).
 2. Compiler bug. For example, Clang 9.0.1 and 10.0.0 may erroneously
replace memcmp() calls with inline code performing unaligned accesses
[2].

All things being considered, it seems preferable for SCTLR.A to be
cleared by default, i.e., CFG_SCTLR_ALIGNMENT_CHECK=n, which is what
this commit does. The configuration variable is kept just in case.
Note that the Linux kernel and the KVM hypervisor do not set SCTLR.A or
HSCTLR.A either.

Link: [2] http://lists.llvm.org/pipermail/llvm-dev/2020-June/141985.html
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
