### PR TITLE
libutils: atomic.h: fix atomic_load_u32() types

### DIFF
--- a/lib/libutils/ext/include/atomic.h
+++ b/lib/libutils/ext/include/atomic.h
@@ -33,7 +33,7 @@ static inline unsigned int atomic_load_uint(unsigned int *p)
 	return __compiler_atomic_load(p);
 }
 
-static inline unsigned int atomic_load_u32(unsigned int *p)
+static inline uint32_t atomic_load_u32(const uint32_t *p)
 {
 	return __compiler_atomic_load(p);
 }


### PR DESCRIPTION
Prior to this patch was atomic_load_u32() using wrong types, unsigned int
instead of the expected uint32_t. Fix this by changing the types.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
