### PR TITLE
core: initialize curr_thread to -1 + fix print_kernel_stack

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -557,6 +557,12 @@ vaddr_t thread_stack_start(void);
 /* Returns the stack size for the current thread */
 size_t thread_stack_size(void);
 
+/*
+ * Returns the start and end addresses of the current stack (thread, temporary
+ * or abort stack).
+ */
+void get_stack_limits(vaddr_t *start, vaddr_t *end);
+
 bool thread_is_in_normal_mode(void);
 
 /*

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -280,6 +280,9 @@ bool thread_init_stack(uint32_t stack_id, vaddr_t sp);
  */
 void thread_init_threads(void);
 
+/* Set thread_core_local::curr_thread = -1 for all CPUs */
+void thread_clr_thread_core_local(void);
+
 /*
  * Initializes a thread to be used during boot
  */

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1146,6 +1146,13 @@ static void init_primary(unsigned long pageable_part, unsigned long nsec_entry)
 	thread_set_exceptions(THREAD_EXCP_ALL);
 	primary_save_cntfrq();
 	init_vfp_sec();
+	/*
+	 * Pager: init_runtime() calls thread_kernel_enable_vfp() so we must
+	 * set a current thread right now to avoid a chicken-and-egg problem
+	 * (thread_init_boot_thread() sets the current thread but needs
+	 * things set by init_runtime()).
+	 */
+	thread_get_core_local()->curr_thread = 0;
 	init_runtime(pageable_part);
 
 #ifndef CFG_VIRTUALIZATION

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -457,6 +457,9 @@ shadow_stack_access_ok:
 
 	set_sp
 
+	/* curr_thread needs to be -1 until threads are properly initialized */
+	bl	thread_clr_thread_core_local
+
 	/* complete ARM secure MP common configuration */
 	bl	plat_primary_init_early
 

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -148,6 +148,9 @@ clear_nex_bss:
 	/* Setup SP_EL0 and SP_EL1, SP will be set to SP_EL0 */
 	set_sp
 
+	/* curr_thread needs to be -1 until threads are properly initialized */
+	bl	thread_clr_thread_core_local
+
 	/* Enable aborts now that we can receive exceptions */
 	msr	daifclr, #DAIFBIT_ABT
 

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -892,7 +892,7 @@ static void init_user_kcode(void)
 
 void thread_init_threads(void)
 {
-	size_t n;
+	size_t n = 0;
 
 	init_thread_stacks();
 	pgt_init();
@@ -903,6 +903,11 @@ void thread_init_threads(void)
 		TAILQ_INIT(&threads[n].tsd.sess_stack);
 		SLIST_INIT(&threads[n].tsd.pgt_cache);
 	}
+}
+
+void thread_clr_thread_core_local(void)
+{
+	size_t n = 0;
 
 	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
 		thread_core_local[n].curr_thread = -1;

--- a/core/arch/arm/kernel/unwind_arm32.c
+++ b/core/arch/arm/kernel/unwind_arm32.c
@@ -450,13 +450,12 @@ void print_stack_arm32(int level, struct unwind_state_arm32 *state,
 
 void print_kernel_stack(int level)
 {
-	struct unwind_state_arm32 state;
+	struct unwind_state_arm32 state = {};
 	uaddr_t exidx = (vaddr_t)__exidx_start;
 	size_t exidx_sz = (vaddr_t)__exidx_end - (vaddr_t)__exidx_start;
-	vaddr_t stack = thread_stack_start();
-	size_t stack_size = thread_stack_size();
+	vaddr_t stack_start = 0;
+	vaddr_t stack_end = 0;
 
-	memset(&state, 0, sizeof(state));
 	/* r7: Thumb-style frame pointer */
 	state.registers[7] = read_r7();
 	/* r11: ARM-style frame pointer */
@@ -465,7 +464,9 @@ void print_kernel_stack(int level)
 	state.registers[LR] = read_lr();
 	state.registers[PC] = (uint32_t)print_kernel_stack;
 
-	print_stack_arm32(level, &state, exidx, exidx_sz, stack, stack_size);
+	get_stack_limits(&stack_start, &stack_end);
+	print_stack_arm32(level, &state, exidx, exidx_sz, stack_start,
+			  stack_end - stack_start);
 }
 
 #endif

--- a/core/arch/arm/kernel/unwind_arm64.c
+++ b/core/arch/arm/kernel/unwind_arm64.c
@@ -122,15 +122,15 @@ void print_stack_arm64(int level, struct unwind_state_arm64 *state,
 
 void print_kernel_stack(int level)
 {
-	struct unwind_state_arm64 state;
-	uaddr_t stack = thread_stack_start();
-	size_t stack_size = thread_stack_size();
+	struct unwind_state_arm64 state = {};
+	vaddr_t stack_start = 0;
+	vaddr_t stack_end = 0;
 
-	memset(&state, 0, sizeof(state));
 	state.pc = read_pc();
 	state.fp = read_fp();
 
-	print_stack_arm64(level, &state, stack, stack_size);
+	get_stack_limits(&stack_start, &stack_end);
+	print_stack_arm64(level, &state, stack_start, stack_end - stack_start);
 }
 
 #endif


### PR DESCRIPTION
The struct thread_core_local for each CPU is global, hence initialized
to zero when .bss is cleared. So before threads are initialized we have
a seemingly valid curr_thread value (0) when we should really have -1.
thread_get_id_may_fail() can return 0 although there is no current
thread.

Fix this by setting curr_thread to -1 earlier in the boot.

Note: this moves code out of thread_init_threads(), which is called by
virt_guest_created() when virtualization is enabled. I think it is the
right thing to do because I see no reason why the thread_core_local
structures should be cleared when a guest is added (the data belong to
.nex_bss).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
