### PR TITLE
core: arm64: clang: increase temporary stack size

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -56,7 +56,11 @@
 #endif /*ARM32*/
 
 #ifdef ARM64
+#if defined(__clang__) && !defined(CFG_CC_OPTIMIZE_FOR_SIZE)
+#define STACK_TMP_SIZE		(4096 + STACK_TMP_OFFS)
+#else
 #define STACK_TMP_SIZE		(2048 + STACK_TMP_OFFS)
+#endif
 #define STACK_THREAD_SIZE	8192
 
 #if TRACE_LEVEL > 0


### PR DESCRIPTION
When building for HiKey with Clang 10.0.0 and DEBUG=1 we get the
following panic:

 D/TC:0 0 check_pa_matches_va:2120 va 0x3b000000 maps 0x3f200000, expect 0x0
 E/TC:0 0 Panic at core/arch/arm/mm/core_mmu.c:2121 <check_pa_matches_va>

The root cause is an overflow of the temporary stack. DEBUG=1 sets
CFG_CC_OPTIMIZE_FOR_SIZE=n which in turn sets the optimization flags to
-O0 instead of -Os. In this configuration, Clang apparently needs much
more stack space (not something observed with GCC).

This commit increases the temporary stacks from approximately 2K per
core to approximately 4K per core.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Acked-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
