### PR TITLE
core: add missing THREAD_CLF_TMP flag updates

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -265,6 +265,8 @@ void thread_init_per_cpu(void);
 
 struct thread_core_local *thread_get_core_local(void);
 
+void thread_core_local_set_tmp_stack_flag(void);
+
 /*
  * Sets the stacks to be used by the different threads. Use THREAD_ID_0 for
  * first stack, THREAD_ID_0 + 1 for the next and so on.

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1174,6 +1174,7 @@ void __weak paged_init_primary(unsigned long fdt)
 	configure_console_from_dt();
 
 	IMSG("OP-TEE version: %s", core_v_str);
+	IMSG("Primary CPU initializing");
 #ifdef CFG_CORE_ASLR
 	DMSG("Executing at offset %#lx with virtual load address %#"PRIxVA,
 	     (unsigned long)boot_mmu_config.load_offset, VCORE_START_VA);
@@ -1189,7 +1190,7 @@ void __weak paged_init_primary(unsigned long fdt)
 	core_mmu_init_virtualization();
 #endif
 	call_finalcalls();
-	DMSG("Primary CPU switching to normal world boot");
+	IMSG("Primary CPU switching to normal world boot");
 }
 
 /* What this function is using is needed each time another CPU is started */
@@ -1197,6 +1198,8 @@ DECLARE_KEEP_PAGER(boot_get_handlers);
 
 static void init_secondary_helper(unsigned long nsec_entry)
 {
+	IMSG("Secondary CPU %zu initalizing", get_core_pos());
+
 	/*
 	 * Mask asynchronous exceptions before switch to the thread vector
 	 * as the thread handler requires those to be masked while
@@ -1213,7 +1216,7 @@ static void init_secondary_helper(unsigned long nsec_entry)
 	init_vfp_sec();
 	init_vfp_nsec();
 
-	DMSG("Secondary CPU Switching to normal world boot");
+	IMSG("Secondary CPU %zu switching to normal world boot", get_core_pos());
 }
 
 /*
@@ -1238,7 +1241,6 @@ void __weak boot_init_primary(unsigned long pageable_part,
 unsigned long boot_cpu_on_handler(unsigned long a0 __maybe_unused,
 				  unsigned long a1 __unused)
 {
-	DMSG("cpu %zu: a0 0x%lx", get_core_pos(), a0);
 	init_secondary_helper(PADDR_INVALID);
 	return 0;
 }

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1198,6 +1198,7 @@ DECLARE_KEEP_PAGER(boot_get_handlers);
 
 static void init_secondary_helper(unsigned long nsec_entry)
 {
+	thread_core_local_set_tmp_stack_flag();
 	IMSG("Secondary CPU %zu initalizing", get_core_pos());
 
 	/*

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -28,6 +28,7 @@ static unsigned int thread_rpc_pnum;
 
 void thread_handle_fast_smc(struct thread_smc_args *args)
 {
+	thread_core_local_set_tmp_stack_flag();
 	thread_check_canaries();
 
 #ifdef CFG_VIRTUALIZATION
@@ -54,6 +55,7 @@ uint32_t thread_handle_std_smc(uint32_t a0, uint32_t a1, uint32_t a2,
 {
 	uint32_t rv = OPTEE_SMC_RETURN_OK;
 
+	thread_core_local_set_tmp_stack_flag();
 	thread_check_canaries();
 
 #ifdef CFG_VIRTUALIZATION

--- a/core/kernel/initcall.c
+++ b/core/kernel/initcall.c
@@ -25,8 +25,6 @@ void __weak call_initcalls(void)
 			     " failed", (vaddr_t)call - VCORE_START_VA);
 		}
 	}
-
-	IMSG("Initialized");
 }
 
 /*
@@ -46,6 +44,4 @@ void __weak call_finalcalls(void)
 			     " failed", (vaddr_t)call - VCORE_START_VA);
 		}
 	}
-
-	IMSG("Done");
 }


### PR DESCRIPTION
There are a few places where the value of thread_core_local::flags
does not reflect the stack being used, i.e., the temporary stack is
used but THREAD_CLF_TMP is not set or the opposite. In such cases,
get_stack_limits() would return invalid values. The consequence is a
debugging issue: no stack dump on core panic or abort.

This was found with the help of compiler instrumentation
(-finstrument-functions).

Signed-off-by: Jerome Forissier <jerome@forissier.org>