### PR TITLE
core: crypto: fix invalid SM3 output with Clang -Os

### DIFF
--- a/core/crypto/sm3.c
+++ b/core/crypto/sm3.c
@@ -83,7 +83,7 @@ static void sm3_process(struct sm3_context *ctx, const uint8_t data[64])
 #define GG1(x, y, z)	(((x) & (y)) | ((~(x)) & (z)))
 
 #define SHL(x, n)	((x) << (n))
-#define ROTL(x, n)	(SHL((x), (n)) | ((x) >> (32 - (n))))
+#define ROTL(x, n)	(SHL((x), (n) & 0x1F) | ((x) >> (32 - ((n) & 0x1F))))
 
 #define P0(x)	((x) ^ ROTL((x), 9) ^ ROTL((x), 17))
 #define P1(x)	((x) ^ ROTL((x), 15) ^ ROTL((x), 23))


### PR DESCRIPTION
Several crypto tests fail when OP-TEE is built with Clang in non-debug
mode, more precisely with -Os. xtest numbers 4001, 4002, 4006 and 4014
are impacted.

The root cause is the right and left shift operation in the ROTL(x, n)
macro. When n > 32, they are undefined because the values to shift are
uint32_t.

Fix the bug by introducing a new macro: ROTL2(x, n) which subtracts 32
from n when n >= 32. ROTL2() can therefore be used with 0 <= n <= 63.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
