### PR TITLE
[RFC] ci: shippable: add secondary cache server

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -15,7 +15,16 @@ build:
     - export CROSS_COMPILE64="ccache aarch64-linux-gnu-"
     - export CFG_DEBUG_INFO=n
     - export CFG_WERROR=y
-    - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && ccache -s && ccache -z; }
+    - export START=$(date +%s)
+    - export PROJ=$ORG_NAME-$REPO_NAME
+    - export SCP_OPT="-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+    - function download_secondary_cache() { ssh $SCP_OPT -p 50122 shippable@shippable-cache.forissier.org "cat ccache-$PROJ.tar.gz" | tar zx -C /root || echo Nevermind; }
+    - function upload_secondary_cache() { if [ ! -e .uploaded ]; then echo Uploading cache && tar c -C /root .ccache | gzip -1 | ssh $SCP_OPT -p 50122 shippable@shippable-cache.forissier.org "cat >ccache-$PROJ.tar.gz" && touch .uploaded || echo Nevermind; fi; }
+    - function check_upload_secondary_cache() { NOW=$(date +%s); if [ $(expr $NOW - $START) -gt 3000 ]; then upload_secondary_cache; fi; }
+    - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && ccache -s && ccache -z && check_upload_secondary_cache; }
+
+    - download_secondary_cache
     - ccache -z
 
     - _make
@@ -143,3 +152,5 @@ build:
     - _make PLATFORM=bcm-ns3 CFG_ARM64_core=y
     - _make PLATFORM=hisilicon-hi3519av100_demo
     - _make PLATFORM=amlogic
+
+    - upload_secondary_cache


### PR DESCRIPTION
Shippable has a maximum build time of 1 hour for Open Source projects.
It is usually sufficient since typical build time is currently around
35 minutes, thanks to caching (ccache). But it can happen that the code
is changed too much by a pull request in which case the cache is
ineffective and build time would exceed 1 hour. When a build times out,
the cache is NOT updated and there is no other choice than to manually
feed the cache with a partial build (by removing some steps in
.shippable.yml) so that the next build can be quicker, wait for the
build to succeed, then restore all the build steps. This is quite
impractical.

This commit introduces a secondary cache on a private server with
automatic upload after 50 minutes of build time (or at the end of the
build). Then if the build times out we still have cached a significant
amount of data so restarting the build should be enough to deal with
the problem.

If the server is unavailable for any reason, errors are ignored and the
build runs as before using the cache stored in the Shippable
infrastructure.

Cache data are transferred using SSH and the cache server is configured
with the public key of the official OP-TEE OS Shippable project (the
one that is used to build pull requests). Each Shippable project has
its own SSH keypair, so forks of the main project can't use the server
by default.

Signed-off-by: Jerome Forissier <jerome@forissier.org>