### PR TITLE
ldelf: arm64: do not unwind past end of stack

### DIFF
--- a/ldelf/unwind_arm64.c
+++ b/ldelf/unwind_arm64.c
@@ -61,6 +61,8 @@ static bool unwind_stack_arm64(struct unwind_state_arm64 *frame,
 	/* FP to previous frame (X29) */
 	if (!copy_in_reg(&frame->fp, fp))
 		return false;
+	if (!frame->fp)
+		return false;
 	/* LR (X30) */
 	if (!copy_in_reg(&frame->pc, fp + 8))
 		return false;


### PR DESCRIPTION
unwind_arm64() currently does not check the value of the frame pointer
after it has done its job unwinding one frame. A NULL value indicates
the end of the call stack, and therefore the function should return
false to stop the caller from unwinding further (a do .. while loop is
used in print_stack_arm64()). Instead invalid values for FP and PC are
returned which causes an erroneous display and the unwind stops one
step too late, when the FP is found to be outside the stack.

Fixes the invalid last line in call stacks such as xtest 1019:

```
 E/TC:? 0 TA panicked with code 0x0
 E/LD:  Status of TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b
 E/LD:   arch: aarch64
 [...]
 E/LD:  Call stack:
 E/LD:   0x0000000080062a50
 E/LD:   0x00000000801df848
 E/LD:   0x00000000800631a8
 E/LD:   0xfffffffffffffffc
```
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
