### PR TITLE
symbolize.py: ignore error if ELF file is not found

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -311,6 +311,8 @@ class Symbolizer(object):
         if elf_name in self._sections:
             return
         elf = self.get_elf(elf_name)
+        if not elf:
+            return
         cmd = self.arch_prefix('objdump', elf)
         if not elf or not cmd:
             return


### PR DESCRIPTION
When processing the memory map of a TA, it can happen that the ELF file
for a region is not found. One typical reason is a missing -d argument
on the command line (can easily happen when a TA uses shared libraries
for instance).

In the above case, the script crashes with no clear indication about
the cause. This commit fixes the crash by ignoring ELFs that are not
found. This is consistent with the general behavior of symbolize.py,
which is to always print out all the information it is fed and simply
augment it with debug information when possible.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
