### PR TITLE
gdb: introduce helper functions to support gdb debugging

### DIFF
--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <compiler.h>
+#include <config.h>
 #include <crypto/crypto.h>
 #include <ctype.h>
 #include <initcall.h>
@@ -657,6 +658,12 @@ static TEE_Result alloc_and_map_ldelf_fobj(struct user_ta_ctx *utc, size_t sz,
 	return res;
 }
 
+static void gdb_helper(const vaddr_t ldelf_addr, const TEE_UUID uuid)
+{
+	(void)ldelf_addr;
+	(void)uuid;
+}
+
 /*
  * This function may leave a few mappings behind on error, but that's taken
  * care of by tee_ta_init_user_ta_session() since the entire context is
@@ -702,6 +709,9 @@ static TEE_Result load_ldelf(struct user_ta_ctx *utc)
 		return res;
 
 	DMSG("ldelf load address %#"PRIxVA, code_addr);
+
+	if (IS_ENABLED(CFG_GDB_HELPERS))
+		gdb_helper(code_addr, utc->uctx.ctx.uuid);
 
 	return TEE_SUCCESS;
 }

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -658,10 +658,15 @@ static TEE_Result alloc_and_map_ldelf_fobj(struct user_ta_ctx *utc, size_t sz,
 	return res;
 }
 
-static void gdb_helper(const vaddr_t ldelf_addr, const TEE_UUID uuid)
+/*
+ * Since we only need the symbols when breaking on the function in gdb and
+ * since there is nothing to do otherwise in this function, we have to force
+ * it to always use the O0 optimization level. If not, then the symbols would
+ * be removed when compiling for other optimization levels than 0.
+ */
+__attribute__((optimize("O0")))
+static void gdb_helper(const vaddr_t ldelf_addr __unused, const TEE_UUID uuid __unused)
 {
-	(void)ldelf_addr;
-	(void)uuid;
 }
 
 /*

--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -120,11 +120,16 @@ static void __noreturn dl_entry(struct dl_entry_arg *arg)
 	sys_return_cleanup();
 }
 
-static void gdb_ldelf_helper(const vaddr_t ta_load_addr,
-			     const TEE_UUID *uuid)
+/*
+ * Since we only need the symbols when breaking on the function in gdb and
+ * since there is nothing to do otherwise in this function, we have to force
+ * it to always use the O0 optimization level. If not, then the symbols would
+ * be removed when compiling for other optimization levels than 0.
+ */
+__attribute__((optimize("O0")))
+static void gdb_ldelf_helper(const vaddr_t ta_load_addr __unused,
+			     const TEE_UUID *uuid __unused)
 {
-	(void)ta_load_addr;
-	(void)uuid;
 }
 
 /*

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -582,3 +582,6 @@ CFG_SCMI_MSG_DRIVERS ?= n
 CFG_SCMI_MSG_CLOCK ?= n
 CFG_SCMI_MSG_RESET_DOMAIN ?= n
 CFG_SCMI_MSG_SMT ?= n
+
+# Enable helper function used when running GDB.
+CFG_GDB_HELPERS ?= n

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -583,5 +583,5 @@ CFG_SCMI_MSG_CLOCK ?= n
 CFG_SCMI_MSG_RESET_DOMAIN ?= n
 CFG_SCMI_MSG_SMT ?= n
 
-# Enable helper function used when running GDB.
+# Enable helper functions used when running GDB.
 CFG_GDB_HELPERS ?= n


### PR DESCRIPTION
Continuation of RFC #3847 which has no more comments. This patch will add the necessary helper functions to figure out correct load addresses from TEE core and LDELF loader.