### PR TITLE
imx: add support for ccbv2

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -5,6 +5,7 @@ mx6ul-flavorlist = \
 	mx6ulevk \
 	mx6ul9x9evk \
 	mx6ulccimx6ulsbcpro \
+	mx6ulccbv2 \
 
 mx6ull-flavorlist = \
 	mx6ullevk \
@@ -287,6 +288,11 @@ endif
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx6ul9x9evk))
 CFG_DDR_SIZE ?= 0x10000000
 CFG_NS_ENTRY_ADDR ?= 0x80800000
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx6ulccbv2))
+CFG_DDR_SIZE ?= 0x10000000
+CFG_UART_BASE ?= UART7_BASE
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mqevk))


### PR DESCRIPTION
The Webasto ccbv2 is a mx6ul based custom board with 256MB of RAM and
the communication done on UART7.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
