### PR TITLE
libutee: add leading underscores

### DIFF
--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -238,9 +238,9 @@ DECLARE_KEEP_PAGER thread_init_vbar
  * returning by restoring the registers saved by thread_enter_user_mode().
  *
  * There's three ways for thread_enter_user_mode() to return to caller,
- * user TA calls utee_return, user TA calls utee_panic or through an abort.
+ * user TA calls _utee_return, user TA calls _utee_panic or through an abort.
  *
- * Calls to utee_return or utee_panic are handled as:
+ * Calls to _utee_return or _utee_panic are handled as:
  * __thread_svc_handler() -> thread_svc_handler() ->tee_svc_do_call() which
  * calls syscall_return() or syscall_panic().
  *

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -265,7 +265,7 @@ bool user_ta_handle_svc(struct thread_svc_regs *regs)
 
 #ifdef ARM32
 #ifdef CFG_UNWIND
-/* Get register values pushed onto the stack by utee_panic() */
+/* Get register values pushed onto the stack by _utee_panic() */
 static void save_panic_regs_a32_ta(struct thread_specific_data *tsd,
 				  uint32_t *pushed)
 {
@@ -326,7 +326,7 @@ static void save_panic_stack(struct thread_svc_regs *regs __unused)
 
 #ifdef ARM64
 #ifdef CFG_UNWIND
-/* Get register values pushed onto the stack by utee_panic() (32-bit TA) */
+/* Get register values pushed onto the stack by _utee_panic() (32-bit TA) */
 static void save_panic_regs_a32_ta(struct thread_specific_data *tsd,
 				   uint32_t *pushed)
 {
@@ -350,7 +350,7 @@ static void save_panic_regs_a32_ta(struct thread_specific_data *tsd,
 	};
 }
 
-/* Get register values pushed onto the stack by utee_panic() (64-bit TA) */
+/* Get register values pushed onto the stack by _utee_panic() (64-bit TA) */
 static void save_panic_regs_a64_ta(struct thread_specific_data *tsd,
 				   uint64_t *pushed)
 {

--- a/ldelf/start_a32.S
+++ b/ldelf/start_a32.S
@@ -48,9 +48,9 @@ FUNC _ldelf_start , :
 
 2:	bl	ldelf
 	mov	r0, #0
-	bl	utee_return
+	bl	_utee_return
 3:	mov	r0, #0
-	bl	utee_panic
+	bl	_utee_panic
 reloc_begin_rel:
     .word __reloc_begin - reloc_begin_rel
 reloc_end_rel:

--- a/ldelf/start_a64.S
+++ b/ldelf/start_a64.S
@@ -51,9 +51,9 @@ FUNC _ldelf_start , :
 
 2:	bl	ldelf
 	mov	x0, #0
-	bl	utee_return
+	bl	_utee_return
 3:	mov	x0, #0
-	bl	utee_panic
+	bl	_utee_panic
 reloc_begin_rel:
     .word __reloc_begin - reloc_begin_rel
 reloc_end_rel:

--- a/ldelf/sys.c
+++ b/ldelf/sys.c
@@ -24,7 +24,7 @@ void __panic(const char *file __maybe_unused, const int line __maybe_unused,
 			 file ? file : "?", file ? line : 0,
 			 func ? "<" : "", func ? func : "", func ? ">" : "");
 
-	utee_panic(1);
+	_utee_panic(1);
 	/*NOTREACHED*/
 	while (true)
 		;
@@ -33,12 +33,12 @@ void __panic(const char *file __maybe_unused, const int line __maybe_unused,
 void sys_return_cleanup(void)
 {
 	if (sess) {
-		if (utee_close_ta_session(sess))
+		if (_utee_close_ta_session(sess))
 			panic();
 		sess = 0;
 	}
 
-	utee_return(0);
+	_utee_return(0);
 	/*NOTREACHED*/
 	while (true)
 		;
@@ -52,14 +52,14 @@ static TEE_Result invoke_sys_ta(uint32_t cmdid, struct utee_params *params)
 	if (!sess) {
 		uint32_t s = 0;
 
-		res = utee_open_ta_session(&(const TEE_UUID)PTA_SYSTEM_UUID,
-					   0, NULL, &s, &ret_orig);
+		res = _utee_open_ta_session(&(const TEE_UUID)PTA_SYSTEM_UUID,
+					    0, NULL, &s, &ret_orig);
 		if (res)
 			return res;
 		sess = s;
 	}
 
-	return utee_invoke_ta_command(sess, 0, cmdid, params, &ret_orig);
+	return _utee_invoke_ta_command(sess, 0, cmdid, params, &ret_orig);
 }
 
 TEE_Result sys_map_zi(size_t num_bytes, uint32_t flags, vaddr_t *va,

--- a/ldelf/sys.h
+++ b/ldelf/sys.h
@@ -30,7 +30,7 @@ void __noreturn sys_return_cleanup(void);
 #define err(res, ...) \
 	do { \
 		trace_printf_helper(TRACE_ERROR, true, __VA_ARGS__); \
-		utee_return(res); \
+		_utee_return(res); \
 	} while (0)
 
 TEE_Result sys_map_zi(size_t num_bytes, uint32_t flags, vaddr_t *va,

--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -615,7 +615,7 @@ static size_t get_pad_begin(void)
 	COMPILE_TIME_ASSERT(CFG_TA_ASLR_MIN_OFFSET_PAGES <
 			    CFG_TA_ASLR_MAX_OFFSET_PAGES);
 	if (max > min) {
-		res = utee_cryp_random_number_generate(&rnd32, sizeof(rnd32));
+		res = _utee_cryp_random_number_generate(&rnd32, sizeof(rnd32));
 		if (res) {
 			DMSG("Random read failed: %#"PRIx32, res);
 			return min * SMALL_PAGE_SIZE;

--- a/lib/libutee/abort.c
+++ b/lib/libutee/abort.c
@@ -11,7 +11,7 @@
 void abort(void)
 {
 	printf("Abort!\n");
-	utee_panic(0);
+	_utee_panic(0);
 	/* Not reached */
 	while (1)
 		;

--- a/lib/libutee/arch/arm/utee_syscalls_a32.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a32.S
@@ -53,7 +53,7 @@ UNWIND( .fnend)
 	END_FUNC \name
         .endm
 
-	FUNC utee_panic, :
+	FUNC _utee_panic, :
 UNWIND( .fnstart)
 	push	{r0-r11, lr}
 UNWIND(	.save	{r0-r11, lr})
@@ -64,6 +64,6 @@ UNWIND(	.save	{lr})
 	bl	__utee_panic
 	/* Not reached */
 UNWIND( .fnend)
-	END_FUNC utee_panic
+	END_FUNC _utee_panic
 
 #include "utee_syscalls_asm.S"

--- a/lib/libutee/arch/arm/utee_syscalls_a64.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a64.S
@@ -37,12 +37,12 @@
         END_FUNC \name
         .endm
 
-	FUNC utee_panic, :
+	FUNC _utee_panic, :
 	stp	x29, x30, [sp, #-16]!
 	mov	x1, sp
 	bl	__utee_panic
 	/* Not reached */
-	END_FUNC utee_panic
+	END_FUNC _utee_panic
 
 #include "utee_syscalls_asm.S"
 

--- a/lib/libutee/arch/arm/utee_syscalls_asm.S
+++ b/lib/libutee/arch/arm/utee_syscalls_asm.S
@@ -5,120 +5,120 @@
  */
 
 
-        UTEE_SYSCALL utee_return, TEE_SCN_RETURN, 1
+        UTEE_SYSCALL _utee_return, TEE_SCN_RETURN, 1
 
-        UTEE_SYSCALL utee_log, TEE_SCN_LOG, 2
+        UTEE_SYSCALL _utee_log, TEE_SCN_LOG, 2
 
         UTEE_SYSCALL __utee_panic, TEE_SCN_PANIC, 2
 
-        UTEE_SYSCALL utee_get_property, TEE_SCN_GET_PROPERTY, 7
+        UTEE_SYSCALL _utee_get_property, TEE_SCN_GET_PROPERTY, 7
 
-        UTEE_SYSCALL utee_get_property_name_to_index, \
+        UTEE_SYSCALL _utee_get_property_name_to_index, \
                 TEE_SCN_GET_PROPERTY_NAME_TO_INDEX, 4
 
-        UTEE_SYSCALL utee_open_ta_session, TEE_SCN_OPEN_TA_SESSION, 5
+        UTEE_SYSCALL _utee_open_ta_session, TEE_SCN_OPEN_TA_SESSION, 5
 
-        UTEE_SYSCALL utee_close_ta_session, TEE_SCN_CLOSE_TA_SESSION, 1
+        UTEE_SYSCALL _utee_close_ta_session, TEE_SCN_CLOSE_TA_SESSION, 1
 
-        UTEE_SYSCALL utee_invoke_ta_command, TEE_SCN_INVOKE_TA_COMMAND, 5
+        UTEE_SYSCALL _utee_invoke_ta_command, TEE_SCN_INVOKE_TA_COMMAND, 5
         
-        UTEE_SYSCALL utee_get_cancellation_flag, \
+        UTEE_SYSCALL _utee_get_cancellation_flag, \
                      TEE_SCN_GET_CANCELLATION_FLAG, 1
 
-        UTEE_SYSCALL utee_check_access_rights, TEE_SCN_CHECK_ACCESS_RIGHTS, 3
+        UTEE_SYSCALL _utee_check_access_rights, TEE_SCN_CHECK_ACCESS_RIGHTS, 3
 
-        UTEE_SYSCALL utee_unmask_cancellation, TEE_SCN_UNMASK_CANCELLATION, 1
+        UTEE_SYSCALL _utee_unmask_cancellation, TEE_SCN_UNMASK_CANCELLATION, 1
 
-        UTEE_SYSCALL utee_mask_cancellation, TEE_SCN_MASK_CANCELLATION, 1
+        UTEE_SYSCALL _utee_mask_cancellation, TEE_SCN_MASK_CANCELLATION, 1
 
-        UTEE_SYSCALL utee_wait, TEE_SCN_WAIT, 1
+        UTEE_SYSCALL _utee_wait, TEE_SCN_WAIT, 1
 
-        UTEE_SYSCALL utee_get_time, TEE_SCN_GET_TIME, 2
+        UTEE_SYSCALL _utee_get_time, TEE_SCN_GET_TIME, 2
 
-        UTEE_SYSCALL utee_set_ta_time, TEE_SCN_SET_TA_TIME, 1
+        UTEE_SYSCALL _utee_set_ta_time, TEE_SCN_SET_TA_TIME, 1
 
-        UTEE_SYSCALL utee_cryp_state_alloc, TEE_SCN_CRYP_STATE_ALLOC, 5
+        UTEE_SYSCALL _utee_cryp_state_alloc, TEE_SCN_CRYP_STATE_ALLOC, 5
 
-        UTEE_SYSCALL utee_cryp_state_copy, TEE_SCN_CRYP_STATE_COPY, 2
+        UTEE_SYSCALL _utee_cryp_state_copy, TEE_SCN_CRYP_STATE_COPY, 2
 
-        UTEE_SYSCALL utee_cryp_state_free, TEE_SCN_CRYP_STATE_FREE, 1
+        UTEE_SYSCALL _utee_cryp_state_free, TEE_SCN_CRYP_STATE_FREE, 1
 
-        UTEE_SYSCALL utee_hash_init, TEE_SCN_HASH_INIT, 3
+        UTEE_SYSCALL _utee_hash_init, TEE_SCN_HASH_INIT, 3
 
-        UTEE_SYSCALL utee_hash_update, TEE_SCN_HASH_UPDATE, 3
+        UTEE_SYSCALL _utee_hash_update, TEE_SCN_HASH_UPDATE, 3
 
-        UTEE_SYSCALL utee_hash_final, TEE_SCN_HASH_FINAL, 5
+        UTEE_SYSCALL _utee_hash_final, TEE_SCN_HASH_FINAL, 5
 
-        UTEE_SYSCALL utee_cipher_init, TEE_SCN_CIPHER_INIT, 3
+        UTEE_SYSCALL _utee_cipher_init, TEE_SCN_CIPHER_INIT, 3
 
-        UTEE_SYSCALL utee_cipher_update, TEE_SCN_CIPHER_UPDATE, 5
+        UTEE_SYSCALL _utee_cipher_update, TEE_SCN_CIPHER_UPDATE, 5
 
-        UTEE_SYSCALL utee_cipher_final, TEE_SCN_CIPHER_FINAL, 5
+        UTEE_SYSCALL _utee_cipher_final, TEE_SCN_CIPHER_FINAL, 5
 
-        UTEE_SYSCALL utee_cryp_obj_get_info, TEE_SCN_CRYP_OBJ_GET_INFO, 2
+        UTEE_SYSCALL _utee_cryp_obj_get_info, TEE_SCN_CRYP_OBJ_GET_INFO, 2
 
-        UTEE_SYSCALL utee_cryp_obj_restrict_usage, \
+        UTEE_SYSCALL _utee_cryp_obj_restrict_usage, \
                      TEE_SCN_CRYP_OBJ_RESTRICT_USAGE, 2
 
-        UTEE_SYSCALL utee_cryp_obj_get_attr, TEE_SCN_CRYP_OBJ_GET_ATTR, 4
+        UTEE_SYSCALL _utee_cryp_obj_get_attr, TEE_SCN_CRYP_OBJ_GET_ATTR, 4
 
-        UTEE_SYSCALL utee_cryp_obj_alloc, TEE_SCN_CRYP_OBJ_ALLOC, 3
+        UTEE_SYSCALL _utee_cryp_obj_alloc, TEE_SCN_CRYP_OBJ_ALLOC, 3
 
-        UTEE_SYSCALL utee_cryp_obj_close, TEE_SCN_CRYP_OBJ_CLOSE, 1
+        UTEE_SYSCALL _utee_cryp_obj_close, TEE_SCN_CRYP_OBJ_CLOSE, 1
 
-        UTEE_SYSCALL utee_cryp_obj_reset, TEE_SCN_CRYP_OBJ_RESET,  1
+        UTEE_SYSCALL _utee_cryp_obj_reset, TEE_SCN_CRYP_OBJ_RESET,  1
 
-        UTEE_SYSCALL utee_cryp_obj_populate, TEE_SCN_CRYP_OBJ_POPULATE, 3
+        UTEE_SYSCALL _utee_cryp_obj_populate, TEE_SCN_CRYP_OBJ_POPULATE, 3
 
-        UTEE_SYSCALL utee_cryp_obj_copy, TEE_SCN_CRYP_OBJ_COPY, 2
+        UTEE_SYSCALL _utee_cryp_obj_copy, TEE_SCN_CRYP_OBJ_COPY, 2
 
-        UTEE_SYSCALL utee_cryp_derive_key, TEE_SCN_CRYP_DERIVE_KEY, 4
+        UTEE_SYSCALL _utee_cryp_derive_key, TEE_SCN_CRYP_DERIVE_KEY, 4
 
-        UTEE_SYSCALL utee_cryp_random_number_generate, \
+        UTEE_SYSCALL _utee_cryp_random_number_generate, \
                      TEE_SCN_CRYP_RANDOM_NUMBER_GENERATE, 2
 
-        UTEE_SYSCALL utee_authenc_init, TEE_SCN_AUTHENC_INIT, 6
+        UTEE_SYSCALL _utee_authenc_init, TEE_SCN_AUTHENC_INIT, 6
 
-        UTEE_SYSCALL utee_authenc_update_aad, TEE_SCN_AUTHENC_UPDATE_AAD, 3
+        UTEE_SYSCALL _utee_authenc_update_aad, TEE_SCN_AUTHENC_UPDATE_AAD, 3
 
-        UTEE_SYSCALL utee_authenc_update_payload, \
+        UTEE_SYSCALL _utee_authenc_update_payload, \
                      TEE_SCN_AUTHENC_UPDATE_PAYLOAD, 5
 
-        UTEE_SYSCALL utee_authenc_enc_final, TEE_SCN_AUTHENC_ENC_FINAL, 7
+        UTEE_SYSCALL _utee_authenc_enc_final, TEE_SCN_AUTHENC_ENC_FINAL, 7
 
-        UTEE_SYSCALL utee_authenc_dec_final, TEE_SCN_AUTHENC_DEC_FINAL, 7
+        UTEE_SYSCALL _utee_authenc_dec_final, TEE_SCN_AUTHENC_DEC_FINAL, 7
 
-        UTEE_SYSCALL utee_asymm_operate, TEE_SCN_ASYMM_OPERATE, 7
+        UTEE_SYSCALL _utee_asymm_operate, TEE_SCN_ASYMM_OPERATE, 7
 
-        UTEE_SYSCALL utee_asymm_verify, TEE_SCN_ASYMM_VERIFY, 7
+        UTEE_SYSCALL _utee_asymm_verify, TEE_SCN_ASYMM_VERIFY, 7
 
-        UTEE_SYSCALL utee_storage_obj_open, TEE_SCN_STORAGE_OBJ_OPEN, 5
+        UTEE_SYSCALL _utee_storage_obj_open, TEE_SCN_STORAGE_OBJ_OPEN, 5
 
-        UTEE_SYSCALL utee_storage_obj_create, TEE_SCN_STORAGE_OBJ_CREATE, 8
+        UTEE_SYSCALL _utee_storage_obj_create, TEE_SCN_STORAGE_OBJ_CREATE, 8
 
-        UTEE_SYSCALL utee_storage_obj_del, TEE_SCN_STORAGE_OBJ_DEL, 1
+        UTEE_SYSCALL _utee_storage_obj_del, TEE_SCN_STORAGE_OBJ_DEL, 1
 
-        UTEE_SYSCALL utee_storage_obj_rename, TEE_SCN_STORAGE_OBJ_RENAME, 3
+        UTEE_SYSCALL _utee_storage_obj_rename, TEE_SCN_STORAGE_OBJ_RENAME, 3
 
-        UTEE_SYSCALL utee_storage_alloc_enum, TEE_SCN_STORAGE_ENUM_ALLOC, 1
+        UTEE_SYSCALL _utee_storage_alloc_enum, TEE_SCN_STORAGE_ENUM_ALLOC, 1
 
-        UTEE_SYSCALL utee_storage_free_enum, TEE_SCN_STORAGE_ENUM_FREE, 1
+        UTEE_SYSCALL _utee_storage_free_enum, TEE_SCN_STORAGE_ENUM_FREE, 1
 
-        UTEE_SYSCALL utee_storage_reset_enum, TEE_SCN_STORAGE_ENUM_RESET, 1
+        UTEE_SYSCALL _utee_storage_reset_enum, TEE_SCN_STORAGE_ENUM_RESET, 1
 
-        UTEE_SYSCALL utee_storage_start_enum, TEE_SCN_STORAGE_ENUM_START, 2
+        UTEE_SYSCALL _utee_storage_start_enum, TEE_SCN_STORAGE_ENUM_START, 2
 
-        UTEE_SYSCALL utee_storage_next_enum, TEE_SCN_STORAGE_ENUM_NEXT, 4
+        UTEE_SYSCALL _utee_storage_next_enum, TEE_SCN_STORAGE_ENUM_NEXT, 4
 
-        UTEE_SYSCALL utee_storage_obj_read, TEE_SCN_STORAGE_OBJ_READ, 4
+        UTEE_SYSCALL _utee_storage_obj_read, TEE_SCN_STORAGE_OBJ_READ, 4
 
-        UTEE_SYSCALL utee_storage_obj_write, TEE_SCN_STORAGE_OBJ_WRITE, 3
+        UTEE_SYSCALL _utee_storage_obj_write, TEE_SCN_STORAGE_OBJ_WRITE, 3
 
-        UTEE_SYSCALL utee_storage_obj_trunc, TEE_SCN_STORAGE_OBJ_TRUNC, 2
+        UTEE_SYSCALL _utee_storage_obj_trunc, TEE_SCN_STORAGE_OBJ_TRUNC, 2
 
-        UTEE_SYSCALL utee_storage_obj_seek, TEE_SCN_STORAGE_OBJ_SEEK, 3
+        UTEE_SYSCALL _utee_storage_obj_seek, TEE_SCN_STORAGE_OBJ_SEEK, 3
 
-        UTEE_SYSCALL utee_cryp_obj_generate_key, \
+        UTEE_SYSCALL _utee_cryp_obj_generate_key, \
                      TEE_SCN_CRYP_OBJ_GENERATE_KEY, 4
 
-        UTEE_SYSCALL utee_cache_operation, TEE_SCN_CACHE_OPERATION, 3
+        UTEE_SYSCALL _utee_cache_operation, TEE_SCN_CACHE_OPERATION, 3

--- a/lib/libutee/assert.c
+++ b/lib/libutee/assert.c
@@ -21,7 +21,7 @@ void _assert_log(const char *expr __maybe_unused,
 
 void __noreturn _assert_break(void)
 {
-	utee_panic(TEE_ERROR_GENERIC);
+	_utee_panic(TEE_ERROR_GENERIC);
 	/* Not reached */
 	while (1)
 		;

--- a/lib/libutee/base64.c
+++ b/lib/libutee/base64.c
@@ -8,18 +8,18 @@
 static const char base64_table[] =
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-size_t base64_enc_len(size_t size)
+size_t _base64_enc_len(size_t size)
 {
 	return 4 * ((size + 2) / 3) + 1;
 }
 
-bool base64_enc(const void *data, size_t dlen, char *buf, size_t *blen)
+bool _base64_enc(const void *data, size_t dlen, char *buf, size_t *blen)
 {
 	size_t n = 0;
 	size_t boffs = 0;
 	const unsigned char *d = data;
 
-	n = base64_enc_len(dlen);
+	n = _base64_enc_len(dlen);
 	if (*blen < n) {
 		*blen = n;
 		return false;
@@ -70,7 +70,7 @@ static bool get_idx(char ch, uint8_t *idx)
 	return false;
 }
 
-bool base64_dec(const char *data, size_t size, void *buf, size_t *blen)
+bool _base64_dec(const char *data, size_t size, void *buf, size_t *blen)
 {
 	bool ret = false;
 	size_t n = 0;

--- a/lib/libutee/base64.h
+++ b/lib/libutee/base64.h
@@ -9,8 +9,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-bool base64_enc(const void *data, size_t size, char *buf, size_t *blen);
-bool base64_dec(const char *data, size_t size, void *buf, size_t *blen);
-size_t base64_enc_len(size_t size);
+bool _base64_enc(const void *data, size_t size, char *buf, size_t *blen);
+bool _base64_dec(const char *data, size_t size, void *buf, size_t *blen);
+size_t _base64_enc_len(size_t size);
 
 #endif /* BASE64_H */

--- a/lib/libutee/include/utee_syscalls.h
+++ b/lib/libutee/include/utee_syscalls.h
@@ -29,253 +29,263 @@
  * length fields.
  */
 
-void utee_return(unsigned long ret) __noreturn;
+void _utee_return(unsigned long ret) __noreturn;
 
-void utee_log(const void *buf, size_t len);
+void _utee_log(const void *buf, size_t len);
 
 /* This is not __noreturn because AArch32 stack unwinding fails otherwise */
-void utee_panic(unsigned long code);
+void _utee_panic(unsigned long code);
 
 /* prop_set is TEE_PROPSET_xxx*/
-TEE_Result utee_get_property(unsigned long prop_set, unsigned long index,
-			     void *name, uint32_t *name_len,
-			     void *buf, uint32_t *blen,
-				uint32_t *prop_type);
-TEE_Result utee_get_property_name_to_index(unsigned long prop_set,
-					   const void *name,
-					   unsigned long name_len,
-					   uint32_t *index);
+TEE_Result _utee_get_property(unsigned long prop_set, unsigned long index,
+			      void *name, uint32_t *name_len, void *buf,
+			      uint32_t *blen, uint32_t *prop_type);
 
-
-/* sess has type TEE_TASessionHandle */
-TEE_Result utee_open_ta_session(const TEE_UUID *dest,
-			unsigned long cancel_req_to, struct utee_params *params,
-			uint32_t *sess, uint32_t *ret_orig);
+TEE_Result _utee_get_property_name_to_index(unsigned long prop_set,
+					    const void *name,
+					    unsigned long name_len,
+					    uint32_t *index);
 
 /* sess has type TEE_TASessionHandle */
-TEE_Result utee_close_ta_session(unsigned long sess);
+TEE_Result _utee_open_ta_session(const TEE_UUID *dest,
+				 unsigned long cancel_req_to,
+				 struct utee_params *params, uint32_t *sess,
+				 uint32_t *ret_orig);
 
 /* sess has type TEE_TASessionHandle */
-TEE_Result utee_invoke_ta_command(unsigned long sess,
-			unsigned long cancel_req_to, unsigned long cmd_id,
-			struct utee_params *params, uint32_t *ret_orig);
+TEE_Result _utee_close_ta_session(unsigned long sess);
 
-TEE_Result utee_check_access_rights(uint32_t flags, const void *buf,
-				    size_t len);
+/* sess has type TEE_TASessionHandle */
+TEE_Result _utee_invoke_ta_command(unsigned long sess,
+				   unsigned long cancel_req_to,
+				   unsigned long cmd_id,
+				   struct utee_params *params,
+				   uint32_t *ret_orig);
+
+TEE_Result _utee_check_access_rights(uint32_t flags, const void *buf,
+				     size_t len);
 
 /* cancel has type bool */
-TEE_Result utee_get_cancellation_flag(uint32_t *cancel);
+TEE_Result _utee_get_cancellation_flag(uint32_t *cancel);
 
 /* old_mask has type bool */
-TEE_Result utee_unmask_cancellation(uint32_t *old_mask);
+TEE_Result _utee_unmask_cancellation(uint32_t *old_mask);
 
 /* old_mask has type bool */
-TEE_Result utee_mask_cancellation(uint32_t *old_mask);
+TEE_Result _utee_mask_cancellation(uint32_t *old_mask);
 
-TEE_Result utee_wait(unsigned long timeout);
+TEE_Result _utee_wait(unsigned long timeout);
 
-/* cat has type enum utee_time_category */
-TEE_Result utee_get_time(unsigned long cat, TEE_Time *time);
+/* cat has type enum _utee_time_category */
+TEE_Result _utee_get_time(unsigned long cat, TEE_Time *time);
 
-TEE_Result utee_set_ta_time(const TEE_Time *time);
+TEE_Result _utee_set_ta_time(const TEE_Time *time);
 
-TEE_Result utee_cryp_state_alloc(unsigned long algo, unsigned long op_mode,
-				 unsigned long key1, unsigned long key2,
-				 uint32_t *state);
-TEE_Result utee_cryp_state_copy(unsigned long dst, unsigned long src);
-TEE_Result utee_cryp_state_free(unsigned long state);
+TEE_Result _utee_cryp_state_alloc(unsigned long algo, unsigned long op_mode,
+				  unsigned long key1, unsigned long key2,
+				  uint32_t *state);
+TEE_Result _utee_cryp_state_copy(unsigned long dst, unsigned long src);
+TEE_Result _utee_cryp_state_free(unsigned long state);
 
 /* iv and iv_len are ignored for some algorithms */
-TEE_Result utee_hash_init(unsigned long state, const void *iv, size_t iv_len);
-TEE_Result utee_hash_update(unsigned long state, const void *chunk,
-			    size_t chunk_size);
-TEE_Result utee_hash_final(unsigned long state, const void *chunk,
-			   size_t chunk_size, void *hash, uint64_t *hash_len);
+TEE_Result _utee_hash_init(unsigned long state, const void *iv, size_t iv_len);
+TEE_Result _utee_hash_update(unsigned long state, const void *chunk,
+			     size_t chunk_size);
+TEE_Result _utee_hash_final(unsigned long state, const void *chunk,
+			    size_t chunk_size, void *hash, uint64_t *hash_len);
 
-TEE_Result utee_cipher_init(unsigned long state, const void *iv, size_t iv_len);
-TEE_Result utee_cipher_update(unsigned long state, const void *src,
-			size_t src_len, void *dest, uint64_t *dest_len);
-TEE_Result utee_cipher_final(unsigned long state, const void *src,
-			size_t src_len, void *dest, uint64_t *dest_len);
+TEE_Result _utee_cipher_init(unsigned long state, const void *iv,
+			     size_t iv_len);
+TEE_Result _utee_cipher_update(unsigned long state, const void *src,
+			       size_t src_len, void *dest, uint64_t *dest_len);
+TEE_Result _utee_cipher_final(unsigned long state, const void *src,
+			      size_t src_len, void *dest, uint64_t *dest_len);
 
 /* Generic Object Functions */
-TEE_Result utee_cryp_obj_get_info(unsigned long obj, TEE_ObjectInfo *info);
-TEE_Result utee_cryp_obj_restrict_usage(unsigned long obj, unsigned long usage);
-TEE_Result utee_cryp_obj_get_attr(unsigned long obj, unsigned long attr_id,
-			void *buffer, uint64_t *size);
+TEE_Result _utee_cryp_obj_get_info(unsigned long obj, TEE_ObjectInfo *info);
+TEE_Result _utee_cryp_obj_restrict_usage(unsigned long obj,
+					 unsigned long usage);
+TEE_Result _utee_cryp_obj_get_attr(unsigned long obj, unsigned long attr_id,
+				   void *buffer, uint64_t *size);
 
 /* Transient Object Functions */
 /* type has type TEE_ObjectType */
-TEE_Result utee_cryp_obj_alloc(unsigned long type, unsigned long max_size,
-			uint32_t *obj);
-TEE_Result utee_cryp_obj_close(unsigned long obj);
-TEE_Result utee_cryp_obj_reset(unsigned long obj);
-TEE_Result utee_cryp_obj_populate(unsigned long obj,
-			struct utee_attribute *attrs, unsigned long attr_count);
-TEE_Result utee_cryp_obj_copy(unsigned long dst_obj, unsigned long src_obj);
+TEE_Result _utee_cryp_obj_alloc(unsigned long type, unsigned long max_size,
+				uint32_t *obj);
+TEE_Result _utee_cryp_obj_close(unsigned long obj);
+TEE_Result _utee_cryp_obj_reset(unsigned long obj);
+TEE_Result _utee_cryp_obj_populate(unsigned long obj,
+				   struct utee_attribute *attrs,
+				   unsigned long attr_count);
+TEE_Result _utee_cryp_obj_copy(unsigned long dst_obj, unsigned long src_obj);
 
-TEE_Result utee_cryp_obj_generate_key(unsigned long obj, unsigned long key_size,
-			const struct utee_attribute *params,
-			unsigned long param_count);
+TEE_Result _utee_cryp_obj_generate_key(unsigned long obj,
+				       unsigned long key_size,
+				       const struct utee_attribute *params,
+				       unsigned long param_count);
 
-TEE_Result utee_cryp_derive_key(unsigned long state,
-			const struct utee_attribute *params,
-			unsigned long param_count, unsigned long derived_key);
+TEE_Result _utee_cryp_derive_key(unsigned long state,
+				 const struct utee_attribute *params,
+				 unsigned long param_count,
+				 unsigned long derived_key);
 
-TEE_Result utee_cryp_random_number_generate(void *buf, size_t blen);
+TEE_Result _utee_cryp_random_number_generate(void *buf, size_t blen);
 
-TEE_Result utee_authenc_init(unsigned long state, const void *nonce,
-			size_t nonce_len, size_t tag_len, size_t aad_len,
-			size_t payload_len);
-TEE_Result utee_authenc_update_aad(unsigned long state, const void *aad_data,
-			size_t aad_data_len);
-TEE_Result utee_authenc_update_payload(unsigned long state,
-			const void *src_data, size_t src_len, void *dest_data,
-			uint64_t *dest_len);
-TEE_Result utee_authenc_enc_final(unsigned long state, const void *src_data,
-			size_t src_len, void *dest_data, uint64_t *dest_len,
-			void *tag, uint64_t *tag_len);
-TEE_Result utee_authenc_dec_final(unsigned long state, const void *src_data,
-			size_t src_len, void *dest_data, uint64_t *dest_len,
-			const void *tag, size_t tag_len);
+TEE_Result _utee_authenc_init(unsigned long state, const void *nonce,
+			      size_t nonce_len, size_t tag_len, size_t aad_len,
+			      size_t payload_len);
+TEE_Result _utee_authenc_update_aad(unsigned long state, const void *aad_data,
+				    size_t aad_data_len);
+TEE_Result _utee_authenc_update_payload(unsigned long state,
+					const void *src_data, size_t src_len,
+					void *dest_data, uint64_t *dest_len);
+TEE_Result _utee_authenc_enc_final(unsigned long state, const void *src_data,
+				   size_t src_len, void *dest_data,
+				   uint64_t *dest_len, void *tag,
+				   uint64_t *tag_len);
+TEE_Result _utee_authenc_dec_final(unsigned long state, const void *src_data,
+				   size_t src_len, void *dest_data,
+				   uint64_t *dest_len, const void *tag,
+				   size_t tag_len);
 
-TEE_Result utee_asymm_operate(unsigned long state,
-			const struct utee_attribute *params,
-			unsigned long num_params, const void *src_data,
-			size_t src_len, void *dest_data, uint64_t *dest_len);
+TEE_Result _utee_asymm_operate(unsigned long state,
+			       const struct utee_attribute *params,
+			       unsigned long num_params, const void *src_data,
+			       size_t src_len, void *dest_data,
+			       uint64_t *dest_len);
 
-TEE_Result utee_asymm_verify(unsigned long state,
-			const struct utee_attribute *params,
-			unsigned long num_params, const void *data,
-			size_t data_len, const void *sig, size_t sig_len);
+TEE_Result _utee_asymm_verify(unsigned long state,
+			      const struct utee_attribute *params,
+			      unsigned long num_params, const void *data,
+			      size_t data_len, const void *sig, size_t sig_len);
 
 /* Persistant Object Functions */
 /* obj is of type TEE_ObjectHandle */
-TEE_Result utee_storage_obj_open(unsigned long storage_id,
-				 const void *object_id,
-				 size_t object_id_len, unsigned long flags,
-				 uint32_t *obj);
+TEE_Result _utee_storage_obj_open(unsigned long storage_id,
+				  const void *object_id, size_t object_id_len,
+				  unsigned long flags, uint32_t *obj);
 
 /*
  * attr is of type TEE_ObjectHandle
  * obj is of type TEE_ObjectHandle
  */
-TEE_Result utee_storage_obj_create(unsigned long storage_id,
-				   const void *object_id,
-				   size_t object_id_len, unsigned long flags,
-				   unsigned long attr, const void *data,
-				   size_t len, uint32_t *obj);
+TEE_Result _utee_storage_obj_create(unsigned long storage_id,
+				    const void *object_id,
+				    size_t object_id_len, unsigned long flags,
+				    unsigned long attr, const void *data,
+				    size_t len, uint32_t *obj);
 
 /* obj is of type TEE_ObjectHandle */
-TEE_Result utee_storage_obj_del(unsigned long obj);
+TEE_Result _utee_storage_obj_del(unsigned long obj);
 
 /* obj is of type TEE_ObjectHandle */
-TEE_Result utee_storage_obj_rename(unsigned long obj, const void *new_obj_id,
-				size_t new_obj_id_len);
+TEE_Result _utee_storage_obj_rename(unsigned long obj, const void *new_obj_id,
+				    size_t new_obj_id_len);
 
 /* Persistent Object Enumeration Functions */
 /* obj_enum is of type TEE_ObjectEnumHandle */
-TEE_Result utee_storage_alloc_enum(uint32_t *obj_enum);
+TEE_Result _utee_storage_alloc_enum(uint32_t *obj_enum);
 
 
 /* obj_enum is of type TEE_ObjectEnumHandle */
-TEE_Result utee_storage_free_enum(unsigned long obj_enum);
+TEE_Result _utee_storage_free_enum(unsigned long obj_enum);
 
 /* obj_enum is of type TEE_ObjectEnumHandle */
-TEE_Result utee_storage_reset_enum(unsigned long obj_enum);
+TEE_Result _utee_storage_reset_enum(unsigned long obj_enum);
 
 /* obj_enum is of type TEE_ObjectEnumHandle */
-TEE_Result utee_storage_start_enum(unsigned long obj_enum,
-			unsigned long storage_id);
+TEE_Result _utee_storage_start_enum(unsigned long obj_enum,
+				    unsigned long storage_id);
 
 /* obj_enum is of type TEE_ObjectEnumHandle */
-TEE_Result utee_storage_next_enum(unsigned long obj_enum, TEE_ObjectInfo *info,
-			void *obj_id, uint64_t *len);
+TEE_Result _utee_storage_next_enum(unsigned long obj_enum, TEE_ObjectInfo *info,
+				   void *obj_id, uint64_t *len);
 
 /* Data Stream Access Functions */
 /* obj is of type TEE_ObjectHandle */
-TEE_Result utee_storage_obj_read(unsigned long obj, void *data, size_t len,
-			uint64_t *count);
+TEE_Result _utee_storage_obj_read(unsigned long obj, void *data, size_t len,
+				  uint64_t *count);
 
 /* obj is of type TEE_ObjectHandle */
-TEE_Result utee_storage_obj_write(unsigned long obj, const void *data,
-			size_t len);
+TEE_Result _utee_storage_obj_write(unsigned long obj, const void *data,
+				   size_t len);
 
 /* obj is of type TEE_ObjectHandle */
-TEE_Result utee_storage_obj_trunc(unsigned long obj, size_t len);
+TEE_Result _utee_storage_obj_trunc(unsigned long obj, size_t len);
 
 /* obj is of type TEE_ObjectHandle */
 /* whence is of type TEE_Whence */
-TEE_Result utee_storage_obj_seek(unsigned long obj, int32_t offset,
-				 unsigned long whence);
+TEE_Result _utee_storage_obj_seek(unsigned long obj, int32_t offset,
+				  unsigned long whence);
 
 /* seServiceHandle is of type TEE_SEServiceHandle */
-TEE_Result utee_se_service_open(uint32_t *seServiceHandle);
+TEE_Result _utee_se_service_open(uint32_t *seServiceHandle);
 
 /* seServiceHandle is of type TEE_SEServiceHandle */
-TEE_Result utee_se_service_close(unsigned long seServiceHandle);
+TEE_Result _utee_se_service_close(unsigned long seServiceHandle);
 
 /*
  * seServiceHandle is of type TEE_SEServiceHandle
  * r is of type TEE_SEReaderHandle
  */
-TEE_Result utee_se_service_get_readers(unsigned long seServiceHandle,
-			uint32_t *r, uint64_t *len);
+TEE_Result _utee_se_service_get_readers(unsigned long seServiceHandle,
+					uint32_t *r, uint64_t *len);
 
 /*
  * r is of type TEE_SEReaderHandle
  * p is defined with defines UTEE_SE_READER_*
  */
-TEE_Result utee_se_reader_get_prop(unsigned long r, uint32_t *p);
+TEE_Result _utee_se_reader_get_prop(unsigned long r, uint32_t *p);
 
 /* r is of type TEE_SEReaderHandle */
-TEE_Result utee_se_reader_get_name(unsigned long r,
-			char *name, uint64_t *name_len);
+TEE_Result _utee_se_reader_get_name(unsigned long r, char *name,
+				    uint64_t *name_len);
 
 /*
  * r is of type TEE_SEReaderHandle
  * s if of type TEE_SESessionHandle
  */
-TEE_Result utee_se_reader_open_session(unsigned long r, uint32_t *s);
+TEE_Result _utee_se_reader_open_session(unsigned long r, uint32_t *s);
 
 /* r is of type TEE_SEReaderHandle */
-TEE_Result utee_se_reader_close_sessions(unsigned long r);
+TEE_Result _utee_se_reader_close_sessions(unsigned long r);
 
 /* s is of type TEE_SESessionHandle */
-TEE_Result utee_se_session_is_closed(unsigned long s);
+TEE_Result _utee_se_session_is_closed(unsigned long s);
 
 /* s is of type TEE_SESessionHandle */
-TEE_Result utee_se_session_get_atr(unsigned long s, void *atr,
-			uint64_t *atr_len);
+TEE_Result _utee_se_session_get_atr(unsigned long s, void *atr,
+				    uint64_t *atr_len);
 
 /*
  * s is of type TEE_SESessionHandle
  * c is of type TEE_SEChannelHandle
  */
-TEE_Result utee_se_session_open_channel(unsigned long s,
-			unsigned long is_logical, const void *aid_buffer,
-			size_t aid_buffer_len, uint32_t *c);
+TEE_Result _utee_se_session_open_channel(unsigned long s,
+					 unsigned long is_logical,
+					 const void *aid_buffer,
+					 size_t aid_buffer_len, uint32_t *c);
 
 /* s is of type TEE_SESessionHandle */
-TEE_Result utee_se_session_close(unsigned long s);
+TEE_Result _utee_se_session_close(unsigned long s);
 
 /* c is of type TEE_SEChannelHandle */
-TEE_Result utee_se_channel_select_next(unsigned long c);
+TEE_Result _utee_se_channel_select_next(unsigned long c);
 
 /* c is of type TEE_SEChannelHandle */
-TEE_Result utee_se_channel_get_select_resp(unsigned long c, void *resp,
-			uint64_t *resp_len);
+TEE_Result _utee_se_channel_get_select_resp(unsigned long c, void *resp,
+					    uint64_t *resp_len);
 
 /* c is of type TEE_SEChannelHandle */
-TEE_Result utee_se_channel_transmit(unsigned long c, void *cmd,
-			size_t cmd_len, void *resp, uint64_t *resp_len);
+TEE_Result _utee_se_channel_transmit(unsigned long c, void *cmd, size_t cmd_len,
+				     void *resp, uint64_t *resp_len);
 
 /* c is of type TEE_SEChannelHandle */
-TEE_Result utee_se_channel_close(unsigned long c);
+TEE_Result _utee_se_channel_close(unsigned long c);
 
-/* op is of type enum utee_cache_operation */
-TEE_Result utee_cache_operation(void *va, size_t l, unsigned long op);
+/* op is of type enum _utee_cache_operation */
+TEE_Result _utee_cache_operation(void *va, size_t l, unsigned long op);
 
-TEE_Result utee_gprof_send(void *buf, size_t size, uint32_t *id);
+TEE_Result _utee_gprof_send(void *buf, size_t size, uint32_t *id);
 
 #endif /* UTEE_SYSCALLS_H */

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -156,8 +156,8 @@ TEE_Result TEE_OpenTASession(const TEE_UUID *destination,
 	res = copy_param(&up, paramTypes, params, &tmp_buf, &tmp_len, tmp_va);
 	if (res)
 		goto out;
-	res = utee_open_ta_session(destination, cancellationRequestTimeout,
-				   &up, &s, returnOrigin);
+	res = _utee_open_ta_session(destination, cancellationRequestTimeout,
+				    &up, &s, returnOrigin);
 	update_out_param(params, tmp_va, &up);
 	if (tmp_buf) {
 		TEE_Result res2 = tee_unmap(tmp_buf, tmp_len);
@@ -182,7 +182,7 @@ out:
 void TEE_CloseTASession(TEE_TASessionHandle session)
 {
 	if (session != TEE_HANDLE_NULL) {
-		TEE_Result res = utee_close_ta_session((uintptr_t)session);
+		TEE_Result res = _utee_close_ta_session((uintptr_t)session);
 
 		if (res != TEE_SUCCESS)
 			TEE_Panic(res);
@@ -205,7 +205,7 @@ TEE_Result TEE_InvokeTACommand(TEE_TASessionHandle session,
 	res = copy_param(&up, paramTypes, params, &tmp_buf, &tmp_len, tmp_va);
 	if (res)
 		goto out;
-	res = utee_invoke_ta_command((uintptr_t)session,
+	res = _utee_invoke_ta_command((uintptr_t)session,
 				      cancellationRequestTimeout,
 				      commandID, &up, &ret_origin);
 	update_out_param(params, tmp_va, &up);
@@ -236,7 +236,7 @@ out:
 bool TEE_GetCancellationFlag(void)
 {
 	uint32_t c;
-	TEE_Result res = utee_get_cancellation_flag(&c);
+	TEE_Result res = _utee_get_cancellation_flag(&c);
 
 	if (res != TEE_SUCCESS)
 		c = 0;
@@ -246,7 +246,7 @@ bool TEE_GetCancellationFlag(void)
 bool TEE_UnmaskCancellation(void)
 {
 	uint32_t old_mask;
-	TEE_Result res = utee_unmask_cancellation(&old_mask);
+	TEE_Result res = _utee_unmask_cancellation(&old_mask);
 
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -256,7 +256,7 @@ bool TEE_UnmaskCancellation(void)
 bool TEE_MaskCancellation(void)
 {
 	uint32_t old_mask;
-	TEE_Result res = utee_mask_cancellation(&old_mask);
+	TEE_Result res = _utee_mask_cancellation(&old_mask);
 
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -274,7 +274,7 @@ TEE_Result TEE_CheckMemoryAccessRights(uint32_t accessFlags, void *buffer,
 		return TEE_SUCCESS;
 
 	/* Check access rights against memory mapping */
-	res = utee_check_access_rights(accessFlags, buffer, size);
+	res = _utee_check_access_rights(accessFlags, buffer, size);
 	if (res != TEE_SUCCESS)
 		goto out;
 
@@ -317,7 +317,7 @@ void *TEE_MemFill(void *buff, uint32_t x, uint32_t size)
 
 void TEE_GetSystemTime(TEE_Time *time)
 {
-	TEE_Result res = utee_get_time(UTEE_TIME_CAT_SYSTEM, time);
+	TEE_Result res = _utee_get_time(UTEE_TIME_CAT_SYSTEM, time);
 
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -325,7 +325,7 @@ void TEE_GetSystemTime(TEE_Time *time)
 
 TEE_Result TEE_Wait(uint32_t timeout)
 {
-	TEE_Result res = utee_wait(timeout);
+	TEE_Result res = _utee_wait(timeout);
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_CANCEL)
 		TEE_Panic(res);
@@ -337,7 +337,7 @@ TEE_Result TEE_GetTAPersistentTime(TEE_Time *time)
 {
 	TEE_Result res;
 
-	res = utee_get_time(UTEE_TIME_CAT_TA_PERSISTENT, time);
+	res = _utee_get_time(UTEE_TIME_CAT_TA_PERSISTENT, time);
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_OVERFLOW) {
 		time->seconds = 0;
@@ -358,7 +358,7 @@ TEE_Result TEE_SetTAPersistentTime(const TEE_Time *time)
 {
 	TEE_Result res;
 
-	res = utee_set_ta_time(time);
+	res = _utee_set_ta_time(time);
 
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_OUT_OF_MEMORY &&
@@ -370,7 +370,7 @@ TEE_Result TEE_SetTAPersistentTime(const TEE_Time *time)
 
 void TEE_GetREETime(TEE_Time *time)
 {
-	TEE_Result res = utee_get_time(UTEE_TIME_CAT_REE, time);
+	TEE_Result res = _utee_get_time(UTEE_TIME_CAT_REE, time);
 
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -401,14 +401,14 @@ void TEE_Free(void *buffer)
 /* Cache maintenance support (TA requires the CACHE_MAINTENANCE property) */
 TEE_Result TEE_CacheClean(char *buf, size_t len)
 {
-	return utee_cache_operation(buf, len, TEE_CACHECLEAN);
+	return _utee_cache_operation(buf, len, TEE_CACHECLEAN);
 }
 TEE_Result TEE_CacheFlush(char *buf, size_t len)
 {
-	return utee_cache_operation(buf, len, TEE_CACHEFLUSH);
+	return _utee_cache_operation(buf, len, TEE_CACHEFLUSH);
 }
 
 TEE_Result TEE_CacheInvalidate(char *buf, size_t len)
 {
-	return utee_cache_operation(buf, len, TEE_CACHEINVALIDATE);
+	return _utee_cache_operation(buf, len, TEE_CACHEINVALIDATE);
 }

--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -755,7 +755,7 @@ void TEE_BigIntComputeExtendedGcd(TEE_BigInt *gcd, TEE_BigInt *u,
 
 static int rng_read(void *ignored __unused, unsigned char *buf, size_t blen)
 {
-	if (utee_cryp_random_number_generate(buf, blen))
+	if (_utee_cryp_random_number_generate(buf, blen))
 		return MBEDTLS_ERR_MPI_FILE_IO_ERROR;
 	return 0;
 }

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -42,7 +42,7 @@ void TEE_GetObjectInfo(TEE_ObjectHandle object, TEE_ObjectInfo *objectInfo)
 {
 	TEE_Result res;
 
-	res = utee_cryp_obj_get_info((unsigned long)object, objectInfo);
+	res = _utee_cryp_obj_get_info((unsigned long)object, objectInfo);
 
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -61,7 +61,7 @@ TEE_Result TEE_GetObjectInfo1(TEE_ObjectHandle object, TEE_ObjectInfo *objectInf
 {
 	TEE_Result res;
 
-	res = utee_cryp_obj_get_info((unsigned long)object, objectInfo);
+	res = _utee_cryp_obj_get_info((unsigned long)object, objectInfo);
 
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
@@ -82,7 +82,7 @@ void TEE_RestrictObjectUsage(TEE_ObjectHandle object, uint32_t objectUsage)
 	TEE_Result res;
 	TEE_ObjectInfo objectInfo;
 
-	res = utee_cryp_obj_get_info((unsigned long)object, &objectInfo);
+	res = _utee_cryp_obj_get_info((unsigned long)object, &objectInfo);
 	if (objectInfo.objectType == TEE_TYPE_CORRUPTED_OBJECT)
 		return;
 
@@ -96,7 +96,8 @@ TEE_Result TEE_RestrictObjectUsage1(TEE_ObjectHandle object, uint32_t objectUsag
 {
 	TEE_Result res;
 
-	res = utee_cryp_obj_restrict_usage((unsigned long)object, objectUsage);
+	res = _utee_cryp_obj_restrict_usage((unsigned long)object,
+					    objectUsage);
 
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_CORRUPT_OBJECT &&
@@ -114,7 +115,7 @@ TEE_Result TEE_GetObjectBufferAttribute(TEE_ObjectHandle object,
 	TEE_ObjectInfo info;
 	uint64_t sz;
 
-	res = utee_cryp_obj_get_info((unsigned long)object, &info);
+	res = _utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
@@ -125,8 +126,8 @@ TEE_Result TEE_GetObjectBufferAttribute(TEE_ObjectHandle object,
 	}
 
 	sz = *size;
-	res = utee_cryp_obj_get_attr((unsigned long)object, attributeID,
-				     buffer, &sz);
+	res = _utee_cryp_obj_get_attr((unsigned long)object, attributeID,
+				      buffer, &sz);
 	*size = sz;
 
 exit:
@@ -149,7 +150,7 @@ TEE_Result TEE_GetObjectValueAttribute(TEE_ObjectHandle object,
 	uint32_t buf[2];
 	uint64_t size = sizeof(buf);
 
-	res = utee_cryp_obj_get_info((unsigned long)object, &info);
+	res = _utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
@@ -159,8 +160,8 @@ TEE_Result TEE_GetObjectValueAttribute(TEE_ObjectHandle object,
 		goto exit;
 	}
 
-	res = utee_cryp_obj_get_attr((unsigned long)object, attributeID, buf,
-				     &size);
+	res = _utee_cryp_obj_get_attr((unsigned long)object, attributeID, buf,
+				      &size);
 
 exit:
 	if (res != TEE_SUCCESS &&
@@ -189,7 +190,7 @@ void TEE_CloseObject(TEE_ObjectHandle object)
 	if (object == TEE_HANDLE_NULL)
 		return;
 
-	res = utee_cryp_obj_close((unsigned long)object);
+	res = _utee_cryp_obj_close((unsigned long)object);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }
@@ -203,7 +204,7 @@ TEE_Result TEE_AllocateTransientObject(TEE_ObjectType objectType,
 	TEE_Result res;
 	uint32_t obj;
 
-	res = utee_cryp_obj_alloc(objectType, maxKeySize, &obj);
+	res = _utee_cryp_obj_alloc(objectType, maxKeySize, &obj);
 
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_OUT_OF_MEMORY &&
@@ -224,14 +225,14 @@ void TEE_FreeTransientObject(TEE_ObjectHandle object)
 	if (object == TEE_HANDLE_NULL)
 		return;
 
-	res = utee_cryp_obj_get_info((unsigned long)object, &info);
+	res = _utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 
 	if ((info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT) != 0)
 		TEE_Panic(0);
 
-	res = utee_cryp_obj_close((unsigned long)object);
+	res = _utee_cryp_obj_close((unsigned long)object);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }
@@ -244,14 +245,14 @@ void TEE_ResetTransientObject(TEE_ObjectHandle object)
 	if (object == TEE_HANDLE_NULL)
 		return;
 
-	res = utee_cryp_obj_get_info((unsigned long)object, &info);
+	res = _utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 
 	if ((info.handleFlags & TEE_HANDLE_FLAG_PERSISTENT) != 0)
 		TEE_Panic(0);
 
-	res = utee_cryp_obj_reset((unsigned long)object);
+	res = _utee_cryp_obj_reset((unsigned long)object);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }
@@ -264,7 +265,7 @@ TEE_Result TEE_PopulateTransientObject(TEE_ObjectHandle object,
 	TEE_ObjectInfo info;
 	struct utee_attribute ua[attrCount];
 
-	res = utee_cryp_obj_get_info((unsigned long)object, &info);
+	res = _utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 
@@ -277,7 +278,7 @@ TEE_Result TEE_PopulateTransientObject(TEE_ObjectHandle object,
 		TEE_Panic(0);
 
 	__utee_from_attr(ua, attrs, attrCount);
-	res = utee_cryp_obj_populate((unsigned long)object, ua, attrCount);
+	res = _utee_cryp_obj_populate((unsigned long)object, ua, attrCount);
 	if (res != TEE_SUCCESS && res != TEE_ERROR_BAD_PARAMETERS)
 		TEE_Panic(res);
 	return res;
@@ -319,7 +320,7 @@ void TEE_CopyObjectAttributes(TEE_ObjectHandle destObject,
 	TEE_Result res;
 	TEE_ObjectInfo src_info;
 
-	res = utee_cryp_obj_get_info((unsigned long)srcObject, &src_info);
+	res = _utee_cryp_obj_get_info((unsigned long)srcObject, &src_info);
 	if (src_info.objectType == TEE_TYPE_CORRUPTED_OBJECT)
 		return;
 
@@ -335,11 +336,11 @@ TEE_Result TEE_CopyObjectAttributes1(TEE_ObjectHandle destObject,
 	TEE_ObjectInfo dst_info;
 	TEE_ObjectInfo src_info;
 
-	res = utee_cryp_obj_get_info((unsigned long)destObject, &dst_info);
+	res = _utee_cryp_obj_get_info((unsigned long)destObject, &dst_info);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	res = utee_cryp_obj_get_info((unsigned long)srcObject, &src_info);
+	res = _utee_cryp_obj_get_info((unsigned long)srcObject, &src_info);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
@@ -352,8 +353,8 @@ TEE_Result TEE_CopyObjectAttributes1(TEE_ObjectHandle destObject,
 	if ((dst_info.handleFlags & TEE_HANDLE_FLAG_INITIALIZED))
 		TEE_Panic(0);
 
-	res = utee_cryp_obj_copy((unsigned long)destObject,
-				 (unsigned long)srcObject);
+	res = _utee_cryp_obj_copy((unsigned long)destObject,
+				  (unsigned long)srcObject);
 
 exit:
 	if (res != TEE_SUCCESS &&
@@ -371,8 +372,8 @@ TEE_Result TEE_GenerateKey(TEE_ObjectHandle object, uint32_t keySize,
 	struct utee_attribute ua[paramCount];
 
 	__utee_from_attr(ua, params, paramCount);
-	res = utee_cryp_obj_generate_key((unsigned long)object, keySize,
-					 ua, paramCount);
+	res = _utee_cryp_obj_generate_key((unsigned long)object, keySize,
+					  ua, paramCount);
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_BAD_PARAMETERS)
 		TEE_Panic(res);
@@ -399,7 +400,7 @@ TEE_Result TEE_OpenPersistentObject(uint32_t storageID, const void *objectID,
 		goto exit;
 	}
 
-	res = utee_storage_obj_open(storageID, objectID, objectIDLen, flags,
+	res = _utee_storage_obj_open(storageID, objectID, objectIDLen, flags,
 				     &obj);
 	if (res == TEE_SUCCESS)
 		*object = (TEE_ObjectHandle)(uintptr_t)obj;
@@ -439,9 +440,9 @@ TEE_Result TEE_CreatePersistentObject(uint32_t storageID, const void *objectID,
 		goto exit;
 	}
 
-	res = utee_storage_obj_create(storageID, objectID, objectIDLen, flags,
-				      (unsigned long)attributes, initialData,
-				      initialDataLen, &obj);
+	res = _utee_storage_obj_create(storageID, objectID, objectIDLen, flags,
+				       (unsigned long)attributes, initialData,
+				       initialDataLen, &obj);
 
 	if (res == TEE_SUCCESS)
 		*object = (TEE_ObjectHandle)(uintptr_t)obj;
@@ -488,7 +489,7 @@ TEE_Result TEE_CloseAndDeletePersistentObject1(TEE_ObjectHandle object)
 	if (object == TEE_HANDLE_NULL)
 		return TEE_ERROR_STORAGE_NOT_AVAILABLE;
 
-	res = utee_storage_obj_del((unsigned long)object);
+	res = _utee_storage_obj_del((unsigned long)object);
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_STORAGE_NOT_AVAILABLE)
 		TEE_Panic(res);
@@ -518,8 +519,8 @@ TEE_Result TEE_RenamePersistentObject(TEE_ObjectHandle object,
 		goto out;
 	}
 
-	res = utee_storage_obj_rename((unsigned long)object, newObjectID,
-				      newObjectIDLen);
+	res = _utee_storage_obj_rename((unsigned long)object, newObjectID,
+				       newObjectIDLen);
 
 out:
 	if (res != TEE_SUCCESS &&
@@ -540,7 +541,7 @@ TEE_Result TEE_AllocatePersistentObjectEnumerator(TEE_ObjectEnumHandle *
 	if (!objectEnumerator)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = utee_storage_alloc_enum(&oe);
+	res = _utee_storage_alloc_enum(&oe);
 
 	if (res != TEE_SUCCESS)
 		oe = TEE_HANDLE_NULL;
@@ -561,7 +562,7 @@ void TEE_FreePersistentObjectEnumerator(TEE_ObjectEnumHandle objectEnumerator)
 	if (objectEnumerator == TEE_HANDLE_NULL)
 		return;
 
-	res = utee_storage_free_enum((unsigned long)objectEnumerator);
+	res = _utee_storage_free_enum((unsigned long)objectEnumerator);
 
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -574,7 +575,7 @@ void TEE_ResetPersistentObjectEnumerator(TEE_ObjectEnumHandle objectEnumerator)
 	if (objectEnumerator == TEE_HANDLE_NULL)
 		return;
 
-	res = utee_storage_reset_enum((unsigned long)objectEnumerator);
+	res = _utee_storage_reset_enum((unsigned long)objectEnumerator);
 
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
@@ -586,8 +587,8 @@ TEE_Result TEE_StartPersistentObjectEnumerator(TEE_ObjectEnumHandle
 {
 	TEE_Result res;
 
-	res = utee_storage_start_enum((unsigned long)objectEnumerator,
-				      storageID);
+	res = _utee_storage_start_enum((unsigned long)objectEnumerator,
+				       storageID);
 
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_ITEM_NOT_FOUND &&
@@ -622,8 +623,8 @@ TEE_Result TEE_GetNextPersistentObject(TEE_ObjectEnumHandle objectEnumerator,
 	else
 		pt_info = &local_info;
 	len = *objectIDLen;
-	res = utee_storage_next_enum((unsigned long)objectEnumerator,
-				     pt_info, objectID, &len);
+	res = _utee_storage_next_enum((unsigned long)objectEnumerator,
+				      pt_info, objectID, &len);
 	*objectIDLen = len;
 
 out:
@@ -650,8 +651,8 @@ TEE_Result TEE_ReadObjectData(TEE_ObjectHandle object, void *buffer,
 	}
 
 	cnt64 = *count;
-	res = utee_storage_obj_read((unsigned long)object, buffer, size,
-				    &cnt64);
+	res = _utee_storage_obj_read((unsigned long)object, buffer, size,
+				     &cnt64);
 	*count = cnt64;
 
 out:
@@ -678,7 +679,7 @@ TEE_Result TEE_WriteObjectData(TEE_ObjectHandle object, const void *buffer,
 		goto out;
 	}
 
-	res = utee_storage_obj_write((unsigned long)object, buffer, size);
+	res = _utee_storage_obj_write((unsigned long)object, buffer, size);
 
 out:
 	if (res != TEE_SUCCESS &&
@@ -700,7 +701,7 @@ TEE_Result TEE_TruncateObjectData(TEE_ObjectHandle object, uint32_t size)
 		goto out;
 	}
 
-	res = utee_storage_obj_trunc((unsigned long)object, size);
+	res = _utee_storage_obj_trunc((unsigned long)object, size);
 
 out:
 	if (res != TEE_SUCCESS &&
@@ -723,7 +724,7 @@ TEE_Result TEE_SeekObjectData(TEE_ObjectHandle object, int32_t offset,
 		goto out;
 	}
 
-	res = utee_cryp_obj_get_info((unsigned long)object, &info);
+	res = _utee_cryp_obj_get_info((unsigned long)object, &info);
 	if (res != TEE_SUCCESS)
 		goto out;
 
@@ -757,7 +758,7 @@ TEE_Result TEE_SeekObjectData(TEE_ObjectHandle object, int32_t offset,
 		goto out;
 	}
 
-	res = utee_storage_obj_seek((unsigned long)object, offset, whence);
+	res = _utee_storage_obj_seek((unsigned long)object, offset, whence);
 
 out:
 	if (res != TEE_SUCCESS &&

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -321,8 +321,8 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		}
 	}
 
-	res = utee_cryp_state_alloc(algorithm, mode, (unsigned long)op->key1,
-				    (unsigned long)op->key2, &op->state);
+	res = _utee_cryp_state_alloc(algorithm, mode, (unsigned long)op->key1,
+				     (unsigned long)op->key2, &op->state);
 	if (res != TEE_SUCCESS)
 		goto out;
 
@@ -332,7 +332,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	 * Non-applicable on asymmetric operations
 	 */
 	if (TEE_ALG_GET_CLASS(algorithm) == TEE_OPERATION_DIGEST) {
-		res = utee_hash_init(op->state, NULL, 0);
+		res = _utee_hash_init(op->state, NULL, 0);
 		if (res != TEE_SUCCESS)
 			goto out;
 		/* v1.1: flags always set for digest operations */
@@ -375,7 +375,7 @@ void TEE_FreeOperation(TEE_OperationHandle operation)
 	 * claimed by the operation they will be freed by
 	 * utee_cryp_state_free().
 	 */
-	res = utee_cryp_state_free(operation->state);
+	res = _utee_cryp_state_free(operation->state);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 
@@ -504,7 +504,7 @@ void TEE_ResetOperation(TEE_OperationHandle operation)
 	operation->operationState = TEE_OPERATION_STATE_INITIAL;
 
 	if (operation->info.operationClass == TEE_OPERATION_DIGEST) {
-		res = utee_hash_init(operation->state, NULL, 0);
+		res = _utee_hash_init(operation->state, NULL, 0);
 		if (res != TEE_SUCCESS)
 			TEE_Panic(res);
 		operation->info.handleState |= TEE_HANDLE_FLAG_INITIALIZED;
@@ -754,7 +754,7 @@ void TEE_CopyOperation(TEE_OperationHandle dst_op, TEE_OperationHandle src_op)
 		TEE_Panic(0);
 	}
 
-	res = utee_cryp_state_copy(dst_op->state, src_op->state);
+	res = _utee_cryp_state_copy(dst_op->state, src_op->state);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }
@@ -770,7 +770,7 @@ static void init_hash_operation(TEE_OperationHandle operation, const void *IV,
 	 * Note : IV and IVLen are never used in current implementation
 	 * This is why coherent values of IV and IVLen are not checked
 	 */
-	res = utee_hash_init(operation->state, IV, IVLen);
+	res = _utee_hash_init(operation->state, IV, IVLen);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 	operation->buffer_offs = 0;
@@ -788,7 +788,7 @@ void TEE_DigestUpdate(TEE_OperationHandle operation,
 
 	operation->operationState = TEE_OPERATION_STATE_ACTIVE;
 
-	res = utee_hash_update(operation->state, chunk, chunkSize);
+	res = _utee_hash_update(operation->state, chunk, chunkSize);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }
@@ -809,7 +809,7 @@ TEE_Result TEE_DigestDoFinal(TEE_OperationHandle operation, const void *chunk,
 	}
 
 	hl = *hashLen;
-	res = utee_hash_final(operation->state, chunk, chunkLen, hash, &hl);
+	res = _utee_hash_final(operation->state, chunk, chunkLen, hash, &hl);
 	*hashLen = hl;
 	if (res != TEE_SUCCESS)
 		goto out;
@@ -849,7 +849,7 @@ void TEE_CipherInit(TEE_OperationHandle operation, const void *IV,
 
 	operation->operationState = TEE_OPERATION_STATE_ACTIVE;
 
-	res = utee_cipher_init(operation->state, IV, IVLen);
+	res = _utee_cipher_init(operation->state, IV, IVLen);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 
@@ -1017,12 +1017,12 @@ TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, const void *srcData,
 
 	dl = *destLen;
 	if (operation->block_size > 1) {
-		res = tee_buffer_update(operation, utee_cipher_update, srcData,
+		res = tee_buffer_update(operation, _utee_cipher_update, srcData,
 					srcLen, destData, &dl);
 	} else {
 		if (srcLen > 0) {
-			res = utee_cipher_update(operation->state, srcData,
-						 srcLen, destData, &dl);
+			res = _utee_cipher_update(operation->state, srcData,
+						  srcLen, destData, &dl);
 		} else {
 			res = TEE_SUCCESS;
 			dl = 0;
@@ -1108,7 +1108,7 @@ TEE_Result TEE_CipherDoFinal(TEE_OperationHandle operation,
 
 	tmp_dlen = *destLen - acc_dlen;
 	if (operation->block_size > 1) {
-		res = tee_buffer_update(operation, utee_cipher_update,
+		res = tee_buffer_update(operation, _utee_cipher_update,
 					srcData, srcLen, dst, &tmp_dlen);
 		if (res != TEE_SUCCESS)
 			goto out;
@@ -1117,11 +1117,12 @@ TEE_Result TEE_CipherDoFinal(TEE_OperationHandle operation,
 		acc_dlen += tmp_dlen;
 
 		tmp_dlen = *destLen - acc_dlen;
-		res = utee_cipher_final(operation->state, operation->buffer,
-					operation->buffer_offs, dst, &tmp_dlen);
+		res = _utee_cipher_final(operation->state, operation->buffer,
+					 operation->buffer_offs, dst,
+					 &tmp_dlen);
 	} else {
-		res = utee_cipher_final(operation->state, srcData,
-					srcLen, dst, &tmp_dlen);
+		res = _utee_cipher_final(operation->state, srcData, srcLen, dst,
+					 &tmp_dlen);
 	}
 	if (res != TEE_SUCCESS)
 		goto out;
@@ -1180,7 +1181,7 @@ void TEE_MACUpdate(TEE_OperationHandle operation, const void *chunk,
 	if (operation->operationState != TEE_OPERATION_STATE_ACTIVE)
 		TEE_Panic(0);
 
-	res = utee_hash_update(operation->state, chunk, chunkSize);
+	res = _utee_hash_update(operation->state, chunk, chunkSize);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }
@@ -1216,7 +1217,7 @@ TEE_Result TEE_MACComputeFinal(TEE_OperationHandle operation,
 	}
 
 	ml = *macLen;
-	res = utee_hash_final(operation->state, message, messageLen, mac, &ml);
+	res = _utee_hash_final(operation->state, message, messageLen, mac, &ml);
 	*macLen = ml;
 	if (res != TEE_SUCCESS)
 		goto out;
@@ -1320,8 +1321,8 @@ TEE_Result TEE_AEInit(TEE_OperationHandle operation, const void *nonce,
 		}
 	}
 
-	res = utee_authenc_init(operation->state, nonce, nonceLen,
-				tagLen / 8, AADLen, payloadLen);
+	res = _utee_authenc_init(operation->state, nonce, nonceLen, tagLen / 8,
+				 AADLen, payloadLen);
 	if (res != TEE_SUCCESS)
 		goto out;
 
@@ -1352,7 +1353,7 @@ void TEE_AEUpdateAAD(TEE_OperationHandle operation, const void *AADdata,
 	if ((operation->info.handleState & TEE_HANDLE_FLAG_INITIALIZED) == 0)
 		TEE_Panic(0);
 
-	res = utee_authenc_update_aad(operation->state, AADdata, AADdataLen);
+	res = _utee_authenc_update_aad(operation->state, AADdata, AADdataLen);
 
 	operation->operationState = TEE_OPERATION_STATE_ACTIVE;
 
@@ -1411,13 +1412,13 @@ TEE_Result TEE_AEUpdate(TEE_OperationHandle operation, const void *srcData,
 
 	dl = *destLen;
 	if (operation->block_size > 1) {
-		res = tee_buffer_update(operation, utee_authenc_update_payload,
+		res = tee_buffer_update(operation, _utee_authenc_update_payload,
 					srcData, srcLen, destData, &dl);
 	} else {
 		if (srcLen > 0) {
-			res = utee_authenc_update_payload(operation->state,
-							  srcData, srcLen,
-							  destData, &dl);
+			res = _utee_authenc_update_payload(operation->state,
+							   srcData, srcLen,
+							   destData, &dl);
 		} else {
 			dl = 0;
 			res = TEE_SUCCESS;
@@ -1496,7 +1497,7 @@ TEE_Result TEE_AEEncryptFinal(TEE_OperationHandle operation,
 	tl = *tagLen;
 	tmp_dlen = *destLen - acc_dlen;
 	if (operation->block_size > 1) {
-		res = tee_buffer_update(operation, utee_authenc_update_payload,
+		res = tee_buffer_update(operation, _utee_authenc_update_payload,
 					srcData, srcLen, dst, &tmp_dlen);
 		if (res != TEE_SUCCESS)
 			goto out;
@@ -1505,14 +1506,14 @@ TEE_Result TEE_AEEncryptFinal(TEE_OperationHandle operation,
 		acc_dlen += tmp_dlen;
 
 		tmp_dlen = *destLen - acc_dlen;
-		res = utee_authenc_enc_final(operation->state,
-					     operation->buffer,
-					     operation->buffer_offs, dst,
-					     &tmp_dlen, tag, &tl);
+		res = _utee_authenc_enc_final(operation->state,
+					      operation->buffer,
+					      operation->buffer_offs, dst,
+					      &tmp_dlen, tag, &tl);
 	} else {
-		res = utee_authenc_enc_final(operation->state, srcData,
-					     srcLen, dst, &tmp_dlen,
-					     tag, &tl);
+		res = _utee_authenc_enc_final(operation->state, srcData,
+					      srcLen, dst, &tmp_dlen,
+					      tag, &tl);
 	}
 	*tagLen = tl;
 	if (res != TEE_SUCCESS)
@@ -1577,7 +1578,7 @@ TEE_Result TEE_AEDecryptFinal(TEE_OperationHandle operation,
 
 	tmp_dlen = *destLen - acc_dlen;
 	if (operation->block_size > 1) {
-		res = tee_buffer_update(operation, utee_authenc_update_payload,
+		res = tee_buffer_update(operation, _utee_authenc_update_payload,
 					srcData, srcLen, dst, &tmp_dlen);
 		if (res != TEE_SUCCESS)
 			goto out;
@@ -1586,14 +1587,14 @@ TEE_Result TEE_AEDecryptFinal(TEE_OperationHandle operation,
 		acc_dlen += tmp_dlen;
 
 		tmp_dlen = *destLen - acc_dlen;
-		res = utee_authenc_dec_final(operation->state,
-					     operation->buffer,
-					     operation->buffer_offs, dst,
-					     &tmp_dlen, tag, tagLen);
+		res = _utee_authenc_dec_final(operation->state,
+					      operation->buffer,
+					      operation->buffer_offs, dst,
+					      &tmp_dlen, tag, tagLen);
 	} else {
-		res = utee_authenc_dec_final(operation->state, srcData,
-					     srcLen, dst, &tmp_dlen,
-					     tag, tagLen);
+		res = _utee_authenc_dec_final(operation->state, srcData,
+					      srcLen, dst, &tmp_dlen,
+					      tag, tagLen);
 	}
 	if (res != TEE_SUCCESS)
 		goto out;
@@ -1644,8 +1645,8 @@ TEE_Result TEE_AsymmetricEncrypt(TEE_OperationHandle operation,
 
 	__utee_from_attr(ua, params, paramCount);
 	dl = *destLen;
-	res = utee_asymm_operate(operation->state, ua, paramCount, srcData,
-				 srcLen, destData, &dl);
+	res = _utee_asymm_operate(operation->state, ua, paramCount, srcData,
+				  srcLen, destData, &dl);
 	*destLen = dl;
 
 	if (res != TEE_SUCCESS &&
@@ -1680,8 +1681,8 @@ TEE_Result TEE_AsymmetricDecrypt(TEE_OperationHandle operation,
 
 	__utee_from_attr(ua, params, paramCount);
 	dl = *destLen;
-	res = utee_asymm_operate(operation->state, ua, paramCount, srcData,
-				 srcLen, destData, &dl);
+	res = _utee_asymm_operate(operation->state, ua, paramCount, srcData,
+				  srcLen, destData, &dl);
 	*destLen = dl;
 
 	if (res != TEE_SUCCESS &&
@@ -1718,8 +1719,8 @@ TEE_Result TEE_AsymmetricSignDigest(TEE_OperationHandle operation,
 
 	__utee_from_attr(ua, params, paramCount);
 	sl = *signatureLen;
-	res = utee_asymm_operate(operation->state, ua, paramCount, digest,
-				 digestLen, signature, &sl);
+	res = _utee_asymm_operate(operation->state, ua, paramCount, digest,
+				  digestLen, signature, &sl);
 	*signatureLen = sl;
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_SHORT_BUFFER)
@@ -1753,8 +1754,8 @@ TEE_Result TEE_AsymmetricVerifyDigest(TEE_OperationHandle operation,
 		TEE_Panic(0);
 
 	__utee_from_attr(ua, params, paramCount);
-	res = utee_asymm_verify(operation->state, ua, paramCount, digest,
-				digestLen, signature, signatureLen);
+	res = _utee_asymm_verify(operation->state, ua, paramCount, digest,
+				 digestLen, signature, signatureLen);
 
 	if (res != TEE_SUCCESS && res != TEE_ERROR_SIGNATURE_INVALID)
 		TEE_Panic(res);
@@ -1789,7 +1790,7 @@ void TEE_DeriveKey(TEE_OperationHandle operation,
 	if ((operation->info.handleState & TEE_HANDLE_FLAG_KEY_SET) == 0)
 		TEE_Panic(0);
 
-	res = utee_cryp_obj_get_info((unsigned long)derivedKey, &key_info);
+	res = _utee_cryp_obj_get_info((unsigned long)derivedKey, &key_info);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 
@@ -1799,8 +1800,8 @@ void TEE_DeriveKey(TEE_OperationHandle operation,
 		TEE_Panic(0);
 
 	__utee_from_attr(ua, params, paramCount);
-	res = utee_cryp_derive_key(operation->state, ua, paramCount,
-				   (unsigned long)derivedKey);
+	res = _utee_cryp_derive_key(operation->state, ua, paramCount,
+				    (unsigned long)derivedKey);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }
@@ -1811,7 +1812,7 @@ void TEE_GenerateRandom(void *randomBuffer, uint32_t randomBufferLen)
 {
 	TEE_Result res;
 
-	res = utee_cryp_random_number_generate(randomBuffer, randomBufferLen);
+	res = _utee_cryp_random_number_generate(randomBuffer, randomBufferLen);
 	if (res != TEE_SUCCESS)
 		TEE_Panic(res);
 }

--- a/lib/libutee/tee_api_panic.c
+++ b/lib/libutee/tee_api_panic.c
@@ -9,5 +9,5 @@
 
 void TEE_Panic(TEE_Result panicCode)
 {
-	utee_panic(panicCode);
+	_utee_panic(panicCode);
 }

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -148,12 +148,13 @@ static TEE_Result propget_get_property(TEE_PropSetHandle h, const char *name,
 		}
 
 		/* get the index from the name */
-		res = utee_get_property_name_to_index((unsigned long)h, name,
-						strlen(name) + 1, &index);
+		res = _utee_get_property_name_to_index((unsigned long)h, name,
+						       strlen(name) + 1,
+						       &index);
 		if (res != TEE_SUCCESS)
 			return res;
-		res = utee_get_property((unsigned long)h, index, NULL, NULL,
-					buf, len, &prop_type);
+		res = _utee_get_property((unsigned long)h, index, NULL, NULL,
+					 buf, len, &prop_type);
 	} else {
 		struct prop_enumerator *pe = (struct prop_enumerator *)h;
 		uint32_t idx = pe->idx;
@@ -169,8 +170,8 @@ static TEE_Result propget_get_property(TEE_PropSetHandle h, const char *name,
 			return propget_get_ext_prop(eps + idx, type, buf, len);
 		idx -= eps_len;
 
-		res = utee_get_property((unsigned long)pe->prop_set, idx,
-					NULL, NULL, buf, len, &prop_type);
+		res = _utee_get_property((unsigned long)pe->prop_set, idx,
+					 NULL, NULL, buf, len, &prop_type);
 		if (res == TEE_ERROR_ITEM_NOT_FOUND)
 			res = TEE_ERROR_BAD_PARAMETERS;
 	}
@@ -501,9 +502,9 @@ TEE_Result TEE_GetPropertyName(TEE_PropSetHandle enumerator,
 			res = TEE_ERROR_SHORT_BUFFER;
 		*name_len = bufferlen;
 	} else {
-		res = utee_get_property((unsigned long)pe->prop_set,
-					pe->idx - eps_len,
-					name, name_len, NULL, NULL, NULL);
+		res = _utee_get_property((unsigned long)pe->prop_set,
+					 pe->idx - eps_len, name, name_len,
+					 NULL, NULL, NULL);
 		if (res != TEE_SUCCESS)
 			goto err;
 	}
@@ -543,9 +544,9 @@ TEE_Result TEE_GetNextProperty(TEE_PropSetHandle enumerator)
 	if (next_idx < eps_len)
 		res = TEE_SUCCESS;
 	else
-		res = utee_get_property((unsigned long)pe->prop_set,
-					next_idx - eps_len,
-					NULL, NULL, NULL, NULL, NULL);
+		res = _utee_get_property((unsigned long)pe->prop_set,
+					 next_idx - eps_len, NULL, NULL, NULL,
+					 NULL, NULL);
 
 out:
 	if (res != TEE_SUCCESS &&

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -99,7 +99,7 @@ static TEE_Result propget_get_ext_prop(const struct user_ta_property *ep,
 		 * string
 		 */
 		l = *len;
-		if (!base64_dec(ep->value, strlen(ep->value), buf, &l) &&
+		if (!_base64_dec(ep->value, strlen(ep->value), buf, &l) &&
 		    l <= *len)
 			return TEE_ERROR_GENERIC;
 		if (*len < l) {
@@ -217,7 +217,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 				 * with the size of the of the base64 encoded
 				 * see base64_enc() function
 				 */
-				tmp_len = base64_enc_len(tmp_len);
+				tmp_len = _base64_enc_len(tmp_len);
 			}
 			*value_len = tmp_len;
 		}
@@ -252,7 +252,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 
 	case USER_TA_PROP_TYPE_BINARY_BLOCK:
 		l = *value_len;	/* l includes the zero-termination */
-		if (!base64_enc(tmp_buf, tmp_len, value, &l) &&
+		if (!_base64_enc(tmp_buf, tmp_len, value, &l) &&
 		    l <= *value_len) {
 			res = TEE_ERROR_GENERIC;
 			goto out;

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -100,7 +100,7 @@ static TEE_Result propget_get_ext_prop(const struct user_ta_property *ep,
 		 */
 		l = *len;
 		if (!base64_dec(ep->value, strlen(ep->value), buf, &l) &&
-		    (l <= *len))
+		    l <= *len)
 			return TEE_ERROR_GENERIC;
 		if (*len < l) {
 			*len = l;
@@ -253,7 +253,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 	case USER_TA_PROP_TYPE_BINARY_BLOCK:
 		l = *value_len;	/* l includes the zero-termination */
 		if (!base64_enc(tmp_buf, tmp_len, value, &l) &&
-		    (l <= *value_len)) {
+		    l <= *value_len) {
 			res = TEE_ERROR_GENERIC;
 			goto out;
 		}

--- a/lib/libutee/trace_ext.c
+++ b/lib/libutee/trace_ext.c
@@ -15,7 +15,7 @@
 
 void trace_ext_puts(const char *str)
 {
-	utee_log(str, strlen(str));
+	_utee_log(str, strlen(str));
 }
 
 int trace_ext_get_thread_id(void)

--- a/lib/libutils/ext/ftrace/ftrace.c
+++ b/lib/libutils/ext/ftrace/ftrace.c
@@ -175,7 +175,7 @@ void __noprof ftrace_enter(unsigned long pc, unsigned long *lr)
 #if defined(__KERNEL__)
 		panic();
 #else
-		utee_panic(0);
+		_utee_panic(0);
 #endif
 	}
 

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -51,12 +51,12 @@ void __noreturn _C_FUNCTION(__ta_entry)(unsigned long func,
 	/*
 	 * __ta_entry is the first TA API called from TEE core. As it being
 	 * __noreturn API, we need to call ftrace_return in this API just
-	 * before utee_return syscall to get proper ftrace call graph.
+	 * before _utee_return syscall to get proper ftrace call graph.
 	 */
 	ftrace_return();
 #endif
 
-	utee_return(res);
+	_utee_return(res);
 }
 
 /*


### PR DESCRIPTION
A couple of patches to `libutee` so that all internal symbols [1] begin with a leading underscore to avoid conflicts with application code.

[1] Internal symbols = those that are not part of the API exported by `libutee`