### PR TITLE
checkpatch: limit maximum line length to 80

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -2,6 +2,7 @@
 --no-tree
 --quiet
 --strict
+--max-line-length=80
 --ignore=CAMELCASE
 --ignore=CONCATENATED_STRING
 --ignore=FILE_PATH_CHANGES


### PR DESCRIPTION
The Linux kernel has recently increased maximum line length to 100, but
still recommends to stay under 80. So make sure the checkpatch still warn
when exceeding 80.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
