### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# For git archive
+.gitignore              export-ignore
+.gitattributes          export-ignore
+.travis.yml             export-ignore
+.github                 export-ignore
+.shippable.yml          export-ignore


### PR DESCRIPTION
This patch adds a .gitattributes file to specify files that should
never end up in a distribution tarball.

A similar change has been rised at https://github.com/OP-TEE/optee_client/pull/212

Signed-off-by: Hu Keping hukeping@huawei.com

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
