### PR TITLE
[RFC] Recursive mutexes

### DIFF
--- a/core/arch/arm/include/kernel/mutex.h
+++ b/core/arch/arm/include/kernel/mutex.h
@@ -5,10 +5,10 @@
 #ifndef KERNEL_MUTEX_H
 #define KERNEL_MUTEX_H
 
-#include <types_ext.h>
-#include <sys/queue.h>
 #include <kernel/refcount.h>
 #include <kernel/wait_queue.h>
+#include <sys/queue.h>
+#include <types_ext.h>
 
 struct mutex {
 	unsigned spin_lock;	/* used when operating on this struct */

--- a/core/arch/arm/kernel/mutex.c
+++ b/core/arch/arm/kernel/mutex.c
@@ -58,6 +58,7 @@ static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 		} else {
 			m->state = -1; /* write locked */
 			if (m->recursive) {
+				assert(m->owner == THREAD_ID_INVALID);
 				m->owner = thread_get_id();
 				refcount_set(&m->lock_count, 1);
 			}

--- a/lib/libutils/ext/mempool.c
+++ b/lib/libutils/ext/mempool.c
@@ -16,7 +16,6 @@
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
 #include <kernel/thread.h>
-#include <kernel/refcount.h>
 #endif
 
 /*
@@ -64,9 +63,7 @@ struct mempool {
 #if defined(__KERNEL__)
 	void (*release_mem)(void *ptr, size_t size);
 	struct mutex mu;
-	struct condvar cv;
-	struct refcount refc;
-	int owner;
+	int refc;
 #endif
 };
 
@@ -77,53 +74,24 @@ struct mempool *mempool_default;
 static void get_pool(struct mempool *pool __maybe_unused)
 {
 #if defined(__KERNEL__)
-	/*
-	 * Owner matches our thread it cannot be changed. If it doesn't
-	 * match it can change any at time we're not holding the mutex to
-	 * any value but our thread id.
-	 */
-	if (atomic_load_int(&pool->owner) == thread_get_id()) {
-		if (!refcount_inc(&pool->refc))
-			panic();
-		return;
-	}
-
 	mutex_lock(&pool->mu);
-
-	/* Wait until the pool is available */
-	while (pool->owner != THREAD_ID_INVALID)
-		condvar_wait(&pool->cv, &pool->mu);
-
-	pool->owner = thread_get_id();
-	refcount_set(&pool->refc, 1);
-
-	mutex_unlock(&pool->mu);
+	pool->refc++;
 #endif
 }
 
 static void put_pool(struct mempool *pool __maybe_unused)
 {
 #if defined(__KERNEL__)
-	assert(atomic_load_int(&pool->owner) == thread_get_id());
-
-	if (refcount_dec(&pool->refc)) {
-		mutex_lock(&pool->mu);
-
-		/*
-		 * Do an atomic store to match the atomic load in
-		 * get_pool() above.
-		 */
-		atomic_store_int(&pool->owner, THREAD_ID_INVALID);
-		condvar_signal(&pool->cv);
-
+	assert(pool->refc);
+	pool->refc--;
+	if (!pool->refc) {
 		/* As the refcount is 0 there should be no items left */
 		if (pool->last_offset >= 0)
 			panic();
 		if (pool->release_mem)
 			pool->release_mem((void *)pool->data, pool->size);
-
-		mutex_unlock(&pool->mu);
 	}
+	mutex_unlock(&pool->mu);
 #endif
 }
 
@@ -142,9 +110,7 @@ mempool_alloc_pool(void *data, size_t size,
 		pool->last_offset = -1;
 #if defined(__KERNEL__)
 		pool->release_mem = release_mem;
-		mutex_init(&pool->mu);
-		condvar_init(&pool->cv);
-		pool->owner = THREAD_ID_INVALID;
+		mutex_init_recursive(&pool->mu);
 #endif
 	}
 


### PR DESCRIPTION
A couple of commits to add support for recursive mutexes, and use one in the mempool functions `get_pool()` and `put_pool()`.

I think it makes the code a bit easier to read, and it also saves one `mutex_unlock()` and one `mutex_lock()` call in a sequence: `get_pool(); get_pool(); ... put_pool(); put_pool();`. The reason is because the mutex remains locked during the whole sequence instead of being locked + unlocked in the first `get_pool()` and again in the last `put_pool()`. I don't expect it to make any practical difference though.

A small drawback is the size of the `mutex` structure is increased for all users. On QEMU that's an additional 104 bytes of `.bss` and another 112 bytes of `.text`, not much at all.

So I am posting this as a RFC. We could also defer until we have at least two users and not just mempool. I did not find another candidate at the moment.