### PR TITLE
stm32_etzpc: rename internal function init_device_from_hw_config()

### DIFF
--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -28,7 +28,7 @@
 #include <mm/core_memprot.h>
 #include <util.h>
 
-/* Devicetree compatibulity */
+/* Devicetree compatibility */
 #define ETZPC_COMPAT			"st,stm32-etzpc"
 
 /* ID Registers */
@@ -288,8 +288,8 @@ static void get_hwcfg(struct etzpc_hwcfg *hwcfg)
 			    ETZPC_HWCFGR_CHUNCKS1N4_SHIFT;
 }
 
-static void init_devive_from_hw_config(struct etzpc_instance *dev,
-					      paddr_t pbase)
+static void init_device_from_hw_config(struct etzpc_instance *dev,
+				       paddr_t pbase)
 {
 	struct etzpc_hwcfg hwcfg = { };
 
@@ -312,7 +312,7 @@ static void init_devive_from_hw_config(struct etzpc_instance *dev,
 
 void stm32_etzpc_init(paddr_t base)
 {
-	init_devive_from_hw_config(&etzpc_dev, base);
+	init_device_from_hw_config(&etzpc_dev, base);
 }
 
 #ifdef CFG_DT
@@ -337,7 +337,7 @@ static TEE_Result init_etzpc_from_dt(void)
 	if (pbase == (paddr_t)-1)
 		panic();
 
-	init_devive_from_hw_config(&etzpc_dev, pbase);
+	init_device_from_hw_config(&etzpc_dev, pbase);
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Fix typo in function label: init_devive_from_hw_config() is renamed
init_device_from_hw_config().

Fix also a typo in source file inline comment.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
