### PR TITLE
mk: core: ta: Configurable Python interpreter

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -245,6 +245,7 @@ ta-mk-file-export-add-ta_arm32 += CROSS_COMPILE32 ?= $$(CROSS_COMPILE)_nl_
 ta-mk-file-export-add-ta_arm32 += CROSS_COMPILE_ta_arm32 ?= $$(CROSS_COMPILE32)_nl_
 ta-mk-file-export-add-ta_arm32 += COMPILER ?= gcc_nl_
 ta-mk-file-export-add-ta_arm32 += COMPILER_ta_arm32 ?= $$(COMPILER)_nl_
+ta-mk-file-export-add-ta_arm32 += PYTHON3 ?= python3_nl_
 endif
 
 ifneq ($(filter ta_arm64,$(ta-targets)),)
@@ -275,6 +276,7 @@ ta-mk-file-export-add-ta_arm64 += CROSS_COMPILE64 ?= $$(CROSS_COMPILE)_nl_
 ta-mk-file-export-add-ta_arm64 += CROSS_COMPILE_ta_arm64 ?= $$(CROSS_COMPILE64)_nl_
 ta-mk-file-export-add-ta_arm64 += COMPILER ?= gcc_nl_
 ta-mk-file-export-add-ta_arm64 += COMPILER_ta_arm64 ?= $$(COMPILER)_nl_
+ta-mk-file-export-add-ta_arm64 += PYTHON3 ?= python3_nl_
 endif
 
 # Set cross compiler prefix for each TA target

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -62,13 +62,13 @@ cleanfiles += $(link-out-dir)/text_unpaged.ld.S
 $(link-out-dir)/text_unpaged.ld.S: $(link-out-dir)/unpaged.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -S -W $< | \
-		./scripts/gen_ld_sects.py .text. > $@
+		$(PYTHON3) ./scripts/gen_ld_sects.py .text. > $@
 
 cleanfiles += $(link-out-dir)/rodata_unpaged.ld.S
 $(link-out-dir)/rodata_unpaged.ld.S: $(link-out-dir)/unpaged.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -S -W $< | \
-		./scripts/gen_ld_sects.py .rodata. > $@
+		$(PYTHON3) ./scripts/gen_ld_sects.py .rodata. > $@
 
 
 cleanfiles += $(link-out-dir)/init_entries.txt
@@ -92,12 +92,12 @@ cleanfiles += $(link-out-dir)/text_init.ld.S
 $(link-out-dir)/text_init.ld.S: $(link-out-dir)/init.o
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(READELFcore) -S -W $< | \
-		./scripts/gen_ld_sects.py .text. > $@
+		$(PYTHON3) ./scripts/gen_ld_sects.py .text. > $@
 
 cleanfiles += $(link-out-dir)/rodata_init.ld.S
 $(link-out-dir)/rodata_init.ld.S: $(link-out-dir)/init.o
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)$(READELFcore) -S -W $< | ./scripts/gen_ld_sects.py .rodata. > $@
+	$(q)$(READELFcore) -S -W $< | $(PYTHON3) ./scripts/gen_ld_sects.py .rodata. > $@
 
 -include $(link-script-dep)
 
@@ -176,39 +176,39 @@ cleanfiles += $(link-out-dir)/tee-pager.bin
 $(link-out-dir)/tee-pager.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 	@echo Warning: $@ is deprecated
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_tee_pager_bin $@
+	$(q)$(PYTHON3) scripts/gen_tee_bin.py --input $< --out_tee_pager_bin $@
 
 cleanfiles += $(link-out-dir)/tee-pageable.bin
 $(link-out-dir)/tee-pageable.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 	@echo Warning: $@ is deprecated
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_tee_pageable_bin $@
+	$(q)$(PYTHON3) scripts/gen_tee_bin.py --input $< --out_tee_pageable_bin $@
 
 all: $(link-out-dir)/tee.bin
 cleanfiles += $(link-out-dir)/tee.bin
 $(link-out-dir)/tee.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_tee_bin $@
+	$(q)$(PYTHON3) scripts/gen_tee_bin.py --input $< --out_tee_bin $@
 
 all: $(link-out-dir)/tee-header_v2.bin
 cleanfiles += $(link-out-dir)/tee-header_v2.bin
 $(link-out-dir)/tee-header_v2.bin: $(link-out-dir)/tee.elf \
 				   scripts/gen_tee_bin.py
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_header_v2 $@
+	$(q)$(PYTHON3) scripts/gen_tee_bin.py --input $< --out_header_v2 $@
 
 all: $(link-out-dir)/tee-pager_v2.bin
 cleanfiles += $(link-out-dir)/tee-pager_v2.bin
 $(link-out-dir)/tee-pager_v2.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_pager_v2 $@
+	$(q)$(PYTHON3) scripts/gen_tee_bin.py --input $< --out_pager_v2 $@
 
 all: $(link-out-dir)/tee-pageable_v2.bin
 cleanfiles += $(link-out-dir)/tee-pageable_v2.bin
 $(link-out-dir)/tee-pageable_v2.bin: $(link-out-dir)/tee.elf \
 				     scripts/gen_tee_bin.py
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_pageable_v2 $@
+	$(q)$(PYTHON3) scripts/gen_tee_bin.py --input $< --out_pageable_v2 $@
 
 all: $(link-out-dir)/tee.symb_sizes
 cleanfiles += $(link-out-dir)/tee.symb_sizes
@@ -222,5 +222,5 @@ mem_usage: $(link-out-dir)/tee.mem_usage
 
 $(link-out-dir)/tee.mem_usage: $(link-out-dir)/tee.elf
 	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)./scripts/mem_usage.py $< > $@
+	$(q)$(PYTHON3) ./scripts/mem_usage.py $< > $@
 endif

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -9,13 +9,13 @@ ifeq ($(CFG_WITH_USER_TA),y)
 gensrcs-y += ta_pub_key
 produce-ta_pub_key = ta_pub_key.c
 depends-ta_pub_key = $(TA_SIGN_KEY) scripts/pem_to_pub_c.py
-recipe-ta_pub_key = scripts/pem_to_pub_c.py --prefix ta_pub_key \
+recipe-ta_pub_key = $(PYTHON3) scripts/pem_to_pub_c.py --prefix ta_pub_key \
 		--key $(TA_SIGN_KEY) --out $(sub-dir-out)/ta_pub_key.c
 
 gensrcs-y += ldelf
 produce-ldelf = ldelf_hex.c
 depends-ldelf = scripts/gen_ldelf_hex.py $(out-dir)/ldelf/ldelf.elf
-recipe-ldelf = scripts/gen_ldelf_hex.py --input $(out-dir)/ldelf/ldelf.elf \
+recipe-ldelf = $(PYTHON3) scripts/gen_ldelf_hex.py --input $(out-dir)/ldelf/ldelf.elf \
 			--output $(sub-dir-out)/ldelf_hex.c
 endif
 
@@ -25,7 +25,7 @@ early-ta-$1-uuid := $(firstword $(subst ., ,$(notdir $1)))
 gensrcs-y += early-ta-$1
 produce-early-ta-$1 = early_ta_$$(early-ta-$1-uuid).c
 depends-early-ta-$1 = $1 scripts/ta_bin_to_c.py
-recipe-early-ta-$1 = scripts/ta_bin_to_c.py --compress --ta $1 \
+recipe-early-ta-$1 = $(PYTHON3) scripts/ta_bin_to_c.py --compress --ta $1 \
 		--out $(sub-dir-out)/early_ta_$$(early-ta-$1-uuid).c
 endef
 $(foreach f, $(EARLY_TA_PATHS), $(eval $(call process_early_ta,$(f))))
@@ -40,7 +40,7 @@ core-embed-fdt-c = $(out-dir)/$(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.
 gensrcs-y += embedded_secure_dtb
 produce-embedded_secure_dtb = arch/$(ARCH)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.c)
 depends-embedded_secure_dtb = $(core-embed-fdt-dtb) scripts/bin_to_c.py
-recipe-embedded_secure_dtb = scripts/bin_to_c.py \
+recipe-embedded_secure_dtb = $(PYTHON3) scripts/bin_to_c.py \
 				--bin $(core-embed-fdt-dtb) \
 				--vname embedded_secure_dtb \
 				--out $(core-embed-fdt-c)
@@ -58,7 +58,7 @@ $(conf-mk-xz-base64): $(conf-mk-file)
 gensrcs-y += conf_str
 produce-conf_str = conf.mk.xz.base64.c
 depends-conf_str = $(conf-mk-xz-base64)
-recipe-conf_str = scripts/bin_to_c.py --text --bin $(conf-mk-xz-base64) \
+recipe-conf_str = $(PYTHON3) scripts/bin_to_c.py --text --bin $(conf-mk-xz-base64) \
 			--out $(sub-dir-out)/conf.mk.xz.base64.c \
 			--vname conf_str
 endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -32,6 +32,12 @@ endif
 # Supported values: undefined, 1, 2 and 3. 3 gives more warnings.
 WARNS ?= 3
 
+# Path to the Python interpreter used by the build system.
+# This variable is set to the default python3 interpreter in the user's
+# path. But build environments that require more explicit control can
+# set the path to a specific interpreter through this variable.
+PYTHON3 ?= python3
+
 # Define DEBUG=1 to compile without optimization (forces -O0)
 # DEBUG=1
 

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -72,7 +72,7 @@ $(lib-shlibstrippedfile): $(lib-shlibfile)
 
 $(lib-shlibtafile): $(lib-shlibstrippedfile) $(TA_SIGN_KEY)
 	@$(cmd-echo-silent) '  SIGN    $$@'
-	$$(q)$$(SIGN) --key $(TA_SIGN_KEY) --uuid $(libuuid) --in $$< --out $$@
+	$$(q)$$(PYTHON3) $$(SIGN) --key $(TA_SIGN_KEY) --uuid $(libuuid) --in $$< --out $$@
 
 $(lib-libuuidln): $(lib-shlibfile)
 	@$(cmd-echo-silent) '  LN      $$@'

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -2,7 +2,7 @@ link-script$(sm) = $(ta-dev-kit-dir$(sm))/src/ta.ld.S
 link-script-pp$(sm) = $(link-out-dir$(sm))/ta.lds
 link-script-dep$(sm) = $(link-out-dir$(sm))/.ta.ld.d
 
-SIGN_ENC ?= $(ta-dev-kit-dir$(sm))/scripts/sign_encrypt.py
+SIGN_ENC ?= $(PYTHON3) $(ta-dev-kit-dir$(sm))/scripts/sign_encrypt.py
 TA_SIGN_KEY ?= $(ta-dev-kit-dir$(sm))/keys/default_ta.pem
 
 ifeq ($(CFG_ENCRYPT_TA),y)

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -47,5 +47,5 @@ $(link-out-dir)/$(shlibuuid).elf: $(link-out-dir)/$(shlibname).so
 $(link-out-dir)/$(shlibuuid).ta: $(link-out-dir)/$(shlibname).stripped.so \
 				$(TA_SIGN_KEY)
 	@$(cmd-echo-silent) '  SIGN    $@'
-	$(q)$(SIGN) --key $(TA_SIGN_KEY) --uuid $(shlibuuid) \
+	$(q)$(PYTHON3) $(SIGN) --key $(TA_SIGN_KEY) --uuid $(shlibuuid) \
 		--in $< --out $@

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -67,7 +67,7 @@ $$(arm32-user-sysregs-out)/$$(arm32-user-sysregs-$(1)-h): \
 		$(1) scripts/arm32_sysreg.py
 	@$(cmd-echo-silent) '  GEN     $$@'
 	$(q)mkdir -p $$(dir $$@)
-	$(q)scripts/arm32_sysreg.py --guard __$$(arm32-user-sysregs-$(1)-h) \
+	$(q)$(PYTHON3) scripts/arm32_sysreg.py --guard __$$(arm32-user-sysregs-$(1)-h) \
 		< $$< > $$@
 
 endef #process-arm32-user-sysreg


### PR DESCRIPTION
Build systems that manage multiple different python interpreters need
explicit control over which version of the interpreter to use.
This patch enables one to override the default interpreter with the path
to a specific one.

Signed-off-by: Dick Olsson <hi@senzilla.io>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
Reviewed-by: Jerome Forissier <jerome@forissier.org>

---

Revision 1:

* Updated the variable name to CFG_PYTHON3
* Clarified the comment in mk/config.mk

Revision 2:

* Fixed the formatting of the commit message

Revision 3:

* Renamed the variable from CFG_PYTHON3 to PYTHON3
* Exporting PYTHON3 to the TA dev kit

Revision 4:

* Added _nl_ to the TA dev kit exports

Revision 5:

* Expand the PYTHON3 variable export in the TA dev kit
* Removed spurious empty line

Revision 6:

* Use same PYTHON3 default (instead of same value assignment)
  between OS and TA
* Applied tags