### PR TITLE
core: log error when secure storage corruption is detected

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -423,6 +423,8 @@ out:
 			fdp->dfh.idx = -1;
 		*fh = (struct tee_file_handle *)fdp;
 	} else {
+		if (res == TEE_ERROR_SECURITY)
+			DMSG("Secure storage corruption detected");
 		if (fdp->fd != -1)
 			tee_fs_rpc_close(OPTEE_RPC_CMD_FS, fdp->fd);
 		if (create)


### PR DESCRIPTION
When CFG_REE_FS and CFG_RPMB_FS are both 'y', the data stored by OP-TEE
in the REE filesystem (typically, under /data/tee) are protected by
hashes stored in the RPMB. Any modifications to the REE files via
external means are therefore detected and TEE_ERROR_SECURITY is
returned. However, no error or debug message is printed to the secure
console which makes troubleshooting more difficult than needed. This
commit adds an error message.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
