### PR TITLE
Coccinelle dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ cscope:
 	${q}find $(PWD) -name "*.[chSs]" | grep -v export-ta_ > cscope.files
 	${q}cscope -b -q -k
 
-.PHONY: checkpatch checkpatch-staging checkpatch-working
+.PHONY: checkpatch checkpatch-staging checkpatch-working coccicheck
 checkpatch: checkpatch-staging checkpatch-working
 
 checkpatch-working:
@@ -116,3 +116,6 @@ checkpatch-working:
 
 checkpatch-staging:
 	${q}./scripts/checkpatch.sh --cached
+
+coccicheck:
+	${q} ./scripts/coccicheck

--- a/scripts/coccicheck
+++ b/scripts/coccicheck
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+DIR="`pwd`"
+OPTIONS=" --dir . "
+TIMESTAMP="`date -R | sed 's/^.\{5\}//' | sed 's/.\{6\}$//' | tr ' ' '_'`"
+
+###########################################################################################
+# Check if spatch is installed
+
+SPATCH="`which ${SPATCH:=spatch}`"
+if [ ! -x "$SPATCH" ]; then
+    echo 'spatch is required to run this script, exiting.'
+    exit 1
+fi
+
+###########################################################################################
+# Help section
+
+if [[ $H -ge 1 ]]; then
+    echo "coccicheck help section"
+    echo "This target allows the execution of *.cocci scripts using the coccinelle semantic patch engine"
+    echo "More information about semantic patching is available at"
+    echo "http://coccinelle.lip6.fr/"
+    echo -e "\n Options \n"
+    echo -e "\t COCCIFILE=<path/to/script.cocci> : specify a single .cocci script"
+    echo -e "\t D=1 : Outputs a debug log, default is /tmp/debug_cocci_\$TIMESTAMP"
+    echo -e "\t DEBUG_FILE=<path/to/file>: specify a different debug file"
+    echo -e "\t EXTERNAL_COCCI=<path/to/external/patchesdir/.> : specify a dir containing .cocci scripts"
+    echo -e "\t MODALITY=<name> : only for external .cocci scripts, specify the virtual mode (-D option)"
+    echo -e "\t V=1 : Verbose mode"
+
+    echo -e "\n Usage: \n"
+    echo -e "\t- Execute all local .cocci scripts on optee-os"
+    echo -e "\t\t make coccicheck [V=1]"
+    echo -e "\t- Execute a single .cocci script "
+    echo -e "\t\t make coccicheck COCCIFILE=<relative/path/to/script.cocci> [V=1]"
+    echo -e "\t- Execute a subset of external .cocci scripts"
+    echo -e "\t\t make coccicheck EXTERNAL_COCCI=<path/to/external/patchesdir/.> [MODALITY=<name>] [V=1]"
+    
+    exit 0
+fi
+
+###########################################################################################
+# Variable init + checks
+
+if [ -z $MODALITY ] ; then
+    MODALITY=report
+fi
+VIRTUAL="-D $MODALITY"
+
+# if USE_SUBSET == 1, an external set of .cocci scripts is executed
+if [[ -v EXTERNAL_COCCI && -d $EXTERNAL_COCCI ]] ; then 
+    USE_SUBSET=1
+
+elif [[ -f $EXTERNAL_COCCI ]] ; then
+    USE_SUBSET=1
+fi
+
+# if USE_COCCIFILE == 1, only the specified .cocci script is executed
+if [[ -v COCCIFILE && -f $COCCIFILE && $USE_SUBSET -ne 1 ]] ; then
+    USE_COCCIFILE=1
+
+elif [[ -v COCCIFILE && -f $COCCIFILE && $USE_SUBSET -eq 1 ]]; then
+    echo "Warining: both EXTERNAL_COCCI and COCCIFILE have been specified."
+    echo "Only .cocci files in $EXTERNAL_COCCI will be executed"
+fi
+
+if [ -e $DEBUG_FILE ] ; then
+    DEBUG_FILE="/tmp/debug_cocci_"$TIMESTAMP
+fi
+
+if [[ $D -eq 1 ]] ; then
+    echo "Debug mode is active, debug file is:"
+    echo $DEBUG_FILE
+    echo -e "\n"
+else
+    DEBUG_FILE="/dev/null"
+fi
+
+if [[ $V -eq "" ]]; then
+    V=0
+fi
+
+###########################################################################################
+# Functions
+
+run_cmd() {
+	if [ $V -ne 0 ] ; then
+		echo "Running semantic patch: $@"
+	fi
+	echo $@ >>$DEBUG_FILE
+	$@ 2>>$DEBUG_FILE
+    
+	err=$?
+	if [[ $err -ne 0 ]]; then
+		echo "coccicheck failed"
+		exit $err
+	fi
+}
+
+coccinelle () {
+    COCCI="$1"
+    run_cmd $SPATCH $VIRTUAL $FLAGS --cocci-file $COCCI $OPTIONS || exit 1 
+}
+
+###########################################################################################
+# Execution possibilities
+
+if [[ $USE_SUBSET -eq 1 ]] ; then
+    # external patches: make <target name> EXTERNAL_COCCI=path/to/external/patchesdir/.  [V=1]
+
+    echo "Using specified subset of semantic pathces"
+    for f in `find ${EXTERNAL_COCCI} -name '*.cocci' -type f | sort`; do
+        coccinelle $f
+    done
+
+elif [[ $USE_COCCIFILE -eq 1 ]] ; then
+    # to launch a single spatch: make <target name> COCCIFILE=relative/path/to/script.cocci [V=1]
+    VIRTUAL=""
+    echo "Using specified semantic patch"
+    coccinelle ${COCCIFILE}
+
+elif [ "$COCCI" = "" ] ; then
+    # to launch the full subset of op-tee semantic patches: make <target name> [V=1]
+    VIRTUAL=""
+    echo "Searching for local semantic patches"
+    for f in `find scripts/coccinelle/ -name '*.cocci' -type f | sort`; do
+        coccinelle $f
+    done
+else
+    coccinelle $COCCI
+fi

--- a/scripts/coccinelle/bad_null.cocci
+++ b/scripts/coccinelle/bad_null.cocci
@@ -1,0 +1,46 @@
+/************************************************************************************
+ * This semantic patch is responsible of replacing "foo *= NULL" expressions, into 
+ * the equivalent contracted form.
+ * 
+ */
+@rule1@
+expression E;
+@@
+
+(
+-   E == NULL
++   !E
+| 
+-   NULL == E
++   !E
+|
+-   E != NULL
++   E
+|
+-   NULL != E
++   E
+)
+
+
+@rule2@
+expression E;
+identifier f;
+@@
+
+E = f(...)
+<...
+( 
+- E == NULL
++ !E
+| 
+- E != NULL
++ E
+| 
+- NULL == E
++ !E
+| 
+- NULL != E
++ E
+)
+...>
+

--- a/scripts/coccinelle/initialize_variables.cocci
+++ b/scripts/coccinelle/initialize_variables.cocci
@@ -1,0 +1,54 @@
+/************************************************************************************
+* This semantic patch matches all occurrencies of variable declaration without 
+* initialization and then initializes them accordingly to their type.
+*   
+*   e.g.
+*   -   int a;
+*   +   int a = 0;
+*
+*/
+
+@variable_declaration@
+identifier v, n;
+type t;
+type numeric = {
+	short, short int, signed short, signed short int, unsigned short, unsigned short int,
+	int, signed, signed int, unsigned, unsigned int, long, long int, signed long, signed long int,
+	unsigned long, unsigned long int, long long, long long int, signed long long, 
+	signed long long int, unsigned long long, unsigned long long int,
+	float, double, long double, size_t
+};
+@@
+
+(
+//  generic char
+char v
++ = NULL
+;
+|
+//  numeric
+numeric v
++ = 0
+;
+|
+//  size_t array
+size_t v[]
++ = {0}
+;
+|
+//  generic array
+t v[]
++ = {NULL}
+;
+|
+//  pointer type
+t* v
++ = NULL
+;
+|
+//  every other type
+t v
++ = NULL
+;
+)
+

--- a/scripts/coccinelle/warning_overflow.cocci
+++ b/scripts/coccinelle/warning_overflow.cocci
@@ -1,0 +1,24 @@
+/************************************************************************************
+ * This semantic patch signals possible cases of overflow.
+ * Currently we are only looking for the following construct:
+ *      if(a + b > c)     
+ * 
+ */
+
+@r1@
+identifier A, B, C;
+binary operator add = {+};
+binary operator gt = {>};
+position p1;
+@@
+
+(
+if@p1 (A add B gt C) {...}
+)
+
+@script:python@
+p1 << r1.p1;
+@@
+
+coccilib.report.print_report(p1[0], "Warning, Possible overflow")
+


### PR DESCRIPTION
scripts: add Coccinelle support

Having to deal with a large project, it is useful to have a tool that allows developers to analyze their code.
Coccinelle is a software used to match code patterns and to transform them programmatically, using ".cocci"scripts, which are also called: Semantic Patches.
This pull request, implements "coccicheck", a script that allows to run semantic patches on the OP-TEE code in three possible ways:
  - Run a local semantic patch
  - Run a whole set of local semantic patches
  - Run a set of external semantic patches
The script is callable as a makefile target, so in order to launch it run:
  make coccicheck <OPTIONS>

The pull request also adds three semantic patches:
  - bad_null: produces patches which simplify expressions that compare to NULL
  - initialize_variables: matches non-initialized variables and produces patches that do so
  - warning_overflow: prints a warning on each occurrence of a specific pattern that could cause an overflow
All the patches produced by this tool are printed to stdout.