### PR TITLE
libutee: TEE_AsymmetricSignDigest support 0 signature len

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1705,7 +1705,7 @@ TEE_Result TEE_AsymmetricSignDigest(TEE_OperationHandle operation,
 
 	if (operation == TEE_HANDLE_NULL ||
 	    (digest == NULL && digestLen != 0) ||
-	    signature == NULL || signatureLen == NULL)
+	    !signatureLen || (!signature && *signatureLen != 0))
 		TEE_Panic(0);
 	if (params == NULL && paramCount != 0)
 		TEE_Panic(0);


### PR DESCRIPTION
User can call TEE_AsymmetricSignDigest with a NULL signature and a valid
zero signatureLen in order to discover the size of the required
signature buffer (function should then return TEE_ERROR_SHORT_BUFFER and
update signatureLen with the required amount).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>