### PR TITLE
core: abort: only print abort dump stack

### DIFF
--- a/core/arch/arm/kernel/unwind_arm32.c
+++ b/core/arch/arm/kernel/unwind_arm32.c
@@ -342,7 +342,10 @@ static bool unwind_tab(struct unwind_state_arm32 *state,
 	 * The program counter was not updated, load it from the link register.
 	 */
 	if (state->registers[PC] == 0) {
-		state->registers[PC] = state->registers[LR];
+		/*
+		 * We substracts 2 here in consideration of thumb instruction.
+		 */
+		state->registers[PC] = state->registers[LR] - 2;
 
 		/*
 		 * If the program counter changed, flag it in the update mask.


### PR DESCRIPTION
Don't run panic() after abort_print_error() since it prints
both the abort and panic dump stacks, while the latter is
usually useless.

Signed-off-by: Fangsuo Wu <fangsuowu@asrmicro.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
