### PR TITLE
build: fix race when generating conf.mk

### DIFF
--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -190,6 +190,7 @@ define mk-file-export
 .PHONY: $(conf-mk-file-export)
 $(conf-mk-file-export):
 	@$$(cmd-echo-silent) '  CHK    ' $$@
+	$(q)mkdir -p $$(dir $$@)
 	$(q)echo sm := $$(sm-$(conf-mk-file-export)) > $$@.tmp
 	$(q)echo sm-$$(sm-$(conf-mk-file-export)) := y >> $$@.tmp
 	$(q)($$(foreach v, $$(ta-mk-file-export-vars-$$(sm-$(conf-mk-file-export))), \


### PR DESCRIPTION
This patch fixes the following error triggered by a heavily parallel build:

 echo sm := ta_arm64 > .../export-ta_arm64/mk/conf.mk.tmp
 /bin/bash: .../export-ta_arm64/mk/conf.mk.tmp: No such file or directory

Fixes: https://github.com/OP-TEE/optee_os/issues/3999
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
