### PR TITLE
ta: export CFG_TEE_TA_LOG_LEVEL with ?= not :=

### DIFF
--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -34,11 +34,11 @@ ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS
 ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS_MPI
 ta-mk-file-export-vars-$(sm) += CFG_SYSTEM_PTA
 ta-mk-file-export-vars-$(sm) += CFG_TA_DYNLINK
-ta-mk-file-export-vars-$(sm) += CFG_TEE_TA_LOG_LEVEL
 ta-mk-file-export-vars-$(sm) += CFG_FTRACE_SUPPORT
 ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
 ta-mk-file-export-vars-$(sm) += CFG_CORE_TPM_EVENT_LOG
+ta-mk-file-export-add-$(sm) += CFG_TEE_TA_LOG_LEVEL ?= $(CFG_TEE_TA_LOG_LEVEL)_nl_
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.


### PR DESCRIPTION
The value of CFG_TEE_TA_LOG_LEVEL used at optee_os build time is
exported to the TA dev kit ($O/export_ta_arm{32,64}/mk/conf.mk). The
purpose is to provide a default value to the TA build environment,
which can easily be changed from the command line ("make
CFG_TEE_TA_LOG_LEVEL=3" for example).

However the following TA Makefile won't behave as expected:
```
 BINARY := <somme uuid>
 CFG_TEE_TA_LOG_LEVEL := 3  # Ignored!
 include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
```
This commit changes := to ?= so that ta_dev_kit.mk won't override any
value that may have been set previously in the TA Makefile or the
environment.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
