### PR TITLE
ci: shippable: use our own cache server

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,8 +1,5 @@
 language: c
 build:
-  cache: true
-  cache_dir_list:
-    - /root/.ccache
   pre_ci_boot:
     image_name: jforissier/optee_os_ci_clangbuilt
     image_tag: latest
@@ -15,7 +12,16 @@ build:
     - export CROSS_COMPILE64="ccache aarch64-linux-gnu-"
     - export CFG_DEBUG_INFO=n
     - export CFG_WERROR=y
-    - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && ccache -s && ccache -z; }
+    - export START=$(date +%s)
+    - export PROJ=$ORG_NAME-$REPO_NAME
+    - export SCP_OPT="-o ConnectTimeout=10 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+    - function download_cache() { ssh $SCP_OPT shippable@shippable-cache.forissier.org "cat ccache-$PROJ.tar.gz" | tar zx -C /root || echo Nevermind; }
+    - function upload_cache() { if [ ! -e .uploaded ]; then echo Uploading cache && tar c -C /root .ccache | gzip -1 | ssh $SCP_OPT shippable@shippable-cache.forissier.org "cat >ccache-$PROJ.tar.gz" && touch .uploaded || echo Nevermind; fi; }
+    - function check_upload_cache() { NOW=$(date +%s); if [ $(expr $NOW - $START) -gt 3000 ]; then upload_cache; fi; }
+    - function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && ccache -s && ccache -z && check_upload_cache; }
+
+    - download_cache
     - ccache -z
 
     - _make
@@ -144,3 +150,5 @@ build:
     - _make PLATFORM=bcm-ns3 CFG_ARM64_core=y
     - _make PLATFORM=hisilicon-hi3519av100_demo
     - _make PLATFORM=amlogic
+
+    - upload_cache


### PR DESCRIPTION
Shippable has a maximum build time of 1 hour for Open Source projects.
It is usually sufficient since typical build time is currently around
35 minutes, thanks to caching (ccache). But it can happen that the code
is changed too much by a pull request in which case the cache is
ineffective and build time would exceed 1 hour. When a build times out,
the cache is NOT updated and there is no other choice than to manually
feed the cache with a partial build (by removing some steps in
.shippable.yml) so that the next build can be quicker, wait for the
build to succeed, then restore all the build steps. This is quite
impractical.

This commit replaces the Shippable built-in caching mechanism with our
own cache on a cloud server (currently a Digital Ocean [1] VM).
Automatic upload is triggered after 50 minutes of build time (or at the
end of the build). Therefore, if the build times out we have a
significant amount of data in the cache and restarting the build is
usually all it takes to deal with the issue.

Cache data are transferred using SSH and the cache server is configured
with the public key of the official OP-TEE OS Shippable project (the
one that is used to build pull requests).

In addition to being tolerant to time outs, this new method is usually
faster too, because the archive is streamed directly to/from the server
whereas Shippable creates a local .tar.gz file first.

For all intents and purposes I am documenting the security configuration
of the VM:
- Ubuntu 20.04 with default settings
- Dedicated user account: 'shippable'
- The OP-TEE SSH key [3] is added to ~shippable/.ssh/authorized_keys
- The login shell for user 'shippable' is /usr/sbin/rush [2] with the
  following /etc/rush.rc:
```
 debug 1

 rule default
   acct on
   limits t10r20
   umask 002
   env - USER LOGNAME HOME PATH
   fall-through

 rule cat-to
   command ^cat >[a-zA-Z0-9_\.-]+$
   chdir /home/shippable
   transform s@(.*)@/usr/bin/bash -c "\\1"@

 rule cat-from
   command ^cat [a-zA-Z0-9_\.-]+$
   chdir /home/shippable
   transform s@(.*)@/usr/bin/bash -c "\\1"@
```
[1] https://digitalocean.com/
[2] https://www.gnu.org/software/rush/
[3] https://app.shippable.com/subs/github/OP-TEE/settings

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
