### PR TITLE
rmpb: fix infinite recursion in dump_fat() when CFG_TEE_CORE_LOG_LEVEL=4

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1806,6 +1806,9 @@ static void dump_fat(void)
 	TEE_Result res = TEE_ERROR_SECURITY;
 	struct rpmb_fat_entry *fe = NULL;
 
+	if (!fs_par)
+		return;
+
 	if (fat_entry_dir_init())
 		return;
 


### PR DESCRIPTION
When CFG_TEE_CORE_LOG_LEVEL=4 and CFG_RPMB_FS=y, the TEE core crashes
with a dead stack canary message:

 E/TC:0 0 Dead canary at end of 'stack_abt[3]'
 E/TC:0 0 Panic at core/arch/arm/kernel/thread.c:192 <thread_check_canaries>
 E/TC:0 0 TEE load address @ 0x1bd0f000
 E/TC:0 0 Call stack:
 E/TC:0 0  0x1bd17b3d print_kernel_stack at optee_os/core/arch/arm/kernel/unwind_arm32.c:452
 E/TC:0 0  0x1bd23a07 __do_panic at optee_os/core/kernel/panic.c:32 (discriminator 1)
 E/TC:0 0  0x1bd120cb thread_check_canaries at optee_os/core/arch/arm/kernel/thread.c:188 (discriminator 2)
 E/TC:0 0  0x1bd12c1f thread_state_suspend at optee_os/core/arch/arm/kernel/thread.c:754
 E/TC:0 0  0x1bd14610 thread_rpc at optee_os/core/arch/arm/kernel/thread_optee_smc_a32.S:227

The issue happens to be with the debug function dump_fat() which causes
infinite recursion. Fix it by doing nothing until after RPMB
initialization has completed.

Fixes: 5f68d7848fe8 ("core: RPMB FS: Caching for FAT FS entries")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
