### PR TITLE
ldelf: __resolve_sym(): support STT_NOTYPE

### DIFF
--- a/ldelf/ta_elf_rel.c
+++ b/ldelf/ta_elf_rel.c
@@ -53,6 +53,7 @@ static bool __resolve_sym(struct ta_elf *elf, unsigned int st_bind,
 		err(TEE_ERROR_BAD_FORMAT, "Symbol location out of range");
 
 	switch (st_type) {
+	case STT_NOTYPE:
 	case STT_OBJECT:
 	case STT_FUNC:
 		*val = st_value + elf->load_addr;


### PR DESCRIPTION
Symbols defined in a linker script are assigned type STT_NOTYPE, but
the __resolve_sym() function in ldelf only supports STT_OBJECT and
STT_FUNCTION. As a result, it is impossible to resolve STT_NOTYPE
symbols at runtime. This causes an error in shared libraries when
ftrace is enabled:
```
  # Platform: QEMU
  $ make CFG_FTRACE_SUPPORT=y CFLAGS_ta_arm32=-pg run

  $ xtest 1019

  D/LD:  ldelf:134 Loading TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b
  E/LD:  __resolve_sym:61 Symbol type not supported
  E/TC:? 0 init_with_ldelf:232 ldelf failed with res: 0xffff000a

  * regression_1019 Test dynamically linked TA
  regression_1000.c:1502: [...] TEEC_ERROR_NOT_SUPPORTED
```
This commit adds STT_NOTYPE to the supported types, handled the same way
as STT_OBJECT and STT_FUNCTION.

Fixes: 97c5ac19427b ("ldelf: check ranges in __resolve_sym()")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
