### PR TITLE
CXX Flags Hard Float Support

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -236,6 +236,7 @@ ta_arm32-platform-aflags += $(platform-aflags-debug-info)
 ta_arm32-platform-aflags += $(arm32-platform-aflags)
 
 ta_arm32-platform-cxxflags += -fpic
+ta_arm32-platform-cxxflags += $(arm32-platform-cxxflags)
 
 ta-mk-file-export-vars-ta_arm32 += CFG_ARM32_ta_arm32
 ta-mk-file-export-vars-ta_arm32 += ta_arm32-platform-cppflags

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -238,6 +238,12 @@ ta_arm32-platform-aflags += $(arm32-platform-aflags)
 ta_arm32-platform-cxxflags += -fpic
 ta_arm32-platform-cxxflags += $(arm32-platform-cxxflags)
 
+ifeq ($(arm32-platform-hard-float-enabled),y)
+ta_arm32-platform-cxxflags += $(arm32-platform-cflags-hard-float)
+else
+ta_arm32-platform-cxxflags += $(arm32-platform-cflags-no-hard-float)
+endif
+
 ta-mk-file-export-vars-ta_arm32 += CFG_ARM32_ta_arm32
 ta-mk-file-export-vars-ta_arm32 += ta_arm32-platform-cppflags
 ta-mk-file-export-vars-ta_arm32 += ta_arm32-platform-cflags

--- a/core/arch/arm/cpu/cortex-a15.mk
+++ b/core/arch/arm/cpu/cortex-a15.mk
@@ -5,5 +5,6 @@ $(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
 arm32-platform-cpuarch 	:= cortex-a15
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cxxflags	+= -mcpu=$(arm32-platform-cpuarch)
 # Program flow prediction may need manual enablement
 CFG_ENABLE_SCTLR_Z ?= y

--- a/core/arch/arm/cpu/cortex-a5.mk
+++ b/core/arch/arm/cpu/cortex-a5.mk
@@ -7,3 +7,4 @@ $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,n)
 arm32-platform-cpuarch 	:= cortex-a5
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cxxflags	+= -mcpu=$(arm32-platform-cpuarch)

--- a/core/arch/arm/cpu/cortex-a7.mk
+++ b/core/arch/arm/cpu/cortex-a7.mk
@@ -6,3 +6,4 @@ $(call force,CFG_ENABLE_SCTLR_Z,n)
 arm32-platform-cpuarch 	:= cortex-a7
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cxxflags	+= -mcpu=$(arm32-platform-cpuarch)

--- a/core/arch/arm/cpu/cortex-a9.mk
+++ b/core/arch/arm/cpu/cortex-a9.mk
@@ -7,5 +7,6 @@ $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,n)
 arm32-platform-cpuarch 	:= cortex-a9
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cxxflags += -mcpu=$(arm32-platform-cpuarch)
 # Program flow prediction may need manual enablement
 CFG_ENABLE_SCTLR_Z ?= y

--- a/core/arch/arm/cpu/cortex-armv8-0.mk
+++ b/core/arch/arm/cpu/cortex-armv8-0.mk
@@ -6,4 +6,5 @@ $(call force,CFG_ENABLE_SCTLR_Z,n)
 arm32-platform-cpuarch 	:= cortex-a53
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cxxflags	+= -mcpu=$(arm32-platform-cpuarch)
 platform-flavor-armv8 := 1


### PR DESCRIPTION
These patches were required to get the latest tests compiled on ARM32, Cortex-A7 (i.MX6UL). Otherwise the tests will complain while linking the cxx object file with the c object file, due to the hard-float soft-float difference.