### PR TITLE
core: juno: update 808870 Unconditional VLDM workaround

### DIFF
--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -12,8 +12,14 @@ include core/arch/arm/cpu/cortex-armv8-0.mk
 platform-debugger-arm := 1
 # Workaround 808870: Unconditional VLDM instructions might cause an
 # alignment fault even though the address is aligned
+# Either hard float must be disabled for AArch32 or strict alignment checks
+# must be disabled
+ifeq ($(CFG_SCTLR_ALIGNMENT_CHECK),y)
 $(call force,CFG_TA_ARM32_NO_HARD_FLOAT_SUPPORT,y)
+else
+$(call force,CFG_SCTLR_ALIGNMENT_CHECK,n)
 endif
+endif #juno
 ifeq ($(PLATFORM_FLAVOR),qemu_armv8a)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 endif


### PR DESCRIPTION
With be3bc461c686 ("ta: experimental C++ support") we have some C++
tests in the regression tests which depends on libraries in the
toolchain with hard float enabled. To be able to compile the regression
tests hard float cannot be disabled. Disabling hard float was our
original workaround for this erratum. Another way to avoid the erratum
is to disable strict alignment checks. So unless
CFG_SCTLR_ALIGNMENT_CHECK isn't explicitly set to 'y' force it to 'n'
instead.

Fixes: be3bc461c686 ("ta: experimental C++ support")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
