### PR TITLE
crypto: add function to free rsa keypair

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -521,6 +521,10 @@ void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s __unused)
 {
 }
 
+void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s __unused)
+{
+}
+
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key __unused,
 				      size_t key_size __unused)
 {

--- a/core/drivers/crypto/caam/acipher/caam_rsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_rsa.c
@@ -81,9 +81,25 @@ struct caam_rsa_keypair {
 static uint8_t caam_era;
 
 /*
- * Free local RSA keypair
+ * Free RSA keypair
  *
  * @key  RSA keypair
+ */
+static void do_free_keypair(struct rsa_keypair *key)
+{
+	crypto_bignum_free(key->e);
+	crypto_bignum_free(key->d);
+	crypto_bignum_free(key->n);
+	crypto_bignum_free(key->p);
+	crypto_bignum_free(key->q);
+	crypto_bignum_free(key->qp);
+	crypto_bignum_free(key->dp);
+}
+
+/*
+ * Free local caam RSA keypair
+ *
+ * @key  caam RSA keypair
  */
 static void do_keypair_free(struct caam_rsa_keypair *key)
 {
@@ -1651,6 +1667,7 @@ static const struct drvcrypt_rsa driver_rsa = {
 	.alloc_keypair = &do_allocate_keypair,
 	.alloc_publickey = &do_allocate_publickey,
 	.free_publickey = &do_free_publickey,
+	.free_keypair = &do_free_keypair,
 	.gen_keypair = &do_gen_keypair,
 	.encrypt = &do_encrypt,
 	.decrypt = &do_decrypt,

--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
@@ -68,6 +68,19 @@ void crypto_acipher_free_rsa_public_key(struct rsa_public_key *key)
 	}
 }
 
+void crypto_acipher_free_rsa_keypair(struct rsa_keypair *key)
+{
+	struct drvcrypt_rsa *rsa = NULL;
+
+	if (key) {
+		rsa = drvcrypt_get_ops(CRYPTO_RSA);
+		if (rsa) {
+			CRYPTO_TRACE("RSA Keypair free");
+			rsa->free_keypair(key);
+		}
+	}
+}
+
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t size_bits)
 {
 	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -83,6 +83,8 @@ struct drvcrypt_rsa {
 				      size_t size_bits);
 	/* Free RSA public key */
 	void (*free_publickey)(struct rsa_public_key *key);
+	/* Free RSA keypair */
+	void (*free_keypair)(struct rsa_keypair *key);
 	/* Generates the RSA keypair */
 	TEE_Result (*gen_keypair)(struct rsa_keypair *key, size_t size_bits);
 

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -172,6 +172,7 @@ TEE_Result crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
 TEE_Result crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
 				   size_t key_size_bits);
 void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s);
+void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s);
 TEE_Result crypto_acipher_alloc_dsa_keypair(struct dsa_keypair *s,
 				size_t key_size_bits);
 TEE_Result crypto_acipher_alloc_dsa_public_key(struct dsa_public_key *s,

--- a/core/lib/libtomcrypt/rsa.c
+++ b/core/lib/libtomcrypt/rsa.c
@@ -138,6 +138,19 @@ void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 	crypto_bignum_free(s->e);
 }
 
+void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
+{
+	if (!s)
+		return;
+	crypto_bignum_free(s->e);
+	crypto_bignum_free(s->d);
+	crypto_bignum_free(s->n);
+	crypto_bignum_free(s->p);
+	crypto_bignum_free(s->q);
+	crypto_bignum_free(s->qp);
+	crypto_bignum_free(s->dp);
+}
+
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size)
 {
 	TEE_Result res;

--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -190,6 +190,19 @@ void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 	crypto_bignum_free(s->e);
 }
 
+void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
+{
+	if (!s)
+		return;
+	crypto_bignum_free(s->e);
+	crypto_bignum_free(s->d);
+	crypto_bignum_free(s->n);
+	crypto_bignum_free(s->p);
+	crypto_bignum_free(s->q);
+	crypto_bignum_free(s->qp);
+	crypto_bignum_free(s->dp);
+}
+
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size)
 {
 	TEE_Result res = TEE_SUCCESS;


### PR DESCRIPTION
There was no function to proper free a rsa kepair from inside a PTA
or the core itself. Now there is crypto_acipher_free_rsa_keypair().

Signed-off-by: E. von Däniken elias.vondaeniken@bluewin.ch

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
