### PR TITLE
Add optimization and debug flags to exported TA C++ flags

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -237,6 +237,8 @@ ta_arm32-platform-aflags += $(arm32-platform-aflags)
 
 ta_arm32-platform-cxxflags += -fpic
 ta_arm32-platform-cxxflags += $(arm32-platform-cxxflags)
+ta_arm32-platform-cxxflags += $(platform-cflags-optimization)
+ta_arm32-platform-cxxflags += $(platform-cflags-debug-info)
 
 ifeq ($(arm32-platform-hard-float-enabled),y)
 ta_arm32-platform-cxxflags += $(arm32-platform-cflags-hard-float)
@@ -278,6 +280,8 @@ ta_arm64-platform-aflags += $(platform-aflags-debug-info)
 ta_arm64-platform-aflags += $(arm64-platform-aflags)
 
 ta_arm64-platform-cxxflags += -fpic
+ta_arm64-platform-cxxflags += $(platform-cflags-optimization)
+ta_arm64-platform-cxxflags += $(platform-cflags-debug-info)
 
 ta-mk-file-export-vars-ta_arm64 += CFG_ARM64_ta_arm64
 ta-mk-file-export-vars-ta_arm64 += ta_arm64-platform-cppflags


### PR DESCRIPTION
$(platform-cflags-optimization) and $(platform-cflags-debug-info) are
added to the TA C flags via ta_arm{32,64}-platform-cflags. Do the same
for C++ flags thanks to ta_arm{32,64}-platform-cxxflags.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMU)
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMUv8)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
