### PR TITLE
boot.c: clear current tread id during initialization

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1153,9 +1153,17 @@ static void init_primary(unsigned long pageable_part, unsigned long nsec_entry)
 	thread_get_core_local()->curr_thread = 0;
 	init_runtime(pageable_part);
 
-#ifndef CFG_VIRTUALIZATION
-	thread_init_boot_thread();
-#endif
+	if (IS_ENABLED(CFG_VIRTUALIZATION)) {
+		/*
+		 * Virtualization: We can't initialize threads right now because
+		 * threads belong to "tee" part and will be initialized
+		 * separately per each new virtual guest. So, we'll clear
+		 * "curr_thread" and call it done.
+		 */
+		thread_get_core_local()->curr_thread = -1;
+	} else {
+		thread_init_boot_thread();
+	}
 	thread_init_primary();
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);


### PR DESCRIPTION
When OP-TEE is built with CFG_VIRTUALIZATION=y, it does not call
`thread_clr_boot_thread()` during boot because the threads are
allocated in "tee" memory area, which is not available when there is
no virtual guests.

So, in this case local core state is left in erroneous state, which
causes assertion violation in thread_alloc_and_run(), when guests
calls OP-TEE for the first time from boot core.

Fixes: b166fabf3e8c ("core: initialize thread_core_local::curr_thread to -1")
Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
