### PR TITLE
mk/subdir.mk: handle C++ flags related variables

### DIFF
--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -6,12 +6,14 @@
 #
 # set     srcs gen-srcs
 # set     cflags-$(oname) cflags-remove-$(oname)
+#         cxxflags-$(oname) cxxflags-remove-$(oname)
 #         aflags-$(oname) aflags-remove-$(oname)
 #         cppflags-$(oname) cppflags-remove-$(oname)
 #         incdirs-$(oname)
 #         incdirs-lib$(libname)-$(sm)  [if libname is defined]
 #         cppflags-lib$(libname)-$(sm) [if libname is defined]
 #         cflags-lib$(libname)-$(sm)   [if libname is defined]
+#         cxxflags-lib$(libname)-$(sm) [if libname is defined]
 # for each file found, oname is the name of the object file for corresponding
 # source file
 
@@ -36,6 +38,9 @@ endif
 cflags-$$(oname) 		:= $$(cflags-y) $$(cflags-$(1)-y)
 cflags-remove-$$(oname) 	:= $$(cflags-remove-y) \
 					$$(cflags-remove-$(1)-y)
+cxxflags-$$(oname) 		:= $$(cxxflags-y) $$(cxxflags-$(1)-y)
+cxxflags-remove-$$(oname) 	:= $$(cxxflags-remove-y) \
+					$$(cxxflags-remove-$(1)-y)
 cppflags-$$(oname) 		:= $$(cppflags-y) $$(cppflags-$(1)-y)
 cppflags-remove-$$(oname) 	:= $$(cppflags-remove-y) \
 					$$(cppflags-remove-$(1)-y)
@@ -48,6 +53,9 @@ incdirs-$$(oname)		:= $$(thissubdir-incdirs) $$(addprefix $(sub-dir)/,$$(incdirs
 cflags-$(1)-y 			:=
 cflags-remove-$(1)-y		:=
 cflags-lib-y			:=
+cxxflags-$(1)-y 		:=
+cxxflags-remove-$(1)-y		:=
+cxxflags-lib-y			:=
 cppflags-$(1)-y			:=
 cppflags-remove-$(1)-y		:=
 cppflags-lib-y			:=
@@ -83,6 +91,9 @@ $2: $$(depends-$1)
 cflags-$$(oname) 		:= $$(cflags-y) $$(cflags-$(1)-y)
 cflags-remove-$$(oname) 	:= $$(cflags-remove-y) \
 					$$(cflags-remove-$(1)-y)
+cxxflags-$$(oname) 		:= $$(cxxflags-y) $$(cxxflags-$(1)-y)
+cxxflags-remove-$$(oname) 	:= $$(cxxflags-remove-y) \
+					$$(cxxflags-remove-$(1)-y)
 cppflags-$$(oname) 		:= $$(cppflags-y) $$(cppflags-$(1)-y)
 cppflags-remove-$$(oname) 	:= $$(cppflags-remove-y) \
 					$$(cppflags-remove-$(1)-y)
@@ -95,6 +106,9 @@ incdirs-$$(oname)		:= $$(thissubdir-incdirs) $$(addprefix $(sub-dir)/,$$(incdirs
 cflags-$(1)-y 			:=
 cflags-remove-$(1)-y		:=
 cflags-lib-y			:=
+cxxflags-$(1)-y 			:=
+cxxflags-remove-$(1)-y		:=
+cxxflags-lib-y			:=
 cppflags-$(1)-y			:=
 cppflags-remove-$(1)-y		:=
 cppflags-lib-y			:=
@@ -129,6 +143,7 @@ thissubdir-incdirs := $(out-dir)/$(base-prefix)$1 $$(addprefix $1/,$$(incdirs-y)
 ifneq ($$(libname),)
 incdirs-lib$$(libname)-$$(sm) := $$(incdirs-lib$$(libname)-$$(sm)) $$(addprefix $1/,$$(incdirs-lib-y))
 cflags-lib$$(libname)-$$(sm) := $$(cflags-lib$$(libname)-$$(sm)) $$(cflags-lib-y)
+cxxflags-lib$$(libname)-$$(sm) := $$(cxxflags-lib$$(libname)-$$(sm)) $$(cxxflags-lib-y)
 cppflags-lib$$(libname)-$$(sm) := $$(cppflags-lib$$(libname)-$$(sm)) $$(cppflags-lib-y)
 endif
 
@@ -140,10 +155,13 @@ $$(foreach a, $$(asm-defines-y), $$(eval $$(call process-subdir-asm-defines-y,$$
 srcs-y :=
 cflags-y :=
 cflags-lib-y :=
+cxxflags-y :=
+cxxflags-lib-y :=
 cppflags-y :=
 cppflags-lib-y :=
 aflags-y :=
 cflags-remove-y :=
+cxxflags-remove-y :=
 aflags-remove-y :=
 subdirs-y :=
 global-incdirs-y :=


### PR DESCRIPTION
Adds proper handling of cxxflags-y, cxxflags-\<file name>-y,
cxxflags-remove-y, cxxflags-remove-\<file name>-y, cxxflags-lib-y in the
same way as for C flags.

Fixes: be3bc461c686 ("ta: experimental C++ support")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
