### PR TITLE
core: add user parameter thread_rpc_shm_cache_alloc()

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -733,11 +733,27 @@ enum thread_shm_type {
 };
 
 /*
- * Returns a pointer to the cached FS RPC memory. Each thread has a unique
- * cache. The pointer is guaranteed to point to a large enough area or to
- * be NULL.
+ * enum thread_shm_cache_user - user of a cache allocation
+ * @THREAD_SHM_CACHE_USER_SOCKET - socket communication
+ * @THREAD_SHM_CACHE_USER_FS - filesystem access
+ * @THREAD_SHM_CACHE_USER_I2C - I2C communication
+ *
+ * To ensure that each user of the shared memory cache doesn't interfere
+ * with each other a unique ID per user is used.
  */
-void *thread_rpc_shm_cache_alloc(enum thread_shm_type shm_type,
+enum thread_shm_cache_user {
+	THREAD_SHM_CACHE_USER_SOCKET,
+	THREAD_SHM_CACHE_USER_FS,
+	THREAD_SHM_CACHE_USER_I2C,
+};
+
+/*
+ * Returns a pointer to the cached RPC memory. Each thread and @user tuple
+ * has a unique cache. The pointer is guaranteed to point to a large enough
+ * area or to be NULL.
+ */
+void *thread_rpc_shm_cache_alloc(enum thread_shm_cache_user user,
+				 enum thread_shm_type shm_type,
 				 size_t size, struct mobj **mobj);
 #endif /*__ASSEMBLER__*/
 

--- a/core/arch/arm/kernel/rpc_io_i2c.c
+++ b/core/arch/arm/kernel/rpc_io_i2c.c
@@ -28,7 +28,8 @@ TEE_Result rpc_io_i2c_transfer(struct rpc_i2c_request *req, size_t *len)
 	if (!len)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_KERNEL_PRIVATE,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_I2C,
+					THREAD_SHM_TYPE_KERNEL_PRIVATE,
 					req->buffer_len, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -43,11 +43,15 @@ struct thread_vfp_state {
 
 #endif /*CFG_WITH_VFP*/
 
-struct thread_shm_cache {
+struct thread_shm_cache_entry {
 	struct mobj *mobj;
 	size_t size;
 	enum thread_shm_type type;
+	enum thread_shm_cache_user user;
+	SLIST_ENTRY(thread_shm_cache_entry) link;
 };
+
+SLIST_HEAD(thread_shm_cache, thread_shm_cache_entry);
 
 struct thread_ctx {
 	struct thread_ctx_regs regs;

--- a/core/tee/socket.c
+++ b/core/tee/socket.c
@@ -33,7 +33,8 @@ static TEE_Result socket_open(uint32_t instance_id, uint32_t param_types,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_SOCKET,
+					THREAD_SHM_TYPE_APPLICATION,
 					params[1].memref.size, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -96,7 +97,8 @@ static TEE_Result socket_send(uint32_t instance_id, uint32_t param_types,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_SOCKET,
+					THREAD_SHM_TYPE_APPLICATION,
 					params[1].memref.size, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -134,7 +136,8 @@ static TEE_Result socket_recv(uint32_t instance_id, uint32_t param_types,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_SOCKET,
+					THREAD_SHM_TYPE_APPLICATION,
 					params[1].memref.size, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -175,7 +178,8 @@ static TEE_Result socket_ioctl(uint32_t instance_id, uint32_t param_types,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_SOCKET,
+					THREAD_SHM_TYPE_APPLICATION,
 					params[1].memref.size, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;

--- a/core/tee/tadb.c
+++ b/core/tee/tadb.c
@@ -97,7 +97,8 @@ static TEE_Result ta_operation_open(unsigned int cmd, uint32_t file_number,
 	TEE_Result res;
 	void *va;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -122,7 +123,8 @@ static TEE_Result ta_operation_remove(uint32_t file_number)
 	struct mobj *mobj;
 	void *va;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;

--- a/core/tee/tee_fs_rpc.c
+++ b/core/tee/tee_fs_rpc.c
@@ -35,7 +35,8 @@ static TEE_Result operation_open(uint32_t id, unsigned int cmd,
 	TEE_Result res;
 	void *va;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -77,7 +78,8 @@ static TEE_Result operation_open_dfh(uint32_t id, unsigned int cmd,
 	TEE_Result res;
 	void *va;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -136,7 +138,8 @@ TEE_Result tee_fs_rpc_read_init(struct tee_fs_rpc_operation *op,
 	if (offset < 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					data_len, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -174,7 +177,8 @@ TEE_Result tee_fs_rpc_write_init(struct tee_fs_rpc_operation *op,
 	if (offset < 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					data_len, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -215,7 +219,8 @@ TEE_Result tee_fs_rpc_remove(uint32_t id, struct tee_pobj *po)
 	struct mobj *mobj;
 	void *va;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -242,7 +247,8 @@ TEE_Result tee_fs_rpc_remove_dfh(uint32_t id,
 	struct mobj *mobj;
 	void *va;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -270,7 +276,8 @@ TEE_Result tee_fs_rpc_rename(uint32_t id, struct tee_pobj *old,
 	char *va;
 	bool temp;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX * 2, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -321,7 +328,8 @@ TEE_Result tee_fs_rpc_opendir(uint32_t id, const TEE_UUID *uuid,
 	if (!dir)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					TEE_FS_NAME_MAX, &mobj);
 	if (!va) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
@@ -381,7 +389,8 @@ TEE_Result tee_fs_rpc_readdir(uint32_t id, struct tee_fs_dir *d,
 	if (!d)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_TYPE_APPLICATION,
+	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_FS,
+					THREAD_SHM_TYPE_APPLICATION,
 					max_name_len, &mobj);
 	if (!va)
 		return TEE_ERROR_OUT_OF_MEMORY;


### PR DESCRIPTION
Adds a user parameter to thread_rpc_shm_cache_alloc() to make sure that
different callers of thread_rpc_shm_cache_alloc() doesn't interfere with
each other. The FS allocation could perhaps be intertwined with I2C
allocations if crypto operations are done over I2C.

Fixes: 9bee8f2a5af7 ("core: add generic rpc shared memory buffer caching")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
