### PR TITLE
libutils: embed AEABI personality routines upon CFG_UNWIND

### DIFF
--- a/lib/libutils/ext/arch/arm/sub.mk
+++ b/lib/libutils/ext/arch/arm/sub.mk
@@ -1,4 +1,6 @@
+ifeq ($(CFG_UNWIND),y)
 srcs-$(CFG_ARM32_$(sm)) += aeabi_unwind.c
+endif
 srcs-$(CFG_ARM32_$(sm)) += atomic_a32.S
 srcs-$(CFG_ARM64_$(sm)) += atomic_a64.S
 ifneq ($(sm),ldelf) # TA, core


### PR DESCRIPTION
Fix a TA build issue found when CFG_UNWIND=n. This issue produces a
build error trace like the below:

.../toolchains/aarch32/bin/arm-linux-gnueabihf-ld.bfd: .../toolchains/aarch32/bin/../lib/gcc/arm-linux-gnueabihf/8.3.0/libgcc_eh.a(unwind-arm.o): in function `__aeabi_unwind_cpp_pr0':
/tmp/dgboter/bbs/rhev-vm8--rhe6x86_64/buildbot/rhe6x86_64--arm-linux-gnueabihf/build/src/gcc/libgcc/config/arm/unwind-arm.c:494: multiple definition of `__aeabi_unwind_cpp_pr0'; .../optee_os/out/arm/export-ta_arm32/lib/libutils.a(aeabi_unwind.o): .../optee_os/lib/libutils/ext/arch/arm/aeabi_unwind.c:9: first defined here
.../optee_os/out/arm/export-ta_arm32/mk/link.mk:109: recipe for target 'out/5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf' failed

I don't understand why toolchain support for __aeabi_unwind_cpp_pr0()
conflicts with the libutils implementation only when CFG_UNWIND=n. Yet
the current change works around the issue.

Fixes: https://github.com/OP-TEE/optee_test/issues/440
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
