### PR TITLE
core: mmu: arm64: fix get_va_width()

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -914,10 +914,11 @@ static void assign_mem_granularity(struct tee_mmap_region *memory_map)
 
 static unsigned int get_va_width(void)
 {
-	if (IS_ENABLED(ARM64))
-		return 64 - __builtin_ctzll(CFG_LPAE_ADDR_SPACE_SIZE);
-	else
-		return 32;
+	if (IS_ENABLED(ARM64)) {
+		COMPILE_TIME_ASSERT(IS_POWER_OF_TWO(CFG_LPAE_ADDR_SPACE_SIZE));
+		return __builtin_ctzll(CFG_LPAE_ADDR_SPACE_SIZE);
+	}
+	return 32;
 }
 
 static bool assign_mem_va(vaddr_t tee_ram_va,


### PR DESCRIPTION
Fixes get_va_width() when CFG_LPAE_ADDR_SPACE_SIZE != (1ull << 32).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
