### PR TITLE
core: Fix the entry on the match table for TPM support.

### DIFF
--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -70,7 +70,7 @@ static void get_tpm_phys_params(void *fdt __maybe_unused,
 #ifdef CFG_DT
 	int node = 0;
 	const char *dt_tpm_match_table = {
-		"arm,nt_fw",
+		"arm,tpm_event_log",
 	};
 
 	if (!fdt) {


### PR DESCRIPTION
TF-A Measured Boot driver expects a tpm_event_log node on the
DTB with the compatible field set to "arm,tpm_event_log", so
fix the match table entry for the TPM support to match the one
used by TF-A.

Signed-off-by: Javier Almansa Sobrino <javier.almansasobrino@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
