### PR TITLE
core: rcar: Enable parsing of /memory nodes from DT from TFA

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -914,58 +914,82 @@ static uint64_t get_dt_val_and_advance(const void *data, size_t *offs,
 	return rv;
 }
 
-static struct core_mmu_phys_mem *get_memory(void *fdt, size_t *nelems)
+static int get_memory_all(void *fdt, struct core_mmu_phys_mem *mem)
 {
-	int offs = 0;
+	const uint8_t *prop = NULL;
+	uint64_t a = 0;
+	uint64_t l = 0;
+	size_t prop_offs = 0;
+	size_t prop_len = 0;
+	int elems_total = 0;
 	int addr_size = 0;
 	int len_size = 0;
-	size_t prop_len = 0;
-	const uint8_t *prop = NULL;
-	size_t prop_offs = 0;
+	int offs = 0;
 	size_t n = 0;
-	struct core_mmu_phys_mem *mem = NULL;
+	int len = 0;
 
-	offs = fdt_subnode_offset(fdt, 0, "memory");
-	if (offs < 0)
-		return NULL;
-
-	prop = fdt_getprop(fdt, offs, "reg", &addr_size);
-	if (!prop)
-		return NULL;
-
-	prop_len = addr_size;
 	addr_size = fdt_address_cells(fdt, 0);
 	if (addr_size < 0)
-		return NULL;
+		return 0;
 
 	len_size = fdt_size_cells(fdt, 0);
 	if (len_size < 0)
-		return NULL;
+		return 0;
 
-	for (n = 0, prop_offs = 0; prop_offs < prop_len; n++) {
-		get_dt_val_and_advance(prop, &prop_offs, addr_size);
-		if (prop_offs >= prop_len) {
-			n--;
+	while (true) {
+		offs = fdt_node_offset_by_prop_value(fdt, offs, "device_type",
+						     "memory",
+						     sizeof("memory"));
+		if (offs < 0)
 			break;
+
+		if (_fdt_get_status(fdt, offs) <= 0)
+			continue;
+
+		prop = fdt_getprop(fdt, offs, "reg", &len);
+		if (!prop)
+			continue;
+
+		prop_len = len;
+		for (n = 0, prop_offs = 0; prop_offs < prop_len; n++) {
+			a = get_dt_val_and_advance(prop, &prop_offs, addr_size);
+			if (prop_offs >= prop_len) {
+				n--;
+				break;
+			}
+
+			l = get_dt_val_and_advance(prop, &prop_offs, len_size);
+			if (mem) {
+				mem->type = MEM_AREA_RAM_NSEC;
+				mem->addr = a;
+				mem->size = l;
+				mem++;
+			}
 		}
-		get_dt_val_and_advance(prop, &prop_offs, len_size);
+
+		elems_total += n;
 	}
 
-	if (!n)
+	return elems_total;
+}
+
+static struct core_mmu_phys_mem *get_memory(void *fdt, size_t *nelems)
+{
+	struct core_mmu_phys_mem *mem = NULL;
+	int elems_total = 0;
+
+	elems_total = get_memory_all(fdt, NULL);
+	if (elems_total <= 0)
 		return NULL;
 
-	*nelems = n;
-	mem = nex_calloc(n, sizeof(*mem));
+	mem = nex_calloc(elems_total, sizeof(*mem));
 	if (!mem)
 		panic();
 
-	for (n = 0, prop_offs = 0; n < *nelems; n++) {
-		mem[n].type = MEM_AREA_RAM_NSEC;
-		mem[n].addr = get_dt_val_and_advance(prop, &prop_offs,
-						     addr_size);
-		mem[n].size = get_dt_val_and_advance(prop, &prop_offs,
-						     len_size);
-	}
+	elems_total = get_memory_all(fdt, mem);
+	assert(elems_total > 0);
+
+	*nelems = elems_total;
 
 	return mem;
 }

--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -40,3 +40,5 @@ supported-ta-targets = ta_arm64
 else
 $(call force,CFG_ARM32_core,y)
 endif
+
+CFG_DT ?= y

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -21,6 +21,7 @@
 #define DT_STATUS_OK_SEC		BIT(1)
 
 #define DT_INFO_INVALID_REG		((paddr_t)-1)
+#define DT_INFO_INVALID_REG_SIZE	((ssize_t)-1)
 #define DT_INFO_INVALID_CLOCK		-1
 #define DT_INFO_INVALID_RESET		-1
 #define DT_INFO_INVALID_INTERRUPT	-1

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -222,7 +222,7 @@ ssize_t _fdt_reg_size(const void *fdt, int offs)
 
 	parent = fdt_parent_offset(fdt, offs);
 	if (parent < 0)
-		return DT_INFO_INVALID_REG;
+		return DT_INFO_INVALID_REG_SIZE;
 
 	reg = (const uint32_t *)fdt_getprop(fdt, offs, "reg", &len);
 	if (!reg)


### PR DESCRIPTION
The TFA can pass DT to the optee-os, however the optee-os cannot parse all possible /memory node formats correctly, e.g. the following does not work:
/ {
      memory@480000000 {
        reg = <0x00000000 0x48000000 0x00000000 0x78000000>;
        device_type = "memory";
      };
      memory@600000000 {
        reg = <0x00000006 0x00000000 0x00000000 0x80000000>;
        device_type = "memory";
      };
    };
Optee-os can only parse the most simple plain /memory node. The above sample is correct per DT specification and rcar gen3 uses it in Linux, so it should be supported by other components too.

This patchset fixes it so that optee-os can handle all possible /memory nodes and enables parsing of memory nodes on rcar gen3.

NOTE: This is re-post of https://github.com/OP-TEE/optee_os/pull/3741