### PR TITLE
ldelf: arm64: support R_AARCH64_TLSDESC relocations

### DIFF
--- a/ldelf/sub.mk
+++ b/ldelf/sub.mk
@@ -1,6 +1,7 @@
 global-incdirs-y += include
 srcs-$(CFG_ARM32_$(sm)) += start_a32.S
 srcs-$(CFG_ARM64_$(sm)) += start_a64.S
+srcs-$(CFG_ARM64_$(sm)) += tlsdesc_rel_a64.S
 srcs-y += dl.c
 srcs-y += main.c
 srcs-y += sys.c

--- a/ldelf/tlsdesc_rel_a64.S
+++ b/ldelf/tlsdesc_rel_a64.S
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020, Huawei Technologies Co. Ltd.
+ */
+
+#include <asm.S>
+
+/*
+ * long tlsdesc_resolve(struct tlsdesc *);
+ *
+ * Must preserve all registers except x0, x1 and the processor flags.
+ * See https://www.fsfla.org/~lxoliva/writeups/TLS/RFC-TLSDESC-ARM.txt section
+ * "Resolvers' Calling Convention". The document applies to 32-bit Arm but other
+ * sources mention similar constraints for other architectures.
+ */
+FUNC tlsdesc_resolve , :
+	ldr	x0, [x0, #8]
+	ret
+END_FUNC tlsdesc_resolve
+

--- a/lib/libutee/include/elf_common.h
+++ b/lib/libutee/include/elf_common.h
@@ -657,6 +657,7 @@ typedef struct {
 #define	R_AARCH64_JUMP_SLOT	1026	/* Set GOT entry to code address. */
 #define	R_AARCH64_RELATIVE	1027	/* Add load address of shared object. */
 #define	R_AARCH64_TLS_TPREL	1030	/* Offset of the TLS block in the TCB */
+#define	R_AARCH64_TLSDESC	1031	/* TLS descriptor to be filled */
 
 #define	R_ARM_NONE		0	/* No relocation. */
 #define	R_ARM_PC24		1


### PR DESCRIPTION
When compiling the __thread test in optee_test (xtest 1029), GCC 8.3
emits R_AARCH64_TLS_TPREL relocations while GCC 6 and 7 generate
R_AARCH64_TLSDESC instead. The latter are quite easy to implement once
the former are done so add the required code to ldelf. This also
enables the C++ tests (xtest 1031) to pass with the older compilers.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Tested-by: Jerome Forissier <jerome@forissier.org> (QEMUv8, GCC 6.2/7.2)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
