### PR TITLE
core: do not trace syscall_log()

### DIFF
--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -123,7 +123,7 @@ static const struct syscall_entry tee_svc_syscall_table[] = {
 #ifdef TRACE_SYSCALLS
 static void trace_syscall(size_t num)
 {
-	if (num == TEE_SCN_RETURN || num > TEE_SCN_MAX)
+	if (num == TEE_SCN_RETURN || num == TEE_SCN_LOG || num > TEE_SCN_MAX)
 		return;
 	FMSG("syscall #%zu (%s)", num, tee_svc_syscall_table[num].name);
 }


### PR DESCRIPTION
Tracing the log syscall is of very little value since it will generate
some output to the console anyways. Worse, it pollutes the TA output in
case of a panic or an abort. For example:
```
 o regression_4005.1 AE case 0 algo 0x40000710 line 2819
 F/TC:?? 0 trace_syscall:132 syscall #27 (syscall_cryp_obj_alloc)
 F/TC:?? 0 trace_syscall:132 syscall #15 (syscall_cryp_state_alloc)
 F/TC:?? 0 trace_syscall:132 syscall #27 (syscall_cryp_obj_alloc)
 F/TC:?? 0 trace_syscall:132 syscall #24 (syscall_cryp_obj_get_info)
 F/TC:?? 0 trace_syscall:132 syscall #30 (syscall_cryp_obj_populate)
 F/TC:?? 0 trace_syscall:132 syscall #24 (syscall_cryp_obj_get_info)
 F/TC:?? 0 trace_syscall:132 syscall #24 (syscall_cryp_obj_get_info)
 F/TC:?? 0 trace_syscall:132 syscall #29 (syscall_cryp_obj_reset)
 F/TC:?? 0 trace_syscall:132 syscall #24 (syscall_cryp_obj_get_info)
 F/TC:?? 0 trace_syscall:132 syscall #24 (syscall_cryp_obj_get_info)
 F/TC:?? 0 trace_syscall:132 syscall #31 (syscall_cryp_obj_copy)
 F/TC:?? 0 trace_syscall:132 syscall #24 (syscall_cryp_obj_get_info)
 F/TC:?? 0 trace_syscall:132 syscall #28 (syscall_cryp_obj_close)
 F/TC:?? 0 trace_syscall:132 syscall #34 (syscall_authenc_init)
 F/TC:?? 0 trace_syscall:132 syscall #2 (syscall_panic)
 E/TC:?? 0
 E/TC:?? 0 TA panicked with code 0xffff0006
 F/TC:?? 0 trace_syscall:132 syscall #1 (syscall_log)
 E/LD:  Status of TA cb3e5ba0-adf1-11e0-998b-0002a5d5c51b
 F/TC:?? 0 trace_syscall:132 syscall #1 (syscall_log)
 E/LD:   arch: aarch64
 F/TC:?? 0 trace_syscall:132 syscall #1 (syscall_log)
 E/LD:  region  0: va 0x40004000 pa 0x100062d000 size 0x002000 flags rw-s (ldelf)
 F/TC:?? 0 trace_syscall:132 syscall #1 (syscall_log)
 E/LD:  region  1: va 0x40006000 pa 0x100062f000 size 0x00d000 flags r-xs (ldelf)
 ...
```
Therefore, skip the trace if the syscall number it TEE_SCN_LOG.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
