### PR TITLE
Add support for Renesas RZ/N1 platform

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -150,5 +150,6 @@ build:
     - _make PLATFORM=bcm-ns3 CFG_ARM64_core=y
     - _make PLATFORM=hisilicon-hi3519av100_demo
     - _make PLATFORM=amlogic
+    - _make PLATFORM=rzn1
 
     - upload_cache

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -163,6 +163,12 @@ R:	[@OP-TEE/plat-rcar]
 S:	Maintained
 F:	core/arch/arm/plat-rcar/
 
+Renesas RZ/N1
+R:	Sumit Garg <sumit.garg@linaro.org> [@b49020]
+R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
+S:	Maintained
+F:	core/arch/arm/plat-rzn1/
+
 Rockchip RK322X
 R:	Rockchip <op-tee@rock-chips.com>
 R:	[@OP-TEE/plat-rockchip]

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -120,7 +120,8 @@ __weak void init_sec_mon(unsigned long nsec_entry)
 	nsec_ctx = sm_get_nsec_ctx();
 	nsec_ctx->mon_lr = nsec_entry;
 	nsec_ctx->mon_spsr = CPSR_MODE_SVC | CPSR_I;
-
+	if (nsec_entry & 1)
+		nsec_ctx->mon_spsr |= CPSR_T;
 }
 #endif
 

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -105,7 +105,7 @@ void console_init(void)
 	pl011_init(&console_data, CONSOLE_UART_BASE, CONSOLE_UART_CLK_IN_HZ,
 		   CONSOLE_BAUDRATE);
 #else
-	ns16550_init(&console_data, CONSOLE_UART_BASE);
+	ns16550_init(&console_data, CONSOLE_UART_BASE, IO_WIDTH_U8, 0);
 #endif
 	register_serial_console(&console_data.chip);
 }

--- a/core/arch/arm/plat-rzn1/a7_plat_init.S
+++ b/core/arch/arm/plat-rzn1/a7_plat_init.S
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2016, Wind River Systems.
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+/*
+ * Entry points for the A7 init.
+ *
+ * Assumptions:
+ * - No stack is available when these routines are called.
+ * - Each routine is called with return address in LR and
+ *   with ARM registers R0, R1, R2, R3 being scratchable.
+ */
+
+#include <arm32.h>
+#include <arm32_macros.S>
+#include <asm.S>
+#include <kernel/unwind.h>
+#include <platform_config.h>
+
+.section .text
+.balign 4
+.code 32
+
+FUNC plat_cpu_reset_early , :
+UNWIND( .fnstart)
+
+	/*
+	 * SCR = 0x00000020
+	 * - FW: Disallow NSec to mask FIQ [bit4=0]
+	 * - AW: Allow NSec to manage Imprecise Abort [bit5=1]
+	 * - EA: Imprecise Abort trapped to Abort Mode [bit3=0]
+	 * - FIQ: In Sec world, FIQ trapped to FIQ Mode [bit2=0]
+	 * - IRQ: IRQ always trapped to IRQ Mode [bit1=0]
+	 * - NS: Secure World [bit0=0]
+	 */
+	mov r0, #SCR_AW
+	write_scr r0
+
+	mov_imm r0, 0x00000000
+	write_sctlr r0
+
+	/*
+	 * ACTRL = 0x00006040
+	 * - DDI: Disable dual issue [bit28=0]
+	 * - DDVM: Disable Distributed Virtual Memory transactions [bit15=0]
+	 * - L1PCTL: L1 Data prefetch control [bit14:13=2b11]
+	 * - L1RADIS: L1 Data Cache read-allocate mode disable [bit12=0]
+	 * - L2RADIS: L2 Data Cache read-allocate mode disable [bit11=0]
+	 * - DODMBS: Disable optimized data memory barrier behavior [bit10=0]
+	 * - SMP: Enables coherent requests to the processor [bit6=0]
+	 */
+	mov_imm r0, 0x00006040
+	write_actlr r0
+
+	/*
+	 * NSACR = 0x00000C00
+	 * - NS_SMP: Non-secure mode cannot change ACTRL.SMP (bit18=0)
+	 * - NSASEDIS/NSD32DIS/CP10/CP11: Non-secure mode can use SIMD/VFP
+	 *                                (bit15:14=2b00, bit11:10=2b11)
+	 */
+	mov_imm r0, 0x00000C00
+	write_nsacr r0
+
+	mov pc, lr
+UNWIND( .fnend)
+END_FUNC plat_cpu_reset_early

--- a/core/arch/arm/plat-rzn1/conf.mk
+++ b/core/arch/arm/plat-rzn1/conf.mk
@@ -1,0 +1,26 @@
+PLATFORM_FLAVOR ?= rzn1
+
+include core/arch/arm/cpu/cortex-a7.mk
+
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+$(call force,CFG_BOOT_SECONDARY_REQUEST,y)
+$(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
+$(call force,CFG_PSCI_ARM32,y)
+$(call force,CFG_16550_UART,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_PAGER,n)
+$(call force,CFG_GIC,y)
+$(call force,CFG_SM_PLATFORM_HANDLER,y)
+$(call force,CFG_TA_FLOAT_SUPPORT,n)
+
+ta-targets = ta_arm32
+
+CFG_TZDRAM_START ?= 0x88000000
+CFG_TZDRAM_SIZE ?= 0x00A00000
+CFG_SHMEM_START ?= 0x87C00000
+CFG_SHMEM_SIZE  ?= 0x00400000
+CFG_TEE_RAM_VA_SIZE ?= 0x00200000
+
+CFG_NUM_THREADS ?= 4
+CFG_NS_ENTRY_ADDR ?= 0x87A00000

--- a/core/arch/arm/plat-rzn1/link.mk
+++ b/core/arch/arm/plat-rzn1/link.mk
@@ -1,0 +1,8 @@
+include core/arch/arm/kernel/link.mk
+
+all: $(link-out-dir)/tee-raw.bin
+
+cleanfiles += $(link-out-dir)/tee-raw.bin
+$(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
+	@$(cmd-echo-silent) '  GEN     $@'
+	$(q)scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@

--- a/core/arch/arm/plat-rzn1/main.c
+++ b/core/arch/arm/plat-rzn1/main.c
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017, Schneider Electric
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#include <arm.h>
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/ns16550.h>
+#include <kernel/boot.h>
+#include <kernel/interrupt.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <rzn1_tz.h>
+
+static struct gic_data gic_data;
+static struct ns16550_data console_data;
+
+register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_PGDIR_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, PERIPH_REG_BASE, CORE_MMU_PGDIR_SIZE);
+register_ddr(DRAM_BASE, DRAM_SIZE);
+
+void console_init(void)
+{
+	ns16550_init(&console_data, CONSOLE_UART_BASE, IO_WIDTH_U32, 2);
+	register_serial_console(&console_data.chip);
+}
+
+void main_init_gic(void)
+{
+	vaddr_t gicc_base = 0;
+	vaddr_t gicd_base = 0;
+
+	gicc_base = (vaddr_t)phys_to_virt(GICC_BASE, MEM_AREA_IO_SEC);
+	gicd_base = (vaddr_t)phys_to_virt(GICD_BASE, MEM_AREA_IO_SEC);
+	if (!gicc_base || !gicd_base)
+		panic();
+
+	gic_init(&gic_data, gicc_base, gicd_base);
+
+	itr_init(&gic_data.chip);
+}
+
+void main_secondary_init_gic(void)
+{
+	gic_cpu_init(&gic_data);
+}
+
+static TEE_Result rzn1_tz_init(void)
+{
+	vaddr_t tza_init_reg = 0;
+	vaddr_t tza_targ_reg = 0;
+
+	tza_init_reg = core_mmu_get_va(FW_STATIC_TZA_INIT, MEM_AREA_IO_SEC);
+	tza_targ_reg = core_mmu_get_va(FW_STATIC_TZA_TARG, MEM_AREA_IO_SEC);
+
+	/* TZ initiator ports */
+	io_write32(tza_init_reg, TZ_INIT_CSA_SEC | TZ_INIT_YS_SEC |
+				 TZ_INIT_YC_SEC | TZ_INIT_YD_SEC);
+
+	/* TZ target ports */
+	io_write32(tza_targ_reg, TZ_TARG_PC_SEC | TZ_TARG_QB_SEC |
+				 TZ_TARG_QA_SEC | TZ_TARG_UB_SEC |
+				 TZ_TARG_UA_SEC);
+
+	return TEE_SUCCESS;
+}
+
+service_init(rzn1_tz_init);

--- a/core/arch/arm/plat-rzn1/platform_config.h
+++ b/core/arch/arm/plat-rzn1/platform_config.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017, Schneider Electric
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* DRAM */
+#define DRAM_BASE			0x80000000
+#define DRAM_SIZE			0x10000000
+
+/* GIC */
+#define GIC_BASE			0x44100000
+#define GICD_OFFSET			0x1000
+#define GICC_OFFSET			0x2000
+#define GICD_BASE			(GIC_BASE + GICD_OFFSET)
+#define GICC_BASE			(GIC_BASE + GICC_OFFSET)
+
+/* Peripheral memory map */
+#define PERIPH_REG_BASE			0x40000000
+
+/* System Control */
+#define SYSCTRL_BASE			0x4000C000
+
+/* UART */
+#define CONSOLE_UART_BASE		0x40060000
+
+#endif /* PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-rzn1/psci.c
+++ b/core/arch/arm/plat-rzn1/psci.c
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017, Schneider Electric
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#include <arm.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/misc.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <sm/psci.h>
+#include <sm/std_smc.h>
+
+#define SYSCTRL_REG_RSTEN		(SYSCTRL_BASE + 0x120)
+#define SYSCTRL_REG_RSTCTRL		(SYSCTRL_BASE + 0x198)
+#define SYSCTRL_BOOTADDR_REG		(SYSCTRL_BASE + 0x204)
+
+#define SYSCTRL_REG_RSTEN_MRESET_EN	BIT(0)
+#define SYSCTRL_REG_RSTEN_SWRST_EN	BIT(6)
+#define SYSCTRL_REG_RSTCTRL_SWRST_REQ	BIT(6)
+
+int psci_features(uint32_t psci_fid)
+{
+	switch (psci_fid) {
+	case PSCI_PSCI_FEATURES:
+	case PSCI_VERSION:
+	case PSCI_CPU_ON:
+	case PSCI_CPU_OFF:
+	case PSCI_SYSTEM_RESET:
+		return PSCI_RET_SUCCESS;
+	default:
+		return PSCI_RET_NOT_SUPPORTED;
+	}
+}
+
+uint32_t psci_version(void)
+{
+	return PSCI_VERSION_1_0;
+}
+
+int psci_cpu_on(uint32_t core_id, uint32_t entry, uint32_t context_id)
+{
+	vaddr_t sctl_va = core_mmu_get_va(SYSCTRL_BOOTADDR_REG,
+					  MEM_AREA_IO_SEC);
+
+	if (core_id == 0 || core_id >= CFG_TEE_CORE_NB_CORE)
+		return PSCI_RET_INVALID_PARAMETERS;
+
+	DMSG("core_id: %" PRIu32, core_id);
+
+	boot_set_core_ns_entry(core_id, entry, context_id);
+	io_write32(sctl_va, TEE_LOAD_ADDR);
+
+	dsb();
+	sev();
+
+	return PSCI_RET_SUCCESS;
+}
+
+int __noreturn psci_cpu_off(void)
+{
+	DMSG("core_id: %" PRIu32, get_core_pos());
+
+	psci_armv7_cpu_off();
+
+	thread_mask_exceptions(THREAD_EXCP_ALL);
+
+	while (1)
+		wfi();
+}
+
+void psci_system_reset(void)
+{
+	/* Enable software reset */
+	io_setbits32(core_mmu_get_va(SYSCTRL_REG_RSTEN, MEM_AREA_IO_SEC),
+		     SYSCTRL_REG_RSTEN_SWRST_EN | SYSCTRL_REG_RSTEN_MRESET_EN);
+
+	/* Trigger software reset */
+	io_setbits32(core_mmu_get_va(SYSCTRL_REG_RSTCTRL, MEM_AREA_IO_SEC),
+		     SYSCTRL_REG_RSTCTRL_SWRST_REQ);
+
+	dsb();
+}

--- a/core/arch/arm/plat-rzn1/rzn1_regauth.h
+++ b/core/arch/arm/plat-rzn1/rzn1_regauth.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017, Schneider Electric
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#ifndef RZN1_REGAUTH_H
+#define RZN1_REGAUTH_H
+
+struct regauth_t {
+	uint32_t paddr;
+	uint32_t size;
+	uint32_t rmask;
+	uint32_t wmask;
+};
+
+static const struct regauth_t regauth[] = {
+	/* OTP */
+	{ 0x40007000U, 0x4U, 0x0U, 0x0U },                /* OTPWCTRL */
+	/* System Controller */
+	{ 0x4000C064U, 0x4U, 0xFFFFFFFFU, 0xFFFFFFE0U },  /* PWRCTRL_DDRC */
+	{ 0x4000C204U, 0x4U, 0x0U, 0x0U },                /* BOOTADDR */
+	/* DDR CTRL */
+	{ 0x4000D16CU, 0x3FCU, 0x0U, 0x0U },              /* DDR_CTL 91-346 */
+	{ 0x4000E000U, 0x4U, 0xFFFFFFFFU, 0xFFFFFFFEU },  /* UNCCTRL */
+	{ 0x4000E004U, 0x4U, 0xFFFFFFFFU, 0xFFFFFFFEU },  /* DLLCTRL */
+};
+
+#endif /* RZN1_REGAUTH_H */

--- a/core/arch/arm/plat-rzn1/rzn1_tz.h
+++ b/core/arch/arm/plat-rzn1/rzn1_tz.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2017, Schneider Electric
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#ifndef RZN1_TZ_H
+#define RZN1_TZ_H
+
+#include <util.h>
+
+/* TZ config registers */
+#define FW_STATIC_TZA_INIT	0x4000C0D0
+#define FW_STATIC_TZA_TARG	0x4000C0D4
+
+/* TZ initiatior ports */
+#define TZ_INIT_CSB_SEC		BIT(7)  /* CoreSight AHB */
+#define TZ_INIT_CSA_SEC		BIT(6)  /* CoreSight AXI */
+#define TZ_INIT_YS_SEC		BIT(5)  /* Cortex-M3 System Bus interface */
+#define TZ_INIT_YC_SEC		BIT(4)  /* Cortex-M3 ICode interface */
+#define TZ_INIT_YD_SEC		BIT(3)  /* Cortex-M3 DCode interface */
+#define TZ_INIT_Z_SEC		BIT(2)  /* Packet Engine */
+#define TZ_INIT_I_SEC		BIT(1)  /* Peripheral Group */
+#define TZ_INIT_F_SEC		BIT(0)  /* Peripheral Group */
+
+/* TZ target ports */
+#define TZ_TARG_W_SEC		BIT(14) /* RTC */
+#define TZ_TARG_PC_SEC		BIT(9)  /* DDR2/3 Controller */
+#define TZ_TARG_RA_SEC		BIT(8)  /* CoreSight */
+#define TZ_TARG_QB_SEC		BIT(7)  /* System Control */
+#define TZ_TARG_QA_SEC		BIT(6)  /* PG0 */
+#define TZ_TARG_NB_SEC		BIT(5)  /* Packet Engine */
+#define TZ_TARG_NA_SEC		BIT(4)  /* Public Key Processor */
+#define TZ_TARG_K_SEC		BIT(3)  /* Peripheral Group */
+#define TZ_TARG_J_SEC		BIT(2)  /* Peripheral Group */
+#define TZ_TARG_UB_SEC		BIT(1)  /* 2MB SRAM */
+#define TZ_TARG_UA_SEC		BIT(0)  /* 2MB SRAM */
+
+#endif /* RZN1_TZ_H */

--- a/core/arch/arm/plat-rzn1/sm_platform_handler.c
+++ b/core/arch/arm/plat-rzn1/sm_platform_handler.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#include <console.h>
+#include <io.h>
+#include <kernel/tee_misc.h>
+#include <mm/core_memprot.h>
+#include <sm/optee_smc.h>
+#include <sm/sm.h>
+
+#include "rzn1_regauth.h"
+
+#define RZN1_OEM_CONSOLE_PUTC		0x01
+#define RZN1_OEM_SYSREG_AUTH		0x10
+
+static const struct regauth_t regauth_pass = {.rmask = ~0U, .wmask = ~0U};
+
+static const struct regauth_t *get_regauth(unsigned long paddr)
+{
+	unsigned int idx = 0;
+	unsigned int len = ARRAY_SIZE(regauth);
+
+	while (idx < len) {
+		if (core_is_buffer_inside(paddr, sizeof(uint32_t),
+					  regauth[idx].paddr,
+					  regauth[idx].size))
+			return &regauth[idx];
+		idx++;
+	}
+
+	return NULL;
+}
+
+static uint32_t oem_sysreg(uint32_t addr, uint32_t mask, uint32_t *pvalue)
+{
+	vaddr_t reg = 0;
+	const struct regauth_t *auth = get_regauth(addr);
+
+	/* Allow operations on registers not in the list */
+	if (!auth)
+		auth = &regauth_pass;
+
+	reg = core_mmu_get_va(addr, MEM_AREA_IO_SEC);
+
+	if (mask) {
+		/* Write operation */
+		mask &= auth->wmask;
+		if (!reg || !mask)
+			DMSG("Blocking write of 0x%"PRIx32" to register 0x%"
+			     PRIx32" (0x%"PRIxVA")", *pvalue, addr, reg);
+		else
+			io_mask32(reg, *pvalue, mask);
+	} else {
+		/* Read operation */
+		if (!reg || !auth->rmask)
+			DMSG("Blocking read of register 0x%"PRIx32" (0x%"
+			     PRIxVA")", addr, reg);
+		else
+			*pvalue = io_read32(reg) & auth->rmask;
+	}
+
+	return 0;
+}
+
+static enum sm_handler_ret oem_service(struct sm_ctx *ctx __unused,
+				       struct thread_smc_args *args)
+{
+	switch (OPTEE_SMC_FUNC_NUM(args->a0)) {
+	case RZN1_OEM_SYSREG_AUTH:
+		args->a0 = oem_sysreg(args->a1, args->a2, &args->a3);
+		args->a1 = args->a3;
+		break;
+	case RZN1_OEM_CONSOLE_PUTC:
+		console_putc(args->a1);
+		break;
+	default:
+		return SM_HANDLER_PENDING_SMC;
+	}
+
+	return SM_HANDLER_SMC_HANDLED;
+}
+
+enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx)
+{
+	struct thread_smc_args *args = (void *)&ctx->nsec.r0;
+
+	if (!OPTEE_SMC_IS_FAST_CALL(args->a0))
+		return SM_HANDLER_PENDING_SMC;
+
+	switch (OPTEE_SMC_OWNER_NUM(args->a0)) {
+	case OPTEE_SMC_OWNER_OEM:
+		return oem_service(ctx, args);
+	default:
+		return SM_HANDLER_PENDING_SMC;
+	}
+}

--- a/core/arch/arm/plat-rzn1/sub.mk
+++ b/core/arch/arm/plat-rzn1/sub.mk
@@ -1,0 +1,5 @@
+global-incdirs-y += .
+srcs-y += main.c
+srcs-y += psci.c
+srcs-y += sm_platform_handler.c
+srcs-y += a7_plat_init.S

--- a/core/include/drivers/ns16550.h
+++ b/core/include/drivers/ns16550.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (C) 2015 Freescale Semiconductor, Inc.
+ * Copyright (c) 2020, Linaro Limited
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,14 +29,37 @@
 #ifndef NS16550_H
 #define NS16550_H
 
-#include <types_ext.h>
 #include <drivers/serial.h>
+#include <io.h>
+#include <types_ext.h>
+
+#define IO_WIDTH_U8		0
+#define IO_WIDTH_U32		1
 
 struct ns16550_data {
 	struct io_pa_va base;
 	struct serial_chip chip;
+	uint8_t io_width;
+	uint8_t reg_shift;
 };
 
-void ns16550_init(struct ns16550_data *pd, paddr_t base);
+static inline unsigned int serial_in(vaddr_t addr, uint8_t io_width)
+{
+	if (io_width == IO_WIDTH_U32)
+		return io_read32(addr);
+	else
+		return io_read8(addr);
+}
+
+static inline void serial_out(vaddr_t addr, uint8_t io_width, int ch)
+{
+	if (io_width == IO_WIDTH_U32)
+		io_write32(addr, ch);
+	else
+		io_write8(addr, ch);
+}
+
+void ns16550_init(struct ns16550_data *pd, paddr_t base, uint8_t io_width,
+		  uint8_t reg_shift);
 
 #endif /* NS16550_H */


### PR DESCRIPTION
Add support for RZ/N1 platform from Renasas:
- Cortex-A7 based dual core processor.

This platform supports TrustZone based IO register access control, so add corresponding OEM service based implementation.

For more information about this platform, refer [here](https://www.renesas.com/us/en/products/microcontrollers-microprocessors/rz/rzn/rzn1d.html).