### PR TITLE
vexpress-qemu_v8a: set CFG_ARM64_core to 'y' by default

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -54,13 +54,13 @@ build:
     - _make CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
     - _make CFG_SECURE_DATA_PATH=y
     - _make CFG_REE_FS_TA_BUFFERED=y
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_CORE_ASLR=y
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y COMPILER=clang
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_WITH_PAGER=y
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_FTRACE_SUPPORT=y CFG_ULIBS_MCOUNT=y CFG_ULIBS_SHARED=y
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_VIRTUALIZATION=y
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_ARM64_core=y CFG_CORE_SEL1_SPMC=y
+    - _make PLATFORM=vexpress-qemu_armv8a CFG_CORE_ASLR=y
+    - _make PLATFORM=vexpress-qemu_armv8a COMPILER=clang
+    - _make PLATFORM=vexpress-qemu_armv8a CFG_WITH_PAGER=y
+    - _make PLATFORM=vexpress-qemu_armv8a CFG_FTRACE_SUPPORT=y CFG_ULIBS_MCOUNT=y CFG_ULIBS_SHARED=y
+    - _make PLATFORM=vexpress-qemu_armv8a CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
+    - _make PLATFORM=vexpress-qemu_armv8a CFG_VIRTUALIZATION=y
+    - _make PLATFORM=vexpress-qemu_armv8a CFG_CORE_SEL1_SPMC=y
     - _make PLATFORM=stm-b2260
     - _make PLATFORM=stm-cannes
     - _make PLATFORM=stm32mp1

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -22,6 +22,7 @@ endif
 endif #juno
 ifeq ($(PLATFORM_FLAVOR),qemu_armv8a)
 include core/arch/arm/cpu/cortex-armv8-0.mk
+CFG_ARM64_core ?= y
 endif
 
 


### PR DESCRIPTION
Enables CFG_ARM64_core by default for PLATFORM=vexpress-qemu_v8a. This
platform is mostly used in full 64-bit mode, especially since until now
the build.git Makefiles do not support anything else [1].

Link: [1] https://github.com/OP-TEE/build/blob/3.10.0/qemu_v8.mk#L9
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
