### PR TITLE
core: mm: fix region lookup in param_mem_to_user_va()

### DIFF
--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -843,7 +843,7 @@ static TEE_Result param_mem_to_user_va(struct user_mode_ctx *uctx,
 		phys_offs += mem->offs;
 		if (phys_offs < region->offset)
 			continue;
-		if (phys_offs >= (region->offset  - region->size))
+		if (phys_offs >= (region->offset + region->size))
 			continue;
 		va = region->va + phys_offs - region->offset;
 		*user_va = (void *)va;


### PR DESCRIPTION
The check, if a memory parameter is located in a region, fails
because of a typo in the comparison. The region size must be
added to the start address, not subtracted.

Fixes: 2667e1359e51 ("core: fix offset calculation in param_mem_to_user_va()")
Signed-off-by: Wolfgang Ocker <weo@reccoware.de>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
