### PR TITLE
core: change all_objs.o init.o unpaged.o file format

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -36,7 +36,7 @@ link-script-cppflags := \
 		$(addprefix -I,$(incdirscore) $(link-out-dir)) \
 		$(cppflagscore))
 
-ldargs-all_objs := -T $(link-script-dummy) --no-check-sections \
+ldargs-all_objs := -r -T $(link-script-dummy) --no-check-sections \
 		   $(link-objs) $(link-ldadd) $(libgcccore)
 cleanfiles += $(link-out-dir)/all_objs.o
 $(link-out-dir)/all_objs.o: $(objs) $(libdeps) $(MAKEFILE_LIST)
@@ -49,7 +49,7 @@ $(link-out-dir)/unpaged_entries.txt: $(link-out-dir)/all_objs.o
 	$(q)$(NMcore) $< | \
 		$(AWK) '/ ____keep_pager/ { printf "-u%s ", $$3 }' > $@
 
-unpaged-ldargs = -T $(link-script-dummy) --no-check-sections --gc-sections
+unpaged-ldargs = -r -T $(link-script-dummy) --no-check-sections --gc-sections
 unpaged-ldadd := $(objs) $(link-ldadd) $(libgcccore)
 cleanfiles += $(link-out-dir)/unpaged.o
 $(link-out-dir)/unpaged.o: $(link-out-dir)/unpaged_entries.txt
@@ -77,7 +77,7 @@ $(link-out-dir)/init_entries.txt: $(link-out-dir)/all_objs.o
 	$(q)$(NMcore) $< | \
 		$(AWK) '/ ____keep_init/ { printf "-u%s ", $$3 }' > $@
 
-init-ldargs := -T $(link-script-dummy) --no-check-sections --gc-sections
+init-ldargs := -r -T $(link-script-dummy) --no-check-sections --gc-sections
 init-ldadd := $(link-objs-init) $(link-out-dir)/version.o  $(link-ldadd) \
 	      $(libgcccore)
 cleanfiles += $(link-out-dir)/init.o

--- a/core/arch/arm/kernel/link_dummy.ld
+++ b/core/arch/arm/kernel/link_dummy.ld
@@ -10,6 +10,9 @@ SECTIONS
 	 * sections etc.
 	 */
 	..dummy : { }
+	/DISCARD/ : {
+	        *(.group .debug*)
+	}
 }
 
 __asan_map_end = .;


### PR DESCRIPTION
A "relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against
symbol" error occurred when I compiling a old version of optee.

This error is caused by a adr instruction exceeding the address
range when linking all_objs.o, and it has been fixed in [1].

Actually these three files are in executable format, and they
are only used to obtain symbol and section information, so
they'd better use relocatable format while avoiding other
compilation errors may caused by relocation during the linking
process.

Compilation errors similar to [1] should only appear in the
final linking of tee.elf, and it is better not to expose it to
the linking process of all_objs.o init.o unpaged.o.

Using the -r and -gc-sections parameters in ld.bfd at the
same time may cause compilation failure[2], this error can be
bypassed by ignoring the .group and .debug* sections.

Link: [1] 150819795e42 ("core: use adr_l to allow bigger data sections")
Link: [2] https://bugs.linaro.org/show_bug.cgi?id=3006

Signed-off-by: Dan Li <ashimida@linux.alibaba.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
