### PR TITLE
core: Add a parameter to vm_map_pad() to specify alignment requirement

### DIFF
--- a/core/include/mm/tee_mmu.h
+++ b/core/include/mm/tee_mmu.h
@@ -32,7 +32,8 @@ void vm_info_final(struct user_mode_ctx *uctx);
 
 TEE_Result vm_map_pad(struct user_mode_ctx *uctx, vaddr_t *va, size_t len,
 		      uint32_t prot, uint32_t flags, struct mobj *mobj,
-		      size_t offs, size_t pad_begin, size_t pad_end);
+		      size_t offs, size_t pad_begin, size_t pad_end,
+		      size_t align);
 
 /*
  * Creates a memory map of a mobj.
@@ -43,7 +44,7 @@ static inline TEE_Result vm_map(struct user_mode_ctx *uctx, vaddr_t *va,
 				size_t len, uint32_t prot, uint32_t flags,
 				struct mobj *mobj, size_t offs)
 {
-	return vm_map_pad(uctx, va, len, prot, flags, mobj, offs, 0, 0);
+	return vm_map_pad(uctx, va, len, prot, flags, mobj, offs, 0, 0, 0);
 }
 
 TEE_Result vm_remap(struct user_mode_ctx *uctx, vaddr_t *new_va, vaddr_t old_va,

--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -165,7 +165,7 @@ static TEE_Result system_map_zi(struct tee_ta_session *s, uint32_t param_types,
 	if (!mobj)
 		return TEE_ERROR_OUT_OF_MEMORY;
 	res = vm_map_pad(&utc->uctx, &va, num_bytes, prot, vm_flags,
-			 mobj, 0, pad_begin, pad_end);
+			 mobj, 0, pad_begin, pad_end, 0);
 	mobj_put(mobj);
 	if (!res)
 		reg_pair_from_64(va, &params[1].value.a, &params[1].value.b);
@@ -456,7 +456,7 @@ static TEE_Result system_map_ta_binary(struct system_ctx *ctx,
 		}
 		res = vm_map_pad(&utc->uctx, &va, num_rounded_bytes,
 				 prot, VM_FLAG_READONLY,
-				 mobj, 0, pad_begin, pad_end);
+				 mobj, 0, pad_begin, pad_end, 0);
 		mobj_put(mobj);
 		if (res)
 			goto err;
@@ -482,7 +482,7 @@ static TEE_Result system_map_ta_binary(struct system_ctx *ctx,
 		}
 		res = vm_map_pad(&utc->uctx, &va, num_rounded_bytes,
 				 TEE_MATTR_PRW, vm_flags, mobj, 0,
-				 pad_begin, pad_end);
+				 pad_begin, pad_end, 0);
 		mobj_put(mobj);
 		if (res)
 			goto err;


### PR DESCRIPTION
Add a parameter to the mapping function to specify the alignment needed for the requested mapping. This is useful for mapping a device like a nor flash, which needs the base address to be aligned at the flash device's sector size.