### PR TITLE
core: thread: add compiler barrier to thread_(un)mask_exceptions()

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -257,7 +257,10 @@ void __nostackcheck thread_set_exceptions(uint32_t exceptions)
 
 	cpsr &= ~(THREAD_EXCP_ALL << CPSR_F_SHIFT);
 	cpsr |= ((exceptions & THREAD_EXCP_ALL) << CPSR_F_SHIFT);
+
+	barrier();
 	write_cpsr(cpsr);
+	barrier();
 }
 #endif /*ARM32*/
 
@@ -279,7 +282,10 @@ void __nostackcheck thread_set_exceptions(uint32_t exceptions)
 
 	daif &= ~(THREAD_EXCP_ALL << DAIF_F_SHIFT);
 	daif |= ((exceptions & THREAD_EXCP_ALL) << DAIF_F_SHIFT);
+
+	barrier();
 	write_daif(daif);
+	barrier();
 }
 #endif /*ARM64*/
 

--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -247,4 +247,6 @@
 #define __compiler_atomic_store(p, val) \
 	__atomic_store_n((p), (val), __ATOMIC_RELAXED)
 
+#define barrier() asm volatile ("" : : : "memory")
+
 #endif /*COMPILER_H*/


### PR DESCRIPTION
With compiler optimizer enable (-O2) compiler generate invalid code
for thread_get_id_may_fail(). The curr_thread read got re-order
after exceptions unmask.

Signed-off-by: Khoa Hoang <admin@khoahoang.com>

code generated for thread_get_id_may_fail() when compile OPTEE with `-O2`
```
000000000e105728 <thread_get_id_may_fail>:
thread_get_id_may_fail():
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:783
 e105728:       a9be7bfd        stp     x29, x30, [sp, #-32]!
 e10572c:       910003fd        mov     x29, sp
 e105730:       f9000bf3        str     x19, [sp, #16]
read_daif():
/home/optee/qemu-optee/optee_os/core/arch/arm/include/arm64.h:313
 e105734:       d53b4233        mrs     x19, daif
 e105738:       d53b4220        mrs     x0, daif
thread_set_exceptions():
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:257
 e10573c:       121a0a73        and     w19, w19, #0x1c0
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:256
 e105740:       12177000        and     w0, w0, #0xfffffe3f
 e105744:       2a130000        orr     w0, w0, w19
write_daif():
/home/optee/qemu-optee/optee_os/core/arch/arm/include/arm64.h:313
 e105748:       32190000        orr     w0, w0, #0x80
 e10574c:       d51b4220        msr     daif, x0
get_core_pos():
/home/optee/qemu-optee/optee_os/core/arch/arm/include/kernel/misc.h:23
 e105750:       97fff08f        bl      e10198c <__get_core_pos>
read_daif():
/home/optee/qemu-optee/optee_os/core/arch/arm/include/arm64.h:313
 e105754:       d53b4221        mrs     x1, daif
thread_set_exceptions():
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:256
 e105758:       12177021        and     w1, w1, #0xfffffe3f
write_daif():
/home/optee/qemu-optee/optee_os/core/arch/arm/include/arm64.h:313
 e10575c:       2a010273        orr     w19, w19, w1
 e105760:       d51b4233        msr     daif, x19      <<<<<<< Exception get unmask here
thread_get_id_may_fail():
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:789
 e105764:       f00002a1        adrp    x1, e15c000 <__scattered_array_0pseudo_tas+0x40>
 e105768:       d37a7c00        ubfiz   x0, x0, #6, #32
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:793
 e10576c:       f9400bf3        ldr     x19, [sp, #16]
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:789
 e105770:       f941a821        ldr     x1, [x1, #848]
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:793
 e105774:       a8c27bfd        ldp     x29, x30, [sp], #32
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:789
 e105778:       8b000021        add     x1, x1, x0
/home/optee/qemu-optee/optee_os/core/arch/arm/kernel/thread.c:793
 e10577c:       b9402820        ldr     w0, [x1, #40]     <<<<<<< ERROR: read happen after enable exception
 e105780:       d65f03c0        ret
```

C code:
```
 782 int thread_get_id_may_fail(void)
 783 {
 784         /*
 785          * thread_get_core_local() requires foreign interrupts to be disabled
 786          */
 787         uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
 788         struct thread_core_local *l = thread_get_core_local();
 789         int ct = l->curr_thread;
 790 
 791         thread_unmask_exceptions(exceptions);
 792         return ct;
 793 }
```

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
