### PR TITLE
libutils: Fix fputs() when TRACE_LEVEL=0

### DIFF
--- a/lib/libutee/trace_ext.c
+++ b/lib/libutee/trace_ext.c
@@ -74,6 +74,10 @@ int putchar(int c)
 
 #else
 
+void trace_ext_puts(const char *str __unused)
+{
+}
+
 int printf(const char *fmt __unused, ...)
 {
 	return 0;


### PR DESCRIPTION
When Optee OS is compiled with TRACE_LEVEL=0, Optee test fails to
compile properly:

arm-none-linux-gnueabihf-ld.bfd: libutils.a(fputs.o): in function 'fputs':
fputs.c:15: undefined reference to 'trace_ext_puts'
link.mk:109: recipe for target '5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf' failed

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
