### PR TITLE
core: arm/kernel: i2c: add retry field

### DIFF
--- a/core/arch/arm/kernel/rpc_io_i2c.c
+++ b/core/arch/arm/kernel/rpc_io_i2c.c
@@ -38,7 +38,7 @@ TEE_Result rpc_io_i2c_transfer(struct rpc_i2c_request *req, size_t *len)
 		memcpy(va, req->buffer, req->buffer_len);
 
 	p[0] = THREAD_PARAM_VALUE(IN, req->mode, req->bus, req->chip);
-	p[1] = THREAD_PARAM_VALUE(IN, req->flags, 0, 0);
+	p[1] = THREAD_PARAM_VALUE(IN, req->flags, req->retries, 0);
 	p[2] = THREAD_PARAM_MEMREF(INOUT, mobj, 0, req->buffer_len);
 	p[3] = THREAD_PARAM_VALUE(OUT, 0, 0, 0);
 

--- a/core/include/kernel/rpc_io_i2c.h
+++ b/core/include/kernel/rpc_io_i2c.h
@@ -29,6 +29,7 @@ struct rpc_i2c_request {
 	uint16_t bus; /* bus identifier used by the REE [0..n] */
 	uint16_t chip; /* slave identifier from its data sheet */
 	uint16_t flags; /* transfer flags (ie: ten bit chip address) */
+	uint16_t retries; /* bus adaptor transfer retries */
 	uint8_t *buffer;
 	size_t buffer_len;
 };

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -158,6 +158,8 @@
  *				16 bit field (either 7 or 10 bit effective).
  * [in]     value[1].a	    The I2C master control flags (ie, 10 bit address).
  *				16 bit field.
+ * [in]     value[1].b	    The I2C bus retry attempts.
+ *				16 bit field.
  * [in/out] memref[2]	    Buffer used for data transfers.
  * [out]    value[3].a	    Number of bytes transferred by the REE.
  */


### PR DESCRIPTION
Some i2c devices do require several transfer attempts from the bus
before they acknowledge the transfers.

This commit enables OP-TEE to program this field on the i2c bus
adapter.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
