### PR TITLE
drivers: caam: fix build warning

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_prime.c
+++ b/core/drivers/crypto/caam/acipher/caam_prime.c
@@ -663,7 +663,7 @@ static void do_checks_primes(uint32_t *desc, const struct caambuf *p,
 	 * We started with 128, 192, or 256 bytes in the OFIFO before we moved
 	 * check_len bytes into MATH registers.
 	 */
-	if (p->length > 128 + check_len) {
+	if (p->length > 128 + (size_t)check_len) {
 		caam_desc_add_word(desc, MOVE(OFIFO, C1_CTX_REG, 0, check_len));
 		caam_desc_add_word(desc, MOVE(OFIFO, C1_CTX_REG, 0,
 					      (p->length - 128 - check_len)));


### PR DESCRIPTION
Compiler warns about comparison of integer expressions of different
signedness. This causes build failures when error on warning is enabled.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
