### PR TITLE
core: use C locale when generating the build date

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -128,10 +128,9 @@ version-o-cflags = $(filter-out -g3,$(core-platform-cflags) \
 			$(platform-cflags) $(cflagscore))
 # SOURCE_DATE_EPOCH defined for reproducible builds
 ifneq ($(SOURCE_DATE_EPOCH),)
-DATE_STR = `date -u -d @$(SOURCE_DATE_EPOCH)`
-else
-DATE_STR = `date -u`
+date-opts = -d @$(SOURCE_DATE_EPOCH)
 endif
+DATE_STR = `LANG=C date -u $(date-opts)`
 BUILD_COUNT_STR = `cat $(link-out-dir)/.buildcount`
 CORE_CC_VERSION = `$(CCcore) -v 2>&1 | grep "version " | sed 's/ *$$//'`
 define gen-version-o


### PR DESCRIPTION
The build date included in the version string depends on the current
locale (language), which is not very good. Force LANG=C so that english
abbreviations are used for the day and month.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
