### PR TITLE
Makefile: sort in-tree TAs in lexical order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ define build-user-ta
 ta-mk-file := $(1)
 include ta/mk/build-user-ta.mk
 endef
-$(foreach t, $(wildcard ta/*/user_ta.mk), $(eval $(call build-user-ta,$(t))))
+$(foreach t, $(sort $(wildcard ta/*/user_ta.mk)), $(eval $(call build-user-ta,$(t))))
 endif
 
 include mk/cleandirs.mk


### PR DESCRIPTION
The Makefile function $(wildcard ...) may return matching files in any
order. Therefore the "make" command is not guaranteed to always produce
the same sequence of commands when building the in-tree TAs. This could
be inconvenient when troubleshooting build errors in different
environments for instance.
In order to produce predictable builds, sort the in-tree TA makefiles in
lexical order.

Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
