### PR TITLE
core: Fix RPMB fat entry cache buffer overflow.

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1639,8 +1639,8 @@ static TEE_Result __maybe_unused fat_entry_dir_update
 	/* Use a temp var to avoid compiler warning if caching disabled. */
 	uint32_t max_cache_entries = CFG_RPMB_FS_CACHE_ENTRIES;
 
-	assert(!(fat_address - RPMB_FS_FAT_START_ADDRESS) %
-	       sizeof(struct rpmb_fat_entry));
+	assert(!((fat_address - RPMB_FS_FAT_START_ADDRESS) %
+	       sizeof(struct rpmb_fat_entry)));
 
 	/* Nothing to update if the cache is not initialized. */
 	if (!fat_entry_dir)
@@ -1650,7 +1650,8 @@ static TEE_Result __maybe_unused fat_entry_dir_update
 			     sizeof(struct rpmb_fat_entry);
 
 	/* Only need to write if index points to an entry in cache. */
-	if (fat_entry_buf_idx < max_cache_entries) {
+	if ((fat_entry_buf_idx < fat_entry_dir->num_buffered) &&
+	    (fat_entry_buf_idx < max_cache_entries)) {
 		memcpy(fat_entry_dir->rpmb_fat_entry_buf + fat_entry_buf_idx,
 		       fat_entry, sizeof(struct rpmb_fat_entry));
 	}

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -1650,8 +1650,8 @@ static TEE_Result __maybe_unused fat_entry_dir_update
 			     sizeof(struct rpmb_fat_entry);
 
 	/* Only need to write if index points to an entry in cache. */
-	if ((fat_entry_buf_idx < fat_entry_dir->num_buffered) &&
-	    (fat_entry_buf_idx < max_cache_entries)) {
+	if (fat_entry_buf_idx < fat_entry_dir->num_buffered &&
+	    fat_entry_buf_idx < max_cache_entries) {
 		memcpy(fat_entry_dir->rpmb_fat_entry_buf + fat_entry_buf_idx,
 		       fat_entry, sizeof(struct rpmb_fat_entry));
 	}


### PR DESCRIPTION
Ensure that fat_entry_dir_update can only update entries less than
the current cache size and not just the maximum size limit of the cache.
Fix an assert in fat_entry_dir_update that always fires when updating
fat entries after the first element in the cache.

Signed-off-by: Neil Shipp neilsh@microsoft.com

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
