### PR TITLE
rpmb: added error handling if encrypt_block() fails in tee_rpmb_req_pack()

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -588,10 +588,13 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 			       RPMB_NONCE_SIZE);
 
 		if (rawdata->data) {
-			if (fek)
-				encrypt_block(datafrm[i].data,
+			if (fek) {
+				res = encrypt_block(datafrm[i].data,
 					rawdata->data + (i * RPMB_DATA_SIZE),
 					*rawdata->blk_idx + i, fek, uuid);
+				if (res != TEE_SUCCESS)
+					goto func_exit;
+			}
 			else
 				memcpy(datafrm[i].data,
 				       rawdata->data + (i * RPMB_DATA_SIZE),


### PR DESCRIPTION
Return value of called function encrypt_block() is not checked in tee_rpmb_req_pack().
Added error handling to abort further processing and to return the same error code.

Signed-off-by: Stefan Schmidt <snst@meek.de>


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
