### PR TITLE
core: lpae: allocate one more translation table for ASLR

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -173,7 +173,7 @@
 #	define XLAT_TABLE_VIRTUALIZATION_EXTRA 0
 #endif
 #ifdef CFG_CORE_ASLR
-#	define XLAT_TABLE_ASLR_EXTRA 2
+#	define XLAT_TABLE_ASLR_EXTRA 3
 #else
 #	define XLAT_TABLE_ASLR_EXTRA 0
 #endif


### PR DESCRIPTION
Depending on the ASLR seed, the MMU code may run out of translation
tables and panic. For instance with seed = 0x71dfb000 in init_mem_map()
the following crash is reproducible:

 D/TC:0   core_mmu_entry_to_finer_grained:761 xlat tables used 7 / 7
 ...
 D/TC:0   tee_entry_exchange_capabilities:102 Dynamic shared memory is enabled
 E/TC:0 0 Panic 'Failed to spread pgdir on small tables' at core/arch/arm/mm/core_mmu.c:1739 <core_mmu_map_pages>
 E/TC:0 0 TEE load address @ 0x7fefb000
 E/TC:0 0 Call stack:
 E/TC:0 0  0x000000007ff06688 print_kernel_stack at optee_os/core/arch/arm/kernel/unwind_arm64.c:79
 E/TC:0 0  0x000000007ff13d24 __do_panic at optee_os/core/kernel/panic.c:24
 E/TC:0 0  0x000000007ff083d8 core_mmu_map_pages at optee_os/core/arch/arm/mm/core_mmu.c:1719
 E/TC:0 0  0x000000007ff0cf8c mobj_reg_shm_inc_map at optee_os/core/arch/arm/mm/mobj_dyn_shm.c:200
 E/TC:0 0  0x000000007ff0d5a0 mobj_inc_map at optee_os/core/arch/arm/include/mm/mobj.h:92
 E/TC:0 0  0x000000007ff03960 map_cmd_buffer at optee_os/core/arch/arm/kernel/thread_optee_smc.c:128

Fix the issue by allocating one more translation table when CFG_ASLR=y.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
