### PR TITLE
plat-stm32mp1: use SCMI reset to manage MCU hold boot

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.c
@@ -76,3 +76,18 @@ TEE_Result stm32_reset_deassert(unsigned int id, unsigned int to_us)
 
 	return TEE_SUCCESS;
 }
+
+void stm32_reset_assert_deassert_mcu(bool assert_not_deassert)
+{
+	vaddr_t rcc_base = stm32_rcc_base();
+
+	/*
+	 * The RCC_MP_GCR is a read/write register.
+	 * Assert the MCU HOLD_BOOT means clear the BOOT_MCU bit
+	 * Deassert the MCU HOLD_BOOT means set the BOOT_MCU the bit
+	 */
+	if (assert_not_deassert)
+		io_clrbits32(rcc_base + RCC_MP_GCR, RCC_MP_GCR_BOOT_MCU);
+	else
+		io_setbits32(rcc_base + RCC_MP_GCR, RCC_MP_GCR_BOOT_MCU);
+}

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -455,6 +455,9 @@
 #define RCC_MP_SREQCLRR_STPREQ_P0	BIT(0)
 #define RCC_MP_SREQCLRR_STPREQ_P1	BIT(1)
 
+/* Global Control Register */
+#define RCC_MP_GCR_BOOT_MCU		BIT(0)
+
 /* RCC_MP_APB5RST(SET|CLR)R bit fields */
 #define RCC_APB5RSTSETR_SPI6RST		BIT(0)
 #define RCC_APB5RSTSETR_I2C4RST		BIT(2)

--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -134,6 +134,7 @@ struct stm32_scmi_rd stm32_scmi0_reset_domain[] = {
 	RESET_CELL(RST_SCMI0_RNG1, RNG1_R, "rng1"),
 	RESET_CELL(RST_SCMI0_MDMA, MDMA_R, "mdma"),
 	RESET_CELL(RST_SCMI0_MCU, MCU_R, "mcu"),
+	RESET_CELL(RST_SCMI0_MCU_HOLD_BOOT, MCU_HOLD_BOOT_R, "mcu_hold_boot"),
 };
 
 struct scmi_agent_resources {
@@ -395,6 +396,9 @@ int32_t plat_scmi_rd_autonomous(unsigned int agent_id, unsigned int scmi_id,
 	if (!stm32mp_nsec_can_access_reset(rd->reset_id))
 		return SCMI_DENIED;
 
+	if (rd->reset_id == MCU_HOLD_BOOT_R)
+		return SCMI_NOT_SUPPORTED;
+
 	/* Supports only reset with context loss */
 	if (state)
 		return SCMI_NOT_SUPPORTED;
@@ -420,6 +424,13 @@ int32_t plat_scmi_rd_set_state(unsigned int agent_id, unsigned int scmi_id,
 
 	if (!stm32mp_nsec_can_access_reset(rd->reset_id))
 		return SCMI_DENIED;
+
+	if (rd->reset_id == MCU_HOLD_BOOT_R) {
+		DMSG("SCMI MCU hold boot %s",
+		     assert_not_deassert ? "set" : "release");
+		stm32_reset_assert_deassert_mcu(assert_not_deassert);
+		return SCMI_SUCCESS;
+	}
 
 	if (assert_not_deassert) {
 		DMSG("SCMI reset %u set", scmi_id);

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -571,6 +571,7 @@ bool stm32mp_nsec_can_access_reset(unsigned int reset_id)
 		shres_id = STM32MP1_SHRES_MDMA;
 		break;
 	case MCU_R:
+	case MCU_HOLD_BOOT_R:
 		shres_id = STM32MP1_SHRES_MCU;
 		break;
 	default:

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -82,6 +82,9 @@ bool stm32mp_nsec_can_access_clock(unsigned long clock_id);
 TEE_Result stm32_reset_assert(unsigned int id, unsigned int timeout_us);
 TEE_Result stm32_reset_deassert(unsigned int id, unsigned int timeout_us);
 
+/* Specific reset to manage the MCU hold boot */
+void stm32_reset_assert_deassert_mcu(bool assert_not_deassert);
+
 static inline void stm32_reset_set(unsigned int id)
 {
 	(void)stm32_reset_assert(id, 0);

--- a/core/include/dt-bindings/reset/stm32mp1-resets.h
+++ b/core/include/dt-bindings/reset/stm32mp1-resets.h
@@ -7,6 +7,7 @@
 #ifndef _DT_BINDINGS_STM32MP1_RESET_H_
 #define _DT_BINDINGS_STM32MP1_RESET_H_
 
+#define MCU_HOLD_BOOT_R	2144
 #define LTDC_R		3072
 #define DSI_R		3076
 #define DDRPERFM_R	3080
@@ -117,5 +118,6 @@
 #define RST_SCMI0_RNG1		8
 #define RST_SCMI0_MDMA		9
 #define RST_SCMI0_MCU		10
+#define RST_SCMI0_MCU_HOLD_BOOT	11
 
 #endif /* _DT_BINDINGS_STM32MP1_RESET_H_ */


### PR DESCRIPTION
Adding the MCU hold boot management through a SCMI dedicated
reset domain. MCU hold boot controls the MCU reboot sequence together
with MCU reset controller already exposed to SCMI agent 0.

Signed-off-by: Lionel Debieve <lionel.debieve@st.com>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
