### PR TITLE
drivers: scmi-msg: add SCMI Voltage Domain protocol

### DIFF
--- a/core/drivers/scmi-msg/common.h
+++ b/core/drivers/scmi-msg/common.h
@@ -127,6 +127,21 @@ scmi_msg_handler_t scmi_msg_get_rd_handler(struct scmi_msg *msg __unused)
 }
 #endif
 
+#ifdef CFG_SCMI_MSG_VOLTAGE_DOMAIN
+/*
+ * scmi_msg_get_voltd_handler - Return a handler for a voltage domain message
+ * @msg - message to process
+ * Return a function handler for the message or NULL
+ */
+scmi_msg_handler_t scmi_msg_get_voltd_handler(struct scmi_msg *msg);
+#else
+static inline
+scmi_msg_handler_t scmi_msg_get_voltd_handler(struct scmi_msg *msg __unused)
+{
+	return NULL;
+}
+#endif
+
 /*
  * Process Read, process and write response for input SCMI message
  *

--- a/core/drivers/scmi-msg/entry.c
+++ b/core/drivers/scmi-msg/entry.c
@@ -45,6 +45,9 @@ void scmi_process_message(struct scmi_msg *msg)
 	case SCMI_PROTOCOL_ID_RESET_DOMAIN:
 		handler = scmi_msg_get_rd_handler(msg);
 		break;
+	case SCMI_PROTOCOL_ID_VOLTAGE_DOMAIN:
+		handler = scmi_msg_get_voltd_handler(msg);
+		break;
 	default:
 		break;
 	}

--- a/core/drivers/scmi-msg/sub.mk
+++ b/core/drivers/scmi-msg/sub.mk
@@ -3,3 +3,4 @@ srcs-$(CFG_SCMI_MSG_CLOCK) += clock.c
 srcs-y += entry.c
 srcs-$(CFG_SCMI_MSG_RESET_DOMAIN) += reset_domain.c
 srcs-$(CFG_SCMI_MSG_SMT) += smt.c
+srcs-$(CFG_SCMI_MSG_VOLTAGE_DOMAIN) += voltage_domain.c

--- a/core/drivers/scmi-msg/voltage_domain.c
+++ b/core/drivers/scmi-msg/voltage_domain.c
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020, Linaro Limited
+ */
+#include <assert.h>
+#include <config.h>
+#include <confine_array_index.h>
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <string.h>
+#include <util.h>
+
+#include "voltage_domain.h"
+#include "common.h"
+
+static bool message_id_is_supported(unsigned int message_id);
+
+size_t __weak plat_scmi_voltd_count(unsigned int agent_id __unused)
+{
+	return 0;
+}
+
+const char __weak *plat_scmi_voltd_get_name(unsigned int agent_id __unused,
+					    unsigned int scmi_id __unused)
+{
+	return NULL;
+}
+
+int32_t __weak plat_scmi_voltd_levels_array(unsigned int agent_id __unused,
+					    unsigned int scmi_id __unused,
+					    size_t start_index __unused,
+					    long *levels __unused,
+					    size_t *nb_elts __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t __weak plat_scmi_voltd_levels_by_step(unsigned int agent_id __unused,
+					      unsigned int scmi_id __unused,
+					      long *steps __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+long __weak plat_scmi_voltd_get_level(unsigned int agent_id __unused,
+				      unsigned int scmi_id __unused)
+{
+	return 0;
+}
+
+int32_t __weak plat_scmi_voltd_set_level(unsigned int agent_id __unused,
+					 unsigned int scmi_id __unused,
+					 long microvolt __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t __weak plat_scmi_voltd_get_config(unsigned int agent_id __unused,
+					  unsigned int scmi_id __unused,
+					  uint32_t *config __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t __weak plat_scmi_voltd_set_config(unsigned int agent_id __unused,
+					  unsigned int scmi_id __unused,
+					  uint32_t config __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+static void report_version(struct scmi_msg *msg)
+{
+	struct scmi_protocol_version_p2a out_args = {
+		.status = SCMI_SUCCESS,
+		.version = SCMI_PROTOCOL_VERSION_VOLTAGE_DOMAIN,
+	};
+
+	if (IS_ENABLED(CFG_SCMI_MSG_STRICT_ABI) && msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &out_args, sizeof(out_args));
+}
+
+static void report_attributes(struct scmi_msg *msg)
+{
+	size_t domain_count = plat_scmi_voltd_count(msg->agent_id);
+	struct scmi_protocol_attributes_p2a out_args = {
+		.status = SCMI_SUCCESS,
+		.attributes = domain_count,
+	};
+
+	assert(!(domain_count & ~SCMI_VOLTAGE_DOMAIN_COUNT_MASK));
+
+	if (IS_ENABLED(CFG_SCMI_MSG_STRICT_ABI) && msg->in_size) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &out_args, sizeof(out_args));
+}
+
+static void report_message_attributes(struct scmi_msg *msg)
+{
+	struct scmi_protocol_message_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_protocol_message_attributes_p2a out_args = {
+		.status = SCMI_SUCCESS,
+		/* For this protocol, attributes shall be zero */
+		.attributes = 0,
+	};
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (!message_id_is_supported(in_args->message_id)) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	scmi_write_response(msg, &out_args, sizeof(out_args));
+}
+
+static void scmi_voltd_domain_attributes(struct scmi_msg *msg)
+{
+	const struct scmi_voltd_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_voltd_attributes_p2a out_args = {
+		.status = SCMI_SUCCESS,
+	};
+	const char *name = NULL;
+	unsigned int domain_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->domain_id >= plat_scmi_voltd_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_voltd_count(msg->agent_id));
+
+	name = plat_scmi_voltd_get_name(msg->agent_id, domain_id);
+	if (!name) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	COPY_NAME_IDENTIFIER(out_args.name, name);
+
+	scmi_write_response(msg, &out_args, sizeof(out_args));
+}
+
+#define LEVELS_BY_ARRAY(_nb_rates, _rem_rates) \
+	SCMI_VOLTAGE_DOMAIN_LEVELS_FLAGS((_nb_rates), \
+					 SCMI_VOLTD_LEVELS_FORMAT_LIST, \
+					 (_rem_rates))
+
+/* List levels array by small chunks fitting in SCMI message max payload size */
+#define LEVELS_ARRAY_SIZE_MAX_2	\
+	((SCMI_PLAYLOAD_MAX - sizeof(struct scmi_voltd_describe_levels_p2a)) / \
+	 sizeof(int32_t))
+
+#define LEVELS_ARRAY_SIZE_MAX	10
+
+#define LEVELS_BY_STEP \
+	SCMI_VOLTAGE_DOMAIN_LEVELS_FLAGS(3, SCMI_VOLTD_LEVELS_FORMAT_RANGE, 0)
+
+static void scmi_voltd_describe_levels(struct scmi_msg *msg)
+{
+	const struct scmi_voltd_describe_levels_a2p *in_args = (void *)msg->in;
+	size_t nb_levels = 0;
+	unsigned int domain_id = 0;
+	int32_t status = SCMI_GENERIC_ERROR;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		status = SCMI_PROTOCOL_ERROR;
+		goto out;
+	}
+
+	if (in_args->domain_id >= plat_scmi_voltd_count(msg->agent_id)) {
+		status = SCMI_INVALID_PARAMETERS;
+		goto out;
+	}
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_voltd_count(msg->agent_id));
+
+	/* Platform may support array rate description */
+	status = plat_scmi_voltd_levels_array(msg->agent_id, domain_id, 0, NULL,
+					      &nb_levels);
+	if (status == SCMI_SUCCESS) {
+		/* Use the stack to get the returned portion of levels array */
+		long plat_levels[LEVELS_ARRAY_SIZE_MAX];
+		size_t ret_nb = 0;
+		size_t rem_nb = 0;
+
+		if (in_args->level_index >= nb_levels) {
+			status = SCMI_INVALID_PARAMETERS;
+			goto out;
+		}
+
+		ret_nb = MIN(ARRAY_SIZE(plat_levels),
+			     nb_levels - in_args->level_index);
+		rem_nb = nb_levels - in_args->level_index - ret_nb;
+
+		status =  plat_scmi_voltd_levels_array(msg->agent_id, domain_id,
+						       in_args->level_index,
+						       plat_levels,
+						       &ret_nb);
+		if (status == SCMI_SUCCESS) {
+			struct scmi_voltd_describe_levels_p2a out_args = {
+				.flags = LEVELS_BY_ARRAY(ret_nb, rem_nb),
+				.status = SCMI_SUCCESS,
+			};
+			int32_t *voltage = NULL;
+			size_t i = 0;
+
+			/* By construction these values are 32bit aligned */
+			voltage = (int32_t *)(uintptr_t)(msg->out +
+							 sizeof(out_args));
+
+			for (i = 0; i < ret_nb; i++)
+				voltage[i] = plat_levels[i];
+
+			memcpy(msg->out, &out_args, sizeof(out_args));
+
+			msg->out_size_out = sizeof(out_args) +
+					    ret_nb * sizeof(uint32_t);
+		}
+	} else if (status == SCMI_NOT_SUPPORTED) {
+		long triplet[3] = { 0, 0, 0 };
+
+		/* Platform may support min/max/step triplet description */
+		status =  plat_scmi_voltd_levels_by_step(msg->agent_id,
+							 domain_id, triplet);
+		if (status == SCMI_SUCCESS) {
+			struct scmi_voltd_describe_levels_p2a out_args = {
+				.flags = LEVELS_BY_STEP,
+				.status = SCMI_SUCCESS,
+			};
+			int32_t *voltage = NULL;
+
+			/* By construction these values are 32bit aligned */
+			voltage = (int32_t *)(uintptr_t)(msg->out +
+							 sizeof(out_args));
+			voltage[0] = triplet[0];
+			voltage[1] = triplet[1];
+			voltage[2] = triplet[2];
+
+			memcpy(msg->out, &out_args, sizeof(out_args));
+
+			msg->out_size_out = sizeof(out_args) +
+					    3 * sizeof(int32_t);
+		}
+	}
+
+out:
+	if (status)
+		scmi_status_response(msg, status);
+}
+
+static void scmi_voltd_config_set(struct scmi_msg *msg)
+{
+	const struct scmi_voltd_config_set_a2p *in_args = (void *)msg->in;
+	unsigned int domain_id = 0;
+	unsigned long config = 0;
+	int32_t status = SCMI_GENERIC_ERROR;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->domain_id >= plat_scmi_voltd_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_voltd_count(msg->agent_id));
+
+	config = in_args->config & SCMI_VOLTAGE_DOMAIN_CONFIG_MASK;
+
+	status = plat_scmi_voltd_set_config(msg->agent_id, domain_id, config);
+
+	scmi_status_response(msg, status);
+}
+
+static void scmi_voltd_config_get(struct scmi_msg *msg)
+{
+	const struct scmi_voltd_config_get_a2p *in_args = (void *)msg->in;
+	struct scmi_voltd_config_get_p2a out_args = { };
+	unsigned int domain_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->domain_id >= plat_scmi_voltd_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_voltd_count(msg->agent_id));
+
+	if (plat_scmi_voltd_get_config(msg->agent_id, domain_id,
+				       &out_args.config)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	scmi_write_response(msg, &out_args, sizeof(out_args));
+}
+
+static void scmi_voltd_level_set(struct scmi_msg *msg)
+{
+	const struct scmi_voltd_level_set_a2p *in_args = (void *)msg->in;
+	int32_t status = SCMI_GENERIC_ERROR;
+	unsigned int domain_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->domain_id >= plat_scmi_voltd_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_voltd_count(msg->agent_id));
+
+	status = plat_scmi_voltd_set_level(msg->agent_id, domain_id,
+					   in_args->voltage_level);
+
+	scmi_status_response(msg, status);
+}
+
+static void scmi_voltd_level_get(struct scmi_msg *msg)
+{
+	const struct scmi_voltd_level_get_a2p *in_args = (void *)msg->in;
+	struct scmi_voltd_level_get_p2a out_args = {
+		.status = SCMI_SUCCESS,
+	};
+	unsigned int domain_id = 0;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (in_args->domain_id >= plat_scmi_voltd_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	domain_id = confine_array_index(in_args->domain_id,
+					plat_scmi_voltd_count(msg->agent_id));
+
+	out_args.voltage_level = plat_scmi_voltd_get_level(msg->agent_id,
+							   domain_id);
+
+	scmi_write_response(msg, &out_args, sizeof(out_args));
+}
+
+static const scmi_msg_handler_t handler_array[] = {
+	[SCMI_PROTOCOL_VERSION] = report_version,
+	[SCMI_PROTOCOL_ATTRIBUTES] = report_attributes,
+	[SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] = report_message_attributes,
+	[SCMI_VOLTAGE_DOMAIN_ATTRIBUTES] = scmi_voltd_domain_attributes,
+	[SCMI_VOLTAGE_DESCRIBE_LEVELS] = scmi_voltd_describe_levels,
+	[SCMI_VOLTAGE_CONFIG_SET] = scmi_voltd_config_set,
+	[SCMI_VOLTAGE_CONFIG_GET] = scmi_voltd_config_get,
+	[SCMI_VOLTAGE_LEVEL_SET] = scmi_voltd_level_set,
+	[SCMI_VOLTAGE_LEVEL_GET] = scmi_voltd_level_get,
+};
+
+static bool message_id_is_supported(size_t id)
+{
+	return id < ARRAY_SIZE(handler_array) && handler_array[id];
+}
+
+scmi_msg_handler_t scmi_msg_get_voltd_handler(struct scmi_msg *msg)
+{
+	const size_t array_size = ARRAY_SIZE(handler_array);
+	unsigned int message_id = 0;
+
+	if (msg->message_id >= array_size) {
+		DMSG("Voltage domain handle not found %u", msg->message_id);
+		return NULL;
+	}
+
+	message_id = confine_array_index(msg->message_id, array_size);
+
+	return handler_array[message_id];
+}

--- a/core/drivers/scmi-msg/voltage_domain.h
+++ b/core/drivers/scmi-msg/voltage_domain.h
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef SCMI_MSG_VOLTAGE_DOMAIN_H
+#define SCMI_MSG_VOLTAGE_DOMAIN_H
+
+#include <stdint.h>
+#include <util.h>
+
+#define SCMI_PROTOCOL_VERSION_VOLTAGE_DOMAIN	0x30000
+
+/*
+ * Identifiers of the SCMI Clock Management Protocol commands
+ */
+enum scmi_voltd_command_id {
+	SCMI_VOLTAGE_DOMAIN_ATTRIBUTES = 0x3,
+	SCMI_VOLTAGE_DESCRIBE_LEVELS = 0x4,
+	SCMI_VOLTAGE_CONFIG_SET = 0x5,
+	SCMI_VOLTAGE_CONFIG_GET = 0x6,
+	SCMI_VOLTAGE_LEVEL_SET = 0x7,
+	SCMI_VOLTAGE_LEVEL_GET = 0x8,
+};
+
+#define SCMI_VOLTAGE_DOMAIN_COUNT_MASK		GENMASK_32(15, 0)
+
+struct scmi_voltd_protocol_attrs_p2a {
+	int32_t status;
+	uint32_t attributes;
+};
+
+struct scmi_voltd_attributes_a2p {
+	uint32_t domain_id;
+};
+
+#define SCMI_VOLTAGE_DOMAIN_NAME_MAX		16
+
+struct scmi_voltd_attributes_p2a {
+	int32_t status;
+	uint32_t attributes;
+	char name[SCMI_VOLTAGE_DOMAIN_NAME_MAX];
+};
+
+struct scmi_voltd_describe_levels_a2p {
+	uint32_t domain_id;
+	uint32_t level_index;
+};
+
+#define SCMI_VOLTD_LEVELS_REMAINING_MASK	GENMASK_32(31, 16)
+#define SCMI_VOLTD_LEVELS_REMAINING_POS		16
+
+#define SCMI_VOLTD_LEVELS_FORMAT_RANGE 1
+#define SCMI_VOLTD_LEVELS_FORMAT_LIST  0
+#define SCMI_VOLTD_LEVELS_FORMAT_MASK		BIT(12)
+#define SCMI_VOLTD_LEVELS_FORMAT_POS		12
+
+#define SCMI_VOLTD_LEVELS_COUNT_MASK		GENMASK_32(11, 0)
+
+#define SCMI_VOLTAGE_DOMAIN_LEVELS_FLAGS(_count, _fmt, _rem_rates) \
+	( \
+		((_count) & SCMI_VOLTD_LEVELS_COUNT_MASK) | \
+		(((_rem_rates) << SCMI_VOLTD_LEVELS_REMAINING_POS) & \
+		 SCMI_VOLTD_LEVELS_REMAINING_MASK) | \
+		(((_fmt) << SCMI_VOLTD_LEVELS_FORMAT_POS) & \
+		 SCMI_VOLTD_LEVELS_FORMAT_MASK) \
+	)
+
+struct scmi_voltd_level {
+	int32_t mircovolt;
+};
+
+struct scmi_voltd_describe_levels_p2a {
+	int32_t status;
+	uint32_t flags;
+	struct scmi_voltd_level voltage[];
+};
+
+struct scmi_voltd_level_set_a2p {
+	uint32_t domain_id;
+	uint32_t flags;
+	int32_t voltage_level;
+};
+
+struct scmi_voltd_level_set_p2a {
+	uint32_t status;
+};
+
+struct scmi_voltd_level_get_a2p {
+	uint32_t domain_id;
+};
+
+struct scmi_voltd_level_get_p2a {
+	int32_t status;
+	int32_t voltage_level;
+};
+
+#define SCMI_VOLTAGE_DOMAIN_CONFIG_MASK		GENMASK_32(3, 0)
+
+struct scmi_voltd_config_set_a2p {
+	uint32_t domain_id;
+	uint32_t config;
+};
+
+struct scmi_voltd_config_set_p2a {
+	uint32_t status;
+};
+
+struct scmi_voltd_config_get_a2p {
+	uint32_t domain_id;
+};
+
+struct scmi_voltd_config_get_p2a {
+	int32_t status;
+	uint32_t config;
+};
+
+#endif /* SCMI_MSG_CLOCK_H */

--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -224,4 +224,86 @@ int32_t plat_scmi_rd_autonomous(unsigned int agent_id, unsigned int scmi_id,
 int32_t plat_scmi_rd_set_state(unsigned int agent_id, unsigned int scmi_id,
 			       bool assert_not_deassert);
 
+/* Handlers for SCMI Voltage Domain protocol services */
+
+/*
+ * Return number of voltage domain for an agent
+ * @agent_id: SCMI agent ID
+ * Return number of voltage domains
+ */
+size_t plat_scmi_voltd_count(unsigned int agent_id);
+
+/*
+ * Get clock controller string ID (aka name)
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI voltage domain ID
+ * Return pointer to name or NULL
+ */
+const char *plat_scmi_voltd_get_name(unsigned int agent_id,
+				     unsigned int scmi_id);
+
+/*
+ * Get voltage domain possible levels as an array of voltages in microvolt.
+ *
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI voltage domain ID
+ * @levels: If NULL, function returns, else output rates array
+ * @start_index: Level index to start from.
+ * @nb_elts: Array size of @levels.
+ * Return an SCMI compliant error code
+ */
+int32_t plat_scmi_voltd_levels_array(unsigned int agent_id,
+				     unsigned int scmi_id, size_t start_index,
+				     long *levels, size_t *nb_elts);
+
+/*
+ * Get voltage domain possible levels as range with regular steps in microvolt
+ *
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI voltage domain ID
+ * @min_max_step: 3 cell array for min, max and step voltage data
+ * Return an SCMI compliant error code
+ */
+int32_t plat_scmi_voltd_levels_by_step(unsigned int agent_id,
+				       unsigned int scmi_id,
+				       long *min_max_step);
+
+/*
+ * Get current voltage domain level in microvolt
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI voltage domain ID
+ * Return clock rate or 0 if not supported
+ */
+long plat_scmi_voltd_get_level(unsigned int agent_id, unsigned int scmi_id);
+
+/*
+ * Set voltage domain level voltage domain
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * @level: Target voltage domain level in microvolt
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_voltd_set_level(unsigned int agent_id, unsigned int scmi_id,
+				  long level);
+
+/*
+ * Get voltage domain state configuration (enabled or disabled)
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI voltage domain ID
+ * @config: output state configuration value
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_voltd_get_config(unsigned int agent_id, unsigned int scmi_id,
+				   uint32_t *config);
+
+/*
+ * Get voltage domain state configuration (enabled or disabled)
+ * @agent_id: SCMI agent ID
+ * @scmi_id: SCMI clock ID
+ * @enable_not_disable: Enable clock if true, disable clock otherwise
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_voltd_set_config(unsigned int agent_id, unsigned int scmi_id,
+				   uint32_t config);
+
 #endif /* SCMI_MSG_H */

--- a/core/include/drivers/scmi.h
+++ b/core/include/drivers/scmi.h
@@ -12,6 +12,7 @@
 #define SCMI_PROTOCOL_ID_CLOCK			0x14
 #define SCMI_PROTOCOL_ID_SENSOR			0x15
 #define SCMI_PROTOCOL_ID_RESET_DOMAIN		0x16
+#define SCMI_PROTOCOL_ID_VOLTAGE_DOMAIN		0x17
 
 /* SCMI error codes reported to agent through server-to-agent messages */
 #define SCMI_SUCCESS			0


### PR DESCRIPTION
SCMI Voltage Domain protocol in defined in the SCMI specification [1]
since its version 3. This protocol allows a SCMI server to expose
voltage regulator control services. The current specific (v3) defines
services to discover the exposed regulators, to enable/disable them
and to set/get the regulator voltage level.

The protocol driver is embedded upon configuration switch
CFG_SCMI_MSG_VOLTAGE_DOMAIN.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
