### PR TITLE
[RFC] Trusted Service abstraction

### DIFF
--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -6,10 +6,11 @@
 #ifndef KERNEL_ABORT_H
 #define KERNEL_ABORT_H
 
-#define ABORT_TYPE_UNDEF	0
-#define ABORT_TYPE_PREFETCH	1
-#define ABORT_TYPE_DATA		2
-#define ABORT_TYPE_TA_PANIC	3 /* Dump stack on TA panic (not an abort) */
+#define ABORT_TYPE_UNDEF		0
+#define ABORT_TYPE_PREFETCH		1
+#define ABORT_TYPE_DATA			2
+/* Dump stack on user mode panic (not an abort) */
+#define ABORT_TYPE_USER_MODE_PANIC	3
 
 #ifndef __ASSEMBLER__
 

--- a/core/arch/arm/include/kernel/pseudo_ta.h
+++ b/core/arch/arm/include/kernel/pseudo_ta.h
@@ -49,12 +49,12 @@ struct pseudo_ta_ctx {
 	struct tee_ta_ctx ctx;
 };
 
-bool is_pseudo_ta_ctx(struct tee_ta_ctx *ctx);
+bool is_pseudo_ta_ctx(struct ts_ctx *ctx);
 
-static inline struct pseudo_ta_ctx *to_pseudo_ta_ctx(struct tee_ta_ctx *ctx)
+static inline struct pseudo_ta_ctx *to_pseudo_ta_ctx(struct ts_ctx *ctx)
 {
 	assert(is_pseudo_ta_ctx(ctx));
-	return container_of(ctx, struct pseudo_ta_ctx, ctx);
+	return container_of(ctx, struct pseudo_ta_ctx, ctx.ts_ctx);
 }
 
 TEE_Result tee_ta_init_pseudo_ta_session(const TEE_UUID *uuid,

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -134,16 +134,16 @@ struct sec_part_ctx {
 
 extern const struct tee_ta_ops secure_partition_ops;
 
-static inline bool is_sp_ctx(struct tee_ta_ctx *ctx __maybe_unused)
+static inline bool is_sp_ctx(struct ts_ctx *ctx __maybe_unused)
 {
 	return IS_ENABLED(CFG_WITH_SECURE_PARTITION) &&
 	       ctx && ctx->ops == &secure_partition_ops;
 }
 
-static inline struct sec_part_ctx *to_sec_part_ctx(struct tee_ta_ctx *ctx)
+static inline struct sec_part_ctx *to_sec_part_ctx(struct ts_ctx *ctx)
 {
 	assert(is_sp_ctx(ctx));
-	return container_of(ctx, struct sec_part_ctx, uctx.ctx);
+	return container_of(ctx, struct sec_part_ctx, uctx.ctx.ts_ctx);
 }
 
 #ifdef CFG_WITH_SECURE_PARTITION

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -126,6 +126,7 @@ struct secure_partition_boot_info {
 
 struct sec_part_ctx {
 	struct user_mode_ctx uctx;
+	struct tee_ta_ctx ta_ctx;
 	struct thread_ctx_regs regs;
 	vaddr_t ns_comm_buf_addr;
 	unsigned int ns_comm_buf_size;
@@ -143,7 +144,7 @@ static inline bool is_sp_ctx(struct ts_ctx *ctx __maybe_unused)
 static inline struct sec_part_ctx *to_sec_part_ctx(struct ts_ctx *ctx)
 {
 	assert(is_sp_ctx(ctx));
-	return container_of(ctx, struct sec_part_ctx, uctx.ctx.ts_ctx);
+	return container_of(ctx, struct sec_part_ctx, ta_ctx.ts_ctx);
 }
 
 #ifdef CFG_WITH_SECURE_PARTITION

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -132,7 +132,7 @@ struct sec_part_ctx {
 	bool is_initializing;
 };
 
-extern const struct tee_ta_ops secure_partition_ops;
+extern const struct ts_ops secure_partition_ops;
 
 static inline bool is_sp_ctx(struct ts_ctx *ctx __maybe_unused)
 {

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -233,7 +233,7 @@ struct thread_ctx_regs {
 #endif /*ARM64*/
 
 struct thread_specific_data {
-	TAILQ_HEAD(, tee_ta_session) sess_stack;
+	TAILQ_HEAD(, ts_session) sess_stack;
 	struct tee_ta_ctx *ctx;
 	struct pgt_cache pgt_cache;
 #ifdef CFG_CORE_FFA

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -234,7 +234,7 @@ struct thread_ctx_regs {
 
 struct thread_specific_data {
 	TAILQ_HEAD(, ts_session) sess_stack;
-	struct tee_ta_ctx *ctx;
+	struct ts_ctx *ctx;
 	struct pgt_cache pgt_cache;
 #ifdef CFG_CORE_FFA
 	uint32_t rpc_target_info;

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -62,18 +62,18 @@ struct user_ta_ctx {
 };
 
 #ifdef CFG_WITH_USER_TA
-bool is_user_ta_ctx(struct tee_ta_ctx *ctx);
+bool is_user_ta_ctx(struct ts_ctx *ctx);
 #else
-static inline bool is_user_ta_ctx(struct tee_ta_ctx *ctx __unused)
+static inline bool is_user_ta_ctx(struct ts_ctx *ctx __unused)
 {
 	return false;
 }
 #endif
 
-static inline struct user_ta_ctx *to_user_ta_ctx(struct tee_ta_ctx *ctx)
+static inline struct user_ta_ctx *to_user_ta_ctx(struct ts_ctx *ctx)
 {
 	assert(is_user_ta_ctx(ctx));
-	return container_of(ctx, struct user_ta_ctx, uctx.ctx);
+	return container_of(ctx, struct user_ta_ctx, uctx.ctx.ts_ctx);
 }
 
 struct user_ta_store_ops;

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -59,6 +59,7 @@ struct user_ta_ctx {
 	vaddr_t stack_ptr;
 	void *ta_time_offs;
 	struct user_mode_ctx uctx;
+	struct tee_ta_ctx ta_ctx;
 };
 
 #ifdef CFG_WITH_USER_TA
@@ -73,7 +74,7 @@ static inline bool is_user_ta_ctx(struct ts_ctx *ctx __unused)
 static inline struct user_ta_ctx *to_user_ta_ctx(struct ts_ctx *ctx)
 {
 	assert(is_user_ta_ctx(ctx));
-	return container_of(ctx, struct user_ta_ctx, uctx.ctx.ts_ctx);
+	return container_of(ctx, struct user_ta_ctx, ta_ctx.ts_ctx);
 }
 
 struct user_ta_store_ops;

--- a/core/arch/arm/include/mm/pgt_cache.h
+++ b/core/arch/arm/include/mm/pgt_cache.h
@@ -19,11 +19,13 @@
 #include <types_ext.h>
 #include <util.h>
 
+struct ts_ctx;
+
 struct pgt {
 	void *tbl;
 #if defined(CFG_PAGED_USER_TA)
 	vaddr_t vabase;
-	struct tee_ta_ctx *ctx;
+	struct ts_ctx *ctx;
 	size_t num_used_entries;
 #endif
 #if defined(CFG_WITH_PAGER)
@@ -55,16 +57,16 @@ static inline bool pgt_check_avail(size_t num_tbls)
 	return num_tbls <= PGT_CACHE_SIZE;
 }
 
-void pgt_alloc(struct pgt_cache *pgt_cache, void *owning_ctx,
+void pgt_alloc(struct pgt_cache *pgt_cache, struct ts_ctx *owning_ctx,
 	       vaddr_t begin, vaddr_t last);
 void pgt_free(struct pgt_cache *pgt_cache, bool save_ctx);
 
 #ifdef CFG_PAGED_USER_TA
-void pgt_flush_ctx_range(struct pgt_cache *pgt_cache, void *ctx,
+void pgt_flush_ctx_range(struct pgt_cache *pgt_cache, struct ts_ctx *ctx,
 			 vaddr_t begin, vaddr_t last);
 #else
 static inline void pgt_flush_ctx_range(struct pgt_cache *pgt_cache __unused,
-				       void *ctx __unused,
+				       struct ts_ctx *ctx __unused,
 				       vaddr_t begin __unused,
 				       vaddr_t last __unused)
 {
@@ -74,7 +76,7 @@ static inline void pgt_flush_ctx_range(struct pgt_cache *pgt_cache __unused,
 void pgt_init(void);
 
 #if defined(CFG_PAGED_USER_TA)
-void pgt_flush_ctx(struct tee_ta_ctx *ctx);
+void pgt_flush_ctx(struct ts_ctx *ctx);
 
 static inline void pgt_inc_used_entries(struct pgt *pgt)
 {
@@ -94,7 +96,7 @@ static inline void pgt_set_used_entries(struct pgt *pgt, size_t val)
 }
 
 #else
-static inline void pgt_flush_ctx(struct tee_ta_ctx *ctx __unused)
+static inline void pgt_flush_ctx(struct ts_ctx *ctx __unused)
 {
 }
 

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -19,8 +19,8 @@
 #include "thread_private.h"
 
 enum fault_type {
-	FAULT_TYPE_USER_TA_PANIC,
-	FAULT_TYPE_USER_TA_VFP,
+	FAULT_TYPE_USER_MODE_PANIC,
+	FAULT_TYPE_USER_MODE_VFP,
 	FAULT_TYPE_PAGEABLE,
 	FAULT_TYPE_IGNORE,
 };
@@ -247,8 +247,8 @@ void abort_print_current_ta(void)
 	ai.pc = tsd->abort_regs.elr;
 	ai.regs = &tsd->abort_regs;
 
-	if (ai.abort_type != ABORT_TYPE_TA_PANIC)
-		__print_abort_info(&ai, "User TA");
+	if (ai.abort_type != ABORT_TYPE_USER_MODE_PANIC)
+		__print_abort_info(&ai, "User mode");
 
 	s->ctx->ops->dump_state(s->ctx);
 
@@ -322,7 +322,7 @@ static void set_abort_info(uint32_t abort_type __unused,
 #endif /*ARM64*/
 
 #ifdef ARM32
-static void handle_user_ta_panic(struct abort_info *ai)
+static void handle_user_mode_panic(struct abort_info *ai)
 {
 	/*
 	 * It was a user exception, stop user execution and return
@@ -344,7 +344,7 @@ static void handle_user_ta_panic(struct abort_info *ai)
 #endif /*ARM32*/
 
 #ifdef ARM64
-static void handle_user_ta_panic(struct abort_info *ai)
+static void handle_user_mode_panic(struct abort_info *ai)
 {
 	uint32_t daif;
 
@@ -365,7 +365,7 @@ static void handle_user_ta_panic(struct abort_info *ai)
 #endif /*ARM64*/
 
 #ifdef CFG_WITH_VFP
-static void handle_user_ta_vfp(void)
+static void handle_user_mode_vfp(void)
 {
 	struct tee_ta_session *s;
 
@@ -446,9 +446,9 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 {
 	if (abort_is_user_exception(ai)) {
 		if (is_vfp_fault(ai))
-			return FAULT_TYPE_USER_TA_VFP;
+			return FAULT_TYPE_USER_MODE_VFP;
 #ifndef CFG_WITH_PAGER
-		return FAULT_TYPE_USER_TA_PANIC;
+		return FAULT_TYPE_USER_MODE_PANIC;
 #endif
 	}
 
@@ -459,7 +459,7 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 
 	if (ai->abort_type == ABORT_TYPE_UNDEF) {
 		if (abort_is_user_exception(ai))
-			return FAULT_TYPE_USER_TA_PANIC;
+			return FAULT_TYPE_USER_MODE_PANIC;
 		abort_print_error(ai);
 		panic("[abort] undefined abort (trap CPU)");
 	}
@@ -467,14 +467,14 @@ static enum fault_type get_fault_type(struct abort_info *ai)
 	switch (core_mmu_get_fault_type(ai->fault_descr)) {
 	case CORE_MMU_FAULT_ALIGNMENT:
 		if (abort_is_user_exception(ai))
-			return FAULT_TYPE_USER_TA_PANIC;
+			return FAULT_TYPE_USER_MODE_PANIC;
 		abort_print_error(ai);
 		panic("[abort] alignement fault!  (trap CPU)");
 		break;
 
 	case CORE_MMU_FAULT_ACCESS_BIT:
 		if (abort_is_user_exception(ai))
-			return FAULT_TYPE_USER_TA_PANIC;
+			return FAULT_TYPE_USER_MODE_PANIC;
 		abort_print_error(ai);
 		panic("[abort] access bit fault!  (trap CPU)");
 		break;
@@ -515,15 +515,15 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 	switch (get_fault_type(&ai)) {
 	case FAULT_TYPE_IGNORE:
 		break;
-	case FAULT_TYPE_USER_TA_PANIC:
+	case FAULT_TYPE_USER_MODE_PANIC:
 		DMSG("[abort] abort in User mode (TA will panic)");
 		save_abort_info_in_tsd(&ai);
 		vfp_disable();
-		handle_user_ta_panic(&ai);
+		handle_user_mode_panic(&ai);
 		break;
 #ifdef CFG_WITH_VFP
-	case FAULT_TYPE_USER_TA_VFP:
-		handle_user_ta_vfp();
+	case FAULT_TYPE_USER_MODE_VFP:
+		handle_user_mode_vfp();
 		break;
 #endif
 	case FAULT_TYPE_PAGEABLE:
@@ -543,7 +543,7 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
 			DMSG("[abort] abort in User mode (TA will panic)");
 			save_abort_info_in_tsd(&ai);
 			vfp_disable();
-			handle_user_ta_panic(&ai);
+			handle_user_mode_panic(&ai);
 		}
 		break;
 	}

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -236,10 +236,7 @@ void abort_print_current_ta(void)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
 	struct abort_info ai = { };
-	struct tee_ta_session *s = NULL;
-
-	if (tee_ta_get_current_session(&s) != TEE_SUCCESS)
-		panic();
+	struct ts_session *s = ts_get_current_session();
 
 	ai.abort_type = tsd->abort_type;
 	ai.fault_descr = tsd->abort_descr;
@@ -367,10 +364,7 @@ static void handle_user_mode_panic(struct abort_info *ai)
 #ifdef CFG_WITH_VFP
 static void handle_user_mode_vfp(void)
 {
-	struct tee_ta_session *s;
-
-	if (tee_ta_get_current_session(&s) != TEE_SUCCESS)
-		panic();
+	struct ts_session *s = ts_get_current_session();
 
 	thread_user_enable_vfp(&to_user_mode_ctx(s->ctx)->vfp);
 }

--- a/core/arch/arm/kernel/pseudo_ta.c
+++ b/core/arch/arm/kernel/pseudo_ta.c
@@ -231,7 +231,7 @@ static void pseudo_ta_destroy(struct ts_ctx *ctx)
 	free(to_pseudo_ta_ctx(ctx));
 }
 
-static const struct tee_ta_ops pseudo_ta_ops = {
+static const struct ts_ops pseudo_ta_ops = {
 	.enter_open_session = pseudo_ta_enter_open_session,
 	.enter_invoke_cmd = pseudo_ta_enter_invoke_cmd,
 	.enter_close_session = pseudo_ta_enter_close_session,

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -742,7 +742,7 @@ static bool spm_handle_svc(struct thread_svc_regs *regs)
 	}
 }
 
-const struct tee_ta_ops secure_partition_ops __rodata_unpaged = {
+const struct ts_ops secure_partition_ops __rodata_unpaged = {
 	.enter_open_session = stmm_enter_open_session,
 	.enter_invoke_cmd = stmm_enter_invoke_cmd,
 	.enter_close_session = stmm_enter_close_session,

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -611,23 +611,17 @@ static bool is_from_user(uint32_t cpsr)
 #ifdef CFG_SYSCALL_FTRACE
 static void __noprof ftrace_suspend(void)
 {
-	struct tee_ta_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
+	struct ts_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
 
-	if (!s)
-		return;
-
-	if (s->fbuf)
+	if (s && s->fbuf)
 		s->fbuf->syscall_trace_suspended = true;
 }
 
 static void __noprof ftrace_resume(void)
 {
-	struct tee_ta_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
+	struct ts_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
 
-	if (!s)
-		return;
-
-	if (s->fbuf)
+	if (s && s->fbuf)
 		s->fbuf->syscall_trace_suspended = false;
 }
 #else
@@ -1528,7 +1522,7 @@ static void setup_unwind_user_mode(struct thread_svc_regs *regs)
  */
 void __weak thread_svc_handler(struct thread_svc_regs *regs)
 {
-	struct tee_ta_session *sess = NULL;
+	struct ts_session *sess = NULL;
 	uint32_t state = 0;
 
 	/* Enable native interrupts */
@@ -1543,7 +1537,7 @@ void __weak thread_svc_handler(struct thread_svc_regs *regs)
 	/* Restore foreign interrupts which are disabled on exception entry */
 	thread_restore_foreign_intr();
 
-	tee_ta_get_current_session(&sess);
+	sess = ts_get_current_session();
 	assert(sess && sess->ctx->ops && sess->ctx->ops->handle_svc);
 	if (sess->ctx->ops->handle_svc(regs)) {
 		/* We're about to switch back to user mode */

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -145,14 +145,14 @@ static void dec_recursion(void)
 }
 
 static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
-			struct tee_ta_session *session,
-			enum utee_entry_func func, uint32_t cmd,
-			struct tee_ta_param *param)
+				struct ts_session *session,
+				enum utee_entry_func func, uint32_t cmd,
+				struct tee_ta_param *param)
 {
 	TEE_Result res = TEE_SUCCESS;
 	struct utee_params *usr_params = NULL;
 	uaddr_t usr_stack = 0;
-	struct user_ta_ctx *utc = to_user_ta_ctx(session->ts_sess.ctx);
+	struct user_ta_ctx *utc = to_user_ta_ctx(session->ctx);
 	TEE_ErrorOrigin serr = TEE_ORIGIN_TEE;
 	struct ts_session *ts_sess __maybe_unused = NULL;
 	void *param_va[TEE_NUM_PARAMS] = { NULL };
@@ -169,7 +169,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 		goto out;
 
 	/* Switch to user ctx */
-	ts_push_current_session(&session->ts_sess);
+	ts_push_current_session(session);
 
 	/* Make room for usr_params at top of stack */
 	usr_stack = utc->stack_ptr;
@@ -208,7 +208,7 @@ static TEE_Result user_ta_enter(TEE_ErrorOrigin *err,
 	tee_mmu_clean_param(&utc->uctx);
 
 	ts_sess = ts_pop_current_session();
-	assert(ts_sess == &session->ts_sess);
+	assert(ts_sess == session);
 
 out:
 	dec_recursion();
@@ -218,7 +218,7 @@ out_clr_cancel:
 	 * time the TA will be invoked will be with a new operation and should
 	 * not have an old cancellation pending.
 	 */
-	session->cancel = false;
+	to_ta_session(session)->cancel = false;
 
 	/*
 	 * Can't update *err until now since it may point to an address
@@ -229,7 +229,7 @@ out_clr_cancel:
 	return res;
 }
 
-static TEE_Result init_with_ldelf(struct tee_ta_session *sess __maybe_unused,
+static TEE_Result init_with_ldelf(struct ts_session *sess __maybe_unused,
 				  struct user_ta_ctx *utc)
 {
 	TEE_Result res = TEE_SUCCESS;
@@ -242,7 +242,7 @@ static TEE_Result init_with_ldelf(struct tee_ta_session *sess __maybe_unused,
 	usr_stack -= ROUNDUP(sizeof(*arg), STACK_ALIGNMENT);
 	arg = (struct ldelf_arg *)usr_stack;
 	memset(arg, 0, sizeof(*arg));
-	arg->uuid = utc->uctx.ctx.uuid;
+	arg->uuid = utc->uctx.ctx.ts_ctx.uuid;
 
 	res = thread_enter_user_mode((vaddr_t)arg, 0, 0, 0,
 				     usr_stack, utc->entry_func,
@@ -279,30 +279,31 @@ static TEE_Result init_with_ldelf(struct tee_ta_session *sess __maybe_unused,
 	utc->dump_entry_func = arg->dump_entry;
 #ifdef CFG_FTRACE_SUPPORT
 	utc->ftrace_entry_func = arg->ftrace_entry;
-	sess->ts_sess.fbuf = arg->fbuf;
+	sess->fbuf = arg->fbuf;
 #endif
 	utc->dl_entry_func = arg->dl_entry;
 
 	return TEE_SUCCESS;
 }
 
-static TEE_Result user_ta_enter_open_session(struct tee_ta_session *s,
-			struct tee_ta_param *param, TEE_ErrorOrigin *eo)
+static TEE_Result user_ta_enter_open_session(struct ts_session *s,
+					     struct tee_ta_param *param,
+					     TEE_ErrorOrigin *eo)
 {
 	return user_ta_enter(eo, s, UTEE_ENTRY_FUNC_OPEN_SESSION, 0, param);
 }
 
-static TEE_Result user_ta_enter_invoke_cmd(struct tee_ta_session *s,
-			uint32_t cmd, struct tee_ta_param *param,
-			TEE_ErrorOrigin *eo)
+static TEE_Result user_ta_enter_invoke_cmd(struct ts_session *s, uint32_t cmd,
+					   struct tee_ta_param *param,
+					   TEE_ErrorOrigin *eo)
 {
 	return user_ta_enter(eo, s, UTEE_ENTRY_FUNC_INVOKE_COMMAND, cmd, param);
 }
 
-static void user_ta_enter_close_session(struct tee_ta_session *s)
+static void user_ta_enter_close_session(struct ts_session *s)
 {
 	/* Only if the TA was fully initialized by ldelf */
-	if (!to_user_ta_ctx(s->ts_sess.ctx)->is_initializing) {
+	if (!to_user_ta_ctx(s->ctx)->is_initializing) {
 		TEE_ErrorOrigin eo = TEE_ORIGIN_TEE;
 		struct tee_ta_param param = { };
 
@@ -428,7 +429,7 @@ static TEE_Result dump_state_ldelf_dbg(struct user_ta_ctx *utc)
 	return res;
 }
 
-static void user_ta_dump_state(struct tee_ta_ctx *ctx)
+static void user_ta_dump_state(struct ts_ctx *ctx)
 {
 	struct user_ta_ctx *utc = to_user_ta_ctx(ctx);
 
@@ -495,7 +496,7 @@ static TEE_Result dump_ftrace(struct user_ta_ctx *utc, void *buf, size_t *blen)
 	return res;
 }
 
-static void user_ta_dump_ftrace(struct tee_ta_ctx *ctx)
+static void user_ta_dump_ftrace(struct ts_ctx *ctx)
 {
 	uint32_t prot = TEE_MATTR_URW;
 	struct user_ta_ctx *utc = to_user_ta_ctx(ctx);
@@ -588,12 +589,12 @@ static void free_utc(struct user_ta_ctx *utc)
 	free(utc);
 }
 
-static void user_ta_ctx_destroy(struct tee_ta_ctx *ctx)
+static void user_ta_ctx_destroy(struct ts_ctx *ctx)
 {
 	free_utc(to_user_ta_ctx(ctx));
 }
 
-static uint32_t user_ta_get_instance_id(struct tee_ta_ctx *ctx)
+static uint32_t user_ta_get_instance_id(struct ts_ctx *ctx)
 {
 	return to_user_ta_ctx(ctx)->uctx.vm_info.asid;
 }
@@ -627,10 +628,10 @@ service_init(init_user_ta);
 
 static void set_ta_ctx_ops(struct tee_ta_ctx *ctx)
 {
-	ctx->ops = _user_ta_ops;
+	ctx->ts_ctx.ops = _user_ta_ops;
 }
 
-bool is_user_ta_ctx(struct tee_ta_ctx *ctx)
+bool is_user_ta_ctx(struct ts_ctx *ctx)
 {
 	return ctx && ctx->ops == _user_ta_ops;
 }
@@ -697,7 +698,7 @@ static TEE_Result load_ldelf(struct user_ta_ctx *utc)
 	if (res)
 		return res;
 
-	tee_mmu_set_ctx(&utc->uctx.ctx);
+	tee_mmu_set_ctx(&utc->uctx.ctx.ts_ctx);
 
 	memcpy((void *)code_addr, ldelf_data, ldelf_code_size);
 	memcpy((void *)rw_addr, ldelf_data + ldelf_code_size, ldelf_data_size);
@@ -738,13 +739,13 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 	 */
 	set_ta_ctx_ops(&utc->uctx.ctx);
 
-	utc->uctx.ctx.uuid = *uuid;
+	utc->uctx.ctx.ts_ctx.uuid = *uuid;
 	res = vm_info_init(&utc->uctx);
 	if (res)
 		goto out;
 
 	mutex_lock(&tee_ta_mutex);
-	s->ts_sess.ctx = &utc->uctx.ctx;
+	s->ts_sess.ctx = &utc->uctx.ctx.ts_ctx;
 	/*
 	 * Another thread trying to load this same TA may need to wait
 	 * until this context is fully initialized. This is needed to
@@ -761,7 +762,7 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 
 	res = load_ldelf(utc);
 	if (!res)
-		res = init_with_ldelf(s, utc);
+		res = init_with_ldelf(&s->ts_sess, utc);
 
 	ts_pop_current_session();
 
@@ -782,7 +783,7 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 out:
 	if (res) {
 		condvar_destroy(&utc->uctx.ctx.busy_cv);
-		pgt_flush_ctx(&utc->uctx.ctx);
+		pgt_flush_ctx(&utc->uctx.ctx.ts_ctx);
 		free_utc(utc);
 	}
 

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -555,6 +555,16 @@ out_free_pl:
 }
 #endif /*CFG_FTRACE_SUPPORT*/
 
+#ifdef CFG_TA_GPROF_SUPPORT
+static void user_ta_gprof_set_status(enum ts_gprof_status status)
+{
+	if (status == TS_GPROF_SUSPEND)
+		tee_ta_update_session_utime_suspend();
+	else
+		tee_ta_update_session_utime_resume();
+}
+#endif /*CFG_TA_GPROF_SUPPORT*/
+
 static void free_utc(struct user_ta_ctx *utc)
 {
 	tee_pager_rem_um_areas(&utc->uctx);
@@ -601,6 +611,9 @@ static const struct ts_ops user_ta_ops __rodata_unpaged = {
 	.destroy = user_ta_ctx_destroy,
 	.get_instance_id = user_ta_get_instance_id,
 	.handle_svc = user_ta_handle_svc,
+#ifdef CFG_TA_GPROF_SUPPORT
+	.gprof_set_status = user_ta_gprof_set_status,
+#endif
 };
 
 /*

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -599,7 +599,7 @@ static uint32_t user_ta_get_instance_id(struct ts_ctx *ctx)
 	return to_user_ta_ctx(ctx)->uctx.vm_info.asid;
 }
 
-static const struct tee_ta_ops user_ta_ops __rodata_unpaged = {
+static const struct ts_ops user_ta_ops __rodata_unpaged = {
 	.enter_open_session = user_ta_enter_open_session,
 	.enter_invoke_cmd = user_ta_enter_invoke_cmd,
 	.enter_close_session = user_ta_enter_close_session,
@@ -616,7 +616,7 @@ static const struct tee_ta_ops user_ta_ops __rodata_unpaged = {
  * Break unpaged attribute dependency propagation to user_ta_ops structure
  * content thanks to a runtime initialization of the ops reference.
  */
-static struct tee_ta_ops const *_user_ta_ops;
+static const struct ts_ops *_user_ta_ops;
 
 static TEE_Result init_user_ta(void)
 {

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1881,7 +1881,8 @@ void core_mmu_populate_user_map(struct core_mmu_table_info *dir_info,
 	/*
 	 * Allocate all page tables in advance.
 	 */
-	pgt_alloc(pgt_cache, &uctx->ctx, r->va, r_last->va + r_last->size - 1);
+	pgt_alloc(pgt_cache, &uctx->ctx.ts_ctx, r->va,
+		  r_last->va + r_last->size - 1);
 	pgt = SLIST_FIRST(pgt_cache);
 
 	core_mmu_set_info_table(&pg_info, dir_info->level + 1, 0, NULL);

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1881,7 +1881,7 @@ void core_mmu_populate_user_map(struct core_mmu_table_info *dir_info,
 	/*
 	 * Allocate all page tables in advance.
 	 */
-	pgt_alloc(pgt_cache, &uctx->ctx.ts_ctx, r->va,
+	pgt_alloc(pgt_cache, uctx->ts_ctx, r->va,
 		  r_last->va + r_last->size - 1);
 	pgt = SLIST_FIRST(pgt_cache);
 

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -430,7 +430,7 @@ static void *mobj_seccpy_shm_get_va(struct mobj *mobj, size_t offs)
 {
 	struct mobj_seccpy_shm *m = to_mobj_seccpy_shm(mobj);
 
-	if (&m->utc->uctx.ctx != thread_get_tsd()->ctx)
+	if (&m->utc->uctx.ctx.ts_ctx != thread_get_tsd()->ctx)
 		return NULL;
 
 	if (offs >= mobj->size)

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -430,7 +430,7 @@ static void *mobj_seccpy_shm_get_va(struct mobj *mobj, size_t offs)
 {
 	struct mobj_seccpy_shm *m = to_mobj_seccpy_shm(mobj);
 
-	if (&m->utc->uctx.ctx.ts_ctx != thread_get_tsd()->ctx)
+	if (&m->utc->ta_ctx.ts_ctx != thread_get_tsd()->ctx)
 		return NULL;
 
 	if (offs >= mobj->size)

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -277,7 +277,7 @@ static struct pgt *pop_from_some_list(vaddr_t vabase, void *ctx)
 	return p;
 }
 
-void pgt_flush_ctx(struct tee_ta_ctx *ctx)
+void pgt_flush_ctx(struct ts_ctx *ctx)
 {
 	struct pgt *p;
 	struct pgt *pp = NULL;
@@ -387,7 +387,7 @@ static void flush_ctx_range_from_list(struct pgt_cache *pgt_cache, void *ctx,
 	}
 }
 
-void pgt_flush_ctx_range(struct pgt_cache *pgt_cache, void *ctx,
+void pgt_flush_ctx_range(struct pgt_cache *pgt_cache, struct ts_ctx *ctx,
 			 vaddr_t begin, vaddr_t last)
 {
 	mutex_lock(&pgt_mu);
@@ -414,13 +414,13 @@ static void pgt_free_unlocked(struct pgt_cache *pgt_cache,
 }
 
 static struct pgt *pop_from_some_list(vaddr_t vabase __unused,
-				      void *ctx __unused)
+				      struct ts_ctx *ctx __unused)
 {
 	return pop_from_free_list();
 }
 #endif /*!CFG_PAGED_USER_TA*/
 
-static bool pgt_alloc_unlocked(struct pgt_cache *pgt_cache, void *ctx,
+static bool pgt_alloc_unlocked(struct pgt_cache *pgt_cache, struct ts_ctx *ctx,
 			       vaddr_t begin, vaddr_t last)
 {
 	const vaddr_t base = ROUNDDOWN(begin, CORE_MMU_PGDIR_SIZE);
@@ -447,7 +447,7 @@ static bool pgt_alloc_unlocked(struct pgt_cache *pgt_cache, void *ctx,
 	return true;
 }
 
-void pgt_alloc(struct pgt_cache *pgt_cache, void *ctx,
+void pgt_alloc(struct pgt_cache *pgt_cache, struct ts_ctx *ctx,
 	       vaddr_t begin, vaddr_t last)
 {
 	if (last <= begin)

--- a/core/arch/arm/mm/tee_mmu.c
+++ b/core/arch/arm/mm/tee_mmu.c
@@ -150,12 +150,12 @@ static TEE_Result alloc_pgt(struct user_mode_ctx *uctx)
 
 #ifdef CFG_PAGED_USER_TA
 	tsd = thread_get_tsd();
-	if (&uctx->ctx.ts_ctx == tsd->ctx) {
+	if (uctx->ts_ctx == tsd->ctx) {
 		/*
 		 * The supplied utc is the current active utc, allocate the
 		 * page tables too as the pager needs to use them soon.
 		 */
-		pgt_alloc(&tsd->pgt_cache, &uctx->ctx.ts_ctx, b, e - 1);
+		pgt_alloc(&tsd->pgt_cache, uctx->ts_ctx, b, e - 1);
 	}
 #endif
 
@@ -184,11 +184,10 @@ static void maybe_free_pgt(struct user_mode_ctx *uctx, struct vm_region *r)
 		return;
 
 	tsd = thread_get_tsd();
-	if (&uctx->ctx.ts_ctx == tsd->ctx)
+	if (uctx->ts_ctx == tsd->ctx)
 		pgt_cache = &tsd->pgt_cache;
 
-	pgt_flush_ctx_range(pgt_cache, &uctx->ctx.ts_ctx, r->va,
-			    r->va + r->size);
+	pgt_flush_ctx_range(pgt_cache, uctx->ts_ctx, r->va, r->va + r->size);
 }
 
 static TEE_Result umap_add_region(struct vm_info *vmi, struct vm_region *reg,
@@ -310,8 +309,8 @@ TEE_Result vm_map_pad(struct user_mode_ctx *uctx, vaddr_t *va, size_t len,
 	 * If the context currently is active set it again to update
 	 * the mapping.
 	 */
-	if (thread_get_tsd()->ctx == &uctx->ctx.ts_ctx)
-		tee_mmu_set_ctx(&uctx->ctx.ts_ctx);
+	if (thread_get_tsd()->ctx == uctx->ts_ctx)
+		tee_mmu_set_ctx(uctx->ts_ctx);
 
 	*va = reg->va;
 
@@ -521,7 +520,7 @@ TEE_Result vm_remap(struct user_mode_ctx *uctx, vaddr_t *new_va, vaddr_t old_va,
 	struct fobj *fobj = NULL;
 	vaddr_t next_va = 0;
 
-	assert(thread_get_tsd()->ctx == &uctx->ctx.ts_ctx);
+	assert(thread_get_tsd()->ctx == uctx->ts_ctx);
 
 	if (!len || ((len | old_va) & SMALL_PAGE_MASK))
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -551,7 +550,7 @@ TEE_Result vm_remap(struct user_mode_ctx *uctx, vaddr_t *new_va, vaddr_t old_va,
 	 * Synchronize change to translation tables. Even though the pager
 	 * case unmaps immediately we may still free a translation table.
 	 */
-	tee_mmu_set_ctx(&uctx->ctx.ts_ctx);
+	tee_mmu_set_ctx(uctx->ts_ctx);
 
 	r_first = TAILQ_FIRST(&regs);
 	while (!TAILQ_EMPTY(&regs)) {
@@ -604,7 +603,7 @@ TEE_Result vm_remap(struct user_mode_ctx *uctx, vaddr_t *new_va, vaddr_t old_va,
 
 	fobj_put(fobj);
 
-	tee_mmu_set_ctx(&uctx->ctx.ts_ctx);
+	tee_mmu_set_ctx(uctx->ts_ctx);
 	*new_va = r_first->va;
 
 	return TEE_SUCCESS;
@@ -624,7 +623,7 @@ err_restore_map:
 			panic("Cannot restore mapping");
 	}
 	fobj_put(fobj);
-	tee_mmu_set_ctx(&uctx->ctx.ts_ctx);
+	tee_mmu_set_ctx(uctx->ts_ctx);
 
 	return res;
 }
@@ -693,7 +692,7 @@ TEE_Result vm_set_prot(struct user_mode_ctx *uctx, vaddr_t va, size_t len,
 	bool was_writeable = false;
 	bool need_sync = false;
 
-	assert(thread_get_tsd()->ctx == &uctx->ctx.ts_ctx);
+	assert(thread_get_tsd()->ctx == uctx->ts_ctx);
 
 	if (prot & ~TEE_MATTR_PROT_MASK || !len)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -717,7 +716,7 @@ TEE_Result vm_set_prot(struct user_mode_ctx *uctx, vaddr_t va, size_t len,
 
 	if (need_sync) {
 		/* Synchronize changes to translation tables */
-		tee_mmu_set_ctx(&uctx->ctx.ts_ctx);
+		tee_mmu_set_ctx(uctx->ts_ctx);
 	}
 
 	for (r = r0; r; r = TAILQ_NEXT(r, link)) {
@@ -757,7 +756,7 @@ TEE_Result vm_unmap(struct user_mode_ctx *uctx, vaddr_t va, size_t len)
 	size_t unmap_end_va = 0;
 	size_t l = 0;
 
-	assert(thread_get_tsd()->ctx == &uctx->ctx.ts_ctx);
+	assert(thread_get_tsd()->ctx == uctx->ts_ctx);
 
 	if (ROUNDUP_OVERFLOW(len, SMALL_PAGE_SIZE, &l))
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -788,7 +787,7 @@ TEE_Result vm_unmap(struct user_mode_ctx *uctx, vaddr_t va, size_t len)
 	 * Synchronize change to translation tables. Even though the pager
 	 * case unmaps immediately we may still free a translation table.
 	 */
-	tee_mmu_set_ctx(&uctx->ctx.ts_ctx);
+	tee_mmu_set_ctx(uctx->ts_ctx);
 
 	return TEE_SUCCESS;
 }

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -596,7 +596,7 @@ static struct tee_pager_area *find_area(struct tee_pager_area_head *areas,
 #ifdef CFG_PAGED_USER_TA
 static struct tee_pager_area *find_uta_area(vaddr_t va)
 {
-	struct tee_ta_ctx *ctx = thread_get_tsd()->ctx;
+	struct ts_ctx *ctx = thread_get_tsd()->ctx;
 
 	if (!is_user_mode_ctx(ctx))
 		return NULL;
@@ -769,7 +769,7 @@ TEE_Result tee_pager_add_um_area(struct user_mode_ctx *uctx, vaddr_t base,
 	struct tee_pager_area *area = NULL;
 	struct core_mmu_table_info dir_info = { NULL };
 
-	if (&uctx->ctx != tsd->ctx) {
+	if (&uctx->ctx.ts_ctx != tsd->ctx) {
 		/*
 		 * Changes are to an utc that isn't active. Just add the
 		 * areas page tables will be dealt with later.

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -769,7 +769,7 @@ TEE_Result tee_pager_add_um_area(struct user_mode_ctx *uctx, vaddr_t base,
 	struct tee_pager_area *area = NULL;
 	struct core_mmu_table_info dir_info = { NULL };
 
-	if (&uctx->ctx.ts_ctx != tsd->ctx) {
+	if (uctx->ts_ctx != tsd->ctx) {
 		/*
 		 * Changes are to an utc that isn't active. Just add the
 		 * areas page tables will be dealt with later.

--- a/core/arch/arm/plat-vexpress/vendor_props.c
+++ b/core/arch/arm/plat-vexpress/vendor_props.c
@@ -25,7 +25,7 @@
  * Note that this code assumes an endorsement seed
  * size == device ID size for convenience.
  */
-static TEE_Result get_prop_endorsement(struct tee_ta_session *sess,
+static TEE_Result get_prop_endorsement(struct ts_session *sess,
 				       void *buf, size_t *blen)
 {
 	TEE_Result res;

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -136,7 +136,7 @@ static void trace_syscall(size_t num __unused)
 #ifdef CFG_SYSCALL_FTRACE
 static void __noprof ftrace_syscall_enter(size_t num)
 {
-	struct tee_ta_session *s = NULL;
+	struct ts_session *s = NULL;
 
 	/*
 	 * Syscalls related to inter-TA communication can't be traced in the
@@ -149,21 +149,15 @@ static void __noprof ftrace_syscall_enter(size_t num)
 		return;
 
 	s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
-	if (!s)
-		return;
-
-	if (s->fbuf)
+	if (s && s->fbuf)
 		s->fbuf->syscall_trace_enabled = true;
 }
 
 static void __noprof ftrace_syscall_leave(void)
 {
-	struct tee_ta_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
+	struct ts_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
 
-	if (!s)
-		return;
-
-	if (s->fbuf)
+	if (s && s->fbuf)
 		s->fbuf->syscall_trace_enabled = false;
 }
 #else
@@ -292,16 +286,14 @@ static void save_panic_regs_a32_ta(struct thread_specific_data *tsd,
 static void save_panic_stack(struct thread_svc_regs *regs)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
-	struct tee_ta_session *s;
-
-	if (tee_ta_get_current_session(&s))
-		panic("No current session");
+	struct ts_session *s = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
 
 	tsd->abort_type = ABORT_TYPE_USER_MODE_PANIC;
 	tsd->abort_descr = 0;
 	tsd->abort_va = 0;
 
-	if (tee_mmu_check_access_rights(&to_user_ta_ctx(s->ctx)->uctx,
+	if (tee_mmu_check_access_rights(&utc->uctx,
 					TEE_MEMORY_ACCESS_READ |
 					TEE_MEMORY_ACCESS_WRITE,
 					(uaddr_t)regs->r1,
@@ -364,13 +356,8 @@ static void save_panic_regs_a64_ta(struct thread_specific_data *tsd,
 static void save_panic_stack(struct thread_svc_regs *regs)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
-	struct tee_ta_session *s = NULL;
-	struct user_ta_ctx *utc = NULL;
-
-	if (tee_ta_get_current_session(&s) != TEE_SUCCESS)
-		panic();
-
-	utc = to_user_ta_ctx(s->ctx);
+	struct ts_session *s = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
 
 	if (tee_mmu_check_access_rights(&utc->uctx, TEE_MEMORY_ACCESS_READ |
 					TEE_MEMORY_ACCESS_WRITE,

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -297,7 +297,7 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 	if (tee_ta_get_current_session(&s))
 		panic("No current session");
 
-	tsd->abort_type = ABORT_TYPE_TA_PANIC;
+	tsd->abort_type = ABORT_TYPE_USER_MODE_PANIC;
 	tsd->abort_descr = 0;
 	tsd->abort_va = 0;
 
@@ -319,7 +319,7 @@ static void save_panic_stack(struct thread_svc_regs *regs __unused)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
 
-	tsd->abort_type = ABORT_TYPE_TA_PANIC;
+	tsd->abort_type = ABORT_TYPE_USER_MODE_PANIC;
 }
 #endif
 #endif /*ARM32*/
@@ -384,7 +384,7 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 		return;
 	}
 
-	tsd->abort_type = ABORT_TYPE_TA_PANIC;
+	tsd->abort_type = ABORT_TYPE_USER_MODE_PANIC;
 	tsd->abort_descr = 0;
 	tsd->abort_va = 0;
 
@@ -398,7 +398,7 @@ static void save_panic_stack(struct thread_svc_regs *regs __unused)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
 
-	tsd->abort_type = ABORT_TYPE_TA_PANIC;
+	tsd->abort_type = ABORT_TYPE_USER_MODE_PANIC;
 }
 #endif /* CFG_UNWIND */
 #endif /*ARM64*/

--- a/core/arch/arm/tee/svc_cache.c
+++ b/core/arch/arm/tee/svc_cache.c
@@ -15,7 +15,7 @@ TEE_Result syscall_cache_operation(void *va, size_t len, unsigned long op)
 	struct user_ta_ctx *utc = NULL;
 	TEE_Result res = TEE_SUCCESS;
 
-	if ((s->ctx->flags & TA_FLAG_CACHE_MAINTENANCE) == 0)
+	if ((to_ta_ctx(s->ctx)->flags & TA_FLAG_CACHE_MAINTENANCE) == 0)
 		return TEE_ERROR_NOT_SUPPORTED;
 
 	utc = to_user_ta_ctx(s->ctx);

--- a/core/arch/arm/tee/svc_cache.c
+++ b/core/arch/arm/tee/svc_cache.c
@@ -11,18 +11,14 @@
 
 TEE_Result syscall_cache_operation(void *va, size_t len, unsigned long op)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct user_ta_ctx *utc;
+	struct ts_session *s = ts_get_current_session();
+	struct user_ta_ctx *utc = NULL;
+	TEE_Result res = TEE_SUCCESS;
 
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-
-	if ((sess->ctx->flags & TA_FLAG_CACHE_MAINTENANCE) == 0)
+	if ((s->ctx->flags & TA_FLAG_CACHE_MAINTENANCE) == 0)
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	utc = to_user_ta_ctx(sess->ctx);
+	utc = to_user_ta_ctx(s->ctx);
 
 	/*
 	 * TAs are allowed to operate cache maintenance on TA memref parameters

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -46,21 +46,22 @@ struct tee_ta_param {
 	} u[TEE_NUM_PARAMS];
 };
 
-struct tee_ta_ctx;
 struct user_ta_ctx;
-struct pseudo_ta_ctx;
 struct thread_svc_regs;
+struct ts_session;
 
 struct tee_ta_ops {
-	TEE_Result (*enter_open_session)(struct tee_ta_session *s,
-			struct tee_ta_param *param, TEE_ErrorOrigin *eo);
-	TEE_Result (*enter_invoke_cmd)(struct tee_ta_session *s, uint32_t cmd,
-			struct tee_ta_param *param, TEE_ErrorOrigin *eo);
-	void (*enter_close_session)(struct tee_ta_session *s);
-	void (*dump_state)(struct tee_ta_ctx *ctx);
-	void (*dump_ftrace)(struct tee_ta_ctx *ctx);
-	void (*destroy)(struct tee_ta_ctx *ctx);
-	uint32_t (*get_instance_id)(struct tee_ta_ctx *ctx);
+	TEE_Result (*enter_open_session)(struct ts_session *s,
+					 struct tee_ta_param *param,
+					 TEE_ErrorOrigin *eo);
+	TEE_Result (*enter_invoke_cmd)(struct ts_session *s, uint32_t cmd,
+				       struct tee_ta_param *param,
+				       TEE_ErrorOrigin *eo);
+	void (*enter_close_session)(struct ts_session *s);
+	void (*dump_state)(struct ts_ctx *ctx);
+	void (*dump_ftrace)(struct ts_ctx *ctx);
+	void (*destroy)(struct ts_ctx *ctx);
+	uint32_t (*get_instance_id)(struct ts_ctx *ctx);
 	bool (*handle_svc)(struct thread_svc_regs *regs);
 };
 
@@ -80,10 +81,9 @@ struct sample_buf {
 
 /* Context of a loaded TA */
 struct tee_ta_ctx {
-	TEE_UUID uuid;
-	const struct tee_ta_ops *ops;
 	uint32_t flags;		/* TA_FLAGS from TA header */
 	TAILQ_ENTRY(tee_ta_ctx) link;
+	struct ts_ctx ts_ctx;
 	uint32_t panicked;	/* True if TA has panicked, written from asm */
 	uint32_t panic_code;	/* Code supplied for panic */
 	uint32_t ref_count;	/* Reference counter for multi session TA */
@@ -178,4 +178,8 @@ to_ta_session(struct ts_session *sess)
 	return container_of(sess, struct tee_ta_session, ts_sess);
 }
 
+static inline struct tee_ta_ctx *to_ta_ctx(struct ts_ctx *ctx)
+{
+	return container_of(ctx, struct tee_ta_ctx, ts_ctx);
+}
 #endif

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -7,6 +7,7 @@
 #ifndef TEE_TA_MANAGER_H
 #define TEE_TA_MANAGER_H
 
+#include <assert.h>
 #include <kernel/mutex.h>
 #include <kernel/tee_common.h>
 #include <kernel/ts_manager.h>
@@ -172,14 +173,18 @@ static inline void tee_ta_ftrace_update_times_suspend(void) {}
 static inline void tee_ta_ftrace_update_times_resume(void) {}
 #endif
 
+bool is_ta_ctx(struct ts_ctx *ctx);
+
 static inline struct tee_ta_session * __noprof
 to_ta_session(struct ts_session *sess)
 {
+	assert(is_ta_ctx(sess->ctx));
 	return container_of(sess, struct tee_ta_session, ts_sess);
 }
 
 static inline struct tee_ta_ctx *to_ta_ctx(struct ts_ctx *ctx)
 {
+	assert(is_ta_ctx(ctx));
 	return container_of(ctx, struct tee_ta_ctx, ts_ctx);
 }
 #endif

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -81,6 +81,8 @@ struct tee_ta_session {
 	struct ts_session ts_sess;
 	uint32_t id;		/* Session handle (0 is invalid) */
 	TEE_Identity clnt_id;	/* Identify of client */
+	struct tee_ta_param *param;
+	TEE_ErrorOrigin err_origin;
 	bool cancel;		/* True if TA invocation is cancelled */
 	bool cancel_mask;	/* True if cancel is masked */
 	TEE_Time cancel_time;	/* Time when to cancel the TA invocation */

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -9,9 +9,9 @@
 
 #include <kernel/mutex.h>
 #include <kernel/tee_common.h>
+#include <kernel/ts_manager.h>
 #include <mm/tee_mmu_types.h>
 #include <sys/queue.h>
-#include <tee_api_types.h>
 #include <tee_api_types.h>
 #include <types_ext.h>
 #include <user_ta_header.h>
@@ -94,9 +94,8 @@ struct tee_ta_ctx {
 
 struct tee_ta_session {
 	TAILQ_ENTRY(tee_ta_session) link;
-	TAILQ_ENTRY(tee_ta_session) link_tsd;
+	struct ts_session ts_sess;
 	uint32_t id;		/* Session handle (0 is invalid) */
-	struct tee_ta_ctx *ctx;	/* TA context */
 	TEE_Identity clnt_id;	/* Identify of client */
 	bool cancel;		/* True if TA invocation is cancelled */
 	bool cancel_mask;	/* True if cancel is masked */
@@ -107,12 +106,6 @@ struct tee_ta_session {
 	struct condvar lock_cv;	/* CV used to wait for lock */
 	short int lock_thread;	/* Id of thread holding the lock */
 	bool unlink;		/* True if session is to be unlinked */
-#if defined(CFG_TA_GPROF_SUPPORT)
-	struct sample_buf *sbuf; /* Profiling data (PC sampling) */
-#endif
-#if defined(CFG_FTRACE_SUPPORT)
-	struct ftrace_buf *fbuf; /* ftrace buffer */
-#endif
 };
 
 /* Registered contexts */
@@ -152,12 +145,7 @@ TEE_Result tee_ta_close_session(struct tee_ta_session *sess,
 				struct tee_ta_session_head *open_sessions,
 				const TEE_Identity *clnt_id);
 
-TEE_Result tee_ta_get_current_session(struct tee_ta_session **sess);
 
-void tee_ta_push_current_session(struct tee_ta_session *sess);
-struct tee_ta_session *tee_ta_pop_current_session(void);
-
-struct tee_ta_session *tee_ta_get_calling_session(void);
 
 struct tee_ta_session *tee_ta_find_session(uint32_t id,
 			struct tee_ta_session_head *open_sessions);
@@ -183,5 +171,11 @@ void tee_ta_ftrace_update_times_resume(void);
 static inline void tee_ta_ftrace_update_times_suspend(void) {}
 static inline void tee_ta_ftrace_update_times_resume(void) {}
 #endif
+
+static inline struct tee_ta_session * __noprof
+to_ta_session(struct ts_session *sess)
+{
+	return container_of(sess, struct tee_ta_session, ts_sess);
+}
 
 #endif

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -48,23 +48,6 @@ struct tee_ta_param {
 };
 
 struct user_ta_ctx;
-struct thread_svc_regs;
-struct ts_session;
-
-struct tee_ta_ops {
-	TEE_Result (*enter_open_session)(struct ts_session *s,
-					 struct tee_ta_param *param,
-					 TEE_ErrorOrigin *eo);
-	TEE_Result (*enter_invoke_cmd)(struct ts_session *s, uint32_t cmd,
-				       struct tee_ta_param *param,
-				       TEE_ErrorOrigin *eo);
-	void (*enter_close_session)(struct ts_session *s);
-	void (*dump_state)(struct ts_ctx *ctx);
-	void (*dump_ftrace)(struct ts_ctx *ctx);
-	void (*destroy)(struct ts_ctx *ctx);
-	uint32_t (*get_instance_id)(struct ts_ctx *ctx);
-	bool (*handle_svc)(struct thread_svc_regs *regs);
-};
 
 #if defined(CFG_TA_GPROF_SUPPORT)
 struct sample_buf {

--- a/core/include/kernel/ts_manager.h
+++ b/core/include/kernel/ts_manager.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2017-2020, Linaro Limited
+ */
+
+#ifndef __KERNEL_TS_MANAGER_H
+#define __KERNEL_TS_MANAGER_H
+
+#include <sys/queue.h>
+
+struct ts_session {
+	TAILQ_ENTRY(ts_session) link_tsd;
+	struct tee_ta_ctx *ctx;	/* TA context */
+#if defined(CFG_TA_GPROF_SUPPORT)
+	struct sample_buf *sbuf; /* Profiling data (PC sampling) */
+#endif
+#if defined(CFG_FTRACE_SUPPORT)
+	struct ftrace_buf *fbuf; /* ftrace buffer */
+#endif
+};
+
+struct ts_session *ts_get_current_session(void);
+struct ts_session *ts_get_current_session_may_fail(void);
+
+void ts_push_current_session(struct ts_session *sess);
+struct ts_session *ts_pop_current_session(void);
+struct ts_session *ts_get_calling_session(void);
+
+#endif /*__KERNEL_TS_MANAGER_H*/

--- a/core/include/kernel/ts_manager.h
+++ b/core/include/kernel/ts_manager.h
@@ -26,15 +26,10 @@ struct ts_session {
 #endif
 };
 
-struct tee_ta_param;
 struct thread_svc_regs;
 struct ts_ops {
-	TEE_Result (*enter_open_session)(struct ts_session *s,
-					 struct tee_ta_param *param,
-					 TEE_ErrorOrigin *eo);
-	TEE_Result (*enter_invoke_cmd)(struct ts_session *s, uint32_t cmd,
-				       struct tee_ta_param *param,
-				       TEE_ErrorOrigin *eo);
+	TEE_Result (*enter_open_session)(struct ts_session *s);
+	TEE_Result (*enter_invoke_cmd)(struct ts_session *s, uint32_t cmd);
 	void (*enter_close_session)(struct ts_session *s);
 	void (*dump_state)(struct ts_ctx *ctx);
 	void (*dump_ftrace)(struct ts_ctx *ctx);

--- a/core/include/kernel/ts_manager.h
+++ b/core/include/kernel/ts_manager.h
@@ -12,7 +12,7 @@
 
 struct ts_ctx {
 	TEE_UUID uuid;
-	const struct tee_ta_ops *ops;
+	const struct ts_ops *ops;
 };
 
 struct ts_session {
@@ -24,6 +24,23 @@ struct ts_session {
 #if defined(CFG_FTRACE_SUPPORT)
 	struct ftrace_buf *fbuf; /* ftrace buffer */
 #endif
+};
+
+struct tee_ta_param;
+struct thread_svc_regs;
+struct ts_ops {
+	TEE_Result (*enter_open_session)(struct ts_session *s,
+					 struct tee_ta_param *param,
+					 TEE_ErrorOrigin *eo);
+	TEE_Result (*enter_invoke_cmd)(struct ts_session *s, uint32_t cmd,
+				       struct tee_ta_param *param,
+				       TEE_ErrorOrigin *eo);
+	void (*enter_close_session)(struct ts_session *s);
+	void (*dump_state)(struct ts_ctx *ctx);
+	void (*dump_ftrace)(struct ts_ctx *ctx);
+	void (*destroy)(struct ts_ctx *ctx);
+	uint32_t (*get_instance_id)(struct ts_ctx *ctx);
+	bool (*handle_svc)(struct thread_svc_regs *regs);
 };
 
 struct ts_session *ts_get_current_session(void);

--- a/core/include/kernel/ts_manager.h
+++ b/core/include/kernel/ts_manager.h
@@ -26,6 +26,11 @@ struct ts_session {
 #endif
 };
 
+enum ts_gprof_status {
+	TS_GPROF_SUSPEND,
+	TS_GPROF_RESUME,
+};
+
 struct thread_svc_regs;
 struct ts_ops {
 	TEE_Result (*enter_open_session)(struct ts_session *s);
@@ -36,6 +41,9 @@ struct ts_ops {
 	void (*destroy)(struct ts_ctx *ctx);
 	uint32_t (*get_instance_id)(struct ts_ctx *ctx);
 	bool (*handle_svc)(struct thread_svc_regs *regs);
+#ifdef CFG_TA_GPROF_SUPPORT
+	void (*gprof_set_status)(enum ts_gprof_status status);
+#endif
 };
 
 struct ts_session *ts_get_current_session(void);

--- a/core/include/kernel/ts_manager.h
+++ b/core/include/kernel/ts_manager.h
@@ -8,10 +8,16 @@
 #define __KERNEL_TS_MANAGER_H
 
 #include <sys/queue.h>
+#include <tee_api_types.h>
+
+struct ts_ctx {
+	TEE_UUID uuid;
+	const struct tee_ta_ops *ops;
+};
 
 struct ts_session {
 	TAILQ_ENTRY(ts_session) link_tsd;
-	struct tee_ta_ctx *ctx;	/* TA context */
+	struct ts_ctx *ctx;	/* Generic TS context */
 #if defined(CFG_TA_GPROF_SUPPORT)
 	struct sample_buf *sbuf; /* Profiling data (PC sampling) */
 #endif

--- a/core/include/kernel/user_mode_ctx.h
+++ b/core/include/kernel/user_mode_ctx.h
@@ -19,8 +19,10 @@ static inline bool is_user_mode_ctx(struct ts_ctx *ctx)
 
 static inline struct user_mode_ctx *to_user_mode_ctx(struct ts_ctx *ctx)
 {
-	assert(is_user_mode_ctx(ctx));
-	return container_of(ctx, struct user_mode_ctx, ctx.ts_ctx);
+	if (is_user_ta_ctx(ctx))
+		return &to_user_ta_ctx(ctx)->uctx;
+	else
+		return &to_sec_part_ctx(ctx)->uctx;
 }
 
 void user_mode_ctx_print_mappings(struct user_mode_ctx *umctx);

--- a/core/include/kernel/user_mode_ctx.h
+++ b/core/include/kernel/user_mode_ctx.h
@@ -12,15 +12,15 @@
 #include <kernel/user_ta.h>
 #include <stdbool.h>
 
-static inline bool is_user_mode_ctx(struct tee_ta_ctx *ctx)
+static inline bool is_user_mode_ctx(struct ts_ctx *ctx)
 {
 	return is_user_ta_ctx(ctx) || is_sp_ctx(ctx);
 }
 
-static inline struct user_mode_ctx *to_user_mode_ctx(struct tee_ta_ctx *ctx)
+static inline struct user_mode_ctx *to_user_mode_ctx(struct ts_ctx *ctx)
 {
 	assert(is_user_mode_ctx(ctx));
-	return container_of(ctx, struct user_mode_ctx, ctx);
+	return container_of(ctx, struct user_mode_ctx, ctx.ts_ctx);
 }
 
 void user_mode_ctx_print_mappings(struct user_mode_ctx *umctx);

--- a/core/include/kernel/user_mode_ctx_struct.h
+++ b/core/include/kernel/user_mode_ctx_struct.h
@@ -16,7 +16,7 @@ struct user_mode_ctx {
 #if defined(CFG_WITH_VFP)
 	struct thread_user_vfp_state vfp;
 #endif
-	struct tee_ta_ctx ctx;
+	struct ts_ctx *ts_ctx;
 };
 #endif /*__KERNEL_USER_MODE_CTX_STRUCT_H*/
 

--- a/core/include/mm/tee_mmu.h
+++ b/core/include/mm/tee_mmu.h
@@ -122,8 +122,8 @@ TEE_Result tee_mmu_check_access_rights(const struct user_mode_ctx *uctx,
 /*-----------------------------------------------------------------------------
  * If ctx is NULL user mapping is removed and ASID set to 0
  *---------------------------------------------------------------------------*/
-void tee_mmu_set_ctx(struct tee_ta_ctx *ctx);
-struct tee_ta_ctx *tee_mmu_get_ctx(void);
+void tee_mmu_set_ctx(struct ts_ctx *ctx);
+struct ts_ctx *tee_mmu_get_ctx(void);
 
 /* init some allocation pools */
 void teecore_init_ta_ram(void);

--- a/core/include/tee/tee_svc.h
+++ b/core/include/tee/tee_svc.h
@@ -5,6 +5,7 @@
 #ifndef TEE_SVC_H
 #define TEE_SVC_H
 
+#include <kernel/ts_manager.h>
 #include <stdint.h>
 #include <types_ext.h>
 #include <tee_api_types.h>
@@ -20,7 +21,7 @@ struct tee_props {
 	const uint32_t prop_type;
 
 	/* either get_prop_func or both data and len */
-	TEE_Result (*get_prop_func)(struct tee_ta_session *sess,
+	TEE_Result (*get_prop_func)(struct ts_session *sess,
 				    void *buf, size_t *blen);
 	const void *data;
 	const size_t len;

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -14,6 +14,7 @@ srcs-y += panic.c
 srcs-y += refcount.c
 srcs-y += tee_misc.c
 srcs-y += tee_ta_manager.c
+srcs-y += ts_manager.c
 srcs-$(CFG_CORE_SANITIZE_UNDEFINED) += ubsan.c
 srcs-y += scattered_array.c
 srcs-y += huk_subkey.c

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -942,3 +942,8 @@ void tee_ta_ftrace_update_times_resume(void)
 	ftrace_update_times(false);
 }
 #endif
+
+bool is_ta_ctx(struct ts_ctx *ctx)
+{
+	return is_user_ta_ctx(ctx) || is_pseudo_ta_ctx(ctx);
+}

--- a/core/kernel/ts_manager.c
+++ b/core/kernel/ts_manager.c
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2020, Linaro Limited
+ */
+
+#include <kernel/panic.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/tee_ta_manager.h>
+#include <kernel/thread.h>
+#include <kernel/user_mode_ctx.h>
+#include <mm/core_mmu.h>
+#include <mm/tee_mmu.h>
+
+static void update_current_ctx(struct thread_specific_data *tsd)
+{
+	struct tee_ta_ctx *ctx = NULL;
+	struct ts_session *s = TAILQ_FIRST(&tsd->sess_stack);
+
+	if (s) {
+		if (is_pseudo_ta_ctx(s->ctx))
+			s = TAILQ_NEXT(s, link_tsd);
+
+		if (s)
+			ctx = s->ctx;
+	}
+
+	if (tsd->ctx != ctx)
+		tee_mmu_set_ctx(ctx);
+	/*
+	 * If current context is of user mode, then it has to be active too.
+	 */
+	if (is_user_mode_ctx(ctx) != core_mmu_user_mapping_is_active())
+		panic("unexpected active mapping");
+}
+
+void ts_push_current_session(struct ts_session *s)
+{
+	struct thread_specific_data *tsd = thread_get_tsd();
+
+	TAILQ_INSERT_HEAD(&tsd->sess_stack, s, link_tsd);
+	update_current_ctx(tsd);
+}
+
+struct ts_session *ts_pop_current_session(void)
+{
+	struct thread_specific_data *tsd = thread_get_tsd();
+	struct ts_session *s = TAILQ_FIRST(&tsd->sess_stack);
+
+	if (s) {
+		TAILQ_REMOVE(&tsd->sess_stack, s, link_tsd);
+		update_current_ctx(tsd);
+	}
+	return s;
+}
+
+struct ts_session *ts_get_calling_session(void)
+{
+	struct ts_session *s = ts_get_current_session();
+
+	if (s)
+		s = TAILQ_NEXT(s, link_tsd);
+	return s;
+}
+
+struct ts_session *ts_get_current_session_may_fail(void)
+{
+	return TAILQ_FIRST(&thread_get_tsd()->sess_stack);
+}
+
+struct ts_session *ts_get_current_session(void)
+{
+	struct ts_session *s = ts_get_current_session_may_fail();
+
+	if (!s)
+		panic();
+	return s;
+}

--- a/core/kernel/ts_manager.c
+++ b/core/kernel/ts_manager.c
@@ -7,6 +7,7 @@
 #include <kernel/panic.h>
 #include <kernel/pseudo_ta.h>
 #include <kernel/tee_ta_manager.h>
+#include <kernel/ts_manager.h>
 #include <kernel/thread.h>
 #include <kernel/user_mode_ctx.h>
 #include <mm/core_mmu.h>
@@ -14,7 +15,7 @@
 
 static void update_current_ctx(struct thread_specific_data *tsd)
 {
-	struct tee_ta_ctx *ctx = NULL;
+	struct ts_ctx *ctx = NULL;
 	struct ts_session *s = TAILQ_FIRST(&tsd->sess_stack);
 
 	if (s) {

--- a/core/kernel/user_access.c
+++ b/core/kernel/user_access.c
@@ -14,14 +14,10 @@
 
 static TEE_Result check_access(uint32_t flags, vaddr_t va, size_t len)
 {
-	struct tee_ta_session *s = NULL;
-	TEE_Result res = tee_ta_get_current_session(&s);
+	struct ts_session *s = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
 
-	if (res)
-		return res;
-
-	return tee_mmu_check_access_rights(&to_user_ta_ctx(s->ctx)->uctx,
-					   flags, va, len);
+	return tee_mmu_check_access_rights(&utc->uctx, flags, va, len);
 }
 
 TEE_Result copy_from_user(void *kaddr, const void *uaddr, size_t len)

--- a/core/pta/gprof.c
+++ b/core/pta/gprof.c
@@ -49,8 +49,7 @@ exit:
 	return res;
 }
 
-static TEE_Result gprof_send(struct tee_ta_session *s,
-			     uint32_t param_types,
+static TEE_Result gprof_send(struct ts_session *s, uint32_t param_types,
 			     TEE_Param params[TEE_NUM_PARAMS])
 {
 	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INOUT,
@@ -65,7 +64,7 @@ static TEE_Result gprof_send(struct tee_ta_session *s,
 			      params[1].memref.size, &params[0].value.a);
 }
 
-static TEE_Result gprof_start_pc_sampling(struct tee_ta_session *s,
+static TEE_Result gprof_start_pc_sampling(struct ts_session *s,
 					  uint32_t param_types,
 					  TEE_Param params[TEE_NUM_PARAMS])
 {
@@ -73,11 +72,11 @@ static TEE_Result gprof_start_pc_sampling(struct tee_ta_session *s,
 					  TEE_PARAM_TYPE_VALUE_INPUT,
 					  TEE_PARAM_TYPE_NONE,
 					  TEE_PARAM_TYPE_NONE);
-	struct sample_buf *sbuf;
-	uint32_t offset;
-	uint32_t scale;
-	uint32_t len;
-	uaddr_t buf;
+	struct sample_buf *sbuf = NULL;
+	uint32_t offset = 0;
+	uint32_t scale = 0;
+	uint32_t len = 0;
+	uaddr_t buf = 0;
 
 	if (exp_pt != param_types)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -107,7 +106,7 @@ static TEE_Result gprof_start_pc_sampling(struct tee_ta_session *s,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result gprof_stop_pc_sampling(struct tee_ta_session *s,
+static TEE_Result gprof_stop_pc_sampling(struct ts_session *s,
 					 uint32_t param_types,
 					 TEE_Param params[TEE_NUM_PARAMS])
 {
@@ -115,8 +114,8 @@ static TEE_Result gprof_stop_pc_sampling(struct tee_ta_session *s,
 					  TEE_PARAM_TYPE_NONE,
 					  TEE_PARAM_TYPE_NONE,
 					  TEE_PARAM_TYPE_NONE);
-	struct sample_buf *sbuf;
-	uint32_t rate;
+	struct sample_buf *sbuf = NULL;
+	uint32_t rate = 0;
 
 	if (exp_pt != param_types)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -151,10 +150,9 @@ static TEE_Result open_session(uint32_t param_types __unused,
 			       TEE_Param params[TEE_NUM_PARAMS] __unused,
 			       void **sess_ctx __unused)
 {
-	struct tee_ta_session *s;
+	struct ts_session *s = ts_get_calling_session();
 
 	/* Check that we're called from a user TA */
-	s = tee_ta_get_calling_session();
 	if (!s)
 		return TEE_ERROR_ACCESS_DENIED;
 	if (!is_user_ta_ctx(s->ctx))
@@ -167,7 +165,7 @@ static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
 				 uint32_t param_types,
 				 TEE_Param params[TEE_NUM_PARAMS])
 {
-	struct tee_ta_session *s = tee_ta_get_calling_session();
+	struct ts_session *s = ts_get_calling_session();
 
 	switch (cmd_id) {
 	case PTA_GPROF_SEND:

--- a/core/pta/tests/fs_htree.c
+++ b/core/pta/tests/fs_htree.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <kernel/ts_manager.h>
 #include <string.h>
 #include <tee/fs_htree.h>
 #include <tee/tee_fs_rpc.h>
@@ -253,19 +254,14 @@ out:
 static TEE_Result htree_test_rewrite(struct test_aux *aux, size_t num_blocks,
 				     size_t w_unsync_begin, size_t w_unsync_num)
 {
-	TEE_Result res;
+	struct ts_session *sess = ts_get_current_session();
+	const TEE_UUID *uuid = &sess->ctx->uuid;
+	TEE_Result res = TEE_SUCCESS;
 	struct tee_fs_htree *ht = NULL;
 	size_t salt = 23;
-	uint8_t hash[TEE_FS_HTREE_HASH_SIZE];
-	const TEE_UUID *uuid;
-	struct tee_ta_session *sess;
+	uint8_t hash[TEE_FS_HTREE_HASH_SIZE] = { 0 };
 
 	assert((w_unsync_begin + w_unsync_num) <= num_blocks);
-
-	res = tee_ta_get_current_session(&sess);
-	if (res)
-		return res;
-	uuid = &sess->ctx->uuid;
 
 	aux->data_len = 0;
 	memset(aux->data, 0xce, aux->data_alloced);
@@ -558,18 +554,13 @@ out:
 
 static TEE_Result test_corrupt(size_t num_blocks)
 {
-	TEE_Result res;
+	struct ts_session *sess = ts_get_current_session();
+	const TEE_UUID *uuid = &sess->ctx->uuid;
+	TEE_Result res = TEE_SUCCESS;
 	struct tee_fs_htree *ht = NULL;
-	struct tee_ta_session *sess;
-	uint8_t hash[TEE_FS_HTREE_HASH_SIZE];
-	const TEE_UUID *uuid;
-	struct test_aux *aux;
-	size_t n;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res)
-		return res;
-	uuid = &sess->ctx->uuid;
+	uint8_t hash[TEE_FS_HTREE_HASH_SIZE] = { 0 };
+	struct test_aux *aux = NULL;
+	size_t n = 0;
 
 	aux = aux_alloc(num_blocks);
 	if (!aux) {

--- a/core/tee/socket.c
+++ b/core/tee/socket.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <tee/tee_fs_rpc.h>
 
-static uint32_t get_instance_id(struct tee_ta_session *sess)
+static uint32_t get_instance_id(struct ts_session *sess)
 {
 	return sess->ctx->ops->get_instance_id(sess->ctx);
 }
@@ -225,11 +225,10 @@ static TEE_Result pta_socket_open_session(uint32_t param_types __unused,
 			TEE_Param pParams[TEE_NUM_PARAMS] __unused,
 			void **sess_ctx)
 {
-	struct tee_ta_session *s;
+	struct ts_session *s = ts_get_calling_session();
 
 	/* Check that we're called from a TA */
-	s = tee_ta_get_calling_session();
-	if (!s)
+	if (!s || !is_user_ta_ctx(s->ctx))
 		return TEE_ERROR_ACCESS_DENIED;
 
 	*sess_ctx = (void *)(vaddr_t)get_instance_id(s);

--- a/core/tee/tee_obj.c
+++ b/core/tee/tee_obj.c
@@ -66,7 +66,7 @@ TEE_Result tee_obj_verify(struct tee_ta_session *sess, struct tee_obj *o)
 	if (res == TEE_ERROR_CORRUPT_OBJECT) {
 		EMSG("Object corrupt");
 		fops->remove(o->pobj);
-		tee_obj_close(to_user_ta_ctx(sess->ctx), o);
+		tee_obj_close(to_user_ta_ctx(sess->ts_sess.ctx), o);
 	}
 
 	fops->close(&fh);

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -797,7 +797,7 @@ TEE_Result syscall_open_ta_session(const TEE_UUID *dest,
 
 	res = tee_ta_open_session(&ret_o, &s, &utc->open_sessions, uuid,
 				  clnt_id, cancel_req_to, param);
-	tee_mmu_set_ctx(&utc->uctx.ctx);
+	tee_mmu_set_ctx(&utc->uctx.ctx.ts_ctx);
 	if (res != TEE_SUCCESS)
 		goto function_exit;
 

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -797,7 +797,7 @@ TEE_Result syscall_open_ta_session(const TEE_UUID *dest,
 
 	res = tee_ta_open_session(&ret_o, &s, &utc->open_sessions, uuid,
 				  clnt_id, cancel_req_to, param);
-	tee_mmu_set_ctx(&utc->uctx.ctx.ts_ctx);
+	tee_mmu_set_ctx(&utc->ta_ctx.ts_ctx);
 	if (res != TEE_SUCCESS)
 		goto function_exit;
 

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -515,7 +515,7 @@ static const struct tee_cryp_obj_type_props tee_cryp_obj_props[] = {
 
 struct attr_ops {
 	TEE_Result (*from_user)(void *attr, const void *buffer, size_t size);
-	TEE_Result (*to_user)(void *attr, struct tee_ta_session *sess,
+	TEE_Result (*to_user)(void *attr, struct ts_session *sess,
 			      void *buffer, uint64_t *size);
 	TEE_Result (*to_binary)(void *attr, void *data, size_t data_len,
 			    size_t *offs);
@@ -572,8 +572,8 @@ static TEE_Result op_attr_secret_value_from_user(void *attr, const void *buffer,
 }
 
 static TEE_Result op_attr_secret_value_to_user(void *attr,
-			struct tee_ta_session *sess __unused,
-			void *buffer, uint64_t *size)
+					       struct ts_session *sess __unused,
+					       void *buffer, uint64_t *size)
 {
 	TEE_Result res;
 	struct tee_cryp_obj_secret *key = attr;
@@ -667,7 +667,7 @@ static TEE_Result op_attr_bignum_from_user(void *attr, const void *buffer,
 }
 
 static TEE_Result op_attr_bignum_to_user(void *attr,
-					 struct tee_ta_session *sess,
+					 struct ts_session *sess,
 					 void *buffer, uint64_t *size)
 {
 	TEE_Result res = TEE_SUCCESS;
@@ -781,7 +781,7 @@ static TEE_Result op_attr_value_from_user(void *attr, const void *buffer,
 }
 
 static TEE_Result op_attr_value_to_user(void *attr,
-					struct tee_ta_session *sess __unused,
+					struct ts_session *sess __unused,
 					void *buffer, uint64_t *size)
 {
 	TEE_Result res;
@@ -886,13 +886,9 @@ static TEE_Result put_user_u64(uint64_t *dst, size_t value)
 
 TEE_Result syscall_cryp_obj_get_info(unsigned long obj, TEE_ObjectInfo *info)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *o;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		goto exit;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *o = NULL;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx),
 			  uref_to_vaddr(obj), &o);
@@ -908,13 +904,9 @@ exit:
 TEE_Result syscall_cryp_obj_restrict_usage(unsigned long obj,
 			unsigned long usage)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *o;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		goto exit;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *o = NULL;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx), uref_to_vaddr(obj), &o);
 	if (res != TEE_SUCCESS)
@@ -979,17 +971,13 @@ static uint32_t get_attribute(const struct tee_obj *o,
 TEE_Result syscall_cryp_obj_get_attr(unsigned long obj, unsigned long attr_id,
 			void *buffer, uint64_t *size)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *o;
-	const struct tee_cryp_obj_type_props *type_props;
-	int idx;
-	const struct attr_ops *ops;
-	void *attr;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *o = NULL;
+	const struct tee_cryp_obj_type_props *type_props = NULL;
+	int idx = 0;
+	const struct attr_ops *ops = NULL;
+	void *attr = NULL;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx), uref_to_vaddr(obj), &o);
 	if (res != TEE_SUCCESS)
@@ -1320,13 +1308,10 @@ TEE_Result tee_obj_set_type(struct tee_obj *o, uint32_t obj_type,
 TEE_Result syscall_cryp_obj_alloc(unsigned long obj_type,
 			unsigned long max_key_size, uint32_t *obj)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *o;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *o = NULL;
 
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	o = tee_obj_alloc();
 	if (!o)
@@ -1348,13 +1333,9 @@ TEE_Result syscall_cryp_obj_alloc(unsigned long obj_type,
 
 TEE_Result syscall_cryp_obj_close(unsigned long obj)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *o;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *o = NULL;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx), uref_to_vaddr(obj), &o);
 	if (res != TEE_SUCCESS)
@@ -1373,13 +1354,9 @@ TEE_Result syscall_cryp_obj_close(unsigned long obj)
 
 TEE_Result syscall_cryp_obj_reset(unsigned long obj)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *o;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *o = NULL;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx), uref_to_vaddr(obj), &o);
 	if (res != TEE_SUCCESS)
@@ -1662,15 +1639,11 @@ TEE_Result syscall_cryp_obj_populate(unsigned long obj,
 			struct utee_attribute *usr_attrs,
 			unsigned long attr_count)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *o;
-	const struct tee_cryp_obj_type_props *type_props;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *o = NULL;
+	const struct tee_cryp_obj_type_props *type_props = NULL;
 	TEE_Attribute *attrs = NULL;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx), uref_to_vaddr(obj), &o);
 	if (res != TEE_SUCCESS)
@@ -1718,14 +1691,10 @@ out:
 
 TEE_Result syscall_cryp_obj_copy(unsigned long dst, unsigned long src)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	struct tee_obj *dst_o;
-	struct tee_obj *src_o;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_obj *dst_o = NULL;
+	struct tee_obj *src_o = NULL;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx),
 			  uref_to_vaddr(dst), &dst_o);
@@ -1904,17 +1873,13 @@ TEE_Result syscall_obj_generate_key(unsigned long obj, unsigned long key_size,
 			const struct utee_attribute *usr_params,
 			unsigned long param_count)
 {
-	TEE_Result res;
-	struct tee_ta_session *sess;
-	const struct tee_cryp_obj_type_props *type_props;
-	struct tee_obj *o;
-	struct tee_cryp_obj_secret *key;
-	size_t byte_size;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	const struct tee_cryp_obj_type_props *type_props = NULL;
+	struct tee_obj *o = NULL;
+	struct tee_cryp_obj_secret *key = NULL;
+	size_t byte_size = 0;
 	TEE_Attribute *params = NULL;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_obj_get(to_user_ta_ctx(sess->ctx), uref_to_vaddr(obj), &o);
 	if (res != TEE_SUCCESS)
@@ -2038,7 +2003,7 @@ out:
 	return res;
 }
 
-static TEE_Result tee_svc_cryp_get_state(struct tee_ta_session *sess,
+static TEE_Result tee_svc_cryp_get_state(struct ts_session *sess,
 					 vaddr_t state_id,
 					 struct tee_cryp_state **state)
 {
@@ -2196,17 +2161,12 @@ TEE_Result syscall_cryp_state_alloc(unsigned long algo, unsigned long mode,
 			unsigned long key1, unsigned long key2,
 			uint32_t *state)
 {
-	TEE_Result res;
-	struct tee_cryp_state *cs;
-	struct tee_ta_session *sess;
+	struct ts_session *sess = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(sess->ctx);
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_cryp_state *cs = NULL;
 	struct tee_obj *o1 = NULL;
 	struct tee_obj *o2 = NULL;
-	struct user_ta_ctx *utc;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-	utc = to_user_ta_ctx(sess->ctx);
 
 	if (key1 != 0) {
 		res = tee_obj_get(utc, uref_to_vaddr(key1), &o1);
@@ -2323,14 +2283,10 @@ out:
 
 TEE_Result syscall_cryp_state_copy(unsigned long dst, unsigned long src)
 {
-	TEE_Result res;
-	struct tee_cryp_state *cs_dst;
-	struct tee_cryp_state *cs_src;
-	struct tee_ta_session *sess;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_cryp_state *cs_dst = NULL;
+	struct tee_cryp_state *cs_src = NULL;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(dst), &cs_dst);
 	if (res != TEE_SUCCESS)
@@ -2374,13 +2330,9 @@ void tee_svc_cryp_free_states(struct user_ta_ctx *utc)
 
 TEE_Result syscall_cryp_state_free(unsigned long state)
 {
-	TEE_Result res;
-	struct tee_cryp_state *cs;
-	struct tee_ta_session *sess;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_cryp_state *cs = NULL;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -2393,13 +2345,9 @@ TEE_Result syscall_hash_init(unsigned long state,
 			     const void *iv __maybe_unused,
 			     size_t iv_len __maybe_unused)
 {
-	TEE_Result res;
-	struct tee_cryp_state *cs;
-	struct tee_ta_session *sess;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct ts_session *sess = ts_get_current_session();
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_cryp_state *cs = NULL;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -2443,7 +2391,7 @@ TEE_Result syscall_hash_init(unsigned long state,
 TEE_Result syscall_hash_update(unsigned long state, const void *chunk,
 			size_t chunk_size)
 {
-	struct tee_ta_session *sess = NULL;
+	struct ts_session *sess = ts_get_current_session();
 	struct tee_cryp_state *cs = NULL;
 	TEE_Result res = TEE_SUCCESS;
 
@@ -2454,10 +2402,6 @@ TEE_Result syscall_hash_update(unsigned long state, const void *chunk,
 	/* Zero length hash is valid, but nothing we need to do. */
 	if (!chunk_size)
 		return TEE_SUCCESS;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_mmu_check_access_rights(&to_user_ta_ctx(sess->ctx)->uctx,
 					  TEE_MEMORY_ACCESS_READ |
@@ -2494,7 +2438,7 @@ TEE_Result syscall_hash_update(unsigned long state, const void *chunk,
 TEE_Result syscall_hash_final(unsigned long state, const void *chunk,
 			size_t chunk_size, void *hash, uint64_t *hash_len)
 {
-	struct tee_ta_session *sess = NULL;
+	struct ts_session *sess = ts_get_current_session();
 	struct tee_cryp_state *cs = NULL;
 	TEE_Result res2 = TEE_SUCCESS;
 	TEE_Result res = TEE_SUCCESS;
@@ -2504,10 +2448,6 @@ TEE_Result syscall_hash_final(unsigned long state, const void *chunk,
 	/* No data, but size provided isn't valid parameters. */
 	if (!chunk && chunk_size)
 		return TEE_ERROR_BAD_PARAMETERS;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_mmu_check_access_rights(&to_user_ta_ctx(sess->ctx)->uctx,
 					  TEE_MEMORY_ACCESS_READ |
@@ -2589,17 +2529,12 @@ out:
 TEE_Result syscall_cipher_init(unsigned long state, const void *iv,
 			size_t iv_len)
 {
+	struct ts_session *sess = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(sess->ctx);
 	struct tee_cryp_obj_secret *key1 = NULL;
-	struct tee_ta_session *sess = NULL;
 	struct tee_cryp_state *cs = NULL;
-	struct user_ta_ctx *utc = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	struct tee_obj *o = NULL;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-	utc = to_user_ta_ctx(sess->ctx);
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -2651,14 +2586,10 @@ static TEE_Result tee_svc_cipher_update_helper(unsigned long state,
 			bool last_block, const void *src, size_t src_len,
 			void *dst, uint64_t *dst_len)
 {
-	struct tee_ta_session *sess = NULL;
+	struct ts_session *sess = ts_get_current_session();
 	struct tee_cryp_state *cs = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	size_t dlen = 0;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -2981,26 +2912,20 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 			const struct utee_attribute *usr_params,
 			unsigned long param_count, unsigned long derived_key)
 {
+	struct ts_session *sess = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(sess->ctx);
 	TEE_Result res = TEE_ERROR_NOT_SUPPORTED;
-	struct tee_ta_session *sess;
-	struct tee_obj *ko;
-	struct tee_obj *so;
-	struct tee_cryp_state *cs;
-	struct tee_cryp_obj_secret *sk;
-	const struct tee_cryp_obj_type_props *type_props;
+	struct tee_obj *ko = NULL;
+	struct tee_obj *so = NULL;
+	struct tee_cryp_state *cs = NULL;
+	struct tee_cryp_obj_secret *sk = NULL;
+	const struct tee_cryp_obj_type_props *type_props = NULL;
 	TEE_Attribute *params = NULL;
-	struct user_ta_ctx *utc;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-	utc = to_user_ta_ctx(sess->ctx);
+	size_t alloc_size = 0;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
 		return res;
-
-	size_t alloc_size = 0;
 
 	if (MUL_OVERFLOW(sizeof(TEE_Attribute), param_count, &alloc_size))
 		return TEE_ERROR_OVERFLOW;
@@ -3262,12 +3187,8 @@ out:
 
 TEE_Result syscall_cryp_random_number_generate(void *buf, size_t blen)
 {
-	struct tee_ta_session *sess = NULL;
+	struct ts_session *sess = ts_get_current_session();
 	TEE_Result res = TEE_SUCCESS;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_mmu_check_access_rights(&to_user_ta_ctx(sess->ctx)->uctx,
 					  TEE_MEMORY_ACCESS_WRITE,
@@ -3286,15 +3207,11 @@ TEE_Result syscall_authenc_init(unsigned long state, const void *nonce,
 				size_t nonce_len, size_t tag_len,
 				size_t aad_len, size_t payload_len)
 {
+	struct ts_session *sess = ts_get_current_session();
 	struct tee_cryp_obj_secret *key = NULL;
-	struct tee_ta_session *sess = NULL;
 	struct tee_cryp_state *cs = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	struct tee_obj *o = NULL;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_mmu_check_access_rights(&to_user_ta_ctx(sess->ctx)->uctx,
 					  TEE_MEMORY_ACCESS_READ |
@@ -3329,13 +3246,9 @@ TEE_Result syscall_authenc_init(unsigned long state, const void *nonce,
 TEE_Result syscall_authenc_update_aad(unsigned long state,
 				      const void *aad_data, size_t aad_data_len)
 {
+	struct ts_session *sess = ts_get_current_session();
 	TEE_Result res = TEE_SUCCESS;
-	struct tee_cryp_state *cs;
-	struct tee_ta_session *sess;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
+	struct tee_cryp_state *cs = NULL;
 
 	res = tee_mmu_check_access_rights(&to_user_ta_ctx(sess->ctx)->uctx,
 					  TEE_MEMORY_ACCESS_READ |
@@ -3368,14 +3281,10 @@ TEE_Result syscall_authenc_update_payload(unsigned long state,
 					  size_t src_len, void *dst_data,
 					  uint64_t *dst_len)
 {
-	struct tee_ta_session *sess = NULL;
+	struct ts_session *sess = ts_get_current_session();
 	struct tee_cryp_state *cs = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	size_t dlen = 0;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -3429,18 +3338,12 @@ TEE_Result syscall_authenc_enc_final(unsigned long state, const void *src_data,
 				     uint64_t *dst_len, void *tag,
 				     uint64_t *tag_len)
 {
-	struct tee_ta_session *sess = NULL;
-	struct user_mode_ctx *uctx = NULL;
+	struct ts_session *sess = ts_get_current_session();
+	struct user_mode_ctx *uctx = &to_user_ta_ctx(sess->ctx)->uctx;
 	struct tee_cryp_state *cs = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	size_t dlen = 0;
 	size_t tlen = 0;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-
-	uctx = &to_user_ta_ctx(sess->ctx)->uctx;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -3520,17 +3423,11 @@ TEE_Result syscall_authenc_dec_final(unsigned long state,
 			const void *src_data, size_t src_len, void *dst_data,
 			uint64_t *dst_len, const void *tag, size_t tag_len)
 {
-	struct tee_ta_session *sess = NULL;
-	struct user_mode_ctx *uctx = NULL;
+	struct ts_session *sess = ts_get_current_session();
+	struct user_mode_ctx *uctx = &to_user_ta_ctx(sess->ctx)->uctx;
 	struct tee_cryp_state *cs = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	size_t dlen = 0;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-
-	uctx = &to_user_ta_ctx(sess->ctx)->uctx;
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -3619,22 +3516,17 @@ TEE_Result syscall_asymm_operate(unsigned long state,
 			size_t num_params, const void *src_data, size_t src_len,
 			void *dst_data, uint64_t *dst_len)
 {
-	TEE_Result res;
-	struct tee_cryp_state *cs;
-	struct tee_ta_session *sess;
-	size_t dlen;
-	struct tee_obj *o;
+	struct ts_session *sess = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(sess->ctx);
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_cryp_state *cs = NULL;
+	size_t dlen = 0;
+	struct tee_obj *o = NULL;
 	void *label = NULL;
 	size_t label_len = 0;
-	size_t n;
-	int salt_len;
+	size_t n = 0;
+	int salt_len = 0;
 	TEE_Attribute *params = NULL;
-	struct user_ta_ctx *utc;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-	utc = to_user_ta_ctx(sess->ctx);
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)
@@ -3806,20 +3698,15 @@ TEE_Result syscall_asymm_verify(unsigned long state,
 			size_t num_params, const void *data, size_t data_len,
 			const void *sig, size_t sig_len)
 {
-	struct tee_ta_session *sess = NULL;
+	struct ts_session *sess = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(sess->ctx);
 	struct tee_cryp_state *cs = NULL;
-	struct user_ta_ctx *utc = NULL;
 	TEE_Result res = TEE_SUCCESS;
 	TEE_Attribute *params = NULL;
 	struct tee_obj *o = NULL;
 	size_t hash_size = 0;
 	uint32_t hash_algo = 0;
 	int salt_len = 0;
-
-	res = tee_ta_get_current_session(&sess);
-	if (res != TEE_SUCCESS)
-		return res;
-	utc = to_user_ta_ctx(sess->ctx);
 
 	res = tee_svc_cryp_get_state(sess, uref_to_vaddr(state), &cs);
 	if (res != TEE_SUCCESS)

--- a/lib/libutils/ext/ftrace/ftrace.c
+++ b/lib/libutils/ext/ftrace/ftrace.c
@@ -33,7 +33,7 @@ static __noprof struct ftrace_buf *get_fbuf(void)
 {
 #if defined(__KERNEL__)
 	short int ct = thread_get_id_may_fail();
-	struct tee_ta_session *s = NULL;
+	struct ts_session *s = NULL;
 	struct thread_specific_data *tsd = NULL;
 
 	if (ct == -1)


### PR DESCRIPTION
As a step in making room for Secure Partitions (SPs) running at S-EL0 add a Trusted Service (TS) abstraction. Both TAs and SPs is a TS.

The idea is to form a struct ts_session and struct ts_ctx and so on that can be used by common code that might deal with both TAs and SPs.