### PR TITLE
core: non-lpae: increase PGT_CACHE_SIZE when CFG_NUM_THREADS=2

### DIFF
--- a/core/arch/arm/include/mm/pgt_cache.h
+++ b/core/arch/arm/include/mm/pgt_cache.h
@@ -35,10 +35,15 @@ struct pgt {
 };
 
 /*
- * Reserve 2 page tables per thread, but at least 4 page tables in total
+ * A proper value for PGT_CACHE_SIZE depends on many factors: CFG_WITH_LPAE,
+ * CFG_TA_ASLR, size of TA, size of memrefs passed to TA, CFG_ULIBS_SHARED and
+ * possibly others. The value is based on the number of threads as an indicator
+ * on how large the system might be.
  */
 #if CFG_NUM_THREADS < 2
 #define PGT_CACHE_SIZE	4
+#elif (CFG_NUM_THREADS == 2 && !defined(CFG_WITH_LPAE))
+#define PGT_CACHE_SIZE	8
 #else
 #define PGT_CACHE_SIZE	ROUNDUP(CFG_NUM_THREADS * 2, PGT_NUM_PGT_PER_PAGE)
 #endif


### PR DESCRIPTION
xtest on QEMU shows allocation errors when CFG_ULIBS_SHARED=y:

```
 # xtest 1010
 ...
 o regression_1010.10 Invalid memory access 5 with 1024 bytes memref
 regression_1000.c:500: [...] 0xffff000c = TEEC_ERROR_OUT_OF_MEMORY [...]
 regression_1000.c:505: [...] 0xffff000c = TEEC_ERROR_OUT_OF_MEMORY [...]
 regression_1010.10 FAILED
 ...
 E/TC:? 0 alloc_pgt:147 5 page tables not available
 E/TC:? 0 alloc_pgt:147 5 page tables not available
```
This configuration needs at least 5 page tables. Use 8 to avoid wasting
space.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
