### PR TITLE
core: non-lpae: allocate one more translation table for ASLR

### DIFF
--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -170,7 +170,7 @@
 
 #ifndef MAX_XLAT_TABLES
 #ifdef CFG_CORE_ASLR
-#	define XLAT_TABLE_ASLR_EXTRA 1
+#	define XLAT_TABLE_ASLR_EXTRA 2
 #else
 #	define XLAT_TABLE_ASLR_EXTRA 0
 #endif


### PR DESCRIPTION
Commit 1579bdf39b3e ("core: lpae: allocate one more translation table
for ASLR") has fixed an issue with LPAE (QEMUv8), but a similar one
occurs with non-LPAE. More specifically, running xtest 1013 on QEMU
with CFG_ULIBS_SHARED=y:
```
 E/TC:0 0 Panic 'Failed to spread pgdir on small tables' at core/arch/arm/mm/core_mmu.c:1737 <core_mmu_map_pages>
 E/TC:0 0 TEE load address @ 0x5a9b5000
 E/TC:0 0 Call stack:
 E/TC:0 0  0x5a9bcba1 print_kernel_stack at optee_os/core/arch/arm/kernel/unwind_arm32.c:109
 E/TC:0 0  0x5a9c8293 __do_panic at optee_os/core/kernel/panic.c:31
 E/TC:0 0  0x5a9bf357 core_mmu_map_pages at optee_os/core/arch/arm/mm/core_mmu.c:1737
 E/TC:0 0  0x5a9c2a2f mobj_reg_shm_inc_map at optee_os/core/arch/arm/mm/mobj_dyn_shm.c:200
 E/TC:0 0  0x5a9e9067 mobj_inc_map at optee_os/core/arch/arm/include/mm/mobj.h:93
 E/TC:0 0  0x5a9e92b1 mobj_mapped_shm_alloc at optee_os/core/arch/arm/mm/mobj_dyn_shm.c:412
 E/TC:0 0  0x5a9ee9d9 msg_param_mobj_from_noncontig at optee_os/core/kernel/msg_param.c:141
 E/TC:0 0  0x5a9b9d43 get_rpc_alloc_res at optee_os/core/arch/arm/kernel/thread_optee_smc.c:541
 E/TC:0 0  0x5a9e479b thread_rpc_alloc at optee_os/core/arch/arm/kernel/thread_optee_smc.c:580
 E/TC:0 0  0x5a9e47bf thread_rpc_alloc_payload at optee_os/core/arch/arm/kernel/thread_optee_smc.c:585
 E/TC:0 0  0x5a9b67db rpc_load at optee_os/core/arch/arm/kernel/ree_fs_ta.c:99
 E/TC:0 0  0x5a9e28e9 ree_fs_ta_open at optee_os/core/arch/arm/kernel/ree_fs_ta.c:146
 E/TC:0 0  0x5a9c9f77 system_open_ta_binary at optee_os/core/pta/system.c:259
 E/TC:0 0  0x5a9ca873 invoke_command at optee_os/core/pta/system.c:890
 E/TC:0 0  0x5a9e3553 pseudo_ta_enter_invoke_cmd at optee_os/core/arch/arm/kernel/pseudo_ta.c:198
 E/TC:0 0  0x5a9ef059 tee_ta_invoke_command at optee_os/core/kernel/tee_ta_manager.c:767
 E/TC:0 0  0x5a9f345f syscall_invoke_ta_command at optee_os/core/tee/tee_svc.c:887
 E/TC:0 0  0x5a9c3128 tee_svc_do_call at optee_os/core/arch/arm/tee/arch_svc_a32.S:54
```
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
