### PR TITLE
libutils: arm: add .cantunwind to __gnu_mcount_nc()

### DIFF
--- a/lib/libutils/ext/arch/arm/mcount_a32.S
+++ b/lib/libutils/ext/arch/arm/mcount_a32.S
@@ -25,6 +25,7 @@
  *   void __mcount_internal(void *frompc, void *selfpc);
  */
 FUNC __gnu_mcount_nc, :
+UNWIND(	.cantunwind)
 	stmdb		sp!, {r0-r3, lr}
 #if defined(CFG_TA_GPROF_SUPPORT) && !defined(__KERNEL__)
 	ldr		r0, [sp, #20]		/* lr of instrumented func */


### PR DESCRIPTION
The __gnu_mcount_nc() function lacks proper annotation as registers are
pushed onto the stack. The unwind table information for this symbol is
therefore incorrect and stack unwinding may fail in spectacular ways.
For example, xtest 1007 enters an infinite loop as ldelf tries to unwind
the call stack when the TA panics:
```
 # Platform: QEMU
 (buildhost)$ make CFG_FTRACE_SUPPORT=y CFLAGS_ta_arm32=-pg run
 (qemu)$ xtest 1007
 ...
 E/TC:? 0 TA panicked with code 0xbeef
 E/LD:  Status of TA 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b
 E/LD:   arch: arm
 E/LD:  region  0: va 0x00102000 pa 0x0e300000 size 0x002000 flags rw-s (ldelf)
 E/LD:  region  1: va 0x00104000 pa 0x0e302000 size 0x00c000 flags r-xs (ldelf)
 E/LD:  region  2: va 0x00110000 pa 0x0e30e000 size 0x001000 flags rw-s (ldelf)
 E/LD:  region  3: va 0x00111000 pa 0x0e30f000 size 0x004000 flags rw-s (ldelf)
 E/LD:  region  4: va 0x00115000 pa 0x0e313000 size 0x001000 flags r--s
 E/LD:  region  5: va 0x00116000 pa 0x0e426000 size 0x003000 flags rw-s (stack)
 E/LD:  region  6: va 0x00149000 pa 0x00001000 size 0x02b000 flags r-xs [0] .ta_head .text .plt .rodata .gnu.hash .ARM.extab .ARM.exidx .dynsym .dynstr .hash
 E/LD:  region  7: va 0x00174000 pa 0x0002c000 size 0x0e7000 flags rw-s [0] .dynamic .tdata .tbss .got .rel.got .rel.plt .data .init_array .bss .rel.dyn
 E/LD:  region  8: va 0x00291000 pa 0x00000000 size 0x00b000 flags r-xs [1] .hash .gnu.hash .dynsym .dynstr .rel.dyn .rel.plt .plt .text .rodata .ARM.extab .ARM.exidx
 E/LD:  region  9: va 0x0029c000 pa 0x0000a000 size 0x002000 flags rw-s [1] .tdata .tbss .init_array .dynamic .got .data .bss
 E/LD:   [0] 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b @ 0x00149000 (out-br/build/optee_test_ext-1.0/ta/os_test/out/5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf)
 E/LD:   [1] ffd2bded-ab7d-4988-95ee-e4962fff7154 @ 0x00291000 (out-br/build/optee_test_ext-1.0/ta/os_test_lib/out/libos_test.so)
 E/LD:  Call stack:
 E/LD:   0x0029481c _utee_panic at optee_os/lib/libutee/arch/arm/utee_syscalls_a32.S:51
 E/LD:   0x002944fc TEE_Panic at optee_os/lib/libutee/tee_api_panic.c:24
 E/LD:   0x0014c494 ta_entry_panic at out-br/build/optee_test_ext-1.0/ta/os_test/os_test.c:787
 E/LD:   0x00293574 __gnu_mcount_nc at optee_os/lib/libutils/ext/arch/arm/mcount_a32.S:44
 E/LD:   0x00293574 __gnu_mcount_nc at optee_os/lib/libutils/ext/arch/arm/mcount_a32.S:44
 E/LD:   0x00293574 __gnu_mcount_nc at optee_os/lib/libutils/ext/arch/arm/mcount_a32.S:44
 [repeats indefinitely]
```
The bug is triggered by commit 3513f961cda0 ("arm32: fold
UNWIND(.fnstart/.fnend) into the FUNC macros"). Prior to that commit,
the unwind entry for __gnu_mcount_nc() was "0x1 [cantunwind]", probably
because the function had no .fnstart/.fnend directive.

This commit adds a .cantunwind directive to restore the previous
behavior: unwinding stops at __gnu_mcount_nc(). Since the ftrace code
overwrites LR on the stack, it seems there is no simple way to produce
correct and comprehensive stack dumps short of introducing an unwind
helper function with a knowledge of the ftrace transformation, similar
to what ftrace_return() does.

At least with this patch the unwinding code does not fail.

Fixes: 3513f961cda0 ("arm32: fold UNWIND(.fnstart/.fnend) into the FUNC macros")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
