### PR TITLE
core: use vaddr_t instead of uint32_t for object IDs

### DIFF
--- a/core/include/tee/tee_obj.h
+++ b/core/include/tee/tee_obj.h
@@ -6,9 +6,10 @@
 #ifndef TEE_OBJ_H
 #define TEE_OBJ_H
 
-#include <tee_api_types.h>
 #include <kernel/tee_ta_manager.h>
 #include <sys/queue.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
 
 #define TEE_USAGE_DEFAULT   0xffffffff
 
@@ -25,7 +26,7 @@ struct tee_obj {
 
 void tee_obj_add(struct user_ta_ctx *utc, struct tee_obj *o);
 
-TEE_Result tee_obj_get(struct user_ta_ctx *utc, uint32_t obj_id,
+TEE_Result tee_obj_get(struct user_ta_ctx *utc, vaddr_t obj_id,
 		       struct tee_obj **obj);
 
 void tee_obj_close(struct user_ta_ctx *utc, struct tee_obj *o);

--- a/core/tee/tee_obj.c
+++ b/core/tee/tee_obj.c
@@ -19,7 +19,7 @@ void tee_obj_add(struct user_ta_ctx *utc, struct tee_obj *o)
 	TAILQ_INSERT_TAIL(&utc->objects, o, link);
 }
 
-TEE_Result tee_obj_get(struct user_ta_ctx *utc, uint32_t obj_id,
+TEE_Result tee_obj_get(struct user_ta_ctx *utc, vaddr_t obj_id,
 		       struct tee_obj **obj)
 {
 	struct tee_obj *o;

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2039,7 +2039,7 @@ out:
 }
 
 static TEE_Result tee_svc_cryp_get_state(struct tee_ta_session *sess,
-					 uint32_t state_id,
+					 vaddr_t state_id,
 					 struct tee_cryp_state **state)
 {
 	struct tee_cryp_state *s;

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -63,7 +63,7 @@ struct tee_storage_enum {
 };
 
 static TEE_Result tee_svc_storage_get_enum(struct user_ta_ctx *utc,
-					   uint32_t enum_id,
+					   vaddr_t enum_id,
 					   struct tee_storage_enum **e_out)
 {
 	struct tee_storage_enum *e;


### PR DESCRIPTION
Some function incorrectly use uint32_t for object identifiers:
tee_obj_get(), tee_svc_cryp_get_state() and tee_svc_storage_get_enum().
Those object IDs are actually virtual addresses so they need to be of
type vaddr_t.

Link: https://github.com/OP-TEE/optee_os/issues/4035#issuecomment-680037072
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
