### PR TITLE
plat: zynqmp: force disable core ALSR

### DIFF
--- a/core/arch/arm/plat-zynqmp/conf.mk
+++ b/core/arch/arm/plat-zynqmp/conf.mk
@@ -8,6 +8,12 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
+# Disable core ASLR for two reasons:
+# 1. There is no source for ALSR seed, as ATF does not provide a
+#    DTB to OP-TEE. Hardware RNG is also not currently supported.
+# 2. OP-TEE does not boot with enabled CFG_CORE_ASLR.
+$(call force,CFG_CORE_ASLR,n)
+
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_WITH_LPAE,y)
 else


### PR DESCRIPTION
Disable core ASLR for two reasons:
1. There is no source for ALSR seed, as ATF does not provide a
   DTB to OP-TEE. Hardware RNG is also not currently supported.
2. OP-TEE does not boot with enabled CFG_CORE_ASLR.

Further investigation is needed to see why enabled ASLR causes
OP-TEE to not boot properly.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>