### PR TITLE
plat: zynqmp: reduce default tzdram/tee shmem size

### DIFF
--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -57,11 +57,11 @@
 #define DRAM0_SIZE		0x80000000
 
 /* Location of trusted dram */
-#define TZDRAM_BASE		0x60000000
-#define TZDRAM_SIZE		0x10000000
+#define TZDRAM_BASE		0x7e000000
+#define TZDRAM_SIZE		(28 * 1024 * 1024)
 
-#define TEE_SHMEM_START		0x70000000
-#define TEE_SHMEM_SIZE		0x10000000
+#define TEE_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
+#define TEE_SHMEM_SIZE		(4 * 1024 * 1024)
 
 #define GICD_OFFSET		0
 #define GICC_OFFSET		0x20000
@@ -85,11 +85,11 @@
 #define DRAM0_SIZE		0x80000000
 
 /* Location of trusted dram */
-#define TZDRAM_BASE		0x60000000
-#define TZDRAM_SIZE		0x10000000
+#define TZDRAM_BASE		0x7e000000
+#define TZDRAM_SIZE		(28 * 1024 * 1024)
 
-#define TEE_SHMEM_START		0x70000000
-#define TEE_SHMEM_SIZE		0x10000000
+#define TEE_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
+#define TEE_SHMEM_SIZE		(4 * 1024 * 1024)
 
 #define GICD_OFFSET		0
 #define GICC_OFFSET		0x20000


### PR DESCRIPTION
Previous default size for both tzdram and tee shmem were way too big
(256MB each), consuming a considerable amount of dram space.

Reduce to a more sane size, giving 28MB to tzdram and 4MB to tee shmem.

Changes done for platforms zc1751_dc1, zc1751_dc2, zcu102 and ultra96.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>