### PR TITLE
core: ffa: Fix the ff-a version returned to Secure Partition

### DIFF
--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -743,7 +743,8 @@ static bool spm_handle_svc(struct thread_svc_regs *regs)
 	switch (regs->x0) {
 	case FFA_VERSION:
 		DMSG("Received FFA version");
-		regs->x0 = FFA_VERSION;
+		regs->x0 = MAKE_FFA_VERSION(FFA_VERSION_MAJOR,
+					    FFA_VERSION_MINOR);
 		return true;
 	case FFA_MSG_SEND_DIRECT_RESP_64:
 		DMSG("Received FFA direct response");


### PR DESCRIPTION
The current Firmware Framework(FF-A) specification defines the major
version of 0x1 and minor version of 0x0. Return these values when
requested through the FFA_VERSION call instead of returning the
FFA_VERSION function id

Signed-off-by: Sughosh Ganu <sughosh.ganu@linaro.org>
