### PR TITLE
core: rpmb: fix off-by-one in block index check

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -571,7 +571,7 @@ static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,
 
 		if (rawdata->blk_idx) {
 			/* Check the block index is within range. */
-			if ((*rawdata->blk_idx + nbr_frms) >
+			if ((*rawdata->blk_idx + nbr_frms - 1) >
 			    rpmb_ctx->max_blk_idx) {
 				res = TEE_ERROR_GENERIC;
 				goto func_exit;


### PR DESCRIPTION
The max block index check in tee_rpmb_req_pack() is incorrect and would
fail when trying to access the last block of the partition.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
