### PR TITLE
stm32mp1: PMIC regulators exposed thru SCMI and minor fixes

### DIFF
--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -109,7 +109,7 @@ struct scmi_msg_channel *plat_scmi_get_channel(unsigned int agent_id)
 		.enabled = _init_enabled, \
 	}
 
-struct stm32_scmi_clk stm32_scmi0_clock[] = {
+static struct stm32_scmi_clk stm32_scmi0_clock[] = {
 	CLOCK_CELL(CK_SCMI0_HSE, CK_HSE, "ck_hse", true),
 	CLOCK_CELL(CK_SCMI0_HSI, CK_HSI, "ck_hsi", true),
 	CLOCK_CELL(CK_SCMI0_CSI, CK_CSI, "ck_csi", true),
@@ -133,7 +133,7 @@ struct stm32_scmi_clk stm32_scmi0_clock[] = {
 	CLOCK_CELL(CK_SCMI0_USART1, USART1_K, "usart1_k", false),
 };
 
-struct stm32_scmi_clk stm32_scmi1_clock[] = {
+static struct stm32_scmi_clk stm32_scmi1_clock[] = {
 	CLOCK_CELL(CK_SCMI1_PLL3_Q, PLL3_Q, "pll3_q", true),
 	CLOCK_CELL(CK_SCMI1_PLL3_R, PLL3_R, "pll3_r", true),
 	CLOCK_CELL(CK_SCMI1_MCU, CK_MCU, "ck_mcu", false),
@@ -145,7 +145,7 @@ struct stm32_scmi_clk stm32_scmi1_clock[] = {
 		.name = _name, \
 	}
 
-struct stm32_scmi_rd stm32_scmi0_reset_domain[] = {
+static struct stm32_scmi_rd stm32_scmi0_reset_domain[] = {
 	RESET_CELL(RST_SCMI0_SPI6, SPI6_R, "spi6"),
 	RESET_CELL(RST_SCMI0_I2C4, I2C4_R, "i2c4"),
 	RESET_CELL(RST_SCMI0_I2C6, I2C6_R, "i2c6"),
@@ -190,7 +190,7 @@ struct scmi_agent_resources {
 	size_t voltd_count;
 };
 
-const struct scmi_agent_resources agent_resources[] = {
+static const struct scmi_agent_resources agent_resources[] = {
 	[0] = {
 		.clock = stm32_scmi0_clock,
 		.clock_count = ARRAY_SIZE(stm32_scmi0_clock),

--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -182,10 +182,6 @@ struct scmi_agent_resources {
 	size_t clock_count;
 	struct stm32_scmi_rd *rd;
 	size_t rd_count;
-	struct stm32_scmi_pd *pd;
-	size_t pd_count;
-	struct stm32_scmi_perfs *perfs;
-	size_t perfs_count;
 	struct stm32_scmi_voltd *voltd;
 	size_t voltd_count;
 };
@@ -226,18 +222,6 @@ static size_t __maybe_unused plat_scmi_protocol_count_paranoid(void)
 
 	for (n = 0; n < agent_count; n++)
 		if (agent_resources[n].rd_count)
-			break;
-	if (n < agent_count)
-		count++;
-
-	for (n = 0; n < agent_count; n++)
-		if (agent_resources[n].pd_count)
-			break;
-	if (n < agent_count)
-		count++;
-
-	for (n = 0; n < agent_count; n++)
-		if (agent_resources[n].perfs_count)
 			break;
 	if (n < agent_count)
 		count++;

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -74,8 +74,15 @@ bool stm32_clock_is_enabled(unsigned long id);
 /* Return true if @clock_id is shared by secure and non-secure worlds */
 bool stm32mp_nsec_can_access_clock(unsigned long clock_id);
 
+#if defined(CFG_STPMIC1)
 /* Return true if non-secure world can manipulate regulator @pmic_regu_name */
 bool stm32mp_nsec_can_access_pmic_regu(const char *pmic_regu_name);
+#else
+static inline bool stm32mp_nsec_can_access_pmic_regu(const char *name __unused)
+{
+	return false;
+}
+#endif
 
 /*
  * Util for reset signal assertion/desassertion for stm32 and platform drivers


### PR DESCRIPTION
This P-R is the companion of https://github.com/OP-TEE/optee_os/pull/4134 that introduced SCMI voltage domains.
This P-R allows STM32MP15 boards to expose some PMIC regulators to the non-secure world thorugh SCMI.
It also includes minor fixup commits to clean platform implementation in the SCMI service.