### PR TITLE
scripts: support both pycryptodome and pycryptodomex

### DIFF
--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -21,8 +21,12 @@ def get_args():
 
 def main():
     import array
-    from Cryptodome.PublicKey import RSA
-    from Cryptodome.Util.number import long_to_bytes
+    try:
+        from Cryptodome.PublicKey import RSA
+        from Cryptodome.Util.number import long_to_bytes
+    except ImportError:
+        from Crypto.PublicKey import RSA
+        from Crypto.Util.number import long_to_bytes
 
     args = get_args()
 

--- a/scripts/sign_encrypt.py
+++ b/scripts/sign_encrypt.py
@@ -147,10 +147,16 @@ def get_args(logger):
 
 
 def main():
-    from Cryptodome.Signature import pss
-    from Cryptodome.Signature import pkcs1_15
-    from Cryptodome.Hash import SHA256
-    from Cryptodome.PublicKey import RSA
+    try:
+        from Cryptodome.Signature import pss
+        from Cryptodome.Signature import pkcs1_15
+        from Cryptodome.Hash import SHA256
+        from Cryptodome.PublicKey import RSA
+    except ImportError:
+        from Crypto.Signature import pss
+        from Crypto.Signature import pkcs1_15
+        from Crypto.Hash import SHA256
+        from Crypto.PublicKey import RSA
     import base64
     import logging
     import os


### PR DESCRIPTION
Current actual Python library for cryptography is being distributed in
two flavors: pycroptodome and pycroptodomex. They are basically the same
library, but with different import names:

 - pycryptodome provides 'Crypto' module and indented to directly replace old
   pycrypto library

 - pycryptodomex provides 'Cryptodome' module and is intended for old
   distributions, where pycrypto is still present

Most of the modern Linux distributions provide both of the libraries, so there
is no difference which one is to use. But some of them (like Yocto/Poky) provide
only one.

This patches makes scripts agnostic to a crypto library flavor being used by
trying to import Cryptodome first and then Crypto if first import fails.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
