### PR TITLE
Asym crypto/ecc keys ops

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -750,25 +750,29 @@ TEE_Result crypto_acipher_ecc_shared_secret(struct ecc_keypair *private_key,
 					       secret_len);
 }
 
-#if !defined(CFG_CRYPTO_SM2_PKE)
-TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key __unused,
-					  const uint8_t *src __unused,
-					  size_t src_len __unused,
-					  uint8_t *dst __unused,
-					  size_t *dst_len __unused)
+TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key,
+					  const uint8_t *src, size_t src_len,
+					  uint8_t *dst, size_t *dst_len)
 {
-	return TEE_ERROR_NOT_IMPLEMENTED;
+	assert(key->ops);
+
+	if (!key->ops->decrypt)
+		return TEE_ERROR_NOT_IMPLEMENTED;
+
+	return key->ops->decrypt(key, src, src_len, dst, dst_len);
 }
 
-TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key __unused,
-					  const uint8_t *src __unused,
-					  size_t src_len __unused,
-					  uint8_t *dst __unused,
-					  size_t *dst_len __unused)
+TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key,
+					  const uint8_t *src, size_t src_len,
+					  uint8_t *dst, size_t *dst_len)
 {
-	return TEE_ERROR_NOT_IMPLEMENTED;
+	assert(key->ops);
+
+	if (!key->ops->encrypt)
+		return TEE_ERROR_NOT_IMPLEMENTED;
+
+	return key->ops->encrypt(key, src, src_len, dst, dst_len);
 }
-#endif /* !CFG_CRYPTO_SM2_PKE */
 
 #if !defined(CFG_CRYPTO_SM2_KEP)
 TEE_Result crypto_acipher_sm2_kep_derive(struct ecc_keypair *my_key __unused,

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -770,27 +770,6 @@ TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key __unused,
 }
 #endif /* !CFG_CRYPTO_SM2_PKE */
 
-#if !defined(CFG_CRYPTO_SM2_DSA)
-TEE_Result crypto_acipher_sm2_dsa_sign(uint32_t algo __unused,
-				       struct ecc_keypair *key __unused,
-				       const uint8_t *msg __unused,
-				       size_t msg_len __unused,
-				       uint8_t *sig __unused,
-				       size_t *sig_len __unused)
-{
-	return TEE_ERROR_NOT_IMPLEMENTED;
-}
-
-TEE_Result crypto_acipher_sm2_dsa_verify(uint32_t algo __unused,
-					 struct ecc_public_key *key __unused,
-					 const uint8_t *msg __unused,
-					 size_t msg_len __unused,
-					 const uint8_t *sig __unused,
-					 size_t sig_len __unused)
-{
-	return TEE_ERROR_NOT_IMPLEMENTED;
-}
-#endif /* !CFG_CRYPTO_SM2_DSA */
 #if !defined(CFG_CRYPTO_SM2_KEP)
 TEE_Result crypto_acipher_sm2_kep_derive(struct ecc_keypair *my_key __unused,
 					 struct ecc_keypair *my_eph_key

--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2018-2020 NXP
+ *
+ * Crypto ECC interface implementation to enable HW driver.
+ */
+#include <crypto/crypto_impl.h>
+#include <drvcrypt.h>
+#include <drvcrypt_acipher.h>
+#include <tee/tee_cryp_utl.h>
+#include <utee_defines.h>
+
+/*
+ * Returns the key size in bytes for the given ECC curve
+ *
+ * @curve   ECC Curve ID
+ */
+static size_t get_ecc_key_size_bytes(uint32_t curve)
+{
+	switch (curve) {
+	case TEE_ECC_CURVE_NIST_P192:
+		return 24;
+
+	case TEE_ECC_CURVE_NIST_P224:
+		return 28;
+
+	case TEE_ECC_CURVE_NIST_P256:
+		return 32;
+
+	case TEE_ECC_CURVE_NIST_P384:
+		return 48;
+
+	case TEE_ECC_CURVE_NIST_P521:
+		return 66;
+
+	default:
+		return 0;
+	}
+}
+
+/*
+ * Verify if the cryptographic algorithm @algo is valid for
+ * the ECC curve
+ *
+ * @curve   ECC curve
+ * @algo    Cryptographic algorithm
+ */
+static bool algo_is_valid(uint32_t curve, uint32_t algo)
+{
+	unsigned int algo_op = TEE_ALG_GET_CLASS(algo);
+	unsigned int algo_id = TEE_ALG_GET_MAIN_ALG(algo);
+	unsigned int algo_curve = TEE_ALG_GET_DIGEST_HASH(algo);
+
+	/* Check first the algo operation and id */
+	if ((algo_op == TEE_OPERATION_ASYMMETRIC_SIGNATURE &&
+	     algo_id == TEE_MAIN_ALGO_ECDSA) ||
+	    (algo_op == TEE_OPERATION_KEY_DERIVATION &&
+	     algo_id == TEE_MAIN_ALGO_ECDH)) {
+		if (curve == algo_curve) {
+			CRYPTO_TRACE("Algo 0x%" PRIx32 " curve 0x%" PRIx32
+				     " is valid", algo, curve);
+			return true;
+		}
+	}
+
+	CRYPTO_TRACE("Algo 0x%" PRIx32 " curve 0x%" PRIx32 " is not valid",
+		     algo, curve);
+
+	return false;
+}
+
+/*
+ * Free an ECC public key
+ *
+ * @key   Public Key
+ */
+static void ecc_free_public_key(struct ecc_public_key *key)
+{
+	struct drvcrypt_ecc *ecc = NULL;
+
+	if (key) {
+		ecc = drvcrypt_get_ops(CRYPTO_ECC);
+		if (ecc) {
+			CRYPTO_TRACE("ECC Public Key free");
+			ecc->free_publickey(key);
+		}
+	}
+}
+
+/*
+ * Generates an ECC keypair
+ *
+ * @key        Keypair
+ * @size_bits  Key size in bits
+ */
+static TEE_Result ecc_generate_keypair(struct ecc_keypair *key,
+				       size_t size_bits __maybe_unused)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct drvcrypt_ecc *ecc = NULL;
+
+	/* Check input parameters */
+	if (!key) {
+		CRYPTO_TRACE("Parameters error key is NULL");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+	if (ecc)
+		ret = ecc->gen_keypair(key, get_ecc_key_size_bytes(key->curve));
+
+	CRYPTO_TRACE("ECC Keypair (%zu bits) generate ret = 0x%" PRIx32,
+		     size_bits, ret);
+
+	return ret;
+}
+
+/*
+ * Sign the message with the ECC Key given by the Keypair
+ *
+ * @algo       ECC algorithm
+ * @key        ECC Keypair
+ * @msg        Message to sign
+ * @msg_len    Length of the message (bytes)
+ * @sig        Signature
+ * @sig_len    [in/out] Length of the signature (bytes)
+ */
+static TEE_Result ecc_sign(uint32_t algo, struct ecc_keypair *key,
+			   const uint8_t *msg, size_t msg_len, uint8_t *sig,
+			   size_t *sig_len)
+{
+	TEE_Result ret = TEE_ERROR_BAD_PARAMETERS;
+	struct drvcrypt_ecc *ecc = NULL;
+	struct drvcrypt_sign_data sdata = { };
+	size_t size_bytes = 0;
+
+	/* Verify first the input parameters */
+	if (!key || !msg || !sig || !sig_len) {
+		CRYPTO_TRACE("Input parameters reference error");
+		return ret;
+	}
+
+	if (!algo_is_valid(key->curve, algo))
+		return ret;
+
+	size_bytes = get_ecc_key_size_bytes(key->curve);
+	if (!size_bytes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Verify the signature length function of the key size */
+	if (*sig_len < 2 * size_bytes) {
+		CRYPTO_TRACE("Length (%zu) too short expected %zu bytes",
+			     *sig_len, 2 * size_bytes);
+		*sig_len = 2 * size_bytes;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+	if (ecc) {
+		/*
+		 * Prepare the Signature structure data
+		 */
+		sdata.algo = algo;
+		sdata.key = key;
+		sdata.size_sec = size_bytes;
+		sdata.message.data = (uint8_t *)msg;
+		sdata.message.length = msg_len;
+		sdata.signature.data = (uint8_t *)sig;
+		sdata.signature.length = *sig_len;
+
+		ret = ecc->sign(&sdata);
+
+		/* Set the signature length */
+		*sig_len = sdata.signature.length;
+	} else {
+		ret = TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	CRYPTO_TRACE("Sign algo (0x%" PRIx32 ") returned 0x%" PRIx32, algo,
+		     ret);
+
+	return ret;
+}
+
+/*
+ * Verify if signature is signed with the given public key.
+ *
+ * @algo       ECC algorithm
+ * @key        ECC Public key
+ * @msg        Message to sign
+ * @msg_len    Length of the message (bytes)
+ * @sig        Signature
+ * @sig_len    Length of the signature (bytes)
+ */
+static TEE_Result ecc_verify(uint32_t algo, struct ecc_public_key *key,
+			     const uint8_t *msg, size_t msg_len,
+			     const uint8_t *sig, size_t sig_len)
+{
+	TEE_Result ret = TEE_ERROR_BAD_PARAMETERS;
+	struct drvcrypt_ecc *ecc = NULL;
+	struct drvcrypt_sign_data sdata = { };
+	size_t size_bytes = 0;
+
+	/* Verify first the input parameters */
+	if (!key || !msg || !sig) {
+		CRYPTO_TRACE("Input parameters reference error");
+		return ret;
+	}
+
+	if (!algo_is_valid(key->curve, algo))
+		return ret;
+
+	size_bytes = get_ecc_key_size_bytes(key->curve);
+	if (!size_bytes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Verify the signature length against key size */
+	if (sig_len != 2 * size_bytes) {
+		CRYPTO_TRACE("Length (%zu) is invalid expected %zu bytes",
+			     sig_len, 2 * size_bytes);
+		return TEE_ERROR_SIGNATURE_INVALID;
+	}
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+	if (ecc) {
+		sdata.algo = algo;
+		sdata.key = key;
+		sdata.size_sec = size_bytes;
+		sdata.message.data = (uint8_t *)msg;
+		sdata.message.length = msg_len;
+		sdata.signature.data = (uint8_t *)sig;
+		sdata.signature.length = sig_len;
+
+		ret = ecc->verify(&sdata);
+	} else {
+		ret = TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	CRYPTO_TRACE("Verify algo (0x%" PRIx32 ") returned 0x%" PRIx32, algo,
+		     ret);
+
+	return ret;
+}
+
+/*
+ * Compute the shared secret data from ECC Private key and Public Key
+ *
+ * @private_key  ECC Private key
+ * @public_key   ECC Public key
+ * @secret       Secret
+ * @secret_len   Length of the secret (bytes)
+ */
+static TEE_Result ecc_shared_secret(struct ecc_keypair *private_key,
+				    struct ecc_public_key *public_key,
+				    void *secret, unsigned long *secret_len)
+{
+	TEE_Result ret = TEE_ERROR_BAD_PARAMETERS;
+	struct drvcrypt_ecc *ecc = NULL;
+	struct drvcrypt_secret_data sdata = { };
+	size_t size_bytes = 0;
+
+	/* Verify first the input parameters */
+	if (!private_key || !public_key || !secret || !secret_len) {
+		CRYPTO_TRACE("Input parameters reference error");
+		return ret;
+	}
+
+	if (private_key->curve != public_key->curve) {
+		CRYPTO_TRACE("Private Key curve (%d) != Public Key curve (%d)",
+			     private_key->curve, public_key->curve);
+		return ret;
+	}
+
+	size_bytes = get_ecc_key_size_bytes(public_key->curve);
+	if (!size_bytes)
+		return ret;
+
+	if (*secret_len < size_bytes) {
+		*secret_len = size_bytes;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+	if (ecc) {
+		/*
+		 * Prepare the Secret structure data
+		 */
+		sdata.key_priv = private_key;
+		sdata.key_pub = public_key;
+		sdata.size_sec = size_bytes;
+		sdata.secret.data = secret;
+		sdata.secret.length = *secret_len;
+
+		ret = ecc->shared_secret(&sdata);
+
+		/* Set the secret length */
+		*secret_len = sdata.secret.length;
+	} else {
+		ret = TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	CRYPTO_TRACE("Shared Secret returned 0x%" PRIx32, ret);
+
+	return ret;
+}
+
+static const struct crypto_ecc_keypair_ops ecc_keypair_ops = {
+	.generate = &ecc_generate_keypair,
+	.sign = &ecc_sign,
+	.shared_secret = &ecc_shared_secret,
+};
+
+TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
+					   uint32_t type, size_t size_bits)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct drvcrypt_ecc *ecc = NULL;
+
+	if (!key || !size_bits) {
+		CRYPTO_TRACE("Bad parameters (key @%p)(size %zu bits)", key,
+			     size_bits);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	switch (type) {
+	case TEE_TYPE_ECDSA_KEYPAIR:
+	case TEE_TYPE_ECDH_KEYPAIR:
+		ecc = drvcrypt_get_ops(CRYPTO_ECC);
+		break;
+	default:
+		break;
+	}
+
+	if (ecc)
+		ret = ecc->alloc_keypair(key, size_bits);
+
+	if (!ret)
+		key->ops = &ecc_keypair_ops;
+
+	CRYPTO_TRACE("ECC Keypair (%zu bits) alloc ret = 0x%" PRIx32, size_bits,
+		     ret);
+	return ret;
+}
+
+static const struct crypto_ecc_public_ops ecc_public_key_ops = {
+	.free = &ecc_free_public_key,
+	.verify = &ecc_verify,
+};
+
+TEE_Result drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key,
+					      uint32_t type, size_t size_bits)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct drvcrypt_ecc *ecc = NULL;
+
+	if (!key || !size_bits) {
+		CRYPTO_TRACE("Bad parameters (key @%p)(size %zu bits)", key,
+			     size_bits);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	switch (type) {
+	case TEE_TYPE_ECDSA_PUBLIC_KEY:
+	case TEE_TYPE_ECDH_PUBLIC_KEY:
+		ecc = drvcrypt_get_ops(CRYPTO_ECC);
+		break;
+	default:
+		break;
+	}
+
+	if (ecc)
+		ret = ecc->alloc_publickey(key, size_bits);
+
+	if (!ret)
+		key->ops = &ecc_public_key_ops;
+
+	CRYPTO_TRACE("ECC Public Key (%zu bits) alloc ret = 0x%" PRIx32,
+		     size_bits, ret);
+	return ret;
+}

--- a/core/drivers/crypto/crypto_api/acipher/sub.mk
+++ b/core/drivers/crypto/crypto_api/acipher/sub.mk
@@ -1,1 +1,2 @@
 srcs-$(CFG_CRYPTO_DRV_RSA) += rsa.c rsamgf.c rsassa.c
+srcs-$(CFG_CRYPTO_DRV_ECC) += ecc.c

--- a/core/drivers/crypto/crypto_api/include/drvcrypt.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt.h
@@ -54,6 +54,7 @@ enum drvcrypt_algo_id {
 	CRYPTO_RSA,      /* Asymmetric RSA driver */
 	CRYPTO_MATH,	 /* Mathematical driver */
 	CRYPTO_CIPHER,   /* Cipher driver */
+	CRYPTO_ECC,      /* Asymmetric ECC driver */
 	CRYPTO_MAX_ALGO  /* Maximum number of algo supported */
 };
 

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -111,4 +111,56 @@ static inline TEE_Result drvcrypt_register_rsa(const struct drvcrypt_rsa *ops)
 	return drvcrypt_register(CRYPTO_RSA, (void *)ops);
 }
 
+/*
+ * Signature data
+ */
+struct drvcrypt_sign_data {
+	uint32_t algo;               /* Operation algorithm */
+	void *key;                   /* Public or Private Key */
+	size_t size_sec;             /* Security size in bytes */
+	struct drvcrypt_buf message;    /* Message to sign or signed */
+	struct drvcrypt_buf signature;  /* Signature of the message */
+};
+
+/*
+ * Shared Secret data
+ */
+struct drvcrypt_secret_data {
+	void *key_priv;		    /* Private Key */
+	void *key_pub;		    /* Public Key */
+	size_t size_sec;	    /* Security size in bytes */
+	struct drvcrypt_buf secret; /* Shared secret */
+};
+
+/*
+ * Crypto ECC driver operations
+ */
+struct drvcrypt_ecc {
+	/* Allocates the ECC keypair */
+	TEE_Result (*alloc_keypair)(struct ecc_keypair *key, size_t size_bits);
+	/* Allocates the ECC public key */
+	TEE_Result (*alloc_publickey)(struct ecc_public_key *key,
+				      size_t size_bits);
+	/* Free ECC public key */
+	void (*free_publickey)(struct ecc_public_key *key);
+	/* Generates the ECC keypair */
+	TEE_Result (*gen_keypair)(struct ecc_keypair *key, size_t size_bytes);
+	/* ECC Sign a message and returns the signature */
+	TEE_Result (*sign)(struct drvcrypt_sign_data *sdata);
+	/* ECC Verify a message's signature */
+	TEE_Result (*verify)(struct drvcrypt_sign_data *sdata);
+	/* ECC Shared Secret */
+	TEE_Result (*shared_secret)(struct drvcrypt_secret_data *sdata);
+};
+
+/*
+ * Register an ECC processing driver in the crypto API
+ *
+ * @ops - Driver operations in the HW layer
+ */
+static inline TEE_Result drvcrypt_register_ecc(struct drvcrypt_ecc *ops)
+{
+	return drvcrypt_register(CRYPTO_ECC, (void *)ops);
+}
+
 #endif /* __DRVCRYPT_ACIPHER_H__ */

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -153,6 +153,7 @@ struct ecc_public_key {
 	struct bignum *x;	/* Public value x */
 	struct bignum *y;	/* Public value y */
 	uint32_t curve;	        /* Curve type */
+	const struct crypto_ecc_public_ops *ops; /* Key Operations */
 };
 
 struct ecc_keypair {
@@ -160,6 +161,7 @@ struct ecc_keypair {
 	struct bignum *x;	/* Public value x */
 	struct bignum *y;	/* Public value y */
 	uint32_t curve;	        /* Curve type */
+	const struct crypto_ecc_keypair_ops *ops; /* Key Operations */
 };
 
 /*
@@ -180,9 +182,11 @@ TEE_Result crypto_acipher_alloc_dsa_public_key(struct dsa_public_key *s,
 TEE_Result crypto_acipher_alloc_dh_keypair(struct dh_keypair *s,
 			       size_t key_size_bits);
 TEE_Result crypto_acipher_alloc_ecc_public_key(struct ecc_public_key *s,
-				   size_t key_size_bits);
+					       uint32_t key_type,
+					       size_t key_size_bits);
 TEE_Result crypto_acipher_alloc_ecc_keypair(struct ecc_keypair *s,
-				size_t key_size_bits);
+					    uint32_t key_type,
+					    size_t key_size_bits);
 void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s);
 
 /*

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -249,13 +249,6 @@ TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key,
 TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key,
 					  const uint8_t *src, size_t src_len,
 					  uint8_t *dst, size_t *dst_len);
-TEE_Result crypto_acipher_sm2_dsa_sign(uint32_t algo, struct ecc_keypair *key,
-				       const uint8_t *msg, size_t msg_len,
-				       uint8_t *sig, size_t *sig_len);
-TEE_Result crypto_acipher_sm2_dsa_verify(uint32_t algo,
-					 struct ecc_public_key *key,
-					 const uint8_t *msg, size_t msg_len,
-					 const uint8_t *sig, size_t sig_len);
 
 struct sm2_kep_parms {
 	uint8_t *out;

--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -303,18 +303,29 @@ drvcrypt_mac_alloc_ctx(struct crypto_mac_ctx **ctx __unused,
  * The ECC public key operations used by the crypto_acipher_ecc_*() and
  * crypto_acipher_free_ecc_*() functions.
  * Reference set in ecc_public_key when key allocated.
+ *
+ * @free    is mandatory
+ * @verify  is optional
+ * @encrypt is optional
  */
 struct crypto_ecc_public_ops {
 	void (*free)(struct ecc_public_key *key);
 	TEE_Result (*verify)(uint32_t algo, struct ecc_public_key *key,
 			     const uint8_t *msg, size_t msg_len,
 			     const uint8_t *sig, size_t sig_len);
+	TEE_Result (*encrypt)(struct ecc_public_key *key, const uint8_t *src,
+			      size_t src_len, uint8_t *dst, size_t *dst_len);
 };
 
 /*
  * The ECC keypair operations used by the crypto_acipher_ecc_*() and
  * crypto_acipher_gen_ecc_*() functions.
  * Reference set in ecc_keypair when key allocated.
+ *
+ * @generate      is mandatory
+ * @sign          is optional
+ * @shared_secret is optional
+ * @decrypt       is optional
  */
 struct crypto_ecc_keypair_ops {
 	TEE_Result (*generate)(struct ecc_keypair *key, size_t key_size_bits);
@@ -324,6 +335,8 @@ struct crypto_ecc_keypair_ops {
 	TEE_Result (*shared_secret)(struct ecc_keypair *private_key,
 				    struct ecc_public_key *public_key,
 				    void *secret, unsigned long *secret_len);
+	TEE_Result (*decrypt)(struct ecc_keypair *key, const uint8_t *src,
+			      size_t src_len, uint8_t *dst, size_t *dst_len);
 };
 
 #ifdef CFG_CRYPTO_ECC

--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -6,6 +6,7 @@
 #ifndef __CRYPTO_CRYPTO_IMPL_H
 #define __CRYPTO_CRYPTO_IMPL_H
 
+#include <crypto/crypto.h>
 #include <tee_api_types.h>
 
 /*
@@ -297,4 +298,81 @@ drvcrypt_mac_alloc_ctx(struct crypto_mac_ctx **ctx __unused,
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 #endif /* CFG_CRYPTO_DRV_MAC */
+
+/*
+ * The ECC public key operations used by the crypto_acipher_ecc_*() and
+ * crypto_acipher_free_ecc_*() functions.
+ * Reference set in ecc_public_key when key allocated.
+ */
+struct crypto_ecc_public_ops {
+	void (*free)(struct ecc_public_key *key);
+	TEE_Result (*verify)(uint32_t algo, struct ecc_public_key *key,
+			     const uint8_t *msg, size_t msg_len,
+			     const uint8_t *sig, size_t sig_len);
+};
+
+/*
+ * The ECC keypair operations used by the crypto_acipher_ecc_*() and
+ * crypto_acipher_gen_ecc_*() functions.
+ * Reference set in ecc_keypair when key allocated.
+ */
+struct crypto_ecc_keypair_ops {
+	TEE_Result (*generate)(struct ecc_keypair *key, size_t key_size_bits);
+	TEE_Result (*sign)(uint32_t algo, struct ecc_keypair *key,
+			   const uint8_t *msg, size_t msg_len, uint8_t *sig,
+			   size_t *sig_len);
+	TEE_Result (*shared_secret)(struct ecc_keypair *private_key,
+				    struct ecc_public_key *public_key,
+				    void *secret, unsigned long *secret_len);
+};
+
+#ifdef CFG_CRYPTO_ECC
+TEE_Result crypto_asym_alloc_ecc_public_key(struct ecc_public_key *key,
+					    uint32_t key_type,
+					    size_t key_size_bits);
+TEE_Result crypto_asym_alloc_ecc_keypair(struct ecc_keypair *key,
+					 uint32_t key_type,
+					 size_t key_size_bits);
+#else
+static inline TEE_Result
+crypto_asym_alloc_ecc_public_key(struct ecc_public_key *key __unused,
+				 uint32_t key_type __unused,
+				 size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static inline TEE_Result
+crypto_asym_alloc_ecc_keypair(struct ecc_keypair *key __unused,
+			      uint32_t key_type __unused,
+			      size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /* CFG_CRYPTO_ECC */
+
+#ifdef CFG_CRYPTO_DRV_ECC
+TEE_Result drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key,
+					      uint32_t key_type,
+					      size_t key_size_bits);
+TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
+					   uint32_t key_type,
+					   size_t key_size_bits);
+#else
+static inline TEE_Result
+drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key __unused,
+				   uint32_t key_type __unused,
+				   size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static inline TEE_Result
+drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key __unused,
+				uint32_t key_type __unused,
+				size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /* CFG_CRYPTO_DRV_ECC */
 #endif /*__CRYPTO_CRYPTO_IMPL_H*/

--- a/core/lib/libtomcrypt/acipher_helpers.h
+++ b/core/lib/libtomcrypt/acipher_helpers.h
@@ -53,4 +53,30 @@ TEE_Result ecc_populate_ltc_public_key(ecc_key *ltc_key,
 
 TEE_Result sm2_kdf(const uint8_t *Z, size_t Z_len, uint8_t *t, size_t tlen);
 
+#ifdef _CFG_CORE_LTC_SM2_DSA
+TEE_Result sm2_ltc_dsa_sign(uint32_t algo, struct ecc_keypair *key,
+			    const uint8_t *msg, size_t msg_len, uint8_t *sig,
+			    size_t *sig_len);
+
+TEE_Result sm2_ltc_dsa_verify(uint32_t algo, struct ecc_public_key *key,
+			      const uint8_t *msg, size_t msg_len,
+			      const uint8_t *sig, size_t sig_len);
+#else
+static inline TEE_Result
+sm2_ltc_dsa_sign(uint32_t algo __unused, struct ecc_keypair *key __unused,
+		 const uint8_t *msg __unused, size_t msg_len __unused,
+		 uint8_t *sig __unused, size_t *sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static inline TEE_Result
+sm2_ltc_dsa_verify(uint32_t algo __unused, struct ecc_public_key *key __unused,
+		   const uint8_t *msg __unused, size_t msg_len __unused,
+		   const uint8_t *sig __unused, size_t sig_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif
+
 #endif /* ACIPHER_HELPERS_H */

--- a/core/lib/libtomcrypt/acipher_helpers.h
+++ b/core/lib/libtomcrypt/acipher_helpers.h
@@ -79,4 +79,29 @@ sm2_ltc_dsa_verify(uint32_t algo __unused, struct ecc_public_key *key __unused,
 }
 #endif
 
+#ifdef _CFG_CORE_LTC_SM2_PKE
+TEE_Result sm2_ltc_pke_decrypt(struct ecc_keypair *key, const uint8_t *src,
+			       size_t src_len, uint8_t *dst, size_t *dst_len);
+
+TEE_Result sm2_ltc_pke_encrypt(struct ecc_public_key *key, const uint8_t *src,
+			       size_t src_len, uint8_t *dst, size_t *dst_len);
+
+#else
+static inline TEE_Result sm2_ltc_pke_decrypt(struct ecc_keypair *key __unused,
+					     const uint8_t *src __unused,
+					     size_t src_len __unused,
+					     uint8_t *dst __unused,
+					     size_t *dst_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static inline TEE_Result
+sm2_ltc_pke_encrypt(struct ecc_public_key *key __unused,
+		    const uint8_t *src __unused, size_t src_len __unused,
+		    uint8_t *dst __unused, size_t *dst_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif
 #endif /* ACIPHER_HELPERS_H */

--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -372,10 +372,12 @@ static const struct crypto_ecc_public_ops sm2_dsa_public_key_ops = {
 
 static const struct crypto_ecc_keypair_ops sm2_pke_keypair_ops = {
 	.generate = &_ltc_ecc_generate_keypair,
+	.decrypt = &sm2_ltc_pke_decrypt,
 };
 
 static const struct crypto_ecc_public_ops sm2_pke_public_key_ops = {
 	.free = &_ltc_ecc_free_public_key,
+	.encrypt = &sm2_ltc_pke_encrypt,
 };
 
 static const struct crypto_ecc_keypair_ops sm2_kep_keypair_ops = {

--- a/core/lib/libtomcrypt/sm2-dsa.c
+++ b/core/lib/libtomcrypt/sm2-dsa.c
@@ -18,10 +18,9 @@
 /*
  * GM/T 0003.1‒2012 Part1 2 Section 6.1
  */
-TEE_Result crypto_acipher_sm2_dsa_sign(uint32_t algo,
-				       struct ecc_keypair *key,
-				       const uint8_t *msg, size_t msg_len,
-				       uint8_t *sig, size_t *sig_len)
+TEE_Result sm2_ltc_dsa_sign(uint32_t algo, struct ecc_keypair *key,
+			    const uint8_t *msg, size_t msg_len, uint8_t *sig,
+			    size_t *sig_len)
 {
 	TEE_Result res = TEE_SUCCESS;
 	ecc_point *x1y1p = NULL;
@@ -137,10 +136,9 @@ out:
 /*
  * GM/T 0003.1‒2012 Part1 2 Section 7.1
  */
-TEE_Result crypto_acipher_sm2_dsa_verify(uint32_t algo,
-					 struct ecc_public_key *key,
-					 const uint8_t *msg, size_t msg_len,
-					 const uint8_t *sig, size_t sig_len)
+TEE_Result sm2_ltc_dsa_verify(uint32_t algo, struct ecc_public_key *key,
+			      const uint8_t *msg, size_t msg_len,
+			      const uint8_t *sig, size_t sig_len)
 {
 	TEE_Result res = TEE_SUCCESS;
 	ecc_key ltc_key = { };

--- a/core/lib/libtomcrypt/sm2-pke.c
+++ b/core/lib/libtomcrypt/sm2-pke.c
@@ -159,8 +159,10 @@ TEE_Result sm2_ltc_pke_decrypt(struct ecc_keypair *key, const uint8_t *src,
 		}
 
 		ltc_res = mp_init_multi(&h, NULL);
-		if (ltc_res != CRYPT_OK)
-			return TEE_ERROR_OUT_OF_MEMORY;
+		if (ltc_res != CRYPT_OK) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto out;
+		}
 
 		ltc_res = mp_set_int(h, ltc_key.dp.cofactor);
 		if (ltc_res != CRYPT_OK) {

--- a/core/lib/libtomcrypt/sm2-pke.c
+++ b/core/lib/libtomcrypt/sm2-pke.c
@@ -104,9 +104,8 @@ static bool is_zero(const uint8_t *buf, size_t size)
  * GM/T 0003.1‒2012 Part 4 Section 7.1
  * Decryption algorithm
  */
-TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key,
-					  const uint8_t *src, size_t src_len,
-					  uint8_t *dst, size_t *dst_len)
+TEE_Result sm2_ltc_pke_decrypt(struct ecc_keypair *key, const uint8_t *src,
+			       size_t src_len, uint8_t *dst, size_t *dst_len)
 {
 	TEE_Result res = TEE_SUCCESS;
 	uint8_t x2y2[64] = { };
@@ -324,9 +323,8 @@ static TEE_Result sm2_point_to_bytes(uint8_t *buf, size_t *size,
  * GM/T 0003.1‒2012 Part 4 Section 6.1
  * Encryption algorithm
  */
-TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key,
-					  const uint8_t *src, size_t src_len,
-					  uint8_t *dst, size_t *dst_len)
+TEE_Result sm2_ltc_pke_encrypt(struct ecc_public_key *key, const uint8_t *src,
+			       size_t src_len, uint8_t *dst, size_t *dst_len)
 {
 	TEE_Result res = TEE_SUCCESS;
 	ecc_key ltc_key = { };

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1287,7 +1287,7 @@ TEE_Result tee_obj_set_type(struct tee_obj *o, uint32_t obj_type,
 	case TEE_TYPE_SM2_DSA_PUBLIC_KEY:
 	case TEE_TYPE_SM2_PKE_PUBLIC_KEY:
 	case TEE_TYPE_SM2_KEP_PUBLIC_KEY:
-		res = crypto_acipher_alloc_ecc_public_key(o->attr,
+		res = crypto_acipher_alloc_ecc_public_key(o->attr, obj_type,
 							  max_key_size);
 		break;
 	case TEE_TYPE_ECDSA_KEYPAIR:
@@ -1295,7 +1295,8 @@ TEE_Result tee_obj_set_type(struct tee_obj *o, uint32_t obj_type,
 	case TEE_TYPE_SM2_DSA_KEYPAIR:
 	case TEE_TYPE_SM2_PKE_KEYPAIR:
 	case TEE_TYPE_SM2_KEP_KEYPAIR:
-		res = crypto_acipher_alloc_ecc_keypair(o->attr, max_key_size);
+		res = crypto_acipher_alloc_ecc_keypair(o->attr, obj_type,
+						       max_key_size);
 		break;
 	default:
 		if (obj_type != TEE_TYPE_DATA) {
@@ -2896,11 +2897,15 @@ static TEE_Result get_sm2_kep_params(const TEE_Attribute *params,
 		BIT(INITIATOR_ID) | BIT(RESPONDER_ID);
 	uint8_t found = 0;
 
-	res = crypto_acipher_alloc_ecc_public_key(peer_key, 256);
+	res = crypto_acipher_alloc_ecc_public_key(peer_key,
+						  TEE_TYPE_SM2_KEP_PUBLIC_KEY,
+						  256);
 	if (res)
 		goto out;
 
-	res = crypto_acipher_alloc_ecc_public_key(peer_eph_key, 256);
+	res = crypto_acipher_alloc_ecc_public_key(peer_eph_key,
+						  TEE_TYPE_SM2_KEP_PUBLIC_KEY,
+						  256);
 	if (res)
 		goto out;
 
@@ -3072,6 +3077,7 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 		struct ecc_public_key key_public;
 		uint8_t *pt_secret;
 		unsigned long pt_secret_len;
+		uint32_t key_type = TEE_TYPE_ECDH_PUBLIC_KEY;
 
 		if (param_count != 2 ||
 		    params[0].attributeID != TEE_ATTR_ECC_PUBLIC_VALUE_X ||
@@ -3102,7 +3108,7 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 		}
 
 		/* Create the public key */
-		res = crypto_acipher_alloc_ecc_public_key(&key_public,
+		res = crypto_acipher_alloc_ecc_public_key(&key_public, key_type,
 							  alloc_size);
 		if (res != TEE_SUCCESS)
 			goto out;

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -3781,14 +3781,10 @@ TEE_Result syscall_asymm_operate(unsigned long state,
 	case TEE_ALG_ECDSA_P256:
 	case TEE_ALG_ECDSA_P384:
 	case TEE_ALG_ECDSA_P521:
+	case TEE_ALG_SM2_DSA_SM3:
 		res = crypto_acipher_ecc_sign(cs->algo, o->attr, src_data,
 					      src_len, dst_data, &dlen);
 		break;
-	case TEE_ALG_SM2_DSA_SM3:
-		res = crypto_acipher_sm2_dsa_sign(cs->algo, o->attr, src_data,
-						  src_len, dst_data, &dlen);
-		break;
-
 	default:
 		res = TEE_ERROR_BAD_PARAMETERS;
 		break;
@@ -3930,13 +3926,9 @@ TEE_Result syscall_asymm_verify(unsigned long state,
 		break;
 
 	case TEE_MAIN_ALGO_ECDSA:
+	case TEE_MAIN_ALGO_SM2_DSA_SM3:
 		res = crypto_acipher_ecc_verify(cs->algo, o->attr, data,
 						data_len, sig, sig_len);
-		break;
-
-	case TEE_MAIN_ALGO_SM2_DSA_SM3:
-		res = crypto_acipher_sm2_dsa_verify(cs->algo, o->attr, data,
-						    data_len, sig, sig_len);
 		break;
 
 	default:


### PR DESCRIPTION
In order to enable one ECC HW driver and one ECC SW library at build and runtime, introduces `struct crypto_ecc_public_ops` and `struct crypto_ecc_keypair_ops` respectively to the `struct ecc_public_key` and `struct ecc_keypair`.

At key (public/keypair) allocation, the HW driver is first called and if key type/size not supported, the SW library is then called.
When key is allocated with success, the key->ops is set with the cryptographic functions pointer to call when using keys to:
     - Generate keypair
     - Sign with keypair
     - Shared secret with keypair
     - Verify with public key
     - Free public key

Modify the tomcrypt and mbedtls libraries to set the ECC keys operations reference function of the key type. 

This is the first phase to introduce the crypto driver API to connect a HW ECC driver in a second PR.
Next step will be to handle all asymmetric keys with the same for RSA, DSA, DH, ...