### PR TITLE
MAINTAINERS: maintain plat-zynqmp

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -218,7 +218,8 @@ S:	Maintained
 F:	core/arch/arm/plat-zynq7k/
 
 Xilinx Zynq UltraScale+ MPSOC
-S:	Orphan
+R:	Ricardo Salveti <ricardo@foundries.io> [@ricardosalveti]
+S:	Maintained
 F:	core/arch/arm/plat-zynqmp/
 
 Virtualization support


### PR DESCRIPTION
Update MAINTAINERS with myself as reviewer for Xilinx Zynq
UltraScale+ MPSOC (plat-zynqmp).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>