### PR TITLE
Fix 'undefined symbol __getauxval' while building xtest TAs

### DIFF
--- a/lib/libutils/ext/arch/arm/auxval.c
+++ b/lib/libutils/ext/arch/arm/auxval.c
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020, EPAM Systems
+ */
+
+#include <compiler.h>
+
+unsigned long int __getauxval (unsigned long int type);
+unsigned long int __getauxval (unsigned long int type __unused)
+{
+	return 0;
+}

--- a/lib/libutils/ext/arch/arm/sub.mk
+++ b/lib/libutils/ext/arch/arm/sub.mk
@@ -3,6 +3,7 @@ srcs-$(CFG_ARM32_$(sm)) += aeabi_unwind.c
 endif
 srcs-$(CFG_ARM32_$(sm)) += atomic_a32.S
 srcs-$(CFG_ARM64_$(sm)) += atomic_a64.S
+srcs-y += auxval.c
 ifneq ($(sm),ldelf) # TA, core
 srcs-$(CFG_ARM32_$(sm)) += mcount_a32.S
 srcs-$(CFG_ARM64_$(sm)) += mcount_a64.S

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -55,8 +55,11 @@ link-ldflags += --eh-frame-hdr
 link-ldadd += $(libstdc++$(sm)) $(libgcc_eh$(sm))
 endif
 link-ldadd += --end-group
-ldargs-$(user-ta-uuid).elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc$(sm))
 
+link-ldadd-after-libgcc += $(addprefix -l,$(libnames-after-libgcc))
+
+ldargs-$(user-ta-uuid).elf := $(link-ldflags) $(objs) $(link-ldadd) \
+				$(libgcc$(sm)) $(link-ldadd-after-libgcc)
 
 link-script-cppflags-$(sm) := \
 	$(filter-out $(CPPFLAGS_REMOVE) $(cppflags-remove), \
@@ -76,6 +79,7 @@ $(link-script-pp$(sm)): $(link-script$(sm)) $(conf-file) $(link-script-pp-makefi
 		$(link-script-cppflags-$(sm)) $$< -o $$@
 
 $(link-out-dir$(sm))/$(user-ta-uuid).elf: $(objs) $(libdeps) \
+					  $(libdeps-after-libgcc) \
 					  $(link-script-pp$(sm)) \
 					  $(dynlistdep) \
 					  $(additional-link-deps)

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -78,6 +78,16 @@ endif
 libnames += dl
 libdeps += $(ta-dev-kit-dir$(sm))/lib/libdl.a
 
+# libutils provides __getauxval symbol which is needed by libgcc 10.x. We can't
+# link libutils after libgcc, because libgcc will replace some symbols provided
+# by libutils, which will cause further linking issues.
+#
+# But if we place libutils before libgcc, linker will not be able to resolve
+# __getauxval. So we need to link with libutils twice: before and after libgcc.
+# Hence it included both in $(libnames) and in $(libnames-after-libgcc)
+libnames-after-libgcc += utils
+libdeps-after-libgcc += $(ta-dev-kit-dir$(sm))/lib/libutils.a
+
 # Pass config variable (CFG_) from conf.mk on the command line
 cppflags$(sm) += $(strip \
 	$(foreach var, $(filter CFG_%,$(.VARIABLES)), \


### PR DESCRIPTION
I stumbled on error

```
aarch64-linux-gnu-ld.bfd: /usr/lib/gcc/aarch64-linux-gnu/10.2.0/libgcc.a(lse-init.o): in function `init_have_lse_atomics':                                     
lse-init.c:(.text.startup+0xc): undefined reference to `__getauxval'  
```

when I tried to build optee_test (along with other OP-TEE components) with GCC 10.2.0.

While we already have `-mno-outline-atomics` option enabled for OP-TEE, it appears that `libgcc_eh` is built with `-moutline-atomics`, so linker fails when it tries to link C++ code in `os_test` TA. 

I see no other way than to provide empty `__getauxval()` function in `libutils`.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
