### PR TITLE
[rfc] core: deprecate register_dynamic_shm()

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -233,10 +233,26 @@ struct core_mmu_phys_mem {
 			__unused
 #endif
 
+/* register_dynamic_shm() is deprecated, please use register_ddr() instead */
 #define register_dynamic_shm(addr, size) \
-		__register_memory(#addr, MEM_AREA_RAM_NSEC, (addr), (size), \
-				  phys_nsec_ddr)
+		__register_memory(#addr, MEM_AREA_DDR_OVERALL, (addr), (size), \
+				  phys_ddr_overall_compat)
 
+/*
+ * register_ddr() - Define a memory range
+ * @addr: Base address
+ * @size: Length
+ *
+ * This macro can be used multiple times to define disjoint ranges. While
+ * initializing holes are carved out of these ranges where it overlaps with
+ * special memory, for instance memory registered with register_sdp_mem().
+ *
+ * The memory that remains is accepted as non-secure shared memory when
+ * communicating with normal world.
+ *
+ * This macro is an alternative to supply the memory description with a
+ * devicetree blob.
+ */
 #define register_ddr(addr, size) \
 		__register_memory(#addr, MEM_AREA_DDR_OVERALL, (addr), \
 				  (size), phys_ddr_overall)
@@ -247,11 +263,11 @@ struct core_mmu_phys_mem {
 #define phys_ddr_overall_end \
 	SCATTERED_ARRAY_END(phys_ddr_overall, struct core_mmu_phys_mem)
 
-#define phys_nsec_ddr_begin \
-	SCATTERED_ARRAY_BEGIN(phys_nsec_ddr, struct core_mmu_phys_mem)
+#define phys_ddr_overall_compat_begin \
+	SCATTERED_ARRAY_BEGIN(phys_ddr_overall_compat, struct core_mmu_phys_mem)
 
-#define phys_nsec_ddr_end \
-	SCATTERED_ARRAY_END(phys_nsec_ddr, struct core_mmu_phys_mem)
+#define phys_ddr_overall_compat_end \
+	SCATTERED_ARRAY_END(phys_ddr_overall_compat, struct core_mmu_phys_mem)
 
 #define phys_sdp_mem_begin \
 	SCATTERED_ARRAY_BEGIN(phys_sdp_mem, struct core_mmu_phys_mem)

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -356,15 +356,6 @@ static uint64_t mattr_to_desc(unsigned level, uint32_t attr)
 	return desc;
 }
 
-static void check_nsec_ddr_max_pa(void)
-{
-	const struct core_mmu_phys_mem *mem;
-
-	for (mem = phys_nsec_ddr_begin; mem < phys_nsec_ddr_end; mem++)
-		if (!core_mmu_check_end_pa(mem->addr, mem->size))
-			panic();
-}
-
 #ifdef CFG_VIRTUALIZATION
 size_t core_mmu_get_total_pages_size(void)
 {
@@ -481,8 +472,6 @@ void core_init_mmu(struct tee_mmap_region *mm)
 			   sizeof(l1_xlation_table) / 2);
 #endif
 	COMPILE_TIME_ASSERT(XLAT_TABLES_SIZE == sizeof(xlat_tables));
-
-	check_nsec_ddr_max_pa();
 
 	/* Initialize default pagetables */
 	core_init_mmu_prtn(&default_partition, mm);


### PR DESCRIPTION
What do you think, does it make sense to deprecate `register_dynamic_shm()`?

We should not merge this until after the current release is done.