### PR TITLE
Make sure tee.elf .text section is not modified at runtime

### DIFF
--- a/core/arch/arm/include/kernel/boot.h
+++ b/core/arch/arm/include/kernel/boot.h
@@ -40,7 +40,7 @@ struct boot_embdata {
 };
 
 extern uint8_t embedded_secure_dtb[];
-extern const struct core_mmu_config boot_mmu_config;
+extern struct core_mmu_config boot_mmu_config;
 
 /* @nsec_entry is unused if using CFG_WITH_ARM_TRUSTED_FW */
 void boot_init_primary(unsigned long pageable_part, unsigned long nsec_entry,

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -557,7 +557,8 @@ shadow_stack_access_ok:
 	 * Compensate for the load offset since cpu_on_handler() is
 	 * called with MMU off.
 	 */
-	ldr	r1, boot_mmu_config + CORE_MMU_CONFIG_LOAD_OFFSET
+	ldr	r1, =boot_mmu_config
+	ldr	r1, [r1, #CORE_MMU_CONFIG_LOAD_OFFSET]
 	sub	r0, r0, r1
 	bl	ffa_secondary_cpu_boot_req
 	b	thread_ffa_msg_wait
@@ -670,7 +671,9 @@ END_FUNC relocate
  */
 LOCAL_FUNC enable_mmu , : , .identity_map
 	/* r0 = core pos */
-	adr	r1, boot_mmu_config
+	adr	r2, boot_mmu_config_rel
+	ldr	r1, [r2]
+	add	r1, r1, r2
 
 #ifdef CFG_WITH_LPAE
 	ldm	r1!, {r2, r3}
@@ -784,9 +787,9 @@ LOCAL_DATA stack_tmp_stride_rel , :
 	.word	stack_tmp_stride - stack_tmp_stride_rel
 END_DATA stack_tmp_stride_rel
 
-DATA boot_mmu_config , : /* struct core_mmu_config */
-	.skip	CORE_MMU_CONFIG_SIZE
-END_DATA boot_mmu_config
+LOCAL_DATA boot_mmu_config_rel , :
+	.word	boot_mmu_config - boot_mmu_config_rel
+END_DATA boot_mmu_config_rel
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 FUNC cpu_on_handler , : , .identity_map
@@ -836,7 +839,9 @@ UNWIND(	.cantunwind)
 	 * this CPU yet we need to restore the corresponding physical
 	 * address.
 	 */
-	adr	r0, boot_mmu_config
+	adr	r1, boot_mmu_config_rel
+	ldr	r0, [r1]
+	add	r0, r0, r1
 	ldr	r0, [r0, #CORE_MMU_CONFIG_LOAD_OFFSET]
 	sub	sp, sp, r0
 #endif

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -298,12 +298,16 @@ DECLARE_KEEP_INIT _start
 #if defined(CFG_PL310) && !defined(CFG_PL310_SIP_PROTOCOL)
 		assert_flat_mapped_range (\vbase), (\line)
 		bl	pl310_base
-		ldr	r1, \vbase
-		ldr	r2, \vend
+		ldr	r1, =\vbase
+		ldr	r1, [r1]
+		ldr	r2, =\vend
+		ldr	r2, [r2]
 		bl	arm_cl2_invbypa
 #endif
-		ldr	r0, \vbase
-		ldr	r1, \vend
+		ldr	r0, =\vbase
+		ldr	r0, [r0]
+		ldr	r1, =\vend
+		ldr	r1, [r1]
 		sub	r1, r1, r0
 		bl	dcache_inv_range
 	.endm
@@ -311,17 +315,23 @@ DECLARE_KEEP_INIT _start
 	.macro __flush_cache_vrange vbase, vend, line
 #if defined(CFG_PL310) && !defined(CFG_PL310_SIP_PROTOCOL)
 		assert_flat_mapped_range (\vbase), (\line)
-		ldr	r0, \vbase
-		ldr	r1, \vend
+		ldr	r0, =\vbase
+		ldr	r0, [r0]
+		ldr	r1, =\vend
+		ldr	r1, [r1]
 		sub	r1, r1, r0
 		bl	dcache_clean_range
 		bl	pl310_base
-		ldr	r1, \vbase
-		ldr	r2, \vend
+		ldr	r1, =\vbase
+		ldr	r1, [r1]
+		ldr	r2, =\vend
+		ldr	r1, [r2]
 		bl	arm_cl2_cleaninvbypa
 #endif
-		ldr	r0, \vbase
-		ldr	r1, \vend
+		ldr	r0, =\vbase
+		ldr	r0, [r0]
+		ldr	r1, =\vend
+		ldr	r1, [r1]
 		sub	r1, r1, r0
 		bl	dcache_cleaninv_range
 	.endm
@@ -364,7 +374,8 @@ UNWIND(	.cantunwind)
 	/* Copy backwards (as memmove) in case we're overlapping */
 	add	r0, r0, r2		/* __init_start + len */
 	add	r1, r1, r2		/* __data_end + len */
-	str	r0, cached_mem_end
+	ldr	r3, =cached_mem_end
+	str	r0, [r3]
 	ldr	r2, =__init_start
 copy_init:
 	ldmdb	r1!, {r3, r8-r12}
@@ -384,7 +395,8 @@ copy_init:
 	/* Copy backwards (as memmove) in case we're overlapping */
 	add	r0, r0, r2
 	add	r1, r1, r2
-	str	r0, cached_mem_end
+	ldr	r3, =cached_mem_end
+	str	r0, [r3]
 	ldr	r2, =__end
 
 copy_init:
@@ -498,9 +510,10 @@ shadow_stack_access_ok:
 	 * Update cached_mem_end address with load offset since it was
 	 * calculated before relocation.
 	 */
-	ldr	r2, cached_mem_end
+	ldr	r3, =cached_mem_end
+	ldr	r2, [r3]
 	add	r2, r2, r0
-	str	r2, cached_mem_end
+	str	r2, [r3]
 
 	bl	relocate
 #endif
@@ -598,9 +611,17 @@ LOCAL_DATA cached_mem_start , :
 	.word	__text_start
 END_DATA cached_mem_start
 
+/*
+ * cached_mem_end is written to at boot time so it should not be in .text. .bss
+ * is not appropriate either since cached_mem_end is set before clear_bss().
+ * .nozi is the place for such uninitialized data.
+ * Note: cached_mem_start is not written to, so it can remain in .text.
+ */
+.pushsection .nozi.cached_mem_end
 LOCAL_DATA cached_mem_end , :
 	.skip	4
 END_DATA cached_mem_end
+.popsection
 
 LOCAL_FUNC unhandled_cpu , :
 	wfi

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -38,6 +38,8 @@
 #define DEBUG_XLAT_TABLE 0
 #endif
 
+struct core_mmu_config boot_mmu_config;
+
 #define SHM_VASPACE_SIZE	(1024 * 1024 * 32)
 
 /*


### PR DESCRIPTION
A couple of patches to prevent the `.text` section of the TEE core from being modified on boot. With this, the content in memory remains identical to what is in the file and therefore it is much easier to implement code integrity verification mechanisms.

(Not for 3.11.0 since it is too late for that.)