### PR TITLE
ci: travis: download checkpatch.pl from linux-next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_script:
 
   # Download checkpatch.pl
   - export KERNEL=$HOME/linux && mkdir -p $KERNEL/scripts && cd $KERNEL/scripts
-  - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl && chmod a+x checkpatch.pl
-  - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+  - wget https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/plain/scripts/checkpatch.pl && chmod a+x checkpatch.pl
+  - wget https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/plain/scripts/spelling.txt
   - echo "invalid.struct.name" >const_structs.checkpatch
   - export PATH=$KERNEL/scripts/:$PATH
   - cd $OPTEE_OS


### PR DESCRIPTION
The Travis CI script obtains checkpatch.pl from a mirror of the master
branch of the Linux repository. Unfortunately, kernel v5.9 has a buggy
checkpatch.pl [1]:

 Global symbol "$gitroot" requires explicit package name [...]

The fix [2] is available in linux-next already but due to the Linux
release schedule it won't make it to the master branch until the end of
the v5.10-rc1 merge window, which is expected two weeks after the v5.9
release.

Downloading checkpatch.pl from linux-next seems to be a better idea in
general. Of course it might break more often due to the unstable nature
of linux-next, but on the other hand fixes appear much more quickly
than in master. A faster update time is even more beneficial in case
new features are added (such as the --kconfig-prefix option I submitted
some time ago [3]) because new patches have to wait up to several weeks
if they miss the merge window.

Therefore, change the checkpatch URL from linux master to linux-next to
fix the above error immediately and hopefully be more convenient in the
future.

Link: [1] https://travis-ci.org/github/OP-TEE/optee_os/builds/737636665#L264
Link: [2] https://lkml.org/lkml/2020/10/18/167
Link: [3] https://lkml.org/lkml/2020/8/18/212
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
