### PR TITLE
build: ld-option: handle any linker warning as an error

### DIFF
--- a/mk/cc-option.mk
+++ b/mk/cc-option.mk
@@ -7,7 +7,7 @@ $(if $($(_var_name)),$(1),$(2))
 endef
 cc-option = $(strip $(call _cc-option,$(1),$(2)))
 
-_ld-option-supported = $(if $(shell $(LD$(sm)) -v $(1) 2>/dev/null >/dev/null || echo "Not supported"),,1)
+_ld-option-supported = $(if $(shell $(LD$(sm)) -v $(1) 2>&1 | grep warning || echo "Not supported"),,1)
 _ld-opt-cached-var-name = $(subst =,~,$(subst $(empty) $(empty),,$(strip cached-ld-option-$(1)-$(LD$(sm)))))
 define _ld-option
 $(eval _var_name := $(call _ld-opt-cached-var-name,$(1)))


### PR DESCRIPTION
The purpose of the ld-option macro is to detect if the linker supports
a given command line option or not. It does so by invoking the linker
with the option and checking the exit status of the process. Some
options however may not cause an error but only generate a warning
message, and the linker exits with a success status. For example,
'-z unrecognized-option' does cause an error with Clang but triggers a
warning with GCC. As a result, $(call ld-option,-z unrecognized-option)
has a different behavior depending on the compiler.

Address this issue by loooking for the word 'warning' in the linker
output in addition to checking the exit status.

Fixes the following warning when building xtest shared libraries with
GCC:

 path/to/bin/arm-linux-gnueabihf-ld.bfd: warning: -z separate-loadable-segments ignored

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
