### PR TITLE
libutils: adjust LICENSE to upstream

### DIFF
--- a/lib/libutils/isoc/newlib/strtoul.c
+++ b/lib/libutils/isoc/newlib/strtoul.c
@@ -126,11 +126,7 @@ PORTABILITY
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *


### PR DESCRIPTION
Adjust the license according with the upstream adjustment done in
9042d0ce65533a26fc3264206db5828d5692332c inspectable on the web at [1].
With the adjusted license, the file also matches its SPDX License
identifier correctly.

[1]: https://sourceware.org/git/?p=newlib-cygwin.git;a=commit;h=9042d0ce65533a26fc3264206db5828d5692332c

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>
