### PR TITLE
core: fix CFG_CORE_UNMAP_CORE_AT_EL0=y for non-default CFG_LPAE_ADDR_…

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -15,7 +15,13 @@ CFG_LTC_OPTEE_THREAD ?= y
 # Size of emulated TrustZone protected SRAM, 448 kB.
 # Only applicable when paging is enabled.
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 458752
-CFG_LPAE_ADDR_SPACE_SIZE ?= (1ull << 32)
+
+ifneq ($(CFG_LPAE_ADDR_SPACE_SIZE),)
+$(warning Error: CFG_LPAE_ADDR_SPACE_SIZE is not supported any longer)
+$(error Error: Please use CFG_LPAE_ADDR_SPACE_BITS instead)
+endif
+
+CFG_LPAE_ADDR_SPACE_BITS ?= 32
 
 CFG_MMAP_REGIONS ?= 13
 CFG_RESERVED_VASPACE_SIZE ?= (1024 * 1024 * 10)

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -53,7 +53,8 @@
  * we rather not expose here. There's a compile time assertion to check
  * that these magic numbers are correct.
  */
-#define CORE_MMU_L1_TBL_OFFSET		(CFG_TEE_CORE_NB_CORE * 4 * 8)
+#define CORE_MMU_L1_TBL_OFFSET		(CFG_TEE_CORE_NB_CORE * \
+					 BIT(CFG_LPAE_ADDR_SPACE_BITS - 30) * 8)
 #endif
 /*
  * TEE_RAM_VA_START:            The start virtual address of the TEE RAM

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -882,8 +882,9 @@ static void assign_mem_granularity(struct tee_mmap_region *memory_map)
 static unsigned int get_va_width(void)
 {
 	if (IS_ENABLED(ARM64)) {
-		COMPILE_TIME_ASSERT(IS_POWER_OF_TWO(CFG_LPAE_ADDR_SPACE_SIZE));
-		return __builtin_ctzll(CFG_LPAE_ADDR_SPACE_SIZE);
+		COMPILE_TIME_ASSERT(CFG_LPAE_ADDR_SPACE_BITS >= 32);
+		COMPILE_TIME_ASSERT(CFG_LPAE_ADDR_SPACE_BITS < 48);
+		return CFG_LPAE_ADDR_SPACE_BITS;
 	}
 	return 32;
 }

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -163,8 +163,8 @@
 #define L1_XLAT_ADDRESS_SHIFT	(L2_XLAT_ADDRESS_SHIFT + \
 				 XLAT_TABLE_ENTRIES_SHIFT)
 
-#define NUM_L1_ENTRIES		\
-		(CFG_LPAE_ADDR_SPACE_SIZE >> L1_XLAT_ADDRESS_SHIFT)
+#define NUM_L1_ENTRIES		BIT(CFG_LPAE_ADDR_SPACE_BITS - \
+				    L1_XLAT_ADDRESS_SHIFT)
 
 #ifndef MAX_XLAT_TABLES
 #ifdef CFG_VIRTUALIZATION
@@ -496,8 +496,8 @@ void core_init_mmu(struct tee_mmap_region *mm)
 	}
 	assert(user_va_idx != -1);
 
-	COMPILE_TIME_ASSERT(CFG_LPAE_ADDR_SPACE_SIZE > 0);
-	assert(max_va < CFG_LPAE_ADDR_SPACE_SIZE);
+	COMPILE_TIME_ASSERT(CFG_LPAE_ADDR_SPACE_BITS > L1_XLAT_ADDRESS_SHIFT);
+	assert(max_va < BIT64(CFG_LPAE_ADDR_SPACE_BITS));
 }
 
 bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
@@ -587,7 +587,7 @@ void core_init_mmu_regs(struct core_mmu_config *cfg)
 	tcr |= TCR_XRGNX_WBWA << TCR_ORGN0_SHIFT;
 	tcr |= TCR_SHX_ISH << TCR_SH0_SHIFT;
 	tcr |= ips << TCR_EL1_IPS_SHIFT;
-	tcr |= 64 - __builtin_ctzl(CFG_LPAE_ADDR_SPACE_SIZE);
+	tcr |= 64 - CFG_LPAE_ADDR_SPACE_BITS;
 
 	/* Disable the use of TTBR1 */
 	tcr |= TCR_EPD1;


### PR DESCRIPTION
…SPACE_SIZE

Prior to this patch CORE_MMU_L1_TBL_OFFSET was calculated without taking
CFG_LPAE_ADDR_SPACE_SIZE into account. This leads to a
COMPILE_TIME_ASSERT() in case CFG_LPAE_ADDR_SPACE_SIZE is assigned
anything but (1ull << 32). Fix this by addign CFG_LPAE_ADDR_SPACE_SIZE
in the expression.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
