### PR TITLE
Separate ldelf from user TAs

### DIFF
--- a/core/arch/arm/include/kernel/ldelf_loader.h
+++ b/core/arch/arm/include/kernel/ldelf_loader.h
@@ -3,16 +3,17 @@
  * Copyright (c) 2020, Arm Limited
  */
 
-#include <kernel/user_ta.h>
+#include <kernel/user_mode_ctx_struct.h>
 #include <tee_api_types.h>
 
 #ifndef KERNEL_LDELF_LOADER_H
 #define KERNEL_LDELF_LOADER_H
 
-TEE_Result ldelf_load_ldelf(struct user_ta_ctx *utc);
+TEE_Result ldelf_load_ldelf(struct user_mode_ctx *uctx);
 TEE_Result ldelf_init_with_ldelf(struct ts_session *sess,
-				 struct user_ta_ctx *utc);
-TEE_Result ldelf_dump_state(struct user_ta_ctx *utc);
-TEE_Result ldelf_dump_ftrace(struct user_ta_ctx *utc, void *buf, size_t *blen);
+				 struct user_mode_ctx *uctx);
+TEE_Result ldelf_dump_state(struct user_mode_ctx *uctx);
+TEE_Result ldelf_dump_ftrace(struct user_mode_ctx *uctx,
+			     void *buf, size_t *blen);
 
 #endif /* KERNEL_LDELF_LOADER_H */

--- a/core/arch/arm/include/kernel/ldelf_loader.h
+++ b/core/arch/arm/include/kernel/ldelf_loader.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020, Arm Limited
+ */
+
+#include <kernel/user_ta.h>
+#include <tee_api_types.h>
+
+#ifndef KERNEL_LDELF_LOADER_H
+#define KERNEL_LDELF_LOADER_H
+
+TEE_Result ldelf_load_ldelf(struct user_ta_ctx *utc);
+TEE_Result ldelf_init_with_ldelf(struct ts_session *sess,
+				 struct user_ta_ctx *utc);
+TEE_Result ldelf_dump_state(struct user_ta_ctx *utc);
+TEE_Result ldelf_dump_ftrace(struct user_ta_ctx *utc, void *buf, size_t *blen);
+
+#endif /* KERNEL_LDELF_LOADER_H */

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2016-2017, Linaro Limited
+ * Copyright (c) 2020, Arm Limited
  */
 
 #ifndef KERNEL_THREAD_H
@@ -250,6 +251,8 @@ struct thread_specific_data {
 	unsigned int syscall_recursion;
 };
 
+struct user_mode_ctx;
+
 #ifdef CFG_WITH_ARM_TRUSTED_FW
 /*
  * These five functions have a __weak default implementation which does
@@ -446,13 +449,12 @@ static inline void thread_user_save_vfp(void)
 
 /*
  * thread_user_clear_vfp() - Clears the vfp state
- * @uvfp:	pointer to saved state to clear
+ * @uctx:	pointer to user mode context containing the saved state to clear
  */
 #ifdef CFG_WITH_VFP
-void thread_user_clear_vfp(struct thread_user_vfp_state *uvfp);
+void thread_user_clear_vfp(struct user_mode_ctx *uctx);
 #else
-static inline void thread_user_clear_vfp(
-			struct thread_user_vfp_state *uvfp __unused)
+static inline void thread_user_clear_vfp(struct user_mode_ctx *uctx __unused)
 {
 }
 #endif

--- a/core/arch/arm/include/kernel/user_ta.h
+++ b/core/arch/arm/include/kernel/user_ta.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2020, Arm Limited
  */
 #ifndef KERNEL_USER_TA_H
 #define KERNEL_USER_TA_H
@@ -23,40 +24,19 @@ SLIST_HEAD(load_seg_head, load_seg);
 
 /*
  * struct user_ta_ctx - user TA context
- * @entry_func:		Entry address in TA
- * @dump_entry_func:	Entry address in TA for dumping address mappings
- *			and stack trace
- * @ftrace_entry_func:	Entry address in ldelf for dumping ftrace data
- * @ldelf_stack_ptr:	Stack pointer used for dumping address mappings and
- *			stack trace
- * @is_32bit:		True if 32-bit TA, false if 64-bit TA
- * @is_initializing:	True if TA is not fully loaded
  * @open_sessions:	List of sessions opened by this TA
  * @cryp_states:	List of cryp states created by this TA
  * @objects:		List of storage objects opened by this TA
  * @storage_enums:	List of storage enumerators opened by this TA
- * @stack_ptr:		Stack pointer
- * @vm_info:		Virtual memory map of this context
  * @ta_time_offs:	Time reference used by the TA
- * @areas:		Memory areas registered by pager
- * @vfp:		State of VFP registers
+ * @uctx:		Generic user mode context
  * @ctx:		Generic TA context
  */
 struct user_ta_ctx {
-	uaddr_t entry_func;
-	uaddr_t dump_entry_func;
-#ifdef CFG_FTRACE_SUPPORT
-	uaddr_t ftrace_entry_func;
-#endif
-	uaddr_t dl_entry_func;
-	uaddr_t ldelf_stack_ptr;
-	bool is_32bit;
-	bool is_initializing;
 	struct tee_ta_session_head open_sessions;
 	struct tee_cryp_state_head cryp_states;
 	struct tee_obj_head objects;
 	struct tee_storage_enum_head storage_enums;
-	vaddr_t stack_ptr;
 	void *ta_time_offs;
 	struct user_mode_ctx uctx;
 	struct tee_ta_ctx ta_ctx;

--- a/core/arch/arm/kernel/ldelf_loader.c
+++ b/core/arch/arm/kernel/ldelf_loader.c
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2015-2020, Linaro Limited
+ * Copyright (c) 2020, Arm Limited
+ */
+
+#include <assert.h>
+#include <kernel/ldelf_loader.h>
+#include <ldelf.h>
+#include <mm/mobj.h>
+#include <mm/vm.h>
+
+extern uint8_t ldelf_data[];
+extern const unsigned int ldelf_code_size;
+extern const unsigned int ldelf_data_size;
+extern const unsigned int ldelf_entry;
+
+/* ldelf has the same architecture/register width as the kernel */
+#ifdef ARM32
+static const bool is_arm32 = true;
+#else
+static const bool is_arm32;
+#endif
+
+static TEE_Result alloc_and_map_ldelf_fobj(struct user_ta_ctx *utc, size_t sz,
+					   uint32_t prot, vaddr_t *va)
+{
+	size_t num_pgs = ROUNDUP(sz, SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE;
+	struct fobj *fobj = fobj_ta_mem_alloc(num_pgs);
+	struct mobj *mobj = mobj_with_fobj_alloc(fobj, NULL);
+	TEE_Result res = TEE_SUCCESS;
+
+	fobj_put(fobj);
+	if (!mobj)
+		return TEE_ERROR_OUT_OF_MEMORY;
+	res = vm_map(&utc->uctx, va, num_pgs * SMALL_PAGE_SIZE,
+		     prot, VM_FLAG_LDELF, mobj, 0);
+	mobj_put(mobj);
+
+	return res;
+}
+
+/*
+ * This function may leave a few mappings behind on error, but that's taken
+ * care of by tee_ta_init_user_ta_session() since the entire context is
+ * removed then.
+ */
+TEE_Result ldelf_load_ldelf(struct user_ta_ctx *utc)
+{
+	TEE_Result res = TEE_SUCCESS;
+	vaddr_t stack_addr = 0;
+	vaddr_t code_addr = 0;
+	vaddr_t rw_addr = 0;
+
+	utc->is_32bit = is_arm32;
+
+	res = alloc_and_map_ldelf_fobj(utc, LDELF_STACK_SIZE,
+				       TEE_MATTR_URW | TEE_MATTR_PRW,
+				       &stack_addr);
+	if (res)
+		return res;
+	utc->ldelf_stack_ptr = stack_addr + LDELF_STACK_SIZE;
+
+	res = alloc_and_map_ldelf_fobj(utc, ldelf_code_size, TEE_MATTR_PRW,
+				       &code_addr);
+	if (res)
+		return res;
+	utc->entry_func = code_addr + ldelf_entry;
+
+	rw_addr = ROUNDUP(code_addr + ldelf_code_size, SMALL_PAGE_SIZE);
+	res = alloc_and_map_ldelf_fobj(utc, ldelf_data_size,
+				       TEE_MATTR_URW | TEE_MATTR_PRW, &rw_addr);
+	if (res)
+		return res;
+
+	vm_set_ctx(&utc->ta_ctx.ts_ctx);
+
+	memcpy((void *)code_addr, ldelf_data, ldelf_code_size);
+	memcpy((void *)rw_addr, ldelf_data + ldelf_code_size, ldelf_data_size);
+
+	res = vm_set_prot(&utc->uctx, code_addr,
+			  ROUNDUP(ldelf_code_size, SMALL_PAGE_SIZE),
+			  TEE_MATTR_URX);
+	if (res)
+		return res;
+
+	DMSG("ldelf load address %#"PRIxVA, code_addr);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result ldelf_init_with_ldelf(struct ts_session *sess __maybe_unused,
+				 struct user_ta_ctx *utc)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct ldelf_arg *arg = NULL;
+	uint32_t panic_code = 0;
+	uint32_t panicked = 0;
+	uaddr_t usr_stack = 0;
+
+	usr_stack = utc->ldelf_stack_ptr;
+	usr_stack -= ROUNDUP(sizeof(*arg), STACK_ALIGNMENT);
+	arg = (struct ldelf_arg *)usr_stack;
+	memset(arg, 0, sizeof(*arg));
+	arg->uuid = utc->ta_ctx.ts_ctx.uuid;
+
+	res = thread_enter_user_mode((vaddr_t)arg, 0, 0, 0,
+				     usr_stack, utc->entry_func,
+				     is_arm32, &panicked, &panic_code);
+
+	thread_user_clear_vfp(&utc->uctx);
+
+	if (panicked) {
+		abort_print_current_ta();
+		EMSG("ldelf panicked");
+		return TEE_ERROR_GENERIC;
+	}
+	if (res) {
+		EMSG("ldelf failed with res: %#"PRIx32, res);
+		return res;
+	}
+
+	res = vm_check_access_rights(&utc->uctx,
+				     TEE_MEMORY_ACCESS_READ |
+				     TEE_MEMORY_ACCESS_ANY_OWNER,
+				     (uaddr_t)arg, sizeof(*arg));
+	if (res)
+		return res;
+
+	/*
+	 * This is already checked by the elf loader, but since it runs in
+	 * user mode we're not trusting it entirely.
+	 */
+	if (arg->flags & ~TA_FLAGS_MASK)
+		return TEE_ERROR_BAD_FORMAT;
+
+	utc->is_32bit = arg->is_32bit;
+	utc->entry_func = arg->entry_func;
+	utc->stack_ptr = arg->stack_ptr;
+	utc->ta_ctx.flags = arg->flags;
+	utc->dump_entry_func = arg->dump_entry;
+#ifdef CFG_FTRACE_SUPPORT
+	utc->ftrace_entry_func = arg->ftrace_entry;
+	sess->fbuf = arg->fbuf;
+#endif
+	utc->dl_entry_func = arg->dl_entry;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result ldelf_dump_state(struct user_ta_ctx *utc)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uaddr_t usr_stack = utc->ldelf_stack_ptr;
+	struct dump_entry_arg *arg = NULL;
+	uint32_t panic_code = 0;
+	uint32_t panicked = 0;
+	struct thread_specific_data *tsd = thread_get_tsd();
+	struct vm_region *r = NULL;
+	size_t n = 0;
+
+	TAILQ_FOREACH(r, &utc->uctx.vm_info.regions, link)
+		if (r->attr & TEE_MATTR_URWX)
+			n++;
+
+	usr_stack = utc->ldelf_stack_ptr;
+	usr_stack -= ROUNDUP(sizeof(*arg) + n * sizeof(struct dump_map),
+			     STACK_ALIGNMENT);
+	arg = (struct dump_entry_arg *)usr_stack;
+
+	res = vm_check_access_rights(&utc->uctx,
+				     TEE_MEMORY_ACCESS_READ |
+				     TEE_MEMORY_ACCESS_ANY_OWNER,
+				     (uaddr_t)arg, sizeof(*arg));
+	if (res) {
+		EMSG("ldelf stack is inaccessible!");
+		return res;
+	}
+
+	memset(arg, 0, sizeof(*arg) + n * sizeof(struct dump_map));
+
+	arg->num_maps = n;
+	n = 0;
+	TAILQ_FOREACH(r, &utc->uctx.vm_info.regions, link) {
+		if (r->attr & TEE_MATTR_URWX) {
+			if (r->mobj)
+				mobj_get_pa(r->mobj, r->offset, 0,
+					    &arg->maps[n].pa);
+			arg->maps[n].va = r->va;
+			arg->maps[n].sz = r->size;
+			if (r->attr & TEE_MATTR_UR)
+				arg->maps[n].flags |= DUMP_MAP_READ;
+			if (r->attr & TEE_MATTR_UW)
+				arg->maps[n].flags |= DUMP_MAP_WRITE;
+			if (r->attr & TEE_MATTR_UX)
+				arg->maps[n].flags |= DUMP_MAP_EXEC;
+			if (r->attr & TEE_MATTR_SECURE)
+				arg->maps[n].flags |= DUMP_MAP_SECURE;
+			if (r->flags & VM_FLAG_EPHEMERAL)
+				arg->maps[n].flags |= DUMP_MAP_EPHEM;
+			if (r->flags & VM_FLAG_LDELF)
+				arg->maps[n].flags |= DUMP_MAP_LDELF;
+			n++;
+		}
+	}
+
+	arg->is_arm32 = utc->is_32bit;
+#ifdef ARM32
+	arg->arm32.regs[0] = tsd->abort_regs.r0;
+	arg->arm32.regs[1] = tsd->abort_regs.r1;
+	arg->arm32.regs[2] = tsd->abort_regs.r2;
+	arg->arm32.regs[3] = tsd->abort_regs.r3;
+	arg->arm32.regs[4] = tsd->abort_regs.r4;
+	arg->arm32.regs[5] = tsd->abort_regs.r5;
+	arg->arm32.regs[6] = tsd->abort_regs.r6;
+	arg->arm32.regs[7] = tsd->abort_regs.r7;
+	arg->arm32.regs[8] = tsd->abort_regs.r8;
+	arg->arm32.regs[9] = tsd->abort_regs.r9;
+	arg->arm32.regs[10] = tsd->abort_regs.r10;
+	arg->arm32.regs[11] = tsd->abort_regs.r11;
+	arg->arm32.regs[12] = tsd->abort_regs.ip;
+	arg->arm32.regs[13] = tsd->abort_regs.usr_sp; /*SP*/
+	arg->arm32.regs[14] = tsd->abort_regs.usr_lr; /*LR*/
+	arg->arm32.regs[15] = tsd->abort_regs.elr; /*PC*/
+#endif /*ARM32*/
+#ifdef ARM64
+	if (utc->is_32bit) {
+		arg->arm32.regs[0] = tsd->abort_regs.x0;
+		arg->arm32.regs[1] = tsd->abort_regs.x1;
+		arg->arm32.regs[2] = tsd->abort_regs.x2;
+		arg->arm32.regs[3] = tsd->abort_regs.x3;
+		arg->arm32.regs[4] = tsd->abort_regs.x4;
+		arg->arm32.regs[5] = tsd->abort_regs.x5;
+		arg->arm32.regs[6] = tsd->abort_regs.x6;
+		arg->arm32.regs[7] = tsd->abort_regs.x7;
+		arg->arm32.regs[8] = tsd->abort_regs.x8;
+		arg->arm32.regs[9] = tsd->abort_regs.x9;
+		arg->arm32.regs[10] = tsd->abort_regs.x10;
+		arg->arm32.regs[11] = tsd->abort_regs.x11;
+		arg->arm32.regs[12] = tsd->abort_regs.x12;
+		arg->arm32.regs[13] = tsd->abort_regs.x13; /*SP*/
+		arg->arm32.regs[14] = tsd->abort_regs.x14; /*LR*/
+		arg->arm32.regs[15] = tsd->abort_regs.elr; /*PC*/
+	} else {
+		arg->arm64.fp = tsd->abort_regs.x29;
+		arg->arm64.pc = tsd->abort_regs.elr;
+		arg->arm64.sp = tsd->abort_regs.sp_el0;
+	}
+#endif /*ARM64*/
+
+	res = thread_enter_user_mode((vaddr_t)arg, 0, 0, 0,
+				     usr_stack, utc->dump_entry_func,
+				     is_arm32, &panicked, &panic_code);
+
+	thread_user_clear_vfp(&utc->uctx);
+
+	if (panicked) {
+		utc->dump_entry_func = 0;
+		EMSG("ldelf dump function panicked");
+		abort_print_current_ta();
+		res = TEE_ERROR_TARGET_DEAD;
+	}
+
+	return res;
+}
+
+#ifdef CFG_FTRACE_SUPPORT
+TEE_Result ldelf_dump_ftrace(struct user_ta_ctx *utc, void *buf, size_t *blen)
+{
+	uaddr_t usr_stack = utc->ldelf_stack_ptr;
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t panic_code = 0;
+	uint32_t panicked = 0;
+	size_t *arg = NULL;
+
+	if (!utc->ftrace_entry_func)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	usr_stack -= ROUNDUP(sizeof(*arg), STACK_ALIGNMENT);
+	arg = (size_t *)usr_stack;
+
+	res = vm_check_access_rights(&utc->uctx,
+				     TEE_MEMORY_ACCESS_READ |
+				     TEE_MEMORY_ACCESS_ANY_OWNER,
+				     (uaddr_t)arg, sizeof(*arg));
+	if (res) {
+		EMSG("ldelf stack is inaccessible!");
+		return res;
+	}
+
+	*arg = *blen;
+
+	res = thread_enter_user_mode((vaddr_t)buf, (vaddr_t)arg, 0, 0,
+				     usr_stack, utc->ftrace_entry_func,
+				     is_arm32, &panicked, &panic_code);
+
+	thread_user_clear_vfp(&utc->uctx);
+
+	if (panicked) {
+		utc->ftrace_entry_func = 0;
+		EMSG("ldelf ftrace function panicked");
+		abort_print_current_ta();
+		res = TEE_ERROR_TARGET_DEAD;
+	}
+
+	if (!res) {
+		if (*arg > *blen)
+			res = TEE_ERROR_SHORT_BUFFER;
+		*blen = *arg;
+	}
+
+	return res;
+}
+#endif /*CFG_FTRACE_SUPPORT*/

--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -69,12 +69,6 @@ static struct stmm_ctx *stmm_alloc_ctx(const TEE_UUID *uuid)
 	return spc;
 }
 
-static void clear_vfp_state(struct stmm_ctx *spc __maybe_unused)
-{
-	if (IS_ENABLED(CFG_WITH_VFP))
-		thread_user_clear_vfp(&spc->uctx.vfp);
-}
-
 static TEE_Result stmm_enter_user_mode(struct stmm_ctx *spc)
 {
 	uint32_t exceptions = 0;
@@ -89,7 +83,7 @@ static TEE_Result stmm_enter_user_mode(struct stmm_ctx *spc)
 	write_cntkctl(cntkctl);
 	thread_unmask_exceptions(exceptions);
 
-	clear_vfp_state(spc);
+	thread_user_clear_vfp(&spc->uctx);
 
 	if (panicked) {
 		abort_print_current_ta();

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -1,5 +1,6 @@
 ifeq ($(CFG_WITH_USER_TA),y)
 srcs-y += user_ta.c
+srcs-y += ldelf_loader.c
 srcs-$(CFG_REE_FS_TA) += ree_fs_ta.c
 srcs-$(CFG_EARLY_TA) += early_ta.c
 srcs-$(CFG_SECSTOR_TA) += secstor_ta.c

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2016, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2020, Arm Limited
  */
 
 #include <platform_config.h>
@@ -21,6 +22,7 @@
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread_defs.h>
 #include <kernel/thread.h>
+#include <kernel/user_mode_ctx_struct.h>
 #include <kernel/virtualization.h>
 #include <mm/core_memprot.h>
 #include <mm/mobj.h>
@@ -1360,8 +1362,9 @@ void thread_user_save_vfp(void)
 	tuv->lazy_saved = true;
 }
 
-void thread_user_clear_vfp(struct thread_user_vfp_state *uvfp)
+void thread_user_clear_vfp(struct user_mode_ctx *uctx)
 {
+	struct thread_user_vfp_state *uvfp = &uctx->vfp;
 	struct thread_ctx *thr = threads + thread_get_id();
 
 	if (uvfp == thr->vfp_state.uvfp)

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -116,13 +116,6 @@ static void update_from_utee_param(struct tee_ta_param *p,
 	}
 }
 
-static void clear_vfp_state(struct user_ta_ctx *utc __unused)
-{
-#ifdef CFG_WITH_VFP
-	thread_user_clear_vfp(&utc->uctx.vfp);
-#endif
-}
-
 static bool inc_recursion(void)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
@@ -186,7 +179,7 @@ static TEE_Result user_ta_enter(struct ts_session *session,
 				     &utc->ta_ctx.panicked,
 				     &utc->ta_ctx.panic_code);
 
-	clear_vfp_state(utc);
+	thread_user_clear_vfp(&utc->uctx);
 
 	if (utc->ta_ctx.panicked) {
 		abort_print_current_ta();
@@ -248,7 +241,7 @@ static TEE_Result init_with_ldelf(struct ts_session *sess __maybe_unused,
 				     usr_stack, utc->entry_func,
 				     is_arm32, &panicked, &panic_code);
 
-	clear_vfp_state(utc);
+	thread_user_clear_vfp(&utc->uctx);
 	if (panicked) {
 		abort_print_current_ta();
 		EMSG("ldelf panicked");
@@ -412,7 +405,7 @@ static TEE_Result dump_state_ldelf_dbg(struct user_ta_ctx *utc)
 	res = thread_enter_user_mode((vaddr_t)arg, 0, 0, 0,
 				     usr_stack, utc->dump_entry_func,
 				     is_arm32, &panicked, &panic_code);
-	clear_vfp_state(utc);
+	thread_user_clear_vfp(&utc->uctx);
 	if (panicked) {
 		utc->dump_entry_func = 0;
 		EMSG("ldelf dump function panicked");
@@ -474,7 +467,7 @@ static TEE_Result dump_ftrace(struct user_ta_ctx *utc, void *buf, size_t *blen)
 	res = thread_enter_user_mode((vaddr_t)buf, (vaddr_t)arg, 0, 0,
 				     usr_stack, utc->ftrace_entry_func,
 				     is_arm32, &panicked, &panic_code);
-	clear_vfp_state(utc);
+	thread_user_clear_vfp(&utc->uctx);
 	if (panicked) {
 		utc->ftrace_entry_func = 0;
 		EMSG("ldelf ftrace function panicked");

--- a/core/arch/arm/tee/arch_svc.c
+++ b/core/arch/arm/tee/arch_svc.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2020, Arm Limited
  */
 
 #include <arm.h>
@@ -362,7 +363,7 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 				   TEE_MEMORY_ACCESS_READ |
 				   TEE_MEMORY_ACCESS_WRITE,
 				   (uaddr_t)regs->x1,
-				   utc->is_32bit ?
+				   utc->uctx.is_32bit ?
 				   TA32_CONTEXT_MAX_SIZE :
 				   TA64_CONTEXT_MAX_SIZE)) {
 		TAMSG_RAW("");
@@ -375,7 +376,7 @@ static void save_panic_stack(struct thread_svc_regs *regs)
 	tsd->abort_descr = 0;
 	tsd->abort_va = 0;
 
-	if (utc->is_32bit)
+	if (utc->uctx.is_32bit)
 		save_panic_regs_a32_ta(tsd, (uint32_t *)regs->x1);
 	else
 		save_panic_regs_a64_ta(tsd, (uint64_t *)regs->x1);

--- a/core/include/kernel/user_mode_ctx_struct.h
+++ b/core/include/kernel/user_mode_ctx_struct.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2020, Arm Limited
  */
 
 #ifndef __KERNEL_USER_MODE_CTX_STRUCT_H
@@ -10,6 +11,23 @@
 #include <kernel/thread.h>
 #include <mm/tee_mmu_types.h>
 
+/*
+ * struct user_mode_ctx - user mode context
+ * @vm_info:		Virtual memory map of this context
+ * @areas:		Memory areas registered by pager
+ * @vfp:		State of VFP registers
+ * @ts_ctx:		Generic TS context
+ * @entry_func:		Entry address in TS
+ * @dump_entry_func:	Entry address in TS for dumping address mappings
+ *			and stack trace
+ * @ftrace_entry_func:	Entry address in ldelf for dumping ftrace data
+ * @dl_entry_func:	Entry address in ldelf for dynamic linking
+ * @ldelf_stack_ptr:	Stack pointer used for dumping address mappings and
+ *			stack trace
+ * @is_32bit:		True if 32-bit TS, false if 64-bit TS
+ * @is_initializing:	True if TS is not fully loaded
+ * @stack_ptr:		Stack pointer
+ */
 struct user_mode_ctx {
 	struct vm_info vm_info;
 	struct tee_pager_area_head *areas;
@@ -17,6 +35,16 @@ struct user_mode_ctx {
 	struct thread_user_vfp_state vfp;
 #endif
 	struct ts_ctx *ts_ctx;
+	uaddr_t entry_func;
+	uaddr_t dump_entry_func;
+#ifdef CFG_FTRACE_SUPPORT
+	uaddr_t ftrace_entry_func;
+#endif
+	uaddr_t dl_entry_func;
+	uaddr_t ldelf_stack_ptr;
+	bool is_32bit;
+	bool is_initializing;
+	vaddr_t stack_ptr;
 };
 #endif /*__KERNEL_USER_MODE_CTX_STRUCT_H*/
 

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2020, Arm Limited
  */
 
 #include <arm.h>
@@ -560,7 +561,7 @@ static TEE_Result tee_ta_init_session_with_context(struct tee_ta_session *s,
 			return TEE_ERROR_ITEM_NOT_FOUND;
 
 		if (!is_user_ta_ctx(&ctx->ts_ctx) ||
-		    !to_user_ta_ctx(&ctx->ts_ctx)->is_initializing)
+		    !to_user_ta_ctx(&ctx->ts_ctx)->uctx.is_initializing)
 			break;
 		/*
 		 * Context is still initializing, wait here until it's

--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -662,7 +662,7 @@ static const bool is_arm32;
 static TEE_Result call_ldelf_dlopen(struct user_ta_ctx *utc, TEE_UUID *uuid,
 				    uint32_t flags)
 {
-	uaddr_t usr_stack = utc->ldelf_stack_ptr;
+	uaddr_t usr_stack = utc->uctx.ldelf_stack_ptr;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct dl_entry_arg *arg = NULL;
 	uint32_t panic_code = 0;
@@ -689,7 +689,7 @@ static TEE_Result call_ldelf_dlopen(struct user_ta_ctx *utc, TEE_UUID *uuid,
 	arg->dlopen.flags = flags;
 
 	res = thread_enter_user_mode((vaddr_t)arg, 0, 0, 0,
-				     usr_stack, utc->dl_entry_func,
+				     usr_stack, utc->uctx.dl_entry_func,
 				     is_arm32, &panicked, &panic_code);
 	if (panicked) {
 		EMSG("ldelf dl_entry function panicked");
@@ -705,7 +705,7 @@ static TEE_Result call_ldelf_dlopen(struct user_ta_ctx *utc, TEE_UUID *uuid,
 static TEE_Result call_ldelf_dlsym(struct user_ta_ctx *utc, TEE_UUID *uuid,
 				   const char *sym, size_t maxlen, vaddr_t *val)
 {
-	uaddr_t usr_stack = utc->ldelf_stack_ptr;
+	uaddr_t usr_stack = utc->uctx.ldelf_stack_ptr;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct dl_entry_arg *arg = NULL;
 	uint32_t panic_code = 0;
@@ -735,7 +735,7 @@ static TEE_Result call_ldelf_dlsym(struct user_ta_ctx *utc, TEE_UUID *uuid,
 	arg->dlsym.symbol[len] = '\0';
 
 	res = thread_enter_user_mode((vaddr_t)arg, 0, 0, 0,
-				     usr_stack, utc->dl_entry_func,
+				     usr_stack, utc->uctx.dl_entry_func,
 				     is_arm32, &panicked, &panic_code);
 	if (panicked) {
 		EMSG("ldelf dl_entry function panicked");


### PR DESCRIPTION
This is a step towards enabling Secure Partitions (SPs) in OP-TEE.
Ldelf should be used for both TAs and SPs, so ldelf related code is moved from user TA specific files to generic files.

~~The work is based on #4126 which is not merged yet, I've included those patches in this PR.~~ It has been merged.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
