### PR TITLE
checkpatch: add --kconfig-prefix=CFG_

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -10,3 +10,4 @@
 --ignore=NOT_UNIFIED_DIFF
 --ignore=PREFER_KERNEL_TYPES
 --ignore=USLEEP_RANGE
+--kconfig-prefix=CFG_


### PR DESCRIPTION
A few days before v5.9-rc1, the checkpatch.pl script was modified in
the Linux kernel tree [1]. This caused spurious warnings in the OP-TEE
CI such as [2]:

 WARNING: IS_ENABLED(CFG_VIRTUALIZATION) is normally used as IS_ENABLED(CONFIG_CFG_VIRTUALIZATION)

Fortunately, checkpatch now has an option to control the prefix used for
configuration variables [3]. Add this option to .checkpatch.conf.

Link: [1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=50161266973bcc662e969e63d68fc7bff71de21b
Link: [2] https://travis-ci.org/github/OP-TEE/optee_os/builds/717905104
Link: [3] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3e89ad8506f39c4739a6c9ca1e1552f506f000c9
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
