### PR TITLE
I2c imx6ull 

### DIFF
--- a/core/arch/arm/plat-imx/registers/imx6-crm.h
+++ b/core/arch/arm/plat-imx/registers/imx6-crm.h
@@ -855,8 +855,4 @@
 #define BM_CCM_ANALOG_PLL_ARM_DIV_SELECT	\
 			SHIFT_U32(0x7F, BS_CCM_ANALOG_PLL_DIV_SELECT)
 
-/* I2C clock gate register and bit mask */
-#define I2C_CLK_CGRBM(__x)	BM_CCM_CCGR2_I2C##__x##_SERIAL
-#define I2C_CLK_CGR(__x)	CCM_CCGR2
-
 #endif /* __IMX6_CRM_H__ */

--- a/core/arch/arm/plat-imx/registers/imx6-crm.h
+++ b/core/arch/arm/plat-imx/registers/imx6-crm.h
@@ -855,4 +855,8 @@
 #define BM_CCM_ANALOG_PLL_ARM_DIV_SELECT	\
 			SHIFT_U32(0x7F, BS_CCM_ANALOG_PLL_DIV_SELECT)
 
+/* I2C clock gate register and bit mask */
+#define I2C_CLK_CGRBM(__x)	BM_CCM_CCGR2_I2C##__x##_SERIAL
+#define I2C_CLK_CGR(__x)	CCM_CCGR2
+
 #endif /* __IMX6_CRM_H__ */

--- a/core/arch/arm/plat-imx/registers/imx6.h
+++ b/core/arch/arm/plat-imx/registers/imx6.h
@@ -145,24 +145,12 @@
 #define I2C2_BASE		0x021a4000
 #define I2C3_BASE		0x02184000
 
-#define IOMUXC_I2C1_SCL_CFG	0x340
-#define IOMUXC_I2C1_SDA_CFG	0x344
-#define I2C_CFG_SCL(__x)	(IOMUXC_I2C1_SCL_CFG + ((__x) - 1) * 0x8)
-#define I2C_CFG_SDA(__x)	(IOMUXC_I2C1_SDA_CFG + ((__x) - 1) * 0x8)
-
-#define IOMUXC_I2C1_SCL_MUX	0xb4
-#define IOMUXC_I2C1_SDA_MUX	0xb8
-#define I2C_MUX_SCL(__x)	(IOMUXC_I2C1_SCL_MUX + ((__x) - 1) * 0x8)
-#define I2C_MUX_SDA(__x)	(IOMUXC_I2C1_SDA_MUX + ((__x) - 1) * 0x8)
-
-#define IOMUXC_I2C1_SCL_INP	0x5a4
-#define IOMUXC_I2C1_SDA_INP	0x5a8
-#define I2C_INP_SCL(__x)	(IOMUXC_I2C1_SCL_INP + ((__x) - 1) * 0x8)
-#define I2C_INP_SDA(__x)	(IOMUXC_I2C1_SDA_INP + ((__x) - 1) * 0x8)
-
-#define I2C_MUX_VAL(__x)	0x12
-#define I2C_CFG_VAL(__x)	0x1b8b0
-#define I2C_INP_VAL(__x)	(((__x) == IOMUXC_I2C1_SCL_INP) ? 0x1 : 0x2)
+#define IOMUXC_I2C1_SCL_CFG_OFF	0x340
+#define IOMUXC_I2C1_SDA_CFG_OFF	0x344
+#define IOMUXC_I2C1_SCL_MUX_OFF	0xb4
+#define IOMUXC_I2C1_SDA_MUX_OFF	0xb8
+#define IOMUXC_I2C1_SCL_INP_OFF	0x5a4
+#define IOMUXC_I2C1_SDA_INP_OFF	0x5a8
 #endif
 
 #endif /* __IMX6_H__ */

--- a/core/arch/arm/plat-imx/registers/imx6.h
+++ b/core/arch/arm/plat-imx/registers/imx6.h
@@ -140,4 +140,29 @@
 #define DIGPROG_OFFSET	0x260
 #endif
 
+#if defined(CFG_MX6ULL)
+#define I2C1_BASE		0x021a0000
+#define I2C2_BASE		0x021a4000
+#define I2C3_BASE		0x02184000
+
+#define IOMUXC_I2C1_SCL_CFG	0x340
+#define IOMUXC_I2C1_SDA_CFG	0x344
+#define I2C_CFG_SCL(__x)	(IOMUXC_I2C1_SCL_CFG + ((__x) - 1) * 0x8)
+#define I2C_CFG_SDA(__x)	(IOMUXC_I2C1_SDA_CFG + ((__x) - 1) * 0x8)
+
+#define IOMUXC_I2C1_SCL_MUX	0xb4
+#define IOMUXC_I2C1_SDA_MUX	0xb8
+#define I2C_MUX_SCL(__x)	(IOMUXC_I2C1_SCL_MUX + ((__x) - 1) * 0x8)
+#define I2C_MUX_SDA(__x)	(IOMUXC_I2C1_SDA_MUX + ((__x) - 1) * 0x8)
+
+#define IOMUXC_I2C1_SCL_INP	0x5a4
+#define IOMUXC_I2C1_SDA_INP	0x5a8
+#define I2C_INP_SCL(__x)	(IOMUXC_I2C1_SCL_INP + ((__x) - 1) * 0x8)
+#define I2C_INP_SDA(__x)	(IOMUXC_I2C1_SDA_INP + ((__x) - 1) * 0x8)
+
+#define I2C_MUX_VAL(__x)	0x12
+#define I2C_CFG_VAL(__x)	0x1b8b0
+#define I2C_INP_VAL(__x)	(((__x) == IOMUXC_I2C1_SCL_INP) ? 0x1 : 0x2)
+#endif
+
 #endif /* __IMX6_H__ */

--- a/core/arch/arm/plat-imx/registers/imx8m-crm.h
+++ b/core/arch/arm/plat-imx/registers/imx8m-crm.h
@@ -29,6 +29,5 @@
 #define CCM_CCRG_I2C1		23
 #define CCM_CCRG_I2C2		24
 #define CCM_CCRG_I2C3		25
-#define I2C_CLK_CGR(__x)	CCM_CCRG_I2C##__x
 
 #endif  /* __IMX8M_CRM_H */

--- a/core/arch/arm/plat-imx/registers/imx8m.h
+++ b/core/arch/arm/plat-imx/registers/imx8m.h
@@ -32,20 +32,10 @@
 #define I2C2_BASE		0x30a30000
 #define I2C3_BASE		0x30a40000
 
-#define IOMUXC_I2C1_SCL_CFG	0x47C
-#define IOMUXC_I2C1_SDA_CFG	0x480
-#define I2C_CFG_SCL(__x)	(IOMUXC_I2C1_SCL_CFG + ((__x) - 1) * 0x8)
-#define I2C_CFG_SDA(__x)	(IOMUXC_I2C1_SDA_CFG + ((__x) - 1) * 0x8)
-
-#define IOMUXC_I2C1_SCL_MUX	0x214
-#define IOMUXC_I2C1_SDA_MUX	0x218
-#define I2C_MUX_SCL(__x)	(IOMUXC_I2C1_SCL_MUX + ((__x) - 1) * 0x8)
-#define I2C_MUX_SDA(__x)	(IOMUXC_I2C1_SDA_MUX + ((__x) - 1) * 0x8)
-
-#define IOMUXC_I2C_MUX_VAL	0x010
-#define IOMUXC_I2C_CFG_VAL	0x1c3
-#define I2C_MUX_VAL(__x)	IOMUXC_I2C_MUX_VAL
-#define I2C_CFG_VAL(__x)	IOMUXC_I2C_CFG_VAL
+#define IOMUXC_I2C1_SCL_CFG_OFF	0x47C
+#define IOMUXC_I2C1_SDA_CFG_OFF	0x480
+#define IOMUXC_I2C1_SCL_MUX_OFF	0x214
+#define IOMUXC_I2C1_SDA_MUX_OFF	0x218
 #endif
 
 #endif /* __IMX8M_H__ */

--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -6,7 +6,10 @@
 #include <drivers/imx_i2c.h>
 #include <initcall.h>
 #include <io.h>
+#include <kernel/boot.h>
 #include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <platform_config.h>
@@ -15,6 +18,9 @@
 #include <util.h>
 
 #define I2C_CLK_RATE	24000000 /* Bits per second */
+
+#define USE_I2C_STATIC_ADDRESS \
+	(!defined(CFG_DT) || defined(CFG_EXTERNAL_DTB_OVERLAY))
 
 /* SoC optional: iomuxc daisy configuration register */
 #ifndef I2C_INP_SCL
@@ -29,6 +35,7 @@
 #endif
 
 static struct io_pa_va i2c_bus[3] = {
+#if USE_I2C_STATIC_ADDRESS
 #if defined(I2C1_BASE)
 	[0] = { .pa = I2C1_BASE, },
 #endif
@@ -37,6 +44,7 @@ static struct io_pa_va i2c_bus[3] = {
 #endif
 #if defined(I2C3_BASE)
 	[2] = { .pa = I2C3_BASE, },
+#endif
 #endif
 };
 
@@ -422,22 +430,87 @@ static TEE_Result get_va(paddr_t pa, vaddr_t *va)
 	return TEE_ERROR_GENERIC;
 }
 
-static TEE_Result i2c_init(void)
+#if !USE_I2C_STATIC_ADDRESS
+static const char *const dt_i2c_match_table[] = {
+	"fsl,imx21-i2c",
+};
+
+static TEE_Result i2c_mapped(const char *i2c_match)
 {
+	TEE_Result ret = TEE_ERROR_GENERIC;
+	void *fdt = get_dt();
+	size_t size = 0;
+	size_t i = 0;
+	int off = 0;
+
+	if (!fdt)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	for (i = 0; i < ARRAY_SIZE(i2c_bus); i++) {
+		off = fdt_node_offset_by_compatible(fdt, off, i2c_match);
+		if (off < 0)
+			break;
+
+		if (!(_fdt_get_status(fdt, off) & DT_STATUS_OK_SEC)) {
+			EMSG("i2c%zu not enabled", i + 1);
+			continue;
+		}
+
+		if (dt_map_dev(fdt, off, &i2c_bus[i].va, &size) < 0) {
+			EMSG("i2c%zu not enabled", i + 1);
+			continue;
+		}
+
+		i2c_bus[i].pa = virt_to_phys((void *)i2c_bus[i].va);
+		ret = TEE_SUCCESS;
+	}
+
+	return ret;
+}
+
+static TEE_Result i2c_map_controller(void)
+{
+	TEE_Result ret = TEE_ERROR_GENERIC;
+	size_t i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(dt_i2c_match_table); i++) {
+		ret = i2c_mapped(dt_i2c_match_table[i]);
+		if (!ret || ret == TEE_ERROR_NOT_SUPPORTED)
+			return ret;
+	}
+
+	return ret;
+}
+#else
+static TEE_Result i2c_map_controller(void)
+{
+	TEE_Result ret = TEE_ERROR_GENERIC;
 	size_t n = 0;
 
+	for (n = 0; n < ARRAY_SIZE(i2c_bus); n++) {
+		if (i2c_bus[n].pa) {
+			if (get_va(i2c_bus[n].pa, &i2c_bus[n].va))
+				EMSG("i2c%zu not enabled", n + 1);
+			else
+				ret = TEE_SUCCESS;
+		} else {
+			IMSG("i2c%zu not enabled", n + 1);
+		}
+	}
+
+	return ret;
+}
+#endif
+
+static TEE_Result i2c_init(void)
+{
 	if (get_va(i2c_clk.base.pa, &i2c_clk.base.va))
 		return TEE_ERROR_GENERIC;
 
 	if (get_va(i2c_mux.base.pa, &i2c_mux.base.va))
 		return TEE_ERROR_GENERIC;
 
-	for (n = 0; n < ARRAY_SIZE(i2c_bus); n++) {
-		if (get_va(i2c_bus[n].pa, &i2c_bus[n].va))
-			EMSG("i2c%zu not available", n + 1);
-	}
-
-	return TEE_SUCCESS;
+	return i2c_map_controller();
 }
 
 early_init(i2c_init);

--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -16,6 +16,18 @@
 
 #define I2C_CLK_RATE	24000000 /* Bits per second */
 
+/* SoC optional: iomuxc daisy configuration register */
+#ifndef I2C_INP_SCL
+#define I2C_INP_SCL(__x) 0
+#define I2C_INP_SDA(__x) 0
+#define I2C_INP_VAL(__x) 0
+#endif
+
+/* SoC optional: clock gate bitmask */
+#ifndef I2C_CLK_CGRBM
+#define I2C_CLK_CGRBM(__x) 0
+#endif
+
 static struct io_pa_va i2c_bus[] = {
 	{ .pa = I2C1_BASE, },
 	{ .pa = I2C2_BASE, },
@@ -25,9 +37,11 @@ static struct io_pa_va i2c_bus[] = {
 static struct imx_i2c_clk {
 	struct io_pa_va base;
 	uint32_t i2c[ARRAY_SIZE(i2c_bus)];
+	uint32_t cgrbm[ARRAY_SIZE(i2c_bus)];
 } i2c_clk = {
 	.base.pa = CCM_BASE,
 	.i2c = { I2C_CLK_CGR(1), I2C_CLK_CGR(2), I2C_CLK_CGR(3), },
+	.cgrbm = { I2C_CLK_CGRBM(1), I2C_CLK_CGRBM(2), I2C_CLK_CGRBM(3), },
 };
 
 static struct imx_i2c_mux {
@@ -35,17 +49,22 @@ static struct imx_i2c_mux {
 	struct imx_i2c_mux_regs {
 		uint32_t scl_mux;
 		uint32_t scl_cfg;
+		uint32_t scl_inp;
 		uint32_t sda_mux;
 		uint32_t sda_cfg;
+		uint32_t sda_inp;
 	} i2c[ARRAY_SIZE(i2c_bus)];
 } i2c_mux = {
 	.base.pa = IOMUXC_BASE,
 	.i2c = {{ .scl_mux = I2C_MUX_SCL(1), .scl_cfg = I2C_CFG_SCL(1),
-		.sda_mux = I2C_MUX_SDA(1), .sda_cfg = I2C_CFG_SDA(1), },
-	       { .scl_mux = I2C_MUX_SCL(2), .scl_cfg = I2C_CFG_SCL(2),
-		.sda_mux = I2C_MUX_SDA(2), .sda_cfg = I2C_CFG_SDA(2), },
-	       { .scl_mux = I2C_MUX_SCL(3), .scl_cfg = I2C_CFG_SCL(3),
-		.sda_mux = I2C_MUX_SDA(3), .sda_cfg = I2C_CFG_SDA(3), },},
+		.scl_inp = I2C_INP_SCL(1), .sda_mux = I2C_MUX_SDA(1),
+		.sda_cfg = I2C_CFG_SDA(1), .sda_inp = I2C_INP_SDA(1), },
+		{ .scl_mux = I2C_MUX_SCL(2), .scl_cfg = I2C_CFG_SCL(2),
+		.scl_inp = I2C_INP_SCL(2), .sda_mux = I2C_MUX_SDA(2),
+		.sda_cfg = I2C_CFG_SDA(2), .sda_inp = I2C_INP_SDA(2), },
+		{ .scl_mux = I2C_MUX_SCL(3), .scl_cfg = I2C_CFG_SCL(3),
+		.scl_inp = I2C_INP_SCL(3), .sda_mux = I2C_MUX_SDA(3),
+		.sda_cfg = I2C_CFG_SDA(3), .sda_inp = I2C_INP_SDA(3), },},
 };
 
 #define I2DR				0x10
@@ -132,10 +151,17 @@ static void i2c_set_prescaler(uint8_t bid, uint32_t bps)
 
 static void i2c_set_bus_speed(uint8_t bid, int bps)
 {
-	/* Enable the clock */
-	io_write32(i2c_clk.base.va + CCM_CCGRx_SET(i2c_clk.i2c[bid]),
-		   CCM_CCGRx_ALWAYS_ON(0));
+	vaddr_t addr = i2c_clk.base.va;
+	uint32_t val = 0;
 
+#if defined(CFG_MX8MM)
+	addr += CCM_CCGRx_SET(i2c_clk.i2c[bid]);
+	val = CCM_CCGRx_ALWAYS_ON(0);
+#elif defined(CFG_MX6ULL)
+	addr += i2c_clk.i2c[bid];
+	val = i2c_clk.cgrbm[bid] | io_read32(addr);
+#endif
+	io_write32(addr, val);
 	i2c_set_prescaler(bid, bps);
 }
 
@@ -350,8 +376,15 @@ TEE_Result imx_i2c_init(uint8_t bid, int bps)
 
 	io_write32(mux->base.va + mux->i2c[bid].scl_mux, I2C_MUX_VAL(bid));
 	io_write32(mux->base.va + mux->i2c[bid].scl_cfg, I2C_CFG_VAL(bid));
+	if (mux->i2c[bid].scl_inp)
+		io_write32(mux->base.va + mux->i2c[bid].scl_inp,
+			   I2C_INP_VAL(mux->i2c[bid].scl_inp));
+
 	io_write32(mux->base.va + mux->i2c[bid].sda_mux, I2C_MUX_VAL(bid));
 	io_write32(mux->base.va + mux->i2c[bid].sda_cfg, I2C_CFG_VAL(bid));
+	if (mux->i2c[bid].sda_inp)
+		io_write32(mux->base.va + mux->i2c[bid].sda_inp,
+			   I2C_INP_VAL(mux->i2c[bid].sda_inp));
 
 	/* Baud rate in bits per second */
 	i2c_set_bus_speed(bid, bps);


### PR DESCRIPTION
Support native I2C access on imx6ull (this SoC has an additional
register to configure the daisy chain in the iomuxc).

Tested on imx6ull-evk 14x14 with the bus at 400Kbps.

A patch has been sent upstream to address the current configuration in U-Boot.
https://lists.denx.de/pipermail/u-boot/2020-October/430482.html
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
