### PR TITLE
Add processing of code coverage for optee core

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -425,5 +425,17 @@ CFG_IMX_CAAM ?= y
 endif
 endif
 
+ifeq ($(CFG_CORE_GCOV_SUPPORT), y)
+ifneq ($(CFG_WITH_LPAE), y)
+# Default:
+# TEE_RAM_VA_SIZE = CORE_MMU_PGDIR_SIZE
+#                 = BIT(CORE_MMU_PGDIR_SHIFT)
+# with LPAE disabled: #define CORE_MMU_PGDIR_SHIFT	20
+#                 = BIT(20)
+#                 = 0x80000 (512 Ko)
+CFG_TEE_RAM_VA_SIZE := 0x200000 # 2MB
+endif
+endif
+
 # Cryptographic configuration
 include core/arch/arm/plat-imx/crypto_conf.mk

--- a/core/core.mk
+++ b/core/core.mk
@@ -63,6 +63,12 @@ endif
 cppflags$(sm)	+= -Ildelf/include
 cppflags$(sm)	+= -Ilib/libutee/include
 
+ifeq ($(CFG_CORE_GCOV_SUPPORT),y)
+cppflags$(sm) += --coverage
+cflags$(sm) += --coverage
+aflags$(sm) += --coverage
+endif
+
 ifeq ($(filter y, $(CFG_CORE_DYN_SHM) $(CFG_CORE_RESERVED_SHM)),)
 $(error error: No shared memory configured)
 endif

--- a/core/core.mk
+++ b/core/core.mk
@@ -119,6 +119,12 @@ include mk/lib.mk
 base-prefix := $(sm)-
 endif
 
+ifeq ($(CFG_GCOV_SUPPORT),y)
+libname = gcov
+libdir = lib/libgcov
+include mk/lib.mk
+endif
+
 ifeq ($(firstword $(subst /, ,$(CFG_CRYPTOLIB_DIR))),core)
 # If a library can be compiled for both core and user space a base-prefix
 # is needed in order to avoid conflicts in the output. However, if the

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2016-2017, Linaro Limited
+ * Copyright 2020 NXP
  */
 
 #ifndef __OPTEE_RPC_CMD_H
@@ -138,6 +139,14 @@
  * [in]     memref[2]	    function graph data
  */
 #define OPTEE_RPC_CMD_FTRACE		11
+
+/*
+ * Send code coverage data to normal world
+ *
+ * [in]     memref[1]	    filepath
+ * [in]     memref[2]	    code coverage data
+ */
+#define OPTEE_RPC_CMD_GCOV 12
 
 /*
  * Register timestamp buffer in the linux kernel optee driver

--- a/core/pta/gcov.c
+++ b/core/pta/gcov.c
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#include <gcov.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/tee_ta_manager.h>
+#include <pta_gcov.h>
+
+/*
+ * Name of the TA
+ */
+#define TA_NAME "gcov.pta"
+
+/*
+ * Proxy function which calls gcov_get_version()
+ *
+ * @ptypes  The ptypes
+ * @params  The parameters
+ *          [out]    value[0].a	    version of gcov
+ *          [none]
+ *          [none]
+ *          [none]
+ */
+static TEE_Result pta_gcov_get_version(uint32_t ptypes, TEE_Param params[4])
+{
+	uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+					      TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_ptypes, ptypes);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return gcov_get_version(&params[0].value.a);
+}
+
+/*
+ * Proxy function which calls gcov_reset_coverage_data()
+ *
+ * @ptypes  The ptypes
+ * @params  The parameters
+ *          [none]
+ *          [none]
+ *          [none]
+ *          [none]
+ */
+static TEE_Result pta_gcov_core_reset(uint32_t ptypes,
+				      __unused TEE_Param params[4])
+{
+	uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_ptypes, ptypes);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return gcov_reset_coverage_data();
+}
+
+/*
+ * Proxy function which calls gcov_dump_coverage_data()
+ *
+ * @ptypes  The ptypes
+ * @params  The parameters
+ *          [in]     memref[0]	    filepath
+ *          [in]     memref[1]	    code coverage data
+ *          [none]
+ *          [none]
+ */
+static TEE_Result pta_gcov_dump(uint32_t ptypes, TEE_Param params[4])
+{
+	uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					      TEE_PARAM_TYPE_MEMREF_INPUT,
+					      TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_ptypes, ptypes);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Dump the data */
+	return gcov_dump_coverage_data(params[0].memref.buffer,
+				       params[1].memref.buffer,
+				       params[1].memref.size);
+}
+
+/*
+ * Proxy function which calls gcov_dump_coverage_data()
+ *
+ * @ptypes  The ptypes
+ * @params  The parameters
+ *          [in]     memref[0]	    description
+ *          [none]
+ *          [none]
+ *          [none]
+ */
+static TEE_Result pta_gcov_core_dump_all(uint32_t ptypes, TEE_Param params[4])
+{
+	uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					      TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE,
+					      TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_ptypes, ptypes);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Dump the data */
+	return gcov_dump_all_coverage_data(params[0].memref.buffer);
+}
+
+/*
+ * @Handler function upon invocation of a command of the TA
+ *
+ * @psess   The Session
+ * @cmd     The command to execute
+ * @ptypes  The types of the parameters
+ * @params  The parameters
+ */
+static TEE_Result invoke_command(void *psess __unused, uint32_t cmd,
+				 uint32_t ptypes, TEE_Param params[4])
+{
+	switch (cmd) {
+	case PTA_CMD_GCOV_GET_VERSION:
+		return pta_gcov_get_version(ptypes, params);
+	case PTA_CMD_GCOV_CORE_RESET:
+		return pta_gcov_core_reset(ptypes, params);
+	case PTA_CMD_GCOV_DUMP:
+		return pta_gcov_dump(ptypes, params);
+	case PTA_CMD_GCOV_CORE_DUMP_ALL:
+		return pta_gcov_core_dump_all(ptypes, params);
+	default:
+		EMSG("Command %d not supported", cmd);
+		break;
+	}
+
+	return TEE_ERROR_BAD_PARAMETERS;
+}
+
+/*
+ * Register the PTA gcov with appropriate handler functions
+ */
+pseudo_ta_register(.uuid = PTA_GCOV_UUID, .name = TA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -11,3 +11,4 @@ srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_SYSTEM_PTA) += system.c
 
 subdirs-y += bcm
+srcs-$(CFG_GCOV_SUPPORT) += gcov.c

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -45,3 +45,4 @@ endif #CFG_WITH_USER_TA,y
 
 srcs-y += uuid.c
 srcs-y += tee_ta_enc_manager.c
+srcs-$(CFG_GCOV_SUPPORT) += tee_gcov_writer.c

--- a/core/tee/tee_gcov_writer.c
+++ b/core/tee/tee_gcov_writer.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#include <string.h>
+#include <trace.h>
+
+#include <initcall.h>
+#include <kernel/thread.h>
+#include <mm/mobj.h>
+#include <mm/tee_mmu_types.h>
+#include <optee_rpc_cmd.h>
+
+#include <gcov.h>
+
+/*
+ * Write the coverage data to filesystem in the file filepath
+ *
+ * @filepath      Path of the file to write
+ * @cov_data      Coverage data to write
+ * @cov_data_size Coverage data size
+ */
+static TEE_Result tee_gcov_writer(const char *filepath, char *cov_data,
+				  uint32_t cov_data_size)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct thread_param params[2] = {};
+	struct mobj *mobj = NULL;
+	char *buf = NULL;
+	size_t pl_sz = 0;
+	uint32_t filepath_size = 0;
+
+	if (!filepath || !cov_data) {
+		EMSG("Wrong parameters");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Compute size counting null terminator */
+	filepath_size = strlen(filepath) + 1;
+
+	pl_sz = ROUNDUP(filepath_size + cov_data_size, SMALL_PAGE_SIZE);
+
+	mobj = thread_rpc_alloc_payload(pl_sz);
+	if (!mobj) {
+		EMSG("Gcov thread_rpc_alloc_payload failed");
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	buf = mobj_get_va(mobj, 0);
+	if (!buf) {
+		EMSG("Can't get pointer on buffer");
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	memcpy(buf, filepath, filepath_size);
+	memcpy(buf + filepath_size, cov_data, cov_data_size);
+
+	params[0] = THREAD_PARAM_MEMREF(IN, mobj, 0, filepath_size);
+	params[1] = THREAD_PARAM_MEMREF(IN, mobj, filepath_size, cov_data_size);
+
+	res = thread_rpc_cmd(OPTEE_RPC_CMD_GCOV, 2, params);
+	if (res)
+		EMSG("Gcov thread_rpc_cmd res: %#" PRIx32, res);
+
+out:
+	thread_rpc_free_payload(mobj);
+
+	return res;
+}
+
+/*
+ * Register tee_gcov_writer() to gcov library
+ */
+static TEE_Result register_gcov_write_late(void)
+{
+	return register_gcov_dump_writer(tee_gcov_writer);
+}
+
+service_init_late(register_gcov_write_late);

--- a/lib/libgcov/core_dump_coverage.c
+++ b/lib/libgcov/core_dump_coverage.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <trace.h>
+
+#include <gcov.h>
+#include <optee_rpc_cmd.h>
+#include <tee/tee_fs_rpc.h>
+#include <tee_api_types.h>
+
+#include "int_gcov.h"
+
+/*
+ * Dump coverage data to REE FS
+ *
+ * The description is prepended to the filepath
+ * Sends the coverage data to the writer
+ *
+ * @desc           Description for storage, null terminated string
+ * @filepath       Name of the coverage file
+ * @cov_data       The coverage data to dump
+ * @cov_data_size  Size of the coverage data
+ */
+static TEE_Result core_direct_dump_data(const char *desc, const char *filepath,
+					void *cov_data, uint32_t cov_data_size)
+{
+	const char *core = "core/";
+	char new_filepath[COVERAGE_PATH_MAX];
+	uint32_t filepath_size = 0;
+
+	if (!desc || !filepath || !cov_data) {
+		EMSG("Wrong parameters");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	filepath_size = strlen(core) + strlen(desc) + strlen(filepath) + 1;
+	if (filepath_size >= COVERAGE_PATH_MAX) {
+		EMSG("Not enough space to store new filepath");
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	filepath_size = 0;
+	strcpy(new_filepath + filepath_size, core);
+	filepath_size += strlen(core);
+
+	strcpy(new_filepath + filepath_size, desc);
+	filepath_size += strlen(desc);
+
+	strcpy(new_filepath + filepath_size, filepath);
+	filepath_size += strlen(filepath);
+
+	filepath_size++;
+
+	return gcov_dump_coverage_data(new_filepath, cov_data, cov_data_size);
+}
+
+gcov_dump_file_fn g_gcov_dump_fn = core_direct_dump_data;

--- a/lib/libgcov/gcov.c
+++ b/lib/libgcov/gcov.c
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#include <string.h>
+#include <trace.h>
+
+#include <gcov.h>
+
+#include "int_gcov.h"
+
+static gcov_dump_writer s_writer_fn;
+
+static bool isnullterm(const char *string, size_t maxlen, size_t *len)
+{
+	size_t s_len = strnlen(string, maxlen);
+
+	if (s_len == maxlen)
+		return false;
+
+	if (len)
+		*len = s_len;
+
+	return true;
+}
+
+void __gcov_init(void *cov_unit_info)
+{
+	if (!g_gcov_impl || !g_gcov_impl->init)
+		EMSG("No implementation");
+	else
+		g_gcov_impl->init(cov_unit_info);
+}
+
+void __gcov_merge_add(void *ctrs, uint32_t nb_ctrs)
+{
+	if (!g_gcov_impl || !g_gcov_impl->merge_add)
+		EMSG("No implementation");
+	else
+		g_gcov_impl->merge_add(ctrs, nb_ctrs);
+}
+
+void __gcov_exit(void)
+{
+	if (!g_gcov_impl || !g_gcov_impl->exit)
+		EMSG("No implementation");
+	else
+		g_gcov_impl->exit();
+}
+
+TEE_Result gcov_get_version(uint32_t *version)
+{
+	/* We test if the implementation has implementeed the function */
+	if (!g_gcov_impl || !g_gcov_impl->get_version) {
+		EMSG("No implementation");
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	if (version)
+		*version = g_gcov_impl->get_version();
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result gcov_reset_coverage_data(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	/* We test if the implementation has implementeed the function */
+	if (!g_gcov_impl || !g_gcov_impl->reset_all_coverage_data) {
+		EMSG("No implementation");
+		res = TEE_ERROR_NOT_IMPLEMENTED;
+	} else {
+		res = g_gcov_impl->reset_all_coverage_data();
+	}
+
+	return res;
+}
+
+TEE_Result register_gcov_dump_writer(gcov_dump_writer writer_fn)
+{
+	s_writer_fn = writer_fn;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result gcov_dump_coverage_data(const char *filepath, char *cov_data,
+				   uint32_t cov_data_size)
+{
+	if (!filepath || !cov_data || !cov_data_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!s_writer_fn) {
+		EMSG("Writer function not registered");
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	if (!isnullterm(filepath, COVERAGE_PATH_MAX, NULL)) {
+		EMSG("filepath is not null terminated");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return s_writer_fn(filepath, cov_data, cov_data_size);
+}
+
+TEE_Result gcov_dump_all_coverage_data(const char *desc)
+{
+	TEE_Result res = TEE_SUCCESS;
+	const char *slash = "/";
+
+	if (!desc) {
+		desc = slash;
+	} else if (!isnullterm(desc, COVERAGE_PATH_MAX, NULL)) {
+		EMSG("description is not null terminated");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* We test if the implementation has implementeed the function */
+	if (!g_gcov_impl || !g_gcov_impl->dump_all_coverage_data ||
+	    !g_gcov_dump_fn) {
+		EMSG("No implementation");
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+
+	if (g_gcov_impl->start_dump_all_coverage_data) {
+		res = g_gcov_impl->start_dump_all_coverage_data();
+		if (res) {
+			EMSG("Failed to start dump of coverage data");
+			return res;
+		}
+	}
+
+	res = g_gcov_impl->dump_all_coverage_data(g_gcov_dump_fn, desc);
+
+	if (g_gcov_impl->start_dump_all_coverage_data &&
+	    g_gcov_impl->end_dump_all_coverage_data)
+		g_gcov_impl->end_dump_all_coverage_data();
+
+	return res;
+}

--- a/lib/libgcov/gcov_gcc.c
+++ b/lib/libgcov/gcov_gcc.c
@@ -1,0 +1,411 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#include <gcov.h>
+#include <tee_api_types.h>
+#include <string.h>
+#include <malloc.h>
+#include <compiler.h>
+#include <trace.h>
+
+#include "int_gcov.h"
+
+#define MAGIC_VALUE(c1, c2, c3, c4) \
+	(((uint32_t)c1 << 24) + ((uint32_t)c2 << 16) + ((uint32_t)c3 << 8) + \
+	 (uint32_t)c4)
+
+#define GCDA_MAGIC MAGIC_VALUE('g', 'c', 'd', 'a')
+
+#define TAG_FUNCTION	    0x01000000
+#define TAG_FUNCTION_LENGTH 3
+
+#define GCC_VERSION_5  50000
+#define GCC_VERSION_7  70000
+#define GCC_VERSION_10 100000
+
+/* The numbers of counters defined by GCC changes through time */
+#if __GCC_VERSION < GCC_VERSION_5
+#define NB_COUNTERS 0
+#elif GCC_VERSION_5 <= __GCC_VERSION && __GCC_VERSION < GCC_VERSION_5
+/* c77556a5d1e225024a4f9dafe5a1a6c316a86b83 basepoints/gcc-5-1775-gc77556a */
+#define NB_COUNTERS 9
+#elif GCC_VERSION_5 <= __GCC_VERSION && __GCC_VERSION < GCC_VERSION_7
+/* afe0c5ee91ab504daf13f1c07ee5559b2ba5b6e4 basepoints/gcc-5-3943-gafe0c5e */
+#define NB_COUNTERS 10
+#elif GCC_VERSION_7 <= __GCC_VERSION && __GCC_VERSION < GCC_VERSION_10
+/* 56b653f1a37372ceaba9ec6cbfc44ce09153c259 basepoints/gcc-7-3351-g56b653f */
+#define NB_COUNTERS 9
+#elif GCC_VERSION_10 <= __GCC_VERSION
+/* e37333bad7b7df7fd9d2e5165f61c2a68b57a30d basepoints/gcc-10-929-ge37333b */
+#define NB_COUNTERS 8
+#endif
+
+enum { CTR_ARCS = 0,
+       CTR_V_INTERVAL,
+       CTR_V_POW2,
+       CTR_V_TOPN,
+       CTR_V_INDIR,
+       CTR_AVERAGE,
+       CTR_IOR,
+       TIME_PROFILER,
+       START_CTR_SUPPORTED = CTR_ARCS,
+       LAST_CTR_SUPPORTED = CTR_ARCS + 1,
+};
+
+static const uint32_t ctr_tags[LAST_CTR_SUPPORTED] = {
+	[CTR_ARCS] = 0x01a10000,
+};
+
+/*
+ * Structure create by gcc to hold code coverade data of an object
+ *
+ * __gcov_ctr_info (func gcc/gcc/coverage.c:build_fn_info_type):
+ *   ctr_info::num: unsigned
+ *   ctr_info::values: <int size> *
+ *
+ * __gcov_fn_info (func build_fn_info_type):
+ *   key: const __gcov_info *
+ *   ident: unsigned
+ *   lineno_checksum: unsigned
+ *   cfg checksum: unsigned
+ *   counters: __gcov_ctr_info[number_of_gcov_counters_in_the_fn - 1]
+ */
+struct func_data {
+	/* Pointer to object containing the function */
+	const struct object_data *object;
+	/* Identifier */
+	uint32_t id;
+	/* Checksum of the line */
+	uint32_t line_chksum;
+	/* Checksum of the configuration */
+	uint32_t cfg_chksum;
+	/* Array of counters data for each type of counter */
+	struct ctr_data {
+		/* Number of counters of the type */
+		uint32_t nb_ctrs;
+		/* Array of counters value */
+		uint64_t *ctrs;
+	} ctrs_data[];
+};
+
+typedef void (*merge_fn)(uint64_t *ctrs, uint32_t nb_ctrs);
+
+/*
+ * Structure create by gcc to hold code coverade data of an object
+ *
+ * __gcov_info (func gcc/gcc/coverage.c:build_fn_info):
+ *   Version ident: unsigned
+ *   next pointer: const __gcov_info *
+ *   stamp: unsigned
+ *   Filename: const char *
+ *   merge fn array: void(*)(<int size>, unsigned)[number of gcov counters]
+ *   n_functions: unsigned
+ *   function_info pointer pointer: const
+ */
+struct object_data {
+	/* version of gcc */
+	uint32_t version;
+	/* pointer for a liked list */
+	struct object_data *next;
+	/* Date of creation */
+	uint32_t timestamp;
+	/* Name of the object */
+	const char *objectname;
+	/* Functions to merge the counters */
+	void (*merge_fn[NB_COUNTERS])(uint64_t *ctrs, uint32_t nb_ctrs);
+	/* Number of functions in the object */
+	uint32_t nb_functions;
+	/* Array of pointers on function data */
+	const struct func_data **arr_func_data;
+};
+
+/* Structure to hold data for the library */
+static struct internal_data {
+	/* Version of gcc */
+	uint32_t gcc_version;
+	/* Size of dump buffer, store the biggest size required */
+	uint32_t dump_buf_size;
+	/* Buffer to dump */
+	void *dump_buf;
+	/* List of all the objects covered */
+	struct object_data *linked_list_objects;
+	/* If a dry run is required */
+	bool dry_run_done;
+} s_int_data;
+
+/*
+ * See gcov_impl_t->get_version
+ */
+static uint32_t gcov_gcc_get_version(void)
+{
+	return s_int_data.gcc_version;
+}
+
+/*
+ * See gcov_impl_t->init
+ */
+static void gcov_gcc_init(void *cov_object_info)
+{
+	struct object_data *od = cov_object_info;
+
+	/* The objects are inserted in LIFO */
+	if (!s_int_data.linked_list_objects) {
+		s_int_data.linked_list_objects = od;
+	} else {
+		od->next = s_int_data.linked_list_objects;
+		s_int_data.linked_list_objects = od;
+	}
+
+	if (!s_int_data.gcc_version)
+		s_int_data.gcc_version = od->version;
+}
+
+/*
+ * See gcov_impl_t->merge_add
+ */
+static void gcov_gcc_merge_add(void *ctrs, uint32_t nb_ctrs)
+{
+	(void)ctrs;
+	(void)nb_ctrs;
+}
+
+static void gcov_gcc_exit(void)
+{
+	/* empty */
+}
+
+/*
+ * See gcov_impl_t->reset_all_coverage_data
+ */
+static TEE_Result gcov_gcc_reset_all_coverage_data(void)
+{
+	struct object_data *od = s_int_data.linked_list_objects;
+	const struct func_data *fd = NULL;
+	const struct ctr_data *cd = NULL;
+	uint32_t cur_fn = 0;
+	uint32_t cur_ctr = 0;
+
+	/* No object registered */
+	if (!od)
+		return TEE_SUCCESS;
+
+	/* We loop over the object data */
+	do {
+		/* We loop over the function data */
+		for (cur_fn = 0; cur_fn < od->nb_functions; cur_fn++) {
+			fd = od->arr_func_data[cur_fn];
+
+			/* We loop over the type of counters */
+			for (cur_ctr = START_CTR_SUPPORTED;
+			     cur_ctr <= LAST_CTR_SUPPORTED; cur_ctr++) {
+				cd = &fd->ctrs_data[cur_ctr];
+
+				/* We reset the enabled counters */
+				if (od->merge_fn[cur_ctr])
+					memset(cd->ctrs, 0,
+					       sizeof(*cd->ctrs) * cd->nb_ctrs);
+			}
+		}
+	} while ((od = od->next));
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * See gcov_impl_t->start_dump_all_coverage_data
+ */
+static TEE_Result gcov_gcc_start_dump_all_coverage_data(void)
+{
+	/* Reuse the biggest buffer size if any */
+	uint32_t buf_size = s_int_data.dump_buf_size;
+
+	s_int_data.dump_buf = malloc(buf_size);
+	if (!s_int_data.dump_buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	s_int_data.dump_buf_size = buf_size;
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * We will always be aligned on a word
+ */
+#define write_u32(buf, val, dry_run) \
+	({ \
+		if (!dry_run) { \
+			*((uint32_t *)buf) = val; \
+			buf = ((uint8_t *)buf) + sizeof(uint32_t); \
+		} \
+		(sizeof(uint32_t)); \
+	})
+
+/*
+ * We are not always aligned on a word boundary else the use of memmove
+ */
+#define write_u64(buf, val, dry_run) \
+	({ \
+		if (!dry_run) { \
+			uint64_t v = val; \
+			memmove(buf, &v, sizeof(uint64_t)); \
+			buf = ((uint8_t *)buf) + sizeof(uint64_t); \
+		} \
+		(sizeof(uint64_t)); \
+	})
+
+/*
+ * Create a GCDA file in the buffer provided
+ *
+ * If the size of the buffer is zero, it returns the size required
+ *
+ * From gcc/gcc/gcov-dump.c
+ *
+ * A FUNCTION block is generally foloowed by blocks for counters, 1 bloc per
+ * counter
+ *
+ * struct gcda_file {
+ *     uint32_t magic;
+ *     uint32_t version;
+ *     uint32_t stamp;
+ *
+ *     struct {
+ *         uint32_t tag;
+ *         uint32_t len;
+ *         union {
+ *             {
+ *                 uint32_t ident;
+ *                 uint32_t lineno_checksum;
+ *                 uint32_t cfg_checksum;
+ *             } gcda_functions;
+ *             {
+ *                 uint64_t values;
+ *             } gcda_counters;
+ *         } *gcda_block;
+ *     } gcda_data;
+ * };
+ */
+static uint32_t gcov_gcc_create_gcda(const struct object_data *od, void *buffer)
+{
+	const struct func_data *fd = NULL;
+	const struct ctr_data *cd = NULL;
+	uint32_t cur_fn = 0;
+	uint32_t cur_ctr = 0;
+	bool dry_run = false;
+	uint32_t size = 0;
+	uint32_t ctr_size = 0;
+	uint32_t i = 0;
+	void *buf = buffer;
+
+	if (!buffer)
+		dry_run = true;
+
+	/* Write file header */
+	size += write_u32(buf, GCDA_MAGIC, dry_run);
+	size += write_u32(buf, s_int_data.gcc_version, dry_run);
+	size += write_u32(buf, od->timestamp, dry_run);
+
+	/* We loop over the function data */
+	for (cur_fn = 0; cur_fn < od->nb_functions; cur_fn++) {
+		fd = od->arr_func_data[cur_fn];
+
+		size += write_u32(buf, TAG_FUNCTION, dry_run);
+		size += write_u32(buf, TAG_FUNCTION_LENGTH, dry_run);
+
+		size += write_u32(buf, fd->id, dry_run);
+		size += write_u32(buf, fd->line_chksum, dry_run);
+		size += write_u32(buf, fd->cfg_chksum, dry_run);
+
+		/* We loop over the type of counters */
+		for (cur_ctr = START_CTR_SUPPORTED;
+		     cur_ctr <= LAST_CTR_SUPPORTED; cur_ctr++) {
+			cd = &fd->ctrs_data[cur_ctr];
+			ctr_size = cd->nb_ctrs * 2;
+
+			/* Pass to next type if no merge function */
+			if (!od->merge_fn[cur_ctr])
+				continue;
+
+			size += write_u32(buf, ctr_tags[cur_ctr], dry_run);
+			size += write_u32(buf, ctr_size, dry_run);
+
+			/* Loop over counter values */
+			for (i = 0; i < cd->nb_ctrs; i++)
+				size += write_u64(buf, cd->ctrs[i], dry_run);
+		}
+	}
+
+	return size;
+}
+
+/*
+ * See gcov_impl_t->dump_all_coverage_data
+ */
+static TEE_Result gcov_gcc_dump_all_coverage_data(gcov_dump_file_fn dump_fn,
+						  const char *desc)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct object_data *od = s_int_data.linked_list_objects;
+	bool dry_run = !s_int_data.dry_run_done;
+	uint32_t size_required = 0;
+	uint32_t size_written = 0;
+	void **buf = &s_int_data.dump_buf;
+
+	/* No object registered */
+	if (!od)
+		return res;
+
+	/* We loop over the object data */
+	do {
+		/* Do a dry run */
+		if (dry_run) {
+			size_required = gcov_gcc_create_gcda(od, NULL);
+
+			/* Check if we need to reallocate the buffer */
+			if (size_required > s_int_data.dump_buf_size) {
+				*buf = realloc(*buf, size_required);
+				if (!s_int_data.dump_buf)
+					return TEE_ERROR_OUT_OF_MEMORY;
+
+				s_int_data.dump_buf_size = size_required;
+			}
+		}
+
+		/* Create the gcda file in buffer */
+		size_written = gcov_gcc_create_gcda(od, *buf);
+
+		/* write the file */
+		res = dump_fn(desc, od->objectname, *buf, size_written);
+
+	} while ((od = od->next));
+
+	s_int_data.dry_run_done = true;
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * See gcov_impl_t->end_dump_all_coverage_data
+ */
+static void gcov_gcc_end_dump_all_coverage_data(void)
+{
+	/* We keep the size of buffer used from this dump */
+	free(s_int_data.dump_buf);
+}
+
+/*
+ * Implementation of gcov for GCC
+ */
+const struct gcov_impl_t gcov_gcc = {
+	.get_version = gcov_gcc_get_version,
+	.init = gcov_gcc_init,
+	.exit = gcov_gcc_exit,
+	.merge_add = gcov_gcc_merge_add,
+	.reset_all_coverage_data = gcov_gcc_reset_all_coverage_data,
+	.start_dump_all_coverage_data = gcov_gcc_start_dump_all_coverage_data,
+	.dump_all_coverage_data = gcov_gcc_dump_all_coverage_data,
+	.end_dump_all_coverage_data = gcov_gcc_end_dump_all_coverage_data,
+};
+
+REGISTR_GCOV_IMPL(&gcov_gcc);

--- a/lib/libgcov/include/gcov.h
+++ b/lib/libgcov/include/gcov.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#ifndef GCOV_H
+#define GCOV_H
+
+#include <tee_api_types.h>
+
+/*
+ * Print debug information about the gcov support
+ *
+ * @version  The version of the implementation
+ */
+TEE_Result gcov_get_version(uint32_t *version);
+
+/*
+ * Reset all the coverage data
+ */
+TEE_Result gcov_reset_coverage_data(void);
+
+/*
+ * Write the coverage data to filesystem in the file filepath
+ *
+ * @filepath      Path of the file to write
+ * @cov_data      Coverage data to write
+ * @cov_data_size Coverage data size
+ */
+typedef TEE_Result (*gcov_dump_writer)(const char *filepath, char *cov_data,
+				       uint32_t cov_data_size);
+
+TEE_Result register_gcov_dump_writer(gcov_dump_writer writer_fn);
+
+/*
+ * Dump coverage data to REE FS
+ *
+ * @filepath       Path of the coverage file
+ * @cov_data       The coverage data to dump
+ * @cov_data_size  Size of the coverage data
+ */
+TEE_Result gcov_dump_coverage_data(const char *filepath, char *cov_data,
+				   uint32_t cov_data_size);
+
+/*
+ * Dump the current state of the coverage data to filesystem
+ *
+ * @desc  Description for storage, null terminated string
+ */
+TEE_Result gcov_dump_all_coverage_data(const char *desc);
+
+#endif /* GCOV_H */

--- a/lib/libgcov/int_gcov.h
+++ b/lib/libgcov/int_gcov.h
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#ifndef INT_GCOV_H
+#define INT_GCOV_H
+
+#include <tee_api_types.h>
+
+/*
+ * Maximum size of a coverage path
+ */
+#define COVERAGE_PATH_MAX 255
+
+/*
+ * Initialize the data from a coverage unit
+ *
+ * @cov_unit_info  The coverage data to initialize
+ */
+void __gcov_init(void *cov_unit_info);
+
+/*
+ * Perform the merge_data operation for @p hProfData
+ *
+ * @ctrs     List of counters to merge
+ * @nb_ctrs  Number of counters to merge
+ */
+void __gcov_merge_add(void *ctrs, uint32_t nb_ctrs);
+
+/*
+ * Coverage processing can be stopped
+ */
+void __gcov_exit(void);
+
+/*
+ * Dump coverage data to REE FS
+ *
+ * The description is prepended to the filepath
+ *
+ * @desc           Description for storage, null terminated string
+ * @filepath       Name of the coverage file
+ * @cov_data       The coverage data to dump
+ * @cov_data_size  Size of the coverage data
+ */
+typedef TEE_Result (*gcov_dump_file_fn)(const char *desc, const char *filepath,
+					void *cov_data, uint32_t cov_data_size);
+
+/*
+ * static Implementation of dump function to use
+ */
+extern gcov_dump_file_fn g_gcov_dump_fn;
+
+/*
+ * Define the functions an implementation shall provide to process the coverage
+ * data
+ */
+struct gcov_impl_t {
+	/*
+	 * Get the version of the implementation
+	 */
+	uint32_t (*get_version)(void);
+	/*
+	 * Initialize the data of the coverage unit
+	 *
+	 * @cov_unit_info  The coverage unit info to initialize
+	 */
+	void (*init)(void *cov_unit_info);
+
+	/*
+	 * Perform the merge_data operation for @p hProfData
+	 *
+	 * @ctrs     List of counters to merge
+	 * @nb_ctrs  Number of counters to merge
+	 */
+	void (*merge_add)(void *ctrs, uint32_t nb_ctrs);
+
+	/*
+	 * Coverage processing can be stopped
+	 */
+	void (*exit)(void);
+
+	/*
+	 * Reset all the coverage data
+	 */
+	TEE_Result (*reset_all_coverage_data)(void);
+
+	/*
+	 * Start dump of all the coverage data
+	 */
+	TEE_Result (*start_dump_all_coverage_data)(void);
+
+	/*
+	 * Dump all the coverage data to filesystem
+	 *
+	 * @dump_fn  The function to call to dump data
+	 * @desc     Description for storage, null terminated string
+	 */
+	TEE_Result (*dump_all_coverage_data)(gcov_dump_file_fn dump_fn,
+					     const char *desc);
+
+	/*
+	 * End dump of all the coverage data
+	 */
+	void (*end_dump_all_coverage_data)(void);
+};
+
+/*
+ * static Implementation of gcov to use
+ */
+extern const struct gcov_impl_t *g_gcov_impl;
+
+/*
+ * Macro to register the implementation of gcov
+ */
+#define REGISTR_GCOV_IMPL(p_impl) const struct gcov_impl_t *g_gcov_impl = p_impl
+
+#endif /* INT_GCOV_H */

--- a/lib/libgcov/sub.mk
+++ b/lib/libgcov/sub.mk
@@ -1,5 +1,6 @@
 global-incdirs-y += include
 srcs-y += gcov.c
+srcs-y += gcov_gcc.c
 
 # Select the dumper of coverage to use in the library depending on the
 # component being built

--- a/lib/libgcov/sub.mk
+++ b/lib/libgcov/sub.mk
@@ -1,0 +1,10 @@
+global-incdirs-y += include
+srcs-y += gcov.c
+
+# Select the dumper of coverage to use in the library depending on the
+# component being built
+ifeq ($(sm-core),y)
+srcs-y += core_dump_coverage.c
+else
+srcs-y += ta_dump_coverage.c
+endif

--- a/lib/libgcov/ta_dump_coverage.c
+++ b/lib/libgcov/ta_dump_coverage.c
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <trace.h>
+
+#include <pta_gcov.h>
+#include <tee_api.h>
+#include <tee_api_types.h>
+
+#include "int_gcov.h"
+
+/*
+ * Dump coverage data to REE FS
+ *
+ * The description is prepended to the filepath
+ * Call the gcov PTA to perform the write of the data
+ *
+ * @desc           Description for storage, null terminated string
+ * @filepath       Name of the coverage file
+ * @cov_data       The coverage data to dump
+ * @cov_data_size  Size of the coverage data
+ */
+static TEE_Result ta_direct_dump_data(const char *desc, const char *filepath,
+				      void *cov_data, uint32_t cov_data_size)
+{
+	TEE_Result res = TEE_SUCCESS;
+	TEE_TASessionHandle sess = NULL;
+	TEE_UUID pta_uuid = PTA_GCOV_UUID;
+	uint32_t cRT = TEE_TIMEOUT_INFINITE;
+	uint32_t paramTypes = 0;
+	TEE_Param params[TEE_NUM_PARAMS] = { 0 };
+	uint32_t err_origin = 0;
+
+	char new_filepath[COVERAGE_PATH_MAX] = { 0 };
+	uint32_t filepath_size = 0;
+
+	if (!desc || !filepath || !cov_data) {
+		EMSG("Wrong parameters");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Compute total size of new filepath:
+	 * <desc>/<filepath>'\0'
+	 */
+	filepath_size = strlen(desc) + strlen(filepath) + 1;
+	if (filepath_size >= COVERAGE_PATH_MAX) {
+		EMSG("Not enough space to store new filepath");
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	/* Create new_filepath with '<desc>/<filepath>'\0'' */
+	filepath_size = 0;
+
+	strcpy(new_filepath + filepath_size, desc);
+	filepath_size += strlen(desc);
+
+	strcpy(new_filepath + filepath_size, filepath);
+	filepath_size += strlen(filepath);
+
+	filepath_size++;
+
+	/* Call gcov pta to dump the data */
+	res = TEE_OpenTASession(&pta_uuid, cRT, 0, NULL, &sess, &err_origin);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_OpenTASession failed with code 0x%x origin 0x%x", res,
+		     err_origin);
+		goto exit;
+	}
+
+	paramTypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				     TEE_PARAM_TYPE_MEMREF_INPUT,
+				     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+
+	/* new_filepath */
+	params[0].memref.buffer = new_filepath;
+	params[0].memref.size = filepath_size;
+
+	/* coverage data */
+	params[1].memref.buffer = cov_data;
+	params[1].memref.size = cov_data_size;
+
+	res = TEE_InvokeTACommand(sess, cRT, PTA_CMD_GCOV_DUMP, paramTypes,
+				  params, &err_origin);
+	if (res != TEE_SUCCESS)
+		EMSG("TEE_InvokeTACommand failed with code 0x%x origin 0x%x",
+		     res, err_origin);
+
+	TEE_CloseTASession(sess);
+
+exit:
+	return res;
+}
+
+gcov_dump_file_fn g_gcov_dump_fn = ta_direct_dump_data;

--- a/lib/libutee/include/pta_gcov.h
+++ b/lib/libutee/include/pta_gcov.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020 NXP
+ */
+
+#ifndef PTA_GCOV_H_
+#define PTA_GCOV_H_
+
+/*
+ * GCOV_UUID The UUID to contact the gcov STA
+ */
+#define PTA_GCOV_UUID \
+	{ \
+		0xa1527d6c, 0x1f80, 0x417c, \
+		{ \
+			0x97, 0x27, 0x1b, 0x93, 0x0c, 0x52, 0xfe, 0x75 \
+		} \
+	}
+
+/* Get version of gcov for the core */
+#define PTA_CMD_GCOV_GET_VERSION 0
+
+/* Store code coverage data */
+#define PTA_CMD_GCOV_DUMP 1
+
+/* Reset the code coverage of the core */
+#define PTA_CMD_GCOV_CORE_RESET 2
+
+/* Generate and store the code coverage for the core */
+#define PTA_CMD_GCOV_CORE_DUMP_ALL 3
+
+#endif /* PTA_GCOV_H_ */

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -9,6 +9,7 @@
 #
 # set	  objs
 # update  cleanfiles
+# update  gcnofiles if CFG_GCOV_SUPPORT is enabled
 #
 # Generates explicit rules for all objs
 
@@ -81,6 +82,15 @@ ifeq ($C,1)
 check-cmd-$2 = $(CHECK) $$(comp-cppflags-$2) $$<
 echo-check-$2 := $(cmd-echo-silent)
 echo-check-cmd-$2 = $(cmd-echo) $$(subst \",\\\",$$(check-cmd-$2))
+endif
+
+ifeq ($(CFG_GCOV_SUPPORT),y)
+ifeq ($$(findstring --coverage, $$(comp-flags-$2)), --coverage)
+gcnofile := $(basename $2).gcno
+cleanfiles := $$(cleanfiles) $(gcnofile)
+gcnofiles := $$(gcnofiles) $(gcnofile)
+$(basename $2).gcno: $2
+endif
 endif
 
 else ifeq ($$(filter %.S,$1),$1)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -619,3 +619,29 @@ CFG_COMPAT_GP10_DES ?= y
 
 # Defines a limit for many levels TAs may call each others.
 CFG_CORE_MAX_SYSCALL_RECURSION ?= 4
+
+# Core coverage.
+# When this option is enabled, code coverage data can be obtained for the
+# components in OP-TEE binary
+#
+# The coverage information will be outputed in gcda format to
+# /core/<user_description>/<tree structure>/<source file>.gcda
+# (path is defined in tee-supplicant)
+CFG_CORE_GCOV_SUPPORT ?= n
+
+ifeq ($(CFG_CORE_GCOV_SUPPORT), y)
+CFG_GCOV_SUPPORT = y
+endif
+
+# TA coverage.
+# When this option is enabled, code coverage data can be obtained for the
+# components in TA binary
+#
+# The coverage information will be outputed in gcda format to
+# /<user_description>/<tree structure>/<source file>.gcda
+# (path is defined in tee-supplicant)
+CFG_TA_GCOV_SUPPORT ?= n
+
+ifeq ($(CFG_TA_GCOV_SUPPORT), y)
+CFG_GCOV_SUPPORT = y
+endif

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+# This script will create the coverage report given the coverage notes and data
+
+import sys  # Handle exit status
+import os  # Interact with PATH env variable and filesystem
+import argparse  # Handle command line
+import logging  # Logging
+import distutils.dir_util  # Copy of tree
+import subprocess  # Call lcov and genhtml
+from pathlib import Path  # Glob on gcda and gcno
+
+
+def find_binary(logger, bin_name, proposed_bin_path):
+    """
+    Finds a binary.
+
+    :param      bin_name:  The bin name
+    :type       bin_name:  string
+
+    Return the path to the binary
+    """
+
+    # Check path passed as argument
+    if proposed_bin_path is not None:
+        if os.path.isfile(proposed_bin_path):
+            return proposed_bin_path
+
+    # Get PATH variable
+    pathvar = os.environ['PATH']
+    paths = pathvar.split(os.pathsep)
+
+    # Loop through paths
+    for path in paths:
+        filepath = os.path.join(path, bin_name)
+
+        # Try to find the file
+        if os.path.isfile(filepath):
+            return filepath
+
+    logger.warning("Could not find {} in {}".format(bin_name, paths))
+
+    # Raise exception
+    raise FileNotFoundError('{}'.format(bin_name))
+
+
+def main():
+    cwd = os.getcwd()
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger("coverage")
+
+    default_gcov = "gcov"
+    default_lcov = "lcov"
+    default_genhtml = "genhtml"
+    default_browser = "firefox"
+
+    p = argparse.ArgumentParser(description='Process coverage data generated \
+                                to create coverage result along with an HTML \
+                                output')
+
+    g1 = p.add_argument_group("Information about the analysis")
+    g1.add_argument("--uc", help="Name of the Use Case", type=str,
+                    default="my_uc")
+    g1.add_argument("--info", help="Name of the info file to create", type=str)
+    g1.add_argument("--outdir", help="Path to the directory for analysis",
+                    type=str)
+    g1.add_argument("--html", help="Generate HTML output", action='store_true')
+    g1.add_argument("--view", help="View HTML output in browser",
+                    action='store_true')
+    g1.add_argument("--src_dir", help="Top dir of the sources", type=str,
+                    required=True)
+
+    g2 = p.add_argument_group("Coverage material generated")
+    g2.add_argument("--notes", help="Directory containing the coverage notes",
+                    type=str, required=True)
+    g2.add_argument("--data", help="Directory containing the coverage data",
+                    type=str, required=True)
+
+    g3 = p.add_argument_group("External tools")
+    g3.add_argument("--gcov", help="Path to the gcov binary", type=str,
+                    default=default_gcov)
+    g3.add_argument("--lcov", help="Path to lcov binary", type=str,
+                    default=default_lcov)
+    g3.add_argument("--genhtml", help="Path to genhtml binary", type=str,
+                    default=default_genhtml)
+    g3.add_argument("--browser", help="Path to browser binary", type=str,
+                    default=default_browser)
+
+    p.add_argument("-v", "--verbose", help="verbose mode", action='store_true')
+
+    # Parse the command line
+    args = p.parse_args()
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    logger.debug("Check analysis parameters")
+    logger.info("Use case name: {}".format(args.uc))
+
+    dir_analysis = (args.outdir if args.outdir is not None
+                    else "{}/{}".format(cwd, args.uc))
+    logger.info("Analysis directory: {}".format(dir_analysis))
+
+    info_filename = (args.info if args.info is not None
+                     else "{}.info".format(args.uc))
+    logger.info("Information filename: {}".format(info_filename))
+
+    info_filepath = "{}/{}".format(dir_analysis, info_filename)
+
+    logger.debug("Check coverage notes directory")
+    if not os.path.isdir(args.notes):
+        raise NotADirectoryError(args.notes)
+    logger.info("Directory containing notes: {}".format(args.notes))
+
+    logger.debug("Check coverage data directory")
+    if not os.path.isdir(args.data):
+        raise NotADirectoryError(args.data)
+    logger.info("Directory containing data: {}".format(args.data))
+
+    logger.debug("Check source directory")
+    if not os.path.isdir(args.src_dir):
+        raise NotADirectoryError(args.src_dir)
+    logger.info("Directory of sources: {}".format(args.src_dir))
+
+    logger.debug("Check external tools")
+    logger.debug("Set gcov binary")
+    gcov_bin = find_binary(l, default_gcov, args.gcov)
+    logger.info("Binary for gcov: {}".format(gcov_bin))
+
+    logger.debug("Set lcov binary")
+    lcov_bin = find_binary(l, default_lcov, args.lcov)
+    logger.info("Binary for lcov: {}".format(lcov_bin))
+
+    if args.html:
+        logger.debug("Set genhtml binary")
+        genhtml_bin = find_binary(l, default_genhtml, args.genhtml)
+        logger.info("Binary for genhtml: {}".format(genhtml_bin))
+
+        if args.view:
+            logger.debug("Set browser binary")
+            browser_bin = find_binary(l, default_browser, args.genhtml)
+            logger.info("Binary for genhtml: {}".format(genhtml_bin))
+
+    logger.debug("Create analysis directory")
+    os.mkdir(dir_analysis)
+    logger.info("Analysis directory: {}".format(dir_analysis))
+
+    logger.debug("Copy notes")
+    distutils.dir_util.copy_tree(args.notes, dir_analysis)
+    logger.debug("Copy notes done")
+
+    logger.debug("Copy data")
+    distutils.dir_util.copy_tree(args.data, dir_analysis)
+    logger.debug("Copy data done")
+
+    logger.debug("Check that the gcno are along the gcda")
+    logger.debug("Search for all the gcda")
+    gcda_files = list(Path(dir_analysis).rglob('*.gcda'))
+
+    if not gcda_files:
+        raise FileNotFoundError("No gcda files can be found in {}".
+                                format(dir_analysis))
+
+    for gcda_file in gcda_files:
+        component = Path(gcda_file).with_suffix('')
+        gcno_file_exp = str(component) + ".gcno"
+        logger.debug("gcda: {}, looking for {}".format(gcda_file,
+                     gcno_file_exp))
+
+        if not os.path.isfile(gcno_file_exp):
+            logger.error("{} does not exists".format(gcno_file_exp))
+            gcno_file = os.path.basename(gcno_file_exp)
+            gcno_files = list(Path(dir_analysis).rglob(gcno_file))
+
+            if not gcno_files:
+                raise FileNotFoundError("{} could not be found in {}".
+                                        format(gcno_file, dir_analysis))
+            else:
+                raise FileNotFoundError('{} not along {}, located at {}'.
+                                        format(gcno_file_exp, gcda_file,
+                                               gcno_files[0]))
+
+    run_analysis_cmd = [lcov_bin, "--capture", "--directory", dir_analysis,
+                        "--gcov-tool", gcov_bin, "--output-file",
+                        info_filepath]
+    logger.debug("Analysis command: {}".format(run_analysis_cmd))
+
+    logger.debug("Run the analysis")
+    run_analysis = subprocess.check_output(run_analysis_cmd,
+                                           stderr=subprocess.STDOUT)
+
+    gcov_errors = ["skipping", "did not produce any data for"]
+
+    logger.debug("Check analysis output")
+    for line in run_analysis.decode("utf-8").splitlines():
+        for error in gcov_errors:
+            if error in line:
+                raise RuntimeError(line)
+
+    logger.info("Analysis done, information file: {}".format(info_filepath))
+
+    if args.html:
+        html_folder = "{}/html".format(dir_analysis)
+
+        generate_html_cmd = [genhtml_bin, "--prefix", args.src_dir, "--legend",
+                             "--title", args.uc, "--output-directory",
+                             html_folder, info_filepath]
+        logger.debug("HTML generation command: {}".format(run_analysis_cmd))
+
+        logger.debug("Create HTML output")
+        generate_html = subprocess.check_output(generate_html_cmd)
+
+        logger.info("HTML generation done, output: {}".format(html_folder))
+
+        html_index = "{}/index.html".format(html_folder)
+        logger.info("HTML index file: {}".format(html_index))
+
+        if args.view:
+            view_cmd = [browser_bin, html_index]
+
+            logger.debug("Show HTML output in browser")
+            logger.info("View HTML in browser: {}".format(view_cmd))
+            subprocess.run(view_cmd)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -47,6 +47,10 @@ link-ldflags += --dynamic-list $(link-out-dir$(sm))/dyn_list
 dynlistdep = $(link-out-dir$(sm))/dyn_list
 cleanfiles += $(link-out-dir$(sm))/dyn_list
 
+ifeq ($(CFG_GCOV_SUPPORT),y)
+	libnames += gcov
+endif
+
 link-ldadd  = $(user-ta-ldadd) $(addprefix -L,$(libdirs))
 link-ldadd += --start-group
 link-ldadd += $(addprefix -l,$(libnames))

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -39,6 +39,9 @@ ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
 ta-mk-file-export-vars-$(sm) += CFG_CORE_TPM_EVENT_LOG
 ta-mk-file-export-add-$(sm) += CFG_TEE_TA_LOG_LEVEL ?= $(CFG_TEE_TA_LOG_LEVEL)_nl_
+ta-mk-file-export-vars-$(sm) += CFG_GCOV_SUPPORT
+ta-mk-file-export-vars-$(sm) += CFG_CORE_GCOV_SUPPORT
+ta-mk-file-export-vars-$(sm) += CFG_TA_GCOV_SUPPORT
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -83,6 +83,13 @@ endif
 
 base-prefix := $(sm)-
 
+ifeq ($(CFG_GCOV_SUPPORT),y)
+libname = gcov
+libdir = lib/libgcov
+libuuid = a97851f6-c80e-11ea-87d0-0242ac130003
+include mk/lib.mk
+endif
+
 libname = utils
 libdir = lib/libutils
 libuuid = 71855bba-6055-4293-a63f-b0963a737360


### PR DESCRIPTION
Code coverage is the notion of knowing which part of the code is executed at runtime during a scenario or normal execution.

Code coverage is a useful tool with different purposes:
- Verify which lines of code are executed during testing
- Optimize branching prediction by feeding scenario at compilation

The code coverage processing is already available for user code or other projects like the Linux kernel using its implementation in different compiler like GCC or Clang.

It was not available in optee for 3 reasons:
- Compilation not configured for it
- No gcov library linked to process the structure added by the compiler into coverage data files
- No method to store the generated data files to place accessible to the user

This pull request adresses these issues in order to add code coverage analysis to optee.

The code coverage is added using 3 main components:
- libgcov: library which handles:
-- keep a list of the structure added by the compiler containing code coverage data
-- reset all coverage data
-- write all coverage data
-- Transform the code coverage structures into data to be written following gcov gcda format
- PTA gcov: Allow to interact with the code coverage of the code or write coverage data file
- coverage data file writer: Write coverage data file to REE FS using new RPC

Code coverage support should be enabled only when developping/debugging as it adds overhead at runtime.
It also increases the size of the binary generated (gcc 9.2.0):
 - tee.elf: 18%
 - libutils: 10%
 - libutee: 5%
 - TA aes_perf (from optee_test): 27%
The time to build is also increased by ~25%

Limitations:
- Clang suport not tested but should be easy as it follows gcov data files format.
- No code coverage of the TA: Current implementation can support it but it needs to call constructor function added by the compiler when loading the TA which is not already done. 

Supporting PR:
- optee_client: https://github.com/OP-TEE/optee_client/pull/231
- optee_test: https://github.com/OP-TEE/optee_test/pull/457

[ta_from_ta.txt.txt](https://github.com/OP-TEE/optee_os/files/5473466/ta_from_ta.txt.txt)
[core_from_ca.txt.txt](https://github.com/OP-TEE/optee_os/files/5473467/core_from_ca.txt.txt)
[core_from_ta.txt.txt](https://github.com/OP-TEE/optee_os/files/5473468/core_from_ta.txt.txt)


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
