### PR TITLE
core: ltc: fix return value in crypto API SM2 PKA decrypt

### DIFF
--- a/core/lib/libtomcrypt/sm2-pke.c
+++ b/core/lib/libtomcrypt/sm2-pke.c
@@ -245,8 +245,10 @@ TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key,
 	*dst_len = out_len;
 	if (out_len < C2_len) {
 		eom = calloc(1, C2_len - out_len);
-		if (!eom)
+		if (!eom) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;
+		}
 		for (i = out_len; i < C2_len; i++)
 		       eom[i - out_len] = src[C1_len + i] ^ t[i];
 	}


### PR DESCRIPTION
Fix calloc() failure case in core crypto API function for SM2 PKE
decryption. Prior this change the function failed but return 0/OK.
This change sets the return value to TEE_ERROR_OUT_OF_MEMORY before
reaching the function exit sequence.

Fixes: f9a7828 (core: ltc: add support for SM2 PKE)
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
