### PR TITLE
core: fix secure partition TA context

### DIFF
--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -160,12 +160,7 @@ static inline void tee_ta_ftrace_update_times_resume(void) {}
 
 bool is_ta_ctx(struct ts_ctx *ctx);
 
-static inline struct tee_ta_session * __noprof
-to_ta_session(struct ts_session *sess)
-{
-	assert(is_ta_ctx(sess->ctx));
-	return container_of(sess, struct tee_ta_session, ts_sess);
-}
+struct tee_ta_session *to_ta_session(struct ts_session *sess);
 
 static inline struct tee_ta_ctx *to_ta_ctx(struct ts_ctx *ctx)
 {


### PR DESCRIPTION
Fix secure partition invocation in tee_ta_manager.c. The TA context
instance is found in the secure partition context (as here *_stmm_ctx()),
instead of the trusted service context as for regular TAs and PTAs.

This change moves to_ta_session() from header file to source file
so that is_stmm_ctx() is visible and can be asserted.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
