### PR TITLE
libmbedtls: add function to free rsa keypair

### DIFF
--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -172,6 +172,7 @@ TEE_Result crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
 TEE_Result crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
 				   size_t key_size_bits);
 void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s);
+void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s);
 TEE_Result crypto_acipher_alloc_dsa_keypair(struct dsa_keypair *s,
 				size_t key_size_bits);
 TEE_Result crypto_acipher_alloc_dsa_public_key(struct dsa_public_key *s,

--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -201,6 +201,7 @@ void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
 	crypto_bignum_free(s->q);
 	crypto_bignum_free(s->qp);
 	crypto_bignum_free(s->dp);
+	crypto_bignum_free(s->dq);
 }
 
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size)

--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -190,6 +190,19 @@ void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 	crypto_bignum_free(s->e);
 }
 
+void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
+{
+	if (!s)
+		return;
+	crypto_bignum_free(s->e);
+	crypto_bignum_free(s->d);
+	crypto_bignum_free(s->n);
+	crypto_bignum_free(s->p);
+	crypto_bignum_free(s->q);
+	crypto_bignum_free(s->qp);
+	crypto_bignum_free(s->dp);
+}
+
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size)
 {
 	TEE_Result res = TEE_SUCCESS;

--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -155,14 +155,7 @@ TEE_Result crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
 
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->e);
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->n);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->q);
-	crypto_bignum_free(s->qp);
-	crypto_bignum_free(s->dp);
-
+	crypto_acipher_free_rsa_keypair(s);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 


### PR DESCRIPTION
Cherry-pick the libmbedtls part of commit a1d5c81f8834 ("crypto: add
function to free rsa keypair") from optee_os master.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
