### PR TITLE
[RFC] 32bit support for StMM secure partition

### DIFF
--- a/core/arch/arm/include/kernel/stmm_sp.h
+++ b/core/arch/arm/include/kernel/stmm_sp.h
@@ -36,16 +36,19 @@
  * address it uses these 2 syscalls to define the memory attributes for the
  * data and code segments after dispatching the binaries.
  *
- * FFA_SVC_MEMORY_ATTRIBUTES_SET_64:
+ * FFA_SVC_MEMORY_ATTRIBUTES_SET_64/FFA_SVC_MEMORY_ATTRIBUTES_SET_32:
  *  - x4: base address
  *  - x5: number of pages
  *  - x6: attributes of the remapping (described above)
  *
- * FFA_SVC_MEMORY_ATTRIBUTES_GET_64: currently only a single page is requested
- *  - x4: base address
+ * FFA_SVC_MEMORY_ATTRIBUTES_GET_32/FFA_SVC_MEMORY_ATTRIBUTES_GET_64:
+ *  - x4: base address, currently only a single page is requested.
  */
 #define FFA_SVC_MEMORY_ATTRIBUTES_GET_64	UINT32_C(0xC4000064)
 #define FFA_SVC_MEMORY_ATTRIBUTES_SET_64	UINT32_C(0xC4000065)
+
+#define FFA_SVC_MEMORY_ATTRIBUTES_GET_32	UINT32_C(0x84000064)
+#define FFA_SVC_MEMORY_ATTRIBUTES_SET_32	UINT32_C(0x84000065)
 
 /*
  * We need to define the RPMB IDs formally, since the plan is
@@ -53,17 +56,20 @@
  * This is fine for now as it represents the internal contract between the
  * EDK2 RPMB driver and Secure Partition
  *
- * FFA_SVC_RPMB_WRITE:
+ * FFA_SVC_RPMB_WRITE/FFA_SVC_RPMB_WRITE_32:
  *  - x4: virtual address of the buffer to write in the device
  *  - x5: buffer byte length
  *  - x6: byte offset in the device
- * FFA_SVC_RPMB_READ:
+ * FFA_SVC_RPMB_READ/FFA_SVC_RPMB_READ_32:
  *  - x4: virtual address of the buffer were RPMB contents are copied
  *  - x5: buffer byte length to read
  *  - x6: byte offset in the device
  */
 #define FFA_SVC_RPMB_READ		UINT32_C(0xC4000066)
 #define FFA_SVC_RPMB_WRITE		UINT32_C(0xC4000067)
+
+#define FFA_SVC_RPMB_READ_32		UINT32_C(0x84000066)
+#define FFA_SVC_RPMB_WRITE_32		UINT32_C(0x84000067)
 
 /* Param header types */
 #define STMM_PARAM_EP			UINT8_C(0x01)

--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -584,7 +584,9 @@ static bool return_helper(bool panic, uint32_t panic_code,
 	struct ts_session *sess = ts_get_current_session();
 	struct stmm_ctx *spc = to_stmm_ctx(sess->ctx);
 
-	if (!panic)
+	if (panic)
+		spc->ta_ctx.panicked = true;
+	else
 		save_sp_ctx(spc, svc_regs);
 
 	SVC_REGS_A0(svc_regs) = 0;

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -63,6 +63,15 @@ UNWIND(	.cantunwind)
 	bx	lr
 END_FUNC thread_set_fiq_sp
 
+FUNC thread_get_usr_sp , :
+	mrs	r1, cpsr
+	cpsid	aif
+	cps	#CPSR_MODE_SYS
+	mov	r0, sp
+	msr	cpsr, r1
+	bx	lr
+END_FUNC thread_get_usr_sp
+
 /* void thread_resume(struct thread_ctx_regs *regs) */
 FUNC thread_resume , :
 UNWIND(	.cantunwind)

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -178,6 +178,9 @@ void thread_set_irq_sp(vaddr_t sp);
 
 /* Sets sp for fiq mode */
 void thread_set_fiq_sp(vaddr_t sp);
+
+/* Read usr_sp banked CPU register */
+uint32_t thread_get_usr_sp(void);
 #endif /*ARM32*/
 
 /* Checks stack canaries */


### PR DESCRIPTION
StMM is used with UEFI features. These few commits propose a 32bit port.
StMM build process is somewhat complex and currently built image have a bad entry code (1st instructions). An embedded hack computes a fixed value before StMM is entered when it boots up. This issue should be addressed in edk2 build, not is optee.
This RFC assumes the StMM SP is compiled for Thumb2 instruction set.