### PR TITLE
core: print "TEE load address" message on abort

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -5,6 +5,7 @@
 
 #include <arm.h>
 #include <kernel/abort.h>
+#include <kernel/linker.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 #include <kernel/tee_ta_manager.h>
@@ -217,8 +218,12 @@ static void __abort_print(struct abort_info *ai, bool stack_dump)
 
 	__print_abort_info(ai, "Core");
 
-	if (stack_dump)
+	if (stack_dump) {
+		trace_printf_helper_raw(TRACE_ERROR, true,
+					"TEE load address @ %#"PRIxVA,
+					VCORE_START_VA);
 		__print_stack_unwind(ai);
+	}
 }
 
 void abort_print(struct abort_info *ai)


### PR DESCRIPTION
Commit 02d307b7db90 ("core: use libunw") has involuntarily removed the
"TEE load address @ ..." message when a TEE core abort occurs. This
information is essential to be able to resolve function addresses when
ASLR is enabled, and scripts/symbolize.py needs this line. Add it back.

Fixes: 02d307b7db90 ("core: use libunw")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
