### PR TITLE
core: use vaddr_t instead of uint32_t for uref

### DIFF
--- a/core/include/kernel/user_access.h
+++ b/core/include/kernel/user_access.h
@@ -33,11 +33,11 @@ static inline TEE_Result copy_from_user(void *kaddr __unused,
 TEE_Result copy_to_user_private(void *uaddr, const void *kaddr, size_t len);
 TEE_Result copy_to_user(void *uaddr, const void *kaddr, size_t len);
 
-TEE_Result copy_kaddr_to_uref(uint32_t *uref, void *kaddr);
+TEE_Result copy_kaddr_to_uref(vaddr_t *uref, void *kaddr);
 
-uint32_t kaddr_to_uref(void *kaddr);
-vaddr_t uref_to_vaddr(uint32_t uref);
-static inline void *uref_to_kaddr(uint32_t uref)
+vaddr_t kaddr_to_uref(void *kaddr);
+vaddr_t uref_to_vaddr(vaddr_t uref);
+static inline void *uref_to_kaddr(vaddr_t uref)
 {
 	return (void *)uref_to_vaddr(uref);
 }

--- a/core/kernel/user_access.c
+++ b/core/kernel/user_access.c
@@ -64,20 +64,20 @@ TEE_Result copy_to_user_private(void *uaddr, const void *kaddr, size_t len)
 	return res;
 }
 
-TEE_Result copy_kaddr_to_uref(uint32_t *uref, void *kaddr)
+TEE_Result copy_kaddr_to_uref(vaddr_t *uref, void *kaddr)
 {
-	uint32_t ref = kaddr_to_uref(kaddr);
+	vaddr_t ref = kaddr_to_uref(kaddr);
 
 	return copy_to_user_private(uref, &ref, sizeof(ref));
 }
 
-uint32_t kaddr_to_uref(void *kaddr)
+vaddr_t kaddr_to_uref(void *kaddr)
 {
 	assert(((vaddr_t)kaddr - VCORE_START_VA) < UINT32_MAX);
 	return (vaddr_t)kaddr - VCORE_START_VA;
 }
 
-vaddr_t uref_to_vaddr(uint32_t uref)
+vaddr_t uref_to_vaddr(vaddr_t uref)
 {
 	return VCORE_START_VA + uref;
 }


### PR DESCRIPTION
In 64-bit platform, the uref may be 64-bit long.
Change the data type of uref from uint32_t to vaddr_t to
prevent the data truncation.

Signed-off-by: JY Ho <JY.Ho@mediatek.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
