### PR TITLE
build: fix ld-option again

### DIFF
--- a/mk/cc-option.mk
+++ b/mk/cc-option.mk
@@ -7,7 +7,7 @@ $(if $($(_var_name)),$(1),$(2))
 endef
 cc-option = $(strip $(call _cc-option,$(1),$(2)))
 
-_ld-option-supported = $(if $(shell $(LD$(sm)) -v $(1) 2>&1 | grep warning || echo "Not supported"),,1)
+_ld-option-supported = $(if $(shell ($(LD$(sm)) -v $(1) 2>&1 || echo warning) | grep warning),,1)
 _ld-opt-cached-var-name = $(subst =,~,$(subst $(empty) $(empty),,$(strip cached-ld-option-$(1)-$(LD$(sm)))))
 define _ld-option
 $(eval _var_name := $(call _ld-opt-cached-var-name,$(1)))


### PR DESCRIPTION
Commit 5510db0b9458 ("build: ld-option: handle any linker warning as an
error") fixed an issue when used with the GNU linker, but while doing
so it broke the Clang use case. The problem is, the exit status tested
by `|| echo "Not supported"' is the one from grep, not the one from the
link command.

The fix provided here is tested with GCC (ld) and Clang (ld.lld).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
