### PR TITLE
core: make sure thread_get_core_local() is unpaged

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -332,6 +332,7 @@ struct thread_core_local * __nostackcheck thread_get_core_local(void)
 
 	return get_core_local(pos);
 }
+DECLARE_KEEP_PAGER(thread_get_core_local);
 
 #ifdef CFG_CORE_DEBUG_CHECK_STACKS
 static void print_stack_limits(void)


### PR DESCRIPTION
Fixes an issue found on QEMUv8 with Clang and CFG_WITH_PAGER=y,
where the platform would not boot because thread_get_core_local()
would point to undefined instructions (zeros).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
