### PR TITLE
core: Add support to import external TA signing public key

### DIFF
--- a/core/sub.mk
+++ b/core/sub.mk
@@ -8,9 +8,9 @@ subdirs-y += tee
 ifeq ($(CFG_WITH_USER_TA),y)
 gensrcs-y += ta_pub_key
 produce-ta_pub_key = ta_pub_key.c
-depends-ta_pub_key = $(TA_SIGN_KEY) scripts/pem_to_pub_c.py
+depends-ta_pub_key = $(TA_PUBLIC_KEY) scripts/pem_to_pub_c.py
 recipe-ta_pub_key = $(PYTHON3) scripts/pem_to_pub_c.py --prefix ta_pub_key \
-		--key $(TA_SIGN_KEY) --out $(sub-dir-out)/ta_pub_key.c
+		--key $(TA_PUBLIC_KEY) --out $(sub-dir-out)/ta_pub_key.c
 
 gensrcs-y += ldelf
 produce-ldelf = ldelf_hex.c

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -190,8 +190,12 @@ CFG_RPMB_FS_CACHE_ENTRIES ?= 0
 # - RPMB key provisioning in a controlled environment (factory setup)
 CFG_RPMB_WRITE_KEY ?= n
 
-# Embed public part of this key in OP-TEE OS
+# Signing key for OP-TEE TA's
+# When performing external HSM signing for TA's TA_SIGN_KEY can be set to dummy
+# key and then set TA_PUBLIC_KEY to match public key from the HSM.
+# TA_PUBLIC_KEY's public key will be embedded into OP-TEE OS.
 TA_SIGN_KEY ?= keys/default_ta.pem
+TA_PUBLIC_KEY ?= $(TA_SIGN_KEY)
 
 # Include lib/libutils/isoc in the build? Most platforms need this, but some
 # may not because they obtain the isoc functions from elsewhere


### PR DESCRIPTION
Build process requires that private key is present when signing TAs.

In order to support external HSM based re-signing of the TAs, add support
to import different TA signing public key into TEE OS binary by
introducing TA_PUBLIC_KEY.

By default TA_PUBLIC_KEY gets the value of TA_SIGN_KEY.

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>