### PR TITLE
pkcs11: Add TEE Identity based authentication support

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -578,6 +578,9 @@ CFG_CRYPTOLIB_DIR ?= core/lib/libtomcrypt
 # that would set = n.
 $(call force,CFG_CORE_MBEDTLS_MPI,y)
 
+# Enable PKCS#11 TA's TEE Identity based authentication support
+CFG_PKCS11_TA_AUTH_TEE_IDENTITY ?= y
+
 # Enable virtualization support. OP-TEE will not work without compatible
 # hypervisor if this option is enabled.
 CFG_VIRTUALIZATION ?= n

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -599,6 +599,47 @@ enum pkcs11_user_type {
 };
 
 /*
+ * TEE Identity based authentication for tokens
+ *
+ * When configuration CFG_PKCS11_TA_AUTH_TEE_IDENTITY is enabled TEE Identity
+ * based authentication scheme is enabled.
+ *
+ * Feature enablement per token basis is controlled by token flag:
+ * pkcs11_token_info->flags & PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH
+ *
+ * When calling C_InitToken() mode is determined based on SO PIN value.
+ * - If the PIN is empty (or NULL_PTR) then active client TEE Identity will be
+ *   used as SO TEE Identity
+ * - If the PIN is given then normal PIN behavior is used
+ *
+ * Once TEE Identity based authentication is activated following operational
+ * changes happen:
+ * - PIN failure counters are disabled to prevent token authentication lockups
+ * - Switching to different authentication mode needs C_InitToken()
+ * - When C_Login() or so is performed actual PIN value is ignored and active
+ *   client TEE Identity will be used
+ *
+ * Different types of TEE Identity authentication methods can be configured:
+ * - Configured with C_InitToken(), C_InitPIN() or by C_SetPIN()
+ * - PIN value follows below PIN syntax
+ *
+ * TEE Identity based authenticate PIN syntax:
+ * - PIN value: NULL_PTR or empty
+ *   - Use active client TEE Identity
+ * - PIN value: public
+ *   - TEE public login
+ * - PIN value: user:<client UUID string>
+ *   - TEE user login with client UUID matching user credentials
+ * - PIN value: group:<client UUID string>
+ *   - TEE group login with client UUID matching group credentials
+ */
+
+/* Keywords for protected authenticated path PIN parser */
+#define PKCS11_AUTH_TEE_IDENTITY_PUBLIC	"public"
+#define PKCS11_AUTH_TEE_IDENTITY_USER	"user:"
+#define PKCS11_AUTH_TEE_IDENTITY_GROUP	"group:"
+
+/*
  * Values for 32bit session flags argument to PKCS11_CMD_OPEN_SESSION
  * and pkcs11_session_info::flags.
  * PKCS11_CKFSS_<x> reflects CryptoKi client API session flags CKF_<x>.

--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -128,6 +128,160 @@ enum pkcs11_rc verify_pin(enum pkcs11_user_type user, const uint8_t *pin,
 	return rc;
 }
 
+#if defined(CFG_PKCS11_TA_AUTH_TEE_IDENTITY)
+enum pkcs11_rc setup_so_identity_auth_from_client(struct ck_token *token)
+{
+	TEE_Identity identity = { };
+	TEE_Result res = TEE_SUCCESS;
+
+	res = TEE_GetPropertyAsIdentity(TEE_PROPSET_CURRENT_CLIENT,
+					"gpd.client.identity", &identity);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_GetPropertyAsIdentity: returned %#"PRIx32, res);
+		return PKCS11_CKR_PIN_INVALID;
+	}
+
+	TEE_MemMove(&token->db_main->so_identity, &identity, sizeof(identity));
+	token->db_main->flags |= PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH;
+
+	token->db_main->so_pin_salt = 0;
+
+	return PKCS11_CKR_OK;
+}
+
+enum pkcs11_rc setup_identity_auth_from_pin(struct ck_token *token,
+					    enum pkcs11_user_type user_type,
+					    const uint8_t *pin,
+					    size_t pin_size)
+{
+	TEE_Identity identity = { };
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t flags_clear = 0;
+	uint32_t flags_set = 0;
+	char *acl_string = NULL;
+	char *uuid_str = NULL;
+
+	assert(token->db_main->flags &
+	       PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH);
+
+	if (!pin) {
+		/* Use client identity */
+		res = TEE_GetPropertyAsIdentity(TEE_PROPSET_CURRENT_CLIENT,
+						"gpd.client.identity",
+						&identity);
+		if (res != TEE_SUCCESS) {
+			EMSG("TEE_GetPropertyAsIdentity: returned %#"PRIx32,
+			     res);
+			return PKCS11_CKR_PIN_INVALID;
+		}
+	} else {
+		/* Parse PIN ACL string: <login type>:<client id> */
+		acl_string = TEE_Malloc(pin_size + 1, TEE_MALLOC_FILL_ZERO);
+		if (!acl_string)
+			return PKCS11_CKR_DEVICE_MEMORY;
+		TEE_MemMove(acl_string, pin, pin_size);
+
+		uuid_str = strstr(acl_string, ":");
+		if (uuid_str)
+			uuid_str++;
+		if (strcmp(PKCS11_AUTH_TEE_IDENTITY_PUBLIC, acl_string) == 0) {
+			identity.login = TEE_LOGIN_PUBLIC;
+		} else if (strstr(acl_string, PKCS11_AUTH_TEE_IDENTITY_USER) ==
+			   acl_string) {
+			identity.login = TEE_LOGIN_USER;
+		} else if (strstr(acl_string, PKCS11_AUTH_TEE_IDENTITY_GROUP) ==
+			   acl_string) {
+			identity.login = TEE_LOGIN_GROUP;
+		} else {
+			EMSG("Invalid PIN ACL string - login");
+			TEE_Free(acl_string);
+			return PKCS11_CKR_PIN_INVALID;
+		}
+
+		if (identity.login != TEE_LOGIN_PUBLIC) {
+			if (!uuid_str) {
+				EMSG("Invalid PIN ACL string - colon");
+				TEE_Free(acl_string);
+				return PKCS11_CKR_PIN_INVALID;
+			}
+
+			res = tee_uuid_from_str(&identity.uuid, uuid_str);
+			if (res) {
+				EMSG("Invalid PIN ACL string - client id");
+				TEE_Free(acl_string);
+				return PKCS11_CKR_PIN_INVALID;
+			}
+		}
+
+		TEE_Free(acl_string);
+	}
+
+	switch (user_type) {
+	case PKCS11_CKU_SO:
+		token->db_main->so_pin_count = 0;
+		token->db_main->so_pin_salt = 0;
+		flags_clear = PKCS11_CKFT_SO_PIN_COUNT_LOW |
+			      PKCS11_CKFT_SO_PIN_FINAL_TRY |
+			      PKCS11_CKFT_SO_PIN_LOCKED |
+			      PKCS11_CKFT_SO_PIN_TO_BE_CHANGED;
+
+		TEE_MemMove(&token->db_main->so_identity, &identity,
+			    sizeof(identity));
+		break;
+	case PKCS11_CKU_USER:
+		token->db_main->user_pin_count = 0;
+		token->db_main->user_pin_salt = 0;
+		flags_clear = PKCS11_CKFT_USER_PIN_COUNT_LOW |
+			      PKCS11_CKFT_USER_PIN_FINAL_TRY |
+			      PKCS11_CKFT_USER_PIN_LOCKED |
+			      PKCS11_CKFT_USER_PIN_TO_BE_CHANGED;
+		flags_set = PKCS11_CKFT_USER_PIN_INITIALIZED;
+
+		TEE_MemMove(&token->db_main->user_identity, &identity,
+			    sizeof(identity));
+		break;
+	default:
+		return PKCS11_CKR_FUNCTION_FAILED;
+	}
+
+	token->db_main->flags &= ~flags_clear;
+	token->db_main->flags |= flags_set;
+
+	return PKCS11_CKR_OK;
+}
+
+enum pkcs11_rc verify_identity_auth(struct ck_token *token,
+				    enum pkcs11_user_type user_type)
+{
+	TEE_Identity identity = { };
+	TEE_Result res = TEE_SUCCESS;
+
+	assert(token->db_main->flags &
+	       PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH);
+
+	res = TEE_GetPropertyAsIdentity(TEE_PROPSET_CURRENT_CLIENT,
+					"gpd.client.identity", &identity);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_GetPropertyAsIdentity: returned %#"PRIx32, res);
+		return PKCS11_CKR_PIN_INVALID;
+	}
+
+	if (user_type == PKCS11_CKU_SO) {
+		if (TEE_MemCompare(&token->db_main->so_identity, &identity,
+				   sizeof(identity)))
+			return PKCS11_CKR_PIN_INCORRECT;
+	} else if (user_type == PKCS11_CKU_USER) {
+		if (TEE_MemCompare(&token->db_main->user_identity, &identity,
+				   sizeof(identity)))
+			return PKCS11_CKR_PIN_INCORRECT;
+	} else {
+		return PKCS11_CKR_PIN_INCORRECT;
+	}
+
+	return PKCS11_CKR_OK;
+}
+#endif /* CFG_PKCS11_TA_AUTH_TEE_IDENTITY */
+
 /*
  * Release resources relate to persistent database
  */

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -855,8 +855,6 @@ enum pkcs11_rc entry_ck_token_initialize(uint32_t ptypes, TEE_Param *params)
 		if (rc)
 			return rc;
 
-		update_persistent_db(token);
-
 		goto inited;
 	}
 
@@ -883,11 +881,14 @@ enum pkcs11_rc entry_ck_token_initialize(uint32_t ptypes, TEE_Param *params)
 		return PKCS11_CKR_PIN_INCORRECT;
 	}
 
+inited:
+	/* Make sure SO PIN counters are zeroed */
 	token->db_main->flags &= ~(PKCS11_CKFT_SO_PIN_COUNT_LOW |
-				   PKCS11_CKFT_SO_PIN_FINAL_TRY);
+				   PKCS11_CKFT_SO_PIN_FINAL_TRY |
+				   PKCS11_CKFT_SO_PIN_LOCKED |
+				   PKCS11_CKFT_SO_PIN_TO_BE_CHANGED);
 	token->db_main->so_pin_count = 0;
 
-inited:
 	TEE_MemMove(token->db_main->label, label, PKCS11_TOKEN_LABEL_SIZE);
 	token->db_main->flags |= PKCS11_CKFT_TOKEN_INITIALIZED;
 	/* Reset user PIN */

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -910,11 +910,12 @@ static enum pkcs11_rc set_pin(struct pkcs11_session *session,
 			      uint8_t *new_pin, size_t new_pin_size,
 			      enum pkcs11_user_type user_type)
 {
+	struct ck_token *token = session->token;
 	enum pkcs11_rc rc = PKCS11_CKR_OK;
 	uint32_t flags_clear = 0;
 	uint32_t flags_set = 0;
 
-	if (session->token->db_main->flags & PKCS11_CKFT_WRITE_PROTECTED)
+	if (token->db_main->flags & PKCS11_CKFT_WRITE_PROTECTED)
 		return PKCS11_CKR_TOKEN_WRITE_PROTECTED;
 
 	if (!pkcs11_session_is_read_write(session))
@@ -927,11 +928,11 @@ static enum pkcs11_rc set_pin(struct pkcs11_session *session,
 	switch (user_type) {
 	case PKCS11_CKU_SO:
 		rc = hash_pin(user_type, new_pin, new_pin_size,
-			      &session->token->db_main->so_pin_salt,
-			      session->token->db_main->so_pin_hash);
+			      &token->db_main->so_pin_salt,
+			      token->db_main->so_pin_hash);
 		if (rc)
 			return rc;
-		session->token->db_main->so_pin_count = 0;
+		token->db_main->so_pin_count = 0;
 		flags_clear = PKCS11_CKFT_SO_PIN_COUNT_LOW |
 			      PKCS11_CKFT_SO_PIN_FINAL_TRY |
 			      PKCS11_CKFT_SO_PIN_LOCKED |
@@ -939,11 +940,11 @@ static enum pkcs11_rc set_pin(struct pkcs11_session *session,
 		break;
 	case PKCS11_CKU_USER:
 		rc = hash_pin(user_type, new_pin, new_pin_size,
-			      &session->token->db_main->user_pin_salt,
-			      session->token->db_main->user_pin_hash);
+			      &token->db_main->user_pin_salt,
+			      token->db_main->user_pin_hash);
 		if (rc)
 			return rc;
-		session->token->db_main->user_pin_count = 0;
+		token->db_main->user_pin_count = 0;
 		flags_clear = PKCS11_CKFT_USER_PIN_COUNT_LOW |
 			      PKCS11_CKFT_USER_PIN_FINAL_TRY |
 			      PKCS11_CKFT_USER_PIN_LOCKED |
@@ -954,10 +955,10 @@ static enum pkcs11_rc set_pin(struct pkcs11_session *session,
 		return PKCS11_CKR_FUNCTION_FAILED;
 	}
 
-	session->token->db_main->flags &= ~flags_clear;
-	session->token->db_main->flags |= flags_set;
+	token->db_main->flags &= ~flags_clear;
+	token->db_main->flags |= flags_set;
 
-	update_persistent_db(session->token);
+	update_persistent_db(token);
 
 	return PKCS11_CKR_OK;
 }

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -63,10 +63,16 @@ struct token_persistent_main {
 	uint32_t flags;
 	uint32_t so_pin_count;
 	uint32_t so_pin_salt;
-	uint8_t so_pin_hash[TEE_MAX_HASH_SIZE];
+	union {
+		uint8_t so_pin_hash[TEE_MAX_HASH_SIZE];
+		TEE_Identity so_identity;
+	};
 	uint32_t user_pin_count;
 	uint32_t user_pin_salt;
-	uint8_t user_pin_hash[TEE_MAX_HASH_SIZE];
+	union {
+		uint8_t user_pin_hash[TEE_MAX_HASH_SIZE];
+		TEE_Identity user_identity;
+	};
 };
 
 /*
@@ -186,6 +192,38 @@ enum pkcs11_rc hash_pin(enum pkcs11_user_type user, const uint8_t *pin,
 enum pkcs11_rc verify_pin(enum pkcs11_user_type user, const uint8_t *pin,
 			  size_t pin_size, uint32_t salt,
 			  const uint8_t hash[TEE_MAX_HASH_SIZE]);
+
+#if defined(CFG_PKCS11_TA_AUTH_TEE_IDENTITY)
+enum pkcs11_rc setup_so_identity_auth_from_client(struct ck_token *token);
+enum pkcs11_rc setup_identity_auth_from_pin(struct ck_token *token,
+					    enum pkcs11_user_type user_type,
+					    const uint8_t *pin,
+					    size_t pin_size);
+enum pkcs11_rc verify_identity_auth(struct ck_token *token,
+				    enum pkcs11_user_type user_type);
+#else
+static inline enum pkcs11_rc
+setup_so_identity_auth_from_client(struct ck_token *token __unused)
+{
+	return PKCS11_CKR_PIN_INVALID;
+}
+
+static inline enum pkcs11_rc
+setup_identity_auth_from_pin(struct ck_token *token __unused,
+			     enum pkcs11_user_type user_type __unused,
+			     const uint8_t *pin __unused,
+			     size_t pin_size __unused)
+{
+	return PKCS11_CKR_PIN_INVALID;
+}
+
+static inline enum pkcs11_rc
+verify_identity_auth(struct ck_token *token __unused,
+		     enum pkcs11_user_type user_type __unused)
+{
+	return PKCS11_CKR_PIN_INCORRECT;
+}
+#endif /* CFG_PKCS11_TA_AUTH_TEE_IDENTITY */
 
 /* Token persistent objects */
 enum pkcs11_rc create_object_uuid(struct ck_token *token,


### PR DESCRIPTION
In C_InitToken() if PIN is NULL_PTR then it will activate TEE Identity
based authentication support for token.

Once activated:
- When ever PIN is required client's TEE Identity will be used for authentication
- PIN failure counters are disabled
- If new PIN is given as input it is in form of PIN ACL string
- It can be disabled with C_InitToken with non-zero PIN

Internally protected authentication path will be used for mode determination.

Implements:
https://github.com/OP-TEE/optee_os/issues/3946

Testing this without having other PKCS11 features like RSA, EC, objects lists and so needs a bit imagination how it would eventually work but I add comments what happens in the test sequence.

Actual functionality has also been verified with "full blown" features in real hardware with NXP CPU. 

Testing in here happened in our custom Yocto build with Xilinx ZynqMPSoC ZCU102 QEMU image.

Testing with normal PIN usage with slot 2:
```
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 2 --init-token --label softtoken1 --so-pin 1234123412341234
Using slot with index 2 (0x2)
Token successfully initialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : softtoken1
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000002
  pin min/max        : 10/128
# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 2 --init-pin --login --so-pin 1234123412341234 --new-pin 1234567890
Using slot with index 2 (0x2)
User PIN successfully initialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : softtoken1
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, PIN initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000002
  pin min/max        : 10/128
```

Please note that now the token flags also behave more logically than before too.

Now initializing token 1 with SO being root user and USER being group membership for 1000.

```
# export CKTEEC_LOGIN_TYPE=user
# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 1 --init-token --label acltoken --so-pin ""
Using slot with index 1 (0x1)
Token successfully initialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : acltoken
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, PIN pad present, rng, token initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000001
  pin min/max        : 10/128
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : softtoken1
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, PIN initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000002
  pin min/max        : 10/128
# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 1 --init-pin --login --so-pin foobar --new-pin group:0ece43ed-001d-51bd-bab7-480c8954c3cf
Using slot with index 1 (0x1)
User PIN successfully initialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : acltoken
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, PIN pad present, rng, token initialized, PIN initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000001
  pin min/max        : 10/128
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : softtoken1
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, PIN initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000002
  pin min/max        : 10/128
```

What to notice from output is that now in token flags there is "PIN pad present" which means that protected authentication path is activated.

Second thing to notice is `CKTEEC_LOGIN_TYPE=user` which was set before token 1 initialization. This told libckteec to use TEE_LOGIN_USER when logging in. As PIN was empty string it told PKCS11 TA to enter into protected authentication path mode AND record current login credentials (gpd.client.identity) for SO.

Third thing to notice is that "foobar" was given as a pin and that was ignored as token is now in TEE Identity authentication mode and actual SO PIN entry is ignored and only OPTEE TEE Client's identity is being used to validate access.

Fourth thing to notice is that user pin is has now a special format that gets activated only when in protected authentication path mode (`group:0ece43ed-001d-51bd-bab7-480c8954c3cf`).

Above means here that "group" is connected to TEE Login type TEE_LOGIN_GROUP and presented UUID is TEE client ID that is populated by Linux kernel.

In here the client ID is calculated with uuidgen tool. (Note: Ubuntu bionic has broken uuidgen tool for namespace operations -- where as focal has already fixed uuidgen).

Client ID calculation MUST match what kernel is generating. An example:
```
# gid=1000 == 0x3e8
$ uuidgen --sha1 --namespace 58ac9ca0-2086-4683-a1b8-ec4bc08e01b6 --name "gid=3e8" 
0ece43ed-001d-51bd-bab7-480c8954c3cf
```

One thing to be aware -- PIN counters are now disabled to make sure that token does not get locked while the device is out there (as that is not practically recoverable) and if access would be wrong then it would be more or less instantly locked as there is not human participant in here.

Now let's switch to user which is member of group 1000.

Testing that ACL works.

```
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : acltoken
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, PIN pad present, rng, token initialized, PIN initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000001
  pin min/max        : 10/128
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : softtoken1
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, PIN initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000002
  pin min/max        : 10/128
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot 2 --login -O
Logging in to "softtoken1".
Please enter User PIN: 
error: PKCS11 function C_Login failed: rv = CKR_PIN_INCORRECT (0xa0)
Aborting.
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot 2 --login -O
Logging in to "softtoken1".
Please enter User PIN: 
error: PKCS11 function C_FindObjectsInit failed: rv = CKR_FUNCTION_NOT_SUPPORTED (0x54)
Aborting.
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot 1 --login -O
error: PKCS11 function C_Login failed: rv = CKR_PIN_INCORRECT (0xa0)
Aborting.
$ export CKTEEC_LOGIN_TYPE=group
$ export CKTEEC_LOGIN_GID=1000
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot 1 --login -O
error: PKCS11 function C_FindObjectsInit failed: rv = CKR_FUNCTION_NOT_SUPPORTED (0x54)
Aborting.
```

First thing that is verified above is that token 2 still accepts PIN.

In first try invalid PIN is given where as in second try valid PIN is given and system just responds back that listing objects is not supported.

Second thing to notice is that when testing token 1 access we first get incorrect PIN error as we tried to login as "TEE_LOGIN_PUBLIC" (being default).

Then CKTEEC_LOGIN_TYPE is configured to "group" to make TEE login to be "group" and CKTEEC_LOGIN_GID specified group identifier to be passed to kernel so that it verifies membership and can then form the client ID.

Now that login is correct it responds back that listing objects is not supported like it was with normal PIN mode.

---

When compiled with CFG_PKCS11_TA_AUTH_TEE_IDENTITY=n and performing initialization steps:
```
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 2 --init-token --label softtoken1 --so-pin 1234123412341234
Using slot with index 2 (0x2)
Token successfully initialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : softtoken1
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000002
  pin min/max        : 10/128
# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 2 --init-pin --login --so-pin 1234123412341234 --new-pin 1234567890
Using slot with index 2 (0x2)
User PIN successfully initialized
# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : softtoken1
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, PIN initialized, other flags=0x200
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000002
  pin min/max        : 10/128
# export CKTEEC_LOGIN_TYPE=user
# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 1 --init-token --label acltoken --so-pin ""
Using slot with index 1 (0x1)
error: PKCS11 function C_InitToken failed: rv = CKR_ARGUMENTS_BAD (0x7)
Aborting.
```

From above output one can see that normal PIN usage is working and then trying to do ACL token fails because SO PIN is invalid (empty and too short).
