### PR TITLE
CAAM HW PRNG Seed with CFG_CRYPTO_DRIVER=n

### DIFF
--- a/core/drivers/crypto/caam/include/caam_desc_defines.h
+++ b/core/drivers/crypto/caam/include/caam_desc_defines.h
@@ -404,6 +404,8 @@
  */
 /* Secure Key */
 #define ALGO_RNG_SK		BIT32(12)
+/* Prediction Resistance */
+#define ALGO_RNG_PR		BIT32(1)
 
 /* State Handle */
 #define ALGO_RNG_SH(sh)		SHIFT_U32((sh) & 0x3, 4)

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -221,7 +221,7 @@ static inline void dump_desc(uint32_t *desc)
  */
 #define RNG_SH_INST(sh)                                                        \
 	(CMD_OP_TYPE | OP_TYPE(CLASS1) | OP_ALGO(RNG) | ALGO_RNG_SH(sh) |      \
-	 ALGO_AS(RNG_INSTANTIATE))
+	 ALGO_AS(RNG_INSTANTIATE) | ALGO_RNG_PR)
 
 /*
  * RNG Generates Secure Keys
@@ -234,7 +234,8 @@ static inline void dump_desc(uint32_t *desc)
  * RNG Generates Data
  */
 #define RNG_GEN_DATA                                                           \
-	(CMD_OP_TYPE | OP_TYPE(CLASS1) | OP_ALGO(RNG) | ALGO_AS(RNG_GENERATE))
+	(CMD_OP_TYPE | OP_TYPE(CLASS1) | OP_ALGO(RNG) | ALGO_AS(RNG_GENERATE) |\
+	ALGO_RNG_PR)
 
 /*
  * Hash Init Operation of algorithm algo


### PR DESCRIPTION
Implement `plat_rng_init()` in case the runtime crypto driver support is disabled. This lets OP-TEE retrieve a hardware generated RNG seed for the software PRNG.

TODO:
- [ ] Test with `CFG_CYRPTO_DRIVER=y` (for the PR enable commits)

I'll setup the tests over this week and will report back till friday. Same goes for the still pending watchdog PR.