### PR TITLE
core: imx: remove security check for i.MX6SDL

### DIFF
--- a/core/arch/arm/plat-imx/drivers/imx_snvs.c
+++ b/core/arch/arm/plat-imx/drivers/imx_snvs.c
@@ -3,16 +3,27 @@
  * Copyright 2020 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
  */
 #include <drivers/imx_snvs.h>
+#include <imx.h>
 #include <tee/tee_fs.h>
 
 bool plat_rpmb_key_is_ready(void)
 {
 	enum snvs_ssm_mode mode = SNVS_SSM_MODE_INIT;
 	enum snvs_security_cfg security = SNVS_SECURITY_CFG_OPEN;
+	bool ssm_secure = false;
 
 	mode = snvs_get_ssm_mode();
 	security = snvs_get_security_cfg();
-	return (mode == SNVS_SSM_MODE_TRUSTED ||
-		mode == SNVS_SSM_MODE_SECURE) &&
-		(security == SNVS_SECURITY_CFG_CLOSED);
+	ssm_secure = (mode == SNVS_SSM_MODE_TRUSTED ||
+		      mode == SNVS_SSM_MODE_SECURE);
+
+	/*
+	 * On i.MX6SDL, the security cfg always returns
+	 * SNVS_SECURITY_CFG_FAB (000), therefore we ignore the security
+	 * configuration for this SoC.
+	 */
+	if (soc_is_imx6sdl())
+		return ssm_secure;
+
+	return ssm_secure && (security == SNVS_SECURITY_CFG_CLOSED);
 }


### PR DESCRIPTION
The i.MX6SDL/SLL SoCs do not expose the security configuration in the
HPSR registers, however the SSM state machine information is still
exposed. Remove the check for the security configuration, since the bits
all read zero on these SoCs, even if they are securely booted.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

I hope I got all the SoCs now, I looked at the reference manual and removed SDL ~and SLL~ since for those, bits 12-14 are marked as reserved.

CC @clementfaure 