### PR TITLE
core: keep.h: set SHF_ALLOC flag in all __keep_meta_vars_pager sections

### DIFF
--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -8,7 +8,7 @@
 #ifdef __ASSEMBLER__
 
 	.macro DECLARE_KEEP_PAGER sym
-	.pushsection __keep_meta_vars_pager
+	.pushsection __keep_meta_vars_pager, "a"
 	.global ____keep_pager_\sym
 	____keep_pager_\sym:
 	.long	\sym
@@ -16,7 +16,7 @@
 	.endm
 
 	.macro DECLARE_KEEP_INIT sym
-	.pushsection __keep_meta_vars_init
+	.pushsection __keep_meta_vars_init, "a"
 	.global ____keep_init_\sym
 	____keep_init_\sym:
 	.long	\sym


### PR DESCRIPTION
The DECLARE_KEEP_PAGER() and DECLARE_KEEP_INIT() macros create symbols
in a special section called __keep_meta_vars_pager. The behavior
differs slightly in C and assembler:

- In C, the section is of type SHT_PROGBITS and has (SHF_ALLOC |
  SHF_WRITE) flags,
- In assembler, the section is also SHT_PROGBITS but has no flags.

Enter the Clang linker, ld.lld. When used with --gc-sections, all
sections without the SHF_ALLOC flag (and a few other conditions) are
marked "live" in a first pass before dependencies on other sections
are considered. A side effect is that the reference to the symbol given
in DECLARE_KEEP_*() is ignored and the macro does not pull the desired
section in the link. That section is garbage collected instead.

Whether or not it is a bug in the linker is slightly above my level of
expertise. However, the DECLARE_KEEP_*() macros declare global symbols
that reference other symbols, so it really is allocatable stuff and
having the SHF_ALLOC flag does make sense. It is also consistent with
the C version. Note that adding the flag does not take more space in the
final executable since core/arch/arm/kernel/kern.ld.S discards the
__keep_meta_vars_pager output section anyways.

Therefore, add "a" to the .section command in DECLARE_KEEP_*().

Fixes a core crash which may be reproduced on QEMUv8 with xtest 1013
when OP-TEE is compiled with Clang 11 and CFG_WITH_PAGER=y.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
