### PR TITLE
ldelf: Add CFG_TA_PIE to help building TAs for non-PIE capable targets

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -116,6 +116,10 @@ ifeq ($(CFG_ARM32_core),y)
 # CFG_DT_ADDR:       if defined, forces Device Tree data physical address.
 endif
 
+# ARM user-space must be relocatable. Forces compiling TA as
+# position-independent executable such it is relocated while loaded.
+$(call force,CFG_TA_PIE,y)
+
 core-platform-cppflags	+= -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel crypto mm tee) $(platform-dir)

--- a/ldelf/ldelf.mk
+++ b/ldelf/ldelf.mk
@@ -7,7 +7,10 @@ sm-$(sm) := y
 link-out-dir$(sm) := $(out-dir)/$(sm)
 
 cppflags$(sm)	:= $(core-platform-cppflags)
-cflags$(sm)	:= $(core-platform-cflags) -fpie -fvisibility=hidden
+cflags$(sm)	:= $(core-platform-cflags) -fvisibility=hidden
+ifeq ($(CFG_TA_PIE),y)
+cflags$(sm) += -fpie
+endif
 aflags$(sm)	:= $(core-platform-aflags)
 
 # ldelf is compiled for the same arch or register width as core

--- a/ldelf/link.mk
+++ b/ldelf/link.mk
@@ -12,7 +12,10 @@ cleanfiles += $(link-out-dir$(sm))/ldelf.map
 cleanfiles += $(link-out-dir$(sm))/ldelf.elf
 cleanfiles += $(link-script-pp$(sm)) $(link-script-dep$(sm))
 
-link-ldflags  = -pie -static --gc-sections
+link-ldflags  = -static --gc-sections
+ifeq ($(CFG_TA_PIE),y)
+link-ldflags += -pie
+endif
 link-ldflags += -T $(link-script-pp$(sm))
 link-ldflags += -Map=$(link-out-dir$(sm))/ldelf.map
 link-ldflags += --sort-section=alignment

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -251,11 +251,20 @@ CFG_WITH_USER_TA ?= y
 # By default, in-tree TAs are built using the first architecture specified in
 # $(ta-targets).
 
+# When enabled Trusted Applications are compiled as position-independent
+# executables
+CFG_TA_PIE ?= y
+
 # Address Space Layout Randomization for user-mode Trusted Applications
 #
 # When this flag is enabled, the ELF loader will introduce a random offset
 # when mapping the application in user space. ASLR makes the exploitation of
 # memory corruption vulnerabilities more difficult.
+# The flag can be enabled only if CFG_TA_PIE is enabled.
+ifneq ($(CFG_TA_PIE),y)
+$(call force,CFG_TA_ASLR,n)
+endif
+
 CFG_TA_ASLR ?= y
 
 # How much ASLR may shift the base address (in pages). The base address is


### PR DESCRIPTION
This introduces CFG_TA_PIE flag to compile Trusted Applications
as position-independent executables or not.
The idea, is to be able to build OP-TEE for targets which are not ASLR
capable.
If enabled, it adds -fpie flag to compile TA code and link using -pie
option. Enabling CFG_TA_ASLR depends on CFG_TA_PIE being enabled.
On arm target, user-space must be relocatable, hence, CFG_TA_PIE is enabled
unconditionally.

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>