### PR TITLE
spi: pl022_spi.c: fifo flush internal API made available to caller.

### DIFF
--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -353,10 +353,10 @@ done:
 		*cpsdvr, *cpsdvr, *scr, *scr);
 }
 
-static void pl022_flush_fifo(struct pl022_data *pd)
+static void pl022_flush_fifo(struct spi_chip *chip)
 {
 	uint32_t __maybe_unused rdat;
-
+	struct pl022_data *pd = container_of(chip, struct pl022_data, chip);
 	do {
 		while (io_read32(pd->base + SSPSR) & SSPSR_RNE) {
 			rdat = io_read32(pd->base + SSPDR);
@@ -469,7 +469,7 @@ static void pl022_configure(struct spi_chip *chip)
 		SSPICR_RORIC | SSPICR_RTIC);
 
 	DMSG("Empty FIFO before starting");
-	pl022_flush_fifo(pd);
+	pl022_flush_fifo(chip);
 }
 
 static void pl022_start(struct spi_chip *chip)
@@ -498,6 +498,7 @@ static const struct spi_ops pl022_ops = {
 	.txrx8 = pl022_txrx8,
 	.txrx16 = pl022_txrx16,
 	.end = pl022_end,
+	.flushfifo = pl022_flush_fifo,
 };
 DECLARE_KEEP_PAGER(pl022_ops);
 

--- a/core/include/spi.h
+++ b/core/include/spi.h
@@ -34,6 +34,7 @@ struct spi_ops {
 	enum spi_result (*txrx16)(struct spi_chip *chip, uint16_t *wdat,
 		uint16_t *rdat, size_t num_pkts);
 	void (*end)(struct spi_chip *chip);
+	void (*flushfifo)(struct spi_chip *chip);
 };
 
 #endif	/* __SPI_H__ */


### PR DESCRIPTION
We identified that the caller of the pl022 driver needs to flush the pl022's internal fifo to make sure next transaction starts clean.
This PR makes existing pl022_flushfifo function available to caller via spi_ops.

The validation is performed on bcm platform.

Signed-off-by: Vahid Dukandar <vahidd@microsoft.com>
