### PR TITLE
core: rpmb: return TEE_ERROR_STORAGE_NO_SPACE if no space left

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2339,8 +2339,13 @@ static TEE_Result rpmb_fs_write_primitive(struct rpmb_file_handle *fh,
 		DMSG("Need to re-allocate");
 		newsize = MAX(end, fh->fat_entry.data_size);
 		mm = tee_mm_alloc(&p, newsize);
+		if (!mm) {
+			DMSG("RPMB: No space left");
+			res = TEE_ERROR_STORAGE_NO_SPACE;
+			goto out;
+		}
 		newbuf = calloc(1, newsize);
-		if (!mm || !newbuf) {
+		if (!newbuf) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;
 		}


### PR DESCRIPTION
So far the error TEE_ERROR_OUT_OF_MEMORY was returned if no
free memory could be allocated in the RPMB to store new data.
According to TEE Internal Core API Specification the error
TEE_ERROR_STORAGE_NO_SPACE shall be returned if insufficient
space is available to create the persistent object.

Signed-off-by: Stefan Schmidt <snst@meek.de>

