### PR TITLE
core: simple framework to execute deferred works

### DIFF
--- a/core/include/kernel/deferred_work.h
+++ b/core/include/kernel/deferred_work.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020, Open Mobile Platform LLC
+ */
+
+#ifndef __KERNEL_DEFERRED_WORK_H
+#define __KERNEL_DEFERRED_WORK_H
+
+#include <tee_api_types.h>
+
+#if defined(CFG_DEFERRED_WORK)
+/**
+ * deferred_work_add() - put a new job in the queue of pending jobs.
+ *
+ * @name: string with a name of a new job.
+ *        The string length is maximum 32 bytes, including '\0'.
+ * @work: pointer to a function which will be executed, when
+ *        the tee-supplicant will start.
+ *        The work has to return 'TEE_SUCCESS', on success case.
+ * @data: pointer to data for @work function.
+ *
+ * Returns 'TEE_SUCCESS' on success. It means the work was added to
+ * the queue successfully.
+ */
+TEE_Result deferred_work_add(const char *name, TEE_Result (*work)(void *data),
+			     void *data);
+
+/**
+ * deferred_work_do_all() - execute all pending works in the queue.
+ *
+ * This function will be called in dw PTA (see 'core/pta/dw.c')
+ * by the tee-supplicant, when it will be run.
+ *
+ * Returns 'TEE_SUCCESS' after execution of all pending works.
+ */
+TEE_Result deferred_work_do_all(void);
+
+#else
+static inline TEE_Result deferred_work_add(const char *name __unused,
+					   TEE_Result (*work)(void *data)
+						   __unused,
+					   void *data __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result deferred_work_do_all(void)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif /* CFG_DEFERRED_WORK */
+
+#endif /* __KERNEL_DEFERRED_WORK_H */

--- a/core/kernel/deferred_work.c
+++ b/core/kernel/deferred_work.c
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020, Open Mobile Platform LLC
+ */
+
+#include <kernel/deferred_work.h>
+#include <kernel/spinlock.h>
+#include <sys/queue.h>
+#include <string.h>
+#include <stdint.h>
+#include <trace.h>
+#include <util.h>
+
+#define DW_NAME_MAX 32
+
+struct deferred_work {
+	TAILQ_ENTRY(deferred_work) link;
+	char name[DW_NAME_MAX];
+	TEE_Result (*work)(void *data);
+	void *data;
+};
+
+static unsigned int dw_lock = SPINLOCK_UNLOCK;
+static TAILQ_HEAD(dw_queue, deferred_work) head = TAILQ_HEAD_INITIALIZER(head);
+
+TEE_Result deferred_work_add(const char *name, TEE_Result (*work)(void *data),
+			     void *data)
+{
+	size_t n;
+	uint32_t exceptions;
+	struct deferred_work *new_dw;
+
+	if (!name) {
+		EMSG("unnamed work isn't allowed");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (!work) {
+		EMSG("<null> work-function (work <%s>) isn't allowed", name);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	new_dw = calloc(1, sizeof(struct deferred_work));
+	if (!new_dw) {
+		EMSG("calloc() failed");
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	n = strlen(name);
+	memcpy(new_dw->name, name, n > DW_NAME_MAX - 1 ? DW_NAME_MAX - 1 : n);
+	new_dw->work = work;
+	new_dw->data = data;
+
+	exceptions = cpu_spin_lock_xsave(&dw_lock);
+	TAILQ_INSERT_TAIL(&head, new_dw, link);
+	cpu_spin_unlock_xrestore(&dw_lock, exceptions);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result deferred_work_do_all(void)
+{
+	uint32_t exceptions;
+	struct deferred_work *dw;
+
+	exceptions = cpu_spin_lock_xsave(&dw_lock);
+	while (!TAILQ_EMPTY(&head)) {
+		dw = TAILQ_FIRST(&head);
+		TAILQ_REMOVE(&head, dw, link);
+		cpu_spin_unlock_xrestore(&dw_lock, exceptions);
+
+		if (dw->work) {
+			TEE_Result res;
+
+			res = dw->work(dw->data);
+			if (res != TEE_SUCCESS)
+				EMSG("dw <%s> failed with code 0x%x", dw->name,
+				     res);
+			else
+				IMSG("dw <%s> successfully finished", dw->name);
+		}
+		free(dw);
+
+		exceptions = cpu_spin_lock_xsave(&dw_lock);
+	}
+	cpu_spin_unlock_xrestore(&dw_lock, exceptions);
+
+	return TEE_SUCCESS;
+}

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -23,3 +23,4 @@ srcs-y += user_mode_ctx.c
 srcs-$(CFG_CORE_TPM_EVENT_LOG) += tpm.c
 srcs-y += initcall.c
 srcs-y += user_access.c
+srcs-$(CFG_DEFERRED_WORK) += deferred_work.c

--- a/core/pta/dw.c
+++ b/core/pta/dw.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2020, Open Mobile Platform LLC
+ */
+
+/*
+ * Small pseudo-TA to trigger deferred works.
+ */
+
+#include <kernel/msg_param.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/user_ta.h>
+#include <kernel/delay.h>
+#include <kernel/deferred_work.h>
+#include <pta_dw.h>
+#include <stdio.h>
+#include <tee_api_defines.h>
+#include <trace.h>
+
+#define TA_NAME "dw"
+
+/*
+ * Trusted Application Entry Points
+ */
+
+static TEE_Result dw_invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+				    uint32_t param_types __unused,
+				    TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	switch (cmd_id) {
+	case DW_PTA_EXEC_ALL_DW:
+		return deferred_work_do_all();
+	default:
+		break;
+	}
+
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+pseudo_ta_register(.uuid = PTA_DEFERRED_WORK_UUID, .name = TA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
+		   .invoke_command_entry_point = dw_invoke_command);

--- a/core/pta/dw.c
+++ b/core/pta/dw.c
@@ -19,6 +19,35 @@
 
 #define TA_NAME "dw"
 
+#if defined(CFG_DEFERRED_WORK_WITH_TESTS)
+
+#define DW_TEST_WORKS_CNT 10
+
+static TEE_Result test_dw_ok(void *data __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static void dw_add_tests(int cnt)
+{
+	int i;
+	char name[32] = { 0 };
+	TEE_Result res;
+
+	for (i = 0; i < cnt; ++i) {
+		(void)snprintf(name, sizeof(name), "test-dw #%d", i);
+
+		res = deferred_work_add(name, test_dw_ok, NULL);
+		if (res != TEE_SUCCESS)
+			EMSG("dw <%s> failed to schedule for deferred execution with code 0x%x",
+			     name, res);
+		else
+			IMSG("dw <%s> was scheduled for deferred execution successfully",
+			     name);
+	}
+}
+#endif /* CFG_DEFERRED_WORK_WITH_TESTS */
+
 /*
  * Trusted Application Entry Points
  */
@@ -27,6 +56,14 @@ static TEE_Result dw_invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
 				    uint32_t param_types __unused,
 				    TEE_Param params[TEE_NUM_PARAMS] __unused)
 {
+#if defined(CFG_DEFERRED_WORK_WITH_TESTS)
+	static int test_done;
+
+	if (!test_done) {
+		dw_add_tests(DW_TEST_WORKS_CNT);
+		test_done = 1;
+	}
+#endif
 	switch (cmd_id) {
 	case DW_PTA_EXEC_ALL_DW:
 		return deferred_work_do_all();

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -10,5 +10,6 @@ endif
 srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_SYSTEM_PTA) += system.c
 srcs-$(CFG_NXP_SE05X) += scp03.c
+srcs-$(CFG_DEFERRED_WORK) += dw.c
 
 subdirs-y += bcm

--- a/lib/libutee/include/pta_dw.h
+++ b/lib/libutee/include/pta_dw.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2020, Open Mobile Platform LLC
+ */
+
+#ifndef __PTA_DW_H
+#define __PTA_DW_H
+
+#define PTA_DEFERRED_WORK_UUID \
+	{ 0x77383949, 0x5627, 0x49b0, \
+		{ 0xa0, 0x81, 0x1f, 0xd1, 0x2e, 0xff, 0x7c, 0xf0} }
+
+/*
+ * Execute all current deferred works
+ */
+#define DW_PTA_EXEC_ALL_DW 0
+
+#endif /* __PTA_DW_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -514,6 +514,10 @@ CFG_DEVICE_ENUM_PTA ?= y
 # The jobs will be triggered by the tee-supplicant, when it will start.
 CFG_DEFERRED_WORK ?= y
 
+# Enable automatically adding some deferred works to the queue
+# before optee will execute ones. The option is needed just for test.
+CFG_DEFERRED_WORK_WITH_TESTS ?= n
+
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,
 # so its value represents log2(cores/cluster).

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -510,6 +510,10 @@ CFG_SYSTEM_PTA ?= y
 # world OS.
 CFG_DEVICE_ENUM_PTA ?= y
 
+# Enable the deferred work framework
+# The jobs will be triggered by the tee-supplicant, when it will start.
+CFG_DEFERRED_WORK ?= y
+
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,
 # so its value represents log2(cores/cluster).


### PR DESCRIPTION
Theses patches add to the kernel a new framework for the ability
to save different works, when Rich OS is still booting
and tee-supplicant has not started yet.

Also the patches adds small PTA to trigger different works for execution.
tee-supplicant starts and sends a cmd to the PTA to run all pending jobs.

This ability might be useful in different cases. For example:
 - Run some specific RPC as soon as possible, when RichOS will start;
 - Remove REE based key store or any other fs operations;
 - Save TEE boot process log

To create a new deferred work entity - use 'deferred_work_add()'.
The works will collect in a queue in the kernel.

Signed-off-by: Aleksandr Anisimov <a.anisimov@omprussia.ru>