### PR TITLE
[RFC] core: add deferred init calls

### DIFF
--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2014,2020 Linaro Limited
  */
 
 #ifndef INITCALL_H
@@ -47,5 +47,14 @@ struct initcall {
 
 void call_initcalls(void);
 void call_finalcalls(void);
+
+#ifdef CFG_CORE_DEFERRED_INIT
+#define deferredcall_begin SCATTERED_ARRAY_BEGIN(deferredcall, struct initcall)
+#define deferredcall_end   SCATTERED_ARRAY_END(deferredcall, struct initcall)
+
+#define deferred_init(fn)		__define_initcall(deferred, 1, fn)
+
+void call_deferredcalls(void);
+#endif
 
 #endif

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -52,6 +52,12 @@ void call_finalcalls(void);
 #define deferredcall_begin SCATTERED_ARRAY_BEGIN(deferredcall, struct initcall)
 #define deferredcall_end   SCATTERED_ARRAY_END(deferredcall, struct initcall)
 
+/*
+ * OP-TEE can't guarantee that the functions registered with
+ * deferred_init() will ever be called. We depend on normal world to
+ * trigger this by invoking a designated PTA when tee-supplicant has
+ * initialized.
+ */
 #define deferred_init(fn)		__define_initcall(deferred, 1, fn)
 
 void call_deferredcalls(void);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -626,3 +626,7 @@ CFG_COMPAT_GP10_DES ?= y
 
 # Defines a limit for many levels TAs may call each others.
 CFG_CORE_MAX_SYSCALL_RECURSION ?= 4
+
+# When enabled provides deferred init calls to be called when tee-supplicant
+# is initialized.
+CFG_CORE_DEFERRED_INIT ?= n


### PR DESCRIPTION
```
Introduces CFG_CORE_DEFERRED_INIT which when 'y' enables deferred init
calls.  Deferred init calls are registered as any other init/final call
except that these are called when a PTA is called after the Linux
tee-supplicant has been initialized.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
```
Relates to https://github.com/OP-TEE/optee_os/pull/4247