### PR TITLE
TZC380: Fix autoconfiguration for bigger DRAM sizes.

### DIFF
--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -253,7 +253,7 @@ int tzc_auto_configure(vaddr_t addr, vaddr_t size, uint32_t attr,
 			lregion++;
 			address += region_size;
 			lsize -= region_size;
-			pow--;
+			pow = tzc.addr_width;
 			continue;
 		}
 
@@ -278,7 +278,7 @@ int tzc_auto_configure(vaddr_t addr, vaddr_t size, uint32_t attr,
 					     TZC_ATTR_REGION_EN_MASK |
 					     mask | attr);
 			lregion++;
-			pow--;
+			pow = tzc.addr_width;
 			continue;
 		}
 		pow--;


### PR DESCRIPTION
Currently the region size is always decremented when finding a region. Instead reset to the biggest size to restart with another start address. Also fixes an unnecessary multiply/divide with the same `region_size`.