### PR TITLE
Initial support for Renesas RZ/G2{HMNE} SoC's

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -134,6 +134,8 @@ build:
     - _make PLATFORM=d02 CFG_ARM64_core=y
     - _make PLATFORM=rcar
     - _make PLATFORM=rcar CFG_ARM64_core=y
+    - _make PLATFORM=rzg
+    - _make PLATFORM=rzg CFG_ARM64_core=y
     - _make PLATFORM=rpi3
     - _make PLATFORM=rpi3 CFG_ARM64_core=y
     - _make PLATFORM=hikey-hikey960

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -168,6 +168,13 @@ R:	[@OP-TEE/plat-rcar]
 S:	Maintained
 F:	core/arch/arm/plat-rcar/
 
+Renesas RZ/G2
+R:	Lad Prabhakar <prabhakar.mahadev-lad.rj@bp.renesas.com> [@prabhakarlad]
+R:	Biju Das <biju.das.jz@bp.renesas.com> [@bijucdas]
+R:	[@OP-TEE/plat-rzg]
+S:	Maintained
+F:	core/arch/arm/plat-rzg/
+
 Renesas RZ/N1
 R:	Sumit Garg <sumit.garg@linaro.org> [@b49020]
 R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -224,3 +224,13 @@ $(link-out-dir)/tee.mem_usage: $(link-out-dir)/tee.elf
 	@$(cmd-echo-silent) '  GEN     $@'
 	$(q)$(PYTHON3) ./scripts/mem_usage.py $< > $@
 endif
+
+cleanfiles += $(link-out-dir)/tee-raw.bin
+$(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
+	@$(cmd-echo-silent) '  GEN     $@'
+	$(q)scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@
+
+cleanfiles += $(link-out-dir)/tee.srec
+$(link-out-dir)/tee.srec: $(link-out-dir)/tee-raw.bin
+	@$(cmd-echo-silent) '  SREC    $@'
+	$(q)$(OBJCOPYcore) -I binary -O srec $< $@

--- a/core/arch/arm/plat-rcar/link.mk
+++ b/core/arch/arm/plat-rcar/link.mk
@@ -1,15 +1,3 @@
 include core/arch/arm/kernel/link.mk
 
 all: $(link-out-dir)/tee.srec
-cleanfiles += $(link-out-dir)/tee.srec
-
-cleanfiles += $(link-out-dir)/tee-raw.bin
-$(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
-	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@
-
-cleanfiles += $(link-out-dir)/tee.srec
-$(link-out-dir)/tee.srec: $(link-out-dir)/tee-raw.bin
-	@$(cmd-echo-silent) '  SREC    $@'
-	$(q)$(OBJCOPYcore) -I binary -O srec $< $@
-

--- a/core/arch/arm/plat-rzg/conf.mk
+++ b/core/arch/arm/plat-rzg/conf.mk
@@ -1,0 +1,46 @@
+PLATFORM_FLAVOR ?= hihope_rzg2m
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_SCIF,y)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+
+# Disable core ASLR for two reasons:
+# 1. There is no source for ALSR seed, as RZ/G2 platform
+#    does not provide DTB to OP-TEE. Also, there is no
+#    publicly available documentation on integrated
+#    hardware RNG, so we can't use it either.
+# 2. OP-TEE crashes during boot with enabled CFG_CORE_ASLR.
+$(call force,CFG_CORE_ASLR,n)
+
+ifeq ($(PLATFORM_FLAVOR),ek874)
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+endif
+ifeq ($(PLATFORM_FLAVOR),hihope_rzg2m)
+$(call force,CFG_TEE_CORE_NB_CORE,6)
+# RZ/G2M have 6 cores for 2 clusters, but the number isn't contiguous.
+# One cluster has ids 0, 1, other has ids 3, 4, 5, 6.
+# CFG_CORE_CLUSTER_SHIFT will process to make the right numbering.
+$(call force,CFG_CORE_CLUSTER_SHIFT,1)
+endif
+ifeq ($(PLATFORM_FLAVOR),hihope_rzg2n)
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+endif
+ifeq ($(PLATFORM_FLAVOR),hihope_rzg2h)
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+endif
+
+CFG_TZDRAM_START ?= 0x44100000
+CFG_TZDRAM_SIZE ?= 0x03D00000
+CFG_TEE_RAM_VA_SIZE ?= 0x100000
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_WITH_LPAE,y)
+supported-ta-targets = ta_arm64
+else
+$(call force,CFG_ARM32_core,y)
+endif
+
+CFG_DT ?= y

--- a/core/arch/arm/plat-rzg/link.mk
+++ b/core/arch/arm/plat-rzg/link.mk
@@ -1,0 +1,3 @@
+include core/arch/arm/kernel/link.mk
+
+all: $(link-out-dir)/tee.srec

--- a/core/arch/arm/plat-rzg/main.c
+++ b/core/arch/arm/plat-rzg/main.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2016, GlobalLogic
+ * Copyright (c) 2019-2020, Renesas Electronics Corporation
+ */
+
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/scif.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, SCIF_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
+
+register_dynamic_shm(NSEC_DDR_0_BASE, NSEC_DDR_0_SIZE);
+#ifdef NSEC_DDR_1_BASE
+register_dynamic_shm(NSEC_DDR_1_BASE, NSEC_DDR_1_SIZE);
+#endif
+#ifdef NSEC_DDR_2_BASE
+register_dynamic_shm(NSEC_DDR_2_BASE, NSEC_DDR_2_SIZE);
+#endif
+#ifdef NSEC_DDR_3_BASE
+register_dynamic_shm(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
+#endif
+
+static struct scif_uart_data console_data __nex_bss;
+
+void console_init(void)
+{
+	scif_uart_init(&console_data, CONSOLE_UART_BASE);
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-rzg/platform_config.h
+++ b/core/arch/arm/plat-rzg/platform_config.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2016, GlobalLogic
+ * Copyright (c) 2020, Renesas Electronics Corporation
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#define GIC_BASE		0xF1000000
+#define GICC_BASE		0xF1020000
+#define GICD_BASE		0xF1010000
+
+#define CONSOLE_UART_BASE	0xE6E88000
+
+#if defined(PLATFORM_FLAVOR_ek874)
+#define NSEC_DDR_0_BASE		0x47E00000U
+#define NSEC_DDR_0_SIZE		0x78200000
+
+#elif defined(PLATFORM_FLAVOR_hihope_rzg2h)
+
+#define NSEC_DDR_0_BASE		0x47E00000U
+#define NSEC_DDR_0_SIZE		0x78200000
+#define NSEC_DDR_1_BASE		0x500000000U
+#define NSEC_DDR_1_SIZE		0x80000000
+
+#elif defined(PLATFORM_FLAVOR_hihope_rzg2m)
+
+#define NSEC_DDR_0_BASE		0x47E00000U
+#define NSEC_DDR_0_SIZE		0x78200000
+#define NSEC_DDR_1_BASE		0x600000000U
+#define NSEC_DDR_1_SIZE		0x80000000
+
+#elif defined(PLATFORM_FLAVOR_hihope_rzg2n)
+
+#define NSEC_DDR_0_BASE		0x47E00000U
+#define NSEC_DDR_0_SIZE		0x78200000
+#define NSEC_DDR_1_BASE		0x480000000U
+#define NSEC_DDR_1_SIZE		0x80000000
+
+#else
+#error "Unknown platform flavor"
+#endif
+
+#define TEE_SHMEM_START		(TZDRAM_BASE + TZDRAM_SIZE)
+#define TEE_SHMEM_SIZE		0x100000
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-rzg/sub.mk
+++ b/core/arch/arm/plat-rzg/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
This patch adds support for Renesas RZ/G2{HMNE} SoC's.

* Compiled with:
    | make PLATFORM=rzg # Defaults to RZ/G2M SoC

Based on the work done from Huynh Thanh Hung for RZ/G2 internally and
similar work done for Renesas RCar-Gen3 SoC's in mainline OP-TEE OS.

Signed-off-by: Lad Prabhakar <prabhakar.mahadev-lad.rj@bp.renesas.com>
Reviewed-by: Biju Das <biju.das.jz@bp.renesas.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
