### PR TITLE
drivers: imx_i2c: remove non-portable use of define

### DIFF
--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -19,9 +19,6 @@
 
 #define I2C_CLK_RATE	24000000 /* Bits per second */
 
-#define USE_I2C_STATIC_ADDRESS \
-	(!defined(CFG_DT) || defined(CFG_EXTERNAL_DTB_OVERLAY))
-
 /* Utility macros (__x identifies the bus [1 .. 3]) */
 #define I2C_CFG_SCL(__x)	(IOMUXC_I2C1_SCL_CFG_OFF + ((__x) - 1) * 0x8)
 #define I2C_CFG_SDA(__x)	(IOMUXC_I2C1_SDA_CFG_OFF + ((__x) - 1) * 0x8)
@@ -52,7 +49,7 @@
 #endif
 
 static struct io_pa_va i2c_bus[3] = {
-#if USE_I2C_STATIC_ADDRESS
+#if !defined(CFG_DT) || defined(CFG_EXTERNAL_DTB_OVERLAY)
 #if defined(I2C1_BASE)
 	[0] = { .pa = I2C1_BASE, },
 #endif
@@ -449,7 +446,7 @@ static TEE_Result get_va(paddr_t pa, vaddr_t *va)
 	return TEE_ERROR_GENERIC;
 }
 
-#if !USE_I2C_STATIC_ADDRESS
+#if defined(CFG_DT) && !defined(CFG_EXTERNAL_DTB_OVERLAY)
 static const char *const dt_i2c_match_table[] = {
 	"fsl,imx21-i2c",
 };
@@ -519,7 +516,7 @@ static TEE_Result i2c_map_controller(void)
 
 	return ret;
 }
-#endif /* !USE_I2C_STATIC_ADDRESS */
+#endif
 
 static TEE_Result i2c_init(void)
 {


### PR DESCRIPTION
Fix the build error triggered when enabling
-Werror=expansion-to-defined

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
