### PR TITLE
build: make 'force' macro more robust

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -177,7 +177,7 @@ cfg-check-value =                                                          \
 # Example:
 # $(call force,CFG_FOO,foo,required by CFG_BAR)
 define force
-$(eval $(call _force,$(1),$(2),$(3)))
+$(eval $(call _force,$(strip $(1)),$(2),$(3)))
 endef
 
 define _force


### PR DESCRIPTION
The 'force' macro can cause unexpected errors in some cases where
the name of the configuration variable is preceded by a space:
'$(call force, CFG_FOO,foo)' instead of '$(call force,CFG_FOO,foo)'.
For example:

 $ make PLATFORM=imx-mx8mmevk CFG_STACK_{TMP,THREAD}_EXTRA=8192 \
   CFG_CRYPTO_DRV_ACIPHER=y CFG_NXP_SE05X=y CFG_NXP_CAAM=y
 core/drivers/crypto/se050/crypto.mk:49: *** CFG_CRYPTO_DRV_ACIPHER is set to '' (from undefined) but its value must be 'y' [Mandated by CFG_NXP_SE05X_ACIPHER_DRV].  Stop.

Fixing the callers is certainly a good thing to do (if only for
consistency) but the current behavior is difficult to troubleshoot.
Therefore, make the 'force' macro more robust by stripping any space
around the variable name.

Reported-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
