### PR TITLE
drivers: crypto: se050: strip spaces from crypto.mk

### DIFF
--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -42,11 +42,11 @@ se050-one-enabled = $(call cfg-one-enabled, \
                         $(foreach v,$(1), CFG_NXP_SE05X_$(v)_DRV))
 # Asymmetric ciphers
 CFG_NXP_SE05X_RSA_DRV ?= y
-$(call force, CFG_NXP_SE05X_ACIPHER_DRV, $(call se050-one-enabled, RSA))
+$(call force,CFG_NXP_SE05X_ACIPHER_DRV,$(call se050-one-enabled,RSA))
 
 # Asymmetric driver
 ifeq ($(CFG_NXP_SE05X_ACIPHER_DRV),y)
-$(call force, CFG_CRYPTO_DRV_ACIPHER,y,Mandated by CFG_NXP_SE05X_ACIPHER_DRV)
+$(call force,CFG_CRYPTO_DRV_ACIPHER,y,Mandated by CFG_NXP_SE05X_ACIPHER_DRV)
 endif
 
 # Asymmetric ciphers configuration
@@ -59,11 +59,11 @@ endif
 
 # Symmetric ciphers
 CFG_NXP_SE05X_CTR_DRV ?= y
-$(call force, CFG_NXP_SE05X_CIPHER_DRV, $(call se050-one-enabled, CTR))
+$(call force,CFG_NXP_SE05X_CIPHER_DRV,$(call se050-one-enabled,CTR))
 
 # Symmetric driver
 ifeq ($(CFG_NXP_SE05X_CIPHER_DRV),y)
-$(call force, CFG_CRYPTO_DRV_CIPHER,y,Mandated by CFG_NXP_SE05X_CIPHER_DRV)
+$(call force,CFG_CRYPTO_DRV_CIPHER,y,Mandated by CFG_NXP_SE05X_CIPHER_DRV)
 endif
 
 # Plug and Trust NXP SE050X OP-TEE enabled static library


### PR DESCRIPTION
Some versions of the force function used in the makefile might produce
incorrect results when spaces are included in the parameter field.

In general is a better practice to strip spaces when invoking this
sort of functions.

To prevent issues (ie: in case of backport) make sure that the SE050
driver is not affected by that variability.

Issue: #4259 

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
