### PR TITLE
core: fix user mode context reference in pager

### DIFF
--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -1703,7 +1703,7 @@ void tee_pager_pgt_save_and_release_entries(struct pgt *pgt)
 	assert(!pgt->num_used_entries);
 
 out:
-	areas = to_user_ta_ctx(pgt->ctx)->uctx.areas;
+	areas = to_user_mode_ctx(pgt->ctx)->areas;
 	if (areas) {
 		TAILQ_FOREACH(area, areas, link) {
 			if (area->pgt == pgt)


### PR DESCRIPTION
Fix tee_pager_gpt_save_and_release_entries() to use to_user_mode_ctx()
to get current context user memory areas instead of to_user_ta_ctx()
since the former supports both SP and TA contexts.

Prior this change was pager asserting with an error trace like below:
E/TC:0 0 assertion 'is_user_ta_ctx(ctx)' failed at core/arch/arm/include/kernel/user_ta.h:56 <to_user_ta_ctx>
E/TC:0 0 Panic at core/kernel/assert.c:28 <_assert_break>

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
