### PR TITLE
core: pager memory optim in rpmb fs driver

### DIFF
--- a/core/arch/arm/include/mm/tee_pager.h
+++ b/core/arch/arm/include/mm/tee_pager.h
@@ -216,10 +216,11 @@ void tee_pager_add_pages(vaddr_t vaddr, size_t npages, bool unmap);
 /*
  * tee_pager_alloc() - Allocate read-write virtual memory from pager.
  * @size:	size of memory in bytes
+ * @area_type   area attributes (locked, ro, rw)
  *
  * @return NULL on failure or a pointer to the virtual memory on success.
  */
-void *tee_pager_alloc(size_t size);
+void *tee_pager_alloc(size_t size, enum tee_pager_area_type area_type);
 
 #ifdef CFG_PAGED_USER_TA
 /*

--- a/core/arch/arm/mm/pgt_cache.c
+++ b/core/arch/arm/mm/pgt_cache.c
@@ -69,7 +69,7 @@ void pgt_init(void)
 	for (n = 0; n < PGT_CACHE_SIZE; n++) {
 		struct pgt *p = pgt_entries + n;
 
-		p->tbl = tee_pager_alloc(PGT_SIZE);
+		p->tbl = tee_pager_alloc(PGT_SIZE, PAGER_AREA_TYPE_LOCK);
 		SLIST_INSERT_HEAD(&pgt_free_list, p, link);
 	}
 }
@@ -83,7 +83,8 @@ void pgt_init(void)
 	COMPILE_TIME_ASSERT(PGT_SIZE * PGT_NUM_PGT_PER_PAGE == SMALL_PAGE_SIZE);
 
 	for (n = 0; n < ARRAY_SIZE(pgt_parents); n++) {
-		uint8_t *tbl = tee_pager_alloc(SMALL_PAGE_SIZE);
+		uint8_t *tbl = tee_pager_alloc(SMALL_PAGE_SIZE,
+					       PAGER_AREA_TYPE_LOCK);
 
 		SLIST_INIT(&pgt_parents[n].pgt_cache);
 		for (m = 0; m < PGT_NUM_PGT_PER_PAGE; m++) {

--- a/core/lib/libtomcrypt/mpi_desc.c
+++ b/core/lib/libtomcrypt/mpi_desc.c
@@ -34,7 +34,7 @@ static struct mempool *get_mp_scratch_memory_pool(void)
 	void *data;
 
 	size = ROUNDUP(MPI_MEMPOOL_SIZE, SMALL_PAGE_SIZE);
-	data = tee_pager_alloc(size);
+	data = tee_pager_alloc(size, PAGER_AREA_TYPE_LOCK);
 	if (!data)
 		panic();
 

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -14,6 +14,7 @@
 #include <kernel/tee_common_otp.h>
 #include <kernel/tee_misc.h>
 #include <kernel/thread.h>
+#include <mempool.h>
 #include <mm/core_memprot.h>
 #include <mm/mobj.h>
 #include <mm/tee_mm.h>
@@ -2437,7 +2438,7 @@ static TEE_Result rpmb_fs_write_primitive(struct rpmb_file_handle *fh,
 		DMSG("Need to re-allocate");
 		newsize = MAX(end, fh->fat_entry.data_size);
 		mm = tee_mm_alloc(&p, newsize);
-		newbuf = calloc(1, newsize);
+		newbuf = mempool_alloc(mempool_default, newsize);
 		if (!mm || !newbuf) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;
@@ -2470,8 +2471,8 @@ static TEE_Result rpmb_fs_write_primitive(struct rpmb_file_handle *fh,
 out:
 	if (pool_result)
 		tee_mm_final(&p);
-	if (newbuf)
-		free(newbuf);
+
+	mempool_free(mempool_default, newbuf);
 
 	return res;
 }


### PR DESCRIPTION
RPMB FS driver may allocates a temporary buffer in the heap on caller data transfer request. These may be big buffers of dozens of kbytes. When pager is enabled and heap not so big such temporary buffers could be allocated in fully pageable read/write memory, preserving the heap.

This P-R addresses that.