### PR TITLE
drivers: crypto: se050: die_id generation

### DIFF
--- a/core/drivers/crypto/se050/core/huk.c
+++ b/core/drivers/crypto/se050/core/huk.c
@@ -16,15 +16,15 @@ int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 	size_t se050_huk_len = sizeof(se050_huk);
 	sss_status_t status = kStatus_SSS_Fail;
 
-	memset(buffer, 0, len);
-
 	status = sss_se05x_session_prop_get_au8(se050_session,
 						kSSS_SessionProp_UID,
 						se050_huk, &se050_huk_len);
 	if (status != kStatus_SSS_Success)
 		return -1;
 
-	memcpy(buffer, se050_huk, MIN(len, se050_huk_len));
+	if (tee_hash_createdigest(TEE_ALG_SHA256, se050_huk, se050_huk_len,
+				  buffer, len))
+		return -1;
 
 	return 0;
 }


### PR DESCRIPTION
Guarantee the uniqueness of the die_id even when the requested length
is smaller than the se050 unique identifier.

Currently, tee_otp_get_die_id requests 12 bytes while the se050 unique
identifier is 18 bytes which is an issue as the uniqueness of the
device can be lost due to the truncation of the identifier.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
