### PR TITLE
plat-rockchip: mark parameters as __maybe_unused in platform_secure_ddr_region

### DIFF
--- a/core/arch/arm/plat-rockchip/platform.c
+++ b/core/arch/arm/plat-rockchip/platform.c
@@ -15,7 +15,9 @@ int __weak platform_secure_init(void)
 	return 0;
 }
 
-int __weak platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
+int __weak platform_secure_ddr_region(int rgn __maybe_unused,
+				      paddr_t st __maybe_unused,
+				      size_t sz __maybe_unused)
 {
 	MSG("Not protecting region %d: 0x%lx-0x%lx\n", rgn, st, st + sz);
 


### PR DESCRIPTION
The weak variant of platform_secure_ddr_region() only emits a message that the
target region won't get protected due to missing platform-code.

Depending on the log-level this can result in the function parameters not
getting used at all, so mark them as __maybe_unused.

Signed-off-by: Heiko Stuebner <heiko.stuebner@theobroma-systems.com>
