### PR TITLE
core: add isb() before reading CNTPCT/CNTVCT

### DIFF
--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -103,4 +103,12 @@
 #include <arm64.h>
 #endif
 
+#ifndef __ASSEMBLER__
+static inline __noprof uint64_t barrier_read_cntpct(void)
+{
+	isb();
+	return read_cntpct();
+}
+#endif
+
 #endif /*ARM_H*/

--- a/core/arch/arm/include/kernel/delay.h
+++ b/core/arch/arm/include/kernel/delay.h
@@ -44,12 +44,12 @@ static inline uint64_t arm_cnt_us2cnt(uint32_t us)
 
 static inline uint64_t timeout_init_us(uint32_t us)
 {
-	return read_cntpct() + arm_cnt_us2cnt(us);
+	return barrier_read_cntpct() + arm_cnt_us2cnt(us);
 }
 
 static inline bool timeout_elapsed(uint64_t expire)
 {
-	return read_cntpct() > expire;
+	return barrier_read_cntpct() > expire;
 }
 
 #endif

--- a/core/arch/arm/kernel/tee_time_arm_cntpct.c
+++ b/core/arch/arm/kernel/tee_time_arm_cntpct.c
@@ -16,7 +16,7 @@
 
 static TEE_Result arm_cntpct_get_sys_time(TEE_Time *time)
 {
-	uint64_t cntpct = read_cntpct();
+	uint64_t cntpct = barrier_read_cntpct();
 	uint32_t cntfrq = read_cntfrq();
 
 	time->seconds = cntpct / cntfrq;
@@ -49,7 +49,7 @@ REGISTER_TIME_SOURCE(arm_cntpct_time_source)
 
 void plat_prng_add_jitter_entropy(enum crypto_rng_src sid, unsigned int *pnum)
 {
-	uint64_t tsc = read_cntpct();
+	uint64_t tsc = barrier_read_cntpct();
 	int bytes = 0, n;
 	static uint8_t first, bits;
 	static uint16_t acc;

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -923,7 +923,7 @@ static void gprof_update_session_utime(bool suspend, struct ts_session *s,
 static void tee_ta_update_session_utime(bool suspend)
 {
 	struct ts_session *s = ts_get_current_session();
-	uint64_t now = read_cntpct();
+	uint64_t now = barrier_read_cntpct();
 
 	gprof_update_session_utime(suspend, s, now);
 }
@@ -947,7 +947,7 @@ static void ftrace_update_times(bool suspend)
 	uint64_t now = 0;
 	uint32_t i = 0;
 
-	now = read_cntpct();
+	now = barrier_read_cntpct();
 
 	fbuf = s->fbuf;
 	if (!fbuf)

--- a/lib/libutee/include/arm_user_sysreg.h
+++ b/lib/libutee/include/arm_user_sysreg.h
@@ -15,4 +15,17 @@
 #include <arm64_user_sysreg.h>
 #endif
 
+#ifndef __ASSEMBLER__
+static inline __noprof void isb(void)
+{
+	asm volatile ("isb");
+}
+
+static inline __noprof uint64_t barrier_read_cntpct(void)
+{
+	isb();
+	return read_cntpct();
+}
+#endif
+
 #endif /*ARM_USER_SYSREG_H*/

--- a/lib/libutils/ext/ftrace/ftrace.c
+++ b/lib/libutils/ext/ftrace/ftrace.c
@@ -165,7 +165,7 @@ void __noprof ftrace_enter(unsigned long pc, unsigned long *lr)
 
 	if (fbuf->ret_idx < FTRACE_RETFUNC_DEPTH) {
 		fbuf->ret_stack[fbuf->ret_idx] = *lr;
-		fbuf->begin_time[fbuf->ret_idx] = read_cntpct();
+		fbuf->begin_time[fbuf->ret_idx] = barrier_read_cntpct();
 		fbuf->ret_idx++;
 	} else {
 		/*
@@ -269,7 +269,7 @@ unsigned long __noprof ftrace_return(void)
 		dur_loc = curr_buf - (fbuf->ret_idx +
 				      (2 * sizeof(unsigned long)) + 11);
 		ftrace_duration(dur_loc, fbuf->begin_time[fbuf->ret_idx],
-				read_cntpct());
+				barrier_read_cntpct());
 	} else {
 		bool full = false;
 
@@ -297,7 +297,7 @@ unsigned long __noprof ftrace_return(void)
 			dur_loc = curr_buf - fbuf->ret_idx - 6;
 			ftrace_duration(dur_loc,
 					fbuf->begin_time[fbuf->ret_idx],
-					read_cntpct());
+					barrier_read_cntpct());
 		}
 	}
 


### PR DESCRIPTION
Arm ARM quite clearly mentions that such reads must be preceded by an
ISB to forbid re-ordering.

Reported-by: Olivier Deprez <Olivier.Deprez@arm.com>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
