### PR TITLE
libutee: fix TEE_BigIntInit() memset()

### DIFF
--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -117,11 +117,9 @@ static void get_mpi(mbedtls_mpi *mpi, const TEE_BigInt *bigInt)
 
 void TEE_BigIntInit(TEE_BigInt *bigInt, uint32_t len)
 {
-	memset(bigInt, 0, TEE_BigIntSizeInU32(len) * sizeof(uint32_t));
-
 	struct bigint_hdr *hdr = (struct bigint_hdr *)bigInt;
 
-
+	memset(bigInt, 0, len * sizeof(uint32_t));
 	hdr->sign = 1;
 	if ((len - BIGINT_HDR_SIZE_IN_U32) > MBEDTLS_MPI_MAX_LIMBS)
 		API_PANIC("Too large bigint");


### PR DESCRIPTION
The TEE_BigIntInit() supplied length is the number of words allocated
for the bigint, including headers. Prior to this patch it seems it was
assumed that length was number of bits given the call to
TEE_BigIntSizeInU32(). With this patch correct this by removing the
TEE_BigIntSizeInU32() call.

Fixes: 062e3d01c039 ("ta: switch to to mbedtls for bignum")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
