### PR TITLE
plat-ls: register dynamic shared memory for lx2160a

### DIFF
--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -58,6 +58,9 @@ static struct ns16550_data console_data;
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 			CORE_MMU_PGDIR_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_PGDIR_SIZE);
+#if defined(PLATFORM_FLAVOR_lx2160ardb)
+register_ddr(CFG_DRAM0_BASE, CFG_DRAM0_SIZE - CFG_TEE_OS_DRAM0_SIZE);
+#endif
 
 #ifdef CFG_ARM32_core
 void plat_primary_init_early(void)


### PR DESCRIPTION
With the recent updates in U-Boot and OP-TEE this platform
can store it's EFI variables in the RPMB partition of it's eMMC
device.
In order for that to happen U-Boot must be able to access OP-TEE.
Since U-Boot only implements dynamic shared memory communication at
the moment, let's register the whole DRAM minus the memory
used for Trusted RAM and the untrusted static shared memory.

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
