### PR TITLE
Check prime number before using it to generate DH key.

### DIFF
--- a/core/lib/libtomcrypt/dh.c
+++ b/core/lib/libtomcrypt/dh.c
@@ -45,6 +45,9 @@ TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
 	if (key_size != 8 * mp_unsigned_bin_size(key->p))
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	if (mp_prime_is_prime(key->p, 0, &ltc_res) != CRYPT_OK || ltc_res != LTC_MP_YES)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	ltc_res = mp_init_multi(&ltc_tmp_key.base, &ltc_tmp_key.prime, NULL);
 	if (ltc_res != CRYPT_OK)
 		return TEE_ERROR_OUT_OF_MEMORY;


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
To generate a DH public key, parsing a prime number from TA into kernel without checking its primality will cause potential call stack error. 
