### PR TITLE
core: split boot_init_primary()

### DIFF
--- a/core/arch/arm/include/kernel/boot.h
+++ b/core/arch/arm/include/kernel/boot.h
@@ -43,10 +43,9 @@ extern uint8_t embedded_secure_dtb[];
 extern const struct core_mmu_config boot_mmu_config;
 
 /* @nsec_entry is unused if using CFG_WITH_ARM_TRUSTED_FW */
-void boot_init_primary(unsigned long pageable_part, unsigned long nsec_entry,
-		       unsigned long fdt);
-
-void paged_init_primary(unsigned long fdt);
+void boot_init_primary_early(unsigned long pageable_part,
+			     unsigned long nsec_entry);
+void boot_init_primary_late(unsigned long fdt);
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 unsigned long cpu_on_handler(unsigned long a0, unsigned long a1);

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -27,6 +27,10 @@ DEFINES
 	DEFINE(THREAD_SVC_REG_R5, offsetof(struct thread_svc_regs, r5));
 	DEFINE(THREAD_SVC_REG_R6, offsetof(struct thread_svc_regs, r6));
 
+	/* struct thread_ctx */
+	DEFINE(THREAD_CTX_STACK_VA_END, offsetof(struct thread_ctx,
+						 stack_va_end));
+
 	/* struct thread_ctx_regs */
 	DEFINE(THREAD_CTX_REGS_USR_SP,
 	       offsetof(struct thread_ctx_regs, usr_sp));
@@ -65,6 +69,8 @@ DEFINES
 
 	/* struct thread_ctx */
 	DEFINE(THREAD_CTX_KERN_SP, offsetof(struct thread_ctx, kern_sp));
+	DEFINE(THREAD_CTX_STACK_VA_END, offsetof(struct thread_ctx,
+						 stack_va_end));
 	DEFINE(THREAD_CTX_SIZE, sizeof(struct thread_ctx));
 
 	/* struct thread_ctx_regs */

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1223,7 +1223,7 @@ static void init_primary(unsigned long pageable_part, unsigned long nsec_entry)
  * Note: this function is weak just to make it possible to exclude it from
  * the unpaged area.
  */
-void __weak paged_init_primary(unsigned long fdt)
+void __weak boot_init_primary_late(unsigned long fdt)
 {
 	init_external_dt(fdt);
 	tpm_map_log_area(get_external_dt());
@@ -1278,9 +1278,8 @@ static void init_secondary_helper(unsigned long nsec_entry)
  * Note: this function is weak just to make it possible to exclude it from
  * the unpaged area so that it lies in the init area.
  */
-void __weak boot_init_primary(unsigned long pageable_part,
-			      unsigned long nsec_entry __maybe_unused,
-			      unsigned long fdt)
+void __weak boot_init_primary_early(unsigned long pageable_part,
+				    unsigned long nsec_entry __maybe_unused)
 {
 	unsigned long e = PADDR_INVALID;
 
@@ -1289,7 +1288,6 @@ void __weak boot_init_primary(unsigned long pageable_part,
 #endif
 
 	init_primary(pageable_part, e);
-	paged_init_primary(fdt);
 }
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -518,8 +518,18 @@ shadow_stack_access_ok:
 
 	mov	r0, r4		/* pageable part address */
 	mov	r1, r5		/* ns-entry address */
-	mov	r2, r6		/* DT address */
-	bl	boot_init_primary
+	bl	boot_init_primary_early
+#ifndef CFG_VIRTUALIZATION
+	mov	r7, sp
+	ldr	r0, =threads
+	ldr	r0, [r0, #THREAD_CTX_STACK_VA_END]
+	mov	sp, r0
+#endif
+	mov	r0, r6		/* DT address */
+	bl	boot_init_primary_late
+#ifndef CFG_VIRTUALIZATION
+	mov	sp, r7
+#endif
 
 	/*
 	 * In case we've touched memory that secondary CPUs will use before
@@ -549,7 +559,9 @@ shadow_stack_access_ok:
 	 * next entry. Matches the thread_init_boot_thread() in
 	 * boot.c.
 	 */
+#ifndef CFG_VIRTUALIZATION
 	bl 	thread_clr_boot_thread
+#endif
 
 #ifdef CFG_CORE_FFA
 	ldr	r0, =cpu_on_handler

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -208,8 +208,18 @@ clear_nex_bss:
 
 	mov	x0, x19		/* pagable part address */
 	mov	x1, #-1
-	mov	x2, x20		/* DT address */
-	bl	boot_init_primary
+	bl	boot_init_primary_early
+#ifndef CFG_VIRTUALIZATION
+	mov	x21, sp
+	adr_l	x0, threads
+	ldr	x0, [x0, #THREAD_CTX_STACK_VA_END]
+	mov	sp, x0
+#endif
+	mov	x0, x20		/* DT address */
+	bl	boot_init_primary_late
+#ifndef CFG_VIRTUALIZATION
+	mov	sp, x21
+#endif
 
 	/*
 	 * In case we've touched memory that secondary CPUs will use before

--- a/core/arch/arm/kernel/link_dummies_init.c
+++ b/core/arch/arm/kernel/link_dummies_init.c
@@ -18,9 +18,8 @@ core_init_mmu_map(unsigned long seed __unused,
 {
 }
 
-void __section(".text.dummy.boot_init_primary")
-boot_init_primary(unsigned long pageable_part __unused,
-		  unsigned long nsec_entry __unused,
-		  unsigned long fdt __unused)
+void __section(".text.dummy.boot_init_primary_early")
+boot_init_primary_early(unsigned long pageable_part __unused,
+			unsigned long nsec_entry __unused)
 {
 }

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -20,8 +20,8 @@ void __section(".text.dummy.call_finalcalls") call_finalcalls(void)
 {
 }
 
-void __section(".text.dummy.paged_init_primary")
-paged_init_primary(unsigned long fdt __unused)
+void __section(".text.dummy.boot_init_primary_late")
+boot_init_primary_late(unsigned long fdt __unused)
 {
 }
 


### PR DESCRIPTION
Splits boot_init_primary() into boot_init_primary_early() and
boot_init_primary_late(). The thread#0 stack pointer is assigned as
stack pointer before boot_init_primary_late() is called. This allows
functions registered to be called by call_finalcalls() to depend on the
full thread stack being available.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

