### PR TITLE
mk/compile.mk: Fix handling of '+' in path for generated include guards

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -223,7 +223,7 @@ $3: $1 $(conf-file) FORCE
 			$$(comp-cmd-file-$3) ;\
 	)
 
-guard-$2 := $$(subst -,_,$$(subst .,_,$$(subst /,_,$2)))
+guard-$2 := $$(subst -,_,$$(subst .,_,$$(subst /,_,$$(subst +,_,$2))))
 
 $(2): $(3)
 	$(q)set -e;							\


### PR DESCRIPTION
When building with bitbake with gitpkgv class git revision details have
'+' as delimeter.

Version details appears in path and this causes following warnings during
the OP-TEE OS build:

```
In file included from core/arch/arm/kernel/entry_a64.S:11:
/build/.../optee-os/devel+gitrAUTOINC+e97c83bd6f-r0/build.zcu102/core/include/generated/asm-defines.h:1:123: warning: extra tokens at end of #ifndef directive
    1 | #ifndef _build_..._optee_os_devel+gitrAUTOINC+e97c83bd6f_r0_build_zcu102_core_include_generated_asm_defines_h
      |                                  ^
/build/.../optee-os/devel+gitrAUTOINC+e97c83bd6f-r0/build.zcu102/core/include/generated/asm-defines.h:2:9: warning: missing whitespace after the macro name
    2 | #define _build_..._optee_os_devel+gitrAUTOINC+e97c83bd6f_r0_build_zcu102_core_include_generated_asm_defines_h
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>