### PR TITLE
qemu_v8: configure secure interrupts

### DIFF
--- a/core/arch/arm/plat-vexpress/platform_config.h
+++ b/core/arch/arm/plat-vexpress/platform_config.h
@@ -67,10 +67,14 @@
 
 #elif defined(PLATFORM_FLAVOR_qemu_armv8a)
 
+#define GIC_BASE		0x08000000
 #define UART0_BASE		0x09000000
 #define UART1_BASE		0x09040000
 
+#define IT_UART1		40
+
 #define CONSOLE_UART_BASE	UART1_BASE
+#define IT_CONSOLE_UART		IT_UART1
 
 #else
 #error "Unknown platform flavor"
@@ -119,6 +123,9 @@
 #define GICC_OFFSET		0x10000
 
 #elif defined(PLATFORM_FLAVOR_qemu_armv8a)
+
+#define GICD_OFFSET		0
+#define GICC_OFFSET		0x10000
 
 #else
 #error "Unknown platform flavor"


### PR DESCRIPTION
Configures GIC and enable reception of interrupts from the secure uart.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
