### PR TITLE
ta: pkcs11: Remove persistent objects on token re-initialization

### DIFF
--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -65,8 +65,8 @@ static void cleanup_volatile_obj_ref(struct pkcs11_object *obj)
 }
 
 /* Release resources of a persistent object including volatile resources */
-static void cleanup_persistent_object(struct pkcs11_object *obj,
-				      struct ck_token *token)
+void cleanup_persistent_object(struct pkcs11_object *obj,
+			       struct ck_token *token)
 {
 	TEE_Result res = TEE_SUCCESS;
 

--- a/ta/pkcs11/src/object.h
+++ b/ta/pkcs11/src/object.h
@@ -10,6 +10,7 @@
 #include <sys/queue.h>
 #include <tee_internal_api.h>
 
+struct ck_token;
 struct obj_attrs;
 struct pkcs11_client;
 struct pkcs11_session;
@@ -44,6 +45,9 @@ struct pkcs11_object *create_token_object(struct obj_attrs *head,
 
 enum pkcs11_rc create_object(void *session, struct obj_attrs *attributes,
 			     uint32_t *handle);
+
+void cleanup_persistent_object(struct pkcs11_object *obj,
+			       struct ck_token *token);
 
 void destroy_object(struct pkcs11_session *session,
 		    struct pkcs11_object *object, bool session_object_only);

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -799,6 +799,7 @@ enum pkcs11_rc entry_ck_token_initialize(uint32_t ptypes, TEE_Param *params)
 	uint32_t token_id = 0;
 	uint32_t pin_size = 0;
 	void *pin = NULL;
+	struct pkcs11_object *obj = NULL;
 
 	if (ptypes != exp_pt)
 		return PKCS11_CKR_ARGUMENTS_BAD;
@@ -899,6 +900,18 @@ inited:
 				   PKCS11_CKFT_USER_PIN_TO_BE_CHANGED);
 
 	update_persistent_db(token);
+
+	/* Remove all persistent objects */
+	while (!LIST_EMPTY(&token->object_list)) {
+		obj = LIST_FIRST(&token->object_list);
+
+		/* Try twice otherwise panic! */
+		if (unregister_persistent_object(token, obj->uuid) &&
+		    unregister_persistent_object(token, obj->uuid))
+			TEE_Panic(0);
+
+		cleanup_persistent_object(obj, token);
+	}
 
 	IMSG("PKCS11 token %"PRIu32": initialized", token_id);
 


### PR DESCRIPTION
When re-initializing a token the previously created objects need
to be removed.

Signed-off-by: Robin van der Gracht <robin@protonic.nl>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
