### PR TITLE
shippable: remove useless CFG_CORE_ASLR=y for QEMU

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -45,8 +45,8 @@ build:
     - _make CFG_WITH_PAGER=y out/core/tee{,-pager,-pageable}.bin
     - _make CFG_WITH_PAGER=y CFG_CRYPTOLIB_NAME=mbedtls CFG_CRYPTOLIB_DIR=lib/libmbedtls
     - _make CFG_WITH_PAGER=y CFG_WITH_LPAE=y
-    - _make CFG_WITH_LPAE=y CFG_CORE_ASLR=y
-    - _make CFG_RPMB_FS=y CFG_CORE_ASLR=y
+    - _make CFG_WITH_LPAE=y
+    - _make CFG_RPMB_FS=y
     - _make CFG_RPMB_FS=y CFG_RPMB_TESTKEY=y
     - _make CFG_REE_FS=n CFG_RPMB_FS=y
     - _make CFG_WITH_PAGER=y CFG_WITH_LPAE=y CFG_RPMB_FS=y CFG_DT=y CFG_TEE_CORE_LOG_LEVEL=1 CFG_TEE_CORE_DEBUG=y CFG_CC_OPT_LEVEL=0 CFG_DEBUG_INFO=y
@@ -56,7 +56,7 @@ build:
     - _make CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
     - _make CFG_SECURE_DATA_PATH=y
     - _make CFG_REE_FS_TA_BUFFERED=y
-    - _make PLATFORM=vexpress-qemu_armv8a CFG_CORE_ASLR=y
+    - _make PLATFORM=vexpress-qemu_armv8a
     - _make PLATFORM=vexpress-qemu_armv8a COMPILER=clang
     - _make PLATFORM=vexpress-qemu_armv8a CFG_WITH_PAGER=y
     - _make PLATFORM=vexpress-qemu_armv8a CFG_FTRACE_SUPPORT=y CFG_ULIBS_MCOUNT=y CFG_ULIBS_SHARED=y


### PR DESCRIPTION
Since commit 87372da451d4 ("Enable ASLR by default"), most platforms
have ASLR turned on and do not need to explicitly set CFG_CORE_ASLR=y
at build time. Remove the redundant settings in .shippable.yml.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
