### PR TITLE
plat-imx, plat-rzn1: remove redundant recipes to generate tee-raw.bin

### DIFF
--- a/core/arch/arm/plat-imx/link.mk
+++ b/core/arch/arm/plat-imx/link.mk
@@ -1,8 +1,3 @@
 include core/arch/arm/kernel/link.mk
 
 all: $(link-out-dir)/tee-raw.bin
-
-cleanfiles += $(link-out-dir)/tee-raw.bin
-$(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
-	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@

--- a/core/arch/arm/plat-rzn1/link.mk
+++ b/core/arch/arm/plat-rzn1/link.mk
@@ -1,8 +1,3 @@
 include core/arch/arm/kernel/link.mk
 
 all: $(link-out-dir)/tee-raw.bin
-
-cleanfiles += $(link-out-dir)/tee-raw.bin
-$(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
-	@$(cmd-echo-silent) '  GEN     $@'
-	$(q)scripts/gen_tee_bin.py --input $< --out_tee_raw_bin $@


### PR DESCRIPTION
Since commit 5ae0290f7f3b ("core: kernel: link.mk: Move rules to generate
tee-raw.bin and tee.srec from rcar platform"), the recipe to produce
tee-raw.bin is in the common makefile core/arch/arm/kernel/link.mk.
Therefore the recipes in core/arch/arm/plat-imx/link.mk and
core/arch/arm/plat-rzn1/link.mk are redundant and need to be removed.
Fixes the following build warning:

 $ make -s PLATFORM=imx-mx6ullevk
 core/arch/arm/plat-imx/link.mk:7: warning: overriding recipe for target 'out/arm-plat-imx/core/tee-raw.bin'
 core/arch/arm/kernel/link.mk:230: warning: ignoring old recipe for target 'out/arm-plat-imx/core/tee-raw.bin'

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
