### PR TITLE
PKCS#11 Fix persistent db panic when empty

### DIFF
--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -350,16 +350,19 @@ struct ck_token *init_persistent_db(unsigned int token_id)
 		if (res || size != sizeof(*db_objs))
 			TEE_Panic(0);
 
-		size += db_objs->count * sizeof(TEE_UUID);
-		ptr = TEE_Realloc(db_objs, size);
-		if (!ptr)
-			goto error;
+		if (db_objs->count > 0) {
+			size += db_objs->count * sizeof(TEE_UUID);
+			ptr = TEE_Realloc(db_objs, size);
+			if (!ptr)
+				goto error;
 
-		db_objs = ptr;
-		size -= sizeof(*db_objs);
-		res = TEE_ReadObjectData(db_hdl, db_objs->uuids, size, &size);
-		if (res || size != (db_objs->count * sizeof(TEE_UUID)))
-			TEE_Panic(0);
+			db_objs = ptr;
+			size -= sizeof(*db_objs);
+			res = TEE_ReadObjectData(db_hdl, db_objs->uuids, size,
+						 &size);
+			if (res || size != (db_objs->count * sizeof(TEE_UUID)))
+				TEE_Panic(0);
+		}
 
 		for (idx = 0; idx < db_objs->count; idx++) {
 			/* Create an empty object instance */

--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -356,7 +356,7 @@ struct ck_token *init_persistent_db(unsigned int token_id)
 			goto error;
 
 		db_objs = ptr;
-		size -= sizeof(struct token_persistent_objs);
+		size -= sizeof(*db_objs);
 		res = TEE_ReadObjectData(db_hdl, db_objs->uuids, size, &size);
 		if (res || size != (db_objs->count * sizeof(TEE_UUID)))
 			TEE_Panic(0);


### PR DESCRIPTION
See issue #4303.

I added a patch that renames a sizeof() call's argument for consistency.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
