### PR TITLE
core: tee_rpmb_fs: Return error when block decryption fails

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -507,6 +507,7 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 			  const TEE_UUID *uuid)
 {
 	uint8_t *tmp __maybe_unused;
+	TEE_Result res = TEE_SUCCESS;
 
 
 	if ((size + offset < size) || (size + offset > RPMB_DATA_SIZE))
@@ -528,15 +529,16 @@ static TEE_Result decrypt(uint8_t *out, const struct rpmb_data_frame *frm,
 			tmp = malloc(RPMB_DATA_SIZE);
 			if (!tmp)
 				return TEE_ERROR_OUT_OF_MEMORY;
-			decrypt_block(tmp, frm->data, blk_idx, fek, uuid);
-			memcpy(out, tmp + offset, size);
+			res = decrypt_block(tmp, frm->data, blk_idx, fek, uuid);
+			if (res == TEE_SUCCESS)
+				memcpy(out, tmp + offset, size);
 			free(tmp);
 		} else {
-			decrypt_block(out, frm->data, blk_idx, fek, uuid);
+			res = decrypt_block(out, frm->data, blk_idx, fek, uuid);
 		}
 	}
 
-	return TEE_SUCCESS;
+	return res;
 }
 
 static TEE_Result tee_rpmb_req_pack(struct rpmb_req *req,


### PR DESCRIPTION
When decrypt_block fails (although unlikely) it shouldn't be silently ignored.
In such case the data in the buffer pointed to by *out is unmodified or bogus
while the return code is TEE_SUCCESS.

Signed-off-by: Robin van der Gracht <robin@protonic.nl>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
