### PR TITLE
ftrace: fix regression causing panic in ftrace_update_times()

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -943,10 +943,13 @@ void tee_ta_update_session_utime_resume(void)
 #if defined(CFG_FTRACE_SUPPORT)
 static void ftrace_update_times(bool suspend)
 {
-	struct ts_session *s = ts_get_current_session();
+	struct ts_session *s = ts_get_current_session_may_fail();
 	struct ftrace_buf *fbuf = NULL;
 	uint64_t now = 0;
 	uint32_t i = 0;
+
+	if (!s)
+		return;
 
 	now = barrier_read_cntpct();
 


### PR DESCRIPTION
Commit 00b3b9a25e76 ("core: add generic struct ts_session") has
introduced a regression in the ftrace code by introducing a call to
ts_get_current_session() in ftrace_update_times() in replacement of
tee_ta_get_current_session(). At this point it can happen that no
current session exists, in which case the function should simply return.
Unfortunately ts_get_current_session() will call panic() is such a
situation. The proper function is ts_get_current_session_may_fail().

Fixes: 00b3b9a25e76 ("core: add generic struct ts_session")
Fixes: https://github.com/OP-TEE/optee_os/issues/4313
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
