### PR TITLE
ta: fix processing of DT_FINI_ARRAY

### DIFF
--- a/lib/libutee/arch/arm/user_ta_entry.c
+++ b/lib/libutee/arch/arm/user_ta_entry.c
@@ -137,7 +137,7 @@ static int _fini_iterate_phdr_cb(struct dl_phdr_info *info,
 	size_t num_fn = 0;
 	size_t i = 0;
 
-	_get_fn_array(info, DT_INIT_ARRAY, DT_FINI_ARRAYSZ, &fn, &num_fn);
+	_get_fn_array(info, DT_FINI_ARRAY, DT_FINI_ARRAYSZ, &fn, &num_fn);
 
 	for (i = 1; i <= num_fn; i++)
 		fn[num_fn - i]();


### PR DESCRIPTION
The code that is supposed to invoke the finalization functions in the
DT_FINI_ARRAY of a TA is broken. It mixes DT_INIT_ARRAY with
DT_FINI_ARRAYSZ. As a result, the finalization functions are never
called and the TA may even crash on exit.

Fix the issue by replacing the erroneous DT_INIT_ARRAY with
DT_FINI_ARRAY.

Fixes: dd655cb9906c ("ldelf, ta: add support for DT_INIT_ARRAY and DT_FINI_ARRAY")
Reported-by: JY Ho <JY.Ho@mediatek.com>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
