### PR TITLE
core: fix file handle leakage in syscall_storage_next_enum()

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -756,7 +756,10 @@ TEE_Result syscall_storage_next_enum(unsigned long obj_enum,
 
 exit:
 	if (o) {
-		tee_pobj_release(o->pobj);
+		if (o->pobj) {
+			o->pobj->fops->close(&o->fh);
+			tee_pobj_release(o->pobj);
+		}
 		tee_obj_free(o);
 	}
 


### PR DESCRIPTION
Prior to this patch was syscall_storage_next_enum() opening a file
handle with tee_svc_storage_read_head() but never freeing the handle.
Fix this by closing the file handle as part of cleaning up before
returning.

Fixes: 928efd065222 ("core: syscall_storage_next_enum() use live pobj")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
