### PR TITLE
core: fix bad memset() in update_write_helper()

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2398,6 +2398,7 @@ static TEE_Result update_write_helper(struct rpmb_file_handle *fh,
 		size_t rd_size = 0;
 
 		blk_size = MIN(TMP_BLOCK_SIZE, new_size - blk_offset);
+		memset(blk_buf, 0, blk_size);
 
 		/* Possibly read old RPMB data in temporary buffer */
 		if (blk_offset < pos && blk_offset < old_size) {
@@ -2430,12 +2431,6 @@ static TEE_Result update_write_helper(struct rpmb_file_handle *fh,
 			memcpy(copy_dst, rem_buf, copy_size);
 			rem_buf += copy_size;
 			rem_size -= copy_size;
-
-			/* Extend from read data to copied data with zeros */
-			memset(blk_buf + rd_size, 0, offset - rd_size);
-		} else {
-			/* Extend from read data to block end with zeros */
-			memset(blk_buf + rd_size, 0, blk_size - rd_size);
 		}
 
 		/* Write temporary buffer to new RPMB destination */


### PR DESCRIPTION
update_write_helper() is clearing uninitialized parts of blk_buf.
There's an error in the logic calculating how much should be cleared
resulting in a negative size being supplied to memset(). Fix this by
always clearing blk_buf before usage.

Fixes: cd799689cd3d ("core: rpmb: fix initialization of new rpmb data")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
