### PR TITLE
ta: link.mk: export trace_ext_prefix and trace_level

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -42,6 +42,8 @@ $(link-out-dir$(sm))/dyn_list:
 ifeq ($(CFG_FTRACE_SUPPORT),y)
 	$(q)echo "__ftrace_info;" >>$@
 endif
+	$(q)echo "trace_ext_prefix;" >>$@
+	$(q)echo "trace_level;" >>$@
 	$(q)echo "};" >>$@
 link-ldflags += --dynamic-list $(link-out-dir$(sm))/dyn_list
 dynlistdep = $(link-out-dir$(sm))/dyn_list


### PR DESCRIPTION
Global data defined in user_ta_header.c need to be made visible to
shared libraries because they may be referenced by them. For example,
trace_level is ultimately referenced by the trace macros (IMSG() and
similar). Therefore, when IMSG() is called in a shared library, the
dynamic loader (ldelf) needs to locate the trace_level symbol in the
TA. But since a TA is a "main executable" and not a shared library,
the linker by default will not add all global symbols to the dynamic
symbol table (.dynsym section). Instead those symbols are put in the
static symbol table (.symtab) which is typically not used at run time
and discarded when executables are stripped. In any case, ldelf only
uses the dynamic symbol table.

Add trace_ext_prefix and trace_level to the list of exported symbols to
fix the IMSG() issue.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
