### PR TITLE
core: imx: remove security check for i.MX6DQ

### DIFF
--- a/core/arch/arm/plat-imx/drivers/imx_snvs.c
+++ b/core/arch/arm/plat-imx/drivers/imx_snvs.c
@@ -18,11 +18,11 @@ bool plat_rpmb_key_is_ready(void)
 		      mode == SNVS_SSM_MODE_SECURE);
 
 	/*
-	 * On i.MX6SDL, the security cfg always returns
+	 * On i.MX6SDL and i.MX6DQ, the security cfg always returns
 	 * SNVS_SECURITY_CFG_FAB (000), therefore we ignore the security
 	 * configuration for this SoC.
 	 */
-	if (soc_is_imx6sdl())
+	if (soc_is_imx6sdl() || soc_is_imx6dq())
 		return ssm_secure;
 
 	return ssm_secure && (security == SNVS_SECURITY_CFG_CLOSED);


### PR DESCRIPTION
Recent commit cfff3778 ("core: imx: remove security check for i.MX6SDL")
fixed an issue where i.MX6SDL SoC does not expose the security
configuration in the HPSR registers correctly.

This issue also affects i.MX6DQ. Let's add a check for this SoC
family in the same place.

Signed-off-by: Michael Scott <mike@foundries.io>
Signed-off-by: Ricardo Salveti <ricardo@foundries.io>