### PR TITLE
ta: pkcs11: Load persistent object attributes during db initialization

### DIFF
--- a/ta/pkcs11/src/attributes.c
+++ b/ta/pkcs11/src/attributes.c
@@ -215,8 +215,8 @@ bool attributes_match_reference(struct obj_attrs *candidate,
 	uint32_t rc = PKCS11_CKR_GENERAL_ERROR;
 
 	if (!ref->attrs_count) {
-		DMSG("Empty reference: no match");
-		return false;
+		DMSG("Empty reference match all");
+		return true;
 	}
 
 	for (count = 0; count < ref->attrs_count; count++) {

--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -428,88 +428,6 @@ enum pkcs11_rc entry_destroy_object(struct pkcs11_client *client,
 	return rc;
 }
 
-static enum pkcs11_rc token_obj_matches_ref(struct obj_attrs *req_attrs,
-					    struct pkcs11_object *obj)
-{
-	enum pkcs11_rc rc = PKCS11_CKR_GENERAL_ERROR;
-	TEE_Result res = TEE_ERROR_GENERIC;
-	TEE_ObjectHandle hdl = obj->attribs_hdl;
-	TEE_ObjectInfo info = { };
-	struct obj_attrs *attr = NULL;
-	uint32_t read_bytes = 0;
-
-	if (obj->attributes) {
-		if (!attributes_match_reference(obj->attributes, req_attrs))
-			return PKCS11_RV_NOT_FOUND;
-
-		return PKCS11_CKR_OK;
-	}
-
-	if (hdl == TEE_HANDLE_NULL) {
-		res = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
-					       obj->uuid, sizeof(*obj->uuid),
-					       TEE_DATA_FLAG_ACCESS_READ,
-					       &hdl);
-		if (res) {
-			EMSG("OpenPersistent failed %#"PRIx32, res);
-			return tee2pkcs_error(res);
-		}
-	}
-
-	res = TEE_GetObjectInfo1(hdl, &info);
-	if (res) {
-		EMSG("GetObjectInfo failed %#"PRIx32, res);
-		rc = tee2pkcs_error(res);
-		goto out;
-	}
-
-	attr = TEE_Malloc(info.dataSize, TEE_MALLOC_FILL_ZERO);
-	if (!attr) {
-		rc = PKCS11_CKR_DEVICE_MEMORY;
-		goto out;
-	}
-
-	res = TEE_ReadObjectData(hdl, attr, info.dataSize, &read_bytes);
-	if (!res) {
-		res = TEE_SeekObjectData(hdl, 0, TEE_DATA_SEEK_SET);
-		if (res)
-			EMSG("Seek to 0 failed with %#"PRIx32, res);
-	}
-
-	if (res) {
-		rc = tee2pkcs_error(res);
-		EMSG("Read %"PRIu32" bytes, failed %#"PRIx32,
-		     read_bytes, res);
-		goto out;
-	}
-
-	if (read_bytes != info.dataSize) {
-		EMSG("Read %"PRIu32" bytes, expected %"PRIu32,
-		     read_bytes, info.dataSize);
-		rc = PKCS11_CKR_GENERAL_ERROR;
-		goto out;
-	}
-
-	if (!attributes_match_reference(attr, req_attrs)) {
-		rc = PKCS11_RV_NOT_FOUND;
-		goto out;
-	}
-
-	obj->attributes = attr;
-	attr = NULL;
-	obj->attribs_hdl = hdl;
-	hdl = TEE_HANDLE_NULL;
-
-	rc = PKCS11_CKR_OK;
-
-out:
-	TEE_Free(attr);
-	if (obj->attribs_hdl == TEE_HANDLE_NULL)
-		TEE_CloseObject(hdl);
-
-	return rc;
-}
-
 static void release_find_obj_context(struct pkcs11_find_objects *find_ctx)
 {
 	if (!find_ctx)
@@ -624,8 +542,7 @@ enum pkcs11_rc entry_find_objects_init(struct pkcs11_client *client,
 		if (check_access_attrs_against_token(session, obj->attributes))
 			continue;
 
-		if (req_attrs->attrs_count &&
-		    !attributes_match_reference(obj->attributes, req_attrs))
+		if (!attributes_match_reference(obj->attributes, req_attrs))
 			continue;
 
 		rc = find_ctx_add(find_ctx, pkcs11_object2handle(obj, session));
@@ -635,16 +552,24 @@ enum pkcs11_rc entry_find_objects_init(struct pkcs11_client *client,
 
 	LIST_FOREACH(obj, &session->token->object_list, link) {
 		uint32_t handle = 0;
+		bool new_load = false;
 
-		if (check_access_attrs_against_token(session, obj->attributes))
+		if (!obj->attributes) {
+			rc = load_persistent_object_attributes(obj);
+			if (rc)
+				return PKCS11_CKR_GENERAL_ERROR;
+
+			new_load = true;
+		}
+
+		if (!obj->attributes ||
+		    check_access_attrs_against_token(session,
+						     obj->attributes) ||
+		    !attributes_match_reference(obj->attributes, req_attrs)) {
+			if (new_load)
+				release_persistent_object_attributes(obj);
+
 			continue;
-
-		if (req_attrs->attrs_count) {
-			rc = token_obj_matches_ref(req_attrs, obj);
-			if (rc == PKCS11_RV_NOT_FOUND)
-				continue;
-			if (rc != PKCS11_CKR_OK)
-				goto out;
 		}
 
 		/* Object may not yet be published in the session */

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -203,6 +203,10 @@ struct ck_token *init_persistent_db(unsigned int token_id);
 void update_persistent_db(struct ck_token *token);
 void close_persistent_db(struct ck_token *token);
 
+/* Load and release persistent object attributes in memory */
+enum pkcs11_rc load_persistent_object_attributes(struct pkcs11_object *obj);
+void release_persistent_object_attributes(struct pkcs11_object *obj);
+
 enum pkcs11_rc hash_pin(enum pkcs11_user_type user, const uint8_t *pin,
 			size_t pin_size, uint32_t *salt,
 			uint8_t hash[TEE_MAX_HASH_SIZE]);


### PR DESCRIPTION
Persistent object attributes are now loaded during the first find
operation. This means that you're forced to do a find operation to make
the objects attributes available.

Right now entry_find_objects_init is broken in such that it tries to
access the obj->attributes for objects in the session->token->object_list
before setting the obj->attributes (by calling token_obj_matches_ref).
This results in a Panic.

This patch fixes both issues.

Signed-off-by: Robin van der Gracht <robin@protonic.nl>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
