### PR TITLE
core: optee_rpc_cmd.h: shorten some I2C defines

### DIFF
--- a/core/include/kernel/rpc_io_i2c.h
+++ b/core/include/kernel/rpc_io_i2c.h
@@ -11,12 +11,12 @@
 
 /* I2C master transfer mode */
 enum rpc_i2c_mode {
-	RPC_I2C_MODE_WRITE = OPTEE_MSG_RPC_CMD_I2C_TRANSFER_WR,
-	RPC_I2C_MODE_READ = OPTEE_MSG_RPC_CMD_I2C_TRANSFER_RD,
+	RPC_I2C_MODE_WRITE = OPTEE_RPC_I2C_TRANSFER_WR,
+	RPC_I2C_MODE_READ = OPTEE_RPC_I2C_TRANSFER_RD,
 };
 
 /* I2C master transfer control flags */
-#define RPC_I2C_FLAGS_TEN_BIT	OPTEE_MSG_RPC_CMD_I2C_FLAGS_TEN_BIT
+#define RPC_I2C_FLAGS_TEN_BIT	OPTEE_RPC_I2C_FLAGS_TEN_BIT
 
 /*
  * The bus identifier defines an implicit ABI with the REE.

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2016-2017, Linaro Limited
+ * Copyright (c) 2016-2021, Linaro Limited
  */
 
 #ifndef __OPTEE_RPC_CMD_H
@@ -151,7 +151,7 @@
 /*
  * Issue master requests (read and write operations) to an I2C chip.
  *
- * [in]     value[0].a	    Transfer mode (OPTEE_MSG_RPC_CMD_I2C_TRANSFER_*)
+ * [in]     value[0].a	    Transfer mode (OPTEE_RPC_I2C_TRANSFER_*)
  * [in]     value[0].b	    The I2C bus (a.k.a adapter).
  *				16 bit field.
  * [in]     value[0].c	    The I2C chip (a.k.a address).
@@ -164,11 +164,11 @@
 #define OPTEE_RPC_CMD_I2C_TRANSFER	21
 
 /* I2C master transfer modes */
-#define OPTEE_MSG_RPC_CMD_I2C_TRANSFER_RD	0
-#define OPTEE_MSG_RPC_CMD_I2C_TRANSFER_WR	1
+#define OPTEE_RPC_I2C_TRANSFER_RD	0
+#define OPTEE_RPC_I2C_TRANSFER_WR	1
 
 /* I2C master control flags */
-#define OPTEE_MSG_RPC_CMD_I2C_FLAGS_TEN_BIT	BIT(0)
+#define OPTEE_RPC_I2C_FLAGS_TEN_BIT	BIT(0)
 
 /*
  * Definition of protocol for command OPTEE_RPC_CMD_FS


### PR DESCRIPTION
Make the I2C defines consistent with the rest of the defines in
optee_rpc_cmd.h.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
