### PR TITLE
lib: libutils: ext/isoc: sub.mk: make sources path platform generic

### DIFF
--- a/lib/libutils/ext/sub.mk
+++ b/lib/libutils/ext/sub.mk
@@ -9,5 +9,5 @@ srcs-y += nex_strdup.c
 srcs-y += consttime_memcmp.c
 srcs-y += memzero_explicit.c
 
-subdirs-$(arch_arm) += arch/$(ARCH)
+subdirs-y += arch/$(ARCH)
 subdirs-y += ftrace

--- a/lib/libutils/isoc/sub.mk
+++ b/lib/libutils/isoc/sub.mk
@@ -37,4 +37,4 @@ srcs-y += write.c
 endif
 
 subdirs-y += newlib
-subdirs-$(arch_arm) += arch/$(ARCH)
+subdirs-y += arch/$(ARCH)


### PR DESCRIPTION
The path to platform specifc code is hard-coded. This commit
changes it to use defined variable. This is helpful in case
of porting OP-TEE OS to a new architecture such we make
maximum reuse of existing sources.

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
