### PR TITLE
ta: pkcs11: Add support for modifying and copying objects

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -526,6 +526,24 @@ enum pkcs11_ta_cmd {
 	 */
 	PKCS11_CMD_SET_ATTRIBUTE_VALUE = 39,
 
+	/*
+	 * PKCS11_CMD_COPY_OBJECT - Copies an object, creating a new object for
+	 *			    the copy.
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit session handle,
+	 *              32bit object handle,
+	 *              (struct pkcs11_object_head)attribs + attributes data
+	 *	 ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = 32bit object handle
+	 *
+	 * This command relates to the PKCS#11 API function C_CopyObject().
+	 * Caller provides an attribute template as 3rd argument in memref[0]
+	 * (referred here as attribs + attributes data).
+	 */
+	PKCS11_CMD_COPY_OBJECT = 40,
+
 };
 
 /*

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -509,6 +509,23 @@ enum pkcs11_ta_cmd {
 	 * attribs + attributes data).
 	 */
 	PKCS11_CMD_GET_ATTRIBUTE_VALUE = 38,
+
+	/*
+	 * PKCS11_CMD_SET_ATTRIBUTE_VALUE - Set the value of object attribute(s)
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit session handle,
+	 *              32bit object handle,
+	 *              (struct pkcs11_object_head)attribs + attributes data
+	 *	 ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 *
+	 * This command relates to the PKCS#11 API function C_SetAttributeValue.
+	 * Caller provides an attribute template as 3rd argument in memref[0]
+	 * (referred here as attribs + attributes data).
+	 */
+	PKCS11_CMD_SET_ATTRIBUTE_VALUE = 39,
+
 };
 
 /*

--- a/ta/pkcs11/src/attributes.h
+++ b/ta/pkcs11/src/attributes.h
@@ -159,6 +159,33 @@ enum pkcs11_rc get_attribute(struct obj_attrs *head, uint32_t attribute,
 			     void *attr, uint32_t *attr_size);
 
 /*
+ * set_attribute() - Set the attribute of a given ID with value
+ * @head:	Pointer to serialized attributes where attribute is to be set,
+ *		can be relocated as attributes are modified/added
+ * @attribute:	Attribute ID to look for
+ * @data:	Holds the attribute value to be set
+ * @size:	Size of the attribute value
+ *
+ * Return PKCS11_CKR_OK on success or a PKCS11 return code.
+ */
+enum pkcs11_rc set_attribute(struct obj_attrs **head, uint32_t attribute,
+			     void *data, size_t size);
+
+/*
+ * modify_attributes_list() - Modify the value of attributes in destination
+ * attribute list (serialized attributes) based on the value of attributes in
+ * the source attribute list
+ * @dst:	Pointer to serialized attrbutes where attributes are to be
+ *		modified, can be relocated as attributes are modified
+ * @head:	Serialized attributes containing attributes which need to be
+ *		modified in the destination attribute list
+ *
+ * Return PKCS11_CKR_OK on success
+ */
+enum pkcs11_rc modify_attributes_list(struct obj_attrs **dst,
+				      struct obj_attrs *head);
+
+/*
  * get_u32_attribute() - Copy out the 32-bit attribute value of a given ID
  * @head:	Pointer to serialized attributes
  * @attribute:	Attribute ID

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -306,6 +306,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 	case PKCS11_CMD_SET_ATTRIBUTE_VALUE:
 		rc = entry_set_attribute_value(client, ptypes, params);
 		break;
+	case PKCS11_CMD_COPY_OBJECT:
+		rc = entry_copy_object(client, ptypes, params);
+		break;
 	default:
 		EMSG("Command %#"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -303,6 +303,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 	case PKCS11_CMD_GET_OBJECT_SIZE:
 		rc = entry_get_object_size(client, ptypes, params);
 		break;
+	case PKCS11_CMD_SET_ATTRIBUTE_VALUE:
+		rc = entry_set_attribute_value(client, ptypes, params);
+		break;
 	default:
 		EMSG("Command %#"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -902,3 +902,108 @@ uint32_t entry_get_object_size(struct pkcs11_client *client,
 
 	return PKCS11_CKR_OK;
 }
+
+enum pkcs11_rc entry_set_attribute_value(struct pkcs11_client *client,
+					 uint32_t ptypes, TEE_Param *params)
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Param *ctrl = params;
+	enum pkcs11_rc rc = PKCS11_CKR_GENERAL_ERROR;
+	struct serialargs ctrlargs = { };
+	struct pkcs11_session *session = NULL;
+	struct pkcs11_object_head *template = NULL;
+	size_t template_size = 0;
+	struct pkcs11_object *obj = NULL;
+	struct obj_attrs *head = NULL;
+	uint32_t object_handle = 0;
+	enum processing_func function = PKCS11_FUNCTION_MODIFY;
+
+	if (!client || ptypes != exp_pt)
+		return PKCS11_CKR_ARGUMENTS_BAD;
+
+	serialargs_init(&ctrlargs, ctrl->memref.buffer, ctrl->memref.size);
+
+	rc = serialargs_get_session_from_handle(&ctrlargs, client, &session);
+	if (rc)
+		return rc;
+
+	rc = serialargs_get(&ctrlargs, &object_handle, sizeof(uint32_t));
+	if (rc)
+		return rc;
+
+	rc = serialargs_alloc_get_attributes(&ctrlargs, &template);
+	if (rc)
+		return rc;
+
+	if (serialargs_remaining_bytes(&ctrlargs)) {
+		rc = PKCS11_CKR_ARGUMENTS_BAD;
+		goto out;
+	}
+
+	obj = pkcs11_handle2object(object_handle, session);
+	if (!obj) {
+		rc = PKCS11_CKR_OBJECT_HANDLE_INVALID;
+		goto out;
+	}
+
+	/* Only session objects can be modified during a read-only session */
+	if (object_is_token(obj->attributes) &&
+	    !pkcs11_session_is_read_write(session)) {
+		DMSG("Can't modify persistent object in a RO session");
+		rc = PKCS11_CKR_SESSION_READ_ONLY;
+		goto out;
+	}
+
+	/*
+	 * Only public objects can be modified unless normal user is logged in
+	 */
+	rc = check_access_attrs_against_token(session, obj->attributes);
+	if (rc) {
+		rc = PKCS11_CKR_USER_NOT_LOGGED_IN;
+		goto out;
+	}
+
+	/* Objects with PKCS11_CKA_MODIFIABLE as false aren't modifiable */
+	if (!object_is_modifiable(obj->attributes)) {
+		rc = PKCS11_CKR_ACTION_PROHIBITED;
+		goto out;
+	}
+
+	template_size = sizeof(*template) + template->attrs_size;
+
+	/*
+	 * Prepare a clean initial state (@head) for the template. Helps in
+	 * removing any duplicates or inconsistent values from the
+	 * template.
+	 */
+	rc = create_attributes_from_template(&head, template, template_size,
+					     NULL, function,
+					     PKCS11_CKM_UNDEFINED_ID,
+					     PKCS11_CKO_UNDEFINED_ID);
+	if (rc)
+		goto out;
+
+	/* Check the attributes in @head to see if they are modifiable */
+	rc = check_attrs_against_modification(session, head, obj, function);
+	if (rc)
+		goto out;
+
+	/*
+	 * All checks complete. The attributes in @head have been checked and
+	 * can now be used to set/modify the object attributes.
+	 */
+	rc = modify_attributes_list(&obj->attributes, head);
+	if (rc)
+		goto out;
+
+	DMSG("PKCS11 session %"PRIu32": set attributes %#"PRIx32,
+	     session->handle, object_handle);
+
+out:
+	TEE_Free(head);
+	TEE_Free(template);
+	return rc;
+}

--- a/ta/pkcs11/src/object.h
+++ b/ta/pkcs11/src/object.h
@@ -76,6 +76,9 @@ enum pkcs11_rc entry_get_attribute_value(struct pkcs11_client *client,
 enum pkcs11_rc entry_get_object_size(struct pkcs11_client *client,
 				     uint32_t ptypes, TEE_Param *params);
 
+enum pkcs11_rc entry_set_attribute_value(struct pkcs11_client *client,
+					 uint32_t ptypes, TEE_Param *params);
+
 void release_session_find_obj_context(struct pkcs11_session *session);
 
 #endif /*PKCS11_TA_OBJECT_H*/

--- a/ta/pkcs11/src/object.h
+++ b/ta/pkcs11/src/object.h
@@ -79,6 +79,9 @@ enum pkcs11_rc entry_get_object_size(struct pkcs11_client *client,
 enum pkcs11_rc entry_set_attribute_value(struct pkcs11_client *client,
 					 uint32_t ptypes, TEE_Param *params);
 
+enum pkcs11_rc entry_copy_object(struct pkcs11_client *client, uint32_t ptypes,
+				 TEE_Param *params);
+
 void release_session_find_obj_context(struct pkcs11_session *session);
 
 #endif /*PKCS11_TA_OBJECT_H*/

--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -1562,6 +1562,13 @@ enum pkcs11_rc check_attrs_against_modification(struct pkcs11_session *session,
 				     pkcs11_session_is_so(session)))
 					return PKCS11_CKR_USER_NOT_LOGGED_IN;
 			}
+
+			/*
+			 * Restriction added - Even for Copy, do not allow
+			 * modification of CKA_PRIVATE from TRUE to FALSE
+			 */
+			if (parent_priv && !obj_priv)
+				return PKCS11_CKR_TEMPLATE_INCONSISTENT;
 		}
 	}
 

--- a/ta/pkcs11/src/pkcs11_attributes.h
+++ b/ta/pkcs11/src/pkcs11_attributes.h
@@ -165,4 +165,22 @@ bool attribute_is_exportable(struct pkcs11_attribute_head *req_attr,
 
 bool object_is_private(struct obj_attrs *head);
 
+bool object_is_token(struct obj_attrs *head);
+
+bool object_is_modifiable(struct obj_attrs *head);
+
+bool object_is_copyable(struct obj_attrs *head);
+
+/*
+ * Check the attributes passed in template against the attributes which can be
+ * modified. These are the attributes marked with * 8,10,11 or 12 in Table 10
+ * in PKCS #11 Cryptographic Token InterfaceBase Specification Version 2.40.
+ * Few attributes not with this marking but explicitly specified as modifiable
+ * in footnote of their tables are also considered to be modifiable
+ */
+enum pkcs11_rc check_attrs_against_modification(struct pkcs11_session *session,
+						struct obj_attrs *head,
+						struct pkcs11_object *obj,
+						enum processing_func function);
+
 #endif /*PKCS11_TA_PKCS11_ATTRIBUTES_H*/

--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -177,6 +177,7 @@ static const struct any_id __maybe_unused string_ta_cmd[] = {
 	PKCS11_ID(PKCS11_CMD_GET_OBJECT_SIZE),
 	PKCS11_ID(PKCS11_CMD_GET_ATTRIBUTE_VALUE),
 	PKCS11_ID(PKCS11_CMD_SET_ATTRIBUTE_VALUE),
+	PKCS11_ID(PKCS11_CMD_COPY_OBJECT),
 };
 
 static const struct any_id __maybe_unused string_slot_flags[] = {

--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -176,6 +176,7 @@ static const struct any_id __maybe_unused string_ta_cmd[] = {
 	PKCS11_ID(PKCS11_CMD_FIND_OBJECTS_FINAL),
 	PKCS11_ID(PKCS11_CMD_GET_OBJECT_SIZE),
 	PKCS11_ID(PKCS11_CMD_GET_ATTRIBUTE_VALUE),
+	PKCS11_ID(PKCS11_CMD_SET_ATTRIBUTE_VALUE),
 };
 
 static const struct any_id __maybe_unused string_slot_flags[] = {


### PR DESCRIPTION
Implement commands
- PKCS11_CMD_SET_ATTRIBUTE_VALUE
- PKCS11_CMD_COPY_OBJECT

optee_client :
https://github.com/OP-TEE/optee_client/pull/251

For testing I have currently used google pkcs11test and softhsm unit tests.
I will also be submitting tests to optee_test repo.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
