### PR TITLE
ta: pkcs11: relocate shared session object db to client session

### DIFF
--- a/ta/pkcs11/src/object.h
+++ b/ta/pkcs11/src/object.h
@@ -20,6 +20,7 @@ struct pkcs11_session;
  * attributes: pointer to the serialized object attributes
  * key_handle: GPD TEE object handle if used in an operation
  * key_type: GPD TEE key type (shortcut used for processing)
+ * token: associated token for the object
  * uuid: object UUID in the persistent database if a persistent object, or NULL
  * attribs_hdl: GPD TEE attributes handles if persistent object
  */
@@ -28,6 +29,7 @@ struct pkcs11_object {
 	struct obj_attrs *attributes;
 	TEE_ObjectHandle key_handle;
 	uint32_t key_type;
+	struct ck_token *token;
 	TEE_UUID *uuid;
 	TEE_ObjectHandle attribs_hdl;
 };
@@ -41,7 +43,8 @@ uint32_t pkcs11_object2handle(struct pkcs11_object *obj,
 			      struct pkcs11_session *session);
 
 struct pkcs11_object *create_token_object(struct obj_attrs *head,
-					  TEE_UUID *uuid);
+					  TEE_UUID *uuid,
+					  struct ck_token *token);
 
 enum pkcs11_rc create_object(void *session, struct obj_attrs *attributes,
 			     uint32_t *handle);

--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -316,6 +316,8 @@ enum pkcs11_rc create_object_uuid(struct ck_token *token,
 	if (!obj->uuid)
 		return PKCS11_CKR_DEVICE_MEMORY;
 
+	obj->token = token;
+
 	do {
 		TEE_GenerateRandom(obj->uuid, sizeof(TEE_UUID));
 	} while (get_persistent_obj_idx(token, obj->uuid) >= 0);
@@ -637,7 +639,7 @@ struct ck_token *init_persistent_db(unsigned int token_id)
 
 			TEE_MemMove(uuid, &db_objs->uuids[idx], sizeof(*uuid));
 
-			obj = create_token_object(NULL, uuid);
+			obj = create_token_object(NULL, uuid, token);
 			if (!obj)
 				TEE_Panic(0);
 

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -171,7 +171,6 @@ struct pkcs11_find_objects {
  * @token - Token this session belongs to
  * @handle - Identifier of the session published to the client
  * @object_list - Entry of the session objects list
- * @object_handle_db - Database for object handles published by the session
  * @state - R/W SO, R/W user, RO user, R/W public, RO public.
  * @processing - Reference to initialized processing context if any
  * @find_ctx - Reference to active search context (null if no active search)
@@ -182,7 +181,6 @@ struct pkcs11_session {
 	struct ck_token *token;
 	enum pkcs11_mechanism_id handle;
 	struct object_list object_list;
-	struct handle_db object_handle_db;
 	enum pkcs11_session_state state;
 	struct active_processing *processing;
 	struct pkcs11_find_objects *find_ctx;
@@ -197,6 +195,9 @@ struct ck_token *get_token(unsigned int token_id);
 
 /* Return token identified from token instance address */
 unsigned int get_token_id(struct ck_token *token);
+
+/* Return client's (shared) object handle database associated with session */
+struct handle_db *get_object_handle_db(struct pkcs11_session *session);
 
 /* Access to persistent database */
 struct ck_token *init_persistent_db(unsigned int token_id);
@@ -261,6 +262,7 @@ enum pkcs11_rc get_persistent_objects_list(struct ck_token *token,
 /*
  * Pkcs11 session support
  */
+struct session_list *get_session_list(struct pkcs11_session *session);
 struct pkcs11_client *tee_session2client(void *tee_session);
 struct pkcs11_client *register_client(void);
 void unregister_client(struct pkcs11_client *client);


### PR DESCRIPTION
PKCS11 has concept of shared objects between different PKCS11 sessions
which need to work.

As in OP-TEE context there can be multiple callers which should not share
the objects use OP-TEE client session association to separate those from
each other.

Specified in:
PKCS #11 Cryptographic Token Interface Usage Guide Version 2.40
2.6 Sessions

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
