### PR TITLE
ta/pkcs11: Use LIST_FOREACH_SAFE when removing objects from list

### DIFF
--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -1286,6 +1286,7 @@ static void session_logout(struct pkcs11_session *session)
 
 	TAILQ_FOREACH(sess, &client->session_list, link) {
 		struct pkcs11_object *obj = NULL;
+		struct pkcs11_object *tobj = NULL;
 		uint32_t handle = 0;
 
 		if (sess->token != session->token)
@@ -1294,7 +1295,7 @@ static void session_logout(struct pkcs11_session *session)
 		release_active_processing(session);
 
 		/* Destroy private session objects */
-		LIST_FOREACH(obj, &sess->object_list, link) {
+		LIST_FOREACH_SAFE(obj, &sess->object_list, link, tobj) {
 			if (object_is_private(obj->attributes))
 				destroy_object(sess, obj, true);
 		}


### PR DESCRIPTION
When traversing object list to remove objects, use LIST_FOREACH_SAFE
to avoid segmentation fault.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
