### PR TITLE
Paged IV and Tags state for RW paged mappings used for user TAs

### DIFF
--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2015-2021, Linaro Limited
  */
 
 #ifndef KERNEL_ABORT_H
@@ -33,6 +33,8 @@ void abort_print_error(struct abort_info *ai);
 void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs);
 
 bool abort_is_user_exception(struct abort_info *ai);
+
+bool abort_is_write_fault(struct abort_info *ai);
 
 /* Called from a normal thread */
 void abort_print_current_ts(void);

--- a/core/arch/arm/include/mm/tee_pager.h
+++ b/core/arch/arm/include/mm/tee_pager.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2016, Linaro Limited
+ * Copyright (c) 2016-2021, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  */
 
@@ -69,6 +69,17 @@ void *tee_pager_phys_to_virt(paddr_t pa);
  * Panics if called twice or some other error occurs.
  */
 void tee_pager_set_alias_area(tee_mm_entry_t *mm_alias);
+
+/*
+ * tee_pager_init_iv_area() - Inialized pager area for tags IVs used by RW
+ *			      paged fobjs
+ * @fobj:	fobj backing the area
+ *
+ * Panics if called twice or some other error occurs.
+ *
+ * Returns virtual address of start of IV area.
+ */
+vaddr_t tee_pager_init_iv_area(struct fobj *fobj);
 
 /*
  * tee_pager_generate_authenc_key() - Generates authenc key for r/w paging

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2015-2021, Linaro Limited
  */
 
 #include <arm.h>
@@ -440,6 +440,19 @@ static bool is_vfp_fault(struct abort_info *ai __unused)
 	return false;
 }
 #endif  /*CFG_WITH_VFP && CFG_WITH_USER_TA*/
+
+bool abort_is_write_fault(struct abort_info *ai)
+{
+#ifdef ARM32
+	unsigned int write_not_read = 11;
+#endif
+#ifdef ARM64
+	unsigned int write_not_read = 6;
+#endif
+
+	return ai->abort_type == ABORT_TYPE_DATA &&
+	       (ai->fault_descr & BIT(write_not_read));
+}
 
 static enum fault_type get_fault_type(struct abort_info *ai)
 {

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2016, Linaro Limited
+ * Copyright (c) 2016-2021, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2020-2021, Arm Limited
  */
@@ -65,7 +65,8 @@ struct thread_core_local thread_core_local[CFG_TEE_CORE_NB_CORE] __nex_bss;
 #endif
 #define STACK_THREAD_SIZE	8192
 
-#if defined(CFG_CORE_SANITIZE_KADDRESS) || defined(__clang__)
+#if defined(CFG_CORE_SANITIZE_KADDRESS) || defined(__clang__) || \
+	!defined(CFG_CRYPTO_WITH_CE)
 #define STACK_ABT_SIZE		3072
 #else
 #define STACK_ABT_SIZE		2048

--- a/core/include/mm/fobj.h
+++ b/core/include/mm/fobj.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2019-2021, Linaro Limited
  */
 
 #ifndef __MM_FOBJ_H
@@ -30,10 +30,12 @@ struct fobj {
 
 /*
  * struct fobj_ops - operations struct for struct fobj
- * @free:	Frees the @fobj
- * @load_page:	Loads page with index @page_idx at address @va
- * @save_page:	Saves page with index @page_idx from address @va
- * @get_pa:	Returns physical address of page at @page_idx if not paged
+ * @free:	  Frees the @fobj
+ * @load_page:	  Loads page with index @page_idx at address @va
+ * @save_page:	  Saves page with index @page_idx from address @va
+ * @get_iv_vaddr: Returns virtual address of tag and IV for the page at
+ *		  @page_idx if tag and IV are paged for this fobj
+ * @get_pa:	  Returns physical address of page at @page_idx if not paged
  */
 struct fobj_ops {
 	void (*free)(struct fobj *fobj);
@@ -42,6 +44,7 @@ struct fobj_ops {
 				void *va);
 	TEE_Result (*save_page)(struct fobj *fobj, unsigned int page_idx,
 				const void *va);
+	vaddr_t (*get_iv_vaddr)(struct fobj *fobj, unsigned int page_idx);
 #endif
 	paddr_t (*get_pa)(struct fobj *fobj, unsigned int page_idx);
 };
@@ -137,6 +140,15 @@ static inline TEE_Result fobj_save_page(struct fobj *fobj,
 		return fobj->ops->save_page(fobj, page_idx, va);
 
 	return TEE_ERROR_GENERIC;
+}
+
+static inline vaddr_t fobj_get_iv_vaddr(struct fobj *fobj,
+					unsigned int page_idx)
+{
+	if (fobj && fobj->ops->get_iv_vaddr)
+		return fobj->ops->get_iv_vaddr(fobj, page_idx);
+
+	return 0;
 }
 #endif
 

--- a/core/mm/fobj.c
+++ b/core/mm/fobj.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2019-2021, Linaro Limited
  */
 
 #include <crypto/crypto.h>
@@ -33,36 +33,34 @@ struct rwp_state {
 	uint8_t tag[RWP_AES_GCM_TAG_LEN];
 };
 
-struct fobj_rwp {
+/*
+ * Note that this struct is padded to a size which is a power of 2, this
+ * guarantees that this state will not span two pages. This avoids a corner
+ * case in the pager when making the state available.
+ */
+struct rwp_state_padded {
+	struct rwp_state state;
+	uint64_t pad;
+};
+
+struct fobj_rwp_unpaged_iv {
 	uint8_t *store;
 	struct rwp_state *state;
 	struct fobj fobj;
 };
 
-static const struct fobj_ops ops_rw_paged;
+struct fobj_rwp_paged_iv {
+	size_t idx;
+	struct fobj fobj;
+};
+
+static const struct fobj_ops ops_rwp_paged_iv;
+static const struct fobj_ops ops_rwp_unpaged_iv;
 
 static struct internal_aes_gcm_key rwp_ae_key;
 
-/*
- * fobj_generate_authenc_key() - Generate authentication key
- *
- * Generates the authentication key used in all fobjs allocated with
- * fobj_rw_paged_alloc().
- */
-static TEE_Result fobj_generate_authenc_key(void)
-{
-	uint8_t key[RWP_AE_KEY_BITS / 8] = { 0 };
-
-	if (crypto_rng_read(key, sizeof(key)) != TEE_SUCCESS)
-		panic("failed to generate random");
-	if (crypto_aes_expand_enc_key(key, sizeof(key), rwp_ae_key.data,
-				      sizeof(rwp_ae_key.data),
-				      &rwp_ae_key.rounds))
-		panic("failed to expand key");
-
-	return TEE_SUCCESS;
-}
-driver_init_late(fobj_generate_authenc_key);
+static struct rwp_state_padded *rwp_state_base;
+static uint8_t *rwp_store_base;
 
 static void fobj_init(struct fobj *fobj, const struct fobj_ops *ops,
 		      unsigned int num_pages)
@@ -80,77 +78,16 @@ static void fobj_uninit(struct fobj *fobj)
 	tee_pager_invalidate_fobj(fobj);
 }
 
-struct fobj *fobj_rw_paged_alloc(unsigned int num_pages)
+static TEE_Result rwp_load_page(void *va, struct rwp_state *state,
+				const uint8_t *src)
 {
-	tee_mm_entry_t *mm = NULL;
-	struct fobj_rwp *rwp = NULL;
-	size_t size = 0;
-
-	assert(num_pages);
-
-	rwp = calloc(1, sizeof(*rwp));
-	if (!rwp)
-		return NULL;
-
-	rwp->state = calloc(num_pages, sizeof(*rwp->state));
-	if (!rwp->state)
-		goto err;
-
-	if (MUL_OVERFLOW(num_pages, SMALL_PAGE_SIZE, &size))
-		goto err;
-	mm = tee_mm_alloc(&tee_mm_sec_ddr, size);
-	if (!mm)
-		goto err;
-	rwp->store = phys_to_virt(tee_mm_get_smem(mm), MEM_AREA_TA_RAM);
-	assert(rwp->store); /* to assist debugging if it would ever happen */
-	if (!rwp->store)
-		goto err;
-
-	fobj_init(&rwp->fobj, &ops_rw_paged, num_pages);
-
-	return &rwp->fobj;
-
-err:
-	tee_mm_free(mm);
-	free(rwp->state);
-	free(rwp);
-
-	return NULL;
-}
-
-static struct fobj_rwp *to_rwp(struct fobj *fobj)
-{
-	assert(fobj->ops == &ops_rw_paged);
-
-	return container_of(fobj, struct fobj_rwp, fobj);
-}
-
-static void rwp_free(struct fobj *fobj)
-{
-	struct fobj_rwp *rwp = to_rwp(fobj);
-
-	fobj_uninit(fobj);
-	tee_mm_free(tee_mm_find(&tee_mm_sec_ddr, virt_to_phys(rwp->store)));
-	free(rwp->state);
-	free(rwp);
-}
-
-static TEE_Result rwp_load_page(struct fobj *fobj, unsigned int page_idx,
-				void *va)
-{
-	struct fobj_rwp *rwp = to_rwp(fobj);
-	struct rwp_state *state = rwp->state + page_idx;
-	uint8_t *src = rwp->store + page_idx * SMALL_PAGE_SIZE;
 	struct rwp_aes_gcm_iv iv = {
 		.iv = { (vaddr_t)state, state->iv >> 32, state->iv }
 	};
 
-	assert(refcount_val(&fobj->refc));
-	assert(page_idx < fobj->num_pages);
-
 	if (!state->iv) {
 		/*
-		 * iv still zero which means that this is previously unused
+		 * IV still zero which means that this is previously unused
 		 * page.
 		 */
 		memset(va, 0, SMALL_PAGE_SIZE);
@@ -161,18 +98,106 @@ static TEE_Result rwp_load_page(struct fobj *fobj, unsigned int page_idx,
 				    NULL, 0, src, SMALL_PAGE_SIZE, va,
 				    state->tag, sizeof(state->tag));
 }
-DECLARE_KEEP_PAGER(rwp_load_page);
 
-static TEE_Result rwp_save_page(struct fobj *fobj, unsigned int page_idx,
-				const void *va)
+static TEE_Result rwp_save_page(const void *va, struct rwp_state *state,
+				uint8_t *dst)
 {
-	struct fobj_rwp *rwp = to_rwp(fobj);
-	struct rwp_state *state = rwp->state + page_idx;
 	size_t tag_len = sizeof(state->tag);
-	uint8_t *dst = rwp->store + page_idx * SMALL_PAGE_SIZE;
-	struct rwp_aes_gcm_iv iv;
+	struct rwp_aes_gcm_iv iv = { };
 
-	memset(&iv, 0, sizeof(iv));
+	assert(state->iv + 1 > state->iv);
+
+	state->iv++;
+
+	/*
+	 * IV is constructed as recommended in section "8.2.1 Deterministic
+	 * Construction" of "Recommendation for Block Cipher Modes of
+	 * Operation: Galois/Counter Mode (GCM) and GMAC",
+	 * http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
+	 */
+	iv.iv[0] = (vaddr_t)state;
+	iv.iv[1] = state->iv >> 32;
+	iv.iv[2] = state->iv;
+
+	return internal_aes_gcm_enc(&rwp_ae_key, &iv, sizeof(iv),
+				    NULL, 0, va, SMALL_PAGE_SIZE, dst,
+				    state->tag, &tag_len);
+}
+
+static struct rwp_state_padded *idx_to_state_padded(size_t idx)
+{
+	assert(rwp_state_base);
+	return rwp_state_base + idx;
+}
+
+static uint8_t *idx_to_store(size_t idx)
+{
+	assert(rwp_store_base);
+	return rwp_store_base + idx * SMALL_PAGE_SIZE;
+}
+
+struct fobj *fobj_rw_paged_alloc(unsigned int num_pages)
+{
+	struct fobj_rwp_paged_iv *rwp = NULL;
+	tee_mm_entry_t *mm = NULL;
+	size_t size = 0;
+
+	COMPILE_TIME_ASSERT(IS_POWER_OF_TWO(sizeof(struct rwp_state_padded)));
+	assert(num_pages);
+
+	rwp = calloc(1, sizeof(*rwp));
+	if (!rwp)
+		return NULL;
+
+	if (MUL_OVERFLOW(num_pages, SMALL_PAGE_SIZE, &size))
+		goto err;
+	mm = tee_mm_alloc(&tee_mm_sec_ddr, size);
+	if (!mm)
+		goto err;
+	rwp->idx = (tee_mm_get_smem(mm) - tee_mm_sec_ddr.lo) / SMALL_PAGE_SIZE;
+
+	memset(idx_to_state_padded(rwp->idx), 0,
+	       num_pages * sizeof(struct rwp_state_padded));
+
+	fobj_init(&rwp->fobj, &ops_rwp_paged_iv, num_pages);
+
+	return &rwp->fobj;
+err:
+	tee_mm_free(mm);
+	free(rwp);
+
+	return NULL;
+}
+
+static struct fobj_rwp_paged_iv *to_rwp_paged_iv(struct fobj *fobj)
+{
+	assert(fobj->ops == &ops_rwp_paged_iv);
+
+	return container_of(fobj, struct fobj_rwp_paged_iv, fobj);
+}
+
+static TEE_Result rwp_paged_iv_load_page(struct fobj *fobj,
+					 unsigned int page_idx, void *va)
+{
+	struct fobj_rwp_paged_iv *rwp = to_rwp_paged_iv(fobj);
+	uint8_t *src = idx_to_store(rwp->idx) + page_idx * SMALL_PAGE_SIZE;
+	struct rwp_state_padded *st = idx_to_state_padded(rwp->idx + page_idx);
+
+	assert(refcount_val(&fobj->refc));
+	assert(page_idx < fobj->num_pages);
+
+	return rwp_load_page(va, &st->state, src);
+}
+DECLARE_KEEP_PAGER(rwp_paged_iv_load_page);
+
+static TEE_Result rwp_paged_iv_save_page(struct fobj *fobj,
+					 unsigned int page_idx, const void *va)
+{
+	struct fobj_rwp_paged_iv *rwp = to_rwp_paged_iv(fobj);
+	uint8_t *dst = idx_to_store(rwp->idx) + page_idx * SMALL_PAGE_SIZE;
+	struct rwp_state_padded *st = idx_to_state_padded(rwp->idx + page_idx);
+
+	assert(page_idx < fobj->num_pages);
 
 	if (!refcount_val(&fobj->refc)) {
 		/*
@@ -183,32 +208,150 @@ static TEE_Result rwp_save_page(struct fobj *fobj, unsigned int page_idx,
 		return TEE_SUCCESS;
 	}
 
-	assert(page_idx < fobj->num_pages);
-	assert(state->iv + 1 > state->iv);
+	return rwp_save_page(va, &st->state, dst);
+}
+DECLARE_KEEP_PAGER(rwp_paged_iv_save_page);
 
-	state->iv++;
+static void rwp_paged_iv_free(struct fobj *fobj)
+{
+	struct fobj_rwp_paged_iv *rwp = to_rwp_paged_iv(fobj);
+	paddr_t pa = rwp->idx * SMALL_PAGE_SIZE + tee_mm_sec_ddr.lo;
+	tee_mm_entry_t *mm = tee_mm_find(&tee_mm_sec_ddr, pa);
+
+	assert(mm);
+
+	fobj_uninit(fobj);
+	tee_mm_free(mm);
+	free(rwp);
+}
+
+static vaddr_t rwp_paged_iv_get_iv_vaddr(struct fobj *fobj,
+					 unsigned int page_idx)
+{
+	struct fobj_rwp_paged_iv *rwp = to_rwp_paged_iv(fobj);
+	struct rwp_state_padded *st = idx_to_state_padded(rwp->idx + page_idx);
+
+	assert(page_idx < fobj->num_pages);
+	return (vaddr_t)&st->state & ~SMALL_PAGE_MASK;
+}
+DECLARE_KEEP_PAGER(rwp_paged_iv_get_iv_vaddr);
+
+static const struct fobj_ops ops_rwp_paged_iv __rodata_unpaged = {
+	.free = rwp_paged_iv_free,
+	.load_page = rwp_paged_iv_load_page,
+	.save_page = rwp_paged_iv_save_page,
+	.get_iv_vaddr = rwp_paged_iv_get_iv_vaddr,
+};
+
+static struct fobj_rwp_unpaged_iv *to_rwp_unpaged_iv(struct fobj *fobj)
+{
+	assert(fobj->ops == &ops_rwp_unpaged_iv);
+
+	return container_of(fobj, struct fobj_rwp_unpaged_iv, fobj);
+}
+
+static TEE_Result rwp_unpaged_iv_load_page(struct fobj *fobj,
+					   unsigned int page_idx, void *va)
+{
+	struct fobj_rwp_unpaged_iv *rwp = to_rwp_unpaged_iv(fobj);
+	uint8_t *src = rwp->store + page_idx * SMALL_PAGE_SIZE;
+
+	assert(refcount_val(&fobj->refc));
+	assert(page_idx < fobj->num_pages);
+
+	return rwp_load_page(va, rwp->state + page_idx, src);
+}
+DECLARE_KEEP_PAGER(rwp_unpaged_iv_load_page);
+
+static TEE_Result rwp_unpaged_iv_save_page(struct fobj *fobj,
+					   unsigned int page_idx,
+					   const void *va)
+{
+	struct fobj_rwp_unpaged_iv *rwp = to_rwp_unpaged_iv(fobj);
+	uint8_t *dst = rwp->store + page_idx * SMALL_PAGE_SIZE;
+
+	assert(page_idx < fobj->num_pages);
+
+	if (!refcount_val(&fobj->refc)) {
+		/*
+		 * This fobj is being teared down, it just hasn't had the time
+		 * to call tee_pager_invalidate_fobj() yet.
+		 */
+		assert(TAILQ_EMPTY(&fobj->areas));
+		return TEE_SUCCESS;
+	}
+
+	return rwp_save_page(va, rwp->state + page_idx, dst);
+}
+DECLARE_KEEP_PAGER(rwp_unpaged_iv_save_page);
+
+static void rwp_unpaged_iv_free(struct fobj *fobj __unused)
+{
+	panic();
+}
+
+static const struct fobj_ops ops_rwp_unpaged_iv __rodata_unpaged = {
+	.free = rwp_unpaged_iv_free,
+	.load_page = rwp_unpaged_iv_load_page,
+	.save_page = rwp_unpaged_iv_save_page,
+};
+
+static TEE_Result rwp_init(void)
+{
+	uint8_t key[RWP_AE_KEY_BITS / 8] = { 0 };
+	struct fobj_rwp_unpaged_iv *rwp = NULL;
+	tee_mm_entry_t *mm = NULL;
+	size_t num_pool_pages = 0;
+	size_t num_fobj_pages = 0;
+	size_t sz = 0;
+
+	if (crypto_rng_read(key, sizeof(key)) != TEE_SUCCESS)
+		panic("failed to generate random");
+	if (crypto_aes_expand_enc_key(key, sizeof(key), rwp_ae_key.data,
+				      sizeof(rwp_ae_key.data),
+				      &rwp_ae_key.rounds))
+		panic("failed to expand key");
+
+	assert(tee_mm_sec_ddr.hi > tee_mm_sec_ddr.lo);
+	sz = tee_mm_sec_ddr.hi - tee_mm_sec_ddr.lo;
+	assert(!(sz & SMALL_PAGE_SIZE));
+
+	num_pool_pages = sz / SMALL_PAGE_SIZE;
+	num_fobj_pages = ROUNDUP(num_pool_pages * sizeof(*rwp_state_base),
+				 SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE;
+
 	/*
-	 * IV is constructed as recommended in section "8.2.1 Deterministic
-	 * Construction" of "Recommendation for Block Cipher Modes of
-	 * Operation: Galois/Counter Mode (GCM) and GMAC",
-	 * http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
+	 * Each page in the pool needs a struct rwp_state.
+	 *
+	 * This isn't entirely true, the pages not used by
+	 * fobj_rw_paged_alloc() don't need any. A future optimization
+	 * may try to avoid allocating for such pages.
 	 */
 
-	iv.iv[0] = (vaddr_t)state;
-	iv.iv[1] = state->iv >> 32;
-	iv.iv[2] = state->iv;
+	rwp = calloc(1, sizeof(*rwp));
+	if (!rwp)
+		panic();
 
-	return internal_aes_gcm_enc(&rwp_ae_key, &iv, sizeof(iv),
-				    NULL, 0, va, SMALL_PAGE_SIZE, dst,
-				    state->tag, &tag_len);
+	rwp->state = calloc(num_fobj_pages, sizeof(*rwp->state));
+	if (!rwp->state)
+		panic();
+	mm = tee_mm_alloc(&tee_mm_sec_ddr, num_fobj_pages * SMALL_PAGE_SIZE);
+	if (!mm)
+		panic();
+	rwp->store = phys_to_virt(tee_mm_get_smem(mm), MEM_AREA_TA_RAM);
+	assert(rwp->store);
+
+	fobj_init(&rwp->fobj, &ops_rwp_unpaged_iv, num_fobj_pages);
+
+	rwp_state_base = (void *)tee_pager_init_iv_area(&rwp->fobj);
+	assert(rwp_state_base);
+
+	rwp_store_base = phys_to_virt(tee_mm_sec_ddr.lo, MEM_AREA_TA_RAM);
+	assert(rwp_store_base);
+
+	return TEE_SUCCESS;
 }
-DECLARE_KEEP_PAGER(rwp_save_page);
-
-static const struct fobj_ops ops_rw_paged __rodata_unpaged = {
-	.free = rwp_free,
-	.load_page = rwp_load_page,
-	.save_page = rwp_save_page,
-};
+driver_init_late(rwp_init);
 
 struct fobj_rop {
 	uint8_t *hashes;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -327,6 +327,13 @@ endif
 # Enable paging, requires SRAM, can't be enabled by default
 CFG_WITH_PAGER ?= n
 
+# Use the pager for user TAs
+CFG_PAGED_USER_TA ?= $(CFG_WITH_PAGER)
+
+# If paging of user TAs, that is, R/W paging default to enable paging of
+# TAG and IV in order to reduce heap usage.
+CFG_CORE_PAGE_TAG_AND_IV ?= $(CFG_PAGED_USER_TA)
+
 # Runtime lock dependency checker: ensures that a proper locking hierarchy is
 # used in the TEE core when acquiring and releasing mutexes. Any violation will
 # cause a panic as soon as the invalid locking condition is detected. If
@@ -340,9 +347,6 @@ CFG_LOCKDEP_RECORD_STACK ?= y
 # BestFit algorithm in bget reduces the fragmentation of the heap when running
 # with the pager enabled or lockdep
 CFG_CORE_BGET_BESTFIT ?= $(call cfg-one-enabled, CFG_WITH_PAGER CFG_LOCKDEP)
-
-# Use the pager for user TAs
-CFG_PAGED_USER_TA ?= $(CFG_WITH_PAGER)
 
 # Enable support for detected undefined behavior in C
 # Uses a lot of memory, can't be enabled by default


### PR DESCRIPTION
This PR reduces the heap usage when paging is enabled by storing the IVs and Tags of the paged user TA pages in a special paged area instead of allocating these from the heap.