### PR TITLE
core: recreate a new hash file when dirfile is not found

### DIFF
--- a/core/include/tee/tee_fs.h
+++ b/core/include/tee/tee_fs.h
@@ -59,6 +59,8 @@ extern const struct tee_file_operations rpmb_fs_ops;
 TEE_Result tee_rpmb_fs_raw_open(const char *fname, bool create,
 				struct tee_file_handle **fh);
 
+TEE_Result tee_rpmb_fs_raw_remove(struct tee_file_handle *fh);
+
 /**
  * Weak function which can be overridden by platforms to indicate that the RPMB
  * key is ready to be written. Defaults to true, platforms can return false to

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -497,8 +497,18 @@ static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 		return res;
 
 	res = tee_fs_dirfile_open(false, hashp, &ree_dirf_ops, dirh);
-	if (res == TEE_ERROR_ITEM_NOT_FOUND)
+	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+		if (hashp) {
+			res = tee_rpmb_fs_raw_remove(ree_fs_rpmb_fh);
+			if (res)
+				return res;
+			res = tee_rpmb_fs_raw_open(fname, true,
+						   &ree_fs_rpmb_fh);
+			if (res)
+				return res;
+		}
 		res = tee_fs_dirfile_open(true, NULL, &ree_dirf_ops, dirh);
+	}
 
 	if (res)
 		rpmb_fs_ops.close(&ree_fs_rpmb_fh);

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -3037,6 +3037,24 @@ TEE_Result tee_rpmb_fs_raw_open(const char *fname, bool create,
 	return res;
 }
 
+TEE_Result tee_rpmb_fs_raw_remove(struct tee_file_handle *fh)
+{
+	TEE_Result res;
+
+	if (!fh)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mutex_lock(&rpmb_mutex);
+
+	res = rpmb_fs_remove_internal((struct rpmb_file_handle *)fh);
+
+	mutex_unlock(&rpmb_mutex);
+
+	rpmb_fs_close(&fh);
+
+	return res;
+}
+
 bool __weak plat_rpmb_key_is_ready(void)
 {
 	return true;


### PR DESCRIPTION
We met an issue that is if one TA calls TEE_OpenPersistentObject after the REE FS is cleaned (RPMB is not cleaned), the REE FS cannot be used anymore. All the TAs call GP API to access the REE FS would panic with TEE_ERROR_SECURITY. The root cause is the hash is not cleaned in RPMB just like issue [3735](https://github.com/OP-TEE/optee_os/issues/3735). The behavior of open_dirh now will recreate a new dirf.db if it's not found even the hash is already existed. So I think when a new dirfile is created, the old hash should be removed from RPMB. I think it would not broke the security mechanism. Could someone give me any advice?