### PR TITLE
core: fix icache_inv_user_range()

### DIFF
--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -855,12 +855,14 @@ icache_inv_user_range:
 
 #ifdef CFG_WITH_LPAE
 	read_ttbr0_64bit r6, r7	/* These registers must be preseved */
-#ifdef CFG_CORE_UNMAP_CORE_AT_EL0
-	add	r2, r6, #CORE_MMU_L1_TBL_OFFSET
-#endif
 	/* switch to user ASID */
 	orr	r3, r7, #BIT(TTBR_ASID_SHIFT - 32)
+#ifdef CFG_CORE_UNMAP_CORE_AT_EL0
+	add	r2, r6, #CORE_MMU_L1_TBL_OFFSET
 	write_ttbr0_64bit r2, r3
+#else
+	write_ttbr0_64bit r6, r3
+#endif
 	isb
 #else /*!CFG_WITH_LPAE*/
 #ifdef CFG_CORE_UNMAP_CORE_AT_EL0


### PR DESCRIPTION
Prior to this patch with CFG_WITH_PAGER=y, CFG_WITH_LPAE=y and
CFG_CORE_UNMAP_CORE_AT_EL0=n icache_inv_user_range() crashes with a
prefetch abort due to TTBR0 being configured with an invalid value.
This happens due to an error in the ifdef logic using an uninitialized
register.

Fix this by using the correct register.

Fixes: c4a57390edef ("core: pager: use icache_inv_user_range()")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
