### PR TITLE
ta: pkcs11: fix TEE identity authentication token reference

### DIFF
--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -846,7 +846,7 @@ enum pkcs11_rc entry_ck_token_initialize(uint32_t ptypes, TEE_Param *params)
 #if defined(CFG_PKCS11_TA_AUTH_TEE_IDENTITY)
 	/* Check TEE Identity based authentication if enabled */
 	if (token->db_main->flags & PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH) {
-		rc = verify_identity_auth(ck_token, PKCS11_CKU_SO);
+		rc = verify_identity_auth(token, PKCS11_CKU_SO);
 		if (rc)
 			return rc;
 	}


### PR DESCRIPTION
Correct token reference pass to verify client credentials.

Fixes: 1a27b197 ("ta: pkcs11: Add TEE Identity based authentication support")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
