### PR TITLE
drivers: crypto: se050: Global Platform SCP03 key provisioning

### DIFF
--- a/core/drivers/crypto/se050/adaptors/include/se050_utils.h
+++ b/core/drivers/crypto/se050/adaptors/include/se050_utils.h
@@ -10,10 +10,12 @@
 #include <se050.h>
 #include <tee_api_types.h>
 
+#define SE050_SCP03_KEY_SZ 16
+
 struct se050_scp_key {
-	uint8_t enc[16];
-	uint8_t mac[16];
-	uint8_t dek[16];
+	uint8_t enc[SE050_SCP03_KEY_SZ];
+	uint8_t mac[SE050_SCP03_KEY_SZ];
+	uint8_t dek[SE050_SCP03_KEY_SZ];
 };
 
 struct s050_scp_rotate_cmd {
@@ -44,9 +46,14 @@ int se050_refcount_final_ctx(uint8_t *cnt);
 
 void se050_display_board_info(sss_se05x_session_t *session);
 
-sss_status_t se050_scp03_get_keys(struct se050_scp_key *keys);
-sss_status_t se050_scp03_put_keys(struct se050_scp_key *new_keys,
-				  struct se050_scp_key *cur_keys);
+enum se050_scp03_ksrc { SCP03_CFG, SCP03_DERIVED, SCP03_OFID };
+void se050_scp03_set_enable(enum se050_scp03_ksrc ksrc);
+void se050_scp03_set_disable(void);
+bool se050_scp03_enabled(void);
+sss_status_t se050_scp03_get_current_keys(struct se050_scp_key *keys);
+sss_status_t se050_scp03_get_keys(struct se050_scp_key *keys,
+				  enum se050_scp03_ksrc);
+sss_status_t se050_scp03_subkey_derive(struct se050_scp_key *keys);
 sss_status_t se050_scp03_prepare_rotate_cmd(struct sss_se05x_ctx *ctx,
 					    struct s050_scp_rotate_cmd *cmd,
 					    struct se050_scp_key *keys);

--- a/core/drivers/crypto/se050/session.c
+++ b/core/drivers/crypto/se050/session.c
@@ -44,6 +44,7 @@ static TEE_Result display_info(void)
 	se050_display_board_info(se050_session);
 	/* the session must be closed after accessing board information */
 	sss_se05x_session_close(se050_session);
+
 	return se050_core_early_init(NULL);
 }
 
@@ -51,18 +52,6 @@ static TEE_Result enable_scp03(void)
 {
 	if (se050_enable_scp03(se050_session) != kStatus_SSS_Success)
 		return TEE_ERROR_GENERIC;
-
-	/*
-	 * Do not provision the keys at this point unless there is guaranteed
-	 * access to trusted storage so the new keys can be written.
-	 *
-	 * This can be done once RPMB is accessible and we can test it
-	 *
-	 * #if defined(CFG_CORE_SE05X_SCP03_PROVISION)
-	 *	if (se050_rotate_scp03_keys(&se050_ctx) != kStatus_SSS_Success)
-	 *		return TEE_ERROR_GENERIC;
-	 * #endif
-	 */
 
 	return TEE_SUCCESS;
 }

--- a/core/include/kernel/huk_subkey.h
+++ b/core/include/kernel/huk_subkey.h
@@ -17,6 +17,7 @@
  * @HUK_SUBKEY_DIE_ID:	  Representing the die ID
  * @HUK_SUBKEY_UNIQUE_TA: TA unique key
  * @HUK_SUBKEY_TA_ENC:    TA encryption key
+ * @HUK_SUBKEY_SE050:     SCP03 set of encryption keys
  *
  * Add more identifiers as needed, be careful to not change the already
  * assigned numbers as that will affect the derived subkey.
@@ -31,6 +32,7 @@ enum huk_subkey_usage {
 	HUK_SUBKEY_DIE_ID = 2,
 	HUK_SUBKEY_UNIQUE_TA = 3,
 	HUK_SUBKEY_TA_ENC = 4,
+	HUK_SUBKEY_SE050 = 5,
 };
 
 #define HUK_SUBKEY_MAX_LEN	TEE_SHA256_HASH_SIZE


### PR DESCRIPTION
Remove the need to store the SCP03 keys by deriving them from the HUK
and the SE050 unique hardware identifier.

Works under the assumption that the HUK is unknown and never exposed
outside the TEE.

 CFG_CORE_SE05X_SCP03_PROVISION
   Needs to be configured to exec the feature.

 CFG_CORE_SE05X_DISPLAY_SCP03_KEYS:
   Outputs the current and the new SCP03 keys to the console during
   provisioning.

Note that to provision new SCP03 keys, SCP03 must already be in
operation (ie, have an encrypted communication channel between the
processor and the SE050).

U-boot support has just been posted to the list
https://lists.denx.de/pipermail/u-boot/2021-February/440455.html

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
