### PR TITLE
core: clarify tlbi_mva_range()

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -618,8 +618,15 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 				   size_t len);
 bool core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len);
 
-/* TLB invalidation for a range of virtual address */
-void tlbi_mva_range(vaddr_t va, size_t size, size_t granule);
+/*
+ * tlbi_mva_range() - Invalidate TLB for virtual address range
+ * @va:		start virtual address, must be a multiple of @granule
+ * @len:	length in bytes of range, must be a multiple of @granule
+ * @granule:	granularity of mapping, supported values are
+ *		CORE_MMU_PGDIR_SIZE or SMALL_PAGE_SIZE. This value must
+ *		match the actual mappings.
+ */
+void tlbi_mva_range(vaddr_t va, size_t len, size_t granule);
 
 /* Cache maintenance operation type */
 enum cache_op {

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1359,18 +1359,15 @@ enum teecore_memtypes core_mmu_get_type_by_pa(paddr_t pa)
 	return map->type;
 }
 
-void tlbi_mva_range(vaddr_t va, size_t size, size_t granule)
+void tlbi_mva_range(vaddr_t va, size_t len, size_t granule)
 {
-	size_t sz = size;
-
 	assert(granule == CORE_MMU_PGDIR_SIZE || granule == SMALL_PAGE_SIZE);
+	assert(!(va & (granule - 1)) && !(len & (granule - 1)));
 
 	dsb_ishst();
-	while (sz) {
+	while (len) {
 		tlbi_mva_allasid_nosync(va);
-		if (sz < granule)
-			break;
-		sz -= granule;
+		len -= granule;
 		va += granule;
 	}
 	dsb_ish();


### PR DESCRIPTION
Clarifies tlbi_mva_range() with a full description of the interface at
the declaration of the function. The supplied VA range must be aligned
on the supplied granularity.

The implementation is updated to take full advantage of this restriction
together with an additional assert.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
