### PR TITLE
core: remove deprecated core_tlb_maintenance()

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -618,21 +618,10 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 				   size_t len);
 bool core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len);
 
-/* various invalidate secure TLB */
-enum teecore_tlb_op {
-	TLBINV_UNIFIEDTLB,	/* invalidate unified tlb */
-	TLBINV_CURRENT_ASID,	/* invalidate unified tlb for current ASID */
-	TLBINV_BY_ASID,		/* invalidate unified tlb by ASID */
-	TLBINV_BY_MVA,		/* invalidate unified tlb by MVA */
-};
-
 /* TLB invalidation for a range of virtual address */
 void tlbi_mva_range(vaddr_t va, size_t size, size_t granule);
 
-/* deprecated: please call straight tlbi_all() and friends */
-int core_tlb_maintenance(int op, unsigned long a) __deprecated;
-
-/* Cache maintenance operation type (deprecated with core_tlb_maintenance()) */
+/* Cache maintenance operation type */
 enum cache_op {
 	DCACHE_CLEAN,
 	DCACHE_AREA_CLEAN,

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1359,31 +1359,6 @@ enum teecore_memtypes core_mmu_get_type_by_pa(paddr_t pa)
 	return map->type;
 }
 
-int __deprecated core_tlb_maintenance(int op, unsigned long a)
-{
-	switch (op) {
-	case TLBINV_UNIFIEDTLB:
-		tlbi_all();
-		break;
-	case TLBINV_CURRENT_ASID:
-#ifdef ARM32
-		tlbi_asid(read_contextidr());
-#endif
-#ifdef ARM64
-		tlbi_asid(read_contextidr_el1());
-#endif
-		break;
-	case TLBINV_BY_ASID:
-		tlbi_asid(a);
-		break;
-	case TLBINV_BY_MVA:
-		panic();
-	default:
-		return 1;
-	}
-	return 0;
-}
-
 void tlbi_mva_range(vaddr_t va, size_t size, size_t granule)
 {
 	size_t sz = size;


### PR DESCRIPTION
Removes the deprecated and unused function core_tlb_maintenance().

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
