### PR TITLE
Add 3DES CMAC implementation

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2017, Linaro Limited
  * Copyright 2020 NXP
+ * Copyright 2021, SumUp Service GmbH
  */
 
 #include <assert.h>
@@ -272,6 +273,9 @@ TEE_Result crypto_mac_alloc_ctx(void **ctx, uint32_t algo)
 			break;
 		case TEE_ALG_DES3_CBC_MAC_PKCS5:
 			res = crypto_des3_cbc_mac_pkcs5_alloc_ctx(&c);
+			break;
+		case TEE_ALG_DES3_CMAC:
+			res = crypto_des3_cmac_alloc_ctx(&c);
 			break;
 		case TEE_ALG_AES_CMAC:
 			res = crypto_aes_cmac_alloc_ctx(&c);

--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2021, SumUp Services GmbH
  */
 
 #ifndef __CRYPTO_CRYPTO_IMPL_H
@@ -135,8 +136,10 @@ CRYPTO_ALLOC_CTX_NOT_IMPLEMENTED(des3_cbc_mac_pkcs5, mac)
 
 #if defined(CFG_CRYPTO_CMAC)
 TEE_Result crypto_aes_cmac_alloc_ctx(struct crypto_mac_ctx **ctx);
+TEE_Result crypto_des3_cmac_alloc_ctx(struct crypto_mac_ctx **ctx);
 #else
 CRYPTO_ALLOC_CTX_NOT_IMPLEMENTED(aes_cmac, mac)
+CRYPTO_ALLOC_CTX_NOT_IMPLEMENTED(des3_cmac, mac)
 #endif
 
 /*

--- a/core/lib/libtomcrypt/cmac.c
+++ b/core/lib/libtomcrypt/cmac.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2014-2019, Linaro Limited
+ * Copyright (c) 2021, SumUp Services GmbH
  */
 
 #include <assert.h>
@@ -82,10 +83,14 @@ static const struct crypto_mac_ops ltc_omac_ops = {
 	.copy_state = ltc_omac_copy_state,
 };
 
-TEE_Result crypto_aes_cmac_alloc_ctx(struct crypto_mac_ctx **ctx_ret)
+static TEE_Result crypto_common_cmac_alloc_ctx(struct crypto_mac_ctx **ctx_ret,
+		const char *cipher)
 {
 	struct ltc_omac_ctx *ctx = NULL;
-	int cipher_idx = find_cipher("aes");
+	int cipher_idx = find_cipher(cipher);
+
+	if (!ctx_ret)
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	if (cipher_idx < 0)
 		return TEE_ERROR_NOT_SUPPORTED;
@@ -99,4 +104,14 @@ TEE_Result crypto_aes_cmac_alloc_ctx(struct crypto_mac_ctx **ctx_ret)
 	*ctx_ret = &ctx->ctx;
 
 	return TEE_SUCCESS;
+}
+
+TEE_Result crypto_aes_cmac_alloc_ctx(struct crypto_mac_ctx **ctx_ret)
+{
+	return crypto_common_cmac_alloc_ctx(ctx_ret, "aes");
+}
+
+TEE_Result crypto_des3_cmac_alloc_ctx(struct crypto_mac_ctx **ctx_ret)
+{
+	return crypto_common_cmac_alloc_ctx(ctx_ret, "3des");
 }

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2021, SumUp Services GmbH
  */
 
 #include <crypto/crypto.h>
@@ -82,6 +83,7 @@ TEE_Result tee_cipher_get_block_size(uint32_t algo, size_t *size)
 	case TEE_ALG_DES3_CBC_MAC_PKCS5:
 	case TEE_ALG_DES3_ECB_NOPAD:
 	case TEE_ALG_DES3_CBC_NOPAD:
+	case TEE_ALG_DES3_CMAC:
 		*size = 8;
 		break;
 

--- a/lib/libmbedtls/core/des3_cmac.c
+++ b/lib/libmbedtls/core/des3_cmac.c
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2018, ARM Limited
+ * Copyright (C) 2019, Linaro Limited
+ * Copyright (C) 2021, SumUp Services GmbH
+ */
+
+#include <assert.h>
+#include <crypto/crypto.h>
+#include <crypto/crypto_impl.h>
+#include <mbedtls/cipher.h>
+#include <mbedtls/cmac.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee_api_types.h>
+#include <utee_defines.h>
+#include <util.h>
+
+struct mbed_des3_cmac_ctx {
+	struct crypto_mac_ctx mac_ctx;
+	mbedtls_cipher_context_t cipher_ctx;
+};
+
+static const struct crypto_mac_ops mbed_des3_cmac_ops;
+
+static struct mbed_des3_cmac_ctx *to_des3_cmac_ctx(struct crypto_mac_ctx *ctx)
+{
+	assert(ctx && ctx->ops == &mbed_des3_cmac_ops);
+
+	return container_of(ctx, struct mbed_des3_cmac_ctx, mac_ctx);
+}
+
+static TEE_Result mbed_des3_cmac_init(struct crypto_mac_ctx *ctx,
+		const uint8_t *key, size_t len)
+{
+	struct mbed_des3_cmac_ctx *c = to_des3_cmac_ctx(ctx);
+	const mbedtls_cipher_info_t *cipher_info = NULL;
+
+	cipher_info = mbedtls_cipher_info_from_values(MBEDTLS_CIPHER_ID_3DES,
+			len * 8,
+			MBEDTLS_MODE_ECB);
+	if (!cipher_info)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	if (mbedtls_cipher_setup_info(&c->cipher_ctx, cipher_info))
+		return TEE_ERROR_BAD_STATE;
+
+	if (mbedtls_cipher_cmac_reset(&c->cipher_ctx))
+		return TEE_ERROR_BAD_STATE;
+
+	if (mbedtls_cipher_cmac_starts(&c->cipher_ctx, key, len * 8))
+		return TEE_ERROR_BAD_STATE;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result mbed_des3_cmac_update(struct crypto_mac_ctx *ctx,
+		const uint8_t *data, size_t len)
+{
+	if (mbedtls_cipher_cmac_update(&to_des3_cmac_ctx(ctx)->cipher_ctx,
+				data, len))
+		return TEE_ERROR_BAD_STATE;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result mbed_des3_cmac_final(struct crypto_mac_ctx *ctx, uint8_t *digest,
+		size_t len)
+{
+	struct mbed_des3_cmac_ctx *c = to_des3_cmac_ctx(ctx);
+	uint8_t block_digest[TEE_DES_BLOCK_SIZE] = { };
+	uint8_t *tmp_digest = NULL;
+
+	if (len == 0)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (len < sizeof(block_digest))
+		tmp_digest = block_digest; /* use a tempory buffer */
+	else
+		tmp_digest = digest;
+
+	if (mbedtls_cipher_cmac_finish(&c->cipher_ctx, tmp_digest))
+		return TEE_ERROR_BAD_STATE;
+
+	if (len < sizeof(block_digest))
+		memcpy(digest, tmp_digest, len);
+
+	return TEE_SUCCESS;
+}
+
+static void mbed_des3_cmac_free_ctx(struct crypto_mac_ctx *ctx)
+{
+	struct mbed_des3_cmac_ctx *c = to_des3_cmac_ctx(ctx);
+
+	mbedtls_cipher_free(&c->cipher_ctx);
+	free(c);
+}
+
+static void mbed_des3_cmac_copy_state(struct crypto_mac_ctx *dst_ctx,
+		struct crypto_mac_ctx *src_ctx)
+{
+	struct mbed_des3_cmac_ctx *src = to_des3_cmac_ctx(src_ctx);
+	struct mbed_des3_cmac_ctx *dst = to_des3_cmac_ctx(dst_ctx);
+
+	assert(!mbedtls_cipher_clone(&dst->cipher_ctx, &src->cipher_ctx));
+}
+
+static const struct crypto_mac_ops mbed_des3_cmac_ops = {
+	.init = mbed_des3_cmac_init,
+	.update = mbed_des3_cmac_update,
+	.final = mbed_des3_cmac_final,
+	.free_ctx = mbed_des3_cmac_free_ctx,
+	.copy_state = mbed_des3_cmac_copy_state,
+};
+
+TEE_Result crypto_des3_cmac_alloc_ctx(struct crypto_mac_ctx **ctx_ret)
+{
+	int mbed_res = 0;
+	struct mbed_des3_cmac_ctx *c = NULL;
+	const mbedtls_cipher_info_t *cipher_info = NULL;
+
+	/*
+	 * Use a default key length for getting 'cipher_info' to do the
+	 * setup. The 'cipher_info' will need to be re-assigned with final
+	 * key length obtained in mbed_des3_cmac_init() above.
+	 *
+	 * This is safe since 'mbedtls_cipher_base_t' (used for cipher
+	 * context) uses the same fixed allocation all key lengths.
+	 */
+	cipher_info = mbedtls_cipher_info_from_values(MBEDTLS_CIPHER_ID_3DES,
+			192, MBEDTLS_MODE_ECB);
+	if (!cipher_info)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	c = calloc(1, sizeof(*c));
+	if (!c)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	c->mac_ctx.ops = &mbed_des3_cmac_ops;
+	mbedtls_cipher_init(&c->cipher_ctx);
+	mbed_res = mbedtls_cipher_setup(&c->cipher_ctx, cipher_info);
+	if (mbed_res) {
+		free(c);
+		if (mbed_res == MBEDTLS_ERR_CIPHER_ALLOC_FAILED)
+			return TEE_ERROR_OUT_OF_MEMORY;
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+	mbed_res = mbedtls_cipher_cmac_setup(&c->cipher_ctx);
+	if (mbed_res) {
+		free(c);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	*ctx_ret = &c->mac_ctx;
+
+	return TEE_SUCCESS;
+}

--- a/lib/libmbedtls/core/sub.mk
+++ b/lib/libmbedtls/core/sub.mk
@@ -19,6 +19,7 @@ endif
 
 srcs-$(CFG_CRYPTO_HMAC) += hmac.c
 srcs-$(CFG_CRYPTO_CMAC) += aes_cmac.c
+srcs-$(CFG_CRYPTO_CMAC) += des3_cmac.c
 
 ifneq ($(CFG_CRYPTO_DSA),y)
 srcs-$(call cfg-one-enabled, CFG_CRYPTO_RSA  CFG_CRYPTO_DH \

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2021, SumUp Services GmbH
  */
 
 #ifndef TEE_API_DEFINES_EXTENSIONS_H
@@ -61,6 +62,11 @@
  */
 
 #define TEE_ALG_RSASSA_PKCS1_V1_5	0xF0000830
+
+/*
+ *  TDEA CMAC (NIST SP800-38B)
+ */
+#define TEE_ALG_DES3_CMAC	0xF0000613
 
 /*
  * Implementation-specific object storage constants

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2021, SumUp Services GmbH
  */
 #ifndef UTEE_DEFINES_H
 #define UTEE_DEFINES_H
@@ -59,6 +60,8 @@ static inline uint32_t __tee_alg_get_class(uint32_t algo)
 		return TEE_OPERATION_KEY_DERIVATION;
 	if (algo == TEE_ALG_RSASSA_PKCS1_V1_5)
 		return TEE_OPERATION_ASYMMETRIC_SIGNATURE;
+	if (algo == TEE_ALG_DES3_CMAC)
+		return TEE_OPERATION_MAC;
 
 	return (algo >> 28) & 0xF; /* Bits [31:28] */
 }
@@ -203,6 +206,7 @@ static inline size_t __tee_alg_get_digest_size(uint32_t algo)
 	case TEE_ALG_DES_CBC_MAC_PKCS5:
 	case TEE_ALG_DES3_CBC_MAC_NOPAD:
 	case TEE_ALG_DES3_CBC_MAC_PKCS5:
+	case TEE_ALG_DES3_CMAC:
 		return TEE_DES_BLOCK_SIZE;
 	default:
 		return 0;

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2021, SumUp Services GmbH
  */
 #include <config.h>
 #include <stdlib.h>
@@ -251,6 +252,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_DES_CBC_MAC_PKCS5:
 	case TEE_ALG_DES3_CBC_MAC_NOPAD:
 	case TEE_ALG_DES3_CBC_MAC_PKCS5:
+	case TEE_ALG_DES3_CMAC:
 	case TEE_ALG_HMAC_MD5:
 	case TEE_ALG_HMAC_SHA1:
 	case TEE_ALG_HMAC_SHA224:


### PR DESCRIPTION
This PR implements DES3 CMAC (NIST SP800-38B).
Usage: 
	   TEE_AllocateOperation(&operation, **TEE_ALG_DES3_CMAC**, TEE_MODE_MAC, inKeyLen * 7);

Application: it is still required, for instance, by ASC X9 TR 31-2018.

