### PR TITLE
ta: pkcs11: Add implementation for random number generation

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -544,6 +544,27 @@ enum pkcs11_ta_cmd {
 	 */
 	PKCS11_CMD_COPY_OBJECT = 40,
 
+	/*
+	 * PKCS11_CMD_SEED_RANDOM - Seed random data generator
+	 *
+	 * [in]  memref[0] = 32bit session handle
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [in]  memref[1] = byte array: seed material to feed into the RNG
+	 *
+	 * This command relates to the PKCS#11 API function C_SeedRandom().
+	 */
+	PKCS11_CMD_SEED_RANDOM = 41,
+
+	/*
+	 * PKCS11_CMD_GENERATE_RANDOM - Generate random data
+	 *
+	 * [in]  memref[0] = 32bit session handle
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = byte array: generated random
+	 *
+	 * This command relates to the PKCS#11 API function C_GenerateRandom().
+	 */
+	PKCS11_CMD_GENERATE_RANDOM = 42,
 };
 
 /*

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -309,6 +309,12 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 	case PKCS11_CMD_COPY_OBJECT:
 		rc = entry_copy_object(client, ptypes, params);
 		break;
+	case PKCS11_CMD_SEED_RANDOM:
+		rc = entry_ck_seed_random(client, ptypes, params);
+		break;
+	case PKCS11_CMD_GENERATE_RANDOM:
+		rc = entry_ck_generate_random(client, ptypes, params);
+		break;
 	default:
 		EMSG("Command %#"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -178,6 +178,8 @@ static const struct any_id __maybe_unused string_ta_cmd[] = {
 	PKCS11_ID(PKCS11_CMD_GET_ATTRIBUTE_VALUE),
 	PKCS11_ID(PKCS11_CMD_SET_ATTRIBUTE_VALUE),
 	PKCS11_ID(PKCS11_CMD_COPY_OBJECT),
+	PKCS11_ID(PKCS11_CMD_SEED_RANDOM),
+	PKCS11_ID(PKCS11_CMD_GENERATE_RANDOM),
 };
 
 static const struct any_id __maybe_unused string_slot_flags[] = {

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -336,5 +336,9 @@ enum pkcs11_rc entry_ck_login(struct pkcs11_client *client,
 			      uint32_t ptypes, TEE_Param *params);
 enum pkcs11_rc entry_ck_logout(struct pkcs11_client *client,
 			       uint32_t ptypes, TEE_Param *params);
+enum pkcs11_rc entry_ck_seed_random(struct pkcs11_client *client,
+				    uint32_t ptypes, TEE_Param *params);
+enum pkcs11_rc entry_ck_generate_random(struct pkcs11_client *client,
+					uint32_t ptypes, TEE_Param *params);
 
 #endif /*PKCS11_TA_PKCS11_TOKEN_H*/


### PR DESCRIPTION
Add code for handling C_SeedRandom() and C_GenerateRandom() functionality.

Relates to:
https://github.com/OP-TEE/optee_os/issues/4283

Goes with:
https://github.com/OP-TEE/optee_client/pull/256
https://github.com/OP-TEE/optee_test/pull/487