### PR TITLE
virt: round down TA RAM memory size to page size

### DIFF
--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -69,9 +69,9 @@ static void set_current_prtn(struct guest_partition *prtn)
 
 static size_t get_ta_ram_size(void)
 {
-	return TA_RAM_SIZE / CFG_VIRT_GUEST_COUNT -
-		VCORE_UNPG_RW_SZ -
-		core_mmu_get_total_pages_size();
+	return ROUNDDOWN(TA_RAM_SIZE / CFG_VIRT_GUEST_COUNT -
+			 VCORE_UNPG_RW_SZ -
+			 core_mmu_get_total_pages_size(), SMALL_PAGE_SIZE);
 }
 
 static struct tee_mmap_region *prepare_memory_map(paddr_t tee_data,


### PR DESCRIPTION
It is possible that get_ta_ram_size() would return size which is not
aligned to a small page size. This will cause panic in core_init_mmu_prtn()
function.

To fix this we need to round down calculated value to a page size.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
