### PR TITLE
build: core: add missing dependencies when generating assembly constants

### DIFF
--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -70,6 +70,15 @@ srcs-y += link_dummies_paged.c
 srcs-y += link_dummies_init.c
 
 asm-defines-y += asm-defines.c
+# Reflect the following dependencies:
+# asm-defines.c includes <kernel/thread.h>
+#   <kernel/thread.h> includes <asm.h>
+#     <asm.h> includes <generated/arm32_sysreg.h>
+#                  and <generated/arm32_gicv3_sysreg.h> (optional)
+asm-defines-asm-defines.c-deps += $(out-dir)/core/include/generated/arm32_sysreg.h
+ifeq ($(CFG_ARM_GICV3),y)
+asm-defines-asm-defines.c-deps += $(out-dir)/core/include/generated/arm32_gicv3_sysreg.h
+endif
 
 ifeq ($(CFG_SYSCALL_FTRACE),y)
 # We would not like to profile thread.c file as it provide common APIs

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -173,6 +173,7 @@ define _gen-asm-defines-file
 # c-filename in $1
 # h-filename in $2
 # s-filename in $3
+# Dependencies in $4
 
 FORCE-GENSRC$(sm): $(2)
 
@@ -208,7 +209,7 @@ comp-cmd-$3 = $$(CC$(sm)) $$(comp-flags-$3) -fverbose-asm -S $$< -o $$@
 -include $$(comp-cmd-file-$3)
 -include $$(comp-dep-$3)
 
-$3: $1 $(conf-file) FORCE
+$3: $1 $(conf-file) $(4) FORCE
 # Check if any prerequisites are newer than the target and
 # check if command line has changed
 	$$(if $$(strip $$(filter-out FORCE, $$?) \
@@ -239,7 +240,7 @@ $(2): $(3)
 endef
 
 define gen-asm-defines-file
-$(call _gen-asm-defines-file,$1,$2,$(dir $2).$(notdir $(2:.h=.s)))
+$(call _gen-asm-defines-file,$1,$2,$(dir $2).$(notdir $(2:.h=.s)),$(asm-defines-$(notdir $(1))-deps))
 endef
 
 $(foreach f,$(asm-defines-files),$(eval $(call gen-asm-defines-file,$(f),$(out-dir)/$(sm)/include/generated/$(basename $(notdir $(f))).h)))


### PR DESCRIPTION
The header file <generated/asm-defines.h> is created at build time. It
contains macro definitions for various offsets in C structures and is
especially useful for use from assembler code. It is generated from
asm-defines.c, which includes a number of header files, of which two
are also generated at build time: <generated/arm32_sysreg.h> and
<generated/arm32_gicv3_sysreg.h>.

These dependencies are expressed nowhere in the makefiles and therefore
build errors can result. For example:

 $ make out/arm-plat-vexpress/core/include/generated/.asm-defines.s
   CHK     out/arm-plat-vexpress/conf.mk
   UPD     out/arm-plat-vexpress/conf.mk
   CHK     out/arm-plat-vexpress/include/generated/conf.h
   UPD     out/arm-plat-vexpress/include/generated/conf.h
   CC      out/arm-plat-vexpress/core/include/generated/.asm-defines.s
 In file included from core/arch/arm/include/arm.h:99,
                  from core/arch/arm/include/kernel/thread.h:12,
                  from core/arch/arm/kernel/asm-defines.c:8:
 core/arch/arm/include/arm32.h:167:10: fatal error: generated/arm32_sysreg.h: No such file or directory
   167 | #include <generated/arm32_sysreg.h>
       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
 compilation terminated.

The error in [1] is believed to have the same root cause: during
parallel build the generated header file might have been created by one
job but not yet written to when another job would open it. The compiler
would see an empty file, thus the missing declarations.

Add the missing dependencies via a new variable at the location where
asm-defines.c is added to the build.

Link: [1] https://ci.linaro.org/job/ledge-oe-premerge-ci/182/DISTRO=rpb,MACHINE=ledge-ti-am572x,label=docker-buster-amd64/console
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
