### PR TITLE
core: pull entropy from the REE

### DIFF
--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -10,6 +10,7 @@ srcs-$(CFG_SECURE_PARTITION) += secure_partition.c
 srcs-$(CFG_EMBEDDED_TS) += embedded_ts.c
 srcs-y += pseudo_ta.c
 srcs-y += tee_time.c
+srcs-$(CFG_PRNG_SOURCE_RANDOM_REE) += tee_random_ree.c
 srcs-y += rpc_io_i2c.c
 srcs-y += otp_stubs.c
 srcs-y += delay.c

--- a/core/arch/arm/kernel/tee_random_ree.c
+++ b/core/arch/arm/kernel/tee_random_ree.c
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Foundries.io Ltd
+ */
+
+#include <compiler.h>
+#include <crypto/crypto.h>
+#include <kernel/tee_random_ree.h>
+#include <kernel/thread.h>
+#include <optee_rpc_cmd.h>
+
+TEE_Result tee_random_add_ree_random(enum crypto_rng_src sid,
+				     unsigned int *pnum)
+{
+	struct thread_param params = THREAD_PARAM_VALUE(OUT, 0, 0, 0);
+	TEE_Result res = TEE_SUCCESS;
+
+	res = thread_rpc_cmd(OPTEE_RPC_CMD_GET_RANDOM, 1, &params);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	crypto_rng_add_event(sid, pnum,
+			     (const void *)&params.u.value,
+			     sizeof(params.u.value));
+
+	return TEE_SUCCESS;
+}

--- a/core/include/kernel/tee_random_ree.h
+++ b/core/include/kernel/tee_random_ree.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Foundries.io Ltd
+ */
+
+#ifndef TEE_RANDOM_H
+#define TEE_RANDOM_H
+
+#include "tee_api_types.h"
+
+#ifdef CFG_PRNG_SOURCE_RANDOM_REE
+TEE_Result tee_random_add_ree_random(enum crypto_rng_src sid,
+				     unsigned int *pnum);
+#else
+static inline TEE_Result
+tee_random_add_ree_random(enum crypto_rng_src sid __unused,
+			  unsigned int *pnum __unused)
+{
+	return TEE_SUCCESS;
+}
+#endif
+#endif /* TEE_RANDOM_H */

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -176,6 +176,17 @@
 #define OPTEE_RPC_I2C_FLAGS_TEN_BIT	BIT(0)
 
 /*
+ * Get random
+ *
+ * Returns random bytes
+ *
+ * [out] param[0].u.value.a	random bytes
+ * [out] param[0].u.value.b	random bytes
+ * [out] param[0].u.value.c	random bytes
+ */
+#define OPTEE_RPC_CMD_GET_RANDOM	22
+
+/*
  * Definition of protocol for command OPTEE_RPC_CMD_FS
  */
 


### PR DESCRIPTION
Pulls random data from the REE and proposes it as a source of entropy to the cryptographic
RNG. It adds fragments of 196 **bits** of entropy.

Original discussion and proposed kernel patch: https://github.com/OP-TEE/optee_os/issues/4392


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
