### PR TITLE
ta: pkcs11: optionally embed a debug & test token

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -578,6 +578,13 @@ CFG_CRYPTOLIB_DIR ?= core/lib/libtomcrypt
 # that would set = n.
 $(call force,CFG_CORE_MBEDTLS_MPI,y)
 
+# Number of tokens implemented by the PKCS11 TA
+CFG_PKCS11_TA_TOKEN_COUNT ?= 3
+
+# CFG_PKCS11_TA_OPTEE_DEBUG_TOKEN implements a PKCS11 token dedicated to
+# debug and test purpose.
+CFG_PKCS11_TA_OPTEE_DEBUG_TOKEN ?= $(CFG_ENABLE_EMBEDDED_TESTS)
+
 # Enable PKCS#11 TA's TEE Identity based authentication support
 CFG_PKCS11_TA_AUTH_TEE_IDENTITY ?= y
 

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -27,6 +27,13 @@
 #define PKCS11_TOKEN_HW_VERSION		PKCS11_SLOT_HW_VERSION
 #define PKCS11_TOKEN_FW_VERSION		PKCS11_SLOT_FW_VERSION
 
+/*
+ * This sepcific slot description is used in OP-TEE test environment
+ * to locate a debug and test PKCS11 token regression tests can safely
+ * play with.
+ */
+#define PKCS11_DEBUG_SLOT_DESCRIPTION	"OP-TEE PKCS11 TA debug slot"
+
 enum pkcs11_token_state {
 	PKCS11_TOKEN_RESET = 0,
 	PKCS11_TOKEN_READ_WRITE,
@@ -197,6 +204,9 @@ struct ck_token *get_token(unsigned int token_id);
 
 /* Return token identified from token instance address */
 unsigned int get_token_id(struct ck_token *token);
+
+/* CFG_PKCS11_TA_OPTEE_DEBUG_TOKEN can reserve a token for debug & test */
+bool token_is_optee_debug_token(struct ck_token *token);
 
 /* Access to persistent database */
 struct ck_token *init_persistent_db(unsigned int token_id);


### PR DESCRIPTION
Introduce configuration switch CFG_PKCS11_TA_OPTEE_DEBUG_TOKEN that,
when enabled, defines a specific debug and test token in PKCS11 TA
with a specific slot description to allow OP-TEE test suites to safely
use and hack into a PKCS11 token without corrupting device private
data.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
