### PR TITLE
pkcs11: Add implementation for C_DeriveKey()

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -565,6 +565,22 @@ enum pkcs11_ta_cmd {
 	 * This command relates to the PKCS#11 API function C_GenerateRandom().
 	 */
 	PKCS11_CMD_GENERATE_RANDOM = 42,
+
+	/*
+	 * PKCS11_CMD_DERIVE_KEY - Derive a key from a parent key.
+	 *
+	 * [in]  memref[0] = [
+	 *              32bit session handle,
+	 *              32bit parent key handle,
+	 *              (struct pkcs11_attribute_head)mechanism + mecha params,
+	 *              (struct pkcs11_object_head)attribs + attributes data
+	 *	 ]
+	 * [out] memref[0] = 32bit return code, enum pkcs11_rc
+	 * [out] memref[2] = 32bit object handle
+	 *
+	 * This command relates to the PKCS#11 API function C_DeriveKey().
+	 */
+	PKCS11_CMD_DERIVE_KEY = 43,
 };
 
 /*

--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -315,6 +315,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 	case PKCS11_CMD_GENERATE_RANDOM:
 		rc = entry_ck_generate_random(client, ptypes, params);
 		break;
+	case PKCS11_CMD_DERIVE_KEY:
+		rc = entry_derive_key(client, ptypes, params);
+		break;
 	default:
 		EMSG("Command %#"PRIx32" is not supported", cmd);
 		return TEE_ERROR_NOT_SUPPORTED;

--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -1245,8 +1245,6 @@ check_parent_attrs_against_processing(enum pkcs11_mechanism_id proc_id,
 	case PKCS11_CKM_AES_CBC_PAD:
 	case PKCS11_CKM_AES_CTS:
 	case PKCS11_CKM_AES_CTR:
-	case PKCS11_CKM_AES_ECB_ENCRYPT_DATA:
-	case PKCS11_CKM_AES_CBC_ENCRYPT_DATA:
 		if (key_class == PKCS11_CKO_SECRET_KEY &&
 		    key_type == PKCS11_CKK_AES)
 			break;
@@ -1256,6 +1254,24 @@ check_parent_attrs_against_processing(enum pkcs11_mechanism_id proc_id,
 
 		return PKCS11_CKR_KEY_FUNCTION_NOT_PERMITTED;
 
+	case PKCS11_CKM_AES_ECB_ENCRYPT_DATA:
+	case PKCS11_CKM_AES_CBC_ENCRYPT_DATA:
+		if (key_class != PKCS11_CKO_SECRET_KEY &&
+		    key_type != PKCS11_CKK_AES)
+			return PKCS11_CKR_KEY_FUNCTION_NOT_PERMITTED;
+
+		if (get_bool(head, PKCS11_CKA_ENCRYPT)) {
+			/*
+			 * Intentionally refuse to proceed despite
+			 * PKCS#11 specifications v2.40 and v3.0 not expecting
+			 * this behavior to avoid potential security issue
+			 * where keys derived by these mechanisms can be
+			 * revealed by doing data encryption using parent key.
+			 */
+			return PKCS11_CKR_FUNCTION_FAILED;
+		}
+
+		break;
 	case PKCS11_CKM_MD5_HMAC:
 	case PKCS11_CKM_SHA_1_HMAC:
 	case PKCS11_CKM_SHA224_HMAC:

--- a/ta/pkcs11/src/pkcs11_helpers.c
+++ b/ta/pkcs11/src/pkcs11_helpers.c
@@ -180,6 +180,7 @@ static const struct any_id __maybe_unused string_ta_cmd[] = {
 	PKCS11_ID(PKCS11_CMD_COPY_OBJECT),
 	PKCS11_ID(PKCS11_CMD_SEED_RANDOM),
 	PKCS11_ID(PKCS11_CMD_GENERATE_RANDOM),
+	PKCS11_ID(PKCS11_CMD_DERIVE_KEY),
 };
 
 static const struct any_id __maybe_unused string_slot_flags[] = {

--- a/ta/pkcs11/src/processing.h
+++ b/ta/pkcs11/src/processing.h
@@ -30,6 +30,9 @@ enum pkcs11_rc entry_processing_step(struct pkcs11_client *client,
 				     enum processing_func function,
 				     enum processing_step step);
 
+enum pkcs11_rc entry_derive_key(struct pkcs11_client *client,
+				uint32_t ptypes, TEE_Param *params);
+
 /*
  * Util
  */
@@ -54,4 +57,8 @@ enum pkcs11_rc step_symm_operation(struct pkcs11_session *session,
 
 enum pkcs11_rc tee_init_ctr_operation(struct active_processing *processing,
 				      void *proc_params, size_t params_size);
+
+enum pkcs11_rc derive_key_by_symm_enc(struct pkcs11_session *session,
+				      struct obj_attrs **head);
+
 #endif /*PKCS11_TA_PROCESSING_H*/


### PR DESCRIPTION
Other PR's related to this :
optee_client - https://github.com/OP-TEE/optee_client/pull/257
optee_test - https://github.com/OP-TEE/optee_test/pull/490

DERIVE_TEMPLATE has not been used in the implementation right now. The specification (even v3.0) doesn't mention clearly about it. The plan is to work on C_Wrap/UnWrap API's next and then revisit the DERIVE_TEMPLATE usage.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
