### PR TITLE
ta: pkcs11: Close file handle after object has been created

### DIFF
--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -244,6 +244,9 @@ enum pkcs11_rc create_object(void *sess, struct obj_attrs *head,
 		if (rc)
 			goto err;
 
+		TEE_CloseObject(obj->attribs_hdl);
+		obj->attribs_hdl = TEE_HANDLE_NULL;
+
 		LIST_INSERT_HEAD(&session->token->object_list, obj, link);
 	} else {
 		rc = PKCS11_CKR_OK;


### PR DESCRIPTION
When creating a object file handle was left open. This was observed in
tee-supplicant as open file handles.

This fixes the situation so that file handles are not left open.

To demonstrate the problem:

Without the fix:

```sh
$ lsof | grep tee-supplicant
279	/usr/sbin/tee-supplicant	/dev/null
279	/usr/sbin/tee-supplicant	socket:[7445]
279	/usr/sbin/tee-supplicant	socket:[7445]
279	/usr/sbin/tee-supplicant	/dev/teepriv0

$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 1 --init-token --label pkcs11test --so-pin 5678567856
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 1 --init-pin --login --so-pin 5678567856 --new-pin 1234123412

$ lsof | grep tee-supplicant
279	/usr/sbin/tee-supplicant	/dev/null
279	/usr/sbin/tee-supplicant	socket:[7445]
279	/usr/sbin/tee-supplicant	socket:[7445]
279	/usr/sbin/tee-supplicant	/dev/teepriv0

$ pkcs11-tool --module /usr/lib/libckteec.so.0 --token-label pkcs11test --login --pin "1234123412" --keygen --key-type aes:32 --label secret-key
$ lsof | grep tee-supplicant
279	/usr/sbin/tee-supplicant	/dev/null
279	/usr/sbin/tee-supplicant	socket:[7445]
279	/usr/sbin/tee-supplicant	socket:[7445]
279	/usr/sbin/tee-supplicant	/dev/teepriv0
279	/usr/sbin/tee-supplicant	/certificates/tee/dirf.db
279	/usr/sbin/tee-supplicant	/certificates/tee/5
```

With the fix:

```sh
$ lsof | grep tee-supplicant
275	/usr/sbin/tee-supplicant	/dev/null
275	/usr/sbin/tee-supplicant	socket:[7378]
275	/usr/sbin/tee-supplicant	socket:[7378]
275	/usr/sbin/tee-supplicant	/dev/teepriv0
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 1 --init-token --label pkcs11test --so-pin 5678567856
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 1 --init-pin --login --so-pin 5678567856 --new-pin 1234123412
$ lsof | grep tee-supplicant
275	/usr/sbin/tee-supplicant	/dev/null
275	/usr/sbin/tee-supplicant	socket:[7378]
275	/usr/sbin/tee-supplicant	socket:[7378]
275	/usr/sbin/tee-supplicant	/dev/teepriv0
$ pkcs11-tool --module /usr/lib/libckteec.so.0 --token-label pkcs11test --login --pin "1234123412" --keygen --key-type aes:32 --label secret-key
$ lsof | grep tee-supplicant
275	/usr/sbin/tee-supplicant	/dev/null
275	/usr/sbin/tee-supplicant	socket:[7378]
275	/usr/sbin/tee-supplicant	socket:[7378]
275	/usr/sbin/tee-supplicant	/dev/teepriv0
```


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
