### PR TITLE
RFC: Enabling Fortuna RNG and HW RNG

### DIFF
--- a/core/crypto/sub.mk
+++ b/core/crypto/sub.mk
@@ -10,11 +10,8 @@ endif
 
 srcs-$(CFG_WITH_USER_TA) += signed_hdr.c
 
-ifeq ($(CFG_WITH_SOFTWARE_PRNG),y)
 srcs-y += rng_fortuna.c
-else
 srcs-y += rng_hw.c
-endif
 
 ifneq ($(CFG_CRYPTO_CBC_MAC_FROM_CRYPTOLIB),y)
 srcs-$(CFG_CRYPTO_CBC_MAC) += cbc-mac.c

--- a/core/drivers/crypto/se050/core/rng.c
+++ b/core/drivers/crypto/se050/core/rng.c
@@ -5,8 +5,11 @@
  */
 
 #include <crypto/crypto.h>
+#include <kernel/panic.h>
+#include <kernel/tee_time.h>
 #include <rng_support.h>
 #include <se050.h>
+#include <string.h>
 #include <tee/tee_cryp_utl.h>
 
 static TEE_Result do_rng_read(void *buf, size_t blen)
@@ -26,6 +29,39 @@ static TEE_Result do_rng_read(void *buf, size_t blen)
 
 void plat_rng_init(void)
 {
+	TEE_Result res = TEE_SUCCESS;
+	TEE_Time t;
+
+#ifndef CFG_SECURE_TIME_SOURCE_REE
+	/*
+	 * This isn't much of a seed. Ideally we should either get a seed from
+	 * a hardware RNG or from a previously saved seed.
+	 *
+	 * Seeding with hardware RNG is currently up to the platform to
+	 * override this function.
+	 *
+	 * Seeding with a saved seed will require cooperation from normal
+	 * world, this is still TODO.
+	 */
+	res = tee_time_get_sys_time(&t);
+#else
+	EMSG("Warning: seeding PRNG with zeroes");
+	memset(&t, 0, sizeof(t));
+#endif
+	/* only need to initialize the prng */
+	if (!res)
+		res = crypto_prng_init(&t, sizeof(t));
+	if (res) {
+		EMSG("Failed to initialize PRNG: %#" PRIx32, res);
+		panic();
+	}
+}
+
+void crypto_rng_add_event(enum crypto_rng_src sid, unsigned int *pnum,
+			  const void *data, size_t dlen)
+{
+	/* only need to add entropy to the prng */
+	crypto_prng_add_event(sid, pnum, data, dlen);
 }
 
 TEE_Result crypto_rng_read(void *buf, size_t blen)

--- a/core/drivers/crypto/se050/glue/user.c
+++ b/core/drivers/crypto/se050/glue/user.c
@@ -85,11 +85,13 @@ void glue_context_free(void *cipher)
 
 sss_status_t glue_rng_get_random(uint8_t *data, size_t len)
 {
-	if (IS_ENABLED(CFG_NXP_SE05X_RNG_DRV))
-		return kStatus_SSS_InvalidArgument;
+	if (IS_ENABLED(CFG_NXP_SE05X_RNG_DRV)) {
+		if (crypto_prng_read(data, len))
+			return kStatus_SSS_Fail;
+		return kStatus_SSS_Success;
+	}
 
 	if (crypto_rng_read(data, len))
 		return kStatus_SSS_Fail;
-
 	return kStatus_SSS_Success;
 }

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -347,6 +347,20 @@ void crypto_rng_add_event(enum crypto_rng_src sid, unsigned int *pnum,
  */
 TEE_Result crypto_rng_read(void *buf, size_t len);
 
+/* These set of functions provide PRNG support when an RNG is already
+ * available
+ *
+ * Secure elements require encryption (SCP03) of the communication channel
+ * between the processor and the element; therefore a random number generator
+ * is required to be able to access the RNG provided by these secure elements
+ */
+TEE_Result crypto_prng_init(const void *data, size_t dlen);
+
+TEE_Result crypto_prng_read(void *buf, size_t len);
+
+void crypto_prng_add_event(enum crypto_rng_src sid, unsigned int *pnum,
+			   const void *data, size_t dlen);
+
 /*
  * crypto_aes_expand_enc_key() - Expand an AES key
  * @key:	AES key buffer


### PR DESCRIPTION
Secure Channel Protocol 03 requires that all communication between the
secure element and the processor is software encrypted.

This means that in order to read the RNG provided by the secure
elements, we first need to gather some entropy to feed to the
software cryptograpnhic algorithms that will do the encryption.

This commit alters the meaning of CFG_WITH_SOFTWARE_PRNG:

1) When enabled, the new interface **crypto_prng_*** should not be used 
as **crypto_rng_*** already provides the randomness.

2) When not enabled, the new interface **crypto_rng_*** provides the 
HWRNG functionality (as usual) while **crypto_prng_*** provides the 
PRNG  (fortuna) randomness.

This means that the rng_fortuna.c is always built. Will this be an issue? should we 
add an extra config for that case when both RNG and PRNG are needed in order to avoid this?

This is a quick and dirty implementation but the idea is somewhere around these
lines (maybe adding an extra CFG_WITH_ADDITIONAL_SOFTWARE_PRNG)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
