### PR TITLE
core: mobj: fix memory leak

### DIFF
--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -190,6 +190,7 @@ static TEE_Result mobj_reg_shm_inc_map(struct mobj *mobj)
 	if (refcount_val(&r->mapcount))
 		goto out;
 
+	assert(!r->mm);
 	sz = ROUNDUP(mobj->size + r->page_offset, SMALL_PAGE_SIZE);
 	r->mm = tee_mm_alloc(&tee_mm_shm, sz);
 	if (!r->mm) {
@@ -222,7 +223,7 @@ static TEE_Result mobj_reg_shm_dec_map(struct mobj *mobj)
 
 	exceptions = cpu_spin_lock_xsave(&reg_shm_map_lock);
 
-	if (refcount_val(&r->mapcount))
+	if (!refcount_val(&r->mapcount))
 		reg_shm_unmap_helper(r);
 
 	cpu_spin_unlock_xrestore(&reg_shm_map_lock, exceptions);


### PR DESCRIPTION
dynamic shared memory is not being released leading to an out of
memory condition.

Issue triggered by exporting the cryptographic random generator to the
REE (Linux) and then loop reading the value via the device interface
(cat /dev/random). This test case generates a couple of 4K allocations
 every ~200ms on imx8mm with one of them always leaking.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
