### PR TITLE
ta: pkcs11: private key can also be public

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -913,13 +913,7 @@ static enum pkcs11_rc check_attrs_misc_integrity(struct obj_attrs *head)
 
 bool object_is_private(struct obj_attrs *head)
 {
-	if (get_class(head) == PKCS11_CKO_PRIVATE_KEY)
-		return true;
-
-	if (get_bool(head, PKCS11_CKA_PRIVATE))
-		return true;
-
-	return false;
+	return get_bool(head, PKCS11_CKA_PRIVATE);
 }
 
 bool object_is_token(struct obj_attrs *head)
@@ -947,11 +941,10 @@ enum pkcs11_rc check_access_attrs_against_token(struct pkcs11_session *session,
 
 	switch (get_class(head)) {
 	case PKCS11_CKO_SECRET_KEY:
+	case PKCS11_CKO_PRIVATE_KEY:
 	case PKCS11_CKO_PUBLIC_KEY:
 	case PKCS11_CKO_DATA:
-		private = get_bool(head, PKCS11_CKA_PRIVATE);
-		break;
-	case PKCS11_CKO_PRIVATE_KEY:
+		private = object_is_private(head);
 		break;
 	default:
 		return PKCS11_CKR_KEY_FUNCTION_NOT_PERMITTED;


### PR DESCRIPTION
Even thou normal operations should mark private key a private with
CKA_PRIVATE attribute it is possible that someone could do
unexpected choise.

Specification does not state that private key class itself means that it
is private, specification only states that CKA_PRIVATE is in control of
the privacy of the object.

This commit moves object class CKO_PRIVATE_KEY processing to normal
handling of CKA_PRIVATE.

CKA_PRIVATE is specified in:
PKCS #11 Cryptographic Token Interface Base Specification Version 2.40
Plus Errata 01
4.4 Storage Objects

Possibility of having private key object with CKA_PRIVATE as false:
PKCS #11 Cryptographic Token Interface Base Specification Version 2.40
Plus Errata 01
4.9 Private key objects

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
