### PR TITLE
Fix value of TEE_ECC_CURVE_SM2

### DIFF
--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -288,7 +288,7 @@
 #define TEE_ECC_CURVE_NIST_P256             0x00000003
 #define TEE_ECC_CURVE_NIST_P384             0x00000004
 #define TEE_ECC_CURVE_NIST_P521             0x00000005
-#define TEE_ECC_CURVE_SM2                   0x00000300
+#define TEE_ECC_CURVE_SM2                   0x00000400
 
 
 /* Panicked Functions Identification */


### PR DESCRIPTION
The GlobalPlatform TEE Internal Core API specification versions 1.2 and
1.2.1 erroneously assigned the same value (0x00000300) to
TEE_ECC_CURVE_SM2 and TEE_ECC_CURVE_25519. TEE_ECC_CURVE_SM2 was later
changed to 0x00000400 in version 1.3. This went unnoticed because
OP-TEE does not support TEE_ECC_CURVE_25519 (yet).

Note that TAs using the erroneous value will have to be recompiled in
order to work with a newer OP-TEE OS.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
