### PR TITLE
Update struct gpio_ops and Add GPIO driver for NXP LS Platforms

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -132,6 +132,11 @@ R:	Sahil Malhotra <sahil.malhotra@nxp.com>
 S:	Maintained
 F:	core/drivers/ls_i2c.c
 
+Core Drivers GPIO
+R:	Manish Tomar <manish.tomar@nxp.com>
+S:	Maintained
+F:	core/drivers/ls_gpio.c
+
 NXP (Freescale) i.MX family
 R:	Peng Fan <peng.fan@nxp.com> [@MrVan]
 R:	Cedric Neveux <cedric.neveux@nxp.com> [@cneveux]

--- a/core/arch/arm/plat-hikey/spi_test.c
+++ b/core/arch/arm/plat-hikey/spi_test.c
@@ -27,8 +27,9 @@ static void spi_cs_callback(enum gpio_level value)
 		pl061_init(&pd);
 		pl061_register(gpio6_base, 6);
 		pl061_set_mode_control(GPIO6_2, PL061_MC_SW);
-		pd.chip.ops->set_interrupt(GPIO6_2, GPIO_INTERRUPT_DISABLE);
-		pd.chip.ops->set_direction(GPIO6_2, GPIO_DIR_OUT);
+		pd.chip.ops->set_interrupt(NULL, GPIO6_2,
+					   GPIO_INTERRUPT_DISABLE);
+		pd.chip.ops->set_direction(NULL, GPIO6_2, GPIO_DIR_OUT);
 		inited = true;
 	}
 
@@ -38,7 +39,7 @@ static void spi_cs_callback(enum gpio_level value)
 		;
 	DMSG("pl022 done - set CS!");
 
-	pd.chip.ops->set_value(GPIO6_2, value);
+	pd.chip.ops->set_value(NULL, GPIO6_2, value);
 }
 
 static void spi_set_cs_mux(uint32_t val)

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -99,6 +99,7 @@ $(call force,CFG_CORE_ARM64_PA_BITS,48)
 $(call force,CFG_EMBED_DT,y)
 $(call force,CFG_EMBED_DTB_SOURCE_FILE,fsl-lx2160a-qds.dts)
 CFG_LS_I2C ?= y
+CFG_LS_GPIO ?= y
 CFG_SHMEM_SIZE ?= 0x00200000
 endif
 
@@ -117,6 +118,7 @@ $(call force,CFG_CORE_ARM64_PA_BITS,48)
 $(call force,CFG_EMBED_DT,y)
 $(call force,CFG_EMBED_DTB_SOURCE_FILE,fsl-lx2160a-rdb.dts)
 CFG_LS_I2C ?= y
+CFG_LS_GPIO ?= y
 CFG_SHMEM_SIZE ?= 0x00200000
 endif
 

--- a/core/drivers/bcm_gpio.c
+++ b/core/drivers/bcm_gpio.c
@@ -74,7 +74,8 @@ static void iproc_clr_bit(unsigned int reg, unsigned int gpio)
 	io_clrbits32(gc->base + offset, BIT(shift));
 }
 
-static void iproc_gpio_set(unsigned int gpio, enum gpio_level val)
+static void iproc_gpio_set(struct gpio_chip *chip __unused, unsigned int gpio,
+			   enum gpio_level val)
 {
 	if (val == GPIO_LEVEL_HIGH)
 		iproc_set_bit(IPROC_GPIO_DATA_OUT_OFFSET, gpio);
@@ -82,7 +83,8 @@ static void iproc_gpio_set(unsigned int gpio, enum gpio_level val)
 		iproc_clr_bit(IPROC_GPIO_DATA_OUT_OFFSET, gpio);
 }
 
-static enum gpio_level iproc_gpio_get(unsigned int gpio)
+static enum gpio_level iproc_gpio_get(struct gpio_chip *chip __unused,
+				      unsigned int gpio)
 {
 	unsigned int offset = IPROC_GPIO_REG(gpio, IPROC_GPIO_DATA_IN_OFFSET);
 	unsigned int shift = IPROC_GPIO_SHIFT(gpio);
@@ -96,7 +98,8 @@ static enum gpio_level iproc_gpio_get(unsigned int gpio)
 		return GPIO_LEVEL_LOW;
 }
 
-static void iproc_gpio_set_dir(unsigned int gpio, enum gpio_dir dir)
+static void iproc_gpio_set_dir(struct gpio_chip *chip __unused,
+			       unsigned int gpio, enum gpio_dir dir)
 {
 	if (dir == GPIO_DIR_OUT)
 		iproc_set_bit(IPROC_GPIO_OUT_EN_OFFSET, gpio);
@@ -104,7 +107,8 @@ static void iproc_gpio_set_dir(unsigned int gpio, enum gpio_dir dir)
 		iproc_clr_bit(IPROC_GPIO_OUT_EN_OFFSET, gpio);
 }
 
-static enum gpio_dir iproc_gpio_get_dir(unsigned int gpio)
+static enum gpio_dir iproc_gpio_get_dir(struct gpio_chip *chip __unused,
+					unsigned int gpio)
 {
 	unsigned int offset = IPROC_GPIO_REG(gpio, IPROC_GPIO_OUT_EN_OFFSET);
 	unsigned int shift = IPROC_GPIO_SHIFT(gpio);
@@ -118,7 +122,8 @@ static enum gpio_dir iproc_gpio_get_dir(unsigned int gpio)
 		return GPIO_DIR_IN;
 }
 
-static enum gpio_interrupt iproc_gpio_get_itr(unsigned int gpio)
+static enum gpio_interrupt iproc_gpio_get_itr(struct gpio_chip *chip __unused,
+					      unsigned int gpio)
 {
 	unsigned int offset = IPROC_GPIO_REG(gpio, IPROC_GPIO_INT_MSK_OFFSET);
 	unsigned int shift = IPROC_GPIO_SHIFT(gpio);
@@ -132,8 +137,8 @@ static enum gpio_interrupt iproc_gpio_get_itr(unsigned int gpio)
 		return GPIO_INTERRUPT_DISABLE;
 }
 
-static void iproc_gpio_set_itr(unsigned int gpio,
-			       enum gpio_interrupt ena_dis)
+static void iproc_gpio_set_itr(struct gpio_chip *chip __unused,
+			       unsigned int gpio, enum gpio_interrupt ena_dis)
 {
 	if (ena_dis == GPIO_INTERRUPT_ENABLE)
 		iproc_set_bit(IPROC_GPIO_OUT_EN_OFFSET, gpio);

--- a/core/drivers/ls_gpio.c
+++ b/core/drivers/ls_gpio.c
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2021 NXP
+ *
+ * Driver for GPIO Controller
+ *
+ */
+
+#include <assert.h>
+#include <drivers/ls_gpio.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/dt.h>
+#include <libfdt.h>
+#include <mm/core_memprot.h>
+
+static const char * const gpio_controller_map[] = {
+	 "/soc/gpio@2300000",
+	 "/soc/gpio@2310000",
+	 "/soc/gpio@2320000",
+	 "/soc/gpio@2330000"
+};
+
+/*
+ * Get value from GPIO controller
+ * chip:        pointer to GPIO controller chip instance
+ * gpio_pin:    pin from which value needs to be read
+ */
+static enum gpio_level gpio_get_value(struct gpio_chip *chip,
+				      unsigned int gpio_pin)
+{
+	vaddr_t gpio_data_addr = 0;
+	uint32_t data = 0;
+	struct ls_gpio_chip_data *gc_data = container_of(chip,
+						      struct ls_gpio_chip_data,
+						      chip);
+
+	assert(gpio_pin <= MAX_GPIO_PINS);
+
+	gpio_data_addr = gc_data->gpio_base + GPIODAT;
+	data = io_read32(gpio_data_addr);
+
+	if (data & PIN_SHIFT(gpio_pin))
+		return GPIO_LEVEL_HIGH;
+	else
+		return GPIO_LEVEL_LOW;
+}
+
+/*
+ * Set value for GPIO controller
+ * chip:        pointer to GPIO controller chip instance
+ * gpio_pin:    pin to which value needs to be write
+ * value:       value needs to be written to the pin
+ */
+static void gpio_set_value(struct gpio_chip *chip, unsigned int gpio_pin,
+			   enum gpio_level value)
+{
+	vaddr_t gpio_data_addr = 0;
+	struct ls_gpio_chip_data *gc_data = container_of(chip,
+						      struct ls_gpio_chip_data,
+						      chip);
+
+	assert(gpio_pin <= MAX_GPIO_PINS);
+
+	gpio_data_addr = gc_data->gpio_base + GPIODAT;
+
+	if (value == GPIO_LEVEL_HIGH)
+		/* if value is high then set pin value */
+		io_setbits32(gpio_data_addr, PIN_SHIFT(gpio_pin));
+	else
+		/* if value is low then clear pin value */
+		io_clrbits32(gpio_data_addr, PIN_SHIFT(gpio_pin));
+}
+
+/*
+ * Get direction from GPIO controller
+ * chip:        pointer to GPIO controller chip instance
+ * gpio_pin:    pin from which direction needs to be read
+ */
+static enum gpio_dir gpio_get_direction(struct gpio_chip *chip,
+					unsigned int gpio_pin)
+{
+	vaddr_t gpio_dir_addr = 0;
+	uint32_t data = 0;
+	struct ls_gpio_chip_data *gc_data = container_of(chip,
+						      struct ls_gpio_chip_data,
+						      chip);
+
+	assert(gpio_pin <= MAX_GPIO_PINS);
+
+	gpio_dir_addr = gc_data->gpio_base + GPIODIR;
+	data = io_read32(gpio_dir_addr);
+
+	if (data & PIN_SHIFT(gpio_pin))
+		return GPIO_DIR_OUT;
+	else
+		return GPIO_DIR_IN;
+}
+
+/*
+ * Set direction for GPIO controller
+ * chip:        pointer to GPIO controller chip instance
+ * gpio_pin:    pin on which direction needs to be set
+ * direction:   direction which needs to be set on pin
+ */
+static void gpio_set_direction(struct gpio_chip *chip, unsigned int gpio_pin,
+			       enum gpio_dir direction)
+{
+	vaddr_t gpio_dir_addr = 0;
+	struct ls_gpio_chip_data *gc_data = container_of(chip,
+						      struct ls_gpio_chip_data,
+						      chip);
+
+	assert(gpio_pin <= MAX_GPIO_PINS);
+
+	gpio_dir_addr = gc_data->gpio_base + GPIODIR;
+
+	if (direction == GPIO_DIR_OUT)
+		io_setbits32(gpio_dir_addr, PIN_SHIFT(gpio_pin));
+	else
+		io_clrbits32(gpio_dir_addr, PIN_SHIFT(gpio_pin));
+}
+
+/*
+ * Get interrupt from GPIO controller
+ * chip:        pointer to GPIO controller chip instance
+ * gpio_pin:    pin from which interrupt value needs to be read
+ */
+static enum gpio_interrupt gpio_get_interrupt(struct gpio_chip *chip,
+					      unsigned int gpio_pin)
+{
+	vaddr_t gpio_ier_addr = 0;
+	uint32_t data = 0;
+	struct ls_gpio_chip_data *gc_data = container_of(chip,
+						      struct ls_gpio_chip_data,
+						      chip);
+
+	assert(gpio_pin <= MAX_GPIO_PINS);
+
+	gpio_ier_addr = gc_data->gpio_base + GPIOIER;
+	data = io_read32(gpio_ier_addr);
+
+	if (data & PIN_SHIFT(gpio_pin))
+		return GPIO_INTERRUPT_ENABLE;
+	else
+		return GPIO_INTERRUPT_DISABLE;
+}
+
+/*
+ * Set interrupt event for GPIO controller
+ * chip:        pointer to GPIO controller chip instance
+ * gpio_pin:    pin on which interrupt value needs to be set
+ * interrupt:   interrupt valie which needs to be set on pin
+ */
+static void gpio_set_interrupt(struct gpio_chip *chip, unsigned int gpio_pin,
+			       enum gpio_interrupt interrupt)
+{
+	vaddr_t gpio_ier_addr = 0;
+	struct ls_gpio_chip_data *gc_data = container_of(chip,
+						      struct ls_gpio_chip_data,
+						      chip);
+
+	assert(gpio_pin <= MAX_GPIO_PINS);
+
+	gpio_ier_addr = gc_data->gpio_base + GPIOIER;
+
+	if (interrupt == GPIO_INTERRUPT_ENABLE)
+		io_setbits32(gpio_ier_addr, PIN_SHIFT(gpio_pin));
+	else
+		io_clrbits32(gpio_ier_addr, PIN_SHIFT(gpio_pin));
+}
+
+/*
+ * Extract information for GPIO Controller from the DTB
+ * gpio_data:	GPIO controller chip instance
+ */
+static TEE_Result get_info_from_device_tree(struct ls_gpio_chip_data *gpio_data)
+{
+	size_t size = 0;
+	int node = 0;
+	vaddr_t ctrl_base = 0;
+	void *fdt = NULL;
+
+	/*
+	 * First get the GPIO Controller base address from the DTB
+	 * if DTB present and if the GPIO Controller defined in it.
+	 */
+	fdt = get_embedded_dt();
+	if (!fdt) {
+		EMSG("Unable to get the Embedded DTB, GPIO init failed\n");
+		return TEE_ERROR_GENERIC;
+	}
+
+	node = fdt_path_offset(fdt, gpio_controller_map
+			       [gpio_data->gpio_controller]);
+	if (node > 0) {
+		if (dt_map_dev(fdt, node, &ctrl_base, &size) < 0) {
+			EMSG("Unable to get virtual address");
+			return TEE_ERROR_GENERIC;
+		}
+	} else {
+		EMSG("Unable to get gpio offset node");
+		return TEE_ERROR_ITEM_NOT_FOUND;
+	}
+
+	gpio_data->gpio_base = ctrl_base;
+
+	return TEE_SUCCESS;
+}
+
+static const struct gpio_ops ls_gpio_ops = {
+	.get_direction = gpio_get_direction,
+	.set_direction = gpio_set_direction,
+	.get_value = gpio_get_value,
+	.set_value = gpio_set_value,
+	.get_interrupt = gpio_get_interrupt,
+	.set_interrupt = gpio_set_interrupt,
+};
+DECLARE_KEEP_PAGER(ls_gpio_ops);
+
+TEE_Result ls_gpio_init(struct ls_gpio_chip_data *gpio_data)
+{
+	TEE_Result status = TEE_ERROR_GENERIC;
+
+	/*
+	 * First get the GPIO Controller base address from the DTB,
+	 * if DTB present and if the GPIO Controller defined in it.
+	 */
+	status = get_info_from_device_tree(gpio_data);
+	if (status == TEE_SUCCESS) {
+		/* set GPIO Input Buffer Enable register */
+		io_setbits32(gpio_data->gpio_base + GPIOIBE, UINT32_MAX);
+
+		/* generic GPIO chip handle */
+		gpio_data->chip.ops = &ls_gpio_ops;
+	} else {
+		EMSG("Unable to get info from device tree");
+	}
+
+	return status;
+}

--- a/core/drivers/pl022_spi.c
+++ b/core/drivers/pl022_spi.c
@@ -294,7 +294,7 @@ static void pl022_control_cs(struct spi_chip *chip, enum gpio_level value)
 			;
 		DMSG("pl022 done - set CS!");
 
-		pd->cs_data.gpio_data.chip->ops->set_value(
+		pd->cs_data.gpio_data.chip->ops->set_value(NULL,
 			pd->cs_data.gpio_data.pin_num, value);
 		break;
 	case PL022_CS_CTRL_CB:
@@ -380,11 +380,11 @@ static void pl022_configure(struct spi_chip *chip)
 	case PL022_CS_CTRL_AUTO_GPIO:
 		DMSG("Use auto GPIO CS control");
 		DMSG("Mask/disable interrupt for CS GPIO");
-		pd->cs_data.gpio_data.chip->ops->set_interrupt(
+		pd->cs_data.gpio_data.chip->ops->set_interrupt(NULL,
 			pd->cs_data.gpio_data.pin_num,
 			GPIO_INTERRUPT_DISABLE);
 		DMSG("Set CS GPIO dir to out");
-		pd->cs_data.gpio_data.chip->ops->set_direction(
+		pd->cs_data.gpio_data.chip->ops->set_direction(NULL,
 			pd->cs_data.gpio_data.pin_num,
 			GPIO_DIR_OUT);
 		break;

--- a/core/drivers/pl061_gpio.c
+++ b/core/drivers/pl061_gpio.c
@@ -40,7 +40,8 @@
 
 static vaddr_t pl061_reg_base[MAX_GPIO_DEVICES];
 
-static enum gpio_dir pl061_get_direction(unsigned int gpio_pin)
+static enum gpio_dir pl061_get_direction(struct gpio_chip *chip __unused,
+					 unsigned int gpio_pin)
 {
 	vaddr_t base_addr;
 	uint8_t data;
@@ -56,7 +57,8 @@ static enum gpio_dir pl061_get_direction(unsigned int gpio_pin)
 	return GPIO_DIR_IN;
 }
 
-static void pl061_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
+static void pl061_set_direction(struct gpio_chip *chip __unused,
+				unsigned int gpio_pin, enum gpio_dir direction)
 {
 	vaddr_t base_addr;
 	unsigned int offset;
@@ -79,7 +81,8 @@ static void pl061_set_direction(unsigned int gpio_pin, enum gpio_dir direction)
  * to be read, and bits that are 0 in the address mask cause the corresponding
  * bits in GPIODATA to be read as 0, regardless of their value.
  */
-static enum gpio_level pl061_get_value(unsigned int gpio_pin)
+static enum gpio_level pl061_get_value(struct gpio_chip *chip __unused,
+				       unsigned int gpio_pin)
 {
 	vaddr_t base_addr;
 	unsigned int offset;
@@ -98,7 +101,8 @@ static enum gpio_level pl061_get_value(unsigned int gpio_pin)
  * from the address bus, PADDR[9:2], must be HIGH. Otherwise the bit values
  * remain unchanged by the write.
  */
-static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
+static void pl061_set_value(struct gpio_chip *chip __unused,
+			    unsigned int gpio_pin, enum gpio_level value)
 {
 	vaddr_t base_addr;
 	unsigned int offset;
@@ -113,7 +117,8 @@ static void pl061_set_value(unsigned int gpio_pin, enum gpio_level value)
 		io_write8(base_addr + BIT(offset + 2), 0);
 }
 
-static enum gpio_interrupt pl061_get_interrupt(unsigned int gpio_pin)
+static enum gpio_interrupt pl061_get_interrupt(struct gpio_chip *chip __unused,
+					       unsigned int gpio_pin)
 {
 	vaddr_t base_addr;
 	uint8_t data;
@@ -129,8 +134,9 @@ static enum gpio_interrupt pl061_get_interrupt(unsigned int gpio_pin)
 	return GPIO_INTERRUPT_DISABLE;
 }
 
-static void pl061_set_interrupt(unsigned int gpio_pin,
-	enum gpio_interrupt ena_dis)
+static void pl061_set_interrupt(struct gpio_chip *chip __unused,
+				unsigned int gpio_pin,
+				enum gpio_interrupt ena_dis)
 {
 	vaddr_t base_addr;
 	unsigned int offset;

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -33,6 +33,7 @@ srcs-$(CFG_BCM_HWRNG) += bcm_hwrng.c
 srcs-$(CFG_BCM_SOTP) += bcm_sotp.c
 srcs-$(CFG_BCM_GPIO) += bcm_gpio.c
 srcs-$(CFG_LS_I2C) += ls_i2c.c
+srcs-$(CFG_LS_GPIO) += ls_gpio.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/include/drivers/ls_gpio.h
+++ b/core/include/drivers/ls_gpio.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2021 NXP
+ *
+ * Helper Code for GPIO controller driver
+ *
+ */
+
+#ifndef __DRIVERS_LS_GPIO_H
+#define __DRIVERS_LS_GPIO_H
+
+#include <gpio.h>
+#include <stdlib.h>
+#include <tee_api_types.h>
+
+/* supported ports for GPIO controller */
+#define MAX_GPIO_PINS 31
+
+/* map register values to LE by subtracting pin number from MAX GPIO PINS */
+#define PIN_SHIFT(x) (1 << (MAX_GPIO_PINS - (x)))
+
+/* gpio register offsets */
+#define GPIODIR 0x0  /* direction register */
+#define GPIOODR 0x4  /* open drain register */
+#define GPIODAT 0x8  /* data register */
+#define GPIOIER 0xc  /* interrupt event register */
+#define GPIOIMR 0x10 /* interrupt mask register */
+#define GPIOICR 0x14 /* interrupt control register */
+#define GPIOIBE 0x18 /* input buffer enable register */
+
+/*
+ * struct ls_gpio_chip_data describes GPIO controller chip instance
+ * The structure contains below members:
+ * chip:		generic GPIO chip handle.
+ * gpio_base:		starting GPIO module base address managed by this GPIO
+ *			controller.
+ * gpio_controller:	GPIO controller to be used.
+ */
+struct ls_gpio_chip_data {
+	struct gpio_chip chip;
+	vaddr_t gpio_base;
+	uint8_t gpio_controller;
+};
+
+/*
+ * Initialize GPIO Controller
+ * gpio_data is a pointer of type 'struct ls_gpio_chip_data'.
+ */
+TEE_Result ls_gpio_init(struct ls_gpio_chip_data *gpio_data);
+
+#endif /* __DRIVERS_LS_GPIO_H */

--- a/core/include/gpio.h
+++ b/core/include/gpio.h
@@ -26,13 +26,18 @@ struct gpio_chip {
 };
 
 struct gpio_ops {
-	enum gpio_dir (*get_direction)(unsigned int gpio_pin);
-	void (*set_direction)(unsigned int gpio_pin, enum gpio_dir direction);
-	enum gpio_level (*get_value)(unsigned int gpio_pin);
-	void (*set_value)(unsigned int gpio_pin, enum gpio_level value);
-	enum gpio_interrupt (*get_interrupt)(unsigned int gpio_pin);
-	void (*set_interrupt)(unsigned int gpio_pin,
-		enum gpio_interrupt ena_dis);
+	enum gpio_dir (*get_direction)(struct gpio_chip *chip,
+				       unsigned int gpio_pin);
+	void (*set_direction)(struct gpio_chip *chip, unsigned int gpio_pin,
+			      enum gpio_dir direction);
+	enum gpio_level (*get_value)(struct gpio_chip *chip,
+				     unsigned int gpio_pin);
+	void (*set_value)(struct gpio_chip *chip, unsigned int gpio_pin,
+			  enum gpio_level value);
+	enum gpio_interrupt (*get_interrupt)(struct gpio_chip *chip,
+					     unsigned int gpio_pin);
+	void (*set_interrupt)(struct gpio_chip *chip, unsigned int gpio_pin,
+			      enum gpio_interrupt ena_dis);
 };
 
 #endif	/* __GPIO_H__ */

--- a/core/pta/bcm/gpio.c
+++ b/core/pta/bcm/gpio.c
@@ -72,10 +72,10 @@ static TEE_Result pta_gpio_config(uint32_t param_types,
 
 	if (dir) {
 		/* Set GPIO to output with default value to 0 */
-		gc->ops->set_direction(gpio_num, GPIO_DIR_OUT);
-		gc->ops->set_value(gpio_num, 0);
+		gc->ops->set_direction(NULL, gpio_num, GPIO_DIR_OUT);
+		gc->ops->set_value(NULL, gpio_num, 0);
 	} else {
-		gc->ops->set_direction(gpio_num, GPIO_DIR_IN);
+		gc->ops->set_direction(NULL, gpio_num, GPIO_DIR_IN);
 	}
 
 	return res;
@@ -115,14 +115,15 @@ static TEE_Result pta_gpio_set(uint32_t param_types,
 	 * need to make sure the PIN is configured in
 	 * output direction.
 	 */
-	if (gc->ops->get_direction(gpio_num) != GPIO_DIR_OUT) {
+	if (gc->ops->get_direction(NULL, gpio_num) != GPIO_DIR_OUT) {
 		EMSG("gpio pin %u is configured as INPUT", gpio_num);
 		return TEE_ERROR_ACCESS_DENIED;
 	}
 
-	gc->ops->set_value(gpio_num, val);
+	gc->ops->set_value(NULL, gpio_num, val);
 
-	DMSG("GPIO(%d) value = 0x%08x", gpio_num, gc->ops->get_value(gpio_num));
+	DMSG("GPIO(%d) value = 0x%08x", gpio_num,
+	     gc->ops->get_value(NULL, gpio_num));
 
 	return res;
 }
@@ -153,7 +154,7 @@ static TEE_Result pta_gpio_get(uint32_t param_types,
 
 	gc = &bcm_gc->chip;
 
-	params[1].value.a = gc->ops->get_value(gpio_num);
+	params[1].value.a = gc->ops->get_value(NULL, gpio_num);
 
 	DMSG("gpio(%d) value = 0x%08x", gpio_num, params[1].value.a);
 


### PR DESCRIPTION
This pull request does 2 things:
1. Add 'struct gpio_chip *chip' in 'struct gpio_ops' and updated bcm_gpio and pl061_gpio as per modified gpio.h definition.
Based on https://github.com/OP-TEE/optee_os/issues/4007 discussion.
2. Add GPIO driver for NXP LS Platforms

