### PR TITLE
core: drivers: export crypto_rng_read to REE

### DIFF
--- a/core/crypto/rng_fortuna.c
+++ b/core/crypto/rng_fortuna.c
@@ -529,3 +529,9 @@ TEE_Result crypto_rng_read(void *buf, size_t blen)
 		offs += n;
 	}
 }
+
+void crypto_rng_get_info(enum crypto_rng_quality *quality)
+{
+	*quality = CRYPTO_RNG_IS_SW;
+}
+

--- a/core/crypto/rng_hw.c
+++ b/core/crypto/rng_hw.c
@@ -20,6 +20,14 @@ void __weak crypto_rng_add_event(enum crypto_rng_src sid __unused,
 {
 }
 
+void __weak crypto_rng_get_info(enum crypto_rng_quality *quality)
+{
+	if (!quality)
+		return;
+
+	*quality = CRYPTO_RNG_IS_HW;
+}
+
 TEE_Result __weak crypto_rng_read(void *buf, size_t blen)
 {
 	uint8_t *b = buf;

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -314,6 +314,12 @@ enum crypto_rng_src {
 	CRYPTO_RNG_SRC_NONSECURE	= (1 << 1 | 0),
 };
 
+enum crypto_rng_quality {
+	CRYPTO_RNG_IS_HW        = (1 << 10),
+	CRYPTO_RNG_IS_HW_SEEDED = (1 << 7),
+	CRYPTO_RNG_IS_SW        = (1 << 1),
+};
+
 /*
  * crypto_rng_init() - initialize the RNG
  * @data:	buffer with initial seed
@@ -346,6 +352,16 @@ void crypto_rng_add_event(enum crypto_rng_src sid, unsigned int *pnum,
  * function call.
  */
 TEE_Result crypto_rng_read(void *buf, size_t len);
+
+/*
+ * crypto_rng_get_info() - get the RNG quality information
+ *
+ * @quality:
+ *   CRYPTO_RNG_IS_HW        : HWRNG or PRNG with high frequency HWRNG seeding,
+ *   CRYPTO_RNG_IS_HW_SEEDED : PRNG with low frequency HWRNG seeding,
+ *   CRYPTO_RNG_IS_SW        : PRNG
+ */
+void crypto_rng_get_info(enum crypto_rng_quality *quality);
 
 /*
  * crypto_aes_expand_enc_key() - Expand an AES key

--- a/core/pta/rng.c
+++ b/core/pta/rng.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2021, Foundries Limited
+ */
+
+#include <crypto/crypto.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/spinlock.h>
+#include <kernel/timer.h>
+#include <mm/core_memprot.h>
+#include <rng_pta.h>
+#include <string.h>
+
+#define PTA_NAME "rng.pta"
+
+static TEE_Result rng_get_entropy(uint32_t types,
+				  TEE_Param params[TEE_NUM_PARAMS])
+{
+	uint8_t *e = NULL;
+	uint32_t rq_size = 0;
+	uint32_t exceptions;
+	TEE_Result res = TEE_SUCCESS;
+
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("bad parameters types: 0x%" PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	rq_size = params[0].memref.size;
+	e = (uint8_t *)params[0].memref.buffer;
+	if (!e)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+	res = crypto_rng_read(e, rq_size);
+	thread_set_exceptions(exceptions);
+
+	return res;
+}
+
+static TEE_Result rng_get_info(uint32_t types,
+			       TEE_Param params[TEE_NUM_PARAMS])
+{
+	enum crypto_rng_quality quality = CRYPTO_RNG_IS_SW;
+
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("bad parameters types: 0x%" PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	crypto_rng_get_info(&quality);
+
+	/*
+	 * value.a is data rate: calls to crypto_rng_read will always generate
+	 * the requested number of bytes from the crypto RNG framework. As a
+	 * consequence, there is no need to artificially wait for it to generate
+	 * additional data.
+	 */
+	params[0].value.a = UINT32_MAX;
+
+	/* value.b is quality: 0 (unknown), 1 (lowest) and 1024(highest) */
+	params[0].value.b = quality;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result invoke_command(void *pSessionContext __unused,
+				 uint32_t cmd, uint32_t nParamTypes,
+				 TEE_Param pParams[TEE_NUM_PARAMS])
+{
+	FMSG("pseudo-TA entry\"%s\"", PTA_NAME);
+
+	switch (cmd) {
+	case PTA_CMD_GET_ENTROPY:
+		return rng_get_entropy(nParamTypes, pParams);
+	case PTA_CMD_GET_RNG_INFO:
+		return rng_get_info(nParamTypes, pParams);
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+}
+
+pseudo_ta_register(.uuid = PTA_RNG_UUID, .name = PTA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS |
+			    TA_FLAG_DEVICE_ENUM | TA_FLAG_CONCURRENT,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -9,5 +9,6 @@ endif
 srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_SYSTEM_PTA) += system.c
 srcs-$(CFG_NXP_SE05X) += scp03.c
+srcs-$(CFG_RNG_PTA) += rng.c
 
 subdirs-y += bcm

--- a/lib/libutee/include/rng_pta.h
+++ b/lib/libutee/include/rng_pta.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2021, Foundries.io Ltd
+ */
+
+#ifndef __RNG_PTA__H
+#define __RNG_PTA__H
+
+#define PTA_RNG_UUID { 0x035a4479, 0xc369, 0x47f4, { \
+		       0x94, 0x51, 0xc6, 0xfd, 0xff, 0x28, 0xad, 0x65 } }
+
+/*
+ * [in/out]	memref[0]	entropy buffer
+ */
+#define PTA_CMD_GET_ENTROPY		0
+
+/*
+ * [out]	value[0].a	RNG data-rate in bytes per second
+ * [out]	value[0].b	quality/entropy per 1024 bit of data
+ */
+#define PTA_CMD_GET_RNG_INFO		1
+
+#endif /* __RNG_PTA__H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -517,6 +517,9 @@ CFG_SYSTEM_PTA ?= y
 # world OS.
 CFG_DEVICE_ENUM_PTA ?= y
 
+# Disable the pseudo TA that provides the crypto RNG to the normal world OS.
+CFG_RNG_PTA ?= n
+
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,
 # so its value represents log2(cores/cluster).


### PR DESCRIPTION
This enables the REE to register the TEE's crypto_rng_read as a hwrng
provider.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
