### PR TITLE
Add Secure partitions (continuation)

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 
 /* Error codes */
+#define FFA_OK			0
 #define FFA_NOT_SUPPORTED	-1
 #define FFA_INVALID_PARAMETERS	-2
 #define FFA_NO_MEMORY		-3

--- a/core/arch/arm/include/kernel/abort.h
+++ b/core/arch/arm/include/kernel/abort.h
@@ -35,7 +35,7 @@ void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs);
 bool abort_is_user_exception(struct abort_info *ai);
 
 /* Called from a normal thread */
-void abort_print_current_ta(void);
+void abort_print_current_ts(void);
 
 #endif /*__ASSEMBLER__*/
 #endif /*KERNEL_ABORT_H*/

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -36,6 +36,7 @@ struct sp_session {
 	uint16_t caller_id;
 	struct ts_session ts_sess;
 	struct sp_ffa_init_info *info;
+	unsigned int spinlock;
 	TAILQ_ENTRY(sp_session) link;
 };
 
@@ -69,6 +70,7 @@ static inline struct sp_ctx *to_sp_ctx(struct ts_ctx *ctx)
 }
 
 struct sp_session *sp_get_session(uint32_t session_id);
+TEE_Result sp_enter(struct thread_smc_args *args, struct sp_session *sp);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct embedded_ts)

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -1,16 +1,76 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2020, Arm Limited.
+ * Copyright (c) 2020-2021, Arm Limited.
  */
-#ifndef KERNEL_SECURE_PARTITION_H
-#define KERNEL_SECURE_PARTITION_H
+#ifndef __KERNEL_SECURE_PARTITION_H
+#define __KERNEL_SECURE_PARTITION_H
 
+#include <assert.h>
+#include <config.h>
 #include <kernel/embedded_ts.h>
+#include <kernel/user_mode_ctx_struct.h>
 #include <stdint.h>
 #include <tee_api_types.h>
+#include <tee/entry_std.h>
+
+TAILQ_HEAD(sp_sessions_head, sp_session);
+
+struct sp_name_value_pair {
+	uint32_t name[4];
+	uint64_t value;
+	uint64_t size;
+};
+
+/* SP entry arguments passed to SP image: see ABI in FF-A specification */
+struct sp_ffa_init_info {
+	uint32_t magic; /* FF-A */
+	uint32_t count; /* Count of name value size pairs */
+	struct sp_name_value_pair nvp[]; /* Array of name value size pairs */
+};
+
+enum sp_status { sp_idle, sp_busy, sp_preempted, sp_dead };
+
+struct sp_session {
+	enum sp_status state;
+	uint16_t endpoint_id;
+	uint16_t caller_id;
+	struct ts_session ts_sess;
+	struct sp_ffa_init_info *info;
+	TAILQ_ENTRY(sp_session) link;
+};
+
+struct sp_ctx {
+	struct thread_ctx_regs sp_regs;
+	struct sp_session *open_session;
+	struct user_mode_ctx uctx;
+	struct ts_ctx ts_ctx;
+};
+
+#ifdef CFG_SECURE_PARTITION
+bool is_sp_ctx(struct ts_ctx *ctx);
+#else
+static inline bool is_sp_ctx(struct ts_ctx *ctx __unused)
+{
+	return false;
+}
+#endif
+
+static inline struct sp_session *__noprof
+to_sp_session(struct ts_session *sess)
+{
+	assert(is_sp_ctx(sess->ctx));
+	return container_of(sess, struct sp_session, ts_sess);
+}
+
+static inline struct sp_ctx *to_sp_ctx(struct ts_ctx *ctx)
+{
+	assert(is_sp_ctx(ctx));
+	return container_of(ctx, struct sp_ctx, ts_ctx);
+}
+
+struct sp_session *sp_get_session(uint32_t session_id);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct embedded_ts)
 
-#endif /* KERNEL_SECURE_PARTITION_H */
-
+#endif /* __KERNEL_SECURE_PARTITION_H */

--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Arm Limited.
+ */
+#ifndef __KERNEL_SPMC_SP_HANDLER_H
+#define __KERNEL_SPMC_SP_HANDLER_H
+
+#include <assert.h>
+#include <kernel/secure_partition.h>
+#include <kernel/user_mode_ctx_struct.h>
+#include <tee_api_types.h>
+#include <tee/entry_std.h>
+
+#define FFA_DST(x)	((x) & UINT16_MAX)
+#define FFA_SRC(x)	(((x) >> 16) & UINT16_MAX)
+
+void spmc_sp_thread_entry(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
+void spmc_sp_msg_handler(struct thread_smc_args *args,
+			 struct sp_session *caller_sp);
+
+#ifdef CFG_SECURE_PARTITION
+void spmc_sp_start_thread(struct thread_smc_args *args);
+#else
+static inline void spmc_sp_start_thread(struct thread_smc_args *args __unused)
+{
+}
+#endif
+
+#endif /* __KERNEL_SPMC_SP_HANDLER_H */

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2016-2017, Linaro Limited
- * Copyright (c) 2020, Arm Limited
+ * Copyright (c) 2020-2021, Arm Limited
  */
 
 #ifndef KERNEL_THREAD_H
@@ -194,6 +194,23 @@ struct thread_svc_regs {
 	uint64_t x14;	/* r14/lr_usr */
 	uint64_t x30;
 	uint64_t sp_el0;
+#ifdef CFG_SECURE_PARTITION
+	uint64_t x15;
+	uint64_t x16;
+	uint64_t x17;
+	uint64_t x18;
+	uint64_t x19;
+	uint64_t x20;
+	uint64_t x21;
+	uint64_t x22;
+	uint64_t x23;
+	uint64_t x24;
+	uint64_t x25;
+	uint64_t x26;
+	uint64_t x27;
+	uint64_t x28;
+	uint64_t x29;
+#endif
 	uint64_t pad;
 } __aligned(16);
 #endif /*ARM64*/

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Arm Limited.
+ */
+#ifndef __KERNEL_THREAD_SPMC_H
+#define __KERNEL_THREAD_SPMC_H
+
+/* FF-A endpoint base ID when OP-TEE is used as a S-EL1 endpoint */
+#define SPMC_ENDPOINT_ID        0x8001
+
+#endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -237,7 +237,7 @@ void abort_print_error(struct abort_info *ai)
 }
 
 /* This function must be called from a normal thread */
-void abort_print_current_ta(void)
+void abort_print_current_ts(void)
 {
 	struct thread_specific_data *tsd = thread_get_tsd();
 	struct abort_info ai = { };

--- a/core/arch/arm/kernel/ldelf_loader.c
+++ b/core/arch/arm/kernel/ldelf_loader.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2015-2020, Linaro Limited
- * Copyright (c) 2020, Arm Limited
+ * Copyright (c) 2020-2021, Arm Limited
  */
 
 #include <assert.h>
@@ -118,7 +118,7 @@ TEE_Result ldelf_init_with_ldelf(struct ts_session *sess,
 	ldelf_sess_cleanup(sess);
 
 	if (panicked) {
-		abort_print_current_ta();
+		abort_print_current_ts();
 		EMSG("ldelf panicked");
 		return TEE_ERROR_GENERIC;
 	}
@@ -273,7 +273,7 @@ TEE_Result ldelf_dump_state(struct user_mode_ctx *uctx)
 	if (panicked) {
 		uctx->dump_entry_func = 0;
 		EMSG("ldelf dump function panicked");
-		abort_print_current_ta();
+		abort_print_current_ts();
 		res = TEE_ERROR_TARGET_DEAD;
 	}
 
@@ -322,7 +322,7 @@ TEE_Result ldelf_dump_ftrace(struct user_mode_ctx *uctx,
 	if (panicked) {
 		uctx->ftrace_entry_func = 0;
 		EMSG("ldelf ftrace function panicked");
-		abort_print_current_ta();
+		abort_print_current_ts();
 		res = TEE_ERROR_TARGET_DEAD;
 	}
 
@@ -378,7 +378,7 @@ TEE_Result ldelf_dlopen(struct user_mode_ctx *uctx, TEE_UUID *uuid,
 
 	if (panicked) {
 		EMSG("ldelf dl_entry function panicked");
-		abort_print_current_ta();
+		abort_print_current_ts();
 		res = TEE_ERROR_TARGET_DEAD;
 	}
 	if (!res)
@@ -432,7 +432,7 @@ TEE_Result ldelf_dlsym(struct user_mode_ctx *uctx, TEE_UUID *uuid,
 
 	if (panicked) {
 		EMSG("ldelf dl_entry function panicked");
-		abort_print_current_ta();
+		abort_print_current_ts();
 		res = TEE_ERROR_TARGET_DEAD;
 	}
 	if (!res) {

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -1,29 +1,258 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2020, Arm Limited.
+ * Copyright (c) 2020-2021, Arm Limited.
  */
 #include <crypto/crypto.h>
 #include <initcall.h>
-#include <kernel/secure_partition.h>
 #include <kernel/embedded_ts.h>
+#include <kernel/ldelf_loader.h>
+#include <kernel/secure_partition.h>
+#include <kernel/thread_spmc.h>
 #include <kernel/ts_store.h>
+#include <ldelf.h>
+#include <mm/core_mmu.h>
+#include <mm/fobj.h>
+#include <mm/mobj.h>
+#include <mm/vm.h>
+#include <optee_ffa.h>
 #include <stdio.h>
 #include <string.h>
+#include <tee_api_types.h>
 #include <trace.h>
+#include <types_ext.h>
 #include <utee_defines.h>
 #include <util.h>
 #include <zlib.h>
+
+static const struct ts_ops *_sp_ops;
+
+/* List that holds all of the loaded SP's */
+static struct sp_sessions_head open_sp_sessions =
+	TAILQ_HEAD_INITIALIZER(open_sp_sessions);
+
+static const struct ts_ops sp_ops __rodata_unpaged = {
+};
 
 static const struct embedded_ts *find_secure_partition(const TEE_UUID *uuid)
 {
 	const struct embedded_ts *sp = NULL;
 
-	for_each_secure_partition(sp)
+	for_each_secure_partition(sp) {
 		if (!memcmp(&sp->uuid, uuid, sizeof(*uuid)))
 			return sp;
+	}
+	return NULL;
+}
+
+bool is_sp_ctx(struct ts_ctx *ctx)
+{
+	return ctx && (ctx->ops == _sp_ops);
+}
+
+static void set_sp_ctx_ops(struct ts_ctx *ctx)
+{
+	ctx->ops = _sp_ops;
+}
+
+struct sp_session *sp_get_session(uint32_t session_id)
+{
+	struct sp_session *s = NULL;
+
+	TAILQ_FOREACH(s, &open_sp_sessions, link) {
+		if (s->endpoint_id == session_id)
+			return s;
+	}
 
 	return NULL;
 }
+
+static void sp_init_info(struct sp_ctx *ctx)
+{
+	struct sp_ffa_init_info *info = NULL;
+
+	ctx->uctx.stack_ptr -= ROUNDUP(sizeof(*info), STACK_ALIGNMENT);
+
+	ctx->sp_regs.x[0]  = (uintptr_t)ctx->uctx.stack_ptr;
+	info = (struct sp_ffa_init_info *)ctx->uctx.stack_ptr;
+
+	info->magic = 0;
+	info->count = 0;
+}
+
+static uint16_t new_session_id(struct sp_sessions_head *open_sessions)
+{
+	struct sp_session *last = NULL;
+	uint16_t id = SPMC_ENDPOINT_ID + 1;
+
+	last = TAILQ_LAST(open_sessions, sp_sessions_head);
+	if (last)
+		id = last->endpoint_id + 1;
+
+	assert(id > SPMC_ENDPOINT_ID);
+	return id;
+}
+
+static TEE_Result sp_create_ctx(const TEE_UUID *uuid, struct sp_session *s)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct sp_ctx *spc = NULL;
+
+	/* Register context */
+	spc = calloc(1, sizeof(struct sp_ctx));
+	if (!spc)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	spc->uctx.ts_ctx = &spc->ts_ctx;
+	spc->open_session = s;
+	s->ts_sess.ctx = &spc->ts_ctx;
+	spc->ts_ctx.uuid = *uuid;
+
+	res = vm_info_init(&spc->uctx);
+	if (res)
+		goto err;
+
+	set_sp_ctx_ops(&spc->ts_ctx);
+
+	return TEE_SUCCESS;
+
+err:
+	free(spc);
+	return res;
+}
+
+static TEE_Result sp_create_session(struct sp_sessions_head *open_sessions,
+				    const TEE_UUID *uuid,
+				    struct sp_session **sess)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct sp_session *s = calloc(1, sizeof(struct sp_session));
+
+	if (!s)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	s->endpoint_id = new_session_id(open_sessions);
+	if (!s->endpoint_id) {
+		res = TEE_ERROR_OVERFLOW;
+		goto err;
+	}
+
+	DMSG("Loading Secure Partition %pUl", (void *)uuid);
+	res = sp_create_ctx(uuid, s);
+	if (res)
+		goto err;
+
+	TAILQ_INSERT_TAIL(open_sessions, s, link);
+	*sess = s;
+	return TEE_SUCCESS;
+
+err:
+	free(s);
+	return res;
+}
+
+static TEE_Result sp_init_set_registers(struct sp_ctx *ctx)
+{
+	struct thread_ctx_regs *sp_regs = &ctx->sp_regs;
+	uint64_t x0 = sp_regs->x[0];
+
+	/* Clear all addresses except x0, x0 contains the info address. */
+	memset(sp_regs, 0, sizeof(*sp_regs));
+	sp_regs->sp = ctx->uctx.stack_ptr;
+	sp_regs->x[0] = x0;
+	sp_regs->pc = ctx->uctx.entry_func;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result sp_open_session(struct sp_session **sess,
+				  struct sp_sessions_head *open_sessions,
+				  const TEE_UUID *uuid)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct sp_session *s = NULL;
+	struct sp_ctx *ctx = NULL;
+
+	if (!find_secure_partition(uuid))
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	res = sp_create_session(open_sessions, uuid, &s);
+	if (res != TEE_SUCCESS) {
+		DMSG("sp_create_session failed %#"PRIx32, res);
+		return res;
+	}
+
+	ctx = to_sp_ctx(s->ts_sess.ctx);
+	assert(ctx);
+	if (!ctx)
+		return TEE_ERROR_TARGET_DEAD;
+	*sess = s;
+
+	ts_push_current_session(&s->ts_sess);
+	/* Load the SP using ldelf. */
+	ldelf_load_ldelf(&ctx->uctx);
+	res = ldelf_init_with_ldelf(&s->ts_sess, &ctx->uctx);
+
+	if (res != TEE_SUCCESS) {
+		EMSG("Failed. loading SP using ldelf %#"PRIx32, res);
+		ts_pop_current_session();
+		return TEE_ERROR_TARGET_DEAD;
+	}
+
+	/* Make the SP ready for its first run */
+	s->state = sp_idle;
+	s->caller_id = 0;
+	sp_init_info(ctx);
+	sp_init_set_registers(ctx);
+	ts_pop_current_session();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result sp_init_uuid(const TEE_UUID *uuid)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct sp_session *sess = NULL;
+
+	res = sp_open_session(&sess,
+			      &open_sp_sessions,
+			      uuid);
+	if (res)
+		return res;
+
+	return res;
+}
+
+static TEE_Result sp_init_all(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+	const struct embedded_ts *sp = NULL;
+	char __maybe_unused msg[60] = { '\0', };
+
+	_sp_ops = &sp_ops;
+
+	for_each_secure_partition(sp) {
+		if (sp->uncompressed_size)
+			snprintf(msg, sizeof(msg),
+				 " (compressed, uncompressed %u)",
+				 sp->uncompressed_size);
+		else
+			msg[0] = '\0';
+		DMSG("SP %pUl size %u%s", (void *)&sp->uuid, sp->size, msg);
+
+		res = sp_init_uuid(&sp->uuid);
+
+		if (res != TEE_SUCCESS) {
+			EMSG("Failed initializing SP(%pUl) err:%#"PRIx32,
+			     &sp->uuid, res);
+			if (!IS_ENABLED(CFG_SP_SKIP_FAILED))
+				panic();
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+boot_final(sp_init_all);
 
 static TEE_Result secure_partition_open(const TEE_UUID *uuid,
 					struct ts_store_handle **h)
@@ -39,23 +268,3 @@ REGISTER_SP_STORE(2) = {
 	.read = emb_ts_read,
 	.close = emb_ts_close,
 };
-
-static TEE_Result secure_partition_init(void)
-{
-	const struct embedded_ts *sp = NULL;
-	char __maybe_unused msg[60] = { '\0', };
-
-	for_each_secure_partition(sp) {
-		if (sp->uncompressed_size)
-			snprintf(msg, sizeof(msg),
-				 " (compressed, uncompressed %u)",
-				 sp->uncompressed_size);
-		else
-			msg[0] = '\0';
-		DMSG("SP %pUl size %u%s", (void *)&sp->uuid, sp->size, msg);
-	}
-
-	return TEE_SUCCESS;
-}
-
-service_init(secure_partition_init);

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Arm Limited
+ */
+#include <assert.h>
+#include <bench.h>
+#include <kernel/panic.h>
+#include <kernel/secure_partition.h>
+#include <kernel/spinlock.h>
+#include <kernel/spmc_sp_handler.h>
+#include <optee_ffa.h>
+#include "thread_private.h"
+
+void spmc_sp_start_thread(struct thread_smc_args *args)
+{
+	thread_sp_alloc_and_run(args);
+}
+
+static void ffa_set_error(struct thread_smc_args *args, uint32_t error)
+{
+	args->a0 = FFA_ERROR;
+	args->a2 = error;
+}
+
+static TEE_Result ffa_get_dst(struct thread_smc_args *args,
+			      struct sp_session *caller,
+			      struct sp_session **dst)
+{
+	struct sp_session *s = NULL;
+
+	if (args->a2 != FFA_PARAM_MBZ)
+		return FFA_INVALID_PARAMETERS;
+
+	s = sp_get_session(FFA_DST(args->a1));
+
+	/* Message came from the NW */
+	if (!caller) {
+		if (!s) {
+			EMSG("Neither destination nor source is a SP");
+			return FFA_INVALID_PARAMETERS;
+		}
+	} else {
+		/* Check if the source matches the endpoint we came from */
+		if (FFA_SRC(args->a1) != caller->endpoint_id) {
+			EMSG("Source address doesn't match the endpoint id");
+			return FFA_INVALID_PARAMETERS;
+		}
+	}
+
+	*dst = s;
+
+	return FFA_OK;
+}
+
+static struct sp_session *
+ffa_handle_sp_direct_req(struct thread_smc_args *args,
+			 struct sp_session *caller_sp)
+{
+	struct sp_session *dst = NULL;
+	TEE_Result res = FFA_OK;
+
+	if (args->a2 != FFA_PARAM_MBZ) {
+		ffa_set_error(args, FFA_INVALID_PARAMETERS);
+		return NULL;
+	}
+
+	res = ffa_get_dst(args, caller_sp, &dst);
+	if (res) {
+		/* Tried to send message to an incorrect endpoint */
+		ffa_set_error(args, res);
+		return caller_sp;
+	}
+	if (!dst) {
+		EMSG("Request to normal world not supported");
+		ffa_set_error(args, FFA_NOT_SUPPORTED);
+		return NULL;
+	}
+
+	cpu_spin_lock(&dst->spinlock);
+	if (dst->state != sp_idle) {
+		DMSG("SP is busy");
+		ffa_set_error(args, FFA_BUSY);
+		cpu_spin_unlock(&dst->spinlock);
+		return caller_sp;
+	}
+
+	dst->state = sp_busy;
+	cpu_spin_unlock(&dst->spinlock);
+
+	/*
+	 * Store the calling endpoint id. This will make it possible to check
+	 * if the response is sent back to the correct endpoint.
+	 */
+	dst->caller_id = FFA_SRC(args->a1);
+
+	/* Forward the message to the destination SP */
+	res = sp_enter(args, dst);
+	if (res) {
+		/* The SP Panicked */
+		ffa_set_error(args, FFA_ABORTED);
+		/* Return error to calling SP */
+		return caller_sp;
+	}
+
+	return dst;
+}
+
+static struct sp_session *
+ffa_handle_sp_direct_resp(struct thread_smc_args *args,
+			  struct sp_session *caller_sp)
+{
+	struct sp_session *dst = NULL;
+	TEE_Result res = FFA_OK;
+
+	if (!caller_sp) {
+		EMSG("Response from normal world not supported");
+		ffa_set_error(args, FFA_NOT_SUPPORTED);
+		return NULL;
+	}
+
+	res = ffa_get_dst(args, caller_sp, &dst);
+	if (res) {
+		/* Tried to send response to an incorrect endpoint */
+		ffa_set_error(args, res);
+		return caller_sp;
+	}
+
+	if (caller_sp->state != sp_busy) {
+		EMSG("SP is not waiting for a request");
+		ffa_set_error(args, FFA_INVALID_PARAMETERS);
+		return caller_sp;
+	}
+
+	if (caller_sp->caller_id != FFA_DST(args->a1)) {
+		EMSG("FFA_MSG_SEND_DIRECT_RESP to incorrect SP");
+		ffa_set_error(args, FFA_INVALID_PARAMETERS);
+		return caller_sp;
+	}
+
+	caller_sp->caller_id = 0;
+
+	cpu_spin_lock(&caller_sp->spinlock);
+	caller_sp->state = sp_idle;
+	cpu_spin_unlock(&caller_sp->spinlock);
+
+	if (!dst) {
+		/* Send message back to the NW */
+		return NULL;
+	}
+
+	/* Forward the message to the destination SP */
+	res = sp_enter(args, dst);
+	if (res) {
+		/* The SP Panicked */
+		ffa_set_error(args, FFA_ABORTED);
+		/* Return error to calling SP */
+		return caller_sp;
+	}
+	return dst;
+}
+
+static struct sp_session *
+ffa_handle_sp_error(struct thread_smc_args *args,
+		    struct sp_session *caller_sp)
+{
+	struct sp_session *dst = NULL;
+
+	dst = sp_get_session(FFA_DST(args->a1));
+
+	/* FFA_ERROR Came from Noral World */
+	if (caller_sp)
+		caller_sp->state = sp_idle;
+
+	/* If dst == NULL send message to Normal World */
+	if (dst && sp_enter(args, dst)) {
+		/*
+		 * We can not return the error. Unwind the call chain with one
+		 * link. Set the state of the SP to dead.
+		 */
+		dst->state = sp_dead;
+		/* Create error. */
+		ffa_set_error(args, FFA_DENIED);
+		return  sp_get_session(dst->caller_id);
+	}
+
+	return dst;
+}
+
+/*
+ * FF-A messages handler for SP. Every messages for or from a SP is handled
+ * here. This is the entry of the sp_spmc kernel thread. The caller_sp is set
+ * to NULL when it is the Normal World.
+ */
+void spmc_sp_msg_handler(struct thread_smc_args *args,
+			 struct sp_session *caller_sp)
+{
+	thread_check_canaries();
+	do {
+		switch (args->a0) {
+		case FFA_MSG_SEND_DIRECT_REQ_32:
+			caller_sp = ffa_handle_sp_direct_req(args, caller_sp);
+			break;
+		case FFA_MSG_SEND_DIRECT_RESP_32:
+			caller_sp = ffa_handle_sp_direct_resp(args, caller_sp);
+			break;
+		case FFA_ERROR:
+			caller_sp = ffa_handle_sp_error(args, caller_sp);
+			break;
+		case FFA_MSG_WAIT:
+			/* FFA_WAIT gives control back to NW */
+			cpu_spin_lock(&caller_sp->spinlock);
+			caller_sp->state = sp_idle;
+			cpu_spin_unlock(&caller_sp->spinlock);
+			caller_sp = NULL;
+			break;
+		default:
+			EMSG("Unhandled FFA function ID %#"PRIx32,
+			     (uint32_t)args->a0);
+			ffa_set_error(args, FFA_INVALID_PARAMETERS);
+		}
+	} while (caller_sp);
+}

--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -119,7 +119,7 @@ static TEE_Result stmm_enter_user_mode(struct stmm_ctx *spc)
 	thread_user_clear_vfp(&spc->uctx);
 
 	if (panicked) {
-		abort_print_current_ta();
+		abort_print_current_ts();
 		DMSG("stmm panicked with code %#"PRIx32, panic_code);
 		return TEE_ERROR_TARGET_DEAD;
 	}

--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -6,7 +6,6 @@ srcs-$(CFG_EARLY_TA) += early_ta.c
 srcs-$(CFG_SECSTOR_TA) += secstor_ta.c
 endif
 
-srcs-$(CFG_SECURE_PARTITION) += secure_partition.c
 srcs-$(CFG_EMBEDDED_TS) += embedded_ts.c
 srcs-y += pseudo_ta.c
 srcs-y += tee_time.c
@@ -54,6 +53,8 @@ srcs-y += mutex.c
 srcs-$(CFG_LOCKDEP) += mutex_lockdep.c
 srcs-y += wait_queue.c
 srcs-$(CFG_WITH_STMM_SP) += stmm_sp.c
+srcs-$(CFG_SECURE_PARTITION) += secure_partition.c
+srcs-$(CFG_SECURE_PARTITION) += spmc_sp_handler.c
 
 srcs-y += boot.c
 srcs-$(CFG_ARM32_core) += entry_a32.S

--- a/core/arch/arm/kernel/thread_private.h
+++ b/core/arch/arm/kernel/thread_private.h
@@ -129,6 +129,7 @@ void thread_std_smc_entry(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
 uint32_t __thread_std_smc_entry(uint32_t a0, uint32_t a1, uint32_t a2,
 				uint32_t a3);
 
+void thread_sp_alloc_and_run(struct thread_smc_args *args);
 
 /*
  * Resumes execution of currently active thread by restoring context and

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -12,6 +12,7 @@
 #include <kernel/spinlock.h>
 #include <kernel/tee_misc.h>
 #include <kernel/thread.h>
+#include <kernel/thread_spmc.h>
 #include <mm/core_mmu.h>
 #include <mm/mobj.h>
 #include <optee_ffa.h>
@@ -85,8 +86,6 @@ struct mem_frag_state {
 	unsigned int frag_offset;
 	SLIST_ENTRY(mem_frag_state) link;
 };
-
-static uint16_t my_sp_id = 0x8001;
 
 /*
  * If @rxtx_size is 0 RX/TX buffers are not mapped or initialized.
@@ -344,7 +343,7 @@ static void handle_partition_info_get(struct thread_smc_args *args)
 	if (rxtx_size && tx_buf_is_mine) {
 		struct ffa_partition_info *fpi = tx_buf;
 
-		fpi->id = my_sp_id;
+		fpi->id = SPMC_ENDPOINT_ID;
 		fpi->execution_context = CFG_TEE_CORE_NB_CORE;
 		fpi->partition_properties = BIT(0) | BIT(1);
 
@@ -418,7 +417,7 @@ static int get_acc_perms(struct mem_accsess_descr *mem_acc,
 		struct mem_access_perm_descr *descr =
 			&mem_acc[n].mem_access_perm_descr;
 
-		if (READ_ONCE(descr->endpoint_id) == my_sp_id) {
+		if (READ_ONCE(descr->endpoint_id) == SPMC_ENDPOINT_ID) {
 			*acc_perms = READ_ONCE(descr->access_perm);
 			*region_offs = READ_ONCE(mem_acc[n].mem_region_offs);
 			return 0;

--- a/core/arch/arm/kernel/thread_spmc_a64.S
+++ b/core/arch/arm/kernel/thread_spmc_a64.S
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2019, Arm Limited
+ * Copyright (c) 2019-2021, Arm Limited
  */
 
 #include <platform_config.h>
@@ -70,6 +70,37 @@ FUNC thread_std_smc_entry , :
 	mov	x7, #FFA_PARAM_MBZ		/* Unused parameter */
 	b	ffa_msg_send_direct_resp
 END_FUNC thread_std_smc_entry
+
+#ifdef CFG_SECURE_PARTITION
+/* void spmc_sp_thread_entry(args) */
+FUNC spmc_sp_thread_entry , :
+	/* Store the parameters as struct thread_smc_args on stack */
+	sub     sp, sp, #THREAD_SMC_ARGS_SIZE
+	store_xregs sp, THREAD_SMC_ARGS_X0, 0, 7
+	mov     x0, sp
+	mov     x1, #0 /* Pass NULL pointer for caller_sp, coming from NW */
+	bl      spmc_sp_msg_handler
+	load_xregs sp, THREAD_SMC_ARGS_X0, 20, 27
+
+	/* Mask all maskable exceptions before switching to temporary stack */
+	msr     daifset, #DAIFBIT_ALL
+	bl      thread_get_tmp_sp
+	mov     sp, x0
+
+	bl      thread_state_free
+
+	/* Restore the FF-A arguments before the SMC instruction. */
+	mov     w0, w20
+	mov     w1, w21
+	mov     w2, w22
+	mov     w3, w23
+	mov     w4, w24
+	mov     w5, w25
+	mov     w6, w26
+	mov     w7, w27
+	b .ffa_msg_loop
+END_FUNC spmc_sp_thread_entry
+#endif
 
 /* void thread_rpc(struct thread_rpc_arg *rpc_arg) */
 FUNC thread_rpc , :

--- a/core/arch/arm/kernel/user_ta.c
+++ b/core/arch/arm/kernel/user_ta.c
@@ -172,7 +172,7 @@ static TEE_Result user_ta_enter(struct ts_session *session,
 	thread_user_clear_vfp(&utc->uctx);
 
 	if (utc->ta_ctx.panicked) {
-		abort_print_current_ta();
+		abort_print_current_ts();
 		DMSG("tee_user_ta_enter: TA panicked with code 0x%x",
 		     utc->ta_ctx.panic_code);
 		res = TEE_ERROR_TARGET_DEAD;
@@ -248,7 +248,7 @@ static void user_ta_dump_state(struct ts_ctx *ctx)
 		 * ldelf_dump_state() fails for some reason.
 		 *
 		 * If ldelf_dump_state() failed with panic
-		 * where done since abort_print_current_ta() will be
+		 * we are done since abort_print_current_ts() will be
 		 * called which will dump the memory map.
 		 */
 	}

--- a/core/include/kernel/user_mode_ctx.h
+++ b/core/include/kernel/user_mode_ctx.h
@@ -1,12 +1,14 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2021, Arm Limited
  */
 
 #ifndef __KERNEL_USER_MODE_CTX_H
 #define __KERNEL_USER_MODE_CTX_H
 
 #include <assert.h>
+#include <kernel/secure_partition.h>
 #include <kernel/stmm_sp.h>
 #include <kernel/user_mode_ctx_struct.h>
 #include <kernel/user_ta.h>
@@ -14,13 +16,15 @@
 
 static inline bool is_user_mode_ctx(struct ts_ctx *ctx)
 {
-	return is_user_ta_ctx(ctx) || is_stmm_ctx(ctx);
+	return is_user_ta_ctx(ctx) || is_stmm_ctx(ctx) || is_sp_ctx(ctx);
 }
 
 static inline struct user_mode_ctx *to_user_mode_ctx(struct ts_ctx *ctx)
 {
 	if (is_user_ta_ctx(ctx))
 		return &to_user_ta_ctx(ctx)->uctx;
+	else if (is_sp_ctx(ctx))
+		return &to_sp_ctx(ctx)->uctx;
 	else
 		return &to_stmm_ctx(ctx)->uctx;
 }

--- a/core/kernel/user_access.c
+++ b/core/kernel/user_access.c
@@ -7,6 +7,7 @@
 #include <initcall.h>
 #include <kernel/linker.h>
 #include <kernel/user_access.h>
+#include <kernel/user_mode_ctx.h>
 #include <mm/vm.h>
 #include <string.h>
 #include <tee_api_types.h>
@@ -15,9 +16,8 @@
 static TEE_Result check_access(uint32_t flags, vaddr_t va, size_t len)
 {
 	struct ts_session *s = ts_get_current_session();
-	struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
 
-	return vm_check_access_rights(&utc->uctx, flags, va, len);
+	return vm_check_access_rights(to_user_mode_ctx(s->ctx), flags, va, len);
 }
 
 TEE_Result copy_from_user(void *kaddr, const void *uaddr, size_t len)

--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -131,7 +131,7 @@ void ldelf(struct ldelf_arg *arg)
 	TEE_Result res = TEE_SUCCESS;
 	struct ta_elf *elf = NULL;
 
-	DMSG("Loading TA %pUl", (void *)&arg->uuid);
+	DMSG("Loading TS %pUl", (void *)&arg->uuid);
 	res = sys_map_zi(mpool_size, 0, &mpool_base, 0, 0);
 	if (res) {
 		EMSG("sys_map_zi(%zu): result %"PRIx32, mpool_size, res);


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
Secure Partitions (SP) are S-EL0 execution service defined in the Arm FF-A specification. This PR adds the following features for SPs:
-Load Secure Partitions at boot.
-Run every Secure Partition after it has been loaded
-Accept FFA_MSG_SEND_DIRECT_REQ_32 and FFA_MSG_SEND_DIRECT_RESP_32 messages from and to SPs.

I will update the documentation as soon as possible to give some extra details about the implementation.
This PR is a continuation of https://github.com/OP-TEE/optee_os/pull/4322. The PR got a bit big.
