### PR TITLE
ci: add .azure-pipelines.yml

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,174 @@
+jobs:
+  - job: build_all
+    displayName: 'Build all'
+    pool:
+      vmImage: ubuntu-18.04
+    container:
+      image: jforissier/optee_os_ci_clangbuilt
+    steps:
+      - task: InstallSSHKey@0
+        displayName: 'Install SSH key for build cache'
+        inputs:
+          hostname: 'shippable-cache.forissier.org'
+          knownHostEntry: 'shippable-cache.forissier.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDhjh94ShHh6M19+0NBjgX8ZUiZINQS60GmQjzLfivljvAxBtheCDlDqK5NLIoXn4HE2FxkNTMqmJ+D0p7eQAy81OyYVtvTrJm4B4dk60wMDzQgUK2Cikl2YWNTuxeHpwvpEXP0EK/AHjX1z+98Us9XP6bMr7n1nN6WM8JEdOKpMgl7O9uK3jqYJHo9k+ldkAR4yX8jYgxothu9qkeu2X8tbaP3rjaLlDEsi90AOZb0VJxVmTRWFjh3DBcbbeiurTQndKrQff6T5SkbK2vjKP7ipFAKfAYK6SDOxsZ6c5KB8/5aMHXnble9aL2tDV2CArlbKlTySM9ozcN274gK8n2at8lKfDgzK1yzCehVk6KQk+EERNqxFESpoFgq28DLGqxcPQW27nD7jqFSxPSHGll3ePTF49e8/sNi6vRD3dvmgGMMZWmdI8QwfR83ELN+jcwb3sCNhUh/kK4ETfDMV3N5kRhSGcJK84Lzb4s85afacGxXRu/9HhiEe7wl+LWv5Es='
+          sshPublicKey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDHVf1VsKwFAc1574TJfQK1v7ugPoYIpASm3UqB8HUQHVl353zH/veEL2xer1g4GSj27LIh0wszGqu6wMIWGNxb1iEozhLBABnavAht9mSYWkeOfzWb8f8c4EgLyK5gWhT049+A1iI8tu9DjHjgGD6JeyYyUXGHwC0cexqu6QJszWuXi2a0arCeM2Dbo/bjTJ4HdKEJBaxHpaO0JbbNmJrKwlAySHKdWtQ7uowKQgdD6BZcjV4n++pj4WfMMUVgBfaw7m3S6DP7I+yAWH4U3mLpf6Yq54rYYCewjLtQHj9H5xAPAi7Yk7b4+DJgeOY8CQ3zSdsnrHf69905ShVy9fUbylilgqdZEiRwxCaQ7Felh9cH9OBmP1DtEDpL1FSj5lj9o7fSNCJ22F8vYKf7hQRK68vjJW16rB1iPh63fHSIdEQV4pobxjhoOctckxI7svHT6u7pf6tP4BW9wu8i4utQq5XaF1HN2DWcKSP8I+R3668/p/kHfAvJQZaHsbFmB+s= jerome@azure-pipelines'
+          sshKeySecureFile: 'ssh_rsa_build-cache'
+      - script: |
+          set -e -v
+          export LC_ALL=C
+          export PATH=/usr/local/bin:$PATH  # clang
+          export CROSS_COMPILE32="ccache arm-linux-gnueabihf-"
+          export CROSS_COMPILE64="ccache aarch64-linux-gnu-"
+          export CFG_DEBUG_INFO=n
+          export CFG_WERROR=y
+          export START=$(date +%s)
+          export PROJ=$(System.CollectionId)-$(System.TeamProject) # $ORG_NAME-$REPO_NAME
+          export SCP_OPT="-o ConnectTimeout=10 -o StrictHostKeyChecking=no"
+
+          function download_cache() { ssh $SCP_OPT shippable@shippable-cache.forissier.org "cat ccache-$PROJ.tar.gz" | tar zx -C $HOME || echo Nevermind; }
+          function upload_cache() { if [ ! -e .uploaded ]; then echo Uploading cache && tar c -C $HOME .ccache | gzip -1 | ssh $SCP_OPT shippable@shippable-cache.forissier.org "cat >ccache-$PROJ.tar.gz" && touch .uploaded || echo Nevermind; fi; }
+          function check_upload_cache() { NOW=$(date +%s); if [ $(expr $NOW - $START) -gt 3000 ]; then upload_cache; fi; }
+          function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && check_upload_cache; }
+          function download_plug_and_trust() { mkdir -p $HOME/se050 && curl -L https://github.com/foundriesio/plug-and-trust/releases/download/v0.0.2/se050-0.0.2.tar.bz2 | tar jxf - --strip-components=1 -C $HOME/se050 || (rm -rf $HOME/se050; echo Nervermind); }
+
+          download_cache
+          ccache -s
+          download_plug_and_trust
+
+          _make
+          _make COMPILER=clang
+          _make CFG_TEE_CORE_LOG_LEVEL=4 CFG_TEE_CORE_DEBUG=y CFG_TEE_TA_LOG_LEVEL=4 CFG_CC_OPT_LEVEL=0 CFG_DEBUG_INFO=y CFG_ENABLE_EMBEDDED_TESTS=y
+          _make CFG_TEE_CORE_LOG_LEVEL=0 CFG_TEE_CORE_DEBUG=n CFG_TEE_TA_LOG_LEVEL=0 CFG_DEBUG_INFO=n
+          _make CFG_TEE_CORE_LOG_LEVEL=0
+          _make CFG_TEE_CORE_MALLOC_DEBUG=y CFG_CORE_DEBUG_CHECK_STACKS=y
+          _make CFG_CORE_SANITIZE_UNDEFINED=y
+          _make CFG_CORE_SANITIZE_KADDRESS=y
+          _make CFG_LOCKDEP=y
+          _make CFG_CRYPTO=n
+          _make CFG_CRYPTO_{AES,DES}=n
+          _make CFG_CRYPTO_{DSA,RSA,DH}=n
+          _make CFG_CRYPTO_{DSA,RSA,DH,ECC}=n
+          _make CFG_CRYPTO_{H,C,CBC_}MAC=n
+          _make CFG_CRYPTO_{G,C}CM=n
+          _make CFG_CRYPTO_{MD5,SHA{1,224,256,384,512,512_256}}=n
+          _make CFG_WITH_PAGER=y out/core/tee{,-pager,-pageable}.bin
+          _make CFG_WITH_PAGER=y CFG_CRYPTOLIB_NAME=mbedtls CFG_CRYPTOLIB_DIR=lib/libmbedtls
+          _make CFG_WITH_PAGER=y CFG_WITH_LPAE=y
+          _make CFG_WITH_LPAE=y
+          _make CFG_RPMB_FS=y
+          _make CFG_RPMB_FS=y CFG_RPMB_TESTKEY=y
+          _make CFG_REE_FS=n CFG_RPMB_FS=y
+          _make CFG_WITH_PAGER=y CFG_WITH_LPAE=y CFG_RPMB_FS=y CFG_DT=y CFG_TEE_CORE_LOG_LEVEL=1 CFG_TEE_CORE_DEBUG=y CFG_CC_OPT_LEVEL=0 CFG_DEBUG_INFO=y
+          _make CFG_WITH_PAGER=y CFG_WITH_LPAE=y CFG_RPMB_FS=y CFG_DT=y CFG_TEE_CORE_LOG_LEVEL=0 CFG_TEE_CORE_DEBUG=n DEBUG=0
+          _make CFG_BUILT_IN_ARGS=y CFG_PAGEABLE_ADDR=0 CFG_NS_ENTRY_ADDR=0 CFG_DT_ADDR=0 CFG_DT=y
+          _make CFG_FTRACE_SUPPORT=y CFG_ULIBS_MCOUNT=y CFG_ULIBS_SHARED=y
+          _make CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
+          _make CFG_SECURE_DATA_PATH=y
+          _make CFG_REE_FS_TA_BUFFERED=y
+          _make PLATFORM=vexpress-qemu_armv8a
+          _make PLATFORM=vexpress-qemu_armv8a COMPILER=clang
+          _make PLATFORM=vexpress-qemu_armv8a CFG_WITH_PAGER=y
+          _make PLATFORM=vexpress-qemu_armv8a CFG_FTRACE_SUPPORT=y CFG_ULIBS_MCOUNT=y CFG_ULIBS_SHARED=y
+          _make PLATFORM=vexpress-qemu_armv8a CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
+          _make PLATFORM=vexpress-qemu_armv8a CFG_VIRTUALIZATION=y
+          _make PLATFORM=vexpress-qemu_armv8a CFG_CORE_SEL1_SPMC=y
+          dd if=/dev/urandom of=BL32_AP_MM.fd bs=2621440 count=1 && _make PLATFORM=vexpress-qemu_armv8a CFG_STMM_PATH=BL32_AP_MM.fd CFG_RPMB_FS=y CFG_CORE_HEAP_SIZE=524288 CFG_TEE_RAM_VA_SIZE=0x00400000
+          _make PLATFORM=stm-b2260
+          _make PLATFORM=stm-cannes
+          _make PLATFORM=stm32mp1
+          _make PLATFORM=stm32mp1-157C_DK2
+          _make PLATFORM=vexpress-fvp
+          _make PLATFORM=vexpress-fvp CFG_ARM64_core=y
+          _make PLATFORM=vexpress-juno
+          _make PLATFORM=vexpress-juno CFG_ARM64_core=y
+          _make PLATFORM=hikey
+          _make PLATFORM=hikey CFG_ARM64_core=y
+          _make PLATFORM=mediatek-mt8173
+          _make PLATFORM=mediatek-mt8183
+          _make PLATFORM=mediatek-mt8516
+          _make PLATFORM=imx-mx6ulevk
+          _make PLATFORM=imx-mx6ulevk CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
+          _make PLATFORM=imx-mx6ul9x9evk
+          _make PLATFORM=imx-mx6ullevk
+          if [ -d $HOME/se050 ]; then _make PLATFORM=imx-mx6ullevk CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{RNG,RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST_LIB=$HOME/se050/buildarm/libse050.a CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050; fi
+          _make PLATFORM=imx-mx6ulzevk
+          _make PLATFORM=imx-mx6slevk
+          _make PLATFORM=imx-mx6sllevk
+          _make PLATFORM=imx-mx6sxsabreauto
+          _make PLATFORM=imx-mx6sxsabresd
+          _make PLATFORM=imx-mx6sxsabresd CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
+          _make PLATFORM=imx-mx6solosabresd
+          _make PLATFORM=imx-mx6solosabreauto
+          _make PLATFORM=imx-mx6sxsabreauto
+          _make PLATFORM=imx-mx6qsabrelite
+          _make PLATFORM=imx-mx6qsabresd
+          _make PLATFORM=imx-mx6qsabresd CFG_RPMB_FS=y
+          _make PLATFORM=imx-mx6qsabreauto
+          _make PLATFORM=imx-mx6qsabreauto CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
+          _make PLATFORM=imx-mx6qpsabreauto
+          _make PLATFORM=imx-mx6qpsabresd
+          _make PLATFORM=imx-mx6dlsabresd
+          _make PLATFORM=imx-mx6dlsabreauto
+          _make PLATFORM=imx-mx6dapalis
+          _make PLATFORM=imx-mx6qapalis
+          _make PLATFORM=imx-mx7dsabresd
+          _make PLATFORM=imx-mx7dsabresd CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
+          _make PLATFORM=imx-mx7ulpevk
+          _make PLATFORM=imx-mx8mmevk
+          _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
+          if [ -d $HOME/se050 ]; then _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_NXP_CAAM_RNG_DRV=y CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_NXP_SE05X_RNG_DRV=n CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST_LIB=$HOME/se050/build/libse050.a CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050 ; fi
+          _make PLATFORM=imx-mx8mnevk
+          _make PLATFORM=imx-mx8mqevk
+          _make PLATFORM=imx-mx8qxpmek
+          _make PLATFORM=imx-mx8qmmek
+          _make PLATFORM=k3-j721e
+          _make PLATFORM=k3-j721e CFG_ARM64_core=y
+          _make PLATFORM=k3-am65x
+          _make PLATFORM=k3-am65x CFG_ARM64_core=y
+          _make PLATFORM=ti-dra7xx out/core/tee{,-pager,-pageable}.bin
+          _make PLATFORM=ti-am57xx
+          _make PLATFORM=ti-am43xx
+          _make PLATFORM=sprd-sc9860
+          _make PLATFORM=sprd-sc9860 CFG_ARM64_core=y
+          _make PLATFORM=ls-ls1021atwr
+          _make PLATFORM=ls-ls1021aqds
+          _make PLATFORM=ls-ls1043ardb
+          _make PLATFORM=ls-ls1046ardb
+          _make PLATFORM=ls-ls1012ardb
+          _make PLATFORM=ls-ls1012afrwy
+          _make PLATFORM=ls-ls1028ardb
+          _make PLATFORM=ls-ls1088ardb
+          _make PLATFORM=ls-ls2088ardb
+          _make PLATFORM=ls-lx2160ardb
+          _make PLATFORM=ls-lx2160aqds
+          _make PLATFORM=zynq7k-zc702
+          _make PLATFORM=zynqmp-zcu102
+          _make PLATFORM=zynqmp-zcu102 CFG_ARM64_core=y
+          _make PLATFORM=d02
+          _make PLATFORM=d02 CFG_ARM64_core=y
+          _make PLATFORM=rcar
+          _make PLATFORM=rcar CFG_ARM64_core=y
+          _make PLATFORM=rzg
+          _make PLATFORM=rzg CFG_ARM64_core=y
+          _make PLATFORM=rpi3
+          _make PLATFORM=rpi3 CFG_ARM64_core=y
+          _make PLATFORM=hikey-hikey960
+          _make PLATFORM=hikey-hikey960 COMPILER=clang
+          _make PLATFORM=hikey-hikey960 CFG_ARM64_core=y
+          _make PLATFORM=hikey-hikey960 CFG_ARM64_core=y COMPILER=clang
+          _make PLATFORM=hikey-hikey960 CFG_SECURE_DATA_PATH=n
+          _make PLATFORM=poplar
+          _make PLATFORM=poplar CFG_ARM64_core=y
+          _make PLATFORM=rockchip-rk322x
+          _make PLATFORM=sam
+          _make PLATFORM=marvell-armada7k8k
+          _make PLATFORM=marvell-armada3700
+          _make PLATFORM=synquacer
+          _make PLATFORM=sunxi-bpi_zero
+          _make PLATFORM=sunxi-sun50i_a64
+          _make PLATFORM=bcm-ns3 CFG_ARM64_core=y
+          _make PLATFORM=hisilicon-hi3519av100_demo
+          _make PLATFORM=amlogic
+          _make PLATFORM=rzn1
+
+          upload_cache


### PR DESCRIPTION
The Shippable Continuous Integration service is scheduled for retirement
on May 3rd, 2021 [1]. Therefore, a replacement has to be found.

This commit introduces .azure-pipelines.yml which serves the same
purpose as .shippable.yml but runs on the Microsoft Azure Pipelines
infrastructure [2].

Link: [1] https://blog.shippable.com/the-next-step-in-the-evolution-of-shippable-jfrog-pipelines
Link: [2] https://azure.microsoft.com/en-us/services/devops/pipelines/
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
