### PR TITLE
Fix a memory-leak in bigint_binary_mod function.

### DIFF
--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -390,6 +390,7 @@ static void bigint_binary_mod(TEE_BigInt *dest, const TEE_BigInt *op1,
 	if (pop2 == &mpi_op2)
 		mbedtls_mpi_free(&mpi_op2);
 	mbedtls_mpi_free(&mpi_t);
+	mbedtls_mpi_free(&mpi_n);
 }
 
 void TEE_BigIntAdd(TEE_BigInt *dest, const TEE_BigInt *op1,


### PR DESCRIPTION
Fix a memory-leak in bigint_binary_mod function.
The modulus n was not released.

Signed-off-by: Matthieu BERTIN <matthieu.bertin@viaccess-orca.com>
