### PR TITLE
GP 1.1: Check parameters annotated in the specification

### DIFF
--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -405,6 +405,8 @@ TEE_Result TEE_OpenPersistentObject(uint32_t storageID, const void *objectID,
 		goto exit;
 	}
 
+	__utee_check_out_annotation(object, sizeof(*object));
+
 	res = _utee_storage_obj_open(storageID, objectID, objectIDLen, flags,
 				     &obj);
 	if (res == TEE_SUCCESS)


### PR DESCRIPTION
Checks that all the function parameters which are annotated in the
specification [1] are compliant with regards to memory access and memory
location. In case the check fails the TA panics to help debugging. The
more precise and expensive checks can be disabled with
CFG_TA_STRICT_ANNOTATION_CHECKS=n.

TEE_Realloc(), TEE_MemMove(), TEE_MemCompare(), TEE_MemFill() are
skipped for performance reasons. The TA will instead die with a fatal
exception if buffers supplied to these functions do not follow the
annotation rules.

[1]: GlobalPlatform TEE Internal Core API Specification v1.1

Signed-off-by: Stefan Schmidt <snst@meek.de>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
