### PR TITLE
core: ADD FF-A rxtx buffer for SPs

### DIFF
--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <config.h>
 #include <kernel/embedded_ts.h>
+#include <kernel/thread_spmc.h>
 #include <kernel/user_mode_ctx_struct.h>
 #include <stdint.h>
 #include <tee_api_types.h>
@@ -31,6 +32,7 @@ struct sp_ffa_init_info {
 enum sp_status { sp_idle, sp_busy, sp_preempted, sp_dead };
 
 struct sp_session {
+	struct ffa_rxtx rxtx;
 	enum sp_status state;
 	uint16_t endpoint_id;
 	uint16_t caller_id;

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -5,7 +5,20 @@
 #ifndef __KERNEL_THREAD_SPMC_H
 #define __KERNEL_THREAD_SPMC_H
 
+#include <kernel/thread.h>
+
 /* FF-A endpoint base ID when OP-TEE is used as a S-EL1 endpoint */
 #define SPMC_ENDPOINT_ID        0x8001
 
+struct ffa_rxtx {
+	void *rx;
+	void *tx;
+	unsigned int size;
+	unsigned int spinlock;
+	bool tx_is_mine;
+};
+
+void spmc_handle_rxtx_map(struct thread_smc_args *args, struct ffa_rxtx *buf);
+void spmc_handle_rxtx_unmap(struct thread_smc_args *args, struct ffa_rxtx *buf);
+void spmc_handle_rx_release(struct thread_smc_args *args, struct ffa_rxtx *buf);
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -213,10 +213,32 @@ void spmc_sp_msg_handler(struct thread_smc_args *args,
 			cpu_spin_unlock(&caller_sp->spinlock);
 			caller_sp = NULL;
 			break;
+#ifdef ARM64
+		case FFA_RXTX_MAP_64:
+#endif
+		case FFA_RXTX_MAP_32:
+			ts_push_current_session(&caller_sp->ts_sess);
+			spmc_handle_rxtx_map(args, &caller_sp->rxtx);
+			ts_pop_current_session();
+			sp_enter(args, caller_sp);
+			break;
+		case FFA_RXTX_UNMAP:
+			ts_push_current_session(&caller_sp->ts_sess);
+			spmc_handle_rxtx_unmap(args, &caller_sp->rxtx);
+			ts_pop_current_session();
+			sp_enter(args, caller_sp);
+			break;
+		case FFA_RX_RELEASE:
+			ts_push_current_session(&caller_sp->ts_sess);
+			spmc_handle_rx_release(args, &caller_sp->rxtx);
+			ts_pop_current_session();
+			sp_enter(args, caller_sp);
+			break;
 		default:
 			EMSG("Unhandled FFA function ID %#"PRIx32,
 			     (uint32_t)args->a0);
 			ffa_set_error(args, FFA_INVALID_PARAMETERS);
+			sp_enter(args, caller_sp);
 		}
 	} while (caller_sp);
 }


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
rxtx buffers are used for SPs and the SPMC to exchange information.
Implements the following FF-A messages for SPs.
FFA_RXTX_MAP_64 and FFA_RXTX_MAP_32 to have a SP map a rxtx buffer
FFA_RXTX_UNMAP: to unmap the rxtx buffer
FFA_RX_RELEASE: to release have the SP release the rx buffer