### PR TITLE
ta: pkcs11: Fix error code returned by entry_processing_key()

### DIFF
--- a/ta/pkcs11/src/processing.c
+++ b/ta/pkcs11/src/processing.c
@@ -528,8 +528,16 @@ enum pkcs11_rc entry_processing_key(struct pkcs11_client *client,
 	 */
 	rc = check_parent_attrs_against_processing(proc_params->id, function,
 						   parent->attributes);
-	if (rc)
+	if (rc) {
+		/*
+		 * CKR_KEY_FUNCTION_NOT_PERMITTED is not in the list of errors
+		 * specified with C_Derive/Unwrap() in the specification. So
+		 * return the next most appropriate error.
+		 */
+		if (rc == PKCS11_CKR_KEY_FUNCTION_NOT_PERMITTED)
+			rc = PKCS11_CKR_KEY_TYPE_INCONSISTENT;
 		goto out;
+	}
 
 	/* Check access of base/parent key */
 	rc = check_access_attrs_against_token(session, parent->attributes);


### PR DESCRIPTION
check_parent_attrs_against_processing() checks if the right attributes
are set in the key to be used for a cryptgraphic purpose. It returns
error - CKR_KEY_FUNCTION_NOT_PERMITTED if this is not the case.
For C_DeriveKey(), C_UnwrapKey(), CKR_KEY_FUNCTION_NOT_PERMITTED is not
specified in the error code list. So, for such errors return
CKR_KEY_TYPE_INCONSISTENT instead.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
