### PR TITLE
core: mm: fix check_pa_matches_va() panic on unlocked paged memory

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -428,8 +428,10 @@ void core_mmu_get_user_map(struct core_mmu_user_map *map);
 
 /*
  * core_mmu_set_user_map() - Set new MMU configuration for user VA space
- * @map:	If NULL will disable user VA space, if not NULL the user
- *		VA space to activate.
+ * @map:	User context MMU configuration or NULL to set core VA space
+ *
+ * Activate user VA space mapping and set its ASID if @map is not NULL,
+ * otherwise activate core mapping and set ASID to 0.
  */
 void core_mmu_set_user_map(struct core_mmu_user_map *map);
 

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -2106,6 +2106,8 @@ static void check_pa_matches_va(void *va, paddr_t pa)
 
 			res = vm_va2pa(to_user_mode_ctx(thread_get_tsd()->ctx),
 				       va, &p);
+			if (res == TEE_ERROR_NOT_SUPPORTED)
+				return;
 			if (res == TEE_SUCCESS && pa != p)
 				panic("bad pa");
 			if (res != TEE_SUCCESS && pa)

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -2197,16 +2197,10 @@ static void check_va_matches_pa(paddr_t pa __unused, void *va __unused)
 
 static void *phys_to_virt_ta_vaspace(paddr_t pa)
 {
-	TEE_Result res = TEE_ERROR_GENERIC;
-	void *va = NULL;
-
 	if (!core_mmu_user_mapping_is_active())
 		return NULL;
 
-	res = vm_pa2va(to_user_mode_ctx(thread_get_tsd()->ctx), pa, &va);
-	if (res != TEE_SUCCESS)
-		return NULL;
-	return va;
+	return vm_pa2va(to_user_mode_ctx(thread_get_tsd()->ctx), pa);
 }
 
 #ifdef CFG_WITH_PAGER

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -2042,8 +2042,8 @@ void asid_free(unsigned int asid)
 static bool arm_va2pa_helper(void *va, paddr_t *pa)
 {
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
-	paddr_t par;
-	paddr_t par_pa_mask;
+	paddr_t par = 0;
+	paddr_t par_pa_mask = 0;
 	bool ret = false;
 
 #ifdef ARM32
@@ -2086,14 +2086,14 @@ static vaddr_t get_linear_map_end(void)
 #if defined(CFG_TEE_CORE_DEBUG)
 static void check_pa_matches_va(void *va, paddr_t pa)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	vaddr_t v = (vaddr_t)va;
 	paddr_t p = 0;
 	struct core_mmu_table_info ti __maybe_unused = { };
 
 	if (core_mmu_user_va_range_is_defined()) {
-		vaddr_t user_va_base;
-		size_t user_va_size;
+		vaddr_t user_va_base = 0;
+		size_t user_va_size = 0;
 
 		core_mmu_get_user_va_range(&user_va_base, &user_va_size);
 		if (v >= user_va_base &&
@@ -2167,7 +2167,7 @@ static void check_pa_matches_va(void *va __unused, paddr_t pa __unused)
 
 paddr_t virt_to_phys(void *va)
 {
-	paddr_t pa;
+	paddr_t pa = 0;
 
 	if (!arm_va2pa_helper(va, &pa))
 		pa = 0;
@@ -2178,7 +2178,7 @@ paddr_t virt_to_phys(void *va)
 #if defined(CFG_TEE_CORE_DEBUG)
 static void check_va_matches_pa(paddr_t pa, void *va)
 {
-	paddr_t p;
+	paddr_t p = 0;
 
 	if (!va)
 		return;
@@ -2197,7 +2197,7 @@ static void check_va_matches_pa(paddr_t pa __unused, void *va __unused)
 
 static void *phys_to_virt_ta_vaspace(paddr_t pa)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	void *va = NULL;
 
 	if (!core_mmu_user_mapping_is_active())
@@ -2219,7 +2219,7 @@ static void *phys_to_virt_tee_ram(paddr_t pa)
 #else
 static void *phys_to_virt_tee_ram(paddr_t pa)
 {
-	struct tee_mmap_region *mmap;
+	struct tee_mmap_region *mmap = NULL;
 
 	mmap = find_map_by_type_and_pa(MEM_AREA_TEE_RAM, pa);
 	if (!mmap)
@@ -2237,7 +2237,7 @@ static void *phys_to_virt_tee_ram(paddr_t pa)
 
 void *phys_to_virt(paddr_t pa, enum teecore_memtypes m)
 {
-	void *va;
+	void *va = NULL;
 
 	switch (m) {
 	case MEM_AREA_TA_VASPACE:
@@ -2264,8 +2264,8 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m)
 
 void *phys_to_virt_io(paddr_t pa)
 {
-	struct tee_mmap_region *map;
-	void *va;
+	struct tee_mmap_region *map = NULL;
+	void *va = NULL;
 
 	map = find_map_by_type_and_pa(MEM_AREA_IO_SEC, pa);
 	if (!map)

--- a/core/arch/arm/mm/mobj.c
+++ b/core/arch/arm/mm/mobj.c
@@ -597,8 +597,10 @@ static TEE_Result mobj_with_fobj_get_pa(struct mobj *mobj, size_t offs,
 	struct mobj_with_fobj *f = to_mobj_with_fobj(mobj);
 	paddr_t p = 0;
 
-	if (!f->fobj->ops->get_pa)
-		return TEE_ERROR_GENERIC;
+	if (!f->fobj->ops->get_pa) {
+		assert(mobj_is_paged(mobj));
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
 
 	p = f->fobj->ops->get_pa(f->fobj, offs / SMALL_PAGE_SIZE) +
 	    offs % SMALL_PAGE_SIZE;

--- a/core/include/mm/vm.h
+++ b/core/include/mm/vm.h
@@ -9,14 +9,10 @@
 #include <kernel/tee_ta_manager.h>
 #include <kernel/user_ta.h>
 
-/*-----------------------------------------------------------------------------
- * Allocate context resources like ASID and MMU table information
- *---------------------------------------------------------------------------*/
+/* Allocate context resources like ASID and MMU table information */
 TEE_Result vm_info_init(struct user_mode_ctx *uctx);
 
-/*-----------------------------------------------------------------------------
- * Release context resources like ASID
- *---------------------------------------------------------------------------*/
+/* Release context resources like ASID */
 void vm_info_final(struct user_mode_ctx *uctx);
 
 /*
@@ -87,26 +83,20 @@ TEE_Result vm_buf_to_mboj_offs(const struct user_mode_ctx *uctx,
 			       const void *va, size_t size,
 			       struct mobj **mobj, size_t *offs);
 
-/*-----------------------------------------------------------------------------
- * vm_va2pa - Translate virtual user address to physical address
- * given the user context.
- * Interface is deprecated, use virt_to_phys() instead.
- *---------------------------------------------------------------------------*/
+/* Helper function for virt_to_phys(), shouldn't be used directly elsewhere */
 TEE_Result vm_va2pa(const struct user_mode_ctx *uctx, void *ua, paddr_t *pa);
 
-/*-----------------------------------------------------------------------------
- * vm_pa2va - Translate physical address to virtual user address
- * given the user context.
- * Interface is deprecated, use phys_to_virt() instead.
- *---------------------------------------------------------------------------*/
+/* Helper function for phys_to_virt(), shouldn't be used directly elsewhere */
 void *vm_pa2va(const struct user_mode_ctx *uctx, paddr_t pa);
 
+/*
+ * Return TEE_SUCCESS or TEE_ERROR_ACCESS_DENIED when buffer exists or return
+ * another TEE_Result code.
+ */
 TEE_Result vm_check_access_rights(const struct user_mode_ctx *uctx,
 				  uint32_t flags, uaddr_t uaddr, size_t len);
 
-/*-----------------------------------------------------------------------------
- * If ctx is NULL user mapping is removed and ASID set to 0
- *---------------------------------------------------------------------------*/
+/* Set user context @ctx or core privileged context if @ctx is NULL */
 void vm_set_ctx(struct ts_ctx *ctx);
 
 #endif /*TEE_MMU_H*/

--- a/core/include/mm/vm.h
+++ b/core/include/mm/vm.h
@@ -99,7 +99,7 @@ TEE_Result vm_va2pa(const struct user_mode_ctx *uctx, void *ua, paddr_t *pa);
  * given the user context.
  * Interface is deprecated, use phys_to_virt() instead.
  *---------------------------------------------------------------------------*/
-TEE_Result vm_pa2va(const struct user_mode_ctx *uctx, paddr_t pa, void **va);
+void *vm_pa2va(const struct user_mode_ctx *uctx, paddr_t pa);
 
 TEE_Result vm_check_access_rights(const struct user_mode_ctx *uctx,
 				  uint32_t flags, uaddr_t uaddr, size_t len);


### PR DESCRIPTION
Change check_pa_matches_va() to not panic on memory references
on fully pageable (unlocked) memory.

This change makes tee_mmu_user_va2pa_attr() (and vm_va2pa()) to
return a null physical address with TEE_SUCCESS on unlocked
pageable memory since these may change of physical page.

An alternative is to inspect the pager to check is there is a
matching physical page but in this case one should lock pager
or at least the page, while va and pa are loaded and
check_pa_matches_va() returns. I think it's not worth the gain.

TODO: rename straight tee_mmu_user_va2pa_attr() to vm_va_info(pa, attr)
and update the inline comments stating vm_va2pa() is deprecated.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
