### PR TITLE
core: remove memory copy when TA invokes another TA

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -538,22 +538,6 @@ static TEE_Result utee_param_to_param(struct user_ta_ctx *utc,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result alloc_temp_sec_mem(size_t size, struct mobj **mobj,
-				     uint8_t **va)
-{
-	/* Allocate section in secure DDR */
-#ifdef CFG_PAGED_USER_TA
-	*mobj = mobj_seccpy_shm_alloc(size);
-#else
-	*mobj = mobj_mm_alloc(mobj_sec_ddr, size, &tee_mm_sec_ddr);
-#endif
-	if (!*mobj)
-		return TEE_ERROR_GENERIC;
-
-	*va = mobj_get_va(*mobj, 0);
-	return TEE_SUCCESS;
-}
-
 /*
  * TA invokes some TA with parameter.
  * If some parameters are memory references:
@@ -566,17 +550,10 @@ static TEE_Result alloc_temp_sec_mem(size_t size, struct mobj **mobj,
 static TEE_Result tee_svc_copy_param(struct ts_session *sess,
 				     struct ts_session *called_sess,
 				     struct utee_params *callee_params,
-				     struct tee_ta_param *param,
-				     void *tmp_buf_va[TEE_NUM_PARAMS],
-				     size_t tmp_buf_size[TEE_NUM_PARAMS],
-				     struct mobj **mobj_tmp)
+				     struct tee_ta_param *param)
 {
 	struct user_ta_ctx *utc = to_user_ta_ctx(sess->ctx);
-	bool ta_private_memref[TEE_NUM_PARAMS] = { false, };
 	TEE_Result res = TEE_SUCCESS;
-	size_t dst_offs = 0;
-	size_t req_mem = 0;
-	uint8_t *dst = 0;
 	void *va = NULL;
 	size_t n = 0;
 	size_t s = 0;
@@ -605,11 +582,7 @@ static TEE_Result tee_svc_copy_param(struct ts_session *sess,
 	}
 
 	/* All mobj in param are of type MOJB_TYPE_VIRT */
-
 	for (n = 0; n < TEE_NUM_PARAMS; n++) {
-
-		ta_private_memref[n] = false;
-
 		switch (TEE_PARAM_TYPE_GET(param->types, n)) {
 		case TEE_PARAM_TYPE_MEMREF_INPUT:
 		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
@@ -619,14 +592,6 @@ static TEE_Result tee_svc_copy_param(struct ts_session *sess,
 			if (!va) {
 				if (s)
 					return TEE_ERROR_BAD_PARAMETERS;
-				break;
-			}
-			/* uTA cannot expose its private memory */
-			if (vm_buf_is_inside_um_private(&utc->uctx, va, s)) {
-				s = ROUNDUP(s, sizeof(uint32_t));
-				if (ADD_OVERFLOW(req_mem, s, &req_mem))
-					return TEE_ERROR_BAD_PARAMETERS;
-				ta_private_memref[n] = true;
 				break;
 			}
 
@@ -641,56 +606,6 @@ static TEE_Result tee_svc_copy_param(struct ts_session *sess,
 		}
 	}
 
-	if (req_mem == 0)
-		return TEE_SUCCESS;
-
-	res = alloc_temp_sec_mem(req_mem, mobj_tmp, &dst);
-	if (res != TEE_SUCCESS)
-		return res;
-	dst_offs = 0;
-
-	for (n = 0; n < TEE_NUM_PARAMS; n++) {
-
-		if (!ta_private_memref[n])
-			continue;
-
-		s = ROUNDUP(param->u[n].mem.size, sizeof(uint32_t));
-
-		switch (TEE_PARAM_TYPE_GET(param->types, n)) {
-		case TEE_PARAM_TYPE_MEMREF_INPUT:
-		case TEE_PARAM_TYPE_MEMREF_INOUT:
-			va = (void *)param->u[n].mem.offs;
-			if (va) {
-				res = copy_from_user(dst, va,
-						     param->u[n].mem.size);
-				if (res != TEE_SUCCESS)
-					return res;
-				param->u[n].mem.offs = dst_offs;
-				param->u[n].mem.mobj = *mobj_tmp;
-				tmp_buf_va[n] = dst;
-				tmp_buf_size[n] = param->u[n].mem.size;
-				dst += s;
-				dst_offs += s;
-			}
-			break;
-
-		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
-			va = (void *)param->u[n].mem.offs;
-			if (va) {
-				param->u[n].mem.offs = dst_offs;
-				param->u[n].mem.mobj = *mobj_tmp;
-				tmp_buf_va[n] = dst;
-				tmp_buf_size[n] = param->u[n].mem.size;
-				dst += s;
-				dst_offs += s;
-			}
-			break;
-
-		default:
-			continue;
-		}
-	}
-
 	return TEE_SUCCESS;
 }
 
@@ -700,45 +615,17 @@ static TEE_Result tee_svc_copy_param(struct ts_session *sess,
  * - either the memref was temporary: copy back data and update size
  * - or it was the original TA memref: update only the size value.
  */
-static TEE_Result tee_svc_update_out_param(
-		struct tee_ta_param *param,
-		void *tmp_buf_va[TEE_NUM_PARAMS],
-		size_t tmp_buf_size[TEE_NUM_PARAMS],
-		struct utee_params *usr_param)
+static TEE_Result tee_svc_update_out_param(struct tee_ta_param *param,
+					   struct utee_params *usr_param)
 {
-	size_t n;
+	size_t n = 0;
 	uint64_t *vals = usr_param->vals;
-	size_t sz = 0;
 
 	for (n = 0; n < TEE_NUM_PARAMS; n++) {
 		switch (TEE_PARAM_TYPE_GET(param->types, n)) {
 		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
 		case TEE_PARAM_TYPE_MEMREF_INOUT:
-			/*
-			 * Memory copy is only needed if there's a temporary
-			 * buffer involved, tmp_buf_va[n] is only update if
-			 * a temporary buffer is used. Otherwise only the
-			 * size needs to be updated.
-			 */
-			sz = param->u[n].mem.size;
-			if (tmp_buf_va[n] && sz <= vals[n * 2 + 1]) {
-				void *src = tmp_buf_va[n];
-				void *dst = (void *)(uintptr_t)vals[n * 2];
-				TEE_Result res = TEE_SUCCESS;
-
-				/*
-				 * TA is allowed to return a size larger than
-				 * the original size. However, in such cases no
-				 * data should be synchronized as per TEE Client
-				 * API spec.
-				 */
-				if (sz <= tmp_buf_size[n]) {
-					res = copy_to_user(dst, src, sz);
-					if (res != TEE_SUCCESS)
-						return res;
-				}
-			}
-			usr_param->vals[n * 2 + 1] = sz;
+			usr_param->vals[n * 2 + 1] = param->u[n].mem.size;
 			break;
 
 		case TEE_PARAM_TYPE_VALUE_OUTPUT:
@@ -766,12 +653,9 @@ TEE_Result syscall_open_ta_session(const TEE_UUID *dest,
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t ret_o = TEE_ORIGIN_TEE;
 	struct tee_ta_session *s = NULL;
-	struct mobj *mobj_param = NULL;
 	TEE_UUID *uuid = malloc(sizeof(TEE_UUID));
 	struct tee_ta_param *param = malloc(sizeof(struct tee_ta_param));
 	TEE_Identity *clnt_id = malloc(sizeof(TEE_Identity));
-	void *tmp_buf_va[TEE_NUM_PARAMS] = { NULL };
-	size_t tmp_buf_size[TEE_NUM_PARAMS] = { 0 };
 
 	if (uuid == NULL || param == NULL || clnt_id == NULL) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
@@ -787,8 +671,7 @@ TEE_Result syscall_open_ta_session(const TEE_UUID *dest,
 	clnt_id->login = TEE_LOGIN_TRUSTED_APP;
 	memcpy(&clnt_id->uuid, &sess->ctx->uuid, sizeof(TEE_UUID));
 
-	res = tee_svc_copy_param(sess, NULL, usr_param, param, tmp_buf_va,
-				 tmp_buf_size, &mobj_param);
+	res = tee_svc_copy_param(sess, NULL, usr_param, param);
 	if (res != TEE_SUCCESS)
 		goto function_exit;
 
@@ -798,11 +681,9 @@ TEE_Result syscall_open_ta_session(const TEE_UUID *dest,
 	if (res != TEE_SUCCESS)
 		goto function_exit;
 
-	res = tee_svc_update_out_param(param, tmp_buf_va, tmp_buf_size,
-				       usr_param);
+	res = tee_svc_update_out_param(param, usr_param);
 
 function_exit:
-	mobj_put_wipe(mobj_param);
 	if (res == TEE_SUCCESS)
 		copy_to_user_private(ta_sess, &s->id, sizeof(s->id));
 	copy_to_user_private(ret_orig, &ret_o, sizeof(ret_o));
@@ -841,9 +722,6 @@ TEE_Result syscall_invoke_ta_command(unsigned long ta_sess,
 	struct tee_ta_param param = { 0 };
 	TEE_Identity clnt_id = { };
 	struct tee_ta_session *called_sess = NULL;
-	struct mobj *mobj_param = NULL;
-	void *tmp_buf_va[TEE_NUM_PARAMS] = { NULL };
-	size_t tmp_buf_size[TEE_NUM_PARAMS] = { };
 
 	called_sess = tee_ta_get_session((uint32_t)ta_sess, true,
 				&utc->open_sessions);
@@ -853,8 +731,8 @@ TEE_Result syscall_invoke_ta_command(unsigned long ta_sess,
 	clnt_id.login = TEE_LOGIN_TRUSTED_APP;
 	memcpy(&clnt_id.uuid, &sess->ctx->uuid, sizeof(TEE_UUID));
 
-	res = tee_svc_copy_param(sess, &called_sess->ts_sess, usr_param, &param,
-				 tmp_buf_va, tmp_buf_size, &mobj_param);
+	res = tee_svc_copy_param(sess, &called_sess->ts_sess, usr_param,
+				 &param);
 	if (res != TEE_SUCCESS)
 		goto function_exit;
 
@@ -863,8 +741,7 @@ TEE_Result syscall_invoke_ta_command(unsigned long ta_sess,
 	if (res == TEE_ERROR_TARGET_DEAD)
 		goto function_exit;
 
-	res2 = tee_svc_update_out_param(&param, tmp_buf_va, tmp_buf_size,
-					usr_param);
+	res2 = tee_svc_update_out_param(&param, usr_param);
 	if (res2 != TEE_SUCCESS) {
 		/*
 		 * Spec for TEE_InvokeTACommand() says:
@@ -883,7 +760,6 @@ TEE_Result syscall_invoke_ta_command(unsigned long ta_sess,
 
 function_exit:
 	tee_ta_put_session(called_sess);
-	mobj_put_wipe(mobj_param);
 	copy_to_user_private(ret_orig, &ret_o, sizeof(ret_o));
 	return res;
 }


### PR DESCRIPTION
Remove the useless implementation of temporary memory use when a TA
invokes another TA. Implementation is useless since [1] release in
tag 3.6.0.

Since [1], user TA takes care of isolating memory passed as parameters
in the invocation. Therefore, there is no need for core to do the same.

Link: [1] ef305e54eac8 ("libutee: allocate temp secmem for invoke")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
