### PR TITLE
core:libmbedtls: Add support for 128 bit keys to 3DES CMAC

### DIFF
--- a/lib/libmbedtls/mbedtls/library/cmac.c
+++ b/lib/libmbedtls/mbedtls/library/cmac.c
@@ -235,6 +235,7 @@ int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
         case MBEDTLS_CIPHER_AES_128_ECB:
         case MBEDTLS_CIPHER_AES_192_ECB:
         case MBEDTLS_CIPHER_AES_256_ECB:
+        case MBEDTLS_CIPHER_DES_EDE_ECB:
         case MBEDTLS_CIPHER_DES_EDE3_ECB:
             break;
         default:


### PR DESCRIPTION
Awhile ago I asked this question
https://github.com/OP-TEE/optee_os/issues/4443

I wrongly assumed that both libtomcrypt and libmdetls don't handle 128 bit 3DES keys correctly and that I have to copy K1 to K3 in order to get correct result for 3DES CMAC with this type of keys.

It turned out that only libmbedtls needs to be changed in order to work correctly with 3DES 128 bit keys.

The story with libtomcrypt implementation was amusing to say the least:

While implementing HW accelerator support for DES/3DES I made a mistake with handling of 128 bit 3DES keys in libtomcrypt (namely in des3_setup() - core/lib/libtomcrypt/src/ciphers/des.c)
In this function 128 bit keys get extended to 192 bit keys by copying the K1 into K3.

Unfortunately this wasn't caught by xtest due to way TEE_CipherInit GP function is implemented if libtomcrypt is used as core crypto library for OP-TEE.

Details:
In the xtest code (namely, 4003) there are two checks related to 128 bit 3DES keys:

-     for TEE_ALG_DES3_ECB_NOPAD algorithm
-     for TEE_ALG_DES3_CBC_NOPAD algorithm

Eventually after all preparation steps TEE_CipherInit() gets called.
To simplify things, let's just say that,  if libtomcrypt is used, it will eventually call another function before calling des3_setup():

    ltc_ecb_init() for  TEE_ALG_DES3_ECB_NOPAD algorithm

    ltc_cbc_init()  TEE_ALG_DES3_CBC_NOPAD algorithm

Both these function call get_des2_key() which converts 128 bit key to 192 key.

This basically means that if there's an error in handling 128 bit key in des3_setup() it won't be detected by tests which use TEE_Cipher()* functions because by the the time key gets to de3_setup() it will be already extended to 192 bits thus code path related to extending the key won't be taken.

I also prepared a PR with additional test to check 128 bit key handling for 3DES CMAC. 