### PR TITLE
ta: pkcs11: Remove class and key check for indirect attributes

### DIFF
--- a/ta/pkcs11/src/sanitize_object.c
+++ b/ta/pkcs11/src/sanitize_object.c
@@ -229,18 +229,8 @@ static uint32_t sanitize_indirect_attr(struct obj_attrs **dst,
 {
 	struct obj_attrs *obj2 = NULL;
 	enum pkcs11_rc rc = PKCS11_CKR_OK;
-	enum pkcs11_class_id class = get_class(*dst);
 
 	assert(pkcs11_attr_has_indirect_attributes(cli_ref->id));
-
-	if (class == PKCS11_CKO_UNDEFINED_ID) {
-		DMSG("Template without CLASS not supported yet");
-		return PKCS11_CKR_TEMPLATE_INCOMPLETE;
-	}
-
-	/* Such attributes are expected only for keys (and vendor defined) */
-	if (!pkcs11_attr_class_is_key(class))
-		return PKCS11_CKR_TEMPLATE_INCONSISTENT;
 
 	rc = init_attributes_head(&obj2);
 	if (rc)


### PR DESCRIPTION
In sanitize_indirect_attributes(), class and key check is performed
to check to check that athe indirect attribute is provided
only for particular type of key objects. This check causes issue
in case an indirect template further has pointer to another
indirect template. It is not essential for an indirect template to
have class and key attributes.

When creating objects for classes which don't support the indirect
template, this would result in scenario where error is not returned.
However, the indirect attribute won't get added to the created object.
This is inline with how the other attributes are dealt with currently.
eg. if when creating a secret key, a public key attribute is passed,
it is currently ignored rather than returning error. A probable
fix is to check all the attributes in the user provided template with
the attributes of the type of object which needs to be created.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
