### PR TITLE
core: fix the loading single instance TA issue

### DIFF
--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -25,6 +25,12 @@
 
 TAILQ_HEAD(tee_ta_session_head, tee_ta_session);
 TAILQ_HEAD(tee_ta_ctx_head, tee_ta_ctx);
+TAILQ_HEAD(tee_initializing_uuid_head, tee_initializing_uuid);
+
+struct tee_initializing_uuid {
+	TEE_UUID uuid;
+	TAILQ_ENTRY(tee_initializing_uuid) link;
+};
 
 struct mobj;
 
@@ -96,6 +102,7 @@ struct tee_ta_session {
 
 /* Registered contexts */
 extern struct tee_ta_ctx_head tee_ctxes;
+extern struct tee_initializing_uuid_head initializing_ctxes;
 
 extern struct mutex tee_ta_mutex;
 extern struct condvar tee_ta_init_cv;


### PR DESCRIPTION
Add new condvar prevent to create the ctx twice for a single instance TA.

Signed-off-by: JY Ho <JY.Ho@mediatek.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
