### PR TITLE
core: libmbedtls: build only necessary files

### DIFF
--- a/lib/libmbedtls/sub.mk
+++ b/lib/libmbedtls/sub.mk
@@ -3,6 +3,7 @@ global-incdirs-y += mbedtls/include
 
 # OBJS_CRYPTO from make file
 SRCS_CRYPTO :=
+ifneq ($(sm),core)
 SRCS_CRYPTO += aes.c
 SRCS_CRYPTO += aesni.c
 SRCS_CRYPTO += arc4.c
@@ -63,6 +64,34 @@ SRCS_CRYPTO += timing.c
 SRCS_CRYPTO += version.c
 SRCS_CRYPTO += version_features.c
 SRCS_CRYPTO += xtea.c
+else
+SRCS_CRYPTO += aes.c
+SRCS_CRYPTO += aesni.c
+SRCS_CRYPTO += asn1parse.c
+SRCS_CRYPTO += asn1write.c
+SRCS_CRYPTO += bignum.c
+SRCS_CRYPTO += cipher.c
+SRCS_CRYPTO += cipher_wrap.c
+SRCS_CRYPTO += cmac.c
+SRCS_CRYPTO += des.c
+SRCS_CRYPTO += dhm.c
+SRCS_CRYPTO += ecdh.c
+SRCS_CRYPTO += ecdsa.c
+SRCS_CRYPTO += ecp.c
+SRCS_CRYPTO += ecp_curves.c
+SRCS_CRYPTO += md.c
+SRCS_CRYPTO += md5.c
+SRCS_CRYPTO += oid.c
+SRCS_CRYPTO += pk.c
+SRCS_CRYPTO += pk_wrap.c
+SRCS_CRYPTO += platform.c
+SRCS_CRYPTO += platform_util.c
+SRCS_CRYPTO += rsa_internal.c
+SRCS_CRYPTO += rsa.c
+SRCS_CRYPTO += sha1.c
+SRCS_CRYPTO += sha256.c
+SRCS_CRYPTO += sha512.c
+endif
 
 # OBJS_X509
 SRCS_X509 :=


### PR DESCRIPTION
When building MBed TLS source files for use in the TEE core, some files
are currently compiled which are not used in the final link. This wastes
some resources (build time and disk space), although not much; but it
also makes it less clear what is actually used by the core.

Introduce a reduced source file list in lib/libmbedtls/sub.mk when the
library is built for the core.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
