### PR TITLE
libutee: include: fix typo in pta_invoke_tests.h

### DIFF
--- a/lib/libutee/include/pta_invoke_tests.h
+++ b/lib/libutee/include/pta_invoke_tests.h
@@ -86,7 +86,7 @@
 /*
  * AES performance tests
  *
- * [in]     value[0].a	Top 16 bits Decrypt, low 16 bits key size in bytes
+ * [in]     value[0].a	Top 16 bits Decrypt, low 16 bits key size in bits
  * [in]     value[0].b	AES mode, one of
  *			PTA_INVOKE_TESTS_AES_{ECB_NOPAD,CBC_NOPAD,CTR,XTS,GCM}
  * [in]     value[1].a	repetition count


### PR DESCRIPTION
In PTA "invoke test", AES performance test command takes as argument key
size value as bits instead of bytes. Fix typo in comments.

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
