### PR TITLE
core: fix rsa public exponent check

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -1739,7 +1739,7 @@ static TEE_Result check_pub_rsa_key(struct bignum *e)
 
 	crypto_bignum_bn2bin(e, bin_key);
 
-	if (!(bin_key[0] & 1)) /* key must be odd */
+	if (!(bin_key[n - 1] & 1)) /* key must be odd */
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	if (n == 3) {


### PR DESCRIPTION
Fixes the check of the RSA Public Exponent in check_pub_rsa_key(). Prior
to this patch was the wrong byte used to check if the bignum was odd.
With this patch is the correct byte selected in the big-endian bignum.

Fixes: 338b123ee66c ("core: syscall_obj_generate_key() check public rsa exponent")
Suggested-by: Cedric Neveux <cedric.neveux@nxp.com>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
