### PR TITLE
core: mm: fix infinite loop in vm_pa2va()

### DIFF
--- a/core/mm/vm.c
+++ b/core/mm/vm.c
@@ -1198,8 +1198,6 @@ void *vm_pa2va(const struct user_mode_ctx *uctx, paddr_t pa)
 		assert(!granule || IS_POWER_OF_TWO(granule));
 
 		for (ofs = region->offset; ofs < region->size; ofs += size) {
-			if (mobj_get_pa(region->mobj, ofs, granule, &p))
-				continue;
 
 			if (granule) {
 				/* From current offset to buffer/granule end */
@@ -1210,6 +1208,9 @@ void *vm_pa2va(const struct user_mode_ctx *uctx, paddr_t pa)
 			} else {
 				size = region->size;
 			}
+
+			if (mobj_get_pa(region->mobj, ofs, granule, &p))
+				continue;
 
 			if (core_is_buffer_inside(pa, 1, p, size)) {
 				/* Remove region offset (mobj phys offset) */


### PR DESCRIPTION
Commit d6ad67f674e5 ("core: mm: change vm_pa2va() to return a virtual
address") moved the call to mobj_get_pa() up in a 'for' loop and added
a 'continue' statement. Moving it was wrong because at this point 'size'
is not yet updated which causes an infinite loop when the PA is not
found.

Move the call back to its original location but keep the 'continue'
which looks correct.

Fixes: d6ad67f674e5 ("core: mm: change vm_pa2va() to return a virtual address")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
