### PR TITLE
core: mm: Use nexus memory allocation api's in carve_out_phys_mem

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -304,7 +304,7 @@ static void carve_out_phys_mem(struct core_mmu_phys_mem **mem, size_t *nelems,
 		/* Remove this entry */
 		(*nelems)--;
 		memmove(m + n, m + n + 1, sizeof(*m) * (*nelems - n));
-		m = realloc(m, sizeof(*m) * *nelems);
+		m = nex_realloc(m, sizeof(*m) * *nelems);
 		if (!m)
 			panic();
 		*mem = m;
@@ -315,7 +315,7 @@ static void carve_out_phys_mem(struct core_mmu_phys_mem **mem, size_t *nelems,
 		m[n].size -= size;
 	} else {
 		/* Need to split the memory entry */
-		m = realloc(m, sizeof(*m) * (*nelems + 1));
+		m = nex_realloc(m, sizeof(*m) * (*nelems + 1));
 		if (!m)
 			panic();
 		*mem = m;


### PR DESCRIPTION
During discovery of the non-secure memory, the memory attributes like
address and size are stored as part of the core_mmu_phys_mem
structure. Memory for this structure is allocated on the nexus heap
area. Subsequently, when memory for this structure is reallocated,
this is done using the plain realloc call. Use the nex_realloc api for
the reallocation.

Signed-off-by: Sughosh Ganu <sughosh.ganu@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
