### PR TITLE
drivers: csu: allow setting CSU_CSL0

### DIFF
--- a/core/arch/arm/plat-imx/drivers/imx_csu.c
+++ b/core/arch/arm/plat-imx/drivers/imx_csu.c
@@ -112,7 +112,7 @@ static TEE_Result csu_init(void)
 
 	csu_setting = csu_config->csl;
 
-	while (csu_setting->csu_index > 0) {
+	while (csu_setting->csu_index >= 0) {
 		io_write32(csu_base + (csu_setting->csu_index * 4),
 				csu_setting->value);
 


### PR DESCRIPTION
The sentinel detection in the initialization loop for the CSU_CSL<n>
registers is wrong in that is doesn't allow to set the first register,
CSU_CSL0 (when csu_index == 0). Fix the conditional so that it stops
on the sentinel value (-1) but still allows 0 as a valid index.
CSU_CSL0 is used for the PWM peripherals on i.MX6 platforms.

Reported-by: Robert Delien <r.delien@payter.nl>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
