### PR TITLE
core: fix wrong conditional expression in tee_ta_clear_busy()

### DIFF
--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -73,7 +73,6 @@ struct tee_ta_ctx {
 	uint32_t panic_code;	/* Code supplied for panic */
 	uint32_t ref_count;	/* Reference counter for multi session TA */
 	bool busy;		/* Context is busy and cannot be entered */
-	bool initializing;	/* Context is initializing */
 	struct condvar busy_cv;	/* CV used when context is busy */
 };
 

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -169,10 +169,8 @@ static void tee_ta_clear_busy(struct tee_ta_ctx *ctx)
 	ctx->busy = false;
 	condvar_signal(&ctx->busy_cv);
 
-	if (!ctx->initializing && (ctx->flags & TA_FLAG_SINGLE_INSTANCE))
+	if (ctx->flags & TA_FLAG_SINGLE_INSTANCE)
 		unlock_single_instance();
-
-	ctx->initializing = false;
 
 	mutex_unlock(&tee_ta_mutex);
 }

--- a/core/kernel/user_ta.c
+++ b/core/kernel/user_ta.c
@@ -431,7 +431,6 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 	if (!utc)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	utc->ta_ctx.initializing = true;
 	utc->uctx.is_initializing = true;
 	TAILQ_INIT(&utc->open_sessions);
 	TAILQ_INIT(&utc->cryp_states);


### PR DESCRIPTION
This is to fix issue [4471](https://github.com/OP-TEE/optee_os/issues/4471)

When a ctx of a single instance user TA is first created,
lock_single_instance() is called in tee_ta_try_set_busy().
However, unlock_single_instance() is not called in
tee_ta_clear_busy() since ctx->initializing is still false.
It results that tee_ta_single_instance_thread is not reset
when CFG_CONCURRENT_SINGLE_INSTANCE_TA is not enabled.
So remove the wrong conditional expression and remove
"initializing" from tee_ta_ctx since it's no longer used.

Signed-off-by: RueiAnHu <Rayan.Hu@mediatek.com>