### PR TITLE
optee_os: fixes compilation problem with trace level 0

### DIFF
--- a/core/arch/arm/kernel/unwind_arm64.c
+++ b/core/arch/arm/kernel/unwind_arm64.c
@@ -74,6 +74,7 @@ err:
 	return NULL;
 }
 
+#if defined(CFG_UNWIND) && (TRACE_LEVEL > 0)
 void print_kernel_stack(void)
 {
 	struct unwind_state_arm64 state = { };
@@ -88,3 +89,4 @@ void print_kernel_stack(void)
 	get_stack_hard_limits(&stack_start, &stack_end);
 	print_stack_arm64(&state, stack_start, stack_end - stack_start);
 }
+#endif


### PR DESCRIPTION
- if CFG_TEE_CORE_LOG_LEVEL in build/common.mk set to zero,
  optee_os doesn't compile
- error is:
```
core/arch/arm/kernel/unwind_arm64.c:77:6: Error: redefinition of »print_kernel_stack«
   77 | void print_kernel_stack(void)
      |      ^~~~~~~~~~~~~~~~~~
in file, included from core/arch/arm/kernel/unwind_arm64.c:35:
core/include/kernel/unwind.h:15:20: Warning: previous definition of »print_kernel_stack« was here
   15 | static inline void print_kernel_stack(void)
      |                    ^~~~~~~~~~~~~~~~~~
```
- to avoid this error we assure the function is not redefined
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
