### PR TITLE
core_mmu: Initialize mmu partition table after relocation

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -703,6 +703,7 @@ struct mmu_partition *core_alloc_mmu_prtn(void *tables);
 void core_free_mmu_prtn(struct mmu_partition *prtn);
 void core_mmu_set_prtn(struct mmu_partition *prtn);
 void core_mmu_set_default_prtn(void);
+void core_mmu_set_default_prtn_tbl(void);
 
 void core_mmu_init_virtualization(void);
 #endif

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -516,6 +516,14 @@ shadow_stack_access_ok:
 	bl	console_init
 #endif
 
+#ifdef CFG_VIRTUALIZATION
+	/*
+	 * Initialize partition tables for each partition to
+	 * default_partition which has been relocated now to a different VA
+	 */
+	bl	core_mmu_set_default_prtn_tbl
+#endif
+
 	mov	r0, r4		/* pageable part address */
 	mov	r1, r5		/* ns-entry address */
 	bl	boot_init_primary_early

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -206,6 +206,14 @@ clear_nex_bss:
 	bl	console_init
 #endif
 
+#ifdef CFG_VIRTUALIZATION
+	/*
+	 * Initialize partition tables for each partition to
+	 * default_partition which has been relocated now to a different VA
+	 */
+	bl	core_mmu_set_default_prtn_tbl
+#endif
+
 	mov	x0, x19		/* pagable part address */
 	mov	x1, #-1
 	bl	boot_init_primary_early

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -425,6 +425,14 @@ void core_mmu_set_default_prtn(void)
 {
 	core_mmu_set_prtn(&default_partition);
 }
+
+void core_mmu_set_default_prtn_tbl(void)
+{
+	size_t n = 0;
+
+	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
+		current_prtn[n] = &default_partition;
+}
 #endif
 
 void core_init_mmu_prtn(struct mmu_partition *prtn, struct tee_mmap_region *mm)
@@ -475,11 +483,6 @@ void core_init_mmu(struct tee_mmap_region *mm)
 
 	/* Initialize default pagetables */
 	core_init_mmu_prtn(&default_partition, mm);
-
-#ifdef CFG_VIRTUALIZATION
-	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
-		current_prtn[n] = &default_partition;
-#endif
 
 	for (n = 0; !core_mmap_is_end_of_table(mm + n); n++) {
 		vaddr_t va_end = mm[n].va + mm[n].size - 1;

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -217,6 +217,14 @@ static struct mmu_partition default_partition = {
 
 #ifdef CFG_VIRTUALIZATION
 static struct mmu_partition *current_prtn[CFG_TEE_CORE_NB_CORE];
+
+void core_mmu_set_default_prtn_tbl(void)
+{
+	size_t n = 0;
+
+	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
+		current_prtn[n] = &default_partition;
+}
 #endif
 
 static struct mmu_partition *get_prtn(void)
@@ -742,13 +750,6 @@ bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
 
 void core_init_mmu(struct tee_mmap_region *mm)
 {
-#ifdef CFG_VIRTUALIZATION
-	size_t n;
-
-	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
-		current_prtn[n] = &default_partition;
-#endif
-
 	/* Initialize default pagetables */
 	core_init_mmu_prtn(&default_partition, mm);
 }


### PR DESCRIPTION
For virtualization support, we have multiple mmu partitions, one per
virtual machine. These partitions are initially mapped to the default
partition in core_init_mmu_map(). With CFG_ASLR=y, the partition table
needs to be reinitialized as default_partition has now been relocated to
a different VA.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
