### PR TITLE
SCMI: introduce an SCMI PTA interface for REE SCMI agents

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -92,6 +92,13 @@ $(call force,CFG_SCMI_MSG_DRIVERS,y,Mandated by CFG_STM32MP1_SCMI_SIP)
 $(call force,CFG_SCMI_MSG_SMT_FASTCALL_ENTRY,y,Mandated by CFG_STM32MP1_SCMI_SIP)
 endif
 
+# Default enable SCMI PTA support
+CFG_SCMI_PTA ?= y
+ifeq ($(CFG_SCMI_PTA),y)
+$(call force,CFG_SCMI_MSG_DRIVERS,y,Mandated by CFG_SCMI_PTA)
+$(call force,CFG_SCMI_MSG_SMT_THREAD_ENTRY,y,Mandated by CFG_SCMI_PTA)
+endif
+
 CFG_SCMI_MSG_DRIVERS ?= n
 ifeq ($(CFG_SCMI_MSG_DRIVERS),y)
 $(call force,CFG_SCMI_MSG_CLOCK,y)

--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -127,6 +127,14 @@ static inline void scmi_smt_threaded_entry(unsigned int channel_id __unused)
  */
 struct scmi_msg_channel *plat_scmi_get_channel(unsigned int channel_id);
 
+/* Scmi-msg uses the channel ID as handle. Must channel_id is valid */
+static inline unsigned int scmi_smt_channel_handle(unsigned int channel_id)
+{
+	assert(plat_scmi_get_channel(channel_id));
+
+	return channel_id;
+}
+
 /*
  * Return how many SCMI protocols supported by the platform
  * According to the SCMI specification, this function does not target

--- a/core/pta/scmi.c
+++ b/core/pta/scmi.c
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019-2021, Linaro Limited
+ * Copyright (c) 2019-2021, STMicroelectronics
+ */
+#include <compiler.h>
+#include <config.h>
+#include <drivers/scmi-msg.h>
+#include <kernel/pseudo_ta.h>
+#include <pta_scmi_client.h>
+#include <stdint.h>
+#include <string.h>
+
+static TEE_Result cmd_capabilities(uint32_t ptypes,
+				   TEE_Param param[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	uint32_t caps = 0;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT))
+		caps |= PTA_SCMI_CAPS_SMT_HEADER;
+
+	param[0].value.a = caps;
+	param[0].value.b = 0;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result cmd_process_smt_channel(uint32_t ptypes,
+					  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	unsigned int channel_id = params[0].value.a;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT)) {
+		struct scmi_msg_channel *channel = NULL;
+
+		channel = plat_scmi_get_channel(channel_id);
+		if (!channel)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		scmi_smt_threaded_entry(channel_id);
+
+		return TEE_SUCCESS;
+	}
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result cmd_process_smt_message(uint32_t ptypes,
+					  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_MEMREF_INOUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	unsigned int channel_id = params[0].value.a;
+	TEE_Param *param1 = params + 1;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT)) {
+		struct scmi_msg_channel *channel = NULL;
+
+		if (param1->memref.size < SMT_BUF_SLOT_SIZE)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		channel = plat_scmi_get_channel(channel_id);
+		if (!channel)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		/*
+		 * Caller provides the buffer, we bind channel to that buffer.
+		 * Once message is processed, unbind the buffer since it is
+		 * valid only for the current invocation.
+		 */
+		scmi_smt_set_shared_buffer(channel, param1->memref.buffer);
+		scmi_smt_threaded_entry(channel_id);
+		scmi_smt_set_shared_buffer(channel, NULL);
+
+		return TEE_SUCCESS;
+	}
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result cmd_get_channel_handle(uint32_t ptypes,
+					 TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INOUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	unsigned int channel_id = params[0].value.a;
+	unsigned int caps = params[0].value.b;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT)) {
+		struct scmi_msg_channel *channel = NULL;
+
+		if (caps != PTA_SCMI_CAPS_SMT_HEADER)
+			return TEE_ERROR_NOT_SUPPORTED;
+
+		channel = plat_scmi_get_channel(channel_id);
+		if (!channel)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		params[0].value.a = scmi_smt_channel_handle(channel_id);
+
+		return TEE_SUCCESS;
+	}
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result pta_scmi_open_session(uint32_t ptypes __unused,
+					TEE_Param par[TEE_NUM_PARAMS] __unused,
+					void **session __unused)
+{
+	struct ts_session *ts = ts_get_current_session();
+	struct tee_ta_session *ta_session = to_ta_session(ts);
+
+	/* Only REE kernel is allowed to access SCMI resources */
+	if (ta_session->clnt_id.login != TEE_LOGIN_REE_KERNEL) {
+		DMSG("Expecting TEE_LOGIN_REE_KERNEL");
+		return TEE_ERROR_ACCESS_DENIED;
+	}
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT))
+		return TEE_SUCCESS;
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result pta_scmi_invoke_command(void *session __unused, uint32_t cmd,
+					  uint32_t ptypes,
+					  TEE_Param params[TEE_NUM_PARAMS])
+{
+	FMSG("SCMI command %#"PRIx32" ptypes %#"PRIx32, cmd, ptypes);
+
+	switch (cmd) {
+	case PTA_SCMI_CMD_CAPABILITIES:
+		return cmd_capabilities(ptypes, params);
+	case PTA_SCMI_CMD_PROCESS_SMT_CHANNEL:
+		return cmd_process_smt_channel(ptypes, params);
+	case PTA_SCMI_CMD_PROCESS_SMT_CHANNEL_MESSAGE:
+		return cmd_process_smt_message(ptypes, params);
+	case PTA_SCMI_CMD_GET_CHANNEL_HANDLE:
+		return cmd_get_channel_handle(ptypes, params);
+	default:
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+}
+
+pseudo_ta_register(.uuid = PTA_SCMI_UUID, .name = PTA_SCMI_NAME,
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_CONCURRENT |
+			    TA_FLAG_DEVICE_ENUM,
+		   .open_session_entry_point = pta_scmi_open_session,
+		   .invoke_command_entry_point = pta_scmi_invoke_command);

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -9,5 +9,6 @@ endif
 srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_SYSTEM_PTA) += system.c
 srcs-$(CFG_NXP_SE05X) += scp03.c
+srcs-$(CFG_SCMI_PTA) += scmi.c
 
 subdirs-y += bcm

--- a/lib/libutee/include/pta_scmi_client.h
+++ b/lib/libutee/include/pta_scmi_client.h
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019-2021, Linaro Limited
+ */
+#ifndef PTA_SCMI_CLIENT_H
+#define PTA_SCMI_CLIENT_H
+
+#define PTA_SCMI_UUID { 0xa8cfe406, 0xd4f5, 0x4a2e, \
+		{ 0x9f, 0x8d, 0xa2, 0x5d, 0xc7, 0x54, 0xc0, 0x99 } }
+
+#define PTA_SCMI_NAME "PTA-SCMI"
+
+/*
+ * PTA_SCMI_CMD_CAPABILITIES - Get channel capabilities
+ *
+ * [out]    value[0].a: Capabilities bit mask (PTA_SCMI_CAPS_*)
+ * [out]    value[0].b: Extended capabilities or 0
+ */
+#define PTA_SCMI_CMD_CAPABILITIES	0
+
+/*
+ * PTA_SCMI_CMD_PROCESS_SMT_CHANNEL - Process SCMI message in SMT buffer
+ *
+ * [in]     value[0].a: Channel handle
+ *
+ * Shared memory used for SCMI message/response exhange is expected
+ * already identified and bound to channel handle in both SCMI agent
+ * and SCMI server (OP-TEE) parts.
+ * The memory uses SMT header to carry SCMI meta-data (protocol ID and
+ * protocol message ID).
+ */
+#define PTA_SCMI_CMD_PROCESS_SMT_CHANNEL	1
+
+/*
+ * PTA_SCMI_CMD_PROCESS_SMT_CHANNEL_MESSAGE - Process SCMI message in
+ *				SMT buffer pointed by memref parameters
+ *
+ * [in]     value[0].a: Channel handle
+ * [in/out] memref[1]: Message/response buffer (SMT and SCMI payload)
+ *
+ * Shared memory used for SCMI message/response is a SMT buffer
+ * referenced by param[1]. It shall be 128 bytes large to fit response
+ * payload whatever message playload size.
+ * The memory uses SMT header to carry SCMI meta-data (protocol ID and
+ * protocol message ID).
+ */
+#define PTA_SCMI_CMD_PROCESS_SMT_CHANNEL_MESSAGE	2
+
+/*
+ * PTA_SCMI_CMD_GET_CHANNEL_HANDLE - Get handle for an SCMI channel
+ *
+ * Get a handle for the SCMI channel. This handle value is to be passed
+ * as argument to some commands as PTA_SCMI_CMD_PROCESS_*.
+ *
+ * [in]     value[0].a: Channel identifier or 0 if no assigned ID
+ * [in]     value[0].b: Requested capabilities mask (PTA_SCMI_CAPS_*)
+ * [out]    value[0].a: Returned channel handle
+ */
+#define PTA_SCMI_CMD_GET_CHANNEL_HANDLE		3
+
+/*
+ * Capabilities
+ */
+
+/* Channel supports shared memory using the SMT header protocol */
+#define PTA_SCMI_CAPS_SMT_HEADER			BIT32(0)
+
+#endif /* SCMI_PTA_SCMI_CLIENT_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -628,6 +628,9 @@ CFG_SCMI_MSG_RESET_DOMAIN ?= n
 CFG_SCMI_MSG_SMT ?= n
 CFG_SCMI_MSG_VOLTAGE_DOMAIN ?= n
 
+# Enable SCMI PTA interface for REE SCMI agents
+CFG_SCMI_PTA ?= n
+
 ifneq ($(CFG_STMM_PATH),)
 $(call force,CFG_WITH_STMM_SP,y)
 else


### PR DESCRIPTION
Adds a PTA interface to REE SCMI agents to get SCMI message communication channel for processing in OP-TEE SCMI server.

Currently implement supports for a SCMI server built with CFG_SCMI_MSG_SMT=y.
The implementation is made so that an alternate SCMI server implementation can added.