### PR TITLE
mk: core: ta: make early TA compress optional

### DIFF
--- a/core/sub.mk
+++ b/core/sub.mk
@@ -20,13 +20,16 @@ recipe-ldelf = $(PYTHON3) scripts/gen_ldelf_hex.py --input $(out-dir)/ldelf/ldel
 endif
 
 ifeq ($(CFG_WITH_USER_TA)-$(CFG_EARLY_TA),y-y)
+ifeq ($(CFG_EARLY_TA_COMPRESS),y)
+early-ta-compress = --compress
+endif
 define process_early_ta
 early-ta-$1-uuid := $(firstword $(subst ., ,$(notdir $1)))
 gensrcs-y += early-ta-$1
 produce-early-ta-$1 = early_ta_$$(early-ta-$1-uuid).c
 depends-early-ta-$1 = $1 scripts/ts_bin_to_c.py
-recipe-early-ta-$1 = $(PYTHON3) scripts/ts_bin_to_c.py --compress --ta $1 \
-		--out $(sub-dir-out)/early_ta_$$(early-ta-$1-uuid).c
+recipe-early-ta-$1 = $(PYTHON3) scripts/ts_bin_to_c.py $(early-ta-compress) \
+		--ta $1 --out $(sub-dir-out)/early_ta_$$(early-ta-$1-uuid).c
 endef
 $(foreach f, $(EARLY_TA_PATHS), $(eval $(call process_early_ta,$(f))))
 $(foreach f, $(CFG_IN_TREE_EARLY_TAS), $(eval $(call \

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -324,6 +324,10 @@ ifeq ($(CFG_EMBEDDED_TS),y)
 $(call force,CFG_ZLIB,y)
 endif
 
+# By default the early TAs are compressed in the TEE binary, it is possible to
+# not compress them with CFG_EARLY_TA_COMPRESS=n
+CFG_EARLY_TA_COMPRESS ?= y
+
 # Enable paging, requires SRAM, can't be enabled by default
 CFG_WITH_PAGER ?= n
 


### PR DESCRIPTION
Define CFG_EARLY_TA_COMPRESS configuration switch to
allow platform to disable early TAs compression at build time.
Disabling the compression drastically reduces the amount of the
core heap required in the embedded part.

Enable the configuration by default for backward compatibility.

Suggested-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
