### PR TITLE
[RFC] SCMI PTA with OCALL

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -740,6 +740,24 @@ struct mobj *thread_rpc_alloc_global_payload(size_t size);
  */
 void thread_rpc_free_global_payload(struct mobj *mobj);
 
+/**
+ * Request that the Client Application allocate shared memory for OCALL payload
+ * buffers.
+ *
+ * @size:	size in bytes of payload buffer
+ *
+ * @returns	mobj that describes allocated buffer or NULL on error
+ */
+struct mobj *thread_rpc_alloc_client_app_payload(size_t size);
+
+/**
+ * Free physical memory previously allocated with
+ * thread_rpc_alloc_client_app_payload()
+ *
+ * @mobj:	mobj that describes the buffer
+ */
+void thread_rpc_free_client_app_payload(struct mobj *mobj);
+
 /*
  * enum thread_shm_type - type of non-secure shared memory
  * @THREAD_SHM_TYPE_APPLICATION - user space application shared memory

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -20,7 +20,7 @@
 #define THREAD_ID_0		0
 #define THREAD_ID_INVALID	-1
 
-#define THREAD_RPC_MAX_NUM_PARAMS	4
+#define THREAD_RPC_MAX_NUM_PARAMS	6
 
 #ifndef __ASSEMBLER__
 

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -5,6 +5,8 @@
 #ifndef OPTEE_SMC_H
 #define OPTEE_SMC_H
 
+#include <util.h>
+
 /*
  * This file is exported by OP-TEE and is in kept in sync between secure
  * world and normal world kernel driver. We're following ARM SMC Calling
@@ -264,20 +266,20 @@
  * a2-7 Preserved
  */
 /* Normal world works as a uniprocessor system */
-#define OPTEE_SMC_NSEC_CAP_UNIPROCESSOR		(1 << 0)
+#define OPTEE_SMC_NSEC_CAP_UNIPROCESSOR		BIT(0)
 /* Secure world has reserved shared memory for normal world to use */
-#define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	(1 << 0)
+#define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	BIT(0)
 /* Secure world can communicate via previously unregistered shared memory */
-#define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	(1 << 1)
+#define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	BIT(1)
 /*
  * Secure world supports commands "register/unregister shared memory",
  * secure world accepts command buffers located in any parts of non-secure RAM
  */
-#define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM		(1 << 2)
+#define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM		BIT(2)
 /* Secure world is built with virtualization support */
-#define OPTEE_SMC_SEC_CAP_VIRTUALIZATION	(1 << 3)
+#define OPTEE_SMC_SEC_CAP_VIRTUALIZATION	BIT(3)
 /* Secure world supports Shared Memory with a NULL reference */
-#define OPTEE_SMC_SEC_CAP_MEMREF_NULL		(1 << 4)
+#define OPTEE_SMC_SEC_CAP_MEMREF_NULL		BIT(4)
 
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -280,6 +280,8 @@
 #define OPTEE_SMC_SEC_CAP_VIRTUALIZATION	BIT(3)
 /* Secure world supports Shared Memory with a NULL reference */
 #define OPTEE_SMC_SEC_CAP_MEMREF_NULL		BIT(4)
+/* Secure world is built with OCALL support */
+#define OPTEE_SMC_SEC_CAP_OCALL			BIT(5)
 
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -626,3 +626,14 @@ void thread_rpc_free_global_payload(struct mobj *mobj)
 	thread_rpc_free(OPTEE_RPC_SHM_TYPE_GLOBAL, mobj_get_cookie(mobj),
 			mobj);
 }
+
+struct mobj *thread_rpc_alloc_client_app_payload(size_t size)
+{
+	return thread_rpc_alloc(size, 8, OPTEE_RPC_SHM_TYPE_CLIENT_APP);
+}
+
+void thread_rpc_free_client_app_payload(struct mobj *mobj)
+{
+	thread_rpc_free(OPTEE_RPC_SHM_TYPE_CLIENT_APP, mobj_get_cookie(mobj),
+			mobj);
+}

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -32,6 +32,7 @@ endif
 include core/arch/arm/cpu/cortex-a7.mk
 
 $(call force,CFG_BOOT_SECONDARY_REQUEST,y)
+$(call force,CFG_CORE_OCALL,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_INIT_CNTVOFF,y)
 $(call force,CFG_PSCI_ARM32,y)
@@ -60,6 +61,8 @@ CFG_TEE_CORE_NB_CORE ?= 2
 CFG_WITH_PAGER ?= y
 CFG_WITH_LPAE ?= y
 CFG_MMAP_REGIONS ?= 23
+
+CFG_NUM_THREADS ?= 3
 
 ifeq ($(CFG_EMBED_DTB_SOURCE_FILE),)
 # Some drivers mandate DT support

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -92,6 +92,13 @@ $(call force,CFG_SCMI_MSG_DRIVERS,y,Mandated by CFG_STM32MP1_SCMI_SIP)
 $(call force,CFG_SCMI_MSG_SMT_FASTCALL_ENTRY,y,Mandated by CFG_STM32MP1_SCMI_SIP)
 endif
 
+# Default enable SCMI PTA support
+CFG_SCMI_PTA ?= y
+ifeq ($(CFG_SCMI_PTA),y)
+$(call force,CFG_SCMI_MSG_DRIVERS,y,Mandated by CFG_SCMI_PTA)
+$(call force,CFG_SCMI_MSG_SMT_THREAD_ENTRY,y,Mandated by CFG_SCMI_PTA)
+endif
+
 CFG_SCMI_MSG_DRIVERS ?= n
 ifeq ($(CFG_SCMI_MSG_DRIVERS),y)
 $(call force,CFG_SCMI_MSG_CLOCK,y)

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -92,6 +92,9 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 	args->a1 |= OPTEE_SMC_SEC_CAP_VIRTUALIZATION;
 #endif
 	args->a1 |= OPTEE_SMC_SEC_CAP_MEMREF_NULL;
+#if defined(CFG_CORE_OCALL)
+	args->a1 |= OPTEE_SMC_SEC_CAP_OCALL;
+#endif
 
 #if defined(CFG_CORE_DYN_SHM)
 	dyn_shm_en = core_mmu_nsec_ddr_is_defined();

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -97,6 +97,12 @@
  * space application
  */
 #define OPTEE_RPC_SHM_TYPE_GLOBAL	2
+/*
+ * Memory shared with the non-secure application that is the client of the TA
+ * that requests shared memory of this type; the client could be running in
+ * non-secure user-mode or in non-secure kernel-mode
+ */
+#define OPTEE_RPC_SHM_TYPE_CLIENT_APP	3
 
 /*
  * Free shared memory previously allocated with OPTEE_RPC_CMD_SHM_ALLOC

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -176,6 +176,18 @@
 #define OPTEE_RPC_I2C_FLAGS_TEN_BIT	BIT(0)
 
 /*
+ * Send an OCALL to the Client Application
+ *
+ * [in]     value[0].a	    CA Command ID (i.e., OCALL# for the CA to execute)
+ * [out]    value[0].b	    OCALL return value
+ * [out]    value[0].c	    OCALL return value origin
+ * [in]     value[1].a	    UUID of TA whence OCALL originated (HI bits)
+ * [out]    value[1].b	    UUID of TA whence OCALL originated (LO bits)
+ * [in/out] any[2..5].*	    OCALL parameters as specified by the TA, if any
+ */
+#define OPTEE_RPC_CMD_OCALL		22
+
+/*
  * Definition of protocol for command OPTEE_RPC_CMD_FS
  */
 

--- a/core/pta/scmi.c
+++ b/core/pta/scmi.c
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019-2021, Linaro Limited
+ * Copyright (c) 2019-2021, STMicroelectronics
+ */
+#include <compiler.h>
+#include <config.h>
+#include <confine_array_index.h>
+#include <drivers/scmi-msg.h>
+#include <kernel/pseudo_ta.h>
+#include <pta_scmi_client.h>
+#include <stdint.h>
+#include <string.h>
+
+static TEE_Result cmd_capabilities(void *session __unused, uint32_t ptypes,
+				   TEE_Param param[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	param[0].value.a = PTA_SCMI_CAPS_NONE;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT))
+		param[0].value.a |= PTA_SCMI_CAPS_SMT_HEADER;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result cmd_process_smt_channel(void *sess __unused, uint32_t ptypes,
+					  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	uint32_t channel_id = (int)params[0].value.a;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT)) {
+		scmi_smt_threaded_entry(channel_id);
+		return TEE_SUCCESS;
+	}
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result cmd_process_smt_message(void *sess __unused, uint32_t ptypes,
+					  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_MEMREF_INOUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	uint32_t __unused channel_id = (int)params[0].value.a;
+	TEE_Param __unused *param1 = params + 1;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result cmd_get_channel(void *sess __unused, uint32_t ptypes,
+				  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INOUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	uint32_t __maybe_unused channel_id = (int)params[0].value.a;
+	uint32_t caps = (int)params[0].value.b;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	FMSG("channel %"PRIu32, channel_id);
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT)) {
+		if (caps == PTA_SCMI_CAPS_SMT_HEADER) {
+			/* Channel handle (value[0].a) is channel ID */
+			return TEE_SUCCESS;
+		}
+	}
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result pta_scmi_session(uint32_t ptypes __unused,
+				   TEE_Param params[TEE_NUM_PARAMS] __unused,
+				   void **session __unused)
+{
+	struct ts_session *ts = ts_get_current_session();
+	struct tee_ta_session *ta_session = to_ta_session(ts);
+
+	FMSG("ptypes %#"PRIx32, ptypes);
+
+	/* Only REE kernel is allowed to access SCMI resources */
+	if (ta_session->clnt_id.login != TEE_LOGIN_REE_KERNEL) {
+		DMSG("Expecting TEE_LOGIN_REE_KERNEL");
+		return TEE_ERROR_ACCESS_DENIED;
+	}
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT))
+		return TEE_SUCCESS;
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static TEE_Result pta_scmi_command(void *session, uint32_t cmd, uint32_t ptypes,
+				   TEE_Param params[TEE_NUM_PARAMS])
+{
+	FMSG("SCMI command %#"PRIx32" ptypes %#"PRIx32, cmd, ptypes);
+
+	switch (cmd) {
+	case PTA_SCMI_CMD_CAPABILITIES:
+		return cmd_capabilities(session, ptypes, params);
+	case PTA_SCMI_CMD_PROCESS_SMT_CHANNEL:
+		return cmd_process_smt_channel(session, ptypes, params);
+	case PTA_SCMI_CMD_PROCESS_SMT_CHANNEL_MESSAGE:
+		return cmd_process_smt_message(session, ptypes, params);
+	case PTA_SCMI_CMD_GET_CHANNEL:
+		return cmd_get_channel(session, ptypes, params);
+	default:
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+}
+
+pseudo_ta_register(.uuid = PTA_SCMI_UUID, .name = PTA_SCMI_NAME,
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_CONCURRENT |
+			    TA_FLAG_DEVICE_ENUM,
+		   .open_session_entry_point = pta_scmi_session,
+		   .invoke_command_entry_point = pta_scmi_command);

--- a/core/pta/scmi.c
+++ b/core/pta/scmi.c
@@ -8,9 +8,17 @@
 #include <confine_array_index.h>
 #include <drivers/scmi-msg.h>
 #include <kernel/pseudo_ta.h>
+#include <optee_rpc_cmd.h>
 #include <pta_scmi_client.h>
 #include <stdint.h>
 #include <string.h>
+#include <tee/uuid.h>
+#include <util.h>
+
+static bool valid_caps(unsigned int caps)
+{
+	return (caps & ~PTA_SCMI_CAPS_VALID_MASK) == 0;
+}
 
 static TEE_Result cmd_capabilities(void *session __unused, uint32_t ptypes,
 				   TEE_Param param[TEE_NUM_PARAMS])
@@ -27,6 +35,8 @@ static TEE_Result cmd_capabilities(void *session __unused, uint32_t ptypes,
 
 	if (IS_ENABLED(CFG_SCMI_MSG_SMT))
 		param[0].value.a |= PTA_SCMI_CAPS_SMT_HEADER;
+	if (IS_ENABLED(CFG_CORE_OCALL))
+		param[0].value.a |= PTA_SCMI_CAPS_OCALL_THREAD;
 
 	return TEE_SUCCESS;
 }
@@ -86,6 +96,116 @@ static TEE_Result cmd_process_smt_message(void *sess __unused, uint32_t ptypes,
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
+/* Process an OCALL RPC to client and report status */
+static enum optee_scmi_ocall_reply pta_scmi_ocall(uint32_t channel_id)
+{
+	static const TEE_UUID uuid = PTA_SCMI_UUID;
+	static uint64_t uuid_octet[2];
+	static bool uuid_ready;
+	struct thread_param params[THREAD_RPC_MAX_NUM_PARAMS] = {
+		/* Ocall command, sub command */
+		THREAD_PARAM_VALUE(INOUT, 0, 0, 0),
+		/* UUID of Ocall initiator */
+		THREAD_PARAM_VALUE(IN, 0, 0, 0),
+		/* Output value argument to get REE feedback */
+		THREAD_PARAM_VALUE(OUT, 0, 0, 0),
+	};
+	uint64_t ocall_res = 0;
+	uint64_t __maybe_unused ocall_ori = 0;
+	enum optee_scmi_ocall_reply agent_request = PTA_SCMI_OCALL_ERROR;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (!IS_ENABLED(CFG_CORE_OCALL))
+		return PTA_SCMI_OCALL_ERROR;
+
+	if (!uuid_ready) {
+		tee_uuid_to_octets((uint8_t *)uuid_octet, &uuid);
+		uuid_ready = true;
+	}
+
+	params[0].u.value.a = PTA_SCMI_OCALL_CMD_THREAD_READY;
+	params[1].u.value.a = uuid_octet[0];
+	params[1].u.value.b = uuid_octet[1];
+
+	params[0] = THREAD_PARAM_VALUE(INOUT, PTA_SCMI_OCALL_CMD_THREAD_READY,
+				       0, 0);
+	params[1] = THREAD_PARAM_VALUE(IN, uuid_octet[0], uuid_octet[1], 0);
+	params[2] = THREAD_PARAM_VALUE(OUT, 0, 0, 0);
+
+	res = thread_rpc_cmd(OPTEE_RPC_CMD_OCALL, ARRAY_SIZE(params), params);
+	if (res) {
+		DMSG("Close thread on RPC error %#"PRIx32, res);
+		return PTA_SCMI_OCALL_ERROR;
+	}
+
+	ocall_res = params[0].u.value.b;
+	ocall_ori = params[0].u.value.c;
+	if (ocall_res) {
+		DMSG("SCMI RPC thread failed %#"PRIx64" from %#"PRIx64,
+		     ocall_res, ocall_ori);
+		return PTA_SCMI_OCALL_ERROR;
+	}
+
+	agent_request = (enum optee_scmi_ocall_reply)params[2].u.value.a;
+
+	switch (agent_request) {
+	case PTA_SCMI_OCALL_PROCESS_SMT_CHANNEL:
+		FMSG("Posting message on channel %u"PRIu32, channel_id);
+		if (IS_ENABLED(CFG_SCMI_MSG_SMT))
+			scmi_smt_threaded_entry(channel_id);
+		else
+			panic();
+		break;
+	case PTA_SCMI_OCALL_CLOSE_THREAD:
+		FMSG("Closing channel %u"PRIu32, channel_id);
+		break;
+	case PTA_SCMI_OCALL_ERROR:
+		FMSG("Error on channel %u"PRIu32, channel_id);
+		break;
+	default:
+		DMSG("Invalid Ocall cmd %#x on channel %u"PRIu32,
+		     agent_request, channel_id);
+		return PTA_SCMI_OCALL_CLOSE_THREAD;
+	}
+
+	return agent_request;
+}
+
+static TEE_Result cmd_scmi_ocall_thread(void *sess __unused, uint32_t ptypes,
+					TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+
+	uint32_t channel_id = (int)params[0].value.a;
+	struct scmi_msg_channel *channel = NULL;
+
+	if (ptypes != exp_ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT))
+		channel = plat_scmi_get_channel(channel_id);
+	else
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	if (!channel)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	FMSG("Enter Ocall thread on channel %u"PRIu32, channel_id);
+	while (1) {
+		switch (pta_scmi_ocall(channel_id)) {
+		case PTA_SCMI_OCALL_PROCESS_SMT_CHANNEL:
+			continue;
+		case PTA_SCMI_OCALL_CLOSE_THREAD:
+			return TEE_SUCCESS;
+		default:
+			return TEE_ERROR_GENERIC;
+		}
+	}
+}
+
 static TEE_Result cmd_get_channel(void *sess __unused, uint32_t ptypes,
 				  TEE_Param params[TEE_NUM_PARAMS])
 {
@@ -96,13 +216,13 @@ static TEE_Result cmd_get_channel(void *sess __unused, uint32_t ptypes,
 	uint32_t __maybe_unused channel_id = (int)params[0].value.a;
 	uint32_t caps = (int)params[0].value.b;
 
-	if (ptypes != exp_ptypes)
+	if (ptypes != exp_ptypes || !valid_caps(caps))
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	FMSG("channel %"PRIu32, channel_id);
 
 	if (IS_ENABLED(CFG_SCMI_MSG_SMT)) {
-		if (caps == PTA_SCMI_CAPS_SMT_HEADER) {
+		if (caps & PTA_SCMI_CAPS_SMT_HEADER) {
 			/* Channel handle (value[0].a) is channel ID */
 			return TEE_SUCCESS;
 		}
@@ -146,6 +266,8 @@ static TEE_Result pta_scmi_command(void *session, uint32_t cmd, uint32_t ptypes,
 		return cmd_process_smt_message(session, ptypes, params);
 	case PTA_SCMI_CMD_GET_CHANNEL:
 		return cmd_get_channel(session, ptypes, params);
+	case PTA_SCMI_CMD_OCALL_THREAD:
+		return cmd_scmi_ocall_thread(session, ptypes, params);
 	default:
 		return TEE_ERROR_NOT_SUPPORTED;
 	}

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -9,5 +9,6 @@ endif
 srcs-$(CFG_WITH_STATS) += stats.c
 srcs-$(CFG_SYSTEM_PTA) += system.c
 srcs-$(CFG_NXP_SE05X) += scp03.c
+srcs-$(CFG_SCMI_PTA) += scmi.c
 
 subdirs-y += bcm

--- a/core/pta/system.c
+++ b/core/pta/system.c
@@ -20,6 +20,7 @@
 #include <mm/file.h>
 #include <mm/fobj.h>
 #include <mm/vm.h>
+#include <optee_rpc_cmd.h>
 #include <pta_system.h>
 #include <stdlib_ext.h>
 #include <stdlib.h>
@@ -29,6 +30,27 @@
 #include <tee/tee_supp_plugin_rpc.h>
 #include <tee/uuid.h>
 #include <util.h>
+
+#define PTR_ADD(ptr, offs) ((void *)((uintptr_t)(ptr) + (uintptr_t)(offs)))
+
+#define ACCESS_RIGHTS_READ \
+	(TEE_MEMORY_ACCESS_READ | TEE_MEMORY_ACCESS_ANY_OWNER)
+#define ACCESS_RIGHTS_WRITE \
+	(TEE_MEMORY_ACCESS_WRITE | TEE_MEMORY_ACCESS_ANY_OWNER)
+#define ACCESS_RIGHTS_READ_WRITE (ACCESS_RIGHTS_READ | ACCESS_RIGHTS_WRITE)
+
+struct bin_handle {
+	const struct user_ta_store_ops *op;
+	struct user_ta_store_handle *h;
+	struct file *f;
+	size_t offs_bytes;
+	size_t size_bytes;
+};
+
+struct system_ctx {
+	struct handle_db db;
+	const struct user_ta_store_ops *store_op;
+};
 
 static unsigned int system_pnum;
 
@@ -310,6 +332,297 @@ static TEE_Result system_supp_plugin_invoke(uint32_t param_types,
 	return res;
 }
 
+#ifdef CFG_USER_OCALL
+static TEE_Result
+ocall_check_memref_access_rights(const struct user_mode_ctx *uctx, uint32_t pt,
+				 uaddr_t buffer, size_t size)
+{
+	uint32_t flags = 0;
+
+	switch (pt) {
+	case TEE_PARAM_TYPE_MEMREF_INPUT:
+		flags = ACCESS_RIGHTS_READ;
+		break;
+	case TEE_PARAM_TYPE_MEMREF_INOUT:
+		flags = ACCESS_RIGHTS_READ_WRITE;
+		break;
+	case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+		flags = ACCESS_RIGHTS_WRITE;
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return vm_check_access_rights(uctx, flags, buffer, size);
+}
+
+static TEE_Result ocall_check_parameters(const struct user_mode_ctx *uctx,
+					 const struct utee_params *up)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uaddr_t buffer = 0;
+	size_t size = 0;
+	uint32_t pt = 0;
+	size_t n = 0;
+
+	res = vm_check_access_rights(uctx, ACCESS_RIGHTS_READ_WRITE,
+				     (uaddr_t)up, sizeof(*up));
+	if (res)
+		return res;
+
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
+		pt = TEE_PARAM_TYPE_GET(up->types, n);
+		switch (pt) {
+		case TEE_PARAM_TYPE_NONE:
+		case TEE_PARAM_TYPE_VALUE_INPUT:
+		case TEE_PARAM_TYPE_VALUE_INOUT:
+		case TEE_PARAM_TYPE_VALUE_OUTPUT:
+			break;
+		case TEE_PARAM_TYPE_MEMREF_INPUT:
+		case TEE_PARAM_TYPE_MEMREF_INOUT:
+		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+			buffer = (uaddr_t)up->vals[n * 2];
+			size = up->vals[n * 2 + 1];
+			if ((buffer && !size) || (!buffer && size))
+				return TEE_ERROR_BAD_PARAMETERS;
+			res = ocall_check_memref_access_rights(uctx, pt, buffer,
+							       size);
+			if (res)
+				return res;
+			break;
+		default:
+			return TEE_ERROR_BAD_PARAMETERS;
+		}
+	}
+
+	return res;
+}
+
+static TEE_Result ocall_compute_mobj_size(struct utee_params *up,
+					  size_t *mobj_size)
+{
+	size_t total = 0;
+	size_t size = 0;
+	size_t n = 0;
+
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
+		switch (TEE_PARAM_TYPE_GET(up->types, n)) {
+		case TEE_PARAM_TYPE_NONE:
+		case TEE_PARAM_TYPE_VALUE_INPUT:
+		case TEE_PARAM_TYPE_VALUE_INOUT:
+		case TEE_PARAM_TYPE_VALUE_OUTPUT:
+			break;
+		case TEE_PARAM_TYPE_MEMREF_INPUT:
+		case TEE_PARAM_TYPE_MEMREF_INOUT:
+		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+			size = up->vals[n * 2 + 1];
+			if (ADD_OVERFLOW(total, size, &total))
+				return TEE_ERROR_SECURITY;
+			break;
+		default:
+			return TEE_ERROR_BAD_PARAMETERS;
+		}
+	}
+
+	*mobj_size = total;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result ocall_pre_process(struct thread_param *params,
+				    struct utee_params *up,
+				    struct mobj *mobj,
+				    void *mobj_va)
+{
+	uint32_t pt = 0;
+	void *buffer = NULL;
+	size_t size = 0;
+	void *destination = NULL;
+	size_t mobj_offs = 0;
+	size_t n = 0;
+
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
+		pt = TEE_PARAM_TYPE_GET(up->types, n);
+		switch (pt) {
+		case TEE_PARAM_TYPE_NONE:
+			params[n].attr = THREAD_PARAM_ATTR_NONE;
+			break;
+		case TEE_PARAM_TYPE_VALUE_INPUT:
+		case TEE_PARAM_TYPE_VALUE_INOUT:
+			params[n].u.value.a = up->vals[n * 2];
+			params[n].u.value.b = up->vals[n * 2 + 1];
+			fallthrough;
+		case TEE_PARAM_TYPE_VALUE_OUTPUT:
+			params[n].attr = THREAD_PARAM_ATTR_VALUE_IN + pt -
+					 TEE_PARAM_TYPE_VALUE_INPUT;
+			break;
+		case TEE_PARAM_TYPE_MEMREF_INPUT:
+		case TEE_PARAM_TYPE_MEMREF_INOUT:
+		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+			buffer = (void *)(uintptr_t)up->vals[n * 2];
+			size = up->vals[n * 2 + 1];
+			if (buffer && pt != TEE_PARAM_TYPE_MEMREF_OUTPUT) {
+				destination = PTR_ADD(mobj_va, mobj_offs);
+				memcpy(destination, buffer, size);
+			}
+			params[n].u.memref.mobj = mobj;
+			params[n].u.memref.offs = mobj_offs;
+			params[n].u.memref.size = size;
+			params[n].attr = THREAD_PARAM_ATTR_MEMREF_IN + pt -
+					 TEE_PARAM_TYPE_MEMREF_INPUT;
+			if (ADD_OVERFLOW(mobj_offs, size, &mobj_offs))
+				return TEE_ERROR_SECURITY;
+			break;
+		default:
+			return TEE_ERROR_BAD_PARAMETERS;
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result ocall_post_process(struct thread_param *params,
+				     struct utee_params *up,
+				     void *mobj_va)
+{
+	uint32_t pt = 0;
+	void *buffer = NULL;
+	size_t size = 0;
+	void *source = NULL;
+	size_t mobj_offs = 0;
+	size_t n = 0;
+
+	for (n = 0; n < TEE_NUM_PARAMS; n++) {
+		pt = TEE_PARAM_TYPE_GET(up->types, n);
+		switch (pt) {
+		case TEE_PARAM_TYPE_NONE:
+		case TEE_PARAM_TYPE_VALUE_INPUT:
+			break;
+		case TEE_PARAM_TYPE_VALUE_INOUT:
+		case TEE_PARAM_TYPE_VALUE_OUTPUT:
+			up->vals[n * 2] = params[n].u.value.a;
+			up->vals[n * 2 + 1] = params[n].u.value.b;
+			break;
+		case TEE_PARAM_TYPE_MEMREF_INPUT:
+			size = up->vals[n * 2 + 1];
+			if (params[n].u.memref.size != size)
+				return TEE_ERROR_BAD_PARAMETERS;
+			if (ADD_OVERFLOW(mobj_offs, size, &mobj_offs))
+				return TEE_ERROR_SECURITY;
+			break;
+		case TEE_PARAM_TYPE_MEMREF_INOUT:
+		case TEE_PARAM_TYPE_MEMREF_OUTPUT:
+			buffer = (void *)(uintptr_t)up->vals[n * 2];
+			size = up->vals[n * 2 + 1];
+			if (params[n].u.memref.size > size)
+				return TEE_ERROR_BAD_PARAMETERS;
+			if (buffer) {
+				source = PTR_ADD(mobj_va, mobj_offs);
+				memcpy(buffer, source, params[n].u.memref.size);
+				if (ADD_OVERFLOW(mobj_offs, size, &mobj_offs))
+					return TEE_ERROR_SECURITY;
+			}
+			break;
+		default:
+			return TEE_ERROR_BAD_PARAMETERS;
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result system_ocall(struct ts_session *cs, uint32_t param_types,
+			       TEE_Param params[TEE_NUM_PARAMS])
+{
+	const struct user_ta_ctx *utc = to_user_ta_ctx(cs->ctx);
+	struct thread_param rpc_params[THREAD_RPC_MAX_NUM_PARAMS] = { };
+	const size_t rpc_num_params = ARRAY_SIZE(rpc_params);
+	uint32_t ocall_id = 0;
+	struct utee_params *ocall_up = NULL;
+	size_t ocall_up_size = 0;
+	struct mobj *mobj = NULL;
+	size_t mobj_size = 0;
+	void *mobj_va = NULL;
+	TEE_Result res = TEE_SUCCESS;
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INOUT,
+						TEE_PARAM_TYPE_MEMREF_INOUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	ocall_up_size = params[1].memref.size;
+	if (ocall_up_size != sizeof(*ocall_up))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	ocall_id = params[0].value.a;
+	ocall_up = (struct utee_params *)params[1].memref.buffer; /* User ptr */
+
+	res = ocall_check_parameters(&utc->uctx, ocall_up);
+	if (res)
+		return res;
+
+	res = ocall_compute_mobj_size(ocall_up, &mobj_size);
+	if (res)
+		return res;
+
+	if (mobj_size) {
+		mobj = thread_rpc_alloc_client_app_payload(mobj_size);
+		if (!mobj)
+			return TEE_ERROR_OUT_OF_MEMORY;
+
+		mobj_va = mobj_get_va(mobj, 0);
+		if (!mobj_va) {
+			res = TEE_ERROR_GENERIC;
+			goto exit;
+		}
+	}
+
+	rpc_params[0] = THREAD_PARAM_VALUE(INOUT, ocall_id, 0, 0);
+	rpc_params[1] = THREAD_PARAM_VALUE(IN, 0, 0, 0);
+	tee_uuid_to_octets((uint8_t *)&rpc_params[1].u.value,
+			   &cs->ctx->uuid);
+
+	res = ocall_pre_process(rpc_params + 2, ocall_up, mobj, mobj_va);
+	if (res)
+		goto exit;
+
+	res = thread_rpc_cmd(OPTEE_RPC_CMD_OCALL, rpc_num_params, rpc_params);
+	if (res) {
+		/*
+		 * Failure to process the OCALL request, as indicated by the
+		 * return code of the RPC, denotes that the state of normal
+		 * world is such that it may not be able to handle an additional
+		 * round-trip to the CA to free the SHM. As such, simply put the
+		 * memory object here.
+		 */
+		mobj_put(mobj);
+		return res;
+	}
+
+	res = ocall_post_process(rpc_params + 2, ocall_up, mobj_va);
+	if (res)
+		goto exit;
+
+	params[0].value.a = rpc_params[0].u.value.b;  /* OCALL ret val */
+	params[0].value.b = rpc_params[0].u.value.c;  /* OCALL ret val origin */
+
+exit:
+	if (mobj)
+		thread_rpc_free_client_app_payload(mobj);
+
+	return res;
+}
+#else
+static TEE_Result system_ocall(struct ts_session *cs __unused,
+			       uint32_t param_types __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*CFG_USER_OCALL*/
+
 static TEE_Result open_session(uint32_t param_types __unused,
 			       TEE_Param params[TEE_NUM_PARAMS] __unused,
 			       void **sess_ctx __unused)
@@ -350,6 +663,8 @@ static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
 		return system_get_tpm_event_log(param_types, params);
 	case PTA_SYSTEM_SUPP_PLUGIN_INVOKE:
 		return system_supp_plugin_invoke(param_types, params);
+	case PTA_SYSTEM_OCALL:
+		return system_ocall(s, param_types, params);
 	default:
 		break;
 	}

--- a/lib/libutee/include/pta_scmi_client.h
+++ b/lib/libutee/include/pta_scmi_client.h
@@ -51,9 +51,7 @@ enum optee_smci_pta_cmd {
 	/*
 	 * PTA_SCMI_CMD_GET_CHANNEL - Get channel handle
 	 *
-	 * SCMI shm information are 0 if agent expects to use OP-TEE regular SHM
-	 *
-	 * [in]     value[0].a: Channel identifier
+	 * [in]     value[0].a: Channel identifier or 0 if no assigned ID
 	 * [out]    value[0].a: Returned channel handle
 	 * [in]     value[0].b: Requested capabilities mask (enum pta_scmi_caps)
 	 */

--- a/lib/libutee/include/pta_scmi_client.h
+++ b/lib/libutee/include/pta_scmi_client.h
@@ -56,6 +56,17 @@ enum optee_smci_pta_cmd {
 	 * [in]     value[0].b: Requested capabilities mask (enum pta_scmi_caps)
 	 */
 	PTA_SCMI_CMD_GET_CHANNEL = 3,
+
+	/*
+	 * PTA_SCMI_CMD_OCALL_THREAD - Allocate a threaded path using OCALL
+	 *
+	 * [in]   value[0].a: channel handle
+	 *
+	 * Use Ocall support to create a provisioned OP-TEE thread context for
+	 * the channel. Successful creation of the thread makes this command to
+	 * return with Ocall command PTA_SCMI_OCALL_CMD_THREAD_READY.
+	 */
+	PTA_SCMI_CMD_OCALL_THREAD = 4,
 };
 
 /*
@@ -68,5 +79,63 @@ enum pta_scmi_caps {
 	 * buffers to carry SCMI protocol synchronisation information.
 	 */
 	PTA_SCMI_CAPS_SMT_HEADER = BIT32(0),
+	/*
+	 * Channel can use command PTA_SCMI_CMD_OCALL_THREAD to provision a
+	 * TEE thread for SCMI message passing.
+	 */
+	PTA_SCMI_CAPS_OCALL_THREAD = BIT32(1),
+};
+
+#define PTA_SCMI_CAPS_VALID_MASK	(PTA_SCMI_CAPS_SMT_HEADER | \
+					 PTA_SCMI_CAPS_OCALL_THREAD)
+
+/*
+ * enum optee_scmi_ocall_cmd
+ * enum optee_scmi_ocall_reply
+ *
+ * These enumerates define the IDs used by REE/TEE to communicate in the
+ * established REE/TEE Ocall thread context.
+ *
+ * At channel setup, we start from the REE: caller requests an Ocall context.
+ *
+ * 1. REE opens a session toward PTA SCMI. REE invokes PTA command
+ *    PTA_SCMI_CMD_GET_CHANNEL to get a channel handler. Then REE invokes
+ *    command PTA_SCMI_CAPS_OCALL_THREAD with an Ocall context. This is the
+ *    initial invocation of the Ocall thread context. Any further error in
+ *    the thread communication will close the thread and return from this
+ *    initial invocation with an invocation error result.
+ *
+ * 2. Upon support of Ocall, OP-TEE creates an Ocall context and returns
+ *    to REE with an Ocall, using Ocall command PTA_SCMI_OCALL_CMD_THREAD_READY.
+ *
+ * 3. REE can return from the Ocall with output param[0].value.a set to
+ *    PTA_SCMI_OCALL_PROCESS_SMT_CHANNEL to have an SCMI message processed.
+ *    In such case, OP-TEE processes the message and returns to REE with
+ *    Ocall command PTA_SCMI_OCALL_CMD_THREAD_READY. The SCMI response is in
+ *    the shared memory buffer.
+ *
+ * 4. Alternatively REE can return from the Ocall with output param[0].value.a
+ *    set to PTA_SCMI_OCALL_CLOSE_THREAD. This requests OP-TEE to terminate the
+ *    Ocall release resource and return from initial command invocation at [1]
+ *    and REE can close the TEE session.
+ *
+ * At anytime, if an error is reported by Ocall commands and replies, OP-TEE
+ * PTA SCMI will release the Ocall thread context and return from initial
+ * invocation at 1. PTA_SCMI_OCALL_ERROR is used in Ocall return to
+ * force an error report.
+ *
+ * At channel setup, REE driver executes steps 1. and 2.
+ * When a REE agent wants to post an SCMI message, agent goes through step 3.
+ * At channel release, REE driver executes step 4.
+ */
+
+enum optee_scmi_ocall_cmd {
+	PTA_SCMI_OCALL_CMD_THREAD_READY = 0,
+};
+
+enum optee_scmi_ocall_reply {
+	PTA_SCMI_OCALL_ERROR = 0,
+	PTA_SCMI_OCALL_CLOSE_THREAD = 1,
+	PTA_SCMI_OCALL_PROCESS_SMT_CHANNEL = 2,
 };
 #endif /* SCMI_PTA_SCMI_CLIENT_H */

--- a/lib/libutee/include/pta_scmi_client.h
+++ b/lib/libutee/include/pta_scmi_client.h
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019-2021, Linaro Limited
+ */
+#ifndef PTA_SCMI_CLIENT_H
+#define PTA_SCMI_CLIENT_H
+
+#define PTA_SCMI_UUID {\
+		0xa8cfe406, 0xd4f5, 0x4a2e, \
+		{ 0x9f, 0x8d, 0xa2, 0x5d, 0xc7, 0x54, 0xc0, 0x99 } \
+	}
+
+#define PTA_SCMI_NAME "PTA-SCMI"
+
+enum optee_smci_pta_cmd {
+	/*
+	 * PTA_SCMI_CMD_CAPABILITIES - Get channel capabilities
+	 *
+	 * [out]    value[0].a: Capability bit mask (enum pta_scmi_caps)
+	 * [out]    value[0].b: Extended capabilities or 0
+	 */
+	PTA_SCMI_CMD_CAPABILITIES = 0,
+
+	/*
+	 * PTA_SCMI_CMD_PROCESS_SMT_CHANNEL - Process SCMI message in SMT buffer
+	 *
+	 * [in]     value[0].a: Channel handle
+	 *
+	 * Shared memory used for SCMI message/response exhange is expected
+	 * already identified and bound to channel handle in both SCMI agent
+	 * and SCMI server (OP-TEE) parts.
+	 * The memory uses SMT header to carry SCMI meta-data (protocol ID and
+	 * protocol message ID).
+	 */
+	PTA_SCMI_CMD_PROCESS_SMT_CHANNEL = 1,
+
+	/*
+	 * PTA_SCMI_CMD_PROCESS_SMT_CHANNEL_MESSAGE - Process SMT/SCMI message
+	 *
+	 * [in]     value[0].a: Channel handle
+	 * [in/out] memref[1]: Message/response buffer (SMT and SCMI payload)
+	 *
+	 * Shared memory used for SCMI message/response is a SMT buffer
+	 * referenced by param[1]. It shall be 128 bytes large to fit response
+	 * payload whatever message playload size.
+	 * The memory uses SMT header to carry SCMI meta-data (protocol ID and
+	 * protocol message ID).
+	 */
+	PTA_SCMI_CMD_PROCESS_SMT_CHANNEL_MESSAGE = 2,
+
+	/*
+	 * PTA_SCMI_CMD_GET_CHANNEL - Get channel handle
+	 *
+	 * SCMI shm information are 0 if agent expects to use OP-TEE regular SHM
+	 *
+	 * [in]     value[0].a: Channel identifier
+	 * [out]    value[0].a: Returned channel handle
+	 * [in]     value[0].b: Requested capabilities mask (enum pta_scmi_caps)
+	 */
+	PTA_SCMI_CMD_GET_CHANNEL = 3,
+};
+
+/*
+ * Capabilities
+ */
+enum pta_scmi_caps {
+	PTA_SCMI_CAPS_NONE = 0,
+	/*
+	 * Supports command using SMT header protocol in shared memory
+	 * buffers to carry SCMI protocol synchronisation information.
+	 */
+	PTA_SCMI_CAPS_SMT_HEADER = BIT32(0),
+};
+#endif /* SCMI_PTA_SCMI_CLIENT_H */

--- a/lib/libutee/include/pta_system.h
+++ b/lib/libutee/include/pta_system.h
@@ -201,4 +201,24 @@
  */
 #define PTA_SYSTEM_SUPP_PLUGIN_INVOKE	13
 
+/*
+ * Send an OCALL to the calling TA's Client Application
+ *
+ * Note that if TA 1 invokes TA 2 which invokes TA N+1 and the latter sends an
+ * OCALL, it is the CA of TA 1 that receives the OCALL. Nevertheless, the OCALL
+ * carries the UUID of the TA that sent it. Therefore, the CA can determine that
+ * the OCALL originated from TA N+1, even though the CA receives the OCALL as a
+ * result of having communicated with TA 1.
+ *
+ * [in/out] value[0].a:	CA command Id (IN), CA command return value (OUT)
+ * [out]    value[0].b:	CA command return value origin
+ * [in/out] memref[1]:	Array of TEE_Param[TEE_NUM_PARAMS], the OCALL params
+ *
+ * Returns TEE_SUCCESS if the OCALL was sent and was processed successfully.
+ * This value is not necessarily the same as the return value of the OCALL
+ * itself, whose interpretation is up to the CA & TA, and is passed to the TA
+ * along with its origin code via this command's parameters as specified above.
+ */
+#define PTA_SYSTEM_OCALL		14
+
 #endif /* __PTA_SYSTEM_H */

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -102,4 +102,11 @@
 /* Private login method for REE kernel clients */
 #define TEE_LOGIN_REE_KERNEL		0x80000000
 
+/*
+ * Implementation-specific origin code constants
+ */
+
+/* The error code originated from the TA's Client Application (CA) */
+#define TEE_ORIGIN_CLIENT_APP		0xF0000001
+
 #endif /* TEE_API_DEFINES_EXTENSIONS_H */

--- a/lib/libutee/include/tee_internal_api_extensions.h
+++ b/lib/libutee/include/tee_internal_api_extensions.h
@@ -36,6 +36,17 @@ TEE_Result TEE_CacheFlush(char *buf, size_t len);
 TEE_Result TEE_CacheInvalidate(char *buf, size_t len);
 
 /*
+ * Send an OCALL to the Client Application
+ *
+ * The semantics are identical to TEEC_InvokeCommand but in the opposite
+ * direction.
+ */
+TEE_Result TEE_InvokeCACommand(uint32_t cancellationRequestTimeout,
+			       uint32_t commandID, uint32_t paramTypes,
+			       TEE_Param params[TEE_NUM_PARAMS],
+			       uint32_t *returnOrigin);
+
+/*
  * tee_map_zi() - Map zero initialized memory
  * @len:	Number of bytes
  * @flags:	0 or TEE_MEMORY_ACCESS_ANY_OWNER to allow sharing with other TAs

--- a/lib/libutee/tee_api_private.h
+++ b/lib/libutee/tee_api_private.h
@@ -8,6 +8,8 @@
 #include <tee_api_types.h>
 #include <utee_types.h>
 
+/* From tee_api.c */
+extern TEE_TASessionHandle __tee_api_system_session;
 
 void __utee_from_attr(struct utee_attribute *ua, const TEE_Attribute *attrs,
 			uint32_t attr_count);

--- a/lib/libutee/tee_system_pta.c
+++ b/lib/libutee/tee_system_pta.c
@@ -10,23 +10,26 @@
 #include <tee_internal_api.h>
 #include <types_ext.h>
 #include <util.h>
+#include "tee_api_private.h"
 
 static TEE_Result invoke_system_pta(uint32_t cmd_id, uint32_t param_types,
 				    TEE_Param params[TEE_NUM_PARAMS])
 {
-	static TEE_TASessionHandle sess = TEE_HANDLE_NULL;
 	static const TEE_UUID uuid = PTA_SYSTEM_UUID;
 
-	if (sess == TEE_HANDLE_NULL) {
+	if (__tee_api_system_session == TEE_HANDLE_NULL) {
 		TEE_Result res = TEE_OpenTASession(&uuid, TEE_TIMEOUT_INFINITE,
-						   0, NULL, &sess, NULL);
+						   0, NULL,
+						   &__tee_api_system_session,
+						   NULL);
 
 		if (res)
 			return res;
 	}
 
-	return TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE, cmd_id,
-				   param_types, params, NULL);
+	return TEE_InvokeTACommand(__tee_api_system_session,
+				   TEE_TIMEOUT_INFINITE, cmd_id, param_types,
+				   params, NULL);
 }
 
 void *tee_map_zi(size_t len, uint32_t flags)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -652,3 +652,10 @@ CFG_COMPAT_GP10_DES ?= y
 
 # Defines a limit for many levels TAs may call each others.
 CFG_CORE_MAX_SYSCALL_RECURSION ?= 4
+
+# CFG_CORE_OCALL=y enables support for OCALLs, allowing core to return
+# from an session or command invocation with an Ocall RPC context.
+CFG_CORE_OCALL ?= n
+ifeq ($(CFG_CORE_SEL1_SPMC)-$(CFG_CORE_OCALL),y-y)
+$(error "SPMC at SEL-1 does not comply with CFG_CORE_OCALL=y")
+endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -662,7 +662,13 @@ CFG_CORE_MAX_SYSCALL_RECURSION ?= 4
 
 # CFG_CORE_OCALL=y enables support for OCALLs, allowing core to return
 # from an session or command invocation with an Ocall RPC context.
+# CFG_USER_TA_OCALL=y enables TAs to invoke commands on their CA. User TA
+# OCALLs are implemented in the System PTA that is a prerequisite.
 CFG_CORE_OCALL ?= n
+CFG_USER_OCALL ?= $(CFG_CORE_OCALL)
+ifeq ($(CFG_USER_OCALL),y)
+$(call force,CFG_SYSTEM_PTA,y,Mandated by CFG_USER_OCALL)
+endif
 ifeq ($(CFG_CORE_SEL1_SPMC)-$(CFG_CORE_OCALL),y-y)
 $(error "SPMC at SEL-1 does not comply with CFG_CORE_OCALL=y")
 endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -628,6 +628,9 @@ CFG_SCMI_MSG_RESET_DOMAIN ?= n
 CFG_SCMI_MSG_SMT ?= n
 CFG_SCMI_MSG_VOLTAGE_DOMAIN ?= n
 
+# Enable SCMI PTA interface for REE SCMI agents
+CFG_SCMI_PTA ?= n
+
 ifneq ($(CFG_STMM_PATH),)
 $(call force,CFG_WITH_STMM_SP,y)
 else

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -631,6 +631,13 @@ CFG_SCMI_MSG_VOLTAGE_DOMAIN ?= n
 # Enable SCMI PTA interface for REE SCMI agents
 CFG_SCMI_PTA ?= n
 
+# Enable SCMI server (SCP-firmware-scmi library)
+CFG_SCMI_SERVER ?= n
+ifeq ($(CFG_SCMI_SERVER),y)
+$(call force,CFG_SCMI_PTA,y,Mandated by CFG_SCMI_SERVER)
+$(call force,CFG_CORE_OCALL,y,Mandated by CFG_SCMI_SERVER)
+endif
+
 ifneq ($(CFG_STMM_PATH),)
 $(call force,CFG_WITH_STMM_SP,y)
 else


### PR DESCRIPTION
This P-R is based on:
- OCALL support https://github.com/OP-TEE/optee_os/pull/3673
- SCMI PTA implementation basics https://github.com/OP-TEE/optee_os/pull/4533.

@HernanGatta, you see in this serie a commit leveraging OCALL to create a provisioned threaded entry in OP-TEE:
core: pta: scmi: ocall threaded context (https://github.com/OP-TEE/optee_os/commit/54d0a2a32f155bd513490d3a99243ca4e67aac55).