### PR TITLE
drivers: se050: Fix incorrect handling of se050 cipher operation mode

### DIFF
--- a/core/drivers/crypto/se050/core/cipher.c
+++ b/core/drivers/crypto/se050/core/cipher.c
@@ -16,8 +16,12 @@
 static TEE_Result do_init(struct drvcrypt_cipher_init *dinit)
 {
 	struct crypto_cipher_ctx *ctx = dinit->ctx;
+	TEE_OperationMode mode = TEE_MODE_DECRYPT;
 
-	return ctx->ops->init(dinit->ctx, dinit->encrypt,
+	if (dinit->encrypt)
+		mode = TEE_MODE_ENCRYPT;
+
+	return ctx->ops->init(dinit->ctx, mode,
 			      dinit->key1.data, dinit->key1.length,
 			      dinit->key2.data, dinit->key2.length,
 			      dinit->iv.data, dinit->iv.length);


### PR DESCRIPTION
A boolean encrypt flag was being passed to the cipher init function that
instead expects a TEE_OperationMode enum. Given that the enum TEE_MODE_ENCRYPT
has as a value of 0, encrypt and decrypt operations were effectively swapped.
This error has no practical effect on current se050 mainline code because the
only AES mode currently supported for se050 is CTR, which ignores the passed
value and always performs an encrypt. But it needs to be fixed before
adding support for ECB or CBC, for example.

Signed-off-by: Dave Herron <dave.herron@gallagher.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
