### PR TITLE
core: stmm: Remove pager constraint on stmm_sp_ops

### DIFF
--- a/core/arch/arm/include/kernel/stmm_sp.h
+++ b/core/arch/arm/include/kernel/stmm_sp.h
@@ -140,12 +140,12 @@ struct stmm_ctx {
 	bool is_initializing;
 };
 
-extern const struct ts_ops stmm_sp_ops;
+extern const struct ts_ops *stmm_sp_ops_ptr;
 
 static inline bool is_stmm_ctx(struct ts_ctx *ctx __maybe_unused)
 {
-	return IS_ENABLED(CFG_WITH_STMM_SP) &&
-	       ctx && ctx->ops == &stmm_sp_ops;
+	return IS_ENABLED(CFG_WITH_STMM_SP) && stmm_sp_ops_ptr &&
+	       ctx && ctx->ops == stmm_sp_ops_ptr;
 }
 
 static inline struct stmm_ctx *to_stmm_ctx(struct ts_ctx *ctx)


### PR DESCRIPTION
Fix a memory layout issue when `CFG_WITH_STMM_SP=y` and `CFG_WITH_PAGER=y`.

Before this change were all StMM operation function handlers their related resources being linked into the pager unpaged sections despite they could be pageable.

The reasons are both `__rodata_unpaged` attribute used for `stmm_sp_ops` instance and also the fact it is referenced in helper function `is_stmm_ctx()` which is referenced in unpaged helper function `is_user_mode_ctx()`.

This change removes `__rodata_unpaged` attribute from `stmm_sp_ops` and removes `stmm_sp_ops` reference pager constraint by using an indirect reference in `is_stmm_ctx()`.