### PR TITLE
core: interrupt: update dt and client interface

### DIFF
--- a/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
@@ -9,6 +9,7 @@
 #include <caam_hal_jr.h>
 #include <caam_jr.h>
 #include <kernel/dt.h>
+#include <kernel/interrupt.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>

--- a/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
@@ -114,8 +114,7 @@ void caam_hal_cfg_get_jobring_dt(void *fdt, struct caam_jrcfg *jrcfg)
 		}
 
 		jrcfg->offset = jr_offset;
-		/* Add index of the first SPI interrupt */
-		jrcfg->it_num = jr_it_num + 32;
+		jrcfg->it_num = jr_it_num;
 	}
 }
 

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -210,10 +210,25 @@ void gic_init(struct gic_data *gd, vaddr_t gicc_base __maybe_unused,
 
 static int gic_dt_get_irq(const uint32_t *properties, int len)
 {
+	int it_num = DT_INFO_INVALID_INTERRUPT;
+
 	if (!properties || len < 2)
 		return DT_INFO_INVALID_INTERRUPT;
 
-	return fdt32_to_cpu(properties[1]);
+	it_num = fdt32_to_cpu(properties[1]);
+
+	switch (fdt32_to_cpu(properties[0])) {
+	case 1:
+		it_num += 16;
+		break;
+	case 0:
+		it_num += 32;
+		break;
+	default:
+		it_num = DT_INFO_INVALID_INTERRUPT;
+	}
+
+	return it_num;
 }
 
 void gic_init_base_addr(struct gic_data *gd, vaddr_t gicc_base __maybe_unused,

--- a/core/drivers/sp805_wdt.c
+++ b/core/drivers/sp805_wdt.c
@@ -106,18 +106,14 @@ TEE_Result sp805_register_itr_handler(struct sp805_wdt_data *pd,
 
 	assert(!pd->chip.wdt_itr);
 
-	wdt_itr = calloc(1, sizeof(*wdt_itr));
+	wdt_itr = itr_alloc_add(itr_num, wdt_itr_cb,
+				itr_flags, &pd->chip);
 	if (!wdt_itr)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	wdt_itr->it = itr_num;
-	wdt_itr->flags = itr_flags;
-	wdt_itr->handler = wdt_itr_cb;
-	wdt_itr->data = &pd->chip;
 	pd->itr_handler = itr_handler;
 	pd->chip.wdt_itr = wdt_itr;
 
-	itr_add(wdt_itr);
 	itr_enable(wdt_itr->it);
 
 	return TEE_SUCCESS;

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -97,18 +97,6 @@ int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size);
 bool dt_have_prop(const void *fdt, int offs, const char *propname);
 
 /*
- * Get the DT interrupt property of the @node. In the DT an interrupt
- * is defined with at least 2x32 bits detailling the interrupt number and type.
- *
- * @fdt reference to the Device Tree
- * @node is the node offset to read
- *
- * Returns the interrupt number if value >= 0
- * otherwise DT_INFO_INVALID_INTERRUPT
- */
-int dt_get_irq(void *fdt, int node);
-
-/*
  * Modify or add "status" property to "disabled"
  *
  * @fdt reference to the Device Tree

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -31,12 +31,15 @@
  * @reg: Device register physical base address or DT_INFO_INVALID_REG
  * @clock: Device identifier (positive value) or DT_INFO_INVALID_CLOCK
  * @reset: Device reset identifier (positive value) or DT_INFO_INVALID_CLOCK
+ * @interrupt: Device interrupt identifier (positive value) or
+ * DT_INFO_INVALID_INTERRUPT
  */
 struct dt_node_info {
 	unsigned int status;
 	paddr_t reg;
 	int clock;
 	int reset;
+	int interrupt;
 };
 
 #if defined(CFG_DT)

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -33,10 +33,14 @@ enum itr_return {
 	ITRR_HANDLED,
 };
 
+struct itr_handler;
+
+typedef enum itr_return (*itr_handler_t)(struct itr_handler *h);
+
 struct itr_handler {
 	size_t it;
 	uint32_t flags;
-	enum itr_return (*handler)(struct itr_handler *h);
+	itr_handler_t handler;
 	void *data;
 	SLIST_ENTRY(itr_handler) link;
 };
@@ -57,6 +61,9 @@ void itr_handle(size_t it);
 int dt_get_irq(const void *fdt, int node);
 #endif
 
+struct itr_handler *itr_alloc_add(size_t it, itr_handler_t handler,
+				  uint32_t flags, void *data);
+void itr_free(struct itr_handler *hdl);
 void itr_add(struct itr_handler *handler);
 void itr_enable(size_t it);
 void itr_disable(size_t it);

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -14,6 +14,7 @@
 
 struct itr_chip {
 	const struct itr_ops *ops;
+	int (*dt_get_irq)(const uint32_t *properties, int len);
 };
 
 struct itr_ops {
@@ -42,6 +43,19 @@ struct itr_handler {
 
 void itr_init(struct itr_chip *data);
 void itr_handle(size_t it);
+
+#ifdef CFG_DT
+/*
+ * Get the DT interrupt property at @node. In the DT an interrupt
+ *
+ * @fdt reference to the Device Tree
+ * @node is the node offset to read
+ *
+ * Returns the interrupt number if value >= 0
+ * otherwise DT_INFO_INVALID_INTERRUPT
+ */
+int dt_get_irq(const void *fdt, int node);
+#endif
 
 void itr_add(struct itr_handler *handler);
 void itr_enable(size_t it);

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <kernel/dt.h>
+#include <kernel/interrupt.h>
 #include <kernel/linker.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>
@@ -267,6 +268,7 @@ void _fdt_fill_device_info(void *fdt, struct dt_node_info *info, int offs)
 		.reg = DT_INFO_INVALID_REG,
 		.clock = DT_INFO_INVALID_CLOCK,
 		.reset = DT_INFO_INVALID_RESET,
+		.interrupt = DT_INFO_INVALID_INTERRUPT,
 	};
 	const fdt32_t *cuint;
 
@@ -283,6 +285,8 @@ void _fdt_fill_device_info(void *fdt, struct dt_node_info *info, int offs)
 		cuint++;
 		dinfo.reset = (int)fdt32_to_cpu(*cuint);
 	}
+
+	dinfo.interrupt = dt_get_irq(fdt, offs);
 
 	dinfo.status = _fdt_get_status(fdt, offs);
 

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -51,27 +51,6 @@ bool dt_have_prop(const void *fdt, int offs, const char *propname)
 	return prop;
 }
 
-int dt_get_irq(void *fdt, int node)
-{
-	const uint32_t *int_prop = NULL;
-	int len_prop = 0;
-	int it_num = DT_INFO_INVALID_INTERRUPT;
-
-	/*
-	 * Interrupt property can be defined with at least 2x32 bits word
-	 *  - Type of interrupt
-	 *  - Interrupt Number
-	 */
-	int_prop = fdt_getprop(fdt, node, "interrupts", &len_prop);
-
-	if (!int_prop || len_prop < 2)
-		return it_num;
-
-	it_num = fdt32_to_cpu(int_prop[1]);
-
-	return it_num;
-}
-
 int dt_disable_status(void *fdt, int node)
 {
 	const char *prop = NULL;

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -3,8 +3,10 @@
  * Copyright (c) 2016-2019, Linaro Limited
  */
 
+#include <kernel/dt.h>
 #include <kernel/interrupt.h>
 #include <kernel/panic.h>
+#include <libfdt.h>
 #include <trace.h>
 #include <assert.h>
 
@@ -24,6 +26,24 @@ void itr_init(struct itr_chip *chip)
 {
 	itr_chip = chip;
 }
+
+#ifdef CFG_DT
+int dt_get_irq(const void *fdt, int node)
+{
+	const uint32_t *prop = NULL;
+	int len = 0;
+	int it_num = DT_INFO_INVALID_INTERRUPT;
+
+	if (!itr_chip || !itr_chip->dt_get_irq)
+		return it_num;
+
+	prop = fdt_getprop(fdt, node, "interrupts", &len);
+	if (!prop)
+		return it_num;
+
+	return itr_chip->dt_get_irq(prop, len);
+}
+#endif
 
 void itr_handle(size_t it)
 {


### PR DESCRIPTION

This patch series:
- Split dt-bindings management to welcome other interrupt drivers.
- Update gic driver to take account the type of interrupt specified in device tree (SPI | PPI)
- Add interrupt resource in dt_node_info.
- Add an interface to allocate and add an interrupt handler.
