### PR TITLE
core/link.mk, plat-rcar: introduce SRECFLAGS variable

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -233,4 +233,4 @@ $(link-out-dir)/tee-raw.bin: $(link-out-dir)/tee.elf scripts/gen_tee_bin.py
 cleanfiles += $(link-out-dir)/tee.srec
 $(link-out-dir)/tee.srec: $(link-out-dir)/tee-raw.bin
 	@$(cmd-echo-silent) '  SREC    $@'
-	$(q)$(OBJCOPYcore) -I binary -O srec $< $@
+	$(q)$(OBJCOPYcore) -I binary -O srec $(SRECFLAGS) $< $@

--- a/core/arch/arm/plat-rcar/link.mk
+++ b/core/arch/arm/plat-rcar/link.mk
@@ -1,3 +1,5 @@
 include core/arch/arm/kernel/link.mk
 
+SRECFLAGS ?= --srec-forceS3 --adjust-vma=$(CFG_TZDRAM_START)
+
 all: $(link-out-dir)/tee.srec


### PR DESCRIPTION
.srec files are used to flash OPTEE on Rcar Gen3 using serial mode. Serial mode
downloader in Rcar does not recognize S2 records in .srec files that objcopy
generates by default. It allows only S3 records. Also, it requires correct load
address present in .srec files.

So, we need to provide additional flags to objcopy during tee.srec file
generation. This change introduces makefile variable SRECFLAGS that can be used
exactly for this task. Also it provides the correct flags for rcar platform.

Note: at the begging tee.srec file was generated directly from tee.elf and had
correct load addresses. As the load address is wider than 24 bits, objcopy
automatically used S3 records. But, later tee-raw.bin were introduced and I
changed source for tee.srec, so now it is generated from tee-raw.bin. As
tee-raw.bin have no load address information this leads to incorrect tee.srec
file.

Strictly speaking, only --adjust-vma option is required. As current load address
is wider than 24 bits, objcopy will switch to S3 records automatically. But I
prefer to have --srec-forceS3 option anyways: for that unlikely chance that
CFG_TZDRAM_START would be changed to something much lower.

Fixes: e66c2639b6b ("plat: rcar: generate .srec file using gen_tee_bin")

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
