### PR TITLE
core: Add a couple of small FF-A messages support for SPs

### DIFF
--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -22,4 +22,7 @@ void spmc_handle_rxtx_map(struct thread_smc_args *args, struct ffa_rxtx *buf);
 void spmc_handle_rxtx_unmap(struct thread_smc_args *args, struct ffa_rxtx *buf);
 void spmc_handle_rx_release(struct thread_smc_args *args, struct ffa_rxtx *buf);
 void spmc_handle_version(struct thread_smc_args *args);
+
+void spmc_set_args(struct thread_smc_args *args, uint32_t fid, uint32_t src_dst,
+		   uint32_t w2, uint32_t w3, uint32_t w4, uint32_t w5);
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -21,4 +21,5 @@ struct ffa_rxtx {
 void spmc_handle_rxtx_map(struct thread_smc_args *args, struct ffa_rxtx *buf);
 void spmc_handle_rxtx_unmap(struct thread_smc_args *args, struct ffa_rxtx *buf);
 void spmc_handle_rx_release(struct thread_smc_args *args, struct ffa_rxtx *buf);
+void spmc_handle_version(struct thread_smc_args *args);
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -238,6 +238,9 @@ void spmc_sp_msg_handler(struct thread_smc_args *args,
 			args->a0 = FFA_SUCCESS_32;
 			args->a2 = caller_sp->endpoint_id;
 			sp_enter(args, caller_sp);
+		case FFA_VERSION:
+			spmc_handle_version(args);
+			sp_enter(args, caller_sp);
 			break;
 		default:
 			EMSG("Unhandled FFA function ID %#"PRIx32,

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -234,6 +234,11 @@ void spmc_sp_msg_handler(struct thread_smc_args *args,
 			ts_pop_current_session();
 			sp_enter(args, caller_sp);
 			break;
+		case FFA_ID_GET:
+			args->a0 = FFA_SUCCESS_32;
+			args->a2 = caller_sp->endpoint_id;
+			sp_enter(args, caller_sp);
+			break;
 		default:
 			EMSG("Unhandled FFA function ID %#"PRIx32,
 			     (uint32_t)args->a0);

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -131,7 +131,7 @@ static void set_args(struct thread_smc_args *args, uint32_t fid,
 					  .a5 = w5, };
 }
 
-static void handle_version(struct thread_smc_args *args)
+void spmc_handle_version(struct thread_smc_args *args)
 {
 	/*
 	 * We currently only support one version, 1.0 so let's keep it
@@ -850,7 +850,7 @@ void thread_spmc_msg_recv(struct thread_smc_args *args)
 	assert((thread_get_exceptions() & THREAD_EXCP_ALL) == THREAD_EXCP_ALL);
 	switch (args->a0) {
 	case FFA_VERSION:
-		handle_version(args);
+		spmc_handle_version(args);
 		break;
 	case FFA_FEATURES:
 		handle_features(args);


### PR DESCRIPTION
Add the following functionality:
FFA_ID_GET: Allow a SP to retrieve it's own id
FFA_VERSION: Allow a SP to retrieve the FF-A version supported
FFA_FEATURES: Allow a SP to retrieve the FF-A features supported.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
