### PR TITLE
core: Add FFA_PARTITION_INFO

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -94,6 +94,10 @@
 /* Special value for MBZ parameters */
 #define FFA_PARAM_MBZ			U(0x0)
 
+/* Flags used for the FFA_PARTITION_INFO_GET  return message */
+#define FFA_PARTITION_DIRECT_REQ_RECV_SUPPORT BIT(0)
+#define FFA_PARTITION_DIRECT_REQ_SEND_SUPPORT BIT(1)
+
 #ifndef __ASSEMBLER__
 /* Constituent memory region descriptor */
 struct ffa_address_range {

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -7,6 +7,7 @@
 
 #include <assert.h>
 #include <config.h>
+#include <ffa.h>
 #include <kernel/embedded_ts.h>
 #include <kernel/thread_spmc.h>
 #include <kernel/user_mode_ctx_struct.h>
@@ -73,6 +74,10 @@ static inline struct sp_ctx *to_sp_ctx(struct ts_ctx *ctx)
 
 struct sp_session *sp_get_session(uint32_t session_id);
 TEE_Result sp_enter(struct thread_smc_args *args, struct sp_session *sp);
+TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
+				  size_t *elements);
+
+TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct embedded_ts)

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -5,6 +5,7 @@
 #ifndef __KERNEL_THREAD_SPMC_H
 #define __KERNEL_THREAD_SPMC_H
 
+#include <ffa.h>
 #include <kernel/thread.h>
 
 /* FF-A endpoint base ID when OP-TEE is used as a S-EL1 endpoint */
@@ -25,4 +26,8 @@ void spmc_handle_version(struct thread_smc_args *args);
 
 void spmc_set_args(struct thread_smc_args *args, uint32_t fid, uint32_t src_dst,
 		   uint32_t w2, uint32_t w3, uint32_t w4, uint32_t w5);
+void spmc_handle_partition_info_get(struct thread_smc_args *args,
+				    struct ffa_rxtx *rxtx);
+void spmc_fill_partition_entry(struct ffa_partition_info *fpi,
+			       uint16_t endpoint_id);
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -29,5 +29,6 @@ void spmc_set_args(struct thread_smc_args *args, uint32_t fid, uint32_t src_dst,
 void spmc_handle_partition_info_get(struct thread_smc_args *args,
 				    struct ffa_rxtx *rxtx);
 void spmc_fill_partition_entry(struct ffa_partition_info *fpi,
-			       uint16_t endpoint_id);
+			       uint16_t endpoint_id,
+			       uint16_t execution_context);
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -95,17 +95,16 @@ TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
 	TAILQ_FOREACH(s, &open_sp_sessions, link) {
 		if (s->state != sp_dead)
 			continue;
-		count++;
 		if (count < in_elements) {
 			spmc_fill_partition_entry(fpi, s->endpoint_id, 1);
 			fpi++;
 		}
+		count++;
 	}
 
+	*elements = count;
 	if (count >= in_elements)
 		return TEE_ERROR_SHORT_BUFFER;
-
-	*elements = count;
 
 	return TEE_SUCCESS;
 }

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -93,20 +93,19 @@ TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
 	uint32_t count = 0;
 
 	TAILQ_FOREACH(s, &open_sp_sessions, link) {
-		if (count < in_elements) {
-			if (s->state != sp_dead) {
-				spmc_fill_partition_entry(fpi, s->endpoint_id);
-				fpi++;
-			}
-		}
 		if (s->state != sp_dead)
-			count++;
+			continue;
+		count++;
+		if (count < in_elements) {
+			spmc_fill_partition_entry(fpi, s->endpoint_id, 1);
+			fpi++;
+		}
 	}
 
-	if (count > in_elements) {
-		*elements = count;
+	if (count >= in_elements)
 		return TEE_ERROR_SHORT_BUFFER;
-	}
+
+	*elements = count;
 
 	return TEE_SUCCESS;
 }

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -56,6 +56,23 @@ static void set_sp_ctx_ops(struct ts_ctx *ctx)
 	ctx->ops = _sp_ops;
 }
 
+TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id)
+{
+	struct sp_session *s = NULL;
+
+	TAILQ_FOREACH(s, &open_sp_sessions, link) {
+		if (!memcmp(&s->ts_sess.ctx->uuid, uuid, sizeof(*uuid))) {
+			if (s->state == sp_dead)
+				return TEE_ERROR_TARGET_DEAD;
+
+			*session_id  = s->endpoint_id;
+			return TEE_SUCCESS;
+		}
+	}
+
+	return TEE_ERROR_ITEM_NOT_FOUND;
+}
+
 struct sp_session *sp_get_session(uint32_t session_id)
 {
 	struct sp_session *s = NULL;
@@ -66,6 +83,32 @@ struct sp_session *sp_get_session(uint32_t session_id)
 	}
 
 	return NULL;
+}
+
+TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
+				  size_t *elements)
+{
+	size_t in_elements = *elements;
+	struct sp_session *s = NULL;
+	uint32_t count = 0;
+
+	TAILQ_FOREACH(s, &open_sp_sessions, link) {
+		if (count < in_elements) {
+			if (s->state != sp_dead) {
+				spmc_fill_partition_entry(fpi, s->endpoint_id);
+				fpi++;
+			}
+		}
+		if (s->state != sp_dead)
+			count++;
+	}
+
+	if (count > in_elements) {
+		*elements = count;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	return TEE_SUCCESS;
 }
 
 static void sp_init_info(struct sp_ctx *ctx, struct thread_smc_args *args)

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -267,11 +267,19 @@ void spmc_sp_msg_handler(struct thread_smc_args *args,
 			args->a0 = FFA_SUCCESS_32;
 			args->a2 = caller_sp->endpoint_id;
 			sp_enter(args, caller_sp);
+			break;
 		case FFA_VERSION:
 			spmc_handle_version(args);
 			sp_enter(args, caller_sp);
+			break;
 		case FFA_FEATURES:
 			handle_features(args);
+			sp_enter(args, caller_sp);
+			break;
+		case FFA_PARTITION_INFO_GET:
+			ts_push_current_session(&caller_sp->ts_sess);
+			spmc_handle_partition_info_get(args, &caller_sp->rxtx);
+			ts_pop_current_session();
 			sp_enter(args, caller_sp);
 			break;
 		default:

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -351,7 +351,7 @@ static uint32_t handle_partition_info_get_all(size_t *elem_count,
 	struct ffa_partition_info *fpi = rxtx->tx;
 
 	/* Add OP-TEE SP */
-	spmc_fill_partition_entry(fpi, my_endpoint_id, 0);
+	spmc_fill_partition_entry(fpi, my_endpoint_id, CFG_TEE_CORE_NB_CORE);
 	rxtx->tx_is_mine = false;
 	*elem_count = 1;
 	fpi++;
@@ -361,7 +361,7 @@ static uint32_t handle_partition_info_get_all(size_t *elem_count,
 
 		if (sp_get_partitions_info(fpi, &elements))
 			return TEE_ERROR_SHORT_BUFFER;
-		elem_count += elements;
+		*elem_count += elements;
 	}
 	return FFA_SUCCESS_32;
 }
@@ -373,6 +373,7 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 	uint32_t rc = 0;
 	uint32_t endpoint_id = my_endpoint_id;
 	struct ffa_partition_info *fpi = NULL;
+	uint16_t execution_context = CFG_TEE_CORE_NB_CORE;
 
 	cpu_spin_lock(&rxtx->spinlock);
 
@@ -412,6 +413,7 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 				rc = FFA_INVALID_PARAMETERS;
 				goto out;
 			}
+			execution_context = 1;
 		} else {
 			ret_fid = FFA_ERROR;
 			rc = FFA_INVALID_PARAMETERS;
@@ -419,7 +421,7 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 		}
 	}
 
-	spmc_fill_partition_entry(fpi, endpoint_id, 1);
+	spmc_fill_partition_entry(fpi, endpoint_id, execution_context);
 	ret_fid = FFA_SUCCESS_32;
 	rxtx->tx_is_mine = false;
 	rc = 1;


### PR DESCRIPTION
Allow SPs to query all SPs loaded inside the system.
Change FFA_PARTITION_INFO to return all SPs loaded in the system.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
