### PR TITLE
core: tee_pobj_get(): detect access conflict

### DIFF
--- a/core/tee/tee_pobj.c
+++ b/core/tee/tee_pobj.c
@@ -83,7 +83,8 @@ TEE_Result tee_pobj_get(TEE_UUID *uuid, void *obj_id, uint32_t obj_id_len,
 			(*obj)->refcnt++;
 			goto out;
 		}
-		if ((*obj)->creating) {
+		if ((*obj)->creating || (usage == TEE_POBJ_USAGE_CREATE &&
+					 !(flags & TEE_DATA_FLAG_OVERWRITE))) {
 			res = TEE_ERROR_ACCESS_CONFLICT;
 			goto out;
 		}


### PR DESCRIPTION
When tee_pobj_get() is called with TEE_POBJ_USAGE_CREATE and without
TEE_DATA_FLAG_OVERWRITE, and the persistent object is found in the list of
open objects, the function should return TEE_ERROR_ACCESS_CONFLICT
immediately. There is no need to call into the FS layer since we know
the object exists at this point.

Fixes: https://github.com/OP-TEE/optee_os/issues/4560
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
