### PR TITLE
plat: rcar: add M3 SoC with 8GB memory and use register_ddr()

### DIFF
--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -44,13 +44,13 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
 	defined(PLATFORM_FLAVOR_salvator_h3_4x2g) || \
 	defined(PLATFORM_FLAVOR_salvator_m3) || \
 	defined(PLATFORM_FLAVOR_salvator_m3_2x4g)
-register_dynamic_shm(NSEC_DDR_0_BASE, NSEC_DDR_0_SIZE);
-register_dynamic_shm(NSEC_DDR_1_BASE, NSEC_DDR_1_SIZE);
+register_ddr(NSEC_DDR_0_BASE, NSEC_DDR_0_SIZE);
+register_ddr(NSEC_DDR_1_BASE, NSEC_DDR_1_SIZE);
 #ifdef NSEC_DDR_2_BASE
-register_dynamic_shm(NSEC_DDR_2_BASE, NSEC_DDR_2_SIZE);
+register_ddr(NSEC_DDR_2_BASE, NSEC_DDR_2_SIZE);
 #endif
 #ifdef NSEC_DDR_3_BASE
-register_dynamic_shm(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
+register_ddr(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
 #endif
 #endif
 

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -42,7 +42,8 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
 /* Legacy platforms */
 #if defined(PLATFORM_FLAVOR_salvator_h3) || \
 	defined(PLATFORM_FLAVOR_salvator_h3_4x2g) || \
-	defined(PLATFORM_FLAVOR_salvator_m3)
+	defined(PLATFORM_FLAVOR_salvator_m3) || \
+	defined(PLATFORM_FLAVOR_salvator_m3_2x4g)
 register_dynamic_shm(NSEC_DDR_0_BASE, NSEC_DDR_0_SIZE);
 register_dynamic_shm(NSEC_DDR_1_BASE, NSEC_DDR_1_SIZE);
 #ifdef NSEC_DDR_2_BASE

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -71,6 +71,14 @@
 #define NSEC_DDR_1_BASE		0x600000000U
 #define NSEC_DDR_1_SIZE		0x80000000
 
+#elif defined(PLATFORM_FLAVOR_salvator_m3_2x4g)
+#define NSEC_DDR_0_BASE		0x47E00000
+#define NSEC_DDR_0_SIZE		0x78200000
+#define NSEC_DDR_1_BASE		0x400000000U
+#define NSEC_DDR_1_SIZE		0x80000000
+#define NSEC_DDR_2_BASE		0x600000000U
+#define NSEC_DDR_2_SIZE		0x100000000U
+
 #else
 
 /* Generic DT-based platform */


### PR DESCRIPTION
Pair of patches that adds support for the new version of M3 SoC and removes deprecated calls.

Theoretically, rcar platform now supports memory configuration via DTB, but for some reason it can't parse memory nodes that describe non-secure RAM. So, for now I'll just add static configuration for m3_2x4gb.