### PR TITLE
Fix for data input size of CAAM CMAC do_update()

### DIFF
--- a/core/drivers/crypto/caam/cipher/caam_cipher_mac.c
+++ b/core/drivers/crypto/caam/cipher/caam_cipher_mac.c
@@ -469,7 +469,7 @@ static TEE_Result do_update_cmac(struct drvcrypt_cipher_update *dupdate)
 		}
 	}
 
-	if (dupdate->src.length) {
+	if (size_inmade) {
 		ret = caam_dmaobj_init_input(&src, dupdate->src.data,
 					     size_inmade);
 		if (ret)


### PR DESCRIPTION
Hello,

These are two fixes for the CAAM CMAC we found while inspecting the code.
xtest does not cover these cases.

Thanks!
Clement