### PR TITLE
core: ldelf: create .debug_frame when using AARCH64 GCC

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -141,6 +141,8 @@ arm32-platform-aflags-no-hard-float ?=
 
 arm64-platform-cflags-no-hard-float ?= -mgeneral-regs-only
 arm64-platform-cflags-hard-float ?=
+# Prevent generation of .eh_frame, will produce .debug_frame when CFG_DEBUG_INFO=y
+arm64-platform-cflags-no-eh-frame := $(call cc-option,-fno-unwind-tables) $(call cc-option,-fno-asynchronous-unwind-tables)
 arm64-platform-cflags-generic := -mstrict-align $(call cc-option,-mno-outline-atomics,)
 
 ifeq ($(DEBUG),1)
@@ -179,6 +181,7 @@ core-platform-cppflags += $(arm64-platform-cppflags)
 core-platform-cflags += $(arm64-platform-cflags)
 core-platform-cflags += $(arm64-platform-cflags-generic)
 core-platform-cflags += $(arm64-platform-cflags-no-hard-float)
+core-platform-cflags += $(arm64-platform-cflags-no-eh-frame)
 core-platform-aflags += $(arm64-platform-aflags)
 else
 core-platform-cppflags += $(arm32-platform-cppflags)

--- a/ldelf/ldelf.ld.S
+++ b/ldelf/ldelf.ld.S
@@ -29,7 +29,6 @@ SECTIONS {
 	}
         .plt : { *(.plt) }
 
-	.eh_frame : { *(.eh_frame) }
 	.rodata : {
 		*(.gnu.linkonce.r.*)
 		*(.rodata .rodata.*)
@@ -82,5 +81,5 @@ SECTIONS {
 	.data : { *(.data .data.* .gnu.linkonce.d.*) }
 	.bss : { *(.bss .bss.* .gnu.linkonce.b.* COMMON) }
 
-	/DISCARD/ : { *(.interp) }
+	/DISCARD/ : { *(.interp) *(.eh_frame .eh_frame.*) }
 }


### PR DESCRIPTION
This patch prevents the generation of the .eh_frame using GCC command
line options. By the same time GCC starts generating .debug_frame
instead. This improves the robustness for call-stack unwinding when
using an external debug probe.
As .eh_frame was removed in the linker scripts this is no functional
change.

Signed-off-by: Alexander Merkle <alexander.merkle@lauterbach.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
