### PR TITLE
ci: travis: select Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+dist: focal
+
 notifications:
   - email: true
 


### PR DESCRIPTION
The default build environment for Travis CI is currently Linux Ubuntu
Xenial (16.04). This is quite an old release (21 April 2016). The latest
release supported by Travis CI is Focal (20.04), released on 23 April
2020. This commit updates to 20.04 by selecting "dist: focal" instead of
keeping the default. The reason is to obtain a more up-to-date codespell
dictionary. For example, it was found that checkpatch detects the
spelling mistake 'becase' on 20.04 but not on 16.04.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
