### PR TITLE
ci: travis: create symlink /usr/share/codespell/dictionary.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+# Ubuntu Focal (20.04)
+# Please check the path to the codespell dictionary below if you change this
 dist: focal
 
 notifications:
@@ -10,6 +12,7 @@ git:
 
 before_install:
   - sudo apt-get -y install codespell
+  - sudo mkdir -p /usr/share/codespell && sudo ln -s /usr/lib/python3/dist-packages/codespell_lib/data/dictionary.txt /usr/share/codespell/dictionary.txt
 
 before_script:
   - export OPTEE_OS=$PWD


### PR DESCRIPTION
checkpatch.pl expects to find the codespell dictionary in
/usr/share/codespell/dictionary.txt, but the codespell package in Ubuntu
20.04 has moved to a different path [1]. Take care of this by creating a
symlink.

Link: [1] https://packages.ubuntu.com/focal/all/codespell/filelist
Fixes: 784103ed82de ("ci: travis: select Ubuntu 20.04")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
