### PR TITLE
[RFC] changes in RPMB configuration

### DIFF
--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -36,6 +36,7 @@
  */
 
 #include <assert.h>
+#include <config.h>
 #include <crypto/crypto.h>
 #include <initcall.h>
 #include <kernel/thread.h>
@@ -493,8 +494,10 @@ static TEE_Result ree_fs_ta_read(struct ts_store_handle *h, void *data,
 		if (res != TEE_SUCCESS)
 			return res;
 
-		if (handle->bs_hdr)
+		if (handle->bs_hdr &&
+		    (IS_ENABLED(CFG_REE_FS) || IS_ENABLED(CFG_RPMB_FS))) {
 			res = check_update_version(handle->bs_hdr);
+		}
 	}
 	return res;
 }

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -472,6 +472,7 @@ static const struct tee_fs_dirfile_operations ree_dirf_ops = {
 static struct tee_fs_dirfile_dirh *ree_fs_dirh;
 static size_t ree_fs_dirh_refcount;
 
+#ifdef CFG_REE_FS_ANTI_ROLLBACK
 #ifdef CFG_RPMB_FS
 static struct tee_file_handle *ree_fs_rpmb_fh;
 
@@ -533,8 +534,10 @@ static void close_dirh(struct tee_fs_dirfile_dirh **dirh)
 	*dirh = NULL;
 	rpmb_fs_ops.close(&ree_fs_rpmb_fh);
 }
-
-#else /*!CFG_RPMB_FS*/
+#else /* CFG_RPMB_FS */
+#error "No anti rollback implementation available for CFG_REE_FS_ANTI_ROLLBACK"
+#endif
+#else /*CFG_REE_FS_ANTI_ROLLBACK*/
 static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 {
 	TEE_Result res;
@@ -556,7 +559,7 @@ static void close_dirh(struct tee_fs_dirfile_dirh **dirh)
 	tee_fs_dirfile_close(*dirh);
 	*dirh = NULL;
 }
-#endif /*!CFG_RPMB_FS*/
+#endif /*CFG_REE_FS_ANTI_ROLLBACK*/
 
 static TEE_Result get_dirh(struct tee_fs_dirfile_dirh **dirh)
 {

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -34,7 +34,7 @@ const struct tee_file_operations *tee_svc_storage_file_ops(uint32_t storage_id)
 #elif defined(CFG_RPMB_FS)
 		return &rpmb_fs_ops;
 #else
-#error At least one filesystem must be enabled.
+		return NULL;
 #endif
 #ifdef CFG_REE_FS
 	case TEE_STORAGE_PRIVATE_REE:

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -298,6 +298,10 @@ CFG_REE_FS_TA ?= y
 CFG_REE_FS_TA_BUFFERED ?= n
 $(eval $(call cfg-depends-all,CFG_REE_FS_TA_BUFFERED,CFG_REE_FS_TA))
 
+# Allow REE FS content to be reset. If .../tee root directory does not
+# exists, assume it is virgin even of an anti rollback hask exists.
+CFG_REE_FS_ALLOW_RESET ?= n
+
 # Support for loading user TAs from a special section in the TEE binary.
 # Such TAs are available even before tee-supplicant is available (hence their
 # name), but note that many services exported to TAs may need tee-supplicant,

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -302,6 +302,15 @@ $(eval $(call cfg-depends-all,CFG_REE_FS_TA_BUFFERED,CFG_REE_FS_TA))
 # exists, assume it is virgin even of an anti rollback hask exists.
 CFG_REE_FS_ALLOW_RESET ?= n
 
+# Protect REE FS secure storage against rollback injection
+ifeq ($(CFG_REE_FS),y)
+ifneq ($(CFG_RPMB_FS),y)
+$(call force,CFG_REE_FS_ANTI_ROLLBACK,n,No support for REE FS anti rollback)
+endif
+CFG_REE_FS_ANTI_ROLLBACK ?= y
+endif
+
+
 # Support for loading user TAs from a special section in the TEE binary.
 # Such TAs are available even before tee-supplicant is available (hence their
 # name), but note that many services exported to TAs may need tee-supplicant,

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -180,6 +180,19 @@ CFG_RPMB_FS_RD_ENTRIES ?= 8
 # in case the cache is too small to hold all elements when traversing.
 CFG_RPMB_FS_CACHE_ENTRIES ?= 0
 
+# Print RPMB data frames send to and received from the RPMB device
+CFG_RPMB_FS_DEBUG_DATA ?= n
+
+# Disable RPMB MAC authentication when CFG_RPMB_FS_NO_MAC=y
+CFG_RPMB_FS_NO_MAC ?= n
+
+# Clear RPMB content to start from a empty VFAT at cold boot
+CFG_RPMB_RESET_FAT ?= n
+
+# Use a RPMB key define at build time in tee_rpmb_fs.c, instead of deriving
+# it from the platform HUK.
+CFG_RPMB_TESTKEY ?= n
+
 # Enables RPMB key programming by the TEE, in case the RPMB partition has not
 # been configured yet.
 # !!! Security warning !!!


### PR DESCRIPTION
This series proposes changes regarding RPMB support in OP-TEE.

1st commit ("config: add description for CFG_RPMB_* config switches") is quite obvious. Not really an RFC :)

2nd commit proposes changes to allow OP-TEE Core to be built without secure storage support. Such configuration is not very common but it should be possible IMO for a platform to not embed any secure storage in OP-TEE.

3rd and 4th commits propose 2 ways to address test environments where REE FS secure storage may be wiped when target filesystems are reloaded from scratched (i.e. /data/tee content wiped out) while RPMB FS secure storage is preserved in device and contains REE FS rollback protection data.