### PR TITLE
core: allow configuration without any secure storage

### DIFF
--- a/core/include/tee/tee_svc_storage.h
+++ b/core/include/tee/tee_svc_storage.h
@@ -11,13 +11,6 @@
 #include <tee/tee_fs.h>
 
 /*
- * Returns the appropriate tee_file_operations for the specified storage ID.
- * The value TEE_STORAGE_PRIVATE will select the REE FS if available, otherwise
- * RPMB.
- */
-const struct tee_file_operations *tee_svc_storage_file_ops(uint32_t storage_id);
-
-/*
  * Persistant Object Functions
  */
 TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,

--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -338,8 +338,11 @@ static TEE_Result check_update_version(struct shdr_bootstrap_ta *hdr)
 		.obj_id_len = sizeof(ta_ver_db_obj_id)
 	};
 
-	mutex_lock(&ta_ver_db_mutex);
 	ops = tee_svc_storage_file_ops(TEE_STORAGE_PRIVATE);
+	if (!ops)
+		return TEE_SUCCESS; /* Compiled with no secure storage */
+
+	mutex_lock(&ta_ver_db_mutex);
 
 	res = ops->open(&pobj, NULL, &fh);
 	if (res != TEE_SUCCESS && res != TEE_ERROR_ITEM_NOT_FOUND)

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -24,31 +24,6 @@
 #include <tee/tee_svc_storage.h>
 #include <trace.h>
 
-const struct tee_file_operations *tee_svc_storage_file_ops(uint32_t storage_id)
-{
-
-	switch (storage_id) {
-	case TEE_STORAGE_PRIVATE:
-#if defined(CFG_REE_FS)
-		return &ree_fs_ops;
-#elif defined(CFG_RPMB_FS)
-		return &rpmb_fs_ops;
-#else
-#error At least one filesystem must be enabled.
-#endif
-#ifdef CFG_REE_FS
-	case TEE_STORAGE_PRIVATE_REE:
-		return &ree_fs_ops;
-#endif
-#ifdef CFG_RPMB_FS
-	case TEE_STORAGE_PRIVATE_RPMB:
-		return &rpmb_fs_ops;
-#endif
-	default:
-		return NULL;
-	}
-}
-
 /* Header of GP formated secure storage files */
 struct tee_svc_storage_head {
 	uint32_t attr_size;


### PR DESCRIPTION
Support a configuration with no secure storage (CFG_REE_FS=n and
CFG_RPMB_FS=n). In such a case, user TAs will get error code
TEEC_ERROR_ITEM_NOT_FOUND when trying to access persistent objects.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Co-developed-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
