### PR TITLE
core: fix thread_alloc_and_run() argument passing

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -574,9 +574,9 @@ static void __thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2,
 }
 
 void thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
-			  uint32_t a4 __unused, uint32_t a5 __unused)
+			  uint32_t a4, uint32_t a5)
 {
-	__thread_alloc_and_run(a0, a1, a2, a3, 0, 0, 0, 0,
+	__thread_alloc_and_run(a0, a1, a2, a3, a4, a5, 0, 0,
 			       thread_std_smc_entry);
 }
 


### PR DESCRIPTION
Fix thread_alloc_and_run() to pass all its arguments to
__thread_alloc_and_run().

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
