### PR TITLE
core: Fix memory leaks in sm2 of Mbedtls lib

### DIFF
--- a/lib/libmbedtls/core/sm2-dsa.c
+++ b/lib/libmbedtls/core/sm2-dsa.c
@@ -139,6 +139,7 @@ out:
 	mbedtls_mpi_free(&r);
 	mbedtls_mpi_free(&s);
 	mbedtls_mpi_free(&tmp);
+	mbedtls_ecp_group_free(&grp);
 	return res;
 }
 
@@ -262,5 +263,6 @@ out:
 	mbedtls_mpi_free(&t);
 	mbedtls_mpi_free(&eprime);
 	mbedtls_mpi_free(&R);
+	mbedtls_ecp_group_free(&grp);
 	return res;
 }

--- a/lib/libmbedtls/core/sm2-pke.c
+++ b/lib/libmbedtls/core/sm2-pke.c
@@ -446,5 +446,7 @@ out:
 	mbedtls_ecp_point_free(&x2y2p);
 	mbedtls_ecp_point_free(&PB);
 	mbedtls_ecp_point_free(&C1);
+	mbedtls_ecp_group_free(&grp);
+	mbedtls_mpi_free(&k);
 	return res;
 }


### PR DESCRIPTION
When enable mbedtls in optee-os , xtest run twice will be fail.
Memory leakage exists in three functions.
1. grp and mpi in sm2_mbedtls_pke_encrypt
2. grp in sm2_mbedtls_dsa_sign
3. grp in sm2_mbedtls_dsa_verify

Fixes: c84eee6397bb ("core: add support for SM2 using MBed TLS")
Reviewed-by: Jerome Forissier <jerome@forissier.org>
Signed-off-by: lubing <lubing@eswin.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
