### PR TITLE
drivers: bcm_hwrng: implement crypto_rng_read()

### DIFF
--- a/core/arch/arm/plat-bcm/conf.mk
+++ b/core/arch/arm/plat-bcm/conf.mk
@@ -25,6 +25,7 @@ $(call force,CFG_SP805_WDT,y)
 $(call force,CFG_BCM_HWRNG,y)
 $(call force,CFG_BCM_SOTP,y)
 $(call force,CFG_BCM_GPIO,y)
++CFG_PTA_BCM_HWRNG ?= y
 CFG_BNXT_FW ?= y
 CFG_BCM_ELOG_DUMP ?= y
 endif

--- a/core/arch/arm/plat-bcm/conf.mk
+++ b/core/arch/arm/plat-bcm/conf.mk
@@ -25,7 +25,8 @@ $(call force,CFG_SP805_WDT,y)
 $(call force,CFG_BCM_HWRNG,y)
 $(call force,CFG_BCM_SOTP,y)
 $(call force,CFG_BCM_GPIO,y)
-+CFG_PTA_BCM_HWRNG ?= y
+CFG_PTA_BCM_HWRNG ?= y
+CFG_WITH_SOFTWARE_PRNG = n
 CFG_BNXT_FW ?= y
 CFG_BCM_ELOG_DUMP ?= y
 endif

--- a/core/drivers/bcm_hwrng.c
+++ b/core/drivers/bcm_hwrng.c
@@ -79,7 +79,7 @@ static size_t do_rng_read(void *buf, size_t blen)
 		data.word = io_read32(bcm_hwrng_base +
 				     RNG_FIFO_DATA_OFFSET);
 
-		copy_len = MIN((blen - copied), 4);
+		copy_len = MIN((blen - copied), sizeof(uint32_t));
 		memcpy((uint8_t *)buf + copied, data.bytes, copy_len);
 		copied += copy_len;
 	}

--- a/core/drivers/bcm_hwrng.c
+++ b/core/drivers/bcm_hwrng.c
@@ -48,11 +48,11 @@ static void bcm_hwrng_reset(void)
 			RNG_CTRL_MASK, RNG_CTRL_ENABLE);
 }
 
-static uint32_t do_rng_read(void *buf, ssize_t blen)
+static size_t do_rng_read(void *buf, size_t blen)
 {
 	uint32_t available = 0;
-	ssize_t copied = 0;
-	ssize_t copy_len = 0;
+	size_t copied = 0;
+	size_t copy_len = 0;
 	union {
 		uint32_t word;
 		uint8_t  bytes[4];
@@ -90,18 +90,15 @@ out:
 
 uint32_t bcm_hwrng_read_rng(uint32_t *p_out, uint32_t words_to_read)
 {
-	ssize_t copy_len = (ssize_t)words_to_read << 2;
+	size_t copy_len = words_to_read * sizeof(uint32_t);
 
 	copy_len = do_rng_read((void *)p_out, copy_len);
 
-	return (copy_len >> 2);
+	return copy_len / sizeof(uint32_t);
 }
 
 TEE_Result crypto_rng_read(void *buf, size_t blen)
 {
-	if (!buf)
-		return TEE_ERROR_BAD_PARAMETERS;
-
 	if (do_rng_read(buf, blen) == blen)
 		return TEE_SUCCESS;
 

--- a/core/pta/bcm/sub.mk
+++ b/core/pta/bcm/sub.mk
@@ -1,6 +1,6 @@
 srcs-$(CFG_BNXT_FW) += bnxt.c
 srcs-$(CFG_SP805_WDT) += wdt.c
-srcs-$(CFG_BCM_HWRNG) += hwrng.c
+srcs-$(CFG_PTA_BCM_HWRNG) += hwrng.c
 srcs-$(CFG_BCM_SOTP) += sotp.c
 srcs-$(CFG_BCM_GPIO) += gpio.c
 srcs-$(CFG_BCM_ELOG_DUMP) += elog.c


### PR DESCRIPTION

- Implement weak functions used by crypto tee_svc:
  - crypto_rng_read()
  - hw_get_random_byte()
- Handle unaligned buffer case, HW reg read is 32-bit while interface is byte level.
- CFG_BCM_HWRNG selects both hwrng driver and PTA.
   - Add separate config CFG_PTA_BCM_HWRNG for PTA so that driver can be used with generic crypto framework.
   - Both configs are enabled by default for backward compatibility.
