### PR TITLE
Add support for OP-TEE TA signature stitching during the build process.

### DIFF
--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -5,13 +5,7 @@ link-script-dep$(sm) = $(link-out-dir$(sm))/.ta.ld.d
 SIGN_ENC ?= $(PYTHON3) $(ta-dev-kit-dir$(sm))/scripts/sign_encrypt.py
 TA_SIGN_KEY ?= $(ta-dev-kit-dir$(sm))/keys/default_ta.pem
 
-# In case the TA offline-signing has been performed.
-ifeq ($(CFG_STITCH_TA),y)
-# The signatures directory. The linking process expects <ta-uuid>.sig files in it.
-TA_SIG_DIR ?= signatures
-# The hash and signing algorithm.
-TA_SIGN_ALG ?= TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256
-endif
+CFG_TEE_SIGN_TAS ?= y
 
 ifeq ($(CFG_ENCRYPT_TA),y)
 # Default TA encryption key is a dummy key derived from default
@@ -115,12 +109,8 @@ $(link-out-dir$(sm))/$(user-ta-uuid).ta: \
 			$(link-out-dir$(sm))/$(user-ta-uuid).stripped.elf \
 			$(TA_SIGN_KEY) \
 			$(lastword $(SIGN_ENC))
+ifeq ($(CFG_TEE_SIGN_TAS),y)
 	@$(cmd-echo-silent) '  $$(cmd-echo$(user-ta-uuid)) $$@'
-ifeq ($(CFG_STITCH_TA),y)
-	$(q)$(SIGN_ENC) stitch --key $(TA_PUBLIC_KEY) $$(crypt-args$(user-ta-uuid)) \
-        --uuid $(user-ta-uuid) --sig $(TA_SIG_DIR)/$(user-ta-uuid).sig \
-		--algo $(TA_SIGN_ALG) --in $$< --out $$@
-else
 	$(q)$(SIGN_ENC) --key $(TA_SIGN_KEY) $$(crypt-args$(user-ta-uuid)) \
 		--uuid $(user-ta-uuid) --ta-version $(user-ta-version) \
 		--in $$< --out $$@

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -5,6 +5,8 @@ link-script-dep$(sm) = $(link-out-dir$(sm))/.ta.ld.d
 SIGN_ENC ?= $(PYTHON3) $(ta-dev-kit-dir$(sm))/scripts/sign_encrypt.py
 TA_SIGN_KEY ?= $(ta-dev-kit-dir$(sm))/keys/default_ta.pem
 
+# If set to 'n', the build process will only generate the TA .elf files.
+# It is up to the user to generate the corresponding .ta files afterwards. 
 CFG_TEE_SIGN_TAS ?= y
 
 ifeq ($(CFG_ENCRYPT_TA),y)

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -5,6 +5,14 @@ link-script-dep$(sm) = $(link-out-dir$(sm))/.ta.ld.d
 SIGN_ENC ?= $(PYTHON3) $(ta-dev-kit-dir$(sm))/scripts/sign_encrypt.py
 TA_SIGN_KEY ?= $(ta-dev-kit-dir$(sm))/keys/default_ta.pem
 
+# In case the TA offline-signing has been performed.
+ifeq ($(CFG_STITCH_TA),y)
+# The signatures directory. The linking process expects <ta-uuid>.sig files in it.
+TA_SIG_DIR ?= signatures
+# The hash and signing algorithm.
+TA_SIGN_ALG ?= TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256
+endif
+
 ifeq ($(CFG_ENCRYPT_TA),y)
 # Default TA encryption key is a dummy key derived from default
 # hardware unique key (an array of 16 zero bytes) to demonstrate
@@ -108,9 +116,15 @@ $(link-out-dir$(sm))/$(user-ta-uuid).ta: \
 			$(TA_SIGN_KEY) \
 			$(lastword $(SIGN_ENC))
 	@$(cmd-echo-silent) '  $$(cmd-echo$(user-ta-uuid)) $$@'
+ifeq ($(CFG_STITCH_TA),y)
+	$(q)$(SIGN_ENC) stitch --key $(TA_PUBLIC_KEY) $$(crypt-args$(user-ta-uuid)) \
+        --uuid $(user-ta-uuid) --sig $(TA_SIG_DIR)/$(user-ta-uuid).sig \
+		--algo $(TA_SIGN_ALG) --in $$< --out $$@
+else
 	$(q)$(SIGN_ENC) --key $(TA_SIGN_KEY) $$(crypt-args$(user-ta-uuid)) \
 		--uuid $(user-ta-uuid) --ta-version $(user-ta-version) \
 		--in $$< --out $$@
+endif
 endef
 
 $(eval $(call gen-link-t))


### PR DESCRIPTION
Signed-off-by: Aleksandar Nikolic <aleksandar.nikolic@mixed-mode.de>

The current build process does not allow stitching of the signature to the OP-TEE TA (e.g. trusted_keys), but only signing. The patch allows the user to sign the OP-TEE TAs (or more accurately the .stripped.elf files) offline and stitch the generated signature during the OP-TEE build process.

**Usage**

The following environment variables are to be defined by the user:

```
CFG_STITCH_TA=y     # Perform the signature stitching instead of TA signing.
TA_PUBLIC_KEY       # Path to the public key used for signature verification. Defaults to TA_SIGN_KEY.
TA_SIG_DIR          # Path to the directory where the signatures are. Defaults to ./signatures. The stitching process expects the signature files to be named as: <ta-uuid>.sig
TA_SIGN_ALG         # Hash and signing algorithm. Defaults to TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256 (same as in sign_encrypt.py).
```

**Example in Yocto**

```
EXTRA_OEMAKE = " \
    ...
    CFG_STITCH_TA=y \
    TA_PUBLIC_KEY=<path to the public key> \
    TA_SIG_DIR=<my-custom-sig-dir> \
    TA_SIGN_ALG=TEE_ALG_RSASSA_PKCS1_V1_5_SHA256 \
    ...
"
```

**Additional improvement**

With this patch the OPTEE build process expects the signature files to be named as: `<ta-uuid>.sig`. In my opinion this shouldn't be an issue for the user. However, if someone does not agree with this, I could adjust the patch so the user can give the list of signatures to be used during the stitching process (this makes things complicated imho)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
