### PR TITLE
FF-A add memory sharing for SPs

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -79,6 +79,9 @@
 /* Memory access permissions: Read-write */
 #define FFA_MEM_ACC_RW			U(0x2)
 
+/* Memory access permissions: executable*/
+#define FFA_MEM_ACC_EXE			BIT(3)
+
 /* Clear memory before mapping in receiver */
 #define FFA_MEMORY_REGION_FLAG_CLEAR		BIT(0)
 /* Relayer may time slice this operation */

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -80,6 +80,8 @@ TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
 
 TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id);
 struct ts_session *sp_get_active(void);
+vaddr_t sp_map_shared_va(struct sp_session *s, struct sp_shared_mem *ssm,
+			 uint32_t perm);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct embedded_ts)

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -41,6 +41,7 @@ struct sp_session {
 	struct sp_ffa_init_info *info;
 	unsigned int spinlock;
 	TAILQ_ENTRY(sp_session) link;
+	SLIST_HEAD(sp_mem_head_t, sp_shared_mem) mem_head;
 };
 
 struct sp_ctx {
@@ -78,6 +79,7 @@ TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
 				  size_t *elements);
 
 TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id);
+struct ts_session *sp_get_active(void);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct embedded_ts)

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -7,6 +7,7 @@
 
 #include <assert.h>
 #include <config.h>
+#include <ffa.h>
 #include <kernel/embedded_ts.h>
 #include <kernel/thread_spmc.h>
 #include <kernel/user_mode_ctx_struct.h>
@@ -73,6 +74,10 @@ static inline struct sp_ctx *to_sp_ctx(struct ts_ctx *ctx)
 
 struct sp_session *sp_get_session(uint32_t session_id);
 TEE_Result sp_enter(struct thread_smc_args *args, struct sp_session *sp);
+TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
+				  size_t *elements);
+
+TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct embedded_ts)

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -82,6 +82,7 @@ TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id);
 struct ts_session *sp_get_active(void);
 vaddr_t sp_map_shared_va(struct sp_session *s, struct sp_shared_mem *ssm,
 			 uint32_t perm);
+TEE_Result sp_unmap_regions(struct sp_session *s, struct sp_shared_mem *m);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct embedded_ts)

--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -17,6 +17,23 @@
 void spmc_sp_thread_entry(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
 void spmc_sp_msg_handler(struct thread_smc_args *args,
 			 struct sp_session *caller_sp);
+TEE_Result spmc_sp_add_share(struct ffa_mem_transaction *input_descr,
+			     uint64_t global_handle, size_t blen);
+
+struct sp_shared_mem {
+	size_t counter;
+	struct shared_mem *s_mem;
+	struct ffa_mem_access *access_descr;
+	uint16_t endpoint_id;
+	SLIST_ENTRY(sp_shared_mem) link;
+};
+
+struct shared_mem {
+	TAILQ_ENTRY(shared_mem) link;
+	uint16_t owner_id;
+	struct ffa_mem_transaction *mem_descr;
+	SLIST_HEAD(mem_head_t, sp_shared_mem) sp_head;
+};
 
 #ifdef CFG_SECURE_PARTITION
 void spmc_sp_start_thread(struct thread_smc_args *args);

--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -26,6 +26,7 @@ struct sp_shared_mem {
 	struct ffa_mem_access *access_descr;
 	uint16_t endpoint_id;
 	SLIST_ENTRY(sp_shared_mem) link;
+	bool zero_flag;
 };
 
 struct shared_mem {
@@ -42,5 +43,4 @@ static inline void spmc_sp_start_thread(struct thread_smc_args *args __unused)
 {
 }
 #endif
-
 #endif /* __KERNEL_SPMC_SP_HANDLER_H */

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -32,6 +32,7 @@ void spmc_fill_partition_entry(struct ffa_partition_info *fpi,
 			       uint16_t endpoint_id);
 void thread_spmc_handle_mem_share(struct thread_smc_args *args,
 				  struct ffa_rxtx *rxtx);
+void thread_spmc_handle_mem_reclaim(struct thread_smc_args *args);
 
 #if defined(CFG_CORE_SEL1_SPMC)
 uint16_t spmc_get_id(void);

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -30,4 +30,10 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 				    struct ffa_rxtx *rxtx);
 void spmc_fill_partition_entry(struct ffa_partition_info *fpi,
 			       uint16_t endpoint_id);
+void thread_spmc_handle_mem_share(struct thread_smc_args *args,
+				  struct ffa_rxtx *rxtx);
+
+#if defined(CFG_CORE_SEL1_SPMC)
+uint16_t spmc_get_id(void);
+#endif
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -5,6 +5,7 @@
 #ifndef __KERNEL_THREAD_SPMC_H
 #define __KERNEL_THREAD_SPMC_H
 
+#include <ffa.h>
 #include <kernel/thread.h>
 
 /* FF-A endpoint base ID when OP-TEE is used as a S-EL1 endpoint */
@@ -25,4 +26,8 @@ void spmc_handle_version(struct thread_smc_args *args);
 
 void spmc_set_args(struct thread_smc_args *args, uint32_t fid, uint32_t src_dst,
 		   uint32_t w2, uint32_t w3, uint32_t w4, uint32_t w5);
+void spmc_handle_partition_info_get(struct thread_smc_args *args,
+				    struct ffa_rxtx *rxtx);
+void spmc_fill_partition_entry(struct ffa_partition_info *fpi,
+			       uint16_t endpoint_id);
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -102,7 +102,7 @@
  * MEM_AREA_EXT_DT:   Memory loads external device tree
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_SHM_VASPACE: Virtual memory space for dynamic shared memory buffers
- * MEM_AREA_TA_VASPACE: TA va space, only used with phys_to_virt()
+ * MEM_AREA_TS_VASPACE: TS va space, only used with phys_to_virt()
  * MEM_AREA_DDR_OVERALL: Overall DDR address range, candidate to dynamic shm.
  * MEM_AREA_SEC_RAM_OVERALL: Whole secure RAM
  * MEM_AREA_MAXTYPE:  lower invalid 'type' value
@@ -126,7 +126,7 @@ enum teecore_memtypes {
 	MEM_AREA_EXT_DT,
 	MEM_AREA_RES_VASPACE,
 	MEM_AREA_SHM_VASPACE,
-	MEM_AREA_TA_VASPACE,
+	MEM_AREA_TS_VASPACE,
 	MEM_AREA_PAGER_VASPACE,
 	MEM_AREA_SDP_MEM,
 	MEM_AREA_DDR_OVERALL,
@@ -155,7 +155,7 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 		[MEM_AREA_EXT_DT] = "EXT_DT",
 		[MEM_AREA_RES_VASPACE] = "RES_VASPACE",
 		[MEM_AREA_SHM_VASPACE] = "SHM_VASPACE",
-		[MEM_AREA_TA_VASPACE] = "TA_VASPACE",
+		[MEM_AREA_TS_VASPACE] = "TS_VASPACE",
 		[MEM_AREA_PAGER_VASPACE] = "PAGER_VASPACE",
 		[MEM_AREA_SDP_MEM] = "SDP_MEM",
 		[MEM_AREA_DDR_OVERALL] = "DDR_OVERALL",

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -56,6 +56,20 @@ static void set_sp_ctx_ops(struct ts_ctx *ctx)
 	ctx->ops = _sp_ops;
 }
 
+struct ts_session *sp_get_active(void)
+{
+	struct ts_session *ts = 0;
+
+	/*
+	 * Make sure that ts_get_current_session_may_fail() won't print an
+	 * error.
+	 */
+	if (thread_get_id_may_fail() >= 0)
+		ts = ts_get_current_session_may_fail();
+
+	return ts;
+}
+
 TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id)
 {
 	struct sp_session *s = NULL;
@@ -248,6 +262,9 @@ static TEE_Result sp_open_session(struct sp_session **sess,
 	s->state = sp_idle;
 	s->caller_id = 0;
 	sp_init_set_registers(ctx);
+
+	SLIST_INIT(&s->mem_head);
+
 	ts_pop_current_session();
 
 	return TEE_SUCCESS;

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -56,6 +56,23 @@ static void set_sp_ctx_ops(struct ts_ctx *ctx)
 	ctx->ops = _sp_ops;
 }
 
+TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id)
+{
+	struct sp_session *s = NULL;
+
+	TAILQ_FOREACH(s, &open_sp_sessions, link) {
+		if (!memcmp(&s->ts_sess.ctx->uuid, uuid, sizeof(*uuid))) {
+			if (s->state == sp_dead)
+				return TEE_ERROR_TARGET_DEAD;
+
+			*session_id  = s->endpoint_id;
+			return TEE_SUCCESS;
+		}
+	}
+
+	return TEE_ERROR_ITEM_NOT_FOUND;
+}
+
 struct sp_session *sp_get_session(uint32_t session_id)
 {
 	struct sp_session *s = NULL;
@@ -66,6 +83,32 @@ struct sp_session *sp_get_session(uint32_t session_id)
 	}
 
 	return NULL;
+}
+
+TEE_Result sp_get_partitions_info(struct ffa_partition_info *fpi,
+				  size_t *elements)
+{
+	size_t in_elements = *elements;
+	struct sp_session *s = NULL;
+	uint32_t count = 0;
+
+	TAILQ_FOREACH(s, &open_sp_sessions, link) {
+		if (count < in_elements) {
+			if (s->state != sp_dead) {
+				spmc_fill_partition_entry(fpi, s->endpoint_id);
+				fpi++;
+			}
+		}
+		if (s->state != sp_dead)
+			count++;
+	}
+
+	if (count > in_elements) {
+		*elements = count;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	return TEE_SUCCESS;
 }
 
 static void sp_init_info(struct sp_ctx *ctx, struct thread_smc_args *args)

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -267,11 +267,19 @@ void spmc_sp_msg_handler(struct thread_smc_args *args,
 			args->a0 = FFA_SUCCESS_32;
 			args->a2 = caller_sp->endpoint_id;
 			sp_enter(args, caller_sp);
+			break;
 		case FFA_VERSION:
 			spmc_handle_version(args);
 			sp_enter(args, caller_sp);
+			break;
 		case FFA_FEATURES:
 			handle_features(args);
+			sp_enter(args, caller_sp);
+			break;
+		case FFA_PARTITION_INFO_GET:
+			ts_push_current_session(&caller_sp->ts_sess);
+			spmc_handle_partition_info_get(args, &caller_sp->rxtx);
+			ts_pop_current_session();
 			sp_enter(args, caller_sp);
 			break;
 		default:

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -929,7 +929,7 @@ out:
 	spmc_set_args(args, ret_fid, ret_w1, ret_w2, ret_w3, 0, 0);
 }
 
-static void handle_mem_reclaim(struct thread_smc_args *args)
+void thread_spmc_handle_mem_reclaim(struct thread_smc_args *args)
 {
 	uint32_t ret_val = FFA_INVALID_PARAMETERS;
 	uint32_t ret_fid = FFA_ERROR;
@@ -1011,7 +1011,7 @@ void thread_spmc_msg_recv(struct thread_smc_args *args)
 		thread_spmc_handle_mem_share(args, &nw_rxtx);
 		break;
 	case FFA_MEM_RECLAIM:
-		handle_mem_reclaim(args);
+		thread_spmc_handle_mem_reclaim(args);
 		break;
 	case FFA_MEM_FRAG_TX:
 		handle_mem_frag_tx(args, &nw_rxtx);

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -505,33 +505,55 @@ static void handle_blocking_call(struct thread_smc_args *args)
 
 #if defined(CFG_CORE_SEL1_SPMC)
 static int get_acc_perms(struct ffa_mem_access *mem_acc,
-			 unsigned int num_mem_accs, uint8_t *acc_perms,
-			 unsigned int *region_offs)
+			 unsigned int num_mem_accs, unsigned int *region_offs)
 {
 	unsigned int n = 0;
+	const uint8_t exp_mem_acc_perm = FFA_MEM_ACC_RW;
+	bool access = false;
 
+	/*
+	 * The spec defines that all of the offsets should be equal. Check if
+	 * all elements are correct and take the last one.
+	 */
 	for (n = 0; n < num_mem_accs; n++) {
 		struct ffa_mem_access_perm *descr = &mem_acc[n].access_perm;
 
+		 /*
+		  * Make sure that the access rights for the OP-TEE SP are
+		  * correct.
+		  */
+
 		if (READ_ONCE(descr->endpoint_id) == my_endpoint_id) {
-			*acc_perms = READ_ONCE(descr->perm);
+			if (READ_ONCE(descr->perm) != exp_mem_acc_perm)
+				return FFA_INVALID_PARAMETERS;
+
 			*region_offs = READ_ONCE(mem_acc[n].region_offs);
-			return 0;
+			access = true;
+#ifdef CFG_SECURE_PARTITION
+		} else if (sp_get_session(descr->endpoint_id)) {
+			*region_offs = READ_ONCE(mem_acc[n].region_offs);
+			access = true;
+#endif
+		} else {
+			EMSG("Incorrect endpoint in memory share");
+			return FFA_INVALID_PARAMETERS;
 		}
 	}
 
-	return FFA_INVALID_PARAMETERS;
+	if (!access)
+		return FFA_INVALID_PARAMETERS;
+	else
+		return 0;
+
 }
 
 static int mem_share_init(void *buf, size_t blen, unsigned int *page_count,
 			  unsigned int *region_count, size_t *addr_range_offs)
 {
 	const uint8_t exp_mem_reg_attr = FFA_NORMAL_MEM_REG_ATTR;
-	const uint8_t exp_mem_acc_perm = FFA_MEM_ACC_RW;
 	struct ffa_mem_region *region_descr = NULL;
 	struct ffa_mem_transaction *descr = NULL;
 	unsigned int num_mem_accs = 0;
-	uint8_t mem_acc_perm = 0;
 	unsigned int region_descr_offs = 0;
 	size_t n = 0;
 
@@ -552,8 +574,7 @@ static int mem_share_init(void *buf, size_t blen, unsigned int *page_count,
 
 	/* Check that the access permissions matches what's expected */
 	if (get_acc_perms(descr->mem_access_array,
-			  num_mem_accs, &mem_acc_perm, &region_descr_offs) ||
-	    mem_acc_perm != exp_mem_acc_perm)
+			  num_mem_accs, &region_descr_offs))
 		return FFA_INVALID_PARAMETERS;
 
 	/* Check that the Composite memory region descriptor fits */
@@ -589,10 +610,22 @@ static int add_mem_share_helper(struct mem_share_state *s, void *buf,
 
 	for (n = 0; n < region_count; n++) {
 		unsigned int page_count = READ_ONCE(arange[n].page_count);
-		uint64_t addr = READ_ONCE(arange[n].address);
+		uint64_t *addr = &arange[n].address;
 
+#if defined(CFG_SECURE_PARTITION)
+		/*
+		 * The address is virtual if the share comes for a SP, update
+		 * the value inside the buffer.
+		 */
+		if (sp_get_active())
+			*addr = virt_to_phys((void *)*addr);
+#endif
+		if (*addr & SMALL_PAGE_MASK) {
+			EMSG("FF-A: Trying to map unaligned memory!");
+			return FFA_INVALID_PARAMETERS;
+		}
 		if (mobj_ffa_add_pages_at(s->mf, &s->current_page_idx,
-					  addr, page_count))
+					  *addr, page_count))
 			return FFA_INVALID_PARAMETERS;
 	}
 
@@ -639,6 +672,7 @@ static int add_mem_share(tee_mm_entry_t *mm, void *buf, size_t blen,
 	struct mem_share_state share = { };
 	size_t addr_range_offs = 0;
 	size_t n = 0;
+	enum buf_is_attr attr = CORE_MEM_NON_SEC;
 
 	if (flen > blen)
 		return FFA_INVALID_PARAMETERS;
@@ -653,7 +687,15 @@ static int add_mem_share(tee_mm_entry_t *mm, void *buf, size_t blen,
 	    ADD_OVERFLOW(n, addr_range_offs, &n) || n > blen)
 		return FFA_INVALID_PARAMETERS;
 
-	share.mf = mobj_ffa_sel1_spmc_new(share.page_count);
+#if defined(CFG_SECURE_PARTITION)
+	/*
+	 * Map in none secure memory when coming from the Normal World,
+	 * Map in secure memory when coming from a SP.
+	 */
+	if (sp_get_active())
+		attr = CORE_MEM_SEC;
+#endif
+	share.mf = mobj_ffa_sel1_spmc_new(share.page_count, attr);
 	if (!share.mf)
 		return FFA_NO_MEMORY;
 
@@ -690,7 +732,15 @@ static int add_mem_share(tee_mm_entry_t *mm, void *buf, size_t blen,
 	}
 
 	*global_handle = mobj_ffa_push_to_inactive(share.mf);
+#ifdef CFG_SECURE_PARTITION
+	rc = spmc_sp_add_share((struct ffa_mem_transaction *)buf,
+			       *global_handle, blen);
 
+	if (rc) {
+		mobj_ffa_sel1_spmc_reclaim(*global_handle);
+		return rc;
+	}
+#endif
 	return 0;
 err:
 	mobj_ffa_sel1_spmc_delete(share.mf);
@@ -757,8 +807,8 @@ static int handle_mem_share_rxbuf(size_t blen, size_t flen,
 	return rc;
 }
 
-static void handle_mem_share(struct thread_smc_args *args,
-			     struct ffa_rxtx *rxtx)
+void thread_spmc_handle_mem_share(struct thread_smc_args *args,
+				  struct ffa_rxtx *rxtx)
 {
 	uint32_t ret_w1 = 0;
 	uint32_t ret_w2 = FFA_INVALID_PARAMETERS;
@@ -958,7 +1008,7 @@ void thread_spmc_msg_recv(struct thread_smc_args *args)
 	case FFA_MEM_SHARE_64:
 #endif
 	case FFA_MEM_SHARE_32:
-		handle_mem_share(args, &nw_rxtx);
+		thread_spmc_handle_mem_share(args, &nw_rxtx);
 		break;
 	case FFA_MEM_RECLAIM:
 		handle_mem_reclaim(args);
@@ -1462,6 +1512,11 @@ static TEE_Result spmc_init(void)
 #endif /*CFG_CORE_SEL2_SPMC*/
 
 #if defined(CFG_CORE_SEL1_SPMC)
+uint16_t spmc_get_id(void)
+{
+	return my_endpoint_id;
+}
+
 static TEE_Result spmc_init(void)
 {
 	my_endpoint_id = SPMC_ENDPOINT_ID;

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -397,7 +397,7 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 		case MEM_AREA_EXT_DT:
 		case MEM_AREA_RES_VASPACE:
 		case MEM_AREA_SHM_VASPACE:
-		case MEM_AREA_TA_VASPACE:
+		case MEM_AREA_TS_VASPACE:
 		case MEM_AREA_PAGER_VASPACE:
 			break;
 		default:
@@ -2197,7 +2197,7 @@ static void check_va_matches_pa(paddr_t pa __unused, void *va __unused)
 }
 #endif
 
-static void *phys_to_virt_ta_vaspace(paddr_t pa)
+static void *phys_to_virt_ts_vaspace(paddr_t pa)
 {
 	if (!core_mmu_user_mapping_is_active())
 		return NULL;
@@ -2236,8 +2236,8 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m)
 	void *va = NULL;
 
 	switch (m) {
-	case MEM_AREA_TA_VASPACE:
-		va = phys_to_virt_ta_vaspace(pa);
+	case MEM_AREA_TS_VASPACE:
+		va = phys_to_virt_ts_vaspace(pa);
 		break;
 	case MEM_AREA_TEE_RAM:
 	case MEM_AREA_TEE_RAM_RX:

--- a/core/include/mm/mobj.h
+++ b/core/include/mm/mobj.h
@@ -218,7 +218,8 @@ TEE_Result mobj_ffa_unregister_by_cookie(uint64_t cookie);
 
 /* Functions for SPMC */
 #ifdef CFG_CORE_SEL1_SPMC
-struct mobj_ffa *mobj_ffa_sel1_spmc_new(unsigned int num_pages);
+struct mobj_ffa *mobj_ffa_sel1_spmc_new(unsigned int num_pages,
+					enum buf_is_attr attr);
 void mobj_ffa_sel1_spmc_delete(struct mobj_ffa *mobj);
 TEE_Result mobj_ffa_sel1_spmc_reclaim(uint64_t cookie);
 #endif

--- a/core/pta/tests/invoke.c
+++ b/core/pta/tests/invoke.c
@@ -46,7 +46,7 @@ static int test_v2p2v(void *va)
 		return 1;
 
 	if (to_ta_session(session)->clnt_id.login == TEE_LOGIN_TRUSTED_APP) {
-		v = phys_to_virt(p, MEM_AREA_TA_VASPACE);
+		v = phys_to_virt(p, MEM_AREA_TS_VASPACE);
 	} else {
 		v = phys_to_virt(p, MEM_AREA_NSEC_SHM);
 		if (!v)


### PR DESCRIPTION
FFA_MEM_SHARE was only supported to share for the Normal World to the endpoint. This PR add support to share a memory region from the Normal World with a SP or from a SP to another SP.

The following features are not supported and will be added later:
-Ownership is not tracked yet. The shared memory region is mapped in the SPs address space. The region is kept in the address space of the calling SP. Currently we still allow the same memory region to be shared again to any other endpoint both from the destination and the source endpoint. We don't keep track of who is the owner of the region or if the region is shared or exclusive.
-Memory region attributes usage are not supported. Currently all shares have the cache as TEE_MATTR_CACHE_CACHED
-When using FFA_MEM_RETRIEVE_REQ, the Address field of the constituent memory region descriptor is ignored. The regions will be mapped to virtual addresses assigned by the SPMC. 
-The memory management interfaces only support the use of the rxtx buffers when being called from a SP. The address parameter is not supported.

core: Add FFA_PARTITION_INFO will be removed when [#4556](https://github.com/OP-TEE/optee_os/pull/4556l) is merged.

Travis fails cause of 2 longer print statements on core/arch/arm/kernel/spmc_sp_handler.c:355 and on core/arch/arm/kernel/spmc_sp_handler.c:354

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
