### PR TITLE
core: pager: fix compiler warning with Clang

### DIFF
--- a/core/mm/sub.mk
+++ b/core/mm/sub.mk
@@ -1,4 +1,5 @@
 srcs-y += mobj.c
 srcs-y += fobj.c
+cflags-fobj.c-$(CFG_CORE_PAGE_TAG_AND_IV) := -Wno-missing-noreturn
 srcs-y += file.c
 srcs-y += vm.c


### PR DESCRIPTION
Function rwp_unpaged_iv_free() is reduced to a call to panic() when
CFG_WITH_PAGER=y and CFG_CORE_PAGE_TAG_AND_IV=y. In this case, Clang 12
suggests a noreturn attribute:

 $ make -s CFG_WITH_PAGER=y COMPILER=clang
 core/mm/fobj.c:322:1: warning: function 'rwp_unpaged_iv_free' could be
 declared with attribute 'noreturn' [-Wmissing-noreturn]
 {
 ^
 1 warning generated.

However the attribute cannot be applied since it would be inappropriate
when CFG_CORE_PAGE_TAG_AND_IV != y. Therefore, disable the warning for
the file core/mm/fobj.c when the problematic configuration is enabled.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
