### PR TITLE
FF-A: secondary core init for FVP

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2018-2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2021, Arm Limited. All rights reserved.
  */
 
 #ifndef __FFA_H
@@ -69,6 +69,7 @@
 #define FFA_MEM_RECLAIM			U(0x84000077)
 #define FFA_MEM_FRAG_RX			U(0x8400007A)
 #define FFA_MEM_FRAG_TX			U(0x8400007B)
+#define FFA_SECONDARY_EP_REGISTER_64	U(0xC4000084)
 
 /* Special value for traffic targeted to the Hypervisor or SPM */
 #define FFA_TARGET_INFO_MBZ		U(0x0)

--- a/core/arch/arm/include/kernel/boot.h
+++ b/core/arch/arm/include/kernel/boot.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015-2020, Linaro Limited
+ * Copyright (c) 2021, Arm Limited
  */
 #ifndef __KERNEL_BOOT_H
 #define __KERNEL_BOOT_H
@@ -85,6 +86,6 @@ void *get_external_dt(void);
 
 unsigned long get_aslr_seed(void *fdt);
 
-void ffa_secondary_cpu_boot_req(vaddr_t secondary_ep, uint64_t cookie);
+void ffa_secondary_cpu_ep_register(vaddr_t secondary_ep);
 
 #endif /* __KERNEL_BOOT_H */

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2021, Arm Limited
  */
 
 #include <arm32_macros.S>
@@ -578,7 +579,7 @@ shadow_stack_access_ok:
 	 */
 	ldr	r1, boot_mmu_config + CORE_MMU_CONFIG_LOAD_OFFSET
 	sub	r0, r0, r1
-	bl	ffa_secondary_cpu_boot_req
+	bl	ffa_secondary_cpu_ep_register
 	b	thread_ffa_msg_wait
 #else /* CFG_CORE_FFA */
 

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2021, Arm Limited
  */
 
 #include <platform_config.h>
@@ -257,7 +258,7 @@ clear_nex_bss:
 	 */
 	ldr	x1, boot_mmu_config + CORE_MMU_CONFIG_LOAD_OFFSET
 	sub	x0, x0, x1
-	bl	ffa_secondary_cpu_boot_req
+	bl	ffa_secondary_cpu_ep_register
 	b	thread_ffa_msg_wait
 #else
 	/*

--- a/core/arch/arm/plat-vexpress/fvp_spmc_pm.c
+++ b/core/arch/arm/plat-vexpress/fvp_spmc_pm.c
@@ -1,89 +1,27 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2019, Arm Limited
+ * Copyright (c) 2019-2021, Arm Limited
  */
 
-#include <arm.h>
 #include <ffa.h>
-#include <initcall.h>
-#include <keep.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
-#include <kernel/misc.h>
 #include <kernel/panic.h>
-#include <mm/core_memprot.h>
-#include <mm/core_mmu.h>
-#include <platform_config.h>
-#include <sm/psci.h>
-#include <stdint.h>
-#include <string.h>
-#include <trace.h>
+#include <kernel/thread.h>
 
-/*
- * Lookup table of core and cluster affinities on the FVP. In the absence of a
- * DT that provides the same information, this table is used to initialise
- * OP-TEE on secondary cores.
- */
-static const uint64_t core_clus_aff_array[] = {
-	0x0000,		/* Cluster 0 Cpu 0 */
-	0x0001,		/* Cluster 0 Cpu 1 */
-	0x0002,		/* Cluster 0 Cpu 2 */
-	0x0003,		/* Cluster 0 Cpu 3 */
-#ifdef CFG_CORE_SEL2_SPMC
-	0x0004,		/* Cluster 1 Cpu 0 */
-	0x0005,		/* Cluster 1 Cpu 1 */
-	0x0006,		/* Cluster 1 Cpu 2 */
-	0x0007,		/* Cluster 1 Cpu 3 */
-#else
-	0x0100,		/* Cluster 1 Cpu 0 */
-	0x0101,		/* Cluster 1 Cpu 1 */
-	0x0102,		/* Cluster 1 Cpu 2 */
-	0x0103,		/* Cluster 1 Cpu 3 */
-#endif
-};
-
-static uint32_t get_cpu_on_fid(void)
+void ffa_secondary_cpu_ep_register(vaddr_t secondary_ep)
 {
-#ifdef ARM64
-	return PSCI_CPU_ON_SMC64;
-#endif
-#ifdef ARM32
-	return PSCI_CPU_ON;
-#endif
-}
+	unsigned long ret = 0;
 
-void ffa_secondary_cpu_boot_req(vaddr_t secondary_ep, uint64_t cookie)
-{
-	unsigned long mpidr = read_mpidr();
-	unsigned int aff_shift = 0;
-	unsigned long a1 = 0;
-	unsigned int cnt = 0;
+	/*
+	 * FFA_SECONDARY_EP_REGISTER_64 is handled by the SPMD if called by an
+	 * S-EL1 SPMC at secure physical FF-A instance.
+	 * It is handled by an S-EL2 SPMC if called by a SP at secure virtual
+	 * FF-A instance.
+	 */
+	ret = thread_smc(FFA_SECONDARY_EP_REGISTER_64, secondary_ep, 0, 0);
 
-	if (mpidr & MPIDR_MT_MASK)
-		aff_shift = MPIDR_CLUSTER_SHIFT;
-
-	for (cnt = 0; cnt < ARRAY_SIZE(core_clus_aff_array); cnt++) {
-		int32_t ret = 0;
-
-		/* Clear out the affinity fields until level 2 */
-		a1 = mpidr & ~(unsigned long)MPIDR_AARCH32_AFF_MASK;
-
-		/* Create an mpidr from core_clus_aff_array */
-		a1 |= core_clus_aff_array[cnt] << aff_shift;
-
-		/* Ignore current cpu */
-		if (a1 == mpidr)
-			continue;
-
-		DMSG("PSCI_CPU_ON op on mpidr 0x%lx", a1);
-
-		/* Invoke the PSCI_CPU_ON function */
-		ret = thread_smc(get_cpu_on_fid(), a1, secondary_ep, cookie);
-
-		if (ret != PSCI_RET_SUCCESS)
-			EMSG("PSCI_CPU_ON op on mpidr 0x%lx failed %"PRId32,
-			     a1, ret);
-		else
-			DMSG("PSCI_CPU_ON op on mpidr 0x%lx done", a1);
+	if (ret != FFA_SUCCESS_64) {
+		EMSG("FFA_SECONDARY_EP_REGISTER_64 ret %ld", ret);
+		panic();
 	}
 }


### PR DESCRIPTION
Replace the non-standard secondary core init mechanism on FVP platform.
Depends on TF-A v2.5, related PR: https://github.com/OP-TEE/manifest/pull/183