### PR TITLE
mem_usage.py: consider all allocatable sections

### DIFF
--- a/scripts/mem_usage.py
+++ b/scripts/mem_usage.py
@@ -118,8 +118,7 @@ def main():
                  flags) = words[:8]
             except BaseException:
                 continue
-            if (flags == 'AX' or flags == 'WA' or flags == 'A' or
-                    flags == 'AL'):
+            if ('A' in flags):
                 sects.append({'name': name, 'addr': addr,
                               'offs': offs, 'size': size})
     first_addr = None


### PR DESCRIPTION
All allocatable sections end up using memory when the TEE binary is
loaded. Therefore the 'A' (allocatable) flag in the readelf output is
all that matters when gathering memory usage data using mem_usage.py.
The hardcoded combinations that are currently hardcoded in the script
('AX', 'WA', 'A', 'AL') are fragile and need to be replaced. For
example, with COMPILER=clang many sections have the 'W' flag set.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
