### PR TITLE
core: pager: fix increment calculation in tee_pager_set_um_region_attr()

### DIFF
--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -839,6 +839,7 @@ static void split_region(struct vm_paged_region_head *regions,
 	uint32_t exceptions = pager_lock_check_stack(64);
 	size_t diff = va - reg->base;
 	size_t r2_pgt_count = 0;
+	size_t reg_pgt_count = 0;
 	size_t n0 = 0;
 	size_t n = 0;
 
@@ -851,8 +852,9 @@ static void split_region(struct vm_paged_region_head *regions,
 	r2->flags = reg->flags;
 
 	r2_pgt_count = get_pgt_count(r2->base, r2->size);
-	n0 = get_pgt_count(reg->base, reg->size) - r2_pgt_count;
-	for (n = n0; n < r2_pgt_count; n++)
+	reg_pgt_count = get_pgt_count(reg->base, reg->size);
+	n0 = reg_pgt_count - r2_pgt_count;
+	for (n = n0; n < reg_pgt_count; n++)
 		r2->pgt_array[n - n0] = reg->pgt_array[n];
 	reg->size = diff;
 

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -1102,11 +1102,11 @@ bool tee_pager_set_um_region_attr(struct user_mode_ctx *uctx, vaddr_t base,
 	exceptions = pager_lock_check_stack(SMALL_PAGE_SIZE);
 
 	while (s) {
-		s2 = MIN(CORE_MMU_PGDIR_SIZE - (b & CORE_MMU_PGDIR_MASK), s);
-		if (!reg || reg->base != b || reg->size != s2) {
+		if (!reg) {
 			ret = false;
 			goto out;
 		}
+		s2 = MIN(reg->size, s);
 		b += s2;
 		s -= s2;
 

--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -832,8 +832,7 @@ TEE_Result tee_pager_add_um_region(struct user_mode_ctx *uctx, vaddr_t base,
 	return TEE_SUCCESS;
 }
 
-static void split_region(struct vm_paged_region_head *regions,
-			 struct vm_paged_region *reg,
+static void split_region(struct vm_paged_region *reg,
 			 struct vm_paged_region *r2, vaddr_t va)
 {
 	uint32_t exceptions = pager_lock_check_stack(64);
@@ -858,7 +857,7 @@ static void split_region(struct vm_paged_region_head *regions,
 		r2->pgt_array[n - n0] = reg->pgt_array[n];
 	reg->size = diff;
 
-	TAILQ_INSERT_AFTER(regions, reg, r2, link);
+	TAILQ_INSERT_BEFORE(reg, r2, link);
 	TAILQ_INSERT_AFTER(&reg->fobj->regions, reg, r2, fobj_link);
 
 	pager_unlock(exceptions);
@@ -882,7 +881,7 @@ TEE_Result tee_pager_split_um_region(struct user_mode_ctx *uctx, vaddr_t va)
 			r2 = alloc_region(va, reg->size - diff);
 			if (!r2)
 				return TEE_ERROR_OUT_OF_MEMORY;
-			split_region(uctx->regions, reg, r2, va);
+			split_region(reg, r2, va);
 			return TEE_SUCCESS;
 		}
 	}


### PR DESCRIPTION
With the introduction of the commit referred below may a paged region
span multiple translation tables, but tee_pager_set_um_region_attr()
wasn't updated to handle this. So fix this by by accurately calculate
the increment in the main loop of that function.

Fixes: 4a3f6ad054d4 ("core: pager: let struct tee_pager_area span multiple translation tables")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
