### PR TITLE
tee_rpmb_fs: Adding offset to memref to ensure 32-bit aligment

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -211,6 +211,9 @@ struct rpmb_req {
 	/* uint8_t data[]; REMOVED! */
 };
 
+#define RPMB_REQ_MEMREF_OFFSET \
+	(ROUNDUP(sizeof(struct rpmb_req), 4) - sizeof(struct rpmb_req))
+
 #define TEE_RPMB_REQ_DATA(req) \
 		((void *)((struct rpmb_req *)(req) + 1))
 
@@ -453,6 +456,8 @@ static TEE_Result tee_rpmb_alloc(size_t req_size, size_t resp_size,
 		goto out;
 	}
 
+	*req = (uint8_t *)*req + RPMB_REQ_MEMREF_OFFSET;
+
 	mem->req_size = req_size;
 	mem->resp_size = resp_size;
 
@@ -465,8 +470,8 @@ out:
 static TEE_Result tee_rpmb_invoke(struct tee_rpmb_mem *mem)
 {
 	struct thread_param params[2] = {
-		[0] = THREAD_PARAM_MEMREF(IN, mem->phreq_mobj, 0,
-					  mem->req_size),
+		[0] = THREAD_PARAM_MEMREF(IN, mem->phreq_mobj,
+				RPMB_REQ_MEMREF_OFFSET, mem->req_size),
 		[1] = THREAD_PARAM_MEMREF(OUT, mem->phresp_mobj, 0,
 					  mem->resp_size),
 	};


### PR DESCRIPTION
### Problem
The supplicant from U-Boot cannot pass the RPMB data frame formatted by OP-TEE core to the RPMB driver on platform stm32mp157c-ed1, as the driver requires a 32 bits alignment for the memory address of the data.
Most of the other rpmb drivers in U-Boot expects a 32 bits aligned address as well.
The supplicant gets the data after a `struct rpmb_req` header of size 6 bytes, which breaks the 4 bytes (32 bits) alignment.
Because the problem is generalized to most of the rpmb drivers, the problem is addressed in optee_os directly.

### Changes
Modifying thread_param struct to add the correct offset.
The `struct rpmb_req` with the offset reaches a size modulo 32bits.
As the memory allocation size is already roundup to 32bits, no need to add the offset as it is calculated to reach a roundup of 32bits.
Adding offset to `struct rpmb_req` fixes this and doesn't break the ABI.

Signed-off-by: Timothée Cercueil <timothee.cercueil@st.com>
Signed-off-by: Timothée Cercueil <litchi.pi@protonmail.com>