### PR TITLE
drivers: caam: remove faulty DMAOJB_TRACE()

### DIFF
--- a/core/drivers/crypto/caam/utils/utils_dmaobj.c
+++ b/core/drivers/crypto/caam/utils/utils_dmaobj.c
@@ -1135,8 +1135,6 @@ static TEE_Result try_allocate_dmabuf_max_size(struct caamdmaobj *obj,
 	bool try_alloc = false;
 	uint32_t exceptions = 0;
 
-	DMAOBJ_TRACE("DMA buffer size require %zu", priv->dmabuf.require);
-
 	alloc_size = get_dma_max_alloc_size(obj);
 	if (alloc_size) {
 		try_alloc = true;


### PR DESCRIPTION
Remove DMA object debug trace that would print a structure
variable through a NULL pointer.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
