### PR TITLE
core: a32: fix parameter passing for __thread_std_smc_entry()

### DIFF
--- a/core/arch/arm/kernel/thread_optee_smc_a32.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a32.S
@@ -161,7 +161,9 @@ DECLARE_KEEP_PAGER thread_vector_table
 
 FUNC thread_std_smc_entry , :
 UNWIND(	.cantunwind)
+	push	{r4, r5} /* Pass these following the arm32 calling convention */
 	bl	__thread_std_smc_entry
+	add	sp, sp, #8 /* There's nothing return, just restore the sp */
 	mov	r4, r0	/* Save return value for later */
 
 	/* Disable interrupts before switching to temporary stack */

--- a/core/arch/arm/kernel/thread_spmc_a32.S
+++ b/core/arch/arm/kernel/thread_spmc_a32.S
@@ -50,8 +50,10 @@ END_FUNC ffa_msg_send_direct_resp
 FUNC thread_std_smc_entry , :
 UNWIND(	.cantunwind)
 
+	push	{r4, r5} /* Pass these following the arm32 calling convention */
 	ror	r4, r0, #16 /* Save target info with src and dst swapped */
 	bl	__thread_std_smc_entry
+	add	sp, sp, #8 /* There's nothing return, just restore the sp */
 	mov	r5, r0	/* Save return value */
 
 	/* Mask all maskable exceptions before switching to temporary stack */


### PR DESCRIPTION
With the commit referred below is __thread_std_smc_entry() changed to
take 6 arguments instead of 4. This means with the arm32 calling
convention [1] that the last two parameters are passed on the stack.
This is handled automatically by the C compiler, but has to be done by
hand when calling from assembly. __thread_std_smc_entry() is called from
assembly so fix the two places where the function is called.

Link [1]: https://developer.arm.com/documentation/ihi0042/latest/

Fixes: 4107d2f93e3e ("core: add a4 and a5 to thread_alloc_and_run()")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
