### PR TITLE
core: pta: scmi: fix missing threaded state of the channel

### DIFF
--- a/core/pta/scmi.c
+++ b/core/pta/scmi.c
@@ -120,6 +120,7 @@ static TEE_Result cmd_get_channel_handle(uint32_t ptypes,
 		if (!channel)
 			return TEE_ERROR_BAD_PARAMETERS;
 
+		channel->threaded = true;
 		params[0].value.a = scmi_smt_channel_handle(channel_id);
 
 		return TEE_SUCCESS;


### PR DESCRIPTION
Enable SMT channel threaded state when SCMI PTA gets a channel. Before
this fixup, Core panics when SCMI message is posted since the assertion
on channel threaded field value in scmi_smt_threaded_entry() when
in debug mode.

Fixes: b0a1c2504aaf ("core: pta: scmi: new interface to REE SCMI agent")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
