### PR TITLE
drivers: caam: fix CMAC data input handling

### DIFF
--- a/core/drivers/crypto/caam/cipher/caam_cipher_mac.c
+++ b/core/drivers/crypto/caam/cipher/caam_cipher_mac.c
@@ -487,15 +487,15 @@ static TEE_Result do_update_cmac(struct drvcrypt_cipher_update *dupdate)
 	     offset += size_done, size_todo -= size_done) {
 		size_done = size_todo;
 
-		CIPHER_TRACE("Do input %zu bytes, offset %zu", size_done,
-			     offset);
-
 		if (size_inmade) {
 			ret = caam_dmaobj_sgtbuf_build(&src, &size_done, offset,
 						       ctx->alg->size_block);
 			if (ret)
 				goto end_cmac;
 		}
+
+		CIPHER_TRACE("Do input %zu bytes, offset %zu", size_done,
+			     offset);
 
 		/*
 		 * Need to re-adjust the length of the data if the
@@ -504,6 +504,7 @@ static TEE_Result do_update_cmac(struct drvcrypt_cipher_update *dupdate)
 		 */
 		if (ctx->blockbuf.filled && size_done < size_todo) {
 			size_done -= ctx->blockbuf.filled;
+			size_todo -= ctx->blockbuf.filled;
 			src.sgtbuf.length = size_done;
 		}
 


### PR DESCRIPTION
Depending on the memory buffer input configuration, the function
caam_dmaobj_sgtbuf_build() might modify the data size to be processed in
the loop.
This case happens sometimes on the imx8mp where the input buffer
physical address in above 32 bits.
This implies reporting the data size re-adjustment when data is saved in
the context buffer.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
