### PR TITLE
core: syscall_storage_obj_open: Add TEE_DATA_FLAG_OVERWRITE to valid flags

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -239,7 +239,8 @@ TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,
 					  TEE_DATA_FLAG_ACCESS_WRITE |
 					  TEE_DATA_FLAG_ACCESS_WRITE_META |
 					  TEE_DATA_FLAG_SHARE_READ |
-					  TEE_DATA_FLAG_SHARE_WRITE;
+					  TEE_DATA_FLAG_SHARE_WRITE |
+					  TEE_DATA_FLAG_OVERWRITE;
 	const struct tee_file_operations *fops =
 			tee_svc_storage_file_ops(storage_id);
 	struct ts_session *sess = ts_get_current_session();


### PR DESCRIPTION
During Storage benchmark testing.

Now here we try to Open persistent object with following flags:

TEE_DATA_FLAG_ACCESS_READ | TEE_DATA_FLAG_ACCESS_WRITE |
TEE_DATA_FLAG_ACCESS_WRITE_META | TEE_DATA_FLAG_OVERWRITE

which lands into syscall_storage_obj_open(), where it checks the flags
which were passed during opening the object and valid flags

TEE_DATA_FLAG_ACCESS_READ | TEE_DATA_FLAG_ACCESS_WRITE |
TEE_DATA_FLAG_ACCESS_WRITE_META | TEE_DATA_FLAG_SHARE_READ |
TEE_DATA_FLAG_SHARE_WRITE

TEE_DATA_FLAG_OVERWRITE flag was missing from valid_flags

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Fixes: https://github.com/OP-TEE/optee_os/issues/4659

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
