### PR TITLE
plat-imx: add compulab iot-gate-imx8 board support

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -63,7 +63,8 @@ mx8mq-flavorlist = \
 	mx8mqevk
 
 mx8mm-flavorlist = \
-	mx8mmevk
+	mx8mmevk \
+	mx8mm_cl_iot_gate
 
 mx8mn-flavorlist = \
 	mx8mnevk
@@ -315,6 +316,13 @@ endif
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mmevk))
 CFG_DDR_SIZE ?= 0x80000000
 CFG_UART_BASE ?= UART2_BASE
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mm_cl_iot_gate))
+CFG_DDR_SIZE ?= 0x40000000
+CFG_UART_BASE ?= UART3_BASE
+CFG_NSEC_DDR_1_BASE ?= 0x80000000UL
+CFG_NSEC_DDR_1_SIZE ?= 0x40000000UL
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mnevk))


### PR DESCRIPTION
Support for Compulab IoT Gateway (imx8mm) platform.
(PLATFORM=imx-mx8mm_cl_iot_gate)

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
