### PR TITLE
Cherry-pick rsa_make_key_bn_e() patch from LibTomCrypt upstream

### DIFF
--- a/core/lib/libtomcrypt/src/headers/tomcrypt_pk.h
+++ b/core/lib/libtomcrypt/src/headers/tomcrypt_pk.h
@@ -52,7 +52,8 @@ typedef struct Rsa_key {
 } rsa_key;
 
 int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key);
-
+int rsa_make_key_ubin_e(prng_state *prng, int wprng, int size,
+                        const unsigned char *e, unsigned long elen, rsa_key *key);
 int rsa_get_size(const rsa_key *key);
 
 int rsa_exptmod(const unsigned char *in,   unsigned long inlen,

--- a/core/lib/libtomcrypt/src/headers/tomcrypt_private.h
+++ b/core/lib/libtomcrypt/src/headers/tomcrypt_private.h
@@ -238,6 +238,11 @@ int pk_get_oid(enum ltc_oid_id id, const char **st);
 int pk_oid_str_to_num(const char *OID, unsigned long *oid, unsigned long *oidlen);
 int pk_oid_num_to_str(const unsigned long *oid, unsigned long oidlen, char *OID, unsigned long *outlen);
 
+#ifdef LTC_MRSA
+int rsa_make_key_bn_e(prng_state *prng, int wprng, int size, void *e,
+                      rsa_key *key); /* used by op-tee */
+#endif
+
 /* ---- DH Routines ---- */
 #ifdef LTC_MDH
 extern const ltc_dh_set_type ltc_dh_sets[];

--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_make_key.c
@@ -16,51 +16,37 @@
 
 #ifdef LTC_MRSA
 
-/**
-   Create an RSA key
-   @param prng     An active PRNG state
-   @param wprng    The index of the PRNG desired
-   @param size     The size of the modulus (key size) desired (octets)
-   @param e        The "e" value (public key).  e==65537 is a good choice
-   @param key      [out] Destination of a newly created private key pair
-   @return CRYPT_OK if successful, upon error all allocated ram is freed
-*/
-int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
+static int s_rsa_make_key(prng_state *prng, int wprng, int size, void *e, rsa_key *key)
 {
-   void *p, *q, *tmp1, *tmp2, *tmp3;
+   void *p, *q, *tmp1, *tmp2;
    int    err;
 
    LTC_ARGCHK(ltc_mp.name != NULL);
    LTC_ARGCHK(key         != NULL);
    LTC_ARGCHK(size        > 0);
 
-   if ((e < 3) || ((e & 1) == 0)) {
-      return CRYPT_INVALID_ARG;
-   }
-
    if ((err = prng_is_valid(wprng)) != CRYPT_OK) {
       return err;
    }
 
-   if ((err = mp_init_multi(&p, &q, &tmp1, &tmp2, &tmp3, NULL)) != CRYPT_OK) {
+   if ((err = mp_init_multi(&p, &q, &tmp1, &tmp2, NULL)) != CRYPT_OK) {
       return err;
    }
 
    /* make primes p and q (optimization provided by Wayne Scott) */
-   if ((err = mp_set_int(tmp3, e)) != CRYPT_OK)                      { goto cleanup; }  /* tmp3 = e */
 
    /* make prime "p" */
    do {
        if ((err = rand_prime( p, size/2, prng, wprng)) != CRYPT_OK)  { goto cleanup; }
        if ((err = mp_sub_d( p, 1,  tmp1)) != CRYPT_OK)               { goto cleanup; }  /* tmp1 = p-1 */
-       if ((err = mp_gcd( tmp1,  tmp3,  tmp2)) != CRYPT_OK)          { goto cleanup; }  /* tmp2 = gcd(p-1, e) */
+       if ((err = mp_gcd( tmp1,  e,  tmp2)) != CRYPT_OK)             { goto cleanup; }  /* tmp2 = gcd(p-1, e) */
    } while (mp_cmp_d( tmp2, 1) != 0);                                                  /* while e divides p-1 */
 
    /* make prime "q" */
    do {
        if ((err = rand_prime( q, size/2, prng, wprng)) != CRYPT_OK)  { goto cleanup; }
        if ((err = mp_sub_d( q, 1,  tmp1)) != CRYPT_OK)               { goto cleanup; } /* tmp1 = q-1 */
-       if ((err = mp_gcd( tmp1,  tmp3,  tmp2)) != CRYPT_OK)          { goto cleanup; } /* tmp2 = gcd(q-1, e) */
+       if ((err = mp_gcd( tmp1,  e,  tmp2)) != CRYPT_OK)          { goto cleanup; } /* tmp2 = gcd(q-1, e) */
    } while (mp_cmp_d( tmp2, 1) != 0);                                                 /* while e divides q-1 */
 
    /* tmp1 = lcm(p-1, q-1) */
@@ -73,7 +59,7 @@ int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
       goto errkey;
    }
 
-   if ((err = mp_set_int( key->e, e)) != CRYPT_OK)                     { goto errkey; } /* key->e =  e */
+   if ((err = mp_copy( e,  key->e)) != CRYPT_OK)                       { goto errkey; } /* key->e =  e */
    if ((err = mp_invmod( key->e,  tmp1,  key->d)) != CRYPT_OK)         { goto errkey; } /* key->d = 1/e mod lcm(p-1,q-1) */
    if ((err = mp_mul( p,  q,  key->N)) != CRYPT_OK)                    { goto errkey; } /* key->N = pq */
 
@@ -97,7 +83,89 @@ int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
 errkey:
    rsa_free(key);
 cleanup:
-   mp_clear_multi(tmp3, tmp2, tmp1, q, p, NULL);
+   mp_clear_multi(tmp2, tmp1, q, p, NULL);
+   return err;
+}
+
+/**
+   Create an RSA key based on a long public exponent type
+   @param prng     An active PRNG state
+   @param wprng    The index of the PRNG desired
+   @param size     The size of the modulus (key size) desired (octets)
+   @param e        The "e" value (public key).  e==65537 is a good choice
+   @param key      [out] Destination of a newly created private key pair
+   @return CRYPT_OK if successful, upon error all allocated ram is freed
+*/
+int rsa_make_key(prng_state *prng, int wprng, int size, long e, rsa_key *key)
+{
+   void *tmp_e;
+   int err;
+
+   if ((e < 3) || ((e & 1) == 0)) {
+     return CRYPT_INVALID_ARG;
+   }
+
+   if ((err = mp_init(&tmp_e)) != CRYPT_OK) {
+     return err;
+   }
+
+   if ((err = mp_set_int(tmp_e, e)) == CRYPT_OK)
+     err = s_rsa_make_key(prng, wprng, size, tmp_e, key);
+
+   mp_clear(tmp_e);
+
+   return err;
+}
+
+/**
+   Create an RSA key based on a hexadecimal public exponent type
+   @param prng     An active PRNG state
+   @param wprng    The index of the PRNG desired
+   @param size     The size of the modulus (key size) desired (octets)
+   @param e        The "e" value (public key).  e==65537 is a good choice
+   @param elen     The length of e (octets)
+   @param key      [out] Destination of a newly created private key pair
+   @return CRYPT_OK if successful, upon error all allocated ram is freed
+*/
+int rsa_make_key_ubin_e(prng_state *prng, int wprng, int size,
+                        const unsigned char *e, unsigned long elen, rsa_key *key)
+{
+   int err;
+   void *tmp_e;
+
+   if ((err = mp_init(&tmp_e)) != CRYPT_OK) {
+      return err;
+   }
+
+   if ((err = mp_read_unsigned_bin(tmp_e, (unsigned char *)e, elen)) == CRYPT_OK)
+     err = rsa_make_key_bn_e(prng, wprng, size, tmp_e, key);
+
+   mp_clear(tmp_e);
+
+   return err;
+}
+
+/**
+   Create an RSA key based on a bignumber public exponent type
+   @param prng     An active PRNG state
+   @param wprng    The index of the PRNG desired
+   @param size     The size of the modulus (key size) desired (octets)
+   @param e        The "e" value (public key).  e==65537 is a good choice
+   @param key      [out] Destination of a newly created private key pair
+   @return CRYPT_OK if successful, upon error all allocated ram is freed
+*/
+int rsa_make_key_bn_e(prng_state *prng, int wprng, int size, void *e, rsa_key *key)
+{
+   int err;
+   int e_bits;
+
+   e_bits = mp_count_bits(e);
+   if ((e_bits > 1 && e_bits < 256) && (mp_get_digit(e, 0) & 1)) {
+     err = s_rsa_make_key(prng, wprng, size, e, key);
+   } else {
+     err = CRYPT_INVALID_ARG;
+   }
+
    return err;
 }
 


### PR DESCRIPTION
This PR applies commit [49556a8e606c](https://github.com/libtom/libtomcrypt/commit/49556a8e606c) ("rsa: add rsa key generate with public exponent upto 256 bits") to the OP-TEE master branch.
I am not expecting any review or comment since this comes from upstream. I am creating a PR mainly to run CI.