### PR TITLE
core_mmu: fix implicit behavior of core_mmu_add_mapping()

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -618,7 +618,8 @@ static inline bool core_mmu_is_shm_cached(void)
 
 TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 				   size_t len);
-bool core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len);
+void *core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr,
+			   size_t len);
 
 /*
  * tlbi_mva_range() - Invalidate TLB for virtual address range

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1053,12 +1053,9 @@ static void init_external_dt(unsigned long phys_dt)
 		return;
 	}
 
-	if (!core_mmu_add_mapping(MEM_AREA_EXT_DT, phys_dt, CFG_DTB_MAX_SIZE))
-		panic("Failed to map external DTB");
-
-	fdt = phys_to_virt(phys_dt, MEM_AREA_EXT_DT);
+	fdt = core_mmu_add_mapping(MEM_AREA_EXT_DT, phys_dt, CFG_DTB_MAX_SIZE);
 	if (!fdt)
-		panic();
+		panic("Failed to map external DTB");
 
 	dt->blob = fdt;
 

--- a/core/drivers/crypto/caam/hal/common/hal_cfg.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg.c
@@ -29,20 +29,11 @@ enum caam_status caam_hal_cfg_get_conf(struct caam_jrcfg *jrcfg)
 		caam_hal_cfg_get_ctrl_dt(fdt, &ctrl_base);
 
 	if (!ctrl_base) {
-		ctrl_base = (vaddr_t)phys_to_virt(CAAM_BASE, MEM_AREA_IO_SEC);
+		ctrl_base = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC,
+							  CAAM_BASE,
+							  CORE_MMU_PGDIR_SIZE);
 		if (!ctrl_base) {
-			if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, CAAM_BASE,
-						  CORE_MMU_PGDIR_SIZE)) {
-				EMSG("Unable to map CAAM Registers");
-				goto exit_get_conf;
-			}
-
-			ctrl_base = (vaddr_t)phys_to_virt(CAAM_BASE,
-							  MEM_AREA_IO_SEC);
-		}
-
-		if (!ctrl_base) {
-			EMSG("Unable to get the CAAM Base address");
+			EMSG("Unable to map CAAM Registers");
 			goto exit_get_conf;
 		}
 	}

--- a/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
@@ -80,14 +80,12 @@ void caam_hal_cfg_get_ctrl_dt(void *fdt, vaddr_t *ctrl_base)
 		return;
 	}
 
-	if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, pctrl_base, size)) {
+	*ctrl_base = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC, pctrl_base,
+						   size);
+	if (!*ctrl_base) {
 		EMSG("CAAM control base MMU PA mapping failure");
 		return;
 	}
-
-	*ctrl_base = (vaddr_t)phys_to_virt(pctrl_base, MEM_AREA_IO_SEC);
-	if (!*ctrl_base)
-		EMSG("CAAM control base MMU VA mapping failure");
 
 	HAL_TRACE("Map Controller 0x%" PRIxVA, *ctrl_base);
 }

--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -436,14 +436,11 @@ TEE_Result imx_i2c_init(uint8_t bid, int bps)
 
 static TEE_Result get_va(paddr_t pa, vaddr_t *va)
 {
-	if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, pa, 0x10000))
+	*va = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC, pa, 0x10000);
+	if (!*va)
 		return TEE_ERROR_GENERIC;
 
-	*va = (vaddr_t)phys_to_virt(pa, MEM_AREA_IO_SEC);
-	if (*va)
-		return TEE_SUCCESS;
-
-	return TEE_ERROR_GENERIC;
+	return TEE_SUCCESS;
 }
 
 #if defined(CFG_DT) && !defined(CFG_EXTERNAL_DTB_OVERLAY)

--- a/core/drivers/imx_rngb.c
+++ b/core/drivers/imx_rngb.c
@@ -118,14 +118,12 @@ static void rng_seed(struct imx_rng *rng)
 
 static TEE_Result map_controller_static(void)
 {
-	if (!core_mmu_add_mapping(MEM_AREA_IO_SEC, rngb.base.pa, rngb.size))
+	rngb.base.va = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC,
+						     rngb.base.pa, rngb.size);
+	if (!rngb.base.va)
 		return TEE_ERROR_GENERIC;
 
-	rngb.base.va = (vaddr_t)phys_to_virt(rngb.base.pa, MEM_AREA_IO_SEC);
-	if (rngb.base.va)
-		return TEE_SUCCESS;
-
-	return TEE_ERROR_GENERIC;
+	return TEE_SUCCESS;
 }
 
 #if !defined(CFG_DT)

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -123,14 +123,10 @@ int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size)
 		mtype = MEM_AREA_IO_NSEC;
 
 	/* Check if we have a mapping, create one if needed */
-	if (!core_mmu_add_mapping(mtype, pbase, sz)) {
+	vbase = (vaddr_t)core_mmu_add_mapping(mtype, pbase, sz);
+	if (!vbase) {
 		EMSG("Failed to map %zu bytes at PA 0x%"PRIxPA,
 		     (size_t)sz, pbase);
-		return -1;
-	}
-	vbase = (vaddr_t)phys_to_virt(pbase, mtype);
-	if (!vbase) {
-		EMSG("Failed to get VA for PA 0x%"PRIxPA, pbase);
 		return -1;
 	}
 

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -129,13 +129,10 @@ void tpm_map_log_area(void *fdt)
 
 	rounded_size = ROUNDUP(tpm_log_size, SMALL_PAGE_SIZE);
 
-	if (!core_mmu_add_mapping(MEM_AREA_RAM_SEC, log_addr, rounded_size)) {
+	tpm_log_addr = core_mmu_add_mapping(MEM_AREA_RAM_SEC, log_addr,
+					    rounded_size);
+	if (!tpm_log_addr) {
 		EMSG("TPM: Failed to map TPM log memory");
 		return;
 	}
-
-	tpm_log_addr = phys_to_virt(log_addr, MEM_AREA_RAM_SEC);
-
-	if (!tpm_log_addr)
-		EMSG("TPM: Error mapping phys mem to va space");
 }


### PR DESCRIPTION
In core_mmu_add_mapping() requested physical address
rounded up/down to granule size (0x100000), which leads
to establishing of virtual mappings with overlapped
physical counterparts. If two virtual mappings overlaps
due to such roundings, then following phys_to_virt() can
implicitly return result of virtual address from
unexpected mapping. This patch fix such behavior by
returning virtual address of newly established mapping.

Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>
Signed-off-by: Anton Rybakov <a.rybakov@omp.ru>