### PR TITLE
core_mmu_lpae: adding level 0 support for address space >= 40 bits

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -46,15 +46,23 @@
 #define CORE_MMU_USER_PARAM_SIZE	BIT(CORE_MMU_USER_PARAM_SHIFT)
 #define CORE_MMU_USER_PARAM_MASK	((paddr_t)CORE_MMU_USER_PARAM_SIZE - 1)
 
+/*
+ * Level of base table (i.e. first level of page table),
+ * depending on address space
+ */
+#define CORE_MMU_BASE_TABLE_SHIFT	U(30)
+#define CORE_MMU_BASE_TABLE_LEVEL	U(1)
 #ifdef CFG_WITH_LPAE
 /*
- * CORE_MMU_L1_TBL_OFFSET is used when switching to/from reduced kernel
+ * CORE_MMU_BASE_TABLE_OFFSET is used when switching to/from reduced kernel
  * mapping. The actual value depends on internals in core_mmu_lpae.c which
  * we rather not expose here. There's a compile time assertion to check
  * that these magic numbers are correct.
  */
-#define CORE_MMU_L1_TBL_OFFSET \
-	(CFG_TEE_CORE_NB_CORE * BIT(CFG_LPAE_ADDR_SPACE_BITS - U(30)) * U(8))
+#define CORE_MMU_BASE_TABLE_OFFSET \
+	(CFG_TEE_CORE_NB_CORE * \
+	 BIT(CFG_LPAE_ADDR_SPACE_BITS - CORE_MMU_BASE_TABLE_SHIFT) * \
+	 U(8))
 #endif
 /*
  * TEE_RAM_VA_START:            The start virtual address of the TEE RAM

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -50,8 +50,16 @@
  * Level of base table (i.e. first level of page table),
  * depending on address space
  */
+#if !defined(CFG_WITH_LPAE) || (CFG_LPAE_ADDR_SPACE_BITS < 40)
 #define CORE_MMU_BASE_TABLE_SHIFT	U(30)
 #define CORE_MMU_BASE_TABLE_LEVEL	U(1)
+#elif (CFG_LPAE_ADDR_SPACE_BITS >= 40) && (CFG_LPAE_ADDR_SPACE_BITS <= 48)
+#define CORE_MMU_BASE_TABLE_SHIFT	U(39)
+#define CORE_MMU_BASE_TABLE_LEVEL	U(0)
+#else /* (CFG_LPAE_ADDR_SPACE_BITS > 48) */
+#error "CFG_WITH_LPAE with CFG_LPAE_ADDR_SPACE_BITS > 48 isn't supported!"
+#endif
+
 #ifdef CFG_WITH_LPAE
 /*
  * CORE_MMU_BASE_TABLE_OFFSET is used when switching to/from reduced kernel

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -363,7 +363,7 @@ END_FUNC thread_unwind_user_mode
 		 * Since the translation table could reside above 4GB we'll
 		 * have to use 64-bit arithmetics.
 		 */
-		subs	r0, r0, #CORE_MMU_L1_TBL_OFFSET
+		subs	r0, r0, #CORE_MMU_BASE_TABLE_OFFSET
 		sbc	r1, r1, #0
 #endif
 		bic	r1, r1, #BIT(TTBR_ASID_SHIFT - 32)
@@ -815,7 +815,7 @@ eret_to_user_mode:
 #ifdef CFG_WITH_LPAE
 	read_ttbr0_64bit r0, r1
 #ifdef CFG_CORE_UNMAP_CORE_AT_EL0
-	add	r0, r0, #CORE_MMU_L1_TBL_OFFSET
+	add	r0, r0, #CORE_MMU_BASE_TABLE_OFFSET
 #endif
 	/* switch to user ASID */
 	orr	r1, r1, #BIT(TTBR_ASID_SHIFT - 32)
@@ -877,7 +877,7 @@ icache_inv_user_range:
 	/* switch to user ASID */
 	orr	r3, r7, #BIT(TTBR_ASID_SHIFT - 32)
 #ifdef CFG_CORE_UNMAP_CORE_AT_EL0
-	add	r2, r6, #CORE_MMU_L1_TBL_OFFSET
+	add	r2, r6, #CORE_MMU_BASE_TABLE_OFFSET
 	write_ttbr0_64bit r2, r3
 #else
 	write_ttbr0_64bit r6, r3

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -181,7 +181,7 @@ END_FUNC thread_unwind_user_mode
 
 		/* Update the mapping to use the full kernel mapping */
 		mrs	x0, ttbr0_el1
-		sub	x0, x0, #CORE_MMU_L1_TBL_OFFSET
+		sub	x0, x0, #CORE_MMU_BASE_TABLE_OFFSET
 		/* switch to kernel mode ASID */
 		bic	x0, x0, #BIT(TTBR_ASID_SHIFT)
 		msr	ttbr0_el1, x0
@@ -494,7 +494,7 @@ eret_to_el0:
 
 	/* Update the mapping to exclude the full kernel mapping */
 	mrs	x0, ttbr0_el1
-	add	x0, x0, #CORE_MMU_L1_TBL_OFFSET
+	add	x0, x0, #CORE_MMU_BASE_TABLE_OFFSET
 	orr	x0, x0, #BIT(TTBR_ASID_SHIFT) /* switch to user mode ASID */
 	msr	ttbr0_el1, x0
 	isb
@@ -550,7 +550,7 @@ icache_inv_user_range:
 
 	/* Update the mapping to exclude the full kernel mapping */
 	mrs	x5, ttbr0_el1	/* this register must be preserved */
-	add	x2, x5, #CORE_MMU_L1_TBL_OFFSET
+	add	x2, x5, #CORE_MMU_BASE_TABLE_OFFSET
 	orr	x2, x2, #BIT(TTBR_ASID_SHIFT) /* switch to user mode ASID */
 	msr	ttbr0_el1, x2
 	isb

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -730,7 +730,7 @@ static void dump_xlat_table(vaddr_t va, int level)
 	va = tbl_info.va_base;
 	for (idx = 0; idx < tbl_info.num_entries; idx++) {
 		core_mmu_get_entry(&tbl_info, idx, &pa, &attr);
-		if (attr || level > 1) {
+		if (attr || level > CORE_MMU_BASE_TABLE_LEVEL) {
 			if (attr & TEE_MATTR_TABLE) {
 #ifdef CFG_WITH_LPAE
 				DMSG_RAW("%*s [LVL%d] VA:0x%010" PRIxVA
@@ -1222,7 +1222,7 @@ void __weak core_init_mmu_map(unsigned long seed, struct core_mmu_config *cfg)
 
 	check_mem_map(tmp_mmap);
 	core_init_mmu(tmp_mmap);
-	dump_xlat_table(0x0, 1);
+	dump_xlat_table(0x0, CORE_MMU_BASE_TABLE_LEVEL);
 	core_init_mmu_regs(cfg);
 	cfg->load_offset = offs;
 	memcpy(static_memory_map, tmp_mmap, sizeof(static_memory_map));
@@ -1629,7 +1629,7 @@ void core_mmu_map_region(struct mmu_partition *prtn, struct tee_mmap_region *mm)
 	assert(!((vaddr | paddr) & SMALL_PAGE_MASK));
 
 	while (size_left > 0) {
-		level = 1;
+		level = CORE_MMU_BASE_TABLE_LEVEL;
 
 		while (true) {
 			assert(level <= CORE_MMU_PGDIR_LEVEL);

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -713,8 +713,8 @@ bool core_mmu_find_table(struct mmu_partition *prtn, vaddr_t va,
 			goto out;
 		}
 
-		/* Copy bits 39:12 from tbl[n] to ntbl */
-		ntbl = tbl[n] & GENMASK_64(39, 12);
+		/* Copy bits 47:12 from tbl[n] to ntbl */
+		ntbl = tbl[n] & GENMASK_64(47, 12);
 
 #ifdef CFG_VIRTUALIZATION
 		if (prtn == &default_partition)
@@ -802,7 +802,7 @@ void core_mmu_get_entry_primitive(const void *table, size_t level,
 	const uint64_t *tbl = table;
 
 	if (pa)
-		*pa = tbl[idx] & GENMASK_64(39, 12);
+		*pa = tbl[idx] & GENMASK_64(47, 12);
 
 	if (attr)
 		*attr = desc_to_mattr(level, tbl[idx]);

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -714,7 +714,7 @@ bool core_mmu_find_table(struct mmu_partition *prtn, vaddr_t va,
 		}
 
 		/* Copy bits 39:12 from tbl[n] to ntbl */
-		ntbl = (tbl[n] & ((1ULL << 40) - 1)) & ~((1 << 12) - 1);
+		ntbl = tbl[n] & GENMASK_64(39, 12);
 
 #ifdef CFG_VIRTUALIZATION
 		if (prtn == &default_partition)
@@ -802,7 +802,7 @@ void core_mmu_get_entry_primitive(const void *table, size_t level,
 	const uint64_t *tbl = table;
 
 	if (pa)
-		*pa = (tbl[idx] & ((1ull << 40) - 1)) & ~((1 << 12) - 1);
+		*pa = tbl[idx] & GENMASK_64(39, 12);
 
 	if (attr)
 		*attr = desc_to_mattr(level, tbl[idx]);
@@ -820,7 +820,7 @@ void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 	if (base)
 		*base = (vaddr_t)user_va_idx << L1_XLAT_ADDRESS_SHIFT;
 	if (size)
-		*size = 1 << L1_XLAT_ADDRESS_SHIFT;
+		*size = BIT64(L1_XLAT_ADDRESS_SHIFT);
 }
 
 bool core_mmu_user_mapping_is_active(void)

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -818,9 +818,9 @@ void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 	assert(user_va_idx != -1);
 
 	if (base)
-		*base = (vaddr_t)user_va_idx << L1_XLAT_ADDRESS_SHIFT;
+		*base = (vaddr_t)user_va_idx << BASE_XLAT_ADDRESS_SHIFT;
 	if (size)
-		*size = BIT64(L1_XLAT_ADDRESS_SHIFT);
+		*size = BASE_XLAT_BLOCK_SIZE;
 }
 
 bool core_mmu_user_mapping_is_active(void)


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

A set of commits to add support for ARM MMU with CFG_LPAE_ADDR_SPACE_BITS>=40.
Till now OPTEE silently ignored that supporting >=40 bits of address space requires using level 0 page table.

Development stages:
1. References to l1_table were renamed to base_table, referencing from TF-A xlat_tables naming.
2. Importing few macros from TF-A xlat_tables_def.h for level 0 calculations.
3. Non-64bit "1 << x", causing bad calculations, were replaced with "BIT64(x)"
4. Build-time CORE_MMU_BASE_TABLE_LEVEL is determined to be 0 or 1 that affects few hard coded places that were referring "1" as the base level.
5. Most of the page table crunching functions (e.g. looping over levels) are magically working with the extra level 0.

References:
* ARMv8 page table granularity and required levels: https://developer.arm.com/documentation/den0024/a/The-Memory-Management-Unit/Translation-tables-in-ARMv8-A/Effect-of-granule-sizes-on-translation-tables