### PR TITLE
core: REE FS: introduce CFG_REE_FS_ALLOW_RESET

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -498,12 +498,19 @@ static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 		return res;
 
 	res = tee_fs_dirfile_open(false, hashp, &ree_dirf_ops, dirh);
+
 	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
-		if (IS_ENABLED(CFG_REE_FS_ALLOW_RESET) && hashp) {
-			DMSG("Clear REE FS hash in RPMB");
-			res = rpmb_fs_ops.truncate(ree_fs_rpmb_fh, 0);
-			if (res) {
-				DMSG("Clear REE FS hash failed: %#"PRIx32, res);
+		if (hashp) {
+			if (IS_ENABLED(CFG_REE_FS_ALLOW_RESET)) {
+				DMSG("dirf.db not found, clear hash in RPMB");
+				res = rpmb_fs_ops.truncate(ree_fs_rpmb_fh, 0);
+				if (res) {
+					DMSG("Can't clear hash: %#"PRIx32, res);
+					res = TEE_ERROR_SECURITY;
+					goto out;
+				}
+			} else {
+				DMSG("dirf.db file not found");
 				res = TEE_ERROR_SECURITY;
 				goto out;
 			}

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -294,6 +294,14 @@ CFG_REE_FS_TA ?= y
 CFG_REE_FS_TA_BUFFERED ?= n
 $(eval $(call cfg-depends-all,CFG_REE_FS_TA_BUFFERED,CFG_REE_FS_TA))
 
+# When CFG_REE_FS=y and CFG_RPMB_FS=y:
+# Allow secure storage in the REE FS to be entirely deleted without causing
+# anti-rollback errors. That is, rm /data/tee/dirf.db or rm -rf /data/tee (or
+# whatever path is configured in tee-supplicant as CFG_TEE_FS_PARENT_PATH)
+# can be used to reset the secure storage to a clean, empty state.
+# Typically used for testing only since it weakens storage security.
+CFG_REE_FS_ALLOW_RESET ?= n
+
 # Support for loading user TAs from a special section in the TEE binary.
 # Such TAs are available even before tee-supplicant is available (hence their
 # name), but note that many services exported to TAs may need tee-supplicant,


### PR DESCRIPTION
New boolean configuration switch CFG_REE_FS_ALLOW_RESET that, when
enabled, will make OP-TEE OS to allow REE FS content to be reset in
the Linux filesystem even when RPMB FS is enabled and already stores a
REE FS rollback protection hash. This switch is intended to test purpose
where REE FS can be wiped because the device flash memory was programmed
with brand new build artifacts.