### PR TITLE
lib: mbedtls: return TEE_ERROR_BAD_PARAMETERS on input data error

### DIFF
--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -22,6 +22,8 @@ static TEE_Result get_tee_result(int lmd_res)
 	switch (lmd_res) {
 	case 0:
 		return TEE_SUCCESS;
+	case MBEDTLS_ERR_RSA_PRIVATE_FAILED +
+		MBEDTLS_ERR_MPI_BAD_INPUT_DATA:
 	case MBEDTLS_ERR_RSA_BAD_INPUT_DATA:
 	case MBEDTLS_ERR_RSA_INVALID_PADDING:
 	case MBEDTLS_ERR_PK_TYPE_MISMATCH:


### PR DESCRIPTION
This changes fixes Keymaster VTS if cryptolib use libmedtls
EncryptionOperationsTest, RsaPkcs1Success and
EncryptionOperationsTest, RsaOaepSuccess probabilistic failure.
We should change error code from libmedtls to TEE_AsymmetricDecrypt.
In the same scenario, the tomcrypt return value is eventually
Converted to TEE_ERROR_BAD_PARAMETERS,and then pass the test.
But mbedtls converted to TEE_ERROR_BAD_STATE,
This then causes panic to return the function TEE_AsymmetricDecrypt.

Signed-off-by: Liu Shiwei <liushiwei@eswin.com>
Tested-by: Liu Shiwei <liushiwei@eswin.com>
Acked-by: Etienne Carriere <etienne.carriere@linaro.org>
Acked-by: Jerome Forissier <jerome@forissier.org>
Acked-by: vchong
Acked-by: Jens Wiklander <jens.wiklander@linaro.org>