### PR TITLE
drivers: caam: fix DMA object when only output reallocated

### DIFF
--- a/core/drivers/crypto/caam/include/caam_utils_dmaobj.h
+++ b/core/drivers/crypto/caam/include/caam_utils_dmaobj.h
@@ -180,9 +180,7 @@ TEE_Result caam_dmaobj_prepare(struct caamdmaobj *input,
 /*
  * Build the CAAM DMA Object's sgtbuf object. Try to build a sgtbuf of
  * maximum @length starting at @offset.
- * Return the @length mapped in the sgtbuf object. If a new data buffer
- * must be reallocated, allocated it to the maximum possible round to @align
- * value.
+ * Return the @length mapped in the sgtbuf object.
  *
  * @obj     CAAM DMA object
  * @length  [in/out] maximum length to do/done

--- a/core/drivers/crypto/caam/utils/utils_dmaobj.c
+++ b/core/drivers/crypto/caam/utils/utils_dmaobj.c
@@ -1394,9 +1394,9 @@ TEE_Result caam_dmaobj_sgtbuf_build(struct caamdmaobj *obj, size_t *length,
 		obj->sgtbuf.paddr = obj->sgtbuf.buf->paddr;
 	}
 
-	*length = max_length;
+	*length = obj->sgtbuf.length;
 	ret = TEE_SUCCESS;
 out:
-	DMAOBJ_TRACE("SGTBUF returns 0x%" PRIx32, ret);
+	DMAOBJ_TRACE("SGTBUF (%zu) returns 0x%" PRIx32, *length, ret);
 	return ret;
 }


### PR DESCRIPTION
In case of cipher operation, the input and output CAAM SGT/Buffer
are built in same time through function caam_dmaobj_sgtbuf_inout_build()
to ensure that both SGT/Buffer do the same cipher block size.

This fix usecase when:
 - cipher block to encrypt/decrypt is more than 1 Kbytes
 - input data are accessible from CAAM (no reallocation)
 - output data is not accessible from CAAM (reallocation of DMA buffer).

Due to this fix, AES CMAC update loop has to be fixed.
