### PR TITLE
ci: azure: run regression tests (make check) in QEMUv8

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -174,3 +174,25 @@ jobs:
           _make PLATFORM=rzn1
 
           upload_cache
+
+  - job: QEMUv8_check
+    displayName: 'Run regression tests (xtest) in QEMUv8'
+    pool:
+      vmImage: ubuntu-18.04
+    container:
+      image: jforissier/optee_os_ci:qemuv8_check
+    steps:
+      - script: |
+          set -e -v
+          export LC_ALL=C
+          WD=$(pwd)
+          sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
+          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
+          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+
+          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(getconf _NPROCESSORS_ONLN) CFG_TEE_CORE_LOG_LEVEL=0 check
+
+          sudo touch /boot/vmlinuz-$(uname -r)
+          sudo -E rm -rf /root/optee_repo_qemu_v8/out-br/build/optee_test*
+          sudo -E make -C /root/optee_repo_qemu_v8/build arm-tf-clean
+          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(getconf _NPROCESSORS_ONLN) CFG_TEE_CORE_LOG_LEVEL=0 check XEN_BOOT=y


### PR DESCRIPTION
Adds a separate job to execute "make check" in the QEMUv8 environment.
The default configuration is tested as well as Normal World
virtualization (XEN_BOOT=y).

The Docker image used for this is jforissier/optee_os_ci:qemuv8_check
on Docker Hub [1]. The Dockerfile is available on Github [2].

Link: [1] https://hub.docker.com/repository/docker/jforissier/optee_os_ci/
Link: [2] https://github.com/jforissier/docker_optee_os_ci/blob/qemuv8_check/Dockerfile
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
