### PR TITLE
core: arm64: use adr_l to reference stack_tmp_stride

### DIFF
--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -25,7 +25,7 @@
 		cmp	x0, #CFG_TEE_CORE_NB_CORE
 		/* Unsupported CPU, park it before it breaks something */
 		bge	unhandled_cpu
-		adr	x1, stack_tmp_stride
+		adr_l	x1, stack_tmp_stride
 		ldr	w1, [x1]
 		mul	x1, x0, x1
 		adr_l	x0, stack_tmp_export

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -28,8 +28,7 @@
 		adr	x1, stack_tmp_stride
 		ldr	w1, [x1]
 		mul	x1, x0, x1
-		adrp	x0, stack_tmp_export
-		add	x0, x0, :lo12:stack_tmp_export
+		adr_l	x0, stack_tmp_export
 		ldr	x0, [x0]
 		msr	spsel, #0
 		add	sp, x1, x0


### PR DESCRIPTION
When CFG_NUM_THREADS and/or CFG_TEE_CORE_NB_CORE become large enough,
link errors are reported:

 $ make -s CFG_TEE_CORE_NB_CORE=48 CFG_NUM_THREADS=48 \
           PLATFORM=vexpress-qemu_armv8a
 out/arm-plat-vexpress/core/arch/arm/kernel/entry_a64.o: in function `clear_bss':
 core/arch/arm/kernel/entry_a64.S:160:(.text._start+0x98): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `stack_tmp_stride' defined in .identity_map.stack_tmp_stride section in out/arm-plat-vexpress/core/arch/arm/kernel/thread.o
 out/arm-plat-vexpress/core/arch/arm/kernel/entry_a64.o: in function `cpu_on_handler':
 core/arch/arm/kernel/entry_a64.S:443:(.text.cpu_on_handler+0x50): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `stack_tmp_stride' defined in .identity_map.stack_tmp_stride section in out/arm-plat-vexpress/core/arch/arm/kernel/thread.o

~~Fix the issue by replacing the addr instruction with the pattern:
 addrp x, sym         ; load page address of sym
 add x, x, :lo12:sym  ; add offset of sym in page~~
Fix the issue by replacing the addr instruction with the adr_l macro.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
