### PR TITLE
Miscellaneous small fixes

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -653,6 +653,7 @@ static int add_dt_overlay_fragment(struct dt_descriptor *dt, int ioffs)
 
 static int init_dt_overlay(struct dt_descriptor *dt, int __maybe_unused dt_size)
 {
+#if !defined(CFG_EXTERNAL_DTB_OVERLAY_ERASE_AT_BOOT)
 	int fragment;
 	int ret;
 
@@ -662,6 +663,7 @@ static int init_dt_overlay(struct dt_descriptor *dt, int __maybe_unused dt_size)
 			dt->frag_id += 1;
 		return ret;
 	}
+#endif
 
 #ifdef CFG_DT_ADDR
 	return fdt_create_empty_tree(dt->blob, dt_size);

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -887,7 +887,7 @@ static int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
 	}
 
 	ret = snprintf(subnode_name, sizeof(subnode_name),
-		       "%s@0x%" PRIxPA, name, pa);
+		       "%s@%" PRIxPA, name, pa);
 	if (ret < 0 || ret >= (int)sizeof(subnode_name))
 		DMSG("truncated node \"%s@0x%"PRIxPA"\"", name, pa);
 	offs = fdt_add_subnode(dt->blob, offs, subnode_name);

--- a/core/drivers/scmi-msg/clock.c
+++ b/core/drivers/scmi-msg/clock.c
@@ -319,7 +319,7 @@ static void scmi_clock_describe_rates(struct scmi_msg *msg)
 	} else if (status == SCMI_NOT_SUPPORTED) {
 		unsigned long triplet[3] = { 0, 0, 0 };
 
-		/* Platform may support min§max/step triplet description */
+		/* Platform may support min/max/step triplet description */
 		status =  plat_scmi_clock_rates_by_step(msg->channel_id,
 							clock_id, triplet);
 		if (status == SCMI_SUCCESS) {


### PR DESCRIPTION
This series contains minor fixes:
- Typo fix in scmi code
- Removal of 0x prefix to node address in unit name as per devicetree specification
- Add option CFG_EXTERNAL_DTB_OVERLAY_ERASE_AT_BOOT which erase the device tree overlay at boot time