### PR TITLE
core: clear temporary stack flag before entering boot_init_primary_late()

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -16,6 +16,8 @@
 #include <sm/teesmc_opteed.h>
 #include <sm/teesmc_opteed_macros.h>
 
+#include "thread_private.h"
+
 .arch_extension sec
 
 .section .data
@@ -551,10 +553,16 @@ shadow_stack_access_ok:
 	ldr	r0, =threads
 	ldr	r0, [r0, #THREAD_CTX_STACK_VA_END]
 	mov	sp, r0
+	bl	thread_get_core_local
+	mov	r8, r0
+	mov	r0, #0
+	str	r0, [r8, #THREAD_CORE_LOCAL_FLAGS]
 #endif
 	mov	r0, r6		/* DT address */
 	bl	boot_init_primary_late
 #ifndef CFG_VIRTUALIZATION
+	mov	r0, #THREAD_CLF_TMP
+	str	r0, [r8, #THREAD_CORE_LOCAL_FLAGS]
 	mov	sp, r7
 #endif
 

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -15,6 +15,8 @@
 #include <sm/teesmc_opteed.h>
 #include <sm/teesmc_opteed_macros.h>
 
+#include "thread_private.h"
+
 	/*
 	 * Setup SP_EL0 and SPEL1, SP will be set to SP_EL0.
 	 * SP_EL0 is assigned stack_tmp_export + cpu_id * stack_tmp_stride
@@ -232,10 +234,15 @@ clear_nex_bss:
 	adr_l	x0, threads
 	ldr	x0, [x0, #THREAD_CTX_STACK_VA_END]
 	mov	sp, x0
+	bl	thread_get_core_local
+	mov	x22, x0
+	str	wzr, [x22, #THREAD_CORE_LOCAL_FLAGS]
 #endif
 	mov	x0, x20		/* DT address */
 	bl	boot_init_primary_late
 #ifndef CFG_VIRTUALIZATION
+	mov	x0, #THREAD_CLF_TMP
+	str     w0, [x22, #THREAD_CORE_LOCAL_FLAGS]
 	mov	sp, x21
 #endif
 


### PR DESCRIPTION
boot_init_primary_late() uses the stack of thread 0, so the flag that
indicates usage of the temporary stack must be cleared in the current
core's thread_core_local structure.

Fixes the following crash when CFG_CORE_DEBUG_CHECK_STACKS=y:

 D/TC:0 0 select_vector:1126 SMCCC_ARCH_WORKAROUND_1 (0x80008000) available
 D/TC:0 0 select_vector:1128 SMC Workaround for CVE-2017-5715 used
 D/TC:0 0 check_stack_limits:370 Stack pointer out of range (0xb7f54fd0)
 D/TC:0 0 print_stack_limits:346 tmp [0] 0xb7f57c90..0xb7f584b0
 D/TC:0 0 print_stack_limits:346 tmp [1] 0xb7f58ad0..0xb7f592f0
 D/TC:0 0 print_stack_limits:346 tmp [2] 0xb7f59910..0xb7f5a130
 D/TC:0 0 print_stack_limits:346 tmp [3] 0xb7f5a750..0xb7f5af70
 D/TC:0 0 print_stack_limits:351 abt [0] 0xb7f4e710..0xb7f4f330
 D/TC:0 0 print_stack_limits:351 abt [1] 0xb7f4f950..0xb7f50570
 D/TC:0 0 print_stack_limits:351 abt [2] 0xb7f50b90..0xb7f517b0
 D/TC:0 0 print_stack_limits:351 abt [3] 0xb7f51dd0..0xb7f529f0
 D/TC:0 0 print_stack_limits:356 thr [0] 0xb7f53030..0xb7f55030
 D/TC:0 0 print_stack_limits:356 thr [1] 0xb7f55670..0xb7f57670
 E/TC:0 0 Panic at core/arch/arm/kernel/thread.c:372 <check_stack_limits>

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
