### PR TITLE
mk: LIBGCC_LOCATE_CFLAGS allows setting sysroot path for GCC

### DIFF
--- a/mk/gcc.mk
+++ b/mk/gcc.mk
@@ -13,11 +13,11 @@ nostdinc$(sm)	:= -nostdinc -isystem $(shell $(CC$(sm)) \
 			-print-file-name=include 2> /dev/null)
 
 # Get location of libgcc from gcc
-libgcc$(sm)  	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) \
+libgcc$(sm)  	:= $(shell $(CC$(sm)) $(LIBGCC_LOCATE_CFLAGS) $(CFLAGS$(arch-bits-$(sm))) \
 			-print-libgcc-file-name 2> /dev/null)
-libstdc++$(sm)	:= $(shell $(CXX$(sm)) $(CXXFLAGS$(arch-bits-$(sm))) $(comp-cxxflags$(sm)) \
+libstdc++$(sm)	:= $(shell $(CXX$(sm)) $(LIBGCC_LOCATE_CFLAGS) $(CXXFLAGS$(arch-bits-$(sm))) $(comp-cxxflags$(sm)) \
 			-print-file-name=libstdc++.a 2> /dev/null)
-libgcc_eh$(sm)	:= $(shell $(CXX$(sm)) $(CXXFLAGS$(arch-bits-$(sm))) $(comp-cxxflags$(sm)) \
+libgcc_eh$(sm)	:= $(shell $(CXX$(sm)) $(LIBGCC_LOCATE_CFLAGS) $(CXXFLAGS$(arch-bits-$(sm))) $(comp-cxxflags$(sm)) \
 			-print-file-name=libgcc_eh.a 2> /dev/null)
 
 # Define these to something to discover accidental use


### PR DESCRIPTION
OP-TEE OS compilation fails with Yocto like build environment
as libgcc.a cannot be find when gcc.mk is executed [1]. A trick
used  was to set comp-cflagscore='--sysroot=/path/to/sysroot'
at OP-TEE OS build. This is no more sufficient as CXXFLAGS
(comp-cxxflagscore=...) may also be needed.

This change implements LIBGCC_LOCATE_CFLAGS as a better way to
path sysroot info for the expected purpose, as proposed in [2] and
[3], recently mentioned in [1] and used in several distributions.

Build environment are expected to set path when needed:
LIBGCC_LOCATE_CFLAGS='--sysroot=/path/to/sysroot'

Link: [1] https://github.com/OP-TEE/optee_os/issues/4673
Link: [2] https://github.com/OP-TEE/optee_os/pull/2853
Link: [3] https://github.com/OP-TEE/optee_os/issues/4485#issuecomment-803025139

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
