### PR TITLE
libutee: TEE_MACCompareFinal(): panic if input size is too large

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1265,6 +1265,11 @@ TEE_Result TEE_MACCompareFinal(TEE_OperationHandle operation,
 	if (res != TEE_SUCCESS)
 		goto out;
 
+	if (macLen > computed_mac_size) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
 	if (computed_mac_size != macLen) {
 		res = TEE_ERROR_MAC_INVALID;
 		goto out;


### PR DESCRIPTION
The GlobalPlatform TEE Internal Core API specification mentions the
following panic reason for TEE_MACCompareFinal(): "if input data exceeds
the maximum length for the algorithm". The current code returns
TEE_ERROR_MAC_INVALID instead. Fix this by assigning error code
TEE_ERROR_BAD_PARAMETERS which gets translated into a panic later.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
