### PR TITLE
crypto: optimize speed of AES CBC MAC

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -22,6 +22,11 @@ CFG_CRYPTO_XTS ?= y
 CFG_CRYPTO_HMAC ?= y
 CFG_CRYPTO_CMAC ?= y
 CFG_CRYPTO_CBC_MAC ?= y
+# Instead of calling the AES CBC encryption function for each 16 byte block of
+# input, bundle a maximum of N blocks when possible. A maximum of N*16 bytes of
+# temporary data are allocated on the heap.
+# Minimum value is 1.
+CFG_CRYPTO_CBC_MAC_BUNDLE_BLOCKS ?= 64
 
 # Hashes
 CFG_CRYPTO_MD5 ?= y


### PR DESCRIPTION
The current AES CBC MAC implementation invokes the AES CBC algorithm via
crypto_cipher_update() for each 16-byte block of the input data. This
can be inefficient especially with hardware accelerated implementations
which may have a significant overhead (I am thinking of proprietary
implementations of MBed TLS for example).

This commit introduces a new config option:
CFG_CRYPTO_CBC_MAC_BUNDLE_BLOCKS (default 64) which allows to bundle
several 16-byte blocks of input data when calling the AES CBC function.
Therefore with the default value, data are processed 1 KB at a time
(assuming the caller provides enough data of course). There is a small
memory overhead (malloc) of the same size at most.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
