### PR TITLE
mm: fix mobj split by adding core_mmu_find_mapping() helper

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -631,6 +631,17 @@ void *core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr,
 			   size_t len);
 
 /*
+ * core_mmu_find_mapping_exclusive() - Find mapping of specified type and
+ *				       length. If more than one mapping of
+ *				       specified type is present, NULL will be
+ *				       returned.
+ * @type:	memory type
+ * @len:	length in bytes
+ */
+struct tee_mmap_region *
+core_mmu_find_mapping_exclusive(enum teecore_memtypes type, size_t len);
+
+/*
  * tlbi_mva_range() - Invalidate TLB for virtual address range
  * @va:		start virtual address, must be a multiple of @granule
  * @len:	length in bytes of range, must be a multiple of @granule

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -89,6 +89,9 @@
  * MEM_AREA_TEE_RAM_RX:  core private read-only/executable memory (secure)
  * MEM_AREA_TEE_RAM_RO:  core private read-only/non-executable memory (secure)
  * MEM_AREA_TEE_RAM_RW:  core private read/write/non-executable memory (secure)
+ * MEM_AREA_INIT_RAM_RO: init private read-only/non-executable memory (secure)
+ * MEM_AREA_INIT_RAM_RX: init private read-only/executable memory (secure)
+ * MEM_AREA_NEX_RAM_RO: nexus private read-only/non-executable memory (secure)
  * MEM_AREA_NEX_RAM_RW: nexus private r/w/non-executable memory (secure)
  * MEM_AREA_TEE_COHERENT: teecore coherent RAM (secure, reserved to TEE)
  * MEM_AREA_TEE_ASAN: core address sanitizer RAM (secure, reserved to TEE)
@@ -113,6 +116,9 @@ enum teecore_memtypes {
 	MEM_AREA_TEE_RAM_RX,
 	MEM_AREA_TEE_RAM_RO,
 	MEM_AREA_TEE_RAM_RW,
+	MEM_AREA_INIT_RAM_RO,
+	MEM_AREA_INIT_RAM_RX,
+	MEM_AREA_NEX_RAM_RO,
 	MEM_AREA_NEX_RAM_RW,
 	MEM_AREA_TEE_COHERENT,
 	MEM_AREA_TEE_ASAN,
@@ -142,6 +148,9 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 		[MEM_AREA_TEE_RAM_RX] = "TEE_RAM_RX",
 		[MEM_AREA_TEE_RAM_RO] = "TEE_RAM_RO",
 		[MEM_AREA_TEE_RAM_RW] = "TEE_RAM_RW",
+		[MEM_AREA_INIT_RAM_RO] = "INIT_RAM_RO",
+		[MEM_AREA_INIT_RAM_RX] = "INIT_RAM_RX",
+		[MEM_AREA_NEX_RAM_RO] = "NEX_RAM_RO",
 		[MEM_AREA_NEX_RAM_RW] = "NEX_RAM_RW",
 		[MEM_AREA_TEE_ASAN] = "TEE_ASAN",
 		[MEM_AREA_IDENTITY_MAP_RX] = "IDENTITY_MAP_RX",

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -152,6 +152,7 @@ void virt_init_memory(struct tee_mmap_region *memory_map)
 		switch (map->type) {
 		case MEM_AREA_TEE_RAM_RX:
 		case MEM_AREA_TEE_RAM_RO:
+		case MEM_AREA_NEX_RAM_RO:
 		case MEM_AREA_NEX_RAM_RW:
 			DMSG("Carving out area of type %d (0x%08lx-0x%08lx)",
 			     map->type, map->pa, map->pa + map->size);

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -1936,6 +1936,31 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 	return TEE_SUCCESS;
 }
 
+struct tee_mmap_region *
+core_mmu_find_mapping_exclusive(enum teecore_memtypes type, size_t len)
+{
+	struct tee_mmap_region *map = NULL;
+	struct tee_mmap_region *map_found = NULL;
+
+	if (!len)
+		return NULL;
+
+	for (map = get_memory_map(); !core_mmap_is_end_of_table(map); map++) {
+		if (map->type != type)
+			continue;
+
+		if (map_found)
+			return NULL;
+
+		map_found = map;
+	}
+
+	if (!map_found || map_found->size < len)
+		return NULL;
+
+	return map_found;
+}
+
 void *core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len)
 {
 	struct core_mmu_table_info tbl_info;


### PR DESCRIPTION
This fixes mobj splitting onto RX/RW parts. Now split can be done
incorrectly if RX and RW regions doesn`t mapped contiguosly.
Added helper core_mmu_find_mapping() allows to find mapping for
specified type and length independently of their order, so then
RX/RW regions for mobjects should be determined correctly.

Signed-off-by: Anton Rybakov <a.rybakov@omp.ru>