### PR TITLE
core: plat-ls: ls1012a: Fix GIC offset

### DIFF
--- a/core/arch/arm/plat-ls/platform_config.h
+++ b/core/arch/arm/plat-ls/platform_config.h
@@ -62,8 +62,16 @@
 #define CAAM_BASE			0x01700000
 #endif
 
-#if defined(PLATFORM_FLAVOR_ls1043ardb) || defined(PLATFORM_FLAVOR_ls1046ardb) \
-|| defined(PLATFORM_FLAVOR_ls1012ardb) || defined(PLATFORM_FLAVOR_ls1012afrwy)
+#if defined(PLATFORM_FLAVOR_ls1012ardb) || defined(PLATFORM_FLAVOR_ls1012afrwy)
+/*  DUART 1 */
+#define UART0_BASE			0x021C0500
+#define GIC_BASE			0x01400000
+#define GICC_OFFSET			0x2000
+#define GICD_OFFSET			0x1000
+#define CAAM_BASE			0x01700000
+#endif
+
+#if defined(PLATFORM_FLAVOR_ls1043ardb) || defined(PLATFORM_FLAVOR_ls1046ardb)
 /*  DUART 1 */
 #define UART0_BASE			0x021C0500
 #define GIC_BASE			0x01400000


### PR DESCRIPTION
The GIC offset for LS1012A is different than the one for
LS1043A and LS1046A.
Fixing for LS1012A

Signed-off-by: Franck LENORMAND <franck.lenormand@nxp.com>