### PR TITLE
core: mm: remove duplicate mobj_put() in vm_map_pad()

### DIFF
--- a/core/mm/vm.c
+++ b/core/mm/vm.c
@@ -293,7 +293,7 @@ TEE_Result vm_map_pad(struct user_mode_ctx *uctx, vaddr_t *va, size_t len,
 
 	res = umap_add_region(&uctx->vm_info, reg, pad_begin, pad_end, align);
 	if (res)
-		goto err_free_reg;
+		goto err_put_mobj;
 
 	res = alloc_pgt(uctx);
 	if (res)
@@ -326,8 +326,9 @@ TEE_Result vm_map_pad(struct user_mode_ctx *uctx, vaddr_t *va, size_t len,
 
 err_rem_reg:
 	TAILQ_REMOVE(&uctx->vm_info.regions, reg, link);
-err_free_reg:
+err_put_mobj:
 	mobj_put(reg->mobj);
+err_free_reg:
 	free(reg);
 	return res;
 }


### PR DESCRIPTION
Whatever the return value of vm_map_pad, the mobj_put() is always called.
Therefore mobj_put() should not be called when mobj_get_cattr(mobj, &cattr) fails.

Signed-off-by: ZheTingLiu \<Gavin.Liu@mediatek.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
