### PR TITLE
scripts: checkpatch_inc.sh: Add CHECKPATCH_OPT for optional arguments

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CHECKPATCH="${CHECKPATCH:-checkpatch.pl}"
+CHECKPATCH_OPT="${CHECKPATCH_OPT:-}"
 # checkpatch.pl will ignore the following paths
 CHECKPATCH_IGNORE=$(echo \
 		core/include/gen-asm-defines.h \
@@ -19,7 +20,7 @@ function _checkpatch() {
 				typedefs_opt="";
 		# Ignore NOT_UNIFIED_DIFF in case patch has no diff
 		# (e.g., all paths filtered out)
-		$CHECKPATCH $typedefs_opt -
+		$CHECKPATCH $CHECKPATCH_OPT $typedefs_opt -
 }
 
 function checkpatch() {


### PR DESCRIPTION
Add new environment variable CHECKPATCH_OPT for configuring common optional
arguments.

In example newer codespell has moved dictionary to new location.

This allows one to use:
```
export CHECKPATCH=<path to linux kernel source>/scripts/checkpatch.pl
export CHECKPATCH_OPT=--codespellfile=/usr/lib/python3/dist-packages/codespell_lib/data/dictionary.txt
```

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
