### PR TITLE
ta: pkcs11: Fix calling twice of C_EncryptInit()/C_DecryptInit()

### DIFF
--- a/ta/pkcs11/src/processing.c
+++ b/ta/pkcs11/src/processing.c
@@ -605,18 +605,18 @@ enum pkcs11_rc entry_processing_init(struct pkcs11_client *client,
 
 	if (serialargs_remaining_bytes(&ctrlargs)) {
 		rc = PKCS11_CKR_ARGUMENTS_BAD;
-		goto out;
+		goto out_free;
 	}
 
 	rc = get_ready_session(session);
 	if (rc)
-		goto out;
+		goto out_free;
 
 	if (function != PKCS11_FUNCTION_DIGEST) {
 		obj = pkcs11_handle2object(key_handle, session);
 		if (!obj) {
 			rc = PKCS11_CKR_KEY_HANDLE_INVALID;
-			goto out;
+			goto out_free;
 		}
 	}
 
@@ -660,9 +660,9 @@ enum pkcs11_rc entry_processing_init(struct pkcs11_client *client,
 	}
 
 out:
-	if (rc && session)
+	if (rc)
 		release_active_processing(session);
-
+out_free:
 	TEE_Free(proc_params);
 
 	return rc;


### PR DESCRIPTION
If C_EncryptInit()/C_DecryptInit() is called twice first starts the
operation and should inform caller that operation is already in progress
 and keep the operation active until it is terminated with C_Encrypt()/
C_Decrypt() or by C_EncryptFinal()/C_DecryptFinal().

Specified in:

PKCS #11 Cryptographic Token Interface Base Specification Version 2.40
Plus Errata 01
5.8 Encryption functions
C_EncryptInit
and
5.9 Decryption functions
C_DecryptInit

Relates to:
- https://github.com/OP-TEE/optee_os/issues/4283

Related PRs:
- https://github.com/OP-TEE/optee_test/pull/537

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
