### PR TITLE
ci: azure: run 'git pull' to update repo tool before 'repo sync'

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -189,6 +189,7 @@ jobs:
           set -e -v
           export LC_ALL=C
           WD=$(pwd)
+          sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
           sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
           sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
           sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os


### PR DESCRIPTION

Update the repo tool to the latest version before running 'repo sync'.
Fixes the following error [1]:
```
 sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
 project .repo/manifests/
 Updating 7b69f4f..30fb9a8
 Fast-forward

 info: A new version of repo is available
 warning: repo is not tracking a remote branch, so it will not receive updates
 repo: Updating release signing keys to keyset ver 2.3
 repo reset: error: Entry 'docs/manifest-format.md' not uptodate. Cannot merge.
 fatal: Could not reset index file to revision 'v2.16.2^0'.
```
Link: [1] https://dev.azure.com/OPTEE/optee_os/_build/results?buildId=855&view=logs&j=705748f3-7146-5e86-79af-1c0266d20a8c&t=d3458a7d-1a81-5639-8e63-8927d807e53a&l=23
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
