### PR TITLE
arm64: format call stack addresses on 8 characters by default

### DIFF
--- a/lib/libunw/unwind_arm64.c
+++ b/lib/libunw/unwind_arm64.c
@@ -74,11 +74,13 @@ bool unwind_stack_arm64(struct unwind_state_arm64 *frame,
 void print_stack_arm64(struct unwind_state_arm64 *state,
 		       vaddr_t stack, size_t stack_size)
 {
+	int width = 8;
+
 	trace_printf_helper_raw(TRACE_ERROR, true, "Call stack:");
 
 	ftrace_map_lr(&state->pc);
 	do {
-		trace_printf_helper_raw(TRACE_ERROR, true, " 0x%016" PRIx64,
-					state->pc);
+		trace_printf_helper_raw(TRACE_ERROR, true, " 0x%0*"PRIx64,
+					width, state->pc);
 	} while (unwind_stack_arm64(state, stack, stack_size));
 }


### PR DESCRIPTION
print_stack_arm64() currently shows the full 64 bit addresses in
hexadecimal with leading zeros (0x0000000000000000). This is a bit hard
to read and is not necessary since virtual addresses are typically 32
or 36 bits (defined by CFG_LPAE_ADDR_SPACE_BITS), and in any case
nowhere near 64 bits.
Therefore, use a 32-bit format by default (0x00000000) and expand the
width as necessary. The new format is already used in ldelf to print
the region addresses so this changes brings consistency.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
