### PR TITLE
ta: pkcs11: Add operation state in session

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -87,8 +87,9 @@ check_mechanism_against_processing(struct pkcs11_session *session,
 		    !session->processing->relogged)
 			return PKCS11_CKR_USER_NOT_LOGGED_IN;
 
-		if (session->processing->updated) {
-			EMSG("Cannot perform one-shot on updated processing");
+		if (session->processing->step == PKCS11_FUNC_STEP_UPDATE ||
+		    session->processing->step == PKCS11_FUNC_STEP_FINAL) {
+			EMSG("Cannot perform one-shot on active processing");
 			return PKCS11_CKR_OPERATION_ACTIVE;
 		}
 
@@ -99,6 +100,12 @@ check_mechanism_against_processing(struct pkcs11_session *session,
 		if (session->processing->always_authen &&
 		    !session->processing->relogged)
 			return PKCS11_CKR_USER_NOT_LOGGED_IN;
+
+		if (session->processing->step == PKCS11_FUNC_STEP_ONESHOT ||
+		    session->processing->step == PKCS11_FUNC_STEP_FINAL) {
+			EMSG("Cannot perform update on finalized processing");
+			return PKCS11_CKR_OPERATION_ACTIVE;
+		}
 
 		allowed = !mechanism_is_one_shot_only(mechanism_type);
 		break;
@@ -118,6 +125,10 @@ check_mechanism_against_processing(struct pkcs11_session *session,
 		    !session->processing->relogged)
 			return PKCS11_CKR_USER_NOT_LOGGED_IN;
 
+		if (session->processing->step == PKCS11_FUNC_STEP_ONESHOT) {
+			EMSG("Cannot perform final on oneshot processing");
+			return PKCS11_CKR_OPERATION_ACTIVE;
+		}
 		return PKCS11_CKR_OK;
 
 	default:

--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -219,6 +219,7 @@ enum pkcs11_rc set_processing_state(struct pkcs11_session *session,
 
 	/* Boolean are default to false and pointers to NULL */
 	proc->state = state;
+	proc->step = PKCS11_FUNC_STEP_INIT;
 	proc->tee_op_handle = TEE_HANDLE_NULL;
 	proc->tee_hash_algo = 0;
 	proc->tee_hash_op_handle = TEE_HANDLE_NULL;

--- a/ta/pkcs11/src/pkcs11_token.h
+++ b/ta/pkcs11/src/pkcs11_token.h
@@ -135,7 +135,7 @@ enum pkcs11_proc_state {
  * @mecha_type - mechanism type of the active processing
  * @always_authen - true if user need to login before each use
  * @relogged - true once client logged since last operation update
- * @updated - true once an active operation is updated
+ * @op_step - last active operation step - update, final or one-shot
  * @tee_op_handle - handle on active crypto operation or TEE_HANDLE_NULL
  * @tee_hash_algo - hash algorithm identifier.
  * @tee_hash_op_handle - handle on active hashing crypto operation or
@@ -145,9 +145,9 @@ enum pkcs11_proc_state {
 struct active_processing {
 	enum pkcs11_proc_state state;
 	uint32_t mecha_type;
+	enum processing_step step;
 	bool always_authen;
 	bool relogged;
-	bool updated;
 	TEE_OperationHandle tee_op_handle;
 	uint32_t tee_hash_algo;
 	TEE_OperationHandle tee_hash_op_handle;

--- a/ta/pkcs11/src/processing.c
+++ b/ta/pkcs11/src/processing.c
@@ -759,11 +759,18 @@ enum pkcs11_rc entry_processing_step(struct pkcs11_client *client,
 
 	if (rc == PKCS11_CKR_OK && (step == PKCS11_FUNC_STEP_UPDATE ||
 				    step == PKCS11_FUNC_STEP_UPDATE_KEY)) {
-		session->processing->updated = true;
+		session->processing->step = PKCS11_FUNC_STEP_UPDATE;
 		DMSG("PKCS11 session%"PRIu32": processing %s %s",
 		     session->handle, id2str_proc(mecha_type),
 		     id2str_function(function));
 	}
+
+	if (rc == PKCS11_CKR_BUFFER_TOO_SMALL &&
+	    step == PKCS11_FUNC_STEP_ONESHOT)
+		session->processing->step = PKCS11_FUNC_STEP_ONESHOT;
+
+	if (rc == PKCS11_CKR_BUFFER_TOO_SMALL && step == PKCS11_FUNC_STEP_FINAL)
+		session->processing->step = PKCS11_FUNC_STEP_FINAL;
 
 out:
 	switch (step) {


### PR DESCRIPTION
Add more operation states to take care of scenarios like failure
of an incremental (update) operation if a one-shot/final operation
has been started.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
