### PR TITLE
Build: Fix CFG_EMBEDDED_TS dependency

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -325,16 +325,22 @@ CFG_REE_FS_ALLOW_RESET ?= n
 # for instance avb/023f8f1a-292a-432b-8fc4-de8471358067
 ifneq ($(EARLY_TA_PATHS)$(CFG_IN_TREE_EARLY_TAS),)
 $(call force,CFG_EARLY_TA,y)
-$(call force,CFG_EMBEDDED_TS,y)
 else
 CFG_EARLY_TA ?= n
 endif
 
+ifeq ($(CFG_EARLY_TA),y)
+$(call force,CFG_EMBEDDED_TS,y)
+endif
+
 ifneq ($(SP_PATHS),)
-$(call force,CFG_SECURE_PARTITION,y)
 $(call force,CFG_EMBEDDED_TS,y)
 else
 CFG_SECURE_PARTITION ?= n
+endif
+
+ifeq ($(CFG_SECURE_PARTITION),y)
+$(call force,CFG_EMBEDDED_TS,y)
 endif
 
 ifeq ($(CFG_EMBEDDED_TS),y)


### PR DESCRIPTION
Set CFG_EMBEDDED_TS when CFG_EARLY_TA or CFG_SECURE_PARTITION
is set even when no early_ta's or SPs are added to the system.

Signed-off-by: Jelle Sels <jelle.sels@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
