### PR TITLE
core: svc: fix ta_time_prot_lvl always 100 problem

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -70,7 +70,11 @@ static const char descr[] = TO_STR(CFG_TEE_IMPL_DESCR);
  * The real-time clock MUST be out of reach of software attacks
  * from the REE.
  */
+#ifdef CFG_SECURE_TIME_SOURCE_REE
 static const uint32_t ta_time_prot_lvl = 100;
+#elif CFG_SECURE_TIME_SOURCE_CNTPCT
+static const uint32_t ta_time_prot_lvl = 1000;
+#endif
 
 /* Elliptic Curve Cryptographic support */
 #ifdef CFG_CRYPTO_ECC


### PR DESCRIPTION
ta_time_prot_lvl value must be defined according
to the platform implementation,it may be 100 or 1000
that According to GP standards.

Signed-off-by: Lu Bing <lubing@eswin.com>
Tested-by: Lu Bing <lubing@eswin.com>
