### PR TITLE
core: rename TA_VASPACE to TS_VASPACE

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -105,7 +105,7 @@
  * MEM_AREA_EXT_DT:   Memory loads external device tree
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_SHM_VASPACE: Virtual memory space for dynamic shared memory buffers
- * MEM_AREA_TA_VASPACE: TA va space, only used with phys_to_virt()
+ * MEM_AREA_TS_VASPACE: TS va space, only used with phys_to_virt()
  * MEM_AREA_DDR_OVERALL: Overall DDR address range, candidate to dynamic shm.
  * MEM_AREA_SEC_RAM_OVERALL: Whole secure RAM
  * MEM_AREA_MAXTYPE:  lower invalid 'type' value
@@ -132,7 +132,7 @@ enum teecore_memtypes {
 	MEM_AREA_EXT_DT,
 	MEM_AREA_RES_VASPACE,
 	MEM_AREA_SHM_VASPACE,
-	MEM_AREA_TA_VASPACE,
+	MEM_AREA_TS_VASPACE,
 	MEM_AREA_PAGER_VASPACE,
 	MEM_AREA_SDP_MEM,
 	MEM_AREA_DDR_OVERALL,
@@ -164,7 +164,7 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 		[MEM_AREA_EXT_DT] = "EXT_DT",
 		[MEM_AREA_RES_VASPACE] = "RES_VASPACE",
 		[MEM_AREA_SHM_VASPACE] = "SHM_VASPACE",
-		[MEM_AREA_TA_VASPACE] = "TA_VASPACE",
+		[MEM_AREA_TS_VASPACE] = "TS_VASPACE",
 		[MEM_AREA_PAGER_VASPACE] = "PAGER_VASPACE",
 		[MEM_AREA_SDP_MEM] = "SDP_MEM",
 		[MEM_AREA_DDR_OVERALL] = "DDR_OVERALL",

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -397,7 +397,7 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 		case MEM_AREA_EXT_DT:
 		case MEM_AREA_RES_VASPACE:
 		case MEM_AREA_SHM_VASPACE:
-		case MEM_AREA_TA_VASPACE:
+		case MEM_AREA_TS_VASPACE:
 		case MEM_AREA_PAGER_VASPACE:
 			break;
 		default:
@@ -2231,7 +2231,7 @@ static void check_va_matches_pa(paddr_t pa __unused, void *va __unused)
 }
 #endif
 
-static void *phys_to_virt_ta_vaspace(paddr_t pa)
+static void *phys_to_virt_ts_vaspace(paddr_t pa)
 {
 	if (!core_mmu_user_mapping_is_active())
 		return NULL;
@@ -2275,8 +2275,8 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m)
 	void *va = NULL;
 
 	switch (m) {
-	case MEM_AREA_TA_VASPACE:
-		va = phys_to_virt_ta_vaspace(pa);
+	case MEM_AREA_TS_VASPACE:
+		va = phys_to_virt_ts_vaspace(pa);
 		break;
 	case MEM_AREA_TEE_RAM:
 	case MEM_AREA_TEE_RAM_RX:

--- a/core/pta/tests/invoke.c
+++ b/core/pta/tests/invoke.c
@@ -46,7 +46,7 @@ static int test_v2p2v(void *va)
 		return 1;
 
 	if (to_ta_session(session)->clnt_id.login == TEE_LOGIN_TRUSTED_APP) {
-		v = phys_to_virt(p, MEM_AREA_TA_VASPACE);
+		v = phys_to_virt(p, MEM_AREA_TS_VASPACE);
 	} else {
 		v = phys_to_virt(p, MEM_AREA_NSEC_SHM);
 		if (!v)


### PR DESCRIPTION
The TA_VASPACE memory will be used by both TAs and SPs.
Rename it to TS_VASPACE so it is clearer that it can be used by both.
Split off from [#4792](https://github.com/OP-TEE/optee_os/pull/4792)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
