### PR TITLE
[RFC #2] Runtime Secure Keys Framework Proposal 

### DIFF
--- a/core/drivers/crypto/crypto_api/cipher/cipher.c
+++ b/core/drivers/crypto/crypto_api/cipher/cipher.c
@@ -169,6 +169,45 @@ static const struct crypto_cipher_ops cipher_ops = {
 	.copy_state = cipher_copy_state,
 };
 
+TEE_Result drvcrypt_cipher_alloc_key(struct tee_cryp_obj_key *key,
+				     uint32_t key_type)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_cipher cipher = { };
+
+	if (!key) {
+		CRYPTO_TRACE("Parameters error (key @%p)", key);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	cipher.op = drvcrypt_get_ops(CRYPTO_CIPHER);
+	if (cipher.op && cipher.op->alloc_key)
+		ret = cipher.op->alloc_key(key, key_type);
+
+	CRYPTO_TRACE("Cipher alloc ret 0x%" PRIX32, ret);
+
+	return ret;
+}
+
+TEE_Result drvcrypt_cipher_gen_key(struct tee_cryp_obj_key *key)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_cipher cipher = { };
+
+	if (!key) {
+		CRYPTO_TRACE("Parameters error (key @%p)", key);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	cipher.op = drvcrypt_get_ops(CRYPTO_CIPHER);
+	if (cipher.op && cipher.op->gen_key)
+		ret = cipher.op->gen_key(key);
+
+	CRYPTO_TRACE("Cipher alloc ret 0x%" PRIX32, ret);
+
+	return ret;
+}
+
 TEE_Result drvcrypt_cipher_alloc_ctx(struct crypto_cipher_ctx **ctx,
 				     uint32_t algo)
 {

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_cipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_cipher.h
@@ -45,6 +45,11 @@ struct drvcrypt_cipher_update {
  * Crypto library cipher driver operations
  */
 struct drvcrypt_cipher {
+	/* Allocate the key */
+	TEE_Result (*alloc_key)(struct tee_cryp_obj_secret *key,
+				uint32_t key_type);
+	/* Generate the key */
+	TEE_Result (*gen_key)(struct tee_cryp_obj_secret *key);
 	/* Allocate context */
 	TEE_Result (*alloc_ctx)(void **ctx, uint32_t algo);
 	/* Free context */

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_mac.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_mac.h
@@ -12,19 +12,23 @@
 #include <tee_api_types.h>
 
 /*
- * Crypto library HMAC driver allocation function prototype
+ * Crypto library MAC driver operations
  */
-typedef TEE_Result (*drvcrypt_mac_allocate)(struct crypto_mac_ctx **ctx,
-					    uint32_t algo);
+struct drvcrypt_mac {
+	TEE_Result (*alloc_key)(struct tee_cryp_obj_secret *key,
+				uint32_t key_type);
+	TEE_Result (*gen_key)(struct tee_cryp_obj_secret *key);
+	TEE_Result (*alloc_ctx)(struct crypto_mac_ctx **ctx, uint32_t algo);
+};
 
 /*
  * Register a HMAC processing driver in the crypto API
  *
  * @allocate - Callback for driver context allocation in the crypto layer
  */
-static inline TEE_Result drvcrypt_register_hmac(drvcrypt_mac_allocate allocate)
+static inline TEE_Result drvcrypt_register_hmac(struct drvcrypt_mac *ops)
 {
-	return drvcrypt_register(CRYPTO_HMAC, (void *)allocate);
+	return drvcrypt_register(CRYPTO_HMAC, (void *)ops);
 }
 
 /*
@@ -32,8 +36,8 @@ static inline TEE_Result drvcrypt_register_hmac(drvcrypt_mac_allocate allocate)
  *
  * @allocate - Callback for driver context allocation in the crypto layer
  */
-static inline TEE_Result drvcrypt_register_cmac(drvcrypt_mac_allocate allocate)
+static inline TEE_Result drvcrypt_register_cmac(struct drvcrypt_mac *ops)
 {
-	return drvcrypt_register(CRYPTO_CMAC, (void *)allocate);
+	return drvcrypt_register(CRYPTO_CMAC, (void *)ops);
 }
 #endif /* __DRVCRYPT_MAC_H__ */

--- a/core/drivers/crypto/crypto_api/mac/mac.c
+++ b/core/drivers/crypto/crypto_api/mac/mac.c
@@ -10,10 +10,49 @@
 #include <utee_defines.h>
 #include <util.h>
 
+TEE_Result drvcrypt_mac_alloc_key(struct tee_cryp_obj_key *key,
+				  uint32_t key_type)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct drvcrypt_mac *mac = NULL;
+
+	if (!key) {
+		CRYPTO_TRACE("Parameters error (key @%p)", key);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	mac = drvcrypt_get_ops(CRYPTO_xMAC);
+	if (mac && mac->alloc_key)
+		ret = mac->alloc_key(key, key_type);
+
+	CRYPTO_TRACE("Cipher alloc ret 0x%" PRIX32, ret);
+
+	return ret;
+}
+
+TEE_Result drvcrypt_mac_gen_key(struct tee_cryp_obj_key *key)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct drvcrypt_mac *mac = NULL;
+
+	if (!key) {
+		CRYPTO_TRACE("Parameters error (key @%p)", key);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	mac = drvcrypt_get_ops(CRYPTO_xMAC);
+	if (mac && mac->gen_key)
+		ret = mac->gen_key(key);
+
+	CRYPTO_TRACE("Cipher alloc ret 0x%" PRIX32, ret);
+
+	return ret;
+}
+
 TEE_Result drvcrypt_mac_alloc_ctx(struct crypto_mac_ctx **ctx, uint32_t algo)
 {
 	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
-	drvcrypt_mac_allocate mac_alloc = NULL;
+	struct drvcrypt_mac *mac = NULL;
 	unsigned int algo_id = TEE_ALG_GET_MAIN_ALG(algo);
 
 	CRYPTO_TRACE("mac alloc_ctx algo 0x%" PRIX32, algo);
@@ -21,12 +60,12 @@ TEE_Result drvcrypt_mac_alloc_ctx(struct crypto_mac_ctx **ctx, uint32_t algo)
 	assert(ctx);
 
 	if (algo_id >= TEE_MAIN_ALGO_MD5 && algo_id <= TEE_MAIN_ALGO_SHA512)
-		mac_alloc = drvcrypt_get_ops(CRYPTO_HMAC);
+		mac = drvcrypt_get_ops(CRYPTO_HMAC);
 	else
-		mac_alloc = drvcrypt_get_ops(CRYPTO_CMAC);
+		mac = drvcrypt_get_ops(CRYPTO_CMAC);
 
-	if (mac_alloc)
-		ret = mac_alloc(ctx, algo);
+	if (mac && mac->alloc_ctx)
+		ret = mac->alloc_ctx(ctx, algo);
 
 	CRYPTO_TRACE("mac alloc_ctx ret 0x%" PRIX32, ret);
 

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -24,6 +24,44 @@
 
 #include <tee_api_types.h>
 
+struct tee_cryp_obj_key {
+	/*
+	 * Security size of the key in bits
+	 * - 128, 192, 256 ... for the cipher
+	 * - 521, 1028, 2048 ... for the acipher
+	 */
+	uint32_t size;
+	/*
+	 * Space allocated to store the key under the desired form (plain text
+	 * or encrypted) in bytes.
+	 * The crypto driver implementation might need more space than the
+	 * security size of the key.
+	 * In the case of a SW generated key, size = alloc_size
+	 */
+	uint32_t alloc_size;
+
+	/* The key buffer of alloc_size size */
+	uint8_t *data;
+
+	/* Tell if the key is rsec or not */
+	bool rsec;
+
+	/*
+	 * Key operation vectors associated with the key. These key operations
+	 * are set during the key generation by the crypto driver.
+	 */
+	struct key_ops *ops;
+};
+
+struct key_ops {
+	/*
+	 * Call after an object is populated by user
+	 * Transform a plain key into Runtime Secure key.
+	 * This function is optional.
+	 */
+	TEE_Result (*wrap)(struct tee_cryp_obj_key *key);
+};
+
 TEE_Result crypto_init(void);
 
 /* Message digest functions */

--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -279,12 +279,24 @@ drvcrypt_hash_alloc_ctx(struct crypto_hash_ctx **ctx __unused,
 #endif /* CFG_CRYPTO_DRV_HASH */
 
 #ifdef CFG_CRYPTO_DRV_CIPHER
+TEE_Result drvcrypt_cipher_alloc_key(struct tee_cryp_obj_secret *key,
+				     uint32_t key_type);
+TEE_Result drvcrypt_cipher_gen_key(struct tee_cryp_obj_secret *key);
 TEE_Result drvcrypt_cipher_alloc_ctx(struct crypto_cipher_ctx **ctx,
 				     uint32_t algo);
 #else
-static inline TEE_Result
-drvcrypt_cipher_alloc_ctx(struct crypto_cipher_ctx **ctx __unused,
-			  uint32_t algo __unused)
+static inline TEE_Result drvcrypt_cipher_alloc_key(
+	struct tee_cryp_obj_secret *key, uint32_t key_type)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+static inline TEE_Result drvcrypt_cipher_gen_key(
+	struct tee_cryp_obj_secret *key)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+static inline TEE_Result drvcrypt_cipher_alloc_ctx(
+	struct crypto_cipher_ctx **ctx, uint32_t algo)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
@@ -292,11 +304,24 @@ drvcrypt_cipher_alloc_ctx(struct crypto_cipher_ctx **ctx __unused,
 
 #ifdef CFG_CRYPTO_DRV_MAC
 /* Cryptographic MAC driver context allocation */
+TEE_Result drvcrypt_mac_alloc_key(struct tee_cryp_obj_secret *key,
+				  uint32_t key_type);
+TEE_Result drvcrypt_mac_gen_key(struct tee_cryp_obj_secret *key);
 TEE_Result drvcrypt_mac_alloc_ctx(struct crypto_mac_ctx **ctx, uint32_t algo);
 #else
 static inline TEE_Result
 drvcrypt_mac_alloc_ctx(struct crypto_mac_ctx **ctx __unused,
 		       uint32_t algo __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+static inline TEE_Result
+drvcrypt_mac_gen_key(struct tee_cryp_obj_secret *key)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+static inline TEE_Result
+drvcrypt_mac_alloc_key(struct tee_cryp_obj_secret *key, uint32_t key_type)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -52,18 +52,6 @@ struct tee_cryp_state {
 	enum cryp_state state;
 };
 
-struct tee_cryp_obj_secret {
-	uint32_t key_size;
-	uint32_t alloc_size;
-
-	/*
-	 * Pseudo code visualize layout of structure
-	 * Next follows data, such as:
-	 *	uint8_t data[alloc_size]
-	 * key_size must never exceed alloc_size
-	 */
-};
-
 #define TEE_TYPE_ATTR_OPTIONAL		BIT(0)
 #define TEE_TYPE_ATTR_REQUIRED		BIT(1)
 #define TEE_TYPE_ATTR_OPTIONAL_GROUP	BIT(2)
@@ -73,11 +61,9 @@ struct tee_cryp_obj_secret {
 #define TEE_TYPE_ATTR_BIGNUM_MAXBITS	BIT(6)
 
     /* Handle storing of generic secret keys of varying lengths */
-#define ATTR_OPS_INDEX_SECRET     0
-    /* Convert to/from big-endian byte array and provider-specific bignum */
-#define ATTR_OPS_INDEX_BIGNUM     1
+#define ATTR_OPS_INDEX_KEY     0
     /* Convert to/from value attribute depending on direction */
-#define ATTR_OPS_INDEX_VALUE      2
+#define ATTR_OPS_INDEX_VALUE   1
 
 struct tee_cryp_obj_type_attrs {
 	uint32_t attr_id;
@@ -91,11 +77,11 @@ struct tee_cryp_obj_type_attrs {
 	.raw_offs = offsetof(_x, _y), .raw_size = MEMBER_SIZE(_x, _y)
 
 static const struct tee_cryp_obj_type_attrs
-	tee_cryp_obj_secret_value_attrs[] = {
+	tee_cryp_obj_key_value_attrs[] = {
 	{
 	.attr_id = TEE_ATTR_SECRET_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR,
-	.ops_index = ATTR_OPS_INDEX_SECRET,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	.raw_offs = 0,
 	.raw_size = 0
 	},
@@ -105,14 +91,14 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_rsa_pub_key_attrs[] = {
 	{
 	.attr_id = TEE_ATTR_RSA_MODULUS,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_public_key, n)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_PUBLIC_EXPONENT,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_public_key, e)
 	},
 };
@@ -121,56 +107,56 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_rsa_keypair_attrs[] = {
 	{
 	.attr_id = TEE_ATTR_RSA_MODULUS,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, n)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_PUBLIC_EXPONENT,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_GEN_KEY_OPT,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, e)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_PRIVATE_EXPONENT,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, d)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_PRIME1,
 	.flags = TEE_TYPE_ATTR_OPTIONAL_GROUP,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, p)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_PRIME2,
 	.flags = TEE_TYPE_ATTR_OPTIONAL_GROUP,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, q)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_EXPONENT1,
 	.flags = TEE_TYPE_ATTR_OPTIONAL_GROUP,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, dp)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_EXPONENT2,
 	.flags = TEE_TYPE_ATTR_OPTIONAL_GROUP,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, dq)
 	},
 
 	{
 	.attr_id = TEE_ATTR_RSA_COEFFICIENT,
 	.flags = TEE_TYPE_ATTR_OPTIONAL_GROUP,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct rsa_keypair, qp)
 	},
 };
@@ -179,28 +165,28 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_dsa_pub_key_attrs[] = {
 	{
 	.attr_id = TEE_ATTR_DSA_PRIME,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_BIGNUM_MAXBITS,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_public_key, p)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DSA_SUBPRIME,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_public_key, q)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DSA_BASE,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_BIGNUM_MAXBITS,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_public_key, g)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DSA_PUBLIC_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_BIGNUM_MAXBITS,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_public_key, y)
 	},
 };
@@ -210,7 +196,7 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_dsa_keypair_attrs[] = {
 	.attr_id = TEE_ATTR_DSA_PRIME,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_GEN_KEY_REQ |
 		 TEE_TYPE_ATTR_BIGNUM_MAXBITS,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_keypair, p)
 	},
 
@@ -218,7 +204,7 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_dsa_keypair_attrs[] = {
 	.attr_id = TEE_ATTR_DSA_SUBPRIME,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR |
 		 TEE_TYPE_ATTR_GEN_KEY_REQ,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_keypair, q)
 	},
 
@@ -226,21 +212,21 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_dsa_keypair_attrs[] = {
 	.attr_id = TEE_ATTR_DSA_BASE,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_GEN_KEY_REQ |
 		 TEE_TYPE_ATTR_BIGNUM_MAXBITS,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_keypair, g)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DSA_PRIVATE_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_BIGNUM_MAXBITS,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_keypair, x)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DSA_PUBLIC_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_BIGNUM_MAXBITS,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dsa_keypair, y)
 	},
 };
@@ -250,35 +236,35 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_dh_keypair_attrs[] = {
 	.attr_id = TEE_ATTR_DH_PRIME,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR |
 		 TEE_TYPE_ATTR_GEN_KEY_REQ,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dh_keypair, p)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DH_BASE,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_GEN_KEY_REQ,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dh_keypair, g)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DH_PUBLIC_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dh_keypair, y)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DH_PRIVATE_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dh_keypair, x)
 	},
 
 	{
 	.attr_id = TEE_ATTR_DH_SUBPRIME,
 	.flags = TEE_TYPE_ATTR_OPTIONAL_GROUP |	 TEE_TYPE_ATTR_GEN_KEY_OPT,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct dh_keypair, q)
 	},
 
@@ -296,7 +282,7 @@ static const struct tee_cryp_obj_type_attrs
 	{
 	.attr_id = TEE_ATTR_HKDF_IKM,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR,
-	.ops_index = ATTR_OPS_INDEX_SECRET,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	.raw_offs = 0,
 	.raw_size = 0
 	},
@@ -309,7 +295,7 @@ static const struct tee_cryp_obj_type_attrs
 	{
 	.attr_id = TEE_ATTR_CONCAT_KDF_Z,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR,
-	.ops_index = ATTR_OPS_INDEX_SECRET,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	.raw_offs = 0,
 	.raw_size = 0
 	},
@@ -322,7 +308,7 @@ static const struct tee_cryp_obj_type_attrs
 	{
 	.attr_id = TEE_ATTR_PBKDF2_PASSWORD,
 	.flags = TEE_TYPE_ATTR_REQUIRED | TEE_TYPE_ATTR_SIZE_INDICATOR,
-	.ops_index = ATTR_OPS_INDEX_SECRET,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	.raw_offs = 0,
 	.raw_size = 0
 	},
@@ -333,14 +319,14 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_ecc_pub_key_attrs[] = {
 	{
 	.attr_id = TEE_ATTR_ECC_PUBLIC_VALUE_X,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct ecc_public_key, x)
 	},
 
 	{
 	.attr_id = TEE_ATTR_ECC_PUBLIC_VALUE_Y,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct ecc_public_key, y)
 	},
 
@@ -356,21 +342,21 @@ static const struct tee_cryp_obj_type_attrs tee_cryp_obj_ecc_keypair_attrs[] = {
 	{
 	.attr_id = TEE_ATTR_ECC_PRIVATE_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct ecc_keypair, d)
 	},
 
 	{
 	.attr_id = TEE_ATTR_ECC_PUBLIC_VALUE_X,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct ecc_keypair, x)
 	},
 
 	{
 	.attr_id = TEE_ATTR_ECC_PUBLIC_VALUE_Y,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
-	.ops_index = ATTR_OPS_INDEX_BIGNUM,
+	.ops_index = ATTR_OPS_INDEX_KEY,
 	RAW_DATA(struct ecc_keypair, y)
 	},
 
@@ -558,10 +544,10 @@ static bool op_u32_from_binary_helper(uint32_t *v, const uint8_t *data,
 	return true;
 }
 
-static TEE_Result op_attr_secret_value_from_user(void *attr, const void *buffer,
+static TEE_Result op_attr_key_value_from_user(void *attr, const void *buffer,
 						 size_t size)
 {
-	struct tee_cryp_obj_secret *key = attr;
+	struct tee_cryp_obj_key *key = attr;
 
 	/* Data size has to fit in allocated buffer */
 	if (size > key->alloc_size)
@@ -571,7 +557,7 @@ static TEE_Result op_attr_secret_value_from_user(void *attr, const void *buffer,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result op_attr_secret_value_to_user(void *attr,
+static TEE_Result op_attr_key_value_to_user(void *attr,
 					       struct ts_session *sess __unused,
 					       void *buffer, uint64_t *size)
 {
@@ -595,7 +581,7 @@ static TEE_Result op_attr_secret_value_to_user(void *attr,
 	return copy_to_user(buffer, key + 1, key->key_size);
 }
 
-static TEE_Result op_attr_secret_value_to_binary(void *attr, void *data,
+static TEE_Result op_attr_key_value_to_binary(void *attr, void *data,
 					   size_t data_len, size_t *offs)
 {
 	TEE_Result res;
@@ -616,7 +602,7 @@ static TEE_Result op_attr_secret_value_to_binary(void *attr, void *data,
 	return TEE_SUCCESS;
 }
 
-static bool op_attr_secret_value_from_binary(void *attr, const void *data,
+static bool op_attr_key_value_from_binary(void *attr, const void *data,
 					     size_t data_len, size_t *offs)
 {
 	struct tee_cryp_obj_secret *key = attr;
@@ -638,7 +624,7 @@ static bool op_attr_secret_value_from_binary(void *attr, const void *data,
 }
 
 
-static TEE_Result op_attr_secret_value_from_obj(void *attr, void *src_attr)
+static TEE_Result op_attr_key_value_from_obj(void *attr, void *src_attr)
 {
 	struct tee_cryp_obj_secret *key = attr;
 	struct tee_cryp_obj_secret *src_key = src_attr;
@@ -650,7 +636,7 @@ static TEE_Result op_attr_secret_value_from_obj(void *attr, void *src_attr)
 	return TEE_SUCCESS;
 }
 
-static void op_attr_secret_value_clear(void *attr)
+static void op_attr_key_value_clear(void *attr)
 {
 	struct tee_cryp_obj_secret *key = attr;
 
@@ -833,14 +819,14 @@ static void op_attr_value_clear(void *attr)
 }
 
 static const struct attr_ops attr_ops[] = {
-	[ATTR_OPS_INDEX_SECRET] = {
-		.from_user = op_attr_secret_value_from_user,
-		.to_user = op_attr_secret_value_to_user,
-		.to_binary = op_attr_secret_value_to_binary,
-		.from_binary = op_attr_secret_value_from_binary,
-		.from_obj = op_attr_secret_value_from_obj,
-		.free = op_attr_secret_value_clear, /* not a typo */
-		.clear = op_attr_secret_value_clear,
+	[ATTR_OPS_INDEX_KEY] = {
+		.from_user = op_attr_key_value_from_user,
+		.to_user = op_attr_key_value_to_user,
+		.to_binary = op_attr_key_value_to_binary,
+		.from_binary = op_attr_key_value_from_binary,
+		.from_obj = op_attr_key_value_from_obj,
+		.free = op_attr_key_value_clear, /* not a typo */
+		.clear = op_attr_key_value_clear,
 	},
 	[ATTR_OPS_INDEX_BIGNUM] = {
 		.from_user = op_attr_bignum_from_user,

--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -102,6 +102,7 @@
 #define TEE_USAGE_SIGN                     0x00000010
 #define TEE_USAGE_VERIFY                   0x00000020
 #define TEE_USAGE_DERIVE                   0x00000040
+#define TEE_USAGE_RSEC                     0xffffffff /* TBD */
 #define TEE_HANDLE_FLAG_PERSISTENT         0x00010000
 #define TEE_HANDLE_FLAG_INITIALIZED        0x00020000
 #define TEE_HANDLE_FLAG_KEY_SET            0x00040000

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -92,6 +92,28 @@ void TEE_RestrictObjectUsage(TEE_ObjectHandle object, uint32_t objectUsage)
 TEE_Result TEE_RestrictObjectUsage1(TEE_ObjectHandle object, uint32_t objectUsage)
 {
 	TEE_Result res;
+	TEE_ObjectInfo objectInfo;
+
+	res = _utee_cryp_obj_get_info((unsigned long)object, &objectInfo);
+	if (res != TEE_SUCCESS)
+		TEE_Panic(res);
+
+	if (!(objectInfo.objectUsage & TEE_USAGE_RSEC) &&
+	    objectUsage & TEE_USAGE_RSEC) {
+		if (info.handleFlags & TEE_HANDLE_FLAG_INITIALIZED) {
+			/*
+			 * Wrap the key from plain text to rsec format by
+			 * calling the (*wrap) function
+			*/
+		} else {
+			/*
+			 * Nothing to do here, the key will be generated as
+			 * rsec by the Crypto driver with the following call
+			 * to TEE_GenerateKey(). Calling this function will set
+			 * the flag TEE_HANDLE_FLAG_INITIALIZED to the object.
+			 */
+		}
+	}
 
 	res = _utee_cryp_obj_restrict_usage((unsigned long)object,
 					    objectUsage);


### PR DESCRIPTION
Hello,

Here is a RFC pull-request for the integration of the runtime secure key within OPTEE as well as its interface for the Crypto HW driver. This work is a follow-up of the RFC made by Sahil and Ruchika a year ago for the RSA runtime secure key proposal. The runtime secure key concept has been extended to all cryptographic algorithms. https://github.com/OP-TEE/optee_os/pull/3514

The notion of encrypted/protected key is called here "rsec" for Runtime Secure key (after Sahil and Ruchika in the first PR). Nothing is definitive, all naming can be changed later.
Please note that the code attached does not feature all changes required for the actual implementation yet.

# Definition of a Runtime Secure Key (or RSEC)  

A Runtime Secure Key is a key protected and handled by the Crypto driver. A RSEC key would have the following properties:

-   The RSEC key buffer never holds the plain text key.
-   The key could only be wrapped in one way : plain text → RSEC. The opposite operation cannot be implemented.
-   Only the crypto driver would be able to use the RSEC key for crypto operations.
-   The RSEC key buffer content is the same whatever the object type (persistent or transient).

All operations related to rsec key are handled by the Crypto driver. By delegating the rsec key handling to the Crypto driver, we ensure that the key is never exposed unprotected in memory. It's up to the Crypto driver to implement the key protection. The crypto driver must implement:

-   Key allocation
-   Key generation and encapsulation
-   Key usage for cryptographic operations

To implement the RSEC key concept, we plan on:

-   Using attributes and object of the TEE Crypto API to do the distinction between RSEC and non-RSEC keys.
-   Introducing a common key object for all algorithms.
-   Adding the RSEC key concept to the Crypto HW API interface so any Crypto Driver could implement its own runtime secure key.

We aim at making the RSEC key implementation as generic as possible so a wide variety of Crypto driver could implement the RSEC key. The RSEC key can be an encrypted key stored in memory but it could also be a key stored in an external secure memory. Because the RSEC key data buffer is only handled by the crypto driver, it leaves the crypto driver a lot of flexibility on how the RSEC key is implemented.

# The implementation

## TEE Crypto API RSEC implementation

If we want to leave the choice to use or not an RSEC key for crypto operations, we need a way to designate the use of a RSEC key in the TA through the TEE Crypto API. Appending the TEE Crypto API for a new encrypted key concept would take a lot of time, the best would be to count on the Crypto API flexibility and "Object Usage".

What we suggest is the add a new **TEE_USAGE_PLAIN_KEY** to designate a RSEC or non-RSEC key. We would use the **TEE_RestrictObjectUsage1()** function to enable this new key usage. This idea was suggested in the previous RFC. In the previous RFC, using the already existing attribute **TEE_USAGE_EXTRACTABLE** as been suggested but it might be confusing to designate a RSEC key.

> The TEE_USAGE* would be called set by the `TEE_RestrictObjectUsage1()` function in 3 different scenarios:
> 
> 1.  When the object is Uninitialized [Transient Uninitialized Object]
> 2.  When object is Initialized and Not-persistent [Transient Initialized Object]
> 3.  When object is Initialized and Persistent. [Persistent Object]
> 
> The case 1 would generate a black key or wrap a plain key into a black key.
> 
> The cases 2 and 3 would encapsulate a plain key into an encrypted key. Since it is possible to call TEE_RestrictObjectUsage1() after the object initialization, the function TEE_RestrictObjectUsage1() will have to call the crypto driver to encapsulate the key. The crypto driver might need to reallocate the key accordingly.
> 
> (Credit @Ruchika)

Since **TEE_RestrictObjectUsage1()** defines the RSEC key and can be invoked at different stages of the object lifecycle, the **TEE_RestrictObjectUsage1()** will need to do a bit more than setting object flags. This function needs to do the following operations:

-   **If TEE_RestrictObjectUsage1(~TEE_USAGE_PLAIN_KEY ) and NOT** **TEE_HANDLE_FLAG_INITIALIZED then ..**
    -   **TEE_GenerateKey()**: call the appropriate Crypto driver to generate the key.
-   **If TEE_RestrictObjectUsage1(~TEE_USAGE_PLAIN_KEY) AND** **TEE_HANDLE_FLAG_INITIALIZED**
    -   **TEE_RestrictObjectUsage1():** call Crypto driver to wrap the key.

Adding a new TEE_USAGE will have an impact on already existing TA using **TEE_RestrictObjectUsage1().** If a TA restricts an object usage without including the newly added **TEE_USAGE_PLAIN_KEY** in the bitfield, then the object will be set as RSEC and that might be not wanted. Same thing would happen if we reuse **TEE_USAGE_EXTRACTABLE.** A TA using this attribute with **TEE_RestrictObjectUsage1****()** might ends up with a RSEC. Using a **TEE_USAGE*** to define a RSEC key or not, will have an impact on retro-compatibility.

Another straight forward solution would be to have a compilation flag for the Crypto Driver like **CFG_CRYPTO_DRV_[CIPHER, MAC, RSA ...] _RSEC** that enables the use by default of RSEC keys. Keys are generated as RSEC and wrapped as RSEC when populated. This way, there is no need to implement the RSEC key use in the TEE Crypto API.

## Introduce a new key object

Introducing a new key object in the code seems to be mandatory for a proper implementation of the rsec key. This object is an extension of obj_secret. Until now, key were handled differently depending of the algorithm. For the acipher, we have the bignum format and for the cipher, we have the combo buffer + length to handle the key. A good idea would be to unify the key format and use the following for all crypto keys:

``` C
struct tee_cryp_obj_key {
        /* Size of the security key */
	size_t size;
        /* Space allocated to store the key in memory */
	size_t alloc_size;
        /* Key buffer */
	uint8_t *data;
        /* A key attribute to know if the key is rsec or not (and potentially more info) */
        bool/uint32_t status;

        /* Key operation vectors */
	struct key_ops *ops;
};
```

-   **size_t size** : this variable holds the key security size. 128, 192, 256 ... for the Cipher and 1024, 2048 or 192, 224, 521 for the Asymmetric crypto. The size would be in bits.
-   **size_t alloc_size**: this variable holds the memory space allocated by the key buffer. Some crypto driver might need more space than the key security size to store metadata, checksum, nonce ... The Black key encapsulation in the CAAM adds at least to 12 more bytes to the encrypted key (6 bytes for the nonce and 6 bytes for the ICV). Because of the ICV, only a valid black key can be loaded. The size would be in bytes.
-   **uint8_t \*data**: data buffer holds the encrypted key and/or metadata.
-   **bool status**: flag that says if the key should be treated as rsec or plain text. We could also use a 32 bits value if we want to store more key attributes which is not the case currently.
-   **struct key_ops \*ops**: key operation vectors implemented by the crypto driver and initialized at key allocation/re-allocation. See bellow.

This key object implementation would discard the bignum format for the OPTEE core and asymmetric keys. For RSA keypair, we would have the following for example:

``` C
struct rsa_keypair {
	struct tee_cryp_obj_key *e;	/* Public exponent */
	struct tee_cryp_obj_key *d;	/* Private exponent */
	struct tee_cryp_obj_key *n;	/* Modulus */

	/* Optional CRT parameters (all NULL if unused) */
	struct tee_cryp_obj_key *p;	    /* N = pq */
	struct tee_cryp_obj_key *q;
	struct tee_cryp_obj_key *qp;	/* 1/q mod p */
	struct tee_cryp_obj_key *dp;	/* d mod (p-1) */
	struct tee_cryp_obj_key *dq;	/* d mod (q-1) */
}
```

The key operation vectors are initialized by the crypto driver upon key allocation. These functions are needed since some special operations must be done by the crypto driver to wrap the key.
``` C
struct key_ops {
	TEE_Result (*wrap)(struct tee_cryp_obj_key *key);
}
```

Currently, there is only one key operation :

-   **wrap() :** the "wrap" operation is the key encapsulation from plain text to RSEC.

## Add the RSEC key support in the Crypto HW API

**Add new cipher operation vectors**

Currently, the cipher and acipher don't have the same operation vectors. Basically, the cipher lacks key allocation and the key generation the acipher currently has. Extending the Crypto HW API to handle this part would allow the Crypto driver to handle the protected key allocation, generation and usage. This way the key generation is extended to the HW Crypto API and not restricted to a software RNG.

Here is what the cipher interface would look like:
``` C
struct drvcrypt_cipher {
	/* Allocate context */
	TEE_Result (*alloc_ctx)(void **ctx, uint32_t algo);
	/* Free context */
	void (*free_ctx)(void *ctx);
	/* Initialize the cipher operation */
	TEE_Result (*init)(struct drvcrypt_cipher_init *dinit);
	/* Update the cipher operation */
	TEE_Result (*update)(struct drvcrypt_cipher_update *dupdate);
	/* Finalize the cipher operation */
	void (*final)(void *ctx);
	/* Copy cipher context */
	void (*copy_state)(void *dst_ctx, void *src_ctx);

    + /* Generate key */
    + TEE_Result (*generate_key)(struct key_object{});
    + /* Allocate key */
    + TEE_Result (*alloc_key)(struct key_object{});
};
```
The same thing must be done for the MAC also ...

# CAAM features

## Black key and Black blob definitions

CAAM's black key mechanism is intended for protection of user keys against bus snooping and memory dumping while the keys are being written to or read from memory external to the SoC. The black key mechanism automatically encapsulates and decapsulates cryptographic keys on-the-fly in an encrypted data structure called a black key. Before a value is copied from a key register to memory, CAAM automatically encrypts the key as a black key (encrypted key) using as the encryption key the current value in the JDKEKR or TDKEKR, modified via the appropriate TZ/SDID value. Thus, each security domain (and TrustZone SecureWorld) has its own private black keys, which cannot be decrypted by the user of a different security domain identifier. When CAAM is instructed to use a black key as an encryption key, CAAM automatically decrypts the black key and places it directly into a key register before using the decrypted value in the user-specified cryptographic operation. Please note that JDKEKR and TDKEKR values are randomly re-generated at boot. The life expectancy of a black key is a power-cycle (reset or suspend/resume). A black key generated during a power cycle n cannot be decrypted and used starting the power cycle n+1. To make a black key power-cycle proof, a black key must be stored as a Blob (see bellow).

CAAM's built-in blob protocol provides a method for protecting user-defined data across system power cycles. The data to be protected is encrypted so that it can be safely placed into non-volatile storage before the chip is powered down. Each time that the blob protocol is used to protect data, a different randomly generated key is used to encrypt the data. This random key is itself encrypted using a key encryption key and the resulting encrypted key is then stored along with the encrypted data. The key-encryption key is derived from the chip's master secret key so the key-encryption key can be recreated when the chip powers up again. The combination of encrypted key and encrypted data is called a blob.

## Technical CAAM RSEC key implementation

On NXP platforms, the RSEC key will be stored as a black blob and not as a black key. The reason is that JDKEK and TDKEK and KEK nonce are regenerated upon every suspend/resume and system reset. Because of this, a black key will be unusable after a simple suspend/resume. Storing the key as blob instead of a black might have an impact on CAAM performance but it is negligible.

# Credits
@lenormandfranck @sahilnxp @cneveux 