### PR TITLE
ta: pkcs11: fix error code in asymmetric signature update sequence

### DIFF
--- a/ta/pkcs11/src/processing_asymm.c
+++ b/ta/pkcs11/src/processing_asymm.c
@@ -526,6 +526,7 @@ enum pkcs11_rc step_asymm_operation(struct pkcs11_session *session,
 
 			TEE_DigestUpdate(proc->tee_hash_op_handle, in_buf,
 					 in_size);
+			rc = PKCS11_CKR_OK;
 			break;
 		default:
 			/*


### PR DESCRIPTION
Correct return code in asymmetric update sequence when digest of
the input data is updated on a multi-stage operation. Prior this
change, the implementation returned CKR_GENERAL_ERROR instead of
CKR_OK because the expected success return value was loaded for
that stage.

Fixes: fb279d8b608e ("ta: pkcs11: Add support for elliptic curve signing & verification")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
