### PR TITLE
core: arm64: remove duplicate definition of THREAD_CTX_SIZE

### DIFF
--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -71,7 +71,6 @@ DEFINES
 	DEFINE(THREAD_CTX_KERN_SP, offsetof(struct thread_ctx, kern_sp));
 	DEFINE(THREAD_CTX_STACK_VA_END, offsetof(struct thread_ctx,
 						 stack_va_end));
-	DEFINE(THREAD_CTX_SIZE, sizeof(struct thread_ctx));
 
 	/* struct thread_ctx_regs */
 	DEFINE(THREAD_CTX_REGS_SP, offsetof(struct thread_ctx_regs, sp));


### PR DESCRIPTION
Following commit 1b302ac09816 ("core: enable FF-A with SPM Core at
S-EL1"), the THREAD_CTX_SIZE macro is now defined twice on arm64
(in $(out-dir)/core/include/generated/asm-defines.h).

Kill the definition in the #ifdef ARM64 block and keep the common
one.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
