### PR TITLE
core: Fix r7 clobbering in reset_primary

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -549,7 +549,7 @@ shadow_stack_access_ok:
 	mov	r1, r5		/* ns-entry address */
 	bl	boot_init_primary_early
 #ifndef CFG_VIRTUALIZATION
-	mov	r7, sp
+	mov	r9, sp
 	ldr	r0, =threads
 	ldr	r0, [r0, #THREAD_CTX_STACK_VA_END]
 	mov	sp, r0
@@ -563,7 +563,7 @@ shadow_stack_access_ok:
 #ifndef CFG_VIRTUALIZATION
 	mov	r0, #THREAD_CLF_TMP
 	str	r0, [r8, #THREAD_CORE_LOCAL_FLAGS]
-	mov	sp, r7
+	mov	sp, r9
 #endif
 
 	/*


### PR DESCRIPTION
During reset_primary, r7 is used to keep the content of r2 register
given to OP-TEE at start. However, r7 is clobbered during boot. This lead
to r2 being incorrectly restored when returning to normal world and
thus r2 value being corrupted. Use r9 instead where needed of r7 to
avoid clobbering it.

Signed-off-by: Clément Léger <clement.leger@bootlin.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
