### PR TITLE
build: ldelf and TAs can rely on CFLAGS32/CFLAGS64

### DIFF
--- a/ldelf/ldelf.mk
+++ b/ldelf/ldelf.mk
@@ -17,6 +17,7 @@ endif
 ifeq ($(CFG_ARM32_core),y)
 CFG_ARM32_$(sm) := y
 endif
+arch-bits-$(sm) := $(arch-bits-core)
 
 cppflags$(sm)	+= -include $(conf-file)
 cppflags$(sm)	+= -DTRACE_LEVEL=$(CFG_TEE_CORE_LOG_LEVEL)

--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -1,4 +1,6 @@
 include mk/cleanvars.mk
+
+# Set $(sm) as the name of the in tree TA being built, for instance "avb" or "pkcs11"
 sm := $(lastword $(subst /, ,$(dir $(ta-mk-file))))
 sm-$(sm) := y
 
@@ -6,6 +8,9 @@ sm-$(sm) := y
 ta-target := $(strip $(if $(CFG_USER_TA_TARGET_$(sm)), \
 		$(filter $(CFG_USER_TA_TARGET_$(sm)), $(ta-targets)), \
 		$(default-user-ta-target)))
+
+arch-bits-ta_arm32 := 32
+arch-bits-ta_arm64 := 64
 
 ta-dev-kit-dir$(sm) := $(out-dir)/export-$(ta-target)
 link-out-dir$(sm) := $(out-dir)/$(patsubst %/,%, $(dir $(ta-mk-file)))

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -26,6 +26,8 @@ libname := $(LIBNAME)
 shlibname := $(SHLIBNAME)
 shlibuuid := $(SHLIBUUID)
 
+arch-bits-ta_arm32 := 32
+arch-bits-ta_arm64 := 64
 
 ifneq ($V,1)
 q := @


### PR DESCRIPTION
Defines arch-bits-$(sm) for ldelf and intree TAs sub components
so that they can build using CFLAGS32 (or CFLAGS64) directives
possibly passed by the build environment.

Defines arch-bits-ta_arm32 (resp. 64) in TA devkit to leverage
CFLAGS32 (reps. CFLAGS64) directive passed by the build process. This
change is needed for external package willing to pass specific
directive to TA build sequence as toolchain's sysroot path.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
