### PR TITLE
ta: remove deprecated CFG_TA_DYNLINK

### DIFF
--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -22,9 +22,6 @@ ifeq ($(CFG_TEE_TA_MALLOC_DEBUG),y)
 $(sm)-platform-cppflags += -DENABLE_MDBG=1
 endif
 
-# Keep CFG_TA_DYNLINK for backwards compatibility
-$(call force,CFG_TA_DYNLINK,y)
-
 # Config variables to be explicitly exported to the dev kit conf.mk
 ta-mk-file-export-vars-$(sm) += CFG_TA_FLOAT_SUPPORT
 ta-mk-file-export-vars-$(sm) += CFG_CACHE_API
@@ -33,7 +30,6 @@ ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS_SELF_TEST
 ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS
 ta-mk-file-export-vars-$(sm) += CFG_TA_MBEDTLS_MPI
 ta-mk-file-export-vars-$(sm) += CFG_SYSTEM_PTA
-ta-mk-file-export-vars-$(sm) += CFG_TA_DYNLINK
 ta-mk-file-export-vars-$(sm) += CFG_FTRACE_SUPPORT
 ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT


### PR DESCRIPTION
Fully remove configuration switch CFG_TA_DYNLINK that is deprecated
since 3.6.0, see commit d1911a85142d ("core: load TAs using ldelf").

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
