### PR TITLE
plat-stm32mp1: Don't call get_embedded_dt() without CFG_EMBED_DT

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -104,7 +104,7 @@ void console_init(void)
 	IMSG("Early console on UART#%u", CFG_STM32_EARLY_CONSOLE_UART);
 }
 
-#ifdef CFG_DT
+#ifdef CFG_EMBED_DTB
 static TEE_Result init_console_from_dt(void)
 {
 	struct stm32_uart_pdata *pd = NULL;

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -162,7 +162,7 @@ static __maybe_unused const char *shres2str_state(enum shres_state id)
 }
 
 /* GPIOZ bank pin count depends on SoC variants */
-#ifdef CFG_DT
+#ifdef CFG_EMBED_DTB
 /* A light count routine for unpaged context to not depend on DTB support */
 static int gpioz_nbpin = -1;
 

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -546,7 +546,7 @@ bool stm32_bsec_nsec_can_access_otp(uint32_t otp_id)
 	       nsec_access_granted(otp_id - otp_upper_base());
 }
 
-#ifdef CFG_DT
+#ifdef CFG_EMBED_DTB
 static void enable_nsec_access(unsigned int otp_id)
 {
 	unsigned int idx = (otp_id - otp_upper_base()) / BITS_PER_WORD;
@@ -647,7 +647,7 @@ static void initialize_bsec_from_dt(void)
 static void initialize_bsec_from_dt(void)
 {
 }
-#endif /*CFG_DT*/
+#endif /*CFG_EMBED_DTB*/
 
 static TEE_Result initialize_bsec(void)
 {

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -315,7 +315,7 @@ void stm32_etzpc_init(paddr_t base)
 	init_device_from_hw_config(&etzpc_dev, base);
 }
 
-#ifdef CFG_DT
+#ifdef CFG_EMBED_DTB
 static TEE_Result init_etzpc_from_dt(void)
 {
 	void *fdt = get_embedded_dt();
@@ -343,4 +343,4 @@ static TEE_Result init_etzpc_from_dt(void)
 }
 
 service_init(init_etzpc_from_dt);
-#endif /*CFG_DT*/
+#endif /*CFG_EMBED_DTB*/


### PR DESCRIPTION
Several pieces of stm32mp1 code call get_embedded_dt(), then use the
resulting pointer without checks, or initiate a panic if it is NULL.
Thus hitting this code results in a non-working binary. For example:

    "PLATFORM=stm32mp1 CFG_DT=y"

The get_embedded_dt() uses were #ifdef'd out based on CFG_DT. However,
as shown, this is problematic, as the calls assumed a valid fdt must
be returned. A non-NULL fdt can be guaranteed with CFG_EMBED_DT, so
use this as the basis for the #ifdefs.

Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
