### PR TITLE
core: don't register heap pools when too small

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -416,8 +416,9 @@ static void init_runtime(unsigned long pageable_part)
 
 	init_asan();
 
-	malloc_add_pool(__heap1_start, __heap1_end - __heap1_start);
+	/* Add heap2 first as heap1 may be too small as initial bget pool */
 	malloc_add_pool(__heap2_start, __heap2_end - __heap2_start);
+	malloc_add_pool(__heap1_start, __heap1_end - __heap1_start);
 
 	/*
 	 * This needs to be initialized early to support address lookup

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -765,15 +765,19 @@ static void gen_malloc_add_pool(struct malloc_ctx *ctx, void *buf, size_t len)
 	uint32_t exceptions;
 	uintptr_t start = (uintptr_t)buf;
 	uintptr_t end = start + len;
-	const size_t min_len = ((sizeof(struct malloc_pool) + (SizeQuant - 1)) &
-					(~(SizeQuant - 1))) +
-				sizeof(struct bhead) * 2;
+	const size_t min_len = sizeof(struct bhead) + sizeof(struct bfhead);
 
 	start = ROUNDUP(start, SizeQuant);
 	end = ROUNDDOWN(end, SizeQuant);
 
 	if (start > end || (end - start) < min_len) {
 		DMSG("Skipping too small pool");
+		return;
+	}
+
+	/* First pool requires a bigger size */
+	if (!ctx->pool_len && (end - start) < MALLOC_INITIAL_POOL_MIN_SIZE) {
+		DMSG("Skipping too small initial pool");
 		return;
 	}
 

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -8,6 +8,12 @@
 #include <stddef.h>
 #include <types_ext.h>
 
+/*
+ * Due to bget implementation, the first memory pool registered shall have
+ * a min size. Choose 1kB which is reasonable.
+ */
+#define MALLOC_INITIAL_POOL_MIN_SIZE	1024
+
 void free(void *ptr);
 
 #ifdef ENABLE_MDBG

--- a/ta/arch/arm/user_ta_header.c
+++ b/ta/arch/arm/user_ta_header.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  */
 #include <compiler.h>
+#include <malloc.h>
 #include <tee_ta_api.h>
 #include <tee_internal_api_extensions.h>
 #include <trace.h>
@@ -90,6 +91,10 @@ const struct ta_head ta_head __section(".ta_head") = {
 };
 
 /* Keeping the heap in bss */
+#if TA_DATA_SIZE < MALLOC_INITIAL_POOL_MIN_SIZE
+#error TA_DATA_SIZE too small
+#endif
+
 uint8_t ta_heap[TA_DATA_SIZE];
 const size_t ta_heap_size = sizeof(ta_heap);
 


### PR DESCRIPTION
Don't add heap1 pool when smaller than 64 bytes when CFG_WITH_PAGER=y.
Bget memory allocation stack fails when pools are too small. This change
does not correct the issue but works around it as losing 64 byte of heap
here is affordable even when OP-TEE pager is enabled.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
