### PR TITLE
core: arm: fix test on CFG_CC_OPTIMIZE_FOR_SIZE value

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -154,10 +154,6 @@ ifeq ($(DEBUG),1)
 $(call force,CFG_CC_OPT_LEVEL,0)
 $(call force,CFG_DEBUG_INFO,y)
 endif
-ifeq ($(CFG_CC_OPTIMIZE_FOR_SIZE),n)
-# For backwards compatibility
-$(call force,CFG_CC_OPT_LEVEL,0)
-endif
 
 # Optimize for size by default, usually gives good performance too
 CFG_CC_OPT_LEVEL ?= s

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -149,17 +149,8 @@ arm64-platform-cflags-no-hard-float ?= -mgeneral-regs-only
 arm64-platform-cflags-hard-float ?=
 arm64-platform-cflags-generic := -mstrict-align $(call cc-option,-mno-outline-atomics,)
 
-ifeq ($(DEBUG),1)
-# For backwards compatibility
-$(call force,CFG_CC_OPT_LEVEL,0)
-$(call force,CFG_DEBUG_INFO,y)
-endif
-
-# Optimize for size by default, usually gives good performance too
-CFG_CC_OPT_LEVEL ?= s
 platform-cflags-optimization ?= -O$(CFG_CC_OPT_LEVEL)
 
-CFG_DEBUG_INFO ?= y
 ifeq ($(CFG_DEBUG_INFO),y)
 platform-cflags-debug-info ?= -g3
 platform-aflags-debug-info ?= -g

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -40,6 +40,18 @@ PYTHON3 ?= python3
 
 # Define DEBUG=1 to compile without optimization (forces -O0)
 # DEBUG=1
+ifeq ($(DEBUG),1)
+# For backwards compatibility
+$(call force,CFG_CC_OPT_LEVEL,0)
+$(call force,CFG_DEBUG_INFO,y)
+endif
+
+# CFG_CC_OPT_LEVEL sets compiler optimization level passed with -O directive.
+# Optimize for size by default, usually gives good performance too.
+CFG_CC_OPT_LEVEL ?= s
+
+# Enabling CFG_DEBUG_INFO makes debug information embedded in core.
+CFG_DEBUG_INFO ?= y
 
 # If y, enable debug features of the TEE core (assertions and lock checks
 # are enabled, panic and assert messages are more verbose, data and prefetch


### PR DESCRIPTION
Makefile should test disabled CFG_CC_OPTIMIZE_FOR_SIZE against not
being 'y' instead of being 'n'.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
