### PR TITLE
core: enable system PTA upon user TA support

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -551,8 +551,10 @@ CFG_SECSTOR_TA_MGMT_PTA ?= $(call cfg-all-enabled,CFG_SECSTOR_TA)
 $(eval $(call cfg-depends-all,CFG_SECSTOR_TA_MGMT_PTA,CFG_SECSTOR_TA))
 
 # Enable the pseudo TA for misc. auxilary services, extending existing
-# GlobalPlatform Core API (for example, re-seeding RNG entropy pool etc.)
-CFG_SYSTEM_PTA ?= y
+# GlobalPlatform TEE Internal Core API (for example, re-seeding RNG entropy
+# pool etc...)
+CFG_SYSTEM_PTA ?= $(CFG_WITH_USER_TA)
+$(eval $(call cfg-depends-all,CFG_SYSTEM_PTA,CFG_WITH_USER_TA))
 
 # Enable the pseudo TA for enumeration of TEE based devices for the normal
 # world OS.


### PR DESCRIPTION
Ensure CFG_SYSTEM_PTA is disabled when CFG_WITH_USER_TA is disabled since
system PTA is designed to provide user TA extended system features.
Without this change, building with CFG_SYSTEM_PTA=y and CFG_WITH_USER_TA=n
may fails with error traces like:
core/pta/system.c:227: undefined reference to 'ldelf_dlopen'
core/pta/system.c:260: undefined reference to 'ldelf_dlsym'

Also fix reference to the GPD TEE Internal Core API in CFG_SYSTEM_PTA
description.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
