### PR TITLE
[RFC] ci: azure: add job to build and run the Rust tests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -242,3 +242,22 @@ jobs:
           sudo -E rm -rf /root/optee_repo_qemu_v8/out-br/build/optee_test*
           sudo -E make -C /root/optee_repo_qemu_v8/build arm-tf-clean
           sudo -E make -C /root/optee_repo_qemu_v8/build -j$(getconf _NPROCESSORS_ONLN) CFG_TEE_CORE_LOG_LEVEL=0 check XEN_BOOT=y
+
+  - job: QEMUv8_build_Rust
+    displayName: 'Run regression tests (Rust) in QEMUv8'
+    pool:
+      vmImage: ubuntu-18.04
+    container:
+      image: jforissier/optee_os_ci:qemuv8_check
+    steps:
+      - script: |
+          set -e -v
+          export HOME=/root
+          export LC_ALL=C
+          WD=$(pwd)
+          sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
+          sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
+          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
+          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+
+          sudo -E bash -c "make -C /root/optee_repo_qemu_v8/build -j$(getconf _NPROCESSORS_ONLN) CFG_TEE_CORE_LOG_LEVEL=0 OPTEE_RUST_ENABLE=y check-rust"


### PR DESCRIPTION
Add a job to the Azure CI to build the Rust examples in the
Teaclave Trustzone SDK [1]. They are part of the "buildroot" target so
restrict the build to that particular target to save time.

Link: [1] https://github.com/apache/incubator-teaclave-trustzone-sdk/
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
