### PR TITLE
plat-ls: conf.mk: correct Embedded DTB flag

### DIFF
--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -89,7 +89,7 @@ $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_PL011,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,48)
-$(call force,CFG_EMBED_DT,y)
+$(call force,CFG_EMBED_DTB,y)
 $(call force,CFG_EMBED_DTB_SOURCE_FILE,fsl-lx2160a-qds.dts)
 CFG_LS_I2C ?= y
 CFG_LS_GPIO ?= y
@@ -108,7 +108,7 @@ $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_PL011,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,48)
-$(call force,CFG_EMBED_DT,y)
+$(call force,CFG_EMBED_DTB,y)
 $(call force,CFG_EMBED_DTB_SOURCE_FILE,fsl-lx2160a-rdb.dts)
 CFG_LS_I2C ?= y
 CFG_LS_GPIO ?= y


### PR DESCRIPTION
Emebedded DTB flag is CFG_EMBED_DTB which was wrongly
set as CFG_EMBED_DT.

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>