### PR TITLE
core: dt: fix missing const attribute on fdt reference

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -150,7 +150,8 @@ int _fdt_get_status(const void *fdt, int offs);
  * a single reset ID line and a single interrupt ID.
  * Default DT_INFO_* macros are used when the relate property is not found.
  */
-void _fdt_fill_device_info(void *fdt, struct dt_node_info *info, int node);
+void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info,
+			   int node);
 
 #else /* !CFG_DT */
 
@@ -195,7 +196,7 @@ static inline int _fdt_get_status(const void *fdt __unused, int offs __unused)
 }
 
 __noreturn
-static inline void _fdt_fill_device_info(void *fdt __unused,
+static inline void _fdt_fill_device_info(const void *fdt __unused,
 					 struct dt_node_info *info __unused,
 					 int node __unused)
 {

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -258,7 +258,7 @@ int _fdt_get_status(const void *fdt, int offs)
 	return st;
 }
 
-void _fdt_fill_device_info(void *fdt, struct dt_node_info *info, int offs)
+void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info, int offs)
 {
 	struct dt_node_info dinfo = {
 		.reg = DT_INFO_INVALID_REG,


### PR DESCRIPTION
The standard FDT reference in libfdt and friends is a const void *. Fix
few function prototypes that miss the const attribute.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
