### PR TITLE
libutils: ta: provide malloc(), calloc() and realloc() when debug is on

### DIFF
--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -684,7 +684,32 @@ void mdbg_check(int bufdump)
 {
 	gen_mdbg_check(&malloc_ctx, bufdump);
 }
-#else
+
+/*
+ * Since malloc debug is enabled, malloc() and friends are redirected by macros
+ * to mdbg_malloc() etc.
+ * We still want to export the standard entry points in case they are referenced
+ * by the application, either directly or via external libraries.
+ */
+#undef malloc
+void *malloc(size_t size)
+{
+	return mdbg_malloc(__FILE__, __LINE__, size);
+}
+
+#undef calloc
+void *calloc(size_t nmemb, size_t size)
+{
+	return mdbg_calloc(__FILE__, __LINE__, nmemb, size);
+}
+
+#undef realloc
+void *realloc(void *ptr, size_t size)
+{
+	return mdbg_realloc(__FILE__, __LINE__, ptr, size);
+}
+
+#else /* ENABLE_MDBG */
 
 void *malloc(size_t size)
 {

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -14,6 +14,10 @@
  */
 #define MALLOC_INITIAL_POOL_MIN_SIZE	1024
 
+void *malloc(size_t size);
+void *calloc(size_t nmemb, size_t size);
+void *realloc(void *ptr, size_t size);
+void *memalign(size_t alignment, size_t size);
 void free(void *ptr);
 
 #ifdef ENABLE_MDBG
@@ -36,15 +40,9 @@ void mdbg_check(int bufdump);
 
 #else
 
-void *malloc(size_t size);
-void *calloc(size_t nmemb, size_t size);
-void *realloc(void *ptr, size_t size);
-void *memalign(size_t alignment, size_t size);
-
 #define mdbg_check(x)        do { } while (0)
 
 #endif
-
 
 /*
  * Returns true if the supplied memory area is within a buffer


### PR DESCRIPTION
When enabling malloc debug for TAs (CFG_TEE_TA_MALLOC_DEBUG=y), the
standard malloc entry points malloc(), calloc() and realloc() are
redirected by C macros to instrumented variants: mdbg_malloc(),
mdbg_calloc() and mdbg_realloc(). In addition, the 'normal' symbols are
not exported by libutils. That is a problem because a TA might still
reference them. For example the C++ code in optee_test requires libstdc++
which relies on malloc() etc.:
```
build (master)$ make -j10 CFG_TEE_TA_MALLOC_DEBUG=y CFG_TEE_TA_LOG_LEVEL=2
...
/home/jerome/work/optee_repo_qemu/build/../toolchains/aarch32/bin/arm-linux-gnueabihf-ld.bfd: /home/jerome/work/toolchains-gcc10.2/aarch32/bin/../lib/gcc/arm-none-linux-gnueabihf/10.2.1/../../../../arm-none-linux-gnueabihf/lib/libstdc++.a(eh_alloc.o): in function `__cxa_allocate_exception':
/tmp/dgboter/bbs/build03--cen7x86_64/buildbot/cen7x86_64--arm-none-linux-gnueabihf/build/src/gcc/libstdc++-v3/libsupc++/eh_alloc.cc:284: undefined reference to `malloc'
...
```
Fix the issue by defining the standard malloc() functions in libutils,
calling the debug variants.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
