### PR TITLE
ta: mk: introduce CFLAGS32 and CFLAGS64

### DIFF
--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -29,6 +29,12 @@ shlibuuid := $(SHLIBUUID)
 arch-bits-ta_arm32 := 32
 arch-bits-ta_arm64 := 64
 
+# For convenience
+ifdef CFLAGS
+CFLAGS32 ?= $(CFLAGS)
+CFLAGS64 ?= $(CFLAGS)
+endif
+
 ifneq ($V,1)
 q := @
 cmd-echo := true


### PR DESCRIPTION
Hello,

With this commit recently merged : https://github.com/OP-TEE/optee_os/pull/4829
It is now required to export `CFLAGS64` and `CFLAGS32` in Yocto optee-test recipe to compile TAs.
This is due to the introduction of : 
https://github.com/OP-TEE/optee_os/blob/3469baa6e7a7b4920596e54ec4c7624314e32042/ta/mk/ta_dev_kit.mk#L29-L30
that make the export `CFLAGS64` and `CFLAGS32` required. Exporting `CFLAGS` only in the recipe won't work.
With this patch, if `CFLAGS` is defined, set `CFLAGS64` and `CFLAGS32` to `$(CFLAGS)`

For reference, the NXP recipes for OPTEE : https://source.codeaurora.org/external/imx/meta-imx/tree/meta-bsp/recipes-security/optee-imx?h=hardknott-5.10.52-2.1.0
Patch similar to a change introduced in b09cddcab1eee090886ca94ab9a4958ec6e174e0

Thanks!
Clement