### PR TITLE
Fix FID for FFA_SECONDARY_EP_REGISTER_64

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -69,7 +69,7 @@
 #define FFA_MEM_RECLAIM			U(0x84000077)
 #define FFA_MEM_FRAG_RX			U(0x8400007A)
 #define FFA_MEM_FRAG_TX			U(0x8400007B)
-#define FFA_SECONDARY_EP_REGISTER_64	U(0xC4000084)
+#define FFA_SECONDARY_EP_REGISTER_64	U(0xC4000087)
 
 /* Special value for traffic targeted to the Hypervisor or SPM */
 #define FFA_TARGET_INFO_MBZ		U(0x0)


### PR DESCRIPTION
From: Sudeep Holla <sudeep.holla@arm.com>

Commit ef30482b4ad6 ("plat-vexpress: FF-A: update secondary core init")
updated secondary core init for the vexpress platform. In the process,
it used FFA_SECONDARY_EP_REGISTER with FID 0xC4000084 based on the ALP0
ABI of the spec and the TF-A upstream implementation at the time with a
note that the function ID needs to updated to the one finalied in the
spec and the TF-A implementation.

Assuming it is all finalised now, let us update the same with correct/
updated FID 0xC4000087.

Cc: Jens Wiklander <jens.wiklander@linaro.org>
Cc: Olivier Deprez <olivier.deprez@arm.com>
Cc: Balint Dobszay <balint.dobszay@arm.com>
Signed-off-by: Sudeep Holla <sudeep.holla@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
