### PR TITLE
plat-stm32mp1: prepare for clock framework

### DIFF
--- a/core/arch/arm/dts/stm32mp157a-dk1.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1.dts
@@ -27,7 +27,6 @@
 
 &rcc {
 	status = "okay";
-	secure-status = "disable";
 };
 
 &bsec {

--- a/core/arch/arm/dts/stm32mp157c-dk2.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2.dts
@@ -95,7 +95,6 @@
 
 &rcc {
 	status = "okay";
-	secure-status = "disable";
 };
 
 &bsec {

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -369,7 +369,6 @@
 
 &rcc {
 	status = "okay";
-	secure-status = "disable";
 };
 
 &bsec {

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -64,8 +64,11 @@ CFG_DTB_MAX_SIZE ?= (256 * 1024)
 
 ifeq ($(CFG_EMBED_DTB_SOURCE_FILE),)
 # Some drivers mandate DT support
+$(call force,CFG_STM32_GPIO,n)
 $(call force,CFG_STM32_I2C,n)
 $(call force,CFG_STPMIC1,n)
+$(call force,CFG_STM32MP1_SCMI_SIP,n)
+$(call force,CFG_SCMI_PTA,n)
 endif
 
 CFG_STM32_BSEC ?= y

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1306,20 +1306,28 @@ static TEE_Result stm32mp1_clk_early_init(void)
 	unsigned int i = 0;
 	int len = 0;
 	int ignored = 0;
+	bool rcc_secure = true;
 
-	fdt = get_embedded_dt();
-	node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_CLK_COMPAT);
+	node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_SECURE_CLK_COMPAT);
+	if (node < 0) {
+		node = fdt_node_offset_by_compatible(fdt, -1,
+						     DT_RCC_CLK_COMPAT);
+		if (node < 0)
+			panic();
 
-	if (node < 0 || _fdt_reg_base_address(fdt, node) != RCC_BASE)
-		panic();
+		rcc_secure = false;
+	}
 
-	if (_fdt_get_status(fdt, node) & DT_STATUS_OK_SEC) {
-		io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
-	} else {
+	assert(_fdt_reg_base_address(fdt, node) == RCC_BASE);
+	assert(_fdt_get_status(fdt, node) != DT_STATUS_DISABLED);
+
+	if (!rcc_secure) {
 		if (io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN)
 			panic("Refuse to release RCC[TZEN]");
 
 		IMSG("RCC is non-secure");
+	} else {
+		io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
 	}
 
 	get_osc_freq_from_dt(fdt);

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1231,7 +1231,7 @@ static const char *stm32mp_osc_node_label[NB_OSC] = {
 	[_USB_PHY_48] = "ck_usbo_48m"
 };
 
-static unsigned int clk_freq_prop(void *fdt, int node)
+static unsigned int clk_freq_prop(const void *fdt, int node)
 {
 	const fdt32_t *cuint = NULL;
 	int ret = 0;
@@ -1247,7 +1247,7 @@ static unsigned int clk_freq_prop(void *fdt, int node)
 	return fdt32_to_cpu(*cuint);
 }
 
-static void get_osc_freq_from_dt(void *fdt)
+static void get_osc_freq_from_dt(const void *fdt)
 {
 	enum stm32mp_osc_id idx = _UNKNOWN_OSC_ID;
 	int clk_node = fdt_path_offset(fdt, "/clocks");
@@ -1299,36 +1299,22 @@ static void enable_static_secure_clocks(void)
 		stm32_clock_enable(RTCAPB);
 }
 
-static TEE_Result stm32mp1_clk_early_init(void)
+static void enable_rcc_tzen(void)
 {
-	void *fdt = NULL;
-	int node = 0;
+	io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
+}
+
+static void disable_rcc_tzen(void)
+{
+	IMSG("RCC is non-secure");
+	io_clrbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
+}
+
+static TEE_Result stm32mp1_clk_init(const void *fdt, int node)
+{
 	unsigned int i = 0;
 	int len = 0;
 	int ignored = 0;
-	bool rcc_secure = true;
-
-	node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_SECURE_CLK_COMPAT);
-	if (node < 0) {
-		node = fdt_node_offset_by_compatible(fdt, -1,
-						     DT_RCC_CLK_COMPAT);
-		if (node < 0)
-			panic();
-
-		rcc_secure = false;
-	}
-
-	assert(_fdt_reg_base_address(fdt, node) == RCC_BASE);
-	assert(_fdt_get_status(fdt, node) != DT_STATUS_DISABLED);
-
-	if (!rcc_secure) {
-		if (io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN)
-			panic("Refuse to release RCC[TZEN]");
-
-		IMSG("RCC is non-secure");
-	} else {
-		io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
-	}
 
 	get_osc_freq_from_dt(fdt);
 
@@ -1368,6 +1354,42 @@ static TEE_Result stm32mp1_clk_early_init(void)
 
 	if (ignored != 0)
 		IMSG("DT clock tree configurations were ignored");
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result stm32mp1_clk_early_init(void)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const void *fdt = get_embedded_dt();
+	bool rcc_secure = true;
+	int node = 0;
+
+	node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_SECURE_CLK_COMPAT);
+	if (node < 0) {
+		node = fdt_node_offset_by_compatible(fdt, -1,
+						     DT_RCC_CLK_COMPAT);
+		if (node < 0)
+			panic();
+
+		rcc_secure = false;
+	}
+
+	assert(_fdt_reg_base_address(fdt, node) == RCC_BASE);
+	assert(_fdt_get_status(fdt, node) != DT_STATUS_DISABLED);
+
+	if (!rcc_secure) {
+		if (io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN)
+			panic("Refuse to release RCC[TZEN]");
+
+		disable_rcc_tzen();
+	} else {
+		enable_rcc_tzen();
+	}
+
+	res = stm32mp1_clk_init(fdt, node);
+	if (res)
+		return res;
 
 	enable_static_secure_clocks();
 

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -593,13 +593,6 @@ static void register_non_secure_pmic(void)
 						 i2c_handle.pinctrl[n].pin);
 
 	stm32mp_register_non_secure_periph_iomem(i2c_handle.base.pa);
-
-	/*
-	 * Non secure PMIC can be used by secure world during power state
-	 * transition when non-secure world is suspended. Therefore secure
-	 * the I2C clock parents, if not specifically the I2C clock itself.
-	 */
-	stm32mp_register_clock_parents_secure(i2c_handle.clock);
 }
 
 static void register_secure_pmic(void)

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -541,7 +541,8 @@
 #define RCC_MP_IWDGFZSETR_IWDG1			BIT(0)
 #define RCC_MP_IWDGFZSETR_IWDG2			BIT(1)
 
-#define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"
+#define DT_RCC_CLK_COMPAT		"st,stm32mp1-rcc"
+#define DT_RCC_SECURE_CLK_COMPAT	"st,stm32mp1-rcc-secure"
 
 #ifndef __ASSEMBLER__
 vaddr_t stm32_rcc_base(void);

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -264,6 +264,7 @@ vaddr_t stm32mp_bkpreg(unsigned int idx)
 	return bkpreg_base() + (idx * sizeof(uint32_t));
 }
 
+#ifdef CFG_STM32_GPIO
 vaddr_t stm32_get_gpio_bank_base(unsigned int bank)
 {
 	static struct io_pa_va gpios_nsec_base = { .pa = GPIOS_NSEC_BASE };
@@ -298,3 +299,4 @@ unsigned int stm32_get_gpio_bank_clock(unsigned int bank)
 	assert(bank <= GPIO_BANK_K);
 	return GPIOA + bank;
 }
+#endif /* CFG_STM32_GPIO */

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2017-2019, STMicroelectronics
+ * Copyright (c) 2017-2021, STMicroelectronics
  */
 
+#include <config.h>
 #include <drivers/stm32_etzpc.h>
 #include <drivers/stm32_gpio.h>
 #include <drivers/stm32mp1_etzpc.h>
@@ -710,8 +711,10 @@ static TEE_Result stm32mp1_init_final_shres(void)
 	}
 
 	set_etzpc_secure_configuration();
-	set_gpio_secure_configuration();
-	register_pm_driver_cb(gpioz_pm, NULL);
+	if (IS_ENABLED(CFG_STM32_GPIO)) {
+		set_gpio_secure_configuration();
+		register_pm_driver_cb(gpioz_pm, NULL);
+	}
 	check_rcc_secure_configuration();
 
 	return TEE_SUCCESS;

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -13,6 +13,7 @@
 #ifndef __STM32_GPIO_H
 #define __STM32_GPIO_H
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -151,6 +152,7 @@ static inline int stm32_pinctrl_get_gpio_level(struct stm32_pinctrl *pinctrl)
 	return stm32_gpio_get_input_level(pinctrl->bank, pinctrl->pin);
 }
 
+#ifdef CFG_STM32_GPIO
 /*
  * Configure pin muxing access permission: can be secure or not
  *
@@ -160,6 +162,14 @@ static inline int stm32_pinctrl_get_gpio_level(struct stm32_pinctrl *pinctrl)
  */
 void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin,
 			       bool secure);
+#else
+static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
+					     unsigned int pin __unused,
+					     bool secure __unused)
+{
+	assert(0);
+}
+#endif
 
 /*
  * Get the number of GPIO pins supported by a target GPIO bank


### PR DESCRIPTION
A series of changes around resources to prepare support for generic clock API.