### PR TITLE
Keep the context of the last session

### DIFF
--- a/core/kernel/ts_manager.c
+++ b/core/kernel/ts_manager.c
@@ -26,13 +26,17 @@ static void update_current_ctx(struct thread_specific_data *tsd)
 			ctx = s->ctx;
 	}
 
-	if (tsd->ctx != ctx)
-		vm_set_ctx(ctx);
-	/*
-	 * If current context is of user mode, then it has to be active too.
-	 */
-	if (is_user_mode_ctx(ctx) != core_mmu_user_mapping_is_active())
-		panic("unexpected active mapping");
+	if(ctx)
+	{
+		if (tsd->ctx != ctx)
+			vm_set_ctx(ctx);
+
+		/*
+		* If current context is of user mode, then it has to be active too.
+		*/
+		if (is_user_mode_ctx(ctx) != core_mmu_user_mapping_is_active())
+			panic("unexpected active mapping");
+	}
 }
 
 void ts_push_current_session(struct ts_session *s)


### PR DESCRIPTION
Keep the context of the last session instead of deleting it when the
TA finishes executing an invoked commend, so if this TA is invoked
again, there's no need to retrieve the context.

Change-Id: Id2fa242e502a82c4e1b0dd6d9607dcad0a4c7a40

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
