### PR TITLE
poplar: disable CFG_SECURE_DATA_PATH by default

### DIFF
--- a/core/arch/arm/plat-poplar/conf.mk
+++ b/core/arch/arm/plat-poplar/conf.mk
@@ -25,7 +25,6 @@ ifeq ($(CFG_PL061),y)
 core-platform-cppflags		+= -DPLAT_PL061_MAX_GPIOS=104
 endif
 
-CFG_SECURE_DATA_PATH ?= y
 CFG_TEE_SDP_MEM_BASE ?= 0x02800000
 CFG_TEE_SDP_MEM_SIZE ?= 0x00400000
 


### PR DESCRIPTION
Since linaro-swg/linux.git branch optee [1] was rebased onto kernel
v5.12, Secure Data Path is broken in xtest [2] because the client side
is based on the ION allocator, which was removed from the kernel.

Therefore, disable SDP support by default.

Link: [1] https://github.com/linaro-swg/linux/tree/optee-v5.12-20210628
Link: [2] https://github.com/OP-TEE/optee_test/blob/3.13.0/host/xtest/regression_1000.c#L1220-L1263

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
