### PR TITLE
core: new config switch CFG_PREALLOC_RPC_CACHE

### DIFF
--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -255,6 +255,11 @@ __weak __rodata_unpaged("mobj_reg_shm_ops") = {
 	.dec_map = mobj_reg_shm_dec_map,
 };
 
+/* Releasing RPC preallocated shm mandates few resources to be unpaged */
+DECLARE_KEEP_PAGER(mobj_reg_shm_get_cookie);
+DECLARE_KEEP_PAGER(mobj_reg_shm_matches);
+DECLARE_KEEP_PAGER(mobj_reg_shm_free);
+
 static bool mobj_reg_shm_matches(struct mobj *mobj __maybe_unused,
 				   enum buf_is_attr attr)
 {

--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -239,8 +239,10 @@ static uint64_t mobj_reg_shm_get_cookie(struct mobj *mobj)
 }
 
 /*
- * Note: this variable is weak just to ease breaking its dependency chain
- * when added to the unpaged area.
+ * When CFG_PREALLOC_RPC_CACHE is disabled, this variable is weak just
+ * to ease breaking its dependency chain when added to the unpaged area.
+ * When CFG_PREALLOC_RPC_CACHE is enabled, releasing RPC preallocated
+ * shm mandates these resources to be unpaged.
  */
 const struct mobj_ops mobj_reg_shm_ops
 __weak __rodata_unpaged("mobj_reg_shm_ops") = {
@@ -255,10 +257,12 @@ __weak __rodata_unpaged("mobj_reg_shm_ops") = {
 	.dec_map = mobj_reg_shm_dec_map,
 };
 
+#ifdef CFG_PREALLOC_RPC_CACHE
 /* Releasing RPC preallocated shm mandates few resources to be unpaged */
 DECLARE_KEEP_PAGER(mobj_reg_shm_get_cookie);
 DECLARE_KEEP_PAGER(mobj_reg_shm_matches);
 DECLARE_KEEP_PAGER(mobj_reg_shm_free);
+#endif
 
 static bool mobj_reg_shm_matches(struct mobj *mobj __maybe_unused,
 				   enum buf_is_attr attr)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -693,3 +693,11 @@ ifeq (,$(CFG_HWRNG_QUALITY))
 $(error CFG_HWRNG_QUALITY not defined)
 endif
 endif
+
+# CFG_PREALLOC_RPC_CACHE, when enabled, makes core to preallocate
+# shared memory for each secure thread. When disabled, RPC shared
+# memory is released once the secure thread has completed is execution.
+ifeq ($(CFG_WITH_PAGER),y)
+CFG_PREALLOC_RPC_CACHE ?= n
+endif
+CFG_PREALLOC_RPC_CACHE ?= y


### PR DESCRIPTION
Since recent changes in Linux kernel to add a shutdown callback to optee driver, I saw an issue with OP-TEE pager.
Disabling SHM cache is done from a fastcall SMC context that mandates unpaged resources. The issue is that moving SHM release resource to unpaged sections cost 6kB (without debug, on armv7-A/stm32mp1).

This change proposes to introduce CFG_PREALLOC_RPC_CACHE to allow disabling RPC shm preallocation. Enabling the switch (default) ensures required resources are resisdent to pager. Disabling the switch prevents these extra 6kB space in unpaged sections.