### PR TITLE
core: add call_preinitcalls()

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1186,6 +1186,12 @@ void init_tee_runtime(void)
 	/* Pager initializes TA RAM early */
 	core_mmu_init_ta_ram();
 #endif
+	/*
+	 * With virtualization we call this function when creating the
+	 * OP-TEE partition instead.
+	 */
+	if (!IS_ENABLED(CFG_VIRTUALIZATION))
+		call_preinitcalls();
 	call_initcalls();
 }
 

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1175,13 +1175,19 @@ static void discover_nsec_memory(void)
 }
 #endif /*!CFG_CORE_DYN_SHM*/
 
-void init_tee_runtime(void)
-{
 #ifdef CFG_VIRTUALIZATION
+static TEE_Result virt_init_heap(void)
+{
 	/* We need to initialize pool for every virtual guest partition */
 	malloc_add_pool(__heap1_start, __heap1_end - __heap1_start);
+
+	return TEE_SUCCESS;
+}
+preinit_early(virt_init_heap);
 #endif
 
+void init_tee_runtime(void)
+{
 #ifndef CFG_WITH_PAGER
 	/* Pager initializes TA RAM early */
 	core_mmu_init_ta_ram();

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -15,6 +15,10 @@
 
 #include "thread_private.h"
 
+void __section(".text.dummy.call_preinitcalls") call_preinitcalls(void)
+{
+}
+
 void __section(".text.dummy.call_initcalls") call_initcalls(void)
 {
 }

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -267,6 +267,8 @@ uint32_t virt_guest_created(uint16_t guest_id)
 
 	/* Initialize threads */
 	thread_init_threads();
+	/* Do the preinitcalls */
+	call_preinitcalls();
 
 	exceptions = cpu_spin_lock_xsave(&prtn_list_lock);
 	LIST_INSERT_HEAD(&prtn_list, prtn, link);

--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -450,4 +450,4 @@ static TEE_Result mobj_mapped_shm_init(void)
 	return TEE_SUCCESS;
 }
 
-service_init(mobj_mapped_shm_init);
+preinit(mobj_mapped_shm_init);

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -593,4 +593,4 @@ const struct mobj_ops mobj_ffa_ops __weak __rodata_unpaged("mobj_ffa_ops") = {
 	.dec_map = ffa_dec_map,
 };
 
-service_init(mapped_shm_init);
+preinit(mapped_shm_init);

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -30,11 +30,66 @@ struct initcall {
 		{ .func = (fn), }
 #endif
 
+#define preinitcall_begin \
+			SCATTERED_ARRAY_BEGIN(preinitcall, struct initcall)
+#define preinitcall_end SCATTERED_ARRAY_END(preinitcall, struct initcall)
+
 #define initcall_begin	SCATTERED_ARRAY_BEGIN(initcall, struct initcall)
 #define initcall_end	SCATTERED_ARRAY_END(initcall, struct initcall)
 
 #define finalcall_begin	SCATTERED_ARRAY_BEGIN(finalcall, struct initcall)
 #define finalcall_end	SCATTERED_ARRAY_END(finalcall, struct initcall)
+
+/*
+ * The preinit_*(), *_init() and boot_final() macros are used to register
+ * callback functions to be called at different stages during
+ * initialization.
+ *
+ * Functions registered with preinit_*() are always called before functions
+ * registered with *_init().
+ *
+ * Functions registered with boot_final() are called before exiting to
+ * normal world the first time.
+ *
+ * Without virtualization this happens in the order of the defines below.
+ *
+ * However, with virtualization things are a bit different. boot_final()
+ * functions are called first before exiting to normal world the first
+ * time. Functions registered with boot_final() can only operate on the
+ * nexus. preinit_*() functions are called early before the first yielding
+ * call into the partition, in the newly created partition. *_init()
+ * functions are called at the first yielding call.
+ *
+ *  +-------------------------------+-----------------------------------+
+ *  | Without virtualization        | With virtualization               |
+ *  +-------------------------------+-----------------------------------+
+ *  | At the end of boot_init_primary_late() just before the print:     |
+ *  | "Primary CPU switching to normal world boot"                      |
+ *  +-------------------------------+-----------------------------------+
+ *  | 1. call_preinitcalls()        | In the nexus                      |
+ *  | 2. call_initcalls()           +-----------------------------------+
+ *  | 3. call_finalcalls()          | 1. call_finalcalls()              |
+ *  +-------------------------------+-----------------------------------+
+ *  | "Primary CPU switching to normal world boot" is printed           |
+ *  +-------------------------------+-----------------------------------+
+ *                                  | A guest is created and            |
+ *                                  | virt_guest_created() is called.   |
+ *                                  | After the partition has been      |
+ *                                  | created and activated.            |
+ *                                  +-----------------------------------+
+ *                                  | 2. call_preinitcalls()            |
+ *                                  +-----------------------------------+
+ *                                  | When the partition is receiving   |
+ *                                  | the first yielding call           |
+ *                                  | virt_on_stdcall() is called.      |
+ *                                  +-----------------------------------+
+ *                                  | 3. call_initcalls()               |
+ *                                  +-----------------------------------+
+ */
+
+#define preinit_early(fn)		__define_initcall(preinit, 1, fn)
+#define preinit(fn)			__define_initcall(preinit, 2, fn)
+#define preinit_late(fn)		__define_initcall(preinit, 3, fn)
 
 #define early_init(fn)			__define_initcall(init, 1, fn)
 #define early_init_late(fn)		__define_initcall(init, 2, fn)
@@ -45,6 +100,7 @@ struct initcall {
 
 #define boot_final(fn)			__define_initcall(final, 1, fn)
 
+void call_preinitcalls(void);
 void call_initcalls(void);
 void call_finalcalls(void);
 

--- a/core/kernel/initcall.c
+++ b/core/kernel/initcall.c
@@ -12,6 +12,25 @@
  * Note: this function is weak just to make it possible to exclude it from
  * the unpaged area.
  */
+void __weak call_preinitcalls(void)
+{
+	const struct initcall *call = NULL;
+	TEE_Result ret = TEE_SUCCESS;
+
+	for (call = preinitcall_begin; call < preinitcall_end; call++) {
+		DMSG("level %d %s()", call->level, call->func_name);
+		ret = call->func();
+		if (ret != TEE_SUCCESS) {
+			EMSG("Preinitcall __text_start + 0x%08" PRIxVA
+			     " failed", (vaddr_t)call - VCORE_START_VA);
+		}
+	}
+}
+
+/*
+ * Note: this function is weak just to make it possible to exclude it from
+ * the unpaged area.
+ */
 void __weak call_initcalls(void)
 {
 	const struct initcall *call = NULL;


### PR DESCRIPTION
Adds call_preinitcalls() for really early initcalls. This function is
supposed to be called before call_initcalls() is called. With
virtualization enabled it is called in a blocking context when the
OP-TEE partition is created.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

This PR breaks out the initcall stuff from https://github.com/OP-TEE/optee_os/pull/4844

I hope to continue the discussion here. I believe that the hooks enabled with with are needed, but the names may have become a bit messy with the extensions added over the time. Perhaps we can find some better name.