### PR TITLE
drivers: imx_ocotp: fix clock enablement for imx7 platforms

### DIFF
--- a/core/drivers/imx_ocotp.c
+++ b/core/drivers/imx_ocotp.c
@@ -38,7 +38,7 @@ static void ocotp_clock_enable(void)
 {
 	vaddr_t va = core_mmu_get_va(CCM_BASE, MEM_AREA_IO_SEC, CCM_SIZE);
 
-	io_setbits32(va + CCM_CCGRx_SET(CCM_CLOCK_DOMAIN_CAAM),
+	io_setbits32(va + CCM_CCGRx_SET(CCM_CLOCK_DOMAIN_OCOTP),
 		     CCM_CCGRx_ALWAYS_ON(0));
 }
 #elif defined(CFG_MX8M)


### PR DESCRIPTION
Hello,
Fix a (embarrassing) mistake in the newly merged OCOTP driver,

Thanks,
Clement