### PR TITLE
ta/pkcs11: Fix the uninitialized variable

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -152,7 +152,7 @@ check_mechanism_against_processing(struct pkcs11_session *session,
 static uint8_t *pkcs11_object_default_boolprop(uint32_t attribute)
 {
 	static const uint8_t bool_true = 1;
-	static const uint8_t bool_false;
+	static const uint8_t bool_false = 0;
 
 	switch (attribute) {
 	/* As per PKCS#11 default value */


### PR DESCRIPTION
When setting the boolean properties to default values,
the bool_false variable was not explicitly set to 0 causing
failures in default values on some platforms.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
