### PR TITLE
plat-totalcompute: Update SP manifest as per latest SPMC changes

### DIFF
--- a/core/arch/arm/plat-totalcompute/fdts/optee_sp_manifest.dts
+++ b/core/arch/arm/plat-totalcompute/fdts/optee_sp_manifest.dts
@@ -14,7 +14,7 @@
 	/* Properties */
 	description = "op-tee";
 	ffa-version = <0x00010000>; /* 31:16 - Major, 15:0 - Minor */
-	uuid = <0x486178e0 0xe7f811e3 0xbc5e0002 0xa5d5c51b>;
+	uuid = <0xe0786148 0xe311f8e7 0x02005ebc 0x1bc5d5a5>;
 	id = <1>;
 	execution-ctx-count = <8>;
 	exception-level = <2>; /* S-EL1 */
@@ -23,7 +23,7 @@
 	entrypoint-offset = <0x1000>;
 	xlat-granule = <0>; /* 4KiB */
 	boot-order = <0>;
-	messaging-method = <0>; /* Direct messaging only */
+	messaging-method = <0x3>; /* Direct request/response supported */
 
 	device-regions {
 		compatible = "arm,ffa-manifest-device-regions";


### PR DESCRIPTION
Update UUID to little endian:
The Hafnium SPMC expects a little endian representation of the UUID
as an array of four integers in the SP manifest.

Update messaging-method:
Fix the SP manifest to align with messaging method field changes
introduced by b596eab in hafnium repository.

Signed-off-by: Davidson K <davidson.kumaresan@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
