### PR TITLE
plat-stm32mp1: fix securing clock tree

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -1173,6 +1173,7 @@ static void secure_parent_clocks(unsigned long parent_id)
 	switch (parent_id) {
 	case _ACLK:
 	case _HCLK2:
+	case _HCLK5:
 	case _HCLK6:
 	case _PCLK4:
 	case _PCLK5:


### PR DESCRIPTION
Fix bug introduced in commit [1] that added HCLK5 parent clock
identifier but did not handle it from secure_parent_clocks() resulting
in core panic when RCC security hardening is enabled.

Fixes: [1] commit ea6f231cbdfa ("plat-stm32mp1: fix clock rate computation for CRYP1/GPIOZ/HASH1/MDMA")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
