### PR TITLE
ta_dev_kit.mk: remove extra -o flag when creating static library

### DIFF
--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -143,7 +143,7 @@ cleanfiles += $(libname).a
 
 $(libname).a: $(objs)
 	@echo '  AR      $@'
-	$(q)rm -f $@ && $(AR$(sm)) rcs -o $@ $^
+	$(q)rm -f $@ && $(AR$(sm)) rcs $@ $^
 endif
 
 ifneq (,$(shlibname))


### PR DESCRIPTION
The archiver command: $(AR$(sm)) is not supposed to take a -o argument
to specify its output, contrary to the linker for instance.

When GNU ar is used, -o is simply ignored. However when LLVM ar is used
an error is printed. Therefore remove this unwanted -o.

Fixes: 9faf0da7b854 ("mk: add library common makefile support")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
