### PR TITLE
drivers: crypto: ecc/rsa/dsa: input parameter validation

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/dsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/dsa.c
@@ -128,7 +128,7 @@ TEE_Result crypto_acipher_dsa_sign(uint32_t algo, struct dsa_keypair *key,
 	size_t l_bytes = 0;
 	size_t n_bytes = 0;
 
-	if (!key || !msg || !sig || !sig_len) {
+	if (!key || !msg || !sig_len) {
 		CRYPTO_TRACE("Input parameters reference error");
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
@@ -147,6 +147,11 @@ TEE_Result crypto_acipher_dsa_sign(uint32_t algo, struct dsa_keypair *key,
 			     *sig_len, 2 * n_bytes);
 		*sig_len = 2 * n_bytes;
 		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	if (!sig) {
+		CRYPTO_TRACE("Parameter \"sig\" reference error");
+		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	dsa = drvcrypt_get_ops(CRYPTO_DSA);

--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -138,7 +138,7 @@ static TEE_Result ecc_sign(uint32_t algo, struct ecc_keypair *key,
 	size_t size_bytes = 0;
 
 	/* Verify first the input parameters */
-	if (!key || !msg || !sig || !sig_len) {
+	if (!key || !msg || !sig_len) {
 		CRYPTO_TRACE("Input parameters reference error");
 		return ret;
 	}
@@ -156,6 +156,11 @@ static TEE_Result ecc_sign(uint32_t algo, struct ecc_keypair *key,
 			     *sig_len, 2 * size_bytes);
 		*sig_len = 2 * size_bytes;
 		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	if (!sig) {
+		CRYPTO_TRACE("Parameter \"sig\" reference error");
+		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	ecc = drvcrypt_get_ops(CRYPTO_ECC);
@@ -263,7 +268,7 @@ static TEE_Result ecc_shared_secret(struct ecc_keypair *private_key,
 	size_t size_bytes = 0;
 
 	/* Verify first the input parameters */
-	if (!private_key || !public_key || !secret || !secret_len) {
+	if (!private_key || !public_key || !secret_len) {
 		CRYPTO_TRACE("Input parameters reference error");
 		return ret;
 	}
@@ -281,6 +286,11 @@ static TEE_Result ecc_shared_secret(struct ecc_keypair *private_key,
 	if (*secret_len < size_bytes) {
 		*secret_len = size_bytes;
 		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	if (!secret) {
+		CRYPTO_TRACE("Parameter \"secret\" reference error");
+		return ret;
 	}
 
 	ecc = drvcrypt_get_ops(CRYPTO_ECC);

--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
@@ -150,7 +150,7 @@ TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
 	struct drvcrypt_rsa *rsa = NULL;
 	struct drvcrypt_rsa_ed rsa_data = { };
 
-	if (!key || !msg || !cipher || !cipher_len) {
+	if (!key || !msg || !cipher_len) {
 		CRYPTO_TRACE("Parameters error (key @%p)\n"
 			     "(msg @%p size %zu bytes)\n"
 			     "(cipher @%p size %zu bytes)",
@@ -168,6 +168,11 @@ TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
 			     *cipher_len, rsa_data.key.n_size);
 		*cipher_len = rsa_data.key.n_size;
 		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	if (!cipher) {
+		CRYPTO_TRACE("Parameter \"cipher\" reference error");
+		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	rsa = drvcrypt_get_ops(CRYPTO_RSA);
@@ -260,7 +265,7 @@ TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
 	struct drvcrypt_rsa *rsa = NULL;
 	struct drvcrypt_rsa_ed rsa_data = { };
 
-	if (!key || !msg || !cipher || !cipher_len || (!label && label_len)) {
+	if (!key || !msg || !cipher_len || (!label && label_len)) {
 		CRYPTO_TRACE("Parameters error (key @%p\n"
 			     "(msg @%p size %zu bytes)\n"
 			     "(cipher @%p size %zu bytes)\n"
@@ -280,6 +285,11 @@ TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
 			     *cipher_len, rsa_data.key.n_size);
 		*cipher_len = rsa_data.key.n_size;
 		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	if (!cipher) {
+		CRYPTO_TRACE("Parameter \"cipher\" reference error");
+		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	rsa = drvcrypt_get_ops(CRYPTO_RSA);
@@ -339,7 +349,7 @@ TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 	struct drvcrypt_rsa *rsa = NULL;
 	struct drvcrypt_rsa_ssa rsa_ssa = { };
 
-	if (!key || !msg || !sig || !sig_len) {
+	if (!key || !msg || !sig_len) {
 		CRYPTO_TRACE("Input parameters reference error");
 		return ret;
 	}
@@ -374,6 +384,11 @@ TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 			     *sig_len, rsa_ssa.key.n_size);
 		*sig_len = rsa_ssa.key.n_size;
 		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	if (!sig) {
+		CRYPTO_TRACE("Parameter \"sig\" reference error");
+		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	rsa = drvcrypt_get_ops(CRYPTO_RSA);


### PR DESCRIPTION
drivers: crypto: ecc/rsa/dsa: input parameter validation
To comply with the PKCS#11 convention for functions returning output
in a variable-length buffer, prefer to check the required size of the
output buffer before the existence of the output buffer itself.

This will save callers from having to allocate a buffer that might not
be used.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>