### PR TITLE
scripts: migrate away from pycryptodome

### DIFF
--- a/scripts/pem_to_pub_c.py
+++ b/scripts/pem_to_pub_c.py
@@ -21,23 +21,28 @@ def get_args():
 
 def main():
     import array
-    try:
-        from Cryptodome.PublicKey import RSA
-        from Cryptodome.Util.number import long_to_bytes
-    except ImportError:
-        from Crypto.PublicKey import RSA
-        from Crypto.Util.number import long_to_bytes
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
 
     args = get_args()
 
-    with open(args.key, 'r') as f:
-        key = RSA.importKey(f.read())
+    with open(args.key, 'rb') as f:
+        data = f.read()
+
+        try:
+            key = serialization.load_pem_private_key(data, password=None,
+                                                     backend=default_backend())
+            key = key.public_key()
+        except ValueError:
+            key = serialization.load_pem_public_key(data,
+                                                    backend=default_backend())
 
     # Refuse public exponent with more than 32 bits. Otherwise the C
     # compiler may simply truncate the value and proceed.
     # This will lead to TAs seemingly having invalid signatures with a
     # possible security issue for any e = k*2^32 + 1 (for any integer k).
-    if key.publickey().e > 0xffffffff:
+    if key.public_numbers().e > 0xffffffff:
         raise ValueError(
             'Unsupported large public exponent detected. ' +
             'OP-TEE handles only public exponents up to 2^32 - 1.')
@@ -46,10 +51,11 @@ def main():
         f.write("#include <stdint.h>\n")
         f.write("#include <stddef.h>\n\n")
         f.write("const uint32_t " + args.prefix + "_exponent = " +
-                str(key.publickey().e) + ";\n\n")
+                str(key.public_numbers().e) + ";\n\n")
         f.write("const uint8_t " + args.prefix + "_modulus[] = {\n")
         i = 0
-        for x in array.array("B", long_to_bytes(key.publickey().n)):
+        nbuf = key.public_numbers().n.to_bytes(key.key_size >> 3, 'big')
+        for x in array.array("B", nbuf):
             f.write("0x" + '{0:02x}'.format(x) + ",")
             i = i + 1
             if i % 8 == 0:


### PR DESCRIPTION
Move away from pycryptodome and use pyca/cryptography instead.

Also, deprecate TEE_ALG_RSASSA_PKCS1_V1_5_SHA256 in sign_encrypt.py. It
is not the default algorithm choice and should not be used anyway.

Signed-off-by: Donald Chan <hoiho@lab126.com>