### PR TITLE
[RFC] Proof of concept run-time integrity check

### DIFF
--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -121,6 +121,7 @@
  * MEM_AREA_EXT_DT:   Memory loads external device tree
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_SHM_VASPACE: Virtual memory space for dynamic shared memory buffers
+ * MEM_AREA_RTI_CHECK_VASPACE: Virtual memory space runtime integrity check
  * MEM_AREA_TS_VASPACE: TS va space, only used with phys_to_virt()
  * MEM_AREA_DDR_OVERALL: Overall DDR address range, candidate to dynamic shm.
  * MEM_AREA_SEC_RAM_OVERALL: Whole secure RAM
@@ -148,6 +149,7 @@ enum teecore_memtypes {
 	MEM_AREA_EXT_DT,
 	MEM_AREA_RES_VASPACE,
 	MEM_AREA_SHM_VASPACE,
+	MEM_AREA_RTI_CHECK_VASPACE,
 	MEM_AREA_TS_VASPACE,
 	MEM_AREA_PAGER_VASPACE,
 	MEM_AREA_SDP_MEM,
@@ -180,6 +182,7 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 		[MEM_AREA_EXT_DT] = "EXT_DT",
 		[MEM_AREA_RES_VASPACE] = "RES_VASPACE",
 		[MEM_AREA_SHM_VASPACE] = "SHM_VASPACE",
+		[MEM_AREA_RTI_CHECK_VASPACE] = "RTI_CHECK_VASPACE",
 		[MEM_AREA_TS_VASPACE] = "TS_VASPACE",
 		[MEM_AREA_PAGER_VASPACE] = "PAGER_VASPACE",
 		[MEM_AREA_SDP_MEM] = "SDP_MEM",
@@ -311,6 +314,10 @@ struct core_mmu_phys_mem {
 /* Default NSec shared memory allocated from NSec world */
 extern unsigned long default_nsec_shm_paddr;
 extern unsigned long default_nsec_shm_size;
+#endif
+
+#ifdef CFG_NS_RTI_CHECK
+extern void *const core_mmu_rti_check_table;
 #endif
 
 /*
@@ -575,7 +582,8 @@ static inline size_t core_mmu_get_block_offset(
 static inline bool core_mmu_is_dynamic_vaspace(struct tee_mmap_region *mm)
 {
 	return mm->type == MEM_AREA_RES_VASPACE ||
-		mm->type == MEM_AREA_SHM_VASPACE;
+	       mm->type == MEM_AREA_SHM_VASPACE ||
+	       mm->type == MEM_AREA_RTI_CHECK_VASPACE;
 }
 
 /*
@@ -608,6 +616,8 @@ TEE_Result core_mmu_map_pages(vaddr_t vstart, paddr_t *pages, size_t num_pages,
 TEE_Result core_mmu_map_contiguous_pages(vaddr_t vstart, paddr_t pstart,
 					 size_t num_pages,
 					 enum teecore_memtypes memtype);
+
+void *core_mmu_map_rti_check(paddr_t pa, size_t len, size_t *mapped_len);
 
 /*
  * core_mmu_unmap_pages() - remove mapping at given virtual address

--- a/core/arch/arm/include/mm/core_mmu.h
+++ b/core/arch/arm/include/mm/core_mmu.h
@@ -617,6 +617,18 @@ TEE_Result core_mmu_map_contiguous_pages(vaddr_t vstart, paddr_t pstart,
 					 size_t num_pages,
 					 enum teecore_memtypes memtype);
 
+/*
+ * core_mmu_map_rti_check() - map range of pages for run-time integrity check
+ * @pa:		Physical address
+ * @len:	Total requested length
+ * @mapped_len:	Range actually mapped
+ *
+ * The function establishes a temporary memory mapping which may be smaller
+ * than the requested range. In such a case is the caller expected to call
+ * again with the remaining range once it's done with the first sub-range.
+ *
+ * @returns:	Pointer to mapped memory range of length @mapped_len.
+ */
 void *core_mmu_map_rti_check(paddr_t pa, size_t len, size_t *mapped_len);
 
 /*

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2015-2021, Linaro Limited
  */
 #ifndef OPTEE_SMC_H
 #define OPTEE_SMC_H
@@ -451,6 +451,91 @@
 #define OPTEE_SMC_FUNCID_GET_THREAD_COUNT	U(15)
 #define OPTEE_SMC_GET_THREAD_COUNT \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_THREAD_COUNT)
+
+/*
+ * Add runtime integrity check for a physical memory range
+ *
+ * The normal world OS or even hypervisor can register physical memory
+ * ranges which are not supposed to change. Secure world will check that
+ * the memory is unchanged periodically.  In case changes are detected
+ * secure world will log this and optionally reset the system.
+ *
+ * Call request usage:
+ * a0	SMC Function ID, OPTEE_SMC_RTI_CHECK
+ * a1	Upper 32 bits of a physical address of the memory range
+ * a2	Lower 32 bits of a physical address of the memory range
+ * a3	Size in bytes of memory range
+ * a4	Flags, unused bits MBZ
+ * a5-6 Not used
+ * a7	Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1-7	Preserved
+ *
+ * Error return:
+ * a0	OPTEE_SMC_RETURN_UNKNOWN_FUNCTION   Requested call is not implemented
+ *	OPTEE_SMC_RETURN_EBADADDR	    Physical memory range out of range
+ *	OPTEE_SMC_RETURN_ENOMEM		    Out of memory, cannot register range
+ * a1-7	Preserved
+ */
+/*
+ * Make the settings for this memory range final, that is, the physical
+ * memory range can't be changed or removed once OPTEE_SMC_ADD_RTI_CHECK
+ * has returned OK.
+ */
+#define OPTEE_SMC_RTI_FLAG_FINAL		BIT(0)
+#define OPTEE_SMC_FUNCID_ADD_RTI_CHECK		U(16)
+#define OPTEE_SMC_ADD_RTI_CHECK \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_ADD_RTI_CHECK)
+
+/*
+ * Remove runtime integrity check for a physical memory range
+ *
+ * Memory ranges not marked as final may be removed.
+ *
+ * Call request usage:
+ * a0	SMC Function ID, OPTEE_SMC_RTI_CHECK
+ * a1	Upper 32 bits of a physical address of the memory range
+ * a2	Lower 32 bits of a physical address of the memory range
+ * a3	Size in bytes of memory range
+ * a4-6 Not used
+ * a7	Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1-7	Preserved
+ *
+ * Error return:
+ * a0	OPTEE_SMC_RETURN_UNKNOWN_FUNCTION   Requested call is not implemented
+ *	OPTEE_SMC_RETURN_EBADADDR	    Physical memory range not
+ *					    registered or not changeable.
+ * a1-7	Preserved
+ */
+#define OPTEE_SMC_FUNCID_REM_RTI_CHECK		U(17)
+#define OPTEE_SMC_REM_RTI_CHECK \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_REM_RTI_CHECK)
+
+/*
+ * Run runtime integrity check on registered memory ranges
+ *
+ * Call request usage:
+ * a0	SMC Function ID, OPTEE_SMC_RTI_CHECK
+ * a1-6 Not used
+ * a7	Hypervisor Client ID register
+ *
+ * Normal return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1-7	Preserved
+ *
+ * Error return:
+ * a0	OPTEE_SMC_RETURN_UNKNOWN_FUNCTION   Requested call is not implemented
+ * a1-7	Preserved
+ */
+#define OPTEE_SMC_FUNCID_RUN_RTI_CHECK		U(18)
+#define OPTEE_SMC_RUN_RTI_CHECK \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_RUN_RTI_CHECK)
+
 
 /*
  * Resume from RPC (for example after processing a foreign interrupt)

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -462,8 +462,8 @@
  *
  * Call request usage:
  * a0	SMC Function ID, OPTEE_SMC_RTI_CHECK
- * a1	Upper 32 bits of a physical address of the memory range
- * a2	Lower 32 bits of a physical address of the memory range
+ * a1	Upper 32 bits of the physical address of the memory range
+ * a2	Lower 32 bits of the physical address of the memory range
  * a3	Size in bytes of memory range
  * a4	Flags, unused bits MBZ
  * a5-6 Not used

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -536,7 +536,6 @@
 #define OPTEE_SMC_RUN_RTI_CHECK \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_RUN_RTI_CHECK)
 
-
 /*
  * Resume from RPC (for example after processing a foreign interrupt)
  *

--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -2495,6 +2495,8 @@ void *core_mmu_map_rti_check(paddr_t pa, size_t len, size_t *mapped_len)
 	uint32_t attr = 0;
 	size_t idx = 0;
 
+	DMSG("%#"PRIxPA":%#zx", pa, len);
+
 	/* Refuse to map memory which isn't know to be non-secure */
 	if (!core_pbuf_is(CORE_MEM_NON_SEC, pa, len))
 		return NULL;
@@ -2572,6 +2574,8 @@ void *core_mmu_map_rti_check(paddr_t pa, size_t len, size_t *mapped_len)
 
 	/* Make sure that the table update above is visible.  */
 	dsb_ishst();
+
+	DMSG("*mapped_len %#zx", *mapped_len);
 
 	return (void *)vabase;
 }

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -226,6 +226,12 @@ static base_xlat_tbls_t base_xlation_table[NUM_BASE_TABLES]
 static xlat_tbl_t xlat_tables[MAX_XLAT_TABLES]
 	__aligned(XLAT_TABLE_SIZE) __section(".nozi.mmu.l2");
 
+#ifdef CFG_NS_RTI_CHECK
+static xlat_tbl_t xlat_table_rti_check
+	__aligned(XLAT_TABLE_SIZE) __section(".nozi.mmu.l2");
+void *const core_mmu_rti_check_table = xlat_table_rti_check;
+#endif
+
 #define XLAT_TABLES_SIZE	(sizeof(xlat_tbl_t) * MAX_XLAT_TABLES)
 
 /* MMU L2 table for TAs, one for each thread */

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -197,6 +197,12 @@ static l1_xlat_tbl_t main_mmu_l1_ttb
 static l2_xlat_tbl_t main_mmu_l2_ttb[MAX_XLAT_TABLES]
 		__aligned(L2_ALIGNMENT) __section(".nozi.mmu.l2");
 
+#ifdef CFG_NS_RTI_CHECK
+static l2_xlat_tbl_t xlat_table_rti_check
+	__aligned(XLAT_TABLE_SIZE) __section(".nozi.mmu.l2");
+void *const core_mmu_rti_check_table = xlat_table_rti_check;
+#endif
+
 /* MMU L1 table for TAs, one for each thread */
 static ul1_xlat_tbl_t main_mmu_ul1_ttb[CFG_NUM_THREADS]
 		__aligned(UL1_ALIGNMENT) __section(".nozi.mmu.ul1");

--- a/core/arch/arm/tee/rti_check.c
+++ b/core/arch/arm/tee/rti_check.c
@@ -43,6 +43,8 @@ static TEE_Result compute_hash(paddr_t pa, size_t sz, uint8_t *digest)
 		return res;
 	while (pos < sz) {
 		p = core_mmu_map_rti_check(pa + pos, sz - pos, &len);
+		if (!p)
+			return TEE_ERROR_ACCESS_CONFLICT;
 		pos += len;
 		res = crypto_atomic_sha256_update(rti_check_ctx, p, len);
 		if (res)

--- a/core/arch/arm/tee/rti_check.c
+++ b/core/arch/arm/tee/rti_check.c
@@ -127,7 +127,6 @@ TEE_Result rti_check_run(void)
 			     range->pa, range->sz);
 			res = TEE_ERROR_SECURITY;
 		}
-
 	}
 	core_mmu_map_rti_check(0, 0, &dummy_len);
 	cpu_spin_unlock(&rti_check_lock);

--- a/core/arch/arm/tee/rti_check.c
+++ b/core/arch/arm/tee/rti_check.c
@@ -36,7 +36,7 @@ static TEE_Result compute_hash(paddr_t pa, size_t sz, uint8_t *digest)
 	TEE_Result res = TEE_SUCCESS;
 	size_t pos = 0;
 	void *p = NULL;
-	size_t len;
+	size_t len = 0;
 
 	res = crypto_atomic_sha256_init(rti_check_ctx);
 	if (res)

--- a/core/arch/arm/tee/rti_check.c
+++ b/core/arch/arm/tee/rti_check.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#include <crypto/crypto.h>
+#include <initcall.h>
+#include <kernel/spinlock.h>
+#include <mm/core_mmu.h>
+#include <stdlib.h>
+#include <string_ext.h>
+#include <sys/queue.h>
+#include <types_ext.h>
+#include <utee_defines.h>
+
+#include "rti_check.h"
+
+struct rti_check_range {
+	paddr_t pa;
+	size_t sz;
+	bool final;
+	uint8_t digest[TEE_SHA256_HASH_SIZE];
+	SLIST_ENTRY(rti_check_range) link;
+};
+
+SLIST_HEAD(rti_check_range_head, rti_check_range);
+
+static struct rti_check_range_head rti_check_head =
+	SLIST_HEAD_INITIALIZER(rti_check_head);
+static unsigned int rti_check_lock = SPINLOCK_UNLOCK;
+static void *rti_check_ctx;
+static uint8_t rti_check_tmp_digest[TEE_SHA256_HASH_SIZE];
+
+static TEE_Result compute_hash(paddr_t pa, size_t sz, uint8_t *digest)
+{
+	TEE_Result res = TEE_SUCCESS;
+	size_t pos = 0;
+	void *p = NULL;
+	size_t len;
+
+	res = crypto_atomic_sha256_init(rti_check_ctx);
+	if (res)
+		return res;
+	while (pos < sz) {
+		p = core_mmu_map_rti_check(pa + pos, sz - pos, &len);
+		pos += len;
+		res = crypto_atomic_sha256_update(rti_check_ctx, p, len);
+		if (res)
+			return res;
+	}
+
+	return crypto_atomic_sha256_final(rti_check_ctx, digest,
+					  TEE_SHA256_HASH_SIZE);
+}
+
+TEE_Result rti_check_add(paddr_t pa, size_t sz, bool final)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct rti_check_range *range = NULL;
+	size_t len = 0;
+
+	if (!rti_check_ctx)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	range = nex_calloc(1, sizeof(*range));
+	if (!range)
+		return TEE_ERROR_OUT_OF_MEMORY;
+	range->pa = pa;
+	range->sz = sz;
+	range->final = final;
+
+	cpu_spin_lock(&rti_check_lock);
+
+	res = compute_hash(pa, sz, range->digest);
+	core_mmu_map_rti_check(0, 0, &len);
+	if (res)
+		nex_free(range);
+	else
+		SLIST_INSERT_HEAD(&rti_check_head, range, link);
+
+	cpu_spin_unlock(&rti_check_lock);
+	return res;
+}
+
+TEE_Result rti_check_rem(paddr_t pa, size_t sz)
+{
+	struct rti_check_range *range_prev = NULL;
+	struct rti_check_range *range = NULL;
+
+	cpu_spin_lock(&rti_check_lock);
+	SLIST_FOREACH(range, &rti_check_head, link) {
+		if (pa == range->pa && sz == range->sz) {
+			if (range->final)
+				SLIST_REMOVE_AFTER(range_prev, link);
+			else
+				range = NULL;
+			break;
+		}
+		range_prev = range;
+	}
+	cpu_spin_unlock(&rti_check_lock);
+
+	if (!range)
+		return TEE_ERROR_ACCESS_CONFLICT;
+
+	nex_free(range);
+	return TEE_SUCCESS;
+}
+
+TEE_Result rti_check_run(void)
+{
+	struct rti_check_range *range = NULL;
+	TEE_Result res = TEE_SUCCESS;
+	size_t dummy_len = 0;
+
+	cpu_spin_lock(&rti_check_lock);
+	SLIST_FOREACH(range, &rti_check_head, link) {
+		res = compute_hash(range->pa, range->sz, rti_check_tmp_digest);
+		if (consttime_memcmp(rti_check_tmp_digest, range->digest,
+				     sizeof(range->digest))) {
+			EMSG("PA:len %#"PRIxPA":%#zx failed RTI check",
+			     range->pa, range->sz);
+			res = TEE_ERROR_SECURITY;
+		}
+
+	}
+	core_mmu_map_rti_check(0, 0, &dummy_len);
+	cpu_spin_unlock(&rti_check_lock);
+
+	return res;
+}
+
+static TEE_Result rti_check_init(void)
+{
+	rti_check_ctx = nex_malloc(crypto_atomic_sha256_get_ctx_size());
+	return TEE_SUCCESS;
+}
+service_init(rti_check_init);

--- a/core/arch/arm/tee/rti_check.h
+++ b/core/arch/arm/tee/rti_check.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#ifndef __TEE_RTI_CHECK_H
+#define __TEE_RTI_CHECK_H
+
+#include <types_ext.h>
+
+#ifdef CFG_NS_RTI_CHECK
+TEE_Result rti_check_add(paddr_t pa, size_t sz, bool final);
+TEE_Result rti_check_rem(paddr_t pa, size_t sz);
+TEE_Result rti_check_run(void);
+#else
+static inline TEE_Result rti_check_add(paddr_t pa __unused, size_t sz __unused,
+				       bool final __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+static inline TEE_Result rti_check_rem(paddr_t pa __unused, size_t sz __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+static inline TEE_Result rti_check_run(void)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /*CFG_NS_RTI_CHECK*/
+
+#endif /*__TEE_RTI_CHECK_H*/

--- a/core/arch/arm/tee/rti_check.h
+++ b/core/arch/arm/tee/rti_check.h
@@ -18,10 +18,12 @@ static inline TEE_Result rti_check_add(paddr_t pa __unused, size_t sz __unused,
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
+
 static inline TEE_Result rti_check_rem(paddr_t pa __unused, size_t sz __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
+
 static inline TEE_Result rti_check_run(void)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;

--- a/core/arch/arm/tee/sub.mk
+++ b/core/arch/arm/tee/sub.mk
@@ -6,6 +6,7 @@ srcs-y += arch_svc.c
 endif
 ifneq ($(CFG_CORE_FFA),y)
 srcs-y += entry_fast.c
+srcs-$(CFG_NS_RTI_CHECK) += rti_check.c
 cppflags-entry_fast.c-y += -DTEE_IMPL_GIT_SHA1=$(TEE_IMPL_GIT_SHA1)
 endif
 srcs-y += cache.c

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -298,6 +298,12 @@ TEE_Result hash_sha256_check(const uint8_t *hash, const uint8_t *data,
 TEE_Result hash_sha512_256_compute(uint8_t *digest, const uint8_t *data,
 		size_t data_size);
 
+size_t crypto_atomic_sha256_get_ctx_size(void);
+TEE_Result crypto_atomic_sha256_init(void *ctx);
+TEE_Result crypto_atomic_sha256_update(void *ctx, const uint8_t *data,
+				       size_t len);
+TEE_Result crypto_atomic_sha256_final(void *ctx, uint8_t *digest, size_t len);
+
 #define CRYPTO_RNG_SRC_IS_QUICK(sid) (!!((sid) & 1))
 
 /*

--- a/core/lib/libtomcrypt/hash.c
+++ b/core/lib/libtomcrypt/hash.c
@@ -184,6 +184,34 @@ TEE_Result hash_sha256_check(const uint8_t *hash, const uint8_t *data,
 		return TEE_ERROR_SECURITY;
 	return TEE_SUCCESS;
 }
+
+size_t crypto_atomic_sha256_get_ctx_size(void)
+{
+	return sizeof(hash_state);
+}
+
+TEE_Result crypto_atomic_sha256_init(void *ctx)
+{
+	if (sha256_init(ctx) != CRYPT_OK)
+		return TEE_ERROR_GENERIC;
+	return TEE_SUCCESS;
+}
+
+TEE_Result crypto_atomic_sha256_update(void *ctx, const uint8_t *data,
+				       size_t len)
+{
+	if (sha256_process(ctx, data, len) != CRYPT_OK)
+		return TEE_ERROR_GENERIC;
+	return TEE_SUCCESS;
+}
+
+TEE_Result crypto_atomic_sha256_final(void *ctx, uint8_t *digest, size_t len)
+{
+	if (len != TEE_SHA256_HASH_SIZE ||
+	    sha256_done(ctx, digest) != CRYPT_OK)
+		return TEE_ERROR_GENERIC;
+	return TEE_SUCCESS;
+}
 #endif
 
 #if defined(_CFG_CORE_LTC_SHA512_256)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -725,3 +725,7 @@ CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
 
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))
+
+# CFG_NS_RTI_CHECK, enables runtime integrity checks of non-secure physical
+# memory
+CFG_NS_RTI_CHECK ?= n


### PR DESCRIPTION
This is a proof of concept implementation for https://linaro.atlassian.net/browse/TS-138 (see a comment in this ticked for a kernel patch for some testing) and https://linaro.atlassian.net/browse/TS-120.

Here's patch for the Linux kernel OP-TEE driver to exercise this code a bit.
[0001-optee-silly-run-time-integrity-test-at-probe.patch.gz](https://github.com/OP-TEE/optee_os/files/7409690/0001-optee-silly-run-time-integrity-test-at-probe.patch.gz)

I'm creating this PR to discuss this and to see if it might be useful for normal world.