### PR TITLE
Stm32 cryp driver and Authenticated Encryption driver interface

### DIFF
--- a/core/arch/arm/dts/stm32mp157c-dk2.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2.dts
@@ -26,6 +26,10 @@
 	};
 };
 
+&cryp1 {
+	status = "okay";
+};
+
 &dsi {
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -107,6 +107,10 @@
 	};
 };
 
+&cryp1 {
+	status = "okay";
+};
+
 &dac {
 	pinctrl-names = "default";
 	pinctrl-0 = <&dac_ch1_pins_a &dac_ch2_pins_a>;

--- a/core/arch/arm/dts/stm32mp157c-ev1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ev1.dts
@@ -80,6 +80,10 @@
 	status = "okay";
 };
 
+&cryp1 {
+	status = "okay";
+};
+
 &dcmi {
 	status = "okay";
 	pinctrl-names = "default", "sleep";

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -64,6 +64,7 @@ CFG_DTB_MAX_SIZE ?= (256 * 1024)
 
 ifeq ($(CFG_EMBED_DTB_SOURCE_FILE),)
 # Some drivers mandate DT support
+$(call force,CFG_STM32_CRYP,n)
 $(call force,CFG_STM32_GPIO,n)
 $(call force,CFG_STM32_I2C,n)
 $(call force,CFG_STPMIC1,n)
@@ -72,6 +73,7 @@ $(call force,CFG_SCMI_PTA,n)
 endif
 
 CFG_STM32_BSEC ?= y
+CFG_STM32_CRYP ?= y
 CFG_STM32_ETZPC ?= y
 CFG_STM32_GPIO ?= y
 CFG_STM32_I2C ?= y
@@ -83,6 +85,11 @@ CFG_TZC400 ?= y
 ifeq ($(CFG_STPMIC1),y)
 $(call force,CFG_STM32_I2C,y)
 $(call force,CFG_STM32_GPIO,y)
+endif
+
+# if any crypto driver is enabled, enable the crypto-framework layer
+ifeq ($(call cfg-one-enabled, CFG_STM32_CRYP),y)
+$(call force,CFG_STM32_CRYPTO_DRIVER,y)
 endif
 
 # Platform specific configuration

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -331,22 +331,30 @@ TEE_Result crypto_mac_final(void *ctx, uint8_t *digest, size_t digest_len)
 
 TEE_Result crypto_authenc_alloc_ctx(void **ctx, uint32_t algo)
 {
-	TEE_Result res = TEE_SUCCESS;
+	TEE_Result res = TEE_ERROR_NOT_IMPLEMENTED;
 	struct crypto_authenc_ctx *c = NULL;
 
-	switch (algo) {
+	/*
+	 * Use default authenc implementation if no matching
+	 * drvcrypt device.
+	 */
+	res = drvcrypt_authenc_alloc_ctx(&c, algo);
+
+	if (res == TEE_ERROR_NOT_IMPLEMENTED) {
+		switch (algo) {
 #if defined(CFG_CRYPTO_CCM)
-	case TEE_ALG_AES_CCM:
-		res = crypto_aes_ccm_alloc_ctx(&c);
-		break;
+		case TEE_ALG_AES_CCM:
+			res = crypto_aes_ccm_alloc_ctx(&c);
+			break;
 #endif
 #if defined(CFG_CRYPTO_GCM)
-	case TEE_ALG_AES_GCM:
-		res = crypto_aes_gcm_alloc_ctx(&c);
-		break;
+		case TEE_ALG_AES_GCM:
+			res = crypto_aes_gcm_alloc_ctx(&c);
+			break;
 #endif
-	default:
-		return TEE_ERROR_NOT_IMPLEMENTED;
+		default:
+			break;
+		}
 	}
 
 	if (!res)

--- a/core/drivers/crypto/crypto_api/authenc/authenc.c
+++ b/core/drivers/crypto/crypto_api/authenc/authenc.c
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, STMicroelectronics - All Rights Reserved
+ *
+ * Crypto authenc interface implementation to enable HW driver.
+ */
+#include <assert.h>
+#include <crypto/crypto.h>
+#include <crypto/crypto_impl.h>
+#include <drvcrypt.h>
+#include <drvcrypt_authenc.h>
+#include <kernel/panic.h>
+#include <malloc.h>
+#include <utee_defines.h>
+#include <util.h>
+
+static const struct crypto_authenc_ops authenc_ops;
+
+/*
+ * Returns the reference to the driver context
+ *
+ * @ctx    Reference the API context pointer
+ */
+static struct crypto_authenc *to_authenc_ctx(struct crypto_authenc_ctx *ctx)
+{
+	assert(ctx && ctx->ops == &authenc_ops);
+
+	return container_of(ctx, struct crypto_authenc, authenc_ctx);
+}
+
+/*
+ * Free authenc context
+ *
+ * @ctx    Reference the API context pointer
+ */
+static void authenc_free_ctx(struct crypto_authenc_ctx *ctx)
+{
+	struct crypto_authenc *authenc = to_authenc_ctx(ctx);
+
+	if (authenc->op && authenc->op->free_ctx)
+		authenc->op->free_ctx(authenc->ctx);
+
+	free(authenc);
+}
+
+/*
+ * Copy authenc context
+ *
+ * @dst_ctx  [out] Reference the API context pointer destination
+ * @src_ctx  Reference the API context pointer source
+ */
+static void authenc_copy_state(struct crypto_authenc_ctx *dst_ctx,
+			       struct crypto_authenc_ctx *src_ctx)
+{
+	struct crypto_authenc *authenc_src = to_authenc_ctx(src_ctx);
+	struct crypto_authenc *authenc_dst = to_authenc_ctx(dst_ctx);
+
+	if (authenc_src->op && authenc_src->op->copy_state)
+		authenc_src->op->copy_state(authenc_dst->ctx, authenc_src->ctx);
+}
+
+/*
+ * Initialization of the authenc operation
+ *
+ * @ctx         Reference the API context pointer
+ * @mode        Operation mode
+ * @key         Key
+ * @key_len     Length of the key
+ * @nonce       Nonce
+ * @nonce_len   Length of the nonce
+ * @tag_len     Length of the requested tag
+ * @aad_len     Length of the associated authenticated data
+ * @payload_len Length of payload
+ */
+static TEE_Result authenc_init(struct crypto_authenc_ctx *ctx,
+			       TEE_OperationMode mode, const uint8_t *key,
+			       size_t key_len, const uint8_t *nonce,
+			       size_t nonce_len, size_t tag_len, size_t aad_len,
+			       size_t payload_len)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_authenc *authenc = to_authenc_ctx(ctx);
+
+	if ((!key && key_len) || (!nonce && nonce_len)) {
+		CRYPTO_TRACE("One of the key is not correct");
+		CRYPTO_TRACE("key   @%p-%zu bytes", key, key_len);
+		CRYPTO_TRACE("nonce @%p-%zu bytes", nonce, nonce_len);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (authenc->op && authenc->op->init) {
+		struct drvcrypt_authenc_init dinit = {
+			.ctx = authenc->ctx,
+			.encrypt = (mode == TEE_MODE_ENCRYPT),
+			.key.data = (uint8_t *)key,
+			.key.length = key_len,
+			.nonce.data = (uint8_t *)nonce,
+			.nonce.length = nonce_len,
+			.tag_len = tag_len,
+			.aad_len = aad_len,
+			.payload_len = payload_len,
+		};
+
+		ret = authenc->op->init(&dinit);
+	}
+
+	CRYPTO_TRACE("authenc ret 0x%" PRIx32, ret);
+	return ret;
+}
+
+/*
+ * Update Additional Authenticated Data part of the authenc operation
+ *
+ * @ctx        Reference the API context pointer
+ * @data       Data to authenticate without encrypt/decrypt (AAD)
+ * @len        AAD length in bytes
+ */
+static TEE_Result authenc_update_aad(struct crypto_authenc_ctx *ctx,
+				     const uint8_t *data, size_t len)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_authenc *authenc = to_authenc_ctx(ctx);
+
+	if (!data && len) {
+		CRYPTO_TRACE("Bad data @%p-%zu bytes", data, len);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (authenc->op && authenc->op->update_aad) {
+		struct drvcrypt_authenc_update_aad dupdate = {
+			.ctx = authenc->ctx,
+			.aad.data = (uint8_t *)data,
+			.aad.length = len,
+		};
+
+		ret = authenc->op->update_aad(&dupdate);
+	}
+
+	CRYPTO_TRACE("authenc ret 0x%" PRIx32, ret);
+	return ret;
+}
+
+/*
+ * Update payload part of the authenc operation
+ *
+ * @ctx        Reference the API context pointer
+ * @data       Data to authenticate and encrypt/decrypt
+ * @len        Length of the input data and output result
+ * @dst        [out] Output data of the operation
+ */
+static TEE_Result authenc_update_payload(struct crypto_authenc_ctx *ctx,
+					 TEE_OperationMode mode,
+					 const uint8_t *data,
+					 size_t len, uint8_t *dst)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_authenc *authenc = to_authenc_ctx(ctx);
+
+	if (!dst) {
+		CRYPTO_TRACE("Destination buffer error");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (!data && len) {
+		CRYPTO_TRACE("Bad data @%p-%zu bytes", data, len);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (authenc->op && authenc->op->update_payload) {
+		struct drvcrypt_authenc_update_payload dupdate = {
+			.ctx = authenc->ctx,
+			.encrypt = (mode == TEE_MODE_ENCRYPT),
+			.src.data = (uint8_t *)data,
+			.src.length = len,
+			.dst.data = dst,
+			.dst.length = len,
+		};
+
+		ret = authenc->op->update_payload(&dupdate);
+	}
+
+	CRYPTO_TRACE("authenc ret 0x%" PRIx32, ret);
+	return ret;
+}
+
+/*
+ * Last block for the authenc encrypt and get tag operation
+ *
+ * @ctx     Reference the API context pointer
+ * @data    Data to authenticate and encrypt (can be NULL)
+ * @len     Length of the input data and output result (can be 0)
+ * @dst     [out] Output data of the operation
+ * @tag     [out] Output tag of the operation
+ * @tag_len [in/out] in: size of the dst_tag buffer
+ *                  out: size of the computed tag
+ */
+static TEE_Result authenc_enc_final(struct crypto_authenc_ctx *ctx,
+				    const uint8_t *data, size_t len,
+				    uint8_t *dst, uint8_t *tag,
+				    size_t *tag_len)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_authenc *authenc = to_authenc_ctx(ctx);
+
+	if (!dst && len) {
+		CRYPTO_TRACE("Bad output @%p-%zu bytes", dst, len);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (!data && len) {
+		CRYPTO_TRACE("Bad input @%p-%zu bytes", data, len);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (authenc->op && authenc->op->enc_final) {
+		struct drvcrypt_authenc_final dfinal = {
+			.ctx = authenc->ctx,
+			.src.data = (uint8_t *)data,
+			.src.length = len,
+			.dst.data = dst,
+			.dst.length = len,
+			.tag.data = tag,
+			.tag.length = *tag_len
+		};
+
+		ret = authenc->op->enc_final(&dfinal);
+		if (ret == TEE_SUCCESS)
+			*tag_len = dfinal.tag.length;
+	}
+
+	CRYPTO_TRACE("authenc ret 0x%" PRIx32, ret);
+	return ret;
+}
+
+/*
+ * Last block for the authenc decrypt and check tag operation
+ *
+ * @ctx         Reference the API context pointer
+ * @src_data    Data to authenticate and encrypt (can be NULL)
+ * @len         Length of the input data and output result (can be 0)
+ * @dst         [out] Output data of the operation
+ * @tag         Tag to check at end of operation
+ * @tag_len     Length of @tag
+ */
+static TEE_Result authenc_dec_final(struct crypto_authenc_ctx *ctx,
+				    const uint8_t *data, size_t len,
+				    uint8_t *dst, const uint8_t *tag,
+				    size_t tag_len)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_authenc *authenc = to_authenc_ctx(ctx);
+
+	if (!dst && len) {
+		CRYPTO_TRACE("Bad output @%p-%zu bytes", dst, len);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (!data && len) {
+		CRYPTO_TRACE("Bad data @%p-%zu bytes", data, len);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (authenc->op && authenc->op->dec_final) {
+		struct drvcrypt_authenc_final dfinal = {
+			.ctx = authenc->ctx,
+			.src.data = (uint8_t *)data,
+			.src.length = len,
+			.dst.data = dst,
+			.dst.length = len,
+			.tag.data = (uint8_t *)tag,
+			.tag.length = tag_len
+		};
+
+		ret = authenc->op->dec_final(&dfinal);
+	}
+
+	CRYPTO_TRACE("authenc ret 0x%" PRIx32, ret);
+	return ret;
+}
+
+/*
+ * Finalize the authenc operation
+ *
+ * @ctx   Reference the API context pointer
+ */
+static void authenc_final(struct crypto_authenc_ctx *ctx)
+{
+	struct crypto_authenc *authenc = to_authenc_ctx(ctx);
+
+	if (authenc->op && authenc->op->final)
+		authenc->op->final(authenc->ctx);
+}
+
+static const struct crypto_authenc_ops authenc_ops = {
+	.init = authenc_init,
+	.update_aad = authenc_update_aad,
+	.update_payload = authenc_update_payload,
+	.enc_final = authenc_enc_final,
+	.dec_final = authenc_dec_final,
+	.final = authenc_final,
+	.free_ctx = authenc_free_ctx,
+	.copy_state = authenc_copy_state,
+};
+
+TEE_Result drvcrypt_authenc_alloc_ctx(struct crypto_authenc_ctx **ctx,
+				      uint32_t algo)
+{
+	TEE_Result ret = TEE_ERROR_NOT_IMPLEMENTED;
+	struct crypto_authenc *authenc = NULL;
+
+	CRYPTO_TRACE("authenc alloc_ctx algo 0x%" PRIx32, algo);
+
+	assert(ctx);
+
+	authenc = calloc(1, sizeof(*authenc));
+	if (!authenc)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	authenc->op = drvcrypt_get_ops(CRYPTO_AUTHENC);
+	if (authenc->op && authenc->op->alloc_ctx)
+		ret = authenc->op->alloc_ctx(&authenc->ctx, algo);
+
+	if (ret != TEE_SUCCESS) {
+		free(authenc);
+	} else {
+		authenc->authenc_ctx.ops = &authenc_ops;
+		*ctx = &authenc->authenc_ctx;
+	}
+
+	CRYPTO_TRACE("authenc alloc_ctx ret 0x%" PRIx32, ret);
+	return ret;
+}

--- a/core/drivers/crypto/crypto_api/authenc/sub.mk
+++ b/core/drivers/crypto/crypto_api/authenc/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += authenc.c

--- a/core/drivers/crypto/crypto_api/include/drvcrypt.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt.h
@@ -57,6 +57,7 @@ enum drvcrypt_algo_id {
 	CRYPTO_ECC,      /* Asymmetric ECC driver */
 	CRYPTO_DH,       /* Asymmetric DH driver */
 	CRYPTO_DSA,	 /* Asymmetric DSA driver */
+	CRYPTO_AUTHENC,  /* Authenticated Encryption driver */
 	CRYPTO_MAX_ALGO  /* Maximum number of algo supported */
 };
 

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_authenc.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_authenc.h
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, STMicroelectronics - All Rights Reserved
+ *
+ * Authenticated Encryption interface calling the crypto driver
+ */
+#ifndef __DRVCRYPT_AUTHENC_H__
+#define __DRVCRYPT_AUTHENC_H__
+
+#include <crypto/crypto_impl.h>
+#include <tee_api_types.h>
+
+/*
+ * Authenticated Encryption operation context
+ */
+struct crypto_authenc {
+	struct crypto_authenc_ctx authenc_ctx;	/* Crypto authenc API context */
+	void *ctx;				/* Authenc context */
+	struct drvcrypt_authenc *op;		/* Reference to the operation */
+};
+
+/*
+ * Authenticated Encryption algorithm initialization data
+ */
+struct drvcrypt_authenc_init {
+	void *ctx;		     /* Software context */
+	bool encrypt;		     /* Encrypt or decrypt direction */
+	struct drvcrypt_buf key;     /* First key */
+	struct drvcrypt_buf nonce;   /* Nonce */
+	size_t tag_len;		     /* Tag length  */
+	size_t aad_len;		     /* Additional Authenticated Data length */
+	size_t payload_len;	     /* Payload length */
+};
+
+/*
+ * Authenticated Encryption algorithm update_aad data
+ */
+struct drvcrypt_authenc_update_aad {
+	void *ctx;		 /* Software context */
+	bool encrypt;		 /* Encrypt or decrypt direction */
+	struct drvcrypt_buf aad; /* Additional Authenticated Data buffer */
+};
+
+/*
+ * Authenticated Encryption algorithm update_aad data
+ */
+struct drvcrypt_authenc_update_payload {
+	void *ctx;		 /* Software context */
+	bool encrypt;		 /* Encrypt or decrypt direction */
+	struct drvcrypt_buf src; /* Buffer source (message or cipher) */
+	struct drvcrypt_buf dst; /* Buffer destination (cipher or message) */
+};
+
+/*
+ * Authenticated Encryption algorithm final data
+ */
+struct drvcrypt_authenc_final {
+	void *ctx;		 /* Software context */
+	bool encrypt;		 /* Encrypt or decrypt direction */
+	struct drvcrypt_buf src; /* Buffer source (message or cipher) */
+	struct drvcrypt_buf dst; /* Buffer destination (cipher or message) */
+	struct drvcrypt_buf tag; /* Tag buffer */
+};
+
+/*
+ * Crypto library authenc driver operations
+ */
+struct drvcrypt_authenc {
+	/* Allocate context */
+	TEE_Result (*alloc_ctx)(void **ctx, uint32_t algo);
+	/* Free context */
+	void (*free_ctx)(void *ctx);
+	/* Initialize the authenc operation */
+	TEE_Result (*init)(struct drvcrypt_authenc_init *dinit);
+	/* Update the authenc operation with associated data */
+	TEE_Result (*update_aad)(struct drvcrypt_authenc_update_aad *dupdate);
+	/* Update the authenc operation with payload data */
+	TEE_Result (*update_payload)(struct drvcrypt_authenc_update_payload *d);
+	/* Update (or not) with payload data and get tag for encrypt op. */
+	TEE_Result (*enc_final)(struct drvcrypt_authenc_final *dfinal);
+	/* Update (or not) with payload data and verify tag for decrypt op. */
+	TEE_Result (*dec_final)(struct drvcrypt_authenc_final *dfinal);
+	/* Finalize the authenc operation */
+	void (*final)(void *ctx);
+	/* Copy authenc context */
+	void (*copy_state)(void *dst_ctx, void *src_ctx);
+};
+
+/*
+ * Register an authenc processing driver in the crypto API
+ *
+ * @ops - Driver operations
+ */
+static inline TEE_Result drvcrypt_register_authenc(struct drvcrypt_authenc *ops)
+{
+	return drvcrypt_register(CRYPTO_AUTHENC, (void *)ops);
+}
+
+#endif /* __DRVCRYPT_AUTHENC_H__ */

--- a/core/drivers/crypto/crypto_api/sub.mk
+++ b/core/drivers/crypto/crypto_api/sub.mk
@@ -7,3 +7,4 @@ subdirs-$(CFG_CRYPTO_DRV_ACIPHER) += acipher
 subdirs-$(CFG_CRYPTO_DRV_ACIPHER) += oid
 subdirs-$(CFG_CRYPTO_DRV_CIPHER) += cipher
 subdirs-$(CFG_CRYPTO_DRV_MAC) += mac
+subdirs-$(CFG_CRYPTO_DRV_AUTHENC) += authenc

--- a/core/drivers/crypto/stm32/authenc.c
+++ b/core/drivers/crypto/stm32/authenc.c
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, STMicroelectronics - All Rights Reserved
+ */
+
+#include <assert.h>
+#include <crypto/crypto.h>
+#include <crypto/crypto_impl.h>
+#include <crypto/internal_aes-gcm.h>
+#include <drvcrypt.h>
+#include <drvcrypt_authenc.h>
+#include <initcall.h>
+#include <kernel/dt.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee_api_types.h>
+#include <utee_defines.h>
+#include <util.h>
+
+#include "common.h"
+#include "stm32_cryp.h"
+
+#define TOBE32(x)			TEE_U32_BSWAP(x)
+#define FROMBE32(x)			TEE_U32_BSWAP(x)
+
+#define MAX_TAG_SIZE			16U
+
+struct stm32_ae_ctx {
+	struct crypto_authenc_ctx a_ctx;
+	struct stm32_cryp_context cryp;
+	enum stm32_cryp_algo_mode algo;
+	uint8_t tag_mask[MAX_TAG_SIZE];
+};
+
+static void xor_vec(uint8_t *r, uint8_t *a, uint8_t *b, size_t len)
+{
+	size_t i = 0;
+
+	for (i = 0; i < len; i++)
+		r[i] = a[i] ^ b[i];
+}
+
+static struct stm32_ae_ctx *to_stm32_ae_ctx(struct crypto_authenc_ctx *ctx)
+{
+	assert(ctx);
+
+	return container_of(ctx, struct stm32_ae_ctx, a_ctx);
+}
+
+static TEE_Result stm32_ae_gcm_generate_iv(struct stm32_ae_ctx *c,
+					   uint32_t *iv,
+					   struct drvcrypt_authenc_init *dinit)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint8_t tag1[MAX_TAG_SIZE] = { 0 };
+	uint8_t tag2[MAX_TAG_SIZE] = { 0 };
+	uint32_t j0[MAX_TAG_SIZE / sizeof(uint32_t)] = { 0 };
+	uint8_t dummy_iv[MAX_TAG_SIZE] = { 0 };
+	struct stm32_cryp_context ctx = { };
+	uint8_t *data_out = NULL;
+
+	if (dinit->nonce.length == 12) {
+		memcpy(iv, dinit->nonce.data, dinit->nonce.length);
+		iv[3] = TOBE32(2);
+		return TEE_SUCCESS;
+	}
+
+	/* Calculate GHASH(dinit->nonce.data) */
+	dummy_iv[15] = 2;
+
+	res = stm32_cryp_init(&ctx, true, STM32_CRYP_MODE_AES_GCM,
+			      dinit->key.data, dinit->key.length,
+			      dummy_iv, sizeof(dummy_iv));
+	if (res)
+		return res;
+
+	res = stm32_cryp_final(&ctx, tag1, sizeof(tag1));
+	if (res)
+		return res;
+
+	memset(&ctx, 0, sizeof(ctx));
+	res = stm32_cryp_init(&ctx, true, STM32_CRYP_MODE_AES_GCM,
+			      dinit->key.data, dinit->key.length,
+			      dummy_iv, sizeof(dummy_iv));
+	if (res)
+		return res;
+
+	data_out = malloc(dinit->nonce.length);
+	if (!data_out)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = stm32_cryp_update_load(&ctx, dinit->nonce.data, data_out,
+				     dinit->nonce.length);
+	free(data_out);
+
+	if (res)
+		return res;
+
+	res = stm32_cryp_final(&ctx, tag2, sizeof(tag2));
+	if (res)
+		return res;
+
+	xor_vec((uint8_t *)j0, tag1, tag2, sizeof(tag1));
+
+	memcpy(iv, j0, sizeof(j0));
+	iv[3] = TOBE32(FROMBE32(iv[3]) + 1);
+
+	/* Compute first mask=AES_ECB(J0_real) into tag1 */
+	memset(&ctx, 0, sizeof(ctx));
+	res = stm32_cryp_init(&ctx, false, STM32_CRYP_MODE_AES_ECB,
+			      dinit->key.data, dinit->key.length,
+			      NULL, 0);
+	if (res)
+		return res;
+
+	res = stm32_cryp_update(&ctx, true, (uint8_t *)j0, tag1,
+				sizeof(tag1));
+	if (res)
+		return res;
+
+	/* Compute second mask=AES_ECB(J0_used_by_HW) into tag2 */
+	memset(&ctx, 0, sizeof(ctx));
+	j0[3] = TOBE32(1);
+	res = stm32_cryp_init(&ctx, false, STM32_CRYP_MODE_AES_ECB,
+			      dinit->key.data, dinit->key.length,
+			      NULL, 0);
+	if (res)
+		return res;
+
+	res = stm32_cryp_update(&ctx, true, (uint8_t *)j0, tag2,
+				sizeof(tag2));
+	if (res)
+		return res;
+
+	/*
+	 * Save the mask we will apply in {enc,dec}_final() to the
+	 * (wrongly) computed tag to get the expected one.
+	 */
+	xor_vec(c->tag_mask, tag1, tag2, sizeof(c->tag_mask));
+
+	return TEE_SUCCESS;
+}
+
+static void stm32_ae_ccm_generate_b0(uint8_t *b0,
+				     struct drvcrypt_authenc_init *dinit)
+{
+	size_t m = dinit->tag_len;
+	size_t l = 15 - dinit->nonce.length;
+	size_t payload_len = dinit->payload_len;
+	size_t i = 15;
+
+	/* The tag_len should be 4, 6, 8, 10, 12, 14 or 16 */
+	assert(m >= 4 && m <= 16 && (m % 2) == 0);
+
+	memset(b0, 0, TEE_AES_BLOCK_SIZE);
+	/* Flags: (Adata << 6) | (M' << 3) | L' */
+	b0[0] = ((dinit->aad_len ? 1 : 0) << 6) |
+		(((m - 2) / 2) << 3) |
+		(l - 1);
+
+	/* Nonce */
+	memcpy(b0 + 1, dinit->nonce.data, dinit->nonce.length);
+
+	/* Payload length */
+	for (i = 15; i >= 15 - l + 1; i--, payload_len >>= 8)
+		b0[i] = payload_len & 0xFF;
+}
+
+static TEE_Result stm32_ae_ccm_push_b1(struct stm32_ae_ctx *c,
+				       struct drvcrypt_authenc_init *dinit)
+{
+	uint8_t b1[TEE_AES_BLOCK_SIZE] = { 0 };
+	size_t len = 0;
+
+	if (dinit->aad_len == 0)
+		return TEE_SUCCESS;
+
+	if (dinit->aad_len < 0x100) {
+		b1[1] = dinit->aad_len;
+		len = 2;
+	} else if (dinit->aad_len < 0xFF00) {
+		b1[0] = dinit->aad_len / 0x100;
+		b1[1] = dinit->aad_len % 0x100;
+		len = 2;
+	} else if  (dinit->aad_len <= UINT32_MAX) {
+		b1[0] = 0xFF;
+		b1[1] = 0xFE;
+		b1[2] = dinit->aad_len & GENMASK_32(7, 0);
+		b1[3] = (dinit->aad_len & GENMASK_32(15, 8)) >> 8;
+		b1[4] = (dinit->aad_len & GENMASK_32(23, 16)) >> 16;
+		b1[5] = (dinit->aad_len & GENMASK_32(31, 24)) >> 24;
+		len = 6;
+	} else {
+		b1[0] = 0xFF;
+		b1[1] = 0xFF;
+		b1[2] = dinit->aad_len & GENMASK_64(7, 0);
+		b1[3] = (dinit->aad_len & GENMASK_64(15, 8)) >> 8;
+		b1[4] = (dinit->aad_len & GENMASK_64(23, 16)) >> 16;
+		b1[5] = (dinit->aad_len & GENMASK_64(31, 24)) >> 24;
+		b1[6] = (dinit->aad_len & GENMASK_64(39, 32)) >> 32;
+		b1[7] = (dinit->aad_len & GENMASK_64(47, 40)) >> 40;
+		b1[8] = (dinit->aad_len & GENMASK_64(55, 48)) >> 48;
+		b1[9] = (dinit->aad_len & GENMASK_64(63, 56)) >> 56;
+		len = 10;
+	}
+
+	return stm32_cryp_update_assodata(&c->cryp, b1, len);
+}
+
+static TEE_Result stm32_ae_initialize(struct drvcrypt_authenc_init *dinit)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t iv[4] = { 0 };
+	struct stm32_ae_ctx *c = to_stm32_ae_ctx(dinit->ctx);
+
+	if (c->algo == STM32_CRYP_MODE_AES_GCM) {
+		res = stm32_ae_gcm_generate_iv(c, iv, dinit);
+		if (res)
+			return res;
+	} else if (c->algo == STM32_CRYP_MODE_AES_CCM) {
+		stm32_ae_ccm_generate_b0((uint8_t *)iv, dinit);
+	}
+
+	res = stm32_cryp_init(&c->cryp, !dinit->encrypt, c->algo,
+			      dinit->key.data, dinit->key.length, iv,
+			      sizeof(iv));
+	if (res)
+		return res;
+
+	if (c->algo == STM32_CRYP_MODE_AES_CCM)
+		return stm32_ae_ccm_push_b1(c, dinit);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result
+stm32_ae_update_aad(struct drvcrypt_authenc_update_aad *dupdate)
+{
+	struct stm32_ae_ctx *c = to_stm32_ae_ctx(dupdate->ctx);
+
+	return stm32_cryp_update_assodata(&c->cryp, dupdate->aad.data,
+					  dupdate->aad.length);
+}
+
+static TEE_Result
+stm32_ae_update_payload(struct drvcrypt_authenc_update_payload *dupdate)
+{
+	struct stm32_ae_ctx *c = to_stm32_ae_ctx(dupdate->ctx);
+	size_t len = MIN(dupdate->src.length, dupdate->dst.length);
+
+	return stm32_cryp_update_load(&c->cryp, dupdate->src.data,
+				      dupdate->dst.data, len);
+}
+
+static TEE_Result stm32_ae_encdec_final(struct stm32_ae_ctx *c, uint8_t *tag,
+					size_t tag_size)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint8_t t[MAX_TAG_SIZE] = { 0 };
+
+	res = stm32_cryp_final(&c->cryp, t, sizeof(t));
+	if (res)
+		return res;
+
+	xor_vec(tag, t, c->tag_mask, tag_size);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result stm32_ae_enc_final(struct drvcrypt_authenc_final *dfinal)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct stm32_ae_ctx *c = to_stm32_ae_ctx(dfinal->ctx);
+	size_t len = MIN(dfinal->src.length, dfinal->dst.length);
+
+	res = stm32_cryp_update_load(&c->cryp, dfinal->src.data,
+				     dfinal->dst.data, len);
+	if (res)
+		return res;
+
+	return stm32_ae_encdec_final(c, dfinal->tag.data, dfinal->tag.length);
+}
+
+static TEE_Result stm32_ae_dec_final(struct drvcrypt_authenc_final *dfinal)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct stm32_ae_ctx *c = to_stm32_ae_ctx(dfinal->ctx);
+	size_t len = MIN(dfinal->src.length, dfinal->dst.length);
+	unsigned char tag_buf[MAX_TAG_SIZE] = { 0 };
+
+	res = stm32_cryp_update_load(&c->cryp, dfinal->src.data,
+				     dfinal->dst.data, len);
+	if (res)
+		return res;
+
+	res = stm32_ae_encdec_final(c, tag_buf, sizeof(tag_buf));
+	if (res)
+		return res;
+
+	if (consttime_memcmp(tag_buf, dfinal->tag.data, dfinal->tag.length))
+		return TEE_ERROR_MAC_INVALID;
+
+	return TEE_SUCCESS;
+}
+
+static void stm32_ae_final(void *ctx __unused)
+{
+}
+
+static void stm32_ae_free(void *ctx)
+{
+	struct stm32_ae_ctx *c = to_stm32_ae_ctx(ctx);
+
+	free(c);
+}
+
+static void stm32_ae_copy_state(void *dst_ctx, void *src_ctx)
+{
+	struct stm32_ae_ctx *src = to_stm32_ae_ctx(src_ctx);
+	struct stm32_ae_ctx *dst = to_stm32_ae_ctx(dst_ctx);
+
+	memcpy(dst, src, sizeof(*dst));
+}
+
+static TEE_Result alloc_ctx(void **ctx, enum stm32_cryp_algo_mode algo)
+{
+	struct stm32_ae_ctx *c = calloc(1, sizeof(*c));
+
+	if (!c)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	c->algo = algo;
+	*ctx = &c->a_ctx;
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Allocate the SW authenc data context
+ *
+ * @ctx   [out] Caller context variable
+ * @algo  Algorithm ID of the context
+ */
+static TEE_Result stm32_ae_allocate(void **ctx, uint32_t algo)
+{
+	/* Convert TEE_ALGO id to CRYP id */
+	switch (algo) {
+	case TEE_ALG_AES_CCM:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_AES_CCM);
+	case TEE_ALG_AES_GCM:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_AES_GCM);
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+}
+
+/*
+ * Registration of the Authenc Driver
+ */
+static struct drvcrypt_authenc driver_authenc = {
+	.alloc_ctx = &stm32_ae_allocate,
+	.free_ctx = &stm32_ae_free,
+	.init = &stm32_ae_initialize,
+	.update_aad = &stm32_ae_update_aad,
+	.update_payload = &stm32_ae_update_payload,
+	.enc_final = &stm32_ae_enc_final,
+	.dec_final = &stm32_ae_dec_final,
+	.final = &stm32_ae_final,
+	.copy_state = &stm32_ae_copy_state,
+};
+
+TEE_Result stm32_register_authenc(void)
+{
+	return drvcrypt_register_authenc(&driver_authenc);
+}

--- a/core/drivers/crypto/stm32/cipher.c
+++ b/core/drivers/crypto/stm32/cipher.c
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, STMicroelectronics - All Rights Reserved
+ */
+
+#include <assert.h>
+#include <crypto/crypto.h>
+#include <crypto/crypto_impl.h>
+#include <drvcrypt.h>
+#include <drvcrypt_cipher.h>
+#include <kernel/dt.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+#include "common.h"
+#include "stm32_cryp.h"
+
+#define DES3_KEY_SIZE		24
+
+struct stm32_cipher_ctx {
+	struct crypto_cipher_ctx c_ctx;
+	struct stm32_cryp_context cryp;
+	enum stm32_cryp_algo_mode algo;
+};
+
+static struct stm32_cipher_ctx *
+to_stm32_cipher_ctx(struct crypto_cipher_ctx *ctx)
+{
+	assert(ctx);
+
+	return container_of(ctx, struct stm32_cipher_ctx, c_ctx);
+}
+
+static TEE_Result stm32_cipher_initialize(struct drvcrypt_cipher_init *dinit)
+{
+	struct stm32_cipher_ctx *c = to_stm32_cipher_ctx(dinit->ctx);
+	uint8_t temp_key[DES3_KEY_SIZE] = { 0 };
+	uint8_t *key = NULL;
+	size_t key_size = 0;
+
+	if (dinit->key1.length == 16 &&
+	    (c->algo == STM32_CRYP_MODE_TDES_ECB ||
+	     c->algo == STM32_CRYP_MODE_TDES_CBC)) {
+		/* Manage DES2: ie K=K1.K2.K1 */
+		memcpy(temp_key, dinit->key1.data, dinit->key1.length);
+		memcpy(temp_key + dinit->key1.length, dinit->key1.data,
+		       dinit->key1.length / 2);
+		key_size = DES3_KEY_SIZE;
+		key = temp_key;
+	} else {
+		key_size =  dinit->key1.length;
+		key = dinit->key1.data;
+	}
+
+	return stm32_cryp_init(&c->cryp, !dinit->encrypt, c->algo,
+			       key, key_size, dinit->iv.data,
+			       dinit->iv.length);
+}
+
+static TEE_Result stm32_cipher_update(struct drvcrypt_cipher_update *dupdate)
+{
+	struct stm32_cipher_ctx *c = to_stm32_cipher_ctx(dupdate->ctx);
+	size_t len = MIN(dupdate->src.length, dupdate->dst.length);
+
+	return stm32_cryp_update(&c->cryp, dupdate->last,
+				 dupdate->src.data, dupdate->dst.data,
+				 len);
+}
+
+static void stm32_cipher_final(void *ctx __unused)
+{
+}
+
+static void stm32_cipher_free(void *ctx)
+{
+	struct stm32_cipher_ctx *c = to_stm32_cipher_ctx(ctx);
+
+	free(c);
+}
+
+static void stm32_cipher_copy_state(void *dst_ctx, void *src_ctx)
+{
+	struct stm32_cipher_ctx *src = to_stm32_cipher_ctx(src_ctx);
+	struct stm32_cipher_ctx *dst = to_stm32_cipher_ctx(dst_ctx);
+
+	memcpy(dst, src, sizeof(*dst));
+}
+
+static TEE_Result alloc_ctx(void **ctx, enum stm32_cryp_algo_mode algo)
+{
+	struct stm32_cipher_ctx *c = calloc(1, sizeof(*c));
+
+	if (!c)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	c->algo = algo;
+	*ctx = &c->c_ctx;
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Allocate the SW cipher data context.
+ *
+ * @ctx   [out] Caller context variable
+ * @algo  Algorithm ID of the context
+ */
+static TEE_Result stm32_cipher_allocate(void **ctx, uint32_t algo)
+{
+	/*
+	 * Convert TEE_ALGO id to internal id
+	 */
+	switch (algo) {
+	case TEE_ALG_DES_ECB_NOPAD:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_DES_ECB);
+	case TEE_ALG_DES_CBC_NOPAD:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_DES_CBC);
+	case TEE_ALG_DES3_ECB_NOPAD:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_TDES_ECB);
+	case TEE_ALG_DES3_CBC_NOPAD:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_TDES_CBC);
+	case TEE_ALG_AES_ECB_NOPAD:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_AES_ECB);
+	case TEE_ALG_AES_CBC_NOPAD:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_AES_CBC);
+	case TEE_ALG_AES_CTR:
+		return alloc_ctx(ctx, STM32_CRYP_MODE_AES_CTR);
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+}
+
+static struct drvcrypt_cipher driver_cipher = {
+	.alloc_ctx = &stm32_cipher_allocate,
+	.free_ctx = &stm32_cipher_free,
+	.init = &stm32_cipher_initialize,
+	.update = &stm32_cipher_update,
+	.final = &stm32_cipher_final,
+	.copy_state = &stm32_cipher_copy_state,
+};
+
+TEE_Result stm32_register_cipher(void)
+{
+	return drvcrypt_register_cipher(&driver_cipher);
+}

--- a/core/drivers/crypto/stm32/common.h
+++ b/core/drivers/crypto/stm32/common.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, STMicroelectronics - All Rights Reserved
+ */
+
+#ifndef __DRIVERS_CRYPTO_STM32_COMMON_H
+#define __DRIVERS_CRYPTO_STM32_COMMON_H
+
+#include <tee_api_types.h>
+
+TEE_Result stm32_register_cipher(void);
+
+#endif /* __DRIVERS_CRYPTO_STM32_COMMON_H */

--- a/core/drivers/crypto/stm32/common.h
+++ b/core/drivers/crypto/stm32/common.h
@@ -8,6 +8,7 @@
 
 #include <tee_api_types.h>
 
+TEE_Result stm32_register_authenc(void);
 TEE_Result stm32_register_cipher(void);
 
 #endif /* __DRIVERS_CRYPTO_STM32_COMMON_H */

--- a/core/drivers/crypto/stm32/crypto.mk
+++ b/core/drivers/crypto/stm32/crypto.mk
@@ -1,0 +1,16 @@
+# CFG_STM32_CRYPTO_DRIVER, when enabled, embeds
+#       STM32 HW cryptographic support and OP-TEE Crypto Driver.
+# CFG_STM32_CRYP, when enabled, embeds
+#       STM32 CRYP module support,
+#       CIPHER Crypto Driver,
+
+ifeq ($(CFG_STM32_CRYPTO_DRIVER),y)
+
+$(call force,CFG_CRYPTO_DRIVER,y)
+CFG_CRYPTO_DRIVER_DEBUG ?= 0
+
+ifeq ($(CFG_STM32_CRYP),y)
+$(call force,CFG_CRYPTO_DRV_CIPHER,y,Mandated by CFG_STM32_CRYP)
+endif
+
+endif # CFG_STM32_CRYPTO_DRIVER

--- a/core/drivers/crypto/stm32/crypto.mk
+++ b/core/drivers/crypto/stm32/crypto.mk
@@ -3,6 +3,7 @@
 # CFG_STM32_CRYP, when enabled, embeds
 #       STM32 CRYP module support,
 #       CIPHER Crypto Driver,
+#       AUTHENC Crypto Driver.
 
 ifeq ($(CFG_STM32_CRYPTO_DRIVER),y)
 
@@ -11,6 +12,10 @@ CFG_CRYPTO_DRIVER_DEBUG ?= 0
 
 ifeq ($(CFG_STM32_CRYP),y)
 $(call force,CFG_CRYPTO_DRV_CIPHER,y,Mandated by CFG_STM32_CRYP)
+endif
+
+ifeq ($(CFG_STM32_CRYP),y)
+$(call force,CFG_CRYPTO_DRV_AUTHENC,y,Mandated by CFG_STM32_CRYP)
 endif
 
 endif # CFG_STM32_CRYPTO_DRIVER

--- a/core/drivers/crypto/stm32/stm32_cryp.c
+++ b/core/drivers/crypto/stm32/stm32_cryp.c
@@ -1290,6 +1290,14 @@ static TEE_Result stm32_cryp_driver_init(void)
 	if (stm32_reset_deassert(cryp_pdata.reset_id, TIMEOUT_US_1MS))
 		panic();
 
+	if (IS_ENABLED(CFG_CRYPTO_DRV_AUTHENC)) {
+		res = stm32_register_authenc();
+		if (res) {
+			EMSG("Failed to register to authenc: %#"PRIx32, res);
+			panic();
+		}
+	}
+
 	if (IS_ENABLED(CFG_CRYPTO_DRV_CIPHER)) {
 		res = stm32_register_cipher();
 		if (res) {

--- a/core/drivers/crypto/stm32/stm32_cryp.c
+++ b/core/drivers/crypto/stm32/stm32_cryp.c
@@ -1,0 +1,1304 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, STMicroelectronics - All Rights Reserved
+ */
+#include <assert.h>
+#include <config.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <kernel/mutex.h>
+#include <libfdt.h>
+#include <mm/core_memprot.h>
+#include <stdint.h>
+#include <stm32_util.h>
+#include <string.h>
+#include <utee_defines.h>
+#include <util.h>
+
+#include "stm32_cryp.h"
+#include "common.h"
+
+#define INT8_BIT			8U
+#define AES_BLOCK_SIZE_BIT		128U
+#define AES_BLOCK_SIZE			(AES_BLOCK_SIZE_BIT / INT8_BIT)
+#define AES_BLOCK_NB_U32		(AES_BLOCK_SIZE / sizeof(uint32_t))
+#define DES_BLOCK_SIZE_BIT		64U
+#define DES_BLOCK_SIZE			(DES_BLOCK_SIZE_BIT / INT8_BIT)
+#define DES_BLOCK_NB_U32		(DES_BLOCK_SIZE / sizeof(uint32_t))
+#define MAX_BLOCK_SIZE_BIT		AES_BLOCK_SIZE_BIT
+#define MAX_BLOCK_SIZE			AES_BLOCK_SIZE
+#define MAX_BLOCK_NB_U32		AES_BLOCK_NB_U32
+#define AES_KEYSIZE_128			16U
+#define AES_KEYSIZE_192			24U
+#define AES_KEYSIZE_256			32U
+
+/* CRYP control register */
+#define _CRYP_CR			0x0U
+/* CRYP status register */
+#define _CRYP_SR			0x04U
+/* CRYP data input register */
+#define _CRYP_DIN			0x08U
+/* CRYP data output register */
+#define _CRYP_DOUT			0x0CU
+/* CRYP DMA control register */
+#define _CRYP_DMACR			0x10U
+/* CRYP interrupt mask set/clear register */
+#define _CRYP_IMSCR			0x14U
+/* CRYP raw interrupt status register */
+#define _CRYP_RISR			0x18U
+/* CRYP masked interrupt status register */
+#define _CRYP_MISR			0x1CU
+/* CRYP key registers */
+#define _CRYP_K0LR			0x20U
+#define _CRYP_K0RR			0x24U
+#define _CRYP_K1LR			0x28U
+#define _CRYP_K1RR			0x2CU
+#define _CRYP_K2LR			0x30U
+#define _CRYP_K2RR			0x34U
+#define _CRYP_K3LR			0x38U
+#define _CRYP_K3RR			0x3CU
+/* CRYP initialization vector registers */
+#define _CRYP_IV0LR			0x40U
+#define _CRYP_IV0RR			0x44U
+#define _CRYP_IV1LR			0x48U
+#define _CRYP_IV1RR			0x4CU
+/* CRYP context swap GCM-CCM registers */
+#define _CRYP_CSGCMCCM0R		0x50U
+#define _CRYP_CSGCMCCM1R		0x54U
+#define _CRYP_CSGCMCCM2R		0x58U
+#define _CRYP_CSGCMCCM3R		0x5CU
+#define _CRYP_CSGCMCCM4R		0x60U
+#define _CRYP_CSGCMCCM5R		0x64U
+#define _CRYP_CSGCMCCM6R		0x68U
+#define _CRYP_CSGCMCCM7R		0x6CU
+/* CRYP context swap GCM registers */
+#define _CRYP_CSGCM0R			0x70U
+#define _CRYP_CSGCM1R			0x74U
+#define _CRYP_CSGCM2R			0x78U
+#define _CRYP_CSGCM3R			0x7CU
+#define _CRYP_CSGCM4R			0x80U
+#define _CRYP_CSGCM5R			0x84U
+#define _CRYP_CSGCM6R			0x88U
+#define _CRYP_CSGCM7R			0x8CU
+/* CRYP hardware configuration register */
+#define _CRYP_HWCFGR			0x3F0U
+/* CRYP HW version register */
+#define _CRYP_VERR			0x3F4U
+/* CRYP identification */
+#define _CRYP_IPIDR			0x3F8U
+/* CRYP HW magic ID */
+#define _CRYP_MID			0x3FCU
+
+#define CRYP_TIMEOUT_US			1000000U
+#define TIMEOUT_US_1MS			1000U
+
+/* CRYP control register fields */
+#define _CRYP_CR_RESET_VALUE		0x0U
+#define _CRYP_CR_NPBLB_MSK		GENMASK_32(23, 20)
+#define _CRYP_CR_NPBLB_OFF		20U
+#define _CRYP_CR_GCM_CCMPH_MSK		GENMASK_32(17, 16)
+#define _CRYP_CR_GCM_CCMPH_OFF		16U
+#define _CRYP_CR_GCM_CCMPH_INIT		0U
+#define _CRYP_CR_GCM_CCMPH_HEADER	1U
+#define _CRYP_CR_GCM_CCMPH_PAYLOAD	2U
+#define _CRYP_CR_GCM_CCMPH_FINAL	3U
+#define _CRYP_CR_CRYPEN			BIT(15)
+#define _CRYP_CR_FFLUSH			BIT(14)
+#define _CRYP_CR_KEYSIZE_MSK		GENMASK_32(9, 8)
+#define _CRYP_CR_KEYSIZE_OFF		8U
+#define _CRYP_CR_KSIZE_128		0U
+#define _CRYP_CR_KSIZE_192		1U
+#define _CRYP_CR_KSIZE_256		2U
+#define _CRYP_CR_DATATYPE_MSK		GENMASK_32(7, 6)
+#define _CRYP_CR_DATATYPE_OFF		6U
+#define _CRYP_CR_DATATYPE_NONE		0U
+#define _CRYP_CR_DATATYPE_HALF_WORD	1U
+#define _CRYP_CR_DATATYPE_BYTE		2U
+#define _CRYP_CR_DATATYPE_BIT		3U
+#define _CRYP_CR_ALGOMODE_MSK		(BIT(19) | GENMASK_32(5, 3))
+#define _CRYP_CR_ALGOMODE_OFF		3U
+#define _CRYP_CR_ALGOMODE_TDES_ECB	0x0U
+#define _CRYP_CR_ALGOMODE_TDES_CBC	0x1U
+#define _CRYP_CR_ALGOMODE_DES_ECB	0x2U
+#define _CRYP_CR_ALGOMODE_DES_CBC	0x3U
+#define _CRYP_CR_ALGOMODE_AES_ECB	0x4U
+#define _CRYP_CR_ALGOMODE_AES_CBC	0x5U
+#define _CRYP_CR_ALGOMODE_AES_CTR	0x6U
+#define _CRYP_CR_ALGOMODE_AES		0x7U
+#define _CRYP_CR_ALGOMODE_AES_GCM	BIT(16)
+#define _CRYP_CR_ALGOMODE_AES_CCM	(BIT(16) | BIT(0))
+#define _CRYP_CR_ALGODIR		BIT(2)
+#define _CRYP_CR_ALGODIR_ENC		0U
+#define _CRYP_CR_ALGODIR_DEC		BIT(2)
+
+/* CRYP status register fields */
+#define _CRYP_SR_BUSY			BIT(4)
+#define _CRYP_SR_OFFU			BIT(3)
+#define _CRYP_SR_OFNE			BIT(2)
+#define _CRYP_SR_IFNF			BIT(1)
+#define _CRYP_SR_IFEM			BIT(0)
+
+/* CRYP DMA control register fields */
+#define _CRYP_DMACR_DOEN		BIT(1)
+#define _CRYP_DMACR_DIEN		BIT(0)
+
+/* CRYP interrupt fields */
+#define _CRYP_I_OUT			BIT(1)
+#define _CRYP_I_IN			BIT(0)
+
+/* CRYP hardware configuration register fields */
+#define _CRYP_HWCFGR_CFG1_MSK		GENMASK_32(3, 0)
+#define _CRYP_HWCFGR_CFG1_OFF		0U
+#define _CRYP_HWCFGR_CFG2_MSK		GENMASK_32(7, 4)
+#define _CRYP_HWCFGR_CFG2_OFF		4U
+#define _CRYP_HWCFGR_CFG3_MSK		GENMASK_32(11, 8)
+#define _CRYP_HWCFGR_CFG3_OFF		8U
+#define _CRYP_HWCFGR_CFG4_MSK		GENMASK_32(15, 12)
+#define _CRYP_HWCFGR_CFG4_OFF		12U
+
+/* CRYP HW version register */
+#define _CRYP_VERR_MSK			GENMASK_32(7, 0)
+#define _CRYP_VERR_OFF			0U
+
+/*
+ * Macro to manage bit manipulation when we work on local variable
+ * before writing only once to the real register.
+ */
+#define CLRBITS(v, bits)		((v) &= ~(bits))
+#define SETBITS(v, bits)		((v) |= (bits))
+
+#define IS_ALGOMODE(cr, mod) \
+	(((cr) & _CRYP_CR_ALGOMODE_MSK) == (_CRYP_CR_ALGOMODE_##mod << \
+					  _CRYP_CR_ALGOMODE_OFF))
+
+#define SET_ALGOMODE(mod, cr) \
+	clrsetbits(&(cr), _CRYP_CR_ALGOMODE_MSK, (_CRYP_CR_ALGOMODE_##mod << \
+						  _CRYP_CR_ALGOMODE_OFF))
+
+#define GET_ALGOMODE(cr) \
+	(((cr) & _CRYP_CR_ALGOMODE_MSK) >> _CRYP_CR_ALGOMODE_OFF)
+
+#define TOBE32(x)			TEE_U32_BSWAP(x)
+#define FROMBE32(x)			TEE_U32_BSWAP(x)
+
+static struct stm32_cryp_platdata cryp_pdata;
+static struct mutex cryp_lock = MUTEX_INITIALIZER;
+
+static void clrsetbits(uint32_t *v, uint32_t mask, uint32_t bits)
+{
+	*v = (*v & ~mask) | bits;
+}
+
+static bool algo_mode_needs_iv(uint32_t cr)
+{
+	return !IS_ALGOMODE(cr, TDES_ECB) && !IS_ALGOMODE(cr, DES_ECB) &&
+		!IS_ALGOMODE(cr, AES_ECB);
+}
+
+static bool algo_mode_is_ecb_cbc(uint32_t cr)
+{
+	return GET_ALGOMODE(cr) < _CRYP_CR_ALGOMODE_AES_CTR;
+}
+
+static bool algo_mode_is_aes(uint32_t cr)
+{
+	return ((cr & _CRYP_CR_ALGOMODE_MSK) >> _CRYP_CR_ALGOMODE_OFF) >=
+		_CRYP_CR_ALGOMODE_AES_ECB;
+}
+
+static bool is_decrypt(uint32_t cr)
+{
+	return (cr & _CRYP_CR_ALGODIR) == _CRYP_CR_ALGODIR_DEC;
+}
+
+static bool is_encrypt(uint32_t cr)
+{
+	return !is_decrypt(cr);
+}
+
+static bool does_need_npblb(uint32_t cr)
+{
+	return (IS_ALGOMODE(cr, AES_GCM) && is_encrypt(cr)) ||
+	       (IS_ALGOMODE(cr, AES_CCM) && is_decrypt(cr));
+}
+
+static TEE_Result wait_sr_bits(vaddr_t base, uint32_t bits)
+{
+	uint64_t timeout_ref = timeout_init_us(CRYP_TIMEOUT_US);
+
+	while ((io_read32(base + _CRYP_SR) & bits) != bits)
+		if (timeout_elapsed(timeout_ref))
+			break;
+
+	if  ((io_read32(base + _CRYP_SR) & bits) != bits)
+		return TEE_ERROR_BUSY;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result wait_end_busy(vaddr_t base)
+{
+	uint64_t timeout_ref = timeout_init_us(CRYP_TIMEOUT_US);
+
+	while (io_read32(base + _CRYP_SR) & _CRYP_SR_BUSY)
+		if (timeout_elapsed(timeout_ref))
+			break;
+
+	if (io_read32(base + _CRYP_SR) & _CRYP_SR_BUSY)
+		return TEE_ERROR_BUSY;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result wait_end_enable(vaddr_t base)
+{
+	uint64_t timeout_ref = timeout_init_us(CRYP_TIMEOUT_US);
+
+	while (io_read32(base + _CRYP_CR) & _CRYP_CR_CRYPEN)
+		if (timeout_elapsed(timeout_ref))
+			break;
+
+	if (io_read32(base + _CRYP_CR) & _CRYP_CR_CRYPEN)
+		return TEE_ERROR_BUSY;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result __must_check write_align_block(struct stm32_cryp_context *ctx,
+						 uint32_t *data)
+{
+	TEE_Result res = TEE_SUCCESS;
+	unsigned int i = 0;
+
+	res = wait_sr_bits(ctx->base, _CRYP_SR_IFNF);
+	if (res)
+		return res;
+
+	for (i = 0; i < ctx->block_u32; i++) {
+		/* No need to htobe() as we configure the HW to swap bytes */
+		io_write32(ctx->base + _CRYP_DIN, data[i]);
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result __must_check write_block(struct stm32_cryp_context *ctx,
+					   uint8_t *data)
+{
+	if (!IS_ALIGNED_WITH_TYPE(data, uint32_t)) {
+		uint32_t data_u32[MAX_BLOCK_NB_U32] = { 0 };
+
+		memcpy(data_u32, data, ctx->block_u32 * sizeof(uint32_t));
+		return write_align_block(ctx, data_u32);
+	}
+
+	return write_align_block(ctx, (void *)data);
+}
+
+static TEE_Result __must_check read_align_block(struct stm32_cryp_context *ctx,
+						uint32_t *data)
+{
+	TEE_Result res = TEE_SUCCESS;
+	unsigned int i = 0;
+
+	res = wait_sr_bits(ctx->base, _CRYP_SR_OFNE);
+	if (res)
+		return res;
+
+	for (i = 0; i < ctx->block_u32; i++) {
+		/* No need to htobe() as we configure the HW to swap bytes */
+		data[i] = io_read32(ctx->base + _CRYP_DOUT);
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result __must_check read_block(struct stm32_cryp_context *ctx,
+					  uint8_t *data)
+{
+	if (!IS_ALIGNED_WITH_TYPE(data, uint32_t)) {
+		TEE_Result res = TEE_SUCCESS;
+		uint32_t data_u32[MAX_BLOCK_NB_U32] = { 0 };
+
+		res = read_align_block(ctx, data_u32);
+		if (res)
+			return res;
+
+		memcpy(data, data_u32, ctx->block_u32 * sizeof(uint32_t));
+
+		return TEE_SUCCESS;
+	}
+
+	return read_align_block(ctx, (void *)data);
+}
+
+static void cryp_end(struct stm32_cryp_context *ctx, TEE_Result prev_error)
+{
+	if (prev_error) {
+		stm32_reset_assert(cryp_pdata.reset_id, TIMEOUT_US_1MS);
+		stm32_reset_deassert(cryp_pdata.reset_id, TIMEOUT_US_1MS);
+	}
+
+	/* Disable the CRYP peripheral */
+	io_clrbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+}
+
+static void cryp_write_iv(struct stm32_cryp_context *ctx)
+{
+	if (algo_mode_needs_iv(ctx->cr)) {
+		unsigned int i = 0;
+
+		/* Restore the _CRYP_IVRx */
+		for (i = 0; i < ctx->block_u32; i++)
+			io_write32(ctx->base + _CRYP_IV0LR + i *
+				   sizeof(uint32_t), ctx->iv[i]);
+	}
+}
+
+static void cryp_save_suspend(struct stm32_cryp_context *ctx)
+{
+	unsigned int i = 0;
+
+	if (IS_ALGOMODE(ctx->cr, AES_GCM) || IS_ALGOMODE(ctx->cr, AES_CCM))
+		for (i = 0; i < ARRAY_SIZE(ctx->pm_gcmccm); i++)
+			ctx->pm_gcmccm[i] = io_read32(ctx->base +
+						      _CRYP_CSGCMCCM0R +
+						      i * sizeof(uint32_t));
+
+	if (IS_ALGOMODE(ctx->cr, AES_GCM))
+		for (i = 0; i < ARRAY_SIZE(ctx->pm_gcm); i++)
+			ctx->pm_gcm[i] = io_read32(ctx->base + _CRYP_CSGCM0R +
+						   i * sizeof(uint32_t));
+}
+
+static void cryp_restore_suspend(struct stm32_cryp_context *ctx)
+{
+	unsigned int i = 0;
+
+	if (IS_ALGOMODE(ctx->cr, AES_GCM) || IS_ALGOMODE(ctx->cr, AES_CCM))
+		for (i = 0; i < ARRAY_SIZE(ctx->pm_gcmccm); i++)
+			io_write32(ctx->base + _CRYP_CSGCMCCM0R +
+				   i * sizeof(uint32_t), ctx->pm_gcmccm[i]);
+
+	if (IS_ALGOMODE(ctx->cr, AES_GCM))
+		for (i = 0; i < ARRAY_SIZE(ctx->pm_gcm); i++)
+			io_write32(ctx->base + _CRYP_CSGCM0R +
+				   i * sizeof(uint32_t), ctx->pm_gcm[i]);
+}
+
+static void cryp_write_key(struct stm32_cryp_context *ctx)
+{
+	vaddr_t reg = 0;
+	int i = 0;
+	uint32_t algo = GET_ALGOMODE(ctx->cr);
+
+	if (algo == _CRYP_CR_ALGOMODE_DES_ECB ||
+	    algo == _CRYP_CR_ALGOMODE_DES_CBC)
+		reg = ctx->base + _CRYP_K1RR;
+	else
+		reg = ctx->base + _CRYP_K3RR;
+
+	for (i = ctx->key_size / sizeof(uint32_t) - 1;
+	     i >= 0;
+	     i--, reg -= sizeof(uint32_t))
+		io_write32(reg, ctx->key[i]);
+}
+
+static TEE_Result cryp_prepare_key(struct stm32_cryp_context *ctx)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	/*
+	 * For AES ECB/CBC decryption, key preparation mode must be selected
+	 * to populate the key.
+	 */
+	if (is_decrypt(ctx->cr) && (IS_ALGOMODE(ctx->cr, AES_ECB) ||
+				    IS_ALGOMODE(ctx->cr, AES_CBC))) {
+		/* Select Algomode "prepare key" */
+		io_clrsetbits32(ctx->base + _CRYP_CR, _CRYP_CR_ALGOMODE_MSK,
+				_CRYP_CR_ALGOMODE_AES << _CRYP_CR_ALGOMODE_OFF);
+
+		cryp_write_key(ctx);
+
+		/* Enable CRYP */
+		io_setbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+
+		res = wait_end_busy(ctx->base);
+		if (res)
+			return res;
+
+		/* Reset 'real' algomode */
+		io_clrsetbits32(ctx->base + _CRYP_CR, _CRYP_CR_ALGOMODE_MSK,
+				ctx->cr & _CRYP_CR_ALGOMODE_MSK);
+	} else {
+		cryp_write_key(ctx);
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result save_context(struct stm32_cryp_context *ctx)
+{
+	/* Device should not be in a processing phase */
+	if (io_read32(ctx->base + _CRYP_SR) & _CRYP_SR_BUSY)
+		return TEE_ERROR_BAD_STATE;
+
+	/* Disable the CRYP peripheral */
+	io_clrbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+
+	/* Save CR */
+	ctx->cr = io_read32(ctx->base + _CRYP_CR);
+
+	cryp_save_suspend(ctx);
+
+	/* If algo mode needs to save current IV */
+	if (algo_mode_needs_iv(ctx->cr)) {
+		unsigned int i = 0;
+
+		/* Save IV */
+		for (i = 0; i < ctx->block_u32; i++)
+			ctx->iv[i] = io_read32(ctx->base + _CRYP_IV0LR + i *
+					       sizeof(uint32_t));
+	}
+
+	return TEE_SUCCESS;
+}
+
+/* To resume the processing of a message */
+static TEE_Result restore_context(struct stm32_cryp_context *ctx)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	/* IP should be disabled */
+	if (io_read32(ctx->base + _CRYP_CR) & _CRYP_CR_CRYPEN) {
+		DMSG("Device is still enabled");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	/* Restore the _CRYP_CR */
+	io_write32(ctx->base + _CRYP_CR, ctx->cr);
+
+	/* Write key and, in case of AES_CBC or AES_ECB decrypt, prepare it */
+	res = cryp_prepare_key(ctx);
+	if (res)
+		return res;
+
+	cryp_restore_suspend(ctx);
+
+	cryp_write_iv(ctx);
+
+	/* Flush internal fifo */
+	io_setbits32(ctx->base + _CRYP_CR, _CRYP_CR_FFLUSH);
+
+	/* Enable the CRYP peripheral */
+	io_setbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Translate a byte index in an array of BE uint32_t into the index of same
+ * byte in the corresponding LE uint32_t array.
+ */
+static size_t be_index(size_t index)
+{
+	return (index & ~0x3) + 3 - (index & 0x3);
+}
+
+static TEE_Result ccm_first_context(struct stm32_cryp_context *ctx)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t b0[AES_BLOCK_NB_U32] = { 0 };
+	uint8_t *iv = (uint8_t *)ctx->iv;
+	size_t l = 0;
+	size_t i = 15;
+
+	/* IP should be disabled */
+	if (io_read32(ctx->base + _CRYP_CR) & _CRYP_CR_CRYPEN)
+		return TEE_ERROR_BAD_STATE;
+
+	/* Write the _CRYP_CR */
+	io_write32(ctx->base + _CRYP_CR, ctx->cr);
+
+	/* Write key */
+	res = cryp_prepare_key(ctx);
+	if (res)
+		return res;
+
+	/* Save full IV that will be b0 */
+	memcpy(b0, iv, sizeof(b0));
+
+	/*
+	 * Update IV to become CTR0/1 before setting it.
+	 * IV is saved as LE uint32_t[4] as expected by hardware,
+	 * but CCM RFC defines bytes to update in a BE array.
+	 */
+	/* Set flag bits to 0 (5 higher bits), keep 3 low bits */
+	iv[be_index(0)] &= 0x7;
+	/* Get size of length field (can be from 2 to 8) */
+	l = iv[be_index(0)] + 1;
+	/* Set Q to 0 */
+	for (i = 15; i >= 15 - l + 1; i--)
+		iv[be_index(i)] = 0;
+	/* Save CTR0 */
+	memcpy(ctx->ctr0_ccm, iv, sizeof(b0));
+	/* Increment Q */
+	iv[be_index(15)] |= 0x1;
+
+	cryp_write_iv(ctx);
+
+	/* Enable the CRYP peripheral */
+	io_setbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+
+	res = write_align_block(ctx, b0);
+
+	return res;
+}
+
+static TEE_Result do_from_init_to_phase(struct stm32_cryp_context *ctx,
+					uint32_t new_phase)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	/*
+	 * We didn't run the init phase yet
+	 * CCM need a specific restore_context phase for the init phase
+	 */
+	if (IS_ALGOMODE(ctx->cr, AES_CCM))
+		res = ccm_first_context(ctx);
+	else
+		res = restore_context(ctx);
+
+	if (res)
+		return res;
+
+	res = wait_end_enable(ctx->base);
+	if (res)
+		return res;
+
+	/* Move to 'new_phase' */
+	io_clrsetbits32(ctx->base + _CRYP_CR, _CRYP_CR_GCM_CCMPH_MSK,
+			new_phase << _CRYP_CR_GCM_CCMPH_OFF);
+
+	/* Enable the CRYP peripheral (init disabled it) */
+	io_setbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result do_from_header_to_phase(struct stm32_cryp_context *ctx,
+					  uint32_t new_phase)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	res = restore_context(ctx);
+	if (res)
+		return res;
+
+	if (ctx->extra_size) {
+		/* Manage unaligned header data before moving to next phase */
+		memset((uint8_t *)ctx->extra + ctx->extra_size, 0,
+		       ctx->block_u32 * sizeof(uint32_t) - ctx->extra_size);
+
+		res = write_align_block(ctx, ctx->extra);
+		if (res)
+			return res;
+
+		ctx->assoc_len += (ctx->extra_size) * INT8_BIT;
+		ctx->extra_size = 0;
+	}
+
+	/* Move to 'new_phase' */
+	io_clrsetbits32(ctx->base + _CRYP_CR, _CRYP_CR_GCM_CCMPH_MSK,
+			new_phase << _CRYP_CR_GCM_CCMPH_OFF);
+
+	return TEE_SUCCESS;
+}
+
+/**
+ * @brief Start a AES computation.
+ * @param ctx: CRYP process context
+ * @param is_dec: true if decryption, false if encryption
+ * @param algo: define the algo mode
+ * @param key: pointer to key
+ * @param key_size: key size
+ * @param iv: pointer to initialization vector (unused if algo is ECB)
+ * @param iv_size: iv size
+ * @note this function doesn't access to hardware but stores in ctx the values
+ *
+ * @retval TEE_SUCCESS if OK.
+ */
+TEE_Result stm32_cryp_init(struct stm32_cryp_context *ctx, bool is_dec,
+			   enum stm32_cryp_algo_mode algo,
+			   const void *key, size_t key_size, const void *iv,
+			   size_t iv_size)
+{
+	unsigned int i = 0;
+	const uint32_t *iv_u32 = NULL;
+	uint32_t local_iv[4] = { 0 };
+	const uint32_t *key_u32 = NULL;
+	uint32_t local_key[8] = { 0 };
+
+	ctx->assoc_len = 0;
+	ctx->load_len = 0;
+	ctx->extra_size = 0;
+	ctx->lock = &cryp_lock;
+
+	ctx->base = io_pa_or_va(&cryp_pdata.base, 1);
+	ctx->cr = _CRYP_CR_RESET_VALUE;
+
+	/* We want buffer to be u32 aligned */
+	if (IS_ALIGNED_WITH_TYPE(key, uint32_t)) {
+		key_u32 = key;
+	} else {
+		memcpy(local_key, key, key_size);
+		key_u32 = local_key;
+	}
+
+	if (IS_ALIGNED_WITH_TYPE(iv, uint32_t)) {
+		iv_u32 = iv;
+	} else {
+		memcpy(local_iv, iv, iv_size);
+		iv_u32 = local_iv;
+	}
+
+	if (is_dec)
+		SETBITS(ctx->cr, _CRYP_CR_ALGODIR);
+	else
+		CLRBITS(ctx->cr, _CRYP_CR_ALGODIR);
+
+	/* Save algo mode */
+	switch (algo) {
+	case STM32_CRYP_MODE_TDES_ECB:
+		SET_ALGOMODE(TDES_ECB, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_TDES_CBC:
+		SET_ALGOMODE(TDES_CBC, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_DES_ECB:
+		SET_ALGOMODE(DES_ECB, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_DES_CBC:
+		SET_ALGOMODE(DES_CBC, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_AES_ECB:
+		SET_ALGOMODE(AES_ECB, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_AES_CBC:
+		SET_ALGOMODE(AES_CBC, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_AES_CTR:
+		SET_ALGOMODE(AES_CTR, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_AES_GCM:
+		SET_ALGOMODE(AES_GCM, ctx->cr);
+		break;
+	case STM32_CRYP_MODE_AES_CCM:
+		SET_ALGOMODE(AES_CCM, ctx->cr);
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/*
+	 * We will use HW Byte swap (_CRYP_CR_DATATYPE_BYTE) for data.
+	 * So we won't need to
+	 * TOBE32(data) before write to DIN
+	 * nor
+	 * FROMBE32 after reading from DOUT.
+	 */
+	clrsetbits(&ctx->cr, _CRYP_CR_DATATYPE_MSK,
+		   _CRYP_CR_DATATYPE_BYTE << _CRYP_CR_DATATYPE_OFF);
+
+	/*
+	 * Configure keysize for AES algorithms
+	 * And save block size
+	 */
+	if (algo_mode_is_aes(ctx->cr)) {
+		switch (key_size) {
+		case AES_KEYSIZE_128:
+			clrsetbits(&ctx->cr, _CRYP_CR_KEYSIZE_MSK,
+				   _CRYP_CR_KSIZE_128 << _CRYP_CR_KEYSIZE_OFF);
+			break;
+		case AES_KEYSIZE_192:
+			clrsetbits(&ctx->cr, _CRYP_CR_KEYSIZE_MSK,
+				   _CRYP_CR_KSIZE_192 << _CRYP_CR_KEYSIZE_OFF);
+			break;
+		case AES_KEYSIZE_256:
+			clrsetbits(&ctx->cr, _CRYP_CR_KEYSIZE_MSK,
+				   _CRYP_CR_KSIZE_256 << _CRYP_CR_KEYSIZE_OFF);
+			break;
+		default:
+			return TEE_ERROR_BAD_PARAMETERS;
+		}
+
+		/* And set block size */
+		ctx->block_u32 = AES_BLOCK_NB_U32;
+	} else {
+		/* And set DES/TDES block size */
+		ctx->block_u32 = DES_BLOCK_NB_U32;
+	}
+
+	/* Save key in HW order */
+	ctx->key_size = key_size;
+	for (i = 0; i < key_size / sizeof(uint32_t); i++)
+		ctx->key[i] = TOBE32(key_u32[i]);
+
+	/* Save IV */
+	if (algo_mode_needs_iv(ctx->cr)) {
+		if (!iv || iv_size != ctx->block_u32 * sizeof(uint32_t))
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		/*
+		 * We save IV in the byte order expected by the
+		 * IV registers
+		 */
+		for (i = 0; i < ctx->block_u32; i++)
+			ctx->iv[i] = TOBE32(iv_u32[i]);
+	}
+
+	/* Reset suspend registers */
+	memset(ctx->pm_gcmccm, 0, sizeof(ctx->pm_gcmccm));
+	memset(ctx->pm_gcm, 0, sizeof(ctx->pm_gcm));
+
+	return TEE_SUCCESS;
+}
+
+/**
+ * @brief Update (or start) a AES authenticate process of
+ *        associated data (CCM or GCM).
+ * @param ctx: CRYP process context
+ * @param data: pointer to associated data
+ * @param data_size: data size
+ * @retval TEE_SUCCESS if OK.
+ */
+TEE_Result stm32_cryp_update_assodata(struct stm32_cryp_context *ctx,
+				      uint8_t *data, size_t data_size)
+{
+	TEE_Result res = TEE_SUCCESS;
+	unsigned int i = 0;
+	uint32_t previous_phase = 0;
+
+	/* If no associated data, nothing to do */
+	if (!data || !data_size)
+		return TEE_SUCCESS;
+
+	mutex_lock(ctx->lock);
+
+	previous_phase = (ctx->cr & _CRYP_CR_GCM_CCMPH_MSK) >>
+			 _CRYP_CR_GCM_CCMPH_OFF;
+
+	switch (previous_phase) {
+	case _CRYP_CR_GCM_CCMPH_INIT:
+		res = do_from_init_to_phase(ctx, _CRYP_CR_GCM_CCMPH_HEADER);
+		break;
+	case _CRYP_CR_GCM_CCMPH_HEADER:
+		/*
+		 * Function update_assodata was already called.
+		 * We only need to restore the context.
+		 */
+		res = restore_context(ctx);
+		break;
+	default:
+		assert(0);
+		res = TEE_ERROR_BAD_STATE;
+	}
+
+	if (res)
+		goto out;
+
+	/* Manage if remaining data from a previous update_assodata call */
+	if (ctx->extra_size &&
+	    (ctx->extra_size + data_size >=
+	     ctx->block_u32 * sizeof(uint32_t))) {
+		uint32_t block[MAX_BLOCK_NB_U32] = { 0 };
+
+		memcpy(block, ctx->extra, ctx->extra_size);
+		memcpy((uint8_t *)block + ctx->extra_size, data,
+		       ctx->block_u32 * sizeof(uint32_t) - ctx->extra_size);
+
+		res = write_align_block(ctx, block);
+		if (res)
+			goto out;
+
+		i += ctx->block_u32 * sizeof(uint32_t) - ctx->extra_size;
+		ctx->extra_size = 0;
+		ctx->assoc_len += ctx->block_u32 * sizeof(uint32_t) * INT8_BIT;
+	}
+
+	while (data_size - i >= ctx->block_u32 * sizeof(uint32_t)) {
+		res = write_block(ctx, data + i);
+		if (res)
+			goto out;
+
+		/* Process next block */
+		i += ctx->block_u32 * sizeof(uint32_t);
+		ctx->assoc_len += ctx->block_u32 * sizeof(uint32_t) * INT8_BIT;
+	}
+
+	/*
+	 * Manage last block if not a block size multiple:
+	 * Save remaining data to manage them later (potentially with new
+	 * associated data).
+	 */
+	if (i < data_size) {
+		memcpy((uint8_t *)ctx->extra + ctx->extra_size, data + i,
+		       data_size - i);
+		ctx->extra_size += data_size - i;
+	}
+
+	res = save_context(ctx);
+out:
+	if (res)
+		cryp_end(ctx, res);
+
+	mutex_unlock(ctx->lock);
+
+	return res;
+}
+
+/**
+ * @brief Update (or start) a AES authenticate and de/encrypt with
+ *        payload data (CCM or GCM).
+ * @param ctx: CRYP process context
+ * @param data_in: pointer to payload
+ * @param data_out: pointer where to save de/encrypted payload
+ * @param data_size: payload size
+ *
+ * @retval TEE_SUCCESS if OK.
+ */
+TEE_Result stm32_cryp_update_load(struct stm32_cryp_context *ctx,
+				  uint8_t *data_in, uint8_t *data_out,
+				  size_t data_size)
+{
+	TEE_Result res = TEE_SUCCESS;
+	unsigned int i = 0;
+	uint32_t previous_phase = 0;
+
+	if (!data_in || !data_size)
+		return TEE_SUCCESS;
+
+	mutex_lock(ctx->lock);
+
+	previous_phase = (ctx->cr & _CRYP_CR_GCM_CCMPH_MSK) >>
+			 _CRYP_CR_GCM_CCMPH_OFF;
+
+	switch (previous_phase) {
+	case _CRYP_CR_GCM_CCMPH_INIT:
+		res = do_from_init_to_phase(ctx, _CRYP_CR_GCM_CCMPH_PAYLOAD);
+		break;
+	case  _CRYP_CR_GCM_CCMPH_HEADER:
+		res = do_from_header_to_phase(ctx, _CRYP_CR_GCM_CCMPH_PAYLOAD);
+		break;
+	case _CRYP_CR_GCM_CCMPH_PAYLOAD:
+		/* new update_load call, we only need to restore context */
+		res = restore_context(ctx);
+		break;
+	default:
+		assert(0);
+		res = TEE_ERROR_BAD_STATE;
+	}
+
+	if (res)
+		goto out;
+
+	/* Manage if incomplete block from a previous update_load call */
+	if (ctx->extra_size &&
+	    (ctx->extra_size + data_size >=
+	     ctx->block_u32 * sizeof(uint32_t))) {
+		uint32_t block_out[MAX_BLOCK_NB_U32] = { 0 };
+
+		memcpy((uint8_t *)ctx->extra + ctx->extra_size, data_in + i,
+		       ctx->block_u32 * sizeof(uint32_t) - ctx->extra_size);
+
+		res = write_align_block(ctx, ctx->extra);
+		if (res)
+			goto out;
+
+		res = read_align_block(ctx, block_out);
+		if (res)
+			goto out;
+
+		memcpy(data_out + i, (uint8_t *)block_out + ctx->extra_size,
+		       ctx->block_u32 * sizeof(uint32_t) - ctx->extra_size);
+
+		i += ctx->block_u32 * sizeof(uint32_t) - ctx->extra_size;
+		ctx->extra_size = 0;
+
+		ctx->load_len += ctx->block_u32 * sizeof(uint32_t) * INT8_BIT;
+	}
+
+	while (data_size - i >= ctx->block_u32 * sizeof(uint32_t)) {
+		res = write_block(ctx, data_in + i);
+		if (res)
+			goto out;
+
+		res = read_block(ctx, data_out + i);
+		if (res)
+			goto out;
+
+		/* Process next block */
+		i += ctx->block_u32 * sizeof(uint32_t);
+		ctx->load_len += ctx->block_u32 * sizeof(uint32_t) * INT8_BIT;
+	}
+
+	res = save_context(ctx);
+	if (res)
+		goto out;
+
+	/*
+	 * Manage last block if not a block size multiple
+	 * We saved context,
+	 * Complete block with 0 and send to CRYP to get {en,de}crypted data
+	 * Store data to resend as last block in final()
+	 *           or to complete next update_load() to get correct tag.
+	 */
+	if (i < data_size) {
+		uint32_t block_out[MAX_BLOCK_NB_U32] = { 0 };
+		size_t prev_extra_size = ctx->extra_size;
+
+		/* Re-enable the CRYP peripheral */
+		io_setbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+
+		memcpy((uint8_t *)ctx->extra + ctx->extra_size, data_in + i,
+		       data_size - i);
+		ctx->extra_size += data_size - i;
+		memset((uint8_t *)ctx->extra + ctx->extra_size, 0,
+		       ctx->block_u32 * sizeof(uint32_t) - ctx->extra_size);
+
+		res = write_align_block(ctx, ctx->extra);
+		if (res)
+			goto out;
+
+		res = read_align_block(ctx, block_out);
+		if (res)
+			goto out;
+
+		memcpy(data_out + i, (uint8_t *)block_out + prev_extra_size,
+		       data_size - i);
+
+		/* Disable the CRYP peripheral */
+		io_clrbits32(ctx->base + _CRYP_CR, _CRYP_CR_CRYPEN);
+	}
+
+out:
+	if (res)
+		cryp_end(ctx, res);
+
+	mutex_unlock(ctx->lock);
+
+	return res;
+}
+
+/**
+ * @brief Get authentication tag for AES authenticated algorithms (CCM or GCM).
+ * @param ctx: CRYP process context
+ * @param tag: pointer where to save the tag
+ * @param data_size: tag size
+ *
+ * @retval TEE_SUCCESS if OK.
+ */
+TEE_Result stm32_cryp_final(struct stm32_cryp_context *ctx, uint8_t *tag,
+			    size_t tag_size)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t tag_u32[4] = { 0 };
+	uint32_t previous_phase = 0;
+
+	mutex_lock(ctx->lock);
+
+	previous_phase = (ctx->cr &  _CRYP_CR_GCM_CCMPH_MSK) >>
+			 _CRYP_CR_GCM_CCMPH_OFF;
+
+	switch (previous_phase) {
+	case _CRYP_CR_GCM_CCMPH_INIT:
+		res = do_from_init_to_phase(ctx, _CRYP_CR_GCM_CCMPH_FINAL);
+		break;
+	case  _CRYP_CR_GCM_CCMPH_HEADER:
+		res = do_from_header_to_phase(ctx, _CRYP_CR_GCM_CCMPH_FINAL);
+		break;
+	case _CRYP_CR_GCM_CCMPH_PAYLOAD:
+		res = restore_context(ctx);
+		if (res)
+			break;
+
+		/* Manage if incomplete block from a previous update_load() */
+		if (ctx->extra_size) {
+			uint32_t block_out[MAX_BLOCK_NB_U32] = { 0 };
+			size_t sz = ctx->block_u32 * sizeof(uint32_t) -
+				    ctx->extra_size;
+
+			if (does_need_npblb(ctx->cr)) {
+				io_clrsetbits32(ctx->base + _CRYP_CR,
+						_CRYP_CR_NPBLB_MSK,
+						sz << _CRYP_CR_NPBLB_OFF);
+			}
+
+			memset((uint8_t *)ctx->extra + ctx->extra_size, 0, sz);
+
+			res = write_align_block(ctx, ctx->extra);
+			if (res)
+				break;
+
+			/* Don't care {en,de}crypted data, already saved */
+			res = read_align_block(ctx, block_out);
+			if (res)
+				break;
+
+			ctx->load_len += (ctx->extra_size * INT8_BIT);
+			ctx->extra_size = 0;
+		}
+
+		/* Move to final phase */
+		io_clrsetbits32(ctx->base + _CRYP_CR, _CRYP_CR_GCM_CCMPH_MSK,
+				_CRYP_CR_GCM_CCMPH_FINAL <<
+				_CRYP_CR_GCM_CCMPH_OFF);
+		break;
+	default:
+		assert(0);
+		res = TEE_ERROR_BAD_STATE;
+	}
+
+	if (res)
+		goto out;
+
+	if (IS_ALGOMODE(ctx->cr, AES_GCM)) {
+		/* No need to htobe() as we configure the HW to swap bytes */
+		io_write32(ctx->base + _CRYP_DIN, 0U);
+		io_write32(ctx->base + _CRYP_DIN, ctx->assoc_len);
+		io_write32(ctx->base + _CRYP_DIN, 0U);
+		io_write32(ctx->base + _CRYP_DIN, ctx->load_len);
+	} else if (IS_ALGOMODE(ctx->cr, AES_CCM)) {
+		/* No need to htobe() in this phase */
+		res = write_align_block(ctx, ctx->ctr0_ccm);
+		if (res)
+			goto out;
+	}
+
+	res = read_align_block(ctx, tag_u32);
+	if (res)
+		goto out;
+
+	memcpy(tag, tag_u32, MIN(sizeof(tag_u32), tag_size));
+
+out:
+	cryp_end(ctx, res);
+	mutex_unlock(ctx->lock);
+
+	return res;
+}
+
+/**
+ * @brief Update (or start) a de/encrypt process.
+ * @param ctx: CRYP process context
+ * @param last_block: true if last payload data block
+ * @param data_in: pointer to payload
+ * @param data_out: pointer where to save de/encrypted payload
+ * @param data_size: payload size
+ *
+ * @retval TEE_SUCCESS if OK.
+ */
+TEE_Result stm32_cryp_update(struct stm32_cryp_context *ctx, bool last_block,
+			     uint8_t *data_in, uint8_t *data_out,
+			     size_t data_size)
+{
+	TEE_Result res = TEE_SUCCESS;
+	unsigned int i = 0;
+
+	mutex_lock(ctx->lock);
+
+	/*
+	 * In CBC and ECB encryption we need to manage specifically last
+	 * 2 blocks if total size in not aligned to a block size.
+	 * Currently return TEE_ERROR_NOT_IMPLEMENTED. Moreover as we need to
+	 * know last 2 blocks, if unaligned and call with less than two blocks,
+	 * return TEE_ERROR_BAD_STATE.
+	 */
+	if (last_block && algo_mode_is_ecb_cbc(ctx->cr) &&
+	    is_encrypt(ctx->cr) &&
+	    (ROUNDDOWN(data_size, ctx->block_u32 * sizeof(uint32_t)) !=
+	     data_size)) {
+		if (data_size < ctx->block_u32 * sizeof(uint32_t) * 2) {
+			/*
+			 * If CBC, size of the last part should be at
+			 * least 2*BLOCK_SIZE
+			 */
+			EMSG("Unexpected last block size");
+			res = TEE_ERROR_BAD_STATE;
+			goto out;
+		}
+		/*
+		 * Moreover the ECB/CBC specific padding for encrypt is not
+		 * yet implemented, and not used in OPTEE
+		 */
+		res = TEE_ERROR_NOT_IMPLEMENTED;
+		goto out;
+	}
+
+	/* Manage remaining CTR mask from previous update call */
+	if (IS_ALGOMODE(ctx->cr, AES_CTR) && ctx->extra_size) {
+		unsigned int j = 0;
+		uint8_t *mask = (uint8_t *)ctx->extra;
+
+		for (j = 0; j < ctx->extra_size && i < data_size; j++, i++)
+			data_out[i] = data_in[i] ^ mask[j];
+
+		if (j != ctx->extra_size) {
+			/*
+			 * We didn't consume all saved mask,
+			 * but no more data.
+			 */
+
+			/* We save remaining mask and its new size */
+			memmove(ctx->extra, ctx->extra + j,
+				ctx->extra_size - j);
+			ctx->extra_size -= j;
+
+			/*
+			 * We don't need to save HW context we didn't
+			 * modify HW state.
+			 */
+			res = TEE_SUCCESS;
+			goto out;
+		}
+
+		/* All extra mask consumed */
+		ctx->extra_size = 0;
+	}
+
+	res = restore_context(ctx);
+	if (res)
+		goto out;
+
+	while (data_size - i >= ctx->block_u32 * sizeof(uint32_t)) {
+		/*
+		 * We only write/read one block at a time
+		 * but CRYP use a in (and out) FIFO of 8 * uint32_t
+		 */
+		res = write_block(ctx, data_in + i);
+		if (res)
+			goto out;
+
+		res = read_block(ctx, data_out + i);
+		if (res)
+			goto out;
+
+		/* Process next block */
+		i += ctx->block_u32 * sizeof(uint32_t);
+	}
+
+	/* Manage last block if not a block size multiple */
+	if (i < data_size) {
+		uint32_t block_in[MAX_BLOCK_NB_U32] = { 0 };
+		uint32_t block_out[MAX_BLOCK_NB_U32] = { 0 };
+
+		if (!IS_ALGOMODE(ctx->cr, AES_CTR)) {
+			/*
+			 * Other algorithm than CTR can manage only multiple
+			 * of block_size.
+			 */
+			res = TEE_ERROR_BAD_PARAMETERS;
+			goto out;
+		}
+
+		/*
+		 * For CTR we save the generated mask to use it at next
+		 * update call.
+		 */
+		memcpy(block_in, data_in + i, data_size - i);
+
+		res = write_align_block(ctx, block_in);
+		if (res)
+			goto out;
+
+		res = read_align_block(ctx, block_out);
+		if (res)
+			goto out;
+
+		memcpy(data_out + i, block_out, data_size - i);
+
+		/* Save mask for possibly next call */
+		ctx->extra_size = ctx->block_u32 * sizeof(uint32_t) -
+			(data_size - i);
+		memcpy(ctx->extra, (uint8_t *)block_out + data_size - i,
+		       ctx->extra_size);
+	}
+
+	if (!last_block)
+		res = save_context(ctx);
+
+out:
+	/* If last block or error, end of CRYP process */
+	if (last_block || res)
+		cryp_end(ctx, res);
+
+	mutex_unlock(ctx->lock);
+
+	return res;
+}
+
+static int fdt_stm32_cryp(struct stm32_cryp_platdata *pdata)
+{
+	int node = -1;
+	struct dt_node_info dt_cryp = { };
+	void *fdt = NULL;
+
+	fdt = get_embedded_dt();
+	if (!fdt)
+		return -FDT_ERR_NOTFOUND;
+
+	node = fdt_node_offset_by_compatible(fdt, node, "st,stm32mp1-cryp");
+	if (node < 0) {
+		EMSG("No CRYP entry in DT");
+		return -FDT_ERR_NOTFOUND;
+	}
+
+	_fdt_fill_device_info(fdt, &dt_cryp, node);
+
+	if (dt_cryp.status == DT_STATUS_DISABLED)
+		return -FDT_ERR_NOTFOUND;
+
+	if (dt_cryp.clock == DT_INFO_INVALID_CLOCK ||
+	    dt_cryp.reset == DT_INFO_INVALID_RESET ||
+	    dt_cryp.reg == DT_INFO_INVALID_REG)
+		return -FDT_ERR_BADVALUE;
+
+	pdata->base.pa = dt_cryp.reg;
+	io_pa_or_va_secure(&pdata->base, 1);
+
+	pdata->clock_id = (unsigned long)dt_cryp.clock;
+	pdata->reset_id = (unsigned int)dt_cryp.reset;
+
+	return 0;
+}
+
+static TEE_Result stm32_cryp_driver_init(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	if (fdt_stm32_cryp(&cryp_pdata))
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	stm32_clock_enable(cryp_pdata.clock_id);
+
+	if (stm32_reset_assert(cryp_pdata.reset_id, TIMEOUT_US_1MS))
+		panic();
+
+	if (stm32_reset_deassert(cryp_pdata.reset_id, TIMEOUT_US_1MS))
+		panic();
+
+	if (IS_ENABLED(CFG_CRYPTO_DRV_CIPHER)) {
+		res = stm32_register_cipher();
+		if (res) {
+			EMSG("Failed to register to cipher: %#"PRIx32, res);
+			panic();
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+driver_init(stm32_cryp_driver_init);

--- a/core/drivers/crypto/stm32/stm32_cryp.h
+++ b/core/drivers/crypto/stm32/stm32_cryp.h
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, STMicroelectronics - All Rights Reserved
+ */
+
+#ifndef STM32_CRYP_H
+#define STM32_CRYP_H
+
+#include <kernel/mutex.h>
+#include <mm/core_memprot.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct stm32_cryp_platdata {
+	struct io_pa_va base;
+	unsigned long clock_id;
+	unsigned int reset_id;
+};
+
+enum stm32_cryp_algo_mode {
+	STM32_CRYP_MODE_TDES_ECB,
+	STM32_CRYP_MODE_TDES_CBC,
+	STM32_CRYP_MODE_DES_ECB,
+	STM32_CRYP_MODE_DES_CBC,
+	STM32_CRYP_MODE_AES_ECB,
+	STM32_CRYP_MODE_AES_CBC,
+	STM32_CRYP_MODE_AES_CTR,
+	STM32_CRYP_MODE_AES_GCM,
+	STM32_CRYP_MODE_AES_CCM,
+};
+
+/*
+ * Full CRYP context.
+ * Store CRYP internal state to be able to compute any supported algorithm.
+ */
+struct stm32_cryp_context {
+	vaddr_t base;
+	uint32_t cr;
+	struct mutex *lock; /* Protect CRYP HW instance access */
+	uint32_t assoc_len;
+	uint32_t load_len;
+	uint32_t key[8]; /* In HW byte order */
+	size_t key_size;
+	size_t block_u32;
+	uint32_t iv[4];  /* In HW byte order */
+	uint32_t pm_gcmccm[8];
+	union {
+		uint32_t pm_gcm[8];
+		uint32_t ctr0_ccm[4];
+	};
+	uint32_t extra[4];
+	size_t extra_size;
+};
+
+TEE_Result stm32_cryp_init(struct stm32_cryp_context *ctx, bool is_decrypt,
+			   enum stm32_cryp_algo_mode mode,
+			   const void *key, size_t key_size, const void *iv,
+			   size_t iv_size);
+TEE_Result stm32_cryp_update(struct stm32_cryp_context *ctx, bool last_block,
+			     uint8_t *data_in, uint8_t *data_out,
+			     size_t data_size);
+TEE_Result stm32_cryp_update_assodata(struct stm32_cryp_context *ctx,
+				      uint8_t *data, size_t data_size);
+TEE_Result stm32_cryp_update_load(struct stm32_cryp_context *ctx,
+				  uint8_t *data_in, uint8_t *data_out,
+				  size_t data_size);
+TEE_Result stm32_cryp_final(struct stm32_cryp_context *ctx, uint8_t *tag,
+			    size_t tag_size);
+#endif

--- a/core/drivers/crypto/stm32/sub.mk
+++ b/core/drivers/crypto/stm32/sub.mk
@@ -1,0 +1,2 @@
+srcs-$(CFG_STM32_CRYP) += stm32_cryp.c
+srcs-$(CFG_CRYPTO_DRV_CIPHER) += cipher.c

--- a/core/drivers/crypto/stm32/sub.mk
+++ b/core/drivers/crypto/stm32/sub.mk
@@ -1,2 +1,3 @@
 srcs-$(CFG_STM32_CRYP) += stm32_cryp.c
 srcs-$(CFG_CRYPTO_DRV_CIPHER) += cipher.c
+srcs-$(CFG_CRYPTO_DRV_AUTHENC) += authenc.c

--- a/core/drivers/crypto/sub.mk
+++ b/core/drivers/crypto/sub.mk
@@ -5,3 +5,5 @@ subdirs-$(CFG_CRYPTO_DRIVER) += crypto_api
 subdirs-$(CFG_NXP_CAAM) += caam
 
 subdirs-$(CFG_NXP_SE05X) += se050
+
+subdirs-$(CFG_STM32_CRYPTO_DRIVER) += stm32

--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -302,6 +302,18 @@ drvcrypt_mac_alloc_ctx(struct crypto_mac_ctx **ctx __unused,
 }
 #endif /* CFG_CRYPTO_DRV_MAC */
 
+#ifdef CFG_CRYPTO_DRV_AUTHENC
+/* Cryptographic Authenticated Encryption driver context allocation */
+TEE_Result drvcrypt_authenc_alloc_ctx(struct crypto_authenc_ctx **ctx,
+				      uint32_t algo);
+#else
+static inline TEE_Result
+drvcrypt_authenc_alloc_ctx(struct crypto_authenc_ctx **ctx __unused,
+			   uint32_t algo __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif /* CFG_CRYPTO_DRV_AUTHENC */
 /*
  * The ECC public key operations used by the crypto_acipher_ecc_*() and
  * crypto_acipher_free_ecc_*() functions.


### PR DESCRIPTION

This branch add support to the STM32 CRYP, an AES/DES hardware IP.
As this IP also support authenticated encryption (AES-CCM, AES-GCM), this branch add support for hardware accelerated Authenc in the OP-TEE crypto framework. (drivers: crypto: implement crypto driver - AUTHENC)
STM32 CRYP ip wil be used (compile and DT "enabled" if a device tree that support it is selected. (
plat-stm32mp1: enable CRYPTO HW if available)