### PR TITLE
drivers: clk: add platform data per compatible identifier

### DIFF
--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -25,7 +25,8 @@ static const struct clk_ops fixed_clk_clk_ops = {
 	.get_rate = fixed_clk_get_rate,
 };
 
-static TEE_Result fixed_clock_setup(const void *fdt, int offs)
+static TEE_Result fixed_clock_setup(const void *fdt, int offs,
+				    const void *compat_data __unused)
 {
 	const uint32_t *freq = NULL;
 	const char *name = NULL;

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -27,7 +27,7 @@ struct clk_dt_phandle_args {
  * probe: probe function for the clock driver
  */
 struct clk_driver {
-	TEE_Result (*probe)(const void *fdt, int nodeoffset);
+	TEE_Result (*probe)(const void *fdt, int nodeoffset, const void *data);
 };
 
 /**

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -57,6 +57,7 @@ struct dt_node_info {
 
 struct dt_device_match {
 	const char *compatible;
+	const void *compat_data;
 };
 
 enum dt_driver_type {


### PR DESCRIPTION
Add a platform data reference field in struct dt_device_match so
that a driver knows data related to the compatible it is probed for.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
