### PR TITLE
drivers: clk: implement clk_is_enabled()

### DIFF
--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -111,6 +111,11 @@ static bool clk_is_enabled_no_lock(struct clk *clk)
 	return refcount_val(&clk->enabled_count) != 0;
 }
 
+bool clk_is_enabled(struct clk *clk)
+{
+	return clk_is_enabled_no_lock(clk);
+}
+
 static void clk_disable_no_lock(struct clk *clk)
 {
 	struct clk *parent = NULL;

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -132,6 +132,16 @@ TEE_Result clk_enable(struct clk *clk);
 void clk_disable(struct clk *clk);
 
 /**
+ * clk_is_enabled - Informative state on the clock
+ *
+ * This function is useful during specific system sequences where core
+ * executes atomically (primary core boot, some low power sequences).
+ *
+ * @clk: Clock refernece
+ */
+bool clk_is_enabled(struct clk *clk);
+
+/**
  * clk_get_parent - Get the current clock parent
  *
  * @clk: Clock for which the parent is needed


### PR DESCRIPTION
Add clock API function clk_is_enabled(). It is not very useful at
runtime since clock state can change at any time. The API function
is useful during specific system sequences where OP-TEE core knows
is executes atomically (primary core boot, low power sequences).

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
