### PR TITLE
[RFC] RAM optimized clk framework : reduce struct clk size : orphan clocks

### DIFF
--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -101,9 +101,15 @@ TEE_Result clk_register(struct clk *clk)
 	clk_init_parent(clk);
 	clk_compute_rate_no_lock(clk);
 
-	DMSG("Registered clock %s, freq %lu", clk->name, clk_get_rate(clk));
+	DMSG("Registered clock %s, freq %lu", clk_get_name(clk),
+	     clk_get_rate(clk));
 
 	return TEE_SUCCESS;
+}
+
+const char *clk_get_name(struct clk *clk)
+{
+	return clk->name;
 }
 
 static bool clk_is_enabled_no_lock(struct clk *clk)
@@ -240,7 +246,9 @@ static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 			return TEE_SUCCESS;
 		}
 	}
-	EMSG("Clock %s is not a parent of clock %s", parent->name, clk->name);
+
+	EMSG("Clock %s is not a parent of clock %s", clk_get_name(parent),
+	     clk_get_name(clk);
 
 	return TEE_ERROR_BAD_PARAMETERS;
 }

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -235,6 +235,14 @@ struct clk *clk_get_parent(struct clk *clk)
 	return clk->parent;
 }
 
+size_t clk_get_num_parents(struct clk *clk)
+{
+	if (clk_is_clk_elt(clk))
+		return to_clk_elt(clk)->num_parents;
+
+	return 0;
+}
+
 static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 				     size_t *pidx)
 {

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -344,6 +344,11 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (!clk)
 			return;
 
+		if (!is_clk_elt(clk)) {
+			EMSG("Can't assign orphan clock %s", clk_get_name(clk));
+			panic();
+		}
+
 		parent = clk_dt_get_by_idx_prop("assigned-clock-parents", fdt,
 						nodeoffset, clock_idx);
 		if (parent) {

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -349,7 +349,7 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (parent) {
 			if (clk_set_parent(clk, parent)) {
 				EMSG("Could not set clk %s parent to clock %s",
-				     clk->name, parent->name);
+				     clk_get_name(clk), clk_get_name(parent));
 				panic();
 			}
 		}

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -16,13 +16,15 @@ struct fixed_clock_data {
 static unsigned long fixed_clk_get_rate(struct clk *clk,
 					unsigned long parent_rate __unused)
 {
-	struct fixed_clock_data *d = clk->priv;
+	struct fixed_clock_data *d = clk_to_clk_elt(clk)->priv;
 
 	return d->rate;
 }
 
 static const struct clk_ops fixed_clk_clk_ops = {
+	.id = CLK_OPS_ELT,
 	.get_rate = fixed_clk_get_rate,
+	.get_name = clk_elt_name,
 };
 
 static TEE_Result fixed_clock_probe(const void *fdt, int offs,
@@ -55,7 +57,7 @@ static TEE_Result fixed_clock_probe(const void *fdt, int offs,
 	}
 
 	fcd->rate = fdt32_to_cpu(*freq);
-	clk->priv = fcd;
+	clk_to_clk_elt(clk)->priv = fcd;
 
 	res = clk_register(clk);
 	if (res)

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -7,25 +7,37 @@
 #include <drivers/clk_dt.h>
 #include <libfdt.h>
 #include <malloc.h>
+#include <mm/core_memprot.h>
 #include <stdint.h>
 
 struct fixed_clock_data {
 	unsigned long rate;
+	const char *name;
+	struct clk clk;
 };
+
+static struct fixed_clock_data *to_fixed_clock(struct clk *clk)
+{
+	return container_of(clk, struct fixed_clock_data, clk);
+}
 
 static unsigned long fixed_clk_get_rate(struct clk *clk,
 					unsigned long parent_rate __unused)
 {
-	struct fixed_clock_data *d = clk_to_clk_elt(clk)->priv;
-
-	return d->rate;
+	return to_fixed_clock(clk)->rate;
 }
 
-static const struct clk_ops fixed_clk_clk_ops = {
-	.id = CLK_OPS_ELT,
+static const char *fixed_clk_get_name(struct clk *clk)
+{
+	return to_fixed_clock(clk)->name;
+}
+
+static const struct clk_ops fixed_clk_ops = {
+	.id = CLK_OPS_ORPHAN,
 	.get_rate = fixed_clk_get_rate,
-	.get_name = clk_elt_name,
+	.get_name = fixed_clk_get_name,
 };
+DECLARE_KEEP_PAGER(fixed_clk_ops);
 
 static TEE_Result fixed_clock_probe(const void *fdt, int offs,
 				    const void *compat_data __unused)
@@ -35,43 +47,50 @@ static TEE_Result fixed_clock_probe(const void *fdt, int offs,
 	struct clk *clk = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct fixed_clock_data *fcd = NULL;
+	char *dup_name = NULL;
 
 	name = fdt_get_name(fdt, offs, NULL);
 	if (!name)
 		name = "fixed-clock";
 
-	clk = clk_alloc(name, &fixed_clk_clk_ops, NULL, 0);
-	if (!clk)
-		return TEE_ERROR_OUT_OF_MEMORY;
-
-	fcd = calloc(1, sizeof(struct fixed_clock_data));
-	if (!fcd) {
-		res = TEE_ERROR_OUT_OF_MEMORY;
-		goto free_clk;
+	if (!is_unpaged((void *)name)) {
+		dup_name = strdup(name);
+		if (!dup_name) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto err;
+		}
+		name = dup_name;
 	}
 
 	freq = fdt_getprop(fdt, offs, "clock-frequency", NULL);
 	if (!freq) {
 		res = TEE_ERROR_BAD_FORMAT;
-		goto free_fcd;
+		goto err;
 	}
 
+	fcd = calloc(1, sizeof(struct fixed_clock_data));
+	if (!fcd) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
+
+	clk_init_instance(&fcd->clk, &fixed_clk_ops);
+
 	fcd->rate = fdt32_to_cpu(*freq);
-	clk_to_clk_elt(clk)->priv = fcd;
+	fcd->name = name;
 
 	res = clk_register(clk);
 	if (res)
-		goto free_fcd;
+		goto err;
 
 	res = clk_dt_register_clk_provider(fdt, offs, clk_dt_get_simple_clk,
 					   clk);
 	if (!res)
 		return TEE_SUCCESS;
 
-free_fcd:
+err:
+	free(dup_name);
 	free(fcd);
-free_clk:
-	clk_free(clk);
 
 	return res;
 }

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -152,10 +152,7 @@ struct clk *clk_get_parent(struct clk *clk);
  * @clk: Clock for which the number of parents is needed
  * Return the number of parents
  */
-static inline size_t clk_get_num_parents(struct clk *clk)
-{
-	return clk->num_parents;
-}
+size_t clk_get_num_parents(struct clk *clk);
 
 /**
  * Get a clock parent by its index

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -66,10 +66,7 @@ struct clk_ops {
  * @clk: Clock for which the name is needed
  * Return a const char * pointing to the clock name
  */
-static inline const char *clk_get_name(struct clk *clk)
-{
-	return clk->name;
-}
+const char *clk_get_name(struct clk *clk);
 
 /**
  * clk_alloc - Allocate a clock structure

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -6,50 +6,74 @@
 #ifndef __DRIVERS_CLK_H
 #define __DRIVERS_CLK_H
 
+#include <assert.h>
 #include <kernel/refcount.h>
 #include <stdint.h>
 #include <tee_api_types.h>
+#include <util.h>
 
 /* Flags for clock */
 #define CLK_SET_RATE_GATE	BIT(0) /* must be gated across rate change */
 #define CLK_SET_PARENT_GATE	BIT(1) /* must be gated across re-parent */
 
-/**
- * struct clk - Clock structure
+/*
+ * Type of clock instantiated:
  *
- * @name: Clock name
- * @priv: Private data for the clock provider
+ * CLK_OP_ELT identities a full fledged clock. The struct clk * reference can be
+ * cast to struct clk_elt * to access clock element data.
+ */
+enum clk_ops_id {
+	CLK_OPS_INVALID = 0,
+	CLK_OPS_ELT,
+};
+
+/**
+ * struct clk - Clock core structure, common to all clocks
+ *
  * @ops: Clock operations
- * @parent: Current parent
+ * @enabled_count: Enable/disable reference counter
+ */
+struct clk {
+	const struct clk_ops *ops;
+	struct refcount enabled_count;
+};
+
+/**
+ * struct clk_elt - Full-fledged clock element
+ *
+ * @clk: Clock core structure
+ * @priv: Private data for the clock provider
+ * @name: Clock name
  * @rate: Current clock rate (cached after init or rate change)
  * @flags: Specific clock flags
- * @enabled_count: Enable/disable reference counter
+ * @parent: Current parent
  * @num_parents: Number of parents
  * @parents: Array of possible parents of the clock
  */
-struct clk {
-	const char *name;
+struct clk_elt {
+	struct clk clk;
 	void *priv;
-	const struct clk_ops *ops;
-	struct clk *parent;
 	unsigned long rate;
+	const char *name;
 	unsigned int flags;
-	struct refcount enabled_count;
+	struct clk *parent;
 	size_t num_parents;
 	struct clk *parents[];
 };
 
 /**
- * struct clk_ops
- *
+ * struct clk_ops - Clock operations
+ * @id: Identifier of the ops type (actually not an operator)
  * @enable: Enable the clock
  * @disable: Disable the clock
  * @set_parent: Set the clock parent based on index
  * @get_parent: Get the current parent index of the clock
  * @set_rate: Set the clock rate
  * @get_rate: Get the clock rate
+ * @get_name: Get clock name (shall be clk_elt_name() when @id is CLK_OPS_ELT)
  */
 struct clk_ops {
+	enum clk_ops_id id;
 	TEE_Result (*enable)(struct clk *clk);
 	void (*disable)(struct clk *clk);
 	TEE_Result (*set_parent)(struct clk *clk, size_t index);
@@ -58,7 +82,23 @@ struct clk_ops {
 			       unsigned long parent_rate);
 	unsigned long (*get_rate)(struct clk *clk,
 				  unsigned long parent_rate);
+	const char *(*get_name)(struct clk *clk);
 };
+
+/*
+ * Helper to identify clock operator type
+ */
+static inline bool is_clk_elt(struct clk *clk)
+{
+	return clk->ops->id == CLK_OPS_ELT;
+}
+
+static inline struct clk_elt *clk_to_clk_elt(struct clk *clk)
+{
+	assert(is_clk_elt(clk));
+
+	return container_of(clk, struct clk_elt, clk);
+}
 
 /**
  * Return the clock name
@@ -69,14 +109,26 @@ struct clk_ops {
 const char *clk_get_name(struct clk *clk);
 
 /**
- * clk_alloc - Allocate a clock structure
+ * Mandated get_name operator when for struct clk_elt instances
+ *
+ * @clk: Clock for which the name is needed
+ * Return a const char * pointing to the clock name
+ *
+ * This function mandates @clk refers to a struct clk_elt instance
+ */
+const char *clk_elt_name(struct clk *clk);
+
+/**
+ * clk_alloc - Allocate a clock element structure
  *
  * @name: Clock name
  * @ops: Clock operations
  * @parent_clks: Parents of the clock
  * @parent_count: Number of parents of the clock
  *
- * Return a clock struct properly initialized or NULL if allocation failed
+ * Return a struct clk * or NULL if allocation failed.
+ * The return address actually points to a struct clk_elt instance.
+ * One can use clk_to_clk_elt() to convert the reference type.
  */
 struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
 		      struct clk **parent_clks, size_t parent_count);


### PR DESCRIPTION
This RFC P-R proposes changes in the clock framework to reduce the memory footprint of generic clock driver.
I propose an alternate implementation: see RFC P-R https://github.com/OP-TEE/optee_os/pull/4943.

This change proposes to define 2 clock alternate structures: full-fledged clocks (`struct clk_elt`) and orphan clocks (`struct clk`, no parent info). Clock drivers register either of these with properly bound operators depending on clock type.

This RFC start with 2 preparatory changes (same as in RFC P-R https://github.com/OP-TEE/optee_os/pull/4943) followed by orphan clock implementation over the 2 commits:
* "drivers: clk: prepare for orphan clocks"
* "drivers: clk: introduce orphan clocks"

As illustration, the 3 last commits port fixed clocks driver and stm32mp1 clock driver to orphan clocks:
* "drivers: clk: move fixed clock to orphan clocks"
* "[PR#4940] core: dt: add platform data per compatible identifier"
* "plat-stm32mp1: move clock driver to clock framework"

The goal for stm32mp1 platform is to move to the generic clock API, yet considering it runs with `CFG_PAGER=y` and current `struct clk` consumes a bit to much memory.

Comments are welcome.