### PR TITLE
[RFC] RAM optimized clk framework : weak functions

### DIFF
--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -7,6 +7,7 @@
 #define __STM32_UTIL_H__
 
 #include <assert.h>
+#include <drivers/clk.h>
 #include <drivers/stm32_bsec.h>
 #include <kernel/panic.h>
 #include <stdint.h>
@@ -70,6 +71,17 @@ void stm32_clock_enable(unsigned long id);
 void stm32_clock_disable(unsigned long id);
 unsigned long stm32_clock_get_rate(unsigned long id);
 bool stm32_clock_is_enabled(unsigned long id);
+
+#ifdef _CFG_DRIVERS_CLK_WEAK
+unsigned int stm32_clock_clk2id(struct clk *clk);
+#else
+static inline unsigned int stm32_clock_clk2id(struct clk *clk __unused)
+{
+	assert(0);
+
+	return ~0;
+}
+#endif
 
 /* Return true if @clock_id is shared by secure and non-secure worlds */
 bool stm32mp_nsec_can_access_clock(unsigned long clock_id);

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -230,6 +230,14 @@ struct clk *clk_get_parent(struct clk *clk)
 	return clk->parent;
 }
 
+size_t clk_get_num_parents(struct clk *clk)
+{
+	if (clk_is_clk_elt(clk))
+		return to_clk_elt(clk)->num_parents;
+
+	return 0;
+}
+
 static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 				     size_t *pidx)
 {

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -101,9 +101,15 @@ TEE_Result clk_register(struct clk *clk)
 	clk_init_parent(clk);
 	clk_compute_rate_no_lock(clk);
 
-	DMSG("Registered clock %s, freq %lu", clk->name, clk_get_rate(clk));
+	DMSG("Registered clock %s, freq %lu", clk_get_name(clk),
+	     clk_get_rate(clk));
 
 	return TEE_SUCCESS;
+}
+
+const char *clk_get_name(struct clk *clk)
+{
+	return clk->name;
 }
 
 static bool clk_is_enabled_no_lock(struct clk *clk)
@@ -235,7 +241,9 @@ static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 			return TEE_SUCCESS;
 		}
 	}
-	EMSG("Clock %s is not a parent of clock %s", parent->name, clk->name);
+
+	EMSG("Clock %s is not a parent of clock %s", clk_get_name(parent),
+	     clk_get_name(clk);
 
 	return TEE_ERROR_BAD_PARAMETERS;
 }

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -342,7 +342,7 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (parent) {
 			if (clk_set_parent(clk, parent)) {
 				EMSG("Could not set clk %s parent to clock %s",
-				     clk->name, parent->name);
+				     clk_get_name(clk), clk_get_name(parent));
 				panic();
 			}
 		}

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -179,7 +179,9 @@ struct clk *clk_dt_get_by_idx(const void *fdt, int nodeoffset,
 	return clk_dt_get_by_idx_prop("clocks", fdt, nodeoffset, clk_idx);
 }
 
-static const struct clk_driver *clk_get_compatible_driver(const char *compat)
+static const struct clk_driver *clk_get_compatible_driver(
+					const char *compat,
+					const struct dt_device_match **out_dm)
 {
 	const struct dt_driver *drv = NULL;
 	const struct dt_device_match *dm = NULL;
@@ -191,8 +193,12 @@ static const struct clk_driver *clk_get_compatible_driver(const char *compat)
 
 		clk_drv = (const struct clk_driver *)drv->driver;
 		for (dm = drv->match_table; dm && dm->compatible; dm++) {
-			if (strcmp(dm->compatible, compat) == 0)
+			if (strcmp(dm->compatible, compat) == 0) {
+				if (out_dm)
+					*out_dm = dm;
+
 				return clk_drv;
+			}
 		}
 	}
 
@@ -247,6 +253,7 @@ static TEE_Result clk_dt_node_clock_setup_driver(const void *fdt, int node)
 	const char *compat = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const struct clk_driver *clk_drv = NULL;
+	const struct dt_device_match *dm = NULL;
 
 	count = fdt_stringlist_count(fdt, node, "compatible");
 	if (count < 0)
@@ -257,11 +264,11 @@ static TEE_Result clk_dt_node_clock_setup_driver(const void *fdt, int node)
 		if (!compat)
 			return TEE_ERROR_GENERIC;
 
-		clk_drv = clk_get_compatible_driver(compat);
+		clk_drv = clk_get_compatible_driver(compat, &dm);
 		if (!clk_drv)
 			continue;
 
-		res = clk_drv->probe(fdt, node);
+		res = clk_drv->probe(fdt, node, dm->compat_data);
 		if (res != TEE_SUCCESS) {
 			EMSG("Failed to probe clock driver for compatible %s",
 			     compat);

--- a/core/drivers/clk/clk_weak.c
+++ b/core/drivers/clk/clk_weak.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: (BSD-2-Clause)
+/*
+ * Copyright (C) 2021, Linaro Limited
+ */
+
+#include <drivers/clk.h>
+#include <tee_api_defines.h>
+
+/* Weak functions for the clock driver. Platform implements the needed API */
+
+const char __weak *clk_get_name(struct clk *clk __unused)
+{
+	static const char no_name[] = "n.a";
+
+	return no_name;
+}
+
+unsigned long __weak clk_get_rate(struct clk *clk __unused)
+{
+	return 0;
+}
+
+TEE_Result __weak clk_set_rate(struct clk *clk __unused,
+			       unsigned long rate __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result __weak clk_enable(struct clk *clk __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void __weak clk_disable(struct clk *clk __unused)
+{
+}
+
+struct clk __weak *clk_get_parent(struct clk *clk __unused)
+{
+	return NULL;
+}
+
+size_t __weak clk_get_num_parents(struct clk *clk __unused)
+{
+	return 0;
+}
+
+struct clk __weak *clk_get_parent_by_index(struct clk *clk __unused,
+					   size_t pidx __unused)
+{
+	return NULL;
+}
+
+TEE_Result __weak clk_set_parent(struct clk *clk __unused,
+				 struct clk *parent __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -25,7 +25,8 @@ static const struct clk_ops fixed_clk_clk_ops = {
 	.get_rate = fixed_clk_get_rate,
 };
 
-static TEE_Result fixed_clock_setup(const void *fdt, int offs)
+static TEE_Result fixed_clock_setup(const void *fdt, int offs,
+				    const void *compat_data __unused)
 {
 	const uint32_t *freq = NULL;
 	const char *name = NULL;

--- a/core/drivers/clk/sub.mk
+++ b/core/drivers/clk/sub.mk
@@ -1,3 +1,4 @@
-srcs-y += clk.c
+srcs-$(CFG_DRIVERS_CLK_CORE) += clk.c
+srcs-$(_CFG_DRIVERS_CLK_WEAK) += clk_weak.c
 srcs-$(CFG_DRIVERS_CLK_DT) += clk_dt.c
 srcs-$(CFG_DRIVERS_CLK_FIXED) += fixed_clk.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -40,6 +40,6 @@ srcs-$(CFG_IMX_OCOTP) += imx_ocotp.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt
-subdirs-$(CFG_DRIVERS_CLK) += clk
+subdirs-y += clk
 subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg
 subdirs-y += imx

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -66,10 +66,7 @@ struct clk_ops {
  * @clk: Clock for which the name is needed
  * Return a const char * pointing to the clock name
  */
-static inline const char *clk_get_name(struct clk *clk)
-{
-	return clk->name;
-}
+const char *clk_get_name(struct clk *clk);
 
 /**
  * clk_alloc - Allocate a clock structure

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -14,6 +14,7 @@
 #define CLK_SET_RATE_GATE	BIT(0) /* must be gated across rate change */
 #define CLK_SET_PARENT_GATE	BIT(1) /* must be gated across re-parent */
 
+#ifdef CFG_DRIVERS_CLK_CORE
 /**
  * struct clk - Clock structure
  *
@@ -61,14 +62,6 @@ struct clk_ops {
 };
 
 /**
- * Return the clock name
- *
- * @clk: Clock for which the name is needed
- * Return a const char * pointing to the clock name
- */
-const char *clk_get_name(struct clk *clk);
-
-/**
  * clk_alloc - Allocate a clock structure
  *
  * @name: Clock name
@@ -95,6 +88,21 @@ void clk_free(struct clk *clk);
  * Return a TEE_Result compliant value
  */
 TEE_Result clk_register(struct clk *clk);
+#else
+/*
+ * struct clk is an opaque structure known from the platform clock provider.
+ * plat_clk_*() function prototypes strictly match their clk_*() counterpart.
+ */
+struct clk;
+#endif /* CFG_DRIVERS_CLK_CORE */
+
+/**
+ * Return the clock name
+ *
+ * @clk: Clock for which the name is needed
+ * Return a const char * pointing to the clock name
+ */
+const char *clk_get_name(struct clk *clk);
 
 /**
  * clk_get_rate - Get clock rate

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -142,10 +142,7 @@ struct clk *clk_get_parent(struct clk *clk);
  * @clk: Clock for which the number of parents is needed
  * Return the number of parents
  */
-static inline size_t clk_get_num_parents(struct clk *clk)
-{
-	return clk->num_parents;
-}
+size_t clk_get_num_parents(struct clk *clk);
 
 /**
  * Get a clock parent by its index

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -27,7 +27,7 @@ struct clk_dt_phandle_args {
  * probe: probe function for the clock driver
  */
 struct clk_driver {
-	TEE_Result (*probe)(const void *fdt, int nodeoffset);
+	TEE_Result (*probe)(const void *fdt, int nodeoffset, const void *data);
 };
 
 /**

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -57,6 +57,7 @@ struct dt_node_info {
 
 struct dt_device_match {
 	const char *compatible;
+	const void *compat_data;
 };
 
 enum dt_driver_type {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -717,11 +717,19 @@ CFG_PREALLOC_RPC_CACHE ?= y
 # When enabled, CFG_DRIVERS_CLK embeds a clock framework in OP-TEE core.
 # This clock framework allows to describe clock tree and provides functions to
 # get and configure the clocks.
+# CFG_DRIVERS_CLK_CORE embeds the generic clock driver implementation
 # CFG_DRIVERS_CLK_DT embeds devicetree clock parsing support
 # CFG_DRIVERS_CLK_FIXED add support for "fixed-clock" compatible clocks
 CFG_DRIVERS_CLK ?= n
+CFG_DRIVERS_CLK_CORE ?= $(CFG_DRIVERS_CLK)
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
-CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
+CFG_DRIVERS_CLK_FIXED ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK_CORE CFG_DRIVERS_CLK_DT)
 
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
-$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))
+$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT CFG_DRIVERS_CLK_CORE))
+
+ifeq ($(CFG_DRIVERS_CLK),y)
+ifneq ($(CFG_DRIVERS_CLK_CORE),y)
+_CFG_DRIVERS_CLK_WEAK = y
+endif
+endif


### PR DESCRIPTION
This RFC P-R proposes changes in the clock framework to reduce the memory footprint of generic clock driver.
I propose an alternate implementation: see RFC P-R https://github.com/OP-TEE/optee_os/pull/4942.

This idea of this P-R is to use clk driver API functions prototypes but not the implementation which is fully provided by a unique platform specific clock driver.

This RFC start with 2 preparatory changes, followed by a commit to introduce `_CFG_DRIVERS_CLK_WEAK`.
The 2 last commit is a port on stm32mp1 clock driver, using #4940. The goal for this platform is to move to the generic clock API, yet considering it runs with `CFG_PAGER=y`. 

Comments are welcome.