### PR TITLE
drivers: imx: add MU driver

### DIFF
--- a/core/drivers/imx_mu.c
+++ b/core/drivers/imx_mu.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2020-2021 NXP
+ */
+#include <drivers/imx_mu.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <tee_api_types.h>
+
+#define MU_ATR(n)     (0x0 + (n) * (4))
+#define MU_ARR(n)     (0x10 + (n) * (4))
+#define MU_ASR_OFFSET 0x20
+#define MU_ACR_OFFSET 0x24
+
+#define MU_SR_RF(n) SHIFT_U32(1, 27 - (n))
+#define MU_SR_TE(n) SHIFT_U32(1, 23 - (n))
+
+#define MU_CR_GIE_MASK GENMASK_32(31, 28)
+#define MU_CR_RIE_MASK GENMASK_32(27, 24)
+#define MU_CR_TIE_MASK GENMASK_32(23, 20)
+#define MU_CR_GIR_MASK GENMASK_32(19, 16)
+#define MU_CR_F_MASK   GENMASK_32(2, 0)
+
+static TEE_Result mu_wait_for(vaddr_t addr, uint32_t mask)
+{
+	uint64_t timeout = timeout_init_us(1000);
+
+	while (!(io_read32(addr) & mask)) {
+		if (timeout_elapsed(timeout))
+			return TEE_ERROR_BUSY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+void mu_init(vaddr_t base)
+{
+	io_clrbits32(base + MU_ACR_OFFSET, MU_CR_GIE_MASK | MU_CR_RIE_MASK |
+					   MU_CR_TIE_MASK | MU_CR_GIR_MASK |
+					   MU_CR_F_MASK);
+}
+
+TEE_Result mu_send_msg(vaddr_t base, unsigned int index, uint32_t msg)
+{
+	/* Wait TX register to be empty */
+	if (mu_wait_for(base + MU_ASR_OFFSET, MU_SR_TE(index)))
+		return TEE_ERROR_BUSY;
+
+	/* Write message in TX register */
+	io_write32(base + MU_ATR(index), msg);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result mu_receive_msg(vaddr_t base, unsigned int index, uint32_t *msg)
+{
+	/* Wait RX register to be full */
+	if (mu_wait_for(base + MU_ASR_OFFSET, MU_SR_RF(index)))
+		return TEE_ERROR_BUSY;
+
+	*msg = io_read32(base + MU_ARR(index));
+
+	return TEE_SUCCESS;
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -37,6 +37,7 @@ srcs-$(CFG_LS_GPIO) += ls_gpio.c
 srcs-$(CFG_LS_DSPI) += ls_dspi.c
 srcs-$(CFG_IMX_RNGB) += imx_rngb.c
 srcs-$(CFG_IMX_OCOTP) += imx_ocotp.c
+srcs-$(CFG_IMX_SC) += imx_mu.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/include/drivers/imx_mu.h
+++ b/core/include/drivers/imx_mu.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2020-2021 NXP
+ */
+#ifndef __DRIVERS_IMX_MU_H
+#define __DRIVERS_IMX_MU_H
+
+#include <tee_api_types.h>
+#include <types_ext.h>
+#include <util.h>
+
+#define MU_NB_RR 4
+#define MU_NB_TR 4
+
+/*
+ * Clear GIE, RIE, TIE, GIR and F registers
+ *
+ * @base   Base address of the MU
+ */
+void mu_init(vaddr_t base);
+
+/*
+ * Send a message through MU
+ *
+ * @base    Base address of the MU
+ * @index   Index of the TR register
+ * @msg     Message to send
+ */
+TEE_Result mu_send_msg(vaddr_t base, unsigned int index, uint32_t msg);
+
+/*
+ * Receive a message through MU
+ *
+ * @base    Base address of the MU
+ * @index   Index of the RR register
+ * @msg     [out] Received message
+ */
+TEE_Result mu_receive_msg(vaddr_t base, unsigned int index, uint32_t *msg);
+#endif /* __DRIVERS_IMX_MU_H */


### PR DESCRIPTION
Hello,

I plan on upstreaming the CAAM support for i.MX8QM and i.MX8QXP.
I will split the code to upstream into multiple pull-requests to ease the review process.

I start today with the MU driver. Please note that the compilation flag for this driver (`CFG_IMX_SC`) is not defined anywhere for now.

Thanks!
Clement