### PR TITLE
Proposal for a driver probing sequence

### DIFF
--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -35,11 +35,17 @@
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the subnode containing a clock property
  * @clk_idx: Clock index to get
+ * @res: Output result code of the operation:
+ *	TEE_SUCCESS in case of success
+ *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
+ *	Any TEE_Result compliant code in case of error.
+ *
  * Returns a clk struct pointer matching the clock at index clk_idx in clocks
- * property or NULL if no clock match the given index.
+ * property or NULL if no clock match the given index in which case @res
+ * provides the error code.
  */
 struct clk *clk_dt_get_by_idx(const void *fdt, int nodeoffset,
-			      unsigned int clk_idx);
+			      unsigned int clk_idx, TEE_Result *res);
 
 /**
  * clk_dt_get_by_name - Get a clock matching a name in the "clock-names"
@@ -48,23 +54,34 @@ struct clk *clk_dt_get_by_idx(const void *fdt, int nodeoffset,
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the subnode containing a clock property
  * @name: Clock name to get
+ * @res: Output result code of the operation:
+ *	TEE_SUCCESS in case of success
+ *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
+ *	Any TEE_Result compliant code in case of error.
+ *
  * Returns a clk struct pointer matching the name in "clock-names" property or
- * NULL if no clock match the given name.
+ * NULL if no clock match the given name in which case @res provides the
+ * error code.
  */
 struct clk *clk_dt_get_by_name(const void *fdt, int nodeoffset,
-			       const char *name);
+			       const char *name, TEE_Result *res);
 
 /**
  * clk_dt_get_func - Typedef of function to get clock from devicetree properties
  *
  * @args: Pointer to devicetree description of the clock to parse
  * @data: Pointer to data given at clk_dt_register_clk_provider() call
+ * @res: Output result code of the operation:
+ *	TEE_SUCCESS in case of success
+ *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
+ *	Any TEE_Result compliant code in case of error.
  *
  * Returns a clk struct pointer pointing to a clock matching the devicetree
- * description or NULL if invalid description.
+ * description or NULL if invalid description in which case @res provides the
+ * error code.
  */
 typedef struct clk *(*clk_dt_get_func)(struct dt_driver_phandle_args *args,
-				       void *data);
+				       void *data, TEE_Result *res);
 
 /**
  * clk_dt_register_clk_provider - Register a clock provider
@@ -90,8 +107,10 @@ TEE_Result clk_dt_register_clk_provider(const void *fdt, int nodeoffset,
  */
 static inline
 struct clk *clk_dt_get_simple_clk(struct dt_driver_phandle_args *args __unused,
-				  void *data)
+				  void *data, TEE_Result *res)
 {
+	*res = TEE_SUCCESS;
+
 	return data;
 }
 

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -97,6 +97,7 @@ struct initcall {
 #define service_init_late(fn)		__define_initcall(init, 4, fn)
 #define driver_init(fn)			__define_initcall(init, 5, fn)
 #define driver_init_late(fn)		__define_initcall(init, 6, fn)
+#define release_init_resource(fn)	__define_initcall(init, 7, fn)
 
 #define boot_final(fn)			__define_initcall(final, 1, fn)
 

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -77,6 +77,7 @@ enum dt_driver_type {
  * @compat_data: Data registered for the compatible that probed the device
  *
  * Return TEE_SUCCESS on successful probe,
+ *	TEE_ERROR_DEFER_DRIVER_INIT if probe must be deferred
  *	TEE_ERROR_ITEM_NOT_FOUND when no driver matched node's compatible string
  *	Any other TEE_ERROR_* compliant code.
  */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -32,12 +32,14 @@ struct dt_driver_phandle_args {
  *
  * @parg: phandle argument(s) referencing the device in the FDT.
  * @data: driver private data registered in struct dt_driver.
+ * @res: Output result code of the operation: TEE_ERROR_BUSY is target
+ *	device is not yet initialized, otherwise any other compliant code.
  *
  * Return a device opaque reference, e.g. a struct clk pointer for a clock
- * driver, or NULL if not found.
+ * driver, or NULL if not found in which case @res provides the error code.
  */
 typedef void *(*get_of_device_func)(struct dt_driver_phandle_args *parg,
-				    void *data);
+				    void *data, TEE_Result *res);
 
 /**
  * dt_driver_register_provider - Register a driver provider
@@ -64,13 +66,16 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
  * @fdt: FDT base address
  * @nodeoffset: node offset in the FDT
  * @prop_idx: index of the phandle data in the property
+ * @res: Output result code of the operation: TEE_ERROR_BUSY is target
+ *	device is not yet initialized, otherwise any other compliant code.
  *
  * Return a device opaque reference, e.g. a struct clk pointer for a clock
- * driver, or NULL if not found.
+ * driver, or NULL if not found in which case @res provides the error code.
  */
 void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 					  const void *fdt, int nodeoffset,
-					  unsigned int prop_idx);
+					  unsigned int prop_idx,
+					  TEE_Result *res);
 
 /*
  * Return driver provider reference from its node offset value in the FDT

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -2,6 +2,8 @@
 /*
  * Copyright (c) 2021, Linaro Limited
  * Copyright (c) 2021, Bootlin
+ * Copyright (c) 2021, Linaro Limited
+ * Copyright (c) 2021, STMicroelectronics
  */
 
 #ifndef __DT_DRIVER_H
@@ -120,4 +122,12 @@ TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
  */
 int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
 			    enum dt_driver_type type);
+
+/*
+ * Called by bus like nodes to propose a node for dt_driver probing
+ *
+ * @fdt: FDT base address
+ * @nodeoffset: Node offset on the FDT for the device
+ */
+TEE_Result dt_driver_maybe_add_probe_node(const void *fdt, int nodeoffset);
 #endif /* __DT_DRIVER_H */

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -146,7 +146,7 @@ static TEE_Result dt_driver_release_provider(void)
 	return TEE_SUCCESS;
 }
 
-driver_init_late(dt_driver_release_provider);
+release_init_resource(dt_driver_release_provider);
 
 /*
  * Helper functions for dt_drivers querying driver provider information
@@ -651,6 +651,30 @@ static TEE_Result probe_dt_drivers(void)
 }
 
 driver_init(probe_dt_drivers);
+
+static TEE_Result release_probe_lists(void)
+{
+	struct dt_driver_probe *elt = NULL;
+	struct dt_driver_probe *next = NULL;
+	const void * __maybe_unused fdt = NULL;
+
+	if (!IS_ENABLED(CFG_EMBED_DTB))
+		return TEE_SUCCESS;
+
+	fdt = get_embedded_dt();
+
+	assert(fdt && TAILQ_EMPTY(&dt_driver_probe_list));
+
+	TAILQ_FOREACH_SAFE(elt, &dt_driver_ready_list, link, next) {
+		DMSG("element: %s on node %s", elt->dt_drv->name,
+		     fdt_get_name(fdt, elt->nodeoffset, NULL));
+		free(elt);
+	}
+
+	return TEE_SUCCESS;
+}
+
+release_init_resource(release_probe_lists);
 
 /*
  * Simple bus support: handy to parse subnodes

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -2,15 +2,40 @@
 /*
  * Copyright (c) 2021, Linaro Limited
  * Copyright (c) 2021, Bootlin
+ * Copyright (c) 2021, Linaro Limited
+ * Copyright (c) 2021, STMicroelectronics
  */
 
+#include <assert.h>
+#include <config.h>
 #include <initcall.h>
+#include <kernel/boot.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <libfdt.h>
 #include <malloc.h>
 #include <sys/queue.h>
+#include <tee_api_defines_extensions.h>
 #include <tee_api_types.h>
+
+/*
+ * struct dt_driver_probe - Node instance in secure FDT to probe a driver for
+ *
+ * @link: List hook
+ * @nodeoffset: Node offset of device referenced in the FDT
+ * @type: One of DT_DRIVER_* or DT_DRIVER_NOTYPE.
+ * @deferrals: Driver probe deferrals count
+ * @dt_drv: Matching driver to probe if found or NULL
+ * @dm: Matching reference if applicable or NULL
+ */
+struct dt_driver_probe {
+	int nodeoffset;
+	enum dt_driver_type type;
+	unsigned int deferrals;
+	const struct dt_driver *dt_drv;
+	const struct dt_device_match *dm;
+	TAILQ_ENTRY(dt_driver_probe) link;
+};
 
 /*
  * struct dt_driver_provider - DT related info on probed device
@@ -35,8 +60,35 @@ struct dt_driver_provider {
 	SLIST_ENTRY(dt_driver_provider) link;
 };
 
+/*
+ * Device driver providers are able to provide a driver specific instance
+ * related to device phandle arguments found in the secure embedded FDT.
+ */
 static SLIST_HEAD(, dt_driver_provider) dt_driver_provider_list =
 	SLIST_HEAD_INITIALIZER(dt_driver_provider_list);
+
+/* FDT nodes for which a matching driver is to be probed */
+static TAILQ_HEAD(dt_driver_probe_head, dt_driver_probe) dt_driver_probe_list =
+	TAILQ_HEAD_INITIALIZER(dt_driver_probe_list);
+
+/* FDT nodes for which a matching driver has been successfully probed */
+static TAILQ_HEAD(, dt_driver_probe) dt_driver_ready_list =
+	TAILQ_HEAD_INITIALIZER(dt_driver_ready_list);
+
+/* Flag enabled when a new node (possibly typed) is added in the probe list */
+static bool added_node;
+
+static void assert_type_is_valid(enum dt_driver_type type)
+{
+	switch (type) {
+	case DT_DRIVER_NOTYPE:
+	case DT_DRIVER_UART:
+	case DT_DRIVER_CLK:
+		return;
+	default:
+		assert(0);
+	}
+}
 
 /*
  * Driver provider registering API functions
@@ -49,6 +101,8 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
 	struct dt_driver_provider *prv = NULL;
 	int provider_cells = 0;
 	uint32_t phandle = 0;
+
+	assert_type_is_valid(type);
 
 	provider_cells = fdt_get_dt_driver_cells(fdt, nodeoffset, type);
 	if (provider_cells < 0) {
@@ -219,6 +273,88 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 	return NULL;
 }
 
+static unsigned int __maybe_unused probe_list_count(void)
+{
+	struct dt_driver_probe *elt = NULL;
+	unsigned int count = 0;
+
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link)
+		count++;
+
+	return count;
+}
+
+static void __maybe_unused print_probe_list(const void *fdt __maybe_unused)
+{
+	struct dt_driver_probe *elt = NULL;
+
+	DMSG("Probe list: %u elements", probe_list_count());
+
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link)
+		DMSG("- Driver %s probes on node %s",
+		     elt->dt_drv->name,
+		     fdt_get_name(fdt, elt->nodeoffset, NULL));
+
+	DMSG("Probe list end");
+}
+
+/*
+ * Probe element: push to ready list if succeeds, push to probe list if probe
+ * if deferred, panic with an error trace otherwise.
+ */
+static TEE_Result probe_driver_node(const void *fdt,
+				    struct dt_driver_probe *elt)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const char __maybe_unused *drv_name = NULL;
+	const char __maybe_unused *node_name = NULL;
+
+	node_name = fdt_get_name(fdt, elt->nodeoffset, NULL);
+	drv_name = elt->dt_drv->name;
+	FMSG("Probing %s on node %s", drv_name, node_name);
+
+	res = elt->dt_drv->probe(fdt, elt->nodeoffset, elt->dm->compat_data);
+	switch (res) {
+	case TEE_SUCCESS:
+		TAILQ_INSERT_HEAD(&dt_driver_ready_list, elt, link);
+
+		DMSG("element: %s on node %s initialized", drv_name, node_name);
+		break;
+	case TEE_ERROR_DEFER_DRIVER_INIT:
+		elt->deferrals++;
+		TAILQ_INSERT_TAIL(&dt_driver_probe_list, elt, link);
+
+		DMSG("element: %s on node %s deferred %u time(s)", drv_name,
+		     node_name, elt->deferrals);
+		break;
+	default:
+		EMSG("Fail to probe %s on node %s: %#"PRIx32,
+		     drv_name, node_name, res);
+		panic();
+	}
+
+	return res;
+}
+
+static TEE_Result alloc_elt_and_probe(const void *fdt, int node,
+				      const struct dt_driver *dt_drv,
+				      const struct dt_device_match *dm)
+{
+	struct dt_driver_probe *elt = NULL;
+
+	/* Will be freed when lists are released */
+	elt = calloc(1, sizeof(*elt));
+	if (!elt)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	elt->nodeoffset = node;
+	elt->dt_drv = dt_drv;
+	elt->dm = dm;
+	elt->type = dt_drv->type;
+
+	return probe_driver_node(fdt, elt);
+}
+
 /* Lookup a compatible driver, possibly of a specific @type, for the FDT node */
 static TEE_Result probe_device_by_compat(const void *fdt, int node,
 					 const char *compat,
@@ -233,12 +369,16 @@ static TEE_Result probe_device_by_compat(const void *fdt, int node,
 
 		for (dm = drv->match_table; dm && dm->compatible; dm++)
 			if (strcmp(dm->compatible, compat) == 0)
-				return drv->probe(fdt, node, dm->compat_data);
+				return alloc_elt_and_probe(fdt, node, drv, dm);
 	}
 
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }
 
+/*
+ * Lookup the best matching compatible driver, possibly of a specific @type,
+ * for the FDT node.
+ */
 TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
 					  enum dt_driver_type type)
 {
@@ -247,6 +387,8 @@ TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
 	int count = 0;
 	const char *compat = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
+
+	assert_type_is_valid(type);
 
 	count = fdt_stringlist_count(fdt, nodeoffset, "compatible");
 	if (count < 0)
@@ -266,3 +408,246 @@ TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
 
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }
+
+static TEE_Result process_probe_list(const void *fdt)
+{
+	struct dt_driver_probe *elt = NULL;
+	struct dt_driver_probe *prev = NULL;
+	unsigned int __maybe_unused loop_count = 0;
+	unsigned int __maybe_unused deferral_loop_count = 0;
+	bool __maybe_unused one_deferred = false;
+	bool one_probed_ok = false;
+
+	do {
+		loop_count++;
+		FMSG("Probe loop %u after %u for deferral(s)", loop_count,
+		     deferral_loop_count);
+
+		/* Hack here for TRACE_DEBUG messages on probe list elements */
+		if (TRACE_LEVEL >= TRACE_FLOW)
+			print_probe_list(fdt);
+
+		if (TAILQ_EMPTY(&dt_driver_probe_list))
+			return TEE_SUCCESS;
+
+		/*
+		 * Probe from current end to top. Deferred probed node are
+		 * pushed back after current tail for the next probe round.
+		 * Reset probe result flags and see status after probe round.
+		 */
+		one_deferred = false;
+		one_probed_ok = false;
+		added_node = false;
+
+		TAILQ_FOREACH_REVERSE_SAFE(elt, &dt_driver_probe_list,
+					   dt_driver_probe_head, link, prev) {
+			TAILQ_REMOVE(&dt_driver_probe_list, elt, link);
+
+			switch (probe_driver_node(fdt, elt)) {
+			case TEE_SUCCESS:
+				one_probed_ok = true;
+				break;
+			case TEE_ERROR_DEFER_DRIVER_INIT:
+				one_deferred = true;
+				break;
+			default:
+				/* We don't expect error return codes */
+				assert(0);
+			}
+		}
+
+		if (one_deferred)
+			deferral_loop_count++;
+
+	} while (added_node || one_probed_ok);
+
+	EMSG("Panic on unresolved dependencies after %u rounds, %u deferred:",
+	     loop_count, deferral_loop_count);
+
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link)
+		EMSG("- %s on node %s", elt->dt_drv->name,
+		     fdt_get_name(fdt, elt->nodeoffset, NULL));
+
+	panic();
+}
+
+static int driver_probe_compare(struct dt_driver_probe *candidate,
+				struct dt_driver_probe *elt)
+{
+	if (candidate->nodeoffset != elt->nodeoffset ||
+	    candidate->type != elt->type)
+		return 1;
+
+	assert(elt->dt_drv == candidate->dt_drv);
+	return 0;
+}
+
+/*
+ * Return TEE_SUCCESS if compatible found
+ *	  TEE_ERROR_OUT_OF_MEMORY if heap is exhausted
+ */
+static TEE_Result add_node_to_probe(const void *fdt, int node,
+				    const struct dt_driver *dt_drv,
+				    const struct dt_device_match *dm)
+{
+	const char __maybe_unused *node_name = fdt_get_name(fdt, node, NULL);
+	const char __maybe_unused *drv_name = dt_drv->name;
+	struct dt_driver_probe *elt = NULL;
+	struct dt_driver_probe elt_new = {
+		.dm = dm,
+		.dt_drv = dt_drv,
+		.nodeoffset = node,
+		.type = dt_drv->type,
+	};
+
+	/* If node/type found in probe list or ready list, nothing to do */
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link)
+		if (!driver_probe_compare(&elt_new, elt))
+			return TEE_SUCCESS;
+
+	TAILQ_FOREACH(elt, &dt_driver_ready_list, link)
+		if (!driver_probe_compare(&elt_new, elt))
+			return TEE_SUCCESS;
+
+	elt = malloc(sizeof(*elt));
+	if (!elt)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	DMSG("element: %s on node %s", node_name, drv_name);
+
+	memcpy(elt, &elt_new, sizeof(*elt));
+
+	added_node = true;
+
+	TAILQ_INSERT_TAIL(&dt_driver_probe_list, elt, link);
+
+	/* Hack here for TRACE_DEBUG messages on current probe list elements */
+	if (TRACE_LEVEL >= TRACE_FLOW)
+		print_probe_list(fdt);
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Add a node to the probe list if a dt_driver matches target compatible.
+ *
+ * If @type is DT_DRIVER_ANY, probe list can hold only 1 driver to probe for
+ * the node. A node may probe several drivers if have a unique driver type.
+ *
+ * Return TEE_SUCCESS if compatible found
+ *	  TEE_ERROR_ITEM_NOT_FOUND if no matching driver
+ *	  TEE_ERROR_OUT_OF_MEMORY if heap is exhausted
+ */
+static TEE_Result add_probe_node_by_compat(const void *fdt, int node,
+					   const char *compat)
+{
+	TEE_Result res = TEE_ERROR_ITEM_NOT_FOUND;
+	const struct dt_driver *dt_drv = NULL;
+	const struct dt_device_match *dm = NULL;
+	uint32_t found_types = 0;
+
+	for_each_dt_driver(dt_drv) {
+		for (dm = dt_drv->match_table; dm && dm->compatible; dm++) {
+			if (strcmp(dm->compatible, compat) == 0) {
+				assert(dt_drv->type < 32);
+
+				res = add_node_to_probe(fdt, node, dt_drv, dm);
+				if (res)
+					return res;
+
+				if (found_types & BIT(dt_drv->type)) {
+					EMSG("Driver %s multi hit on type %u",
+					     dt_drv->name, dt_drv->type);
+					panic();
+				}
+				found_types |= BIT(dt_drv->type);
+
+				/* Matching found for this driver, try next */
+				break;
+			}
+		}
+	}
+
+	return res;
+}
+
+/*
+ * Add the node to the probe list if matching compatible drivers are found.
+ * Follow node's compatible property list ordering to find matching driver.
+ */
+TEE_Result dt_driver_maybe_add_probe_node(const void *fdt, int node)
+{
+	int idx = 0;
+	int len = 0;
+	int count = 0;
+	const char *compat = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (_fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
+		return TEE_SUCCESS;
+
+	count = fdt_stringlist_count(fdt, node, "compatible");
+	if (count < 0)
+		return TEE_SUCCESS;
+
+	for (idx = 0; idx < count; idx++) {
+		compat = fdt_stringlist_get(fdt, node, "compatible", idx, &len);
+		assert(compat && len > 0);
+
+		res = add_probe_node_by_compat(fdt, node, compat);
+
+		/* Stop lookup if something was found */
+		if (res != TEE_ERROR_ITEM_NOT_FOUND)
+			return res;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static void parse_node(const void *fdt, int node)
+{
+	TEE_Result __maybe_unused res = TEE_ERROR_GENERIC;
+	int subnode = 0;
+
+	fdt_for_each_subnode(subnode, fdt, node) {
+		res = dt_driver_maybe_add_probe_node(fdt, subnode);
+		if (res) {
+			EMSG("Failed on node %s with %#"PRIx32,
+			     fdt_get_name(fdt, subnode, NULL), res);
+			panic();
+		}
+
+		/*
+		 * Rescursively parse the FDT, skipping disabled nodes.
+		 * FDT is expected reliable and core shall have sufficient
+		 * stack depth to possibly parse all DT nodes.
+		 */
+		if (IS_ENABLED(CFG_DRIVERS_DT_RECURSIVE_PROBE)) {
+			if (_fdt_get_status(fdt, subnode) == DT_STATUS_DISABLED)
+				continue;
+
+			parse_node(fdt, subnode);
+		}
+	}
+}
+
+/*
+ * Parse FDT for nodes and save in probe list the node for which a dt_driver
+ * matches node's compatible property.
+ */
+static TEE_Result probe_dt_drivers(void)
+{
+	const void *fdt = NULL;
+
+	if (!IS_ENABLED(CFG_EMBED_DTB))
+		return TEE_SUCCESS;
+
+	fdt = get_embedded_dt();
+	assert(fdt);
+
+	parse_node(fdt, fdt_path_offset(fdt, "/"));
+
+	return process_probe_list(fdt);
+}
+
+driver_init(probe_dt_drivers);

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -651,3 +651,35 @@ static TEE_Result probe_dt_drivers(void)
 }
 
 driver_init(probe_dt_drivers);
+
+/*
+ * Simple bus support: handy to parse subnodes
+ */
+static TEE_Result simple_bus_probe(const void *fdt, int node,
+				   const void *compat_data __unused)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int subnode = 0;
+
+	fdt_for_each_subnode(subnode, fdt, node) {
+		res = dt_driver_maybe_add_probe_node(fdt, subnode);
+		if (res) {
+			EMSG("Failed on node %s with %#"PRIx32,
+			     fdt_get_name(fdt, subnode, NULL), res);
+			panic();
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+static const struct dt_device_match simple_bus_match_table[] = {
+	{ .compatible = "simple-bus" },
+	{ }
+};
+
+const struct dt_driver simple_bus_dt_driver __dt_driver = {
+	.name = "simple-bus",
+	.match_table = simple_bus_match_table,
+	.probe = simple_bus_probe,
+};

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -1,11 +1,24 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2014-2021, Linaro Limited
  * Copyright (c) 2021, SumUp Services GmbH
  */
 
 #ifndef TEE_API_DEFINES_EXTENSIONS_H
 #define TEE_API_DEFINES_EXTENSIONS_H
+
+/*
+ * API extended result codes as per TEE_Result IDs defined in GPD TEE
+ * Internal Core API specification v1.1:
+ *
+ * 0x70000000 - 0x7FFFFFFF: Reserved for implementation-specific return
+ *			    code providing non-error information
+ * 0x80000000 - 0x8FFFFFFF: Reserved for implementation-specific errors
+ *
+ * TEE_ERROR_DEFER_DRIVER_INIT - Device driver failed to initialize because
+ * the driver depends on a device not yet initialized.
+ */
+#define TEE_ERROR_DEFER_DRIVER_INIT	0x80000000
 
 /*
  * HMAC-based Extract-and-Expand Key Derivation Function (HKDF)


### PR DESCRIPTION
**(edited atfer #4965 merge)**

This RFC proposes a unified driver probing sequence for compatible drivers registered as dt_driver. The main goal of this unified driver probing implementation is to resolve device driver dependencies without requiring specific static initcall levels.

This changes introduce implementation in _core/kernel/dt_drivers.c_, executed at `driver_init` initcall level. The function parses DT nodes and probes registered compatible drivers. Driver probe function can register as a device driver provider. Driver probe function can query device(s) to the driver provider which may in turn request caller probe to be deferred when the target device is not yet registered in the driver provider database.

**Preparatory changes:**

~~This scheme reuses and adapts the implementation from clk framework (device driver probing, registration and device queries) to propose a generic device driver model.~~
~~Commit _"core: factorize dt_driver probing helper function"_ moves some functions from _clk_dt.c_ to _dt_driver.c_.~~
_**(e)** addressed by #4965_

In this P-R (at least its initial state), ~~`TEE_ERROR_BUSY`~~ **New `TEE_ERROR_DEFER_DRIVER_INIT`** is used as return code from a driver probe function when the driver is waiting for device to be probed/initialized.
See commit _"core: dt_driver: get return code when querying a device"_.

**Driver probing loop**

The unified driver probing sequence is implemented in commit _"core: dt_driver probe sequence"_.
The implementation uses link lists to track DT nodes for which we want to probe a compatible driver, the devices that have been successfully initialized and initialized/registered device provider drivers.
The probe loop starts by scanning each subnode of the FDT root node. Compatible drivers, when probed, may add new nodes to the to-be-probed list. As far as nodes are added and drivers are probed, driver dependencies should be resolved.
The loop states that some dependencies can't be resolved if all remaining to-be-probed devices request probe deferral while no new node is added in the to-be-probed list.

Commit _"core: dt_driver: add simple bus driver"_ implement a simple bus driver. Simple bus is related to nodes for which each subnode is to be added to the to-be-probed list, typically used in `soc` node description (i.e [fsl-lx2160a](https://github.com/OP-TEE/optee_os/blob/3.15.0/core/arch/arm/dts/fsl-lx2160a.dtsi#L464-L465) and [stm32mp15](https://github.com/OP-TEE/optee_os/blob/3.15.0/core/arch/arm/dts/stm32mp151.dtsi#L110-L111))

**Add-on: post-init resource release**

3 last commits proposes an initcall specific level (`release_init_resource`) for releasing all resources needed only during core initialization. The driver probing model implementation uses it to release of memory allocated for resolving device dependencies. As an example, se050 driver is updated to leverage this new initcall level, when core initialization is completed.