### PR TITLE
core: pta: socket: enable TA to query recv out buffer

### DIFF
--- a/core/tee/socket.c
+++ b/core/tee/socket.c
@@ -122,9 +122,9 @@ static TEE_Result socket_send(uint32_t instance_id, uint32_t param_types,
 static TEE_Result socket_recv(uint32_t instance_id, uint32_t param_types,
 			      TEE_Param params[TEE_NUM_PARAMS])
 {
-	struct mobj *mobj;
-	TEE_Result res;
-	void *va;
+	struct mobj *mobj = NULL;
+	TEE_Result res = TEE_SUCCESS;
+	void *va = NULL;
 	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 					  TEE_PARAM_TYPE_MEMREF_OUTPUT,
 					  TEE_PARAM_TYPE_NONE,
@@ -136,11 +136,13 @@ static TEE_Result socket_recv(uint32_t instance_id, uint32_t param_types,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_SOCKET,
-					THREAD_SHM_TYPE_APPLICATION,
-					params[1].memref.size, &mobj);
-	if (!va)
-		return TEE_ERROR_OUT_OF_MEMORY;
+	if (params[1].memref.size) {
+		va = thread_rpc_shm_cache_alloc(THREAD_SHM_CACHE_USER_SOCKET,
+						THREAD_SHM_TYPE_APPLICATION,
+						params[1].memref.size, &mobj);
+		if (!va)
+			return TEE_ERROR_OUT_OF_MEMORY;
+	}
 
 	struct thread_param tpm[3] = {
 		[0] = THREAD_PARAM_VALUE(IN, OPTEE_RPC_SOCKET_RECV, instance_id,
@@ -152,11 +154,10 @@ static TEE_Result socket_recv(uint32_t instance_id, uint32_t param_types,
 
 	res = thread_rpc_cmd(OPTEE_RPC_CMD_SOCKET, 3, tpm);
 
-	if (tpm[1].u.memref.size > params[1].memref.size)
-		return TEE_ERROR_GENERIC;
-	params[1].memref.size = tpm[1].u.memref.size;
 	if (params[1].memref.size)
-		memcpy(params[1].memref.buffer, va, params[1].memref.size);
+		memcpy(params[1].memref.buffer, va,
+		       MIN(params[1].memref.size, tpm[1].u.memref.size));
+	params[1].memref.size = tpm[1].u.memref.size;
 
 	return res;
 }


### PR DESCRIPTION
Propagate out size for socket recv event when it's larger than the
supplied in size. Also enable passing a NULL buffer while querying the
size of the buffer.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
