### PR TITLE
plat-sam: add sama5d2 clock tree support

### DIFF
--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -22,6 +22,11 @@ $(call force,CFG_NO_SMP,y)
 $(call force,CFG_PL310,y)
 $(call force,CFG_PL310_LOCKED,y)
 $(call force,CFG_AT91_MATRIX,y)
+$(call force,CFG_DRIVERS_CLK,y)
+$(call force,CFG_DRIVERS_CLK_DT,y)
+$(call force,CFG_DRIVERS_CLK_FIXED,y)
+$(call force,CFG_DRIVERS_SAM_CLK,y)
+$(call force,CFG_DRIVERS_SAMA5D2_CLK,y)
 
 # These values are forced because of matrix configuration for secure area.
 # When modifying these, always update matrix settings in

--- a/core/arch/arm/plat-sam/sam_sfr.h
+++ b/core/arch/arm/plat-sam/sam_sfr.h
@@ -8,10 +8,15 @@
 
 #include <util.h>
 
+/* UTMI Clock Trimming Register */
+#define AT91_SFR_UTMICKTRIM	0x30
 /* L2 cache RAM used as an internal SRAM */
 #define AT91_SFR_L2CC_HRAMC		0x58
 /* I2SC Register */
 #define AT91_SFR_I2SCLKSEL	0x90
+
+/* Field definitions */
+#define AT91_UTMICKTRIM_FREQ			GENMASK_32(1, 0)
 
 vaddr_t sam_sfr_base(void);
 

--- a/core/arch/arm/plat-sam/sam_sfr.h
+++ b/core/arch/arm/plat-sam/sam_sfr.h
@@ -10,6 +10,8 @@
 
 /* L2 cache RAM used as an internal SRAM */
 #define AT91_SFR_L2CC_HRAMC		0x58
+/* I2SC Register */
+#define AT91_SFR_I2SCLKSEL	0x90
 
 vaddr_t sam_sfr_base(void);
 

--- a/core/drivers/clk/sam/at91_audio_pll.c
+++ b/core/drivers/clk/sam/at91_audio_pll.c
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2016 Atmel Corporation,
+ *		       Songjun Wu <songjun.wu@atmel.com>,
+ *		       Nicolas Ferre <nicolas.ferre@atmel.com>
+ *  Copyright (C) 2017 Free Electrons,
+ *		       Quentin Schulz <quentin.schulz@free-electrons.com>
+ *
+ * The Sama5d2 SoC has two audio PLLs (PMC and PAD) that shares the same parent
+ * (FRAC). FRAC can output between 620 and 700MHz and only multiply the rate of
+ * its own parent. PMC and PAD can then divide the FRAC rate to best match the
+ * asked rate.
+ *
+ * Traits of FRAC clock:
+ * enable - clk_enable writes nd, fracr parameters and enables PLL
+ * rate - rate is adjustable.
+ *        clk->rate = parent->rate * ((nd + 1) + (fracr / 2^22))
+ * parent - fixed parent.  No clk_set_parent support
+ *
+ * Traits of PMC clock:
+ * enable - clk_enable writes qdpmc, and enables PMC output
+ * rate - rate is adjustable.
+ *        clk->rate = parent->rate / (qdpmc + 1)
+ * parent - fixed parent.  No clk_set_parent support
+ *
+ * Traits of PAD clock:
+ * enable - clk_enable writes divisors and enables PAD output
+ * rate - rate is adjustable.
+ *        clk->rate = parent->rate / (qdaudio * div))
+ * parent - fixed parent.  No clk_set_parent support
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <string.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define AUDIO_PLL_DIV_FRAC	BIT(22)
+#define AUDIO_PLL_ND_MAX	(AT91_PMC_AUDIO_PLL_ND_MASK >> \
+					AT91_PMC_AUDIO_PLL_ND_OFFSET)
+
+#define AUDIO_PLL_QDPAD(qd, div) \
+				((AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV(qd) & \
+				  AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV_MASK) | \
+				 (AT91_PMC_AUDIO_PLL_QDPAD_DIV(div) & \
+				  AT91_PMC_AUDIO_PLL_QDPAD_DIV_MASK))
+
+#define AUDIO_PLL_QDPMC_MAX		(AT91_PMC_AUDIO_PLL_QDPMC_MASK >> \
+						AT91_PMC_AUDIO_PLL_QDPMC_OFFSET)
+
+#define AUDIO_PLL_FOUT_MIN	620000000UL
+#define AUDIO_PLL_FOUT_MAX	700000000UL
+
+struct clk_audio_frac {
+	vaddr_t base;
+	uint32_t fracr;
+	uint8_t nd;
+};
+
+struct clk_audio_pad {
+	vaddr_t base;
+	uint8_t qdaudio;
+	uint8_t div;
+};
+
+struct clk_audio_pmc {
+	vaddr_t base;
+	uint8_t qdpmc;
+};
+
+static TEE_Result clk_audio_pll_frac_enable(struct clk *clk)
+{
+	struct clk_audio_frac *frac = clk->priv;
+
+	io_clrbits32(frac->base + AT91_PMC_AUDIO_PLL0,
+		     AT91_PMC_AUDIO_PLL_RESETN);
+	io_setbits32(frac->base + AT91_PMC_AUDIO_PLL0,
+		     AT91_PMC_AUDIO_PLL_RESETN);
+	io_clrsetbits32(frac->base + AT91_PMC_AUDIO_PLL1,
+			AT91_PMC_AUDIO_PLL_FRACR_MASK, frac->fracr);
+
+	/*
+	 * reset and enable have to be done in 2 separated writes
+	 * for AT91_PMC_AUDIO_PLL0
+	 */
+	io_clrsetbits32(frac->base + AT91_PMC_AUDIO_PLL0,
+			AT91_PMC_AUDIO_PLL_PLLEN |
+			AT91_PMC_AUDIO_PLL_ND_MASK,
+			AT91_PMC_AUDIO_PLL_PLLEN |
+			AT91_PMC_AUDIO_PLL_ND(frac->nd));
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result clk_audio_pll_pad_enable(struct clk *clk)
+{
+	struct clk_audio_pad *apad_ck = clk->priv;
+
+	io_clrsetbits32(apad_ck->base + AT91_PMC_AUDIO_PLL1,
+			AT91_PMC_AUDIO_PLL_QDPAD_MASK,
+			AUDIO_PLL_QDPAD(apad_ck->qdaudio, apad_ck->div));
+	io_clrsetbits32(apad_ck->base + AT91_PMC_AUDIO_PLL0,
+			AT91_PMC_AUDIO_PLL_PADEN, AT91_PMC_AUDIO_PLL_PADEN);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result clk_audio_pll_pmc_enable(struct clk *clk)
+{
+	struct clk_audio_pmc *apmc_ck = clk->priv;
+
+	io_clrsetbits32(apmc_ck->base + AT91_PMC_AUDIO_PLL0,
+			AT91_PMC_AUDIO_PLL_PMCEN |
+			AT91_PMC_AUDIO_PLL_QDPMC_MASK,
+			AT91_PMC_AUDIO_PLL_PMCEN |
+			AT91_PMC_AUDIO_PLL_QDPMC(apmc_ck->qdpmc));
+	return TEE_SUCCESS;
+}
+
+static void clk_audio_pll_frac_disable(struct clk *clk)
+{
+	struct clk_audio_frac *frac = clk->priv;
+
+	io_clrbits32(frac->base + AT91_PMC_AUDIO_PLL0,
+		     AT91_PMC_AUDIO_PLL_PLLEN);
+	/* Requires 2 separated writes */
+	io_clrbits32(frac->base + AT91_PMC_AUDIO_PLL0,
+		     AT91_PMC_AUDIO_PLL_RESETN);
+}
+
+static void clk_audio_pll_pad_disable(struct clk *clk)
+{
+	struct clk_audio_pad *apad_ck = clk->priv;
+
+	io_clrbits32(apad_ck->base + AT91_PMC_AUDIO_PLL0,
+		     AT91_PMC_AUDIO_PLL_PADEN);
+}
+
+static void clk_audio_pll_pmc_disable(struct clk *clk)
+{
+	struct clk_audio_pmc *apmc_ck = clk->priv;
+
+	io_clrbits32(apmc_ck->base + AT91_PMC_AUDIO_PLL0,
+		     AT91_PMC_AUDIO_PLL_PMCEN);
+}
+
+static unsigned long clk_audio_pll_fout(unsigned long parent_rate,
+					unsigned long nd, unsigned long fracr)
+{
+	unsigned long long fr = (unsigned long long)parent_rate * fracr;
+
+	fr = UDIV_ROUND_NEAREST(fr, AUDIO_PLL_DIV_FRAC);
+
+	return parent_rate * (nd + 1) + fr;
+}
+
+static unsigned long clk_audio_pll_frac_get_rate(struct clk *clk,
+						 unsigned long parent_rate)
+{
+	struct clk_audio_frac *frac = clk->priv;
+
+	return clk_audio_pll_fout(parent_rate, frac->nd, frac->fracr);
+}
+
+static unsigned long clk_audio_pll_pad_get_rate(struct clk *clk,
+						unsigned long parent_rate)
+{
+	struct clk_audio_pad *apad_ck = clk->priv;
+	unsigned long apad_rate = 0;
+
+	if (apad_ck->qdaudio && apad_ck->div)
+		apad_rate = parent_rate / (apad_ck->qdaudio * apad_ck->div);
+
+	return apad_rate;
+}
+
+static unsigned long clk_audio_pll_pmc_get_rate(struct clk *clk,
+						unsigned long parent_rate)
+{
+	struct clk_audio_pmc *apmc_ck = clk->priv;
+
+	return parent_rate / (apmc_ck->qdpmc + 1);
+}
+
+static TEE_Result clk_audio_pll_frac_compute_frac(unsigned long rate,
+						  unsigned long parent_rate,
+						  unsigned long *nd,
+						  unsigned long *fracr)
+{
+	unsigned long long tmp = 0;
+	unsigned long long rem = 0;
+
+	if (!rate || !parent_rate)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	tmp = rate;
+	rem = tmp % parent_rate;
+	tmp /= parent_rate;
+	if (!tmp || tmp >= AUDIO_PLL_ND_MAX)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	*nd = tmp - 1;
+
+	tmp = rem * AUDIO_PLL_DIV_FRAC;
+	tmp = UDIV_ROUND_NEAREST(tmp, parent_rate);
+	if (tmp > AT91_PMC_AUDIO_PLL_FRACR_MASK)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* we can cast here as we verified the bounds just above */
+	*fracr = (unsigned long)tmp;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result clk_audio_pll_frac_set_rate(struct clk *clk,
+					      unsigned long rate,
+					      unsigned long parent_rate)
+{
+	struct clk_audio_frac *frac = clk->priv;
+	unsigned long fracr = 0;
+	unsigned long nd = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (rate < AUDIO_PLL_FOUT_MIN || rate > AUDIO_PLL_FOUT_MAX)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = clk_audio_pll_frac_compute_frac(rate, parent_rate, &nd, &fracr);
+	if (res)
+		return res;
+
+	frac->nd = nd;
+	frac->fracr = fracr;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result clk_audio_pll_pad_set_rate(struct clk *clk,
+					     unsigned long rate,
+					     unsigned long parent_rate)
+{
+	struct clk_audio_pad *apad_ck = clk->priv;
+	uint8_t tmp_div = 1;
+
+	if (!rate)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	tmp_div = parent_rate / rate;
+	if (tmp_div % 3 == 0) {
+		apad_ck->qdaudio = tmp_div / 3;
+		apad_ck->div = 3;
+	} else {
+		apad_ck->qdaudio = tmp_div / 2;
+		apad_ck->div = 2;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result clk_audio_pll_pmc_set_rate(struct clk *clk,
+					     unsigned long rate,
+					     unsigned long parent_rate)
+{
+	struct clk_audio_pmc *apmc_ck = clk->priv;
+
+	if (!rate)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	apmc_ck->qdpmc = parent_rate / rate - 1;
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops audio_pll_frac_ops = {
+	.enable = clk_audio_pll_frac_enable,
+	.disable = clk_audio_pll_frac_disable,
+	.get_rate = clk_audio_pll_frac_get_rate,
+	.set_rate = clk_audio_pll_frac_set_rate,
+};
+
+static const struct clk_ops audio_pll_pad_ops = {
+	.enable = clk_audio_pll_pad_enable,
+	.disable = clk_audio_pll_pad_disable,
+	.get_rate = clk_audio_pll_pad_get_rate,
+	.set_rate = clk_audio_pll_pad_set_rate,
+};
+
+static const struct clk_ops audio_pll_pmc_ops = {
+	.enable = clk_audio_pll_pmc_enable,
+	.disable = clk_audio_pll_pmc_disable,
+	.get_rate = clk_audio_pll_pmc_get_rate,
+	.set_rate = clk_audio_pll_pmc_set_rate,
+};
+
+struct clk *
+at91_clk_register_audio_pll_frac(struct pmc_data *pmc, const char *name,
+				 struct clk *parent)
+{
+	struct clk_audio_frac *frac_ck = NULL;
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &audio_pll_frac_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	frac_ck = calloc(1, sizeof(*frac_ck));
+	if (!frac_ck) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	clk->flags = CLK_SET_RATE_GATE;
+
+	frac_ck->base = pmc->base;
+
+	clk->priv = frac_ck;
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(frac_ck);
+		return NULL;
+	}
+
+	return clk;
+}
+
+struct clk *
+at91_clk_register_audio_pll_pad(struct pmc_data *pmc, const char *name,
+				struct clk *parent)
+{
+	struct clk_audio_pad *apad_ck = NULL;
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &audio_pll_pad_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	apad_ck = calloc(1, sizeof(*apad_ck));
+	if (!apad_ck) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	clk->flags = CLK_SET_RATE_GATE | CLK_SET_PARENT_GATE;
+
+	apad_ck->base = pmc->base;
+
+	clk->priv = apad_ck;
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(apad_ck);
+		return NULL;
+	}
+
+	return clk;
+}
+
+struct clk *
+at91_clk_register_audio_pll_pmc(struct pmc_data *pmc, const char *name,
+				struct clk *parent)
+{
+	struct clk_audio_pmc *apmc_ck = NULL;
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &audio_pll_pmc_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	apmc_ck = calloc(1, sizeof(*apmc_ck));
+	if (!apmc_ck) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	clk->flags = CLK_SET_RATE_GATE | CLK_SET_PARENT_GATE;
+
+	apmc_ck->base = pmc->base;
+
+	clk->priv = apmc_ck;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(apmc_ck);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_clk.h
+++ b/core/drivers/clk/sam/at91_clk.h
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause */
+/*
+ * include/linux/clk/at91_pmc.h
+ *
+ * Copyright (C) 2005 Ivan Kokshaysky
+ * Copyright (C) SAN People
+ * Copyright (C) 2021 Microchip
+ *
+ * Power Management Controller (PMC) - System peripherals registers.
+ * Based on AT91RM9200 datasheet revision E.
+ */
+
+#ifndef AT91_CLK_H
+#define AT91_CLK_H
+
+#include <drivers/clk.h>
+#include <drivers/clk_dt.h>
+
+#include "at91_pmc.h"
+
+#define ffs(x)	__builtin_ffs(x)
+
+#define field_get(_mask, _reg) \
+	({ \
+		typeof(_mask) __mask = _mask; \
+		\
+		(((_reg) & (__mask)) >> (ffs(__mask) - 1)); \
+	})
+#define field_prep(_mask, _val)  \
+	({ \
+		typeof(_mask) __mask = _mask; \
+		\
+		(((_val) << (ffs(__mask) - 1)) & (__mask)); \
+	})
+
+struct clk_range {
+	unsigned long min;
+	unsigned long max;
+};
+
+#define CLK_RANGE(MIN, MAX) {.min = MIN, .max = MAX,}
+
+struct pmc_clk {
+	struct clk *clk;
+	uint8_t id;
+};
+
+struct pmc_data {
+	vaddr_t base;
+	unsigned int ncore;
+	struct pmc_clk *chws;
+	unsigned int nsystem;
+	struct pmc_clk *shws;
+	unsigned int nperiph;
+	struct pmc_clk *phws;
+	unsigned int ngck;
+	struct pmc_clk *ghws;
+	unsigned int npck;
+	struct pmc_clk *pchws;
+
+	struct pmc_clk hwtable[];
+};
+
+/* PLL */
+struct clk_pll_layout {
+	uint32_t pllr_mask;
+	uint32_t mul_mask;
+	uint32_t frac_mask;
+	uint32_t div_mask;
+	uint32_t endiv_mask;
+	uint8_t mul_shift;
+	uint8_t frac_shift;
+	uint8_t div_shift;
+	uint8_t endiv_shift;
+};
+
+struct clk_pcr_layout {
+	uint32_t offset;
+	uint32_t cmd;
+	uint32_t div_mask;
+	uint32_t gckcss_mask;
+	uint32_t pid_mask;
+};
+
+struct clk_pll_charac {
+	struct clk_range input;
+	int num_output;
+	const struct clk_range *output;
+	uint16_t *icpll;
+	uint8_t *out;
+	uint8_t upll : 1;
+};
+
+extern const struct clk_pll_layout sama5d3_pll_layout;
+
+/* Master */
+struct clk_master_charac {
+	struct clk_range output;
+	uint32_t divisors[5];
+	uint8_t have_div3_pres;
+};
+
+struct clk_master_layout {
+	uint32_t offset;
+	uint32_t mask;
+	uint8_t pres_shift;
+};
+
+struct clk_programmable_layout {
+	uint8_t pres_mask;
+	uint8_t pres_shift;
+	uint8_t css_mask;
+	uint8_t have_slck_mck;
+	uint8_t is_pres_direct;
+};
+
+extern const struct clk_master_layout at91sam9x5_master_layout;
+
+struct pmc_data *pmc_data_allocate(unsigned int ncore, unsigned int nsystem,
+				   unsigned int nperiph, unsigned int ngck,
+				   unsigned int npck);
+
+struct clk *clk_dt_pmc_get(struct dt_driver_phandle_args *args, void *data,
+			   TEE_Result *res);
+
+struct clk *pmc_clk_get_by_name(struct pmc_clk *clks, unsigned int nclk,
+				const char *name);
+
+/* Main clock */
+struct clk *pmc_register_main_rc_osc(struct pmc_data *pmc, const char *name,
+				     unsigned long freq);
+
+struct clk *pmc_register_main_osc(struct pmc_data *pmc, const char *name,
+				  struct clk *parent, bool bypass);
+
+struct clk *at91_clk_register_sam9x5_main(struct pmc_data *pmc,
+					  const char *name,
+					  struct clk **parent_clocks,
+					  unsigned int num_parents);
+
+/* PLL */
+struct clk *
+at91_clk_register_pll(struct pmc_data *pmc, const char *name,
+		      struct clk *parent, uint8_t id,
+		      const struct clk_pll_layout *layout,
+		      const struct clk_pll_charac *charac);
+
+struct clk *
+at91_clk_register_plldiv(struct pmc_data *pmc, const char *name,
+			 struct clk *parent);
+
+/* UTMI */
+struct clk *
+at91_clk_register_utmi(struct pmc_data *pmc, const char *name,
+		       struct clk *parent);
+
+/* Master */
+struct clk *
+at91_clk_register_master_pres(struct pmc_data *pmc,
+			      const char *name, int num_parents,
+			      struct clk **parents,
+			      const struct clk_master_layout *layout,
+			      const struct clk_master_charac *charac,
+			      int chg_pid);
+
+struct clk *
+at91_clk_register_master_div(struct pmc_data *pmc,
+			     const char *name, struct clk *parent,
+			     const struct clk_master_layout *layout,
+			     const struct clk_master_charac *charac);
+
+/* H32MX */
+struct clk *
+at91_clk_register_h32mx(struct pmc_data *pmc, const char *name,
+			struct clk *parent);
+
+/* USB */
+struct clk *
+at91sam9x5_clk_register_usb(struct pmc_data *pmc, const char *name,
+			    struct clk **parents, uint8_t num_parents);
+
+/* Programmable */
+struct clk *
+at91_clk_register_programmable(struct pmc_data *pmc,
+			       const char *name, struct clk **parents,
+			       uint8_t num_parents, uint8_t id,
+			       const struct clk_programmable_layout *layout);
+
+struct clk *
+at91_clk_register_system(struct pmc_data *pmc, const char *name,
+			 struct clk *parent, uint8_t id);
+
+struct clk *
+at91_clk_register_sam9x5_periph(struct pmc_data *pmc,
+				const struct clk_pcr_layout *layout,
+				const char *name, struct clk *parent,
+				uint32_t id, const struct clk_range *range);
+
+struct clk *
+at91_clk_register_generated(struct pmc_data *pmc,
+			    const struct clk_pcr_layout *layout,
+			    const char *name, struct clk **parents,
+			    uint8_t num_parents, uint8_t id,
+			    const struct clk_range *range,
+			    int chg_pid);
+
+struct clk *
+at91_clk_i2s_mux_register(const char *name, struct clk **parents,
+			  unsigned int num_parents, uint8_t bus_id);
+
+/* Audio PLL */
+struct clk *
+at91_clk_register_audio_pll_frac(struct pmc_data *pmc, const char *name,
+				 struct clk *parent);
+
+struct clk *
+at91_clk_register_audio_pll_pad(struct pmc_data *pmc, const char *name,
+				struct clk *parent);
+
+struct clk *
+at91_clk_register_audio_pll_pmc(struct pmc_data *pmc, const char *name,
+				struct clk *parent);
+
+#endif

--- a/core/drivers/clk/sam/at91_generated.c
+++ b/core/drivers/clk/sam/at91_generated.c
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2015 - 2021 Atmel Corporation,
+ *                            Nicolas Ferre <nicolas.ferre@atmel.com>
+ *
+ * Based on clk-programmable & clk-peripheral drivers by Boris BREZILLON.
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <string.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define GENERATED_MAX_DIV	255
+
+struct clk_generated {
+	vaddr_t base;
+	struct clk_range range;
+	uint32_t *mux_table;
+	uint32_t id;
+	uint32_t gckdiv;
+	const struct clk_pcr_layout *layout;
+	uint8_t parent_id;
+	int chg_pid;
+};
+
+static TEE_Result clk_generated_enable(struct clk *clk)
+{
+	struct clk_generated *gck = clk->priv;
+
+	io_write32(gck->base + gck->layout->offset,
+		   (gck->id & gck->layout->pid_mask));
+	io_clrsetbits32(gck->base + gck->layout->offset,
+			AT91_PMC_PCR_GCKDIV_MASK | gck->layout->gckcss_mask |
+			gck->layout->cmd | AT91_PMC_PCR_GCKEN,
+			field_prep(gck->layout->gckcss_mask, gck->parent_id) |
+			gck->layout->cmd |
+			((gck->gckdiv << AT91_PMC_PCR_GCKDIV_SHIFT) &
+			 AT91_PMC_PCR_GCKDIV_MASK) |
+			AT91_PMC_PCR_GCKEN);
+
+	return TEE_SUCCESS;
+}
+
+static void clk_generated_disable(struct clk *clk)
+{
+	struct clk_generated *gck = clk->priv;
+
+	io_write32(gck->base + gck->layout->offset,
+		   gck->id & gck->layout->pid_mask);
+	io_clrsetbits32(gck->base + gck->layout->offset, AT91_PMC_PCR_GCKEN,
+			gck->layout->cmd);
+}
+
+static unsigned long
+clk_generated_get_rate(struct clk *clk, unsigned long parent_rate)
+{
+	struct clk_generated *gck = clk->priv;
+
+	return UDIV_ROUND_NEAREST(parent_rate, gck->gckdiv + 1);
+}
+
+/* No modification of hardware as we have the flag CLK_SET_PARENT_GATE set */
+static TEE_Result clk_generated_set_parent(struct clk *clk, size_t index)
+{
+	struct clk_generated *gck = clk->priv;
+
+	if (index >= clk_get_num_parents(clk))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	gck->parent_id = index;
+
+	return TEE_SUCCESS;
+}
+
+static size_t clk_generated_get_parent(struct clk *clk)
+{
+	struct clk_generated *gck = clk->priv;
+
+	return gck->parent_id;
+}
+
+/* No modification of hardware as we have the flag CLK_SET_RATE_GATE set */
+static TEE_Result clk_generated_set_rate(struct clk *clk, unsigned long rate,
+					 unsigned long parent_rate)
+{
+	struct clk_generated *gck = clk->priv;
+	uint32_t div = 1;
+
+	if (!rate)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (gck->range.max && rate > gck->range.max)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	div = UDIV_ROUND_NEAREST(parent_rate, rate);
+	if (div > GENERATED_MAX_DIV + 1 || !div)
+		return TEE_ERROR_GENERIC;
+
+	gck->gckdiv = div - 1;
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops generated_ops = {
+	.enable = clk_generated_enable,
+	.disable = clk_generated_disable,
+	.get_rate = clk_generated_get_rate,
+	.get_parent = clk_generated_get_parent,
+	.set_parent = clk_generated_set_parent,
+	.set_rate = clk_generated_set_rate,
+};
+
+/**
+ * clk_generated_startup - Initialize a given clock to its default parent and
+ * divisor parameter.
+ *
+ * @gck:	Generated clock to set the startup parameters for.
+ *
+ * Take parameters from the hardware and update local clock configuration
+ * accordingly.
+ */
+static void clk_generated_startup(struct clk_generated *gck)
+{
+	uint32_t tmp = 0;
+
+	io_write32(gck->base + gck->layout->offset,
+		   (gck->id & gck->layout->pid_mask));
+	tmp = io_read32(gck->base + gck->layout->offset);
+
+	gck->parent_id = field_get(gck->layout->gckcss_mask, tmp);
+	gck->gckdiv = (tmp & AT91_PMC_PCR_GCKDIV_MASK) >>
+		      AT91_PMC_PCR_GCKDIV_SHIFT;
+}
+
+struct clk *
+at91_clk_register_generated(struct pmc_data *pmc,
+			    const struct clk_pcr_layout *layout,
+			    const char *name, struct clk **parents,
+			    uint8_t num_parents, uint8_t id,
+			    const struct clk_range *range,
+			    int chg_pid)
+{
+	struct clk_generated *gck = NULL;
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &generated_ops, parents, num_parents);
+	if (!clk)
+		return NULL;
+
+	gck = calloc(1, sizeof(*gck));
+	if (!gck) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	clk->flags = CLK_SET_RATE_GATE | CLK_SET_PARENT_GATE;
+
+	gck->id = id;
+	gck->base = pmc->base;
+	memcpy(&gck->range, range, sizeof(gck->range));
+	gck->chg_pid = chg_pid;
+	gck->layout = layout;
+
+	clk->priv = gck;
+
+	clk_generated_startup(gck);
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(gck);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_h32mx.c
+++ b/core/drivers/clk/sam/at91_h32mx.c
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2014 Atmel
+ *
+ * Alexandre Belloni <alexandre.belloni@free-electrons.com>
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define H32MX_MAX_FREQ	90000000
+
+static unsigned long clk_sama5d4_h32mx_get_rate(struct clk *clk,
+						unsigned long parent_rate)
+{
+	struct pmc_data *pmc = clk->priv;
+	unsigned int mckr = io_read32(pmc->base + AT91_PMC_MCKR);
+
+	if (mckr & AT91_PMC_H32MXDIV)
+		return parent_rate / 2;
+
+	if (parent_rate > H32MX_MAX_FREQ)
+		IMSG("H32MX clock is too fast");
+
+	return parent_rate;
+}
+
+static TEE_Result clk_sama5d4_h32mx_set_rate(struct clk *clk,
+					     unsigned long rate,
+					     unsigned long parent_rate)
+{
+	struct pmc_data *pmc = clk->priv;
+	uint32_t mckr = 0;
+
+	if (parent_rate != rate && (parent_rate / 2) != rate)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if ((parent_rate / 2) == rate)
+		mckr = AT91_PMC_H32MXDIV;
+
+	io_clrsetbits32(pmc->base + AT91_PMC_MCKR, AT91_PMC_H32MXDIV, mckr);
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops h32mx_ops = {
+	.get_rate = clk_sama5d4_h32mx_get_rate,
+	.set_rate = clk_sama5d4_h32mx_set_rate,
+};
+
+struct clk *
+at91_clk_register_h32mx(struct pmc_data *pmc, const char *name,
+			struct clk *parent)
+{
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &h32mx_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	clk->ops = &h32mx_ops;
+	clk->priv = pmc;
+	clk->name = name;
+	clk->flags = CLK_SET_RATE_GATE;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_i2s_mux.c
+++ b/core/drivers/clk/sam/at91_i2s_mux.c
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2018 Microchip Technology Inc,
+ *                     Codrin Ciubotariu <codrin.ciubotariu@microchip.com>
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <sam_sfr.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+struct clk_i2s_mux {
+	vaddr_t sfr_base;
+	uint8_t bus_id;
+};
+
+static size_t clk_i2s_mux_get_parent(struct clk *clk)
+{
+	struct clk_i2s_mux *mux = clk->priv;
+	uint32_t val = io_read32(mux->sfr_base + AT91_SFR_I2SCLKSEL);
+
+	return (val & BIT(mux->bus_id)) >> mux->bus_id;
+}
+
+static TEE_Result clk_i2s_mux_set_parent(struct clk *clk, size_t index)
+{
+	struct clk_i2s_mux *mux = clk->priv;
+
+	io_clrsetbits32(mux->sfr_base + AT91_SFR_I2SCLKSEL,
+			BIT(mux->bus_id), index << mux->bus_id);
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops clk_i2s_mux_ops = {
+	.get_parent = clk_i2s_mux_get_parent,
+	.set_parent = clk_i2s_mux_set_parent,
+};
+
+struct clk *
+at91_clk_i2s_mux_register(const char *name, struct clk **parents,
+			  unsigned int num_parents, uint8_t bus_id)
+{
+	struct clk_i2s_mux *i2s_ck = NULL;
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &clk_i2s_mux_ops, parents, num_parents);
+	if (!clk)
+		return NULL;
+
+	i2s_ck = calloc(1, sizeof(*i2s_ck));
+	if (!i2s_ck) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	i2s_ck->bus_id = bus_id;
+	i2s_ck->sfr_base = sam_sfr_base();
+
+	clk->priv = i2s_ck;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(i2s_ck);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_main.c
+++ b/core/drivers/clk/sam/at91_main.c
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define SLOW_CLOCK_FREQ		32768
+#define MAINF_DIV		16
+#define USEC_PER_SEC		1000000L
+#define MAINF_LOOP_MIN_WAIT	(USEC_PER_SEC / SLOW_CLOCK_FREQ)
+
+#define OSC_READY_TIMEOUT_US	1000
+
+#define MOR_KEY_MASK		(0xFF << 16)
+
+#define CLK_MAIN_PARENT_SELECT(s)	(((s) & \
+					(AT91_PMC_MOSCEN | \
+					AT91_PMC_OSCBYPASS)) ? 1 : 0)
+
+/*
+ * Main RC Oscillator
+ */
+
+struct main_rc_osc {
+	unsigned long freq;
+	vaddr_t base;
+};
+
+static bool pmc_main_rc_osc_ready(struct main_rc_osc *osc)
+{
+	uint32_t status = io_read32(osc->base + AT91_PMC_SR);
+
+	return status & AT91_PMC_MOSCRCS;
+}
+
+static TEE_Result pmc_main_rc_osc_enable(struct clk *clk)
+{
+	struct main_rc_osc *osc = clk->priv;
+	uint32_t mor = io_read32(osc->base + AT91_CKGR_MOR);
+
+	/* Enable the oscillator if not */
+	if (!(mor & AT91_PMC_MOSCRCEN)) {
+		io_clrsetbits32(osc->base + AT91_CKGR_MOR,
+				MOR_KEY_MASK | AT91_PMC_MOSCRCEN,
+				AT91_PMC_MOSCRCEN | AT91_PMC_KEY);
+	}
+
+	while (!pmc_main_rc_osc_ready(osc))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static void pmc_main_rc_osc_disable(struct clk *clk)
+{
+	struct main_rc_osc *osc = clk->priv;
+	uint32_t mor = io_read32(osc->base + AT91_CKGR_MOR);
+
+	if (!(mor & AT91_PMC_MOSCRCEN))
+		return;
+
+	io_clrsetbits32(osc->base + AT91_CKGR_MOR,
+			MOR_KEY_MASK | AT91_PMC_MOSCRCEN, AT91_PMC_KEY);
+}
+
+static unsigned long
+pmc_main_rc_osc_get_rate(struct clk *clk, unsigned long parent_rate __unused)
+{
+	struct main_rc_osc *osc = clk->priv;
+
+	return osc->freq;
+}
+
+static const struct clk_ops pmc_main_rc_osc_clk_ops = {
+	.enable = pmc_main_rc_osc_enable,
+	.disable = pmc_main_rc_osc_disable,
+	.get_rate = pmc_main_rc_osc_get_rate,
+};
+
+struct clk *pmc_register_main_rc_osc(struct pmc_data *pmc, const char *name,
+				     unsigned long freq)
+{
+	struct clk *clk = NULL;
+	struct main_rc_osc *osc = NULL;
+
+	clk = clk_alloc(name, &pmc_main_rc_osc_clk_ops, NULL, 0);
+	if (!clk)
+		return NULL;
+
+	osc = calloc(1, sizeof(*osc));
+	if (!osc) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	osc->freq = freq;
+	osc->base = pmc->base;
+
+	clk->priv = osc;
+
+	if (clk_register(clk)) {
+		free(osc);
+		clk_free(clk);
+		return NULL;
+	}
+
+	return clk;
+}
+
+/*
+ * Main Oscillator
+ */
+static bool pmc_main_osc_ready(struct pmc_data *pmc)
+{
+	uint32_t status = io_read32(pmc->base + AT91_PMC_SR);
+
+	return status & AT91_PMC_MOSCS;
+}
+
+static TEE_Result pmc_main_osc_enable(struct clk *clk)
+{
+	struct pmc_data *pmc = clk->priv;
+	uint32_t mor = io_read32(pmc->base + AT91_CKGR_MOR);
+
+	mor &= ~MOR_KEY_MASK;
+
+	if (mor & AT91_PMC_OSCBYPASS)
+		return TEE_SUCCESS;
+
+	if (!(mor & AT91_PMC_MOSCEN)) {
+		mor |= AT91_PMC_MOSCEN | AT91_PMC_KEY;
+		io_write32(pmc->base + AT91_CKGR_MOR, mor);
+	}
+
+	while (!pmc_main_osc_ready(pmc))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static void pmc_main_osc_disable(struct clk *clk)
+{
+	struct pmc_data *pmc = clk->priv;
+	uint32_t mor = io_read32(pmc->base + AT91_CKGR_MOR);
+
+	if (mor & AT91_PMC_OSCBYPASS)
+		return;
+
+	if (!(mor & AT91_PMC_MOSCEN))
+		return;
+
+	mor &= ~(AT91_PMC_KEY | AT91_PMC_MOSCEN);
+	io_write32(pmc->base + AT91_CKGR_MOR, mor | AT91_PMC_KEY);
+}
+
+static const struct clk_ops pmc_main_osc_clk_ops = {
+	.enable = pmc_main_osc_enable,
+	.disable = pmc_main_osc_disable,
+};
+
+struct clk *pmc_register_main_osc(struct pmc_data *pmc, const char *name,
+				  struct clk *parent, bool bypass)
+{
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &pmc_main_osc_clk_ops, &parent, 1);
+	if (!clk)
+		panic();
+
+	clk->priv = pmc;
+
+	if (bypass)
+		io_clrsetbits32(pmc->base + AT91_CKGR_MOR,
+				MOR_KEY_MASK | AT91_PMC_OSCBYPASS,
+				AT91_PMC_OSCBYPASS | AT91_PMC_KEY);
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	return clk;
+}
+
+/*
+ * Main Clock
+ */
+static TEE_Result clk_main_probe_frequency(vaddr_t base)
+{
+	while (!(io_read32(base + AT91_CKGR_MCFR) & AT91_PMC_MAINRDY))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static unsigned long clk_main_get_rate(vaddr_t base,
+				       unsigned long parent_rate)
+{
+	uint32_t mcfr = 0;
+
+	if (parent_rate)
+		return parent_rate;
+
+	IMSG("Main crystal frequency not set, using approximate value");
+	mcfr = io_read32(base + AT91_CKGR_MCFR);
+	if (!(mcfr & AT91_PMC_MAINRDY))
+		return 0;
+
+	return ((mcfr & AT91_PMC_MAINF) * SLOW_CLOCK_FREQ) / MAINF_DIV;
+}
+
+static bool clk_sam9x5_main_ready(vaddr_t base)
+{
+	uint32_t status = io_read32(base + AT91_PMC_SR);
+
+	return status & AT91_PMC_MOSCSELS;
+}
+
+static TEE_Result clk_sam9x5_main_enable(struct clk *clk)
+{
+	struct pmc_data *pmc = clk->priv;
+
+	while (!clk_sam9x5_main_ready(pmc->base))
+		;
+
+	return clk_main_probe_frequency(pmc->base);
+}
+
+static unsigned long clk_sam9x5_main_get_rate(struct clk *clk,
+					      unsigned long parent_rate)
+{
+	struct pmc_data *pmc = clk->priv;
+
+	return clk_main_get_rate(pmc->base, parent_rate);
+}
+
+static TEE_Result clk_sam9x5_main_set_parent(struct clk *clk, size_t index)
+{
+	struct pmc_data *pmc = clk->priv;
+	uint32_t tmp = 0;
+
+	if (index > 1)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	tmp = io_read32(pmc->base + AT91_CKGR_MOR);
+
+	if (index && !(tmp & AT91_PMC_MOSCSEL))
+		tmp = AT91_PMC_MOSCSEL;
+	else if (!index && (tmp & AT91_PMC_MOSCSEL))
+		tmp = 0;
+	else
+		return TEE_SUCCESS;
+
+	io_clrsetbits32(pmc->base + AT91_CKGR_MOR,
+			AT91_PMC_MOSCSEL | MOR_KEY_MASK,
+			tmp | AT91_PMC_KEY);
+
+	while (!clk_sam9x5_main_ready(pmc->base))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static size_t clk_sam9x5_main_get_parent(struct clk *clk)
+{
+	struct pmc_data *pmc = clk->priv;
+	uint32_t status = io_read32(pmc->base + AT91_CKGR_MOR);
+
+	return CLK_MAIN_PARENT_SELECT(status);
+}
+
+static const struct clk_ops sam9x5_main_ops = {
+	.enable = clk_sam9x5_main_enable,
+	.get_rate = clk_sam9x5_main_get_rate,
+	.set_parent = clk_sam9x5_main_set_parent,
+	.get_parent = clk_sam9x5_main_get_parent,
+};
+
+struct clk *
+at91_clk_register_sam9x5_main(struct pmc_data *pmc,
+			      const char *name,
+			      struct clk **parent_clocks,
+			      unsigned int num_parents)
+{
+	struct clk *clk = NULL;
+
+	if (!name)
+		return NULL;
+
+	if (!parent_clocks || !num_parents)
+		return NULL;
+
+	clk = clk_alloc(name, &sam9x5_main_ops, parent_clocks, num_parents);
+	if (!clk)
+		return NULL;
+
+	clk->flags = CLK_SET_PARENT_GATE;
+	clk->priv = pmc;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_master.c
+++ b/core/drivers/clk/sam/at91_master.c
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define MASTER_PRES_MASK	0x7
+#define MASTER_PRES_MAX		MASTER_PRES_MASK
+#define MASTER_DIV_SHIFT	8
+#define MASTER_DIV_MASK		0x7
+
+struct clk_master {
+	vaddr_t base;
+	const struct clk_master_layout *layout;
+	const struct clk_master_charac *charac;
+	uint32_t *mux_table;
+	uint32_t mckr;
+	int chg_pid;
+	uint8_t div;
+};
+
+static bool clk_master_ready(struct clk_master *master)
+{
+	uint32_t status = io_read32(master->base + AT91_PMC_SR);
+
+	return status & AT91_PMC_MCKRDY;
+}
+
+static TEE_Result clk_master_enable(struct clk *clk)
+{
+	struct clk_master *master = clk->priv;
+
+	while (!clk_master_ready(master))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static unsigned long clk_master_div_get_rate(struct clk *clk,
+					     unsigned long parent_rate)
+{
+	uint8_t div = 1;
+	uint32_t mckr = 0;
+	unsigned long rate = parent_rate;
+	struct clk_master *master = clk->priv;
+	const struct clk_master_layout *layout = master->layout;
+	const struct clk_master_charac *charac = master->charac;
+
+	mckr = io_read32(master->base + master->layout->offset);
+
+	mckr &= layout->mask;
+
+	div = (mckr >> MASTER_DIV_SHIFT) & MASTER_DIV_MASK;
+
+	rate /= charac->divisors[div];
+
+	if (rate < charac->output.min)
+		IMSG("master clk div is underclocked");
+	else if (rate > charac->output.max)
+		IMSG("master clk div is overclocked");
+
+	return rate;
+}
+
+static const struct clk_ops master_div_ops = {
+	.enable = clk_master_enable,
+	.get_rate = clk_master_div_get_rate,
+};
+
+static unsigned long clk_master_pres_get_rate(struct clk *clk,
+					      unsigned long parent_rate)
+{
+	struct clk_master *master = clk->priv;
+	const struct clk_master_charac *charac = master->charac;
+	uint32_t val = 0;
+	unsigned int pres = 0;
+
+	val = io_read32(master->base + master->layout->offset);
+
+	pres = (val >> master->layout->pres_shift) & MASTER_PRES_MASK;
+	if (pres != 3 || !charac->have_div3_pres)
+		pres = BIT(pres);
+
+	return UDIV_ROUND_NEAREST(parent_rate, pres);
+}
+
+static size_t clk_master_pres_get_parent(struct clk *clk)
+{
+	struct clk_master *master = clk->priv;
+	uint32_t mckr = 0;
+
+	mckr = io_read32(master->base + master->layout->offset);
+
+	return mckr & AT91_PMC_CSS;
+}
+
+static const struct clk_ops master_pres_ops = {
+	.enable = clk_master_enable,
+	.get_rate = clk_master_pres_get_rate,
+	.get_parent = clk_master_pres_get_parent,
+};
+
+static struct clk *
+at91_clk_register_master_internal(struct pmc_data *pmc,
+				  const char *name, int num_parents,
+				  struct clk **parents,
+				  const struct clk_master_layout *layout,
+				  const struct clk_master_charac *charac,
+				  const struct clk_ops *ops, int chg_pid)
+{
+	struct clk_master *master = NULL;
+	struct clk *clk = NULL;
+
+	if (!name || !num_parents || !parents)
+		return NULL;
+
+	clk = clk_alloc(name, ops, parents, num_parents);
+	if (!clk)
+		return NULL;
+
+	master = calloc(1, sizeof(*master));
+	if (!master) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	master->layout = layout;
+	master->charac = charac;
+	master->base = pmc->base;
+	master->chg_pid = chg_pid;
+
+	clk->priv = master;
+	clk->flags = CLK_SET_RATE_GATE;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(master);
+		return NULL;
+	}
+
+	return clk;
+}
+
+struct clk *
+at91_clk_register_master_pres(struct pmc_data *pmc,
+			      const char *name, int num_parents,
+			      struct clk **parents,
+			      const struct clk_master_layout *layout,
+			      const struct clk_master_charac *charac,
+			      int chg_pid)
+{
+	return at91_clk_register_master_internal(pmc, name, num_parents,
+						 parents, layout,
+						 charac,
+						 &master_pres_ops, chg_pid);
+}
+
+struct clk *
+at91_clk_register_master_div(struct pmc_data *pmc,
+			     const char *name, struct clk *parent,
+			     const struct clk_master_layout *layout,
+			     const struct clk_master_charac *charac)
+{
+	return at91_clk_register_master_internal(pmc, name, 1,
+						 &parent, layout,
+						 charac,
+						 &master_div_ops, -1);
+}
+
+const struct clk_master_layout at91sam9x5_master_layout = {
+	.mask = 0x373,
+	.pres_shift = 4,
+	.offset = AT91_PMC_MCKR,
+};

--- a/core/drivers/clk/sam/at91_peripheral.c
+++ b/core/drivers/clk/sam/at91_peripheral.c
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define PERIPHERAL_ID_MIN	2
+#define PERIPHERAL_ID_MASK	31
+#define PERIPHERAL_MASK(id)	BIT((id) & PERIPHERAL_ID_MASK)
+
+#define PERIPHERAL_MAX_SHIFT	3
+
+struct clk_sam9x5_peripheral {
+	vaddr_t base;
+	struct clk_range range;
+	uint32_t id;
+	uint32_t div;
+	const struct clk_pcr_layout *layout;
+	bool auto_div;
+};
+
+static void clk_sam9x5_peripheral_autodiv(struct clk *clk)
+{
+	struct clk *parent = NULL;
+	struct clk_sam9x5_peripheral *periph = clk->priv;
+	unsigned long parent_rate = 0;
+	int shift = 0;
+
+	if (!periph->auto_div)
+		return;
+
+	if (periph->range.max) {
+		parent = clk_get_parent_by_index(clk, 0);
+		parent_rate = clk_get_rate(parent);
+		if (!parent_rate)
+			return;
+
+		for (shift = 0; shift < PERIPHERAL_MAX_SHIFT; shift++) {
+			if (parent_rate >> shift <= periph->range.max)
+				break;
+		}
+	}
+
+	periph->auto_div = false;
+	periph->div = shift;
+}
+
+static TEE_Result clk_sam9x5_peripheral_enable(struct clk *clk)
+{
+	struct clk_sam9x5_peripheral *periph = clk->priv;
+
+	if (periph->id < PERIPHERAL_ID_MIN)
+		return TEE_SUCCESS;
+
+	io_write32(periph->base + periph->layout->offset,
+		   (periph->id & periph->layout->pid_mask));
+	io_clrsetbits32(periph->base + periph->layout->offset,
+			periph->layout->div_mask | periph->layout->cmd |
+			AT91_PMC_PCR_EN,
+			field_prep(periph->layout->div_mask, periph->div) |
+			periph->layout->cmd |
+			AT91_PMC_PCR_EN);
+
+	return TEE_SUCCESS;
+}
+
+static void clk_sam9x5_peripheral_disable(struct clk *clk)
+{
+	struct clk_sam9x5_peripheral *periph = clk->priv;
+
+	if (periph->id < PERIPHERAL_ID_MIN)
+		return;
+
+	io_write32(periph->base + periph->layout->offset,
+		   (periph->id & periph->layout->pid_mask));
+	io_clrsetbits32(periph->base + periph->layout->offset,
+			AT91_PMC_PCR_EN | periph->layout->cmd,
+			periph->layout->cmd);
+}
+
+static unsigned long
+clk_sam9x5_peripheral_get_rate(struct clk *clk,
+			       unsigned long parent_rate)
+{
+	struct clk_sam9x5_peripheral *periph = clk->priv;
+	uint32_t status = 0;
+
+	if (periph->id < PERIPHERAL_ID_MIN)
+		return parent_rate;
+
+	io_write32(periph->base + periph->layout->offset,
+		   periph->id & periph->layout->pid_mask);
+	status = io_read32(periph->base + periph->layout->offset);
+
+	if (status & AT91_PMC_PCR_EN) {
+		periph->div = field_get(periph->layout->div_mask, status);
+		periph->auto_div = false;
+	} else {
+		clk_sam9x5_peripheral_autodiv(clk);
+	}
+
+	return parent_rate >> periph->div;
+}
+
+static TEE_Result clk_sam9x5_peripheral_set_rate(struct clk *clk,
+						 unsigned long rate,
+						 unsigned long parent_rate)
+{
+	unsigned int shift = 0;
+	struct clk_sam9x5_peripheral *periph = clk->priv;
+
+	if (periph->id < PERIPHERAL_ID_MIN || !periph->range.max) {
+		if (parent_rate == rate)
+			return TEE_SUCCESS;
+		else
+			return TEE_ERROR_GENERIC;
+	}
+
+	if (periph->range.max && rate > periph->range.max)
+		return TEE_ERROR_GENERIC;
+
+	for (shift = 0; shift <= PERIPHERAL_MAX_SHIFT; shift++) {
+		if (parent_rate >> shift == rate) {
+			periph->auto_div = false;
+			periph->div = shift;
+			return TEE_SUCCESS;
+		}
+	}
+
+	return TEE_ERROR_GENERIC;
+}
+
+static const struct clk_ops sam9x5_peripheral_ops = {
+	.enable = clk_sam9x5_peripheral_enable,
+	.disable = clk_sam9x5_peripheral_disable,
+	.get_rate = clk_sam9x5_peripheral_get_rate,
+	.set_rate = clk_sam9x5_peripheral_set_rate,
+};
+
+struct clk *
+at91_clk_register_sam9x5_periph(struct pmc_data *pmc,
+				const struct clk_pcr_layout *layout,
+				const char *name, struct clk *parent,
+				uint32_t id, const struct clk_range *range)
+{
+	struct clk_sam9x5_peripheral *periph = NULL;
+	struct clk *clk = NULL;
+
+	if (!name || !parent)
+		return NULL;
+
+	clk = clk_alloc(name, &sam9x5_peripheral_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	periph = calloc(1, sizeof(*periph));
+	if (!periph) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	periph->id = id;
+	periph->div = 0;
+	periph->base = pmc->base;
+	if (layout->div_mask)
+		periph->auto_div = true;
+	periph->layout = layout;
+	periph->range = *range;
+
+	clk->priv = periph;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(periph);
+		return 0;
+	}
+
+	clk_sam9x5_peripheral_autodiv(clk);
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_pll.c
+++ b/core/drivers/clk/sam/at91_pll.c
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <util.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define PLL_STATUS_MASK(id)	BIT(1 + (id))
+#define PLL_REG(id)		(AT91_CKGR_PLLAR + ((id) * 4))
+#define PLL_DIV_MASK		0xff
+#define PLL_DIV_MAX		PLL_DIV_MASK
+#define PLL_DIV(reg)		((reg) & PLL_DIV_MASK)
+#define PLL_MUL(reg, layout) \
+	({ \
+		typeof(layout) __layout = layout; \
+		\
+		(((reg) >> (__layout)->mul_shift) & (__layout)->mul_mask); \
+	})
+#define PLL_MUL_MIN		2
+#define PLL_MUL_MASK(layout)	((layout)->mul_mask)
+#define PLL_MUL_MAX(layout)	(PLL_MUL_MASK(layout) + 1)
+#define PLL_ICPR_SHIFT(id)	((id) * 16)
+#define PLL_ICPR_MASK(id)	(0xffff << PLL_ICPR_SHIFT(id))
+#define PLL_MAX_COUNT		0x3f
+#define PLL_COUNT_SHIFT		8
+#define PLL_OUT_SHIFT		14
+#define PLL_MAX_ID		1
+
+struct clk_pll {
+	vaddr_t base;
+	uint8_t id;
+	uint8_t div;
+	uint8_t range;
+	uint16_t mul;
+	const struct clk_pll_layout *layout;
+	const struct clk_pll_charac *charac;
+};
+
+static bool clk_pll_ready(vaddr_t base, int id)
+{
+	unsigned int status = io_read32(base + AT91_PMC_SR);
+
+	return status & PLL_STATUS_MASK(id);
+}
+
+static TEE_Result clk_pll_enable(struct clk *clk)
+{
+	struct clk_pll *pll = clk->priv;
+	const struct clk_pll_layout *layout = pll->layout;
+	const struct clk_pll_charac *charac = pll->charac;
+	uint8_t id = pll->id;
+	uint32_t mask = PLL_STATUS_MASK(id);
+	int offset = PLL_REG(id);
+	uint8_t out = 0;
+	unsigned int pllr = 0;
+	unsigned int status = 0;
+	uint8_t div = 0;
+	uint16_t mul = 0;
+
+	pllr = io_read32(pll->base + offset);
+	div = PLL_DIV(pllr);
+	mul = PLL_MUL(pllr, layout);
+
+	status = io_read32(pll->base + AT91_PMC_SR);
+	if ((status & mask) &&
+	    (div == pll->div && mul == pll->mul))
+		return TEE_SUCCESS;
+
+	if (charac->out)
+		out = charac->out[pll->range];
+
+	if (charac->icpll)
+		io_clrsetbits32(pll->base + AT91_PMC_PLLICPR, PLL_ICPR_MASK(id),
+				charac->icpll[pll->range] <<
+				PLL_ICPR_SHIFT(id));
+
+	io_clrsetbits32(pll->base + offset, layout->pllr_mask,
+			pll->div | (PLL_MAX_COUNT << PLL_COUNT_SHIFT) |
+			(out << PLL_OUT_SHIFT) |
+			((pll->mul & layout->mul_mask) << layout->mul_shift));
+
+	while (!clk_pll_ready(pll->base, pll->id))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static void clk_pll_disable(struct clk *clk)
+{
+	struct clk_pll *pll = clk->priv;
+	unsigned int mask = pll->layout->pllr_mask;
+
+	io_clrsetbits32(pll->base + PLL_REG(pll->id), mask, ~mask);
+}
+
+static unsigned long clk_pll_get_rate(struct clk *clk,
+				      unsigned long parent_rate)
+{
+	struct clk_pll *pll = clk->priv;
+
+	if (!pll->div || !pll->mul)
+		return 0;
+
+	return (parent_rate / pll->div) * (pll->mul + 1);
+}
+
+static long clk_pll_get_best_div_mul(struct clk_pll *pll, unsigned long rate,
+				     unsigned long parent_rate,
+				     uint32_t *div, uint32_t *mul,
+				     uint32_t *index)
+{
+	const struct clk_pll_layout *layout = pll->layout;
+	const struct clk_pll_charac *charac = pll->charac;
+	unsigned long bestremainder = ULONG_MAX;
+	unsigned long maxdiv = 1;
+	unsigned long mindiv = 1;
+	unsigned long tmpdiv = 1;
+	long bestrate = -1;
+	unsigned long bestdiv = 0;
+	unsigned long bestmul = 0;
+	int i = 0;
+
+	/* Check if parent_rate is a valid input rate */
+	if (parent_rate < charac->input.min)
+		return -1;
+
+	/*
+	 * Calculate minimum divider based on the minimum multiplier, the
+	 * parent_rate and the requested rate.
+	 * Should always be 2 according to the input and output charac
+	 * of the PLL blocks.
+	 */
+	mindiv = (parent_rate * PLL_MUL_MIN) / rate;
+	if (!mindiv)
+		mindiv = 1;
+
+	if (parent_rate > charac->input.max) {
+		tmpdiv = DIV_ROUND_UP(parent_rate, charac->input.max);
+		if (tmpdiv > PLL_DIV_MAX)
+			return -1;
+
+		if (tmpdiv > mindiv)
+			mindiv = tmpdiv;
+	}
+
+	/*
+	 * Calculate the maximum divider which is limited by PLL register
+	 * layout (limited by the MUL or DIV field size).
+	 */
+	maxdiv = DIV_ROUND_UP(parent_rate * PLL_MUL_MAX(layout), rate);
+	if (maxdiv > PLL_DIV_MAX)
+		maxdiv = PLL_DIV_MAX;
+
+	/*
+	 * Iterate over the acceptable divider values to find the best
+	 * divider/multiplier pair (the one that generates the closest
+	 * rate to the requested one).
+	 */
+	for (tmpdiv = mindiv; tmpdiv <= maxdiv; tmpdiv++) {
+		unsigned long remainder = 0;
+		unsigned long tmprate = 0;
+		unsigned long tmpmul = 0;
+
+		/*
+		 * Calculate the multiplier associated with the current
+		 * divider that provide the closest rate to the requested one.
+		 */
+		tmpmul = UDIV_ROUND_NEAREST(rate, parent_rate / tmpdiv);
+		tmprate = (parent_rate / tmpdiv) * tmpmul;
+		if (tmprate > rate)
+			remainder = tmprate - rate;
+		else
+			remainder = rate - tmprate;
+
+		/*
+		 * Compare the remainder with the best remainder found until
+		 * now and elect a new best multiplier/divider pair if the
+		 * current remainder is smaller than the best one.
+		 */
+		if (remainder < bestremainder) {
+			bestremainder = remainder;
+			bestdiv = tmpdiv;
+			bestmul = tmpmul;
+			bestrate = tmprate;
+		}
+
+		/*
+		 * We've found a perfect match!
+		 * Stop searching now and use this multiplier/divider pair.
+		 */
+		if (!remainder)
+			break;
+	}
+
+	/* We haven't found any multiplier/divider pair => return -ERANGE */
+	if (bestrate < 0)
+		return bestrate;
+
+	/* Check if bestrate is a valid output rate  */
+	for (i = 0; i < charac->num_output; i++) {
+		if (bestrate >= (long)charac->output[i].min &&
+		    bestrate <= (long)charac->output[i].max)
+			break;
+	}
+
+	if (i >= charac->num_output)
+		return -1;
+
+	if (div)
+		*div = bestdiv;
+	if (mul)
+		*mul = bestmul - 1;
+	if (index)
+		*index = i;
+
+	return bestrate;
+}
+
+static TEE_Result clk_pll_set_rate(struct clk *clk, unsigned long rate,
+				   unsigned long parent_rate)
+{
+	struct clk_pll *pll = clk->priv;
+	long ret = -1;
+	uint32_t div = 1;
+	uint32_t mul = 0;
+	uint32_t index = 0;
+
+	ret = clk_pll_get_best_div_mul(pll, rate, parent_rate,
+				       &div, &mul, &index);
+	if (ret < 0)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	pll->range = index;
+	pll->div = div;
+	pll->mul = mul;
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops pll_ops = {
+	.enable = clk_pll_enable,
+	.disable = clk_pll_disable,
+	.get_rate = clk_pll_get_rate,
+	.set_rate = clk_pll_set_rate,
+};
+
+struct clk *
+at91_clk_register_pll(struct pmc_data *pmc, const char *name,
+		      struct clk *parent, uint8_t id,
+		      const struct clk_pll_layout *layout,
+		      const struct clk_pll_charac *charac)
+{
+	struct clk *clk = NULL;
+	struct clk_pll *pll = NULL;
+	int offset = PLL_REG(id);
+	uint32_t pllr = 0;
+
+	if (!name || !parent)
+		return NULL;
+
+	clk = clk_alloc(name, &pll_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	if (id > PLL_MAX_ID)
+		return NULL;
+
+	pll = calloc(1, sizeof(*pll));
+	if (!pll) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	pll->id = id;
+	pll->layout = layout;
+	pll->charac = charac;
+	pll->base = pmc->base;
+	pllr = io_read32(pmc->base + offset);
+	pll->div = PLL_DIV(pllr);
+	pll->mul = PLL_MUL(pllr, layout);
+
+	clk->flags = CLK_SET_RATE_GATE;
+	clk->priv = pll;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(pll);
+		return NULL;
+	}
+
+	return clk;
+}
+
+const struct clk_pll_layout sama5d3_pll_layout = {
+	.pllr_mask = 0x1FFFFFF,
+	.mul_shift = 18,
+	.mul_mask = 0x7F,
+};

--- a/core/drivers/clk/sam/at91_plldiv.c
+++ b/core/drivers/clk/sam/at91_plldiv.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+static unsigned long clk_plldiv_get_rate(struct clk *clk,
+					 unsigned long parent_rate)
+{
+	struct pmc_data *pmc = clk->priv;
+	unsigned int mckr = io_read32(pmc->base + AT91_PMC_MCKR);
+
+	if (mckr & AT91_PMC_PLLADIV2)
+		return parent_rate / 2;
+
+	return parent_rate;
+}
+
+static TEE_Result clk_plldiv_set_rate(struct clk *clk, unsigned long rate,
+				      unsigned long parent_rate)
+{
+	struct pmc_data *pmc = clk->priv;
+
+	if (parent_rate != rate && (parent_rate / 2 != rate))
+		return TEE_ERROR_GENERIC;
+
+	io_clrsetbits32(pmc->base + AT91_PMC_MCKR, AT91_PMC_PLLADIV2,
+			parent_rate != rate ? AT91_PMC_PLLADIV2 : 0);
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops plldiv_ops = {
+	.get_rate = clk_plldiv_get_rate,
+	.set_rate = clk_plldiv_set_rate,
+};
+
+struct clk *
+at91_clk_register_plldiv(struct pmc_data *pmc, const char *name,
+			 struct clk *parent)
+{
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &plldiv_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	clk->priv = pmc;
+	clk->flags = CLK_SET_RATE_GATE;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_pmc.c
+++ b/core/drivers/clk/sam/at91_pmc.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <dt-bindings/clock/at91.h>
+#include <kernel/panic.h>
+#include <malloc.h>
+#include <string.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+static struct clk *pmc_clk_get_by_id(struct pmc_clk *clks, unsigned int nclk,
+				     unsigned int id)
+{
+	unsigned int i = 0;
+
+	for (i = 0; i < nclk; i++) {
+		if (clks[i].clk && clks[i].id == id)
+			return clks[i].clk;
+	}
+
+	return NULL;
+}
+
+struct clk *pmc_clk_get_by_name(struct pmc_clk *clks, unsigned int nclk,
+				const char *name)
+{
+	unsigned int i = 0;
+
+	for (i = 0; i < nclk; i++)
+		if (strcmp(clks[i].clk->name, name) == 0)
+			return clks[i].clk;
+
+	return NULL;
+}
+
+struct clk *clk_dt_pmc_get(struct dt_driver_phandle_args *clkspec, void *data,
+			   TEE_Result *res)
+{
+	unsigned int type = clkspec->args[0];
+	unsigned int idx = clkspec->args[1];
+	struct pmc_data *pmc_data = data;
+	struct pmc_clk *clks = NULL;
+	struct clk *clk = NULL;
+	unsigned int nclk = 0;
+	*res = TEE_ERROR_GENERIC;
+
+	if (clkspec->args_count != 2) {
+		*res = TEE_ERROR_BAD_PARAMETERS;
+		return NULL;
+	}
+
+	switch (type) {
+	case PMC_TYPE_CORE:
+		nclk = pmc_data->ncore;
+		clks = pmc_data->chws;
+		break;
+	case PMC_TYPE_SYSTEM:
+		nclk = pmc_data->nsystem;
+		clks = pmc_data->shws;
+		break;
+	case PMC_TYPE_PERIPHERAL:
+		nclk = pmc_data->nperiph;
+		clks = pmc_data->phws;
+		break;
+	case PMC_TYPE_GCK:
+		nclk = pmc_data->ngck;
+		clks = pmc_data->ghws;
+		break;
+	case PMC_TYPE_PROGRAMMABLE:
+		nclk = pmc_data->npck;
+		clks = pmc_data->pchws;
+		break;
+	default:
+		return NULL;
+	}
+
+	clk = pmc_clk_get_by_id(clks, nclk, idx);
+	if (clk)
+		*res = TEE_SUCCESS;
+
+	return clk;
+}
+
+struct pmc_data *pmc_data_allocate(unsigned int ncore, unsigned int nsystem,
+				   unsigned int nperiph, unsigned int ngck,
+				   unsigned int npck)
+{
+	unsigned int num_clks = ncore + nsystem + nperiph + ngck + npck;
+	unsigned int alloc_size = sizeof(struct pmc_data) +
+				  num_clks * sizeof(struct pmc_clk);
+	struct pmc_data *pmc_data = NULL;
+
+	pmc_data = calloc(1, alloc_size);
+	if (!pmc_data)
+		return NULL;
+
+	pmc_data->ncore = ncore;
+	pmc_data->chws = pmc_data->hwtable;
+
+	pmc_data->nsystem = nsystem;
+	pmc_data->shws = pmc_data->chws + ncore;
+
+	pmc_data->nperiph = nperiph;
+	pmc_data->phws = pmc_data->shws + nsystem;
+
+	pmc_data->ngck = ngck;
+	pmc_data->ghws = pmc_data->phws + nperiph;
+
+	pmc_data->npck = npck;
+	pmc_data->pchws = pmc_data->ghws + ngck;
+
+	return pmc_data;
+}

--- a/core/drivers/clk/sam/at91_pmc.h
+++ b/core/drivers/clk/sam/at91_pmc.h
@@ -1,0 +1,260 @@
+/* SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause */
+/*
+ * Copyright (C) 2005 Ivan Kokshaysky
+ * Copyright (C) SAN People
+ *
+ * Power Management Controller (PMC) - System peripherals registers.
+ * Based on AT91RM9200 datasheet revision E.
+ */
+
+#ifndef DRIVERS_CLK_SAM_AT91_PM_H
+#define DRIVERS_CLK_SAM_AT91_PM_H
+
+#include <util.h>
+
+#define AT91_PMC_V1				(1)
+#define AT91_PMC_V2				(2)
+
+#define	AT91_PMC_SCER				0x00
+#define	AT91_PMC_SCDR				0x04
+
+#define	AT91_PMC_SCSR				0x08
+#define	  AT91_PMC_PCK				BIT(0)
+#define	  AT91RM9200_PMC_UDP			BIT(1)
+#define	  AT91RM9200_PMC_MCKUDP			BIT(2)
+#define	  AT91RM9200_PMC_UHP			BIT(4)
+#define	  AT91SAM926x_PMC_UHP			BIT(6)
+#define	  AT91SAM926x_PMC_UDP			BIT(7)
+#define	  AT91_PMC_PCK0				BIT(8)
+#define	  AT91_PMC_PCK1				BIT(9)
+#define	  AT91_PMC_PCK2				BIT(10)
+#define	  AT91_PMC_PCK3				BIT(11)
+#define	  AT91_PMC_PCK4				BIT(12)
+#define	  AT91_PMC_HCK0				BIT(16)
+#define	  AT91_PMC_HCK1				BIT(17)
+
+#define AT91_PMC_PLL_CTRL0			0x0C
+#define	  AT91_PMC_PLL_CTRL0_ENPLL		BIT(28)
+#define	  AT91_PMC_PLL_CTRL0_ENPLLCK		BIT(29)
+#define	  AT91_PMC_PLL_CTRL0_ENLOCK		BIT(31)
+
+#define AT91_PMC_PLL_CTRL1			0x10
+
+#define	AT91_PMC_PCER				0x10
+#define	AT91_PMC_PCDR				0x14
+#define	AT91_PMC_PCSR				0x18
+
+#define AT91_PMC_PLL_ACR			0x18
+#define	  AT91_PMC_PLL_ACR_DEFAULT_UPLL		0x12020010UL
+#define	  AT91_PMC_PLL_ACR_DEFAULT_PLLA		0x00020010UL
+#define	  AT91_PMC_PLL_ACR_UTMIVR		BIT(12)
+#define	  AT91_PMC_PLL_ACR_UTMIBG		BIT(13)
+
+#define	AT91_CKGR_UCKR				0x1C
+#define	  AT91_PMC_UPLLEN			BIT(16)
+#define	  AT91_PMC_UPLLCOUNT			(0xf << 20)
+#define	  AT91_PMC_BIASEN			BIT(24)
+#define	  AT91_PMC_BIASCOUNT			(0xf << 28)
+
+#define AT91_PMC_PLL_UPDT			0x1C
+#define	  AT91_PMC_PLL_UPDT_UPDATE		BIT(8)
+#define	  AT91_PMC_PLL_UPDT_ID			BIT(0)
+#define	  AT91_PMC_PLL_UPDT_ID_MSK		(0xf)
+#define	  AT91_PMC_PLL_UPDT_STUPTIM		(0xff << 16)
+
+#define	AT91_CKGR_MOR				0x20
+#define	  AT91_PMC_MOSCEN			BIT(0)
+#define	  AT91_PMC_OSCBYPASS			BIT(1)
+#define	  AT91_PMC_WAITMODE			BIT(2)
+#define	  AT91_PMC_MOSCRCEN			BIT(3)
+#define	  AT91_PMC_OSCOUNT			(0xff << 8)
+#define	  AT91_PMC_KEY_MASK			(0xff << 16)
+#define	  AT91_PMC_KEY				(0x37 << 16)
+#define	  AT91_PMC_MOSCSEL			BIT(24)
+#define	  AT91_PMC_CFDEN			BIT(25)
+
+#define	AT91_CKGR_MCFR				0x24
+#define	  AT91_PMC_MAINF			(0xffff << 0)
+#define	  AT91_PMC_MAINRDY			BIT(16)
+
+#define	AT91_CKGR_PLLAR				0x28
+#define	AT91_CKGR_PLLBR				0x2c
+#define	  AT91_PMC_DIV				(0xff << 0)
+#define	  AT91_PMC_PLLCOUNT			(0x3f << 8)
+#define	  AT91_PMC_OUT				(3 << 14)
+#define	  AT91_PMC_MUL				(0x7ff << 16)
+#define	  AT91_PMC_MUL_GET(n)			((n) >> 16 & 0x7ff)
+#define	  AT91_PMC3_MUL				(0x7f << 18)
+#define	  AT91_PMC3_MUL_GET(n)			((n) >> 18 & 0x7f)
+#define	  AT91_PMC_USBDIV			(3 << 28)
+#define     AT91_PMC_USBDIV_1			(0 << 28)
+#define     AT91_PMC_USBDIV_2			BIT(28)
+#define     AT91_PMC_USBDIV_4			(2 << 28)
+#define	  AT91_PMC_USB96M			BIT(28)
+
+#define AT91_PMC_CPU_CKR			0x28
+
+#define	AT91_PMC_MCKR				0x30
+#define	  AT91_PMC_CSS				(3 << 0)
+#define     AT91_PMC_CSS_SLOW			(0 << 0)
+#define     AT91_PMC_CSS_MAIN			BIT(0)
+#define     AT91_PMC_CSS_PLLA			(2 << 0)
+#define     AT91_PMC_CSS_PLLB			(3 << 0)
+#define     AT91_PMC_CSS_UPLL			(3 << 0)
+#define	  PMC_PRES_OFFSET			2
+#define	  AT91_PMC_PRES				(7 << PMC_PRES_OFFSET)
+#define     AT91_PMC_PRES_1			(0 << PMC_PRES_OFFSET)
+#define     AT91_PMC_PRES_2			BIT(PMC_PRES_OFFSET)
+#define     AT91_PMC_PRES_4			(2 << PMC_PRES_OFFSET)
+#define     AT91_PMC_PRES_8			(3 << PMC_PRES_OFFSET)
+#define     AT91_PMC_PRES_16			(4 << PMC_PRES_OFFSET)
+#define     AT91_PMC_PRES_32			(5 << PMC_PRES_OFFSET)
+#define     AT91_PMC_PRES_64			(6 << PMC_PRES_OFFSET)
+#define	  PMC_ALT_PRES_OFFSET			4
+#define	  AT91_PMC_ALT_PRES			(7 << PMC_ALT_PRES_OFFSET)
+#define     AT91_PMC_ALT_PRES_1			(0 << PMC_ALT_PRES_OFFSET)
+#define     AT91_PMC_ALT_PRES_2			BIT(PMC_ALT_PRES_OFFSET)
+#define     AT91_PMC_ALT_PRES_4			(2 << PMC_ALT_PRES_OFFSET)
+#define     AT91_PMC_ALT_PRES_8			(3 << PMC_ALT_PRES_OFFSET)
+#define     AT91_PMC_ALT_PRES_16		(4 << PMC_ALT_PRES_OFFSET)
+#define     AT91_PMC_ALT_PRES_32		(5 << PMC_ALT_PRES_OFFSET)
+#define     AT91_PMC_ALT_PRES_64		(6 << PMC_ALT_PRES_OFFSET)
+#define	  AT91_PMC_MDIV				(3 << 8)
+#define     AT91RM9200_PMC_MDIV_1		(0 << 8)
+#define     AT91RM9200_PMC_MDIV_2		BIT(8)
+#define     AT91RM9200_PMC_MDIV_3		(2 << 8)
+#define     AT91RM9200_PMC_MDIV_4		(3 << 8)
+#define     AT91SAM9_PMC_MDIV_1			(0 << 8)
+#define     AT91SAM9_PMC_MDIV_2			BIT(8)
+#define     AT91SAM9_PMC_MDIV_4			(2 << 8)
+#define     AT91SAM9_PMC_MDIV_6			(3 << 8)
+#define     AT91SAM9_PMC_MDIV_3			(3 << 8)
+#define	  AT91_PMC_PDIV				BIT(12)
+#define     AT91_PMC_PDIV_1			(0 << 12)
+#define     AT91_PMC_PDIV_2			BIT(12)
+#define	  AT91_PMC_PLLADIV2			BIT(12)
+#define     AT91_PMC_PLLADIV2_OFF		(0 << 12)
+#define     AT91_PMC_PLLADIV2_ON		BIT(12)
+#define	  AT91_PMC_H32MXDIV	BIT(24)
+
+#define AT91_PMC_XTALF				0x34
+
+#define	AT91_PMC_USB				0x38
+#define	  AT91_PMC_USBS				(0x1 << 0)
+#define     AT91_PMC_USBS_PLLA			(0 << 0)
+#define     AT91_PMC_USBS_UPLL			BIT(0)
+#define     AT91_PMC_USBS_PLLB			BIT(0)
+#define	  AT91_PMC_OHCIUSBDIV			(0xF << 8)
+#define     AT91_PMC_OHCIUSBDIV_1		(0x0 << 8)
+#define     AT91_PMC_OHCIUSBDIV_2		(0x1 << 8)
+
+#define	AT91_PMC_SMD				0x3c
+#define	  AT91_PMC_SMDS				(0x1 << 0)
+#define	  AT91_PMC_SMD_DIV			(0x1f << 8)
+#define	  AT91_PMC_SMDDIV(n)			(((n) << 8) & AT91_PMC_SMD_DIV)
+
+#define	AT91_PMC_PCKR(n)			(0x40 + ((n) * 4))
+#define	  AT91_PMC_ALT_PCKR_CSS			(0x7 << 0)
+#define     AT91_PMC_CSS_MASTER			(4 << 0)
+#define	  AT91_PMC_CSSMCK			(0x1 << 8)
+#define     AT91_PMC_CSSMCK_CSS			(0 << 8)
+#define     AT91_PMC_CSSMCK_MCK			BIT(8)
+
+#define	AT91_PMC_IER				0x60
+#define	AT91_PMC_IDR				0x64
+#define	AT91_PMC_SR				0x68
+#define	  AT91_PMC_MOSCS			BIT(0)
+#define	  AT91_PMC_LOCKA			BIT(1)
+#define	  AT91_PMC_LOCKB			BIT(2)
+#define	  AT91_PMC_MCKRDY			BIT(3)
+#define	  AT91_PMC_LOCKU			BIT(6)
+#define	  AT91_PMC_OSCSEL			BIT(7)
+#define	  AT91_PMC_PCK0RDY			BIT(8)
+#define	  AT91_PMC_PCK1RDY			BIT(9)
+#define	  AT91_PMC_PCK2RDY			BIT(10)
+#define	  AT91_PMC_PCK3RDY			BIT(11)
+#define	  AT91_PMC_MOSCSELS			BIT(16)
+#define	  AT91_PMC_MOSCRCS			BIT(17)
+#define	  AT91_PMC_CFDEV			BIT(18)
+#define	  AT91_PMC_GCKRDY			BIT(24)
+#define	  AT91_PMC_MCKXRDY			BIT(26)
+#define	AT91_PMC_IMR				0x6c
+
+#define AT91_PMC_FSMR				0x70
+#define AT91_PMC_FSTT(n)			BIT(n)
+#define AT91_PMC_RTTAL				BIT(16)
+#define AT91_PMC_RTCAL				BIT(17)
+#define AT91_PMC_USBAL				BIT(18)
+#define AT91_PMC_SDMMC_CD			BIT(19)
+#define AT91_PMC_LPM				BIT(20)
+#define AT91_PMC_RXLP_MCE			BIT(24)
+#define AT91_PMC_ACC_CE				BIT(25)
+
+#define AT91_PMC_FSPR				0x74
+
+#define AT91_PMC_FS_INPUT_MASK			0x7ff
+
+#define AT91_PMC_PLLICPR			0x80
+
+#define AT91_PMC_PROT				0xe4
+#define	  AT91_PMC_WPEN				(0x1 << 0)
+#define	  AT91_PMC_WPKEY			(0xffffff << 8)
+#define	  AT91_PMC_PROTKEY			(0x504d43 << 8)
+
+#define AT91_PMC_WPSR				0xe8
+#define	  AT91_PMC_WPVS				(0x1 << 0)
+#define	  AT91_PMC_WPVSRC			(0xffff << 8)
+
+#define AT91_PMC_PLL_ISR0			0xEC
+
+#define AT91_PMC_PCER1				0x100
+#define AT91_PMC_PCDR1				0x104
+#define AT91_PMC_PCSR1				0x108
+
+#define AT91_PMC_PCR				0x10c
+#define	  AT91_PMC_PCR_PID_MASK			0x3f
+#define	  AT91_PMC_PCR_CMD			(0x1 << 12)
+#define	  AT91_PMC_PCR_GCKDIV_SHIFT		20
+#define	  AT91_PMC_PCR_GCKDIV_MASK \
+				GENMASK_32(27, AT91_PMC_PCR_GCKDIV_SHIFT)
+#define	  AT91_PMC_PCR_EN			(0x1 << 28)
+#define	  AT91_PMC_PCR_GCKEN			(0x1 << 29)
+
+#define AT91_PMC_AUDIO_PLL0			0x14c
+#define	  AT91_PMC_AUDIO_PLL_PLLEN		BIT(0)
+#define	  AT91_PMC_AUDIO_PLL_PADEN		BIT(1)
+#define	  AT91_PMC_AUDIO_PLL_PMCEN		BIT(2)
+#define	  AT91_PMC_AUDIO_PLL_RESETN		BIT(3)
+#define	  AT91_PMC_AUDIO_PLL_ND_OFFSET	8
+#define	  AT91_PMC_AUDIO_PLL_ND_MASK \
+				(0x7f << AT91_PMC_AUDIO_PLL_ND_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_ND(n) \
+				SHIFT_U32(n, AT91_PMC_AUDIO_PLL_ND_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_QDPMC_OFFSET	16
+#define	  AT91_PMC_AUDIO_PLL_QDPMC_MASK \
+				(0x7f << AT91_PMC_AUDIO_PLL_QDPMC_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_QDPMC(n) \
+				SHIFT_U32(n, AT91_PMC_AUDIO_PLL_QDPMC_OFFSET)
+
+#define AT91_PMC_AUDIO_PLL1			0x150
+#define	  AT91_PMC_AUDIO_PLL_FRACR_MASK		0x3fffff
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_OFFSET	24
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_MASK \
+				(0x7f << AT91_PMC_AUDIO_PLL_QDPAD_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_QDPAD(n) \
+				SHIFT_U32(n, AT91_PMC_AUDIO_PLL_QDPAD_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_DIV_OFFSET \
+				AT91_PMC_AUDIO_PLL_QDPAD_OFFSET
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_DIV_MASK \
+				(0x3 << AT91_PMC_AUDIO_PLL_QDPAD_DIV_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_DIV(n) \
+			SHIFT_U32(n, AT91_PMC_AUDIO_PLL_QDPAD_DIV_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV_OFFSET	26
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV_MAX		0x1f
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV_MASK \
+				(AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV_MAX << \
+				AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV_OFFSET)
+#define	  AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV(n) \
+			SHIFT_U32(n, AT91_PMC_AUDIO_PLL_QDPAD_EXTDIV_OFFSET)
+
+#endif

--- a/core/drivers/clk/sam/at91_programmable.c
+++ b/core/drivers/clk/sam/at91_programmable.c
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define PROG_ID_MAX		7
+
+#define PROG_STATUS_MASK(id)	(1 << ((id) + 8))
+#define PROG_PRES(layout, pckr)	\
+	({ \
+		typeof(layout) __layout = layout; \
+		\
+		(((pckr) >> (__layout)->pres_shift) & (__layout)->pres_mask); \
+	})
+#define PROG_MAX_RM9200_CSS	3
+
+struct clk_programmable {
+	vaddr_t base;
+	uint8_t id;
+	const struct clk_programmable_layout *layout;
+};
+
+static unsigned long clk_programmable_get_rate(struct clk *clk,
+					       unsigned long parent_rate)
+{
+	struct clk_programmable *prog = clk->priv;
+	const struct clk_programmable_layout *layout = prog->layout;
+	unsigned int pckr = io_read32(prog->base + AT91_PMC_PCKR(prog->id));
+	unsigned long rate = 0;
+
+	if (layout->is_pres_direct)
+		rate = parent_rate / (PROG_PRES(layout, pckr) + 1);
+	else
+		rate = parent_rate >> PROG_PRES(layout, pckr);
+
+	return rate;
+}
+
+static TEE_Result clk_programmable_set_parent(struct clk *clk, size_t index)
+{
+	struct clk_programmable *prog = clk->priv;
+	const struct clk_programmable_layout *layout = prog->layout;
+	unsigned int mask = layout->css_mask;
+	unsigned int pckr = index;
+
+	if (layout->have_slck_mck)
+		mask |= AT91_PMC_CSSMCK_MCK;
+
+	if (index > layout->css_mask) {
+		if (index > PROG_MAX_RM9200_CSS && !layout->have_slck_mck)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		pckr |= AT91_PMC_CSSMCK_MCK;
+	}
+
+	io_clrsetbits32(prog->base + AT91_PMC_PCKR(prog->id), mask, pckr);
+
+	return TEE_SUCCESS;
+}
+
+static size_t clk_programmable_get_parent(struct clk *clk)
+{
+	struct clk_programmable *prog = clk->priv;
+	const struct clk_programmable_layout *layout = prog->layout;
+	unsigned int pckr = io_read32(prog->base + AT91_PMC_PCKR(prog->id));
+	size_t ret = 0;
+
+	ret = pckr & layout->css_mask;
+
+	if (layout->have_slck_mck && (pckr & AT91_PMC_CSSMCK_MCK) && !ret)
+		ret = PROG_MAX_RM9200_CSS + 1;
+
+	return ret;
+}
+
+static unsigned int flsi(unsigned int val)
+{
+	if (val == 0)
+		return 0;
+
+	return sizeof(unsigned int) * 8 - __builtin_clz(val);
+}
+
+static TEE_Result clk_programmable_set_rate(struct clk *clk, unsigned long rate,
+					    unsigned long parent_rate)
+{
+	struct clk_programmable *prog = clk->priv;
+	const struct clk_programmable_layout *layout = prog->layout;
+	unsigned long div = parent_rate / rate;
+	int shift = 0;
+
+	if (!div)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (layout->is_pres_direct) {
+		shift = div - 1;
+
+		if (shift > layout->pres_mask)
+			return TEE_ERROR_BAD_PARAMETERS;
+	} else {
+		shift = flsi(div) - 1;
+
+		if (div != (1ULL << shift))
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		if (shift >= layout->pres_mask)
+			return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	io_clrsetbits32(prog->base + AT91_PMC_PCKR(prog->id),
+			layout->pres_mask << layout->pres_shift,
+			shift << layout->pres_shift);
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops programmable_ops = {
+	.get_rate = clk_programmable_get_rate,
+	.get_parent = clk_programmable_get_parent,
+	.set_parent = clk_programmable_set_parent,
+	.set_rate = clk_programmable_set_rate,
+};
+
+struct clk *
+at91_clk_register_programmable(struct pmc_data *pmc,
+			       const char *name, struct clk **parents,
+			       uint8_t num_parents, uint8_t id,
+			       const struct clk_programmable_layout *layout)
+{
+	struct clk_programmable *prog = NULL;
+	struct clk *clk = NULL;
+
+	assert(id <= PROG_ID_MAX);
+
+	clk = clk_alloc(name, &programmable_ops, parents, num_parents);
+	prog = calloc(1, sizeof(*prog));
+	if (!prog || !clk)
+		return NULL;
+
+	prog->id = id;
+	prog->layout = layout;
+	prog->base = pmc->base;
+
+	clk->priv = prog;
+	clk->flags = CLK_SET_RATE_GATE | CLK_SET_PARENT_GATE;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(prog);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_sckc.c
+++ b/core/drivers/clk/sam/at91_sckc.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <drivers/clk.h>
+#include <drivers/clk_dt.h>
+
+#define SLOW_CLOCK_FREQ			32768
+
+static unsigned long sckc_get_rate(struct clk *clk __unused,
+				   unsigned long parent_rate __unused)
+{
+	return SLOW_CLOCK_FREQ;
+}
+
+static const struct clk_ops sckc_clk_ops = {
+	.get_rate = sckc_get_rate,
+};
+
+static TEE_Result sckc_pmc_setup(const void *fdt __unused, int offs,
+				 const void *data __unused)
+{
+	struct clk *clk = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	clk = clk_alloc("slowck", &sckc_clk_ops, NULL, 0);
+	if (!clk)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = clk_register(clk);
+	if (res) {
+		clk_free(clk);
+		return res;
+	}
+
+	return clk_dt_register_clk_provider(fdt, offs, clk_dt_get_simple_clk,
+					    clk);
+}
+
+CLK_DT_DECLARE(at91_sckc, "atmel,sama5d4-sckc", sckc_pmc_setup);

--- a/core/drivers/clk/sam/at91_system.c
+++ b/core/drivers/clk/sam/at91_system.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define SYSTEM_MAX_ID		31
+
+#define SYSTEM_MAX_NAME_SZ	32
+
+struct clk_system {
+	vaddr_t base;
+	uint8_t id;
+};
+
+static bool is_pck(int id)
+{
+	return (id >= 8) && (id <= 15);
+}
+
+static bool clk_system_ready(vaddr_t base, int id)
+{
+	uint32_t status = io_read32(base + AT91_PMC_SR);
+
+	return status & BIT(id);
+}
+
+static TEE_Result clk_system_enable(struct clk *clk)
+{
+	struct clk_system *sys = clk->priv;
+
+	io_write32(sys->base + AT91_PMC_SCER, 1 << sys->id);
+
+	if (!is_pck(sys->id))
+		return TEE_SUCCESS;
+
+	while (!clk_system_ready(sys->base, sys->id))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static void clk_system_disable(struct clk *clk)
+{
+	struct clk_system *sys = clk->priv;
+
+	io_write32(sys->base + AT91_PMC_SCDR, 1 << sys->id);
+}
+
+static const struct clk_ops system_ops = {
+	.enable = clk_system_enable,
+	.disable = clk_system_disable,
+};
+
+struct clk *
+at91_clk_register_system(struct pmc_data *pmc, const char *name,
+			 struct clk *parent, uint8_t id)
+{
+	struct clk_system *sys = NULL;
+	struct clk *clk = NULL;
+
+	if (!parent || id > SYSTEM_MAX_ID)
+		return NULL;
+
+	clk = clk_alloc(name, &system_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	sys = calloc(1, sizeof(*sys));
+	if (!sys) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	sys->id = id;
+	sys->base = pmc->base;
+
+	clk->priv = sys;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(sys);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/at91_usb.c
+++ b/core/drivers/clk/sam/at91_usb.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+#define SAM9X5_USB_DIV_SHIFT	8
+#define SAM9X5_USB_DIV_COUNT	BIT32(4)
+#define SAM9X5_USB_MAX_DIV	(SAM9X5_USB_DIV_COUNT - 1)
+
+#define SAM9X5_USBS_MASK	BIT(0)
+
+struct at91sam9x5_clk_usb {
+	vaddr_t base;
+	uint32_t usbs_mask;
+};
+
+static unsigned long at91sam9x5_clk_usb_get_rate(struct clk *clk,
+						 unsigned long parent_rate)
+{
+	struct at91sam9x5_clk_usb *usb = clk->priv;
+	uint8_t usbdiv = 1;
+	unsigned int usbr = io_read32(usb->base + AT91_PMC_USB);
+
+	usbdiv = (usbr & AT91_PMC_OHCIUSBDIV) >> SAM9X5_USB_DIV_SHIFT;
+
+	return UDIV_ROUND_NEAREST(parent_rate, (usbdiv + 1));
+}
+
+static TEE_Result at91sam9x5_clk_usb_set_parent(struct clk *clk, size_t index)
+{
+	struct at91sam9x5_clk_usb *usb = clk->priv;
+
+	if (index >= clk_get_num_parents(clk))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	io_clrsetbits32(usb->base + AT91_PMC_USB, usb->usbs_mask, index);
+
+	return TEE_SUCCESS;
+}
+
+static size_t at91sam9x5_clk_usb_get_parent(struct clk *clk)
+{
+	struct at91sam9x5_clk_usb *usb = clk->priv;
+	unsigned int usbr = io_read32(usb->base + AT91_PMC_USB);
+
+	return usbr & usb->usbs_mask;
+}
+
+static TEE_Result at91sam9x5_clk_usb_set_rate(struct clk *clk,
+					      unsigned long rate,
+					      unsigned long parent_rate)
+{
+	struct at91sam9x5_clk_usb *usb = clk->priv;
+	unsigned long div = 1;
+
+	if (!rate)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	div = UDIV_ROUND_NEAREST(parent_rate, rate);
+	if (div > SAM9X5_USB_MAX_DIV + 1 || !div)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	io_clrsetbits32(usb->base + AT91_PMC_USB, AT91_PMC_OHCIUSBDIV,
+			(div - 1) << SAM9X5_USB_DIV_SHIFT);
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops at91sam9x5_usb_ops = {
+	.get_rate = at91sam9x5_clk_usb_get_rate,
+	.get_parent = at91sam9x5_clk_usb_get_parent,
+	.set_parent = at91sam9x5_clk_usb_set_parent,
+	.set_rate = at91sam9x5_clk_usb_set_rate,
+};
+
+static struct clk *
+_at91sam9x5_clk_register_usb(struct pmc_data *pmc, const char *name,
+			     struct clk **parents, uint8_t num_parents,
+			     uint32_t usbs_mask)
+{
+	struct at91sam9x5_clk_usb *usb = NULL;
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &at91sam9x5_usb_ops, parents, num_parents);
+	if (!clk)
+		return NULL;
+
+	usb = calloc(1, sizeof(*usb));
+	if (!usb)
+		return NULL;
+
+	usb->base = pmc->base;
+	usb->usbs_mask = usbs_mask;
+
+	clk->priv = usb;
+	clk->flags = CLK_SET_RATE_GATE | CLK_SET_PARENT_GATE;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(usb);
+		return NULL;
+	}
+
+	return clk;
+}
+
+struct clk *
+at91sam9x5_clk_register_usb(struct pmc_data *pmc, const char *name,
+			    struct clk **parents, uint8_t num_parents)
+{
+	return _at91sam9x5_clk_register_usb(pmc, name, parents,
+					    num_parents, SAM9X5_USBS_MASK);
+}

--- a/core/drivers/clk/sam/at91_utmi.c
+++ b/core/drivers/clk/sam/at91_utmi.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ *  Copyright (C) 2013 Boris BREZILLON <b.brezillon@overkiz.com>
+ *  Copyright (C) 2021 Microchip
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <sam_sfr.h>
+#include <types_ext.h>
+
+#include "at91_clk.h"
+
+/*
+ * The purpose of this clock is to generate a 480 MHz signal. A different
+ * rate can't be configured.
+ */
+#define UTMI_RATE	480000000
+
+struct clk_utmi {
+	vaddr_t pmc_base;
+	vaddr_t sfr_base;
+};
+
+static bool clk_utmi_ready(vaddr_t pmc_base)
+{
+	uint32_t status = io_read32(pmc_base + AT91_PMC_SR);
+
+	return status & AT91_PMC_LOCKU;
+}
+
+static TEE_Result clk_utmi_enable(struct clk *clk)
+{
+	struct clk *clk_parent = NULL;
+	struct clk_utmi *utmi = clk->priv;
+	unsigned int uckr = AT91_PMC_UPLLEN | AT91_PMC_UPLLCOUNT |
+			    AT91_PMC_BIASEN;
+	unsigned int utmi_ref_clk_freq = 0;
+	unsigned long parent_rate = 0;
+
+	/*
+	 * If mainck rate is different from 12 MHz, we have to configure the
+	 * FREQ field of the SFR_UTMICKTRIM register to generate properly
+	 * the utmi clock.
+	 */
+	clk_parent = clk_get_parent(clk);
+	parent_rate = clk_get_rate(clk_parent);
+
+	switch (parent_rate) {
+	case 12000000:
+		utmi_ref_clk_freq = 0;
+		break;
+	case 16000000:
+		utmi_ref_clk_freq = 1;
+		break;
+	case 24000000:
+		utmi_ref_clk_freq = 2;
+		break;
+	/*
+	 * Not supported on SAMA5D2 but it's not an issue since MAINCK
+	 * maximum value is 24 MHz.
+	 */
+	case 48000000:
+		utmi_ref_clk_freq = 3;
+		break;
+	default:
+		EMSG("UTMICK: unsupported mainck rate");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (utmi->sfr_base) {
+		io_clrsetbits32(utmi->sfr_base + AT91_SFR_UTMICKTRIM,
+				AT91_UTMICKTRIM_FREQ, utmi_ref_clk_freq);
+	} else if (utmi_ref_clk_freq) {
+		EMSG("UTMICK: sfr node required");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	io_clrsetbits32(utmi->pmc_base + AT91_CKGR_UCKR, uckr, uckr);
+
+	while (!clk_utmi_ready(utmi->pmc_base))
+		;
+
+	return TEE_SUCCESS;
+}
+
+static void clk_utmi_disable(struct clk *clk)
+{
+	struct clk_utmi *utmi = clk->priv;
+
+	io_clrbits32(utmi->pmc_base + AT91_CKGR_UCKR, AT91_PMC_UPLLEN);
+}
+
+static unsigned long clk_utmi_get_rate(struct clk *clk __unused,
+				       unsigned long parent_rate __unused)
+{
+	/* UTMI clk rate is fixed. */
+	return UTMI_RATE;
+}
+
+static const struct clk_ops utmi_ops = {
+	.enable = clk_utmi_enable,
+	.disable = clk_utmi_disable,
+	.get_rate = clk_utmi_get_rate,
+};
+
+struct clk *
+at91_clk_register_utmi(struct pmc_data *pmc, const char *name,
+		       struct clk *parent)
+{
+	struct clk_utmi *utmi = NULL;
+	struct clk *clk = NULL;
+
+	clk = clk_alloc(name, &utmi_ops, &parent, 1);
+	if (!clk)
+		return NULL;
+
+	utmi = calloc(1, sizeof(*utmi));
+	if (!utmi) {
+		clk_free(clk);
+		return NULL;
+	}
+
+	utmi->pmc_base = pmc->base;
+	utmi->sfr_base = sam_sfr_base();
+	clk->flags = CLK_SET_RATE_GATE;
+
+	clk->priv = utmi;
+
+	if (clk_register(clk)) {
+		clk_free(clk);
+		free(utmi);
+		return NULL;
+	}
+
+	return clk;
+}

--- a/core/drivers/clk/sam/sama5d2_clk.c
+++ b/core/drivers/clk/sam/sama5d2_clk.c
@@ -1,0 +1,593 @@
+// SPDX-License-Identifier: GPL-2.0+ or BSD-3-Clause
+/*
+ * Copyright (c) 2021, Microchip
+ */
+#include <assert.h>
+#include <kernel/boot.h>
+#include <libfdt.h>
+#include <kernel/dt.h>
+#include <kernel/panic.h>
+#include <matrix.h>
+#include <sama5d2.h>
+#include <stdint.h>
+#include <util.h>
+
+#include "at91_clk.h"
+
+#include <dt-bindings/clock/at91.h>
+
+#define PROGCK_PARENT_COUNT	6
+#define PARENT_SIZE		ARRAY_SIZE(sama5d2_systemck)
+
+struct sam_clk {
+	const char *n;
+	uint8_t id;
+};
+
+static const struct clk_master_charac mck_charac = {
+	.output = { .min = 124000000, .max = 166000000 },
+	.divisors = { 1, 2, 4, 3 },
+};
+
+static uint8_t plla_out[1];
+
+static uint16_t plla_icpll[1];
+
+static const struct clk_range plla_outputs[] = {
+	{ .min = 600000000, .max = 1200000000 },
+};
+
+static const struct clk_pll_charac plla_charac = {
+	.input = { .min = 12000000, .max = 24000000 },
+	.num_output = ARRAY_SIZE(plla_outputs),
+	.output = plla_outputs,
+	.icpll = plla_icpll,
+	.out = plla_out,
+};
+
+static const struct clk_pcr_layout sama5d2_pcr_layout = {
+	.offset = 0x10c,
+	.cmd = BIT(12),
+	.gckcss_mask = GENMASK_32(10, 8),
+	.pid_mask = GENMASK_32(6, 0),
+};
+
+static const struct clk_programmable_layout sama5d2_prog_layout = {
+	.pres_mask = 0xff,
+	.pres_shift = 4,
+	.css_mask = 0x7,
+	.have_slck_mck = 0,
+	.is_pres_direct = 1,
+};
+
+static const struct sam_clk sama5d2_systemck[] = {
+	{ .n = "ddrck", .id = 2 },
+	{ .n = "lcdck", .id = 3 },
+	{ .n = "uhpck", .id = 6 },
+	{ .n = "udpck", .id = 7 },
+	{ .n = "pck0",  .id = 8 },
+	{ .n = "pck1",  .id = 9 },
+	{ .n = "pck2",  .id = 10 },
+	{ .n = "iscck", .id = 18 },
+};
+
+static const struct {
+	struct sam_clk clk;
+	struct clk_range r;
+} sama5d2_peri32ck[] = {
+	{
+		.clk = { .n = "macb0_clk", .id = 5 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "tdes_clk", .id = 11 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "matrix1_clk", .id = 14 },
+	},
+	{
+		.clk = { .n = "hsmc_clk", .id = 17 },
+	},
+	{
+		.clk = { .n = "pioA_clk", .id = 18 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "flx0_clk", .id = 19 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "flx1_clk", .id = 20 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "flx2_clk", .id = 21 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "flx3_clk", .id = 22 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "flx4_clk", .id = 23 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "uart0_clk", .id = 24 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "uart1_clk", .id = 25 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "uart2_clk", .id = 26 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "uart3_clk", .id = 27 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "uart4_clk", .id = 28 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "twi0_clk", .id = 29 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "twi1_clk", .id = 30 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "spi0_clk", .id = 33 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "spi1_clk", .id = 34 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "tcb0_clk", .id = 35 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "tcb1_clk", .id = 36 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "pwm_clk", .id = 38 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "adc_clk", .id = 40 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "uhphs_clk", .id = 41 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "udphs_clk", .id = 42 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "ssc0_clk", .id = 43 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "ssc1_clk", .id = 44 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "trng_clk", .id = 47 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "pdmic_clk", .id = 48 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "securam_clk", .id = 51 }, },
+	{
+		.clk = { .n = "i2s0_clk", .id = 54 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "i2s1_clk", .id = 55 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "can0_clk", .id = 56 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "can1_clk", .id = 57 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "ptc_clk", .id = 58 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+	{
+		.clk = { .n = "classd_clk", .id = 59 },
+		.r = { .min = 0, .max = 83000000 },
+	},
+};
+
+static const struct sam_clk sama5d2_perick[] = {
+	{ .n = "dma0_clk",    .id = 6 },
+	{ .n = "dma1_clk",    .id = 7 },
+	{ .n = "aes_clk",     .id = 9 },
+	{ .n = "aesb_clk",    .id = 10 },
+	{ .n = "sha_clk",     .id = 12 },
+	{ .n = "mpddr_clk",   .id = 13 },
+	{ .n = "matrix0_clk", .id = 15 },
+	{ .n = "sdmmc0_hclk", .id = 31 },
+	{ .n = "sdmmc1_hclk", .id = 32 },
+	{ .n = "lcdc_clk",    .id = 45 },
+	{ .n = "isc_clk",     .id = 46 },
+	{ .n = "qspi0_clk",   .id = 52 },
+	{ .n = "qspi1_clk",   .id = 53 },
+};
+
+static const struct {
+	struct sam_clk clk;
+	struct clk_range r;
+	int chg_pid;
+} sama5d2_gck[] = {
+	{
+		.clk = { .n = "sdmmc0_gclk", .id = 31 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "sdmmc1_gclk", .id = 32 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "tcb0_gclk", .id = 35 },
+		.r = { .min = 0, .max = 83000000 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "tcb1_gclk", .id = 36 },
+		.r = { .min = 0, .max = 83000000 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "pwm_gclk", .id = 38 },
+		.r = { .min = 0, .max = 83000000 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "isc_gclk", .id = 46 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "pdmic_gclk", .id = 48 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "i2s0_gclk", .id = 54 },
+		.chg_pid = 5,
+	},
+	{
+		.clk = { .n = "i2s1_gclk", .id = 55 },
+		.chg_pid = 5,
+	},
+	{
+		.clk = { .n = "can0_gclk", .id = 56 },
+		.r = { .min = 0, .max = 80000000 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "can1_gclk",   .id = 57 },
+		.r = { .min = 0, .max = 80000000 },
+		.chg_pid = INT_MIN,
+	},
+	{
+		.clk = { .n = "classd_gclk", .id = 59 },
+		.chg_pid = 5,
+		.r = { .min = 0, .max = 100000000 },
+	},
+};
+
+static const struct sam_clk sama5d2_progck[] = {
+	{ .n = "prog0", .id = 0 },
+	{ .n = "prog1", .id = 1 },
+	{ .n = "prog2", .id = 2 },
+};
+
+static TEE_Result pmc_setup(const void *fdt, int nodeoffset,
+			    const void *data __unused)
+{
+	size_t size = 0;
+	vaddr_t base = 0;
+	unsigned int i = 0;
+	int bypass = 0;
+	const uint32_t *fdt_prop = NULL;
+	struct pmc_clk *pmc_clk = NULL;
+	struct pmc_data *pmc = NULL;
+	const struct sam_clk *sam_clk = NULL;
+	struct clk_range range = CLK_RANGE(0, 0);
+	struct clk *h32mxck = NULL;
+	struct clk *mckdivck = NULL;
+	struct clk *plladivck = NULL;
+	struct clk *usbck = NULL;
+	struct clk *audiopll_pmcck = NULL;
+	struct clk *parents[PARENT_SIZE] = {NULL};
+	struct clk *main_clk = NULL;
+	struct clk *utmi_clk = NULL;
+	struct clk *slow_clk = NULL;
+	struct clk *clk = NULL;
+	struct clk *main_rc_osc = NULL;
+	struct clk *main_osc = NULL;
+	struct clk *main_xtal_clk = NULL;
+	struct clk *audiopll_fracck = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	/*
+	 * We want PARENT_SIZE to be MAX(ARRAY_SIZE(sama5d2_systemck),6)
+	 * but using this define won't allow static initialization of parents
+	 * due to dynamic size.
+	 */
+	COMPILE_TIME_ASSERT(ARRAY_SIZE(sama5d2_systemck) == PARENT_SIZE);
+	COMPILE_TIME_ASSERT(PARENT_SIZE >= 6);
+
+	if (dt_map_dev(fdt, nodeoffset, &base, &size) < 0)
+		panic();
+
+	if (_fdt_get_status(fdt, nodeoffset) == DT_STATUS_OK_SEC)
+		matrix_configure_periph_secure(AT91C_ID_PMC);
+
+	slow_clk = clk_dt_get_by_name(fdt, nodeoffset, "slow_clk", &res);
+	if (res)
+		panic();
+
+	main_xtal_clk = clk_dt_get_by_name(fdt, nodeoffset, "main_xtal", &res);
+	if (res)
+		panic();
+
+	pmc = pmc_data_allocate(PMC_MCK_PRES + 1,
+				ARRAY_SIZE(sama5d2_systemck),
+				ARRAY_SIZE(sama5d2_perick) +
+				ARRAY_SIZE(sama5d2_peri32ck),
+				ARRAY_SIZE(sama5d2_gck),
+				ARRAY_SIZE(sama5d2_progck));
+	if (!pmc)
+		panic();
+	pmc->base = base;
+
+	main_rc_osc = pmc_register_main_rc_osc(pmc, "main_rc_osc", 12000000);
+	if (!main_rc_osc)
+		panic();
+
+	fdt_prop = fdt_getprop(fdt, nodeoffset, "atmel,osc-bypass", NULL);
+	if (fdt_prop)
+		bypass = fdt32_to_cpu(*fdt_prop);
+
+	main_osc = pmc_register_main_osc(pmc, "main_osc", main_xtal_clk,
+					 bypass);
+	if (!main_osc)
+		panic();
+
+	parents[0] = main_rc_osc;
+	parents[1] = main_osc;
+	main_clk = at91_clk_register_sam9x5_main(pmc, "mainck", parents, 2);
+	if (!main_clk)
+		panic();
+
+	pmc_clk = &pmc->chws[PMC_MAIN];
+	pmc_clk->clk = main_clk;
+	pmc_clk->id = PMC_MAIN;
+
+	clk = at91_clk_register_pll(pmc, "pllack", main_clk, 0,
+				    &sama5d3_pll_layout, &plla_charac);
+	if (!clk)
+		panic();
+
+	plladivck = at91_clk_register_plldiv(pmc, "plladivck", clk);
+	if (!plladivck)
+		panic();
+
+	pmc_clk = &pmc->chws[PMC_PLLACK];
+	pmc_clk->clk = plladivck;
+	pmc_clk->id = PMC_PLLACK;
+
+	audiopll_fracck = at91_clk_register_audio_pll_frac(pmc,
+							   "audiopll_fracck",
+							   main_clk);
+	if (!audiopll_fracck)
+		panic();
+
+	clk = at91_clk_register_audio_pll_pad(pmc, "audiopll_padck",
+					      audiopll_fracck);
+	if (!clk)
+		panic();
+
+	audiopll_pmcck = at91_clk_register_audio_pll_pmc(pmc, "audiopll_pmcck",
+							 audiopll_fracck);
+	if (!audiopll_pmcck)
+		panic();
+
+	pmc_clk = &pmc->chws[PMC_AUDIOPLLCK];
+	pmc_clk->clk = audiopll_pmcck;
+	pmc_clk->id = PMC_AUDIOPLLCK;
+
+	utmi_clk = at91_clk_register_utmi(pmc, "utmick", main_clk);
+	if (!utmi_clk)
+		panic();
+
+	pmc_clk = &pmc->chws[PMC_UTMI];
+	pmc_clk->clk = utmi_clk;
+	pmc_clk->id = PMC_UTMI;
+
+	parents[0] = slow_clk;
+	parents[1] = main_clk;
+	parents[2] = plladivck;
+	parents[3] = utmi_clk;
+
+	clk = at91_clk_register_master_pres(pmc, "masterck_pres", 4,
+					    parents,
+					    &at91sam9x5_master_layout,
+					    &mck_charac, INT_MIN);
+	if (!clk)
+		panic();
+
+	pmc_clk = &pmc->chws[PMC_MCK_PRES];
+	pmc_clk->clk = clk;
+	pmc_clk->id = PMC_MCK_PRES;
+
+	mckdivck = at91_clk_register_master_div(pmc, "masterck_div",
+						clk,
+						&at91sam9x5_master_layout,
+						&mck_charac);
+	if (!mckdivck)
+		panic();
+
+	pmc_clk = &pmc->chws[PMC_MCK];
+	pmc_clk->clk = mckdivck;
+	pmc_clk->id = PMC_MCK;
+
+	h32mxck = at91_clk_register_h32mx(pmc, "h32mxck", mckdivck);
+	if (!h32mxck)
+		panic();
+
+	pmc_clk = &pmc->chws[PMC_MCK2];
+	pmc_clk->clk = h32mxck;
+	pmc_clk->id = PMC_MCK2;
+
+	parents[0] = plladivck;
+	parents[1] = utmi_clk;
+	usbck = at91sam9x5_clk_register_usb(pmc, "usbck", parents, 2);
+	if (!usbck)
+		panic();
+
+	if (clk_set_parent(usbck, utmi_clk) != TEE_SUCCESS)
+		panic();
+
+	clk_set_rate(usbck, 48000000);
+
+	parents[0] = slow_clk;
+	parents[1] = main_clk;
+	parents[2] = plladivck;
+	parents[3] = utmi_clk;
+	parents[4] = mckdivck;
+	parents[5] = audiopll_pmcck;
+	for (i = 0; i < ARRAY_SIZE(sama5d2_progck); i++) {
+		sam_clk = &sama5d2_progck[i];
+		clk = at91_clk_register_programmable(pmc, sam_clk->n,
+						     parents,
+						     PROGCK_PARENT_COUNT, i,
+						     &sama5d2_prog_layout);
+		if (!clk)
+			panic();
+
+		pmc_clk = &pmc->pchws[i];
+		pmc_clk->clk = clk;
+		pmc_clk->id = sam_clk->id;
+	}
+
+	/* This array order must match the one in sama5d2_systemck */
+	parents[0] = mckdivck;
+	parents[1] = mckdivck;
+	parents[2] = usbck;
+	parents[3] = usbck;
+	parents[4] = pmc->pchws[0].clk;
+	parents[5] = pmc->pchws[1].clk;
+	parents[6] = pmc->pchws[2].clk;
+	parents[7] = mckdivck;
+	for (i = 0; i < ARRAY_SIZE(sama5d2_systemck); i++) {
+		sam_clk = &sama5d2_systemck[i];
+		clk = at91_clk_register_system(pmc, sam_clk->n,
+					       parents[i],
+					       sam_clk->id);
+		if (!clk)
+			panic();
+
+		pmc_clk = &pmc->shws[i];
+		pmc_clk->clk = clk;
+		pmc_clk->id = sam_clk->id;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(sama5d2_perick); i++) {
+		sam_clk = &sama5d2_perick[i];
+		clk = at91_clk_register_sam9x5_periph(pmc,
+						      &sama5d2_pcr_layout,
+						      sam_clk->n,
+						      mckdivck,
+						      sam_clk->id,
+						      &range);
+		if (!clk)
+			panic();
+
+		pmc_clk = &pmc->phws[i];
+		pmc_clk->clk = clk;
+		pmc_clk->id = sam_clk->id;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(sama5d2_peri32ck); i++) {
+		sam_clk = &sama5d2_peri32ck[i].clk;
+		clk = at91_clk_register_sam9x5_periph(pmc,
+						      &sama5d2_pcr_layout,
+						      sam_clk->n,
+						      h32mxck,
+						      sam_clk->id,
+						      &sama5d2_peri32ck[i].r);
+		if (!clk)
+			panic();
+
+		pmc_clk = &pmc->phws[ARRAY_SIZE(sama5d2_perick) + i];
+		pmc_clk->clk = clk;
+		pmc_clk->id = sam_clk->id;
+	}
+
+	parents[0] = slow_clk;
+	parents[1] = main_clk;
+	parents[2] = plladivck;
+	parents[3] = utmi_clk;
+	parents[4] = mckdivck;
+	parents[5] = audiopll_pmcck;
+	for (i = 0; i < ARRAY_SIZE(sama5d2_gck); i++) {
+		sam_clk = &sama5d2_gck[i].clk;
+		clk = at91_clk_register_generated(pmc,
+						  &sama5d2_pcr_layout,
+						  sam_clk->n,
+						  parents, 6,
+						  sam_clk->id,
+						  &sama5d2_gck[i].r,
+						  sama5d2_gck[i].chg_pid);
+		if (!clk)
+			panic();
+
+		pmc_clk = &pmc->ghws[i];
+		pmc_clk->clk = clk;
+		pmc_clk->id = sam_clk->id;
+	}
+
+	parents[0] = pmc_clk_get_by_name(pmc->phws, pmc->nperiph, "i2s0_clk");
+	parents[1] = pmc_clk_get_by_name(pmc->ghws, pmc->ngck, "i2s0_gclk");
+	clk = at91_clk_i2s_mux_register("i2s0_muxclk", parents, 2, 0);
+	if (!clk)
+		panic();
+
+	pmc->chws[PMC_I2S0_MUX].clk = clk;
+	pmc->chws[PMC_I2S0_MUX].id = PMC_I2S0_MUX;
+
+	parents[0] = pmc_clk_get_by_name(pmc->phws, pmc->nperiph, "i2s1_clk");
+	parents[1] = pmc_clk_get_by_name(pmc->ghws, pmc->ngck, "i2s1_gclk");
+	clk = at91_clk_i2s_mux_register("i2s1_muxclk", parents, 2, 1);
+	if (!clk)
+		panic();
+
+	pmc->chws[PMC_I2S1_MUX].clk = clk;
+	pmc->chws[PMC_I2S1_MUX].id = PMC_I2S1_MUX;
+
+	clk_dt_register_clk_provider(fdt, nodeoffset, clk_dt_pmc_get, pmc);
+
+	return TEE_SUCCESS;
+}
+
+CLK_DT_DECLARE(sama5d2_clk, "atmel,sama5d2-pmc", pmc_setup);

--- a/core/drivers/clk/sam/sub.mk
+++ b/core/drivers/clk/sam/sub.mk
@@ -1,0 +1,8 @@
+global-incdirs-y += .
+
+at91-common = at91_sckc.c at91_main.c at91_pmc.c at91_pll.c at91_plldiv.c
+at91-common += at91_utmi.c at91_master.c at91_h32mx.c at91_usb.c
+at91-common += at91_programmable.c at91_system.c at91_peripheral.c
+at91-common += at91_generated.c at91_i2s_mux.c at91_audio_pll.c
+
+srcs-$(CFG_DRIVERS_SAMA5D2_CLK) += $(at91-common) sama5d2_clk.c

--- a/core/drivers/clk/sub.mk
+++ b/core/drivers/clk/sub.mk
@@ -1,3 +1,5 @@
 srcs-y += clk.c
 srcs-$(CFG_DRIVERS_CLK_DT) += clk_dt.c
 srcs-$(CFG_DRIVERS_CLK_FIXED) += fixed_clk.c
+
+subdirs-$(CFG_DRIVERS_SAM_CLK) += sam

--- a/core/include/dt-bindings/clock/at91.h
+++ b/core/include/dt-bindings/clock/at91.h
@@ -39,27 +39,4 @@
 #define PMC_ETHPLL		(PMC_MAIN + 8)
 #define PMC_CPU			(PMC_MAIN + 9)
 
-#ifndef AT91_PMC_MOSCS
-/* MOSCS Flag */
-#define AT91_PMC_MOSCS		0
-/* PLLA Lock */
-#define AT91_PMC_LOCKA		1
-/* PLLB Lock */
-#define AT91_PMC_LOCKB		2
-/* Master Clock */
-#define AT91_PMC_MCKRDY		3
-/* UPLL Lock */
-#define AT91_PMC_LOCKU		6
-/* Programmable Clock */
-#define AT91_PMC_PCKRDY(id)	(8 + (id))
-/* Main Oscillator Selection */
-#define AT91_PMC_MOSCSELS	16
-/* Main On-Chip RC */
-#define AT91_PMC_MOSCRCS	17
-/* Clock Failure Detector Event */
-#define AT91_PMC_CFDEV		18
-/* Generated Clocks */
-#define AT91_PMC_GCKRDY		24
-#endif
-
 #endif

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -75,6 +75,12 @@
 /* Round down the even multiple of size, size has to be a multiple of 2 */
 #define ROUNDDOWN(v, size) ((v) & ~((__typeof__(v))(size) - 1))
 
+/*
+ * Round up the result of x / y to the nearest upper integer if result is not 
+ * already an integer.
+ */
+#define DIV_ROUND_UP(x, y) (((x) + (y) - 1) / (y))
+
 /* Unsigned integer division with nearest rounding variant */
 #define UDIV_ROUND_NEAREST(x, y) \
 	(__extension__ ({ __typeof__(x) _x = (x); \


### PR DESCRIPTION
This series add complete support for SAMA5D2 clock tree.
Drivers have been partially ported from Linux and have been relicensed with dual GPL2 and BSD-3-Clause.
This will need to be acked by @Noglitch and @bbrezillon.