### PR TITLE
plat: zynqmp: register ddr for dyn shm support

### DIFF
--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -58,6 +58,10 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 			ROUNDDOWN(GIC_BASE + GICD_OFFSET, CORE_MMU_PGDIR_SIZE),
 			CORE_MMU_PGDIR_SIZE);
 
+#ifdef DRAM0_BASE
+register_ddr(DRAM0_BASE, DRAM0_SIZE);
+#endif
+
 void main_init_gic(void)
 {
 	vaddr_t gicc_base, gicd_base;


### PR DESCRIPTION
Register DDR based on the DRAM base and size definitions from
platform_config.h for supporting dynamic shared memory usage.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>