### PR TITLE
dt_node_info: add the reg size to manage core virtual address map

### DIFF
--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -128,7 +128,7 @@ void console_init(void)
 static TEE_Result get_gic_base_addr_from_dt(paddr_t *gic_addr)
 {
 	paddr_t paddr = 0;
-	ssize_t size = 0;
+	size_t size = 0;
 
 	void *fdt = get_embedded_dt();
 	int gic_offset = 0;
@@ -147,7 +147,7 @@ static TEE_Result get_gic_base_addr_from_dt(paddr_t *gic_addr)
 		}
 
 		size = _fdt_reg_size(fdt, gic_offset);
-		if (size < 0) {
+		if (size == DT_INFO_INVALID_REG_SIZE) {
 			EMSG("GIC: Unable to get size of base addr from DT");
 			return TEE_ERROR_ITEM_NOT_FOUND;
 		}

--- a/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
@@ -52,7 +52,7 @@ static paddr_t find_jr_offset(void *fdt, int status, int *find_node)
 
 void caam_hal_cfg_get_ctrl_dt(void *fdt, vaddr_t *ctrl_base)
 {
-	ssize_t size = 0;
+	size_t size = 0;
 	int node = 0;
 	paddr_t pctrl_base = 0;
 
@@ -75,7 +75,7 @@ void caam_hal_cfg_get_ctrl_dt(void *fdt, vaddr_t *ctrl_base)
 	}
 
 	size = _fdt_reg_size(fdt, node);
-	if (size < 0) {
+	if (size == DT_INFO_INVALID_REG_SIZE) {
 		HAL_TRACE("CAAM control base address size not defined");
 		return;
 	}

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -290,7 +290,7 @@ struct i2c_request {
 
 static vaddr_t get_base(struct i2c_handle_s *hi2c)
 {
-	return io_pa_or_va_secure(&hi2c->base, I2C_SIZE);
+	return io_pa_or_va_secure(&hi2c->base, hi2c->reg_size);
 }
 
 static void notif_i2c_timeout(struct i2c_handle_s *hi2c)
@@ -692,11 +692,14 @@ int stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 	memset(init, 0, sizeof(*init));
 
 	_fdt_fill_device_info(fdt, &info, node);
+	assert(info.reg != DT_INFO_INVALID_REG &&
+	       info.reg_size != DT_INFO_INVALID_REG_SIZE &&
+	       info.clock != DT_INFO_INVALID_CLOCK);
+
 	init->dt_status = info.status;
 	init->pbase = info.reg;
+	init->reg_size = info.reg_size;
 	init->clock = info.clock;
-	assert(info.reg != DT_INFO_INVALID_REG &&
-	       info.clock != DT_INFO_INVALID_CLOCK);
 
 	cuint = fdt_getprop(fdt, node, "i2c-scl-rising-time-ns", NULL);
 	if (cuint)
@@ -754,6 +757,7 @@ int stm32_i2c_init(struct i2c_handle_s *hi2c,
 
 	hi2c->dt_status = init_data->dt_status;
 	hi2c->base.pa = init_data->pbase;
+	hi2c->reg_size = init_data->reg_size;
 	hi2c->clock = init_data->clock;
 
 	rc = i2c_setup_timing(hi2c, init_data, &timing);

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -217,7 +217,8 @@ static TEE_Result stm32_rng_init(void)
 			panic();
 
 		assert(dt_info.clock != DT_INFO_INVALID_CLOCK &&
-		       dt_info.reg != DT_INFO_INVALID_REG);
+		       dt_info.reg != DT_INFO_INVALID_REG &&
+		       dt_info.reg_size != DT_INFO_INVALID_REG_SIZE);
 
 		if (dt_info.status & DT_STATUS_OK_NSEC) {
 			stm32mp_register_non_secure_periph_iomem(dt_info.reg);
@@ -229,7 +230,7 @@ static TEE_Result stm32_rng_init(void)
 
 		stm32_rng->base.pa = dt_info.reg;
 		stm32_rng->base.va = (vaddr_t)phys_to_virt(dt_info.reg, mtype,
-							   1);
+							   dt_info.reg_size);
 
 		stm32_rng->clock = (unsigned long)dt_info.clock;
 

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -139,7 +139,8 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 		return NULL;
 
 	assert(info.clock != DT_INFO_INVALID_CLOCK &&
-	       info.reg != DT_INFO_INVALID_REG);
+	       info.reg != DT_INFO_INVALID_REG &&
+	       info.reg_size != DT_INFO_INVALID_REG_SIZE);
 
 	pd = calloc(1, sizeof(*pd));
 	if (!pd)
@@ -153,7 +154,7 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	assert(cpu_mmu_enabled());
 	pd->base.va = (vaddr_t)phys_to_virt(pd->base.pa,
 					    pd->secure ? MEM_AREA_IO_SEC :
-					    MEM_AREA_IO_NSEC, 1);
+					    MEM_AREA_IO_NSEC, info.reg_size);
 
 	count = stm32_pinctrl_fdt_get_pinctrl(fdt, node, NULL, 0);
 	if (count < 0)

--- a/core/include/drivers/stm32_i2c.h
+++ b/core/include/drivers/stm32_i2c.h
@@ -31,6 +31,7 @@
  *
  * @dt_status: non-secure/secure status read from DT
  * @pbase: I2C interface base address
+ * @reg_size: I2C interface register map size
  * @clock: I2C bus/interface clock
  * @addr_mode_10b_not_7b: True if 10bit addressing mode, otherwise 7bit mode
  * @own_address1: 7-bit or 10-bit first device own address.
@@ -48,6 +49,7 @@
 struct stm32_i2c_init_s {
 	unsigned int dt_status;
 	paddr_t pbase;
+	size_t reg_size;
 	unsigned int clock;
 	bool addr_mode_10b_not_7b;
 	uint32_t own_address1;
@@ -100,6 +102,7 @@ struct i2c_cfg {
 /*
  * I2C bus device
  * @base: I2C SoC registers base address
+ * @reg_size: I2C SoC registers address map size
  * @dt_status: non-secure/secure status read from DT
  * @clock: clock ID
  * @i2c_state: Driver state ID I2C_STATE_*
@@ -112,6 +115,7 @@ struct i2c_cfg {
  */
 struct i2c_handle_s {
 	struct io_pa_va base;
+	size_t reg_size;
 	unsigned int dt_status;
 	unsigned long clock;
 	enum i2c_state_e i2c_state;

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -30,6 +30,7 @@
 /*
  * @status: Bit mask for DT_STATUS_*
  * @reg: Device register physical base address or DT_INFO_INVALID_REG
+ * @reg_size: Device register size or DT_INFO_INVALID_REG_SIZE
  * @clock: Device identifier (positive value) or DT_INFO_INVALID_CLOCK
  * @reset: Device reset identifier (positive value) or DT_INFO_INVALID_CLOCK
  * @interrupt: Device interrupt identifier (positive value) or
@@ -42,6 +43,7 @@
 struct dt_node_info {
 	unsigned int status;
 	paddr_t reg;
+	size_t reg_size;
 	int clock;
 	int reset;
 	int interrupt;

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -22,7 +22,7 @@
 #define DT_STATUS_OK_SEC		BIT(1)
 
 #define DT_INFO_INVALID_REG		((paddr_t)-1)
-#define DT_INFO_INVALID_REG_SIZE	((ssize_t)-1)
+#define DT_INFO_INVALID_REG_SIZE	((size_t)-1)
 #define DT_INFO_INVALID_CLOCK		-1
 #define DT_INFO_INVALID_RESET		-1
 #define DT_INFO_INVALID_INTERRUPT	-1
@@ -148,7 +148,7 @@ paddr_t _fdt_reg_base_address(const void *fdt, int offs);
  * Return the reg size for the reg property of the specified node or -1 in case
  * of error
  */
-ssize_t _fdt_reg_size(const void *fdt, int offs);
+size_t _fdt_reg_size(const void *fdt, int offs);
 
 /*
  * Read the status and secure-status properties into a bitfield.
@@ -199,10 +199,10 @@ static inline paddr_t _fdt_reg_base_address(const void *fdt __unused,
 	return (paddr_t)-1;
 }
 
-static inline ssize_t _fdt_reg_size(const void *fdt __unused,
-				    int offs __unused)
+static inline size_t _fdt_reg_size(const void *fdt __unused,
+				   int offs __unused)
 {
-	return -1;
+	return (size_t)-1;
 }
 
 static inline int _fdt_get_status(const void *fdt __unused, int offs __unused)

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -262,6 +262,7 @@ void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info, int offs)
 {
 	struct dt_node_info dinfo = {
 		.reg = DT_INFO_INVALID_REG,
+		.reg_size = DT_INFO_INVALID_REG_SIZE,
 		.clock = DT_INFO_INVALID_CLOCK,
 		.reset = DT_INFO_INVALID_RESET,
 		.interrupt = DT_INFO_INVALID_INTERRUPT,
@@ -269,6 +270,7 @@ void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info, int offs)
 	const fdt32_t *cuint;
 
 	dinfo.reg = _fdt_reg_base_address(fdt, offs);
+	dinfo.reg_size = _fdt_reg_size(fdt, offs);
 
 	cuint = fdt_getprop(fdt, offs, "clocks", NULL);
 	if (cuint) {

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -101,7 +101,7 @@ int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size)
 	enum teecore_memtypes mtype;
 	paddr_t pbase;
 	vaddr_t vbase;
-	ssize_t sz;
+	size_t sz;
 	int st;
 
 	assert(cpu_mmu_enabled());
@@ -114,7 +114,7 @@ int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size)
 	if (pbase == DT_INFO_INVALID_REG)
 		return -1;
 	sz = _fdt_reg_size(fdt, offs);
-	if (sz < 0)
+	if (sz == DT_INFO_INVALID_REG_SIZE)
 		return -1;
 
 	if ((st & DT_STATUS_OK_SEC) && !(st & DT_STATUS_OK_NSEC))
@@ -188,7 +188,7 @@ paddr_t _fdt_reg_base_address(const void *fdt, int offs)
 	return _fdt_read_paddr(reg, ncells);
 }
 
-ssize_t _fdt_reg_size(const void *fdt, int offs)
+size_t _fdt_reg_size(const void *fdt, int offs)
 {
 	const uint32_t *reg;
 	uint32_t sz;
@@ -202,22 +202,22 @@ ssize_t _fdt_reg_size(const void *fdt, int offs)
 
 	reg = (const uint32_t *)fdt_getprop(fdt, offs, "reg", &len);
 	if (!reg)
-		return -1;
+		return DT_INFO_INVALID_REG_SIZE;
 
 	n = fdt_address_cells(fdt, parent);
 	if (n < 1 || n > 2)
-		return -1;
+		return DT_INFO_INVALID_REG_SIZE;
 
 	reg += n;
 
 	n = fdt_size_cells(fdt, parent);
 	if (n < 1 || n > 2)
-		return -1;
+		return DT_INFO_INVALID_REG_SIZE;
 
 	sz = fdt32_to_cpu(*reg);
 	if (n == 2) {
 		if (sz)
-			return -1;
+			return DT_INFO_INVALID_REG_SIZE;
 		reg++;
 		sz = fdt32_to_cpu(*reg);
 	}


### PR DESCRIPTION
A series of changes that use the reg_size from the device tree to manage the call to phys_to_virt which now adds the len management.
Initial patch is to define the size as size_t to be compliant with the different functions using length as size_t and not ssize_t.
Update the driver using the _fdt_fill_device_info to retrieve the reg size and use it to get virtual address.
