### PR TITLE
ci: azure: fix build error in Buildroot's OpenSSL

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -231,6 +231,9 @@ jobs:
       - script: |
           set -e -v
           export LC_ALL=C
+          # Azure CI sets ${SYSTEM} to "build" which prevents OpenSSL from building due to:
+          # https://github.com/openssl/openssl/blob/OpenSSL_1_1_1l/config#L56
+          unset SYSTEM
           WD=$(pwd)
           sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
           sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"


### PR DESCRIPTION
After the addition of Buildroot package host-python3-cryptography as a
dependency of optee_client_ext and optee_examples_ext [1], we now have
a build error in the Azure CI "QEMUv8 check" job:
```
 >>> host-libopenssl 1.1.1l Configuring
 (cd /root/optee_repo_qemu_v8/out-br/build/host-libopenssl-1.1.1l; ...
  ./config ...)
 Operating system: x86_64-whatever-build
 This system (build) is not supported. See file INSTALL for details.
```
The same command runs OK manually in the Docker image, but not in the
Azure environment. It is due to the fact that Azure sets a number of
environment variables, one of which (${SYSTEM}) conflicts with the
OpenSSL configuration script. Since we don't use this variable in our
script, just unset it.

Link: [1] https://github.com/OP-TEE/build/commit/a3b368f89a1c
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
