### PR TITLE
Driver probing sequence - step1 - factorize clk_dt code

### DIFF
--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -13,28 +13,6 @@
 #include <libfdt.h>
 #include <stddef.h>
 
-static struct dt_driver_provider *clk_get_provider_by_node(int nodeoffset)
-{
-	struct dt_driver_provider *prv = NULL;
-
-	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
-		if (prv->nodeoffset == nodeoffset)
-			return prv;
-
-	return NULL;
-}
-
-static struct dt_driver_provider *clk_get_provider_by_phandle(uint32_t phandle)
-{
-	struct dt_driver_provider *prv = NULL;
-
-	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
-		if (prv->phandle == phandle)
-			return prv;
-
-	return NULL;
-}
-
 static struct clk *clk_dt_get_from_provider(struct dt_driver_provider *prv,
 					    unsigned int clock_cells,
 					    const uint32_t *prop)
@@ -91,7 +69,7 @@ static struct clk *clk_dt_get_by_idx_prop(const char *prop_name,
 		idx32 = idx / sizeof(uint32_t);
 		phandle = fdt32_to_cpu(prop[idx32]);
 
-		prv = clk_get_provider_by_phandle(phandle);
+		prv = dt_driver_get_provider_by_node(phandle);
 		if (!prv)
 			return NULL;
 
@@ -232,7 +210,7 @@ static TEE_Result clk_probe_clock_provider_node(const void *fdt, int node)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	/* Check if node has already been probed */
-	if (clk_get_provider_by_node(node))
+	if (dt_driver_get_provider_by_node(node))
 		return TEE_SUCCESS;
 
 	/* Check if the node has a clock property first to probe parent */

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -12,23 +12,12 @@
 #include <sys/queue.h>
 
 /**
- * struct clk_driver - Clock driver setup struct
- * probe: probe function for the clock driver
- */
-struct clk_driver {
-	TEE_Result (*probe)(const void *fdt, int nodeoffset, const void *data);
-};
-
-/**
  * CLK_DT_DECLARE - Declare a clock driver
  * @__name: Clock driver name
  * @__compat: Compatible string
  * @__probe: Clock probe function
  */
 #define CLK_DT_DECLARE(__name, __compat, __probe) \
-	static const struct clk_driver __name ## _driver = { \
-		.probe = __probe, \
-	}; \
 	static const struct dt_device_match __name ## _match_table[] = { \
 		{ .compatible = __compat }, \
 		{ } \
@@ -37,7 +26,7 @@ struct clk_driver {
 		.name = # __name, \
 		.type = DT_DRIVER_CLK, \
 		.match_table = __name ## _match_table, \
-		.driver = &__name ## _driver, \
+		.probe = __probe, \
 	}
 
 /**

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -86,8 +86,14 @@ typedef struct clk *(*clk_dt_get_func)(struct dt_driver_phandle_args *args,
  * @data: Data which will be passed to the get_dt_clk callback
  * Returns TEE_Result value
  */
+static inline
 TEE_Result clk_dt_register_clk_provider(const void *fdt, int nodeoffset,
-					clk_dt_get_func get_dt_clk, void *data);
+					clk_dt_get_func get_dt_clk, void *data)
+{
+	return dt_driver_register_provider(fdt, nodeoffset,
+					   (get_of_device_func)get_dt_clk,
+					   data, DT_DRIVER_CLK);
+}
 
 /**
  * clk_dt_get_simple_clk: simple clock matching function for single clock

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -7,20 +7,9 @@
 #define __DRIVERS_CLK_DT_H
 
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <stdint.h>
 #include <sys/queue.h>
-
-/**
- * struct clk_dt_phandle_args - Devicetree clock args
- * @nodeoffset: Clock consumer node offset
- * @args_count: Count of items in @args
- * @args: Clocks consumer specifiers
- */
-struct clk_dt_phandle_args {
-	int nodeoffset;
-	int args_count;
-	uint32_t *args;
-};
 
 /**
  * struct clk_driver - Clock driver setup struct
@@ -85,7 +74,7 @@ struct clk *clk_dt_get_by_name(const void *fdt, int nodeoffset,
  * Returns a clk struct pointer pointing to a clock matching the devicetree
  * description or NULL if invalid description.
  */
-typedef struct clk *(*clk_dt_get_func)(struct clk_dt_phandle_args *args,
+typedef struct clk *(*clk_dt_get_func)(struct dt_driver_phandle_args *args,
 				       void *data);
 
 /**
@@ -105,7 +94,7 @@ TEE_Result clk_dt_register_clk_provider(const void *fdt, int nodeoffset,
  * providers
  */
 static inline
-struct clk *clk_dt_get_simple_clk(struct clk_dt_phandle_args *args __unused,
+struct clk *clk_dt_get_simple_clk(struct dt_driver_phandle_args *args __unused,
 				  void *data)
 {
 	return data;

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2016, Linaro Limited
+ * Copyright (c) 2016-2021, Linaro Limited
  */
 
 #ifndef KERNEL_DT_H
@@ -10,6 +10,7 @@
 #include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <stdint.h>
+#include <tee_api_types.h>
 #include <types_ext.h>
 #include <util.h>
 
@@ -66,11 +67,35 @@ enum dt_driver_type {
 	DT_DRIVER_CLK,
 };
 
+/*
+ * dt_driver_probe_func - Callback probe function for a driver.
+ *
+ * @fdt: FDT base address
+ * @nodeoffset: Offset of the node in the FDT
+ * @compat_data: Data registered for the compatible that probed the device
+ *
+ * Return TEE_SUCCESS on successful probe,
+ *	TEE_ERROR_ITEM_NOT_FOUND when no driver matched node's compatible string
+ *	Any other TEE_ERROR_* compliant code.
+ */
+typedef TEE_Result (*dt_driver_probe_func)(const void *fdt, int nodeoffset,
+					   const void *compat_data);
+
+/*
+ * Driver instance registered to be probed on compatible node found in the DT.
+ *
+ * @name: Driver name
+ * @type: Drive type
+ * @match_table: Compatible matching identifiers, null terminated
+ * @driver: Driver private reference or NULL
+ * @probe: Probe callback (see dt_driver_probe_func) or NULL
+ */
 struct dt_driver {
 	const char *name;
 	enum dt_driver_type type;
 	const struct dt_device_match *match_table; /* null-terminated */
 	const void *driver;
+	TEE_Result (*probe)(const void *fdt, int node, const void *compat_data);
 };
 
 #define __dt_driver __section(".rodata.dtdrv" __SECTION_FLAGS_RODATA)

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -80,6 +80,22 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
 				       void *data, enum dt_driver_type type);
 
 /*
+ * dt_driver_device_from_node_idx_prop - Return a device instance based on a
+ *	property name and FDT information
+ *
+ * @prop_name: DT property name, e.g. "clocks" for clock resources
+ * @fdt: FDT base address
+ * @nodeoffset: node offset in the FDT
+ * @prop_idx: index of the phandle data in the property
+ *
+ * Return a device opaque reference, e.g. a struct clk pointer for a clock
+ * driver, or NULL if not found.
+ */
+void *dt_driver_device_from_node_idx_prop(const char *prop_name,
+					  const void *fdt, int nodeoffset,
+					  unsigned int prop_idx);
+
+/*
  * Return driver provider reference from its node offset value in the FDT
  */
 struct dt_driver_provider *dt_driver_get_provider_by_node(int nodeoffset);

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -80,6 +80,16 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
 				       void *data, enum dt_driver_type type);
 
 /*
+ * Return driver provider reference from its node offset value in the FDT
+ */
+struct dt_driver_provider *dt_driver_get_provider_by_node(int nodeoffset);
+
+/*
+ * Return driver provider reference from its phandle value in the FDT
+ */
+struct dt_driver_provider *dt_driver_get_provider_by_phandle(uint32_t phandle);
+
+/*
  * Return number cells used for phandle arguments by a driver provider
  */
 unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv);

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -10,6 +10,7 @@
 #include <kernel/dt.h>
 #include <stdint.h>
 #include <sys/queue.h>
+#include <tee_api_types.h>
 
 /**
  * struct dt_driver_phandle_args - Devicetree phandle arguments
@@ -60,4 +61,39 @@ struct dt_driver_provider {
 
 SLIST_HEAD(dt_driver_prov_list, dt_driver_provider);
 extern struct dt_driver_prov_list dt_driver_provider_list;
+
+/**
+ * dt_driver_register_provider - Register a driver provider
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset in the FDT
+ * @get_of_device: Function to match the devicetree with a device instance
+ * @data: Data which will be passed to the @get_of_device callback
+ * @type: Driver type
+ *
+ * @get_of_device returns a void *. Driver provider is expected to
+ * include a shim helper to cast to device reference into provider driver
+ * target structure reference (e.g (struct clk *) for clock devices).
+ */
+TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
+				       get_of_device_func get_of_device,
+				       void *data, enum dt_driver_type type);
+
+/*
+ * Return number cells used for phandle arguments by a driver provider
+ */
+unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv);
+
+/*
+ * Get cells count of a device node given its dt_driver type
+ *
+ * @fdt: FDT base address
+ * @nodeoffset: Node offset on the FDT for the device
+ * @type: One of the supported DT_DRIVER_* value.
+ *
+ * Currently supports type DT_DRIVER_CLK.
+ * Return a positive cell count value (>= 0) or a negative FDT_ error code
+ */
+int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
+			    enum dt_driver_type type);
 #endif /* __DT_DRIVER_H */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * Copyright (c) 2021, Bootlin
+ */
+
+#ifndef __DT_DRIVER_H
+#define __DT_DRIVER_H
+
+#include <kernel/dt.h>
+#include <stdint.h>
+#include <sys/queue.h>
+
+/**
+ * struct dt_driver_phandle_args - Devicetree phandle arguments
+ * @args_count: Count of cells for the device
+ * @args: Device consumer specifiers
+ */
+struct dt_driver_phandle_args {
+	int args_count;
+	uint32_t args[];
+};
+
+/*
+ * get_of_device_func - Callback function for returning a driver private
+ *	instance based on a FDT phandle with possible arguments and the
+ *	registered dt_driver private data reference.
+ *
+ * @parg: phandle argument(s) referencing the device in the FDT.
+ * @data: driver private data registered in struct dt_driver.
+ *
+ * Return a device opaque reference, e.g. a struct clk pointer for a clock
+ * driver, or NULL if not found.
+ */
+typedef void *(*get_of_device_func)(struct dt_driver_phandle_args *parg,
+				    void *data);
+
+/*
+ * struct dt_driver_provider - DT related info on probed device
+ *
+ * Saves information on the probed device so that device
+ * drivers can get resources from DT phandle and related arguments.
+ *
+ * @nodeoffset: Node offset of device referenced in the FDT
+ * @type: One of DT_DRIVER_* or DT_DRIVER_NOTYPE.
+ * @provider_cells: Cells count in the FDT used by the driver's references
+ * @get_of_device: Function to get driver's device ref from phandle data
+ * @priv_data: Driver private data passed as @get_of_device argument
+ * @link: Reference in DT driver providers list
+ */
+struct dt_driver_provider {
+	int nodeoffset;
+	enum dt_driver_type type;
+	unsigned int provider_cells;
+	uint32_t phandle;
+	get_of_device_func get_of_device;
+	void *priv_data;
+	SLIST_ENTRY(dt_driver_provider) link;
+};
+
+SLIST_HEAD(dt_driver_prov_list, dt_driver_provider);
+extern struct dt_driver_prov_list dt_driver_provider_list;
+#endif /* __DT_DRIVER_H */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -111,6 +111,22 @@ struct dt_driver_provider *dt_driver_get_provider_by_phandle(uint32_t phandle);
 unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv);
 
 /*
+ * dt_driver_probe_device_by_node - Probe matching driver to create a device
+ *	from a FDT node
+ *
+ * @fdt: FDT base address
+ * @nodeoffset: Node byte offset from FDT base
+ * @type: Target driver to match or DT_DRIVER_ANY
+ *
+ * Read the dt_driver database. Compatible list is looked up in the order
+ * of the FDT "compatible" property list. @type can be used to probe only
+ * specific drivers.
+ *
+ */
+TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
+					  enum dt_driver_type type);
+
+/*
  * Get cells count of a device node given its dt_driver type
  *
  * @fdt: FDT base address

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -12,6 +12,9 @@
 #include <sys/queue.h>
 #include <tee_api_types.h>
 
+/* Opaque reference to DT driver device provider instance */
+struct dt_driver_provider;
+
 /**
  * struct dt_driver_phandle_args - Devicetree phandle arguments
  * @args_count: Count of cells for the device
@@ -35,32 +38,6 @@ struct dt_driver_phandle_args {
  */
 typedef void *(*get_of_device_func)(struct dt_driver_phandle_args *parg,
 				    void *data);
-
-/*
- * struct dt_driver_provider - DT related info on probed device
- *
- * Saves information on the probed device so that device
- * drivers can get resources from DT phandle and related arguments.
- *
- * @nodeoffset: Node offset of device referenced in the FDT
- * @type: One of DT_DRIVER_* or DT_DRIVER_NOTYPE.
- * @provider_cells: Cells count in the FDT used by the driver's references
- * @get_of_device: Function to get driver's device ref from phandle data
- * @priv_data: Driver private data passed as @get_of_device argument
- * @link: Reference in DT driver providers list
- */
-struct dt_driver_provider {
-	int nodeoffset;
-	enum dt_driver_type type;
-	unsigned int provider_cells;
-	uint32_t phandle;
-	get_of_device_func get_of_device;
-	void *priv_data;
-	SLIST_ENTRY(dt_driver_provider) link;
-};
-
-SLIST_HEAD(dt_driver_prov_list, dt_driver_provider);
-extern struct dt_driver_prov_list dt_driver_provider_list;
 
 /**
  * dt_driver_register_provider - Register a driver provider

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -12,7 +12,30 @@
 #include <sys/queue.h>
 #include <tee_api_types.h>
 
-struct dt_driver_prov_list dt_driver_provider_list =
+/*
+ * struct dt_driver_provider - DT related info on probed device
+ *
+ * Saves information on the probed device so that device
+ * drivers can get resources from DT phandle and related arguments.
+ *
+ * @nodeoffset: Node offset of device referenced in the FDT
+ * @type: One of DT_DRIVER_* or DT_DRIVER_NOTYPE.
+ * @provider_cells: Cells count in the FDT used by the driver's references
+ * @get_of_device: Function to get driver's device ref from phandle data
+ * @priv_data: Driver private data passed as @get_of_device argument
+ * @link: Reference in DT driver providers list
+ */
+struct dt_driver_provider {
+	int nodeoffset;
+	enum dt_driver_type type;
+	unsigned int provider_cells;
+	uint32_t phandle;
+	get_of_device_func get_of_device;
+	void *priv_data;
+	SLIST_ENTRY(dt_driver_provider) link;
+};
+
+static SLIST_HEAD(, dt_driver_provider) dt_driver_provider_list =
 	SLIST_HEAD_INITIALIZER(dt_driver_provider_list);
 
 /*

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * Copyright (c) 2021, Bootlin
+ */
+
+#include <kernel/dt_driver.h>
+#include <sys/queue.h>
+
+struct dt_driver_prov_list dt_driver_provider_list =
+	SLIST_HEAD_INITIALIZER(dt_driver_provider_list);

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -4,8 +4,103 @@
  * Copyright (c) 2021, Bootlin
  */
 
+#include <initcall.h>
+#include <kernel/dt.h>
 #include <kernel/dt_driver.h>
+#include <libfdt.h>
+#include <malloc.h>
 #include <sys/queue.h>
+#include <tee_api_types.h>
 
 struct dt_driver_prov_list dt_driver_provider_list =
 	SLIST_HEAD_INITIALIZER(dt_driver_provider_list);
+
+/*
+ * Driver provider registering API functions
+ */
+
+TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
+				       get_of_device_func get_of_device,
+				       void *priv, enum dt_driver_type type)
+{
+	struct dt_driver_provider *prv = NULL;
+	int provider_cells = 0;
+	uint32_t phandle = 0;
+
+	provider_cells = fdt_get_dt_driver_cells(fdt, nodeoffset, type);
+	if (provider_cells < 0) {
+		DMSG("Failed to find provider cells: %d", provider_cells);
+		return TEE_ERROR_GENERIC;
+	}
+
+	phandle = fdt_get_phandle(fdt, nodeoffset);
+	if (!phandle || phandle == (uint32_t)-1) {
+		DMSG("Failed to find provide phandle");
+		return TEE_ERROR_GENERIC;
+	}
+
+	prv = calloc(1, sizeof(*prv));
+	if (!prv)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	prv->nodeoffset = nodeoffset;
+	prv->type = type;
+	prv->provider_cells = provider_cells;
+	prv->phandle = phandle;
+	prv->get_of_device = get_of_device;
+	prv->priv_data = priv;
+
+	SLIST_INSERT_HEAD(&dt_driver_provider_list, prv, link);
+
+	return TEE_SUCCESS;
+}
+
+/* Release driver provider references once all dt_drivers are initialized */
+static TEE_Result dt_driver_release_provider(void)
+{
+	struct dt_driver_provider *prv = NULL;
+
+	while (!SLIST_EMPTY(&dt_driver_provider_list)) {
+		prv = SLIST_FIRST(&dt_driver_provider_list);
+		SLIST_REMOVE_HEAD(&dt_driver_provider_list, link);
+		free(prv);
+	}
+
+	return TEE_SUCCESS;
+}
+
+driver_init_late(dt_driver_release_provider);
+
+/*
+ * Helper functions for dt_drivers querying driver provider information
+ */
+
+int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
+			    enum dt_driver_type type)
+{
+	const char *cells_name = NULL;
+	const fdt32_t *c = NULL;
+	int len = 0;
+
+	switch (type) {
+	case DT_DRIVER_CLK:
+		cells_name = "#clock-cells";
+		break;
+	default:
+		panic();
+	}
+
+	c = fdt_getprop(fdt, nodeoffset, cells_name, &len);
+	if (!c)
+		return len;
+
+	if (len != sizeof(*c))
+		return -FDT_ERR_BADNCELLS;
+
+	return fdt32_to_cpu(*c);
+}
+
+unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv)
+{
+	return prv->provider_cells;
+}

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -104,3 +104,25 @@ unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv)
 {
 	return prv->provider_cells;
 }
+
+struct dt_driver_provider *dt_driver_get_provider_by_node(int nodeoffset)
+{
+	struct dt_driver_provider *prv = NULL;
+
+	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
+		if (prv->nodeoffset == nodeoffset)
+			return prv;
+
+	return NULL;
+}
+
+struct dt_driver_provider *dt_driver_get_provider_by_phandle(uint32_t phandle)
+{
+	struct dt_driver_provider *prv = NULL;
+
+	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
+		if (prv->phandle == phandle)
+			return prv;
+
+	return NULL;
+}

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -3,6 +3,7 @@ cflags-remove-asan.c-y += $(cflags_kasan)
 srcs-y += assert.c
 srcs-y += console.c
 srcs-$(CFG_DT) += dt.c
+srcs-$(CFG_DT) += dt_driver.c
 srcs-y += pm.c
 srcs-y += handle.c
 srcs-y += interrupt.c


### PR DESCRIPTION
This P-R implements the first commits from RFC P-R #4949 that moves code from **core/drivers/clk/clk_dt.c** to a newly created source file **core/kernel/dt_driver.c** to use the sequences and resources for other drivers than clocks.