### PR TITLE
BTI support for OP-TEE core and TA's

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -167,6 +167,14 @@ ifeq ($(CFG_CORE_ASLR),y)
 core-platform-cflags += -fpie
 endif
 
+ifeq ($(CFG_CORE_BTI),y)
+bti-opt := $(call cc-option,-mbranch-protection=bti)
+ifeq (,$(bti-opt))
+$(error -mbranch-protection=bti not supported)
+endif
+core-platform-cflags += $(bti-opt)
+endif
+
 ifeq ($(CFG_ARM64_core),y)
 core-platform-cppflags += $(arm64-platform-cppflags)
 core-platform-cflags += $(arm64-platform-cflags)

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -290,6 +290,14 @@ ta_arm64-platform-cxxflags += -fpic
 ta_arm64-platform-cxxflags += $(platform-cflags-optimization)
 ta_arm64-platform-cxxflags += $(platform-cflags-debug-info)
 
+ifeq ($(CFG_TA_BTI),y)
+bti-ta-opt := $(call cc-option,-mbranch-protection=bti)
+ifeq (,$(bti-ta-opt))
+$(error -mbranch-protection=bti not supported)
+endif
+ta_arm64-platform-cflags += $(bti-ta-opt)
+endif
+
 ta-mk-file-export-vars-ta_arm64 += CFG_ARM64_ta_arm64
 ta-mk-file-export-vars-ta_arm64 += ta_arm64-platform-cppflags
 ta-mk-file-export-vars-ta_arm64 += ta_arm64-platform-cflags

--- a/core/arch/arm/crypto/aes_modes_armv8a_ce_a64.S
+++ b/core/arch/arm/crypto/aes_modes_armv8a_ce_a64.S
@@ -660,3 +660,5 @@ FUNC ce_aes_xor_block , :
 	st1	{v0.16b}, [x0]
 	ret
 END_FUNC ce_aes_xor_block
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/crypto/ghash-ce-core_a64.S
+++ b/core/arch/arm/crypto/ghash-ce-core_a64.S
@@ -646,3 +646,5 @@ FUNC pmull_gcm_aes_sub , :
 	umov	w0, v0.s[0]
 	ret
 END_FUNC pmull_gcm_aes_sub
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/crypto/sha1_armv8a_ce_a64.S
+++ b/core/arch/arm/crypto/sha1_armv8a_ce_a64.S
@@ -121,3 +121,5 @@ FUNC sha1_ce_transform , :
 .Lsha1_rcon:
 	.word		0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6
 END_FUNC sha1_ce_transform
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/crypto/sha256_armv8a_ce_a64.S
+++ b/core/arch/arm/crypto/sha256_armv8a_ce_a64.S
@@ -132,3 +132,5 @@ FUNC sha256_ce_transform , :
 	.word		0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208
 	.word		0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
 END_FUNC sha256_ce_transform
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -6,6 +6,7 @@
 #ifndef ARM_H
 #define ARM_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <util.h>
 
@@ -112,6 +113,16 @@ static inline __noprof uint64_t barrier_read_counter_timer(void)
 	return read_cntvct();
 #else
 	return read_cntpct();
+#endif
+}
+
+static inline bool feat_bti_is_implemented(void)
+{
+#ifdef ARM32
+	return false;
+#else
+	return ((read_id_aa64pfr1_el1() & ID_AA64PFR1_EL1_BT_MASK) ==
+		FEAT_BTI_IMPLEMENTED);
 #endif
 }
 #endif

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -196,6 +196,9 @@
 #define TLBI_ASID_SHIFT		U(48)
 #define TLBI_ASID_MASK		U(0xff)
 
+#define ID_AA64PFR1_EL1_BT_MASK	ULL(0xf)
+#define FEAT_BTI_IMPLEMENTED	ULL(0x1)
+
 #ifndef __ASSEMBLER__
 static inline __noprof void isb(void)
 {
@@ -354,6 +357,8 @@ DEFINE_U64_REG_READ_FUNC(midr_el1)
 DEFINE_U64_REG_READ_FUNC(par_el1)
 
 DEFINE_U64_REG_WRITE_FUNC(mair_el1)
+
+DEFINE_U64_REG_READ_FUNC(id_aa64pfr1_el1)
 
 /* Register read/write functions for GICC registers by using system interface */
 DEFINE_REG_READ_FUNC_(icc_ctlr, uint32_t, S3_0_C12_C12_4)

--- a/core/arch/arm/kernel/cache_helpers_a64.S
+++ b/core/arch/arm/kernel/cache_helpers_a64.S
@@ -237,3 +237,5 @@ loop_ic_inv:
 	ret
 
 END_FUNC icache_inv_range
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/cache_helpers_a64.S
+++ b/core/arch/arm/kernel/cache_helpers_a64.S
@@ -102,6 +102,7 @@ LOCAL_FUNC do_dcsw_op , :
 	cbz	x3, exit
 	adr	x14, dcsw_loop_table	// compute inner loop address
 	add	x14, x14, x0, lsl #5	// inner loop is 8x32-bit instructions
+BTI(	add	x14, x14, x0, lsl #2)	// inner loop is + "bti j" instruction
 	mov	x0, x9
 	mov	w8, #1
 loop1:
@@ -127,6 +128,7 @@ loop1:
 	br	x14			// jump to DC operation specific loop
 
 	.macro	dcsw_loop _op
+BTI(	bti	j)
 loop2_\_op:
 	lsl	w7, w6, w2		// w7 = aligned max set number
 

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -479,7 +479,7 @@ END_FUNC unhandled_cpu
 
 	.section .identity_map, "ax", %progbits
 	.align	11
-LOCAL_FUNC reset_vect_table , :, .identity_map
+LOCAL_FUNC reset_vect_table , :, .identity_map, , nobti
 	/* -----------------------------------------------------
 	 * Current EL with SP0 : 0x0 - 0x180
 	 * -----------------------------------------------------

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -576,3 +576,5 @@ SErrorA32:
 	check_vector_size SErrorA32
 
 END_FUNC reset_vect_table
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -144,6 +144,7 @@ SECTIONS
 	}
 
 	.got : { *(.got.plt) *(.got) }
+	.note.gnu.property : { *(.note.gnu.property) }
 	.plt : { *(.plt) }
 
 	.ctors : ALIGN(8) {

--- a/core/arch/arm/kernel/ldelf_loader.c
+++ b/core/arch/arm/kernel/ldelf_loader.c
@@ -55,6 +55,7 @@ TEE_Result ldelf_load_ldelf(struct user_mode_ctx *uctx)
 	vaddr_t stack_addr = 0;
 	vaddr_t code_addr = 0;
 	vaddr_t rw_addr = 0;
+	uint32_t prot = 0;
 
 	uctx->is_32bit = is_arm32;
 
@@ -82,9 +83,12 @@ TEE_Result ldelf_load_ldelf(struct user_mode_ctx *uctx)
 	memcpy((void *)code_addr, ldelf_data, ldelf_code_size);
 	memcpy((void *)rw_addr, ldelf_data + ldelf_code_size, ldelf_data_size);
 
+	prot = TEE_MATTR_URX;
+	if (IS_ENABLED(CFG_CORE_BTI))
+		prot |= TEE_MATTR_GUARDED;
+
 	res = vm_set_prot(uctx, code_addr,
-			  ROUNDUP(ldelf_code_size, SMALL_PAGE_SIZE),
-			  TEE_MATTR_URX);
+			  ROUNDUP(ldelf_code_size, SMALL_PAGE_SIZE), prot);
 	if (res)
 		return res;
 

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -13,6 +13,14 @@ link-ldflags  = $(LDFLAGS)
 ifeq ($(CFG_CORE_ASLR),y)
 link-ldflags += -pie -Bsymbolic -z notext -z norelro $(ldflag-apply-dynamic-relocs)
 endif
+ifeq ($(CFG_CORE_BTI),y)
+# force-bti tells the linker to warn if some object files lack the .note.gnu.property
+# section with the BTI flag, and to turn on the BTI flag in the output anyway. The
+# resulting executable would likely fail at runtime so we use this flag along
+# with the --fatal-warnings below to check and prevent this situation (with useful
+# diagnostics).
+link-ldflags += $(call ld-option,-z force-bti) --fatal-warnings
+endif
 link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
 link-ldflags += --sort-section=alignment
 link-ldflags += --fatal-warnings

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -51,3 +51,5 @@ WEAK_FUNC get_core_pos_mpidr , :
 
 	ret
 END_FUNC get_core_pos_mpidr
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/spin_lock_a64.S
+++ b/core/arch/arm/kernel/spin_lock_a64.S
@@ -88,3 +88,5 @@ FUNC __cpu_spin_unlock , :
 	stlr	wzr, [x0]
 	ret
 END_FUNC __cpu_spin_unlock
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -1028,3 +1028,5 @@ LOCAL_FUNC elx_fiq , :
 	native_intr_handler	fiq
 #endif
 END_FUNC elx_fiq
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -191,7 +191,7 @@ END_FUNC thread_unwind_user_mode
 		ldr	x0, =1f
 		br	x0
 	1:
-
+BTI(		bti	j)
 		/* Point to the vector into the full mapping */
 		adr_l	x0, thread_user_kcode_offset
 		ldr	x0, [x0]
@@ -488,7 +488,7 @@ eret_to_el0:
 	sub	x1, x1, x0
 	br	x1
 1:
-
+BTI(	bti	j)
 	load_xregs sp, THREAD_CORE_LOCAL_X0, 0, 1
 	msr	tpidrro_el0, x0
 
@@ -547,7 +547,7 @@ icache_inv_user_range:
 	sub	x3, x3, x2
 	br	x3
 1:
-
+BTI(	bti	j)
 	/* Update the mapping to exclude the full kernel mapping */
 	mrs	x5, ttbr0_el1	/* this register must be preserved */
 	add	x2, x5, #CORE_MMU_BASE_TABLE_OFFSET
@@ -591,7 +591,7 @@ icache_inv_user_range:
 	ldr	x0, =1f
 	br	x0
 1:
-
+BTI(	bti	j)
 	/* Point to the vector into the full mapping */
 	msr	vbar_el1, x4
 	isb

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -225,7 +225,7 @@ END_FUNC thread_unwind_user_mode
 	.endm
 
 #define INV_INSN	0
-FUNC thread_excp_vect , : align=2048
+FUNC thread_excp_vect , : , default, 2048, nobti
 	/* -----------------------------------------------------
 	 * EL1 with SP0 : 0x0 - 0x180
 	 * -----------------------------------------------------

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -131,7 +131,7 @@ END_FUNC vector_system_reset_entry
  * Note that ARM-TF depends on the layout of this vector table, any change
  * in layout has to be synced with ARM-TF.
  */
-FUNC thread_vector_table , : , .identity_map
+FUNC thread_vector_table , : , .identity_map, , nobti
 	b	vector_std_smc_entry
 	b	vector_fast_smc_entry
 	b	vector_cpu_on_entry

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -236,3 +236,5 @@ FUNC thread_foreign_intr_exit , :
 	smc	#0
 	b	.	/* SMC should not return */
 END_FUNC thread_foreign_intr_exit
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -30,6 +30,7 @@
 	ldr	x16, =1111f
 	br	x16
 1111:
+BTI(	bti	j)
 #endif
 	.endm
 

--- a/core/arch/arm/kernel/thread_spmc_a64.S
+++ b/core/arch/arm/kernel/thread_spmc_a64.S
@@ -181,3 +181,5 @@ FUNC thread_foreign_intr_exit , :
 	mov	w7, w0
 	b	ffa_msg_send_direct_resp
 END_FUNC thread_foreign_intr_exit
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/tlb_helpers_a64.S
+++ b/core/arch/arm/kernel/tlb_helpers_a64.S
@@ -37,3 +37,5 @@ FUNC tlbi_asid , :
 	isb			/* Sync execution on tlb update */
 	ret
 END_FUNC tlbi_asid
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/kernel/vfp_a64.S
+++ b/core/arch/arm/kernel/vfp_a64.S
@@ -46,3 +46,5 @@ FUNC vfp_restore_extension_regs , :
 	ldp	q30, q31, [x0, #16 * 30]
 	ret
 END_FUNC vfp_restore_extension_regs
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/arch/arm/tee/arch_svc_a64.S
+++ b/core/arch/arm/tee/arch_svc_a64.S
@@ -195,3 +195,5 @@ FUNC syscall_panic , :
 	ldr	x3, [x19, #SC_REC_X0] /* pointer to struct thread_svc_regs */
 	b	tee_svc_sys_return_helper
 END_FUNC syscall_panic
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/core/include/mm/tee_mmu_types.h
+++ b/core/include/mm/tee_mmu_types.h
@@ -24,7 +24,8 @@
 #define TEE_MATTR_URW			(TEE_MATTR_UR | TEE_MATTR_UW)
 #define TEE_MATTR_URX			(TEE_MATTR_UR | TEE_MATTR_UX)
 #define TEE_MATTR_URWX			(TEE_MATTR_URW | TEE_MATTR_UX)
-#define TEE_MATTR_PROT_MASK		(TEE_MATTR_PRWX | TEE_MATTR_URWX)
+#define TEE_MATTR_PROT_MASK	\
+		(TEE_MATTR_PRWX | TEE_MATTR_URWX | TEE_MATTR_GUARDED)
 
 #define TEE_MATTR_GLOBAL		BIT(10)
 #define TEE_MATTR_SECURE		BIT(11)
@@ -34,6 +35,8 @@
 /* These are shifted TEE_MATTR_CACHE_SHIFT */
 #define TEE_MATTR_CACHE_NONCACHE U(0)
 #define TEE_MATTR_CACHE_CACHED	U(1)
+
+#define TEE_MATTR_GUARDED		BIT(15)
 
 /*
  * Tags TA mappings which are only used during a single call (open session

--- a/core/kernel/ldelf_syscalls.c
+++ b/core/kernel/ldelf_syscalls.c
@@ -276,6 +276,7 @@ TEE_Result ldelf_syscall_map_bin(vaddr_t *va, size_t num_bytes,
 	uint32_t prot = 0;
 	const uint32_t accept_flags = LDELF_MAP_FLAG_SHAREABLE |
 				      LDELF_MAP_FLAG_WRITEABLE |
+				      LDELF_MAP_FLAG_BTI |
 				      LDELF_MAP_FLAG_EXECUTABLE;
 
 	if (!sys_ctx)
@@ -304,6 +305,8 @@ TEE_Result ldelf_syscall_map_bin(vaddr_t *va, size_t num_bytes,
 		prot |= TEE_MATTR_UW | TEE_MATTR_PW;
 	if (flags & LDELF_MAP_FLAG_EXECUTABLE)
 		prot |= TEE_MATTR_UX;
+	if (flags & LDELF_MAP_FLAG_BTI)
+		prot |= TEE_MATTR_GUARDED;
 
 	offs_pages = offs_bytes >> SMALL_PAGE_SHIFT;
 	if (ROUNDUP_OVERFLOW(num_bytes, SMALL_PAGE_SIZE, &num_rounded_bytes))
@@ -453,6 +456,7 @@ TEE_Result ldelf_syscall_set_prot(unsigned long va, size_t num_bytes,
 	uint32_t vm_flags = 0;
 	vaddr_t end_va = 0;
 	const uint32_t accept_flags = LDELF_MAP_FLAG_WRITEABLE |
+				      LDELF_MAP_FLAG_BTI |
 				      LDELF_MAP_FLAG_EXECUTABLE;
 
 	if ((flags & accept_flags) != flags)
@@ -461,6 +465,8 @@ TEE_Result ldelf_syscall_set_prot(unsigned long va, size_t num_bytes,
 		prot |= TEE_MATTR_UW | TEE_MATTR_PW;
 	if (flags & LDELF_MAP_FLAG_EXECUTABLE)
 		prot |= TEE_MATTR_UX;
+	if (flags & LDELF_MAP_FLAG_BTI)
+		prot |= TEE_MATTR_GUARDED;
 
 	/*
 	 * The vm_get_flags() and vm_unmap() are supposed to detect or handle

--- a/core/mm/vm.c
+++ b/core/mm/vm.c
@@ -794,15 +794,19 @@ TEE_Result vm_unmap(struct user_mode_ctx *uctx, vaddr_t va, size_t len)
 
 static TEE_Result map_kinit(struct user_mode_ctx *uctx)
 {
-	TEE_Result res;
-	struct mobj *mobj;
-	size_t offs;
-	vaddr_t va;
-	size_t sz;
+	TEE_Result res = TEE_SUCCESS;
+	struct mobj *mobj = NULL;
+	size_t offs = 0;
+	vaddr_t va = 0;
+	size_t sz = 0;
+	uint32_t prot = 0;
 
 	thread_get_user_kcode(&mobj, &offs, &va, &sz);
 	if (sz) {
-		res = vm_map(uctx, &va, sz, TEE_MATTR_PRX, VM_FLAG_PERMANENT,
+		prot = TEE_MATTR_PRX;
+		if (IS_ENABLED(CFG_CORE_BTI))
+			prot |= TEE_MATTR_GUARDED;
+		res = vm_map(uctx, &va, sz, prot, VM_FLAG_PERMANENT,
 			     mobj, offs);
 		if (res)
 			return res;

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -189,6 +189,24 @@ static TEE_Result get_prop_ta_app_id(struct ts_session *sess,
 	return copy_to_user(buf, &sess->ctx->uuid, sizeof(TEE_UUID));
 }
 
+#ifdef CFG_TA_BTI
+static TEE_Result
+get_prop_feat_bti_implemented(struct ts_session *sess __unused, void *buf,
+			      size_t *blen)
+{
+	bool bti_impl = false;
+
+	if (*blen < sizeof(bti_impl)) {
+		*blen = sizeof(bti_impl);
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+	*blen = sizeof(bti_impl);
+	bti_impl = feat_bti_is_implemented();
+
+	return copy_to_user(buf, &bti_impl, sizeof(bti_impl));
+}
+#endif
+
 /* Properties of the set TEE_PROPSET_CURRENT_CLIENT */
 const struct tee_props tee_propset_client[] = {
 	{
@@ -297,6 +315,13 @@ const struct tee_props tee_propset_tee[] = {
 		.data = fw_manufacturer,
 		.len = sizeof(fw_manufacturer)
 	},
+#ifdef CFG_TA_BTI
+	{
+		.name = "org.trustedfirmware.optee.cpu.feat_bti_implemented",
+		.prop_type = USER_TA_PROP_TYPE_BOOL,
+		.get_prop_func = get_prop_feat_bti_implemented
+	},
+#endif
 
 	/*
 	 * Following properties are processed directly in libutee:

--- a/ldelf/include/ldelf.h
+++ b/ldelf/include/ldelf.h
@@ -105,6 +105,7 @@ struct dl_entry_arg {
 #define LDELF_MAP_FLAG_SHAREABLE	BIT32(0)
 #define LDELF_MAP_FLAG_WRITEABLE	BIT32(1)
 #define LDELF_MAP_FLAG_EXECUTABLE	BIT32(2)
+#define LDELF_MAP_FLAG_BTI		BIT32(3)
 
 #endif /*!__ASSEMBLER__*/
 

--- a/ldelf/ldelf.ld.S
+++ b/ldelf/ldelf.ld.S
@@ -27,6 +27,7 @@ SECTIONS {
 		*(.vfp11_veneer)
 		__text_end = .;
 	}
+	.note.gnu.property : { *(.note.gnu.property) }
         .plt : { *(.plt) }
 
 	.eh_frame : { *(.eh_frame) }

--- a/ldelf/link.mk
+++ b/ldelf/link.mk
@@ -17,6 +17,9 @@ link-ldflags += -T $(link-script-pp$(sm))
 link-ldflags += -Map=$(link-out-dir$(sm))/ldelf.map
 link-ldflags += --sort-section=alignment
 link-ldflags += -z max-page-size=4096 # OP-TEE always uses 4K alignment
+ifeq ($(CFG_CORE_BTI),y)
+link-ldflags += $(call ld-option,-z force-bti) --fatal-warnings
+endif
 link-ldflags += $(link-ldflags$(sm))
 
 link-ldadd  = $(addprefix -L,$(libdirs))

--- a/ldelf/start_a64.S
+++ b/ldelf/start_a64.S
@@ -60,3 +60,5 @@ reloc_begin_rel:
 reloc_end_rel:
     .word __reloc_end - reloc_end_rel
 END_FUNC _ldelf_start
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/ldelf/syscalls_a64.S
+++ b/ldelf/syscalls_a64.S
@@ -29,3 +29,5 @@
 	END_FUNC _ldelf_panic
 
 #include "syscalls_asm.S"
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/ldelf/ta_elf.h
+++ b/ldelf/ta_elf.h
@@ -29,6 +29,7 @@ struct ta_elf {
 	bool is_main;
 	bool is_32bit;	/* Initialized from Elf32_Ehdr/Elf64_Ehdr */
 	bool is_legacy;
+	bool bti_enabled;
 
 	vaddr_t load_addr;
 	vaddr_t max_addr;
@@ -78,6 +79,11 @@ struct ta_elf {
 	/* Offset of the copy of the TLS block in the TLS area of the TCB */
 	size_t tls_tcb_offs;
 #endif
+
+	/* PT_GNU_PROPERTY segment */
+	vaddr_t prop_start;
+	size_t prop_align;
+	size_t prop_memsz;
 
 	uint32_t handle;
 

--- a/ldelf/tlsdesc_rel_a64.S
+++ b/ldelf/tlsdesc_rel_a64.S
@@ -18,3 +18,4 @@ FUNC tlsdesc_resolve , :
 	ret
 END_FUNC tlsdesc_resolve
 
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/lib/libutee/arch/arm/utee_syscalls_a64.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a64.S
@@ -46,3 +46,4 @@
 
 #include "utee_syscalls_asm.S"
 
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/lib/libutee/include/elf_common.h
+++ b/lib/libutee/include/elf_common.h
@@ -63,6 +63,14 @@ typedef struct {
 	uint32_t	gh_maskwords;	/* #maskwords used in bloom filter. */
 	uint32_t	gh_shift2;	/* Bloom filter shift count. */
 } Elf_GNU_Hash_Header;
+
+/*
+ * Program Property Array
+ */
+typedef struct {
+	uint32_t	pr_type;
+	uint32_t	pr_datasz;
+} Elf_Prop;
 #endif /*__ASSEMBLER__*/
 
 /* Indexes into the e_ident array.  Keep synced with
@@ -352,6 +360,7 @@ typedef struct {
 #define	PT_GNU_EH_FRAME	0x6474e550
 #define	PT_GNU_STACK	0x6474e551
 #define	PT_GNU_RELRO	0x6474e552
+#define	PT_GNU_PROPERTY	0x6474e553
 #define	PT_LOSUNW	0x6ffffffa
 #define	PT_SUNWBSS	0x6ffffffa	/* Sun Specific segment */
 #define	PT_SUNWSTACK	0x6ffffffb	/* describes the stack segment */
@@ -505,6 +514,12 @@ typedef struct {
 #define	DF_1_INTERPOSE	0x00000400	/* Interpose all objects but main */
 #define	DF_1_NODEFLIB	0x00000800	/* Do not search default paths */
 
+/* Note section names */
+#define	ELF_NOTE_FREEBSD	"FreeBSD"
+#define	ELF_NOTE_NETBSD		"NetBSD"
+#define	ELF_NOTE_SOLARIS	"SUNW Solaris"
+#define	ELF_NOTE_GNU		"GNU"
+
 /* Values for n_type.  Used in core files. */
 #define	NT_PRSTATUS	1	/* Process status. */
 #define	NT_FPREGSET	2	/* Floating point registers. */
@@ -519,6 +534,23 @@ typedef struct {
 #define	NT_PROCSTAT_OSREL	14	/* Procstat osreldate data. */
 #define	NT_PROCSTAT_PSSTRINGS	15	/* Procstat ps_strings data. */
 #define	NT_PROCSTAT_AUXV	16	/* Procstat auxv data. */
+
+/* GNU note types. */
+#define	NT_GNU_ABI_TAG		1
+#define	NT_GNU_HWCAP		2
+#define	NT_GNU_BUILD_ID		3
+#define	NT_GNU_GOLD_VERSION	4
+#define	NT_GNU_PROPERTY_TYPE_0	5
+
+#define	GNU_PROPERTY_LOPROC			0xc0000000
+#define	GNU_PROPERTY_HIPROC			0xdfffffff
+
+#define	GNU_PROPERTY_AARCH64_FEATURE_1_AND	0xc0000000
+
+#define	GNU_PROPERTY_AARCH64_FEATURE_1_BTI	0x00000001
+#define	GNU_PROPERTY_AARCH64_FEATURE_1_PAC	0x00000002
+
+#define	GNU_PROPERTY_X86_FEATURE_1_AND		0xc0000002
 
 /* Symbol Binding - ELFNN_ST_BIND - st_info */
 #define	STB_LOCAL	0	/* Local symbol */

--- a/lib/libutils/ext/arch/arm/atomic_a64.S
+++ b/lib/libutils/ext/arch/arm/atomic_a64.S
@@ -28,3 +28,4 @@ FUNC atomic_dec32 , :
 	ret
 END_FUNC atomic_dec32
 
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/lib/libutils/ext/arch/arm/mcount_a64.S
+++ b/lib/libutils/ext/arch/arm/mcount_a64.S
@@ -81,3 +81,5 @@ END_FUNC __ftrace_return
 #endif
 
 #endif /* CFG_TA_GPROF_SUPPORT || CFG_FTRACE_SUPPORT */
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/lib/libutils/ext/include/arm64_bti.S
+++ b/lib/libutils/ext/include/arm64_bti.S
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#include <elf_common.h>
+
+/*
+ * This macro emits a program property note section identifying
+ * architecture features which require special handling, mainly for
+ * use in assembly files in the libraries linked with TA's.
+ */
+
+.macro emit_aarch64_feature_1_and, feat
+	.pushsection .note.gnu.property, "a"
+	.align  3
+	.long   2f - 1f				/* n_namesz */
+	.long   6f - 3f				/* n_desc_sz */
+	.long   NT_GNU_PROPERTY_TYPE_0		/* n_type */
+1:      .string "GNU"				/* name */
+2:
+	.align  3
+3:      .long   GNU_PROPERTY_AARCH64_FEATURE_1_AND 	/* pr_type */
+	.long   5f - 4f					/* pr_datasz */
+4:
+	/*
+	 * This is described with an array of char in the Linux API
+	 * spec but the text and all other usage (including binutils,
+	 * clang and GCC) treat this as a 32 bit value so no swizzling
+	 * is required for big endian.
+	 */
+	.long   \feat					/* property */
+5:
+	.align  3
+6:
+	.popsection
+.endm

--- a/lib/libutils/ext/include/asm.S
+++ b/lib/libutils/ext/include/asm.S
@@ -4,6 +4,13 @@
  * Copyright (c) 2020, Linaro Limited
  */
 
+#if defined(__aarch64__) && ((defined(__KERNEL__) && defined(CFG_CORE_BTI)) || \
+			     (!defined(__KERNEL__) && defined(CFG_TA_BTI)))
+#define BTI(...) __VA_ARGS__
+#else
+#define BTI(...)
+#endif
+
 #if defined(CFG_UNWIND) && defined(__arm__)
 #define UNWIND(...) __VA_ARGS__
 #else
@@ -21,6 +28,7 @@
 	.balign \align
 	\name \colon
 UNWIND(	.fnstart)
+BTI(	bti	c)
 	.endm
 
 	.macro LOCAL_FUNC name colon section=default align=4
@@ -33,6 +41,7 @@ UNWIND(	.fnstart)
 	.balign \align
 	\name \colon
 UNWIND(	.fnstart)
+BTI(	bti	c)
 	.endm
 
 	.macro WEAK_FUNC name colon section=default align=4
@@ -46,6 +55,7 @@ UNWIND(	.fnstart)
 	.balign \align
 	\name \colon
 UNWIND(	.fnstart)
+BTI(	bti	c)
 	.endm
 
 	.macro END_FUNC name

--- a/lib/libutils/ext/include/asm.S
+++ b/lib/libutils/ext/include/asm.S
@@ -17,7 +17,7 @@
 #define UNWIND(...)
 #endif
 
-	.macro FUNC name colon section=default align=4
+	.macro FUNC name colon section=default align=4 _bti=default
 	.ifc	\section\(),default
 	.section .text.\name
 	.else
@@ -28,10 +28,12 @@
 	.balign \align
 	\name \colon
 UNWIND(	.fnstart)
+	.ifc	\_bti\(),default
 BTI(	bti	c)
+	.endif
 	.endm
 
-	.macro LOCAL_FUNC name colon section=default align=4
+	.macro LOCAL_FUNC name colon section=default align=4 _bti=default
 	.ifc	\section\(),default
 	.section .text.\name
 	.else
@@ -41,10 +43,12 @@ BTI(	bti	c)
 	.balign \align
 	\name \colon
 UNWIND(	.fnstart)
+	.ifc	\_bti\(),default
 BTI(	bti	c)
+	.endif
 	.endm
 
-	.macro WEAK_FUNC name colon section=default align=4
+	.macro WEAK_FUNC name colon section=default align=4 _bti=default
 	.ifc	\section\(),default
 	.section .text.\name
 	.else
@@ -55,7 +59,9 @@ BTI(	bti	c)
 	.balign \align
 	\name \colon
 UNWIND(	.fnstart)
+	.ifc	\_bti\(),default
 BTI(	bti	c)
+	.endif
 	.endm
 
 	.macro END_FUNC name

--- a/lib/libutils/ext/include/asm.S
+++ b/lib/libutils/ext/include/asm.S
@@ -4,6 +4,10 @@
  * Copyright (c) 2020, Linaro Limited
  */
 
+#if defined(__aarch64__)
+#include <arm64_bti.S>
+#endif
+
 #if defined(__aarch64__) && ((defined(__KERNEL__) && defined(CFG_CORE_BTI)) || \
 			     (!defined(__KERNEL__) && defined(CFG_TA_BTI)))
 #define BTI(...) __VA_ARGS__

--- a/lib/libutils/isoc/arch/arm/setjmp_a64.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a64.S
@@ -90,8 +90,17 @@ BTI(	bti	c)
 	mov	sp, x16
 	cmp	w1, #0
 	cinc	w0, w1, eq
+/*
+ * clang has a bug and doesn't insert bti after setjmp
+ * causing BTI ecxception. Remove this when the bug is fixed.
+ * https://bugs.llvm.org/show_bug.cgi?id=49544
+ */
+#if defined(__clang__) && defined(CFG_TA_BTI)
+	ret
+#else
 	// use br not ret, as ret is guaranteed to mispredict
 	br	x30
+#endif
 	.size	longjmp, .-longjmp
 
 BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/lib/libutils/isoc/arch/arm/setjmp_a64.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a64.S
@@ -27,6 +27,8 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <asm.S>
+
 #define GPR_LAYOUT			\
 	REG_PAIR (x19, x20,  0);	\
 	REG_PAIR (x21, x22, 16);	\
@@ -46,6 +48,7 @@
 	.global	setjmp
 	.type	setjmp, %function
 setjmp:
+BTI(	bti	c)
 	mov	x16, sp
 #define REG_PAIR(REG1, REG2, OFFS)	stp REG1, REG2, [x0, OFFS]
 #define REG_ONE(REG1, OFFS)		str REG1, [x0, OFFS]
@@ -68,6 +71,7 @@ setjmp:
 	.global	longjmp
 	.type	longjmp, %function
 longjmp:
+BTI(	bti	c)
 #define REG_PAIR(REG1, REG2, OFFS)	ldp REG1, REG2, [x0, OFFS]
 #define REG_ONE(REG1, OFFS)		ldr REG1, [x0, OFFS]
 #ifdef CFG_FTRACE_SUPPORT

--- a/lib/libutils/isoc/arch/arm/setjmp_a64.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a64.S
@@ -93,3 +93,5 @@ BTI(	bti	c)
 	// use br not ret, as ret is guaranteed to mispredict
 	br	x30
 	.size	longjmp, .-longjmp
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -742,3 +742,26 @@ $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))
 
 # Enables warnings for declarations mixed with statements
 CFG_WARN_DECL_AFTER_STATEMENT ?= y
+
+# Branch Target Identification (part of the ARMv8.5 Extensions) provides a
+# mechanism to limit the set of locations to which computed branch instructions
+# such as BR or BLR can jump. To make use of BTI in TEE core and ldelf on CPU's
+# that support it, enable this option. A GCC toolchain built with
+# --enable-standard-branch-protection is needed to use this option.
+CFG_CORE_BTI ?= n
+
+$(eval $(call cfg-depends-all,CFG_CORE_BTI,CFG_ARM64_core))
+
+# To make use of BTI in user space libraries and TA's on CPU's that support it,
+# enable this option.
+CFG_TA_BTI ?= $(CFG_CORE_BTI)
+
+$(eval $(call cfg-depends-all,CFG_TA_BTI,CFG_ARM64_core))
+
+ifeq (y-y,$(CFG_VIRTUALIZATION)-$(call cfg-one-enabled, CFG_TA_BTI CFG_CORE_BTI))
+$(error CFG_VIRTUALIZATION and BTI are currently incompatible)
+endif
+
+ifeq (y-y,$(CFG_PAGED_USER_TA)-$(CFG_TA_BTI))
+$(error CFG_PAGED_USER_TA and CFG_TA_BTI are currently incompatible)
+endif

--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -59,11 +59,15 @@ $(lib-libfile): $(objs)
 	$$(q)rm -f $$@ && $$(AR$(sm)) rcs $$@ $$^
 endif
 ifeq ($(CFG_ULIBS_SHARED),y)
+ifeq ($(sm)-$(CFG_TA_BTI),ta_arm64-y)
+lib-ldflags$(libuuid) += $$(call ld-option,-z force-bti) --fatal-warnings
+endif
 $(lib-shlibfile): $(objs) $(lib-needed-so-files)
 	@$(cmd-echo-silent) '  LD      $$@'
 	@mkdir -p $$(dir $$@)
 	$$(q)$$(LD$(sm)) $(lib-ldflags) -shared -z max-page-size=4096 \
 		$(call ld-option,-z separate-loadable-segments) \
+		$$(lib-ldflags$(libuuid)) \
 		--soname=$(libuuid) -o $$@ $$(filter-out %.so,$$^) $(lib-Ll-args)
 
 $(lib-shlibstrippedfile): $(lib-shlibfile)

--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -8,6 +8,7 @@ CHECKPATCH_IGNORE=$(echo \
 		core/lib/lib{fdt,tomcrypt} core/lib/zlib \
 		lib/libutils lib/libmbedtls \
 		lib/libutee/include/elf.h \
+		lib/libutee/include/elf_common.h \
 		core/arch/arm/include/arm{32,64}.h \
 		core/arch/arm/plat-ti/api_monitor_index_a{9,15}.h \
 		core/arch/arm/dts \

--- a/ta/arch/arm/link.mk
+++ b/ta/arch/arm/link.mk
@@ -31,6 +31,9 @@ link-ldflags += -T $(link-script-pp$(sm))
 link-ldflags += -Map=$(link-out-dir$(sm))/$(user-ta-uuid).map
 link-ldflags += --sort-section=alignment
 link-ldflags += -z max-page-size=4096 # OP-TEE always uses 4K alignment
+ifeq ($(sm)-$(CFG_TA_BTI),ta_arm64-y)
+link-ldflags += $(call ld-option,-z force-bti) --fatal-warnings
+endif
 link-ldflags += --as-needed # Do not add dependency on unused shlib
 link-ldflags += $(link-ldflags$(sm))
 

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -20,6 +20,9 @@ cleanfiles += $(link-out-dir)/$(shlibuuid).ta
 shlink-ldflags  = $(LDFLAGS)
 shlink-ldflags += -shared -z max-page-size=4096
 shlink-ldflags += $(call ld-option,-z separate-loadable-segments)
+ifeq ($(sm)-$(CFG_TA_BTI),ta_arm64-y)
+shlink-ldflags += $(call ld-option,-z force-bti) --fatal-warnings
+endif
 shlink-ldflags += --as-needed # Do not add dependency on unused shlib
 
 shlink-ldadd  = $(LDADD)

--- a/ta/arch/arm/ta.ld.S
+++ b/ta/arch/arm/ta.ld.S
@@ -26,6 +26,7 @@ SECTIONS {
 		*(.vfp11_veneer)
 		__text_end = .;
 	}
+	.note.gnu.property : { *(.note.gnu.property) }
         .plt : { *(.plt) }
 
 	.eh_frame_hdr : {

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -33,6 +33,7 @@ ta-mk-file-export-vars-$(sm) += CFG_SYSTEM_PTA
 ta-mk-file-export-vars-$(sm) += CFG_FTRACE_SUPPORT
 ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
+ta-mk-file-export-vars-$(sm) += CFG_TA_BTI
 ta-mk-file-export-vars-$(sm) += CFG_CORE_TPM_EVENT_LOG
 ta-mk-file-export-add-$(sm) += CFG_TEE_TA_LOG_LEVEL ?= $(CFG_TEE_TA_LOG_LEVEL)_nl_
 ta-mk-file-export-vars-$(sm) += CFG_TA_BGET_TEST


### PR DESCRIPTION
The patch series add supports of protecting optee-core and TA's with BTI. 

The Branch Target Identification extension, introduced to AArch64 in Armv8.5-A, adds the BTI instruction, which is used to mark valid targets of indirect branches. When enabled, the processor will trap if an instruction in a protected page tries to perform an indirect branch to any instruction other than a BTI. The BTI instruction uses encodings which were NOPs in earlier versions of the architecture, so BTI-enabled code will still run on earlier hardware, just without the extra protection. More information on BTI can be found at [1]

The patch series has been tested with gcc10.2 on qemuv8 with " -cpu max,sve=off" instead of "-cpu cortex-a57".

All xtests including the GP tests pass.

With xen , linux doesn't boot up on qemu with -cpu max,sve=off i.e ARMv8.5 capability linux. This needs to be investigated further before we can try BTI enabled OP-TEE with xen.

Further work:
Test it with clang 
Add test case in optee-tests.

[1] - https://developer.arm.com/documentation/102433/0100/Jump-oriented-programming 