### PR TITLE
ci: azure: fix build error in Buildroot's OpenSSL (Rust)

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -257,6 +257,9 @@ jobs:
           set -e -v
           export HOME=/root
           export LC_ALL=C
+          # Azure CI sets ${SYSTEM} to "build" which prevents OpenSSL from building due to:
+          # https://github.com/openssl/openssl/blob/OpenSSL_1_1_1l/config#L56
+          unset SYSTEM
           WD=$(pwd)
           sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
           sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"


### PR DESCRIPTION
Same fix as commit 58676b162a91 ("ci: azure: fix build error in
Buildroot's OpenSSL") but for the Rust job.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
