### PR TITLE
drivers: clk: skip clock with no matching compatible

### DIFF
--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -257,7 +257,7 @@ static TEE_Result clk_dt_node_clock_probe_driver(const void *fdt, int node)
 
 	count = fdt_stringlist_count(fdt, node, "compatible");
 	if (count < 0)
-		return TEE_ERROR_GENERIC;
+		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	for (idx = 0; idx < count; idx++) {
 		compat = fdt_stringlist_get(fdt, node, "compatible", idx, &len);
@@ -278,7 +278,7 @@ static TEE_Result clk_dt_node_clock_probe_driver(const void *fdt, int node)
 		}
 	}
 
-	return TEE_ERROR_GENERIC;
+	return TEE_ERROR_ITEM_NOT_FOUND;
 }
 
 static TEE_Result clk_probe_clock_provider_node(const void *fdt, int node)


### PR DESCRIPTION
Clock DT node without a matching compatible in the registered DT drivers
should be ignored (return TEE_ERROR_ITEM_NOT_FOUND) instead of
returning a TEE_ERROR_GENERIC error code.

Fixes: dbe94a85c1a1 ("drivers: clk: add devicetree support")

Note this change conflicts with P-R https://github.com/OP-TEE/optee_os/pull/4965 that moves the related functino to dt_driver.c and doing so also addresses this change [(see proposed `dt_driver_probe_device_by_node()`)](https://github.com/OP-TEE/optee_os/pull/4965/commits/6244eab4145df6dfa4bd95a3ebc6425a4eec1f17#diff-5fca14f73705cc642bdbbd044cd99b88cfca252717f0ca813b7d6664eaba0bcaR218-R232). I think it's worth considering this change first, I'll update P-R https://github.com/OP-TEE/optee_os/pull/4965 accordingly.

@clementleger, do you agree?

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
