### PR TITLE
[RFC 2] core: pta: add remote attestation PTA

### DIFF
--- a/core/include/mm/file.h
+++ b/core/include/mm/file.h
@@ -105,5 +105,10 @@ void file_put(struct file *f);
  */
 struct file_slice *file_find_slice(struct file *f, unsigned int page_offset);
 
+TEE_Result file_find_page_offset(struct file *f, struct fobj *fobj,
+				 unsigned int *page_offset);
+
+uint8_t *file_get_tag(struct file *f);
+
 #endif /*__MM_FILE_H*/
 

--- a/core/include/mm/mobj.h
+++ b/core/include/mm/mobj.h
@@ -297,4 +297,6 @@ struct mobj *mobj_seccpy_shm_alloc(size_t size);
 
 struct mobj *mobj_with_fobj_alloc(struct fobj *fobj, struct file *file);
 
+struct file *to_file_may_fail(struct mobj *mobj);
+
 #endif /*__MM_MOBJ_H*/

--- a/core/mm/file.c
+++ b/core/mm/file.c
@@ -193,6 +193,25 @@ struct file_slice *file_find_slice(struct file *f, unsigned int page_offset)
 	return NULL;
 }
 
+TEE_Result file_find_page_offset(struct file *f, struct fobj *fobj,
+				 unsigned int *page_offset)
+{
+	struct file_slice_elem *fse = NULL;
+
+	assert(f->mu.state);
+
+	SLIST_FOREACH(fse, &f->slice_head, link) {
+		struct file_slice *fs = &fse->slice;
+
+		if (fs->fobj == fobj) {
+			*page_offset = fs->page_offset;
+			return TEE_SUCCESS;
+		}
+	}
+
+	return TEE_ERROR_ITEM_NOT_FOUND;
+}
+
 void file_lock(struct file *f)
 {
 	mutex_lock(&f->mu);
@@ -206,4 +225,9 @@ bool file_trylock(struct file *f)
 void file_unlock(struct file *f)
 {
 	mutex_unlock(&f->mu);
+}
+
+uint8_t *file_get_tag(struct file *f)
+{
+	return f->tag;
 }

--- a/core/mm/mobj.c
+++ b/core/mm/mobj.c
@@ -594,6 +594,23 @@ static struct mobj_with_fobj *to_mobj_with_fobj(struct mobj *mobj)
 	return container_of(mobj, struct mobj_with_fobj, mobj);
 }
 
+static struct mobj_with_fobj *to_mobj_with_fobj_may_fail(struct mobj *mobj)
+{
+	if (!mobj || mobj->ops != &mobj_with_fobj_ops)
+		return NULL;
+
+	return to_mobj_with_fobj(mobj);
+}
+
+struct file *to_file_may_fail(struct mobj *mobj)
+{
+	struct mobj_with_fobj *m = to_mobj_with_fobj_may_fail(mobj);
+
+	if (!m)
+		return NULL;
+	return m->file;
+}
+
 static bool mobj_with_fobj_matches(struct mobj *mobj __maybe_unused,
 				 enum buf_is_attr attr)
 {

--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2021, Huawei Technologies Co., Ltd
+ */
+
+#include <crypto/crypto.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/tee_ta_manager.h>
+#include <kernel/ts_manager.h>
+#include <kernel/user_mode_ctx.h>
+#include <kernel/user_ta.h>
+#include <mm/file.h>
+#include <mm/mobj.h>
+#include <pta_attestation.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/queue.h>
+#include <tee/entry_std.h>
+#include <tee/uuid.h>
+#include <utee_defines.h>
+
+#define PTA_NAME "attestation.pta"
+
+/*
+ * Is region valid for hashing?
+ * Exclude writable regions as well as those that are not specific to the TA
+ * (ldelf, kernel or temporary mappings).
+ */
+static bool is_region_valid(struct vm_region *r)
+{
+	uint32_t skip_flags = VM_FLAG_EPHEMERAL | VM_FLAG_PERMANENT |
+			      VM_FLAG_LDELF;
+
+	return !(r->flags & skip_flags || r->attr & TEE_MATTR_UW);
+}
+
+/*
+ * With this comparison function, we're hashing the smaller regions first.
+ * Regions of equal size are ordered based on their content (memcmp()).
+ * Identical regions can be in any order since they will yield the same hash
+ * anyways.
+ */
+static int cmp_regions(const void *a, const void *b)
+{
+	const struct vm_region *r1 = *(const struct vm_region **)a;
+	const struct vm_region *r2 = *(const struct vm_region **)b;
+
+	if (r1->size < r2->size)
+		return -1;
+
+	if (r1->size > r2->size)
+		return 1;
+
+	return memcmp((void *)r1->va, (void *)r2->va, r1->size);
+}
+
+static TEE_Result hash_update_method_tags(void *ctx, struct vm_region *r)
+{
+	struct fobj *fobj = r->mobj->ops->get_fobj(r->mobj);
+	struct file *f = to_file_may_fail(r->mobj);
+	uint64_t offs_and_size[2] = { };
+	TEE_Result res = TEE_SUCCESS;
+	unsigned int poffs = 0;
+	uint8_t *tag = NULL;
+
+	/* Regions we're interested in should all have a struct file */
+	assert(f);
+
+	tag = file_get_tag(f);
+	assert(tag);
+
+	res = crypto_hash_update(ctx, tag, FILE_TAG_SIZE);
+	if (!res)
+		return res;
+
+	file_lock(f);
+	res = file_find_page_offset(f, fobj, &poffs);
+	file_unlock(f);
+	if (!res)
+		return res;
+
+	offs_and_size[0] = poffs * SMALL_PAGE_SIZE;
+	offs_and_size[1] = r->mobj->size;
+
+	return crypto_hash_update(ctx, (uint8_t *)offs_and_size,
+				  sizeof(offs_and_size));
+}
+
+static TEE_Result hash_update(void *ctx, struct vm_region *r, uint32_t method)
+{
+	switch (method) {
+	case PTA_ATTESTATION_HASH_METHOD_FULL:
+		return crypto_hash_update(ctx, (uint8_t *)r->va, r->size);
+	case PTA_ATTESTATION_HASH_METHOD_TAGS:
+		return hash_update_method_tags(ctx, r);
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}
+
+static TEE_Result hash_regions(struct vm_info *vm_info, uint8_t *hash,
+			       uint32_t method)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct vm_region *r = NULL;
+	struct vm_region **regions = NULL;
+	size_t nregions = 0;
+	void *ctx = NULL;
+	size_t i = 0;
+
+	res = crypto_hash_alloc_ctx(&ctx, TEE_ALG_SHA256);
+	if (res)
+		return res;
+
+	res = crypto_hash_init(ctx);
+	if (res)
+		goto out;
+
+	/*
+	 * Make an array of region pointers so we can use qsort() to order it.
+	 */
+
+	TAILQ_FOREACH(r, &vm_info->regions, link)
+		if (is_region_valid(r))
+			nregions++;
+
+	regions = malloc(nregions * sizeof(*regions));
+	if (!regions) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	TAILQ_FOREACH(r, &vm_info->regions, link)
+		if (is_region_valid(r))
+			regions[i++] = r;
+
+	/*
+	 * Sort regions so that they are in a consistent order even when TA ASLR
+	 * is enabled.
+	 */
+	qsort(regions, nregions, sizeof(*regions), cmp_regions);
+
+	/* Hash regions in order */
+	for (i = 0; i < nregions; i++) {
+		r = regions[i];
+		DMSG("va %p size %zu", (void *)r->va, r->size);
+		res = hash_update(ctx, r, method);
+		if (res)
+			goto out;
+	}
+
+	res = crypto_hash_final(ctx, hash, TEE_SHA256_HASH_SIZE);
+out:
+	free(regions);
+	crypto_hash_free_ctx(ctx);
+	return res;
+}
+
+static TEE_Result hash_ta(struct user_mode_ctx *uctx, uint32_t types,
+			  TEE_Param params[TEE_NUM_PARAMS])
+{
+	uint32_t method = params[0].value.a;
+	uint8_t *hash = params[1].memref.buffer;
+	size_t hash_sz = params[1].memref.size;
+	TEE_Result res = TEE_SUCCESS;
+	struct ts_session *s = NULL;
+
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+				     TEE_PARAM_TYPE_MEMREF_OUTPUT,
+				     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!hash || hash_sz != TEE_SHA256_HASH_SIZE)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	s = ts_pop_current_session();
+	res = hash_regions(&uctx->vm_info, hash, method);
+	ts_push_current_session(s);
+
+	return res;
+}
+
+static TEE_Result open_session(uint32_t param_types __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
+			       void **sess_ctx __unused)
+{
+	struct ts_session *s = NULL;
+	struct user_mode_ctx *uctx = NULL;
+
+	/* Check that we're called from a user TA */
+	s = ts_get_calling_session();
+	if (!s)
+		return TEE_ERROR_ACCESS_DENIED;
+	uctx = to_user_mode_ctx(s->ctx);
+	if (!uctx)
+		return TEE_ERROR_ACCESS_DENIED;
+
+	return hash_ta(uctx, param_types, params);
+}
+
+static TEE_Result invoke_command(void *sess_ctx __unused,
+				 uint32_t cmd_id __unused,
+				 uint32_t param_types __unused,
+				 TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	return TEE_SUCCESS;
+}
+
+pseudo_ta_register(.uuid = PTA_ATTESTATION_UUID, .name = PTA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
+		   .open_session_entry_point = open_session,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -1,5 +1,6 @@
 subdirs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += tests
 
+srcs-$(CFG_ATTESTATION_PTA) += attestation.c
 srcs-$(CFG_TEE_BENCHMARK) += benchmark.c
 srcs-$(CFG_DEVICE_ENUM_PTA) += device.c
 srcs-$(CFG_TA_GPROF_SUPPORT) += gprof.c

--- a/lib/libutee/include/pta_attestation.h
+++ b/lib/libutee/include/pta_attestation.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2021, Huawei Technologies Co., Ltd
+ */
+
+/*
+ * Provide remote attestation services
+ */
+
+#ifndef __PTA_ATTESTATION_H
+#define __PTA_ATTESTATION_H
+
+#define PTA_ATTESTATION_UUID { 0x0dc571c7, 0xb1a7, 0x43fb, \
+		{ 0xa8, 0x78, 0x72, 0xc7, 0xb8, 0xc5, 0x88, 0xbb } }
+
+/*
+ * Get [signed TBD] hash for a running user space TA, which must be the caller
+ * of this PTA.
+ *
+ * Parameters to pass to TEE_OpenTASession():
+ *
+ * [in]     value[0].a       Hash method (PTA_ATTESTATION_HASH_METHOD_* below)
+ * [out]    memref[1]        SHA256 hash of all the TA memory pages that contain
+ *                           immutable data (code, RO data)
+ *
+ * Return codes:
+ * TEE_SUCCESS
+ * TEE_ERROR_ACCESS_DENIED - Caller is not a user space TA
+ * TEE_ERROR_BAD_PARAMETERS - Incorrect input param
+ * TEE_ERROR_SHORT_BUFFER - Output buffer size less than required
+ */
+
+/*
+ * Hash all the TA memory pages that contain immutable data (code, RO data).
+ * Can be used for authentication as well as periodic integrity checking.
+ */
+#define PTA_ATTESTATION_HASH_METHOD_FULL	0x0
+/*
+ * Hash the tags computed at load time. Faster than "full" mode but cannot
+ * detect memory corruption.
+ */
+#define PTA_ATTESTATION_HASH_METHOD_TAGS	0x1
+
+#endif /* __PTA_ATTESTATION_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -572,6 +572,10 @@ $(eval $(call cfg-depends-all,CFG_SYSTEM_PTA,CFG_WITH_USER_TA))
 # world OS.
 CFG_DEVICE_ENUM_PTA ?= y
 
+# The attestation pseudo TA provides an interface for user space TAs to request
+# a measurement of their own code and read-only data pages.
+CFG_ATTESTATION_PTA ?= n
+
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,
 # so its value represents log2(cores/cluster).

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -36,6 +36,7 @@ ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
 ta-mk-file-export-vars-$(sm) += CFG_CORE_TPM_EVENT_LOG
 ta-mk-file-export-add-$(sm) += CFG_TEE_TA_LOG_LEVEL ?= $(CFG_TEE_TA_LOG_LEVEL)_nl_
 ta-mk-file-export-vars-$(sm) += CFG_TA_BGET_TEST
+ta-mk-file-export-vars-$(sm) += CFG_ATTESTATION_PTA
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.


### PR DESCRIPTION
Add a PTA to perform remote attestation of user space TAs. Enabled with
CFG_ATTESTATION_PTA=y.

This feature allows a user space TA to request a measurement of itself
from the OP-TEE core. Typical use case: a client application invokes
its companion TA to obtain secure services and it needs some guarantees
that the code running in the TEE is indeed the expected one and has not
been tampered with or corrupted. The CA generates a random nonce and
sends it to the TA using a custom command. The TA opens a session to
the attestation PTA and passes the nonce. The PTA measures the caller,
thus generating a hash, which is then signed together with the nonce.
At this point the CA (or any other entity involved in the call flow,
such as a remote server for instance) can verify the signature. If it
is valid and the nonce is the expected one, then the TA hash can be
trusted and compared against a known good value.

TODO: implement the nonce and signature.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
