### PR TITLE
lib: mbebtls: correct return value in RSA-SSA signature verification

### DIFF
--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -627,7 +627,7 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 
 	bigint_size = crypto_bignum_num_bytes(key->n);
 	if (sig_len < bigint_size) {
-		res = TEE_ERROR_MAC_INVALID;
+		res = TEE_ERROR_SIGNATURE_INVALID;
 		goto err;
 	}
 


### PR DESCRIPTION
The value TEE_ERROR_MAC_INVALID returned by function
crypto_acipher_rsassa_verify() of mbedtls library will
cause TEE_AsymmetricVerifyDigest() to call TEE_Panic()
when it reports an invalid signature. Fix this by returning
TEE_ERROR_SIGNATURE_INVALID instead as specified by
the GPD TEE Internal Core API specifications.

Signed-off-by: lubing <lubing@eswin.com>
Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>
Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
