### PR TITLE
RAM optimized clk framework, take 2: raw clocks

### DIFF
--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -197,7 +197,7 @@ void clk_disable(struct clk *clk)
 	cpu_spin_unlock_xrestore(&clk_lock, exceptions);
 }
 
-unsigned long clk_get_rate(struct clk *clk)
+unsigned long clk_elt_rate(struct clk *clk)
 {
 	return clk->rate;
 }

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -238,6 +238,11 @@ struct clk *clk_get_parent(struct clk *clk)
 	return clk->parent;
 }
 
+size_t clk_get_num_parents(struct clk *clk)
+{
+	return clk->num_parents;
+}
+
 static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 				     size_t *pidx)
 {

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -62,7 +62,7 @@ static void cache_rate_no_lock(struct clk *clk)
 	unsigned long parent_rate = 0;
 
 	if (clk->parent)
-		parent_rate = clk->parent->rate;
+		parent_rate = clk_get_rate(clk->parent);
 
 	if (clk->ops->compute_rate)
 		clk->rate = clk->ops->compute_rate(clk, parent_rate);

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -81,17 +81,25 @@ void clk_lw_free(struct clk *clk)
 
 static bool __maybe_unused clk_check(struct clk *clk)
 {
-	if (!clk->ops)
+	if (!clk->ops) {
+		DMSG("Missing ops reference on clock");
 		return false;
+	}
 
 	if (is_clk_std(clk)) {
 		struct clk_std *clk_std = clk_to_clk_std(clk);
 
-		if (clk->ops->set_parent && !clk->ops->get_parent)
+		if (clk->ops->set_parent && !clk->ops->get_parent) {
+			DMSG("set_parent but no get_parent ops on clock %s",
+			     clk_get_name(clk));
 			return false;
+		}
 
-		if (clk_std->num_parents > 1 && !clk->ops->get_parent)
+		if (clk_std->num_parents > 1 && !clk->ops->get_parent) {
+			DMSG("Several parents but no get_parent op on clock %s",
+			     clk_get_name(clk));
 			return false;
+		}
 
 		return true;
 	}

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -38,9 +38,10 @@ struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
 	return clk;
 }
 
-void clk_free(struct clk *clk)
+void clk_elt_free(struct clk *clk)
 {
-	free(clk);
+	if (clk)
+		free(clk_to_clk_elt(clk));
 }
 
 static bool __maybe_unused clk_check(struct clk *clk)

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -51,12 +51,6 @@ struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
 	return &clk_std->clk;
 }
 
-void clk_std_free(struct clk *clk)
-{
-	if (clk)
-		free(clk_to_clk_std(clk));
-}
-
 struct clk *clk_lw_alloc(const struct clk_ops *ops, size_t count)
 {
 	struct clk *clk = NULL;
@@ -74,9 +68,14 @@ struct clk *clk_lw_alloc(const struct clk_ops *ops, size_t count)
 	return clk;
 }
 
-void clk_lw_free(struct clk *clk)
+void clk_free(struct clk *clk)
 {
-	free(clk);
+	void *p = clk;
+
+	if (clk && is_clk_std(clk))
+		p = clk_to_clk_std(clk);
+
+	free(p);
 }
 
 static bool __maybe_unused clk_check(struct clk *clk)

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -101,7 +101,8 @@ TEE_Result clk_register(struct clk *clk)
 	clk_init_parent(clk);
 	clk_compute_rate_no_lock(clk);
 
-	DMSG("Registered clock %s, freq %lu", clk->name, clk_get_rate(clk));
+	DMSG("Registered clock %s, freq %lu", clk_get_name(clk),
+	     clk_get_rate(clk));
 
 	return TEE_SUCCESS;
 }
@@ -240,7 +241,9 @@ static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 			return TEE_SUCCESS;
 		}
 	}
-	EMSG("Clock %s is not a parent of clock %s", parent->name, clk->name);
+
+	EMSG("Clock %s is not a parent of clock %s", clk_get_name(parent),
+	     clk_get_name(clk));
 
 	return TEE_ERROR_BAD_PARAMETERS;
 }

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -20,6 +20,9 @@ struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
 	struct clk *clk = NULL;
 	size_t parent = 0;
 
+	if (name && !ops->get_name)
+		DMSG("Clock name unregistered for %s", name);
+
 	clk = calloc(1, sizeof(*clk) + parent_count * sizeof(clk));
 	if (!clk)
 		return NULL;
@@ -105,6 +108,11 @@ TEE_Result clk_register(struct clk *clk)
 	     clk_get_rate(clk));
 
 	return TEE_SUCCESS;
+}
+
+const char *clk_elt_name(struct clk *clk)
+{
+	return clk->name;
 }
 
 static bool clk_is_enabled_no_lock(struct clk *clk)

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -64,8 +64,8 @@ static void clk_compute_rate_no_lock(struct clk *clk)
 	if (clk->parent)
 		parent_rate = clk->parent->rate;
 
-	if (clk->ops->get_rate)
-		clk->rate = clk->ops->get_rate(clk, parent_rate);
+	if (clk->ops->compute_rate)
+		clk->rate = clk->ops->compute_rate(clk, parent_rate);
 	else
 		clk->rate = parent_rate;
 }

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -57,7 +57,7 @@ static bool __maybe_unused clk_check(struct clk *clk)
 	return true;
 }
 
-static void clk_compute_rate_no_lock(struct clk *clk)
+static void cache_rate_no_lock(struct clk *clk)
 {
 	unsigned long parent_rate = 0;
 
@@ -102,7 +102,7 @@ TEE_Result clk_register(struct clk *clk)
 	assert(clk_check(clk));
 
 	clk_init_parent(clk);
-	clk_compute_rate_no_lock(clk);
+	cache_rate_no_lock(clk);
 
 	DMSG("Registered clock %s, freq %lu", clk_get_name(clk),
 	     clk_get_rate(clk));
@@ -214,7 +214,7 @@ static TEE_Result clk_set_rate_no_lock(struct clk *clk, unsigned long rate)
 	if (res)
 		return res;
 
-	clk_compute_rate_no_lock(clk);
+	cache_rate_no_lock(clk);
 
 	return TEE_SUCCESS;
 }
@@ -289,7 +289,7 @@ static TEE_Result clk_set_parent_no_lock(struct clk *clk, struct clk *parent,
 	clk->parent = parent;
 
 	/* The parent changed and the rate might also have changed */
-	clk_compute_rate_no_lock(clk);
+	cache_rate_no_lock(clk);
 
 out:
 	/* Call is needed to increment refcount on the new parent tree */

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -110,6 +110,12 @@ TEE_Result clk_register(struct clk *clk)
 	return TEE_SUCCESS;
 }
 
+TEE_Result clk_set_priv(struct clk *clk, void *priv)
+{
+	clk->priv = priv;
+	return TEE_SUCCESS;
+}
+
 const char *clk_elt_name(struct clk *clk)
 {
 	return clk->name;

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -150,7 +150,7 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (parent) {
 			if (clk_set_parent(clk, parent)) {
 				EMSG("Could not set clk %s parent to clock %s",
-				     clk->name, parent->name);
+				     clk_get_name(clk), clk_get_name(parent));
 				panic();
 			}
 		}

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -145,6 +145,11 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (!clk)
 			return;
 
+		if (!is_clk_std(clk)) {
+			EMSG("Can't set parent clock to %s", clk_get_name(clk));
+			panic();
+		}
+
 		parent = clk_dt_get_by_idx_prop("assigned-clock-parents", fdt,
 						nodeoffset, clock_idx);
 		if (parent) {

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -56,7 +56,7 @@ static TEE_Result fixed_clock_probe(const void *fdt, int offs,
 	}
 
 	fcd->rate = fdt32_to_cpu(*freq);
-	clk->priv = fcd;
+	clk_set_priv(clk, fcd);
 
 	res = clk_register(clk);
 	if (res)

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -22,8 +22,9 @@ static unsigned long fixed_clk_compute_rate(struct clk *clk,
 }
 
 static const struct clk_ops fixed_clk_clk_ops = {
-	.get_name = clk_elt_name,
-	.get_rate = clk_elt_rate,
+	.id = CLK_OPS_STANDARD,
+	.get_name = clk_std_name,
+	.get_rate = clk_std_rate,
 	.compute_rate = fixed_clk_compute_rate,
 };
 

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -22,6 +22,7 @@ static unsigned long fixed_clk_get_rate(struct clk *clk,
 }
 
 static const struct clk_ops fixed_clk_clk_ops = {
+	.get_name = clk_elt_name,
 	.get_rate = fixed_clk_get_rate,
 };
 

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -16,7 +16,7 @@ struct fixed_clock_data {
 static unsigned long fixed_clk_get_rate(struct clk *clk,
 					unsigned long parent_rate __unused)
 {
-	struct fixed_clock_data *d = clk->priv;
+	struct fixed_clock_data *d = clk_priv(clk);
 
 	return d->rate;
 }

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -13,8 +13,8 @@ struct fixed_clock_data {
 	unsigned long rate;
 };
 
-static unsigned long fixed_clk_get_rate(struct clk *clk,
-					unsigned long parent_rate __unused)
+static unsigned long fixed_clk_compute_rate(struct clk *clk,
+					    unsigned long parent_rate __unused)
 {
 	struct fixed_clock_data *d = clk_priv(clk);
 
@@ -23,7 +23,7 @@ static unsigned long fixed_clk_get_rate(struct clk *clk,
 
 static const struct clk_ops fixed_clk_clk_ops = {
 	.get_name = clk_elt_name,
-	.get_rate = fixed_clk_get_rate,
+	.compute_rate = fixed_clk_compute_rate,
 };
 
 static TEE_Result fixed_clock_probe(const void *fdt, int offs,

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -23,6 +23,7 @@ static unsigned long fixed_clk_compute_rate(struct clk *clk,
 
 static const struct clk_ops fixed_clk_clk_ops = {
 	.get_name = clk_elt_name,
+	.get_rate = clk_elt_rate,
 	.compute_rate = fixed_clk_compute_rate,
 };
 

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -47,6 +47,7 @@ struct clk {
  * @set_parent: Set the clock parent based on index
  * @get_parent: Get the current parent index of the clock
  * @set_rate: Set the clock rate
+ * @get_rate: Get the clock rate (possibly cached)
  * @compute_rate: Compute and return effective clock rate from new parent rate
  * @get_name: Get the clock name
  */
@@ -57,6 +58,7 @@ struct clk_ops {
 	size_t (*get_parent)(struct clk *clk);
 	TEE_Result (*set_rate)(struct clk *clk, unsigned long rate,
 			       unsigned long parent_rate);
+	unsigned long (*get_rate)(struct clk *clk);
 	unsigned long (*compute_rate)(struct clk *clk,
 				      unsigned long parent_rate);
 	const char *(*get_name)(struct clk *clk);
@@ -64,6 +66,7 @@ struct clk_ops {
 
 /* Generic helper clock operators */
 const char *clk_elt_name(struct clk *clk);
+unsigned long clk_elt_rate(struct clk *clk);
 
 /**
  * Return the clock name
@@ -133,7 +136,13 @@ static inline void *clk_priv(struct clk *clk)
  * @clk: Clock for which the rate is needed
  * Return the clock rate in Hz
  */
-unsigned long clk_get_rate(struct clk *clk);
+static inline unsigned long clk_get_rate(struct clk *clk)
+{
+	if (clk->ops->get_rate)
+		return clk->ops->get_rate(clk);
+
+	return 0;
+}
 
 /**
  * clk_set_rate - Set a clock rate

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -30,17 +30,11 @@ enum clk_ops_id {
 /**
  * struct clk - Clock core structure, common to all clocks
  *
- * @name: Clock name
- * @priv: Private data for the clock provider
  * @ops: Clock operations
- * @rate: Current clock rate (cached after init or rate change)
  * @enabled_count: Enable/disable reference counter
  */
 struct clk {
-	const char *name;
-	void *priv;
 	const struct clk_ops *ops;
-	unsigned long rate;
 	struct refcount enabled_count;
 };
 
@@ -48,6 +42,9 @@ struct clk {
  * struct clk_std - Full-fledged standard clock
  *
  * @clk: Clock core structure
+ * @priv: Private data for the clock provider
+ * @name: Clock name
+ * @rate: Current clock rate (cached after init or rate change)
  * @flags: Specific clock flags
  * @parent: Current parent
  * @num_parents: Number of parents
@@ -55,6 +52,9 @@ struct clk {
  */
 struct clk_std {
 	struct clk clk;
+	void *priv;
+	const char *name;
+	unsigned long rate;
 	unsigned int flags;
 	struct clk *parent;
 	size_t num_parents;
@@ -174,7 +174,7 @@ TEE_Result clk_set_priv(struct clk *clk, void *priv);
  */
 static inline void *clk_priv(struct clk *clk)
 {
-	return clk->priv;
+	return clk_to_clk_std(clk)->priv;
 }
 
 /**

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -163,10 +163,7 @@ struct clk *clk_get_parent(struct clk *clk);
  * @clk: Clock for which the number of parents is needed
  * Return the number of parents
  */
-static inline size_t clk_get_num_parents(struct clk *clk)
-{
-	return clk->num_parents;
-}
+size_t clk_get_num_parents(struct clk *clk);
 
 /**
  * Get a clock parent by its index

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -47,7 +47,7 @@ struct clk {
  * @set_parent: Set the clock parent based on index
  * @get_parent: Get the current parent index of the clock
  * @set_rate: Set the clock rate
- * @get_rate: Get the clock rate
+ * @compute_rate: Compute and return effective clock rate from new parent rate
  * @get_name: Get the clock name
  */
 struct clk_ops {
@@ -57,8 +57,8 @@ struct clk_ops {
 	size_t (*get_parent)(struct clk *clk);
 	TEE_Result (*set_rate)(struct clk *clk, unsigned long rate,
 			       unsigned long parent_rate);
-	unsigned long (*get_rate)(struct clk *clk,
-				  unsigned long parent_rate);
+	unsigned long (*compute_rate)(struct clk *clk,
+				      unsigned long parent_rate);
 	const char *(*get_name)(struct clk *clk);
 };
 

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -116,6 +116,17 @@ TEE_Result clk_register(struct clk *clk);
  */
 TEE_Result clk_set_priv(struct clk *clk, void *priv);
 
+/*
+ * clk_priv - Get clock private data reference
+ *
+ * @clk: Target clock
+ * Return clock's private data reference
+ */
+static inline void *clk_priv(struct clk *clk)
+{
+	return clk->priv;
+}
+
 /**
  * clk_get_rate - Get clock rate
  *

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -77,7 +77,6 @@ struct clk_std {
  * @get_rate: Get the clock rate (possibly cached)
  * @compute_rate: Compute and return effective clock rate from new parent rate
  * @get_name: Get the clock name
- * @free: Release the clock instance
  */
 struct clk_ops {
 	enum clk_ops_id id;
@@ -91,14 +90,11 @@ struct clk_ops {
 	unsigned long (*compute_rate)(struct clk *clk,
 				      unsigned long parent_rate);
 	const char *(*get_name)(struct clk *clk);
-	void (*free)(struct clk *clk);
 };
 
 /* Generic helper clock operators */
 const char *clk_std_name(struct clk *clk);
 unsigned long clk_std_rate(struct clk *clk);
-void clk_std_free(struct clk *clk);
-void clk_lw_free(struct clk *clk);
 
 /*
  * Helper to identify clock operator type
@@ -169,15 +165,12 @@ struct clk *clk_lw_alloc(const struct clk_ops *ops, size_t count);
 void clk_init_instance(struct clk *clk, const struct clk_ops *ops);
 
 /**
- * clk_free - Free a clock structure
+ * clk_free - Free clock reference (possible clock array reference) returned by
+ * clk_alloc() or clk_lw_alloc()
  *
- * @clk: Clock to be freed or NULL
+ * @clk: A reference returned by clk_alloc()/clk_lw_alloc() or NULL
  */
-static inline void clk_free(struct clk *clk)
-{
-	if (clk && clk->ops->free)
-		clk->ops->free(clk);
-}
+void clk_free(struct clk *clk);
 
 /**
  * clk_register - Register a clock within the clock framework

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -107,6 +107,15 @@ void clk_free(struct clk *clk);
  */
 TEE_Result clk_register(struct clk *clk);
 
+/*
+ * clk_set_priv - Set clock private data
+ *
+ * @clk: Target clock
+ * @priv: Private data reference to set
+ * Return a TEE_Result compliant value
+ */
+TEE_Result clk_set_priv(struct clk *clk, void *priv);
+
 /**
  * clk_get_rate - Get clock rate
  *

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -48,6 +48,7 @@ struct clk {
  * @get_parent: Get the current parent index of the clock
  * @set_rate: Set the clock rate
  * @get_rate: Get the clock rate
+ * @get_name: Get the clock name
  */
 struct clk_ops {
 	TEE_Result (*enable)(struct clk *clk);
@@ -58,7 +59,11 @@ struct clk_ops {
 			       unsigned long parent_rate);
 	unsigned long (*get_rate)(struct clk *clk,
 				  unsigned long parent_rate);
+	const char *(*get_name)(struct clk *clk);
 };
+
+/* Generic helper clock operators */
+const char *clk_elt_name(struct clk *clk);
 
 /**
  * Return the clock name
@@ -68,7 +73,10 @@ struct clk_ops {
  */
 static inline const char *clk_get_name(struct clk *clk)
 {
-	return clk->name;
+	if (clk->ops->get_name)
+		return clk->ops->get_name(clk);
+
+	return NULL;
 }
 
 /**


### PR DESCRIPTION
This P-R supersedes https://github.com/OP-TEE/optee_os/pull/4942 with orphan clocks renamed raw clocks.
