### PR TITLE
core: mmu: fix overflow with high address in tee_mm_pool_t

### DIFF
--- a/core/arch/arm/mm/core_mmu.c
+++ b/core/arch/arm/mm/core_mmu.c
@@ -2463,7 +2463,7 @@ void core_mmu_init_ta_ram(void)
 	vaddr_t s = 0;
 	vaddr_t e = 0;
 	paddr_t ps = 0;
-	paddr_t pe = 0;
+	size_t size = 0;
 
 	/*
 	 * Get virtual addr/size of RAM where TA are loaded/executedNSec
@@ -2475,14 +2475,14 @@ void core_mmu_init_ta_ram(void)
 		core_mmu_get_mem_by_type(MEM_AREA_TA_RAM, &s, &e);
 
 	ps = virt_to_phys((void *)s);
-	pe = virt_to_phys((void *)(e - 1)) + 1;
+	size = e - s;
 
 	if (!ps || (ps & CORE_MMU_USER_CODE_MASK) ||
-	    !pe || (pe & CORE_MMU_USER_CODE_MASK))
+	    !size || (size & CORE_MMU_USER_CODE_MASK))
 		panic("invalid TA RAM");
 
 	/* extra check: we could rely on core_mmu_get_mem_by_type() */
-	if (!tee_pbuf_is_sec(ps, pe - ps))
+	if (!tee_pbuf_is_sec(ps, size))
 		panic("TA RAM is not secure");
 
 	if (!tee_mm_is_empty(&tee_mm_sec_ddr))
@@ -2490,6 +2490,6 @@ void core_mmu_init_ta_ram(void)
 
 	/* remove previous config and init TA ddr memory pool */
 	tee_mm_final(&tee_mm_sec_ddr);
-	tee_mm_init(&tee_mm_sec_ddr, ps, pe, CORE_MMU_USER_CODE_SHIFT,
+	tee_mm_init(&tee_mm_sec_ddr, ps, size, CORE_MMU_USER_CODE_SHIFT,
 		    TEE_MM_POOL_NO_FLAGS);
 }

--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -441,8 +441,8 @@ static TEE_Result mobj_mapped_shm_init(void)
 	if (!pool_start || !pool_end)
 		panic("Can't find region for shmem pool");
 
-	if (!tee_mm_init(&tee_mm_shm, pool_start, pool_end, SMALL_PAGE_SHIFT,
-		    TEE_MM_POOL_NO_FLAGS))
+	if (!tee_mm_init(&tee_mm_shm, pool_start, pool_end - pool_start,
+			 SMALL_PAGE_SHIFT, TEE_MM_POOL_NO_FLAGS))
 		panic("Could not create shmem pool");
 
 	DMSG("Shared memory address range: %" PRIxVA ", %" PRIxVA,

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -27,7 +27,7 @@ typedef struct _tee_mm_entry_t tee_mm_entry_t;
 struct _tee_mm_pool_t {
 	tee_mm_entry_t *entry;
 	paddr_t lo;		/* low boundary of the pool */
-	paddr_t hi;		/* high boundary of the pool */
+	paddr_size_t size;	/* pool size */
 	uint32_t flags;		/* Config flags for the pool */
 	uint8_t shift;		/* size shift */
 	unsigned int lock;
@@ -70,8 +70,8 @@ static inline bool tee_mm_validate(const tee_mm_pool_t *pool, paddr_t addr)
 uintptr_t tee_mm_get_smem(const tee_mm_entry_t *mm);
 
 /* Init managed memory area */
-bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_t hi, uint8_t shift,
-		 uint32_t flags);
+bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_size_t size,
+		 uint8_t shift, uint32_t flags);
 
 /* Kill managed memory area*/
 void tee_mm_final(tee_mm_pool_t *pool);
@@ -107,7 +107,7 @@ static inline uint32_t tee_mm_get_offset(tee_mm_entry_t *p)
 /* Return size of the mm entry in bytes */
 size_t tee_mm_get_bytes(const tee_mm_entry_t *mm);
 
-bool tee_mm_addr_is_within_range(tee_mm_pool_t *pool, paddr_t addr);
+bool tee_mm_addr_is_within_range(const tee_mm_pool_t *pool, paddr_t addr);
 
 bool tee_mm_is_empty(tee_mm_pool_t *pool);
 

--- a/core/mm/mobj.c
+++ b/core/mm/mobj.c
@@ -691,7 +691,7 @@ bool mobj_is_paged(struct mobj *mobj)
 static TEE_Result mobj_init(void)
 {
 	mobj_sec_ddr = mobj_phys_alloc(tee_mm_sec_ddr.lo,
-				       tee_mm_sec_ddr.hi - tee_mm_sec_ddr.lo,
+				       tee_mm_sec_ddr.size,
 				       OPTEE_SMC_SHM_CACHED, CORE_MEM_TA_RAM);
 	if (!mobj_sec_ddr)
 		panic("Failed to register secure ta ram");


### PR DESCRIPTION
In case of TA_RAM defined at the end of address range,
the high address will be defined outside the vaddr_t limits
which ends in a 0 address usage.
The size must be used rather than the high address that will
avoid this overflow issue. Update the corresponding files due
to API modification.

Signed-off-by: Lionel Debieve <lionel.debieve@foss.st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
