### PR TITLE
drivers: clk: add verbosity on provider probe error case

### DIFF
--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -68,8 +68,12 @@ static TEE_Result parse_clock_property(const void *fdt, int node)
 
 		/* Parent probe should not fail or clock won't be available */
 		res = clk_probe_clock_provider_node(fdt, parent_node);
-		if (res)
-			panic("Failed to probe parent clock");
+		if (res) {
+			EMSG("Probe parent clock node %s on node %s: %#"PRIx32,
+			     fdt_get_name(fdt, parent_node, NULL),
+			     fdt_get_name(fdt, node, NULL), res);
+			panic();
+		}
 
 		clock_cells = fdt_get_dt_driver_cells(fdt, parent_node,
 						      DT_DRIVER_CLK);


### PR DESCRIPTION
Prints the names of the parent node and node for which core failed to
probe a clock instance. Also prints the returned error code. These
added debug information help understanding where and FDT parsing failed.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
