### PR TITLE
core: drivers: caam: disable jobring in dts only in case of external DTB

### DIFF
--- a/core/arch/arm/include/kernel/boot.h
+++ b/core/arch/arm/include/kernel/boot.h
@@ -89,4 +89,10 @@ unsigned long get_aslr_seed(void *fdt);
 
 void ffa_secondary_cpu_ep_register(vaddr_t secondary_ep);
 
+/* Returns true if passed DTB is same as Embedded DTB, otherwise false */
+static inline bool is_embedded_dt(void *fdt)
+{
+	return fdt && fdt == get_embedded_dt();
+}
+
 #endif /* __KERNEL_BOOT_H */

--- a/core/drivers/crypto/caam/hal/common/hal_cfg.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2017-2019 NXP
+ * Copyright 2017-2019, 2021 NXP
  *
  * Brief   CAAM Configuration.
  */
@@ -9,6 +9,7 @@
 #include <caam_hal_ctrl.h>
 #include <caam_hal_jr.h>
 #include <caam_jr.h>
+#include <config.h>
 #include <kernel/boot.h>
 #include <mm/core_memprot.h>
 #include <registers/jr_regs.h>
@@ -52,12 +53,13 @@ enum caam_status caam_hal_cfg_get_conf(struct caam_jrcfg *jrcfg)
 		jrcfg->offset = (CFG_JR_INDEX + 1) * JRX_BLOCK_SIZE;
 		jrcfg->it_num = CFG_JR_INT;
 
-#ifdef CFG_NXP_CAAM_RUNTIME_JR
-		if (fdt) {
-			/* Ensure Secure Job Ring is secure only into DTB */
-			caam_hal_cfg_disable_jobring_dt(fdt, jrcfg);
+		if (IS_ENABLED(CFG_NXP_CAAM_RUNTIME_JR) &&
+		    !is_embedded_dt(fdt)) {
+			if (fdt) {
+				/* Ensure Secure Job Ring is secure in DTB */
+				caam_hal_cfg_disable_jobring_dt(fdt, jrcfg);
+			}
 		}
-#endif
 	}
 
 	jrcfg->nb_jobs = NB_JOBS_QUEUE;

--- a/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2017-2019 NXP
+ * Copyright 2017-2019, 2021 NXP
  *
  * Brief   CAAM Configuration.
  */
@@ -8,6 +8,7 @@
 #include <caam_hal_cfg.h>
 #include <caam_hal_jr.h>
 #include <caam_jr.h>
+#include <kernel/boot.h>
 #include <kernel/dt.h>
 #include <kernel/interrupt.h>
 #include <libfdt.h>
@@ -98,10 +99,12 @@ void caam_hal_cfg_get_jobring_dt(void *fdt, struct caam_jrcfg *jrcfg)
 
 	jr_offset = find_jr_offset(fdt, DT_STATUS_OK_SEC, &node);
 	if (jr_offset) {
-		/* Disable JR for Normal World */
-		if (dt_enable_secure_status(fdt, node)) {
-			EMSG("Not able to disable JR DTB entry");
-			return;
+		if (!is_embedded_dt(fdt)) {
+			/* Disable JR for Normal World */
+			if (dt_enable_secure_status(fdt, node)) {
+				EMSG("Not able to disable JR DTB entry");
+				return;
+			}
 		}
 
 		/* Get the job ring interrupt */


### PR DESCRIPTION
On LX2160 board, Embedded DTB is enabled.
While booting with CAAM enabled, a crash comes in OP-TEE because it
tries to disable the Job Ring in Embedded DTB, which is read only.
So disable Job ring only when using External DTB.

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>