### PR TITLE
Introduce boot warning print for vanilla developer builds

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1253,6 +1253,10 @@ void __weak boot_init_primary_late(unsigned long fdt)
 	configure_console_from_dt();
 
 	IMSG("OP-TEE version: %s", core_v_str);
+	if (IS_ENABLED(CFG_WARN_INSECURE)) {
+		IMSG("WARNING: This OP-TEE configuration might be insecure!");
+		IMSG("WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html");
+	}
 	IMSG("Primary CPU initializing");
 #ifdef CFG_CORE_ASLR
 	DMSG("Executing at offset %#lx with virtual load address %#"PRIxVA,

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -723,5 +723,15 @@ CFG_DRIVERS_CLK ?= n
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
 CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
 
+# The purpose of this flag is to show a print when booting up the device that
+# indicates whether the board runs a standard developer configuration or not.
+# A developer configuration doesn't necessarily has to be secure. The intention
+# is that the one making products based on OP-TEE should override this flag in
+# plat-xxx/conf.mk for the platform they're basing their products on after
+# they've finalized implementing stubbed functionality (see OP-TEE
+# documentation/Porting guidelines) as well as vendor specific security
+# configuration.
+CFG_WARN_INSECURE ?= y
+
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))


### PR DESCRIPTION
Recent security issues reported to the OP-TEE project covering iMX-devices has mostly been about current CSU configuration in the OP-TEE project. This purpose of this PR is to reduce the likelihood of configuring plat-imx incorrectly. It's simply a debug print. It might seem overkill to have something like this, but I think we've seen enough reports now that we can justify adding this.