### PR TITLE
[FIX] core: dt_driver: pass driver type to clk_get_provider_by_*()

### DIFF
--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -33,6 +33,7 @@ static struct clk *clk_dt_get_by_idx_prop(const char *prop_name,
 {
 	void *device = dt_driver_device_from_node_idx_prop(prop_name, fdt,
 							   nodeoffset, clk_idx,
+							   DT_DRIVER_CLK,
 							   res);
 
 	return (struct clk *)device;
@@ -100,7 +101,7 @@ static TEE_Result clk_probe_clock_provider_node(const void *fdt, int node)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	/* Check if node has already been probed */
-	if (dt_driver_get_provider_by_node(node))
+	if (dt_driver_get_provider_by_node(node, DT_DRIVER_CLK))
 		return TEE_SUCCESS;
 
 	/* Check if the node has a clock property first to probe parent */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -68,6 +68,7 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
  * @fdt: FDT base address
  * @nodeoffset: node offset in the FDT
  * @prop_idx: index of the phandle data in the property
+ * @type: Driver type
  * @res: Output result code of the operation: TEE_ERROR_BUSY is target
  *	device is not yet initialized, otherwise any other compliant code.
  *
@@ -77,17 +78,20 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
 void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 					  const void *fdt, int nodeoffset,
 					  unsigned int prop_idx,
+					  enum dt_driver_type type,
 					  TEE_Result *res);
 
 /*
  * Return driver provider reference from its node offset value in the FDT
  */
-struct dt_driver_provider *dt_driver_get_provider_by_node(int nodeoffset);
+struct dt_driver_provider *
+dt_driver_get_provider_by_node(int nodeoffset, enum dt_driver_type type);
 
 /*
  * Return driver provider reference from its phandle value in the FDT
  */
-struct dt_driver_provider *dt_driver_get_provider_by_phandle(uint32_t phandle);
+struct dt_driver_provider *
+dt_driver_get_provider_by_phandle(uint32_t phandle, enum dt_driver_type type);
 
 /*
  * Return number cells used for phandle arguments by a driver provider

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -182,23 +182,25 @@ unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv)
 	return prv->provider_cells;
 }
 
-struct dt_driver_provider *dt_driver_get_provider_by_node(int nodeoffset)
+struct dt_driver_provider *
+dt_driver_get_provider_by_node(int nodeoffset, enum dt_driver_type type)
 {
 	struct dt_driver_provider *prv = NULL;
 
 	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
-		if (prv->nodeoffset == nodeoffset)
+		if (prv->nodeoffset == nodeoffset && prv->type == type)
 			return prv;
 
 	return NULL;
 }
 
-struct dt_driver_provider *dt_driver_get_provider_by_phandle(uint32_t phandle)
+struct dt_driver_provider *
+dt_driver_get_provider_by_phandle(uint32_t phandle, enum dt_driver_type type)
 {
 	struct dt_driver_provider *prv = NULL;
 
 	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
-		if (prv->phandle == phandle)
+		if (prv->phandle == phandle && prv->type == type)
 			return prv;
 
 	return NULL;
@@ -233,6 +235,7 @@ static void *device_from_provider_prop(struct dt_driver_provider *prv,
 void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 					  const void *fdt, int nodeoffset,
 					  unsigned int prop_idx,
+					  enum dt_driver_type type,
 					  TEE_Result *res)
 {
 	int len = 0;
@@ -253,7 +256,7 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 		idx32 = idx / sizeof(uint32_t);
 		phandle = fdt32_to_cpu(prop[idx32]);
 
-		prv = dt_driver_get_provider_by_phandle(phandle);
+		prv = dt_driver_get_provider_by_phandle(phandle, type);
 		if (!prv) {
 			*res = TEE_ERROR_GENERIC;
 			return NULL;


### PR DESCRIPTION
Adds driver type argument in clk_get_provider_by_*() functions to find
the target provider since a DT node may register providers of different
types. Updates dt_driver_device_from_node_idx_prop() accordingly.

Fixes: f498c4042931 ("core: dt_driver: factorize clk_get_provider_by_*()")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
