### PR TITLE
Fix SSK generation for CFG_CORE_HUK_SUBKEY_COMPAT

### DIFF
--- a/core/kernel/huk_subkey.c
+++ b/core/kernel/huk_subkey.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019, Linaro Limited
  */
 
+#include <config.h>
 #include <crypto/crypto.h>
 #include <kernel/huk_subkey.h>
 #include <kernel/tee_common_otp.h>
@@ -15,17 +16,18 @@ static TEE_Result mac_usage(void *ctx, uint32_t usage)
 }
 
 #ifdef CFG_CORE_HUK_SUBKEY_COMPAT
-/*
- * This gives the result of the default tee_otp_get_die_id()
- * implementation.
- */
-static void get_dummy_die_id(uint8_t *buffer, size_t len)
+static TEE_Result get_otp_die_id(uint8_t *buffer, size_t len)
 {
 	static const char pattern[4] = { 'B', 'E', 'E', 'F' };
 	size_t i;
 
+	if (IS_ENABLED(CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID))
+		return tee_otp_get_die_id(buffer, len);
+
 	for (i = 0; i < len; i++)
 		buffer[i] = pattern[i % 4];
+
+	return TEE_SUCCESS;
 }
 
 /*
@@ -42,7 +44,9 @@ static TEE_Result huk_compat(void *ctx, enum huk_subkey_usage usage)
 	case HUK_SUBKEY_RPMB:
 		return TEE_SUCCESS;
 	case HUK_SUBKEY_SSK:
-		get_dummy_die_id(chip_id, sizeof(chip_id));
+		res = get_otp_die_id(chip_id, sizeof(chip_id));
+		if (res)
+			return res;
 		res = crypto_mac_update(ctx, chip_id, sizeof(chip_id));
 		if (res)
 			return res;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -648,6 +648,10 @@ endif
 # Enables backwards compatible derivation of RPMB and SSK keys
 CFG_CORE_HUK_SUBKEY_COMPAT ?= y
 
+# Use SoC specific tee_otp_get_die_id() implementation for SSK key generation.
+# This option depends on CFG_CORE_HUK_SUBKEY_COMPAT=y.
+CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID ?= n
+
 # Compress and encode conf.mk into the TEE core, and show the encoded string on
 # boot (with severity TRACE_INFO).
 CFG_SHOW_CONF_ON_BOOT ?= n


### PR DESCRIPTION
Legacy code has used the result of tee_otp_get_die_id function for SSK
generation. get_dummy_die_id function always returns default value and
this doesn't work for devices that initialized RPMB partition with old
OP-TEE version and have SoC specific tee_otp_get_die_id implementation.

Signed-off-by: Ruslan Piasetskyi <ruslan.piasetskyi@gmail.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
