### PR TITLE
core: dt_driver: debug trace if property not found

### DIFF
--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -245,6 +245,8 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 
 	prop = fdt_getprop(fdt, nodeoffset, prop_name, &len);
 	if (!prop) {
+		DMSG("Property %s missing in node %s", prop_name,
+		     fdt_get_name(fdt, nodeoffset, NULL));
 		*res = TEE_ERROR_GENERIC;
 		return NULL;
 	}


### PR DESCRIPTION
Adds a debug level trace message in dt_driver_device_from_node_idx_prop()
when unexpectedly not finding provider expected property in target node.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
