### PR TITLE
core: dt_driver: allow driver probe/init failure without panicking

### DIFF
--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -132,22 +132,6 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
 	return TEE_SUCCESS;
 }
 
-/* Release driver provider references once all dt_drivers are initialized */
-static TEE_Result dt_driver_release_provider(void)
-{
-	struct dt_driver_provider *prv = NULL;
-
-	while (!SLIST_EMPTY(&dt_driver_provider_list)) {
-		prv = SLIST_FIRST(&dt_driver_provider_list);
-		SLIST_REMOVE_HEAD(&dt_driver_provider_list, link);
-		free(prv);
-	}
-
-	return TEE_SUCCESS;
-}
-
-release_init_resource(dt_driver_release_provider);
-
 /*
  * Helper functions for dt_drivers querying driver provider information
  */
@@ -656,6 +640,8 @@ static TEE_Result release_probe_lists(void)
 {
 	struct dt_driver_probe *elt = NULL;
 	struct dt_driver_probe *next = NULL;
+	struct dt_driver_provider *prov = NULL;
+	struct dt_driver_provider *next_prov = NULL;
 	const void * __maybe_unused fdt = NULL;
 
 	if (!IS_ENABLED(CFG_EMBED_DTB))
@@ -665,11 +651,11 @@ static TEE_Result release_probe_lists(void)
 
 	assert(fdt && TAILQ_EMPTY(&dt_driver_probe_list));
 
-	TAILQ_FOREACH_SAFE(elt, &dt_driver_ready_list, link, next) {
-		DMSG("element: %s on node %s", elt->dt_drv->name,
-		     fdt_get_name(fdt, elt->nodeoffset, NULL));
+	TAILQ_FOREACH_SAFE(elt, &dt_driver_ready_list, link, next)
 		free(elt);
-	}
+
+	SLIST_FOREACH_SAFE(prov, &dt_driver_provider_list, link, next_prov)
+	       free(prov);
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Following recent discussions, a driver initialization failure (aside from probe deferral error case) should not panic core.
These patches changes the common driver probing sequence to not panic in such case.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
