### PR TITLE
core: dt_driver: fix missing probe deferral report

### DIFF
--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -257,7 +257,8 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 
 		prv = dt_driver_get_provider_by_phandle(phandle);
 		if (!prv) {
-			*res = TEE_ERROR_GENERIC;
+			/* No provider registered yet */
+			*res = TEE_ERROR_DEFER_DRIVER_INIT;
 			return NULL;
 		}
 


### PR DESCRIPTION
During discussions around P-R https://github.com/OP-TEE/optee_os/pull/4965 I missed an instruction in the implementation: where dt_driver provider reports a probe deferral error case: that is when expected provider is not yet registered.
This is fixed by commit "core: dt_driver: return TEE_ERROR_DEFER_DRIVER_INIT if no provider".

**(edited) the driver probing test part has been removed from this P-R**
~~This P-R also proposes some test support for driver probing, based on a dedicated embedded DTB. It adds a command to the invocation test PTA, to retrieve the status of the DT drivers probing tests.~~

~~Because the test currently relies only on clock resources, a commit adds config switch `CFG_DRIVERS_CLK_EARLY_PROBE` to have clock drivers probed with other registered compatible drivers so we can test deferring a clock consumer due to its clock device dependency.~~

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
