### PR TITLE
core: reset controller driver interface

### DIFF
--- a/core/drivers/rstctrl/rstctrl.c
+++ b/core/drivers/rstctrl/rstctrl.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#include <assert.h>
+#include <drivers/rstctrl.h>
+#include <io.h>
+#include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <kernel/spinlock.h>
+#include <libfdt.h>
+#include <stdint.h>
+
+/* Global reset controller access lock */
+
+TEE_Result rstctrl_get_exclusive(struct rstctrl *rstctrl)
+{
+	uint32_t exceptions = 0;
+	TEE_Result res = TEE_ERROR_ACCESS_CONFLICT;
+	static unsigned int rstctrl_lock = SPINLOCK_UNLOCK;
+
+	exceptions = cpu_spin_lock_xsave(&rstctrl_lock);
+
+	if (!rstctrl->exclusive) {
+		rstctrl->exclusive = true;
+		res = TEE_SUCCESS;
+	}
+
+	cpu_spin_unlock_xrestore(&rstctrl_lock, exceptions);
+
+	return res;
+}
+
+void rstctrl_put_exclusive(struct rstctrl *rstctrl)
+{
+	assert(rstctrl->exclusive);
+
+	WRITE_ONCE(rstctrl->exclusive, false);
+}
+
+TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
+				  const char *name, struct rstctrl **rstctrl)
+{
+	int index = 0;
+
+	index = fdt_stringlist_search(fdt, nodeoffset, "reset-names", name);
+	if (index < 0)
+		return TEE_ERROR_GENERIC;
+
+	return rstctrl_dt_get_by_index(fdt, nodeoffset, index, rstctrl);
+}

--- a/core/drivers/rstctrl/sub.mk
+++ b/core/drivers/rstctrl/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += rstctrl.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -50,5 +50,6 @@ srcs-$(CFG_ZYNQMP_HUK) += zynqmp_huk.c
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt
 subdirs-$(CFG_DRIVERS_CLK) += clk
+subdirs-$(CFG_DRIVERS_RSTCTRL) += rstctrl
 subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg
 subdirs-y += imx

--- a/core/include/drivers/rstctrl.h
+++ b/core/include/drivers/rstctrl.h
@@ -1,0 +1,234 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#ifndef __DRIVERS_RSTCTRL_H
+#define __DRIVERS_RSTCTRL_H
+
+#include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+struct rstctrl;
+
+struct rstctrl_ops {
+	/*
+	 * Operators on reset control(s) exposed by a reset controller
+	 *
+	 * @assert_level: Assert reset level on control with a timeout hint
+	 * @deassert_level: Deassert reset level on control with a timeout hint
+	 * @get_name: Get a string name for the controller, or NULL is none
+	 *
+	 * Operator functions @assert_level and @deassert_level use arguments:
+	 * @rstctrl: Reset controller
+	 * @id: Identifier for the reset level control in the reset controller
+	 * @to_ms: Timeout in microseconds or RSTCTRL_NO_TIMEOUT, may be ignored
+	 * by reset controller.
+	 * Return a TEE_Result compliant code.
+	 */
+	TEE_Result (*assert_level)(struct rstctrl *rstctrl, unsigned int to_us);
+	TEE_Result (*deassert_level)(struct rstctrl *rstctrl,
+				     unsigned int to_us);
+	const char *(*get_name)(struct rstctrl *rstctrl);
+};
+
+/*
+ * struct rstctrl - Instance of a control exposed by a reset controller
+ * @ops: Operators of the reset controller
+ * @exclusive: Set when a consumer has exclusive control on the reset level
+ */
+struct rstctrl {
+	const struct rstctrl_ops *ops;
+	bool exclusive;
+};
+
+/**
+ * RSTCTRL_DECLARE - Declare a reset controller driver with a single
+ * device tree compatible string.
+ *
+ * @__name: Reset controller driver name
+ * @__compat: Compatible string
+ * @__probe: Reset controller probe function
+ */
+#define RSTCTRL_DT_DECLARE(__name, __compat, __probe) \
+	static const struct dt_device_match __name ## _match_table[] = { \
+		{ .compatible = __compat }, \
+		{ } \
+	}; \
+	DEFINE_DT_DRIVER(__name ## _dt_driver) = { \
+		.name = # __name, \
+		.type = DT_DRIVER_RSTCTRL, \
+		.match_table = __name ## _match_table, \
+		.probe = __probe, \
+	}
+
+/*
+ * Platform driver may ignore the timeout hint according to their
+ * capabilities. RSTCTRL_NO_TIMEOUT specifies no timeout hint.
+ */
+#define RSTCTRL_NO_TIMEOUT	0
+
+/*
+ * rstctrl_assert_to - Assert reset control possibly with timeout
+ * rstctrl_assert - Assert reset control
+ * rstctrl_deassert_to - Deassert reset control possibly with timeout
+ * rstctrl_deassert - Deassert reset control
+ *
+ * @rstctrl: Reset controller
+ * @to_us: Timeout in microseconds
+ * Return a TEE_Result compliant code
+ */
+static inline TEE_Result rstctrl_assert_to(struct rstctrl *rstctrl,
+					   unsigned int to_us)
+{
+	return rstctrl->ops->assert_level(rstctrl, to_us);
+}
+
+static inline TEE_Result rstctrl_assert(struct rstctrl *rstctrl)
+{
+	return rstctrl_assert_to(rstctrl, RSTCTRL_NO_TIMEOUT);
+}
+
+static inline TEE_Result rstctrl_deassert_to(struct rstctrl *rstctrl,
+					     unsigned int to_us)
+{
+	return rstctrl->ops->deassert_level(rstctrl, to_us);
+}
+
+static inline TEE_Result rstctrl_deassert(struct rstctrl *rstctrl)
+{
+	return rstctrl_deassert_to(rstctrl, RSTCTRL_NO_TIMEOUT);
+}
+
+/*
+ * rstctrl_name - Get a name for the reset level control or NULL
+ *
+ * @rstctrl: Reset controller
+ * Return a pointer to controller name or NULL
+ */
+static inline const char *rstctrl_name(struct rstctrl *rstctrl)
+{
+	if (rstctrl->ops->get_name)
+		return rstctrl->ops->get_name(rstctrl);
+
+	return NULL;
+}
+
+/**
+ * rstctrl_dt_get_exclusive - Get exclusive access to reset controller
+ *
+ * @rstctrl: Reset controller
+ * Return a TEE_Result compliant value
+ */
+TEE_Result rstctrl_get_exclusive(struct rstctrl *rstctrl);
+
+/**
+ * rstctrl_put_exclusive - Release exclusive access to target
+ *
+ * @rstctrl: Reset controller
+ */
+void rstctrl_put_exclusive(struct rstctrl *rstctrl);
+
+/**
+ * rstctrl_ops_is_valid - Check reset controller ops is valid
+ *
+ * @ops: Reference to reset controller operator instance
+ */
+static inline bool rstctrl_ops_is_valid(const struct rstctrl_ops *ops)
+{
+	return ops && ops->assert_level && ops->deassert_level;
+}
+
+#ifdef CFG_DT
+/**
+ * rstctrl_dt_get_by_index - Get a reset controller at a specific index in
+ * 'resets' property
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the subnode containing a 'resets' property
+ * @index: Reset controller index in 'resets' property
+ * @rstctrl: Output reset controller reference upon success
+ *
+ * Return TEE_SUCCESS in case of success
+ * Return TEE_ERROR_DEFER_DRIVER_INIT if reset controller is not initialized
+ * Return a TEE_Result compliant code in case of error
+ */
+static inline TEE_Result rstctrl_dt_get_by_index(const void *fdt,
+						 int nodeoffset,
+						 unsigned int index,
+						 struct rstctrl **rstctrl)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	*rstctrl = dt_driver_device_from_node_idx_prop("resets", fdt,
+						       nodeoffset, index,
+						       DT_DRIVER_RSTCTRL, &res);
+	return res;
+}
+#else
+static inline TEE_Result rstctrl_dt_get_by_index(const void *fdt __unused,
+						 int nodeoffset __unused,
+						 unsigned int index __unused,
+						 struct rstctrl **rstctrl)
+{
+	*rstctrl = NULL;
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif /*CFG_DT*/
+
+/**
+ * rstctrl_dt_get_by_name - Get a reset controller matching a name in the
+ * 'reset-names' property
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the subnode containing a 'resets' property
+ * @name: Reset controller name to get
+ * @rstctrl: Output reset controller reference upon success
+ *
+ * Return TEE_SUCCESS in case of success
+ * Return TEE_ERROR_DEFER_DRIVER_INIT if reset controller is not initialized
+ * Return a TEE_Result compliant code in case of error
+ */
+TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
+				  const char *name, struct rstctrl **rstctrl);
+
+/**
+ * rstctrl_dt_get_func - Typedef of function to get reset controller from
+ * devicetree properties
+ *
+ * @a: Pointer to devicetree description of the reset controller to parse
+ * @data: Pointer to data given at rstctrl_dt_register_provider() call
+ * @res: Output result code of the operation:
+ *	TEE_SUCCESS in case of success
+ *	TEE_ERROR_DEFER_DRIVER_INIT if reset controller is not initialized
+ *	Any TEE_Result compliant code in case of error.
+ *
+ * Returns a struct rstctrl pointer pointing to a reset controller matching
+ * the devicetree description or NULL if invalid description in which case
+ * @res provides the error code.
+ */
+typedef struct rstctrl *(*rstctrl_dt_get_func)(struct dt_driver_phandle_args *a,
+					       void *data, TEE_Result *res);
+
+/**
+ * rstctrl_dt_register_provider - Register a reset controller provider
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the reset controller
+ * @get_dt_rstctrl: Callback to match the reset controller with a struct rstctrl
+ * @data: Data which will be passed to the get_dt_rstctrl callback
+ * Returns TEE_Result value
+ */
+static inline
+TEE_Result rstctrl_register_provider(const void *fdt, int nodeoffset,
+				     rstctrl_dt_get_func get_dt_rstctrl,
+				     void *data)
+{
+	return dt_driver_register_provider(fdt, nodeoffset,
+					   (get_of_device_func)get_dt_rstctrl,
+					   data, DT_DRIVER_RSTCTRL);
+}
+#endif /* __DRIVERS_RSTCTRL_H */
+

--- a/core/include/io.h
+++ b/core/include/io.h
@@ -11,13 +11,14 @@
 #include <utee_defines.h>
 
 /*
- * Make sure that compiler reads given variable only once. This is needed
+ * Make sure that compiler reads/writes given variable only once. This is needed
  * in cases when we have normal shared memory, and this memory can be changed
  * at any moment. Compiler does not knows about this, so it can optimize memory
- * access in any way, including repeated read from the same address. This macro
- * enforces compiler to access memory only once.
+ * access in any way, including repeated accesses from the same address.
+ * These macro enforce compiler to access memory only once.
  */
-#define READ_ONCE(p) __compiler_atomic_load(&(p))
+#define READ_ONCE(p)		__compiler_atomic_load(&(p))
+#define WRITE_ONCE(p, v)	__compiler_atomic_store(&(p), (v))
 
 static inline void io_write8(vaddr_t addr, uint8_t val)
 {

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -66,6 +66,7 @@ enum dt_driver_type {
 	DT_DRIVER_NOTYPE,
 	DT_DRIVER_UART,
 	DT_DRIVER_CLK,
+	DT_DRIVER_RSTCTRL,
 };
 
 /*

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -103,8 +103,9 @@ static void assert_type_is_valid(enum dt_driver_type type)
 {
 	switch (type) {
 	case DT_DRIVER_NOTYPE:
-	case DT_DRIVER_UART:
 	case DT_DRIVER_CLK:
+	case DT_DRIVER_RSTCTRL:
+	case DT_DRIVER_UART:
 		return;
 	default:
 		assert(0);
@@ -167,6 +168,9 @@ int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
 	switch (type) {
 	case DT_DRIVER_CLK:
 		cells_name = "#clock-cells";
+		break;
+	case DT_DRIVER_RSTCTRL:
+		cells_name = "#reset-cells";
 		break;
 	default:
 		panic();

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -729,6 +729,9 @@ CFG_DRIVERS_CLK ?= n
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
 CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
 
+$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
+$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))
+
 # The purpose of this flag is to show a print when booting up the device that
 # indicates whether the board runs a standard developer configuration or not.
 # A developer configuration doesn't necessarily has to be secure. The intention
@@ -738,9 +741,6 @@ CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
 # documentation/Porting guidelines) as well as vendor specific security
 # configuration.
 CFG_WARN_INSECURE ?= y
-
-$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
-$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))
 
 # Enables warnings for declarations mixed with statements
 CFG_WARN_DECL_AFTER_STATEMENT ?= y

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -732,6 +732,10 @@ CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))
 
+# When enabled, CFG_DRIVERS_RSTCTRL embeds a reset controller framework in
+# OP-TEE core to provide reset controls on subsystems of the devices.
+CFG_DRIVERS_RSTCTRL ?= n
+
 # The purpose of this flag is to show a print when booting up the device that
 # indicates whether the board runs a standard developer configuration or not.
 # A developer configuration doesn't necessarily has to be secure. The intention


### PR DESCRIPTION
This P-R proposes a reset controller driver interface and means to register in the DT driver provider framework ~~and some embedded tests~~:
* commit "_drivers: add reset controller framework_"
* ~~commit "_core: dt_driver: test reset-controller probing_"~~

~~This P-R reuses other changes alrerady under in others P-R:~~
~~* commit "_core: dt_driver: pass driver type to clk_get_provider_by_*()_" (from [P-R 4988](https://github.com/OP-TEE/optee_os/pull/4988)) is needed for provider to possibly differentiate providers relate to a same device node in the embedded DT.~~
~~* commits "core: dt_driver: return TEE_ERROR_DEFER_DRIVER_INIT if no provider",
"drivers: clk: add CFG_DRIVERS_CLK_EARLY_PROBE" and "core: dt_driver: drivers to test probe deferral"
(from [P-R 4995](https://github.com/OP-TEE/optee_os/pull/4995)) are foundation of DT driver probing tests, needed to add test on reset controller drivers probing.~~
