### PR TITLE
dt drive rprobing: probe before/after crypto initialization

### DIFF
--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -82,6 +82,21 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 					  TEE_Result *res);
 
 /*
+ * dt_driver_get_crypto() - Request crypto support for driver initialization
+ *
+ * Return TEE_SUCCESS if cryptography services are initialized, otherwise return
+ * TEE_ERROR_DEFER_DRIVER_INIT.
+ */
+TEE_Result dt_driver_get_crypto(void);
+
+#ifdef CFG_DT
+/* Inform DT driver probe sequence that core crypto support is initialized */
+void dt_driver_crypt_init_complete(void);
+#else
+static inline void dt_driver_crypt_init_complete(void) {}
+#endif
+
+/*
  * Return driver provider reference from its node offset value in the FDT
  */
 struct dt_driver_provider *

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -82,6 +82,23 @@ static TAILQ_HEAD(, dt_driver_probe) dt_driver_failed_list =
 /* Flag enabled when a new node (possibly typed) is added in the probe list */
 static bool added_node;
 
+/* Resolve drivers dependencies on core crypto layer */
+static bool tee_crypt_is_ready;
+
+void dt_driver_crypt_init_complete(void)
+{
+	assert(!tee_crypt_is_ready);
+	tee_crypt_is_ready = true;
+}
+
+TEE_Result dt_driver_get_crypto(void)
+{
+	if (tee_crypt_is_ready)
+		return TEE_SUCCESS;
+	else
+		return TEE_ERROR_DEFER_DRIVER_INIT;
+}
+
 static void assert_type_is_valid(enum dt_driver_type type)
 {
 	switch (type) {

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2014, Linaro Limited
+ * Copyright (c) 2014-2021, Linaro Limited
  * Copyright (c) 2021, SumUp Services GmbH
  */
 
 #include <crypto/crypto.h>
 #include <initcall.h>
+#include <kernel/dt_driver.h>
 #include <kernel/panic.h>
 #include <kernel/tee_time.h>
 #include <rng_support.h>
@@ -207,6 +208,8 @@ static TEE_Result tee_cryp_init(void)
 		panic();
 	}
 	plat_rng_init();
+
+	dt_driver_crypt_init_complete();
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
This series changes the driver probing sequence to probe drivers before and after core crypto and rng services are initialized.

Driver registering the the drvcrypt framework must be registered before crypto API is used. Drivers depending on the crypto service should be deferred to after crypto init.