### PR TITLE
build: use CFLAGS32/CFLAGS64 when building in-tree TAs

### DIFF
--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -9,8 +9,12 @@ ta-target := $(strip $(if $(CFG_USER_TA_TARGET_$(sm)), \
 		$(filter $(CFG_USER_TA_TARGET_$(sm)), $(ta-targets)), \
 		$(default-user-ta-target)))
 
-arch-bits-ta_arm32 := 32
-arch-bits-ta_arm64 := 64
+ifeq ($(ta-target),ta_arm32)
+arch-bits-$(sm) := 32
+endif
+ifeq ($(ta-target),ta_arm64)
+arch-bits-$(sm) := 64
+endif
 
 ta-dev-kit-dir$(sm) := $(out-dir)/export-$(ta-target)
 link-out-dir$(sm) := $(out-dir)/$(patsubst %/,%, $(dir $(ta-mk-file)))


### PR DESCRIPTION
Commit 19fdfcf617e3 ("build: ldelf and TAs can rely on CFLAGS32/CFLAGS64")
only partially implements what is mentioned in the commit description.
The ldelf part is OK, but in-tree TAs still don't use CFLAGS32 or
CFLAGS64. The reason is that the submodule name $(sm) is not ta_arm32 or
ta_arm64 like for TAs build with the "dev kit". Instead, $(sm) is the
name of the directory (such as "avb" for core/ta/avb, "pkcs11" for
core/ta/pkcs11, etc.). Therefore, it is not arch-bits-ta_arm32 or
arch-bits-ta_arm64 that needs to be set but arch-bits-$(sm).

Fixes: 19fdfcf617e3 ("build: ldelf and TAs can rely on CFLAGS32/CFLAGS64")
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
