### PR TITLE
[RFC v4] Remote attestation PTA

### DIFF
--- a/core/include/tee/tee_svc_storage.h
+++ b/core/include/tee/tee_svc_storage.h
@@ -63,10 +63,6 @@ void tee_svc_storage_init(void);
 struct tee_pobj;
 TEE_Result tee_svc_storage_create_filename(void *buf, size_t blen,
 					   struct tee_pobj *po, bool transient);
-struct tee_fs_dirfile_fileh;
-TEE_Result
-tee_svc_storage_create_filename_dfh(void *buf, size_t blen,
-				    const struct tee_fs_dirfile_fileh *dfh);
 
 TEE_Result tee_svc_storage_create_dirname(void *buf, size_t blen,
 					  const TEE_UUID *uuid);

--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -1,0 +1,533 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2021, Huawei Technologies Co., Ltd
+ */
+
+#include <crypto/crypto.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/ts_store.h>
+#include <mm/file.h>
+#include <pta_attestation.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee/entry_std.h>
+#include <tee/tee_fs.h>
+#include <tee/tee_pobj.h>
+#include <tee/uuid.h>
+#include <utee_defines.h>
+
+#define PTA_NAME "attestation.pta"
+
+#define MAX_KEY_SIZE 4096
+
+static TEE_UUID pta_uuid = PTA_ATTESTATION_UUID;
+
+static struct rsa_keypair *key;
+
+static const uint8_t key_file_name[] = "key";
+
+static TEE_Result allocate_key(void)
+{
+	assert(!key);
+
+	key = calloc(sizeof(*key), 1);
+	if (!key)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	COMPILE_TIME_ASSERT(CFG_ATTESTATION_PTA_KEY_SIZE <= MAX_KEY_SIZE);
+	return crypto_acipher_alloc_rsa_keypair(key, MAX_KEY_SIZE);
+}
+
+static void free_key(void)
+{
+	crypto_acipher_free_rsa_keypair(key);
+	free(key);
+	key = NULL;
+}
+
+static TEE_Result generate_key(void)
+{
+	uint32_t e = TEE_U32_TO_BIG_ENDIAN(65537);
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = allocate_key();
+	if (res)
+		return res;
+
+	crypto_bignum_bin2bn((uint8_t *)&e, sizeof(e), key->e);
+
+	/*
+	 * For security reasons, the RSA modulus size has to be at least the
+	 * size of the data to be signed.
+	 */
+	DMSG("Generating %u bit RSA key pair", CFG_ATTESTATION_PTA_KEY_SIZE);
+	COMPILE_TIME_ASSERT(CFG_ATTESTATION_PTA_KEY_SIZE >=
+			    TEE_SHA256_HASH_SIZE);
+	res = crypto_acipher_gen_rsa_key(key, CFG_ATTESTATION_PTA_KEY_SIZE);
+	if (res)
+		free_key();
+
+	return res;
+}
+
+/*
+ * Return values:
+ * > 0 : Number of bytes written to buf
+ *   0 : @sz too large (> UINT16_MAX) or @buf_sz too small
+ */
+static size_t serialize_bignum(uint8_t *buf, size_t buf_sz, struct bignum *bn)
+{
+	uint8_t *p = buf;
+	size_t sz = crypto_bignum_num_bytes(bn);
+	uint16_t val = TEE_U16_TO_BIG_ENDIAN(sz);
+	size_t total_sz = sizeof(val) + sz;
+
+	if (sz > UINT16_MAX || total_sz > buf_sz)
+		return 0;
+
+	memcpy(p, &val, sizeof(val));
+	p += sizeof(val);
+
+	crypto_bignum_bn2bin(bn, p);
+
+	return total_sz;
+}
+
+static TEE_Result serialize_key(uint8_t **buf, size_t *size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *p = NULL;
+	size_t max_sz = 0;
+	size_t e_sz = 0;
+	size_t d_sz = 0;
+	size_t n_sz = 0;
+	size_t sz = 0;
+
+	assert(key);
+
+	e_sz = crypto_bignum_num_bytes(key->e);
+	d_sz = crypto_bignum_num_bytes(key->d);
+	n_sz = crypto_bignum_num_bytes(key->n);
+	if (e_sz > UINT16_MAX || d_sz > UINT16_MAX || n_sz > UINT16_MAX)
+		return TEE_ERROR_GENERIC;
+
+	max_sz = e_sz + d_sz + n_sz + 3 * sizeof(uint16_t);
+	p = calloc(max_sz, 1);
+	if (!p)
+		return TEE_ERROR_OUT_OF_MEMORY;
+	*buf = p;
+	*size = max_sz;
+
+	sz = serialize_bignum(p, max_sz, key->e);
+	if (!sz)
+		goto err;
+	p += sz;
+	max_sz -= sz;
+	sz = serialize_bignum(p, max_sz, key->d);
+	if (!sz)
+		goto err;
+	p += sz;
+	max_sz -= sz;
+	sz = serialize_bignum(p, max_sz, key->n);
+	if (!sz)
+		goto err;
+	max_sz -= sz;
+	assert(!max_sz);
+
+	return TEE_SUCCESS;
+err:
+	free(p);
+	*buf = NULL;
+	*size = 0;
+	return res;
+}
+
+static size_t deserialize_bignum(uint8_t *buf, size_t max_sz, struct bignum *bn)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *p = buf;
+	uint16_t val = 0;
+	size_t sz = 0;
+
+	if (max_sz < sizeof(val))
+		return 0;
+
+	memcpy(&val, p, sizeof(val));
+	sz = TEE_U16_FROM_BIG_ENDIAN(val);
+	p += sizeof(val);
+	max_sz -= sizeof(val);
+	if (max_sz < sz)
+		return 0;
+
+	res = crypto_bignum_bin2bn(p, sz, bn);
+	if (res)
+		return 0;
+
+	return sizeof(val) + sz;
+}
+
+static TEE_Result deserialize_key(uint8_t *buf, size_t buf_sz)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *p = buf;
+	size_t sz = 0;
+
+	res = allocate_key();
+	if (res)
+		goto out;
+
+	sz = deserialize_bignum(p, buf_sz, key->e);
+	if (!sz)
+		goto out;
+	p += sz;
+	buf_sz -= sz;
+	sz = deserialize_bignum(p, buf_sz, key->d);
+	if (!sz)
+		goto out;
+	p += sz;
+	buf_sz -= sz;
+	sz = deserialize_bignum(p, buf_sz, key->n);
+	if (!sz)
+		goto out;
+	buf_sz -= sz;
+	assert(!buf_sz);
+out:
+	return res;
+}
+
+static TEE_Result sec_storage_obj_read(TEE_UUID *uuid, uint32_t storage_id,
+				       const uint8_t *obj_id,
+				       size_t obj_id_len,
+				       uint8_t *data, size_t *len,
+				       size_t offset, uint32_t flags)
+{
+	const struct tee_file_operations *fops = NULL;
+	TEE_Result res = TEE_ERROR_BAD_STATE;
+	struct tee_file_handle *fh = NULL;
+	struct tee_pobj *po = NULL;
+	size_t file_size = 0;
+	size_t read_len = 0;
+
+	fops = tee_svc_storage_file_ops(storage_id);
+	if (!fops)
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	if (obj_id_len > TEE_OBJECT_ID_MAX_LEN)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = tee_pobj_get(uuid, (void *)obj_id, obj_id_len, flags, false, fops,
+			   &po);
+	if (res)
+		return res;
+
+	res = po->fops->open(po, &file_size, &fh);
+	if (res)
+		goto out;
+
+	read_len = *len;
+	res = po->fops->read(fh, offset, data, &read_len);
+	if (res == TEE_ERROR_CORRUPT_OBJECT) {
+		EMSG("Object corrupt");
+		po->fops->remove(po);
+	} else if (!res) {
+		*len = read_len;
+	}
+
+	po->fops->close(&fh);
+out:
+	tee_pobj_release(po);
+
+	return res;
+}
+
+static TEE_Result sec_storage_obj_write(TEE_UUID *uuid, uint32_t storage_id,
+					const uint8_t *obj_id,
+					size_t obj_id_len,
+					const uint8_t *data, size_t len,
+					size_t offset, uint32_t flags)
+
+{
+	const struct tee_file_operations *fops = NULL;
+	struct tee_file_handle *fh = NULL;
+	TEE_Result res = TEE_SUCCESS;
+	struct tee_pobj *po = NULL;
+
+	fops = tee_svc_storage_file_ops(storage_id);
+	if (!fops)
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	if (obj_id_len > TEE_OBJECT_ID_MAX_LEN)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = tee_pobj_get(uuid, (void *)obj_id, obj_id_len, flags, false,
+			   fops, &po);
+	if (res)
+		return res;
+
+	res = po->fops->open(po, NULL, &fh);
+	if (res == TEE_ERROR_ITEM_NOT_FOUND)
+		res = po->fops->create(po, false, NULL, 0, NULL, 0, NULL, 0,
+				       &fh);
+	if (!res) {
+		res = po->fops->write(fh, offset, data, len);
+		po->fops->close(&fh);
+	}
+
+	tee_pobj_release(po);
+
+	return res;
+}
+
+static TEE_Result load_key(void)
+{
+	/*
+	 * Serialized key pair is 3 bignums (e, p and n) plus their sizes
+	 * encoded as uint16_t. e is 65537 so it needs only 3 bytes.
+	 */
+	size_t size = 3 + 2 * MAX_KEY_SIZE / 8 + 3 * sizeof(uint16_t);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *buf;
+
+	buf = calloc(size, 1);
+	if (!buf)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	DMSG("Loading RSA key pair from secure storage");
+	res = sec_storage_obj_read(&pta_uuid, TEE_STORAGE_PRIVATE,
+				   key_file_name, sizeof(key_file_name) - 1,
+				   buf, &size, 0, TEE_DATA_FLAG_ACCESS_READ);
+	if (res)
+		goto out;
+	DMSG("Read %zu bytes", size);
+	res = deserialize_key(buf, size);
+	if (!res)
+		DMSG("Loaded %zu bit key pair", crypto_bignum_num_bits(key->n));
+
+out:
+	free(buf);
+	return res;
+}
+
+static TEE_Result write_key(void)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *buf = NULL;
+	size_t size = 0;
+
+	DMSG("Saving key pair");
+	res = serialize_key(&buf, &size);
+	if (res)
+		return res;
+
+	res = sec_storage_obj_write(&pta_uuid, TEE_STORAGE_PRIVATE,
+				    key_file_name, sizeof(key_file_name) - 1,
+				    buf, size, 0, TEE_DATA_FLAG_ACCESS_WRITE);
+	if (!res)
+		DMSG("Wrote %zu bytes", size);
+	free(buf);
+	return res;
+}
+
+static TEE_Result init_key(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	if (!key) {
+		res = load_key();
+		if (res) {
+			res = generate_key();
+			if (res)
+				return res;
+			res = write_key();
+			if (res)
+				return res;
+		}
+	}
+	return res;
+}
+
+static TEE_Result hash_binary(const TEE_UUID *uuid, uint8_t *hash)
+{
+	TEE_Result res = TEE_ERROR_ITEM_NOT_FOUND;
+	unsigned int tag_len = FILE_TAG_SIZE;
+	const struct ts_store_ops *ops = NULL;
+	struct ts_store_handle *h = NULL;
+
+	SCATTERED_ARRAY_FOREACH(ops, ta_stores, struct ts_store_ops) {
+		res = ops->open(uuid, &h);
+		if (!res)
+			break;  /* TA found */
+	}
+	if (res)
+		return res;
+
+	/*
+	 * Output hash size is assumed to be the same size as the file tag
+	 * size which is the size of the digest in the TA shdr. If one or the
+	 * other changes, additional hashing will be needed.
+	 */
+	COMPILE_TIME_ASSERT(FILE_TAG_SIZE == TEE_SHA256_HASH_SIZE);
+	assert(ops);
+	res = ops->get_tag(h, hash, &tag_len);
+	if (res)
+		goto out;
+
+	DMSG("TA %pUl hash:", uuid);
+	DHEXDUMP(hash, TEE_SHA256_HASH_SIZE);
+out:
+	ops->close(h);
+	return res;
+}
+
+static TEE_Result digest_nonce_and_hash(uint8_t *digest, uint8_t *nonce,
+					size_t nonce_sz, uint8_t *hash)
+{
+	TEE_Result res = TEE_SUCCESS;
+	void *ctx = NULL;
+
+	res = crypto_hash_alloc_ctx(&ctx, TEE_ALG_SHA256);
+	if (res)
+		return res;
+
+	res = crypto_hash_init(ctx);
+	if (res)
+		goto out;
+	if (nonce) {
+		res = crypto_hash_update(ctx, nonce, nonce_sz);
+		if (res)
+			goto out;
+	}
+	res = crypto_hash_update(ctx, hash, TEE_SHA256_HASH_SIZE);
+	if (res)
+		goto out;
+	res = crypto_hash_final(ctx, digest, TEE_SHA256_HASH_SIZE);
+out:
+	crypto_hash_free_ctx(ctx);
+	return res;
+}
+
+static TEE_Result sign_digest(uint8_t *sig, size_t sig_len,
+			      const uint8_t *digest)
+{
+	return crypto_acipher_rsassa_sign(TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256,
+					  key,
+					  TEE_SHA256_HASH_SIZE, /* salt len */
+					  digest, TEE_SHA256_HASH_SIZE,
+					  sig, &sig_len);
+}
+
+static TEE_Result cmd_hash_ta(uint32_t param_types,
+			      TEE_Param params[TEE_NUM_PARAMS])
+{
+	uint8_t digest[TEE_SHA256_HASH_SIZE] = { };
+	TEE_UUID *uuid = params[0].memref.buffer;
+	size_t uuid_sz = params[0].memref.size;
+	uint8_t *nonce = params[1].memref.buffer;
+	size_t nonce_sz = params[1].memref.size;
+	uint8_t *out = params[2].memref.buffer;
+	size_t out_sz = params[2].memref.size;
+	size_t min_out_sz = 0;
+	TEE_Result res = TEE_SUCCESS;
+
+	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					   TEE_PARAM_TYPE_MEMREF_INPUT,
+					   TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					   TEE_PARAM_TYPE_NONE))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (uuid_sz != sizeof(*uuid))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!out && out_sz)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = init_key();
+	if (res)
+		return res;
+
+	min_out_sz = TEE_SHA256_HASH_SIZE + crypto_bignum_num_bytes(key->n);
+	if (out_sz < min_out_sz) {
+		params[2].memref.size = min_out_sz;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+	params[2].memref.size = min_out_sz;
+
+	/*
+	 * out = [ hash | sig(sha256(nonce | hash)) ]
+	 *         ^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^
+	 *          32B                modulus size
+	 */
+
+	res = hash_binary(uuid, out);
+	if (res)
+		return res;
+	res = digest_nonce_and_hash(digest, nonce, nonce_sz, out);
+	if (res)
+		return res;
+	return sign_digest(out + TEE_SHA256_HASH_SIZE,
+			   out_sz - TEE_SHA256_HASH_SIZE, digest);
+}
+
+static TEE_Result cmd_get_pubkey(uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *e = params[0].memref.buffer;
+	uint32_t *e_out_sz = &params[0].memref.size;
+	uint8_t *n = params[1].memref.buffer;
+	uint32_t *n_out_sz = &params[1].memref.size;
+	size_t sz = 0;
+
+	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					   TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					   TEE_PARAM_TYPE_NONE,
+					   TEE_PARAM_TYPE_NONE))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = init_key();
+	if (res)
+		return res;
+
+	sz = crypto_bignum_num_bytes(key->e);
+	if (*e_out_sz >= sz)
+		crypto_bignum_bn2bin(key->e, e);
+	else
+		res = TEE_ERROR_SHORT_BUFFER;
+	*e_out_sz = sz;
+
+	sz = crypto_bignum_num_bytes(key->n);
+	if (*n_out_sz >= sz)
+		crypto_bignum_bn2bin(key->n, n);
+	else
+		res = TEE_ERROR_SHORT_BUFFER;
+	*n_out_sz = sz;
+
+	return res;
+}
+
+static TEE_Result open_session(uint32_t param_types __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
+			       void **sess_ctx __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static TEE_Result invoke_command(void *sess_ctx __unused, uint32_t cmd_id,
+				 uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	switch (cmd_id) {
+	case PTA_ATTESTATION_HASH_TA:
+		return cmd_hash_ta(param_types, params);
+	case PTA_ATTESTATION_GET_PUBKEY:
+		return cmd_get_pubkey(param_types, params);
+	default:
+		break;
+	}
+	return TEE_ERROR_BAD_PARAMETERS;
+}
+
+pseudo_ta_register(.uuid = PTA_ATTESTATION_UUID, .name = PTA_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
+		   .open_session_entry_point = open_session,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -1,5 +1,6 @@
 subdirs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += tests
 
+srcs-$(CFG_ATTESTATION_PTA) += attestation.c
 srcs-$(CFG_TEE_BENCHMARK) += benchmark.c
 srcs-$(CFG_DEVICE_ENUM_PTA) += device.c
 srcs-$(CFG_TA_GPROF_SUPPORT) += gprof.c

--- a/core/pta/tests/invoke.c
+++ b/core/pta/tests/invoke.c
@@ -422,7 +422,7 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 		return test_dump_sdp(nParamTypes, pParams);
 	case PTA_INVOKE_TESTS_CMD_SELF_TESTS:
 		return core_self_tests(nParamTypes, pParams);
-#if defined(CFG_WITH_USER_TA)
+#if defined(CFG_REE_FS) && defined(CFG_WITH_USER_TA)
 	case PTA_INVOKE_TESTS_CMD_FS_HTREE:
 		return core_fs_htree_tests(nParamTypes, pParams);
 #endif

--- a/core/pta/tests/sub.mk
+++ b/core/pta/tests/sub.mk
@@ -1,4 +1,4 @@
-srcs-$(CFG_WITH_USER_TA) += fs_htree.c
+srcs-$(call cfg-all-enabled,CFG_REE_FS CFG_WITH_USER_TA) += fs_htree.c
 srcs-y += invoke.c
 srcs-$(CFG_LOCKDEP) += lockdep.c
 srcs-y += misc.c

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -24,25 +24,29 @@ srcs-$(CFG_CRYPTO_CONCAT_KDF) += tee_cryp_concat_kdf.c
 srcs-$(CFG_CRYPTO_PBKDF2) += tee_cryp_pbkdf2.c
 
 ifeq ($(CFG_WITH_USER_TA),y)
-
+srcs-y += tee_obj.c
 srcs-y += tee_svc.c
-cppflags-tee_svc.c-y += -DTEE_IMPL_VERSION=$(TEE_IMPL_VERSION)
 srcs-y += tee_svc_cryp.c
 srcs-y += tee_svc_storage.c
-srcs-$(CFG_RPMB_FS) += tee_rpmb_fs.c
-srcs-$(CFG_REE_FS) += tee_ree_fs.c
-srcs-$(CFG_REE_FS) += fs_htree.c
-srcs-$(CFG_REE_FS) += fs_dirfile.c
-srcs-$(CFG_REE_FS) += tee_fs_rpc.c
-srcs-y += tee_fs_key_manager.c
-srcs-y += tee_obj.c
-srcs-y += tee_pobj.c
+cppflags-tee_svc.c-y += -DTEE_IMPL_VERSION=$(TEE_IMPL_VERSION)
 srcs-y += tee_time_generic.c
 srcs-$(CFG_SECSTOR_TA) += tadb.c
 srcs-$(CFG_GP_SOCKETS) += socket.c
 srcs-y += tee_ta_enc_manager.c
-
 endif #CFG_WITH_USER_TA,y
+
+ifeq ($(_CFG_WITH_SECURE_STORAGE),y)
+srcs-y += tee_fs_key_manager.c
+srcs-$(CFG_RPMB_FS) += tee_rpmb_fs.c
+srcs-$(CFG_REE_FS) += tee_ree_fs.c
+srcs-$(CFG_REE_FS) += fs_dirfile.c
+srcs-$(CFG_REE_FS) += fs_htree.c
+srcs-$(CFG_REE_FS) += tee_fs_rpc.c
+endif
+
+ifeq ($(call cfg-one-enabled,CFG_WITH_USER_TA _CFG_WITH_SECURE_STORAGE),y)
+srcs-y += tee_pobj.c
+endif
 
 srcs-y += uuid.c
 srcs-y += tee_supp_plugin_rpc.c

--- a/core/tee/sub.mk
+++ b/core/tee/sub.mk
@@ -31,8 +31,7 @@ srcs-y += tee_svc_cryp.c
 srcs-y += tee_svc_storage.c
 srcs-$(CFG_RPMB_FS) += tee_rpmb_fs.c
 srcs-$(CFG_REE_FS) += tee_ree_fs.c
-srcs-$(call cfg-one-enabled,CFG_REE_FS CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += \
-	fs_htree.c
+srcs-$(CFG_REE_FS) += fs_htree.c
 srcs-$(CFG_REE_FS) += fs_dirfile.c
 srcs-$(CFG_REE_FS) += tee_fs_rpc.c
 srcs-y += tee_fs_key_manager.c

--- a/core/tee/tee_fs_rpc.c
+++ b/core/tee/tee_fs_rpc.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string_ext.h>
 #include <string.h>
+#include <tee/fs_dirfile.h>
 #include <tee/tee_fs.h>
 #include <tee/tee_fs_rpc.h>
 #include <tee/tee_pobj.h>
@@ -22,6 +23,27 @@ struct tee_fs_dir {
 	int nw_dir;
 	struct tee_fs_dirent d;
 };
+
+/* "/dirf.db" or "/<file number>" */
+static TEE_Result
+tee_svc_storage_create_filename_dfh(void *buf, size_t blen,
+				    const struct tee_fs_dirfile_fileh *dfh)
+{
+	char *file = buf;
+	size_t pos = 0;
+	size_t l;
+
+	if (pos >= blen)
+		return TEE_ERROR_SHORT_BUFFER;
+
+	file[pos] = '/';
+	pos++;
+	if (pos >= blen)
+		return TEE_ERROR_SHORT_BUFFER;
+
+	l = blen - pos;
+	return tee_fs_dirfile_fileh_to_fname(dfh, file + pos, &l);
+}
 
 static TEE_Result operation_commit(struct tee_fs_rpc_operation *op)
 {

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <tee_api_defines_extensions.h>
 #include <tee_api_defines.h>
-#include <tee/fs_dirfile.h>
 #include <tee/tee_fs.h>
 #include <tee/tee_obj.h>
 #include <tee/tee_pobj.h>
@@ -103,29 +102,6 @@ TEE_Result tee_svc_storage_create_filename(void *buf, size_t blen,
 
 	return TEE_SUCCESS;
 }
-
-#ifdef CFG_REE_FS
-/* "/dirf.db" or "/<file number>" */
-TEE_Result
-tee_svc_storage_create_filename_dfh(void *buf, size_t blen,
-				    const struct tee_fs_dirfile_fileh *dfh)
-{
-	char *file = buf;
-	size_t pos = 0;
-	size_t l;
-
-	if (pos >= blen)
-		return TEE_ERROR_SHORT_BUFFER;
-
-	file[pos] = '/';
-	pos++;
-	if (pos >= blen)
-		return TEE_ERROR_SHORT_BUFFER;
-
-	l = blen - pos;
-	return tee_fs_dirfile_fileh_to_fname(dfh, file + pos, &l);
-}
-#endif
 
 /* "/TA_uuid" */
 TEE_Result tee_svc_storage_create_dirname(void *buf, size_t blen,

--- a/lib/libutee/include/pta_attestation.h
+++ b/lib/libutee/include/pta_attestation.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2021, Huawei Technologies Co., Ltd
+ */
+
+/*
+ * Provide remote attestation services
+ */
+
+#ifndef __PTA_ATTESTATION_H
+#define __PTA_ATTESTATION_H
+
+#define PTA_ATTESTATION_UUID { 0x59590731, 0x6966, 0x4b76, \
+		{ 0x9c, 0xad, 0xb8, 0xf9, 0x0d, 0x9a, 0x77, 0xcd } }
+
+/*
+ * Get signed hash for a Trusted Application binary or for a shared library
+ *
+ * [in]     memref[0]        UUID of the TA or shared library to measure
+ * [in]     memref[1]        Nonce (random value of any size to prevent replay
+ *                           attacks)
+ * [out]    memref[2]        Output buffer. Receives a signed SHA256 hash that
+ *                           uniquely represents the content of the TA binary
+ *                           file.
+ *                           - The first 32 bytes are the hash itself (TA hash)
+ *                           - The following bytes are a signature:
+ *                               SIG(SHA256(Nonce | TA hash))
+ *                           - The algorithm is
+ *                             TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256 with a salt
+ *                             length of 32.
+ *                           - The key pair is generated internally and stored
+ *                             in secure storage. The public key can be
+ *                             retrieved with command PTA_ATTESTATION_GET_PUBKEY
+ *                             (typically during device provisioning).
+ *                           Given that the sigature length is equal to the
+ *                           RSA modulus size in bytes, the output buffer size
+ *                           should be at least 32 + modulus size bytes. For
+ *                           example, for a 3072 bit key (384 bytes) the minimum
+ *                           buffer size is 416 bytes.
+ *
+ * Return codes:
+ * TEE_SUCCESS
+ * TEE_ERROR_BAD_PARAMETERS - Incorrect input param
+ * TEE_ERROR_SHORT_BUFFER - Output buffer size less than required
+ */
+#define PTA_ATTESTATION_HASH_TA		0x0
+
+/*
+ * Get the RSA public key use for signing the TA measurement returned by
+ * command PTA_ATTESTATION_HASH_TA.
+ *
+ * [out]    memref[0]        Public key exponent in big endian order
+ * [out]    memref[1]        Modulus in big endian order
+ *
+ * Return codes:
+ * TEE_SUCCESS
+ * TEE_ERROR_GENERIC - Internal error
+ * TEE_ERROR_SHORT_BUFFER - One or both buffers are too small, required size
+ *                          is provided in memref[i].size
+ */
+#define PTA_ATTESTATION_GET_PUBKEY	0x1
+
+#endif /* __PTA_ATTESTATION_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -574,6 +574,17 @@ $(eval $(call cfg-depends-all,CFG_SYSTEM_PTA,CFG_WITH_USER_TA))
 # world OS.
 CFG_DEVICE_ENUM_PTA ?= y
 
+# The attestation pseudo TA provides an interface to request a measurement of
+# a given TA binary or shared library given its UUID.
+CFG_ATTESTATION_PTA ?= $(_CFG_WITH_SECURE_STORAGE)
+$(eval $(call cfg-depends-all,CFG_ATTESTATION_PTA,_CFG_WITH_SECURE_STORAGE))
+
+# RSA key size (in bits) for the attestation PTA. Must be at least 2048 which
+# is the size of the data to be signed (an SHA-256 hash).
+# 3072 is a better value by today's standards but it takes longer to generate.
+# A smaller default is better for testing.
+CFG_ATTESTATION_PTA_KEY_SIZE ?= 2048
+
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,
 # so its value represents log2(cores/cluster).

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -213,6 +213,8 @@ CFG_RPMB_TESTKEY ?= n
 # - RPMB key provisioning in a controlled environment (factory setup)
 CFG_RPMB_WRITE_KEY ?= n
 
+_CFG_WITH_SECURE_STORAGE := $(call cfg-one-enabled,CFG_REE_FS CFG_RPMB_FS)
+
 # Signing key for OP-TEE TA's
 # When performing external HSM signing for TA's TA_SIGN_KEY can be set to dummy
 # key and then set TA_PUBLIC_KEY to match public key from the HSM.

--- a/scripts/dump_ta_header.py
+++ b/scripts/dump_ta_header.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (C) 2021 Huawei Technologies Co., Ltd
+
+
+def dump(msg, buf):
+    import codecs
+
+    print(msg, end='')
+    print(codecs.encode(buf, 'hex').decode('utf-8'))
+
+
+def main():
+    import struct
+    import sys
+
+    img_type_name = {1: 'SHDR_BOOTSTRAP_TA', 2: 'SHDR_ENCRYPTED_TA'}
+    algo_name = {0x70414930: 'RSASSA_PKCS1_PSS_MGF1_SHA256',
+                 0x70004830: 'RSASSA_PKCS1_V1_5_SHA256'}
+
+    with open(sys.argv[1], 'rb') as f:
+        shdr = f.read(20)
+        (magic, img_type, img_size, algo, digest_len,
+            sig_len) = struct.unpack('<IIIIHH', shdr)
+        print(f'Magic: 0x{magic:x} ', end='')
+        if magic == 0x4f545348:  # SHDR_MAGIC
+            print('(correct)')
+        else:
+            print('(**INCORRECT**)')
+            return
+        print(f'Image type: {img_type} ({img_type_name[img_type]})')
+        print(f'Image size: {img_size} bytes')
+        print(f'Signing algorithm: 0x{algo:x} ({algo_name[algo]})')
+        print(f'Digest length: {digest_len} bytes')
+        print(f'Signature length: {sig_len} bytes')
+        digest = f.read(digest_len)
+        dump('Digest: ', digest)
+
+
+if __name__ == '__main__':
+    main()

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -36,6 +36,7 @@ ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
 ta-mk-file-export-vars-$(sm) += CFG_CORE_TPM_EVENT_LOG
 ta-mk-file-export-add-$(sm) += CFG_TEE_TA_LOG_LEVEL ?= $(CFG_TEE_TA_LOG_LEVEL)_nl_
 ta-mk-file-export-vars-$(sm) += CFG_TA_BGET_TEST
+ta-mk-file-export-vars-$(sm) += CFG_ATTESTATION_PTA
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.


### PR DESCRIPTION
Differences with [v3](https://github.com/OP-TEE/optee_os/pull/4992):
- The RSA signing key is generated by the PTA the first time it is called, then written to secure storage. Implements the suggestions by @etienne-lms and @b49020. A PTA command is added to obtain the public key.

The hashing method is unchanged: the PTA still returns the hash found in the TA header as in RFC v3. For simplicity I have chosen not to re-introduce the in-memory hashing found in RFC v1 and v2 which I think addresses a slightly different use case. It could easily be done if needed.