### PR TITLE
plat-stm32mp1: fixes for CRYP1 support

### DIFF
--- a/core/arch/arm/dts/stm32mp157c-dk2.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2.dts
@@ -26,10 +26,6 @@
 	};
 };
 
-&cryp1 {
-	status = "okay";
-};
-
 &dsi {
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -107,10 +107,6 @@
 	};
 };
 
-&cryp1 {
-	status = "okay";
-};
-
 &dac {
 	pinctrl-names = "default";
 	pinctrl-0 = <&dac_ch1_pins_a &dac_ch2_pins_a>;

--- a/core/arch/arm/dts/stm32mp157c-ev1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ev1.dts
@@ -80,10 +80,6 @@
 	status = "okay";
 };
 
-&cryp1 {
-	status = "okay";
-};
-
 &dcmi {
 	status = "okay";
 	pinctrl-names = "default", "sleep";

--- a/core/drivers/crypto/stm32/stm32_cryp.c
+++ b/core/drivers/crypto/stm32/stm32_cryp.c
@@ -1282,6 +1282,8 @@ static TEE_Result stm32_cryp_driver_init(void)
 	if (fdt_stm32_cryp(&cryp_pdata))
 		return TEE_ERROR_NOT_SUPPORTED;
 
+	stm32mp_register_secure_periph_iomem(cryp_pdata.base.pa);
+
 	stm32_clock_enable(cryp_pdata.clock_id);
 
 	if (stm32_reset_assert(cryp_pdata.reset_id, TIMEOUT_US_1MS))


### PR DESCRIPTION
Don't enable CRYP1 support in OP-TEE core from ST boards supporting stm32mp1 platform to comply with the upstream boards DTS files since v5.11 in Linux kernel that enables CRYP1 in non-secure world.

Adds registering of CRYP1 device as a secure peripheral when it is registered as a crypto driver.