### PR TITLE
core: dt: fix inline description of _fdt_get_status()

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -180,8 +180,8 @@ size_t _fdt_reg_size(const void *fdt, int offs);
 
 /*
  * Read the status and secure-status properties into a bitfield.
- * @status is set to DT_STATUS_DISABLED or a combination of DT_STATUS_OK_NSEC
- * and DT_STATUS_OK_SEC.
+ * Return -1 on failure, DT_STATUS_DISABLED if the node is disabled,
+ * otherwise return a combination of DT_STATUS_OK_NSEC and DT_STATUS_OK_SEC.
  */
 int _fdt_get_status(const void *fdt, int offs);
 


### PR DESCRIPTION
Corrects inline comment describing _fdt_get_status() helper function.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
