### PR TITLE
[RFC] core: Use the embedded DT with dynamic shared memory

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1133,7 +1133,7 @@ static void discover_nsec_memory(void)
 	const struct core_mmu_phys_mem *mem_begin = NULL;
 	const struct core_mmu_phys_mem *mem_end = NULL;
 	size_t nelems;
-	void *fdt = get_external_dt();
+	void *fdt = get_dt();
 
 	if (fdt) {
 		mem = get_nsec_memory(fdt, &nelems);


### PR DESCRIPTION
Dynamic shared memory only uses the external DT at this time.
With this change, the embedded DT or the external DT can be
used for non-secure memory.

Signed-off-by: John Linn <linnj@xilinx.com>
