### PR TITLE
libtomcrypt/sha256_accel: fix stringop-overflow error

### DIFF
--- a/core/lib/libtomcrypt/sha256_accel.c
+++ b/core/lib/libtomcrypt/sha256_accel.c
@@ -68,9 +68,9 @@ int sha256_ce_transform(ulong32 *state, const unsigned char *buf, int blocks);
 static int sha256_compress_nblocks(hash_state *md, const unsigned char *buf,
 				   int blocks)
 {
-   void *state = md->sha1.state;
+   void *state = md->sha256.state;
 
-   COMPILE_TIME_ASSERT(sizeof(md->sha1.state[0]) == sizeof(uint32_t));
+   COMPILE_TIME_ASSERT(sizeof(md->sha256.state[0]) == sizeof(uint32_t));
 
     crypto_accel_sha256_compress(state, buf, blocks);
     return CRYPT_OK;


### PR DESCRIPTION
Attempting to build optee-os with gcc11 fails with the following error
```
In function ‘sha256_compress_nblocks’,
    inlined from ‘sha256_compress’ at core/lib/libtomcrypt/sha256_accel.c:81:11,
    inlined from ‘sha256_done’ at core/lib/libtomcrypt/sha256_accel.c:158:5:
core/lib/libtomcrypt/sha256_accel.c:75:5: error: ‘crypto_accel_sha256_compress’ accessing 32 bytes in a region of size 20 [-Werror=stringop-overflow=]
   75 |     crypto_accel_sha256_compress(state, buf, blocks);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/lib/libtomcrypt/sha256_accel.c: In function ‘sha256_done’:
core/lib/libtomcrypt/sha256_accel.c:75:5: note: referencing argument 1 of type ‘uint32_t *’ {aka ‘unsigned int *’}
In file included from core/lib/libtomcrypt/sha256_accel.c:41:
core/include/crypto/crypto_accel.h:45:6: note: in a call to function ‘crypto_accel_sha256_compress’
   45 | void crypto_accel_sha256_compress(uint32_t state[8], const void *src,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Indeed, the 'state' argument here is taken from sha1.state which is a
uint32_t state[5], so 20 bytes long instead of the uint32_t state[8]
crypto_accel_sha256_compress expects.

OTOH we're in a sha256 function, and sha256.state conveniently is of the
correct size, so use sha256.state as appropriate instead.

Note that hash_state is a union and sha{1,256}.state are at the same
offset, so this is actually a no-op change.

Signed-off-by: Dominique Martinet <dominique.martinet@atmark-techno.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
