### PR TITLE
crypto: drivers: se050: object identifier range [FIX]

### DIFF
--- a/core/drivers/crypto/se050/adaptors/utils/utils.c
+++ b/core/drivers/crypto/se050/adaptors/utils/utils.c
@@ -115,7 +115,8 @@ static uint32_t se050_key(uint64_t key)
 	if (!IS_WATERMARKED(key))
 		return 0;
 
-	if (oid < OID_MIN || oid > OID_MAX)
+	/* oid > OID_MAX could have been created by an external client */
+	if (oid < OID_MIN)
 		return 0;
 
 	return oid;


### PR DESCRIPTION
With the introduction of the se050 APDU driver, external clients can
create persistent objects on the secure element non-volatile memory.

The unique identifiers for these objects do not necessarily need to
fall within the range defined for objects created using the
cyptographic operation interfaces (keypair_gen).

This commit fixes the use case where a key stored in the SE05x device
(for example via a cloud service communicating to the optee-client's
libseteec) is imported into the secure world (ie the pkcs#11 database) and then used for
authentication (ie, EC sign)

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
