### PR TITLE
core: dt_driver: skip drivers not providing a probe operator

### DIFF
--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -313,6 +313,12 @@ static TEE_Result probe_driver_node(const void *fdt,
 
 	node_name = fdt_get_name(fdt, elt->nodeoffset, NULL);
 	drv_name = elt->dt_drv->name;
+
+	if (!elt->dt_drv->probe) {
+		DMSG("No probe operator for driver %s, skipped", drv_name);
+		return TEE_SUCCESS;
+	}
+
 	FMSG("Probing %s on node %s", drv_name, node_name);
 
 	res = elt->dt_drv->probe(fdt, elt->nodeoffset, elt->dm->compat_data);


### PR DESCRIPTION
If drivers is not providing a probe operator, that can result in
crash, so skip drivers not providing a probe operator.

Signed-off-by: Sahil Malhotra <sahil.malhotra@oss.nxp.com>
Fixes: 5017