### PR TITLE
core: dt: prevent build failure when CFG_DT is disabled

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -52,8 +52,6 @@ struct dt_node_info {
 	uint32_t prio;
 };
 
-#if defined(CFG_DT)
-
 /*
  * DT-aware drivers
  */
@@ -84,6 +82,7 @@ enum dt_driver_type {
 typedef TEE_Result (*dt_driver_probe_func)(const void *fdt, int nodeoffset,
 					   const void *compat_data);
 
+#if defined(CFG_DT)
 /*
  * Driver instance registered to be probed on compatible node found in the DT.
  *


### PR DESCRIPTION
Fixes dt.h to prevent build failure when dt_driver.h is pre-compiled
while CFG_DT is disabled. Below are examples of such build error
traces:

core/include/kernel/dt_driver.h:61:29: warning: ‘enum dt_driver_type’ declared inside parameter list will not be visible outside of this definition or declaration
   61 |            void *data, enum dt_driver_type type);
      |                             ^~~~~~~~~~~~~~
core/include/drivers/clk_dt.h: In function ‘clk_dt_register_clk_provider’:
core/include/drivers/clk_dt.h:101:15: error: ‘DT_DRIVER_CLK’ undeclared (first use in this function); did you mean ‘CFG_DRIVERS_CLK’?
  101 |         data, DT_DRIVER_CLK);
      |               ^~~~~~~~~~~~~

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
