### PR TITLE
drivers: stm32_cryp: prevent error trace when disabled

### DIFF
--- a/core/drivers/crypto/stm32/stm32_cryp.c
+++ b/core/drivers/crypto/stm32/stm32_cryp.c
@@ -1279,8 +1279,14 @@ static TEE_Result stm32_cryp_driver_init(void)
 {
 	TEE_Result res = TEE_SUCCESS;
 
-	if (fdt_stm32_cryp(&cryp_pdata))
-		return TEE_ERROR_NOT_SUPPORTED;
+	switch (fdt_stm32_cryp(&cryp_pdata)) {
+	case 0:
+		break;
+	case -FDT_ERR_NOTFOUND:
+		return TEE_SUCCESS;
+	default:
+		panic();
+	}
 
 	stm32mp_register_secure_periph_iomem(cryp_pdata.base.pa);
 


### PR DESCRIPTION
Changes stm32_crypt initialization function to not report an error
when the device is not defined or disabled in the embedded DT.

Prevents error trace message seen at boot time:
E/TC:0 0 call_initcalls:43 Initcall __text_start + 0x0002b958 failed

Fixes: 5c3bcc386415 ("dts: stm32mp1: disable CRYP1 device")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
