### PR TITLE
plat-sam: Set QSPI memories as non secure

### DIFF
--- a/core/arch/arm/plat-sam/main.c
+++ b/core/arch/arm/plat-sam/main.c
@@ -176,8 +176,20 @@ static void matrix_configure_slave_h64mx(void)
 					ssr_setting);
 
 	/* 11:  Internal SRAM 128K (Cache L2): Default */
-	/* 12:  QSPI0: Default */
-	/* 13:  QSPI1: Default */
+
+	/* 12:  QSPI0: Normal world */
+	/* 13:  QSPI1: Normal world */
+	srtop_setting = MATRIX_SRTOP(0, MATRIX_SRTOP_VALUE_128M);
+	sasplit_setting = MATRIX_SASPLIT(0, MATRIX_SASPLIT_VALUE_128M);
+	ssr_setting = MATRIX_LANSECH_NS(0) | MATRIX_RDNSECH_NS(0) |
+		      MATRIX_WRNSECH_NS(0);
+
+	matrix_configure_slave_security(matrix64_base(), H64MX_SLAVE_QSPI0,
+					srtop_setting, sasplit_setting,
+					ssr_setting);
+	matrix_configure_slave_security(matrix64_base(), H64MX_SLAVE_QSPI1,
+					srtop_setting, sasplit_setting,
+					ssr_setting);
 	/* 14:  AESB: Default */
 }
 


### PR DESCRIPTION
plat-sam: set QSPI memories as non secure

When left unconfigured, the QSPI memories are in the secure world.
However, the controller is not secure and Linux expect to use these
memories with them and it will fail because the memories are not
accessible. Configure them as non secure to let linux handle the QSPI
controller.

Signed-off-by: Clément Léger <clement.leger@bootlin.com>
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
