### PR TITLE
drivers: atmel-rstc: add support for reset controller

### DIFF
--- a/core/drivers/atmel_rstc.c
+++ b/core/drivers/atmel_rstc.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Microchip
+ */
+
+#include <drivers/atmel_rstc.h>
+#include <io.h>
+#include <kernel/dt.h>
+#include <tee_api_defines.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+#define AT91_RSTC_CR		0x0
+#define AT91_RSTC_CR_KEY	SHIFT_U32(0xA5, 24)
+#define AT91_RSTC_CR_PROCRST	BIT32(0)
+#define AT91_RSTC_CR_PERRST	BIT32(2)
+
+static vaddr_t rstc_base;
+
+bool atmel_rstc_available(void)
+{
+	return rstc_base != 0;
+}
+
+void __noreturn atmel_rstc_reset(void)
+{
+	uint32_t val = AT91_RSTC_CR_KEY | AT91_RSTC_CR_PROCRST |
+		       AT91_RSTC_CR_PERRST;
+
+	io_write32(rstc_base + AT91_RSTC_CR, val);
+
+	/*
+	 * After the previous write, the CPU will reset so we will never hit
+	 * this loop.
+	 */
+	while (true)
+		;
+}
+
+static TEE_Result atmel_rstc_probe(const void *fdt, int node,
+				   const void *compat_data __unused)
+
+{
+	size_t size = 0;
+
+	if (dt_map_dev(fdt, node, &rstc_base, &size) < 0)
+		return TEE_ERROR_GENERIC;
+
+	return TEE_SUCCESS;
+}
+
+static const struct dt_device_match atmel_rstc_match_table[] = {
+	{ .compatible = "atmel,sama5d3-rstc" },
+	{ }
+};
+
+const struct dt_driver atmel_rstc_dt_driver __dt_driver = {
+	.name = "atmel_rstc",
+	.type = DT_DRIVER_NOTYPE,
+	.match_table = atmel_rstc_match_table,
+	.probe = atmel_rstc_probe,
+};

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -21,6 +21,7 @@ srcs-$(CFG_DRA7_RNG) += dra7_rng.c
 srcs-$(CFG_STIH_UART) += stih_asc.c
 srcs-$(CFG_ATMEL_UART) += atmel_uart.c
 srcs-$(CFG_ATMEL_TRNG) += atmel_trng.c
+srcs-$(CFG_ATMEL_RSTC) += atmel_rstc.c
 srcs-$(CFG_AMLOGIC_UART) += amlogic_uart.c
 srcs-$(CFG_MVEBU_UART) += mvebu_uart.c
 srcs-$(CFG_STM32_BSEC) += stm32_bsec.c

--- a/core/include/drivers/atmel_rstc.h
+++ b/core/include/drivers/atmel_rstc.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Microchip
+ */
+#ifndef __DRIVERS_ATMEL_RSTC_H
+#define __DRIVERS_ATMEL_RSTC_H
+
+#include <compiler.h>
+#include <stdbool.h>
+
+#if defined(CFG_ATMEL_RSTC)
+bool atmel_rstc_available(void);
+
+void __noreturn atmel_rstc_reset(void);
+#else
+static inline bool atmel_rstc_available(void)
+{
+	return false;
+}
+
+static inline void atmel_rstc_reset(void) {}
+#endif
+
+#endif /* __DRIVERS_ATMEL_RSTC_H */


### PR DESCRIPTION
This reset controller will be used by PSCI to reset the SoC.

Signed-off-by: Clément Léger <clement.leger@bootlin.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
