### PR TITLE
core: arm: lpae: fix build with large number of CPU cores

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -216,6 +216,16 @@
 				 XLAT_TABLE_USER_EXTRA)
 #endif /*!MAX_XLAT_TABLES*/
 
+#if (CORE_MMU_BASE_TABLE_LEVEL == 0)
+#if (MAX_XLAT_TABLES <= UINT8_MAX)
+typedef uint8_t l1_idx_t;
+#elif (MAX_XLAT_TABLES <= UINT16_MAX)
+typedef uint16_t l1_idx_t;
+#else
+#error MAX_XLAT_TABLES is suspiciously large, please check
+#endif
+#endif
+
 typedef uint64_t base_xlat_tbls_t[CFG_TEE_CORE_NB_CORE][NUM_BASE_LEVEL_ENTRIES];
 typedef uint64_t xlat_tbl_t[XLAT_TABLE_ENTRIES];
 
@@ -257,7 +267,7 @@ struct mmu_partition {
 	 * Indexes of the L1 table from 'xlat_tables'
 	 * that points to the user mappings.
 	 */
-	uint8_t user_l1_table_idx[NUM_BASE_TABLES][CFG_TEE_CORE_NB_CORE];
+	l1_idx_t user_l1_table_idx[NUM_BASE_TABLES][CFG_TEE_CORE_NB_CORE];
 #endif
 };
 


### PR DESCRIPTION
A compile time assertion is triggered by the following command:

 $ make -j10 -s PLATFORM=vexpress-qemu_armv8a CFG_TEE_CORE_NB_CORE=128 \
                CFG_LPAE_ADDR_SPACE_BITS=40
 In file included from core/arch/arm/mm/core_mmu_lpae.c:61:
 core/arch/arm/mm/core_mmu_lpae.c: In function ‘core_init_mmu_prtn_ta_core’:
 lib/libutils/isoc/include/assert.h:30:24: error: duplicate case value
    30 |   switch (0) { case 0: case ((x) ? 1: 0): default : break; } \
       |                        ^~~~
 core/arch/arm/mm/core_mmu_lpae.c:697:2: note: in expansion of macro ‘COMPILE_TIME_ASSERT’
   697 |  COMPILE_TIME_ASSERT(MAX_XLAT_TABLES <
       |  ^~~~~~~~~~~~~~~~~~~
 lib/libutils/isoc/include/assert.h:30:16: note: previously used here
    30 |   switch (0) { case 0: case ((x) ? 1: 0): default : break; } \
       |                ^~~~
 core/arch/arm/mm/core_mmu_lpae.c:697:2: note: in expansion of macro ‘COMPILE_TIME_ASSERT’
   697 |  COMPILE_TIME_ASSERT(MAX_XLAT_TABLES <
       |  ^~~~~~~~~~~~~~~~~~~
 core/arch/arm/mm/core_mmu_lpae.c:708:8: warning: unused variable ‘ret’ [-Wunused-variable]
   708 |   bool ret = false;
       |        ^~~

The type used for struct mmu_partition::user_l1_table_idx, currently
uint8_t, is not wide enough. Fix the issue by using uint8_t or uint16_t
based on the value of MAX_XLAT_TABLES.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
