### PR TITLE
ta: pkcs11: increase default heap size to 32kB

### DIFF
--- a/ta/pkcs11/sub.mk
+++ b/ta/pkcs11/sub.mk
@@ -4,8 +4,8 @@ CFG_PKCS11_TA_ALLOW_DIGEST_KEY ?= y
 # Enable PKCS#11 TA's TEE Identity based authentication support
 CFG_PKCS11_TA_AUTH_TEE_IDENTITY ?= y
 
-# PKCS#11 TA heap size can be customized if 16kB is not enough
-CFG_PKCS11_TA_HEAP_SIZE ?= (16 * 1024)
+# PKCS#11 TA heap size can be customized if 32kB is not enough
+CFG_PKCS11_TA_HEAP_SIZE ?= (32 * 1024)
 
 # Defines the number of PKCS11 token implemented by the PKCS11 TA
 CFG_PKCS11_TA_TOKEN_COUNT ?= 3


### PR DESCRIPTION
In some test cases, 16kB memory configured is not enough, specifically
while generating RSA keys, So increasing the default heap size to 32kB

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Signed-off-by: Clement Faure <clement.faure@nxp.com>
