### PR TITLE
core: pm: fix incorrect flag check in pm_callback

### DIFF
--- a/core/kernel/pm.c
+++ b/core/kernel/pm.c
@@ -65,7 +65,7 @@ static TEE_Result do_pm_callback(enum pm_op op, uint32_t pm_hint,
 	TEE_Result res = TEE_ERROR_GENERIC;
 	bool suspending = op == PM_OP_SUSPEND;
 
-	if (suspending == (bool)(hdl->flags | PM_FLAG_SUSPENDED))
+	if (suspending == (bool)(hdl->flags & PM_FLAG_SUSPENDED))
 		return TEE_SUCCESS;
 
 	DMSG("%s %s", suspending ? "Suspend" : "Resume", hdl->name);


### PR DESCRIPTION
Fix test error check that always return true with current
the condition. The check must be done to identify if the
SUSPENDED flag as been set.

Signed-off-by: Lionel Debieve <lionel.debieve@foss.st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
