### PR TITLE
ta: pkcs11: Fix memory leak

### DIFF
--- a/ta/pkcs11/src/sanitize_object.c
+++ b/ta/pkcs11/src/sanitize_object.c
@@ -232,10 +232,6 @@ static uint32_t sanitize_indirect_attr(struct obj_attrs **dst,
 
 	assert(pkcs11_attr_has_indirect_attributes(cli_ref->id));
 
-	rc = init_attributes_head(&obj2);
-	if (rc)
-		return rc;
-
 	/* Build a new serial object while sanitizing the attributes list */
 	rc = sanitize_client_object(&obj2, data, cli_ref->size,
 				    PKCS11_CKO_UNDEFINED_ID,


### PR DESCRIPTION
When sanitizing indirect templates, obj2 was getting allocated
twice leading to memory leak.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

Fixes - https://github.com/OP-TEE/optee_os/issues/5022

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
