### PR TITLE
driver: atmel_trng: remove wrong assertion

### DIFF
--- a/core/drivers/atmel_trng.c
+++ b/core/drivers/atmel_trng.c
@@ -101,7 +101,6 @@ uint8_t hw_get_random_byte(void)
 /* This is a true RNG, no need for seeding */
 void plat_rng_init(void)
 {
-	assert(trng_base);
 }
 
 static void atmel_trng_reset(void)


### PR DESCRIPTION
Remove mistakenly added assert which will always trigger in debug
mode.

Signed-off-by: Clément Léger <clement.leger@bootlin.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
