### PR TITLE
libutils: qsort.c: fix undefined pointer subtraction

### DIFF
--- a/lib/libutils/isoc/qsort.c
+++ b/lib/libutils/isoc/qsort.c
@@ -47,7 +47,7 @@ static __inline void	 swapfunc(char *, char *, int, int);
 			*pj++ = t;				\
 		} while (--i > 0);				\
 }
-#define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long) || \
+#define SWAPINIT(a, es) swaptype = (uintptr_t)a % sizeof(long) || \
 		es % sizeof(long) ? 2 : es == sizeof(long)? 0 : 1;
 static __inline void
 swapfunc(char *a, char *b, int n, int swaptype)


### PR DESCRIPTION
Clang 13.0.0 produces the following warning:

 lib/libutils/isoc/qsort.c:81:8: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
         loop:   SWAPINIT(a, es);
                 ^~~~~~~~~~~~~~~
 lib/libutils/isoc/qsort.c:50:47: note: expanded from macro 'SWAPINIT'
 #define SWAPINIT(a, es) swaptype = ((char *)a - (char *)0) % sizeof(long)
                                               ^ ~~~~~~~~~

Replace the subtraction with a simple cast to uintptr_t.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
