### PR TITLE
Helper macro DEFINE_RODATA_UNPAGED()

### DIFF
--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -40,14 +40,6 @@ __thread_std_smc_entry(uint32_t a0 __unused, uint32_t a1 __unused,
 	return 0;
 }
 
-const struct mobj_ops mobj_reg_shm_ops __rodata_dummy;
-const struct mobj_ops mobj_ffa_ops __rodata_dummy;
-const struct mobj_ops mobj_phys_ops __rodata_dummy;
-const struct mobj_ops mobj_virt_ops __rodata_dummy;
-const struct mobj_ops mobj_mm_ops __rodata_dummy;
-const struct mobj_ops mobj_shm_ops __rodata_dummy;
-const struct mobj_ops mobj_seccpy_shm_ops __rodata_dummy;
-const struct mobj_ops mobj_with_fobj_ops __rodata_dummy;
 const struct fobj_ops ops_rwp_paged_iv __rodata_dummy;
 const struct fobj_ops ops_rwp_unpaged_iv __rodata_dummy;
 const struct fobj_ops ops_ro_paged __rodata_dummy;

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -56,4 +56,3 @@ const struct fobj_ops ops_locked_paged __rodata_dummy;
 const struct fobj_ops ops_sec_mem __rodata_dummy;
 const struct ts_ops user_ta_ops __rodata_dummy;
 const struct ts_ops stmm_sp_ops __rodata_dummy;
-const struct ts_ops sp_ops __rodata_dummy;

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -39,10 +39,3 @@ __thread_std_smc_entry(uint32_t a0 __unused, uint32_t a1 __unused,
 {
 	return 0;
 }
-
-const struct fobj_ops ops_rwp_paged_iv __rodata_dummy;
-const struct fobj_ops ops_rwp_unpaged_iv __rodata_dummy;
-const struct fobj_ops ops_ro_paged __rodata_dummy;
-const struct fobj_ops ops_ro_reloc_paged __rodata_dummy;
-const struct fobj_ops ops_locked_paged __rodata_dummy;
-const struct fobj_ops ops_sec_mem __rodata_dummy;

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -54,4 +54,3 @@ const struct fobj_ops ops_ro_paged __rodata_dummy;
 const struct fobj_ops ops_ro_reloc_paged __rodata_dummy;
 const struct fobj_ops ops_locked_paged __rodata_dummy;
 const struct fobj_ops ops_sec_mem __rodata_dummy;
-const struct ts_ops user_ta_ops __rodata_dummy;

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -55,4 +55,3 @@ const struct fobj_ops ops_ro_reloc_paged __rodata_dummy;
 const struct fobj_ops ops_locked_paged __rodata_dummy;
 const struct fobj_ops ops_sec_mem __rodata_dummy;
 const struct ts_ops user_ta_ops __rodata_dummy;
-const struct ts_ops stmm_sp_ops __rodata_dummy;

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -301,7 +301,7 @@ static TEE_Result sp_enter_invoke_cmd(struct ts_session *s,
 	uint32_t exceptions = 0;
 	uint64_t cpsr = 0;
 	struct sp_session *sp_s = to_sp_session(s);
-	struct ts_session *sess = NULL;
+	struct ts_session __maybe_unused *sess = NULL;
 	struct thread_ctx_regs *sp_regs = NULL;
 	uint32_t panicked = false;
 	uint32_t panic_code = 0;
@@ -357,9 +357,8 @@ static bool sp_handle_svc(struct thread_svc_regs *regs)
 {
 	struct ts_session *ts = ts_get_current_session();
 	struct sp_ctx *uctx = to_sp_ctx(ts->ctx);
-	struct sp_session *s = uctx->open_session;
 
-	assert(s);
+	assert(uctx->open_session);
 
 	sp_svc_store_registers(regs, &uctx->sp_regs);
 

--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -864,11 +864,7 @@ static bool spm_handle_svc(struct thread_svc_regs *regs)
 	}
 }
 
-/*
- * Note: this variable is weak just to ease breaking its dependency chain
- * when added to the unpaged area.
- */
-const struct ts_ops stmm_sp_ops __weak __rodata_unpaged("stmm_sp_ops") = {
+DEFINE_RODATA_UNPAGED(struct ts_ops, stmm_sp) = {
 	.enter_open_session = stmm_enter_open_session,
 	.enter_invoke_cmd = stmm_enter_invoke_cmd,
 	.enter_close_session = stmm_enter_close_session,

--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -245,8 +245,7 @@ static uint64_t mobj_reg_shm_get_cookie(struct mobj *mobj)
  * When CFG_PREALLOC_RPC_CACHE is enabled, releasing RPC preallocated
  * shm mandates these resources to be unpaged.
  */
-const struct mobj_ops mobj_reg_shm_ops
-__weak __rodata_unpaged("mobj_reg_shm_ops") = {
+DEFINE_RODATA_UNPAGED(struct mobj_ops, mobj_reg_shm_ops) = {
 	.get_pa = mobj_reg_shm_get_pa,
 	.get_phys_offs = mobj_reg_shm_get_phys_offs,
 	.get_va = mobj_reg_shm_get_va,

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -592,11 +592,7 @@ static TEE_Result mapped_shm_init(void)
 	return TEE_SUCCESS;
 }
 
-/*
- * Note: this variable is weak just to ease breaking its dependency chain
- * when added to the unpaged area.
- */
-const struct mobj_ops mobj_ffa_ops __weak __rodata_unpaged("mobj_ffa_ops") = {
+DEFINE_RODATA_UNPAGED(struct mobj_ops, mobj_ffa_ops) = {
 	.get_pa = ffa_get_pa,
 	.get_phys_offs = ffa_get_phys_offs,
 	.get_va = ffa_get_va,

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -33,6 +33,11 @@
 		__section("__keep_meta_vars_pager") = (unsigned long)&(sym)
 
 #define __DECLARE_KEEP_PAGER1(sym, file_id) __DECLARE_KEEP_PAGER2(sym, file_id)
+
+/*
+ * DECLARE_KEEP_PAGER() - Resource and its dependencies are linked in
+ * an unpaged section
+ */
 #define DECLARE_KEEP_PAGER(sym) __DECLARE_KEEP_PAGER1(sym, __FILE_ID__)
 
 #define __DECLARE_KEEP_INIT2(sym, file_id) \
@@ -41,6 +46,11 @@
 		__section("__keep_meta_vars_init") = (unsigned long)&(sym)
 
 #define __DECLARE_KEEP_INIT1(sym, file_id) __DECLARE_KEEP_INIT2(sym, file_id)
+
+/*
+ * DECLARE_KEEP_INIT() - Resource and its dependencies are linked in
+ * an init (a.k.a pageable pre-mapped) section
+ */
 #define DECLARE_KEEP_INIT(sym) __DECLARE_KEEP_INIT1(sym, __FILE_ID__)
 
 /*

--- a/core/include/keep.h
+++ b/core/include/keep.h
@@ -43,6 +43,19 @@
 #define __DECLARE_KEEP_INIT1(sym, file_id) __DECLARE_KEEP_INIT2(sym, file_id)
 #define DECLARE_KEEP_INIT(sym) __DECLARE_KEEP_INIT1(sym, __FILE_ID__)
 
+/*
+ * DEFINE_RODATA_UNPAGED() - Define a read-only unpaged variable
+ *
+ * Define a const variable linked into an unpaged read-only section without
+ * propagating its unpaged constrain to the references the variable may refer
+ * to. This requires defining it twice with specific attributes for pager
+ * linker management. The variable is global (not static) since using __weak
+ * attribute for the dual definition.
+ */
+#define DEFINE_RODATA_UNPAGED(_type, _label) \
+	const _type _label __rodata_dummy; \
+	const _type _label __weak __rodata_unpaged(#_label)
+
 #endif /* __ASSEMBLER__ */
 
 #endif /*KEEP_H*/

--- a/core/kernel/user_ta.c
+++ b/core/kernel/user_ta.c
@@ -370,11 +370,7 @@ static uint32_t user_ta_get_instance_id(struct ts_ctx *ctx)
 	return to_user_ta_ctx(ctx)->uctx.vm_info.asid;
 }
 
-/*
- * Note: this variable is weak just to ease breaking its dependency chain
- * when added to the unpaged area.
- */
-const struct ts_ops user_ta_ops __weak __rodata_unpaged("user_ta_ops") = {
+DEFINE_RODATA_UNPAGED(struct ts_ops, user_ta_ops) = {
 	.enter_open_session = user_ta_enter_open_session,
 	.enter_invoke_cmd = user_ta_enter_invoke_cmd,
 	.enter_close_session = user_ta_enter_close_session,


### PR DESCRIPTION
Follow-up of comment thread starting here https://github.com/OP-TEE/optee_os/pull/4985#issuecomment-985582516 with @jforissier, here is a proposal for a helper macro `DEFINE_RODATA_UNPAGED()` as a complement to existing `__rodata_unpage()` and the need to define the variable twice.

Note checkpatch is not happy with the macro definition. It looks good to me however and i would treat reported error as a false positive. That said, suggestions are welcome if one sees a way to fix the issues.

```c
Checking commit(s):
ea0a4f66c core: DEFINE_RODATA_UNPAGED() helper macro
WARNING: Possible unwrapped commit description (prefer a maximum 75 chars per line)
#13: 
ERROR: Macros with multiple statements should be enclosed in a do - while loop

ERROR: Macros with multiple statements should be enclosed in a do - while loop
#53: FILE: core/include/keep.h:55:
+#define DEFINE_RODATA_UNPAGED(_type, _label) \
+	const _type _label __rodata_dummy; \
+	const _type _label __weak __rodata_unpaged(#_label)

CHECK: Macro argument reuse '_type' - possible side-effects?
#53: FILE: core/include/keep.h:55:
+#define DEFINE_RODATA_UNPAGED(_type, _label) \
+	const _type _label __rodata_dummy; \
+	const _type _label __weak __rodata_unpaged(#_label)

CHECK: Macro argument reuse '_label' - possible side-effects?
#53: FILE: core/include/keep.h:55:
+#define DEFINE_RODATA_UNPAGED(_type, _label) \
+	const _type _label __rodata_dummy; \
+	const _type _label __weak __rodata_unpaged(#_label)

total: 1 errors, 1 warnings, 2 checks, 19 lines checked
```
