### PR TITLE
crypto: drivers: se050 updates

### DIFF
--- a/core/drivers/crypto/se050/adaptors/include/se050_sss_apis.h
+++ b/core/drivers/crypto/se050/adaptors/include/se050_sss_apis.h
@@ -22,8 +22,14 @@ struct sss_se05x_ctx {
 		NXSCP03_StaticCtx_t static_ctx;
 		NXSCP03_DynCtx_t dynamic_ctx;
 	} se05x_auth;
+
 	sss_user_impl_session_t host_session;
 	sss_key_store_t host_ks;
+
+	struct se05x_se_info {
+		uint8_t applet[3];
+		uint8_t oefid[2];
+	} se_info;
 };
 
 sss_status_t se050_key_store_and_object_init(struct sss_se05x_ctx *ctx);

--- a/core/drivers/crypto/se050/adaptors/include/se050_utils.h
+++ b/core/drivers/crypto/se050/adaptors/include/se050_utils.h
@@ -44,7 +44,7 @@ uint64_t se050_generate_private_key(uint32_t oid);
 void se050_refcount_init_ctx(uint8_t **cnt);
 int se050_refcount_final_ctx(uint8_t *cnt);
 
-void se050_display_board_info(sss_se05x_session_t *session);
+sss_status_t se050_get_se_info(sss_se05x_session_t *session, bool display);
 
 enum se050_scp03_ksrc { SCP03_CFG, SCP03_DERIVED, SCP03_OFID };
 void se050_scp03_set_enable(enum se050_scp03_ksrc ksrc);

--- a/core/drivers/crypto/se050/adaptors/utils/scp_config.c
+++ b/core/drivers/crypto/se050/adaptors/utils/scp_config.c
@@ -293,10 +293,12 @@ sss_status_t se050_scp03_prepare_rotate_cmd(struct sss_se05x_ctx *ctx,
 
 static sss_status_t get_ofid_key(struct se050_scp_key *keys)
 {
+	uint32_t oefid = SHIFT_U32(se050_ctx.se_info.oefid[0], 8) |
+			 SHIFT_U32(se050_ctx.se_info.oefid[1], 0);
 	sss_status_t status = kStatus_SSS_Success;
 	uint32_t id = 0;
 
-	status = get_id_from_ofid(CFG_CORE_SE05X_OEFID, &id);
+	status = get_id_from_ofid(oefid, &id);
 	if (status != kStatus_SSS_Success)
 		return status;
 

--- a/core/drivers/crypto/se050/core/rsa.c
+++ b/core/drivers/crypto/se050/core/rsa.c
@@ -463,13 +463,21 @@ static TEE_Result do_encrypt(struct drvcrypt_rsa_ed *rsa_data)
 {
 	switch (rsa_data->rsa_id) {
 	case DRVCRYPT_RSA_PKCS_V1_5:
+		return encrypt_es(TEE_ALG_RSAES_PKCS1_V1_5,
+				  rsa_data->key.key,
+				  rsa_data->cipher.data,
+				  rsa_data->cipher.length,
+				  rsa_data->message.data,
+				  &rsa_data->message.length);
+
 	case DRVCRYPT_RSA_OAEP:
 		return encrypt_es(rsa_data->hash_algo,
 				  rsa_data->key.key,
-				  rsa_data->message.data,
-				  rsa_data->message.length,
 				  rsa_data->cipher.data,
-				  &rsa_data->cipher.length);
+				  rsa_data->cipher.length,
+				  rsa_data->message.data,
+				  &rsa_data->message.length);
+
 
 	case DRVCRYPT_RSASSA_PSS:
 	case DRVCRYPT_RSASSA_PKCS_V1_5:
@@ -485,13 +493,20 @@ static TEE_Result do_decrypt(struct drvcrypt_rsa_ed *rsa_data)
 {
 	switch (rsa_data->rsa_id) {
 	case DRVCRYPT_RSA_PKCS_V1_5:
+		return decrypt_es(TEE_ALG_RSAES_PKCS1_V1_5,
+				  rsa_data->key.key,
+				  rsa_data->cipher.data,
+				  rsa_data->cipher.length,
+				  rsa_data->message.data,
+				  &rsa_data->message.length);
+
 	case DRVCRYPT_RSA_OAEP:
 		return decrypt_es(rsa_data->hash_algo,
 				  rsa_data->key.key,
-				  rsa_data->message.data,
-				  rsa_data->message.length,
 				  rsa_data->cipher.data,
-				  &rsa_data->cipher.length);
+				  rsa_data->cipher.length,
+				  rsa_data->message.data,
+				  &rsa_data->message.length);
 
 	case DRVCRYPT_RSASSA_PSS:
 	case DRVCRYPT_RSASSA_PKCS_V1_5:

--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -13,8 +13,6 @@ CFG_CORE_SE05X_DISPLAY_INFO ?= y
 CFG_CORE_SE05X_SCP03_EARLY ?= y
 # Deletes all persistent storage from the SE050 at boot
 CFG_CORE_SE05X_INIT_NVM ?= n
-# Selects the default SCP03 keys based on the configured OEFID
-CFG_CORE_SE05X_OEFID ?= 0
 
 # I2C bus baudrate (depends on SoC)
 CFG_CORE_SE05X_BAUDRATE ?= 3400000


### PR DESCRIPTION
ECC sign fix:
----------------

The crypto API validates the size of the buffer that will hold the
resulting signature. This means that the SE05X driver can not use the
variable length buffer mechanism to request extra bytes to handle the
DER format.

To address this situation, this patch allocates a temporary buffer to
get the signature from the Plug-and-Trust subsystem; then, upon doing
the DER to binary conversion, copies the resulting data to the output
buffer.

OEFID runtime detection:
----------------------------------

The CFG_CORE_SE05X_OEFID definition is not required as the SE05X OEFID
can be read during early init - before the SCP03 session has been
established.
    
However we can continue to define it optionally: when that occurs, the OP-TEE driver 
will only initialize when such OEFID is  available.

FIX rsa encrypt/decrypt
------------------------------
 Fix input/output buffers (they were swapped).
 Fix algorithm selection for RSAES

Test:
  
```
  echo "data to sign (max 100 bytes)" > data

  openssl rsautl -encrypt -inkey rsa-pubkey.pub \
                  -in data -pubin -out data.crypt

  pkcs11-tool --module /usr/lib/libckteec.so.0.1 \
          --pin 87654321 --decrypt --id 01 \
          --token-label fio --mechanism RSA-PKCS \
	  --input-file data.crypt > data.decrypted

 diff data data.decrypted
```

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
