### PR TITLE
plat-sam: add psci support for reset and shutdown

### DIFF
--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -27,6 +27,7 @@ $(call force,CFG_DRIVERS_CLK_DT,y)
 $(call force,CFG_DRIVERS_CLK_FIXED,y)
 $(call force,CFG_DRIVERS_SAM_CLK,y)
 $(call force,CFG_DRIVERS_SAMA5D2_CLK,y)
+$(call force,CFG_PSCI_ARM32,y)
 
 # These values are forced because of matrix configuration for secure area.
 # When modifying these, always update matrix settings in
@@ -49,3 +50,6 @@ ifeq ($(CFG_ATMEL_TRNG),y)
 CFG_HWRNG_PTA ?= y
 $(call force,CFG_HWRNG_QUALITY,1024)
 endif
+
+CFG_ATMEL_RSTC ?= y
+CFG_ATMEL_SHDWC ?= y

--- a/core/arch/arm/plat-sam/pm/psci.c
+++ b/core/arch/arm/plat-sam/pm/psci.c
@@ -3,16 +3,38 @@
  * Copyright (c) 2021, Microchip
  */
 
+#include <drivers/atmel_rstc.h>
+#include <kernel/panic.h>
 #include <sm/psci.h>
 #include <sm/std_smc.h>
 #include <stdint.h>
+#include <trace.h>
+
+void __noreturn psci_system_reset(void)
+{
+	if (!atmel_rstc_available())
+		panic();
+
+	atmel_rstc_reset();
+}
 
 int psci_features(uint32_t psci_fid)
 {
 	switch (psci_fid) {
 	case ARM_SMCCC_VERSION:
+	case PSCI_PSCI_FEATURES:
+	case PSCI_VERSION:
 		return PSCI_RET_SUCCESS;
+	case PSCI_SYSTEM_RESET:
+		if (atmel_rstc_available())
+			return PSCI_RET_SUCCESS;
+		return PSCI_RET_NOT_SUPPORTED;
 	default:
 		return PSCI_RET_NOT_SUPPORTED;
 	}
+}
+
+uint32_t psci_version(void)
+{
+	return PSCI_VERSION_1_0;
 }

--- a/core/arch/arm/plat-sam/pm/psci.c
+++ b/core/arch/arm/plat-sam/pm/psci.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Microchip
+ */
+
+#include <sm/psci.h>
+#include <sm/std_smc.h>
+#include <stdint.h>
+
+int psci_features(uint32_t psci_fid)
+{
+	switch (psci_fid) {
+	case ARM_SMCCC_VERSION:
+		return PSCI_RET_SUCCESS;
+	default:
+		return PSCI_RET_NOT_SUPPORTED;
+	}
+}

--- a/core/arch/arm/plat-sam/pm/psci.c
+++ b/core/arch/arm/plat-sam/pm/psci.c
@@ -4,11 +4,20 @@
  */
 
 #include <drivers/atmel_rstc.h>
+#include <drivers/atmel_shdwc.h>
 #include <kernel/panic.h>
 #include <sm/psci.h>
 #include <sm/std_smc.h>
 #include <stdint.h>
 #include <trace.h>
+
+void __noreturn psci_system_off(void)
+{
+	if (!atmel_shdwc_available())
+		panic();
+
+	atmel_shdwc_shutdown();
+}
 
 void __noreturn psci_system_reset(void)
 {
@@ -27,6 +36,10 @@ int psci_features(uint32_t psci_fid)
 		return PSCI_RET_SUCCESS;
 	case PSCI_SYSTEM_RESET:
 		if (atmel_rstc_available())
+			return PSCI_RET_SUCCESS;
+		return PSCI_RET_NOT_SUPPORTED;
+	case PSCI_SYSTEM_OFF:
+		if (atmel_shdwc_available())
 			return PSCI_RET_SUCCESS;
 		return PSCI_RET_NOT_SUPPORTED;
 	default:

--- a/core/arch/arm/plat-sam/pm/sub.mk
+++ b/core/arch/arm/plat-sam/pm/sub.mk
@@ -1,0 +1,1 @@
+srcs-$(CFG_PSCI_ARM32) += psci.c

--- a/core/arch/arm/plat-sam/sub.mk
+++ b/core/arch/arm/plat-sam/sub.mk
@@ -2,3 +2,4 @@ global-incdirs-y += .
 srcs-y += main.c
 srcs-$(CFG_AT91_MATRIX) += matrix.c
 srcs-$(CFG_PL310) += sam_pl310.c
+subdirs-y += pm


### PR DESCRIPTION
This PR adds support for reset and shutdown via PSCI for plat-sam. It depends on reset controller and shutdown controller support which is currently under review.