### PR TITLE
Initialize CAAM drivers with job ring base address

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_dh.c
+++ b/core/drivers/crypto/caam/acipher/caam_dh.c
@@ -480,16 +480,12 @@ static struct drvcrypt_dh driver_dh = {
 	.shared_secret = do_shared_secret,
 };
 
-/*
- * Initialize the DH module
- *
- * @ctrl_addr   Controller base address
- */
-enum caam_status caam_dh_init(vaddr_t ctrl_addr)
+enum caam_status caam_dh_init(struct caam_jrcfg *caam_jrcfg)
 {
 	enum caam_status retstatus = CAAM_FAILURE;
+	vaddr_t jr_base = caam_jrcfg->base + caam_jrcfg->offset;
 
-	if (caam_hal_ctrl_pknum(ctrl_addr) &&
+	if (caam_hal_ctrl_pknum(jr_base) &&
 	    drvcrypt_register_dh(&driver_dh) == TEE_SUCCESS)
 		retstatus = CAAM_NO_ERROR;
 

--- a/core/drivers/crypto/caam/acipher/caam_ecc.c
+++ b/core/drivers/crypto/caam/acipher/caam_ecc.c
@@ -700,11 +700,12 @@ static struct drvcrypt_ecc driver_ecc = {
 	.shared_secret = do_shared_secret,
 };
 
-enum caam_status caam_ecc_init(vaddr_t ctrl_addr)
+enum caam_status caam_ecc_init(struct caam_jrcfg *caam_jrcfg)
 {
 	enum caam_status retstatus = CAAM_FAILURE;
+	vaddr_t jr_base = caam_jrcfg->base + caam_jrcfg->offset;
 
-	if (caam_hal_ctrl_pknum(ctrl_addr))
+	if (caam_hal_ctrl_pknum(jr_base))
 		if (drvcrypt_register_ecc(&driver_ecc) == TEE_SUCCESS)
 			retstatus = CAAM_NO_ERROR;
 

--- a/core/drivers/crypto/caam/acipher/caam_math.c
+++ b/core/drivers/crypto/caam/acipher/caam_math.c
@@ -114,11 +114,12 @@ static const struct drvcrypt_math driver_math = {
 	.xor_mod_n = &do_xor_mod_n,
 };
 
-enum caam_status caam_math_init(vaddr_t ctrl_addr __unused)
+enum caam_status caam_math_init(struct caam_jrcfg *caam_jrcfg)
 {
 	enum caam_status retstatus = CAAM_FAILURE;
+	vaddr_t jr_base = caam_jrcfg->base + caam_jrcfg->offset;
 
-	if (caam_hal_ctrl_pknum(ctrl_addr))
+	if (caam_hal_ctrl_pknum(jr_base))
 		if (!drvcrypt_register_math(&driver_math))
 			retstatus = CAAM_NO_ERROR;
 

--- a/core/drivers/crypto/caam/acipher/caam_rsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_rsa.c
@@ -1555,12 +1555,13 @@ static const struct drvcrypt_rsa driver_rsa = {
 	.optional.ssa_verify = NULL,
 };
 
-enum caam_status caam_rsa_init(vaddr_t ctrl_addr)
+enum caam_status caam_rsa_init(struct caam_jrcfg *caam_jrcfg)
 {
 	enum caam_status retstatus = CAAM_FAILURE;
+	vaddr_t jr_base = caam_jrcfg->base + caam_jrcfg->offset;
 
-	if (caam_hal_ctrl_pknum(ctrl_addr)) {
-		caam_era = caam_hal_ctrl_era(ctrl_addr);
+	if (caam_hal_ctrl_pknum(jr_base)) {
+		caam_era = caam_hal_ctrl_era(jr_base);
 		RSA_TRACE("CAAM Era %d", caam_era);
 
 		if (!drvcrypt_register_rsa(&driver_rsa))

--- a/core/drivers/crypto/caam/caam_ctrl.c
+++ b/core/drivers/crypto/caam/caam_ctrl.c
@@ -54,7 +54,7 @@ static TEE_Result crypto_driver_init(void)
 	}
 
 	/* Initialize the Hash Module */
-	retstatus = caam_hash_init(jrcfg.base);
+	retstatus = caam_hash_init(&jrcfg);
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;
@@ -82,7 +82,7 @@ static TEE_Result crypto_driver_init(void)
 	}
 
 	/* Initialize the HMAC Module */
-	retstatus = caam_hmac_init(jrcfg.base);
+	retstatus = caam_hmac_init(&jrcfg);
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;

--- a/core/drivers/crypto/caam/caam_ctrl.c
+++ b/core/drivers/crypto/caam/caam_ctrl.c
@@ -61,14 +61,14 @@ static TEE_Result crypto_driver_init(void)
 	}
 
 	/* Initialize the MATH Module */
-	retstatus = caam_math_init(jrcfg.base);
+	retstatus = caam_math_init(&jrcfg);
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;
 	}
 
 	/* Initialize the RSA Module */
-	retstatus = caam_rsa_init(jrcfg.base);
+	retstatus = caam_rsa_init(&jrcfg);
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;
@@ -103,14 +103,14 @@ static TEE_Result crypto_driver_init(void)
 	}
 
 	/* Initialize the ECC Module */
-	retstatus = caam_ecc_init(jrcfg.base);
+	retstatus = caam_ecc_init(&jrcfg);
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;
 	}
 
 	/* Initialize the DH Module */
-	retstatus = caam_dh_init(jrcfg.base);
+	retstatus = caam_dh_init(&jrcfg);
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;

--- a/core/drivers/crypto/caam/hash/caam_hash.c
+++ b/core/drivers/crypto/caam/hash/caam_hash.c
@@ -703,11 +703,12 @@ void caam_hash_hmac_copy_state(struct hashctx *dst, struct hashctx *src)
 	}
 }
 
-enum caam_status caam_hash_init(vaddr_t ctrl_addr)
+enum caam_status caam_hash_init(struct caam_jrcfg *caam_jrcfg)
 {
 	enum caam_status retstatus = CAAM_FAILURE;
+	vaddr_t jr_base = caam_jrcfg->base + caam_jrcfg->offset;
 
-	caam_hash_limit = caam_hal_ctrl_hash_limit(ctrl_addr);
+	caam_hash_limit = caam_hal_ctrl_hash_limit(jr_base);
 
 	if (caam_hash_limit != UINT8_MAX) {
 		if (drvcrypt_register_hash(&caam_hash_allocate) == TEE_SUCCESS)

--- a/core/drivers/crypto/caam/hash/caam_hash_mac.c
+++ b/core/drivers/crypto/caam/hash/caam_hash_mac.c
@@ -333,12 +333,14 @@ err:
 	return ret;
 }
 
-enum caam_status caam_hmac_init(vaddr_t ctrl_addr)
+enum caam_status caam_hmac_init(struct caam_jrcfg *caam_jrcfg)
 {
-	caam_hash_limit = caam_hal_ctrl_hash_limit(ctrl_addr);
+	vaddr_t jr_base = caam_jrcfg->base + caam_jrcfg->offset;
+
+	caam_hash_limit = caam_hal_ctrl_hash_limit(jr_base);
 
 	if (caam_hash_limit != UINT8_MAX &&
-	    caam_hal_ctrl_splitkey_support(ctrl_addr)) {
+	    caam_hal_ctrl_splitkey_support(jr_base)) {
 		if (drvcrypt_register_hmac(&caam_hmac_allocate))
 			return CAAM_FAILURE;
 	}

--- a/core/drivers/crypto/caam/include/caam_acipher.h
+++ b/core/drivers/crypto/caam/include/caam_acipher.h
@@ -14,11 +14,12 @@
 /*
  * Initialize the RSA module
  *
- * @ctrl_addr   Controller base address
+ * @caam_jrcfg   JR configuration structure
  */
-enum caam_status caam_rsa_init(vaddr_t ctrl_addr);
+enum caam_status caam_rsa_init(struct caam_jrcfg *caam_jrcfg);
 #else
-static inline enum caam_status caam_rsa_init(vaddr_t ctrl_addr __unused)
+static inline enum caam_status
+caam_rsa_init(struct caam_jrcfg *caam_jrcfg __unused)
 {
 	return CAAM_NO_ERROR;
 }
@@ -28,11 +29,12 @@ static inline enum caam_status caam_rsa_init(vaddr_t ctrl_addr __unused)
 /*
  * Initialize the DH module
  *
- * @ctrl_addr   Controller base address
+ * @caam_jrcfg   JR configuration structure
  */
-enum caam_status caam_dh_init(vaddr_t ctrl_addr);
+enum caam_status caam_dh_init(struct caam_jrcfg *caam_jrcfg);
 #else
-static inline enum caam_status caam_dh_init(vaddr_t ctrl_addr __unused)
+static inline enum caam_status
+caam_dh_init(struct caam_jrcfg *caam_jrcfg __unused)
 {
 	return CAAM_NO_ERROR;
 }
@@ -42,11 +44,12 @@ static inline enum caam_status caam_dh_init(vaddr_t ctrl_addr __unused)
 /*
  * Initialize the MATH module
  *
- * @ctrl_addr   Controller base address
+ * @caam_jrcfg   JR configuration structure
  */
-enum caam_status caam_math_init(vaddr_t ctrl_addr);
+enum caam_status caam_math_init(struct caam_jrcfg *caam_jrcfg);
 #else
-static inline enum caam_status caam_math_init(vaddr_t ctrl_addr __unused)
+static inline enum caam_status
+caam_math_init(struct caam_jrcfg *caam_jrcfg __unused)
 {
 	return CAAM_NO_ERROR;
 }
@@ -56,11 +59,12 @@ static inline enum caam_status caam_math_init(vaddr_t ctrl_addr __unused)
 /*
  * Initialize the Cipher module
  *
- * @ctrl_addr   Controller base address
+ * @caam_jrcfg   JR configuration structure
  */
-enum caam_status caam_ecc_init(vaddr_t ctrl_addr);
+enum caam_status caam_ecc_init(struct caam_jrcfg *caam_jrcfg);
 #else
-static inline enum caam_status caam_ecc_init(vaddr_t ctrl_addr __unused)
+static inline enum caam_status
+caam_ecc_init(struct caam_jrcfg *caam_jrcfg __unused)
 {
 	return CAAM_NO_ERROR;
 }

--- a/core/drivers/crypto/caam/include/caam_hash.h
+++ b/core/drivers/crypto/caam/include/caam_hash.h
@@ -1,21 +1,24 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2018-2019 NXP
+ * Copyright 2018-2021 NXP
  *
  * Brief   CAAM Hash manager header.
  */
 #ifndef __CAAM_HASH_H__
 #define __CAAM_HASH_H__
 
+#include <caam_jr.h>
+
 #ifdef CFG_NXP_CAAM_HASH_DRV
 /*
  * Initialize the Hash module
  *
- * @ctrl_addr   Controller base address
+ * @caam_jrcfg	JR configuration structure
  */
-enum caam_status caam_hash_init(vaddr_t ctrl_addr);
+enum caam_status caam_hash_init(struct caam_jrcfg *caam_jrcfg);
 #else
-static inline enum caam_status caam_hash_init(vaddr_t ctrl_addr __unused)
+static inline enum caam_status
+caam_hash_init(struct caam_jrcfg *caam_jrcfg __unused)
 {
 	return CAAM_NO_ERROR;
 }
@@ -25,11 +28,12 @@ static inline enum caam_status caam_hash_init(vaddr_t ctrl_addr __unused)
 /*
  * Initialize the HMAC module
  *
- * @ctrl_addr   Controller base address
+ * @caam_jrcfg	JR configuration structure
  */
-enum caam_status caam_hmac_init(vaddr_t ctrl_addr);
+enum caam_status caam_hmac_init(struct caam_jrcfg *caam_jrcfg);
 #else
-static inline enum caam_status caam_hmac_init(vaddr_t ctrl_addr __unused)
+static inline enum caam_status
+caam_hmac_init(struct caam_jrcfg *caam_jrcfg __unused)
 {
 	return CAAM_NO_ERROR;
 }


### PR DESCRIPTION
Hello,

A patch set to initialize CAAM hash, ecc, rsa and math drivers with the given JR base address instead of taking JR0 as base address systematically.
It prepares the CAAM support for imx8q/qxp

Thanks!
Clement