### PR TITLE
lib: libutils: trace.c: make print_core_id() architecture-independent

### DIFF
--- a/core/arch/arm/kernel/trace_ext.c
+++ b/core/arch/arm/kernel/trace_ext.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <trace.h>
 #include <console.h>
+#include <kernel/misc.h>
 #include <kernel/spinlock.h>
 #include <kernel/thread.h>
 #include <mm/core_mmu.h>
@@ -50,4 +51,13 @@ void trace_ext_puts(const char *str)
 int trace_ext_get_thread_id(void)
 {
 	return thread_get_id_may_fail();
+}
+
+int trace_ext_get_core_id(void)
+{
+	/* If foreign interrupts aren't masked we report invalid core ID */
+	if (thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR)
+		return get_core_pos();
+	else
+		return -1;
 }

--- a/lib/libutils/ext/include/trace.h
+++ b/lib/libutils/ext/include/trace.h
@@ -25,6 +25,7 @@ extern int trace_level;
 extern const char trace_ext_prefix[];
 void trace_ext_puts(const char *str);
 int trace_ext_get_thread_id(void);
+int trace_ext_get_core_id(void);
 void trace_set_level(int level);
 int trace_get_level(void);
 void plat_trace_ext_puts(const char *str);

--- a/lib/libutils/ext/trace.c
+++ b/lib/libutils/ext/trace.c
@@ -5,7 +5,6 @@
 
 #if defined(__KERNEL__)
 #include <platform_config.h>
-#include <kernel/misc.h>
 #endif
 
 #include <printk.h>
@@ -85,9 +84,10 @@ static int print_core_id(char *buf, size_t bs)
 	const int num_digits = 1;
 	const char qm[] = "?";
 #endif
+	int core_id = trace_ext_get_core_id();
 
-	if (thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR)
-		return snprintk(buf, bs, "%0*zu ", num_digits, get_core_pos());
+	if (core_id >= 0)
+		return snprintk(buf, bs, "%0*u ", num_digits, core_id);
 	else
 		return snprintk(buf, bs, "%s ", qm);
 }


### PR DESCRIPTION
The function` print_core_id()` in `lib/libutils/ext/trace.c` is calling
architecture-specific routines to retrieve the core id. It is more
relevant to create a new abstract function `trace_ext_get_core_id()`
in `lib/libutee/trace_ext.c` that needs to be implemented in the
architecture-specific code. This is is similar to `print_thread_id()`
which calls `trace_ext_get_thread_id()` implemented in
`core/arch/arm/kernel/trace_ext.c`

Signed-off-by: Maroune Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
