### PR TITLE
lib: libutils: ext: mempool.c: remove unused thread.h

### DIFF
--- a/lib/libutils/ext/mempool.c
+++ b/lib/libutils/ext/mempool.c
@@ -15,7 +15,6 @@
 #if defined(__KERNEL__)
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
-#include <kernel/thread.h>
 #endif
 
 /*


### PR DESCRIPTION
This commit removes `thread.h` from `lib/libutils/ext/mempool.c` since it is
not used, but also to eliminate the dependency between generic libraries
code and architecture-specific core functions.

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
