### PR TITLE
drivers: clk: change API functions clk_dt_get_by_*()

### DIFF
--- a/core/drivers/atmel_trng.c
+++ b/core/drivers/atmel_trng.c
@@ -128,7 +128,7 @@ static TEE_Result trng_node_probe(const void *fdt, int node,
 
 	matrix_configure_periph_secure(AT91C_ID_TRNG);
 
-	clk = clk_dt_get_by_idx(fdt, node, 0, &res);
+	res = clk_dt_get_by_index(fdt, node, 0, &clk);
 	if (res)
 		return res;
 

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -148,7 +148,7 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 				&rate_len);
 	rate_len /= sizeof(uint32_t);
 
-	while (1) {
+	while (true) {
 		res = clk_dt_get_by_idx_prop("assigned-clocks", fdt, nodeoffset,
 					     clock_idx, &clk);
 		if (!clk)

--- a/core/drivers/clk/sam/sama5d2_clk.c
+++ b/core/drivers/clk/sam/sama5d2_clk.c
@@ -342,11 +342,11 @@ static TEE_Result pmc_setup(const void *fdt, int nodeoffset,
 	if (_fdt_get_status(fdt, nodeoffset) == DT_STATUS_OK_SEC)
 		matrix_configure_periph_secure(AT91C_ID_PMC);
 
-	slow_clk = clk_dt_get_by_name(fdt, nodeoffset, "slow_clk", &res);
+	res = clk_dt_get_by_name(fdt, nodeoffset, "slow_clk", &slow_clk);
 	if (res)
 		panic();
 
-	main_xtal_clk = clk_dt_get_by_name(fdt, nodeoffset, "main_xtal", &res);
+	res = clk_dt_get_by_name(fdt, nodeoffset, "main_xtal", &main_xtal_clk);
 	if (res)
 		panic();
 

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -30,41 +30,34 @@
 	}
 
 /**
- * clk_dt_get_by_idx - Get a clock at a specific index in "clocks" property
+ * clk_dt_get_by_index - Get a clock at a specific index in "clocks" property
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the subnode containing a clock property
  * @clk_idx: Clock index to get
- * @res: Output result code of the operation:
- *	TEE_SUCCESS in case of success
- *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
- *	Any TEE_Result compliant code in case of error.
+ * @clk: Output clock reference upon success
  *
- * Returns a clk struct pointer matching the clock at index clk_idx in clocks
- * property or NULL if no clock match the given index in which case @res
- * provides the error code.
+ * Return TEE_SUCCESS in case of success
+ * Return TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
+ * Return any other TEE_Result compliant code in case of error
  */
-struct clk *clk_dt_get_by_idx(const void *fdt, int nodeoffset,
-			      unsigned int clk_idx, TEE_Result *res);
+TEE_Result clk_dt_get_by_index(const void *fdt, int nodeoffset,
+			       unsigned int clk_idx, struct clk **clk);
 
 /**
- * clk_dt_get_by_name - Get a clock matching a name in the "clock-names"
- * property
+ * clk_dt_get_by_name - Get a clock matching a name in "clock-names" property
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the subnode containing a clock property
  * @name: Clock name to get
- * @res: Output result code of the operation:
- *	TEE_SUCCESS in case of success
- *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
- *	Any TEE_Result compliant code in case of error.
+ * @clk: Output clock reference upon success
  *
- * Returns a clk struct pointer matching the name in "clock-names" property or
- * NULL if no clock match the given name in which case @res provides the
- * error code.
+ * Return TEE_SUCCESS in case of success
+ * Return TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
+ * Return any other TEE_Result compliant code in case of error
  */
-struct clk *clk_dt_get_by_name(const void *fdt, int nodeoffset,
-			       const char *name, TEE_Result *res);
+TEE_Result clk_dt_get_by_name(const void *fdt, int nodeoffset,
+			      const char *name, struct clk **clk);
 
 /**
  * clk_dt_get_func - Typedef of function to get clock from devicetree properties


### PR DESCRIPTION
* drivers: clk: change `clk_dt_get_by_*()` prototype
Changes `clk_dt_get_by_idx()` and `clk_dt_get_by_name()` to return a the `TEE_Result` code and use an output argument to pass back clock reference rather than the opposite. This change makes `clk_dt_get_by_*()` function more consistent with the other OP-TEE core API functions.
Also renames`clk_dt_get_by_idx()` to `clk_dt_get_by_index()`.
Updates _sama5d2_clk.c_ and _atmel_trng.c_ accordingly.

* drivers: clk: use `while (true)`
Changes _clk_dt.c_ to use `while (true)` instead of `while (1)` for consistency in optee_os implementation.
