### PR TITLE
ta: pkcs11: Clean up temporary_object_list in err condition

### DIFF
--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -85,6 +85,8 @@ static void cleanup_volatile_obj_ref(struct pkcs11_object *obj)
 	if (!obj)
 		return;
 
+	LIST_REMOVE(obj, link);
+
 	if (obj->key_handle != TEE_HANDLE_NULL)
 		TEE_FreeTransientObject(obj->key_handle);
 
@@ -119,8 +121,6 @@ void cleanup_persistent_object(struct pkcs11_object *obj,
 	obj->attribs_hdl = TEE_HANDLE_NULL;
 	destroy_object_uuid(token, obj);
 
-	LIST_REMOVE(obj, link);
-
 	cleanup_volatile_obj_ref(obj);
 }
 
@@ -139,8 +139,6 @@ void destroy_object(struct pkcs11_session *session, struct pkcs11_object *obj,
 	if (obj->uuid)
 		MSG_RAW("[destroy] obj uuid %pUl", (void *)obj->uuid);
 #endif
-
-	LIST_REMOVE(obj, link);
 
 	if (session_only) {
 		/* Destroy object due to session closure */


### PR DESCRIPTION
When handle_get() failed in create_object(), ssession obj is not removed from temporary_object_list.
Only token obj is removed inside cleanup_persistent_object().
Add LIST_REMOVE for session obj.

Signed-off-by: Mengchi Cheng <mengcc@amazon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
