### PR TITLE
core: stmm: Increase the shared number of pages

### DIFF
--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -69,8 +69,8 @@ static const uint16_t ffa_storage_id = 4U;
 
 static const unsigned int stmm_stack_size = 4 * SMALL_PAGE_SIZE;
 static const unsigned int stmm_heap_size = 398 * SMALL_PAGE_SIZE;
-static const unsigned int stmm_sec_buf_size = SMALL_PAGE_SIZE;
-static const unsigned int stmm_ns_comm_buf_size = SMALL_PAGE_SIZE;
+static const unsigned int stmm_sec_buf_size = 4 * SMALL_PAGE_SIZE;
+static const unsigned int stmm_ns_comm_buf_size = 4 * SMALL_PAGE_SIZE;
 
 extern unsigned char stmm_image[];
 extern const unsigned int stmm_image_size;


### PR DESCRIPTION
Currently we only allow single page sharing for the StanAloneMM non-secure
world buffer.  There are cases on EFI variables though which this isn't
enough.  For example an EFI signature list (.esl) containing more than
two keys would fail since the payload is larger than a single page.  So
let's bump the number to something more reasonable.

Note that we could add this on a config option with an upper boundary, but
four pages should be enough for embedded use cases

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
