### PR TITLE
plat-imx: add Advantech RSB-3720 board support

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -70,7 +70,8 @@ mx8mn-flavorlist = \
 	mx8mnevk
 
 mx8mp-flavorlist = \
-	mx8mpevk
+	mx8mpevk \
+	mx8mp_rsb3720_6g
 
 mx8qm-flavorlist = \
 	mx8qmmek \
@@ -342,6 +343,14 @@ endif
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mpevk))
 CFG_DDR_SIZE ?= UL(0x180000000)
 CFG_UART_BASE ?= UART2_BASE
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mp_rsb3720_6g))
+CFG_DDR_SIZE ?= UL(0x180000000)
+CFG_UART_BASE ?= UART3_BASE
+CFG_TZDRAM_START ?= 0x56000000
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 endif


### PR DESCRIPTION
Support for Advantech RSB-3720 board (imx8mp).
(PLATFORM=imx-mx8mp_rsb3720_6g)

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
