### PR TITLE
core: libtomcrypt: increase MPI_MEMPOOL_SIZE to 46kB

### DIFF
--- a/core/lib/libtomcrypt/mpi_desc.c
+++ b/core/lib/libtomcrypt/mpi_desc.c
@@ -19,7 +19,7 @@
 #endif
 
 /* Size needed for xtest to pass reliably on both ARM32 and ARM64 */
-#define MPI_MEMPOOL_SIZE	(42 * 1024)
+#define MPI_MEMPOOL_SIZE	(46 * 1024)
 
 /* From mbedtls/library/bignum.c */
 #define ciL		(sizeof(mbedtls_mpi_uint))	/* chars in limb  */


### PR DESCRIPTION
This value is increased because xtest pkcs11_1019 when run
in loop, leads to extensive use of memory pool which
sometimes leads to memory allocation failure.

Problem is the way mempool_alloc() is implemented in combination
with how it's used from ltc_ecc_projective_add_point().

mempool_alloc() has a stack like allocation scheme. When freeing
the top element that memory is returned to the pool, but if memory
further down is free it's not returned until all elements above has
been freed. If two or more elements gets allocated and freed in a
cycle they can continue to use more and more memory with nothing
returned.

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Fixes: https://github.com/OP-TEE/optee_os/issues/5022