### PR TITLE
mempool based on bget

### DIFF
--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -346,8 +346,8 @@ static bool bpool_foreach(struct malloc_ctx *ctx,
 	for (bpool_foreach_iterator_init((ctx),(iterator));   \
 	     bpool_foreach((ctx),(iterator), (bp));)
 
-static void *raw_memalign(size_t hdr_size, size_t ftr_size, size_t alignment,
-			  size_t pl_size, struct malloc_ctx *ctx)
+void *raw_memalign(size_t hdr_size, size_t ftr_size, size_t alignment,
+		   size_t pl_size, struct malloc_ctx *ctx)
 {
 	void *ptr = NULL;
 	bufsize s;
@@ -372,8 +372,8 @@ out:
 	return ptr;
 }
 
-static void *raw_malloc(size_t hdr_size, size_t ftr_size, size_t pl_size,
-			struct malloc_ctx *ctx)
+void *raw_malloc(size_t hdr_size, size_t ftr_size, size_t pl_size,
+		 struct malloc_ctx *ctx)
 {
 	/*
 	 * Note that we're feeding SizeQ as alignment, this is the smallest
@@ -382,7 +382,7 @@ static void *raw_malloc(size_t hdr_size, size_t ftr_size, size_t pl_size,
 	return raw_memalign(hdr_size, ftr_size, SizeQ, pl_size, ctx);
 }
 
-static void raw_free(void *ptr, struct malloc_ctx *ctx, bool wipe)
+void raw_free(void *ptr, struct malloc_ctx *ctx, bool wipe)
 {
 	raw_malloc_validate_pools(ctx);
 
@@ -390,8 +390,8 @@ static void raw_free(void *ptr, struct malloc_ctx *ctx, bool wipe)
 		brel(ptr, &ctx->poolset, wipe);
 }
 
-static void *raw_calloc(size_t hdr_size, size_t ftr_size, size_t pl_nmemb,
-			size_t pl_size, struct malloc_ctx *ctx)
+void *raw_calloc(size_t hdr_size, size_t ftr_size, size_t pl_nmemb,
+		 size_t pl_size, struct malloc_ctx *ctx)
 {
 	void *ptr = NULL;
 	bufsize s;
@@ -415,8 +415,8 @@ out:
 	return ptr;
 }
 
-static void *raw_realloc(void *ptr, size_t hdr_size, size_t ftr_size,
-			 size_t pl_size, struct malloc_ctx *ctx)
+void *raw_realloc(void *ptr, size_t hdr_size, size_t ftr_size,
+		  size_t pl_size, struct malloc_ctx *ctx)
 {
 	void *p = NULL;
 	bufsize s;
@@ -889,6 +889,30 @@ out:
 	malloc_unlock(ctx, exceptions);
 	return ret;
 }
+
+size_t raw_malloc_get_ctx_size(void)
+{
+	return sizeof(struct malloc_ctx);
+}
+
+void raw_malloc_init_ctx(struct malloc_ctx *ctx)
+{
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->poolset.freelist.ql.flink = &ctx->poolset.freelist;
+	ctx->poolset.freelist.ql.blink = &ctx->poolset.freelist;
+}
+
+void raw_malloc_add_pool(struct malloc_ctx *ctx, void *buf, size_t len)
+{
+	gen_malloc_add_pool(ctx, buf, len);
+}
+
+#ifdef CFG_WITH_STATS
+void raw_malloc_get_stats(struct malloc_ctx *ctx, struct malloc_stats *stats)
+{
+	gen_malloc_get_stats(ctx, stats);
+}
+#endif
 
 void malloc_add_pool(void *buf, size_t len)
 {

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -142,4 +142,19 @@ void nex_malloc_reset_stats(void);
 
 #endif	/* CFG_VIRTUALIZATION */
 
+struct malloc_ctx;
+void *raw_memalign(size_t hdr_size, size_t ftr_size, size_t alignment,
+		   size_t pl_size, struct malloc_ctx *ctx);
+void *raw_malloc(size_t hdr_size, size_t ftr_size, size_t pl_size,
+		 struct malloc_ctx *ctx);
+void raw_free(void *ptr, struct malloc_ctx *ctx, bool wipe);
+void *raw_calloc(size_t hdr_size, size_t ftr_size, size_t pl_nmemb,
+		 size_t pl_size, struct malloc_ctx *ctx);
+void *raw_realloc(void *ptr, size_t hdr_size, size_t ftr_size,
+		  size_t pl_size, struct malloc_ctx *ctx);
+size_t raw_malloc_get_ctx_size(void);
+void raw_malloc_init_ctx(struct malloc_ctx *ctx);
+void raw_malloc_add_pool(struct malloc_ctx *ctx, void *buf, size_t len);
+void raw_malloc_get_stats(struct malloc_ctx *ctx, struct malloc_stats *stats);
+
 #endif /* MALLOC_H */

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -155,6 +155,8 @@ void *raw_realloc(void *ptr, size_t hdr_size, size_t ftr_size,
 size_t raw_malloc_get_ctx_size(void);
 void raw_malloc_init_ctx(struct malloc_ctx *ctx);
 void raw_malloc_add_pool(struct malloc_ctx *ctx, void *buf, size_t len);
+#ifdef CFG_WITH_STATS
 void raw_malloc_get_stats(struct malloc_ctx *ctx, struct malloc_stats *stats);
+#endif
 
 #endif /* MALLOC_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -773,3 +773,6 @@ endif
 # interrupt ID must be configurged by the platform too. Currently is only
 # CFG_CORE_ASYNC_NOTIF_GIC_INTID defined.
 CFG_CORE_ASYNC_NOTIF ?= n
+
+$(eval $(call cfg-enable-all-depends,CFG_MEMPOOL_REPORT_LAST_OFFSET, \
+	 CFG_WITH_STATS))


### PR DESCRIPTION
This relates to the issue https://github.com/OP-TEE/optee_os/issues/5022 and the recently merged PR https://github.com/OP-TEE/optee_os/pull/5065

Reply to https://github.com/OP-TEE/optee_os/issues/5022#issuecomment-996885144
> > Interesting, I wonder how much it can increase. Perhaps it's time to start looking for a alternative implementation to the mempool. I have an idea where bget could actually be reused with this.
> 
> Yes, we should look for some other mempool implementation as it hogs memory which is already free in some cases. It would be great if we can improve this implementation with bget.

This PR attempts to do this. Note that I haven't tried to tune `MPI_MEMPOOL_SIZE`.

The purpose of mempool is to be able to guarantee that temporary memory allocations will succeed during asymmetric cipher operations. As long as we return the memory allocated with mempool_alloc() we can use it in other functions too. There's a couple of examples of that in the code already. So the rule is: if you allocate memory with mempool_alloc() you should free it again before returning.

