### PR TITLE
core: use adr_l for global r/w variable threads

### DIFF
--- a/core/arch/arm/kernel/thread_spmc_a64.S
+++ b/core/arch/arm/kernel/thread_spmc_a64.S
@@ -170,7 +170,7 @@ DECLARE_KEEP_PAGER thread_rpc
 FUNC thread_foreign_intr_exit , :
 	/* load threads[w0].tsd.rpc_target_info into w1 */
 	mov	x1, #THREAD_CTX_SIZE
-	adr	x2, threads
+	adr_l	x2, threads
 	madd	x1, x1, x0, x2
 	ldr	w1, [x1, #THREAD_CTX_TSD_RPC_TARGET_INFO]
 	mov	x2, #FFA_PARAM_MBZ


### PR DESCRIPTION
Replace an adr instruction with adr_l in thread_foreign_intr_exit to
make sure that the r/w global variable threads is accessible even if the
optee binary is very large.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
