### PR TITLE
core: arch: kernel: move spmc functions from thread.h to thread_spmc.h

### DIFF
--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -777,11 +777,6 @@ void *thread_rpc_shm_cache_alloc(enum thread_shm_cache_user user,
 				 enum thread_shm_type shm_type,
 				 size_t size, struct mobj **mobj);
 
-#if defined(CFG_CORE_SEL2_SPMC)
-struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie);
-void thread_spmc_relinquish(uint64_t memory_region_handle);
-#endif
-
 #endif /*__ASSEMBLER__*/
 
 #endif /*KERNEL_THREAD_H*/

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -31,4 +31,9 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 void spmc_fill_partition_entry(struct ffa_partition_info *fpi,
 			       uint16_t endpoint_id,
 			       uint16_t execution_context);
+#if defined(CFG_CORE_SEL2_SPMC)
+struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie);
+void thread_spmc_relinquish(uint64_t memory_region_handle);
+#endif
+
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -9,6 +9,7 @@
 #include <keep.h>
 #include <kernel/refcount.h>
 #include <kernel/spinlock.h>
+#include <kernel/thread_spmc.h>
 #include <mm/mobj.h>
 #include <sys/queue.h>
 


### PR DESCRIPTION
It is more relevant to declare `thread_spmc_populate_mobj_from_rx()` and
`thread_spmc_relinquish()` in `thread_spmc.h` instead of `thread.h`
Source file `mobj_ffa.c` makes use of these two functions, hence include
`kernel/secure_partition.h` header.

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
