### PR TITLE
libutils: provide __sprintf_chk implementation

### DIFF
--- a/lib/libutils/isoc/include/stdio.h
+++ b/lib/libutils/isoc/include/stdio.h
@@ -20,6 +20,8 @@ int snprintf(char *str, size_t size, const char *fmt, ...)
                     __attribute__ ((__format__ (__printf__, 3, 4)));
 int vsnprintf (char *str, size_t size, const char *fmt, va_list ap)
                     __attribute__ ((__format__ (__printf__, 3, 0)));
+int __sprintf_chk(char *str, int flag, size_t slen, const char *fmt, ...)
+                    __attribute__ ((__format__ (__printf__, 4, 5)));
 
 int puts(const char *str);
 int putchar(int c);

--- a/lib/libutils/isoc/sprintf.c
+++ b/lib/libutils/isoc/sprintf.c
@@ -3,8 +3,10 @@
  * Copyright (c) 2020, Huawei Technologies Co., Ltd
  */
 
+#include <compiler.h>
 #include <printk.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int sprintf(char *str, const char *fmt, ...)
 {
@@ -14,6 +16,25 @@ int sprintf(char *str, const char *fmt, ...)
 	va_start(ap, fmt);
 	retval = __vsprintf(str, fmt, ap);
 	va_end(ap);
+
+	return retval;
+}
+
+int __sprintf_chk(char *str, int flag __unused, size_t slen,
+		  const char *fmt, ...)
+{
+	int retval;
+	va_list ap;
+
+	if (slen == 0)
+		abort();
+
+	va_start(ap, fmt);
+	retval = __vsnprintf(str, slen, fmt, ap, false);
+	va_end(ap);
+
+	if (retval > 0 && (size_t)retval >= slen)
+		abort();
 
 	return retval;
 }


### PR DESCRIPTION
While building optee_test CXX test-cases natively on aarch64, OP-TEE
build relies on toolchain provided by buildroot. The buildroot toolchain
is built with flag: -fstack-protector-strong which requires
__sprintf_chk symbol provided by standard glibc. For OP-TEE we use a
customized libc which leads to below error:

CC out/init.o
CC out/os_test.o
CC out/ta_entry.o
CXX out/cxx_tests.o
CC out/user_ta_header.o
CPP out/ta.lds
LD out/5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.elf
/home/sumit/optee_br/build/../toolchains/aarch64/bin/aarch64-linux-ld.bfd: /home/sumit/optee_br/toolchains/aarch64/bin/../lib/gcc/aarch64-buildroot-linux-gnu/10.3.0/../../../../aarch64-buildroot-linux-gnu/lib/../lib64/libstdc++.a(cp-demangle.o): in function d_append_num': cp-demangle.c:(.text+0x830): undefined reference to __sprintf_chk'

Fix this issue by providing __sprintf_chk implementation.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
