### PR TITLE
ci: azure: do not run trusted-keys tests with Xen

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -244,7 +244,8 @@ jobs:
 
           sudo -E rm -rf /root/optee_repo_qemu_v8/out-br/build/optee_test*
           sudo -E make -C /root/optee_repo_qemu_v8/build arm-tf-clean
-          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(getconf _NPROCESSORS_ONLN) CFG_TEE_CORE_LOG_LEVEL=0 check XEN_BOOT=y
+          # CHECK_TESTS=xtest because CHECK_TESTS=trusted-keys is not supported with Xen
+          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(getconf _NPROCESSORS_ONLN) CFG_TEE_CORE_LOG_LEVEL=0 check CHECK_TESTS=xtest XEN_BOOT=y
 
   - job: QEMUv8_build_Rust
     displayName: 'Run regression tests (Rust) in QEMUv8'


### PR DESCRIPTION
The QEMU/QEMUv8 self-tests have recently been extended to run Trusted
Keys tests [1], but they don't work with Xen. Therefore use the
CHECK_TESTS variable introduced by [2] to exclude them.

Link: [1] https://github.com/OP-TEE/build/commit/45cf44c5d3ba6bf58af8cfb0c5acb0c057352451
Link: [2] https://github.com/OP-TEE/build/commit/92d86ba02b834cd5d7279a597d0ddb49482f1765
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
