### PR TITLE
libutee: Panic when IV is provided for ECB modes

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -849,6 +849,14 @@ void TEE_CipherInit(TEE_OperationHandle operation, const void *IV,
 	if (operation->operationState != TEE_OPERATION_STATE_INITIAL)
 		TEE_ResetOperation(operation);
 
+	if (IV && IVLen) {
+		if (operation->info.algorithm == TEE_ALG_AES_ECB_NOPAD ||
+		    operation->info.algorithm == TEE_ALG_DES_ECB_NOPAD ||
+		    operation->info.algorithm == TEE_ALG_DES3_ECB_NOPAD ||
+		    operation->info.algorithm == TEE_ALG_SM4_ECB_NOPAD)
+			TEE_Panic(0);
+	}
+
 	operation->operationState = TEE_OPERATION_STATE_ACTIVE;
 
 	res = _utee_cipher_init(operation->state, IV, IVLen);


### PR DESCRIPTION
Ideally, the ECB mode doesn't need an IV at all.
The GlobalPlatform spec says "IV required: No" for
the algorithms that use this mode (Table 6-6b).

So, in order to be inclined to the requirement of the
spec,  the implementation can panic when IV is provided
for ECB modes.

Signed-off-by: Sadiq Hussain <sadiq.muchumarri@intel.com>