### PR TITLE
Enable support for Pointer Authentication for TAs

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -297,12 +297,23 @@ ta_arm64-platform-cxxflags += -fpic
 ta_arm64-platform-cxxflags += $(platform-cflags-optimization)
 ta_arm64-platform-cxxflags += $(platform-cflags-debug-info)
 
-ifeq ($(CFG_TA_BTI),y)
-bti-ta-opt := $(call cc-option,-mbranch-protection=bti)
-ifeq (,$(bti-ta-opt))
-$(error -mbranch-protection=bti not supported)
+ifeq ($(CFG_TA_PAUTH),y)
+bp-ta-opt := $(call cc-option,-mbranch-protection=pac-ret+leaf)
 endif
-ta_arm64-platform-cflags += $(bti-ta-opt)
+
+ifeq ($(CFG_TA_BTI),y)
+bp-ta-opt := $(call cc-option,-mbranch-protection=bti)
+endif
+
+ifeq (y-y,$(CFG_TA_PAUTH)-$(CFG_TA_BTI))
+bp-ta-opt := $(call cc-option,-mbranch-protection=pac-ret+leaf+bti)
+endif
+
+ifeq (y,$(filter $(CFG_TA_BTI) $(CFG_TA_PAUTH),y))
+ifeq (,$(bp-ta-opt))
+$(error -mbranch-protection not supported)
+endif
+ta_arm64-platform-cflags += $(bp-ta-opt)
 endif
 
 ta-mk-file-export-vars-ta_arm64 += CFG_ARM64_ta_arm64

--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -126,6 +126,23 @@ static inline bool feat_bti_is_implemented(void)
 		FEAT_BTI_IMPLEMENTED);
 #endif
 }
+
+static inline bool feat_pauth_is_implemented(void)
+{
+#ifdef ARM32
+	return false;
+#else
+	uint64_t mask =
+		SHIFT_U64(ID_AA64ISAR1_GPI_MASK, ID_AA64ISAR1_GPI_SHIFT) |
+		SHIFT_U64(ID_AA64ISAR1_GPA_MASK, ID_AA64ISAR1_GPA_SHIFT) |
+		SHIFT_U64(ID_AA64ISAR1_API_MASK, ID_AA64ISAR1_API_SHIFT) |
+		SHIFT_U64(ID_AA64ISAR1_APA_MASK, ID_AA64ISAR1_APA_SHIFT);
+
+	/* If any of the fields is not zero, PAuth is implemented by arch */
+	return (read_id_aa64isar1_el1() & mask) != 0U;
+#endif
+}
+
 #endif
 
 #endif /*ARM_H*/

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -15,8 +15,14 @@
 #define SCTLR_C		BIT32(2)
 #define SCTLR_SA	BIT32(3)
 #define SCTLR_I		BIT32(12)
+#define SCTLR_ENDB	BIT32(13)
 #define SCTLR_WXN	BIT32(19)
 #define SCTLR_SPAN	BIT32(23)
+#define SCTLR_ENDA	BIT32(27)
+#define SCTLR_ENIB	BIT32(30)
+#define SCTLR_ENIA	BIT32(31)
+#define SCTLR_BT0	BIT32(35)
+#define SCTLR_BT1	BIT32(36)
 
 #define TTBR_ASID_MASK		U(0xff)
 #define TTBR_ASID_SHIFT		U(48)
@@ -135,11 +141,15 @@
 #define ESR_EC_AARCH32_CP14_LS	U(0x06)
 #define ESR_EC_FP_ASIMD		U(0x07)
 #define ESR_EC_AARCH32_CP10_ID	U(0x08)
+#define ESR_EC_PAUTH		U(0x09)
 #define ESR_EC_AARCH32_CP14_64	U(0x0c)
+#define ESR_EC_BTI		U(0x0d)
 #define ESR_EC_ILLEGAL		U(0x0e)
 #define ESR_EC_AARCH32_SVC	U(0x11)
 #define ESR_EC_AARCH64_SVC	U(0x15)
 #define ESR_EC_AARCH64_SYS	U(0x18)
+#define ESR_EC_ERET		U(0x1a)
+#define ESR_EC_FPAC		U(0x1c)
 #define ESR_EC_IABT_EL0		U(0x20)
 #define ESR_EC_IABT_EL1		U(0x21)
 #define ESR_EC_PC_ALIGN		U(0x22)
@@ -198,6 +208,34 @@
 
 #define ID_AA64PFR1_EL1_BT_MASK	ULL(0xf)
 #define FEAT_BTI_IMPLEMENTED	ULL(0x1)
+
+#define ID_AA64ISAR1_GPI_SHIFT		U(28)
+#define ID_AA64ISAR1_GPI_MASK		U(0xf)
+#define ID_AA64ISAR1_GPI_NI		U(0x0)
+#define ID_AA64ISAR1_GPI_IMP_DEF	U(0x1)
+
+#define ID_AA64ISAR1_GPA_SHIFT		U(24)
+#define ID_AA64ISAR1_GPA_MASK		U(0xf)
+#define ID_AA64ISAR1_GPA_NI		U(0x0)
+#define ID_AA64ISAR1_GPA_ARCHITECTED	U(0x1)
+
+#define ID_AA64ISAR1_API_SHIFT			U(8)
+#define ID_AA64ISAR1_API_MASK			U(0xf)
+#define ID_AA64ISAR1_API_NI			U(0x0)
+#define ID_AA64ISAR1_API_IMP_DEF		U(0x1)
+#define ID_AA64ISAR1_API_IMP_DEF_EPAC		U(0x2)
+#define ID_AA64ISAR1_API_IMP_DEF_EPAC2		U(0x3)
+#define ID_AA64ISAR1_API_IMP_DEF_EPAC2_FPAC	U(0x4)
+#define ID_AA64ISAR1_API_IMP_DEF_EPAC2_FPAC_CMB	U(0x5)
+
+#define ID_AA64ISAR1_APA_SHIFT			U(4)
+#define ID_AA64ISAR1_APA_MASK			U(0xf)
+#define ID_AA64ISAR1_APA_NI			U(0x0)
+#define ID_AA64ISAR1_APA_ARCHITECTED		U(0x1)
+#define ID_AA64ISAR1_APA_ARCH_EPAC		U(0x2)
+#define ID_AA64ISAR1_APA_ARCH_EPAC2		U(0x3)
+#define ID_AA64ISAR1_APA_ARCH_EPAC2_FPAC	U(0x4)
+#define ID_AA64ISAR1_APA_ARCH_EPAC2_FPAC_CMB	U(0x5)
 
 #ifndef __ASSEMBLER__
 static inline __noprof void isb(void)
@@ -327,7 +365,7 @@ DEFINE_U32_REG_READWRITE_FUNCS(fpsr)
 DEFINE_U32_REG_READ_FUNC(ctr_el0)
 #define read_ctr() read_ctr_el0()
 DEFINE_U32_REG_READ_FUNC(contextidr_el1)
-DEFINE_U32_REG_READ_FUNC(sctlr_el1)
+DEFINE_U64_REG_READ_FUNC(sctlr_el1)
 
 /* ARM Generic timer functions */
 DEFINE_REG_READ_FUNC_(cntfrq, uint32_t, cntfrq_el0)
@@ -359,6 +397,21 @@ DEFINE_U64_REG_READ_FUNC(par_el1)
 DEFINE_U64_REG_WRITE_FUNC(mair_el1)
 
 DEFINE_U64_REG_READ_FUNC(id_aa64pfr1_el1)
+DEFINE_U64_REG_READ_FUNC(id_aa64isar1_el1)
+DEFINE_REG_READ_FUNC_(apiakeylo, uint64_t, S3_0_c2_c1_0)
+DEFINE_REG_READ_FUNC_(apiakeyhi, uint64_t, S3_0_c2_c1_1)
+
+DEFINE_REG_WRITE_FUNC_(apibkeylo, uint64_t, S3_0_c2_c1_2)
+DEFINE_REG_WRITE_FUNC_(apibkeyhi, uint64_t, S3_0_c2_c1_3)
+
+DEFINE_REG_READ_FUNC_(apdakeylo, uint64_t, S3_0_c2_c2_0)
+DEFINE_REG_READ_FUNC_(apdakeyhi, uint64_t, S3_0_c2_c2_1)
+
+DEFINE_REG_WRITE_FUNC_(apdbkeylo, uint64_t, S3_0_c2_c2_2)
+DEFINE_REG_WRITE_FUNC_(apdbkeyhi, uint64_t, S3_0_c2_c2_3)
+
+DEFINE_REG_WRITE_FUNC_(apgakeylo, uint64_t, S3_0_c2_c3_0)
+DEFINE_REG_WRITE_FUNC_(apgakeyhi, uint64_t, S3_0_c2_c3_1)
 
 /* Register read/write functions for GICC registers by using system interface */
 DEFINE_REG_READ_FUNC_(icc_ctlr, uint32_t, S3_0_C12_C12_4)

--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -132,3 +132,19 @@
 		b	.
 #endif
 	.endm
+
+	.macro read_apiakeylo reg
+	mrs	\reg, S3_0_c2_c1_0
+	.endm
+
+	.macro read_apiakeyhi reg
+	mrs	\reg, S3_0_c2_c1_1
+	.endm
+
+	.macro write_apiakeylo reg
+	msr	S3_0_c2_c1_0, \reg
+	.endm
+
+	.macro write_apiakeyhi reg
+	msr	S3_0_c2_c1_1, \reg
+	.endm

--- a/core/arch/arm/include/kernel/thread.h
+++ b/core/arch/arm/include/kernel/thread.h
@@ -73,6 +73,11 @@ struct thread_user_vfp_state {
 	bool saved;
 };
 
+struct thread_pauth_keys {
+	uint64_t hi;
+	uint64_t lo;
+};
+
 #ifdef ARM32
 struct thread_smc_args {
 	uint32_t a0;	/* SMC function ID */
@@ -211,6 +216,10 @@ struct thread_svc_regs {
 	uint64_t x28;
 	uint64_t x29;
 #endif
+#ifdef CFG_TA_PAUTH
+	uint64_t apiakey_hi;
+	uint64_t apiakey_lo;
+#endif
 	uint64_t pad;
 } __aligned(16);
 #endif /*ARM64*/
@@ -247,6 +256,10 @@ struct thread_ctx_regs {
 	uint64_t cpsr;
 	uint64_t x[31];
 	uint64_t tpidr_el0;
+#ifdef CFG_TA_PAUTH
+	uint64_t apiakey_hi;
+	uint64_t apiakey_lo;
+#endif
 };
 #endif /*ARM64*/
 

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -58,6 +58,10 @@ DEFINES
 	DEFINE(THREAD_SVC_REG_ELR, offsetof(struct thread_svc_regs, elr));
 	DEFINE(THREAD_SVC_REG_SPSR, offsetof(struct thread_svc_regs, spsr));
 	DEFINE(THREAD_SVC_REG_SP_EL0, offsetof(struct thread_svc_regs, sp_el0));
+#ifdef CFG_TA_PAUTH
+	DEFINE(THREAD_SVC_REG_APIAKEY_HI, offsetof(struct thread_svc_regs,
+						   apiakey_hi));
+#endif
 	DEFINE(THREAD_SVC_REG_SIZE, sizeof(struct thread_svc_regs));
 
 	/* struct thread_abort_regs */
@@ -81,6 +85,10 @@ DEFINES
 	DEFINE(THREAD_CTX_REGS_X19, offsetof(struct thread_ctx_regs, x[19]));
 	DEFINE(THREAD_CTX_REGS_TPIDR_EL0, offsetof(struct thread_ctx_regs,
 						   tpidr_el0));
+#ifdef CFG_TA_PAUTH
+	DEFINE(THREAD_CTX_REGS_APIAKEY_HI, offsetof(struct thread_ctx_regs,
+						    apiakey_hi));
+#endif
 
 	/* struct thread_user_mode_rec */
 	DEFINE(THREAD_USER_MODE_REC_CTX_REGS_PTR,

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -36,6 +36,28 @@
 		b.eq	\label
 	.endm
 
+	.macro disable_pauth reg
+#ifdef	CFG_TA_PAUTH
+		mrs	\reg, sctlr_el1
+		bic     \reg, \reg, #SCTLR_ENIA
+#ifdef CFG_TA_BTI
+		orr     \reg, \reg, #(SCTLR_BT0 | SCTLR_BT1)
+#endif
+		msr	sctlr_el1, \reg
+#endif
+	.endm
+
+	.macro enable_pauth reg
+#ifdef	CFG_TA_PAUTH
+		mrs	\reg, sctlr_el1
+		orr     \reg, \reg, #SCTLR_ENIA
+#ifdef CFG_TA_BTI
+		bic     \reg, \reg, #(SCTLR_BT0 | SCTLR_BT1)
+#endif
+		msr	sctlr_el1, \reg
+#endif
+	.endm
+
 /* void thread_resume(struct thread_ctx_regs *regs) */
 FUNC thread_resume , :
 	load_xregs x0, THREAD_CTX_REGS_SP, 1, 3
@@ -52,7 +74,15 @@ FUNC thread_resume , :
 	ldr	x0, [x0, THREAD_CTX_REGS_X0]
 	return_from_exception
 
-1:	load_xregs x0, THREAD_CTX_REGS_X1, 1, 3
+1:
+#ifdef	CFG_TA_PAUTH
+	/* Restore PAC keys before return to el0 */
+	load_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
+	write_apiakeyhi	x1
+	write_apiakeylo	x2
+#endif
+
+	load_xregs x0, THREAD_CTX_REGS_X1, 1, 3
 	ldr	x0, [x0, THREAD_CTX_REGS_X0]
 
 	msr	spsel, #1
@@ -126,6 +156,13 @@ FUNC __thread_enter_user_mode , :
 	msr	sp_el0, x1
 	msr	elr_el1, x2
 	msr	spsr_el1, x3
+
+#ifdef	CFG_TA_PAUTH
+	/* Load APIAKEY */
+	load_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
+	write_apiakeyhi	x1
+	write_apiakeylo	x2
+#endif
 
 	/*
 	 * Save the values for x0 and x1 in struct thread_core_local to be
@@ -284,6 +321,7 @@ el1_serror_sp1:
 	.balign	128, INV_INSN
 el0_sync_a64:
 	restore_mapping
+	/* PAuth will be disabled later else check_vector_size will fail */
 
 	mrs	x2, esr_el1
 	mrs	x3, sp_el0
@@ -296,6 +334,7 @@ el0_sync_a64:
 	.balign	128, INV_INSN
 el0_irq_a64:
 	restore_mapping
+	disable_pauth x1
 
 	b	elx_irq
 	check_vector_size el0_irq_a64
@@ -303,6 +342,7 @@ el0_irq_a64:
 	.balign	128, INV_INSN
 el0_fiq_a64:
 	restore_mapping
+	disable_pauth x1
 
 	b	elx_fiq
 	check_vector_size el0_fiq_a64
@@ -466,6 +506,7 @@ workaround_el0_serror_a32:
  * that it's always available.
  */
 eret_to_el0:
+	enable_pauth x1
 
 #ifdef CFG_CORE_UNMAP_CORE_AT_EL0
 	/* Point to the vector into the reduced mapping */
@@ -614,6 +655,7 @@ thread_excp_vect_end:
 END_FUNC thread_excp_vect
 
 LOCAL_FUNC el0_svc , :
+	disable_pauth x1
 	/* get pointer to current thread context in x0 */
 	get_thread_ctx sp, 0, 1, 2
 	mrs	x1, tpidr_el0
@@ -640,6 +682,14 @@ LOCAL_FUNC el0_svc , :
 	mrs	x0, elr_el1
 	mrs	x1, spsr_el1
 	store_xregs sp, THREAD_SVC_REG_ELR, 0, 1
+
+#ifdef CFG_TA_PAUTH
+	/* Save APIAKEY */
+	read_apiakeyhi	x0
+	read_apiakeylo	x1
+	store_xregs sp, THREAD_SVC_REG_APIAKEY_HI, 0, 1
+#endif
+
 	mov	x0, sp
 
 	/*
@@ -687,7 +737,15 @@ LOCAL_FUNC el0_svc , :
 
 	return_from_exception
 
-1:	ldp	x0, x1, [x30, THREAD_SVC_REG_X0]
+1:
+#ifdef	CFG_TA_PAUTH
+	/* Restore APIAKEY */
+	load_xregs x30, THREAD_SVC_REG_APIAKEY_HI, 0, 1
+	write_apiakeyhi	x0
+	write_apiakeylo	x1
+#endif
+
+	ldp	x0, x1, [x30, THREAD_SVC_REG_X0]
 	ldr	x30, [x30, #THREAD_SVC_REG_X30]
 
 	msr	spsel, #1
@@ -779,6 +837,7 @@ END_FUNC el1_sync_abort
 
 	/* sp_el0 in x3 */
 LOCAL_FUNC el0_sync_abort , :
+	disable_pauth x1
 	/*
 	 * Update core local flags
 	 */

--- a/core/include/kernel/user_mode_ctx_struct.h
+++ b/core/include/kernel/user_mode_ctx_struct.h
@@ -16,6 +16,7 @@
  * @vm_info:		Virtual memory map of this context
  * @regions:		Memory regions registered by pager
  * @vfp:		State of VFP registers
+ * @keys:		Pointer authentication keys
  * @ts_ctx:		Generic TS context
  * @entry_func:		Entry address in TS
  * @dump_entry_func:	Entry address in TS for dumping address mappings
@@ -33,6 +34,9 @@ struct user_mode_ctx {
 	struct vm_paged_region_head *regions;
 #if defined(CFG_WITH_VFP)
 	struct thread_user_vfp_state vfp;
+#endif
+#if defined(CFG_TA_PAUTH)
+	struct thread_pauth_keys keys;
 #endif
 	struct ts_ctx *ts_ctx;
 	uaddr_t entry_func;

--- a/core/kernel/user_ta.c
+++ b/core/kernel/user_ta.c
@@ -442,6 +442,10 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 	if (res)
 		goto out;
 
+#ifdef CFG_TA_PAUTH
+	crypto_rng_read(&utc->uctx.keys, sizeof(utc->uctx.keys));
+#endif
+
 	mutex_lock(&tee_ta_mutex);
 	s->ts_sess.ctx = &utc->ta_ctx.ts_ctx;
 	s->ts_sess.handle_svc = s->ts_sess.ctx->ops->handle_svc;

--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -207,6 +207,24 @@ get_prop_feat_bti_implemented(struct ts_session *sess __unused, void *buf,
 }
 #endif
 
+#ifdef CFG_TA_PAUTH
+static TEE_Result
+get_prop_feat_pauth_implemented(struct ts_session *sess __unused, void *buf,
+				size_t *blen)
+{
+	bool pauth_impl = false;
+
+	if (*blen < sizeof(pauth_impl)) {
+		*blen = sizeof(pauth_impl);
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+	*blen = sizeof(pauth_impl);
+	pauth_impl = feat_pauth_is_implemented();
+
+	return copy_to_user(buf, &pauth_impl, sizeof(pauth_impl));
+}
+#endif
+
 /* Properties of the set TEE_PROPSET_CURRENT_CLIENT */
 const struct tee_props tee_propset_client[] = {
 	{
@@ -321,6 +339,13 @@ const struct tee_props tee_propset_tee[] = {
 		.prop_type = USER_TA_PROP_TYPE_BOOL,
 		.get_prop_func = get_prop_feat_bti_implemented
 	},
+#endif
+#ifdef CFG_TA_PAUTH
+	{
+		.name = "org.trustedfirmware.optee.cpu.feat_pauth_implemented",
+		.prop_type = USER_TA_PROP_TYPE_BOOL,
+		.get_prop_func = get_prop_feat_pauth_implemented
+	}
 #endif
 
 	/*

--- a/ldelf/pauth.c
+++ b/ldelf/pauth.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <types_ext.h>
+#include <util.h>
+#include "pauth.h"
+
+void pauth_strip_pac(uint64_t *lr)
+{
+	const uint64_t va_mask = GENMASK_64(CFG_LPAE_ADDR_SPACE_BITS - 1, 0);
+
+	*lr = *lr & va_mask;
+}

--- a/ldelf/pauth.h
+++ b/ldelf/pauth.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#ifndef PAUTH_H
+#define PAUTH_H
+
+#include <types_ext.h>
+#include <util.h>
+
+void pauth_strip_pac(uint64_t *lr);
+
+#endif /*PAUTH_H*/
+

--- a/ldelf/sub.mk
+++ b/ldelf/sub.mk
@@ -10,3 +10,4 @@ srcs-y += sys.c
 srcs-y += ta_elf.c
 srcs-y += ta_elf_rel.c
 srcs-$(CFG_FTRACE_SUPPORT) += ftrace.c
+srcs-$(CFG_TA_PAUTH) += pauth.c

--- a/lib/libunw/include/unw/unwind.h
+++ b/lib/libunw/include/unw/unwind.h
@@ -118,4 +118,7 @@ static inline void print_stack_arm64(struct unwind_state_arm64 *state __unused,
  */
 void ftrace_map_lr(uint64_t *lr);
 
+/* Strip out PAuth tags from LR content if applicable */
+void pauth_strip_pac(uint64_t *lr);
+
 #endif /*UNW_UNWIND_H*/

--- a/lib/libunw/unwind_arm64.c
+++ b/lib/libunw/unwind_arm64.c
@@ -34,8 +34,12 @@
 #include <trace.h>
 #include <types_ext.h>
 #include <unw/unwind.h>
+#include <util.h>
 
 void __weak ftrace_map_lr(uint64_t *lr __unused)
+{}
+
+void __weak pauth_strip_pac(uint64_t *lr __unused)
 {}
 
 static bool copy_in_reg(uint64_t *reg, vaddr_t addr)
@@ -63,6 +67,8 @@ bool unwind_stack_arm64(struct unwind_state_arm64 *frame,
 	/* LR (X30) */
 	if (!copy_in_reg(&frame->pc, fp + 8))
 		return false;
+
+	pauth_strip_pac(&frame->pc);
 
 	ftrace_map_lr(&frame->pc);
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -780,3 +780,12 @@ CFG_CORE_ASYNC_NOTIF ?= n
 
 $(eval $(call cfg-enable-all-depends,CFG_MEMPOOL_REPORT_LAST_OFFSET, \
 	 CFG_WITH_STATS))
+
+# Pointer Authentication (part of ARMv8.3 Extensions) provides
+# instructions for signing and authenticating pointers against secret keys.
+# These can be used to mitigate ROP (Return oriented programming) attacks.
+# This option enables these instructions for TA's at EL0. When this option is
+# enabled , TEE core will initialize secret keys per TA.
+CFG_TA_PAUTH ?= n
+
+$(eval $(call cfg-depends-all,CFG_TA_PAUTH,CFG_ARM64_core))

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -34,6 +34,7 @@ ta-mk-file-export-vars-$(sm) += CFG_FTRACE_SUPPORT
 ta-mk-file-export-vars-$(sm) += CFG_UNWIND
 ta-mk-file-export-vars-$(sm) += CFG_TA_MCOUNT
 ta-mk-file-export-vars-$(sm) += CFG_TA_BTI
+ta-mk-file-export-vars-$(sm) += CFG_TA_PAUTH
 ta-mk-file-export-vars-$(sm) += CFG_CORE_TPM_EVENT_LOG
 ta-mk-file-export-add-$(sm) += CFG_TEE_TA_LOG_LEVEL ?= $(CFG_TEE_TA_LOG_LEVEL)_nl_
 ta-mk-file-export-vars-$(sm) += CFG_TA_BGET_TEST


### PR DESCRIPTION
 Pointer Authentication (part of ARMv8.3 Extensions) provides instructions for signing and authenticating pointers against secret keys. These can be used to mitigate ROP (Return oriented programming) attacks. The patches enables these instructions for TA's at EL0. When this option is chosen, TEE core will initialise secret keys per TA at the load time. 

The PAUTH support in ARMv8.3 introduces 2 keys for instruction space (APIA/B), 2 for data space (APDA/B) and 1 for general use (APG). The patchset uses only one key i.e APIAKey for TA's.

All xtests along with GP tests pass with the patch-set.

Changes have been done in thread_a64.S to save and restore the keys. Currently it is assumed we are enabling pauth when transitioning to el0 and disabling it whenever there is a sys call or exception return to el1.

To test this, CTX_INCLUDE_PAUTH_REGS needs to be enabled when compiling TF-A to allow for saving/restoring of PAUTH key registers at context switch in TF-A and enabling access of these registers by EL1.