### PR TITLE
crypto: drivers: se050: rsa: various fixes

### DIFF
--- a/core/drivers/crypto/se050/core/rsa.c
+++ b/core/drivers/crypto/se050/core/rsa.c
@@ -420,7 +420,8 @@ static TEE_Result sign_ssa(uint32_t algo, struct rsa_keypair *key,
 	st = sss_se05x_asymmetric_context_init(&ctx, se050_session, &kobject,
 					       tee2se050(algo), kMode_SSS_Sign);
 	if (st != kStatus_SSS_Success) {
-		sss_se05x_key_store_erase_key(se050_kstore, &kobject);
+		if (!se050_rsa_keypair_from_nvm(key))
+			sss_se05x_key_store_erase_key(se050_kstore, &kobject);
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 

--- a/core/drivers/crypto/se050/core/rsa.c
+++ b/core/drivers/crypto/se050/core/rsa.c
@@ -605,18 +605,21 @@ static TEE_Result do_encrypt(struct drvcrypt_rsa_ed *rsa_data)
 	case DRVCRYPT_RSA_PKCS_V1_5:
 		return encrypt_es(TEE_ALG_RSAES_PKCS1_V1_5,
 				  rsa_data->key.key,
-				  rsa_data->cipher.data,
-				  rsa_data->cipher.length,
 				  rsa_data->message.data,
-				  &rsa_data->message.length);
+				  rsa_data->message.length,
+				  rsa_data->cipher.data,
+				  &rsa_data->cipher.length);
 
 	case DRVCRYPT_RSA_OAEP:
-		return encrypt_es(rsa_data->hash_algo,
+		if (rsa_data->hash_algo != TEE_ALG_SHA1)
+			return TEE_ERROR_NOT_IMPLEMENTED;
+
+		return encrypt_es(TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA1,
 				  rsa_data->key.key,
-				  rsa_data->cipher.data,
-				  rsa_data->cipher.length,
 				  rsa_data->message.data,
-				  &rsa_data->message.length);
+				  rsa_data->message.length,
+				  rsa_data->cipher.data,
+				  &rsa_data->cipher.length);
 
 	default:
 		break;
@@ -646,7 +649,10 @@ static TEE_Result do_decrypt(struct drvcrypt_rsa_ed *rsa_data)
 				  &rsa_data->message.length);
 
 	case DRVCRYPT_RSA_OAEP:
-		return decrypt_es(rsa_data->hash_algo,
+		if (rsa_data->hash_algo != TEE_ALG_SHA1)
+			return TEE_ERROR_NOT_IMPLEMENTED;
+
+		return decrypt_es(TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA1,
 				  rsa_data->key.key,
 				  rsa_data->cipher.data,
 				  rsa_data->cipher.length,


### PR DESCRIPTION
crypto: drivers: se050: rsa: add RSA_NOPAD enc/dec support
---
Commit 8563cdc ("drivers: crypto: se050: limitations to RSA
crypto") removed RSA_NOPAD support based on the Plug And Trust MW
documentation, Release v02,14,00 (Apr 03, 2020).

That documentation was incorrect as RSA_NOPAD is indeed supported by
the secure element as described in the SE050 APDU specification [1],
section 4.3.14, table 32.

This commit restores the functionality and fixes previous bugs.

Validated on xtest 4006 and 4011.

[1] https://www.nxp.com/docs/en/application-note/AN12413.pdf

crypto: drivers: se050: rsa: fix OAEP and revert regression
--
Revert a regression introduced in the encrypt operation when swapping
buffers (fixes part of 'commit e1c70d7 ("crypto: drivers: se050:
fix rsa encrypt/decrypt")'

Fix misuse of the hash_algo field during OAEP encrypt/decrypt.

All tests passing
  * xtest -t regression 4006

crypto: drivers: se050: rsa: decrypt_es, validate the output buffer
--
The size of the decrypted output is not known until decryption has
happened.

Use an intermediate buffer large enough to guarantee that the
decrypted message will fit.

This allows the driver to validate the size of the output buffer
passed in the interface.

pkcs11 test passing now
 * xtest pkcs11_1023.

 crypto: drivers: se050: rsa: sign_ssa error handling
--
SE NVM keys shall only be deleted using either the pkcs#11 interface
(if the key was created by pkcs#11) or the free_keypair crypto API
interface and never as a result of some error handling operation.
    
Notice that calling free_keypair will invalidate any copy made of that
keypair since the keypair for a SE only holds a handle to the key
stored in the SE NVM.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
