### PR TITLE
drivers: crypto: rsa: handle not implemented sign/verify operations

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
@@ -402,9 +402,11 @@ TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 		rsa_ssa.salt_len = salt_len;
 		rsa_ssa.mgf = &drvcrypt_rsa_mgf1;
 
+		ret = TEE_ERROR_NOT_IMPLEMENTED;
 		if (rsa->optional.ssa_sign)
 			ret = rsa->optional.ssa_sign(&rsa_ssa);
-		else
+
+		if (ret == TEE_ERROR_NOT_IMPLEMENTED)
 			ret = drvcrypt_rsassa_sign(&rsa_ssa);
 
 		/* Set the signature length */
@@ -476,9 +478,11 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 		rsa_ssa.salt_len = salt_len;
 		rsa_ssa.mgf = &drvcrypt_rsa_mgf1;
 
+		ret = TEE_ERROR_NOT_IMPLEMENTED;
 		if (rsa->optional.ssa_verify)
 			ret = rsa->optional.ssa_verify(&rsa_ssa);
-		else
+
+		if (ret == TEE_ERROR_NOT_IMPLEMENTED)
 			ret = drvcrypt_rsassa_verify(&rsa_ssa);
 
 	} else {


### PR DESCRIPTION
Route the unimplemented RSA sign/verify optional cases to their
software implementations.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
