### PR TITLE
plat-stm32mp1: default enable CFG_ENABLE_EMBEDDED_TESTS

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -119,7 +119,7 @@ $(call force,CFG_SCMI_MSG_VOLTAGE_DOMAIN,y)
 endif
 
 # Default enable some test facitilites
-CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
+CFG_ENABLE_EMBEDDED_TESTS ?= y
 CFG_WITH_STATS ?= y
 
 # Default disable some support for pager memory size constraint


### PR DESCRIPTION
Changes platform stm32m1 to default enable CFG_ENABLE_EMBEDDED_TESTS
rather than CFG_TEE_CORE_EMBED_INTERNAL_TESTS to get all embedded tests
support including the test interface PTAs.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
