### PR TITLE
FF-A device memory

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -78,6 +78,12 @@
 #define FFA_NORMAL_MEM_REG_ATTR		U(0x2f)
 
 /* Device memory attributes */
+#define FFA_DEV_MEM_REG_ATTR_MASK	U(0x1c)
+#define FFA_DEV_MEM_REG_ATTR		BIT(4)
+
+/* FF-A Device memory attributes */
+#define FFA_DEV_MEM_SHIFT		U(2)
+#define FFA_DEV_MEM_MASK		U(0x3)
 #define FFA_DEV_MEM_nGnRnE		U(0x0)
 #define FFA_DEV_MEM_nGnRE		U(0x1)
 

--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2018-2021, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited. All rights reserved.
  */
 
 #ifndef __FFA_H
@@ -76,6 +76,10 @@
 
 /* Memory attributes: Normal memory, Write-Back cacheable, Inner shareable */
 #define FFA_NORMAL_MEM_REG_ATTR		U(0x2f)
+
+/* Device memory attributes */
+#define FFA_DEV_MEM_nGnRnE		U(0x0)
+#define FFA_DEV_MEM_nGnRE		U(0x1)
 
 /* Memory access permissions: Read-write */
 #define FFA_MEM_ACC_RW			BIT(1)

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2020-2021, Arm Limited.
+ * Copyright (c) 2020-2022, Arm Limited.
  */
 #include <bench.h>
 #include <crypto/crypto.h>
@@ -240,6 +240,8 @@ TEE_Result sp_map_shared(struct sp_session *s,
 	struct sp_ctx *ctx = NULL;
 	uint32_t perm = TEE_MATTR_UR;
 	struct sp_mem_map_region *reg = NULL;
+	uint32_t cache_type = 0;
+	bool is_device = smem->mem_reg_attr & FFA_DEV_MEM_REG_ATTR;
 
 	ctx = to_sp_ctx(s->ts_sess.ctx);
 
@@ -263,7 +265,28 @@ TEE_Result sp_map_shared(struct sp_session *s,
 	if (*va)
 		return TEE_ERROR_NOT_SUPPORTED;
 
+	if (is_device) {
+		uint8_t dev_type = (smem->mem_reg_attr >> FFA_DEV_MEM_SHIFT) &
+				    FFA_DEV_MEM_MASK;
+
+		if (sp_mem_ffa_dev_to_cache_type(dev_type, &cache_type))
+			return FFA_INVALID_PARAMETERS;
+	}
+
 	SLIST_FOREACH(reg, &smem->regions, link) {
+		/* Check device region attributes */
+		if (is_device) {
+			uint32_t mcache_type = 0;
+
+			if (mobj_get_cattr(reg->mobj, &mcache_type))
+				return FFA_INVALID_PARAMETERS;
+
+			if (cache_type != mcache_type) {
+				EMSG("Inccorect device type");
+				return FFA_INVALID_PARAMETERS;
+			}
+		}
+
 		res = vm_map(&ctx->uctx, va, reg->page_count * SMALL_PAGE_SIZE,
 			     perm, 0, reg->mobj, reg->page_offset);
 

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -221,8 +221,37 @@ err:
 	return res;
 }
 
+static TEE_Result mem_set_cache_type(struct sp_mem *smem,
+				     uint8_t permission, struct mobj *m)
+{
+	uint8_t dev_type = 0;
+	uint32_t cache_type = 0;
+
+	if (smem->mem_reg_attr & FFA_DEV_MEM_REG_ATTR) {
+		if (smem->mem_reg_attr & ~FFA_DEV_MEM_REG_ATTR_MASK)
+			return FFA_INVALID_PARAMETERS;
+
+		dev_type = (smem->mem_reg_attr >> FFA_DEV_MEM_SHIFT) &
+			   FFA_DEV_MEM_MASK;
+
+		if (sp_mem_ffa_dev_to_cache_type(dev_type, &cache_type))
+			return FFA_INVALID_PARAMETERS;
+
+		if (permission  & FFA_MEM_ACC_EXE)
+			return FFA_INVALID_PARAMETERS;
+
+	} else {
+		cache_type = TEE_MATTR_MEM_TYPE_CACHED;
+	}
+
+	sp_mem_set_cattr(m, cache_type);
+
+	return TEE_SUCCESS;
+}
+
 static int spmc_sp_add_nw_region(struct sp_mem *smem,
-				 struct ffa_mem_region *mem_reg)
+				 struct ffa_mem_region *mem_reg,
+				 uint8_t highest_permission)
 {
 	uint64_t page_count = READ_ONCE(mem_reg->total_page_count);
 	struct sp_mem_map_region *region = NULL;
@@ -259,6 +288,12 @@ static int spmc_sp_add_nw_region(struct sp_mem *smem,
 	if (!sp_has_exclusive_access(region, NULL)) {
 		free(region);
 		res = FFA_DENIED;
+		goto clean_up;
+	}
+
+	res = mem_set_cache_type(smem, highest_permission, m);
+	if (res) {
+		free(region);
 		goto clean_up;
 	}
 
@@ -344,7 +379,7 @@ int spmc_sp_add_share(struct ffa_rxtx *rxtx,
 				goto cleanup;
 		}
 	} else {
-		res = spmc_sp_add_nw_region(smem, mem_reg);
+		res = spmc_sp_add_nw_region(smem, mem_reg, highest_permission);
 		if (res)
 			goto cleanup;
 	}

--- a/core/include/mm/sp_mem.h
+++ b/core/include/mm/sp_mem.h
@@ -81,4 +81,6 @@ void sp_mem_add(struct sp_mem *smem);
 struct mobj *sp_mem_new_mobj(uint64_t pages);
 int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 		     paddr_t pa, unsigned int num_pages);
+void sp_mem_set_cattr(struct mobj *mobj, uint32_t cache_type);
+TEE_Result sp_mem_ffa_dev_to_cache_type(uint8_t dev_type, uint32_t *cache_type);
 #endif /*__MM_SP_MEM_H*/


### PR DESCRIPTION
Add support for FF-A SPs to map device memory. 
For SPs to be able to map memory as a device memory region the following changes have to be made:

-Extend `mmu_lpae` to be able to map the different device types.
-Extend sp_mem to allow to map device memory
-Extend the FF-A sharing messages to support memory to be mapped as a device region.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
