### PR TITLE
scripts/sign_encrypt.py: Support verification of a signed TA

### DIFF
--- a/scripts/sign_encrypt.py
+++ b/scripts/sign_encrypt.py
@@ -32,7 +32,7 @@ def int_parse(str):
 def get_args(logger):
     from argparse import ArgumentParser, RawDescriptionHelpFormatter
     import textwrap
-    command_base = ['sign-enc', 'digest', 'stitch']
+    command_base = ['sign-enc', 'digest', 'stitch', 'verify']
     command_aliases_digest = ['generate-digest']
     command_aliases_stitch = ['stitch-ta']
     command_aliases = command_aliases_digest + command_aliases_stitch
@@ -64,7 +64,9 @@ def get_args(logger):
         '                 TA raw image and its signature. Takes' +
         ' arguments --uuid, --in, --key, --out,\n' +
         '                 --enc-key (optional), --enc-key-type (optional),\n' +
-        '                 --algo (optional) and --sig.\n\n' +
+        '                 --algo (optional) and --sig.\n' +
+        '     verify      Verify signed TA binary\n' +
+        '                 Takes arguments --uuid, --in, --key\n\n' +
         '   %(prog)s --help  show available commands and arguments\n\n',
         formatter_class=RawDescriptionHelpFormatter,
         epilog=textwrap.dedent('''\
@@ -327,13 +329,81 @@ def main():
             write_image_with_signature(sig)
             logger.info('Successfully applied signature.')
 
+    def verify_ta():
+        # Extract header
+        [magic,
+         img_type,
+         img_size,
+         algo_value,
+         digest_len,
+         sig_len] = struct.unpack('<IIIIHH', img[:SHDR_SIZE])
+
+        # Extract digest and signature
+        start, end = SHDR_SIZE, SHDR_SIZE + digest_len
+        digest = img[start:end]
+
+        start, end = end, SHDR_SIZE + digest_len + sig_len
+        signature = img[start:end]
+
+        # Extract UUID and TA version
+        start, end = end, end + 16 + 4
+        [uuid, ta_version] = struct.unpack('<16sI', img[start:end])
+
+        if magic != SHDR_MAGIC:
+            raise Exception("Un-expected magic: 0x{:08x}".format(magic))
+
+        if img_type != SHDR_BOOTSTRAP_TA:
+            raise Exception("Un-supported image type: {}".format(img_type))
+
+        if algo_value not in algo.values():
+            raise Exception('Un-recognized algorithm: 0x{:08x}'
+                            .format(algo_value))
+
+        # Verify signature against hash digest
+        if algo_value == 0x70414930:
+            key.verify(
+                signature,
+                digest,
+                padding.PSS(
+                    mgf=padding.MGF1(chosen_hash),
+                    salt_length=digest_len
+                ),
+                utils.Prehashed(chosen_hash)
+            )
+        else:
+            key.verify(
+                signature,
+                digest,
+                padding.PKCS1v15(),
+                utils.Prehashed(chosen_hash)
+            )
+
+        h = hashes.Hash(chosen_hash, default_backend())
+
+        # sizeof(struct shdr)
+        h.update(img[:SHDR_SIZE])
+
+        # sizeof(struct shdr_bootstrap_ta)
+        h.update(img[start:end])
+
+        # raw image
+        start = end
+        end += img_size
+        h.update(img[start:end])
+
+        if digest != h.finalize():
+            raise Exception('Hash digest does not match')
+
+        logger.info('Trusted application is correctly verified.')
+
     # dispatch command
     {
         'sign-enc': sign_encrypt_ta,
         'digest': generate_digest,
         'generate-digest': generate_digest,
         'stitch': stitch_ta,
-        'stitch-ta': stitch_ta
+        'stitch-ta': stitch_ta,
+        'verify': verify_ta,
     }.get(args.command, 'sign_encrypt_ta')()
 
 


### PR DESCRIPTION
Adds a new option 'verify' to sign_encrypt.py to verify whether a
Trusted Application is signed correctly.

Required arguments: --uuid, --in, --key
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
