### PR TITLE
core: fix link error with CFG_CC_OPT_LEVEL=0

### DIFF
--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -17,17 +17,25 @@
 void spmc_sp_thread_entry(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
 void spmc_sp_msg_handler(struct thread_smc_args *args,
 			 struct sp_session *caller_sp);
-int spmc_sp_add_share(struct ffa_rxtx *rxtx,
-		      size_t blen, uint64_t *global_handle,
-		      struct sp_session *owner_sp);
 bool ffa_mem_reclaim(struct thread_smc_args *args,
 		     struct sp_session *caller_sp);
 
 #ifdef CFG_SECURE_PARTITION
 void spmc_sp_start_thread(struct thread_smc_args *args);
+int spmc_sp_add_share(struct ffa_rxtx *rxtx,
+		      size_t blen, uint64_t *global_handle,
+		      struct sp_session *owner_sp);
 #else
 static inline void spmc_sp_start_thread(struct thread_smc_args *args __unused)
 {
+}
+
+static inline int spmc_sp_add_share(struct ffa_rxtx *rxtx __unused,
+				    size_t blen __unused,
+				    uint64_t *global_handle __unused,
+				    struct sp_session *owner_sp __unused)
+{
+	return FFA_NOT_SUPPORTED;
 }
 #endif
 


### PR DESCRIPTION
Prior to this patch there's a link error when compiled with
CFG_CC_OPT_LEVEL=0 CFG_CORE_SEL1_SPMC=y CFG_SECURE_PARTITION=n:
  LD      out/arm/core/all_objs.o
aarch64-linux-gnu-ld.bfd: out/arm/core/arch/arm/kernel/thread_spmc.o: in function `handle_mem_share_rxbuf':
core/arch/arm/kernel/thread_spmc.c:781: undefined reference to `spmc_sp_add_share'

Fix this by adding a dummy static inline spmc_sp_add_share().

Fixes: 6a1b230ce97c ("core: FFA_SHARE: Process Normal World share")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
