### PR TITLE
core: the FF-A ABI is now a stable ABI

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -92,8 +92,6 @@ endif
 
 # SPMC configuration "S-EL1 SPMC" where SPM Core is implemented at S-EL1,
 # that is, OP-TEE.
-# Note that this is an experimental feature, ABIs etc may have incompatible
-# changes
 ifeq ($(CFG_CORE_SEL1_SPMC),y)
 $(call force,CFG_CORE_FFA,y)
 $(call force,CFG_CORE_SEL2_SPMC,n)


### PR DESCRIPTION
The OP-TEE FF-A driver in the Linux kernel has been merged, so the
changes in the ABI towards the Linux kernel from now on have to be
backwards compatible.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
