### PR TITLE
core: define DT drivers using scattered arrays

### DIFF
--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -130,11 +130,6 @@ SECTIONS
 		*(.rodata .rodata.__unpaged .rodata.__unpaged.*)
 #include <rodata_unpaged.ld.S>
 #else
-#ifdef CFG_DT
-		__rodata_dtdrv_start = .;
-		KEEP(*(.rodata.dtdrv))
-		__rodata_dtdrv_end = .;
-#endif
 		*(.rodata .rodata.*)
 		. = ALIGN(8);
 		KEEP(*(SORT(.scattered_array*)));
@@ -341,11 +336,6 @@ SECTIONS
 	__flatmap_init_ro_size = __init_end - __flatmap_init_ro_start;
 
 	.rodata_pageable : ALIGN(8) {
-#ifdef CFG_DT
-		__rodata_dtdrv_start = .;
-		KEEP(*(.rodata.dtdrv))
-		__rodata_dtdrv_end = .;
-#endif
 		*(.rodata*)
 	}
 

--- a/core/drivers/atmel_rstc.c
+++ b/core/drivers/atmel_rstc.c
@@ -54,7 +54,7 @@ static const struct dt_device_match atmel_rstc_match_table[] = {
 	{ }
 };
 
-const struct dt_driver atmel_rstc_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(atmel_rstc_dt_driver) = {
 	.name = "atmel_rstc",
 	.type = DT_DRIVER_NOTYPE,
 	.match_table = atmel_rstc_match_table,

--- a/core/drivers/atmel_shdwc.c
+++ b/core/drivers/atmel_shdwc.c
@@ -174,7 +174,7 @@ static const struct dt_device_match atmel_shdwc_match_table[] = {
 	{ }
 };
 
-const struct dt_driver atmel_shdwc_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(atmel_shdwc_dt_driver) = {
 	.name = "atmel_shdwc",
 	.type = DT_DRIVER_NOTYPE,
 	.match_table = atmel_shdwc_match_table,

--- a/core/drivers/atmel_trng.c
+++ b/core/drivers/atmel_trng.c
@@ -147,7 +147,7 @@ static const struct dt_device_match atmel_trng_match_table[] = {
 	{ }
 };
 
-const struct dt_driver atmel_trng_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(atmel_trng_dt_driver) = {
 	.name = "atmel_trng",
 	.type = DT_DRIVER_NOTYPE,
 	.match_table = atmel_trng_match_table,

--- a/core/drivers/imx_lpuart.c
+++ b/core/drivers/imx_lpuart.c
@@ -125,7 +125,7 @@ static const struct dt_device_match imx_match_table[] = {
 	{ 0 }
 };
 
-const struct dt_driver imx_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(imx_dt_driver) = {
 	.name = "imx_lpuart",
 	.type = DT_DRIVER_UART,
 	.match_table = imx_match_table,

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -192,7 +192,7 @@ static const struct dt_device_match imx_match_table[] = {
 	{ 0 }
 };
 
-const struct dt_driver imx_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(imx_dt_driver) = {
 	.name = "imx_uart",
 	.type = DT_DRIVER_UART,
 	.match_table = imx_match_table,

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -222,7 +222,7 @@ static const struct dt_device_match pl011_match_table[] = {
 	{ 0 }
 };
 
-const struct dt_driver pl011_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(pl011_dt_driver) = {
 	.name = "pl011",
 	.type = DT_DRIVER_UART,
 	.match_table = pl011_match_table,

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -158,7 +158,7 @@ static const struct dt_device_match serial8250_match_table[] = {
 	{ 0 }
 };
 
-const struct dt_driver serial8250_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(serial8250_dt_driver) = {
 	.name = "serial8250_uart",
 	.type = DT_DRIVER_UART,
 	.match_table = serial8250_match_table,

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -8,6 +8,7 @@
 
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
+#include <scattered_array.h>
 #include <stdint.h>
 #include <sys/queue.h>
 
@@ -22,7 +23,7 @@
 		{ .compatible = __compat }, \
 		{ } \
 	}; \
-	const struct dt_driver __name ## _dt_driver __dt_driver = { \
+	DEFINE_DT_DRIVER(__name ## _dt_driver) = { \
 		.name = # __name, \
 		.type = DT_DRIVER_CLK, \
 		.match_table = __name ## _match_table, \

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -33,16 +33,6 @@ const struct dt_driver *dt_find_compatible_driver(const void *fdt, int offs)
 	return NULL;
 }
 
-const struct dt_driver *__dt_driver_start(void)
-{
-	return &__rodata_dtdrv_start;
-}
-
-const struct dt_driver *__dt_driver_end(void)
-{
-	return &__rodata_dtdrv_end;
-}
-
 bool dt_have_prop(const void *fdt, int offs, const char *propname)
 {
 	const void *prop;

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -758,7 +758,7 @@ static const struct dt_device_match simple_bus_match_table[] = {
 	{ }
 };
 
-const struct dt_driver simple_bus_dt_driver __dt_driver = {
+DEFINE_DT_DRIVER(simple_bus_dt_driver) = {
 	.name = "simple-bus",
 	.match_table = simple_bus_match_table,
 	.probe = simple_bus_probe,


### PR DESCRIPTION
Replace the specific mechanism used to define and enumerate DT drivers
with scattered arrays. Doing so simplifies the TEE linker file a bit.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
