### PR TITLE
Enable CAAM driver on imx8qm/qxp

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -186,7 +186,6 @@ $(call force,CFG_IMX_SNVS,n)
 CFG_IMX_LPUART ?= y
 CFG_DRAM_BASE ?= 0x80000000
 CFG_TEE_CORE_NB_CORE ?= 6
-$(call force,CFG_NXP_CAAM,n)
 $(call force,CFG_IMX_OCOTP,n)
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8qx-flavorlist)))
 $(call force,CFG_MX8QX,y)
@@ -195,7 +194,6 @@ $(call force,CFG_IMX_SNVS,n)
 CFG_IMX_LPUART ?= y
 CFG_DRAM_BASE ?= 0x80000000
 CFG_TEE_CORE_NB_CORE ?= 4
-$(call force,CFG_NXP_CAAM,n)
 $(call force,CFG_IMX_OCOTP,n)
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")

--- a/core/arch/arm/plat-imx/crypto_conf.mk
+++ b/core/arch/arm/plat-imx/crypto_conf.mk
@@ -37,10 +37,12 @@ CFG_CAAM_SGT_ALIGN ?= 1
 CFG_NXP_CAAM_SGT_V1 ?= y
 
 ifeq ($(filter y, $(CFG_MX8QM) $(CFG_MX8QX)),y)
+$(call force, CFG_CAAM_SIZE_ALIGN,4)
 $(call force, CFG_JR_BLOCK_SIZE,0x10000)
 $(call force,CFG_JR_INDEX,3)
 $(call force,CFG_JR_INT,486)
 else
+$(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force, CFG_JR_BLOCK_SIZE,0x1000)
 $(call force, CFG_JR_INDEX,0)
 $(call force, CFG_JR_INT,137)

--- a/core/arch/arm/plat-imx/crypto_conf.mk
+++ b/core/arch/arm/plat-imx/crypto_conf.mk
@@ -36,15 +36,15 @@ CFG_CAAM_SGT_ALIGN ?= 1
 # Version of the SGT implementation to use
 CFG_NXP_CAAM_SGT_V1 ?= y
 
-#
-# CAAM Job Ring configuration
-#  - Normal boot settings
-#  - HAB support boot settings
-#
+ifeq ($(filter y, $(CFG_MX8QM) $(CFG_MX8QX)),y)
+$(call force, CFG_JR_BLOCK_SIZE,0x10000)
+$(call force,CFG_JR_INDEX,3)
+$(call force,CFG_JR_INT,486)
+else
 $(call force, CFG_JR_BLOCK_SIZE,0x1000)
-
-$(call force, CFG_JR_INDEX,0)  # Default JR index used
-$(call force, CFG_JR_INT,137)  # Default JR IT Number (105 + 32) = 137
+$(call force, CFG_JR_INDEX,0)
+$(call force, CFG_JR_INT,137)
+endif
 
 #
 # Configuration of the Crypto Driver

--- a/core/arch/arm/plat-ls/crypto_conf.mk
+++ b/core/arch/arm/plat-ls/crypto_conf.mk
@@ -32,6 +32,8 @@ $(call force, CFG_CAAM_SGT_ALIGN,4)
 # Enable the BLOB module used for the hardware unique key
 CFG_NXP_CAAM_BLOB_DRV ?= y
 
+$(call force, CFG_CAAM_SIZE_ALIGN,1)
+
 #
 # CAAM Job Ring configuration
 #  - Normal boot settings

--- a/core/drivers/crypto/caam/utils/utils_mem.c
+++ b/core/drivers/crypto/caam/utils/utils_mem.c
@@ -46,6 +46,10 @@ static void *mem_alloc(size_t size, uint8_t type)
 	if (type & MEM_TYPE_ALIGN) {
 		size_t cacheline_size = dcache_get_line_size();
 
+		if (ROUNDUP_OVERFLOW(alloc_size, CFG_CAAM_SIZE_ALIGN,
+				     &alloc_size))
+			return NULL;
+
 		if (ROUNDUP_OVERFLOW(alloc_size, cacheline_size, &alloc_size))
 			return NULL;
 


### PR DESCRIPTION
Hello,

Here is the last PR that will enable the CAAM support for mx8qmmek and mx8qxpmek platforms.

Thanks!