### PR TITLE
crypto: drivers: se050: ecc sign/verify padding

### DIFF
--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -147,28 +147,39 @@ static TEE_Result ecc_get_key_size(uint32_t curve, uint32_t algo,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result ecc_get_msg_size(uint32_t algo, size_t *len)
+static TEE_Result ecc_prepare_msg(uint32_t algo, const uint8_t *msg,
+				  size_t *msg_len, uint8_t **msg_padded)
 {
-	switch (algo) {
-	case kAlgorithm_SSS_ECDSA_SHA1:
-		*len = MIN((size_t)TEE_SHA1_HASH_SIZE, *len);
+	struct {
+		uint32_t algo;
+		size_t len;
+	} map[] = {
+		{ kAlgorithm_SSS_ECDSA_SHA1, TEE_SHA1_HASH_SIZE },
+		{ kAlgorithm_SSS_ECDSA_SHA224, TEE_SHA224_HASH_SIZE },
+		{ kAlgorithm_SSS_ECDSA_SHA256, TEE_SHA256_HASH_SIZE },
+		{ kAlgorithm_SSS_ECDSA_SHA384, TEE_SHA384_HASH_SIZE },
+		{ kAlgorithm_SSS_ECDSA_SHA512, TEE_SHA512_HASH_SIZE },
+	};
+	uint32_t i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(map); i++) {
+		if (algo != map[i].algo)
+			continue;
+		if (*msg_len >= map[i].len) {
+			/* truncate */
+			*msg_len = map[i].len;
+			return TEE_SUCCESS;
+		}
 		break;
-	case kAlgorithm_SSS_ECDSA_SHA224:
-		*len = MIN((size_t)TEE_SHA224_HASH_SIZE, *len);
-		break;
-	case kAlgorithm_SSS_ECDSA_SHA256:
-		*len = MIN((size_t)TEE_SHA256_HASH_SIZE, *len);
-		break;
-	case kAlgorithm_SSS_ECDSA_SHA384:
-		*len = MIN((size_t)TEE_SHA384_HASH_SIZE, *len);
-		break;
-	case kAlgorithm_SSS_ECDSA_SHA512:
-		*len = MIN((size_t)TEE_SHA512_HASH_SIZE, *len);
-		break;
-	default:
-		EMSG("invalid se050 %#"PRIx32" algorithm", algo);
-		return TEE_ERROR_BAD_PARAMETERS;
 	}
+
+	/* pad */
+	*msg_padded = calloc(1, map[i].len);
+	if (!*msg_padded)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memcpy(*msg_padded, msg, *msg_len);
+	*msg_len = map[i].len;
 
 	return TEE_SUCCESS;
 }
@@ -403,6 +414,7 @@ static TEE_Result sign(uint32_t algo, struct ecc_keypair *key,
 	size_t sig_der_len = 0;
 	size_t key_bytes = 0;
 	size_t key_bits = 0;
+	uint8_t *p = NULL;
 
 	res = ecc_get_key_size(key->curve, algo, &key_bytes, &key_bits);
 	if (res != TEE_SUCCESS)
@@ -417,7 +429,8 @@ static TEE_Result sign(uint32_t algo, struct ecc_keypair *key,
 		goto exit;
 	}
 
-	res = ecc_get_msg_size(algo_tee2se050(algo), &msg_len);
+	/* truncate or pad the message as needed */
+	res = ecc_prepare_msg(algo_tee2se050(algo), msg, &msg_len, &p);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
@@ -433,8 +446,8 @@ static TEE_Result sign(uint32_t algo, struct ecc_keypair *key,
 		goto exit;
 	}
 
-	st = sss_se05x_asymmetric_sign_digest(&ctx, (uint8_t *)msg, msg_len,
-					      sig_der, &sig_der_len);
+	st = sss_se05x_asymmetric_sign_digest(&ctx, p ? p : (uint8_t *)msg,
+					      msg_len, sig_der, &sig_der_len);
 	if (st != kStatus_SSS_Success) {
 		EMSG("curve: %#"PRIx32, key->curve);
 		res = TEE_ERROR_BAD_PARAMETERS;
@@ -457,6 +470,7 @@ exit:
 	sss_se05x_asymmetric_context_free(&ctx);
 
 	free(sig_der);
+	free(p);
 
 	return res;
 }
@@ -473,12 +487,14 @@ static TEE_Result verify(uint32_t algo, struct ecc_public_key *key,
 	size_t signature_len = sizeof(signature);
 	size_t key_bytes = 0;
 	size_t key_bits = 0;
+	uint8_t *p = NULL;
 
 	res = ecc_get_key_size(key->curve, algo, &key_bytes, &key_bits);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	res = ecc_get_msg_size(algo_tee2se050(algo), &msg_len);
+	/* truncate or pad the message as needed */
+	res = ecc_prepare_msg(algo_tee2se050(algo), msg, &msg_len, &p);
 	if (res != TEE_SUCCESS)
 		goto exit;
 
@@ -501,14 +517,15 @@ static TEE_Result verify(uint32_t algo, struct ecc_public_key *key,
 		goto exit;
 	}
 
-	st = sss_se05x_asymmetric_verify_digest(&ctx, (uint8_t *)msg, msg_len,
-						(uint8_t *)signature,
+	st = sss_se05x_asymmetric_verify_digest(&ctx, p ? p : (uint8_t *)msg,
+						msg_len, (uint8_t *)signature,
 						signature_len);
 	if (st != kStatus_SSS_Success)
 		res = TEE_ERROR_SIGNATURE_INVALID;
 exit:
 	sss_se05x_key_store_erase_key(se050_kstore, &kobject);
 	sss_se05x_asymmetric_context_free(&ctx);
+	free(p);
 
 	return res;
 }


### PR DESCRIPTION
Pad small messages with zeroes during sign/verify.
Fixes xtest pkcs11_1019

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
