### PR TITLE
core: imx: add support for i.MX8DXL

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -167,6 +167,7 @@ jobs:
           _make PLATFORM=imx-mx8mpevk
           _make PLATFORM=imx-mx8qxpmek
           _make PLATFORM=imx-mx8qmmek
+          _make PLATFORM=imx-mx8dxlevk
           _make PLATFORM=k3-j721e
           _make PLATFORM=k3-j721e CFG_ARM64_core=y
           _make PLATFORM=k3-am65x

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -79,6 +79,9 @@ mx8qm-flavorlist = \
 mx8qx-flavorlist = \
 	mx8qxpmek \
 
+mx8dxl-flavorlist = \
+	mx8dxlevk \
+
 ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6ul-flavorlist)))
 $(call force,CFG_MX6,y)
 $(call force,CFG_MX6UL,y)
@@ -195,6 +198,15 @@ CFG_IMX_LPUART ?= y
 CFG_DRAM_BASE ?= 0x80000000
 CFG_TEE_CORE_NB_CORE ?= 4
 $(call force,CFG_IMX_OCOTP,n)
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8dxl-flavorlist)))
+$(call force,CFG_MX8DXL,y)
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_IMX_SNVS,n)
+CFG_IMX_LPUART ?= y
+CFG_DRAM_BASE ?= 0x80000000
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+$(call force,CFG_IMX_OCOTP,n)
+$(call force,CFG_NXP_CAAM,n)
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif
@@ -363,6 +375,11 @@ CFG_NSEC_DDR_1_SIZE  ?= 0x380000000UL
 CFG_CORE_ARM64_PA_BITS ?= 40
 endif
 
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx8dxlevk))
+CFG_DDR_SIZE ?= 0x40000000
+CFG_UART_BASE ?= UART0_BASE
+endif
+
 # i.MX6 Solo/SL/SoloX/DualLite/Dual/Quad specific config
 ifeq ($(filter y, $(CFG_MX6QP) $(CFG_MX6Q) $(CFG_MX6D) $(CFG_MX6DL) $(CFG_MX6S) \
 	$(CFG_MX6SL) $(CFG_MX6SLL) $(CFG_MX6SX)), y)
@@ -460,7 +477,7 @@ CFG_IMX_OCOTP ?= y
 CFG_NXP_CAAM ?= n
 
 ifeq ($(CFG_NXP_CAAM),y)
-ifeq ($(filter y, $(CFG_MX8QM) $(CFG_MX8QX)), y)
+ifeq ($(filter y, $(CFG_MX8QM) $(CFG_MX8QX) $(CFG_MX8DXL)), y)
 CFG_IMX_SC ?= y
 endif
 

--- a/core/arch/arm/plat-imx/imx-common.c
+++ b/core/arch/arm/plat-imx/imx-common.c
@@ -62,6 +62,8 @@ uint32_t imx_get_digprog(void)
 		imx_digprog = SOC_MX8QX << 16;
 	else if (IS_ENABLED(CFG_MX8QM))
 		imx_digprog = SOC_MX8QM << 16;
+	else if (IS_ENABLED(CFG_MX8DXL))
+		imx_digprog = SOC_MX8DXL << 16;
 
 	return imx_digprog;
 }

--- a/core/arch/arm/plat-imx/imx-regs.h
+++ b/core/arch/arm/plat-imx/imx-regs.h
@@ -39,10 +39,10 @@
 #elif defined(CFG_MX8MQ) || defined(CFG_MX8MM) || defined(CFG_MX8MN) || \
 	defined(CFG_MX8MP)
 #include <registers/imx8m.h>
-#elif defined(CFG_MX8QX) || defined(CFG_MX8QM)
+#elif defined(CFG_MX8QX) || defined(CFG_MX8QM) || defined(CFG_MX8DXL)
 #include <registers/imx8q.h>
 #else
-#error "CFG_MX6/7/7ULP or CFG_MX8MQ/8MM/8MN/8MP/8QX/8QM is not defined"
+#error "CFG_MX6/7/7ULP or CFG_MX8MQ/8MM/8MN/8MP/8QX/8QM/8DXL is not defined"
 #endif
 
 #define IOMUXC_GPR4_OFFSET	0x10

--- a/core/arch/arm/plat-imx/imx.h
+++ b/core/arch/arm/plat-imx/imx.h
@@ -22,6 +22,7 @@
 #define SOC_MX7ULP	0xE1
 #define SOC_MX8QX	0xE2
 #define SOC_MX8QM	0xE3
+#define SOC_MX8DXL	0xE4
 #define SOC_MX8M	0x82
 
 #ifndef __ASSEMBLER__


### PR DESCRIPTION
Hello!
A patch to add the i.MX 8DXL platform support.
Please note that the CAAM is currently disabled and will be enabled later.

Thanks,
Clement