### PR TITLE
scripts/sign_encrypt.py: Support signing TAs using AWS KMS

### DIFF
--- a/scripts/sign_helper_kms.py
+++ b/scripts/sign_helper_kms.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright Amazon.com Inc. or its affiliates
+#
+import typing
+
+import boto3
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import (
+    AsymmetricSignatureContext,
+    utils as asym_utils,
+)
+from cryptography.hazmat.primitives.asymmetric.padding import (
+    AsymmetricPadding,
+    PKCS1v15,
+    PSS,
+)
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+    RSAPrivateKey,
+    RSAPrivateNumbers,
+    RSAPublicKey,
+)
+
+
+class _RSAPrivateKeyInKMS(RSAPrivateKey):
+
+    def __init__(self, arn):
+        self.arn = arn
+        self.client = boto3.client('kms')
+        response = self.client.get_public_key(KeyId=self.arn)
+
+        # Parse public key
+        self.public_key = serialization.load_der_public_key(
+                response['PublicKey'])
+
+    @property
+    def key_size(self):
+        return self.public_key.key_size
+
+    def public_key(self) -> RSAPublicKey:
+        return self.public_key
+
+    def sign(self, data: bytes, padding: AsymmetricPadding,
+             algorithm: typing.Union[asym_utils.Prehashed,
+                                     hashes.HashAlgorithm]
+             ) -> bytes:
+        if isinstance(algorithm, asym_utils.Prehashed):
+            message_type = 'DIGEST'
+        else:
+            message_type = 'RAW'
+
+        if isinstance(padding, PSS):
+            signing_alg = 'RSASSA_PSS_'
+        elif isinstance(padding, PKCS1v15):
+            signing_alg = 'RSASSA_PKCS1_V1_5_'
+        else:
+            raise TypeError("Unsupported padding")
+
+        if (isinstance(algorithm._algorithm, hashes.SHA256) or
+                isinstance(algorithm, hashes.SHA256)):
+            signing_alg += 'SHA_256'
+        elif (isinstance(algorithm._algorithm, hashes.SHA384) or
+                isinstance(algorithm, hashes.SHA384)):
+            signing_alg += 'SHA_384'
+        elif (isinstance(algorithm._algorithm, hashes.SHA512) or
+                isinstance(algorithm, hashes.SHA512)):
+            signing_alg += 'SHA_512'
+        else:
+            raise TypeError("Unsupported hashing algorithm")
+
+        response = self.client.sign(
+                KeyId=self.arn, Message=data,
+                MessageType=message_type,
+                SigningAlgorithm=signing_alg)
+
+        return response['Signature']
+
+    # No need to implement these functions so we raise an exception
+    def signer(
+        self, padding: AsymmetricPadding, algorithm: hashes.HashAlgorithm
+    ) -> AsymmetricSignatureContext:
+        raise NotImplementedError
+
+    def decrypt(self, ciphertext: bytes, padding: AsymmetricPadding) -> bytes:
+        raise NotImplementedError
+
+    def private_numbers(self) -> RSAPrivateNumbers:
+        raise NotImplementedError
+
+    def private_bytes(
+        self,
+        encoding: serialization.Encoding,
+        format: serialization.PrivateFormat,
+        encryption_algorithm: serialization.KeySerializationEncryption
+    ) -> bytes:
+        raise NotImplementedError


### PR DESCRIPTION
This adds support for signing trusted applications (TAs) using
a customer owned AWS KMS asymmetric key.

When the option to --key points to a valid Amazon Resource Name (ARN),
the signing operation will be delegated to AWS KMS. IAM credentials are
provided via environment variables.

Requires boto3 to work correctly.

Signed-off-by: Donald Chan <hoiho@amazon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
