### PR TITLE
drivers: crypto: se050: build plug-and-trust in tree

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
           function upload_cache() { if [ ! -e .uploaded ]; then echo Uploading cache && tar c -C $HOME .ccache | gzip -1 | ssh $SCP_OPT optee_os_ci@cache.forissier.org "cat >ccache-$PROJ.tar.gz" && touch .uploaded || echo Nevermind; fi; }
           function check_upload_cache() { NOW=$(date +%s); if [ $(expr $NOW - $START) -gt 3000 ]; then upload_cache; fi; }
           function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && check_upload_cache; }
-          function download_plug_and_trust() { mkdir -p $HOME/se050 && curl -L https://github.com/foundriesio/plug-and-trust/releases/download/v0.0.4/se050-0.0.4.tar.bz2 | tar jxf - --strip-components=1 -C $HOME/se050 || (rm -rf $HOME/se050; echo Nervermind); }
+          function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.1.0 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
 
           download_cache
           ccache -s
@@ -135,7 +135,7 @@ jobs:
           _make PLATFORM=imx-mx6ulevk CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
           _make PLATFORM=imx-mx6ul9x9evk
           _make PLATFORM=imx-mx6ullevk CFG_WITH_SOFTWARE_PRNG=n CFG_IMX_RNGB=y
-          if [ -d $HOME/se050 ]; then _make PLATFORM=imx-mx6ullevk CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{DIEID,RNG,RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST_LIB=$HOME/se050/buildarm/libse050.a CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050; fi
+          if [ -d $HOME/se050/plug-and-trust ]; then _make PLATFORM=imx-mx6ullevk CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{DIEID,RNG,RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050/plug-and-trust ; fi
           _make PLATFORM=imx-mx6ulzevk
           _make PLATFORM=imx-mx6slevk
           _make PLATFORM=imx-mx6sllevk
@@ -161,7 +161,7 @@ jobs:
           _make PLATFORM=imx-mx7ulpevk
           _make PLATFORM=imx-mx8mmevk
           _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
-          if [ -d $HOME/se050 ]; then _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_NXP_CAAM_RNG_DRV=y CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_NXP_SE05X_RNG_DRV=n CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{DIEID,RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST_LIB=$HOME/se050/build/libse050.a CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050 ; fi
+          if [ -d $HOME/se050/plug-and-trust ]; then _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_NXP_CAAM_RNG_DRV=y CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_NXP_SE05X_RNG_DRV=n CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{DIEID,RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050/plug-and-trust ; fi
           _make PLATFORM=imx-mx8mnevk
           _make PLATFORM=imx-mx8mqevk
           _make PLATFORM=imx-mx8mpevk

--- a/core/drivers/crypto/se050/adaptors/sub.mk
+++ b/core/drivers/crypto/se050/adaptors/sub.mk
@@ -1,6 +1,7 @@
 cflags-y += -Wno-strict-aliasing
-include core/drivers/crypto/se050/cflags.mk
+include ${CFG_NXP_SE05X_PLUG_AND_TRUST}/cflags.mk
 
+incdirs_ext-y += ${CFG_NXP_SE05X_PLUG_AND_TRUST}/optee_lib/include
 incdirs-y += ./include
 
 srcs-y += utils/scp_config.c

--- a/core/drivers/crypto/se050/cflags.mk
+++ b/core/drivers/crypto/se050/cflags.mk
@@ -1,6 +1,0 @@
-cflags-y += -DAX_EMBEDDED=1
-cflags-y += -DUSE_RTOS=0
-cflags-y += -DVERBOSE_APDU_LOGS=0
-cflags-y += -DT1oI2C_UM11225
-cflags-y += -DT1oI2C
-cflags-y += -DSSS_USE_FTR_FILE

--- a/core/drivers/crypto/se050/core/sub.mk
+++ b/core/drivers/crypto/se050/core/sub.mk
@@ -1,5 +1,6 @@
-include core/drivers/crypto/se050/cflags.mk
+include ${CFG_NXP_SE05X_PLUG_AND_TRUST}/cflags.mk
 
+incdirs_ext-y += ${CFG_NXP_SE05X_PLUG_AND_TRUST}/optee_lib/include
 incdirs-y += ../adaptors/include
 incdirs-y += include
 

--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -81,6 +81,4 @@ ifeq ($(CFG_NXP_SE05X_CIPHER_DRV),y)
 $(call force,CFG_CRYPTO_DRV_CIPHER,y,Mandated by CFG_NXP_SE05X_CIPHER_DRV)
 endif
 
-# Plug and Trust NXP SE050X OP-TEE enabled static library
-ldflags-external += $(CFG_NXP_SE05X_PLUG_AND_TRUST_LIB)
 endif  # CFG_NXP_SE05X

--- a/core/drivers/crypto/se050/sub.mk
+++ b/core/drivers/crypto/se050/sub.mk
@@ -1,10 +1,11 @@
-core-platform-cflags += "-I${CFG_NXP_SE05X_PLUG_AND_TRUST}/optee_lib/include"
-include core/drivers/crypto/se050/cflags.mk
+include ${CFG_NXP_SE05X_PLUG_AND_TRUST}/cflags.mk
 
+incdirs_ext-y += ${CFG_NXP_SE05X_PLUG_AND_TRUST}/optee_lib/include
 incdirs-y += adaptors/include
 
 subdirs-y += adaptors
 subdirs-y += core
+subdirs_ext-y += ${CFG_NXP_SE05X_PLUG_AND_TRUST}
 
 srcs-y += session.c
 srcs-y += glue/i2c.c

--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -137,9 +137,9 @@ sub-dir-out := $(out-dir)/$(base-prefix)$1
 endif
 
 include $1/sub.mk
-sub-subdirs := $$(addprefix $1/,$$(subdirs-y))
+sub-subdirs := $$(addprefix $1/,$$(subdirs-y)) $$(subdirs_ext-y)
 incdirs$(sm) := $(incdirs$(sm)) $$(addprefix $1/,$$(global-incdirs-y))
-thissubdir-incdirs := $(out-dir)/$(base-prefix)$1 $$(addprefix $1/,$$(incdirs-y))
+thissubdir-incdirs := $(out-dir)/$(base-prefix)$1 $$(addprefix $1/,$$(incdirs-y)) $$(incdirs_ext-y)
 ifneq ($$(libname),)
 incdirs-lib$$(libname)-$$(sm) := $$(incdirs-lib$$(libname)-$$(sm)) $$(addprefix $1/,$$(incdirs-lib-y))
 cflags-lib$$(libname)-$$(sm) := $$(cflags-lib$$(libname)-$$(sm)) $$(cflags-lib-y)
@@ -164,9 +164,11 @@ cflags-remove-y :=
 cxxflags-remove-y :=
 aflags-remove-y :=
 subdirs-y :=
+subdirs_ext-y :=
 global-incdirs-y :=
 incdirs-lib-y :=
 incdirs-y :=
+incdirs_ext-y :=
 gensrcs-y :=
 this-out-dir :=
 asm-defines-y :=


### PR DESCRIPTION
Building the Plug-and-Trust library required building OP-TEE first in
order to get some architecture specific definitions. This makes the
integration with Yocto metas unnecessarily complex.

The following commit simplifies the build sequence: the user would
clone the Plug-and-Trust tree [1] into the external (ext) folder and
build OP-TEE as usual.

[1] https://github.com/foundriesio/plug-and-trust.git

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
