### PR TITLE
core: Fix flags and tag check_retrieve_request()

### DIFF
--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -377,8 +377,8 @@ static TEE_Result check_retrieve_request(struct sp_mem_receiver *receiver,
 	struct ffa_mem_access *retr_access = NULL;
 	uint8_t share_perm = receiver->perm.perm;
 	uint32_t retr_perm = 0;
-	uint32_t retr_flags = READ_ONCE(retr_dsc->tag);
-	uint64_t retr_tag = READ_ONCE(retr_dsc->flags);
+	uint32_t retr_flags = READ_ONCE(retr_dsc->flags);
+	uint64_t retr_tag = READ_ONCE(retr_dsc->tag);
 	struct sp_mem_map_region *reg = NULL;
 
 	/*


### PR DESCRIPTION
Inside check_retrieve_request() the flags and tag where swapped.
Store them in the correct variable.

Signed-off-by: Jelle Sels <jelle.sels@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
