### PR TITLE
core: plat-ls: ls1028a: fix uart address

### DIFF
--- a/core/arch/arm/plat-ls/platform_config.h
+++ b/core/arch/arm/plat-ls/platform_config.h
@@ -100,7 +100,7 @@
 
 #if defined(PLATFORM_FLAVOR_ls1028ardb)
 /*  DUART 1 */
-#define UART0_BASE			0x021C0600
+#define UART0_BASE			0x021C0500
 #define GIC_BASE			0x06000000
 #define GICC_OFFSET			0x0
 #define GICD_OFFSET			0x0


### PR DESCRIPTION
Fix UART0_BASE address for LS1028 platform

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>