### PR TITLE
arm: Add Aspeed AST2600 platform support

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -280,6 +280,13 @@ R:	Volodymyr Babchuk <vlad.babchuk@gmail.com>
 S:	Maintained
 F:	core/arch/arm/kernel/virtualization.c
 
+Aspeed AST2600
+R:	Chia-Wei Wang <chiawei_wang@aspeedtech.com> [@ChiaweiW]
+R:	Neal Liu <neal_liu@aspeedtech.com> [@Neal-liu]
+R:	[@OP-TEE/plat-aspeed]
+S:	Maintained
+F:	core/arch/arm/plat-aspeed/
+
 THE REST
 M:	Joakim Bech <joakim.bech@linaro.org> [@jbech-linaro]
 M:	Jens Wiklander <jens.wiklander@linaro.org> [@jenswi-linaro]

--- a/core/arch/arm/plat-aspeed/conf.mk
+++ b/core/arch/arm/plat-aspeed/conf.mk
@@ -1,0 +1,23 @@
+PLATFORM_FLAVOR ?= ast2600
+
+ifeq ($(PLATFORM_FLAVOR),ast2600)
+include core/arch/arm/cpu/cortex-a7.mk
+
+$(call force,CFG_8250_UART,y)
+$(call force,CFG_ARM32_core,y)
+$(call force,CFG_TEE_CORE_NB_CORE,2)
+$(call force,CFG_GIC,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+
+CFG_NUM_THREADS ?= $(CFG_TEE_CORE_NB_CORE)
+
+CFG_DRAM_BASE ?= 0x80000000
+CFG_DRAM_SIZE ?= 0x40000000
+
+CFG_TZDRAM_START ?= 0x88000000
+CFG_TZDRAM_SIZE ?= 0x01000000
+
+CFG_CORE_RESERVED_SHM ?= n
+else
+$(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
+endif

--- a/core/arch/arm/plat-aspeed/core_pos_a32.S
+++ b/core/arch/arm/plat-aspeed/core_pos_a32.S
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Aspeed Technology Inc.
+ */
+
+#include <asm.S>
+#include <arm.h>
+#include <arm32_macros.S>
+
+FUNC get_core_pos_mpidr , :
+	/*
+	 * need this to correct core0 - 0xf00, core1 - 0xf01, ...
+	 */
+	and	r0, r0, #MPIDR_CPU_MASK
+	bx	lr
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-aspeed/platform_ast2600.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2600.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Aspeed Technology Inc.
+ */
+
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/serial8250_uart.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/panic.h>
+
+enum TZM_PERM {
+	TZM_PERM_VGA_CURSOR_RD,
+	TZM_PERM_VGA_CRT_RD,
+	TZM_PERM_SOC_DISPLAY_RD,
+	TZM_PERM_PCIE_BUS1_RW,
+	TZM_PERM_VIDEO_HIGH_WR,
+	TZM_PERM_CPU_RW,
+	TZM_PERM_SLI_RW,
+	TZM_PERM_PCIE_BUS2_RW,
+	TZM_PERM_USB20_HUB_EHCI1_DMA_RW,
+	TZM_PERM_USB20_DEV_EHCI2_DMA_RW,
+	TZM_PERM_USB11_UCHI_HOST_RW,
+	TZM_PERM_AHB_RW,
+	TZM_PERM_CM3_DATA_RW,
+	TZM_PERM_CM3_INSN_RW,
+	TZM_PERM_MAC0_DMA_RW,
+	TZM_PERM_MAC1_DMA_RW,
+	TZM_PERM_SDIO_DMA_RW,
+	TZM_PERM_PILOT_RW,
+	TZM_PERM_XDMA1_RW,
+	TZM_PERM_MCTP1_RW,
+	TZM_PERM_VIDEO_FLAG_RW,
+	TZM_PERM_VIDEO_LOW_WR,
+	TZM_PERM_2D_DATA_RW,
+	TZM_PERM_ENCRYPT_RW,
+	TZM_PERM_MCTP2_RW,
+	TZM_PERM_XDMA2_RW,
+	TZM_PERM_ECC_RSA_RW,
+};
+
+register_phys_mem(MEM_AREA_IO_NSEC,
+		  CONSOLE_UART_BASE,
+		  SMALL_PAGE_SIZE);
+
+register_phys_mem(MEM_AREA_IO_SEC,
+		  GIC_BASE + GICD_OFFSET,
+		  SMALL_PAGE_SIZE);
+
+register_phys_mem(MEM_AREA_IO_SEC,
+		  GIC_BASE + GICC_OFFSET,
+		  SMALL_PAGE_SIZE);
+
+register_phys_mem(MEM_AREA_IO_SEC,
+		  AHBC_BASE,
+		  SMALL_PAGE_SIZE);
+
+#define AHBC_REG_WR_PROT	0x204
+#define AHBC_TZM_ST(i)		(0x300 + ((i) * 0x10))
+#define AHBC_TZM_ED(i)		(0x304 + ((i) * 0x10))
+#define AHBC_TZM_PERM(i)	(0x308 + ((i) * 0x10))
+
+register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
+
+static struct serial8250_uart_data console_data;
+static struct gic_data gic_data;
+
+void main_init_gic(void)
+{
+	vaddr_t gicc_base = 0;
+	vaddr_t gicd_base = 0;
+
+	gicc_base = core_mmu_get_va(GIC_BASE + GICC_OFFSET,
+				    MEM_AREA_IO_SEC, SMALL_PAGE_SIZE);
+	gicd_base = core_mmu_get_va(GIC_BASE + GICD_OFFSET,
+				    MEM_AREA_IO_SEC, SMALL_PAGE_SIZE);
+	if (!gicc_base || !gicd_base)
+		panic();
+
+	gic_init(&gic_data, gicc_base, gicd_base);
+	itr_init(&gic_data.chip);
+}
+
+void main_secondary_init_gic(void)
+{
+	gic_cpu_init(&gic_data);
+}
+
+void itr_core_handler(void)
+{
+	gic_it_handle(&gic_data);
+}
+
+void console_init(void)
+{
+	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+	register_serial_console(&console_data.chip);
+}
+
+void plat_primary_init_early(void)
+{
+	vaddr_t ahbc_virt = 0;
+
+	ahbc_virt = core_mmu_get_va(AHBC_BASE,
+				    MEM_AREA_IO_SEC, SMALL_PAGE_SIZE);
+	if (!ahbc_virt)
+		panic();
+
+	io_write32(ahbc_virt + AHBC_TZM_PERM(0),
+		   BIT(TZM_PERM_CPU_RW));
+	io_write32(ahbc_virt + AHBC_TZM_ED(0),
+		   CFG_TZDRAM_START + CFG_TZDRAM_SIZE - 1);
+	io_write32(ahbc_virt + AHBC_TZM_ST(0),
+		   CFG_TZDRAM_START | BIT(0));
+	io_write32(ahbc_virt + AHBC_REG_WR_PROT, BIT(16));
+}

--- a/core/arch/arm/plat-aspeed/platform_config.h
+++ b/core/arch/arm/plat-aspeed/platform_config.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Aspeed Technology Inc.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT		64
+
+#if defined(PLATFORM_FLAVOR_ast2600)
+#define GIC_BASE		0x40460000
+#define GICC_OFFSET		0x2000
+#define GICD_OFFSET		0x1000
+
+#define AHBC_BASE		0x1e600000
+#define UART5_BASE		0x1e784000
+
+#define CONSOLE_UART_BASE	UART5_BASE
+#define CONSOLE_BAUDRATE	115200
+#define CONSOLE_UART_CLK_IN_HZ	1846153
+#else
+#error "Unknown platform flavor"
+#endif
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-aspeed/sub.mk
+++ b/core/arch/arm/plat-aspeed/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-$(PLATFORM_FLAVOR_ast2600) += platform_ast2600.c core_pos_a32.S


### PR DESCRIPTION
Aspeed AST2600 is a dual-core SoC with ARM Cortex-A7 integrated.
This PR aims to add the initial OP-TEE support for AST2600 platform.