### PR TITLE
core: use a paged scattered array for DT drivers list

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -103,7 +103,7 @@ struct dt_driver {
 };
 
 #define DEFINE_DT_DRIVER(name) \
-		SCATTERED_ARRAY_DEFINE_ITEM(dt_drivers, struct dt_driver)
+		SCATTERED_ARRAY_DEFINE_PG_ITEM(dt_drivers, struct dt_driver)
 
 /*
  * Find a driver that is suitable for the given DT node, that is, with


### PR DESCRIPTION
Fixes macro DEFINE_DT_DRIVER() to use SCATTERED_ARRAY_DEFINE_PG_ITEM()
that defines a paged list whereas SCATTERED_ARRAY_DEFINE_ITEM()
assumes array must be linked in the rodata_init section. Indeed
DT driver probing is done after pager is initialized.

Fixes: 61bdedea9452 ("core: define DT drivers using scattered arrays")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
