### PR TITLE
crypto: drivers: se050: remove implicit dependency

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
           function upload_cache() { if [ ! -e .uploaded ]; then echo Uploading cache && tar c -C $HOME .ccache | gzip -1 | ssh $SCP_OPT optee_os_ci@cache.forissier.org "cat >ccache-$PROJ.tar.gz" && touch .uploaded || echo Nevermind; fi; }
           function check_upload_cache() { NOW=$(date +%s); if [ $(expr $NOW - $START) -gt 3000 ]; then upload_cache; fi; }
           function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && check_upload_cache; }
-          function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.1.0 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
+          function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.1.1 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
 
           download_cache
           ccache -s

--- a/core/drivers/crypto/se050/glue/i2c.c
+++ b/core/drivers/crypto/se050/glue/i2c.c
@@ -5,31 +5,13 @@
  */
 
 #include <compiler.h>
-#include <drivers/imx_i2c.h>
 #include <glue.h>
+#include <i2c_native.h>
 #include <initcall.h>
 #include <kernel/rpc_io_i2c.h>
 #include <phNxpEsePal_i2c.h>
 
 static TEE_Result (*transfer)(struct rpc_i2c_request *req, size_t *bytes);
-
-static TEE_Result native_i2c_transfer(struct rpc_i2c_request *req,
-				      size_t *bytes)
-{
-	TEE_Result ret = TEE_ERROR_GENERIC;
-
-	if (req->mode == RPC_I2C_MODE_READ)
-		ret = imx_i2c_read(req->bus, req->chip, req->buffer,
-				   req->buffer_len);
-	else
-		ret = imx_i2c_write(req->bus, req->chip, req->buffer,
-				    req->buffer_len);
-
-	if (!ret)
-		*bytes = req->buffer_len;
-
-	return ret;
-}
 
 static int i2c_transfer(uint8_t *buffer, int len, enum rpc_i2c_mode mode)
 {
@@ -69,13 +51,7 @@ int glue_i2c_init(void)
 
 	transfer = native_i2c_transfer;
 
-	if (imx_i2c_init(CFG_CORE_SE05X_I2C_BUS, CFG_CORE_SE05X_BAUDRATE))
-		return -1;
-
-	if (imx_i2c_probe(CFG_CORE_SE05X_I2C_BUS, SMCOM_I2C_ADDRESS >> 1))
-		return -1;
-
-	return 0;
+	return native_i2c_init();
 }
 
 static TEE_Result load_trampoline(void)

--- a/core/drivers/crypto/se050/glue/i2c_imx.c
+++ b/core/drivers/crypto/se050/glue/i2c_imx.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) Foundries Ltd. 2022 - All Rights Reserved
+ * Author: Jorge Ramirez <jorge@foundries.io>
+ */
+
+#include <drivers/imx_i2c.h>
+#include <i2c_native.h>
+#include <phNxpEsePal_i2c.h>
+
+TEE_Result native_i2c_transfer(struct rpc_i2c_request *req,
+			       size_t *bytes)
+{
+	TEE_Result ret = TEE_ERROR_GENERIC;
+
+	if (req->mode == RPC_I2C_MODE_READ)
+		ret = imx_i2c_read(req->bus, req->chip, req->buffer,
+				   req->buffer_len);
+	else
+		ret = imx_i2c_write(req->bus, req->chip, req->buffer,
+				    req->buffer_len);
+
+	if (!ret)
+		*bytes = req->buffer_len;
+
+	return ret;
+}
+
+int native_i2c_init(void)
+{
+	if (imx_i2c_init(CFG_CORE_SE05X_I2C_BUS, CFG_CORE_SE05X_BAUDRATE))
+		return -1;
+
+	if (imx_i2c_probe(CFG_CORE_SE05X_I2C_BUS, SMCOM_I2C_ADDRESS >> 1))
+		return -1;
+
+	return 0;
+}

--- a/core/drivers/crypto/se050/glue/include/i2c_native.h
+++ b/core/drivers/crypto/se050/glue/include/i2c_native.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) Foundries Ltd. 2022 - All Rights Reserved
+ * Author: Jorge Ramirez <jorge@foundries.io>
+ */
+
+#ifndef I2C_NATIVE_H_
+#define I2C_NATIVE_H_
+
+#include <kernel/rpc_io_i2c.h>
+
+TEE_Result native_i2c_transfer(struct rpc_i2c_request *req,
+			       size_t *bytes);
+int native_i2c_init(void);
+
+#endif

--- a/core/drivers/crypto/se050/sub.mk
+++ b/core/drivers/crypto/se050/sub.mk
@@ -2,11 +2,13 @@ include ${CFG_NXP_SE05X_PLUG_AND_TRUST}/cflags.mk
 
 incdirs_ext-y += ${CFG_NXP_SE05X_PLUG_AND_TRUST}/optee_lib/include
 incdirs-y += adaptors/include
+incdirs-y += glue/include
 
 subdirs-y += adaptors
 subdirs-y += core
 subdirs_ext-y += ${CFG_NXP_SE05X_PLUG_AND_TRUST}
 
 srcs-y += session.c
+srcs-$(CFG_IMX_I2C) += glue/i2c_imx.c
 srcs-y += glue/i2c.c
 srcs-y += glue/user.c


### PR DESCRIPTION
The SE05X device is platform independent and therefore does not need
the iMX I2C driver but the actual driver for the particular platform
is connected into.

Implementing these changes required a fix in the Plug-and-Trust tree
(the addition of a missing dependency), therefore we will also bump
the Plug-and-Trust version used in the Azure pipeline.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
