### PR TITLE
Ffa el3 spmc

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -95,11 +95,21 @@ endif
 ifeq ($(CFG_CORE_SEL1_SPMC),y)
 $(call force,CFG_CORE_FFA,y)
 $(call force,CFG_CORE_SEL2_SPMC,n)
+$(call force,CFG_CORE_EL3_SPMC,n)
 endif
 # SPMC configuration "S-EL2 SPMC" where SPM Core is implemented at S-EL2,
 # that is, the hypervisor sandboxing OP-TEE
 ifeq ($(CFG_CORE_SEL2_SPMC),y)
 $(call force,CFG_CORE_FFA,y)
+$(call force,CFG_CORE_SEL1_SPMC,n)
+$(call force,CFG_CORE_EL3_SPMC,n)
+endif
+# SPMC configuration "EL3 SPMC" where SPM Core is implemented at EL3, that
+# is, in TF-A
+ifeq ($(CFG_CORE_EL3_SPMC),y)
+$(call force,CFG_CORE_FFA,y)
+$(call force,CFG_CORE_SEL2_SPMC,n)
+$(call force,CFG_CORE_SEL1_SPMC,n)
 endif
 
 # Unmaps all kernel mode code except the code needed to take exceptions

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -31,7 +31,7 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 void spmc_fill_partition_entry(struct ffa_partition_info *fpi,
 			       uint16_t endpoint_id,
 			       uint16_t execution_context);
-#if defined(CFG_CORE_SEL2_SPMC)
+#if !defined(CFG_CORE_SEL1_SPMC)
 struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie);
 void thread_spmc_relinquish(uint64_t memory_region_handle);
 #endif

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1390,8 +1390,7 @@ static struct ffa_mem_transaction *spmc_retrieve_req(uint64_t cookie)
 	trans_descr->sender_id = thread_get_tsd()->rpc_target_info;
 	trans_descr->mem_reg_attr = FFA_NORMAL_MEM_REG_ATTR;
 	trans_descr->global_handle = cookie;
-	trans_descr->flags = FFA_MEMORY_REGION_FLAG_TIME_SLICE |
-			     FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE |
+	trans_descr->flags = FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE |
 			     FFA_MEMORY_REGION_FLAG_ANY_ALIGNMENT;
 	trans_descr->mem_access_count = 1;
 	acc_descr_array = trans_descr->mem_access_array;
@@ -1400,7 +1399,7 @@ static struct ffa_mem_transaction *spmc_retrieve_req(uint64_t cookie)
 	perm_descr = &acc_descr_array->access_perm;
 	perm_descr->endpoint_id = my_endpoint_id;
 	perm_descr->perm = FFA_MEM_ACC_RW;
-	perm_descr->flags = FFA_MEMORY_REGION_FLAG_TIME_SLICE;
+	perm_descr->flags = 0;
 
 	thread_smccc(&args);
 	if (args.a0 != FFA_MEM_RETRIEVE_RESP) {

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -63,11 +63,7 @@ static uint16_t my_endpoint_id;
  * the lock.
  */
 
-#ifdef CFG_CORE_SEL2_SPMC
-static uint8_t __rx_buf[SMALL_PAGE_SIZE] __aligned(SMALL_PAGE_SIZE);
-static uint8_t __tx_buf[SMALL_PAGE_SIZE] __aligned(SMALL_PAGE_SIZE);
-static struct ffa_rxtx nw_rxtx = { .rx = __rx_buf, .tx = __tx_buf };
-#else
+#ifdef CFG_CORE_SEL1_SPMC
 static struct ffa_rxtx nw_rxtx;
 
 static bool is_nw_buf(struct ffa_rxtx *rxtx)
@@ -77,6 +73,10 @@ static bool is_nw_buf(struct ffa_rxtx *rxtx)
 
 static SLIST_HEAD(mem_frag_state_head, mem_frag_state) frag_state_head =
 	SLIST_HEAD_INITIALIZER(&frag_state_head);
+#else
+static uint8_t __rx_buf[SMALL_PAGE_SIZE] __aligned(SMALL_PAGE_SIZE);
+static uint8_t __tx_buf[SMALL_PAGE_SIZE] __aligned(SMALL_PAGE_SIZE);
+static struct ffa_rxtx nw_rxtx = { .rx = __rx_buf, .tx = __tx_buf };
 #endif
 
 static uint32_t swap_src_dst(uint32_t src_dst)
@@ -1320,7 +1320,15 @@ void thread_spmc_register_secondary_ep(vaddr_t ep)
 		EMSG("FFA_SECONDARY_EP_REGISTER_64 ret %#lx", ret);
 }
 
-#ifdef CFG_CORE_SEL2_SPMC
+#if defined(CFG_CORE_SEL1_SPMC)
+static TEE_Result spmc_init(void)
+{
+	my_endpoint_id = SPMC_ENDPOINT_ID;
+	DMSG("My endpoint ID %#x", my_endpoint_id);
+
+	return TEE_SUCCESS;
+}
+#else /* !defined(CFG_CORE_SEL1_SPMC) */
 static bool is_ffa_success(uint32_t fid)
 {
 #ifdef ARM64
@@ -1482,13 +1490,13 @@ struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie)
 	descr = (struct ffa_mem_region *)((vaddr_t)retrieve_desc + offs);
 
 	num_pages = READ_ONCE(descr->total_page_count);
-	mf = mobj_ffa_sel2_spmc_new(cookie, num_pages);
+	mf = mobj_ffa_spmc_new(cookie, num_pages);
 	if (!mf)
 		goto out;
 
 	if (set_pages(descr->address_range_array,
 		      READ_ONCE(descr->address_range_count), num_pages, mf)) {
-		mobj_ffa_sel2_spmc_delete(mf);
+		mobj_ffa_spmc_delete(mf);
 		goto out;
 	}
 
@@ -1509,16 +1517,6 @@ static TEE_Result spmc_init(void)
 
 	return TEE_SUCCESS;
 }
-#endif /*CFG_CORE_SEL2_SPMC*/
-
-#if defined(CFG_CORE_SEL1_SPMC)
-static TEE_Result spmc_init(void)
-{
-	my_endpoint_id = SPMC_ENDPOINT_ID;
-	DMSG("My endpoint ID %#x", my_endpoint_id);
-
-	return TEE_SUCCESS;
-}
-#endif /*CFG_CORE_SEL1_SPMC*/
+#endif /* !defined(CFG_CORE_SEL1_SPMC) */
 
 service_init(spmc_init);

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1338,8 +1338,8 @@ static void spmc_rxtx_map(struct ffa_rxtx *rxtx)
 #else
 		.a0 = FFA_RXTX_MAP_32,
 #endif
-		.a1 = (vaddr_t)rxtx->tx,
-		.a2 = (vaddr_t)rxtx->rx,
+		.a1 = virt_to_phys(rxtx->tx),
+		.a2 = virt_to_phys(rxtx->rx),
 		.a3 = 1,
 	};
 

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -973,7 +973,7 @@ void thread_spmc_msg_recv(struct thread_smc_args *args)
 #endif /*CFG_CORE_SEL1_SPMC*/
 	case FFA_INTERRUPT:
 		itr_core_handler();
-		spmc_set_args(args, FFA_SUCCESS_32, args->a1, 0, 0, 0, 0);
+		spmc_set_args(args, FFA_MSG_WAIT, 0, 0, 0, 0, 0);
 		break;
 	case FFA_MSG_SEND_DIRECT_REQ_32:
 		if (IS_ENABLED(CFG_SECURE_PARTITION) &&

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -91,8 +91,8 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
-#if defined(IT_CONSOLE_UART) && \
-	!(defined(CFG_WITH_ARM_TRUSTED_FW) && defined(CFG_ARM_GICV3))
+#if defined(IT_CONSOLE_UART) && !defined(CFG_VIRTUALIZATION) && \
+	!(defined(CFG_WITH_ARM_TRUSTED_FW) && defined(CFG_ARM_GICV2))
 /*
  * This cannot be enabled with TF-A and GICv3 because TF-A then need to
  * assign the interrupt number of the UART to OP-TEE (S-EL1). Currently

--- a/core/include/mm/mobj.h
+++ b/core/include/mm/mobj.h
@@ -180,7 +180,7 @@ static inline uint64_t mobj_get_cookie(struct mobj *mobj)
 	if (mobj && mobj->ops && mobj->ops->get_cookie)
 		return mobj->ops->get_cookie(mobj);
 
-#if defined(CFG_CORE_SEL1_SPMC) || defined(CFG_CORE_SEL2_SPMC)
+#if defined(CFG_CORE_FFA)
 	return OPTEE_MSG_FMEM_INVALID_GLOBAL_ID;
 #else
 	return 0;
@@ -243,11 +243,9 @@ TEE_Result mobj_ffa_unregister_by_cookie(uint64_t cookie);
 struct mobj_ffa *mobj_ffa_sel1_spmc_new(unsigned int num_pages);
 void mobj_ffa_sel1_spmc_delete(struct mobj_ffa *mobj);
 TEE_Result mobj_ffa_sel1_spmc_reclaim(uint64_t cookie);
-#endif
-#ifdef CFG_CORE_SEL2_SPMC
-struct mobj_ffa *mobj_ffa_sel2_spmc_new(uint64_t cookie,
-					unsigned int num_pages);
-void mobj_ffa_sel2_spmc_delete(struct mobj_ffa *mobj);
+#else
+struct mobj_ffa *mobj_ffa_spmc_new(uint64_t cookie, unsigned int num_pages);
+void mobj_ffa_spmc_delete(struct mobj_ffa *mobj);
 #endif
 
 uint64_t mobj_ffa_get_cookie(struct mobj_ffa *mobj);


### PR DESCRIPTION
Please wait with this until after the release.

This adds support for FF-A with SPMC at EL3. There's a dependency to patches in TF-A since that's where the SPMC is implemented in this configuration.

This is built using https://github.com/OP-TEE/build/pull/548

The patches I've tested with are available at https://github.com/jenswi-linaro/arm-trusted-firmware/tree/poc/ffa_el3_spmc with QEMU specific patches on top

The base patches are reviewed at https://review.trustedfirmware.org/q/topic:%22ffa_el3_spmc%22+(status:open%20OR%20status:merged)
