### PR TITLE
drivers: caam: instantiate RNG state handle with prediction resistance

### DIFF
--- a/core/drivers/crypto/caam/include/caam_desc_defines.h
+++ b/core/drivers/crypto/caam/include/caam_desc_defines.h
@@ -412,6 +412,9 @@
 /* State Handle */
 #define ALGO_RNG_SH(sh)		SHIFT_U32((sh) & 0x3, 4)
 
+/* Prediction Resistance */
+#define ALGO_RNG_PR BIT32(1)
+
 /* State */
 #define AS_RNG_GENERATE		0x0
 #define AS_RNG_INSTANTIATE	0x1

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -265,7 +265,7 @@ static inline void dump_desc(uint32_t *desc)
  */
 #define RNG_SH_INST(sh)                                                        \
 	(CMD_OP_TYPE | OP_TYPE(CLASS1) | OP_ALGO(RNG) | ALGO_RNG_SH(sh) |      \
-	 ALGO_AS(RNG_INSTANTIATE))
+	 ALGO_AS(RNG_INSTANTIATE) | ALGO_RNG_PR)
 
 /*
  * RNG Generates Secure Keys


### PR DESCRIPTION
Instantiate RNG state handles with Prediction Resistance (PR) support.
This way SW further downstream (e.g. Rich OS, boot loader etc.) is able
to use the "PR" bit in RNG generation descriptors (forcing TRNG
re-seeding before PRNG / DRBG outputs random data).

Note: current patch does not deal with RNG state handles that have
already been initialized, but without PR support (this could happen if
U-boot would run before OP-TEE etc.). In this case, RNG state handle
would have to be deinstantiated first, and then reinstantiated with
PR support.

Signed-off-by: Franck LENORMAND <franck.lenormand@nxp.com>
Signed-off-by: Horia Geantă <horia.geanta@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
