### PR TITLE
Xilinx Zynq MPSoC fix memory allocation

### DIFF
--- a/core/arch/arm/plat-zynqmp/conf.mk
+++ b/core/arch/arm/plat-zynqmp/conf.mk
@@ -23,8 +23,20 @@ else
 $(call force,CFG_ARM32_core,y)
 endif
 
-# Configure DDR size either by using device tree or override it with:
+ifneq (,$(filter $(PLATFORM_FLAVOR),zcu102 zc1751_dc1 zc1751_dc2))
+# ZCU102 features 4 GiB of DDR
+ifeq ($(CFG_ARM64_core),y)
+CFG_DDR_SIZE ?= 0x100000000
+else
+# On 32 bit build limit to 2 GiB of RAM
 CFG_DDR_SIZE ?= 0x80000000
+endif
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),ultra96))
+# Ultra96 features 2 GiB of DDR
+CFG_DDR_SIZE ?= 0x80000000
+endif
 
 # By default use DT address as specified by Xilinx
 CFG_DT_ADDR ?= 0x100000

--- a/core/arch/arm/plat-zynqmp/conf.mk
+++ b/core/arch/arm/plat-zynqmp/conf.mk
@@ -16,6 +16,9 @@ $(call force,CFG_CORE_ASLR,n)
 
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_WITH_LPAE,y)
+
+# ZynqMP supports up to 40 bits of physical addresses
+CFG_CORE_ARM64_PA_BITS ?= 40
 else
 $(call force,CFG_ARM32_core,y)
 endif

--- a/core/arch/arm/plat-zynqmp/conf.mk
+++ b/core/arch/arm/plat-zynqmp/conf.mk
@@ -23,6 +23,9 @@ else
 $(call force,CFG_ARM32_core,y)
 endif
 
+# By default use DT address as specified by Xilinx
+CFG_DT_ADDR ?= 0x100000
+
 CFG_TZDRAM_START ?= 0x60000000
 CFG_TZDRAM_SIZE  ?= 0x10000000
 CFG_SHMEM_START  ?= 0x70000000

--- a/core/arch/arm/plat-zynqmp/conf.mk
+++ b/core/arch/arm/plat-zynqmp/conf.mk
@@ -23,6 +23,9 @@ else
 $(call force,CFG_ARM32_core,y)
 endif
 
+# Configure DDR size either by using device tree or override it with:
+CFG_DDR_SIZE ?= 0x80000000
+
 # By default use DT address as specified by Xilinx
 CFG_DT_ADDR ?= 0x100000
 

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -65,8 +65,16 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CSU_BASE, CSU_SIZE);
 #endif
 
-#ifdef DRAM0_BASE
-register_ddr(DRAM0_BASE, DRAM0_SIZE);
+#if CFG_DDR_SIZE > 0x80000000
+
+#ifdef CFG_ARM32_core
+#error DDR size over 2 GiB is not supported in 32 bit ARM mode
+#endif
+
+register_ddr(DRAM0_BASE, 0x80000000);
+register_ddr(DRAM1_BASE, CFG_DDR_SIZE - 0x80000000);
+#else
+register_ddr(DRAM0_BASE, CFG_DDR_SIZE);
 #endif
 
 void main_init_gic(void)

--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -39,6 +39,14 @@
 #error "Pager not supported for zynqmp"
 #endif
 
+/* DDR Low area base */
+#define DRAM0_BASE		0
+
+#ifdef ARM64
+/* DDR High area base is only available when compiling for 64 bits */
+#define DRAM1_BASE		0x800000000
+#endif
+
 #if defined(PLATFORM_FLAVOR_zc1751_dc1) || \
 	defined(PLATFORM_FLAVOR_zc1751_dc2) || \
 	defined(PLATFORM_FLAVOR_zcu102)
@@ -55,9 +63,6 @@
 #define CONSOLE_UART_BASE	UART0_BASE
 #define IT_CONSOLE_UART		IT_UART0
 #define CONSOLE_UART_CLK_IN_HZ	UART0_CLK_IN_HZ
-
-#define DRAM0_BASE		0
-#define DRAM0_SIZE		0x80000000
 
 #define GICD_OFFSET		0
 #define GICC_OFFSET		0x20000
@@ -76,9 +81,6 @@
 #define CONSOLE_UART_BASE	UART1_BASE
 #define IT_CONSOLE_UART		IT_UART1
 #define CONSOLE_UART_CLK_IN_HZ	UART1_CLK_IN_HZ
-
-#define DRAM0_BASE		0
-#define DRAM0_SIZE		0x80000000
 
 #define GICD_OFFSET		0
 #define GICC_OFFSET		0x20000


### PR DESCRIPTION
Xilinx Zynq MPSoC features two base addresses for DDR memories:
- First 2 GiB of DRAM (DDR Low): 0x0000_0000 .. 0x8000_0000
- And then rest of memory (DDR High): 0x0008_0000_0000 .. 0x000F_FFFF_FFFF

This change configures DDR base addresses depending on the size of DDR memory configured during build time and also helps on taking in use device tree to capture memory size from there.

Fixes physical address space bits to 40 bits allowing all peripherals to be used in OP-TEE.

This change also fixes DDR memory size for Xilinx ZCU102 board to 4 GB.

Tested that ZCU102 boots with and without device tree being used.

Also tested with custom board with larger DDR memory.

Fixes: https://github.com/OP-TEE/optee_os/issues/5144
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
