### PR TITLE
core: panic at unexpected smc return

### DIFF
--- a/core/arch/arm/include/arm32_macros.S
+++ b/core/arch/arm/include/arm32_macros.S
@@ -17,3 +17,10 @@
 		.endif
 	.endm
 
+	.macro panic_at_smc_return
+#if defined(CFG_TEE_CORE_DEBUG)
+		bl	__panic_at_smc_return
+#else
+		b	.
+#endif
+	.endm

--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -124,3 +124,11 @@
 	adrp	\reg, \sym
 	add	\reg, \reg, :lo12:\sym
 	.endm
+
+	.macro panic_at_smc_return
+#if defined(CFG_TEE_CORE_DEBUG)
+		bl	__panic_at_smc_return
+#else
+		b	.
+#endif
+	.endm

--- a/core/arch/arm/include/kernel/boot.h
+++ b/core/arch/arm/include/kernel/boot.h
@@ -48,6 +48,8 @@ void boot_init_primary_early(unsigned long pageable_part,
 			     unsigned long nsec_entry);
 void boot_init_primary_late(unsigned long fdt);
 
+void __panic_at_smc_return(void) __noreturn;
+
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 unsigned long cpu_on_handler(unsigned long a0, unsigned long a1);
 unsigned long boot_cpu_on_handler(unsigned long a0, unsigned long a1);

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -112,6 +112,15 @@ __weak unsigned long plat_get_aslr_seed(void)
 	return 0;
 }
 
+/*
+ * This function is called as a guard after each smc call which is not
+ * supposed to return.
+ */
+void __panic_at_smc_return(void)
+{
+	panic();
+}
+
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 void init_sec_mon(unsigned long nsec_entry __maybe_unused)
 {

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -626,7 +626,8 @@ shadow_stack_access_ok:
 
 	mov	r0, #TEESMC_OPTEED_RETURN_ENTRY_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 #endif /* CFG_CORE_FFA */
 END_FUNC reset_primary
 
@@ -918,7 +919,8 @@ UNWIND(	.cantunwind)
 	mov	r3, #0
 	mov	r4, #0
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC reset_secondary
 DECLARE_KEEP_PAGER reset_secondary
 #endif /* defined(CFG_WITH_ARM_TRUSTED_FW) */

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -287,7 +287,8 @@ clear_nex_bss:
 	sub	x1, x1, x0
 	mov	x0, #TEESMC_OPTEED_RETURN_ENTRY_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 #endif
 END_FUNC _start
 DECLARE_KEEP_INIT _start

--- a/core/arch/arm/kernel/thread_optee_smc_a32.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a32.S
@@ -3,6 +3,7 @@
  * Copyright (c) 2019, Linaro Limited
  */
 
+#include <arm32_macros.S>
 #include <arm.h>
 #include <asm.S>
 #include <generated/asm-defines.h>
@@ -49,7 +50,8 @@ UNWIND(	.cantunwind)
 	mov	r1, r0
 	ldr	r0, =TEESMC_OPTEED_RETURN_CALL_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_std_smc_entry
 
 FUNC vector_fast_smc_entry , : , .identity_map
@@ -61,7 +63,8 @@ UNWIND(	.cantunwind)
 	pop	{r1-r8}
 	ldr	r0, =TEESMC_OPTEED_RETURN_CALL_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_fast_smc_entry
 
 FUNC vector_fiq_entry , : , .identity_map
@@ -72,7 +75,8 @@ UNWIND(	.cantunwind)
 	bl	itr_core_handler
 	ldr	r0, =TEESMC_OPTEED_RETURN_FIQ_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_fiq_entry
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
@@ -83,7 +87,8 @@ UNWIND(	.cantunwind)
 	mov	r1, r0
 	ldr	r0, =TEESMC_OPTEED_RETURN_ON_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_on_entry
 
 LOCAL_FUNC vector_cpu_off_entry , : , .identity_map
@@ -93,7 +98,8 @@ UNWIND(	.cantunwind)
 	mov	r1, r0
 	ldr	r0, =TEESMC_OPTEED_RETURN_OFF_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_off_entry
 
 LOCAL_FUNC vector_cpu_suspend_entry , : , .identity_map
@@ -103,7 +109,8 @@ UNWIND(	.cantunwind)
 	mov	r1, r0
 	ldr	r0, =TEESMC_OPTEED_RETURN_SUSPEND_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_suspend_entry
 
 LOCAL_FUNC vector_cpu_resume_entry , : , .identity_map
@@ -113,7 +120,8 @@ UNWIND(	.cantunwind)
 	mov	r1, r0
 	ldr	r0, =TEESMC_OPTEED_RETURN_RESUME_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_resume_entry
 
 LOCAL_FUNC vector_system_off_entry , : , .identity_map
@@ -123,7 +131,8 @@ UNWIND(	.cantunwind)
 	mov	r1, r0
 	ldr	r0, =TEESMC_OPTEED_RETURN_SYSTEM_OFF_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_system_off_entry
 
 LOCAL_FUNC vector_system_reset_entry , : , .identity_map
@@ -133,7 +142,8 @@ UNWIND(	.cantunwind)
 	mov	r1, r0
 	ldr	r0, =TEESMC_OPTEED_RETURN_SYSTEM_RESET_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_system_reset_entry
 
 /*
@@ -179,7 +189,8 @@ UNWIND(	.cantunwind)
 	mov	r3, #0
 	mov	r4, #0
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC thread_std_smc_entry
 
 /* void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]) */
@@ -206,7 +217,8 @@ UNWIND(	.save	{r0, lr})
 	ldr	r0, =TEESMC_OPTEED_RETURN_CALL_DONE
 	ldm	r5, {r1-r3}		/* Load rv[] into r0-r2 */
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 
 .thread_rpc_return:
 	/*
@@ -238,5 +250,6 @@ FUNC thread_foreign_intr_exit , :
 	mov	r2, #0
 	mov	r3, #0
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC thread_foreign_intr_exit

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -46,7 +46,8 @@ LOCAL_FUNC vector_std_smc_entry , : , .identity_map
 	mov	w1, w0
 	ldr	x0, =TEESMC_OPTEED_RETURN_CALL_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_std_smc_entry
 
 LOCAL_FUNC vector_fast_smc_entry , : , .identity_map
@@ -59,7 +60,8 @@ LOCAL_FUNC vector_fast_smc_entry , : , .identity_map
 	add	sp, sp, #THREAD_SMC_ARGS_SIZE
 	ldr	x0, =TEESMC_OPTEED_RETURN_CALL_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_fast_smc_entry
 
 LOCAL_FUNC vector_fiq_entry , : , .identity_map
@@ -69,7 +71,8 @@ LOCAL_FUNC vector_fiq_entry , : , .identity_map
 	bl	itr_core_handler
 	ldr	x0, =TEESMC_OPTEED_RETURN_FIQ_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_fiq_entry
 
 LOCAL_FUNC vector_cpu_on_entry , : , .identity_map
@@ -77,7 +80,8 @@ LOCAL_FUNC vector_cpu_on_entry , : , .identity_map
 	mov	x1, x0
 	ldr	x0, =TEESMC_OPTEED_RETURN_ON_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_on_entry
 
 LOCAL_FUNC vector_cpu_off_entry , : , .identity_map
@@ -86,7 +90,8 @@ LOCAL_FUNC vector_cpu_off_entry , : , .identity_map
 	mov	x1, x0
 	ldr	x0, =TEESMC_OPTEED_RETURN_OFF_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_off_entry
 
 LOCAL_FUNC vector_cpu_suspend_entry , : , .identity_map
@@ -95,7 +100,8 @@ LOCAL_FUNC vector_cpu_suspend_entry , : , .identity_map
 	mov	x1, x0
 	ldr	x0, =TEESMC_OPTEED_RETURN_SUSPEND_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_suspend_entry
 
 LOCAL_FUNC vector_cpu_resume_entry , : , .identity_map
@@ -104,7 +110,8 @@ LOCAL_FUNC vector_cpu_resume_entry , : , .identity_map
 	mov	x1, x0
 	ldr	x0, =TEESMC_OPTEED_RETURN_RESUME_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_cpu_resume_entry
 
 LOCAL_FUNC vector_system_off_entry , : , .identity_map
@@ -113,7 +120,8 @@ LOCAL_FUNC vector_system_off_entry , : , .identity_map
 	mov	x1, x0
 	ldr	x0, =TEESMC_OPTEED_RETURN_SYSTEM_OFF_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_system_off_entry
 
 LOCAL_FUNC vector_system_reset_entry , : , .identity_map
@@ -122,7 +130,8 @@ LOCAL_FUNC vector_system_reset_entry , : , .identity_map
 	mov	x1, x0
 	ldr	x0, =TEESMC_OPTEED_RETURN_SYSTEM_RESET_DONE
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC vector_system_reset_entry
 
 /*
@@ -162,7 +171,8 @@ FUNC thread_std_smc_entry , :
 	mov	x3, #0
 	mov	x4, #0
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC thread_std_smc_entry
 
 /* void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]) */
@@ -202,7 +212,8 @@ FUNC thread_rpc , :
 	mov	x2, x22
 	mov	x3, x23
 	smc	#0
-	b	.		/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 
 .thread_rpc_return:
 	/*
@@ -234,7 +245,8 @@ FUNC thread_foreign_intr_exit , :
 	mov	w2, #0
 	mov	w3, #0
 	smc	#0
-	b	.	/* SMC should not return */
+	/* SMC should not return */
+	panic_at_smc_return
 END_FUNC thread_foreign_intr_exit
 
 BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)


### PR DESCRIPTION
Certain smc's are not expected to return. Prior to this patch in order
to guard against unexpected return a "b ." instruction was added after
each such smc to at least capture the cpu. With the introduction of FF-A
TF-A may in case there's a mismatch between OP-TEE and TF-A
configuration return some error code when an unrecognized smc is
encountered. The result is typically that the boot hangs after the print:
I/TC: Primary CPU switching to normal world boot

To help diagnosing such errors a call to panic is added after
each smc which isn't expected to return. The result becomes instead:
I/TC: Primary CPU switching to normal world boot
E/TC:0   Panic at core/arch/arm/kernel/boot.c:122 <__panic_at_smc_return>
E/TC:0   TEE load address @ 0xe100000
E/TC:0   Call stack:
E/TC:0    0x0e10d23c
E/TC:0    0x0e124848
E/TC:0    0x0e10be60

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
