### PR TITLE
[RFC] Combinded rpc arg

### DIFF
--- a/core/arch/arm/include/optee_ffa.h
+++ b/core/arch/arm/include/optee_ffa.h
@@ -82,8 +82,16 @@
  *                   as the second MSG arg struct for
  *                   OPTEE_FFA_YIELDING_CALL_WITH_ARG.
  *        Bit[31:8]: Reserved (MBZ)
- * w5-w7: Note used (MBZ)
+ * w5:	  Bitfield of secure world capabilities OPTEE_FFA_SEC_CAP_* below,
+ *	  unused bits MBZ.
+ * w6-w7: Not used (MBZ)
  */
+/*
+ * Secure world supports using an offset into the argument shared memory
+ * object, see also OPTEE_FFA_YIELDING_CALL_WITH_ARG
+ */
+#define OPTEE_FFA_SEC_CAP_ARG_OFFSET	BIT(0)
+
 #define OPTEE_FFA_EXCHANGE_CAPABILITIES OPTEE_FFA_BLOCKING_CALL(2)
 
 /*
@@ -113,6 +121,8 @@
  *	  OPTEE_MSG_GET_ARG_SIZE(num_params) follows a struct optee_msg_arg
  *	  for RPC, this struct has reserved space for the number of RPC
  *	  parameters as returned by OPTEE_FFA_EXCHANGE_CAPABILITIES.
+ *	  MBZ unless the bit OPTEE_FFA_SEC_CAP_ARG_OFFSET is received with
+ *	  OPTEE_FFA_EXCHANGE_CAPABILITIES.
  * w7:    Not used (MBZ)
  * Resume from RPC. Register usage:
  * w3:    Service ID, OPTEE_FFA_YIELDING_CALL_RESUME
@@ -132,7 +142,7 @@
  *
  * Possible error codes in register w3:
  * 0:                       Success
- * FFA_DENIED:             w4 isn't one of OPTEE_FFA_YIELDING_CALL_START
+ * FFA_DENIED:              w4 isn't one of OPTEE_FFA_YIELDING_CALL_START
  *                          OPTEE_FFA_YIELDING_CALL_RESUME
  *
  * Possible error codes for OPTEE_FFA_YIELDING_CALL_START,

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -496,7 +496,8 @@ static void handle_blocking_call(struct thread_smc_args *args)
 	case OPTEE_FFA_EXCHANGE_CAPABILITIES:
 		spmc_set_args(args, FFA_MSG_SEND_DIRECT_RESP_32,
 			      swap_src_dst(args->a1), 0, 0,
-			      THREAD_RPC_MAX_NUM_PARAMS, 0);
+			      THREAD_RPC_MAX_NUM_PARAMS,
+			      OPTEE_FFA_SEC_CAP_ARG_OFFSET);
 		break;
 	case OPTEE_FFA_UNREGISTER_SHM:
 		spmc_set_args(args, FFA_MSG_SEND_DIRECT_RESP_32,

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -107,6 +107,9 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 #endif
 
 	DMSG("Dynamic shared memory is %sabled", dyn_shm_en ? "en" : "dis");
+
+	args->a1 |= OPTEE_SMC_SEC_CAP_RPC_ARG;
+	args->a3 = THREAD_RPC_MAX_NUM_PARAMS;
 }
 
 static void tee_entry_disable_shm_cache(struct thread_smc_args *args)

--- a/core/include/mm/mobj.h
+++ b/core/include/mm/mobj.h
@@ -299,6 +299,11 @@ static inline struct mobj *mobj_mapped_shm_alloc(paddr_t *pages __unused,
 {
 	return NULL;
 }
+
+static inline struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie __unused)
+{
+	return NULL;
+}
 #endif
 
 struct mobj *mobj_shm_alloc(paddr_t pa, size_t size, uint64_t cookie);


### PR DESCRIPTION
This PR proposes a way to combine the RPC argument struct with the main struct when using the SMC ABI. This approach is already used with the FF-A ABI. This PR also enables efficient caching of argument structs in the kernel driver, see corresponding changes at https://github.com/jenswi-linaro/linux-1/tree/rpc_arg