### PR TITLE
watchdog: add glue and arm-smc-wdt smc handler

### DIFF
--- a/core/arch/arm/dts/at91-sama5d27_som1_ek.dts
+++ b/core/arch/arm/dts/at91-sama5d27_som1_ek.dts
@@ -145,10 +145,6 @@
 				};
 			};
 
-			watchdog@f8048040 {
-				status = "okay";
-			};
-
 			uart3: serial@fc008000 {
 				atmel,use-dma-rx;
 				atmel,use-dma-tx;

--- a/core/arch/arm/dts/at91-sama5d2_xplained.dts
+++ b/core/arch/arm/dts/at91-sama5d2_xplained.dts
@@ -354,10 +354,6 @@
 				};
 			};
 
-			watchdog@f8048040 {
-				status = "okay";
-			};
-
 			i2s0: i2s@f8050000 {
 				pinctrl-names = "default";
 				pinctrl-0 = <&pinctrl_i2s0_default>;

--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -32,6 +32,8 @@
 			compatible = "arm,cortex-a5";
 			reg = <0>;
 			next-level-cache = <&L2>;
+			clocks = <&pmc PMC_TYPE_CORE PMC_MCK_PRES>;
+			clock-names = "cpu";
 		};
 	};
 

--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -696,6 +696,7 @@
 				interrupts = <4 IRQ_TYPE_LEVEL_HIGH 7>;
 				clocks = <&clk32k>;
 				status = "disabled";
+				secure-status = "okay";
 			};
 
 			clk32k: sckc@f8048050 {

--- a/core/arch/arm/include/kernel/boot.h
+++ b/core/arch/arm/include/kernel/boot.h
@@ -67,6 +67,7 @@ void init_tee_runtime(void);
 void plat_cpu_reset_early(void);
 void plat_primary_init_early(void);
 unsigned long plat_get_aslr_seed(void);
+unsigned long plat_get_freq(void);
 void arm_cl2_config(vaddr_t pl310);
 void arm_cl2_enable(vaddr_t pl310);
 

--- a/core/arch/arm/include/kernel/misc.h
+++ b/core/arch/arm/include/kernel/misc.h
@@ -28,5 +28,7 @@ size_t get_core_pos_mpidr(uint32_t mpidr);
 uint32_t read_mode_sp(int cpu_mode);
 uint32_t read_mode_lr(int cpu_mode);
 
+void wait_cycles(unsigned long cycles);
+
 #endif /*KERNEL_MISC_H*/
 

--- a/core/arch/arm/kernel/delay.c
+++ b/core/arch/arm/kernel/delay.c
@@ -27,8 +27,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <kernel/boot.h>
 #include <kernel/delay.h>
+#include <kernel/misc.h>
 
+#ifdef CFG_CORE_HAS_GENERIC_TIMER
 void udelay(uint32_t us)
 {
 	uint64_t target = timeout_init_us(us);
@@ -36,6 +39,22 @@ void udelay(uint32_t us)
 	while (!timeout_elapsed(target))
 		;
 }
+#else
+
+void udelay(uint32_t us)
+{
+	uint64_t cycles = 0;
+	uint32_t cycles_to_wait = 0;
+
+	cycles = (uint64_t)us * ((uint64_t)plat_get_freq() / 1000000ULL);
+
+	while (cycles) {
+		cycles_to_wait = MIN(cycles, UINT32_MAX);
+		wait_cycles(cycles_to_wait);
+		cycles -= cycles_to_wait;
+	}
+}
+#endif
 
 void mdelay(uint32_t ms)
 {

--- a/core/arch/arm/kernel/misc_a32.S
+++ b/core/arch/arm/kernel/misc_a32.S
@@ -93,3 +93,16 @@ UNWIND(	.save	{r4, lr})
 	msr	cpsr, r4		/* back to the old mode */
 	pop	{r4, pc}
 END_FUNC read_mode_lr
+
+/* void wait_cycles(unsigned long cycles) */
+FUNC wait_cycles , :
+	/* Divide by 4 since each loop will take 4 cycles to complete */
+	lsrs	r0, r0, #2
+	bxeq	lr
+loop:
+	subs	r0, r0, #1
+	nop
+	bne	loop
+
+	bx lr
+END_FUNC wait_cycles

--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -73,3 +73,10 @@ CFG_ATMEL_PM_SUSPEND_MODE ?= 0
 $(call force,CFG_ATMEL_SHDWC,y)
 $(call force,CFG_PM_ARM32,y)
 endif
+
+CFG_WDT ?= y
+CFG_WDT_SM_HANDLER ?= y
+ifeq ($(CFG_WDT_SM_HANDLER),y)
+CFG_WDT_SM_HANDLER_ID := 0x2000500
+endif
+CFG_ATMEL_WDT ?= y

--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -30,6 +30,7 @@ $(call force,CFG_DRIVERS_SAM_CLK,y)
 $(call force,CFG_DRIVERS_SAMA5D2_CLK,y)
 $(call force,CFG_PSCI_ARM32,y)
 $(call force,CFG_SM_PLATFORM_HANDLER,y)
+$(call force,CFG_CORE_HAS_GENERIC_TIMER,n)
 
 # These values are forced because of matrix configuration for secure area.
 # When modifying these, always update matrix settings in

--- a/core/arch/arm/plat-sam/freq.c
+++ b/core/arch/arm/plat-sam/freq.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022 Microchip
+ */
+
+#include <assert.h>
+#include <drivers/clk.h>
+#include <drivers/clk_dt.h>
+#include <kernel/boot.h>
+#include <kernel/panic.h>
+#include <libfdt.h>
+
+static unsigned long freq;
+
+static TEE_Result get_freq_from_dt(void)
+{
+	int node;
+	struct clk *clk;
+	const void *fdt = get_embedded_dt();
+
+	if (!fdt)
+		panic();
+
+	node = fdt_node_offset_by_compatible(fdt, -1, "arm,cortex-a5");
+	if (!node)
+		panic();
+
+	if (clk_dt_get_by_name(fdt, node, "cpu", &clk))
+		panic();
+
+	freq = clk_get_rate(clk);
+
+	return TEE_SUCCESS;
+}
+early_init_late(get_freq_from_dt);
+
+unsigned long plat_get_freq(void)
+{
+	assert(freq);
+
+	return freq;
+}

--- a/core/arch/arm/plat-sam/sub.mk
+++ b/core/arch/arm/plat-sam/sub.mk
@@ -1,5 +1,5 @@
 global-incdirs-y += .
-srcs-y += main.c
+srcs-y += main.c freq.c
 srcs-$(CFG_AT91_MATRIX) += matrix.c
 srcs-$(CFG_PL310) += sam_pl310.c
 subdirs-y += pm

--- a/core/arch/arm/sm/sm.c
+++ b/core/arch/arm/sm/sm.c
@@ -6,6 +6,7 @@
 #include <arm.h>
 #include <compiler.h>
 #include <config.h>
+#include <drivers/wdt.h>
 #include <kernel/misc.h>
 #include <kernel/thread.h>
 #include <platform_config.h>
@@ -66,6 +67,9 @@ uint32_t sm_from_nsec(struct sm_ctx *ctx)
 	COMPILE_TIME_ASSERT(!(offsetof(struct sm_ctx, sec.r0) % 8));
 	COMPILE_TIME_ASSERT(!(offsetof(struct sm_ctx, nsec.r0) % 8));
 	COMPILE_TIME_ASSERT(!(sizeof(struct sm_ctx) % 8));
+
+	if (wdt_sm_handler(args) == SM_HANDLER_SMC_HANDLED)
+		return SM_EXIT_TO_NON_SECURE;
 
 	if (IS_ENABLED(CFG_SM_PLATFORM_HANDLER) &&
 	    sm_platform_handler(ctx) == SM_HANDLER_SMC_HANDLED)

--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022 Microchip
+ */
+
+#include <assert.h>
+#include <drivers/clk.h>
+#include <drivers/clk_dt.h>
+#include <drivers/wdt.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <kernel/pm.h>
+#include <matrix.h>
+#include <sama5d2.h>
+#include <tee_api_types.h>
+
+#define WDT_CR			0x0
+#define WDT_CR_KEY		SHIFT_U32(0xA5, 24)
+#define WDT_CR_WDRSTT		BIT(0)
+
+#define WDT_MR			0x4
+#define WDT_MR_WDV		GENMASK_32(11, 0)
+#define WDT_MR_WDV_SET(val)	((val) & WDT_MR_WDV)
+#define WDT_MR_WDFIEN		BIT(12)
+#define WDT_MR_WDRSTEN		BIT(13)
+#define WDT_MR_WDDIS		BIT(15)
+#define WDT_MR_WDD_SHIFT	16
+#define WDT_MR_WDD_MASK		GENMASK_32(11, 0)
+#define WDT_MR_WDD		SHIFT_U32(WDT_MR_WDD_MASK, WDT_MR_WDD_SHIFT)
+#define WDT_MR_WDD_SET(val) \
+			SHIFT_U32(((val) & WDT_MR_WDD_MASK), WDT_MR_WDD_SHIFT)
+#define WDT_MR_WDDBGHLT		BIT(28)
+#define WDT_MR_WDIDLEHLT	BIT(29)
+
+#define WDT_SR			0x8
+#define WDT_SR_DUNF		BIT(0)
+#define WDT_SR_DERR		BIT(1)
+
+/*
+ * The watchdog is clocked by a 32768Hz clock/128 and the counter is on
+ * 12 bits.
+ */
+#define SLOW_CLOCK_FREQ		(32768)
+#define WDT_CLOCK_FREQ		(SLOW_CLOCK_FREQ / 128)
+#define WDT_MIN_TIMEOUT		1
+#define WDT_MAX_TIMEOUT		(BIT(12) / WDT_CLOCK_FREQ)
+
+#define WDT_DEFAULT_TIMEOUT	WDT_MAX_TIMEOUT
+
+/*
+ * We must wait at least 3 clocks period before accessing registers MR and CR.
+ * Ensure that we see at least 4 edges
+ */
+#define WDT_REG_ACCESS_UDELAY	(1000000ULL / SLOW_CLOCK_FREQ * 4)
+
+#define SEC_TO_WDT(sec)		(((sec) * WDT_CLOCK_FREQ) - 1)
+
+#define WDT_ENABLED(mr)		(!((mr) & WDT_MR_WDDIS))
+
+struct atmel_wdt {
+	struct wdt_chip chip;
+	vaddr_t base;
+	unsigned long rate;
+	uint32_t mr;
+	bool enabled;
+};
+
+static void atmel_wdt_write_sleep(struct atmel_wdt *wdt, uint32_t reg,
+				  uint32_t val)
+{
+	udelay(WDT_REG_ACCESS_UDELAY);
+
+	io_write32(wdt->base + reg, val);
+}
+
+static TEE_Result atmel_wdt_settimeout(struct wdt_chip *chip,
+				       unsigned long timeout)
+{
+	struct atmel_wdt *wdt = container_of(chip, struct atmel_wdt, chip);
+
+	wdt->mr &= ~WDT_MR_WDV;
+	wdt->mr |= WDT_MR_WDV_SET(SEC_TO_WDT(timeout));
+
+	/* WDV and WDD can only be updated when the watchdog is running */
+	if (WDT_ENABLED(wdt->mr))
+		atmel_wdt_write_sleep(wdt, WDT_MR, wdt->mr);
+
+	return TEE_SUCCESS;
+}
+
+static void atmel_wdt_ping(struct wdt_chip *chip)
+{
+	struct atmel_wdt *wdt = container_of(chip, struct atmel_wdt, chip);
+
+	atmel_wdt_write_sleep(wdt, WDT_CR, WDT_CR_KEY | WDT_CR_WDRSTT);
+}
+
+static void atmel_wdt_start(struct atmel_wdt *wdt)
+{
+	wdt->mr &= ~WDT_MR_WDDIS;
+	atmel_wdt_write_sleep(wdt, WDT_MR, wdt->mr);
+}
+
+static void atmel_wdt_enable(struct wdt_chip *chip)
+{
+	struct atmel_wdt *wdt = container_of(chip, struct atmel_wdt, chip);
+
+	wdt->enabled = true;
+	atmel_wdt_start(wdt);
+}
+
+static void atmel_wdt_stop(struct atmel_wdt *wdt)
+{
+	wdt->mr |= WDT_MR_WDDIS;
+	atmel_wdt_write_sleep(wdt, WDT_MR, wdt->mr);
+}
+
+static void atmel_wdt_disable(struct wdt_chip *chip)
+{
+	struct atmel_wdt *wdt = container_of(chip, struct atmel_wdt, chip);
+
+	wdt->enabled = false;
+	atmel_wdt_stop(wdt);
+}
+
+static enum itr_return atmel_wdt_itr_cb(struct itr_handler *h)
+{
+	struct atmel_wdt *wdt = h->data;
+	uint32_t sr = io_read32(wdt->base + WDT_SR);
+
+	if (sr & WDT_SR_DUNF)
+		DMSG("Watchdog Underflow !");
+	if (sr & WDT_SR_DERR)
+		DMSG("Watchdog Error !");
+
+	panic("Watchdog interrupt");
+
+	return ITRR_HANDLED;
+}
+
+static TEE_Result atmel_wdt_init(struct wdt_chip *chip __unused,
+				 unsigned long *min_timeout,
+				 unsigned long *max_timeout)
+{
+	*min_timeout = WDT_MIN_TIMEOUT;
+	*max_timeout = WDT_MAX_TIMEOUT;
+
+	return TEE_SUCCESS;
+}
+
+static const struct wdt_ops atmel_wdt_ops = {
+	.init = atmel_wdt_init,
+	.start = atmel_wdt_enable,
+	.stop = atmel_wdt_disable,
+	.ping = atmel_wdt_ping,
+	.set_timeout = atmel_wdt_settimeout,
+};
+
+static void atmel_wdt_init_hw(struct atmel_wdt *wdt)
+{
+	uint32_t mr = 0;
+
+	/*
+	 * If we are resuming, we disabled the watchdog on suspend but the
+	 * bootloader might have enabled the watchdog. If so, disable it
+	 * properly.
+	 */
+	if (!WDT_ENABLED(wdt->mr)) {
+		mr = io_read32(wdt->base + WDT_MR);
+		if (WDT_ENABLED(mr))
+			io_write32(wdt->base + WDT_MR, mr | WDT_MR_WDDIS);
+	}
+
+	/* Enable interrupt, and disable watchdog in debug and idle */
+	wdt->mr |= WDT_MR_WDFIEN | WDT_MR_WDDBGHLT | WDT_MR_WDIDLEHLT;
+	wdt->mr |= WDT_MR_WDD_SET(SEC_TO_WDT(WDT_MAX_TIMEOUT));
+	wdt->mr |= WDT_MR_WDV_SET(SEC_TO_WDT(WDT_DEFAULT_TIMEOUT));
+
+	/*
+	 * If the watchdog was enabled, write the configuration which will ping
+	 * the watchdog.
+	 */
+	if (WDT_ENABLED(wdt->mr))
+		io_write32(wdt->base + WDT_MR, wdt->mr);
+}
+
+#ifdef CFG_PM_ARM32
+static TEE_Result atmel_wdt_pm(enum pm_op op, uint32_t pm_hint __unused,
+			       const struct pm_callback_handle *hdl)
+{
+	struct atmel_wdt *wdt = hdl->handle;
+
+	switch (op) {
+	case PM_OP_RESUME:
+		atmel_wdt_init_hw(wdt);
+		if (wdt->enabled)
+			atmel_wdt_start(wdt);
+		break;
+	case PM_OP_SUSPEND:
+		if (wdt->enabled)
+			atmel_wdt_stop(wdt);
+		break;
+	default:
+		panic("Invalid PM operation");
+	}
+
+	return TEE_SUCCESS;
+}
+
+static void atmel_wdt_register_pm(struct atmel_wdt *wdt)
+{
+	register_pm_driver_cb(atmel_wdt_pm, wdt, "atmel_wdt");
+}
+#else
+static void atmel_wdt_register_pm(struct atmel_wdt *wdt __unused)
+{
+}
+#endif
+
+static TEE_Result wdt_node_probe(const void *fdt, int node,
+				 const void *compat_data __unused)
+{
+	size_t size = 0;
+	struct atmel_wdt *wdt;
+	uint32_t irq_type = 0;
+	uint32_t irq_prio = 0;
+	int it = DT_INFO_INVALID_INTERRUPT;
+	struct itr_handler *it_hdlr;
+
+	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	matrix_configure_periph_secure(AT91C_ID_WDT);
+
+	wdt = calloc(1, sizeof(*wdt));
+	if (!wdt)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	wdt->chip.ops = &atmel_wdt_ops;
+
+	it = dt_get_irq_type_prio(fdt, node, &irq_type, &irq_prio);
+	if (it == DT_INFO_INVALID_INTERRUPT)
+		goto err_free_wdt;
+
+	it_hdlr = itr_alloc_add_type_prio(it, &atmel_wdt_itr_cb, 0, wdt,
+					  irq_type, irq_prio);
+	if (!it_hdlr)
+		goto err_free_wdt;
+
+	if (dt_map_dev(fdt, node, &wdt->base, &size) < 0)
+		goto err_free_itr_handler;
+
+	/* Get current state of the watchdog */
+	wdt->mr = io_read32(wdt->base + WDT_MR) & WDT_MR_WDDIS;
+
+	atmel_wdt_init_hw(wdt);
+	itr_enable(it);
+	atmel_wdt_register_pm(wdt);
+
+	return watchdog_register(&wdt->chip);
+
+err_free_itr_handler:
+	itr_free(it_hdlr);
+err_free_wdt:
+	free(wdt);
+
+	return TEE_ERROR_GENERIC;
+}
+
+static const struct dt_device_match atmel_wdt_match_table[] = {
+	{ .compatible = "atmel,sama5d4-wdt" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(atmel_wdt_dt_driver) = {
+	.name = "atmel_wdt",
+	.type = DT_DRIVER_NOTYPE,
+	.match_table = atmel_wdt_match_table,
+	.probe = wdt_node_probe,
+};

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -24,6 +24,7 @@ srcs-$(CFG_ATMEL_TRNG) += atmel_trng.c
 srcs-$(CFG_ATMEL_RSTC) += atmel_rstc.c
 srcs-$(CFG_ATMEL_SHDWC) += atmel_shdwc.c atmel_shdwc_a32.S
 srcs-$(CFG_ATMEL_SAIC) += atmel_saic.c
+srcs-$(CFG_ATMEL_WDT) += atmel_wdt.c
 srcs-$(CFG_AMLOGIC_UART) += amlogic_uart.c
 srcs-$(CFG_MVEBU_UART) += mvebu_uart.c
 srcs-$(CFG_STM32_BSEC) += stm32_bsec.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -55,3 +55,4 @@ subdirs-$(CFG_DRIVERS_RSTCTRL) += rstctrl
 subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg
 subdirs-y += imx
 subdirs-y += pm
+subdirs-y += wdt

--- a/core/drivers/wdt/sub.mk
+++ b/core/drivers/wdt/sub.mk
@@ -1,1 +1,2 @@
 srcs-$(CFG_WDT) += watchdog.c
+srcs-$(CFG_WDT_SM_HANDLER) += watchdog_sm.c

--- a/core/drivers/wdt/sub.mk
+++ b/core/drivers/wdt/sub.mk
@@ -1,0 +1,1 @@
+srcs-$(CFG_WDT) += watchdog.c

--- a/core/drivers/wdt/watchdog.c
+++ b/core/drivers/wdt/watchdog.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022 Microchip
+ */
+
+#include <drivers/wdt.h>
+
+struct wdt_chip *wdt_chip;
+
+TEE_Result watchdog_register(struct wdt_chip *chip)
+{
+	if (!chip->ops->start || !chip->ops->ping  || !chip->ops->set_timeout)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	wdt_chip = chip;
+
+	return TEE_SUCCESS;
+}

--- a/core/drivers/wdt/watchdog_sm.c
+++ b/core/drivers/wdt/watchdog_sm.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022 Microchip
+ */
+
+#include <drivers/wdt.h>
+#include <kernel/spinlock.h>
+#include <sm/optee_smc.h>
+#include <sm/psci.h>
+
+enum smcwd_call {
+	SMCWD_INIT		= 0,
+	SMCWD_SET_TIMEOUT	= 1,
+	SMCWD_ENABLE		= 2,
+	SMCWD_PET		= 3,
+	SMCWD_GET_TIMELEFT	= 4,
+};
+
+static unsigned long wdt_min_timeout;
+static unsigned long wdt_max_timeout;
+/* Lock for timeout variables */
+static unsigned int wdt_lock = SPINLOCK_UNLOCK;
+
+enum sm_handler_ret __wdt_sm_handler(struct thread_smc_args *args)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t exceptions = 0;
+	unsigned long min_timeout = 0;
+	unsigned long max_timeout = 0;
+
+	switch (args->a1) {
+	case SMCWD_INIT:
+		exceptions = cpu_spin_lock_xsave(&wdt_lock);
+		res = watchdog_init(&wdt_min_timeout, &wdt_max_timeout);
+		cpu_spin_unlock_xrestore(&wdt_lock, exceptions);
+
+		if (res) {
+			args->a0 = PSCI_RET_INTERNAL_FAILURE;
+		} else {
+			args->a0 = PSCI_RET_SUCCESS;
+			args->a1 = wdt_min_timeout;
+			args->a2 = wdt_max_timeout;
+		}
+		break;
+	case SMCWD_SET_TIMEOUT:
+		exceptions = cpu_spin_lock_xsave(&wdt_lock);
+		min_timeout = wdt_min_timeout;
+		max_timeout = wdt_max_timeout;
+		cpu_spin_unlock_xrestore(&wdt_lock, exceptions);
+
+		if (args->a2 < min_timeout || args->a2 > max_timeout) {
+			args->a0 = PSCI_RET_INVALID_PARAMETERS;
+			break;
+		}
+
+		watchdog_settimeout(args->a2);
+		args->a0 = PSCI_RET_SUCCESS;
+		break;
+	case SMCWD_ENABLE:
+		if (args->a2 == 0) {
+			watchdog_stop();
+			args->a0 = PSCI_RET_SUCCESS;
+		} else if (args->a2 == 1) {
+			watchdog_start();
+			args->a0 = PSCI_RET_SUCCESS;
+		} else {
+			args->a0 = PSCI_RET_INVALID_PARAMETERS;
+		}
+		break;
+	case SMCWD_PET:
+		watchdog_ping();
+		args->a0 = PSCI_RET_SUCCESS;
+		break;
+	/* SMCWD_GET_TIMELEFT is optional */
+	case SMCWD_GET_TIMELEFT:
+	default:
+		args->a0 = PSCI_RET_NOT_SUPPORTED;
+	}
+
+	return SM_HANDLER_SMC_HANDLED;
+}

--- a/core/include/drivers/wdt.h
+++ b/core/include/drivers/wdt.h
@@ -6,6 +6,7 @@
 #ifndef DRIVERS_WDT_H
 #define DRIVERS_WDT_H
 
+#include <assert.h>
 #include <kernel/interrupt.h>
 #include <tee_api_types.h>
 
@@ -17,6 +18,7 @@ struct wdt_chip {
 /*
  * struct wdt_ops - The watchdog device operations
  *
+ * @init:	The routine to initialized the watchdog resources.
  * @start:	The routine for starting the watchdog device.
  * @stop:	The routine for stopping the watchdog device.
  * @ping:	The routine that sends a keepalive ping to the watchdog device.
@@ -27,10 +29,71 @@ struct wdt_chip {
  * that control a watchdog device.
  */
 struct wdt_ops {
+	TEE_Result (*init)(struct wdt_chip *chip, unsigned long *min_timeout,
+			   unsigned long *max_timeout);
 	void (*start)(struct wdt_chip *chip);
 	void (*stop)(struct wdt_chip *chip);
 	void (*ping)(struct wdt_chip *chip);
 	TEE_Result (*set_timeout)(struct wdt_chip *chip, unsigned long timeout);
 };
+
+#ifdef CFG_WDT
+extern struct wdt_chip *wdt_chip;
+
+/* Register a watchdog as the system watchdog */
+TEE_Result watchdog_register(struct wdt_chip *chip);
+
+static inline
+TEE_Result watchdog_init(unsigned long *min_timeout, unsigned long *max_timeout)
+{
+	if (!wdt_chip)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	if (!wdt_chip->ops->init)
+		return TEE_SUCCESS;
+
+	return wdt_chip->ops->init(wdt_chip, min_timeout, max_timeout);
+}
+
+static inline void watchdog_start(void)
+{
+	if (wdt_chip)
+		wdt_chip->ops->start(wdt_chip);
+}
+
+static inline void watchdog_stop(void)
+{
+	if (wdt_chip && wdt_chip->ops->stop)
+		wdt_chip->ops->stop(wdt_chip);
+}
+
+static inline void watchdog_ping(void)
+{
+	if (wdt_chip)
+		wdt_chip->ops->ping(wdt_chip);
+}
+
+static inline void watchdog_settimeout(unsigned long timeout)
+{
+	if (wdt_chip)
+		wdt_chip->ops->set_timeout(wdt_chip, timeout);
+}
+#else
+static inline TEE_Result watchdog_register(struct wdt_chip *chip __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result watchdog_init(unsigned long *min_timeout __unused,
+				       unsigned long *max_timeout __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline void watchdog_start(void) {}
+static inline void watchdog_stop(void) {}
+static inline void watchdog_ping(void) {}
+static inline void watchdog_settimeout(unsigned long timeout __unused) {}
+#endif
 
 #endif /* DRIVERS_WDT_H */

--- a/core/include/drivers/wdt.h
+++ b/core/include/drivers/wdt.h
@@ -8,6 +8,8 @@
 
 #include <assert.h>
 #include <kernel/interrupt.h>
+#include <kernel/thread.h>
+#include <sm/sm.h>
 #include <tee_api_types.h>
 
 struct wdt_chip {
@@ -94,6 +96,25 @@ static inline void watchdog_start(void) {}
 static inline void watchdog_stop(void) {}
 static inline void watchdog_ping(void) {}
 static inline void watchdog_settimeout(unsigned long timeout __unused) {}
+#endif
+
+#ifdef CFG_WDT_SM_HANDLER
+enum sm_handler_ret __wdt_sm_handler(struct thread_smc_args *args);
+
+static inline
+enum sm_handler_ret wdt_sm_handler(struct thread_smc_args *args)
+{
+	if (args->a0 != CFG_WDT_SM_HANDLER_ID)
+		return SM_HANDLER_PENDING_SMC;
+
+	return __wdt_sm_handler(args);
+}
+#else
+static inline
+enum sm_handler_ret wdt_sm_handler(struct thread_smc_args *args __unused)
+{
+	return SM_HANDLER_PENDING_SMC;
+}
 #endif
 
 #endif /* DRIVERS_WDT_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -801,3 +801,7 @@ endif
 ifeq (y-y,$(CFG_FTRACE_SUPPORT)-$(CFG_TA_PAUTH))
 $(error CFG_FTRACE_SUPPORT and CFG_TA_PAUTH are currently incompatible)
 endif
+
+# Enable support for generic watchdog registration
+# This watchdog will then be usable by non-secure world through SMC calls.
+CFG_WDT ?= n

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -814,3 +814,8 @@ $(eval $(call cfg-enable-all-depends,CFG_WDT_SM_HANDLER,CFG_WDT))
 ifeq (y-,$(CFG_WDT_SM_HANDLER)-$(CFG_WDT_SM_HANDLER_ID))
 $(error CFG_WDT_SM_HANDLER_ID must be defined when enabling CFG_WDT_SM_HANDLER)
 endif
+
+# Allow using the udelay/mdelay function for platforms without ARM generic timer
+# extension. When set to 'n', the plat_get_freq() function must be defined by
+# the platform code
+CFG_CORE_HAS_GENERIC_TIMER ?= y

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -805,3 +805,12 @@ endif
 # Enable support for generic watchdog registration
 # This watchdog will then be usable by non-secure world through SMC calls.
 CFG_WDT ?= n
+
+# Enable watchdog SMC handling compatible with arm-smc-wdt Linux driver
+# When enabled, CFG_WDT_SM_HANDLER_ID must be defined with a SMC ID
+CFG_WDT_SM_HANDLER ?= n
+
+$(eval $(call cfg-enable-all-depends,CFG_WDT_SM_HANDLER,CFG_WDT))
+ifeq (y-,$(CFG_WDT_SM_HANDLER)-$(CFG_WDT_SM_HANDLER_ID))
+$(error CFG_WDT_SM_HANDLER_ID must be defined when enabling CFG_WDT_SM_HANDLER)
+endif


### PR DESCRIPTION
This commits adds a thin glue layer for watchdog access and adds a SMC handler which handles the `arm-smc-wdt` compatible Linux driver [1].

[1] https://lwn.net/Articles/819480/