### PR TITLE
cfg: Add restrictions with CFG_TA_PAUTH

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -789,3 +789,15 @@ $(eval $(call cfg-enable-all-depends,CFG_MEMPOOL_REPORT_LAST_OFFSET, \
 CFG_TA_PAUTH ?= n
 
 $(eval $(call cfg-depends-all,CFG_TA_PAUTH,CFG_ARM64_core))
+
+ifeq (y-y,$(CFG_VIRTUALIZATION)-$(CFG_TA_PAUTH))
+$(error CFG_VIRTUALIZATION and CFG_TA_PAUTH are currently incompatible)
+endif
+
+ifeq (y-y,$(CFG_TA_GPROF_SUPPORT)-$(CFG_TA_PAUTH))
+$(error CFG_TA_GPROF_SUPPORT and CFG_TA_PAUTH are currently incompatible)
+endif
+
+ifeq (y-y,$(CFG_FTRACE_SUPPORT)-$(CFG_TA_PAUTH))
+$(error CFG_FTRACE_SUPPORT and CFG_TA_PAUTH are currently incompatible)
+endif


### PR DESCRIPTION
Linux boot fails with XEN on CPU's with FEAT_PAUTH. So,
CFG_TA_PAUTH currently has not been tested and is incompatible
with CFG_VIRTUALIZATION.

It is also incompatible with debug options like FTRACE and GPROF.

If these incompatible options are selected together by a platform,
compilation will stop and user will be warned with an error
message.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
