### PR TITLE
plat-sam: add suspend mode support

### DIFF
--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -29,6 +29,7 @@ $(call force,CFG_DRIVERS_CLK_FIXED,y)
 $(call force,CFG_DRIVERS_SAM_CLK,y)
 $(call force,CFG_DRIVERS_SAMA5D2_CLK,y)
 $(call force,CFG_PSCI_ARM32,y)
+$(call force,CFG_SM_PLATFORM_HANDLER,y)
 
 # These values are forced because of matrix configuration for secure area.
 # When modifying these, always update matrix settings in

--- a/core/arch/arm/plat-sam/nsec-service/sm_platform_handler.c
+++ b/core/arch/arm/plat-sam/nsec-service/sm_platform_handler.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2021, Microchip
  */
 
+#include <drivers/pm/sam/atmel_pm.h>
 #include <console.h>
 #include <io.h>
 #include <kernel/tee_misc.h>
@@ -14,6 +15,10 @@
 static enum sm_handler_ret sam_sip_handler(struct thread_smc_args *args)
 {
 	switch (OPTEE_SMC_FUNC_NUM(args->a0)) {
+	case SAMA5_SMC_SIP_SET_SUSPEND_MODE:
+		return at91_pm_set_suspend_mode(args);
+	case SAMA5_SMC_SIP_GET_SUSPEND_MODE:
+		return at91_pm_get_suspend_mode(args);
 	default:
 		return SM_HANDLER_PENDING_SMC;
 	}

--- a/core/arch/arm/plat-sam/nsec-service/sm_platform_handler.c
+++ b/core/arch/arm/plat-sam/nsec-service/sm_platform_handler.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Microchip
+ */
+
+#include <console.h>
+#include <io.h>
+#include <kernel/tee_misc.h>
+#include <mm/core_memprot.h>
+#include <sm/optee_smc.h>
+#include <sm/sm.h>
+#include <smc_ids.h>
+
+static enum sm_handler_ret sam_sip_handler(struct thread_smc_args *args)
+{
+	switch (OPTEE_SMC_FUNC_NUM(args->a0)) {
+	default:
+		return SM_HANDLER_PENDING_SMC;
+	}
+
+	return SM_HANDLER_SMC_HANDLED;
+}
+
+enum sm_handler_ret sm_platform_handler(struct sm_ctx *ctx)
+{
+	uint32_t *nsec_r0 = (uint32_t *)(&ctx->nsec.r0);
+	uint16_t smc_owner = OPTEE_SMC_OWNER_NUM(*nsec_r0);
+
+	switch (smc_owner) {
+	case OPTEE_SMC_OWNER_SIP:
+		return sam_sip_handler((struct thread_smc_args *)nsec_r0);
+	default:
+		return SM_HANDLER_PENDING_SMC;
+	}
+}
+

--- a/core/arch/arm/plat-sam/nsec-service/smc_ids.h
+++ b/core/arch/arm/plat-sam/nsec-service/smc_ids.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Microchip
+ */
+
+#ifndef SMC_IDS_H
+#define SMC_IDS_H
+
+#define SAMA5_SMC_SIP_SET_SUSPEND_MODE	0x400
+#define SAMA5_SMC_SIP_GET_SUSPEND_MODE	0x401
+
+/* SAMA5 SMC return codes */
+#define SAMA5_SMC_SIP_RETURN_SUCCESS	0x0
+#define SAMA5_SMC_SIP_RETURN_EINVAL	0x1
+
+#endif /* SMC_IDS_H */

--- a/core/arch/arm/plat-sam/nsec-service/sub.mk
+++ b/core/arch/arm/plat-sam/nsec-service/sub.mk
@@ -1,0 +1,3 @@
+global-incdirs-y += .
+
+srcs-y += sm_platform_handler.c

--- a/core/arch/arm/plat-sam/sub.mk
+++ b/core/arch/arm/plat-sam/sub.mk
@@ -3,3 +3,4 @@ srcs-y += main.c
 srcs-$(CFG_AT91_MATRIX) += matrix.c
 srcs-$(CFG_PL310) += sam_pl310.c
 subdirs-y += pm
+subdirs-y += nsec-service

--- a/core/include/drivers/pm/sam/atmel_pm.h
+++ b/core/include/drivers/pm/sam/atmel_pm.h
@@ -6,6 +6,8 @@
 #define __DRIVERS_PM_SAM_ATMEL_PM_H
 
 #include <compiler.h>
+#include <kernel/thread.h>
+#include <sm/sm.h>
 #include <stdbool.h>
 #include <tee_api_types.h>
 #include <types_ext.h>
@@ -24,6 +26,10 @@ void atmel_pm_cpu_idle(void);
 TEE_Result atmel_pm_suspend(uintptr_t entry, struct sm_nsec_ctx *nsec);
 
 TEE_Result sama5d2_pm_init(const void *fdt, vaddr_t shdwc);
+
+enum sm_handler_ret at91_pm_set_suspend_mode(struct thread_smc_args *args);
+
+enum sm_handler_ret at91_pm_get_suspend_mode(struct thread_smc_args *args);
 
 #else
 
@@ -44,6 +50,18 @@ static inline TEE_Result sama5d2_pm_init(const void *fdt __unused,
 					 vaddr_t shdwc __unused)
 {
 	return TEE_SUCCESS;
+}
+
+static inline enum sm_handler_ret
+at91_pm_set_suspend_mode(struct thread_smc_args *args __unused)
+{
+	return SM_HANDLER_PENDING_SMC;
+}
+
+static inline enum sm_handler_ret
+at91_pm_get_suspend_mode(struct thread_smc_args *args __unused)
+{
+	return SM_HANDLER_PENDING_SMC;
 }
 
 #endif


### PR DESCRIPTION
PSCI allows entering platform suspend with `SYSTEM_SUSPEND` call which is meant to enter the system in its deepest power state. sama5d2 platform supports multiple suspend power states.
Currently, Linux supports the atmel.pm_modes command line option which allows to select this suspend state. Since Linux uses PSCI `SYSTEM_SUSPEND` to enter suspend mode, we are not able to pass information (such as done for `CPU_SUSPEND`).
In order to select the mode that will be entered by `SYSTEM_SUSPEND` from normal world and thus select the desired suspend state, SMCs are added to allow selecting and getting this power mode.

This commits adds `sm_platform_handler()` support as well as handling of SiP SMCs to select/get the suspend mode from Linux.