### PR TITLE
ci: azure: plug-and-trust: disable build warnings

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
           function upload_cache() { if [ ! -e .uploaded ]; then echo Uploading cache && tar c -C $HOME .ccache | gzip -1 | ssh $SCP_OPT optee_os_ci@cache.forissier.org "cat >ccache-$PROJ.tar.gz" && touch .uploaded || echo Nevermind; fi; }
           function check_upload_cache() { NOW=$(date +%s); if [ $(expr $NOW - $START) -gt 3000 ]; then upload_cache; fi; }
           function _make() { make -j$(getconf _NPROCESSORS_ONLN) -s O=out $* && check_upload_cache; }
-          function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.1.1 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
+          function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.1.2 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
 
           download_cache
           ccache -s


### PR DESCRIPTION
The NXP SE05X Plug-and-Trust library generates too many warnings
causing it to flood the CI logs while building.

This commit bumps the Plug-and-Trust library version to a tag where
these warnings have been disabled.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

References: https://github.com/OP-TEE/optee_os/issues/5162

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
