### PR TITLE
pkcs11: keep EC_POINT in attributes for private object creation

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -467,6 +467,7 @@ static const uint32_t ec_private_key_mandated[] = {
 
 static const uint32_t ec_private_key_opt_or_null[] = {
 	PKCS11_CKA_EC_PARAMS,
+	PKCS11_CKA_EC_POINT,
 	PKCS11_CKA_VALUE,
 };
 

--- a/ta/pkcs11/src/processing_ec.c
+++ b/ta/pkcs11/src/processing_ec.c
@@ -568,6 +568,7 @@ enum pkcs11_rc generate_ec_keys(struct pkcs11_attribute_head *proc_params,
 		return PKCS11_CKR_TEMPLATE_INCONSISTENT;
 
 	if (remove_empty_attribute(pub_head, PKCS11_CKA_EC_POINT) ||
+	    remove_empty_attribute(priv_head, PKCS11_CKA_EC_POINT) ||
 	    remove_empty_attribute(priv_head, PKCS11_CKA_VALUE) ||
 	    remove_empty_attribute(priv_head, PKCS11_CKA_EC_PARAMS)) {
 		EMSG("Unexpected attribute(s) found");


### PR DESCRIPTION
EC_POINT attribute should be stored in both private and public object.
Remove the empty EC_POINT attribute when TA try to generate EC keys.

Signed-off-by: Steven Cai <steven.cai@gallagher.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
When using imported EC keypair to sign a digest. It will be failed in c_signinit, which
unable to find the EC_POINT attribute in the private key object. The root cause of that
 is EC_POINT doesn't be stored in the private key object when it's created. This PR
 tries to add the EC_POINT attribute from input templates if it's available. And remove 
the empty EC_POINT attribute when it tries to generate an EC key.

issue: #5165 