### PR TITLE
plat: rcar: enable GIC support and add initial port for Renesas RCar Gen4 

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -5,6 +5,7 @@ include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_SCIF,y)
+$(call force,CFG_GIC,y)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 $(call force,CFG_TEE_CORE_NB_CORE,8)

--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -12,11 +12,30 @@ $(call force,CFG_TEE_CORE_NB_CORE,8)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_LPAE,y)
 
+ifeq ($(PLATFORM_FLAVOR), spider_s4)
+$(call force,CFG_RCAR_GEN4, y)
+else
+$(call force,CFG_RCAR_GEN3, y)
+endif
+
 CFG_TZDRAM_START ?= 0x44100000
 CFG_TZDRAM_SIZE	 ?= 0x03D00000
 CFG_TEE_RAM_VA_SIZE ?= 0x100000
-CFG_HWRNG_QUALITY ?= 1024
-CFG_HWRNG_PTA ?= y
 supported-ta-targets = ta_arm64
 
+ifeq ($(CFG_RCAR_GEN3), y)
+CFG_HWRNG_QUALITY ?= 1024
+CFG_HWRNG_PTA ?= y
 CFG_DT ?= y
+$(call force,CFG_RCAR_ROMAPI, y)
+endif
+
+ifeq ($(CFG_RCAR_GEN4), y)
+# 1xx - for SCIFxx
+# 2xx - for HSCIFxx
+CFG_RCAR_UART ?= 200
+$(call force,CFG_RCAR_ROMAPI, n)
+$(call force,CFG_CORE_CLUSTER_SHIFT, 1)
+$(call force,CFG_ARM_GICV3, y)
+endif
+

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -37,15 +37,18 @@
 #include <rng_support.h>
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, SCIF_REG_SIZE);
-register_phys_mem_pgdir(MEM_AREA_IO_SEC, PRR_BASE, SMALL_PAGE_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
-register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
+#ifdef PRR_BASE
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, PRR_BASE, SMALL_PAGE_SIZE);
+#endif
 
 /* Legacy platforms */
 #if defined(PLATFORM_FLAVOR_salvator_h3) || \
 	defined(PLATFORM_FLAVOR_salvator_h3_4x2g) || \
 	defined(PLATFORM_FLAVOR_salvator_m3) || \
-	defined(PLATFORM_FLAVOR_salvator_m3_2x4g)
+	defined(PLATFORM_FLAVOR_salvator_m3_2x4g) || \
+	defined(PLATFORM_FLAVOR_spider_s4)
 register_ddr(NSEC_DDR_0_BASE, NSEC_DDR_0_SIZE);
 register_ddr(NSEC_DDR_1_BASE, NSEC_DDR_1_SIZE);
 #ifdef NSEC_DDR_2_BASE
@@ -58,7 +61,10 @@ register_ddr(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
 
 static struct scif_uart_data console_data __nex_bss;
 static struct gic_data gic_data __nex_bss;
+
+#ifdef PRR_BASE
 uint32_t rcar_prr_value __nex_bss;
+#endif
 
 void console_init(void)
 {
@@ -66,6 +72,7 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
+#ifdef CFG_RCAR_ROMAPI
 unsigned long plat_get_aslr_seed(void)
 {
 	unsigned long seed = 0;
@@ -77,6 +84,7 @@ unsigned long plat_get_aslr_seed(void)
 
 	return seed;
 }
+#endif
 
 void main_init_gic(void)
 {

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -57,6 +57,7 @@ register_ddr(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
 #endif
 
 static struct scif_uart_data console_data __nex_bss;
+static struct gic_data gic_data __nex_bss;
 uint32_t rcar_prr_value __nex_bss;
 
 void console_init(void)
@@ -76,3 +77,20 @@ unsigned long plat_get_aslr_seed(void)
 
 	return seed;
 }
+
+void main_init_gic(void)
+{
+	gic_init(&gic_data, GICC_BASE, GICD_BASE);
+	itr_init(&gic_data.chip);
+}
+
+void main_secondary_init_gic(void)
+{
+	gic_cpu_init(&gic_data);
+}
+
+void itr_core_handler(void)
+{
+	gic_it_handle(&gic_data);
+}
+

--- a/core/arch/arm/plat-rcar/platform_config.h
+++ b/core/arch/arm/plat-rcar/platform_config.h
@@ -36,6 +36,8 @@
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		RCAR_CACHE_LINE_SZ
 
+#if defined(CFG_RCAR_GEN3)
+
 #define GIC_BASE		0xF1000000
 #define GICC_BASE		0xF1020000
 #define GICD_BASE		0xF1010000
@@ -43,6 +45,19 @@
 #define CONSOLE_UART_BASE	0xE6E88000
 
 #define PRR_BASE		0xFFF00000
+
+#elif defined(CFG_RCAR_GEN4)
+
+#define GICC_BASE		0xF1060000
+#define GICD_BASE		0xF1000000
+
+#if CFG_RCAR_UART == 103	/* SCIF3 */
+#define CONSOLE_UART_BASE	0xE6C50000
+#elif CFG_RCAR_UART == 200	/* HSCIF0 */
+#define CONSOLE_UART_BASE	0xE6540000
+#endif
+
+#endif	/* CFG_RCAR_GENx */
 
 #if defined(PLATFORM_FLAVOR_salvator_h3)
 #define NSEC_DDR_0_BASE		0x47E00000
@@ -77,6 +92,12 @@
 #define NSEC_DDR_1_SIZE		0x80000000
 #define NSEC_DDR_2_BASE		0x600000000U
 #define NSEC_DDR_2_SIZE		0x100000000U
+
+#elif defined(PLATFORM_FLAVOR_spider_s4)
+#define NSEC_DDR_0_BASE		0x48000000
+#define NSEC_DDR_0_SIZE		0x78000000
+#define NSEC_DDR_1_BASE		0x480000000U
+#define NSEC_DDR_1_SIZE		0x80000000U
 
 #else
 

--- a/core/arch/arm/plat-rcar/sub.mk
+++ b/core/arch/arm/plat-rcar/sub.mk
@@ -1,6 +1,6 @@
 global-incdirs-y += .
 srcs-y += main.c
-srcs-y += core_pos_a64.S
-srcs-y += romapi.c
-srcs-y += romapi_call.S
-srcs-y += hw_rng.c
+srcs-${CFG_RCAR_GEN3} += core_pos_a64.S
+srcs-${CFG_RCAR_ROMAPI} += romapi.c
+srcs-${CFG_RCAR_ROMAPI} += romapi_call.S
+srcs-${CFG_RCAR_ROMAPI} += hw_rng.c


### PR DESCRIPTION
There are two patches, first one adds GIC support for Gen3, second one adds support for Gen4.

