### PR TITLE
core: imx: add missing imx6 SoC IDs to soc_is_imx6()

### DIFF
--- a/core/arch/arm/plat-imx/imx-common.c
+++ b/core/arch/arm/plat-imx/imx-common.c
@@ -140,11 +140,12 @@ bool soc_is_imx6dqp(void)
 
 bool soc_is_imx6(void)
 {
-	return ((imx_soc_type() == SOC_MX6SX) ||
-			(imx_soc_type() == SOC_MX6UL) ||
-			(imx_soc_type() == SOC_MX6ULL) ||
-			(imx_soc_type() == SOC_MX6DL) ||
-			(imx_soc_type() == SOC_MX6Q));
+	uint32_t soc = imx_soc_type();
+
+	return (soc == SOC_MX6SLL) || (soc == SOC_MX6SL) ||
+	       (soc == SOC_MX6D) || (soc == SOC_MX6SX) ||
+	       (soc == SOC_MX6UL) || (soc == SOC_MX6ULL) ||
+	       (soc == SOC_MX6DL) || (soc == SOC_MX6Q);
 }
 
 bool soc_is_imx7ds(void)


### PR DESCRIPTION
Add the following SoC IDs to soc_is_imx6()
 - SOC_MX6SL
 - SOC_MX6SLL
 - SOC_MX6D

Fixes: 16e73240d ("core: imx: add CSU module")
Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
