### PR TITLE
drivers: crypto: add parameter checks for RSA signature

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/rsassa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsassa.c
@@ -743,6 +743,9 @@ static TEE_Result rsassa_pss_sign(struct drvcrypt_rsa_ssa *ssa_data)
 	modBits--;
 	EM.length = ROUNDUP(modBits, 8) / 8;
 
+	if (EM.length < ssa_data->digest_size + ssa_data->salt_len + 2)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	EM.data = malloc(EM.length);
 	if (!EM.data)
 		return TEE_ERROR_OUT_OF_MEMORY;
@@ -813,6 +816,9 @@ static TEE_Result rsassa_pss_verify(struct drvcrypt_rsa_ssa *ssa_data)
 	 */
 	modBits--;
 	EM.length = ROUNDUP(modBits, 8) / 8;
+
+	if (EM.length < ssa_data->digest_size + ssa_data->salt_len + 2)
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	EM.data = malloc(EM.length);
 	if (!EM.data)


### PR DESCRIPTION
Add size check in the crypto driver for RSA sign and verify functions.
For both functions, the encoded message length has some size
constraints [1].

[1]: Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography
https://datatracker.ietf.org/doc/html/rfc3447#section-9.1.1

Fixes: f5a70e3ef ("drivers: crypto: generic resources for crypto device driver - RSA")
Signed-off-by: Cedric Neveux <cedric.neveux@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
