### PR TITLE
[Hikey] Define SDP in embedded dtb

### DIFF
--- a/core/arch/arm/dts/hikey_sdp.dts
+++ b/core/arch/arm/dts/hikey_sdp.dts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, NXP. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		sdp@0x3e800000 {
+			reg = <0x3E800000 0x00400000>;
+		};
+	};
+};

--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -44,6 +44,8 @@ CFG_TEE_SDP_MEM_SIZE ?= 0x00400000
 ifeq ($(PLATFORM_FLAVOR),hikey)
 CFG_CONSOLE_UART ?= 3
 CFG_DRAM_SIZE_GB ?= 2
+
+flavor_dts_file-hikey = hikey_sdp.dts
 endif
 
 ifeq ($(PLATFORM_FLAVOR),hikey960)
@@ -57,6 +59,8 @@ endif
 ifneq (,$(filter 4 6,$(CFG_DRAM_SIZE_GB)))
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 endif
+
+flavor_dts_file-hikey960 = hikey_sdp.dts
 endif
 
 CFG_TZDRAM_START ?= 0x3F000000
@@ -66,3 +70,7 @@ CFG_SHMEM_SIZE ?= 0x00200000
 CFG_TEE_RAM_VA_SIZE ?= 0x00200000
 
 CFG_IN_TREE_EARLY_TAS += avb/023f8f1a-292a-432b-8fc4-de8471358067
+
+ifneq ($(flavor_dts_file-$(PLATFORM_FLAVOR)),)
+CFG_EMBED_DTB_SOURCE_FILE ?= $(flavor_dts_file-$(PLATFORM_FLAVOR))
+endif


### PR DESCRIPTION
Allow definition of the Secure Data Path memory region in an embedded dtb
It remove SDP memory intersection checking as embedded DTB is not
available during init of tee core memory mapping

Comply with reserved memory bindings
Linux documentation file:
Documentation/devicetree/bindings/reserved-memory/reserved-memory.yaml

Signed-off-by: Olivier Masse <olivier.masse@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
