### PR TITLE
plat: arm: refactor GIC initialization

### DIFF
--- a/core/arch/arm/plat-aspeed/platform_ast2600.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2600.c
@@ -61,17 +61,7 @@ static struct gic_data gic_data;
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base = 0;
-	vaddr_t gicd_base = 0;
-
-	gicc_base = core_mmu_get_va(GIC_BASE + GICC_OFFSET,
-				    MEM_AREA_IO_SEC, SMALL_PAGE_SIZE);
-	gicd_base = core_mmu_get_va(GIC_BASE + GICD_OFFSET,
-				    MEM_AREA_IO_SEC, SMALL_PAGE_SIZE);
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -117,33 +117,12 @@ void console_init(void)
 
 void main_init_gic(void)
 {
-#ifdef CFG_ARM_GICV3
-	vaddr_t gicd_base;
-
-	gicd_base = core_mmu_get_va(GICD_BASE, MEM_AREA_IO_SEC, 0x10000);
-
-	if (!gicd_base)
-		panic();
-
-	/* Initialize GIC */
-	gic_init(&gic_data, 0, gicd_base);
-	itr_init(&gic_data.chip);
+#ifdef GICD_BASE
+	gic_init(&gic_data, 0, GICD_BASE);
 #else
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = core_mmu_get_va(GIC_BASE + GICC_OFFSET, MEM_AREA_IO_SEC,
-				    1);
-	gicd_base = core_mmu_get_va(GIC_BASE + GICD_OFFSET, MEM_AREA_IO_SEC,
-				    0x10000);
-
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	/* Initialize GIC */
-	gic_init(&gic_data, gicc_base, gicd_base);
-	itr_init(&gic_data.chip);
+	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 #endif
+	itr_init(&gic_data.chip);
 }
 
 #if CFG_TEE_CORE_NB_CORE > 1

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -202,9 +202,6 @@ static void get_gic_offset(uint32_t *offsetc, uint32_t *offsetd)
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base = 0;
-	vaddr_t gicd_base = 0;
-
 	paddr_t gic_base = 0;
 	uint32_t gicc_offset = 0;
 	uint32_t gicd_offset = 0;
@@ -217,19 +214,13 @@ void main_init_gic(void)
 #endif
 	get_gic_offset(&gicc_offset, &gicd_offset);
 
-	gicc_base = (vaddr_t)phys_to_virt(gic_base + gicc_offset,
-					  MEM_AREA_IO_SEC, 1);
-	gicd_base = (vaddr_t)phys_to_virt(gic_base + gicd_offset,
-					  MEM_AREA_IO_SEC, 1);
-	if (!gicc_base || !gicd_base)
-		panic();
-
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	gic_init_base_addr(&gic_data, gic_base + gicc_offset,
+			   gic_base + gicd_offset);
 #else
 	/* Initialize GIC */
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, gic_base + gicc_offset, gic_base + gicd_offset);
 #endif
 	itr_init(&gic_data.chip);
 }

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -26,21 +26,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base = 0;
-	vaddr_t gicd_base = 0;
-
-#if !defined(CFG_ARM_GICV3)
-	gicc_base = (vaddr_t)phys_to_virt(GICC_BASE, MEM_AREA_IO_SEC, 1);
-	if (!gicc_base)
-		panic();
-#endif
-
-	gicd_base = (vaddr_t)phys_to_virt(GICD_BASE, MEM_AREA_IO_SEC, 1);
-	if (!gicd_base)
-		panic();
-
-	/* Initialize GIC */
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, GICC_BASE, GICD_BASE);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-rzn1/main.c
+++ b/core/arch/arm/plat-rzn1/main.c
@@ -44,16 +44,7 @@ void console_init(void)
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base = 0;
-	vaddr_t gicd_base = 0;
-
-	gicc_base = (vaddr_t)phys_to_virt(GICC_BASE, MEM_AREA_IO_SEC, 1);
-	gicd_base = (vaddr_t)phys_to_virt(GICD_BASE, MEM_AREA_IO_SEC, 1);
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	gic_init(&gic_data, gicc_base, gicd_base);
-
+	gic_init(&gic_data, GICC_BASE, GICD_BASE);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -135,16 +135,7 @@ void plat_primary_init_early(void)
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_CPU_BASE, MEM_AREA_IO_SEC, 1);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_DIST_BASE, MEM_AREA_IO_SEC, 1);
-
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, GIC_CPU_BASE, GIC_DIST_BASE);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -156,9 +156,7 @@ void itr_core_handler(void)
 
 void main_init_gic(void)
 {
-	assert(cpu_mmu_enabled());
-
-	gic_init(&gic_data, get_gicc_base(), get_gicd_base());
+	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 	itr_init(&gic_data.chip);
 
 	stm32mp_register_online_cpu();
@@ -191,13 +189,6 @@ static TEE_Result init_stm32mp1_drivers(void)
 	return TEE_SUCCESS;
 }
 service_init_late(init_stm32mp1_drivers);
-
-vaddr_t get_gicc_base(void)
-{
-	struct io_pa_va base = { .pa = GIC_BASE + GICC_OFFSET };
-
-	return io_pa_or_va_secure(&base, 1);
-}
 
 vaddr_t get_gicd_base(void)
 {

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -24,7 +24,6 @@ void stm32mp_syscfg_enable_io_compensation(void);
 void stm32mp_syscfg_disable_io_compensation(void);
 
 /* Platform util for the GIC */
-vaddr_t get_gicc_base(void);
 vaddr_t get_gicd_base(void);
 
 /*

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -128,17 +128,7 @@ static inline void tzpc_init(void)
 #ifndef CFG_WITH_ARM_TRUSTED_FW
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = core_mmu_get_va(GIC_BASE + GICC_OFFSET, MEM_AREA_IO_SEC, 1);
-	gicd_base = core_mmu_get_va(GIC_BASE + GICD_OFFSET, MEM_AREA_IO_SEC, 1);
-
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	/* Initialize GIC */
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -38,17 +38,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GICC_BASE, MEM_AREA_IO_SEC,
-					  GICC_SIZE);
-	gicd_base = (vaddr_t)phys_to_virt(GICD_BASE, MEM_AREA_IO_SEC,
-					  GICD_SIZE);
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, GICC_BASE, GICD_BASE);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -50,22 +50,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC, GIC_CPU_REG_SIZE);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, GIC_DIST_REG_SIZE);
-	if (!gicc_base || !gicd_base)
-		panic();
-
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
+			   GIC_BASE + GICD_OFFSET);
 #else
-	/* Initialize GIC */
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 #endif
 	itr_init(&gic_data.chip);
 }

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -144,19 +144,7 @@ void arm_cl2_enable(vaddr_t pl310_base)
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	/* Initialize GIC */
-	gic_init(&gic_data, gicc_base, gicd_base);
+	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -182,9 +182,9 @@ void gic_init(struct gic_data *gd, paddr_t gicc_base_pa, paddr_t gicd_base_pa)
 		/* Mark interrupts non-secure */
 		if (n == 0) {
 			/* per-CPU inerrupts config:
-                         * ID0-ID7(SGI)   for Non-secure interrupts
-                         * ID8-ID15(SGI)  for Secure interrupts.
-                         * All PPI config as Non-secure interrupts.
+			 * ID0-ID7(SGI)	  for Non-secure interrupts
+			 * ID8-ID15(SGI)  for Secure interrupts.
+			 * All PPI config as Non-secure interrupts.
 			 */
 			io_write32(gd->gicd_base + GICD_IGROUPR(n), 0xffff00ff);
 		} else {

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -31,10 +31,10 @@ struct gic_data {
  * then used by the other functions.
  */
 
-void gic_init(struct gic_data *gd, vaddr_t gicc_base, vaddr_t gicd_base);
+void gic_init(struct gic_data *gd, paddr_t gicc_base_pa, paddr_t gicd_base_pa);
 /* initial base address only */
-void gic_init_base_addr(struct gic_data *gd, vaddr_t gicc_base,
-			vaddr_t gicd_base);
+void gic_init_base_addr(struct gic_data *gd, paddr_t gicc_base_pa,
+			paddr_t gicd_base_pa);
 /* initial cpu if only, mainly use for secondary cpu setup cpu interface */
 void gic_cpu_init(struct gic_data *gd);
 


### PR DESCRIPTION
All platforms (except STM32MP1) follow the same pattern during GIC
initialization: get virtual addresses for distributor (and optionally,
for CPU interface), check that they are not NULL, call either
`gic_init()` or `gic_init_base_addr()`.

We can move most of this logic into `gic_init_base_addr()` while platform
code will supply only base physical addresses for distributor and CPU
interface. This will simplify and align platform code.

ST32MP1 had more complex logic, as it used `io_pa_or_va_secure()` to get
MMIO range addresses. However, as `main_init_gic()` called
`assert(cpu_mmu_enabled())`, there is no sense in using
`io_pa_or_va_secure()`, because we already ensured that VA will be
always used. Thus `assert()` call was moved to `gic_init_base_addr()`, and
STM32MP1 were aligned with other platforms.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

---

This PR is the result of discussion in https://github.com/OP-TEE/optee_os/pull/5168
