### PR TITLE
plat-imx: Add SA settings for i.MX7DS

### DIFF
--- a/core/arch/arm/plat-imx/drivers/imx_csu.c
+++ b/core/arch/arm/plat-imx/drivers/imx_csu.c
@@ -73,13 +73,14 @@ const struct csu_setting csu_setting_imx7ds[] = {
 
 /* Set all masters to non-secure except the Cortex-A7 */
 const struct csu_sa_setting csu_sa_imx6ul = { 0x10554550, 0x20aa8aa2 };
+const struct csu_sa_setting csu_sa_imx7ds = { 0x15554554, 0x2aaa8aaa };
 
 const struct csu_config csu_imx6 = { NULL, csu_setting_imx6 };
 const struct csu_config csu_imx6ul = { &csu_sa_imx6ul, csu_setting_imx6ul };
 const struct csu_config csu_imx6ull = { NULL, csu_setting_imx6ull };
 const struct csu_config csu_imx6sl = { NULL, csu_setting_imx6sl };
 const struct csu_config csu_imx6sx = { NULL, csu_setting_imx6sx };
-const struct csu_config csu_imx7ds = { NULL, csu_setting_imx7ds };
+const struct csu_config csu_imx7ds = { &csu_sa_imx7ds, csu_setting_imx7ds };
 
 static void rngb_configure(vaddr_t csu_base)
 {


### PR DESCRIPTION
The Secure Access register configures the access mode for
non-TrustZone aware DMA masters. To ensure that no DMA master can read
the secure memory for OP-TEE, we set access for all masters except the
ARM CP15 register to non-secure only and lock the settings afterwards.

Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
