### PR TITLE
RFC fault mitigation

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1311,7 +1311,7 @@ static void __noinline hej_test(void)
 	if (res)
 		goto err;
 
-	ftmn_expect_state(&check, FTMN_STEP_COUNT1(3), res);
+	ftmn_expect_state(&check, FTMN_INCR1, FTMN_STEP_COUNT1(3), res);
 	DMSG("end OK");
 	return;
 err:

--- a/core/include/signed_hdr.h
+++ b/core/include/signed_hdr.h
@@ -5,6 +5,7 @@
 #ifndef SIGNED_HDR_H
 #define SIGNED_HDR_H
 
+#include <fault_mitigation.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <tee_api_types.h>
@@ -146,6 +147,7 @@ static inline void shdr_free(struct shdr *shdr)
  *
  * Returns TEE_SUCCESS on success or TEE_ERROR_SECURITY on failure
  */
-TEE_Result shdr_verify_signature(const struct shdr *shdr);
+TEE_Result shdr_verify_signature(const struct shdr *shdr,
+				 struct ftmn_func_arg *ftmn_arg);
 
 #endif /*SIGNED_HDR_H*/

--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -160,7 +160,7 @@ static TEE_Result ree_fs_ta_open(const TEE_UUID *uuid,
 	FTMN_CALL_FUNC(res, &check, FTMN_INCR0, shdr_verify_signature, shdr);
 	if (res != TEE_SUCCESS)
 		goto error_free_payload;
-	ftmn_expect_state(&check, FTMN_STEP_COUNT1(1), res);
+	ftmn_expect_state(&check, FTMN_INCR1, FTMN_STEP_COUNT1(1), res);
 
 	if (shdr->img_type != SHDR_TA && shdr->img_type != SHDR_BOOTSTRAP_TA &&
 	    shdr->img_type != SHDR_ENCRYPTED_TA) {

--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -137,6 +137,7 @@ static TEE_Result ree_fs_ta_open(const TEE_UUID *uuid,
 	size_t offs = 0;
 	struct shdr_bootstrap_ta *bs_hdr = NULL;
 	struct shdr_encrypted_ta *ehdr = NULL;
+	struct ftmn_check check = { };
 	size_t shdr_sz = 0;
 
 	handle = calloc(1, sizeof(*handle));
@@ -156,9 +157,11 @@ static TEE_Result ree_fs_ta_open(const TEE_UUID *uuid,
 	}
 
 	/* Validate header signature */
-	res = shdr_verify_signature(shdr);
+	FTMN_CALL_FUNC(res, &check, FTMN_INCR0, shdr_verify_signature, shdr);
 	if (res != TEE_SUCCESS)
 		goto error_free_payload;
+	ftmn_expect_state(&check, FTMN_STEP_COUNT1(1), res);
+
 	if (shdr->img_type != SHDR_TA && shdr->img_type != SHDR_BOOTSTRAP_TA &&
 	    shdr->img_type != SHDR_ENCRYPTED_TA) {
 		res = TEE_ERROR_SECURITY;

--- a/core/pta/secstor_ta_mgmt.c
+++ b/core/pta/secstor_ta_mgmt.c
@@ -139,8 +139,9 @@ err:
 static TEE_Result bootstrap(uint32_t param_types,
 			    TEE_Param params[TEE_NUM_PARAMS])
 {
-	TEE_Result res;
-	struct shdr *shdr;
+	TEE_Result res = TEE_SUCCESS;
+	struct shdr *shdr = NULL;
+	struct ftmn_check check = { };
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 						TEE_PARAM_TYPE_NONE,
 						TEE_PARAM_TYPE_NONE,
@@ -153,9 +154,10 @@ static TEE_Result bootstrap(uint32_t param_types,
 	if (!shdr)
 		return TEE_ERROR_SECURITY;
 
-	res = shdr_verify_signature(shdr);
+	FTMN_CALL_FUNC(res, &check, FTMN_INCR0, shdr_verify_signature, shdr);
 	if (res)
 		goto out;
+	ftmn_expect_state(&check, FTMN_STEP_COUNT1(1), res);
 
 	res = install_ta(shdr, params->memref.buffer, params->memref.size);
 out:

--- a/lib/libutils/ext/arch/arm/fault_mitigation_a32.S
+++ b/lib/libutils/ext/arch/arm/fault_mitigation_a32.S
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <asm.S>
+
+/*
+ * void ftmn_expect_val(struct ftmn_check *check, enum ftmn_incr incr,
+ *			unsigned long ret, unsigned long val)
+ * {
+ * 	if (ret != val)
+ * 		ftmn_panic();
+ * 	check->steps += incr;
+ * }
+ */
+FUNC ftmn_expect_val , :
+	/*
+	 * Clear PSTATE.Z and swap r0 and r1 to make sure that the
+	 * instruction just before the test must be executed.
+	 *
+	 * Make reduntant comparisons interleaved with the xoring to make
+	 * it harder to glitch a cmp instruction without affecting an
+	 * eor(s).
+	 *
+	 * Note that the ldreq depends on r0 and r1 being swapped so it's a
+	 * way of seeing that the instructions just before the cmp wasn't
+	 * glitched either.
+	 */
+	eors	r0, r0, r1
+	cmp	r2, r3
+	eor	r1, r1, r0
+	bne	ftmn_do_panic
+	eors	r0, r0, r1
+	cmp	r2, r3
+	ldreq	r2, [r1]
+	bne	ftmn_do_panic
+	addeq	r2, r2, r0
+	streq	r2, [r1]
+	blx	lr
+END_FUNC ftmn_expect_val
+
+/*
+ * void ftmn_expect_not_val(struct ftmn_check *check, enum ftmn_incr incr,
+ *			    unsigned long ret, unsigned long val);
+ * {
+ * 	if (ret == val)
+ * 		ftmn_panic();
+ * 	check->steps += incr;
+ * }
+ */
+FUNC ftmn_expect_not_val , :
+	/*
+	 * Set PSTATE.Z and swap r0 and r1 to make sure that the
+	 * instruction just before the test must be executed.
+	 *
+	 * Make reduntant comparisons interleaved with the xoring to make
+	 * it harder to glitch a cmp instruction without affecting an
+	 * eor(s).
+	 *
+	 * Note that the ldreq depends on r0 and r1 being swapped so it's a
+	 * way of seeing that the instructions just before the cmp wasn't
+	 * glitched either.
+	 */
+	eors	r12, r12, r12
+	cmp	r2, r3
+	eor	r0, r0, r1
+	beq	ftmn_do_panic
+	eors	r12, r12, r12
+	eor	r1, r1, r0
+	eor	r0, r0, r1
+	cmp	r2, r3
+	ldrne	r2, [r1]
+	beq	ftmn_do_panic
+	addne	r2, r2, r0
+	strne	r2, [r1]
+	blx	lr
+END_FUNC ftmn_expect_not_val
+
+/*
+ * unsigned long __ftmn_return_val(unsigned long hashed_val, unsigned long hash,
+ *				   unsigned long val)
+ * {
+ * 	if ((hashed_val ^ hash) != val)
+ * 		ftmn_panic();
+ * 	return val;
+ * }
+ */
+FUNC __ftmn_return_val , :
+	/*
+	 * r0 holds a bit pattern which is very unlikely the desired return
+	 * value. When extracting the return value be careful to only update
+	 * r0 once we're just about to return.
+	 */
+	cmp	r1, #0
+	eor	r3, r0, r1
+	cmp	r3, r2
+	bne	ftmn_do_panic
+	cmp	r1, #0
+	mov	r12, r3
+	cmp	r12, r2
+	bne	ftmn_do_panic
+	mov	r0, r12
+	blx	lr
+END_FUNC __ftmn_return_val
+
+#ifdef __KERNEL__
+LOCAL_FUNC ftmn_do_panic , :
+#ifdef CFG_TEE_CORE_DEBUG
+	/* Be nice to the stack unwinding */
+	push	{r12, lr}
+UNWIND(	.save	{r12, lr})
+	adr	r0, 1f
+	mov	r1, #__LINE__
+#else
+UNWIND(	.cantunwind)
+	mov	r0, #0
+	mov	r1, #0
+#endif
+	mov	r2, #0
+	mov	r3, #0
+	bl	__do_panic
+#ifdef CFG_TEE_CORE_DEBUG
+1:	.asciz __FILE__
+	.balign 4
+#endif
+END_FUNC ftmn_do_panic
+
+#else /* !__KERNEL__*/
+LOCAL_FUNC ftmn_do_panic , :
+	mov	r0, #0
+	bl	TEE_Panic
+END_FUNC ftmn_do_panic
+#endif

--- a/lib/libutils/ext/arch/arm/fault_mitigation_a64.S
+++ b/lib/libutils/ext/arch/arm/fault_mitigation_a64.S
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <asm.S>
+
+/*
+ * void ftmn_expect_val(struct ftmn_check *check, enum ftmn_incr incr,
+ *			unsigned long ret, unsigned long val);
+ */
+FUNC ftmn_expect_val , :
+	/*
+	 * Clear PSTATE.Z and swap x0 and x1 to make sure that the
+	 * instruction just before the test must be executed.
+	 *
+	 * Make reduntant comparisons interleaved with the xoring to make
+	 * it harder to glitch a cmp instruction without affecting an
+	 * eor(s).
+	 *
+	 * Note that the ldr depends on x0 and x1 being swapped so it's a
+	 * way of seeing that the instructions just before the cmp wasn't
+	 * glitched either.
+	 */
+	subs	x4, x4, x4
+	eor	x0, x0, x1
+	cmp	x2, x3
+	b.ne	ftmn_do_panic
+	eor	x1, x1, x0
+	b.ne	ftmn_do_panic
+	subs	x4, x4, x4
+	eor	x0, x0, x1
+	cmp	x2, x3
+	b.ne	ftmn_do_panic
+	ldr	x2, [x1]
+	b.ne	ftmn_do_panic
+	add	x2, x2, x0
+	b.ne	ftmn_do_panic
+	str	x2, [x1]
+	br	lr
+	b	ftmn_do_panic
+END_FUNC ftmn_expect_val
+
+/*
+ * void ftmn_expect_not_val(struct ftmn_check *check, enum ftmn_incr incr,
+ *			    unsigned long ret, unsigned long val);
+ */
+FUNC ftmn_expect_not_val , :
+	/*
+	 * Set PSTATE.Z and swap r0 and r1 to make sure that the
+	 * instruction just before the test must be executed.
+	 *
+	 * Make reduntant comparisons interleaved with the xoring to make
+	 * it harder to glitch a cmp instruction without affecting an
+	 * eor(s).
+	 *
+	 * Note that the ldreq depends on r0 and r1 being swapped so it's a
+	 * way of seeing that the instructions just before the cmp wasn't
+	 * glitched either.
+	 */
+	subs	x4, x4, x4
+	eor	x0, x0, x1
+	cmp	x2, x3
+	b.eq	ftmn_do_panic
+	eor	x1, x1, x0
+	b.eq	ftmn_do_panic
+	subs	x4, x4, x4
+	eor	x0, x0, x1
+	cmp	x2, x3
+	b.eq	ftmn_do_panic
+	ldr	x2, [x1]
+	b.eq	ftmn_do_panic
+	add	x2, x2, x0
+	b.eq	ftmn_do_panic
+	str	x2, [x1]
+	br	lr
+	b	ftmn_do_panic
+END_FUNC ftmn_expect_not_val
+
+#ifdef __KERNEL__
+LOCAL_FUNC ftmn_do_panic , :
+#ifdef CFG_TEE_CORE_DEBUG
+	adr	x0, 1f
+	mov	x1, #__LINE__
+#else
+	mov	x0, #0
+	mov	x1, #0
+#endif
+	mov	x2, #0
+	mov	x3, #0
+	bl	__do_panic
+#ifdef CFG_TEE_CORE_DEBUG
+1:	.asciz __FILE__
+	.balign 4
+#endif
+END_FUNC ftmn_do_panic
+
+#else /* !__KERNEL__*/
+LOCAL_FUNC ftmn_do_panic , :
+	mov	x0, #0
+	bl	TEE_Panic
+END_FUNC ftmn_do_panic
+#endif

--- a/lib/libutils/ext/arch/arm/sub.mk
+++ b/lib/libutils/ext/arch/arm/sub.mk
@@ -8,3 +8,6 @@ ifneq ($(sm),ldelf) # TA, core
 srcs-$(CFG_ARM32_$(sm)) += mcount_a32.S
 srcs-$(CFG_ARM64_$(sm)) += mcount_a64.S
 endif
+srcs-$(CFG_ARM32_$(sm)) += fault_mitigation_a32.S
+srcs-$(CFG_ARM64_$(sm)) += fault_mitigation_a64.S
+

--- a/lib/libutils/ext/fault_mitigation.c
+++ b/lib/libutils/ext/fault_mitigation.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <compiler.h>
+#include <fault_mitigation.h>
+
+/*
+ * These functions are supposed to be implemented in assembly providing
+ * the same API but an implementation more resilient to fault injections.
+ *
+ * The implementations are here as way of documenting the assembly versions
+ * as they are more cryptic than normal assmebly functions.
+ */
+
+void __weak __ftmn_change_val(struct ftmn_check *check, enum ftmn_incr incr,
+			     unsigned long hash, unsigned long old_val,
+			     unsigned long new_val)
+{
+	if ((check->val ^ hash) != old_val)
+		ftmn_panic();
+	check->val = new_val ^ hash;
+	check->steps += incr;
+}
+
+void __weak __ftmn_rehash_val(struct ftmn_check *check, enum ftmn_incr incr,
+			      unsigned long old_hashed_val,
+			      unsigned long old_hash, unsigned long new_hash,
+			      unsigned long val)
+{
+	if ((old_hashed_val ^ old_hash) != val)
+		ftmn_panic();
+	check->val = val ^ new_hash;
+	check->steps += incr;
+}
+
+unsigned long __weak __ftmn_return_val(unsigned long hashed_val,
+				       unsigned long hash, unsigned long val)
+{
+	if ((hashed_val ^ hash) != val)
+		ftmn_panic();
+	return val;
+}
+
+void __weak __ftmn_expect_val(struct ftmn_check *check, enum ftmn_incr incr,
+			      unsigned long ret, unsigned long val)
+{
+	if (ret != val)
+		ftmn_panic();
+	check->steps += incr;
+}
+
+void __weak __ftmn_expect_not_val(struct ftmn_check *check, enum ftmn_incr incr,
+				  unsigned long ret, unsigned long val)
+{
+	if (ret == val)
+		ftmn_panic();
+	check->steps += incr;
+}

--- a/lib/libutils/ext/include/fault_mitigation.h
+++ b/lib/libutils/ext/include/fault_mitigation.h
@@ -8,13 +8,8 @@
 #include <config.h>
 #ifdef __KERNEL__
 #include <kernel/panic.h>
-#include <io.h>
 #else
-#include <compiler.h>
 #include <tee_api.h>
-
-#define READ_ONCE(p)		__compiler_atomic_load(&(p))
-#define WRITE_ONCE(p, v)	__compiler_atomic_store(&(p), (v))
 #endif
 
 /*
@@ -295,13 +290,14 @@ static inline void ftmn_expect_not_null(struct ftmn_check *check,
 }
 
 static inline void ftmn_expect_state(struct ftmn_check *check,
-				     unsigned long steps, unsigned long val)
+				     enum ftmn_incr incr, unsigned long steps,
+				     unsigned long val)
 {
 	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION)) {
-		ftmn_expect_val(check, FTMN_INCR_RESERVED, check->steps, steps);
+		ftmn_expect_val(check, incr, check->steps, steps);
 		if ((check->val ^ FTMN_DEFAULT_HASH) != val)
 			ftmn_panic();
-		if (check->steps != (steps + FTMN_INCR_RESERVED))
+		if (check->steps != (steps + incr))
 			ftmn_panic();
 	}
 }

--- a/lib/libutils/ext/include/fault_mitigation.h
+++ b/lib/libutils/ext/include/fault_mitigation.h
@@ -1,0 +1,317 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+#ifndef __FAULT_MITIGATION_H
+#define __FAULT_MITIGATION_H
+
+#include <config.h>
+#ifdef __KERNEL__
+#include <kernel/panic.h>
+#include <io.h>
+#else
+#include <compiler.h>
+#include <tee_api.h>
+
+#define READ_ONCE(p)		__compiler_atomic_load(&(p))
+#define WRITE_ONCE(p, v)	__compiler_atomic_store(&(p), (v))
+#endif
+
+/*
+ * Fault migitigation helpers to make successful Hardware Fault Attacks
+ * harder to achieve. The paper [1] by Riscure gives background to the
+ * problem.
+ *
+ * Sensitive function can use these helpers to add an extra layer of
+ * protection as in this simple example:
+ *
+ * // This function must only return 0 on success anything else is a failure
+ * uint32_t sensitive_function(void)
+ * {
+ *	struct ftmn_check chk = { };
+ *	uint32_t res = 0;
+ *	uint32_t value = 0;
+ *
+ *	// if read_some_value() fails it returns a non-zero value
+ *	res = read_some_value(&value);
+ *
+ *	// First we check the return value and if OK check it again
+ *	// with ftmn_check() which will increas and internal counter and
+ *	// return true if OK
+ *	if (res || !ftmn_check(&chk, FTMN_INCR0, res))
+ *		goto out;
+ *
+ *	// Again, first check that we have the expected value then
+ *	// check it again with ftmn_exp_res_check().
+ *	if (value != 42 || !ftmn_exp_res_check(&chk, FTMN_INCR1, 42, value))
+ *		res = 0xffffff01;
+ *
+ * out:
+ *	// If res is 0 ftmn_final() checks that the two functions ftmn_check()
+ *	// and ftmn_exp_res_check() has succeeded with help of the constant
+ *	// provided by FTMN_STEP_COUNT2(). If the numbers doesn't add up
+ *	// 0xffffff02 will be returned instead.
+ *	return ftmn_final(0xffffff02, &chk, FTMN_STEP_COUNT2(1, 1), res);
+ * }
+ *
+ * With this pattern applied an attacker will need to do at least a double
+ * glitch (glitch at least one instruction, execute some instructions, and
+ * glitch at least one more instruction) while this function or one of the
+ * ftmn_*() functions are executed.
+ *
+ * [1] https://www.riscure.com/uploads/2020/05/Riscure_Whitepaper_Fault_Mitigation_Patterns_final.pdf
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+struct ftmn_check {
+	unsigned long steps;
+	unsigned long val;
+};
+
+struct ftmn_func_arg {
+	unsigned long hash;
+	unsigned long ret;
+};
+
+enum ftmn_incr {
+	FTMN_INCR0 = 7873,
+	FTMN_INCR1 = 7877,
+	FTMN_INCR2 = 7879,
+	FTMN_INCR3 = 7883,
+	FTMN_INCR4 = 7901,
+	FTMN_INCR5 = 7907,
+	FTMN_INCR_RESERVED = 7919,
+};
+
+#ifdef __ILP32__
+#define FTMN_DEFAULT_HASH	0x9c478bf6UL
+#else
+#define FTMN_DEFAULT_HASH	0xc478bf63e9500cb5UL
+#endif
+/*
+ * Function names are "hashed" into an unsigned long. The "hashing" is done
+ * by xoring each 32/64 bit word of the function name producing a bit
+ * pattern that should be mostly unique for each function. Only the first
+ * 256 characters of the name are used when xoring as this is expected to
+ * be optimized to be calculated when compiling the source code in order to
+ * minimize the overhead.
+ */
+#define __FTMN_MAX_FUNC_LEN	256
+
+#define __FUNC_BYTE(f, o, l)	((o) < (l) ? (uint8_t)(f)[(o)] : 0)
+
+#define __FTMN_GET_FUNC_U64(f, o, l) \
+	(SHIFT_U64(__FUNC_BYTE((f), (o), (l)), 0) | \
+	 SHIFT_U64(__FUNC_BYTE((f), (o) + 1, (l)), 8) | \
+	 SHIFT_U64(__FUNC_BYTE((f), (o) + 2, (l)), 16) | \
+	 SHIFT_U64(__FUNC_BYTE((f), (o) + 3, (l)), 24) | \
+	 SHIFT_U64(__FUNC_BYTE((f), (o) + 4, (l)), 32) | \
+	 SHIFT_U64(__FUNC_BYTE((f), (o) + 5, (l)), 40) | \
+	 SHIFT_U64(__FUNC_BYTE((f), (o) + 6, (l)), 48) | \
+	 SHIFT_U64(__FUNC_BYTE((f), (o) + 7, (l)), 56))
+
+#define __FUNC_HASH32(f, o, l) \
+	(__FTMN_GET_FUNC_U64((f), (o), (l)) ^ \
+	 __FTMN_GET_FUNC_U64((f), (o) + 8, (l)))
+
+#define __FUNC_HASH16(f, o, l) \
+	(__FUNC_HASH32((f), (o), (l)) ^ \
+	 __FUNC_HASH32((f), (o) + __FTMN_MAX_FUNC_LEN / 16, (l)))
+
+#define __FUNC_HASH8(f, o, l) \
+	(__FUNC_HASH16((f), (o), (l)) ^ \
+	 __FUNC_HASH16((f), (o) + __FTMN_MAX_FUNC_LEN / 8, (l)))
+
+#define __FUNC_HASH4(f, o, l) \
+	(__FUNC_HASH8((f), (o), (l)) ^ \
+	 __FUNC_HASH8((f), (o) + __FTMN_MAX_FUNC_LEN / 4, (l)))
+
+#define __FUNC_HASH2(f, l) \
+	(__FUNC_HASH4(f, 0, l) ^ \
+	 __FUNC_HASH4(f, __FTMN_MAX_FUNC_LEN / 2, l))
+
+#ifdef __ILP32__
+#define __FUNC_HASH(f, l) \
+	(unsigned long)(__FUNC_HASH2((f), (l)) ^ (__FUNC_HASH2((f), (l)) >> 32))
+#else
+#define __FUNC_HASH(f, l)	(unsigned long)__FUNC_HASH2((f), (l))
+#endif
+
+#define FTMN_FUNC_HASH(name)	__FUNC_HASH(name, sizeof(name))
+
+#ifdef CFG_CORE_FAULT_MITIGATION
+#define FTMN_CALL_FUNC(res, ftmn_check, incr, func, ...) \
+	do { \
+		struct ftmn_func_arg __ftmn_arg = { }; \
+		\
+		__ftmn_arg.hash = FTMN_FUNC_HASH(__func__); \
+		(res) = func(__VA_ARGS__, &__ftmn_arg); \
+		ftmn_check_call_done(&__ftmn_arg, \
+				     FTMN_FUNC_HASH(__func__) ^ \
+				     FTMN_FUNC_HASH(#func), \
+				     (res), (ftmn_check), incr); \
+	} while (0)
+
+#define FTMN_CALL_VOID_FUNC(ftmn_check, incr, func, ...) \
+	do { \
+		struct ftmn_func_arg __ftmn_arg = { }; \
+		\
+		__ftmn_arg.hash = FTMN_FUNC_HASH(__func__); \
+		func(__VA_ARGS__, &__ftmn_arg); \
+		ftmn_check_call_done(&__ftmn_arg, \
+				     FTMN_FUNC_HASH(__func__) ^ \
+				     FTMN_FUNC_HASH(#func), \
+				     0, (ftmn_check), incr); \
+	} while (0)
+#else
+#define FTMN_CALL_FUNC(res, ftmn_check, incr, func, ...) \
+	do { (res) = func(__VA_ARGS__, NULL); } while (0)
+#define FTMN_CALL_VOID_FUNC(ftmn_check, incr, func, ...) \
+	do { func(__VA_ARGS__, NULL); } while (0)
+#endif
+#define FTMN_CALLEE_DONE(arg, res) \
+	ftmn_callee_done((arg), FTMN_FUNC_HASH(__func__), (res))
+
+
+#define FTMN_STEP_COUNT1(c0)			((c0) * FTMN_INCR0)
+#define FTMN_STEP_COUNT2(c0, c1)		(FTMN_STEP_COUNT1(c0) + \
+						 (c1) * FTMN_INCR1)
+#define FTMN_STEP_COUNT3(c0, c1, c2)		(FTMN_STEP_COUNT2(c0, c1) + \
+						 (c2) * FTMN_INCR2)
+#define FTMN_STEP_COUNT4(c0, c1, c2, c3)	\
+			(FTMN_STEP_COUNT3(c0, c1, c2) + (c3) * FTMN_INCR3)
+#define FTMN_STEP_COUNT5(c0, c1, c2, c3, c4)	\
+			(FTMN_STEP_COUNT4(c0, c1, c2, c3) + (c4) * FTMN_INCR4)
+#define FTMN_STEP_COUNT6(c0, c1, c2, c3, c4, c5)	\
+			(FTMN_STEP_COUNT5(c0, c1, c2, c3, c4) + \
+			 (c5) * FTMN_INCR5)
+
+static inline void ftmn_panic(void)
+{
+#ifdef __KERNEL__
+	panic();
+#else
+	TEE_Panic(0);
+#endif
+}
+
+void __ftmn_change_val(struct ftmn_check *check, enum ftmn_incr incr,
+		       unsigned long hash, unsigned long old_val,
+		       unsigned long new_val);
+void __ftmn_rehash_val(struct ftmn_check *check, enum ftmn_incr incr,
+		       unsigned long old_hashed_val, unsigned long old_hash,
+		       unsigned long new_hash, unsigned long val);
+unsigned long __ftmn_return_val(unsigned long hashed_val, unsigned long hash,
+				unsigned long val);
+void __ftmn_expect_val(struct ftmn_check *check, enum ftmn_incr incr,
+		       unsigned long ret, unsigned long val);
+void __ftmn_expect_not_val(struct ftmn_check *check, enum ftmn_incr incr,
+			   unsigned long ret, unsigned long val);
+
+
+static inline void ftmn_callee_done(struct ftmn_func_arg *arg,
+				    unsigned long hash, unsigned long ret)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION)) {
+		barrier();
+		arg->hash ^= hash;
+		arg->ret = arg->hash ^ ret;
+		barrier();
+	}
+}
+
+static inline void ftmn_checkpoint(struct ftmn_check *check,
+				   enum ftmn_incr incr)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION)) {
+		barrier();
+		check->steps += incr;
+		barrier();
+	}
+}
+
+static inline void ftmn_check_call_done(struct ftmn_func_arg *arg,
+					unsigned long hash, unsigned long ret,
+					struct ftmn_check *check,
+					enum ftmn_incr incr)
+{
+	/*
+	 * Transfer the return value into check with a new xor mask. This
+	 * verifies the saved value with the old hash so this is also a
+	 * check that the hash is correct, that is, that the function
+	 * really was called.
+	 */
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		__ftmn_rehash_val(check, incr, arg->ret, hash,
+				  FTMN_DEFAULT_HASH, ret);
+}
+
+static inline void ftmn_expect_val(struct ftmn_check *check,
+				   enum ftmn_incr incr, unsigned long ret,
+				   unsigned long val)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		__ftmn_expect_val(check, incr, ret, val);
+}
+
+static inline void ftmn_expect_not_val(struct ftmn_check *check,
+				       enum ftmn_incr incr, unsigned long ret,
+				       unsigned long val)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		__ftmn_expect_not_val(check, incr, ret, val);
+}
+
+static inline void ftmn_save_val(struct ftmn_check *check, enum ftmn_incr incr,
+				 unsigned long val)
+{
+	ftmn_expect_val(check, incr, val, val);
+}
+
+static inline void ftmn_save_ptr(struct ftmn_check *check, enum ftmn_incr incr,
+				 void *p)
+{
+	ftmn_save_val(check, incr, (unsigned long)p);
+}
+
+static inline void ftmn_expect_nonzero(struct ftmn_check *check,
+				       enum ftmn_incr incr, unsigned long ret)
+{
+	ftmn_expect_not_val(check, incr, ret, 0);
+}
+
+static inline void ftmn_expect_null(struct ftmn_check *check,
+				    enum ftmn_incr incr, void *p)
+{
+	ftmn_expect_val(check, incr, (unsigned long)p, 0);
+}
+
+static inline void ftmn_expect_not_null(struct ftmn_check *check,
+					enum ftmn_incr incr, void *p)
+{
+	ftmn_expect_nonzero(check, incr, (unsigned long)p);
+}
+
+static inline void ftmn_expect_state(struct ftmn_check *check,
+				     unsigned long steps, unsigned long val)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION)) {
+		ftmn_expect_val(check, FTMN_INCR_RESERVED, check->steps, steps);
+		if ((check->val ^ FTMN_DEFAULT_HASH) != val)
+			ftmn_panic();
+		if (check->steps != (steps + FTMN_INCR_RESERVED))
+			ftmn_panic();
+	}
+}
+
+static inline unsigned long ftmn_return_val(struct ftmn_check *check,
+					    unsigned long val)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		return __ftmn_return_val(check->val, FTMN_DEFAULT_HASH, val);
+	return val;
+}
+
+#endif /*__FAULT_MITIGATION_H*/

--- a/lib/libutils/ext/sub.mk
+++ b/lib/libutils/ext/sub.mk
@@ -8,6 +8,7 @@ srcs-y += mempool.c
 srcs-y += nex_strdup.c
 srcs-y += consttime_memcmp.c
 srcs-y += memzero_explicit.c
+srcs-y += fault_mitigation.c
 
 subdirs-y += arch/$(ARCH)
 subdirs-y += ftrace

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -819,3 +819,7 @@ endif
 # extension. When set to 'n', the plat_get_freq() function must be defined by
 # the platform code
 CFG_CORE_HAS_GENERIC_TIMER ?= y
+
+# Enables best effort mitigations agains fault injected when the hardware
+# is tampered with
+CFG_CORE_FAULT_MITIGATION ?= y


### PR DESCRIPTION
This is a true RFC PR, I don't wish to have this merged at this stage.

I'm trying to add some mitigations again fault injection attacks on the hardware, more specifically glitching attacks. The basic assumption is that glitch can cause a one or more instructions in sequence to act as nops when executed. Anything can happen of course but I'm using this approximation to have something more concrete to work with.

I'm starting with the calls to shdr_verify_signature() to see what that can lead to. I'm designing a check to see that a function has been called and that the returned value is correct. None of this can be 100%, but I'm trying to add enough redundancy in the code it should typically not be enough to glitch a single sequence of instructions.

One concern here is how intrusive we can it to be. I don't expect that too many functions will be targeted. The best way to approach this is probably with a use-case, like verifying the signature of a TA, and then see which functions are critical.