### PR TITLE
dirvers: stm32_gpio: Fix register access before enabling clocks

### DIFF
--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -394,9 +394,9 @@ int stm32_gpio_get_input_level(unsigned int bank, unsigned int pin)
 	struct clk *clk = stm32_get_gpio_bank_clk(bank);
 	int rc = 0;
 
-	assert(valid_gpio_config(bank, pin, true));
-
 	clk_enable(clk);
+
+	assert(valid_gpio_config(bank, pin, true));
 
 	if (io_read32(base + GPIO_IDR_OFFSET) == BIT(pin))
 		rc = 1;
@@ -411,9 +411,9 @@ void stm32_gpio_set_output_level(unsigned int bank, unsigned int pin, int level)
 	vaddr_t base = stm32_get_gpio_bank_base(bank);
 	struct clk *clk = stm32_get_gpio_bank_clk(bank);
 
-	assert(valid_gpio_config(bank, pin, false));
-
 	clk_enable(clk);
+
+	assert(valid_gpio_config(bank, pin, false));
 
 	if (level)
 		io_write32(base + GPIO_BSRR_OFFSET, BIT(pin));


### PR DESCRIPTION
The valid_gpio_config function did access the GPIO register
before the clock was enabled, which did lead to the assert always
failing when using stm32_gpio_set_output_level.

Signed-off-by: Loïc Bauer <loic.bauer@socomec.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
