### PR TITLE
core: FS: make dirfile interface accept empty object ID

### DIFF
--- a/core/tee/fs_dirfile.c
+++ b/core/tee/fs_dirfile.c
@@ -27,6 +27,20 @@ struct dirfile_entry {
 	uint32_t file_number;
 };
 
+#define OID_EMPTY_NAME 1
+
+/*
+ * An object can have an ID of size zero. This object is represented by
+ * oidlen == 0 and oid[0] == OID_EMPTY_NAME. When both are zero, the entry is
+ * not a valid object.
+ */
+static bool is_free(struct dirfile_entry *dent)
+{
+	assert(dent->oidlen || !dent->oid[0] || dent->oid[0] == OID_EMPTY_NAME);
+
+	return !dent->oidlen && !dent->oid[0];
+}
+
 /*
  * File layout
  *
@@ -133,7 +147,7 @@ TEE_Result tee_fs_dirfile_open(bool create, uint8_t *hash,
 			goto out;
 		}
 
-		if (!dent.oidlen)
+		if (is_free(&dent))
 			continue;
 
 		if (test_file(dirh, dent.file_number)) {
@@ -198,31 +212,21 @@ TEE_Result tee_fs_dirfile_find(struct tee_fs_dirfile_dirh *dirh,
 			       const TEE_UUID *uuid, const void *oid,
 			       size_t oidlen, struct tee_fs_dirfile_fileh *dfh)
 {
-	TEE_Result res;
-	struct dirfile_entry dent;
-	int n;
-	int first_free = -1;
+	TEE_Result res = TEE_SUCCESS;
+	struct dirfile_entry dent = { };
+	int n = 0;
 
 	for (n = 0;; n++) {
 		res = read_dent(dirh, n, &dent);
-		if (res == TEE_ERROR_ITEM_NOT_FOUND && !oidlen) {
-			memset(&dent, 0, sizeof(dent));
-			if (first_free != -1)
-				n = first_free;
-			break;
-		}
 		if (res)
 			return res;
 
-		/* TODO check this loop when oidlen == 0 */
-
-		if (!dent.oidlen && first_free == -1)
-			first_free = n;
+		if (is_free(&dent))
+			continue;
 		if (dent.oidlen != oidlen)
 			continue;
 
-		assert(!oidlen || !dent.oidlen ||
-		       test_file(dirh, dent.file_number));
+		assert(test_file(dirh, dent.file_number));
 
 		if (!memcmp(&dent.uuid, uuid, sizeof(dent.uuid)) &&
 		    !memcmp(&dent.oid, oid, oidlen))
@@ -235,6 +239,26 @@ TEE_Result tee_fs_dirfile_find(struct tee_fs_dirfile_dirh *dirh,
 		memcpy(dfh->hash, dent.hash, sizeof(dent.hash));
 	}
 
+	return TEE_SUCCESS;
+}
+
+static TEE_Result find_empty_idx(struct tee_fs_dirfile_dirh *dh, int *idx)
+{
+	struct dirfile_entry dent = { };
+	TEE_Result res = TEE_SUCCESS;
+	int n = 0;
+
+	for (n = 0;; n++) {
+		res = read_dent(dh, n, &dent);
+		if (res == TEE_ERROR_ITEM_NOT_FOUND)
+			break;
+		if (res)
+			return res;
+		if (is_free(&dent))
+			break;
+	}
+
+	*idx = n;
 	return TEE_SUCCESS;
 }
 
@@ -267,11 +291,15 @@ TEE_Result tee_fs_dirfile_rename(struct tee_fs_dirfile_dirh *dirh,
 	TEE_Result res;
 	struct dirfile_entry dent;
 
-	if (!oidlen || oidlen > sizeof(dent.oid))
+	if (oidlen > sizeof(dent.oid))
 		return TEE_ERROR_BAD_PARAMETERS;
 	memset(&dent, 0, sizeof(dent));
 	dent.uuid = *uuid;
-	memcpy(dent.oid, oid, oidlen);
+	if (oidlen)
+		memcpy(dent.oid, oid, oidlen);
+	else
+		dent.oid[0] = OID_EMPTY_NAME;
+
 	dent.oidlen = oidlen;
 	memcpy(dent.hash, dfh->hash, sizeof(dent.hash));
 	dent.file_number = dfh->file_number;
@@ -282,8 +310,7 @@ TEE_Result tee_fs_dirfile_rename(struct tee_fs_dirfile_dirh *dirh,
 		res = tee_fs_dirfile_find(dirh, uuid, oid, oidlen, &dfh2);
 		if (res) {
 			if (res == TEE_ERROR_ITEM_NOT_FOUND)
-				res = tee_fs_dirfile_find(dirh, uuid, NULL, 0,
-							  &dfh2);
+				res = find_empty_idx(dirh, &dfh2.idx);
 			if (res)
 				return res;
 		}
@@ -304,7 +331,7 @@ TEE_Result tee_fs_dirfile_remove(struct tee_fs_dirfile_dirh *dirh,
 	if (res)
 		return res;
 
-	if (!dent.oidlen)
+	if (is_free(&dent))
 		return TEE_SUCCESS;
 
 	file_number = dent.file_number;
@@ -352,7 +379,7 @@ TEE_Result tee_fs_dirfile_get_next(struct tee_fs_dirfile_dirh *dirh,
 		if (res)
 			return res;
 		if (!memcmp(&dent.uuid, uuid, sizeof(dent.uuid)) &&
-		    dent.oidlen)
+		    !is_free(&dent))
 			break;
 	}
 

--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -192,10 +192,12 @@ TEE_Result syscall_storage_obj_open(unsigned long storage_id, void *object_id,
 		goto exit;
 	}
 
-	res = vm_check_access_rights(&utc->uctx, TEE_MEMORY_ACCESS_READ,
-				     (uaddr_t)object_id, object_id_len);
-	if (res != TEE_SUCCESS)
-		goto err;
+	if (object_id_len) {
+		res = vm_check_access_rights(&utc->uctx, TEE_MEMORY_ACCESS_READ,
+					     (uaddr_t)object_id, object_id_len);
+		if (res != TEE_SUCCESS)
+			goto err;
+	}
 
 	res = tee_pobj_get((void *)&sess->ctx->uuid, object_id,
 			   object_id_len, flags, TEE_POBJ_USAGE_OPEN, fops,
@@ -333,10 +335,12 @@ TEE_Result syscall_storage_obj_create(unsigned long storage_id, void *object_id,
 	if (object_id_len > TEE_OBJECT_ID_MAX_LEN)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = vm_check_access_rights(&utc->uctx, TEE_MEMORY_ACCESS_READ,
-				     (uaddr_t)object_id, object_id_len);
-	if (res != TEE_SUCCESS)
-		goto err;
+	if (object_id_len) {
+		res = vm_check_access_rights(&utc->uctx, TEE_MEMORY_ACCESS_READ,
+					     (uaddr_t)object_id, object_id_len);
+		if (res != TEE_SUCCESS)
+			goto err;
+	}
 
 	res = tee_pobj_get((void *)&sess->ctx->uuid, object_id,
 			   object_id_len, flags, TEE_POBJ_USAGE_CREATE,
@@ -488,10 +492,12 @@ TEE_Result syscall_storage_obj_rename(unsigned long obj, void *object_id,
 		goto exit;
 	}
 
-	res = vm_check_access_rights(&utc->uctx, TEE_MEMORY_ACCESS_READ,
-				     (uaddr_t)object_id, object_id_len);
-	if (res != TEE_SUCCESS)
-		goto exit;
+	if (object_id_len) {
+		res = vm_check_access_rights(&utc->uctx, TEE_MEMORY_ACCESS_READ,
+					     (uaddr_t)object_id, object_id_len);
+		if (res != TEE_SUCCESS)
+			goto exit;
+	}
 
 	/* reserve dest name */
 	fops = o->pobj->fops;

--- a/lib/libutee/tee_api_objects.c
+++ b/lib/libutee/tee_api_objects.c
@@ -400,11 +400,6 @@ TEE_Result TEE_OpenPersistentObject(uint32_t storageID, const void *objectID,
 	TEE_Result res;
 	uint32_t obj;
 
-	if (!objectID) {
-		res = TEE_ERROR_ITEM_NOT_FOUND;
-		goto exit;
-	}
-
 	__utee_check_out_annotation(object, sizeof(*object));
 
 	res = _utee_storage_obj_open(storageID, objectID, objectIDLen, flags,
@@ -412,7 +407,6 @@ TEE_Result TEE_OpenPersistentObject(uint32_t storageID, const void *objectID,
 	if (res == TEE_SUCCESS)
 		*object = (TEE_ObjectHandle)(uintptr_t)obj;
 
-exit:
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_ITEM_NOT_FOUND &&
 	    res != TEE_ERROR_ACCESS_CONFLICT &&
@@ -437,11 +431,6 @@ TEE_Result TEE_CreatePersistentObject(uint32_t storageID, const void *objectID,
 	TEE_Result res;
 	uint32_t obj;
 
-	if (!objectID) {
-		res = TEE_ERROR_ITEM_NOT_FOUND;
-		goto exit;
-	}
-
 	__utee_check_out_annotation(object, sizeof(*object));
 
 	res = _utee_storage_obj_create(storageID, objectID, objectIDLen, flags,
@@ -451,7 +440,6 @@ TEE_Result TEE_CreatePersistentObject(uint32_t storageID, const void *objectID,
 	if (res == TEE_SUCCESS)
 		*object = (TEE_ObjectHandle)(uintptr_t)obj;
 
-exit:
 	if (res != TEE_SUCCESS &&
 	    res != TEE_ERROR_ITEM_NOT_FOUND &&
 	    res != TEE_ERROR_ACCESS_CONFLICT &&


### PR DESCRIPTION
A fix to allow persistent objects with an empty ID.