### PR TITLE
Extending watchdog timeout

### DIFF
--- a/core/arch/arm/kernel/sub.mk
+++ b/core/arch/arm/kernel/sub.mk
@@ -7,8 +7,10 @@ srcs-y += idle.c
 
 srcs-$(CFG_SECURE_TIME_SOURCE_CNTPCT) += tee_time_arm_cntpct.c
 srcs-$(CFG_SECURE_TIME_SOURCE_REE) += tee_time_ree.c
+ifeq ($(CFG_CORE_HAS_GENERIC_TIMER),y)
+srcs-$(CFG_ARM32_core) += timer_a32.c
+endif
 srcs-$(CFG_ARM64_core) += timer_a64.c
-
 srcs-$(CFG_ARM32_core) += spin_lock_a32.S
 srcs-$(CFG_ARM64_core) += spin_lock_a64.S
 srcs-$(CFG_ARM32_core) += tlb_helpers_a32.S

--- a/core/arch/arm/kernel/timer_a32.c
+++ b/core/arch/arm/kernel/timer_a32.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <arm32.h>
+#include <kernel/spinlock.h>
+#include <kernel/thread.h>
+#include <kernel/timer.h>
+#include <stdbool.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+#define CNTP_CTL_ENABLE		BIT(0)
+#define CNTP_CTL_IMASK		BIT(1)
+#define CNTP_CTL_ISTATUS	BIT(2)
+
+static unsigned int timer_lock = SPINLOCK_UNLOCK;
+static bool timer_running;
+
+static TEE_Result reload_timer(uint32_t time_ms)
+{
+	uint64_t mult = ((uint64_t)read_cntfrq() * time_ms) / 1000;
+	uint32_t timer_ticks = mult;
+
+	if (read_cntp_ctl() & CNTP_CTL_ISTATUS)
+		return TEE_ERROR_GENERIC;
+
+	if (read_cntp_ctl() & CNTP_CTL_ENABLE)
+		return TEE_ERROR_BAD_STATE;
+
+	if (!mult || mult > UINT32_MAX)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	write_cntp_ctl(read_cntp_ctl() & ~(CNTP_CTL_ENABLE | CNTP_CTL_IMASK));
+	write_cntp_tval(timer_ticks);
+	write_cntp_ctl(read_cntp_ctl() | CNTP_CTL_ENABLE);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result generic_timer_start(uint32_t time_ms)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t exceptions = 0;
+
+	exceptions = cpu_spin_lock_xsave(&timer_lock);
+
+	if (timer_running) {
+		res = TEE_ERROR_BUSY;
+		goto exit;
+	}
+
+	res = reload_timer(time_ms);
+	if (res)
+		goto exit;
+
+	timer_running = true;
+
+exit:
+	cpu_spin_unlock_xrestore(&timer_lock, exceptions);
+
+	return res;
+}
+
+TEE_Result generic_timer_stop(void)
+{
+	uint32_t exceptions = cpu_spin_lock_xsave(&timer_lock);
+
+	write_cntp_ctl(read_cntp_ctl() & ~(CNTP_CTL_ENABLE | CNTP_CTL_IMASK));
+
+	timer_running = false;
+
+	cpu_spin_unlock_xrestore(&timer_lock, exceptions);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result generic_timer_handler(uint32_t time_ms)
+{
+	/* This is expected to be called from the timer interrutp service */
+	if ((read_cntp_ctl() & CNTP_CTL_ISTATUS) == 0) {
+		EMSG("Timer interrupt asserted");
+		return TEE_ERROR_GENERIC;
+	}
+
+	/* Disable then re-arm the timer */
+	write_cntp_ctl(read_cntp_ctl() & ~(CNTP_CTL_ENABLE | CNTP_CTL_IMASK));
+
+	return reload_timer(time_ms);
+}

--- a/core/arch/arm/kernel/timer_a64.c
+++ b/core/arch/arm/kernel/timer_a64.c
@@ -15,6 +15,7 @@ TEE_Result generic_timer_start(uint32_t time_ms)
 {
 	uint32_t exceptions = cpu_spin_lock_xsave(&timer_lock);
 	uint32_t timer_ticks = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (timer_running) {
 		res = TEE_ERROR_BUSY;

--- a/core/drivers/wdt/watchdog.c
+++ b/core/drivers/wdt/watchdog.c
@@ -1,11 +1,183 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright 2022 Microchip
+ * Copyright (c) 2022 Linaro Limited
  */
 
+#include <config.h>
 #include <drivers/wdt.h>
+#include <initcall.h>
+#include <keep.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <kernel/timer.h>
+#include <stdint.h>
 
 struct wdt_chip *wdt_chip;
+
+#ifdef CFG_WDT_EXTEND_TIMEOUT
+
+#ifndef CFG_CORE_HAS_GENERIC_TIMER
+#error CFG_WDT_EXTEND_TIMEOUT currently mandates CFG_CORE_HAS_GENERIC_TIMER
+#endif
+
+/*
+ * Extended non-secure watchdog timeout
+ * @end_cnt - Counter end value until which watchdog must be refreshed
+ * @refresh_ms - Watchdog refresh timer rate in milliseconds
+ * @lock - Currentl protection on struct and generic timer access
+ */
+struct extend_timeout {
+	uint64_t end_cnt;
+	unsigned int refresh_ms;
+	unsigned int lock;
+};
+
+static struct extend_timeout extended_timeout = {
+	.lock = SPINLOCK_UNLOCK,
+};
+
+static enum itr_return wdt_arm_cntp_itr_cb(struct itr_handler *handler __unused)
+{
+	uint64_t __maybe_unused ext_to = 0;
+	uint64_t cntpct = 0;
+	uint32_t exceptions = 0;
+
+	/* Ensure consistency of @iwdg content and generic timer control */
+	exceptions = cpu_spin_lock_xsave(&extended_timeout.lock);
+
+	cntpct = barrier_read_counter_timer();
+	if (wdt_chip && cntpct < extended_timeout.end_cnt) {
+		ext_to = (extended_timeout.end_cnt - cntpct) / read_cntfrq();
+
+		if (generic_timer_handler(extended_timeout.refresh_ms))
+			panic("reload arm cntp");
+
+		wdt_chip->ops->ping(wdt_chip);
+	} else {
+		generic_timer_stop();
+	}
+
+	cpu_spin_unlock_xrestore(&extended_timeout.lock, exceptions);
+
+	if (ext_to)
+		DMSG("Extending watchdog timeout for %"PRIu64"s", ext_to);
+	else
+		DMSG("Stop extending watchdog timeout");
+
+	return ITRR_HANDLED;
+}
+DECLARE_KEEP_PAGER(wdt_arm_cntp_itr_cb);
+
+static bool supports_extend_timeout(void)
+{
+	return wdt_chip && wdt_chip->ops->get_timeout;
+}
+
+/*
+ * Platform can override this function when platform constraints make
+ * periodic timer interrupt not always available.
+ */
+bool __weak watchdog_extend_timeout_timer_is_available(void)
+{
+	return true;
+}
+
+unsigned long watchdog_extend_timeout_max(void)
+{
+	if (!supports_extend_timeout())
+		return 0;
+
+	return CFG_WDT_EXTEND_TIMEOUT_MAX_SEC;
+}
+
+TEE_Result watchdog_extend_timeout(unsigned long delay_seconds)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	unsigned long timeout = 0;
+	uint32_t exceptions = 0;
+	uint64_t cnt = 0;
+
+	if (!delay_seconds) {
+		DMSG("Stop extending watchdog timeout");
+
+		exceptions = cpu_spin_lock_xsave(&extended_timeout.lock);
+
+		generic_timer_stop();
+
+		extended_timeout.end_cnt = 0;
+		extended_timeout.refresh_ms = 0;
+
+		cpu_spin_unlock_xrestore(&extended_timeout.lock, exceptions);
+
+		return TEE_SUCCESS;
+	}
+
+	if (!supports_extend_timeout())
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	if (!watchdog_extend_timeout_timer_is_available())
+		return TEE_ERROR_BAD_STATE;
+
+	if (delay_seconds > CFG_WDT_EXTEND_TIMEOUT_MAX_SEC)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (extended_timeout.end_cnt) {
+		EMSG("On-going timeout extension");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	wdt_chip->ops->ping(wdt_chip);
+
+	timeout = wdt_chip->ops->get_timeout(wdt_chip);
+	if (timeout > delay_seconds)
+		return TEE_SUCCESS;
+
+	cnt = read_cntfrq();
+	if (MUL_OVERFLOW(delay_seconds, cnt, &cnt) ||
+	    ADD_OVERFLOW(barrier_read_counter_timer(), cnt, &cnt))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	exceptions = cpu_spin_lock_xsave(&extended_timeout.lock);
+
+	extended_timeout.end_cnt = cnt;
+	extended_timeout.refresh_ms = timeout * 1000 / 2;
+
+	res = generic_timer_start(extended_timeout.refresh_ms);
+
+	cpu_spin_unlock_xrestore(&extended_timeout.lock, exceptions);
+
+	if (res)
+		return res;
+
+	DMSG("Extending watchdog for %lus", delay_seconds);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result watchdog_extend_timeout_init(void)
+{
+	static struct itr_handler wdt_arm_cntp_itr = {
+		.it = CFG_GENERIC_TIMER_GIC_INTD,
+		.handler = wdt_arm_cntp_itr_cb,
+	};
+
+	COMPILE_TIME_ASSERT(CFG_GENERIC_TIMER_GIC_INTD != 0);
+
+	if (!watchdog_extend_timeout_timer_is_available()) {
+		EMSG("Timer not available");
+		return TEE_ERROR_GENERIC;
+	}
+
+	itr_add(&wdt_arm_cntp_itr);
+	itr_enable(wdt_arm_cntp_itr.it);
+
+	return TEE_SUCCESS;
+}
+
+driver_init(watchdog_extend_timeout_init);
+#endif /* CFG_WDT_EXTEND_TIMEOUT */
 
 TEE_Result watchdog_register(struct wdt_chip *chip)
 {

--- a/core/drivers/wdt/watchdog.c
+++ b/core/drivers/wdt/watchdog.c
@@ -9,6 +9,11 @@ struct wdt_chip *wdt_chip;
 
 TEE_Result watchdog_register(struct wdt_chip *chip)
 {
+	if (wdt_chip) {
+		DMSG("Cannot register several watchdog instances");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
 	if (!chip->ops->start || !chip->ops->ping  || !chip->ops->set_timeout)
 		return TEE_ERROR_BAD_PARAMETERS;
 

--- a/core/include/drivers/wdt.h
+++ b/core/include/drivers/wdt.h
@@ -100,6 +100,36 @@ static inline void watchdog_ping(void) {}
 static inline void watchdog_settimeout(unsigned long timeout __unused) {}
 #endif
 
+#ifdef CFG_WDT_EXTEND_TIMEOUT
+/*
+ * Request OP-TEE to refresh non-secure watchdog during a given period.
+ * A non-zero period arms the refresh sequence. A zero period disables
+ * the sequence. Sequence must be explicitly disabled before it is abled
+ * again.
+ */
+TEE_Result watchdog_extend_timeout(unsigned long delay_seconds);
+
+/* Return max period in seconds OP-TEE can relay non-secure watchdog refresh */
+unsigned long watchdog_extend_timeout_max(void);
+#else
+static inline
+TEE_Result watchdog_extend_timeout(unsigned long delay_seconds __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline unsigned long watchdog_extend_timeout_max(void)
+{
+	return 0;
+}
+#endif /* CFG_WDT_EXTEND_NSEC_TIMEOUT */
+
+/*
+ * Platform cann implements this function for watchdog to check when timer
+ * resource for timeout extension is available.
+ */
+bool watchdog_extend_timeout_timer_is_available(void);
+
 #ifdef CFG_WDT_SM_HANDLER
 enum sm_handler_ret __wdt_sm_handler(struct thread_smc_args *args);
 

--- a/core/include/drivers/wdt.h
+++ b/core/include/drivers/wdt.h
@@ -26,6 +26,7 @@ struct wdt_chip {
  * @ping:	The routine that sends a keepalive ping to the watchdog device.
  * @set_timeout:The routine that finds the load value that will reset system in
  * required timeout (in seconds).
+ * @get_timeout:The routine that returns programmed timeout in seconds.
  *
  * The wdt_ops structure contains a list of low-level operations
  * that control a watchdog device.
@@ -37,6 +38,7 @@ struct wdt_ops {
 	void (*stop)(struct wdt_chip *chip);
 	void (*ping)(struct wdt_chip *chip);
 	TEE_Result (*set_timeout)(struct wdt_chip *chip, unsigned long timeout);
+	unsigned long (*get_timeout)(struct wdt_chip *chip);
 };
 
 #ifdef CFG_WDT

--- a/core/include/kernel/timer.h
+++ b/core/include/kernel/timer.h
@@ -1,15 +1,21 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (C) 2018, Linaro Limited
+ * Copyright (C) 2018-2022, Linaro Limited
  */
 
 #ifndef __TIMER_H
 #define __TIMER_H
 
-void generic_timer_start(uint32_t time_ms);
-void generic_timer_stop(void);
+#include <stdint.h>
+#include <tee_api_types.h>
 
-/* Handler for timer expiry interrupt */
-void generic_timer_handler(uint32_t time_ms);
+/* Enable generic timer to the targe telpasure time */
+TEE_Result generic_timer_start(uint32_t time_ms);
+
+/* Disable generic timer */
+TEE_Result generic_timer_stop(void);
+
+/* Reload timer from interrupt context for the next event */
+TEE_Result generic_timer_handler(uint32_t time_ms);
 
 #endif /* __TIMER_H */

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -13,5 +13,6 @@ srcs-$(CFG_APDU_PTA) += apdu.c
 srcs-$(CFG_SCMI_PTA) += scmi.c
 srcs-$(CFG_HWRNG_PTA) += hwrng.c
 srcs-$(CFG_RTC_PTA) += rtc.c
+srcs-$(CFG_WATCHDOG_PTA) += watchdog.c
 
 subdirs-y += bcm

--- a/core/pta/watchdog.c
+++ b/core/pta/watchdog.c
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019, Broadcom
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <drivers/gic.h>
+#include <drivers/wdt.h>
+#include <kernel/pseudo_ta.h>
+#include <pta_watchdog.h>
+#include <trace.h>
+
+static bool is_wdt_registered(void)
+{
+	return wdt_chip;
+}
+
+static TEE_Result pta_wdt_config(uint32_t ptypes,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (exp_ptypes != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = watchdog_init(NULL, NULL);
+	if (res)
+		return res;
+
+	watchdog_settimeout(params[0].value.a);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result pta_wdt_start(uint32_t ptypes,
+				TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (exp_ptypes != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = watchdog_init(NULL, NULL);
+	if (res)
+		return res;
+
+	watchdog_start();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result pta_wdt_ping(uint32_t ptypes,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!is_wdt_registered())
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	watchdog_ping();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result pta_wdt_stop(uint32_t ptypes,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!is_wdt_registered())
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	watchdog_stop();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result pta_wdt_set_timeout(uint32_t ptypes,
+				      TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!is_wdt_registered())
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	watchdog_settimeout(params[0].value.a);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result pta_wdt_extend_timeout_caps(uint32_t ptypes,
+					      TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+
+	if (exp_pt != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	params[0].value.a = watchdog_extend_timeout_max();
+	params[0].value.b = 0;
+	params[1].value.a = 0;
+	params[1].value.b = 0;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result pta_wdt_extend_timeout_start(uint32_t ptypes,
+					       TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+	unsigned long timeout = params[0].value.a;
+
+	if (exp_ptypes != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* 0 sec is not a valid value */
+	if (!timeout)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return watchdog_extend_timeout(timeout);
+}
+
+static TEE_Result pta_wdt_extend_timeout_stop(uint32_t ptypes,
+					      TEE_Param params[] __unused)
+{
+	const uint32_t exp_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE,
+						    TEE_PARAM_TYPE_NONE);
+
+	if (exp_ptypes != ptypes)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return watchdog_extend_timeout(0);
+}
+
+static TEE_Result invoke_command(void *session_context __unused,
+				 uint32_t cmd_id, uint32_t ptypes,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	switch (cmd_id) {
+	case PTA_WATCHDOG_CMD_CONFIG:
+		res = pta_wdt_config(ptypes, params);
+		break;
+	case PTA_WATCHDOG_CMD_START:
+		res = pta_wdt_start(ptypes, params);
+		break;
+	case PTA_WATCHDOG_CMD_PING:
+		res = pta_wdt_ping(ptypes, params);
+		break;
+	case PTA_WATCHDOG_CMD_STOP:
+		res = pta_wdt_stop(ptypes, params);
+		break;
+	case PTA_WATCHDOG_CMD_SET_TIMEOUT:
+		res = pta_wdt_set_timeout(ptypes, params);
+		break;
+	case PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_CAPS:
+		res = pta_wdt_extend_timeout_caps(ptypes, params);
+		break;
+	case PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_START:
+		res = pta_wdt_extend_timeout_start(ptypes, params);
+		break;
+	case PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_STOP:
+		res = pta_wdt_extend_timeout_stop(ptypes, params);
+		break;
+
+	default:
+		EMSG("cmd: %d not supported by %s", cmd_id, PTA_WATCHDOG_NAME);
+		res = TEE_ERROR_NOT_SUPPORTED;
+		break;
+	}
+
+	return res;
+}
+
+pseudo_ta_register(.uuid = PTA_WATCHDOG_UUID,
+		   .name = PTA_WATCHDOG_NAME,
+		   .flags = PTA_DEFAULT_FLAGS | TA_FLAG_DEVICE_ENUM,
+		   .invoke_command_entry_point = invoke_command);

--- a/lib/libutee/include/pta_watchdog.h
+++ b/lib/libutee/include/pta_watchdog.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019-2021, Linaro Limited
+ */
+#ifndef PTA_WATCHDOG_H
+#define PTA_WATCHDOG_H
+
+#define PTA_WATCHDOG_UUID \
+	{ 0xa8cfe406, 0xd4f5, 0x4a2e, \
+	  { 0x9f, 0x8d, 0xa2, 0x5d, 0xc7, 0x54, 0xc0, 0xa9 } }
+
+#define PTA_WATCHDOG_NAME	"PTA-WATCHDOG"
+
+/*
+ * PTA_WATCHDOG_CMD_CONFIG - Configure watchdog
+ *
+ * [in]     value[0].a: Watchdog timeout in seconds
+ */
+#define PTA_WATCHDOG_CMD_CONFIG		0
+
+/*
+ * PTA_WATCHDOG_CMD_START - Start watchdog
+ */
+#define PTA_WATCHDOG_CMD_START		1
+
+/*
+ * PTA_WATCHDOG_CMD_PIN - Refresh watchdog
+ */
+#define PTA_WATCHDOG_CMD_PING		2
+
+/*
+ * PTA_WATCHDOG_CMD_STOP - Stop watchdog
+ */
+#define PTA_WATCHDOG_CMD_STOP		3
+
+/*
+ * PTA_WATCHDOG_CMD_SET_TIMEOUT - Set watchdog timeout
+ *
+ * [in]     value[0].a: Watchdog timeout in seconds
+ */
+#define PTA_WATCHDOG_CMD_SET_TIMEOUT	4
+
+/*
+ * PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_CAPS - Extended tiemout capabilities
+ *
+ * [out]    value[0].a: Max extended watchdog timeout in seconds or 0
+ * [out]    value[0].b: Reserved, must be 0.
+ * [out]    value[1].a: Reserved, must be 0.
+ * [out]    value[1].b: Reserved, must be 0.
+ */
+#define PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_CAPS	5
+
+/*
+ * PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_START - Start extending watchdog timeout
+ *
+ * [in]     value[0].a: Requested extended timeout in seconds
+ */
+#define PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_START	6
+
+/*
+ * PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_STOP - Stop extending watchdog timeout
+ */
+#define PTA_WATCHDOG_CMD_EXTEND_TIMEOUT_STOP	7
+
+#endif /* PTA_WATCHDOG_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -825,3 +825,22 @@ CFG_DRIVERS_RTC ?= n
 
 # Enable PTA for RTC access from non-secure world
 CFG_RTC_PTA ?= n
+
+# CFG_WDT_EXTEND_IMEOUT allows OP-TEE to refresh watchdog using a timer
+# interrupt for boot time cases when non-secure world is not able to refresh
+# the watchdog before watchdog max physically programmable timeout expires.
+# This may happen during boot stage to operating system transition.
+#
+# CFG_WDT_EXTEND_TIMEOUT_MAX_SEC sets the max authorised relay period
+# in seconds. Default configuration value is 5 minutes.
+#
+# Current implementation relies on generic timer interrupt to refresh the
+# watchdog for the given period of time. CFG_GENERIC_TIMER_GIC_INTD shall
+# provide the platform generic timer interrupt.
+CFG_WDT_EXTEND_TIMEOUT ?= n
+ifeq ($(CFG_WDT_EXTEND_TIMEOUT),y)
+CFG_WDT_EXTEND_TIMEOUT_MAX_SEC ?= 300
+CFG_GENERIC_TIMER_GIC_INTD ?= 0
+$(eval $(call cfg-depends-all,CFG_WDT_EXTEND_TIMEOUT,\
+	 CFG_CORE_HAS_GENERIC_TIMER))
+endif


### PR DESCRIPTION
This series proposes to allow OP-TEE to offer a new watchdog service to non-secure world: extension of the watchdog programmable timeout. 

The need comes from some REE distributions that may take a long time between bootloader sequence completion and operating system installation. During that time, few mintues, operating system may not be able to refresh the watchdog. To overcome that, i watchdog service proposes to use a timer interrupt to refresh watchdog during the desired period.

This series starts with implementation of generic timer interrupt support for 32bit Arm architecture.
Follows changes in watchdog framework to implement the watchdog timeout extension.
Last commit proposes a PTA service for watchdog resources that mimics the services recently merged through a SMC interface.