### PR TITLE
ldelf: allow ELFs without DT_HASH to be loaded

### DIFF
--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -283,9 +283,11 @@ static void save_hashtab(struct ta_elf *elf)
 						  phdr[n].p_memsz);
 	}
 
-	check_hashtab(elf, elf->hashtab, 0, 0);
-	hashtab = elf->hashtab;
-	check_hashtab(elf, elf->hashtab, hashtab[0], hashtab[1]);
+	if (elf->hashtab) {
+		check_hashtab(elf, elf->hashtab, 0, 0);
+		hashtab = elf->hashtab;
+		check_hashtab(elf, elf->hashtab, hashtab[0], hashtab[1]);
+	}
 }
 
 static void save_soname_from_segment(struct ta_elf *elf, unsigned int type,

--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -218,6 +218,9 @@ static void save_hashtab_from_segment(struct ta_elf *elf, unsigned int type,
 		if (tag == DT_HASH) {
 			elf->hashtab = (void *)(val + elf->load_addr);
 			break;
+		} else if (tag == DT_GNU_HASH) {
+			elf->gnu_hashtab = (void *)(val + elf->load_addr);
+			break;
 		}
 	}
 }
@@ -262,6 +265,61 @@ static void check_hashtab(struct ta_elf *elf, void *ptr, size_t num_buckets,
 	check_range(elf, "DT_HASH", ptr, sz);
 }
 
+static void check_gnu_hashtab(struct ta_elf *elf, void *ptr)
+{
+	uint32_t *hashtab = ptr;
+	uint32_t *bucket = NULL;
+	size_t last_sym = 0;
+	/*
+	 * Starting from 4 as the first four words are mandatory and hold
+	 * nbuckets, first symbol index, bloom_size, and bloom shift.
+	 */
+	size_t num_words = 4;
+	size_t sz = 0;
+
+	if (!IS_ALIGNED_WITH_TYPE(ptr, uint32_t))
+		err(TEE_ERROR_BAD_FORMAT, "Bad alignment of DT_GNU_HASH %p",
+		    ptr);
+
+	check_range(elf, "DT_GNU_HASH", ptr, sz);
+
+	/*
+	 * Aside from the four uint32_t's, the structure contains:
+	 * the bloom filter array, which is either an uint32_t or uint64_t
+	 * array of size bloom_size;
+	 * the bucket array, which is an uint32_t array of size nbuckets;
+	 * and the symbols array, which is an uint32_t array.
+	 */
+
+	if (ADD_OVERFLOW(num_words, hashtab[0], &num_words) || /* nbuckets */
+	    ADD_OVERFLOW(num_words, hashtab[2], &num_words) || /* bloom_size */
+	    (!elf->is_32bit &&				/* x2 for uint64_t */
+	     ADD_OVERFLOW(num_words, hashtab[2], &num_words)) ||
+	    MUL_OVERFLOW(num_words, sizeof(uint32_t), &sz))
+		err(TEE_ERROR_BAD_FORMAT, "DT_GNU_HASH overflow");
+
+	/*
+	 * There is no total number of exported symbols in DT_GNU_HASH,
+	 * so we have to find the highest bucket value manually.
+	 * See http://deroko.phearless.org/dt_gnu_hash.txt .
+	 */
+	bucket = hashtab + 4 + hashtab[2] * (elf->is_32bit ? 1 : 2);
+	last_sym = 0;
+	for (uint32_t i = 0; i < hashtab[0]; i++)
+		if (bucket[i] > last_sym)
+			last_sym = bucket[i];
+
+	if (MUL_OVERFLOW(last_sym, sizeof(uint32_t), &last_sym) ||
+	    ADD_OVERFLOW(num_words, last_sym, &num_words))
+		err(TEE_ERROR_BAD_FORMAT, "DT_GNU_HASH overflow");
+
+	/* shouldn't be less than the first dynsym offset */
+	if (last_sym < hashtab[1])
+		err(TEE_ERROR_BAD_FORMAT, "Bad DT_GNU_HASH");
+
+	check_range(elf, "DT_GNU_HASH", ptr, sz);
+}
+
 static void save_hashtab(struct ta_elf *elf)
 {
 	uint32_t *hashtab = NULL;
@@ -288,6 +346,8 @@ static void save_hashtab(struct ta_elf *elf)
 		hashtab = elf->hashtab;
 		check_hashtab(elf, elf->hashtab, hashtab[0], hashtab[1]);
 	}
+	if (elf->gnu_hashtab)
+		check_gnu_hashtab(elf, elf->gnu_hashtab);
 }
 
 static void save_soname_from_segment(struct ta_elf *elf, unsigned int type,

--- a/ldelf/ta_elf.h
+++ b/ldelf/ta_elf.h
@@ -59,6 +59,8 @@ struct ta_elf {
 
 	/* DT_HASH hash table for faster resolution of external symbols */
 	void *hashtab;
+	/* DT_GNU_HASH table as an alternative to DT_HASH */
+	void *gnu_hashtab;
 
 	/* DT_SONAME */
 	char *soname;


### PR DESCRIPTION
It is possible for an ELF to be compiled with --hash-style=gnu;
some distros even have that as their default. This produces an ELF
with no .hash section, but with a .gnu.hash section in its stead.

As a first step towards detaching table-traversal code from
the rest of the symbol resolution code, do not fail in the case
of a missing DT_HASH, but use the old bruteforce lookup code
when elf->hashtab is NULL.

Signed-off-by: Elvira Khabirova <e.khabirova@omp.ru>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
