### PR TITLE
dt driver: test for driver probing sequence

### DIFF
--- a/core/arch/arm/dts/dt_driver_test.dtsi
+++ b/core/arch/arm/dts/dt_driver_test.dtsi
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ *  Copyright (c) 2022, Linaro Limited
+ */
+
+/ {
+	/*
+	 * Device dt-test-consumer consumes resource, it is expected
+	 * to defer its probe until resources are ready.
+	 */
+	dt-test-consumer {
+		compatible = "linaro,dt-test-consumer";
+		clocks = <&dt_test_provider 3>, <&dt_test_provider 7>;
+		clock-names = "clk0", "clk1";
+		resets = <&dt_test_provider 35>, <&dt_test_provider 5>;
+		reset-names = "rst0", "rst1";
+	};
+
+	/*
+	 * Resource device are discovered from subnode added to probe
+	 * list by related drivers (here all simple-bus).
+	 */
+	dt-test-bus-b0 {
+		compatible = "simple-bus";
+
+		dt-test-bus-b1 {
+			compatible = "simple-bus";
+
+			dt-test-bus-b2 {
+				compatible = "simple-bus";
+
+				dt-test-bus-b3 {
+					compatible = "simple-bus";
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					dt_test_provider: dt-test-provider@0 {
+						compatible = "linaro,dt-test-provider";
+						reg = <0>;
+						#clock-cells = <1>;
+						#reset-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+
+	dt-test-crypt-consumer {
+		compatible = "linaro,dt-test-crypt-consumer";
+	};
+};

--- a/core/arch/arm/dts/embedded_dtb_test.dts
+++ b/core/arch/arm/dts/embedded_dtb_test.dts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ *  Copyright (c) 2022, Linaro Limited
+ */
+/dts-v1/;
+
+#include "dt_driver_test.dtsi"
+
+/ {
+	model = "Embedded device tree for OP-TEE/Qemu platform test purpose";
+};

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -126,3 +126,10 @@ CFG_TEE_SDP_MEM_SIZE ?= 0x00400000
 $(call force,CFG_DT,y)
 CFG_DTB_MAX_SIZE ?= 0x100000
 endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),qemu_virt qemu_armv8a))
+CFG_DT_DRIVER_EMBEDDED_TEST ?= y
+ifeq ($(CFG_DT_DRIVER_EMBEDDED_TEST),y)
+$(call force,CFG_EMBED_DTB_SOURCE_FILE,embedded_dtb_test.dts,Mandated for DT tests)
+endif
+endif

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -45,6 +45,7 @@ TEE_Result clk_dt_get_by_index(const void *fdt, int nodeoffset,
 	return clk_dt_get_by_idx_prop("clocks", fdt, nodeoffset, clk_idx, clk);
 }
 
+#ifdef CFG_DRIVERS_CLK_EARLY_PROBE
 /* Recursively called from parse_clock_property() */
 static TEE_Result clk_probe_clock_provider_node(const void *fdt, int node);
 
@@ -209,3 +210,4 @@ static TEE_Result clk_dt_probe(void)
 	return TEE_SUCCESS;
 }
 early_init(clk_dt_probe);
+#endif

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -153,4 +153,19 @@ int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
  * @nodeoffset: Node offset on the FDT for the device
  */
 TEE_Result dt_driver_maybe_add_probe_node(const void *fdt, int nodeoffset);
+
+#ifdef CFG_DT_DRIVER_EMBEDDED_TEST
+/*
+ * Return TEE_ERROR_NOT_IMPLEMENTED if test are not implemented
+ * otherwise return TEE_ERROR_GENERIC if some test has failed
+ * otherwise return TEE_SUCCESS (tests succeed or skipped)
+ */
+TEE_Result dt_driver_test_status(void);
+#else
+static inline TEE_Result dt_driver_test_status(void)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif
+
 #endif /* __DT_DRIVER_H */

--- a/core/kernel/dt_driver_test.c
+++ b/core/kernel/dt_driver_test.c
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Linaro Limited
+ *
+ * Tests introduce dummy test drivers and assiciated devices defined in
+ * dt_driver_test.dtsi file with device resource dependencies.
+ */
+
+#include <assert.h>
+#include <config.h>
+#include <crypto/crypto.h>
+#include <drivers/clk.h>
+#include <drivers/clk_dt.h>
+#include <drivers/rstctrl.h>
+#include <initcall.h>
+#include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <libfdt.h>
+#include <malloc.h>
+#include <sys/queue.h>
+#include <tee_api_defines_extensions.h>
+#include <tee_api_types.h>
+
+#define DT_TEST_MSG(...)	FMSG("(dt-driver-test) " __VA_ARGS__)
+
+/* Test state IDs */
+enum dt_test_sid { DEFAULT = 0, IN_PROGRESS, SUCCESS, FAILED };
+
+/*
+ * DT tests state to be reported from PTA_INVOKE_TESTS_CMD_DT_TEST_STATUS
+ * possibly printed to console. A test can be skipped (DEFAULT) or be
+ * successful (SUCCESS) orthewise it has failed (IN_PROGRESS, FAILED).
+ */
+struct dt_test_state {
+	enum dt_test_sid probe_deferral;
+	enum dt_test_sid probe_clocks;
+	enum dt_test_sid probe_resets;
+	enum dt_test_sid crypto_dependencies;
+};
+
+/*
+ * References allocated from heap to be free once test completed
+ * dt_test_alloc(), dt_test_free(), dt_test_free_all()
+ */
+struct dt_test_free_ref {
+	void *p;
+	SLIST_ENTRY(dt_test_free_ref) link;
+};
+
+static struct dt_test_state dt_test_state;
+
+static const char __maybe_unused * const dt_test_str_sid[] = {
+	[DEFAULT] = "not passed",
+	[IN_PROGRESS] = "in-progress",
+	[SUCCESS] = "successful",
+	[FAILED] = "failed",
+};
+
+/* Reference allocations during test for release_init_resource initcall level */
+static SLIST_HEAD(dt_test_free_refs, dt_test_free_ref) dt_test_free_list =
+	SLIST_HEAD_INITIALIZER(dt_test_free_list);
+
+static void __maybe_unused *dt_test_alloc(size_t size)
+{
+	struct dt_test_free_ref *ref = NULL;
+
+	ref = calloc(1, sizeof(*ref) + size);
+	if (!ref)
+		return NULL;
+
+	ref->p = ref + 1;
+	SLIST_INSERT_HEAD(&dt_test_free_list, ref, link);
+
+	return ref->p;
+}
+
+static void __maybe_unused dt_test_free(void *p)
+{
+	struct dt_test_free_ref *ref = NULL;
+	struct dt_test_free_ref *t_ref = NULL;
+
+	if (!p)
+		return;
+
+	SLIST_FOREACH_SAFE(ref, &dt_test_free_list, link, t_ref) {
+		if (ref->p == p) {
+			SLIST_REMOVE(&dt_test_free_list, ref,
+				     dt_test_free_ref, link);
+			free(ref);
+			return;
+		}
+	}
+
+	panic();
+}
+
+static void dt_test_free_all(void)
+{
+	while (!SLIST_EMPTY(&dt_test_free_list)) {
+		struct dt_test_free_ref *ref = SLIST_FIRST(&dt_test_free_list);
+
+		SLIST_REMOVE(&dt_test_free_list, ref, dt_test_free_ref, link);
+		free(ref);
+	}
+}
+
+static TEE_Result dt_test_release(void)
+{
+	dt_test_free_all();
+
+	DT_TEST_MSG("Probe deferral: %s",
+		    dt_test_str_sid[dt_test_state.probe_deferral]);
+	DT_TEST_MSG("Clocks probe: %s",
+		    dt_test_str_sid[dt_test_state.probe_clocks]);
+	DT_TEST_MSG("Reset ctrl probe: %s",
+		    dt_test_str_sid[dt_test_state.probe_resets]);
+	DT_TEST_MSG("Crypto deps.: %s",
+		    dt_test_str_sid[dt_test_state.crypto_dependencies]);
+
+	return dt_driver_test_status();
+}
+
+release_init_resource(dt_test_release);
+
+TEE_Result dt_driver_test_status(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	if (dt_test_state.probe_deferral != SUCCESS) {
+		EMSG("Probe deferral test failed");
+		res = TEE_ERROR_GENERIC;
+	}
+	if (IS_ENABLED(CFG_DRIVERS_CLK) &&
+	    dt_test_state.probe_clocks != SUCCESS) {
+		EMSG("Clocks probing test failed");
+		res = TEE_ERROR_GENERIC;
+	}
+	if (IS_ENABLED(CFG_DRIVERS_RSTCTRL) &&
+	    dt_test_state.probe_resets != SUCCESS) {
+		EMSG("Reset controllers probing test failed");
+		res = TEE_ERROR_GENERIC;
+	}
+	if (dt_test_state.crypto_dependencies != SUCCESS) {
+		EMSG("Probe deferral on crypto dependencies test failed");
+		res = TEE_ERROR_GENERIC;
+	}
+
+	return res;
+}
+
+/*
+ * Consumer test driver: instance probed from the compatible
+ * node parsed in the DT. It consumes emulated resource obtained
+ * from DT references. Probe shall succeed only once all resources
+ * are found.
+ */
+static TEE_Result dt_test_consumer_probe(const void *fdt, int node,
+					 const void *compat_data __unused)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (IS_ENABLED(CFG_DRIVERS_CLK)) {
+		struct clk *clk0 = NULL;
+		struct clk *clk1 = NULL;
+		struct clk *clk = NULL;
+
+		DT_TEST_MSG("Probe clocks");
+
+		res = clk_dt_get_by_index(fdt, node, 0, &clk0);
+		if (res)
+			goto err_probe;
+		res = clk_dt_get_by_index(fdt, node, 1, &clk1);
+		if (res)
+			goto err_probe;
+
+		DT_TEST_MSG("Check valid clock references");
+
+		if (clk_enable(clk0)) {
+			DT_TEST_MSG("Can't enable %s", clk_get_name(clk0));
+			return TEE_ERROR_GENERIC;
+		}
+		clk_disable(clk0);
+
+		res = clk_dt_get_by_name(fdt, node, "clk0", &clk);
+		if (res || clk != clk0) {
+			DT_TEST_MSG("Unexpected clock reference");
+			return TEE_ERROR_GENERIC;
+		}
+
+		res = clk_dt_get_by_name(fdt, node, "clk1", &clk);
+		if (res || clk != clk1) {
+			DT_TEST_MSG("Unexpected clock reference");
+			return TEE_ERROR_GENERIC;
+		}
+
+		DT_TEST_MSG("Bad clock reference");
+
+		res = clk_dt_get_by_index(fdt, node, 3, &clk);
+		if (!res) {
+			DT_TEST_MSG("Unexpected clock found on invalid index");
+			return TEE_ERROR_GENERIC;
+		}
+
+		res = clk_dt_get_by_name(fdt, node, "clk2", &clk);
+		if (!res) {
+			DT_TEST_MSG("Unexpected clock found on invalid name");
+			return TEE_ERROR_GENERIC;
+		}
+
+		dt_test_state.probe_clocks = SUCCESS;
+	}
+
+	if (IS_ENABLED(CFG_DRIVERS_RSTCTRL)) {
+		struct rstctrl *rstctrl0 = NULL;
+		struct rstctrl *rstctrl1 = NULL;
+		struct rstctrl *rstctrl = NULL;
+
+		DT_TEST_MSG("Probe reset controllers");
+
+		res = rstctrl_dt_get_by_index(fdt, node, 0, &rstctrl0);
+		if (res)
+			goto err_probe;
+
+		DT_TEST_MSG("Check valid reset controller");
+
+		if (rstctrl_assert(rstctrl0)) {
+			EMSG("Can't assert rstctrl %s", rstctrl_name(rstctrl0));
+			return TEE_ERROR_GENERIC;
+		}
+
+		res = rstctrl_dt_get_by_name(fdt, node, "rst0", &rstctrl);
+		if (res)
+			return res;
+
+		if (rstctrl != rstctrl0) {
+			EMSG("Unexpected reset controller reference");
+			return TEE_ERROR_GENERIC;
+		}
+
+		res = rstctrl_dt_get_by_name(fdt, node, "rst1", &rstctrl1);
+		if (res)
+			goto err_probe;
+
+		if (!rstctrl1 || rstctrl1 == rstctrl0) {
+			EMSG("Unexpected reset controller reference");
+			return TEE_ERROR_GENERIC;
+		}
+
+		dt_test_state.probe_resets = SUCCESS;
+	}
+
+	if (dt_test_state.probe_deferral != IN_PROGRESS) {
+		dt_test_state.probe_deferral = FAILED;
+		return TEE_ERROR_GENERIC;
+	}
+
+	dt_test_state.probe_deferral = SUCCESS;
+
+	return TEE_SUCCESS;
+
+err_probe:
+	assert(res);
+
+	if (res == TEE_ERROR_DEFER_DRIVER_INIT &&
+	    dt_test_state.probe_deferral == DEFAULT) {
+		/* We expect at least a probe deferral */
+		dt_test_state.probe_deferral = IN_PROGRESS;
+	}
+
+	return res;
+}
+
+static const struct dt_device_match dt_test_consumer_match_table[] = {
+	{ .compatible = "linaro,dt-test-consumer", },
+	{ }
+};
+
+DEFINE_DT_DRIVER(dt_test_consumer_driver) = {
+	.name = "dt-test-consumer",
+	.match_table = dt_test_consumer_match_table,
+	.probe = dt_test_consumer_probe,
+};
+
+static TEE_Result dt_test_crypt_consumer_probe(const void *fdt __unused,
+					       int node __unused,
+					       const void *compat_data __unused)
+{
+	TEE_Result res = dt_driver_get_crypto();
+	uint8_t __maybe_unused byte = 0;
+
+	if (res == TEE_ERROR_DEFER_DRIVER_INIT &&
+	    dt_test_state.crypto_dependencies == DEFAULT) {
+		/* We expect to be deferred */
+		dt_test_state.crypto_dependencies = IN_PROGRESS;
+	}
+
+	if (res)
+		return res;
+
+	if (dt_test_state.crypto_dependencies == DEFAULT) {
+		EMSG("Test expects at least a driver probe deferral");
+		dt_test_state.crypto_dependencies = FAILED;
+		return TEE_ERROR_GENERIC;
+	}
+
+	if (crypto_rng_read(&byte, sizeof(byte))) {
+		dt_test_state.crypto_dependencies = FAILED;
+		return TEE_ERROR_GENERIC;
+	}
+
+	dt_test_state.crypto_dependencies = SUCCESS;
+	return TEE_SUCCESS;
+}
+
+static const struct dt_device_match dt_test_crypt_consumer_match_table[] = {
+	{ .compatible = "linaro,dt-test-crypt-consumer", },
+	{ }
+};
+
+DEFINE_DT_DRIVER(dt_test_consumer_driver) = {
+	.name = "dt-test-crypt-consumer",
+	.match_table = dt_test_crypt_consumer_match_table,
+	.probe = dt_test_crypt_consumer_probe,
+};
+
+#ifdef CFG_DRIVERS_CLK
+#define DT_TEST_CLK_COUNT		2
+
+#define DT_TEST_CLK0_BINDING_ID		3
+#define DT_TEST_CLK1_BINDING_ID		7
+
+static const char *dt_test_clk_name[DT_TEST_CLK_COUNT] = {
+	"dt_test-clk3",
+	"dt_test-clk7",
+};
+
+/* Emulating a clock does not require operators */
+static const struct clk_ops dt_test_clock_provider_ops;
+
+static struct clk *dt_test_get_clk(struct dt_driver_phandle_args *args,
+				   void *data, TEE_Result *res)
+{
+	struct clk *clk_ref = data;
+	struct clk *clk = NULL;
+
+	if (args->args_count != 1) {
+		*res = TEE_ERROR_BAD_PARAMETERS;
+		return NULL;
+	}
+
+	switch (args->args[0]) {
+	case DT_TEST_CLK0_BINDING_ID:
+		clk = clk_ref;
+		break;
+	case DT_TEST_CLK1_BINDING_ID:
+		clk = clk_ref + 1;
+		break;
+	default:
+		EMSG("Unexpected binding ID %"PRIu32, args->args[0]);
+		*res = TEE_ERROR_BAD_PARAMETERS;
+		return NULL;
+	}
+
+	DT_TEST_MSG("Providing clock %s", clk_get_name(clk));
+
+	*res = TEE_SUCCESS;
+	return clk;
+}
+
+static TEE_Result dt_test_clock_provider_probe(const void *fdt, int node,
+					       const void *compat_data __unused)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct clk *clk = NULL;
+	size_t n = 0;
+
+	DT_TEST_MSG("Register clocks");
+
+	clk = dt_test_alloc(DT_TEST_CLK_COUNT * sizeof(*clk));
+	if (!clk)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	for (n = 0; n < DT_TEST_CLK_COUNT; n++) {
+		clk[n].ops = &dt_test_clock_provider_ops;
+		clk[n].name = dt_test_clk_name[n];
+
+		res = clk_register(clk + n);
+		if (res)
+			goto err;
+	}
+
+	res = clk_dt_register_clk_provider(fdt, node, dt_test_get_clk, clk);
+	if (res)
+		goto err;
+
+	return TEE_SUCCESS;
+
+err:
+	dt_test_free(clk);
+	return res;
+}
+
+CLK_DT_DECLARE(dt_test_clock_provider, "linaro,dt-test-provider",
+	       dt_test_clock_provider_probe);
+#endif /* CFG_DRIVERS_CLK */
+
+#ifdef CFG_DRIVERS_RSTCTRL
+#define DT_TEST_RSTCTRL_COUNT		2
+
+#define DT_TEST_RSTCTRL0_BINDING_ID	5
+#define DT_TEST_RSTCTRL1_BINDING_ID	35
+
+struct dt_test_rstctrl {
+	unsigned int dt_binding;
+	struct rstctrl rstctrl;
+};
+
+static struct dt_test_rstctrl *to_test_rstctrl(struct rstctrl *rstctrl)
+{
+	return container_of(rstctrl, struct dt_test_rstctrl, rstctrl);
+}
+
+static TEE_Result dt_test_rstctrl_stub(struct rstctrl *rstctrl __maybe_unused,
+				       unsigned int to_us __unused)
+{
+	struct dt_test_rstctrl *dev = to_test_rstctrl(rstctrl);
+
+	switch (dev->dt_binding) {
+	case DT_TEST_RSTCTRL0_BINDING_ID:
+	case DT_TEST_RSTCTRL1_BINDING_ID:
+		return TEE_SUCCESS;
+	default:
+		EMSG("Unexpected rstctrl reference");
+		return TEE_ERROR_GENERIC;
+	}
+}
+
+static const char *dt_test_rstctrl_name(struct rstctrl *rstctrl __maybe_unused)
+{
+	static const char *rstctrl_name[DT_TEST_RSTCTRL_COUNT] = {
+		"dt_test-rstctrl5",
+		"dt_test-rstctrl35",
+	};
+	struct dt_test_rstctrl *dev = to_test_rstctrl(rstctrl);
+
+	switch (dev->dt_binding) {
+	case DT_TEST_RSTCTRL0_BINDING_ID:
+		return rstctrl_name[0];
+	case DT_TEST_RSTCTRL1_BINDING_ID:
+		return rstctrl_name[1];
+	default:
+		EMSG("Unexpected rstctrl reference");
+		return NULL;
+	}
+}
+
+const struct rstctrl_ops dt_test_rstctrl_ops = {
+	.assert_level = dt_test_rstctrl_stub,
+	.deassert_level = dt_test_rstctrl_stub,
+	.get_name = dt_test_rstctrl_name,
+};
+
+static struct rstctrl *dt_test_get_rstctrl(struct dt_driver_phandle_args *args,
+					   void *data, TEE_Result *res)
+{
+	struct dt_test_rstctrl *ref = data;
+	struct rstctrl *rstctrl = NULL;
+
+	if (args->args_count != 1) {
+		*res = TEE_ERROR_BAD_PARAMETERS;
+		return NULL;
+	}
+
+	switch (args->args[0]) {
+	case DT_TEST_RSTCTRL0_BINDING_ID:
+		rstctrl = &ref[0].rstctrl;
+		break;
+	case DT_TEST_RSTCTRL1_BINDING_ID:
+		rstctrl = &ref[1].rstctrl;
+		break;
+	default:
+		EMSG("Unexpected binding ID %"PRIu32, args->args[0]);
+		*res = TEE_ERROR_BAD_PARAMETERS;
+		return NULL;
+	}
+
+	DT_TEST_MSG("Providing reset controller %s", rstctrl_name(rstctrl));
+
+	*res = TEE_SUCCESS;
+	return rstctrl;
+}
+
+static TEE_Result dt_test_rstctrl_provider_probe(const void *fdt, int offs,
+						 const void *data __unused)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct dt_test_rstctrl *devices = NULL;
+
+	DT_TEST_MSG("Register reset controllers");
+
+	assert(rstctrl_ops_is_valid(&dt_test_rstctrl_ops));
+
+	devices = dt_test_alloc(DT_TEST_RSTCTRL_COUNT * sizeof(*devices));
+	if (!devices)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	devices[0].rstctrl.ops = &dt_test_rstctrl_ops;
+	devices[0].dt_binding = DT_TEST_RSTCTRL0_BINDING_ID;
+
+	devices[1].rstctrl.ops = &dt_test_rstctrl_ops;
+	devices[1].dt_binding = DT_TEST_RSTCTRL1_BINDING_ID;
+
+	res = rstctrl_register_provider(fdt, offs, dt_test_get_rstctrl,
+					devices);
+	if (res) {
+		dt_test_free(devices);
+		return res;
+	}
+
+	return TEE_SUCCESS;
+}
+
+RSTCTRL_DT_DECLARE(dt_test_rstctrl_provider, "linaro,dt-test-provider",
+		   dt_test_rstctrl_provider_probe);
+#endif /* CFG_DRIVERS_RSTCTRL */

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -5,6 +5,7 @@ srcs-y += assert.c
 srcs-y += console.c
 srcs-$(CFG_DT) += dt.c
 srcs-$(CFG_DT) += dt_driver.c
+srcs-$(CFG_DT_DRIVER_EMBEDDED_TEST) += dt_driver_test.c
 srcs-y += pm.c
 srcs-y += handle.c
 srcs-y += interrupt.c

--- a/core/pta/tests/invoke.c
+++ b/core/pta/tests/invoke.c
@@ -432,6 +432,8 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 		return core_lockdep_tests(nParamTypes, pParams);
 	case PTA_INVOKE_TEST_CMD_AES_PERF:
 		return core_aes_perf_tests(nParamTypes, pParams);
+	case PTA_INVOKE_TESTS_CMD_DT_DRIVER_TESTS:
+		return core_dt_driver_tests(nParamTypes, pParams);
 	default:
 		break;
 	}

--- a/core/pta/tests/misc.c
+++ b/core/pta/tests/misc.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  */
 #include <assert.h>
+#include <config.h>
+#include <kernel/dt_driver.h>
 #include <malloc.h>
 #include <stdbool.h>
 #include <trace.h>
@@ -548,6 +550,7 @@ static int self_test_nex_malloc(void)
 	return 0;
 }
 #endif
+
 /* exported entry points for some basic test */
 TEE_Result core_self_tests(uint32_t nParamTypes __unused,
 		TEE_Param pParams[TEE_NUM_PARAMS] __unused)
@@ -559,5 +562,19 @@ TEE_Result core_self_tests(uint32_t nParamTypes __unused,
 		EMSG("some self_test_xxx failed! you should enable local LOG");
 		return TEE_ERROR_GENERIC;
 	}
+	return TEE_SUCCESS;
+}
+
+/* Exported entrypoint for dt_driver tests */
+TEE_Result core_dt_driver_tests(uint32_t nParamTypes __unused,
+				TEE_Param pParams[TEE_NUM_PARAMS] __unused)
+{
+	if (IS_ENABLED(CFG_DT_DRIVER_EMBEDDED_TEST)) {
+		if (dt_driver_test_status())
+			return TEE_ERROR_GENERIC;
+	} else {
+		IMSG("dt_driver tests are not embedded");
+	}
+
 	return TEE_SUCCESS;
 }

--- a/core/pta/tests/misc.h
+++ b/core/pta/tests/misc.h
@@ -34,4 +34,7 @@ static inline TEE_Result core_lockdep_tests(
 TEE_Result core_aes_perf_tests(uint32_t param_types,
 			       TEE_Param params[TEE_NUM_PARAMS]);
 
+TEE_Result core_dt_driver_tests(uint32_t param_types,
+				TEE_Param params[TEE_NUM_PARAMS]);
+
 #endif /*CORE_PTA_TESTS_MISC_H*/

--- a/lib/libutee/include/pta_invoke_tests.h
+++ b/lib/libutee/include/pta_invoke_tests.h
@@ -103,5 +103,10 @@
  */
 #define PTA_INVOKE_TESTS_CMD_MEMREF_NULL	10
 
+/*
+ * Retrieve results of the dt_driver framework internal test
+ */
+#define PTA_INVOKE_TESTS_CMD_DT_DRIVER_TESTS	11
+
 #endif /*__PTA_INVOKE_TESTS_H*/
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -739,9 +739,11 @@ CFG_PREALLOC_RPC_CACHE ?= y
 # get and configure the clocks.
 # CFG_DRIVERS_CLK_DT embeds devicetree clock parsing support
 # CFG_DRIVERS_CLK_FIXED add support for "fixed-clock" compatible clocks
+# CFG_DRIVERS_CLK_EARLY_PROBE makes clocks probed at early_init initcall level.
 CFG_DRIVERS_CLK ?= n
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
 CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
+CFG_DRIVERS_CLK_EARLY_PROBE ?= $(CFG_DRIVERS_CLK_DT)
 
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -478,6 +478,11 @@ CFG_DRIVERS_CLK_EARLY_PROBE ?= n
 $(call force,CFG_DRIVERS_DT_RECURSIVE_PROBE,n,Mandated by CFG_DT_DRIVER_EMBEDDED_TEST)
 endif
 
+# CFG_DRIVERS_DT_RECURSIVE_PROBE when enabled forces a recursive subnode
+# parsing in the embedded DTB for driver probing. The alternative is
+# an exploration based on compatible drivers found. It is default disabled.
+CFG_DRIVERS_DT_RECURSIVE_PROBE ?= n
+
 # This option enables OP-TEE to respond to SMP boot request: the Rich OS
 # issues this to request OP-TEE to release secondaries cores out of reset,
 # with specific core number and non-secure entry address.

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -466,6 +466,18 @@ CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= $(CFG_ENABLE_EMBEDDED_TESTS)
 # Compiles bget_main_test() to be called from a test TA
 CFG_TA_BGET_TEST ?= $(CFG_ENABLE_EMBEDDED_TESTS)
 
+# CFG_DT_DRIVER_EMBEDDED_TEST when enabled embedb DT driver probing tests.
+# This also requires embeddeding a DTB with expected content.
+# Defautl disable CFG_DRIVERS_CLK_EARLY_PROBE to probe clocks as other drivers.
+# A probe deferral test mandates CFG_DRIVERS_DT_RECURSIVE_PROBE=n.
+CFG_DT_DRIVER_EMBEDDED_TEST ?= n
+ifeq ($(CFG_DT_DRIVER_EMBEDDED_TEST),y)
+CFG_DRIVERS_CLK ?= y
+CFG_DRIVERS_RSTCTRL ?= y
+CFG_DRIVERS_CLK_EARLY_PROBE ?= n
+$(call force,CFG_DRIVERS_DT_RECURSIVE_PROBE,n,Mandated by CFG_DT_DRIVER_EMBEDDED_TEST)
+endif
+
 # This option enables OP-TEE to respond to SMP boot request: the Rich OS
 # issues this to request OP-TEE to release secondaries cores out of reset,
 # with specific core number and non-secure entry address.


### PR DESCRIPTION
Implement _dt_driver_test.c_ with emulated resources (starting with clk's and rstctrl's) and a consumer device that gets those resources (possibly deferring its probe). A test DTSI defines the topology. After initcall completion, collect the status and let core self test (`xtest -t regression 1001`) report any failure (with a companion error traces).

Former change introduces `CFG_DRIVERS_CLK_EARLY_PROBE=y|n` to ease probe deferral (clocks not always early probe).
Note: can be useful when a clock depends on a pinctrl, probed after clock, but no occurrence in existing platforms.

Later change adds a missing description for CFG_DRIVERS_DT_RECURSIVE_PROBE.

The series default enables the test for qemu's platforms. The don't embed any DTB so use a template DTS file.