### PR TITLE
core: mm: fix core virtual address range constraint in lpae

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -813,13 +813,16 @@ void core_init_mmu(struct tee_mmap_region *mm)
 	assert(max_va < BIT64(CFG_LPAE_ADDR_SPACE_BITS));
 }
 
-bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
+#ifdef CFG_WITH_PAGER
+/* Prefer to consume only 1 base xlat table for the whole mapping */
+bool core_mmu_prefer_tee_ram_at_top(paddr_t paddr)
 {
 	size_t base_level_size = BASE_XLAT_BLOCK_SIZE;
 	paddr_t base_level_mask = base_level_size - 1;
 
 	return (paddr & base_level_mask) > (base_level_size / 2);
 }
+#endif
 
 #ifdef ARM32
 void core_init_mmu_regs(struct core_mmu_config *cfg)

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -750,11 +750,6 @@ void core_init_mmu_prtn(struct mmu_partition *prtn, struct tee_mmap_region *mm)
 			core_mmu_map_region(prtn, mm + n);
 }
 
-bool core_mmu_place_tee_ram_at_top(paddr_t paddr)
-{
-	return paddr > 0x80000000;
-}
-
 void core_init_mmu(struct tee_mmap_region *mm)
 {
 	/* Initialize default pagetables */

--- a/core/include/mm/core_mmu.h
+++ b/core/include/mm/core_mmu.h
@@ -276,7 +276,8 @@ extern unsigned long default_nsec_shm_size;
 void core_init_mmu_map(unsigned long seed, struct core_mmu_config *cfg);
 void core_init_mmu_regs(struct core_mmu_config *cfg);
 
-bool core_mmu_place_tee_ram_at_top(paddr_t paddr);
+/* Arch specific function to help optimizing 1 MMU xlat table */
+bool core_mmu_prefer_tee_ram_at_top(paddr_t paddr);
 
 /*
  * struct mmu_partition - stores MMU partition.


### PR DESCRIPTION
Removes constraint in LPAE implementation that expects core virtual
address range to fit a single block of the MMU base table used to
map the area. The implementation allows virtual addresses to spread
over several blocks of the base table. Therefor the limitation can be
removed.

As a result, selecting whether core virtual address range spreads
above or below the chosen base address depends on its location
against the virtual range mid address.

Fixes: https://github.com/OP-TEE/optee_os/issues/5201
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
