### PR TITLE
FF-A map manifest region

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -92,6 +92,7 @@
 
 /* Memory access permissions: executable */
 #define FFA_MEM_ACC_EXE			BIT(3)
+#define FFA_MEM_ACC_NSEC		BIT(4)
 
 /* Memory access permissions mask */
 #define FFA_MEM_ACC_MASK		0xf

--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -88,11 +88,18 @@
 #define FFA_DEV_MEM_nGnRE		U(0x1)
 
 /* Memory access permissions: Read-write */
+#define FFA_MEM_ACC_R			BIT(0)
 #define FFA_MEM_ACC_RW			BIT(1)
+#define FFA_MEM_ACC_W			BIT(5)
 
 /* Memory access permissions: executable */
 #define FFA_MEM_ACC_EXE			BIT(3)
 #define FFA_MEM_ACC_NSEC		BIT(4)
+
+#define FFA_MEM_MANIFEST_R	BIT(0)
+#define FFA_MEM_MANIFEST_W	BIT(1)
+#define FFA_MEM_MANIFEST_EXE	BIT(2)
+#define FFA_MEM_MANIFEST_NSEC	BIT(7)
 
 /* Memory access permissions mask */
 #define FFA_MEM_ACC_MASK		0xf

--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -78,6 +78,12 @@
 #define FFA_NORMAL_MEM_REG_ATTR		U(0x2f)
 
 /* Device memory attributes */
+#define FFA_DEV_MEM_REG_ATTR_MASK	U(0x1c)
+#define FFA_DEV_MEM_REG_ATTR		BIT(4)
+
+/* FF-A Device memory attributes */
+#define FFA_DEV_MEM_SHIFT		U(2)
+#define FFA_DEV_MEM_MASK		U(0x3)
 #define FFA_DEV_MEM_nGnRnE		U(0x0)
 #define FFA_DEV_MEM_nGnRE		U(0x1)
 

--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2018-2021, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited. All rights reserved.
  */
 
 #ifndef __FFA_H
@@ -76,6 +76,10 @@
 
 /* Memory attributes: Normal memory, Write-Back cacheable, Inner shareable */
 #define FFA_NORMAL_MEM_REG_ATTR		U(0x2f)
+
+/* Device memory attributes */
+#define FFA_DEV_MEM_nGnRnE		U(0x0)
+#define FFA_DEV_MEM_nGnRE		U(0x1)
 
 /* Memory access permissions: Read-write */
 #define FFA_MEM_ACC_RW			BIT(1)

--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -20,6 +20,9 @@ void spmc_sp_msg_handler(struct thread_smc_args *args,
 bool ffa_mem_reclaim(struct thread_smc_args *args,
 		     struct sp_session *caller_sp);
 
+int spmc_sp_add_nw_region(struct sp_mem *smem,
+			  struct ffa_mem_region *mem_reg,
+			  uint8_t highest_permission);
 #ifdef CFG_SECURE_PARTITION
 void spmc_sp_start_thread(struct thread_smc_args *args);
 int spmc_sp_add_share(struct ffa_rxtx *rxtx,

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -276,6 +276,8 @@ TEE_Result sp_map_shared(struct sp_session *s,
 	struct sp_ctx *ctx = NULL;
 	uint32_t perm = TEE_MATTR_UR;
 	struct sp_mem_map_region *reg = NULL;
+	uint32_t cache_type = 0;
+	bool is_device = smem->mem_reg_attr & FFA_DEV_MEM_REG_ATTR;
 
 	ctx = to_sp_ctx(s->ts_sess.ctx);
 
@@ -299,7 +301,28 @@ TEE_Result sp_map_shared(struct sp_session *s,
 	if (*va)
 		return TEE_ERROR_NOT_SUPPORTED;
 
+	if (is_device) {
+		uint8_t dev_type = (smem->mem_reg_attr >> FFA_DEV_MEM_SHIFT) &
+				    FFA_DEV_MEM_MASK;
+
+		if (sp_mem_ffa_dev_to_cache_type(dev_type, &cache_type))
+			return FFA_INVALID_PARAMETERS;
+	}
+
 	SLIST_FOREACH(reg, &smem->regions, link) {
+		/* Check device region attributes */
+		if (is_device) {
+			uint32_t mcache_type = 0;
+
+			if (mobj_get_cattr(reg->mobj, &mcache_type))
+				return FFA_INVALID_PARAMETERS;
+
+			if (cache_type != mcache_type) {
+				EMSG("Inccorect device type");
+				return FFA_INVALID_PARAMETERS;
+			}
+		}
+
 		res = vm_map(&ctx->uctx, va, reg->page_count * SMALL_PAGE_SIZE,
 			     perm, 0, reg->mobj, reg->page_offset);
 

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -249,9 +249,9 @@ static TEE_Result mem_set_cache_type(struct sp_mem *smem,
 	return TEE_SUCCESS;
 }
 
-static int spmc_sp_add_nw_region(struct sp_mem *smem,
-				 struct ffa_mem_region *mem_reg,
-				 uint8_t highest_permission)
+int spmc_sp_add_nw_region(struct sp_mem *smem,
+			  struct ffa_mem_region *mem_reg,
+			  uint8_t highest_permission)
 {
 	uint64_t page_count = READ_ONCE(mem_reg->total_page_count);
 	struct sp_mem_map_region *region = NULL;
@@ -264,6 +264,7 @@ static int spmc_sp_add_nw_region(struct sp_mem *smem,
 	if (!m)
 		return FFA_NO_MEMORY;
 
+	sp_mem_set_secure(m, !(highest_permission & FFA_MEM_ACC_NSEC));
 	for (i = 0; i < address_count; i++) {
 		struct ffa_address_range *addr_range = NULL;
 
@@ -386,6 +387,8 @@ int spmc_sp_add_share(struct ffa_rxtx *rxtx,
 				goto cleanup;
 		}
 	} else {
+		highest_permission |= FFA_MEM_ACC_NSEC;
+
 		res = spmc_sp_add_nw_region(smem, mem_reg, highest_permission);
 		if (res)
 			goto cleanup;

--- a/core/arch/arm/mm/sp_mem.c
+++ b/core/arch/arm/mm/sp_mem.c
@@ -84,6 +84,14 @@ int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 	if (ADD_OVERFLOW(*idx, num_pages, &n) || n > tot_page_count)
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	if (ms->is_secure) {
+		if (tee_pbuf_is_non_sec(pa, num_pages * SMALL_PAGE_SIZE))
+			return TEE_ERROR_BAD_PARAMETERS;
+	} else {
+		if (tee_pbuf_is_sec(pa, num_pages * SMALL_PAGE_SIZE))
+			return TEE_ERROR_BAD_PARAMETERS;
+	}
+
 	for (n = 0; n < num_pages; n++)
 		ms->pages[n + *idx] = pa + n * SMALL_PAGE_SIZE;
 
@@ -136,8 +144,6 @@ static bool mobj_sp_matches(struct mobj *mobj __maybe_unused,
 			    enum buf_is_attr attr)
 {
 	struct mobj_sp *m = to_mobj_sp(mobj);
-
-	assert(mobj->ops == &mobj_sp_ops);
 
 	if (m->is_secure)
 		return attr == CORE_MEM_SEC;

--- a/core/arch/arm/mm/sp_mem.c
+++ b/core/arch/arm/mm/sp_mem.c
@@ -99,6 +99,24 @@ int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 	return TEE_SUCCESS;
 }
 
+TEE_Result sp_mem_alloc(unsigned int num_pages, paddr_t *pa)
+{
+	size_t size = 0;
+	tee_mm_entry_t *mm = NULL;
+
+	if (MUL_OVERFLOW(num_pages, SMALL_PAGE_SIZE, &size))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mm = tee_mm_alloc(&tee_mm_sec_ddr, size);
+
+	if (!mm)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	*pa = tee_mm_get_smem(mm);
+
+	return TEE_SUCCESS;
+}
+
 TEE_Result sp_mem_ffa_dev_to_cache_type(uint8_t dev_type, uint32_t *cache_type)
 {
 	*cache_type = TEE_MATTR_MEM_TYPE_DEV;

--- a/core/include/mm/sp_mem.h
+++ b/core/include/mm/sp_mem.h
@@ -81,4 +81,6 @@ void sp_mem_add(struct sp_mem *smem);
 struct mobj *sp_mem_new_mobj(uint64_t pages);
 int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 		     paddr_t pa, unsigned int num_pages);
+void sp_mem_set_cattr(struct mobj *mobj, uint32_t cache_type);
+TEE_Result sp_mem_ffa_dev_to_cache_type(uint8_t dev_type, uint32_t *cache_type);
 #endif /*__MM_SP_MEM_H*/

--- a/core/include/mm/sp_mem.h
+++ b/core/include/mm/sp_mem.h
@@ -83,4 +83,5 @@ int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 		     paddr_t pa, unsigned int num_pages);
 void sp_mem_set_cattr(struct mobj *mobj, uint32_t cache_type);
 TEE_Result sp_mem_ffa_dev_to_cache_type(uint8_t dev_type, uint32_t *cache_type);
+void sp_mem_set_secure(struct mobj *mobj, bool is_secure);
 #endif /*__MM_SP_MEM_H*/

--- a/core/include/mm/sp_mem.h
+++ b/core/include/mm/sp_mem.h
@@ -84,4 +84,5 @@ int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 void sp_mem_set_cattr(struct mobj *mobj, uint32_t cache_type);
 TEE_Result sp_mem_ffa_dev_to_cache_type(uint8_t dev_type, uint32_t *cache_type);
 void sp_mem_set_secure(struct mobj *mobj, bool is_secure);
+TEE_Result sp_mem_alloc(unsigned int num_pages, paddr_t *pa);
 #endif /*__MM_SP_MEM_H*/


### PR DESCRIPTION
Map the device and memory regions from the SP manifest file into the SP memory space.
Iterate over all device and manifest regions in the manifest file. Map the regions inside the SP memory space.
With this patch the Trusted Service crypto can use the hardware TRNG.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
