### PR TITLE
core: imx: generate uImage for imx6 and imx7 platforms

### DIFF
--- a/core/arch/arm/plat-imx/link.mk
+++ b/core/arch/arm/plat-imx/link.mk
@@ -1,3 +1,11 @@
 include core/arch/arm/kernel/link.mk
 
 all: $(link-out-dir)/tee-raw.bin
+
+.PHONY: uTee
+uTee: $(link-out-dir)/uTee
+cleanfiles += $(link-out-dir)/uTee
+$(link-out-dir)/uTee: $(link-out-dir)/tee-raw.bin
+	@$(cmd-echo-silent) '  MKIMAGE $@'
+	$(q)ADDR=`printf 0x%x $$(($(CFG_TZDRAM_START)))`; \
+		mkimage -A arm -O linux -C none -a $$ADDR -e $$ADDR -d $< $@


### PR DESCRIPTION
In the NXP BSP, for imx6 and imx7 platforms (ARMv7), optee-os
is booted by U-Boot as a uImage file.
The generation of this uImage requires:
 - optee-os load address. This address is fetched in the tee.elf file
 with readelf.
 - mkimage u-boot-tools. This tool takes the load address and the
 tee-raw.bin as an input to generate the uImage uTee.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
