### PR TITLE
core: mm: fix mobj_shm_ops support .get_cattr.

### DIFF
--- a/core/mm/mobj.c
+++ b/core/mm/mobj.c
@@ -396,6 +396,17 @@ static bool mobj_shm_matches(struct mobj *mobj __unused, enum buf_is_attr attr)
 	return attr == CORE_MEM_NSEC_SHM || attr == CORE_MEM_NON_SEC;
 }
 
+static TEE_Result mobj_shm_get_cattr(struct mobj *mobj __unused,
+				     uint32_t *cattr)
+{
+	if (!cattr)
+		return TEE_ERROR_GENERIC;
+
+	*cattr = TEE_MATTR_MEM_TYPE_CACHED;
+
+	return TEE_SUCCESS;
+}
+
 static void mobj_shm_free(struct mobj *mobj)
 {
 	struct mobj_shm *m = to_mobj_shm(mobj);
@@ -417,6 +428,7 @@ __weak __relrodata_unpaged("mobj_shm_ops") = {
 	.get_va = mobj_shm_get_va,
 	.get_pa = mobj_shm_get_pa,
 	.get_phys_offs = mobj_shm_get_phys_offs,
+	.get_cattr = mobj_shm_get_cattr,
 	.matches = mobj_shm_matches,
 	.free = mobj_shm_free,
 	.get_cookie = mobj_shm_get_cookie,
@@ -441,6 +453,7 @@ struct mobj *mobj_shm_alloc(paddr_t pa, size_t size, uint64_t cookie)
 
 	m->mobj.size = size;
 	m->mobj.ops = &mobj_shm_ops;
+	m->mobj.phys_granule = SMALL_PAGE_SIZE;
 	refcount_set(&m->mobj.refc, 1);
 	m->pa = pa;
 	m->cookie = cookie;


### PR DESCRIPTION
ftrace use static shared memory returns an object of type mobj_shm_ops.
But the get_cattr function is not implemented in mobj_shm_ops.This will
cause ftrace to not work properly.

Signed-off-by: Lejia Zhang <zhanlej@gmail.com>
Suggested-by: Sumit Garg <sumit.garg@linaro.org>

See #5198 for detail.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
