### PR TITLE
FF-A map manifest region

### DIFF
--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2021, Arm Limited
+ * Copyright (c) 2021-2022, Arm Limited
  */
 #include <assert.h>
 #include <bench.h>
@@ -226,7 +226,7 @@ static int spmc_sp_add_nw_region(struct sp_mem *smem,
 {
 	uint64_t page_count = READ_ONCE(mem_reg->total_page_count);
 	struct sp_mem_map_region *region = NULL;
-	struct mobj *m = sp_mem_new_mobj(page_count);
+	struct mobj *m = sp_mem_new_mobj(page_count, TEE_MATTR_MEM_TYPE_CACHED);
 	unsigned int i = 0;
 	unsigned int idx = 0;
 	int res = FFA_OK;

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -226,7 +226,8 @@ static int spmc_sp_add_nw_region(struct sp_mem *smem,
 {
 	uint64_t page_count = READ_ONCE(mem_reg->total_page_count);
 	struct sp_mem_map_region *region = NULL;
-	struct mobj *m = sp_mem_new_mobj(page_count, TEE_MATTR_MEM_TYPE_CACHED);
+	struct mobj *m = sp_mem_new_mobj(page_count, TEE_MATTR_MEM_TYPE_CACHED,
+					 false);
 	unsigned int i = 0;
 	unsigned int idx = 0;
 	int res = FFA_OK;

--- a/core/include/mm/sp_mem.h
+++ b/core/include/mm/sp_mem.h
@@ -78,7 +78,8 @@ void *sp_mem_get_va(const struct user_mode_ctx *uctx, size_t offset,
 		    struct mobj *mobj);
 void sp_mem_remove(struct sp_mem *s_mem);
 void sp_mem_add(struct sp_mem *smem);
-struct mobj *sp_mem_new_mobj(uint64_t pages, uint32_t cache_type);
+struct mobj *sp_mem_new_mobj(uint64_t pages, uint32_t cache_type,
+			     bool is_secure);
 int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 		     paddr_t pa, unsigned int num_pages);
 #endif /*__MM_SP_MEM_H*/

--- a/core/include/mm/sp_mem.h
+++ b/core/include/mm/sp_mem.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2022, Arm Limited.
  */
 
 #ifndef __MM_SP_MEM_H
@@ -78,7 +78,7 @@ void *sp_mem_get_va(const struct user_mode_ctx *uctx, size_t offset,
 		    struct mobj *mobj);
 void sp_mem_remove(struct sp_mem *s_mem);
 void sp_mem_add(struct sp_mem *smem);
-struct mobj *sp_mem_new_mobj(uint64_t pages);
+struct mobj *sp_mem_new_mobj(uint64_t pages, uint32_t cache_type);
 int sp_mem_add_pages(struct mobj *mobj, unsigned int *idx,
 		     paddr_t pa, unsigned int num_pages);
 #endif /*__MM_SP_MEM_H*/


### PR DESCRIPTION
This is a replacement for #5215. The original author (@jellesels-arm) won't be able to continue the original PR.
I moved the contents without modification (only squash and rebase), please add any new comments on this PR.

Map the device and memory regions from the SP manifest file into the SP memory space.
Iterate over all device and manifest regions in the manifest file. Map the regions inside the SP memory space.
With this patch the Trusted Service crypto can use the hardware TRNG.
