### PR TITLE
drivers: imx_ocotp: initialize OCOTP driver earlier

### DIFF
--- a/core/drivers/imx_ocotp.c
+++ b/core/drivers/imx_ocotp.c
@@ -280,4 +280,4 @@ static TEE_Result imx_ocotp_init(void)
 
 	return TEE_SUCCESS;
 }
-driver_init(imx_ocotp_init);
+service_init(imx_ocotp_init);


### PR DESCRIPTION
Initialize the OCOTP driver earlier with service_init() instead of
driver_init().

With CFG_CORE_HUK_SUBKEY_COMPAT=y, tee_fs_init_key_manager() and consequently
tee_otp_get_die_id() get executed earlier than the OCOTP driver
initialization. tee_fs_init_key_manager() is called by
service_init_late() routine.

On platforms featuring the OCOTP driver, the function
tee_otp_get_die_id() relies on the driver to be initialized.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
