### PR TITLE
overlay: use the __symbols__ node in DTB to help overlay generation

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -161,7 +161,7 @@ jobs:
           _make PLATFORM=imx-mx7ulpevk
           _make PLATFORM=imx-mx8mmevk
           _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_CRYPTO_DRIVER=y
-          if [ -d $HOME/se050/plug-and-trust ]; then _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_NXP_CAAM_RNG_DRV=y CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_NXP_SE05X_RNG_DRV=n CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{DIEID,RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050/plug-and-trust ; fi
+          if [ -d $HOME/se050/plug-and-trust ]; then _make PLATFORM=imx-mx8mmevk CFG_NXP_CAAM=y CFG_DT=y CFG_NSEC_DTB_OVERLAY_ADDR=0x43200000 CFG_NXP_CAAM_RNG_DRV=y CFG_NXP_SE05X=y CFG_IMX_I2C=y CFG_STACK_{THREAD,TMP}_EXTRA=8192 CFG_CRYPTO_DRV_{CIPHER,ACIPHER}=y CFG_NXP_SE05X_RNG_DRV=n CFG_WITH_SOFTWARE_PRNG=n CFG_NXP_SE05X_{DIEID,RSA,ECC,CTR}_DRV=y CFG_NXP_SE05X_PLUG_AND_TRUST=$HOME/se050/plug-and-trust ; fi
           _make PLATFORM=imx-mx8mnevk
           _make PLATFORM=imx-mx8mqevk
           _make PLATFORM=imx-mx8mpevk

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -59,6 +59,7 @@ void boot_init_secondary(unsigned long nsec_entry);
 
 void main_init_gic(void);
 void main_secondary_init_gic(void);
+const char * const *main_get_optee_reserved_drivers(size_t *num);
 
 void init_sec_mon(unsigned long nsec_entry);
 void init_tee_runtime(void);

--- a/lib/libutils/isoc/include/string.h
+++ b/lib/libutils/isoc/include/string.h
@@ -30,6 +30,7 @@ char *strstr(const char *big, const char *little);
 char *strcpy(char *dest, const char *src);
 char *strncpy(char *dest, const char *src, size_t n);
 char *strrchr(const char *s, int i);
+char *strtok_r(char *str, const char *delim, char **saveptr);
 
 void *memchr(const void *buf, int c, size_t length);
 

--- a/lib/libutils/isoc/newlib/strtok_r.c
+++ b/lib/libutils/isoc/newlib/strtok_r.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 1988 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <string.h>
+
+static char *
+__strtok_r (register char *s,
+	register const char *delim,
+	char **lasts,
+	int skip_leading_delim)
+{
+	register char *spanp;
+	register int c, sc;
+	char *tok;
+
+
+	if (s == NULL && (s = *lasts) == NULL)
+		return (NULL);
+
+	/*
+	 * Skip (span) leading delimiters (s += strspn(s, delim), sort of).
+	 */
+cont:
+	c = *s++;
+	for (spanp = (char *)delim; (sc = *spanp++) != 0;) {
+		if (c == sc) {
+			if (skip_leading_delim) {
+				goto cont;
+			}
+			else {
+				*lasts = s;
+				s[-1] = 0;
+				return (s - 1);
+			}
+		}
+	}
+
+	if (c == 0) {		/* no non-delimiter characters */
+		*lasts = NULL;
+		return (NULL);
+	}
+	tok = s - 1;
+
+	/*
+	 * Scan token (scan for delimiters: s += strcspn(s, delim), sort of).
+	 * Note that delim must have one NUL; we stop if we see that, too.
+	 */
+	for (;;) {
+		c = *s++;
+		spanp = (char *)delim;
+		do {
+			if ((sc = *spanp++) == c) {
+				if (c == 0)
+					s = NULL;
+				else
+					s[-1] = 0;
+				*lasts = s;
+				return (tok);
+			}
+		} while (sc != 0);
+	}
+	/* NOTREACHED */
+}
+
+char *
+strtok_r (register char *__restrict s,
+	register const char *__restrict delim,
+	char **__restrict lasts)
+{
+	return __strtok_r (s, delim, lasts, 1);
+}

--- a/lib/libutils/isoc/newlib/sub.mk
+++ b/lib/libutils/isoc/newlib/sub.mk
@@ -25,3 +25,4 @@ srcs-y += strnlen.c
 srcs-y += strrchr.c
 srcs-y += strstr.c
 srcs-y += strtoul.c
+srcs-y += strtok_r.c


### PR DESCRIPTION
Summary
-------------
The following patchset reads the `__symbols__` node in a DTB passed in bootargs to help generating the kernel DTB overlay and avoid having to hardcode node paths (node's path-name are not stable and may change thus requiring firmware updates to handle those changes)

**Tested in imx8m - preparing changes for upstreaming to the imx-atf project**

iMX-ATF changes required to support this feature on iMX8m
--------------------------------------------------------------------------------
Trusted Firmware for iMX: https://source.codeaurora.org/external/imx/imx-atf

The imx8mm boot sequence is as follows:
![imx8mm](https://user-images.githubusercontent.com/10456021/152163007-28a87900-7efc-41aa-943b-a1bc634aea84.png)

The current imx8m  TF-A 1) does not expect any params from SPL 2) therefore [hardcodes](https://source.codeaurora.org/external/imx/imx-atf/commit/?h=imx_5.4.3_2.0.0&id=f1a195b5cce64365a7227557a9009a4f545aa02d) the addresses where the FDT overlay will be located for OP-TEE (BL32) and U-Boot (BL33) 3) and clears the FDT overlay memory region

This could be modified so that SPL handles the DTB it reads from a FIT to TF-A:

```
diff --git a/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c b/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
index 049192880..66af6de5f 100644
--- a/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mm/imx8mm_bl31_setup.c
@@ -176,7 +176,10 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
        /* Make sure memory is clean */
        mmio_write_32(BL32_FDT_OVERLAY_ADDR, 0);
        bl33_image_ep_info.args.arg3 = BL32_FDT_OVERLAY_ADDR;
-   bl32_image_ep_info.args.arg3 = BL32_FDT_OVERLAY_ADDR;
+ /* bl32 could be receiving a DTB on input while also asked to generate
+  * an overlay
+  */
+ bl32_image_ep_info.args.arg3 = arg1 > 0 ? arg1 : BL32_FDT_OVERLAY_ADDR;
 #endif
 #endif

```

Then to actually receive the arguments TF-A could do:

1) if the HW/Bootrom allows for it, do the reset actions in SPL and then


```
diff --git a/plat/imx/imx8m/imx8mm/platform.mk b/plat/imx/imx8m/imx8mm/platform.mk
index 600a3c449..0161ff8e2 100644
--- a/plat/imx/imx8m/imx8mm/platform.mk
+++ b/plat/imx/imx8m/imx8mm/platform.mk
@@ -50,7 +50,7 @@ BL31_SOURCES          +=      plat/imx/common/imx8_helpers.S                  \
                                ${IMX_GIC_SOURCES}
 
 USE_COHERENT_MEM       :=      1
-RESET_TO_BL31              :=      1
+RESET_TO_BL31                :=      0
 A53_DISABLE_NON_TEMPORAL_HINT := 0
 
 ERRATA_A53_835769      :=      1

```

2) Alternatively (**preferred**) we could not clear the arguments passed by SPL while keeping RESET_TO_BL31. For instance just define a new macro for imx8m (KEEP_FIRST_BOOTLOADER_ARGUMENTS) and continue to enter via reset.


```
diff --git a/bl31/aarch64/bl31_entrypoint.S b/bl31/aarch64/bl31_entrypoint.S
index ed058648f..f62b60520 100644
--- a/bl31/aarch64/bl31_entrypoint.S
+++ b/bl31/aarch64/bl31_entrypoint.S
@@ -72,11 +72,14 @@ func bl31_entrypoint
         * there's no argument to relay from a previous bootloader. Zero the
         * arguments passed to the platform layer to reflect that.
         * ---------------------------------------------------------------------
-    */
+ */
+#ifndef KEEP_FIRST_BOOTLOADER_ARGUMENTS
        mov     x20, 0
        mov     x21, 0
        mov     x22, 0
        mov     x23, 0
+#endif
+

```