### PR TITLE
Forwarding TPM event log to FF-A SPs

### DIFF
--- a/core/include/kernel/tpm.h
+++ b/core/include/kernel/tpm.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2020, ARM Limited. All rights reserved.
+ * Copyright (c) 2020-2022, ARM Limited. All rights reserved.
  */
 
 #ifndef __KERNEL_TPM_H__
@@ -18,6 +18,8 @@
  */
 TEE_Result tpm_get_event_log(void *buf, size_t *size);
 
+TEE_Result tpm_get_event_log_size(size_t *size);
+
 /*
  * Reads the TPM Event log information and store it internally.
  * If support for DTB is enabled, it will read the parameters there.
@@ -32,6 +34,11 @@ void tpm_map_log_area(void *fdt);
 
 static inline TEE_Result tpm_get_event_log(void *buf __unused,
 					   size_t *size __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result tpm_get_event_log_size(size_t *size __unused)
 {
 	return TEE_ERROR_NOT_SUPPORTED;
 }

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -122,6 +122,13 @@ TEE_Result tpm_get_event_log(void *buf, size_t *size)
 	return TEE_SUCCESS;
 }
 
+TEE_Result tpm_get_event_log_size(size_t *size)
+{
+	*size = tpm_log_size;
+
+	return TEE_SUCCESS;
+}
+
 void tpm_map_log_area(void *fdt)
 {
 	paddr_t log_addr = 0;

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2020, ARM Limited. All rights reserved.
+ * Copyright (c) 2020-2022, ARM Limited. All rights reserved.
  */
 
 #include <compiler.h>
@@ -31,18 +31,23 @@ static int read_dt_tpm_log_info(void *fdt, int node, paddr_t *buf,
 	int len_prop = 0;
 	paddr_t log_addr = 0;
 	int err = 0;
+#ifdef CFG_MAP_EXT_DT_SECURE
+	const char *dt_tpm_event_log_addr = "tpm_event_log_addr";
+#else
+	const char *dt_tpm_event_log_addr = "tpm_event_log_sm_addr";
+#endif
 
 	/*
 	 * Get the TPM Log address.
 	 */
-	property = fdt_getprop(fdt, node, "tpm_event_log_sm_addr", &len_prop);
+	property = fdt_getprop(fdt, node, dt_tpm_event_log_addr, &len_prop);
 
 	if (!property  || len_prop != sizeof(uint32_t) * 2)
 		return -1;
 
 	log_addr = fdt32_to_cpu(property[1]);
 
-	err = fdt_setprop(fdt, node, "tpm_event_log_sm_addr", &zero_addr,
+	err = fdt_setprop(fdt, node, dt_tpm_event_log_addr, &zero_addr,
 			  sizeof(uint32_t) * 2);
 	if (err < 0) {
 		EMSG("Error setting property DTB to zero\n");

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2016, 2022 Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
  */
 
 #include <assert.h>
@@ -642,6 +643,15 @@ uint32_t core_mmu_type_to_attr(enum teecore_memtypes t)
 	case MEM_AREA_NSEC_SHM:
 		return attr | TEE_MATTR_PRW | cached;
 	case MEM_AREA_EXT_DT:
+		/*
+		 * If CFG_MAP_EXT_DT_SECURE is enabled map the external device
+		 * tree as secure non-cached memory, otherwise, fall back to
+		 * non-secure mapping.
+		 */
+		if (IS_ENABLED(CFG_MAP_EXT_DT_SECURE))
+			return attr | TEE_MATTR_SECURE | TEE_MATTR_PRW |
+			       noncache;
+		fallthrough;
 	case MEM_AREA_IO_NSEC:
 		return attr | TEE_MATTR_PRW | noncache;
 	case MEM_AREA_IO_SEC:

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -421,6 +421,9 @@ CFG_STACK_TMP_EXTRA ?= 0
 # the address of a DTB in register X2/R2 provided by the early boot stage
 # or value 0 if boot stage provides no DTB.
 #
+# When CFG_MAP_EXT_DT_SECURE is enabled the external device tree is expected to
+# be in the secure memory.
+#
 # When CFG_EMBED_DTB is enabled, CFG_EMBED_DTB_SOURCE_FILE shall define the
 # relative path of a DTS file located in core/arch/$(ARCH)/dts.
 # The DTS file is compiled into a DTB file which content is embedded in a
@@ -433,6 +436,10 @@ $(call force,CFG_DT,y)
 endif
 CFG_EMBED_DTB ?= n
 CFG_DT ?= n
+CFG_MAP_EXT_DT_SECURE ?= n
+ifeq ($(CFG_MAP_EXT_DT_SECURE),y)
+$(call force,CFG_DT,y)
+endif
 
 # Maximum size of the Device Tree Blob, has to be large enough to allow
 # editing of the supplied DTB.

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -680,7 +680,7 @@ CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID ?= n
 CFG_SHOW_CONF_ON_BOOT ?= n
 
 # Enables support for passing a TPM Event Log stored in secure memory
-# to a TA, so a TPM Service could use it to extend any measurement
+# to a TA or FF-A SP, so a TPM Service could use it to extend any measurement
 # taken before the service was up and running.
 CFG_CORE_TPM_EVENT_LOG ?= n
 


### PR DESCRIPTION
**The first three commits of this PR are being reviewed in a separate PR: #5223** 

Forward TPM event log to FF-A SPs, so the initial attestation service of trusted-services can access it.
The PR consists of two parts:

- Enable OP-TEE to read the external device tree from secure memory. If OP-TEE acts like a SEL-1 SPMC Trusted Firmware-A passes a device tree in the secure memory (TOS FW config) and it forwards the details of TPM event log buffer in this device tree. Compared to the "traditional" OP-TEE boot (non-FF-A) the standard "tpm_event_log_addr" property is being used instead of "tpm_event_log_sm_addr".
- Map the TPM event log into the FF-A SP if its manifest has an "arm,tpm_event_log" compatible node indicating its need for the event log.