### PR TITLE
drivers: dcp: fix HUK support

### DIFF
--- a/core/drivers/imx/dcp/dcp.c
+++ b/core/drivers/imx/dcp/dcp.c
@@ -362,7 +362,6 @@ TEE_Result dcp_cipher_do_init(struct dcp_cipher_data *data,
 		desc->ctrl0 |= DCP_CONTROL0_CIPHER_ENCRYPT;
 
 	if (init->key_mode == DCP_OTP) {
-		desc->ctrl0 |= DCP_CONTROL0_OTP_KEY;
 		desc->ctrl1 |= DCP_CONTROL1_KEY_SELECT_OTP_CRYPTO;
 	} else if (init->key_mode == DCP_PAYLOAD) {
 		desc->ctrl0 |= DCP_CONTROL0_PAYLOAD_KEY;


### PR DESCRIPTION
According to the i.MX6ULL manual, to read the UNIQUE_KEY from DCP
we must **not** set the OTP_KEY bit in ctrl0 and must use 0xFE for
the KEY_SELECT value in ctrl1 to retrieve the UNIQUE_KEY from
KEY ram where it is loaded just after SoC reset.

While ctrl1 was set correctly, OTP_KEY was being set in ctrl0.

Change proposed by Michael Scott <mike@foundries.io> at
https://github.com/OP-TEE/optee_os/pull/4094, but didn't end up being
part of the final changes.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>