### PR TITLE
cscope: exclude .ld.S files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,8 @@ clean:
 cscope:
 	@echo '  CSCOPE  .'
 	${q}rm -f cscope.*
-	${q}find $(PWD) -name "*.[chSs]" | grep -v export-ta_ > cscope.files
+	${q}find $(PWD) -name "*.[chSs]" | grep -v export-ta_ | \
+		grep -v -F _init.ld.S | grep -v -F _unpaged.ld.S > cscope.files
 	${q}cscope -b -q -k
 
 .PHONY: checkpatch checkpatch-staging checkpatch-working


### PR DESCRIPTION
The .ld.S files contains nothing worth indexing with cscope. The
generated *_unpaged.ld.S and *_init.ld.S are especially unfriendly as
they adds lots of false positive matches for cscope. Fix this by
excluding all the .ld.S files.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
