### PR TITLE
Fix device-tree assigned-clocks properties parsing

### DIFF
--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -167,7 +167,7 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 			}
 		}
 
-		if (rate_prop && clock_idx <= rate_len) {
+		if (rate_prop && clock_idx < rate_len) {
 			rate = fdt32_to_cpu(rate_prop[clock_idx]);
 			if (rate && clk_set_rate(clk, rate) != TEE_SUCCESS)
 				panic();

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -266,6 +266,13 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 	while (idx < len) {
 		idx32 = idx / sizeof(uint32_t);
 		phandle = fdt32_to_cpu(prop[idx32]);
+		if (!phandle) {
+			if (!prop_idx)
+				break;
+			idx += sizeof(phandle);
+			prop_idx--;
+			continue;
+		}
 
 		prv = dt_driver_get_provider_by_phandle(phandle, type);
 		if (!prv) {


### PR DESCRIPTION
This small series fixes parsing problems when using `assigned-clocks` properties:
- Wrong check for assigned-clock-rates property
- Handling of phandle == 0