### PR TITLE
RFC proof of concept fault mitigation

### DIFF
--- a/core/crypto/signed_hdr.c
+++ b/core/crypto/signed_hdr.c
@@ -12,6 +12,7 @@
 #include <tee/tee_cryp_utl.h>
 #include <utee_defines.h>
 #include <util.h>
+#include <fault_mitigation.h>
 
 struct shdr *shdr_alloc_and_copy(const struct shdr *img, size_t img_size)
 {
@@ -46,43 +47,56 @@ struct shdr *shdr_alloc_and_copy(const struct shdr *img, size_t img_size)
 
 TEE_Result shdr_verify_signature(const struct shdr *shdr)
 {
-	struct rsa_public_key key;
+	struct rsa_public_key key = { };
 	TEE_Result res;
 	uint32_t e = TEE_U32_TO_BIG_ENDIAN(ta_pub_key_exponent);
+	struct ftmn ftmn = { };
+	unsigned int err_incr = 2;
 	size_t hash_size;
 
 	if (shdr->magic != SHDR_MAGIC)
-		return TEE_ERROR_SECURITY;
+		goto err;
 
 	if (TEE_ALG_GET_MAIN_ALG(shdr->algo) != TEE_MAIN_ALGO_RSA)
-		return TEE_ERROR_SECURITY;
+		goto err;
 
 	res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(shdr->algo),
 				      &hash_size);
 	if (res)
-		return TEE_ERROR_SECURITY;
+		goto err;
 	if (hash_size != shdr->hash_size)
-		return TEE_ERROR_SECURITY;
+		goto err;
 
 	res = crypto_acipher_alloc_rsa_public_key(&key,
 						  ta_pub_key_modulus_size * 8);
 	if (res)
-		return TEE_ERROR_SECURITY;
+		goto err;
 
 	res = crypto_bignum_bin2bn((uint8_t *)&e, sizeof(e), key.e);
 	if (res)
-		goto out;
+		goto err;
 	res = crypto_bignum_bin2bn(ta_pub_key_modulus, ta_pub_key_modulus_size,
 				   key.n);
 	if (res)
-		goto out;
+		goto err;
 
+	FTMN_PUSH_LINKED_CALL(&ftmn,
+			      FTMN_FUNC_HASH("crypto_acipher_rsassa_verify"));
 	res = crypto_acipher_rsassa_verify(shdr->algo, &key, shdr->hash_size,
 					   SHDR_GET_HASH(shdr), shdr->hash_size,
 					   SHDR_GET_SIG(shdr), shdr->sig_size);
+	FTMN_SET_CHECK_RES_FROM_CALL(&ftmn, FTMN_INCR0, res);
+	FTMN_POP_LINKED_CALL(&ftmn);
+	if (!res) {
+		ftmn_checkpoint(&ftmn, FTMN_INCR0);
+		goto out;
+	}
+	err_incr = 1;
+err:
+	res = TEE_ERROR_SECURITY;
+	FTMN_SET_CHECK_RES_NOT_ZERO(&ftmn, err_incr * FTMN_INCR0, res);
 out:
+	FTMN_CALLEE_DONE_CHECK(&ftmn, FTMN_INCR0, FTMN_STEP_COUNT(2), res);
 	crypto_acipher_free_rsa_public_key(&key);
-	if (res)
-		return TEE_ERROR_SECURITY;
-	return TEE_SUCCESS;
+	return res;
 }

--- a/core/drivers/crypto/crypto_api/acipher/rsa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsa.c
@@ -4,8 +4,9 @@
  *
  * Crypto RSA interface implementation to enable HW driver.
  */
-#include <drvcrypt.h>
 #include <crypto/crypto.h>
+#include <drvcrypt.h>
+#include <fault_mitigation.h>
 #include <tee_api_defines_extensions.h>
 #include <tee/tee_cryp_utl.h>
 #include <utee_defines.h>
@@ -433,7 +434,7 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 
 	if (!key || !msg || !sig) {
 		CRYPTO_TRACE("Input parameters reference error");
-		return ret;
+		goto out;
 	}
 
 	if (algo != TEE_ALG_RSASSA_PKCS1_V1_5) {
@@ -444,12 +445,13 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 		ret = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
 					      &rsa_ssa.digest_size);
 		if (ret != TEE_SUCCESS)
-			return ret;
+			goto out;
 
 		if (msg_len != rsa_ssa.digest_size) {
 			CRYPTO_TRACE("Input msg length (%zu expected %zu)",
 				     msg_len, rsa_ssa.digest_size);
-			return TEE_ERROR_BAD_PARAMETERS;
+			ret = TEE_ERROR_BAD_PARAMETERS;
+			goto out;
 		}
 	} else {
 		rsa_ssa.hash_algo = 0;
@@ -464,7 +466,8 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 	if (rsa_ssa.key.n_size > sig_len) {
 		CRYPTO_TRACE("Signature length expected %zu",
 			     rsa_ssa.key.n_size);
-		return TEE_ERROR_SIGNATURE_INVALID;
+		ret = TEE_ERROR_SIGNATURE_INVALID;
+		goto out;
 	}
 
 	rsa = drvcrypt_get_ops(CRYPTO_RSA);
@@ -492,5 +495,7 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 	CRYPTO_TRACE("Signature verif algo (0x%" PRIx32 ") returned 0x%" PRIx32,
 		     algo, ret);
 
+out:
+	FTMN_CALLEE_DONE(ret);
 	return ret;
 }

--- a/core/include/kernel/thread.h
+++ b/core/include/kernel/thread.h
@@ -43,6 +43,9 @@ struct thread_specific_data {
 	bool stackcheck_recursion;
 #endif
 	unsigned int syscall_recursion;
+#ifdef CFG_CORE_FAULT_MITIGATION
+	struct ftmn_func_arg *ftmn_arg;
+#endif
 };
 
 void thread_init_canaries(void);

--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -54,6 +54,7 @@
 #include <tee/tee_ta_enc_manager.h>
 #include <tee/uuid.h>
 #include <utee_defines.h>
+#include <fault_mitigation.h>
 
 struct ree_fs_ta_handle {
 	struct shdr *nw_ta; /* Non-secure (shared memory) */
@@ -331,7 +332,8 @@ static TEE_Result check_digest(struct ree_fs_ta_handle *h)
 		res = TEE_ERROR_SECURITY;
 		goto out;
 	}
-	if (memcmp(digest, SHDR_GET_HASH(h->shdr), h->shdr->hash_size))
+	if (FTMN_CALLEE_DONE_MEMCMP(memcmp, digest, SHDR_GET_HASH(h->shdr),
+				    h->shdr->hash_size))
 		res = TEE_ERROR_SECURITY;
 out:
 	free(digest);
@@ -565,14 +567,21 @@ static TEE_Result buf_ta_open(const TEE_UUID *uuid,
 			      struct ts_store_handle **h)
 {
 	struct buf_ree_fs_ta_handle *handle = NULL;
+	struct ftmn ftmn = { };
 	TEE_Result res = TEE_SUCCESS;
 
 	handle = calloc(1, sizeof(*handle));
 	if (!handle)
 		return TEE_ERROR_OUT_OF_MEMORY;
+	FTMN_PUSH_LINKED_CALL(&ftmn, FTMN_FUNC_HASH("shdr_verify_signature"));
 	res = ree_fs_ta_open(uuid, &handle->h);
+	if (!res)
+		FTMN_SET_CHECK_RES_FROM_CALL(&ftmn, FTMN_INCR0, res);
+	FTMN_POP_LINKED_CALL(&ftmn);
 	if (res)
-		goto err2;
+		goto err_free_handle;
+	ftmn_checkpoint(&ftmn, FTMN_INCR1);
+
 	res = ree_fs_ta_get_size(handle->h, &handle->ta_size);
 	if (res)
 		goto err;
@@ -602,18 +611,26 @@ static TEE_Result buf_ta_open(const TEE_UUID *uuid,
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto err;
 	}
+
+	FTMN_PUSH_LINKED_CALL(&ftmn, FTMN_FUNC_HASH("check_digest"));
 	res = ree_fs_ta_read(handle->h, handle->buf, handle->ta_size);
+	if (!res)
+		FTMN_SET_CHECK_RES_FROM_CALL(&ftmn, FTMN_INCR0, res);
+	FTMN_POP_LINKED_CALL(&ftmn);
 	if (res)
 		goto err;
+	ftmn_checkpoint(&ftmn, FTMN_INCR1);
+
 	*h = (struct ts_store_handle *)handle;
+	ree_fs_ta_close(handle->h);
+	return ftmn_return_res(&ftmn, FTMN_STEP_COUNT(2, 2), TEE_SUCCESS);
+
 err:
 	ree_fs_ta_close(handle->h);
-err2:
-	if (res) {
-		tee_mm_free(handle->mm);
-		free(handle->tag);
-		free(handle);
-	}
+	tee_mm_free(handle->mm);
+	free(handle->tag);
+err_free_handle:
+	free(handle);
 	return res;
 }
 

--- a/core/lib/libtomcrypt/rsa.c
+++ b/core/lib/libtomcrypt/rsa.c
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2014-2019, Linaro Limited
+ * Copyright (c) 2014-2019, 2022 Linaro Limited
  */
 
 #include <crypto/crypto.h>
+#include <fault_mitigation.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tee_api_types.h>
 #include <tee_api_defines_extensions.h>
+#include <tee_api_types.h>
 #include <tee/tee_cryp_utl.h>
 #include <trace.h>
 #include <utee_defines.h>
@@ -535,6 +536,7 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 		.e = key->e,
 		.N = key->n
 	};
+	struct ftmn   ftmn = { };
 
 	if (algo != TEE_ALG_RSASSA_PKCS1_V1_5) {
 		res = tee_alg_get_digest_size(TEE_DIGEST_HASH_TO_ALGO(algo),
@@ -585,9 +587,18 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 		goto err;
 	}
 
+	FTMN_PUSH_LINKED_CALL(&ftmn, FTMN_FUNC_HASH("rsa_verify_hash_ex"));
 	ltc_res = rsa_verify_hash_ex(sig, sig_len, msg, msg_len, ltc_rsa_algo,
 				     ltc_hashindex, salt_len, &stat, &ltc_key);
 	res = convert_ltc_verify_status(ltc_res, stat);
+	if (res)
+		FTMN_SET_CHECK_RES_NOT_ZERO(&ftmn, FTMN_INCR0, res);
+	else
+		FTMN_SET_CHECK_RES_FROM_CALL(&ftmn, FTMN_INCR0, 0);
+	FTMN_POP_LINKED_CALL(&ftmn);
+	FTMN_CALLEE_DONE_CHECK(&ftmn, FTMN_INCR0, FTMN_STEP_COUNT(1), res);
+	return res;
 err:
+	FTMN_CALLEE_DONE_NOT_ZERO(res);
 	return res;
 }

--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_pss_decode.c
@@ -7,6 +7,7 @@
  * The library is free for all purposes without any express
  * guarantee it works.
  */
+#include <fault_mitigation.h>
 #include "tomcrypt_private.h"
 
 /**
@@ -149,7 +150,7 @@ int pkcs_1_pss_decode(const unsigned char *msghash, unsigned long msghashlen,
    }
 
    /* mask == hash means valid signature */
-   if (XMEM_NEQ(mask, hash, hLen) == 0) {
+   if (FTMN_CALLEE_DONE_MEMCMP(XMEM_NEQ, mask, hash, hLen) == 0) {
       *res = 1;
    }
 

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -4,6 +4,7 @@ subdirs-y += kernel
 subdirs-y += mm
 subdirs-y += pta
 subdirs-y += tee
+subdirs-$(CFG_TEE_CORE_EMBED_INTERNAL_TESTS) += tests
 
 ifeq ($(CFG_WITH_USER_TA),y)
 gensrcs-y += ta_pub_key

--- a/core/tests/ftmn_boot_tests.c
+++ b/core/tests/ftmn_boot_tests.c
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <assert.h>
+#include <fault_mitigation.h>
+#include <initcall.h>
+#include <kernel/thread.h>
+#include <types_ext.h>
+#include <trace.h>
+
+/*
+ * Simple straightforward tests.
+ */
+static TEE_Result simple_call_func_res;
+
+static TEE_Result __noinline simple_call_func1(void)
+{
+	TEE_Result res = simple_call_func_res;
+
+	FTMN_CALLEE_DONE(res);
+	return res;
+}
+
+static TEE_Result __noinline simple_call_memcmp(const void *s1, const void *s2,
+						size_t n)
+{
+	if (!FTMN_CALLEE_DONE_MEMCMP(memcmp, s1, s2, n))
+		return TEE_SUCCESS;
+	return TEE_ERROR_GENERIC;
+}
+
+static void __noinline simple_call(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct ftmn ftmn = { };
+	static const char s1[] = "s1";
+
+	simple_call_func_res = TEE_SUCCESS;
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0, simple_call_func1);
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(1), res);
+
+	simple_call_func_res = TEE_ERROR_GENERIC;
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0, simple_call_func1);
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(2, 1), res);
+
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0,
+		       simple_call_memcmp, s1, s1, sizeof(s1));
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(3, 2), res);
+}
+
+/*
+ * Simulate calling with multiple unmitigated functions in the chain
+ * between checked callee and the caller. The result has always been set
+ * regardless of return value.
+ */
+
+static TEE_Result __noinline two_level_call_memcmp2(const void *s1,
+						    const void *s2, size_t n)
+{
+	if (!FTMN_CALLEE_DONE_MEMCMP(memcmp, s1, s2, n))
+		return TEE_SUCCESS;
+	/*
+	 * If FTMN_CALLEE_DONE_MEMCMP() returned non-zero the strings are
+	 * different. Update with an error code we can understand.
+	 */
+	FTMN_CALLEE_UPDATE_NOT_ZERO(TEE_ERROR_GENERIC);
+	return TEE_ERROR_GENERIC;
+}
+
+static TEE_Result __noinline two_level_call_memcmp1(const void *s1,
+						    const void *s2, size_t n)
+{
+	return two_level_call_memcmp2(s1, s2, n);
+}
+
+static TEE_Result __noinline two_level_call_memcmp(const void *s1,
+						   const void *s2, size_t n)
+{
+	unsigned long func_hash = FTMN_FUNC_HASH("two_level_call_memcmp2");
+	struct ftmn ftmn = { };
+	TEE_Result res = TEE_SUCCESS;
+
+	FTMN_PUSH_LINKED_CALL(&ftmn, func_hash);
+	res = two_level_call_memcmp1(s1, s2, n);
+	FTMN_SET_CHECK_RES_FROM_CALL(&ftmn, 0, res);
+	FTMN_POP_LINKED_CALL(&ftmn);
+	FTMN_CALLEE_DONE_CHECK(&ftmn, FTMN_INCR1, 0, res);
+
+	return res;
+}
+
+static void __noinline two_level_call(void)
+{
+	struct ftmn ftmn = { };
+	TEE_Result res = TEE_SUCCESS;
+	static const char s1[] = "s1";
+	static const char s2[] = "s2";
+
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0,
+		       two_level_call_memcmp, s1, s1, sizeof(s1));
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(1), res);
+
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0,
+		       two_level_call_memcmp, s1, s2, sizeof(s1));
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(2, 1), res);
+}
+
+/*
+ * Simulate chained calls in several levels.
+ *
+ * For instance ree_fs_ta_open() -> shdr_verify_signature() ->
+ * crypto_acipher_rsassa_verify() -> ... ->
+ * mbedtls_rsa_rsassa_pss_verify_ext()
+ */
+
+static TEE_Result __noinline chained_call_memcmp2(const void *s1,
+						  const void *s2, size_t n)
+{
+	if (!FTMN_CALLEE_DONE_MEMCMP(memcmp, s1, s2, n))
+		return TEE_SUCCESS;
+	return TEE_ERROR_GENERIC;
+}
+
+static TEE_Result __noinline chained_call_memcmp1(const void *s1,
+						  const void *s2, size_t n)
+{
+	TEE_Result res = chained_call_memcmp2(s1, s2, n);
+
+	/*
+	 * If s1 and s2 has the same content but different pointers we're
+	 * testing the case with an error detected after the linked leaf
+	 * function has been called.
+	 */
+	if (!res && s1 != s2)
+		res = TEE_ERROR_BAD_STATE;
+
+	return res;
+}
+
+static TEE_Result __noinline chained_call_memcmp(const void *s1,
+						 const void *s2, size_t n)
+{
+	struct ftmn ftmn = { };
+	TEE_Result res = TEE_SUCCESS;
+
+	FTMN_PUSH_LINKED_CALL(&ftmn, FTMN_FUNC_HASH("chained_call_memcmp2"));
+
+	res = chained_call_memcmp1(s1, s2, n);
+
+	if (!res)
+		FTMN_SET_CHECK_RES_FROM_CALL(&ftmn, FTMN_INCR0, res);
+	else
+		FTMN_SET_CHECK_RES(&ftmn, FTMN_INCR0, res);
+	FTMN_POP_LINKED_CALL(&ftmn);
+	FTMN_CALLEE_DONE_CHECK(&ftmn, FTMN_INCR0, FTMN_STEP_COUNT(1), res);
+
+	return res;
+}
+
+static void __noinline chained_calls(void)
+{
+	struct ftmn ftmn = { };
+	static const char s[] = "s1s2s1";
+	TEE_Result res = TEE_SUCCESS;
+
+	/* Test a normal success case. */
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0, chained_call_memcmp, s, s, 2);
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(1), res);
+
+	/* Test the case where the leaf function detects an error. */
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0,
+		       chained_call_memcmp, s, s + 2, 2);
+	assert(res == TEE_ERROR_GENERIC);
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(2, 1),
+			  TEE_ERROR_GENERIC);
+
+	/*
+	 * Test the case where a function in the call chain detects an error
+	 * after a the leaf function has returned success.
+	 */
+	FTMN_CALL_FUNC(res, &ftmn, FTMN_INCR0,
+		       chained_call_memcmp, s, s + 4, 2);
+	assert(res == TEE_ERROR_BAD_STATE);
+	ftmn_expect_state(&ftmn, FTMN_INCR1, FTMN_STEP_COUNT(3, 2),
+			  TEE_ERROR_BAD_STATE);
+}
+
+#define CALL_TEST_FUNC(x) do { \
+		DMSG("Calling " #x "()"); \
+		x(); \
+		DMSG("Return from " #x "()"); \
+	} while (0)
+
+static TEE_Result ftmn_boot_tests(void)
+{
+	CALL_TEST_FUNC(simple_call);
+	CALL_TEST_FUNC(two_level_call);
+	CALL_TEST_FUNC(chained_calls);
+
+	DMSG("*************************************************");
+	DMSG("**************  Tests complete  *****************");
+	DMSG("*************************************************");
+	return TEE_SUCCESS;
+}
+
+driver_init_late(ftmn_boot_tests);

--- a/core/tests/sub.mk
+++ b/core/tests/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += ftmn_boot_tests.c

--- a/lib/libmbedtls/mbedtls/library/rsa.c
+++ b/lib/libmbedtls/mbedtls/library/rsa.c
@@ -2472,8 +2472,8 @@ int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
      * Compare
      */
 
-    if( ( ret = mbedtls_safer_memcmp( encoded, encoded_expected,
-                                      sig_len ) ) != 0 )
+    if( ( ret = FTMN_CALLEE_DONE_MEMCMP(mbedtls_safer_memcmp, encoded,
+                                        encoded_expected, sig_len ) ) != 0 )
     {
         ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
         goto cleanup;

--- a/lib/libmbedtls/mbedtls/library/rsa.c
+++ b/lib/libmbedtls/mbedtls/library/rsa.c
@@ -64,6 +64,8 @@
 #define mbedtls_free   free
 #endif
 
+#include <fault_mitigation.h>
+
 #if !defined(MBEDTLS_RSA_ALT)
 
 /* Parameter validation macros */
@@ -2366,7 +2368,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
     if ( ret != 0 )
         goto exit;
 
-    if( memcmp( hash_start, result, hlen ) != 0 )
+    if( FTMN_CALLEE_DONE_MEMCMP( memcmp, hash_start, result, hlen ) != 0 )
     {
         ret = MBEDTLS_ERR_RSA_VERIFY_FAILED;
         goto exit;

--- a/lib/libutils/ext/fault_mitigation.c
+++ b/lib/libutils/ext/fault_mitigation.c
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <compiler.h>
+#include <fault_mitigation.h>
+
+#ifndef __KERNEL__
+struct ftmn_func_arg *__ftmn_global_func_arg;
+#endif
+
+/*
+ * These functions can be implemented in assembly if needed. They would
+ * provide the same API but an implementation more resilient to fault
+ * injections.
+ *
+ * For now there is no need since it's enough with the single redundancy
+ * provided just by having these function implemented separately from where
+ * they are used.
+ */
+
+unsigned long __weak ___ftmn_return_res(struct ftmn_check *check,
+					unsigned long steps, unsigned long res)
+{
+	if (check->steps != steps)
+		FTMN_PANIC();
+	if ((check->res ^ FTMN_DEFAULT_HASH) != res)
+		FTMN_PANIC();
+	return res;
+}
+
+void __weak ___ftmn_expect_state(struct ftmn_check *check, enum ftmn_incr incr,
+				 unsigned long steps, unsigned long res)
+{
+	if ((check->res ^ FTMN_DEFAULT_HASH) != res)
+		FTMN_PANIC();
+	if (check->steps != steps)
+		FTMN_PANIC();
+	check->steps += incr;
+}
+
+void __weak ___ftmn_callee_done(struct ftmn_func_arg *arg,
+				unsigned long my_hash,
+				unsigned long res)
+{
+	arg->hash ^= my_hash;
+	arg->res = arg->hash ^ res;
+}
+
+void __weak ___ftmn_callee_done_not_zero(struct ftmn_func_arg *arg,
+					 unsigned long my_hash,
+					 unsigned long res)
+{
+	if (res == 0)
+		FTMN_PANIC();
+	arg->hash ^= my_hash;
+	arg->res = arg->hash ^ res;
+}
+
+void __weak ___ftmn_callee_done_memcmp(struct ftmn_func_arg *arg,
+				       unsigned long my_hash, int res,
+				       ftmn_memcmp_t my_memcmp,
+					const void *p1, const void *p2,
+					size_t nb)
+{
+	int res2 = 0;
+
+	if (!nb)
+		FTMN_PANIC();
+
+	res2 = my_memcmp(p1, p2, nb);
+	if (res2 != res)
+		FTMN_PANIC();
+
+	arg->hash ^= my_hash;
+	arg->res = arg->hash ^ res;
+}
+
+void __weak ___ftmn_callee_done_check(struct ftmn_func_arg *arg,
+				      unsigned long my_hash,
+				      struct ftmn_check *check,
+				      enum ftmn_incr incr, unsigned long steps,
+				      unsigned long res)
+{
+	if ((check->res ^ FTMN_DEFAULT_HASH) != res)
+		FTMN_PANIC();
+	if (check->steps != steps)
+		FTMN_PANIC();
+
+	check->steps += incr;
+	if (arg) {
+		arg->hash ^= my_hash;
+		arg->res = check->res ^ FTMN_DEFAULT_HASH ^ arg->hash;
+	}
+
+}
+
+void ___ftmn_callee_update_not_zero(struct ftmn_func_arg *arg,
+				    unsigned long res)
+{
+	if (!res)
+		FTMN_PANIC();
+	arg->res = arg->hash ^ res;
+}
+
+
+void __weak ___ftmn_copy_linked_call_res(struct ftmn_check *check,
+					 enum ftmn_incr incr,
+					 struct ftmn_func_arg *arg,
+					 unsigned long res)
+{
+	if ((arg->res ^ arg->hash) != res)
+		FTMN_PANIC();
+	check->res = res ^ FTMN_DEFAULT_HASH;
+	check->steps += incr;
+}
+
+void __weak ___ftmn_set_check_res(struct ftmn_check *check, enum ftmn_incr incr,
+				  unsigned long res)
+{
+	check->steps += incr;
+	check->res = res ^ FTMN_DEFAULT_HASH;
+}
+
+void __weak ___ftmn_set_check_res_not_zero(struct ftmn_check *check,
+					   enum ftmn_incr incr,
+					   unsigned long res)
+{
+	if (!res)
+		FTMN_PANIC();
+	check->steps += incr;
+	check->res = res ^ FTMN_DEFAULT_HASH;
+}
+
+void __weak ___ftmn_set_check_res_memcmp(struct ftmn_check *check,
+					 enum ftmn_incr incr, int res,
+					 ftmn_memcmp_t my_memcmp,
+					 const void *p1, const void *p2,
+					 size_t nb)
+{
+	int res2 = 0;
+
+	if (!nb)
+		FTMN_PANIC();
+
+	res2 = my_memcmp(p1, p2, nb);
+	if (res2 != res)
+		FTMN_PANIC();
+
+	check->steps += incr;
+	check->res = FTMN_DEFAULT_HASH ^ res;
+}

--- a/lib/libutils/ext/include/fault_mitigation.h
+++ b/lib/libutils/ext/include/fault_mitigation.h
@@ -1,0 +1,659 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+#ifndef __FAULT_MITIGATION_H
+#define __FAULT_MITIGATION_H
+
+#include <assert.h>
+#include <config.h>
+#include <string.h>
+#include <util.h>
+
+#ifdef __KERNEL__
+#include <kernel/panic.h>
+#include <kernel/thread.h>
+#else
+#include <tee_api.h>
+#endif
+
+/*
+ * Fault migitigation helpers to make successful Hardware Fault Attacks
+ * harder to achieve. The paper [1] by Riscure gives background to the
+ * problem.
+ *
+ * These helpers aim to make it hard for a single glitch attack to succeed
+ * while the protected function or one of the ftmn_*() functions are
+ * executed.
+ *
+ * To have something to work with we assume that a single glitch may affect
+ * a few instructions in sequence to do nothing or to corrupt the content
+ * of a few registers.
+ *
+ * Using the terminology from [1] we are implementing the following patterns:
+ * 3 FAULT.VALUE.CHECK
+ * 5 FAULT.DECISION.CHECK
+ * 9 FAULT.FLOW.CONTROL
+ *
+ * Additionally are the following patterns also racknowledged with a few
+ * comments:
+ * 1. FAULT.CONSTANT.CODING
+ *	Zero is normally a success code in OP-TEE so special functions are
+ *	added to record anything but a zero result.
+ * 8. FAULT.NESTED.CHECK
+ *	The linked calls performed by for instance FTMN_CALL_FUNC() addresses
+ *	this by relying on the called function to update a state in
+ *	struct ftmn_func_arg which is checked when the function has returned.
+ * 11. FAULT.PENALTY
+ *	This is implicit since we're normally trying to protect things post
+ *	boot and booting takes quite some time.
+ *
+ * [1] https://www.riscure.com/uploads/2020/05/Riscure_Whitepaper_Fault_Mitigation_Patterns_final.pdf
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * struct ftmn_check - track current checked state
+ * @steps:	accumulated checkpoints
+ * @res:	last stored result or return value
+ *
+ * While a function is executed it can update its state as a way of keeping
+ * track of important passages inside the function. Before the function
+ * returns with for instance ftmn_return_res() to check that the
+ * accumulated state matches the expected state.
+ *
+ * @res is xored with FTMN_DEFAULT_HASH in order to retrieve the saved
+ * result or return value.
+ */
+struct ftmn_check {
+	unsigned long steps;
+	unsigned long res;
+};
+
+/*
+ * struct ftmn_func_arg - track a called function
+ * @hash:	xor bitmask
+ * @res:	stored result xored with @hash
+ *
+ * When the call of a function is tracked @hash is initialized to hash of
+ * caller xored with hash of called function. Before the called function
+ * updates @res it first xors @hash with its own hash, which is supposed to
+ * restore @hash to the hash of the calling function. This allows the
+ * calling function to confirm that the correct function has been called.
+ */
+struct ftmn_func_arg {
+	unsigned long hash;
+	unsigned long res;
+};
+
+/*
+ * struct ftmn - link a tracked call chain
+ * @check:	local checked state
+ * @arg:	argument for the next called tracked function
+ * @saved_arg:	pointer to an optional argument passed to this function
+ * @arg_pp:	cached return value from __ftmn_get_tsd_func_arg_pp()
+ * @my_hash:	the hash of the calling function
+ * @called_hash:the hash of the called function
+ *
+ * In order to maintain the linked call chain of tracked functions the
+ * struct ftmn_func_arg passed to this function is saved in @saved_arg
+ * before updating the argument pointer with @arg.
+ */
+struct ftmn {
+	struct ftmn_check check;
+	struct ftmn_func_arg arg;
+	struct ftmn_func_arg *saved_arg;
+	struct ftmn_func_arg **arg_pp;
+	unsigned long my_hash;
+	unsigned long called_hash;
+};
+
+/*
+ * enum ftmn_incr - increase counter values
+ *
+ * Prime numbers to be used when increasing the accumulated state.
+ * Different increase counters can be used to keep apart different
+ * checkpoints.
+ */
+enum ftmn_incr {
+	FTMN_INCR0 = 7873,
+	FTMN_INCR1 = 7877,
+	FTMN_INCR2 = 7879,
+	FTMN_INCR3 = 7883,
+	FTMN_INCR4 = 7901,
+	FTMN_INCR5 = 7907,
+	FTMN_INCR_RESERVED = 7919,
+};
+
+typedef int (*ftmn_memcmp_t)(const void *p1, const void *p2, size_t nb);
+
+/* The default hash used when xoring the result in struct ftmn_check */
+#ifdef __ILP32__
+#define FTMN_DEFAULT_HASH	0x9c478bf6UL
+#else
+#define FTMN_DEFAULT_HASH	0xc478bf63e9500cb5UL
+#endif
+
+/*
+ * FTMN_PANIC() - FTMN specific panic function
+ *
+ * This function is called whenever the FTMN function detects an
+ * inconsistency.  An inconsistency is able to occur if the system is
+ * subject to an fault injection attack, in this case doing a panic() isn't
+ * an extreme measure.
+ */
+#ifdef __KERNEL__
+#define FTMN_PANIC()	panic();
+#else
+#define FTMN_PANIC()	TEE_Panic(0);
+#endif
+
+#define __FTMN_MAX_FUNC_NAME_LEN	256
+
+#define __FTMN_FUNC_BYTE(f, o, l)	((o) < (l) ? (uint8_t)(f)[(o)] : 0)
+
+#define __FTMN_GET_FUNC_U64(f, o, l) \
+	(SHIFT_U64(__FTMN_FUNC_BYTE((f), (o), (l)), 0) | \
+	 SHIFT_U64(__FTMN_FUNC_BYTE((f), (o) + 1, (l)), 8) | \
+	 SHIFT_U64(__FTMN_FUNC_BYTE((f), (o) + 2, (l)), 16) | \
+	 SHIFT_U64(__FTMN_FUNC_BYTE((f), (o) + 3, (l)), 24) | \
+	 SHIFT_U64(__FTMN_FUNC_BYTE((f), (o) + 4, (l)), 32) | \
+	 SHIFT_U64(__FTMN_FUNC_BYTE((f), (o) + 5, (l)), 40) | \
+	 SHIFT_U64(__FTMN_FUNC_BYTE((f), (o) + 6, (l)), 48) | \
+	 SHIFT_U64(__FTMN_FUNC_BYTE((f), (o) + 7, (l)), 56))
+
+#define __FTMN_FUNC_HASH32(f, o, l) \
+	(__FTMN_GET_FUNC_U64((f), (o), (l)) ^ \
+	 __FTMN_GET_FUNC_U64((f), (o) + 8, (l)))
+
+#define __FTMN_FUNC_HASH16(f, o, l) \
+	(__FTMN_FUNC_HASH32((f), (o), (l)) ^ \
+	 __FTMN_FUNC_HASH32((f), (o) + __FTMN_MAX_FUNC_NAME_LEN / 16, (l)))
+
+#define __FTMN_FUNC_HASH8(f, o, l) \
+	(__FTMN_FUNC_HASH16((f), (o), (l)) ^ \
+	 __FTMN_FUNC_HASH16((f), (o) + __FTMN_MAX_FUNC_NAME_LEN / 8, (l)))
+
+#define __FTMN_FUNC_HASH4(f, o, l) \
+	(__FTMN_FUNC_HASH8((f), (o), (l)) ^ \
+	 __FTMN_FUNC_HASH8((f), (o) + __FTMN_MAX_FUNC_NAME_LEN / 4, (l)))
+
+#define __FTMN_FUNC_HASH2(f, l) \
+	(__FTMN_FUNC_HASH4(f, 0, l) ^ \
+	 __FTMN_FUNC_HASH4(f, __FTMN_MAX_FUNC_NAME_LEN / 2, l))
+
+#ifdef __ILP32__
+#define __FTMN_FUNC_HASH(f, l) \
+	(unsigned long)(__FTMN_FUNC_HASH2((f), (l)) ^ \
+		        (__FTMN_FUNC_HASH2((f), (l)) >> 32))
+#else
+#define __FTMN_FUNC_HASH(f, l)	(unsigned long)__FTMN_FUNC_HASH2((f), (l))
+#endif
+
+#define __ftmn_step_count_1(c0) ((c0) * FTMN_INCR0)
+#define __ftmn_step_count_2(c0, c1) \
+	(__ftmn_step_count_1(c0) + (c1) * FTMN_INCR1)
+#define __ftmn_step_count_3(c0, c1, c2) \
+	(__ftmn_step_count_2(c0, c1) + (c2) * FTMN_INCR2)
+#define __ftmn_step_count_4(c0, c1, c2, c3)	\
+	(__ftmn_step_count_3(c0, c1, c2) + (c3) * FTMN_INCR3)
+#define __ftmn_step_count_5(c0, c1, c2, c3, c4)	\
+	(__ftmn_step_count_4(c0, c1, c2, c3) + (c4) * FTMN_INCR4)
+#define __ftmn_step_count_6(c0, c1, c2, c3, c4, c5)	\
+	(__ftmn_step_count_5(c0, c1, c2, c3, c4) + (c5) * FTMN_INCR5)
+#define ___ftmn_args_count(_0, _1, _2, _3, _4, _5, x, ...) x
+#define __ftmn_args_count(...) \
+	___ftmn_args_count(__VA_ARGS__, 6, 5, 4, 3, 2, 1, 0)
+#define ___ftmn_step_count(count, ...)	__ftmn_step_count_ ## count(__VA_ARGS__)
+#define __ftmn_step_count(count, ...)	___ftmn_step_count(count, __VA_ARGS__)
+
+unsigned long ___ftmn_return_res(struct ftmn_check *check, unsigned long steps,
+				 unsigned long res);
+void ___ftmn_expect_state(struct ftmn_check *check, enum ftmn_incr incr,
+			  unsigned long steps, unsigned long res);
+
+void ___ftmn_callee_done(struct ftmn_func_arg *arg, unsigned long my_hash,
+			 unsigned long res);
+void ___ftmn_callee_done_not_zero(struct ftmn_func_arg *arg,
+				  unsigned long my_hash,
+				  unsigned long res);
+void ___ftmn_callee_done_memcmp(struct ftmn_func_arg *arg,
+				unsigned long my_hash, int res,
+				ftmn_memcmp_t my_memcmp,
+				const void *p1, const void *p2, size_t nb);
+void ___ftmn_callee_done_check(struct ftmn_func_arg *arg, unsigned long my_hash,
+			       struct ftmn_check *check, enum ftmn_incr incr,
+			       unsigned long steps, unsigned long res);
+
+void ___ftmn_callee_update_not_zero(struct ftmn_func_arg *arg,
+				    unsigned long res);
+
+void ___ftmn_set_check_res(struct ftmn_check *check, enum ftmn_incr incr,
+			   unsigned long res);
+void ___ftmn_set_check_res_not_zero(struct ftmn_check *check,
+				    enum ftmn_incr incr,
+				    unsigned long res);
+void ___ftmn_set_check_res_memcmp(struct ftmn_check *check, enum ftmn_incr incr,
+				  int res, ftmn_memcmp_t my_memcmp,
+				  const void *p1, const void *p2, size_t nb);
+
+void ___ftmn_copy_linked_call_res(struct ftmn_check *check, enum ftmn_incr incr,
+				  struct ftmn_func_arg *arg, unsigned long res);
+
+
+#ifndef __KERNEL__
+extern struct ftmn_func_arg *__ftmn_global_func_arg;
+#endif
+
+static inline struct ftmn_func_arg **__ftmn_get_tsd_func_arg_pp(void)
+{
+#if defined(CFG_CORE_FAULT_MITIGATION) && defined(__KERNEL__)
+	return &thread_get_tsd()->ftmn_arg;
+#elif defined(CFG_CORE_FAULT_MITIGATION)
+	return &__ftmn_global_func_arg;
+#else
+	return NULL;
+#endif
+}
+
+static inline struct ftmn_func_arg *__ftmn_get_tsd_func_arg(void)
+{
+	struct ftmn_func_arg **pp = __ftmn_get_tsd_func_arg_pp();
+
+	if (!pp)
+		return NULL;
+
+	return *pp;
+}
+
+static inline void __ftmn_push_linked_call(struct ftmn *ftmn,
+					 unsigned long my_hash,
+					 unsigned long called_hash)
+{
+	struct ftmn_func_arg **arg_pp = __ftmn_get_tsd_func_arg_pp();
+
+	if (arg_pp) {
+		ftmn->arg_pp = arg_pp;
+		ftmn->my_hash = my_hash;
+		ftmn->called_hash = called_hash;
+		ftmn->saved_arg = *ftmn->arg_pp;
+		*ftmn->arg_pp = &ftmn->arg;
+		ftmn->arg.hash = my_hash;
+	}
+}
+
+static inline void __ftmn_pop_linked_call(struct ftmn *ftmn)
+{
+	if (ftmn->arg_pp)
+		*ftmn->arg_pp = ftmn->saved_arg;
+}
+
+static inline void __ftmn_copy_linked_call_res(struct ftmn *f,
+					       enum ftmn_incr incr,
+					       unsigned long res)
+{
+	if (f->arg_pp) {
+		assert(f->arg.hash == (f->my_hash ^ f->called_hash));
+		assert(&f->arg == *f->arg_pp);
+		assert((f->arg.hash ^ f->arg.res) == res);
+		___ftmn_copy_linked_call_res(&f->check, incr, &f->arg, res);
+	}
+}
+
+static inline void __ftmn_callee_done(struct ftmn_func_arg *arg,
+				      unsigned long my_hash, unsigned long res)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		___ftmn_callee_done(arg, my_hash, res);
+}
+
+static inline void __ftmn_callee_done_not_zero(struct ftmn_func_arg *arg,
+					       unsigned long hash,
+					       unsigned long res)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION) && arg)
+		___ftmn_callee_done_not_zero(arg, hash, res);
+}
+
+static inline int
+__ftmn_callee_done_memcmp(struct ftmn_func_arg *arg, unsigned long hash,
+			  ftmn_memcmp_t my_memcmp,
+			  const void *p1, const void *p2, size_t nb)
+{
+	int res = my_memcmp(p1, p2, nb);
+
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION) && arg)
+		___ftmn_callee_done_memcmp(arg, hash, res, my_memcmp,
+					   p1, p2, nb);
+
+	return res;
+}
+
+static inline void __ftmn_callee_done_check(struct ftmn *ftmn,
+					    unsigned long my_hash,
+					    enum ftmn_incr incr,
+					    unsigned long steps,
+					    unsigned long res)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		___ftmn_callee_done_check(__ftmn_get_tsd_func_arg(), my_hash,
+					  &ftmn->check, incr, steps, res);
+}
+
+static inline void __ftmn_callee_update_not_zero(struct ftmn_func_arg *arg,
+						 unsigned long res)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION) && arg)
+		___ftmn_callee_update_not_zero(arg, res);
+}
+
+static inline void __ftmn_set_check_res(struct ftmn *ftmn, enum ftmn_incr incr,
+				      unsigned long res)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		___ftmn_set_check_res(&ftmn->check, incr, res);
+}
+
+static inline void __ftmn_set_check_res_not_zero(struct ftmn *ftmn,
+					       enum ftmn_incr incr,
+					       unsigned long res)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		___ftmn_set_check_res_not_zero(&ftmn->check, incr, res);
+}
+
+
+
+/*
+ * FTMN_FUNC_HASH() - "hash" a function name
+ *
+ * Function names are "hashed" into an unsigned long. The "hashing" is done
+ * by xoring each 32/64 bit word of the function name producing a bit
+ * pattern that should be mostly unique for each function. Only the first
+ * 256 characters of the name are used when xoring as this is expected to
+ * be optimized to be calculated when compiling the source code in order to
+ * minimize the overhead.
+ */
+#define FTMN_FUNC_HASH(name)	__FTMN_FUNC_HASH(name, sizeof(name))
+
+/*
+ * FTMN_PUSH_LINKED_CALL() - push call into a linked call chain
+ * @ftmn:		The local struct ftmn
+ * @called_func_hash:	The hash of the called function
+ *
+ * Inserts a call into a linked call chain or starts a new call chain if
+ * the passed struct ftmn_func_arg pointer was NULL.
+ *
+ * Each FTMN_PUSH_LINKED_CALL() is supposed to be match by a
+ * FTMN_POP_LINKED_CALL().
+ */
+#define FTMN_PUSH_LINKED_CALL(ftmn, called_func_hash) \
+	__ftmn_push_linked_call((ftmn), FTMN_FUNC_HASH(__func__), \
+				(called_func_hash))
+
+/*
+ * FTMN_SET_CHECK_RES_FROM_CALL() - copy the result from a linked call
+ * @ftmn:	The struct ftmn used during the linked call
+ * @incr:	Value to increase the checked state with
+ * @res:	Returned result to be match against the saved/copied result
+ *
+ * This macro is called just after a checked linked function has returned.
+ * The return value from the function is copied from the struct ftmn_func_arg
+ * passed to the called fuction into the local checked state. The checked
+ * state is increased with @incr. @res is checked against the saved result
+ * of the called function.
+ */
+#define FTMN_SET_CHECK_RES_FROM_CALL(ftmn, incr, res) \
+	__ftmn_copy_linked_call_res((ftmn), (incr), (res))
+
+/*
+ * FTMN_POP_LINKED_CALL() - remove a call from a linked call chain
+ * @ftmn:	The local struct ftmn
+ *
+ * Supposed to match a call to FTMN_PUSH_LINKED_CALL()
+ */
+#define FTMN_POP_LINKED_CALL(ftmn) __ftmn_pop_linked_call((ftmn))
+
+/*
+ * FTMN_CALL_FUNC() - Do a linked call to a function
+ * @res:	Variable to be assigned the result of the called function
+ * @ftmn:	The local struct ftmn
+ * @incr:	Value to increase the checked state with
+ * @func:	Function to be called
+ * @...:	Arguments to pass to @func
+ *
+ * This macro can be used to make a linked call to another function, the
+ * callee. This macro depends on the callee to always update the struct
+ * ftmn_func_arg (part of struct ftmn) even when returning an error.
+ *
+ * Note that in the cases where the callee may skip updating the struct
+ * ftmn_func_arg this macro cannot be used as
+ * FTMN_SET_CHECK_RES_FROM_CALL() would cause a panic due to mismatching
+ * return value and saved result.
+ */
+#define FTMN_CALL_FUNC(res, ftmn, incr, func, ...) \
+	do { \
+		FTMN_PUSH_LINKED_CALL((ftmn), FTMN_FUNC_HASH(#func)); \
+		(res) = func(__VA_ARGS__); \
+		FTMN_SET_CHECK_RES_FROM_CALL((ftmn), (incr), (res)); \
+		FTMN_POP_LINKED_CALL((ftmn)); \
+	} while (0)
+
+/*
+ * FTMN_CALLEE_DONE() - Record result of callee
+ * @res:	Result or return value
+ *
+ * The passed result will be stored in the struct ftmn_func_arg struct
+ * supplied by the caller. This function must only be called once by the
+ * callee.
+ *
+ * Note that this function is somewhat dangerous as any passed value will
+ * be stored so if the value has been tampered with there is no additional
+ * redundant checks to rely on.
+ */
+#define FTMN_CALLEE_DONE(res) \
+	__ftmn_callee_done(__ftmn_get_tsd_func_arg(), \
+			   FTMN_FUNC_HASH(__func__), (res))
+/*
+ * FTMN_CALLEE_DONE_NOT_ZERO() - Record non-zero result of callee
+ * @res:	Result or return value
+ *
+ * The passed result will be stored in the struct ftmn_func_arg struct
+ * supplied by the caller. This function must only be called once by the
+ * callee.
+ *
+ * Note that this function is somewhat dangerous as any passed value will
+ * be stored so if the value has been tampered with there is no additional
+ * redundant checks to rely on. However, there are extra checks against
+ * unintentionally storing a zero which often is interpreted as a
+ * successful return value.
+ */
+#define FTMN_CALLEE_DONE_NOT_ZERO(res) \
+	__ftmn_callee_done_not_zero(__ftmn_get_tsd_func_arg(), \
+				    FTMN_FUNC_HASH(__func__), (res))
+
+/*
+ * FTMN_CALLEE_DONE_CHECK() - Record result of callee with checked state
+ * @ftmn:	The local struct ftmn
+ * @incr:	Value to increase the checked state with
+ * @exp_steps:	Expected recorded checkpoints
+ * @res:	Result or return value
+ *
+ * The passed result will be stored in the struct ftmn_func_arg struct
+ * supplied by the caller. This function must only be called once by the
+ * callee.
+ *
+ * @res is double checked against the value stored in local checked state.
+ * @exp_steps is checked against the locate checked state. The local
+ * checked state is increased by @incr.
+ */
+#define FTMN_CALLEE_DONE_CHECK(ftmn, incr, exp_steps, res) \
+	__ftmn_callee_done_check((ftmn), FTMN_FUNC_HASH(__func__), \
+				 (incr), (exp_steps), (res))
+
+/*
+ * FTMN_CALLEE_DONE_MEMCMP() - Record result of memcmp() in a callee
+ * @my_memcmp:		Function pointer of custom memcmp()
+ * @p1:			Pointer to first buffer
+ * @p2:			Pointer to second buffer
+ * @nb:			Number of bytes
+ *
+ * The result from the mem compare is saved in the local checked state.
+ * This function must only be called once by the callee.
+ */
+#define FTMN_CALLEE_DONE_MEMCMP(my_memcmp, p1, p2, nb) \
+	__ftmn_callee_done_memcmp(__ftmn_get_tsd_func_arg(), \
+				  FTMN_FUNC_HASH(__func__), (my_memcmp), \
+				  (p1), (p2), (nb))
+
+/*
+ * FTMN_CALLEE_UPDATE_NOT_ZERO() - Update the result of a callee with a
+ *				   non-zero value
+ * @res:	Result or return value
+ *
+ * The passed result will be stored in the struct ftmn_func_arg struct
+ * supplied by the caller. This function can be called any number of times
+ * by the callee, provided that one of the FTMN_CALLEE_DONE_XXX() function has
+ * been called first.
+ *
+ * Note that this function is somewhat dangerous as any passed value will
+ * be stored so if the value has been tampered with there is no additional
+ * redundant checks to rely on. However, there are extra checks against
+ * unintentionally storing a zero which often is interpreted as a
+ * successful return value.
+ */
+#define FTMN_CALLEE_UPDATE_NOT_ZERO(res) \
+	__ftmn_callee_update_not_zero(__ftmn_get_tsd_func_arg(), res)
+
+/*
+ * FTMN_SET_CHECK_RES() - records a result in local checked state
+ * @ftmn:	The local struct ftmn
+ * @incr:	Value to increase the checked state with
+ * @res:	Result or return value
+ *
+ * Note that this function is somewhat dangerous as any passed value will
+ * be stored so if the value has been tampered with there is no additional
+ * redundant checks to rely on.
+ */
+#define FTMN_SET_CHECK_RES(ftmn, incr, res) \
+	__ftmn_set_check_res((ftmn), (incr), (res))
+
+/*
+ * FTMN_SET_CHECK_RES_NOT_ZERO() - records a non-zero result in local checked
+ *				   state
+ * @ftmn:	The local struct ftmn
+ * @incr:	Value to increase the checked state with
+ * @res:	Result or return value
+ *
+ * Note that this function is somewhat dangerous as any passed value will
+ * be stored so if the value has been tampered with there is no additional
+ * redundant checks to rely on. However, there are extra checks against
+ * unintentionally storing a zero which often is interpreted as a
+ * successful return value.
+ */
+#define FTMN_SET_CHECK_RES_NOT_ZERO(ftmn, incr, res) \
+	__ftmn_set_check_res_not_zero((ftmn), (incr), (res))
+
+static inline int ftmn_set_check_res_memcmp(struct ftmn *ftmn,
+					    enum ftmn_incr incr,
+					    ftmn_memcmp_t my_memcmp,
+					    const void *p1, const void *p2,
+					    size_t nb)
+{
+	int res = my_memcmp(p1, p2, nb);
+
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION))
+		___ftmn_set_check_res_memcmp(&ftmn->check, incr, res,
+					     my_memcmp, p1, p2, nb);
+
+	return res;
+}
+
+/*
+ * FTMN_STEP_COUNT() - Calculate total step count
+ *
+ * Takes variable number of arguments, up to a total of 6. Where arg0
+ * is the number of times the counter has been increased by FTMN_INCR0,
+ * arg1 FTMN_INCR1 and so on.
+ */
+#define FTMN_STEP_COUNT(...)	\
+	__ftmn_step_count(__ftmn_args_count(__VA_ARGS__), __VA_ARGS__)
+
+/*
+ * ftmn_checkpoint() - Add a checkpoint
+ * @ftmn:	The local struct ftmn
+ * @incr:	Value to increase the checked state with
+ *
+ * Adds a checkpoint by increasing the internal checked state. This
+ * can be checked at a later point in the calling function, for instance
+ * with ftmn_return_res().
+ */
+static inline void ftmn_checkpoint(struct ftmn *ftmn, enum ftmn_incr incr)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION)) {
+		/*
+		 * The purpose of the barriers is to prevent the compiler
+		 * from optimizing this increase to some other location
+		 * in the calling function.
+		 */
+		barrier();
+		ftmn->check.steps += incr;
+		barrier();
+	}
+}
+
+/*
+ * ftmn_expect_state() - Check expected state
+ * @ftmn:	The local struct ftmn
+ * @incr:	Value to increase the checked state with
+ * @steps:	Expected accumulated steps
+ * @res:	Expected saved result or return value
+ *
+ * This is a more advanced version of ftmn_checkpoint() which before
+ * increasing the accumulated steps first checks the accumulated steps and
+ * saved result or return value.
+ */
+static inline void ftmn_expect_state(struct ftmn *ftmn,
+				     enum ftmn_incr incr, unsigned long steps,
+				     unsigned long res)
+{
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION)) {
+		assert((ftmn->check.res ^ FTMN_DEFAULT_HASH) == res);
+		assert(ftmn->check.steps == steps);
+
+		___ftmn_expect_state(&ftmn->check, incr, steps, res);
+	}
+}
+
+/*
+ * ftmn_return_res() - Check and return result
+ * @ftmn:	The local struct ftmn
+ * @steps:	Expected accumulated steps
+ * @res:	Expected saved result or return value
+ *
+ * Checks that the internal accumulated state matches the supplied @steps
+ * and that the saved result or return value matches the supplied one.
+ *
+ * Returns @res.
+ */
+static inline unsigned long ftmn_return_res(struct ftmn *ftmn,
+					    unsigned long steps,
+					    unsigned long res)
+{
+	/*
+	 * We're expecting that the compiler does a tail call optimization
+	 * allowing ___ftmn_return_res() to have full control over the
+	 * returned value. Thus trying to reduce the window where the
+	 * return value can be tampered with.
+	 */
+	if (IS_ENABLED(CFG_CORE_FAULT_MITIGATION)) {
+		assert((ftmn->check.res ^ FTMN_DEFAULT_HASH) == res);
+		assert(ftmn->check.steps == steps);
+
+		return ___ftmn_return_res(&ftmn->check, steps, res);
+	}
+	return res;
+}
+#endif /*__FAULT_MITIGATION_H*/

--- a/lib/libutils/ext/sub.mk
+++ b/lib/libutils/ext/sub.mk
@@ -8,6 +8,7 @@ srcs-y += mempool.c
 srcs-y += nex_strdup.c
 srcs-y += consttime_memcmp.c
 srcs-y += memzero_explicit.c
+srcs-y += fault_mitigation.c
 
 subdirs-y += arch/$(ARCH)
 subdirs-y += ftrace

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -885,3 +885,7 @@ CFG_DRIVERS_TPM2_MMIO ?= n
 ifeq ($(CFG_CORE_TPM_EVENT_LOG),y)
 CFG_CORE_TCG_PROVIDER ?= $(CFG_DRIVERS_TPM2)
 endif
+
+# Enables best effort mitigations against fault injected when the hardware
+# is tampered with. Details in lib/libutils/ext/include/fault_mitigation.h
+CFG_CORE_FAULT_MITIGATION ?= y


### PR DESCRIPTION
This is a replacement for https://github.com/OP-TEE/optee_os/pull/5181

The selected use-case is to make `buf_ta_open()` more resilient. As a consequence I've addressed the different versions of `crypto_acipher_rsassa_verify()`.