### PR TITLE
core: fix use after free in tee_ta_open_session()

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -750,10 +750,6 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 	panicked = ctx->panicked;
 	s->param = NULL;
 
-	tee_ta_put_session(s);
-	if (panicked || (res != TEE_SUCCESS))
-		tee_ta_close_session(s, open_sessions, KERN_IDENTITY);
-
 	/*
 	 * Origin error equal to TEE_ORIGIN_TRUSTED_APP for "regular" error,
 	 * apart from panicking.
@@ -762,6 +758,10 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 		*err = TEE_ORIGIN_TEE;
 	else
 		*err = s->err_origin;
+
+	tee_ta_put_session(s);
+	if (panicked || res != TEE_SUCCESS)
+		tee_ta_close_session(s, open_sessions, KERN_IDENTITY);
 
 	if (res != TEE_SUCCESS)
 		EMSG("Failed. Return error 0x%x", res);


### PR DESCRIPTION
Fixes a use after free where the session pointer 's' was used after
tee_ta_close_session() while recovering from an error.

Fixes: 82061b8d7b34 ("core: store TA params in session struct")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
