### PR TITLE
mk: update CROSS_COMPILE and CROSS_COMPILE64 defaults

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -17,9 +17,9 @@
 # (CFG_* variables only).
 
 # Cross-compiler prefix and suffix
-CROSS_COMPILE ?= arm-linux-gnueabihf-
+CROSS_COMPILE ?= arm-none-linux-gnueabihf-
 CROSS_COMPILE32 ?= $(CROSS_COMPILE)
-CROSS_COMPILE64 ?= aarch64-linux-gnu-
+CROSS_COMPILE64 ?= aarch64-none-linux-gnu-
 COMPILER ?= gcc
 
 # For convenience


### PR DESCRIPTION
After ARM's 9.2-2019.12 release of their GNU toolchain in 2019, ARM has
consistently named their toolchains aarch64-none-linux-gnu and
arm-none-linux-gnueabihf including the latest 11.2-2022.02 released
this February. Currently optee still uses the old naming for the
default CROSS_COMPILE and CROSS_COMPILE64 flags, requiring many who use
the newest toolchain versions to override these flags.

Update the default CROSS_COMPILE and CROSS_COMPILE64 flags to reduce
the number of compiler variables needed to compile optee.

Signed-off-by: Bryan Brattlof <bb@ti.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
