### PR TITLE
drivers: caam: fix function definition when CFG_CAAM_NO_ITR=y

### DIFF
--- a/core/arch/arm/plat-imx/crypto_conf.mk
+++ b/core/arch/arm/plat-imx/crypto_conf.mk
@@ -51,13 +51,16 @@ $(call force,CFG_CAAM_SIZE_ALIGN,1)
 $(call force,CFG_JR_BLOCK_SIZE,0x1000)
 $(call force,CFG_JR_INDEX,2)
 $(call force,CFG_JR_INT,114)
-$(call force,CFG_CAAM_NO_ITR,y)
+$(call force,CFG_CAAM_ITR,n)
 else
 $(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force, CFG_JR_BLOCK_SIZE,0x1000)
 $(call force, CFG_JR_INDEX,0)
 $(call force, CFG_JR_INT,137)
 endif
+
+# Enable JR interruptions
+CFG_CAAM_ITR ?= y
 
 #
 # Configuration of the Crypto Driver

--- a/core/drivers/crypto/caam/hal/common/hal_jr.c
+++ b/core/drivers/crypto/caam/hal/common/hal_jr.c
@@ -136,7 +136,7 @@ void caam_hal_jr_del_job(vaddr_t baseaddr)
 	io_caam_write32(baseaddr + JRX_ORJRR, 1);
 }
 
-#ifdef CFG_CAAM_NO_ITR
+#ifdef CFG_CAAM_ITR
 void caam_hal_jr_disable_itr(vaddr_t baseaddr)
 {
 	io_setbits32(baseaddr + JRX_JRCFGR_LS, JRX_JRCFGR_LS_IMSK);
@@ -151,7 +151,7 @@ void caam_hal_jr_enable_itr(vaddr_t baseaddr)
 #else
 void caam_hal_jr_disable_itr(vaddr_t baseaddr __unused) {}
 void caam_hal_jr_enable_itr(vaddr_t baseaddr __unused) {}
-#endif /* CFG_CAAM_NO_ITR */
+#endif /* CFG_CAAM_ITR */
 
 bool caam_hal_jr_check_ack_itr(vaddr_t baseaddr)
 {


### PR DESCRIPTION
There is a bug in the CAAM JR interruption enablement logic. When
CFG_CAAM_NO_ITR=y, the JR interruptions are used and when
CFG_CAAM_NO_ITR=n, the JR interruptions are not used.

Even with this wrong logic, the CAAM is still able to enqueue jobs.
When no JR interruptions are received, the CAAM will manually dequeue
jobs from the jobring by checking the number of jobs done in the output
ring slots full register.

CAAM JR interruptions are not mandatory for the CAAM to work properly
but it makes the dequeuing faster than polling the output ring slot full
register.

Fixes: 3f45afc31 ("drivers: caam: disable the use of interrupts for some platforms")
Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
