### PR TITLE
core: set CFG_TEE_CORE_LOG_LEVEL to 2 (info) by default

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -64,10 +64,10 @@ CFG_TEE_CORE_DEBUG ?= y
 # logs from the TAs.
 # 0: none
 # 1: error
-# 2: error + warning
-# 3: error + warning + debug
-# 4: error + warning + debug + flow
-CFG_TEE_CORE_LOG_LEVEL ?= 1
+# 2: error + info
+# 3: error + info + debug
+# 4: error + info + debug + flow
+CFG_TEE_CORE_LOG_LEVEL ?= 2
 
 # TA log level
 # If user-mode library libutils.a is built with CFG_TEE_TA_LOG_LEVEL=0,


### PR DESCRIPTION
The default log level of the TEE core is 1 (error), which means it is
normally silent. Set it to 2 (info) so that the boot sequence can be
seen (OP-TEE version banner, CPUs detected etc.).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
