### PR TITLE
plat: arm: fix refactor GIC initialization

### DIFF
--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -27,18 +27,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GICC_BASE, MEM_AREA_IO_SEC,
-					  GICC_SIZE);
-	gicd_base = (vaddr_t)phys_to_virt(GICD_BASE, MEM_AREA_IO_SEC,
-					  GICD_SIZE);
-
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	gic_init_base_addr(&gic_data, GICC_BASE, GICD_BASE);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -75,19 +75,13 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, CORE_MMU_PGDIR_SIZE);
 
 void main_init_gic(void)
 {
-	vaddr_t gicd_base;
-	vaddr_t gicc_base = 0;
+	paddr_t gicd_base;
+	paddr_t gicc_base = 0;
 
 #ifdef GICC_BASE
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	if (!gicc_base)
-		panic();
+	gicc_base = GIC_BASE + GICC_OFFSET;
 #endif
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	if (!gicd_base)
-		panic();
+	gicd_base = GIC_BASE + GICD_OFFSET;
 
 	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
 

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -29,17 +29,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICC_OFFSET,
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base = 0;
-	vaddr_t gicd_base = 0;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 
 	itr_init(&gic_data.chip);
 }

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -50,17 +50,7 @@ static struct gic_data gic_data;
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	if (!gicc_base || !gicd_base)
-		panic();
-
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 
 	itr_init(&gic_data.chip);
 }

--- a/core/arch/arm/plat-synquacer/main.c
+++ b/core/arch/arm/plat-synquacer/main.c
@@ -42,16 +42,8 @@ void console_init(void)
 
 void main_init_gic(void)
 {
-	vaddr_t gicd_base;
-
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-
-	if (!gicd_base)
-		panic();
-
 	/* On ARMv8-A, GIC configuration is initialized in TF-A */
-	gic_init_base_addr(&gic_data, 0, gicd_base);
+	gic_init_base_addr(&gic_data, 0, GIC_BASE + GICD_OFFSET);
 
 	itr_init(&gic_data.chip);
 }

--- a/core/arch/arm/plat-totalcompute/main.c
+++ b/core/arch/arm/plat-totalcompute/main.c
@@ -32,18 +32,11 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 #ifndef CFG_CORE_SEL2_SPMC
 void main_init_gic(void)
 {
-	vaddr_t gicc_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC);
-	if (!gicc_base)
-		panic();
-
 	/*
 	 * On ARMv8, GIC configuration is initialized in ARM-TF
 	 * gicd base address is same as gicc_base.
 	 */
-	gic_init_base_addr(&gic_data, gicc_base, gicc_base);
+	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICC_OFFSET);
 	itr_init(&gic_data.chip);
 }
 #endif

--- a/core/arch/arm/plat-uniphier/main.c
+++ b/core/arch/arm/plat-uniphier/main.c
@@ -39,14 +39,7 @@ static struct serial8250_uart_data console_data;
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base, gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC, CORE_MMU_PGDIR_SIZE);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, CORE_MMU_PGDIR_SIZE);
-
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 	itr_init(&gic_data.chip);
 }
 

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -79,14 +79,8 @@ register_ddr(DRAM0_BASE, CFG_DDR_SIZE);
 
 void main_init_gic(void)
 {
-	vaddr_t gicc_base, gicd_base;
-
-	gicc_base = (vaddr_t)phys_to_virt(GIC_BASE + GICC_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
-	gicd_base = (vaddr_t)phys_to_virt(GIC_BASE + GICD_OFFSET,
-					  MEM_AREA_IO_SEC, 1);
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
+	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void itr_core_handler(void)


### PR DESCRIPTION
The commit 60801696667d converts functions gic_init_base_addr() and
gic_init() to take physical addresses instead of virtual, but only
converts half the platforms. This causes boot failure on all the others.

Convert the rest here.

Fixes: 60801696667d ("plat: arm: refactor GIC initialization")
Signed-off-by: Andrew Davis <afd@ti.com>