### PR TITLE
drivers: caam: add JR interruption only if CFG_CAAM_ITR=y

### DIFF
--- a/core/drivers/crypto/caam/caam_jr.c
+++ b/core/drivers/crypto/caam/caam_jr.c
@@ -583,7 +583,7 @@ enum caam_status caam_jr_init(struct caam_jrcfg *jrcfg)
 	jr_privdata->it_handler.handler = caam_jr_irqhandler;
 	jr_privdata->it_handler.data = jr_privdata;
 
-#ifdef CFG_NXP_CAAM_RUNTIME_JR
+#if defined(CFG_NXP_CAAM_RUNTIME_JR) && defined(CFG_CAAM_ITR)
 	itr_add(&jr_privdata->it_handler);
 #endif
 	caam_hal_jr_enable_itr(jr_privdata->baseaddr);


### PR DESCRIPTION
Adding the JR interruption in the OPTEE CAAM driver, even if not used in
OPTEE, prevents the Linux CAAM driver from using the JR interruption on
platforms sharing the same line of interruption for all job rings.

To dequeue job from the job ring, the Linux CAAM driver would pull the
number of jobs done from the output ring slot full register.

The fix is to add the JR interruption only if CFG_CAAM_ITR=y. This
allows the Linux CAAM driver from dequeuing job faster than polling from
a register.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
