### PR TITLE
plat-rockchip: rk3399: define GICC_BASE

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -208,6 +208,7 @@ jobs:
           _make PLATFORM=poplar
           _make PLATFORM=poplar CFG_ARM64_core=y
           _make PLATFORM=rockchip-rk322x
+          _make PLATFORM=rockchip-rk3399
           _make PLATFORM=sam
           _make PLATFORM=marvell-armada7k8k
           _make PLATFORM=marvell-armada3700

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -47,6 +47,7 @@
 
 #define GIC_BASE		(MMIO_BASE + 0x06E00000)
 #define GIC_SIZE		SIZE_M(2)
+#define GICC_BASE		(MMIO_BASE + 0x07F00000)
 #define GICD_BASE		GIC_BASE
 #define GICR_BASE		(GIC_BASE + SIZE_M(1))
 


### PR DESCRIPTION
Commit 60801696667d ("plat: arm: refactor GIC initialization") has
introduced a build regression for Rockchip:

 $ make -s PLATFORM=rockchip-rk3399
 core/arch/arm/plat-rockchip/main.c: In function ‘main_init_gic’:
 core/arch/arm/plat-rockchip/main.c:29:29: error: ‘GICC_BASE’ undeclared (first use in this function); did you mean ‘GIC_BASE’?
    29 |         gic_init(&gic_data, GICC_BASE, GICD_BASE);
       |                             ^~~~~~~~~
       |                             GIC_BASE

Fix that by defining GICC_BASE unconditionally as most platforms do.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
