### PR TITLE
drivers: versal: PM, MBOX and NVM

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -82,6 +82,13 @@ R:	Jorge Ramirez <jorge@foundries.io> [@ldts]
 S:	Maintained
 F:	core/drivers/crypto/se050
 
+Core Drivers Versal ACAP
+R:	Jorge Ramirez <jorge@foundries.io> [@ldts]
+S:	Maintained
+F:	core/drivers/versal_mbox.c
+F:	core/drivers/versal_nvm.c
+F:	core/drivers/versal_pm.c
+
 Core Drivers ZYNQMP
 R:	Jorge Ramirez <jorge@foundries.io> [@ldts]
 S:	Maintained

--- a/core/arch/arm/plat-versal/conf.mk
+++ b/core/arch/arm/plat-versal/conf.mk
@@ -32,3 +32,5 @@ $(call force,CFG_WITH_LPAE,y)
 else
 $(call force,CFG_ARM32_core,y)
 endif
+
+$(call force, CFG_VERSAL_PM,y)

--- a/core/arch/arm/plat-versal/conf.mk
+++ b/core/arch/arm/plat-versal/conf.mk
@@ -35,6 +35,7 @@ endif
 
 $(call force, CFG_VERSAL_PM,y)
 $(call force, CFG_VERSAL_MBOX,y)
+$(call force, CFG_VERSAL_NVM,y)
 
 # MBOX configuration
 CFG_VERSAL_MBOX_IPI_ID ?=3

--- a/core/arch/arm/plat-versal/conf.mk
+++ b/core/arch/arm/plat-versal/conf.mk
@@ -34,3 +34,8 @@ $(call force,CFG_ARM32_core,y)
 endif
 
 $(call force, CFG_VERSAL_PM,y)
+$(call force, CFG_VERSAL_MBOX,y)
+
+# MBOX configuration
+CFG_VERSAL_MBOX_IPI_ID ?=3
+

--- a/core/arch/arm/plat-versal/main.c
+++ b/core/arch/arm/plat-versal/main.c
@@ -7,6 +7,7 @@
 #include <console.h>
 #include <drivers/gic.h>
 #include <drivers/pl011.h>
+#include <drivers/versal_pm.h>
 #include <kernel/boot.h>
 #include <kernel/interrupt.h>
 #include <kernel/misc.h>
@@ -56,3 +57,20 @@ void console_init(void)
 		   CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
 	register_serial_console(&console_data.chip);
 }
+
+static TEE_Result platform_banner(void)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	uint8_t version = 0;
+
+	ret = versal_soc_version(&version);
+	if (ret) {
+		EMSG("Failure to retrieve SoC version");
+		return ret;
+	}
+
+	IMSG("Platform Versal - Silicon Revision v%d", version);
+
+	return TEE_SUCCESS;
+}
+service_init(platform_banner);

--- a/core/arch/arm/plat-versal/platform_config.h
+++ b/core/arch/arm/plat-versal/platform_config.h
@@ -9,7 +9,8 @@
 #include <mm/generic_ram_layout.h>
 
 /* Make stacks aligned to data cache line length */
-#define STACK_ALIGNMENT		64
+#define CACHELINE_LEN		64
+#define STACK_ALIGNMENT		CACHELINE_LEN
 
 #if defined(PLATFORM_FLAVOR_generic)
 

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -51,6 +51,7 @@ srcs-$(CFG_ZYNQMP_CSUDMA) += zynqmp_csudma.c
 srcs-$(CFG_ZYNQMP_CSU_AES) += zynqmp_csu_aes.c
 srcs-$(CFG_ZYNQMP_PM) += zynqmp_pm.c
 srcs-$(CFG_ZYNQMP_HUK) += zynqmp_huk.c
+srcs-$(CFG_VERSAL_PM) += versal_pm.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -52,6 +52,7 @@ srcs-$(CFG_ZYNQMP_CSU_AES) += zynqmp_csu_aes.c
 srcs-$(CFG_ZYNQMP_PM) += zynqmp_pm.c
 srcs-$(CFG_ZYNQMP_HUK) += zynqmp_huk.c
 srcs-$(CFG_VERSAL_PM) += versal_pm.c
+srcs-$(CFG_VERSAL_MBOX) += versal_mbox.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -53,6 +53,7 @@ srcs-$(CFG_ZYNQMP_PM) += zynqmp_pm.c
 srcs-$(CFG_ZYNQMP_HUK) += zynqmp_huk.c
 srcs-$(CFG_VERSAL_PM) += versal_pm.c
 srcs-$(CFG_VERSAL_MBOX) += versal_mbox.c
+srcs-$(CFG_VERSAL_NVM) += versal_nvm.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/drivers/versal_mbox.c
+++ b/core/drivers/versal_mbox.c
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2022 Foundries.io Ltd
+ * Jorge Ramirez-Ortiz <jorge@foundries.io>
+ */
+
+#include <initcall.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <mm/core_mmu.h>
+#include <string.h>
+#include <tee/cache.h>
+#include "drivers/versal_mbox.h"
+
+#define PM_SIP_SVC	0xc2000000
+
+/* ipi targets */
+#define IPI_ID_PMC	1
+#define IPI_ID_0	2
+#define IPI_ID_RPU0	3
+#define IPI_ID_RPU1	4
+#define IPI_ID_3	5
+#define IPI_ID_4	6
+#define IPI_ID_5	7
+
+/* buffers */
+#define IPI_BUFFER_BASEADDR		0xFF3F0000
+#define IPI_BUFFER_APU_ID_0_BASE	(IPI_BUFFER_BASEADDR + 0x400)
+#define IPI_BUFFER_APU_ID_3_BASE	(IPI_BUFFER_BASEADDR + 0xA00)
+#define IPI_BUFFER_APU_ID_4_BASE	(IPI_BUFFER_BASEADDR + 0xC00)
+#define IPI_BUFFER_APU_ID_5_BASE	(IPI_BUFFER_BASEADDR + 0xE00)
+#define IPI_BUFFER_PMC_BASE		(IPI_BUFFER_BASEADDR + 0x200)
+#define IPI_BUFFER_TARGET_APU_OFFSET	0x80
+#define IPI_BUFFER_TARGET_PMC_OFFSET	0x40
+#define IPI_BUFFER_REQ_OFFSET		0x0
+#define IPI_BUFFER_RESP_OFFSET		0x20
+
+#define IPI_BUFFER_LOCAL_OFFSET		IPI_BUFFER_TARGET_APU_OFFSET
+#define IPI_BUFFER_REMOTE_OFFSET	IPI_BUFFER_TARGET_PMC_OFFSET
+
+#define IPI_BLOCK		1
+#define IPI_NON_BLOCK		0
+
+/* mailbox api */
+enum ipi_api_id {
+	IPI_MAILBOX_OPEN = 0x1000,
+	IPI_MAILBOX_RELEASE,
+	IPI_MAILBOX_STATUS_ENQUIRY,
+	IPI_MAILBOX_NOTIFY,
+	IPI_MAILBOX_ACK,
+	IPI_MAILBOX_ENABLE_IRQ,
+	IPI_MAILBOX_DISABLE_IRQ
+};
+
+static struct versal_ipi {
+	uint32_t lcl;
+	const uint32_t rmt;
+	paddr_t buf;
+	/* Exclusive access to the IPI shared buffer */
+	struct mutex lock;
+	void *rsp;
+	void *req;
+} ipi = {
+	.buf = IPI_BUFFER_APU_ID_3_BASE,
+	.rmt = IPI_ID_PMC,
+	.lcl = IPI_ID_3,
+};
+
+static TEE_Result mbox_call(enum ipi_api_id id, uint32_t blocking_call)
+{
+	struct thread_smc_args args = {
+		.a0 = PM_SIP_SVC | id,
+		.a1 = reg_pair_to_64(0, ipi.lcl),
+		.a2 = reg_pair_to_64(0, ipi.rmt),
+		.a3 = reg_pair_to_64(0, blocking_call),
+	};
+
+	thread_smccc(&args);
+
+	if (IS_ENABLED(CFG_VERSAL_TRACE_PLM))
+		mdelay(1000);
+
+	if (args.a0)
+		return TEE_ERROR_GENERIC;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result versal_mbox_write_req(struct ipi_cmd *cmd)
+{
+	size_t i = 0;
+
+	for (i = 0; i < MAX_IPI_BUF; i++) {
+		if (!cmd->ibuf[i].p)
+			continue;
+
+		if (!IS_ALIGNED((uintptr_t)cmd->ibuf[i].p, CACHELINE_LEN))
+			return TEE_ERROR_GENERIC;
+
+		if (!IS_ALIGNED(cmd->ibuf[i].len, CACHELINE_LEN))
+			return TEE_ERROR_GENERIC;
+
+		cache_operation(TEE_CACHEFLUSH,
+				cmd->ibuf[i].p, cmd->ibuf[i].len);
+	}
+
+	memcpy(ipi.req, cmd->data, sizeof(cmd->data));
+	/* cache operation on the IPI buffer is safe */
+	cache_operation(TEE_CACHEFLUSH, ipi.req, sizeof(cmd->data));
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result versal_mbox_read_rsp(struct ipi_cmd *cmd, struct ipi_cmd *rsp,
+				       uint32_t *status)
+{
+	size_t i = 0;
+
+	/* cache operation on the IPI buffer is safe */
+	cache_operation(TEE_CACHEINVALIDATE, ipi.rsp, sizeof(rsp->data));
+
+	*status = *(uint32_t *)ipi.rsp;
+
+	if (rsp)
+		memcpy(rsp->data, ipi.rsp, sizeof(rsp->data));
+
+	if (*status)
+		return TEE_ERROR_GENERIC;
+
+	for (i = 0; i < MAX_IPI_BUF; i++) {
+		if (!cmd->ibuf[i].p)
+			continue;
+
+		if (!IS_ALIGNED((uintptr_t)cmd->ibuf[i].p, CACHELINE_LEN))
+			return TEE_ERROR_GENERIC;
+
+		if (!IS_ALIGNED(cmd->ibuf[i].len, CACHELINE_LEN))
+			return TEE_ERROR_GENERIC;
+
+		cache_operation(TEE_CACHEINVALIDATE,
+				cmd->ibuf[i].p, cmd->ibuf[i].len);
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result versal_mbox_notify(struct ipi_cmd *cmd, struct ipi_cmd *rsp)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	uint32_t remote_status = 0;
+
+	mutex_lock(&ipi.lock);
+
+	ret = versal_mbox_write_req(cmd);
+	if (ret) {
+		EMSG("Can't write the request command");
+		goto out;
+	}
+
+	ret = mbox_call(IPI_MAILBOX_NOTIFY, IPI_BLOCK);
+	if (ret) {
+		EMSG("IPI error");
+		goto out;
+	}
+
+	ret = versal_mbox_read_rsp(cmd, rsp, &remote_status);
+	if (ret) {
+		EMSG("Can't read the remote response");
+		goto out;
+	}
+
+	if (remote_status) {
+		/* Check xplmi_status.h in the PLM code (hundreds of types) */
+		EMSG("PLM (err=0x%x)", remote_status >> 16);
+		ret = TEE_ERROR_GENERIC;
+	}
+out:
+	mutex_unlock(&ipi.lock);
+
+	return ret;
+}
+
+static TEE_Result versal_mbox_init(void)
+{
+	switch (CFG_VERSAL_MBOX_IPI_ID) {
+	case 0:
+		ipi.buf = IPI_BUFFER_APU_ID_0_BASE;
+		ipi.lcl = IPI_ID_0;
+		break;
+	case 3:
+		break;
+	case 4:
+		ipi.buf = IPI_BUFFER_APU_ID_4_BASE;
+		ipi.lcl = IPI_ID_4;
+		break;
+	case 5:
+		ipi.buf = IPI_BUFFER_APU_ID_5_BASE;
+		ipi.lcl = IPI_ID_5;
+		break;
+	default:
+		EMSG("Invalid IPI requested");
+		return TEE_ERROR_GENERIC;
+	}
+
+	ipi.req = core_mmu_add_mapping(MEM_AREA_RAM_SEC,
+				       ipi.buf + IPI_BUFFER_REMOTE_OFFSET +
+				       IPI_BUFFER_REQ_OFFSET,
+				       sizeof(struct ipi_cmd));
+
+	ipi.rsp = core_mmu_add_mapping(MEM_AREA_RAM_SEC,
+				       ipi.buf + IPI_BUFFER_REMOTE_OFFSET +
+				       IPI_BUFFER_RESP_OFFSET,
+				       sizeof(struct ipi_cmd));
+	if (!ipi.req || !ipi.rsp)
+		panic();
+
+	mutex_init(&ipi.lock);
+
+	return mbox_call(IPI_MAILBOX_OPEN, IPI_BLOCK);
+}
+early_init(versal_mbox_init);

--- a/core/drivers/versal_nvm.c
+++ b/core/drivers/versal_nvm.c
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2022 Foundries.io Ltd
+ * Jorge Ramirez-Ortiz <jorge@foundries.io>
+ */
+
+#include <arm.h>
+#include <drivers/versal_nvm.h>
+#include <drivers/versal_mbox.h>
+#include <initcall.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <string.h>
+#include <tee/cache.h>
+
+#include "drivers/versal_nvm.h"
+
+/* Protocol API with the remote processor */
+#define NVM_MODULE_SHIFT	8
+#define NVM_MODULE		11
+#define NVM_API_ID(_id) ((NVM_MODULE << NVM_MODULE_SHIFT) | (_id))
+
+/*
+ * Max size of the buffer needed for the remote processor to DMA efuse _data_
+ * to/from
+ */
+#define EFUSE_MAX_LEN (EFUSE_MAX_USER_FUSES * sizeof(uint32_t))
+
+enum versal_nvm_api_id {
+	API_FEATURES			= 0,
+	BBRAM_WRITE_AES_KEY		= 1,
+	BBRAM_ZEROIZE			= 2,
+	BBRAM_WRITE_USER_DATA		= 3,
+	BBRAM_READ_USER_DATA		= 4,
+	BBRAM_LOCK_WRITE_USER_DATA	= 5,
+	EFUSE_WRITE			= 6,
+	EFUSE_WRITE_PUF			= 7,
+	EFUSE_PUF_USER_FUSE_WRITE	= 8,
+	EFUSE_READ_IV			= 9,
+	EFUSE_READ_REVOCATION_ID	= 10,
+	EFUSE_READ_OFFCHIP_REVOCATION_ID = 11,
+	EFUSE_READ_USER_FUSES		= 12,
+	EFUSE_READ_MISC_CTRL		= 13,
+	EFUSE_READ_SEC_CTRL		= 14,
+	EFUSE_READ_SEC_MISC1		= 15,
+	EFUSE_READ_BOOT_ENV_CTRL	= 16,
+	EFUSE_READ_PUF_SEC_CTRL		= 17,
+	EFUSE_READ_PPK_HASH		= 18,
+	EFUSE_READ_DEC_EFUSE_ONLY	= 19,
+	EFUSE_READ_DNA			= 20,
+	EFUSE_READ_PUF_USER_FUSES	= 21,
+	EFUSE_READ_PUF			= 22,
+	EFUSE_INVALID			= 23,
+};
+
+struct versal_efuse_sec_ctrl_bits {
+	uint8_t aes_dis;
+	uint8_t jtag_err_out_dis;
+	uint8_t jtag_dis;
+	uint8_t ppk0_wr_lk;
+	uint8_t ppk1_wr_lk;
+	uint8_t ppk2_wr_lk;
+	uint8_t aes_crc_lk;
+	uint8_t aes_wr_lk;
+	uint8_t user_key0_crc_lk;
+	uint8_t user_key0_wr_lk;
+	uint8_t user_key1_crc_lk;
+	uint8_t user_key1_wr_lk;
+	uint8_t sec_dbg_dis;
+	uint8_t sec_lock_dbg_dis;
+	uint8_t boot_env_wr_lk;
+	uint8_t reg_init_dis;
+	uint8_t pad[48];
+} __packed;
+
+struct versal_efuse_puf_sec_ctrl_bits {
+	uint8_t puf_regen_dis;
+	uint8_t puf_hd_invalid;
+	uint8_t puf_test2_dis;
+	uint8_t puf_dis;
+	uint8_t puf_syn_lk;
+	uint8_t pad[59];
+} __packed;
+
+struct versal_efuse_misc_ctrl_bits {
+	uint8_t glitch_det_halt_boot_en;
+	uint8_t glitch_det_rom_monitor_en;
+	uint8_t halt_boot_error;
+	uint8_t halt_boot_env;
+	uint8_t vrypto_kat_en;
+	uint8_t lbist_en;
+	uint8_t safety_mission_en;
+	uint8_t ppk0_invalid;
+	uint8_t ppk1_invalid;
+	uint8_t ppk2_invalid;
+	uint8_t pad[54];
+} __packed;
+
+struct versal_efuse_sec_misc1_bits {
+	uint8_t lpd_mbist_en;
+	uint8_t pmc_mbist_en;
+	uint8_t lpd_noc_sc_en;
+	uint8_t sysmon_volt_mon_en;
+	uint8_t sysmon_temp_mon_en;
+	uint8_t pad[59];
+} __packed;
+
+struct versal_efuse_boot_env_ctrl_bits {
+	uint8_t prgm_sysmon_temp_hot;
+	uint8_t prgm_sysmon_volt_pmc;
+	uint8_t prgm_sysmon_volt_pslp;
+	uint8_t prgm_sysmon_temp_cold;
+	uint8_t sysmon_temp_en;
+	uint8_t sysmon_volt_en;
+	uint8_t sysmon_volt_soc;
+	uint8_t sysmon_temp_hot;
+	uint8_t sysmon_volt_pmc;
+	uint8_t sysmon_volt_pslp;
+	uint8_t sysmon_temp_cold;
+	uint8_t pad[53];
+} __packed;
+
+struct versal_efuse_glitch_cfg_bits {
+	uint8_t prgm_glitch;
+	uint8_t glitch_det_wr_lk;
+	uint32_t glitch_det_trim;
+	uint8_t gd_rom_monitor_en;
+	uint8_t gd_halt_boot_en;
+	uint8_t pad[56];
+} __packed;
+
+struct versal_efuse_aes_keys {
+	uint8_t prgm_aes_key;
+	uint8_t prgm_user_key0;
+	uint8_t prgm_user_key1;
+	uint32_t aes_key[8];
+	uint32_t user_key0[8];
+	uint32_t user_key1[8];
+	uint8_t pad[29];
+} __packed;
+
+struct versal_efuse_ppk_hash {
+	uint8_t prgm_ppk0_hash;
+	uint8_t prgm_ppk1_hash;
+	uint8_t prgm_ppk2_hash;
+	uint32_t ppk0_hash[8];
+	uint32_t ppk1_hash[8];
+	uint32_t ppk2_hash[8];
+	uint8_t pad[29];
+} __packed;
+
+struct versal_efuse_dec_only {
+	uint8_t prgm_dec_only;
+	uint8_t pad[63];
+} __packed;
+
+struct versal_efuse_revoke_ids {
+	uint8_t prgm_revoke_id;
+	uint32_t revoke_id[8];
+	uint8_t pad[31];
+} __packed;
+
+struct versal_efuse_offchip_ids {
+	uint8_t prgm_offchip_id;
+	uint32_t offchip_id[8];
+	uint8_t pad[31];
+} __packed;
+
+struct versal_efuse_ivs {
+	uint8_t prgm_meta_header_iv;
+	uint8_t prgm_blk_obfus_iv;
+	uint8_t prgm_plm_iv;
+	uint8_t prgm_data_partition_iv;
+	uint32_t meta_header_iv[3];
+	uint32_t blk_obfus_iv[3];
+	uint32_t plm_iv[3];
+	uint32_t data_partition_iv[3];
+	uint8_t pad[12];
+} __packed;
+
+struct versal_efuse_user_data {
+	uint32_t start;
+	uint32_t num;
+	uint64_t addr;
+	uint8_t pad[48];
+} __packed;
+
+struct versal_efuse_puf_fuse {
+	uint8_t env_monitor_dis;
+	uint8_t prgm_puf_fuse;
+	uint32_t start;
+	uint32_t num;
+	uint64_t addr;
+	uint8_t pad[46];
+} __packed;
+
+struct versal_efuse_puf_hd {
+	struct versal_efuse_puf_sec_ctrl_bits puf_sec_ctrl_bits;
+	uint8_t prgm_puf_helper_data;
+	uint8_t env_monitor_dis;
+	uint32_t efuse_syn_data[127];
+	uint32_t chash;
+	uint32_t aux;
+	uint8_t pad[58];
+} __packed;
+
+struct versal_efuse_data {
+	uint64_t env_mon_dis_flag;
+	uint64_t aes_key_addr;
+	uint64_t ppk_hash_addr;
+	uint64_t dec_only_addr;
+	uint64_t sec_ctrl_addr;
+	uint64_t misc_ctrl_addr;
+	uint64_t revoke_id_addr;
+	uint64_t iv_addr;
+	uint64_t user_fuse_addr;
+	uint64_t glitch_cfg_addr;
+	uint64_t boot_env_ctrl_addr;
+	uint64_t misc1_ctrl_addr;
+	uint64_t offchip_id_addr;
+	uint8_t pad[24];
+} __packed;
+
+/* Helper read and write requests (not part of the protocol) */
+struct versal_nvm_read_req {
+	enum versal_nvm_api_id efuse_id;
+	enum versal_nvm_revocation_id revocation_id;
+	enum versal_nvm_offchip_id offchip_id;
+	enum versal_nvm_ppk_type ppk_type;
+	enum versal_nvm_iv_type iv_type;
+	struct ipi_buf ibuf[MAX_IPI_BUF];
+};
+
+enum versal_nvm_write_efuse_id {
+	EFUSE_WRITE_USER_FUSES = 0,
+	EFUSE_WRITE_INVALID = 0xffff,
+};
+
+struct versal_nvm_write_req {
+	struct versal_efuse_data data;
+	enum versal_nvm_write_efuse_id id;
+	struct ipi_buf ibuf[MAX_IPI_BUF];
+};
+
+struct cmd_args {
+	uint32_t data[3];
+	size_t len;
+};
+
+static TEE_Result prepare_cmd(struct ipi_cmd *cmd, enum versal_nvm_api_id efuse,
+			      struct ipi_buf *ibufs, struct cmd_args *arg)
+{
+	size_t i = 0;
+
+	cmd->data[i++] = NVM_API_ID(efuse);
+	for (i = 1; i < arg->len + 1; i++)
+		cmd->data[i] = arg->data[i];
+
+	if (!ibufs[0].p)
+		return TEE_SUCCESS;
+
+	cmd->data[i++] = virt_to_phys(ibufs[0].p);
+	cmd->data[i++] = virt_to_phys(ibufs[0].p) >> 32;
+
+	for (i = 0; i < MAX_IPI_BUF; i++) {
+		cmd->ibuf[i].len = ibufs[i].len;
+		cmd->ibuf[i].p = ibufs[i].p;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result efuse_req(enum versal_nvm_api_id efuse, struct ipi_buf *ibufs,
+			    struct cmd_args *arg)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	struct ipi_cmd cmd = { };
+
+	ret = prepare_cmd(&cmd, efuse, ibufs, arg);
+	if (ret)
+		return ret;
+
+	ret = versal_mbox_notify(&cmd, NULL);
+	if (ret)
+		EMSG("Mailbox error");
+
+	return ret;
+}
+
+static TEE_Result versal_nvm_read(struct versal_nvm_read_req *req)
+{
+	struct cmd_args args = { };
+
+	if (!req)
+		return TEE_ERROR_GENERIC;
+
+	switch (req->efuse_id) {
+	case EFUSE_READ_DNA:
+	case EFUSE_READ_DEC_EFUSE_ONLY:
+	case EFUSE_READ_PUF_SEC_CTRL:
+	case EFUSE_READ_BOOT_ENV_CTRL:
+	case EFUSE_READ_SEC_CTRL:
+	case EFUSE_READ_MISC_CTRL:
+	case EFUSE_READ_SEC_MISC1:
+	case BBRAM_READ_USER_DATA:
+	case EFUSE_READ_USER_FUSES:
+	case EFUSE_READ_PUF_USER_FUSES:
+	case EFUSE_READ_PUF:
+		break;
+	case BBRAM_ZEROIZE:
+	case BBRAM_LOCK_WRITE_USER_DATA:
+		if (req->ibuf[0].p)
+			return TEE_ERROR_GENERIC;
+		break;
+	case EFUSE_READ_OFFCHIP_REVOCATION_ID:
+		args.data[0] = req->offchip_id;
+		args.len = 1;
+		break;
+	case EFUSE_READ_REVOCATION_ID:
+		args.data[0] = req->revocation_id;
+		args.len = 1;
+		break;
+	case EFUSE_READ_IV:
+		args.data[0] = req->iv_type;
+		args.len = 1;
+		break;
+	case EFUSE_READ_PPK_HASH:
+		args.data[0] = req->ppk_type;
+		args.len = 1;
+		break;
+	default:
+		return TEE_ERROR_GENERIC;
+	}
+
+	return efuse_req(req->efuse_id, req->ibuf, &args);
+}
+
+static TEE_Result versal_nvm_write(struct versal_nvm_write_req *req)
+{
+	enum versal_nvm_api_id efuse_id = EFUSE_INVALID;
+	struct cmd_args args = { };
+
+	switch (req->id) {
+	case EFUSE_WRITE_USER_FUSES:
+		efuse_id = EFUSE_WRITE;
+		break;
+	default:
+		return TEE_ERROR_GENERIC;
+	}
+
+	return efuse_req(efuse_id, req->ibuf, &args);
+}
+
+TEE_Result versal_read_efuse_dna(uint32_t *buf, size_t len)
+{
+	uint8_t lbuf[EFUSE_MAX_LEN] __aligned_efuse = { 0 };
+	struct versal_nvm_read_req req = { 0 };
+
+	if (len < EFUSE_DNA_LEN)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Prepare request */
+	req.efuse_id = EFUSE_READ_DNA;
+
+	/* Request cache management */
+	req.ibuf[0].p = lbuf;
+	req.ibuf[0].len = sizeof(lbuf);
+
+	if (versal_nvm_read(&req))
+		return TEE_ERROR_GENERIC;
+
+	memcpy(buf, lbuf, EFUSE_DNA_LEN);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result versal_read_efuse_user(uint32_t *buf, size_t len, uint32_t first,
+				  size_t num)
+{
+	uint8_t lbuf[EFUSE_MAX_LEN] __aligned_efuse = { 0 };
+	struct versal_efuse_user_data cfg __aligned_efuse = {
+		.addr = (uintptr_t)lbuf,
+		.start = first,
+		.num = num, /* fuses needs to be at least 40 bytes */
+	};
+	struct versal_nvm_read_req req = { 0 };
+
+	if (first + num > EFUSE_MAX_USER_FUSES || len < num * sizeof(uint32_t))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Prepare request */
+	req.efuse_id = EFUSE_READ_USER_FUSES;
+
+	/* Request cache management */
+	req.ibuf[0].p = &cfg;
+	req.ibuf[0].len = sizeof(cfg);
+	req.ibuf[1].p = lbuf;
+	req.ibuf[1].len = sizeof(lbuf);
+
+	/* Update the command buffer */
+	cfg.addr = (paddr_t)virt_to_phys((void *)cfg.addr);
+
+	if (versal_nvm_read(&req))
+		return TEE_ERROR_GENERIC;
+
+	memcpy(buf, lbuf, num * sizeof(uint32_t));
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result versal_read_efuse_iv(uint32_t *buf, size_t len,
+				enum versal_nvm_iv_type type)
+{
+	uint8_t lbuf[EFUSE_MAX_LEN] __aligned_efuse = { 0 };
+	struct versal_nvm_read_req req = { .iv_type = type, };
+
+	if (len < EFUSE_IV_LEN)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Prepare the request */
+	req.efuse_id = EFUSE_READ_IV;
+
+	/* Request cache management */
+	req.ibuf[0].p = lbuf;
+	req.ibuf[0].len = sizeof(lbuf);
+
+	if (versal_nvm_read(&req))
+		return TEE_ERROR_GENERIC;
+
+	memcpy(buf, lbuf, EFUSE_IV_LEN);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result versal_read_efuse_ppk(uint32_t *buf, size_t len,
+				 enum versal_nvm_ppk_type type)
+{
+	uint8_t lbuf[EFUSE_MAX_LEN]__aligned_efuse = { 0 };
+	struct versal_nvm_read_req req = { .ppk_type = type, };
+
+	if (len < EFUSE_PPK_LEN)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Prepare the request */
+	req.efuse_id = EFUSE_READ_PPK_HASH;
+
+	/* Request cache management */
+	req.ibuf[0].p = lbuf;
+	req.ibuf[0].len = sizeof(lbuf);
+
+	if (versal_nvm_read(&req))
+		return TEE_ERROR_GENERIC;
+
+	memcpy(buf, lbuf, EFUSE_PPK_LEN);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result versal_write_efuse_user(uint32_t *buf, size_t len, uint32_t first,
+				   size_t num)
+{
+	uint32_t lbuf[EFUSE_MAX_USER_FUSES] __aligned_efuse = { 0 };
+	struct versal_efuse_user_data cfg __aligned_efuse = {
+		.addr = (uintptr_t)lbuf,
+		.start = first,
+		.num = num,
+	};
+	struct versal_nvm_write_req req __aligned_efuse = {
+		.data.env_mon_dis_flag = 1,
+		.data.user_fuse_addr = (uintptr_t)&cfg,
+		.id = EFUSE_WRITE_USER_FUSES,
+	};
+	size_t i = 0;
+
+	if (first + num > EFUSE_MAX_USER_FUSES || len  < num * sizeof(uint32_t))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Update the command buffers with physical addresses */
+	req.data.user_fuse_addr = (paddr_t)
+				  virt_to_phys((void *)req.data.user_fuse_addr);
+	cfg.addr = (paddr_t)virt_to_phys(lbuf);
+
+	/* Request cache management */
+	req.ibuf[0].p = &req.data;
+	req.ibuf[0].len = sizeof(req.data);
+	req.ibuf[1].p = &cfg;
+	req.ibuf[1].len = sizeof(cfg);
+	req.ibuf[2].p = lbuf;
+	req.ibuf[2].len = sizeof(lbuf);
+
+	/* Prepare fuses to write with some random data */
+	for (i = 0; i < cfg.num; i++)
+		lbuf[i] = buf[i];
+
+	return versal_nvm_write(&req);
+}

--- a/core/drivers/versal_pm.c
+++ b/core/drivers/versal_pm.c
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2022 Foundries.io Ltd
+ * Jorge Ramirez-Ortiz <jorge@foundries.io>
+ */
+
+#include <arm.h>
+#include <drivers/versal_pm.h>
+#include <kernel/cache_helpers.h>
+#include <kernel/delay.h>
+#include <kernel/thread.h>
+#include <mm/core_memprot.h>
+#include <string.h>
+#include <tee/cache.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+#include <utee_defines.h>
+
+#define PAYLOAD_ARG_CNT		6
+#define PM_SIP_SVC		0xc2000000
+
+/* PM API ids */
+#define PM_GET_API_VERSION		1
+#define PM_GET_DEVICE_STATUS		3
+#define PM_GET_OP_CHARACTERISTIC	4
+#define PM_REGISTER_NOTIFIER		5
+#define PM_REQ_SUSPEND			6
+#define PM_SELF_SUSPEND			7
+#define PM_FORCE_POWERDOWN		8
+#define PM_ABORT_SUSPEND		9
+#define PM_REQ_WAKEUP			10
+#define PM_SET_WAKEUP_SOURCE		11
+#define PM_SYSTEM_SHUTDOWN		12
+#define PM_REQUEST_DEVICE		13
+#define PM_RELEASE_DEVICE		14
+#define PM_SET_REQUIREMENT		15
+#define PM_SET_MAX_LATENCY		16
+#define PM_RESET_ASSERT			17
+#define PM_RESET_GET_STATUS		18
+#define PM_INIT_FINALIZE		21
+#define PM_GET_CHIPID			24
+#define	PM_PINCTRL_REQUEST		28
+#define	PM_PINCTRL_RELEASE		29
+#define	PM_PINCTRL_GET_FUNCTION		30
+#define	PM_PINCTRL_SET_FUNCTION		31
+#define	PM_PINCTRL_CONFIG_PARAM_GET	32
+#define	PM_PINCTRL_CONFIG_PARAM_SET	33
+#define PM_IOCTL			34
+#define PM_QUERY_DATA			35
+#define PM_CLOCK_ENABLE			36
+#define PM_CLOCK_DISABLE		37
+#define PM_CLOCK_GETSTATE		38
+#define PM_CLOCK_SETDIVIDER		39
+#define PM_CLOCK_GETDIVIDER		40
+#define PM_CLOCK_SETRATE		41
+#define PM_CLOCK_GETRATE		42
+#define PM_CLOCK_SETPARENT		43
+#define PM_CLOCK_GETPARENT		44
+#define PM_PLL_SET_PARAMETER		48
+#define PM_PLL_GET_PARAMETER		49
+#define PM_PLL_SET_MODE			50
+#define PM_PLL_GET_MODE			51
+
+struct versal_sip_payload {
+	uint32_t data[PAYLOAD_ARG_CNT];
+};
+
+static uint32_t versal_sip_call(uint32_t pm_api_id, uint32_t arg0,
+				uint32_t arg1, uint32_t arg2, uint32_t arg3,
+				struct versal_sip_payload *payload)
+{
+	struct thread_smc_args args = {
+		.a0 = PM_SIP_SVC | pm_api_id,
+		.a1 = reg_pair_to_64(arg1, arg0),
+		.a2 = reg_pair_to_64(arg3, arg2),
+	};
+
+	thread_smccc(&args);
+
+	if (payload) {
+		reg_pair_from_64(args.a0, &payload->data[1], &payload->data[0]);
+		reg_pair_from_64(args.a1, &payload->data[3], &payload->data[2]);
+		reg_pair_from_64(args.a2, &payload->data[5], &payload->data[4]);
+	}
+
+	if (IS_ENABLED(CFG_VERSAL_TRACE_PLM))
+		mdelay(1000);
+
+	return args.a0;
+}
+
+TEE_Result versal_soc_version(uint8_t *version)
+{
+	struct versal_sip_payload payload = { };
+	const uint32_t version_shift = 12;
+	uint32_t res = 0;
+
+	if (!version)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = versal_sip_call(PM_GET_CHIPID, 0, 0, 0, 0, &payload);
+	if (res) {
+		EMSG("Failed to retrieve version");
+		return TEE_ERROR_GENERIC;
+	}
+
+	*version = payload.data[2] >> version_shift;
+
+	return TEE_SUCCESS;
+}

--- a/core/include/drivers/versal_mbox.h
+++ b/core/include/drivers/versal_mbox.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Foundries.io Ltd
+ */
+#ifndef __DRIVERS_VERSAL_MBOX_H
+#define __DRIVERS_VERSAL_MBOX_H
+
+#include <platform_config.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+#define MAX_IPI_BUF 5
+
+struct ipi_buf {
+	size_t len;
+	void *p;
+};
+
+struct ipi_cmd {
+	uint32_t data[8];
+	struct ipi_buf ibuf[MAX_IPI_BUF];
+};
+
+TEE_Result versal_mbox_notify(struct ipi_cmd *cmd, struct ipi_cmd *rsp);
+
+#endif /* __DRIVERS_VERSAL_MBOX_H */

--- a/core/include/drivers/versal_nvm.h
+++ b/core/include/drivers/versal_nvm.h
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2022 Foundries.io Ltd
+ */
+
+#ifndef __DRIVERS_VERSAL_NVM_H__
+#define __DRIVERS_VERSAL_NVM_H__
+
+#include <drivers/versal_mbox.h>
+#include <platform_config.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+#include <util.h>
+
+#define EFUSE_MAX_USER_FUSES 64
+#define EFUSE_IV_LEN 12
+#define EFUSE_DNA_LEN 16
+#define EFUSE_PPK_LEN 32
+
+enum versal_nvm_iv_type {
+	EFUSE_META_HEADER_IV_RANGE = 0,
+	EFUSE_BLACK_IV,
+	EFUSE_PLM_IV_RANGE,
+	EFUSE_DATA_PARTITION_IV_RANGE
+};
+
+enum versal_nvm_ppk_type {
+	EFUSE_PPK0 = 0,
+	EFUSE_PPK1,
+	EFUSE_PPK2
+};
+
+enum versal_nvm_revocation_id {
+	EFUSE_REVOCATION_ID_0 = 0,
+	EFUSE_REVOCATION_ID_1,
+	EFUSE_REVOCATION_ID_2,
+	EFUSE_REVOCATION_ID_3,
+	EFUSE_REVOCATION_ID_4,
+	EFUSE_REVOCATION_ID_5,
+	EFUSE_REVOCATION_ID_6,
+	EFUSE_REVOCATION_ID_7
+};
+
+enum versal_nvm_offchip_id {
+	EFUSE_INVLD = -1,
+	EFUSE_OFFCHIP_REVOKE_ID_0 = 0,
+	EFUSE_OFFCHIP_REVOKE_ID_1,
+	EFUSE_OFFCHIP_REVOKE_ID_2,
+	EFUSE_OFFCHIP_REVOKE_ID_3,
+	EFUSE_OFFCHIP_REVOKE_ID_4,
+	EFUSE_OFFCHIP_REVOKE_ID_5,
+	EFUSE_OFFCHIP_REVOKE_ID_6,
+	EFUSE_OFFCHIP_REVOKE_ID_7
+};
+
+#define __aligned_efuse			__aligned(CACHELINE_LEN)
+
+TEE_Result versal_read_efuse_dna(uint32_t *buf, size_t len);
+TEE_Result versal_read_efuse_user(uint32_t *buf, size_t len, uint32_t first,
+				  size_t num);
+TEE_Result versal_read_efuse_iv(uint32_t *buf, size_t len,
+				enum versal_nvm_iv_type type);
+TEE_Result versal_read_efuse_ppk(uint32_t *buf, size_t len,
+				 enum versal_nvm_ppk_type type);
+TEE_Result versal_write_efuse_user(uint32_t *buf, size_t len,
+				   uint32_t first, size_t num);
+
+#endif /*__DRIVERS_VERSAL_NVM_H__*/

--- a/core/include/drivers/versal_pm.h
+++ b/core/include/drivers/versal_pm.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2022 Foundries.io Ltd
+ */
+
+#ifndef __DRIVERS_VERSAL_PM_H__
+#define __DRIVERS_VERSAL_PM_H__
+
+#include <platform_config.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+TEE_Result versal_soc_version(uint8_t *version);
+
+#endif /*__DRIVERS_VERSAL_PM_H__*/


### PR DESCRIPTION
The PLM firmware controls several subsystems in the Versal ACAD
platform. The NVM driver provides access to the PLM NVM subsystem interface via the MBOX interface.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
