### PR TITLE
arm: vfp_a32: check the existence of FPU NEON by CPACR

### DIFF
--- a/core/arch/arm/kernel/vfp_a32.S
+++ b/core/arch/arm/kernel/vfp_a32.S
@@ -3,6 +3,8 @@
  * Copyright (c) 2015-2016, Linaro Limited
  */
 
+#include <arm32.h>
+#include <arm32_macros.S>
 #include <asm.S>
 
 	.fpu	neon
@@ -10,6 +12,9 @@
 /* void vfp_save_extension_regs(uint64_t regs[VFP_NUM_REGS]); */
 FUNC vfp_save_extension_regs , :
 	vstm	r0!, {d0-d15}
+	read_cpacr r1
+	tst	r1, #CPACR_D32DIS
+	bxne	lr
 	vstm	r0, {d16-d31}
 	bx	lr
 END_FUNC vfp_save_extension_regs
@@ -17,6 +22,9 @@ END_FUNC vfp_save_extension_regs
 /* void vfp_restore_extension_regs(uint64_t regs[VFP_NUM_REGS]); */
 FUNC vfp_restore_extension_regs , :
 	vldm	r0!, {d0-d15}
+	read_cpacr r1
+	tst	r1, #CPACR_D32DIS
+	bxne	lr
 	vldm	r0, {d16-d31}
 	bx	lr
 END_FUNC vfp_restore_extension_regs


### PR DESCRIPTION
Almost all Cortex-A processors come with a Floating-Point Unit (FPU)
and most also have a NEON unit. However, use of registers D16-D31 of
the VFP register file depends on the processor's FPU implementation.

Arm coprocessor access control register (CPACR.D32DIS) indicates if
FPU and Advanced SIMD is implemented. Check this bit to see if the
processor is supported or not.

Signed-off-by: Neal Liu <neal_liu@aspeedtech.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
-----------------
Fix the issue of undefined instruction abort.
```
E/LD:  Call stack:
E/LD:   0x40112710
  regression_1010.4 OK
o regression_1010.5 Invalid memory access 5
E/TC:0 0
E/TC:0 0 Core undef-abort at address 0x88002fd4
E/TC:0 0  fsr 0x00000000  ttbr0 0x8806786a  ttbr1 0x8806006a  cidr 0x2
E/TC:0 0  cpu #0          cpsr 0x400001df
E/TC:0 0  r0 0x880416c8      r4 0x00000000    r8 0x001510c0   r12 0xfffd4e40
E/TC:0 0  r1 0x00000001      r5 0x88041640    r9 0x00112730    sp 0x880684a8
E/TC:0 0  r2 0x00000000      r6 0x00000000   r10 0x0000000a    lr 0x88002fb7
E/TC:0 0  r3 0x00000000      r7 0x00112740   r11 0x00235708    pc 0x88002fd4
E/TC:0 0 TEE load address @ 0x88000000
E/TC:0 0 Call stack:
E/TC:0 0  0x88002fd4
E/TC:0 0  0x88002fb7
E/TC:0 0 Panic '[abort] abort in abort handler (trap CPU)' at core/arch/arm/kernel/abort.c:468 <get_fault_type>
```