### PR TITLE
MAINTAINERS: Updates related to GitHub IDs and email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,8 +10,8 @@ MAINTAINER file for the description of section entries [1].
 Note that OP-TEE development mainly occurs on GitHub [2] so this file should be
 used a bit differently compared to the Linux MAINTAINERS file:
 
-1. GitHub accounts or team names may be given in square brackets, starting with
-an @ sign. For example, [@jbech-linaro] or [@OP-TEE/linaro].
+1. GitHub accounts may be given in square brackets, starting with an @ sign.
+For example, [@jbech-linaro].
 
 2. Patches should generally be submitted as GitHub pull requests (more details
 in documentation/github.md). Therefore, please do NOT send patches to the
@@ -33,14 +33,12 @@ basis (R:).
 ----------
 
 ARM Foundation FVP
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
-R:	[@OP-TEE/plat-vexpress]
+R:	Jens Wiklander <jens.wiklander@linaro.org> [@jenswi-linaro]
 S:	Maintained
 F:	core/arch/arm/plat-vexpress/
 
 ARM Juno
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
-R:	[@OP-TEE/plat-vexpress]
+R:	Jens Wiklander <jens.wiklander@linaro.org> [@jenswi-linaro]
 S:	Maintained
 F:	core/arch/arm/plat-vexpress/
 
@@ -61,7 +59,6 @@ F:	core/arch/arm/plat-amlogic/
 
 Atmel ATSAMA5D2-XULT
 R:	Akshay Bhat <akshay.bhat@timesys.com> [@nodeax]
-R:	[@OP-TEE/plat-sam]
 S:	Maintained
 F:	core/arch/arm/plat-sam/
 
@@ -71,17 +68,17 @@ S:	Orphan
 F:	core/arch/arm/plat-bcm/
 
 Core Drivers I2C
-R:	Jorge Ramirez <jorge@foundries.io>
+R:	Jorge Ramirez <jorge@foundries.io> [@ldts]
 S:	Maintained
 F:	core/drivers/imx_i2c.c
 
 Core Drivers RNGB
-R:	Jorge Ramirez <jorge@foundries.io>
+R:	Jorge Ramirez <jorge@foundries.io> [@ldts]
 S:	Maintained
 F:	core/drivers/imx_rngb.c
 
 Core Drivers SE050
-R:	Jorge Ramirez <jorge@foundries.io>
+R:	Jorge Ramirez <jorge@foundries.io> [@ldts]
 S:	Maintained
 F:	core/drivers/crypto/se050
 
@@ -101,20 +98,16 @@ F:	ldelf/ftrace.c
 F:	lib/libutils/ext/ftrace/
 
 HiSilicon D02
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
-S:	Maintained
+S:	Orphan
 F:	core/arch/arm/plat-d02/
 
 HiSilicon HiKey (Kirin 620), HiKey960 (Kirin 960)
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
-R:	[@OP-TEE/plat-hikey]
+R:	Jerome Forissier <jerome.forissier@linaro.org> [@jforissier]
 S:	Maintained
 F:	core/arch/arm/plat-hikey/
 
 HiSilicon Poplar (Hi3798C V200)
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
 R:	Igor Opaniuk <igor.opaniuk@gmail.com> [@igoropaniuk]
-R:	[@OP-TEE/plat-poplar]
 S:	Maintained
 F:	core/arch/arm/plat-poplar/
 
@@ -125,7 +118,6 @@ F:	core/arch/arm/plat-hisilicon
 
 Marvell Armada 70x0, Armada 80x0, Armada 3700, OcteonTX2 CN96XX, OcteonTX2 CFN95XX, OcteonTX2 CN98XX
 R:	Tao Lu <taolu@marvell.com> [@taovcu]
-R:	[@OP-TEE/plat-ls]
 S:	Maintained
 F:	core/arch/arm/plat-marvell/
 
@@ -136,22 +128,21 @@ F:	core/arch/arm/plat-mediatek/
 NXP LS1021A, LS1043A-RDB, LS1046A-RDB, LS1012A-RDB, LS1012A-FRWY, LS1028A-RDB, LS1088A-RDB, LS2088A-RDB, LX2160A-RDB, LX2160A-QDS
 R:	Pankaj Gupta <pankaj.gupta@nxp.com> [@pangupta]
 R:	Sahil Malhotra <sahil.malhotra@nxp.com> [@sahilnxp]
-R:	[@OP-TEE/plat-ls]
 S:	Maintained
 F:	core/arch/arm/plat-ls/
 
 Core Drivers I2C
-R:	Sahil Malhotra <sahil.malhotra@nxp.com>
+R:	Sahil Malhotra <sahil.malhotra@nxp.com> [@sahilnxp]
 S:	Maintained
 F:	core/drivers/ls_i2c.c
 
 LS Core Drivers GPIO
-R:	Sahil Malhotra <sahil.malhotra@nxp.com>
+R:	Sahil Malhotra <sahil.malhotra@nxp.com> [@sahilnxp]
 S:	Maintained
 F:	core/drivers/ls_gpio.c
 
 LS Core Drivers DSPI
-R:	Sahil Malhotra <sahil.malhotra@nxp.com>
+R:	Sahil Malhotra <sahil.malhotra@nxp.com> [@sahilnxp]
 S:	Maintained
 F:	core/drivers/ls_dspi.c
 
@@ -160,7 +151,6 @@ R:	Peng Fan <peng.fan@nxp.com> [@MrVan]
 R:	Cedric Neveux <cedric.neveux@nxp.com> [@cneveux]
 R:	Silvano Di Ninno <silvano.dininno@nxp.com> [@sdininno]
 R:	Clement Faure <clement.faure@nxp.com> [@clementfaure]
-R:	[@OP-TEE/plat-imx]
 S:	Maintained
 F:	core/arch/arm/plat-imx/
 F:	core/arch/arm/plat-imx/registers
@@ -186,50 +176,44 @@ F:	core/arch/arm/plat-imx/conf.mk
 
 PKCS#11 TA
 R:	Etienne Carriere <etienne.carriere@st.com> [@etienne-lms]
-R:	Ruchika Gupta <ruchika.gupta@linaro.org> [@ruchi393]
+R:	Ruchika Gupta <gupta.ruchika@gmail.com> [@ruchi393]
 R:	Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com> [@vesajaaskelainen]
 S:	Maintained
 F:	ta/pkcs11
 
 QEMU (32 and 64 bits)
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
+R:	Jens Wiklander <jens.wiklander@linaro.org> [@jenswi-linaro]
 S:	Maintained
 F:	core/arch/arm/plat-vexpress/
 
 Raspberry Pi3
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
-R:	[@OP-TEE/rpi3]
+R:	Joakim Bech <joakim.bech@linaro.org> [@jbech-linaro]
 S:	Maintained
 F:	core/arch/arm/plat-rpi3/
 
 Renesas RCAR
 R:	Volodymyr Babchuk <vlad.babchuk@gmail.com> [@lorc]
-R:	[@OP-TEE/plat-rcar]
 S:	Maintained
 F:	core/arch/arm/plat-rcar/
 
 Renesas RZ/G2
 R:	Lad Prabhakar <prabhakar.mahadev-lad.rj@bp.renesas.com> [@prabhakarlad]
 R:	Biju Das <biju.das.jz@bp.renesas.com> [@bijucdas]
-R:	[@OP-TEE/plat-rzg]
 S:	Maintained
 F:	core/arch/arm/plat-rzg/
 
 Renesas RZ/N1
 R:	Sumit Garg <sumit.garg@linaro.org> [@b49020]
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
 S:	Maintained
 F:	core/arch/arm/plat-rzn1/
 
 Rockchip RK322X
 R:	Rockchip <op-tee@rock-chips.com>
-R:	[@OP-TEE/plat-rockchip]
 S:	Maintained
 F:	core/arch/arm/plat-rockchip/
 
 Socionext DeveloperBox (Synquacer SC2A11)
 R:	Sumit Garg <sumit.garg@linaro.org> [@b49020]
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
 S:	Maintained
 F:	core/arch/arm/plat-synquacer/
 
@@ -240,24 +224,21 @@ S:	Maintained
 F:	core/arch/arm/plat-uniphier/
 
 Spreadtrum SC9860
-R:	Aijun Sun <aijun.sun@unisoc.com>
-R:	[@OP-TEE/plat-sprd]
-S:	Maintained
+S:	Orphan
 F:	core/arch/arm/plat-sprd/
 
 STMicroelectronics b2260-h410, b2120-h310/h410
-R:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
-R:	[@OP-TEE/plat-stm]
+R:	Etienne Carriere <etienne.carriere@linaro.org> [@etienne-lms]
 S:	Maintained
 F:	core/arch/arm/plat-stm/
 
 STMicroelectronics stm32mp1
-R:	Etienne Carriere <etienne.carriere@st.com>
+R:	Etienne Carriere <etienne.carriere@st.com> [@etienne-lms]
 S:	Maintained
 F:	core/arch/arm/plat-stm32mp1/
 
 Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x, J721E
-R:	[@OP-TEE/plat-ti]
+R:	Andrew Davis <afd@ti.com> [@glneo]
 S:	Maintained
 F:	core/arch/arm/plat-ti/
 F:	core/arch/arm/plat-k3/
@@ -265,7 +246,6 @@ F:	core/arch/arm/plat-k3/
 Xilinx Zynq 7000 ZC702 Board
 R:	Yan Yan <yan.yan@windriver.com>
 R:	Feng Yu <Yu.Feng@windriver.com>
-R:	[@OP-TEE/plat-zynq7k]
 S:	Maintained
 F:	core/arch/arm/plat-zynq7k/
 
@@ -280,14 +260,13 @@ S:	Maintained
 F:	core/arch/arm/plat-versal/
 
 Virtualization support
-R:	Volodymyr Babchuk <vlad.babchuk@gmail.com>
+R:	Volodymyr Babchuk <vlad.babchuk@gmail.com> [@lorc]
 S:	Maintained
 F:	core/arch/arm/kernel/virtualization.c
 
 Aspeed AST2600
 R:	Chia-Wei Wang <chiawei_wang@aspeedtech.com> [@ChiaweiW]
 R:	Neal Liu <neal_liu@aspeedtech.com> [@Neal-liu]
-R:	[@OP-TEE/plat-aspeed]
 S:	Maintained
 F:	core/arch/arm/plat-aspeed/
 
@@ -295,7 +274,6 @@ THE REST
 M:	Joakim Bech <joakim.bech@linaro.org> [@jbech-linaro]
 M:	Jens Wiklander <jens.wiklander@linaro.org> [@jenswi-linaro]
 M:	Jerome Forissier <jerome.forissier@linaro.org> [@jforissier]
-M:	Linaro <op-tee@linaro.org> [@OP-TEE/linaro]
 R:	Etienne Carriere <etienne.carriere@linaro.org> [@etienne-lms]
 L:	op-tee@lists.trustedfirmware.org
 S:	Maintained


### PR DESCRIPTION
- Update the MAINTAINERS file to reflect the removal of GitHub team
  names. The GitHub team ID's weren't used much, hence we agreed to
  delete them.

- Add individual reviewers to platforms that previously just had a
  GitHub team.

- Add missing GitHub ID's to some individuals names.

- Update email addresses to some individuals that have change email
  address.

- Mark the Spreadtrum SC9860 platform as Orphan.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
