### PR TITLE
plat-k3: Setup HUK for K3 HS Generic SOCs

### DIFF
--- a/core/arch/arm/plat-k3/drivers/sec_proxy.c
+++ b/core/arch/arm/plat-k3/drivers/sec_proxy.c
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Texas Instruments K3 Secure Proxy Driver
+ *
+ * Copyright (C) 2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Manorit Chawdhry <m-chawdhry@ti.com>
+ */
+
+#include <io.h>
+#include <kernel/delay.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <trace.h>
+
+#include "sec_proxy.h"
+
+/* SEC PROXY RT THREAD STATUS */
+#define RT_THREAD_STATUS_REG            0x0
+#define RT_THREAD_STATUS_ERROR_MASK     BIT(31)
+#define RT_THREAD_STATUS_CUR_CNT_MASK   GENMASK_32(7, 0)
+
+/* SEC PROXY SCFG THREAD CTRL */
+#define SCFG_THREAD_CTRL_REG            0x1000
+#define SCFG_THREAD_CTRL_DIR_SHIFT      31
+#define SCFG_THREAD_CTRL_DIR_MASK       BIT(31)
+
+/* SECURE PROXY GENERIC HELPERS */
+enum threads {
+	SEC_PROXY_TX_THREAD,
+	SEC_PROXY_RX_THREAD,
+	SEC_PROXY_MAX_THREADS
+};
+
+#define SEC_PROXY_THREAD(base, x)       ((base) + (0x1000 * (x)))
+#define SEC_PROXY_DATA_START_OFFS       0x4
+#define SEC_PROXY_DATA_END_OFFS         0x3c
+
+#define THREAD_DIR_TX (0)
+#define THREAD_DIR_RX (1)
+
+/**
+ * struct k3_sec_proxy_thread - Description of a Secure Proxy Thread
+ * @id:		Thread ID
+ * @data:	Thread Data path region for target
+ * @scfg:	Secure Config Region for Thread
+ * @rt:		RealTime Region for Thread
+ */
+struct k3_sec_proxy_thread {
+	const char *name;
+	vaddr_t data;
+	vaddr_t scfg;
+	vaddr_t rt;
+} spts[SEC_PROXY_MAX_THREADS];
+
+/**
+ * k3_sec_proxy_verify_thread() - Verify thread status before
+ *				  sending/receiving data
+ * @dir: Direction of the thread
+ */
+static TEE_Result k3_sec_proxy_verify_thread(uint32_t dir)
+{
+	struct k3_sec_proxy_thread *spt = &spts[dir];
+	uint64_t timeout = 0;
+	uint32_t val = 0;
+	unsigned int retry = 2;
+
+	FMSG("Check for thread corruption");
+	val = io_read32(spt->rt + RT_THREAD_STATUS_REG);
+
+	/* Check for any errors already available */
+	while ((val & RT_THREAD_STATUS_ERROR_MASK) && retry--) {
+		if (!retry) {
+			EMSG("Thread %s is corrupted, cannot send data.",
+			     spt->name);
+			return TEE_ERROR_BAD_STATE;
+		}
+
+		/* Write Bit 0 to this location */
+		IMSG("Resetting proxy thread %s", spt->name);
+		val ^= RT_THREAD_STATUS_ERROR_MASK;
+		io_write32(spt->rt + RT_THREAD_STATUS_REG, val);
+	}
+
+	FMSG("Check for thread direction");
+	/* Make sure thread is configured for right direction */
+	if ((io_read32(spt->scfg + SCFG_THREAD_CTRL_REG) &
+	     SCFG_THREAD_CTRL_DIR_MASK) >> SCFG_THREAD_CTRL_DIR_SHIFT != dir) {
+		if (dir == SEC_PROXY_TX_THREAD)
+			EMSG("Trying to receive data on tx Thread %s",
+			     spt->name);
+		else
+			EMSG("Trying to send data on rx Thread %s", spt->name);
+		return TEE_ERROR_COMMUNICATION;
+	}
+
+	FMSG("Check for thread queue");
+	/* Check the message queue before sending/receiving data */
+	timeout = timeout_init_us(SEC_PROXY_TIMEOUT_US);
+	while (!(io_read32(spt->rt + RT_THREAD_STATUS_REG) &
+		 RT_THREAD_STATUS_CUR_CNT_MASK)) {
+		DMSG("Waiting for thread %s to %s", spt->name,
+		     (dir == THREAD_DIR_TX) ? "empty" : "fill");
+		if (timeout_elapsed(timeout)) {
+			EMSG("Queue is busy");
+			return TEE_ERROR_BUSY;
+		}
+	}
+
+	FMSG("Success");
+	return TEE_SUCCESS;
+}
+
+/**
+ * k3_sec_proxy_send() - Send data over a Secure Proxy thread
+ * @msg: Pointer to k3_sec_proxy_msg
+ */
+TEE_Result k3_sec_proxy_send(const struct k3_sec_proxy_msg *msg)
+{
+	struct k3_sec_proxy_thread *spt = &spts[SEC_PROXY_TX_THREAD];
+	int num_words = 0;
+	int trail_bytes = 0;
+	int i = 0;
+	uintptr_t data_reg = 0;
+	uint32_t data_word = 0;
+	TEE_Result ret = TEE_SUCCESS;
+
+	FMSG("Verifying the thread");
+	ret = k3_sec_proxy_verify_thread(THREAD_DIR_TX);
+	if (ret) {
+		EMSG("Thread %s verification failed. ret = %d", spt->name, ret);
+		return ret;
+	}
+
+	/* Check the message size. */
+	if (msg->len > SEC_PROXY_MAX_MSG_SIZE) {
+		EMSG("Thread %s message length %zu > max msg size %d",
+		     spt->name, msg->len, SEC_PROXY_MAX_MSG_SIZE);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	/* Send the message */
+	data_reg = spt->data + SEC_PROXY_DATA_START_OFFS;
+	num_words = msg->len / sizeof(uint32_t);
+	for (i = 0; i < num_words; i++) {
+		memcpy(&data_word, &msg->buf[i * 4], sizeof(uint32_t));
+		io_write32(data_reg, data_word);
+		data_reg += sizeof(uint32_t);
+	}
+
+	trail_bytes = msg->len % sizeof(uint32_t);
+	if (trail_bytes) {
+		uint32_t data_trail = 0;
+
+		i = msg->len - trail_bytes;
+		while (trail_bytes--) {
+			data_trail <<= 8;
+			data_trail |= msg->buf[i++];
+		}
+
+		io_write32(data_reg, data_trail);
+		data_reg += sizeof(uint32_t);
+	}
+
+	/*
+	 * 'data_reg' indicates next register to write. If we did not already
+	 * write on tx complete reg(last reg), we must do so for transmit
+	 */
+	if (data_reg <= (spt->data + SEC_PROXY_DATA_END_OFFS))
+		io_write32(spt->data + SEC_PROXY_DATA_END_OFFS, 0);
+
+	return TEE_SUCCESS;
+}
+
+/**
+ * k3_sec_proxy_recv() - Receive data from a Secure Proxy thread
+ * @msg: Pointer to k3_sec_proxy_msg
+ */
+TEE_Result k3_sec_proxy_recv(struct k3_sec_proxy_msg *msg)
+{
+	struct k3_sec_proxy_thread *spt = &spts[SEC_PROXY_RX_THREAD];
+	int num_words = 0;
+	int i = 0;
+	int trail_bytes = 0;
+	uint32_t data_trail = 0;
+	uint32_t data_word = 0;
+	uintptr_t data_reg = 0;
+	TEE_Result ret = TEE_SUCCESS;
+
+	FMSG("Verifying thread");
+	ret = k3_sec_proxy_verify_thread(THREAD_DIR_RX);
+	if (ret) {
+		EMSG("Thread %s verification failed. ret = %d", spt->name, ret);
+		return ret;
+	}
+
+	/* Receive the message */
+	data_reg = spt->data + SEC_PROXY_DATA_START_OFFS;
+	num_words = msg->len / sizeof(uint32_t);
+	for (i = 0; i < num_words; i++) {
+		data_word = io_read32(data_reg);
+		memcpy(&msg->buf[i * 4], &data_word, sizeof(uint32_t));
+		data_reg += sizeof(uint32_t);
+	}
+
+	trail_bytes = msg->len % sizeof(uint32_t);
+	if (trail_bytes) {
+		data_trail = io_read32(data_reg);
+		data_reg += sizeof(uint32_t);
+
+		i = msg->len - trail_bytes;
+		while (trail_bytes--) {
+			msg->buf[i] = data_trail & 0xff;
+			data_trail >>= 8;
+		}
+	}
+
+	/*
+	 * 'data_reg' indicates next register to read. If we did not already
+	 * read on rx complete reg(last reg), we must do so for receive
+	 */
+	if (data_reg <= (spt->data + SEC_PROXY_DATA_END_OFFS))
+		io_read32(spt->data + SEC_PROXY_DATA_END_OFFS);
+
+	return TEE_SUCCESS;
+}
+
+/**
+ * k3_sec_proxy_init() - Initialize the secure proxy threads
+ */
+TEE_Result k3_sec_proxy_init(void)
+{
+	struct k3_sec_proxy_thread *thread;
+	int rx_thread = SEC_PROXY_RESPONSE_THREAD;
+	int tx_thread = SEC_PROXY_REQUEST_THREAD;
+	uint32_t target_data = 0;
+	uint32_t cfg_scfg = 0;
+	uint32_t cfg_rt = 0;
+
+	DMSG("tx_thread: %d, rx_thread: %d", tx_thread, rx_thread);
+
+	/* TX_THREAD */
+	target_data = SEC_PROXY_THREAD(SEC_PROXY_DATA_BASE, tx_thread);
+	cfg_scfg = SEC_PROXY_THREAD(SEC_PROXY_SCFG_BASE, tx_thread);
+	cfg_rt = SEC_PROXY_THREAD(SEC_PROXY_RT_BASE, tx_thread);
+
+	thread = &spts[SEC_PROXY_TX_THREAD];
+	thread->name = "SEC_PROXY_LOW_PRIORITY_THREAD";
+
+	thread->data = core_mmu_get_va(target_data, MEM_AREA_IO_SEC,
+				       SEC_PROXY_DATA_SIZE);
+	if (!thread->data)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	thread->scfg = core_mmu_get_va(cfg_scfg, MEM_AREA_IO_SEC,
+				       SEC_PROXY_SCFG_SIZE);
+	if (!thread->scfg)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	thread->rt = core_mmu_get_va(cfg_rt, MEM_AREA_IO_SEC,
+				     SEC_PROXY_RT_SIZE);
+	if (!thread->rt)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	/* RX_THREAD */
+	target_data = SEC_PROXY_THREAD(SEC_PROXY_DATA_BASE, rx_thread);
+	cfg_scfg = SEC_PROXY_THREAD(SEC_PROXY_SCFG_BASE, rx_thread);
+	cfg_rt = SEC_PROXY_THREAD(SEC_PROXY_RT_BASE, rx_thread);
+
+	thread = &spts[SEC_PROXY_RX_THREAD];
+	thread->name = "SEC_PROXY_RESPONSE_THREAD";
+
+	thread->data = core_mmu_get_va(target_data, MEM_AREA_IO_SEC,
+				       SEC_PROXY_DATA_SIZE);
+	if (!thread->data)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	thread->scfg = core_mmu_get_va(cfg_scfg, MEM_AREA_IO_SEC,
+				       SEC_PROXY_SCFG_SIZE);
+	if (!thread->scfg)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	thread->rt = core_mmu_get_va(cfg_rt, MEM_AREA_IO_SEC,
+				     SEC_PROXY_RT_SIZE);
+	if (!thread->rt)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	return TEE_SUCCESS;
+}

--- a/core/arch/arm/plat-k3/drivers/sec_proxy.h
+++ b/core/arch/arm/plat-k3/drivers/sec_proxy.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Texas Instruments K3 Secure Proxy Driver
+ *
+ * Copyright (C) 2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Manorit Chawdhry <m-chawdhry@ti.com>
+ */
+
+#ifndef SEC_PROXY_H
+#define SEC_PROXY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+#define SEC_PROXY_MAX_MSG_SIZE 60
+
+/**
+ * struct k3_sec_proxy_msg - Secure proxy message structure
+ * @len: Length of data in the Buffer
+ * @buf: Buffer pointer
+ *
+ * This is the structure for data used in k3_sec_proxy_{send,recv}()
+ */
+struct k3_sec_proxy_msg {
+	size_t len;
+	uint8_t *buf;
+};
+
+/**
+ * k3_sec_proxy_send() - Send data over a Secure Proxy thread
+ * @msg: Pointer to k3_sec_proxy_msg
+ */
+TEE_Result k3_sec_proxy_send(const struct k3_sec_proxy_msg *msg);
+
+/**
+ * k3_sec_proxy_recv() - Receive data from a Secure Proxy thread
+ * @msg: Pointer to k3_sec_proxy_msg
+ */
+TEE_Result k3_sec_proxy_recv(struct k3_sec_proxy_msg *msg);
+
+/**
+ * k3_sec_proxy_init() - Initialize the secure proxy threads
+ */
+TEE_Result k3_sec_proxy_init(void);
+
+#endif /* __SEC_PROXY_H */

--- a/core/arch/arm/plat-k3/drivers/sub.mk
+++ b/core/arch/arm/plat-k3/drivers/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += sec_proxy.c

--- a/core/arch/arm/plat-k3/drivers/sub.mk
+++ b/core/arch/arm/plat-k3/drivers/sub.mk
@@ -1,1 +1,2 @@
 srcs-y += sec_proxy.c
+srcs-y += ti_sci.c

--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Texas Instruments System Control Interface Driver
+ *   Based on TF-A implementation
+ *
+ * Copyright (C) 2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Manorit Chawdhry <m-chawdhry@ti.com>
+ */
+
+#include <malloc.h>
+#include <platform_config.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee_api_defines.h>
+#include <trace.h>
+
+#include "sec_proxy.h"
+#include "ti_sci.h"
+#include "ti_sci_protocol.h"
+
+static uint8_t message_sequence;
+
+/**
+ * struct ti_sci_xfer - Structure representing a message flow
+ * @tx_message:	Transmit message
+ * @rx_message:	Receive message
+ */
+struct ti_sci_xfer {
+	struct k3_sec_proxy_msg tx_message;
+	struct k3_sec_proxy_msg rx_message;
+};
+
+/**
+ * ti_sci_setup_xfer() - Setup message transfer
+ *
+ * @msg_type:	Message type
+ * @msg_flags:	Flag to set for the message
+ * @tx_buf:	Buffer to be sent to mailbox channel
+ * @tx_message_size: transmit message size
+ * @rx_buf:	Buffer to be received from mailbox channel
+ * @rx_message_size: receive message size
+ * @xfer:	Transfer message
+ *
+ * Helper function which is used by various command functions that are
+ * exposed to clients of this driver for allocating a message traffic event.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+static int ti_sci_setup_xfer(uint16_t msg_type, uint32_t msg_flags,
+			     void *tx_buf,
+			     size_t tx_message_size,
+			     void *rx_buf,
+			     size_t rx_message_size,
+			     struct ti_sci_xfer *xfer)
+{
+	struct ti_sci_msg_hdr *hdr = NULL;
+
+	/* Ensure we have sane transfer sizes */
+	if (rx_message_size > SEC_PROXY_MAX_MSG_SIZE ||
+	    tx_message_size > SEC_PROXY_MAX_MSG_SIZE ||
+	    rx_message_size < sizeof(*hdr) ||
+	    tx_message_size < sizeof(*hdr)) {
+		EMSG("Message transfer size not sane");
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	hdr = (struct ti_sci_msg_hdr *)tx_buf;
+	hdr->seq = ++message_sequence;
+	hdr->type = msg_type;
+	hdr->host = OPTEE_HOST_ID;
+	hdr->flags = msg_flags | TI_SCI_FLAG_REQ_ACK_ON_PROCESSED;
+
+	xfer->tx_message.buf = tx_buf;
+	xfer->tx_message.len = tx_message_size;
+
+	xfer->rx_message.buf = rx_buf;
+	xfer->rx_message.len = rx_message_size;
+
+	return 0;
+}
+
+/**
+ * ti_sci_get_response() - Receive response from mailbox channel
+ *
+ * @xfer:	Transfer to initiate and wait for response
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+static inline int ti_sci_get_response(struct ti_sci_xfer *xfer)
+{
+	struct k3_sec_proxy_msg *msg = &xfer->rx_message;
+	struct ti_sci_msg_hdr *hdr = NULL;
+	unsigned int retry = 5;
+	int ret = 0;
+
+	for (; retry > 0; retry--) {
+		/* Receive the response */
+		ret = k3_sec_proxy_recv(msg);
+		if (ret) {
+			EMSG("Message receive failed (%d)", ret);
+			return ret;
+		}
+
+		/* msg is updated by Secure Proxy driver */
+		hdr = (struct ti_sci_msg_hdr *)msg->buf;
+
+		/* Sanity check for message response */
+		if (hdr->seq == message_sequence)
+			break;
+
+		IMSG("Message with sequence ID %u is not expected", hdr->seq);
+	}
+	if (!retry) {
+		EMSG("Timed out waiting for message");
+		return TEE_ERROR_BUSY;
+	}
+
+	if (!(hdr->flags & TI_SCI_FLAG_RESP_GENERIC_ACK)) {
+		EMSG("Message not acknowledged");
+		return TEE_ERROR_GENERIC;
+	}
+
+	return 0;
+}
+
+/**
+ * ti_sci_do_xfer() - Do one transfer
+ *
+ * @xfer: Transfer to initiate and wait for response
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+static inline int ti_sci_do_xfer(struct ti_sci_xfer *xfer)
+{
+	struct k3_sec_proxy_msg *msg = &xfer->tx_message;
+	int ret = 0;
+
+	/* Send the message */
+	ret = k3_sec_proxy_send(msg);
+	if (ret) {
+		EMSG("Message sending failed (%d)", ret);
+		return ret;
+	}
+
+	/* Get the response */
+	ret = ti_sci_get_response(xfer);
+	if (ret) {
+		EMSG("Failed to get response (%d)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * ti_sci_get_revision() - Get the revision of the SCI entity
+ *
+ * Updates the SCI information in the internal data structure.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_revision(struct ti_sci_msg_resp_version *rev_info)
+{
+	struct ti_sci_msg_req_version req = { };
+	struct ti_sci_xfer xfer = { };
+	int ret = 0;
+
+	ret = ti_sci_setup_xfer(TI_SCI_MSG_VERSION, 0x0,
+				&req, sizeof(req),
+				rev_info, sizeof(*rev_info),
+				&xfer);
+	if (ret)
+		return ret;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+/**
+ * ti_sci_init() - Basic initialization
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_init(void)
+{
+	struct ti_sci_msg_resp_version rev_info = { };
+	int ret = 0;
+
+	ret = ti_sci_get_revision(&rev_info);
+	if (ret) {
+		EMSG("Unable to communicate with control firmware (%d)", ret);
+		return ret;
+	}
+
+	IMSG("SYSFW ABI: %d.%d (firmware rev 0x%04x '%s')",
+	     rev_info.abi_major, rev_info.abi_minor,
+	     rev_info.firmware_revision,
+	     rev_info.firmware_description);
+
+	return 0;
+}

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Manorit Chawdhry <m-chawdhry@ti.com>
+ */
+
+#ifndef TI_SCI_H
+#define TI_SCI_H
+
+#include <compiler.h>
+#include <stdint.h>
+#include <util.h>
+
+#include "ti_sci_protocol.h"
+
+/**
+ * ti_sci_get_revision() - Get the revision of the SCI entity
+ *
+ * Updates the SCI information in the internal data structure.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_revision(struct ti_sci_msg_resp_version *rev_info);
+
+/**
+ * ti_sci_init() - Basic initialization
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_init(void);
+
+#endif

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -23,6 +23,21 @@
 int ti_sci_get_revision(struct ti_sci_msg_resp_version *rev_info);
 
 /**
+ * ti_sci_get_dkek() - Get the DKEK
+ * @sa2ul_instance:	SA2UL instance to get key
+ * @context:		Context string input to KDF
+ * @label:		Label string input to KDF
+ * @dkek:		Returns with DKEK populated
+ *
+ * Updates the DKEK the internal data structure.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_dkek(uint8_t sa2ul_instance,
+		    const char *context, const char *label,
+		    uint8_t dkek[SA2UL_DKEK_KEY_LEN]);
+
+/**
  * ti_sci_init() - Basic initialization
  *
  * Return: 0 if all goes well, else appropriate error message

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2016-2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Lokesh Vutla <lokeshvutla@ti.com>
+ *	Manorit Chawdhry <m-chawdhry@ti.com>
+ */
+
+#ifndef TI_SCI_PROTOCOL_H
+#define TI_SCI_PROTOCOL_H
+
+#include <compiler.h>
+#include <stdint.h>
+#include <util.h>
+
+/* Generic Messages */
+#define TI_SCI_MSG_VERSION               0x0002
+
+/**
+ * struct ti_sci_secure_msg_hdr - Secure Message Header for All messages
+ *				 and responses
+ *
+ * @checksum:	Integrity check for HS devices
+ * @reserved:	Reserved for future uses
+ */
+struct ti_sci_secure_msg_hdr {
+	uint16_t checksum;
+	uint16_t reserved;
+} __packed;
+
+/**
+ * struct ti_sci_msg_hdr - Generic Message Header for All messages and responses
+ * @type:	Type of messages: One of TI_SCI_MSG* values
+ * @host:	Host of the message
+ * @seq:	Message identifier indicating a transfer sequence
+ * @flags:	Flag for the message
+ */
+struct ti_sci_msg_hdr {
+	struct ti_sci_secure_msg_hdr sec_hdr;
+	uint16_t type;
+	uint8_t host;
+	uint8_t seq;
+#define TI_SCI_MSG_FLAG(val)			BIT(val)
+#define TI_SCI_FLAG_REQ_GENERIC_NORESPONSE	0x0
+#define TI_SCI_FLAG_REQ_ACK_ON_RECEIVED		TI_SCI_MSG_FLAG(0)
+#define TI_SCI_FLAG_REQ_ACK_ON_PROCESSED	TI_SCI_MSG_FLAG(1)
+#define TI_SCI_FLAG_RESP_GENERIC_NACK		0x0
+#define TI_SCI_FLAG_RESP_GENERIC_ACK		TI_SCI_MSG_FLAG(1)
+	/* Additional Flags */
+	uint32_t flags;
+} __packed;
+
+/**
+ * struct ti_sci_msg_version_req - Request for firmware version information
+ * @hdr:	Generic header
+ *
+ * Request for TI_SCI_MSG_VERSION
+ */
+struct ti_sci_msg_req_version {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_version - Response for firmware version information
+ * @hdr:		Generic header
+ * @firmware_description: String describing the firmware
+ * @firmware_revision:	Firmware revision
+ * @abi_major:		Major version of the ABI that firmware supports
+ * @abi_minor:		Minor version of the ABI that firmware supports
+ * @sub_version:	Sub-version number of the firmware
+ * @patch_version:	Patch-version number of the firmware.
+ *
+ * In general, ABI version changes follow the rule that minor version increments
+ * are backward compatible. Major revision changes in ABI may not be
+ * backward compatible.
+ *
+ * Response to request TI_SCI_MSG_VERSION
+ */
+struct ti_sci_msg_resp_version {
+	struct ti_sci_msg_hdr hdr;
+#define FIRMWARE_DESCRIPTION_LENGTH 32
+	char firmware_description[FIRMWARE_DESCRIPTION_LENGTH];
+	uint16_t firmware_revision;
+	uint8_t abi_major;
+	uint8_t abi_minor;
+	uint8_t sub_version;
+	uint8_t patch_version;
+} __packed;
+
+#endif

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -15,6 +15,9 @@
 /* Generic Messages */
 #define TI_SCI_MSG_VERSION               0x0002
 
+/* Security Management Messages */
+#define TI_SCI_MSG_SA2UL_GET_DKEK        0x9029
+
 /**
  * struct ti_sci_secure_msg_hdr - Secure Message Header for All messages
  *				 and responses
@@ -84,6 +87,38 @@ struct ti_sci_msg_resp_version {
 	uint8_t abi_minor;
 	uint8_t sub_version;
 	uint8_t patch_version;
+} __packed;
+
+/**
+ * struct ti_sci_msg_sa2ul_get_dkek_req - Request for DKEK value
+ * @hdr:			Generic header
+ * @sa2ul_instance:		SA2UL instance number - set to 0
+ * @kdf_label_len:		Length of "Label" input to KDF
+ * @kdf_context_len:		Length of "Context" input to KDF
+ * @kdf_label_and_context:	"Label" and "Context" bytes
+ *
+ * Request for TI_SCI_MSG_SA2UL_GET_DKEK
+ */
+struct ti_sci_msg_req_sa2ul_get_dkek {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t sa2ul_instance;
+	uint8_t kdf_label_len;
+	uint8_t kdf_context_len;
+#define KDF_LABEL_AND_CONTEXT_LEN_MAX 41
+	uint8_t kdf_label_and_context[KDF_LABEL_AND_CONTEXT_LEN_MAX];
+} __packed;
+
+/**
+ * struct ti_sci_msg_sa2ul_get_dkek_req - Response for DKEK value
+ * @hdr:	Generic header
+ * @dkek:	Array containing Derived KEK
+ *
+ * Response to request TI_SCI_MSG_SA2UL_GET_DKEK
+ */
+struct ti_sci_msg_resp_sa2ul_get_dkek {
+	struct ti_sci_msg_hdr hdr;
+#define SA2UL_DKEK_KEY_LEN 32
+	uint8_t dkek[SA2UL_DKEK_KEY_LEN];
 } __packed;
 
 #endif

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -24,6 +24,11 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GICC_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GICD_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 		  SERIAL8250_UART_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_DATA_BASE,
+			SEC_PROXY_DATA_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_SCFG_BASE,
+			SEC_PROXY_SCFG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_RT_BASE, SEC_PROXY_RT_SIZE);
 
 void main_init_gic(void)
 {

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -27,6 +27,27 @@
 #define GICD_OFFSET     0x0
 #define GICD_SIZE       0x10000
 #endif
+#if defined(PLATFORM_FLAVOR_am65x) || defined(PLATFORM_FLAVOR_j721e)
+#define SEC_PROXY_DATA_BASE             0x32c00000
+#define SEC_PROXY_DATA_SIZE             0x100000
+#define SEC_PROXY_SCFG_BASE             0x32800000
+#define SEC_PROXY_SCFG_SIZE             0x100000
+#define SEC_PROXY_RT_BASE               0x32400000
+#define SEC_PROXY_RT_SIZE               0x100000
+#define SEC_PROXY_RESPONSE_THREAD       6
+#define SEC_PROXY_REQUEST_THREAD        7
+#else
+#define SEC_PROXY_DATA_BASE             0x4d000000
+#define SEC_PROXY_DATA_SIZE             0x80000
+#define SEC_PROXY_SCFG_BASE             0x4a400000
+#define SEC_PROXY_SCFG_SIZE             0x80000
+#define SEC_PROXY_RT_BASE               0x4a600000
+#define SEC_PROXY_RT_SIZE               0x80000
+#define SEC_PROXY_RESPONSE_THREAD       10
+#define SEC_PROXY_REQUEST_THREAD        11
+#endif
+#define OPTEE_HOST_ID                   11
+#define SEC_PROXY_TIMEOUT_US            1000000
 #define GICC_BASE       (SCU_BASE + GICC_OFFSET)
 #define GICD_BASE       (SCU_BASE + GICD_OFFSET)
 

--- a/core/arch/arm/plat-k3/sub.mk
+++ b/core/arch/arm/plat-k3/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += .
 srcs-y += main.c
+subdirs-y += drivers


### PR DESCRIPTION
K3 HS devices have KEK embedded in them but it can't be extracted
directly due to security reasons. The system firmware provides us with a
Derived key encryption key (DKEK) which can be used for setting up the
HUK. 

For getting DKEK, we need the support of TI-SCI which in-turn
requires secure proxy driver for communicating with it. 

This patch series adds support for setting up HUK in OPTEE for 
K3 Generic SOCs.

K3 Lite devices aren't supported as of now.

Signed-off-by: Manorit Chawdhry <m-chawdhry@ti.com>