### PR TITLE
core:crypto: Add X25519 support

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -47,6 +47,10 @@ CFG_CRYPTO_ECC ?= y
 CFG_CRYPTO_SM2_PKE ?= y
 CFG_CRYPTO_SM2_DSA ?= y
 CFG_CRYPTO_SM2_KEP ?= y
+# X25519 is only supported by libtomcrypt
+ifeq ($(CFG_CRYPTOLIB_NAME),tomcrypt)
+CFG_CRYPTO_X25519 ?= y
+endif
 
 # Authenticated encryption
 CFG_CRYPTO_CCM ?= y
@@ -163,6 +167,7 @@ core-ltc-vars += SIZE_OPTIMIZATION
 core-ltc-vars += SM2_PKE
 core-ltc-vars += SM2_DSA
 core-ltc-vars += SM2_KEP
+core-ltc-vars += X25519
 # Assigned selected CFG_CRYPTO_xxx as _CFG_CORE_LTC_xxx
 $(foreach v, $(core-ltc-vars), $(eval _CFG_CORE_LTC_$(v) := $(CFG_CRYPTO_$(v))))
 _CFG_CORE_LTC_MPI := $(CFG_CORE_MBEDTLS_MPI)
@@ -186,6 +191,7 @@ _CFG_CORE_LTC_SHA512_DESC := $(CFG_CRYPTO_DSA)
 _CFG_CORE_LTC_XTS := $(CFG_CRYPTO_XTS)
 _CFG_CORE_LTC_CCM := $(CFG_CRYPTO_CCM)
 _CFG_CORE_LTC_AES_DESC := $(call cfg-one-enabled, CFG_CRYPTO_XTS CFG_CRYPTO_CCM)
+$(call force,CFG_CRYPTO_X25519,n,not supported by mbedtls)
 endif
 
 ###############################################################
@@ -226,6 +232,7 @@ _CFG_CORE_LTC_HASH := $(call ltc-one-enabled, MD5 SHA1 SHA224 SHA256 SHA384 \
 _CFG_CORE_LTC_MAC := $(call ltc-one-enabled, HMAC CMAC CBC_MAC)
 _CFG_CORE_LTC_CBC := $(call ltc-one-enabled, CBC CBC_MAC)
 _CFG_CORE_LTC_ASN1 := $(call ltc-one-enabled, RSA DSA ECC)
+_CFG_CORE_LTC_EC25519 := $(call ltc-one-enabled, X25519)
 
 ###############################################################
 # Platform independent crypto-driver configuration

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -800,6 +800,31 @@ TEE_Result crypto_acipher_sm2_kep_derive(struct ecc_keypair *my_key __unused,
 }
 #endif
 
+#if !defined(CFG_CRYPTO_X25519)
+TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *key
+								__unused,
+					       size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_gen_x25519_key(struct x25519_keypair *key __unused,
+					 size_t key_size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_x25519_shared_secret(struct x25519_keypair
+					       *private_key __unused,
+					       void *public_key __unused,
+					       void *secret __unused,
+					       unsigned long
+					       *secret_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif
+
 __weak void crypto_storage_obj_del(uint8_t *data __unused, size_t len __unused)
 {
 }

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -167,6 +167,11 @@ struct ecc_keypair {
 	const struct crypto_ecc_keypair_ops *ops; /* Key Operations */
 };
 
+struct x25519_keypair {
+	uint8_t *priv;	/* Private value */
+	uint8_t *pub;	/* Public value */
+};
+
 /*
  * Key allocation functions
  * Allocate the bignum's inside a key structure.
@@ -191,6 +196,8 @@ TEE_Result crypto_acipher_alloc_ecc_keypair(struct ecc_keypair *s,
 					    uint32_t key_type,
 					    size_t key_size_bits);
 void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s);
+TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *s,
+					       size_t key_size_bits);
 
 /*
  * Key generation functions
@@ -200,6 +207,8 @@ TEE_Result crypto_acipher_gen_dsa_key(struct dsa_keypair *key, size_t key_size);
 TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
 				     size_t xbits, size_t key_size);
 TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key, size_t key_size);
+TEE_Result crypto_acipher_gen_x25519_key(struct x25519_keypair *key,
+					 size_t key_size);
 
 TEE_Result crypto_acipher_dh_shared_secret(struct dh_keypair *private_key,
 					   struct bignum *public_key,
@@ -252,6 +261,10 @@ TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key,
 TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key,
 					  const uint8_t *src, size_t src_len,
 					  uint8_t *dst, size_t *dst_len);
+TEE_Result crypto_acipher_x25519_shared_secret(struct x25519_keypair
+					       *private_key,
+					       void *public_key, void *secret,
+					       unsigned long *secret_len);
 
 struct sm2_kep_parms {
 	uint8_t *out;

--- a/core/lib/libtomcrypt/src/pk/ec25519/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/ec25519/sub.mk
@@ -1,0 +1,2 @@
+srcs-y += ec25519_export.c
+srcs-y += tweetnacl.c

--- a/core/lib/libtomcrypt/src/pk/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/sub.mk
@@ -5,3 +5,5 @@ subdirs-$(_CFG_CORE_LTC_RSA) += pkcs1
 subdirs-$(_CFG_CORE_LTC_RSA) += rsa
 subdirs-$(_CFG_CORE_LTC_DH) += dh
 subdirs-$(_CFG_CORE_LTC_ECC) += ecc
+subdirs-$(_CFG_CORE_LTC_X25519) += ec25519
+subdirs-$(_CFG_CORE_LTC_X25519) += x25519

--- a/core/lib/libtomcrypt/src/pk/x25519/sub.mk
+++ b/core/lib/libtomcrypt/src/pk/x25519/sub.mk
@@ -1,0 +1,5 @@
+srcs-y += x25519_export.c
+srcs-y += x25519_import.c
+srcs-y += x25519_make_key.c
+srcs-y += x25519_set_key.c
+srcs-y += x25519_shared_secret.c

--- a/core/lib/libtomcrypt/src/pk/x25519/x25519_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/x25519/x25519_make_key.c
@@ -27,7 +27,6 @@ int x25519_make_key(prng_state *prng, int wprng, curve25519_key *key)
 {
    int err;
 
-   LTC_ARGCHK(prng != NULL);
    LTC_ARGCHK(key  != NULL);
 
    if ((err = prng_is_valid(wprng)) != CRYPT_OK) {

--- a/core/lib/libtomcrypt/src/sub.mk
+++ b/core/lib/libtomcrypt/src/sub.mk
@@ -6,3 +6,4 @@ subdirs-$(_CFG_CORE_LTC_ACIPHER) += math
 subdirs-y += misc
 subdirs-y += modes
 subdirs-$(_CFG_CORE_LTC_ACIPHER) += pk
+subdirs-$(_CFG_CORE_LTC_EC25519) += pk

--- a/core/lib/libtomcrypt/sub.mk
+++ b/core/lib/libtomcrypt/sub.mk
@@ -101,6 +101,8 @@ ifneq (,$(filter y,$(_CFG_CORE_LTC_SM2_DSA) $(_CFG_CORE_LTC_SM2_PKE)))
    cppflags-lib-y += -DLTC_ECC_SM2
 endif
 
+cppflags-lib-$(_CFG_CORE_LTC_X25519) += -DLTC_CURVE25519
+
 cppflags-lib-y += -DLTC_NO_PKCS
 
 cppflags-lib-y += -DLTC_DER
@@ -133,7 +135,7 @@ endif
 srcs-$(_CFG_CORE_LTC_SM2_DSA) += sm2-dsa.c
 srcs-$(_CFG_CORE_LTC_SM2_PKE) += sm2-pke.c
 srcs-$(_CFG_CORE_LTC_SM2_KEP) += sm2-kep.c
-
+srcs-$(_CFG_CORE_LTC_X25519) += x25519.c
 ifeq ($(_CFG_CORE_LTC_ACIPHER),y)
 srcs-y += mpi_desc.c
 endif

--- a/core/lib/libtomcrypt/tomcrypt.c
+++ b/core/lib/libtomcrypt/tomcrypt.c
@@ -16,7 +16,7 @@
 #include <kernel/thread.h>
 #endif
 
-#if defined(_CFG_CORE_LTC_ACIPHER)
+#if defined(_CFG_CORE_LTC_ACIPHER) || defined(_CFG_CORE_LTC_EC25519)
 /* Random generator */
 static int prng_crypto_start(prng_state *prng __unused)
 {
@@ -117,7 +117,7 @@ static void tee_ltc_reg_algs(void)
 #if defined(_CFG_CORE_LTC_SHA512) || defined(_CFG_CORE_LTC_SHA512_DESC)
 	register_hash(&sha512_desc);
 #endif
-#if defined(_CFG_CORE_LTC_ACIPHER)
+#if defined(_CFG_CORE_LTC_ACIPHER) || defined(_CFG_CORE_LTC_EC25519)
 	register_prng(&prng_crypto_desc);
 #endif
 }

--- a/core/lib/libtomcrypt/x25519.c
+++ b/core/lib/libtomcrypt/x25519.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Technology Innovation Institute (TII)
+ */
+
+#include <crypto/crypto.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee_api_types.h>
+#include <trace.h>
+#include <utee_defines.h>
+
+#include "acipher_helpers.h"
+
+/* X25519 key is an octet string of 32 bytes */
+#define X25519_KEY_SIZE_BYTES UL(32)
+
+TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *key,
+					       size_t key_size)
+{
+	size_t key_size_bytes = key_size / 8;
+
+	if (!key)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(key, 0, sizeof(*key));
+
+	if (key_size_bytes != X25519_KEY_SIZE_BYTES)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	key->priv = calloc(1, key_size_bytes);
+	key->pub = calloc(1, key_size_bytes);
+
+	if (!key->priv || !key->pub) {
+		free(key->priv);
+		free(key->pub);
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result crypto_acipher_gen_x25519_key(struct x25519_keypair *key,
+					 size_t key_size)
+{
+	curve25519_key ltc_tmp_key = { };
+	size_t key_size_bytes = key_size / 8;
+
+	if (key_size_bytes != X25519_KEY_SIZE_BYTES)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (x25519_make_key(NULL, find_prng("prng_crypto"), &ltc_tmp_key) !=
+	    CRYPT_OK)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (key_size_bytes < sizeof(ltc_tmp_key.pub) ||
+	    key_size_bytes < sizeof(ltc_tmp_key.priv))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memcpy(key->pub, ltc_tmp_key.pub, sizeof(ltc_tmp_key.pub));
+	memcpy(key->priv, ltc_tmp_key.priv, sizeof(ltc_tmp_key.priv));
+	memzero_explicit(&ltc_tmp_key, sizeof(ltc_tmp_key));
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result crypto_acipher_x25519_shared_secret(struct x25519_keypair
+					       *private_key,
+					       void *public_key,
+					       void *secret,
+					       unsigned long *secret_len)
+{
+	curve25519_key ltc_private_key = {
+		.type = PK_PRIVATE,
+		.algo = PKA_X25519,
+	};
+	curve25519_key ltc_public_key = {
+		.type = PK_PUBLIC,
+		.algo = PKA_X25519,
+	};
+
+	if (!private_key || !public_key || !secret || !secret_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	static_assert(sizeof(ltc_public_key.pub) == X25519_KEY_SIZE_BYTES &&
+		      sizeof(ltc_public_key.priv) == X25519_KEY_SIZE_BYTES);
+
+	memcpy(ltc_public_key.pub, public_key, X25519_KEY_SIZE_BYTES);
+	memcpy(ltc_private_key.priv, private_key->priv, X25519_KEY_SIZE_BYTES);
+
+	if (x25519_shared_secret(&ltc_private_key, &ltc_public_key,
+				 secret, secret_len) != CRYPT_OK)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/* Clear private key from the stack */
+	memzero_explicit(&ltc_private_key, sizeof(ltc_private_key));
+
+	/*
+	 * RFC 7748, sec 6.1, check for all zero shared secret output to reject
+	 * input points of low order.
+	 */
+	if (*secret_len != X25519_KEY_SIZE_BYTES ||
+	    !consttime_memcmp(secret, ltc_private_key.pub,
+			       X25519_KEY_SIZE_BYTES))
+		return TEE_ERROR_SECURITY;
+
+	return TEE_SUCCESS;
+}

--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -199,6 +199,7 @@
 #define TEE_ALG_ECDH_P521                       0x80005042
 #define TEE_ALG_SM2_PKE                         0x80000045
 #define TEE_ALG_SM3                             0x50000007
+#define TEE_ALG_X25519                          0x80000044
 #define TEE_ALG_ILLEGAL_VALUE                   0xEFFFFFFF
 
 /* Object Types */
@@ -232,6 +233,8 @@
 #define TEE_TYPE_GENERIC_SECRET             0xA0000000
 #define TEE_TYPE_CORRUPTED_OBJECT           0xA00000BE
 #define TEE_TYPE_DATA                       0xA00000BF
+#define TEE_TYPE_X25519_PUBLIC_KEY          0xA0000044
+#define TEE_TYPE_X25519_KEYPAIR             0xA1000044
 
 /* List of Object or Operation Attributes */
 
@@ -268,6 +271,8 @@
 #define TEE_ATTR_SM2_KEP_CONFIRMATION_OUT   0xD0000846
 #define TEE_ATTR_ECC_EPHEMERAL_PUBLIC_VALUE_X 0xD0000946 /* Missing in 1.2.1 */
 #define TEE_ATTR_ECC_EPHEMERAL_PUBLIC_VALUE_Y 0xD0000A46 /* Missing in 1.2.1 */
+#define TEE_ATTR_X25519_PUBLIC_VALUE        0xD0000944
+#define TEE_ATTR_X25519_PRIVATE_VALUE       0xC0000A44
 
 #define TEE_ATTR_FLAG_PUBLIC		(1 << 28)
 #define TEE_ATTR_FLAG_VALUE		(1 << 29)
@@ -288,8 +293,8 @@
 #define TEE_ECC_CURVE_NIST_P256             0x00000003
 #define TEE_ECC_CURVE_NIST_P384             0x00000004
 #define TEE_ECC_CURVE_NIST_P521             0x00000005
+#define TEE_ECC_CURVE_25519                 0x00000300
 #define TEE_ECC_CURVE_SM2                   0x00000400
-
 
 /* Panicked Functions Identification */
 /* TA Interface */

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -38,6 +38,7 @@
 #define TEE_MAIN_ALGO_HKDF       0xC0 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_CONCAT_KDF 0xC1 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_PBKDF2     0xC2 /* OP-TEE extension */
+#define TEE_MAIN_ALGO_X25519     0x44 /* Not in v1.2 spec */
 
 
 #define TEE_CHAIN_MODE_ECB_NOPAD        0x0
@@ -75,6 +76,8 @@ static inline uint32_t __tee_alg_get_main_alg(uint32_t algo)
 		return TEE_MAIN_ALGO_SM2_PKE;
 	case TEE_ALG_SM2_KEP:
 		return TEE_MAIN_ALGO_SM2_KEP;
+	case TEE_ALG_X25519:
+		return TEE_MAIN_ALGO_X25519;
 	default:
 		break;
 	}

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -105,7 +105,10 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		if (maxKeySize != 521)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
-
+	case TEE_ALG_X25519:
+		if (maxKeySize != 256)
+			return TEE_ERROR_NOT_SUPPORTED;
+		break;
 	default:
 		break;
 	}
@@ -223,6 +226,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_CONCAT_KDF_SHA512_DERIVE_KEY:
 	case TEE_ALG_PBKDF2_HMAC_SHA1_DERIVE_KEY:
 	case TEE_ALG_SM2_KEP:
+	case TEE_ALG_X25519:
 		if (mode != TEE_MODE_DERIVE)
 			return TEE_ERROR_NOT_SUPPORTED;
 		with_private_key = true;
@@ -2065,6 +2069,10 @@ TEE_Result TEE_IsAlgorithmSupported(uint32_t alg, uint32_t element)
 	}
 	if (IS_ENABLED(CFG_CRYPTO_SM2_PKE)) {
 		if (alg == TEE_ALG_SM2_PKE && element == TEE_ECC_CURVE_SM2)
+			return TEE_SUCCESS;
+	}
+	if (IS_ENABLED(CFG_CRYPTO_X25519)) {
+		if (alg == TEE_ALG_X25519 && element == TEE_ECC_CURVE_25519)
 			return TEE_SUCCESS;
 	}
 


### PR DESCRIPTION
Hey folks!

This PR adds X25519 support for OP-TEE as defined in GlobalPlatform TEE Internal Core API v1.2 using libtomcrypt as the backend crypto implementation.

Since the Curve25519 implementation does not support bignums, there is also a new key attribute type (octet reference) as defined in GlobalPlatform TEE Internal Core API v1.2 Table 6-15.