### PR TITLE
Add AM64x and AM62x device support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -173,6 +173,10 @@ jobs:
           _make PLATFORM=k3-j721e CFG_ARM64_core=y
           _make PLATFORM=k3-am65x
           _make PLATFORM=k3-am65x CFG_ARM64_core=y
+          _make PLATFORM=k3-am64x
+          _make PLATFORM=k3-am64x CFG_ARM64_core=y
+          _make PLATFORM=k3-am62x
+          _make PLATFORM=k3-am62x CFG_ARM64_core=y
           _make PLATFORM=ti-dra7xx out/core/tee{,-pager,-pageable}.bin
           _make PLATFORM=ti-am57xx
           _make PLATFORM=ti-am43xx

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -237,7 +237,7 @@ R:	Etienne Carriere <etienne.carriere@st.com> [@etienne-lms]
 S:	Maintained
 F:	core/arch/arm/plat-stm32mp1/
 
-Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x, J721E
+Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x, J721E, AM64x, AM62x
 R:	Andrew Davis <afd@ti.com> [@glneo]
 S:	Maintained
 F:	core/arch/arm/plat-ti/


### PR DESCRIPTION
Nothing extra is needed yet from the OP-TEE side to run on these devices (we have been using the `am65x` flavor for these SoCs so far), but we are starting to add drivers that will have different configurations on these two devices. Add named support here.