### PR TITLE
Unified hardware random number get bytes

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -24,6 +24,7 @@ CFG_TEE_RAM_VA_SIZE ?= 0x100000
 supported-ta-targets = ta_arm64
 
 ifeq ($(CFG_RCAR_GEN3), y)
+CFG_WITH_SOFTWARE_PRNG ?= n
 CFG_HWRNG_QUALITY ?= 1024
 CFG_HWRNG_PTA ?= y
 CFG_DT ?= y

--- a/core/crypto/rng_hw.c
+++ b/core/crypto/rng_hw.c
@@ -8,29 +8,6 @@
 #include <tee/tee_cryp_utl.h>
 #include <types_ext.h>
 
-/*
- * This is only here to keep the compiler happy while we convert over
- * platforms. Either hw_get_random_bytes() is overridden or this
- * function is, in either case this is never called.
- */
-uint8_t __weak hw_get_random_byte(void)
-{
-	panic();
-	return 4; // chosen by fair dice roll.
-		  // guaranteed to be random.
-}
-
-TEE_Result __weak hw_get_random_bytes(void *buf, size_t blen)
-{
-	uint8_t *b = buf;
-	size_t n = 0;
-
-	for (n = 0; n < blen; n++)
-		b[n] = hw_get_random_byte();
-
-	return TEE_SUCCESS;
-}
-
 /* This is a HW RNG, no need for seeding */
 TEE_Result __weak crypto_rng_init(const void *data __unused,
 				  size_t dlen __unused)

--- a/core/crypto/rng_hw.c
+++ b/core/crypto/rng_hw.c
@@ -7,12 +7,25 @@
 #include <tee/tee_cryp_utl.h>
 #include <types_ext.h>
 
+TEE_Result __weak hw_get_random_bytes(void *buf, size_t blen)
+{
+	uint8_t *b = buf;
+	size_t n = 0;
+
+	for (n = 0; n < blen; n++)
+		b[n] = hw_get_random_byte();
+
+	return TEE_SUCCESS;
+}
+
+/* This is a HW RNG, no need for seeding */
 TEE_Result __weak crypto_rng_init(const void *data __unused,
 				  size_t dlen __unused)
 {
 	return TEE_SUCCESS;
 }
 
+/* This is a HW RNG, no need to add entropy */
 void __weak crypto_rng_add_event(enum crypto_rng_src sid __unused,
 				 unsigned int *pnum __unused,
 				 const void *data __unused,
@@ -22,15 +35,8 @@ void __weak crypto_rng_add_event(enum crypto_rng_src sid __unused,
 
 TEE_Result __weak crypto_rng_read(void *buf, size_t blen)
 {
-	uint8_t *b = buf;
-	size_t n;
-
-	if (!b)
+	if (!buf)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	for (n = 0; n < blen; n++)
-		b[n] = hw_get_random_byte();
-
-	return TEE_SUCCESS;
+	return hw_get_random_bytes(buf, blen);
 }
-

--- a/core/crypto/rng_hw.c
+++ b/core/crypto/rng_hw.c
@@ -3,9 +3,22 @@
 
 #include <compiler.h>
 #include <crypto/crypto.h>
+#include <kernel/panic.h>
 #include <rng_support.h>
 #include <tee/tee_cryp_utl.h>
 #include <types_ext.h>
+
+/*
+ * This is only here to keep the compiler happy while we convert over
+ * platforms. Either hw_get_random_bytes() is overridden or this
+ * function is, in either case this is never called.
+ */
+uint8_t __weak hw_get_random_byte(void)
+{
+	panic();
+	return 4; // chosen by fair dice roll.
+		  // guaranteed to be random.
+}
 
 TEE_Result __weak hw_get_random_bytes(void *buf, size_t blen)
 {

--- a/core/crypto/rng_hw.c
+++ b/core/crypto/rng_hw.c
@@ -9,21 +9,20 @@
 #include <types_ext.h>
 
 /* This is a HW RNG, no need for seeding */
-TEE_Result __weak crypto_rng_init(const void *data __unused,
-				  size_t dlen __unused)
+TEE_Result crypto_rng_init(const void *data __unused, size_t dlen __unused)
 {
 	return TEE_SUCCESS;
 }
 
 /* This is a HW RNG, no need to add entropy */
-void __weak crypto_rng_add_event(enum crypto_rng_src sid __unused,
-				 unsigned int *pnum __unused,
-				 const void *data __unused,
-				 size_t dlen __unused)
+void crypto_rng_add_event(enum crypto_rng_src sid __unused,
+			  unsigned int *pnum __unused,
+			  const void *data __unused,
+			  size_t dlen __unused)
 {
 }
 
-TEE_Result __weak crypto_rng_read(void *buf, size_t blen)
+TEE_Result crypto_rng_read(void *buf, size_t blen)
 {
 	if (!buf)
 		return TEE_ERROR_BAD_PARAMETERS;

--- a/core/drivers/crypto/caam/caam_rng.c
+++ b/core/drivers/crypto/caam/caam_rng.c
@@ -556,22 +556,12 @@ enum caam_status caam_rng_init(vaddr_t ctrl_addr)
 }
 
 #ifdef CFG_NXP_CAAM_RNG_DRV
-TEE_Result crypto_rng_read(void *buf, size_t blen)
+TEE_Result hw_get_random_bytes(void *buf, size_t blen)
 {
 	if (!buf)
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	return do_rng_read(buf, blen);
-}
-
-uint8_t hw_get_random_byte(void)
-{
-	uint8_t data = 0;
-
-	if (do_rng_read(&data, 1) != TEE_SUCCESS)
-		panic();
-
-	return data;
 }
 
 void plat_rng_init(void)

--- a/core/drivers/crypto/se050/core/rng.c
+++ b/core/drivers/crypto/se050/core/rng.c
@@ -28,20 +28,10 @@ void plat_rng_init(void)
 {
 }
 
-TEE_Result crypto_rng_read(void *buf, size_t blen)
+TEE_Result hw_get_random_bytes(void *buf, size_t blen)
 {
 	if (!buf)
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	return do_rng_read(buf, blen);
-}
-
-uint8_t hw_get_random_byte(void)
-{
-	uint8_t data = 0;
-
-	if (do_rng_read(&data, 1))
-		return 0;
-
-	return data;
 }

--- a/core/drivers/dra7_rng.c
+++ b/core/drivers/dra7_rng.c
@@ -71,6 +71,7 @@
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, RNG_BASE, RNG_REG_SIZE);
 
 static unsigned int rng_lock = SPINLOCK_UNLOCK;
+static vaddr_t rng;
 
 uint8_t hw_get_random_byte(void)
 {
@@ -79,8 +80,6 @@ uint8_t hw_get_random_byte(void)
 		uint32_t val[2];
 		uint8_t byte[8];
 	} random;
-	vaddr_t rng = (vaddr_t)phys_to_virt(RNG_BASE, MEM_AREA_IO_SEC,
-					    RNG_REG_SIZE);
 	uint8_t ret;
 
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
@@ -126,9 +125,9 @@ uint8_t hw_get_random_byte(void)
 
 static TEE_Result dra7_rng_init(void)
 {
-	vaddr_t rng = (vaddr_t)phys_to_virt(RNG_BASE, MEM_AREA_IO_SEC,
-					    RNG_REG_SIZE);
 	uint32_t val;
+
+	rng = (vaddr_t)phys_to_virt(RNG_BASE, MEM_AREA_IO_SEC, RNG_REG_SIZE);
 
 	/* Execute a software reset */
 	io_write32(rng + RNG_SOFT_RESET_REG, RNG_SOFT_RESET);

--- a/core/drivers/dra7_rng.c
+++ b/core/drivers/dra7_rng.c
@@ -82,8 +82,7 @@ uint8_t hw_get_random_byte(void)
 	} random;
 	uint8_t ret;
 
-	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
-	cpu_spin_lock(&rng_lock);
+	uint32_t exceptions = cpu_spin_lock_xsave(&rng_lock);
 
 	if (!pos) {
 		/* Is the result ready (available)? */
@@ -117,8 +116,7 @@ uint8_t hw_get_random_byte(void)
 
 	pos = (pos + 1) % 8;
 
-	cpu_spin_unlock(&rng_lock);
-	thread_set_exceptions(exceptions);
+	cpu_spin_unlock_xrestore(&rng_lock, exceptions);
 
 	return ret;
 }

--- a/core/drivers/imx_rngb.c
+++ b/core/drivers/imx_rngb.c
@@ -166,7 +166,7 @@ static TEE_Result map_controller(void)
 }
 #endif
 
-TEE_Result crypto_rng_read(void *buf, size_t len)
+TEE_Result hw_get_random_bytes(void *buf, size_t len)
 {
 	uint32_t *rngbuf = buf;
 	uint32_t status = 0;
@@ -174,8 +174,6 @@ TEE_Result crypto_rng_read(void *buf, size_t len)
 
 	if (!rngb.ready)
 		return TEE_ERROR_BAD_STATE;
-
-	assert(buf);
 
 	while (len) {
 		status = io_read32(rngb.base.va + RNG_SR);
@@ -196,16 +194,6 @@ TEE_Result crypto_rng_read(void *buf, size_t len)
 	}
 
 	return TEE_SUCCESS;
-}
-
-uint8_t hw_get_random_byte(void)
-{
-	uint8_t data = 0;
-
-	if (crypto_rng_read(&data, 1))
-		panic();
-
-	return data;
 }
 
 void plat_rng_init(void)

--- a/core/drivers/smccc_trng.c
+++ b/core/drivers/smccc_trng.c
@@ -213,18 +213,8 @@ void plat_rng_init(void)
 
 /* If CFG_WITH_SOFTWARE_PRNG is disabled, TRNG is our HW RNG */
 #ifndef CFG_WITH_SOFTWARE_PRNG
-TEE_Result crypto_rng_read(void *buf, size_t len)
+TEE_Result hw_get_random_bytes(void *buf, size_t len)
 {
 	return smccc_trng_read(buf, len);
-}
-
-uint8_t hw_get_random_byte(void)
-{
-	uint8_t data = 0;
-
-	if (smccc_trng_read(&data, 1))
-		panic();
-
-	return data;
 }
 #endif

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -215,19 +215,9 @@ void plat_rng_init(void)
 	DMSG("PRNG seeded with RNG");
 }
 #else
-TEE_Result crypto_rng_read(void *out, size_t size)
+TEE_Result hw_get_random_bytes(void *out, size_t size)
 {
 	return stm32_rng_read(out, size);
-}
-
-uint8_t hw_get_random_byte(void)
-{
-	uint8_t byte = 0;
-
-	if (stm32_rng_read(&byte, sizeof(byte)))
-		panic();
-
-	return byte;
 }
 #endif
 

--- a/core/include/rng_support.h
+++ b/core/include/rng_support.h
@@ -8,5 +8,6 @@
 #include <stdint.h>
 
 uint8_t hw_get_random_byte(void);
+TEE_Result hw_get_random_bytes(void *buf, size_t blen);
 
 #endif /* __RNG_SUPPORT_H__ */

--- a/core/include/rng_support.h
+++ b/core/include/rng_support.h
@@ -7,7 +7,6 @@
 
 #include <stdint.h>
 
-uint8_t hw_get_random_byte(void);
 TEE_Result hw_get_random_bytes(void *buf, size_t blen);
 
 #endif /* __RNG_SUPPORT_H__ */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -106,7 +106,7 @@ CFG_MSG_LONG_PREFIX_MASK ?= 0x1a
 # PRNG configuration
 # If CFG_WITH_SOFTWARE_PRNG is enabled, crypto provider provided
 # software PRNG implementation is used.
-# Otherwise, you need to implement hw_get_random_byte() for your platform
+# Otherwise, you need to implement hw_get_random_bytes() for your platform
 CFG_WITH_SOFTWARE_PRNG ?= y
 
 # Number of threads


### PR DESCRIPTION
When in the process of adding a new RNG driver, I noticed a couple oddities we have in the driver-side HW RNG API.

The normal way to implement a HW RNG driver is to override `hw_get_random_byte()`. The issue here is that all the supported RNG hardware outputs more than one byte at a time, leading to the need for buffering of bytes to be read out by this interface in the drivers. Reading out one byte at a time has a bit of a performance overhead, so instead several drivers also override `crypto_rng_read()` (which can read out multiple bytes in one call). Since all users of HW RNG read out in multiple bytes in a loop anyway, there is no need for this single byte API.

Switch all users of RNG over to only `crypto_rng_read()`. Have all drivers implement only `hw_get_random_bytes()`. When HW RNG is enabled `crypto_rng_read()` simply calls `hw_get_random_bytes()`.

DRA7x RNG for instance, the performance was improved while simplifying the driver logic in the process.

The process of converting over most drivers was straightforward but some sanity checks from owners would be nice.

Performance and correctness can be checked by enabling the HW RNG PTA on your plat:

```
CFG_HWRNG_QUALITY ?= 1024
CFG_HWRNG_PTA ?= y
```

In Linux check that `/dev/hwrng` is using the optee_rng driver:

`# cat /sys/class/misc/hw_random/rng_current`

Then run:

`# rngtest -c 100 < /dev/hwrng`