### PR TITLE
libutee: fix value of TEE_ECC_CURVE_SM2

### DIFF
--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -288,7 +288,7 @@
 #define TEE_ECC_CURVE_NIST_P256             0x00000003
 #define TEE_ECC_CURVE_NIST_P384             0x00000004
 #define TEE_ECC_CURVE_NIST_P521             0x00000005
-#define TEE_ECC_CURVE_SM2                   0x00000300
+#define TEE_ECC_CURVE_SM2                   0x00000400
 
 
 /* Panicked Functions Identification */


### PR DESCRIPTION
The GlobalPlatform TEE Interbal Core API specification v1.3 has the
following text:

 In TEE Internal Core API v1.2 and v1.2.1, TEE_ECC_CURVE_25519 and
 TEE_ECC_CURVE_SM2 were incorrectly assigned the same identifier.

Indeed, both were 0x00000300. In v1.3, TEE_ECC_CURVE_SM2 is now
0x00000400. Update the code accordingly.

This is an API and ABI change, but note that this value is used only
in TEE_IsAlgorithmSupported(). Therefore, only TAs that dynamically
check for algorithm support at runtime may be impacted.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
