### PR TITLE
plat-ti: Enable hardware RNG PTA

### DIFF
--- a/core/arch/arm/plat-ti/conf.mk
+++ b/core/arch/arm/plat-ti/conf.mk
@@ -41,4 +41,6 @@ $(call force,CFG_SM_PLATFORM_HANDLER,y)
 $(call force,CFG_GIC,y)
 ifneq ($(CFG_WITH_SOFTWARE_PRNG),y)
 $(call force,CFG_DRA7_RNG,y)
+CFG_HWRNG_QUALITY ?= 1024
+CFG_HWRNG_PTA ?= y
 endif


### PR DESCRIPTION
When the hardware RNG is available we should also enable
the HWRNG PTA so we can use it from the REE.
