### PR TITLE
core: decrease register size for gicv2

### DIFF
--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -9,8 +9,13 @@
 #include <types_ext.h>
 #include <kernel/interrupt.h>
 
+#if defined(CFG_ARM_GICV3)
 #define GIC_DIST_REG_SIZE	0x10000
 #define GIC_CPU_REG_SIZE	0x10000
+#else
+#define GIC_DIST_REG_SIZE	0x1000
+#define GIC_CPU_REG_SIZE	0x1000
+#endif
 
 #define GIC_PPI_BASE		U(16)
 #define GIC_SPI_BASE		U(32)


### PR DESCRIPTION
The mapped size for GIC distributor and cpu registers is currently
defined to the size used for GICv3. GICv2 doesn't need such large sizes,
in fact some platforms has the distributor and cpu registers next to
each other in the physical memory map. This causes an overlap that can
be confusing. Fix this by selecting a smaller size when a GICv2 is used
instead.

It should be noted GICC_DIR is at offset 0x1000 in the cpu interface so
this register will not be accessible, but this should not be a problem
since OP-TEE doesn't use that register.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
