### PR TITLE
build: allow multiple occurrences of the same directory in subdirs-y

### DIFF
--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -21,6 +21,8 @@ srcs :=
 gen-srcs :=
 asm-defines-files :=
 
+uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
+
 define process-subdir-srcs-y
 ifeq ($$(sub-dir),.)
 srcs 				+= $1
@@ -174,8 +176,8 @@ this-out-dir :=
 asm-defines-y :=
 
 # Process subdirectories in current directory
-$$(foreach sd, $$(sub-subdirs), $$(eval $$(call process-subdir,$$(sd))))
+$$(foreach sd, $$(call uniq,$$(sub-subdirs)), $$(eval $$(call process-subdir,$$(sd))))
 endef #process-subdir
 
 # Top subdirectories
-$(foreach sd, $(subdirs), $(eval $(call process-subdir,$(sd))))
+$(foreach sd, $(call uniq,$(subdirs)), $(eval $(call process-subdir,$(sd))))


### PR DESCRIPTION
This change enables adding the same directory several times to subdirs-y
in sub.mk without causing warnings. This means we can now use patterns
such as:

 subdirs-$(CFG_FOO) += foobar
 subdirs-$(CFG_BAR) += foobar

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
