### PR TITLE
core: libtomcrypt: Fix compilation issue with CFG_CRYPTO_ECC=n

### DIFF
--- a/core/lib/libtomcrypt/acipher_helpers.h
+++ b/core/lib/libtomcrypt/acipher_helpers.h
@@ -35,7 +35,7 @@ static inline TEE_Result convert_ltc_verify_status(int ltc_res, int ltc_stat)
 	}
 }
 
-#ifdef CFG_CRYPTOLIB_NAME_tomcrypt
+#ifdef _CFG_CORE_LTC_ECC
 TEE_Result ecc_populate_ltc_private_key(ecc_key *ltc_key,
 					struct ecc_keypair *key,
 					uint32_t algo, size_t *key_size_bytes);


### PR DESCRIPTION
Hey folks,

This PR fixes a compilation issue with `CFG_CRYPTO_ECC=n`.

Disabling `ECC` crypto does not disable the `LTC ECC` related declarations, so `CFG_CRYPTO_ECC=n` gives a compilation error. 

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
