### PR TITLE
drivers: caam: fix cache operation on SGT table

### DIFF
--- a/core/drivers/crypto/caam/utils/utils_sgt.c
+++ b/core/drivers/crypto/caam/utils/utils_sgt.c
@@ -15,6 +15,18 @@
 #include <tee/cache.h>
 #include <util.h>
 
+/*
+ * Perform cache management clean operation on the SGT table entry
+ *
+ * @sgtbuf     SGT table to manage
+ */
+static void caam_sgt_entries_cache_clean(const struct caamsgtbuf *sgtbuf)
+{
+	cache_operation(TEE_CACHECLEAN, (void *)sgtbuf->sgt,
+			ROUNDUP(sgtbuf->number, CFG_CAAM_SGT_ALIGN) *
+				sizeof(*sgtbuf->sgt));
+}
+
 void caam_sgt_cache_op(enum utee_cache_operation op, struct caamsgtbuf *insgt,
 		       size_t length)
 {
@@ -22,9 +34,7 @@ void caam_sgt_cache_op(enum utee_cache_operation op, struct caamsgtbuf *insgt,
 	size_t op_size = 0;
 	size_t rem_length = length;
 
-	cache_operation(TEE_CACHECLEAN, (void *)insgt->sgt,
-			ROUNDUP(insgt->number, CFG_CAAM_SGT_ALIGN) *
-				sizeof(union caamsgt));
+	caam_sgt_entries_cache_clean(insgt);
 
 	SGT_TRACE("SGT @%p %d entries", insgt, insgt->number);
 	for (idx = 0; idx < insgt->number && rem_length; idx++) {
@@ -105,8 +115,7 @@ enum caam_status caam_sgt_derive(struct caamsgtbuf *sgt,
 		 * Push the SGT Table into memory now because
 		 * derived objects are not pushed.
 		 */
-		cache_operation(TEE_CACHECLEAN, sgt->sgt,
-				sgt->number * sizeof(*sgt->sgt));
+		caam_sgt_entries_cache_clean(sgt);
 
 		sgt->paddr = virt_to_phys(sgt->sgt);
 	} else {


### PR DESCRIPTION
The cache operation of the SGT table in caam_sgt_derive() was wrong and
it did not take into account the CAAM "burst" defined by the value
CFG_CAAM_SGT_ALIGN.
The cache operation of the SGT table in caam_sgt_cache_op() is done
correctly however.

This patch adds caam_sgt_entries_cache_op() to do this operation and
avoid implementation errors.

Signed-off-by: Franck LENORMAND <franck.lenormand@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
