### PR TITLE
core: imx: link: generate entry_point_address.txt for uTee image

### DIFF
--- a/core/arch/arm/plat-imx/link.mk
+++ b/core/arch/arm/plat-imx/link.mk
@@ -7,5 +7,5 @@ uTee: $(link-out-dir)/uTee
 cleanfiles += $(link-out-dir)/uTee
 $(link-out-dir)/uTee: $(link-out-dir)/tee-raw.bin
 	@$(cmd-echo-silent) '  MKIMAGE $@'
-	$(q)ADDR=`printf 0x%x $$(($(CFG_TZDRAM_START)))`; \
+	$(q)ADDR=`printf 0x%x $$(($(subst UL,,$(CFG_TZDRAM_START))))`; \
 		mkimage -A arm -O linux -C none -a $$ADDR -e $$ADDR -d $< $@


### PR DESCRIPTION
For some platforms like mx7ulpevk, the `UL` attribute for CFG_DRAM_BASE
is necessary to avoid the following error:

$ PLATFORM=imx-mx7ulpevk make uTee
core/mm/mobj.c: In function ‘mobj_init’:
./out/arm-plat-imx/include/generated/conf.h:222:64: warning: integer overflow in expression of type ‘int’ results in ‘-1644167168’ [-Woverflow]
  222 | #define CFG_TZDRAM_START (0x60000000 - 0x01e00000 - 0x00200000 + 0x40000000)
      |                                                                ^

However, this `UL` attribute prevents the shell from properly computing
the CFG_TZDRAM_START value :

$ PLATFORM=imx-mx7ulpevk make uTee
bash: (UL(0x60000000) - 0x01e00000 - 0x00200000 + 0x40000000): missing `)' (error token is "(0x60000000) - 0x01e00000 - 0x00200000 + 0x40000000)")

To address both issues, the OP-TEE OS start address is read from tee.elf
and stored in entry_point_address.txt file.

Fixes: 0f8347dcafe ("core: imx: generate uImage for imx6 and imx7 platforms")
Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
