### PR TITLE
K3 SA2UL true random-number generator driver

### DIFF
--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -1,6 +1,6 @@
 CFG_WITH_STATS ?= y
 CFG_CRYPTO_WITH_CE ?= n
-CFG_WITH_SOFTWARE_PRNG ?= y
+CFG_WITH_SOFTWARE_PRNG ?= n
 CFG_CONSOLE_UART ?= 0
 
 CFG_TZDRAM_START ?= 0x9e800000
@@ -16,5 +16,11 @@ $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
+
+ifneq ($(CFG_WITH_SOFTWARE_PRNG),y)
+$(call force,CFG_SA2UL,y)
+CFG_HWRNG_QUALITY ?= 1024
+CFG_HWRNG_PTA ?= y
+endif
 
 include core/arch/arm/cpu/cortex-armv8-0.mk

--- a/core/arch/arm/plat-k3/drivers/sa2ul.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.c
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Texas Instruments K3 SA2UL Driver
+ *
+ * Copyright (C) 2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Andrew Davis <afd@ti.com>
+ */
+
+#include <drivers/ti_sci.h>
+#include <initcall.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/interrupt.h>
+#include <kernel/misc.h>
+#include <kernel/spinlock.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <rng_support.h>
+
+#include "sa2ul.h"
+
+#define	SA2UL_ES                0x0008
+#define SA2UL_ES_TRNG           BIT(3)
+#define	SA2UL_EEC               0x1000
+#define SA2UL_EEC_TRNG          BIT(3)
+
+#define FW_ENABLE_REGION        0x0a
+#define FW_BIG_ARM_PRIVID       0x01
+#define FW_WILDCARD_PRIVID      0xc3
+#define FW_SECURE_ONLY          GENMASK_32(8, 0)
+#define FW_NON_SECURE           GENMASK_32(16, 0)
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SA2UL_BASE, SA2UL_REG_SIZE);
+
+static TEE_Result sa2ul_init(void)
+{
+	vaddr_t sa2ul = (vaddr_t)phys_to_virt(SA2UL_BASE, MEM_AREA_IO_SEC,
+					      RNG_REG_SIZE);
+	uint16_t fwl_id = SA2UL_TI_SCI_FW_ID;
+	uint16_t sa2ul_region = SA2UL_TI_SCI_FW_RGN_ID;
+	uint16_t rng_region = RNG_TI_SCI_FW_RGN_ID;
+	uint8_t owner_index = OPTEE_HOST_ID;
+	uint8_t owner_privid = 0;
+	uint16_t owner_permission_bits = 0;
+	uint32_t control = 0;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
+	uint64_t start_address = 0;
+	uint64_t end_address = 0;
+	uint32_t val = 0;
+	TEE_Result result = TEE_SUCCESS;
+	int ret = 0;
+
+	/* Power on the SA2UL device */
+	ret = ti_sci_device_get(SA2UL_TI_SCI_DEV_ID);
+	if (ret) {
+		EMSG("Failed to get SA2UL device");
+		return TEE_ERROR_GENERIC;
+	}
+
+	IMSG("Activated SA2UL device");
+
+	/* Try to claim the SA2UL firewall for ourselves */
+	ret = ti_sci_change_fwl_owner(fwl_id, sa2ul_region, owner_index,
+				      &owner_privid, &owner_permission_bits);
+	if (ret) {
+		/*
+		 * This is not fatal, it just means we are on an HS device
+		 * where the DMSC already owns the SA2UL. On GP we need
+		 * to do additional setup for access permissions below.
+		 */
+		DMSG("Could not change SA2UL firewall owner");
+	} else {
+		DMSG("Fixing SA2UL firewall owner for GP device");
+
+		/* Get current SA2UL firewall configuration */
+		ret = ti_sci_get_fwl_region(fwl_id, sa2ul_region, 1,
+					    &control, permissions,
+					    &start_address, &end_address);
+		if (ret) {
+			EMSG("Could not get firewall region information");
+			return TEE_ERROR_GENERIC;
+		}
+
+		/* Modify SA2UL firewall to allow all others access*/
+		control = FW_ENABLE_REGION;
+		permissions[0] = (FW_WILDCARD_PRIVID << 16) | FW_NON_SECURE;
+		ret = ti_sci_set_fwl_region(fwl_id, sa2ul_region, 1,
+					    control, permissions,
+					    start_address, end_address);
+		if (ret) {
+			EMSG("Could not set firewall region information");
+			return TEE_ERROR_GENERIC;
+		}
+	}
+
+	/* Claim the TRNG firewall for ourselves */
+	ret = ti_sci_change_fwl_owner(fwl_id, rng_region, owner_index,
+				      &owner_privid, &owner_permission_bits);
+	if (ret) {
+		EMSG("Could not change TRNG firewall owner");
+		return TEE_ERROR_GENERIC;
+	}
+
+	/* Get current TRNG firewall configuration */
+	ret = ti_sci_get_fwl_region(fwl_id, rng_region, 1,
+				    &control, permissions,
+				    &start_address, &end_address);
+	if (ret) {
+		EMSG("Could not get firewall region information");
+		return TEE_ERROR_GENERIC;
+	}
+
+	/* Modify TRNG firewall to block all others access */
+	control = FW_ENABLE_REGION;
+	permissions[0] = (FW_BIG_ARM_PRIVID << 16) | FW_SECURE_ONLY;
+	ret = ti_sci_set_fwl_region(fwl_id, rng_region, 1,
+				    control, permissions,
+				    start_address, end_address);
+	if (ret) {
+		EMSG("Could not set firewall region information");
+		return TEE_ERROR_GENERIC;
+	}
+
+	IMSG("Enabled firewalls for SA2UL TRNG device");
+
+	/* Enable RNG engine in SA2UL if not already enabled */
+	val = io_read32(sa2ul + SA2UL_ES);
+	if (!(val & SA2UL_ES_TRNG)) {
+		IMSG("Enabling SA2UL TRNG engine");
+		io_setbits32(sa2ul + SA2UL_EEC, SA2UL_EEC_TRNG);
+	}
+
+	/* Initialize the RNG Module */
+	result = sa2ul_rng_init();
+	if (result != TEE_SUCCESS)
+		return result;
+
+	IMSG("SA2UL Drivers initialized");
+
+	return TEE_SUCCESS;
+}
+driver_init(sa2ul_init);

--- a/core/arch/arm/plat-k3/drivers/sa2ul.h
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Texas Instruments K3 SA2UL Driver
+ *
+ * Copyright (C) 2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Andrew Davis <afd@ti.com>
+ */
+
+#ifndef __DRIVERS_SA2UL_H
+#define __DRIVERS_SA2UL_H
+
+#include <tee_api_types.h>
+
+TEE_Result sa2ul_rng_init(void);
+
+#endif /* __DRIVERS_SA2UL_H */

--- a/core/arch/arm/plat-k3/drivers/sa2ul_rng.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul_rng.c
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Texas Instruments K3 SA2UL RNG Driver
+ *
+ * Copyright (C) 2022 Texas Instruments Incorporated - https://www.ti.com/
+ *	Andrew Davis <afd@ti.com>
+ */
+
+#include <initcall.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/interrupt.h>
+#include <kernel/misc.h>
+#include <kernel/spinlock.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <rng_support.h>
+
+#include "sa2ul.h"
+
+#define	RNG_OUTPUT_0            0x00
+#define	RNG_OUTPUT_1            0x04
+#define	RNG_OUTPUT_2            0x08
+#define	RNG_OUTPUT_3            0x0C
+#define	RNG_STATUS              0x10
+#define RNG_READY               BIT(0)
+#define SHUTDOWN_OFLO           BIT(1)
+#define	RNG_INTACK              0x10
+#define	RNG_CONTROL             0x14
+#define ENABLE_TRNG             BIT(10)
+#define	RNG_CONFIG              0x18
+#define	RNG_ALARMCNT            0x1C
+#define	RNG_FROENABLE           0x20
+#define	RNG_FRODETUNE           0x24
+#define	RNG_ALARMMASK           0x28
+#define	RNG_ALARMSTOP           0x2C
+#define	RNG_OPTIONS             0x78
+#define	RNG_EIP_REV             0x7C
+
+#define RNG_CONTROL_STARTUP_CYCLES_SHIFT        16
+#define RNG_CONTROL_STARTUP_CYCLES_MASK         GENMASK_32(31, 16)
+
+#define RNG_CONFIG_MAX_REFIL_CYCLES_SHIFT       16
+#define RNG_CONFIG_MAX_REFIL_CYCLES_MASK        GENMASK_32(31, 16)
+#define RNG_CONFIG_MIN_REFIL_CYCLES_SHIFT       0
+#define RNG_CONFIG_MIN_REFIL_CYCLES_MASK        GENMASK_32(7, 0)
+
+#define RNG_ALARMCNT_ALARM_TH_SHIFT             0
+#define RNG_ALARMCNT_ALARM_TH_MASK              GENMASK_32(7, 0)
+#define RNG_ALARMCNT_SHUTDOWN_TH_SHIFT          16
+#define RNG_ALARMCNT_SHUTDOWN_TH_MASK           GENMASK_32(20, 16)
+
+#define RNG_CONTROL_STARTUP_CYCLES              0xff
+#define RNG_CONFIG_MIN_REFIL_CYCLES             0x5
+#define RNG_CONFIG_MAX_REFIL_CYCLES             0x22
+#define RNG_ALARM_THRESHOLD                     0xff
+#define RNG_SHUTDOWN_THRESHOLD                  0x4
+
+#define RNG_FRO_MASK    GENMASK_32(23, 0)
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, RNG_BASE, RNG_REG_SIZE);
+
+static unsigned int rng_lock = SPINLOCK_UNLOCK;
+static vaddr_t rng;
+
+uint8_t hw_get_random_byte(void)
+{
+	static int pos;
+	static union {
+		uint32_t val[4];
+		uint8_t byte[16];
+	} random;
+	uint32_t exceptions = 0;
+	uint8_t ret = 0;
+
+	assert(rng);
+
+	exceptions = cpu_spin_lock_xsave(&rng_lock);
+
+	if (!pos) {
+		/* Is the result ready (available)? */
+		while (!(io_read32(rng + RNG_STATUS) & RNG_READY)) {
+			/* Is the shutdown threshold reached? */
+			if (io_read32(rng + RNG_STATUS) & SHUTDOWN_OFLO) {
+				uint32_t alarm = io_read32(rng + RNG_ALARMSTOP);
+				uint32_t tune = io_read32(rng + RNG_FRODETUNE);
+
+				/* Clear the alarm events */
+				io_write32(rng + RNG_ALARMMASK, 0x0);
+				io_write32(rng + RNG_ALARMSTOP, 0x0);
+				/* De-tune offending FROs */
+				io_write32(rng + RNG_FRODETUNE, tune ^ alarm);
+				/* Re-enable the shut down FROs */
+				io_write32(rng + RNG_FROENABLE, RNG_FRO_MASK);
+				/* Clear the shutdown overflow event */
+				io_write32(rng + RNG_INTACK, SHUTDOWN_OFLO);
+
+				DMSG("Fixed FRO shutdown");
+			}
+		}
+		/* Read random value */
+		random.val[0] = io_read32(rng + RNG_OUTPUT_0);
+		random.val[1] = io_read32(rng + RNG_OUTPUT_1);
+		random.val[2] = io_read32(rng + RNG_OUTPUT_2);
+		random.val[3] = io_read32(rng + RNG_OUTPUT_3);
+		/* Acknowledge read complete */
+		io_write32(rng + RNG_INTACK, RNG_READY);
+	}
+
+	ret = random.byte[pos];
+
+	pos = (pos + 1) % 16;
+
+	cpu_spin_unlock_xrestore(&rng_lock, exceptions);
+
+	return ret;
+}
+
+TEE_Result sa2ul_rng_init(void)
+{
+	uint32_t val = 0;
+
+	rng = (vaddr_t)phys_to_virt(RNG_BASE, MEM_AREA_IO_SEC, RNG_REG_SIZE);
+
+	/* Ensure initial latency */
+	val |= RNG_CONFIG_MIN_REFIL_CYCLES << RNG_CONFIG_MIN_REFIL_CYCLES_SHIFT;
+	val |= RNG_CONFIG_MAX_REFIL_CYCLES << RNG_CONFIG_MAX_REFIL_CYCLES_SHIFT;
+	io_write32(rng + RNG_CONFIG, val);
+
+	/* Configure the desired FROs */
+	io_write32(rng + RNG_FRODETUNE, 0x0);
+
+	/* Enable all FROs */
+	io_write32(rng + RNG_FROENABLE, 0xffffff);
+
+	io_write32(rng + RNG_CONTROL, ENABLE_TRNG);
+
+	IMSG("SA2UL TRNG initialized");
+
+	return TEE_SUCCESS;
+}

--- a/core/arch/arm/plat-k3/drivers/sub.mk
+++ b/core/arch/arm/plat-k3/drivers/sub.mk
@@ -1,2 +1,4 @@
 srcs-y += sec_proxy.c
 srcs-y += ti_sci.c
+srcs-$(CFG_SA2UL) += sa2ul.c
+srcs-$(CFG_SA2UL) += sa2ul_rng.c

--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -179,6 +179,40 @@ int ti_sci_get_revision(struct ti_sci_msg_resp_version *rev_info)
 	return 0;
 }
 
+static int ti_sci_device_set_state(uint32_t id, uint32_t flags, uint8_t state)
+{
+	struct ti_sci_msg_req_set_device_state req = { };
+	struct ti_sci_msg_resp_set_device_state resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret = 0;
+
+	ret = ti_sci_setup_xfer(TI_SCI_MSG_SET_DEVICE_STATE, flags,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret)
+		return ret;
+
+	req.id = id;
+	req.state = state;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+int ti_sci_device_get(uint32_t id)
+{
+	return ti_sci_device_set_state(id, 0, MSG_DEVICE_SW_STATE_ON);
+}
+
+int ti_sci_device_put(uint32_t id)
+{
+	return ti_sci_device_set_state(id, 0, MSG_DEVICE_SW_STATE_AUTO_OFF);
+}
+
 /**
  * ti_sci_get_dkek() - Get the DKEK
  * @sa2ul_instance:	SA2UL instance to get key

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -23,6 +23,24 @@
 int ti_sci_get_revision(struct ti_sci_msg_resp_version *rev_info);
 
 /**
+ * Device control operations
+ *
+ * - ti_sci_device_get - Get access to device managed by TISCI
+ * - ti_sci_device_put - Release access to device managed by TISCI
+ *
+ * NOTE: for all these functions, the following are generic in nature:
+ * @id:		Device Identifier
+ *
+ * Returns 0 for successful request, else returns corresponding error message.
+ *
+ * Request for the device - NOTE: the client MUST maintain integrity of
+ * usage count by balancing get_device with put_device. No refcounting is
+ * managed by driver for that purpose.
+ */
+int ti_sci_device_get(uint32_t id);
+int ti_sci_device_put(uint32_t id);
+
+/**
  * ti_sci_get_dkek() - Get the DKEK
  * @sa2ul_instance:	SA2UL instance to get key
  * @context:		Context string input to KDF

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -41,6 +41,75 @@ int ti_sci_device_get(uint32_t id);
 int ti_sci_device_put(uint32_t id);
 
 /**
+ * ti_sci_set_fwl_region() - Request for configuring a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Number of permission registers to set
+ * @control:            Contents of the firewall CONTROL register to set
+ * @permissions:        Contents of the firewall PERMISSION register to set
+ * @start_address:      Contents of the firewall START_ADDRESS register to set
+ * @end_address:        Contents of the firewall END_ADDRESS register to set
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_set_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t control,
+			  const uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t start_address, uint64_t end_address);
+/**
+ * ti_sci_cmd_get_fwl_region() - Request for getting a firewall region
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @n_permission_regs:  Region or channel number to set config info
+ * @control:            Contents of the firewall CONTROL register
+ * @permissions:        Contents of the firewall PERMISSION register
+ * @start_address:      Contents of the firewall START_ADDRESS register
+ * @end_address:        Contents of the firewall END_ADDRESS register
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_get_fwl_region(uint16_t fwl_id, uint16_t region,
+			  uint32_t n_permission_regs, uint32_t *control,
+			  uint32_t permissions[FWL_MAX_PRIVID_SLOTS],
+			  uint64_t *start_address, uint64_t *end_address);
+/**
+ * ti_sci_change_fwl_owner() - Request for changing a firewall owner
+ *
+ * @fwl_id:             Firewall ID in question. fwl_id is defined in the TRM.
+ * @region:             Region or channel number to set config info. This field
+ *                      is unused in case of a simple firewall and must be
+ *                      initialized to zero. In case of a region based
+ *                      firewall, this field indicates the region in question
+ *                      (index starting from 0). In case of a channel based
+ *                      firewall, this field indicates the channel in question
+ *                      (index starting from 0).
+ * @owner_index:        New owner index to transfer ownership to
+ * @owner_privid:       New owner priv-ID returned by DMSC. This field is
+ *                      currently initialized to zero by DMSC.
+ * @owner_permission_bits: New owner permission bits returned by DMSC. This
+ *                         field is currently initialized to zero by DMSC.
+ *
+ * Return: 0 if all went well, else returns appropriate error value.
+ */
+int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
+			    uint8_t owner_index, uint8_t *owner_privid,
+			    uint16_t *owner_permission_bits);
+
+/**
  * ti_sci_get_dkek() - Get the DKEK
  * @sa2ul_instance:	SA2UL instance to get key
  * @context:		Context string input to KDF

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -19,6 +19,9 @@
 #define TI_SCI_MSG_SET_DEVICE_STATE      0x0200
 
 /* Security Management Messages */
+#define TI_SCI_MSG_FWL_SET               0x9000
+#define TI_SCI_MSG_FWL_GET               0x9001
+#define TI_SCI_MSG_FWL_CHANGE_OWNER      0x9002
 #define TI_SCI_MSG_SA2UL_GET_DKEK        0x9029
 
 /**
@@ -137,6 +140,128 @@ struct ti_sci_msg_req_set_device_state {
  */
 struct ti_sci_msg_resp_set_device_state {
 	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+#define FWL_MAX_PRIVID_SLOTS 3U
+
+/**
+ * struct ti_sci_msg_req_fwl_set_firewall_region - Set firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to set
+ * @control:		Contents of the firewall CONTROL register to set
+ * @permissions:	Contents of the firewall PERMISSION register to set
+ * @start_address:	Contents of the firewall START_ADDRESS register to set
+ * @end_address:	Contents of the firewall END_ADDRESS register to set
+ */
+struct ti_sci_msg_req_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+struct ti_sci_msg_resp_fwl_set_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_get_firewall_region - Retrieve firewall permissions
+ * @hdr:		Generic Header
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers to retrieve
+ */
+struct ti_sci_msg_req_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_get_firewall_region - Response for retrieving the
+ *						    firewall permissions
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number to set config info.
+ *			This field is unused in case of a simple firewall and
+ *			must be initialized to zero.  In case of a region based
+ *			firewall, this field indicates the region (index
+ *			starting from 0). In case of a channel based firewall,
+ *			this field indicates the channel (index starting
+ *			from 0).
+ * @n_permission_regs:	Number of permission registers retrieved
+ * @control:		Contents of the firewall CONTROL register
+ * @permissions:	Contents of the firewall PERMISSION registers
+ * @start_address:	Contents of the firewall START_ADDRESS register
+ * @end_address:	Contents of the firewall END_ADDRESS register
+ */
+struct ti_sci_msg_resp_fwl_get_firewall_region {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint32_t n_permission_regs;
+	uint32_t control;
+	uint32_t permissions[FWL_MAX_PRIVID_SLOTS];
+	uint64_t start_address;
+	uint64_t end_address;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_fwl_change_owner_info - Request change firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID in question
+ * @region:		Region or channel number if applicable
+ * @owner_index:	New owner index to transfer ownership to
+ */
+struct ti_sci_msg_req_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_fwl_change_owner_info - Response for change
+ *						  firewall owner
+ *
+ * @hdr:		Generic Header
+ *
+ * @fwl_id:		Firewall ID specified in request
+ * @region:		Region or channel number specified in request
+ * @owner_index:	Owner index specified in request
+ * @owner_privid:	New owner priv-ID returned by DMSC.
+ * @owner_permission_bits:	New owner permission bits returned by DMSC.
+ */
+struct ti_sci_msg_resp_fwl_change_owner_info {
+	struct ti_sci_msg_hdr hdr;
+	uint16_t fwl_id;
+	uint16_t region;
+	uint8_t owner_index;
+	uint8_t owner_privid;
+	uint16_t owner_permission_bits;
 } __packed;
 
 /**

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -15,6 +15,9 @@
 /* Generic Messages */
 #define TI_SCI_MSG_VERSION               0x0002
 
+/* Device requests */
+#define TI_SCI_MSG_SET_DEVICE_STATE      0x0200
+
 /* Security Management Messages */
 #define TI_SCI_MSG_SA2UL_GET_DKEK        0x9029
 
@@ -87,6 +90,53 @@ struct ti_sci_msg_resp_version {
 	uint8_t abi_minor;
 	uint8_t sub_version;
 	uint8_t patch_version;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_set_device_state - Set the desired state of the device
+ * @hdr:	Generic header
+ * @id:		Indicates which device to modify
+ * @reserved:	Reserved space in message, must be 0 for backward compatibility
+ * @state:	The desired state of the device.
+ *
+ * Certain flags can also be set to alter the device state:
+ * + MSG_FLAG_DEVICE_WAKE_ENABLED - Configure the device to be a wake source.
+ * The meaning of this flag will vary slightly from device to device and from
+ * SoC to SoC but it generally allows the device to wake the SoC out of deep
+ * suspend states.
+ * + MSG_FLAG_DEVICE_RESET_ISO - Enable reset isolation for this device.
+ * + MSG_FLAG_DEVICE_EXCLUSIVE - Claim this device exclusively. When passed
+ * with STATE_RETENTION or STATE_ON, it will claim the device exclusively.
+ * If another host already has this device set to STATE_RETENTION or STATE_ON,
+ * the message will fail. Once successful, other hosts attempting to set
+ * STATE_RETENTION or STATE_ON will fail.
+ *
+ * Request type is TI_SCI_MSG_SET_DEVICE_STATE, responded with a generic
+ * ACK/NACK message.
+ */
+struct ti_sci_msg_req_set_device_state {
+	/* Additional hdr->flags options */
+#define MSG_FLAG_DEVICE_WAKE_ENABLED	TI_SCI_MSG_FLAG(8)
+#define MSG_FLAG_DEVICE_RESET_ISO	TI_SCI_MSG_FLAG(9)
+#define MSG_FLAG_DEVICE_EXCLUSIVE	TI_SCI_MSG_FLAG(10)
+	struct ti_sci_msg_hdr hdr;
+	uint32_t id;
+	uint32_t reserved;
+
+#define MSG_DEVICE_SW_STATE_AUTO_OFF	0
+#define MSG_DEVICE_SW_STATE_RETENTION	1
+#define MSG_DEVICE_SW_STATE_ON		2
+	uint8_t state;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_set_device_state - Response for set device state
+ * @hdr:	Generic header
+ *
+ * Response to request TI_SCI_MSG_SET_DEVICE_STATE
+ */
+struct ti_sci_msg_resp_set_device_state {
+	struct ti_sci_msg_hdr hdr;
 } __packed;
 
 /**

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -54,6 +54,28 @@
 #define GICC_BASE       (SCU_BASE + GICC_OFFSET)
 #define GICD_BASE       (SCU_BASE + GICD_OFFSET)
 
+/* SA2UL */
+#if defined(PLATFORM_FLAVOR_am65x)
+#define SA2UL_BASE		0x04e00000
+#define SA2UL_TI_SCI_DEV_ID	136
+#define SA2UL_TI_SCI_FW_ID	2112
+#elif defined(PLATFORM_FLAVOR_j721e)
+#define SA2UL_BASE		0x40900000
+#define SA2UL_TI_SCI_DEV_ID	265
+#define SA2UL_TI_SCI_FW_ID	1196
+#else
+#define SA2UL_BASE		0x40900000
+#define SA2UL_TI_SCI_DEV_ID	133
+#define SA2UL_TI_SCI_FW_ID	35
+#endif
+#define SA2UL_REG_SIZE		0x1000
+#define SA2UL_TI_SCI_FW_RGN_ID	0
+
+/* RNG */
+#define RNG_BASE		(SA2UL_BASE + 0x10000)
+#define RNG_REG_SIZE		0x1000
+#define RNG_TI_SCI_FW_RGN_ID	3
+
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		64
 


### PR DESCRIPTION
This series adds a couple commands to the TI-SCI driver for device control and firewall setup. We use these to enable and secure the SA2UL device available on all K3 platforms. One of the parts of the SA2UL being a TRNG which we add support for here. Support for the other SA2UL HW crypto engines will be added in subsequent series.