### PR TITLE
plat-k3: Add DDR setup in k3 platform

### DIFF
--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -36,6 +36,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_DATA_BASE,
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_SCFG_BASE,
 			SEC_PROXY_SCFG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_RT_BASE, SEC_PROXY_RT_SIZE);
+register_ddr(DRAM0_BASE, DRAM0_SIZE);
 
 void main_init_gic(void)
 {

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -15,6 +15,9 @@
 #define CONSOLE_BAUDRATE        115200
 #define CONSOLE_UART_CLK_IN_HZ  48000000
 
+#define DRAM0_BASE      0x80000000
+#define DRAM0_SIZE      0x80000000
+
 #define SCU_BASE        0x01800000
 #if defined(PLATFORM_FLAVOR_j721e)
 #define GICC_OFFSET     0x100000


### PR DESCRIPTION
This patch introduces DDR setup for possible use of
CFG_CORE_DYN_SHM/dynamic shared memory on k3 platform.

Signed-off-by: Ivan Mikhaylov <ivan.mikhaylov@siemens.com>
