### PR TITLE
build: introduce CFG_OPTEE_REVISION_EXTRA

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -128,10 +128,11 @@ CFG_OS_REV_REPORTS_GIT_SHA1 ?= y
 # that TEE_IMPL_VERSION contains the major and minor revision numbers.
 CFG_OPTEE_REVISION_MAJOR ?= 3
 CFG_OPTEE_REVISION_MINOR ?= 17
+CFG_OPTEE_REVISION_EXTRA ?=
 
 # Trusted OS implementation version
 TEE_IMPL_VERSION ?= $(shell git describe --always --dirty=-dev 2>/dev/null || \
-		      echo Unknown_$(CFG_OPTEE_REVISION_MAJOR).$(CFG_OPTEE_REVISION_MINOR))
+		      echo Unknown_$(CFG_OPTEE_REVISION_MAJOR).$(CFG_OPTEE_REVISION_MINOR))$(CFG_OPTEE_REVISION_EXTRA)
 ifeq ($(CFG_OS_REV_REPORTS_GIT_SHA1),y)
 TEE_IMPL_GIT_SHA1 := 0x$(shell git rev-parse --short=8 HEAD 2>/dev/null || echo 0)
 else


### PR DESCRIPTION
Adds CFG_OPTEE_REVISION_EXTRA (default: empty) which can be used to
append a custom string to the revision string shown in the boot banner.
A typical use case is build environments such as Yocto/OpenEmbedded
which check out a particular version of the optee_os repository and may
add patches on top. In this case the revision string is something like:

  3.17.0-dev (gcc version ...

which doesn't give any information on what modifications are added and
therefore makes it difficult to know for sure if a deployed binary is
indeed the expected one (even more so when the build date is fixed via
SOURCE_DATE_EPOCH for reproducible builds).
CFG_OPTEE_REVISION_EXTRA allows to append a specific build identifier.
For example:

  $ make CFG_OPTEE_REVISION_EXTRA=-mybuild_1234

would give:

  3.17.0-dev-mybuild_1234

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
