### PR TITLE
Simplify setting of CFG_ARM64_core, CFG_ARM32_core, CFG_WITH_LPAE

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -35,6 +35,7 @@ CFG_KERN_LINKER_ARCH ?= aarch64
 # 36 bits, 64GB.
 # (etc.)
 CFG_CORE_ARM64_PA_BITS ?= 32
+$(call force,CFG_WITH_LPAE,y)
 else
 ifeq ($(CFG_ARM32_core),y)
 CFG_KERN_LINKER_FORMAT ?= elf32-littlearm

--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -26,6 +26,9 @@ CFG_MMAP_REGIONS ?= 13
 CFG_RESERVED_VASPACE_SIZE ?= (1024 * 1024 * 10)
 
 ifeq ($(CFG_ARM64_core),y)
+ifeq ($(CFG_ARM32_core),y)
+$(error CFG_ARM64_core and CFG_ARM32_core cannot be both 'y')
+endif
 CFG_KERN_LINKER_FORMAT ?= elf64-littleaarch64
 CFG_KERN_LINKER_ARCH ?= aarch64
 # TCR_EL1.IPS needs to be initialized according to the largest physical
@@ -37,12 +40,9 @@ CFG_KERN_LINKER_ARCH ?= aarch64
 CFG_CORE_ARM64_PA_BITS ?= 32
 $(call force,CFG_WITH_LPAE,y)
 else
-ifeq ($(CFG_ARM32_core),y)
+$(call force,CFG_ARM32_core,y)
 CFG_KERN_LINKER_FORMAT ?= elf32-littlearm
 CFG_KERN_LINKER_ARCH ?= arm
-else
-$(error Error: CFG_ARM64_core or CFG_ARM32_core should be defined)
-endif
 endif
 
 ifeq ($(CFG_TA_FLOAT_SUPPORT),y)

--- a/core/arch/arm/plat-amlogic/conf.mk
+++ b/core/arch/arm/plat-amlogic/conf.mk
@@ -15,4 +15,3 @@ $(call force,CFG_AMLOGIC_UART,y)
 
 $(call force,CFG_WITH_PAGER,n)
 $(call force,CFG_ARM64_core,y)
-$(call force,CFG_WITH_LPAE,y)

--- a/core/arch/arm/plat-d02/conf.mk
+++ b/core/arch/arm/plat-d02/conf.mk
@@ -18,7 +18,6 @@ $(call force,CFG_WITH_LPAE,y)
 ifeq ($(CFG_ARM64_core),y)
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 655360
 else
-$(call force,CFG_ARM32_core,y)
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 524288
 endif
 

--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -7,9 +7,7 @@ $(call force,CFG_PL011,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 endif
 

--- a/core/arch/arm/plat-hikey/conf.mk
+++ b/core/arch/arm/plat-hikey/conf.mk
@@ -7,10 +7,6 @@ $(call force,CFG_PL011,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-ifneq ($(CFG_ARM64_core),y)
-$(call force,CFG_ARM32_core,y)
-endif
-
 CFG_NUM_THREADS ?= 8
 CFG_CRYPTO_WITH_CE ?= y
 

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -462,7 +462,6 @@ ifeq ($(CFG_ARM64_core),y)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_GIC,y)
-$(call force,CFG_WITH_LPAE,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 

--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -18,8 +18,4 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 
-ifneq ($(CFG_ARM64_core),y)
-$(call force,CFG_ARM32_core,y)
-endif
-
 include core/arch/arm/cpu/cortex-armv8-0.mk

--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -18,9 +18,7 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 endif
 

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -142,9 +142,7 @@ endif
 #Keeping Number of TEE thread equal to number of cores on the SoC
 CFG_NUM_THREADS ?= CFG_TEE_CORE_NB_CORE
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 $(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
 endif

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -143,7 +143,6 @@ endif
 CFG_NUM_THREADS ?= CFG_TEE_CORE_NB_CORE
 
 ifneq ($(CFG_ARM64_core),y)
-$(call force,CFG_ARM32_core,y)
 $(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
 endif
 

--- a/core/arch/arm/plat-marvell/conf.mk
+++ b/core/arch/arm/plat-marvell/conf.mk
@@ -98,9 +98,7 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 endif
 

--- a/core/arch/arm/plat-marvell/conf.mk
+++ b/core/arch/arm/plat-marvell/conf.mk
@@ -98,8 +98,4 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 
-ifneq ($(CFG_ARM64_core),y)
-$(call force,CFG_ARM32_core,y)
-endif
-
 CFG_WITH_STATS ?= y

--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -8,9 +8,7 @@ $(call force,CFG_8250_UART,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 endif
 

--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -8,10 +8,6 @@ $(call force,CFG_8250_UART,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-ifneq ($(CFG_ARM64_core),y)
-$(call force,CFG_ARM32_core,y)
-endif
-
 # default DRAM base address
 CFG_DRAM_BASE ?= 0x40000000
 

--- a/core/arch/arm/plat-poplar/conf.mk
+++ b/core/arch/arm/plat-poplar/conf.mk
@@ -7,7 +7,6 @@ $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
 ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 655360
 else
 $(call force,CFG_ARM32_core,y)

--- a/core/arch/arm/plat-poplar/conf.mk
+++ b/core/arch/arm/plat-poplar/conf.mk
@@ -9,7 +9,6 @@ $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 ifeq ($(CFG_ARM64_core),y)
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 655360
 else
-$(call force,CFG_ARM32_core,y)
 CFG_CORE_TZSRAM_EMUL_SIZE ?= 524288
 endif
 

--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -58,6 +58,5 @@ endif
 ifeq ($(platform-flavor-armv8),1)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
-$(call force,CFG_WITH_LPAE,y)
 ta-targets = ta_arm64
 endif

--- a/core/arch/arm/plat-rpi3/conf.mk
+++ b/core/arch/arm/plat-rpi3/conf.mk
@@ -12,9 +12,7 @@ $(call force,CFG_8250_UART,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 endif
 

--- a/core/arch/arm/plat-rpi3/conf.mk
+++ b/core/arch/arm/plat-rpi3/conf.mk
@@ -12,10 +12,6 @@ $(call force,CFG_8250_UART,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-ifneq ($(CFG_ARM64_core),y)
-$(call force,CFG_ARM32_core,y)
-endif
-
 CFG_NUM_THREADS ?= 4
 CFG_CRYPTO_WITH_CE ?= n
 

--- a/core/arch/arm/plat-rzg/conf.mk
+++ b/core/arch/arm/plat-rzg/conf.mk
@@ -37,7 +37,6 @@ CFG_TZDRAM_START ?= 0x44100000
 CFG_TZDRAM_SIZE ?= 0x03D00000
 CFG_TEE_RAM_VA_SIZE ?= 0x100000
 ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
 supported-ta-targets = ta_arm64
 else
 $(call force,CFG_ARM32_core,y)

--- a/core/arch/arm/plat-rzg/conf.mk
+++ b/core/arch/arm/plat-rzg/conf.mk
@@ -38,8 +38,6 @@ CFG_TZDRAM_SIZE ?= 0x03D00000
 CFG_TEE_RAM_VA_SIZE ?= 0x100000
 ifeq ($(CFG_ARM64_core),y)
 supported-ta-targets = ta_arm64
-else
-$(call force,CFG_ARM32_core,y)
 endif
 
 CFG_DT ?= y

--- a/core/arch/arm/plat-sprd/conf.mk
+++ b/core/arch/arm/plat-sprd/conf.mk
@@ -4,11 +4,6 @@ include core/arch/arm/cpu/cortex-armv8-0.mk
 
 $(call force,CFG_TEE_CORE_NB_CORE,8)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
-
-ifneq ($(CFG_ARM64_core),y)
-$(call force,CFG_ARM32_core,y)
-endif
-
 $(call force,CFG_GIC,y)
 $(call force,CFG_SPRD_UART,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)

--- a/core/arch/arm/plat-sprd/conf.mk
+++ b/core/arch/arm/plat-sprd/conf.mk
@@ -5,9 +5,7 @@ include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,8)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 endif
 

--- a/core/arch/arm/plat-sunxi/conf.mk
+++ b/core/arch/arm/plat-sunxi/conf.mk
@@ -29,7 +29,6 @@ endif
 ifeq ($(PLATFORM_FLAVOR),sun50i_a64)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_ARM64_core,y)
-$(call force,CFG_WITH_LPAE,y)
 
 CFG_TZDRAM_START ?= 0x40000000
 CFG_TZDRAM_SIZE  ?= 0x2000000

--- a/core/arch/arm/plat-synquacer/conf.mk
+++ b/core/arch/arm/plat-synquacer/conf.mk
@@ -14,7 +14,6 @@ CFG_SHMEM_SIZE ?= 0x00400000
 
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 
-$(call force,CFG_WITH_LPAE,y)
 $(call force,CFG_ARM64_core,y)
 supported-ta-targets = ta_arm64
 

--- a/core/arch/arm/plat-totalcompute/conf.mk
+++ b/core/arch/arm/plat-totalcompute/conf.mk
@@ -16,7 +16,6 @@ $(call force,CFG_PL011,y)
 $(call force,CFG_PM_STUBS,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_ARM64_core,y)
-$(call force,CFG_WITH_LPAE,y)
 
 ifeq ($(platform-debugger-arm),1)
 # ARM debugger needs this

--- a/core/arch/arm/plat-uniphier/conf.mk
+++ b/core/arch/arm/plat-uniphier/conf.mk
@@ -37,7 +37,6 @@ $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 ta-targets = ta_arm32
 
 ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
 ta-targets += ta_arm64
 else
 $(call force,CFG_ARM32_core,y)

--- a/core/arch/arm/plat-versal/conf.mk
+++ b/core/arch/arm/plat-versal/conf.mk
@@ -28,7 +28,6 @@ CFG_SHMEM_SIZE     ?= 0x10000000
 
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_CORE_ARM64_PA_BITS,43)
-$(call force,CFG_WITH_LPAE,y)
 else
 $(call force,CFG_ARM32_core,y)
 endif

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -48,9 +48,7 @@ CFG_TPM_LOG_BASE_ADDR ?= 0x402c951
 CFG_TPM_MAX_LOG_SIZE ?= 0x200
 endif
 
-ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-else
+ifneq ($(CFG_ARM64_core),y)
 $(call force,CFG_ARM32_core,y)
 endif
 

--- a/core/arch/arm/plat-zynqmp/conf.mk
+++ b/core/arch/arm/plat-zynqmp/conf.mk
@@ -15,8 +15,6 @@ $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_CORE_ASLR,n)
 
 ifeq ($(CFG_ARM64_core),y)
-$(call force,CFG_WITH_LPAE,y)
-
 # ZynqMP supports up to 40 bits of physical addresses
 CFG_CORE_ARM64_PA_BITS ?= 40
 else


### PR DESCRIPTION
A couple of patches to move common patterns from platform config to `core/arch/arm/arm.mk`.