### PR TITLE
drivers: xiphera_trng: Add support for XIP8001B TRNG

### DIFF
--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -46,6 +46,7 @@ srcs-$(CFG_LS_DSPI) += ls_dspi.c
 srcs-$(CFG_IMX_RNGB) += imx_rngb.c
 srcs-$(CFG_IMX_OCOTP) += imx_ocotp.c
 srcs-$(CFG_IMX_SC) += imx_mu.c imx_sc_api.c
+srcs-$(CFG_XIPHERA_TRNG) += xiphera_trng.c
 srcs-$(CFG_ZYNQMP_CSU_PUF) += zynqmp_csu_puf.c
 srcs-$(CFG_ZYNQMP_CSUDMA) += zynqmp_csudma.c
 srcs-$(CFG_ZYNQMP_CSU_AES) += zynqmp_csu_aes.c

--- a/core/drivers/xiphera_trng.c
+++ b/core/drivers/xiphera_trng.c
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Vaisala Oyj
+ */
+
+#include <assert.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <kernel/spinlock.h>
+#include <libfdt.h>
+#include <platform_config.h>
+#include <rng_support.h>
+#include <string.h>
+#include <tee/tee_cryp_utl.h>
+
+#define CONTROL_REG                     0x00000000
+#define STATUS_REG                      0x00000004
+#define RAND_REG                        0x00000000
+
+#define HOST_TO_TRNG_RESET              0x00000001
+#define HOST_TO_TRNG_RELEASE_RESET      0x00000002
+#define HOST_TO_TRNG_ENABLE             0x80000000
+#define HOST_TO_TRNG_ZEROIZE            0x80000004
+#define HOST_TO_TRNG_ACK_ZEROIZE        0x80000008
+#define HOST_TO_TRNG_READ               0x8000000F
+
+/* trng statuses */
+#define TRNG_ACK_RESET                  0x000000AC
+#define TRNG_SUCCESSFUL_STARTUP         0x00000057
+#define TRNG_FAILED_STARTUP             0x000000FA
+#define TRNG_NEW_RAND_AVAILABLE         0x000000ED
+
+static unsigned int trng_lock = SPINLOCK_UNLOCK;
+
+static vaddr_t xiphera_trng_base;
+
+static uint32_t xiphera_trng_read32(void)
+{
+	uint32_t value = 0;
+	uint32_t exceptions = 0;
+	uint32_t status = 0;
+
+	exceptions = cpu_spin_lock_xsave(&trng_lock);
+
+	while (true) {
+		/* Wait until we have value available */
+		status = io_read32(xiphera_trng_base + STATUS_REG);
+		if (status != TRNG_NEW_RAND_AVAILABLE)
+			continue;
+
+		value = io_read32(xiphera_trng_base + RAND_REG);
+
+		/*
+		 * Ack that RNG value has been consumed and trigger new one to
+		 * be generated
+		 */
+		io_write32(xiphera_trng_base + CONTROL_REG, HOST_TO_TRNG_READ);
+		io_write32(xiphera_trng_base + CONTROL_REG,
+			   HOST_TO_TRNG_ENABLE);
+
+		break;
+	}
+
+	cpu_spin_unlock_xrestore(&trng_lock, exceptions);
+
+	return value;
+}
+
+/* This is a true RNG, no need for seeding */
+void plat_rng_init(void)
+{
+}
+
+TEE_Result crypto_rng_read(void *buf, size_t len)
+{
+	uint8_t *rngbuf = buf;
+	uint32_t val = 0;
+	size_t len_to_copy = 0;
+
+	assert(buf);
+	assert(xiphera_trng_base);
+
+	while (len) {
+		val = xiphera_trng_read32();
+		len_to_copy = MIN(len, sizeof(uint32_t));
+		memcpy(rngbuf, &val, len_to_copy);
+		rngbuf += len_to_copy;
+		len -= len_to_copy;
+	}
+
+	return TEE_SUCCESS;
+}
+
+uint8_t hw_get_random_byte(void)
+{
+	uint8_t data = 0;
+
+	assert(xiphera_trng_base);
+
+	data = xiphera_trng_read32() & 0xFF;
+
+	return data;
+}
+
+static TEE_Result xiphera_trng_probe(const void *fdt, int node,
+				     const void *compat_data __unused)
+{
+	int dt_status = _fdt_get_status(fdt, node);
+	uint32_t status = 0;
+	size_t size = 0;
+
+	/* Skip non-secure instances */
+	if (dt_status != DT_STATUS_OK_SEC)
+		return TEE_ERROR_NODE_DISABLED;
+
+	if (xiphera_trng_base) {
+		EMSG("Only one secure instance is supported");
+		return TEE_ERROR_GENERIC;
+	}
+
+	if (dt_map_dev(fdt, node, &xiphera_trng_base, &size) < 0)
+		return TEE_ERROR_GENERIC;
+
+	/*
+	 * The TRNG needs to be first reset in order to provide stable
+	 * operation.
+	 *
+	 * Reset of the chip should complete within 200 us but in some cases it
+	 * could take up to 400 us. If it is not ready within 400 us assume
+	 * there is problem.
+	 */
+	io_write32(xiphera_trng_base + CONTROL_REG, HOST_TO_TRNG_RESET);
+	udelay(200);
+
+	status = io_read32(xiphera_trng_base + STATUS_REG);
+	if (status != TRNG_ACK_RESET) {
+		/*
+		 * Give it additional 200 us to allow it to reset.
+		 *
+		 * If still not done -> error out.
+		 */
+		udelay(200);
+		status = io_read32(xiphera_trng_base + STATUS_REG);
+		if (status != TRNG_ACK_RESET) {
+			EMSG("Failed to reset TRNG\n");
+			return TEE_ERROR_GENERIC;
+		}
+	}
+
+	/*
+	 * Now TRNG should be internally stable.
+	 *
+	 * Clear internal random number generation engine to start in stable
+	 * state and give it 20 ms to enable good random number entropy and
+	 * then check that random number engine is ready.
+	 */
+	io_write32(xiphera_trng_base + CONTROL_REG,
+		   HOST_TO_TRNG_RELEASE_RESET);
+	io_write32(xiphera_trng_base + CONTROL_REG, HOST_TO_TRNG_ENABLE);
+	io_write32(xiphera_trng_base + CONTROL_REG, HOST_TO_TRNG_ZEROIZE);
+	mdelay(20);
+
+	status = io_read32(xiphera_trng_base + STATUS_REG);
+	if (status != TRNG_SUCCESSFUL_STARTUP) {
+		/*
+		 * Check specifically if there were startup test errors to aid
+		 * in debugging TRNG implementation in FPGA
+		 */
+		if (status == TRNG_FAILED_STARTUP) {
+			EMSG("Startup tests have failed\n");
+			return TEE_ERROR_GENERIC;
+		}
+
+		EMSG("Startup tests yielded no response -> TRNG stuck\n");
+		return TEE_ERROR_GENERIC;
+	}
+
+	io_write32(xiphera_trng_base + CONTROL_REG, HOST_TO_TRNG_ACK_ZEROIZE);
+
+	DMSG("TRNG initialized\n");
+
+	return TEE_SUCCESS;
+}
+
+static const struct dt_device_match xiphera_trng_match_table[] = {
+	{ .compatible = "xiphera,xip8001b-trng" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(xiphera_trng_dt_driver) = {
+	.name = "xiphera_trng",
+	.type = DT_DRIVER_NOTYPE,
+	.match_table = xiphera_trng_match_table,
+	.probe = xiphera_trng_probe,
+};

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -358,6 +358,9 @@ static TEE_Result probe_driver_node(const void *fdt,
 		DMSG("element: %s on node %s deferred %u time(s)", drv_name,
 		     node_name, elt->deferrals);
 		break;
+	case TEE_ERROR_NODE_DISABLED:
+		DMSG("element: %s on node %s is disabled", drv_name, node_name);
+		break;
 	default:
 		TAILQ_INSERT_HEAD(&dt_driver_failed_list, elt, link);
 

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -21,6 +21,12 @@
 #define TEE_ERROR_DEFER_DRIVER_INIT	0x80000000
 
 /*
+ * TEE_ERROR_NODE_DISABLED - Device driver failed to initialize because it is
+ * not allocated for TEE environment.
+ */
+#define TEE_ERROR_NODE_DISABLED		0x80000001
+
+/*
  * HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
  */
 


### PR DESCRIPTION
Adds support for Xiphera's XIP8001B true random number generator.

XIP8001B is a FPGA IP core that can be synthesized in FPGA devices to
provide TRNG source for device where it is missing like Xilinx Zynq-7000
and Xilinx Zynq MPSoC.

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>
Co-developed-by: Atte Tommiska <atte.tommiska@xiphera.com>

---

Example device tree entries:
```
       xiphera_trng_0: xiphera_trng@aaaa0000 {
                compatible = "xiphera,xip8001b-trng";
                status = "okay";
                secure-status = "disabled";

                reg = <0x0 0xaaaa0000 0x0 0x10000>;

                clock-names = "S_AXI_ACLK";
                clocks = <&zynqmp_clk 71>;
        };

        xiphera_trng_1: xiphera_trng@bbbb0000 {
                compatible = "xiphera,xip8001b-trng";
                status = "disabled";
                secure-status = "okay";

                reg = <0x0 0xbbbb0000  0x0 0x10000>;

                clock-names = "S_AXI_ACLK";
                clocks = <&zynqmp_clk 71>;
        };
```

Complementary PR:
- https://github.com/OP-TEE/optee_os/pull/5350
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
