### PR TITLE
Add support to use external device tree and then map specifically device as secure

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -131,6 +131,20 @@ const struct dt_driver *dt_find_compatible_driver(const void *fdt, int offs);
 int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size);
 
 /*
+ * Map a device into secure memory and return the base VA and the mapping size.
+ * If the mapping already exists, the function simply returns the @base and
+ * @size information.
+ *
+ * @offs is the offset of the node that describes the device in @fdt.
+ * @base receives the base virtual address corresponding to the base physical
+ * address of the "reg" property
+ * @size receives the size of the mapping
+ *
+ * Returns 0 on success or -1 in case of error.
+ */
+int dt_map_secure_dev(const void *fdt, int offs, vaddr_t *base, size_t *size);
+
+/*
  * Check whether the node at @offs contains the property with propname or not.
  *
  * @offs is the offset of the node that describes the device in @fdt.

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -671,11 +671,9 @@ static TEE_Result probe_dt_drivers_early(void)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const void *fdt = NULL;
 
-	if (!IS_ENABLED(CFG_EMBED_DTB))
+	fdt = get_dt();
+	if (!fdt)
 		return TEE_SUCCESS;
-
-	fdt = get_embedded_dt();
-	assert(fdt);
 
 	parse_node(fdt, fdt_path_offset(fdt, "/"));
 
@@ -694,11 +692,9 @@ static TEE_Result probe_dt_drivers(void)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const void *fdt = NULL;
 
-	if (!IS_ENABLED(CFG_EMBED_DTB))
+	fdt = get_dt();
+	if (!fdt)
 		return TEE_SUCCESS;
-
-	fdt = get_embedded_dt();
-	assert(fdt);
 
 	res = process_probe_list(fdt);
 	if (res || !TAILQ_EMPTY(&dt_driver_failed_list)) {
@@ -720,12 +716,11 @@ static TEE_Result release_probe_lists(void)
 	struct dt_driver_probe *next = NULL;
 	struct dt_driver_provider *prov = NULL;
 	struct dt_driver_provider *next_prov = NULL;
-	const void * __maybe_unused fdt = NULL;
+	const void *fdt = NULL;
 
-	if (!IS_ENABLED(CFG_EMBED_DTB))
+	fdt = get_dt();
+	if (!fdt)
 		return TEE_SUCCESS;
-
-	fdt = get_embedded_dt();
 
 	assert(fdt && TAILQ_EMPTY(&dt_driver_probe_list));
 


### PR DESCRIPTION
We are using system level device tree where we use Xilinx Vivado tooling style device tree as a base (cleaned up version of that) .
This allows flexibility for our FPGA developers to change base addresses of devices more freely and then device trees just match that.

In order to load our Xiphera TRNG devices and our own drivers in OP-TEE this PR enabled support to load also devices from external device tree.

Other feature that this PR adds is possibility to map TrustZone aware IP core we have developed as secure in OP-TEE and then Linux will use it in non-secure. With standard device mapping logic device would be mapped as non-secure and OP-TEE would not allow the access.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
