### PR TITLE
Fixes for the SNVS driver

### DIFF
--- a/core/drivers/imx_snvs.c
+++ b/core/drivers/imx_snvs.c
@@ -207,7 +207,7 @@ bool plat_rpmb_key_is_ready(void)
 
 TEE_Result imx_snvs_set_master_otpmk(void)
 {
-	if (is_otpmk_valid())
+	if (!is_otpmk_valid())
 		return TEE_ERROR_BAD_STATE;
 
 	if (is_mks_locked()) {

--- a/core/drivers/imx_snvs.c
+++ b/core/drivers/imx_snvs.c
@@ -121,8 +121,8 @@ static enum snvs_security_cfg snvs_get_security_cfg(void)
 	vaddr_t base = core_mmu_get_va(SNVS_BASE, MEM_AREA_IO_SEC,
 				       SNVS_SIZE);
 
-	val = io_read32(base + SNVS_HPSR) &
-	      SNVS_HPSR_SYS_SECURITY_CFG >> SNVS_HPSR_SYS_SECURITY_CFG_OFFSET;
+	val = (io_read32(base + SNVS_HPSR) & SNVS_HPSR_SYS_SECURITY_CFG) >>
+	      SNVS_HPSR_SYS_SECURITY_CFG_OFFSET;
 
 	switch (val) {
 	case 0b0000:
@@ -149,8 +149,8 @@ static enum snvs_security_cfg snvs_get_security_cfg(void)
 	vaddr_t base = core_mmu_get_va(SNVS_BASE, MEM_AREA_IO_SEC,
 				       SNVS_SIZE);
 
-	val = io_read32(base + SNVS_HPSR) &
-	      SNVS_HPSR_SYS_SECURITY_CFG >> SNVS_HPSR_SYS_SECURITY_CFG_OFFSET;
+	val = (io_read32(base + SNVS_HPSR) & SNVS_HPSR_SYS_SECURITY_CFG) >>
+	      SNVS_HPSR_SYS_SECURITY_CFG_OFFSET;
 
 	switch (val) {
 	case 0b000:


### PR DESCRIPTION
Hello,

Here are two fixes for silly mistakes in the SNVS driver.
These two problems have been found after testing on a 8mscale closed platform with OTP selected as a master key.

