### PR TITLE
SP: Add dump state

### DIFF
--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -807,6 +807,20 @@ static bool sp_handle_svc(struct thread_svc_regs *regs)
 	return false;
 }
 
+static void sp_dump_state(struct ts_ctx *ctx)
+{
+	struct sp_ctx *utc = to_sp_ctx(ctx);
+
+	if (utc->uctx.dump_entry_func) {
+		TEE_Result res = ldelf_dump_state(&utc->uctx);
+
+		if (!res || res == TEE_ERROR_TARGET_DEAD)
+			return;
+	}
+
+	user_mode_ctx_print_mappings(&utc->uctx);
+}
+
 /*
  * Note: this variable is weak just to ease breaking its dependency chain
  * when added to the unpaged area.
@@ -814,6 +828,7 @@ static bool sp_handle_svc(struct thread_svc_regs *regs)
 const struct ts_ops sp_ops __weak __relrodata_unpaged("sp_ops") = {
 	.enter_invoke_cmd = sp_enter_invoke_cmd,
 	.handle_svc = sp_handle_svc,
+	.dump_state = sp_dump_state,
 };
 
 static TEE_Result sp_init_all(void)


### PR DESCRIPTION
Add dump state for SPs. This will make it possible for the symbolize
script to print SP call stack on a panic,


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
