### PR TITLE
core: pta: attestation: fix buffer size for generated key

### DIFF
--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -180,23 +180,26 @@ static TEE_Result deserialize_key(uint8_t *buf, size_t buf_sz)
 
 	res = allocate_key();
 	if (res)
-		goto out;
+		return res;
 
 	sz = deserialize_bignum(p, buf_sz, key->e);
 	if (!sz)
-		goto out;
+		goto err;
 	p += sz;
 	buf_sz -= sz;
 	sz = deserialize_bignum(p, buf_sz, key->d);
 	if (!sz)
-		goto out;
+		goto err;
 	p += sz;
 	buf_sz -= sz;
 	sz = deserialize_bignum(p, buf_sz, key->n);
 	if (!sz)
-		goto out;
-out:
-	return res;
+		goto err;
+
+	return TEE_SUCCESS;
+err:
+	free_key();
+	return TEE_ERROR_GENERIC;
 }
 
 static TEE_Result sec_storage_obj_read(TEE_UUID *uuid, uint32_t storage_id,

--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -195,8 +195,6 @@ static TEE_Result deserialize_key(uint8_t *buf, size_t buf_sz)
 	sz = deserialize_bignum(p, buf_sz, key->n);
 	if (!sz)
 		goto out;
-	buf_sz -= sz;
-	assert(!buf_sz);
 out:
 	return res;
 }


### PR DESCRIPTION
There is assertion error in the attestation PTA when it comes to
deserialize the key. Here are the logs:

* regression_1037 Remote attestation
o regression_1037.1 Get public key
E/TC:? 0 assertion '!buf_sz' failed at core/pta/attestation.c:199 <deserialize_key>
E/TC:3 0 Panic at core/kernel/assert.c:28 <_assert_break>
E/TC:3 0 TEE load address @ 0xbe000000
E/TC:3 0 Call stack:
E/TC:3 0  0xbe0091b4
E/TC:3 0  0xbe024b5c
E/TC:3 0  0xbe02292c
E/TC:3 0  0xbe02fde4
E/TC:3 0  0xbe0300c4
E/TC:3 0  0xbe029a3c
E/TC:3 0  0xbe025e70
E/TC:3 0  0xbe0336e0
E/TC:3 0  0xbe007070
E/TC:3 0  0xbe0071ec

To reproduce the issue, you need a persistent storage and follow these
steps:
 $ xtest 1037
 *reboot the platform*
 $ xtest 1037

When allocating the key buffer, the maximum buffer size is allocated
(1033 bytes) whatever the size specified by CFG_ATTESTATION_PTA_KEY_SIZE.

With default attestation key size (CFG_ATTESTATION_PTA_KEY_SIZE) of
3072 bits, only 777 bytes is needed to store the key but the allocated
buffer size is still 1033 bytes.

When the key has already been generated, the key stored is deserialized
and the deserialize_key() function expects the size of the previously
generated key to be equal to the maximum buffer size.

This issue can be fixed by allocating only the required buffer size of
the key size specified by CFG_ATTESTATION_PTA_KEY_SIZE.

Fixes: 7e05ec25b ("core: pta: add remote attestation PTA")
Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
