### PR TITLE
core: armv7: fix ASLR error

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -878,17 +878,6 @@ UNWIND(	.cantunwind)
 	wait_primary
 
 	set_sp
-#ifdef CFG_CORE_ASLR
-	/*
-	 * stack_tmp_export which is used as base when initializing sp has
-	 * been relocated to the new offset. Since MMU isn't enabled on
-	 * this CPU yet we need to restore the corresponding physical
-	 * address.
-	 */
-	adr	r0, boot_mmu_config
-	ldr	r0, [r0, #CORE_MMU_CONFIG_LOAD_OFFSET]
-	sub	sp, sp, r0
-#endif
 
 #if defined (CFG_BOOT_SECONDARY_REQUEST)
 	/* if L1 is not invalidated before, do it here */


### PR DESCRIPTION
With commit 528dabb28254 ("core: suppress text relocation on
stack_tmp_export") the stack pointer is calculated using a relative
address instead of based on an absolute address which is relocated with
ASLR enabled.

Prior to this on Armv7 we compensate for a relocation update for
stack_tmp_export_rel in reset_secondary() just after the stack pointer
was initialized. So now when the relocation update of stack_tmp_export_rel
is gone remove the compensating code too.

Fixes: 528dabb28254 ("core: suppress text relocation on stack_tmp_export")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
