### PR TITLE
core: sp: fix SP manifest UUID endianness

### DIFF
--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -396,7 +396,7 @@ static TEE_Result check_fdt(const void * const fdt, const TEE_UUID *uuid)
 	}
 
 	for (i = 0; i < 4; i++)
-		uuid_array[i] = fdt32_to_cpu(prop[i]);
+		uuid_array[i] = TEE_U32_FROM_BIG_ENDIAN(fdt32_to_cpu(prop[i]));
 	tee_uuid_from_octets(&fdt_uuid, (uint8_t *)uuid_array);
 
 	if (memcmp(uuid, &fdt_uuid, sizeof(fdt_uuid))) {


### PR DESCRIPTION
The Trusted Services project writes the SP UUIDs into the SP manifest in
big-endian format. However, tee_uuid_from_octets() expects little-endian
input. Fix this mismatch.