### PR TITLE
crypto-api: ecc keypairgen for NIST P521

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -39,6 +39,28 @@ static size_t get_ecc_key_size_bytes(uint32_t curve)
 }
 
 /*
+ * Returns the key size in bits for the given ECC curve
+ *
+ * @curve   ECC Curve ID
+ */
+static size_t get_ecc_key_size_bits(uint32_t curve)
+{
+	switch (curve) {
+	case TEE_ECC_CURVE_NIST_P192:
+	case TEE_ECC_CURVE_NIST_P224:
+	case TEE_ECC_CURVE_NIST_P256:
+	case TEE_ECC_CURVE_NIST_P384:
+		return 8 * get_ecc_key_size_bytes(curve);
+
+	case TEE_ECC_CURVE_NIST_P521:
+		return 521;
+
+	default:
+		return 0;
+	}
+}
+
+/*
  * Verify if the cryptographic algorithm @algo is valid for
  * the ECC curve
  *
@@ -106,7 +128,7 @@ static TEE_Result ecc_generate_keypair(struct ecc_keypair *key,
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	key_size_bits = get_ecc_key_size_bytes(key->curve) * 8;
+	key_size_bits = get_ecc_key_size_bits(key->curve);
 
 	ecc = drvcrypt_get_ops(CRYPTO_ECC);
 	if (ecc)


### PR DESCRIPTION
Provide the valid number of bits for the curve to the underlying interface.
This allows the call to be routed to software implementations.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
