### PR TITLE
drivers: scmi-msg: Fix parameter type

### DIFF
--- a/core/drivers/scmi-msg/clock.c
+++ b/core/drivers/scmi-msg/clock.c
@@ -367,7 +367,7 @@ static const scmi_msg_handler_t scmi_clock_handler_table[] = {
 	[SCMI_CLOCK_CONFIG_SET] = scmi_clock_config_set,
 };
 
-static bool message_id_is_supported(size_t message_id)
+static bool message_id_is_supported(unsigned int message_id)
 {
 	return message_id < ARRAY_SIZE(scmi_clock_handler_table) &&
 	       scmi_clock_handler_table[message_id];

--- a/core/drivers/scmi-msg/voltage_domain.c
+++ b/core/drivers/scmi-msg/voltage_domain.c
@@ -385,7 +385,7 @@ static const scmi_msg_handler_t handler_array[] = {
 	[SCMI_VOLTAGE_LEVEL_GET] = scmi_voltd_level_get,
 };
 
-static bool message_id_is_supported(size_t id)
+static bool message_id_is_supported(unsigned int id)
 {
 	return id < ARRAY_SIZE(handler_array) && handler_array[id];
 }


### PR DESCRIPTION
In order to make clock.c and voltage_domain.c compile on
64 bit architecture, we cannot use unsigned int in the
function prototype and size_t in the function definition.

Signed-off-by: Ludvig Pärsson <ludvig.parsson@axis.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
