### PR TITLE
ldelf: add DT_GNU_HASH support

### DIFF
--- a/ldelf/ta_elf.h
+++ b/ldelf/ta_elf.h
@@ -59,6 +59,8 @@ struct ta_elf {
 
 	/* DT_HASH hash table for faster resolution of external symbols */
 	void *hashtab;
+	/* DT_GNU_HASH table as an alternative to DT_HASH */
+	void *gnu_hashtab;
 
 	/* DT_SONAME */
 	char *soname;
@@ -94,6 +96,21 @@ struct ta_elf {
 };
 
 TAILQ_HEAD(ta_elf_queue, ta_elf);
+
+/* Format of the DT_GNU_HASH entry in the ELF dynamic section */
+struct gnu_hashtab {
+	uint32_t nbuckets;
+	uint32_t symoffset;
+	uint32_t bloom_size;
+	uint32_t bloom_shift;
+	/*
+	 * Followed by:
+	 *
+	 * uint{32,64}_t bloom[bloom_size];
+	 * uint32_t buckets[nbuckets];
+	 * uint32_t chain[];
+	 */
+};
 
 typedef void (*print_func_t)(void *pctx, const char *fmt, va_list ap)
 	__printf(2, 0);

--- a/ldelf/ta_elf_rel.c
+++ b/ldelf/ta_elf_rel.c
@@ -32,10 +32,21 @@ static uint32_t elf_hash(const char *name)
 	return h;
 }
 
-static bool __resolve_sym(struct ta_elf *elf, unsigned int st_bind,
-			  unsigned int st_type, size_t st_shndx,
-			  size_t st_name, size_t st_value, const char *name,
-			  vaddr_t *val, bool weak_ok)
+static uint32_t gnu_hash(const char *name)
+{
+	const unsigned char *p = (const unsigned char *)name;
+	uint32_t h = 5381;
+
+	while (*p)
+		h = (h << 5) + h + *p++;
+
+	return h;
+}
+
+static bool sym_compare(struct ta_elf *elf, unsigned int st_bind,
+			unsigned int st_type, size_t st_shndx,
+			size_t st_name, size_t st_value, const char *name,
+			vaddr_t *val, bool weak_ok)
 {
 	bool bind_ok = false;
 
@@ -78,63 +89,112 @@ static bool __resolve_sym(struct ta_elf *elf, unsigned int st_bind,
 	return true;
 }
 
-static TEE_Result resolve_sym_helper(uint32_t hash, const char *name,
-				     vaddr_t *val, struct ta_elf *elf,
-				     bool weak_ok)
+static bool check_found_sym(struct ta_elf *elf, const char *name, vaddr_t *val,
+			    bool weak_ok, size_t n)
 {
+	Elf32_Sym *sym32 = NULL;
+	Elf64_Sym *sym64 = NULL;
+
+	if (n >= elf->num_dynsyms)
+		err(TEE_ERROR_BAD_FORMAT, "Index out of range");
+
 	/*
-	 * Using uint32_t here for convenience because both Elf64_Word
-	 * and Elf32_Word are 32-bit types
+	 * We're loading values from sym[] which later
+	 * will be used to load something.
+	 * => Spectre V1 pattern, need to cap the index
+	 * against speculation.
 	 */
-	uint32_t *hashtab = elf->hashtab;
-	uint32_t nbuckets = hashtab[0];
-	uint32_t nchains = hashtab[1];
-	uint32_t *bucket = &hashtab[2];
-	uint32_t *chain = &bucket[nbuckets];
-	size_t n = 0;
+	n = confine_array_index(n, elf->num_dynsyms);
 
 	if (elf->is_32bit) {
-		Elf32_Sym *sym = elf->dynsymtab;
-
-		for (n = bucket[hash % nbuckets]; n; n = chain[n]) {
-			if (n >= nchains || n >= elf->num_dynsyms)
-				err(TEE_ERROR_BAD_FORMAT,
-				    "Index out of range");
-			/*
-			 * We're loading values from sym[] which later
-			 * will be used to load something.
-			 * => Spectre V1 pattern, need to cap the index
-			 * against speculation.
-			 */
-			n = confine_array_index(n, elf->num_dynsyms);
-			if (__resolve_sym(elf,
-					  ELF32_ST_BIND(sym[n].st_info),
-					  ELF32_ST_TYPE(sym[n].st_info),
-					  sym[n].st_shndx,
-					  sym[n].st_name,
-					  sym[n].st_value, name, val, weak_ok))
-				return TEE_SUCCESS;
-		}
+		sym32 = elf->dynsymtab;
+		if (sym_compare(elf,
+				ELF32_ST_BIND(sym32[n].st_info),
+				ELF32_ST_TYPE(sym32[n].st_info),
+				sym32[n].st_shndx,
+				sym32[n].st_name,
+				sym32[n].st_value, name, val, weak_ok))
+			return true;
 	} else {
-		Elf64_Sym *sym = elf->dynsymtab;
+		sym64 = elf->dynsymtab;
+		if (sym_compare(elf,
+				ELF64_ST_BIND(sym64[n].st_info),
+				ELF64_ST_TYPE(sym64[n].st_info),
+				sym64[n].st_shndx,
+				sym64[n].st_name,
+				sym64[n].st_value, name, val, weak_ok))
+			return true;
+	}
+
+	return false;
+}
+
+static TEE_Result resolve_sym_helper(const char *name, vaddr_t *val,
+				     struct ta_elf *elf, bool weak_ok)
+{
+	uint32_t n = 0;
+	uint32_t hash = 0;
+
+	if (elf->gnu_hashtab) {
+		struct gnu_hashtab *h = elf->gnu_hashtab;
+		uint32_t *bucket = NULL;
+		uint32_t *chain = NULL;
+		uint32_t hashval = 0;
+
+		hash = gnu_hash(name);
+
+		if (elf->is_32bit) {
+			uint32_t *bloom = (void *)(h + 1);
+			uint32_t word = bloom[(hash / 32) % h->bloom_size];
+			uint32_t mask = BIT32(hash % 32) |
+					BIT32((hash >> h->bloom_shift) % 32);
+
+			if ((word & mask) != mask)
+				return TEE_ERROR_ITEM_NOT_FOUND;
+			bucket = bloom + h->bloom_size;
+		} else {
+			uint64_t *bloom = (void *)(h + 1);
+			uint64_t word = bloom[(hash / 64) % h->bloom_size];
+			uint64_t mask = BIT64(hash % 64) |
+					BIT64((hash >> h->bloom_shift) % 64);
+
+			if ((word & mask) != mask)
+				return TEE_ERROR_ITEM_NOT_FOUND;
+			bucket = (uint32_t *)(bloom + h->bloom_size);
+		}
+		chain = bucket + h->nbuckets;
+
+		n = bucket[hash % h->nbuckets];
+		if (n < h->symoffset)
+			return TEE_ERROR_ITEM_NOT_FOUND;
+
+		hash |= 1;
+		do {
+			hashval = chain[n - h->symoffset];
+
+			if (((hashval | 1) == hash) &&
+			    (check_found_sym(elf, name, val, weak_ok, n)))
+				return TEE_SUCCESS;
+
+			n++;
+		} while (!(hashval & 1));
+	} else if (elf->hashtab) {
+		/*
+		 * Using uint32_t here for convenience because both Elf64_Word
+		 * and Elf32_Word are 32-bit types
+		 */
+		uint32_t *hashtab = elf->hashtab;
+		uint32_t nbuckets = hashtab[0];
+		uint32_t nchains = hashtab[1];
+		uint32_t *bucket = &hashtab[2];
+		uint32_t *chain = &bucket[nbuckets];
+
+		hash = elf_hash(name);
 
 		for (n = bucket[hash % nbuckets]; n; n = chain[n]) {
-			if (n >= nchains || n >= elf->num_dynsyms)
-				err(TEE_ERROR_BAD_FORMAT,
-				    "Index out of range");
-			/*
-			 * We're loading values from sym[] which later
-			 * will be used to load something.
-			 * => Spectre V1 pattern, need to cap the index
-			 * against speculation.
-			 */
-			n = confine_array_index(n, elf->num_dynsyms);
-			if (__resolve_sym(elf,
-					  ELF64_ST_BIND(sym[n].st_info),
-					  ELF64_ST_TYPE(sym[n].st_info),
-					  sym[n].st_shndx,
-					  sym[n].st_name,
-					  sym[n].st_value, name, val, weak_ok))
+			if (n >= nchains)
+				err(TEE_ERROR_BAD_FORMAT, "Index out of range");
+			if (check_found_sym(elf, name, val, weak_ok, n))
 				return TEE_SUCCESS;
 		}
 	}
@@ -154,25 +214,19 @@ TEE_Result ta_elf_resolve_sym(const char *name, vaddr_t *val,
 			      struct ta_elf **found_elf,
 			      struct ta_elf *elf)
 {
-	uint32_t hash = elf_hash(name);
-
 	if (elf) {
 		/* Search global symbols */
-		if (!resolve_sym_helper(hash, name, val, elf,
-					false /* !weak_ok */))
+		if (!resolve_sym_helper(name, val, elf, false /* !weak_ok */))
 			goto success;
 		/* Search weak symbols */
-		if (!resolve_sym_helper(hash, name, val, elf,
-					true /* weak_ok */))
+		if (!resolve_sym_helper(name, val, elf, true /* weak_ok */))
 			goto success;
 	}
 
 	TAILQ_FOREACH(elf, &main_elf_queue, link) {
-		if (!resolve_sym_helper(hash, name, val, elf,
-					false /* !weak_ok */))
+		if (!resolve_sym_helper(name, val, elf, false /* !weak_ok */))
 			goto success;
-		if (!resolve_sym_helper(hash, name, val, elf,
-					true /* weak_ok */))
+		if (!resolve_sym_helper(name, val, elf, true /* weak_ok */))
 			goto success;
 	}
 


### PR DESCRIPTION
It is possible for an ELF to be compiled with --hash-style=gnu;
some distros even have that as their default. This produces an ELF
with no .hash section, but with a .gnu.hash section in its stead.

GNU-style hash sections have better performance than old SYSV-style ones.
It can be expected that, as time goes on, it becomes the new default.

Use the DT_GNU_HASH table for symbol lookup when present, then fall
back onto DT_HASH.

Co-developed-by: Elvira Khabirova <e.khabirova@omp.ru>
Signed-off-by: Elvira Khabirova <e.khabirova@omp.ru>
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
