### PR TITLE
core: dt_driver: rework dt_driver_register_provider()

### DIFF
--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -133,7 +133,10 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
 	}
 
 	phandle = fdt_get_phandle(fdt, nodeoffset);
-	if (!phandle || phandle == (uint32_t)-1) {
+	if (!phandle)
+		return TEE_SUCCESS;
+
+	if (phandle == (uint32_t)-1) {
 		DMSG("Failed to find provide phandle");
 		return TEE_ERROR_GENERIC;
 	}


### PR DESCRIPTION
This change makes dt_driver_register_provider() function return a TEE_SUCCESS instead of an error. Not getting a phandle should result in the provider not being registered with no error returned.