### PR TITLE
plat-stm32mp1: use stm32mp_dt_bindings.h helper

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2019-2020, STMicroelectronics
+ * Copyright (c) 2019-2022, STMicroelectronics
  */
 
 #include <drivers/clk.h>
-#include <dt-bindings/clock/stm32mp1-clks.h>
+#include <drivers/stm32mp_dt_bindings.h>
 #include <initcall.h>
 #include <kernel/delay.h>
 #include <mm/core_memprot.h>

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2017-2018, STMicroelectronics
+ * Copyright (c) 2017-2022, STMicroelectronics
  * Copyright (c) 2016-2018, Linaro Limited
  */
 
@@ -13,7 +13,7 @@
 #include <drivers/stm32_tamp.h>
 #include <drivers/stm32_uart.h>
 #include <drivers/stm32mp1_etzpc.h>
-#include <dt-bindings/clock/stm32mp1-clks.h>
+#include <drivers/stm32mp_dt_bindings.h>
 #include <kernel/boot.h>
 #include <kernel/dt.h>
 #include <kernel/interrupt.h>

--- a/core/arch/arm/plat-stm32mp1/pm/psci.c
+++ b/core/arch/arm/plat-stm32mp1/pm/psci.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2017-2018, STMicroelectronics
+ * Copyright (c) 2017-2022, STMicroelectronics
  */
 
 #include <arm.h>
@@ -10,7 +10,7 @@
 #include <drivers/stm32mp1_pmic.h>
 #include <drivers/stm32mp1_rcc.h>
 #include <drivers/stpmic1.h>
-#include <dt-bindings/clock/stm32mp1-clks.h>
+#include <drivers/stm32mp_dt_bindings.h>
 #include <io.h>
 #include <kernel/cache_helpers.h>
 #include <kernel/delay.h>

--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2019, STMicroelectronics
+ * Copyright (c) 2019-2022, STMicroelectronics
  */
 #include <assert.h>
 #include <compiler.h>
@@ -14,9 +14,7 @@
 #include <drivers/stm32mp1_pwr.h>
 #include <drivers/stpmic1.h>
 #include <drivers/stpmic1_regulator.h>
-#include <dt-bindings/clock/stm32mp1-clks.h>
-#include <dt-bindings/regulator/st,stm32mp15-regulator.h>
-#include <dt-bindings/reset/stm32mp1-resets.h>
+#include <drivers/stm32mp_dt_bindings.h>
 #include <initcall.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2017-2021, STMicroelectronics
+ * Copyright (c) 2017-2022, STMicroelectronics
  */
 
 #include <config.h>
@@ -8,8 +8,7 @@
 #include <drivers/stm32_gpio.h>
 #include <drivers/stm32mp1_etzpc.h>
 #include <drivers/stm32mp1_rcc.h>
-#include <dt-bindings/clock/stm32mp1-clks.h>
-#include <dt-bindings/reset/stm32mp1-resets.h>
+#include <drivers/stm32mp_dt_bindings.h>
 #include <initcall.h>
 #include <io.h>
 #include <keep.h>

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -8,7 +8,7 @@
 #include <drivers/stm32mp1_rcc.h>
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
-#include <dt-bindings/clock/stm32mp1-clks.h>
+#include <drivers/stm32mp_dt_bindings.h>
 #include <initcall.h>
 #include <io.h>
 #include <keep.h>

--- a/core/include/drivers/stm32mp_dt_bindings.h
+++ b/core/include/drivers/stm32mp_dt_bindings.h
@@ -13,6 +13,7 @@
 
 #ifdef CFG_STM32MP15
 #include <dt-bindings/clock/stm32mp1-clks.h>
+#include <dt-bindings/regulator/st,stm32mp15-regulator.h>
 #include <dt-bindings/reset/stm32mp1-resets.h>
 #endif
 

--- a/core/include/drivers/stm32mp_dt_bindings.h
+++ b/core/include/drivers/stm32mp_dt_bindings.h
@@ -13,7 +13,6 @@
 
 #ifdef CFG_STM32MP15
 #include <dt-bindings/clock/stm32mp1-clks.h>
-#include <dt-bindings/clock/stm32mp1-clksrc.h>
 #include <dt-bindings/reset/stm32mp1-resets.h>
 #endif
 


### PR DESCRIPTION
This P-R implements the use of the stm32mp_dt_bindings.h helper which was upstreamed but not used.

This header groups all the device tree bindings necessary to compile a particular platform. This way, drivers do not include some headers under compilation switches: they remain in this helper.
