### PR TITLE
plat-stm32mp1: rework the use of shared resources

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -69,10 +69,12 @@ endif
 ifeq ($(CFG_STM32MP13),y)
 $(call force,CFG_STM32MP15,n)
 $(call force,CFG_STM32MP_CLK_CORE,y)
+$(call force,CFG_STM32MP1_SHARED_RESOURCES,n)
 $(call force,CFG_STM32MP13_CLK,y)
 $(call force,CFG_STM32MP15_CLK,n)
 CFG_STM32MP_OPP_COUNT ?= 2
 else
+$(call force,CFG_STM32MP1_SHARED_RESOURCES,y)
 $(call force,CFG_STM32MP15,y)
 $(call force,CFG_STM32MP15_CLK,y)
 endif

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -41,6 +41,7 @@ $(call force,CFG_PSCI_ARM32,y)
 $(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_SM_PLATFORM_HANDLER,y)
+$(call force,CFG_STM32_SHARED_IO,y)
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
 
 CFG_TEE_CORE_NB_CORE ?= 2

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -15,7 +15,6 @@
 #include <kernel/boot.h>
 #include <kernel/panic.h>
 #include <kernel/pm.h>
-#include <kernel/spinlock.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
@@ -28,40 +27,6 @@
  * new resources. This ensures resource state cannot change.
  */
 static bool registering_locked;
-
-/*
- * Shared register access: upon shared resource lock
- */
-static unsigned int shregs_lock = SPINLOCK_UNLOCK;
-
-/* Shared resource lock: assume not required if MMU is disabled */
-static uint32_t lock_stm32shregs(void)
-{
-	return may_spin_lock(&shregs_lock);
-}
-
-static void unlock_stm32shregs(uint32_t exceptions)
-{
-	may_spin_unlock(&shregs_lock, exceptions);
-}
-
-void io_mask32_stm32shregs(vaddr_t va, uint32_t value, uint32_t mask)
-{
-	uint32_t exceptions = lock_stm32shregs();
-
-	io_mask32(va, value, mask);
-
-	unlock_stm32shregs(exceptions);
-}
-
-void io_clrsetbits32_stm32shregs(vaddr_t va, uint32_t clr, uint32_t set)
-{
-	uint32_t exceptions = lock_stm32shregs();
-
-	io_clrsetbits32(va, clr, set);
-
-	unlock_stm32shregs(exceptions);
-}
 
 /*
  * Shared peripherals and resources registration

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2018-2019, STMicroelectronics
+ * Copyright (c) 2018-2022, STMicroelectronics
  */
 
 #ifndef __STM32_UTIL_H__
@@ -109,24 +109,6 @@ void stm32mp_get_bsec_static_cfg(struct stm32_bsec_static_cfg *cfg);
  * Return true if platform is in closed_device mode
  */
 bool stm32mp_is_closed_device(void);
-
-/*
- * Shared registers support: common lock for accessing SoC registers
- * shared between several drivers.
- */
-void io_mask32_stm32shregs(vaddr_t va, uint32_t value, uint32_t mask);
-
-static inline void io_setbits32_stm32shregs(vaddr_t va, uint32_t value)
-{
-	io_mask32_stm32shregs(va, value, value);
-}
-
-static inline void io_clrbits32_stm32shregs(vaddr_t va, uint32_t value)
-{
-	io_mask32_stm32shregs(va, 0, value);
-}
-
-void io_clrsetbits32_stm32shregs(vaddr_t va, uint32_t clr, uint32_t set);
 
 /*
  * Shared reference counter: increments by 2 on secure increment

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -69,8 +69,16 @@ void may_spin_unlock(unsigned int *lock, uint32_t exceptions);
 /* Helper from platform RCC clock driver */
 struct clk *stm32mp_rcc_clock_id_to_clk(unsigned long clock_id);
 
+#ifdef CFG_STM32MP1_SHARED_RESOURCES
 /* Return true if @clock_id is shared by secure and non-secure worlds */
 bool stm32mp_nsec_can_access_clock(unsigned long clock_id);
+#else /* CFG_STM32MP1_SHARED_RESOURCES */
+static inline bool stm32mp_nsec_can_access_clock(unsigned long clock_id
+						 __unused)
+{
+	return true;
+}
+#endif /* CFG_STM32MP1_SHARED_RESOURCES */
 
 extern const struct clk_ops stm32mp1_clk_ops;
 
@@ -84,8 +92,15 @@ static inline bool stm32mp_nsec_can_access_pmic_regu(const char *name __unused)
 }
 #endif
 
+#ifdef CFG_STM32MP1_SHARED_RESOURCES
 /* Return true if and only if @reset_id relates to a non-secure peripheral */
 bool stm32mp_nsec_can_access_reset(unsigned int reset_id);
+#else /* CFG_STM32MP1_SHARED_RESOURCES */
+static inline bool stm32mp_nsec_can_access_reset(unsigned int reset_id __unused)
+{
+	return true;
+}
+#endif /* CFG_STM32MP1_SHARED_RESOURCES */
 
 /* Return rstctrl instance related to RCC reset controller DT binding ID */
 struct rstctrl *stm32mp_rcc_reset_id_to_rstctrl(unsigned int binding_id);
@@ -211,6 +226,7 @@ enum stm32mp_shres {
 	STM32MP1_SHRES_COUNT
 };
 
+#ifdef CFG_STM32MP1_SHARED_RESOURCES
 /* Register resource @id as a secure peripheral */
 void stm32mp_register_secure_periph(enum stm32mp_shres id);
 
@@ -255,14 +271,64 @@ bool stm32mp_gpio_bank_is_shared(unsigned int bank);
 /* Return true if and only if GPIO bank @bank is registered as non-secure */
 bool stm32mp_gpio_bank_is_non_secure(unsigned int bank);
 
-#if defined(CFG_STM32MP15)
 /* Register parent clocks of @clock (ID used in clock DT bindings) as secure */
 void stm32mp_register_clock_parents_secure(unsigned long clock_id);
-#else
+
+#else /* CFG_STM32MP1_SHARED_RESOURCES */
+
+static inline void stm32mp_register_secure_periph(enum stm32mp_shres id
+						  __unused)
+{
+}
+
+static inline void stm32mp_register_non_secure_periph(enum stm32mp_shres id
+						      __unused)
+{
+}
+
+static inline void stm32mp_register_secure_periph_iomem(vaddr_t base __unused)
+{
+}
+
+static inline void stm32mp_register_non_secure_periph_iomem(vaddr_t base
+							    __unused)
+{
+}
+
+static inline void stm32mp_register_secure_gpio(unsigned int bank __unused,
+						unsigned int pin __unused)
+{
+}
+
+static inline void stm32mp_register_non_secure_gpio(unsigned int bank __unused,
+						    unsigned int pin __unused)
+{
+}
+
+static inline bool stm32mp_periph_is_secure(enum stm32mp_shres id __unused)
+{
+	return true;
+}
+
+static inline bool stm32mp_gpio_bank_is_secure(unsigned int bank __unused)
+{
+	return true;
+}
+
+static inline bool stm32mp_gpio_bank_is_shared(unsigned int bank __unused)
+{
+	return false;
+}
+
+static inline bool stm32mp_gpio_bank_is_non_secure(unsigned int bank __unused)
+{
+	return false;
+}
+
 static inline void stm32mp_register_clock_parents_secure(unsigned long clock_id
 							 __unused)
 {
 }
-#endif
 
+#endif /* CFG_STM32MP1_SHARED_RESOURCES */
 #endif /*__STM32_UTIL_H__*/

--- a/core/arch/arm/plat-stm32mp1/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/sub.mk
@@ -4,7 +4,7 @@ srcs-y += main.c
 srcs-y += reset.S
 srcs-$(CFG_STM32_RNG) += rng_seed.c
 srcs-$(CFG_SCMI_MSG_DRIVERS) += scmi_server.c
-srcs-y += shared_resources.c
+srcs-$(CFG_STM32MP1_SHARED_RESOURCES) += shared_resources.c
 srcs-$(CFG_TZC400) += plat_tzc400.c
 srcs-$(CFG_WITH_PAGER) += link_dummies_paged.c
 

--- a/core/drivers/clk/clk-stm32-core.c
+++ b/core/drivers/clk/clk-stm32-core.c
@@ -6,6 +6,7 @@
 #include <config.h>
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
+#include <drivers/stm32_shared_io.h>
 #include <io.h>
 #include <kernel/boot.h>
 #include <kernel/delay.h>

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0+)
 /*
- * Copyright (C) 2018-2019, STMicroelectronics
+ * Copyright (C) 2018-2022, STMicroelectronics
  */
 
 #include <assert.h>
@@ -8,6 +8,7 @@
 #include <drivers/stm32mp1_rcc.h>
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
+#include <drivers/stm32_shared_io.h>
 #include <drivers/stm32mp_dt_bindings.h>
 #include <initcall.h>
 #include <io.h>

--- a/core/drivers/stm32_shared_io.c
+++ b/core/drivers/stm32_shared_io.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2017-2022, STMicroelectronics
+ */
+
+#include <drivers/stm32_shared_io.h>
+#include <io.h>
+#include <kernel/spinlock.h>
+#include <stm32_util.h>
+
+static unsigned int shregs_lock = SPINLOCK_UNLOCK;
+
+static uint32_t lock_stm32shregs(void)
+{
+	return may_spin_lock(&shregs_lock);
+}
+
+static void unlock_stm32shregs(uint32_t exceptions)
+{
+	may_spin_unlock(&shregs_lock, exceptions);
+}
+
+void io_mask32_stm32shregs(vaddr_t va, uint32_t value, uint32_t mask)
+{
+	uint32_t exceptions = lock_stm32shregs();
+
+	io_mask32(va, value, mask);
+
+	unlock_stm32shregs(exceptions);
+}
+
+void io_clrsetbits32_stm32shregs(vaddr_t va, uint32_t clr, uint32_t set)
+{
+	uint32_t exceptions = lock_stm32shregs();
+
+	io_clrsetbits32(va, clr, set);
+
+	unlock_stm32shregs(exceptions);
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -36,6 +36,7 @@ srcs-$(CFG_STM32_GPIO) += stm32_gpio.c
 srcs-$(CFG_STM32_IWDG) += stm32_iwdg.c
 srcs-$(CFG_STM32_I2C) += stm32_i2c.c
 srcs-$(CFG_STM32_RNG) += stm32_rng.c
+srcs-$(CFG_STM32_SHARED_IO) += stm32_shared_io.c
 srcs-$(CFG_STM32_TAMP) += stm32_tamp.c
 srcs-$(CFG_STM32_UART) += stm32_uart.c
 srcs-$(CFG_STPMIC1) += stpmic1.c

--- a/core/include/drivers/stm32_shared_io.h
+++ b/core/include/drivers/stm32_shared_io.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, STMicroelectronics
+ */
+
+#ifndef __DRIVERS_STM32_SHARED_IO_H__
+#define __DRIVERS_STM32_SHARED_IO_H__
+
+#include <stdint.h>
+#include <types_ext.h>
+
+/*
+ * Shared registers support: common lock for accessing SoC registers
+ * shared between several drivers.
+ */
+void io_clrsetbits32_stm32shregs(vaddr_t va, uint32_t clr, uint32_t set);
+void io_mask32_stm32shregs(vaddr_t va, uint32_t value, uint32_t mask);
+
+static inline void io_setbits32_stm32shregs(vaddr_t va, uint32_t value)
+{
+	io_mask32_stm32shregs(va, value, value);
+}
+
+static inline void io_clrbits32_stm32shregs(vaddr_t va, uint32_t value)
+{
+	io_mask32_stm32shregs(va, 0, value);
+}
+
+#endif /* __DRIVERS_STM32_SHARED_IO_H__ */


### PR DESCRIPTION
This P-R introduce the use of the shared IO driver which use is to isolate the use of shared resources that aren't relevant for STM32MP13 platform.

Now, the use of such resources is under the CFG_STM32MP1_SHARED_RESOURCES compilation flag, which is disabled by
default but enabled for STM32MP15.