### PR TITLE
dts: sama5d2: Set TCB1 as secure

### DIFF
--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -405,6 +405,8 @@
 				interrupts = <36 IRQ_TYPE_LEVEL_HIGH 0>;
 				clocks = <&pmc PMC_TYPE_PERIPHERAL 36>, <&pmc PMC_TYPE_GCK 36>, <&clk32k>;
 				clock-names = "t0_clk", "gclk", "slow_clk";
+				status = "disabled";
+				secure-status = "okay";
 			};
 
 			hsmc: hsmc@f8014000 {


### PR DESCRIPTION
While checking for OP-TEE 3.18, found that the device-tree modifications
to enable the TCB were missing. Add missing status-okay line to enable
TCB1 for OP-TEE usage.

Signed-off-by: Clément Léger <clement.leger@bootlin.com>