### PR TITLE
core: make sure build date is always in English

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -148,7 +148,7 @@ version-o-cflags = $(filter-out -g3,$(core-platform-cflags) \
 ifneq ($(SOURCE_DATE_EPOCH),)
 date-opts = -d @$(SOURCE_DATE_EPOCH)
 endif
-DATE_STR = `LANG=C date -u $(date-opts)`
+DATE_STR = `LC_ALL=C date -u $(date-opts)`
 BUILD_COUNT_STR = `cat $(link-out-dir)/.buildcount`
 CORE_CC_VERSION = `$(CCcore) -v 2>&1 | grep "version " | sed 's/ *$$//'`
 define gen-version-o


### PR DESCRIPTION
Setting LANG=C before invoking the date command doesn't always result in
the "C" (English) locale being selected. The correct way is to set
LC_ALL. As explained in the locale(7) man page:

 If the second argument to setlocale(3) is an empty string, "", for the
 default locale, it is determined using the following steps:

 1. If there is a non-null environment variable LC_ALL, the value of
    LC_ALL is used.

 2. If an environment variable with the same name as one of the
    categories above exists and is non-null, its value is used for that
    category.

 3. If there is a non-null environment variable LANG, the value of LANG
    is used.

Fixes: 3e2b963515c1 ("core: use C locale when generating the build date")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
