### PR TITLE
imx_ocotp: correct ocotp fuse address computation

### DIFF
--- a/core/drivers/imx_ocotp.c
+++ b/core/drivers/imx_ocotp.c
@@ -14,7 +14,12 @@
 #define OCOTP_CTRL		    0x0
 #define OCOTP_CTRL_ERROR	    BIT32(9)
 #define OCOTP_CTRL_BUSY		    BIT32(8)
+
+#if defined(CFG_MX6) || defined(CFG_MX7ULP)
+#define OCOTP_SHADOW_OFFSET(_b, _w) ((_b) * (0x80) + (_w) * (0x10) + 0x400)
+#else
 #define OCOTP_SHADOW_OFFSET(_b, _w) ((_b) * (0x40) + (_w) * (0x10) + 0x400)
+#endif
 
 struct ocotp_instance {
 	unsigned char nb_banks;
@@ -117,22 +122,22 @@ static TEE_Result ocotp_get_die_id_mx7ulp(uint64_t *ret_uid)
 	uint32_t val = 0;
 	uint64_t uid = 0;
 
-	res = imx_ocotp_read(2, 6, &val);
+	res = imx_ocotp_read(1, 6, &val);
 	if (res)
 		goto out;
 	uid = val & GENMASK_32(15, 0);
 
-	res = imx_ocotp_read(2, 5, &val);
+	res = imx_ocotp_read(1, 5, &val);
 	if (res)
 		goto out;
 	uid = SHIFT_U64(uid, 16) | (val & GENMASK_32(15, 0));
 
-	res = imx_ocotp_read(2, 4, &val);
+	res = imx_ocotp_read(1, 4, &val);
 	if (res)
 		goto out;
 	uid = SHIFT_U64(uid, 16) | (val & GENMASK_32(15, 0));
 
-	res = imx_ocotp_read(2, 3, &val);
+	res = imx_ocotp_read(1, 3, &val);
 	if (res)
 		goto out;
 	uid = SHIFT_U64(uid, 16) | (val & GENMASK_32(15, 0));


### PR DESCRIPTION
Not all the imx platforms have the same bank spacing. In particular
the imx6 and imx7ulp both have bank sizes that are twice as large
as the imx8m.

This will set the correct computation.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
