### PR TITLE
drivers: imx_snvs: re-work security state for imx8m platforms

### DIFF
--- a/core/drivers/imx_snvs.c
+++ b/core/drivers/imx_snvs.c
@@ -24,6 +24,7 @@
 #define HPSR_SSM_ST_SHIFT 8
 
 #define SNVS_HPSR_SYS_SECURITY_CFG_OFFSET 12
+#define SNVS_HPSR_SYS_SECURITY_CFG	  GENMASK_32(14, 12)
 
 #define SNVS_HPSR_OTPMK_SYND	      GENMASK_32(24, 16)
 #define SNVS_HPSR_OTPMK_ZERO	      BIT(27)
@@ -112,37 +113,6 @@ static bool is_otpmk_valid(void)
 	return !(status & (SNVS_HPSR_OTPMK_ZERO | SNVS_HPSR_OTPMK_SYND));
 }
 
-#ifdef CFG_MX8M
-#define SNVS_HPSR_SYS_SECURITY_CFG GENMASK_32(15, 12)
-
-static enum snvs_security_cfg snvs_get_security_cfg(void)
-{
-	uint32_t val = 0;
-	vaddr_t base = core_mmu_get_va(SNVS_BASE, MEM_AREA_IO_SEC,
-				       SNVS_SIZE);
-
-	val = (io_read32(base + SNVS_HPSR) & SNVS_HPSR_SYS_SECURITY_CFG) >>
-	      SNVS_HPSR_SYS_SECURITY_CFG_OFFSET;
-
-	switch (val) {
-	case 0b0000:
-	case 0b1000:
-		return SNVS_SECURITY_CFG_FAB;
-	case 0b0001:
-	case 0b0010:
-	case 0b0011:
-		return SNVS_SECURITY_CFG_OPEN;
-	case 0b1010:
-	case 0b1001:
-	case 0b1011:
-		return SNVS_SECURITY_CFG_CLOSED;
-	default:
-		return SNVS_SECURITY_CFG_FIELD_RETURN;
-	}
-}
-#else
-#define SNVS_HPSR_SYS_SECURITY_CFG GENMASK_32(14, 12)
-
 static enum snvs_security_cfg snvs_get_security_cfg(void)
 {
 	uint32_t val = 0;
@@ -163,7 +133,6 @@ static enum snvs_security_cfg snvs_get_security_cfg(void)
 		return SNVS_SECURITY_CFG_FIELD_RETURN;
 	}
 }
-#endif
 
 bool snvs_is_device_closed(void)
 {


### PR DESCRIPTION
The current implementation of snvs_get_security_cfg() for
imx8m platforms includes the read of SYS_SECURE_BOOT bit.
This fourth bit shows if the board boots from internal
ROM. This bit will reset to 1 for a board in the field
and 0 for a test chip.

The read of this bit is out of scope of the snvs_get_security_cfg()
purpose which is to return the system security configuration.
The SYS_SECURE_BOOT bit (msb) can be discarded.

Fixes: d0fa513dcef5 (drivers: imx_snvs: fix SNVS security configuration values)
Signed-off-by: Franck LENORMAND <franck.lenormand@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
