### PR TITLE
Disable SA2UL RNG driver on unsupported flavors

### DIFF
--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -1,6 +1,5 @@
 CFG_WITH_STATS ?= y
 CFG_CRYPTO_WITH_CE ?= n
-CFG_WITH_SOFTWARE_PRNG ?= n
 CFG_CONSOLE_UART ?= 0
 
 CFG_TZDRAM_START ?= 0x9e800000
@@ -16,6 +15,12 @@ $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
+
+ifeq (,$(filter ${PLATFORM_FLAVOR},am65x j721e am64x))
+$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+else
+CFG_WITH_SOFTWARE_PRNG ?= n
+endif
 
 ifneq ($(CFG_WITH_SOFTWARE_PRNG),y)
 $(call force,CFG_SA2UL,y)

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -63,7 +63,7 @@
 #define SA2UL_BASE		0x40900000
 #define SA2UL_TI_SCI_DEV_ID	265
 #define SA2UL_TI_SCI_FW_ID	1196
-#else
+#elif defined(PLATFORM_FLAVOR_am64x)
 #define SA2UL_BASE		0x40900000
 #define SA2UL_TI_SCI_DEV_ID	133
 #define SA2UL_TI_SCI_FW_ID	35


### PR DESCRIPTION
Only enable the SA2UL TRNG on platform flavors that are currently
supported. This can be relaxed for platforms as support is verified.