### PR TITLE
build: use CFLAGS_ta_arm32 etc. when building in-tree TAs

### DIFF
--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -32,8 +32,9 @@ CROSS_COMPILE_$(sm)	:= $(CROSS_COMPILE_$(ta-target))
 COMPILER_$(sm)		:= $(COMPILER_$(ta-target))
 include mk/$(COMPILER_$(sm)).mk
 
-cppflags$(sm)	:= $(cppflags$(ta-target)) -I$(ta-dev-kit-dir$(sm))/include
-cflags$(sm)	:= $(cflags$(ta-target))
+cppflags$(sm)	:= $(cppflags$(ta-target)) $(CPPFLAGS_$(ta-target)) \
+			-I$(ta-dev-kit-dir$(sm))/include
+cflags$(sm)	:= $(cflags$(ta-target)) $(CFLAGS_$(ta-target))
 aflags$(sm)	:= $(aflags$(ta-target))
 
 ifeq ($(CFG_ULIBS_SHARED),y)


### PR DESCRIPTION
In-tree TAs currently ignore CFLAGS_ta_arm32/CFLAGS_ta_arm64 and
CPPFLAGS_ta_arm32/CPPFLAGS_ta_arm64, contrary to out-of tree TAs which
are built with ta/mk/ta_dev_kit.mk. Add these flags for convenience and
consistency.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
