### PR TITLE
core: crypto: mte: strip tag before calling vm_check_access_rights()

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -755,6 +755,8 @@ static TEE_Result op_attr_bignum_to_user(void *attr,
 	if (s < req_size || !buffer)
 		return TEE_ERROR_SHORT_BUFFER;
 
+	buffer = memtag_strip_tag(buffer);
+
 	/* Check we can access data using supplied user mode pointer */
 	res = vm_check_access_rights(&to_user_ta_ctx(sess->ctx)->uctx,
 				     TEE_MEMORY_ACCESS_READ |


### PR DESCRIPTION
op_attr_bignum_to_user() lacks a call to memtag_strip_tag() before it
calls vm_check_access_rights(). This results in the memory buffer not
being found and the function returning TEE_ERROR_ACCESS_DENIED.

Test case: xtest pkcs11_1019 on QEMUv8, build command:

 make CFG_PKCS11_TA=y CFG_USER_TA_TARGET_pkcs11=ta_arm64 MEMTAG=y run

Fixes: ef142203a36b ("core: syscalls: strip tags from user space pointers")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
