### PR TITLE
plat-zynqmp: Added __nex_bss symbol for virtualization support

### DIFF
--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -47,8 +47,8 @@
 #include <tee/tee_fs.h>
 #include <trace.h>
 
-static struct gic_data gic_data;
-static struct cdns_uart_data console_data;
+static struct gic_data gic_data __nex_bss;
+static struct cdns_uart_data console_data __nex_bss;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 			ROUNDDOWN(CONSOLE_UART_BASE, CORE_MMU_PGDIR_SIZE),


### PR DESCRIPTION
Without the __nex_bss symbol added to gic_data and console_data
the zynqmp platform results in a deadlock when attempting
to write to the serial device on the platform.  This fix resolves
the deadlock issue.  More details can be found at this issue
link https://github.com/OP-TEE/optee_os/issues/5384

Signed-off-by: Michael Doran <michael.doran@dornerworks.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
