### PR TITLE
drivers: caam: increase the minimum entropy delay the imx6sx

### DIFF
--- a/core/drivers/crypto/caam/hal/common/registers/rng_regs.h
+++ b/core/drivers/crypto/caam/hal/common/registers/rng_regs.h
@@ -28,8 +28,12 @@
 #define TRNG_SDCTL_ENT_DLY(val)		SHIFT_U32(((val) & 0xFFFF), 16)
 #define TRNG_SDCTL_SAMP_SIZE(val)	((val) & 0xFFFF)
 
+#ifdef CFG_MX6SX
+#define TRNG_SDCTL_ENT_DLY_MIN 12000
+#else
 #define TRNG_SDCTL_ENT_DLY_MIN		3200
-#define TRNG_SDCTL_ENT_DLY_MAX		12800
+#endif
+#define TRNG_SDCTL_ENT_DLY_MAX 12800
 
 /* Frequency Count Minimum Limit */
 #define TRNG_FRQMIN			0x0618


### PR DESCRIPTION
The i.MX6SX requires to start the RNG instantiation at a higher
entropy delay to provide a stable RNG generation and avoid RNG
hardware errors.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
