### PR TITLE
core: plat-ls: set CFG_NUM_THREADS=2 in case of LS1012ARDB

### DIFF
--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -33,6 +33,7 @@ include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,1)
 $(call force,CFG_DRAM0_SIZE,0x40000000)
 $(call force,CFG_CORE_CLUSTER_SHIFT,2)
+CFG_NUM_THREADS ?= 2
 CFG_SHMEM_SIZE ?= 0x00200000
 endif
 


### PR DESCRIPTION
xtest regression_1009.3 was failing on LS1012ARDB, so setting
CFG_NUM_THREADS=2 in case of ls1012ardb.

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>