### PR TITLE
core: plat-ls: remove OP-TEE support for LS1012A-FRWY platform

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -188,7 +188,6 @@ jobs:
           _make PLATFORM=ls-ls1043ardb
           _make PLATFORM=ls-ls1046ardb
           _make PLATFORM=ls-ls1012ardb
-          _make PLATFORM=ls-ls1012afrwy
           _make PLATFORM=ls-ls1028ardb
           _make PLATFORM=ls-ls1088ardb
           _make PLATFORM=ls-ls2088ardb

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -37,14 +37,6 @@ CFG_NUM_THREADS ?= 2
 CFG_SHMEM_SIZE ?= 0x00200000
 endif
 
-ifeq ($(PLATFORM_FLAVOR),ls1012afrwy)
-include core/arch/arm/cpu/cortex-armv8-0.mk
-$(call force,CFG_TEE_CORE_NB_CORE,1)
-$(call force,CFG_CORE_CLUSTER_SHIFT,2)
-CFG_DRAM0_SIZE ?= 0x20000000
-CFG_SHMEM_SIZE ?= 0x00200000
-endif
-
 ifeq ($(PLATFORM_FLAVOR),ls1043ardb)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,4)

--- a/core/arch/arm/plat-ls/crypto_conf.mk
+++ b/core/arch/arm/plat-ls/crypto_conf.mk
@@ -42,10 +42,7 @@ $(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force,CFG_JR_BLOCK_SIZE,0x10000)
 $(call force,CFG_JR_INDEX,2)  # Default JR index used
 
-ifneq (,$(filter $(PLATFORM_FLAVOR),ls1012afrwy))
-$(call force,CFG_CAAM_BIG_ENDIAN,y)
-$(call force,CFG_JR_INT,105)
-else ifneq (,$(filter $(PLATFORM_FLAVOR),ls1012ardb))
+ifneq (,$(filter $(PLATFORM_FLAVOR),ls1012ardb))
 $(call force,CFG_CAAM_BIG_ENDIAN,y)
 $(call force,CFG_JR_INT,105)
 else ifneq (,$(filter $(PLATFORM_FLAVOR),ls1021atwr))

--- a/core/arch/arm/plat-ls/platform_config.h
+++ b/core/arch/arm/plat-ls/platform_config.h
@@ -63,7 +63,7 @@
 #define CAAM_SIZE			0x100000
 #endif
 
-#if defined(PLATFORM_FLAVOR_ls1012ardb) || defined(PLATFORM_FLAVOR_ls1012afrwy)
+#if defined(PLATFORM_FLAVOR_ls1012ardb)
 /*  DUART 1 */
 #define UART0_BASE			0x021C0500
 #define GIC_BASE			0x01400000


### PR DESCRIPTION
LS1012A-FRWY does not support OP-TEE anymore, removing its
support.

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>