### PR TITLE
libutee: Add more TEE_MALLOC hints

### DIFF
--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -83,6 +83,8 @@
 
 /* Memory Management Constant */
 #define TEE_MALLOC_FILL_ZERO               0x00000000
+#define TEE_MALLOC_NO_FILL                 0x00000001
+#define TEE_MALLOC_NO_SHARE                0x00000010
 
 /* Other constants */
 #define TEE_STORAGE_PRIVATE                0x00000001

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -401,12 +401,20 @@ void *TEE_Malloc(uint32_t len, uint32_t hint)
 	if (!len)
 		return TEE_NULL_SIZED_VA;
 
-	if (hint == TEE_MALLOC_FILL_ZERO)
+	switch (hint) {
+	case TEE_MALLOC_FILL_ZERO:
 		return calloc(1, len);
-	else if (hint == TEE_USER_MEM_HINT_NO_FILL_ZERO)
+	case TEE_MALLOC_NO_FILL:
+		/* SHALL be used with TEE_MALLOC_NO_SHARE */
+		TEE_Panic(TEE_ERROR_BAD_PARAMETERS);
+		break;
+	case TEE_MALLOC_NO_FILL | TEE_MALLOC_NO_SHARE:
+	case TEE_USER_MEM_HINT_NO_FILL_ZERO:
 		return malloc(len);
-
-	EMSG("Invalid hint %#" PRIx32, hint);
+	default:
+		EMSG("Invalid hint %#" PRIx32, hint);
+		break;
+	}
 
 	return NULL;
 }


### PR DESCRIPTION
This patch adds the definitions and related code with the hint
values: TEE_MALLOC_NO_SHARE and TEE_MALLOC_NO_FILL. They were
added from TEE Internal Core API v1.2.

Also, TEE_MALLOC_NO_FILL SHALL be used in conjunction with
TEE_MALLOC_NO_SHARE. If user uses it in wrong way, a TEE panic is
triggered.

The original TEE_USER_MEM_HINT_NO_FILL_ZERO is preserved for
backward compatibility.

Signed-off-by: Che-Chia Chang <alvinga@andestech.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
