### PR TITLE
core: plat-bcm: remove virtual address lookup from main_init_gic()

### DIFF
--- a/core/arch/arm/plat-bcm/main.c
+++ b/core/arch/arm/plat-bcm/main.c
@@ -81,14 +81,6 @@ void itr_core_handler(void)
 
 void main_init_gic(void)
 {
-	vaddr_t gicd_base;
-
-	gicd_base = core_mmu_get_va(GICD_BASE, MEM_AREA_IO_SEC, 1);
-
-	if (!gicd_base)
-		panic();
-
-	gic_init_base_addr(&gic_data, 0, gicd_base);
+	gic_init_base_addr(&gic_data, 0, GICD_BASE);
 	itr_init(&gic_data.chip);
-
 }


### PR DESCRIPTION
- Commit 60801696667d ("plat: arm: refactor GIC initialization")
  refactored GIC initialization to have a virtual address lookup be
  performed within gic_init_base_addr() instead of requiring a
  platform's init_gic() to perform it.
- Before this change, BCM's main_init_gic() still performed the lookup
  before calling gic_init_base_addr() and would hand over a virtual
  address instead of a physical one. This caused the new virtual lookup
  in gic_init_base_addr() to fail and panic.
- This change removes the virtual memory lookup in BCM's gic_init() and
  has it hand gic_init_base_addr() a physical address instead.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
