### PR TITLE
libutils: util.h: add get_field_u{32,64}() and set_field_u{32,64}()

### DIFF
--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -172,6 +172,27 @@ static inline void reg_pair_from_64(uint64_t val, uint32_t *reg0,
 	*reg0 = val >> 32;
 	*reg1 = val;
 }
+
+/* Get and set bit fields  */
+static inline uint32_t get_field_u32(uint32_t reg, uint32_t mask)
+{
+	return (reg & mask) / (mask & ~(mask - 1));
+}
+
+static inline uint32_t set_field_u32(uint32_t reg, uint32_t mask, uint32_t val)
+{
+	return (reg & ~mask) | (val * (mask & ~(mask - 1)));
+}
+
+static inline uint64_t get_field_u64(uint64_t reg, uint64_t mask)
+{
+	return (reg & mask) / (mask & ~(mask - 1));
+}
+
+static inline uint64_t set_field_u64(uint64_t reg, uint64_t mask, uint64_t val)
+{
+	return (reg & ~mask) | (val * (mask & ~(mask - 1)));
+}
 #endif
 
 #endif /*UTIL_H*/


### PR DESCRIPTION
This commit defines `get_field_u{32,64}()` and `set_field_u{32,64}()` macros for respectively getting and setting bit fields.

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
