### PR TITLE
ci: code_style: clone repository with full history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 50 # >= the highest number of commits expected in a single PR
+          fetch-depth: 0 # full history so checkpatch can check commit IDs in commit messages
       - name: Update Git config
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: Run checkpatch


### PR DESCRIPTION
```
The code_style job runs checkpatch, which checks if commit references
found in commit descriptions are valid or not. In order for this to
work, the Git repo must contain the full history otherwise some IDs
might be reported as unknown. For example [1]:

 WARNING: Unknown commit id '60801696667d', maybe rebased or not pulled?
 #7:
 - Commit 60801696667d ("plat: arm: refactor GIC initialization")

Link: [1] https://github.com/OP-TEE/optee_os/runs/7529955940?check_suite_focus=true#step:5:35
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```