### PR TITLE
ci: cancel obsolete workflows

### DIFF
--- a/.github/workflows/ci-cancel.yml
+++ b/.github/workflows/ci-cancel.yml
@@ -1,0 +1,19 @@
+# Cancel previous CI workflows that are still running when a new one is
+# requested with the same ID. Happens when a branch is pushed to,
+# including when a PR is updated. It would be wasteful to leave CI
+# running on obsolete content.
+# See https://github.com/marketplace/actions/cancel-workflow-action#advanced-pull-requests-from-forks
+name: Cancel obsolete CI
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [requested]
+    branches-ignore: [master]
+jobs:
+  cancel:
+    name: Cancel obsolete CI workflows
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@0.10.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
When the CI workflow is triggered, we usually don't want previous jobs
related to the same branch or pull request to keep running; it is
just wasteful of resources. Therefore add a special workflow to deal
with the situation [1].

An exception is made for CI workflows started by updates to the master
branch so that several PR merged in a row do not cancel previous CI runs
started on master.

Link: [1] https://github.com/marketplace/actions/cancel-workflow-action#advanced-pull-requests-from-forks
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
