### PR TITLE
ci: zynqmp: Add compilation for optional drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
           _make PLATFORM=zynq7k-zc702
           _make PLATFORM=zynqmp-zcu102
           _make PLATFORM=zynqmp-zcu102 CFG_ARM64_core=y
+          _make PLATFORM=zynqmp-zcu102 CFG_ARM64_core=y CFG_WITH_SOFTWARE_PRNG=n CFG_XIPHERA_TRNG=y CFG_ZYNQMP_HUK=y
           _make PLATFORM=d02
           _make PLATFORM=d02 CFG_ARM64_core=y
           _make PLATFORM=rcar


### PR DESCRIPTION
Test compile optional Xiphera TRNG and HUK drivers (and its related
drivers).

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

---

Depends on:
- https://github.com/OP-TEE/optee_os/pull/5460
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
