### PR TITLE
drivers: imx_i2c: update the daisy chain setting for I2C1

### DIFF
--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -460,7 +460,7 @@ TEE_Result imx_i2c_init(uint8_t bid, int bps)
 	io_write32(mux->base.va + mux->i2c[bid].sda_cfg, I2C_CFG_VAL(bid));
 	if (mux->i2c[bid].sda_inp)
 		io_write32(mux->base.va + mux->i2c[bid].sda_inp,
-			   I2C_INP_VAL(bid + 1));
+			   I2C_INP_VAL(bid + 2));
 
 	/* Baud rate in bits per second */
 	i2c_set_bus_speed(bid, bps);


### PR DESCRIPTION
Looking at IMX6ULLRM Rev. 1, 11/2017 paragraph 32.6.329
says the daisy chain for SDA on I2C1 on imx6ull-evk is 2 not 1.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
