### PR TITLE
drivers: imx_i2c: update the I2C initialization

### DIFF
--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -358,7 +358,12 @@ static TEE_Result i2c_init_transfer(uint8_t bid, uint8_t chip)
 		return ret;
 
 	/* Enable the interface */
-	i2c_io_write8(bid, I2CR, I2CR_IEN);
+	tmp = !(i2c_io_read8(bid, I2CR) & I2CR_IEN);
+	if (tmp) {
+		i2c_io_write8(bid, I2CR, I2CR_IEN);
+		udelay(50);
+	}
+	i2c_io_write8(bid, I2SR, 0);
 
 	tmp = i2c_io_read8(bid, I2CR) | I2CR_MSTA;
 	i2c_io_write8(bid, I2CR, tmp);


### PR DESCRIPTION
NXP drivers in both u-boot and linux waits 50us after enabling
the bus controller to stablize the bus.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
