### PR TITLE
core: plat-ls: reenable CAAM JR interrupts

### DIFF
--- a/core/arch/arm/plat-ls/crypto_conf.mk
+++ b/core/arch/arm/plat-ls/crypto_conf.mk
@@ -86,6 +86,9 @@ ifneq ($(CFG_NXP_CAAM_SGT_V2),y)
 $(call force,CFG_NXP_CAAM_SGT_V1,y)
 endif
 
+# Enable JR interruptions
+CFG_CAAM_ITR ?= y
+
 #
 # Configuration of the Crypto Driver
 #


### PR DESCRIPTION
- Commit 3f45afc31955 ("drivers: caam: disable the use of interrupts for
  some platforms") and commit 497dbec86795 ("drivers: caam: fix function
  definition when CFG_CAAM_NO_ITR=y") introduced the flag CFG_CAAM_ITR
  which enables CAAM Job Ring driver Interrupts when defined.
- These changes also set CFG_CAAM_ITR to be enabled by default for
  plat-imx but not plat-ls. This introduced a regression bug that made
  all plat-ls cpus compile without CAAM Job Ring Interruptions enabled.
- This new change enables the CFG_CAAM_ITR flag by default in plat-ls to
  restore the CAAM Job Ring Interrupt behavior from before the breaking
  change.

Signed-off-by: Andrew Mustea <andrew.mustea@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
