### PR TITLE
core: tee_svc.c: add missing comma

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -365,7 +365,7 @@ const struct tee_props tee_propset_tee[] = {
 		.name = "org.trustedfirmware.optee.cpu.feat_pauth_implemented",
 		.prop_type = USER_TA_PROP_TYPE_BOOL,
 		.get_prop_func = get_prop_feat_pauth_implemented
-	}
+	},
 #endif
 #if MEMTAG_IS_ENABLED
 	{


### PR DESCRIPTION
Add missing comma to fix the following error:

 $ make -s PLATFORM=vexpress-qemu_armv8a CFG_TA_PAUTH=y CFG_MEMTAG=y
 core/tee/tee_svc.c:371:9: error: expected ‘}’ before ‘{’ token
   371 |         {
       |         ^
 core/tee/tee_svc.c:280:44: note: to match this ‘{’
   280 | const struct tee_props tee_propset_tee[] = {
       |                                            ^

Fixes: a0e8ffe9ba8f ("core: add support for MTE")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
