### PR TITLE
drivers: scmi-msg: Propagate errors from platform voltd_get_level

### DIFF
--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -812,18 +812,27 @@ int32_t plat_scmi_voltd_levels_array(unsigned int channel_id,
 	}
 }
 
-long plat_scmi_voltd_get_level(unsigned int channel_id, unsigned int scmi_id)
+int32_t plat_scmi_voltd_get_level(unsigned int channel_id, unsigned int scmi_id,
+				  long *level)
 {
 	struct stm32_scmi_voltd *voltd = find_voltd(channel_id, scmi_id);
+	long voltage = 0;
 
 	if (!voltd)
-		return 0;
+		return SCMI_INVALID_PARAMETERS;
 
 	switch (voltd->priv_dev) {
 	case VOLTD_PWR:
-		return pwr_get_level(voltd);
+		*level = pwr_get_level(voltd);
+		return SCMI_SUCCESS;
 	case VOLTD_PMIC:
-		return pmic_get_level(voltd);
+		voltage = pmic_get_level(voltd);
+		if (voltage > 0) {
+			*level = voltage;
+			return SCMI_SUCCESS;
+		} else {
+			return SCMI_GENERIC_ERROR;
+		}
 	default:
 		panic();
 	}

--- a/core/drivers/scmi-msg/voltage_domain.c
+++ b/core/drivers/scmi-msg/voltage_domain.c
@@ -43,10 +43,11 @@ int32_t __weak plat_scmi_voltd_levels_by_step(unsigned int channel_id __unused,
 	return SCMI_NOT_SUPPORTED;
 }
 
-long __weak plat_scmi_voltd_get_level(unsigned int channel_id __unused,
-				      unsigned int scmi_id __unused)
+int32_t __weak plat_scmi_voltd_get_level(unsigned int channel_id __unused,
+					 unsigned int scmi_id __unused,
+					 long *level __unused)
 {
-	return 0;
+	return SCMI_NOT_SUPPORTED;
 }
 
 int32_t __weak plat_scmi_voltd_set_level(unsigned int channel_id __unused,
@@ -353,6 +354,7 @@ static void scmi_voltd_level_get(struct scmi_msg *msg)
 		.status = SCMI_SUCCESS,
 	};
 	unsigned int domain_id = 0;
+	long level = 0;
 
 	if (msg->in_size != sizeof(*in_args)) {
 		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
@@ -367,8 +369,9 @@ static void scmi_voltd_level_get(struct scmi_msg *msg)
 	domain_id = confine_array_index(in_args->domain_id,
 					plat_scmi_voltd_count(msg->channel_id));
 
-	out_args.voltage_level = plat_scmi_voltd_get_level(msg->channel_id,
-							   domain_id);
+	out_args.status = plat_scmi_voltd_get_level(msg->channel_id, domain_id,
+						    &level);
+	out_args.voltage_level = level;
 
 	scmi_write_response(msg, &out_args, sizeof(out_args));
 }

--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -352,9 +352,11 @@ int32_t plat_scmi_voltd_levels_by_step(unsigned int channel_id,
  * Get current voltage domain level in microvolt
  * @channel_id: SCMI channel ID
  * @scmi_id: SCMI voltage domain ID
- * Return clock rate or 0 if not supported
+ * @level: Out parameter for the current voltage level
+ * Return an SCMI compliant error code
  */
-long plat_scmi_voltd_get_level(unsigned int channel_id, unsigned int scmi_id);
+int32_t plat_scmi_voltd_get_level(unsigned int channel_id, unsigned int scmi_id,
+				  long *level);
 
 /*
  * Set voltage domain level voltage domain


### PR DESCRIPTION
plat_scmi_voltd_get_level is refactored to return an SCMI error code and
retrieve the voltage via an out parameter. This allows errors from the
platform SCMI server implementation to be propagated to the REE.

The implementation for stm32mp1 is updated to handle at least some
possible errors.

Signed-off-by: Anton Eliasson <anton.eliasson@axis.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
