### PR TITLE
core: spmc: add SPMC manifest handling

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -98,6 +98,7 @@ ifeq ($(CFG_CORE_SEL1_SPMC),y)
 $(call force,CFG_CORE_FFA,y)
 $(call force,CFG_CORE_SEL2_SPMC,n)
 $(call force,CFG_CORE_EL3_SPMC,n)
+$(call force,CFG_DT,y)
 endif
 # SPMC configuration "S-EL2 SPMC" where SPM Core is implemented at S-EL2,
 # that is, the hypervisor sandboxing OP-TEE

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
- * Copyright (c) 2021, Arm Limited
+ * Copyright (c) 2021-2022, Arm Limited
  */
 
 #include <platform_config.h>
@@ -128,11 +128,11 @@ FUNC _start , :
 #if defined(CFG_CORE_SEL1_SPMC)
 	/*
 	 * With OP-TEE as SPMC at S-EL1 the SPMD (SPD_spmd) in TF-A passes
-	 * the DTB in x0, pagaeble part in x1 and the rest of the registers
-	 * are unused
+	 * the SPMC manifest in x0, HW_CONFIG DT in x1 and the rest of the
+	 * registers are unused
 	 */
-	mov	x19, x1		/* Save pagable part */
-	mov	x20, x0		/* Save DT address */
+	mov	x19, x0		/* Save SPMC manifest */
+	mov	x20, x1		/* Save DT address */
 #else
 	mov	x19, x0		/* Save pagable part address */
 #if defined(CFG_DT_ADDR)
@@ -303,7 +303,11 @@ clear_nex_bss:
 	bl	core_mmu_set_default_prtn_tbl
 #endif
 
+#if defined(CFG_CORE_SEL1_SPMC)
+	mov	x0, #0		/* pager not used */
+#else
 	mov	x0, x19		/* pagable part address */
+#endif
 	mov	x1, #-1
 	bl	boot_init_primary_early
 
@@ -321,6 +325,11 @@ clear_nex_bss:
 	str	wzr, [x22, #THREAD_CORE_LOCAL_FLAGS]
 #endif
 	mov	x0, x20		/* DT address */
+#if defined(CFG_CORE_SEL1_SPMC)
+	mov	x1, x19		/* SPMC manifest */
+#else
+	mov	x1, #0		/* unused */
+#endif
 	bl	boot_init_primary_late
 #ifndef CFG_VIRTUALIZATION
 	mov	x0, #THREAD_CLF_TMP

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2017-2021, Linaro Limited
+ * Copyright (c) 2022, Arm Limited
  */
 #include <compiler.h>
 #include <initcall.h>
@@ -27,7 +28,8 @@ void __section(".text.dummy.call_finalcalls") call_finalcalls(void)
 }
 
 void __section(".text.dummy.boot_init_primary_late")
-boot_init_primary_late(unsigned long fdt __unused)
+boot_init_primary_late(unsigned long fdt __unused,
+		       unsigned long spmc_manifest __unused)
 {
 }
 

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015-2020, Linaro Limited
- * Copyright (c) 2021, Arm Limited
+ * Copyright (c) 2021-2022, Arm Limited
  */
 #ifndef __KERNEL_BOOT_H
 #define __KERNEL_BOOT_H
@@ -46,7 +46,7 @@ extern const struct core_mmu_config boot_mmu_config;
 /* @nsec_entry is unused if using CFG_WITH_ARM_TRUSTED_FW */
 void boot_init_primary_early(unsigned long pageable_part,
 			     unsigned long nsec_entry);
-void boot_init_primary_late(unsigned long fdt);
+void boot_init_primary_late(unsigned long fdt, unsigned long spmc_manifest);
 void boot_init_memtag(void);
 
 void __panic_at_smc_return(void) __noreturn;
@@ -88,6 +88,9 @@ void *get_embedded_dt(void);
 
 /* Returns external DTB if present, otherwise NULL */
 void *get_external_dt(void);
+
+/* Returns the SPMC manifest DT if present, otherwise NULL */
+void *get_spmc_manifest_dt(void);
 
 /*
  * get_aslr_seed() - return a random seed for core ASLR

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -31,7 +31,7 @@ static int read_dt_tpm_log_info(void *fdt, int node, paddr_t *buf,
 	int len_prop = 0;
 	paddr_t log_addr = 0;
 	int err = 0;
-#ifdef CFG_MAP_EXT_DT_SECURE
+#if defined CFG_MAP_EXT_DT_SECURE || defined CFG_CORE_SEL1_SPMC
 	const char *dt_tpm_event_log_addr = "tpm_event_log_addr";
 #else
 	const char *dt_tpm_event_log_addr = "tpm_event_log_sm_addr";


### PR DESCRIPTION
If the SPMD is enabled in TF-A, the register usage at BL31 -> BL32
handover is the following [1]:
  - x0: TOS_FW_CONFIG DT (SPMC manifest)
  - x1: HW_CONFIG DT

This commit modifies the entry function to get aligned with this
convention if OP-TEE is the S-EL1 SPMC. It also adds functionality to
map the SPMC manifest and retrieve it later.

Link: [1] https://trustedfirmware-a.readthedocs.io/en/latest/components/secure-partition-manager.html#spmc-boot
Signed-off-by: Balint Dobszay <balint.dobszay@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
