### PR TITLE
core: mbedtls: Add ecc signature size check

### DIFF
--- a/lib/libmbedtls/core/ecc.c
+++ b/lib/libmbedtls/core/ecc.c
@@ -242,6 +242,12 @@ static TEE_Result ecc_sign(uint32_t algo, struct ecc_keypair *key,
 	if (res != TEE_SUCCESS)
 		goto out;
 
+	if (*sig_len < 2 * key_size_bytes) {
+		*sig_len = 2 * key_size_bytes;
+		res = TEE_ERROR_SHORT_BUFFER;
+		goto out;
+	}
+
 	pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECDSA);
 	if (pk_info == NULL) {
 		res = TEE_ERROR_NOT_SUPPORTED;


### PR DESCRIPTION
The ecc signature implementation must check that the output buffer
has sufficient space to store the signature. This check was missing
in the mbedtls version of ecc_sign.

Fixes: ad6cfae7c0 ("libmbedtls: support mbedtls ECC function")
Signed-off-by: Lars Persson <lars.persson@axis.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
