### PR TITLE
drivers: se050: optional I2C access via trampoline

### DIFF
--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -18,6 +18,8 @@ CFG_CORE_SE05X_INIT_NVM ?= n
 CFG_CORE_SE05X_BAUDRATE ?= 3400000
 # I2C bus [0..2] (depends on board)
 CFG_CORE_SE05X_I2C_BUS ?= 2
+# I2C access via REE after TEE boot
+CFG_CORE_SE05X_I2C_TRAMPOLINE ?= y
 
 # Extra stacks required to support the Plug and Trust external library
 ifeq ($(shell test $(CFG_STACK_THREAD_EXTRA) -lt 8192; echo $$?), 0)

--- a/core/drivers/crypto/se050/glue/i2c.c
+++ b/core/drivers/crypto/se050/glue/i2c.c
@@ -5,6 +5,7 @@
  */
 
 #include <compiler.h>
+#include <config.h>
 #include <glue.h>
 #include <i2c_native.h>
 #include <initcall.h>
@@ -56,7 +57,8 @@ int glue_i2c_init(void)
 
 static TEE_Result load_trampoline(void)
 {
-	transfer = rpc_io_i2c_transfer;
+	if (IS_ENABLED(CFG_CORE_SE05X_I2C_TRAMPOLINE))
+		transfer = rpc_io_i2c_transfer;
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Platforms with secure I2C buses (i.e: STM32MP1) or those with only
a secure element on the bus might prefer not to delegate the I2C
traffic to the REE.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
