### PR TITLE
core: do not access RPMB storage if accessing from REE fops.

### DIFF
--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -472,7 +472,7 @@ static const struct tee_fs_dirfile_operations ree_dirf_ops = {
 static struct tee_fs_dirfile_dirh *ree_fs_dirh;
 static size_t ree_fs_dirh_refcount;
 
-#ifdef CFG_RPMB_FS
+#ifdef CFG_REE_FS_INTEGRITY_RPMB
 static struct tee_file_handle *ree_fs_rpmb_fh;
 
 static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
@@ -544,7 +544,7 @@ static void close_dirh(struct tee_fs_dirfile_dirh **dirh)
 	rpmb_fs_ops.close(&ree_fs_rpmb_fh);
 }
 
-#else /*!CFG_RPMB_FS*/
+#else /*!CFG_REE_FS_INTEGRITY_RPMB*/
 static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 {
 	TEE_Result res;
@@ -566,7 +566,7 @@ static void close_dirh(struct tee_fs_dirfile_dirh **dirh)
 	tee_fs_dirfile_close(*dirh);
 	*dirh = NULL;
 }
-#endif /*!CFG_RPMB_FS*/
+#endif /*!CFG_REE_FS_INTEGRITY_RPMB*/
 
 static TEE_Result get_dirh(struct tee_fs_dirfile_dirh **dirh)
 {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -157,6 +157,11 @@ CFG_REE_FS ?= y
 # RPMB file system support
 CFG_RPMB_FS ?= n
 
+# Enable roll-back protection of REE file system using RPMB.
+# Roll-back protection only works if CFG_RPMB_FS = y.
+CFG_REE_FS_INTEGRITY_RPMB ?= $(CFG_RPMB_FS)
+$(eval $(call cfg-depends-all,CFG_REE_FS_INTEGRITY_RPMB,CFG_RPMB_FS))
+
 # Device identifier used when CFG_RPMB_FS = y.
 # The exact meaning of this value is platform-dependent. On Linux, the
 # tee-supplicant process will open /dev/mmcblk<id>rpmb


### PR DESCRIPTION
If we enable CFG_RPMB_FS and CFG_REE_FS at the same time. A call from
ree_fs_open() will falsely accessing RPMB to get directory handle by
calling get_dirh() to open_dirh().

How-tested: execute `xtest -t regression` with optee-os CFG_REE_FS=y
and CFG_RPMB_FS=y. Testcase 1004 will fail.

Actually I don't understand why keeping a path CFG_RPMB_FS inside
tee_ree_fs.c. In our case we need both RPMB and REE fs enabled
because we want to test if the platform has been provisioned
with RPMB key. But we don't want to use RPMB for secure storage
just yet. So I need to keep both CFG_RPMB_FS and CFG_REE_FS
enabled and let storage id choose which applies.

Signed-off-by: Judy Wang <wangjudy@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
