### PR TITLE
clang.mk: fix build on AArch64 host

### DIFF
--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -4,6 +4,9 @@
 # instance "/some/path/ccache /other/path/arm-linux-gnueabihf-").
 # We try to extract any ccache command if present.
 clang-target	:= $(patsubst %-,%,$(notdir $(lastword $(CROSS_COMPILE_$(sm)))))
+ifeq ($(clang-target),aarch64-linux)
+clang-target	:= aarch64-linux-gnu
+endif
 ccache-cmd	:= $(if $(findstring ccache,$(CROSS_COMPILE_$(sm))),$(firstword $(CROSS_COMPILE_$(sm))) ,)
 
 CC$(sm)		:= $(ccache-cmd)$(OPTEE_CLANG_COMPILER_PATH)clang --target=$(clang-target)


### PR DESCRIPTION
When building on an AArch64 host and using OP-TEE's build.git [1], the
AArch64 cross compiler prefix is "aarch64-linux-" instead of the usual
"aarch64-linux-gnu-". This happens due to [2]. Clang still expects
--target=aarch64-linux-gnu so for convenience map the prefix accordingly
in mk/clang.mk.

Link: [1] https://github.com/OP-TEE/build.git
Link: [2] https://github.com/OP-TEE/build/blob/3.18.0/toolchain.mk#L97
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
