### PR TITLE
RNG async get entropy framework

### DIFF
--- a/core/crypto/rng_hw.c
+++ b/core/crypto/rng_hw.c
@@ -3,14 +3,85 @@
 
 #include <compiler.h>
 #include <crypto/crypto.h>
+#include <kernel/mutex.h>
 #include <kernel/panic.h>
+#include <malloc.h>
 #include <rng_support.h>
 #include <tee/tee_cryp_utl.h>
 #include <types_ext.h>
 
+static uint8_t *rng_fifo;
+static size_t rng_fifo_size;
+static size_t rng_fifo_pos;
+static struct mutex rng_fifo_mutex = MUTEX_INITIALIZER;
+
+TEE_Result __weak hw_get_max_available_entropy(size_t *blen)
+{
+	*blen = sizeof(size_t);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result __weak hw_get_available_entropy(void *buf)
+{
+	TEE_Result ret;
+
+	ret = hw_get_random_bytes(buf, sizeof(size_t));
+	if (ret != TEE_SUCCESS)
+		return ret;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result __weak hw_get_random_bytes(void *buf, size_t blen)
+{
+	uint8_t *buffer = buf;
+	size_t buffer_pos = 0;
+	TEE_Result ret = TEE_SUCCESS;
+
+	mutex_lock(&rng_fifo_mutex);
+
+	while (buffer_pos < blen) {
+		/* Refill our FIFO */
+		if (rng_fifo_pos == 0) {
+			while (true) {
+				ret = hw_get_available_entropy(rng_fifo);
+				if (ret == TEE_SUCCESS)
+					break;
+				else if (ret != TEE_ERROR_BUSY)
+					goto out;
+			}
+		}
+
+		buffer[buffer_pos++] = rng_fifo[rng_fifo_pos++];
+		if (rng_fifo_pos == rng_fifo_size)
+			rng_fifo_pos = 0;
+	}
+
+out:
+	mutex_unlock(&rng_fifo_mutex);
+	return ret;
+}
+
 /* This is a HW RNG, no need for seeding */
 TEE_Result crypto_rng_init(const void *data __unused, size_t dlen __unused)
 {
+	TEE_Result ret;
+
+	/*
+	 * We do not need to seed our HW RNG, but we do need to allocate
+	 * a buffer for storing extra entropy, set that up here.
+	 */
+	ret = hw_get_max_available_entropy(&rng_fifo_size);
+	if (ret != TEE_SUCCESS) {
+		rng_fifo_size = 0;
+		return ret;
+	}
+
+	rng_fifo = malloc(rng_fifo_size);
+	if (!rng_fifo)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
 	return TEE_SUCCESS;
 }
 

--- a/core/include/rng_support.h
+++ b/core/include/rng_support.h
@@ -9,4 +9,22 @@
 
 TEE_Result hw_get_random_bytes(void *buf, size_t blen);
 
+/*
+ * hw_get_max_available_entropy() - Get the maximum bytes of entropy per call
+ * @blen:  [out] Maximum number of bytes of entropy that can be returned
+ *               in a single call to the hw_get_available_entropy() function
+ *
+ * Returns TEE_SUCCESS on success.
+ */
+TEE_Result hw_get_max_available_entropy(size_t *blen);
+
+/*
+ * hw_get_available_entropy() - Get currently available entropy
+ * @buf:  [out] Buffer pointer for storing entropy bytes
+ *
+ * Returns TEE_SUCCESS on success or an error code on failure or
+ * if not enough entropy is yet available.
+ */
+TEE_Result hw_get_available_entropy(void *buf);
+
 #endif /* __RNG_SUPPORT_H__ */

--- a/core/include/rng_support.h
+++ b/core/include/rng_support.h
@@ -7,8 +7,6 @@
 
 #include <stdint.h>
 
-TEE_Result hw_get_random_bytes(void *buf, size_t blen);
-
 /*
  * hw_get_max_available_entropy() - Get the maximum bytes of entropy per call
  * @blen:  [out] Maximum number of bytes of entropy that can be returned


### PR DESCRIPTION
As discussed in the early comments of #5300, there is a desire to move the RNG framework to something more asynchronous. Both to support the SMCCC TRNG interface and to reduce time spent locked waiting for new RNG.

The plan here is to move to hw_get_max_available_entropy() and hw_get_available_entropy() as described in the first patch. This includes temporary helpers to allow this to work during the conversion phase.

Given the recent migration to hw_get_random_bytes(), most RNG drivers are already in a state that lends themselves to easy conversion. As and example the second patch converts DRA7x RNG. If this works for folks, we can start converting all the other drivers in a similar way.

The last patch is an example of what we can do after all drivers are converted. Showing what functions were temporary and how the final `core/crypto/rng_hw.c` can look.
