### PR TITLE
core: arm: use CFG_STACK_THREAD_EXTRA also with CFG_WITH_PAGER

### DIFF
--- a/core/arch/arm/include/kernel/thread_private_arch.h
+++ b/core/arch/arm/include/kernel/thread_private_arch.h
@@ -25,7 +25,12 @@
 #else
 #define STACK_TMP_SIZE		(2048 + STACK_TMP_OFFS)
 #endif
+
+#ifdef CFG_WITH_PAGER
+#define STACK_THREAD_SIZE	(8192 + CFG_STACK_THREAD_EXTRA)
+#else
 #define STACK_THREAD_SIZE	8192
+#endif
 
 #if defined(CFG_CORE_SANITIZE_KADDRESS) || defined(__clang__) || \
 	!defined(CFG_CRYPTO_WITH_CE)
@@ -42,7 +47,12 @@
 #else
 #define STACK_TMP_SIZE		(2048 + STACK_TMP_OFFS)
 #endif
+
+#ifdef CFG_WITH_PAGER
+#define STACK_THREAD_SIZE	(8192 + CFG_STACK_THREAD_EXTRA)
+#else
 #define STACK_THREAD_SIZE	8192
+#endif
 
 #if TRACE_LEVEL > 0
 #define STACK_ABT_SIZE		3072


### PR DESCRIPTION
The Plug-and-Trust[1] companion project to the se050 crypto driver
has high stack requirements.
Due to this the driver is configured with CFG_STACK_THREAD_EXTRA.

This configuration however is not enforced by OP-TEE when the pager
is running - as it happens on the STM32MP1 platform; this causes the
driver to hit core data-aborts during some cryptographic operations
due to the Plug-and-Trust overflowing the stack.

Fix this by applying CFG_STACK_THREAD_EXTRA to the STACK_THREAD_SIZE
also when the pager is enabled.

[1] https://github.com/NXP/plug-and-trust

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
