### PR TITLE
Fix binutils 2.39 ld warning about missing .note.GNU-stack section and executable stack

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -9,6 +9,11 @@ link-script-dep = $(link-out-dir)/.kern.ld.d
 
 AWK	 = awk
 
+link-ldflags-common += $(call ld-option,--no-warn-rwx-segments)
+ifeq ($(CFG_ARM32_core),y)
+link-ldflags-common += $(call ld-option,--no-warn-execstack)
+endif
+
 link-ldflags  = $(LDFLAGS)
 ifeq ($(CFG_CORE_ASLR),y)
 link-ldflags += -pie -Bsymbolic -z norelro $(ldflag-apply-dynamic-relocs)
@@ -31,7 +36,7 @@ link-ldflags += -T $(link-script-pp) -Map=$(link-out-dir)/tee.map
 link-ldflags += --sort-section=alignment
 link-ldflags += --fatal-warnings
 link-ldflags += --gc-sections
-link-ldflags += $(call ld-option,--no-warn-rwx-segments)
+link-ldflags += $(link-ldflags-common)
 
 link-ldadd  = $(LDADD)
 link-ldadd += $(ldflags-external)
@@ -56,7 +61,7 @@ link-script-cppflags := \
 		$(cppflagscore))
 
 ldargs-all_objs := -T $(link-script-dummy) --no-check-sections \
-		   $(call ld-option,--no-warn-rwx-segments) \
+		   $(link-ldflags-common) \
 		   $(link-objs) $(link-ldadd) $(libgcccore)
 cleanfiles += $(link-out-dir)/all_objs.o
 $(link-out-dir)/all_objs.o: $(objs) $(libdeps) $(MAKEFILE_LIST)
@@ -70,7 +75,7 @@ $(link-out-dir)/unpaged_entries.txt: $(link-out-dir)/all_objs.o
 		$(AWK) '/ ____keep_pager/ { printf "-u%s ", $$3 }' > $@
 
 unpaged-ldargs := -T $(link-script-dummy) --no-check-sections --gc-sections \
-		 $(call ld-option,--no-warn-rwx-segments)
+		 $(link-ldflags-common)
 unpaged-ldadd := $(objs) $(link-ldadd) $(libgcccore)
 cleanfiles += $(link-out-dir)/unpaged.o
 $(link-out-dir)/unpaged.o: $(link-out-dir)/unpaged_entries.txt
@@ -99,7 +104,7 @@ $(link-out-dir)/init_entries.txt: $(link-out-dir)/all_objs.o
 		$(AWK) '/ ____keep_init/ { printf "-u%s ", $$3 }' > $@
 
 init-ldargs := -T $(link-script-dummy) --no-check-sections --gc-sections \
-	       $(call ld-option,--no-warn-rwx-segments)
+	       $(link-ldflags-common)
 init-ldadd := $(link-objs-init) $(link-out-dir)/version.o  $(link-ldadd) \
 	      $(libgcccore)
 cleanfiles += $(link-out-dir)/init.o

--- a/ldelf/link.mk
+++ b/ldelf/link.mk
@@ -20,6 +20,9 @@ link-ldflags += -z max-page-size=4096 # OP-TEE always uses 4K alignment
 ifeq ($(CFG_CORE_BTI),y)
 link-ldflags += $(call ld-option,-z force-bti) --fatal-warnings
 endif
+ifeq ($(CFG_ARM32_$(sm)), y)
+link-ldflags += $(call ld-option,--no-warn-execstack)
+endif
 link-ldflags += $(link-ldflags$(sm))
 
 link-ldadd  = $(addprefix -L,$(libdirs))

--- a/lib/libutee/arch/arm/utee_syscalls_a32.S
+++ b/lib/libutee/arch/arm/utee_syscalls_a32.S
@@ -7,6 +7,8 @@
 #include <tee_syscall_numbers.h>
 #include <asm.S>
 
+	.section .note.GNU-stack,"",%progbits
+
         .section .text
         .balign 4
         .code 32

--- a/lib/libutils/ext/arch/arm/atomic_a32.S
+++ b/lib/libutils/ext/arch/arm/atomic_a32.S
@@ -5,6 +5,8 @@
 
 #include <asm.S>
 
+	.section .note.GNU-stack,"",%progbits
+
 /* uint32_t atomic_inc32(uint32_t *v); */
 FUNC atomic_inc32 , :
 	ldrex	r1, [r0]

--- a/lib/libutils/ext/arch/arm/mcount_a32.S
+++ b/lib/libutils/ext/arch/arm/mcount_a32.S
@@ -7,6 +7,8 @@
 
 #if defined(CFG_TA_GPROF_SUPPORT) || defined(CFG_FTRACE_SUPPORT)
 
+	.section .note.GNU-stack,"",%progbits
+
 /*
  * Convert return address to call site address by subtracting the size of the
  * mcount call instruction (blx __gnu_mcount_nc).

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod_a32.S
@@ -5,6 +5,8 @@
 
 #include <asm.S>
 
+	.section .note.GNU-stack,"",%progbits
+
 /*
  * signed ret_idivmod_values(signed quot, signed rem);
  * return quotient and remaining the EABI way (regs r0,r1)

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_ldivmod_a32.S
@@ -5,6 +5,8 @@
 
 #include <asm.S>
 
+	.section .note.GNU-stack,"",%progbits
+
 /*
  * __value_in_regs lldiv_t __aeabi_ldivmod( long long n, long long d)
  */

--- a/lib/libutils/isoc/arch/arm/setjmp_a32.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a32.S
@@ -51,6 +51,8 @@
 #define SIZE(x)
 #endif
 
+	.section .note.GNU-stack,"",%progbits
+
 /* Arm/Thumb interworking support:
 
    The interworking scheme expects functions to use a BX instruction

--- a/ta/arch/arm/ta_entry_a32.S
+++ b/ta/arch/arm/ta_entry_a32.S
@@ -5,6 +5,8 @@
 
 #include <asm.S>
 
+	.section .note.GNU-stack,"",%progbits
+
 /*
  * This function is the bottom of the user call stack. Mark it as such so that
  * the unwinding code won't try to go further down.


### PR DESCRIPTION
Addressing https://github.com/OP-TEE/optee_os/issues/5471#issuecomment-1222621421.