### PR TITLE
plat: rcar: fix core pos calculation for H3 boards

### DIFF
--- a/core/arch/arm/plat-rcar/core_pos_a64.S
+++ b/core/arch/arm/plat-rcar/core_pos_a64.S
@@ -64,9 +64,10 @@ FUNC get_core_pos_mpidr , :
 1:	mov	w2, #PRR_PRODUCT_M3W
 	and	w3, w3, #PRR_PRODUCT_MASK
 	cmp	w2, w3
-	bne	2f	/* if (IsM3W) { x1 <<= 1; } */
+	beq	2f	/* if (!IsM3W) { x1 <<= 2; } else { x1 <<= 1} */
 	lsl	x1, x1, #1
-2:	add	x0, x0, x1
+2:	lsl	x1, x1, #1
+	add	x0, x0, x1
 
 	ret
 END_FUNC get_core_pos_mpidr


### PR DESCRIPTION
Due to mistake, cluster position wasn't shifted left if chip is not M3W. This
led to erroneous core ID calculation on chips that are not M3W. Actually, this
affected only H3, as only this chip has two clusters.

Fix this by always shifting x1 (cluster ID) to the left, before doing one
additional shift for non-M3W chips.

Fixes: 572afdce53ea ("plat: rcar: Derive core map from PRR")

Reported-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>
Tested-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com> (R-Car M3)
Tested-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com> (R-Car H3)
Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
