### PR TITLE
FF-A: Enable loading Secure Partitions from the FIP

### DIFF
--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -53,7 +53,7 @@ struct sp_ctx {
 
 struct sp_image {
 	struct embedded_ts image;
-	const void * const fdt;
+	const void *fdt;
 };
 
 #ifdef CFG_SECURE_PARTITION
@@ -94,5 +94,18 @@ TEE_Result sp_unmap_ffa_regions(struct sp_session *s, struct sp_mem *smem);
 
 #define for_each_secure_partition(_sp) \
 	SCATTERED_ARRAY_FOREACH(_sp, sp_images, struct sp_image)
+
+struct fip_sp {
+	tee_mm_entry_t *mm;
+	struct sp_image sp_img;
+
+	STAILQ_ENTRY(fip_sp) link;
+};
+
+STAILQ_HEAD(fip_sp_head, fip_sp);
+extern struct fip_sp_head fip_sp_list;
+
+#define for_each_fip_sp(_sp) \
+	STAILQ_FOREACH(_sp, &fip_sp_list, link)
 
 #endif /* __KERNEL_SECURE_PARTITION_H */

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -349,7 +349,7 @@ static TEE_Result sp_dt_get_u64(const void *fdt, int node, const char *property,
 	if (!p || len != sizeof(*p))
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	*value = fdt64_to_cpu(*p);
+	*value = fdt64_ld(p);
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
TF-A offers a mechanism to encapsulate an SP image and its manifest into an SP package and add that to the FIP. During boot BL2 will load these packages into memory and the SPMC manifest is used to pass the load addresses to the SPMC. 
https://trustedfirmware-a.readthedocs.io/en/v2.6/components/secure-partition-manager.html#secure-partition-packages

This is an alternate method to the current way of embedding the SPs into the OP-TEE binary. It makes integration of the system easier, since OP-TEE won't depend on the SPs images. At build time this means that we don't have to rebuild OP-TEE if an SP is changed, it only gets replaced in the FIP. Also, Hafnium (S-EL2 SPMC) uses the same FIP SP mechanism so adding this feature to OP-TEE reduces the fragmentation between the SPMC implementations.