### PR TITLE
ffa: Export ffa.h to be used by host

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -909,3 +909,6 @@ CFG_DRIVERS_TPM2_MMIO ?= n
 ifeq ($(CFG_CORE_TPM_EVENT_LOG),y)
 CFG_CORE_TCG_PROVIDER ?= $(CFG_DRIVERS_TPM2)
 endif
+
+# Enable the FF-A SPMC tests in xtests
+CFG_SPMC_TESTS ?= n

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -120,7 +120,10 @@ incfiles-extra-host += core/include/signed_hdr.h
 ifeq ($(ta-target),ta_arm32)
 incfiles-extra-host += $(out-dir)/include/generated/arm32_user_sysreg.h
 endif
-
+ifeq ($(CFG_SPMC_TESTS),y)
+incfiles-extra-host += core/arch/arm/include/ffa.h
+incfiles-extra-host += core/arch/arm/include/smccc.h
+endif
 #
 # Copy lib files and exported headers from each lib
 #


### PR DESCRIPTION
The ffa.h file is needed by the OP-TEE test suite. Export it so it can
be used by it. The corresponding test PR can be found [here](https://github.com/OP-TEE/optee_test/pull/614) 

Signed-off-by: Jelle Sels <jelle.sels@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
