### PR TITLE
plat-stm32mp1: reset system using rstctrl device

### DIFF
--- a/core/arch/arm/plat-stm32mp1/pm/psci.c
+++ b/core/arch/arm/plat-stm32mp1/pm/psci.c
@@ -7,6 +7,7 @@
 #include <boot_api.h>
 #include <console.h>
 #include <drivers/clk.h>
+#include <drivers/rstctrl.h>
 #include <drivers/stm32mp1_pmic.h>
 #include <drivers/stm32mp1_rcc.h>
 #include <drivers/stpmic1.h>
@@ -239,11 +240,7 @@ void __noreturn psci_system_off(void)
 /* Override default psci_system_reset() with platform specific sequence */
 void __noreturn psci_system_reset(void)
 {
-	vaddr_t rcc_base = stm32_rcc_base();
-
-	DMSG("core %u", get_core_pos());
-
-	io_write32(rcc_base + RCC_MP_GRSTCSETR, RCC_MP_GRSTCSETR_MPSYSRST);
+	rstctrl_assert(stm32mp_rcc_reset_id_to_rstctrl(MPSYST_R));
 	udelay(100);
 	panic();
 }

--- a/core/include/dt-bindings/reset/stm32mp1-resets.h
+++ b/core/include/dt-bindings/reset/stm32mp1-resets.h
@@ -31,6 +31,7 @@
 #define CRC1_R		3284
 #define USBH_R		3288
 #define MDMA_R		3328
+#define MPSYST_R	8224
 #define MCU_R		8225
 #define TIM2_R		19456
 #define TIM3_R		19457

--- a/core/include/dt-bindings/reset/stm32mp13-resets.h
+++ b/core/include/dt-bindings/reset/stm32mp13-resets.h
@@ -7,6 +7,7 @@
 #ifndef _DT_BINDINGS_STM32MP13_RESET_H_
 #define _DT_BINDINGS_STM32MP13_RESET_H_
 
+#define MPSYST_R	2208
 #define TIM2_R		13568
 #define TIM3_R		13569
 #define TIM4_R		13570


### PR DESCRIPTION
Implements PSCI system reset support in STM32MP13 by using rstctrl API to reset the system rather than a SoC specific resource in plat-stm32mp1.