### PR TITLE
libutils:assert.h:add compiler check for static_assert

### DIFF
--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -33,6 +33,7 @@ void _assert_log(const char *expr, const char *file, const int line,
 
 #endif
 
+#if !defined(__cplusplus) || (__cplusplus < 201103L)
 #if defined(__HAVE_SINGLE_ARGUMENT_STATIC_ASSERT)
 #define static_assert _Static_assert
 #else
@@ -51,4 +52,5 @@ void _assert_log(const char *expr, const char *file, const int line,
 
 #define static_assert(...) \
 	__static_assert(__args_count(__VA_ARGS__), __VA_ARGS__)
+#endif
 #endif


### PR DESCRIPTION
This PR is used to fix ```static_assert``` issue in [issue 5502](https://github.com/OP-TEE/optee_os/issues/5502)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
