### PR TITLE
core: add missing pauth key saving in foreign interrupt handler

### DIFF
--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -1071,6 +1071,12 @@ END_FUNC el0_sync_abort
 	/* Save original x0..x3 */
 	store_xregs x0, THREAD_CTX_REGS_X0, 10, 13
 
+#ifdef CFG_TA_PAUTH
+	/* Save APIAKEY */
+	read_apiakeyhi	x1
+	read_apiakeylo	x2
+	store_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
+#endif
 	/* load tmp_stack_va_end */
 	ldr	x1, [sp, #THREAD_CORE_LOCAL_TMP_STACK_VA_END]
 	/* Switch to SP_EL0 */


### PR DESCRIPTION
When a foreign interrupt (non-secure) is trapped in OP-TEE the state of the current thread is saved similarly to when an RPC is performed.

With pointer authentication enabled two more registers which are part of the current context, APIAKEYHI-EL1 and APIAKEYLO-EL1, are added. These registers contains a key needed for pointer authentication. This key is unique per context so it must always be saved and restored when switching context.

Prior to this patch the step where this key is saved in the foreign interrupt handler was missing, so fix this by adding the missing step.

Fixes: 2b06f9dede33 ("Add basic pointer authentication support for TA's")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
