### PR TITLE
core: storage: improve SE05x deletion of NVM objects

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -883,6 +883,7 @@ TEE_Result crypto_acipher_ed25519ctx_verify(struct ed25519_keypair *key
 }
 #endif
 
-__weak void crypto_storage_obj_del(uint8_t *data __unused, size_t len __unused)
+__weak TEE_Result crypto_storage_obj_del(struct tee_obj *obj __unused)
 {
+	return TEE_ERROR_NOT_IMPLEMENTED;
 }

--- a/core/drivers/crypto/se050/core/storage.c
+++ b/core/drivers/crypto/se050/core/storage.c
@@ -5,22 +5,49 @@
  */
 
 #include <crypto/crypto.h>
+#include <mm/core_mmu.h>
 #include <se050.h>
 #include <se050_utils.h>
 #include <string.h>
+#include <tee/tee_fs.h>
+#include <tee/tee_obj.h>
+#include <tee/tee_pobj.h>
 
-void crypto_storage_obj_del(uint8_t *data, size_t len)
+TEE_Result crypto_storage_obj_del(struct tee_obj *o)
 {
 	sss_status_t status = kStatus_SSS_Success;
 	uint32_t val = SE050_KEY_WATERMARK;
+	TEE_Result ret = TEE_ERROR_GENERIC;
 	sss_se05x_object_t k_object = { };
+	uint8_t *data = NULL;
+	uint8_t *p = NULL;
 	bool found = false;
-	uint8_t *p = data;
+	size_t len = 0;
 
-	if (!p)
-		return;
+	if (!o)
+		return TEE_ERROR_BAD_PARAMETERS;
 
-	while (len > sizeof(uint64_t) && !found) {
+	len = o->info.dataSize;
+
+	/* Supported keys (ECC/RSA) require less than 4KB of storage */
+	if (len > SMALL_PAGE_SIZE || len <= sizeof(uint64_t))
+		return TEE_SUCCESS;
+
+	data = calloc(1, len);
+	if (!data)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	/* Read the object into memory */
+	ret = o->pobj->fops->read(o->fh, o->info.dataPosition, data, &len);
+	if (ret) {
+		EMSG("se05x: can not read the object prior removal");
+		free(data);
+		goto out;
+	}
+
+	/* Scan the object for the watermark */
+	p = data;
+	while (len >= sizeof(uint32_t) && !found) {
 		if (memcmp(p, &val, sizeof(val)) != 0) {
 			p++;
 			len--;
@@ -29,22 +56,53 @@ void crypto_storage_obj_del(uint8_t *data, size_t len)
 		found = true;
 	}
 
-	if (!found)
-		return;
+	if (!found) {
+		free(data);
+		return TEE_SUCCESS;
+	}
 
+	/* Retrieve the object identifier */
 	p = p - 4;
 	memcpy((void *)&val, p, sizeof(val));
+	free(data);
 
 	if (val < OID_MIN || val > OID_MAX)
-		return;
+		return TEE_SUCCESS;
 
 	status = sss_se05x_key_object_init(&k_object, se050_kstore);
-	if (status != kStatus_SSS_Success)
-		return;
+	if (status != kStatus_SSS_Success) {
+		ret = TEE_ERROR_BAD_STATE;
+		goto out;
+	}
 
 	status = sss_se05x_key_object_get_handle(&k_object, val);
-	if (status != kStatus_SSS_Success)
-		return;
+	if (status != kStatus_SSS_Success) {
+		EMSG("se05x: can not communicate with the secure element");
+		ret = TEE_ERROR_BAD_STATE;
+		goto out;
+	}
 
-	sss_se05x_key_store_erase_key(se050_kstore, &k_object);
+	status = sss_se05x_key_store_erase_key(se050_kstore, &k_object);
+	if (status != kStatus_SSS_Success) {
+		EMSG("se05x: can not communicate with the secure element");
+		ret = TEE_ERROR_BAD_STATE;
+		goto out;
+	}
+
+out:
+	/*
+	 * Users can delete the SE05X NVM objects during boot using a built
+	 * time configuration flag (CFG_CORE_SE05X_INIT_NVM).
+	 *
+	 * This could cause the deletion of the secure storage objects holding
+	 * references to those IDs via crypto_storage_obj_del() to fail, leaving
+	 * broken links in the file system.
+	 *
+	 * Therefore we only permit this call to block the deletion upon an
+	 * additional specific config.
+	 */
+	if (ret && IS_ENABLED(CFG_CORE_SE05X_BLOCK_OBJ_DEL_ON_ERROR))
+		return ret;
+
+	return TEE_SUCCESS;
 }

--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -13,6 +13,10 @@ CFG_CORE_SE05X_DISPLAY_INFO ?= y
 CFG_CORE_SE05X_SCP03_EARLY ?= y
 # Deletes all persistent storage from the SE050 at boot
 CFG_CORE_SE05X_INIT_NVM ?= n
+# Prevents the deletion of the secure storage object holding a reference to a
+# Secure Element (SE) Non Volatile Memory object unless there is explicit
+# confirmation from the SE that the NVM object has been removed.
+CFG_CORE_SE05X_BLOCK_OBJ_DEL_ON_ERROR ?= n
 
 # I2C bus baudrate (depends on SoC)
 CFG_CORE_SE05X_BAUDRATE ?= 3400000

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -22,6 +22,7 @@
 #ifndef __CRYPTO_CRYPTO_H
 #define __CRYPTO_CRYPTO_H
 
+#include <tee/tee_obj.h>
 #include <tee_api_types.h>
 
 TEE_Result crypto_init(void);
@@ -82,7 +83,7 @@ void crypto_authenc_free_ctx(void *ctx);
 void crypto_authenc_copy_state(void *dst_ctx, void *src_ctx);
 
 /* Informs crypto that the data in the buffer will be removed from storage */
-void crypto_storage_obj_del(uint8_t *data, size_t len);
+TEE_Result crypto_storage_obj_del(struct tee_obj *obj);
 
 /* Implementation-defined big numbers */
 


### PR DESCRIPTION
Keys created on the Secure Element NVM via the PKCS#11 TA are removed by scanning the data buffer holding the reference to the key during the release of the object.

The storage allocated to hold those keys (ECC/RSA) is always below the page size length which seems like a reasonable figure to use for future extensions.

This commit avoids scanning objects larger than that length.

Incidentally also fixes regression 6018: this test releases an object of size 0xA0000 which can't be scanned due to this part of the code hitting an OOM.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
