### PR TITLE
core: pta: bcm: add option to disable sotp pta after first session

### DIFF
--- a/core/pta/bcm/sotp.c
+++ b/core/pta/bcm/sotp.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019, Broadcom
  */
 
+#include <config.h>
 #include <drivers/bcm_sotp.h>
 #include <io.h>
 #include <kernel/misc.h>
@@ -18,6 +19,20 @@ enum pta_bcm_sotp_cmd {
 };
 
 #define SOTP_TA_NAME		"pta_bcm_sotp.ta"
+
+static bool sotp_access_disabled;
+
+/**
+ * close_session() - Print a debug message when closing a session and set the
+ *		     driver to disallow any more pta sessions to connect.
+ * @pSessionContext	Unused.
+ */
+static void close_session(void *pSessionContext __unused)
+{
+	DMSG("close entry point for \"%s\"", SOTP_TA_NAME);
+	if (IS_ENABLED(CFG_BCM_SOTP_SINGLE_SESSION))
+		sotp_access_disabled = true;
+}
 
 static TEE_Result pta_sotp_read(uint32_t param_types,
 				TEE_Param params[TEE_NUM_PARAMS])
@@ -58,6 +73,11 @@ static TEE_Result invoke_command(void *session_context __unused,
 
 	DMSG("command entry point[%d] for \"%s\"", cmd_id, SOTP_TA_NAME);
 
+	if (IS_ENABLED(CFG_BCM_SOTP_SINGLE_SESSION) && sotp_access_disabled) {
+		DMSG("bcm sotp pta access disabled");
+		return TEE_ERROR_ACCESS_DENIED;
+	}
+
 	switch (cmd_id) {
 	case PTA_BCM_SOTP_CMD_READ:
 		res = pta_sotp_read(param_types, params);
@@ -77,4 +97,5 @@ static TEE_Result invoke_command(void *session_context __unused,
 pseudo_ta_register(.uuid = SOTP_SERVICE_UUID,
 		   .name = SOTP_TA_NAME,
 		   .flags = PTA_DEFAULT_FLAGS,
+		   .close_session_entry_point = close_session,
 		   .invoke_command_entry_point = invoke_command);


### PR DESCRIPTION
- If the config flag CFG_BCM_SOTP_SINGLE_SESSION is enabled, the BCM
  SOTP driver should prevent any further connections after the first PTA
  SOTP session disconnects.
- When enabling this flag, it will be possible to restrict any SOTP
  access after firmware bootup is complete.

Signed-off-by: Andrew Mustea <andrew.mustea@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
