### PR TITLE
core: drivers: bcm: add nitro hot patch feature

### DIFF
--- a/core/drivers/bnxt/bnxt_nitro_hot_patch.c
+++ b/core/drivers/bnxt/bnxt_nitro_hot_patch.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022 Microsoft
+ *
+ * Driver for the Broadcom BNXT Nitro hot patch driver.
+ */
+
+#include <drivers/bcm/bnxt_nitro_hot_patch.h>
+
+static vaddr_t staging_addr;
+static uint32_t staging_size;
+static uint32_t space_assigned;
+
+TEE_Result nitro_hot_patch_init(paddr_t addr, uint32_t size)
+{
+	if (!size) {
+		EMSG("Nitro hot patch init given memory size of 0x0");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	space_assigned = 0;
+	staging_addr = (vaddr_t)phys_to_virt(addr, MEM_AREA_RAM_SEC, 1);
+	if (!staging_addr) {
+		EMSG("Couldn't translate address: %"PRIxPA, addr);
+		staging_size = 0;
+		return TEE_ERROR_ITEM_NOT_FOUND;
+	}
+
+	staging_size = size;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result nitro_hot_patch_deinit(void)
+{
+	staging_addr = NULL;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result update_nitro_hot_patch(void *buffer, uint32_t size)
+{
+	uint32_t new_total_patch_size = space_assigned;
+
+	if (!staging_addr) {
+		EMSG("Nitro hot patch driver not initialized");
+		return TEE_ERROR_BAD_STATE;
+	}
+	if (!buffer) {
+		EMSG("Nitro hot patch source buffer not valid");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+	if (!size) {
+		EMSG("Given nitro hot patch size of 0x0");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	new_total_patch_size += size;
+	if (new_total_patch_size > staging_size) {
+		EMSG("New total memory size will be larger than staging size");
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	space_assigned = new_total_patch_size;
+
+	memcpy((void *)(staging_addr + space_assigned), buffer, size);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result verify_nitro_hot_patch(vaddr_t *staging_mem)
+{
+	if (staging_addr) {
+		EMSG("Nitro hot patch driver not initialized");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	if (!space_assigned) {
+		EMSG("No data stored in staging memory");
+		return TEE_ERROR_GENERIC;
+	}
+
+	staging_mem = staging_addr;
+
+	return TEE_SUCCESS;
+}

--- a/core/drivers/bnxt/sub.mk
+++ b/core/drivers/bnxt/sub.mk
@@ -1,3 +1,4 @@
 srcs-y += bnxt.c
 srcs-y += bnxt_fw.c
 srcs-y += bnxt_images.c
+srcs-$(CFG_BCM_NITRO_HOT_PATCH) += bnxt_nitro_hot_patch.c

--- a/core/include/drivers/bcm/bnxt.h
+++ b/core/include/drivers/bcm/bnxt.h
@@ -42,4 +42,12 @@ struct bnxt_images_info {
 int get_bnxt_images_info(struct bnxt_images_info *bnxt_info,
 			 int chip_type, vaddr_t ddr_dest);
 
-#endif
+/**
+ * apply_nitro_hot_patch() - Verify that the bnxt image in the Nitro hot patch
+ *			     staging area is valid and write it to memory.
+ *
+ * Return:		TEE_SUCCESS or > 0 on error.
+ */
+TEE_Result apply_nitro_hot_patch(void);
+
+#endif /* BNXT_H */

--- a/core/include/drivers/bcm/bnxt_nitro_hot_patch.h
+++ b/core/include/drivers/bcm/bnxt_nitro_hot_patch.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022 Microsoft
+ *
+ * Definitions for the Broadcom BNXT Nitro hot patch driver.
+ */
+
+#ifndef NITRO_HOT_PATCH_H
+#define NITRO_HOT_PATCH_H
+
+#include <mm/core_memprot.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/**
+ * nitro_hot_patch_init() - Initialize the staging memory location to hold the
+ *			    nitro hot patch until it gets verified and flashed.
+ * @paddr:	Physical address of the hot patch staging area.
+ * @size:	Size of the hot patch staging area.
+ *
+ * Return:	TEE_SUCCESS or > 0 on error.
+ */
+TEE_Result nitro_hot_patch_init(paddr_t paddr, uint32_t size);
+
+/**
+ * nitro_hot_patch_deinit() - Resets the driver by setting the staging address
+ *			      to NULL.
+ *
+ * Return:	TEE_SUCCESS.
+ */
+TEE_Result nitro_hot_patch_deinit(void);
+
+/**
+ * update_nitro_hot_patch() - Add data from a given buffer to the nitro hot
+ *			      patch staging area.
+ * @buffer:	Pointer to the data to copy.
+ * @size:	Size of incoming data patch.
+ *
+ * This function can be called more than once as long as the total size of the
+ * hot patch does not exceed the staging memory size set during initialization.
+ *
+ * Return:	TEE_SUCCESS or > 0 on error.
+ */
+TEE_Result update_nitro_hot_patch(void *buffer, uint32_t size);
+
+/**
+ * verify_nitro_hot_patch() - Verify the nitro hot patch in staging memory and
+ *			      update a given pointer with the hot patch address
+ *			      if the hot patch has been initialized and has a
+ *			      total size of > 0.
+ * @staging_mem:	Pointer to potentially return the hot patch info
+ *			address with.
+ *
+ * Return:		TEE_SUCCESS or > 0 on error.
+ */
+TEE_Result verify_nitro_hot_patch(vaddr_t *staging_mem);
+
+#endif

--- a/core/pta/bcm/bnxt.c
+++ b/core/pta/bcm/bnxt.c
@@ -36,6 +36,10 @@ enum pta_bnxt_cmd {
 	PTA_BNXT_HEALTH_STATUS,
 	PTA_BNXT_HANDSHAKE_STATUS,
 	PTA_BNXT_CRASH_DUMP_COPY,
+	PTA_BNXT_NITRO_HOT_PATCH_INIT,
+	PTA_BNXT_NITRO_HOT_PATCH_DEINIT,
+	PTA_BNXT_UPDATE_NITRO_HOT_PATCH,
+	PTA_BNXT_APPLY_NITRO_HOT_PATCH
 };
 
 #define BNXT_TA_NAME		"pta_bnxt.ta"
@@ -95,6 +99,93 @@ static TEE_Result copy_bnxt_crash_dump(uint32_t types,
 	return res;
 }
 
+/**
+ * hot_patch_init() - TEE command to initialize the nitro hot patch driver.
+ * @types:	Expected TEE_Param types.
+ * @params:	Parameters to use for hot patch initialization.
+ *
+ * Return:	TEE_Success or > 0 on error.
+ */
+static TEE_Result hot_patch_init(uint32_t types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("Bad parameter types: 0x%"PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return nitro_hot_patch_init((paddr_t)params[0].value.a,
+				    params[0].value.b);
+}
+
+/**
+ * hot_patch_deinit() - TEE command to reset the nitro hot patch driver.
+ * @types:	Expected TEE_Param types.
+ * @params:	Unused.
+ *
+ * Return:	TEE_SUCCESS or > 0 on error.
+ */
+static TEE_Result hot_patch_deinit(uint32_t types,
+				   TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("Bad parameter types: 0x%"PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return nitro_hot_patch_deinit();
+}
+
+/**
+ * func_name - TEE command to update the nitro hot patch with.
+ * @types:	Expected TEE_Param types.
+ * @__unused:	Parameters for shared memory to update the hot patch with.
+ *
+ * Return:	TEE_SUCCESS or > 0 on error.
+ */
+static TEE_Result update_hot_patch(uint32_t types,
+				   TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		DMSG("bad parameters types: 0x%" PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return update_nitro_hot_patch(params[0].memref.buffer,
+				      params[0].memref.size);
+}
+
+/**
+ * apply_hot_patch() - TEE command to verify and flash a nitro hot patch in
+ *		       staging memory.
+ * @types:	Expected TEE_Param types.
+ * @params:	Unused.
+ *
+ * Return:	TEE_Success or > 0 on error.
+ */
+static TEE_Result apply_hot_patch(uint32_t types,
+				  TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE)) {
+		EMSG("Bad parameter types: 0x%"PRIx32, types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return apply_nitro_hot_patch;
+}
+
 static TEE_Result invoke_command(void *session_context __unused,
 				 uint32_t cmd_id,
 				 uint32_t param_types __unused,
@@ -110,15 +201,43 @@ static TEE_Result invoke_command(void *session_context __unused,
 		if (bnxt_load_fw(1) != BNXT_SUCCESS)
 			return TEE_ERROR_TARGET_DEAD;
 		break;
+
 	case PTA_BNXT_HEALTH_STATUS:
 		DMSG("bnxt health status");
 		return get_bnxt_status(param_types, params);
+
 	case PTA_BNXT_HANDSHAKE_STATUS:
 		DMSG("bnxt handshake status");
 		return get_bnxt_handshake_status(param_types, params);
+
 	case PTA_BNXT_CRASH_DUMP_COPY:
 		DMSG("bnxt copy crash dump data");
 		return copy_bnxt_crash_dump(param_types, params);
+
+	case PTA_BNXT_NITRO_HOT_PATCH_INIT:
+		if (IS_ENABLED(CFG_BCM_NITRO_HOT_PATCH))
+			return hot_patch_init(param_types, params);
+		DMSG("cmd: %d Not supported %s", cmd_id, BNXT_TA_NAME);
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	case PTA_BNXT_NITRO_HOT_PATCH_DEINIT:
+		if (IS_ENABLED(CFG_BCM_NITRO_HOT_PATCH))
+			return hot_patch_deinit(param_types, params);
+		DMSG("cmd: %d Not supported %s", cmd_id, BNXT_TA_NAME);
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	case PTA_BNXT_UPDATE_NITRO_HOT_PATCH:
+		if (IS_ENABLED(CFG_BCM_NITRO_HOT_PATCH))
+			return update_hot_patch(param_types, params);
+		DMSG("cmd: %d Not supported %s", cmd_id, BNXT_TA_NAME);
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	case PTA_BNXT_APPLY_NITRO_HOT_PATCH:
+		if (IS_ENABLED(CFG_BCM_NITRO_HOT_PATCH))
+			return apply_hot_patch_cmd(param_types, params);
+		DMSG("cmd: %d Not supported %s", cmd_id, BNXT_TA_NAME);
+		return TEE_ERROR_NOT_SUPPORTED;
+
 	default:
 		DMSG("cmd: %d Not supported %s", cmd_id, BNXT_TA_NAME);
 		res = TEE_ERROR_NOT_SUPPORTED;


### PR DESCRIPTION
- BCM uses nitro as its network driver and updating it requires the NIC to be down for a few seconds while flashing.
- This feature adds a hot patch ability that can update the nitro image without needing to have the NIC go down.

Signed-off-by: Andrew Mustea <andrew.mustea@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
