### PR TITLE
core: add pointer authentication support

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -200,12 +200,23 @@ ifeq ($(CFG_CORE_ASLR),y)
 core-platform-cflags += -fpie
 endif
 
-ifeq ($(CFG_CORE_BTI),y)
-bti-opt := $(call cc-option,-mbranch-protection=bti)
-ifeq (,$(bti-opt))
-$(error -mbranch-protection=bti not supported)
+ifeq ($(CFG_CORE_PAUTH),y)
+bp-core-opt := $(call cc-option,-mbranch-protection=pac-ret+leaf)
 endif
-core-platform-cflags += $(bti-opt)
+
+ifeq ($(CFG_CORE_BTI),y)
+bp-core-opt := $(call cc-option,-mbranch-protection=bti)
+endif
+
+ifeq (y-y,$(CFG_CORE_PAUTH)-$(CFG_CORE_BTI))
+bp-core-opt := $(call cc-option,-mbranch-protection=pac-ret+leaf+bti)
+endif
+
+ifeq (y,$(filter $(CFG_CORE_BTI) $(CFG_CORE_PAUTH),y))
+ifeq (,$(bp-core-opt))
+$(error -mbranch-protection not supported)
+endif
+core-platform-cflags += $(bp-core-opt)
 endif
 
 ifeq ($(CFG_ARM64_core),y)

--- a/core/arch/arm/include/kernel/thread_arch.h
+++ b/core/arch/arm/include/kernel/thread_arch.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
- * Copyright (c) 2016-2017, Linaro Limited
+ * Copyright (c) 2016-2022, Linaro Limited
  * Copyright (c) 2020-2021, Arm Limited
  */
 
@@ -29,6 +29,16 @@
 
 struct mobj;
 
+/*
+ * Storage of keys used for pointer authentication. FEAT_PAuth supports a
+ * number of keys of which only the APIA key is currently used, depending on
+ * configuration.
+ */
+struct thread_pauth_keys {
+	uint64_t apia_hi;
+	uint64_t apia_lo;
+};
+
 struct thread_core_local {
 #ifdef ARM32
 	uint32_t r[2];
@@ -36,6 +46,9 @@ struct thread_core_local {
 #endif
 #ifdef ARM64
 	uint64_t x[4];
+#endif
+#ifdef CFG_CORE_PAUTH
+	struct thread_pauth_keys keys;
 #endif
 	vaddr_t tmp_stack_va_end;
 	long kcode_offset;
@@ -71,11 +84,6 @@ struct thread_user_vfp_state {
 	struct vfp_state vfp;
 	bool lazy_saved;
 	bool saved;
-};
-
-struct thread_pauth_keys {
-	uint64_t hi;
-	uint64_t lo;
 };
 
 #ifdef ARM32
@@ -161,6 +169,10 @@ struct thread_abort_regs {
 	uint64_t elr;
 	uint64_t spsr;
 	uint64_t sp_el0;
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+	uint64_t apiakey_hi;
+	uint64_t apiakey_lo;
+#endif
 };
 #endif /*ARM64*/
 
@@ -216,7 +228,7 @@ struct thread_svc_regs {
 	uint64_t x28;
 	uint64_t x29;
 #endif
-#ifdef CFG_TA_PAUTH
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
 	uint64_t apiakey_hi;
 	uint64_t apiakey_lo;
 #endif
@@ -256,7 +268,7 @@ struct thread_ctx_regs {
 	uint64_t cpsr;
 	uint64_t x[31];
 	uint64_t tpidr_el0;
-#ifdef CFG_TA_PAUTH
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
 	uint64_t apiakey_hi;
 	uint64_t apiakey_lo;
 #endif

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2016, Linaro Limited
+ * Copyright (c) 2016-2022, Linaro Limited
  */
 
 #include <gen-asm-defines.h>
@@ -70,11 +70,18 @@ DEFINES
 	DEFINE(THREAD_ABT_REG_X30, offsetof(struct thread_abort_regs, x30));
 	DEFINE(THREAD_ABT_REG_SPSR, offsetof(struct thread_abort_regs, spsr));
 	DEFINE(THREAD_ABT_REGS_SIZE, sizeof(struct thread_abort_regs));
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+	DEFINE(THREAD_ABT_REGS_APIAKEY_HI, offsetof(struct thread_abort_regs,
+						    apiakey_hi));
+#endif
 
 	/* struct thread_ctx */
 	DEFINE(THREAD_CTX_KERN_SP, offsetof(struct thread_ctx, kern_sp));
 	DEFINE(THREAD_CTX_STACK_VA_END, offsetof(struct thread_ctx,
 						 stack_va_end));
+#if defined(CFG_CORE_PAUTH)
+	DEFINE(THREAD_CTX_KEYS, offsetof(struct thread_ctx, keys));
+#endif
 
 	/* struct thread_ctx_regs */
 	DEFINE(THREAD_CTX_REGS_SP, offsetof(struct thread_ctx_regs, sp));
@@ -85,7 +92,7 @@ DEFINES
 	DEFINE(THREAD_CTX_REGS_X19, offsetof(struct thread_ctx_regs, x[19]));
 	DEFINE(THREAD_CTX_REGS_TPIDR_EL0, offsetof(struct thread_ctx_regs,
 						   tpidr_el0));
-#ifdef CFG_TA_PAUTH
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
 	DEFINE(THREAD_CTX_REGS_APIAKEY_HI, offsetof(struct thread_ctx_regs,
 						    apiakey_hi));
 #endif
@@ -107,6 +114,10 @@ DEFINES
 #ifdef CFG_CORE_WORKAROUND_SPECTRE_BP_SEC
 	DEFINE(THREAD_CORE_LOCAL_BHB_LOOP_COUNT,
 	       offsetof(struct thread_core_local, bhb_loop_count));
+#endif
+#if defined(CFG_CORE_PAUTH)
+	DEFINE(THREAD_CORE_LOCAL_KEYS,
+	       offsetof(struct thread_core_local, keys));
 #endif
 #endif /*ARM64*/
 

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1252,6 +1252,14 @@ void init_tee_runtime(void)
 	if (!IS_ENABLED(CFG_VIRTUALIZATION))
 		call_preinitcalls();
 	call_initcalls();
+
+	/*
+	 * These two functions uses crypto_rng_read() to initialize the
+	 * pauth keys. Once call_initcalls() returns we're guaranteed that
+	 * crypto_rng_read() is ready to be used.
+	 */
+	thread_init_core_local_pauth_keys();
+	thread_init_thread_pauth_keys();
 }
 
 static void init_primary(unsigned long pageable_part, unsigned long nsec_entry)

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2015-2022, Linaro Limited
  * Copyright (c) 2021, Arm Limited
  */
 
@@ -72,6 +72,12 @@
 		bic	x0, x0, #SCTLR_TCF0_MASK
 111:
 #endif
+#if defined(CFG_TA_PAUTH) && defined(CFG_TA_BTI)
+		orr	x0, x0, #SCTLR_BT0
+#endif
+#if defined(CFG_CORE_PAUTH) && defined(CFG_CORE_BTI)
+		orr	x0, x0, #SCTLR_BT1
+#endif
 		msr	sctlr_el1, x0
 	.endm
 
@@ -122,6 +128,17 @@
 
 		isb
 11:
+	.endm
+
+	.macro init_pauth_per_cpu
+		msr	spsel, #1
+		ldp	x0, x1, [sp, #THREAD_CORE_LOCAL_KEYS]
+		msr	spsel, #0
+		write_apiakeyhi x0
+		write_apiakeylo x1
+		mrs	x0, sctlr_el1
+		orr	x0, x0, #SCTLR_ENIA
+		msr	sctlr_el1, x0
 	.endm
 
 FUNC _start , :
@@ -322,6 +339,10 @@ clear_nex_bss:
 #endif
 	mov	x0, x20		/* DT address */
 	bl	boot_init_primary_late
+#ifdef CFG_CORE_PAUTH
+	init_pauth_per_cpu
+#endif
+
 #ifndef CFG_VIRTUALIZATION
 	mov	x0, #THREAD_CLF_TMP
 	str     w0, [x22, #THREAD_CORE_LOCAL_FLAGS]
@@ -535,6 +556,9 @@ FUNC cpu_on_handler , :
 
 #ifdef CFG_MEMTAG
 	init_memtag_per_cpu
+#endif
+#ifdef CFG_CORE_PAUTH
+	init_pauth_per_cpu
 #endif
 
 	mov	x0, x19

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2015-2020, Linaro Limited
+ * Copyright (c) 2015-2022, Linaro Limited
  */
 
 #include <arm64_macros.S>
@@ -35,24 +35,30 @@
 		b.eq	\label
 	.endm
 
-	.macro disable_pauth reg
-#ifdef	CFG_TA_PAUTH
+	.macro pauth_el0_to_el1 reg
+		/*
+		 * If pauth is only enabled in one of core or TA (xor) we
+		 * need to update sctlr.
+		 */
+#if (defined(CFG_TA_PAUTH) && !defined(CFG_CORE_PAUTH)) || \
+    (!defined(CFG_TA_PAUTH) && defined(CFG_CORE_PAUTH))
 		mrs	\reg, sctlr_el1
-		bic     \reg, \reg, #SCTLR_ENIA
-#ifdef CFG_TA_BTI
-		orr     \reg, \reg, #(SCTLR_BT0 | SCTLR_BT1)
-#endif
+		/* Flip the SCTLR_ENIA bit */
+		eor     \reg, \reg, #SCTLR_ENIA
 		msr	sctlr_el1, \reg
 #endif
 	.endm
 
-	.macro enable_pauth reg
-#ifdef	CFG_TA_PAUTH
+	.macro pauth_el1_to_el0 reg
+		/*
+		 * If pauth is only enabled in one of core or TA (xor) we
+		 * need to update sctlr.
+		 */
+#if (defined(CFG_TA_PAUTH) && !defined(CFG_CORE_PAUTH)) || \
+    (!defined(CFG_TA_PAUTH) && defined(CFG_CORE_PAUTH))
 		mrs	\reg, sctlr_el1
-		orr     \reg, \reg, #SCTLR_ENIA
-#ifdef CFG_TA_BTI
-		bic     \reg, \reg, #(SCTLR_BT0 | SCTLR_BT1)
-#endif
+		/* Flip the SCTLR_ENIA bit */
+		eor     \reg, \reg, #SCTLR_ENIA
 		msr	sctlr_el1, \reg
 #endif
 	.endm
@@ -67,20 +73,22 @@ FUNC thread_resume , :
 	ldr	x1, [x0, THREAD_CTX_REGS_TPIDR_EL0]
 	msr	tpidr_el0, x1
 
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+	load_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
+	write_apiakeyhi	x1
+	write_apiakeylo	x2
+#endif
 	b_if_spsr_is_el0 w3, 1f
 
+#if defined(CFG_CORE_PAUTH) || defined(CFG_TA_PAUTH)
+	/* SCTLR or the APIA key has changed */
+	isb
+#endif
 	load_xregs x0, THREAD_CTX_REGS_X1, 1, 3
 	ldr	x0, [x0, THREAD_CTX_REGS_X0]
 	return_from_exception
 
 1:
-#ifdef	CFG_TA_PAUTH
-	/* Restore PAC keys before return to el0 */
-	load_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
-	write_apiakeyhi	x1
-	write_apiakeylo	x2
-#endif
-
 	load_xregs x0, THREAD_CTX_REGS_X1, 1, 3
 	ldr	x0, [x0, THREAD_CTX_REGS_X0]
 
@@ -330,7 +338,7 @@ el0_sync_a64:
 	.balign	128, INV_INSN
 el0_irq_a64:
 	restore_mapping
-	disable_pauth x1
+	pauth_el0_to_el1 x1
 
 	b	elx_irq
 	check_vector_size el0_irq_a64
@@ -338,7 +346,7 @@ el0_irq_a64:
 	.balign	128, INV_INSN
 el0_fiq_a64:
 	restore_mapping
-	disable_pauth x1
+	pauth_el0_to_el1 x1
 
 	b	elx_fiq
 	check_vector_size el0_fiq_a64
@@ -613,7 +621,7 @@ wa_spectre_bhb_el0_serror_a32:
  * that it's always available.
  */
 eret_to_el0:
-	enable_pauth x1
+	pauth_el1_to_el0 x1
 
 #ifdef CFG_CORE_UNMAP_CORE_AT_EL0
 	/* Point to the vector into the reduced mapping */
@@ -779,23 +787,40 @@ thread_excp_vect_end:
 END_FUNC thread_excp_vect
 
 LOCAL_FUNC el0_svc , :
-	disable_pauth x1
+	pauth_el0_to_el1 x1
 	/* get pointer to current thread context in x0 */
 	get_thread_ctx sp, 0, 1, 2
 	mrs	x1, tpidr_el0
 	str	x1, [x0, #THREAD_CTX_REGS_TPIDR_EL0]
 	/* load saved kernel sp */
-	ldr	x0, [x0, #THREAD_CTX_KERN_SP]
+	ldr	x3, [x0, #THREAD_CTX_KERN_SP]
 	/* Keep pointer to initial recod in x1 */
 	mov	x1, sp
 	/* Switch to SP_EL0 and restore kernel sp */
 	msr	spsel, #0
 	mov	x2, sp	/* Save SP_EL0 */
-	mov	sp, x0
+	mov	sp, x3
 
 	/* Make room for struct thread_svc_regs */
 	sub	sp, sp, #THREAD_SVC_REG_SIZE
-	stp	x30,x2, [sp, #THREAD_SVC_REG_X30]
+	stp	x30, x2, [sp, #THREAD_SVC_REG_X30]
+
+#ifdef CFG_TA_PAUTH
+	/* Save APIAKEY */
+	read_apiakeyhi	x2
+	read_apiakeylo	x3
+	stp	x2, x3, [sp, #THREAD_SVC_REG_APIAKEY_HI]
+#endif
+
+#ifdef CFG_CORE_PAUTH
+	ldp	x2, x3, [x0, #THREAD_CTX_KEYS]
+	write_apiakeyhi	x2
+	write_apiakeylo	x3
+#endif
+#if defined(CFG_CORE_PAUTH) || defined(CFG_TA_PAUTH)
+	/* SCTLR or the APIA key has changed */
+	isb
+#endif
 
 	/* Restore x0-x3 */
 	ldp	x2, x3, [x1, #THREAD_CORE_LOCAL_X2]
@@ -806,13 +831,6 @@ LOCAL_FUNC el0_svc , :
 	mrs	x0, elr_el1
 	mrs	x1, spsr_el1
 	store_xregs sp, THREAD_SVC_REG_ELR, 0, 1
-
-#ifdef CFG_TA_PAUTH
-	/* Save APIAKEY */
-	read_apiakeyhi	x0
-	read_apiakeylo	x1
-	store_xregs sp, THREAD_SVC_REG_APIAKEY_HI, 0, 1
-#endif
 
 	mov	x0, sp
 
@@ -897,7 +915,7 @@ LOCAL_FUNC el1_sync_abort , :
 	b	.Lset_sp
 
 .Lsel_tmp_sp:
-	/* Select tmp stack */
+	/* We have an abort while using the abort stack, select tmp stack */
 	ldr	x2, [x0, #THREAD_CORE_LOCAL_TMP_STACK_VA_END]
 	orr	w1, w1, #THREAD_CLF_TMP	/* flags |= THREAD_CLF_TMP; */
 
@@ -919,8 +937,18 @@ LOCAL_FUNC el1_sync_abort , :
 	ldp	x2, x3, [x0, #THREAD_CORE_LOCAL_X2]
 	store_xregs sp, THREAD_ABT_REG_X2, 2, 29
 	/* Store x30, elr_el1 */
-	mrs	x0, elr_el1
-	stp	x30, x0, [sp, #THREAD_ABT_REG_X30]
+	mrs	x1, elr_el1
+	stp	x30, x1, [sp, #THREAD_ABT_REG_X30]
+
+#if defined(CFG_CORE_PAUTH)
+	read_apiakeyhi	x2
+	read_apiakeylo	x3
+	stp	x2, x3, [sp, #THREAD_ABT_REGS_APIAKEY_HI]
+	ldp	x2, x3, [x0, #THREAD_CORE_LOCAL_KEYS]
+	write_apiakeyhi	x2
+	write_apiakeylo	x3
+	isb
+#endif
 
 	/*
 	 * Call handler
@@ -952,6 +980,13 @@ LOCAL_FUNC el1_sync_abort , :
 	lsr	w0, w0, #THREAD_CLF_SAVED_SHIFT
 	str	w0, [sp, #THREAD_CORE_LOCAL_FLAGS]
 
+#if defined(CFG_CORE_PAUTH)
+	ldp	x0, x1, [x3, #THREAD_ABT_REGS_APIAKEY_HI]
+	write_apiakeyhi	x0
+	write_apiakeylo	x1
+	isb
+#endif
+
 	/* Restore x0 to x3 */
 	load_xregs sp, THREAD_CORE_LOCAL_X0, 0, 3
 
@@ -961,7 +996,7 @@ END_FUNC el1_sync_abort
 
 	/* sp_el0 in x3 */
 LOCAL_FUNC el0_sync_abort , :
-	disable_pauth x1
+	pauth_el0_to_el1 x1
 	/*
 	 * Update core local flags
 	 */
@@ -992,8 +1027,25 @@ LOCAL_FUNC el0_sync_abort , :
 	ldp	x2, x3, [x0, #THREAD_CORE_LOCAL_X2]
 	store_xregs sp, THREAD_ABT_REG_X2, 2, 29
 	/* Store x30, elr_el1 */
-	mrs	x0, elr_el1
-	stp	x30, x0, [sp, #THREAD_ABT_REG_X30]
+	mrs	x1, elr_el1
+	stp	x30, x1, [sp, #THREAD_ABT_REG_X30]
+
+#if defined(CFG_TA_PAUTH)
+	read_apiakeyhi	x2
+	read_apiakeylo	x3
+	stp	x2, x3, [sp, #THREAD_ABT_REGS_APIAKEY_HI]
+#endif
+
+#if defined(CFG_CORE_PAUTH)
+	ldp	x2, x3, [x0, #THREAD_CORE_LOCAL_KEYS]
+	write_apiakeyhi	x2
+	write_apiakeylo	x3
+#endif
+
+#if defined(CFG_CORE_PAUTH) || defined(CFG_TA_PAUTH)
+	/* SCTLR or the APIA key has changed */
+	isb
+#endif
 
 	/*
 	 * Call handler
@@ -1026,10 +1078,21 @@ LOCAL_FUNC el0_sync_abort , :
 	lsr	w1, w1, #THREAD_CLF_SAVED_SHIFT
 	str	w1, [sp, #THREAD_CORE_LOCAL_FLAGS]
 
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+	ldp	x1, x2, [x3, #THREAD_ABT_REGS_APIAKEY_HI]
+	write_apiakeyhi	x1
+	write_apiakeylo	x2
+#endif
+
 	/* Restore x2 to x3 */
 	load_xregs sp, THREAD_CORE_LOCAL_X2, 2, 3
 
 	b_if_spsr_is_el0 w0, 1f
+
+#if defined(CFG_CORE_PAUTH)
+	/* the APIA key has changed */
+	isb
+#endif
 
 	/* Restore x0 to x1 */
 	load_xregs sp, THREAD_CORE_LOCAL_X0, 0, 1
@@ -1071,11 +1134,17 @@ END_FUNC el0_sync_abort
 	/* Save original x0..x3 */
 	store_xregs x0, THREAD_CTX_REGS_X0, 10, 13
 
-#ifdef CFG_TA_PAUTH
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
 	/* Save APIAKEY */
 	read_apiakeyhi	x1
 	read_apiakeylo	x2
 	store_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
+#endif
+#if defined(CFG_CORE_PAUTH)
+	ldp	x1, x2, [sp, #THREAD_CORE_LOCAL_KEYS]
+	write_apiakeyhi	x1
+	write_apiakeylo	x2
+	isb
 #endif
 	/* load tmp_stack_va_end */
 	ldr	x1, [sp, #THREAD_CORE_LOCAL_TMP_STACK_VA_END]
@@ -1128,12 +1197,23 @@ END_FUNC el0_sync_abort
  * 	uint64_t x[19 - 4]; x4..x18
  * 	uint64_t lr;
  * 	uint64_t sp_el0;
+ * #if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+ * 	uint64_t apiakey_hi;
+ * 	uint64_t apiakey_lo;
+ * #endif
  * };
  */
 #define ELX_NINTR_REC_X(x)		(8 * ((x) - 4))
 #define ELX_NINTR_REC_LR		(8 + ELX_NINTR_REC_X(19))
 #define ELX_NINTR_REC_SP_EL0		(8 + ELX_NINTR_REC_LR)
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+#define ELX_NINTR_REG_APIAKEY_HI	(8 + ELX_NINTR_REC_SP_EL0)
+#define ELX_NINTR_REG_APIAKEY_LO	(8 + ELX_NINTR_REG_APIAKEY_HI)
+#define ELX_NINTR_REC_SIZE		(8 + ELX_NINTR_REG_APIAKEY_LO)
+#else
 #define ELX_NINTR_REC_SIZE		(8 + ELX_NINTR_REC_SP_EL0)
+#endif
+
 
 /* The handler of native interrupt. */
 .macro native_intr_handler mode:req
@@ -1150,24 +1230,39 @@ END_FUNC el0_sync_abort
 	orr	w1, w1, #THREAD_CLF_TMP
 	str	w1, [sp, #THREAD_CORE_LOCAL_FLAGS]
 
+	/*
+	 * Save registers on the temp stack that can be corrupted by a call
+	 * to a C function.
+	 *
+	 * Note that we're temporarily using x1 to access the temp stack
+	 * until we're ready to switch to sp_el0 and update sp.
+	 */
 	/* load tmp_stack_va_end */
 	ldr	x1, [sp, #THREAD_CORE_LOCAL_TMP_STACK_VA_END]
-	/* Keep original SP_EL0 */
+	/* Make room for struct elx_nintr_rec */
+	sub	x1, x1, #ELX_NINTR_REC_SIZE
+	/* Store lr and original sp_el0 */
 	mrs	x2, sp_el0
+	stp	x30, x2, [x1, #ELX_NINTR_REC_LR]
+	/* Store x4..x18 */
+	store_xregs x1, ELX_NINTR_REC_X(4), 4, 18
+
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+	read_apiakeyhi	x2
+	read_apiakeylo	x3
+	stp	x2, x3, [x1, #ELX_NINTR_REG_APIAKEY_HI]
+#if defined(CFG_CORE_PAUTH)
+	ldp	x2, x3, [sp, #THREAD_CORE_LOCAL_KEYS]
+	write_apiakeyhi	x2
+	write_apiakeylo	x3
+#endif
+	/* SCTLR or the APIA key has changed */
+	isb
+#endif
+
 	/* Switch to SP_EL0 */
 	msr	spsel, #0
 	mov	sp, x1
-
-	/*
-	 * Save registers on stack that can be corrupted by a call to
-	 * a C function
-	 */
-	/* Make room for struct elx_nintr_rec */
-	sub	sp, sp, #ELX_NINTR_REC_SIZE
-	/* Store x4..x18 */
-	store_xregs sp, ELX_NINTR_REC_X(4), 4, 18
-	/* Store lr and original sp_el0 */
-	stp	x30, x2, [sp, #ELX_NINTR_REC_LR]
 
 	bl	thread_check_canaries
 	bl	itr_core_handler
@@ -1175,6 +1270,13 @@ END_FUNC el0_sync_abort
 	/*
 	 * Restore registers
 	 */
+
+#if defined(CFG_TA_PAUTH) || defined(CFG_CORE_PAUTH)
+	ldp	x0, x1, [sp, #ELX_NINTR_REG_APIAKEY_HI]
+	write_apiakeyhi	x0
+	write_apiakeylo	x1
+#endif
+
 	/* Restore x4..x18 */
 	load_xregs sp, ELX_NINTR_REC_X(4), 4, 18
 	/* Load  lr and original sp_el0 */
@@ -1190,9 +1292,15 @@ END_FUNC el0_sync_abort
 	str	w0, [sp, #THREAD_CORE_LOCAL_FLAGS]
 
 	mrs	x0, spsr_el1
+
 	/* Restore x2..x3 */
 	load_xregs sp, THREAD_CORE_LOCAL_X2, 2, 3
 	b_if_spsr_is_el0 w0, 1f
+
+#if defined(CFG_CORE_PAUTH)
+	/* APIA key has changed */
+	isb
+#endif
 
 	/* Restore x0..x1 */
 	load_xregs sp, THREAD_CORE_LOCAL_X0, 0, 1

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -192,6 +192,13 @@ FUNC thread_rpc , :
 	store_xregs x0, THREAD_CTX_REGS_X19, 19, 30
 	mov	x19, x0
 
+#if defined(CFG_CORE_PAUTH)
+	/* Save APIAKEY */
+	read_apiakeyhi  x1
+	read_apiakeylo  x2
+	store_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
+#endif
+
 	bl	thread_get_tmp_sp
 	pop	x1, xzr		/* Match "push x1, x30" above */
 	mov	x2, sp

--- a/core/arch/arm/kernel/thread_spmc_a64.S
+++ b/core/arch/arm/kernel/thread_spmc_a64.S
@@ -117,6 +117,13 @@ FUNC thread_rpc , :
 	store_xregs x0, THREAD_CTX_REGS_X19, 19, 30
 	mov	x19, x0
 
+#if defined(CFG_CORE_PAUTH)
+	/* Save APIAKEY */
+	read_apiakeyhi  x1
+	read_apiakeylo  x2
+	store_xregs x0, THREAD_CTX_REGS_APIAKEY_HI, 1, 2
+#endif
+
 	bl	thread_get_tmp_sp
 	pop	x1, xzr		/* Match "push x1, x30" above */
 	mov	x2, sp

--- a/core/arch/arm/kernel/unwind_arm64.c
+++ b/core/arch/arm/kernel/unwind_arm64.c
@@ -37,6 +37,15 @@
 
 #include "unwind_private.h"
 
+#if defined(CFG_CORE_PAUTH)
+void pauth_strip_pac(uint64_t *lr)
+{
+	const uint64_t va_mask = GENMASK_64(CFG_LPAE_ADDR_SPACE_BITS - 1, 0);
+
+	*lr = *lr & va_mask;
+}
+#endif
+
 vaddr_t *unw_get_kernel_stack(void)
 {
 	size_t n = 0;

--- a/core/include/kernel/thread.h
+++ b/core/include/kernel/thread.h
@@ -74,6 +74,14 @@ void thread_init_threads(void);
 void thread_init_thread_core_local(void);
 void thread_init_core_local_stacks(void);
 
+#if defined(CFG_CORE_PAUTH)
+void thread_init_thread_pauth_keys(void);
+void thread_init_core_local_pauth_keys(void);
+#else
+static inline void thread_init_thread_pauth_keys(void) { }
+static inline void thread_init_core_local_pauth_keys(void) { }
+#endif
+
 /*
  * Initializes a thread to be used during boot
  */

--- a/core/include/kernel/thread_private.h
+++ b/core/include/kernel/thread_private.h
@@ -42,6 +42,9 @@ struct thread_ctx {
 #ifdef ARM64
 	vaddr_t kern_sp;	/* Saved kernel SP during user TA execution */
 #endif
+#ifdef CFG_CORE_PAUTH
+	struct thread_pauth_keys keys;
+#endif
 #ifdef CFG_WITH_VFP
 	struct thread_vfp_state vfp_state;
 #endif

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2016-2021, Linaro Limited
+ * Copyright (c) 2016-2022, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2020-2021, Arm Limited
  */
 
 #include <config.h>
+#include <crypto/crypto.h>
 #include <kernel/asan.h>
 #include <kernel/lockdep.h>
 #include <kernel/misc.h>
@@ -478,6 +479,27 @@ void thread_init_core_local_stacks(void)
 		tcl[n].abt_stack_va_end = GET_STACK_BOTTOM(stack_abt, n);
 	}
 }
+
+#if defined(CFG_CORE_PAUTH)
+void thread_init_thread_pauth_keys(void)
+{
+	size_t n = 0;
+
+	for (n = 0; n < CFG_NUM_THREADS; n++)
+		if (crypto_rng_read(&threads[n].keys, sizeof(threads[n].keys)))
+			panic("Failed to init thread pauth keys");
+}
+
+void thread_init_core_local_pauth_keys(void)
+{
+	struct thread_core_local *tcl = thread_core_local;
+	size_t n = 0;
+
+	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
+		if (crypto_rng_read(&tcl[n].keys, sizeof(tcl[n].keys)))
+			panic("Failed to init core local pauth keys");
+}
+#endif
 
 struct thread_specific_data *thread_get_tsd(void)
 {


### PR DESCRIPTION
Previously pointer authentication was only supported for TAs. With this patch add a configuration option CFG_CORE_PAUTH to enable support for core. Each privileged thread has its own APIA key. There are also a separate APIA key for each physical core used when handling an abort or when using the tmp stack.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
