### PR TITLE
ci: QEMUv8_check: also run tests with Cryptographic Extension enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,17 +253,20 @@ jobs:
           # make check task
           set -e
           export LC_ALL=C
+          export CFG_TEE_CORE_LOG_LEVEL=0
           WD=$(pwd)
           sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
           sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
           sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
           sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
 
-          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) CFG_TEE_CORE_LOG_LEVEL=0 check
+          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check
+
+          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check CFG_CRYPTO_WITH_CE=y
 
           sudo -E rm -rf /root/optee_repo_qemu_v8/out-br/build/optee_test*
           sudo -E make -C /root/optee_repo_qemu_v8/build arm-tf-clean
-          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) CFG_TEE_CORE_LOG_LEVEL=0 check XEN_BOOT=y
+          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check XEN_BOOT=y
 
   QEMUv8_check_rust:
     name: make check-rust (QEMUv8)


### PR DESCRIPTION
Adds a line to build and run regression tests with CFG_CRYPTO_WITH_CE=y. Many Armv8 CPUs support this extension so it is very commonly used and deserves to be tested here.

While we're at it, set CFG_TEE_CORE_LOG_LEVEL=0 at the beginning to avoid duplication.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
