### PR TITLE
core: fix compile error with CFG_CORE_WORKAROUND_SPECTRE_BP_SEC=n

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -593,6 +593,7 @@ static uint32_t __maybe_unused get_midr_revision(uint32_t midr)
 	return (midr >> MIDR_REVISION_SHIFT) & MIDR_REVISION_MASK;
 }
 
+#ifdef CFG_CORE_WORKAROUND_SPECTRE_BP_SEC
 #ifdef ARM64
 static bool probe_workaround_available(uint32_t wa_id)
 {
@@ -629,9 +630,10 @@ static vaddr_t __maybe_unused select_vector_wa_spectre_v2(void)
 	return (vaddr_t)thread_excp_vect_wa_spectre_v2;
 }
 #endif
+#endif
 
-static vaddr_t __maybe_unused
-select_vector_wa_spectre_bhb(uint8_t loop_count __maybe_unused)
+#ifdef CFG_CORE_WORKAROUND_SPECTRE_BP_SEC
+static vaddr_t select_vector_wa_spectre_bhb(uint8_t loop_count __maybe_unused)
 {
 	/*
 	 * Spectre-BHB has only been analyzed for AArch64 so far. For
@@ -655,6 +657,7 @@ select_vector_wa_spectre_bhb(uint8_t loop_count __maybe_unused)
 	return select_vector_wa_spectre_v2();
 #endif
 }
+#endif
 
 static vaddr_t get_excp_vect(void)
 {


### PR DESCRIPTION
Prior to this patch there's a compile error when building with CFG_CORE_WORKAROUND_SPECTRE_BP_SEC=n:
core/arch/arm/kernel/thread.c: In function 'select_vector_wa_spectre_bhb': core/arch/arm/kernel/thread.c:644:48: error: 'thread_user_kdata_page' undeclared (first use in this function); did you mean 'thread_user_kcode_size'?
  644 |         struct thread_core_local *cl = (void *)thread_user_kdata_page;
      |                                                ^~~~~~~~~~~~~~~~~~~~~~
      |                                                thread_user_kcode_size
core/arch/arm/kernel/thread.c:644:48: note: each undeclared identifier is reported only once for each function it appears in
core/arch/arm/kernel/thread.c:646:27: error: 'struct thread_core_local' has no member named 'bhb_loop_count'
  646 |         cl[get_core_pos()].bhb_loop_count = loop_count;
      |                           ^
core/arch/arm/kernel/thread.c:648:32: error: 'struct thread_core_local' has no member named 'bhb_loop_count'
  648 |         thread_get_core_local()->bhb_loop_count = loop_count;
      |                                ^~

Fix this by by disabling the unused code.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
