### PR TITLE
core: mmu: Fix wrong input argument of tee_mm_init

### DIFF
--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -140,7 +140,7 @@ void virt_init_memory(struct tee_mmap_region *memory_map)
 
 	/* Init page pool that covers all secure RAM */
 	if (!tee_mm_init(&virt_mapper_pool, TEE_RAM_START,
-			 TA_RAM_START + TA_RAM_SIZE,
+			 TA_RAM_START + TA_RAM_SIZE - TEE_RAM_START,
 			 SMALL_PAGE_SHIFT,
 			 TEE_MM_POOL_NEX_MALLOC))
 		panic("Can't create pool with free pages");

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -599,7 +599,8 @@ static TEE_Result mapped_shm_init(void)
 	if (!pool_start || !pool_end)
 		panic("Can't find region for shmem pool");
 
-	if (!tee_mm_init(&tee_mm_shm, pool_start, pool_end, SMALL_PAGE_SHIFT,
+	if (!tee_mm_init(&tee_mm_shm, pool_start, pool_end - pool_start,
+			 SMALL_PAGE_SHIFT,
 			 TEE_MM_POOL_NO_FLAGS))
 		panic("Could not create shmem pool");
 

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2310,6 +2310,7 @@ static TEE_Result rpmb_fs_open_internal(struct rpmb_file_handle *fh,
 {
 	tee_mm_pool_t p;
 	bool pool_result;
+	paddr_size_t pool_sz = 0;
 	TEE_Result res = TEE_ERROR_GENERIC;
 
 	/* We need to do setup in order to make sure fs_par is filled in */
@@ -2320,9 +2321,10 @@ static TEE_Result rpmb_fs_open_internal(struct rpmb_file_handle *fh,
 	fh->uuid = uuid;
 	if (create) {
 		/* Upper memory allocation must be used for RPMB_FS. */
+		pool_sz = fs_par->max_rpmb_address - RPMB_STORAGE_START_ADDRESS;
 		pool_result = tee_mm_init(&p,
 					  RPMB_STORAGE_START_ADDRESS,
-					  fs_par->max_rpmb_address,
+					  pool_sz,
 					  RPMB_BLOCK_SIZE_SHIFT,
 					  TEE_MM_POOL_HI_ALLOC);
 
@@ -2502,6 +2504,7 @@ static TEE_Result rpmb_fs_write_primitive(struct rpmb_file_handle *fh,
 	bool pool_result = false;
 	size_t end = 0;
 	uint32_t start_addr = 0;
+	paddr_size_t pool_sz = 0;
 
 	if (!size)
 		return TEE_SUCCESS;
@@ -2514,9 +2517,10 @@ static TEE_Result rpmb_fs_write_primitive(struct rpmb_file_handle *fh,
 	dump_fh(fh);
 
 	/* Upper memory allocation must be used for RPMB_FS. */
+	pool_sz = fs_par->max_rpmb_address - RPMB_STORAGE_START_ADDRESS;
 	pool_result = tee_mm_init(&p,
 				  RPMB_STORAGE_START_ADDRESS,
-				  fs_par->max_rpmb_address,
+				  pool_sz,
 				  RPMB_BLOCK_SIZE_SHIFT,
 				  TEE_MM_POOL_HI_ALLOC);
 	if (!pool_result) {
@@ -2709,6 +2713,7 @@ static TEE_Result rpmb_fs_truncate(struct tee_file_handle *tfh, size_t length)
 	uint8_t *newbuf = NULL;
 	uintptr_t newaddr;
 	TEE_Result res = TEE_ERROR_GENERIC;
+	paddr_size_t pool_sz = 0;
 
 	mutex_lock(&rpmb_mutex);
 
@@ -2725,9 +2730,10 @@ static TEE_Result rpmb_fs_truncate(struct tee_file_handle *tfh, size_t length)
 	if (newsize > fh->fat_entry.data_size) {
 		/* Extend file */
 
+		pool_sz = fs_par->max_rpmb_address - RPMB_STORAGE_START_ADDRESS;
 		pool_result = tee_mm_init(&p,
 					  RPMB_STORAGE_START_ADDRESS,
-					  fs_par->max_rpmb_address,
+					  pool_sz,
 					  RPMB_BLOCK_SIZE_SHIFT,
 					  TEE_MM_POOL_HI_ALLOC);
 		if (!pool_result) {


### PR DESCRIPTION
tee_mm_init() take pool size instead of end address after below change.

'2380d700a176 ("core: mmu: fix overflow with high address in tee_mm_pool_t")'

Correct the input arg of caller which still use old definition.

Signed-off-by: james.jiang <james.jiang@mediatek.com>
Signed-off-by: Mark-PK Tsai <mark-pk.tsai@mediatek.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
