### PR TITLE
libtomcrypt: Remove prng_state* NULL pointer check from ed25519_make_key()

### DIFF
--- a/core/lib/libtomcrypt/src/pk/ed25519/ed25519_make_key.c
+++ b/core/lib/libtomcrypt/src/pk/ed25519/ed25519_make_key.c
@@ -20,7 +20,6 @@ int ed25519_make_key(prng_state *prng, int wprng, curve25519_key *key)
 {
    int err;
 
-   LTC_ARGCHK(prng != NULL);
    LTC_ARGCHK(key  != NULL);
 
    if ((err = tweetnacl_crypto_sign_keypair(prng, wprng, key->pub, key->priv)) != CRYPT_OK) {


### PR DESCRIPTION
For the same reasons as in commit 2d7740f6f44c ("core: libtomcrypt: Remove prng_state* NULL pointer check from x25519_make_key()"), remove the NULL pointer check in ed25519_make_key().

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
