### PR TITLE
core: huk definition

### DIFF
--- a/core/arch/arm/kernel/otp_stubs.c
+++ b/core/arch/arm/kernel/otp_stubs.c
@@ -19,6 +19,7 @@
 
 __weak TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
+	huk.locked = false;
 	memset(&hwkey->data[0], 0, sizeof(hwkey->data));
 	return TEE_SUCCESS;
 }

--- a/core/include/kernel/tee_common_otp.h
+++ b/core/include/kernel/tee_common_otp.h
@@ -13,6 +13,8 @@
 
 struct tee_hw_unique_key {
 	uint8_t data[HW_UNIQUE_KEY_LENGTH];
+	/* The hardware unique key is now inmmutable */
+	bool locked;
 };
 
 TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey);


### PR DESCRIPTION
The RPMB key derivation algorithm consumes the HUK and therefore is impacted by changes in its value.

The platform specific function plat_rpmb_key_is_ready() should be allowed to query the HUK in order to allow/deny burning the RPMB key.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
