### PR TITLE
Add OPTEE RNG support for J784S4 platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,8 @@ jobs:
           _make PLATFORM=imx-mx93evk
           _make PLATFORM=k3-j721e
           _make PLATFORM=k3-j721e CFG_ARM64_core=y
+          _make PLATFORM=k3-j784s4
+          _make PLATFORM=k3-j784s4 CFG_ARM64_core=y
           _make PLATFORM=k3-am65x
           _make PLATFORM=k3-am65x CFG_ARM64_core=y
           _make PLATFORM=k3-am64x

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -242,7 +242,7 @@ R:	Etienne Carriere <etienne.carriere@st.com> [@etienne-lms]
 S:	Maintained
 F:	core/arch/arm/plat-stm32mp1/
 
-Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x, J721E, AM64x, AM62x
+Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x, J721E, J784S4, AM64x, AM62x
 R:	Andrew Davis <afd@ti.com> [@glneo]
 S:	Maintained
 F:	core/arch/arm/plat-ti/

--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -18,7 +18,7 @@ $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 
-ifneq (,$(filter ${PLATFORM_FLAVOR},am65x j721e am64x))
+ifneq (,$(filter ${PLATFORM_FLAVOR},am65x j721e j784s4 am64x))
 CFG_WITH_SOFTWARE_PRNG ?= n
 else
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)

--- a/core/arch/arm/plat-k3/drivers/sa2ul.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.c
@@ -52,11 +52,13 @@ static TEE_Result sa2ul_init(void)
 	TEE_Result result = TEE_SUCCESS;
 	int ret = 0;
 
-	/* Power on the SA2UL device */
-	ret = ti_sci_device_get(SA2UL_TI_SCI_DEV_ID);
-	if (ret) {
-		EMSG("Failed to get SA2UL device");
-		return TEE_ERROR_GENERIC;
+	if (SA2UL_TI_SCI_DEV_ID != -1) {
+		/* Power on the SA2UL device */
+		ret = ti_sci_device_get(SA2UL_TI_SCI_DEV_ID);
+		if (ret) {
+			EMSG("Failed to get SA2UL device");
+			return TEE_ERROR_GENERIC;
+		}
 	}
 
 	IMSG("Activated SA2UL device");

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -22,7 +22,7 @@
 #define DRAM1_SIZE      0x80000000
 
 #define SCU_BASE        0x01800000
-#if defined(PLATFORM_FLAVOR_j721e)
+#if defined(PLATFORM_FLAVOR_j721e) || defined(PLATFORM_FLAVOR_j784s4)
 #define GICC_OFFSET     0x100000
 #define GICC_SIZE       0x100000
 #define GICD_OFFSET     0x0
@@ -33,7 +33,7 @@
 #define GICD_OFFSET     0x0
 #define GICD_SIZE       0x10000
 #endif
-#if defined(PLATFORM_FLAVOR_am65x) || defined(PLATFORM_FLAVOR_j721e)
+#if defined(PLATFORM_FLAVOR_am65x) || defined(PLATFORM_FLAVOR_j721e) || defined(PLATFORM_FLAVOR_j784s4)
 #define SEC_PROXY_DATA_BASE             0x32c00000
 #define SEC_PROXY_DATA_SIZE             0x100000
 #define SEC_PROXY_SCFG_BASE             0x32800000
@@ -65,6 +65,10 @@
 #elif defined(PLATFORM_FLAVOR_j721e)
 #define SA2UL_BASE		0x40900000
 #define SA2UL_TI_SCI_DEV_ID	265
+#define SA2UL_TI_SCI_FW_ID	1196
+#elif defined(PLATFORM_FLAVOR_j784s4)
+#define SA2UL_BASE		0x40900000
+#define SA2UL_TI_SCI_DEV_ID	-1
 #define SA2UL_TI_SCI_FW_ID	1196
 #elif defined(PLATFORM_FLAVOR_am64x)
 #define SA2UL_BASE		0x40900000


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
Add support for trng in the TI SoC J784S4 through optee.