### PR TITLE
core: crypto: remove TEE_ATTR_ECC_CURVE as an attribute of TEE_TYPE_ED25519_KEYPAIR

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -473,13 +473,6 @@ const struct tee_cryp_obj_type_attrs tee_cryp_obj_ed25519_keypair_attrs[] = {
 	.ops_index = ATTR_OPS_INDEX_25519,
 	RAW_DATA(struct ed25519_keypair, pub)
 	},
-
-	{
-	.attr_id = TEE_ATTR_ECC_CURVE,
-	.flags = TEE_TYPE_ATTR_SIZE_INDICATOR | TEE_TYPE_ATTR_GEN_KEY_REQ,
-	.ops_index = ATTR_OPS_INDEX_VALUE,
-	RAW_DATA(struct ed25519_keypair, curve)
-	},
 };
 
 struct tee_cryp_obj_type_props {


### PR DESCRIPTION
The ECC curve is not an attribute of an Ed25519 key pair, let alone a mandatory one for key generation. It was mistakenly added by commit 03e07432b68f ("ta: pkcs11: Add Ed25519 support"), thus breaking xtest regression_4007_ed25519 (subcase .1 Generate Ed25519 key). Remove that attribute from the key type definition.

Fixes: 03e07432b68f ("ta: pkcs11: Add Ed25519 support")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
