### PR TITLE
[RFC] Sw RSA ops fallback

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_rsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_rsa.c
@@ -1543,6 +1543,7 @@ static TEE_Result do_decrypt(struct drvcrypt_rsa_ed *rsa_data)
 /*
  * Registration of the RSA Driver
  */
+static const struct drvcrypt_rsa *driver_rsa_ptr;
 static const struct drvcrypt_rsa driver_rsa = {
 	.alloc_keypair = do_allocate_keypair,
 	.alloc_publickey = do_allocate_publickey,
@@ -1555,6 +1556,11 @@ static const struct drvcrypt_rsa driver_rsa = {
 	.optional.ssa_verify = NULL,
 };
 
+const struct drvcrypt_rsa *drvcrypt_get_rsa_ops(size_t key_size_bytes __unused)
+{
+	return driver_rsa_ptr;
+}
+
 enum caam_status caam_rsa_init(struct caam_jrcfg *caam_jrcfg)
 {
 	enum caam_status retstatus = CAAM_FAILURE;
@@ -1564,8 +1570,8 @@ enum caam_status caam_rsa_init(struct caam_jrcfg *caam_jrcfg)
 		caam_era = caam_hal_ctrl_era(jr_base);
 		RSA_TRACE("CAAM Era %d", caam_era);
 
-		if (!drvcrypt_register_rsa(&driver_rsa))
-			retstatus = CAAM_NO_ERROR;
+		driver_rsa_ptr = &driver_rsa;
+		retstatus = CAAM_NO_ERROR;
 	}
 
 	return retstatus;

--- a/core/drivers/crypto/crypto_api/acipher/rsassa.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsassa.c
@@ -180,7 +180,7 @@ static TEE_Result rsassa_pkcs1_v1_5_sign(struct drvcrypt_rsa_ssa *ssa_data)
 	TEE_Result ret = TEE_ERROR_BAD_PARAMETERS;
 	struct drvcrypt_buf EM = { };
 	struct drvcrypt_rsa_ed rsa_data = { };
-	struct drvcrypt_rsa *rsa = NULL;
+	const struct drvcrypt_rsa *rsa = NULL;
 
 	EM.length = ssa_data->key.n_size;
 	EM.data = malloc(EM.length);
@@ -204,7 +204,7 @@ static TEE_Result rsassa_pkcs1_v1_5_sign(struct drvcrypt_rsa_ssa *ssa_data)
 	rsa_data.key.isprivate = true;
 	rsa_data.key.n_size = ssa_data->key.n_size;
 
-	rsa = drvcrypt_get_ops(CRYPTO_RSA);
+	rsa = drvcrypt_get_rsa_ops(rsa_data.key.n_size);
 	if (!rsa) {
 		ret = TEE_ERROR_NOT_IMPLEMENTED;
 		goto out;
@@ -241,7 +241,7 @@ static TEE_Result rsassa_pkcs1_v1_5_verify(struct drvcrypt_rsa_ssa *ssa_data)
 	struct drvcrypt_buf EM = { };
 	struct drvcrypt_buf EM_gen = { };
 	struct drvcrypt_rsa_ed rsa_data = { };
-	struct drvcrypt_rsa *rsa = NULL;
+	const struct drvcrypt_rsa *rsa = NULL;
 
 	EM.length = ssa_data->key.n_size;
 	EM.data = malloc(EM.length);
@@ -262,7 +262,7 @@ static TEE_Result rsassa_pkcs1_v1_5_verify(struct drvcrypt_rsa_ssa *ssa_data)
 	rsa_data.key.isprivate = false;
 	rsa_data.key.n_size = ssa_data->key.n_size;
 
-	rsa = drvcrypt_get_ops(CRYPTO_RSA);
+	rsa = drvcrypt_get_rsa_ops(rsa_data.key.n_size);
 	if (rsa) {
 		/* Prepare the encryption data parameters */
 		rsa_data.rsa_id = DRVCRYPT_RSASSA_PKCS_V1_5;
@@ -728,7 +728,7 @@ static TEE_Result rsassa_pss_sign(struct drvcrypt_rsa_ssa *ssa_data)
 	struct drvcrypt_buf EM = { };
 	size_t modBits = 0;
 	struct drvcrypt_rsa_ed rsa_data = { };
-	struct drvcrypt_rsa *rsa = NULL;
+	const struct drvcrypt_rsa *rsa = NULL;
 
 	key = ssa_data->key.key;
 
@@ -767,7 +767,7 @@ static TEE_Result rsassa_pss_sign(struct drvcrypt_rsa_ssa *ssa_data)
 		rsa_data.key.isprivate = true;
 		rsa_data.key.n_size = ssa_data->key.n_size;
 
-		rsa = drvcrypt_get_ops(CRYPTO_RSA);
+		rsa = drvcrypt_get_rsa_ops(rsa_data.key.n_size);
 		if (rsa) {
 			/* Prepare the decryption data parameters */
 			rsa_data.rsa_id = DRVCRYPT_RSASSA_PSS;
@@ -802,7 +802,7 @@ static TEE_Result rsassa_pss_verify(struct drvcrypt_rsa_ssa *ssa_data)
 	struct drvcrypt_buf EM = { };
 	size_t modBits = 0;
 	struct drvcrypt_rsa_ed rsa_data = { };
-	struct drvcrypt_rsa *rsa = NULL;
+	const struct drvcrypt_rsa *rsa = NULL;
 
 	key = ssa_data->key.key;
 
@@ -836,7 +836,7 @@ static TEE_Result rsassa_pss_verify(struct drvcrypt_rsa_ssa *ssa_data)
 	rsa_data.key.isprivate = false;
 	rsa_data.key.n_size = ssa_data->key.n_size;
 
-	rsa = drvcrypt_get_ops(CRYPTO_RSA);
+	rsa = drvcrypt_get_rsa_ops(rsa_data.key.n_size);
 	if (rsa) {
 		/* Prepare the encryption data parameters */
 		rsa_data.rsa_id = DRVCRYPT_RSASSA_PSS;

--- a/core/drivers/crypto/crypto_api/include/drvcrypt.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt.h
@@ -51,7 +51,6 @@ enum drvcrypt_algo_id {
 	CRYPTO_HASH = 0, /* Hash driver */
 	CRYPTO_HMAC,	 /* HMAC driver */
 	CRYPTO_CMAC,	 /* CMAC driver */
-	CRYPTO_RSA,      /* Asymmetric RSA driver */
 	CRYPTO_MATH,	 /* Mathematical driver */
 	CRYPTO_CIPHER,   /* Cipher driver */
 	CRYPTO_ECC,      /* Asymmetric ECC driver */

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -101,6 +101,7 @@ struct drvcrypt_rsa {
 	} optional;
 };
 
+extern const struct drvcrypt_rsa drvcrypt_rsa_sw_ops;
 const struct drvcrypt_rsa *drvcrypt_get_rsa_ops(size_t key_size_bytes);
 
 /*

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -101,15 +101,7 @@ struct drvcrypt_rsa {
 	} optional;
 };
 
-/*
- * Register a RSA processing driver in the crypto API
- *
- * @ops - Driver operations in the HW layer
- */
-static inline TEE_Result drvcrypt_register_rsa(const struct drvcrypt_rsa *ops)
-{
-	return drvcrypt_register(CRYPTO_RSA, (void *)ops);
-}
+const struct drvcrypt_rsa *drvcrypt_get_rsa_ops(size_t key_size_bytes);
 
 /*
  * Signature data

--- a/core/drivers/crypto/se050/core/rsa.c
+++ b/core/drivers/crypto/se050/core/rsa.c
@@ -744,6 +744,7 @@ static TEE_Result do_ssa_verify(struct drvcrypt_rsa_ssa *ssa_data)
 			ssa_data->signature.length);
 }
 
+static const struct drvcrypt_rsa *driver_rsa_ptr;
 static const struct drvcrypt_rsa driver_rsa = {
 	.alloc_keypair = do_alloc_keypair,
 	.alloc_publickey = do_alloc_publickey,
@@ -756,9 +757,16 @@ static const struct drvcrypt_rsa driver_rsa = {
 	.optional.ssa_verify = do_ssa_verify,
 };
 
+const struct drvcrypt_rsa *drvcrypt_get_rsa_ops(size_t key_size_bytes __unused)
+{
+	return driver_rsa_ptr;
+}
+
 static TEE_Result rsa_init(void)
 {
-	return drvcrypt_register_rsa(&driver_rsa);
+	driver_rsa_ptr = &driver_rsa;
+
+	return TEE_SUCCESS;
 }
 
 driver_init_late(rsa_init);

--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -403,4 +403,50 @@ drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key __unused,
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 #endif /* CFG_CRYPTO_DRV_ECC */
+
+TEE_Result sw_crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
+					       size_t key_size_bits);
+
+TEE_Result sw_crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
+						  size_t key_size_bits);
+
+void sw_crypto_acipher_free_rsa_public_key(struct rsa_public_key *s);
+
+void sw_crypto_acipher_free_rsa_keypair(struct rsa_keypair *s);
+
+TEE_Result sw_crypto_acipher_gen_rsa_key(struct rsa_keypair *key,
+					 size_t key_size);
+
+TEE_Result sw_crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
+					      const uint8_t *src,
+					      size_t src_len, uint8_t *dst,
+					      size_t *dst_len);
+TEE_Result sw_crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
+					      const uint8_t *src,
+					      size_t src_len, uint8_t *dst,
+					      size_t *dst_len);
+TEE_Result sw_crypto_acipher_rsaes_decrypt(uint32_t algo,
+					   struct rsa_keypair *key,
+					   const uint8_t *label,
+					   size_t label_len, const uint8_t *src,
+					   size_t src_len, uint8_t *dst,
+					   size_t *dst_len);
+
+TEE_Result sw_crypto_acipher_rsaes_encrypt(uint32_t algo,
+					   struct rsa_public_key *key,
+					   const uint8_t *label,
+					   size_t label_len, const uint8_t *src,
+					   size_t src_len, uint8_t *dst,
+					   size_t *dst_len);
+
+TEE_Result sw_crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
+					 int salt_len, const uint8_t *msg,
+					 size_t msg_len, uint8_t *sig,
+					 size_t *sig_len);
+
+TEE_Result sw_crypto_acipher_rsassa_verify(uint32_t algo,
+					   struct rsa_public_key *key,
+					   int salt_len, const uint8_t *msg,
+					   size_t msg_len, const uint8_t *sig,
+					   size_t sig_len);
 #endif /*__CRYPTO_CRYPTO_IMPL_H*/

--- a/core/lib/libtomcrypt/rsa.c
+++ b/core/lib/libtomcrypt/rsa.c
@@ -4,6 +4,7 @@
  */
 
 #include <crypto/crypto.h>
+#include <crypto/crypto_impl.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tee_api_types.h>
@@ -84,6 +85,10 @@ static TEE_Result tee_algo_to_ltc_hashindex(uint32_t algo, int *ltc_hashindex)
 
 TEE_Result crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
 					    size_t key_size_bits __unused)
+__weak_alias("sw_crypto_acipher_alloc_rsa_keypair");
+
+TEE_Result sw_crypto_acipher_alloc_rsa_keypair(struct rsa_keypair *s,
+					       size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->e))
@@ -109,8 +114,13 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
+
 TEE_Result crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
 					       size_t key_size_bits __unused)
+__weak_alias("sw_crypto_acipher_alloc_rsa_public_key");
+
+TEE_Result sw_crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
+						  size_t key_size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->e))
@@ -123,7 +133,11 @@ err:
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
+
 void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
+__weak_alias("sw_crypto_acipher_free_rsa_public_key");
+
+void sw_crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 {
 	if (!s)
 		return;
@@ -131,7 +145,11 @@ void crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 	crypto_bignum_free(s->e);
 }
 
+
 void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
+__weak_alias("sw_crypto_acipher_free_rsa_keypair");
+
+void sw_crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
 {
 	if (!s)
 		return;
@@ -145,7 +163,12 @@ void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
 	crypto_bignum_free(s->dq);
 }
 
-TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key, size_t key_size)
+TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key,
+				      size_t key_size)
+__weak_alias("sw_crypto_acipher_gen_rsa_key");
+
+TEE_Result sw_crypto_acipher_gen_rsa_key(struct rsa_keypair *key,
+					 size_t key_size)
 {
 	TEE_Result res;
 	rsa_key ltc_tmp_key;
@@ -239,8 +262,15 @@ out:
 }
 
 TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
-					   const uint8_t *src, size_t src_len,
-					   uint8_t *dst, size_t *dst_len)
+					   const uint8_t *src,
+					   size_t src_len, uint8_t *dst,
+					   size_t *dst_len)
+__weak_alias("sw_crypto_acipher_rsanopad_encrypt");
+
+TEE_Result sw_crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
+					      const uint8_t *src,
+					      size_t src_len, uint8_t *dst,
+					      size_t *dst_len)
 {
 	TEE_Result res;
 	rsa_key ltc_key = { 0, };
@@ -254,8 +284,15 @@ TEE_Result crypto_acipher_rsanopad_encrypt(struct rsa_public_key *key,
 }
 
 TEE_Result crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
-					   const uint8_t *src, size_t src_len,
-					   uint8_t *dst, size_t *dst_len)
+					   const uint8_t *src,
+					   size_t src_len, uint8_t *dst,
+					   size_t *dst_len)
+__weak_alias("sw_crypto_acipher_rsanopad_decrypt");
+
+TEE_Result sw_crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
+					      const uint8_t *src,
+					      size_t src_len, uint8_t *dst,
+					      size_t *dst_len)
 {
 	TEE_Result res;
 	rsa_key ltc_key = { 0, };
@@ -276,10 +313,20 @@ TEE_Result crypto_acipher_rsanopad_decrypt(struct rsa_keypair *key,
 	return res;
 }
 
-TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo, struct rsa_keypair *key,
-					const uint8_t *label, size_t label_len,
-					const uint8_t *src, size_t src_len,
-					uint8_t *dst, size_t *dst_len)
+TEE_Result crypto_acipher_rsaes_decrypt(uint32_t algo,
+					struct rsa_keypair *key,
+					const uint8_t *label,
+					size_t label_len, const uint8_t *src,
+					size_t src_len, uint8_t *dst,
+					size_t *dst_len)
+__weak_alias("sw_crypto_acipher_rsaes_decrypt");
+
+TEE_Result sw_crypto_acipher_rsaes_decrypt(uint32_t algo,
+					   struct rsa_keypair *key,
+					   const uint8_t *label,
+					   size_t label_len, const uint8_t *src,
+					   size_t src_len, uint8_t *dst,
+					   size_t *dst_len)
 {
 	TEE_Result res = TEE_SUCCESS;
 	void *buf = NULL;
@@ -374,9 +421,18 @@ out:
 
 TEE_Result crypto_acipher_rsaes_encrypt(uint32_t algo,
 					struct rsa_public_key *key,
-					const uint8_t *label, size_t label_len,
-					const uint8_t *src, size_t src_len,
-					uint8_t *dst, size_t *dst_len)
+					const uint8_t *label,
+					size_t label_len, const uint8_t *src,
+					size_t src_len, uint8_t *dst,
+					size_t *dst_len)
+__weak_alias("sw_crypto_acipher_rsaes_encrypt");
+
+TEE_Result sw_crypto_acipher_rsaes_encrypt(uint32_t algo,
+					   struct rsa_public_key *key,
+					   const uint8_t *label,
+					   size_t label_len, const uint8_t *src,
+					   size_t src_len, uint8_t *dst,
+					   size_t *dst_len)
 {
 	TEE_Result res;
 	uint32_t mod_size;
@@ -433,6 +489,12 @@ TEE_Result crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
 				      int salt_len, const uint8_t *msg,
 				      size_t msg_len, uint8_t *sig,
 				      size_t *sig_len)
+__weak_alias("sw_crypto_acipher_rsassa_sign");
+
+TEE_Result sw_crypto_acipher_rsassa_sign(uint32_t algo, struct rsa_keypair *key,
+					 int salt_len, const uint8_t *msg,
+					 size_t msg_len, uint8_t *sig,
+					 size_t *sig_len)
 {
 	TEE_Result res;
 	size_t hash_size, mod_size;
@@ -525,6 +587,13 @@ TEE_Result crypto_acipher_rsassa_verify(uint32_t algo,
 					int salt_len, const uint8_t *msg,
 					size_t msg_len, const uint8_t *sig,
 					size_t sig_len)
+__weak_alias("sw_crypto_acipher_rsassa_verify");
+
+TEE_Result sw_crypto_acipher_rsassa_verify(uint32_t algo,
+					   struct rsa_public_key *key,
+					   int salt_len, const uint8_t *msg,
+					   size_t msg_len, const uint8_t *sig,
+					   size_t sig_len)
 {
 	TEE_Result res;
 	uint32_t bigint_size;

--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -20,6 +20,7 @@
 #define __packed	__attribute__((packed))
 #endif
 #define __weak		__attribute__((weak))
+#define __weak_alias(x) __attribute__((weak, alias(x)))
 #ifndef __noreturn
 #define __noreturn	__attribute__((__noreturn__))
 #endif


### PR DESCRIPTION
The commits:
- core: compiler.h: introduce __weak_alias(x) 
- crypto_impl: rsa: support the crypto driver 
- core: ltc: rsa: support the crypto driver
are copied from https://github.com/OP-TEE/optee_os/pull/5516, please keep the review of those to https://github.com/OP-TEE/optee_os/pull/5516

The two commits:
- core: crypto: add drvcrypt_get_rsa_ops() 
- core: crypto: add drvcrypt_rsa_sw_ops 
explores a way of using a software fallback transparent to the crypto_acipher_*rsa_*() functions in `core/drivers/crypto/crypto_api/acipher/rsa.c` and `core/drivers/crypto/crypto_api/acipher/rsassa.c `. The new function drvcrypt_get_rsa_ops() takes a key_size parameter to help selecting the right RSA ops struct.

We could if desired extend this further and store the RSA ops pointer in struct rsa_keypair and struct rsa_public_key to avoid a few calls to drvcrypt_get_rsa_ops().