### PR TITLE
core: entry_a64.S: add missing isb in init_pauth_per_cpu

### DIFF
--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -139,6 +139,7 @@
 		mrs	x0, sctlr_el1
 		orr	x0, x0, #SCTLR_ENIA
 		msr	sctlr_el1, x0
+		isb
 	.endm
 
 FUNC _start , :


### PR DESCRIPTION
After updating sctlr_el1 to enable pointer authentication, the isb instruction is needed to ensure that the subsequent code execution is correct.

See the implementation in TF-A: https://github.com/ARM-software/arm-trusted-firmware/blob/master/lib/extensions/pauth/pauth_helpers.S#L41 for reference.

Fixes: 93dc6b2 ("core: add pointer authentication support")
Signed-off-by: Jason Li <jasl@nvidia.com>