### PR TITLE
plat-stm32mp1: conf: default enable CFG_EXTERNAL_DT for mp15

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -56,9 +56,6 @@ ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-MP15)),)
 $(call force,CFG_STM32MP15,y)
 endif
 
-# Default do not access external DT passed to non-secure boot stage
-CFG_EXTERNAL_DT ?= n
-
 # CFG_STM32MP1x switches are exclusive.
 # - CFG_STM32MP15 is enabled for STM32MP15x-* targets (default)
 # - CFG_STM32MP13 is enabled for STM32MP13x-* targets
@@ -97,6 +94,7 @@ $(call force,CFG_STM32MP1_SHARED_RESOURCES,n)
 $(call force,CFG_STM32MP13_CLK,y)
 $(call force,CFG_TEE_CORE_NB_CORE,1)
 $(call force,CFG_WITH_NSEC_GPIOS,n)
+CFG_EXTERNAL_DT ?= n
 CFG_STM32MP_OPP_COUNT ?= 2
 CFG_WITH_PAGER ?= n
 endif # CFG_STM32MP13
@@ -108,6 +106,7 @@ $(call force,CFG_SECONDARY_INIT_CNTFRQ,y)
 $(call force,CFG_STM32MP1_SHARED_RESOURCES,y)
 $(call force,CFG_STM32MP15_CLK,y)
 CFG_CORE_RESERVED_SHM ?= y
+CFG_EXTERNAL_DT ?= y
 CFG_TEE_CORE_NB_CORE ?= 2
 CFG_WITH_PAGER ?= y
 endif # CFG_STM32MP15


### PR DESCRIPTION
Changes stm32mp1 MP15 variant default configuration for CFG_EXTERNAL_DT that is now default enabled. This is needed as mainline U-Boot and Linux may not yet define the necessary optee nodes in their DT. Therefore prefer external DT be accessed by default and let external OP-TEE configuration disable the switch if desired.

This change does not modify MP13 variant default configuration where CFG_EXTERNAL_DT is default disabled.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
