### PR TITLE
core: libtomcrypt: fix ed25519ctx signature

### DIFF
--- a/core/lib/libtomcrypt/ed25519.c
+++ b/core/lib/libtomcrypt/ed25519.c
@@ -63,14 +63,16 @@ TEE_Result crypto_acipher_ed25519_sign(struct ed25519_keypair *key,
 				       uint8_t *sig, size_t *sig_len)
 {
 	int err;
-	unsigned long siglen;
+	unsigned long siglen = 0;
 	curve25519_key private_key = {
 		.type = PK_PRIVATE,
 		.algo = LTC_OID_ED25519,
 	};
 
-	if (!key)
+	if (!key || !sig_len)
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	siglen = *sig_len;
 
 	memcpy(private_key.priv, key->priv, sizeof(private_key.priv));
 	memcpy(private_key.pub, key->pub, sizeof(private_key.pub));
@@ -92,14 +94,16 @@ TEE_Result crypto_acipher_ed25519ctx_sign(struct ed25519_keypair *key,
 					  const uint8_t *ctx, size_t ctxlen)
 {
 	int err = CRYPT_ERROR;
-	unsigned long siglen;
+	unsigned long siglen = 0;
 	curve25519_key private_key = {
 		.type = PK_PRIVATE,
 		.algo = LTC_OID_ED25519,
 	};
 
-	if (!key)
+	if (!key || !sig_len)
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	siglen = *sig_len;
 
 	memcpy(private_key.priv, key->priv, sizeof(private_key.priv));
 	memcpy(private_key.pub, key->pub, sizeof(private_key.pub));


### PR DESCRIPTION
Fixes signature size value not properly set from caller argument in crypto_acipher_ed25519_sign() and crypto_acipher_ed25519ctx_sign().

Prior this patch could execution fail or not fail, depending on content previously loaded in siglen stack memory cell.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
