### PR TITLE
plat-vexpress: qemu: Add secured and non-secured DRAM start addresses and sizes for CFG_CORE_SEL2_SPMC 

### DIFF
--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -115,8 +115,13 @@ endif
 ifeq ($(PLATFORM_FLAVOR),qemu_armv8a)
 CFG_TEE_CORE_NB_CORE = 4
 # [0e00.0000 0e0f.ffff] is reserved to early boot
+ifeq ($(CFG_CORE_SEL2_SPMC),y)
+CFG_TZDRAM_START ?= 0x0e704000
+CFG_TZDRAM_SIZE  ?= 0x00900000
+else
 CFG_TZDRAM_START ?= 0x0e100000
 CFG_TZDRAM_SIZE  ?= 0x00f00000
+endif
 # SHM chosen arbitrary, in a way that it does not interfere
 # with initial location of linux kernel, dtb and initrd.
 CFG_SHMEM_START ?= 0x42000000

--- a/core/arch/arm/plat-vexpress/platform_config.h
+++ b/core/arch/arm/plat-vexpress/platform_config.h
@@ -126,6 +126,11 @@
 
 #elif defined(PLATFORM_FLAVOR_qemu_armv8a)
 
+#ifdef CFG_CORE_SEL2_SPMC
+#define DRAM0_BASE             0x40000000
+#define DRAM0_SIZE             0xC0000000
+#endif
+
 #define GICD_OFFSET		0
 #define GICC_OFFSET		0x10000
 


### PR DESCRIPTION
Add secured and non-secured DRAM addresses and sizes for CFG_CORE_SEL2_SPMC in the plat-vexpress qemu.
 
Signed-off-by: Shiju Jose <shiju.jose@huawei.com>
