### PR TITLE
libutils: util.h: fix the ROUNDUP_OVERFLOW macro

### DIFF
--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -54,7 +54,7 @@
 	typeof(v) __roundup_mask = (typeof(v))(size) - 1; \
 	\
 	ADD_OVERFLOW((v), __roundup_mask, &__roundup_tmp) ? 1 : \
-		(void)(*(res) = __roundup_tmp & ~__roundup_mask), 0; \
+		((void)(*(res) = __roundup_tmp & ~__roundup_mask), 0); \
 }))
 
 /*


### PR DESCRIPTION
Some parenthesis are missing in the ROUNDUP_OVERFLOW expression. The macro can only return false.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
