### PR TITLE
Avoid panic in TEE core init_head_from_data

### DIFF
--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -338,7 +338,7 @@ static TEE_Result init_head_from_data(struct tee_fs_htree *ht,
 			}
 
 			if (idx)
-				return TEE_ERROR_SECURITY;
+				return TEE_ERROR_CORRUPT_OBJECT;
 		}
 	} else {
 		struct tee_fs_htree_image head[2];


### PR DESCRIPTION
init_head_from_data triggers a TA panic in case corrupt data is read from the secure storage, for instance by request from the PKCS#11 trusted application.
"Every Trusted Storage implementation is expected to return TEE_ERROR_CORRUPT_OBJECT if a Trusted Application attempts to open an object and the TEE determines that its contents (or those of the storage itself) have been tampered with or rolled back." See TEE Internal Core API Specification v1.1.2, section 5.7.1.

Signed-off-by: Joakim Nordell <joakim.nordell@axis.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
