### PR TITLE
core: dt: Make it possible to alter device mapping

### DIFF
--- a/core/drivers/atmel_piobu.c
+++ b/core/drivers/atmel_piobu.c
@@ -357,7 +357,7 @@ static TEE_Result atmel_secumod_probe(const void *fdt, int node,
 	if (secumod_base)
 		return TEE_ERROR_GENERIC;
 
-	if (dt_map_dev(fdt, node, &secumod_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &secumod_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	secumod_hw_init(fdt, node);

--- a/core/drivers/atmel_rstc.c
+++ b/core/drivers/atmel_rstc.c
@@ -43,7 +43,7 @@ static TEE_Result atmel_rstc_probe(const void *fdt, int node,
 {
 	size_t size = 0;
 
-	if (dt_map_dev(fdt, node, &rstc_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &rstc_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	return TEE_SUCCESS;

--- a/core/drivers/atmel_rtc.c
+++ b/core/drivers/atmel_rtc.c
@@ -293,7 +293,7 @@ static TEE_Result atmel_rtc_probe(const void *fdt, int node,
 
 	matrix_configure_periph_secure(AT91C_ID_SYS);
 
-	if (dt_map_dev(fdt, node, &rtc_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &rtc_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	atmel_rtc_write(RTC_CR, 0);

--- a/core/drivers/atmel_saic.c
+++ b/core/drivers/atmel_saic.c
@@ -283,7 +283,7 @@ TEE_Result atmel_saic_setup(void)
 	if (node < 0)
 		return TEE_ERROR_GENERIC;
 
-	ret = dt_map_dev(fdt, node, &saic.base, &size);
+	ret = dt_map_dev(fdt, node, &saic.base, &size, DT_MAP_AUTO);
 	if (ret) {
 		EMSG("Failed to map SAIC\n");
 		return TEE_ERROR_GENERIC;

--- a/core/drivers/atmel_shdwc.c
+++ b/core/drivers/atmel_shdwc.c
@@ -150,7 +150,7 @@ static TEE_Result atmel_shdwc_probe(const void *fdt, int node,
 	 */
 	COMPILE_TIME_ASSERT(CFG_TEE_CORE_NB_CORE == 1);
 
-	if (dt_map_dev(fdt, node, &shdwc_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &shdwc_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	ddr_node = fdt_node_offset_by_compatible(fdt, -1,
@@ -158,7 +158,7 @@ static TEE_Result atmel_shdwc_probe(const void *fdt, int node,
 	if (ddr_node < 0)
 		return TEE_ERROR_GENERIC;
 
-	if (dt_map_dev(fdt, ddr_node, &mpddrc_base, &size) < 0)
+	if (dt_map_dev(fdt, ddr_node, &mpddrc_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	ddr = io_read32(mpddrc_base + AT91_DDRSDRC_MDR) & AT91_DDRSDRC_MD;

--- a/core/drivers/atmel_tcb.c
+++ b/core/drivers/atmel_tcb.c
@@ -172,7 +172,7 @@ static TEE_Result atmel_tcb_probe(const void *fdt, int node,
 	if (res)
 		return res;
 
-	if (dt_map_dev(fdt, node, &tcb_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &tcb_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	if (tcb_base == AT91C_BASE_TC0)

--- a/core/drivers/atmel_trng.c
+++ b/core/drivers/atmel_trng.c
@@ -98,7 +98,7 @@ static TEE_Result trng_node_probe(const void *fdt, int node,
 	if (res)
 		return res;
 
-	if (dt_map_dev(fdt, node, &trng_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &trng_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	clk_enable(clk);

--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -248,7 +248,7 @@ static TEE_Result wdt_node_probe(const void *fdt, int node,
 	if (!it_hdlr)
 		goto err_free_wdt;
 
-	if (dt_map_dev(fdt, node, &wdt->base, &size) < 0)
+	if (dt_map_dev(fdt, node, &wdt->base, &size, DT_MAP_AUTO) < 0)
 		goto err_free_itr_handler;
 
 	/* Get current state of the watchdog */

--- a/core/drivers/clk/sam/sama5d2_clk.c
+++ b/core/drivers/clk/sam/sama5d2_clk.c
@@ -344,7 +344,7 @@ static TEE_Result pmc_setup(const void *fdt, int nodeoffset,
 	COMPILE_TIME_ASSERT(ARRAY_SIZE(sama5d2_systemck) == PARENT_SIZE);
 	COMPILE_TIME_ASSERT(PARENT_SIZE >= 6);
 
-	if (dt_map_dev(fdt, nodeoffset, &base, &size) < 0)
+	if (dt_map_dev(fdt, nodeoffset, &base, &size, DT_MAP_AUTO) < 0)
 		panic();
 
 	if (_fdt_get_status(fdt, nodeoffset) == DT_STATUS_OK_SEC)

--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -510,7 +510,8 @@ static TEE_Result i2c_mapped(const char *i2c_match)
 			continue;
 		}
 
-		if (dt_map_dev(fdt, off, &i2c_bus[i].va, &size) < 0) {
+		if (dt_map_dev(fdt, off, &i2c_bus[i].va, &size,
+			       DT_MAP_AUTO) < 0) {
 			EMSG("i2c%zu not enabled", i + 1);
 			continue;
 		}

--- a/core/drivers/imx_lpuart.c
+++ b/core/drivers/imx_lpuart.c
@@ -96,7 +96,7 @@ static int imx_lpuart_dev_init(struct serial_chip *chip, const void *fdt,
 	if (parms && parms[0])
 		IMSG("imx_lpuart: device parameters ignored (%s)", parms);
 
-	if (dt_map_dev(fdt, offs, &vbase, &size) < 0)
+	if (dt_map_dev(fdt, offs, &vbase, &size, DT_MAP_AUTO) < 0)
 		return -1;
 
 	pbase = virt_to_phys((void *)vbase);

--- a/core/drivers/imx_rngb.c
+++ b/core/drivers/imx_rngb.c
@@ -157,7 +157,7 @@ static TEE_Result map_controller(void)
 	if (dt_enable_secure_status(fdt, off))
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	if (dt_map_dev(fdt, off, &rngb.base.va, &rngb.size) < 0)
+	if (dt_map_dev(fdt, off, &rngb.base.va, &rngb.size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_NOT_SUPPORTED;
 
 	rngb.base.pa = virt_to_phys((void *)rngb.base.va);

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -164,7 +164,7 @@ static int imx_uart_dev_init(struct serial_chip *chip, const void *fdt,
 	if (parms && parms[0])
 		IMSG("imx_uart: device parameters ignored (%s)", parms);
 
-	if (dt_map_dev(fdt, offs, &vbase, &size) < 0)
+	if (dt_map_dev(fdt, offs, &vbase, &size, DT_MAP_AUTO) < 0)
 		return -1;
 
 	pbase = virt_to_phys((void *)vbase);

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -138,7 +138,7 @@ static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)
 	ext_reset_output = dt_have_prop(fdt, found_off,
 					"fsl,ext-reset-output");
 
-	if (dt_map_dev(fdt, found_off, &vbase, &sz) < 0) {
+	if (dt_map_dev(fdt, found_off, &vbase, &sz, DT_MAP_AUTO) < 0) {
 		EMSG("Failed to map Watchdog\n");
 		return TEE_ERROR_ITEM_NOT_FOUND;
 	}

--- a/core/drivers/ls_dspi.c
+++ b/core/drivers/ls_dspi.c
@@ -556,7 +556,8 @@ static TEE_Result get_info_from_device_tree(struct ls_dspi_data *dspi_data)
 		bus_num = fdt_getprop(fdt, node, "bus-num", NULL);
 		if (bus_num && dspi_data->slave_bus ==
 			(unsigned int)fdt32_to_cpu(*bus_num)) {
-			if (dt_map_dev(fdt, node, &ctrl_base, &size) < 0) {
+			if (dt_map_dev(fdt, node, &ctrl_base, &size,
+				       DT_MAP_AUTO) < 0) {
 				EMSG("Unable to get virtual address");
 				return TEE_ERROR_GENERIC;
 			}

--- a/core/drivers/ls_gpio.c
+++ b/core/drivers/ls_gpio.c
@@ -194,7 +194,8 @@ static TEE_Result get_info_from_device_tree(struct ls_gpio_chip_data *gpio_data)
 	node = fdt_path_offset(fdt, gpio_controller_map
 			       [gpio_data->gpio_controller]);
 	if (node > 0) {
-		if (dt_map_dev(fdt, node, &ctrl_base, &size) < 0) {
+		if (dt_map_dev(fdt, node, &ctrl_base, &size,
+			       DT_MAP_AUTO) < 0) {
 			EMSG("Unable to get virtual address");
 			return TEE_ERROR_GENERIC;
 		}

--- a/core/drivers/ls_i2c.c
+++ b/core/drivers/ls_i2c.c
@@ -139,7 +139,8 @@ TEE_Result i2c_init(struct ls_i2c_data *i2c_data)
 	node = fdt_path_offset(fdt,
 			       i2c_controller_map[i2c_data->i2c_controller]);
 	if (node > 0) {
-		if (dt_map_dev(fdt, node, &ctrl_base, &size) < 0) {
+		if (dt_map_dev(fdt, node, &ctrl_base, &size,
+			       DT_MAP_AUTO) < 0) {
 			EMSG("Unable to get virtual address");
 			return TEE_ERROR_GENERIC;
 		}

--- a/core/drivers/ls_sec_mon.c
+++ b/core/drivers/ls_sec_mon.c
@@ -99,7 +99,7 @@ static TEE_Result ls_sec_mon_init(void)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 	}
 
-	if (dt_map_dev(fdt, node, &ctrl_base, &size) < 0) {
+	if (dt_map_dev(fdt, node, &ctrl_base, &size, DT_MAP_AUTO) < 0) {
 		EMSG("Unable to get the SecMon virtual address");
 		return TEE_ERROR_GENERIC;
 	}

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -190,7 +190,7 @@ static int pl011_dev_init(struct serial_chip *chip, const void *fdt, int offs,
 	if (parms && parms[0])
 		IMSG("pl011: device parameters ignored (%s)", parms);
 
-	if (dt_map_dev(fdt, offs, &vbase, &size) < 0)
+	if (dt_map_dev(fdt, offs, &vbase, &size, DT_MAP_AUTO) < 0)
 		return -1;
 
 	if (size != 0x1000) {

--- a/core/drivers/pm/sam/at91_pm.c
+++ b/core/drivers/pm/sam/at91_pm.c
@@ -344,7 +344,7 @@ static TEE_Result at91_pm_dt_dram_init(const void *fdt)
 	if (node < 0)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	if (dt_map_dev(fdt, node, &soc_pm.ramc, &size) < 0)
+	if (dt_map_dev(fdt, node, &soc_pm.ramc, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	return TEE_SUCCESS;
@@ -359,7 +359,7 @@ static TEE_Result at91_pm_backup_init(const void *fdt)
 	if (node < 0)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	if (dt_map_dev(fdt, node, &soc_pm.sfrbu, &size) < 0)
+	if (dt_map_dev(fdt, node, &soc_pm.sfrbu, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	if (_fdt_get_status(fdt, node) == DT_STATUS_OK_SEC)
@@ -382,7 +382,8 @@ static TEE_Result at91_pm_sram_init(const void *fdt)
 	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_GENERIC;
 
-	if (dt_map_dev(fdt, node, &at91_suspend_sram_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &at91_suspend_sram_base, &size,
+		       DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	at91_suspend_sram_pbase = virt_to_phys((void *)at91_suspend_sram_base);
@@ -415,7 +416,7 @@ static TEE_Result at91_securam_init(const void *fdt)
 	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_GENERIC;
 
-	if (dt_map_dev(fdt, node, &soc_pm.securam, &size) < 0)
+	if (dt_map_dev(fdt, node, &soc_pm.securam, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	res = clk_dt_get_by_index(fdt, node, 0, &clk);
@@ -437,7 +438,7 @@ static TEE_Result at91_securam_init(const void *fdt)
 	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_GENERIC;
 
-	if (dt_map_dev(fdt, node, &soc_pm.secumod, &size) < 0)
+	if (dt_map_dev(fdt, node, &soc_pm.secumod, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	return TEE_SUCCESS;

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -125,7 +125,7 @@ static int serial8250_uart_dev_init(struct serial_chip *chip,
 	if (parms && parms[0])
 		IMSG("serial8250_uart: device parameters ignored (%s)", parms);
 
-	if (dt_map_dev(fdt, offs, &vbase, &size) < 0)
+	if (dt_map_dev(fdt, offs, &vbase, &size, DT_MAP_AUTO) < 0)
 		return -1;
 
 	if (size < SERIAL8250_UART_REG_SIZE) {

--- a/core/drivers/xiphera_trng.c
+++ b/core/drivers/xiphera_trng.c
@@ -110,7 +110,7 @@ static TEE_Result xiphera_trng_probe(const void *fdt, int node,
 		return TEE_ERROR_GENERIC;
 	}
 
-	if (dt_map_dev(fdt, node, &xiphera_trng_base, &size) < 0)
+	if (dt_map_dev(fdt, node, &xiphera_trng_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
 	/*

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -70,6 +70,17 @@ enum dt_driver_type {
 };
 
 /*
+ * DT_MAP_AUTO: Uses status properties from device tree to determine mapping.
+ * DT_MAP_SECURE: Force mapping for device to be secure.
+ * DT_MAP_NON_SECURE: Force mapping for device to be non-secure.
+ */
+enum dt_map_dev_directive {
+	DT_MAP_AUTO,
+	DT_MAP_SECURE,
+	DT_MAP_NON_SECURE
+};
+
+/*
  * dt_driver_probe_func - Callback probe function for a driver.
  *
  * @fdt: FDT base address
@@ -125,10 +136,12 @@ const struct dt_driver *dt_find_compatible_driver(const void *fdt, int offs);
  * @base receives the base virtual address corresponding to the base physical
  * address of the "reg" property
  * @size receives the size of the mapping
+ * @mapping what kind of mapping is done for memory.
  *
  * Returns 0 on success or -1 in case of error.
  */
-int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size);
+int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size,
+	       enum dt_map_dev_directive mapping);
 
 /*
  * Check whether the node at @offs contains the property with propname or not.
@@ -234,7 +247,8 @@ static inline const struct dt_driver *dt_find_compatible_driver(
 }
 
 static inline int dt_map_dev(const void *fdt __unused, int offs __unused,
-			     vaddr_t *vbase __unused, size_t *size __unused)
+			     vaddr_t *vbase __unused, size_t *size __unused,
+			     enum dt_map_dev_directive mapping __unused)
 {
 	return -1;
 }


### PR DESCRIPTION
In case where IP core device is TrustZone aware and is used by both REE
and TEE dt_map_dev() would normally cause non-secure mapping for the
device.

When selected registers in IP core are only accessible by TrustZone device
needs to be mapped with MEM_AREA_IO_SEC to cause actual AXI memory access
be made with AWPROT[1] and ARPROT[1] bits configured properly.

This adds new argument for dt_map_dev() to enable forcing mapping to be
secure or non-secure.

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
