### PR TITLE
ci: code_style: run pycodestyle even if checkpatch has failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           fi
           [ -z "$failed" ]
       - name: Run pycodestyle
+        if: success() || failure()
         run: |
           # pycodestyle task
           sudo -E bash -c "apt update -qq -y && apt install -qq -y pycodestyle"


### PR DESCRIPTION
When checkpatch reports issues, it returns an error status which make the code_style job fail as expected. However, by default when a job step fails the subsequent ones are not executed. Therefore, pycodestyle is skipped which is bad because we sometimes want to ignore some checkpatch errors and we still want to detect Python issues.

This problem is fixed by adding a condition to the "Run pycodestyle" step.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
