### PR TITLE
plat-k3: am62x: add SA2UL and TRNG support

### DIFF
--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -18,7 +18,7 @@ $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 
-ifneq (,$(filter ${PLATFORM_FLAVOR},am65x j721e j784s4 am64x))
+ifneq (,$(filter ${PLATFORM_FLAVOR},am65x j721e j784s4 am64x am62x))
 CFG_WITH_SOFTWARE_PRNG ?= n
 else
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -63,26 +63,38 @@
 #define SA2UL_BASE		0x04e00000
 #define SA2UL_TI_SCI_DEV_ID	136
 #define SA2UL_TI_SCI_FW_ID	2112
+#define SA2UL_TI_SCI_FW_RGN_ID	0
 #elif defined(PLATFORM_FLAVOR_j721e)
 #define SA2UL_BASE		0x40900000
 #define SA2UL_TI_SCI_DEV_ID	265
 #define SA2UL_TI_SCI_FW_ID	1196
+#define SA2UL_TI_SCI_FW_RGN_ID	0
 #elif defined(PLATFORM_FLAVOR_j784s4)
 #define SA2UL_BASE		0x40900000
 #define SA2UL_TI_SCI_DEV_ID	-1
 #define SA2UL_TI_SCI_FW_ID	1196
+#define SA2UL_TI_SCI_FW_RGN_ID	0
 #elif defined(PLATFORM_FLAVOR_am64x)
 #define SA2UL_BASE		0x40900000
 #define SA2UL_TI_SCI_DEV_ID	133
 #define SA2UL_TI_SCI_FW_ID	35
+#define SA2UL_TI_SCI_FW_RGN_ID	0
+#elif defined(PLATFORM_FLAVOR_am62x)
+#define SA2UL_BASE		0x40900000
+#define SA2UL_TI_SCI_DEV_ID	-1
+#define SA2UL_TI_SCI_FW_ID	66
+#define SA2UL_TI_SCI_FW_RGN_ID	1
 #endif
 #define SA2UL_REG_SIZE		0x1000
-#define SA2UL_TI_SCI_FW_RGN_ID	0
 
 /* RNG */
 #define RNG_BASE		(SA2UL_BASE + 0x10000)
 #define RNG_REG_SIZE		0x1000
+#if defined(PLATFORM_FLAVOR_am62x)
+#define RNG_TI_SCI_FW_RGN_ID	2
+#else
 #define RNG_TI_SCI_FW_RGN_ID	3
+#endif
 
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT		64


### PR DESCRIPTION
plat-k3: am62x: add SA2UL and TRNG support

Add SA2UL and TRNG support for TI SoC AM62X through OP-TEE.

Signed-off-by: Kamlesh Gurudasani <kamlesh@ti.com>
Acked-by: Jerome Forissier <jerome.forissier@linaro.org>
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
