### PR TITLE
FF-A: Add support for FFA_MEM_PERM_GET/SET

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2018-2021, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited. All rights reserved.
  */
 
 #ifndef __FFA_H
@@ -11,6 +11,7 @@
 
 #include <smccc.h>
 #include <stdint.h>
+#include <util.h>
 
 /* Error codes */
 #define FFA_OK			0
@@ -70,6 +71,10 @@
 #define FFA_MEM_FRAG_RX			U(0x8400007A)
 #define FFA_MEM_FRAG_TX			U(0x8400007B)
 #define FFA_SECONDARY_EP_REGISTER_64	U(0xC4000087)
+#define FFA_MEM_PERM_GET_32		U(0x84000088)
+#define FFA_MEM_PERM_GET_64		U(0xC4000088)
+#define FFA_MEM_PERM_SET_32		U(0x84000089)
+#define FFA_MEM_PERM_SET_64		U(0xC4000089)
 
 /* Special value for traffic targeted to the Hypervisor or SPM */
 #define FFA_TARGET_INFO_MBZ		U(0x0)
@@ -97,6 +102,16 @@
 #define FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE SHIFT_U32(1, 3)
 /* Relayer must choose the alignment boundary */
 #define FFA_MEMORY_REGION_FLAG_ANY_ALIGNMENT	0
+
+#define FFA_MEM_PERM_DATA_PERM		GENMASK_32(1, 0)
+#define FFA_MEM_PERM_RW			U(0x1)
+#define FFA_MEM_PERM_RO			U(0x3)
+
+#define FFA_MEM_PERM_INSTRUCTION_PERM	BIT(2)
+#define FFA_MEM_PERM_NX			BIT(2)
+#define FFA_MEM_PERM_X			U(0)
+
+#define FFA_MEM_PERM_RESERVED		GENMASK_32(31, 3)
 
 /* Special value for MBZ parameters */
 #define FFA_PARAM_MBZ			U(0x0)

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -42,6 +42,7 @@ struct sp_session {
 	struct sp_ffa_init_info *info;
 	unsigned int spinlock;
 	const void *fdt;
+	bool is_initialized;
 	TAILQ_ENTRY(sp_session) link;
 };
 

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -941,12 +941,15 @@ static TEE_Result sp_first_run(struct sp_session *sess)
 
 	ts_pop_current_session();
 
+	sess->is_initialized = false;
 	if (sp_enter(&args, sess)) {
 		vm_unmap(&ctx->uctx, va, num_pgs);
 		return FFA_ABORTED;
 	}
 
 	spmc_sp_msg_handler(&args, sess);
+
+	sess->is_initialized = true;
 
 	ts_push_current_session(&sess->ts_sess);
 out:


### PR DESCRIPTION
Handle FFA_MEM_PERM_GET and FFA_MEM_PERM_SET interfaces for enabling SPs to query and set the access rights of their memory regions. These interfaces are only permitted in the initialization phase thus a new state variable is being introduced in sp_session. SPs indicate the end of their initialization phase through the FFA_MSG_WAIT interface.

Some tests have been added to the Trusted Services repo and can be found here: https://review.trustedfirmware.org/c/TS/trusted-services/+/17390

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
