### PR TITLE
dts: fsl-lx2160a: add SecMon dts node

### DIFF
--- a/core/arch/arm/dts/fsl-lx2160a.dtsi
+++ b/core/arch/arm/dts/fsl-lx2160a.dtsi
@@ -525,6 +525,13 @@
 			little-endian;
 		};
 
+		sec_mon: sec-mon@1e90000 {
+			compatible = "fsl,lx2160a-sec-mon";
+			reg = <0x0 0x1e90000 0x0 0x1000>;
+			status = "disabled";
+			secure-status = "okay";
+		};
+
 		/* WRIOP0: 0x8b8_0000, E-MDIO1: 0x1_6000 */
 		emdio1: mdio@8b96000 {
 			compatible = "fsl,fman-memac-mdio";


### PR DESCRIPTION
- Enabled the secure-status property and disabled the status property so that the sec-mon node is only usable in the secure world.

Signed-off-by: Andrew Mustea <andrew.mustea@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
