### PR TITLE
SCMI server from SCP-firmware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,11 @@ jobs:
 
           function _make() { make -j$(nproc) -s O=out $*; }
           function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.4.0 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
+          function download_scp_firmware() { git clone --single-branch -b add-optee-arch https://github.com/etienne-lms/SCP-firmware.git $HOME/scp-firmware || echo Nervermind; }
 
           ccache -s -v
           download_plug_and_trust
+          download_scp_firmware
 
           _make
           _make COMPILER=clang
@@ -130,6 +132,7 @@ jobs:
           _make PLATFORM=stm32mp1
           _make PLATFORM=stm32mp1-135F_DK
           _make PLATFORM=stm32mp1-157C_DK2
+          if [ -d $HOME/scp-firmware ]; then _make PLATFORM=stm32mp1-157C_DK2 CFG_SCMI_SERVER=y CFG_SCP_FIRMWARE=$HOME/scp-firmware; fi
           _make PLATFORM=vexpress-fvp
           _make PLATFORM=vexpress-fvp CFG_ARM64_core=y
           _make PLATFORM=vexpress-fvp CFG_ARM64_core=y CFG_CORE_SEL1_SPMC=y CFG_SECURE_PARTITION=y

--- a/core/arch/arm/include/scmi/scmi_server.h
+++ b/core/arch/arm/include/scmi/scmi_server.h
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019-2022, Linaro Limited
+ */
+#ifndef SCMI_SERVER_H
+#define SCMI_SERVER_H
+
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+#ifdef CFG_SCMI_SERVER
+/*
+ * Request processing of an incoming event in the SCMI server for a target
+ * MHU/SMT mailbox.
+ * The function is exported by scmi-server.
+ *
+ * @channel_id: SCMI channel handler
+ */
+TEE_Result scmi_server_smt_process_thread(unsigned int channel_id);
+
+/*
+ * Request processing of an incoming event in the SCMI server for a target
+ * MHU/MSG mailbox.
+ * The function is exported by scmi-server.
+ *
+ * @id: SCMI channel handler
+ * @in_buf: Input message MSG buffer
+ * @in_size: Input message MSG buffer size
+ * @out_buf: Output message MSG buffer
+ * @out_size: Reference to output message MSG buffer size
+ */
+TEE_Result scmi_server_msg_process_thread(unsigned int channel_id, void *in_buf,
+					  size_t in_size, void *out_buf,
+					  size_t *out_size);
+
+/*
+ * Get SCP-firmware channel device ID from the client channel ID.
+ *
+ * @channel_id: SCMI channel handler
+ * @handle: Output SCP-firmware device ID for the target SCMI mailbox
+ */
+TEE_Result scmi_server_get_channel(unsigned int channel_id, int *handle);
+
+/* Get number of channels supported by the SCMI platform/server */
+int scmi_server_get_channels_count(void);
+
+#else /* CFG_SCMI_SERVER */
+static inline
+TEE_Result scmi_server_smt_process_thread(unsigned int channel_id __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline
+TEE_Result scmi_server_msg_process_thread(unsigned int channel_id __unused,
+					  void *in_buf __unused,
+					  size_t in_size __unused,
+					  void *out_buf __unused,
+					  size_t *out_size __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result scmi_server_get_channel(unsigned int id __unused,
+						 int *handle __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline int scmi_server_get_channels_count(void)
+{
+	return 0;
+}
+#endif /* CFG_SCMI_SERVER */
+#endif /* SCMI_SERVER_H */

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -190,6 +190,11 @@ CFG_WDT ?= $(CFG_STM32_IWDG)
 # Platform specific configuration
 CFG_STM32MP_PANIC_ON_TZC_PERM_VIOLATION ?= y
 
+# Default enable scmi-msg server if SCP-firmware SCMI server is disabled
+ifneq ($(CFG_SCMI_SERVER),y)
+CFG_SCMI_MSG_DRIVERS ?= y
+endif
+
 # SiP/OEM service for non-secure world
 CFG_STM32_BSEC_SIP ?= y
 CFG_STM32MP1_SCMI_SIP ?= n
@@ -202,10 +207,18 @@ endif
 # Default enable SCMI PTA support
 CFG_SCMI_PTA ?= y
 ifeq ($(CFG_SCMI_PTA),y)
+ifneq ($(CFG_SCMI_SERVER),y)
 $(call force,CFG_SCMI_MSG_DRIVERS,y,Mandated by CFG_SCMI_PTA)
 $(call force,CFG_SCMI_MSG_SMT_THREAD_ENTRY,y,Mandated by CFG_SCMI_PTA)
 CFG_SCMI_MSG_SHM_MSG ?= y
 CFG_SCMI_MSG_SMT ?= y
+endif # !CFG_SCMI_SERVER
+endif # CFG_SCMI_PTA
+
+CFG_SCMI_SERVER ?= n
+ifeq ($(CFG_SCMI_SERVER),y)
+$(call force,CFG_SCMI_SERVER_PRODUCT,optee-stm32mp1)
+cflags-plat-scmi-server-$(CFG_STPMIC1) += -DCFG_STPMIC1
 endif
 
 CFG_SCMI_MSG_DRIVERS ?= n

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -14,6 +14,7 @@
 #include <drivers/stm32_uart.h>
 #include <drivers/stm32mp1_etzpc.h>
 #include <drivers/stm32mp_dt_bindings.h>
+#include <io.h>
 #include <kernel/boot.h>
 #include <kernel/dt.h>
 #include <kernel/interrupt.h>
@@ -24,6 +25,7 @@
 #include <platform_config.h>
 #include <sm/psci.h>
 #include <stm32_util.h>
+#include <string.h>
 #include <trace.h>
 
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, APB1_BASE, APB1_SIZE);
@@ -44,6 +46,11 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, APB6_BASE, APB6_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, AHB4_BASE, AHB4_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, AHB5_BASE, AHB5_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
+
+#ifdef CFG_STM32MP1_SCMI_SHM_BASE
+register_phys_mem(MEM_AREA_IO_NSEC, CFG_STM32MP1_SCMI_SHM_BASE,
+		  CFG_STM32MP1_SCMI_SHM_SIZE);
+#endif
 
 register_ddr(DDR_BASE, CFG_DRAM_SIZE);
 
@@ -307,6 +314,18 @@ static TEE_Result init_stm32mp1_drivers(void)
 
 	etzpc_configure_tzma(1, SYSRAM_SEC_SIZE >> SMALL_PAGE_SHIFT);
 	etzpc_lock_tzma(1);
+
+	if (SYSRAM_SIZE > SYSRAM_SEC_SIZE) {
+		size_t nsec_size = SYSRAM_SIZE - SYSRAM_SEC_SIZE;
+		paddr_t nsec_start = SYSRAM_BASE + SYSRAM_SEC_SIZE;
+		uint8_t *va = phys_to_virt(nsec_start, MEM_AREA_IO_NSEC,
+					   nsec_size);
+
+		IMSG("Non-secure SYSRAM [%p %p]", va, va + nsec_size - 1);
+
+		/* Clear content from the non-secure part */
+		memset(va, 0, nsec_size);
+	}
 
 	return TEE_SUCCESS;
 }

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -69,6 +69,11 @@ CFG_SHMEM_SIZE   ?= 0x00200000
 # DRAM1 is defined above 4G
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
+ifeq ($(CFG_SCMI_SERVER),y)
+$(call force,CFG_SCMI_SERVER_PRODUCT,optee-fvp)
+$(call force,CFG_SCMI_SERVER_SMT_HEADER,n)
+$(call force,CFG_SCMI_SERVER_MSG_HEADER,y)
+endif
 endif
 
 ifeq ($(PLATFORM_FLAVOR),juno)
@@ -125,6 +130,11 @@ CFG_SHMEM_SIZE  ?= 0x00200000
 CFG_TEE_SDP_MEM_SIZE ?= 0x00400000
 $(call force,CFG_DT,y)
 CFG_DTB_MAX_SIZE ?= 0x100000
+ifeq ($(CFG_SCMI_SERVER),y)
+$(call force,CFG_SCMI_SERVER_PRODUCT,optee-fvp)
+$(call force,CFG_SCMI_SERVER_SMT_HEADER,n)
+$(call force,CFG_SCMI_SERVER_MSG_HEADER,y)
+endif
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),qemu_virt qemu_armv8a))

--- a/core/core.mk
+++ b/core/core.mk
@@ -146,6 +146,12 @@ libname = unw
 libdir = lib/libunw
 include mk/lib.mk
 
+ifeq ($(CFG_SCMI_SERVER),y)
+libname = scmi-server
+libdir = core/lib/scmi-server
+include mk/lib.mk
+endif
+
 #
 # Do main source
 #

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -301,3 +301,12 @@ out:
 
 	return res;
 }
+
+TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
+			       unsigned long *rates, size_t *nb_elts)
+{
+	if (!clk->ops->get_rates_array)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	return clk->ops->get_rates_array(clk, start_index, rates, nb_elts);
+}

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -48,6 +48,7 @@ struct clk {
  * @get_parent: Get the current parent index of the clock
  * @set_rate: Set the clock rate
  * @get_rate: Get the clock rate
+ * @get_rates_array: Get the supported clock rates as array
  */
 struct clk_ops {
 	TEE_Result (*enable)(struct clk *clk);
@@ -58,6 +59,8 @@ struct clk_ops {
 			       unsigned long parent_rate);
 	unsigned long (*get_rate)(struct clk *clk,
 				  unsigned long parent_rate);
+	TEE_Result (*get_rates_array)(struct clk *clk, size_t start_index,
+				      unsigned long *rates, size_t *nb_elts);
 };
 
 /**
@@ -177,5 +180,18 @@ struct clk *clk_get_parent_by_index(struct clk *clk, size_t pidx);
  * Return a TEE_Result compliant value
  */
 TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
+
+/**
+ * clk_get_rates_array - Get supported rates as an array
+ *
+ * @clk: Clock for which the rates are requested
+ * @start_index: start index of requested rates
+ * @rates: Array of rates allocated by caller or NULL to query count of rates
+ * @nb_elts: Max number of elements that the array can hold as input. Contains
+ * the number of elements that was added in the array as output.
+ * Returns a TEE_Result compliant value
+ */
+TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
+			       unsigned long *rates, size_t *nb_elts);
 
 #endif /* __DRIVERS_CLK_H */

--- a/core/lib/scmi-server/include/optee_scmi.h
+++ b/core/lib/scmi-server/include/optee_scmi.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019-2022, Linaro Limited
+ */
+#ifndef OPTEE_SCMI_H
+#define OPTEE_SCMI_H
+
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+/*
+ * Return virtual address mapped for target SMT IOMEM address range
+ *
+ * @pa: Target address range base physical address
+ * @sz: Target address range byte size
+ * @shmem_is_secure: True if memory is secure, false otherwise
+ * Return a virtual address or 0 is memory is not mapped
+ */
+uintptr_t smt_phys_to_virt(uintptr_t pa, size_t sz, bool shmem_is_secure);
+
+#endif /* OPTEE_SCMI_H */

--- a/core/lib/scmi-server/scmi_server.c
+++ b/core/lib/scmi-server/scmi_server.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019-2022, Linaro Limited
+ */
+
+#include <arch_main.h>
+#include <config.h>
+#include <initcall.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <optee_scmi.h>
+#include <scmi/scmi_server.h>
+
+/*
+ * OP-TEE helper function exported to SCP-firmware
+ */
+uintptr_t smt_phys_to_virt(uintptr_t pa, size_t sz, bool shmem_is_secure)
+{
+	if (shmem_is_secure)
+		return (uintptr_t)phys_to_virt(pa, MEM_AREA_IO_SEC, sz);
+	else
+		return (uintptr_t)phys_to_virt(pa, MEM_AREA_IO_NSEC, sz);
+}
+
+/*
+ * SCMI server APIs exported to OP-TEE core
+ */
+int scmi_server_get_channels_count(void)
+{
+	return scmi_get_devices_count();
+}
+
+TEE_Result scmi_server_get_channel(unsigned int channel_id, int *handle)
+{
+	int fwk_id = 0;
+
+	fwk_id = scmi_get_device(channel_id);
+	if (fwk_id < 0)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (handle)
+		*handle = fwk_id;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result scmi_server_smt_process_thread(unsigned int channel_id)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int fwk_id = 0;
+
+	res = scmi_server_get_channel(channel_id, &fwk_id);
+	if (!res)
+		scmi_process_mbx_smt(fwk_id);
+
+	return res;
+}
+
+TEE_Result scmi_server_msg_process_thread(unsigned int channel_id,
+					  void *in_buf, size_t in_sz,
+					  void *out_buf, size_t *out_sz)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int fwk_id = 0;
+
+	res = scmi_server_get_channel(channel_id, &fwk_id);
+	if (!res)
+		scmi_process_mbx_msg(fwk_id, in_buf, in_sz, out_buf, out_sz);
+
+	return res;
+}
+
+static TEE_Result scmi_server_initialize(void)
+{
+	int rc = 0;
+
+	rc = scmi_arch_init();
+	if (rc < 0) {
+		EMSG("SCMI server init failed: %d", rc);
+		panic();
+	}
+
+	return TEE_SUCCESS;
+}
+
+boot_final(scmi_server_initialize);

--- a/core/lib/scmi-server/sub.mk
+++ b/core/lib/scmi-server/sub.mk
@@ -1,0 +1,36 @@
+# SCMI server library is built from SCP-firmware source tree.
+# The firmware is made of the framework, a product and modules
+# from either the generic path (subdir module/) or form the
+# product path (subdir product/*/module/).
+
+scmi-server-scp-path = $(CFG_SCP_FIRMWARE)
+scmi-server-product = $(CFG_SCMI_SERVER_PRODUCT)
+scmi-server-out-path := $(out-dir)/$(libdir)
+
+srcs-y += scmi_server.c
+incdirs-y += include
+incdirs_ext-y += $(scmi-server-scp-path)/arch/none/optee/include
+
+scp-firmware-output = $(scmi-server-out-path)/build/product/$(scmi-server-product)/fw/libscmi-fw-all.a
+
+libdeps := $(scp-firmware-output) $(libdeps)
+cleanfiles += $(scp-firmware-output)
+
+cflags-scmi-server-y = $(cflags-plat-scmi-server-y)
+cflags-scmi-server-y += -I$(CURDIR)/lib/libutils/isoc/include
+cflags-scmi-server-y += -I$(CURDIR)/lib/libutils/ext/include
+cflags-scmi-server-y += $(subst -include $(conf-file),,$(cflagscore) $(cppflagscore))
+
+scmi-server-cmake-flags-y = -DSCP_FIRMWARE_SOURCE_DIR:PATH=$(scmi-server-product)/fw
+scmi-server-cmake-flags-$(CFG_TEE_CORE_DEBUG) += -DSCP_LOG_LEVEL="TRACE"
+scmi-server-cmake-flags-y += -DDISABLE_CPPCHECK=1
+scmi-server-cmake-flags-y += -DCFG_NUM_THREADS=$(CFG_NUM_THREADS)
+scmi-server-cmake-flags-y += -DSCP_OPTEE_DIR:PATH=$(CURDIR)
+scmi-server-cmake-flags-y += -DCFG_CROSS_COMPILE=$(lastword $(CROSS_COMPILE_core))
+scmi-server-cmake-flags-y += -DCFG_CFLAGS_OPTEE="$(cflags-scmi-server-y)"
+
+$(scp-firmware-output): FORCE
+	cmake -S $(scmi-server-scp-path) -B $(scmi-server-out-path)/build $(scmi-server-cmake-flags-y)
+	make -C $(scmi-server-out-path)/build scmi-fw-all
+
+$(scmi-server-out-path)/lib$(libname).a: $(scp-firmware-output)

--- a/core/pta/scmi.c
+++ b/core/pta/scmi.c
@@ -6,10 +6,26 @@
 #include <compiler.h>
 #include <config.h>
 #include <drivers/scmi-msg.h>
+#include <scmi/scmi_server.h>
 #include <kernel/pseudo_ta.h>
 #include <pta_scmi_client.h>
 #include <stdint.h>
 #include <string.h>
+
+static uint32_t supported_caps(void)
+{
+	uint32_t caps = 0;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT) ||
+	    IS_ENABLED(CFG_SCMI_SERVER_SMT_HEADER))
+		caps |= PTA_SCMI_CAPS_SMT_HEADER;
+
+	if (IS_ENABLED(CFG_SCMI_MSG_SHM_MSG) ||
+	    IS_ENABLED(CFG_SCMI_SERVER_MSG_HEADER))
+		caps |= PTA_SCMI_CAPS_MSG_HEADER;
+
+	return caps;
+}
 
 static TEE_Result cmd_capabilities(uint32_t ptypes,
 				   TEE_Param param[TEE_NUM_PARAMS])
@@ -18,17 +34,11 @@ static TEE_Result cmd_capabilities(uint32_t ptypes,
 						    TEE_PARAM_TYPE_NONE,
 						    TEE_PARAM_TYPE_NONE,
 						    TEE_PARAM_TYPE_NONE);
-	uint32_t caps = 0;
 
 	if (ptypes != exp_ptypes)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (IS_ENABLED(CFG_SCMI_MSG_SMT))
-		caps |= PTA_SCMI_CAPS_SMT_HEADER;
-	if (IS_ENABLED(CFG_SCMI_MSG_SHM_MSG))
-		caps |= PTA_SCMI_CAPS_MSG_HEADER;
-
-	param[0].value.a = caps;
+	param[0].value.a = supported_caps();
 	param[0].value.b = 0;
 
 	return TEE_SUCCESS;
@@ -57,6 +67,9 @@ static TEE_Result cmd_process_smt_channel(uint32_t ptypes,
 
 		return TEE_SUCCESS;
 	}
+
+	if (IS_ENABLED(CFG_SCMI_SERVER))
+		return scmi_server_smt_process_thread(channel_id);
 
 	return TEE_ERROR_NOT_SUPPORTED;
 }
@@ -116,8 +129,11 @@ static TEE_Result cmd_process_msg_channel(uint32_t ptypes,
 	if (ptypes != exp_pt || !in_buf || !out_buf)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (IS_ENABLED(CFG_SCMI_MSG_SHM_MSG)) {
+	if (IS_ENABLED(CFG_SCMI_MSG_DRIVERS)) {
 		struct scmi_msg_channel *channel = NULL;
+
+		if (!IS_ENABLED(CFG_SCMI_MSG_SHM_MSG))
+			return TEE_ERROR_NOT_SUPPORTED;
 
 		channel = plat_scmi_get_channel(channel_id);
 		if (!channel)
@@ -127,6 +143,21 @@ static TEE_Result cmd_process_msg_channel(uint32_t ptypes,
 					      out_buf, &out_size);
 		if (!res)
 			params[2].memref.size = out_size;
+
+		return res;
+	}
+
+	if (IS_ENABLED(CFG_SCMI_SERVER)) {
+		if (!in_buf || !out_buf)
+			return TEE_ERROR_BAD_PARAMETERS;
+
+		res = scmi_server_msg_process_thread(channel_id, in_buf,
+						     in_size, out_buf,
+						     &out_size);
+		if (!res) {
+			params[2].memref.size = (uint32_t)out_size;
+			IMSG("scmi optee shm: out %zu", out_size);
+		}
 
 		return res;
 	}
@@ -143,20 +174,15 @@ static TEE_Result cmd_get_channel_handle(uint32_t ptypes,
 						    TEE_PARAM_TYPE_NONE);
 	unsigned int channel_id = params[0].value.a;
 	unsigned int caps = params[0].value.b;
-	const unsigned int supported_caps = PTA_SCMI_CAPS_SMT_HEADER |
-					    PTA_SCMI_CAPS_MSG_HEADER;
 
-	if (ptypes != exp_ptypes || caps & ~supported_caps)
+	if (ptypes != exp_ptypes || caps & ~PTA_SCMI_CAPS_MASK)
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!(caps & supported_caps()))
+		return TEE_ERROR_NOT_SUPPORTED;
 
 	if (IS_ENABLED(CFG_SCMI_MSG_DRIVERS)) {
 		struct scmi_msg_channel *channel = NULL;
-
-		if ((!IS_ENABLED(CFG_SCMI_MSG_SMT) &&
-		     caps & PTA_SCMI_CAPS_SMT_HEADER) ||
-		    (!IS_ENABLED(CFG_SCMI_MSG_SHM_MSG) &&
-		     caps & PTA_SCMI_CAPS_MSG_HEADER))
-			return TEE_ERROR_NOT_SUPPORTED;
 
 		channel = plat_scmi_get_channel(channel_id);
 		if (!channel)
@@ -166,6 +192,11 @@ static TEE_Result cmd_get_channel_handle(uint32_t ptypes,
 		params[0].value.a = scmi_smt_channel_handle(channel_id);
 
 		return TEE_SUCCESS;
+	}
+
+	if (IS_ENABLED(CFG_SCMI_SERVER)) {
+		/* Only check the channel ID is known from SCP-firwmare */
+		return scmi_server_get_channel(channel_id, NULL);
 	}
 
 	return TEE_ERROR_NOT_SUPPORTED;
@@ -184,7 +215,8 @@ static TEE_Result pta_scmi_open_session(uint32_t ptypes __unused,
 		return TEE_ERROR_ACCESS_DENIED;
 	}
 
-	if (IS_ENABLED(CFG_SCMI_MSG_SMT) || IS_ENABLED(CFG_SCMI_MSG_SHM_MSG))
+	if (IS_ENABLED(CFG_SCMI_MSG_SMT) || IS_ENABLED(CFG_SCMI_MSG_SHM_MSG) ||
+	    IS_ENABLED(CFG_SCMI_SERVER))
 		return TEE_SUCCESS;
 
 	return TEE_ERROR_NOT_SUPPORTED;

--- a/lib/libutee/include/pta_scmi_client.h
+++ b/lib/libutee/include/pta_scmi_client.h
@@ -78,4 +78,7 @@
 /* Channel supports shared memory using the MSG header protocol */
 #define PTA_SCMI_CAPS_MSG_HEADER			BIT32(1)
 
+/* Mask of defined capabilities */
+#define PTA_SCMI_CAPS_MASK				GENMASK_32(1, 0)
+
 #endif /* SCMI_PTA_SCMI_CLIENT_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -757,6 +757,13 @@ endif
 # configuration mandates target product identifier is configured with
 # CFG_SCMI_SERVER_PRODUCT and the SCP-firmware source tree path with
 # CFG_SCP_FIRMWARE.
+#
+# There are several protocols supported for exchanging SCMI message through
+# shared memory.
+# CFG_SCMI_SERVER_SMT_HEADER, when set, indicates to SCMI PTA that SCMI SMT
+# protocol based statically allocated IOMEM shared memory is supported.
+# CFG_SCMI_SERVER_MSG_HEADER, when set, indicates to SCMI PTA that SCMI MSG_SMT
+# protocol based generic dynamially allocated OP-TEE shared memory is supported.
 CFG_SCMI_SERVER ?= n
 
 ifeq ($(CFG_SCMI_SERVER),y)
@@ -767,6 +774,8 @@ endif
 ifeq (,$(wildcard $(CFG_SCP_FIRMWARE)/CMakeLists.txt))
 $(error CFG_SCMI_SERVER=y mandates CFG_SCP_FIRMWARE configuration)
 endif
+CFG_SCMI_SERVER_SMT_HEADER ?= y
+CFG_SCMI_SERVER_MSG_HEADER ?= y
 endif #CFG_SCMI_SERVER
 
 ifeq ($(CFG_SCMI_MSG_DRIVERS)-$(CFG_SCMI_SERVER),y-y)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -752,6 +752,27 @@ $(eval $(call cfg-depends-all,CFG_SCMI_MSG_SMT_INTERRUPT_ENTRY,CFG_SCMI_MSG_SMT)
 $(eval $(call cfg-depends-one,CFG_SCMI_MSG_SMT_THREAD_ENTRY,CFG_SCMI_MSG_SMT CFG_SCMI_MSG_SHM_MSG))
 endif
 
+# CFG_SCMI_SERVER, when enabled, embeds the reference SCMI server implementation
+# from SCP-firmware package as an built-in SCMI stack in core. This
+# configuration mandates target product identifier is configured with
+# CFG_SCMI_SERVER_PRODUCT and the SCP-firmware source tree path with
+# CFG_SCP_FIRMWARE.
+CFG_SCMI_SERVER ?= n
+
+ifeq ($(CFG_SCMI_SERVER),y)
+$(call force,CFG_SCMI_PTA,y,Required by CFG_SCMI_SERVER)
+ifeq (,$(CFG_SCMI_SERVER_PRODUCT))
+$(error CFG_SCMI_SERVER=y mandates CFG_SCMI_SERVER_PRODUCT configuration)
+endif
+ifeq (,$(wildcard $(CFG_SCP_FIRMWARE)/CMakeLists.txt))
+$(error CFG_SCMI_SERVER=y mandates CFG_SCP_FIRMWARE configuration)
+endif
+endif #CFG_SCMI_SERVER
+
+ifeq ($(CFG_SCMI_MSG_DRIVERS)-$(CFG_SCMI_SERVER),y-y)
+$(error CFG_SCMI_MSG_DRIVERS=y and CFG_SCMI_SERVER=y are mutually exclusive)
+endif
+
 # Enable SCMI PTA interface for REE SCMI agents
 CFG_SCMI_PTA ?= n
 


### PR DESCRIPTION
The P-R allows a platform to build an SCMI server stack to run in OP-TEE core. The SCMI server is built from SCP-firmware reference  implementation https://github.com/ARM-software/SCP-firmware.git which source are to be fetch externally to optee_os and path set from `CFG_SCP_FIRMWARE`. 

This P-R implements an SCMI for platforms fvp and stm32mp this is embedded when `CFG_SCMI_SERVER=y`.
P-Rs https://github.com/OP-TEE/manifest/pull/220 and https://github.com/OP-TEE/build/pull/600 allows one to fetch and build stm32mp1 with SCP-firmware SCMI server.