### PR TITLE
core: dt: allow null value in reg property

### DIFF
--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -161,9 +161,6 @@ static paddr_t _fdt_read_paddr(const uint32_t *cell, int n)
 #endif
 	}
 
-	if (!addr)
-		goto bad;
-
 	return addr;
 bad:
 	return DT_INFO_INVALID_REG;


### PR DESCRIPTION
This change allows reg property to have value 0. The reg property can be used to describe an element that is not a physical address  but an offset and for which 0 is a valid value.
