### PR TITLE
ldelf: supports riscv ldelf startup and riscv TAs loading

### DIFF
--- a/ldelf/ldelf.ld.S
+++ b/ldelf/ldelf.ld.S
@@ -12,6 +12,9 @@ OUTPUT_ARCH(arm)
 OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH(aarch64)
 #endif
+#ifdef RV64
+OUTPUT_ARCH(riscv)
+#endif
 
 ENTRY(_ldelf_start)
 SECTIONS {

--- a/ldelf/ldelf.mk
+++ b/ldelf/ldelf.mk
@@ -17,6 +17,10 @@ endif
 ifeq ($(CFG_ARM32_core),y)
 CFG_ARM32_$(sm) := y
 endif
+ifeq ($(CFG_RV64_core),y)
+CFG_RV64_$(sm) := y
+endif
+
 arch-bits-$(sm) := $(arch-bits-core)
 
 cppflags$(sm)	+= -include $(conf-file)

--- a/ldelf/start_rv64.S
+++ b/ldelf/start_rv64.S
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright  2022  Beijing ESWIN Computing Technology Co., Ltd.
+ */
+
+#include <asm.S>
+#include <elf_common.h>
+
+/*
+ * _ldelf_start() - Entry of ldelf
+ *
+ * See include/ldelf.h for details on TEE Core interaction.
+ *
+ * void _ldelf_start(struct ldelf_arg *arg);
+ */
+FUNC _ldelf_start , :
+	/*
+	 * First ldelf needs to be relocated. The binary is compiled to
+	 * contain only a minimal number of R_RISCV_RELATIVE relocations in
+	 * read/write memory, leaving read-only and executable memory
+	 * untouched.
+	 */
+	lla	a1, reloc_end_rel
+	lw	a3, 0(a1)
+	lla	a1, reloc_begin_rel
+	lw	a2, 0(a1)
+	add	a2, a2, a1
+	add	a3, a3, a1
+	beq	a2, a3, 2f
+
+	lla	a1, _ldelf_start	/* Get the load offset */
+
+	/* Loop over the relocations (Elf64_Rela) and process all entries */
+1:
+	ld	t1, 0(a2)	/* t1 = r_offset */
+	ld	t2, 8(a2)	/* t2 = r_info */
+	ld	t3, 16(a2)	/* t3 = r_addend */
+	addi	a2, a2, 24
+	and	t2, t2, 0xff
+	addi	t4, zero, R_RISCV_RELATIVE
+	bne	t2, t4, 3f
+
+	/* Update the pointer at r_offset + load offset */
+	add	t1, a1, t1
+	ld	t4, 0(t1)
+	add	t4, t4, t3
+	add	t4, t4, a1
+	sd	t4, 0(t1)
+	ble	a2, a3, 1b
+2:
+	jal	ldelf
+	addi	a0, a0, 0
+	jal	_ldelf_return
+3:
+	addi	a0, a0, 0
+	jal	_ldelf_panic
+reloc_begin_rel:
+    .word __reloc_begin - reloc_begin_rel
+reloc_end_rel:
+    .word __reloc_end - reloc_end_rel
+END_FUNC _ldelf_start

--- a/ldelf/sub.mk
+++ b/ldelf/sub.mk
@@ -4,6 +4,7 @@ srcs-$(CFG_ARM64_$(sm)) += start_a64.S
 srcs-$(CFG_ARM32_$(sm)) += syscalls_a32.S
 srcs-$(CFG_ARM64_$(sm)) += syscalls_a64.S
 srcs-$(CFG_ARM64_$(sm)) += tlsdesc_rel_a64.S
+srcs-$(CFG_RV64_$(sm)) += start_rv64.S
 srcs-y += dl.c
 srcs-y += main.c
 srcs-y += sys.c

--- a/ldelf/ta_elf_rel.c
+++ b/ldelf/ta_elf_rel.c
@@ -478,7 +478,7 @@ static void e32_relocate(struct ta_elf *elf, unsigned int rel_sidx)
 	}
 }
 
-#ifdef ARM64
+#if defined(ARM64) || defined(RV64)
 static void e64_get_sym_name(const Elf64_Sym *sym_tab, size_t num_syms,
 			     const char *str_tab, size_t str_tab_size,
 			     Elf64_Rela *rela, const char **name,
@@ -518,6 +518,7 @@ static void e64_process_dyn_rela(const Elf64_Sym *sym_tab, size_t num_syms,
 	*where = val;
 }
 
+#ifdef ARM64
 static void e64_process_tls_tprel_rela(const Elf64_Sym *sym_tab,
 				       size_t num_syms, const char *str_tab,
 				       size_t str_tab_size, Elf64_Rela *rela,
@@ -570,6 +571,7 @@ static void e64_process_tlsdesc_rela(const Elf64_Sym *sym_tab, size_t num_syms,
 	e64_process_tls_tprel_rela(sym_tab, num_syms, str_tab, str_tab_size,
 				   rela, where + 1, elf);
 }
+#endif /*ARM64*/
 
 static void e64_relocate(struct ta_elf *elf, unsigned int rel_sidx)
 {
@@ -652,6 +654,7 @@ static void e64_relocate(struct ta_elf *elf, unsigned int rel_sidx)
 		where = (Elf64_Addr *)(elf->load_addr + rela->r_offset);
 
 		switch (ELF64_R_TYPE(rela->r_info)) {
+#ifdef ARM64
 		case R_AARCH64_NONE:
 			/*
 			 * One would expect linker prevents such useless entry
@@ -692,19 +695,41 @@ static void e64_relocate(struct ta_elf *elf, unsigned int rel_sidx)
 						 str_tab_size, rela, where,
 						 elf);
 			break;
+#endif /*ARM64*/
+#ifdef RV64
+		case R_RISCV_NONE:
+			/*
+			 * One would expect linker prevents such useless entry
+			 * in the relocation table. We still handle this type
+			 * here in case such entries exist.
+			 */
+			break;
+		case R_RISCV_RELATIVE:
+			*where = rela->r_addend + elf->load_addr;
+			break;
+		case R_RISCV_64:
+			e64_process_dyn_rela(sym_tab, num_syms, str_tab,
+					     str_tab_size, rela, where);
+			*where += rela->r_addend;
+			break;
+		case R_RISCV_JUMP_SLOT:
+			e64_process_dyn_rela(sym_tab, num_syms, str_tab,
+					     str_tab_size, rela, where);
+			break;
+#endif /*RV64*/
 		default:
 			err(TEE_ERROR_BAD_FORMAT, "Unknown relocation type %zd",
 			     ELF64_R_TYPE(rela->r_info));
 		}
 	}
 }
-#else /*ARM64*/
+#else /*ARM64 || RV64*/
 static void __noreturn e64_relocate(struct ta_elf *elf __unused,
 				    unsigned int rel_sidx __unused)
 {
 	err(TEE_ERROR_NOT_SUPPORTED, "arm64 not supported");
 }
-#endif /*ARM64*/
+#endif /*ARM64 || RV64*/
 
 void ta_elf_relocate(struct ta_elf *elf)
 {

--- a/lib/libutee/include/elf_common.h
+++ b/lib/libutee/include/elf_common.h
@@ -251,6 +251,7 @@ typedef struct {
 #define	EM_UNICORE	110	/* Microprocessor series from PKU-Unity Ltd.
 				   and MPRC of Peking University */
 #define	EM_AARCH64	183	/* AArch64 (64-bit ARM) */
+#define	EM_RISCV	243	/* RISC-V */
 
 /* Non-standard or deprecated. */
 #define	EM_486		6	/* Intel i486. */
@@ -682,6 +683,13 @@ typedef struct {
 #define	R_386_TLS_DTPOFF32	36	/* GOT entry containing TLS offset */
 #define	R_386_TLS_TPOFF32	37	/* GOT entry of -ve static TLS offset */
 #define	R_386_IRELATIVE		42	/* PLT entry resolved indirectly at runtime */
+
+#define	R_RISCV_NONE		0	/* No relocation. */
+#define	R_RISCV_64		2	/* 64-bit relocation. */
+#define	R_RISCV_RELATIVE	3	/* Adjust a link address (A) to its
+					   load address (B + A). */
+#define	R_RISCV_JUMP_SLOT	5	/* Indicates the symbol associated
+					   with a PLT entry. */
 
 #define	R_AARCH64_NONE		0	/* No relocation. */
 #define	R_AARCH64_ABS64		257

--- a/lib/libutils/ext/include/confine_array_index.h
+++ b/lib/libutils/ext/include/confine_array_index.h
@@ -142,4 +142,16 @@ static inline size_t confine_array_index(size_t index, size_t size) {
   return safe_index;
 }
 #endif
+
+#ifdef __riscv
+static inline size_t confine_array_index(size_t index, size_t size) {
+	/*
+	 * The naive C implementation without protection
+	 * against side-channel attacks.
+	 */
+	if (index < size)
+		return index;
+	return 0;
+}
+#endif
 #endif  // FBL_CONFINE_ARRAY_INDEX_H_


### PR DESCRIPTION
Added 64-bit riscv ldelf startup assembly and
parsing 64-bit elf files.

Tested-by: Liu Shiwei <liushiwei@eswincomputing.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
