### PR TITLE
Added ZCU104 and ZCU106 flavour support

### DIFF
--- a/core/arch/arm/plat-zynqmp/conf.mk
+++ b/core/arch/arm/plat-zynqmp/conf.mk
@@ -21,7 +21,7 @@ else
 $(call force,CFG_ARM32_core,y)
 endif
 
-ifneq (,$(filter $(PLATFORM_FLAVOR),zcu102 zc1751_dc1 zc1751_dc2))
+ifneq (,$(filter $(PLATFORM_FLAVOR),zcu102 zcu104 zcu106 zc1751_dc1 zc1751_dc2))
 
 CFG_UART_BASE ?= UART0_BASE
 CFG_UART_IT ?= IT_UART0

--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -55,7 +55,9 @@
 
 #if defined(PLATFORM_FLAVOR_zc1751_dc1) || \
 	defined(PLATFORM_FLAVOR_zc1751_dc2) || \
-	defined(PLATFORM_FLAVOR_zcu102)
+	defined(PLATFORM_FLAVOR_zcu102) || \
+	defined(PLATFORM_FLAVOR_zcu104) || \
+	defined(PLATFORM_FLAVOR_zcu106)
 
 #define GIC_BASE		0xF9010000
 #define UART0_BASE		0xFF000000


### PR DESCRIPTION
Adding support for the ZCU104 and ZCU106 boards since they possess the same core as the ZCU102. This is to avoid having the "flavour not supported error" when compiling for the ZCU104 and ZCU106

Tested succesfully on the ZCU106