### PR TITLE
core: ree_fs: check ta size early

### DIFF
--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -424,6 +424,14 @@ static TEE_Result ree_fs_ta_open(const TEE_UUID *uuid,
 			goto error_free_hash;
 		}
 
+		/*
+		 * This is checked further down too, but we must sanity
+		 * check shdr->img_size before it's used below.
+		 */
+		if (ta_size != sz + shdr->img_size) {
+			res = TEE_ERROR_SECURITY;
+			goto error_free_hash;
+		}
 
 		ehdr = malloc(ehdr_sz);
 		if (!ehdr) {

--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -439,7 +439,10 @@ static TEE_Result ree_fs_ta_open(const TEE_UUID *uuid,
 			goto error_free_hash;
 		}
 
-		memcpy(ehdr, ((uint8_t *)ta + offs), ehdr_sz);
+		*ehdr = img_ehdr;
+		memcpy((uint8_t *)ehdr + sizeof(img_ehdr),
+		       (uint8_t *)ta + offs + sizeof(img_ehdr),
+		       ehdr_sz - sizeof(img_ehdr));
 
 		res = crypto_hash_update(hash_ctx, (uint8_t *)ehdr, ehdr_sz);
 		if (res != TEE_SUCCESS)


### PR DESCRIPTION
As soon as TA signature has been verified check that the total loaded size matches what is in the sign header. This prevents an eventual attacker from providing arbitrary values in the img_size field of the signed header.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
