### PR TITLE
core: fix potential integer overflow in syscall_log()

### DIFF
--- a/core/tee/tee_svc.c
+++ b/core/tee/tee_svc.c
@@ -29,25 +29,26 @@
 
 vaddr_t tee_svc_uref_base;
 
-void syscall_log(const void *buf __maybe_unused, size_t len __maybe_unused)
+void syscall_log(const void *buf, size_t len)
 {
-#ifdef CFG_TEE_CORE_TA_TRACE
-	char *kbuf;
+	if (IS_ENABLED(CFG_TEE_CORE_TA_TRACE)) {
+		char *kbuf = NULL;
+		size_t sz = 0;
 
-	if (len == 0)
-		return;
+		if (!len || ADD_OVERFLOW(len, 1, &sz))
+			return;
 
-	kbuf = malloc(len + 1);
-	if (kbuf == NULL)
-		return;
+		kbuf = malloc(sz);
+		if (!kbuf)
+			return;
 
-	if (copy_from_user(kbuf, buf, len) == TEE_SUCCESS) {
-		kbuf[len] = '\0';
-		trace_ext_puts(kbuf);
+		if (copy_from_user(kbuf, buf, len) == TEE_SUCCESS) {
+			kbuf[len] = '\0';
+			trace_ext_puts(kbuf);
+		}
+
+		free_wipe(kbuf);
 	}
-
-	free_wipe(kbuf);
-#endif
 }
 
 TEE_Result syscall_not_supported(void)


### PR DESCRIPTION
Fixes a potential integer overflow in syscall_log(). Note that an eventual overflow would still be caught by copy_from_user(), but it's preferable to catch this earlier.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
