### PR TITLE
core: ffa: Allow multiple SPs with same UUID

### DIFF
--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -43,6 +43,7 @@ struct sp_session {
 	unsigned int spinlock;
 	const void *fdt;
 	bool is_initialized;
+	TEE_UUID ffa_uuid;
 	TAILQ_ENTRY(sp_session) link;
 };
 
@@ -82,10 +83,9 @@ static inline struct sp_ctx *to_sp_ctx(struct ts_ctx *ctx)
 
 struct sp_session *sp_get_session(uint32_t session_id);
 TEE_Result sp_enter(struct thread_smc_args *args, struct sp_session *sp);
-TEE_Result sp_partition_info_get_all(struct ffa_partition_info *fpi,
-				     size_t *elem_count);
+TEE_Result sp_partition_info_get(struct ffa_partition_info *fpi,
+				 const TEE_UUID *ffa_uuid, size_t *elem_count);
 
-TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id);
 bool sp_has_exclusive_access(struct sp_mem_map_region *mem,
 			     struct user_mode_ctx *uctx);
 TEE_Result sp_map_shared(struct sp_session *s,


### PR DESCRIPTION
The FF-A spec doesn't forbid multiple SPs to have the same UUID. This makes it possible to use the FF-A UUID as a identifier for the protocol on top of the FF-A layer.
To achieve this we have to make sure that the FFA_PARTITION_INFO_GET can return more then one endpoint id if we pass a UUID. We also need to change the naming convention of the SPs. This used to be {UUID}.stripped.elf. This has been changed to be
{SP_NAME}_{UUID}.stripped.elf. To make sure we don't use any special characters when creating the name of the SP array we take the hash of the name first.

Build change: https://github.com/OP-TEE/build/pull/603
Trusted Services changes:
https://review.trustedfirmware.org/c/TS/trusted-services/+/16587/
https://review.trustedfirmware.org/c/TS/trusted-services/+/16586

Testing can be done by using:
repo init -u https://github.com/jellesels-arm/manifest.git -m fvp-spmc-test.xml -b multiple_uuid && repo sync -j8 --no-clone-bundle


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
