### PR TITLE
core: include: Fix simple typo in drivers/stm32_gpio.h

### DIFF
--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -63,8 +63,8 @@ struct gpio_cfg {
  *
  * @bank: GPIO bank identifier as assigned by the platform
  * @pin: Pin number in the GPIO bank
- * @active_cfg: Configuratioh in active state
- * @standby_cfg: Configuratioh in standby state
+ * @active_cfg: Configuration in active state
+ * @standby_cfg: Configuration in standby state
  */
 struct stm32_pinctrl {
 	uint8_t bank;


### PR DESCRIPTION
Replace "Configuratioh" with "Configuration".

Signed-off-by: Ding Tao <miyatsu@qq.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
