### PR TITLE
make X25519 & Ed25519 available for mbedtls configurations

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -47,11 +47,8 @@ CFG_CRYPTO_ECC ?= y
 CFG_CRYPTO_SM2_PKE ?= y
 CFG_CRYPTO_SM2_DSA ?= y
 CFG_CRYPTO_SM2_KEP ?= y
-# X25519 and Ed25519 are only supported by libtomcrypt
-ifeq ($(CFG_CRYPTOLIB_NAME),tomcrypt)
 CFG_CRYPTO_ED25519 ?= y
 CFG_CRYPTO_X25519 ?= y
-endif
 
 # Authenticated encryption
 CFG_CRYPTO_CCM ?= y
@@ -192,8 +189,8 @@ _CFG_CORE_LTC_SHA512_DESC := $(CFG_CRYPTO_DSA)
 _CFG_CORE_LTC_XTS := $(CFG_CRYPTO_XTS)
 _CFG_CORE_LTC_CCM := $(CFG_CRYPTO_CCM)
 _CFG_CORE_LTC_AES_DESC := $(call cfg-one-enabled, CFG_CRYPTO_XTS CFG_CRYPTO_CCM)
-$(call force,CFG_CRYPTO_X25519,n,not supported by mbedtls)
-$(call force,CFG_CRYPTO_ED25519,n,not supported by mbedtls)
+_CFG_CORE_LTC_X25519 := $(CFG_CRYPTO_X25519)
+_CFG_CORE_LTC_ED25519 := $(CFG_CRYPTO_ED25519)
 endif
 
 ###############################################################


### PR DESCRIPTION
Make LTC implementations of X25519 & Ed25519 algorithms available when crypto library is chosen to be mbedtls (which yet lacks support for these algorithms).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
