### PR TITLE
core: arm: stmm: use mempool to decompress stmm image

### DIFF
--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -11,6 +11,7 @@
 #include <kernel/stmm_sp.h>
 #include <kernel/thread_private.h>
 #include <kernel/user_mode_ctx.h>
+#include <mempool.h>
 #include <mm/fobj.h>
 #include <mm/mobj.h>
 #include <mm/vm.h>
@@ -184,12 +185,12 @@ static TEE_Result alloc_and_map_sp_fobj(struct stmm_ctx *spc, size_t sz,
 static void *zalloc(void *opaque __unused, unsigned int items,
 		    unsigned int size)
 {
-	return malloc(items * size);
+	return mempool_alloc(mempool_default, items * size);
 }
 
 static void zfree(void *opaque __unused, void *address)
 {
-	free(address);
+	mempool_free(mempool_default, address);
 }
 
 static void uncompress_image(void *dst, size_t dst_size, void *src,


### PR DESCRIPTION
Changes StMM management to have zlib using default mempool to allocate buffers for StMM image decompression. This is useful as the process can require buffer of several kilobytes.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
