### PR TITLE
[RFC] StMM: 32bit mode requires cpu usr_lr to be preserved

### DIFF
--- a/core/arch/arm/include/kernel/thread_private_arch.h
+++ b/core/arch/arm/include/kernel/thread_private_arch.h
@@ -181,6 +181,8 @@ void thread_set_fiq_sp(vaddr_t sp);
 
 /* Read usr_sp banked CPU register */
 uint32_t thread_get_usr_sp(void);
+uint32_t thread_get_usr_lr(void);
+void thread_set_usr_lr(uint32_t usr_lr);
 #endif /*ARM32*/
 
 void thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,

--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -111,7 +111,18 @@ static TEE_Result stmm_enter_user_mode(struct stmm_ctx *spc)
 	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 	cntkctl = read_cntkctl();
 	write_cntkctl(cntkctl | CNTKCTL_PL0PCTEN);
+
+#ifdef ARM32
+	/* Handle usr_lr in place of __thread_enter_user_mode() */
+	thread_set_usr_lr(spc->regs.usr_lr);
+#endif
+
 	__thread_enter_user_mode(&spc->regs, &panicked, &panic_code);
+
+#ifdef ARM32
+	spc->regs.usr_lr = thread_get_usr_lr();
+#endif
+
 	write_cntkctl(cntkctl);
 	thread_unmask_exceptions(exceptions);
 

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -71,6 +71,24 @@ FUNC thread_get_usr_sp , :
 	bx	lr
 END_FUNC thread_get_usr_sp
 
+FUNC thread_get_usr_lr , :
+	mrs	r1, cpsr
+	cpsid	aif
+	cps	#CPSR_MODE_SYS
+	mov	r0, lr
+	msr	cpsr, r1
+	bx	lr
+END_FUNC thread_get_usr_lr
+
+FUNC thread_set_usr_lr , :
+	mrs	r1, cpsr
+	cpsid	aif
+	cps	#CPSR_MODE_SYS
+	mov	lr, r0
+	msr	cpsr, r1
+	bx	lr
+END_FUNC thread_set_usr_lr
+
 /* void thread_resume(struct thread_ctx_regs *regs) */
 FUNC thread_resume , :
 UNWIND(	.cantunwind)


### PR DESCRIPTION
This P-R tries to fix an issue in StMM management in 32bit mode where CPU register USR_LR is not preserved in StMM execution context.