### PR TITLE
Add support for compiler stack protector

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -567,6 +567,13 @@ shadow_stack_access_ok:
 	mov	sp, r9
 #endif
 
+#ifdef _CFG_CORE_STACK_PROTECTOR
+	/* Update stack canary value */
+	bl	plat_get_random_stack_canary
+	ldr	r1, =__stack_chk_guard
+	str	r0, [r1]
+#endif
+
 	/*
 	 * In case we've touched memory that secondary CPUs will use before
 	 * they have turned on their D-cache, clean and invalidate the

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -350,6 +350,13 @@ clear_nex_bss:
 	mov	sp, x21
 #endif
 
+#ifdef _CFG_CORE_STACK_PROTECTOR
+	/* Update stack canary value */
+	bl	plat_get_random_stack_canary
+	adr_l	x5, __stack_chk_guard
+	str	x0, [x5]
+#endif
+
 	/*
 	 * In case we've touched memory that secondary CPUs will use before
 	 * they have turned on their D-cache, clean and invalidate the

--- a/core/core.mk
+++ b/core/core.mk
@@ -24,6 +24,12 @@ cppflags$(sm)	+= -include $(conf-file)
 cppflags$(sm)	+= -I$(out-dir)/core/include
 cppflags$(sm)	+= $(core-platform-cppflags)
 cflags$(sm)	+= $(core-platform-cflags)
+
+core-stackp-cflags-$(CFG_CORE_STACK_PROTECTOR) := -fstack-protector
+core-stackp-cflags-$(CFG_CORE_STACK_PROTECTOR_STRONG) := -fstack-protector-strong
+core-stackp-cflags-$(CFG_CORE_STACK_PROTECTOR_ALL) := -fstack-protector-all
+cflags$(sm)	+= $(core-stackp-cflags-y)
+
 ifeq ($(CFG_CORE_SANITIZE_UNDEFINED),y)
 cflags$(sm)	+= -fsanitize=undefined
 endif

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -69,6 +69,9 @@ void plat_cpu_reset_early(void);
 void plat_primary_init_early(void);
 unsigned long plat_get_aslr_seed(void);
 unsigned long plat_get_freq(void);
+#if defined(_CFG_CORE_STACK_PROTECTOR)
+uintptr_t plat_get_random_stack_canary(void);
+#endif
 void arm_cl2_config(vaddr_t pl310);
 void arm_cl2_enable(vaddr_t pl310);
 

--- a/lib/libutils/isoc/stack_check.c
+++ b/lib/libutils/isoc/stack_check.c
@@ -3,13 +3,27 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  */
 #include <compiler.h>
+#include <trace.h>
+
+#if defined(__KERNEL__)
+# include <kernel/panic.h>
+# define PANIC() panic()
+#elif defined(__LDELF__)
+# include <ldelf_syscalls.h>
+# define PANIC() _ldelf_panic(2)
+#else
+# include <utee_syscalls.h>
+# define PANIC() _utee_panic(TEE_ERROR_OVERFLOW)
+#endif
+
 void *__stack_chk_guard __nex_data = (void *)0x00000aff;
 
 void __attribute__((noreturn)) __stack_chk_fail(void);
 
 void __stack_chk_fail(void)
 {
+	EMSG_RAW("stack smashing detected");
 	while (1)
-		;
+		PANIC();
 }
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -313,6 +313,37 @@ CFG_TA_ASLR_MAX_OFFSET_PAGES ?= 128
 # corruption vulnerabilities more difficult.
 CFG_CORE_ASLR ?= y
 
+# Stack Protection for TEE Core
+# This flag enables the compiler stack protection mechanisms -fstack-protector.
+# It will check the stack canary value before returning from a function to
+# prevent buffer overflow attacks. Stack protector canary logic will be added
+# for vulnerable functions that contain:
+# - A character array larger than 8 bytes.
+# - An 8-bit integer array larger than 8 bytes.
+# - A call to alloca() with either a variable size or a constant size bigger
+#   than 8 bytes.
+CFG_CORE_STACK_PROTECTOR ?= n
+# This enable stack protector flag -fstack-protector-strong. Stack protector
+# canary logic will be added for vulnerable functions that contain:
+# - An array of any size and type.
+# - A call to alloca().
+# - A local variable that has its address taken.
+CFG_CORE_STACK_PROTECTOR_STRONG ?= y
+# This enable stack protector flag -fstack-protector-all. Stack protector canary
+# logic will be added to all functions regardless of their vulnerability.
+CFG_CORE_STACK_PROTECTOR_ALL ?= n
+# Stack Protection for TA
+CFG_TA_STACK_PROTECTOR ?= n
+CFG_TA_STACK_PROTECTOR_STRONG ?= y
+CFG_TA_STACK_PROTECTOR_ALL ?= n
+
+_CFG_CORE_STACK_PROTECTOR := $(call cfg-one-enabled, CFG_CORE_STACK_PROTECTOR \
+						     CFG_CORE_STACK_PROTECTOR_STRONG \
+						     CFG_CORE_STACK_PROTECTOR_ALL)
+_CFG_TA_STACK_PROTECTOR := $(call cfg-one-enabled, CFG_TA_STACK_PROTECTOR \
+						   CFG_TA_STACK_PROTECTOR_STRONG \
+						   CFG_TA_STACK_PROTECTOR_ALL)
+
 # Load user TAs from the REE filesystem via tee-supplicant
 CFG_REE_FS_TA ?= y
 

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -12,6 +12,11 @@ include mk/$(COMPILER_$(sm)).mk
 # Config flags from mk/config.mk
 #
 
+ta-stackp-cflags-$(CFG_TA_STACK_PROTECTOR) := -fstack-protector
+ta-stackp-cflags-$(CFG_TA_STACK_PROTECTOR_STRONG) := -fstack-protector-strong
+ta-stackp-cflags-$(CFG_TA_STACK_PROTECTOR_ALL) := -fstack-protector-all
+$(sm)-platform-cflags += $(ta-stackp-cflags-y)
+
 ifeq ($(CFG_TA_MBEDTLS_SELF_TEST),y)
 $(sm)-platform-cppflags += -DMBEDTLS_SELF_TEST
 endif


### PR DESCRIPTION
This change add support for CFG_CORE_STACK_PROTECTOR and CFG_TA_STACK_PROTECTOR. This flag enable the compiler stack overflow protection feature -fstack-protector-strong and also generate random stack canary value on kernel boot and TA entry.

Weak function plat_get_random_stack_canary() should be override by platform to provide random stack canary value for the core kernel.

Signed-off-by: Khoa Hoang <admin@khoahoang.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
