### PR TITLE
crypto_api: add ecc encrypt and decrypt to crypto

### DIFF
--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -340,10 +340,156 @@ static TEE_Result ecc_shared_secret(struct ecc_keypair *private_key,
 	return ret;
 }
 
+static TEE_Result ecc_sm2_encrypt(struct ecc_public_key *key,
+				  const uint8_t *src, size_t src_len,
+				  uint8_t *dst, size_t *dst_len)
+{
+	TEE_Result ret = TEE_ERROR_BAD_PARAMETERS;
+	struct drvcrypt_ecc_ed cdata = { };
+	struct drvcrypt_ecc *ecc = NULL;
+	size_t ciphertext_len = 0;
+	size_t size_bytes = 0;
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+
+	size_bytes = get_ecc_key_size_bytes(key->curve);
+	if (!size_bytes) {
+		CRYPTO_TRACE("Curve 0x%08"PRIx32" not supported", key->curve);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Uncompressed form indicator */
+	dst[0] = 0x04;
+
+	ciphertext_len = 2 * size_bytes + src_len + TEE_SM3_HASH_SIZE;
+
+	cdata.key = key;
+	cdata.size_sec = size_bytes;
+	cdata.plaintext.data = (uint8_t *)src;
+	cdata.plaintext.length = src_len;
+	cdata.ciphertext.data = dst + 1;
+	cdata.ciphertext.length = ciphertext_len;
+
+	ret = ecc->encrypt(&cdata);
+
+	if (!ret || ret == TEE_ERROR_SHORT_BUFFER)
+		*dst_len = cdata.ciphertext.length + 1;
+
+	return ret;
+}
+
+static TEE_Result ecc_encrypt(struct ecc_public_key *key,
+			      const uint8_t *src, size_t src_len,
+			      uint8_t *dst, size_t *dst_len)
+{
+	struct drvcrypt_ecc *ecc = NULL;
+
+	if (!key || !src || !dst) {
+		CRYPTO_TRACE("Input parameters reference error");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+	if (!ecc || !ecc->encrypt)
+		return TEE_ERROR_NOT_IMPLEMENTED;
+
+	switch (key->curve) {
+	case TEE_ECC_CURVE_SM2:
+		return ecc_sm2_encrypt(key, src, src_len, dst, dst_len);
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+}
+
+static TEE_Result ecc_sm2_decrypt(struct ecc_keypair *key,
+				  const uint8_t *src, size_t src_len,
+				  uint8_t *dst, size_t *dst_len)
+{
+	TEE_Result ret = TEE_ERROR_BAD_PARAMETERS;
+	struct drvcrypt_ecc_ed cdata = { };
+	struct drvcrypt_ecc *ecc = NULL;
+	uint8_t *ciphertext = NULL;
+	size_t ciphertext_len = 0;
+	size_t size_bytes = 0;
+	size_t plaintext_len = 0;
+	/* Point Compression */
+	uint8_t pc = 0;
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+
+	size_bytes = get_ecc_key_size_bytes(key->curve);
+	if (!size_bytes) {
+		CRYPTO_TRACE("Curve 0x%08"PRIx32" not supported", key->curve);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	pc = src[0];
+	switch (pc) {
+	case 0x02:
+	case 0x03:
+		/* Compressed form */
+		return TEE_ERROR_NOT_SUPPORTED;
+	case 0x04:
+		/* Uncompressed form */
+		ciphertext = (uint8_t *)src + 1;
+		ciphertext_len = src_len - 1;
+		break;
+	case 0x06:
+	case 0x07:
+		/* Hybrid form */
+		return TEE_ERROR_NOT_SUPPORTED;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (SUB_OVERFLOW(ciphertext_len, 2 * size_bytes + TEE_SM3_HASH_SIZE,
+			 &plaintext_len))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	cdata.key = key;
+	cdata.size_sec = size_bytes;
+	cdata.ciphertext.data = ciphertext;
+	cdata.ciphertext.length = ciphertext_len;
+	cdata.plaintext.data = dst;
+	cdata.plaintext.length = plaintext_len;
+
+	ret = ecc->decrypt(&cdata);
+
+	/* Set the plaintext length */
+	if (!ret || ret == TEE_ERROR_SHORT_BUFFER)
+		*dst_len = cdata.plaintext.length;
+
+	return ret;
+}
+
+static TEE_Result ecc_decrypt(struct ecc_keypair *key,
+			      const uint8_t *src, size_t src_len,
+			      uint8_t *dst, size_t *dst_len)
+{
+	struct drvcrypt_ecc *ecc = NULL;
+
+	if (!key || !src || !dst) {
+		CRYPTO_TRACE("Input parameters reference error");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	ecc = drvcrypt_get_ops(CRYPTO_ECC);
+	if (!ecc || !ecc->decrypt)
+		return TEE_ERROR_NOT_IMPLEMENTED;
+
+	switch (key->curve) {
+	case TEE_ECC_CURVE_SM2:
+		return ecc_sm2_decrypt(key, src, src_len, dst, dst_len);
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+}
+
 static const struct crypto_ecc_keypair_ops ecc_keypair_ops = {
 	.generate = ecc_generate_keypair,
 	.sign = ecc_sign,
 	.shared_secret = ecc_shared_secret,
+	.decrypt = ecc_decrypt,
 };
 
 TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
@@ -361,6 +507,7 @@ TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
 	switch (type) {
 	case TEE_TYPE_ECDSA_KEYPAIR:
 	case TEE_TYPE_ECDH_KEYPAIR:
+	case TEE_TYPE_SM2_PKE_KEYPAIR:
 		ecc = drvcrypt_get_ops(CRYPTO_ECC);
 		break;
 	default:
@@ -370,8 +517,17 @@ TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
 	if (ecc)
 		ret = ecc->alloc_keypair(key, size_bits);
 
-	if (!ret)
+	if (!ret) {
 		key->ops = &ecc_keypair_ops;
+
+		switch (type) {
+		case TEE_TYPE_SM2_PKE_KEYPAIR:
+			key->curve = TEE_ECC_CURVE_SM2;
+			break;
+		default:
+			break;
+		}
+	}
 
 	CRYPTO_TRACE("ECC Keypair (%zu bits) alloc ret = 0x%" PRIx32, size_bits,
 		     ret);
@@ -381,6 +537,7 @@ TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
 static const struct crypto_ecc_public_ops ecc_public_key_ops = {
 	.free = ecc_free_public_key,
 	.verify = ecc_verify,
+	.encrypt = ecc_encrypt,
 };
 
 TEE_Result drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key,
@@ -398,6 +555,7 @@ TEE_Result drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key,
 	switch (type) {
 	case TEE_TYPE_ECDSA_PUBLIC_KEY:
 	case TEE_TYPE_ECDH_PUBLIC_KEY:
+	case TEE_TYPE_SM2_PKE_PUBLIC_KEY:
 		ecc = drvcrypt_get_ops(CRYPTO_ECC);
 		break;
 	default:
@@ -407,8 +565,17 @@ TEE_Result drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key,
 	if (ecc)
 		ret = ecc->alloc_publickey(key, size_bits);
 
-	if (!ret)
+	if (!ret) {
 		key->ops = &ecc_public_key_ops;
+
+		switch (type) {
+		case TEE_TYPE_SM2_PKE_PUBLIC_KEY:
+			key->curve = TEE_ECC_CURVE_SM2;
+			break;
+		default:
+			break;
+		}
+	}
 
 	CRYPTO_TRACE("ECC Public Key (%zu bits) alloc ret = 0x%" PRIx32,
 		     size_bits, ret);

--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -24,6 +24,7 @@ static size_t get_ecc_key_size_bytes(uint32_t curve)
 		return 28;
 
 	case TEE_ECC_CURVE_NIST_P256:
+	case TEE_ECC_CURVE_SM2:
 		return 32;
 
 	case TEE_ECC_CURVE_NIST_P384:

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -134,6 +134,17 @@ struct drvcrypt_secret_data {
 };
 
 /*
+ * Encrypt/Decrypt data
+ */
+struct drvcrypt_ecc_ed {
+	uint32_t algo;                  /* Operation algorithm */
+	void *key;                      /* Public or Private Key */
+	size_t size_sec;                /* Security size in bytes */
+	struct drvcrypt_buf plaintext;  /* Clear text message */
+	struct drvcrypt_buf ciphertext; /* Encrypted message */
+};
+
+/*
  * Crypto ECC driver operations
  */
 struct drvcrypt_ecc {
@@ -152,6 +163,10 @@ struct drvcrypt_ecc {
 	TEE_Result (*verify)(struct drvcrypt_sign_data *sdata);
 	/* ECC Shared Secret */
 	TEE_Result (*shared_secret)(struct drvcrypt_secret_data *sdata);
+	/* ECC Encrypt */
+	TEE_Result (*encrypt)(struct drvcrypt_ecc_ed *cdata);
+	/* ECC Decrypt */
+	TEE_Result (*decrypt)(struct drvcrypt_ecc_ed *cdata);
 };
 
 /*


### PR DESCRIPTION
1. add ecc encrypt to ecc_public_key_ops and add ecc decrypt to ecc_keypair_ops.
2. define struct drvcrypt_encrypt_data

Signed-off-by: yuzexi <yuzexi@hisilicon.com>
Reviewed-by: Xiaoxu Zeng <zengxiaoxu@huawei.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
