### PR TITLE
core: ffa: remove pager annotations

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -121,6 +121,10 @@ $(call force,CFG_CORE_SEL2_SPMC,n)
 $(call force,CFG_CORE_SEL1_SPMC,n)
 endif
 
+ifeq ($(CFG_CORE_FFA)-$(CFG_WITH_PAGER),y-y)
+$(error CFG_CORE_FFA and CFG_WITH_PAGER are not compatible)
+endif
+
 # Unmaps all kernel mode code except the code needed to take exceptions
 # from user space and restore kernel mode mapping again. This gives more
 # strict control over what is accessible while in user mode.

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -40,7 +40,6 @@ __thread_std_smc_entry(uint32_t a0 __unused, uint32_t a1 __unused,
 }
 
 const struct mobj_ops mobj_reg_shm_ops __rodata_dummy;
-const struct mobj_ops mobj_ffa_ops __rodata_dummy;
 const struct mobj_ops mobj_phys_ops __rodata_dummy;
 const struct mobj_ops mobj_virt_ops __rodata_dummy;
 const struct mobj_ops mobj_mm_ops __rodata_dummy;
@@ -55,4 +54,3 @@ const struct fobj_ops ops_locked_paged __rodata_dummy;
 const struct fobj_ops ops_sec_mem __rodata_dummy;
 const struct ts_ops user_ta_ops __rodata_dummy;
 const struct ts_ops stmm_sp_ops __rodata_dummy;
-const struct ts_ops sp_ops __rodata_dummy;

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -60,7 +60,7 @@ struct sp_pkg_header {
 
 struct fip_sp_head fip_sp_list = STAILQ_HEAD_INITIALIZER(fip_sp_list);
 
-const struct ts_ops sp_ops;
+static const struct ts_ops sp_ops;
 
 /* List that holds all of the loaded SP's */
 static struct sp_sessions_head open_sp_sessions =
@@ -1089,11 +1089,7 @@ static void sp_dump_state(struct ts_ctx *ctx)
 	user_mode_ctx_print_mappings(&utc->uctx);
 }
 
-/*
- * Note: this variable is weak just to ease breaking its dependency chain
- * when added to the unpaged area.
- */
-const struct ts_ops sp_ops __weak __relrodata_unpaged("sp_ops") = {
+static const struct ts_ops sp_ops = {
 	.enter_invoke_cmd = sp_enter_invoke_cmd,
 	.handle_svc = sp_handle_svc,
 	.dump_state = sp_dump_state,

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1063,8 +1063,7 @@ out_put_mobj:
 /*
  * Helper routine for the assembly function thread_std_smc_entry()
  *
- * Note: this function is weak just to make it possible to exclude it from
- * the unpaged area.
+ * Note: this function is weak just to make link_dummies_paged.c happy.
  */
 uint32_t __weak __thread_std_smc_entry(uint32_t a0, uint32_t a1,
 				       uint32_t a2, uint32_t a3,

--- a/core/arch/arm/kernel/thread_spmc_a32.S
+++ b/core/arch/arm/kernel/thread_spmc_a32.S
@@ -10,7 +10,6 @@
 #include <asm.S>
 #include <ffa.h>
 #include <generated/asm-defines.h>
-#include <keep.h>
 #include <kernel/thread.h>
 #include <optee_ffa.h>
 
@@ -112,7 +111,6 @@ UNWIND(	.save	{r0, lr})
 	stm	r12, {r0-r3}		/* Store r0-r3 into rv[] */
 	bx	lr
 END_FUNC thread_rpc
-DECLARE_KEEP_PAGER thread_rpc
 
 /*
  * void thread_foreign_intr_exit(uint32_t thread_index)

--- a/core/arch/arm/kernel/thread_spmc_a64.S
+++ b/core/arch/arm/kernel/thread_spmc_a64.S
@@ -11,7 +11,6 @@
 #include <asm.S>
 #include <ffa.h>
 #include <generated/asm-defines.h>
-#include <keep.h>
 #include <kernel/thread.h>
 #include <optee_ffa.h>
 
@@ -164,7 +163,6 @@ FUNC thread_rpc , :
 	store_wregs x16, 0, 0, 3	/* Store w0-w3 into rv[] */
 	ret
 END_FUNC thread_rpc
-DECLARE_KEEP_PAGER thread_rpc
 
 /*
  * void thread_foreign_intr_exit(uint32_t thread_index)

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -7,7 +7,6 @@
 #include <bitstring.h>
 #include <ffa.h>
 #include <initcall.h>
-#include <keep.h>
 #include <kernel/refcount.h>
 #include <kernel/spinlock.h>
 #include <kernel/thread_spmc.h>
@@ -41,7 +40,7 @@ static struct mobj_ffa_head shm_inactive_head =
 
 static unsigned int shm_lock = SPINLOCK_UNLOCK;
 
-const struct mobj_ops mobj_ffa_ops;
+static const struct mobj_ops mobj_ffa_ops;
 
 static struct mobj_ffa *to_mobj_ffa(struct mobj *mobj)
 {
@@ -456,7 +455,6 @@ static TEE_Result ffa_get_pa(struct mobj *mobj, size_t offset,
 
 	return TEE_SUCCESS;
 }
-DECLARE_KEEP_PAGER(ffa_get_pa);
 
 static size_t ffa_get_phys_offs(struct mobj *mobj,
 				size_t granule __maybe_unused)
@@ -609,12 +607,7 @@ static TEE_Result mapped_shm_init(void)
 	return TEE_SUCCESS;
 }
 
-/*
- * Note: this variable is weak just to ease breaking its dependency chain
- * when added to the unpaged area.
- */
-const struct mobj_ops mobj_ffa_ops
-__weak __relrodata_unpaged("mobj_ffa_ops") = {
+static const struct mobj_ops mobj_ffa_ops = {
 	.get_pa = ffa_get_pa,
 	.get_phys_offs = ffa_get_phys_offs,
 	.get_va = ffa_get_va,

--- a/core/arch/arm/mm/sp_mem.c
+++ b/core/arch/arm/mm/sp_mem.c
@@ -17,8 +17,7 @@ static unsigned int sp_mem_lock = SPINLOCK_UNLOCK;
 /* mem_shares stores all active FF-A shares. */
 SLIST_HEAD(sp_mem_head, sp_mem);
 static struct sp_mem_head mem_shares = SLIST_HEAD_INITIALIZER(sp_mem_head);
-/* Weak instance of mobj_sp_ops mandates it is not static */
-const struct mobj_ops mobj_sp_ops;
+static const struct mobj_ops mobj_sp_ops;
 
 struct mobj_sp {
 	struct mobj mobj;
@@ -174,7 +173,7 @@ static void inactivate(struct mobj *mobj)
 	cpu_spin_unlock_xrestore(&sp_mem_lock, exceptions);
 }
 
-const struct mobj_ops mobj_sp_ops __weak __relrodata_unpaged("mobj_sp_ops") = {
+static const struct mobj_ops mobj_sp_ops = {
 	.get_pa = get_pa,
 	.get_phys_offs = get_phys_offs,
 	.get_mem_type = get_mem_type,


### PR DESCRIPTION
Configuration with pager and FF-A is currently not supported. Supporting this would require extensions to the FF-A specification to be able to load OP-TEE with paging enabled. So far we don't have any platforms with FF-A which are memory constrained enough that paging can be motivated. If this would change we'll have a good use case to test with when adding pager support for FF-A.

Currently we have a few pager annotations (DECLARE_KEEP_PAGER() and __*_unpaged) which are effectively unused. So save us from adding yet more unused annotations by removing the few we have in the FF-A specific code.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
