### PR TITLE
plat-stm32mp1: fixes in DTS files

### DIFF
--- a/core/arch/arm/dts/stm32mp151.dtsi
+++ b/core/arch/arm/dts/stm32mp151.dtsi
@@ -1646,7 +1646,7 @@
 		 * Break node order to solve dependency probe issue between
 		 * pinctrl and exti.
 		 */
-		pinctrl: pin-controller@50002000 {
+		pinctrl: pinctrl@50002000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			compatible = "st,stm32mp157-pinctrl";
@@ -1777,7 +1777,7 @@
 			};
 		};
 
-		pinctrl_z: pin-controller-z@54004000 {
+		pinctrl_z: pinctrl@54004000 {
 			#address-cells = <1>;
 			#size-cells = <1>;
 			compatible = "st,stm32mp157-z-pinctrl";

--- a/core/arch/arm/dts/stm32mp157a-dk1.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1.dts
@@ -27,13 +27,13 @@
 	};
 };
 
-&rcc {
-	status = "okay";
-};
-
 &bsec {
 	board_id: board_id@ec {
 		reg = <0xec 0x4>;
 		st,non-secure-otp;
 	};
+};
+
+&rcc {
+	status = "okay";
 };

--- a/core/arch/arm/dts/stm32mp157c-dk2.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2.dts
@@ -30,7 +30,7 @@
 };
 
 &dsi {
-	status = "okay";
+	status = "disabled";
 	phy-dsi-supply = <&reg18>;
 
 	ports {
@@ -78,7 +78,7 @@
 };
 
 &ltdc {
-	status = "okay";
+	status = "disabled";
 
 	port {
 		ltdc_ep1_out: endpoint@1 {

--- a/core/arch/arm/dts/stm32mp157c-dk2.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2.dts
@@ -29,6 +29,13 @@
 	};
 };
 
+&bsec {
+	board_id: board_id@ec {
+		reg = <0xec 0x4>;
+		st,non-secure-otp;
+	};
+};
+
 &dsi {
 	status = "disabled";
 	phy-dsi-supply = <&reg18>;
@@ -88,21 +95,14 @@
 	};
 };
 
+&rcc {
+	status = "okay";
+};
+
 &usart2 {
 	pinctrl-names = "default", "sleep", "idle";
 	pinctrl-0 = <&usart2_pins_c>;
 	pinctrl-1 = <&usart2_sleep_pins_c>;
 	pinctrl-2 = <&usart2_idle_pins_c>;
 	status = "disabled";
-};
-
-&rcc {
-	status = "okay";
-};
-
-&bsec {
-	board_id: board_id@ec {
-		reg = <0xec 0x4>;
-		st,non-secure-otp;
-	};
 };

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -115,6 +115,13 @@
 	};
 };
 
+&bsec {
+	board_id: board_id@ec {
+		reg = <0xec 0x4>;
+		st,non-secure-otp;
+	};
+};
+
 &crc1 {
 	status = "disabled";
 };
@@ -326,6 +333,10 @@
 	vdd_3v3_usbfs-supply = <&vdd_usb>;
 };
 
+&rcc {
+	status = "okay";
+};
+
 &rng1 {
 	status = "okay";
 };
@@ -400,15 +411,4 @@
 
 &usbphyc_port1 {
 	phy-supply = <&vdd_usb>;
-};
-
-&rcc {
-	status = "okay";
-};
-
-&bsec {
-	board_id: board_id@ec {
-		reg = <0xec 0x4>;
-		st,non-secure-otp;
-	};
 };

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -116,7 +116,7 @@
 };
 
 &crc1 {
-	status = "okay";
+	status = "disabled";
 };
 
 &dac {
@@ -133,7 +133,7 @@
 };
 
 &dts {
-	status = "okay";
+	status = "disabled";
 };
 
 &gpu {
@@ -141,7 +141,7 @@
 };
 
 &hash1 {
-	status = "okay";
+	status = "disabled";
 };
 
 &i2c4 {
@@ -287,7 +287,7 @@
 			interrupts = <IT_PONKEY_F 0>, <IT_PONKEY_R 0>;
 			interrupt-names = "onkey-falling", "onkey-rising";
 			power-off-time-sec = <10>;
-			status = "okay";
+			status = "disabled";
 		};
 
 		watchdog {
@@ -298,7 +298,7 @@
 };
 
 &ipcc {
-	status = "okay";
+	status = "disabled";
 };
 
 &iwdg1 {
@@ -318,7 +318,7 @@
 	mbox-names = "vq0", "vq1", "shutdown", "detach";
 	interrupt-parent = <&exti>;
 	interrupts = <68 1>;
-	status = "okay";
+	status = "disabled";
 };
 
 &pwr_regulators {
@@ -331,7 +331,7 @@
 };
 
 &rtc {
-	status = "okay";
+	status = "disabled";
 };
 
 &sdmmc1 {
@@ -351,7 +351,7 @@
 	sd-uhs-sdr25;
 	sd-uhs-sdr50;
 	sd-uhs-ddr50;
-	status = "okay";
+	status = "disabled";
 };
 
 &sdmmc2 {
@@ -367,11 +367,11 @@
 	vmmc-supply = <&v3v3>;
 	vqmmc-supply = <&vdd>;
 	mmc-ddr-3_3v;
-	status = "okay";
+	status = "disabled";
 };
 
 &timers6 {
-	status = "okay";
+	status = "disabled";
 	/* spare dmas for other usage */
 	/delete-property/dmas;
 	/delete-property/dma-names;

--- a/core/arch/arm/dts/stm32mp157c-ev1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ev1.dts
@@ -72,11 +72,11 @@
 &cec {
 	pinctrl-names = "default";
 	pinctrl-0 = <&cec_pins_a>;
-	status = "okay";
+	status = "disabled";
 };
 
 &dcmi {
-	status = "okay";
+	status = "disabled";
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&dcmi_pins_a>;
 	pinctrl-1 = <&dcmi_sleep_pins_a>;
@@ -95,7 +95,7 @@
 
 &dsi {
 	phy-dsi-supply = <&reg18>;
-	status = "okay";
+	status = "disabled";
 
 	ports {
 		port@0 {
@@ -130,7 +130,7 @@
 };
 
 &ethernet0 {
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&ethernet0_rgmii_pins_a>;
 	pinctrl-1 = <&ethernet0_rgmii_sleep_pins_a>;
 	pinctrl-names = "default", "sleep";
@@ -152,7 +152,7 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&fmc_pins_a>;
 	pinctrl-1 = <&fmc_sleep_pins_a>;
-	status = "okay";
+	status = "disabled";
 
 	nand-controller@4,0 {
 		status = "okay";
@@ -172,7 +172,7 @@
 	pinctrl-1 = <&i2c2_sleep_pins_a>;
 	i2c-scl-rising-time-ns = <185>;
 	i2c-scl-falling-time-ns = <20>;
-	status = "okay";
+	status = "disabled";
 
 	ov5640: camera@3c {
 		compatible = "ovti,ov5640";
@@ -226,11 +226,11 @@
 	pinctrl-1 = <&i2c5_sleep_pins_a>;
 	i2c-scl-rising-time-ns = <185>;
 	i2c-scl-falling-time-ns = <20>;
-	status = "okay";
+	status = "disabled";
 };
 
 &ltdc {
-	status = "okay";
+	status = "disabled";
 
 	port {
 		ltdc_ep0_out: endpoint@0 {
@@ -244,7 +244,7 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&m_can1_pins_a>;
 	pinctrl-1 = <&m_can1_sleep_pins_a>;
-	status = "okay";
+	status = "disabled";
 };
 
 &qspi {
@@ -254,7 +254,7 @@
 	reg = <0x58003000 0x1000>, <0x70000000 0x4000000>;
 	#address-cells = <1>;
 	#size-cells = <0>;
-	status = "okay";
+	status = "disabled";
 
 	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
@@ -355,7 +355,7 @@
 
 &usbh_ehci {
 	phys = <&usbphyc_port0>;
-	status = "okay";
+	status = "disabled";
 };
 
 &usbotg_hs {
@@ -363,11 +363,11 @@
 	pinctrl-names = "default";
 	phys = <&usbphyc_port1 0>;
 	phy-names = "usb2-phy";
-	status = "okay";
+	status = "disabled";
 };
 
 &usbphyc {
-	status = "okay";
+	status = "disabled";
 };
 
 &usbphyc_port0 {

--- a/core/arch/arm/dts/stm32mp157c-ev1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ev1.dts
@@ -7,7 +7,6 @@
 
 #include "stm32mp157c-ed1.dts"
 #include <dt-bindings/gpio/gpio.h>
-/* #include <dt-bindings/input/input.h> Remove due to BSD license issue */
 
 / {
 	model = "STMicroelectronics STM32MP157C eval daughter on eval mother";
@@ -37,31 +36,26 @@
 		pinctrl-names = "default";
 		button-0 {
 			label = "JoySel";
-			/* linux,code = <KEY_ENTER>; BSD license issue */
 			interrupt-parent = <&stmfx_pinctrl>;
 			interrupts = <0 IRQ_TYPE_EDGE_RISING>;
 		};
 		button-1 {
 			label = "JoyDown";
-			/* linux,code = <KEY_DOWN>; BSD license issue */
 			interrupt-parent = <&stmfx_pinctrl>;
 			interrupts = <1 IRQ_TYPE_EDGE_RISING>;
 		};
 		button-2 {
 			label = "JoyLeft";
-			/* linux,code = <KEY_LEFT>; BSD license issue */
 			interrupt-parent = <&stmfx_pinctrl>;
 			interrupts = <2 IRQ_TYPE_EDGE_RISING>;
 		};
 		button-3 {
 			label = "JoyRight";
-			/* linux,code = <KEY_RIGHT>; BSD license issue */
 			interrupt-parent = <&stmfx_pinctrl>;
 			interrupts = <3 IRQ_TYPE_EDGE_RISING>;
 		};
 		button-4 {
 			label = "JoyUp";
-			/* linux,code = <KEY_UP>; BSD license issue */
 			interrupt-parent = <&stmfx_pinctrl>;
 			interrupts = <4 IRQ_TYPE_EDGE_RISING>;
 		};

--- a/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
@@ -67,6 +67,7 @@
 			gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "heartbeat";
 			default-state = "off";
+			status = "disabled";
 		};
 	};
 
@@ -78,7 +79,7 @@
 			"Capture" , "MCLK",
 			"MICL" , "Mic Bias";
 		dais = <&sai2a_port &sai2b_port &i2s2_port>;
-		status = "okay";
+		status = "disabled";
 	};
 
 	vin: vin {
@@ -121,19 +122,19 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&cec_pins_b>;
 	pinctrl-1 = <&cec_sleep_pins_b>;
-	status = "okay";
+	status = "disabled";
 };
 
 &crc1 {
-	status = "okay";
+	status = "disabled";
 };
 
 &dts {
-	status = "okay";
+	status = "disabled";
 };
 
 &ethernet0 {
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&ethernet0_rgmii_pins_a>;
 	pinctrl-1 = <&ethernet0_rgmii_sleep_pins_a>;
 	pinctrl-names = "default", "sleep";
@@ -156,7 +157,7 @@
 };
 
 &hash1 {
-	status = "okay";
+	status = "disabled";
 };
 
 &i2c1 {
@@ -165,7 +166,7 @@
 	pinctrl-1 = <&i2c1_sleep_pins_a>;
 	i2c-scl-rising-time-ns = <100>;
 	i2c-scl-falling-time-ns = <7>;
-	status = "okay";
+	status = "disabled";
 	/delete-property/dmas;
 	/delete-property/dma-names;
 
@@ -433,7 +434,7 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&i2s2_pins_a>;
 	pinctrl-1 = <&i2s2_sleep_pins_a>;
-	status = "okay";
+	status = "disabled";
 
 	i2s2_port: port {
 		i2s2_endpoint: endpoint {
@@ -445,7 +446,7 @@
 };
 
 &ipcc {
-	status = "okay";
+	status = "disabled";
 };
 
 &iwdg1 {
@@ -462,7 +463,7 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&ltdc_pins_a>;
 	pinctrl-1 = <&ltdc_sleep_pins_a>;
-	status = "okay";
+	status = "disabled";
 
 	port {
 		ltdc_ep0_out: endpoint@0 {
@@ -501,7 +502,7 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&sai2a_pins_a>, <&sai2b_pins_b>;
 	pinctrl-1 = <&sai2a_sleep_pins_a>, <&sai2b_sleep_pins_b>;
-	status = "okay";
+	status = "disabled";
 
 	sai2a: audio-controller@4400b004 {
 		#clock-cells = <0>;
@@ -550,7 +551,7 @@
 	st,neg-edge;
 	bus-width = <4>;
 	vmmc-supply = <&v3v3>;
-	status = "okay";
+	status = "disabled";
 };
 
 &sdmmc3 {
@@ -681,14 +682,14 @@
 
 &usbh_ehci {
 	phys = <&usbphyc_port0>;
-	status = "okay";
+	status = "disabled";
 };
 
 &usbotg_hs {
 	phys = <&usbphyc_port1 0>;
 	phy-names = "usb2-phy";
 	usb-role-switch;
-	status = "okay";
+	status = "disabled";
 
 	port {
 		usbotg_hs_ep: endpoint {
@@ -698,7 +699,7 @@
 };
 
 &usbphyc {
-	status = "okay";
+	status = "disabled";
 };
 
 &usbphyc_port0 {

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -142,7 +142,8 @@ static unsigned int get_gpioz_nbpin(void)
 static TEE_Result set_gpioz_nbpin_from_dt(void)
 {
 	void *fdt = get_embedded_dt();
-	int node = fdt_path_offset(fdt, "/soc/pin-controller-z");
+	int node = fdt_node_offset_by_compatible(fdt, -1,
+						 "st,stm32mp157-z-pinctrl");
 	int count = stm32_get_gpio_count(fdt, node, GPIO_BANK_Z);
 
 	if (count < 0 || count > STM32MP1_GPIOZ_PIN_MAX_COUNT)


### PR DESCRIPTION
Changes in stm32mp15 DTSI files and ST boards DTS files without functional changes in generated images:
 - Remove commented out gpio properties (stm32mp157c-ev1.dts)
 - Disable nodes not consumed by optee (stm32mp157c-{dk1|dk2|ed1|ev1}.dts) 
 - Sync gpio-z node name with linux dtsi files (stm32mp151.dtsi)
 - Reorder node in board dts files (stm32mp157c-{dk1|dk2|ed1}.dts) 