### PR TITLE
core: add overflow checks in crypto_aes_ccm_init()

### DIFF
--- a/core/lib/libtomcrypt/ccm.c
+++ b/core/lib/libtomcrypt/ccm.c
@@ -85,6 +85,10 @@ static TEE_Result crypto_aes_ccm_init(struct crypto_authenc_ctx *aectx,
 	if (nonce_len > TEE_CCM_NONCE_MAX_LENGTH)
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	/* Check that payload_len and aad_len will fit into ints */
+	if (payload_len > INT_MAX || aad_len > INT_MAX)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	/* check the tag len */
 	if ((tag_len < 4) || (tag_len > TEE_CCM_TAG_MAX_LENGTH) ||
 	    (tag_len % 2 != 0))


### PR DESCRIPTION
aad_len and payload_len are of the type size_t which has a greater range than int which is used for the corresponding arguments when passed to ccm_init(). So to guard against wrapped or truncated values check that the variables can be in a int first before calling ccm_init().

Reviewed-by: Jerome Forissier <jerome.forissier@linaro.org>
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
