### PR TITLE
Update reported version to GP Core Internal API v1.3.1

### DIFF
--- a/lib/libutee/include/tee_api_compat.h
+++ b/lib/libutee/include/tee_api_compat.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#ifndef __TEE_API_COMPAT_H
+#define __TEE_API_COMPAT_H
+
+#endif /*__TEE_API_COMPAT_H*/

--- a/lib/libutee/include/tee_internal_api.h
+++ b/lib/libutee/include/tee_internal_api.h
@@ -7,6 +7,10 @@
 #ifndef TEE_INTERNAL_API_H
 #define TEE_INTERNAL_API_H
 
+#ifdef __TEE_API_COMPAT_H
+#error "<tee_api_compat.h> must not be included before <tee_internal_api.h>"
+#endif
+
 #include <compiler.h>
 #include <stddef.h>
 #include <tee_api_defines.h>

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -988,3 +988,6 @@ CFG_TA_STATS ?= n
 # Enables best effort mitigations against fault injected when the hardware
 # is tampered with. Details in lib/libutils/ext/include/fault_mitigation.h
 CFG_FAULT_MITIGATION ?= y
+
+# Enable TEE Internal Core API v1.1 compatibility for in-tree TAs
+CFG_TA_OPTEE_CORE_API_COMPAT_1_1 ?= y

--- a/ta/mk/build-user-ta.mk
+++ b/ta/mk/build-user-ta.mk
@@ -34,6 +34,9 @@ include mk/$(COMPILER_$(sm)).mk
 
 cppflags$(sm)	:= $(cppflags$(ta-target)) $(CPPFLAGS_$(ta-target)) \
 			-I$(ta-dev-kit-dir$(sm))/include
+ifeq ($(CFG_TA_OPTEE_CORE_API_COMPAT_1_1),y)
+cppflags$(sm)	+= -D__OPTEE_CORE_API_COMPAT_1_1=1
+endif
 cflags$(sm)	:= $(cflags$(ta-target)) $(CFLAGS_$(ta-target))
 aflags$(sm)	:= $(aflags$(ta-target))
 

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -65,6 +65,9 @@ ifneq (,$(shlibname))
 cxxflags$(sm)  += -fno-exceptions
 endif
 
+ifeq ($(CFG_TA_OPTEE_CORE_API_COMPAT_1_1),y)
+cppflags$(sm)	+= -D__OPTEE_CORE_API_COMPAT_1_1=1
+endif
 CFG_TEE_TA_LOG_LEVEL ?= 2
 cppflags$(sm) += -DTRACE_LEVEL=$(CFG_TEE_TA_LOG_LEVEL)
 


### PR DESCRIPTION
Updates the reported version to 1.3.1. Three new defines:
- TEE_CORE_API_REQUIRED_MAJOR_VERSION
- TEE_CORE_API_REQUIRED_MINOR_VERSION
- TEE_CORE_API_REQUIRED_MAINTENANCE_VERSION are added by the standard as a way for the TA to specify required version of the API. OP-TEE only supports downgrading to version 1.1.

A simplified OP-TEE specific method is also provided: Adds the configuration option CFG_TA_OPTEE_CORE_API_COMPAT_1_1 which enables TEE Internal Core API v1.1 compatibility for in-tree TAs.

The TA dev kit is also updated to recognize
CFG_TA_OPTEE_CORE_API_COMPAT_1_1 and set define
__OPTEE_CORE_API_COMPAT_1_1 to 1 if set.

These new defines does not do anything yet, but in following commits functions and types will be updated gradually until all functions and types changed in version 1.3.1 compared to the ones in v1.1 have been updated.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
