### PR TITLE
ta: pkcs11: save mechanism type on operation initialization

### DIFF
--- a/ta/pkcs11/src/processing.c
+++ b/ta/pkcs11/src/processing.c
@@ -669,7 +669,6 @@ enum pkcs11_rc entry_processing_init(struct pkcs11_client *client,
 		rc = PKCS11_CKR_MECHANISM_INVALID;
 
 	if (rc == PKCS11_CKR_OK) {
-		session->processing->mecha_type = proc_params->id;
 		DMSG("PKCS11 session %"PRIu32": init processing %s %s",
 		     session->handle, id2str_proc(proc_params->id),
 		     id2str_function(function));
@@ -971,8 +970,6 @@ enum pkcs11_rc entry_processing_key(struct pkcs11_client *client,
 		if (rc)
 			goto out;
 
-		session->processing->mecha_type = proc_params->id;
-
 		switch (function) {
 		case PKCS11_FUNCTION_DERIVE:
 			rc = derive_key_by_symm_enc(session, &out_buf,
@@ -989,8 +986,6 @@ enum pkcs11_rc entry_processing_key(struct pkcs11_client *client,
 			goto out;
 
 	} else if (processing_is_tee_asymm(proc_params->id)) {
-		session->processing->mecha_type = proc_params->id;
-
 		switch (function) {
 		case PKCS11_FUNCTION_DERIVE:
 			rc = init_asymm_operation(session, function,
@@ -1261,8 +1256,6 @@ enum pkcs11_rc entry_wrap_key(struct pkcs11_client *client,
 	rc = alloc_key_data_to_wrap(key->attributes, &key_data, &key_sz);
 	if (rc)
 		goto out;
-
-	session->processing->mecha_type = proc_params->id;
 
 	if (processing_is_tee_symm(proc_params->id)) {
 		rc = init_symm_operation(session, PKCS11_FUNCTION_ENCRYPT,

--- a/ta/pkcs11/src/processing_asymm.c
+++ b/ta/pkcs11/src/processing_asymm.c
@@ -430,7 +430,11 @@ enum pkcs11_rc init_asymm_operation(struct pkcs11_session *session,
 	if (rc)
 		return rc;
 
-	return init_tee_operation(session, proc_params, obj);
+	rc = init_tee_operation(session, proc_params, obj);
+	if (!rc)
+		session->processing->mecha_type = proc_params->id;
+
+	return rc;
 }
 
 /*

--- a/ta/pkcs11/src/processing_digest.c
+++ b/ta/pkcs11/src/processing_digest.c
@@ -88,9 +88,15 @@ allocate_tee_operation(struct pkcs11_session *session,
 enum pkcs11_rc init_digest_operation(struct pkcs11_session *session,
 				     struct pkcs11_attribute_head *proc_params)
 {
+	enum pkcs11_rc rc = PKCS11_CKR_GENERAL_ERROR;
+
 	assert(processing_is_tee_digest(proc_params->id));
 
-	return allocate_tee_operation(session, proc_params);
+	rc = allocate_tee_operation(session, proc_params);
+	if (!rc)
+		session->processing->mecha_type = proc_params->id;
+
+	return rc;
 }
 
 /*

--- a/ta/pkcs11/src/processing_symm.c
+++ b/ta/pkcs11/src/processing_symm.c
@@ -624,7 +624,11 @@ enum pkcs11_rc init_symm_operation(struct pkcs11_session *session,
 	if (rc)
 		return rc;
 
-	return init_tee_operation(session, proc_params);
+	rc = init_tee_operation(session, proc_params);
+	if (!rc)
+		session->processing->mecha_type = proc_params->id;
+
+	return rc;
 }
 
 /* Validate input buffer size as per PKCS#11 constraints */


### PR DESCRIPTION
> Sets session active processing mechanism type from init_symm_operation(),
> init_asymm_operation() and init_disgest_operation() rather than from
> their caller functions. No functional change.

During #5647 review I saw storage of `mecha_type` was not consistent accross functions. This P-R proposes to address that. @varder, may I ask you to have a look?
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
