### PR TITLE
core: support RISC-V syscall

### DIFF
--- a/lib/libutee/arch/riscv/sub.mk
+++ b/lib/libutee/arch/riscv/sub.mk
@@ -1,3 +1,3 @@
 cppflags-y += -I$(sub-dir)/../..
 
-srcs-$(CFG_RV64_$(sm)) += utee_syscalls_rv64.S
+srcs-y += utee_syscalls_rv.S

--- a/lib/libutee/arch/riscv/utee_syscalls_rv.S
+++ b/lib/libutee/arch/riscv/utee_syscalls_rv.S
@@ -14,14 +14,15 @@
 	.if \num_args > TEE_SVC_MAX_ARGS || \num_args > 8
 	.error "Too many arguments for syscall"
 	.endif
-	mv	t0, (\scn)
+	li	t0, \scn
+	li	t1, \num_args
 	ecall
 	ret
 	END_FUNC \name
 	.endm
 
 	FUNC _utee_panic, :
-	j __utee_panic
+	j	__utee_panic
 	END_FUNC _utee_panic
 
 #include <utee_syscalls_asm.S>


### PR DESCRIPTION
Add 64-bit RISC-V system call function of connection.

Signed-off-by: liushiwei <liushiwei@eswincomputing.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
