### PR TITLE
plat-totalcompute: change entrypoint of secure partition

### DIFF
--- a/core/arch/arm/plat-totalcompute/fdts/optee_sp_manifest.dts
+++ b/core/arch/arm/plat-totalcompute/fdts/optee_sp_manifest.dts
@@ -20,7 +20,7 @@
 	exception-level = <2>; /* S-EL1 */
 	execution-state = <0>; /* AARCH64 */
 	load-address = <0xfd280000>;
-	entrypoint-offset = <0x1000>;
+	entrypoint-offset = <0x4000>;
 	xlat-granule = <0>; /* 4KiB */
 	boot-order = <0>;
 	messaging-method = <0x3>; /* Direct request/response supported */


### PR DESCRIPTION
The default image offset is changed from 0x1000 to 0x4000 to accomodate the boot protocol information.

Signed-off-by: Davidson K <davidson.kumaresan@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
