### PR TITLE
[plat-sam] sama5d2 improvements

### DIFF
--- a/core/arch/arm/dts/at91-sama5d27_som1.dtsi
+++ b/core/arch/arm/dts/at91-sama5d27_som1.dtsi
@@ -106,7 +106,7 @@
 				};
 			};
 
-			pinctrl@fc038000 {
+			pinctrl@fc039000 {
 				pinctrl_i2c0_default: i2c0_default {
 					pinmux = <PIN_PD21__TWD0>,
 						 <PIN_PD22__TWCK0>;

--- a/core/arch/arm/dts/at91-sama5d27_som1_ek.dts
+++ b/core/arch/arm/dts/at91-sama5d27_som1_ek.dts
@@ -223,7 +223,7 @@
 				status = "disabled";
 			};
 
-			pinctrl@fc038000 {
+			pinctrl@fc039000 {
 
 				pinctrl_can1_default: can1_default {
 					pinmux = <PIN_PC26__CANTX1>,

--- a/core/arch/arm/dts/at91-sama5d2_xplained.dts
+++ b/core/arch/arm/dts/at91-sama5d2_xplained.dts
@@ -419,7 +419,7 @@
 				status = "okay";
 			};
 
-			pinctrl@fc038000 {
+			pinctrl@fc039000 {
 				/*
 				 * There is no real pinmux for ADC, if the pin
 				 * is not requested by another peripheral then

--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -1095,9 +1095,9 @@
 				status = "disabled";
 			};
 
-			pioA: pinctrl@fc038000 {
+			pioA: pinctrl@fc039000 {
 				compatible = "atmel,sama5d2-pinctrl";
-				reg = <0xfc038000 0x600>;
+				reg = <0xfc039000 0x600>;
 				interrupts = <18 IRQ_TYPE_LEVEL_HIGH 7>,
 					     <68 IRQ_TYPE_LEVEL_HIGH 7>,
 					     <69 IRQ_TYPE_LEVEL_HIGH 7>,

--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -711,6 +711,8 @@
 
 				clocks = <&slow_xtal>;
 				#clock-cells = <0>;
+				status = "disabled";
+				secure-status = "okay";
 			};
 
 			rtc: rtc@f80480b0 {

--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -678,6 +678,8 @@
 				compatible = "atmel,sama5d3-rstc";
 				reg = <0xf8048000 0x10>;
 				clocks = <&clk32k>;
+				status = "disabled";
+				secure-status = "okay";
 			};
 
 			shutdown_controller: shdwc@f8048010 {
@@ -687,6 +689,8 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 				atmel,wakeup-rtc-timer;
+				status = "disabled";
+				secure-status = "okay";
 			};
 
 			pit: timer@f8048030 {

--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -286,6 +286,8 @@
 				#clock-cells = <2>;
 				clocks = <&clk32k>, <&main_xtal>;
 				clock-names = "slow_clk", "main_xtal";
+				status = "disabled";
+				secure-status = "okay";
 			};
 
 			qspi0: spi@f0020000 {

--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -516,6 +516,8 @@
 			sfr: sfr@f8030000 {
 				compatible = "atmel,sama5d2-sfr", "syscon";
 				reg = <0xf8030000 0x98>;
+				status = "disabled";
+				secure-status = "okay";
 			};
 
 			flx0: flexcom@f8034000 {

--- a/core/drivers/atmel_rstc.c
+++ b/core/drivers/atmel_rstc.c
@@ -6,6 +6,8 @@
 #include <drivers/atmel_rstc.h>
 #include <io.h>
 #include <kernel/dt.h>
+#include <matrix.h>
+#include <sama5d2.h>
 #include <tee_api_defines.h>
 #include <tee_api_types.h>
 #include <types_ext.h>
@@ -42,6 +44,11 @@ static TEE_Result atmel_rstc_probe(const void *fdt, int node,
 
 {
 	size_t size = 0;
+
+	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	matrix_configure_periph_secure(AT91C_ID_SYS);
 
 	if (dt_map_dev(fdt, node, &rstc_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;

--- a/core/drivers/atmel_shdwc.c
+++ b/core/drivers/atmel_shdwc.c
@@ -12,6 +12,8 @@
 #include <kernel/dt.h>
 #include <kernel/thread.h>
 #include <libfdt.h>
+#include <matrix.h>
+#include <sama5d2.h>
 #include <stdbool.h>
 #include <tee_api_defines.h>
 #include <tee_api_types.h>
@@ -149,6 +151,11 @@ static TEE_Result atmel_shdwc_probe(const void *fdt, int node,
 	 * any other one to invalidate TLB/I-Cache.
 	 */
 	COMPILE_TIME_ASSERT(CFG_TEE_CORE_NB_CORE == 1);
+
+	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	matrix_configure_periph_secure(AT91C_ID_SYS);
 
 	if (dt_map_dev(fdt, node, &shdwc_base, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;

--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -174,6 +174,8 @@ static void atmel_wdt_init_hw(struct atmel_wdt *wdt)
 
 	/* Enable interrupt, and disable watchdog in debug and idle */
 	wdt->mr |= WDT_MR_WDFIEN | WDT_MR_WDDBGHLT | WDT_MR_WDIDLEHLT;
+	/* Enable watchdog reset */
+	wdt->mr |= WDT_MR_WDRSTEN;
 	wdt->mr |= WDT_MR_WDD_SET(SEC_TO_WDT(WDT_MAX_TIMEOUT));
 	wdt->mr |= WDT_MR_WDV_SET(SEC_TO_WDT(WDT_DEFAULT_TIMEOUT));
 


### PR DESCRIPTION
This series embeds multiple improvements for the sama5d2 support. It mainly target at improving secure status for multiple devices as well as enabling reboot on watchdog reset.
