### PR TITLE
[RFC] User libname.map as version script if available

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -62,7 +62,11 @@ ifeq ($(CFG_ULIBS_SHARED),y)
 ifeq ($(sm)-$(CFG_TA_BTI),ta_arm64-y)
 lib-ldflags$(libuuid) += $$(call ld-option,-z force-bti) --fatal-warnings
 endif
-$(lib-shlibfile): $(objs) $(lib-needed-so-files)
+ifneq ($(wildcard $(libname).map),)
+lib-ldflags$(libuuid) += --version-script=$(libname).map
+libdeps += $(shlibname).map
+endif
+$(lib-shlibfile): $(objs) $(lib-needed-so-files) $(libdeps)
 	@$(cmd-echo-silent) '  LD      $$@'
 	@mkdir -p $$(dir $$@)
 	$$(q)$$(LD$(sm)) $(lib-ldflags) -shared -z max-page-size=4096 \

--- a/ta/arch/arm/link_shlib.mk
+++ b/ta/arch/arm/link_shlib.mk
@@ -18,6 +18,10 @@ cleanfiles += $(link-out-dir)/$(shlibuuid).elf
 cleanfiles += $(link-out-dir)/$(shlibuuid).ta
 
 shlink-ldflags  = $(LDFLAGS)
+ifneq ($(wildcard $(shlibname).map),)
+shlink-ldflags += --version-script=$(shlibname).map
+libdeps += $(shlibname).map
+endif
 shlink-ldflags += -shared -z max-page-size=4096
 shlink-ldflags += $(call ld-option,-z separate-loadable-segments)
 ifeq ($(sm)-$(CFG_TA_BTI),ta_arm64-y)


### PR DESCRIPTION
If a shared library is linked and a version script is available with the name `$(libname).map`, pass it to the linker as: `--version-script=$(libname).map`

This enables symbol versioning of the shared library.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
