### PR TITLE
libutee: clarify that the used version is still 1.1

### DIFF
--- a/lib/libutee/include/tee_api_defines.h
+++ b/lib/libutee/include/tee_api_defines.h
@@ -4,21 +4,26 @@
  * Copyright (c) 2022, Linaro Limited
  */
 
-/* Based on GP TEE Internal Core API Specification Version 1.3.1 */
+/* Based on GP TEE Internal Core API Specification Version 1.1 */
 
 #ifndef TEE_API_DEFINES_H
 #define TEE_API_DEFINES_H
 
 #define TEE_CORE_API_MAJOR_VERSION		1U
-#define TEE_CORE_API_MINOR_VERSION		3U
-#define TEE_CORE_API_MAINTENANCE_VERSION	1U
+#define TEE_CORE_API_MINOR_VERSION		1U
+#define TEE_CORE_API_MAINTENANCE_VERSION	0U
 #define TEE_CORE_API_VERSION \
 			((TEE_CORE_API_MAJOR_VERSION << 24) | \
 			 (TEE_CORE_API_MINOR_VERSION << 16) | \
 			 (TEE_CORE_API_MAINTENANCE_VERSION << 8))
-#define TEE_CORE_API_1_3_1
+#define TEE_CORE_API_1_1
 
 /*
+ * The things that follows below to select compatibility version 1.1 doesn't
+ * do much useful at the moment since OP-TEE is already compatible with that
+ * version by default. However, that will change when a newer version of
+ * this API is provided.
+ *
  * Below follows the GP defined way of letting a TA define that it wants an
  * API compatible with version 1.1 or the latest. An alternative approach
  * is to set __OPTEE_CORE_API_COMPAT_1_1, but that's an OP-TEE extension.


### PR DESCRIPTION
Clarifies that the used version in TEE Internal Core API is still v1.1. Changes the version defines back to v1.1.0.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
