### PR TITLE
core: crypto: fix TEE_ATTR_EDDSA_PREHASH interpretation

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2192,7 +2192,14 @@ tee_svc_obj_ed25519_parse_params(const TEE_Attribute *params, size_t num_params,
 	for (n = 0; n < num_params; n++) {
 		switch (params[n].attributeID) {
 		case TEE_ATTR_EDDSA_PREHASH:
-			*ph_flag = true;
+			if (params[n].content.value.b)
+				return TEE_ERROR_BAD_PARAMETERS;
+			if (!params[n].content.value.a)
+				*ph_flag = false;
+			else if (params[n].content.value.a == 1)
+				*ph_flag = true;
+			else
+				return TEE_ERROR_BAD_PARAMETERS;
 			break;
 
 		case TEE_ATTR_EDDSA_CTX:


### PR DESCRIPTION
Commit 0aaad418ac8b ("core: crypto: add Ed25519 support") introduced support for the ED25519 algorithm. This included parsing a TEE_ATTR_EDDSA_PREHASH parameter that unfortunately was not fully compliant with the standard.  So fix this with a more strict interpretation of TEE_ATTR_EDDSA_PREHASH as described in the specification.

Fixes: 0aaad418ac8b ("core: crypto: add Ed25519 support")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>


@varder FYI
