### PR TITLE
Support NVMEM layout for BSEC

### DIFF
--- a/core/arch/arm/dts/stm32mp131.dtsi
+++ b/core/arch/arm/dts/stm32mp131.dtsi
@@ -194,6 +194,41 @@
 			reg = <0x5c005000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			cfg0_otp: cfg0_otp@0 {
+				reg = <0x0 0x2>;
+			};
+			part_number_otp: part_number_otp@4 {
+				reg = <0x4 0x2>;
+			};
+			monotonic_otp: monotonic_otp@10 {
+				reg = <0x10 0x4>;
+			};
+			nand_otp: cfg9_otp@24 {
+				reg = <0x24 0x4>;
+			};
+			uid_otp: uid_otp@34 {
+				reg = <0x34 0xc>;
+			};
+			hw2_otp: hw2_otp@48 {
+				reg = <0x48 0x4>;
+			};
+			ts_cal1: calib@5c {
+				reg = <0x5c 0x2>;
+			};
+			ts_cal2: calib@5e {
+				reg = <0x5e 0x2>;
+			};
+			pkh_otp: pkh_otp@60 {
+				reg = <0x60 0x20>;
+			};
+			ethernet_mac1_address: mac1@e4 {
+				reg = <0xe4 0xc>;
+				st,non-secure-otp;
+			};
+			oem_enc_key: oem_enc_key@170 {
+				reg = <0x170 0x10>;
+			};
 		};
 
 		tzc400: tzc@5c006000 {

--- a/core/arch/arm/dts/stm32mp135f-dk.dts
+++ b/core/arch/arm/dts/stm32mp135f-dk.dts
@@ -58,6 +58,13 @@
 	};
 };
 
+&bsec {
+	board_id: board_id@f0 {
+		reg = <0xf0 0x4>;
+		st,non-secure-otp;
+	};
+};
+
 &rcc {
 	compatible = "st,stm32mp13-rcc", "syscon";
 

--- a/core/arch/arm/dts/stm32mp151.dtsi
+++ b/core/arch/arm/dts/stm32mp151.dtsi
@@ -1600,13 +1600,38 @@
 			reg = <0x5c005000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <1>;
+
+			cfg0_otp: cfg0_otp@0 {
+				reg = <0x0 0x1>;
+			};
+			part_number_otp: part_number_otp@4 {
+				reg = <0x4 0x1>;
+			};
+			monotonic_otp: monotonic_otp@10 {
+				reg = <0x10 0x4>;
+			};
+			nand_otp: nand_otp@24 {
+				reg = <0x24 0x4>;
+			};
+			uid_otp: uid_otp@34 {
+				reg = <0x34 0xc>;
+			};
+			package_otp: package_otp@40 {
+				reg = <0x40 0x4>;
+			};
+			hw2_otp: hw2_otp@48 {
+				reg = <0x48 0x4>;
+			};
 			ts_cal1: calib@5c {
 				reg = <0x5c 0x2>;
 			};
 			ts_cal2: calib@5e {
 				reg = <0x5e 0x2>;
 			};
-			mac_addr: mac_addr@e4 {
+			pkh_otp: pkh_otp@60 {
+				reg = <0x60 0x20>;
+			};
+			ethernet_mac_address: mac@e4 {
 				reg = <0xe4 0x8>;
 				st,non-secure-otp;
 			};

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -485,6 +485,8 @@ TEE_Result stm32_get_iwdg_otp_config(paddr_t pbase,
 				     struct stm32_iwdg_otp_data *otp_data)
 {
 	unsigned int idx = 0;
+	uint32_t otp_id = 0;
+	size_t bit_len = 0;
 	uint32_t otp_value = 0;
 
 	switch (pbase) {
@@ -498,7 +500,11 @@ TEE_Result stm32_get_iwdg_otp_config(paddr_t pbase,
 		panic();
 	}
 
-	if (stm32_bsec_read_otp(&otp_value, HW2_OTP))
+	if (stm32_bsec_find_otp_in_nvmem_layout("hw2_otp", &otp_id, &bit_len) ||
+	    bit_len != 32)
+		panic();
+
+	if (stm32_bsec_read_otp(&otp_value, otp_id))
 		panic();
 
 	otp_data->hw_enabled = otp_value &

--- a/core/include/drivers/stm32_bsec.h
+++ b/core/include/drivers/stm32_bsec.h
@@ -147,4 +147,15 @@ TEE_Result stm32_bsec_otp_lock(uint32_t service);
  */
 bool stm32_bsec_nsec_can_access_otp(uint32_t otp_id);
 
+/*
+ * Find and get OTP location from its name.
+ * @name: sub-node name to look up.
+ * @otp_id: pointer to output OTP number or NULL.
+ * @otp_bit_len: pointer to output OTP length in bits or NULL.
+ * Return a TEE_Result compliant status
+ */
+TEE_Result stm32_bsec_find_otp_in_nvmem_layout(const char *name,
+					       uint32_t *otp_id,
+					       size_t *otp_bit_len);
+
 #endif /*__STM32_BSEC_H*/


### PR DESCRIPTION
Support the NVMEM layout that is used to describe OTP mapping in the device-tree.

This allows drivers to find an OTP location (BSEC word number and bit size) from the OTP string identifier, name of the cell in device tree. No more hardcoded OTP index :)
