### PR TITLE
ci: drop optee_rust patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,6 @@ jobs:
           WD=$(pwd)
           sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
           sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8/optee_rust && curl https://github.com/apache/incubator-teaclave-trustzone-sdk/commit/6af7f7eb3c1910866598a82b66537fd539ee150b.patch | git am"
           sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
           sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
 


### PR DESCRIPTION
Now that optee_rust has been updated [1] ("qemu_v8: Pin optee_rust to the latest version"), drop the patch in ci.yml.

Link: [1] https://github.com/OP-TEE/manifest/commit/286184404963afc4b298dfd94e3463e00177cc45
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
