### PR TITLE
Add BSEC otp provisionning

### DIFF
--- a/core/arch/arm/dts/stm32mp135f-dk.dts
+++ b/core/arch/arm/dts/stm32mp135f-dk.dts
@@ -65,6 +65,10 @@
 	};
 };
 
+&oem_enc_key {
+	st,non-secure-otp-provisioning;
+};
+
 &rcc {
 	compatible = "st,stm32mp13-rcc", "syscon";
 


### PR DESCRIPTION
Add a way for non-secure world to provision One Time Programmed resources using "st,non-secure-otp" device tree property.