### PR TITLE
riscv: kernel: initial implementation of thread management routines for RISC-V 

### DIFF
--- a/core/arch/riscv/include/kernel/arch_scall.h
+++ b/core/arch/riscv/include/kernel/arch_scall.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#ifndef __KERNEL_ARCH_SCALL_H
+#define __KERNEL_ARCH_SCALL_H
+
+#include <kernel/thread.h>
+#include <riscv.h>
+#include <types_ext.h>
+
+static inline void scall_get_max_args(struct thread_scall_regs *regs,
+				      size_t *scn, size_t *max_args)
+{
+	*scn = regs->t0;
+	*max_args = regs->t1;
+}
+
+static inline void scall_set_retval(struct thread_scall_regs *regs,
+				    uint32_t ret_val)
+{
+	regs->a0 = ret_val;
+}
+
+static inline void scall_set_sys_return_regs(struct thread_scall_regs *regs,
+					     bool panic, uint32_t panic_code)
+{
+	regs->a1 = panic;
+	regs->a2 = panic_code;
+}
+
+#endif /*__KERNEL_ARCH_SCALL_H*/

--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  */
 
 #ifndef __KERNEL_THREAD_ARCH_H
@@ -14,12 +14,13 @@
 
 #ifndef __ASSEMBLER__
 
-#define THREAD_CORE_LOCAL_ALIGNED __aligned(2 * RISCV_XLEN_BYTES)
+#define THREAD_CORE_LOCAL_ALIGNED __aligned(16)
 
 struct thread_pauth_keys {
 };
 
 struct thread_core_local {
+	unsigned long x[4];
 	uint32_t hart_id;
 	vaddr_t tmp_stack_va_end;
 	short int curr_thread;
@@ -32,6 +33,9 @@ struct thread_core_local {
 	bool stackcheck_recursion;
 #endif
 } THREAD_CORE_LOCAL_ALIGNED;
+
+struct thread_user_vfp_state {
+};
 
 struct thread_smc_args {
 	unsigned long a0;	/* SBI function ID */
@@ -52,6 +56,8 @@ struct thread_abort_regs {
 	unsigned long t0;
 	unsigned long t1;
 	unsigned long t2;
+	unsigned long s0;
+	unsigned long s1;
 	unsigned long a0;
 	unsigned long a1;
 	unsigned long a2;
@@ -60,13 +66,63 @@ struct thread_abort_regs {
 	unsigned long a5;
 	unsigned long a6;
 	unsigned long a7;
+	unsigned long s2;
+	unsigned long s3;
+	unsigned long s4;
+	unsigned long s5;
+	unsigned long s6;
+	unsigned long s7;
+	unsigned long s8;
+	unsigned long s9;
+	unsigned long s10;
+	unsigned long s11;
+	unsigned long t3;
+	unsigned long t4;
+	unsigned long t5;
+	unsigned long t6;
+	unsigned long status;
+	unsigned long cause;
+	unsigned long epc;
+	unsigned long tval;
+	unsigned long satp;
+};
+
+struct thread_trap_regs {
+	unsigned long ra;
+	unsigned long sp;
+	unsigned long gp;
+	unsigned long tp;
+	unsigned long t0;
+	unsigned long t1;
+	unsigned long t2;
+	unsigned long s0;
+	unsigned long s1;
+	unsigned long a0;
+	unsigned long a1;
+	unsigned long a2;
+	unsigned long a3;
+	unsigned long a4;
+	unsigned long a5;
+	unsigned long a6;
+	unsigned long a7;
+	unsigned long s2;
+	unsigned long s3;
+	unsigned long s4;
+	unsigned long s5;
+	unsigned long s6;
+	unsigned long s7;
+	unsigned long s8;
+	unsigned long s9;
+	unsigned long s10;
+	unsigned long s11;
 	unsigned long t3;
 	unsigned long t4;
 	unsigned long t5;
 	unsigned long t6;
 	unsigned long epc;
 	unsigned long status;
-};
+	unsigned long satp;
+} __aligned(16);
 
 struct thread_scall_regs {
 	unsigned long a0;
@@ -79,19 +135,21 @@ struct thread_scall_regs {
 	unsigned long a7;
 	unsigned long t0;
 	unsigned long t1;
-	unsigned long t2;
-	unsigned long t3;
-	unsigned long t4;
-	unsigned long t5;
-	unsigned long t6;
 	unsigned long ra;
+	unsigned long sp;
 	unsigned long status;
-};
+} __aligned(16);
 
 struct thread_ctx_regs {
 	unsigned long ra;
 	unsigned long sp;
-	unsigned long fp;
+	unsigned long gp;
+	unsigned long tp;
+	unsigned long t0;
+	unsigned long t1;
+	unsigned long t2;
+	unsigned long s0;
+	unsigned long s1;
 	unsigned long a0;
 	unsigned long a1;
 	unsigned long a2;
@@ -100,6 +158,20 @@ struct thread_ctx_regs {
 	unsigned long a5;
 	unsigned long a6;
 	unsigned long a7;
+	unsigned long s2;
+	unsigned long s3;
+	unsigned long s4;
+	unsigned long s5;
+	unsigned long s6;
+	unsigned long s7;
+	unsigned long s8;
+	unsigned long s9;
+	unsigned long s10;
+	unsigned long s11;
+	unsigned long t3;
+	unsigned long t4;
+	unsigned long t5;
+	unsigned long t6;
 	unsigned long status;
 };
 
@@ -109,11 +181,47 @@ struct user_mode_ctx;
  * These flags should vary according to the privilege mode selected
  * to run OP-TEE core on (M/HS/S). For now default to S-Mode.
  */
-#define THREAD_EXCP_FOREIGN_INTR	MIP_SEIP
-#define THREAD_EXCP_NATIVE_INTR		MIP_SSIP
-#define THREAD_EXCP_ALL			(THREAD_EXCP_FOREIGN_INTR |	\
-					 THREAD_EXCP_NATIVE_INTR |	\
-					 MIP_STIP)
+
+#define CSR_XIE_SIE	BIT64(IRQ_XSOFT)
+#define CSR_XIE_TIE	BIT64(IRQ_XTIMER)
+#define CSR_XIE_EIE	BIT64(IRQ_XEXT)
+
+#define THREAD_EXCP_FOREIGN_INTR	CSR_XIE_EIE
+#define THREAD_EXCP_NATIVE_INTR	        (CSR_XIE_SIE | CSR_XIE_TIE)
+#define THREAD_EXCP_ALL			(THREAD_EXCP_FOREIGN_INTR |\
+					 THREAD_EXCP_NATIVE_INTR)
+
+#ifdef CFG_WITH_VFP
+uint32_t thread_kernel_enable_vfp(void);
+void thread_kernel_disable_vfp(uint32_t state);
+void thread_kernel_save_vfp(void);
+void thread_kernel_restore_vfp(void);
+void thread_user_enable_vfp(struct thread_user_vfp_state *uvfp);
+#else /*CFG_WITH_VFP*/
+static inline void thread_kernel_save_vfp(void)
+{
+}
+
+static inline void thread_kernel_restore_vfp(void)
+{
+}
+#endif /*CFG_WITH_VFP*/
+#ifdef CFG_WITH_VFP
+void thread_user_save_vfp(void);
+#else
+static inline void thread_user_save_vfp(void)
+{
+}
+#endif
+#ifdef CFG_WITH_VFP
+void thread_user_clear_vfp(struct user_mode_ctx *uctx);
+#else
+static inline void thread_user_clear_vfp(struct user_mode_ctx *uctx __unused)
+{
+}
+#endif
+
+vaddr_t thread_get_saved_thread_sp(void);
 
 static inline void thread_get_user_kcode(struct mobj **mobj, size_t *offset,
 					 vaddr_t *va, size_t *sz)
@@ -132,6 +240,9 @@ static inline void thread_get_user_kdata(struct mobj **mobj, size_t *offset,
 	*va = 0;
 	*sz = 0;
 }
+
+bool thread_disable_prealloc_rpc_cache(uint64_t *cookie);
+bool thread_enable_prealloc_rpc_cache(void);
 
 #endif /*__ASSEMBLER__*/
 #endif /*__KERNEL_THREAD_ARCH_H*/

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#ifndef __KERNEL_THREAD_PRIVATE_ARCH_H
+#define __KERNEL_THREAD_PRIVATE_ARCH_H
+
+#ifndef __ASSEMBLER__
+
+#include <kernel/thread.h>
+
+#define STACK_TMP_OFFS		0
+
+#if defined(__clang__) && !defined(__OPTIMIZE_SIZE__)
+#define STACK_TMP_SIZE		(4096 + STACK_TMP_OFFS + CFG_STACK_TMP_EXTRA)
+#else
+#define STACK_TMP_SIZE		(2048 + STACK_TMP_OFFS + CFG_STACK_TMP_EXTRA)
+#endif
+
+#define STACK_THREAD_SIZE	(8192 + CFG_STACK_THREAD_EXTRA)
+
+#if TRACE_LEVEL > 0
+#define STACK_ABT_SIZE		3072
+#else
+#define STACK_ABT_SIZE		1024
+#endif
+
+#define STACK_CHECK_EXTRA	0
+
+#define THREAD_RPC_NUM_ARGS     4
+
+#define	TRAP_MODE_KERNEL	0
+#define	TRAP_MODE_USER		1
+
+struct thread_user_mode_rec {
+	unsigned long ctx_regs_ptr;
+	unsigned long exit_status0_ptr;
+	unsigned long exit_status1_ptr;
+	unsigned long pad;
+	/*
+	 * x[] is used to save registers for user/kernel context-switching
+	 * 0-3: ra-tp
+	 * 4-6: s0-s1
+	 * 6-15: s2-s11
+	 */
+	unsigned long x[16];
+};
+
+extern long thread_user_kcode_offset;
+
+void thread_trap_handler(long cause, unsigned long epc,
+			 struct thread_trap_regs *regs,
+			 bool user);
+/*
+ * Initializes TVEC for current hart. Called by thread_init_per_cpu()
+ */
+void thread_init_tvec(void);
+void thread_trap_vect(void);
+void thread_trap_vect_end(void);
+
+/*
+ * Private functions made available for thread_rv.S
+ */
+int thread_state_suspend(uint32_t flags, uint32_t status, vaddr_t pc);
+void thread_resume(struct thread_ctx_regs *regs);
+uint32_t __thread_enter_user_mode(struct thread_ctx_regs *regs,
+				  uint32_t *exit_status0,
+				  uint32_t *exit_status1);
+void *thread_get_tmp_sp(void);
+void thread_state_free(void);
+struct thread_ctx_regs *thread_get_ctx_regs(void);
+void thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
+			  uint32_t a4, uint32_t a5);
+void thread_resume_from_rpc(uint32_t thread_id, uint32_t a0, uint32_t a1,
+			    uint32_t a2, uint32_t a3);
+void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]);
+void thread_scall_handler(struct thread_scall_regs *regs);
+void thread_exit_user_mode(unsigned long a0, unsigned long a1,
+			   unsigned long a2, unsigned long a3,
+			   unsigned long sp, unsigned long pc,
+			   unsigned long status);
+
+#endif /*__ASSEMBLER__*/
+#endif /*__KERNEL_THREAD_PRIVATE_ARCH_H*/

--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -25,6 +25,26 @@
 #define LDR       ld
 #endif
 
+/* Bind registers to their ABI names */
+#define REG_RA	1
+#define REG_SP	2
+#define REG_GP	3
+#define REG_TP	4
+#define REG_T0	5
+#define REG_T2	7
+#define REG_S0	8
+#define REG_S1	9
+#define REG_A0	10
+#define REG_A1	11
+#define REG_A2	12
+#define REG_A3	13
+#define REG_A5	15
+#define REG_A7	17
+#define REG_S2	18
+#define REG_S11	27
+#define REG_T3	28
+#define REG_T6	31
+
 #if defined(CFG_RISCV_M_MODE)
 #define CSR_MODE_OFFSET	PRV_M
 #define XRET			mret

--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
  */
 
 #ifndef RISCV_H
@@ -33,7 +33,7 @@
 #define XRET			sret
 #endif
 
-#define CSR_MODE_BITS	SHIFT_U64(CSR_MODE_OFFSET, 8)
+#define CSR_MODE_BITS		SHIFT_U64(CSR_MODE_OFFSET, 8)
 
 #define CSR_XSTATUS		(CSR_MODE_BITS | 0x000)
 #define CSR_XIE			(CSR_MODE_BITS | 0x004)
@@ -43,6 +43,20 @@
 #define CSR_XCAUSE		(CSR_MODE_BITS | 0x042)
 #define CSR_XTVAL		(CSR_MODE_BITS | 0x043)
 #define CSR_XIP			(CSR_MODE_BITS | 0x044)
+
+#define IRQ_XSOFT		(CSR_MODE_OFFSET + 0)
+#define IRQ_XTIMER		(CSR_MODE_OFFSET + 4)
+#define IRQ_XEXT		(CSR_MODE_OFFSET + 8)
+
+#define CSR_XIE_SIE		BIT64(IRQ_XSOFT)
+#define CSR_XIE_TIE		BIT64(IRQ_XTIMER)
+#define CSR_XIE_EIE		BIT64(IRQ_XEXT)
+
+#define CSR_XSTATUS_IE		BIT(CSR_MODE_OFFSET + 0)
+#define CSR_XSTATUS_PIE		BIT(CSR_MODE_OFFSET + 4)
+#define CSR_XSTATUS_SPP		BIT(8)
+#define CSR_XSTATUS_SUM		BIT(18)
+#define CSR_XSTATUS_MXR		BIT(19)
 
 #ifndef __ASSEMBLER__
 

--- a/core/arch/riscv/include/riscv_macros.S
+++ b/core/arch/riscv/include/riscv_macros.S
@@ -1,9 +1,54 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2022 NXP
+ * Copyright 2022-2023 NXP
+ * Copyright (c) 2015, Linaro Limited
  */
 
 	.altmacro
+
+
+	/*
+	 * This helper macro concatenates instr_prefix, instr_suffix, to
+	 * create a l(w,d)/s(w,d) instruction.
+	 */
+	.macro __do_reg instr_prefix, base_reg, base_offs, reg
+		\instr_prefix x\reg, \base_offs(\base_reg)
+	.endm
+
+	/*
+	 * This helper macro uses recursion to create a loop with a single
+	 * load/store.
+	 */
+	.macro _do_regs instr_prefix, reg_bytes, base_reg, base_offs, \
+			from_regnum, to_regnum
+
+		.if (\to_regnum - \from_regnum + 1) > 1
+			_do_regs \instr_prefix, \reg_bytes, \base_reg, \
+				%(\base_offs + 1 * \reg_bytes), \
+				%(\from_regnum + 1), \to_regnum
+		.endif
+
+		__do_reg \instr_prefix, \base_reg, \base_offs, \from_regnum
+	.endm
+
+	/*
+	 * Stores registers x[from_regnum]..x[to_regnum] at
+	 * [base_reg, #base_offs]
+	 */
+	.macro store_xregs base_reg, base_offs, from_regnum, to_regnum
+		_do_regs STR, RISCV_XLEN_BYTES, \base_reg, \base_offs, \
+			 \from_regnum, \to_regnum
+	.endm
+
+	/*
+	 * Loads registers x[from_regnum]..x[to_regnum] at
+	 * [base_reg, #base_offs]
+	 */
+	.macro load_xregs base_reg, base_offs, from_regnum, to_regnum
+		_do_regs LDR, RISCV_XLEN_BYTES, \base_reg, \base_offs, \
+			 \from_regnum, \to_regnum
+	.endm
+
 	/*
 	 * Multiplication macro for RISC-V harts without M extension.
 	 */

--- a/core/arch/riscv/kernel/abort.c
+++ b/core/arch/riscv/kernel/abort.c
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022-2023 NXP
+ * Copyright (c) 2015-2022, Linaro Limited
+ */
+
+#include <kernel/abort.h>
+#include <kernel/linker.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/tee_ta_manager.h>
+#include <kernel/thread_private.h>
+#include <kernel/user_mode_ctx.h>
+#include <mm/core_mmu.h>
+#include <mm/mobj.h>
+#include <riscv.h>
+#include <tee/tee_svc.h>
+#include <trace.h>
+#include <unw/unwind.h>
+
+enum fault_type {
+	FAULT_TYPE_USER_MODE_PANIC,
+	FAULT_TYPE_USER_MODE_VFP,
+	FAULT_TYPE_PAGE_FAULT,
+	FAULT_TYPE_IGNORE,
+};
+
+#ifdef CFG_UNWIND
+
+/* Kernel mode unwind */
+static void __print_stack_unwind(struct abort_info *ai)
+{
+	struct unwind_state_rv state = {
+		.fp = ai->regs->s0,
+		.sp = ai->regs->sp,
+		.pc = ai->regs->epc,
+	};
+
+	print_stack_rv(&state, thread_stack_start(), thread_stack_size());
+}
+
+#else /* CFG_UNWIND */
+static void __print_stack_unwind(struct abort_info *ai __unused)
+{
+}
+#endif /* CFG_UNWIND */
+
+static __maybe_unused const char *abort_type_to_str(uint32_t abort_type)
+{
+	if (abort_type == ABORT_TYPE_DATA)
+		return "data";
+	if (abort_type == ABORT_TYPE_PREFETCH)
+		return "prefetch";
+	return "undef";
+}
+
+static __maybe_unused const char *
+fault_to_str(uint32_t abort_type, uint32_t fault_descr)
+{
+	/* fault_descr is only valid for data or prefetch abort */
+	if (abort_type != ABORT_TYPE_DATA && abort_type != ABORT_TYPE_PREFETCH)
+		return "";
+
+	switch (core_mmu_get_fault_type(fault_descr)) {
+	case CORE_MMU_FAULT_ALIGNMENT:
+		return " (alignment fault)";
+	case CORE_MMU_FAULT_TRANSLATION:
+		return " (translation fault)";
+	case CORE_MMU_FAULT_READ_PERMISSION:
+		return " (read permission fault)";
+	case CORE_MMU_FAULT_WRITE_PERMISSION:
+		return " (write permission fault)";
+	case CORE_MMU_FAULT_TAG_CHECK:
+		return " (tag check fault)";
+	default:
+		return "";
+	}
+}
+
+static __maybe_unused void
+__print_abort_info(struct abort_info *ai __maybe_unused,
+		   const char *ctx __maybe_unused)
+{
+	__maybe_unused size_t core_pos = 0;
+
+	if (abort_is_user_exception(ai))
+		core_pos = thread_get_tsd()->abort_core;
+	else
+		core_pos = get_core_pos();
+
+	EMSG_RAW("");
+	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s",
+		 ctx, abort_type_to_str(ai->abort_type), ai->va,
+		 fault_to_str(ai->abort_type, ai->fault_descr));
+	EMSG_RAW("cpu\t#%zu", core_pos);
+	EMSG_RAW("cause\t%016" PRIxPTR " epc\t%016" PRIxPTR,
+		 ai->regs->cause, ai->regs->epc);
+	EMSG_RAW("tval\t%016" PRIxPTR " status\t%016" PRIxPTR,
+		 ai->regs->tval, ai->regs->status);
+	EMSG_RAW("ra\t%016" PRIxPTR " sp\t%016" PRIxPTR,
+		 ai->regs->ra, ai->regs->sp);
+	EMSG_RAW("gp\t%016" PRIxPTR " tp\t%016" PRIxPTR,
+		 ai->regs->gp, ai->regs->tp);
+	EMSG_RAW("t0\t%016" PRIxPTR " t1\t%016" PRIxPTR,
+		 ai->regs->t0, ai->regs->t1);
+	EMSG_RAW("t2\t%016" PRIxPTR " s0\t%016" PRIxPTR,
+		 ai->regs->t2, ai->regs->s0);
+	EMSG_RAW("s1\t%016" PRIxPTR " a0\t%016" PRIxPTR,
+		 ai->regs->s1, ai->regs->a0);
+	EMSG_RAW("a1\t%016" PRIxPTR " a2\t%016" PRIxPTR,
+		 ai->regs->a1, ai->regs->a2);
+	EMSG_RAW("a3\t%016" PRIxPTR " a4\t%016" PRIxPTR,
+		 ai->regs->a3, ai->regs->a4);
+	EMSG_RAW("a5\t%016" PRIxPTR " a5\t%016" PRIxPTR,
+		 ai->regs->a5, ai->regs->a5);
+	EMSG_RAW("a6\t%016" PRIxPTR " a7\t%016" PRIxPTR,
+		 ai->regs->a6, ai->regs->a7);
+	EMSG_RAW("s2\t%016" PRIxPTR " s3\t%016" PRIxPTR,
+		 ai->regs->s2, ai->regs->s3);
+	EMSG_RAW("s4\t%016" PRIxPTR " s5\t%016" PRIxPTR,
+		 ai->regs->s4, ai->regs->s5);
+	EMSG_RAW("s6\t%016" PRIxPTR " s7\t%016" PRIxPTR,
+		 ai->regs->s6, ai->regs->s7);
+	EMSG_RAW("s8\t%016" PRIxPTR " s9\t%016" PRIxPTR,
+		 ai->regs->s8, ai->regs->s9);
+	EMSG_RAW("s10\t%016" PRIxPTR " s11\t%016" PRIxPTR,
+		 ai->regs->s10, ai->regs->s11);
+	EMSG_RAW("t3\t%016" PRIxPTR " t4\t%016" PRIxPTR,
+		 ai->regs->t3, ai->regs->t4);
+	EMSG_RAW("t5\t%016" PRIxPTR " t6\t%016" PRIxPTR,
+		 ai->regs->t5, ai->regs->t6);
+}
+
+/*
+ * Print abort info and (optionally) stack dump to the console
+ * @ai kernel-mode abort info.
+ * @stack_dump true to show a stack trace
+ */
+static void __abort_print(struct abort_info *ai, bool stack_dump)
+{
+	assert(!abort_is_user_exception(ai));
+
+	__print_abort_info(ai, "Core");
+
+	if (stack_dump) {
+		trace_printf_helper_raw(TRACE_ERROR, true,
+					"TEE load address @ %#"PRIxVA,
+					VCORE_START_VA);
+		__print_stack_unwind(ai);
+	}
+}
+
+void abort_print(struct abort_info *ai)
+{
+	__abort_print(ai, false);
+}
+
+void abort_print_error(struct abort_info *ai)
+{
+	__abort_print(ai, true);
+}
+
+/* This function must be called from a normal thread */
+void abort_print_current_ts(void)
+{
+	struct thread_specific_data *tsd = thread_get_tsd();
+	struct abort_info ai = { };
+	struct ts_session *s = ts_get_current_session();
+
+	ai.abort_type = tsd->abort_type;
+	ai.fault_descr = tsd->abort_descr;
+	ai.va = tsd->abort_va;
+	ai.pc = tsd->abort_regs.epc;
+	ai.regs = &tsd->abort_regs;
+
+	if (ai.abort_type != ABORT_TYPE_USER_MODE_PANIC)
+		__print_abort_info(&ai, "User mode");
+
+	s->ctx->ops->dump_state(s->ctx);
+
+#if defined(CFG_FTRACE_SUPPORT)
+	if (s->ctx->ops->dump_ftrace) {
+		s->fbuf = NULL;
+		s->ctx->ops->dump_ftrace(s->ctx);
+	}
+#endif
+}
+
+static void save_abort_info_in_tsd(struct abort_info *ai)
+{
+	struct thread_specific_data *tsd = thread_get_tsd();
+
+	tsd->abort_type = ai->abort_type;
+	tsd->abort_descr = ai->fault_descr;
+	tsd->abort_va = ai->va;
+	tsd->abort_regs = *ai->regs;
+	tsd->abort_core = get_core_pos();
+}
+
+static void set_abort_info(uint32_t abort_type __unused,
+			   struct thread_abort_regs *regs,
+			   struct abort_info *ai)
+{
+	ai->fault_descr = regs->cause;
+	switch (ai->fault_descr) {
+	case CAUSE_MISALIGNED_FETCH:
+	case CAUSE_FETCH_ACCESS:
+	case CAUSE_FETCH_PAGE_FAULT:
+	case CAUSE_FETCH_GUEST_PAGE_FAULT:
+		ai->abort_type = ABORT_TYPE_PREFETCH;
+		break;
+	case CAUSE_MISALIGNED_LOAD:
+	case CAUSE_LOAD_ACCESS:
+	case CAUSE_MISALIGNED_STORE:
+	case CAUSE_STORE_ACCESS:
+	case CAUSE_LOAD_PAGE_FAULT:
+	case CAUSE_STORE_PAGE_FAULT:
+	case CAUSE_LOAD_GUEST_PAGE_FAULT:
+	case CAUSE_STORE_GUEST_PAGE_FAULT:
+		ai->abort_type = ABORT_TYPE_DATA;
+		break;
+	default:
+		ai->abort_type = ABORT_TYPE_UNDEF;
+	}
+
+	ai->va = regs->tval;
+	ai->pc = regs->epc;
+	ai->regs = regs;
+}
+
+static void handle_user_mode_panic(struct abort_info *ai)
+{
+	/*
+	 * It was a user exception, stop user execution and return
+	 * to TEE Core.
+	 */
+	ai->regs->a0 = TEE_ERROR_TARGET_DEAD;
+	ai->regs->a1 = true;
+	ai->regs->a2 = 0xdeadbeef;
+	ai->regs->ra = (vaddr_t)thread_unwind_user_mode;
+	ai->regs->sp = thread_get_saved_thread_sp();
+	ai->regs->status = read_csr(CSR_XSTATUS);
+
+	thread_exit_user_mode(ai->regs->a0, ai->regs->a1, ai->regs->a2,
+			      ai->regs->a3, ai->regs->sp, ai->regs->ra,
+			      ai->regs->status);
+}
+
+#ifdef CFG_WITH_VFP
+static void handle_user_mode_vfp(void)
+{
+	struct ts_session *s = ts_get_current_session();
+
+	thread_user_enable_vfp(&to_user_mode_ctx(s->ctx)->vfp);
+}
+#endif /*CFG_WITH_VFP*/
+
+#ifdef CFG_WITH_USER_TA
+
+/* Returns true if the exception originated from user mode */
+bool abort_is_user_exception(struct abort_info *ai)
+{
+	return (ai->regs->status & CSR_XSTATUS_SPP) == 0;
+}
+
+#else /*CFG_WITH_USER_TA*/
+bool abort_is_user_exception(struct abort_info *ai __unused)
+{
+	return false;
+}
+#endif /*CFG_WITH_USER_TA*/
+
+#if defined(CFG_WITH_VFP) && defined(CFG_WITH_USER_TA)
+static bool is_vfp_fault(struct abort_info *ai)
+{
+	/* Implement */
+	return false;
+}
+#else /*CFG_WITH_VFP && CFG_WITH_USER_TA*/
+static bool is_vfp_fault(struct abort_info *ai __unused)
+{
+	return false;
+}
+#endif  /*CFG_WITH_VFP && CFG_WITH_USER_TA*/
+
+static enum fault_type get_fault_type(struct abort_info *ai)
+{
+	if (abort_is_user_exception(ai)) {
+		if (is_vfp_fault(ai))
+			return FAULT_TYPE_USER_MODE_VFP;
+		return FAULT_TYPE_USER_MODE_PANIC;
+	}
+
+	if (thread_is_from_abort_mode()) {
+		abort_print_error(ai);
+		panic("[abort] abort in abort handler (trap CPU)");
+	}
+
+	if (ai->abort_type == ABORT_TYPE_UNDEF) {
+		if (abort_is_user_exception(ai))
+			return FAULT_TYPE_USER_MODE_PANIC;
+		abort_print_error(ai);
+		panic("[abort] undefined abort (trap CPU)");
+	}
+
+	switch (core_mmu_get_fault_type(ai->fault_descr)) {
+	case CORE_MMU_FAULT_ALIGNMENT:
+		if (abort_is_user_exception(ai))
+			return FAULT_TYPE_USER_MODE_PANIC;
+		abort_print_error(ai);
+		panic("[abort] alignment fault!  (trap CPU)");
+		break;
+
+	case CORE_MMU_FAULT_ACCESS_BIT:
+		if (abort_is_user_exception(ai))
+			return FAULT_TYPE_USER_MODE_PANIC;
+		abort_print_error(ai);
+		panic("[abort] access bit fault!  (trap CPU)");
+		break;
+
+	case CORE_MMU_FAULT_DEBUG_EVENT:
+		if (!abort_is_user_exception(ai))
+			abort_print(ai);
+		DMSG("[abort] Ignoring debug event!");
+		return FAULT_TYPE_IGNORE;
+
+	case CORE_MMU_FAULT_TRANSLATION:
+	case CORE_MMU_FAULT_WRITE_PERMISSION:
+	case CORE_MMU_FAULT_READ_PERMISSION:
+		return FAULT_TYPE_PAGE_FAULT;
+
+	case CORE_MMU_FAULT_ASYNC_EXTERNAL:
+		if (!abort_is_user_exception(ai))
+			abort_print(ai);
+		DMSG("[abort] Ignoring async external abort!");
+		return FAULT_TYPE_IGNORE;
+
+	case CORE_MMU_FAULT_TAG_CHECK:
+		if (abort_is_user_exception(ai))
+			return FAULT_TYPE_USER_MODE_PANIC;
+		abort_print_error(ai);
+		panic("[abort] Tag check fault! (trap CPU)");
+		break;
+
+	case CORE_MMU_FAULT_OTHER:
+	default:
+		if (!abort_is_user_exception(ai))
+			abort_print(ai);
+		DMSG("[abort] Unhandled fault!");
+		return FAULT_TYPE_IGNORE;
+	}
+}
+
+void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs)
+{
+	struct abort_info ai;
+
+	set_abort_info(abort_type, regs, &ai);
+
+	switch (get_fault_type(&ai)) {
+	case FAULT_TYPE_IGNORE:
+		break;
+	case FAULT_TYPE_USER_MODE_PANIC:
+		DMSG("[abort] abort in User mode (TA will panic)");
+		save_abort_info_in_tsd(&ai);
+#ifdef CFG_WITH_VFP
+		vfp_disable();
+#endif
+		handle_user_mode_panic(&ai);
+		break;
+#ifdef CFG_WITH_VFP
+	case FAULT_TYPE_USER_MODE_VFP:
+		handle_user_mode_vfp();
+		break;
+#endif
+	case FAULT_TYPE_PAGE_FAULT:
+	default:
+		if (thread_get_id_may_fail() < 0) {
+			abort_print_error(&ai);
+			panic("abort outside thread context");
+		}
+
+		if (!abort_is_user_exception(&ai)) {
+			abort_print_error(&ai);
+			panic("unhandled page fault abort");
+		}
+		DMSG("[abort] abort in User mode (TA will panic)");
+		save_abort_info_in_tsd(&ai);
+#ifdef CFG_WITH_VFP
+		vfp_disable();
+#endif
+		handle_user_mode_panic(&ai);
+		break;
+	}
+}

--- a/core/arch/riscv/kernel/arch_scall.c
+++ b/core/arch/riscv/kernel/arch_scall.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022-2023 NXP
+ * Copyright (c) 2014-2022, Linaro Limited
+ * Copyright (c) 2020, Arm Limited
+ */
+
+#include <kernel/abort.h>
+#include <kernel/scall.h>
+#include <kernel/thread.h>
+#include <kernel/trace_ta.h>
+#include <kernel/user_ta.h>
+#include <mm/vm.h>
+#include <riscv.h>
+#include <types_ext.h>
+
+#define TA_CONTEXT_MAX_SIZE	(RISCV_XLEN_BYTES * 32)
+
+#ifdef CFG_UNWIND
+
+static void save_panic_regs_rv_ta(struct thread_specific_data *tsd,
+				  unsigned long *pushed)
+{
+	tsd->abort_regs = (struct thread_abort_regs){
+		.ra = pushed[0],
+		.sp = (unsigned long)pushed,
+		.gp = pushed[1],
+		.tp = pushed[2],
+		.t0 = pushed[3],
+		.t1 = pushed[4],
+		.t2 = pushed[5],
+		.s0 = pushed[6],
+		.s1 = pushed[7],
+		.a0 = pushed[8],
+		.a1 = pushed[9],
+		.a2 = pushed[10],
+		.a3 = pushed[11],
+		.a4 = pushed[12],
+		.a5 = pushed[13],
+		.a6 = pushed[14],
+		.a7 = pushed[15],
+		.s2 = pushed[16],
+		.s3 = pushed[17],
+		.s4 = pushed[18],
+		.s5 = pushed[19],
+		.s6 = pushed[20],
+		.s7 = pushed[21],
+		.s8 = pushed[22],
+		.s9 = pushed[23],
+		.s10 = pushed[24],
+		.s11 = pushed[25],
+		.t3 = pushed[26],
+		.t4 = pushed[27],
+		.t5 = pushed[28],
+		.t6 = pushed[29],
+		.status = read_csr(CSR_XSTATUS),
+	};
+}
+
+void scall_save_panic_stack(struct thread_scall_regs *regs)
+{
+	struct thread_specific_data *tsd = thread_get_tsd();
+	struct ts_session *s = ts_get_current_session();
+	struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
+
+	if (vm_check_access_rights(&utc->uctx,
+				   TEE_MEMORY_ACCESS_READ |
+				   TEE_MEMORY_ACCESS_WRITE,
+				   (uaddr_t)regs->a1,
+				   TA_CONTEXT_MAX_SIZE)) {
+		TAMSG_RAW("");
+		TAMSG_RAW("Can't unwind invalid user stack 0x%"PRIxUA,
+			  (uaddr_t)regs->a1);
+		return;
+	}
+
+	tsd->abort_type = ABORT_TYPE_USER_MODE_PANIC;
+	tsd->abort_descr = 0;
+	tsd->abort_va = 0;
+
+	save_panic_regs_rv_ta(tsd, (unsigned long *)regs->a1);
+}
+
+#else /* CFG_UNWIND */
+void scall_save_panic_stack(struct thread_scall_regs *regs __unused)
+{
+	struct thread_specific_data *tsd = thread_get_tsd();
+
+	tsd->abort_type = ABORT_TYPE_USER_MODE_PANIC;
+}
+#endif /* CFG_UNWIND */

--- a/core/arch/riscv/kernel/arch_scall_rv.S
+++ b/core/arch/riscv/kernel/arch_scall_rv.S
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+#include "tee_syscall_numbers.h"
+#include "trace_levels.h"
+#include <asm.S>
+#include <generated/asm-defines.h>
+#include <kernel/thread.h>
+#include <riscv.h>
+#include <riscv_macros.S>
+#include <tee_api_defines.h>
+
+/*
+ * uint32_t scall_do_call(struct thread_scall_regs *regs, syscall_t func);
+ *
+ * Called from scall_handle_user_ta()
+ */
+FUNC scall_do_call , :
+	addi	sp, sp, -16
+
+	/* Save scall regs to t0 */
+	mv	t0, a0
+
+	/* Save func to t1 */
+	mv	t1, a1
+
+	/* Push return address to stack */
+	store_xregs sp, 0, 1
+
+	/* Load arguments to function */
+	load_xregs a0, THREAD_SCALL_REG_A0, 10, 17
+
+	/* Call the syscall function */
+	jalr	t1
+
+	/* Pop return address from stack */
+	load_xregs	sp, 0, 1
+
+	addi	sp, sp, 16
+	ret
+END_FUNC scall_do_call
+
+/*
+ * void syscall_sys_return(uint32_t ret);
+ */
+FUNC syscall_sys_return , :
+	li	a1, 0  /* panic = false */
+	li	a2, 0  /* panic_code = 0 */
+	mv	a3, t0 /* pointer to struct thread_scall_regs */
+	j	scall_sys_return_helper
+END_FUNC syscall_sys_return
+
+/*
+ * void syscall_panic(uint32_t code);
+ */
+FUNC syscall_panic , :
+	li	a1, 1  /* panic = true */
+	mv	a2, a0  /* code */
+	li	a0, TEE_ERROR_TARGET_DEAD
+	mv	a3, t0 /* pointer to struct thread_scall_regs */
+	j	scall_sys_return_helper
+END_FUNC syscall_panic

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#include <gen-asm-defines.h>
+#include <kernel/thread.h>
+#include <kernel/thread_private.h>
+#include <types_ext.h>
+
+DEFINES
+{
+	/* struct thread_ctx */
+	DEFINE(THREAD_CTX_KERN_SP, offsetof(struct thread_ctx, kern_sp));
+	DEFINE(THREAD_CTX_STACK_VA_END, offsetof(struct thread_ctx,
+						 stack_va_end));
+	DEFINE(THREAD_CTX_SIZE, sizeof(struct thread_ctx));
+
+	/* struct thread_core_local */
+	DEFINE(THREAD_CORE_LOCAL_SIZE, sizeof(struct thread_core_local));
+	DEFINE(THREAD_CORE_LOCAL_HART_ID,
+	       offsetof(struct thread_core_local, hart_id));
+	DEFINE(THREAD_CORE_LOCAL_TMP_STACK_VA_END,
+	       offsetof(struct thread_core_local, tmp_stack_va_end));
+	DEFINE(THREAD_CORE_LOCAL_CURR_THREAD,
+	       offsetof(struct thread_core_local, curr_thread));
+	DEFINE(THREAD_CORE_LOCAL_FLAGS,
+	       offsetof(struct thread_core_local, flags));
+	DEFINE(THREAD_CORE_LOCAL_ABT_STACK_VA_END,
+	       offsetof(struct thread_core_local, abt_stack_va_end));
+	DEFINE(THREAD_CORE_LOCAL_X10, offsetof(struct thread_core_local, x[0]));
+
+	DEFINE(STACK_TMP_GUARD, STACK_CANARY_SIZE / 2 + STACK_TMP_OFFS);
+
+	/* struct thread_ctx_regs */
+	DEFINE(THREAD_CTX_REG_STATUS, offsetof(struct thread_ctx_regs, status));
+	DEFINE(THREAD_CTX_REG_RA, offsetof(struct thread_ctx_regs, ra));
+	DEFINE(THREAD_CTX_REG_SP, offsetof(struct thread_ctx_regs, sp));
+	DEFINE(THREAD_CTX_REG_T0, offsetof(struct thread_ctx_regs, t0));
+	DEFINE(THREAD_CTX_REG_S0, offsetof(struct thread_ctx_regs, s0));
+	DEFINE(THREAD_CTX_REG_A0, offsetof(struct thread_ctx_regs, a0));
+	DEFINE(THREAD_CTX_REG_S2, offsetof(struct thread_ctx_regs, s2));
+	DEFINE(THREAD_CTX_REG_T3, offsetof(struct thread_ctx_regs, t3));
+	DEFINE(THREAD_CTX_REGS_SIZE, sizeof(struct thread_ctx_regs));
+
+	/* struct thread_user_mode_rec */
+	DEFINE(THREAD_USER_MODE_REC_CTX_REGS_PTR,
+	       offsetof(struct thread_user_mode_rec, ctx_regs_ptr));
+	DEFINE(THREAD_USER_MODE_REC_X1,
+	       offsetof(struct thread_user_mode_rec, x[0]));
+	DEFINE(THREAD_USER_MODE_REC_X8,
+	       offsetof(struct thread_user_mode_rec, x[4]));
+	DEFINE(THREAD_USER_MODE_REC_X18,
+	       offsetof(struct thread_user_mode_rec, x[6]));
+	DEFINE(THREAD_USER_MODE_REC_SIZE, sizeof(struct thread_user_mode_rec));
+
+	/* struct thread_trap_regs */
+	DEFINE(THREAD_TRAP_REG_SP, offsetof(struct thread_trap_regs, sp));
+	DEFINE(THREAD_TRAP_REG_RA, offsetof(struct thread_trap_regs, ra));
+	DEFINE(THREAD_TRAP_REG_GP, offsetof(struct thread_trap_regs, gp));
+	DEFINE(THREAD_TRAP_REG_TP, offsetof(struct thread_trap_regs, tp));
+	DEFINE(THREAD_TRAP_REG_T0, offsetof(struct thread_trap_regs, t0));
+	DEFINE(THREAD_TRAP_REG_A0, offsetof(struct thread_trap_regs, a0));
+	DEFINE(THREAD_TRAP_REG_T3, offsetof(struct thread_trap_regs, t3));
+	DEFINE(THREAD_TRAP_REG_EPC, offsetof(struct thread_trap_regs, epc));
+	DEFINE(THREAD_TRAP_REG_STATUS,
+	       offsetof(struct thread_trap_regs, status));
+	DEFINE(THREAD_TRAP_REGS_SIZE, sizeof(struct thread_trap_regs));
+
+	/* struct thread_scall_regs */
+	DEFINE(THREAD_SCALL_REG_STATUS,
+	       offsetof(struct thread_scall_regs, status));
+	DEFINE(THREAD_SCALL_REG_RA, offsetof(struct thread_scall_regs, ra));
+	DEFINE(THREAD_SCALL_REG_SP, offsetof(struct thread_scall_regs, sp));
+	DEFINE(THREAD_SCALL_REG_A0, offsetof(struct thread_scall_regs, a0));
+	DEFINE(THREAD_SCALL_REGS_SIZE, sizeof(struct thread_scall_regs));
+}

--- a/core/arch/riscv/kernel/cache_helpers_rv.S
+++ b/core/arch/riscv/kernel/cache_helpers_rv.S
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#include <asm.S>
+#include <riscv.h>
+
+/*
+ * On the below data cache management, we rely on FENCE instruction.
+ * The FENCE instruction is used to order device I/O and memory accesses
+ * as viewed by other RISC-V harts and external devices or coprocessors.
+ * "fence" below is a pseudo-instruction of "fence iorw, iorw" which
+ * performs Fence on all memory and I/O.
+ */
+
+/* void dcache_cleaninv_range(void *addr, size_t size); */
+FUNC dcache_cleaninv_range , :
+	fence
+	ret
+END_FUNC dcache_cleaninv_range
+
+/* void dcache_clean_range(void *addr, size_t size); */
+FUNC dcache_clean_range , :
+	fence
+	ret
+END_FUNC dcache_clean_range
+
+/* void dcache_inv_range(void *addr, size_t size); */
+FUNC dcache_inv_range , :
+	fence
+	ret
+END_FUNC dcache_inv_range
+
+/* void dcache_op_all(unsigned long op_type); */
+FUNC dcache_op_all , :
+	fence
+	ret
+END_FUNC dcache_op_all
+
+/* void icache_inv_all(void); */
+FUNC icache_inv_all , :
+	/*
+	 * FENCE.I instruction provides explicit synchronization
+	 * between writes to instruction memory and instruction
+	 * fetches on the same hart. This implies instruction cache
+	 * management operations as result of executing this instruction.
+	 */
+	fence.i
+	ret
+END_FUNC icache_inv_all
+
+/* void icache_inv_range(void *addr, size_t size); */
+FUNC icache_inv_range , :
+	/*
+	 * RISC-V does not have an instruction to flush a range
+	 * of the I$, therefore, flush it entirely as invoking
+	 * icache_inv_all().
+	 */
+	fence.i
+	ret
+END_FUNC icache_inv_range

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -8,4 +8,5 @@ srcs-y += entry.S
 srcs-y += abort.c
 srcs-y += thread_rv.S
 srcs-y += thread_arch.c
+srcs-y += arch_scall.c
 asm-defines-y += asm-defines.c

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -7,4 +7,5 @@ srcs-y += boot.c
 srcs-y += entry.S
 srcs-y += abort.c
 srcs-y += thread_rv.S
+srcs-y += thread_arch.c
 asm-defines-y += asm-defines.c

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -1,4 +1,5 @@
 srcs-y += spinlock.S
+srcs-y += cache_helpers_rv.S
 srcs-y += idle.c
 srcs-$(CFG_RISCV_TIME_SOURCE_RDTIME) += tee_time_rdtime.c
 srcs-$(CFG_RISCV_SBI) += sbi.c

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -5,3 +5,4 @@ srcs-$(CFG_RISCV_SBI) += sbi.c
 srcs-$(CFG_RISCV_SBI_CONSOLE) += sbi_console.c
 srcs-y += boot.c
 srcs-y += entry.S
+asm-defines-y += asm-defines.c

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -5,5 +5,6 @@ srcs-$(CFG_RISCV_SBI) += sbi.c
 srcs-$(CFG_RISCV_SBI_CONSOLE) += sbi_console.c
 srcs-y += boot.c
 srcs-y += entry.S
+srcs-y += abort.c
 srcs-y += thread_rv.S
 asm-defines-y += asm-defines.c

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -5,4 +5,5 @@ srcs-$(CFG_RISCV_SBI) += sbi.c
 srcs-$(CFG_RISCV_SBI_CONSOLE) += sbi_console.c
 srcs-y += boot.c
 srcs-y += entry.S
+srcs-y += thread_rv.S
 asm-defines-y += asm-defines.c

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -8,5 +8,6 @@ srcs-y += entry.S
 srcs-y += abort.c
 srcs-y += thread_rv.S
 srcs-y += thread_arch.c
+srcs-y += arch_scall_rv.S
 srcs-y += arch_scall.c
 asm-defines-y += asm-defines.c

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022-2023 NXP
+ * Copyright (c) 2016-2022, Linaro Limited
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2020-2021, Arm Limited
+ */
+
+#include <platform_config.h>
+
+#include <assert.h>
+#include <config.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/asan.h>
+#include <kernel/boot.h>
+#include <kernel/linker.h>
+#include <kernel/lockdep.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <kernel/tee_ta_manager.h>
+#include <kernel/thread.h>
+#include <kernel/thread_private.h>
+#include <kernel/user_mode_ctx_struct.h>
+#include <kernel/virtualization.h>
+#include <mm/core_memprot.h>
+#include <mm/mobj.h>
+#include <mm/tee_mm.h>
+#include <mm/vm.h>
+#include <riscv.h>
+#include <trace.h>
+#include <util.h>
+
+uint32_t __nostackcheck thread_get_exceptions(void)
+{
+	return read_csr(CSR_XIE) & THREAD_EXCP_ALL;
+}
+
+void __nostackcheck thread_set_exceptions(uint32_t exceptions)
+{
+	/* Foreign interrupts must not be unmasked while holding a spinlock */
+	if (!(exceptions & THREAD_EXCP_FOREIGN_INTR))
+		assert_have_no_spinlock();
+
+	barrier();
+	write_csr(CSR_XIE, exceptions);
+	barrier();
+}
+
+uint32_t __nostackcheck thread_mask_exceptions(uint32_t exceptions)
+{
+	uint32_t state = thread_get_exceptions();
+
+	thread_set_exceptions(state | (exceptions & THREAD_EXCP_ALL));
+	return state;
+}
+
+void __nostackcheck thread_unmask_exceptions(uint32_t state)
+{
+	thread_set_exceptions(state & THREAD_EXCP_ALL);
+}
+
+static void thread_lazy_save_ns_vfp(void)
+{
+	static_assert(!IS_ENABLED(CFG_WITH_VFP));
+}
+
+static void thread_lazy_restore_ns_vfp(void)
+{
+	static_assert(!IS_ENABLED(CFG_WITH_VFP));
+}
+
+static void setup_unwind_user_mode(struct thread_scall_regs *regs)
+{
+	regs->ra = (uintptr_t)thread_unwind_user_mode;
+	regs->status = read_csr(CSR_XSTATUS);
+	regs->sp = thread_get_saved_thread_sp();
+}
+
+static void thread_unhandled_trap(struct thread_trap_regs *regs __unused,
+				  unsigned long cause __unused)
+{
+	DMSG("Unhandled trap xepc:0x%016lx xcause:0x%016lx xtval:0x%016lx",
+	     read_csr(CSR_XEPC), read_csr(CSR_XCAUSE), read_csr(CSR_XTVAL));
+	panic();
+}
+
+void  thread_scall_handler(struct thread_scall_regs *regs)
+{
+	struct ts_session *sess = NULL;
+	uint32_t state = 0;
+
+	/* Enable native interrupts */
+	state = thread_get_exceptions();
+	thread_unmask_exceptions(state & ~THREAD_EXCP_NATIVE_INTR);
+
+	thread_user_save_vfp();
+
+	sess = ts_get_current_session();
+
+	/* Restore foreign interrupts which are disabled on exception entry */
+	thread_restore_foreign_intr();
+
+	assert(sess && sess->handle_scall);
+
+	if (!sess->handle_scall(regs)) {
+		setup_unwind_user_mode(regs);
+		thread_exit_user_mode(regs->a0, regs->a1, regs->a2,
+				      regs->a3, regs->sp, regs->ra,
+				      regs->status);
+	}
+}
+
+static void copy_scall_to_trap(struct thread_scall_regs *scall_regs,
+			       struct thread_trap_regs *trap_regs)
+{
+	trap_regs->a0 = scall_regs->a0;
+	trap_regs->a1 = scall_regs->a1;
+	trap_regs->a2 = scall_regs->a2;
+	trap_regs->a3 = scall_regs->a3;
+	trap_regs->a4 = scall_regs->a4;
+	trap_regs->a5 = scall_regs->a5;
+	trap_regs->a6 = scall_regs->a6;
+	trap_regs->a7 = scall_regs->a7;
+	trap_regs->t0 = scall_regs->t0;
+	trap_regs->t1 = scall_regs->t1;
+}
+
+static void copy_trap_to_scall(struct thread_trap_regs *trap_regs,
+			       struct thread_scall_regs *scall_regs)
+{
+	*scall_regs = (struct thread_scall_regs) {
+		.status = trap_regs->status,
+		.ra = trap_regs->ra,
+		.a0 = trap_regs->a0,
+		.a1 = trap_regs->a1,
+		.a2 = trap_regs->a2,
+		.a3 = trap_regs->a3,
+		.a4 = trap_regs->a4,
+		.a5 = trap_regs->a5,
+		.a6 = trap_regs->a6,
+		.a7 = trap_regs->a7,
+		.t0 = trap_regs->t0,
+		.t1 = trap_regs->t1,
+	};
+}
+
+static void thread_user_ecall_handler(struct thread_trap_regs *trap_regs)
+{
+	struct thread_scall_regs scall_regs;
+	struct thread_core_local *l = thread_get_core_local();
+	int ct = l->curr_thread;
+
+	copy_trap_to_scall(trap_regs, &scall_regs);
+	thread_scall_handler(&scall_regs);
+	copy_scall_to_trap(&scall_regs, trap_regs);
+	/*
+	 * Save kernel sp we'll had at the beginning of this function.
+	 * This is when this TA has called another TA because
+	 * __thread_enter_user_mode() also saves the stack pointer in this
+	 * field.
+	 */
+	threads[ct].kern_sp = (unsigned long)(trap_regs + 1);
+	/*
+	 * We are returning to U-Mode, on return, the program counter
+	 * is set to xsepc (pc=xepc), we add 4 (size of an instruction)
+	 * to continue to next instruction.
+	 */
+	trap_regs->epc += 4;
+}
+
+static void copy_trap_to_abort(struct thread_trap_regs *trap_regs,
+			       struct thread_abort_regs *abort_regs)
+{
+	*abort_regs = (struct thread_abort_regs) {
+		.status = trap_regs->status,
+		.ra = trap_regs->ra,
+		.sp = trap_regs->sp,
+		.gp = trap_regs->gp,
+		.tp = trap_regs->tp,
+		.t0 = trap_regs->t0,
+		.t1 = trap_regs->t1,
+		.t2 = trap_regs->t2,
+		.s0 = trap_regs->s0,
+		.s1 = trap_regs->s1,
+		.a0 = trap_regs->a0,
+		.a1 = trap_regs->a1,
+		.a2 = trap_regs->a2,
+		.a3 = trap_regs->a3,
+		.a4 = trap_regs->a4,
+		.a5 = trap_regs->a5,
+		.a6 = trap_regs->a6,
+		.a7 = trap_regs->a7,
+		.s2 = trap_regs->s2,
+		.s3 = trap_regs->s3,
+		.s4 = trap_regs->s4,
+		.s5 = trap_regs->s5,
+		.s6 = trap_regs->s6,
+		.s7 = trap_regs->s7,
+		.s8 = trap_regs->s8,
+		.s9 = trap_regs->s9,
+		.s10 = trap_regs->s10,
+		.s11 = trap_regs->s11,
+		.t3 = trap_regs->t3,
+		.t4 = trap_regs->t4,
+		.t5 = trap_regs->t5,
+		.t6 = trap_regs->t6,
+	};
+}
+
+static void thread_abort_handler(struct thread_trap_regs *trap_regs,
+				 unsigned long cause)
+{
+	struct thread_abort_regs abort_regs = { };
+
+	assert(cause == read_csr(CSR_XCAUSE));
+	copy_trap_to_abort(trap_regs, &abort_regs);
+	abort_regs.cause = read_csr(CSR_XCAUSE);
+	abort_regs.epc = read_csr(CSR_XEPC);
+	abort_regs.tval = read_csr(CSR_XTVAL);
+	abort_regs.satp = read_csr(CSR_SATP);
+	abort_handler(cause, &abort_regs);
+}
+
+static void thread_exception_handler(unsigned long cause,
+				     struct thread_trap_regs *regs)
+{
+	switch (cause) {
+	case CAUSE_USER_ECALL:
+		thread_user_ecall_handler(regs);
+		break;
+	default:
+		thread_abort_handler(regs, cause);
+		break;
+	}
+}
+
+static void thread_irq_handler(void)
+{
+	itr_core_handler();
+}
+
+static void thread_interrupt_handler(unsigned long cause,
+				     struct thread_trap_regs *regs)
+{
+	switch (cause & LONG_MAX) {
+	case IRQ_XTIMER:
+		clear_csr(CSR_XIE, CSR_XIE_TIE);
+		break;
+	case IRQ_XSOFT:
+		thread_unhandled_trap(regs, cause);
+		break;
+	case IRQ_XEXT:
+		thread_irq_handler();
+		break;
+	default:
+		thread_unhandled_trap(regs, cause);
+	}
+}
+
+void thread_trap_handler(long cause, unsigned long epc __unused,
+			 struct thread_trap_regs *regs,
+			 bool user __maybe_unused)
+{
+	/*
+	 * The Interrupt bit (XLEN-1) in the cause register is set
+	 * if the trap was caused by an interrupt.
+	 */
+	if (cause < 0)
+		thread_interrupt_handler(cause, regs);
+	/*
+	 * Otherwise, cause is never written by the implementation,
+	 * though it may be explicitly written by software.
+	 */
+	else
+		thread_exception_handler(cause, regs);
+}
+
+static void init_regs(struct thread_ctx *thread, uint32_t a0, uint32_t a1,
+		      uint32_t a2, uint32_t a3, uint32_t a4, uint32_t a5,
+		      uint32_t a6, uint32_t a7, void *pc)
+{
+	thread->regs.ra = (uintptr_t)pc;
+
+	/* Set up xstatus */
+	thread->regs.status = read_csr(CSR_XSTATUS);
+
+	/* Reinitialize stack pointer */
+	thread->regs.sp = thread->stack_va_end;
+
+	/*
+	 * Copy arguments into context. This will make the
+	 * arguments appear in a0-a7 when thread is started.
+	 */
+	thread->regs.a0 = a0;
+	thread->regs.a1 = a1;
+	thread->regs.a2 = a2;
+	thread->regs.a3 = a3;
+	thread->regs.a4 = a4;
+	thread->regs.a5 = a5;
+	thread->regs.a6 = a6;
+	thread->regs.a7 = a7;
+}
+
+static void __thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2,
+				   uint32_t a3, uint32_t a4, uint32_t a5,
+				   uint32_t a6, uint32_t a7,
+				   void *pc)
+{
+	struct thread_core_local *l = thread_get_core_local();
+	bool found_thread = false;
+	size_t n = 0;
+
+	assert(l->curr_thread == THREAD_ID_INVALID);
+
+	thread_lock_global();
+
+	for (n = 0; n < CFG_NUM_THREADS; n++) {
+		if (threads[n].state == THREAD_STATE_FREE) {
+			threads[n].state = THREAD_STATE_ACTIVE;
+			found_thread = true;
+			break;
+		}
+	}
+
+	thread_unlock_global();
+
+	if (!found_thread)
+		return;
+
+	l->curr_thread = n;
+
+	threads[n].flags = 0;
+	init_regs(threads + n, a0, a1, a2, a3, a4, a5, a6, a7, pc);
+
+	thread_lazy_save_ns_vfp();
+
+	l->flags &= ~THREAD_CLF_TMP;
+
+	thread_resume(&threads[n].regs);
+	/*NOTREACHED*/
+	panic();
+}
+
+void thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
+			  uint32_t a4, uint32_t a5)
+{
+	__thread_alloc_and_run(a0, a1, a2, a3, a4, a5, 0, 0,
+			       thread_std_smc_entry);
+}
+
+static void copy_a0_to_a3(struct thread_ctx_regs *regs, uint32_t a0,
+			  uint32_t a1, uint32_t a2, uint32_t a3)
+{
+	regs->a0 = a0;
+	regs->a1 = a1;
+	regs->a2 = a2;
+	regs->a3 = a3;
+}
+
+static bool is_from_user(unsigned long status)
+{
+	return status & CSR_XSTATUS_SPP;
+}
+
+#ifdef CFG_SYSCALL_FTRACE
+static void __noprof ftrace_suspend(void)
+{
+	struct ts_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
+
+	if (s && s->fbuf)
+		s->fbuf->syscall_trace_suspended = true;
+}
+
+static void __noprof ftrace_resume(void)
+{
+	struct ts_session *s = TAILQ_FIRST(&thread_get_tsd()->sess_stack);
+
+	if (s && s->fbuf)
+		s->fbuf->syscall_trace_suspended = false;
+}
+#else
+static void __maybe_unused __noprof ftrace_suspend(void)
+{
+}
+
+static void __noprof ftrace_resume(void)
+{
+}
+#endif
+
+static bool is_user_mode(struct thread_ctx_regs *regs)
+{
+	return is_from_user((uint32_t)regs->status);
+}
+
+vaddr_t thread_get_saved_thread_sp(void)
+{
+	struct thread_core_local *l = thread_get_core_local();
+	int ct = l->curr_thread;
+
+	assert(ct != THREAD_ID_INVALID);
+	return threads[ct].kern_sp;
+}
+
+void thread_resume_from_rpc(uint32_t thread_id, uint32_t a0, uint32_t a1,
+			    uint32_t a2, uint32_t a3)
+{
+	size_t n = thread_id;
+	struct thread_core_local *l = thread_get_core_local();
+	bool found_thread = false;
+
+	assert(l->curr_thread == THREAD_ID_INVALID);
+
+	thread_lock_global();
+
+	if (n < CFG_NUM_THREADS && threads[n].state == THREAD_STATE_SUSPENDED) {
+		threads[n].state = THREAD_STATE_ACTIVE;
+		found_thread = true;
+	}
+
+	thread_unlock_global();
+
+	if (!found_thread)
+		return;
+
+	l->curr_thread = n;
+
+	if (threads[n].have_user_map) {
+		core_mmu_set_user_map(&threads[n].user_map);
+		if (threads[n].flags & THREAD_FLAGS_EXIT_ON_FOREIGN_INTR)
+			tee_ta_ftrace_update_times_resume();
+	}
+
+	if (is_user_mode(&threads[n].regs))
+		tee_ta_update_session_utime_resume();
+
+	/*
+	 * Return from RPC to request service of a foreign interrupt must not
+	 * get parameters from non-secure world.
+	 */
+	if (threads[n].flags & THREAD_FLAGS_COPY_ARGS_ON_RETURN) {
+		copy_a0_to_a3(&threads[n].regs, a0, a1, a2, a3);
+		threads[n].flags &= ~THREAD_FLAGS_COPY_ARGS_ON_RETURN;
+	}
+
+	thread_lazy_save_ns_vfp();
+
+	if (threads[n].have_user_map)
+		ftrace_resume();
+
+	l->flags &= ~THREAD_CLF_TMP;
+	thread_resume(&threads[n].regs);
+	/*NOTREACHED*/
+	panic();
+}
+
+void thread_state_free(void)
+{
+	struct thread_core_local *l = thread_get_core_local();
+	int ct = l->curr_thread;
+
+	assert(ct != THREAD_ID_INVALID);
+
+	thread_lazy_restore_ns_vfp();
+
+	thread_lock_global();
+
+	assert(threads[ct].state == THREAD_STATE_ACTIVE);
+	threads[ct].state = THREAD_STATE_FREE;
+	threads[ct].flags = 0;
+	l->curr_thread = THREAD_ID_INVALID;
+
+	if (IS_ENABLED(CFG_VIRTUALIZATION))
+		virt_unset_guest();
+	thread_unlock_global();
+}
+
+int thread_state_suspend(uint32_t flags, uint32_t status, vaddr_t pc)
+{
+	struct thread_core_local *l = thread_get_core_local();
+	int ct = l->curr_thread;
+
+	assert(ct != THREAD_ID_INVALID);
+
+	if (core_mmu_user_mapping_is_active())
+		ftrace_suspend();
+
+	thread_check_canaries();
+
+	if (is_from_user(status)) {
+		thread_user_save_vfp();
+		tee_ta_update_session_utime_suspend();
+		tee_ta_gprof_sample_pc(pc);
+	}
+	thread_lazy_restore_ns_vfp();
+
+	thread_lock_global();
+
+	assert(threads[ct].state == THREAD_STATE_ACTIVE);
+	threads[ct].flags |= flags;
+	threads[ct].regs.status = status;
+	threads[ct].regs.ra = pc;
+	threads[ct].state = THREAD_STATE_SUSPENDED;
+
+	threads[ct].have_user_map = core_mmu_user_mapping_is_active();
+	if (threads[ct].have_user_map) {
+		if (threads[ct].flags & THREAD_FLAGS_EXIT_ON_FOREIGN_INTR)
+			tee_ta_ftrace_update_times_suspend();
+		core_mmu_get_user_map(&threads[ct].user_map);
+		core_mmu_set_user_map(NULL);
+	}
+
+	l->curr_thread = THREAD_ID_INVALID;
+
+	if (IS_ENABLED(CFG_VIRTUALIZATION))
+		virt_unset_guest();
+
+	thread_unlock_global();
+
+	return ct;
+}
+
+bool thread_init_stack(uint32_t thread_id, vaddr_t sp)
+{
+	if (thread_id >= CFG_NUM_THREADS)
+		return false;
+	threads[thread_id].stack_va_end = sp;
+	return true;
+}
+
+static void init_user_kcode(void)
+{
+}
+
+void thread_init_primary(void)
+{
+	/* Initialize canaries around the stacks */
+	thread_init_canaries();
+
+	init_user_kcode();
+}
+
+static vaddr_t get_trap_vect(void)
+{
+	return (vaddr_t)thread_trap_vect;
+}
+
+void thread_init_tvec(void)
+{
+	unsigned long tvec = (unsigned long)get_trap_vect();
+
+	static_assert(sizeof(struct thread_trap_regs) % 16 == 0);
+	write_csr(CSR_XTVEC, tvec);
+	assert(read_csr(CSR_XTVEC) == tvec);
+}
+
+void thread_init_per_cpu(void)
+{
+	thread_init_tvec();
+	/*
+	 * We may receive traps from now, therefore, zeroize xSCRATCH such
+	 * that thread_trap_vect() can distinguish between user traps
+	 * and kernel traps.
+	 */
+	write_csr(CSR_XSCRATCH, 0);
+	/* Allow access to user pages */
+	set_csr(CSR_XSTATUS, CSR_XSTATUS_SUM);
+}
+
+static void set_ctx_regs(struct thread_ctx_regs *regs, unsigned long a0,
+			 unsigned long a1, unsigned long a2, unsigned long a3,
+			 unsigned long user_sp, unsigned long entry_func,
+			 uint32_t status,
+			 struct thread_pauth_keys *keys __unused)
+{
+	*regs = (struct thread_ctx_regs){
+		.a0 = a0,
+		.a1 = a1,
+		.a2 = a2,
+		.a3 = a3,
+		.sp = user_sp,
+		.ra = entry_func,
+		.status = status
+	};
+}
+
+uint32_t thread_enter_user_mode(unsigned long a0, unsigned long a1,
+				unsigned long a2, unsigned long a3,
+				unsigned long user_sp,
+				unsigned long entry_func,
+				bool is_32bit __unused,
+				uint32_t *exit_status0,
+				uint32_t *exit_status1)
+{
+	uint32_t status = 0;
+	uint32_t exceptions = 0;
+	uint32_t rc = 0;
+	struct thread_ctx_regs *regs = NULL;
+
+	tee_ta_update_session_utime_resume();
+
+	exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
+	regs = thread_get_ctx_regs();
+	status = CSR_XSTATUS_SUM | CSR_XSTATUS_PIE;
+	set_field_u64(status, CSR_XSTATUS_SPP, PRV_U);
+	set_ctx_regs(regs, a0, a1, a2, a3, user_sp, entry_func, status, NULL);
+	rc = __thread_enter_user_mode(regs, exit_status0, exit_status1);
+	thread_unmask_exceptions(exceptions);
+
+	return rc;
+}

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -1,0 +1,376 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#include <asm.S>
+#include <generated/asm-defines.h>
+#include <keep.h>
+#include <kernel/thread.h>
+#include <kernel/thread_private.h>
+#include <mm/core_mmu.h>
+#include <riscv.h>
+#include <riscv_macros.S>
+
+.macro get_thread_ctx res, tmp0
+	lw	\tmp0, THREAD_CORE_LOCAL_CURR_THREAD(tp)
+	la	\res, threads
+1:
+	beqz	\tmp0, 2f
+	addi	\res, \res, THREAD_CTX_SIZE
+	addi	\tmp0, \tmp0, -1
+	bnez	\tmp0, 1b
+2:
+.endm
+
+.macro save_regs, mode
+	addi	sp, sp, -THREAD_TRAP_REGS_SIZE
+.if \mode == TRAP_MODE_USER
+
+	/* Save user thread pointer and load kernel thread pointer */
+	store_xregs sp, THREAD_TRAP_REG_TP, REG_TP
+	load_xregs sp, (THREAD_TRAP_REGS_SIZE - RISCV_XLEN_BYTES), REG_TP
+
+	store_xregs sp, THREAD_TRAP_REG_GP, REG_GP
+
+	/*
+	 * Set the scratch register to 0 such in case of a recursive
+	 * exception thread_trap_vect() knows that it is emitted from kernel.
+	 */
+	csrrw	gp, CSR_XSCRATCH, zero
+	store_xregs sp, THREAD_TRAP_REG_SP, REG_GP
+.option push
+.option norelax
+	la	gp, __global_pointer$
+.option pop
+.endif
+	store_xregs sp, THREAD_TRAP_REG_T3, REG_T3, REG_T6
+	store_xregs sp, THREAD_TRAP_REG_T0, REG_T0, REG_T2
+	store_xregs sp, THREAD_TRAP_REG_A0, REG_A0, REG_A7
+	store_xregs sp, THREAD_TRAP_REG_RA, REG_RA
+
+	csrr	t0, CSR_XSTATUS
+	store_xregs sp, THREAD_TRAP_REG_STATUS, REG_T0
+
+	csrr	a0, CSR_XCAUSE
+	csrr	a1, CSR_XEPC
+
+	store_xregs sp, THREAD_TRAP_REG_EPC, REG_A1
+
+	mv	a2, sp
+
+	/* a0 = cause
+	 * a1 = epc
+	 * a2 = sp
+	 * a3 = user
+	 * thread_trap_handler(cause, epc, sp, user)
+	 */
+.endm
+
+.macro restore_regs, mode
+	load_xregs sp, THREAD_TRAP_REG_EPC, REG_T0
+	csrw	CSR_XEPC, t0
+
+	load_xregs sp, THREAD_TRAP_REG_STATUS, REG_T0
+	csrw	CSR_XSTATUS, t0
+
+	load_xregs sp, THREAD_TRAP_REG_RA, REG_RA
+	load_xregs sp, THREAD_TRAP_REG_A0, REG_A0, REG_A7
+	load_xregs sp, THREAD_TRAP_REG_T0, REG_T0, REG_T2
+	load_xregs sp, THREAD_TRAP_REG_T3, REG_T3, REG_T6
+
+.if \mode == TRAP_MODE_USER
+	addi	gp, sp, THREAD_TRAP_REGS_SIZE
+
+	store_xregs gp, REGOFF(-1), REG_TP
+	csrw	CSR_XSCRATCH, gp
+
+	load_xregs sp, THREAD_TRAP_REG_TP, REG_TP
+	load_xregs sp, THREAD_TRAP_REG_GP, REG_GP
+	load_xregs sp, THREAD_TRAP_REG_SP, REG_SP
+
+.else
+	addi	sp, sp, THREAD_TRAP_REGS_SIZE
+.endif
+.endm
+
+/* size_t __get_core_pos(void); */
+FUNC __get_core_pos , : , .identity_map
+	lw	a0, THREAD_CORE_LOCAL_HART_ID(tp)
+	ret
+END_FUNC __get_core_pos
+
+FUNC thread_trap_vect , :
+	csrrw	sp, CSR_XSCRATCH, sp
+	bnez	sp, 0f
+	csrrw	sp, CSR_XSCRATCH, sp
+	j	trap_from_kernel
+0:
+	j	trap_from_user
+thread_trap_vect_end:
+END_FUNC thread_trap_vect
+
+LOCAL_FUNC trap_from_kernel, :
+	save_regs TRAP_MODE_KERNEL
+	li	a3, 0
+	jal	thread_trap_handler
+	restore_regs TRAP_MODE_KERNEL
+	XRET
+END_FUNC trap_from_kernel
+
+LOCAL_FUNC trap_from_user, :
+	save_regs TRAP_MODE_USER
+	li	a3, 1
+	jal	thread_trap_handler
+	restore_regs TRAP_MODE_USER
+	XRET
+END_FUNC trap_from_user
+
+/*
+ * void thread_unwind_user_mode(uint32_t ret, uint32_t exit_status0,
+ * 		uint32_t exit_status1);
+ * See description in thread.h
+ */
+FUNC thread_unwind_user_mode , :
+
+	/* Store the exit status */
+	load_xregs sp, THREAD_USER_MODE_REC_CTX_REGS_PTR, REG_A3, REG_A5
+	sw	a1, (a4)
+	sw	a2, (a5)
+
+	/* Save user callee regs */
+	store_xregs a3, THREAD_CTX_REG_S0, REG_S0, REG_S1
+	store_xregs a3, THREAD_CTX_REG_S2, REG_S2, REG_S11
+	store_xregs a3, THREAD_CTX_REG_SP, REG_SP, REG_TP
+
+	/* Restore kernel callee regs */
+	mv	a1, sp
+
+	load_xregs a1, THREAD_USER_MODE_REC_X1, REG_RA, REG_TP
+	load_xregs a1, THREAD_USER_MODE_REC_X8, REG_S0, REG_S1
+	load_xregs a1, THREAD_USER_MODE_REC_X18, REG_S2, REG_S11
+
+	add	sp, sp, THREAD_USER_MODE_REC_SIZE
+
+	/*
+	 * Zeroize xSCRATCH to indicate to thread_trap_vect()
+	 * that we are executing in kernel.
+	 */
+	csrw	CSR_XSCRATCH, zero
+
+	/* Return from the call of thread_enter_user_mode() */
+	ret
+END_FUNC thread_unwind_user_mode
+
+/*
+ * void thread_exit_user_mode(unsigned long a0, unsigned long a1,
+ *			       unsigned long a2, unsigned long a3,
+ *			       unsigned long sp, unsigned long pc,
+ *			       unsigned long status);
+ */
+FUNC thread_exit_user_mode , :
+	/* Set kernel stack pointer */
+	mv	sp, a4
+
+	/* Set xSTATUS */
+	csrw	CSR_XSTATUS, a6
+
+	/* Set return address thread_unwind_user_mode() */
+	mv	ra, a5
+	ret
+END_FUNC thread_exit_user_mode
+
+/*
+ * uint32_t __thread_enter_user_mode(struct thread_ctx_regs *regs,
+ *				     uint32_t *exit_status0,
+ *				     uint32_t *exit_status1);
+ */
+FUNC __thread_enter_user_mode , :
+	/*
+	 * Create and fill in the struct thread_user_mode_rec
+	 */
+	addi	sp, sp, -THREAD_USER_MODE_REC_SIZE
+	store_xregs sp, THREAD_USER_MODE_REC_CTX_REGS_PTR, REG_A0, REG_A2
+	store_xregs sp, THREAD_USER_MODE_REC_X1, REG_RA, REG_TP
+	store_xregs sp, THREAD_USER_MODE_REC_X8, REG_S0, REG_S1
+	store_xregs sp, THREAD_USER_MODE_REC_X18, REG_S2, REG_S11
+
+	/*
+	 * Save the kernel stack pointer in the thread context
+	 */
+
+	/* Get pointer to current thread context */
+	get_thread_ctx s0, s1
+
+	/*
+	 * Save kernel stack pointer to ensure that
+	 * thread_exit_user_mode() uses correct stack pointer.
+	 */
+
+	store_xregs s0, THREAD_CTX_KERN_SP, REG_SP
+	/*
+	 * Save kernel stack pointer in xSCRATCH to ensure that
+	 * thread_trap_vect() uses correct stack pointer.
+	 */
+	csrw	CSR_XSCRATCH, sp
+
+	/*
+	 * Save kernel thread pointer below of the kernel stack pointer
+	 * to enure that thread_trap_vect() uses correct tp when traps
+	 * come from user.
+	 */
+	store_xregs sp, REGOFF(-1), REG_TP
+
+	/* Set user status */
+	load_xregs a0, THREAD_CTX_REG_STATUS, REG_S0
+	csrw	CSR_XSTATUS, s0
+
+	/*
+	 * Save the values for a1 and a2 in struct thread_core_local to be
+	 * restored later just before the xRET.
+	 */
+	store_xregs tp, THREAD_CORE_LOCAL_X10, REG_A1, REG_A2
+
+	/* Load the rest of the general purpose registers */
+	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_TP
+	load_xregs a0, THREAD_CTX_REG_T0, REG_T0, REG_T2
+	load_xregs a0, THREAD_CTX_REG_S0, REG_S0, REG_S1
+	load_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
+	load_xregs a0, THREAD_CTX_REG_T3, REG_T3, REG_T6
+	load_xregs a0, THREAD_CTX_REG_A0, REG_A0, REG_A7
+
+	/* Set exception program counter */
+	csrw		CSR_XEPC, ra
+
+	/* Jump into user mode */
+	XRET
+END_FUNC __thread_enter_user_mode
+
+/*
+ * Implement based on the transport method used to communicate between
+ * untrusted domain and trusted domain. It could be an SBI/ECALL-based to
+ * a security monitor running in M-Mode and panic or messaging-based across
+ * domains where we return to a messaging callback which parses and handles
+ * messages.
+ */
+LOCAL_FUNC thread_return_from_nsec_call , :
+	/* Implement */
+	j	.
+END_FUNC thread_return_from_nsec_call
+
+
+FUNC thread_std_smc_entry , :
+	jal	__thread_std_smc_entry
+
+	/* Save return value */
+	mv	s0, a0
+
+	/* Disable all interrupts */
+	csrc	CSR_XSTATUS, CSR_XSTATUS_IE
+
+	/* Switch to temporary stack */
+	jal	thread_get_tmp_sp
+	mv	sp, a0
+
+	/*
+	 * We are returning from thread_alloc_and_run()
+	 * set thread state as free
+	 */
+	jal	thread_state_free
+
+	/* Restore __thread_std_smc_entry() return value */
+	mv	a1, s0
+	li	a2, 0
+	li	a3, 0
+	li	a4, 0
+	li	a0, TEESMC_OPTEED_RETURN_CALL_DONE
+
+	/* Return to untrusted domain */
+	jal	thread_return_from_nsec_call
+END_FUNC thread_std_smc_entry
+
+/* void thread_resume(struct thread_ctx_regs *regs) */
+FUNC thread_resume , :
+	/*
+	 * Restore all registers assuming that GP
+	 * and TP were not changed.
+	 */
+	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_SP
+	load_xregs a0, THREAD_CTX_REG_T0, REG_T0, REG_T2
+	load_xregs a0, THREAD_CTX_REG_S0, REG_S0, REG_S1
+	load_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
+	load_xregs a0, THREAD_CTX_REG_T3, REG_T3, REG_T6
+	load_xregs a0, THREAD_CTX_REG_A0, REG_A0, REG_A7
+	store_xregs tp, THREAD_CORE_LOCAL_X10, REG_A0, REG_A1
+	ret
+END_FUNC thread_resume
+
+/* void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]) */
+FUNC thread_rpc , :
+	 /* Use stack for temporary storage */
+	addi	sp, sp, -16
+
+	/* Read xSTATUS */
+	csrr	a1, CSR_XSTATUS
+
+	/* Save return address xSTATUS and pointer to rv */
+	STR	a0, REGOFF(0)(sp)
+	STR	a1, REGOFF(1)(sp)
+	STR	ra, REGOFF(2)(sp)
+
+	/* Save thread state */
+	jal	thread_get_ctx_regs
+	store_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_SP
+	store_xregs a0, THREAD_CTX_REG_S0, REG_S0, REG_S1
+	store_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
+
+	/* Get to tmp stack */
+	jal	thread_get_tmp_sp
+
+	/* Get pointer to rv */
+	LDR	s0, REGOFF(0)(sp)
+
+	/* xSTATUS to restore */
+	LDR	a1, REGOFF(1)(sp)
+	/* Switch to tmp stack */
+	mv	sp, a0
+
+	/* Early load rv[] into s1-s3 */
+	lw	s1, 0(s0)
+	lw	s2, 4(s0)
+	lw	s3, 8(s0)
+
+	li	a0, THREAD_FLAGS_COPY_ARGS_ON_RETURN
+	la	a2, .thread_rpc_return
+	jal	thread_state_suspend
+
+	mv	a4, a0	/* thread index */
+	mv	a1, s1	/* rv[0] */
+	mv	a2, s2	/* rv[1] */
+	mv	a3, s3	/* rv[2] */
+	li	a0, TEESMC_OPTEED_RETURN_CALL_DONE
+
+	/* Return to untrusted domain */
+	jal	thread_return_from_nsec_call
+.thread_rpc_return:
+	/*
+	 * Jumps here from thread_resume() above when RPC has returned.
+	 * At this point has the stack pointer been restored to the value
+	 * stored in THREAD_CTX above.
+	 */
+
+	/* Get pointer to rv[] */
+	LDR	a4, REGOFF(0)(sp)
+
+	/* Store a0-a3 into rv[] */
+	sw	a0, 0(a4)
+	sw	a1, 4(a4)
+	sw	a2, 8(a4)
+	sw	a3, 12(a4)
+
+	/* Pop return address from stack */
+	LDR	ra, REGOFF(2)(sp)
+
+	addi	sp, sp, 16
+	ret
+END_FUNC thread_rpc


### PR DESCRIPTION
Summary of changes:
- Introduce helper macros to load/store a range registers from/to a base register at a given offset. It uses LDR and STR macros defined in riscv.h for respectively RV32 and RV64. Offsets are shifted by `RISCV_XLEN_BYTES`.
- Exceptions un/masking
- Trap handling, including syscalls handling.
- Thread allocation, execution, suspension, freeing with slight changes to set RISC-V registers such as CSRs.
-  An entry point of trap handler in non-vectored mode. `thread_unwind_user_mode()` and `thread_exit_user_mode()` to return from U-Mode.
-  `__thread_enter_user_mode()` to jump to U-Mode from S-Mode or M-Mode.
-  `thread_std_smc_entry` and `thread_resume()` to transfer execution to the desired routine.
- Introduce a new function `thread_return_from_nsec_call()` to return to untrusted domain. To be implemented according to the TD-UD programming model. Messaging-based between domains or SBI/ECALL return to a M-Mode security monitor.
-  Declares stacks sizes, `thread_user_mode_rec()` structure to restore context after exiting from U-Mode. It also adds prototypes for thread_rv.s and thread.c.
- Thread RPC to untrusted Domain.

Pending routines:
- Floatting point support F/D/Q/L extensions and software FP.
- Abort mode.
