### PR TITLE
riscv: driver: implement platform-level interrupt controller (PLIC) driver for RISC-V

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -95,12 +95,12 @@ __weak void plat_primary_init_early(void)
 DECLARE_KEEP_PAGER(plat_primary_init_early);
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void main_init_gic(void)
+__weak void primary_init_intc(void)
 {
 }
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void main_secondary_init_gic(void)
+__weak void main_secondary_init_intc(void)
 {
 }
 
@@ -1199,7 +1199,7 @@ void __weak boot_init_primary_late(unsigned long fdt,
 			IMSG("WARNING: This ARM core does not have NMFI enabled, no need for workaround");
 	}
 
-	main_init_gic();
+	primary_init_intc();
 	init_vfp_nsec();
 	if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
 		IMSG("Initializing virtualization support");
@@ -1227,7 +1227,7 @@ static void init_secondary_helper(unsigned long nsec_entry)
 	secondary_init_cntfrq();
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
-	main_secondary_init_gic();
+	main_secondary_init_intc();
 	init_vfp_sec();
 	init_vfp_nsec();
 

--- a/core/arch/arm/plat-aspeed/platform_ast2600.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2600.c
@@ -60,12 +60,12 @@ register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
 
 static struct serial8250_uart_data console_data;
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-aspeed/platform_ast2700.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2700.c
@@ -18,12 +18,12 @@ register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
 
 static struct serial8250_uart_data console_data;
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(0, GICD_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-bcm/main.c
+++ b/core/arch/arm/plat-bcm/main.c
@@ -72,7 +72,7 @@ void console_init(void)
 		      CFG_BCM_ELOG_AP_UART_LOG_SIZE);
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(0, GICD_BASE);
 }

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -21,12 +21,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -106,7 +106,7 @@ void console_init(void)
 #endif
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 #ifdef GICD_BASE
 	gic_init(0, GICD_BASE);
@@ -116,7 +116,7 @@ void main_init_gic(void)
 }
 
 #if CFG_TEE_CORE_NB_CORE > 1
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
+++ b/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
@@ -214,11 +214,11 @@ int imx7d_lowpower_idle(uint32_t power_state __unused,
 		if (!get_core_pos())
 			plat_primary_init_early();
 
-		main_init_gic();
+		primary_init_intc();
 		gic_inited = 1;
 		DMSG("=== Back from Suspended ===\n");
 	} else {
-		main_secondary_init_gic();
+		main_secondary_init_intc();
 		gic_inited = 0;
 	}
 

--- a/core/arch/arm/plat-imx/pm/imx7_suspend.c
+++ b/core/arch/arm/plat-imx/pm/imx7_suspend.c
@@ -63,7 +63,7 @@ int imx7_cpu_suspend(uint32_t power_state __unused, uintptr_t entry,
 	/* Set entry for back to Linux */
 	nsec->mon_lr = (uint32_t)entry;
 
-	main_init_gic();
+	primary_init_intc();
 
 	DMSG("=== Back from Suspended ===\n");
 

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -32,12 +32,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_RT_BASE, SEC_PROXY_RT_SIZE);
 register_ddr(DRAM0_BASE, DRAM0_SIZE);
 register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -199,7 +199,7 @@ static void get_gic_offset(uint32_t *offsetc, uint32_t *offsetd)
 #endif
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	paddr_t gic_base = 0;
 	uint32_t gicc_offset = 0;
@@ -215,7 +215,7 @@ void main_init_gic(void)
 	gic_init(gic_base + gicc_offset, gic_base + gicd_offset);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -71,7 +71,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, CORE_MMU_PGDIR_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, CORE_MMU_PGDIR_SIZE);
 #endif
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	paddr_t gicd_base = 0;
 	paddr_t gicc_base = 0;

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -25,7 +25,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICD_OFFSET,
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICC_OFFSET,
 			CORE_MMU_PGDIR_SIZE);
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-nuvoton/main.c
+++ b/core/arch/arm/plat-nuvoton/main.c
@@ -39,7 +39,7 @@ static void print_version(void)
 	IMSG(COLOR_NORMAL);
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	if (IS_ENABLED(CFG_NPCM_DEBUG))
 		print_version();

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -87,12 +87,12 @@ unsigned long plat_get_aslr_seed(void)
 }
 #endif
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -22,12 +22,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC,
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-rzn1/main.c
+++ b/core/arch/arm/plat-rzn1/main.c
@@ -40,12 +40,12 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-sam/main.c
+++ b/core/arch/arm/plat-sam/main.c
@@ -338,7 +338,7 @@ void plat_primary_init_early(void)
 	matrix_init();
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	if (atmel_saic_setup())
 		panic("Failed to init interrupts\n");

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -45,7 +45,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 			ROUNDDOWN(GIC_BASE + GICD_OFFSET, CORE_MMU_PGDIR_SIZE),
 			CORE_MMU_PGDIR_SIZE);
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -132,12 +132,12 @@ void plat_primary_init_early(void)
 		io_write32(GIC_DIST_BASE + GIC_DIST_ISR1 + i, 0xFFFFFFFF);
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_CPU_BASE, GIC_DIST_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -150,14 +150,14 @@ service_init_late(init_console_from_dt);
 /*
  * GIC init, used also for primary/secondary boot core wake completion
  */
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 
 	stm32mp_register_online_cpu();
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -123,12 +123,12 @@ static inline void tzpc_init(void)
 #endif /* SUNXI_TZPC_BASE */
 
 #ifndef CFG_WITH_ARM_TRUSTED_FW
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-synquacer/main.c
+++ b/core/arch/arm/plat-synquacer/main.c
@@ -35,7 +35,7 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(0, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-ti/a9_plat_init.S
+++ b/core/arch/arm/plat-ti/a9_plat_init.S
@@ -82,7 +82,7 @@ after_resume:
 	mov	r0, r5
 	bl	init_sec_mon
 
-	bl	main_init_gic
+	bl	primary_init_intc
 
 	mov	r0, #TEESMC_OPTEED_RETURN_ENTRY_DONE
 	mov	r1, #0

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -34,12 +34,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GICD_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 		  SERIAL8250_UART_REG_SIZE);
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-totalcompute/main.c
+++ b/core/arch/arm/plat-totalcompute/main.c
@@ -26,7 +26,7 @@ register_ddr(DRAM0_BASE, DRAM0_SIZE);
 register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
 #ifndef CFG_CORE_SEL2_SPMC
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICC_OFFSET);
 }

--- a/core/arch/arm/plat-uniphier/main.c
+++ b/core/arch/arm/plat-uniphier/main.c
@@ -35,7 +35,7 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
 static struct serial8250_uart_data console_data;
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-versal/main.c
+++ b/core/arch/arm/plat-versal/main.c
@@ -46,7 +46,7 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 register_ddr(DRAM2_BASE, DRAM2_SIZE);
 #endif
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -47,13 +47,13 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }
@@ -61,7 +61,7 @@ void main_secondary_init_gic(void)
 #endif /*CFG_GIC*/
 
 #ifdef CFG_CORE_HAFNIUM_INTC
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	hfic_init();
 }

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -141,12 +141,12 @@ void arm_cl2_enable(vaddr_t pl310_base)
 		write_actlr(read_actlr() | (1 << 3));
 }
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
-void main_secondary_init_gic(void)
+void main_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -75,7 +75,7 @@ register_ddr(DRAM1_BASE, CFG_DDR_SIZE - 0x80000000);
 register_ddr(DRAM0_BASE, CFG_DDR_SIZE);
 #endif
 
-void main_init_gic(void)
+void primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -115,12 +115,12 @@ __weak void plat_primary_init_early(void)
 }
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void main_init_plic(void)
+__weak void primary_init_intc(void)
 {
 }
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void main_secondary_init_plic(void)
+__weak void secondary_init_intc(void)
 {
 }
 
@@ -144,7 +144,7 @@ void boot_init_primary_late(unsigned long fdt,
 		IMSG("WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html");
 	}
 	IMSG("Primary CPU initializing");
-	main_init_plic();
+	primary_init_intc();
 	init_tee_runtime();
 	call_finalcalls();
 	IMSG("Primary CPU initialized");
@@ -171,7 +171,7 @@ static void init_secondary_helper(unsigned long nsec_entry)
 
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
-	main_secondary_init_plic();
+	secondary_init_intc();
 
 	IMSG("Secondary CPU %zu initialized", pos);
 }

--- a/core/drivers/plic.c
+++ b/core/drivers/plic.c
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#include <assert.h>
+#include <config.h>
+#include <drivers/plic.h>
+#include <io.h>
+#include <kernel/dt.h>
+#include <kernel/interrupt.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <trace.h>
+
+#define PLIC_PRIORITY_OFFSET		0
+#define PLIC_PENDING_OFFSET		0x1000
+#define PLIC_ENABLE_OFFSET		0x2000
+#define PLIC_THRESHOLD_OFFSET		0x200000
+#define PLIC_CLAIM_OFFSET		0x200004
+
+#define PLIC_PRIORITY_SHIFT_PER_SOURCE	U(2)
+#define PLIC_PENDING_SHIFT_PER_SOURCE	U(0)
+
+#define PLIC_ENABLE_SHIFT_PER_TARGET	U(7)
+#define PLIC_THRESHOLD_SHIFT_PER_TARGET	U(12)
+#define PLIC_CLAIM_SHIFT_PER_TARGET	U(12)
+
+#define PLIC_PRIORITY(base, source) \
+		((base) + PLIC_PRIORITY_OFFSET + \
+		SHIFT_U32(source, PLIC_PRIORITY_SHIFT_PER_SOURCE) \
+	)
+#define PLIC_PENDING(base, source) \
+		((base) + PLIC_PENDING_OFFSET + \
+		(4 * ((source) / 32)) \
+	)
+#define PLIC_ENABLE(base, source, hart) \
+		((base) + PLIC_ENABLE_OFFSET + \
+		SHIFT_U32(hart, PLIC_ENABLE_SHIFT_PER_TARGET) +\
+		(4 * ((source) / 32)) \
+	)
+#define PLIC_THRESHOLD(base, hart) \
+		((base) + PLIC_THRESHOLD_OFFSET + \
+		SHIFT_U32(hart, PLIC_THRESHOLD_SHIFT_PER_TARGET) \
+	)
+#define PLIC_COMPLETE(base, hart) \
+		((base) + PLIC_CLAIM_OFFSET + \
+		SHIFT_U32(hart, PLIC_CLAIM_SHIFT_PER_TARGET) \
+	)
+#define PLIC_CLAIM(base, hart) PLIC_COMPLETE(base, hart)
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, PLIC_BASE, PLIC_REG_SIZE);
+
+static bool __maybe_unused
+plic_is_pending(struct plic_data *pd, uint32_t source)
+{
+	return io_read32(PLIC_PENDING(pd->plic_base, source)) &
+	       BIT(source % 32);
+}
+
+static void plic_set_pending(struct plic_data *pd, uint32_t source)
+{
+	io_setbits32(PLIC_PENDING(pd->plic_base, source), BIT(source % 32));
+}
+
+static void plic_enable_interrupt(struct plic_data *pd, uint32_t source)
+{
+	io_setbits32(PLIC_ENABLE(pd->plic_base, source, get_core_pos()),
+		     BIT(source & 0x1f));
+}
+
+static uint32_t __maybe_unused
+plic_get_interrupt_enable(struct plic_data *pd, uint32_t source)
+{
+	return io_read32(PLIC_ENABLE(pd->plic_base, source, get_core_pos())) &
+	       BIT(source & 0x1f);
+}
+
+static void plic_disable_interrupt(struct plic_data *pd, uint32_t source)
+{
+	io_clrbits32(PLIC_ENABLE(pd->plic_base, source, get_core_pos()),
+		     BIT(source & 0x1f));
+}
+
+static uint32_t __maybe_unused plic_get_threshold(struct plic_data *pd)
+{
+	return io_read32(PLIC_THRESHOLD(pd->plic_base, get_core_pos()));
+}
+
+static void plic_set_threshold(struct plic_data *pd, uint32_t threshold)
+{
+	io_write32(PLIC_THRESHOLD(pd->plic_base, get_core_pos()), threshold);
+}
+
+static uint32_t __maybe_unused
+plic_get_priority(struct plic_data *pd, uint32_t source)
+{
+	return io_read32(PLIC_PRIORITY(pd->plic_base, source));
+}
+
+static void plic_set_priority(struct plic_data *pd, uint32_t source,
+			      uint32_t priority)
+{
+	io_write32(PLIC_PRIORITY(pd->plic_base, source), priority);
+}
+
+static uint32_t plic_claim_interrupt(struct plic_data *pd)
+{
+	return io_read32(PLIC_CLAIM(pd->plic_base, get_core_pos()));
+}
+
+static void plic_complete_interrupt(struct plic_data *pd, uint32_t source)
+{
+	io_write32(PLIC_CLAIM(pd->plic_base, get_core_pos()), source);
+}
+
+static void plic_op_add(struct itr_chip *chip, size_t it,
+			uint32_t type __unused,
+			uint32_t prio)
+{
+	struct plic_data *pd = container_of(chip, struct plic_data, chip);
+
+	if (it > pd->max_it)
+		panic();
+
+	plic_disable_interrupt(pd, it);
+	plic_set_priority(pd, it, prio);
+}
+
+static void plic_op_enable(struct itr_chip *chip, size_t it)
+{
+	struct plic_data *pd = container_of(chip, struct plic_data, chip);
+
+	if (it > pd->max_it)
+		panic();
+
+	plic_enable_interrupt(pd, it);
+}
+
+static void plic_op_disable(struct itr_chip *chip, size_t it)
+{
+	struct plic_data *pd = container_of(chip, struct plic_data, chip);
+
+	if (it > pd->max_it)
+		panic();
+
+	plic_disable_interrupt(pd, it);
+}
+
+static void plic_op_raise_pi(struct itr_chip *chip, size_t it)
+{
+	struct plic_data *pd = container_of(chip, struct plic_data, chip);
+
+	if (it > pd->max_it)
+		panic();
+
+	plic_set_pending(pd, it);
+}
+
+static void plic_op_raise_sgi(struct itr_chip *chip __unused,
+			      size_t it __unused, uint8_t cpu_mask __unused)
+{
+}
+
+static void plic_op_set_affinity(struct itr_chip *chip __unused,
+				 size_t it __unused, uint8_t cpu_mask __unused)
+{
+}
+
+static int plic_dt_get_irq(const uint32_t *properties __unused,
+			   int count __unused, uint32_t *type __unused,
+			   uint32_t *prio __unused)
+{
+	return DT_INFO_INVALID_INTERRUPT;
+}
+
+static size_t probe_max_it(vaddr_t plic_base __unused)
+{
+	return PLIC_NUM_SOURCES;
+}
+
+static const struct itr_ops plic_ops = {
+	.add = plic_op_add,
+	.enable = plic_op_enable,
+	.disable = plic_op_disable,
+	.raise_pi = plic_op_raise_pi,
+	.raise_sgi = plic_op_raise_sgi,
+	.set_affinity = plic_op_set_affinity,
+};
+
+void plic_init_base_addr(struct plic_data *pd, paddr_t plic_base_pa)
+{
+	vaddr_t plic_base = 0;
+
+	assert(cpu_mmu_enabled());
+
+	plic_base = core_mmu_get_va(plic_base_pa, MEM_AREA_IO_SEC,
+				    PLIC_REG_SIZE);
+	if (!plic_base)
+		panic();
+
+	pd->plic_base = plic_base;
+	pd->max_it = probe_max_it(plic_base);
+	pd->chip.ops = &plic_ops;
+
+	if (IS_ENABLED(CFG_DT))
+		pd->chip.dt_get_irq = plic_dt_get_irq;
+}
+
+void plic_hart_init(struct plic_data *pd __unused)
+{
+	/* TODO: To be called by secondary harts */
+}
+
+void plic_init(struct plic_data *pd, paddr_t plic_base_pa)
+{
+	size_t n = 0;
+
+	plic_init_base_addr(pd, plic_base_pa);
+
+	for (n = 0; n <= pd->max_it; n++) {
+		plic_disable_interrupt(pd, n);
+		plic_set_priority(pd, n, 1);
+	}
+
+	plic_set_threshold(pd, 0);
+}
+
+void plic_it_handle(struct plic_data *pd)
+{
+	uint32_t id = plic_claim_interrupt(pd);
+
+	if (id <= pd->max_it)
+		itr_handle(id);
+	else
+		DMSG("ignoring interrupt %" PRIu32, id);
+
+	plic_complete_interrupt(pd, id);
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -76,7 +76,7 @@ srcs-$(CFG_VERSAL_SHA3_384) += versal_sha3_384.c
 srcs-$(CFG_VERSAL_PUF) += versal_puf.c
 srcs-$(CFG_VERSAL_HUK) += versal_huk.c
 srcs-$(CFG_CBMEM_CONSOLE) += cbmem_console.c
-
+srcs-$(CFG_RISCV_PLIC) += plic.c
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt
 subdirs-$(CFG_DRIVERS_CLK) += clk

--- a/core/include/drivers/plic.h
+++ b/core/include/drivers/plic.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#ifndef DRIVERS_PLIC_H
+#define DRIVERS_PLIC_H
+
+#include <kernel/interrupt.h>
+#include <kernel/misc.h>
+#include <platform_config.h>
+
+struct plic_data {
+	vaddr_t plic_base;
+	size_t max_it;
+	struct itr_chip chip;
+};
+
+void plic_init(struct plic_data *pd, paddr_t plic_base_pa);
+void plic_init_base_addr(struct plic_data *pd, paddr_t plic_base_pa);
+void plic_hart_init(struct plic_data *pd);
+void plic_it_handle(struct plic_data *pd);
+void plic_dump_state(struct plic_data *pd);
+
+#endif /*DRIVERS_PLIC_H*/

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -58,8 +58,8 @@ unsigned long boot_cpu_on_handler(unsigned long a0, unsigned long a1);
 void boot_init_secondary(unsigned long nsec_entry);
 #endif
 
-void main_init_gic(void);
-void main_secondary_init_gic(void);
+void primary_init_intc(void);
+void main_secondary_init_intc(void);
 
 void init_sec_mon(unsigned long nsec_entry);
 void init_tee_runtime(void);


### PR DESCRIPTION
An initial implementation of RISC-V PLIC driver conforming to the specification.
`CFG_RISCV_PLIC` flag allows building it or not for platforms with custom PLIC IP.