### PR TITLE
riscv: kernel: implement boot flow for RISC-V

### DIFF
--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#include <assert.h>
+#include <compiler.h>
+#include <config.h>
+#include <console.h>
+#include <keep.h>
+#include <kernel/boot.h>
+#include <kernel/linker.h>
+#include <kernel/misc.h>
+#include <kernel/panic.h>
+#include <kernel/thread.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <mm/tee_mm.h>
+#include <mm/tee_pager.h>
+#include <platform_config.h>
+#include <riscv.h>
+#include <sbi.h>
+#include <stdio.h>
+#include <trace.h>
+#include <util.h>
+
+#define PADDR_INVALID               ULONG_MAX
+
+paddr_t start_addr;
+unsigned long boot_args[4];
+
+uint32_t sem_cpu_sync[CFG_TEE_CORE_NB_CORE];
+
+void init_sec_mon(unsigned long nsec_entry __maybe_unused)
+{
+	assert(nsec_entry == PADDR_INVALID);
+	/* Do nothing as we don't have a secure monitor */
+}
+
+#ifdef CFG_RISCV_S_MODE
+static void start_secondary_cores(void)
+{
+	size_t i = 0;
+	size_t pos = get_core_pos();
+
+	for (i = 0; i < CFG_TEE_CORE_NB_CORE; i++)
+		if (i != pos && IS_ENABLED(CFG_RISCV_SBI) &&
+		    sbi_boot_hart(i, start_addr, i))
+			EMSG("Error starting secondary hart %zu", i);
+}
+#endif
+
+static void init_runtime(void)
+{
+	malloc_add_pool(__heap1_start, __heap1_end - __heap1_start);
+
+	IMSG_RAW("\n");
+}
+
+void init_tee_runtime(void)
+{
+	core_mmu_init_ta_ram();
+	call_preinitcalls();
+	call_initcalls();
+}
+
+static void init_primary(unsigned long nsec_entry)
+{
+	/*
+	 * Mask asynchronous exceptions before switch to the thread vector
+	 * as the thread handler requires those to be masked while
+	 * executing with the temporary stack. The thread subsystem also
+	 * asserts that the foreign interrupts are blocked when using most of
+	 * its functions.
+	 */
+	thread_set_exceptions(THREAD_EXCP_ALL);
+
+	init_runtime();
+	thread_init_boot_thread();
+	thread_init_primary();
+	thread_init_per_cpu();
+	init_sec_mon(nsec_entry);
+}
+
+/* May be overridden in plat-$(PLATFORM)/main.c */
+__weak void plat_primary_init_early(void)
+{
+}
+
+/* May be overridden in plat-$(PLATFORM)/main.c */
+__weak void main_init_plic(void)
+{
+}
+
+/* May be overridden in plat-$(PLATFORM)/main.c */
+__weak void main_secondary_init_plic(void)
+{
+}
+
+void boot_init_primary_early(unsigned long pageable_part __unused,
+			     unsigned long nsec_entry __unused)
+{
+	unsigned long e = PADDR_INVALID;
+
+	init_primary(e);
+}
+
+void boot_init_primary_late(unsigned long fdt __unused)
+{
+	IMSG("OP-TEE version: %s", core_v_str);
+	if (IS_ENABLED(CFG_WARN_INSECURE)) {
+		IMSG("WARNING: This OP-TEE configuration might be insecure!");
+		IMSG("WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html");
+	}
+	IMSG("Primary CPU initializing");
+	main_init_plic();
+	init_tee_runtime();
+	call_finalcalls();
+	IMSG("Primary CPU initialized");
+
+#ifdef CFG_RISCV_S_MODE
+	start_secondary_cores();
+#endif
+}
+
+static void init_secondary_helper(unsigned long nsec_entry)
+{
+	size_t pos = get_core_pos();
+
+	IMSG("Secondary CPU %zu initializing", pos);
+
+	/*
+	 * Mask asynchronous exceptions before switch to the thread vector
+	 * as the thread handler requires those to be masked while
+	 * executing with the temporary stack. The thread subsystem also
+	 * asserts that the foreign interrupts are blocked when using most of
+	 * its functions.
+	 */
+	thread_set_exceptions(THREAD_EXCP_ALL);
+
+	thread_init_per_cpu();
+	init_sec_mon(nsec_entry);
+	main_secondary_init_plic();
+
+	IMSG("Secondary CPU %zu initialized", pos);
+}
+
+void boot_init_secondary(unsigned long nsec_entry __unused)
+{
+	init_secondary_helper(PADDR_INVALID);
+}

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -1,0 +1,220 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#include <asm.S>
+#include <generated/asm-defines.h>
+#include <keep.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <riscv.h>
+#include <riscv_macros.S>
+
+.section .data
+.balign 4
+
+#ifdef CFG_BOOT_SYNC_CPU
+.equ SEM_CPU_READY, 1
+#endif
+
+	/*
+	 * Setup sp to point to the top of the tmp stack for the current CPU:
+	 * sp is assigned:
+	 * stack_tmp + cpu_id * stack_tmp_stride - STACK_TMP_GUARD
+	 */
+.macro set_sp
+	/* Unsupported CPU, park it before it breaks something */
+	li	t1, CFG_TEE_CORE_NB_CORE
+	csrr	t0, CSR_XSCRATCH
+	bge	t0, t1, unhandled_cpu
+	la	t2, stack_tmp
+	lw	t1, stack_tmp_stride
+	/*
+	 * t0 is core pos + 1
+	 * t1 is value of stack_tmp_stride
+	 * t2 is value of stack_tmp
+	 */
+	mv	sp, t2
+	mul	t2, t1, t0
+	add	sp, sp, t2
+.endm
+
+.macro cpu_is_ready
+#ifdef CFG_BOOT_SYNC_CPU
+	csrr	t0, CSR_XSCRATCH
+	la	t1, sem_cpu_sync
+	slli	t0, t0, 2
+	add	t1, t1, t0
+	li	t2, SEM_CPU_READY
+	sw	t2, 0(t1)
+	fence
+#endif
+.endm
+
+.macro set_tp
+	csrr	a0, CSR_XSCRATCH
+	li	a1, THREAD_CORE_LOCAL_SIZE
+	la	tp, thread_core_local
+	mul	a2, a1, a0
+	add	tp, tp, a2
+	sw	a0, THREAD_CORE_LOCAL_HART_ID(tp)
+.endm
+
+.macro set_satp
+	la	a1, boot_mmu_config
+	LDR	a0, CORE_MMU_CONFIG_SATP(a1)
+	csrw	CSR_SATP, a0
+	sfence.vma	zero, zero
+.endm
+
+.macro wait_primary
+#ifdef CFG_BOOT_SYNC_CPU
+	la	t0, sem_cpu_sync
+	li	t2, SEM_CPU_READY
+1:
+	fence	w, w
+	lw	t1, 0(t0)
+	bne	t1, t2, 1b
+#endif
+.endm
+
+.macro wait_secondary
+#ifdef CFG_BOOT_SYNC_CPU
+	la	t0, sem_cpu_sync
+	li	t1, CFG_TEE_CORE_NB_CORE
+	li	t2, SEM_CPU_READY
+1:
+	addi	t1, t1, -1
+	beqz	t1, 3f
+	addi	t0, t0, 4
+2:
+	fence
+	lw	t1, 0(t0)
+	bne	t1, t2, 2b
+	j	1b
+3:
+#endif
+.endm
+
+#ifdef CFG_BOOT_SYNC_CPU
+#define flush_cpu_semaphores \
+		la	t0, sem_cpu_sync_start
+		la	t1, sem_cpu_sync_end
+		fence
+#else
+#define flush_cpu_semaphores
+#endif
+
+.macro bootargs_entry
+	/*
+	 * Save boot arguments
+	 */
+	la	t0, boot_args
+	/* Save boot hart */
+	STR	a0, REGOFF(0)(t0)
+	/* Save FDT address */
+	STR	a1, REGOFF(1)(t0)
+.endm
+
+FUNC _start , :
+.option push
+.option norelax
+	la	gp, __global_pointer$
+.option pop
+#ifdef CFG_RISCV_M_MODE
+	csrr	a0, CSR_MHARTID
+#endif
+	csrw	CSR_XSCRATCH, a0
+	bnez	a0, reset_secondary
+	jal	reset_primary
+	j	.
+END_FUNC _start
+
+LOCAL_FUNC reset_primary , : , .identity_map
+UNWIND(	.cantunwind)
+
+	bootargs_entry
+
+	/*
+	 * Zero bss
+	 */
+	lla	t0, __bss_start
+	lla	t1, __bss_end
+	beq	t0, t1, 1f
+0:
+	STR	zero, (t0)
+	add	t0, t0, RISCV_XLEN_BYTES
+	bne	t0, t1, 0b
+1:
+#ifdef CFG_RISCV_S_MODE
+	lla	t0, _start
+	lla	t1, start_addr
+	STR	t0, (t1)
+#endif
+
+	csrw	CSR_SATP, zero
+	set_sp
+	set_tp
+
+	jal	thread_init_thread_core_local
+	jal	plat_primary_init_early
+	jal	console_init
+
+	mv	a0, x0
+	la	a1, boot_mmu_config
+	jal	core_init_mmu_map
+
+	set_satp
+
+	jal	boot_init_primary_early
+	jal	boot_init_primary_late
+
+	cpu_is_ready
+	flush_cpu_semaphores
+	wait_secondary
+
+	jal	thread_clr_boot_thread
+	j	mu_service
+END_FUNC reset_primary
+
+LOCAL_FUNC reset_secondary , : , .identity_map
+UNWIND(	.cantunwind)
+	wait_primary
+	csrw	CSR_SATP, zero
+	set_sp
+	set_tp
+	set_satp
+	cpu_is_ready
+
+	jal	boot_init_secondary
+	j	.
+END_FUNC reset_secondary
+
+LOCAL_FUNC unhandled_cpu , :
+	wfi
+	j	unhandled_cpu
+END_FUNC unhandled_cpu
+
+#ifdef CFG_BOOT_SYNC_CPU
+LOCAL_DATA sem_cpu_sync_start , :
+	.word	sem_cpu_sync
+END_DATA sem_cpu_sync_start
+
+LOCAL_DATA sem_cpu_sync_end , :
+	.word	sem_cpu_sync + (CFG_TEE_CORE_NB_CORE << 2)
+END_DATA sem_cpu_sync_end
+#endif
+
+LOCAL_DATA stack_tmp_rel , :
+	.word	stack_tmp - stack_tmp_rel - STACK_TMP_GUARD
+END_DATA stack_tmp_rel
+
+LOCAL_DATA stack_tmp_stride_rel , :
+	.word	stack_tmp_stride - stack_tmp_stride_rel
+END_DATA stack_tmp_stride_rel
+
+	.balign	8
+LOCAL_DATA boot_mmu_config , : /* struct core_mmu_config */
+	.skip	CORE_MMU_CONFIG_SIZE
+END_DATA boot_mmu_config

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -3,3 +3,4 @@ srcs-y += idle.c
 srcs-$(CFG_RISCV_TIME_SOURCE_RDTIME) += tee_time_rdtime.c
 srcs-$(CFG_RISCV_SBI) += sbi.c
 srcs-$(CFG_RISCV_SBI_CONSOLE) += sbi_console.c
+srcs-y += boot.c

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -4,3 +4,4 @@ srcs-$(CFG_RISCV_TIME_SOURCE_RDTIME) += tee_time_rdtime.c
 srcs-$(CFG_RISCV_SBI) += sbi.c
 srcs-$(CFG_RISCV_SBI_CONSOLE) += sbi_console.c
 srcs-y += boot.c
+srcs-y += entry.S


### PR DESCRIPTION
Implement boot flow in boot.c and entry.S

**entry.S** provides core's single entry point for RV32/RV64 in S/M Modes. For now it performs: booting primary and secondary harts. Setting stack pointer, thread pointer (to `thread_core_local`), supervisor address translation and protection register, clearing BSS...etc and calls to appropriate functions to initialize the MMU and continue to boot flow from boot.c.

**boot.c** provides an implementation of `init_tee_runtime()`, `plat_primary_init_early()`, `boot_init_primary_early()`, `boot_init_primary_late()`, `boot_init_secondary()` and helper functions.  For now `init_sec_mon()` is kept to be replaced later by a routine to initialize SBI implementation (to for example, probe for available SBI extensions).
