### PR TITLE
core: drivers: nxp: update LX series SFP fuse timeout

### DIFF
--- a/core/drivers/ls_sfp.c
+++ b/core/drivers/ls_sfp.c
@@ -174,7 +174,7 @@ static TEE_Result ls_sfp_program_fuses(void)
 	io_write32(sfp_ingr_va, SFP_INGR_PROGFB_CMD);
 
 	/* Wait until fuse programming is successful */
-	timeout = timeout_init_us(SFP_INGR_FUSE_TIMEOUT);
+	timeout = timeout_init_us(SFP_INGR_FUSE_TIMEOUT_US);
 	while (io_read32(sfp_ingr_va) & SFP_INGR_PROGFB_CMD) {
 		if (timeout_elapsed(timeout)) {
 			EMSG("SFP fusing timed out");

--- a/core/include/drivers/ls_sfp.h
+++ b/core/include/drivers/ls_sfp.h
@@ -16,7 +16,7 @@
 /* SFP is big endian */
 #define SFP_INGR_PROGFB_CMD 0x2
 #define SFP_INGR_ERROR_MASK 0x100
-#define SFP_INGR_FUSE_TIMEOUT 10000
+#define SFP_INGR_FUSE_TIMEOUT_US 150000
 
 /* SFP configuration register */
 #define SFP_SFPCR_SB 0x20000000


### PR DESCRIPTION
- The LX series manual specifies that fusing the SFP can take up to 100ms to complete.
- The fuse timeout in the LS SFP driver should be changed to 150ms so that the possible 100ms timeout has a buffer to interpret errors.

Signed-off-by: Andrew Mustea <andrew.mustea@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
