### PR TITLE
core: drivers: nxp: bit shift the ITS and SB bits when reading the SFP

### DIFF
--- a/core/drivers/ls_sfp.c
+++ b/core/drivers/ls_sfp.c
@@ -264,7 +264,8 @@ TEE_Result ls_sfp_get_its(uint32_t *its)
 	if (!its)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	*its = io_read32((vaddr_t)&sfp_regs->ospr0) & SFP_OSPR0_ITS;
+	*its = (io_read32((vaddr_t)&sfp_regs->ospr0) & SFP_OSPR0_ITS_MASK) >>
+	       SFP_OSPR0_ITS_OFFSET;
 
 	return TEE_SUCCESS;
 }
@@ -300,7 +301,8 @@ TEE_Result ls_sfp_get_sb(uint32_t *sb)
 	if (!sb)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	*sb = io_read32((vaddr_t)&sfp_regs->sfpcr) & SFP_SFPCR_SB;
+	*sb = (io_read32((vaddr_t)&sfp_regs->sfpcr) & SFP_SFPCR_SB_MASK) >>
+	      SFP_SFPCR_SB_OFFSET;
 
 	return TEE_SUCCESS;
 }
@@ -359,12 +361,12 @@ TEE_Result ls_sfp_set_its_wp(void)
 	}
 
 	ospr0 = io_read32((vaddr_t)&sfp_regs->ospr0);
-	if (ospr0 & (SFP_OSPR0_WP | SFP_OSPR0_ITS)) {
+	if (ospr0 & (SFP_OSPR0_WP_MASK | SFP_OSPR0_ITS_MASK)) {
 		DMSG("SFP is already fused");
 		return TEE_ERROR_SECURITY;
 	}
 
-	ospr0 |= SFP_OSPR0_WP | SFP_OSPR0_ITS;
+	ospr0 |= SFP_OSPR0_WP_MASK | SFP_OSPR0_ITS_MASK;
 	io_write32((vaddr_t)&sfp_regs->ospr0, ospr0);
 
 	return ls_sfp_program_fuses();

--- a/core/include/drivers/ls_sfp.h
+++ b/core/include/drivers/ls_sfp.h
@@ -19,11 +19,13 @@
 #define SFP_INGR_FUSE_TIMEOUT 10000
 
 /* SFP configuration register */
-#define SFP_SFPCR_SB 0x20000000
+#define SFP_SFPCR_SB_MASK 0x20000000
+#define SFP_SFPCR_SB_OFFSET 29
 
 /* SFP OEM security policy register 0 */
-#define SFP_OSPR0_WP 0x1
-#define SFP_OSPR0_ITS 0x4
+#define SFP_OSPR0_WP_MASK 0x1
+#define SFP_OSPR0_ITS_MASK 0x4
+#define SFP_OSPR0_ITS_OFFSET 0x2
 
 /* SFP OEM security policy register 1 */
 #define SFP_OSPR1_DBLEV_MASK 0x7


### PR DESCRIPTION
- The Intent to Secure (ITS) and Secure Boot (SB) flags are written to a given pointer in ls_sfp_get_its() and ls_sfp_get_sb() respectively.
- The written values are equivalent to the entire masked OSPR0 and OSPR1 registers.
- The two functions should instead update a pointer with a boolean integer containing the bit shifted value of the desired flag.

Signed-off-by: Andrew Mustea <andrew.mustea@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
