### PR TITLE
scripts: checkpatch: allow git revision selections as arguments

### DIFF
--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -21,15 +21,53 @@ source "$DIR/checkpatch_inc.sh"
 hash $CHECKPATCH 2>/dev/null ||
 		{ echo >&2 "Could not find checkpatch.pl, aborting"; exit 1; }
 
-usage() {
-  SCR=$(basename "$0")
-  echo "Usage: $SCR [--working]                 Check working area"
-  echo "       $SCR <commit>...                 Check specific commits,
-                                                symbolic names, and/or revision
-                                                selections"
-  echo "       $SCR --diff <commit1> <commit2>  Check diff commit1...commit2"
-  echo "       $SCR --cached                    Check staging area"
-  echo "       $SCR --help                      This help"
+help() {
+  cat <<-EOF
+Usage:
+  checkpatch.sh [--working]
+  checkpatch.sh <COMMIT>...
+  checkpatch.sh <SELECTION>...
+  checkpatch.sh --diff <COMMIT> <COMMIT>
+  checkpatch.sh --cached
+  checkpatch.sh --help
+
+Args:
+  <COMMIT>        Any commit or any number of commits.
+  <SELECTION>     Any number of Git Revision Selections. (requires git v2.19)
+                  https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
+
+Options:
+  --working                     Check the working area [Default].
+  --cached                      Check the staging area.
+  --diff <commit1> <commit2>    Check the diff between commit1 and commit2.
+  --help                        Print this help message.
+
+Examples:
+  checkpatch.sh commit1 commit2 commit3   Check commit1, commit2, and commit3.
+
+  checkpatch.sh HEAD~5                    Check the commit 5 revisions before
+                                          the current HEAD.
+
+  checkpatch.sh commit1..^commit2         Check each commit from commit1 to
+                                          commit2 inclusively.
+                                          (requires git v2.19)
+
+  checkpatch.sh HEAD~5..HEAD~1            Check each commit from HEAD~5 to
+                                          HEAD~1 exclusively, aka not including
+                                          HEAD~1. (requires git v2.19)
+
+  checkpatch.sh commit1...tags/tag1       Check each commit that exists
+                                          exclusively within the history of
+                                          only one of each given revision.
+                                          (requires git v2.19)
+
+  checkpatch.sh HEAD~10-5                 Check 5 commits moving forward in
+                                          history starting from HEAD~10.
+                                          (requires git v2.19)
+
+  checkpatch.sh branch1 tags/tag1         Check the HEAD of branch1 and the
+                                          HEAD of tag1. (requires git v2.19)
+EOF
   exit 1
 }
 
@@ -48,7 +86,7 @@ case "$op" in
 		checkworking
 		;;
 	--help|-h)
-		usage
+		help
 		;;
 	*)
 		echo "Checking commit(s):"


### PR DESCRIPTION
- The git commands `git rev-parse` and `git rev-list` were added in version 2.19.
- `git rev-parse` can parse revision names or any revision selection and return the corresponding object name. This includes being able to parse commit ranges, specific hashes, branch names, git tags, etc. See 'https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection' for more info.
- If `git rev-parse` returns a range of git objects, `git rev-list` can convert it into a list of commit ids.

Signed-off-by: Andrew Mustea <andrew.mustea@microsoft.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
