### PR TITLE
core: Correct the description of core_is_buffer_outside

### DIFF
--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -95,7 +95,7 @@ bool core_is_buffer_inside(paddr_t b, paddr_size_t bl,
 	return false;
 }
 
-/* Returns true when buffer 'b' is fully contained in area 'a' */
+/* Returns true when buffer 'b' is fully outside area 'a' */
 bool core_is_buffer_outside(paddr_t b, paddr_size_t bl,
 			    paddr_t a, paddr_size_t al)
 {


### PR DESCRIPTION
Correct the function description of core_is_buffer_outside in comment.

Signed-off-by: Mark-PK Tsai <mark-pk.tsai@mediatek.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
