### PR TITLE
core: mbedtls: fix use of SHA-256 crypto accelerated routines

### DIFF
--- a/lib/libmbedtls/include/mbedtls_config_kernel.h
+++ b/lib/libmbedtls/include/mbedtls_config_kernel.h
@@ -31,7 +31,7 @@
 #if defined(CFG_CRYPTO_SHA224) || defined(CFG_CRYPTO_SHA256)
 #define MBEDTLS_SHA256_C
 #define MBEDTLS_MD_C
-#if defined(CFG_CRYPTO_SHA256_ACCEL)
+#if defined(CFG_CORE_CRYPTO_SHA256_ACCEL)
 #define MBEDTLS_SHA256_PROCESS_ALT
 #endif
 #endif


### PR DESCRIPTION
The wrong name of a configuration was used to test in mbedtls if the accelerated SHA-256 routines should be used. Fix this by using the correct name CFG_CORE_CRYPTO_SHA256_ACCEL instead.

Fixes: 2fc5dc95a949 ("core: mbedtls: use SHA-256 crypto accelerated routines")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
