### PR TITLE
plat-k3: Increase size of high DDR memory region

### DIFF
--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -19,7 +19,7 @@
 #define DRAM0_SIZE      0x80000000
 
 #define DRAM1_BASE      0x880000000
-#define DRAM1_SIZE      0x80000000
+#define DRAM1_SIZE      0x780000000
 
 #define SCU_BASE        0x01800000
 #if defined(PLATFORM_FLAVOR_j721e) || defined(PLATFORM_FLAVOR_j784s4)


### PR DESCRIPTION
With the addition of j784s4 in K3 devices, DRAM size is increased to 32GB.

Update the size of higher memory addresses to handle this.

Signed-off-by: Manorit Chawdhry <m-chawdhry@ti.com>