### PR TITLE
drivers: stm32_bsec: use DT NVMEM layout API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
           _make PLATFORM=stm-cannes
           _make PLATFORM=stm32mp1
           _make PLATFORM=stm32mp1-135F_DK
-          _make PLATFORM=stm32mp1-157C_DK2
           _make PLATFORM=vexpress-fvp
           _make PLATFORM=vexpress-fvp CFG_ARM64_core=y
           _make PLATFORM=vexpress-fvp CFG_ARM64_core=y CFG_CORE_SEL1_SPMC=y CFG_SECURE_PARTITION=y

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -43,6 +43,7 @@ $(error Invalid platform flavor $(PLATFORM_FLAVOR))
 endif
 CFG_EMBED_DTB_SOURCE_FILE ?= $(flavor_dts_file-$(PLATFORM_FLAVOR))
 endif
+CFG_EMBED_DTB_SOURCE_FILE ?= stm32mp157c-dk2.dts
 
 ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-no_cryp)),)
 $(call force,CFG_STM32_CRYP,n)
@@ -75,6 +76,7 @@ endif
 include core/arch/arm/cpu/cortex-a7.mk
 
 $(call force,CFG_DRIVERS_CLK,y)
+$(call force,CFG_DRIVERS_CLK_DT,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_INIT_CNTVOFF,y)
 $(call force,CFG_PSCI_ARM32,y)
@@ -117,21 +119,6 @@ CFG_WITH_SOFTWARE_PRNG ?= y
 CFG_MMAP_REGIONS ?= 23
 CFG_DTB_MAX_SIZE ?= (256 * 1024)
 CFG_CORE_ASLR ?= n
-
-ifeq ($(CFG_EMBED_DTB_SOURCE_FILE),)
-# Some drivers mandate DT support
-$(call force,CFG_DRIVERS_CLK_DT,n)
-$(call force,CFG_STM32_CRYP,n)
-$(call force,CFG_STM32_GPIO,n)
-$(call force,CFG_STM32_I2C,n)
-$(call force,CFG_STM32_IWDG,n)
-$(call force,CFG_STM32_TAMP,n)
-$(call force,CFG_STPMIC1,n)
-$(call force,CFG_STM32MP1_SCMI_SIP,n)
-$(call force,CFG_SCMI_PTA,n)
-else
-$(call force,CFG_DRIVERS_CLK_DT,y)
-endif
 
 ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-512M)),)
 CFG_TZDRAM_START ?= 0xde000000

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -109,15 +109,6 @@
 
 #define OTP_MAX_SIZE			(STM32MP1_OTP_MAX_ID + 1U)
 
-#define CFG0_OTP			0
-#define PART_NUMBER_OTP			1
-#define MONOTONIC_OTP			4
-#define NAND_OTP			9
-#define UID0_OTP			13
-#define UID1_OTP			14
-#define UID2_OTP			15
-#define HW2_OTP				18
-
 /* Bit map for BSEC word CFG0_OTP */
 #ifdef CFG_STM32MP13
 #define CFG0_OTP_CLOSED_DEVICE		U(0x3F)

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -168,12 +168,18 @@ static bool state_is_secured_mode(void)
 
 static bool state_is_closed_mode(void)
 {
+	uint32_t otp_cfg = 0;
 	uint32_t close_mode = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (IS_ENABLED(CFG_STM32MP13))
 		return bsec_status() & BSEC_MODE_CLOSED;
 
-	if (stm32_bsec_read_otp(&close_mode, CFG0_OTP))
+	res = stm32_bsec_find_otp_in_nvmem_layout("cfg0_otp", &otp_cfg, NULL);
+	if (res)
+		panic("CFG0 OTP not found");
+
+	if (stm32_bsec_read_otp(&close_mode, otp_cfg))
 		panic("Unable to read OTP");
 
 	return close_mode & CFG0_OTP_CLOSED_DEVICE;


### PR DESCRIPTION
Use of NVMEM layout in BSEC  driver instead of hardcoded OTP numbers.
