### PR TITLE
plat-stm32mp1: enable debug feature on non secure-closed chip

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -310,6 +310,9 @@ $(error CFG_STM32MP15_HUK_BSEC_KEY and CFG_STM32MP15_HUK_BSEC_DERIVE_UID are exc
 endif
 endif # CFG_STM32MP15_HUK
 
+CFG_TEE_CORE_DEBUG ?= y
+CFG_STM32_DEBUG_ACCESS ?= $(CFG_TEE_CORE_DEBUG)
+
 # Sanity on choice config switches
 ifeq ($(call cfg-all-enabled,CFG_STM32MP15 CFG_STM32MP13),y)
 $(error CFG_STM32MP13_CLK and CFG_STM32MP15_CLK are exclusive)


### PR DESCRIPTION
This P-R enables full debug features if the board is not in secure-closed mode and CFG_TEE_CORE_DEBUG is enabled.
