### PR TITLE
riscv: Implement setjmp() and longjmp() for RISC-V

### DIFF
--- a/lib/libutils/isoc/arch/riscv/setjmp_rv.S
+++ b/lib/libutils/isoc/arch/riscv/setjmp_rv.S
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+#include <asm.S>
+
+#ifdef RV32
+#define STR       sw
+#define LDR       lw
+#define REGOFF(x) ((x) * 4)
+#else
+#define STR       sd
+#define LDR       ld
+#define REGOFF(x) ((x) * 8)
+#endif /*RV32*/
+
+/* int setjmp (jmp_buf) */
+FUNC setjmp , :
+	STR	s0, REGOFF(0)(a0)
+	STR	s1, REGOFF(1)(a0)
+	STR	s2, REGOFF(2)(a0)
+	STR	s3, REGOFF(3)(a0)
+	STR	s4, REGOFF(4)(a0)
+	STR	s5, REGOFF(5)(a0)
+	STR	s6, REGOFF(6)(a0)
+	STR	s7, REGOFF(7)(a0)
+	STR	s8, REGOFF(8)(a0)
+	STR	s9, REGOFF(9)(a0)
+	STR	s10, REGOFF(10)(a0)
+	STR	s11, REGOFF(11)(a0)
+	STR	ra, REGOFF(12)(a0)
+	STR	sp, REGOFF(13)(a0)
+#ifdef CFG_FTRACE_SUPPORT
+	addi	sp, sp, -16
+	STR	ra, (sp)
+	mov	x29, sp
+	addi	a0, a0, REGOFF(12)
+	jal	ftrace_setjmp
+	LDR	ra, (sp)
+	addi	sp, sp, 16
+#endif
+	li 	a0, 0
+	ret
+END_FUNC setjmp
+
+/* void longjmp (jmp_buf, int) __attribute__ ((noreturn)) */
+FUNC longjmp , :
+#ifdef CFG_FTRACE_SUPPORT
+	addi	sp, sp, -16
+	STR	a0, REGOFF(0)(sp)
+	STR	a1, REGOFF(1)(sp)
+	STR	ra, REGOFF(2)(sp)
+	addi	a0, a0, REGOFF(12)
+	jal	ftrace_longjmp
+	LDR	a0, REGOFF(0)(sp)
+	LDR	a1, REGOFF(1)(sp)
+	LDR	ra, REGOFF(2)(sp)
+	addi	sp, sp, 16
+#endif
+	LDR	s0, REGOFF(0)(a0)
+	LDR	s1, REGOFF(1)(a0)
+	LDR	s2, REGOFF(2)(a0)
+	LDR	s3, REGOFF(3)(a0)
+	LDR	s4, REGOFF(4)(a0)
+	LDR	s5, REGOFF(5)(a0)
+	LDR	s6, REGOFF(6)(a0)
+	LDR	s7, REGOFF(7)(a0)
+	LDR	s8, REGOFF(8)(a0)
+	LDR	s9, REGOFF(9)(a0)
+	LDR	s10, REGOFF(10)(a0)
+	LDR	s11, REGOFF(11)(a0)
+	LDR	ra, REGOFF(12)(a0)
+	LDR	sp, REGOFF(13)(a0)
+	seqz	a0, a1
+	add	a0, a0, a1
+	ret
+END_FUNC longjmp

--- a/lib/libutils/isoc/arch/riscv/sub.mk
+++ b/lib/libutils/isoc/arch/riscv/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += setjmp_rv.S

--- a/lib/libutils/isoc/include/setjmp.h
+++ b/lib/libutils/isoc/include/setjmp.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 1994-2009  Red Hat, Inc.
  * Copyright (c) 2016, Linaro Limited
+ * Copyright 2022-2023 NXP
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,6 +51,14 @@
 #if defined(ARM64)
 #define _JBLEN 22
 #define _JBTYPE long long
+#endif
+/*
+ * Callee preserved registers:
+ * s0-s11, ra, sp
+ */
+#if defined(RV64) || defined(RV32)
+#define _JBLEN 14
+#define _JBTYPE unsigned long
 #endif
 
 #ifdef _JBLEN


### PR DESCRIPTION
- Add jmp buffer size and type for RISC-V in setjmp.h
- Implement `setjmp()` and `longjmp()` in setjmp_rv.S