### PR TITLE
libutils: riscv: provide atomic_rv.S

### DIFF
--- a/lib/libutils/ext/arch/riscv/atomic_rv.S
+++ b/lib/libutils/ext/arch/riscv/atomic_rv.S
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2022-2023 NXP
+ */
+
+#include <asm.S>
+
+/* uint32_t atomic_inc32(uint32_t *v); */
+FUNC atomic_inc32 , :
+	li	a1, 1
+	amoadd.w.aqrl a2, a1, (a0)
+	add	a0, a1, a2
+	ret
+END_FUNC atomic_inc32
+
+/* uint32_t atomic_dec32(uint32_t *v); */
+FUNC atomic_dec32 , :
+	li	a1, -1
+	amoadd.w.aqrl a2, a1, (a0)
+	add	a0, a1, a2
+	ret
+END_FUNC atomic_dec32

--- a/lib/libutils/ext/arch/riscv/sub.mk
+++ b/lib/libutils/ext/arch/riscv/sub.mk
@@ -1,0 +1,1 @@
+srcs-y+= atomic_rv.S


### PR DESCRIPTION
Implement `atomic_inc32()` and `atomic_dec32()` in atomic_rv.S. The implementation is based on atomic addition instruction with acquire and release suffix to add additional memory order constraints.

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
