### PR TITLE
libutils: change assert() to conform with stdlib implementation

### DIFF
--- a/lib/libutils/isoc/include/assert.h
+++ b/lib/libutils/isoc/include/assert.h
@@ -12,17 +12,19 @@ void __noreturn _assert_break(void);
 void _assert_log(const char *expr, const char *file, const int line,
 			const char *func);
 
-/* assert() specs: generates a log but does not panic if NDEBUG is defined */
+static inline void __noreturn _assert_trap(const char *expr_str,
+					   const char *file, const int line,
+					   const char *func)
+{
+	_assert_log(expr_str, file, line, func);
+	_assert_break();
+}
+
 #ifdef NDEBUG
-#define assert(expr)	do { } while (0)
+#define assert(expr)	((void)0)
 #else
-#define assert(expr) \
-	do { \
-		if (!(expr)) { \
-			_assert_log(#expr, __FILE__, __LINE__, __func__); \
-			_assert_break(); \
-		} \
-	} while (0)
+#define assert(expr)	\
+	((expr) ? (void)0 : _assert_trap(#expr, __FILE__, __LINE__, __func__))
 #endif
 
 /* This macro is deprecated, please use static_assert instead */


### PR DESCRIPTION
Changes assert() definition to return a (dummy) value when expression to true. This change allows to integrate external libraries which assume assert() conforms to such implementation, as found in GCC or LLVM toolchains.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
