### PR TITLE
Differentiate device tree property access error codes

### DIFF
--- a/core/drivers/rstctrl/rstctrl.c
+++ b/core/drivers/rstctrl/rstctrl.c
@@ -46,7 +46,7 @@ TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
 
 	index = fdt_stringlist_search(fdt, nodeoffset, "reset-names", name);
 	if (index < 0)
-		return TEE_ERROR_GENERIC;
+		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	return rstctrl_dt_get_by_index(fdt, nodeoffset, index, rstctrl);
 }

--- a/core/include/drivers/rstctrl.h
+++ b/core/include/drivers/rstctrl.h
@@ -153,6 +153,7 @@ static inline bool rstctrl_ops_is_valid(const struct rstctrl_ops *ops)
  *
  * Return TEE_SUCCESS in case of success
  * Return TEE_ERROR_DEFER_DRIVER_INIT if reset controller is not initialized
+ * Return TEE_ERROR_ITEM_NOT_FOUND if the resets property does not exist
  * Return a TEE_Result compliant code in case of error
  */
 static inline TEE_Result rstctrl_dt_get_by_index(const void *fdt,
@@ -189,6 +190,7 @@ static inline TEE_Result rstctrl_dt_get_by_index(const void *fdt __unused,
  *
  * Return TEE_SUCCESS in case of success
  * Return TEE_ERROR_DEFER_DRIVER_INIT if reset controller is not initialized
+ * Return TEE_ERROR_ITEM_NOT_FOUND if the reset-names property does not exist
  * Return a TEE_Result compliant code in case of error
  */
 TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -74,6 +74,7 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
  * @res: Output result code of the operation:
  *	TEE_SUCCESS in case of success
  *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
+ *	TEE_ERROR_ITEM_NOT_FOUND if prop_name does not match a property's name
  *	Any TEE_Result compliant code in case of error.
  *
  * Return a device opaque reference, e.g. a struct clk pointer for a clock

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -262,7 +262,7 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 	if (!prop) {
 		DMSG("Property %s missing in node %s", prop_name,
 		     fdt_get_name(fdt, nodeoffset, NULL));
-		*res = TEE_ERROR_GENERIC;
+		*res = TEE_ERROR_ITEM_NOT_FOUND;
 		return NULL;
 	}
 
@@ -294,7 +294,7 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 		return device_from_provider_prop(prv, prop + idx32, res);
 	}
 
-	*res = TEE_ERROR_GENERIC;
+	*res = TEE_ERROR_ITEM_NOT_FOUND;
 	return NULL;
 }
 


### PR DESCRIPTION
Add a way to differentiate missing properties from actual device tree errors when looking for a property.