### PR TITLE
plat-k3: Add support for modifying extended OTP bits

### DIFF
--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -16,6 +16,7 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_K3_OTP_KEYWRITING,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 
 ifneq (,$(filter ${PLATFORM_FLAVOR},am65x j721e j784s4 am64x am62x))

--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -154,13 +154,6 @@ static inline int ti_sci_do_xfer(struct ti_sci_xfer *xfer)
 	return 0;
 }
 
-/**
- * ti_sci_get_revision() - Get the revision of the SCI entity
- *
- * Updates the SCI information in the internal data structure.
- *
- * Return: 0 if all goes well, else appropriate error message
- */
 int ti_sci_get_revision(struct ti_sci_msg_resp_version *rev_info)
 {
 	struct ti_sci_msg_req_version req = { };
@@ -318,17 +311,6 @@ int ti_sci_change_fwl_owner(uint16_t fwl_id, uint16_t region,
 	return 0;
 }
 
-/**
- * ti_sci_get_dkek() - Get the DKEK
- * @sa2ul_instance:	SA2UL instance to get key
- * @context:		Context string input to KDF
- * @label:		Label string input to KDF
- * @dkek:		Returns with DKEK populated
- *
- * Updates the DKEK the internal data structure.
- *
- * Return: 0 if all goes well, else appropriate error message
- */
 int ti_sci_get_dkek(uint8_t sa2ul_instance,
 		    const char *context, const char *label,
 		    uint8_t dkek[SA2UL_DKEK_KEY_LEN])
@@ -364,15 +346,6 @@ int ti_sci_get_dkek(uint8_t sa2ul_instance,
 	return 0;
 }
 
-/**
- * ti_sci_read_otp_mmr() - Get the Extended OTP
- * @mmr_idx:		32-bit MMR index
- * @val:		Value of the 32-bit MMR
- *
- * Reads the extended OTP bits from efuse
- *
- * Return: 0 if all goes well, else appropriate error message
- */
 int ti_sci_read_otp_mmr(uint8_t mmr_idx, uint32_t *val)
 {
 	struct ti_sci_msg_req_read_otp_mmr req = { };
@@ -398,16 +371,6 @@ exit:
 	return ret;
 }
 
-/**
- * ti_sci_write_otp_row() - Write the extended OTP row
- * @row_idx:		Index of the OTP row. Zero indexing
- * @row_val:		Value to be written
- * @row_mask:		Mask bits for row_val to be written
- *
- * Writes a Row in the extended OTP field
- *
- * Return: 0 if all goes well, else appropriate error message
- */
 int ti_sci_write_otp_row(uint8_t row_idx, uint32_t row_val, uint32_t row_mask)
 {
 	struct ti_sci_msg_req_write_otp_row req = { };
@@ -443,17 +406,6 @@ exit:
 	return ret;
 }
 
-/**
- * ti_sci_lock_otp_row - Locking the Extended OTP row
- * @row_idx:		Index of the OTP row. Zero indexing
- * @hw_write_lock:	Hardware write lock
- * @hw_read_lock:	Hardware read lock
- * @row_soft_lock:	Software write lock
- *
- * Locks a Row in the extended OTP field to prevent read/writes
- *
- * Return: 0 if all goes well, else appropriate error message
- */
 int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
 			uint8_t hw_read_lock, uint8_t row_soft_lock)
 {
@@ -479,11 +431,6 @@ int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
 	return 0;
 }
 
-/**
- * ti_sci_init() - Basic initialization
- *
- * Return: 0 if all goes well, else appropriate error message
- */
 int ti_sci_init(void)
 {
 	struct ti_sci_msg_resp_version rev_info = { };

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -125,6 +125,43 @@ int ti_sci_get_dkek(uint8_t sa2ul_instance,
 		    uint8_t dkek[SA2UL_DKEK_KEY_LEN]);
 
 /**
+ * ti_sci_read_otp_mmr() - Get the Extended OTP
+ * @mmr_idx:	        32-bit MMR index
+ * @val:		Value of the 32-bit MMR
+ *
+ * Reads the extended OTP bits from efuse
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_read_otp_mmr(uint8_t mmr_idx, uint32_t *val);
+
+/**
+ * ti_sci_write_otp_row() - Write the extended OTP row
+ * @row_idx:		Index of the OTP row. Zero indexing
+ * @row_val:		Value to be written
+ * @row_mask:		Mask bits for row_val to be written
+ *
+ * Writes a Row in the extended OTP field
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_write_otp_row(uint8_t row_idx, uint32_t row_val, uint32_t row_mask);
+
+/**
+ * ti_sci_lock_otp_row - Locking the Extended OTP row
+ * @row_idx:		Index of the OTP row. Zero indexing
+ * @hw_write_lock:	Hardware write lock
+ * @hw_read_lock:	Hardware read lock
+ * @row_soft_lock:	Software write lock
+ *
+ * Lockes a Row in the extended OTP field to prevent read/writes
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
+			uint8_t hw_read_lock, uint8_t row_soft_lock);
+
+/**
  * ti_sci_init() - Basic initialization
  *
  * Return: 0 if all goes well, else appropriate error message

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -23,6 +23,9 @@
 #define TI_SCI_MSG_FWL_GET               0x9001
 #define TI_SCI_MSG_FWL_CHANGE_OWNER      0x9002
 #define TI_SCI_MSG_SA2UL_GET_DKEK        0x9029
+#define TI_SCI_MSG_READ_OTP_MMR          0x9022
+#define TI_SCI_MSG_WRITE_OTP_ROW         0x9023
+#define TI_SCI_MSG_LOCK_OTP_ROW          0x9024
 
 /**
  * struct ti_sci_secure_msg_hdr - Secure Message Header for All messages
@@ -294,6 +297,86 @@ struct ti_sci_msg_resp_sa2ul_get_dkek {
 	struct ti_sci_msg_hdr hdr;
 #define SA2UL_DKEK_KEY_LEN 32
 	uint8_t dkek[SA2UL_DKEK_KEY_LEN];
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_read_otp_mmr - Request for reading extended OTP
+ * @hdr:	Generic header
+ * @mmr_idx:	Index of 32 bit MMR
+ *
+ * Request for TI_SCI_MSG_READ_OTP_MMR
+ */
+struct ti_sci_msg_req_read_otp_mmr {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t mmr_idx;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_read_otp_mmr - Response for reading extended OTP
+ * @hdr:	Generic header
+ * @mmr_val:	Value written in the OTP
+ *
+ * Response to request TI_SCI_MSG_READ_OTP_MMR
+ */
+struct ti_sci_msg_resp_read_otp_mmr {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t mmr_val;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_write_otp_row - Request for writing Extended OTP
+ * @hdr:	Generic header
+ * @row_idx:		Index of the OTP row. Zero indexing
+ * @row_val:		Value to be written
+ * @row_mask:		Mask bits for row_val to be written
+ *
+ * Request for TI_SCI_MSG_WRITE_OTP_ROW
+ */
+struct ti_sci_msg_req_write_otp_row {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t row_idx;
+	uint32_t row_val;
+	uint32_t row_mask;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_write_otp_row - Response for writing Extended OTP
+ * @hdr:		Generic header
+ * @row_val:		Value that is written
+ *
+ * Response to request TI_SCI_MSG_WRITE_OTP_ROW
+ */
+struct ti_sci_msg_resp_write_otp_row {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t row_val;
+} __packed;
+
+/**
+ * struct ti_sci_msg_req_lock_otp_row - Request for Lock OTP row
+ * @hdr:		Generic header
+ * @row_idx:		Index of the OTP row. Zero indexing
+ * @hw_write_lock:	0x5A indicates row will be write protected
+ * @hw_read_lock:	0x5A indicates row will be read protected
+ * @row_soft_lock:	Software write lock
+ *
+ * Request for TI_SCI_MSG_LOCK_OTP_ROW
+ */
+struct ti_sci_msg_req_lock_otp_row {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t row_idx;
+	uint8_t hw_write_lock;
+	uint8_t hw_read_lock;
+	uint8_t row_soft_lock;
+} __packed;
+
+/**
+ * struct ti_sci_msg_resp_lock_otp_row - Response for Lock OTP row
+ * @hdr:	Generic header
+ *
+ * Response to request TI_SCI_MSG_LOCK_OTP_ROW
+ */
+struct ti_sci_msg_resp_lock_otp_row {
+	struct ti_sci_msg_hdr hdr;
 } __packed;
 
 #endif

--- a/core/pta/k3/otp.c
+++ b/core/pta/k3/otp.c
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Texas Instruments System Control Interface Driver
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *	Manorit Chawdhry <m-chawdhry@ti.com>
+ */
+
+#include <drivers/ti_sci.h>
+#include <inttypes.h>
+#include <k3/otp_keywriting_ta.h>
+#include <kernel/pseudo_ta.h>
+
+static TEE_Result write_otp_row(uint32_t param_types, TEE_Param params[4])
+{
+	TEE_Result ret = TEE_SUCCESS;
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE);
+
+	/*
+	 * Safely get the invocation parameters
+	 */
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	ret = ti_sci_write_otp_row(params[0].value.a, params[1].value.a,
+				   params[1].value.b);
+	if (ret)
+		return ret;
+
+	DMSG("Written the value: 0x%08"PRIx32, params[1].value.a);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result read_otp_mmr(uint32_t param_types, TEE_Param params[4])
+{
+	TEE_Result ret = TEE_SUCCESS;
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_VALUE_OUTPUT,
+				TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+
+	/*
+	 * Safely get the invocation parameters
+	 */
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	ret = ti_sci_read_otp_mmr(params[0].value.a, &params[1].value.a);
+	if (ret)
+		return ret;
+
+	DMSG("Got the value: 0x%08"PRIx32, params[1].value.a);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result lock_otp_row(uint32_t param_types, TEE_Param params[4])
+{
+	TEE_Result ret = TEE_SUCCESS;
+	int hw_write_lock = 0;
+	int hw_read_lock = 0;
+	int soft_lock = 0;
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+
+	/*
+	 * Safely get the invocation parameters
+	 */
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (params[0].value.b & K3_OTP_KEYWRITING_SOFT_LOCK)
+		soft_lock = 0x5A;
+	if (params[0].value.b & K3_OTP_KEYWRITING_HW_READ_LOCK)
+		hw_read_lock = 0x5A;
+	if (params[0].value.b & K3_OTP_KEYWRITING_HW_WRITE_LOCK)
+		hw_write_lock = 0x5A;
+
+	DMSG("hw_write_lock: 0x%#x", hw_write_lock);
+	DMSG("hw_read_lock: 0x%#x", hw_read_lock);
+	DMSG("soft_lock: 0x%#x", soft_lock);
+
+	ret = ti_sci_lock_otp_row(params[0].value.a, hw_write_lock,
+				  hw_read_lock, soft_lock);
+
+	if (ret)
+		return ret;
+
+	DMSG("Locked the row: 0x%08"PRIx32, params[1].value.a);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result invoke_command(void *session __unused,
+				 uint32_t command, uint32_t param_types,
+				 TEE_Param params[4])
+{
+	switch (command) {
+	case TA_OTP_KEYWRITING_CMD_READ_MMR:
+		return read_otp_mmr(param_types, params);
+	case TA_OTP_KEYWRITING_CMD_WRITE_ROW:
+		return write_otp_row(param_types, params);
+	case TA_OTP_KEYWRITING_CMD_LOCK_ROW:
+		return lock_otp_row(param_types, params);
+	default:
+		EMSG("Command ID 0x%"PRIx32" is not supported", command);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+}
+
+pseudo_ta_register(.uuid = PTA_K3_OTP_KEYWRITING_UUID,
+		   .name = PTA_K3_OTP_KEYWRITING_NAME,
+		   .flags = PTA_DEFAULT_FLAGS,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/pta/k3/sub.mk
+++ b/core/pta/k3/sub.mk
@@ -1,0 +1,1 @@
+srcs-$(CFG_K3_OTP_KEYWRITING) += otp.c

--- a/core/pta/sub.mk
+++ b/core/pta/sub.mk
@@ -18,3 +18,4 @@ srcs-$(CFG_RTC_PTA) += rtc.c
 subdirs-y += bcm
 subdirs-y += stm32mp
 subdirs-y += imx
+subdirs-y += k3

--- a/lib/libutee/include/k3/otp_keywriting_ta.h
+++ b/lib/libutee/include/k3/otp_keywriting_ta.h
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Texas Instruments System Control Interface Driver
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *	Manorit Chawdhry <m-chawdhry@ti.com>
+ */
+
+#ifndef __K3_OTP_KEYWRITING_TA_H__
+#define __K3_OTP_KEYWRITING_TA_H__
+
+/* UUID of the trusted application */
+#define PTA_K3_OTP_KEYWRITING_UUID \
+	{ 0xacc50f40, 0x0613, 0x4abd, \
+		{ 0x8d, 0xfe, 0xa9, 0x64, 0xcb, 0x74, 0xeb, 0x69} }
+
+#define PTA_K3_OTP_KEYWRITING_NAME "pta_k3_otp.ta"
+
+/*
+ * TA_OTP_KEYWRITING_CMD_READ_MMR - Read an extended OTP bit
+ * param[0] (value/input)  32-bit MMR index
+ * param[1] (value/output) OTP value written in efuse
+ * param[2] unused
+ * param[3] unused
+ */
+#define TA_OTP_KEYWRITING_CMD_READ_MMR		0
+
+/*
+ * TA_OTP_KEYWRITING_CMD_WRITE_ROW - Write into extended OTP row
+ * param[0] (value/input) Row index
+ * param[1].a (value/input) Value to be written
+ * param[1].b (value/input) Mask for the value
+ * param[2] unused
+ * param[3] unused
+ */
+#define TA_OTP_KEYWRITING_CMD_WRITE_ROW		1
+
+/*
+ * TA_OTP_KEYWRITING_CMD_LOCK_ROW - Lock an extended OTP row
+ * param[0].a (value/input) Row index
+ * param[0].b (value/input)
+ *	BIT(0) - soft_lock
+ *	BIT(1) - hw_read_lock
+ *	BIT(2) - hw_write_lock
+ * param[1] unused
+ * param[2] unused
+ * param[3] unused
+ */
+#define TA_OTP_KEYWRITING_CMD_LOCK_ROW		2
+
+#define K3_OTP_KEYWRITING_SOFT_LOCK		BIT(0)
+#define K3_OTP_KEYWRITING_HW_READ_LOCK		BIT(1)
+#define K3_OTP_KEYWRITING_HW_WRITE_LOCK		BIT(2)
+
+#endif /* __K3_OTP_KEYWRITING_TA_H__ */


### PR DESCRIPTION
K3 family of devices have a set of one-time programmable(OTP) efuses to carry root of trust keys and other information used during device boot. The purpose of these efuses is fixed. K3 family of devices have another set of OTP efuses for general purpose use by the customer. 

The PR adds support for reading/writing into these bits through a K3 specific PTA, any ideas around making it a generic like HUK would be a plus. Open to suggestions

https://software-dl.ti.com/tisci/esd/latest/6_topic_user_guides/extended_otp.html