### PR TITLE
core: pta: scmi: fix typo in open session test

### DIFF
--- a/core/pta/scmi.c
+++ b/core/pta/scmi.c
@@ -213,7 +213,7 @@ static TEE_Result pta_scmi_open_session(uint32_t ptypes __unused,
 		return TEE_ERROR_ACCESS_DENIED;
 	}
 
-	if (IS_ENABLED(CFG_SCMI_MSG_DRVIERS) || IS_ENABLED(CFG_SCMI_SCPFW))
+	if (IS_ENABLED(CFG_SCMI_MSG_DRIVERS) || IS_ENABLED(CFG_SCMI_SCPFW))
 		return TEE_SUCCESS;
 
 	return TEE_ERROR_NOT_SUPPORTED;


### PR DESCRIPTION
Fixes a typo in config switch name CFG_SCMI_MSG_DRIVERS in SCMI PTA open session function.

Fixes: 7ff454421a8c ("core: pta: scmi: support SCP-firmware SCMI resources")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
