### PR TITLE
core: sp: Allow v2 FIP package format

### DIFF
--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2020-2022, Arm Limited.
+ * Copyright (c) 2020-2023, Arm Limited.
  */
 #include <bench.h>
 #include <crypto/crypto.h>
@@ -47,7 +47,8 @@
 					 SP_MANIFEST_ATTR_EXEC)
 
 #define SP_PKG_HEADER_MAGIC (0x474b5053)
-#define SP_PKG_HEADER_VERSION (0x1)
+#define SP_PKG_HEADER_VERSION_V1 (0x1)
+#define SP_PKG_HEADER_VERSION_V2 (0x2)
 
 struct sp_pkg_header {
 	uint32_t magic;
@@ -1130,7 +1131,8 @@ static TEE_Result process_sp_pkg(uint64_t sp_pkg_pa, TEE_UUID *sp_uuid)
 		goto err_unmap;
 	}
 
-	if (sp_pkg_hdr->version != SP_PKG_HEADER_VERSION) {
+	if (sp_pkg_hdr->version != SP_PKG_HEADER_VERSION_V1 &&
+	    sp_pkg_hdr->version != SP_PKG_HEADER_VERSION_V2) {
 		EMSG("Invalid SP header version");
 		res = TEE_ERROR_BAD_FORMAT;
 		goto err_unmap;


### PR DESCRIPTION
Commit 2e82874cc9b7922e000dd4d7718e3153e347b1d7 in Trusted Firmware-A slightly changes the SP package format in the FIP image. The new format is compatible with the previous version thus it is only necessary to allow the new version number on FIP SP load.

Signed-off-by: Imre Kis <imre.kis@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
