### PR TITLE
pta: stm32mp: mention access denied error code in BSEC PTA API

### DIFF
--- a/lib/libutee/include/pta_stm32mp_bsec.h
+++ b/lib/libutee/include/pta_stm32mp_bsec.h
@@ -20,6 +20,7 @@
  * Return codes:
  * TEE_SUCCESS - Invoke command success
  * TEE_ERROR_BAD_PARAMETERS - Incorrect input param
+ * TEE_ERROR_ACCESS_DENIED - OTP not accessible by caller
  */
 #define PTA_BSEC_CMD_READ_OTP		0x0
 


### PR DESCRIPTION
Fixes BSEC PTA API header file that did not mention possible error code TEE_ERROR_ACCESS_DENIED for command PTA_BSEC_CMD_READ_OTP.

Fixes: 4583de067b5d ("pta: stm32mp: add BSEC PTA")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
