### PR TITLE
config: add CFG_BUILD_USER_TA flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,13 @@ endef
 $(foreach t, $(ta-targets), $(eval $(call build-ta-target, $(t))))
 
 # Build user TAs included in this git
+ifeq ($(CFG_BUILD_IN_TREE_TA),y)
 define build-user-ta
 ta-mk-file := $(1)
 include ta/mk/build-user-ta.mk
 endef
 $(foreach t, $(sort $(wildcard ta/*/user_ta.mk)), $(eval $(call build-user-ta,$(t))))
+endif
 endif
 
 include mk/cleandirs.mk

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -271,6 +271,9 @@ endif
 # Enable support for dynamically loaded user TAs
 CFG_WITH_USER_TA ?= y
 
+# Build user TAs included in this source tree
+CFG_BUILD_IN_TREE_TA ?= y
+
 # Choosing the architecture(s) of user-mode libraries (used by TAs)
 #
 # Platforms may define a list of supported architectures for user-mode code


### PR DESCRIPTION
This flag allows us to enable or disable building "User TAs". By disabling "User TAs" we could build "TA_DEV_KIT" without building TAs present in optee-os project under ta/*/user_ta.mk.

Signed-off-by: Julien Masson <jmasson@baylibre.com>
Signed-off-by: Balsam CHIHI <bchihi@baylibre.com>
Signed-off-by: Safae Ouajih <souajih@baylibre.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
