### PR TITLE
ta: avb: fix object leakage at lock state write

### DIFF
--- a/ta/avb/entry.c
+++ b/ta/avb/entry.c
@@ -239,7 +239,11 @@ static TEE_Result write_lock_state(uint32_t pt,
 	if (count == sizeof(lock_state) && lock_state == wlock_state)
 		goto out;
 
-	res = create_rb_state(wlock_state, &h);
+	res = TEE_SeekObjectData(h, 0, TEE_DATA_SEEK_SET);
+	if (res)
+		goto out;
+
+	res = TEE_WriteObjectData(h, &wlock_state, sizeof(wlock_state));
 out:
 	TEE_CloseObject(h);
 	return res;


### PR DESCRIPTION
Should close object created for reading, so better use seek and then close the object.

Fixes: b29b41950 ("ta: add AVB TA")
Signed-off-by: Ivan Khoronzhuk <ivan.khoronzhuk@globallogic.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
