### PR TITLE
mm: core_memprot: align convenience macroses usage

### DIFF
--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -189,7 +189,7 @@ static uint32_t std_entry_with_parg(paddr_t parg, bool with_rpc_arg)
 	uint32_t rv = 0;
 
 	/* Check if this region is in static shared space */
-	if (core_pbuf_is(CORE_MEM_NSEC_SHM, parg, sz)) {
+	if (tee_pbuf_is_nsec_shm(parg, sz)) {
 		if (!IS_ALIGNED_WITH_TYPE(parg, struct optee_msg_arg))
 			goto bad_addr;
 
@@ -207,7 +207,7 @@ static uint32_t std_entry_with_parg(paddr_t parg, bool with_rpc_arg)
 			rpc_arg = (void *)((uint8_t *)arg + sz);
 			sz += OPTEE_MSG_GET_ARG_SIZE(THREAD_RPC_MAX_NUM_PARAMS);
 		}
-		if (!core_pbuf_is(CORE_MEM_NSEC_SHM, parg, sz))
+		if (!tee_pbuf_is_nsec_shm(parg, sz))
 			goto bad_addr;
 
 		return call_entry_std(arg, num_params, rpc_arg);
@@ -369,7 +369,7 @@ out:
 static struct mobj *rpc_shm_mobj_alloc(paddr_t pa, size_t sz, uint64_t cookie)
 {
 	/* Check if this region is in static shared space */
-	if (core_pbuf_is(CORE_MEM_NSEC_SHM, pa, sz))
+	if (tee_pbuf_is_nsec_shm(pa, sz))
 		return mobj_shm_alloc(pa, sz, cookie);
 
 	if (IS_ENABLED(CFG_CORE_DYN_SHM) &&

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -161,7 +161,7 @@ static int map_buf(paddr_t pa, unsigned int sz, void **va_ret)
 {
 	tee_mm_entry_t *mm = NULL;
 
-	if (!core_pbuf_is(CORE_MEM_NON_SEC, pa, sz))
+	if (!tee_pbuf_is_non_sec(pa, sz))
 		return FFA_INVALID_PARAMETERS;
 
 	mm = tee_mm_alloc(&tee_mm_shm, sz);
@@ -735,7 +735,7 @@ static int handle_mem_share_tmem(paddr_t pbuf, size_t blen, size_t flen,
 
 	if (MUL_OVERFLOW(page_count, SMALL_PAGE_SIZE, &len))
 		return FFA_INVALID_PARAMETERS;
-	if (!core_pbuf_is(CORE_MEM_NON_SEC, pbuf, len))
+	if (!tee_pbuf_is_non_sec(pbuf, len))
 		return FFA_INVALID_PARAMETERS;
 
 	/*

--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -326,8 +326,8 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 			goto err;
 
 		/* Only Non-secure memory can be mapped there */
-		if (!core_pbuf_is(CORE_MEM_NON_SEC, mobj_reg_shm->pages[i],
-				  SMALL_PAGE_SIZE))
+		if (!tee_pbuf_is_non_sec(mobj_reg_shm->pages[i],
+					 SMALL_PAGE_SIZE))
 			goto err;
 	}
 

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -215,7 +215,7 @@ TEE_Result mobj_ffa_add_pages_at(struct mobj_ffa *mf, unsigned int *idx,
 	if (ADD_OVERFLOW(*idx, num_pages, &n) || n > tot_page_count)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (!core_pbuf_is(CORE_MEM_NON_SEC, pa, num_pages * SMALL_PAGE_SIZE))
+	if (!tee_pbuf_is_non_sec(pa, num_pages * SMALL_PAGE_SIZE))
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	for (n = 0; n < num_pages; n++)

--- a/core/drivers/crypto/caam/utils/utils_mem.c
+++ b/core/drivers/crypto/caam/utils/utils_mem.c
@@ -190,7 +190,7 @@ bool caam_mem_is_cached_buf(void *buf, size_t size)
 	if (mtype == MEM_AREA_MAXTYPE)
 		is_cached = true;
 	else
-		is_cached = core_vbuf_is(CORE_MEM_CACHED, buf, size);
+		is_cached = tee_vbuf_is_cached(buf, size);
 
 	return is_cached;
 }

--- a/core/include/mm/core_memprot.h
+++ b/core/include/mm/core_memprot.h
@@ -38,6 +38,9 @@ enum buf_is_attr {
 #define tee_vbuf_is     core_vbuf_is
 
 /* Convenience macros */
+#define tee_pbuf_is_nsec_shm(buf, len) \
+		core_pbuf_is(CORE_MEM_NSEC_SHM, (paddr_t)(buf), (len))
+
 #define tee_pbuf_is_non_sec(buf, len) \
 		core_pbuf_is(CORE_MEM_NON_SEC, (paddr_t)(buf), (len))
 
@@ -49,6 +52,12 @@ enum buf_is_attr {
 
 #define tee_vbuf_is_sec(buf, len) \
 		core_vbuf_is(CORE_MEM_SEC, (void *)(buf), (len))
+
+#define tee_vbuf_is_sdp(buf, len) \
+		core_vbuf_is(CORE_MEM_SDP_MEM, (void *)(buf), (len))
+
+#define tee_vbuf_is_cached(buf, len) \
+		core_vbuf_is(CORE_MEM_CACHED, (void *)(buf), (len))
 
 /*
  * This function return true if the buf complies with supplied flags.

--- a/core/mm/mobj.c
+++ b/core/mm/mobj.c
@@ -445,7 +445,7 @@ struct mobj *mobj_shm_alloc(paddr_t pa, size_t size, uint64_t cookie)
 {
 	struct mobj_shm *m;
 
-	if (!core_pbuf_is(CORE_MEM_NSEC_SHM, pa, size))
+	if (!tee_pbuf_is_nsec_shm(pa, size))
 		return NULL;
 
 	m = calloc(1, sizeof(*m));

--- a/core/pta/tests/invoke.c
+++ b/core/pta/tests/invoke.c
@@ -267,8 +267,7 @@ static TEE_Result test_inject_sdp(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 		return TEE_ERROR_SHORT_BUFFER;
 	}
 
-	if (!core_vbuf_is(CORE_MEM_NON_SEC, src, sz) ||
-	    !core_vbuf_is(CORE_MEM_SDP_MEM, dst, sz)) {
+	if (!tee_vbuf_is_non_sec(src, sz) || !tee_vbuf_is_sdp(dst, sz)) {
 		DMSG("bad memref secure attribute");
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
@@ -305,7 +304,7 @@ static TEE_Result test_transform_sdp(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-	if (!core_vbuf_is(CORE_MEM_SDP_MEM, buf, sz)) {
+	if (!tee_vbuf_is_sdp(buf, sz)) {
 		DMSG("bad memref secure attribute");
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
@@ -349,8 +348,7 @@ static TEE_Result test_dump_sdp(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 		return TEE_ERROR_SHORT_BUFFER;
 	}
 
-	if (!core_vbuf_is(CORE_MEM_SDP_MEM, src, sz) ||
-	    !core_vbuf_is(CORE_MEM_NON_SEC, dst, sz)) {
+	if (!tee_vbuf_is_sdp(src, sz) || !tee_vbuf_is_non_sec(dst, sz)) {
 		DMSG("bad memref secure attribute");
 		return TEE_ERROR_BAD_PARAMETERS;
 	}


### PR DESCRIPTION
As the macroses exist, why not to use them.

Signed-off-by: Ivan Khoronzhuk <ivan.khoronzhuk@globallogic.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
