### PR TITLE
crypto: drivers: se050: fix generation of oid values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           export CFG_WERROR=y
 
           function _make() { make -j$(nproc) -s O=out $*; }
-          function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.4.0 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
+          function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.4.1 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
           function download_scp_firmware() { git clone --single-branch https://github.com/ARM-software/SCP-firmware.git $HOME/scp-firmware || echo Nervermind; }
 
           ccache -s -v

--- a/core/drivers/crypto/se050/adaptors/utils/utils.c
+++ b/core/drivers/crypto/se050/adaptors/utils/utils.c
@@ -77,7 +77,12 @@ static sss_status_t generate_oid(uint32_t *val)
 			return kStatus_SSS_Fail;
 
 		oid = OID_MIN + (random & OID_MAX);
-		if (oid > OID_MAX)
+
+		/*
+		 * The less significant byte different than zero prevents bignum
+		 * conversions from discarding it
+		 */
+		if (oid > OID_MAX || !(oid & 0xFF))
 			continue;
 
 		if (!se050_key_exists(oid, &se050_session->s_ctx)) {


### PR DESCRIPTION
Converting the OID watermarked value to a bignum removes the first byte if this is different than zero.

The failing case observed the value 0x57.72.15.66.1a.f2.9d.00 being retrieved as 0x57.72.15.66.1a.f2.9d after having been transformed into a bignum and back to its original binary value.

This will cause cryptographic operations to fail as the secured keys and objects become not addressable.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
