### PR TITLE
drivers: crypto: se050: increase DER signature buffer

### DIFF
--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -592,8 +592,8 @@ static TEE_Result verify(uint32_t algo, struct ecc_public_key *key,
 	sss_se05x_asymmetric_t ctx = { };
 	sss_se05x_object_t kobject = { };
 	TEE_Result res = TEE_SUCCESS;
-	uint8_t signature[128];
-	size_t signature_len = sizeof(signature);
+	uint8_t *signature = NULL;
+	size_t signature_len = sig_len + DER_SIGNATURE_SZ;
 	size_t key_bytes = 0;
 	size_t key_bits = 0;
 	uint8_t *p = NULL;
@@ -623,6 +623,12 @@ static TEE_Result verify(uint32_t algo, struct ecc_public_key *key,
 		goto exit;
 	}
 
+	signature = calloc(1, signature_len);
+	if (!signature) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto exit;
+	}
+
 	st = sss_se05x_signature_bin2der(signature, &signature_len,
 					 (uint8_t *)sig, sig_len);
 	if (st != kStatus_SSS_Success) {
@@ -639,6 +645,7 @@ exit:
 	sss_se05x_key_store_erase_key(se050_kstore, &kobject);
 	sss_se05x_asymmetric_context_free(&ctx);
 	free(p);
+	free(signature);
 
 	return res;
 }


### PR DESCRIPTION
In order to support P-521 (132 byte {r,s} pairs), the buffer storing the DER signature must be large enough.

Tested with:
`$ xtest -l 2 -t pkcs11 1019
`
Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
