### PR TITLE
Introduce binary format SP support

### DIFF
--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -368,8 +368,11 @@ static TEE_Result sp_dt_get_u64(const void *fdt, int node, const char *property,
 	int len = 0;
 
 	p = fdt_getprop(fdt, node, property, &len);
-	if (!p || len != sizeof(*p))
+	if (!p)
 		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	if (len != sizeof(*p))
+		return TEE_ERROR_BAD_FORMAT;
 
 	*value = fdt64_ld(p);
 
@@ -383,8 +386,11 @@ static TEE_Result sp_dt_get_u32(const void *fdt, int node, const char *property,
 	int len = 0;
 
 	p = fdt_getprop(fdt, node, property, &len);
-	if (!p || len != sizeof(*p))
+	if (!p)
 		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	if (len != sizeof(*p))
+		return TEE_ERROR_BAD_FORMAT;
 
 	*value = fdt32_to_cpu(*p);
 
@@ -400,8 +406,11 @@ static TEE_Result sp_dt_get_uuid(const void *fdt, int node,
 	int i = 0;
 
 	p = fdt_getprop(fdt, node, property, &len);
-	if (!p || len != sizeof(TEE_UUID))
+	if (!p)
 		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	if (len != sizeof(TEE_UUID))
+		return TEE_ERROR_BAD_FORMAT;
 
 	for (i = 0; i < 4; i++)
 		uuid_array[i] = fdt32_to_cpu(p[i]);

--- a/core/include/kernel/user_mode_ctx_struct.h
+++ b/core/include/kernel/user_mode_ctx_struct.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2019-2021, Linaro Limited
- * Copyright (c) 2020, Arm Limited
+ * Copyright (c) 2020-2023, Arm Limited
  */
 
 #ifndef __KERNEL_USER_MODE_CTX_STRUCT_H
@@ -41,6 +41,7 @@ struct user_mode_ctx {
 #endif
 	struct ts_ctx *ts_ctx;
 	uaddr_t entry_func;
+	uaddr_t load_addr;
 	uaddr_t dump_entry_func;
 #ifdef CFG_FTRACE_SUPPORT
 	uaddr_t ftrace_entry_func;

--- a/core/kernel/ldelf_loader.c
+++ b/core/kernel/ldelf_loader.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2015-2020, 2022 Linaro Limited
- * Copyright (c) 2020-2021, Arm Limited
+ * Copyright (c) 2020-2023, Arm Limited
  */
 
 #include <assert.h>
@@ -152,6 +152,7 @@ TEE_Result ldelf_init_with_ldelf(struct ts_session *sess,
 
 	uctx->is_32bit = arg->is_32bit;
 	uctx->entry_func = arg->entry_func;
+	uctx->load_addr = arg->load_addr;
 	uctx->stack_ptr = arg->stack_ptr;
 	uctx->dump_entry_func = arg->dump_entry;
 #ifdef CFG_FTRACE_SUPPORT

--- a/ldelf/include/ldelf.h
+++ b/ldelf/include/ldelf.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2019, Linaro Limited
- * Copyright (c) 2020, Arm Limited
+ * Copyright (c) 2020-2023, Arm Limited
  * Copyright 2022-2023 NXP
  */
 
@@ -33,6 +33,7 @@ struct ldelf_arg {
 	uint32_t is_32bit;
 	uint32_t flags;
 	uint64_t entry_func;
+	uint64_t load_addr;
 	uint64_t stack_ptr;
 	uint64_t dump_entry;
 	uint64_t ftrace_entry;

--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2022-2023, Arm Limited
  */
 
 #include <assert.h>
@@ -156,7 +157,7 @@ void ldelf(struct ldelf_arg *arg)
 		ta_elf_finalize_mappings(elf);
 	}
 
-	ta_elf_finalize_load_main(&arg->entry_func);
+	ta_elf_finalize_load_main(&arg->entry_func, &arg->load_addr);
 
 	arg->ftrace_entry = 0;
 #ifdef CFG_FTRACE_SUPPORT

--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2019, Linaro Limited
- * Copyright (c) 2020, Arm Limited
+ * Copyright (c) 2020-2023, Arm Limited
  */
 
 #include <assert.h>
@@ -1274,7 +1274,7 @@ void ta_elf_load_main(const TEE_UUID *uuid, uint32_t *is_32bit, uint64_t *sp,
 	ta_stack_size = elf->head->stack_size;
 }
 
-void ta_elf_finalize_load_main(uint64_t *entry)
+void ta_elf_finalize_load_main(uint64_t *entry, uint64_t *load_addr)
 {
 	struct ta_elf *elf = TAILQ_FIRST(&main_elf_queue);
 	TEE_Result res = TEE_SUCCESS;
@@ -1292,6 +1292,8 @@ void ta_elf_finalize_load_main(uint64_t *entry)
 		*entry = elf->head->depr_entry;
 	else
 		*entry = elf->e_entry + elf->load_addr;
+
+	*load_addr = elf->load_addr;
 }
 
 

--- a/ldelf/ta_elf.h
+++ b/ldelf/ta_elf.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2019, Linaro Limited
+ * Copyright (c) 2022-2023, Arm Limited
  */
 
 #ifndef TA_ELF_H
@@ -121,7 +122,7 @@ struct ta_elf *ta_elf_find_elf(const TEE_UUID *uuid);
 
 void ta_elf_load_main(const TEE_UUID *uuid, uint32_t *is_32bit, uint64_t *sp,
 		      uint32_t *ta_flags);
-void ta_elf_finalize_load_main(uint64_t *entry);
+void ta_elf_finalize_load_main(uint64_t *entry, uint64_t *load_addr);
 void ta_elf_load_dependency(struct ta_elf *elf, bool is_32bit);
 void ta_elf_relocate(struct ta_elf *elf);
 void ta_elf_finalize_mappings(struct ta_elf *elf);

--- a/scripts/ts_bin_to_c.py
+++ b/scripts/ts_bin_to_c.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2017, 2020, Linaro Limited
-# Copyright (c) 2020-2022, Arm Limited.
+# Copyright (c) 2020-2023, Arm Limited.
 #
 
 import argparse
 import array
-from elftools.elf.elffile import ELFFile
+from elftools.elf.elffile import ELFFile, ELFError
 import os
 import re
 import struct
@@ -74,7 +74,11 @@ def ta_get_flags(ta_f):
 
 def sp_get_flags(sp_f):
     with open(sp_f, 'rb') as f:
-        elffile = ELFFile(f)
+        try:
+            elffile = ELFFile(f)
+        except ELFError:
+            # Binary format SP, return zero flags
+            return 0
 
         for s in elffile.iter_sections():
             if get_name(s) == '.sp_head':


### PR DESCRIPTION
This pull request introduces support for an SPMC agnostic SP format. In order to make it easier to implement support for this format, a simple flat binary format was chosen so it won't require an ELF loader. The SPMC only has to copy the SP binary into an RWX memory area then it can jump to its entry point. The access rights of different sections of the SP can be set by either via the load relative memory region definitions of the SP manifest or by invoking the `FFA_MEM_PERM_SET` FF-A interface from the SP during the boot phase. Setting up the stack, clearing the .bss section, handling relocations, etc. are all handled by the SP startup code.
The ELF format SPs remain supported by OP-TEE. The SP loader can distinguish between the two formats by the `legacy-elf-format` field of the SP manifest.
trusted-services already provides SP deployments in this new format (config: default-sp).
This PR requires the patches of https://github.com/OP-TEE/build/pull/613 in the build repository.
For more detailed description see the [PR in optee_docs](https://github.com/OP-TEE/optee_docs/pull/181).