### PR TITLE
dts: stm32: clean device tree for STM32MP13

### DIFF
--- a/core/arch/arm/dts/stm32mp13-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp13-pinctrl.dtsi
@@ -43,17 +43,4 @@
 			bias-pull-up;
 		};
 	};
-
-	uart8_pins_a: uart8-0 {
-		pins1 {
-			pinmux = <STM32_PINMUX('E', 1, AF8)>; /* UART8_TX */
-			bias-disable;
-			drive-push-pull;
-			slew-rate = <0>;
-		};
-		pins2 {
-			pinmux = <STM32_PINMUX('F', 9, AF8)>; /* UART8_RX */
-			bias-pull-up;
-		};
-	};
 };

--- a/core/arch/arm/dts/stm32mp135f-dk.dts
+++ b/core/arch/arm/dts/stm32mp135f-dk.dts
@@ -29,17 +29,17 @@
 		reg = <0xc0000000 0x20000000>;
 	};
 
-        reserved-memory {
-                #address-cells = <1>;
-                #size-cells = <1>;
-                ranges;
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
 
-                optee_framebuffer: optee-framebuffer@dd000000 {
-                        /* Secure framebuffer memory */
-                        reg = <0xdd000000 0x1000000>;
-                        no-map;
-                };
-        };
+		optee_framebuffer: optee-framebuffer@dd000000 {
+			/* Secure framebuffer memory */
+			reg = <0xdd000000 0x1000000>;
+			no-map;
+		};
+	};
 
 	vin: vin {
 		compatible = "regulator-fixed";
@@ -233,11 +233,5 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&usart1_pins_a>;
 	uart-has-rtscts;
-	status = "disabled";
-};
-
-&uart8 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&uart8_pins_a>;
 	status = "disabled";
 };


### PR DESCRIPTION
Unused peripherals shouldn't be supported at board level for STM32MP13.