### PR TITLE
mk/compile.mk: add -Ulinux -Uunix to dtb-cppflags

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -268,7 +268,7 @@ cleanfiles := $$(cleanfiles) $2 \
 		$$(dtb-predts-$2) $$(dtb-predep-$2) \
 		$$(dtb-dep-$2) $$(dtb-cmd-file-$2)
 
-dtb-cppflags-$2	:= -Icore/include/ -x assembler-with-cpp \
+dtb-cppflags-$2 := -Icore/include/ -x assembler-with-cpp -Ulinux -Uunix \
 		   -E -ffreestanding $$(CPPFLAGS) \
 		   -MD -MF $$(dtb-predep-$2) -MT $2
 


### PR DESCRIPTION
Add -Ulinux and -Uunix to dtb-cppflags to fix two corner cases, where DTS file might contain properties like following:

dma_coherent: coherent {
	compatible = "shared-dma-pool";
	linux,dma-default;
}

Without these flags, C preprocessor will modify "linux,dma-default" to "1,dma-default"

Thanks jerome.forissier for quickly identifying the root cause.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
