### PR TITLE
versal: enable the crypto driver

### DIFF
--- a/core/arch/arm/plat-versal/conf.mk
+++ b/core/arch/arm/plat-versal/conf.mk
@@ -57,10 +57,12 @@ CFG_VERSAL_TRNG_DF_MUL ?= 2
 $(call force, CFG_VERSAL_NVM,y)
 
 # Crypto driver
-$(call force,CFG_CRYPTO_DRIVER,y)
-CFG_CRYPTO_DRIVER_DEBUG ?= 0
-
 CFG_VERSAL_CRYPTO_DRIVER ?= y
+ifeq ($(CFG_VERSAL_CRYPTO_DRIVER),y)
+# Disable Fault Mitigation: triggers false positives due to
+# the driver's software fallback operations - need further work
+CFG_FAULT_MITIGATION ?= n
+endif
 
 # SHA3-384 crypto engine
 CFG_VERSAL_SHA3_384 ?= y

--- a/core/arch/arm/plat-versal/conf.mk
+++ b/core/arch/arm/plat-versal/conf.mk
@@ -82,3 +82,5 @@ CFG_VERSAL_HUK_KEY ?= 12
 ifneq ($(CFG_VERSAL_HUK_KEY),$(filter 6 7 11 12,$(firstword $(CFG_VERSAL_HUK_KEY))))
 $(error Invalid value: CFG_VERSAL_HUK_KEY=$(CFG_VERSAL_HUK_KEY))
 endif
+
+CFG_CORE_HEAP_SIZE ?= 262144

--- a/core/drivers/crypto/versal/crypto.mk
+++ b/core/drivers/crypto/versal/crypto.mk
@@ -1,0 +1,11 @@
+ifeq ($(CFG_VERSAL_CRYPTO_DRIVER),y)
+# Enable the crypto driver
+$(call force,CFG_CRYPTO_DRIVER,y)
+
+CFG_CRYPTO_DRIVER_DEBUG ?= 0
+$(call force,CFG_CRYPTO_DRV_ACIPHER,y)
+$(call force,CFG_CRYPTO_DRV_ECC,y)
+$(call force,CFG_CRYPTO_DRV_RSA,y)
+$(call force,CFG_CRYPTO_DRV_AUTHENC,y)
+
+endif

--- a/core/drivers/crypto/versal/rsa.c
+++ b/core/drivers/crypto/versal/rsa.c
@@ -40,9 +40,6 @@ static TEE_Result do_encrypt(struct drvcrypt_rsa_ed *rsa_data)
 
 	switch (rsa_data->rsa_id) {
 	case DRVCRYPT_RSA_PKCS_V1_5:
-		if (rsa_data->key.n_size != 128)
-			break;
-
 		return sw_crypto_acipher_rsaes_encrypt(rsa_data->algo,
 						rsa_data->key.key,
 						rsa_data->label.data,
@@ -132,9 +129,6 @@ static TEE_Result do_decrypt(struct drvcrypt_rsa_ed *rsa_data)
 
 	switch (rsa_data->rsa_id) {
 	case DRVCRYPT_RSA_PKCS_V1_5:
-		if (rsa_data->key.n_size != 128)
-			break;
-
 		return sw_crypto_acipher_rsaes_decrypt(rsa_data->algo,
 						rsa_data->key.key,
 						rsa_data->label.data,


### PR DESCRIPTION
The crypto driver API provides an extra indirection level to enable different ciphers.

Since Versal ACAP supports acipher and authenc, enable them.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
