### PR TITLE
libutils: mte: add missing calls to strip_tag()

### DIFF
--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -953,7 +953,7 @@ bool raw_malloc_buffer_overlaps_heap(struct malloc_ctx *ctx,
 	raw_malloc_validate_pools(ctx);
 
 	for (n = 0; n < ctx->pool_len; n++) {
-		uintptr_t pool_start = (uintptr_t)ctx->pool[n].buf;
+		uintptr_t pool_start = (uintptr_t)strip_tag(ctx->pool[n].buf);
 		uintptr_t pool_end = pool_start + ctx->pool[n].len;
 
 		if (buf_start > buf_end || pool_start > pool_end)
@@ -986,7 +986,7 @@ bool raw_malloc_buffer_is_within_alloced(struct malloc_ctx *ctx,
 		uint8_t *end_b = NULL;
 		size_t s = 0;
 
-		start_b = get_payload_start_size(b, &s);
+		start_b = strip_tag(get_payload_start_size(b, &s));
 		end_b = start_b + s;
 		if (start_buf >= start_b && end_buf <= end_b)
 			return true;


### PR DESCRIPTION
Add missing calls to strip_tag() ins raw_malloc_buffer_overlaps_heap() and raw_malloc_buffer_is_within_alloced(). Without them pointer arithmetic cannot work. Fixes xtest 1001.1 (make check MEMTAG=y).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
