### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
   QEMUv8_check:
     name: make check (QEMUv8)
     runs-on: ubuntu-latest
-    container: jforissier/optee_os_ci:qemuv8_check
+    container: jforissier/optee_os_ci:qemuv8_check2
     steps:
       - name: Restore build cache
         uses: actions/cache@v3
@@ -266,8 +266,7 @@ jobs:
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0
           WD=$(pwd)
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
+          sudo -E /root/get_optee_qemuv8.sh
           sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
           sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
 
@@ -278,7 +277,7 @@ jobs:
   QEMUv8_Xen_check:
     name: make check (QEMUv8, Xen)
     runs-on: ubuntu-latest
-    container: jforissier/optee_os_ci:qemuv8_check
+    container: jforissier/optee_os_ci:qemuv8_check2
     steps:
       - name: Restore build cache
         uses: actions/cache@v3
@@ -297,8 +296,7 @@ jobs:
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
+          sudo -E /root/get_optee_qemuv8.sh
           sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
           sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
 
@@ -307,7 +305,7 @@ jobs:
   QEMUv8_check_rust:
     name: make check-rust (QEMUv8)
     runs-on: ubuntu-latest
-    container: jforissier/optee_os_ci:qemuv8_check
+    container: jforissier/optee_os_ci:qemuv8_check2
     steps:
       - name: Restore build cache
         uses: actions/cache@v3
@@ -325,9 +323,10 @@ jobs:
           export LC_ALL=C
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
+          sudo -E /root/get_optee_qemuv8.sh
           sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
           sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
 
-          sudo -E bash -c "make -C /root/optee_repo_qemu_v8/build -j$(nproc) CFG_TEE_CORE_LOG_LEVEL=0 OPTEE_RUST_ENABLE=y check-rust"
+          # Without this line, the following one fails with "ld: cannot find -lteec" when building acipher-rs
+          sudo -E bash -c "make -C /root/optee_repo_qemu_v8/build -j$(nproc)"
+          sudo -E bash -c "make -C /root/optee_repo_qemu_v8/build -j$(nproc) OPTEE_RUST_ENABLE=y check-rust"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,8 +274,32 @@ jobs:
 
           sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check CFG_CRYPTO_WITH_CE82=y
 
-          sudo -E rm -rf /root/optee_repo_qemu_v8/out-br/build/optee_test*
-          sudo -E make -C /root/optee_repo_qemu_v8/build arm-tf-clean
+  QEMUv8_Xen_check:
+    name: make check (QEMUv8, Xen)
+    runs-on: ubuntu-latest
+    container: jforissier/optee_os_ci:qemuv8_check
+    steps:
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          path: /github/home/.cache/ccache
+          key: qemuv8_xen_check-cache-${{ github.sha }}
+          restore-keys: |
+            qemuv8_xen_check-cache-
+      - name: Checkout
+        uses: actions/checkout@v3
+      - shell: bash
+        run: |
+          # make check task
+          set -e
+          export LC_ALL=C
+          export CFG_TEE_CORE_LOG_LEVEL=0
+          WD=$(pwd)
+          sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
+          sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
+          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
+          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+
           sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check XEN_BOOT=y
 
   QEMUv8_check_rust:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
       - shell: bash
         run: |
           # make check task
-          set -e
+          set -e -v
           export LC_ALL=C
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0
@@ -292,7 +292,7 @@ jobs:
       - shell: bash
         run: |
           # make check task
-          set -e
+          set -e -v
           export LC_ALL=C
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,7 @@ jobs:
           # make check task
           set -e
           export LC_ALL=C
+          export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0
           WD=$(pwd)
           sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
@@ -294,6 +295,7 @@ jobs:
           set -e
           export LC_ALL=C
           export CFG_TEE_CORE_LOG_LEVEL=0
+          export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
           sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
           sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"
@@ -307,14 +309,21 @@ jobs:
     runs-on: ubuntu-latest
     container: jforissier/optee_os_ci:qemuv8_check
     steps:
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          path: /github/home/.cache/ccache
+          key: qemuv8_check_rust-cache-${{ github.sha }}
+          restore-keys: |
+            qemuv8_check_rust-cache-
       - name: Checkout
         uses: actions/checkout@v3
       - shell: bash
         run: |
           # make check-rust task
           set -e -v
-          export HOME=/root
           export LC_ALL=C
+          export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
           sudo -E bash -c "cd /root/optee_repo_qemu_v8/.repo/repo && git pull"
           sudo -E bash -c "cd /root/optee_repo_qemu_v8 && repo sync -j 10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,44 @@ jobs:
 
           sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check XEN_BOOT=y
 
+  QEMUv8_check_BTI_MTE_PAC:
+    name: make check (QEMUv8, BTI+MTE+PAC)
+    runs-on: ubuntu-latest
+    container: jforissier/optee_os_ci:qemuv8_check2
+    steps:
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          path: /github/home/.cache/ccache
+          key: qemuv8_check_bti_mte_pac-cache-${{ github.sha }}
+          restore-keys: |
+            qemuv8_check_bti_mte_pac-cache-
+      - name: Checkout
+        uses: actions/checkout@v3
+      - shell: bash
+        run: |
+          # make check task
+          set -e -v
+          export LC_ALL=C
+          # The BTI-enabled toolchain is aarch64-unknown-linux-uclibc-gcc in /usr/local/bin
+          export PATH=/usr/local/bin:$PATH
+          export AARCH64_CROSS_COMPILE=aarch64-unknown-linux-uclibc-
+          # TF-A v2.6 fails to build with the above toolchain so override it
+          export TF_A_EXPORTS="CROSS_COMPILE=/root/optee_repo_qemu_v8/toolchains/aarch64/bin/aarch64-linux-gnu-"
+          export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export CFG_TEE_CORE_LOG_LEVEL=0
+          export CFG_USER_TA_TARGETS=ta_arm64
+          WD=$(pwd)
+          sudo -E /root/get_optee_qemuv8.sh
+          # QEMU v7.2.0 has an issue with MTE
+          # https://github.com/OP-TEE/optee_os/issues/5759#issuecomment-1380590951
+          sudo -E bash -c "cd /root/optee_repo_qemu_v8/qemu && git fetch github && git checkout 13356edb87"
+          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
+          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+
+          # xtest 1031 is excluded because 1031.4 (C++ exception from shared library) fails with this cross-compiler
+          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) CFG_CORE_BTI=y CFG_TA_BTI=y MEMTAG=y PAUTH=y XTEST_ARGS="-x 1031" check
+
   QEMUv8_check_rust:
     name: make check-rust (QEMUv8)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,7 @@ jobs:
 
   QEMUv8_check_rust:
     name: make check-rust (QEMUv8)
+    if: false # disabled until https://github.com/OP-TEE/optee_os/pull/5688#issuecomment-1370608865 is addressed
     runs-on: ubuntu-latest
     container: jforissier/optee_os_ci:qemuv8_check2
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,13 +266,16 @@ jobs:
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0
           WD=$(pwd)
-          sudo -E /root/get_optee_qemuv8.sh
-          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
-          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+          cd ..
+          TOP=$(pwd)/optee_repo_qemu_v8
+          /root/get_optee_qemuv8.sh ${TOP}
+          mv ${TOP}/optee_os ${TOP}/optee_os_old
+          ln -s ${WD} ${TOP}/optee_os
+          cd ${TOP}/build
 
-          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check
+          make -j$(nproc) check
 
-          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check CFG_CRYPTO_WITH_CE82=y
+          make -j$(nproc) check CFG_CRYPTO_WITH_CE82=y
 
   QEMUv8_Xen_check:
     name: make check (QEMUv8, Xen)
@@ -296,11 +299,14 @@ jobs:
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
-          sudo -E /root/get_optee_qemuv8.sh
-          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
-          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+          cd ..
+          TOP=$(pwd)/optee_repo_qemu_v8
+          /root/get_optee_qemuv8.sh ${TOP}
+          mv ${TOP}/optee_os ${TOP}/optee_os_old
+          ln -s ${WD} ${TOP}/optee_os
+          cd ${TOP}/build
 
-          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) check XEN_BOOT=y
+          make -j$(nproc) check XEN_BOOT=y
 
   QEMUv8_check_BTI_MTE_PAC:
     name: make check (QEMUv8, BTI+MTE+PAC)
@@ -324,21 +330,24 @@ jobs:
           # The BTI-enabled toolchain is aarch64-unknown-linux-uclibc-gcc in /usr/local/bin
           export PATH=/usr/local/bin:$PATH
           export AARCH64_CROSS_COMPILE=aarch64-unknown-linux-uclibc-
-          # TF-A v2.6 fails to build with the above toolchain so override it
-          export TF_A_EXPORTS="CROSS_COMPILE=/root/optee_repo_qemu_v8/toolchains/aarch64/bin/aarch64-linux-gnu-"
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0
           export CFG_USER_TA_TARGETS=ta_arm64
           WD=$(pwd)
-          sudo -E /root/get_optee_qemuv8.sh
+          cd ..
+          TOP=$(pwd)/optee_repo_qemu_v8
+          # TF-A v2.6 fails to build with the above toolchain so override it
+          export TF_A_EXPORTS="CROSS_COMPILE=${TOP}/toolchains/aarch64/bin/aarch64-linux-gnu-"
+          /root/get_optee_qemuv8.sh ${TOP}
           # QEMU v7.2.0 has an issue with MTE
           # https://github.com/OP-TEE/optee_os/issues/5759#issuecomment-1380590951
-          sudo -E bash -c "cd /root/optee_repo_qemu_v8/qemu && git fetch github && git checkout 13356edb87"
-          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
-          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+          cd ${TOP}/qemu && git fetch github && git checkout 13356edb87
+          mv ${TOP}/optee_os ${TOP}/optee_os_old
+          ln -s ${WD} ${TOP}/optee_os
+          cd ${TOP}/build
 
           # xtest 1031 is excluded because 1031.4 (C++ exception from shared library) fails with this cross-compiler
-          sudo -E make -C /root/optee_repo_qemu_v8/build -j$(nproc) CFG_CORE_BTI=y CFG_TA_BTI=y MEMTAG=y PAUTH=y XTEST_ARGS="-x 1031" check
+          make -j$(nproc) CFG_CORE_BTI=y CFG_TA_BTI=y MEMTAG=y PAUTH=y XTEST_ARGS="-x 1031" check
 
   QEMUv8_check_rust:
     name: make check-rust (QEMUv8)
@@ -361,10 +370,13 @@ jobs:
           export LC_ALL=C
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
-          sudo -E /root/get_optee_qemuv8.sh
-          sudo mv /root/optee_repo_qemu_v8/optee_os /root/optee_repo_qemu_v8/optee_os_old
-          sudo ln -s ${WD} /root/optee_repo_qemu_v8/optee_os
+          cd ..
+          TOP=$(pwd)/optee_repo_qemu_v8
+          /root/get_optee_qemuv8.sh ${TOP}
+          mv ${TOP}/optee_os ${TOP}/optee_os_old
+          ln -s ${WD} ${TOP}/optee_os
+          cd ${TOP}/build
 
           # Without this line, the following one fails with "ld: cannot find -lteec" when building acipher-rs
-          sudo -E bash -c "make -C /root/optee_repo_qemu_v8/build -j$(nproc)"
-          sudo -E bash -c "make -C /root/optee_repo_qemu_v8/build -j$(nproc) OPTEE_RUST_ENABLE=y check-rust"
+          make -j$(nproc)
+          make -j$(nproc) OPTEE_RUST_ENABLE=y check-rust


### PR DESCRIPTION
A few improvements to the CI script, mostly to:
- improve stability (avoid "no space left on device" and build errors) when upgrading external components such as Buildroot or QEMU, and more generally to make my life easier regarding the management of the Docker image :wink: -- that's commit "ci: make QEMUv8 jobs download source tree from scratch";
- add a CI job with the various security/code hardening extensions enabled (BTI + MTE + PAC).