### PR TITLE
libutee: add TEE_MAIN_ALGO_SHAKE values

### DIFF
--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -44,6 +44,8 @@
 #define TEE_MAIN_ALGO_CONCAT_KDF 0xC1 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_PBKDF2     0xC2 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_X25519     0x44 /* Not in v1.2 spec */
+#define TEE_MAIN_ALGO_SHAKE128   0xC3 /* OP-TEE extension */
+#define TEE_MAIN_ALGO_SHAKE256   0xC4 /* OP-TEE extension */
 
 
 #define TEE_CHAIN_MODE_ECB_NOPAD        0x0
@@ -95,6 +97,10 @@ static inline uint32_t __tee_alg_get_main_alg(uint32_t algo)
 		return TEE_MAIN_ALGO_ECDSA;
 	case TEE_ALG_HKDF:
 		return TEE_MAIN_ALGO_HKDF;
+	case TEE_ALG_SHAKE128:
+		return TEE_MAIN_ALGO_SHAKE128;
+	case TEE_ALG_SHAKE256:
+		return TEE_MAIN_ALGO_SHAKE256;
 	default:
 		break;
 	}


### PR DESCRIPTION
The CAAM driver relies on TEE_ALG_GET_MAIN_ALG() macro to retrieve the main algorithm ID from the TEE_ALG_* value.

With the addition of TEE_ALG_SHAKE128 and TEE_ALG_SHAKE256, TEE_ALG_GET_MAIN_ALG() would return 0x01 (TEE_MAIN_ALGO_MD5) and 0x02 (TEE_MAIN_ALGO_SHA1). These returned values are wrong.

Add TEE_MAIN_ALGO_SHAKE128 and TEE_MAIN_ALGO_SHAKE256 values for respectively TEE_ALG_SHAKE128 and TEE_ALG_SHAKE256.

Signed-off-by: Clement Faure <clement.faure@nxp.com>

@jforissier I'm not sure about the `TEE_MAIN_ALGO_SHAKE` values tho ...
