### PR TITLE
plat-stm32mp1: remove code for when DT is not supported

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -59,14 +59,9 @@ register_ddr(DDR_BASE, CFG_DRAM_SIZE);
 
 static TEE_Result platform_banner(void)
 {
-#ifdef CFG_EMBED_DTB
 	IMSG("Platform stm32mp1: flavor %s - DT %s",
 		ID2STR(PLATFORM_FLAVOR),
 		ID2STR(CFG_EMBED_DTB_SOURCE_FILE));
-#else
-	IMSG("Platform stm32mp1: flavor %s - no device tree",
-		ID2STR(PLATFORM_FLAVOR));
-#endif
 
 	return TEE_SUCCESS;
 }
@@ -118,7 +113,6 @@ void console_init(void)
 	IMSG("Early console on UART#%u", CFG_STM32_EARLY_CONSOLE_UART);
 }
 
-#ifdef CFG_EMBED_DTB
 static TEE_Result init_console_from_dt(void)
 {
 	struct stm32_uart_pdata *pd = NULL;
@@ -156,7 +150,6 @@ static TEE_Result init_console_from_dt(void)
 
 /* Probe console from DT once clock inits (service init level) are completed */
 service_init_late(init_console_from_dt);
-#endif
 
 /*
  * GIC init, used also for primary/secondary boot core wake completion
@@ -298,10 +291,6 @@ early_init_late(set_all_gpios_non_secure);
 
 static TEE_Result init_stm32mp1_drivers(void)
 {
-	/* Without secure DTB support, some drivers must be inited */
-	if (!IS_ENABLED(CFG_EMBED_DTB))
-		stm32_etzpc_init(ETZPC_BASE);
-
 	/* Secure internal memories for the platform, once ETZPC is ready */
 	etzpc_configure_tzma(0, ETZPC_TZMA_ALL_SECURE);
 	etzpc_lock_tzma(0);

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -127,7 +127,6 @@ static __maybe_unused const char *shres2str_state(enum shres_state id)
 }
 
 /* GPIOZ bank pin count depends on SoC variants */
-#ifdef CFG_EMBED_DTB
 /* A light count routine for unpaged context to not depend on DTB support */
 static int gpioz_nbpin = -1;
 
@@ -155,12 +154,6 @@ static TEE_Result set_gpioz_nbpin_from_dt(void)
 }
 /* Get GPIOZ pin count before drivers initialization, hence service_init() */
 service_init(set_gpioz_nbpin_from_dt);
-#else
-static unsigned int get_gpioz_nbpin(void)
-{
-	return STM32MP1_GPIOZ_PIN_MAX_COUNT;
-}
-#endif
 
 static void register_periph(enum stm32mp_shres id, enum shres_state state)
 {

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1162,7 +1162,6 @@ void stm32mp_register_clock_parents_secure(unsigned long clock_id)
 	secure_parent_clocks(parent_id);
 }
 
-#ifdef CFG_EMBED_DTB
 static const char *stm32mp_osc_node_label[NB_OSC] = {
 	[OSC_LSI] = "clk-lsi",
 	[OSC_LSE] = "clk-lse",
@@ -1222,7 +1221,6 @@ static void get_osc_freq_from_dt(const void *fdt)
 			DMSG("Osc %s: no frequency info", name);
 	}
 }
-#endif /*CFG_EMBED_DTB*/
 
 static void enable_static_secure_clocks(void)
 {
@@ -1253,7 +1251,6 @@ static void __maybe_unused disable_rcc_tzen(void)
 	io_clrbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
 }
 
-#ifdef CFG_EMBED_DTB
 static TEE_Result stm32mp1_clk_fdt_init(const void *fdt, int node)
 {
 	unsigned int i = 0;
@@ -1301,7 +1298,6 @@ static TEE_Result stm32mp1_clk_fdt_init(const void *fdt, int node)
 
 	return TEE_SUCCESS;
 }
-#endif /*CFG_EMBED_DTB*/
 
 /*
  * Conversion between clk references and clock gates and clock on internals
@@ -1502,7 +1498,6 @@ static TEE_Result register_stm32mp1_clocks(void)
 	return TEE_SUCCESS;
 }
 
-#ifdef CFG_DRIVERS_CLK_DT
 static struct clk *stm32mp1_clk_dt_get_clk(struct dt_driver_phandle_args *pargs,
 					   void *data __unused, TEE_Result *res)
 {
@@ -1571,21 +1566,3 @@ DEFINE_DT_DRIVER(stm32mp1_clock_dt_driver) = {
 	.match_table = stm32mp1_clock_match_table,
 	.probe = stm32mp1_clock_provider_probe,
 };
-#else /*CFG_DRIVERS_CLK_DT*/
-static TEE_Result stm32mp1_clk_early_init(void)
-{
-	TEE_Result __maybe_unused res = TEE_ERROR_GENERIC;
-
-	res = register_stm32mp1_clocks();
-	if (res) {
-		EMSG("Failed to register clocks: %#"PRIx32, res);
-		panic();
-	}
-
-	enable_static_secure_clocks();
-
-	return TEE_SUCCESS;
-}
-
-service_init(stm32mp1_clk_early_init);
-#endif /*CFG_DRIVERS_CLK_DT*/

--- a/core/drivers/rstctrl/stm32_rstctrl.c
+++ b/core/drivers/rstctrl/stm32_rstctrl.c
@@ -178,7 +178,6 @@ struct rstctrl *stm32mp_rcc_reset_id_to_rstctrl(unsigned int binding_id)
 	return &rstline->rstctrl;
 }
 
-#ifdef CFG_EMBED_DTB
 static struct rstctrl *stm32_rstctrl_get_dev(struct dt_driver_phandle_args *arg,
 					     void *priv_data __unused,
 					     TEE_Result *res)
@@ -230,4 +229,3 @@ DEFINE_DT_DRIVER(stm32_rstctrl_dt_driver) = {
 	.match_table = stm32_rstctrl_match_table,
 	.probe = stm32_rstctrl_provider_probe,
 };
-#endif /*CFG_EMBED_DTB*/

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -659,7 +659,6 @@ TEE_Result stm32_bsec_get_state(uint32_t *state)
 	return TEE_SUCCESS;
 }
 
-#ifdef CFG_EMBED_DTB
 static void enable_nsec_access(unsigned int otp_id)
 {
 	unsigned int idx = (otp_id - otp_upper_base()) / BSEC_BITS_PER_WORD;
@@ -855,11 +854,6 @@ static void initialize_bsec_from_dt(void)
 
 	save_dt_nvmem_layout(fdt, node);
 }
-#else
-static void initialize_bsec_from_dt(void)
-{
-}
-#endif /*CFG_EMBED_DTB*/
 
 static TEE_Result bsec_pm(enum pm_op op, uint32_t pm_hint __unused,
 			  const struct pm_callback_handle *hdl __unused)
@@ -890,8 +884,7 @@ static TEE_Result initialize_bsec(void)
 	if (state_is_invalid_mode())
 		panic();
 
-	if (IS_ENABLED(CFG_EMBED_DTB))
-		initialize_bsec_from_dt();
+	initialize_bsec_from_dt();
 
 	register_pm_core_service_cb(bsec_pm, NULL, "stm32_bsec");
 

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -315,7 +315,6 @@ void stm32_etzpc_init(paddr_t base)
 	init_device_from_hw_config(&etzpc_dev, base);
 }
 
-#ifdef CFG_EMBED_DTB
 static TEE_Result init_etzpc_from_dt(void)
 {
 	void *fdt = get_embedded_dt();
@@ -343,4 +342,3 @@ static TEE_Result init_etzpc_from_dt(void)
 }
 
 service_init(init_etzpc_from_dt);
-#endif /*CFG_EMBED_DTB*/

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -162,7 +162,6 @@ void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt)
 			     &pinctrl[n].standby_cfg);
 }
 
-#ifdef CFG_DT
 /* Panic if GPIO bank information from platform do not match DTB description */
 static void ckeck_gpio_bank(void *fdt, uint32_t bank, int pinctrl_node)
 {
@@ -370,7 +369,6 @@ int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank)
 
 	return -1;
 }
-#endif /*CFG_DT*/
 
 static __maybe_unused bool valid_gpio_config(unsigned int bank,
 					     unsigned int pin, bool input)

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -423,7 +423,6 @@ stm32_rng_pm(enum pm_op op, unsigned int pm_hint __unused,
 }
 DECLARE_KEEP_PAGER(stm32_rng_pm);
 
-#ifdef CFG_EMBED_DTB
 static TEE_Result stm32_rng_parse_fdt(const void *fdt, int node)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
@@ -548,4 +547,3 @@ static TEE_Result stm32_rng_release(void)
 }
 
 release_init_resource(stm32_rng_release);
-#endif /*CFG_EMBED_DTB*/

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -108,7 +108,6 @@ void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base)
 	pd->chip.ops = &stm32_uart_serial_ops;
 }
 
-#ifdef CFG_DT
 static void register_secure_uart(struct stm32_uart_pdata *pd)
 {
 	size_t n = 0;
@@ -190,4 +189,3 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 
 	return pd;
 }
-#endif /*CFG_DT*/


### PR DESCRIPTION
T***w***o patches to remove tests on CFG_DT and CFG_EMBED_DTB in stm32mp1 platform and drivers.

**_(edited)_**
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
