### PR TITLE
core: tpm: fix syntax in trace message

### DIFF
--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -112,7 +112,7 @@ TEE_Result tpm_get_event_log(void *buf, size_t *size)
 	}
 
 	if (buf_size < tpm_log_size) {
-		EMSG("TPM: Not enough space for the log: %zu, %lu",
+		EMSG("TPM: Not enough space for the log: %zu, %zu",
 		     buf_size, tpm_log_size);
 		return TEE_ERROR_SHORT_BUFFER;
 	}


### PR DESCRIPTION
Fixes build warning (trace message below) when CFG_CORE_TPM_EVENT_LOG=y.
