### PR TITLE
libutee: add CNTVCT to user system registers

### DIFF
--- a/lib/libutee/arch/arm/arm32_user_sysreg.txt
+++ b/lib/libutee/arch/arm/arm32_user_sysreg.txt
@@ -11,3 +11,4 @@
 @ B8.2 Generic Timer registers summary
 CNTFRQ    c14 0 c0  0 RW Counter Frequency register
 CNTPCT    -   0 c14 - RO Physical Count register
+CNTVCT    -   1 c14 - RO Virtual Count register


### PR DESCRIPTION
Adds CNTVCT to user system registers. Needed when compiling with CFG_CORE_SEL2_SPMC=y and CFG_MEMTAG=y.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
