### PR TITLE
libutils: add stubs for pthread functions

### DIFF
--- a/lib/libutils/ext/pthread_stubs.c
+++ b/lib/libutils/ext/pthread_stubs.c
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023, Linaro Limited
+ */
+
+#include <compiler.h>
+
+#define pthread_mutex_t void
+
+int pthread_mutex_lock(pthread_mutex_t *mutex __unused);
+int pthread_mutex_unlock(pthread_mutex_t *mutex __unused);
+
+int __weak pthread_mutex_lock(pthread_mutex_t *mutex __unused)
+{
+	return 0;
+}
+
+int __weak pthread_mutex_unlock(pthread_mutex_t *mutex __unused)
+{
+	return 0;
+}

--- a/lib/libutils/ext/sub.mk
+++ b/lib/libutils/ext/sub.mk
@@ -10,5 +10,9 @@ srcs-y += consttime_memcmp.c
 srcs-y += memzero_explicit.c
 srcs-y += fault_mitigation.c
 
+ifneq (,$(filter ta_%,$(sm)))
+srcs-y += pthread_stubs.c
+endif
+
 subdirs-y += arch/$(ARCH)
 subdirs-y += ftrace


### PR DESCRIPTION
When building with GCC 11.3.1 [1], the linker reports undefined symbols in the C++ test TA:
```
 $ make 2>&1 | grep -E "(in function|undefined reference)" | sed 's@.*/@@'
 libstdc++.a(eh_alloc.o): in function `(anonymous namespace)::pool::free(void*) [clone .constprop.0]':
 gthr-default.h:749: undefined reference to `pthread_mutex_lock'
 gthr-default.h:779: undefined reference to `pthread_mutex_unlock'
 libstdc++.a(eh_alloc.o): in function `(anonymous namespace)::pool::allocate(unsigned long) [clone .constprop.0]':
 gthr-default.h:749: undefined reference to `pthread_mutex_lock'
 gthr-default.h:779: undefined reference to `pthread_mutex_unlock'
 libgcc_eh.a(unwind-dw2-fde-dip.o): in function `__gthread_mutex_lock':
 gthr-default.h:749: undefined reference to `pthread_mutex_lock'
 libgcc_eh.a(unwind-dw2-fde-dip.o): in function `__gthread_mutex_unlock':
 gthr-default.h:779: undefined reference to `pthread_mutex_unlock'
 [more of the same follow]
```
To fix that issue, introduce no-op stubs as weak symbols in libutils. Doing so is valid because TAs are single threaded and non-reentrant.

Link: [1] https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-linux-gnu.tar.xz
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
