### PR TITLE
core: ffa: add TOS_FW_CONFIG handling

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2014, Linaro Limited
- * Copyright (c) 2021, Arm Limited
+ * Copyright (c) 2021-2023, Arm Limited
  */
 
 #include <arm32_macros.S>
@@ -560,6 +560,7 @@ shadow_stack_access_ok:
 	str	r0, [r8, #THREAD_CORE_LOCAL_FLAGS]
 #endif
 	mov	r0, r6		/* DT address */
+	mov	r1, #0		/* unused */
 	bl	boot_init_primary_late
 #ifndef CFG_NS_VIRTUALIZATION
 	mov	r0, #THREAD_CLF_TMP

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015-2022, Linaro Limited
- * Copyright (c) 2021, Arm Limited
+ * Copyright (c) 2021-2023, Arm Limited
  */
 
 #include <platform_config.h>
@@ -320,7 +320,11 @@ clear_nex_bss:
 	bl	core_mmu_set_default_prtn_tbl
 #endif
 
+#ifdef CFG_CORE_SEL1_SPMC
+	mov	x0, xzr		/* pager not used */
+#else
 	mov	x0, x19		/* pagable part address */
+#endif
 	mov	x1, #-1
 	bl	boot_init_primary_early
 
@@ -337,7 +341,12 @@ clear_nex_bss:
 	mov	x22, x0
 	str	wzr, [x22, #THREAD_CORE_LOCAL_FLAGS]
 #endif
-	mov	x0, x20		/* DT address */
+	mov	x0, x20		/* DT address also known as HW_CONFIG */
+#ifdef CFG_CORE_SEL1_SPMC
+	mov	x1, x19		/* TOS_FW_CONFIG DT address */
+#else
+	mov	x1, xzr		/* unused */
+#endif
 	bl	boot_init_primary_late
 #ifdef CFG_CORE_PAUTH
 	init_pauth_per_cpu

--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2017-2021, Linaro Limited
+ * Copyright (c) 2023, Arm Limited
  */
 #include <compiler.h>
 #include <initcall.h>
@@ -27,7 +28,8 @@ void __section(".text.dummy.call_finalcalls") call_finalcalls(void)
 }
 
 void __section(".text.dummy.boot_init_primary_late")
-boot_init_primary_late(unsigned long fdt __unused)
+boot_init_primary_late(unsigned long fdt __unused,
+		       unsigned long tos_fw_config __unused)
 {
 }
 

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -1532,7 +1532,7 @@ static TEE_Result fip_sp_map_all(void)
 	int subnode = 0;
 	int root = 0;
 
-	fdt = get_external_dt();
+	fdt = get_tos_fw_config_dt();
 	if (!fdt) {
 		EMSG("No SPMC manifest found");
 		return TEE_ERROR_GENERIC;

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015-2020, Linaro Limited
- * Copyright (c) 2021, Arm Limited
+ * Copyright (c) 2021-2023, Arm Limited
  */
 #ifndef __KERNEL_BOOT_H
 #define __KERNEL_BOOT_H
@@ -46,7 +46,7 @@ extern const struct core_mmu_config boot_mmu_config;
 /* @nsec_entry is unused if using CFG_WITH_ARM_TRUSTED_FW */
 void boot_init_primary_early(unsigned long pageable_part,
 			     unsigned long nsec_entry);
-void boot_init_primary_late(unsigned long fdt);
+void boot_init_primary_late(unsigned long fdt, unsigned long tos_fw_config);
 void boot_init_memtag(void);
 
 void __panic_at_smc_return(void) __noreturn;
@@ -102,6 +102,9 @@ void *get_embedded_dt(void);
 
 /* Returns external DTB if present, otherwise NULL */
 void *get_external_dt(void);
+
+/* Returns TOS_FW_CONFIG DTB if present, otherwise NULL */
+void *get_tos_fw_config_dt(void);
 
 /*
  * get_aslr_seed() - return a random seed for core ASLR


### PR DESCRIPTION
At boot TF-A passes two DT addresses (HW_CONFIG and TOS_FW_CONFIG), but currently only the HW_CONFIG address is saved, the other one is dropped. This commit adds functionality to save the TOS_FW_CONFIG too, so we can retrieve it later. This is necessary for the CFG_CORE_SEL1_SPMC use case, because the SPMC manifest is passed in this DT.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
