### PR TITLE
build: mk/lib.mk: use full path to shared library in flags variable

### DIFF
--- a/mk/lib.mk
+++ b/mk/lib.mk
@@ -60,14 +60,14 @@ $(lib-libfile): $(objs)
 endif
 ifeq ($(CFG_ULIBS_SHARED),y)
 ifeq ($(sm)-$(CFG_TA_BTI),ta_arm64-y)
-lib-ldflags$(libuuid) += $$(call ld-option,-z force-bti) --fatal-warnings
+lib-ldflags$(lib-shlibfile) += $$(call ld-option,-z force-bti) --fatal-warnings
 endif
 $(lib-shlibfile): $(objs) $(lib-needed-so-files)
 	@$(cmd-echo-silent) '  LD      $$@'
 	@mkdir -p $$(dir $$@)
 	$$(q)$$(LD$(sm)) $(lib-ldflags) -shared -z max-page-size=4096 \
 		$(call ld-option,-z separate-loadable-segments) \
-		$$(lib-ldflags$(libuuid)) \
+		$$(lib-ldflags$(lib-shlibfile)) \
 		--soname=$(libuuid) -o $$@ $$(filter-out %.so,$$^) $(lib-Ll-args)
 
 $(lib-shlibstrippedfile): $(lib-shlibfile)


### PR DESCRIPTION
To add link flags for a shared library, a makefile variable is used that is called lib-ldflags$(libuuid). That's incorrect because the UUID is not enough to uniquely identify a shared library in the build. For example when both 32-bit and 64-bit user space is generated there are two versions of the shared library with the same UUID. It is not a problem at the moment because lib-ldflags$(libuuid) is used only for one target: ta_arm64, but fix this anyways so that the variable may be used for more complex cases.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
