### PR TITLE
core: crypto: fix memory leak in Ed25519 support

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -866,6 +866,13 @@ TEE_Result crypto_acipher_alloc_ed25519_keypair(struct ed25519_keypair *key
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
+TEE_Result
+crypto_acipher_alloc_ed25519_public_key(struct ed25519_public_key *key __unused,
+					size_t key_size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
 TEE_Result crypto_acipher_gen_ed25519_key(struct ed25519_keypair *key __unused,
 					  size_t key_size __unused)
 {
@@ -881,11 +888,12 @@ TEE_Result crypto_acipher_ed25519_sign(struct ed25519_keypair *key __unused,
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
-TEE_Result crypto_acipher_ed25519_verify(struct ed25519_keypair *key __unused,
-					 const uint8_t *msg __unused,
-					 size_t msg_len __unused,
-					 const uint8_t *sig __unused,
-					 size_t sig_len __unused)
+TEE_Result
+crypto_acipher_ed25519_verify(struct ed25519_public_key *key __unused,
+			      const uint8_t *msg __unused,
+			      size_t msg_len __unused,
+			      const uint8_t *sig __unused,
+			      size_t sig_len __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
@@ -902,15 +910,15 @@ TEE_Result crypto_acipher_ed25519ctx_sign(struct ed25519_keypair *key __unused,
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
-TEE_Result crypto_acipher_ed25519ctx_verify(struct ed25519_keypair *key
-							 __unused,
-					    const uint8_t *msg __unused,
-					    size_t msg_len __unused,
-					    const uint8_t *sig __unused,
-					    size_t sig_len __unused,
-					    bool ph_flag __unused,
-					    const uint8_t *ctx __unused,
-					    size_t ctxlen __unused)
+TEE_Result
+crypto_acipher_ed25519ctx_verify(struct ed25519_public_key *key __unused,
+				 const uint8_t *msg __unused,
+				 size_t msg_len __unused,
+				 const uint8_t *sig __unused,
+				 size_t sig_len __unused,
+				 bool ph_flag __unused,
+				 const uint8_t *ctx __unused,
+				 size_t ctxlen __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -179,6 +179,11 @@ struct ed25519_keypair {
 	uint32_t curve;
 };
 
+struct ed25519_public_key {
+	uint8_t *pub;
+	uint32_t curve;
+};
+
 /*
  * Key allocation functions
  * Allocate the bignum's inside a key structure.
@@ -207,6 +212,9 @@ TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *s,
 					       size_t key_size_bits);
 TEE_Result crypto_acipher_alloc_ed25519_keypair(struct ed25519_keypair *s,
 						size_t key_size_bits);
+TEE_Result
+crypto_acipher_alloc_ed25519_public_key(struct ed25519_public_key *key,
+					size_t key_size);
 
 /*
  * Key generation functions
@@ -228,10 +236,10 @@ TEE_Result crypto_acipher_ed25519ctx_sign(struct ed25519_keypair *key,
 					  uint8_t *sig, size_t *sig_len,
 					  bool ph_flag,
 					  const uint8_t *ctx, size_t ctxlen);
-TEE_Result crypto_acipher_ed25519_verify(struct ed25519_keypair *key,
+TEE_Result crypto_acipher_ed25519_verify(struct ed25519_public_key *key,
 					 const uint8_t *msg, size_t msg_len,
 					 const uint8_t *sig, size_t sig_len);
-TEE_Result crypto_acipher_ed25519ctx_verify(struct ed25519_keypair *key,
+TEE_Result crypto_acipher_ed25519ctx_verify(struct ed25519_public_key *key,
 					    const uint8_t *msg, size_t msg_len,
 					    const uint8_t *sig, size_t sig_len,
 					    bool ph_flag,

--- a/core/lib/libtomcrypt/ed25519.c
+++ b/core/lib/libtomcrypt/ed25519.c
@@ -36,6 +36,23 @@ TEE_Result crypto_acipher_alloc_ed25519_keypair(struct ed25519_keypair *key,
 	return TEE_SUCCESS;
 }
 
+TEE_Result
+crypto_acipher_alloc_ed25519_public_key(struct ed25519_public_key *key,
+					size_t key_size)
+{
+	if (!key || key_size != ED25519_KEY_SIZE)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(key, 0, sizeof(*key));
+
+	key->pub = calloc(1, key_size >> 3);
+
+	if (!key->pub)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	return TEE_SUCCESS;
+}
+
 TEE_Result crypto_acipher_gen_ed25519_key(struct ed25519_keypair *key,
 					  size_t key_size)
 {
@@ -124,7 +141,7 @@ TEE_Result crypto_acipher_ed25519ctx_sign(struct ed25519_keypair *key,
 	return TEE_SUCCESS;
 }
 
-TEE_Result crypto_acipher_ed25519_verify(struct ed25519_keypair *key,
+TEE_Result crypto_acipher_ed25519_verify(struct ed25519_public_key *key,
 					 const uint8_t *msg, size_t msg_len,
 					 const uint8_t *sig, size_t sig_len)
 {
@@ -149,7 +166,7 @@ TEE_Result crypto_acipher_ed25519_verify(struct ed25519_keypair *key,
 	return TEE_SUCCESS;
 }
 
-TEE_Result crypto_acipher_ed25519ctx_verify(struct ed25519_keypair *key,
+TEE_Result crypto_acipher_ed25519ctx_verify(struct ed25519_public_key *key,
 					    const uint8_t *msg, size_t msg_len,
 					    const uint8_t *sig, size_t sig_len,
 					    bool ph_flag,

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -454,7 +454,7 @@ const struct tee_cryp_obj_type_attrs tee_cryp_obj_ed25519_pub_key_attrs[] = {
 	.attr_id = TEE_ATTR_ED25519_PUBLIC_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
 	.ops_index = ATTR_OPS_INDEX_25519,
-	RAW_DATA(struct ed25519_keypair, pub)
+	RAW_DATA(struct ed25519_public_key, pub)
 	},
 };
 
@@ -621,7 +621,7 @@ static const struct tee_cryp_obj_type_props tee_cryp_obj_props[] = {
 	     tee_cryp_obj_x25519_keypair_attrs),
 
 	PROP(TEE_TYPE_ED25519_PUBLIC_KEY, 1, 256, 256,
-	     sizeof(struct ed25519_keypair),
+	     sizeof(struct ed25519_public_key),
 	     tee_cryp_obj_ed25519_pub_key_attrs),
 
 	PROP(TEE_TYPE_ED25519_KEYPAIR, 1, 256, 256,
@@ -1541,9 +1541,12 @@ TEE_Result tee_obj_set_type(struct tee_obj *o, uint32_t obj_type,
 							  max_key_size);
 		break;
 	case TEE_TYPE_ED25519_KEYPAIR:
-	case TEE_TYPE_ED25519_PUBLIC_KEY:
 		res = crypto_acipher_alloc_ed25519_keypair(o->attr,
 							   max_key_size);
+		break;
+	case TEE_TYPE_ED25519_PUBLIC_KEY:
+		res = crypto_acipher_alloc_ed25519_public_key(o->attr,
+							      max_key_size);
 		break;
 	default:
 		if (obj_type != TEE_TYPE_DATA) {
@@ -2268,7 +2271,7 @@ tee_svc_obj_ed25519_sign(struct ed25519_keypair *key,
 }
 
 static TEE_Result
-tee_svc_obj_ed25519_verify(struct ed25519_keypair *key,
+tee_svc_obj_ed25519_verify(struct ed25519_public_key *key,
 			   const uint8_t *msg, size_t msg_len,
 			   const uint8_t *sig, size_t sig_len,
 			   const TEE_Attribute *params, size_t num_params)


### PR DESCRIPTION
The software implemetation of ED25519 algorithm has a memory leak in the key and keypair allocation. Upon every public key allocation, a key pair is allocated (public and private components). When freeing the public key, only the public component is freed. To reproduce the issue:

$ while xtest 4016; do :; done

Until the following error:

* regression_4016 Test TEE Internal API ED25519 sign/verify E/LD:  copy_section_headers:1124 sys_copy_from_ta_bin E/TC:? 0 ldelf_init_with_ldelf:131 ldelf failed with res: 0xffff000c /usr/src/debug/optee-test/master.imx-r0/host/xtest/regression_4000.c:6062: xtest_teec_open_session(&session, &crypt_user_ta_uuid, ((void *)0), &ret_orig) has an unexpected value: 0xffff000c = TEEC_ERROR_OUT_OF_MEMORY, expected 0x0 = TEEC_SUCCESS
  regression_4016 FAILED

To fix the memory leak, a separate public key allocation function must be defined along a ED25519 public key structure.

Fixes: 0aaad418ac8b ("core: crypto: add Ed25519 support")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
