### PR TITLE
core: drivers: crypto: caam: Check PKCS_V1_5 decryption buffer size

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_rsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_rsa.c
@@ -1456,6 +1456,14 @@ static TEE_Result do_caam_decrypt(struct drvcrypt_rsa_ed *rsa_data,
 			cache_operation(TEE_CACHEINVALIDATE, size_msg.data,
 					size_msg.length);
 
+			/* Check if the original buffer size is large enough */
+			if (msg.orig.length < caam_read_val32(size_msg.data)) {
+				rsa_data->message.length =
+						caam_read_val32(size_msg.data);
+				ret = TEE_ERROR_SHORT_BUFFER;
+				goto exit_decrypt;
+			}
+
 			msg.orig.length = caam_read_val32(size_msg.data);
 			RSA_TRACE("New length %zu", msg.orig.length);
 		}


### PR DESCRIPTION
Check if original buffer is large enough for a result of RSA PKCS_V1_5 decryption operation.
With this change PKCS11 variable length buffers are supported for all RSA operations:
- Crypto API checks it for PKCS_V1_5 and OAEP encryptions.
- OAEP decryption already supports it.

This fixes: https://github.com/OP-TEE/optee_os/issues/5841

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
