### PR TITLE
drivers: pinctrl: add device-tree pinctrl support 

### DIFF
--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -1116,6 +1116,8 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				clocks = <&pmc PMC_TYPE_PERIPHERAL 18>;
+				status = "disabled";
+				secure-status = "okay";
 			};
 
 			pioBU: secumod@fc040000 {

--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -94,6 +94,8 @@ ifeq ($(PLATFORM_FLAVOR),sama5d27_wlsom1_ek)
 CFG_DRIVERS_GPIO ?= y
 CFG_DRIVERS_I2C ?= y
 CFG_ATMEL_I2C ?= y
+CFG_DRIVERS_PINCTRL ?= y
+CFG_ATMEL_PIO ?= y
 endif
 
 # SCMI related configuration

--- a/core/drivers/pinctrl/atmel_pio.c
+++ b/core/drivers/pinctrl/atmel_pio.c
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2019 Microchip.
+ */
+#include <assert.h>
+#include <drivers/clk.h>
+#include <drivers/clk_dt.h>
+#include <drivers/pinctrl.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/dt.h>
+#include <libfdt.h>
+#include <malloc.h>
+#include <matrix.h>
+#include <platform_config.h>
+#include <trace.h>
+#include <util.h>
+
+#define PIO_GROUP_COUNT		4
+#define PIO_GROUP_OFFSET	0x40
+#define PIO_REG(reg, group)	((reg) + ((group) * PIO_GROUP_OFFSET))
+/* Mask register */
+#define PIO_MSKR(group)		PIO_REG(0x0, (group))
+/* Configuration register */
+#define PIO_CFGR(group)		PIO_REG(0x4, (group))
+#define PIO_CFGR_FUNC		GENMASK(2, 0)
+#define PIO_CFGR_PUEN		BIT(9)
+#define PIO_CFGR_PDEN		BIT(10)
+
+/* Non-Secure configuration register */
+#define PIO_SIONR(group)	PIO_REG(0x30, (group))
+/* Secure configuration register */
+#define PIO_SIOSR(group)	PIO_REG(0x34, (group))
+
+#define DT_GET_PIN_NO(val)	((val) & 0xFF)
+#define DT_GET_FUNC(val)	(((val) >> 16) & 0xF)
+
+struct atmel_pio {
+	vaddr_t base;
+};
+
+struct atmel_pio_pin_conf {
+	uint32_t pin_mask;
+	uint32_t pin_cfg;
+	uint8_t pio_group;
+	struct atmel_pio *pio;
+};
+
+static void pio_write(struct atmel_pio *pio, unsigned int offset, uint32_t val)
+{
+	io_write32(pio->base + offset, val);
+}
+
+static TEE_Result pio_conf_apply(struct pinconf *conf)
+{
+	struct atmel_pio_pin_conf *pio_conf = conf->priv;
+	struct atmel_pio *pio = pio_conf->pio;
+
+	DMSG("Apply cfg %#" PRIx32 " on group %" PRIu8 ", pins %#" PRIx32,
+	     pio_conf->pin_cfg, pio_conf->pio_group, pio_conf->pin_mask);
+
+	pio_write(pio, PIO_SIOSR(pio_conf->pio_group), pio_conf->pin_mask);
+	pio_write(pio, PIO_MSKR(pio_conf->pio_group), pio_conf->pin_mask);
+	pio_write(pio, PIO_CFGR(pio_conf->pio_group), pio_conf->pin_cfg);
+
+	return TEE_SUCCESS;
+}
+
+static void pio_conf_free(struct pinconf *conf)
+{
+	free(conf);
+}
+
+static const struct pinctrl_ops pio_pinctrl_ops = {
+	.conf_apply = pio_conf_apply,
+	.conf_free = pio_conf_free,
+};
+
+static struct pinconf *pio_pinctrl_dt_get(struct dt_driver_phandle_args *a,
+					  void *data, TEE_Result *res)
+{
+	int i = 0;
+	int func = 0;
+	int group = 0;
+	int pin_no = 0;
+	uint32_t cfg = 0;
+	int prop_count = 0;
+	int pio_group = -1;
+	uint32_t pinmux = 0;
+	uint32_t pin_mask = 0;
+	bitstr_t *cfg_modes = NULL;
+	const uint32_t *prop = NULL;
+	struct pinconf *pinconf = NULL;
+	struct atmel_pio *atmel_pio = data;
+	struct atmel_pio_pin_conf *pio_conf = NULL;
+
+	prop = fdt_getprop(a->fdt, a->phandle_node, "pinmux", &prop_count);
+	if (!prop) {
+		*res = TEE_ERROR_ITEM_NOT_FOUND;
+		return NULL;
+	}
+
+	prop_count /= sizeof(uint32_t);
+	for (i = 0; i < prop_count; i++) {
+		pinmux = fdt32_to_cpu(prop[i]);
+
+		pin_no = DT_GET_PIN_NO(pinmux);
+		func = DT_GET_FUNC(pinmux);
+
+		group = pin_no / 32;
+		if (pio_group == -1) {
+			pio_group = group;
+		} else {
+			if (group != pio_group) {
+				EMSG("Unexpected group %d vs %d", group,
+				     pio_group);
+				*res = TEE_ERROR_GENERIC;
+				return NULL;
+			}
+		}
+
+		pin_mask |= BIT(pin_no % 32);
+	}
+
+	cfg = func;
+
+	*res = pinctrl_parse_dt_pin_modes(a->fdt, a->phandle_node, &cfg_modes);
+	if (*res)
+		return NULL;
+
+	for (i = 0; i < PINCTRL_DT_PROP_MAX; i++) {
+		if (!bit_test(cfg_modes, i))
+			continue;
+
+		switch (i) {
+		case PINCTRL_DT_PROP_BIAS_PULL_UP:
+			cfg |= PIO_CFGR_PUEN;
+			cfg &= ~PIO_CFGR_PDEN;
+			break;
+		case PINCTRL_DT_PROP_BIAS_PULL_DOWN:
+			cfg |= PIO_CFGR_PDEN;
+			cfg &= ~PIO_CFGR_PUEN;
+			break;
+		case PINCTRL_DT_PROP_BIAS_DISABLE:
+			break;
+		default:
+			EMSG("Unhandled config %u", i);
+			break;
+		}
+	}
+
+	free(cfg_modes);
+
+	pinconf = calloc(1, sizeof(*pinconf) + sizeof(*pio_conf));
+	if (!pinconf) {
+		*res = TEE_ERROR_OUT_OF_MEMORY;
+		return NULL;
+	}
+
+	pio_conf = (struct atmel_pio_pin_conf *)(pinconf + 1);
+
+	pio_conf->pin_mask = pin_mask;
+	pio_conf->pin_cfg = cfg;
+	pio_conf->pio = atmel_pio;
+	pio_conf->pio_group = pio_group;
+	pinconf->priv = pio_conf;
+	pinconf->ops = &pio_pinctrl_ops;
+
+	*res = TEE_SUCCESS;
+
+	return pinconf;
+}
+
+static void pio_init_hw(struct atmel_pio *pio)
+{
+	int i = 0;
+
+	/* Set all IOs as non-secure */
+	for (i = 0; i < PIO_GROUP_COUNT; i++)
+		pio_write(pio, PIO_SIONR(PIO_GROUP_COUNT), GENMASK_32(31, 0));
+}
+
+static TEE_Result pio_node_probe(const void *fdt, int node,
+				 const void *compat_data __unused)
+{
+	size_t size = 0;
+	struct clk *clk = NULL;
+	struct atmel_pio *pio = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+		return TEE_ERROR_BAD_STATE;
+
+	pio = calloc(1, sizeof(*pio));
+	if (!pio)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	res = clk_dt_get_by_index(fdt, node, 0, &clk);
+	if (res)
+		goto free_pio;
+
+	if (dt_map_dev(fdt, node, &pio->base, &size, DT_MAP_AUTO) < 0)
+		goto free_pio;
+
+	res = clk_enable(clk);
+	if (res)
+		goto free_pio;
+
+	matrix_configure_periph_secure(AT91C_ID_PIOA);
+	matrix_configure_periph_secure(AT91C_ID_PIOB);
+	matrix_configure_periph_secure(AT91C_ID_PIOC);
+	matrix_configure_periph_secure(AT91C_ID_PIOD);
+
+	pio_init_hw(pio);
+
+	res = pinctrl_register_provider(fdt, node, pio_pinctrl_dt_get, pio);
+	if (res)
+		goto disable_clock;
+
+	return TEE_SUCCESS;
+
+disable_clock:
+	clk_disable(clk);
+free_pio:
+	free(pio);
+
+	return res;
+}
+
+static const struct dt_device_match atmel_pio_match_table[] = {
+	{ .compatible = "atmel,sama5d2-pinctrl" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(atmel_pio_dt_driver) = {
+	.name = "atmel_pio",
+	.type = DT_DRIVER_PINCTRL,
+	.match_table = atmel_pio_match_table,
+	.probe = pio_node_probe,
+};

--- a/core/drivers/pinctrl/pinctrl.c
+++ b/core/drivers/pinctrl/pinctrl.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023, Microchip
+ */
+
+#include <assert.h>
+#include <drivers/pinctrl.h>
+#include <libfdt.h>
+#include <stdio.h>
+#include <tee_api_defines.h>
+#include <tee_api_defines_extensions.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+static const char * const pin_modes[PINCTRL_DT_PROP_MAX] = {
+	[PINCTRL_DT_PROP_BIAS_DISABLE] = "bias-disable",
+	[PINCTRL_DT_PROP_BIAS_PULL_UP] = "bias-pull-up",
+	[PINCTRL_DT_PROP_BIAS_PULL_DOWN] = "bias-pull-down",
+};
+
+TEE_Result pinctrl_parse_dt_pin_modes(const void *fdt, int node,
+				      bitstr_t **modes)
+{
+	unsigned int i = 0;
+	bitstr_t *modes_ptr = NULL;
+
+	modes_ptr = bit_alloc(PINCTRL_DT_PROP_MAX);
+	if (!modes_ptr)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	for (i = 0; i < ARRAY_SIZE(pin_modes); i++)
+		if (fdt_getprop(fdt, node, pin_modes[i], NULL))
+			bit_set(modes_ptr, i);
+
+	*modes = modes_ptr;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pinctrl_apply_state(struct pinctrl_state *state)
+{
+	unsigned int i = 0;
+	struct pinconf *conf = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	for (i = 0; i < state->conf_count; i++) {
+		conf = state->confs[i];
+
+		res = conf->ops->conf_apply(conf);
+		if (res) {
+			EMSG("Failed to apply pin conf");
+			return res;
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+void pinctrl_free_state(struct pinctrl_state *state)
+{
+	unsigned int i = 0;
+
+	for (i = 0; i < state->conf_count; i++)
+		state->confs[i]->ops->conf_free(state->confs[i]);
+
+	free(state);
+}
+
+TEE_Result pinctrl_get_state_by_idx(const void *fdt, int nodeoffset,
+				    unsigned int pinctrl_index,
+				    struct pinctrl_state **state_ret)
+{
+	int bw = 0;
+	unsigned int conf_id = 0;
+	const uint32_t *prop = NULL;
+	unsigned int conf_count = 0;
+	/* Enough char to hold "pinctrl-<max_int>" */
+	char prop_name[8 + 20 + 1] = { };
+	struct pinctrl_state *state = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	bw = snprintf(prop_name, sizeof(prop_name), "pinctrl-%d",
+		      pinctrl_index);
+	if (bw >= (int)sizeof(prop_name))
+		return TEE_ERROR_OVERFLOW;
+
+	prop = fdt_getprop(fdt, nodeoffset, prop_name, (int *)&conf_count);
+	if (!prop)
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	conf_count /= sizeof(uint32_t);
+	state = calloc(1, sizeof(struct pinctrl_state) +
+			  conf_count * sizeof(struct pinconf *));
+	if (!state)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	state->conf_count = conf_count;
+	for (conf_id = 0; conf_id < conf_count; conf_id++) {
+		state->confs[conf_id] =
+			dt_driver_device_from_node_idx_prop(prop_name, fdt,
+							    nodeoffset, conf_id,
+							    DT_DRIVER_PINCTRL,
+							    &res);
+		if (res) {
+			free(state);
+			return res;
+		}
+	}
+
+	*state_ret = state;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pinctrl_get_state_by_name(const void *fdt, int nodeoffset,
+				     const char *name,
+				     struct pinctrl_state **state)
+{
+	int pinctrl_index = 0;
+
+	if (!name)
+		name = "default";
+
+	pinctrl_index = fdt_stringlist_search(fdt, nodeoffset, "pinctrl-names",
+					      name);
+	if (pinctrl_index < 0) {
+		*state = NULL;
+		return TEE_ERROR_GENERIC;
+	}
+
+	return pinctrl_get_state_by_idx(fdt, nodeoffset, pinctrl_index, state);
+}

--- a/core/drivers/pinctrl/sub.mk
+++ b/core/drivers/pinctrl/sub.mk
@@ -1,0 +1,1 @@
+srcs-$(CFG_DRIVERS_PINCTRL) += pinctrl.c

--- a/core/drivers/pinctrl/sub.mk
+++ b/core/drivers/pinctrl/sub.mk
@@ -1,1 +1,2 @@
 srcs-$(CFG_DRIVERS_PINCTRL) += pinctrl.c
+srcs-$(CFG_ATMEL_PIO) += atmel_pio.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -82,6 +82,7 @@ subdirs-$(CFG_BNXT_FW) += bnxt
 subdirs-$(CFG_DRIVERS_CLK) += clk
 subdirs-$(CFG_DRIVERS_GPIO) += gpio
 subdirs-$(CFG_DRIVERS_I2C) += i2c
+subdirs-$(CFG_DRIVERS_PINCTRL) += pinctrl
 subdirs-$(CFG_DRIVERS_RSTCTRL) += rstctrl
 subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg
 subdirs-y += imx

--- a/core/include/drivers/pinctrl.h
+++ b/core/include/drivers/pinctrl.h
@@ -1,0 +1,176 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022-2023, Microchip
+ */
+
+#ifndef __DRIVERS_PINCTRL_H
+#define __DRIVERS_PINCTRL_H
+
+#include <bitstring.h>
+#include <kernel/dt_driver.h>
+#include <sys/queue.h>
+#include <tee_api_types.h>
+
+enum pinctrl_dt_prop {
+	/* Property "bias-disable" found in pinctrl node */
+	PINCTRL_DT_PROP_BIAS_DISABLE,
+	/* Property "bias-pull-up" found in pinctrl node */
+	PINCTRL_DT_PROP_BIAS_PULL_UP,
+	/* Property "bias-pull-down" found in pinctrl node */
+	PINCTRL_DT_PROP_BIAS_PULL_DOWN,
+	/* Terminal ID */
+	PINCTRL_DT_PROP_MAX
+};
+
+/*
+ * struct pinconf - Pinctrl device
+ * @ops: Operation handlers
+ * @priv: Pinctrl driver private data
+ */
+struct pinconf {
+	const struct pinctrl_ops *ops;
+	void *priv;
+};
+
+/*
+ * struct pinctrl_state - Pinctrl configuration state
+ * @conf_count: Number of cells in @confs
+ * @confs: Array of pin configurations related to the pinctrl config state
+ */
+struct pinctrl_state {
+	unsigned int conf_count;
+	struct pinconf *confs[];
+};
+
+struct pinctrl_ops {
+	/* Apply a pinctrl configuration */
+	TEE_Result (*conf_apply)(struct pinconf *conf);
+	/* Release resources allocated for a pinctrl configuration */
+	void (*conf_free)(struct pinconf *conf);
+};
+
+typedef struct pinconf *(*pinctrl_dt_get_func)(struct dt_driver_phandle_args *a,
+					       void *data, TEE_Result *res);
+
+#ifdef CFG_DRIVERS_PINCTRL
+/**
+ * pinctrl_dt_register_provider - Register a pinctrl controller provider
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the pin controller
+ * @get_pinctrl: Callback to match the pin controller with a struct pinconf
+ * @data: Data which will be passed to the get_pinctrl callback
+ * Return a TEE_Result compliant value
+ */
+static inline
+TEE_Result pinctrl_register_provider(const void *fdt, int nodeoffset,
+				     pinctrl_dt_get_func get_pinctrl,
+				     void *data)
+{
+	return dt_driver_register_provider(fdt, nodeoffset,
+					   (get_of_device_func)get_pinctrl,
+					   data, DT_DRIVER_PINCTRL);
+}
+
+/**
+ * pinctrl_get_state_by_name - Obtain a pinctrl state by name
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the pin controller
+ * @name: name of the pinctrl state to obtain from device-tree
+ * @state: Pointer filled with the retrieved state, must be freed after use
+   using pinctrl_free_state()
+ * Return a TEE_Result compliant value
+ */
+TEE_Result pinctrl_get_state_by_name(const void *fdt, int nodeoffset,
+				     const char *name,
+				     struct pinctrl_state **state);
+
+/**
+ * pinctrl_get_state_by_idx - Obtain a pinctrl state by index
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the pin controller
+ * @pinctrl_id: Index of the pinctrl state to obtain from device-tree
+ * @state: Pointer filled with the retrieved state, must be freed after use
+   using pinctrl_free_state()
+ * Return a TEE_Result compliant value
+ */
+TEE_Result pinctrl_get_state_by_idx(const void *fdt, int nodeoffset,
+				    unsigned int pinctrl_id,
+				    struct pinctrl_state **state);
+
+/**
+ * pinctrl_free_state - Free a pinctrl state that was previously obtained
+ *
+ * @state: State to be freed
+ */
+void pinctrl_free_state(struct pinctrl_state *state);
+
+/**
+ * pinctrl_apply_state - apply a pinctrl state
+ *
+ * @state: State to be applied
+ * Return a TEE_Result compliant value
+ */
+TEE_Result pinctrl_apply_state(struct pinctrl_state *state);
+
+/*
+ * pinctrl_parse_dt_pin_modes - Parse DT node properties
+ * @fdt: Device tree to work on
+ * @nodeoffset: Pinctrl node
+ * @modes: Output allocated regulator properties
+ * Return a TEE_Result compliant value
+ */
+TEE_Result pinctrl_parse_dt_pin_modes(const void *fdt, int nodeoffset,
+				      bitstr_t **modes);
+#else /* CFG_DRIVERS_PINCTRL */
+static inline
+TEE_Result pinctrl_register_provider(const void *fdt __unused,
+				     int nodeoffset __unused,
+				     pinctrl_dt_get_func get_pinctrl __unused,
+				     void *data __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline
+TEE_Result pinctrl_get_state_by_name(const void *fdt __unused,
+				     int nodeoffset __unused,
+				     const char *name __unused,
+				     struct pinctrl_state **state __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline
+TEE_Result pinctrl_get_state_by_idx(const void *fdt __unused,
+				    int nodeoffset __unused,
+				    unsigned int pinctrl_id __unused,
+				    struct pinctrl_state **state __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline
+void pinctrl_free_state(struct pinctrl_state *state __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline
+TEE_Result pinctrl_apply_state(struct pinctrl_state *state __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline
+TEE_Result pinctrl_parse_dt_pin_modes(const void *fdt __unused,
+				      int nodeoffset __unused,
+				      bitstr_t **modes __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+#endif /* CFG_DRIVERS_PINCTRL */
+#endif /* __DRIVERS_PINCTRL_H */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -22,6 +22,7 @@
  * DT_DRIVER_RSTCTRL Reset controller using generic reset DT bindings
  * DT_DRIVER_I2C    I2C bus controller using generic I2C bus DT bindings
  * DT_DRIVER_GPIO   GPIO controller using generic GPIO DT bindings
+ * DT_DRIVER_PINCTRL Pin controller using generic reset DT bindings
  */
 enum dt_driver_type {
 	DT_DRIVER_NOTYPE,
@@ -29,7 +30,8 @@ enum dt_driver_type {
 	DT_DRIVER_CLK,
 	DT_DRIVER_RSTCTRL,
 	DT_DRIVER_I2C,
-	DT_DRIVER_GPIO
+	DT_DRIVER_GPIO,
+	DT_DRIVER_PINCTRL
 };
 
 /*

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -889,6 +889,11 @@ CFG_DRIVERS_GPIO ?= n
 # When enabled, CFG_DRIVERS_I2C provides I2C controller and devices support.
 CFG_DRIVERS_I2C ?= n
 
+# When enabled, CFG_DRIVERS_PINCTRL embeds a pin muxing controller framework in
+# OP-TEE core to provide drivers a way to apply pin muxing configurations based
+# on device-tree.
+CFG_DRIVERS_PINCTRL ?= n
+
 # The purpose of this flag is to show a print when booting up the device that
 # indicates whether the board runs a standard developer configuration or not.
 # A developer configuration doesn't necessarily has to be secure. The intention


### PR DESCRIPTION
Add pinctrl support code for device-tree parsing and to allow drivers to apply pin muxing configuration based on the `pinctrl-<x>`and `pinctrl-names`. Also add a PIO driver for the sama5d2 pin muxing controller that provides a way to apply these configurations. This support will be used for the upcoming mcp16502 I2C connected PMIC support.