### PR TITLE
Stop using deprecated constants TEE_ALG_ECDSA_P* and TEE_ALG_ECDH_P*

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -76,20 +76,26 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		break;
 
 	case TEE_ALG_ECDSA_SHA1:
+	case TEE_ALG_ECDSA_SHA224:
+	case TEE_ALG_ECDSA_SHA256:
+	case TEE_ALG_ECDSA_SHA384:
+	case TEE_ALG_ECDSA_SHA512:
+		if (maxKeySize < 160 || maxKeySize > 521)
+			return TEE_ERROR_NOT_SUPPORTED;
+		break;
+
 	case __OPTEE_ALG_ECDSA_P192:
 	case __OPTEE_ALG_ECDH_P192:
 		if (maxKeySize != 192)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA224:
 	case __OPTEE_ALG_ECDSA_P224:
 	case __OPTEE_ALG_ECDH_P224:
 		if (maxKeySize != 224)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA256:
 	case __OPTEE_ALG_ECDSA_P256:
 	case __OPTEE_ALG_ECDH_P256:
 	case TEE_ALG_SM2_PKE:
@@ -104,14 +110,12 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA384:
 	case __OPTEE_ALG_ECDSA_P384:
 	case __OPTEE_ALG_ECDH_P384:
 		if (maxKeySize != 384)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA512:
 	case __OPTEE_ALG_ECDSA_P521:
 	case __OPTEE_ALG_ECDH_P521:
 		if (maxKeySize != 521)

--- a/ta/pkcs11/src/processing_ec.c
+++ b/ta/pkcs11/src/processing_ec.c
@@ -425,11 +425,10 @@ enum pkcs11_rc pkcs2tee_algo_ecdsa(uint32_t *tee_id,
 	switch (proc_params->id) {
 	case PKCS11_CKM_ECDSA:
 		/*
-		 * FIXME
 		 * ECDSA without hashing. The TEE algo to use is unknown at this
-		 * point.
+		 * point. Return the one with the largest digest size.
 		 */
-		return PKCS11_CKR_GENERAL_ERROR;
+		return TEE_ALG_ECDSA_SHA512;
 	case PKCS11_CKM_ECDSA_SHA1:
 		*tee_id = TEE_ALG_ECDSA_SHA1;
 		break;


### PR DESCRIPTION
Updates related to the deprecation of ECDSA and ECDH algorithm identifiers. This is a draft because of the last commit ("ta: pkcs11: do not use deprecated TEE_ALG_ECDSA_P* and TEE_ALG_ECDH_P*") which is incomplete. Help from PKCS#11 experts appreciated ;)