### PR TITLE
ldelf: syscall: support RISC-V ldelf sycall

### DIFF
--- a/ldelf/ldelf.mk
+++ b/ldelf/ldelf.mk
@@ -20,7 +20,9 @@ endif
 ifeq ($(CFG_RV64_core),y)
 CFG_RV64_$(sm) := y
 endif
-
+ifeq ($(CFG_RV32_core),y)
+CFG_RV32_$(sm) := y
+endif
 arch-bits-$(sm) := $(arch-bits-core)
 
 cppflags$(sm)	+= -include $(conf-file)

--- a/ldelf/sub.mk
+++ b/ldelf/sub.mk
@@ -5,6 +5,7 @@ srcs-$(CFG_ARM32_$(sm)) += syscalls_a32.S
 srcs-$(CFG_ARM64_$(sm)) += syscalls_a64.S
 srcs-$(CFG_ARM64_$(sm)) += tlsdesc_rel_a64.S
 srcs-$(CFG_RV64_$(sm)) += start_rv64.S
+srcs-$(call cfg-one-enabled,CFG_RV32_$(sm) CFG_RV64_$(sm)) += syscalls_rv.S
 srcs-y += dl.c
 srcs-y += main.c
 srcs-y += sys.c

--- a/ldelf/syscalls_rv.S
+++ b/ldelf/syscalls_rv.S
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 ESWIN Corp. or its affiliates.
+ * Authors:
+ *   Liu Shiwei <liushiwei@eswincomputing.com>
+ */
+
+#include <asm.S>
+
+	.section .text
+
+	.macro LDELF_SYSCALL name, scn, num_args
+FUNC \name , :
+
+	.if \num_args > 8
+	.error "Too many arguments for syscall"
+	.endif
+
+	li	t0, \scn
+	li	t1, \num_args
+	ecall
+	ret
+END_FUNC \name
+	.endm
+
+FUNC _ldelf_panic, :
+	j	__ldelf_panic
+	/* Not reached */
+END_FUNC _ldelf_panic
+
+#include "syscalls_asm.S"


### PR DESCRIPTION
Added 32-bit and 64-bit RISC-V ldelf system calls.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
