### PR TITLE
core: drivers: zynqmp_csu_puf.c: increase regen time to 6ms

### DIFF
--- a/core/drivers/zynqmp_csu_puf.c
+++ b/core/drivers/zynqmp_csu_puf.c
@@ -24,7 +24,7 @@
 
 #define PUF_CFG0_DEFAULT		0x02
 #define PUF_SHUT_DEFAULT		0x01000100
-#define PUF_REGEN_TIME_MS		3
+#define PUF_REGEN_TIME_MS		6
 
 TEE_Result zynqmp_csu_puf_regenerate(void)
 {


### PR DESCRIPTION
With further evaluation of the ZU+ PUF, we have determined that it is possible for the PUF regeneration time to exceed 3ms.  For this reason, the 2023.1 version of the Xilinx xilskey library will bump the wait time for PUF regeneration to 6ms.  This patch brings optee in line with this change.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
