### PR TITLE
core: fix out-of-bounds access of dump_ctx

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -982,7 +982,10 @@ TEE_Result tee_ta_instance_stats(void *buf, uint32_t *buf_size)
 			ta_count++;
 
 	sz = sizeof(struct tee_ta_dump_stats) * ta_count;
-	if (!buf || *buf_size < sz) {
+	if (!sz) {
+		/* sz = 0 means there is no UTA, return no item found. */
+		res = TEE_ERROR_ITEM_NOT_FOUND;
+	} else if (!buf || *buf_size < sz) {
 		/*
 		 * buf is null or pass size less than actual size
 		 * means caller try to query the buffer size.


### PR DESCRIPTION
Problem: in the case of no UTA running, the buffer of dump_ctx will be allocated with 0 size and passed to init_dump_ctx(). That causes buffer overrunning.

Solution: Check buffer size before allocate the buffer. If it's 0, return TEE_ERROR_ITEM_NOT_FOUND.

Tested-by: Weizhao Jiang <weizhaoj@amazon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
