### PR TITLE
plat-stm32mp1: pager resident size optims

### DIFF
--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -794,7 +794,6 @@ void core_init_mmu_regs(struct core_mmu_config *cfg)
 	 */
 	cfg->ttbcr = TTBCR_N_VALUE;
 }
-DECLARE_KEEP_PAGER(core_init_mmu_regs);
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fsr)
 {

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -119,10 +119,18 @@ CFG_WITH_PAGER ?= y
 CFG_WITH_SOFTWARE_PRNG ?= y
 endif # CFG_STM32MP15
 
+ifeq ($(CFG_WITH_PAGER),y)
+CFG_WITH_LPAE ?= n
+endif
 CFG_WITH_LPAE ?= y
 CFG_MMAP_REGIONS ?= 23
 CFG_DTB_MAX_SIZE ?= (256 * 1024)
 CFG_CORE_ASLR ?= n
+
+ifneq ($(CFG_WITH_LPAE),y)
+# Without LPAE, default TEE virtual address range is 1MB, we need at least 2MB.
+CFG_TEE_RAM_VA_SIZE ?= 0x00200000
+endif
 
 ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-512M)),)
 CFG_TZDRAM_START ?= 0xde000000

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -11,6 +11,13 @@
 /* Make stacks aligned to data cache line length */
 #define STACK_ALIGNMENT			32
 
+/* Translation table */
+#ifdef CFG_WITH_LPAE
+#define MAX_XLAT_TABLES			4
+#else
+#define MAX_XLAT_TABLES			8
+#endif
+
 /* SoC interface registers base address ranges */
 #define APB1_BASE			0x40000000
 #define APB1_SIZE			0x0001d000

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1379,7 +1379,7 @@ struct clk *stm32mp_rcc_clock_id_to_clk(unsigned long clock_id)
 	return clock_id_to_clk(clock_id);
 }
 
-#if CFG_TEE_CORE_LOG_LEVEL >= TRACE_DEBUG
+#if (CFG_TEE_CORE_LOG_LEVEL >= TRACE_DEBUG) && defined(CFG_TEE_CORE_DEBUG)
 struct clk_name {
 	unsigned int clock_id;
 	const char *name;


### PR DESCRIPTION
Few changes it optimize a bit resident memory size when using pager.