### PR TITLE
core: crypto: fix pkcs_1_v1_5_decode when empty message

### DIFF
--- a/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_decode.c
+++ b/core/lib/libtomcrypt/src/pk/pkcs1/pkcs_1_v1_5_decode.c
@@ -58,7 +58,7 @@ int pkcs_1_v1_5_decode(const unsigned char *msg,
     }
     ps_len = i++ - 2;
 
-    if (i >= modulus_len) {
+    if (i > modulus_len) {
       /* There was no octet with hexadecimal value 0x00 to separate ps from m.
        */
       result = CRYPT_INVALID_PACKET;


### PR DESCRIPTION
In case of EME-PKCS1-v1_5 decoding, the encoded message format is as follow : EM = 0x00 || 0x02 || PS || 0x00 || M. When using an empty message, the 0x00 octet that separates the padding string and message is located at the end. Thus, update the condition to pass the check in case of empty message.

This fixes the following AOSP cts test:
Module: CtsKeystoreTestCases
Test: testEmptyPlaintextEncryptsAndDecrypts
Link: https://android.googlesource.com/platform/cts/+/refs/tags/android-cts-12.0_r6/tests/tests/keystore/src/android/keystore/cts/CipherTest.java

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
