### PR TITLE
core: ffa: Allow multiple SPs with same UUID

### DIFF
--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -43,6 +43,7 @@ struct sp_session {
 	unsigned int spinlock;
 	const void *fdt;
 	bool is_initialized;
+	TEE_UUID ffa_uuid;
 	TAILQ_ENTRY(sp_session) link;
 };
 
@@ -82,10 +83,9 @@ static inline struct sp_ctx *to_sp_ctx(struct ts_ctx *ctx)
 
 struct sp_session *sp_get_session(uint32_t session_id);
 TEE_Result sp_enter(struct thread_smc_args *args, struct sp_session *sp);
-TEE_Result sp_partition_info_get_all(struct ffa_partition_info *fpi,
-				     size_t *elem_count);
+TEE_Result sp_partition_info_get(struct ffa_partition_info *fpi,
+				 const TEE_UUID *ffa_uuid, size_t *elem_count);
 
-TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id);
 bool sp_has_exclusive_access(struct sp_mem_map_region *mem,
 			     struct user_mode_ctx *uctx);
 TEE_Result sp_map_shared(struct sp_session *s,

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -97,23 +97,6 @@ static void set_sp_ctx_ops(struct ts_ctx *ctx)
 	ctx->ops = &sp_ops;
 }
 
-TEE_Result sp_find_session_id(const TEE_UUID *uuid, uint32_t *session_id)
-{
-	struct sp_session *s = NULL;
-
-	TAILQ_FOREACH(s, &open_sp_sessions, link) {
-		if (!memcmp(&s->ts_sess.ctx->uuid, uuid, sizeof(*uuid))) {
-			if (s->state == sp_dead)
-				return TEE_ERROR_TARGET_DEAD;
-
-			*session_id  = s->endpoint_id;
-			return TEE_SUCCESS;
-		}
-	}
-
-	return TEE_ERROR_ITEM_NOT_FOUND;
-}
-
 struct sp_session *sp_get_session(uint32_t session_id)
 {
 	struct sp_session *s = NULL;
@@ -126,14 +109,18 @@ struct sp_session *sp_get_session(uint32_t session_id)
 	return NULL;
 }
 
-TEE_Result sp_partition_info_get_all(struct ffa_partition_info *fpi,
-				     size_t *elem_count)
+TEE_Result sp_partition_info_get(struct ffa_partition_info *fpi,
+				 const TEE_UUID *ffa_uuid, size_t *elem_count)
 {
 	size_t in_count = *elem_count;
 	struct sp_session *s = NULL;
 	size_t count = 0;
 
 	TAILQ_FOREACH(s, &open_sp_sessions, link) {
+		if (ffa_uuid &&
+		    memcmp(&s->ffa_uuid, ffa_uuid, sizeof(*ffa_uuid)))
+			continue;
+
 		if (s->state == sp_dead)
 			continue;
 		if (count < in_count) {
@@ -187,7 +174,7 @@ static uint16_t new_session_id(struct sp_sessions_head *open_sessions)
 	return id;
 }
 
-static TEE_Result sp_create_ctx(const TEE_UUID *uuid, struct sp_session *s)
+static TEE_Result sp_create_ctx(const TEE_UUID *bin_uuid, struct sp_session *s)
 {
 	TEE_Result res = TEE_SUCCESS;
 	struct sp_ctx *spc = NULL;
@@ -199,7 +186,7 @@ static TEE_Result sp_create_ctx(const TEE_UUID *uuid, struct sp_session *s)
 
 	spc->open_session = s;
 	s->ts_sess.ctx = &spc->ts_ctx;
-	spc->ts_ctx.uuid = *uuid;
+	spc->ts_ctx.uuid = *bin_uuid;
 
 	res = vm_info_init(&spc->uctx, &spc->ts_ctx);
 	if (res)
@@ -215,7 +202,7 @@ err:
 }
 
 static TEE_Result sp_create_session(struct sp_sessions_head *open_sessions,
-				    const TEE_UUID *uuid,
+				    const TEE_UUID *bin_uuid,
 				    struct sp_session **sess)
 {
 	TEE_Result res = TEE_SUCCESS;
@@ -230,8 +217,8 @@ static TEE_Result sp_create_session(struct sp_sessions_head *open_sessions,
 		goto err;
 	}
 
-	DMSG("Loading Secure Partition %pUl", (void *)uuid);
-	res = sp_create_ctx(uuid, s);
+	DMSG("Loading Secure Partition %pUl", (void *)bin_uuid);
+	res = sp_create_ctx(bin_uuid, s);
 	if (res)
 		goto err;
 
@@ -515,7 +502,8 @@ err:
 
 static TEE_Result sp_open_session(struct sp_session **sess,
 				  struct sp_sessions_head *open_sessions,
-				  const TEE_UUID *uuid,
+				  const TEE_UUID *ffa_uuid,
+				  const TEE_UUID *bin_uuid,
 				  const void *fdt)
 {
 	TEE_Result res = TEE_SUCCESS;
@@ -523,10 +511,10 @@ static TEE_Result sp_open_session(struct sp_session **sess,
 	struct sp_ctx *ctx = NULL;
 	bool is_elf_format = false;
 
-	if (!find_secure_partition(uuid))
+	if (!find_secure_partition(bin_uuid))
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	res = sp_create_session(open_sessions, uuid, &s);
+	res = sp_create_session(open_sessions, bin_uuid, &s);
 	if (res != TEE_SUCCESS) {
 		DMSG("sp_create_session failed %#"PRIx32, res);
 		return res;
@@ -564,16 +552,16 @@ static TEE_Result sp_open_session(struct sp_session **sess,
 	s->state = sp_idle;
 	s->caller_id = 0;
 	sp_init_set_registers(ctx);
+	memcpy(&s->ffa_uuid, ffa_uuid, sizeof(*ffa_uuid));
 	ts_pop_current_session();
 
 	return TEE_SUCCESS;
 }
 
-static TEE_Result check_fdt(const void * const fdt, const TEE_UUID *uuid)
+static TEE_Result fdt_get_uuid(const void * const fdt, TEE_UUID *uuid)
 {
 	const struct fdt_property *description = NULL;
 	int description_name_len = 0;
-	TEE_UUID fdt_uuid = { };
 
 	if (fdt_node_check_compatible(fdt, 0, "arm,ffa-manifest-1.0")) {
 		EMSG("Failed loading SP, manifest not found");
@@ -585,13 +573,8 @@ static TEE_Result check_fdt(const void * const fdt, const TEE_UUID *uuid)
 	if (description)
 		DMSG("Loading SP: %s", description->data);
 
-	if (sp_dt_get_uuid(fdt, 0, "uuid", &fdt_uuid)) {
+	if (sp_dt_get_uuid(fdt, 0, "uuid", uuid)) {
 		EMSG("Missing or invalid UUID in SP manifest");
-		return TEE_ERROR_BAD_FORMAT;
-	}
-
-	if (memcmp(uuid, &fdt_uuid, sizeof(fdt_uuid))) {
-		EMSG("Failed loading SP, UUID mismatch");
 		return TEE_ERROR_BAD_FORMAT;
 	}
 
@@ -1198,16 +1181,19 @@ err_unmap:
 	return res;
 }
 
-static TEE_Result sp_init_uuid(const TEE_UUID *uuid, const void * const fdt)
+static TEE_Result sp_init_uuid(const TEE_UUID *bin_uuid, const void * const fdt)
 {
 	TEE_Result res = TEE_SUCCESS;
 	struct sp_session *sess = NULL;
+	TEE_UUID ffa_uuid = {};
 
-	res = check_fdt(fdt, uuid);
+	res = fdt_get_uuid(fdt, &ffa_uuid);
 	if (res)
 		return res;
 
-	res = sp_open_session(&sess, &open_sp_sessions, uuid, fdt);
+	res = sp_open_session(&sess,
+			      &open_sp_sessions,
+			      &ffa_uuid, bin_uuid, fdt);
 	if (res)
 		return res;
 


### PR DESCRIPTION
The FF-A spec doesn't forbid multiple SPs to have the same UUID. This makes it possible to use the FF-A UUID as a identifier for the protocol on top of the FF-A layer.
To achieve this we have to make sure that the FFA_PARTITION_INFO_GET can return more then one endpoint id if we pass a UUID. To make sure that there is no collision between the SP binaries names, we distinguish between the FF-A UUID and the SP UUID. The SP UUID is used to identify the SP itself. While the FF-A UUID is used as part of the FF-A protocol.


Build changes can be found [#636](https://github.com/OP-TEE/build/pull/636)
This is a follow-up on [#5650](https://github.com/OP-TEE/build/pull/603)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
