### PR TITLE
core: dt: add kernel DT API functions and cleaning

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1081,7 +1081,7 @@ static int get_nsec_memory_helper(void *fdt, struct core_mmu_phys_mem *mem)
 		if (offs < 0)
 			break;
 
-		if (_fdt_get_status(fdt, offs) != (DT_STATUS_OK_NSEC |
+		if (fdt_get_status(fdt, offs) != (DT_STATUS_OK_NSEC |
 						   DT_STATUS_OK_SEC))
 			continue;
 

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -143,13 +143,13 @@ static TEE_Result get_gic_base_addr_from_dt(paddr_t *gic_addr)
 					     "/interrupt-controller@6000000");
 
 	if (gic_offset > 0) {
-		paddr = _fdt_reg_base_address(fdt, gic_offset);
+		paddr = fdt_reg_base_address(fdt, gic_offset);
 		if (paddr == DT_INFO_INVALID_REG) {
 			EMSG("GIC: Unable to get base addr from DT");
 			return TEE_ERROR_ITEM_NOT_FOUND;
 		}
 
-		size = _fdt_reg_size(fdt, gic_offset);
+		size = fdt_reg_size(fdt, gic_offset);
 		if (size == DT_INFO_INVALID_REG_SIZE) {
 			EMSG("GIC: Unable to get size of base addr from DT");
 			return TEE_ERROR_ITEM_NOT_FOUND;

--- a/core/arch/arm/plat-sam/matrix.c
+++ b/core/arch/arm/plat-sam/matrix.c
@@ -577,7 +577,7 @@ TEE_Result matrix_dt_get_id(const void *fdt, int node, unsigned int *id)
 	unsigned int i = 0;
 	paddr_t pbase = 0;
 
-	pbase = _fdt_reg_base_address(fdt, node);
+	pbase = fdt_reg_base_address(fdt, node);
 	if (pbase == DT_INFO_INVALID_REG)
 		return TEE_ERROR_BAD_PARAMETERS;
 

--- a/core/arch/arm/plat-sam/sam_sfr.c
+++ b/core/arch/arm/plat-sam/sam_sfr.c
@@ -42,7 +42,7 @@ void atmel_sfr_set_usb_suspend(bool set)
 static TEE_Result atmel_sfr_probe(const void *fdt, int node,
 				  const void *compat_data __unused)
 {
-	if (_fdt_get_status(fdt, node) == DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) == DT_STATUS_OK_SEC)
 		matrix_configure_periph_secure(AT91C_ID_SFR);
 
 	return TEE_SUCCESS;

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -61,7 +61,7 @@ static int dt_pmic_status(void)
 		int node = dt_get_pmic_node(fdt);
 
 		if (node > 0)
-			return _fdt_get_status(fdt, node);
+			return fdt_get_status(fdt, node);
 	}
 
 	return -1;
@@ -430,7 +430,7 @@ static void parse_regulator_fdt_nodes(void)
 		panic();
 
 	fdt_for_each_subnode(regu_node, fdt, regulators_node) {
-		int status = _fdt_get_status(fdt, regu_node);
+		int status = fdt_get_status(fdt, regu_node);
 		const char *regu_name = NULL;
 		size_t n = 0;
 
@@ -489,7 +489,7 @@ static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
 	if (i2c_node < 0)
 		return -FDT_ERR_NOTFOUND;
 
-	_fdt_fill_device_info(fdt, i2c_info, i2c_node);
+	fdt_fill_device_info(fdt, i2c_info, i2c_node);
 	if (!i2c_info->reg)
 		return -FDT_ERR_NOTFOUND;
 

--- a/core/drivers/atmel_rstc.c
+++ b/core/drivers/atmel_rstc.c
@@ -45,7 +45,7 @@ static TEE_Result atmel_rstc_probe(const void *fdt, int node,
 {
 	size_t size = 0;
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	matrix_configure_periph_secure(AT91C_ID_SYS);

--- a/core/drivers/atmel_rtc.c
+++ b/core/drivers/atmel_rtc.c
@@ -288,7 +288,7 @@ static TEE_Result atmel_rtc_probe(const void *fdt, int node,
 	if (rtc_base)
 		return TEE_ERROR_GENERIC;
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	matrix_configure_periph_secure(AT91C_ID_SYS);

--- a/core/drivers/atmel_shdwc.c
+++ b/core/drivers/atmel_shdwc.c
@@ -152,7 +152,7 @@ static TEE_Result atmel_shdwc_probe(const void *fdt, int node,
 	 */
 	COMPILE_TIME_ASSERT(CFG_TEE_CORE_NB_CORE == 1);
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	matrix_configure_periph_secure(AT91C_ID_SYS);

--- a/core/drivers/atmel_tcb.c
+++ b/core/drivers/atmel_tcb.c
@@ -165,7 +165,7 @@ static TEE_Result atmel_tcb_probe(const void *fdt, int node,
 	if (tcb_base)
 		return TEE_SUCCESS;
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_SUCCESS;
 
 	res = clk_dt_get_by_name(fdt, node, "slow_clk", &clk);

--- a/core/drivers/atmel_trng.c
+++ b/core/drivers/atmel_trng.c
@@ -84,7 +84,7 @@ static void atmel_trng_reset(void)
 static TEE_Result trng_node_probe(const void *fdt, int node,
 				  const void *compat_data __unused)
 {
-	int status = _fdt_get_status(fdt, node);
+	int status = fdt_get_status(fdt, node);
 	size_t size = 0;
 	struct clk *clk = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;

--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -230,7 +230,7 @@ static TEE_Result wdt_node_probe(const void *fdt, int node,
 	int it = DT_INFO_INVALID_INTERRUPT;
 	struct itr_handler *it_hdlr;
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	matrix_configure_periph_secure(AT91C_ID_WDT);

--- a/core/drivers/clk/clk-stm32mp13.c
+++ b/core/drivers/clk/clk-stm32mp13.c
@@ -1439,7 +1439,7 @@ static int clk_stm32_parse_oscillator_fdt(const void *fdt, int node,
 			return ret;
 
 		if (strncmp(cchar, name, (size_t)ret) ||
-		    _fdt_get_status(fdt, subnode) == DT_STATUS_DISABLED)
+		    fdt_get_status(fdt, subnode) == DT_STATUS_DISABLED)
 			continue;
 
 		cuint = fdt_getprop(fdt, subnode, "clock-frequency", &ret);
@@ -1457,8 +1457,8 @@ static int clk_stm32_parse_oscillator_fdt(const void *fdt, int node,
 		if (fdt_getprop(fdt, subnode, "st,css", NULL))
 			osci->css = true;
 
-		osci->drive = _fdt_read_uint32_default(fdt, subnode, "st,drive",
-						       LSEDRV_MEDIUM_HIGH);
+		osci->drive = fdt_read_uint32_default(fdt, subnode, "st,drive",
+						      LSEDRV_MEDIUM_HIGH);
 
 		return 0;
 	}
@@ -1498,13 +1498,13 @@ static int clk_stm32_load_vco_config_fdt(const void *fdt, int subnode,
 {
 	int ret = 0;
 
-	ret = _fdt_read_uint32_array(fdt, subnode, "divmn", vco->div_mn,
-				     PLL_DIV_MN_NB);
+	ret = fdt_read_uint32_array(fdt, subnode, "divmn", vco->div_mn,
+				    PLL_DIV_MN_NB);
 	if (ret != 0)
 		return ret;
 
-	ret = _fdt_read_uint32_array(fdt, subnode, "csg", vco->csg,
-				     PLL_CSG_NB);
+	ret = fdt_read_uint32_array(fdt, subnode, "csg", vco->csg,
+				    PLL_CSG_NB);
 
 	vco->csg_enabled = (ret == 0);
 
@@ -1517,9 +1517,9 @@ static int clk_stm32_load_vco_config_fdt(const void *fdt, int subnode,
 	vco->status = RCC_PLLNCR_DIVPEN | RCC_PLLNCR_DIVQEN |
 		      RCC_PLLNCR_DIVREN | RCC_PLLNCR_PLLON;
 
-	vco->frac = _fdt_read_uint32_default(fdt, subnode, "frac", 0);
+	vco->frac = fdt_read_uint32_default(fdt, subnode, "frac", 0);
 
-	vco->src = _fdt_read_uint32_default(fdt, subnode, "src", UINT32_MAX);
+	vco->src = fdt_read_uint32_default(fdt, subnode, "src", UINT32_MAX);
 
 	return 0;
 }
@@ -1527,8 +1527,8 @@ static int clk_stm32_load_vco_config_fdt(const void *fdt, int subnode,
 static int clk_stm32_load_output_config_fdt(const void *fdt, int subnode,
 					    struct stm32_pll_output *output)
 {
-	return _fdt_read_uint32_array(fdt, subnode, "st,pll_div_pqr",
-				      output->output, (int)PLL_DIV_PQR_NB);
+	return fdt_read_uint32_array(fdt, subnode, "st,pll_div_pqr",
+				     output->output, (int)PLL_DIV_PQR_NB);
 }
 
 static int clk_stm32_parse_pll_fdt(const void *fdt, int subnode,
@@ -1611,17 +1611,17 @@ static int stm32_clk_parse_fdt_opp(const void *fdt, int node,
 			panic();
 		}
 
-		opp_cfg->frq = _fdt_read_uint32_default(fdt, subnode,
-							"hz",
-							UINT32_MAX);
+		opp_cfg->frq = fdt_read_uint32_default(fdt, subnode,
+						       "hz",
+						       UINT32_MAX);
 
-		opp_cfg->src = _fdt_read_uint32_default(fdt, subnode,
-							"st,clksrc",
-							UINT32_MAX);
+		opp_cfg->src = fdt_read_uint32_default(fdt, subnode,
+						       "st,clksrc",
+						       UINT32_MAX);
 
-		opp_cfg->div = _fdt_read_uint32_default(fdt, subnode,
-							"st,clkdiv",
-							UINT32_MAX);
+		opp_cfg->div = fdt_read_uint32_default(fdt, subnode,
+						       "st,clkdiv",
+						       UINT32_MAX);
 
 		ret = clk_stm32_parse_pll_fdt(fdt, subnode, &opp_cfg->pll_cfg);
 		if (ret)

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1178,7 +1178,7 @@ static unsigned int clk_freq_prop(const void *fdt, int node)
 	int ret = 0;
 
 	/* Disabled clocks report null rate */
-	if (_fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
+	if (fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
 		return 0;
 
 	cuint = fdt_getprop(fdt, node, "clock-frequency", &ret);

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -97,7 +97,7 @@ static TEE_Result clk_probe_clock_provider_node(const void *fdt, int node)
 	int status = 0;
 	TEE_Result res = TEE_ERROR_GENERIC;
 
-	status = _fdt_get_status(fdt, node);
+	status = fdt_get_status(fdt, node);
 	if (!(status & DT_STATUS_OK_SEC))
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
@@ -124,7 +124,7 @@ static void clk_probe_node(const void *fdt, int parent_node)
 	__maybe_unused TEE_Result res = TEE_ERROR_GENERIC;
 
 	fdt_for_each_subnode(child, fdt, parent_node) {
-		status = _fdt_get_status(fdt, child);
+		status = fdt_get_status(fdt, child);
 		if (status == DT_STATUS_DISABLED)
 			continue;
 
@@ -186,7 +186,7 @@ static void clk_probe_assigned(const void *fdt, int parent_node)
 	fdt_for_each_subnode(child, fdt, parent_node) {
 		clk_probe_assigned(fdt, child);
 
-		status = _fdt_get_status(fdt, child);
+		status = fdt_get_status(fdt, child);
 		if (status == DT_STATUS_DISABLED)
 			continue;
 

--- a/core/drivers/clk/sam/sama5d2_clk.c
+++ b/core/drivers/clk/sam/sama5d2_clk.c
@@ -347,7 +347,7 @@ static TEE_Result pmc_setup(const void *fdt, int nodeoffset,
 	if (dt_map_dev(fdt, nodeoffset, &base, &size, DT_MAP_AUTO) < 0)
 		panic();
 
-	if (_fdt_get_status(fdt, nodeoffset) == DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, nodeoffset) == DT_STATUS_OK_SEC)
 		matrix_configure_periph_secure(AT91C_ID_PMC);
 
 	res = clk_dt_get_by_name(fdt, nodeoffset, "slow_clk", &slow_clk);

--- a/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
@@ -39,9 +39,9 @@ static paddr_t find_jr_offset(void *fdt, int status, int *find_node)
 	     node = fdt_node_offset_by_compatible(fdt, node,
 						  dt_jr_match_table)) {
 		HAL_TRACE("Found Job Ring node status @%" PRId32, node);
-		if (_fdt_get_status(fdt, node) == status) {
+		if (fdt_get_status(fdt, node) == status) {
 			HAL_TRACE("Found Job Ring node @%" PRId32, node);
-			jr_offset = _fdt_reg_base_address(fdt, node);
+			jr_offset = fdt_reg_base_address(fdt, node);
 			*find_node = node;
 			break;
 		}
@@ -69,13 +69,13 @@ void caam_hal_cfg_get_ctrl_dt(void *fdt, vaddr_t *ctrl_base)
 	 * already present in the MMU table.
 	 * Then get the virtual address of the CAAM controller
 	 */
-	pctrl_base = _fdt_reg_base_address(fdt, node);
+	pctrl_base = fdt_reg_base_address(fdt, node);
 	if (pctrl_base == DT_INFO_INVALID_REG) {
 		HAL_TRACE("CAAM control base address not defined");
 		return;
 	}
 
-	size = _fdt_reg_size(fdt, node);
+	size = fdt_reg_size(fdt, node);
 	if (size == DT_INFO_INVALID_REG_SIZE) {
 		HAL_TRACE("CAAM control base address size not defined");
 		return;
@@ -127,7 +127,7 @@ void caam_hal_cfg_disable_jobring_dt(void *fdt, struct caam_jrcfg *jrcfg)
 	     node = fdt_node_offset_by_compatible(fdt, node,
 						  dt_jr_match_table)) {
 		HAL_TRACE("Found Job Ring node @%" PRId32, node);
-		if (_fdt_reg_base_address(fdt, node) == jrcfg->offset) {
+		if (fdt_reg_base_address(fdt, node) == jrcfg->offset) {
 			HAL_TRACE("Disable Job Ring node @%" PRId32, node);
 			if (dt_enable_secure_status(fdt, node))
 				panic();

--- a/core/drivers/crypto/stm32/stm32_cryp.c
+++ b/core/drivers/crypto/stm32/stm32_cryp.c
@@ -1253,7 +1253,7 @@ static TEE_Result stm32_cryp_probe(const void *fdt, int node,
 	struct rstctrl *rstctrl = NULL;
 	struct clk *clk = NULL;
 
-	_fdt_fill_device_info(fdt, &dt_cryp, node);
+	fdt_fill_device_info(fdt, &dt_cryp, node);
 
 	if (dt_cryp.reg == DT_INFO_INVALID_REG ||
 	    dt_cryp.reg_size == DT_INFO_INVALID_REG_SIZE)

--- a/core/drivers/imx/dcp/dcp.c
+++ b/core/drivers/imx/dcp/dcp.c
@@ -694,7 +694,7 @@ static TEE_Result dcp_pbase(paddr_t *base)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 	}
 
-	if (_fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
+	if (fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	/* Force secure-status = "okay" and status="disabled" */
@@ -703,7 +703,7 @@ static TEE_Result dcp_pbase(paddr_t *base)
 		return TEE_ERROR_NOT_SUPPORTED;
 	}
 
-	*base = _fdt_reg_base_address(fdt, node);
+	*base = fdt_reg_base_address(fdt, node);
 	if (*base == DT_INFO_INVALID_REG) {
 		EMSG("Unable to get the DCP Base address");
 		return TEE_ERROR_ITEM_NOT_FOUND;

--- a/core/drivers/imx_i2c.c
+++ b/core/drivers/imx_i2c.c
@@ -505,7 +505,7 @@ static TEE_Result i2c_mapped(const char *i2c_match)
 		if (off < 0)
 			break;
 
-		if (!(_fdt_get_status(fdt, off) & DT_STATUS_OK_SEC)) {
+		if (!(fdt_get_status(fdt, off) & DT_STATUS_OK_SEC)) {
 			EMSG("i2c%zu not enabled", i + 1);
 			continue;
 		}

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -116,7 +116,7 @@ static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)
 		while (off >= 0) {
 			off = fdt_node_offset_by_compatible(fdt, off, match);
 			if (off > 0) {
-				st = _fdt_get_status(fdt, off);
+				st = fdt_get_status(fdt, off);
 				if (st & DT_STATUS_OK_SEC) {
 					DMSG("Wdog found at %u", off);
 					found_off = off;

--- a/core/drivers/ls_dspi.c
+++ b/core/drivers/ls_dspi.c
@@ -550,7 +550,7 @@ static TEE_Result get_info_from_device_tree(struct ls_dspi_data *dspi_data)
 	while (node != -FDT_ERR_NOTFOUND) {
 		node = fdt_node_offset_by_compatible(fdt, node,
 						     "fsl,lx2160a-dspi");
-		if (!(_fdt_get_status(fdt, node) & DT_STATUS_OK_SEC))
+		if (!(fdt_get_status(fdt, node) & DT_STATUS_OK_SEC))
 			continue;
 
 		bus_num = fdt_getprop(fdt, node, "bus-num", NULL);

--- a/core/drivers/pm/sam/at91_pm.c
+++ b/core/drivers/pm/sam/at91_pm.c
@@ -362,7 +362,7 @@ static TEE_Result at91_pm_backup_init(const void *fdt)
 	if (dt_map_dev(fdt, node, &soc_pm.sfrbu, &size, DT_MAP_AUTO) < 0)
 		return TEE_ERROR_GENERIC;
 
-	if (_fdt_get_status(fdt, node) == DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) == DT_STATUS_OK_SEC)
 		matrix_configure_periph_secure(AT91C_ID_SFRBU);
 
 	return TEE_SUCCESS;
@@ -379,7 +379,7 @@ static TEE_Result at91_pm_sram_init(const void *fdt)
 	if (node < 0)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_GENERIC;
 
 	if (dt_map_dev(fdt, node, &at91_suspend_sram_base, &size,
@@ -413,7 +413,7 @@ static TEE_Result at91_securam_init(const void *fdt)
 	if (node < 0)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_GENERIC;
 
 	if (dt_map_dev(fdt, node, &soc_pm.securam, &size, DT_MAP_AUTO) < 0)
@@ -435,7 +435,7 @@ static TEE_Result at91_securam_init(const void *fdt)
 	if (node < 0)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
-	if (_fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
 		return TEE_ERROR_GENERIC;
 
 	if (dt_map_dev(fdt, node, &soc_pm.secumod, &size, DT_MAP_AUTO) < 0)

--- a/core/drivers/rstctrl/stm32_rstctrl.c
+++ b/core/drivers/rstctrl/stm32_rstctrl.c
@@ -208,7 +208,7 @@ static TEE_Result stm32_rstctrl_provider_probe(const void *fdt, int offs,
 
 	assert(rstctrl_ops_is_valid(&stm32_rstctrl_ops));
 
-	_fdt_fill_device_info(fdt, &info, offs);
+	fdt_fill_device_info(fdt, &info, offs);
 
 	assert(info.reg == RCC_BASE &&
 	       info.reg_size != DT_INFO_INVALID_REG_SIZE);

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -688,8 +688,8 @@ static void bsec_dt_otp_nsec_access(void *fdt, int bsec_node)
 		unsigned int i = 0;
 		size_t size = 0;
 
-		reg_offset = _fdt_reg_base_address(fdt, bsec_subnode);
-		reg_size = _fdt_reg_size(fdt, bsec_subnode);
+		reg_offset = fdt_reg_base_address(fdt, bsec_subnode);
+		reg_size = fdt_reg_size(fdt, bsec_subnode);
 
 		assert(reg_offset != DT_INFO_INVALID_REG &&
 		       reg_size != DT_INFO_INVALID_REG_SIZE);
@@ -794,8 +794,8 @@ static void save_dt_nvmem_layout(void *fdt, int bsec_node)
 		if (!string || !len)
 			continue;
 
-		reg_offset = _fdt_reg_base_address(fdt, node);
-		reg_length = _fdt_reg_size(fdt, node);
+		reg_offset = fdt_reg_base_address(fdt, node);
+		reg_length = fdt_reg_size(fdt, node);
 
 		if (reg_offset == DT_INFO_INVALID_REG ||
 		    reg_length == DT_INFO_INVALID_REG_SIZE) {
@@ -844,7 +844,7 @@ static void initialize_bsec_from_dt(void)
 	if (node < 0)
 		panic();
 
-	_fdt_fill_device_info(fdt, &bsec_info, node);
+	fdt_fill_device_info(fdt, &bsec_info, node);
 
 	if (bsec_info.reg != bsec_dev.base.pa ||
 	    !(bsec_info.status & DT_STATUS_OK_SEC))

--- a/core/drivers/stm32_etzpc.c
+++ b/core/drivers/stm32_etzpc.c
@@ -328,11 +328,11 @@ static TEE_Result init_etzpc_from_dt(void)
 		panic();
 	assert(fdt_node_offset_by_compatible(fdt, node, ETZPC_COMPAT) < 0);
 
-	status = _fdt_get_status(fdt, node);
+	status = fdt_get_status(fdt, node);
 	if (!(status & DT_STATUS_OK_SEC))
 		panic();
 
-	pbase = _fdt_reg_base_address(fdt, node);
+	pbase = fdt_reg_base_address(fdt, node);
 	if (pbase == (paddr_t)-1)
 		panic();
 

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -187,7 +187,7 @@ static void ckeck_gpio_bank(void *fdt, uint32_t bank, int pinctrl_node)
 			panic();
 
 		/* Check controller is enabled */
-		if (_fdt_get_status(fdt, pinctrl_subnode) == DT_STATUS_DISABLED)
+		if (fdt_get_status(fdt, pinctrl_subnode) == DT_STATUS_DISABLED)
 			panic();
 
 		return;

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -695,7 +695,7 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 	/* Default STM32 specific configs caller may need to overwrite */
 	memset(init, 0, sizeof(*init));
 
-	_fdt_fill_device_info(fdt, &info, node);
+	fdt_fill_device_info(fdt, &info, node);
 	assert(info.reg != DT_INFO_INVALID_REG &&
 	       info.reg_size != DT_INFO_INVALID_REG_SIZE);
 

--- a/core/drivers/stm32_iwdg.c
+++ b/core/drivers/stm32_iwdg.c
@@ -252,7 +252,7 @@ static TEE_Result stm32_iwdg_parse_fdt(struct stm32_iwdg_device *iwdg,
 	struct dt_node_info dt_info = { };
 	const fdt32_t *cuint = NULL;
 
-	_fdt_fill_device_info(fdt, &dt_info, node);
+	fdt_fill_device_info(fdt, &dt_info, node);
 
 	if (dt_info.reg == DT_INFO_INVALID_REG ||
 	    dt_info.reg_size == DT_INFO_INVALID_REG_SIZE)

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -428,7 +428,7 @@ static TEE_Result stm32_rng_parse_fdt(const void *fdt, int node)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct dt_node_info dt_rng = { };
 
-	_fdt_fill_device_info(fdt, &dt_rng, node);
+	fdt_fill_device_info(fdt, &dt_rng, node);
 	if (dt_rng.reg == DT_INFO_INVALID_REG)
 		return TEE_ERROR_BAD_PARAMETERS;
 

--- a/core/drivers/stm32_tamp.c
+++ b/core/drivers/stm32_tamp.c
@@ -218,7 +218,7 @@ static TEE_Result stm32_tamp_parse_fdt(struct stm32_tamp_instance *tamp,
 {
 	struct dt_node_info dt_tamp = { };
 
-	_fdt_fill_device_info(fdt, &dt_tamp, node);
+	fdt_fill_device_info(fdt, &dt_tamp, node);
 
 	if (dt_tamp.reg == DT_INFO_INVALID_REG ||
 	    dt_tamp.reg_size == DT_INFO_INVALID_REG_SIZE)

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -136,7 +136,7 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	struct stm32_pinctrl *pinctrl_cfg = NULL;
 	int count = 0;
 
-	_fdt_fill_device_info(fdt, &info, node);
+	fdt_fill_device_info(fdt, &info, node);
 
 	if (info.status == DT_STATUS_DISABLED)
 		return NULL;

--- a/core/drivers/xiphera_trng.c
+++ b/core/drivers/xiphera_trng.c
@@ -97,7 +97,7 @@ TEE_Result hw_get_random_bytes(void *buf, size_t len)
 static TEE_Result xiphera_trng_probe(const void *fdt, int node,
 				     const void *compat_data __unused)
 {
-	int dt_status = _fdt_get_status(fdt, node);
+	int dt_status = fdt_get_status(fdt, node);
 	uint32_t status = 0;
 	size_t size = 0;
 

--- a/core/drivers/zynqmp_csu_aes.c
+++ b/core/drivers/zynqmp_csu_aes.c
@@ -403,7 +403,7 @@ TEE_Result zynqmp_csu_aes_dt_enable_secure_status(void)
 	if (node < 0)
 		return TEE_SUCCESS;
 
-	if (_fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
+	if (fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
 		return TEE_SUCCESS;
 
 	if (dt_enable_secure_status(fdt, node)) {

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -236,15 +236,6 @@ uint32_t fdt_read_uint32_default(const void *fdt, int node,
 				 const char *prop_name, uint32_t dflt_value);
 
 /*
- * Check whether the node at @node has a reference name.
- *
- * @node is the offset of the node that describes the device in @fdt.
- *
- * Returns true on success or false if no property
- */
-bool fdt_check_node(const void *fdt, int node);
-
-/*
  * This function fills reg node info (base & size) with an index.
  *
  * Returns 0 on success and a negative FDT error code on failure.

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -244,6 +244,23 @@ uint32_t fdt_read_uint32_default(const void *fdt, int node,
  */
 bool fdt_check_node(const void *fdt, int node);
 
+/*
+ * This function fills reg node info (base & size) with an index.
+ *
+ * Returns 0 on success and a negative FDT error code on failure.
+ */
+int fdt_get_reg_props_by_index(const void *fdt, int node, int index,
+			       paddr_t *base, size_t *size);
+
+/*
+ * This function fills reg node info (base & size) with an index found by
+ * checking the reg-names node.
+ *
+ * Returns 0 on success and a negative FDT error code on failure.
+ */
+int fdt_get_reg_props_by_name(const void *fdt, int node, const char *name,
+			      paddr_t *base, size_t *size);
+
 #else /* !CFG_DT */
 
 static inline const struct dt_driver *dt_find_compatible_driver(
@@ -315,6 +332,24 @@ static inline int fdt_read_uint32_index(const void *fdt __unused,
 					const char *prop_name __unused,
 					int index __unused,
 					uint32_t *value __unused)
+{
+	return -1;
+}
+
+static inline int fdt_get_reg_props_by_index(const void *fdt __unused,
+					     int node __unused,
+					     int index __unused,
+					     paddr_t *base __unused,
+					     size_t *size __unused)
+{
+	return -1;
+}
+
+static inline int fdt_get_reg_props_by_name(const void *fdt __unused,
+					    int node __unused,
+					    const char *name __unused,
+					    paddr_t *base __unused,
+					    size_t *size __unused)
 {
 	return -1;
 }

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -181,20 +181,20 @@ int dt_enable_secure_status(void *fdt, int node);
  * Return the base address for the "reg" property of the specified node or
  * (paddr_t)-1 in case of error
  */
-paddr_t _fdt_reg_base_address(const void *fdt, int offs);
+paddr_t fdt_reg_base_address(const void *fdt, int offs);
 
 /*
  * Return the reg size for the reg property of the specified node or -1 in case
  * of error
  */
-size_t _fdt_reg_size(const void *fdt, int offs);
+size_t fdt_reg_size(const void *fdt, int offs);
 
 /*
  * Read the status and secure-status properties into a bitfield.
  * Return -1 on failure, DT_STATUS_DISABLED if the node is disabled,
  * otherwise return a combination of DT_STATUS_OK_NSEC and DT_STATUS_OK_SEC.
  */
-int _fdt_get_status(const void *fdt, int offs);
+int fdt_get_status(const void *fdt, int offs);
 
 /*
  * fdt_fill_device_info - Get generic device info from a node
@@ -204,29 +204,29 @@ int _fdt_get_status(const void *fdt, int offs);
  * a single reset ID line and a single interrupt ID.
  * Default DT_INFO_* macros are used when the relate property is not found.
  */
-void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info,
-			   int node);
+void fdt_fill_device_info(const void *fdt, struct dt_node_info *info,
+			  int node);
 /*
  * Read cells from a given property of the given node. Any number of 32-bit
  * cells of the property can be read. Returns 0 on success, or a negative
  * FDT error value otherwise.
  */
-int _fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
-			   uint32_t *array, size_t count);
+int fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
+			  uint32_t *array, size_t count);
 
 /*
  * Read one cell from a given property of the given node.
  * Returns 0 on success, or a negative FDT error value otherwise.
  */
-int _fdt_read_uint32(const void *fdt, int node, const char *prop_name,
-		     uint32_t *value);
+int fdt_read_uint32(const void *fdt, int node, const char *prop_name,
+		    uint32_t *value);
 
 /*
  * Read one cell from a property of a cell or default to a given value
  * Returns the 32bit cell value or @dflt_value on failure.
  */
-uint32_t _fdt_read_uint32_default(const void *fdt, int node,
-				  const char *prop_name, uint32_t dflt_value);
+uint32_t fdt_read_uint32_default(const void *fdt, int node,
+				 const char *prop_name, uint32_t dflt_value);
 
 /*
  * Check whether the node at @node has a reference name.
@@ -235,7 +235,7 @@ uint32_t _fdt_read_uint32_default(const void *fdt, int node,
  *
  * Returns true on success or false if no property
  */
-bool _fdt_check_node(const void *fdt, int node);
+bool fdt_check_node(const void *fdt, int node);
 
 #else /* !CFG_DT */
 
@@ -253,52 +253,52 @@ static inline int dt_map_dev(const void *fdt __unused, int offs __unused,
 	return -1;
 }
 
-static inline paddr_t _fdt_reg_base_address(const void *fdt __unused,
-					    int offs __unused)
+static inline paddr_t fdt_reg_base_address(const void *fdt __unused,
+					   int offs __unused)
 {
 	return (paddr_t)-1;
 }
 
-static inline size_t _fdt_reg_size(const void *fdt __unused,
-				   int offs __unused)
+static inline size_t fdt_reg_size(const void *fdt __unused,
+				  int offs __unused)
 {
 	return (size_t)-1;
 }
 
-static inline int _fdt_get_status(const void *fdt __unused, int offs __unused)
+static inline int fdt_get_status(const void *fdt __unused, int offs __unused)
 {
 	return -1;
 }
 
 __noreturn
-static inline void _fdt_fill_device_info(const void *fdt __unused,
-					 struct dt_node_info *info __unused,
-					 int node __unused)
+static inline void fdt_fill_device_info(const void *fdt __unused,
+					struct dt_node_info *info __unused,
+					int node __unused)
 {
 	panic();
 }
 
-static inline int _fdt_read_uint32_array(const void *fdt __unused,
-					 int node __unused,
-					 const char *prop_name __unused,
-					 uint32_t *array __unused,
-					 size_t count __unused)
+static inline int fdt_read_uint32_array(const void *fdt __unused,
+					int node __unused,
+					const char *prop_name __unused,
+					uint32_t *array __unused,
+					size_t count __unused)
 {
 	return -1;
 }
 
-static inline int _fdt_read_uint32(const void *fdt __unused,
-				   int node __unused,
-				   const char *prop_name __unused,
-				   uint32_t *value __unused)
+static inline int fdt_read_uint32(const void *fdt __unused,
+				  int node __unused,
+				  const char *prop_name __unused,
+				  uint32_t *value __unused)
 {
 	return -1;
 }
 
-static inline uint32_t _fdt_read_uint32_default(const void *fdt __unused,
-						int node __unused,
-						const char *prop_name __unused,
-						uint32_t dflt_value __unused)
+static inline uint32_t fdt_read_uint32_default(const void *fdt __unused,
+					       int node __unused,
+					       const char *prop_name __unused,
+					       uint32_t dflt_value __unused)
 {
 	return dflt_value;
 }

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -215,6 +215,13 @@ int fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
 			  uint32_t *array, size_t count);
 
 /*
+ * Read one cell from a given multi-value property of the given node.
+ * Returns 0 on success, or a negative FDT error value otherwise.
+ */
+int fdt_read_uint32_index(const void *fdt, int node, const char *prop_name,
+			  int index, uint32_t *value);
+
+/*
  * Read one cell from a given property of the given node.
  * Returns 0 on success, or a negative FDT error value otherwise.
  */
@@ -301,6 +308,15 @@ static inline uint32_t fdt_read_uint32_default(const void *fdt __unused,
 					       uint32_t dflt_value __unused)
 {
 	return dflt_value;
+}
+
+static inline int fdt_read_uint32_index(const void *fdt __unused,
+					int node __unused,
+					const char *prop_name __unused,
+					int index __unused,
+					uint32_t *value __unused)
+{
+	return -1;
 }
 
 #endif /* !CFG_DT */

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -189,10 +189,25 @@ paddr_t fdt_reg_base_address(const void *fdt, int offs)
 	return fdt_read_paddr(reg, ncells);
 }
 
+static size_t fdt_read_size(const uint32_t *cell, int n)
+{
+	uint32_t sz = 0;
+
+	sz = fdt32_to_cpu(*cell);
+	if (n == 2) {
+		if (sz)
+			return DT_INFO_INVALID_REG_SIZE;
+
+		cell++;
+		sz = fdt32_to_cpu(*cell);
+	}
+
+	return sz;
+}
+
 size_t fdt_reg_size(const void *fdt, int offs)
 {
 	const uint32_t *reg;
-	uint32_t sz;
 	int n;
 	int len;
 	int parent;
@@ -215,15 +230,7 @@ size_t fdt_reg_size(const void *fdt, int offs)
 	if (n < 1 || n > 2)
 		return DT_INFO_INVALID_REG_SIZE;
 
-	sz = fdt32_to_cpu(*reg);
-	if (n == 2) {
-		if (sz)
-			return DT_INFO_INVALID_REG_SIZE;
-		reg++;
-		sz = fdt32_to_cpu(*reg);
-	}
-
-	return sz;
+	return fdt_read_size(reg, n);
 }
 
 static bool is_okay(const char *st, int len)

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -309,7 +309,7 @@ int fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
 
 	cuint = fdt_getprop(fdt, node, prop_name, &len);
 	if (!cuint)
-		return -FDT_ERR_NOTFOUND;
+		return len;
 
 	if ((uint32_t)len != (count * sizeof(uint32_t)))
 		return -FDT_ERR_BADLAYOUT;

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -316,6 +316,24 @@ int fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
 	return 0;
 }
 
+int fdt_read_uint32_index(const void *fdt, int node, const char *prop_name,
+			  int index, uint32_t *value)
+{
+	const fdt32_t *cuint = NULL;
+	int len = 0;
+
+	cuint = fdt_getprop(fdt, node, prop_name, &len);
+	if (!cuint)
+		return len;
+
+	if ((uint32_t)len < (sizeof(uint32_t) * (index + 1)))
+		return -FDT_ERR_BADLAYOUT;
+
+	*value = fdt32_to_cpu(cuint[index]);
+
+	return 0;
+}
+
 int fdt_read_uint32(const void *fdt, int node, const char *prop_name,
 		    uint32_t *value)
 {
@@ -325,10 +343,9 @@ int fdt_read_uint32(const void *fdt, int node, const char *prop_name,
 uint32_t fdt_read_uint32_default(const void *fdt, int node,
 				 const char *prop_name, uint32_t dflt_value)
 {
-	uint32_t value = 0;
+	uint32_t ret = dflt_value;
 
-	if (fdt_read_uint32(fdt, node, prop_name, &value) < 0)
-		return dflt_value;
+	fdt_read_uint32_index(fdt, node, prop_name, 0, &ret);
 
-	return value;
+	return ret;
 }

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -97,14 +97,14 @@ int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size,
 
 	assert(cpu_mmu_enabled());
 
-	st = _fdt_get_status(fdt, offs);
+	st = fdt_get_status(fdt, offs);
 	if (st == DT_STATUS_DISABLED)
 		return -1;
 
-	pbase = _fdt_reg_base_address(fdt, offs);
+	pbase = fdt_reg_base_address(fdt, offs);
 	if (pbase == DT_INFO_INVALID_REG)
 		return -1;
-	sz = _fdt_reg_size(fdt, offs);
+	sz = fdt_reg_size(fdt, offs);
 	if (sz == DT_INFO_INVALID_REG_SIZE)
 		return -1;
 
@@ -140,7 +140,7 @@ int dt_map_dev(const void *fdt, int offs, vaddr_t *base, size_t *size,
 }
 
 /* Read a physical address (n=1 or 2 cells) */
-static paddr_t _fdt_read_paddr(const uint32_t *cell, int n)
+static paddr_t fdt_read_paddr(const uint32_t *cell, int n)
 {
 	paddr_t addr;
 
@@ -167,7 +167,7 @@ bad:
 
 }
 
-paddr_t _fdt_reg_base_address(const void *fdt, int offs)
+paddr_t fdt_reg_base_address(const void *fdt, int offs)
 {
 	const void *reg;
 	int ncells;
@@ -186,10 +186,10 @@ paddr_t _fdt_reg_base_address(const void *fdt, int offs)
 	if (ncells < 0)
 		return DT_INFO_INVALID_REG;
 
-	return _fdt_read_paddr(reg, ncells);
+	return fdt_read_paddr(reg, ncells);
 }
 
-size_t _fdt_reg_size(const void *fdt, int offs)
+size_t fdt_reg_size(const void *fdt, int offs)
 {
 	const uint32_t *reg;
 	uint32_t sz;
@@ -231,7 +231,7 @@ static bool is_okay(const char *st, int len)
 	return !strncmp(st, "ok", len) || !strncmp(st, "okay", len);
 }
 
-int _fdt_get_status(const void *fdt, int offs)
+int fdt_get_status(const void *fdt, int offs)
 {
 	const char *prop;
 	int st = 0;
@@ -259,7 +259,7 @@ int _fdt_get_status(const void *fdt, int offs)
 	return st;
 }
 
-void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info, int offs)
+void fdt_fill_device_info(const void *fdt, struct dt_node_info *info, int offs)
 {
 	struct dt_node_info dinfo = {
 		.reg = DT_INFO_INVALID_REG,
@@ -270,8 +270,8 @@ void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info, int offs)
 	};
 	const fdt32_t *cuint;
 
-	dinfo.reg = _fdt_reg_base_address(fdt, offs);
-	dinfo.reg_size = _fdt_reg_size(fdt, offs);
+	dinfo.reg = fdt_reg_base_address(fdt, offs);
+	dinfo.reg_size = fdt_reg_size(fdt, offs);
 
 	cuint = fdt_getprop(fdt, offs, "clocks", NULL);
 	if (cuint) {
@@ -288,13 +288,13 @@ void _fdt_fill_device_info(const void *fdt, struct dt_node_info *info, int offs)
 	dinfo.interrupt = dt_get_irq_type_prio(fdt, offs, &dinfo.type,
 					       &dinfo.prio);
 
-	dinfo.status = _fdt_get_status(fdt, offs);
+	dinfo.status = fdt_get_status(fdt, offs);
 
 	*info = dinfo;
 }
 
-int _fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
-			   uint32_t *array, size_t count)
+int fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
+			  uint32_t *array, size_t count)
 {
 	const fdt32_t *cuint = NULL;
 	int len = 0;
@@ -316,18 +316,18 @@ int _fdt_read_uint32_array(const void *fdt, int node, const char *prop_name,
 	return 0;
 }
 
-int _fdt_read_uint32(const void *fdt, int node, const char *prop_name,
-		     uint32_t *value)
+int fdt_read_uint32(const void *fdt, int node, const char *prop_name,
+		    uint32_t *value)
 {
-	return _fdt_read_uint32_array(fdt, node, prop_name, value, 1);
+	return fdt_read_uint32_array(fdt, node, prop_name, value, 1);
 }
 
-uint32_t _fdt_read_uint32_default(const void *fdt, int node,
-				  const char *prop_name, uint32_t dflt_value)
+uint32_t fdt_read_uint32_default(const void *fdt, int node,
+				 const char *prop_name, uint32_t dflt_value)
 {
 	uint32_t value = 0;
 
-	if (_fdt_read_uint32(fdt, node, prop_name, &value) < 0)
+	if (fdt_read_uint32(fdt, node, prop_name, &value) < 0)
 		return dflt_value;
 
 	return value;

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -620,7 +620,7 @@ TEE_Result dt_driver_maybe_add_probe_node(const void *fdt, int node)
 	const char *compat = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 
-	if (_fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
+	if (fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
 		return TEE_SUCCESS;
 
 	count = fdt_stringlist_count(fdt, node, "compatible");
@@ -660,7 +660,7 @@ static void parse_node(const void *fdt, int node)
 		 * stack depth to possibly parse all DT nodes.
 		 */
 		if (IS_ENABLED(CFG_DRIVERS_DT_RECURSIVE_PROBE)) {
-			if (_fdt_get_status(fdt, subnode) == DT_STATUS_DISABLED)
+			if (fdt_get_status(fdt, subnode) == DT_STATUS_DISABLED)
 				continue;
 
 			parse_node(fdt, subnode);

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -289,13 +289,13 @@ static bool dtb_get_sdp_region(void)
 			     fdt_get_name(fdt, tmp_node, NULL));
 	}
 
-	tmp_addr = _fdt_reg_base_address(fdt, node);
+	tmp_addr = fdt_reg_base_address(fdt, node);
 	if (tmp_addr == DT_INFO_INVALID_REG) {
 		EMSG("%s: Unable to get base addr from DT", tz_sdp_match);
 		return false;
 	}
 
-	tmp_size = _fdt_reg_size(fdt, node);
+	tmp_size = fdt_reg_size(fdt, node);
 	if (tmp_size == DT_INFO_INVALID_REG_SIZE) {
 		EMSG("%s: Unable to get size of base addr from DT",
 		     tz_sdp_match);


### PR DESCRIPTION
Adds _fdt_read_uint32_index() device-tree API to easily ready at an index into a multi-value property.

This completes _fdt_read_uint32_array() and _fdt_read_uint32()

Disclaimer:
New API is not used ATM but could be by anyone interested. The last past is simply cleaning the header file

Edit:
Also adds _fdt_get_reg_props_by_index() and _fdt_get_reg_props_by_name()

Removes _fdt_check_node() ghost prototype

Edit2:

Replaced all  `_fdt_`  prefixes by  fdt_ 