### PR TITLE
se050: ecc: SE050-F shared secret

### DIFF
--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -36,9 +36,6 @@ static bool oefid_key_supported(size_t bits)
 
 static bool oefid_algo_supported(uint32_t algo)
 {
-	if (!algo)
-		return true;
-
 	switch (se050_get_oefid()) {
 	case SE050F_ID:
 		switch (algo) {


### PR DESCRIPTION
The SE050-F does not support shared secret generation. 
This commit allows the operation to fallback to its software implementation.

Fixes: regression 4009
Note: sw fallback will only execute if the private key is _not _ in the secure element (obviously)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
