### PR TITLE
ta: pkcs11: Fix token initialization's authentication

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -900,7 +900,7 @@ enum pkcs11_user_type {
  * Once TEE Identity based authentication is activated following operational
  * changes happen:
  * - PIN failure counters are disabled to prevent token authentication lockups
- * - Switching to different authentication mode needs C_InitToken()
+ * - Switching to different authentication mode is not possible
  * - When C_Login() or so is performed actual PIN value is ignored and active
  *   client TEE Identity will be used
  *

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -900,9 +900,28 @@ enum pkcs11_user_type {
  * Once TEE Identity based authentication is activated following operational
  * changes happen:
  * - PIN failure counters are disabled to prevent token authentication lockups
- * - Switching to different authentication mode is not possible
  * - When C_Login() or so is performed actual PIN value is ignored and active
  *   client TEE Identity will be used
+ *
+ * After a successful call to C_InitToken(), one can switch authentication
+ * mode as user credentials have been cleared. After user credentials has been
+ * set authentication mode switching is protected.
+ *
+ * To switch the authentication mode from PIN to TEE Identity:
+ * - Make sure active TEE Identity is set for the TA connection
+ * - Login as SO so that PIN change affects SO
+ * - Call C_SetPIN() with empty PIN to capture current TEE Identity as SO
+ *   credential
+ * - Optional: Successive call to C_SetPIN() can be used for change to other
+ *   TEE Identity vs. current TA connection
+ *
+ * To switch the authentication mode from TEE Identity to PIN:
+ * - Make sure SO's TEE Identity is set for the TA connection
+ * - Login as SO so that PIN change affects SO
+ * - Call C_SetPIN() with any PIN that does not match TEE Identity PIN syntax
+ * - Optional: Successive call to C_SetPIN() can be used to change SO
+ *   credential to any valid PIN if there was collision with TEE Identity PIN
+ *   syntax
  *
  * Different types of TEE Identity authentication methods can be configured:
  * - Configured with C_InitToken(), C_InitPIN() or by C_SetPIN()


### PR DESCRIPTION
When token has been initialized make sure that SO is properly authenticated based on authentication mode setting to follow PKCS#11 2.40 specification for `C_InitToken()`.
    
This makes it impossible to change authentication mode with `C_InitToken()`.

To enable authentication mode switching add logic to `C_SetPIN()` operation but require that token has been initialized but user PIN is not yet set.

---

Example sequence without the fix in place to demonstrate the problem:
```
root@qemuarm64-secureboot:~# dmesg | grep optee
[    5.718771] optee: probing for conduit method.
[    5.724213] optee: revision 3.20 (8e74d476)
[    5.731371] optee: dynamic shared memory is enabled
[    5.789814] optee: initialized driver
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-token --label device --so-pin "12345"
Using slot with index 0 (0x0)
Token successfully initialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-pin --login --so-pin "12345" --new-pin "54321"
Using slot with index 0 (0x0)
User PIN successfully initialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --token-label device --login --pin "54321" --keypairgen --key-type RSA:2048 --label rsa-test-key --id 00112233
Key pair generated:
Private Key Object; RSA 
  label:      rsa-test-key
  ID:         00112233
  Usage:      decrypt, sign
  Access:     sensitive, always sensitive, never extractable, local
Public Key Object; RSA 2048 bits
  label:      rsa-test-key
  ID:         00112233
  Usage:      encrypt, verify
  Access:     local
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-objects --token device --login --pin "54321"
Private Key Object; RSA 
  label:      rsa-test-key
  ID:         00112233
  Usage:      decrypt, sign
  Access:     sensitive, always sensitive, never extractable, local
Public Key Object; RSA 2048 bits
  label:      rsa-test-key
  ID:         00112233
  Usage:      encrypt, verify
  Access:     local
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-token --label device --so-pin ""
Using slot with index 0 (0x0)
Token successfully initialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, PIN pad present, rng, token initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
```

And with the fix in place:
```
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-token --label device --so-pin ""
Using slot with index 0 (0x0)
error: PKCS11 function C_InitToken failed: rv = CKR_PIN_INCORRECT (0xa0)
Aborting.
```

In order to change the mode to TEE Identity authentication:
```
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-token --label device --so-pin "12345"
Using slot with index 0 (0x0)
Token successfully initialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --login --login-type so --change-pin --so-pin "12345" --new-pin ""
Using slot with index 0 (0x0)
PIN successfully changed
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, PIN pad present, rng, token initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-pin --login --so-pin "" --new-pin group:ac2cb5e7-4961-50f8-bc6a-4c1571125a55
Using slot with index 0 (0x0)
User PIN successfully initialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, PIN pad present, rng, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --login --login-type so --change-pin --so-pin "" --new-pin "1122334455"
Using slot with index 0 (0x0)
error: PKCS11 function C_SetPIN failed: rv = CKR_PIN_INVALID (0xa1)
Aborting.
```

Note the "PIN pad present" becomes visible in `token flags` to indicate TEE Identity based authentication.

And then back to PIN mode:
```
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-token --label device --so-pin ""
Using slot with index 0 (0x0)
Token successfully initialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, PIN pad present, rng, token initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --login --login-type so --change-pin --so-pin "" --new-pin "1122334455"
Using slot with index 0 (0x0)
PIN successfully changed
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --slot-index 0 --init-pin --login --so-pin "1122334455" --new-pin "54321"
Using slot with index 0 (0x0)
User PIN successfully initialized
root@qemuarm64-secureboot:~# pkcs11-tool --module /usr/lib/libckteec.so.0 --list-slots
Available slots:
Slot 0 (0x0): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token label        : device
  token manufacturer : Linaro
  token model        : OP-TEE TA
  token flags        : login required, rng, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.1
  serial num         : 0000000000000000
  pin min/max        : 4/128
Slot 1 (0x1): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
Slot 2 (0x2): OP-TEE PKCS11 TA - TEE UUID 94e9ab89-4c43-56ea-8b35-45dc07226830
  token state:   uninitialized
```
