### PR TITLE
pta: attestation: fix compilation incompatible pointer warning

### DIFF
--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -355,9 +355,9 @@ static TEE_Result cmd_get_pubkey(uint32_t param_types,
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	uint8_t *e = params[0].memref.buffer;
-	uint32_t *e_out_sz = &params[0].memref.size;
+	size_t *e_out_sz = &params[0].memref.size;
 	uint8_t *n = params[1].memref.buffer;
-	uint32_t *n_out_sz = &params[1].memref.size;
+	size_t *n_out_sz = &params[1].memref.size;
 	size_t sz = 0;
 
 	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_OUTPUT,


### PR DESCRIPTION
To reproduce (any 64bits platform will do):
$ make PLATFORM=imx-mx8mmevk CFG_ATTESTATION_PTA=y CFG_WERROR=y

core/pta/attestation.c: In function ‘cmd_get_pubkey’: core/pta/attestation.c:358:30: warning: initialization of ‘uint32_t *’ {aka ‘unsigned int *’} from incompatible pointer type ‘size_t *’ {aka ‘long unsigned int *’} [-Wincompatible-pointer-types]
  358 |         uint32_t *e_out_sz = &params[0].memref.size;
      |                              ^
core/pta/attestation.c:360:30: warning: initialization of ‘uint32_t *’ {aka ‘unsigned int *’} from incompatible pointer type ‘size_t *’ {aka ‘long unsigned int *’} [-Wincompatible-pointer-types]
  360 |         uint32_t *n_out_sz = &params[1].memref.size;
      |                              ^

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
