### PR TITLE
core: imx: remove duplicate driver_init() call

### DIFF
--- a/core/arch/arm/plat-imx/drivers/tzc380.c
+++ b/core/arch/arm/plat-imx/drivers/tzc380.c
@@ -82,7 +82,6 @@ static TEE_Result imx_configure_tzasc(void)
 	}
 	return TEE_SUCCESS;
 }
-driver_init(imx_configure_tzasc);
 
 static TEE_Result
 pm_enter_resume(enum pm_op op, uint32_t pm_hint __unused,


### PR DESCRIPTION
Remove duplicated call to driver_init().
The previous driver_init() call would only initialize the driver. The new driver_init() call initializes the driver and its power management callback.

Fixes: 97eb916803fe ("drivers: imx: tzc380: re-configure TZ380 upon PM resume")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
