### PR TITLE
drivers: nvmem: add DT API for nvmem provider and consumer

### DIFF
--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -737,6 +737,16 @@
 				secure-status = "okay";
 			};
 
+			sfc: sfc@f804c000 {
+				compatible = "atmel,sama5d2-sfc";
+				reg = <0xf804c000 0x64>;
+				read-only;
+				status = "disabled";
+				secure-status = "okay";
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+
 			i2s0: i2s@f8050000 {
 				compatible = "atmel,sama5d2-i2s";
 				reg = <0xf8050000 0x100>;

--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -108,3 +108,7 @@ $(call force,CFG_SCMI_MSG_CLOCK,y)
 $(call force,CFG_SCMI_MSG_USE_CLK,y)
 $(call force,CFG_SCMI_MSG_SMT_FASTCALL_ENTRY,y)
 endif
+
+CFG_DRIVERS_NVMEM ?= y
+CFG_ATMEL_SFC ?= y
+CFG_NVMEM_OTP_KEY ?= y

--- a/core/drivers/nvmem/atmel_sfc.c
+++ b/core/drivers/nvmem/atmel_sfc.c
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Microchip
+ */
+
+#include <drivers/nvmem.h>
+#include <io.h>
+#include <kernel/dt.h>
+#include <malloc.h>
+#include <matrix.h>
+#include <sama5d2.h>
+#include <string.h>
+#include <tee_api_defines.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+#define ATMEL_SFC_KR		0x0
+#define ATMEL_SFC_SR		0x1C
+#define ATMEL_SFC_SR_PGMC	BIT(0)
+#define ATMEL_SFC_SR_PGMF	BIT(1)
+#define ATMEL_SFC_DR		0x20
+
+#define ATMEL_SFC_CELLS_32	17
+#define ATMEL_SFC_CELLS_8	(ATMEL_SFC_CELLS_32 * sizeof(uint32_t))
+
+struct atmel_sfc {
+	paddr_t base;
+	uint8_t fuses[ATMEL_SFC_CELLS_8];
+};
+
+static TEE_Result atmel_sfc_read_cell(struct nvmem_cell *cell, uint8_t **data,
+				      size_t *len __unused)
+{
+	struct atmel_sfc *atmel_sfc = cell->drv_data;
+
+	memcpy(*data, &atmel_sfc->fuses[cell->offset], cell->len);
+
+	return TEE_SUCCESS;
+}
+
+static void atmel_sfc_free_cell(struct nvmem_cell *cell)
+{
+	free(cell);
+}
+
+static const struct nvmem_ops atmel_sfc_nvmem_ops = {
+	.read_cell = atmel_sfc_read_cell,
+	.free_cell = atmel_sfc_free_cell,
+};
+
+static struct nvmem_cell *atmel_sfc_dt_get(struct dt_pargs *a,
+					   void *data, TEE_Result *res)
+{
+	struct nvmem_cell *cell = NULL;
+
+	cell = calloc(1, sizeof(*cell));
+	if (!cell) {
+		*res = TEE_ERROR_OUT_OF_MEMORY;
+		return NULL;
+	}
+
+	*res = nvmem_cell_parse_dt(a->fdt, a->phandle_node, cell);
+	if (*res)
+		goto out_free;
+
+	if (cell->offset + cell->len > ATMEL_SFC_CELLS_8) {
+		*res = TEE_ERROR_GENERIC;
+		goto out_free;
+	}
+
+	cell->ops = &atmel_sfc_nvmem_ops;
+	cell->drv_data = data;
+	*res = TEE_SUCCESS;
+
+	return cell;
+
+out_free:
+	free(cell);
+
+	return NULL;
+}
+
+static void atmel_sfc_read_fuse(struct atmel_sfc *atmel_sfc)
+{
+	size_t i = 0;
+	uint32_t val = 0;
+
+	for (i = 0; i < ATMEL_SFC_CELLS_32; i++) {
+		val = io_read32(atmel_sfc->base + ATMEL_SFC_DR + i * 4);
+		memcpy(&atmel_sfc->fuses[i * 4], &val, sizeof(val));
+	}
+}
+
+static TEE_Result atmel_sfc_probe(const void *fdt, int node,
+				  const void *compat_data __unused)
+{
+	paddr_t base = 0;
+	size_t size = 0;
+	struct atmel_sfc *atmel_sfc = NULL;
+
+	if (fdt_get_status(fdt, node) != DT_STATUS_OK_SEC)
+		return TEE_ERROR_NODE_DISABLED;
+
+	matrix_configure_periph_secure(AT91C_ID_SFC);
+
+	if (dt_map_dev(fdt, node, &base, &size, DT_MAP_AUTO) < 0)
+		return TEE_ERROR_GENERIC;
+
+	atmel_sfc = calloc(1, sizeof(*atmel_sfc));
+	if (!atmel_sfc)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	atmel_sfc->base = base;
+
+	atmel_sfc_read_fuse(atmel_sfc);
+
+	return nvmem_register_provider(fdt, node, atmel_sfc_dt_get, atmel_sfc);
+}
+
+static const struct dt_device_match atmel_sfc_match_table[] = {
+	{ .compatible = "atmel,sama5d2-sfc" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(atmel_sfc_dt_driver) = {
+	.name = "atmel_sfc",
+	.type = DT_DRIVER_NOTYPE,
+	.match_table = atmel_sfc_match_table,
+	.probe = atmel_sfc_probe,
+};

--- a/core/drivers/nvmem/nvmem.c
+++ b/core/drivers/nvmem/nvmem.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023, Microchip
+ */
+
+#include <drivers/nvmem.h>
+#include <kernel/dt.h>
+#include <libfdt.h>
+
+TEE_Result nvmem_cell_parse_dt(const void *fdt, int nodeoffset,
+			       struct nvmem_cell *cell)
+{
+	size_t buf_len = 0;
+	paddr_t offset = 0;
+
+	buf_len = fdt_reg_size(fdt, nodeoffset);
+	if (buf_len == DT_INFO_INVALID_REG_SIZE)
+		return TEE_ERROR_GENERIC;
+
+	offset = fdt_reg_base_address(fdt, nodeoffset);
+	if (offset == DT_INFO_INVALID_REG)
+		return TEE_ERROR_GENERIC;
+
+	cell->len = buf_len;
+	cell->offset = offset;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result nvmem_get_cell_by_name(const void *fdt, int nodeoffset,
+				  const char *name, struct nvmem_cell **cell)
+{
+	int index = 0;
+
+	index = fdt_stringlist_search(fdt, nodeoffset, "nvmem-cell-names",
+				      name);
+	if (index < 0)
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	return nvmem_get_cell_by_index(fdt, nodeoffset, index, cell);
+}

--- a/core/drivers/nvmem/nvmem_otp_key.c
+++ b/core/drivers/nvmem/nvmem_otp_key.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023, Microchip
+ */
+
+#include <drivers/nvmem.h>
+#include <io.h>
+#include <kernel/dt.h>
+#include <kernel/huk_subkey.h>
+#include <kernel/tee_common_otp.h>
+#include <malloc.h>
+#include <matrix.h>
+#include <sama5d2.h>
+#include <tee_api_defines.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+#include <trace.h>
+
+static uint8_t *hw_unique_key;
+static uint8_t *die_id;
+static size_t die_id_len;
+
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+{
+	if (!hw_unique_key)
+		return TEE_ERROR_NO_DATA;
+
+	memcpy(hwkey->data, hw_unique_key, HW_UNIQUE_KEY_LENGTH);
+
+	return TEE_SUCCESS;
+}
+
+int tee_otp_get_die_id(uint8_t *buffer, size_t len)
+{
+	if (!die_id) {
+		if (huk_subkey_derive(HUK_SUBKEY_DIE_ID, NULL, 0, buffer, len))
+			return -1;
+		return 0;
+	}
+
+	memcpy(buffer, die_id, MIN(die_id_len, len));
+
+	return 0;
+}
+
+static TEE_Result nvmem_otp_read_hw_unique_key(const void *fdt, int node)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct nvmem_cell *cell = NULL;
+	uint8_t *data = NULL;
+	size_t len = 0;
+
+	res = nvmem_get_cell_by_name(fdt, node, "hw_unique_key", &cell);
+	if (res)
+		return res;
+
+	res = nvmem_cell_read(cell, &data, &len);
+	if (res)
+		goto out_free_cell;
+
+	if (len != HW_UNIQUE_KEY_LENGTH) {
+		res = TEE_ERROR_GENERIC;
+		free(data);
+		goto out_free_cell;
+	}
+	hw_unique_key = data;
+
+out_free_cell:
+	nvmem_put_cell(cell);
+
+	return res;
+}
+
+static TEE_Result nvmem_otp_read_die_id(const void *fdt, int node)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct nvmem_cell *cell = NULL;
+	uint8_t *data = NULL;
+
+	res = nvmem_get_cell_by_name(fdt, node, "die_id", &cell);
+	if (res)
+		return res;
+
+	res = nvmem_cell_read(cell, &data, &die_id_len);
+	if (!res)
+		die_id = data;
+
+	nvmem_put_cell(cell);
+
+	return res;
+}
+
+static TEE_Result nvmem_otp_key_probe(const void *fdt, int node,
+				      const void *compat_data __unused)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = nvmem_otp_read_hw_unique_key(fdt, node);
+	if (res)
+		return res;
+
+	res = nvmem_otp_read_die_id(fdt, node);
+	if (res) {
+		free(hw_unique_key);
+		hw_unique_key = NULL;
+	}
+
+	return res;
+}
+
+static const struct dt_device_match nvmem_otp_key_match_table[] = {
+	{ .compatible = "optee,nvmem-otp-key" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(nvmem_otp_key_dt_driver) = {
+	.name = "nvmem_otp_key",
+	.type = DT_DRIVER_NOTYPE,
+	.match_table = nvmem_otp_key_match_table,
+	.probe = nvmem_otp_key_probe,
+};

--- a/core/drivers/nvmem/sub.mk
+++ b/core/drivers/nvmem/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += nvmem.c

--- a/core/drivers/nvmem/sub.mk
+++ b/core/drivers/nvmem/sub.mk
@@ -1,1 +1,2 @@
 srcs-y += nvmem.c
+srcs-$(CFG_ATMEL_SFC) += atmel_sfc.c

--- a/core/drivers/nvmem/sub.mk
+++ b/core/drivers/nvmem/sub.mk
@@ -1,2 +1,3 @@
 srcs-y += nvmem.c
 srcs-$(CFG_ATMEL_SFC) += atmel_sfc.c
+srcs-$(CFG_NVMEM_OTP_KEY) += nvmem_otp_key.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -82,6 +82,7 @@ subdirs-$(CFG_BNXT_FW) += bnxt
 subdirs-$(CFG_DRIVERS_CLK) += clk
 subdirs-$(CFG_DRIVERS_GPIO) += gpio
 subdirs-$(CFG_DRIVERS_I2C) += i2c
+subdirs-$(CFG_DRIVERS_NVMEM) += nvmem
 subdirs-$(CFG_DRIVERS_PINCTRL) += pinctrl
 subdirs-$(CFG_DRIVERS_RSTCTRL) += rstctrl
 subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg

--- a/core/include/drivers/nvmem.h
+++ b/core/include/drivers/nvmem.h
@@ -1,0 +1,188 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023, Microchip
+ */
+
+#ifndef __DRIVERS_NVMEM_H
+#define __DRIVERS_NVMEM_H
+
+#include <kernel/dt_driver.h>
+#include <tee_api_defines.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+struct nvmem_cell;
+
+/*
+ * struct nvmem_ops - Nvmem device driver operations
+ * @alloc_read_cell: Allocate @data in the heap and load @len bytes to from an
+ * nvmem cell
+ * @free_cell: Release resources allocated from nvmem_dt_get_func callback
+ * function
+ */
+struct nvmem_ops {
+	TEE_Result (*read_cell)(struct nvmem_cell *cell, uint8_t **data,
+				size_t *len);
+	void (*free_cell)(struct nvmem_cell *cell);
+};
+
+/*
+ * struct nvmem_cell - Description of an nvmem cell
+ * @offset: Cell byte offset in the NVMEM device
+ * @len: Cell byte size
+ * @ops: Nvmem device driver operation handlers
+ * @drv_data: Nvmem device driver private data
+ */
+struct nvmem_cell {
+	paddr_t offset;
+	size_t len;
+	const struct nvmem_ops *ops;
+	void *drv_data;
+};
+
+/*
+ * nvmem_dt_get_func - Typedef of function to get an nvmem reference from a DT
+ * node
+ *
+ * @a: Reference to phandle arguments
+ * @data: Pointer to data given at nvmem_dt_get_func() call
+ * @res: Output result code of the operation:
+ *	TEE_SUCCESS in case of success
+ *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
+ *	Any TEE_Result compliant code in case of error.
+ */
+typedef
+struct nvmem_cell *(*nvmem_dt_get_func)(struct dt_pargs *a,
+					void *data, TEE_Result *res);
+
+#ifdef CFG_DRIVERS_NVMEM
+/**
+ * nvmem_register_provider() - Register a nvmem controller
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of nvmem cell consumer
+ * @get_dt_pinctrl: Callback to match the devicetree nvmem reference with
+ * nvmem_cell
+ * @data: Data which will be passed to the get_dt_nvmem callback
+ * Return a TEE_Result compliant value
+ */
+static inline TEE_Result nvmem_register_provider(const void *fdt,
+						 int nodeoffset,
+						 nvmem_dt_get_func get_dt_nvmem,
+						 void *data)
+{
+	return dt_driver_register_provider(fdt, nodeoffset,
+					   (get_of_device_func)get_dt_nvmem,
+					   data, DT_DRIVER_NVMEM);
+}
+
+/**
+ * nvmem_get_cell_by_name() - Obtain a nvmem cell from its name in the DT node
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of nvmem cell consumer
+ * @name: name of the nvmem cell to obtain from the device tree
+ * @cell: Pointer filled with the retrieved cell, must be freed after use
+   using nvmem_put_cell()
+ * Return a TEE_Result compliant value
+ */
+TEE_Result nvmem_get_cell_by_name(const void *fdt, int nodeoffset,
+				  const char *name, struct nvmem_cell **cell);
+
+/**
+ * nvmem_get_cell_by_index() - Obtain a nvmem cell from property nvmem-cells
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of nvmem cell consumer
+ * @index: Index of the nvmem cell to obtain from device-tree
+ * @cell: Pointer filled with the retrieved cell, must be freed after use
+ * using nvmem_put_cell()
+ * Return a TEE_Result compliant value
+ */
+static inline TEE_Result nvmem_get_cell_by_index(const void *fdt,
+						 int nodeoffset,
+						 unsigned int index,
+						 struct nvmem_cell **cell)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	*cell = dt_driver_device_from_node_idx_prop("nvmem-cells", fdt,
+						    nodeoffset, index,
+						    DT_DRIVER_NVMEM, &res);
+	return res;
+}
+
+/**
+ * nvmem_cell_parse_dt() - Parse device-tree information to fill a nvmem cell
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the nvmem cell controller
+ * @cell: Pointer to cell that will be filled
+ */
+TEE_Result nvmem_cell_parse_dt(const void *fdt, int nodeoffset,
+			       struct nvmem_cell *cell);
+
+/**
+ * nvmem_put_cell() - Free resource allocated from nvmem_get_cell_by_*()
+ *
+ * @cell: Cell to be freed
+ */
+static inline void nvmem_put_cell(struct nvmem_cell *cell)
+{
+	if (cell->ops->free_cell)
+		cell->ops->free_cell(cell);
+}
+
+/*
+ * nvmem_cell_read() - Allocate and read data from a nvmem cell
+ * @cell: Cell to read from nvmem
+ * @data: Output allocated buffer where nvmem cell data are stored upon success,
+ * shall be released with free().
+ * @len: Output byte size of the nvmem cell data read
+ */
+static inline TEE_Result nvmem_cell_read(struct nvmem_cell *cell,
+					 uint8_t **data, size_t *len)
+{
+	if (!cell->ops->read_cell)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	return cell->ops->read_cell(cell, data, len);
+}
+
+#else /* CFG_DRIVERS_NVMEM */
+static inline TEE_Result nvmem_register_provider(const void *fdt __unused,
+						 int nodeoffset __unused,
+						 nvmem_dt_get_func fn __unused,
+						 void *data __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result nvmem_get_cell_by_name(const void *fdt __unused,
+						int nodeoffset __unused,
+						const char *name __unused,
+						struct nvmem_cell **c __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result nvmem_get_cell_by_index(const void *fdt,
+						 int nodeoffset,
+						 unsigned int index,
+						 struct nvmem_cell **cell)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result nvmem_cell_parse_dt(const void *fdt __unused,
+					     int nodeoffset __unused,
+					     struct nvmem_cell *cell __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline void nvmem_put_cell(struct nvmem_cell *cell __unused)
+{
+}
+#endif /* CFG_DRIVERS_NVMEM */
+#endif /* __DRIVERS_NVMEM_H */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -24,6 +24,7 @@
  * DT_DRIVER_GPIO   GPIO controller using generic GPIO DT bindings
  * DT_DRIVER_PINCTRL Pin controller using generic reset DT bindings
  * DT_DRIVER_INTERRUPT Interrupt controller using generic DT bindings
+ * DT_DRIVER_NVMEM  NVMEM controller using generic NVMEM DT bindings
  */
 enum dt_driver_type {
 	DT_DRIVER_NOTYPE,
@@ -34,6 +35,7 @@ enum dt_driver_type {
 	DT_DRIVER_GPIO,
 	DT_DRIVER_PINCTRL,
 	DT_DRIVER_INTERRUPT,
+	DT_DRIVER_NVMEM,
 };
 
 /*

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -110,6 +110,7 @@ static void assert_type_is_valid(enum dt_driver_type type)
 	case DT_DRIVER_I2C:
 	case DT_DRIVER_PINCTRL:
 	case DT_DRIVER_INTERRUPT:
+	case DT_DRIVER_NVMEM:
 		return;
 	default:
 		assert(0);
@@ -162,6 +163,7 @@ static bool dt_driver_use_parent_controller(enum dt_driver_type type)
 {
 	switch (type) {
 	case DT_DRIVER_PINCTRL:
+	case DT_DRIVER_NVMEM:
 		return true;
 	default:
 		return false;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -889,6 +889,10 @@ CFG_DRIVERS_GPIO ?= n
 # When enabled, CFG_DRIVERS_I2C provides I2C controller and devices support.
 CFG_DRIVERS_I2C ?= n
 
+# When enabled, CFG_DRIVERS_NVMEM provides a framework to register nvmem
+# providers allow consumer drivers to get NVMEM cells using the Device Tree.
+CFG_DRIVERS_NVMEM ?= n
+
 # When enabled, CFG_DRIVERS_PINCTRL embeds a pin muxing controller framework in
 # OP-TEE core to provide drivers a way to apply pin muxing configurations based
 # on device-tree.


### PR DESCRIPTION
Add support for nvmem devices using the existing device-tree bindings for nvmem cells.
Also provides a driver to expose hardware unique key and die id using this nvmem framework.
This allows to let the user of the SoC to specify were the key were written using "nvmem-cells".
The bindings for the nvmem-otp-key driver are not specify and might also be not the way to do
it since it does not really describe a hardware device but rather a software feature. Any ideas are
welcomed on that part.
