### PR TITLE
core: check TA initialization completion before dump it

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -854,6 +854,10 @@ static TEE_Result dump_ta_memstats(struct tee_ta_session *s,
 	if (!ts_ctx)
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
+	if (is_user_ta_ctx(ts_ctx) &&
+	    to_user_ta_ctx(ts_ctx)->uctx.is_initializing)
+		return TEE_ERROR_BAD_STATE;
+
 	ctx = ts_to_ta_ctx(ts_ctx);
 
 	if (ctx->panicked)


### PR DESCRIPTION
Problem: In some concurrent cases, ta dump will try to dump a TA which has not completed TA initialization and the TA stack pointer isn't set. That causes a data abort when accessing its stack.

Solution: Check the user TA initialization is completed or not. If it is still being initialized, return TEE_ERROR_BAD_STATE. https://github.com/OP-TEE/optee_os/issues/5905

Tested-by: Weizhao Jiang <weizhaoj@amazon.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
