### PR TITLE
CAAM compilation fix

### DIFF
--- a/core/drivers/crypto/caam/acipher/sub.mk
+++ b/core/drivers/crypto/caam/acipher/sub.mk
@@ -1,7 +1,7 @@
 incdirs-y += ../include
 
-srcs-$(CFG_NXP_CAAM_RSA_DRV) += caam_rsa.c
+srcs-$(CFG_NXP_CAAM_RSA_DRV) += caam_rsa.c caam_prime_rsa.c
 srcs-$(CFG_NXP_CAAM_DH_DRV)  += caam_dh.c
-srcs-y += caam_prime_rsa.c caam_math.c
 srcs-$(CFG_NXP_CAAM_ECC_DRV) += caam_ecc.c
 srcs-$(CFG_NXP_CAAM_DSA_DRV) += caam_dsa.c caam_prime_dsa.c
+srcs-$(CFG_NXP_CAAM_MATH_DRV) += caam_math.c

--- a/core/drivers/crypto/caam/hal/common/hal_ctrl.c
+++ b/core/drivers/crypto/caam/hal/common/hal_ctrl.c
@@ -131,6 +131,7 @@ void caam_hal_ctrl_inc_priblob(vaddr_t baseaddr)
 		panic("Written PRIBLOB and read PRIBLOB do not match!");
 }
 
+#ifdef CFG_NXP_CAAM_MP_DRV
 uint8_t caam_hal_ctrl_get_mpcurve(vaddr_t ctrl_addr)
 {
 	uint32_t val_scfgr = 0;
@@ -252,3 +253,4 @@ void caam_hal_ctrl_fill_mpmr(vaddr_t ctrl_addr, struct caambuf *msg_mpmr)
 		DMSG("val_scfgr = %#"PRIx32, io_caam_read32(ctrl_addr + SCFGR));
 	}
 }
+#endif /* CFG_NXP_CAAM_MP_DRV */

--- a/core/drivers/crypto/caam/include/caam_acipher.h
+++ b/core/drivers/crypto/caam/include/caam_acipher.h
@@ -40,7 +40,7 @@ caam_dh_init(struct caam_jrcfg *caam_jrcfg __unused)
 }
 #endif /* CFG_NXP_CAAM_DH_DRV */
 
-#ifdef CFG_NXP_CAAM_ACIPHER_DRV
+#ifdef CFG_NXP_CAAM_MATH_DRV
 /*
  * Initialize the MATH module
  *
@@ -53,7 +53,7 @@ caam_math_init(struct caam_jrcfg *caam_jrcfg __unused)
 {
 	return CAAM_NO_ERROR;
 }
-#endif /* CFG_NXP_CAAM_ACIPHER_DRV */
+#endif /* CFG_NXP_CAAM_MATH_DRV */
 
 #ifdef CFG_NXP_CAAM_ECC_DRV
 /*

--- a/core/drivers/crypto/caam/include/caam_hal_ctrl.h
+++ b/core/drivers/crypto/caam/include/caam_hal_ctrl.h
@@ -60,6 +60,7 @@ uint8_t caam_hal_ctrl_era(vaddr_t baseaddr);
  */
 void caam_hal_ctrl_inc_priblob(vaddr_t baseaddr);
 
+#ifdef CFG_NXP_CAAM_MP_DRV
 /*
  * Get the SCFGR content and check the MPCURVE fields.
  * The function returns either:
@@ -93,4 +94,5 @@ void caam_hal_ctrl_fill_mpmr(vaddr_t ctrl_addr, struct caambuf *msg_mpmr);
  * @ctrl_addr  Controller base address
  */
 bool caam_hal_ctrl_is_mp_set(vaddr_t ctrl_addr);
+#endif /* CFG_NXP_CAAM_MP_DRV */
 #endif /* __CAAM_HAL_CTRL_H__ */


### PR DESCRIPTION
Hello,

Here is a quick rework for the CAAM `crypto.mk` that was IMO cumbersome to read.
@ldts Let me know that configuration is still compatible with SE050 configuration.
With that, I did some minor fixes on CAAM compilation flags.

Thanks!