### PR TITLE
core: mm: Fix idx truncation bug

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -1138,7 +1138,7 @@ static uint64_t *core_mmu_get_user_mapping_entry(struct mmu_partition *prtn,
 						 unsigned int base_idx)
 {
 #if (CORE_MMU_BASE_TABLE_LEVEL == 0)
-	uint8_t idx = 0;
+	l1_idx_t idx = 0;
 	uint64_t *tbl = NULL;
 #endif
 


### PR DESCRIPTION
When the idx of TA memory mapping is assigned, it is saved in the l1_idx_t, which is the uint8_t or uint16_t type. But when it is parsed, it is save in the only uint8_t that will lead to error. To solve this problem, the idx should be saved in the uint16_t type when parsing the idx.

Signed-off-by: LeiSen <leisen1@huawei.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
