### PR TITLE
TZASC: Allow 32KB region size

### DIFF
--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -242,7 +242,7 @@ int tzc_auto_configure(vaddr_t addr, vaddr_t size, uint32_t attr,
 	 */
 	pow = tzc.addr_width;
 
-	while (lsize != 0 && pow > 15) {
+	while (lsize != 0 && pow >= 15) {
 		region_size = 1ULL << pow;
 
 		/* Case region fits alignment and covers requested area */


### PR DESCRIPTION
According to the ARM TZC-380 Technical Reference Manual, 32KB is the minimum region size [1]. But before this patch, tzc_auto_configure() allowed only 64KB as minimum.

(pow > 15) implies the following:
	region_size = (1ULL << pow) = (2^pow) > 32KB

After this patch, (pow >= 15) gives us region_size >= 32KB.

[1] TZC-380 TRM, Table 3.16 (https://developer.arm.com/documentation/ddi0431/c/programmers-model/register-descriptions/region-attributes--n--register?lang=en)

Tested on i.MX6UL
Signed-off-by: Philip Oberfichtner <pro@denx.de>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
