### PR TITLE
plat-zynqmp: fixes interrupt controller

### DIFF
--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -82,6 +82,7 @@ void main_init_gic(void)
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
 	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
 			   GIC_BASE + GICD_OFFSET);
+	itr_init(&gic_data.chip);
 }
 
 void itr_core_handler(void)

--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -70,7 +70,7 @@
 #define UART1_CLK_IN_HZ		100000000
 
 #define GICD_OFFSET		0
-#define GICC_OFFSET		0x20000
+#define GICC_OFFSET		0x10000
 
 #elif defined(PLATFORM_FLAVOR_ultra96)
 
@@ -85,7 +85,7 @@
 #define UART1_CLK_IN_HZ		100000000
 
 #define GICD_OFFSET		0
-#define GICC_OFFSET		0x20000
+#define GICC_OFFSET		0x10000
 
 #else
 #error "Unknown platform flavor"


### PR DESCRIPTION
Updates GICC_OFFSET to account for the already-offset GIC_BASE. Additionally initializes the interrupt controller with a pointer to the interrupt chip.

Fixes #5949 