### PR TITLE
core: arm64: virt: fix adr link error

### DIFF
--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -234,8 +234,8 @@ clear_bss:
 	 * Clear .nex_bss, this code obviously depends on the linker keeping
 	 * start/end of .bss at least 8 byte aligned.
 	 */
-	adr	x0, __nex_bss_start
-	adr	x1, __nex_bss_end
+	adr_l	x0, __nex_bss_start
+	adr_l	x1, __nex_bss_end
 clear_nex_bss:
 	str	xzr, [x0], #8
 	cmp	x0, x1


### PR DESCRIPTION
Replace the two remaining "adr" instructions with "adr_l" to avoid link error with virtualization and debugging enabled:
out/arm/core/arch/arm/kernel/entry_a64.o: in function `clear_bss': core/arch/arm/kernel/entry_a64.S:237:(.text._start+0x8c): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `__nex_bss_start' defined in .bss.mempool_default section in out/arm/core/all_objs.o core/arch/arm/kernel/entry_a64.S:238:(.text._start+0x90): relocation truncated to fit: R_AARCH64_ADR_PREL_LO21 against symbol `__nex_bss_end' defined in .bss.mempool_default section in out/arm/core/all_objs.o

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
