### PR TITLE
Fix issues with CFG_SYSCALL_FTRACE=y

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,8 +278,8 @@ jobs:
           cd ${TOP}/build
 
           make -j$(nproc) check
-
           make -j$(nproc) check CFG_CRYPTO_WITH_CE82=y
+          make -j$(nproc) check CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y XTEST_ARGS=regression_1001
 
   QEMUv8_Xen_check:
     name: make check (QEMUv8, Xen)

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -379,7 +379,7 @@ short int __noprof thread_get_id_may_fail(void)
 	return ct;
 }
 
-short int thread_get_id(void)
+short int __noprof thread_get_id(void)
 {
 	short int ct = thread_get_id_may_fail();
 
@@ -499,7 +499,7 @@ void thread_init_core_local_pauth_keys(void)
 }
 #endif
 
-struct thread_specific_data *thread_get_tsd(void)
+struct thread_specific_data * __noprof thread_get_tsd(void)
 {
 	return &threads[thread_get_id()].tsd;
 }

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -366,7 +366,7 @@ bool __weak thread_is_in_normal_mode(void)
 	return ret;
 }
 
-short int thread_get_id_may_fail(void)
+short int __noprof thread_get_id_may_fail(void)
 {
 	/*
 	 * thread_get_core_local() requires foreign interrupts to be disabled

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -466,7 +466,7 @@ void __nostackcheck thread_init_thread_core_local(void)
 	tcl[0].tmp_stack_va_end = GET_STACK_BOTTOM(stack_tmp, 0);
 }
 
-void thread_init_core_local_stacks(void)
+void __nostackcheck thread_init_core_local_stacks(void)
 {
 	size_t n = 0;
 	struct thread_core_local *tcl = thread_core_local;


### PR DESCRIPTION
With CFG_FTRACE_SUPPORT=y CFG_ULIBS_MCOUNT=y CFG_SYSCALL_FTRACE=y (tested on QEMUv8), OP-TE boot hangs do to infinite recursion:

ftrace_enter()
  get_fbuf()
    thread_get_id_may_fail()
      _mcount()
        ftrace_enter()
          ...

Break the cycle by tagging thread_get_id_may_fail() with __noprof.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
