### PR TITLE
crypto_api: ecc allocation api

### DIFF
--- a/core/drivers/crypto/caam/acipher/caam_ecc.c
+++ b/core/drivers/crypto/caam/acipher/caam_ecc.c
@@ -142,7 +142,9 @@ static enum caam_ecc_curve get_caam_curve(uint32_t tee_curve)
  * @key        Keypair
  * @size_bits  Key size in bits
  */
-static TEE_Result do_allocate_keypair(struct ecc_keypair *key, size_t size_bits)
+static TEE_Result do_allocate_keypair(struct ecc_keypair *key,
+				      uint32_t type __unused,
+				      size_t size_bits)
 {
 	ECC_TRACE("Allocate Keypair of %zu bits", size_bits);
 
@@ -182,6 +184,7 @@ err:
  * @size_bits  Key size in bits
  */
 static TEE_Result do_allocate_publickey(struct ecc_public_key *key,
+					uint32_t type __unused,
 					size_t size_bits)
 {
 	ECC_TRACE("Allocate Public Key of %zu bits", size_bits);

--- a/core/drivers/crypto/crypto_api/acipher/ecc.c
+++ b/core/drivers/crypto/crypto_api/acipher/ecc.c
@@ -523,7 +523,7 @@ TEE_Result drvcrypt_asym_alloc_ecc_keypair(struct ecc_keypair *key,
 	}
 
 	if (ecc)
-		ret = ecc->alloc_keypair(key, size_bits);
+		ret = ecc->alloc_keypair(key, type, size_bits);
 
 	if (!ret) {
 		key->ops = &ecc_keypair_ops;
@@ -574,7 +574,7 @@ TEE_Result drvcrypt_asym_alloc_ecc_public_key(struct ecc_public_key *key,
 	}
 
 	if (ecc)
-		ret = ecc->alloc_publickey(key, size_bits);
+		ret = ecc->alloc_publickey(key, type, size_bits);
 
 	if (!ret) {
 		key->ops = &ecc_public_key_ops;

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -149,9 +149,10 @@ struct drvcrypt_ecc_ed {
  */
 struct drvcrypt_ecc {
 	/* Allocates the ECC keypair */
-	TEE_Result (*alloc_keypair)(struct ecc_keypair *key, size_t size_bits);
+	TEE_Result (*alloc_keypair)(struct ecc_keypair *key, uint32_t type,
+				    size_t size_bits);
 	/* Allocates the ECC public key */
-	TEE_Result (*alloc_publickey)(struct ecc_public_key *key,
+	TEE_Result (*alloc_publickey)(struct ecc_public_key *key, uint32_t type,
 				      size_t size_bits);
 	/* Free ECC public key */
 	void (*free_publickey)(struct ecc_public_key *key);

--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -727,6 +727,7 @@ static TEE_Result do_verify(struct drvcrypt_sign_data *sdata)
 }
 
 static TEE_Result do_alloc_keypair(struct ecc_keypair *s,
+				   uint32_t type __unused,
 				   size_t size_bits __unused)
 {
 	memset(s, 0, sizeof(*s));
@@ -745,7 +746,9 @@ err:
 }
 
 static TEE_Result do_alloc_publickey(struct ecc_public_key *s,
+				     uint32_t type __unused,
 				     size_t size_bits __unused)
+
 {
 	memset(s, 0, sizeof(*s));
 	if (!bn_alloc_max(&s->x))

--- a/core/drivers/crypto/versal/ecc.c
+++ b/core/drivers/crypto/versal/ecc.c
@@ -366,7 +366,9 @@ static TEE_Result do_gen_keypair(struct ecc_keypair *s, size_t size_bits)
 	return keypair_ops->generate(s, size_bits);
 }
 
-static TEE_Result do_alloc_keypair(struct ecc_keypair *s, size_t size_bits)
+static TEE_Result do_alloc_keypair(struct ecc_keypair *s,
+				   uint32_t type __unused,
+				   size_t size_bits)
 {
 	TEE_Result ret = TEE_SUCCESS;
 
@@ -380,7 +382,9 @@ static TEE_Result do_alloc_keypair(struct ecc_keypair *s, size_t size_bits)
 	return TEE_SUCCESS;
 }
 
-static TEE_Result do_alloc_publickey(struct ecc_public_key *s, size_t size_bits)
+static TEE_Result do_alloc_publickey(struct ecc_public_key *s,
+				     uint32_t type __unused,
+				     size_t size_bits)
 {
 	TEE_Result ret = TEE_SUCCESS;
 


### PR DESCRIPTION
For **Elliptic Curve**, the cryptographic api can fallback to its software
operation instead of failing due to the lack of hardware support.
    
The relevant code can be see seen in key allocation functions for 
the [public](https://github.com/OP-TEE/optee_os/blob/c4cab13e43f8170575612892f66bdbc8c9e67285/core/crypto/crypto.c#L709) and [private](https://github.com/OP-TEE/optee_os/blob/c4cab13e43f8170575612892f66bdbc8c9e67285/core/crypto/crypto.c#L727) keys

crypto_api/acipher/ecc.c (i.e [pair]( https://github.com/OP-TEE/optee_os/blob/c4cab13e43f8170575612892f66bdbc8c9e67285/core/drivers/crypto/crypto_api/acipher/ecc.c#L348) ) however does not pass the key type to 
the relevant driver and therefore the driver can not take the correct
action at allocation time.
    
This commit addresses that limitation and fixes 3.21.0 regression_4006 
for the **Versal ACAP** platform and any **NXP SE05X enabled** platform.
` regression_4006.43 Asym Crypto case 426 algo 0x80000046 line 373`
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
