### PR TITLE
CRC32 HW support discovery

### DIFF
--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
- * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited. All rights reserved.
  */
 #ifndef ARM_H
 #define ARM_H
@@ -157,6 +157,16 @@ static inline unsigned int feat_mte_implemented(void)
 #else
 	return (read_id_aa64pfr1_el1() >> ID_AA64PFR1_EL1_MTE_SHIFT) &
 	       ID_AA64PFR1_EL1_MTE_MASK;
+#endif
+}
+
+static inline bool feat_crc32_implemented(void)
+{
+#ifdef ARM32
+	return false;
+#else
+	return ((read_id_aa64isar0_el1() >> ID_AA64ISAR0_EL1_CRC32_SHIFT) &
+		ID_AA64ISAR0_EL1_CRC32_MASK) == FEAT_CRC32_IMPLEMENTED;
 #endif
 }
 

--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2023, Arm Limited
  */
 #ifndef ARM64_H
 #define ARM64_H
@@ -237,6 +238,11 @@
 #define FEAT_MTE2_IMPLEMENTED		U(0x2)
 #define FEAT_MTE3_IMPLEMENTED		U(0x3)
 
+#define ID_AA64ISAR0_EL1_CRC32_MASK	UL(0xf)
+#define ID_AA64ISAR0_EL1_CRC32_SHIFT	U(16)
+#define FEAT_CRC32_NOT_IMPLEMENTED	U(0x0)
+#define FEAT_CRC32_IMPLEMENTED		U(0x1)
+
 #define ID_AA64ISAR1_GPI_SHIFT		U(28)
 #define ID_AA64ISAR1_GPI_MASK		U(0xf)
 #define ID_AA64ISAR1_GPI_NI		U(0x0)
@@ -427,6 +433,7 @@ DEFINE_U64_REG_READ_FUNC(par_el1)
 DEFINE_U64_REG_WRITE_FUNC(mair_el1)
 
 DEFINE_U64_REG_READ_FUNC(id_aa64pfr1_el1)
+DEFINE_U64_REG_READ_FUNC(id_aa64isar0_el1)
 DEFINE_U64_REG_READ_FUNC(id_aa64isar1_el1)
 DEFINE_REG_READ_FUNC_(apiakeylo, uint64_t, S3_0_c2_c1_0)
 DEFINE_REG_READ_FUNC_(apiakeyhi, uint64_t, S3_0_c2_c1_1)


### PR DESCRIPTION
Add support for discovering if the CRC32 instruction family is implemented by the PE.
Convey this information to Secure Partitions through the SP manifest DT.
