### PR TITLE
core: thread: Add support for canary value randomization

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -571,9 +571,15 @@ shadow_stack_access_ok:
 
 #ifdef _CFG_CORE_STACK_PROTECTOR
 	/* Update stack canary value */
-	bl	plat_get_random_stack_canary
+	sub	sp, sp, #0x8
+	mov	r0, sp
+	mov	r1, #1
+	mov	r2, #0x4
+	bl	plat_get_random_stack_canaries
+	ldr	r0, [sp]
 	ldr	r1, =__stack_chk_guard
 	str	r0, [r1]
+	add	sp, sp, #0x8
 #endif
 
 	/*

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -396,9 +396,15 @@ clear_nex_bss:
 
 #ifdef _CFG_CORE_STACK_PROTECTOR
 	/* Update stack canary value */
-	bl	plat_get_random_stack_canary
+	sub	sp, sp, #0x10
+	mov	x0, sp
+	mov	x1, #1
+	mov	x2, #0x8
+	bl	plat_get_random_stack_canaries
+	ldr	x0, [sp]
 	adr_l	x5, __stack_chk_guard
 	str	x0, [x5]
+	add	sp, sp, #0x10
 #endif
 
 	/*

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -70,8 +70,16 @@ void plat_cpu_reset_early(void);
 void plat_primary_init_early(void);
 unsigned long plat_get_aslr_seed(void);
 unsigned long plat_get_freq(void);
-#if defined(_CFG_CORE_STACK_PROTECTOR)
-uintptr_t plat_get_random_stack_canary(void);
+#if defined(_CFG_CORE_STACK_PROTECTOR) || defined(CFG_WITH_STACK_CANARIES)
+/*
+ * plat_get_random_stack_canaries() - Get random values for stack canaries.
+ * @buf:	Pointer to the buffer where to store canaries
+ * @ncan:	The number of canaries to generate.
+ * @size:	The size (in bytes) of each canary.
+ *
+ * This function has a __weak default implementation.
+ */
+void plat_get_random_stack_canaries(void *buf, size_t ncan, size_t size);
 #endif
 void arm_cl2_config(vaddr_t pl310);
 void arm_cl2_enable(vaddr_t pl310);

--- a/core/include/kernel/thread.h
+++ b/core/include/kernel/thread.h
@@ -52,6 +52,12 @@ void thread_init_canaries(void);
 void thread_init_primary(void);
 void thread_init_per_cpu(void);
 
+#if defined(CFG_WITH_STACK_CANARIES)
+void thread_update_canaries(void);
+#else
+static inline void thread_update_canaries(void) { }
+#endif
+
 struct thread_core_local *thread_get_core_local(void);
 
 /*


### PR DESCRIPTION
Currently hardcoded magic number is used as thread stack canary, an attacker with full control over the overflow can embed the hardcoded canary value on the right location to bypass the overflow detection.

To add extra layer of security, redefine the canary value as variable, such that the canary can be initialized during runtime.

Weak function plat_set_thread_canary() can be overridden by platform to initialize the thread canary with random numbers from TRNG hardware.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
