### PR TITLE
Cbmem console

### DIFF
--- a/core/drivers/cbmem_console.c
+++ b/core/drivers/cbmem_console.c
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023, Linaro Limited
+ */
+
+#include <compiler.h>
+#include <console.h>
+#include <drivers/cbmem_console.h>
+#include <io.h>
+#include <keep.h>
+#include <kernel/dt.h>
+#include <libfdt.h>
+#include <mm/core_mmu.h>
+#include <util.h>
+
+#define CURSOR_MASK (BIT(28) - 1)
+#define BIT(31)
+
+/*
+ * Structures describing coreboot's in-memory descriptor tables. See
+ * <coreboot>/src/commonlib/include/commonlib/coreboot_tables.h for
+ * canonical implementation.
+ */
+
+struct cb_header {
+	char signature[4];
+	uint32_t header_bytes;
+	uint32_t header_checksum;
+	uint32_t table_bytes;
+	uint32_t table_checksum;
+	uint32_t table_entries;
+};
+
+#define CB_TAG_CBMEM_CONSOLE 0x17
+
+struct cb_entry {
+	uint32_t tag;
+	uint32_t size;
+	uint64_t uint64;
+};
+
+static struct cbmem_console_data cbmem_console;
+
+static void cbmem_console_flush(struct serial_chip *chip __unused)
+{
+}
+
+static int cbmem_console_getchar(struct serial_chip *chip __unused)
+{
+	return 0;
+}
+
+static bool cbmem_console_have_rx_data(struct serial_chip *chip __unused)
+{
+	return false;
+}
+
+static void cbmem_console_putc(struct serial_chip *chip, int ch)
+{
+	struct cbmem_console_data *pd =
+		container_of(chip, struct cbmem_console_data, chip);
+	if (pd->size == 0)
+		return;
+
+	if ((pd->console->cursor & CURSOR_MASK) + 1 >= pd->size) {
+		pd->console->cursor &= ~CURSOR_MASK;
+		pd->console->cursor |= OVERFLOW;
+		pd->console->body[0] = (uint8_t)(ch & 0xFF);
+	} else {
+		pd->console->body[pd->console->cursor & CURSOR_MASK] =
+			(uint8_t)(ch & 0xFF);
+		pd->console->cursor++;
+	}
+}
+
+static const struct serial_ops cbmem_console_ops = {
+	.flush = cbmem_console_flush,
+	.getchar = cbmem_console_getchar,
+	.have_rx_data = cbmem_console_have_rx_data,
+	.putc = cbmem_console_putc,
+};
+DECLARE_KEEP_PAGER(cbmem_console_ops);
+
+static paddr_t get_cbmem_console_from_coreboot_table(paddr_t table_addr,
+						     size_t table_size)
+{
+	struct cb_header_t *header;
+	void *ptr;
+	uint32_t i;
+	struct cb_entry_t *entry;
+	paddr_t cbmem_console_base = 0;
+	void *base = core_mmu_add_mapping(MEM_AREA_RAM_NSEC, table_addr,
+					     table_size);
+	if (!base)
+		return 0;
+
+	header = (struct cb_header_t *)base;
+	if (strncmp(header->signature, "LBIO", 4))
+		goto done;
+
+	if (header->header_bytes + header->table_bytes > table_size)
+		goto done;
+
+	ptr = (uint8_t *)base + header->header_bytes;
+	for (i = 0; i < header->table_entries; ++i) {
+		entry = (struct cb_entry_t *)ptr;
+		if ((uint8_t *)ptr >= (uint8_t *)base + table_size -
+				sizeof(cb_entry_t)) {
+			goto done;
+		}
+
+		switch (get_le32(&entry->tag)) {
+		case CB_TAG_CBMEM_CONSOLE:
+			cbmem_console_base = get_le64(&entry->uint64);
+			goto done;
+		default:
+			/* We skip all but one tag type. */
+			break;
+		}
+
+		ptr = (uint8_t *)ptr + get_le32(&entry->size);
+	}
+
+done:
+	core_mmu_remove_mapping(MEM_AREA_RAM_NSEC, base, table_size);
+	return cbmem_console_base;
+}
+
+bool cbmem_console_init_from_dt(void *fdt)
+{
+	int offset;
+	paddr_t cb_addr;
+	size_t cb_size;
+	paddr_t cbmem_console_base;
+
+	if (!fdt)
+		return false;
+
+	offset = fdt_path_offset(fdt, "/firmware/coreboot");
+	if (offset < 0)
+		return false;
+
+	cb_addr = _fdt_reg_base_address(fdt, offset);
+	cb_size = _fdt_reg_size(fdt, offset);
+
+	cbmem_console_base = get_cbmem_console_from_coreboot_table(cb_addr,
+								   cb_size);
+	if (!cbmem_console_base)
+		return false;
+
+	cbmem_console.base = cbmem_console_base;
+	cbmem_console.console = (struct cbmem_console *)
+		core_mmu_add_mapping(MEM_AREA_RAM_NSEC, cbmem_console_base,
+				     sizeof(struct cbmem_console));
+	if (!cbmem_console.console)
+		return false;
+
+	/*
+	 * Copy the size now to prevent non-secure world from spoofing
+	 * it later.
+	 */
+	cbmem_console.size = cbmem_console.console->size;
+	cbmem_console.chip.ops = &cbmem_console_ops;
+
+	register_serial_console(&cbmem_console.chip);
+	return true;
+}

--- a/core/drivers/cbmem_console.c
+++ b/core/drivers/cbmem_console.c
@@ -14,7 +14,7 @@
 #include <util.h>
 
 #define CURSOR_MASK (BIT(28) - 1)
-#define BIT(31)
+#define OVERFLOW BIT(31)
 
 /*
  * Structures describing coreboot's in-memory descriptor tables. See
@@ -84,17 +84,17 @@ DECLARE_KEEP_PAGER(cbmem_console_ops);
 static paddr_t get_cbmem_console_from_coreboot_table(paddr_t table_addr,
 						     size_t table_size)
 {
-	struct cb_header_t *header;
+	struct cb_header *header;
 	void *ptr;
 	uint32_t i;
-	struct cb_entry_t *entry;
+	struct cb_entry *entry;
 	paddr_t cbmem_console_base = 0;
 	void *base = core_mmu_add_mapping(MEM_AREA_RAM_NSEC, table_addr,
 					     table_size);
 	if (!base)
 		return 0;
 
-	header = (struct cb_header_t *)base;
+	header = (struct cb_header *)base;
 	if (strncmp(header->signature, "LBIO", 4))
 		goto done;
 
@@ -103,9 +103,9 @@ static paddr_t get_cbmem_console_from_coreboot_table(paddr_t table_addr,
 
 	ptr = (uint8_t *)base + header->header_bytes;
 	for (i = 0; i < header->table_entries; ++i) {
-		entry = (struct cb_entry_t *)ptr;
+		entry = (struct cb_entry *)ptr;
 		if ((uint8_t *)ptr >= (uint8_t *)base + table_size -
-				sizeof(cb_entry_t)) {
+				sizeof(struct cb_entry)) {
 			goto done;
 		}
 

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -72,6 +72,7 @@ srcs-$(CFG_VERSAL_NVM) += versal_nvm.c
 srcs-$(CFG_VERSAL_SHA3_384) += versal_sha3_384.c
 srcs-$(CFG_VERSAL_PUF) += versal_puf.c
 srcs-$(CFG_VERSAL_HUK) += versal_huk.c
+srcs-$(CFG_CBMEM_CONSOLE) += cbmem_console.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/include/drivers/cbmem_console.h
+++ b/core/include/drivers/cbmem_console.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023, Linaro Limited
+ */
+#ifndef CBMEM_CONSOLE_H
+#define CBMEM_CONSOLE_H
+
+#include <types_ext.h>
+#include <drivers/serial.h>
+
+struct cbmem_console {
+	uint32_t size;
+	uint32_t cursor;
+	uint8_t body[0];
+} __packed;
+
+struct cbmem_console_data {
+	paddr_t base;
+	struct cbmem_console *console;
+	struct serial_chip chip;
+	uint32_t size;
+};
+
+bool cbmem_console_init_from_dt(void *fdt);
+
+#endif /* CBMEM_CONSOLE_H */
+

--- a/core/include/drivers/serial.h
+++ b/core/include/drivers/serial.h
@@ -13,6 +13,7 @@
 
 struct serial_chip {
 	const struct serial_ops *ops;
+	struct serial_chip *next;
 };
 
 struct serial_ops {

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -34,7 +34,8 @@ void __weak console_flush(void)
 	struct serial_chip *curr_console = serial_console;
 
 	while (curr_console) {
-		curr_console->ops->flush(curr_console);
+		if (curr_console->ops->flush)
+			curr_console->ops->flush(curr_console);
 		curr_console = curr_console->next;
 	}
 }

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -5,6 +5,7 @@
 
 #include <compiler.h>
 #include <console.h>
+#include <drivers/cbmem_console.h>
 #include <drivers/serial.h>
 #include <kernel/dt.h>
 #include <kernel/boot.h>
@@ -127,6 +128,12 @@ void configure_console_from_dt(void)
 	int offs;
 
 	fdt = get_dt();
+
+#if defined(CFG_CBMEM_CONSOLE)
+	if (cbmem_console_init_from_dt(fdt))
+		return;
+#endif
+
 	if (get_console_node_from_dt(fdt, &offs, &uart, &parms))
 		return;
 


### PR DESCRIPTION
This adds a console driver to OP-TEE for logging to the coreboot mem console. It does this by passing a device tree from TF-A into OP-TEE that contains the firmware/coreboot node as describe in the Linux device tree specification. OP-TEE then parses the table to extract the address of the coreboot console.

A second commit adds support for logging to multiple serial consoles, which is useful when developing with the coreboot mem console driver enabled.
