### PR TITLE
Re-work CAAM Crypto configuration file + move CFG_WITH_SOFTWARE_PRNG definition

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -517,6 +517,5 @@ ifneq (,$(filter y, $(CFG_MX6) $(CFG_MX7) $(CFG_MX7ULP)))
 CFG_IMX_CAAM ?= y
 endif
 
-CFG_WITH_SOFTWARE_PRNG ?= y
 endif
 

--- a/core/arch/arm/plat-ls/conf.mk
+++ b/core/arch/arm/plat-ls/conf.mk
@@ -124,7 +124,3 @@ CFG_CRYPTO_SIZE_OPTIMIZATION ?= n
 # NXP CAAM support is not enabled by default and can be enabled
 # on the command line
 CFG_NXP_CAAM ?= n
-
-ifneq ($(CFG_NXP_CAAM),y)
-$(call force,CFG_WITH_SOFTWARE_PRNG,y)
-endif

--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -73,6 +73,12 @@ CFG_CRYPTO_AES_GCM_FROM_CRYPTOLIB ?= n
 
 endif
 
+# PRNG configuration
+# If CFG_WITH_SOFTWARE_PRNG is enabled, crypto provider provided
+# software PRNG implementation is used.
+# Otherwise, you need to implement hw_get_random_bytes() for your platform
+CFG_WITH_SOFTWARE_PRNG ?= y
+
 ifeq ($(CFG_WITH_PAGER),y)
 ifneq ($(CFG_CRYPTO_SHA256),y)
 $(warning Warning: Enabling CFG_CRYPTO_SHA256 [required by CFG_WITH_PAGER])

--- a/core/drivers/crypto/caam/crypto.mk
+++ b/core/drivers/crypto/caam/crypto.mk
@@ -171,9 +171,8 @@ endif
 
 endif # !CFG_LS
 
-$(call force, CFG_NXP_CAAM_ACIPHER_DRV, $(call cryphw-one-enabled, RSA ECC DH DSA))
+$(call force, CFG_CRYPTO_DRV_ACIPHER , $(call cryphw-one-enabled, RSA ECC DH DSA))
 $(call force, CFG_CRYPTO_DRV_MAC, $(call cryphw-one-enabled, HMAC CMAC))
-CFG_CRYPTO_DRV_ACIPHER ?= $(CFG_NXP_CAAM_ACIPHER_DRV)
 
 # Disable SM2 as it is not supported by the CAAM driver
 ifeq ($(CFG_NXP_CAAM_ECC_DRV),y)

--- a/core/drivers/crypto/caam/crypto.mk
+++ b/core/drivers/crypto/caam/crypto.mk
@@ -1,5 +1,4 @@
 ifeq ($(CFG_NXP_CAAM),y)
-#
 # CAAM Debug: define 3x32 bits value (same bit used to debug a module)
 # CFG_DBG_CAAM_TRACE  Module print trace
 # CFG_DBG_CAAM_DESC   Module descriptor dump
@@ -21,63 +20,86 @@ ifeq ($(CFG_NXP_CAAM),y)
 # DBG_DH     BIT32(13) // DH Trace
 # DBG_DSA    BIT32(14) // DSA trace
 # DBG_MP     BIT32(15) // MP trace
-
 CFG_DBG_CAAM_TRACE ?= 0x2
 CFG_DBG_CAAM_DESC ?= 0x0
 CFG_DBG_CAAM_BUF ?= 0x0
 
+# CAAM default drivers
+caam-drivers = RNG BLOB
+
+# CAAM default drivers connected to the HW crypto API
+caam-crypto-drivers = CIPHER HASH HMAC CMAC
+
 ifneq (,$(filter $(PLATFORM_FLAVOR),ls1012ardb ls1043ardb ls1046ardb))
-$(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force, CFG_CAAM_BIG_ENDIAN,y)
 $(call force, CFG_JR_BLOCK_SIZE,0x10000)
 $(call force, CFG_JR_INDEX,2)
 $(call force, CFG_JR_INT,105)
+$(call force, CFG_CAAM_SGT_ALIGN,4)
+$(call force, CFG_CAAM_64BIT,y)
 $(call force, CFG_NXP_CAAM_SGT_V1,y)
+$(call force, CFG_CAAM_ITR,n)
+caam-crypto-drivers += RSA DSA ECC DH MATH
 else ifneq (,$(filter $(PLATFORM_FLAVOR),ls1088ardb ls2088ardb ls1028ardb))
-$(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force, CFG_CAAM_LITTLE_ENDIAN,y)
 $(call force, CFG_JR_BLOCK_SIZE,0x10000)
 $(call force, CFG_JR_INDEX,2)
 $(call force, CFG_JR_INT,174)
 $(call force, CFG_NXP_CAAM_SGT_V2,y)
+$(call force, CFG_CAAM_SGT_ALIGN,4)
+$(call force, CFG_CAAM_64BIT,y)
+$(call force, CFG_CAAM_ITR,n)
+caam-crypto-drivers += RSA DSA ECC DH MATH
 else ifneq (,$(filter $(PLATFORM_FLAVOR),lx2160aqds lx2160ardb))
-$(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force, CFG_CAAM_LITTLE_ENDIAN,y)
 $(call force, CFG_JR_BLOCK_SIZE,0x10000)
 $(call force, CFG_JR_INDEX,2)
 $(call force, CFG_JR_INT, 174)
 $(call force, CFG_NB_JOBS_QUEUE, 80)
 $(call force, CFG_NXP_CAAM_SGT_V2,y)
+$(call force, CFG_CAAM_SGT_ALIGN,4)
+$(call force, CFG_CAAM_64BIT,y)
+$(call force, CFG_CAAM_ITR,n)
+caam-crypto-drivers += RSA DSA ECC DH MATH
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8qm-flavorlist) $(mx8qx-flavorlist)))
 $(call force, CFG_CAAM_SIZE_ALIGN,4)
 $(call force, CFG_JR_BLOCK_SIZE,0x10000)
 $(call force, CFG_JR_INDEX,3)
 $(call force, CFG_JR_INT,486)
 $(call force, CFG_NXP_CAAM_SGT_V1,y)
-else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mm-flavorlist) $(mx8mn-flavorlist) $(mx8mp-flavorlist) $(mx8mq-flavorlist)))
-$(call force, CFG_CAAM_SIZE_ALIGN,1)
+caam-crypto-drivers += RSA DSA ECC DH MATH
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mm-flavorlist) $(mx8mn-flavorlist) \
+	$(mx8mp-flavorlist) $(mx8mq-flavorlist)))
 $(call force, CFG_JR_BLOCK_SIZE,0x1000)
 $(call force, CFG_JR_INDEX,2)
 $(call force, CFG_JR_INT,146)
 $(call force, CFG_NXP_CAAM_SGT_V1,y)
+$(call force, CFG_JR_HAB_INDEX,0)
+caam-drivers += MP
+caam-crypto-drivers += RSA DSA ECC DH MATH
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8ulp-flavorlist)))
-$(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force, CFG_JR_BLOCK_SIZE,0x1000)
 $(call force, CFG_JR_INDEX,2)
 $(call force, CFG_JR_INT,114)
 $(call force, CFG_NXP_CAAM_SGT_V1,y)
 $(call force, CFG_CAAM_ITR,n)
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx7ulp-flavorlist)))
-$(call force, CFG_CAAM_SIZE_ALIGN,1)
 $(call force, CFG_JR_BLOCK_SIZE,0x1000)
 $(call force, CFG_JR_INDEX,0)
 $(call force, CFG_JR_INT,137)
 $(call force, CFG_NXP_CAAM_SGT_V1,y)
 $(call force, CFG_CAAM_ITR,n)
-else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6ul-flavorlist) $(mx6q-flavorlist) \
-        $(mx6qp-flavorlist) $(mx6sx-flavorlist) $(mx6d-flavorlist) $(mx6dl-flavorlist) \
-        $(mx6s-flavorlist) $(mx7d-flavorlist) $(mx7s-flavorlist) $(mx8ulp-flavorlist)))
-$(call force, CFG_CAAM_SIZE_ALIGN,1)
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6ul-flavorlist) $(mx7d-flavorlist) \
+	$(mx7s-flavorlist)))
+$(call force, CFG_JR_BLOCK_SIZE,0x1000)
+$(call force, CFG_JR_INDEX,0)
+$(call force, CFG_JR_INT,137)
+$(call force, CFG_NXP_CAAM_SGT_V1,y)
+caam-drivers += MP
+caam-crypto-drivers += RSA DSA ECC DH MATH
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx6q-flavorlist) $(mx6qp-flavorlist) \
+	$(mx6sx-flavorlist) $(mx6d-flavorlist) $(mx6dl-flavorlist) \
+        $(mx6s-flavorlist) $(mx8ulp-flavorlist)))
 $(call force, CFG_JR_BLOCK_SIZE,0x1000)
 $(call force, CFG_JR_INDEX,0)
 $(call force, CFG_JR_INT,137)
@@ -86,93 +108,84 @@ else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif
 
-# Enable the BLOB module used for the hardware unique key
-CFG_NXP_CAAM_BLOB_DRV ?= y
+# Disable the i.MX CAAM driver
+$(call force,CFG_IMX_CAAM,n,Mandated by CFG_NXP_CAAM)
 
-ifeq ($(CFG_LS),y)
-CFG_CRYPTO_DRIVER ?= y
-CFG_CAAM_64BIT ?= y
+# CAAM buffer alignment size
+CFG_CAAM_SIZE_ALIGN ?= 1
 
-$(call force, CFG_CAAM_SGT_ALIGN,4)
-
-else # !CFG_LS, that is, MX family of platforms
-
-CFG_CAAM_ITR ?= y
+# Default padding number for SGT allocation
 CFG_CAAM_SGT_ALIGN ?= 1
-$(call force,CFG_IMX_CAAM,n)
 
-endif # !CFG_LS
+# Enable job ring interruption
+CFG_CAAM_ITR ?= y
+
+# Keep the CFG_JR_INDEX as secure at runtime
+CFG_NXP_CAAM_RUNTIME_JR ?= y
+
+# Define the RSA Private Key Format used by the CAAM
+#   Format #1: (n, d)
+#   Format #2: (p, q, d)
+#   Format #3: (p, q, dp, dq, qp)
+CFG_NXP_CAAM_RSA_KEY_FORMAT ?= 3
+
+# Disable device tree status of the secure job ring
+CFG_CAAM_JR_DISABLE_NODE ?= y
+
+# Enable CAAM non-crypto drivers
+$(foreach drv, $(caam-drivers), $(eval CFG_NXP_CAAM_$(drv)_DRV ?= y))
+
+# Disable software RNG if CAAM RNG driver is enabled
+ifeq ($(CFG_NXP_CAAM_RNG_DRV), y)
+$(call force, CFG_WITH_SOFTWARE_PRNG,n,Mandated by CFG_NXP_CAAM_RNG_DRV)
+endif
 
 ifeq ($(CFG_CRYPTO_DRIVER), y)
-
-# Crypto Driver Debug
-# DRV_DBG_TRACE BIT32(0) // Driver trace
-# DRV_DBG_BUF   BIT32(1) // Driver dump Buffer
 CFG_CRYPTO_DRIVER_DEBUG ?= 0
 
-$(call force, CFG_NXP_CAAM_RUNTIME_JR, y)
+# Enable CAAM Crypto drivers
+$(foreach drv, $(caam-crypto-drivers), $(eval CFG_NXP_CAAM_$(drv)_DRV ?= y))
 
-# Force to 'y' the CFG_NXP_CAAM_xxx_DRV to enable the CAAM HW driver
-# and enable the associated CFG_CRYPTO_DRV_xxx Crypto driver
-# API
-#
-# Example: Enable CFG_CRYPTO_DRV_HASH and CFG_NXP_CAAM_HASH_DRV
-#     $(eval $(call cryphw-enable-drv-hw, HASH))
-define cryphw-enable-drv-hw
-_var := $(strip $(1))
-$$(call force, CFG_NXP_CAAM_$$(_var)_DRV, y)
-$$(call force, CFG_CRYPTO_DRV_$$(_var), y)
-endef
-
-# Return 'y' if at least one of the variable
-# CFG_CRYPTO_xxx_HW is 'y'
-cryphw-one-enabled = $(call cfg-one-enabled, \
-                        $(foreach v,$(1), CFG_NXP_CAAM_$(v)_DRV))
-
-$(call force, CFG_NXP_CAAM_RNG_DRV, y)
-CFG_WITH_SOFTWARE_PRNG = n
-$(eval $(call cryphw-enable-drv-hw, HASH))
-$(eval $(call cryphw-enable-drv-hw, CIPHER))
-$(call force, CFG_NXP_CAAM_HMAC_DRV,y)
-$(call force, CFG_NXP_CAAM_CMAC_DRV,y)
-
-ifeq ($(CFG_LS),y)
-
-$(eval $(call cryphw-enable-drv-hw, RSA))
-$(eval $(call cryphw-enable-drv-hw, ECC))
-$(eval $(call cryphw-enable-drv-hw, DH))
-$(eval $(call cryphw-enable-drv-hw, DSA))
-
-# Define the RSA Private Key Format used by the CAAM
-#   Format #1: (n, d)
-#   Format #2: (p, q, d)
-#   Format #3: (p, q, dp, dq, qp)
-CFG_NXP_CAAM_RSA_KEY_FORMAT ?= 3
-
-else # !CFG_LS, that is, MX family of platforms
-
-ifneq ($(filter y, $(CFG_MX6QP) $(CFG_MX6Q) $(CFG_MX6D) $(CFG_MX6DL) \
-        $(CFG_MX6S) $(CFG_MX6SL) $(CFG_MX6SLL) $(CFG_MX6SX) $(CFG_MX7ULP) $(CFG_MX8ULP)), y)
-$(eval $(call cryphw-enable-drv-hw, RSA))
-$(eval $(call cryphw-enable-drv-hw, ECC))
-$(eval $(call cryphw-enable-drv-hw, DH))
-$(eval $(call cryphw-enable-drv-hw, DSA))
-
-# Define the RSA Private Key Format used by the CAAM
-#   Format #1: (n, d)
-#   Format #2: (p, q, d)
-#   Format #3: (p, q, dp, dq, qp)
-CFG_NXP_CAAM_RSA_KEY_FORMAT ?= 3
+# Enable MAC crypto driver
+ifeq ($(call cfg-one-enabled,CFG_NXP_CAAM_HMAC_DRV CFG_NXP_CAAM_CMAC_DRV),y)
+$(call force, CFG_CRYPTO_DRV_MAC,y,Mandated by CFG_NXP_CAAM_HMAC/CMAC_DRV)
 endif
 
-ifneq ($(filter y, $(CFG_MX8QM) $(CFG_MX8QX) $(CFG_MX8DXL)), y)
-$(eval $(call cryphw-enable-drv-hw, MP))
+# Enable CIPHER crypto driver
+ifeq ($(CFG_NXP_CAAM_CIPHER_DRV), y)
+$(call force, CFG_CRYPTO_DRV_CIPHER,y,Mandated by CFG_NXP_CAAM_CIPHER_DRV)
 endif
 
-endif # !CFG_LS
+# Enable HASH crypto driver
+ifeq ($(CFG_NXP_CAAM_HASH_DRV), y)
+$(call force, CFG_CRYPTO_DRV_HASH,y,Mandated by CFG_NXP_CAAM_HASH_DRV)
+endif
 
-$(call force, CFG_CRYPTO_DRV_ACIPHER , $(call cryphw-one-enabled, RSA ECC DH DSA))
-$(call force, CFG_CRYPTO_DRV_MAC, $(call cryphw-one-enabled, HMAC CMAC))
+# Enable RSA crypto driver
+ifeq ($(CFG_NXP_CAAM_RSA_DRV), y)
+$(call force, CFG_CRYPTO_DRV_RSA,y,Mandated by CFG_NXP_CAAM_RSA_DRV)
+endif
+
+# Enable ECC crypto driver
+ifeq ($(CFG_NXP_CAAM_ECC_DRV), y)
+$(call force, CFG_CRYPTO_DRV_ECC,y,Mandated by CFG_NXP_CAAM_ECC_DRV)
+endif
+
+# Enable DSA crypto driver
+ifeq ($(CFG_NXP_CAAM_DSA_DRV), y)
+$(call force, CFG_CRYPTO_DRV_DSA,y,Mandated by CFG_NXP_CAAM_DSA_DRV)
+endif
+
+# Enable DH crypto driver
+ifeq ($(CFG_NXP_CAAM_DH_DRV), y)
+$(call force, CFG_CRYPTO_DRV_DH,y,Mandated by CFG_NXP_CAAM_DH_DRV)
+endif
+
+# Enable ACIPHER crypto driver
+ifeq ($(call cfg-one-enabled,CFG_CRYPTO_DRV_RSA CFG_CRYPTO_DRV_ECC \
+	CFG_CRYPTO_DRV_DSA CFG_CRYPTO_DRV_DH),y)
+$(call force, CFG_CRYPTO_DRV_ACIPHER,y,Mandated by CFG_CRYPTO_DRV_{RSA|ECC|DSA|DH})
+endif
 
 # Disable SM2 as it is not supported by the CAAM driver
 ifeq ($(CFG_NXP_CAAM_ECC_DRV),y)

--- a/core/drivers/crypto/caam/sub.mk
+++ b/core/drivers/crypto/caam/sub.mk
@@ -10,6 +10,6 @@ srcs-y += caam_rng.c
 srcs-y += caam_desc.c
 subdirs-$(call cfg-one-enabled, CFG_NXP_CAAM_HASH_DRV CFG_NXP_CAAM_HMAC_DRV) += hash
 subdirs-$(call cfg-one-enabled, CFG_NXP_CAAM_CIPHER_DRV CFG_NXP_CAAM_CMAC_DRV) += cipher
-subdirs-$(CFG_NXP_CAAM_ACIPHER_DRV) += acipher
+subdirs-y += acipher
 subdirs-$(CFG_NXP_CAAM_BLOB_DRV) += blob
 subdirs-$(CFG_NXP_CAAM_MP_DRV) += mp

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -103,12 +103,6 @@ CFG_CORE_DUMP_OOM ?= $(CFG_TEE_CORE_MALLOC_DEBUG)
 # Levels: 0=none 1=error 2=info 3=debug 4=flow
 CFG_MSG_LONG_PREFIX_MASK ?= 0x1a
 
-# PRNG configuration
-# If CFG_WITH_SOFTWARE_PRNG is enabled, crypto provider provided
-# software PRNG implementation is used.
-# Otherwise, you need to implement hw_get_random_bytes() for your platform
-CFG_WITH_SOFTWARE_PRNG ?= y
-
 # Number of threads
 CFG_NUM_THREADS ?= 2
 


### PR DESCRIPTION
Hello,

This PR combines the re-work of the CAAM crypto configuration file for i.MX/LS and the move of CFG_WITH_SOFTWARE_PRNG definition from mk/config.mk to mk/crypto.mk.
The latter allows the HW Crypto driver to overide the default CFG_WITH_SOFTWARE_PRNG value. Let me know what you think about this change.

Thanks!