### PR TITLE
CAAM Black key support for asymmetric crypto

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -79,6 +79,13 @@ endif
 # Otherwise, you need to implement hw_get_random_bytes() for your platform
 CFG_WITH_SOFTWARE_PRNG ?= y
 
+# Define the maximum size, in bits, for big numbers in the TEE core (privileged
+# layer).
+# This value is an upper limit for the key size in any cryptographic algorithm
+# implemented by the TEE core.
+# Set this to a lower value to reduce the memory footprint.
+CFG_CORE_BIGNUM_MAX_BITS ?= 4096
+
 ifeq ($(CFG_WITH_PAGER),y)
 ifneq ($(CFG_CRYPTO_SHA256),y)
 $(warning Warning: Enabling CFG_CRYPTO_SHA256 [required by CFG_WITH_PAGER])

--- a/core/drivers/crypto/caam/acipher/caam_prime_dsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_prime_dsa.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2020-2021 NXP
+ * Copyright 2020-2021, 2023 NXP
  *
  * CAAM DSA Prime Numbering.
  * Implementation of Prime Number functions
@@ -98,7 +98,7 @@ static void do_desc_prime_q(uint32_t *desc, struct caambuf *seed,
 	}
 
 	caam_desc_add_word(desc, MOVE(C1_ALIGN, OFIFO, 0, seed->length));
-	caam_desc_add_word(desc, FIFO_ST(MSG_DATA, seed->length));
+	caam_desc_add_word(desc, FIFO_ST(CLASS_NO, MSG_DATA, seed->length));
 	caam_desc_add_ptr(desc, seed->paddr);
 
 	/*
@@ -143,7 +143,7 @@ static void do_desc_prime_q(uint32_t *desc, struct caambuf *seed,
 	caam_desc_add_word(desc, prime->q->length);
 
 	/* Store the Prime q here because Miller-Rabin test affect PKHA N */
-	caam_desc_add_word(desc, FIFO_ST(PKHA_N, prime->q->length));
+	caam_desc_add_word(desc, FIFO_ST(CLASS_NO, PKHA_N, prime->q->length));
 	caam_desc_add_ptr(desc, prime->q->paddr);
 
 	/*
@@ -265,7 +265,7 @@ static void do_desc_gen_x(uint32_t *desc, struct caambuf *x,
 			   FIFO_LD(CLASS_1, PKHA_A, NOACTION, seed->length));
 	caam_desc_add_ptr(desc, seed->paddr);
 	caam_desc_add_word(desc, PKHA_OP(MOD_ADD_A_B, A));
-	caam_desc_add_word(desc, FIFO_ST(PKHA_A, seed->length));
+	caam_desc_add_word(desc, FIFO_ST(CLASS_NO, PKHA_A, seed->length));
 	caam_desc_add_ptr(desc, seed->paddr);
 
 	caam_desc_add_word(desc, PKHA_CPY_NSIZE(A0, B1));
@@ -419,7 +419,7 @@ static void do_desc_prime_p(uint32_t *desc, struct prime_data_dsa *prime,
 	 * affected by the Miller-Rabin test
 	 */
 	caam_desc_add_word(desc, PKHA_CPY_SSIZE(A0, N0));
-	caam_desc_add_word(desc, FIFO_ST(PKHA_N, prime->p->length));
+	caam_desc_add_word(desc, FIFO_ST(CLASS_NO, PKHA_N, prime->p->length));
 	caam_desc_add_ptr(desc, prime->p->paddr);
 	caam_desc_add_word(desc, FIFO_ST_SEQ(MSG_DATA, 0));
 
@@ -648,7 +648,7 @@ static enum caam_status do_generator(uint32_t *desc,
 					  retry_new_h - desclen));
 
 	/* g is good save it */
-	caam_desc_add_word(desc, FIFO_ST(PKHA_A, prime->g->length));
+	caam_desc_add_word(desc, FIFO_ST(CLASS_NO, PKHA_A, prime->g->length));
 	caam_desc_add_ptr(desc, prime->g->paddr);
 
 	DSA_DUMPDESC(desc);

--- a/core/drivers/crypto/caam/caam_ctrl.c
+++ b/core/drivers/crypto/caam/caam_ctrl.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2017-2021 NXP
+ * Copyright 2017-2021, 2023 NXP
  *
  * Brief   CAAM Global Controller.
  */
@@ -13,6 +13,7 @@
 #include <caam_hal_ctrl.h>
 #include <caam_hash.h>
 #include <caam_jr.h>
+#include <caam_key.h>
 #include <caam_blob.h>
 #include <caam_mp.h>
 #include <caam_pwr.h>
@@ -150,6 +151,13 @@ static TEE_Result crypto_driver_init(void)
 
 	/* Initialize the secure memory */
 	retstatus = caam_sm_init(&jrcfg);
+	if (retstatus != CAAM_NO_ERROR) {
+		retresult = TEE_ERROR_GENERIC;
+		goto exit_init;
+	}
+
+	/* Initialize the KEY Module */
+	retstatus = caam_key_init();
 	if (retstatus != CAAM_NO_ERROR) {
 		retresult = TEE_ERROR_GENERIC;
 		goto exit_init;

--- a/core/drivers/crypto/caam/caam_key.c
+++ b/core/drivers/crypto/caam/caam_key.c
@@ -1,0 +1,752 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2023 NXP
+ */
+#include <assert.h>
+#include <caam_desc_helper.h>
+#include <caam_key.h>
+#include <caam_status.h>
+#include <caam_trace.h>
+#include <caam_utils_mem.h>
+#include <crypto/crypto.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <stdint.h>
+#include <string.h>
+#include <tee/cache.h>
+#include <tee_api_defines.h>
+#include <trace.h>
+#include <utee_types.h>
+
+/*
+ * CAAM Key magic number.
+ * When the first 32 bits of a key buffer are equal to this value, the buffer
+ * is a serialized CAAM key structure.
+ */
+#define MAGIC_NUMBER 0xCAAFBFFB
+
+/*
+ * Because the CAAM driver relies on this magic number to determine if the key
+ * is plain text or black, collision can happen. A randomly generated plain text
+ * key could feature the magic number. That's unlikely but still possible.
+ *
+ * Regarding the possibility of collision or forging attack, there are no
+ * security concerns. Forging and trying to make a plain text key look like a
+ * black key, won't do much. If the key is forged to look like an ECB Black
+ * key, the singing operation will output a corrupted result. If the key is
+ * forged to look like a CCM Black key, the import key will fail (because the
+ * MAC verification) and no signing operation will be done.
+ */
+
+#define BLOB_BKEK_SIZE	     32 /* Blob key encryption key size */
+#define BLOB_MAC_SIZE	     16 /* Blob MAC size */
+#define BLOB_PAD_SIZE	     (BLOB_BKEK_SIZE + BLOB_MAC_SIZE)
+
+/*
+ * CAAM Blob key modifier
+ * Key modifier used to derive Blob-key encryption key (BKEK) from the CAAM
+ * master key.
+ *
+ * A CAAM black key is encrypted using a volatile Job Descriptor key encryption
+ * key or JDKEK. Black keys are not intended for storage of keys across SoC
+ * power cycles. The JDKEK is re-generated upon every power cycle (reset,
+ * suspend/resume ...) or CAAM RNG re-seed.
+ *
+ * To retain key across power cycles, the black key must be encapsulated as a
+ * blob. The blob key encryption key is derived from the CAAM master key which
+ * makes it non-volatile and can be re-created when the chip powers up again.
+ */
+#define KEY_BLOB_MODIFIER_SIZE 16
+static const uint8_t key_blob_modifier[KEY_BLOB_MODIFIER_SIZE] =
+	"NXP_OPTEE_BLOB";
+
+/*
+ * Serialized CAAM key structure format.
+ *
+ * If the incoming key buffer is the following:
+ *	| Magic number | key type | key size | key blob buffer |
+ * The CAAM Key structure will be populated as following:
+ * struct caamkey {
+ *	.key_type = key type,
+ *	.key_size = key size,
+ *	.is_blob = true,
+ *	.buf = key blob buffer
+ * }
+ *
+ * If the incoming key buffer is the following:
+ *	| Key buffer |
+ * The CAAM Key structure will be populated as following:
+ * struct caamkey {
+ *	.key_type = CAAM_KEY_PLAIN_TEXT,
+ *	.key_size = sizeof(Key buffer),
+ *	.is_blob = false,
+ *	.buf = key buffer
+ * }
+ */
+struct caam_key_serialized {
+	uint32_t magic_number; /* Magic number */
+	uint32_t key_type; /* Black key type */
+	uint32_t sec_size; /* The original plain text key size */
+	uint8_t key[];
+};
+
+/*
+ * CAAM key type enumeration to string
+ */
+static const char *const caam_key_type_to_str[] __maybe_unused = {
+	[CAAM_KEY_PLAIN_TEXT] = "Plain Text",
+	[CAAM_KEY_BLACK_ECB] = "Black ECB",
+	[CAAM_KEY_BLACK_CCM] = "Black CCM",
+};
+
+static struct caam_key_serialized *data_to_serialized_key(const uint8_t *data,
+							  size_t size)
+{
+	assert(data && size);
+	assert(size > sizeof(struct caam_key_serialized));
+
+	/*
+	 * It's important to make sure uint8_t and caam_key_serialized{} are
+	 * actually aligned for performance purpose.
+	 *
+	 * A __packed attribute to caam_key_serialized{} could solve the
+	 * alignment issue but at the cost of un-optimize memory access.
+	 * To avoid using the __packed attribute, caam_key_serialized{} is
+	 * defined to be aligned on uint8_t. The following assert checks
+	 * for this alignment.
+	 */
+	assert(IS_ALIGNED_WITH_TYPE(data, struct caam_key_serialized));
+
+	/*
+	 * The cast to void* instead of struct caam_key_serialized* is needed
+	 * to avoid the cast alignment compilation warning.
+	 */
+	return (void *)data;
+}
+
+/*
+ * Return the CAAM key type of the given key buffer
+ *
+ * @data	Input buffer
+ * @size	Input buffer size
+ */
+static enum caam_key_type get_key_type(const uint8_t *data, size_t size)
+{
+	struct caam_key_serialized *key = data_to_serialized_key(data, size);
+
+	if (key->magic_number != MAGIC_NUMBER)
+		return CAAM_KEY_PLAIN_TEXT;
+
+	return key->key_type;
+}
+
+/*
+ * Return the CAAM key size of the given key buffer
+ *
+ * @data	Input buffer
+ * @size	Input buffer size
+ */
+static size_t get_key_sec_size(const uint8_t *data, size_t size)
+{
+	struct caam_key_serialized *key = data_to_serialized_key(data, size);
+
+	if (key->magic_number != MAGIC_NUMBER)
+		return size;
+
+	return key->sec_size;
+}
+
+/*
+ * Return the CAAM key buffer pointer of the given key buffer
+ *
+ * @data	Input buffer
+ * @size	Input buffer size
+ */
+static unsigned long get_key_buf_offset(const uint8_t *data, size_t size)
+{
+	struct caam_key_serialized *key = data_to_serialized_key(data, size);
+
+	if (key->magic_number != MAGIC_NUMBER)
+		return 0;
+	else
+		return offsetof(struct caam_key_serialized, key);
+}
+
+/*
+ * Return the CAAM key buffer size of the given key buffer
+ *
+ * @data	Input buffer
+ * @size	Input buffer size
+ */
+static size_t get_key_buf_size(const uint8_t *data, size_t size)
+{
+	struct caam_key_serialized *key = data_to_serialized_key(data, size);
+
+	/*
+	 * In the caam_key_serialized{}, the last element of the structure is
+	 * a variable-sized buffer.
+	 */
+	return size - sizeof(*key);
+}
+
+size_t caam_key_get_alloc_size(const struct caamkey *key)
+{
+	if (!key)
+		return 0;
+
+	/* A blob size is independent from the key encryption algorithm */
+	if (key->is_blob)
+		return key->sec_size + BLOB_PAD_SIZE;
+
+	switch (key->key_type) {
+	case CAAM_KEY_PLAIN_TEXT:
+		/*
+		 * If the key is plain text, the allocation size is equal to the
+		 * key size and no blob operation on this key is possible.
+		 */
+		return key->sec_size;
+	case CAAM_KEY_BLACK_ECB:
+		/* ECB-black key must be a multiple of 16 bytes */
+		return ROUNDUP(key->sec_size, 16);
+	case CAAM_KEY_BLACK_CCM:
+		/*
+		 * CCM-black key must be a multiple of 8 bytes. The nonce and
+		 * ICV add another 12 bytes to the allocation size
+		 */
+		return ROUNDUP(key->sec_size, 8) + BLACK_KEY_NONCE_SIZE +
+		       BLACK_KEY_ICV_SIZE;
+	default:
+		return 0;
+	}
+}
+
+void caam_key_dump(const char *trace, const struct caamkey *key)
+{
+	if (!key || !trace)
+		return;
+
+	if (key->key_type >= CAAM_KEY_MAX_VALUE)
+		return;
+
+	KEY_TRACE("%s key_type:%s key_size:%zu is_blob:%s addr:%p",
+		  caam_key_type_to_str[key->key_type], trace, key->sec_size,
+		  key->is_blob ? "yes" : "no", key->buf.data);
+
+	if (key->buf.data)
+		KEY_DUMPBUF("Key data", key->buf.data, key->buf.length);
+}
+
+enum caam_status caam_key_alloc(struct caamkey *key)
+{
+	size_t alloc_size = 0;
+
+	if (!key)
+		return CAAM_BAD_PARAM;
+
+	if (key->buf.data) {
+		KEY_TRACE("Key already allocated");
+		return CAAM_BAD_PARAM;
+	}
+
+	alloc_size = caam_key_get_alloc_size(key);
+	if (!alloc_size)
+		return CAAM_FAILURE;
+
+	return caam_calloc_align_buf(&key->buf, alloc_size);
+}
+
+void caam_key_free(struct caamkey *key)
+{
+	if (!key)
+		return;
+
+	caam_free_buf(&key->buf);
+}
+
+void caam_key_cache_op(enum utee_cache_operation op, const struct caamkey *key)
+{
+	if (!key)
+		return;
+
+	if (!key->buf.nocache)
+		cache_operation(op, key->buf.data, key->buf.length);
+}
+
+#define BLOB_OP_DESC_ENTRIES 12
+enum caam_status caam_key_operation_blob(const struct caamkey *in_key,
+					 struct caamkey *out_key)
+{
+	enum caam_status status = CAAM_FAILURE;
+	struct caam_jobctx jobctx = { };
+	uint32_t opflag = PROT_BLOB_TYPE(BLACK_KEY);
+	uint32_t *desc = NULL;
+	size_t output_buffer_size = 0;
+	size_t input_buffer_size = 0;
+
+	assert(in_key && out_key);
+
+	KEY_TRACE("Blob %scapsulation of the following key",
+		  in_key->is_blob ? "de" : "en");
+
+	caam_key_dump("Blob input key", in_key);
+
+	/* This function blobs or un-blobs */
+	if (in_key->is_blob == out_key->is_blob) {
+		KEY_TRACE("Only one key must be defined as a blob");
+		return CAAM_BAD_PARAM;
+	}
+
+	/* A black blob cannot take a plain test key as input */
+	if (out_key->key_type == CAAM_KEY_PLAIN_TEXT ||
+	    in_key->key_type == CAAM_KEY_PLAIN_TEXT) {
+		KEY_TRACE("A blob in/out operation cannot be plain text");
+		return CAAM_BAD_PARAM;
+	}
+
+	/* The key type must remain the same */
+	if (out_key->key_type != in_key->key_type) {
+		KEY_TRACE("The in/out keys must have the same key type");
+		return CAAM_BAD_PARAM;
+	}
+
+	/* Define blob operation direction */
+	if (out_key->is_blob)
+		opflag |= BLOB_ENCAPS;
+	else
+		opflag |= BLOB_DECAPS;
+
+	/* Build OP flags depending on the blob type */
+	switch (out_key->key_type) {
+	case CAAM_KEY_BLACK_ECB:
+		opflag |= PROT_BLOB_INFO(ECB);
+		break;
+	case CAAM_KEY_BLACK_CCM:
+		opflag |= PROT_BLOB_INFO(CCM);
+		break;
+	default:
+		return CAAM_BAD_PARAM;
+	}
+
+	/* Allocate the descriptor */
+	desc = caam_calloc_desc(BLOB_OP_DESC_ENTRIES);
+	if (!desc) {
+		KEY_TRACE("CAAM Context Descriptor Allocation error");
+		return CAAM_OUT_MEMORY;
+	}
+
+	status = caam_key_alloc(out_key);
+	if (status) {
+		KEY_TRACE("Key output allocation error");
+		goto err;
+	}
+
+	/* Define input and output buffer size */
+	if (out_key->is_blob) {
+		/*
+		 * For a blob operation, the input key size is the original key
+		 * size of the black key.
+		 * The output key size is the final blob size.
+		 */
+		input_buffer_size = in_key->sec_size;
+		output_buffer_size = out_key->buf.length;
+	} else {
+		/*
+		 * For an non-blob operation, the input key size is the original
+		 * key size of the black key.
+		 * The output key size is the key security size.
+		 */
+		input_buffer_size = in_key->buf.length;
+		output_buffer_size = out_key->sec_size;
+	}
+
+	/* Create the blob encapsulation/decapsulation descriptor */
+	caam_desc_init(desc);
+	caam_desc_add_word(desc, DESC_HEADER(0));
+
+	/* Load the key modifier */
+	caam_desc_add_word(desc,
+			   LD_NOIMM(CLASS_2, REG_KEY, KEY_BLOB_MODIFIER_SIZE));
+	caam_desc_add_ptr(desc, virt_to_phys((void *)key_blob_modifier));
+
+	/* Define the Input data sequence */
+	caam_desc_add_word(desc, SEQ_IN_PTR(input_buffer_size));
+	caam_desc_add_ptr(desc, in_key->buf.paddr);
+
+	/* Define the Output data sequence */
+	caam_desc_add_word(desc, SEQ_OUT_PTR(output_buffer_size));
+	caam_desc_add_ptr(desc, out_key->buf.paddr);
+	caam_desc_add_word(desc, opflag);
+
+	KEY_DUMPDESC(desc);
+
+	caam_key_cache_op(TEE_CACHECLEAN, in_key);
+	caam_key_cache_op(TEE_CACHECLEAN, out_key);
+
+	jobctx.desc = desc;
+	status = caam_jr_enqueue(&jobctx, NULL);
+
+	if (status == CAAM_NO_ERROR) {
+		KEY_TRACE("CAAM Blob %scapsulation Done",
+			  out_key->is_blob ? "En" : "De");
+
+		caam_key_cache_op(TEE_CACHEINVALIDATE, out_key);
+		caam_key_dump("Blob output key", out_key);
+
+		goto out;
+	} else {
+		KEY_TRACE("CAAM Blob Status 0x%08" PRIx32 "", jobctx.status);
+	}
+
+err:
+	caam_key_free(out_key);
+out:
+	caam_free_desc(&desc);
+	return status;
+}
+
+enum caam_status caam_key_deserialize_from_bin(uint8_t *data, size_t size,
+					       struct caamkey *key,
+					       size_t sec_size)
+{
+	enum caam_status status = CAAM_FAILURE;
+	struct caamkey blob = { };
+
+	assert(data && size && key);
+
+	KEY_TRACE("Deserialization binary buffer");
+	KEY_DUMPBUF("Deserialize key buffer input", data, size);
+
+	/*
+	 * If a security key size is given, use it. Otherwise, rely on
+	 * the buffer size.
+	 * In some case, like ECC keys, the bignum size is less than the
+	 * security size and it requires the key to be padded with 0's.
+	 */
+	if (sec_size == 0)
+		sec_size = get_key_sec_size(data, size);
+
+	blob.key_type = get_key_type(data, size);
+	blob.sec_size = sec_size;
+	blob.is_blob = true;
+
+	if (blob.key_type == CAAM_KEY_PLAIN_TEXT) {
+		key->sec_size = blob.sec_size;
+		key->key_type = blob.key_type;
+		key->is_blob = false;
+
+		status = caam_key_alloc(key);
+		if (status) {
+			KEY_TRACE("Key allocation error");
+			return status;
+		}
+
+		/* Some asymmetric keys have leading zeros we must preserve */
+		memcpy(key->buf.data + key->buf.length - size, data, size);
+
+		return CAAM_NO_ERROR;
+	}
+
+	status = caam_key_alloc(&blob);
+	if (status) {
+		KEY_TRACE("Key allocation error");
+		return status;
+	}
+
+	memcpy(blob.buf.data, data + get_key_buf_offset(data, size),
+	       get_key_buf_size(data, size));
+
+	/* Set destination key */
+	key->key_type = blob.key_type;
+	key->sec_size = blob.sec_size;
+	key->is_blob = false;
+
+	/* De-blob operation */
+	status = caam_key_operation_blob(&blob, key);
+	if (status) {
+		KEY_TRACE("De-blob operation fail");
+		goto out;
+	}
+
+	KEY_TRACE("Deserialization binary buffer done");
+	caam_key_dump("Deserialization output key", key);
+out:
+	caam_key_free(&blob);
+	return status;
+}
+
+enum caam_status caam_key_serialize_to_bin(uint8_t *data, size_t size,
+					   const struct caamkey *key)
+{
+	struct caam_key_serialized key_ser = { };
+	struct caamkey blob = { };
+	enum caam_status status = CAAM_FAILURE;
+	size_t serialized_size = 0;
+
+	assert(data && size && key);
+
+	caam_key_dump("Serialization input key", key);
+
+	/* If the key is plain text, just copy key to buffer */
+	if (key->key_type == CAAM_KEY_PLAIN_TEXT) {
+		if (size < key->buf.length) {
+			KEY_TRACE("Buffer is too short");
+			return CAAM_SHORT_BUFFER;
+		}
+
+		memcpy(data, key->buf.data, key->buf.length);
+
+		return CAAM_NO_ERROR;
+	}
+
+	/* The input key must not be a blob */
+	assert(!key->is_blob);
+
+	/* Blob the given key for serialization and export */
+	blob.is_blob = true;
+	blob.sec_size = key->sec_size;
+	blob.key_type = key->key_type;
+
+	/*
+	 * Check if the destination is big enough for the black blob buffer and
+	 * header.
+	 */
+	status = caam_key_serialized_size(&blob, &serialized_size);
+	if (status)
+		return status;
+
+	if (size < serialized_size) {
+		KEY_TRACE("Destination buffer is too short %zu < %zu", size,
+			  serialized_size);
+		return CAAM_OUT_MEMORY;
+	}
+
+	/* Blob the given key */
+	status = caam_key_operation_blob(key, &blob);
+	if (status) {
+		KEY_TRACE("Blob operation fail");
+		return status;
+	}
+
+	/* Copy the header to destination */
+	key_ser.magic_number = MAGIC_NUMBER;
+	key_ser.key_type = blob.key_type;
+	key_ser.sec_size = blob.sec_size;
+	memcpy(data, &key_ser, sizeof(key_ser));
+
+	/* Copy the key buffer */
+	memcpy(data + sizeof(key_ser), blob.buf.data, blob.buf.length);
+
+	KEY_DUMPBUF("Key data", data, size);
+
+	caam_key_free(&blob);
+
+	return status;
+}
+
+enum caam_status caam_key_serialized_size(const struct caamkey *key,
+					  size_t *size)
+{
+	assert(key && size);
+
+	/* For a plain text key, the serialized key is identical to the key */
+	*size = key->buf.length;
+
+	/*
+	 * For black keys, the serialized key includes the header and must be
+	 * in a blob format
+	 */
+	if (key->key_type != CAAM_KEY_PLAIN_TEXT) {
+		size_t alloc = 0;
+		const struct caamkey tmp = {
+			.key_type = key->key_type,
+			.sec_size = key->sec_size,
+			.is_blob = true,
+		};
+
+		alloc = caam_key_get_alloc_size(&tmp);
+		if (!alloc)
+			return CAAM_FAILURE;
+
+		*size = alloc + sizeof(struct caam_key_serialized);
+	}
+
+	return CAAM_NO_ERROR;
+}
+
+enum caam_status caam_key_deserialize_from_bn(const struct bignum *inkey,
+					      struct caamkey *outkey,
+					      size_t size_sec)
+{
+	enum caam_status status = CAAM_FAILURE;
+	uint8_t *buf = NULL;
+	size_t size = 0;
+
+	assert(inkey && outkey);
+
+	KEY_TRACE("Deserialization bignum");
+
+	/* Get bignum size */
+	size = crypto_bignum_num_bytes((struct bignum *)inkey);
+
+	/* Allocate temporary buffer */
+	buf = caam_calloc(size);
+	if (!buf)
+		return CAAM_OUT_MEMORY;
+
+	/* Convert bignum to binary */
+	crypto_bignum_bn2bin(inkey, buf);
+
+	status = caam_key_deserialize_from_bin(buf, size, outkey, size_sec);
+
+	caam_key_dump("Output key", outkey);
+
+	caam_free(buf);
+
+	return status;
+}
+
+enum caam_status caam_key_serialize_to_bn(struct bignum *outkey,
+					  const struct caamkey *inkey)
+{
+	enum caam_status status = CAAM_FAILURE;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *buf = NULL;
+	size_t size = 0;
+
+	assert(inkey && outkey);
+
+	KEY_TRACE("Serialization bignum");
+	caam_key_dump("Input key", inkey);
+
+	status = caam_key_serialized_size(inkey, &size);
+	if (status)
+		return status;
+
+	buf = caam_calloc(size);
+	if (!buf)
+		return CAAM_OUT_MEMORY;
+
+	status = caam_key_serialize_to_bin(buf, size, inkey);
+	if (status)
+		goto out;
+
+	res = crypto_bignum_bin2bn(buf, size, outkey);
+	if (res)
+		status = CAAM_FAILURE;
+out:
+	caam_free(buf);
+
+	return status;
+}
+
+#define MAX_DESC_ENTRIES 22
+enum caam_status caam_key_black_encapsulation(struct caamkey *key,
+					      enum caam_key_type key_type)
+{
+	enum caam_status status = CAAM_FAILURE;
+	struct caambuf input_buf = { };
+	struct caam_jobctx jobctx = { };
+	uint32_t *desc = NULL;
+
+	assert(key);
+	assert(!key->is_blob && key->key_type == CAAM_KEY_PLAIN_TEXT);
+	assert(key_type != CAAM_KEY_PLAIN_TEXT);
+
+	KEY_TRACE("Black key encapsulation");
+
+	/* Copy input plain text key to temp buffer */
+	status = caam_calloc_align_buf(&input_buf, key->buf.length);
+	if (status)
+		return status;
+
+	memcpy(input_buf.data, key->buf.data, key->buf.length);
+	cache_operation(TEE_CACHEFLUSH, input_buf.data, input_buf.length);
+
+	/* Re-allocate the output key for black format */
+	caam_key_free(key);
+	key->key_type = key_type;
+
+	status = caam_key_alloc(key);
+	if (status)
+		goto out;
+
+	/* Allocate the descriptor */
+	desc = caam_calloc_desc(MAX_DESC_ENTRIES);
+	if (!desc) {
+		KEY_TRACE("Allocation descriptor error");
+		status = CAAM_OUT_MEMORY;
+		goto out;
+	}
+
+	caam_key_dump("Input key", key);
+
+	caam_desc_init(desc);
+	caam_desc_add_word(desc, DESC_HEADER(0));
+	caam_desc_add_word(desc, LD_KEY(CLASS_1, PKHA_E, key->sec_size));
+	caam_desc_add_ptr(desc, input_buf.paddr);
+
+	switch (key->key_type) {
+	case CAAM_KEY_BLACK_ECB:
+		caam_desc_add_word(desc, FIFO_ST(CLASS_NO, PKHA_E_AES_ECB_JKEK,
+						 key->sec_size));
+		break;
+	case CAAM_KEY_BLACK_CCM:
+		caam_desc_add_word(desc, FIFO_ST(CLASS_NO, PKHA_E_AES_CCM_JKEK,
+						 key->sec_size));
+		break;
+	default:
+		status = CAAM_FAILURE;
+		goto out;
+	}
+
+	caam_desc_add_ptr(desc, key->buf.paddr);
+
+	KEY_DUMPDESC(desc);
+
+	caam_key_cache_op(TEE_CACHEFLUSH, key);
+
+	jobctx.desc = desc;
+	status = caam_jr_enqueue(&jobctx, NULL);
+	if (status != CAAM_NO_ERROR) {
+		KEY_TRACE("CAAM return 0x%08x Status 0x%08" PRIx32, status,
+			  jobctx.status);
+		status = CAAM_FAILURE;
+		goto out;
+	}
+
+	caam_key_cache_op(TEE_CACHEINVALIDATE, key);
+
+	caam_key_dump("Output Key", key);
+
+out:
+	caam_free_buf(&input_buf);
+	caam_free_desc(&desc);
+
+	return status;
+}
+
+enum caam_status caam_key_init(void)
+{
+	size_t alloc_size = 0;
+	const struct caamkey key = {
+		.key_type = caam_key_default_key_gen_type(),
+		.sec_size = 4096, /* Max RSA key size */
+		.is_blob = true,
+	};
+
+	/*
+	 * Ensure bignum format maximum size is enough to store a black key
+	 * blob. The largest key is a 4096 bits RSA key pair.
+	 */
+	if (caam_key_serialized_size(&key, &alloc_size))
+		return CAAM_FAILURE;
+
+	assert(alloc_size <= CFG_CORE_BIGNUM_MAX_BITS);
+
+	KEY_TRACE("Max serialized key size %zu", alloc_size);
+
+	KEY_TRACE("Default CAAM key generation type %s",
+		  caam_key_type_to_str[caam_key_default_key_gen_type()]);
+
+	return CAAM_NO_ERROR;
+}

--- a/core/drivers/crypto/caam/caam_rng.c
+++ b/core/drivers/crypto/caam/caam_rng.c
@@ -174,7 +174,7 @@ static enum caam_status prepare_gen_desc(struct rngdata *rng)
 	caam_desc_init(desc);
 	caam_desc_add_word(desc, DESC_HEADER(0));
 	caam_desc_add_word(desc, op);
-	caam_desc_add_word(desc, FIFO_ST(RNG_TO_MEM, rng->size));
+	caam_desc_add_word(desc, FIFO_ST(CLASS_NO, RNG_TO_MEM, rng->size));
 	caam_desc_add_ptr(desc, paddr);
 
 	RNG_DUMPDESC(desc);

--- a/core/drivers/crypto/caam/crypto.mk
+++ b/core/drivers/crypto/caam/crypto.mk
@@ -145,6 +145,12 @@ CFG_NXP_CAAM_RSA_KEY_FORMAT ?= 3
 # Disable device tree status of the secure job ring
 CFG_CAAM_JR_DISABLE_NODE ?= y
 
+# Define the default CAAM private key encryption generation and the bignum
+# maximum size needed.
+# CAAM_KEY_PLAIN_TEXT    -> 4096 bits
+# CAAM_KEY_BLACK_ECB|CCM -> 4156 bits
+CFG_CORE_BIGNUM_MAX_BITS ?= 4156
+
 # Enable CAAM non-crypto drivers
 $(foreach drv, $(caam-drivers), $(eval CFG_NXP_CAAM_$(drv)_DRV ?= y))
 

--- a/core/drivers/crypto/caam/hash/caam_hash_mac.c
+++ b/core/drivers/crypto/caam/hash/caam_hash_mac.c
@@ -176,7 +176,8 @@ static TEE_Result do_hmac_init(struct crypto_mac_ctx *ctx, const uint8_t *inkey,
 	caam_desc_add_word(desc, HMAC_INIT_DECRYPT(alg->type));
 	caam_desc_add_word(desc, FIFO_LD_IMM(CLASS_2, MSG, LAST_C2, 0));
 	/* Store the split key */
-	caam_desc_add_word(desc, FIFO_ST(C2_MDHA_SPLIT_KEY_AES_ECB_JKEK,
+	caam_desc_add_word(desc, FIFO_ST(CLASS_NO,
+					 C2_MDHA_SPLIT_KEY_AES_ECB_JKEK,
 					 hmac_ctx->key.length));
 	caam_desc_add_ptr(desc, hmac_ctx->key.paddr);
 	HASH_DUMPDESC(desc);

--- a/core/drivers/crypto/caam/include/caam_desc_defines.h
+++ b/core/drivers/crypto/caam/include/caam_desc_defines.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2018-2021 NXP
+ * Copyright 2018-2021, 2023 NXP
  *
  * Brief   CAAM Descriptor defines.
  */
@@ -324,6 +324,26 @@
 #define PROT_RSA_KEY(format)	SHIFT_U32((PROT_RSA_KEY_##format) & 0x3, 0)
 #define PROT_RSA_KEY_ALL	0
 #define PROT_RSA_KEY_N_D	2
+
+#define PROT_RSA_FINISH_KEY_ENC_OUT(alg) PROT_RSA_FINISH_KEY_ENC_OUT_##alg
+#define PROT_RSA_FINISH_KEY_ENC_OUT_ECB	 BIT32(6)
+#define PROT_RSA_FINISH_KEY_ENC_OUT_CCM	 BIT32(6)
+
+#define PROT_RSA_FINISH_KEY_ENC(alg) PROT_RSA_FINISH_KEY_ENC_##alg
+#define PROT_RSA_FINISH_KEY_ENC_ECB  0
+#define PROT_RSA_FINISH_KEY_ENC_CCM  BIT32(4)
+
+#define PROT_RSA_FINISH_KEY(alg) PROT_RSA_FINISH_KEY_##alg
+#define PROT_RSA_FINISH_KEY_NONE 0
+#define PROT_RSA_FINISH_KEY_ECB (PROT_RSA_FINISH_KEY_ENC_OUT_ECB | \
+				 PROT_RSA_FINISH_KEY_ENC_ECB)
+#define PROT_RSA_FINISH_KEY_CCM (PROT_RSA_FINISH_KEY_ENC_OUT_CCM | \
+				 PROT_RSA_FINISH_KEY_ENC_CCM)
+
+#define PROT_RSA_KEY_ENC(format) SHIFT_U32((PROT_RSA_KEY_ENC_##format) & 0x3, 8)
+#define PROT_RSA_KEY_ENC_NONE	 0
+#define PROT_RSA_KEY_ENC_ECB	 1
+#define PROT_RSA_KEY_ENC_CCM	 3
 
 /*
  * ECC Protocol Information

--- a/core/drivers/crypto/caam/include/caam_desc_defines.h
+++ b/core/drivers/crypto/caam/include/caam_desc_defines.h
@@ -354,6 +354,16 @@
 #define PROT_PK_TYPE(type)	SHIFT_U32(PROT_PK_##type, 1)
 #define PROT_PK_DL		0
 #define PROT_PK_ECC		1
+#define PROT_PRI_ENC(alg)	PROT_PRI_ENC_##alg
+#define PROT_PRI_ENC_ECB	BIT32(2)
+#define PROT_PRI_ENC_CCM	BIT32(2)
+#define PROT_PRI_EXT(type)	PROT_PRI_EXT_##type
+#define PROT_PRI_EXT_ECB	0
+#define PROT_PRI_EXT_CCM	BIT32(4)
+#define PROT_PRI(alg)		PROT_PRI_##alg
+#define PROT_PRI_NONE		0
+#define PROT_PRI_ECB		(PROT_PRI_ENC(ECB) | PROT_PRI_EXT(ECB))
+#define PROT_PRI_CCM		(PROT_PRI_ENC(CCM) | PROT_PRI_EXT(CCM))
 
 /*
  * BLOB Protocol Information

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -491,8 +491,9 @@ static inline void dump_desc(uint32_t *desc)
 /*
  * RSA Finalize Key in format
  */
-#define RSA_FINAL_KEY(format)                                                  \
-	(CMD_OP_TYPE | PROTID(RSA_FINISH_KEY) | PROT_RSA_KEY(format))
+#define RSA_FINAL_KEY(format, alg)                                             \
+	(CMD_OP_TYPE | PROTID(RSA_FINISH_KEY) | PROT_RSA_KEY(format) |         \
+	 PROT_RSA_FINISH_KEY(alg))
 
 /*
  * Public Keypair generation

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -32,7 +32,7 @@ void caam_desc_add_dmaobj(uint32_t *desc, struct caamdmaobj *data,
 #define caam_desc_store(desc, data, cla, src)                                  \
 	caam_desc_add_dmaobj(desc, data, ST_NOIMM(cla, src, 0))
 #define caam_desc_fifo_store(desc, data, src)                                  \
-	caam_desc_add_dmaobj(desc, data, FIFO_ST(src, 0))
+	caam_desc_add_dmaobj(desc, data, FIFO_ST(CLASS_NO, src, 0))
 #define caam_desc_seq_out(desc, data)                                          \
 	caam_desc_add_dmaobj(desc, data, SEQ_OUT_PTR(0))
 
@@ -234,8 +234,9 @@ static inline void dump_desc(uint32_t *desc)
 /*
  * FIFO Store from register src of length len
  */
-#define FIFO_ST(src, len)                                                      \
-	(CMD_FIFO_STORE_TYPE | FIFO_STORE_OUTPUT(src) | FIFO_STORE_LENGTH(len))
+#define FIFO_ST(cla, src, len)                                                 \
+	(CMD_FIFO_STORE_TYPE | CMD_CLASS(cla) | FIFO_STORE_OUTPUT(src) |       \
+	 FIFO_STORE_LENGTH(len))
 
 /*
  * FIFO Store from register src.

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -519,9 +519,9 @@ static inline void dump_desc(uint32_t *desc)
 /*
  * DH/ECC Shared Secret
  */
-#define SHARED_SECRET(type)                                                    \
+#define SHARED_SECRET(type, alg)                                               \
 	(CMD_OP_TYPE | OP_TYPE(UNI) | PROTID(SHARED_SECRET) |                  \
-	 PROT_PK_TYPE(type))
+	 PROT_PK_TYPE(type) | PROT_PRI(alg))
 
 /*
  * Blob Master Key Verification

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -396,6 +396,12 @@ static inline void dump_desc(uint32_t *desc)
 	 KEY_LENGTH(len))
 
 /*
+ * Load a class cla key of length len to register dst.
+ */
+#define LD_KEY(cla, dst, len)                                                  \
+	(CMD_KEY_TYPE | CMD_CLASS(cla) | KEY_DEST(dst) | KEY_LENGTH(len))
+
+/*
  * MPPRIVK generation function.
  */
 #define MPPRIVK (CMD_OP_TYPE | OP_TYPE(ENCAPS) | PROTID(MPKEY))

--- a/core/drivers/crypto/caam/include/caam_desc_helper.h
+++ b/core/drivers/crypto/caam/include/caam_desc_helper.h
@@ -498,15 +498,16 @@ static inline void dump_desc(uint32_t *desc)
 /*
  * Public Keypair generation
  */
-#define PK_KEYPAIR_GEN(type)                                                   \
-	(CMD_OP_TYPE | OP_TYPE(UNI) | PROTID(PKKEY) | PROT_PK_TYPE(type))
+#define PK_KEYPAIR_GEN(type, alg)                                              \
+	(CMD_OP_TYPE | OP_TYPE(UNI) | PROTID(PKKEY) | PROT_PK_TYPE(type) |     \
+	 PROT_PRI(alg))
 
 /*
  * DSA/ECDSA signature of message of msg_type
  */
-#define DSA_SIGN(type, msg_type)                        \
+#define DSA_SIGN(type, msg_type, alg) \
 	(CMD_OP_TYPE | OP_TYPE(UNI) | PROTID(DSASIGN) | \
-	 PROT_PK_MSG(msg_type) | PROT_PK_TYPE(type))
+	 PROT_PK_MSG(msg_type) | PROT_PK_TYPE(type) | PROT_PRI(alg))
 
 /*
  * DSA/ECDSA signature verify message of msg_type

--- a/core/drivers/crypto/caam/include/caam_key.h
+++ b/core/drivers/crypto/caam/include/caam_key.h
@@ -1,0 +1,155 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2023 NXP
+ */
+#ifndef __CAAM_KEY_H__
+#define __CAAM_KEY_H__
+
+#include <caam_types.h>
+#include <crypto/crypto.h>
+#include <types_ext.h>
+
+/*
+ * CAAM Key types
+ */
+enum caam_key_type {
+	CAAM_KEY_PLAIN_TEXT = 0, /* Plain text key or red key */
+	CAAM_KEY_BLACK_ECB, /* Black key AES-ECB encrypted */
+	CAAM_KEY_BLACK_CCM, /* Black key AES-CCM encrypted */
+	CAAM_KEY_MAX_VALUE, /* Max value - not valid */
+};
+
+/*
+ * CAAM key structure
+ */
+struct caamkey {
+	struct caambuf buf; /* Key buffer */
+	enum caam_key_type key_type; /* CAAM Key type */
+	size_t sec_size; /* Security key size */
+	bool is_blob; /* Shows if the key is in blob format */
+};
+
+/*
+ * Returns the default key type for CAAM key generation.
+ * The CAAM can only generate one key type.
+ */
+static inline enum caam_key_type caam_key_default_key_gen_type(void)
+{
+	return CAAM_KEY_BLACK_CCM;
+}
+
+/*
+ * Print CAAM Key structure
+ *
+ * @trace Additional log string
+ * @key Key to print
+ */
+void caam_key_dump(const char *trace, const struct caamkey *key);
+
+/*
+ * Allocate CAAM key buffer based on the CAAM key type, key security size, and
+ * whether it is in a blob format or not.
+ *
+ * @key CAAM key to allocate
+ */
+enum caam_status caam_key_alloc(struct caamkey *key);
+
+/*
+ * Free the CAAM key buffer
+ *
+ * @key CAAM key to free
+ */
+void caam_key_free(struct caamkey *key);
+
+/*
+ * Perform a cache operation on CAAM key buffer.
+ *
+ * @op Cache operation type
+ * @key CAAM key buffer to operate
+ */
+void caam_key_cache_op(enum utee_cache_operation op, const struct caamkey *key);
+
+/*
+ * Encapsulate or decapsulate the given CAAM key
+ *
+ * @in_key CAAM Key to encapsulate or decapsulate
+ * @out_key CAAM Key operation result. The out_key is allocated by the function.
+ */
+enum caam_status caam_key_operation_blob(const struct caamkey *in_key,
+					 struct caamkey *out_key);
+
+/*
+ * Deserialize CAAM key structure from binary buffer
+ *
+ * @data	Buffer input
+ * @size	Buffer input size
+ * @key		CAAM key structure to populate
+ * @sec_size	Security key size to deserialize, optional. If not needed,
+ *		set it to 0.
+ */
+enum caam_status caam_key_deserialize_from_bin(uint8_t *data, size_t size,
+					       struct caamkey *key,
+					       size_t sec_size);
+
+/*
+ * Serialize CAAM key structure to binary buffer
+ *
+ * @data	Buffer output
+ * @size	Buffer output size
+ * @key		CAAM key structure to serialize
+ */
+enum caam_status caam_key_serialize_to_bin(uint8_t *data, size_t size,
+					   const struct caamkey *key);
+
+/*
+ * Deserialize CAAM key structure from bignum
+ *
+ * @inkey	Bignum input
+ * @outkey	CAAM key structure to populate
+ * @size_sec	Security key size to deserialize, optional. If not needed,
+ *		set it to zero.
+ */
+enum caam_status caam_key_deserialize_from_bn(const struct bignum *inkey,
+					      struct caamkey *outkey,
+					      size_t size_sec);
+
+/*
+ * Serialize CAAM key structure to bignum
+ *
+ * @outkey	Bignum output
+ * @inkey	CAAM key structure to serialize
+ */
+enum caam_status caam_key_serialize_to_bn(struct bignum *outkey,
+					  const struct caamkey *inkey);
+
+/*
+ * Return the key buffer size needed given the CAAM key type, key security size,
+ * and whether it is in a blob format or not
+ *
+ * @key	CAAM key structure input
+ */
+size_t caam_key_get_alloc_size(const struct caamkey *key);
+
+/*
+ * Return the buffer size needed to serialize the given CAAM key structure
+ *
+ * @key		CAAM Key structure to serialize
+ * @size	returned buffer size
+ */
+enum caam_status caam_key_serialized_size(const struct caamkey *key,
+					  size_t *size);
+
+/*
+ * Encapsulate a plain text key to CAAM black key.
+ *
+ * @key		CAAM key to encapsulate
+ * @key_type	CAAM key encapsulation type
+ */
+enum caam_status caam_key_black_encapsulation(struct caamkey *key,
+					      enum caam_key_type key_type);
+
+/*
+ * CAAM Key initialization
+ */
+enum caam_status caam_key_init(void);
+#endif /* __CAAM_KEY_H__ */

--- a/core/drivers/crypto/caam/include/caam_trace.h
+++ b/core/drivers/crypto/caam/include/caam_trace.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2019-2021 NXP
+ * Copyright 2019-2021, 2023 NXP
  *
  * Brief   CAAM driver trace include file.
  *         Definition of the internal driver trace macros.
@@ -42,6 +42,7 @@
 #define DBG_TRACE_DSA	 BIT32(14) /* DSA trace */
 #define DBG_TRACE_MP	 BIT32(15) /* MP trace */
 #define DBG_TRACE_SM	 BIT32(16) /* Secure Memory trace */
+#define DBG_TRACE_KEY	 BIT32(17) /* KEY trace */
 
 /* HAL */
 #if CAAM_DBG_TRACE(HAL)
@@ -278,6 +279,29 @@
 #define MP_TRACE(...) do { } while (0)
 #define MP_DUMPDESC(desc)
 #define MP_DUMPBUF(...)
+#endif
+
+/* KEY */
+#if CAAM_DBG_TRACE(KEY)
+#define KEY_TRACE DRV_TRACE
+#if CAAM_DBG_DESC(KEY)
+#define KEY_DUMPDESC(desc)			\
+	do {					\
+		KEY_TRACE("KEY Descriptor");	\
+		DRV_DUMPDESC(desc);		\
+	} while (0)
+#else
+#define KEY_DUMPDESC(desc)
+#endif
+#if CAAM_DBG_BUF(KEY)
+#define KEY_DUMPBUF DRV_DUMPBUF
+#else
+#define KEY_DUMPBUF(...)
+#endif
+#else
+#define KEY_TRACE(...) do { } while (0)
+#define KEY_DUMPDESC(desc) do { } while (0)
+#define KEY_DUMPBUF(...) do { } while (0)
 #endif
 
 #if (TRACE_LEVEL >= TRACE_DEBUG)

--- a/core/drivers/crypto/caam/include/caam_trace.h
+++ b/core/drivers/crypto/caam/include/caam_trace.h
@@ -240,7 +240,7 @@
 #if CAAM_DBG_DESC(DSA)
 #define DSA_DUMPDESC(desc)                                                     \
 	do {                                                                   \
-		MP_TRACE("DSA Descriptor");                                    \
+		DSA_TRACE("DSA Descriptor");                                   \
 		DRV_DUMPDESC(desc);                                            \
 	} while (0)
 #else

--- a/core/drivers/crypto/caam/include/caam_utils_status.h
+++ b/core/drivers/crypto/caam/include/caam_utils_status.h
@@ -7,6 +7,7 @@
 #ifndef __CAAM_UTILS_STATUS_H__
 #define __CAAM_UTILS_STATUS_H__
 
+#include <caam_status.h>
 #include <stdint.h>
 #include <tee_api_types.h>
 

--- a/core/drivers/crypto/caam/sub.mk
+++ b/core/drivers/crypto/caam/sub.mk
@@ -9,6 +9,7 @@ srcs-y += caam_jr.c
 srcs-y += caam_rng.c
 srcs-y += caam_desc.c
 srcs-$(CFG_NXP_CAAM_SM_DRV) += caam_sm.c
+srcs-y += caam_key.c
 subdirs-$(call cfg-one-enabled, CFG_NXP_CAAM_HASH_DRV CFG_NXP_CAAM_HMAC_DRV) += hash
 subdirs-$(call cfg-one-enabled, CFG_NXP_CAAM_CIPHER_DRV CFG_NXP_CAAM_CMAC_DRV) += cipher
 subdirs-y += acipher

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -703,13 +703,6 @@ CFG_CORE_LARGE_PHYS_ADDR ?= n
 # Set this to a lower value to reduce the TA memory footprint.
 CFG_TA_BIGNUM_MAX_BITS ?= 2048
 
-# Define the maximum size, in bits, for big numbers in the TEE core (privileged
-# layer).
-# This value is an upper limit for the key size in any cryptographic algorithm
-# implemented by the TEE core.
-# Set this to a lower value to reduce the memory footprint.
-CFG_CORE_BIGNUM_MAX_BITS ?= 4096
-
 # Not used since libmpa was removed. Force the values to catch build scripts
 # that would set = n.
 $(call force,CFG_TA_MBEDTLS_MPI,y)


### PR DESCRIPTION
# CAAM Black/Blob support in OPTEE

## CAAM Black key overview
The CAAM provides a key encapsulation mechanism called Black key. This is a protection of user keys against bus snooping attacks when the keys are being written or read from external memory (outside the SoC). The black key mechanism encapsulates/decapsulates keys on the fly in an encrypted data structure called a black key. Before copying the plain text key to memory, the CAAM automatically encrypts the key in the black key format using a key encryption key. This key encryption key is called JDKEK - Job ring descriptor key encryption key.

## CAAM Black key types
There are two different black key formats
 - AES-ECB : The key is encrypted using AES-ECB. The resulting black key will a multiple of 16 bytes. => AES-ECB(plain text key + zero padding)
 - AES-CCM : The key is encrypted using AES-CCM (slower than ECB). This format also includes a MAC to ensure integrity and authenticity. This black key is at least 12 bytes longer than the plain text key. Key modulo(8 bytes) + 6 bytes nonce + 6 bytes ICV => AES-CCM(plain text key + zero padding + nonce) + ICV

Please note that in the CAAM context, a plain text key is called a Red key.
The CAAM driver requires the user to specify the given key type in the job descriptor. The CAAM cannot tell if the key given is Red or Black-ECB/CCM.
Once encapsulated, a black key cannot be decapsulated to memory. The CAAM will prevent any Black key to plain text key in memory operation. A black key can only be decapsulated to CAAM key registers.

## JDKEK
Each job ring has its own key encryption key to encapsulate keys into black key format. This key is randomly re-generated upon each reset. The black key encapsulation is modified via the appropriate Trustzone status and SDID value. With this, each domain has its own black keys and cannot use black keys generated by other domains. When the CAAM is instructed to use a black key, the CAAM automatically decrypts the incoming black key in its own key register to do the crypto operations.
JDKEK has a limited lifetime, and it is re-generated (randomly) upon each power cycle (reset, suspend/resume). A black key generated in a power cycle will be unusable after the next power cycle.
Please note that trusted descriptor key encryption keys - TDKEK can also be used to encapsulate black keys, but this is not supported in this PR.

## Black blobs
To retain encrypted keys across power cycles, the CAAM is able to encrypt keys using a secure non-volatile key encryption key. This non-volatile KEK is device specific and cannot be extracted from the device. The non-volatile KEK is derived from the device master key. There are several methods to define the master key.
Black blobs provide confidentiality and integrity protection, and keys can be stored in a long-term storage. To make a black key power cycle proof, the CAAM generates a random blob key to encrypt the black key. This random blob key is then encrypted with the non-volatile Blob KEK.

A black key can be encapsulated into a black blob, and a black blob can be decapsulated to a black key (in memory) or plain text key (CAAM key registers).
```

                                                                BKEK
                                                                  │
                                                                  ▼
                                                            ┌────────────┐
                                                            │ AES-ECB    │
                     JDKEK or               RNG ───────────►│ Encryption │
                       TDKEK                 │              └─────┬──────┘
                         │                   │ Blob key           │
                         │                   │                    ▼
                         │                   │              ┌────────────┐
                         ▼                   ▼              │  Key blob  │
                  ┌─────────────┐      ┌────────────┐       ├────────────┤
┌───────────┐     │ AES-ECB/CCM │      │ AES-CCM    │       │            │
│ Black key ├────►│  Decryption ├─────►│ Encryption ├──────►│ Data blob  │
└───────────┘     └─────────────┘      └──────────┬─┘       │            │
                                                  │         │            │
                                                  │         ├────────────┤
                                                  └────────►│   MAC      │
                                                            └────────────┘
```

# CAAM Black key/blob in OPTEE

## Pull-request overview
This PR aims at adding the support of Black key/blob to CAAM asymmetric cryptographic operations. The key generation and the cryptographic operations being linked by the same API vectors, the support for asymmetric crypto does not require modification in the OPTEE core.
This PR also provides to the CAAM driver the ability to handle plain text keys and black keys. Indeed, the CAAM driver is able to use a previously generated black key or a plain text key given by the user as an input.
Please note that, in the case of asymmetric keys, only the private part of the key pair is encapsulated as a black key/blob.

## Black key supported formats
This PR adds the support for AES-ECB and AES-CCM black keys. Only one key generation format is supported at the same time. It must be chosen at compilation. It defines the default format for CAAM key generation.
There are 3 formats available:
 - Plain text
 - AES-ECB
 - AES-CCM
Even if the CAAM supports only one key generation format by default, the CAAM is still able to use any key format (plain text, AES-ECB/CCM ...) for its crypto operations.

I would advise sticking to AES-CCM. It provides better security, adds authenticity and performance regarding the black key encapsulation/decapsulation are similar to AES-ECB.

Because a cryptographic key pair is a TEE object and can be saved in persistent memory at any time, private key pairs will always be stored as a black blob (which is power cycle proof).
```
┌─────────────────────────┐
│                         │
│   CAAM Key generation   ├──────────────►   Key format defined by `caam_key_default_key_gen_type()`
│                         │
└─────────────────────────┘

┌─────────────────────────┐
│                         │
│  CAAM Crypto operations │◄──────────────   Plain text key, black key ECB, CCM, ...
│                         │
└─────────────────────────┘
```

## How to handle both Black keys and plain text keys?
Along the key data, a header with some metadata must be added to tell the CAAM how to handle the incoming key.
Metadata:
 - Magic number (32 bits): a magic number the CAAM driver can detect on the first 32 bits of the key buffer is needed. If a magic number is detected, the key is a black key generated by the CAAM. If not, this is a plain text key.
 - Key type (32 bits): specify the CAAM black key type. This info is needed by the CAAM for the black key decapsulation.
 - Key security size (32 bits): this is the security key size of the black key. This is different from the actual buffer key size. This info is needed by the CAAM for the black key decapsulation.

When generating a key pair, the CAAM driver encapsulates the generated private key in the following format `struct caam_key_serialized {}` :

```
Black blob key generated by the CAAM:
+-----------------------------------------------------+
| MAGIC number - 0xCAAFBFFB (32 bits)                 |
+-----------------------------------------------------+
| Key type (if magic number is present)               |
| -  CAAM_KEY_PLAIN_TEXT                              |
| -  CAAM_KEY_BLACK_ECB                               |
| -  CAAM_KEY_BLACK_CCM                               |
+-----------------------------------------------------+
| Plain text key size (if magic number is present)    |
+-----------------------------------------------------+
| Black blob                                          |
+-----------------------------------------------------+
```

```
Regular key generated by the CAAM:
+-----------------------------------------------------+
| Plain text data                                     |
+-----------------------------------------------------+
```

## Black blobs as a bignum in OPTEE core
Because a black key or blob is always bigger than the original plain text key size, the maximum bignum size must be increased. This is especially true for RSA-4096 key pair. `CFG_CORE_BIGNUM_MAX_BITS` value must be increased accordingly.

The private part of the key pair can be any size : the OPTEE core does not rely on the buffer size of the private key to determine the key pair size. The CAAM black key size overhead is not a problem for asymmetric crypto.

## Supported algos?
This PR adds the black key/blob support for the following algorithms:
 - DH
 - DSA
 - RSA
 - ECC
The CAAM directly outputs the private part of the key pair encapsulated in a black key format. The plain text private key is never exposed in the memory.
Note for RSA: currently, the RSA key pair generation CAAM function outputs the private part of the key pair in plain text format to memory. The plain text private key is manually encapsulated as a black key right after key pair generation. This will be solved in the future with the support of CAAM internal secure memory.
For the other algorithms, the key generation operations directly output the private key part in a black format.

## What about the support for symmetric algos?
The black key support for symmetric algos is another story and will most likely require changes in OPTEE Core. There are multiples obstacles:

 1. **The key buffer size is not equal to the key security size.**
 In the case of an encapsulated symmetric key, the actual key buffer size does not reflect the actual security key size. For the CAAM, a 256 bits key requires at least a 640 bits buffer to encapsulate the key as a black blob.
 An HW crypto driver could also refer to key IDs if it has its own keystore/internal memory (like the SE050).

 One way to work around this core/GP limitation would be to have a crypto HW driver callback that returns the actual security key size of the given encapsulated key. This way, the OPTEE core would ask the HW crypto driver for its key size checks ... If such callback is not implemented by the HW driver, the core would rely on the buffer size to determine the security key size.

 2.**The black key generation cannot be done through TEE Crypto API**
 There is no clean way to specify the crypto HW driver the type of key to generate. Going through `TEE_GenerateKey()` would require to add new `TEE_TYPE_...` like `TEE_TYPE_AES_BLACK_KEY` or something ... which is not very GP compliant.
 The only way to generate black keys would be a PTA.

Feel free to ask questions.

Regards,
Clement