### PR TITLE
crypto: se050: compare symmetric keys in constant time

### DIFF
--- a/core/drivers/crypto/se050/adaptors/apis/sss.c
+++ b/core/drivers/crypto/se050/adaptors/apis/sss.c
@@ -9,6 +9,7 @@
 #include <se050.h>
 #include <se050_utils.h>
 #include <string.h>
+#include <string_ext.h>
 
 static const sss_policy_u asym_key = {
 	.type = KPolicy_Asym_Key,
@@ -94,9 +95,9 @@ sss_status_t se050_rotate_scp03_keys(struct sss_se05x_ctx *ctx)
 			 new_keys.enc, SE050_SCP03_KEY_SZ);
 	}
 
-	if (!memcmp(new_keys.enc, cur_keys.enc, SE050_SCP03_KEY_SZ) &&
-	    !memcmp(new_keys.mac, cur_keys.mac, SE050_SCP03_KEY_SZ) &&
-	    !memcmp(new_keys.dek, cur_keys.dek, SE050_SCP03_KEY_SZ))
+	if (!consttime_memcmp(new_keys.enc, cur_keys.enc, SE050_SCP03_KEY_SZ) &&
+	    !consttime_memcmp(new_keys.mac, cur_keys.mac, SE050_SCP03_KEY_SZ) &&
+	    !consttime_memcmp(new_keys.dek, cur_keys.dek, SE050_SCP03_KEY_SZ))
 		return kStatus_SSS_Success;
 
 	connect_ctx = &ctx->open_ctx;


### PR DESCRIPTION
Symmetric keys should be compared in constant time to protect against side channel attacks.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
