### PR TITLE
drivers: i2c: fix fdt_xxx() function label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
           _make PLATFORM=rockchip-rk322x
           _make PLATFORM=rockchip-rk3399
           _make PLATFORM=sam
+          _make PLATFORM=sam-sama5d27_wlsom1_ek
           _make PLATFORM=marvell-armada7k8k
           _make PLATFORM=marvell-armada3700
           _make PLATFORM=marvell-otx2t96

--- a/core/drivers/i2c/atmel_i2c.c
+++ b/core/drivers/i2c/atmel_i2c.c
@@ -302,7 +302,7 @@ static TEE_Result atmel_i2c_node_probe(const void *fdt, int node,
 	struct i2c_ctrl *i2c_ctrl = NULL;
 	struct atmel_i2c *atmel_i2c = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
-	int status = _fdt_get_status(fdt, node);
+	int status = fdt_get_status(fdt, node);
 
 	if (status != DT_STATUS_OK_SEC)
 		return TEE_SUCCESS;

--- a/core/drivers/i2c/i2c.c
+++ b/core/drivers/i2c/i2c.c
@@ -17,7 +17,7 @@ struct i2c_dev *i2c_create_dev(struct i2c_ctrl *i2c_ctrl, const void *fdt,
 			       int node)
 {
 	struct i2c_dev *i2c_dev = NULL;
-	paddr_t addr = _fdt_reg_base_address(fdt, node);
+	paddr_t addr = fdt_reg_base_address(fdt, node);
 
 	if (addr == DT_INFO_INVALID_REG)
 		return NULL;


### PR DESCRIPTION
Fixes I2C bus driver and atmle_i2c driver regarding function fdt_reg_base_address() and fdt_get_status() labels change in commit [1].

Fixes: f354a5d8f98e ("core: replace _fdt_ prefix with fdt_ for device tree API")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
