### PR TITLE
core: dt_driver: move related content from dt.h to dt_driver.h

### DIFF
--- a/core/arch/arm/plat-sam/sam_sfr.c
+++ b/core/arch/arm/plat-sam/sam_sfr.c
@@ -7,6 +7,7 @@
 
 #include <io.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <matrix.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>

--- a/core/drivers/atmel_piobu.c
+++ b/core/drivers/atmel_piobu.c
@@ -12,6 +12,7 @@
 #include <io.h>
 #include <kernel/boot.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/pm.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>

--- a/core/drivers/atmel_rstc.c
+++ b/core/drivers/atmel_rstc.c
@@ -6,6 +6,7 @@
 #include <drivers/atmel_rstc.h>
 #include <io.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <matrix.h>
 #include <sama5d2.h>
 #include <tee_api_defines.h>

--- a/core/drivers/atmel_rtc.c
+++ b/core/drivers/atmel_rtc.c
@@ -10,6 +10,7 @@
 #include <drivers/rtc.h>
 #include <io.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <matrix.h>
 #include <mm/core_memprot.h>
 #include <sama5d2.h>

--- a/core/drivers/atmel_shdwc.c
+++ b/core/drivers/atmel_shdwc.c
@@ -10,6 +10,7 @@
 #include <drivers/pm/sam/atmel_pm.h>
 #include <io.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/thread.h>
 #include <libfdt.h>
 #include <matrix.h>

--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -10,6 +10,7 @@
 #include <io.h>
 #include <kernel/delay.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/pm.h>
 #include <matrix.h>
 #include <sama5d2.h>

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -14,6 +14,7 @@
 #include <io.h>
 #include <keep.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/boot.h>
 #include <kernel/panic.h>
 #include <kernel/spinlock.h>

--- a/core/drivers/crypto/stm32/authenc.c
+++ b/core/drivers/crypto/stm32/authenc.c
@@ -10,7 +10,6 @@
 #include <drvcrypt.h>
 #include <drvcrypt_authenc.h>
 #include <initcall.h>
-#include <kernel/dt.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string_ext.h>

--- a/core/drivers/crypto/stm32/cipher.c
+++ b/core/drivers/crypto/stm32/cipher.c
@@ -8,7 +8,6 @@
 #include <crypto/crypto_impl.h>
 #include <drvcrypt.h>
 #include <drvcrypt_cipher.h>
-#include <kernel/dt.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tee_api_types.h>

--- a/core/drivers/crypto/stm32/stm32_cryp.c
+++ b/core/drivers/crypto/stm32/stm32_cryp.c
@@ -12,6 +12,7 @@
 #include <kernel/boot.h>
 #include <kernel/delay.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/mutex.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>

--- a/core/drivers/i2c/atmel_i2c.c
+++ b/core/drivers/i2c/atmel_i2c.c
@@ -8,6 +8,7 @@
 #include <drivers/clk_dt.h>
 #include <drivers/i2c.h>
 #include <io.h>
+#include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <libfdt.h>
 #include <matrix.h>

--- a/core/drivers/i2c/i2c.c
+++ b/core/drivers/i2c/i2c.c
@@ -5,7 +5,6 @@
 
 #include <drivers/i2c.h>
 #include <kernel/dt.h>
-#include <kernel/dt_driver.h>
 #include <libfdt.h>
 #include <malloc.h>
 #include <tee_api_defines_extensions.h>

--- a/core/drivers/imx_lpuart.c
+++ b/core/drivers/imx_lpuart.c
@@ -8,6 +8,7 @@
 #include <io.h>
 #include <keep.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <util.h>
 
 #define STAT		0x14

--- a/core/drivers/imx_uart.c
+++ b/core/drivers/imx_uart.c
@@ -32,6 +32,7 @@
 #include <io.h>
 #include <keep.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <util.h>
 
 /* Register definitions */

--- a/core/drivers/pl011.c
+++ b/core/drivers/pl011.c
@@ -7,6 +7,7 @@
 #include <io.h>
 #include <keep.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <stdlib.h>
 #include <trace.h>
 #include <types_ext.h>

--- a/core/drivers/rstctrl/rstctrl.c
+++ b/core/drivers/rstctrl/rstctrl.c
@@ -6,8 +6,6 @@
 #include <assert.h>
 #include <drivers/rstctrl.h>
 #include <io.h>
-#include <kernel/dt.h>
-#include <kernel/dt_driver.h>
 #include <kernel/spinlock.h>
 #include <libfdt.h>
 #include <stdint.h>

--- a/core/drivers/rstctrl/stm32_rstctrl.c
+++ b/core/drivers/rstctrl/stm32_rstctrl.c
@@ -10,6 +10,7 @@
 #include <io.h>
 #include <kernel/delay.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <stm32_util.h>

--- a/core/drivers/serial8250_uart.c
+++ b/core/drivers/serial8250_uart.c
@@ -8,8 +8,9 @@
 #include <drivers/serial8250_uart.h>
 #include <io.h>
 #include <keep.h>
-#include <util.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <util.h>
 
 /* uart register defines */
 #define UART_RHR	0x0

--- a/core/drivers/stm32_iwdg.c
+++ b/core/drivers/stm32_iwdg.c
@@ -13,6 +13,7 @@
 #include <kernel/boot.h>
 #include <kernel/delay.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>

--- a/core/drivers/stm32_tamp.c
+++ b/core/drivers/stm32_tamp.c
@@ -8,6 +8,7 @@
 #include <drivers/stm32_tamp.h>
 #include <io.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/interrupt.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -6,7 +6,6 @@
 #ifndef __DRIVERS_CLK_DT_H
 #define __DRIVERS_CLK_DT_H
 
-#include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <scattered_array.h>
 #include <stdint.h>

--- a/core/include/drivers/i2c.h
+++ b/core/include/drivers/i2c.h
@@ -6,7 +6,6 @@
 #ifndef __DRIVERS_I2C_H
 #define __DRIVERS_I2C_H
 
-#include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <libfdt.h>
 #include <tee_api_types.h>

--- a/core/include/drivers/rstctrl.h
+++ b/core/include/drivers/rstctrl.h
@@ -6,7 +6,6 @@
 #ifndef __DRIVERS_RSTCTRL_H
 #define __DRIVERS_RSTCTRL_H
 
-#include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <stdint.h>
 #include <tee_api_types.h>

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -62,14 +62,6 @@ struct dt_device_match {
 	const void *compat_data;
 };
 
-enum dt_driver_type {
-	DT_DRIVER_NOTYPE,
-	DT_DRIVER_UART,
-	DT_DRIVER_CLK,
-	DT_DRIVER_RSTCTRL,
-	DT_DRIVER_I2C,
-};
-
 /*
  * DT_MAP_AUTO: Uses status properties from device tree to determine mapping.
  * DT_MAP_SECURE: Force mapping for device to be secure.
@@ -81,42 +73,7 @@ enum dt_map_dev_directive {
 	DT_MAP_NON_SECURE
 };
 
-/*
- * dt_driver_probe_func - Callback probe function for a driver.
- *
- * @fdt: FDT base address
- * @nodeoffset: Offset of the node in the FDT
- * @compat_data: Data registered for the compatible that probed the device
- *
- * Return TEE_SUCCESS on successful probe,
- *	TEE_ERROR_DEFER_DRIVER_INIT if probe must be deferred
- *	TEE_ERROR_ITEM_NOT_FOUND when no driver matched node's compatible string
- *	Any other TEE_ERROR_* compliant code.
- */
-typedef TEE_Result (*dt_driver_probe_func)(const void *fdt, int nodeoffset,
-					   const void *compat_data);
-
-#if defined(CFG_DT)
-/*
- * Driver instance registered to be probed on compatible node found in the DT.
- *
- * @name: Driver name
- * @type: Drive type
- * @match_table: Compatible matching identifiers, null terminated
- * @driver: Driver private reference or NULL
- * @probe: Probe callback (see dt_driver_probe_func) or NULL
- */
-struct dt_driver {
-	const char *name;
-	enum dt_driver_type type;
-	const struct dt_device_match *match_table; /* null-terminated */
-	const void *driver;
-	TEE_Result (*probe)(const void *fdt, int node, const void *compat_data);
-};
-
-#define DEFINE_DT_DRIVER(name) \
-		SCATTERED_ARRAY_DEFINE_PG_ITEM(dt_drivers, struct dt_driver)
-
+#ifdef CFG_DT
 /*
  * Find a driver that is suitable for the given DT node, that is, with
  * a matching "compatible" property.
@@ -347,10 +304,4 @@ static inline int fdt_get_reg_props_by_name(const void *fdt __unused,
 }
 
 #endif /* !CFG_DT */
-
-#define for_each_dt_driver(drv) \
-	for (drv = SCATTERED_ARRAY_BEGIN(dt_drivers, struct dt_driver); \
-	     drv < SCATTERED_ARRAY_END(dt_drivers, struct dt_driver); \
-	     drv++)
-
 #endif /* KERNEL_DT_H */

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -7,6 +7,7 @@
 #include <console.h>
 #include <drivers/serial.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/boot.h>
 #include <kernel/panic.h>
 #include <libfdt.h>

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/interrupt.h>
 #include <kernel/linker.h>
 #include <libfdt.h>

--- a/core/kernel/dt_driver_test.c
+++ b/core/kernel/dt_driver_test.c
@@ -13,7 +13,6 @@
 #include <drivers/clk_dt.h>
 #include <drivers/rstctrl.h>
 #include <initcall.h>
-#include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <libfdt.h>
 #include <malloc.h>


### PR DESCRIPTION
Moves so-called dt_driver related declarations and definitions from dt.h to dt_drivers.h. Incidentally adds an inline description to enum dt_driver_type. This change clarifies when a source file shall include dt.h and/or dt_driver.h.

This change updates driver source files to include none, one or both of these header files where applicable.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
