### PR TITLE
core: riscv: kernel: Fix compilation error with missing parameter

### DIFF
--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -105,7 +105,8 @@ void boot_init_primary_early(unsigned long pageable_part __unused,
 	init_primary(e);
 }
 
-void boot_init_primary_late(unsigned long fdt __unused)
+void boot_init_primary_late(unsigned long fdt __unused,
+			    unsigned long tos_fw_config __unused)
 {
 	IMSG("OP-TEE version: %s", core_v_str);
 	if (IS_ENABLED(CFG_WARN_INSECURE)) {


### PR DESCRIPTION
This patch adds "unsigned long tos_fw_config" as second parameter for RISC-V's boot_init_primary_late() to solve compilation error.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
