### PR TITLE
core: riscv: Fix macro for inline assembly

### DIFF
--- a/core/arch/riscv/include/encoding.h
+++ b/core/arch/riscv/include/encoding.h
@@ -316,37 +316,6 @@
 #define RISCV_PGSHIFT 12
 #define RISCV_PGSIZE (1 << RISCV_PGSHIFT)
 
-#ifndef __ASSEMBLER__
-
-#ifdef __GNUC__
-
-#define read_csr(reg) ({ unsigned long __tmp; \
-  asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
-  __tmp; })
-
-#define write_csr(reg, val) ({ \
-  asm volatile ("csrw " #reg ", %0" :: "rK"(val)); })
-
-#define swap_csr(reg, val) ({ unsigned long __tmp; \
-  asm volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val)); \
-  __tmp; })
-
-#define set_csr(reg, bit) ({ unsigned long __tmp; \
-  asm volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
-  __tmp; })
-
-#define clear_csr(reg, bit) ({ unsigned long __tmp; \
-  asm volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
-  __tmp; })
-
-#define rdtime() read_csr(time)
-#define rdcycle() read_csr(cycle)
-#define rdinstret() read_csr(instret)
-
-#endif
-
-#endif
-
 #endif
 
 #endif

--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -80,6 +80,46 @@
 
 #ifndef __ASSEMBLER__
 
+#define read_csr(csr)							\
+	({								\
+		unsigned long __tmp;					\
+		asm volatile ("csrr %0, %1" : "=r"(__tmp) : "i"(csr));	\
+		__tmp;							\
+	})
+
+#define write_csr(csr, val)						\
+	({								\
+		asm volatile ("csrw %0, %1" : : "i"(csr), "rK"(val));	\
+	})
+
+#define swap_csr(csr, val)						\
+	({								\
+		unsigned long __tmp;					\
+		asm volatile ("csrrw %0, %1, %2"			\
+			      : "=r"(__tmp) : "i"(csr), "rK"(val));	\
+		__tmp;							\
+	})
+
+#define set_csr(csr, bit)						\
+	({								\
+		unsigned long __tmp;					\
+		asm volatile ("csrrs %0, %1, %2"			\
+			      : "=r"(__tmp) : "i"(csr), "rK"(bit));	\
+		__tmp;							\
+	})
+
+#define clear_csr(csr, bit)						\
+	({								\
+		unsigned long __tmp;					\
+		asm volatile ("csrrc %0, %1, %2"			\
+			      : "=r"(__tmp) : "i"(csr), "rK"(bit));	\
+		__tmp;							\
+	})
+
+#define rdtime() read_csr(CSR_TIME)
+#define rdcycle() read_csr(CSR_CYCLE)
+#define rdinstret() read_csr(CSR_INSTRET)
+
 static inline __noprof void mb(void)
 {
 	asm volatile ("fence" : : : "memory");


### PR DESCRIPTION
The "CSR_XXX" definitions are not only used for pure assembly code, but also used for inline assembly in C code. But using SHIFT_U64() in inline assembly will lead to compilation error, since this macro casts value to (uint64_t) first.

For example, "read_csr(CSR_XSTATUS)" will be expanded by pre-processor as "csrr a5,(((uint64_t)(1)<<(8))|0x000)", which is not acceptable for assembly language.

Fix this by using UINT64_C macro instead, since it suffixes the value with ULL instead of C type.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
