### PR TITLE
core: riscv: kernel: Fix stack pointer initialization for each hart

### DIFF
--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -21,23 +21,27 @@
 	/*
 	 * Setup sp to point to the top of the tmp stack for the current CPU:
 	 * sp is assigned:
-	 * stack_tmp + cpu_id * stack_tmp_stride - STACK_TMP_GUARD
+	 * stack_tmp + (hartid + 1) * stack_tmp_stride - STACK_TMP_GUARD
 	 */
 .macro set_sp
 	/* Unsupported CPU, park it before it breaks something */
 	li	t1, CFG_TEE_CORE_NB_CORE
 	csrr	t0, CSR_XSCRATCH
 	bge	t0, t1, unhandled_cpu
-	la	t2, stack_tmp
+	addi	t0, t0, 1
 	lw	t1, stack_tmp_stride
 	/*
-	 * t0 is core pos + 1
-	 * t1 is value of stack_tmp_stride
-	 * t2 is value of stack_tmp
+	 * t0 = (hartid + 1)
+	 * t1 = value of stack_tmp_stride
+	 * value of stack_tmp_rel = stack_tmp - stack_tmp_rel - STACK_TMP_GUARD
+	 * sp = stack_tmp + (hartid + 1) * stack_tmp_stride - STACK_TMP_GUARD
+	 *    = stack_tmp_rel + (value of stack_tmp_rel) + (t0 * t1)
 	 */
-	mv	sp, t2
-	mul	t2, t1, t0
-	add	sp, sp, t2
+	mul	t1, t0, t1
+	la	t2, stack_tmp_rel
+	lw	t0, 0(t2)
+	add	t0, t0, t2
+	add	sp, t1, t0
 .endm
 
 .macro cpu_is_ready


### PR DESCRIPTION
The RISC-V privileged specification defines that at least one hart must have a hart ID of zero. Since at least one stack_tmp_stride is required for calculating the initial SP value for each hart, the formula should be address of stack_tmp plus (hartid+1) multiplied by stack_tmp_stride.

This commit fixes the formula for initializing SP of each hart, otherwise the stack underflow happens to hart 0. Also we remove some unused local data.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
