### PR TITLE
Add warning options relating to packed structs

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -37,6 +37,8 @@ comp-cflags-warns-high = \
 	-Wwrite-strings \
 	-Wno-missing-field-initializers -Wno-format-zero-length \
 	-Wno-c2x-extensions
+comp-cflags-warns-high += $(call cc-option,-Wpacked-not-aligned)
+comp-cflags-warns-high += $(call cc-option,-Waddress-of-packed-member)
 ifeq ($(CFG_WARN_DECL_AFTER_STATEMENT),y)
 comp-cflags-warns-high += $(call cc-option,-Wdeclaration-after-statement)
 endif


### PR DESCRIPTION
Adds the two warning options -Wpacked-not-aligned and -Waddress-of-packed-member to the default compiler flags.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
