### PR TITLE
Add missing conditional compilation for RISC-V

### DIFF
--- a/core/include/kernel/thread_private.h
+++ b/core/include/kernel/thread_private.h
@@ -39,7 +39,7 @@ struct thread_ctx {
 	uint32_t flags;
 	struct core_mmu_user_map user_map;
 	bool have_user_map;
-#ifdef ARM64
+#if defined(ARM64) || defined(RV64)
 	vaddr_t kern_sp;	/* Saved kernel SP during user TA execution */
 #endif
 #ifdef CFG_CORE_PAUTH

--- a/lib/libutee/include/elf.h
+++ b/lib/libutee/include/elf.h
@@ -5,7 +5,7 @@
 #ifndef _ELF_H_
 #define _ELF_H_
 
-#if defined(ARM32)
+#if defined(ARM32) || defined(RV32)
 
 #include <elf32.h>
 
@@ -33,7 +33,7 @@ typedef Elf32_Verneed Elf_Verneed;
 typedef Elf32_Vernaux Elf_Vernaux;
 typedef Elf32_Syminfo Elf_Syminfo;
 
-#elif defined(ARM64)
+#elif defined(ARM64) || defined(RV64)
 
 #include <elf64.h>
 


### PR DESCRIPTION
RV64 also uses kern_sp. The elf.h is also used by RV32 and RV64.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
