### PR TITLE
plat-rzn1: increase DDR size to 1GB

### DIFF
--- a/core/arch/arm/plat-rzn1/platform_config.h
+++ b/core/arch/arm/plat-rzn1/platform_config.h
@@ -11,7 +11,7 @@
 
 /* DRAM */
 #define DRAM_BASE			0x80000000
-#define DRAM_SIZE			0x10000000
+#define DRAM_SIZE			0x40000000 /* 1GB, and support 256MB */
 
 /* GIC */
 #define GIC_BASE			0x44100000


### PR DESCRIPTION
There are now some RZ/N1 devices with 1GB rather than 256MB. The
first-stage bootloader does not support passing a DT to OP-TEE, so
static values are set at compile time. Increase the DDR size so as to
avoid OP-TEE calls failing with TEEC_ERROR_OUT_OF_MEMORY.

Signed-off-by: Ralph Siemsen <ralph.siemsen@linaro.org>
