### PR TITLE
core: riscv: kernel: Add missing initialization for core local stacks

### DIFF
--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -66,6 +66,8 @@ void init_tee_runtime(void)
 
 static void init_primary(unsigned long nsec_entry)
 {
+	thread_init_core_local_stacks();
+
 	/*
 	 * Mask asynchronous exceptions before switch to the thread vector
 	 * as the thread handler requires those to be masked while


### PR DESCRIPTION
The thread core local stacks should be initialized when the primary core performs system initialization.

Fixes: ca82589 ("core: split core/arch/arm/kernel/thread.c")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
