### PR TITLE
Disable stack protector for __aeabi_uidivmod/__aeabi_idivmod

### DIFF
--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -276,4 +276,9 @@
 #define fallthrough do {} while (0) /* fallthrough */
 #endif
 
+#ifndef __clang__
+#define __no_stackprot __attribute__((__optimize__ ("-fno-stack-protector")))
+#else
+#define __no_stackprot
+#endif
 #endif /*COMPILER_H*/

--- a/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod.c
+++ b/lib/libutils/isoc/arch/arm/arm32_aeabi_divmod.c
@@ -17,6 +17,8 @@
  *     unsigned denominator);
  */
 
+#include <compiler.h>
+
 /* struct qr - stores qutient/remainder to handle divmod EABI interfaces. */
 struct qr {
 	unsigned q;		/* computed quotient */
@@ -103,7 +105,7 @@ unsigned __aeabi_uidiv(unsigned numerator, unsigned denominator)
 	return qr.q;
 }
 
-unsigned __aeabi_uidivmod(unsigned numerator, unsigned denominator)
+unsigned __no_stackprot __aeabi_uidivmod(unsigned numerator, unsigned denominator)
 {
 	struct qr qr = { .q_n = 0, .r_n = 0 };
 
@@ -131,7 +133,7 @@ signed __aeabi_idiv(signed numerator, signed denominator)
 	return qr.q;
 }
 
-signed __aeabi_idivmod(signed numerator, signed denominator)
+signed __no_stackprot __aeabi_idivmod(signed numerator, signed denominator)
 {
 	struct qr qr = { .q_n = 0, .r_n = 0 };
 


### PR DESCRIPTION
Some toolchain build optee_os with "-fstack-protector-strong", But the generated codes add "check stack" operations after the "ret_idivmod_values", which overwrite the r1 value.

So __aeabi_uidivmod/__aeabi_idivmod will got error value,

Bug: https://github.com/OP-TEE/optee_os/issues/6007

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
