### PR TITLE
core: interrupt: factorization & renaming

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1163,7 +1163,7 @@ DECLARE_KEEP_PAGER(thread_system_reset_handler);
 #endif /*CFG_WITH_ARM_TRUSTED_FW*/
 
 #ifdef CFG_CORE_WORKAROUND_ARM_NMFI
-void __noreturn itr_core_handler(void)
+void __noreturn interrupt_main_handler(void)
 {
 	/*
 	 * Note: overrides the default implementation of this function so that

--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -468,7 +468,7 @@ END_FUNC thread_unwind_user_mode
 	.endif
 
 	bl	thread_check_canaries
-	bl	itr_core_handler
+	bl	interrupt_main_handler
 
 	mrs	r0, spsr
 	cmp_spsr_user_mode r0

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -1272,7 +1272,7 @@ END_FUNC el0_sync_abort
 	mov	sp, x1
 
 	bl	thread_check_canaries
-	bl	itr_core_handler
+	bl	interrupt_main_handler
 
 	/*
 	 * Restore registers

--- a/core/arch/arm/kernel/thread_optee_smc_a32.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a32.S
@@ -72,7 +72,7 @@ UNWIND(	.cantunwind)
 	readjust_pc
  	/* Secure Monitor received a FIQ and passed control to us. */
 	bl	thread_check_canaries
-	bl	itr_core_handler
+	bl	interrupt_main_handler
 	ldr	r0, =TEESMC_OPTEED_RETURN_FIQ_DONE
 	smc	#0
 	/* SMC should not return */

--- a/core/arch/arm/kernel/thread_optee_smc_a64.S
+++ b/core/arch/arm/kernel/thread_optee_smc_a64.S
@@ -70,7 +70,7 @@ LOCAL_FUNC vector_fiq_entry , : , .identity_map
 	readjust_pc
 	/* Secure Monitor received a FIQ and passed control to us. */
 	bl	thread_check_canaries
-	bl	itr_core_handler
+	bl	interrupt_main_handler
 	ldr	x0, =TEESMC_OPTEED_RETURN_FIQ_DONE
 	smc	#0
 	/* SMC should not return */

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -974,7 +974,7 @@ void thread_spmc_msg_recv(struct thread_smc_args *args)
 		break;
 #endif /*CFG_CORE_SEL1_SPMC*/
 	case FFA_INTERRUPT:
-		itr_core_handler();
+		interrupt_main_handler();
 		spmc_set_args(args, FFA_MSG_WAIT, 0, 0, 0, 0, 0);
 		break;
 #ifdef ARM64

--- a/core/arch/arm/plat-aspeed/platform_ast2600.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2600.c
@@ -59,22 +59,15 @@ register_phys_mem(MEM_AREA_IO_NSEC, SCU_BASE, SMALL_PAGE_SIZE);
 register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
 
 static struct serial8250_uart_data console_data;
-static struct gic_data gic_data;
 
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
-	itr_init(&gic_data.chip);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_cpu_init();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-bcm/main.c
+++ b/core/arch/arm/plat-bcm/main.c
@@ -8,14 +8,12 @@
 #include <drivers/gic.h>
 #include <drivers/serial8250_uart.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <mm/tee_pager.h>
 #include <platform_config.h>
 #include <stdint.h>
 
-static struct gic_data gic_data;
 struct serial8250_uart_data console_data;
 
 #ifdef BCM_DEVICE0_BASE
@@ -74,13 +72,7 @@ void console_init(void)
 		      CFG_BCM_ELOG_AP_UART_LOG_SIZE);
 }
 
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}
-
 void main_init_gic(void)
 {
-	gic_init_base_addr(&gic_data, 0, GICD_BASE);
-	itr_init(&gic_data.chip);
+	gic_init_base_addr(0, GICD_BASE);
 }

--- a/core/arch/arm/plat-bcm/main.c
+++ b/core/arch/arm/plat-bcm/main.c
@@ -74,5 +74,5 @@ void console_init(void)
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(0, GICD_BASE);
+	gic_init(0, GICD_BASE);
 }

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -23,7 +23,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(GICC_BASE, GICD_BASE);
+	gic_init(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -12,7 +12,6 @@
 #include <stdint.h>
 #include <trace.h>
 
-static struct gic_data gic_data __nex_bss;
 static struct pl011_data console_data __nex_bss;
 
 register_ddr(DRAM0_BASE, DRAM0_SIZE);
@@ -24,18 +23,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(&gic_data, GICC_BASE, GICD_BASE);
-	itr_init(&gic_data.chip);
+	gic_init_base_addr(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_cpu_init();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -35,13 +35,10 @@
 #include <imx.h>
 #include <io.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <platform_config.h>
 #include <stdint.h>
-
-static struct gic_data gic_data __nex_bss;
 
 static struct imx_uart_data console_data __nex_bss;
 
@@ -101,11 +98,6 @@ register_ddr(CFG_DRAM_BASE, CFG_DDR_SIZE);
 register_ddr(CFG_NSEC_DDR_1_BASE, CFG_NSEC_DDR_1_SIZE);
 #endif
 
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}
-
 void console_init(void)
 {
 #ifdef CONSOLE_UART_BASE
@@ -117,16 +109,15 @@ void console_init(void)
 void main_init_gic(void)
 {
 #ifdef GICD_BASE
-	gic_init(&gic_data, 0, GICD_BASE);
+	gic_init(0, GICD_BASE);
 #else
-	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 #endif
-	itr_init(&gic_data.chip);
 }
 
 #if CFG_TEE_CORE_NB_CORE > 1
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }
 #endif

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -12,7 +12,6 @@
 #include <drivers/serial8250_uart.h>
 #include <drivers/ti_sci.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <kernel/tee_common_otp.h>
 #include <mm/core_memprot.h>
@@ -21,7 +20,6 @@
 #include <stdint.h>
 #include <string_ext.h>
 
-static struct gic_data gic_data;
 static struct serial8250_uart_data console_data;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GICC_SIZE);
@@ -38,18 +36,12 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(&gic_data, GICC_BASE, GICD_BASE);
-	itr_init(&gic_data.chip);
+	gic_init_base_addr(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_cpu_init();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -36,7 +36,7 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(GICC_BASE, GICD_BASE);
+	gic_init(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -50,7 +50,6 @@
 #include <kernel/tee_common_otp.h>
 #include <mm/core_mmu.h>
 
-static struct gic_data gic_data;
 #ifdef CFG_PL011
 static struct pl011_data console_data;
 #else
@@ -216,16 +215,14 @@ void main_init_gic(void)
 
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(&gic_data, gic_base + gicc_offset,
-			   gic_base + gicd_offset);
+	gic_init_base_addr(gic_base + gicc_offset, gic_base + gicd_offset);
 #else
 	/* Initialize GIC */
-	gic_init(&gic_data, gic_base + gicc_offset, gic_base + gicd_offset);
+	gic_init(gic_base + gicc_offset, gic_base + gicd_offset);
 #endif
-	itr_init(&gic_data.chip);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -212,14 +212,7 @@ void main_init_gic(void)
 	gic_base = GIC_BASE;
 #endif
 	get_gic_offset(&gicc_offset, &gicd_offset);
-
-#if defined(CFG_WITH_ARM_TRUSTED_FW)
-	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(gic_base + gicc_offset, gic_base + gicd_offset);
-#else
-	/* Initialize GIC */
 	gic_init(gic_base + gicc_offset, gic_base + gicd_offset);
-#endif
 }
 
 void main_secondary_init_gic(void)

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -81,7 +81,7 @@ void main_init_gic(void)
 #endif
 	gicd_base = GIC_BASE + GICD_OFFSET;
 
-	gic_init_base_addr(gicc_base, gicd_base);
+	gic_init(gicc_base, gicd_base);
 }
 #endif
 

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -40,7 +40,6 @@
 #include <io.h>
 #include <keep.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 #include <kernel/tee_common_otp.h>
@@ -51,7 +50,6 @@
 #include <stdint.h>
 #include <string.h>
 
-static struct gic_data gic_data;
 #if defined(PLATFORM_FLAVOR_armada7k8k)
 static struct serial8250_uart_data console_data;
 #elif defined(PLATFORM_FLAVOR_armada3700)
@@ -75,7 +73,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, CORE_MMU_PGDIR_SIZE);
 
 void main_init_gic(void)
 {
-	paddr_t gicd_base;
+	paddr_t gicd_base = 0;
 	paddr_t gicc_base = 0;
 
 #ifdef GICC_BASE
@@ -83,16 +81,9 @@ void main_init_gic(void)
 #endif
 	gicd_base = GIC_BASE + GICD_OFFSET;
 
-	gic_init_base_addr(&gic_data, gicc_base, gicd_base);
-
-	itr_init(&gic_data.chip);
+	gic_init_base_addr(gicc_base, gicd_base);
 }
 #endif
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}
 
 void console_init(void)
 {

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -20,8 +20,6 @@ static struct serial8250_uart_data console_data;
 register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
 
 #ifdef CFG_GIC
-static struct gic_data gic_data;
-
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICD_OFFSET,
 			CORE_MMU_PGDIR_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICC_OFFSET,
@@ -29,15 +27,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICC_OFFSET,
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
-			   GIC_BASE + GICD_OFFSET);
-
-	itr_init(&gic_data.chip);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 #endif
 

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -27,7 +27,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICC_OFFSET,
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 #endif
 

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -60,7 +60,6 @@ register_ddr(NSEC_DDR_3_BASE, NSEC_DDR_3_SIZE);
 #endif
 
 static struct scif_uart_data console_data __nex_bss;
-static struct gic_data gic_data __nex_bss;
 
 #ifdef PRR_BASE
 uint32_t rcar_prr_value __nex_bss;
@@ -90,17 +89,10 @@ unsigned long plat_get_aslr_seed(void)
 
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GICC_BASE, GICD_BASE);
-	itr_init(&gic_data.chip);
+	gic_init(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}
-

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -14,8 +14,6 @@
 #include <platform_config.h>
 #include <stdint.h>
 
-static struct gic_data gic_data;
-
 #if defined(CFG_EARLY_CONSOLE)
 static struct serial8250_uart_data early_console_data;
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC,
@@ -26,13 +24,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
 
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GICC_BASE, GICD_BASE);
-	itr_init(&gic_data.chip);
+	gic_init(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-rzn1/main.c
+++ b/core/arch/arm/plat-rzn1/main.c
@@ -10,7 +10,6 @@
 #include <drivers/ns16550.h>
 #include <kernel/boot.h>
 #include <kernel/delay.h>
-#include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
@@ -29,7 +28,6 @@
 /* Timeout waiting for Master Idle Request Acknowledge */
 #define IDLE_ACK_TIMEOUT_US		1000
 
-static struct gic_data gic_data;
 static struct ns16550_data console_data;
 
 register_phys_mem(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_PGDIR_SIZE);
@@ -44,13 +42,12 @@ void console_init(void)
 
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GICC_BASE, GICD_BASE);
-	itr_init(&gic_data.chip);
+	gic_init(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }
 
 static TEE_Result rzn1_tz_init(void)

--- a/core/arch/arm/plat-sam/main.c
+++ b/core/arch/arm/plat-sam/main.c
@@ -32,7 +32,6 @@
 #include <drivers/atmel_uart.h>
 #include <io.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 #include <kernel/tz_ssvce_def.h>
@@ -337,11 +336,6 @@ static int matrix_init(void)
 void plat_primary_init_early(void)
 {
 	matrix_init();
-}
-
-void itr_core_handler(void)
-{
-	atmel_saic_it_handle();
 }
 
 void main_init_gic(void)

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -28,7 +28,6 @@
 
 #include <drivers/gic.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <mm/core_memprot.h>
 #include <platform_config.h>
@@ -46,17 +45,8 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 			ROUNDDOWN(GIC_BASE + GICD_OFFSET, CORE_MMU_PGDIR_SIZE),
 			CORE_MMU_PGDIR_SIZE);
 
-static struct gic_data gic_data;
-
 void main_init_gic(void)
 {
-	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
-			   GIC_BASE + GICD_OFFSET);
-
-	itr_init(&gic_data.chip);
+	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -47,6 +47,6 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -9,7 +9,6 @@
 #include <drivers/stih_asc.h>
 #include <io.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 #include <kernel/tz_ssvce_pl310.h>
@@ -33,7 +32,6 @@ register_ddr(DRAM0_BASE, DRAM0_SIZE);
 register_ddr(DRAM1_BASE, DRAM1_SIZE);
 #endif
 
-static struct gic_data gic_data;
 static struct stih_asc_pd console_data;
 
 #if defined(PLATFORM_FLAVOR_b2260)
@@ -136,16 +134,10 @@ void plat_primary_init_early(void)
 
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GIC_CPU_BASE, GIC_DIST_BASE);
-	itr_init(&gic_data.chip);
+	gic_init(GIC_CPU_BASE, GIC_DIST_BASE);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_cpu_init();
 }

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -17,7 +17,6 @@
 #include <io.h>
 #include <kernel/boot.h>
 #include <kernel/dt.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 #include <kernel/spinlock.h>
@@ -154,24 +153,16 @@ service_init_late(init_console_from_dt);
 /*
  * GIC init, used also for primary/secondary boot core wake completion
  */
-static struct gic_data gic_data;
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}
-
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
-	itr_init(&gic_data.chip);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 
 	stm32mp_register_online_cpu();
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 
 	stm32mp_register_online_cpu();
 }

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -82,9 +82,6 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, SUNXI_SMC_BASE, TZC400_REG_SIZE);
 #define SMC_MASTER_BYPASS_EN_MASK 0x1
 #endif
 
-#ifdef GIC_BASE
-static struct gic_data gic_data;
-#endif
 #ifdef SUNXI_TZPC_BASE
 static void tzpc_init(void);
 #endif
@@ -128,13 +125,12 @@ static inline void tzpc_init(void)
 #ifndef CFG_WITH_ARM_TRUSTED_FW
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
-	itr_init(&gic_data.chip);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }
 #endif
 

--- a/core/arch/arm/plat-synquacer/main.c
+++ b/core/arch/arm/plat-synquacer/main.c
@@ -37,8 +37,7 @@ void console_init(void)
 
 void main_init_gic(void)
 {
-	/* On ARMv8-A, GIC configuration is initialized in TF-A */
-	gic_init_base_addr(0, GIC_BASE + GICD_OFFSET);
+	gic_init(0, GIC_BASE + GICD_OFFSET);
 }
 
 static enum itr_return timer_itr_cb(struct itr_handler *h __unused)

--- a/core/arch/arm/plat-synquacer/main.c
+++ b/core/arch/arm/plat-synquacer/main.c
@@ -20,7 +20,6 @@
 
 #include "synquacer_rng_pta.h"
 
-static struct gic_data gic_data;
 static struct pl011_data console_data;
 
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
@@ -28,11 +27,6 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, CORE_MMU_PGDIR_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, THERMAL_SENSOR_BASE,
 			CORE_MMU_PGDIR_SIZE);
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}
 
 void console_init(void)
 {
@@ -44,9 +38,7 @@ void console_init(void)
 void main_init_gic(void)
 {
 	/* On ARMv8-A, GIC configuration is initialized in TF-A */
-	gic_init_base_addr(&gic_data, 0, GIC_BASE + GICD_OFFSET);
-
-	itr_init(&gic_data.chip);
+	gic_init_base_addr(0, GIC_BASE + GICD_OFFSET);
 }
 
 static enum itr_return timer_itr_cb(struct itr_handler *h __unused)

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -9,7 +9,6 @@
 #include <drivers/gic.h>
 #include <drivers/serial8250_uart.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/mutex.h>
 #include <kernel/panic.h>
@@ -25,7 +24,6 @@
 
 #define PLAT_HW_UNIQUE_KEY_LENGTH 32
 
-static struct gic_data gic_data;
 static struct serial8250_uart_data console_data;
 static uint8_t plat_huk[PLAT_HW_UNIQUE_KEY_LENGTH];
 
@@ -38,18 +36,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GICC_BASE, GICD_BASE);
-	itr_init(&gic_data.chip);
+	gic_init(GICC_BASE, GICD_BASE);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_cpu_init();
 }
 
 struct plat_nsec_ctx {

--- a/core/arch/arm/plat-totalcompute/main.c
+++ b/core/arch/arm/plat-totalcompute/main.c
@@ -28,11 +28,7 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 #ifndef CFG_CORE_SEL2_SPMC
 void main_init_gic(void)
 {
-	/*
-	 * On ARMv8, GIC configuration is initialized in ARM-TF
-	 * gicd base address is same as gicc_base.
-	 */
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICC_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICC_OFFSET);
 }
 #endif
 

--- a/core/arch/arm/plat-totalcompute/main.c
+++ b/core/arch/arm/plat-totalcompute/main.c
@@ -9,16 +9,12 @@
 #include <drivers/pl011.h>
 #include <initcall.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
 
 #include <mm/core_mmu.h>
 #include <platform_config.h>
 
-#ifndef CFG_CORE_SEL2_SPMC
-static struct gic_data gic_data __nex_bss;
-#endif
 static struct pl011_data console_data __nex_bss;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
@@ -36,20 +32,9 @@ void main_init_gic(void)
 	 * On ARMv8, GIC configuration is initialized in ARM-TF
 	 * gicd base address is same as gicc_base.
 	 */
-	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
-			   GIC_BASE + GICC_OFFSET);
-	itr_init(&gic_data.chip);
+	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICC_OFFSET);
 }
 #endif
-
-void itr_core_handler(void)
-{
-#ifdef CFG_CORE_SEL2_SPMC
-	panic("Secure interrupt handler not defined");
-#else
-	gic_it_handle(&gic_data);
-#endif
-}
 
 void console_init(void)
 {

--- a/core/arch/arm/plat-uniphier/main.c
+++ b/core/arch/arm/plat-uniphier/main.c
@@ -33,20 +33,11 @@ register_ddr(DRAM0_BASE, DRAM0_SIZE);
 register_ddr(DRAM1_BASE, DRAM1_SIZE);
 #endif
 
-static struct gic_data gic_data;
-
 static struct serial8250_uart_data console_data;
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
-			   GIC_BASE + GICD_OFFSET);
-	itr_init(&gic_data.chip);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-uniphier/main.c
+++ b/core/arch/arm/plat-uniphier/main.c
@@ -37,7 +37,7 @@ static struct serial8250_uart_data console_data;
 
 void main_init_gic(void)
 {
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-versal/main.c
+++ b/core/arch/arm/plat-versal/main.c
@@ -48,8 +48,7 @@ register_ddr(DRAM2_BASE, DRAM2_SIZE);
 
 void main_init_gic(void)
 {
-	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-versal/main.c
+++ b/core/arch/arm/plat-versal/main.c
@@ -11,7 +11,6 @@
 #include <drivers/versal_pm.h>
 #include <io.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/tee_time.h>
 #include <mm/core_memprot.h>
@@ -26,7 +25,6 @@
 #define VERSAL_AHWROT_REG 0x14C
 #define VERSAL_SHWROT_REG 0x150
 
-static struct gic_data gic_data;
 static struct pl011_data console_data;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC,
@@ -51,14 +49,7 @@ register_ddr(DRAM2_BASE, DRAM2_SIZE);
 void main_init_gic(void)
 {
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(&gic_data,
-			   GIC_BASE + GICC_OFFSET,
-			   GIC_BASE + GICD_OFFSET);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -27,8 +27,6 @@
 #include <string.h>
 #include <trace.h>
 
-static struct gic_data gic_data __maybe_unused __nex_bss;
-static struct hfic_data hfic_data __maybe_unused __nex_bss;
 static struct pl011_data console_data __nex_bss;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
@@ -53,37 +51,24 @@ void main_init_gic(void)
 {
 #if defined(CFG_WITH_ARM_TRUSTED_FW)
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
-			   GIC_BASE + GICD_OFFSET);
+	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 #else
-	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 #endif
-	itr_init(&gic_data.chip);
 }
 
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }
 #endif
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
-}
 #endif /*CFG_GIC*/
 
 #ifdef CFG_CORE_HAFNIUM_INTC
 void main_init_gic(void)
 {
-	hfic_init(&hfic_data);
-	itr_init(&hfic_data.chip);
-}
-
-void itr_core_handler(void)
-{
-	hfic_it_handle(&hfic_data);
+	hfic_init();
 }
 #endif
 

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -49,12 +49,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
 
 void main_init_gic(void)
 {
-#if defined(CFG_WITH_ARM_TRUSTED_FW)
-	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
-#else
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
-#endif
 }
 
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -44,7 +44,6 @@
 #include <stdint.h>
 #include <tee/entry_fast.h>
 
-static struct gic_data gic_data;
 static struct cdns_uart_data console_data;
 
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
@@ -144,13 +143,12 @@ void arm_cl2_enable(vaddr_t pl310_base)
 
 void main_init_gic(void)
 {
-	gic_init(&gic_data, GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
-	itr_init(&gic_data.chip);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void main_secondary_init_gic(void)
 {
-	gic_cpu_init(&gic_data);
+	gic_cpu_init();
 }
 
 static vaddr_t slcr_access_range[] = {

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -77,8 +77,7 @@ register_ddr(DRAM0_BASE, CFG_DDR_SIZE);
 
 void main_init_gic(void)
 {
-	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -39,7 +39,6 @@
 #include <console.h>
 #include <io.h>
 #include <kernel/boot.h>
-#include <kernel/interrupt.h>
 #include <kernel/misc.h>
 #include <kernel/tee_common_otp.h>
 #include <kernel/tee_time.h>
@@ -47,7 +46,6 @@
 #include <tee/tee_fs.h>
 #include <trace.h>
 
-static struct gic_data gic_data __nex_bss;
 static struct cdns_uart_data console_data __nex_bss;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC,
@@ -80,14 +78,7 @@ register_ddr(DRAM0_BASE, CFG_DDR_SIZE);
 void main_init_gic(void)
 {
 	/* On ARMv8, GIC configuration is initialized in ARM-TF */
-	gic_init_base_addr(&gic_data, GIC_BASE + GICC_OFFSET,
-			   GIC_BASE + GICD_OFFSET);
-	itr_init(&gic_data.chip);
-}
-
-void itr_core_handler(void)
-{
-	gic_it_handle(&gic_data);
+	gic_init_base_addr(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
 void console_init(void)

--- a/core/arch/riscv/plat-virt/main.c
+++ b/core/arch/riscv/plat-virt/main.c
@@ -22,7 +22,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, UART0_BASE,
 void main_init_plic(void)
 {
 	plic_init(&plic_data, PLIC_BASE);
-	itr_init(&plic_data.chip);
+	interrupt_main_init(&plic_data.chip);
 }
 
 void main_secondary_init_plic(void)

--- a/core/drivers/atmel_saic.c
+++ b/core/drivers/atmel_saic.c
@@ -43,7 +43,7 @@ static uint32_t saic_read_reg(uint32_t reg)
 	return io_read32(saic.base + reg);
 }
 
-void itr_core_handler(void)
+void interrupt_main_handler(void)
 {
 	uint32_t irqnr = saic_read_reg(AT91_AIC_IVR);
 

--- a/core/drivers/atmel_saic.c
+++ b/core/drivers/atmel_saic.c
@@ -43,7 +43,7 @@ static uint32_t saic_read_reg(uint32_t reg)
 	return io_read32(saic.base + reg);
 }
 
-void atmel_saic_it_handle(void)
+void itr_core_handler(void)
 {
 	uint32_t irqnr = saic_read_reg(AT91_AIC_IVR);
 

--- a/core/drivers/atmel_saic.c
+++ b/core/drivers/atmel_saic.c
@@ -295,7 +295,7 @@ TEE_Result atmel_saic_setup(void)
 	saic_init_external(fdt, node);
 	saic_init_hw();
 
-	itr_init(&saic_chip);
+	interrupt_main_init(&saic_chip);
 	saic_register_pm();
 
 	return TEE_SUCCESS;

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -497,8 +497,8 @@ static void __maybe_unused gic_native_itr_handler(void)
 }
 
 #ifndef CFG_CORE_WORKAROUND_ARM_NMFI
-/* Override itr_core_handler() with core interrupt controller implementation */
-void itr_core_handler(void)
+/* Override interrupt_main_handler() with driver implementation */
+void interrupt_main_handler(void)
 {
 	gic_native_itr_handler();
 }

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -284,7 +284,7 @@ void gic_init(paddr_t gicc_base_pa, paddr_t gicd_base_pa)
 #endif
 #endif /*CFG_WITH_ARM_TRUSTED_FW*/
 
-	itr_init(&gic_data.chip);
+	interrupt_main_init(&gic_data.chip);
 }
 
 static void gic_it_add(struct gic_data *gd, size_t it)

--- a/core/drivers/hfic.c
+++ b/core/drivers/hfic.c
@@ -4,12 +4,19 @@
  */
 
 #include <assert.h>
+#include <compiler.h>
 #include <config.h>
 #include <drivers/hfic.h>
 #include <hafnium.h>
 #include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <kernel/thread.h>
+
+struct hfic_data {
+	struct itr_chip chip;
+};
+
+static struct hfic_data hfic_data __nex_bss;
 
 static void hfic_op_add(struct itr_chip *chip __unused, size_t it __unused,
 			uint32_t type __unused, uint32_t prio __unused)
@@ -60,12 +67,14 @@ static const struct itr_ops hfic_ops = {
 	.set_affinity = hfic_op_set_affinity,
 };
 
-void hfic_init(struct hfic_data *hd)
+void hfic_init(void)
 {
-	hd->chip.ops = &hfic_ops;
+	hfic_data.chip.ops = &hfic_ops;
+	itr_init(&hfic_data.chip);
 }
 
-void hfic_it_handle(struct hfic_data *hd __unused)
+/* Override itr_core_handler() with core interrupt controller implementation */
+void itr_core_handler(void)
 {
 	uint32_t id = 0;
 	uint32_t res __maybe_unused = 0;

--- a/core/drivers/hfic.c
+++ b/core/drivers/hfic.c
@@ -73,8 +73,8 @@ void hfic_init(void)
 	itr_init(&hfic_data.chip);
 }
 
-/* Override itr_core_handler() with core interrupt controller implementation */
-void itr_core_handler(void)
+/* Override interrupt_main_handler() with driver implementation */
+void interrupt_main_handler(void)
 {
 	uint32_t id = 0;
 	uint32_t res __maybe_unused = 0;

--- a/core/drivers/hfic.c
+++ b/core/drivers/hfic.c
@@ -70,7 +70,7 @@ static const struct itr_ops hfic_ops = {
 void hfic_init(void)
 {
 	hfic_data.chip.ops = &hfic_ops;
-	itr_init(&hfic_data.chip);
+	interrupt_main_init(&hfic_data.chip);
 }
 
 /* Override interrupt_main_handler() with driver implementation */

--- a/core/include/drivers/atmel_saic.h
+++ b/core/include/drivers/atmel_saic.h
@@ -41,8 +41,6 @@
 #define AT91_AIC_WPMR	0xe4
 #define AT91_AIC_WPSR	0xe8
 
-void atmel_saic_it_handle(void);
-
 TEE_Result atmel_saic_setup(void);
 
 #endif /*__DRIVERS_ATMEL_SAIC_H*/

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -32,9 +32,6 @@
 /* Initialize GIC */
 void gic_init(paddr_t gicc_base_pa, paddr_t gicd_base_pa);
 
-/* Only set GIC base address */
-void gic_init_base_addr(paddr_t gicc_base_pa, paddr_t gicd_base_pa);
-
 /* Only initialize CPU GIC interface, mainly use for secondary CPUs */
 void gic_cpu_init(void);
 

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -24,26 +24,20 @@
 #define GIC_PPI_TO_ITNUM(x)	((x) + GIC_PPI_BASE)
 #define GIC_SPI_TO_ITNUM(x)	((x) + GIC_SPI_BASE)
 
-struct gic_data {
-	vaddr_t gicc_base;
-	vaddr_t gicd_base;
-	size_t max_it;
-	struct itr_chip chip;
-};
-
 /*
  * The two gic_init_* functions initializes the struct gic_data which is
  * then used by the other functions.
  */
 
-void gic_init(struct gic_data *gd, paddr_t gicc_base_pa, paddr_t gicd_base_pa);
-/* initial base address only */
-void gic_init_base_addr(struct gic_data *gd, paddr_t gicc_base_pa,
-			paddr_t gicd_base_pa);
-/* initial cpu if only, mainly use for secondary cpu setup cpu interface */
-void gic_cpu_init(struct gic_data *gd);
+/* Initialize GIC */
+void gic_init(paddr_t gicc_base_pa, paddr_t gicd_base_pa);
 
-void gic_it_handle(struct gic_data *gd);
+/* Only set GIC base address */
+void gic_init_base_addr(paddr_t gicc_base_pa, paddr_t gicd_base_pa);
 
-void gic_dump_state(struct gic_data *gd);
+/* Only initialize CPU GIC interface, mainly use for secondary CPUs */
+void gic_cpu_init(void);
+
+/* Print GIC state to console */
+void gic_dump_state(void);
 #endif /*__DRIVERS_GIC_H*/

--- a/core/include/drivers/hfic.h
+++ b/core/include/drivers/hfic.h
@@ -5,13 +5,7 @@
 
 #ifndef __DRIVERS_HFIC_H
 #define __DRIVERS_HFIC_H
-#include <kernel/interrupt.h>
 
-struct hfic_data {
-	struct itr_chip chip;
-};
-
-void hfic_init(struct hfic_data *hd);
-void hfic_it_handle(struct hfic_data *hd);
+void hfic_init(void);
 
 #endif /*__DRIVERS_HFIC_H*/

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -113,7 +113,7 @@ void itr_set_affinity(size_t it, uint8_t cpu_mask);
  * received. The default function calls panic() immediately, platforms which
  * expects to receive secure interrupts should override this function.
  */
-void itr_core_handler(void);
+void interrupt_main_handler(void);
 
 static inline void itr_add(struct itr_handler *handler)
 {

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -57,7 +57,12 @@ struct itr_handler {
 	SLIST_ENTRY(itr_handler) link;
 };
 
-void itr_init(struct itr_chip *data);
+/*
+ * Initialise core interrupt controller driver
+ * @data Core controller main data reference to register
+ */
+void interrupt_main_init(struct itr_chip *data);
+
 void itr_handle(size_t it);
 
 #ifdef CFG_DT

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -134,7 +134,7 @@ void itr_set_affinity(size_t it, uint8_t cpu_mask)
 }
 
 /* This function is supposed to be overridden in platform specific code */
-void __weak __noreturn itr_core_handler(void)
+void __weak __noreturn interrupt_main_handler(void)
 {
 	panic("Secure interrupt handler not defined");
 }

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -23,7 +23,7 @@ static struct itr_chip *itr_chip __nex_bss;
 static SLIST_HEAD(, itr_handler) handlers __nex_data =
 	SLIST_HEAD_INITIALIZER(handlers);
 
-void itr_init(struct itr_chip *chip)
+void interrupt_main_init(struct itr_chip *chip)
 {
 	itr_chip = chip;
 }


### PR DESCRIPTION
This change prepares changes to move to the interrupt management API function proposed in https://github.com/OP-TEE/optee_docs/pull/192 and to the generic interrupt chip framework proposed by https://github.com/OP-TEE/optee_os/pull/5954.

Commit "core: define main interrupt controller data from its driver" factorizes CPU **~~core~~ main** interrupt controller initialization and **~~root~~ main native interrupt** handling.

Commit "drivers: gic: factorize call to gic_init() or gic_init_base_addr()" makes `gic_init()` a unique entry point to initialize GIC driver.

Commit "core: interrupt: rename itr_core_handler()" renames `itr_core_handler()` to **~~`interrupt_core_handler()`~~ `interrupt_main_handler()`**.

Commit "core: interrupt: rename itr_init()" renames `itr_init()` to **~~`interrupt_core_init()`~~ `interrupt_main_init()`**.

**(edited) updated from review comments**