### PR TITLE
RISC-V: Add Makefile variables for platform ISA, ABI, and code model

### DIFF
--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -18,6 +18,8 @@ $(call force,CFG_NUM_THREADS,1)
 $(call force,CFG_BOOT_SYNC_CPU,y)
 
 # RISC-V-specific flags
+rv64-platform-isa ?= rv64imafdc_zicsr_zifencei
+
 $(call force,CFG_RISCV_PLIC,y)
 $(call force,CFG_SBI_CONSOLE,n)
 $(call force,CFG_16550_UART,y)

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -71,9 +71,19 @@ core-platform-cppflags	+= -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)
 
-# more convenient to move it to platform instead
-rv64-platform-cppflags += -mcmodel=medany -march=rv64imafd -mabi=lp64d
+# Default values for "-mcmodel", "-march", and "-abi" compiler flags.
+# Platform-specific overrides are in core/arch/riscv/plat-*/conf.mk.
+riscv-platform-mcmodel ?= medany
+rv64-platform-isa ?= rv64imafd
+rv64-platform-abi ?= lp64d
+rv32-platform-isa ?= rv32imafd
+rv32-platform-abi ?= ilp32d
+
+rv64-platform-cppflags += -mcmodel=$(riscv-platform-mcmodel)
+rv64-platform-cppflags += -march=$(rv64-platform-isa) -mabi=$(rv64-platform-abi)
 rv64-platform-cppflags += -Wno-missing-include-dirs
+rv32-platform-cppflags += -mcmodel=$(riscv-platform-mcmodel)
+rv32-platform-cppflags += -march=$(rv32-platform-isa) -mabi=$(rv32-platform-abi)
 
 rv64-platform-cppflags += -DRV64=1 -D__LP64__=1
 rv32-platform-cppflags += -DRV32=1 -D__ILP32__=1


### PR DESCRIPTION
In RISC-V, each platform may have different supported ISA extensions, ABI, and code model.

In the first commit, we define the default variables of ISA extensions, ABI, and code model in RISC-V core Makefile `riscv.mk`.
In the second commit, we show that how the virt platform overrides the ISA in its `conf.mk`.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
