### PR TITLE
core: rename dt_driver_phandle_args to dt_pargs

### DIFF
--- a/core/drivers/atmel_piobu.c
+++ b/core/drivers/atmel_piobu.c
@@ -204,13 +204,13 @@ static const struct gpio_ops atmel_piobu_ops = {
 	.set_interrupt = secumod_gpio_set_interrupt,
 };
 
-static struct gpio *secumod_dt_get(struct dt_driver_phandle_args *a, void *data,
+static struct gpio *secumod_dt_get(struct dt_pargs *pargs, void *data,
 				   TEE_Result *res)
 {
 	struct gpio *gpio = NULL;
 	struct gpio_chip *chip = data;
 
-	gpio = gpio_dt_alloc_pin(a, res);
+	gpio = gpio_dt_alloc_pin(pargs, res);
 	if (*res)
 		return NULL;
 

--- a/core/drivers/clk/clk-stm32-core.c
+++ b/core/drivers/clk/clk-stm32-core.c
@@ -544,7 +544,7 @@ struct clk *stm32mp_rcc_clock_id_to_clk(unsigned long clock_id)
 	return priv->clk_refs[clock_id];
 }
 
-static struct clk *stm32mp_clk_dt_get_clk(struct dt_driver_phandle_args *pargs,
+static struct clk *stm32mp_clk_dt_get_clk(struct dt_pargs *pargs,
 					  void *data __unused, TEE_Result *res)
 {
 	unsigned long clock_id = pargs->args[0];

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1499,7 +1499,7 @@ static TEE_Result register_stm32mp1_clocks(void)
 	return TEE_SUCCESS;
 }
 
-static struct clk *stm32mp1_clk_dt_get_clk(struct dt_driver_phandle_args *pargs,
+static struct clk *stm32mp1_clk_dt_get_clk(struct dt_pargs *pargs,
 					   void *data __unused, TEE_Result *res)
 {
 	unsigned long clock_id = pargs->args[0];

--- a/core/drivers/clk/sam/at91_clk.h
+++ b/core/drivers/clk/sam/at91_clk.h
@@ -130,8 +130,7 @@ struct pmc_data *pmc_data_allocate(unsigned int ncore, unsigned int nsystem,
 				   unsigned int nperiph, unsigned int ngck,
 				   unsigned int npck);
 
-struct clk *clk_dt_pmc_get(struct dt_driver_phandle_args *args, void *data,
-			   TEE_Result *res);
+struct clk *clk_dt_pmc_get(struct dt_pargs *args, void *data, TEE_Result *res);
 
 struct clk *pmc_clk_get_by_name(struct pmc_clk *clks, unsigned int nclk,
 				const char *name);

--- a/core/drivers/clk/sam/at91_pmc.c
+++ b/core/drivers/clk/sam/at91_pmc.c
@@ -80,7 +80,7 @@ TEE_Result pmc_clk_get(struct pmc_data *pmc, unsigned int type,
 	return TEE_SUCCESS;
 }
 
-struct clk *clk_dt_pmc_get(struct dt_driver_phandle_args *clkspec, void *data,
+struct clk *clk_dt_pmc_get(struct dt_pargs *clkspec, void *data,
 			   TEE_Result *res)
 {
 	unsigned int type = clkspec->args[0];

--- a/core/drivers/gpio/gpio.c
+++ b/core/drivers/gpio/gpio.c
@@ -11,12 +11,11 @@
 #include <tee_api_types.h>
 #include <util.h>
 
-struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a,
-			       TEE_Result *res)
+struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs, TEE_Result *res)
 {
 	struct gpio *gpio = NULL;
 
-	if (a->args_count != 2) {
+	if (pargs->args_count != 2) {
 		*res = TEE_ERROR_BAD_PARAMETERS;
 		return NULL;
 	}
@@ -27,8 +26,8 @@ struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a,
 		return NULL;
 	}
 
-	gpio->pin = a->args[0];
-	gpio->dt_flags = a->args[1];
+	gpio->pin = pargs->args[0];
+	gpio->dt_flags = pargs->args[1];
 
 	*res = TEE_SUCCESS;
 	return gpio;

--- a/core/drivers/i2c/atmel_i2c.c
+++ b/core/drivers/i2c/atmel_i2c.c
@@ -278,13 +278,13 @@ static const struct i2c_ctrl_ops atmel_i2c_ops = {
 	.smbus = atmel_i2c_smbus,
 };
 
-static struct i2c_dev *atmel_i2c_get_dt_i2c(struct dt_driver_phandle_args *a,
-					    void *data, TEE_Result *res)
+static struct i2c_dev *atmel_i2c_get_dt_i2c(struct dt_pargs *args, void *data,
+					    TEE_Result *res)
 {
 	struct i2c_dev *i2c_dev = NULL;
 	struct i2c_ctrl *i2c_ctrl = data;
 
-	i2c_dev = i2c_create_dev(i2c_ctrl, a->fdt, a->phandle_node);
+	i2c_dev = i2c_create_dev(i2c_ctrl, args->fdt, args->phandle_node);
 	if (!i2c_dev) {
 		*res = TEE_ERROR_OUT_OF_MEMORY;
 		return NULL;

--- a/core/drivers/pinctrl/atmel_pio.c
+++ b/core/drivers/pinctrl/atmel_pio.c
@@ -76,7 +76,7 @@ static const struct pinctrl_ops pio_pinctrl_ops = {
 	.conf_free = pio_conf_free,
 };
 
-static struct pinconf *pio_pinctrl_dt_get(struct dt_driver_phandle_args *a,
+static struct pinconf *pio_pinctrl_dt_get(struct dt_pargs *pargs,
 					  void *data, TEE_Result *res)
 {
 	int i = 0;
@@ -94,7 +94,8 @@ static struct pinconf *pio_pinctrl_dt_get(struct dt_driver_phandle_args *a,
 	struct atmel_pio *atmel_pio = data;
 	struct atmel_pio_pin_conf *pio_conf = NULL;
 
-	prop = fdt_getprop(a->fdt, a->phandle_node, "pinmux", &prop_count);
+	prop = fdt_getprop(pargs->fdt, pargs->phandle_node, "pinmux",
+			   &prop_count);
 	if (!prop) {
 		*res = TEE_ERROR_ITEM_NOT_FOUND;
 		return NULL;
@@ -124,7 +125,8 @@ static struct pinconf *pio_pinctrl_dt_get(struct dt_driver_phandle_args *a,
 
 	cfg = func;
 
-	*res = pinctrl_parse_dt_pin_modes(a->fdt, a->phandle_node, &cfg_modes);
+	*res = pinctrl_parse_dt_pin_modes(pargs->fdt, pargs->phandle_node,
+					  &cfg_modes);
 	if (*res)
 		return NULL;
 

--- a/core/drivers/rstctrl/stm32_rstctrl.c
+++ b/core/drivers/rstctrl/stm32_rstctrl.c
@@ -179,7 +179,7 @@ struct rstctrl *stm32mp_rcc_reset_id_to_rstctrl(unsigned int binding_id)
 	return &rstline->rstctrl;
 }
 
-static struct rstctrl *stm32_rstctrl_get_dev(struct dt_driver_phandle_args *arg,
+static struct rstctrl *stm32_rstctrl_get_dev(struct dt_pargs *arg,
 					     void *priv_data __unused,
 					     TEE_Result *res)
 {

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -75,8 +75,8 @@ TEE_Result clk_dt_get_by_name(const void *fdt, int nodeoffset,
  * description or NULL if invalid description in which case @res provides the
  * error code.
  */
-typedef struct clk *(*clk_dt_get_func)(struct dt_driver_phandle_args *args,
-				       void *data, TEE_Result *res);
+typedef struct clk *(*clk_dt_get_func)(struct dt_pargs *args, void *data,
+				       TEE_Result *res);
 
 /**
  * clk_dt_register_clk_provider - Register a clock provider
@@ -100,9 +100,8 @@ TEE_Result clk_dt_register_clk_provider(const void *fdt, int nodeoffset,
  * clk_dt_get_simple_clk: simple clock matching function for single clock
  * providers
  */
-static inline
-struct clk *clk_dt_get_simple_clk(struct dt_driver_phandle_args *args __unused,
-				  void *data, TEE_Result *res)
+static inline struct clk *clk_dt_get_simple_clk(struct dt_pargs *args __unused,
+						void *data, TEE_Result *res)
 {
 	*res = TEE_SUCCESS;
 

--- a/core/include/drivers/gpio.h
+++ b/core/include/drivers/gpio.h
@@ -117,7 +117,7 @@ static inline enum gpio_level gpio_get_value(struct gpio *gpio)
 /**
  * gpio_dt_alloc_pin() - Get an allocated GPIO instance from its DT phandle
  *
- * @a: Pointer to devicetree description of the GPIO controller to parse
+ * @pargs: Pointer to devicetree description of the GPIO controller to parse
  * @res: Output result code of the operation:
  *	TEE_SUCCESS in case of success
  *	TEE_ERROR_DEFER_DRIVER_INIT if GPIO controller is not initialized
@@ -127,8 +127,7 @@ static inline enum gpio_level gpio_get_value(struct gpio *gpio)
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a,
-			       TEE_Result *res);
+struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs, TEE_Result *res);
 
 /**
  * gpio_dt_get_by_index() - Get a GPIO controller at a specific index in
@@ -158,9 +157,8 @@ static inline TEE_Result gpio_dt_get_by_index(const void *fdt __unused,
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-static inline
-struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a __unused,
-			       TEE_Result *res)
+static inline struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs __unused,
+					     TEE_Result *res)
 {
 	*res = TEE_ERROR_NOT_SUPPORTED;
 	return NULL;
@@ -171,7 +169,7 @@ struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a __unused,
  * gpio_dt_get_func - Typedef of function to get GPIO instance from
  * devicetree properties
  *
- * @a: Pointer to GPIO phandle and its argument in the FDT
+ * @pargs: Pointer to GPIO phandle and its argument in the FDT
  * @data: Pointer to the data given at gpio_dt_register_provider() call
  * @res: Output result code of the operation:
  *	TEE_SUCCESS in case of success
@@ -182,8 +180,8 @@ struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a __unused,
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-typedef struct gpio *(*gpio_dt_get_func)(struct dt_driver_phandle_args *a,
-					 void *data, TEE_Result *res);
+typedef struct gpio *(*gpio_dt_get_func)(struct dt_pargs *pargs, void *data,
+					 TEE_Result *res);
 
 /**
  * gpio_dt_register_provider() - Register a GPIO controller provider

--- a/core/include/drivers/i2c.h
+++ b/core/include/drivers/i2c.h
@@ -228,7 +228,7 @@ static inline TEE_Result i2c_dt_get_dev(const void *fdt __unused,
  * i2c_dt_get_func - Typedef of function to get I2C bus device from
  * devicetree properties
  *
- * @a: Pointer to devicetree description of the I2C bus device to parse
+ * @args: Pointer to devicetree description of the I2C bus device to parse
  * @data: Pointer to data given at i2c_dt_register_provider() call
  * @res: Output result code of the operation:
  *	TEE_SUCCESS in case of success
@@ -239,8 +239,8 @@ static inline TEE_Result i2c_dt_get_dev(const void *fdt __unused,
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-typedef struct i2c_dev *(*i2c_dt_get_func)(struct dt_driver_phandle_args *a,
-					   void *data, TEE_Result *res);
+typedef struct i2c_dev *(*i2c_dt_get_func)(struct dt_pargs *args, void *data,
+					   TEE_Result *res);
 
 /**
  * i2c_dt_register_provider - Register a I2C controller provider and add all the

--- a/core/include/drivers/pinctrl.h
+++ b/core/include/drivers/pinctrl.h
@@ -49,7 +49,7 @@ struct pinctrl_ops {
 	void (*conf_free)(struct pinconf *conf);
 };
 
-typedef struct pinconf *(*pinctrl_dt_get_func)(struct dt_driver_phandle_args *a,
+typedef struct pinconf *(*pinctrl_dt_get_func)(struct dt_pargs *pargs,
 					       void *data, TEE_Result *res);
 
 #ifdef CFG_DRIVERS_PINCTRL

--- a/core/include/drivers/rstctrl.h
+++ b/core/include/drivers/rstctrl.h
@@ -199,7 +199,7 @@ TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
  * rstctrl_dt_get_func - Typedef of function to get reset controller from
  * devicetree properties
  *
- * @a: Pointer to devicetree description of the reset controller to parse
+ * @args: Pointer to devicetree description of the reset controller to parse
  * @data: Pointer to data given at rstctrl_dt_register_provider() call
  * @res: Output result code of the operation:
  *	TEE_SUCCESS in case of success
@@ -210,7 +210,7 @@ TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-typedef struct rstctrl *(*rstctrl_dt_get_func)(struct dt_driver_phandle_args *a,
+typedef struct rstctrl *(*rstctrl_dt_get_func)(struct dt_pargs *args,
 					       void *data, TEE_Result *res);
 
 /**

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -78,13 +78,13 @@ struct dt_driver {
 struct dt_driver_provider;
 
 /**
- * struct dt_driver_phandle_args - Devicetree phandle arguments
+ * struct dt_pargs - Devicetree phandle arguments
  * @fdt: Device-tree to work on
  * @phandle_node: Node pointed by the specifier phandle
  * @args_count: Count of cells for the device
  * @args: Device consumer specifiers
  */
-struct dt_driver_phandle_args {
+struct dt_pargs {
 	const void *fdt;
 	int phandle_node;
 	int args_count;
@@ -106,8 +106,8 @@ struct dt_driver_phandle_args {
  * Return a device opaque reference, e.g. a struct clk pointer for a clock
  * driver, or NULL if not found in which case @res provides the error code.
  */
-typedef void *(*get_of_device_func)(struct dt_driver_phandle_args *parg,
-				    void *data, TEE_Result *res);
+typedef void *(*get_of_device_func)(struct dt_pargs *parg, void *data,
+				    TEE_Result *res);
 
 /**
  * dt_driver_register_provider - Register a driver provider

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -240,7 +240,7 @@ static void *device_from_provider_prop(struct dt_driver_provider *prv,
 				       const void *fdt, int phandle_node,
 				       const uint32_t *prop, TEE_Result *res)
 {
-	struct dt_driver_phandle_args *pargs = NULL;
+	struct dt_pargs *pargs = NULL;
 	unsigned int n = 0;
 	void *device = NULL;
 

--- a/core/pta/tests/dt_driver_test.c
+++ b/core/pta/tests/dt_driver_test.c
@@ -443,8 +443,8 @@ static const char *dt_test_clk_name[DT_TEST_CLK_COUNT] = {
 /* Emulating a clock does not require operators */
 static const struct clk_ops dt_test_clock_provider_ops;
 
-static struct clk *dt_test_get_clk(struct dt_driver_phandle_args *args,
-				   void *data, TEE_Result *res)
+static struct clk *dt_test_get_clk(struct dt_pargs *args, void *data,
+				   TEE_Result *res)
 {
 	struct clk *clk_ref = data;
 	struct clk *clk = NULL;
@@ -566,8 +566,8 @@ const struct rstctrl_ops dt_test_rstctrl_ops = {
 	.get_name = dt_test_rstctrl_name,
 };
 
-static struct rstctrl *dt_test_get_rstctrl(struct dt_driver_phandle_args *args,
-					   void *data, TEE_Result *res)
+static struct rstctrl *dt_test_get_rstctrl(struct dt_pargs *args, void *data,
+					   TEE_Result *res)
 {
 	struct dt_test_rstctrl *ref = data;
 	struct rstctrl *rstctrl = NULL;
@@ -698,13 +698,13 @@ static const struct gpio_ops dt_test_gpio_ops = {
 	.set_value = dt_test_gpio_set_value,
 };
 
-static struct gpio *dt_test_gpio_get_dt(struct dt_driver_phandle_args *a,
-					void *data, TEE_Result *res)
+static struct gpio *dt_test_gpio_get_dt(struct dt_pargs *args, void *data,
+					TEE_Result *res)
 {
 	struct gpio *gpio = NULL;
 	struct dt_test_gpio *gpios = (struct dt_test_gpio *)data;
 
-	gpio = gpio_dt_alloc_pin(a, res);
+	gpio = gpio_dt_alloc_pin(args, res);
 	if (*res)
 		return NULL;
 


### PR DESCRIPTION
Renames struct dt_driver_phandle_args to struct dt_pargs to shorten the label and prevent ugly line breaks in function signatures.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
