### PR TITLE
core: riscv: fix interrupt_main_handler() reference

### DIFF
--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -238,7 +238,7 @@ static void thread_exception_handler(unsigned long cause,
 
 static void thread_irq_handler(void)
 {
-	itr_core_handler();
+	interrupt_main_handler();
 }
 
 static void thread_interrupt_handler(unsigned long cause,

--- a/core/arch/riscv/plat-virt/main.c
+++ b/core/arch/riscv/plat-virt/main.c
@@ -37,7 +37,7 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
-void itr_core_handler(void)
+void interrupt_main_handler(void)
 {
 	if (IS_ENABLED(CFG_RISCV_PLIC))
 		plic_it_handle(&plic_data);


### PR DESCRIPTION
Fixes itr_core_handler() reference in RiscV architecture that was renamed interrupt_main_handler() in commit referred below.

Fixes: 358bf47c0612 ("core: interrupt: rename itr_core_handler()")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
