### PR TITLE
libutee: riscv: Fix relocation type of function call into __utee_panic()

### DIFF
--- a/lib/libutee/arch/riscv/utee_syscalls_rv.S
+++ b/lib/libutee/arch/riscv/utee_syscalls_rv.S
@@ -22,7 +22,7 @@
 	.endm
 
 	FUNC _utee_panic, :
-	j	__utee_panic
+	tail	__utee_panic
 	END_FUNC _utee_panic
 
 #include <utee_syscalls_asm.S>


### PR DESCRIPTION
In RISC-V, "j" instruction has R_RISCV_JAL relocation that can represent an even signed 21-bit offset (+-1MiB). However, this range is not enough to be position independent code, and the linker generates linking error. Fix it by using "tail" instruction which has R_RISCV_CALL_PLT relocation that the execution can jump to +-2GB location.

Note that we won't return from _utee_panic(), that's why we use "tail" instead of "call" instruction so that we won't generate redundant return instruction.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
