### PR TITLE
drivers: pinctrl: fix stubbed pinctrl_free_state()

### DIFF
--- a/core/include/drivers/pinctrl.h
+++ b/core/include/drivers/pinctrl.h
@@ -155,7 +155,6 @@ TEE_Result pinctrl_get_state_by_idx(const void *fdt __unused,
 static inline
 void pinctrl_free_state(struct pinctrl_state *state __unused)
 {
-	return TEE_ERROR_NOT_SUPPORTED;
 }
 
 static inline


### PR DESCRIPTION
Fixes pinctrl_free_state() when CFG_DRIVERS_PINCTRL is disabled as the API function has no return value.

The issue is reported by GCC with an error trace like the below:

core/include/drivers/pinctrl.h: In function ‘pinctrl_free_state’: lib/libutee/include/tee_api_defines.h:117:43: error: ‘return’ with a value, in function returning void [-Werror=return-type]
  117 | #define TEE_ERROR_NOT_SUPPORTED           0xFFFF000A
      |                                           ^~~~~~~~~~
core/include/drivers/pinctrl.h:158:16: note: in expansion of macro ‘TEE_ERROR_NOT_SUPPORTED’
  158 |         return TEE_ERROR_NOT_SUPPORTED;
      |                ^~~~~~~~~~~~~~~~~~~~~~~
In file included from core/include/drivers/stm32_uart.h:10,
                 from core/arch/arm/plat-stm32mp1/main.c:14:
core/include/drivers/pinctrl.h:156:6: note: declared here
  156 | void pinctrl_free_state(struct pinctrl_state *state __unused)
      |      ^~~~~~~~~~~~~~~~~~

Fixes: 9aec039ec0d7 ("drivers: pinctrl: add pinctrl support")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
