### PR TITLE
stm32_gpio: move to pinctrl framework

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -92,6 +92,7 @@ include core/arch/arm/cpu/cortex-a7.mk
 
 $(call force,CFG_DRIVERS_CLK,y)
 $(call force,CFG_DRIVERS_CLK_DT,y)
+$(call force,CFG_DRIVERS_GPIO,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_INIT_CNTVOFF,y)
 $(call force,CFG_PSCI_ARM32,y)

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -93,6 +93,7 @@ include core/arch/arm/cpu/cortex-a7.mk
 $(call force,CFG_DRIVERS_CLK,y)
 $(call force,CFG_DRIVERS_CLK_DT,y)
 $(call force,CFG_DRIVERS_GPIO,y)
+$(call force,CFG_DRIVERS_PINCTRL,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_INIT_CNTVOFF,y)
 $(call force,CFG_PSCI_ARM32,y)

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -460,8 +460,13 @@ static void parse_regulator_fdt_nodes(void)
  * Return 0 on success, 1 if no PMIC node found and a negative value otherwise
  */
 static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
+#ifdef CFG_DRIVERS_PINCTRL
+			      struct pinctrl_state **pinctrl_active,
+			      struct pinctrl_state **pinctrl_sleep,
+#else
 			      struct stm32_pinctrl **pinctrl,
 			      size_t *pinctrl_count,
+#endif
 			      struct stm32_i2c_init_s *init)
 {
 	int pmic_node = 0;
@@ -493,9 +498,15 @@ static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
 	if (!i2c_info->reg)
 		return -FDT_ERR_NOTFOUND;
 
+#ifdef CFG_DRIVERS_PINCTRL
+	if (stm32_i2c_get_setup_from_fdt(fdt, i2c_node, init, pinctrl_active,
+					 pinctrl_sleep))
+		panic();
+#else
 	if (stm32_i2c_get_setup_from_fdt(fdt, i2c_node, init,
 					 pinctrl, pinctrl_count))
 		panic();
+#endif
 
 	return 0;
 }
@@ -510,17 +521,22 @@ static bool initialize_pmic_i2c(void)
 	int ret = 0;
 	struct dt_node_info i2c_info = { };
 	struct i2c_handle_s *i2c = &i2c_handle;
-	struct stm32_pinctrl *pinctrl = NULL;
-	size_t pin_count = 0;
 	struct stm32_i2c_init_s i2c_init = { };
 
-	ret = dt_pmic_i2c_config(&i2c_info, &pinctrl, &pin_count, &i2c_init);
+#ifdef CFG_DRIVERS_PINCTRL
+	if (dt_pmic_i2c_config(&i2c_info, &i2c->pinctrl, &i2c->pinctrl_sleep,
+			       &i2c_init))
+		panic();
+#else
+	ret = dt_pmic_i2c_config(&i2c_info, &i2c->pinctrl, &i2c->pinctrl_count,
+				 &i2c_init);
 	if (ret < 0) {
 		EMSG("I2C configuration failed %d", ret);
 		panic();
 	}
 	if (ret)
 		return false;
+#endif
 
 	/* Initialize PMIC I2C */
 	i2c->base.pa = i2c_info.reg;
@@ -532,9 +548,6 @@ static bool initialize_pmic_i2c(void)
 	i2c_init.own_address1 = pmic_i2c_addr;
 	i2c_init.analog_filter = true;
 	i2c_init.digital_filter_coef = 0;
-
-	i2c->pinctrl = pinctrl;
-	i2c->pinctrl_count = pin_count;
 
 	stm32mp_get_pmic();
 
@@ -586,26 +599,36 @@ void stm32mp_put_pmic(void)
 
 static void register_non_secure_pmic(void)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
 	/* Allow this function to be called when STPMIC1 not used */
 	if (!i2c_handle.base.pa)
 		return;
 
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_non_secure_pinctrl(i2c_handle.pinctrl);
+	stm32mp_register_non_secure_pinctrl(i2c_handle.pinctrl_sleep);
+#else
 	for (n = 0; n < i2c_handle.pinctrl_count; n++)
 		stm32mp_register_non_secure_gpio(i2c_handle.pinctrl[n].bank,
 						 i2c_handle.pinctrl[n].pin);
+#endif
 
 	stm32mp_register_non_secure_periph_iomem(i2c_handle.base.pa);
 }
 
 static void register_secure_pmic(void)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_secure_pinctrl(i2c_handle.pinctrl);
+	stm32mp_register_secure_pinctrl(i2c_handle.pinctrl_sleep);
+#else
 	for (n = 0; n < i2c_handle.pinctrl_count; n++)
 		stm32mp_register_secure_gpio(i2c_handle.pinctrl[n].bank,
 					     i2c_handle.pinctrl[n].pin);
+#endif
 
 	stm32mp_register_secure_periph_iomem(i2c_handle.base.pa);
 	register_pm_driver_cb(pmic_pm, NULL, "stm32mp1-pmic");

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -8,6 +8,7 @@
 #include <config.h>
 #include <console.h>
 #include <drivers/gic.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_etzpc.h>
 #include <drivers/stm32_iwdg.h>
 #include <drivers/stm32_tamp.h>
@@ -535,3 +536,6 @@ static TEE_Result init_debug(void)
 }
 early_init_late(init_debug);
 #endif /* CFG_STM32_DEBUG_ACCESS */
+
+/* Some generic resources need to be unpaged */
+DECLARE_KEEP_PAGER(pinctrl_apply_state);

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -408,33 +408,6 @@ static bool __maybe_unused bank_is_valid(unsigned int bank)
 	panic();
 }
 
-vaddr_t stm32_get_gpio_bank_base(unsigned int bank)
-{
-	static struct io_pa_va base = { .pa = GPIOA_BASE };
-
-	static_assert(GPIO_BANK_A == 0);
-	assert(bank_is_valid(bank));
-
-	if (IS_ENABLED(CFG_STM32MP15)) {
-		static struct io_pa_va zbase = { .pa = GPIOZ_BASE };
-
-		/* Get secure mapping address for GPIOZ */
-		if (bank == GPIO_BANK_Z)
-			return io_pa_or_va_secure(&zbase, GPIO_BANK_OFFSET);
-
-		/* Other are mapped non-secure */
-		return io_pa_or_va_nsec(&base, (bank + 1) * GPIO_BANK_OFFSET) +
-		       (bank * GPIO_BANK_OFFSET);
-	}
-
-	if (IS_ENABLED(CFG_STM32MP13))
-		return io_pa_or_va_secure(&base,
-					  (bank + 1) * GPIO_BANK_OFFSET) +
-		       (bank * GPIO_BANK_OFFSET);
-
-	panic();
-}
-
 unsigned int stm32_get_gpio_bank_offset(unsigned int bank)
 {
 	assert(bank_is_valid(bank));

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -445,28 +445,6 @@ unsigned int stm32_get_gpio_bank_offset(unsigned int bank)
 	return bank * GPIO_BANK_OFFSET;
 }
 
-unsigned int stm32_get_gpio_bank_clock(unsigned int bank)
-{
-	assert(bank_is_valid(bank));
-
-#ifdef CFG_STM32MP15
-	if (bank == GPIO_BANK_Z)
-		return GPIOZ;
-#endif
-
-	return GPIOA + bank;
-}
-
-struct clk *stm32_get_gpio_bank_clk(unsigned int bank)
-{
-	assert(bank_is_valid(bank));
-
-	if (!IS_ENABLED(CFG_DRIVERS_CLK))
-		return NULL;
-
-	return stm32mp_rcc_clock_id_to_clk(stm32_get_gpio_bank_clock(bank));
-}
-
 #ifdef CFG_STM32_IWDG
 TEE_Result stm32_get_iwdg_otp_config(paddr_t pbase,
 				     struct stm32_iwdg_otp_data *otp_data)

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -433,23 +433,6 @@ bool stm32mp_periph_is_secure(enum stm32mp_shres id)
 	return shres_state[id] == SHRES_SECURE;
 }
 
-bool stm32mp_gpio_bank_is_shared(unsigned int bank)
-{
-	unsigned int not_secure = 0;
-	unsigned int pin = 0;
-
-	lock_registering();
-
-	if (bank != GPIO_BANK_Z)
-		return false;
-
-	for (pin = 0; pin < get_gpioz_nbpin(); pin++)
-		if (!stm32mp_periph_is_secure(STM32MP1_SHRES_GPIOZ(pin)))
-			not_secure++;
-
-	return not_secure > 0 && not_secure < get_gpioz_nbpin();
-}
-
 bool stm32mp_gpio_bank_is_non_secure(unsigned int bank)
 {
 	unsigned int not_secure = 0;

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2017-2022, STMicroelectronics
+ * Copyright (c) 2017-2023, STMicroelectronics
  */
 
 #include <config.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_etzpc.h>
 #include <drivers/stm32_gpio.h>
 #include <drivers/stm32mp1_etzpc.h>
@@ -368,6 +369,56 @@ void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin)
 	default:
 		break;
 	}
+}
+
+void stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl)
+{
+	unsigned int *bank = NULL;
+	unsigned int *pin = NULL;
+	size_t count = 0;
+	size_t n = 0;
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, NULL, NULL, &count);
+	if (!count)
+		return;
+
+	bank = calloc(count, sizeof(*bank));
+	pin = calloc(count, sizeof(*pin));
+	if (!bank || !pin)
+		panic();
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, bank, pin, &count);
+
+	for (n = 0; n < count; n++)
+		stm32mp_register_secure_gpio(bank[n], pin[n]);
+
+	free(bank);
+	free(pin);
+}
+
+void stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl)
+{
+	unsigned int *bank = NULL;
+	unsigned int *pin = NULL;
+	size_t count = 0;
+	size_t n = 0;
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, NULL, NULL, &count);
+	if (!count)
+		return;
+
+	bank = calloc(count, sizeof(*bank));
+	pin = calloc(count, sizeof(*pin));
+	if (!bank || !pin)
+		panic();
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, bank, pin, &count);
+
+	for (n = 0; n < count; n++)
+		stm32mp_register_non_secure_gpio(bank[n], pin[n]);
+
+	free(bank);
+	free(pin);
 }
 
 static void lock_registering(void)

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -272,9 +272,6 @@ bool stm32mp_periph_is_secure(enum stm32mp_shres id);
 /* Return true if and only if GPIO bank @bank is registered as secure */
 bool stm32mp_gpio_bank_is_secure(unsigned int bank);
 
-/* Return true if and only if GPIO bank @bank is registered as shared */
-bool stm32mp_gpio_bank_is_shared(unsigned int bank);
-
 /* Return true if and only if GPIO bank @bank is registered as non-secure */
 bool stm32mp_gpio_bank_is_non_secure(unsigned int bank);
 

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -8,6 +8,7 @@
 
 #include <assert.h>
 #include <drivers/clk.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_bsec.h>
 #include <kernel/panic.h>
 #include <stdint.h>
@@ -254,6 +255,20 @@ void stm32mp_register_secure_gpio(unsigned int bank, unsigned int pin);
  */
 void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin);
 
+/*
+ * Register pin resource of a pin control state as a secure peripheral
+ * @bank: Bank of the target GPIO
+ * @pin: Bit position of the target GPIO in the bank
+ */
+void stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl);
+
+/*
+ * Register pin resource of a pin control state as a non-secure peripheral
+ * @bank: Bank of the target GPIO
+ * @pin: Bit position of the target GPIO in the bank
+ */
+void stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl);
+
 /* Return true if and only if resource @id is registered as secure */
 bool stm32mp_periph_is_secure(enum stm32mp_shres id);
 
@@ -297,6 +312,16 @@ static inline void stm32mp_register_secure_gpio(unsigned int bank __unused,
 
 static inline void stm32mp_register_non_secure_gpio(unsigned int bank __unused,
 						    unsigned int pin __unused)
+{
+}
+
+static inline
+void stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl __unused)
+{
+}
+
+static inline
+void stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl __unused)
 {
 }
 

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -43,7 +43,6 @@ vaddr_t get_gicd_base(void);
  * check DT configuration matches platform implementation of the banks
  * description.
  */
-vaddr_t stm32_get_gpio_bank_base(unsigned int bank);
 unsigned int stm32_get_gpio_bank_offset(unsigned int bank);
 
 /* Platform util for PMIC support */

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -45,8 +45,6 @@ vaddr_t get_gicd_base(void);
  */
 vaddr_t stm32_get_gpio_bank_base(unsigned int bank);
 unsigned int stm32_get_gpio_bank_offset(unsigned int bank);
-unsigned int stm32_get_gpio_bank_clock(unsigned int bank);
-struct clk *stm32_get_gpio_bank_clk(unsigned int bank);
 
 /* Platform util for PMIC support */
 bool stm32mp_with_pmic(void);

--- a/core/drivers/atmel_piobu.c
+++ b/core/drivers/atmel_piobu.c
@@ -204,13 +204,13 @@ static const struct gpio_ops atmel_piobu_ops = {
 	.set_interrupt = secumod_gpio_set_interrupt,
 };
 
-static struct gpio *secumod_dt_get(struct dt_driver_phandle_args *a, void *data,
+static struct gpio *secumod_dt_get(struct dt_pargs *pargs, void *data,
 				   TEE_Result *res)
 {
 	struct gpio *gpio = NULL;
 	struct gpio_chip *chip = data;
 
-	gpio = gpio_dt_alloc_pin(a, res);
+	gpio = gpio_dt_alloc_pin(pargs, res);
 	if (*res)
 		return NULL;
 

--- a/core/drivers/clk/clk-stm32-core.c
+++ b/core/drivers/clk/clk-stm32-core.c
@@ -544,7 +544,7 @@ struct clk *stm32mp_rcc_clock_id_to_clk(unsigned long clock_id)
 	return priv->clk_refs[clock_id];
 }
 
-static struct clk *stm32mp_clk_dt_get_clk(struct dt_driver_phandle_args *pargs,
+static struct clk *stm32mp_clk_dt_get_clk(struct dt_pargs *pargs,
 					  void *data __unused, TEE_Result *res)
 {
 	unsigned long clock_id = pargs->args[0];

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1499,7 +1499,7 @@ static TEE_Result register_stm32mp1_clocks(void)
 	return TEE_SUCCESS;
 }
 
-static struct clk *stm32mp1_clk_dt_get_clk(struct dt_driver_phandle_args *pargs,
+static struct clk *stm32mp1_clk_dt_get_clk(struct dt_pargs *pargs,
 					   void *data __unused, TEE_Result *res)
 {
 	unsigned long clock_id = pargs->args[0];

--- a/core/drivers/clk/sam/at91_clk.h
+++ b/core/drivers/clk/sam/at91_clk.h
@@ -130,8 +130,7 @@ struct pmc_data *pmc_data_allocate(unsigned int ncore, unsigned int nsystem,
 				   unsigned int nperiph, unsigned int ngck,
 				   unsigned int npck);
 
-struct clk *clk_dt_pmc_get(struct dt_driver_phandle_args *args, void *data,
-			   TEE_Result *res);
+struct clk *clk_dt_pmc_get(struct dt_pargs *args, void *data, TEE_Result *res);
 
 struct clk *pmc_clk_get_by_name(struct pmc_clk *clks, unsigned int nclk,
 				const char *name);

--- a/core/drivers/clk/sam/at91_pmc.c
+++ b/core/drivers/clk/sam/at91_pmc.c
@@ -80,7 +80,7 @@ TEE_Result pmc_clk_get(struct pmc_data *pmc, unsigned int type,
 	return TEE_SUCCESS;
 }
 
-struct clk *clk_dt_pmc_get(struct dt_driver_phandle_args *clkspec, void *data,
+struct clk *clk_dt_pmc_get(struct dt_pargs *clkspec, void *data,
 			   TEE_Result *res)
 {
 	unsigned int type = clkspec->args[0];

--- a/core/drivers/crypto/se050/glue/i2c_stm32.c
+++ b/core/drivers/crypto/se050/glue/i2c_stm32.c
@@ -34,13 +34,8 @@ TEE_Result native_i2c_transfer(struct rpc_i2c_request *req, size_t *bytes)
 }
 
 static int dt_i2c_bus_config(struct stm32_i2c_init_s *init,
-#ifdef CFG_DRIVERS_PINCTRL
 			     struct pinctrl_state **pinctrl_active,
-			     struct pinctrl_state **pinctrl_sleep
-#else
-			     struct stm32_pinctrl **pctrl,  size_t *pcnt
-#endif
-			     )
+			     struct pinctrl_state **pinctrl_sleep)
 {
 	const fdt32_t *cuint = NULL;
 	const char *path = NULL;
@@ -68,12 +63,8 @@ static int dt_i2c_bus_config(struct stm32_i2c_init_s *init,
 	else if (I2C_STANDARD_RATE != CFG_CORE_SE05X_BAUDRATE)
 		IMSG("SE05x ignoring CFG_CORE_SE05X_BAUDRATE, use built-in");
 
-#ifdef CFG_DRIVERS_PINCTRL
 	return stm32_i2c_get_setup_from_fdt(fdt, node, init, pinctrl_active,
 					    pinctrl_sleep);
-#else
-	return stm32_i2c_get_setup_from_fdt(fdt, node, init, pctrl, pcnt);
-#endif
 }
 
 int native_i2c_init(void)
@@ -85,13 +76,8 @@ int native_i2c_init(void)
 		return 0;
 
 	/* Support only one device on the platform */
-#ifdef CFG_DRIVERS_PINCTRL
 	if (dt_i2c_bus_config(&i2c_init, &i2c.pinctrl, &i2c.pinctrl_sleep))
 		return -1;
-#else
-	if (dt_i2c_bus_config(&i2c_init, &pinctrl, &pin_count))
-		return -1;
-#endif
 
 	/* Probe the device */
 	i2c_init.own_address1 = SMCOM_I2C_ADDRESS;

--- a/core/drivers/gpio/gpio.c
+++ b/core/drivers/gpio/gpio.c
@@ -11,12 +11,11 @@
 #include <tee_api_types.h>
 #include <util.h>
 
-struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a,
-			       TEE_Result *res)
+struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs, TEE_Result *res)
 {
 	struct gpio *gpio = NULL;
 
-	if (a->args_count != 2) {
+	if (pargs->args_count != 2) {
 		*res = TEE_ERROR_BAD_PARAMETERS;
 		return NULL;
 	}
@@ -27,8 +26,8 @@ struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a,
 		return NULL;
 	}
 
-	gpio->pin = a->args[0];
-	gpio->dt_flags = a->args[1];
+	gpio->pin = pargs->args[0];
+	gpio->dt_flags = pargs->args[1];
 
 	*res = TEE_SUCCESS;
 	return gpio;

--- a/core/drivers/i2c/atmel_i2c.c
+++ b/core/drivers/i2c/atmel_i2c.c
@@ -278,13 +278,13 @@ static const struct i2c_ctrl_ops atmel_i2c_ops = {
 	.smbus = atmel_i2c_smbus,
 };
 
-static struct i2c_dev *atmel_i2c_get_dt_i2c(struct dt_driver_phandle_args *a,
-					    void *data, TEE_Result *res)
+static struct i2c_dev *atmel_i2c_get_dt_i2c(struct dt_pargs *args, void *data,
+					    TEE_Result *res)
 {
 	struct i2c_dev *i2c_dev = NULL;
 	struct i2c_ctrl *i2c_ctrl = data;
 
-	i2c_dev = i2c_create_dev(i2c_ctrl, a->fdt, a->phandle_node);
+	i2c_dev = i2c_create_dev(i2c_ctrl, args->fdt, args->phandle_node);
 	if (!i2c_dev) {
 		*res = TEE_ERROR_OUT_OF_MEMORY;
 		return NULL;

--- a/core/drivers/pinctrl/atmel_pio.c
+++ b/core/drivers/pinctrl/atmel_pio.c
@@ -76,7 +76,7 @@ static const struct pinctrl_ops pio_pinctrl_ops = {
 	.conf_free = pio_conf_free,
 };
 
-static struct pinconf *pio_pinctrl_dt_get(struct dt_driver_phandle_args *a,
+static struct pinconf *pio_pinctrl_dt_get(struct dt_pargs *pargs,
 					  void *data, TEE_Result *res)
 {
 	int i = 0;
@@ -94,7 +94,8 @@ static struct pinconf *pio_pinctrl_dt_get(struct dt_driver_phandle_args *a,
 	struct atmel_pio *atmel_pio = data;
 	struct atmel_pio_pin_conf *pio_conf = NULL;
 
-	prop = fdt_getprop(a->fdt, a->phandle_node, "pinmux", &prop_count);
+	prop = fdt_getprop(pargs->fdt, pargs->phandle_node, "pinmux",
+			   &prop_count);
 	if (!prop) {
 		*res = TEE_ERROR_ITEM_NOT_FOUND;
 		return NULL;

--- a/core/drivers/rstctrl/stm32_rstctrl.c
+++ b/core/drivers/rstctrl/stm32_rstctrl.c
@@ -179,7 +179,7 @@ struct rstctrl *stm32mp_rcc_reset_id_to_rstctrl(unsigned int binding_id)
 	return &rstline->rstctrl;
 }
 
-static struct rstctrl *stm32_rstctrl_get_dev(struct dt_driver_phandle_args *arg,
+static struct rstctrl *stm32_rstctrl_get_dev(struct dt_pargs *arg,
 					     void *priv_data __unused,
 					     TEE_Result *res)
 {

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -266,33 +266,33 @@ static void set_gpio_cfg(uint32_t bank_id, uint32_t pin, struct gpio_cfg *cfg)
 
 	/* Load GPIO MODE value, 2bit value shifted by twice the pin number */
 	io_clrsetbits32(bank->base + GPIO_MODER_OFFSET,
-			GPIO_MODE_MASK << (pin << 1),
-			cfg->mode << (pin << 1));
+			SHIFT_U32(GPIO_MODE_MASK, pin << 1),
+			SHIFT_U32(cfg->mode, pin << 1));
 
 	/* Load GPIO Output TYPE value, 1bit shifted by pin number value */
 	io_clrsetbits32(bank->base + GPIO_OTYPER_OFFSET, BIT(pin),
-			cfg->otype << pin);
+			SHIFT_U32(cfg->otype, pin));
 
 	/* Load GPIO Output Speed confguration, 2bit value */
 	io_clrsetbits32(bank->base + GPIO_OSPEEDR_OFFSET,
-			GPIO_OSPEED_MASK << (pin << 1),
-			cfg->ospeed << (pin << 1));
+			SHIFT_U32(GPIO_OSPEED_MASK, pin << 1),
+			SHIFT_U32(cfg->ospeed, pin << 1));
 
 	/* Load GPIO pull configuration, 2bit value */
 	io_clrsetbits32(bank->base + GPIO_PUPDR_OFFSET, BIT(pin),
-			cfg->pupd << (pin << 1));
+			SHIFT_U32(cfg->pupd, pin << 1));
 
 	/* Load pin mux Alternate Function configuration, 4bit value */
 	if (pin < GPIO_ALT_LOWER_LIMIT) {
 		io_clrsetbits32(bank->base + GPIO_AFRL_OFFSET,
-				GPIO_ALTERNATE_MASK << (pin << 2),
-				cfg->af << (pin << 2));
+				SHIFT_U32(GPIO_ALTERNATE_MASK, pin << 2),
+				SHIFT_U32(cfg->af, pin << 2));
 	} else {
 		size_t shift = (pin - GPIO_ALT_LOWER_LIMIT) << 2;
 
 		io_clrsetbits32(bank->base + GPIO_AFRH_OFFSET,
-				GPIO_ALTERNATE_MASK << shift,
-				cfg->af << shift);
+				SHIFT_U32(GPIO_ALTERNATE_MASK, shift),
+				SHIFT_U32(cfg->af, shift));
 	}
 
 	/* Load GPIO Output direction confuguration, 1bit */

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -6,6 +6,7 @@
  */
 
 #include <assert.h>
+#include <compiler.h>
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
 #include <drivers/gpio.h>
@@ -55,6 +56,61 @@
 #define DT_GPIO_MODE_MASK	GENMASK_32(7, 0)
 
 #define DT_GPIO_BANK_NAME0	"GPIOA"
+
+#define GPIO_MODE_INPUT		0x0
+#define GPIO_MODE_OUTPUT	0x1
+#define GPIO_MODE_ALTERNATE	0x2
+#define GPIO_MODE_ANALOG	0x3
+
+#define GPIO_OTYPE_PUSH_PULL	0x0
+#define GPIO_OTYPE_OPEN_DRAIN	0x1
+
+#define GPIO_OSPEED_LOW		0x0
+#define GPIO_OSPEED_MEDIUM	0x1
+#define GPIO_OSPEED_HIGH	0x2
+#define GPIO_OSPEED_VERY_HIGH	0x3
+
+#define GPIO_PUPD_NO_PULL	0x0
+#define GPIO_PUPD_PULL_UP	0x1
+#define GPIO_PUPD_PULL_DOWN	0x2
+
+#define GPIO_OD_LEVEL_LOW	0x0
+#define GPIO_OD_LEVEL_HIGH	0x1
+
+/*
+ * GPIO configuration description structured as single 16bit word
+ * for efficient save/restore when GPIO pin suspends or resumes.
+ *
+ * @mode: One of GPIO_MODE_*
+ * @otype: One of GPIO_OTYPE_*
+ * @ospeed: One of GPIO_OSPEED_*
+ * @pupd: One of GPIO_PUPD_*
+ * @od: One of GPIO_OD_*
+ * @af: Alternate function numerical ID between 0 and 15
+ */
+struct gpio_cfg {
+	uint16_t mode:		2;
+	uint16_t otype:		1;
+	uint16_t ospeed:	2;
+	uint16_t pupd:		2;
+	uint16_t od:		1;
+	uint16_t af:		4;
+};
+
+/*
+ * Descrption of a pin and its 2 states muxing
+ *
+ * @bank: GPIO bank identifier as assigned by the platform
+ * @pin: Pin number in the GPIO bank
+ * @cfg: Pin configuration
+ * @active_cfg: Configuration in active state
+ * @standby_cfg: Configuration in standby state
+ */
+struct stm32_pinctrl {
+	uint8_t bank;
+	uint8_t pin;
+	struct gpio_cfg cfg;
+};
 
 /*
  * struct stm32_pinctrl_array - Array of pins in a pin control state

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -428,8 +428,8 @@ static TEE_Result dt_stm32_gpio_bank(const void *fdt, int node,
 }
 
 /* Parse a pinctrl node to register the GPIO banks it describes */
-static TEE_Result __unused dt_stm32_gpio_pinctrl(const void *fdt, int node,
-						 const void *compat_data)
+static TEE_Result dt_stm32_gpio_pinctrl(const void *fdt, int node,
+					const void *compat_data)
 {
 	TEE_Result res = TEE_SUCCESS;
 	const fdt32_t *cuint = NULL;
@@ -611,3 +611,24 @@ void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin, bool secure)
 	clk_disable(clk);
 	cpu_spin_unlock_xrestore(&gpio_lock, exceptions);
 }
+
+static TEE_Result stm32_pinctrl_probe(const void *fdt, int node,
+				      const void *compat_data)
+{
+	/* Register GPIO banks described in this pin control node */
+	return dt_stm32_gpio_pinctrl(fdt, node, compat_data);
+}
+
+static const struct dt_device_match stm32_pinctrl_match_table[] = {
+	{ .compatible = "st,stm32mp135-pinctrl" },
+	{ .compatible = "st,stm32mp157-pinctrl" },
+	{ .compatible = "st,stm32mp157-z-pinctrl" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(stm32_pinctrl_dt_driver) = {
+	.name = "stm32_gpio-pinctrl",
+	.type = DT_DRIVER_PINCTRL,
+	.match_table = stm32_pinctrl_match_table,
+	.probe = stm32_pinctrl_probe,
+};

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -853,6 +853,29 @@ out:
 	*count = pin_count;
 }
 
+void stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl, bool secure)
+{
+	size_t conf_index = 0;
+
+	if (!pinctrl)
+		return;
+
+	for (conf_index = 0; conf_index < pinctrl->conf_count; conf_index++) {
+		struct pinconf *pinconf = pinctrl->confs[conf_index];
+		struct stm32_pinctrl_array *ref = pinconf->priv;
+		struct stm32_pinctrl *pc = NULL;
+		size_t n = 0;
+
+		for (n = 0; n < ref->count; n++) {
+			if (pinconf->ops != &stm32_pinctrl_ops)
+				continue;
+
+			pc = ref->pinctrl + n;
+			stm32_gpio_set_secure_cfg(pc->bank, pc->pin, secure);
+		}
+	}
+}
+
 /* Allocate and return a pinctrl configuration from a DT reference */
 static struct pinconf *stm32_pinctrl_dt_get(struct dt_pargs *pargs,
 					    void *data __unused,

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -258,6 +258,7 @@ static int get_pinctrl_from_fdt(void *fdt, int node,
 		uint32_t pin = 0;
 		uint32_t mode = 0;
 		uint32_t alternate = 0;
+		uint32_t odata = 0;
 		bool opendrain = false;
 
 		pincfg = fdt32_to_cpu(*cuint);
@@ -303,6 +304,20 @@ static int get_pinctrl_from_fdt(void *fdt, int node,
 		if (fdt_getprop(fdt, node, "drive-open-drain", NULL))
 			opendrain = true;
 
+		if (fdt_getprop(fdt, node, "output-high", NULL)) {
+			if (mode == GPIO_MODE_INPUT) {
+				mode = GPIO_MODE_OUTPUT;
+				odata = 1;
+			}
+		}
+
+		if (fdt_getprop(fdt, node, "output-low", NULL)) {
+			if (mode == GPIO_MODE_INPUT) {
+				mode = GPIO_MODE_OUTPUT;
+				odata = 0;
+			}
+		}
+
 		/* Check GPIO bank clock/base address against platform */
 		ckeck_gpio_bank(fdt, bank, pinctrl_node);
 
@@ -315,7 +330,7 @@ static int get_pinctrl_from_fdt(void *fdt, int node,
 			ref->active_cfg.otype = opendrain ? 1 : 0;
 			ref->active_cfg.ospeed = speed;
 			ref->active_cfg.pupd = pull;
-			ref->active_cfg.od = 0;
+			ref->active_cfg.od = odata;
 			ref->active_cfg.af = alternate;
 			/* Default to analog mode for standby state */
 			ref->standby_cfg.mode = GPIO_MODE_ANALOG;

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -302,69 +302,6 @@ static void set_gpio_cfg(uint32_t bank_id, uint32_t pin, struct gpio_cfg *cfg)
 	cpu_spin_unlock_xrestore(&gpio_lock, exceptions);
 }
 
-#if !defined(CFG_DRIVERS_PINCTRL)
-void stm32_pinctrl_load_active_cfg(struct stm32_pinctrl *pinctrl, size_t cnt)
-{
-	size_t n = 0;
-
-	for (n = 0; n < cnt; n++)
-		set_gpio_cfg(pinctrl[n].bank, pinctrl[n].pin,
-			     &pinctrl[n].active_cfg);
-}
-
-void stm32_pinctrl_load_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt)
-{
-	size_t n = 0;
-
-	for (n = 0; n < cnt; n++)
-		set_gpio_cfg(pinctrl[n].bank, pinctrl[n].pin,
-			     &pinctrl[n].standby_cfg);
-}
-
-void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt)
-{
-	size_t n = 0;
-
-	for (n = 0; n < cnt; n++)
-		get_gpio_cfg(pinctrl[n].bank, pinctrl[n].pin,
-			     &pinctrl[n].standby_cfg);
-}
-
-/* Panic if GPIO bank information from platform do not match DTB description */
-static void ckeck_gpio_bank(const void *fdt, uint32_t bank, int pinctrl_node)
-{
-	int pinctrl_subnode = 0;
-
-	fdt_for_each_subnode(pinctrl_subnode, fdt, pinctrl_node) {
-		TEE_Result res = TEE_ERROR_GENERIC;
-		const fdt32_t *cuint = NULL;
-		struct clk *clk = NULL;
-
-		if (fdt_getprop(fdt, pinctrl_subnode,
-				"gpio-controller", NULL) == NULL)
-			continue;
-
-		/* Check bank register offset matches platform assumptions */
-		cuint = fdt_getprop(fdt, pinctrl_subnode, "reg", NULL);
-		if (fdt32_to_cpu(*cuint) != stm32_get_gpio_bank_offset(bank))
-			continue;
-
-		/* Check bank clock matches platform assumptions */
-		res = clk_dt_get_by_index(fdt, pinctrl_subnode, 0, &clk);
-		if (res || clk != stm32_get_gpio_bank_clk(bank))
-			panic();
-
-		/* Check controller is enabled */
-		if (fdt_get_status(fdt, pinctrl_subnode) == DT_STATUS_DISABLED)
-			panic();
-
-		return;
-	}
-
-	panic();
-}
-#endif /*CFG_DRIVERS_PINCTRL*/
-
 /* Count pins described in the DT node and get related data if possible */
 static int get_pinctrl_from_fdt(const void *fdt, int node,
 				struct stm32_pinctrl *pinctrl, size_t count)
@@ -372,7 +309,6 @@ static int get_pinctrl_from_fdt(const void *fdt, int node,
 	const fdt32_t *cuint = NULL;
 	const fdt32_t *slewrate = NULL;
 	int len = 0;
-	int __maybe_unused pinctrl_node = 0;
 	uint32_t i = 0;
 	uint32_t speed = GPIO_OSPEED_LOW;
 	uint32_t pull = GPIO_PUPD_NO_PULL;
@@ -381,12 +317,6 @@ static int get_pinctrl_from_fdt(const void *fdt, int node,
 	cuint = fdt_getprop(fdt, node, "pinmux", &len);
 	if (!cuint)
 		return -FDT_ERR_NOTFOUND;
-
-#if !defined(CFG_DRIVERS_PINCTRL)
-	pinctrl_node = fdt_parent_offset(fdt, fdt_parent_offset(fdt, node));
-	if (pinctrl_node < 0)
-		return -FDT_ERR_NOTFOUND;
-#endif
 
 	slewrate = fdt_getprop(fdt, node, "slew-rate", NULL);
 	if (slewrate)
@@ -463,34 +393,17 @@ static int get_pinctrl_from_fdt(const void *fdt, int node,
 			}
 		}
 
-#if !defined(CFG_DRIVERS_PINCTRL)
-		/* Check GPIO bank clock/base address against platform */
-		ckeck_gpio_bank(fdt, bank, pinctrl_node);
-#endif
-
 		if (found < count) {
 			struct stm32_pinctrl *ref = &pinctrl[found];
 
 			ref->bank = (uint8_t)bank;
 			ref->pin = (uint8_t)pin;
-#ifdef CFG_DRIVERS_PINCTRL
 			ref->cfg.mode = mode;
 			ref->cfg.otype = opendrain ? 1 : 0;
 			ref->cfg.ospeed = speed;
 			ref->cfg.pupd = pull;
 			ref->cfg.od = odata;
 			ref->cfg.af = alternate;
-#else
-			ref->active_cfg.mode = mode;
-			ref->active_cfg.otype = opendrain ? 1 : 0;
-			ref->active_cfg.ospeed = speed;
-			ref->active_cfg.pupd = pull;
-			ref->active_cfg.od = odata;
-			ref->active_cfg.af = alternate;
-			/* Default to analog mode for standby state */
-			ref->standby_cfg.mode = GPIO_MODE_ANALOG;
-			ref->standby_cfg.pupd = GPIO_PUPD_NO_PULL;
-#endif
 		}
 
 		found++;
@@ -712,50 +625,6 @@ static TEE_Result dt_stm32_gpio_pinctrl(const void *fdt, int node,
 	return TEE_SUCCESS;
 }
 
-#ifndef CFG_DRIVERS_PINCTRL
-int stm32_pinctrl_fdt_get_pinctrl(void *fdt, int device_node,
-				  struct stm32_pinctrl *pinctrl, size_t count)
-{
-	const fdt32_t *cuint = NULL;
-	int lenp = 0;
-	int i = 0;
-	size_t found = 0;
-
-	cuint = fdt_getprop(fdt, device_node, "pinctrl-0", &lenp);
-	if (!cuint)
-		return -FDT_ERR_NOTFOUND;
-
-	for (i = 0; i < (lenp / 4); i++) {
-		int node = 0;
-		int subnode = 0;
-
-		node = fdt_node_offset_by_phandle(fdt, fdt32_to_cpu(*cuint));
-		if (node < 0)
-			return -FDT_ERR_NOTFOUND;
-
-		fdt_for_each_subnode(subnode, fdt, node) {
-			size_t n = 0;
-			int rc = 0;
-
-			if (count > found)
-				n = count - found;
-			else
-				n = 0;
-
-			rc = get_pinctrl_from_fdt(fdt, subnode,
-						  &pinctrl[found], n);
-			if (rc < 0)
-				return rc;
-
-			found += (size_t)rc;
-		}
-
-		cuint++;
-	}
-
-	return (int)found;
-}
-#endif /*CFG_DRIVERS_PINCTRL*/
 
 int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank)
 {

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -686,14 +686,8 @@ static int i2c_config_analog_filter(struct i2c_handle_s *hi2c,
 
 TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 					struct stm32_i2c_init_s *init,
-#ifdef CFG_DRIVERS_PINCTRL
 					struct pinctrl_state **pinctrl,
-					struct pinctrl_state **pinctrl_sleep
-#else
-					struct stm32_pinctrl **pinctrl,
-					size_t *pinctrl_count
-#endif
-					)
+					struct pinctrl_state **pinctrl_sleep)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const fdt32_t *cuint = NULL;
@@ -740,7 +734,6 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 		init->bus_rate = I2C_STANDARD_RATE;
 	}
 
-#ifdef CFG_DRIVERS_PINCTRL
 	if (pinctrl) {
 		res = pinctrl_get_state_by_name(fdt, node, "default", pinctrl);
 		if (res)
@@ -753,28 +746,6 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 		if (res)
 			return res;
 	}
-#else
-	count = stm32_pinctrl_fdt_get_pinctrl(fdt, node, NULL, 0);
-	if (count <= 0) {
-		*pinctrl = NULL;
-		*pinctrl_count = count;
-		DMSG("Failed to get pinctrl: FDT errno %d", count);
-		return TEE_ERROR_GENERIC;
-	}
-
-	if (count > 2) {
-		DMSG("Too many PINCTRLs found: %zd", count);
-		return TEE_ERROR_GENERIC;
-	}
-
-	*pinctrl = calloc(count, sizeof(**pinctrl));
-	if (!*pinctrl)
-		return TEE_ERROR_OUT_OF_MEMORY;
-
-	*pinctrl_count = stm32_pinctrl_fdt_get_pinctrl(fdt, node,
-						       *pinctrl, count);
-	assert(*pinctrl_count == (unsigned int)count);
-#endif /*CFG_DRIVERS_PINCTRL*/
 
 	return TEE_SUCCESS;
 }
@@ -857,14 +828,8 @@ int stm32_i2c_init(struct i2c_handle_s *hi2c,
 	if (rc)
 		DMSG("I2C analog filter error %d", rc);
 
-#ifdef CFG_DRIVERS_PINCTRL
 	if (IS_ENABLED(CFG_STM32MP13))
 		stm32_pinctrl_set_secure_cfg(hi2c->pinctrl, true);
-#else
-	if (IS_ENABLED(CFG_STM32MP13))
-		stm32_gpio_set_secure_cfg(hi2c->pinctrl->bank,
-					  hi2c->pinctrl->pin, true);
-#endif
 
 	clk_disable(hi2c->clock);
 
@@ -1555,12 +1520,8 @@ void stm32_i2c_resume(struct i2c_handle_s *hi2c)
 	    (hi2c->i2c_state != I2C_STATE_SUSPENDED))
 		panic();
 
-#ifdef CFG_DRIVERS_PINCTRL
 	if (pinctrl_apply_state(hi2c->pinctrl))
 		panic();
-#else
-	stm32_pinctrl_load_active_cfg(hi2c->pinctrl, hi2c->pinctrl_count);
-#endif
 
 	if (hi2c->i2c_state == I2C_STATE_RESET) {
 		/* There is no valid I2C configuration to be loaded yet */
@@ -1569,14 +1530,8 @@ void stm32_i2c_resume(struct i2c_handle_s *hi2c)
 
 	restore_cfg(hi2c, &hi2c->sec_cfg);
 
-#ifdef CFG_DRIVERS_PINCTRL
 	if (IS_ENABLED(CFG_STM32MP13))
 		stm32_pinctrl_set_secure_cfg(hi2c->pinctrl, true);
-#else
-	if (IS_ENABLED(CFG_STM32MP13))
-		stm32_gpio_set_secure_cfg(hi2c->pinctrl->bank,
-					  hi2c->pinctrl->pin, true);
-#endif
 
 	hi2c->i2c_state = I2C_STATE_READY;
 }
@@ -1591,12 +1546,8 @@ void stm32_i2c_suspend(struct i2c_handle_s *hi2c)
 
 	save_cfg(hi2c, &hi2c->sec_cfg);
 
-#ifdef CFG_DRIVERS_PINCTRL
 	if (pinctrl_apply_state(hi2c->pinctrl_sleep))
 		panic();
-#else
-	stm32_pinctrl_load_standby_cfg(hi2c->pinctrl, hi2c->pinctrl_count);
-#endif
 
 	hi2c->i2c_state = I2C_STATE_SUSPENDED;
 }

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -12,6 +12,8 @@
 #include <arm.h>
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
+#include <drivers/pinctrl.h>
+#include <drivers/stm32_gpio.h>
 #include <drivers/stm32_i2c.h>
 #include <io.h>
 #include <kernel/delay.h>
@@ -684,13 +686,19 @@ static int i2c_config_analog_filter(struct i2c_handle_s *hi2c,
 
 TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 					struct stm32_i2c_init_s *init,
+#ifdef CFG_DRIVERS_PINCTRL
+					struct pinctrl_state **pinctrl,
+					struct pinctrl_state **pinctrl_sleep
+#else
 					struct stm32_pinctrl **pinctrl,
-					size_t *pinctrl_count)
+					size_t *pinctrl_count
+#endif
+					)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const fdt32_t *cuint = NULL;
 	struct dt_node_info info = { .status = 0 };
-	int count = 0;
+	int __maybe_unused count = 0;
 
 	/* Default STM32 specific configs caller may need to overwrite */
 	memset(init, 0, sizeof(*init));
@@ -732,6 +740,20 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 		init->bus_rate = I2C_STANDARD_RATE;
 	}
 
+#ifdef CFG_DRIVERS_PINCTRL
+	if (pinctrl) {
+		res = pinctrl_get_state_by_name(fdt, node, "default", pinctrl);
+		if (res)
+			return res;
+	}
+
+	if (pinctrl_sleep) {
+		res = pinctrl_get_state_by_name(fdt, node, "sleep",
+						pinctrl_sleep);
+		if (res)
+			return res;
+	}
+#else
 	count = stm32_pinctrl_fdt_get_pinctrl(fdt, node, NULL, 0);
 	if (count <= 0) {
 		*pinctrl = NULL;
@@ -752,6 +774,7 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 	*pinctrl_count = stm32_pinctrl_fdt_get_pinctrl(fdt, node,
 						       *pinctrl, count);
 	assert(*pinctrl_count == (unsigned int)count);
+#endif /*CFG_DRIVERS_PINCTRL*/
 
 	return TEE_SUCCESS;
 }
@@ -834,9 +857,14 @@ int stm32_i2c_init(struct i2c_handle_s *hi2c,
 	if (rc)
 		DMSG("I2C analog filter error %d", rc);
 
+#ifdef CFG_DRIVERS_PINCTRL
+	if (IS_ENABLED(CFG_STM32MP13))
+		stm32_pinctrl_set_secure_cfg(hi2c->pinctrl, true);
+#else
 	if (IS_ENABLED(CFG_STM32MP13))
 		stm32_gpio_set_secure_cfg(hi2c->pinctrl->bank,
 					  hi2c->pinctrl->pin, true);
+#endif
 
 	clk_disable(hi2c->clock);
 
@@ -1527,7 +1555,12 @@ void stm32_i2c_resume(struct i2c_handle_s *hi2c)
 	    (hi2c->i2c_state != I2C_STATE_SUSPENDED))
 		panic();
 
+#ifdef CFG_DRIVERS_PINCTRL
+	if (pinctrl_apply_state(hi2c->pinctrl))
+		panic();
+#else
 	stm32_pinctrl_load_active_cfg(hi2c->pinctrl, hi2c->pinctrl_count);
+#endif
 
 	if (hi2c->i2c_state == I2C_STATE_RESET) {
 		/* There is no valid I2C configuration to be loaded yet */
@@ -1536,9 +1569,14 @@ void stm32_i2c_resume(struct i2c_handle_s *hi2c)
 
 	restore_cfg(hi2c, &hi2c->sec_cfg);
 
+#ifdef CFG_DRIVERS_PINCTRL
+	if (IS_ENABLED(CFG_STM32MP13))
+		stm32_pinctrl_set_secure_cfg(hi2c->pinctrl, true);
+#else
 	if (IS_ENABLED(CFG_STM32MP13))
 		stm32_gpio_set_secure_cfg(hi2c->pinctrl->bank,
 					  hi2c->pinctrl->pin, true);
+#endif
 
 	hi2c->i2c_state = I2C_STATE_READY;
 }
@@ -1552,7 +1590,13 @@ void stm32_i2c_suspend(struct i2c_handle_s *hi2c)
 		panic();
 
 	save_cfg(hi2c, &hi2c->sec_cfg);
+
+#ifdef CFG_DRIVERS_PINCTRL
+	if (pinctrl_apply_state(hi2c->pinctrl_sleep))
+		panic();
+#else
 	stm32_pinctrl_load_standby_cfg(hi2c->pinctrl, hi2c->pinctrl_count);
+#endif
 
 	hi2c->i2c_state = I2C_STATE_SUSPENDED;
 }

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -110,22 +110,30 @@ void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base)
 
 static void register_secure_uart(struct stm32_uart_pdata *pd)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
 	stm32mp_register_secure_periph_iomem(pd->base.pa);
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_secure_pinctrl(pd->pinctrl);
+#else
 	for (n = 0; n < pd->pinctrl_count; n++)
 		stm32mp_register_secure_gpio(pd->pinctrl[n].bank,
 					     pd->pinctrl[n].pin);
+#endif
 }
 
 static void register_non_secure_uart(struct stm32_uart_pdata *pd)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
 	stm32mp_register_non_secure_periph_iomem(pd->base.pa);
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_non_secure_pinctrl(pd->pinctrl);
+#else
 	for (n = 0; n < pd->pinctrl_count; n++)
 		stm32mp_register_non_secure_gpio(pd->pinctrl[n].bank,
 						 pd->pinctrl[n].pin);
+#endif
 }
 
 struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
@@ -133,8 +141,10 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct stm32_uart_pdata *pd = NULL;
 	struct dt_node_info info = { };
+#if !defined(CFG_DRIVERS_PINCTRL)
 	struct stm32_pinctrl *pinctrl_cfg = NULL;
 	int count = 0;
+#endif
 
 	fdt_fill_device_info(fdt, &info, node);
 
@@ -167,6 +177,19 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 					    pd->secure ? MEM_AREA_IO_SEC :
 					    MEM_AREA_IO_NSEC, info.reg_size);
 
+#ifdef CFG_DRIVERS_PINCTRL
+	res = pinctrl_get_state_by_name(fdt, node, "default", &pd->pinctrl);
+	if (res)
+		panic();
+
+	res = pinctrl_get_state_by_name(fdt, node, "sleep", &pd->pinctrl_sleep);
+	if (res)
+		panic();
+
+	res = pinctrl_apply_state(pd->pinctrl);
+	if (res)
+		panic();
+#else
 	count = stm32_pinctrl_fdt_get_pinctrl(fdt, node, NULL, 0);
 	if (count < 0)
 		panic();
@@ -181,6 +204,7 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	}
 	pd->pinctrl = pinctrl_cfg;
 	pd->pinctrl_count = count;
+#endif
 
 	if (pd->secure)
 		register_secure_uart(pd);

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -113,13 +113,7 @@ static void register_secure_uart(struct stm32_uart_pdata *pd)
 	size_t __maybe_unused n = 0;
 
 	stm32mp_register_secure_periph_iomem(pd->base.pa);
-#ifdef CFG_DRIVERS_PINCTRL
 	stm32mp_register_secure_pinctrl(pd->pinctrl);
-#else
-	for (n = 0; n < pd->pinctrl_count; n++)
-		stm32mp_register_secure_gpio(pd->pinctrl[n].bank,
-					     pd->pinctrl[n].pin);
-#endif
 }
 
 static void register_non_secure_uart(struct stm32_uart_pdata *pd)
@@ -127,13 +121,7 @@ static void register_non_secure_uart(struct stm32_uart_pdata *pd)
 	size_t __maybe_unused n = 0;
 
 	stm32mp_register_non_secure_periph_iomem(pd->base.pa);
-#ifdef CFG_DRIVERS_PINCTRL
 	stm32mp_register_non_secure_pinctrl(pd->pinctrl);
-#else
-	for (n = 0; n < pd->pinctrl_count; n++)
-		stm32mp_register_non_secure_gpio(pd->pinctrl[n].bank,
-						 pd->pinctrl[n].pin);
-#endif
 }
 
 struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
@@ -141,10 +129,6 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct stm32_uart_pdata *pd = NULL;
 	struct dt_node_info info = { };
-#if !defined(CFG_DRIVERS_PINCTRL)
-	struct stm32_pinctrl *pinctrl_cfg = NULL;
-	int count = 0;
-#endif
 
 	fdt_fill_device_info(fdt, &info, node);
 
@@ -177,7 +161,6 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 					    pd->secure ? MEM_AREA_IO_SEC :
 					    MEM_AREA_IO_NSEC, info.reg_size);
 
-#ifdef CFG_DRIVERS_PINCTRL
 	res = pinctrl_get_state_by_name(fdt, node, "default", &pd->pinctrl);
 	if (res)
 		panic();
@@ -189,22 +172,6 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	res = pinctrl_apply_state(pd->pinctrl);
 	if (res)
 		panic();
-#else
-	count = stm32_pinctrl_fdt_get_pinctrl(fdt, node, NULL, 0);
-	if (count < 0)
-		panic();
-
-	if (count) {
-		pinctrl_cfg = calloc(count, sizeof(*pinctrl_cfg));
-		if (!pinctrl_cfg)
-			panic();
-
-		stm32_pinctrl_fdt_get_pinctrl(fdt, node, pinctrl_cfg, count);
-		stm32_pinctrl_load_active_cfg(pinctrl_cfg, count);
-	}
-	pd->pinctrl = pinctrl_cfg;
-	pd->pinctrl_count = count;
-#endif
 
 	if (pd->secure)
 		register_secure_uart(pd);

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -75,8 +75,8 @@ TEE_Result clk_dt_get_by_name(const void *fdt, int nodeoffset,
  * description or NULL if invalid description in which case @res provides the
  * error code.
  */
-typedef struct clk *(*clk_dt_get_func)(struct dt_driver_phandle_args *args,
-				       void *data, TEE_Result *res);
+typedef struct clk *(*clk_dt_get_func)(struct dt_pargs *args, void *data,
+				       TEE_Result *res);
 
 /**
  * clk_dt_register_clk_provider - Register a clock provider
@@ -100,9 +100,8 @@ TEE_Result clk_dt_register_clk_provider(const void *fdt, int nodeoffset,
  * clk_dt_get_simple_clk: simple clock matching function for single clock
  * providers
  */
-static inline
-struct clk *clk_dt_get_simple_clk(struct dt_driver_phandle_args *args __unused,
-				  void *data, TEE_Result *res)
+static inline struct clk *clk_dt_get_simple_clk(struct dt_pargs *args __unused,
+						void *data, TEE_Result *res)
 {
 	*res = TEE_SUCCESS;
 

--- a/core/include/drivers/gpio.h
+++ b/core/include/drivers/gpio.h
@@ -127,8 +127,7 @@ static inline enum gpio_level gpio_get_value(struct gpio *gpio)
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a,
-			       TEE_Result *res);
+struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs, TEE_Result *res);
 
 /**
  * gpio_dt_get_by_index() - Get a GPIO controller at a specific index in
@@ -158,9 +157,8 @@ static inline TEE_Result gpio_dt_get_by_index(const void *fdt __unused,
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-static inline
-struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a __unused,
-			       TEE_Result *res)
+static inline struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs __unused,
+					     TEE_Result *res)
 {
 	*res = TEE_ERROR_NOT_SUPPORTED;
 	return NULL;
@@ -182,8 +180,8 @@ struct gpio *gpio_dt_alloc_pin(struct dt_driver_phandle_args *a __unused,
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-typedef struct gpio *(*gpio_dt_get_func)(struct dt_driver_phandle_args *a,
-					 void *data, TEE_Result *res);
+typedef struct gpio *(*gpio_dt_get_func)(struct dt_pargs *pargs, void *data,
+					 TEE_Result *res);
 
 /**
  * gpio_dt_register_provider() - Register a GPIO controller provider

--- a/core/include/drivers/i2c.h
+++ b/core/include/drivers/i2c.h
@@ -239,8 +239,8 @@ static inline TEE_Result i2c_dt_get_dev(const void *fdt __unused,
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-typedef struct i2c_dev *(*i2c_dt_get_func)(struct dt_driver_phandle_args *a,
-					   void *data, TEE_Result *res);
+typedef struct i2c_dev *(*i2c_dt_get_func)(struct dt_pargs *args, void *data,
+					   TEE_Result *res);
 
 /**
  * i2c_dt_register_provider - Register a I2C controller provider and add all the

--- a/core/include/drivers/pinctrl.h
+++ b/core/include/drivers/pinctrl.h
@@ -49,7 +49,7 @@ struct pinctrl_ops {
 	void (*conf_free)(struct pinconf *conf);
 };
 
-typedef struct pinconf *(*pinctrl_dt_get_func)(struct dt_driver_phandle_args *a,
+typedef struct pinconf *(*pinctrl_dt_get_func)(struct dt_pargs *pargs,
 					       void *data, TEE_Result *res);
 
 #ifdef CFG_DRIVERS_PINCTRL

--- a/core/include/drivers/pinctrl.h
+++ b/core/include/drivers/pinctrl.h
@@ -155,7 +155,6 @@ TEE_Result pinctrl_get_state_by_idx(const void *fdt __unused,
 static inline
 void pinctrl_free_state(struct pinctrl_state *state __unused)
 {
-	return TEE_ERROR_NOT_SUPPORTED;
 }
 
 static inline

--- a/core/include/drivers/rstctrl.h
+++ b/core/include/drivers/rstctrl.h
@@ -210,7 +210,7 @@ TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-typedef struct rstctrl *(*rstctrl_dt_get_func)(struct dt_driver_phandle_args *a,
+typedef struct rstctrl *(*rstctrl_dt_get_func)(struct dt_pargs *args,
 					       void *data, TEE_Result *res);
 
 /**

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -111,47 +111,6 @@ void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
 int stm32_pinctrl_fdt_get_pinctrl(void *fdt, int node,
 				  struct stm32_pinctrl *pinctrl, size_t count);
 
-/*
- * Set target output GPIO pin to high or low level
- *
- * @bank: GPIO bank identifier as assigned by the platform
- * @pin: GPIO pin position in the GPIO bank
- * @high: 1 to set GPIO to high level, 0 to set to GPIO low level
- */
-void stm32_gpio_set_output_level(unsigned int bank, unsigned int pin, int high);
-
-/*
- * Set output GPIO pin referenced by @pinctrl to high or low level
- *
- * @pinctrl: Reference to pinctrl
- * @high: 1 to set GPIO to high level, 0 to set to GPIO low level
- */
-static inline void stm32_pinctrl_set_gpio_level(struct stm32_pinctrl *pinctrl,
-						int high)
-{
-	stm32_gpio_set_output_level(pinctrl->bank, pinctrl->pin, high);
-}
-
-/*
- * Get input GPIO pin current level, high or low
- *
- * @bank: GPIO bank identifier as assigned by the platform
- * @pin: GPIO pin position in the GPIO bank
- * Return 1 if GPIO level is high, 0 if it is low
- */
-int stm32_gpio_get_input_level(unsigned int bank, unsigned int pin);
-
-/*
- * Set target output GPIO pin to high or low level
- *
- * @pinctrl: Reference to pinctrl
- * Return 1 if GPIO level is high, 0 if it is low
- */
-static inline int stm32_pinctrl_get_gpio_level(struct stm32_pinctrl *pinctrl)
-{
-	return stm32_gpio_get_input_level(pinctrl->bank, pinctrl->pin);
-}
-
 #ifdef CFG_STM32_GPIO
 /*
  * Configure pin muxing access permission: can be secure or not

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -33,6 +33,8 @@
 #define GPIO_OD_LEVEL_LOW	0x0
 #define GPIO_OD_LEVEL_HIGH	0x1
 
+struct pinctrl_state;
+
 /*
  * GPIO configuration description structured as single 16bit word
  * for efficient save/restore when GPIO pin suspends or resumes.
@@ -142,4 +144,25 @@ static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
  */
 int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
+#ifdef CFG_DRIVERS_PINCTRL
+/*
+ * Get the bank and pin indices related to a pin control state
+ * @pinctrl: Pinctrl state
+ * @bank: Output bank indices array or NULL
+ * @pin: Output pin indices array or NULL
+ * @count: [in] Number of cells of @bank and @pin, [out] pin count in @pinctrl
+ */
+void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *pinctrl,
+				 unsigned int *bank, unsigned int *pin,
+				 unsigned int *count);
+#else
+static inline
+void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *p __unused,
+				 unsigned int *bank __unused,
+				 unsigned int *pin __unused,
+				 unsigned int *count __maybe_unused)
+{
+	assert(!count);
+}
+#endif /*CFG_DRIVERS_PINCTRL*/
 #endif /*DRIVERS_STM32_GPIO_H*/

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -1,19 +1,14 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2017-2019, STMicroelectronics
- *
- * STM32 GPIO driver relies on platform util fiunctions to get base address
- * and clock ID of the GPIO banks. The drvier API allows to retrieve pin muxing
- * configuration for given nodes and load them at runtime. A pin control
- * instance provide an active and a standby configuration. Pin onwer is
- * responsible to load to expected configuration during PM state transitions
- * as STM32 GPIO driver does no register callbacks to the PM framework.
+ * Copyright (c) 2017-2023, STMicroelectronics
  */
 
 #ifndef DRIVERS_STM32_GPIO_H
 #define DRIVERS_STM32_GPIO_H
 
 #include <assert.h>
+#include <compiler.h>
+#include <drivers/pinctrl.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -63,16 +58,22 @@ struct gpio_cfg {
  *
  * @bank: GPIO bank identifier as assigned by the platform
  * @pin: Pin number in the GPIO bank
+ * @cfg: Pin configuration
  * @active_cfg: Configuration in active state
  * @standby_cfg: Configuration in standby state
  */
 struct stm32_pinctrl {
 	uint8_t bank;
 	uint8_t pin;
+#ifdef CFG_DRIVERS_PINCTRL
+	struct gpio_cfg cfg;
+#else
 	struct gpio_cfg active_cfg;
 	struct gpio_cfg standby_cfg;
+#endif
 };
 
+#ifndef CFG_DRIVERS_PINCTRL
 /*
  * Apply series of pin muxing configuration, active state and standby state
  *
@@ -89,6 +90,7 @@ void stm32_pinctrl_load_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
  * @count: Number of entries in @pinctrl
  */
 void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
+#endif
 
 /*
  * Save pinctrl instances defined in DT node: identifiers and power states

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -67,32 +67,8 @@ struct gpio_cfg {
 struct stm32_pinctrl {
 	uint8_t bank;
 	uint8_t pin;
-#ifdef CFG_DRIVERS_PINCTRL
 	struct gpio_cfg cfg;
-#else
-	struct gpio_cfg active_cfg;
-	struct gpio_cfg standby_cfg;
-#endif
 };
-
-#ifndef CFG_DRIVERS_PINCTRL
-/*
- * Apply series of pin muxing configuration, active state and standby state
- *
- * @pinctrl: array of pinctrl references
- * @count: Number of entries in @pinctrl
- */
-void stm32_pinctrl_load_active_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
-void stm32_pinctrl_load_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
-
-/*
- * Save the current pin configuration as the standby state for a pin series
- *
- * @pinctrl: array of pinctrl references
- * @count: Number of entries in @pinctrl
- */
-void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
-#endif
 
 /*
  * Save pinctrl instances defined in DT node: identifiers and power states
@@ -125,14 +101,6 @@ int stm32_pinctrl_fdt_get_pinctrl(void *fdt, int node,
  */
 void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin,
 			       bool secure);
-#else
-static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
-					     unsigned int pin __unused,
-					     bool secure __unused)
-{
-	assert(0);
-}
-#endif
 
 /*
  * Get the number of GPIO pins supported by a target GPIO bank
@@ -144,7 +112,6 @@ static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
  */
 int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
-#ifdef CFG_DRIVERS_PINCTRL
 /*
  * Configure pin muxing access permission: can be secure or not
  *
@@ -179,5 +146,5 @@ void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *p __unused,
 {
 	assert(!count);
 }
-#endif /*CFG_DRIVERS_PINCTRL*/
+#endif /*CFG_STM32_GPIO*/
 #endif /*DRIVERS_STM32_GPIO_H*/

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -10,8 +10,8 @@
  * as STM32 GPIO driver does no register callbacks to the PM framework.
  */
 
-#ifndef __STM32_GPIO_H
-#define __STM32_GPIO_H
+#ifndef DRIVERS_STM32_GPIO_H
+#define DRIVERS_STM32_GPIO_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -181,4 +181,4 @@ static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
  */
 int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
-#endif /*__STM32_GPIO_H*/
+#endif /*DRIVERS_STM32_GPIO_H*/

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -7,68 +7,13 @@
 #define DRIVERS_STM32_GPIO_H
 
 #include <assert.h>
-#include <compiler.h>
 #include <drivers/pinctrl.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 
-#define GPIO_MODE_INPUT		0x0
-#define GPIO_MODE_OUTPUT	0x1
-#define GPIO_MODE_ALTERNATE	0x2
-#define GPIO_MODE_ANALOG	0x3
-
-#define GPIO_OTYPE_PUSH_PULL	0x0
-#define GPIO_OTYPE_OPEN_DRAIN	0x1
-
-#define GPIO_OSPEED_LOW		0x0
-#define GPIO_OSPEED_MEDIUM	0x1
-#define GPIO_OSPEED_HIGH	0x2
-#define GPIO_OSPEED_VERY_HIGH	0x3
-
-#define GPIO_PUPD_NO_PULL	0x0
-#define GPIO_PUPD_PULL_UP	0x1
-#define GPIO_PUPD_PULL_DOWN	0x2
-
-#define GPIO_OD_LEVEL_LOW	0x0
-#define GPIO_OD_LEVEL_HIGH	0x1
-
 struct pinctrl_state;
-
-/*
- * GPIO configuration description structured as single 16bit word
- * for efficient save/restore when GPIO pin suspends or resumes.
- *
- * @mode: One of GPIO_MODE_*
- * @otype: One of GPIO_OTYPE_*
- * @ospeed: One of GPIO_OSPEED_*
- * @pupd: One of GPIO_PUPD_*
- * @od: One of GPIO_OD_*
- * @af: Alternate function numerical ID between 0 and 15
- */
-struct gpio_cfg {
-	uint16_t mode:		2;
-	uint16_t otype:		1;
-	uint16_t ospeed:	2;
-	uint16_t pupd:		2;
-	uint16_t od:		1;
-	uint16_t af:		4;
-};
-
-/*
- * Descrption of a pin and its 2 states muxing
- *
- * @bank: GPIO bank identifier as assigned by the platform
- * @pin: Pin number in the GPIO bank
- * @cfg: Pin configuration
- * @active_cfg: Configuration in active state
- * @standby_cfg: Configuration in standby state
- */
-struct stm32_pinctrl {
-	uint8_t bank;
-	uint8_t pin;
-	struct gpio_cfg cfg;
-};
+struct stm32_pinctrl;
 
 /*
  * Save pinctrl instances defined in DT node: identifiers and power states

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -146,6 +146,14 @@ int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
 #ifdef CFG_DRIVERS_PINCTRL
 /*
+ * Configure pin muxing access permission: can be secure or not
+ *
+ * @pinctrl: Pin control state where STM32_GPIO pin are to configure
+ * @secure: True if pin is secure, false otherwise
+ */
+void stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl, bool secure);
+
+/*
  * Get the bank and pin indices related to a pin control state
  * @pinctrl: Pinctrl state
  * @bank: Output bank indices array or NULL
@@ -156,6 +164,13 @@ void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *pinctrl,
 				 unsigned int *bank, unsigned int *pin,
 				 unsigned int *count);
 #else
+static inline
+void stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl __maybe_unused,
+				  bool secure __unused)
+{
+	assert(!pinctrl);
+}
+
 static inline
 void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *p __unused,
 				 unsigned int *bank __unused,

--- a/core/include/drivers/stm32_i2c.h
+++ b/core/include/drivers/stm32_i2c.h
@@ -8,7 +8,6 @@
 
 #include <drivers/clk.h>
 #include <drivers/pinctrl.h>
-#include <drivers/stm32_gpio.h>
 #include <kernel/dt.h>
 #include <mm/core_memprot.h>
 #include <stdbool.h>
@@ -112,11 +111,8 @@ struct i2c_cfg {
  * @saved_timing: Saved timing value if already computed
  * @saved_frequency: Saved frequency value if already computed
  * @sec_cfg: I2C registers configuration storage
- * Case CFG_DRIVERS_PINCTRL
  * @pinctrl: Pin control configuration for the I2C bus in active state
  * @pinctrl_sleep: Pin control configuration for the I2C bus in standby state
- * Case !CFG_DRIVERS_PINCTRL
- * @pinctrl: PINCTRLs configuration for the I2C PINs
  * @pinctrl_count: Number of PINCTRLs elements
  */
 struct i2c_handle_s {
@@ -129,13 +125,8 @@ struct i2c_handle_s {
 	uint32_t saved_timing;
 	unsigned long saved_frequency;
 	struct i2c_cfg sec_cfg;
-#ifdef CFG_DRIVERS_PINCTRL
 	struct pinctrl_state *pinctrl;
 	struct pinctrl_state *pinctrl_sleep;
-#else
-	struct stm32_pinctrl *pinctrl;
-	size_t pinctrl_count;
-#endif
 };
 
 /* STM32 specific defines */
@@ -145,7 +136,6 @@ struct i2c_handle_s {
 #define STM32_I2C_ANALOG_FILTER_DELAY_MAX	U(260)	/* ns */
 #define STM32_I2C_DIGITAL_FILTER_MAX		U(16)
 
-#ifdef CFG_DRIVERS_PINCTRL
 /*
  * Fill struct stm32_i2c_init_s from DT content for a given I2C node
  *
@@ -160,22 +150,6 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 					struct stm32_i2c_init_s *init,
 					struct pinctrl_state **pinctrl_active,
 					struct pinctrl_state **pinctrl_sleep);
-#else
-/*
- * Fill struct stm32_i2c_init_s from DT content for a given I2C node
- *
- * @fdt: Reference to DT
- * @node: Target I2C node in the DT
- * @init: Output stm32_i2c_init_s structure
- * @pinctrl: Reference to output pinctrl array
- * @pinctrl_count: Input @pinctrl array size, output expected size upon success
- * Return a TEE_Result compliant value
- */
-TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
-					struct stm32_i2c_init_s *init,
-					struct stm32_pinctrl **pinctrl,
-					size_t *pinctrl_count);
-#endif /*CFG_DRIVERS_PINCTRL*/
 
 /*
  * Initialize I2C bus handle from input configuration directives

--- a/core/include/drivers/stm32_uart.h
+++ b/core/include/drivers/stm32_uart.h
@@ -1,22 +1,31 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2017-2018, STMicroelectronics
+ * Copyright (c) 2017-2023, STMicroelectronics
  */
 
-#ifndef __STM32_UART_H__
-#define __STM32_UART_H__
+#ifndef DRIVERS_STM32_UART_H
+#define DRIVERS_STM32_UART_H
 
 #include <drivers/clk.h>
-#include <drivers/serial.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_gpio.h>
+#include <drivers/serial.h>
+#include <io.h>
+#include <types_ext.h>
+#include <stdbool.h>
 
 struct stm32_uart_pdata {
 	struct io_pa_va base;
 	struct serial_chip chip;
 	bool secure;
 	struct clk *clock;
+#ifdef CFG_DRIVERS_PINCTRL
+	struct pinctrl_state *pinctrl;
+#else
 	struct stm32_pinctrl *pinctrl;
 	size_t pinctrl_count;
+#endif
+	struct pinctrl_state *pinctrl_sleep;
 };
 
 /*
@@ -39,4 +48,4 @@ void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base);
  */
 struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node);
 
-#endif /*__STM32_UART_H__*/
+#endif /*DRIVERS_STM32_UART_H*/

--- a/core/include/drivers/stm32_uart.h
+++ b/core/include/drivers/stm32_uart.h
@@ -8,7 +8,6 @@
 
 #include <drivers/clk.h>
 #include <drivers/pinctrl.h>
-#include <drivers/stm32_gpio.h>
 #include <drivers/serial.h>
 #include <io.h>
 #include <types_ext.h>
@@ -19,12 +18,7 @@ struct stm32_uart_pdata {
 	struct serial_chip chip;
 	bool secure;
 	struct clk *clock;
-#ifdef CFG_DRIVERS_PINCTRL
 	struct pinctrl_state *pinctrl;
-#else
-	struct stm32_pinctrl *pinctrl;
-	size_t pinctrl_count;
-#endif
 	struct pinctrl_state *pinctrl_sleep;
 };
 

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -78,13 +78,13 @@ struct dt_driver {
 struct dt_driver_provider;
 
 /**
- * struct dt_driver_phandle_args - Devicetree phandle arguments
+ * struct dt_pargs - Devicetree phandle arguments
  * @fdt: Device-tree to work on
  * @phandle_node: Node pointed by the specifier phandle
  * @args_count: Count of cells for the device
  * @args: Device consumer specifiers
  */
-struct dt_driver_phandle_args {
+struct dt_pargs {
 	const void *fdt;
 	int phandle_node;
 	int args_count;
@@ -106,8 +106,8 @@ struct dt_driver_phandle_args {
  * Return a device opaque reference, e.g. a struct clk pointer for a clock
  * driver, or NULL if not found in which case @res provides the error code.
  */
-typedef void *(*get_of_device_func)(struct dt_driver_phandle_args *parg,
-				    void *data, TEE_Result *res);
+typedef void *(*get_of_device_func)(struct dt_pargs *parg, void *data,
+				    TEE_Result *res);
 
 /**
  * dt_driver_register_provider - Register a driver provider

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -240,7 +240,7 @@ static void *device_from_provider_prop(struct dt_driver_provider *prv,
 				       const void *fdt, int phandle_node,
 				       const uint32_t *prop, TEE_Result *res)
 {
-	struct dt_driver_phandle_args *pargs = NULL;
+	struct dt_pargs *pargs = NULL;
 	unsigned int n = 0;
 	void *device = NULL;
 

--- a/core/pta/tests/dt_driver_test.c
+++ b/core/pta/tests/dt_driver_test.c
@@ -443,8 +443,8 @@ static const char *dt_test_clk_name[DT_TEST_CLK_COUNT] = {
 /* Emulating a clock does not require operators */
 static const struct clk_ops dt_test_clock_provider_ops;
 
-static struct clk *dt_test_get_clk(struct dt_driver_phandle_args *args,
-				   void *data, TEE_Result *res)
+static struct clk *dt_test_get_clk(struct dt_pargs *args, void *data,
+				   TEE_Result *res)
 {
 	struct clk *clk_ref = data;
 	struct clk *clk = NULL;
@@ -566,8 +566,8 @@ const struct rstctrl_ops dt_test_rstctrl_ops = {
 	.get_name = dt_test_rstctrl_name,
 };
 
-static struct rstctrl *dt_test_get_rstctrl(struct dt_driver_phandle_args *args,
-					   void *data, TEE_Result *res)
+static struct rstctrl *dt_test_get_rstctrl(struct dt_pargs *args, void *data,
+					   TEE_Result *res)
 {
 	struct dt_test_rstctrl *ref = data;
 	struct rstctrl *rstctrl = NULL;
@@ -698,13 +698,13 @@ static const struct gpio_ops dt_test_gpio_ops = {
 	.set_value = dt_test_gpio_set_value,
 };
 
-static struct gpio *dt_test_gpio_get_dt(struct dt_driver_phandle_args *a,
-					void *data, TEE_Result *res)
+static struct gpio *dt_test_gpio_get_dt(struct dt_pargs *args, void *data,
+					TEE_Result *res)
 {
 	struct gpio *gpio = NULL;
 	struct dt_test_gpio *gpios = (struct dt_test_gpio *)data;
 
-	gpio = gpio_dt_alloc_pin(a, res);
+	gpio = gpio_dt_alloc_pin(args, res);
 	if (*res)
 		return NULL;
 


### PR DESCRIPTION
This P-R ports stm32_gpio driver to the recently merged pinctrl framework.

The series includes 2 changes already under review in specific P-Rs: #6041 and #6049.

Checkpatch complains on false positive warnings on several commits of this series because of a structure field names `od`, for example:
```c
30243dba7 drivers: stm32_gpio: consider DT output data configuration
WARNING: 'od' may be misspelled - perhaps 'of'?
#52: FILE: core/drivers/stm32_gpio.c:306:
+			ref->active_cfg.od = odata;
 			                ^^

total: 0 errors, 1 warnings, 0 checks, 35 lines checked
```

