### PR TITLE
drivers: stm32_gpio: helper function to register GPIO banks

### DIFF
--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -428,8 +428,8 @@ static TEE_Result dt_stm32_gpio_bank(const void *fdt, int node,
 }
 
 /* Parse a pinctrl node to register the GPIO banks it describes */
-static TEE_Result __unused dt_stm32_gpio_pinctrl(const void *fdt, int node,
-						 const void *compat_data)
+static TEE_Result dt_stm32_gpio_pinctrl(const void *fdt, int node,
+					const void *compat_data)
 {
 	TEE_Result res = TEE_SUCCESS;
 	const fdt32_t *cuint = NULL;
@@ -611,3 +611,24 @@ void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin, bool secure)
 	clk_disable(clk);
 	cpu_spin_unlock_xrestore(&gpio_lock, exceptions);
 }
+
+static TEE_Result stm32_pinctrl_probe(const void *fdt, int node,
+				      const void *compat_data)
+{
+	/* Register GPIO banks described in this pin control node */
+	return dt_stm32_gpio_pinctrl(fdt, node, compat_data);
+}
+
+static const struct dt_device_match stm32_pinctrl_match_table[] = {
+	{ .compatible = "st,stm32mp135-pinctrl" },
+	{ .compatible = "st,stm32mp157-pinctrl" },
+	{ .compatible = "st,stm32mp157-z-pinctrl" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(stm32_pinctrl_dt_driver) = {
+	.name = "stm32_gpio-pinctrl",
+	.type = DT_DRIVER_PINCTRL,
+	.match_table = stm32_pinctrl_match_table,
+	.probe = stm32_pinctrl_probe,
+};

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -10,8 +10,8 @@
  * as STM32 GPIO driver does no register callbacks to the PM framework.
  */
 
-#ifndef __STM32_GPIO_H
-#define __STM32_GPIO_H
+#ifndef DRIVERS_STM32_GPIO_H
+#define DRIVERS_STM32_GPIO_H
 
 #include <assert.h>
 #include <stdbool.h>
@@ -181,4 +181,4 @@ static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
  */
 int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
-#endif /*__STM32_GPIO_H*/
+#endif /*DRIVERS_STM32_GPIO_H*/


### PR DESCRIPTION
Adds an helper function (dt_stm32_gpio_bank()) to register GPIO banks in stm32_gpio driver based on DT pinctrl nodes. GPIO banks are registered in a local list from which will be later used to find a bank based on its ID number. The function is expected to be called from the driver probe sequence. The function ensures a bank is not registered twice.

This P-R is a preparatory patch for moving stm32_gpio driver to pinctrl (`CFG_DRIVERS_PINCTRL`) and gpio (`CFG_DRIVERS_GPIO`) frameworks.