### PR TITLE
drivers: stm32_gpio: consider DT output data configuration

### DIFF
--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -231,6 +231,7 @@ static int get_pinctrl_from_fdt(void *fdt, int node,
 		uint32_t pin = 0;
 		uint32_t mode = 0;
 		uint32_t alternate = 0;
+		uint32_t odata = 0;
 		bool opendrain = false;
 
 		pincfg = fdt32_to_cpu(*cuint);
@@ -276,6 +277,18 @@ static int get_pinctrl_from_fdt(void *fdt, int node,
 		if (fdt_getprop(fdt, node, "drive-open-drain", NULL))
 			opendrain = true;
 
+		if (fdt_getprop(fdt, node, "output-high", NULL) &&
+		    mode == GPIO_MODE_INPUT) {
+			mode = GPIO_MODE_OUTPUT;
+			odata = 1;
+		}
+
+		if (fdt_getprop(fdt, node, "output-low", NULL) &&
+		    mode == GPIO_MODE_INPUT) {
+			mode = GPIO_MODE_OUTPUT;
+			odata = 0;
+		}
+
 		/* Check GPIO bank clock/base address against platform */
 		ckeck_gpio_bank(fdt, bank, pinctrl_node);
 
@@ -288,7 +301,7 @@ static int get_pinctrl_from_fdt(void *fdt, int node,
 			ref->active_cfg.otype = opendrain ? 1 : 0;
 			ref->active_cfg.ospeed = speed;
 			ref->active_cfg.pupd = pull;
-			ref->active_cfg.od = 0;
+			ref->active_cfg.od = odata;
 			ref->active_cfg.af = alternate;
 			/* Default to analog mode for standby state */
 			ref->standby_cfg.mode = GPIO_MODE_ANALOG;


### PR DESCRIPTION
Get output data pin configuration from DT node property "output-high" and "output-low".

This P-R is a preparatory patch for moving stm32_gpio driver to pinctrl (`CFG_DRIVERS_PINCTRL`) and gpio (`CFG_DRIVERS_GPIO`) frameworks.

Checkpatch emits a warning message because a field of existing `struct stm32_gpio` is named `od` (which reflect the related GPIO configuration register GPIO_ODR described in the SoC reference manual):
```
cbdf0432a drivers: stm32_gpio: consider DT output data configuration
WARNING: 'od' may be misspelled - perhaps 'of'?
#52: FILE: core/drivers/stm32_gpio.c:306:
+			ref->active_cfg.od = odata;
 			                ^^

total: 0 errors, 1 warnings, 0 checks, 35 lines checked