### PR TITLE
plat-stm32mp1: remove unused stm32mp_gpio_bank_is_shared()

### DIFF
--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -382,23 +382,6 @@ bool stm32mp_periph_is_secure(enum stm32mp_shres id)
 	return shres_state[id] == SHRES_SECURE;
 }
 
-bool stm32mp_gpio_bank_is_shared(unsigned int bank)
-{
-	unsigned int not_secure = 0;
-	unsigned int pin = 0;
-
-	lock_registering();
-
-	if (bank != GPIO_BANK_Z)
-		return false;
-
-	for (pin = 0; pin < get_gpioz_nbpin(); pin++)
-		if (!stm32mp_periph_is_secure(STM32MP1_SHRES_GPIOZ(pin)))
-			not_secure++;
-
-	return not_secure > 0 && not_secure < get_gpioz_nbpin();
-}
-
 bool stm32mp_gpio_bank_is_non_secure(unsigned int bank)
 {
 	unsigned int not_secure = 0;

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -260,9 +260,6 @@ bool stm32mp_periph_is_secure(enum stm32mp_shres id);
 /* Return true if and only if GPIO bank @bank is registered as secure */
 bool stm32mp_gpio_bank_is_secure(unsigned int bank);
 
-/* Return true if and only if GPIO bank @bank is registered as shared */
-bool stm32mp_gpio_bank_is_shared(unsigned int bank);
-
 /* Return true if and only if GPIO bank @bank is registered as non-secure */
 bool stm32mp_gpio_bank_is_non_secure(unsigned int bank);
 
@@ -308,11 +305,6 @@ static inline bool stm32mp_periph_is_secure(enum stm32mp_shres id __unused)
 static inline bool stm32mp_gpio_bank_is_secure(unsigned int bank __unused)
 {
 	return true;
-}
-
-static inline bool stm32mp_gpio_bank_is_shared(unsigned int bank __unused)
-{
-	return false;
 }
 
 static inline bool stm32mp_gpio_bank_is_non_secure(unsigned int bank __unused)


### PR DESCRIPTION
Removes platform function stm32mp_gpio_bank_is_shared() that is not used.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
