### PR TITLE
drivers: stm32_rng: fix case when RNG is not ready

### DIFF
--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -213,8 +213,12 @@ static TEE_Result read_available(vaddr_t rng_base, uint8_t *out, size_t *size)
 
 	/* RNG is ready: read up to 4 32bit words */
 	while (len) {
-		uint32_t data32 = io_read32(rng_base + RNG_DR);
+		uint32_t data32 = 0;
 		size_t sz = MIN(len, sizeof(uint32_t));
+
+		if (!(io_read32(rng_base + RNG_SR) & RNG_SR_DRDY))
+			break;
+		data32 = io_read32(rng_base + RNG_DR);
 
 		/* Late seed error case: DR being 0 is an error status */
 		if (!data32) {
@@ -227,7 +231,7 @@ static TEE_Result read_available(vaddr_t rng_base, uint8_t *out, size_t *size)
 		len -= sz;
 	}
 
-	*size = req_size;
+	*size = req_size - len;
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Checks RNG data ready status bit before each read of a 32bit sample from the RNG FIFO. Indeed the data ready status bit tells that the RNG FIFO contains random bytes by burst of 32bit word, not by burst of 4 32bit words.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
