### PR TITLE
RISC-V: Implement stack unwinding

### DIFF
--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -133,6 +133,24 @@ static inline __noprof unsigned long read_tp(void)
 	return tp;
 }
 
+static inline __noprof unsigned long read_fp(void)
+{
+	unsigned long fp = 0;
+
+	asm volatile ("mv %0, fp" : "=r" (fp));
+
+	return fp;
+}
+
+static inline __noprof unsigned long read_pc(void)
+{
+	unsigned long pc = 0;
+
+	asm volatile ("auipc %0, 0" : "=r" (pc));
+
+	return pc;
+}
+
 static inline __noprof void wfi(void)
 {
 	asm volatile ("wfi");

--- a/core/arch/riscv/kernel/abort.c
+++ b/core/arch/riscv/kernel/abort.c
@@ -30,13 +30,12 @@ enum fault_type {
 /* Kernel mode unwind */
 static void __print_stack_unwind(struct abort_info *ai)
 {
-	struct unwind_state_rv state = {
+	struct unwind_state_riscv state = {
 		.fp = ai->regs->s0,
-		.sp = ai->regs->sp,
 		.pc = ai->regs->epc,
 	};
 
-	print_stack_rv(&state, thread_stack_start(), thread_stack_size());
+	print_stack_riscv(&state, thread_stack_start(), thread_stack_size());
 }
 
 #else /* CFG_UNWIND */

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -60,6 +60,7 @@ DEFINES
 	DEFINE(THREAD_TRAP_REG_GP, offsetof(struct thread_trap_regs, gp));
 	DEFINE(THREAD_TRAP_REG_TP, offsetof(struct thread_trap_regs, tp));
 	DEFINE(THREAD_TRAP_REG_T0, offsetof(struct thread_trap_regs, t0));
+	DEFINE(THREAD_TRAP_REG_S0, offsetof(struct thread_trap_regs, s0));
 	DEFINE(THREAD_TRAP_REG_A0, offsetof(struct thread_trap_regs, a0));
 	DEFINE(THREAD_TRAP_REG_T3, offsetof(struct thread_trap_regs, t3));
 	DEFINE(THREAD_TRAP_REG_EPC, offsetof(struct thread_trap_regs, epc));

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -6,6 +6,7 @@
 #include <asm.S>
 #include <generated/asm-defines.h>
 #include <keep.h>
+#include <kernel/thread_private.h>
 #include <mm/core_mmu.h>
 #include <platform_config.h>
 #include <riscv.h>
@@ -172,7 +173,30 @@ UNWIND(	.cantunwind)
 	set_satp
 
 	jal	boot_init_primary_early
+
+	/*
+	 * Before entering boot_init_primary_late(), we do these two steps:
+	 * 1. Save current sp to s2, and set sp as threads[0].stack_va_end
+	 * 2. Clear the flag which indicates usage of the temporary stack in the
+	 *    current hart's thread_core_local structure.
+	 */
+	mv	s2, sp
+	la	a0, threads
+	LDR	a0, THREAD_CTX_STACK_VA_END(a0)
+	mv	sp, a0
+	jal	thread_get_core_local
+	mv	s3, a0
+	STR	x0, THREAD_CORE_LOCAL_FLAGS(s3)
+
 	jal	boot_init_primary_late
+
+	/*
+	 * After returning from boot_init_primary_late(), the flag and sp are
+	 * restored.
+	 */
+	li	a0, THREAD_CLF_TMP
+	STR	a0, THREAD_CORE_LOCAL_FLAGS(s3)
+	mv	sp, s2
 
 	cpu_is_ready
 	flush_cpu_semaphores

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -11,4 +11,5 @@ srcs-y += thread_rv.S
 srcs-y += thread_arch.c
 srcs-y += arch_scall_rv.S
 srcs-y += arch_scall.c
+srcs-$(CFG_UNWIND) += unwind_rv.c
 asm-defines-y += asm-defines.c

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -48,6 +48,10 @@
 	store_xregs sp, THREAD_TRAP_REG_T0, REG_T0, REG_T2
 	store_xregs sp, THREAD_TRAP_REG_A0, REG_A0, REG_A7
 	store_xregs sp, THREAD_TRAP_REG_RA, REG_RA
+#if defined(CFG_UNWIND)
+	/* To unwind stack we need s0, which is frame pointer. */
+	store_xregs sp, THREAD_TRAP_REG_S0, REG_S0
+#endif
 
 	csrr	t0, CSR_XSTATUS
 	store_xregs sp, THREAD_TRAP_REG_STATUS, REG_T0
@@ -78,6 +82,10 @@
 	load_xregs sp, THREAD_TRAP_REG_A0, REG_A0, REG_A7
 	load_xregs sp, THREAD_TRAP_REG_T0, REG_T0, REG_T2
 	load_xregs sp, THREAD_TRAP_REG_T3, REG_T3, REG_T6
+#if defined(CFG_UNWIND)
+	/* To unwind stack we need s0, which is frame pointer. */
+	load_xregs sp, THREAD_TRAP_REG_S0, REG_S0
+#endif
 
 .if \mode == TRAP_MODE_USER
 	addi	gp, sp, THREAD_TRAP_REGS_SIZE

--- a/core/arch/riscv/kernel/unwind_rv.c
+++ b/core/arch/riscv/kernel/unwind_rv.c
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*-
+ * Copyright (c) 2023 Andes Technology Corporation
+ * Copyright (c) 2015 Linaro Limited
+ * Copyright (c) 2015 The FreeBSD Foundation
+ */
+
+#include <kernel/linker.h>
+#include <kernel/thread.h>
+#include <kernel/unwind.h>
+#include <riscv.h>
+#include <unw/unwind.h>
+
+#if defined(CFG_UNWIND) && (TRACE_LEVEL > 0)
+void print_kernel_stack(void)
+{
+	struct unwind_state_riscv state = { };
+	vaddr_t stack_start = 0;
+	vaddr_t stack_end = 0;
+
+	state.pc = read_pc();
+	state.fp = read_fp();
+
+	trace_printf_helper_raw(TRACE_ERROR, true,
+				"TEE load address @ %#"PRIxVA, VCORE_START_VA);
+	get_stack_hard_limits(&stack_start, &stack_end);
+	print_stack_riscv(&state, stack_start, stack_end - stack_start);
+}
+#endif

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -114,6 +114,11 @@ ifeq ($(CFG_CORE_ASLR),y)
 core-platform-cflags += -fpie
 endif
 
+ifeq ($(CFG_UNWIND),y)
+core-platform-cppflags += -fno-omit-frame-pointer
+core-platform-cflags += -fno-omit-frame-pointer
+endif
+
 ifeq ($(CFG_RV64_core),y)
 core-platform-cppflags += $(rv64-platform-cppflags)
 core-platform-cflags += $(rv64-platform-cflags)

--- a/lib/libunw/include/unw/unwind.h
+++ b/lib/libunw/include/unw/unwind.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: (BSD-2-Clause AND MIT-CMU) */
 /*-
+ * Copyright (c) 2023 Andes Technology Corporation
  * Copyright (c) 2015-2019, Linaro Limited
  * Copyright (c) 2000, 2001 Ben Harris
  * Copyright (c) 1996 Scott K. Stevens
@@ -106,6 +107,38 @@ static inline bool unwind_stack_arm64(struct unwind_state_arm64 *state __unused,
 }
 
 static inline void print_stack_arm64(struct unwind_state_arm64 *state __unused,
+				     vaddr_t stack __unused,
+				     size_t stack_size __unused)
+{
+}
+#endif
+
+/* The state of the unwind process */
+struct unwind_state_riscv {
+	unsigned long fp;
+	unsigned long pc;
+};
+
+#if (defined(RV32) || defined(RV64)) && defined(CFG_UNWIND)
+/*
+ * Unwind stack.
+ * @stack, @stack_size: the bottom of the stack and its size, respectively.
+ * Returns false when there is nothing more to unwind.
+ */
+bool unwind_stack_riscv(struct unwind_state_riscv *state,
+			vaddr_t stack, size_t stack_size);
+
+void print_stack_riscv(struct unwind_state_riscv *state,
+		       vaddr_t stack, size_t stack_size);
+#else
+static inline bool unwind_stack_riscv(struct unwind_state_riscv *state __unused,
+				      vaddr_t stack __unused,
+				      size_t stack_size __unused)
+{
+	return false;
+}
+
+static inline void print_stack_riscv(struct unwind_state_riscv *state __unused,
 				     vaddr_t stack __unused,
 				     size_t stack_size __unused)
 {

--- a/lib/libunw/sub.mk
+++ b/lib/libunw/sub.mk
@@ -2,4 +2,7 @@ global-incdirs-y += include
 ifeq ($(CFG_UNWIND),y)
 srcs-y += unwind_arm32.c
 srcs-$(CFG_ARM64_$(sm)) += unwind_arm64.c
+ifneq (,$(filter y,$(CFG_RV32_$(sm)) $(CFG_RV64_$(sm))))
+srcs-y += unwind_riscv.c
+endif
 endif

--- a/lib/libunw/unwind_riscv.c
+++ b/lib/libunw/unwind_riscv.c
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*-
+ * Copyright (c) 2023 Andes Technology Corporation
+ * Copyright (c) 2015-2019 Linaro Limited
+ * Copyright (c) 2015 The FreeBSD Foundation
+ */
+
+#include <compiler.h>
+#include <string.h>
+#include <trace.h>
+#include <types_ext.h>
+#include <unw/unwind.h>
+#include <util.h>
+
+void __weak ftrace_map_lr(uint64_t *lr __unused)
+{
+}
+
+bool unwind_stack_riscv(struct unwind_state_riscv *frame,
+			vaddr_t stack, size_t stack_size)
+{
+	vaddr_t fp = frame->fp;
+	struct unwind_state_riscv *caller_state = NULL;
+
+	if (fp < stack)
+		return false;
+	if (fp > stack + stack_size)
+		return false;
+
+	/*
+	 *  |    .....    |       ^  unwind upwards
+	 *  |    .....    |       |
+	 *  +=============+  <--+ |  +======= caller FP ==========+
+	 *  |     RA      |     | |
+	 *  +-------------+     | |
+	 *  |  caller FP  |  ---|-+               ^
+	 *  +-------------+     |          caller stack frame
+	 *  |    .....    |     |                 v
+	 *  |    .....    |     |
+	 *  |    .....    |     |
+	 *  +=============+     |    +== caller SP / trapped FP ==+
+	 *  |     RA      |     |
+	 *  +-------------+     |
+	 *  |  caller FP  |  ---+                 ^
+	 *  +-------------+               trapped stack frame
+	 *  |    .....    |                       v
+	 *  |    .....    |
+	 *  |    .....    |
+	 *  +=============+          +======== trapped SP ========+
+	 *         |
+	 *         |  grow downwards
+	 *         V
+	 */
+
+	/* Get caller FP and RA */
+	caller_state = (struct unwind_state_riscv *)fp - 1;
+	frame->fp = caller_state->fp;
+	frame->pc = caller_state->pc;
+
+	ftrace_map_lr(&frame->pc);
+
+	frame->pc -= 4;
+
+	return true;
+}
+
+void print_stack_riscv(struct unwind_state_riscv *state,
+		       vaddr_t stack, size_t stack_size)
+{
+	int width = sizeof(unsigned long);
+
+	trace_printf_helper_raw(TRACE_ERROR, true, "Call stack:");
+
+	ftrace_map_lr(&state->pc);
+	do {
+		trace_printf_helper_raw(TRACE_ERROR, true, " 0x%0*"PRIxVA,
+					width, state->pc);
+	} while (unwind_stack_riscv(state, stack, stack_size));
+}

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -43,8 +43,8 @@ nm) are used to extract the debug info. If the CROSS_COMPILE environment
 variable is set, it is used as a prefix to the binutils tools. That is, the
 script will invoke $(CROSS_COMPILE)addr2line etc. If it is not set however,
 the prefix will be determined automatically for each ELF file based on its
-architecture (arm-linux-gnueabihf-, aarch64-linux-gnu-). The resulting command
-is then expected to be found in the user's PATH.
+architecture. The resulting command is then expected to be found in the user's
+PATH.
 
 OP-TEE abort and panic messages are sent to the secure console. They look like
 the following:
@@ -170,6 +170,11 @@ class Symbolizer(object):
             self._arch = 'aarch64-linux-gnu-'
         elif b'ARM,' in output[0]:
             self._arch = 'arm-linux-gnueabihf-'
+        elif b'RISC-V,' in output[0]:
+            if b'32-bit' in output[0]:
+                self._arch = 'riscv32-unknown-linux-gnu-'
+            elif b'64-bit' in output[0]:
+                self._arch = 'riscv64-unknown-linux-gnu-'
 
     def arch_prefix(self, cmd, elf):
         self.set_arch(elf)


### PR DESCRIPTION
This patch sets implement the kernel stack unwinding for RISC-V architecture.
The detail can be found in the commit message of [libunw: Implement RISC-V stack unwinding](https://github.com/OP-TEE/optee_os/commit/904034a75ccf31c59831f23cf704dd6012aa5eb6)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
