### PR TITLE
arm64: memtag: strip tag from crash dumps

### DIFF
--- a/core/arch/arm/kernel/abort.c
+++ b/core/arch/arm/kernel/abort.c
@@ -11,6 +11,7 @@
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread_private.h>
 #include <kernel/user_mode_ctx.h>
+#include <memtag.h>
 #include <mm/core_mmu.h>
 #include <mm/mobj.h>
 #include <mm/tee_pager.h>
@@ -148,9 +149,16 @@ __print_abort_info(struct abort_info *ai __maybe_unused,
 #endif /*ARM64*/
 
 	EMSG_RAW("");
-	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s",
-		ctx, abort_type_to_str(ai->abort_type), ai->va,
-		fault_to_str(ai->abort_type, ai->fault_descr));
+	if (IS_ENABLED(CFG_MEMTAG))
+		EMSG_RAW("%s %s-abort at address 0x%" PRIxVA
+			 " [tagged 0x%" PRIxVA "]%s", ctx,
+			 abort_type_to_str(ai->abort_type),
+			 memtag_strip_tag_vaddr((void *)ai->va), ai->va,
+			 fault_to_str(ai->abort_type, ai->fault_descr));
+	else
+		EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s", ctx,
+			 abort_type_to_str(ai->abort_type), ai->va,
+			 fault_to_str(ai->abort_type, ai->fault_descr));
 #ifdef ARM32
 	EMSG_RAW(" fsr 0x%08x  ttbr0 0x%08x  ttbr1 0x%08x  cidr 0x%X",
 		 ai->fault_descr, read_ttbr0(), read_ttbr1(),

--- a/lib/libunw/unwind_arm64.c
+++ b/lib/libunw/unwind_arm64.c
@@ -30,6 +30,7 @@
  */
 
 #include <compiler.h>
+#include <memtag.h>
 #include <string.h>
 #include <trace.h>
 #include <types_ext.h>
@@ -80,13 +81,15 @@ bool unwind_stack_arm64(struct unwind_state_arm64 *frame,
 void print_stack_arm64(struct unwind_state_arm64 *state,
 		       vaddr_t stack, size_t stack_size)
 {
+	vaddr_t va = 0;
 	int width = 8;
 
 	trace_printf_helper_raw(TRACE_ERROR, true, "Call stack:");
 
 	ftrace_map_lr(&state->pc);
 	do {
-		trace_printf_helper_raw(TRACE_ERROR, true, " 0x%0*"PRIx64,
-					width, state->pc);
+		va = memtag_strip_tag_vaddr((void *)state->pc);
+		trace_printf_helper_raw(TRACE_ERROR, true, " 0x%0*"PRIxVA,
+					width, va);
 	} while (unwind_stack_arm64(state, stack, stack_size));
 }

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -249,16 +249,9 @@ class Symbolizer(object):
             ret = '!!!'
         return ret
 
-    # Armv8.5 with Memory Tagging Extension (MTE)
-    def strip_armv85_mte_tag(self, addr):
-        i_addr = int(addr, 16)
-        i_addr &= ~(0xf << 56)
-        return '0x{:x}'.format(i_addr)
-
     def symbol_plus_offset(self, addr):
         ret = ''
         prevsize = 0
-        addr = self.strip_armv85_mte_tag(addr)
         reladdr = self.subtract_load_addr(addr)
         elf_name = self.elf_for_addr(addr)
         if elf_name is None:


### PR DESCRIPTION
The MTE tag is not really useful when displaying a crash dump. In fact it makes it more complicated for tools like script/symbolize.py to retrieve the actual (untagged) virtual address, especially as we now support non-Arm architectures and therefore blindly stripping the MTE bits is not possible.

This commit strips the tag in call stacks displayed by print_stack_arm64(). It also removes it from the virtual address shown on abort (__print_abort_info()) since symbolize.py does try to resolve the address as symbol + offset ; but in this case the tagged address is printed as well, because it can be helpful to diagnose tag check faults.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
