### PR TITLE
FF-A v1.1 boot protocol for SPs

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2018-2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited. All rights reserved.
  */
 
 #ifndef __FFA_H
@@ -307,8 +307,22 @@ struct ffa_mem_relinquish {
 	uint16_t endpoint_id_array[];
 };
 
+/* FF-A v1.0 boot information name-value pairs */
+struct ffa_boot_info_nvp_1_0 {
+	uint32_t name[4];
+	uint64_t value;
+	uint64_t size;
+};
+
+/* FF-A v1.0 boot information descriptor */
+struct ffa_boot_info_1_0 {
+	uint32_t magic;
+	uint32_t count;
+	struct ffa_boot_info_nvp_1_0 nvp[];
+};
+
 /* FF-A v1.1 boot information descriptor */
-struct ffa_boot_info {
+struct ffa_boot_info_1_1 {
 	char name[FFA_BOOT_INFO_NAME_LEN];
 	uint8_t type;
 	uint8_t reserved;
@@ -318,7 +332,7 @@ struct ffa_boot_info {
 };
 
 /* FF-A v1.1 boot information header */
-struct ffa_boot_info_header {
+struct ffa_boot_info_header_1_1 {
 	uint32_t signature;
 	uint32_t version;
 	uint32_t blob_size;

--- a/core/arch/arm/include/kernel/secure_partition.h
+++ b/core/arch/arm/include/kernel/secure_partition.h
@@ -18,19 +18,6 @@
 
 TAILQ_HEAD(sp_sessions_head, sp_session);
 
-struct sp_name_value_pair {
-	uint32_t name[4];
-	uint64_t value;
-	uint64_t size;
-};
-
-/* SP entry arguments passed to SP image: see ABI in FF-A specification */
-struct sp_ffa_init_info {
-	uint32_t magic; /* FF-A */
-	uint32_t count; /* Count of name value size pairs */
-	struct sp_name_value_pair nvp[]; /* Array of name value size pairs */
-};
-
 enum sp_status { sp_idle, sp_busy, sp_preempted, sp_dead };
 
 struct sp_session {
@@ -39,7 +26,6 @@ struct sp_session {
 	uint16_t endpoint_id;
 	uint16_t caller_id;
 	struct ts_session ts_sess;
-	struct sp_ffa_init_info *info;
 	unsigned int spinlock;
 	const void *fdt;
 	bool is_initialized;

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1629,9 +1629,9 @@ unsigned long __weak get_aslr_seed(void *fdt __unused)
 #endif /*CFG_CORE_ASLR*/
 
 #if defined(CFG_CORE_SEL2_SPMC) && defined(CFG_CORE_PHYS_RELOCATABLE)
-static void *get_fdt_from_boot_info(struct ffa_boot_info_header *hdr)
+static void *get_fdt_from_boot_info(struct ffa_boot_info_header_1_1 *hdr)
 {
-	struct ffa_boot_info *desc = NULL;
+	struct ffa_boot_info_1_1 *desc = NULL;
 	uint8_t content_fmt = 0;
 	uint8_t name_fmt = 0;
 	void *fdt = NULL;


### PR DESCRIPTION
Implement the FF-A v1.1 boot protocol for passing boot info to Secure Partitions.