### PR TITLE
RISC-V: Implement TA stack unwinding

### DIFF
--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -137,7 +137,7 @@ static inline __noprof unsigned long read_fp(void)
 {
 	unsigned long fp = 0;
 
-	asm volatile ("mv %0, fp" : "=r" (fp));
+	asm volatile ("mv %0, s0" : "=r" (fp));
 
 	return fp;
 }

--- a/core/arch/riscv/kernel/arch_scall.c
+++ b/core/arch/riscv/kernel/arch_scall.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
+ * Copyright (c) 2023 Andes Technology Corporation
  * Copyright 2022-2023 NXP
  * Copyright (c) 2014-2022, Linaro Limited
  * Copyright (c) 2020, Arm Limited
@@ -18,42 +19,19 @@
 
 #ifdef CFG_UNWIND
 
+/* Get register values pushed onto the stack by _utee_panic() */
 static void save_panic_regs_rv_ta(struct thread_specific_data *tsd,
 				  unsigned long *pushed)
 {
 	tsd->abort_regs = (struct thread_abort_regs){
-		.ra = pushed[0],
 		.sp = (unsigned long)pushed,
-		.gp = pushed[1],
-		.tp = pushed[2],
-		.t0 = pushed[3],
-		.t1 = pushed[4],
-		.t2 = pushed[5],
-		.s0 = pushed[6],
-		.s1 = pushed[7],
-		.a0 = pushed[8],
-		.a1 = pushed[9],
-		.a2 = pushed[10],
-		.a3 = pushed[11],
-		.a4 = pushed[12],
-		.a5 = pushed[13],
-		.a6 = pushed[14],
-		.a7 = pushed[15],
-		.s2 = pushed[16],
-		.s3 = pushed[17],
-		.s4 = pushed[18],
-		.s5 = pushed[19],
-		.s6 = pushed[20],
-		.s7 = pushed[21],
-		.s8 = pushed[22],
-		.s9 = pushed[23],
-		.s10 = pushed[24],
-		.s11 = pushed[25],
-		.t3 = pushed[26],
-		.t4 = pushed[27],
-		.t5 = pushed[28],
-		.t6 = pushed[29],
-		.status = read_csr(CSR_XSTATUS),
+#if defined(RV32)
+		.s0 = pushed[2],
+		.epc = pushed[3],
+#elif defined(RV64)
+		.s0 = pushed[0],
+		.epc = pushed[1],
+#endif
 	};
 }
 

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -161,6 +161,7 @@ ta_rv32-platform-cflags += $(platform-cflags-debug-info)
 ta_rv32-platform-cflags += -fpic
 
 ifeq ($(CFG_UNWIND),y)
+ta_rv32-platform-cflags += -fno-omit-frame-pointer
 ta_rv32-platform-cflags += -funwind-tables
 endif
 ta_rv32-platform-aflags += $(platform-aflags-generic)
@@ -196,6 +197,9 @@ ta_rv64-platform-cflags += $(platform-cflags-optimization)
 ta_rv64-platform-cflags += $(platform-cflags-debug-info)
 ta_rv64-platform-cflags += -fpic
 ta_rv64-platform-cflags += $(rv64-platform-cflags-generic)
+ifeq ($(CFG_UNWIND),y)
+ta_rv64-platform-cflags += -fno-omit-frame-pointer
+endif
 ifeq ($(rv64-platform-hard-float-enabled),y)
 ta_rv64-platform-cflags += $(rv64-platform-cflags-hard-float)
 else

--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -35,17 +35,24 @@ static void __noreturn __maybe_unused dump_ta_state(struct dump_entry_arg *arg)
 
 	assert(elf && elf->is_main);
 	EMSG_RAW("Status of TA %pUl", (void *)&elf->uuid);
+#if defined(ARM32) || defined(ARM64)
 	EMSG_RAW(" arch: %s", elf->is_32bit ? "arm" : "aarch64");
-
+#elif defined(RV32) || defined(RV64)
+	EMSG_RAW(" arch: %s", elf->is_32bit ? "riscv32" : "riscv64");
+#endif
 
 	ta_elf_print_mappings(NULL, print_to_console, &main_elf_queue,
 			      arg->num_maps, arg->maps, mpool_base);
 
+#if defined(ARM32) || defined(ARM64)
 	if (arg->is_32bit)
 		ta_elf_stack_trace_a32(arg->arm32.regs);
 	else
 		ta_elf_stack_trace_a64(arg->arm64.fp, arg->arm64.sp,
 				       arg->arm64.pc);
+#elif defined(RV32) || defined(RV64)
+	ta_elf_stack_trace_riscv(arg->rv.fp, arg->rv.pc);
+#endif
 
 	sys_return_cleanup();
 }

--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -1538,6 +1538,8 @@ void ta_elf_print_mappings(void *pctx, print_func_t print_func,
 }
 
 #ifdef CFG_UNWIND
+
+#if defined(ARM32) || defined(ARM64)
 /* Called by libunw */
 bool find_exidx(vaddr_t addr, vaddr_t *idx_start, vaddr_t *idx_end)
 {
@@ -1578,7 +1580,16 @@ void ta_elf_stack_trace_a64(uint64_t fp, uint64_t sp, uint64_t pc)
 
 	print_stack_arm64(&state, ta_stack, ta_stack_size);
 }
+#elif defined(RV32) || defined(RV64)
+void ta_elf_stack_trace_riscv(uint64_t fp, uint64_t pc)
+{
+	struct unwind_state_riscv state = { .fp = fp, .pc = pc };
+
+	print_stack_riscv(&state, ta_stack, ta_stack_size);
+}
 #endif
+
+#endif /* CFG_UNWIND */
 
 TEE_Result ta_elf_add_library(const TEE_UUID *uuid)
 {

--- a/ldelf/ta_elf.h
+++ b/ldelf/ta_elf.h
@@ -134,11 +134,14 @@ void ta_elf_print_mappings(void *pctx, print_func_t print_func,
 #ifdef CFG_UNWIND
 void ta_elf_stack_trace_a32(uint32_t regs[16]);
 void ta_elf_stack_trace_a64(uint64_t fp, uint64_t sp, uint64_t pc);
+void ta_elf_stack_trace_riscv(uint64_t fp, uint64_t pc);
 #else
 static inline void ta_elf_stack_trace_a32(uint32_t regs[16] __unused) { }
 static inline void ta_elf_stack_trace_a64(uint64_t fp __unused,
 					  uint64_t sp __unused,
 					  uint64_t pc __unused) { }
+static inline void ta_elf_stack_trace_riscv(uint64_t fp __unused,
+					    uint64_t pc __unused) { }
 #endif /*CFG_UNWIND*/
 
 TEE_Result ta_elf_resolve_sym(const char *name, vaddr_t *val,

--- a/lib/libutee/arch/riscv/utee_syscalls_rv.S
+++ b/lib/libutee/arch/riscv/utee_syscalls_rv.S
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
+ * Copyright (c) 2023 Andes Technology Corporation
  * Copyright  2022  Beijing ESWIN Computing Technology Co., Ltd.
  */
 
@@ -22,7 +23,21 @@
 	.endm
 
 	FUNC _utee_panic, :
+	/* The stack pointer is always kept 16-byte aligned */
+	add	sp, sp, -16
+	/* Save return address and frame pointer to stack */
+#if defined(RV32)
+	sw	s0, 8(sp)
+	sw	ra, 12(sp)
+#elif defined(RV64)
+	sd	s0, 0(sp)
+	sd	ra, 8(sp)
+#endif
+	/* Assign a1 as stack pointer for scall_save_panic_stack() */
+	mv	a1, sp
+	/* Use tail call here because we will not return from it */
 	tail	__utee_panic
+	/* Not reached */
 	END_FUNC _utee_panic
 
 #include <utee_syscalls_asm.S>


### PR DESCRIPTION
This PR adds support for TA stack unwinding on RISC-V architecture.

To test it, `TEE_Panic(0)` is invoked in function `inc_value()` of hello_word example TA.
Use `script/symbolize.py` to parse the debug information:

```
$ cat dump_ta.txt | ./optee_os/scripts/symbolize.py -d ./out-br/build/optee_examples_ext-1.0/hello_world/ta/out
I/TA: Hello World!
Invoking TA to increment 42
D/TA:  inc_value:105 has been called
I/TA: Got value: 42 from NW
I/TA: Increase value to: 43
E/TC:? 0
E/TC:? 0 TA panicked with code 0x0
E/LD:  Status of TA 8aaaf200-2450-11e4-abe2-0002a5d5c51b
E/LD:   arch: riscv64
E/LD:  region  0: va 0x40000000 pa 0x8e200000 size 0x002000 flags rw-s (ldelf)
E/LD:  region  1: va 0x40002000 pa 0x8e202000 size 0x00c000 flags r-xs (ldelf)
E/LD:  region  2: va 0x4000e000 pa 0x8e20e000 size 0x001000 flags rw-s (ldelf)
E/LD:  region  3: va 0x4000f000 pa 0x8e20f000 size 0x004000 flags rw-s (ldelf)
E/LD:  region  4: va 0x40013000 pa 0x8e213000 size 0x001000 flags r--s
E/LD:  region  5: va 0x40014000 pa 0x8e236000 size 0x001000 flags rw-s (stack)
E/LD:  region  6: va 0x40030000 pa 0x00001000 size 0x016000 flags r-xs [0] .ta_head .text .rodata .gnu.hash .dynsym .dynstr .hash .rela.dyn
E/LD:  region  7: va 0x40046000 pa 0x00017000 size 0x00c000 flags rw-s [0] .dynamic .got .rela.got .data .bss
E/LD:   [0] 8aaaf200-2450-11e4-abe2-0002a5d5c51b @ 0x40030000 (out-br/build/optee_examples_ext-1.0/hello_world/ta/out/8aaaf200-2450-11e4-abe2-0002a5d5c51b.elf)
E/LD:  Call stack:
E/LD:   0x4003211e TEE_Panic at optee_os/lib/libutee/tee_api_panic.c:24
E/LD:   0x400304d4 inc_value at out-br/build/optee_examples_ext-1.0/hello_world/ta/hello_world_ta.c:114
E/LD:   0x400305d2 __GP11_TA_InvokeCommandEntryPoint at out-br/build/optee_examples_ext-1.0/hello_world/ta/hello_world_ta.c:151
E/LD:   0x4003344a __ta_invoke_cmd at optee_os/lib/libutee/user_ta_entry_compat.c:95
E/LD:   0x400306d6 TA_InvokeCommandEntryPoint at /home/users1/alvinga/optee_riscv/optee_os/out/riscv/export-ta_rv64/src/user_ta_header.c:211
E/LD:   0x4003305e entry_invoke_command at optee_os/lib/libutee/user_ta_entry.c:382
E/LD:   0x40033112 __utee_entry at optee_os/lib/libutee/user_ta_entry.c:432
E/LD:   0x4003063c __ta_entry at /home/users1/alvinga/optee_riscv/optee_os/out/riscv/export-ta_rv64/src/user_ta_header.c:70
E/LD:   0x400305fa __GP11_TA_InvokeCommandEntryPoint at out-br/build/optee_examples_ext-1.0/hello_world/ta/hello_world_ta.c:157
D/TC:? 0 user_ta_enter:176 tee_user_ta_enter: TA panicked with code 0x0
D/TC:? 0 destroy_ta_ctx_from_session:341 Remove references to context (0x8e0adf18)
D/TC:? 0 destroy_context:326 Destroy TA ctx (0x8e0adf00)
optee_example_hello_world: TEEC_InvokeCommand failed with code 0xffff3024 origin 0x3
D/TC:? 0 tee_ta_close_session:529 csess 0x8e0adf60 id 1
D/TC:? 0 tee_ta_close_session:548 Destroy session
```

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
