### PR TITLE
mk: Support user static lib for aosp build

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -106,7 +106,11 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := $(local_module)
 LOCAL_PREBUILT_MODULE_FILE := $(OPTEE_TA_OUT_DIR)/$(LOCAL_MODULE)
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib/optee_armtz
+ifneq ($(filter %.ta, $(local_module)),)
 LOCAL_MODULE_CLASS := EXECUTABLES
+else
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+endif
 LOCAL_MODULE_TAGS := optional
 
 TA_TMP_DIR := $(subst /,_,$(LOCAL_PATH))

--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -141,10 +141,10 @@ endif
 
 ifneq ($(libname),)
 # Build target is static library
-all: $(libname).a
-cleanfiles += $(libname).a
+all: $(link-out-dir$(sm))/$(libname).a
+cleanfiles += $(link-out-dir$(sm))/$(libname).a
 
-$(libname).a: $(objs)
+$(link-out-dir$(sm))/$(libname).a: $(objs)
 	@echo '  AR      $@'
 	$(q)rm -f $@ && $(AR$(sm)) rcs $@ $^
 endif


### PR DESCRIPTION
For AOSP environment to build user static libraries, there are two issues we had met,

1. the static library is default writing to the current source folder which is not allowed by AOSP build environment.
2. the static library is not necessarily installed to vendor lib folder like a TA or a shared library.

Propose to use `$(out-link-dir$(sm))` (passed by `$O`) to place the generated user static library, and change LOCAL_MODULE_CLASS to STATIC_LIBRARIES for it in AOSP build to avoid unnecessarily installation.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
