### PR TITLE
drivers: pinctrl: pinctrl name may not be found

### DIFF
--- a/core/drivers/pinctrl/pinctrl.c
+++ b/core/drivers/pinctrl/pinctrl.c
@@ -125,7 +125,10 @@ TEE_Result pinctrl_get_state_by_name(const void *fdt, int nodeoffset,
 					      name);
 	if (pinctrl_index < 0) {
 		*state = NULL;
-		return TEE_ERROR_GENERIC;
+		if (pinctrl_index == -FDT_ERR_NOTFOUND)
+			return TEE_ERROR_ITEM_NOT_FOUND;
+		else
+			return TEE_ERROR_GENERIC;
 	}
 
 	return pinctrl_get_state_by_idx(fdt, nodeoffset, pinctrl_index, state);


### PR DESCRIPTION
Changes pinctrl_get_state_by_name() to return TEE_ERROR_ITEM_NOT_FOUND instead of TEE_ERROR_GENERIC when an pinctrl state index is not found in the DT.

Fixes: 9aec039ec0d7 ("drivers: pinctrl: add pinctrl support")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
