### PR TITLE
plat-stm32mp1: bumping to pinctrl framework 

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -93,6 +93,7 @@ include core/arch/arm/cpu/cortex-a7.mk
 $(call force,CFG_DRIVERS_CLK,y)
 $(call force,CFG_DRIVERS_CLK_DT,y)
 $(call force,CFG_DRIVERS_GPIO,y)
+$(call force,CFG_DRIVERS_PINCTRL,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_INIT_CNTVOFF,y)
 $(call force,CFG_PSCI_ARM32,y)

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -460,13 +460,8 @@ static void parse_regulator_fdt_nodes(void)
  * Return 0 on success, 1 if no PMIC node found and a negative value otherwise
  */
 static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
-#ifdef CFG_DRIVERS_PINCTRL
 			      struct pinctrl_state **pinctrl_active,
 			      struct pinctrl_state **pinctrl_sleep,
-#else
-			      struct stm32_pinctrl **pinctrl,
-			      size_t *pinctrl_count,
-#endif
 			      struct stm32_i2c_init_s *init)
 {
 	int pmic_node = 0;
@@ -498,15 +493,9 @@ static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
 	if (!i2c_info->reg)
 		return -FDT_ERR_NOTFOUND;
 
-#ifdef CFG_DRIVERS_PINCTRL
 	if (stm32_i2c_get_setup_from_fdt(fdt, i2c_node, init, pinctrl_active,
 					 pinctrl_sleep))
 		panic();
-#else
-	if (stm32_i2c_get_setup_from_fdt(fdt, i2c_node, init,
-					 pinctrl, pinctrl_count))
-		panic();
-#endif
 
 	return 0;
 }
@@ -523,20 +512,9 @@ static bool initialize_pmic_i2c(void)
 	struct i2c_handle_s *i2c = &i2c_handle;
 	struct stm32_i2c_init_s i2c_init = { };
 
-#ifdef CFG_DRIVERS_PINCTRL
 	if (dt_pmic_i2c_config(&i2c_info, &i2c->pinctrl, &i2c->pinctrl_sleep,
 			       &i2c_init))
 		panic();
-#else
-	ret = dt_pmic_i2c_config(&i2c_info, &i2c->pinctrl, &i2c->pinctrl_count,
-				 &i2c_init);
-	if (ret < 0) {
-		EMSG("I2C configuration failed %d", ret);
-		panic();
-	}
-	if (ret)
-		return false;
-#endif
 
 	/* Initialize PMIC I2C */
 	i2c->base.pa = i2c_info.reg;
@@ -605,15 +583,9 @@ static void register_non_secure_pmic(void)
 	if (!i2c_handle.base.pa)
 		return;
 
-#ifdef CFG_DRIVERS_PINCTRL
 	stm32mp_register_non_secure_pinctrl(i2c_handle.pinctrl);
 	if (i2c_handle.pinctrl_sleep)
 		stm32mp_register_non_secure_pinctrl(i2c_handle.pinctrl_sleep);
-#else
-	for (n = 0; n < i2c_handle.pinctrl_count; n++)
-		stm32mp_register_non_secure_gpio(i2c_handle.pinctrl[n].bank,
-						 i2c_handle.pinctrl[n].pin);
-#endif
 
 	stm32mp_register_non_secure_periph_iomem(i2c_handle.base.pa);
 }
@@ -622,15 +594,9 @@ static void register_secure_pmic(void)
 {
 	size_t __maybe_unused n = 0;
 
-#ifdef CFG_DRIVERS_PINCTRL
 	stm32mp_register_secure_pinctrl(i2c_handle.pinctrl);
 	if (i2c_handle.pinctrl_sleep)
 		stm32mp_register_secure_pinctrl(i2c_handle.pinctrl_sleep);
-#else
-	for (n = 0; n < i2c_handle.pinctrl_count; n++)
-		stm32mp_register_secure_gpio(i2c_handle.pinctrl[n].bank,
-					     i2c_handle.pinctrl[n].pin);
-#endif
 
 	stm32mp_register_secure_periph_iomem(i2c_handle.base.pa);
 	register_pm_driver_cb(pmic_pm, NULL, "stm32mp1-pmic");

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -460,8 +460,13 @@ static void parse_regulator_fdt_nodes(void)
  * Return 0 on success, 1 if no PMIC node found and a negative value otherwise
  */
 static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
+#ifdef CFG_DRIVERS_PINCTRL
+			      struct pinctrl_state **pinctrl_active,
+			      struct pinctrl_state **pinctrl_sleep,
+#else
 			      struct stm32_pinctrl **pinctrl,
 			      size_t *pinctrl_count,
+#endif
 			      struct stm32_i2c_init_s *init)
 {
 	int pmic_node = 0;
@@ -493,9 +498,15 @@ static int dt_pmic_i2c_config(struct dt_node_info *i2c_info,
 	if (!i2c_info->reg)
 		return -FDT_ERR_NOTFOUND;
 
+#ifdef CFG_DRIVERS_PINCTRL
+	if (stm32_i2c_get_setup_from_fdt(fdt, i2c_node, init, pinctrl_active,
+					 pinctrl_sleep))
+		panic();
+#else
 	if (stm32_i2c_get_setup_from_fdt(fdt, i2c_node, init,
 					 pinctrl, pinctrl_count))
 		panic();
+#endif
 
 	return 0;
 }
@@ -510,17 +521,22 @@ static bool initialize_pmic_i2c(void)
 	int ret = 0;
 	struct dt_node_info i2c_info = { };
 	struct i2c_handle_s *i2c = &i2c_handle;
-	struct stm32_pinctrl *pinctrl = NULL;
-	size_t pin_count = 0;
 	struct stm32_i2c_init_s i2c_init = { };
 
-	ret = dt_pmic_i2c_config(&i2c_info, &pinctrl, &pin_count, &i2c_init);
+#ifdef CFG_DRIVERS_PINCTRL
+	if (dt_pmic_i2c_config(&i2c_info, &i2c->pinctrl, &i2c->pinctrl_sleep,
+			       &i2c_init))
+		panic();
+#else
+	ret = dt_pmic_i2c_config(&i2c_info, &i2c->pinctrl, &i2c->pinctrl_count,
+				 &i2c_init);
 	if (ret < 0) {
 		EMSG("I2C configuration failed %d", ret);
 		panic();
 	}
 	if (ret)
 		return false;
+#endif
 
 	/* Initialize PMIC I2C */
 	i2c->base.pa = i2c_info.reg;
@@ -532,9 +548,6 @@ static bool initialize_pmic_i2c(void)
 	i2c_init.own_address1 = pmic_i2c_addr;
 	i2c_init.analog_filter = true;
 	i2c_init.digital_filter_coef = 0;
-
-	i2c->pinctrl = pinctrl;
-	i2c->pinctrl_count = pin_count;
 
 	stm32mp_get_pmic();
 
@@ -586,26 +599,38 @@ void stm32mp_put_pmic(void)
 
 static void register_non_secure_pmic(void)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
 	/* Allow this function to be called when STPMIC1 not used */
 	if (!i2c_handle.base.pa)
 		return;
 
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_non_secure_pinctrl(i2c_handle.pinctrl);
+	if (i2c_handle.pinctrl_sleep)
+		stm32mp_register_non_secure_pinctrl(i2c_handle.pinctrl_sleep);
+#else
 	for (n = 0; n < i2c_handle.pinctrl_count; n++)
 		stm32mp_register_non_secure_gpio(i2c_handle.pinctrl[n].bank,
 						 i2c_handle.pinctrl[n].pin);
+#endif
 
 	stm32mp_register_non_secure_periph_iomem(i2c_handle.base.pa);
 }
 
 static void register_secure_pmic(void)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_secure_pinctrl(i2c_handle.pinctrl);
+	if (i2c_handle.pinctrl_sleep)
+		stm32mp_register_secure_pinctrl(i2c_handle.pinctrl_sleep);
+#else
 	for (n = 0; n < i2c_handle.pinctrl_count; n++)
 		stm32mp_register_secure_gpio(i2c_handle.pinctrl[n].bank,
 					     i2c_handle.pinctrl[n].pin);
+#endif
 
 	stm32mp_register_secure_periph_iomem(i2c_handle.base.pa);
 	register_pm_driver_cb(pmic_pm, NULL, "stm32mp1-pmic");

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -8,6 +8,7 @@
 #include <config.h>
 #include <console.h>
 #include <drivers/gic.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_etzpc.h>
 #include <drivers/stm32_gpio.h>
 #include <drivers/stm32_iwdg.h>
@@ -578,3 +579,6 @@ static TEE_Result init_debug(void)
 }
 early_init_late(init_debug);
 #endif /* CFG_STM32_DEBUG_ACCESS */
+
+/* Some generic resources need to be unpaged */
+DECLARE_KEEP_PAGER(pinctrl_apply_state);

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
- * Copyright (c) 2017-2022, STMicroelectronics
+ * Copyright (c) 2017-2023, STMicroelectronics
  */
 
 #include <config.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_etzpc.h>
 #include <drivers/stm32_gpio.h>
 #include <drivers/stm32mp1_etzpc.h>
@@ -384,6 +385,54 @@ void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin)
 	default:
 		break;
 	}
+}
+
+void stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl)
+{
+	unsigned int *bank = NULL;
+	unsigned int *pin = NULL;
+	size_t count = 0;
+	size_t n = 0;
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, NULL, NULL, &count);
+	if (!count)
+		return;
+
+	bank = calloc(count, sizeof(*bank));
+	pin = calloc(count, sizeof(*pin));
+	if (!bank || !pin)
+		panic();
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, bank, pin, &count);
+	for (n = 0; n < count; n++)
+		stm32mp_register_secure_gpio(bank[n], pin[n]);
+
+	free(bank);
+	free(pin);
+}
+
+void stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl)
+{
+	unsigned int *bank = NULL;
+	unsigned int *pin = NULL;
+	size_t count = 0;
+	size_t n = 0;
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, NULL, NULL, &count);
+	if (!count)
+		return;
+
+	bank = calloc(count, sizeof(*bank));
+	pin = calloc(count, sizeof(*pin));
+	if (!bank || !pin)
+		panic();
+
+	stm32_gpio_pinctrl_bank_pin(pinctrl, bank, pin, &count);
+	for (n = 0; n < count; n++)
+		stm32mp_register_non_secure_gpio(bank[n], pin[n]);
+
+	free(bank);
+	free(pin);
 }
 
 static void lock_registering(void)

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -8,9 +8,11 @@
 
 #include <assert.h>
 #include <drivers/clk.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_bsec.h>
 #include <kernel/panic.h>
 #include <stdint.h>
+#include <tee_api_types.h>
 #include <types_ext.h>
 
 /* Backup registers and RAM utils */
@@ -255,6 +257,20 @@ void stm32mp_register_secure_gpio(unsigned int bank, unsigned int pin);
  */
 void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin);
 
+/*
+ * Register pin resource of a pin control state as a secure peripheral
+ * @bank: Bank of the target GPIO
+ * @pin: Bit position of the target GPIO in the bank
+ */
+void stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl);
+
+/*
+ * Register pin resource of a pin control state as a non-secure peripheral
+ * @bank: Bank of the target GPIO
+ * @pin: Bit position of the target GPIO in the bank
+ */
+void stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl);
+
 /* Return true if and only if resource @id is registered as secure */
 bool stm32mp_periph_is_secure(enum stm32mp_shres id);
 
@@ -295,6 +311,16 @@ static inline void stm32mp_register_secure_gpio(unsigned int bank __unused,
 
 static inline void stm32mp_register_non_secure_gpio(unsigned int bank __unused,
 						    unsigned int pin __unused)
+{
+}
+
+static inline void
+stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl __unused)
+{
+}
+
+static inline void
+stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl __unused)
 {
 }
 

--- a/core/drivers/crypto/se050/glue/i2c_stm32.c
+++ b/core/drivers/crypto/se050/glue/i2c_stm32.c
@@ -34,13 +34,8 @@ TEE_Result native_i2c_transfer(struct rpc_i2c_request *req, size_t *bytes)
 }
 
 static int dt_i2c_bus_config(struct stm32_i2c_init_s *init,
-#ifdef CFG_DRIVERS_PINCTRL
 			     struct pinctrl_state **pinctrl_active,
-			     struct pinctrl_state **pinctrl_sleep
-#else
-			     struct stm32_pinctrl **pctrl,  size_t *pcnt
-#endif
-			     )
+			     struct pinctrl_state **pinctrl_sleep)
 {
 	const fdt32_t *cuint = NULL;
 	const char *path = NULL;
@@ -68,12 +63,8 @@ static int dt_i2c_bus_config(struct stm32_i2c_init_s *init,
 	else if (I2C_STANDARD_RATE != CFG_CORE_SE05X_BAUDRATE)
 		IMSG("SE05x ignoring CFG_CORE_SE05X_BAUDRATE, use built-in");
 
-#ifdef CFG_DRIVERS_PINCTRL
 	return stm32_i2c_get_setup_from_fdt(fdt, node, init, pinctrl_active,
 					    pinctrl_sleep);
-#else
-	return stm32_i2c_get_setup_from_fdt(fdt, node, init, pctrl, pcnt);
-#endif
 }
 
 int native_i2c_init(void)
@@ -85,13 +76,8 @@ int native_i2c_init(void)
 		return 0;
 
 	/* Support only one device on the platform */
-#ifdef CFG_DRIVERS_PINCTRL
 	if (dt_i2c_bus_config(&i2c_init, &i2c.pinctrl, &i2c.pinctrl_sleep))
 		return -1;
-#else
-	if (dt_i2c_bus_config(&i2c_init, &pinctrl, &pin_count))
-		return -1;
-#endif
 
 	/* Probe the device */
 	i2c_init.own_address1 = SMCOM_I2C_ADDRESS;

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -865,6 +865,43 @@ static const struct pinctrl_ops stm32_pinctrl_ops = {
 
 DECLARE_KEEP_PAGER(stm32_pinctrl_ops);
 
+void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *pinctrl,
+				 unsigned int *bank, unsigned int *pin,
+				 unsigned int *count)
+{
+	size_t conf_index = 0;
+	size_t pin_count = 0;
+	size_t n = 0;
+
+	assert(count);
+	if (!pinctrl)
+		goto out;
+
+	for (conf_index = 0; conf_index < pinctrl->conf_count; conf_index++) {
+		struct pinconf *pinconf = pinctrl->confs[conf_index];
+		struct stm32_pinctrl_array *ref = pinconf->priv;
+
+		/* Consider only the stm32_gpio pins */
+		if (pinconf->ops != &stm32_pinctrl_ops)
+			continue;
+
+		if (bank || pin) {
+			for (n = 0; n < ref->count; n++) {
+				if (bank && pin_count < *count)
+					bank[pin_count] = ref->pinctrl[n].bank;
+				if (pin && pin_count < *count)
+					pin[pin_count] = ref->pinctrl[n].pin;
+				pin_count++;
+			}
+		} else {
+			pin_count += ref->count;
+		}
+	}
+
+out:
+	*count = pin_count;
+}
+
 /* Allocate and return a pinctrl configuration from a DT reference */
 static TEE_Result stm32_pinctrl_dt_get(struct dt_pargs *pargs,
 				       void *data __unused,

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -6,6 +6,7 @@
  */
 
 #include <assert.h>
+#include <compiler.h>
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
 #include <drivers/gpio.h>
@@ -19,6 +20,7 @@
 #include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stm32_util.h>
 #include <sys/queue.h>
 #include <trace.h>
@@ -55,6 +57,59 @@
 #define DT_GPIO_MODE_MASK	GENMASK_32(7, 0)
 
 #define DT_GPIO_BANK_NAME0	"GPIOA"
+
+#define GPIO_MODE_INPUT		U(0x0)
+#define GPIO_MODE_OUTPUT	U(0x1)
+#define GPIO_MODE_ALTERNATE	U(0x2)
+#define GPIO_MODE_ANALOG	U(0x3)
+
+#define GPIO_OTYPE_PUSH_PULL	U(0x0)
+#define GPIO_OTYPE_OPEN_DRAIN	U(0x1)
+
+#define GPIO_OSPEED_LOW		U(0x0)
+#define GPIO_OSPEED_MEDIUM	U(0x1)
+#define GPIO_OSPEED_HIGH	U(0x2)
+#define GPIO_OSPEED_VERY_HIGH	U(0x3)
+
+#define GPIO_PUPD_NO_PULL	U(0x0)
+#define GPIO_PUPD_PULL_UP	U(0x1)
+#define GPIO_PUPD_PULL_DOWN	U(0x2)
+
+#define GPIO_OD_LEVEL_LOW	U(0x0)
+#define GPIO_OD_LEVEL_HIGH	U(0x1)
+
+/*
+ * GPIO configuration description structured as single 16bit word
+ * for efficient save/restore when GPIO pin suspends or resumes.
+ *
+ * @mode: One of GPIO_MODE_*
+ * @otype: One of GPIO_OTYPE_*
+ * @ospeed: One of GPIO_OSPEED_*
+ * @pupd: One of GPIO_PUPD_*
+ * @od: One of GPIO_OD_*
+ * @af: Alternate function numerical ID between 0 and 15
+ */
+struct gpio_cfg {
+	uint16_t mode:		2;
+	uint16_t otype:		1;
+	uint16_t ospeed:	2;
+	uint16_t pupd:		2;
+	uint16_t od:		1;
+	uint16_t af:		4;
+};
+
+/*
+ * Description of a pin and its muxing
+ *
+ * @bank: GPIO bank identifier as assigned by the platform
+ * @pin: Pin number in the GPIO bank
+ * @cfg: Pin configuration
+ */
+struct stm32_pinctrl {
+	uint8_t bank;
+	uint8_t pin;
+	struct gpio_cfg cfg;
+};
 
 /*
  * struct stm32_pinctrl_array - Array of pins in a pin control state

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -902,6 +902,29 @@ out:
 	*count = pin_count;
 }
 
+void stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl, bool secure)
+{
+	size_t conf_index = 0;
+
+	if (!pinctrl)
+		return;
+
+	for (conf_index = 0; conf_index < pinctrl->conf_count; conf_index++) {
+		struct pinconf *pinconf = pinctrl->confs[conf_index];
+		struct stm32_pinctrl_array *ref = pinconf->priv;
+		struct stm32_pinctrl *pc = NULL;
+		size_t n = 0;
+
+		for (n = 0; n < ref->count; n++) {
+			if (pinconf->ops != &stm32_pinctrl_ops)
+				continue;
+
+			pc = ref->pinctrl + n;
+			stm32_gpio_set_secure_cfg(pc->bank, pc->pin, secure);
+		}
+	}
+}
+
 /* Allocate and return a pinctrl configuration from a DT reference */
 static TEE_Result stm32_pinctrl_dt_get(struct dt_pargs *pargs,
 				       void *data __unused,

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -113,16 +113,9 @@ static void register_secure_uart(struct stm32_uart_pdata *pd)
 	size_t __maybe_unused n = 0;
 
 	stm32mp_register_secure_periph_iomem(pd->base.pa);
-#ifdef CFG_DRIVERS_PINCTRL
 	stm32mp_register_secure_pinctrl(pd->pinctrl);
 	if (pd->pinctrl_sleep)
 		stm32mp_register_secure_pinctrl(pd->pinctrl_sleep);
-
-#else
-	for (n = 0; n < pd->pinctrl_count; n++)
-		stm32mp_register_secure_gpio(pd->pinctrl[n].bank,
-					     pd->pinctrl[n].pin);
-#endif
 }
 
 static void register_non_secure_uart(struct stm32_uart_pdata *pd)
@@ -130,15 +123,9 @@ static void register_non_secure_uart(struct stm32_uart_pdata *pd)
 	size_t __maybe_unused n = 0;
 
 	stm32mp_register_non_secure_periph_iomem(pd->base.pa);
-#ifdef CFG_DRIVERS_PINCTRL
 	stm32mp_register_non_secure_pinctrl(pd->pinctrl);
 	if (pd->pinctrl_sleep)
 		stm32mp_register_non_secure_pinctrl(pd->pinctrl_sleep);
-#else
-	for (n = 0; n < pd->pinctrl_count; n++)
-		stm32mp_register_non_secure_gpio(pd->pinctrl[n].bank,
-						 pd->pinctrl[n].pin);
-#endif
 }
 
 struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
@@ -146,10 +133,6 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct stm32_uart_pdata *pd = NULL;
 	struct dt_node_info info = { };
-#if !defined(CFG_DRIVERS_PINCTRL)
-	struct stm32_pinctrl *pinctrl_cfg = NULL;
-	int count = 0;
-#endif
 
 	fdt_fill_device_info(fdt, &info, node);
 
@@ -182,7 +165,6 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 					    pd->secure ? MEM_AREA_IO_SEC :
 					    MEM_AREA_IO_NSEC, info.reg_size);
 
-#ifdef CFG_DRIVERS_PINCTRL
 	res = pinctrl_get_state_by_name(fdt, node, "default", &pd->pinctrl);
 	if (res)
 		panic();
@@ -194,22 +176,6 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	res = pinctrl_apply_state(pd->pinctrl);
 	if (res)
 		panic();
-#else
-	count = stm32_pinctrl_fdt_get_pinctrl(fdt, node, NULL, 0);
-	if (count < 0)
-		panic();
-
-	if (count) {
-		pinctrl_cfg = calloc(count, sizeof(*pinctrl_cfg));
-		if (!pinctrl_cfg)
-			panic();
-
-		stm32_pinctrl_fdt_get_pinctrl(fdt, node, pinctrl_cfg, count);
-		stm32_pinctrl_load_active_cfg(pinctrl_cfg, count);
-	}
-	pd->pinctrl = pinctrl_cfg;
-	pd->pinctrl_count = count;
-#endif
 
 	if (pd->secure)
 		register_secure_uart(pd);

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -110,22 +110,35 @@ void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base)
 
 static void register_secure_uart(struct stm32_uart_pdata *pd)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
 	stm32mp_register_secure_periph_iomem(pd->base.pa);
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_secure_pinctrl(pd->pinctrl);
+	if (pd->pinctrl_sleep)
+		stm32mp_register_secure_pinctrl(pd->pinctrl_sleep);
+
+#else
 	for (n = 0; n < pd->pinctrl_count; n++)
 		stm32mp_register_secure_gpio(pd->pinctrl[n].bank,
 					     pd->pinctrl[n].pin);
+#endif
 }
 
 static void register_non_secure_uart(struct stm32_uart_pdata *pd)
 {
-	size_t n = 0;
+	size_t __maybe_unused n = 0;
 
 	stm32mp_register_non_secure_periph_iomem(pd->base.pa);
+#ifdef CFG_DRIVERS_PINCTRL
+	stm32mp_register_non_secure_pinctrl(pd->pinctrl);
+	if (pd->pinctrl_sleep)
+		stm32mp_register_non_secure_pinctrl(pd->pinctrl_sleep);
+#else
 	for (n = 0; n < pd->pinctrl_count; n++)
 		stm32mp_register_non_secure_gpio(pd->pinctrl[n].bank,
 						 pd->pinctrl[n].pin);
+#endif
 }
 
 struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
@@ -133,8 +146,10 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct stm32_uart_pdata *pd = NULL;
 	struct dt_node_info info = { };
+#if !defined(CFG_DRIVERS_PINCTRL)
 	struct stm32_pinctrl *pinctrl_cfg = NULL;
 	int count = 0;
+#endif
 
 	fdt_fill_device_info(fdt, &info, node);
 
@@ -167,6 +182,19 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 					    pd->secure ? MEM_AREA_IO_SEC :
 					    MEM_AREA_IO_NSEC, info.reg_size);
 
+#ifdef CFG_DRIVERS_PINCTRL
+	res = pinctrl_get_state_by_name(fdt, node, "default", &pd->pinctrl);
+	if (res)
+		panic();
+
+	res = pinctrl_get_state_by_name(fdt, node, "sleep", &pd->pinctrl_sleep);
+	if (res && res != TEE_ERROR_ITEM_NOT_FOUND)
+		panic();
+
+	res = pinctrl_apply_state(pd->pinctrl);
+	if (res)
+		panic();
+#else
 	count = stm32_pinctrl_fdt_get_pinctrl(fdt, node, NULL, 0);
 	if (count < 0)
 		panic();
@@ -181,6 +209,7 @@ struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)
 	}
 	pd->pinctrl = pinctrl_cfg;
 	pd->pinctrl_count = count;
+#endif
 
 	if (pd->secure)
 		register_secure_uart(pd);

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -60,63 +60,13 @@ struct gpio_cfg {
  *
  * @bank: GPIO bank identifier as assigned by the platform
  * @pin: Pin number in the GPIO bank
- * ifdef CFG_DRIVERS_PINCTRL
  * @cfg: Pin configuration
- * else
- * @active_cfg: Configuration in active state
- * @standby_cfg: Configuration in standby state
- * endif
  */
 struct stm32_pinctrl {
 	uint8_t bank;
 	uint8_t pin;
-#ifdef CFG_DRIVERS_PINCTRL
 	struct gpio_cfg cfg;
-#else
-	struct gpio_cfg active_cfg;
-	struct gpio_cfg standby_cfg;
-#endif
 };
-
-#ifndef CFG_DRIVERS_PINCTRL
-/*
- * Apply series of pin muxing configuration, active state and standby state
- *
- * @pinctrl: array of pinctrl references
- * @count: Number of entries in @pinctrl
- */
-void stm32_pinctrl_load_active_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
-void stm32_pinctrl_load_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
-
-/*
- * Save the current pin configuration as the standby state for a pin series
- *
- * @pinctrl: array of pinctrl references
- * @count: Number of entries in @pinctrl
- */
-void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
-#endif
-
-/*
- * Save pinctrl instances defined in DT node: identifiers and power states
- *
- * @fdt: device tree
- * @node: device node in the device tree
- * @pinctrl: NULL or pointer to array of struct stm32_pinctrl
- * @count: number of elements pointed by argument cfg
- *
- * Return the number of pinctrl instances found or a negative value on error.
- *
- * When @count is 0, @pinctrl may be NULL. The function will return only the
- * number of pinctrl instances found in the device tree for the target
- * device node.
- *
- * If more instances than @count are found then the function returns the
- * effective number of pincltr instance found in the node but fills
- * output array @pinctrl only for the input @count first entries.
- */
-int stm32_pinctrl_fdt_get_pinctrl(void *fdt, int node,
-				  struct stm32_pinctrl *pinctrl, size_t count);
 
 #ifdef CFG_STM32_GPIO
 /*
@@ -128,14 +78,6 @@ int stm32_pinctrl_fdt_get_pinctrl(void *fdt, int node,
  */
 void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin,
 			       bool secure);
-#else
-static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
-					     unsigned int pin __unused,
-					     bool secure __unused)
-{
-	assert(0);
-}
-#endif
 
 /*
  * Get the number of GPIO pins supported by a target GPIO bank
@@ -147,7 +89,6 @@ static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
  */
 int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
-#ifdef CFG_DRIVERS_PINCTRL
 /*
  * Configure pin muxing access permission: can be secure or not
  *
@@ -179,5 +120,5 @@ static inline void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *p __unused,
 					       unsigned int *count __unused)
 {
 }
-#endif /*CFG_DRIVERS_PINCTRL*/
+#endif /*CFG_STM32_GPIO*/
 #endif /*DRIVERS_STM32_GPIO_H*/

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -33,6 +33,8 @@
 #define GPIO_OD_LEVEL_LOW	0x0
 #define GPIO_OD_LEVEL_HIGH	0x1
 
+struct pinctrl_state;
+
 /*
  * GPIO configuration description structured as single 16bit word
  * for efficient save/restore when GPIO pin suspends or resumes.
@@ -145,4 +147,23 @@ static inline void stm32_gpio_set_secure_cfg(unsigned int bank __unused,
  */
 int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
+#ifdef CFG_DRIVERS_PINCTRL
+/*
+ * Get the bank and pin indices related to a pin control state
+ * @pinctrl: Pinctrl state
+ * @bank: Output bank indices array or NULL
+ * @pin: Output pin indices array or NULL
+ * @count: [in] Number of cells of @bank and @pin, [out] pin count in @pinctrl
+ */
+void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *pinctrl,
+				 unsigned int *bank, unsigned int *pin,
+				 unsigned int *count);
+#else
+static inline void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *p __unused,
+					       unsigned int *bank __unused,
+					       unsigned int *pin __unused,
+					       unsigned int *count __unused)
+{
+}
+#endif /*CFG_DRIVERS_PINCTRL*/
 #endif /*DRIVERS_STM32_GPIO_H*/

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -7,66 +7,13 @@
 #define DRIVERS_STM32_GPIO_H
 
 #include <assert.h>
-#include <compiler.h>
 #include <drivers/pinctrl.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 
-#define GPIO_MODE_INPUT		0x0
-#define GPIO_MODE_OUTPUT	0x1
-#define GPIO_MODE_ALTERNATE	0x2
-#define GPIO_MODE_ANALOG	0x3
-
-#define GPIO_OTYPE_PUSH_PULL	0x0
-#define GPIO_OTYPE_OPEN_DRAIN	0x1
-
-#define GPIO_OSPEED_LOW		0x0
-#define GPIO_OSPEED_MEDIUM	0x1
-#define GPIO_OSPEED_HIGH	0x2
-#define GPIO_OSPEED_VERY_HIGH	0x3
-
-#define GPIO_PUPD_NO_PULL	0x0
-#define GPIO_PUPD_PULL_UP	0x1
-#define GPIO_PUPD_PULL_DOWN	0x2
-
-#define GPIO_OD_LEVEL_LOW	0x0
-#define GPIO_OD_LEVEL_HIGH	0x1
-
 struct pinctrl_state;
-
-/*
- * GPIO configuration description structured as single 16bit word
- * for efficient save/restore when GPIO pin suspends or resumes.
- *
- * @mode: One of GPIO_MODE_*
- * @otype: One of GPIO_OTYPE_*
- * @ospeed: One of GPIO_OSPEED_*
- * @pupd: One of GPIO_PUPD_*
- * @od: One of GPIO_OD_*
- * @af: Alternate function numerical ID between 0 and 15
- */
-struct gpio_cfg {
-	uint16_t mode:		2;
-	uint16_t otype:		1;
-	uint16_t ospeed:	2;
-	uint16_t pupd:		2;
-	uint16_t od:		1;
-	uint16_t af:		4;
-};
-
-/*
- * Description of a pin and its muxing
- *
- * @bank: GPIO bank identifier as assigned by the platform
- * @pin: Pin number in the GPIO bank
- * @cfg: Pin configuration
- */
-struct stm32_pinctrl {
-	uint8_t bank;
-	uint8_t pin;
-	struct gpio_cfg cfg;
-};
+struct stm32_pinctrl;
 
 #ifdef CFG_STM32_GPIO
 /*

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -149,6 +149,14 @@ int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
 
 #ifdef CFG_DRIVERS_PINCTRL
 /*
+ * Configure pin muxing access permission: can be secure or not
+ *
+ * @pinctrl: Pin control state where STM32_GPIO pin are to configure
+ * @secure: True if pin is secure, false otherwise
+ */
+void stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl, bool secure);
+
+/*
  * Get the bank and pin indices related to a pin control state
  * @pinctrl: Pinctrl state
  * @bank: Output bank indices array or NULL
@@ -159,6 +167,12 @@ void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *pinctrl,
 				 unsigned int *bank, unsigned int *pin,
 				 unsigned int *count);
 #else
+static inline void
+stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl __unused,
+			     bool secure __unused)
+{
+}
+
 static inline void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *p __unused,
 					       unsigned int *bank __unused,
 					       unsigned int *pin __unused,

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -1,19 +1,14 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2017-2019, STMicroelectronics
- *
- * STM32 GPIO driver relies on platform util fiunctions to get base address
- * and clock ID of the GPIO banks. The drvier API allows to retrieve pin muxing
- * configuration for given nodes and load them at runtime. A pin control
- * instance provide an active and a standby configuration. Pin onwer is
- * responsible to load to expected configuration during PM state transitions
- * as STM32 GPIO driver does no register callbacks to the PM framework.
+ * Copyright (c) 2017-2023, STMicroelectronics
  */
 
 #ifndef DRIVERS_STM32_GPIO_H
 #define DRIVERS_STM32_GPIO_H
 
 #include <assert.h>
+#include <compiler.h>
+#include <drivers/pinctrl.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -59,20 +54,29 @@ struct gpio_cfg {
 };
 
 /*
- * Descrption of a pin and its 2 states muxing
+ * Description of a pin and its muxing
  *
  * @bank: GPIO bank identifier as assigned by the platform
  * @pin: Pin number in the GPIO bank
+ * ifdef CFG_DRIVERS_PINCTRL
+ * @cfg: Pin configuration
+ * else
  * @active_cfg: Configuration in active state
  * @standby_cfg: Configuration in standby state
+ * endif
  */
 struct stm32_pinctrl {
 	uint8_t bank;
 	uint8_t pin;
+#ifdef CFG_DRIVERS_PINCTRL
+	struct gpio_cfg cfg;
+#else
 	struct gpio_cfg active_cfg;
 	struct gpio_cfg standby_cfg;
+#endif
 };
 
+#ifndef CFG_DRIVERS_PINCTRL
 /*
  * Apply series of pin muxing configuration, active state and standby state
  *
@@ -89,6 +93,7 @@ void stm32_pinctrl_load_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
  * @count: Number of entries in @pinctrl
  */
 void stm32_pinctrl_store_standby_cfg(struct stm32_pinctrl *pinctrl, size_t cnt);
+#endif
 
 /*
  * Save pinctrl instances defined in DT node: identifiers and power states

--- a/core/include/drivers/stm32_i2c.h
+++ b/core/include/drivers/stm32_i2c.h
@@ -8,7 +8,6 @@
 
 #include <drivers/clk.h>
 #include <drivers/pinctrl.h>
-#include <drivers/stm32_gpio.h>
 #include <kernel/dt.h>
 #include <mm/core_memprot.h>
 #include <stdbool.h>
@@ -112,12 +111,8 @@ struct i2c_cfg {
  * @saved_timing: Saved timing value if already computed
  * @saved_frequency: Saved frequency value if already computed
  * @sec_cfg: I2C registers configuration storage
- * Case CFG_DRIVERS_PINCTRL
  * @pinctrl: Pin control configuration for the I2C bus in active state
  * @pinctrl_sleep: Pin control configuration for the I2C bus in standby state
- * Case !CFG_DRIVERS_PINCTRL
- * @pinctrl: PINCTRLs configuration for the I2C PINs
- * @pinctrl_count: Number of PINCTRLs elements
  */
 struct i2c_handle_s {
 	struct io_pa_va base;
@@ -129,13 +124,8 @@ struct i2c_handle_s {
 	uint32_t saved_timing;
 	unsigned long saved_frequency;
 	struct i2c_cfg sec_cfg;
-#ifdef CFG_DRIVERS_PINCTRL
 	struct pinctrl_state *pinctrl;
 	struct pinctrl_state *pinctrl_sleep;
-#else
-	struct stm32_pinctrl *pinctrl;
-	size_t pinctrl_count;
-#endif
 };
 
 /* STM32 specific defines */
@@ -145,7 +135,6 @@ struct i2c_handle_s {
 #define STM32_I2C_ANALOG_FILTER_DELAY_MAX	U(260)	/* ns */
 #define STM32_I2C_DIGITAL_FILTER_MAX		U(16)
 
-#ifdef CFG_DRIVERS_PINCTRL
 /*
  * Fill struct stm32_i2c_init_s from DT content for a given I2C node
  *
@@ -160,22 +149,6 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 					struct stm32_i2c_init_s *init,
 					struct pinctrl_state **pinctrl_active,
 					struct pinctrl_state **pinctrl_sleep);
-#else
-/*
- * Fill struct stm32_i2c_init_s from DT content for a given I2C node
- *
- * @fdt: Reference to DT
- * @node: Target I2C node in the DT
- * @init: Output stm32_i2c_init_s structure
- * @pinctrl: Reference to output pinctrl array
- * @pinctrl_count: Input @pinctrl array size, output expected size upon success
- * Return a TEE_Result compliant value
- */
-TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
-					struct stm32_i2c_init_s *init,
-					struct stm32_pinctrl **pinctrl,
-					size_t *pinctrl_count);
-#endif /*CFG_DRIVERS_PINCTRL*/
 
 /*
  * Initialize I2C bus handle from input configuration directives

--- a/core/include/drivers/stm32_uart.h
+++ b/core/include/drivers/stm32_uart.h
@@ -1,22 +1,31 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2017-2018, STMicroelectronics
+ * Copyright (c) 2017-2023, STMicroelectronics
  */
 
-#ifndef __STM32_UART_H__
-#define __STM32_UART_H__
+#ifndef DRIVERS_STM32_UART_H
+#define DRIVERS_STM32_UART_H
 
 #include <drivers/clk.h>
-#include <drivers/serial.h>
+#include <drivers/pinctrl.h>
 #include <drivers/stm32_gpio.h>
+#include <drivers/serial.h>
+#include <io.h>
+#include <types_ext.h>
+#include <stdbool.h>
 
 struct stm32_uart_pdata {
 	struct io_pa_va base;
 	struct serial_chip chip;
 	bool secure;
 	struct clk *clock;
+#ifdef CFG_DRIVERS_PINCTRL
+	struct pinctrl_state *pinctrl;
+#else
 	struct stm32_pinctrl *pinctrl;
 	size_t pinctrl_count;
+#endif
+	struct pinctrl_state *pinctrl_sleep;
 };
 
 /*
@@ -39,4 +48,4 @@ void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base);
  */
 struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node);
 
-#endif /*__STM32_UART_H__*/
+#endif /*DRIVERS_STM32_UART_H*/

--- a/core/include/drivers/stm32_uart.h
+++ b/core/include/drivers/stm32_uart.h
@@ -8,7 +8,6 @@
 
 #include <drivers/clk.h>
 #include <drivers/pinctrl.h>
-#include <drivers/stm32_gpio.h>
 #include <drivers/serial.h>
 #include <io.h>
 #include <types_ext.h>
@@ -19,12 +18,7 @@ struct stm32_uart_pdata {
 	struct serial_chip chip;
 	bool secure;
 	struct clk *clock;
-#ifdef CFG_DRIVERS_PINCTRL
 	struct pinctrl_state *pinctrl;
-#else
-	struct stm32_pinctrl *pinctrl;
-	size_t pinctrl_count;
-#endif
 	struct pinctrl_state *pinctrl_sleep;
 };
 


### PR DESCRIPTION
Bump stm32_gpio driver to recently merged  pinctrl device driver probing support.

For STM32MP13 variant to comply with pinctrl support (and not panic on driver probe errors), I needed to update STM32MP13 DTS and DTSI file and 2 stm32 drivers (stm32_etzpc and stm32_rstctrl). They are part of this series.

A patch fixing a pinctrl driver probe function in under review at https://github.com/OP-TEE/optee_os/pull/6081.