### PR TITLE
itr_chip drivers: dt_driver resources for interrupts bindings

### DIFF
--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -23,6 +23,7 @@
  * DT_DRIVER_I2C    I2C bus controller using generic I2C bus DT bindings
  * DT_DRIVER_GPIO   GPIO controller using generic GPIO DT bindings
  * DT_DRIVER_PINCTRL Pin controller using generic reset DT bindings
+ * DT_DRIVER_INTERRUPT Interrupt controller using generic DT bindings
  */
 enum dt_driver_type {
 	DT_DRIVER_NOTYPE,
@@ -31,7 +32,8 @@ enum dt_driver_type {
 	DT_DRIVER_RSTCTRL,
 	DT_DRIVER_I2C,
 	DT_DRIVER_GPIO,
-	DT_DRIVER_PINCTRL
+	DT_DRIVER_PINCTRL,
+	DT_DRIVER_INTERRUPT,
 };
 
 /*

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -172,6 +172,22 @@ void *dt_driver_device_from_parent(const void *fdt, int nodeoffset,
 				   enum dt_driver_type type, TEE_Result *res);
 
 /*
+ * dt_driver_device_from_node_idx_prop_phandle() - Same as
+ *	dt_driver_device_from_node_idx_prop() but phandle is not the first
+ *	cells in property @prop_name but is passed as an argument.
+ *
+ * This function is used for DT bindings as "interrupts" property where the
+ * property carries the interrupt information but not the interrupt controller
+ * phandle which is found in a specific property (here "interrupt-parent").
+ */
+void *dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
+						  const void *fdt, int nodeoffs,
+						  unsigned int prop_index,
+						  enum dt_driver_type type,
+						  uint32_t phandle,
+						  TEE_Result *res);
+
+/*
  * dt_driver_get_crypto() - Request crypto support for driver initialization
  *
  * Return TEE_SUCCESS if cryptography services are initialized, otherwise return

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -109,6 +109,7 @@ static void assert_type_is_valid(enum dt_driver_type type)
 	case DT_DRIVER_GPIO:
 	case DT_DRIVER_I2C:
 	case DT_DRIVER_PINCTRL:
+	case DT_DRIVER_INTERRUPT:
 		return;
 	default:
 		assert(0);
@@ -184,6 +185,9 @@ int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
 	switch (type) {
 	case DT_DRIVER_CLK:
 		cells_name = "#clock-cells";
+		break;
+	case DT_DRIVER_INTERRUPT:
+		cells_name = "#interrupt-cells";
 		break;
 	case DT_DRIVER_RSTCTRL:
 		cells_name = "#reset-cells";


### PR DESCRIPTION
2 patches extracted from https://github.com/OP-TEE/optee_os/pull/5954:

"core: dt_driver: define interrupt controller drivers identifier":
@jenswi-linaro review tag applied (https://github.com/OP-TEE/optee_os/pull/5954#issuecomment-1570403576).
 
"core: dt_driver: add helper for old fashion interrupt bindings"
@jenswi-linaro review tag (https://github.com/OP-TEE/optee_os/pull/5954#pullrequestreview-1464333713) is NOT YET applied as I squashed in a fix (https://github.com/OP-TEE/optee_os/pull/5954#discussion_r1219294494).