### PR TITLE
ffa: remove ffa.h from host export list

### DIFF
--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -125,10 +125,6 @@ incfiles-extra-host += core/include/signed_hdr.h
 ifeq ($(ta-target),ta_arm32)
 incfiles-extra-host += $(out-dir)/include/generated/arm32_user_sysreg.h
 endif
-ifeq ($(CFG_SPMC_TESTS),y)
-incfiles-extra-host += core/arch/arm/include/ffa.h
-incfiles-extra-host += core/arch/arm/include/smccc.h
-endif
 #
 # Copy lib files and exported headers from each lib
 #


### PR DESCRIPTION
`commit 5489e94f0566 ("core: ffa: add boot info structs and defines")` causes the compiler error below in host applications.
```
ffa.h:196:41: error: implicit declaration of function ‘U’ [-Werror=implicit-function-declaration]
  196 | #define FFA_BOOT_INFO_NAME_LEN          U(16)
      |                                         ^
ffa.h:319:19: note: in expansion of macro ‘FFA_BOOT_INFO_NAME_LEN’
  319 |         char name[FFA_BOOT_INFO_NAME_LEN];
      |                   ^~~~~~~~~~~~~~~~~~~~~~
ffa.h:319:14: error: variably modified ‘name’ at file scope
  319 |         char name[FFA_BOOT_INFO_NAME_LEN];
      |              ^~~~
```
`ffa.h` uses the `U` macro which is only part of OP-TEE's libc and not a standard macro. This causes a compiler error when compiling a host application and the libc is provided by the compiler. This makes `ffa.h` not suitable for host export.

Related PR in optee_test: https://github.com/OP-TEE/optee_test/pull/673/commits/c607d4c5d9ca5187ddf1f7d3f6850110b165c5e8

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
