### PR TITLE
plat-stm32mp1: fix default setting GPIO as non-secure

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -244,41 +244,6 @@ static TEE_Result set_etzpc_secure_configuration(void)
 
 driver_init_late(set_etzpc_secure_configuration);
 #endif /* CFG_STM32_ETZPC */
-
-#ifdef CFG_STM32_GPIO
-
-#define NB_PINS_PER_BANK		U(16)
-#define NB_PINS_BANK_H			U(14)
-#define NB_PINS_BANK_I			U(8)
-
-static TEE_Result set_all_gpios_non_secure(void)
-{
-	unsigned int bank = 0;
-	unsigned int pin = 0;
-	unsigned int nb_pin_bank = 0;
-
-	for (bank = 0; bank <= GPIO_BANK_I; bank++) {
-		switch (bank) {
-		case GPIO_BANK_H:
-			nb_pin_bank = NB_PINS_BANK_H;
-			break;
-		case GPIO_BANK_I:
-			nb_pin_bank = NB_PINS_BANK_I;
-			break;
-		default:
-			nb_pin_bank = NB_PINS_PER_BANK;
-			break;
-		}
-
-		for (pin = 0; pin <= nb_pin_bank; pin++)
-			stm32_gpio_set_secure_cfg(bank, pin, false);
-	}
-
-	return TEE_SUCCESS;
-}
-
-early_init_late(set_all_gpios_non_secure);
-#endif /* CFG_STM32_GPIO */
 #endif /* CFG_STM32MP13 */
 
 static TEE_Result init_stm32mp1_drivers(void)

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -446,6 +446,14 @@ static TEE_Result dt_stm32_gpio_bank(const void *fdt, int node,
 	return TEE_SUCCESS;
 }
 
+static void set_bank_gpio_non_secure(struct stm32_gpio_bank *bank)
+{
+	unsigned int pin = 0;
+
+	for (pin = 0; pin <= bank->ngpios; pin++)
+		stm32_gpio_set_secure_cfg(bank->bank_id, pin, false);
+}
+
 /* Parse a pinctrl node to register the GPIO banks it describes */
 static TEE_Result dt_stm32_gpio_pinctrl(const void *fdt, int node,
 					const void *compat_data)
@@ -485,6 +493,9 @@ static TEE_Result dt_stm32_gpio_pinctrl(const void *fdt, int node,
 				return res;
 
 			STAILQ_INSERT_TAIL(&bank_list, bank, link);
+
+			if (IS_ENABLED(CFG_STM32MP13))
+				set_bank_gpio_non_secure(bank);
 		} else {
 			if (len != -FDT_ERR_NOTFOUND)
 				panic();


### PR DESCRIPTION
Fixes STM32MP13 sequence that default configures GPIO as non-secure from `set_all_gpios_non_secure()` registered at `early_init_late` initcall level, that is at same level driver are initially probed by dt_driver framework. This result on `set_all_gpios_non_secure()` possibly needing a bank resource before it is probed. Fix that by removing initcall function `set_all_gpios_non_secure()` and default configuring GPIO pins for STM32MP13 variant on their GPIO bank registering.

Fixes: 077d486ef09d ("drivers: stm32_gpio: add helper function stm32_gpio_get_bank()")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
