### PR TITLE
core: interrupt: new interrupt API functions

### DIFF
--- a/core/drivers/atmel_saic.c
+++ b/core/drivers/atmel_saic.c
@@ -149,6 +149,8 @@ static void saic_set_affinity(struct itr_chip *chip __unused,
 
 static const struct itr_ops saic_ops = {
 	.add = saic_add,
+	.mask = saic_disable,
+	.unmask = saic_enable,
 	.enable = saic_enable,
 	.disable = saic_disable,
 	.raise_pi = saic_raise_pi,

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -94,6 +94,8 @@ static void gic_op_set_affinity(struct itr_chip *chip, size_t it,
 
 static const struct itr_ops gic_ops = {
 	.add = gic_op_add,
+	.mask = gic_op_disable,
+	.unmask = gic_op_enable,
 	.enable = gic_op_enable,
 	.disable = gic_op_disable,
 	.raise_pi = gic_op_raise_pi,

--- a/core/drivers/hfic.c
+++ b/core/drivers/hfic.c
@@ -60,6 +60,8 @@ static void hfic_op_set_affinity(struct itr_chip *chip __unused,
 
 static const struct itr_ops hfic_ops = {
 	.add = hfic_op_add,
+	.mask = hfic_op_disable,
+	.unmask = hfic_op_enable,
 	.enable = hfic_op_enable,
 	.disable = hfic_op_disable,
 	.raise_pi = hfic_op_raise_pi,

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -6,21 +6,29 @@
 #define __KERNEL_INTERRUPT_H
 
 #include <dt-bindings/interrupt-controller/irq.h>
-#include <types_ext.h>
+#include <mm/core_memprot.h>
 #include <sys/queue.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
 #include <util.h>
 
 #define ITRF_TRIGGER_LEVEL	BIT(0)
 #define ITRF_SHARED		BIT(1)
 
+struct itr_handler;
+
 /*
  * struct itr_chip - Interrupt controller
  *
  * @ops Operation callback functions
+ * @name Controller name, for debug purpose
+ * @handlers Registered handlers list head
  * @dt_get_irq Device tree node parsing function
  */
 struct itr_chip {
 	const struct itr_ops *ops;
+	const char *name;
+	SLIST_HEAD(, itr_handler) handlers;
 	/*
 	 * dt_get_irq - parse a device tree interrupt property
 	 *
@@ -39,15 +47,22 @@ struct itr_chip {
  * @add		Register and configure an interrupt
  * @enable	Enable an interrupt
  * @disable	Disable an interrupt
+ * @mask	Mask an interrupt, may be called from an interrupt context
+ * @unmask	Unmask an interrupt, may be called from an interrupt context
  * @raise_pi	Raise per-cpu interrupt or NULL if not applicable
  * @raise_sgi	Raise a SGI or NULL if not applicable to that controller
  * @set_affinity Set interrupt/cpu affinity or NULL if not applicable
+ *
+ * Handlers @enable, @disable, @mask, @unmask and @add are mandated. Handlers
+ * @mask and @unmask have unpaged memory contrainsts. See itr_chip_is_valid().
  */
 struct itr_ops {
 	void (*add)(struct itr_chip *chip, size_t it, uint32_t type,
 		    uint32_t prio);
 	void (*enable)(struct itr_chip *chip, size_t it);
 	void (*disable)(struct itr_chip *chip, size_t it);
+	void (*mask)(struct itr_chip *chip, size_t it);
+	void (*unmask)(struct itr_chip *chip, size_t it);
 	void (*raise_pi)(struct itr_chip *chip, size_t it);
 	void (*raise_sgi)(struct itr_chip *chip, size_t it,
 		uint8_t cpu_mask);
@@ -61,16 +76,15 @@ enum itr_return {
 	ITRR_HANDLED,
 };
 
-struct itr_handler;
-
 /* Interrupt handler signature */
 typedef enum itr_return (*itr_handler_t)(struct itr_handler *h);
 
 /*
  * struct itr_handler - Interrupt handler reference
  * @it Interrupt number
- * @flags Property bit flags ITR_FLAG_*
+ * @flags Property bit flags (ITRF_*) or 0
  * @data Private data for that interrupt handler
+ * @chip Interrupt controller chip device
  * @link Reference in controller handler list
  */
 struct itr_handler {
@@ -78,8 +92,35 @@ struct itr_handler {
 	uint32_t flags;
 	itr_handler_t handler;
 	void *data;
+	struct itr_chip *chip;
 	SLIST_ENTRY(itr_handler) link;
 };
+
+#define ITR_HANDLER(_chip, _itr_num, _flags, _fn, _priv) \
+	((struct itr_handler){ \
+		.chip = (_chip), .it = (_itr_num), .flags = (_flags), \
+		.handler = (_fn), .data = (_priv), \
+	})
+
+/*
+ * Return true only if interrupt chip provides required handlers
+ * @chip: Interrupt controller reference
+ */
+static inline bool itr_chip_is_valid(struct itr_chip *chip)
+{
+	return chip && is_unpaged(chip) && chip->ops &&
+	       is_unpaged((void *)chip->ops) &&
+	       chip->ops->mask && is_unpaged(chip->ops->mask) &&
+	       chip->ops->unmask && is_unpaged(chip->ops->unmask) &&
+	       chip->ops->enable && chip->ops->disable &&
+	       chip->ops->add;
+}
+
+/*
+ * Initialise an interrupt controller handle
+ * @chip	Interrupt controller
+ */
+TEE_Result itr_chip_init(struct itr_chip *chip);
 
 /*
  * Initialise main interrupt controller driver
@@ -164,4 +205,142 @@ static inline struct itr_handler *itr_alloc_add(size_t it,
 				       0);
 }
 
+/*
+ * Interrupt controller chip API functions
+ */
+
+/*
+ * interrupt_call_handlers() - Call registered handlers for an interrupt
+ * @chip	Interrupt controller
+ * @itr_num	Interrupt number
+ *
+ * This function is called from an interrupt context by a primary interrupt
+ * handler. This function calls the handlers registered for that interrupt.
+ * If interrupt is not handled, it is masked.
+ */
+void interrupt_call_handlers(struct itr_chip *chip, size_t itr_num);
+
+/*
+ * interrupt_mask() - Mask an interrupt
+ * @chip	Interrupt controller
+ * @itr_num	Interrupt number
+ *
+ * This function may be called in interrupt context
+ */
+static inline void interrupt_mask(struct itr_chip *chip, size_t itr_num)
+{
+	chip->ops->mask(chip, itr_num);
+}
+
+/*
+ * interrupt_unmask() - Unmask an interrupt
+ * @chip	Interrupt controller
+ * @itr_num	Interrupt number
+ *
+ * This function may be called in interrupt context
+ */
+static inline void interrupt_unmask(struct itr_chip *chip, size_t itr_num)
+{
+	chip->ops->unmask(chip, itr_num);
+}
+
+/*
+ * interrupt_enable() - Enable an interrupt
+ * @chip	Interrupt controller
+ * @itr_num	Interrupt number
+ */
+static inline void interrupt_enable(struct itr_chip *chip, size_t itr_num)
+{
+	chip->ops->enable(chip, itr_num);
+}
+
+/*
+ * interrupt_disable() - Disable an interrupt
+ * @chip	Interrupt controller
+ * @itr_num	Interrupt number
+ */
+static inline void interrupt_disable(struct itr_chip *chip, size_t itr_num)
+{
+	chip->ops->disable(chip, itr_num);
+}
+
+/*
+ * interrupt_configure() - Configure an interrupt in an interrupt controller
+ * @chip	Interrupt controller
+ * @itr_num	Interrupt number
+ * @type	Interrupt trigger type (IRQ_TYPE_* defines) or IRQ_TYPE_NONE
+ * @prio	Interrupt priority or 0
+ *
+ * Interrupt consumers that get their interrupt from the DT do not need to
+ * call interrupt_configure() since the interrupt configuration has already
+ * been done by interrupt controller based on the DT bidings.
+ */
+TEE_Result interrupt_configure(struct itr_chip *chip, size_t itr_num,
+			       uint32_t type, uint32_t prio);
+
+/*
+ * interrupt_add_and_configure_handler() - Register and configure a handler
+ * @hdl		Interrupt handler to register
+ * @type	Interrupt trigger type (IRQ_TYPE_* defines) or IRQ_TYPE_NONE
+ * @prio	Interrupt priority or 0
+ */
+TEE_Result interrupt_add_configure_handler(struct itr_handler *hdl,
+					   uint32_t type, uint32_t prio);
+
+/*
+ * interrupt_add_handler() - Register an interrupt handler
+ * @hdl		Interrupt handler to register
+ *
+ * This helper function assumes interrupt type is set to IRQ_TYPE_NONE
+ * and interrupt priority to 0.
+ */
+static inline TEE_Result interrupt_add_handler(struct itr_handler *hdl)
+{
+	return interrupt_add_configure_handler(hdl, IRQ_TYPE_NONE, 0);
+}
+
+/*
+ * interrupt_add_handler_with_chip() - Register an interrupt handler providing
+ *	the interrupt chip reference in specific argument @chip.
+ * @chip	Interrupt controller
+ * @h		Interrupt handler to register
+ */
+static inline TEE_Result interrupt_add_handler_with_chip(struct itr_chip *chip,
+							 struct itr_handler *h)
+{
+	h->chip = chip;
+	return interrupt_add_handler(h);
+}
+
+/*
+ * interrupt_remove_handler() - Remove a registered interrupt handler
+ * @hdl		Interrupt handler to remove
+ *
+ * This function is the counterpart of interrupt_add_handler().
+ * This function may panic on non-NULL invalid @hdl reference.
+ */
+void interrupt_remove_handler(struct itr_handler *hdl);
+
+/*
+ * interrupt_alloc_add_handler() - Allocate and register an interrupt handler
+ * @chip	Interrupt controller
+ * @itr_num	Interrupt number
+ * @handler	Interrupt handler to register
+ * @flags	Bitmask flag ITRF_*
+ * @data	Private data reference passed to @handler
+ * @out_hdl	NULL or output pointer to allocated struct itr_handler
+ */
+TEE_Result interrupt_alloc_add_handler(struct itr_chip *chip, size_t it_num,
+				       itr_handler_t handler, uint32_t flags,
+				       void *data,
+				       struct itr_handler **out_hdl);
+
+/*
+ * interrupt_remove_free_handler() - Remove/free a registered interrupt handler
+ * @hdl		Interrupt handler to remove and free
+ *
+ * This function is the counterpart of interrupt_alloc_add_handler().
+ * This function may panic on non-NULL invalid @hdl reference.
+ */
+void interrupt_remove_free_handler(struct itr_handler *hdl);
 #endif /*__KERNEL_INTERRUPT_H*/

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -21,8 +21,6 @@
  */
 
 static struct itr_chip *itr_main_chip __nex_bss;
-static SLIST_HEAD(, itr_handler) handlers __nex_data =
-	SLIST_HEAD_INITIALIZER(handlers);
 
 TEE_Result itr_chip_init(struct itr_chip *chip)
 {
@@ -36,7 +34,9 @@ TEE_Result itr_chip_init(struct itr_chip *chip)
 
 void interrupt_main_init(struct itr_chip *chip)
 {
-	assert(itr_chip_is_valid(chip));
+	if (itr_chip_init(chip))
+		panic();
+
 	itr_main_chip = chip;
 }
 
@@ -67,22 +67,7 @@ int dt_get_irq_type_prio(const void *fdt, int node, uint32_t *type,
 
 void itr_handle(size_t it)
 {
-	struct itr_handler *h = NULL;
-	bool was_handled = false;
-
-	SLIST_FOREACH(h, &handlers, link) {
-		if (h->it == it) {
-			if (h->handler(h) == ITRR_HANDLED)
-				was_handled = true;
-			else if (!(h->flags & ITRF_SHARED))
-				break;
-		}
-	}
-
-	if (!was_handled) {
-		EMSG("Disabling unhandled interrupt %zu", it);
-		itr_main_chip->ops->disable(itr_main_chip, it);
-	}
+	interrupt_call_handlers(itr_main_chip, it);
 }
 
 struct itr_handler *itr_alloc_add_type_prio(size_t it, itr_handler_t handler,
@@ -109,7 +94,7 @@ void itr_free(struct itr_handler *hdl)
 
 	itr_main_chip->ops->disable(itr_main_chip, hdl->it);
 
-	SLIST_REMOVE(&handlers, hdl, itr_handler, link);
+	SLIST_REMOVE(&itr_main_chip->handlers, hdl, itr_handler, link);
 	free(hdl);
 }
 
@@ -117,13 +102,13 @@ void itr_add_type_prio(struct itr_handler *h, uint32_t type, uint32_t prio)
 {
 	struct itr_handler __maybe_unused *hdl = NULL;
 
-	SLIST_FOREACH(hdl, &handlers, link)
+	SLIST_FOREACH(hdl, &itr_main_chip->handlers, link)
 		if (hdl->it == h->it)
 			assert((hdl->flags & ITRF_SHARED) &&
 			       (h->flags & ITRF_SHARED));
 
 	itr_main_chip->ops->add(itr_main_chip, h->it, type, prio);
-	SLIST_INSERT_HEAD(&handlers, h, link);
+	SLIST_INSERT_HEAD(&itr_main_chip->handlers, h, link);
 }
 
 void itr_enable(size_t it)

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -7,6 +7,7 @@
 #include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <libfdt.h>
+#include <mm/core_memprot.h>
 #include <stdlib.h>
 #include <trace.h>
 #include <assert.h>
@@ -23,8 +24,19 @@ static struct itr_chip *itr_main_chip __nex_bss;
 static SLIST_HEAD(, itr_handler) handlers __nex_data =
 	SLIST_HEAD_INITIALIZER(handlers);
 
+TEE_Result itr_chip_init(struct itr_chip *chip)
+{
+	if (!itr_chip_is_valid(chip))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	SLIST_INIT(&chip->handlers);
+
+	return TEE_SUCCESS;
+}
+
 void interrupt_main_init(struct itr_chip *chip)
 {
+	assert(itr_chip_is_valid(chip));
 	itr_main_chip = chip;
 }
 
@@ -143,4 +155,127 @@ void itr_set_affinity(size_t it, uint8_t cpu_mask)
 void __weak __noreturn interrupt_main_handler(void)
 {
 	panic("Secure interrupt handler not defined");
+}
+
+/*
+ * Interrupt controller chip support
+ */
+void interrupt_call_handlers(struct itr_chip *chip, size_t itr_num)
+{
+	struct itr_handler *h = NULL;
+	bool was_handled = false;
+
+	assert(chip);
+
+	SLIST_FOREACH(h, &chip->handlers, link) {
+		if (h->it == itr_num) {
+			if (h->handler(h) == ITRR_HANDLED)
+				was_handled = true;
+			else if (!(h->flags & ITRF_SHARED))
+				break;
+		}
+	}
+
+	if (!was_handled) {
+		EMSG("Mask unhandled interrupt %s:%zu", chip->name, itr_num);
+		interrupt_mask(chip, itr_num);
+	}
+}
+
+TEE_Result interrupt_configure(struct itr_chip *chip, size_t itr_num,
+			       uint32_t type, uint32_t prio)
+{
+	chip->ops->add(chip, itr_num, type, prio);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result interrupt_add_configure_handler(struct itr_handler *hdl,
+					   uint32_t type, uint32_t prio)
+{
+	struct itr_handler *h = NULL;
+
+	assert(hdl && hdl->chip->ops && is_unpaged(hdl) &&
+	       hdl->handler && is_unpaged(hdl->handler));
+
+	SLIST_FOREACH(h, &hdl->chip->handlers, link) {
+		if (h->it == hdl->it &&
+		    (!(hdl->flags & ITRF_SHARED) ||
+		     !(h->flags & ITRF_SHARED))) {
+			EMSG("Shared and non-shared flags on interrupt %s#%zu",
+			     hdl->chip->name, hdl->it);
+			return TEE_ERROR_GENERIC;
+		}
+	}
+
+	interrupt_configure(hdl->chip, hdl->it, type, prio);
+
+	SLIST_INSERT_HEAD(&hdl->chip->handlers, hdl, link);
+
+	return TEE_SUCCESS;
+}
+
+void interrupt_remove_handler(struct itr_handler *hdl)
+{
+	struct itr_handler *h = NULL;
+	bool disable_itr = true;
+
+	if (!hdl)
+		return;
+
+	SLIST_FOREACH(h, &hdl->chip->handlers, link)
+		if (h == hdl)
+			break;
+	if (!h) {
+		DMSG("Invalid %s:%zu", hdl->chip->name, hdl->it);
+		assert(false);
+		return;
+	}
+
+	if (hdl->flags & ITRF_SHARED) {
+		SLIST_FOREACH(h, &hdl->chip->handlers, link) {
+			if (h != hdl && h->it == hdl->it) {
+				disable_itr = false;
+				break;
+			}
+		}
+	}
+
+	if (disable_itr)
+		interrupt_disable(hdl->chip, hdl->it);
+
+	SLIST_REMOVE(&hdl->chip->handlers, hdl, itr_handler, link);
+}
+
+TEE_Result interrupt_alloc_add_handler(struct itr_chip *chip, size_t itr_num,
+				       itr_handler_t handler, uint32_t flags,
+				       void *data, struct itr_handler **out_hdl)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct itr_handler *hdl = NULL;
+
+	hdl = calloc(1, sizeof(*hdl));
+	if (!hdl)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	*hdl = ITR_HANDLER(chip, itr_num, flags, handler, data);
+
+	res = interrupt_add_handler(hdl);
+	if (res) {
+		free(hdl);
+		return res;
+	}
+
+	if (out_hdl)
+		*out_hdl = hdl;
+
+	return TEE_SUCCESS;
+}
+
+void interrupt_remove_free_handler(struct itr_handler *hdl)
+{
+	if (hdl) {
+		interrupt_remove_handler(hdl);
+		free(hdl);
+	}
 }


### PR DESCRIPTION
5 patches etracted from https://github.com/OP-TEE/optee_os/pull/5954 + a fixup patch (for an added change not proposed in that reference P-R: sanity test on pageable attribute of interrupt handling resources) to propose new interrupt management API functions that can be used on CPU main interrupt controller as well as on secondary interrupt controllers.