### PR TITLE
core: dt_driver: swap TEE_result and retrieved device reference

### DIFF
--- a/core/drivers/atmel_piobu.c
+++ b/core/drivers/atmel_piobu.c
@@ -204,24 +204,26 @@ static const struct gpio_ops atmel_piobu_ops = {
 	.set_interrupt = secumod_gpio_set_interrupt,
 };
 
-static struct gpio *secumod_dt_get(struct dt_pargs *pargs, void *data,
-				   TEE_Result *res)
+static TEE_Result secumod_dt_get(struct dt_pargs *pargs, void *data,
+				 struct gpio **out_gpio)
 {
+	TEE_Result res = TEE_ERROR_GENERIC;
 	struct gpio *gpio = NULL;
 	struct gpio_chip *chip = data;
 
-	gpio = gpio_dt_alloc_pin(pargs, res);
-	if (*res)
-		return NULL;
+	res = gpio_dt_alloc_pin(pargs, &gpio);
+	if (res)
+		return res;
 
 	if (gpio_protected & BIT32(gpio->pin)) {
 		free(gpio);
-		return NULL;
+		return TEE_ERROR_GENERIC;
 	}
 
 	gpio->chip = chip;
+	*out_gpio = gpio;
 
-	return gpio;
+	return TEE_SUCCESS;
 }
 
 static enum itr_return secumod_it_handler(struct itr_handler *handler __unused)

--- a/core/drivers/clk/clk-stm32-core.c
+++ b/core/drivers/clk/clk-stm32-core.c
@@ -544,23 +544,23 @@ struct clk *stm32mp_rcc_clock_id_to_clk(unsigned long clock_id)
 	return priv->clk_refs[clock_id];
 }
 
-static struct clk *stm32mp_clk_dt_get_clk(struct dt_pargs *pargs,
-					  void *data __unused, TEE_Result *res)
+static TEE_Result stm32mp_clk_dt_get_clk(struct dt_pargs *pargs,
+					 void *data __unused,
+					 struct clk **out_clk)
 {
 	unsigned long clock_id = pargs->args[0];
 	struct clk *clk = NULL;
 
-	*res = TEE_ERROR_BAD_PARAMETERS;
-
 	if (pargs->args_count != 1)
-		return NULL;
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	clk = stm32mp_rcc_clock_id_to_clk(clock_id);
 	if (!clk)
-		return NULL;
+		return TEE_ERROR_BAD_PARAMETERS;
 
-	*res = TEE_SUCCESS;
-	return clk;
+	*out_clk = clk;
+
+	return TEE_SUCCESS;
 }
 
 static void clk_stm32_register_clocks(struct clk_stm32_priv *priv)

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1499,23 +1499,23 @@ static TEE_Result register_stm32mp1_clocks(void)
 	return TEE_SUCCESS;
 }
 
-static struct clk *stm32mp1_clk_dt_get_clk(struct dt_pargs *pargs,
-					   void *data __unused, TEE_Result *res)
+static TEE_Result stm32mp1_clk_dt_get_clk(struct dt_pargs *pargs,
+					  void *data __unused,
+					  struct clk **out_clk)
 {
 	unsigned long clock_id = pargs->args[0];
 	struct clk *clk = NULL;
 
-	*res = TEE_ERROR_BAD_PARAMETERS;
-
 	if (pargs->args_count != 1)
-		return NULL;
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	clk = clock_id_to_clk(clock_id);
 	if (!clk)
-		return NULL;
+		return TEE_ERROR_BAD_PARAMETERS;
 
-	*res = TEE_SUCCESS;
-	return clk;
+	*out_clk = clk;
+
+	return TEE_SUCCESS;
 }
 
 /* Non-null reference for compat data */

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -32,10 +32,14 @@ static TEE_Result clk_dt_get_by_idx_prop(const char *prop_name, const void *fdt,
 					 struct clk **clk)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+	void *out_clk = NULL;
 
-	*clk = dt_driver_device_from_node_idx_prop(prop_name, fdt, nodeoffset,
-						   clk_idx, DT_DRIVER_CLK,
-						   &res);
+	res = dt_driver_device_from_node_idx_prop(prop_name, fdt, nodeoffset,
+						  clk_idx, DT_DRIVER_CLK,
+						  &out_clk);
+	if (!res)
+		*clk = out_clk;
+
 	return res;
 }
 

--- a/core/drivers/clk/sam/at91_clk.h
+++ b/core/drivers/clk/sam/at91_clk.h
@@ -130,7 +130,7 @@ struct pmc_data *pmc_data_allocate(unsigned int ncore, unsigned int nsystem,
 				   unsigned int nperiph, unsigned int ngck,
 				   unsigned int npck);
 
-struct clk *clk_dt_pmc_get(struct dt_pargs *args, void *data, TEE_Result *res);
+TEE_Result clk_dt_pmc_get(struct dt_pargs *args, void *data, struct clk **clk);
 
 struct clk *pmc_clk_get_by_name(struct pmc_clk *clks, unsigned int nclk,
 				const char *name);

--- a/core/drivers/clk/sam/at91_pmc.c
+++ b/core/drivers/clk/sam/at91_pmc.c
@@ -80,22 +80,17 @@ TEE_Result pmc_clk_get(struct pmc_data *pmc, unsigned int type,
 	return TEE_SUCCESS;
 }
 
-struct clk *clk_dt_pmc_get(struct dt_pargs *clkspec, void *data,
-			   TEE_Result *res)
+TEE_Result clk_dt_pmc_get(struct dt_pargs *clkspec, void *data,
+			  struct clk **out_clk)
 {
 	unsigned int type = clkspec->args[0];
 	unsigned int idx = clkspec->args[1];
 	struct pmc_data *pmc_data = data;
-	struct clk *clk = NULL;
 
-	if (clkspec->args_count != 2) {
-		*res = TEE_ERROR_BAD_PARAMETERS;
-		return NULL;
-	}
+	if (clkspec->args_count != 2)
+		return TEE_ERROR_BAD_PARAMETERS;
 
-	*res = pmc_clk_get(pmc_data, type, idx, &clk);
-
-	return clk;
+	return pmc_clk_get(pmc_data, type, idx, out_clk);
 }
 
 struct pmc_data *pmc_data_allocate(unsigned int ncore, unsigned int nsystem,

--- a/core/drivers/i2c/atmel_i2c.c
+++ b/core/drivers/i2c/atmel_i2c.c
@@ -278,20 +278,19 @@ static const struct i2c_ctrl_ops atmel_i2c_ops = {
 	.smbus = atmel_i2c_smbus,
 };
 
-static struct i2c_dev *atmel_i2c_get_dt_i2c(struct dt_pargs *args, void *data,
-					    TEE_Result *res)
+static TEE_Result atmel_i2c_get_dt_i2c(struct dt_pargs *args, void *data,
+				       struct i2c_dev **out_device)
 {
 	struct i2c_dev *i2c_dev = NULL;
 	struct i2c_ctrl *i2c_ctrl = data;
 
 	i2c_dev = i2c_create_dev(i2c_ctrl, args->fdt, args->phandle_node);
-	if (!i2c_dev) {
-		*res = TEE_ERROR_OUT_OF_MEMORY;
-		return NULL;
-	}
+	if (!i2c_dev)
+		return TEE_ERROR_OUT_OF_MEMORY;
 
-	*res = TEE_SUCCESS;
-	return i2c_dev;
+	*out_device = i2c_dev;
+
+	return TEE_SUCCESS;
 }
 
 static TEE_Result atmel_i2c_node_probe(const void *fdt, int node,

--- a/core/drivers/pinctrl/pinctrl.c
+++ b/core/drivers/pinctrl/pinctrl.c
@@ -96,15 +96,18 @@ TEE_Result pinctrl_get_state_by_idx(const void *fdt, int nodeoffset,
 
 	state->conf_count = conf_count;
 	for (conf_id = 0; conf_id < conf_count; conf_id++) {
-		state->confs[conf_id] =
-			dt_driver_device_from_node_idx_prop(prop_name, fdt,
-							    nodeoffset, conf_id,
-							    DT_DRIVER_PINCTRL,
-							    &res);
+		void *pinconf = NULL;
+
+		res = dt_driver_device_from_node_idx_prop(prop_name, fdt,
+							  nodeoffset, conf_id,
+							  DT_DRIVER_PINCTRL,
+							  &pinconf);
 		if (res) {
 			free(state);
 			return res;
 		}
+
+		state->confs[conf_id] = pinconf;
 	}
 
 	*state_ret = state;

--- a/core/drivers/rstctrl/stm32_rstctrl.c
+++ b/core/drivers/rstctrl/stm32_rstctrl.c
@@ -179,27 +179,25 @@ struct rstctrl *stm32mp_rcc_reset_id_to_rstctrl(unsigned int binding_id)
 	return &rstline->rstctrl;
 }
 
-static struct rstctrl *stm32_rstctrl_get_dev(struct dt_pargs *arg,
-					     void *priv_data __unused,
-					     TEE_Result *res)
+static TEE_Result stm32_rstctrl_get_dev(struct dt_pargs *arg,
+					void *priv_data __unused,
+					struct rstctrl **out_device)
 {
 	struct stm32_rstline *stm32_rstline = NULL;
 	uintptr_t control_id = 0;
 
-	if (arg->args_count != 1) {
-		*res = TEE_ERROR_BAD_PARAMETERS;
-		return NULL;
-	}
+	if (arg->args_count != 1)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	control_id = arg->args[0];
 
 	stm32_rstline = find_or_allocate_rstline(control_id);
-	if (!stm32_rstline) {
-		*res = TEE_ERROR_OUT_OF_MEMORY;
-		return NULL;
-	}
+	if (!stm32_rstline)
+		return TEE_ERROR_OUT_OF_MEMORY;
 
-	*res = TEE_SUCCESS;
-	return &stm32_rstline->rstctrl;
+	*out_device = &stm32_rstline->rstctrl;
+
+	return TEE_SUCCESS;
 }
 
 static TEE_Result stm32_rstctrl_provider_probe(const void *fdt, int offs,

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -489,9 +489,10 @@ static int get_pinctrl_from_fdt(void *fdt, int node,
 	return (int)found;
 }
 
-static struct gpio *stm32_gpio_get_dt(struct dt_pargs *pargs,
-				      void *data, TEE_Result *res)
+static TEE_Result stm32_gpio_get_dt(struct dt_pargs *pargs, void *data,
+				    struct gpio **out_gpio)
 {
+	TEE_Result res = TEE_ERROR_GENERIC;
 	struct stm32_gpio_bank *bank = data;
 	struct gpio *gpio = NULL;
 	unsigned int shift_1b = 0;
@@ -501,14 +502,14 @@ static struct gpio *stm32_gpio_get_dt(struct dt_pargs *pargs,
 	uint32_t pupd = 0;
 	uint32_t mode = 0;
 
-	gpio = gpio_dt_alloc_pin(pargs, res);
-	if (*res)
-		return NULL;
+	res = gpio_dt_alloc_pin(pargs, &gpio);
+	if (res)
+		return res;
 
 	if (gpio->pin >= bank->ngpios) {
 		DMSG("Invalid GPIO reference");
 		free(gpio);
-		return NULL;
+		return TEE_ERROR_GENERIC;
 	}
 
 	shift_1b = gpio->pin;
@@ -547,9 +548,9 @@ static struct gpio *stm32_gpio_get_dt(struct dt_pargs *pargs,
 
 	gpio->chip = &bank->gpio_chip;
 
-	*res = TEE_SUCCESS;
+	*out_gpio = gpio;
 
-	return gpio;
+	return TEE_SUCCESS;
 }
 
 /* Get bank ID from bank node property st,bank-name or panic on failure */

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -66,46 +66,40 @@ TEE_Result clk_dt_get_by_name(const void *fdt, int nodeoffset,
  *
  * @args: Pointer to devicetree description of the clock to parse
  * @data: Pointer to data given at clk_dt_register_clk_provider() call
- * @res: Output result code of the operation:
- *	TEE_SUCCESS in case of success
- *	TEE_ERROR_DEFER_DRIVER_INIT if clock is not initialized
- *	Any TEE_Result compliant code in case of error.
- *
- * Returns a clk struct pointer pointing to a clock matching the devicetree
- * description or NULL if invalid description in which case @res provides the
- * error code.
+ * @clk: Output clock reference upon success
  */
-typedef struct clk *(*clk_dt_get_func)(struct dt_pargs *args, void *data,
-				       TEE_Result *res);
+typedef TEE_Result (*clk_dt_get_func)(struct dt_pargs *args, void *data,
+				      struct clk **out_clk);
 
 /**
  * clk_dt_register_clk_provider - Register a clock provider
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the clock
- * @get_dt_clk: Callback to match the devicetree clock with a clock struct
+ * @func: Callback to match the devicetree clock with a clock struct
  * @data: Data which will be passed to the get_dt_clk callback
  * Returns TEE_Result value
  */
-static inline
-TEE_Result clk_dt_register_clk_provider(const void *fdt, int nodeoffset,
-					clk_dt_get_func get_dt_clk, void *data)
+static inline TEE_Result clk_dt_register_clk_provider(const void *fdt,
+						      int nodeoffset,
+						      clk_dt_get_func func,
+						      void *data)
 {
 	return dt_driver_register_provider(fdt, nodeoffset,
-					   (get_of_device_func)get_dt_clk,
-					   data, DT_DRIVER_CLK);
+					   (get_of_device_func)func, data,
+					   DT_DRIVER_CLK);
 }
 
 /**
  * clk_dt_get_simple_clk: simple clock matching function for single clock
  * providers
  */
-static inline struct clk *clk_dt_get_simple_clk(struct dt_pargs *args __unused,
-						void *data, TEE_Result *res)
+static inline TEE_Result clk_dt_get_simple_clk(struct dt_pargs *args __unused,
+					       void *data, struct clk **out_clk)
 {
-	*res = TEE_SUCCESS;
+	*out_clk = data;
 
-	return data;
+	return TEE_SUCCESS;
 }
 
 #endif /* __DRIVERS_CLK_DT_H */

--- a/core/include/drivers/gpio.h
+++ b/core/include/drivers/gpio.h
@@ -147,7 +147,7 @@ static inline void gpio_put(struct gpio *gpio)
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs, TEE_Result *res);
+TEE_Result gpio_dt_alloc_pin(struct dt_pargs *pargs, struct gpio **gpio);
 
 /**
  * gpio_dt_get_by_index() - Get a GPIO controller at a specific index in
@@ -171,17 +171,15 @@ static inline TEE_Result gpio_dt_get_by_index(const void *fdt __unused,
 					      int nodeoffset __unused,
 					      unsigned int index  __unused,
 					      const char *gpio_name  __unused,
-					      struct gpio **gpio)
+					      struct gpio **gpio __unused)
 {
-	*gpio = NULL;
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-static inline struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs __unused,
-					     TEE_Result *res)
+static inline TEE_Result gpio_dt_alloc_pin(struct dt_pargs *pargs __unused,
+					   struct gpio **gpio __unused)
 {
-	*res = TEE_ERROR_NOT_SUPPORTED;
-	return NULL;
+	return TEE_ERROR_NOT_SUPPORTED;
 }
 #endif /*CFG_DT*/
 
@@ -200,8 +198,8 @@ static inline struct gpio *gpio_dt_alloc_pin(struct dt_pargs *pargs __unused,
  * the devicetree description or NULL if invalid description in which case
  * @res provides the error code.
  */
-typedef struct gpio *(*gpio_dt_get_func)(struct dt_pargs *pargs, void *data,
-					 TEE_Result *res);
+typedef TEE_Result (*gpio_dt_get_func)(struct dt_pargs *pargs, void *data,
+				       struct gpio **out_gpio);
 
 /**
  * gpio_dt_register_provider() - Register a GPIO controller provider

--- a/core/include/drivers/pinctrl.h
+++ b/core/include/drivers/pinctrl.h
@@ -49,8 +49,16 @@ struct pinctrl_ops {
 	void (*conf_free)(struct pinconf *conf);
 };
 
-typedef struct pinconf *(*pinctrl_dt_get_func)(struct dt_pargs *pargs,
-					       void *data, TEE_Result *res);
+/**
+ * pinctrl_dt_get_func - Typedef of function to get a pin configuration from
+ * a device tree property
+ *
+ * @args: Pointer to device tree phandle arguments of the pin control reference
+ * @data: Pointer to data given at pinctrl_register_provider() call
+ * @out_pinconf: Output pin configuration reference upon success
+ */
+typedef TEE_Result (*pinctrl_dt_get_func)(struct dt_pargs *pargs, void *data,
+					  struct pinconf **out_pinconf);
 
 #ifdef CFG_DRIVERS_PINCTRL
 /**
@@ -62,14 +70,14 @@ typedef struct pinconf *(*pinctrl_dt_get_func)(struct dt_pargs *pargs,
  * @data: Data which will be passed to the get_pinctrl callback
  * Return a TEE_Result compliant value
  */
-static inline
-TEE_Result pinctrl_register_provider(const void *fdt, int nodeoffset,
-				     pinctrl_dt_get_func get_pinctrl,
-				     void *data)
+static inline TEE_Result pinctrl_register_provider(const void *fdt,
+						   int nodeoffset,
+						   pinctrl_dt_get_func func,
+						   void *data)
 {
 	return dt_driver_register_provider(fdt, nodeoffset,
-					   (get_of_device_func)get_pinctrl,
-					   data, DT_DRIVER_PINCTRL);
+					   (get_of_device_func)func, data,
+					   DT_DRIVER_PINCTRL);
 }
 
 /**
@@ -125,11 +133,9 @@ TEE_Result pinctrl_apply_state(struct pinctrl_state *state);
 TEE_Result pinctrl_parse_dt_pin_modes(const void *fdt, int nodeoffset,
 				      bitstr_t **modes);
 #else /* CFG_DRIVERS_PINCTRL */
-static inline
-TEE_Result pinctrl_register_provider(const void *fdt __unused,
-				     int nodeoffset __unused,
-				     pinctrl_dt_get_func get_pinctrl __unused,
-				     void *data __unused)
+static inline TEE_Result
+pinctrl_register_provider(const void *fdt __unused, int nodeoffset __unused,
+			  get_of_device_func func __unused, void *data __unused)
 {
 	return TEE_ERROR_NOT_SUPPORTED;
 }

--- a/core/include/drivers/pinctrl.h
+++ b/core/include/drivers/pinctrl.h
@@ -140,39 +140,34 @@ pinctrl_register_provider(const void *fdt __unused, int nodeoffset __unused,
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-static inline
-TEE_Result pinctrl_get_state_by_name(const void *fdt __unused,
-				     int nodeoffset __unused,
-				     const char *name __unused,
-				     struct pinctrl_state **state __unused)
+static inline TEE_Result
+pinctrl_get_state_by_name(const void *fdt __unused, int nodeoffset __unused,
+			  const char *name __unused,
+			  struct pinctrl_state **state __unused)
 {
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-static inline
-TEE_Result pinctrl_get_state_by_idx(const void *fdt __unused,
-				    int nodeoffset __unused,
-				    unsigned int pinctrl_id __unused,
-				    struct pinctrl_state **state __unused)
+static inline TEE_Result
+pinctrl_get_state_by_idx(const void *fdt __unused, int nodeoffset __unused,
+			 unsigned int pinctrl_id __unused,
+			 struct pinctrl_state **state __unused)
 {
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-static inline
-void pinctrl_free_state(struct pinctrl_state *state __unused)
+static inline void pinctrl_free_state(struct pinctrl_state *state __unused)
 {
 }
 
-static inline
-TEE_Result pinctrl_apply_state(struct pinctrl_state *state __unused)
+static inline TEE_Result pinctrl_apply_state(struct pinctrl_state *s __unused)
 {
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 
-static inline
-TEE_Result pinctrl_parse_dt_pin_modes(const void *fdt __unused,
-				      int nodeoffset __unused,
-				      bitstr_t **modes __unused)
+static inline TEE_Result pinctrl_parse_dt_pin_modes(const void *fdt __unused,
+						    int nodeoffset __unused,
+						    bitstr_t **modes __unused)
 {
 	return TEE_ERROR_NOT_SUPPORTED;
 }

--- a/core/include/drivers/rstctrl.h
+++ b/core/include/drivers/rstctrl.h
@@ -158,22 +158,25 @@ static inline bool rstctrl_ops_is_valid(const struct rstctrl_ops *ops)
 static inline TEE_Result rstctrl_dt_get_by_index(const void *fdt,
 						 int nodeoffset,
 						 unsigned int index,
-						 struct rstctrl **rstctrl)
+						 struct rstctrl **out_rstctrl)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+	void *rstctrl = NULL;
 
-	*rstctrl = dt_driver_device_from_node_idx_prop("resets", fdt,
-						       nodeoffset, index,
-						       DT_DRIVER_RSTCTRL, &res);
+	res = dt_driver_device_from_node_idx_prop("resets", fdt, nodeoffset,
+						  index, DT_DRIVER_RSTCTRL,
+						  &rstctrl);
+	if (!res)
+		*out_rstctrl = rstctrl;
+
 	return res;
 }
 #else
 static inline TEE_Result rstctrl_dt_get_by_index(const void *fdt __unused,
 						 int nodeoffset __unused,
 						 unsigned int index __unused,
-						 struct rstctrl **rstctrl)
+						 struct rstctrl **ctrl __unused)
 {
-	*rstctrl = NULL;
 	return TEE_ERROR_NOT_SUPPORTED;
 }
 #endif /*CFG_DT*/
@@ -201,35 +204,28 @@ TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
  *
  * @args: Pointer to devicetree description of the reset controller to parse
  * @data: Pointer to data given at rstctrl_dt_register_provider() call
- * @res: Output result code of the operation:
- *	TEE_SUCCESS in case of success
- *	TEE_ERROR_DEFER_DRIVER_INIT if reset controller is not initialized
- *	Any TEE_Result compliant code in case of error.
- *
- * Returns a struct rstctrl pointer pointing to a reset controller matching
- * the devicetree description or NULL if invalid description in which case
- * @res provides the error code.
+ * @rstctrl: Output reset controller reference upon success
  */
-typedef struct rstctrl *(*rstctrl_dt_get_func)(struct dt_pargs *args,
-					       void *data, TEE_Result *res);
+typedef TEE_Result (*rstctrl_dt_get_func)(struct dt_pargs *args, void *data,
+					  struct rstctrl **out_rstctrl);
 
 /**
  * rstctrl_dt_register_provider - Register a reset controller provider
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the reset controller
- * @get_dt_rstctrl: Callback to match the reset controller with a struct rstctrl
+ * @func: Callback to match the reset controller with a struct rstctrl
  * @data: Data which will be passed to the get_dt_rstctrl callback
  * Returns TEE_Result value
  */
-static inline
-TEE_Result rstctrl_register_provider(const void *fdt, int nodeoffset,
-				     rstctrl_dt_get_func get_dt_rstctrl,
-				     void *data)
+static inline TEE_Result rstctrl_register_provider(const void *fdt,
+						   int nodeoffset,
+						   rstctrl_dt_get_func func,
+						   void *data)
 {
 	return dt_driver_register_provider(fdt, nodeoffset,
-					   (get_of_device_func)get_dt_rstctrl,
-					   data, DT_DRIVER_RSTCTRL);
+					   (get_of_device_func)func, data,
+					   DT_DRIVER_RSTCTRL);
 }
 #endif /* __DRIVERS_RSTCTRL_H */
 

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -108,8 +108,8 @@ struct dt_pargs {
  * Return a device opaque reference, e.g. a struct clk pointer for a clock
  * driver, or NULL if not found in which case @res provides the error code.
  */
-typedef void *(*get_of_device_func)(struct dt_pargs *parg, void *data,
-				    TEE_Result *res);
+typedef TEE_Result (*get_of_device_func)(struct dt_pargs *parg, void *data,
+					 void **out_device);
 
 /**
  * dt_driver_register_provider - Register a driver provider
@@ -137,20 +137,21 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
  * @nodeoffset: node offset in the FDT
  * @prop_idx: index of the phandle data in the property
  * @type: Driver type
- * @res: Output result code of the operation:
- *	TEE_SUCCESS in case of success
- *	TEE_ERROR_DEFER_DRIVER_INIT if device driver is not yet initialized
- *	TEE_ERROR_ITEM_NOT_FOUND if prop_name does not match a property's name
- *	Any TEE_Result compliant code in case of error.
- *
- * Return a device opaque reference, e.g. a struct clk pointer for a clock
- * driver, or NULL if not found in which case @res provides the error code.
+ * @out_device: output device opaque reference upon support, for example
+ *	a struct clk pointer for a clock driver.
+
+ * Return code:
+ * TEE_SUCCESS in case of success,
+ * TEE_ERROR_DEFER_DRIVER_INIT if device driver is not yet initialized
+ * TEE_ERROR_ITEM_NOT_FOUND if @prop_name does not match a property's name
+ *	or @prop_idx does not match any index in @prop_name phandle list
+ * Any TEE_Result compliant code in case of error.
  */
-void *dt_driver_device_from_node_idx_prop(const char *prop_name,
-					  const void *fdt, int nodeoffset,
-					  unsigned int prop_idx,
-					  enum dt_driver_type type,
-					  TEE_Result *res);
+TEE_Result dt_driver_device_from_node_idx_prop(const char *prop_name,
+					       const void *fdt, int nodeoffset,
+					       unsigned int prop_idx,
+					       enum dt_driver_type type,
+					       void **out_device);
 
 /*
  * dt_driver_device_from_parent - Return a device instance based on the parent.
@@ -160,16 +161,17 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
  * @fdt: FDT base address
  * @nodeoffset: node offset in the FDT
  * @type: Driver type
- * @res: Output result code of the operation:
- *	TEE_SUCCESS in case of success
- *	TEE_ERROR_DEFER_DRIVER_INIT if device driver is not yet initialized
- *	Any TEE_Result compliant code in case of error.
+ * @dout_device: output device opaque reference upon success, for example
+ *	a struct i2c_dev pointer for a I2C bus driver
  *
- * Return a device opaque reference, e.g. a struct i2c_dev pointer for a I2C bus
- * driver, or NULL if not found in which case @res provides the error code.
+ * Return code:
+ * TEE_SUCCESS in case of success,
+ * TEE_ERROR_DEFER_DRIVER_INIT if device driver is not yet initialized
+ * Any TEE_Result compliant code in case of error.
  */
-void *dt_driver_device_from_parent(const void *fdt, int nodeoffset,
-				   enum dt_driver_type type, TEE_Result *res);
+TEE_Result dt_driver_device_from_parent(const void *fdt, int nodeoffset,
+					enum dt_driver_type type,
+					void **out_device);
 
 /*
  * dt_driver_device_from_node_idx_prop_phandle() - Same as
@@ -180,12 +182,13 @@ void *dt_driver_device_from_parent(const void *fdt, int nodeoffset,
  * property carries the interrupt information but not the interrupt controller
  * phandle which is found in a specific property (here "interrupt-parent").
  */
-void *dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
-						  const void *fdt, int nodeoffs,
-						  unsigned int prop_index,
-						  enum dt_driver_type type,
-						  uint32_t phandle,
-						  TEE_Result *res);
+TEE_Result dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
+						       const void *fdt,
+						       int nodeoffs,
+						       unsigned int prop_index,
+						       enum dt_driver_type type,
+						       uint32_t phandle,
+						       void **out_device);
 
 /*
  * dt_driver_get_crypto() - Request crypto support for driver initialization


### PR DESCRIPTION
Changes dt_driver callback function to return a `TEE_Result` value and pass retrieved device reference by a output argument rather than the opposite.

This change updates _dt_driver.c_, _dt_driver.h_, _dt_driver_test.c_ and all drivers implementing related dt_driver callback functions.

As a consequence, this change removes all type definition related to device specific callback handler function types which are useless as all these now comply with type `dt_driver_probe_func` defined in _dt_driver.h_.

This P-R is related to discussion thread https://github.com/OP-TEE/optee_os/pull/5954#discussion_r1211837322.