### PR TITLE
core: riscv: Fix misuse of cppflags

### DIFF
--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -79,11 +79,11 @@ rv64-platform-abi ?= lp64d
 rv32-platform-isa ?= rv32imafd
 rv32-platform-abi ?= ilp32d
 
-rv64-platform-cppflags += -mcmodel=$(riscv-platform-mcmodel)
-rv64-platform-cppflags += -march=$(rv64-platform-isa) -mabi=$(rv64-platform-abi)
-rv64-platform-cppflags += -Wno-missing-include-dirs
-rv32-platform-cppflags += -mcmodel=$(riscv-platform-mcmodel)
-rv32-platform-cppflags += -march=$(rv32-platform-isa) -mabi=$(rv32-platform-abi)
+rv64-platform-cflags += -mcmodel=$(riscv-platform-mcmodel)
+rv64-platform-cflags += -march=$(rv64-platform-isa) -mabi=$(rv64-platform-abi)
+rv64-platform-cflags += -Wno-missing-include-dirs
+rv32-platform-cflags += -mcmodel=$(riscv-platform-mcmodel)
+rv32-platform-cflags += -march=$(rv32-platform-isa) -mabi=$(rv32-platform-abi)
 
 rv64-platform-cppflags += -DRV64=1 -D__LP64__=1
 rv32-platform-cppflags += -DRV32=1 -D__ILP32__=1


### PR DESCRIPTION
The -mxxx and -Wxxx are not preprocessor flags. Fix it by defining them as C flags.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
