### PR TITLE
mk/aosp_optee.mk: fix build dependency for static libraries

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -112,6 +112,7 @@ else
 LOCAL_MODULE_CLASS := STATIC_LIBRARIES
 endif
 LOCAL_MODULE_TAGS := optional
+LOCAL_REQUIRED_MODULES := $(local_module_deps)
 
 TA_TMP_DIR := $(subst /,_,$(LOCAL_PATH))
 TA_TMP_FILE := $(OPTEE_TA_OUT_DIR)/$(TA_TMP_DIR)/$(LOCAL_MODULE)
@@ -119,11 +120,6 @@ $(LOCAL_PREBUILT_MODULE_FILE): $(TA_TMP_FILE)
 	@mkdir -p $(dir $@)
 	cp -vf $< $@
 
-TA_TMP_FILE_DEPS :=
-ifneq ($(local_module_deps), )
-$(foreach dep,$(local_module_deps), $(eval TA_TMP_FILE_DEPS += $(TARGET_OUT_VENDOR)/lib/optee_armtz/$(dep)))
-endif
-$(TA_TMP_FILE): $(TA_TMP_FILE_DEPS)
 $(TA_TMP_FILE): PRIVATE_TA_SRC_DIR := $(LOCAL_PATH)
 $(TA_TMP_FILE): PRIVATE_TA_TMP_FILE := $(TA_TMP_FILE)
 $(TA_TMP_FILE): PRIVATE_TA_TMP_DIR := $(TA_TMP_DIR)


### PR DESCRIPTION
After skipping installation for static libraries by commit  667213e21e8b ("mk: Support user static lib for aosp build").  The dependency set by $(local_module_deps) needs different file paths for static libraries. Use aosp macro to build the dependency with the intermediate file instead of installed file.

The dependency change also affects user TAs and shared libraries. Since installed location could be changed for some customization requirement, I think using the intermediate-dir should make it easier if we would like to change the `$(LOCAL_MODULE_PATH)` for TAs.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
