### PR TITLE
core: mm: Refine architecture specific translation level

### DIFF
--- a/core/arch/arm/include/mm/core_mmu_arch.h
+++ b/core/arch/arm/include/mm/core_mmu_arch.h
@@ -210,6 +210,17 @@ static inline unsigned int core_mmu_get_va_width(void)
 	}
 	return 32;
 }
+
+static inline bool core_mmu_level_in_range(unsigned int level)
+{
+#if CORE_MMU_BASE_TABLE_LEVEL == 0
+	return level <= CORE_MMU_PGDIR_LEVEL;
+#else
+	return level >= CORE_MMU_BASE_TABLE_LEVEL &&
+	       level <= CORE_MMU_PGDIR_LEVEL;
+#endif
+}
+
 #endif /*__ASSEMBLER__*/
 
 #endif /* CORE_MMU_H */

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -948,6 +948,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 		unsigned level, vaddr_t va_base, void *table)
 {
 	tbl_info->level = level;
+	tbl_info->next_level = level + 1;
 	tbl_info->table = table;
 	tbl_info->va_base = va_base;
 	tbl_info->shift = XLAT_ADDR_SHIFT(level);
@@ -1028,6 +1029,7 @@ bool core_mmu_find_table(struct mmu_partition *prtn, vaddr_t va,
 			tbl_info->table = tbl;
 			tbl_info->va_base = va_base;
 			tbl_info->level = level;
+			tbl_info->next_level = level + 1;
 			tbl_info->shift = level_size_shift;
 			tbl_info->num_entries = num_entries;
 #ifdef CFG_NS_VIRTUALIZATION

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -485,6 +485,7 @@ void core_mmu_set_info_table(struct core_mmu_table_info *tbl_info,
 		unsigned level, vaddr_t va_base, void *table)
 {
 	tbl_info->level = level;
+	tbl_info->next_level = level + 1;
 	tbl_info->table = table;
 	tbl_info->va_base = va_base;
 	assert(level <= 2);

--- a/core/arch/riscv/include/mm/core_mmu_arch.h
+++ b/core/arch/riscv/include/mm/core_mmu_arch.h
@@ -128,6 +128,11 @@ static inline unsigned int core_mmu_get_va_width(void)
 {
 	return RISCV_MMU_VA_WIDTH;
 }
+
+static inline bool core_mmu_level_in_range(unsigned int level)
+{
+	return level <= CORE_MMU_BASE_TABLE_LEVEL;
+}
 #endif /*__ASSEMBLER__*/
 
 #endif /* __CORE_MMU_ARCH_H */

--- a/core/include/mm/core_mmu.h
+++ b/core/include/mm/core_mmu.h
@@ -381,12 +381,12 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map);
 struct core_mmu_table_info {
 	void *table;
 	vaddr_t va_base;
-	unsigned level;
-	unsigned shift;
 	unsigned num_entries;
 #ifdef CFG_NS_VIRTUALIZATION
 	struct mmu_partition *prtn;
 #endif
+	uint8_t level;
+	uint8_t shift;
 };
 
 /*

--- a/core/include/mm/core_mmu.h
+++ b/core/include/mm/core_mmu.h
@@ -375,6 +375,7 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map);
  * @table:	Pointer to translation table
  * @va_base:	VA base address of the transaltion table
  * @level:	Translation table level
+ * @next_level:	Finer grained translation table level according to @level.
  * @shift:	The shift of each entry in the table
  * @num_entries: Number of entries in this table.
  */
@@ -387,6 +388,7 @@ struct core_mmu_table_info {
 #endif
 	uint8_t level;
 	uint8_t shift;
+	uint8_t next_level;
 };
 
 /*

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1764,7 +1764,7 @@ void core_mmu_map_region(struct mmu_partition *prtn, struct tee_mmap_region *mm)
 		while (true) {
 			paddr_t block_size = 0;
 
-			assert(level <= CORE_MMU_PGDIR_LEVEL);
+			assert(core_mmu_level_in_range(level));
 
 			table_found = core_mmu_find_table(prtn, vaddr, level,
 							  &tbl_info);

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1786,7 +1786,7 @@ void core_mmu_map_region(struct mmu_partition *prtn, struct tee_mmap_region *mm)
 								     idx,
 								     secure))
 					panic("Can't divide MMU entry");
-				level++;
+				level = tbl_info.next_level;
 				continue;
 			}
 
@@ -1999,7 +1999,7 @@ void core_mmu_populate_user_map(struct core_mmu_table_info *dir_info,
 	pgt_get_all(uctx);
 	pgt = SLIST_FIRST(pgt_cache);
 
-	core_mmu_set_info_table(&pg_info, dir_info->level + 1, 0, NULL);
+	core_mmu_set_info_table(&pg_info, dir_info->next_level, 0, NULL);
 
 	TAILQ_FOREACH(r, &uctx->vm_info.regions, link)
 		set_pg_region(dir_info, r, &pgt, &pg_info);


### PR DESCRIPTION
This PR is initiated from the discussion in https://github.com/OP-TEE/optee_os/issues/5725

To decouple the architecture specific address translation rule from core mm.
The `next_level` filed is added in the `struct core_mmu_table_info` to represent the next finer grained level.

Some ARM is also modified based on this change.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
