### PR TITLE
Stm32mp1 bsec

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -516,6 +516,7 @@ TEE_Result stm32_get_iwdg_otp_config(paddr_t pbase,
 	unsigned int idx = 0;
 	uint32_t otp_id = 0;
 	size_t bit_len = 0;
+	uint8_t bit_offset = 0;
 	uint32_t otp_value = 0;
 
 	switch (pbase) {
@@ -529,8 +530,9 @@ TEE_Result stm32_get_iwdg_otp_config(paddr_t pbase,
 		panic();
 	}
 
-	if (stm32_bsec_find_otp_in_nvmem_layout("hw2_otp", &otp_id, &bit_len) ||
-	    bit_len != 32)
+	if (stm32_bsec_find_otp_in_nvmem_layout("hw2_otp", &otp_id, &bit_offset,
+						&bit_len) ||
+	    bit_len != 32 || bit_offset != 0)
 		panic();
 
 	if (stm32_bsec_read_otp(&otp_value, otp_id))

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -401,7 +401,6 @@ out:
 
 	return result;
 }
-#endif /*CFG_STM32_BSEC_WRITE*/
 
 TEE_Result stm32_bsec_permanent_lock_otp(uint32_t otp_id)
 {
@@ -476,6 +475,7 @@ out:
 
 	return result;
 }
+#endif /*CFG_STM32_BSEC_WRITE*/
 
 TEE_Result stm32_bsec_write_debug_conf(uint32_t value)
 {

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -634,7 +634,7 @@ TEE_Result stm32_bsec_find_otp_in_nvmem_layout(const char *name,
 	DMSG("nvmem %s failed", name);
 
 	return TEE_ERROR_ITEM_NOT_FOUND;
-};
+}
 
 TEE_Result stm32_bsec_get_state(enum stm32_bsec_sec_state *state)
 {

--- a/core/drivers/stm32mp15_huk.c
+++ b/core/drivers/stm32mp15_huk.c
@@ -25,11 +25,14 @@ static TEE_Result stm32mp15_read_uid(uint32_t *uid)
 	uint32_t *q = uid;
 	uint32_t otp_idx = 0;
 	size_t __maybe_unused sz = 0;
+	uint8_t __maybe_unused offset = 0;
 
-	ret = stm32_bsec_find_otp_in_nvmem_layout("uid_otp", &otp_idx, &sz);
+	ret = stm32_bsec_find_otp_in_nvmem_layout("uid_otp", &otp_idx, &offset,
+						  &sz);
 	if (ret)
 		return ret;
 	assert(sz == 3 * 32);
+	assert(offset == 0);
 
 	/*
 	 * Shadow memory for UID words might not be locked: to guarante that
@@ -128,14 +131,16 @@ static __maybe_unused TEE_Result pos_from_dt(uint32_t otp_id[HUK_NB_OTP])
 {
 	TEE_Result ret = TEE_SUCCESS;
 	uint32_t otp_start = 0;
-	size_t tmp = 0;
+	size_t sz = 0;
+	uint8_t offset = 0;
 	size_t i = 0;
 
-	ret = stm32_bsec_find_otp_in_nvmem_layout("huk-otp", &otp_start, &tmp);
+	ret = stm32_bsec_find_otp_in_nvmem_layout("huk-otp", &otp_start,
+						  &offset, &sz);
 	if (ret)
 		return ret;
 
-	if (tmp != (HW_UNIQUE_KEY_LENGTH * CHAR_BIT))
+	if (sz != (HW_UNIQUE_KEY_LENGTH * CHAR_BIT) || offset != 0)
 		return TEE_ERROR_SECURITY;
 
 	for (i = 0; i < HUK_NB_OTP; i++)

--- a/core/include/drivers/stm32_bsec.h
+++ b/core/include/drivers/stm32_bsec.h
@@ -82,7 +82,14 @@ static inline TEE_Result stm32_bsec_program_otp(uint32_t value __unused,
  * @otp_id: OTP number
  * Return a TEE_Result compliant return value
  */
+#ifdef CFG_STM32_BSEC_WRITE
 TEE_Result stm32_bsec_permanent_lock_otp(uint32_t otp_id);
+#else
+static inline TEE_Result stm32_bsec_permanent_lock_otp(uint32_t otp_id __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif
 
 /*
  * Enable/disable debug service

--- a/core/include/drivers/stm32_bsec.h
+++ b/core/include/drivers/stm32_bsec.h
@@ -170,11 +170,13 @@ bool stm32_bsec_nsec_can_access_otp(uint32_t otp_id);
  * Find and get OTP location from its name.
  * @name: sub-node name to look up.
  * @otp_id: pointer to output OTP number or NULL.
+ * @otp_bit_offset: pointer to output OTP bit offset in the NVMEM cell or NULL.
  * @otp_bit_len: pointer to output OTP length in bits or NULL.
  * Return a TEE_Result compliant status
  */
 TEE_Result stm32_bsec_find_otp_in_nvmem_layout(const char *name,
 					       uint32_t *otp_id,
+					       uint8_t *otp_bit_offset,
 					       size_t *otp_bit_len);
 
 /*

--- a/core/include/drivers/stm32_bsec.h
+++ b/core/include/drivers/stm32_bsec.h
@@ -180,6 +180,19 @@ TEE_Result stm32_bsec_find_otp_in_nvmem_layout(const char *name,
 					       size_t *otp_bit_len);
 
 /*
+ * Find and get OTP location from its phandle.
+ * @phandle: node phandle to look up.
+ * @otp_id: pointer to read OTP number or NULL.
+ * @otp_bit_offset: pointer to read offset in OTP in bits or NULL.
+ * @otp_bit_len: pointer to read OTP length in bits or NULL.
+ * Return a TEE_Result compliant status
+ */
+TEE_Result stm32_bsec_find_otp_by_phandle(const uint32_t phandle,
+					  uint32_t *otp_id,
+					  uint8_t *otp_bit_offset,
+					  size_t *otp_bit_len);
+
+/*
  * Get BSEC global sec state.
  * @sec_state: Global BSEC current sec state
  * Return a TEE_Result compliant status


### PR DESCRIPTION
Some updates in the BSEC driver used to OTPs access on STM32MP13x and STM32MP15x SoC family,
based on STMicroelectronics patches present in https://github.com/STMicroelectronics/optee_os.

The OTP descriptions are based on NVMEM cell binding.

The addition of the API "get otp by phandle()" is a preliminary steps for next series.

