### PR TITLE
plat-k3: drivers: add TISCI calls to retrieve OTP values that configure secure boot

### DIFF
--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -454,6 +454,28 @@ int ti_sci_get_swrev(uint32_t *swrev)
 	return 0;
 }
 
+int ti_sci_get_keycnt_keyrev(uint32_t *key_cnt, uint32_t *key_rev)
+{
+	struct ti_sci_msq_req_get_keycnt_keyrev req = { };
+	struct ti_sci_msq_resp_get_keycnt_keyrev resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret = 0;
+
+	ret = ti_sci_setup_xfer(TI_SCI_MSG_READ_KEYCNT_KEYREV, 0,
+				&req, sizeof(req), &resp, sizeof(resp), &xfer);
+	if (ret)
+		return ret;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		return ret;
+
+	*key_cnt = resp.keycnt;
+	*key_rev = resp.keyrev;
+	memzero_explicit(&resp, sizeof(resp));
+	return 0;
+}
+
 int ti_sci_init(void)
 {
 	struct ti_sci_msg_resp_version rev_info = { };

--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -431,6 +431,29 @@ int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
 	return 0;
 }
 
+int ti_sci_get_swrev(uint32_t *swrev)
+{
+	struct ti_sci_msq_req_get_swrev req = { };
+	struct ti_sci_msq_resp_get_swrev resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret = 0;
+
+	ret = ti_sci_setup_xfer(TI_SCI_MSG_READ_SWREV, 0,
+				&req, sizeof(req), &resp, sizeof(resp), &xfer);
+	if (ret)
+		return ret;
+
+	req.identifier = OTP_REV_ID_SEC_BRDCFG;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		return ret;
+
+	*swrev = resp.swrev;
+	memzero_explicit(&resp, sizeof(resp));
+	return 0;
+}
+
 int ti_sci_init(void)
 {
 	struct ti_sci_msg_resp_version rev_info = { };

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -162,6 +162,17 @@ int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
 			uint8_t hw_read_lock, uint8_t row_soft_lock);
 
 /**
+ * ti_sci_get_swrev - Read Software Revision
+ * @swrev:	Software Revision
+ *
+ * Reads the software revision. The System Firmware currently supports reading
+ * only the software revision from the Secure Board Configuration.
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_swrev(uint32_t *swrev);
+
+/**
  * ti_sci_init() - Basic initialization
  *
  * Return: 0 if all goes well, else appropriate error message

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -173,6 +173,17 @@ int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
 int ti_sci_get_swrev(uint32_t *swrev);
 
 /**
+ * ti_sci_get_keycnt_keyrev - Read Key Count and Key Revision values
+ * @key_cnt:	Key Count
+ * @key_rev:	Key Revision
+ *
+ * Reads the Key Count and Key Revision in OTP
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_get_keycnt_keyrev(uint32_t *key_cnt, uint32_t *key_rev);
+
+/**
  * ti_sci_init() - Basic initialization
  *
  * Return: 0 if all goes well, else appropriate error message

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -385,4 +385,43 @@ struct ti_sci_msg_resp_lock_otp_row {
 	struct ti_sci_msg_hdr hdr;
 } __packed;
 
+/**
+ * \brief OTP Revision Identifiers
+ */
+enum tisci_otp_revision_identifier {
+	/** Software Revision SBL */
+	OTP_REV_ID_SBL        = 0,
+	/** Software Revision SYSFW */
+	OTP_REV_ID_SYSFW      = 1,
+	/** Software Revision Secure Board Configuration */
+	OTP_REV_ID_SEC_BRDCFG = 2,
+};
+
+/**
+ * struct ti_sci_msq_req_get_swrev - Request for reading the Software Revision
+ * in OTP
+ * @hdr:	Generic header
+ * @identifier: One of the entries from enum tisci_otp_revision_identifier
+ *		(Current support only for OTP_REV_ID_SEC_BRDCFG)
+ *
+ * Request for TI_SCI_MSG_READ_SWREV
+ */
+struct ti_sci_msq_req_get_swrev {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t identifier;
+} __packed;
+
+/**
+ * struct ti_sci_msq_req_get_swrev - Response for reading the Software Revision
+ * in OTP
+ * @hdr:	Generic header
+ * @swrev:	Decoded Sofrware Revision value from efuses
+ *
+ * Response for TI_SCI_MSG_READ_SWREV
+ */
+struct ti_sci_msq_resp_get_swrev {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t swrev;
+} __packed;
+
 #endif

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -27,6 +27,12 @@
 #define TI_SCI_MSG_WRITE_OTP_ROW         0x9023
 #define TI_SCI_MSG_LOCK_OTP_ROW          0x9024
 
+/* OTP Revision Read/Write Message Description */
+#define TI_SCI_MSG_WRITE_SWREV           0x9032
+#define TI_SCI_MSG_READ_SWREV            0x9033
+#define TI_SCI_MSG_READ_KEYCNT_KEYREV    0x9034
+#define TI_SCI_MSG_WRITE_KEYREV          0x9035
+
 /**
  * struct ti_sci_secure_msg_hdr - Secure Message Header for All messages
  *				 and responses

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -424,4 +424,29 @@ struct ti_sci_msq_resp_get_swrev {
 	uint32_t swrev;
 } __packed;
 
+/**
+ * struct ti_sci_msq_req_get_keycnt_keyrev - Request for reading the Key Count
+ * and Key Revision in OTP
+ * @hdr:	Generic header
+ *
+ * Request for TI_SCI_MSG_READ_KEYCNT_KEYREV
+ */
+struct ti_sci_msq_req_get_keycnt_keyrev {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
+ * struct ti_sci_msq_req_get_swrev - Response for reading the Key Count and Key
+ * Revision in OTP
+ * @hdr:	Generic header
+ * @keycnt:	Key Count integer value
+ * @keyrev:	Key Revision integer value
+ *
+ * Response for TI_SCI_MSG_READ_SWREV
+ */
+struct ti_sci_msq_resp_get_keycnt_keyrev {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t keycnt;
+	uint32_t keyrev;
+} __packed;
 #endif

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -4,8 +4,6 @@
  *	Andrew F. Davis <afd@ti.com>
  */
 
-#include <platform_config.h>
-
 #include <console.h>
 #include <drivers/gic.h>
 #include <drivers/sec_proxy.h>
@@ -65,6 +63,7 @@ static TEE_Result init_ti_sci(void)
 
 	return TEE_SUCCESS;
 }
+
 service_init(init_ti_sci);
 
 static TEE_Result secure_boot_information(void)

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -67,6 +67,19 @@ static TEE_Result init_ti_sci(void)
 }
 service_init(init_ti_sci);
 
+static TEE_Result secure_boot_information(void)
+{
+	uint32_t swrev = 0;
+
+	if (!ti_sci_get_swrev(&swrev))
+		IMSG("Secure Board Configuration Software: Rev %"PRIu32,
+		     swrev);
+
+	return TEE_SUCCESS;
+}
+
+service_init_late(secure_boot_information);
+
 TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	uint8_t dkek[SA2UL_DKEK_KEY_LEN] = { };

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -68,11 +68,17 @@ service_init(init_ti_sci);
 
 static TEE_Result secure_boot_information(void)
 {
+	uint32_t keycnt = 0;
+	uint32_t keyrev = 0;
 	uint32_t swrev = 0;
 
 	if (!ti_sci_get_swrev(&swrev))
 		IMSG("Secure Board Configuration Software: Rev %"PRIu32,
 		     swrev);
+
+	if (!ti_sci_get_keycnt_keyrev(&keycnt, &keyrev))
+		IMSG("Secure Boot Keys: Count %"PRIu32 ", Rev %"PRIu32,
+		     keycnt, keyrev);
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Add requests to read OTP values used during secure boot
 - SWREV: Secure Board Configuration revision
 - KEY Count, Key Revision : the number of keys (max = 2), active key

Messages are documented below:
https://software-dl.ti.com/tisci/esd/latest/2_tisci_msgs/security/otp_revision.html#sec-api-rd-swrev-otp

Code tested on TI am62b HS and am62b HS-FS

Below console output on a secured board (ROM verified boot) where only one key (SMPK hash) was fused.

```
NOTICE:  BL31: v2.7(release):v2.7.0-359-g1309c6c80                                                                                                                                                                                                                                                                                                                                                                              
NOTICE:  BL31: Built : 11:43:54, Jun 14 2023                                                                                                                                                                                                                                                                                                                                                                                    
I/TC:                                                                                                                                                                                                                                                                                                                                                                                                                           
I/TC: OP-TEE version: 3.21.0-210-g66f61f4ff (gcc version 11.3.0 (Ubuntu 11.3.0-1ubuntu1~22.04.1)) #1 Wed Jun 14 09:44:05 UTC 2023 aarch64                                                                                                                                                                                                                                                                                       
I/TC: WARNING: This OP-TEE configuration might be insecure!                                                                                                                                                                                                                                                                                                                                                                     
I/TC: WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html                                                                                                                                                                                                                                                                                                                         
I/TC: Primary CPU initializing                                                                                                                                                                                                                                                                                                                                                                                                  
I/TC: SYSFW ABI: 3.1 (firmware rev 0x0008 '8.6.4--v08.06.04 (Chill Capybar')                                                                                                                                                                                                                                                                                                                                                    
I/TC: Secure Board Configuration Software: Rev 1                                                                                                                                                                                                                                                                                                                                                                             
I/TC: Secure Boot Keys: Count 1, Rev 1                                                                                                                                                                                                                                                                                                                                                                                          
I/TC: HUK Initialized                                                                                                                                                                                                                                                                                                                                                                                                           
I/TC: Activated SA2UL device                                                                                                                                                                                                                                                                                                                                                                                                    
I/TC: Enabled firewalls for SA2UL TRNG device                                                                                                                                                                                                                                                                                                                                                                                   
I/TC: SA2UL TRNG initialized                                                                                                                                                                                                                                                                                                                                                                                                    
I/TC: SA2UL Drivers initialized                                                                                                                                                                                                                                                                                                                                                                                                 
I/TC: Primary CPU switching to normal world boot 
```

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
