### PR TITLE
Bounce buffers for syscall processing

### DIFF
--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -271,6 +271,8 @@
 #define ID_AA64ISAR1_APA_ARCH_EPAC2_FPAC	U(0x4)
 #define ID_AA64ISAR1_APA_ARCH_EPAC2_FPAC_CMB	U(0x5)
 
+#define ID_MMFR3_EL1_PAN_SHIFT			U(16)
+
 #define GCR_EL1_RRND				BIT64(16)
 
 #ifndef __ASSEMBLER__
@@ -460,6 +462,21 @@ DEFINE_REG_WRITE_FUNC_(icc_eoir0, uint32_t, S3_0_c12_c8_1)
 DEFINE_REG_WRITE_FUNC_(icc_eoir1, uint32_t, S3_0_c12_c12_1)
 DEFINE_REG_WRITE_FUNC_(icc_igrpen0, uint32_t, S3_0_C12_C12_6)
 DEFINE_REG_WRITE_FUNC_(icc_igrpen1, uint32_t, S3_0_C12_C12_7)
+
+DEFINE_REG_WRITE_FUNC_(pan, uint64_t, S3_0_c4_c2_3)
+
+static inline void write_pan_enable(void)
+{
+	/* msr pan, #1 */
+	asm volatile("msr	S0_0_c4_c1_4, xzr" ::: "memory" );
+}
+
+static inline void write_pan_disable(void)
+{
+	/* msr pan, #0 */
+	asm volatile("msr	S0_0_c4_c0_4, xzr" ::: "memory" );
+}
+
 #endif /*__ASSEMBLER__*/
 
 #endif /*ARM64_H*/

--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -148,3 +148,18 @@
 	.macro write_apiakeyhi reg
 	msr	S3_0_c2_c1_1, \reg
 	.endm
+
+	.macro write_pan reg
+	/* msr pan, \reg */
+	msr	S3_0_c4_c2_3, \reg
+	.endm
+
+	.macro write_pan_enable
+	/* msr pan, #1 */
+	msr	S0_0_c4_c1_4, xzr
+	.endm
+
+	.macro write_pan_disable
+	/* msr pan, #0 */
+	msr	S0_0_c4_c0_4, xzr
+	.endm

--- a/core/arch/arm/include/kernel/user_access_arch.h
+++ b/core/arch/arm/include/kernel/user_access_arch.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023, Amazon.com Inc. or its affiliates. All rights Reserved.
+ */
+
+#ifndef __KERNEL_USER_ACCESS_ARCH_H
+#define __KERNEL_USER_ACCESS_ARCH_H
+
+#include <arm.h>
+
+#ifdef CFG_PAN
+/* Enter a section where user mode access is temporarily enabled. */
+static inline void enter_user_access(void)
+{
+	write_pan_disable();
+}
+
+/* Exit from the section where user mode access was temporarily enabled. */
+static inline void exit_user_access(void)
+{
+	write_pan_enable();
+}
+#else
+static inline void enter_user_access(void) {}
+static inline void exit_user_access(void) {}
+#endif /* CFG_PAN */
+
+#endif /* __KERNEL_USER_ACCESS_ARCH_H */

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -51,6 +51,11 @@
 		ubfx	\reg, \reg, #ID_AA64PFR1_EL1_MTE_SHIFT, #4
 	.endm
 
+	.macro read_feat_pan reg
+		mrs	\reg, id_mmfr3_el1
+		ubfx	\reg, \reg, #ID_MMFR3_EL1_PAN_SHIFT, #4
+	.endm
+
 	.macro set_sctlr_el1
 		mrs	x0, sctlr_el1
 		orr	x0, x0, #SCTLR_I
@@ -143,6 +148,17 @@
 		isb
 	.endm
 
+	.macro init_pan
+		read_feat_pan x0
+		cmp	x0, #0
+		b.eq	1f
+		mrs	x0, sctlr_el1
+		bic	x0, x0, #SCTLR_SPAN
+		msr	sctlr_el1, x0
+		write_pan_enable
+	1:
+	.endm
+
 FUNC _start , :
 	/*
 	 * Register use:
@@ -172,6 +188,10 @@ FUNC _start , :
 	adr	x0, reset_vect_table
 	msr	vbar_el1, x0
 	isb
+
+#ifdef CFG_PAN
+	init_pan
+#endif
 
 	set_sctlr_el1
 	isb
@@ -598,6 +618,10 @@ FUNC cpu_on_handler , :
 
 	set_sctlr_el1
 	isb
+
+#ifdef CFG_PAN
+	init_pan
+#endif
 
 	/* Enable aborts now that we can receive exceptions */
 	msr	daifclr, #DAIFBIT_ABT

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -23,6 +23,7 @@
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <kernel/thread_private.h>
+#include <kernel/user_access.h>
 #include <kernel/user_mode_ctx_struct.h>
 #include <kernel/virtualization.h>
 #include <mm/core_memprot.h>
@@ -1102,6 +1103,8 @@ void __weak thread_scall_handler(struct thread_scall_regs *regs)
 	struct ts_session *sess = NULL;
 	uint32_t state = 0;
 
+	enter_user_access();
+
 	/* Enable native interrupts */
 	state = thread_get_exceptions();
 	thread_unmask_exceptions(state & ~THREAD_EXCP_NATIVE_INTR);
@@ -1126,6 +1129,8 @@ void __weak thread_scall_handler(struct thread_scall_regs *regs)
 		/* We're returning from __thread_enter_user_mode() */
 		setup_unwind_user_mode(regs);
 	}
+
+	exit_user_access();
 }
 
 #ifdef CFG_WITH_ARM_TRUSTED_FW

--- a/core/arch/riscv/include/kernel/user_access_arch.h
+++ b/core/arch/riscv/include/kernel/user_access_arch.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023, Amazon.com Inc. or its affiliates. All rights Reserved.
+ */
+
+#ifndef __KERNEL_USER_ACCESS_ARCH_H
+#define __KERNEL_USER_ACCESS_ARCH_H
+
+/* Enter a section where user mode access is temporarily enabled. */
+static inline void enter_user_access(void) {}
+
+/* Exit from the section where user mode access was temporarily enabled. */
+static inline void exit_user_access(void) {}
+
+#endif /* __KERNEL_USER_ACCESS_ARCH_H */

--- a/core/include/kernel/ldelf_loader.h
+++ b/core/include/kernel/ldelf_loader.h
@@ -19,6 +19,6 @@ TEE_Result ldelf_dump_ftrace(struct user_mode_ctx *uctx,
 TEE_Result ldelf_dlopen(struct user_mode_ctx *uctx, TEE_UUID *uuid,
 			uint32_t flags);
 TEE_Result ldelf_dlsym(struct user_mode_ctx *uctx, TEE_UUID *uuid,
-		       const char *sym, size_t maxlen, vaddr_t *val);
+		       const char *sym, size_t symlen, vaddr_t *val);
 
 #endif /* KERNEL_LDELF_LOADER_H */

--- a/core/include/kernel/user_access.h
+++ b/core/include/kernel/user_access.h
@@ -7,6 +7,7 @@
 #define __KERNEL_USER_ACCESS_H
 
 #include <assert.h>
+#include <kernel/user_access_arch.h>
 #include <tee_api_types.h>
 #include <types_ext.h>
 

--- a/core/include/kernel/user_access.h
+++ b/core/include/kernel/user_access.h
@@ -95,6 +95,24 @@ TEE_Result bb_memdup_user(const void *src, size_t len, void **p);
  */
 TEE_Result bb_memdup_user_private(const void *src, size_t len, void **p);
 
+/*
+ * bb_strndup_user() - Duplicate a user-space string into a bounce buffer
+ * @src:    Pointer to the user string to be duplicated.
+ * @maxlen: Maximum length of the user string
+ * @dst:    Holds duplicated string on success, or unchanged on failure.
+ * @dstlen: Length of string, excluding the terminating zero, returned in
+ *          @dst.
+ *
+ * Note that the returned buffer is allocated by bb_alloc() and normally
+ * doesn't have to be freed. But if it is to be freed the supplied length
+ * to bb_free() should be dstlen + 1.
+ *
+ * Return TEE_SUCCESS on success.
+ * Return TEE_ERROR_OUT_OF_MEMORY or TEE_ERROR_ACCESS_DENIED on error.
+ */
+TEE_Result bb_strndup_user(const char *src, size_t maxlen, char **dst,
+			   size_t *dstlen);
+
 TEE_Result copy_kaddr_to_uref(uint32_t *uref, void *kaddr);
 
 uint32_t kaddr_to_uref(void *kaddr);

--- a/core/include/kernel/user_access.h
+++ b/core/include/kernel/user_access.h
@@ -31,6 +31,38 @@ static inline TEE_Result copy_from_user(void *kaddr __unused,
 
 #endif
 
+/*
+ * bb_alloc() - Allocate a bounce buffer
+ * @len:	Length of bounce buffer
+ *
+ * The bounce buffer is allocated from a per user TA context region reserved
+ * for bounce buffers. Buffers are allocated in a stack like fashion so
+ * only the last buffer can be free. Buffers generally don't have to be
+ * freed, all bounce buffer allocations are reset on each syscall entry.
+ *
+ * Return NULL on failure or a valid pointer on success.
+ */
+void *bb_alloc(size_t len);
+
+/*
+ * bb_free() - Free a bounce buffer
+ * @bb:		Buffer
+ * @len:	Length of buffer
+ *
+ * The bounce buffer is only freed if it is last on the stack of allocated
+ * bounce buffers. This function does normally not need to be called, see
+ * description of bb_alloc().
+ */
+void bb_free(void *bb, size_t len);
+
+/*
+ * bb_reset() - Reset bounce buffer allocation
+ *
+ * Resets the bounce buffer allocatation state, old pointers allocated
+ * with bb_alloc() should not be used any longer.
+ */
+void bb_reset(void);
+
 TEE_Result copy_to_user_private(void *uaddr, const void *kaddr, size_t len);
 TEE_Result copy_to_user(void *uaddr, const void *kaddr, size_t len);
 

--- a/core/include/kernel/user_access.h
+++ b/core/include/kernel/user_access.h
@@ -66,6 +66,35 @@ void bb_reset(void);
 TEE_Result copy_to_user_private(void *uaddr, const void *kaddr, size_t len);
 TEE_Result copy_to_user(void *uaddr, const void *kaddr, size_t len);
 
+TEE_Result clear_user(void *uaddr, size_t n);
+
+size_t strnlen_user(const void *s, size_t n);
+
+/*
+ * bb_memdup_user() - Duplicate a user-space buffer into a bounce buffer
+ * @src:    Pointer to the user buffer to be duplicated.
+ * @len:    Length of the user buffer to be duplicated.
+ * @p:      Holds duplicated bounce buffer on success, or unchanged on failure.
+ *          Note that the returned buffer is allocated by bb_alloc() and
+ *          normally doesn't have to be freed.
+ * Return TEE_SUCCESS on success.
+ * Return TEE_ERROR_OUT_OF_MEMORY or TEE_ERROR_ACCESS_DENIED on error.
+ */
+TEE_Result bb_memdup_user(const void *src, size_t len, void **p);
+
+/*
+ * bb_memdup_user_private() - Duplicate a private user-space buffer
+ * @src:    Pointer to the user buffer to be duplicated. The buffer should
+ *          be private to current TA (i.e., !TEE_MEMORY_ACCESS_ANY_OWNER).
+ * @len:    Length of the user buffer to be duplicated.
+ * @p:      Holds duplicated kernel buffer on success, or unchanged on failure.
+ *          Note that the returned buffer is allocated by bb_alloc() and
+ *          normally doesn't have to be freed.
+ * Return TEE_SUCCESS on success.
+ * Return TEE_ERROR_OUT_OF_MEMORY or TEE_ERROR_ACCESS_DENIED on error.
+ */
+TEE_Result bb_memdup_user_private(const void *src, size_t len, void **p);
+
 TEE_Result copy_kaddr_to_uref(uint32_t *uref, void *kaddr);
 
 uint32_t kaddr_to_uref(void *kaddr);
@@ -74,5 +103,26 @@ static inline void *uref_to_kaddr(uint32_t uref)
 {
 	return (void *)uref_to_vaddr(uref);
 }
+
+#define GET_USER_SCALAR(_x, _p) ({					\
+	TEE_Result __res = TEE_SUCCESS;					\
+	__typeof((_x)) __tmp = 0;					\
+									\
+	static_assert(sizeof(_x) == sizeof(*(_p)));			\
+									\
+	__res = copy_from_user(&__tmp, (const void *)_p, sizeof(_x));	\
+	(_x) = (__tmp);							\
+	__res;								\
+})
+
+#define PUT_USER_SCALAR(_x, _p) ({					\
+	TEE_Result __res = TEE_SUCCESS;					\
+	__typeof((_x)) __x = (_x);					\
+									\
+	static_assert(sizeof(_x) == sizeof(*(_p)));			\
+									\
+	__res = copy_to_user((void *)_p, &(__x), sizeof(*(_p)));	\
+	__res;								\
+})
 
 #endif /*__KERNEL_USER_ACCESS_H*/

--- a/core/include/kernel/user_mode_ctx_struct.h
+++ b/core/include/kernel/user_mode_ctx_struct.h
@@ -28,6 +28,9 @@
  * @is_32bit:		True if 32-bit TS, false if 64-bit TS
  * @is_initializing:	True if TS is not fully loaded
  * @stack_ptr:		Stack pointer
+ * @bbuf:		Bounce buffer for user buffers
+ * @bbuf_size:		Size of bounce buffer
+ * @bbuf_offs:		Offset to unused part of bounce buffer
  */
 struct user_mode_ctx {
 	struct vm_info vm_info;
@@ -51,6 +54,9 @@ struct user_mode_ctx {
 	bool is_32bit;
 	bool is_initializing;
 	vaddr_t stack_ptr;
+	uint8_t *bbuf;
+	size_t bbuf_size;
+	size_t bbuf_offs;
 };
 #endif /*__KERNEL_USER_MODE_CTX_STRUCT_H*/
 

--- a/core/kernel/scall.c
+++ b/core/kernel/scall.c
@@ -14,6 +14,7 @@
 #include <kernel/tee_ta_manager.h>
 #include <kernel/thread.h>
 #include <kernel/trace_ta.h>
+#include <kernel/user_access.h>
 #include <kernel/user_ta.h>
 #include <ldelf.h>
 #include <mm/vm.h>
@@ -211,6 +212,7 @@ bool scall_handle_user_ta(struct thread_scall_regs *regs)
 	size_t max_args = 0;
 	syscall_t scf = NULL;
 
+	bb_reset();
 	scall_get_max_args(regs, &scn, &max_args);
 
 	trace_syscall(scn);
@@ -257,6 +259,7 @@ bool scall_handle_ldelf(struct thread_scall_regs *regs)
 	size_t max_args = 0;
 	syscall_t scf = NULL;
 
+	bb_reset();
 	scall_get_max_args(regs, &scn, &max_args);
 
 	trace_syscall(scn);

--- a/core/kernel/user_access.c
+++ b/core/kernel/user_access.c
@@ -203,6 +203,30 @@ TEE_Result bb_memdup_user_private(const void *src, size_t len, void **p)
 	return res;
 }
 
+TEE_Result bb_strndup_user(const char *src, size_t maxlen, char **dst,
+			   size_t *dstlen)
+{
+	uint32_t flags = TEE_MEMORY_ACCESS_READ | TEE_MEMORY_ACCESS_ANY_OWNER;
+	TEE_Result res = TEE_SUCCESS;
+	size_t l = 0;
+	char *d = NULL;
+
+	src = memtag_strip_tag_const(src);
+	res = check_access(flags, src, maxlen);
+	if (res)
+		return res;
+	l = strnlen(src, maxlen);
+	d = bb_alloc(l + 1);
+	if (!d)
+		return TEE_ERROR_OUT_OF_MEMORY;
+	memcpy(d, src, l);
+	d[l] = 0;
+
+	*dst = d;
+	*dstlen = l;
+	return TEE_SUCCESS;
+}
+
 TEE_Result copy_kaddr_to_uref(uint32_t *uref, void *kaddr)
 {
 	uint32_t ref = kaddr_to_uref(kaddr);

--- a/core/kernel/user_access.c
+++ b/core/kernel/user_access.c
@@ -14,12 +14,34 @@
 #include <tee_api_types.h>
 #include <types_ext.h>
 
-static TEE_Result check_access(uint32_t flags, const void *uaddr, size_t len)
+#define BB_ALIGNMENT	(sizeof(long) * 2)
+
+static struct user_mode_ctx *get_current_uctx(void)
 {
 	struct ts_session *s = ts_get_current_session();
 
-	return vm_check_access_rights(to_user_mode_ctx(s->ctx), flags,
-				      (vaddr_t)uaddr, len);
+	if (!is_user_mode_ctx(s->ctx)) {
+		/*
+		 * We may be called within a PTA session, which doesn't
+		 * have a user_mode_ctx. Here, try to retrieve the
+		 * user_mode_ctx associated with the calling session.
+		 */
+		s = TAILQ_NEXT(s, link_tsd);
+		if (!s || !is_user_mode_ctx(s->ctx))
+			return NULL;
+	}
+
+	return to_user_mode_ctx(s->ctx);
+}
+
+static TEE_Result check_access(uint32_t flags, const void *uaddr, size_t len)
+{
+	struct user_mode_ctx *uctx = get_current_uctx();
+
+	if (!uctx)
+		return TEE_ERROR_GENERIC;
+
+	return vm_check_access_rights(uctx, flags, (vaddr_t)uaddr, len);
 }
 
 TEE_Result copy_from_user(void *kaddr, const void *uaddr, size_t len)
@@ -72,6 +94,48 @@ TEE_Result copy_to_user_private(void *uaddr, const void *kaddr, size_t len)
 		memcpy(uaddr, kaddr, len);
 
 	return res;
+}
+
+void *bb_alloc(size_t len)
+{
+	struct user_mode_ctx *uctx = get_current_uctx();
+	size_t offs = 0;
+	void *bb = NULL;
+
+	if (uctx && !ADD_OVERFLOW(uctx->bbuf_offs, len, &offs) &&
+	    offs <= uctx->bbuf_size) {
+		bb = uctx->bbuf + uctx->bbuf_offs;
+		uctx->bbuf_offs = ROUNDUP(offs, BB_ALIGNMENT);
+	}
+	return bb;
+}
+
+static void bb_free_helper(struct user_mode_ctx *uctx, vaddr_t bb, size_t len)
+{
+	vaddr_t bbuf = (vaddr_t)uctx->bbuf;
+
+	if (bb > bbuf && IS_ALIGNED(bb, BB_ALIGNMENT)) {
+		size_t prev_offs = bb - bbuf;
+
+		if (prev_offs + ROUNDUP(len, BB_ALIGNMENT) == uctx->bbuf_offs)
+			uctx->bbuf_offs = prev_offs;
+	}
+}
+
+void bb_free(void *bb, size_t len)
+{
+	struct user_mode_ctx *uctx = get_current_uctx();
+
+	if (uctx)
+		bb_free_helper(uctx, (vaddr_t)bb, len);
+}
+
+void bb_reset(void)
+{
+	struct user_mode_ctx *uctx = get_current_uctx();
+
+	if (uctx)
+		uctx->bbuf_offs = 0;
 }
 
 TEE_Result copy_kaddr_to_uref(uint32_t *uref, void *kaddr)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -943,6 +943,12 @@ ifeq (y-y,$(CFG_WITH_PAGER)-$(CFG_MEMTAG))
 $(error CFG_WITH_PAGER and CFG_MEMTAG are not compatible)
 endif
 
+# Privileged Access Never (PAN, part of the ARMv8.1 Extensiosn) can be
+# used to restrict accesses to unprivileged memory from privileged mode.
+CFG_PAN ?= n
+
+$(eval $(call cfg-depends-all,CFG_PAN,CFG_ARM64_core))
+
 # CFG_CORE_ASYNC_NOTIF is defined by the platform to enable support
 # for sending asynchronous notifications to normal world. Note that an
 # interrupt ID must be configurged by the platform too. Currently is only


### PR DESCRIPTION
This relates to https://github.com/OP-TEE/optee_os/pull/6061 and tries to solve the problem with unpredictable memory allocation for bounce buffers. There's some example usage in the commit "core: use user-access functions in ldelf interaction".