### PR TITLE
scripts/symbolize.py: Fix crash when .elf file not found

### DIFF
--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -262,6 +262,8 @@ class Symbolizer(object):
         if elf_name is None:
             return ''
         elf = self.get_elf(elf_name)
+        if elf is None:
+            return ''
         cmd = self.arch_prefix('nm', elf)
         if not reladdr or not elf or not cmd:
             return ''
@@ -303,6 +305,8 @@ class Symbolizer(object):
         if elf_name is None:
             return ''
         elf = self.get_elf(elf_name)
+        if elf is None:
+            return ''
         cmd = self.arch_prefix('objdump', elf)
         if not reladdr or not elf or not cmd:
             return ''


### PR DESCRIPTION
The script will crash if the xxx.elf file can not be found.

Here is a example
```sh
# Run symbolize.py without specifying `-d /optee/optee-qemu-v8/optee_os/out/arm/core/`. In this case the script can not find `tee.elf` and will crash
/optee/optee-qemu-v8/optee_os/scripts/symbolize.py -d /optee/optee-qemu-v8/out-br/build/optee_examples_ext-1.0/test_ta/ta/out/
```
```
D/TC:0 0 abort_handler:530 [abort] abort in User mode (TA will panic)
E/TC:? 0 
E/TC:? 0 User mode data-abort at address 0x0 (translation fault)
E/TC:? 0  esr 0x92000045  ttbr0 0x400000e1a3000   ttbr1 0x00000000   cidr 0x0
E/TC:? 0  cpu #0          cpsr 0x20000100
E/TC:? 0  x0  0000000000000000 x1  000000000000004c
E/TC:? 0  x2  0000000000000000 x3  0000000040015d90
E/TC:? 0  x4  0000000000000001 x5  0000000000000001
E/TC:? 0  x6  00000000fffffffe x7  00000000ffffffff
E/TC:? 0  x8  0000000000000001 x9  0000000040015ad8
E/TC:? 0  x10 0000000000000038 x11 0000000000000000
E/TC:? 0  x12 0000000000000000 x13 0000000040015a6c
E/TC:? 0  x14 0000000000000020 x15 0000000000000000
E/TC:? 0  x16 000000002157c0e8 x17 0000000000000000
E/TC:? 0  x18 0000000000000000 x19 0000000040015e08
E/TC:? 0  x20 00000000401a3b98 x21 00000000401a2b68
E/TC:? 0  x22 00000000401a3bb0 x23 0000000000000001
E/TC:? 0  x24 0000000000000048 x25 00000000401a0d06
E/TC:? 0  x26 0000000000000003 x27 00000000401a3000
E/TC:? 0  x28 0000000000000000 x29 0000000040015da0
E/TC:? 0  x30 0000000040051440 elr 0000000040051444
E/TC:? 0  sp_el0 0000000040015da0
E/LD:  Status of TA 3d7e51cf-42ee-4494-9d58-23e5feff97f5
E/LD:   arch: aarch64
E/LD:  region  0: va 0x40004000 pa 0x0e32e000 size 0x002000 flags rw-s (ldelf)
E/LD:  region  1: va 0x40006000 pa 0x0e330000 size 0x009000 flags r-xs (ldelf)
E/LD:  region  2: va 0x4000f000 pa 0x0e339000 size 0x001000 flags rw-s (ldelf)
E/LD:  region  3: va 0x40010000 pa 0x0e33a000 size 0x004000 flags rw-s (ldelf)
E/LD:  region  4: va 0x40014000 pa 0x0e33e000 size 0x001000 flags r--s
E/LD:  region  5: va 0x40015000 pa 0x0e511000 size 0x001000 flags rw-s (stack)
E/LD:  region  6: va 0x40033000 pa 0x00001000 size 0x079000 flags r-xs [0] .ta_head .text .init .fini .plt .eh_frame_hdr .eh_frame .gcc_except_table .dynsym .dynstr .hash .rela.dyn
E/LD:  region  7: va 0x400ac000 pa 0x0007a000 size 0x159000 flags rw-s [0] .dynamic .got .rela.data .rela.got .rela.plt .rodata .data .init_array .init_array.00000 .bss
E/LD:   [0] 3d7e51cf-42ee-4494-9d58-23e5feff97f5 @ 0x40033000 (/optee/optee-qemu-v8/out-br/build/optee_examples_ext-1.0/test_ta/ta/out/3d7e51cf-42ee-4494-9d58-23e5feff97f5.elf)
Traceback (most recent call last):
  File "/optee/optee-qemu-v8/optee_os/scripts/symbolize.py", line 520, in <module>
    main()
  File "/optee/optee-qemu-v8/optee_os/scripts/symbolize.py", line 512, in main
    symbolizer.write(line)
  File "/optee/optee-qemu-v8/optee_os/scripts/symbolize.py", line 476, in write
    self._out.write(self.process_abort(self._saved_abort_line))
  File "/optee/optee-qemu-v8/optee_os/scripts/symbolize.py", line 295, in process_abort
    sym = self.symbol_plus_offset(addr)
  File "/optee/optee-qemu-v8/optee_os/scripts/symbolize.py", line 226, in symbol_plus_offset
    cmd = self.arch_prefix('nm', elf)
  File "/optee/optee-qemu-v8/optee_os/scripts/symbolize.py", line 141, in arch_prefix
    self.set_arch(elf)
  File "/optee/optee-qemu-v8/optee_os/scripts/symbolize.py", line 132, in set_arch
    p = subprocess.Popen(['file', '-L', elf], stdout=subprocess.PIPE)
  File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1639, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
TypeError: expected str, bytes or os.PathLike object, not NoneType
```


This commit add check for `None` value.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
