### PR TITLE
ftrace: change implementation to use binary circular buffer

### DIFF
--- a/ldelf/ftrace.c
+++ b/ldelf/ftrace.c
@@ -5,8 +5,10 @@
 
 #include <assert.h>
 #include <printk.h>
+#include <string.h>
 #include <sys/queue.h>
 #include <types_ext.h>
+#include <user_ta_header.h>
 #include <util.h>
 
 #include "ftrace.h"
@@ -25,6 +27,9 @@ bool ftrace_init(struct ftrace_buf **fbuf_ptr)
 	vaddr_t val = 0;
 	int count = 0;
 	size_t fbuf_size = 0;
+	size_t pad = 0;
+	char *p = NULL;
+	char magic[] = { 'F', 'T', 'R', 'A', 'C', 'E', 0x00, 0x01 };
 
 	res = ta_elf_resolve_sym("__ftrace_info", &val, NULL, NULL);
 	if (res)
@@ -45,17 +50,32 @@ bool ftrace_init(struct ftrace_buf **fbuf_ptr)
 
 	fbuf = (struct ftrace_buf *)(vaddr_t)finfo->buf_start.ptr64;
 	fbuf->head_off = sizeof(struct ftrace_buf);
-	count = snprintk((char *)fbuf + fbuf->head_off, MAX_HEADER_STRLEN,
+	p = (char *)fbuf + fbuf->head_off;
+	count = snprintk(p, MAX_HEADER_STRLEN,
 			 "Function graph for TA: %pUl @ %lx\n",
 			 (void *)&elf->uuid, elf->load_addr);
 	assert(count < MAX_HEADER_STRLEN);
+	p += count;
 
 	fbuf->ret_func_ptr = finfo->ret_ptr.ptr64;
 	fbuf->ret_idx = 0;
 	fbuf->lr_idx = 0;
 	fbuf->suspend_time = 0;
 	fbuf->buf_off = fbuf->head_off + count;
-	fbuf->curr_size = 0;
+	/* For proper alignment of uint64_t values in the ftrace buffer  */
+	pad = 8 - (vaddr_t)p % 8;
+	if (pad == 8)
+		pad = 0;
+	while (pad--) {
+		*p++ = 0;
+		fbuf->buf_off++;
+		count++;
+	}
+	/* Delimiter for easier decoding */
+	memcpy(p, magic, sizeof(magic));
+	fbuf->buf_off += sizeof(magic);
+	count += sizeof(magic);
+	fbuf->curr_idx = 0;
 	fbuf->max_size = fbuf_size - sizeof(struct ftrace_buf) - count;
 	fbuf->syscall_trace_enabled = false;
 	fbuf->syscall_trace_suspended = false;
@@ -70,11 +90,30 @@ void ftrace_copy_buf(void *pctx, void (*copy_func)(void *pctx, void *b,
 {
 	if (fbuf) {
 		struct ta_elf *elf = TAILQ_FIRST(&main_elf_queue);
-		size_t dump_size = fbuf->buf_off - fbuf->head_off +
-				   fbuf->curr_size;
+		char *hstart = (char *)fbuf + fbuf->head_off;
+		char *cstart = (char *)fbuf + fbuf->buf_off;
+		char *ccurr = cstart + fbuf->curr_idx * sizeof(uint64_t);
+		size_t csize = 0;
+		size_t dump_size = 0;
+		char *end = NULL;
 
 		assert(elf && elf->is_main);
-		copy_func(pctx, (char *)fbuf + fbuf->head_off, dump_size);
+
+		if (fbuf->overflow)
+			csize = fbuf->max_size;
+		else
+			csize = fbuf->curr_idx * sizeof(uint64_t);
+		dump_size = fbuf->buf_off - fbuf->head_off + csize;
+		end = hstart + dump_size;
+
+		/* Header */
+		copy_func(pctx, hstart, fbuf->buf_off - fbuf->head_off);
+		if (fbuf->overflow) {
+			/* From current index to end of circular buffer */
+			copy_func(pctx, ccurr, end - ccurr);
+		}
+		/* From start of circular buffer to current index */
+		copy_func(pctx, cstart, ccurr - cstart);
 	}
 }
 

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -67,12 +67,13 @@ struct ftrace_buf {
 	uint32_t lr_idx;	/* lr index used for stack unwinding */
 	uint64_t begin_time[FTRACE_RETFUNC_DEPTH]; /* Timestamp */
 	uint64_t suspend_time;	/* Suspend timestamp */
-	uint32_t curr_size;	/* Size of ftrace buffer */
+	uint32_t curr_idx;	/* Current entry in the (circular) buffer */
 	uint32_t max_size;	/* Max allowed size of ftrace buffer */
 	uint32_t head_off;	/* Ftrace buffer header offset */
 	uint32_t buf_off;	/* Ftrace buffer offset */
 	bool syscall_trace_enabled; /* Some syscalls are never traced */
 	bool syscall_trace_suspended; /* By foreign interrupt or RPC */
+	bool overflow;		/* Circular buffer has wrapped */
 };
 
 /* Defined by the linker script */

--- a/lib/libutils/ext/ftrace/ftrace.c
+++ b/lib/libutils/ext/ftrace/ftrace.c
@@ -11,6 +11,7 @@
  */
 
 #include <assert.h>
+#include <types_ext.h>
 #include <user_ta_header.h>
 #if defined(__KERNEL__)
 #include <arm.h>
@@ -24,13 +25,6 @@
 #include <utee_syscalls.h>
 #endif
 #include "ftrace.h"
-
-#define DURATION_MAX_LEN		16
-#define ENTRY_SIZE(idx)			(DURATION_MAX_LEN + (idx) + \
-					 (2 * sizeof(unsigned long)) + 8)
-#define EXIT_SIZE(idx)			(DURATION_MAX_LEN + (idx) + 3)
-
-static const char hex_str[] = "0123456789abcdef";
 
 static __noprof struct ftrace_buf *get_fbuf(void)
 {
@@ -62,112 +56,40 @@ static __noprof struct ftrace_buf *get_fbuf(void)
 #endif
 }
 
-#if defined(_CFG_FTRACE_BUF_WHEN_FULL_shift)
-
-/*
- * This API shifts/moves ftrace buffer to create space for new dump
- * in case the buffer size falls short of actual dump.
- */
-static bool __noprof fbuf_make_room(struct ftrace_buf *fbuf, size_t size)
+static void __noprof add_elem(struct ftrace_buf *fbuf, uint8_t level,
+			       uint64_t val)
 {
-	char *dst = (char *)fbuf + fbuf->buf_off;
-	const char *src = (char *)fbuf + fbuf->buf_off + size;
-	size_t n = 0;
+	uint64_t *elem = NULL;
+	size_t idx = fbuf->curr_idx;
 
-	fbuf->curr_size -= size;
+	/* Make sure the topmost byte doesn't contain useful information */
+	assert(!(val >> 56));
 
-	for (n = 0; n < fbuf->curr_size; n++)
-		dst[n] = src[n];
+	elem = (uint64_t *)((vaddr_t)fbuf + fbuf->buf_off) + idx;
+	*elem = SHIFT_U64(level, 56) | val;
 
-	return true;
-}
+	idx++;
+	if ((idx + 1) * sizeof(*elem) > fbuf->max_size) {
+		idx = 0;
+		fbuf->overflow = true;
+	}
 
-#elif defined(_CFG_FTRACE_BUF_WHEN_FULL_wrap)
-
-/* Makes room in the trace buffer by discarding the previously recorded data. */
-static bool __noprof fbuf_make_room(struct ftrace_buf *fbuf,
-				    size_t size)
-{
-	if (fbuf->buf_off + size > fbuf->max_size)
-		return false;
-
-	fbuf->curr_size = 0;
-
-	return true;
-}
-
-#elif defined(_CFG_FTRACE_BUF_WHEN_FULL_stop)
-
-static bool __noprof fbuf_make_room(struct ftrace_buf *fbuf __unused,
-				    size_t size __unused)
-{
-	return false;
-}
-
-#else
-#error CFG_FTRACE_BUF_WHEN_FULL value not supported
-#endif
-
-static size_t __noprof to_func_enter_fmt(char *buf, uint32_t ret_idx,
-					 unsigned long pc)
-{
-	char *str = buf;
-	uint32_t addr_size = 2 * sizeof(unsigned long);
-	uint32_t i = 0;
-
-	for (i = 0; i < (DURATION_MAX_LEN + ret_idx); i++)
-		if (i == (DURATION_MAX_LEN - 2))
-			*str++ = '|';
-		else
-			*str++ = ' ';
-
-	*str++ = '0';
-	*str++ = 'x';
-
-	for (i = 0; i < addr_size; i++)
-		*str++ = hex_str[(pc >> 4 * (addr_size - i - 1)) & 0xf];
-
-	*str++ = '(';
-	*str++ = ')';
-	*str++ = ' ';
-	*str++ = '{';
-	*str++ = '\n';
-	*str = '\0';
-
-	return str - buf;
+	fbuf->curr_idx = idx;
 }
 
 void __noprof ftrace_enter(unsigned long pc, unsigned long *lr)
 {
-	struct ftrace_buf *fbuf = NULL;
-	size_t line_size = 0;
-	bool full = false;
-
-	fbuf = get_fbuf();
+	uint64_t now = barrier_read_counter_timer();
+	struct ftrace_buf *fbuf = get_fbuf();
 
 	if (!fbuf || !fbuf->buf_off || !fbuf->max_size)
 		return;
 
-	line_size = ENTRY_SIZE(fbuf->ret_idx);
-
-	/*
-	 * Check if we have enough space in ftrace buffer. If not then try to
-	 * make room.
-	 */
-	full = (fbuf->curr_size + line_size) > fbuf->max_size;
-	if (full)
-		full = !fbuf_make_room(fbuf, line_size);
-
-	if (!full)
-		fbuf->curr_size += to_func_enter_fmt((char *)fbuf +
-						     fbuf->buf_off +
-						     fbuf->curr_size,
-						     fbuf->ret_idx,
-						     pc);
+	add_elem(fbuf, fbuf->ret_idx + 1, pc);
 
 	if (fbuf->ret_idx < FTRACE_RETFUNC_DEPTH) {
 		fbuf->ret_stack[fbuf->ret_idx] = *lr;
-		fbuf->begin_time[fbuf->ret_idx] = barrier_read_counter_timer();
+		fbuf->begin_time[fbuf->ret_idx] = now;
 		fbuf->ret_idx++;
 	} else {
 		/*
@@ -184,134 +106,22 @@ void __noprof ftrace_enter(unsigned long pc, unsigned long *lr)
 	*lr = (unsigned long)&__ftrace_return;
 }
 
-static void __noprof ftrace_duration(char *buf, uint64_t start, uint64_t end)
-{
-	uint32_t max_us = CFG_FTRACE_US_MS;
-	uint32_t cntfrq = read_cntfrq();
-	uint64_t ticks = end - start;
-	uint32_t ms = 0;
-	uint32_t us = 0;
-	uint32_t ns = 0;
-	uint32_t frac = 0;
-	uint32_t in = 0;
-	char unit = 'u';
-	int i = 0;
-
-	ticks = ticks * 1000000000 / cntfrq;
-	us = ticks / 1000;
-	ns = ticks % 1000;
-
-	if (max_us && us >= max_us) {
-		/* Display value in milliseconds */
-		unit = 'm';
-		ms = us / 1000;
-		us = us % 1000;
-		frac = us;
-		in = ms;
-	} else {
-		/* Display value in microseconds */
-		frac = ns;
-		in = us;
-	}
-
-	*buf-- = 's';
-	*buf-- = unit;
-	*buf-- = ' ';
-
-	COMPILE_TIME_ASSERT(DURATION_MAX_LEN == 16);
-	if (in > 999999) {
-		/* Not enough space to print the value */
-		for (i = 0; i < 10; i++)
-			*buf-- = '-';
-		return;
-	}
-
-	for (i = 0; i < 3; i++) {
-		*buf-- = hex_str[frac % 10];
-		frac /= 10;
-	}
-
-	*buf-- = '.';
-
-	while (in) {
-		*buf-- = hex_str[in % 10];
-		in /= 10;
-	}
-}
-
 unsigned long __noprof ftrace_return(void)
 {
-	struct ftrace_buf *fbuf = NULL;
-	char *line = NULL;
-	size_t line_size = 0;
-	char *dur_loc = NULL;
-	uint32_t i = 0;
-
-	fbuf = get_fbuf();
+	uint64_t now = barrier_read_counter_timer();
+	struct ftrace_buf *fbuf = get_fbuf();
+	uint64_t start = 0;
+	uint64_t elapsed = 0;
 
 	/* Check for valid return index */
-	if (fbuf && fbuf->ret_idx && fbuf->ret_idx <= FTRACE_RETFUNC_DEPTH)
-		fbuf->ret_idx--;
-	else
+	if (!fbuf || !fbuf->ret_idx || fbuf->ret_idx > FTRACE_RETFUNC_DEPTH)
 		return 0;
 
-	/*
-	 * Check if we have a minimum ftrace buffer current size. If we have
-	 * somehow corrupted ftrace buffer formatting, the function call chain
-	 * shouldn't get broken since we have a valid fbuf->ret_idx at this
-	 * point which can retrieve correct return pointer from fbuf->ret_stack.
-	 */
-	line_size = ENTRY_SIZE(fbuf->ret_idx);
-	if (fbuf->curr_size < line_size)
-		goto out;
+	fbuf->ret_idx--;
+	start = fbuf->begin_time[fbuf->ret_idx];
+	elapsed = (now - start) * 1000000000 / read_cntfrq();
+	add_elem(fbuf, 0, elapsed);
 
-	line = (char *)fbuf + fbuf->buf_off + fbuf->curr_size - line_size;
-
-	/*
-	 * Check for '{' symbol as it represents if it is an exit from current
-	 * or nested function. If exit is from current function, than exit dump
-	 * via ';' symbol else exit dump via '}' symbol.
-	 */
-	if (line[line_size - 2] == '{') {
-		line[line_size - 3] = ';';
-		line[line_size - 2] = '\n';
-		line[line_size - 1] = '\0';
-		fbuf->curr_size -= 1;
-
-		dur_loc = &line[DURATION_MAX_LEN - 3];
-		ftrace_duration(dur_loc, fbuf->begin_time[fbuf->ret_idx],
-				barrier_read_counter_timer());
-	} else {
-		bool full = false;
-
-		line_size = EXIT_SIZE(fbuf->ret_idx);
-		full = (fbuf->curr_size + line_size) > fbuf->max_size;
-		if (full)
-			full = !fbuf_make_room(fbuf, line_size);
-
-		if (!full) {
-			line = (char *)fbuf + fbuf->buf_off + fbuf->curr_size;
-
-			for (i = 0; i < DURATION_MAX_LEN + fbuf->ret_idx; i++) {
-				if (i == (DURATION_MAX_LEN - 2))
-					line[i] = '|';
-				else
-					line[i] = ' ';
-			}
-
-			line[i] = '}';
-			line[i + 1] = '\n';
-			line[i + 2] = '\0';
-
-			fbuf->curr_size += line_size - 1;
-
-			dur_loc = &line[DURATION_MAX_LEN - 4];
-			ftrace_duration(dur_loc,
-					fbuf->begin_time[fbuf->ret_idx],
-					barrier_read_counter_timer());
-		}
-	}
-out:
 	return fbuf->ret_stack[fbuf->ret_idx];
 }
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -570,25 +570,9 @@ CFG_TA_GPROF_SUPPORT ?= n
 # TA function tracing.
 # When this option is enabled, OP-TEE can execute Trusted Applications
 # instrumented with GCC's -pg flag and will output function tracing
-# information in ftrace.out format to /tmp/ftrace-<ta_uuid>.out (path is
-# defined in tee-supplicant)
+# information for all functions compiled with -pg to
+# /tmp/ftrace-<ta_uuid>.out (path is defined in tee-supplicant).
 CFG_FTRACE_SUPPORT ?= n
-
-# How to make room when the function tracing buffer is full?
-# 'shift': shift the previously stored data by the amount needed in order
-#    to always keep the latest logs (slower, especially with big buffer sizes)
-# 'wrap': discard the previous data and start at the beginning of the buffer
-#    again (fast, but can result in a mostly empty buffer)
-# 'stop': stop logging new data
-CFG_FTRACE_BUF_WHEN_FULL ?= shift
-$(call cfg-check-value,FTRACE_BUF_WHEN_FULL,shift stop wrap)
-$(call force,_CFG_FTRACE_BUF_WHEN_FULL_$(CFG_FTRACE_BUF_WHEN_FULL),y)
-
-# Function tracing: unit to be used when displaying durations
-#  0: always display durations in microseconds
-# >0: if duration is greater or equal to the specified value (in microseconds),
-#     display it in milliseconds
-CFG_FTRACE_US_MS ?= 10000
 
 # Core syscall function tracing.
 # When this option is enabled, OP-TEE core is instrumented with GCC's

--- a/scripts/ftrace_format.py
+++ b/scripts/ftrace_format.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2023, Linaro Limited
+#
+# Converts a ftrace binary file to text. The input file has the following
+# format:
+#
+#  <ASCII text> <zero or more nul bytes> FTRACE\x00\x01 <binary data>...
+#
+# <binary data> is an array of 64-bit integers.
+# - When the topmost byte is 0, the entry indicates a function return and the
+# remaining bytes are a duration in nanoseconds.
+# - A non-zero value is a stack depth, indicating a function entry, and the
+# remaining bytes are the function's address.
+
+import sys
+
+
+line = ""
+curr_depth = 0
+
+
+def usage():
+    print(f"Usage: {sys.argv[0]} ftrace.out")
+    print("Converts a ftrace file to text. Output is written to stdout.")
+    sys.exit(0)
+
+
+def format_time(ns):
+    if ns < 1000000:
+        us = ns / 1000
+        return f"{us:7.3f} us"
+    else:
+        ms = ns / 1000000
+        return f"{ms:7.3f} ms"
+
+
+def display(depth, val):
+    global line, curr_depth
+    if depth != 0:
+        curr_depth = depth
+        if line != "":
+            line = line.replace("TIME", " " * 10) + " {"
+            print(line)
+            line = ""
+        line = f" TIME | {depth:3} | " + " " * depth + f"0x{val:016x}()"
+    else:
+        if line != "":
+            line = line.replace("TIME", format_time(val))
+            print(line)
+            line = ""
+        else:
+            if curr_depth != 0:
+                curr_depth = curr_depth - 1
+                print(" " + format_time(val) + f" | {curr_depth:3} | " +
+                      " " * curr_depth + "}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+    with open(sys.argv[1], 'rb') as f:
+        s = f.read()
+    magic = s.find(b'FTRACE\x00\x01')
+    if magic == -1:
+        print("Magic not found", file=sys.stderr)
+        sys.exit(1)
+    print(s[:magic].rstrip(b'\x00').decode())
+    s = s[magic + 8:]
+    for i in range(0, len(s), 8):
+        elem = int.from_bytes(s[i:i + 8], byteorder="little", signed=False)
+        depth = elem >> 56
+        val = elem & 0xFFFFFFFFFFFFFF
+        display(depth, val)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The current implementation of function tracing (CFG_FTRACE_SUPPORT) produces human-readable text into the output buffer that is passed to tee-supplicant and ultimately saved to the Linux filesystem. Two main issues with that:

1. The string formatting code is somewhat complex. It introduces significant overhead in the execution time of the instrumented functions.
2. The various policies about how to handle a buffer full condition (CFG_FTRACE_BUF_WHEN_FULL) are not very convenient. In particular, "shift" is typically the most desirable option because it always keeps the most recent entries, but it is very inefficient to the point of not being usable in practice.

This commit addresses the above concerns by making the ftrace buffer circular one, each entry being a 16-byte binary structure. The formatting code is offloaded to a new Python script: scripts/ftrace_format.py. The output is mostly unchanged except for an added field showing the current depth in the call stack and indentation being two spaces instead of just one.

Typical usage (captured on QEMUv8):
```
 build$ mkdir -p ../tmp
 build$ chmod a+w ../tmp
 build$ make CFG_FTRACE_SUPPORT=y CFG_FTRACE_BUF_SIZE=15000 \
             CFG_TA_MCOUNT=y CFG_ULIBS_MCOUNT=y CFG_SYSCALL_FTRACE=y \
             QEMU_VIRTFS_AUTOMOUNT=y run
 $ xtest regression_1004
 ...
 $ cp /tmp/ftrace-cb3e5ba0-adf1-11e0-998b-0002a5d5c51b.out /mnt/host/tmp
 build$ cd ..
 optee$ optee_os/scripts/ftrace_format.py \
           tmp/ftrace-cb3e5ba0-adf1-11e0-998b-0002a5d5c51b.out |
        optee_os/scripts/symbolize.py \
           -d optee_os/out/arm/core \
           -d out-br/build/optee_test_ext-1.0/ta/*/out | less
 TEE load address @ 0x5ab04000
 Function graph for TA: cb3e5ba0-adf1-11e0-998b-0002a5d5c51b @ 80085000
             |   1 |   __ta_entry() {
             |   2 |     __utee_entry() {
   43.840 us |   3 |       ta_header_get_session()
    7.216 us |   3 |       tahead_get_trace_level()
   14.480 us |   3 |       trace_set_level()
             |   3 |       malloc_add_pool() {
             |   4 |         raw_malloc_add_pool() {
   46.032 us |   5 |           bpool()
             |   5 |           raw_realloc() {
  166.256 us |   6 |             bget()
   23.056 us |   6 |             raw_malloc_return_hook()
  267.952 us |   5 |           }
  398.720 us |   4 |         }
  426.992 us |   3 |       }
             |   3 |       TEE_GetPropertyAsU32() {
   23.600 us |   4 |         is_propset_pseudo_handle()
             |   4 |         __utee_check_instring_annotation() {
   26.416 us |   5 |           strlen()
             |   5 |           check_access() {
             |   6 |             TEE_CheckMemoryAccessRights() {
             |   7 |               _utee_check_access_rights() {
             |   8 |                 syscall_check_access_rights() {
             |   9 |                   ts_get_current_session() {
    4.304 us |  10 |                     ts_get_current_session_may_fail()
   10.976 us |   9 |                   }
             |   9 |                   to_user_ta_ctx() {
    2.496 us |  10 |                     is_user_ta_ctx()
    8.096 us |   9 |                   }
             |   9 |                   vm_check_access_rights() {
             |  10 |                     vm_buf_is_inside_um_private() {
             |  11 |                       core_is_buffer_inside() {
 ...
```
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
