### PR TITLE
Update CHANGELOG for 3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,63 @@
+# OP-TEE - version 3.22.0 (2023-07-07)
+
+- Links to the release pages, commits and pull requests merged into this release for:
+  - OP-TEE/optee_os: [release page][OP_TEE_optee_os_release_3_22_0], [commits][OP_TEE_optee_os_commits_3_22_0] and [pull requests][OP_TEE_optee_os_pr_3_22_0]
+  - OP-TEE/optee_client: [release page][OP_TEE_optee_client_release_3_22_0], [commits][OP_TEE_optee_client_commits_3_22_0] and [pull requests][OP_TEE_optee_client_pr_3_22_0]
+  - OP-TEE/optee_test: [release page][OP_TEE_optee_test_release_3_22_0], [commits][OP_TEE_optee_test_commits_3_22_0] and [pull requests][OP_TEE_optee_test_pr_3_22_0]
+  - OP-TEE/build: [release page][OP_TEE_build_release_3_22_0], [commits][OP_TEE_build_commits_3_22_0] and [pull requests][OP_TEE_build_pr_3_22_0]
+  - linaro-swg/optee_examples: [release page][linaro_swg_optee_examples_release_3_22_0], [commits][linaro_swg_optee_examples_commits_3_22_0] and [pull requests][linaro_swg_optee_examples_pr_3_22_0]
+
+
+[OP_TEE_optee_os_release_3_22_0]: https://github.com/OP-TEE/optee_os/releases/tag/3.22.0
+[OP_TEE_optee_os_commits_3_22_0]: https://github.com/OP-TEE/optee_os/compare/3.21.0...3.22.0
+[OP_TEE_optee_os_pr_3_22_0]: https://github.com/OP-TEE/optee_os/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2023-04-14..2023-07-07
+
+[OP_TEE_optee_client_release_3_22_0]: https://github.com/OP-TEE/optee_client/releases/tag/3.22.0
+[OP_TEE_optee_client_commits_3_22_0]: https://github.com/OP-TEE/optee_client/compare/3.21.0...3.22.0
+[OP_TEE_optee_client_pr_3_22_0]: https://github.com/OP-TEE/optee_client/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2023-04-14..2023-07-07
+
+[OP_TEE_optee_test_release_3_22_0]: https://github.com/OP-TEE/optee_test/releases/tag/3.22.0
+[OP_TEE_optee_test_commits_3_22_0]: https://github.com/OP-TEE/optee_test/compare/3.21.0...3.22.0
+[OP_TEE_optee_test_pr_3_22_0]: https://github.com/OP-TEE/optee_test/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2023-04-14..2023-07-07
+
+[OP_TEE_build_release_3_22_0]: https://github.com/OP-TEE/build/releases/tag/3.22.0
+[OP_TEE_build_commits_3_22_0]: https://github.com/OP-TEE/build/compare/3.21.0...3.22.0
+[OP_TEE_build_pr_3_22_0]: https://github.com/OP-TEE/build/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2023-04-14..2023-07-07
+
+[linaro_swg_optee_examples_release_3_22_0]: https://github.com/linaro-swg/optee_examples/releases/tag/3.22.0
+[linaro_swg_optee_examples_commits_3_22_0]: https://github.com/linaro-swg/optee_examples/compare/3.21.0...3.22.0
+[linaro_swg_optee_examples_pr_3_22_0]: https://github.com/linaro-swg/optee_examples/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2023-04-14..2023-07-07
+
+# OP-TEE - version 3.22 (2023-07-07)
+
+- Links to the release pages, commits and pull requests merged into this release for:
+  - OP-TEE/optee_os: [release page][OP_TEE_optee_os_release_3_22], [commits][OP_TEE_optee_os_commits_3_22] and [pull requests][OP_TEE_optee_os_pr_3_22]
+  - OP-TEE/optee_client: [release page][OP_TEE_optee_client_release_3_22], [commits][OP_TEE_optee_client_commits_3_22] and [pull requests][OP_TEE_optee_client_pr_3_22]
+  - OP-TEE/optee_test: [release page][OP_TEE_optee_test_release_3_22], [commits][OP_TEE_optee_test_commits_3_22] and [pull requests][OP_TEE_optee_test_pr_3_22]
+  - OP-TEE/build: [release page][OP_TEE_build_release_3_22], [commits][OP_TEE_build_commits_3_22] and [pull requests][OP_TEE_build_pr_3_22]
+  - linaro-swg/optee_examples: [release page][linaro_swg_optee_examples_release_3_22], [commits][linaro_swg_optee_examples_commits_3_22] and [pull requests][linaro_swg_optee_examples_pr_3_22]
+
+
+[OP_TEE_optee_os_release_3_22]: https://github.com/OP-TEE/optee_os/releases/tag/3.22
+[OP_TEE_optee_os_commits_3_22]: https://github.com/OP-TEE/optee_os/compare/3.21...3.22
+[OP_TEE_optee_os_pr_3_22]: https://github.com/OP-TEE/optee_os/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A..2023-07-07
+
+[OP_TEE_optee_client_release_3_22]: https://github.com/OP-TEE/optee_client/releases/tag/3.22
+[OP_TEE_optee_client_commits_3_22]: https://github.com/OP-TEE/optee_client/compare/3.21...3.22
+[OP_TEE_optee_client_pr_3_22]: https://github.com/OP-TEE/optee_client/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A..2023-07-07
+
+[OP_TEE_optee_test_release_3_22]: https://github.com/OP-TEE/optee_test/releases/tag/3.22
+[OP_TEE_optee_test_commits_3_22]: https://github.com/OP-TEE/optee_test/compare/3.21...3.22
+[OP_TEE_optee_test_pr_3_22]: https://github.com/OP-TEE/optee_test/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A..2023-07-07
+
+[OP_TEE_build_release_3_22]: https://github.com/OP-TEE/build/releases/tag/3.22
+[OP_TEE_build_commits_3_22]: https://github.com/OP-TEE/build/compare/3.21...3.22
+[OP_TEE_build_pr_3_22]: https://github.com/OP-TEE/build/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A..2023-07-07
+
+[linaro_swg_optee_examples_release_3_22]: https://github.com/linaro-swg/optee_examples/releases/tag/3.22
+[linaro_swg_optee_examples_commits_3_22]: https://github.com/linaro-swg/optee_examples/compare/3.21...3.22
+[linaro_swg_optee_examples_pr_3_22]: https://github.com/linaro-swg/optee_examples/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A..2023-07-07
+
 # OP-TEE - version 3.21.0 (2023-04-14)
 
 - Links to the release pages, commits and pull requests merged into this release for:

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -121,7 +121,7 @@ CFG_OS_REV_REPORTS_GIT_SHA1 ?= y
 # with limited depth not including any tag, so there is really no guarantee
 # that TEE_IMPL_VERSION contains the major and minor revision numbers.
 CFG_OPTEE_REVISION_MAJOR ?= 3
-CFG_OPTEE_REVISION_MINOR ?= 21
+CFG_OPTEE_REVISION_MINOR ?= 22
 CFG_OPTEE_REVISION_EXTRA ?=
 
 # Trusted OS implementation version


### PR DESCRIPTION
Update CHANGELOG for 3.22.0 and collect Tested-by tags.

Maintainers etc, we will use this PR for the upcoming 3.22 release. In the docs it says that the release is July 14th. But due to vacations, holidays etc, we've decided to release one week earlier, i.e,. July 7th will be the release date for OP-TEE 3.22.0.

RC-tags will be created in about a week, but it probably doesn't hurt to start sanitize testing already now.
**EDIT 2023-06-30**
I have just submitted the 3.22.0-rc1 tag to all of our git repositories.

// Regards
Joakim
