### PR TITLE
libutils: malloc: fix raw_malloc_buffer_overlaps_heap()

### DIFF
--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -960,7 +960,7 @@ bool raw_malloc_buffer_overlaps_heap(struct malloc_ctx *ctx,
 			return true;	/* Wrapping buffers, shouldn't happen */
 
 		if ((buf_start >= pool_start && buf_start < pool_end) ||
-		    (buf_end >= pool_start && buf_end < pool_end))
+		    (buf_end > pool_start && buf_end < pool_end))
 			return true;
 	}
 


### PR DESCRIPTION
When checking if there's an overlap between allocated buffer and heap, raw_malloc_buffer_overlaps_heap() considers two cases: when buffer comes before the pool and the opposite. On the first case, overlap will happen if the buffer end after the loop start. Since buf_end is computed as buf_start + len, it will point to the address of the first byte after the memory region allocated to the buffer.

Fix raw_malloc_buffer_overlaps_heap() by considering overlap only when buffer end is bigger than the pool start.

Fixes: 12d739bd5028 (libutils: use raw_malloc_*() as more primitive bget wrappers)
Signed-off-by: Vitor Sato Eschholz <vsatoes@baylibre.com>
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
