### PR TITLE
core: spmc: handle missing FFA_MSG_SEND_VM_DESTROYED

### DIFF
--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -677,6 +677,20 @@ static void handle_framework_direct_request(struct thread_smc_args *args,
 				w3 = FFA_INVALID_PARAMETERS;
 		}
 		break;
+	case FFA_MSG_SEND_VM_DESTROYED:
+		if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
+			uint16_t guest_id = args->a5;
+			TEE_Result res = virt_guest_destroyed(guest_id);
+
+			w0 = FFA_MSG_SEND_DIRECT_RESP_32;
+			w1 = swap_src_dst(args->a1);
+			w2 = FFA_MSG_FLAG_FRAMEWORK | FFA_MSG_RESP_VM_DESTROYED;
+			if (res == TEE_SUCCESS)
+				w3 = FFA_OK;
+			else
+				w3 = FFA_INVALID_PARAMETERS;
+		}
+		break;
 	case FFA_MSG_VERSION_REQ:
 		w0 = FFA_MSG_SEND_DIRECT_RESP_32;
 		w1 = swap_src_dst(args->a1);


### PR DESCRIPTION
Handles the previously missing FFA_MSG_SEND_VM_DESTROYED message used to signal the destruction of a non-secure guest. This is the counter part of FFA_MSG_SEND_VM_CREATED that is used to signal the creation of a non-secure guest.

Fixes: a65dd3a6b64d ("core: spmc: support virtualization with SPMC at S-EL1")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
