### PR TITLE
qemu_armv8a: fix build with CFG_USER_TA_TARGETS=ta_arm32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ include core/core.mk
 
 # Platform/arch config is supposed to assign the targets
 ta-targets ?= invalid
-default-user-ta-target ?= $(firstword $(ta-targets))
+$(call force,default-user-ta-target,$(firstword $(ta-targets)))
 
 ifeq ($(CFG_WITH_USER_TA),y)
 include ldelf/ldelf.mk

--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -23,7 +23,7 @@ endif #juno
 ifeq ($(PLATFORM_FLAVOR),qemu_armv8a)
 include core/arch/arm/cpu/cortex-armv8-0.mk
 CFG_ARM64_core ?= y
-default-user-ta-target ?= ta_arm64
+supported-ta-targets ?= ta_arm64 ta_arm32
 endif
 
 


### PR DESCRIPTION
The proper way to build in-tree TAs in 64-bit mode by default is to set supported-ta-targets to "ta_arm64 ta_arm32". Indeed, the default target is always defined as the first entry in supported-ta-targets, as documented in mk/config.mk.

Fixes the following build error:

 $ make CFG_USER_TA_TARGETS=ta_arm32 PLATFORM=vexpress-qemu_armv8a
 bash: -W: invalid option
 ...

default-user-ta-target is not to be used by the platform configuration files. It is meant to be set by the main Makefile. For this reason, replace the conditional assignment (?=) with $(call force, ...) in order to catch inconsistencies in a more friendly way.

Fixes: 07031b23de23 ("qemu_armv8a: set default-user-ta-target ?= ta_arm64")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
