### PR TITLE
core: tee_svc_cryp: report RSAES_PKCS1_OAEP_MGF1 bad hash ID

### DIFF
--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -4257,14 +4257,14 @@ TEE_Result syscall_asymm_operate(unsigned long state,
 				if (params[n].content.ref.length !=
 				    sizeof(hash)) {
 					res = TEE_ERROR_BAD_PARAMETERS;
-					break;
+					goto out;
 				}
 				memcpy(&hash, params[n].content.ref.buffer,
 				       sizeof(hash));
 				if (hash !=
 				    TEE_INTERNAL_HASH_TO_ALGO(cs->algo)) {
 					res = TEE_ERROR_NOT_SUPPORTED;
-					break;
+					goto out;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes syscall_asymm_operate() to report inconsistent hash algorithm specified as attribute for TEE_ALG_RSAES_PKCS1_OAEP_MGF1_* operations as OP-TEE only supports the hash predefined for the request algorithm TEE_ALG_RSAES_PKCS1_OAEP_MGF1_xxx.

Fixes: https://github.com/OP-TEE/optee_os/issues/6143

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
