### PR TITLE
RISC-V: Support device tree

### DIFF
--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -42,6 +42,26 @@ struct dt_descriptor {
 static struct dt_descriptor external_dt __nex_bss;
 #endif
 
+void *get_dt(void)
+{
+	void *fdt = get_embedded_dt();
+
+	if (!fdt)
+		fdt = get_external_dt();
+
+	return fdt;
+}
+
+void *get_secure_dt(void)
+{
+	void *fdt = get_embedded_dt();
+
+	if (!fdt && IS_ENABLED(CFG_MAP_EXT_DT_SECURE))
+		fdt = get_external_dt();
+
+	return fdt;
+}
+
 #if defined(CFG_EMBED_DTB)
 void *get_embedded_dt(void)
 {

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -42,6 +42,31 @@ struct dt_descriptor {
 static struct dt_descriptor external_dt __nex_bss;
 #endif
 
+#if defined(CFG_EMBED_DTB)
+void *get_embedded_dt(void)
+{
+	static bool checked;
+
+	assert(cpu_mmu_enabled());
+
+	if (!checked) {
+		IMSG("Embedded DTB found");
+
+		if (fdt_check_header(embedded_secure_dtb))
+			panic("Invalid embedded DTB");
+
+		checked = true;
+	}
+
+	return embedded_secure_dtb;
+}
+#else
+void *get_embedded_dt(void)
+{
+	return NULL;
+}
+#endif /*CFG_EMBED_DTB*/
+
 #if defined(CFG_DT)
 void *get_external_dt(void)
 {

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -123,6 +123,14 @@
 .endm
 
 FUNC _start , :
+	/*
+	 * Register use:
+	 * a0	- if non-NULL holds the hart ID
+	 * a1	- if non-NULL holds the system DTB address
+	 *
+	 * CSR_XSCRATCH - saved a0
+	 * s1 - saved a1
+	 */
 .option push
 .option norelax
 	la	gp, __global_pointer$
@@ -131,6 +139,11 @@ FUNC _start , :
 	csrr	a0, CSR_MHARTID
 #endif
 	csrw	CSR_XSCRATCH, a0
+#if defined(CFG_DT_ADDR)
+	li	s1, CFG_DT_ADDR
+#else
+	mv	s1, a1		/* Save DT address */
+#endif
 	bnez	a0, reset_secondary
 	jal	reset_primary
 	j	.
@@ -188,6 +201,8 @@ UNWIND(	.cantunwind)
 	mv	s3, a0
 	STR	x0, THREAD_CORE_LOCAL_FLAGS(s3)
 
+	mv	a0, s1		/* DT address */
+	mv	a1, x0		/* unused */
 	jal	boot_init_primary_late
 
 	/*


### PR DESCRIPTION
This series add support for device tree.
The device tree may be provided by early boot stage (i.e., M-mode firmware such as openSBI), or embedded in OP-TEE core.
RISC-V boot stage will initialize and update the device tree if it is necessary.
For example, add reserved-memory node for secure memory.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
