### PR TITLE
[v2] RISC-V: Support device tree

### DIFF
--- a/core/arch/arm/plat-sam/freq.c
+++ b/core/arch/arm/plat-sam/freq.c
@@ -7,6 +7,7 @@
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
 #include <kernel/boot.h>
+#include <kernel/dt.h>
 #include <kernel/panic.h>
 #include <libfdt.h>
 

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -13,6 +13,7 @@
 #include <io.h>
 #include <keep.h>
 #include <kernel/boot.h>
+#include <kernel/dt.h>
 #include <kernel/panic.h>
 #include <kernel/pm.h>
 #include <libfdt.h>

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
+ * Copyright (c) 2023 Andes Technology Corporation
  * Copyright 2022-2023 NXP
  */
 
@@ -9,6 +10,7 @@
 #include <console.h>
 #include <keep.h>
 #include <kernel/boot.h>
+#include <kernel/dt.h>
 #include <kernel/linker.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
@@ -30,6 +32,29 @@ paddr_t start_addr;
 unsigned long boot_args[4];
 
 uint32_t sem_cpu_sync[CFG_TEE_CORE_NB_CORE];
+
+#if defined(CFG_DT)
+static int mark_tddram_as_reserved(struct dt_descriptor *dt)
+{
+	return add_res_mem_dt_node(dt, "optee_core", CFG_TDDRAM_START,
+				   CFG_TDDRAM_SIZE);
+}
+
+static void update_external_dt(void)
+{
+	struct dt_descriptor *dt = get_external_dt_desc();
+
+	if (!dt || !dt->blob)
+		return;
+
+	if (mark_tddram_as_reserved(dt))
+		panic("Failed to config secure memory");
+}
+#else /*CFG_DT*/
+static void update_external_dt(void)
+{
+}
+#endif /*!CFG_DT*/
 
 void init_sec_mon(unsigned long nsec_entry __maybe_unused)
 {
@@ -107,9 +132,12 @@ void boot_init_primary_early(unsigned long pageable_part __unused,
 	init_primary(e);
 }
 
-void boot_init_primary_late(unsigned long fdt __unused,
+void boot_init_primary_late(unsigned long fdt,
 			    unsigned long tos_fw_config __unused)
 {
+	init_external_dt(fdt);
+	update_external_dt();
+
 	IMSG("OP-TEE version: %s", core_v_str);
 	if (IS_ENABLED(CFG_WARN_INSECURE)) {
 		IMSG("WARNING: This OP-TEE configuration might be insecure!");

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
+ * Copyright (c) 2023 Andes Technology Corporation
  * Copyright 2022-2023 NXP
  */
 
@@ -123,6 +124,14 @@
 .endm
 
 FUNC _start , :
+	/*
+	 * Register usage:
+	 * a0	- if non-NULL holds the hart ID
+	 * a1	- if non-NULL holds the system DTB address
+	 *
+	 * CSR_XSCRATCH - saved a0
+	 * s1 - saved a1
+	 */
 .option push
 .option norelax
 	la	gp, __global_pointer$
@@ -131,6 +140,11 @@ FUNC _start , :
 	csrr	a0, CSR_MHARTID
 #endif
 	csrw	CSR_XSCRATCH, a0
+#if defined(CFG_DT_ADDR)
+	li	s1, CFG_DT_ADDR
+#else
+	mv	s1, a1		/* Save device tree address into s1 */
+#endif
 	bnez	a0, reset_secondary
 	jal	reset_primary
 	j	.
@@ -188,6 +202,8 @@ UNWIND(	.cantunwind)
 	mv	s3, a0
 	STR	x0, THREAD_CORE_LOCAL_FLAGS(s3)
 
+	mv	a0, s1		/* s1 contains saved device tree address */
+	mv	a1, x0		/* unused */
 	jal	boot_init_primary_late
 
 	/*

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -8,6 +8,7 @@
 #include <drivers/clk_dt.h>
 #include <initcall.h>
 #include <kernel/boot.h>
+#include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <kernel/panic.h>
 #include <libfdt.h>

--- a/core/drivers/crypto/caam/hal/common/hal_cfg.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg.c
@@ -11,6 +11,7 @@
 #include <caam_jr.h>
 #include <config.h>
 #include <kernel/boot.h>
+#include <kernel/dt.h>
 #include <mm/core_memprot.h>
 #include <registers/jr_regs.h>
 

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -40,7 +40,6 @@ struct boot_embdata {
 	uint32_t reloc_len;
 };
 
-extern uint8_t embedded_secure_dtb[];
 extern const struct core_mmu_config boot_mmu_config;
 
 /* @nsec_entry is unused if using CFG_WITH_ARM_TRUSTED_FW */
@@ -92,26 +91,6 @@ int boot_core_release(size_t core_idx, paddr_t entry);
 struct ns_entry_context *boot_core_hpen(void);
 #endif
 
-/* Returns embedded DTB if present, then external DTB if found, then NULL */
-void *get_dt(void);
-
-/*
- * get_secure_dt() - returns secure DTB for drivers
- *
- * Returns device tree that is considered secure for drivers to use.
- *
- * 1. Returns embedded DTB if available,
- * 2. Secure external DTB if available,
- * 3. If neither then NULL
- */
-void *get_secure_dt(void);
-
-/* Returns embedded DTB location if present, otherwise NULL */
-void *get_embedded_dt(void);
-
-/* Returns external DTB if present, otherwise NULL */
-void *get_external_dt(void);
-
 /* Returns TOS_FW_CONFIG DTB if present, otherwise NULL */
 void *get_tos_fw_config_dt(void);
 
@@ -122,11 +101,5 @@ void *get_tos_fw_config_dt(void);
  * This function has a __weak default implementation.
  */
 unsigned long get_aslr_seed(void *fdt);
-
-/* Returns true if passed DTB is same as Embedded DTB, otherwise false */
-static inline bool is_embedded_dt(void *fdt)
-{
-	return fdt && fdt == get_embedded_dt();
-}
 
 #endif /* __KERNEL_BOOT_H */

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -74,6 +74,20 @@ enum dt_map_dev_directive {
 };
 
 /*
+ * struct dt_descriptor - Descriptor of the device tree
+ * @blob: Pointer to the device tree binary
+ * @frag_id: Used ID of fragments for device tree overlay
+ */
+struct dt_descriptor {
+	void *blob;
+#ifdef _CFG_USE_DTB_OVERLAY
+	int frag_id;
+#endif
+};
+
+extern uint8_t embedded_secure_dtb[];
+
+/*
  * dt_getprop_as_number() - get a DT property a unsigned number
  * @fdt: DT base address
  * @nodeoffset: node offset
@@ -224,6 +238,70 @@ int fdt_get_reg_props_by_index(const void *fdt, int node, int index,
 int fdt_get_reg_props_by_name(const void *fdt, int node, const char *name,
 			      paddr_t *base, size_t *size);
 
+/* Returns embedded DTB if present, then external DTB if found, then NULL */
+void *get_dt(void);
+
+/*
+ * get_secure_dt() - returns secure DTB for drivers
+ *
+ * Returns device tree that is considered secure for drivers to use.
+ *
+ * 1. Returns embedded DTB if available,
+ * 2. Secure external DTB if available,
+ * 3. If neither then NULL
+ */
+void *get_secure_dt(void);
+
+/* Returns embedded DTB location if present, otherwise NULL */
+void *get_embedded_dt(void);
+
+/* Returns true if passed DTB is same as Embedded DTB, otherwise false */
+static inline bool is_embedded_dt(void *fdt)
+{
+	return fdt && fdt == get_embedded_dt();
+}
+
+/* Returns DTB descriptor of the external DTB if present, otherwise NULL */
+struct dt_descriptor *get_external_dt_desc(void);
+
+/*
+ * init_external_dt() - Initialize the external DTB located at given address.
+ * @phys_dt:	Physical address where the external DTB located.
+ *
+ * Initialize the external DTB.
+ *
+ * 1. Add MMU mapping of the external DTB,
+ * 2. Initialize device tree overlay
+ */
+void init_external_dt(unsigned long phys_dt);
+
+/* Returns external DTB if present, otherwise NULL */
+void *get_external_dt(void);
+
+/*
+ * add_dt_path_subnode() - Add new child node into a parent node.
+ * @dt:		Pointer to a device tree descriptor which has DTB.
+ * @path:	Path to the parent node.
+ * @subnode:	Name of the child node.
+ *
+ * Returns the offset of the child node in DTB on success or a negative value
+ * upon error.
+ */
+int add_dt_path_subnode(struct dt_descriptor *dt, const char *path,
+			const char *subnode);
+
+/*
+ * add_res_mem_dt_node() - Create "reserved-memory" parent and child nodes.
+ * @dt:		Pointer to a device tree descriptor which has DTB.
+ * @name:	Name of the child node.
+ * @pa:		Physical address of specific reserved memory region.
+ * @size:	Size of specific reserved memory region.
+ *
+ * Returns 0 if succeeds, otherwise -1.
+ */
+int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
+			paddr_t pa, size_t size);
+
 #else /* !CFG_DT */
 
 static inline const struct dt_driver *dt_find_compatible_driver(
@@ -313,6 +391,55 @@ static inline int fdt_get_reg_props_by_name(const void *fdt __unused,
 					    const char *name __unused,
 					    paddr_t *base __unused,
 					    size_t *size __unused)
+{
+	return -1;
+}
+
+static inline void *get_dt(void)
+{
+	return NULL;
+}
+
+static inline void *get_secure_dt(void)
+{
+	return NULL;
+}
+
+static inline void *get_embedded_dt(void)
+{
+	return NULL;
+}
+
+static inline bool is_embedded_dt(void *fdt __unused)
+{
+	return false;
+}
+
+static inline struct dt_descriptor *get_external_dt_desc(void)
+{
+	return NULL;
+}
+
+static inline void init_external_dt(unsigned long phys_dt __unused)
+{
+}
+
+static inline void *get_external_dt(void)
+{
+	return NULL;
+}
+
+static inline int add_dt_path_subnode(struct dt_descriptor *dt __unused,
+				      const char *path __unused,
+				      const char *subnode __unused)
+{
+	return -1;
+}
+
+static inline int add_res_mem_dt_node(struct dt_descriptor *dt __unused,
+				      const char *name __unused,
+				      paddr_t pa __unused,
+				      size_t size __unused)
 {
 	return -1;
 }

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -284,8 +284,8 @@ void *get_external_dt(void);
  * @path:	Path to the parent node.
  * @subnode:	Name of the child node.
  *
- * Returns the offset of the child node in DTB on success or a negative value
- * upon error.
+ * Returns the offset of the child node in DTB on success or a negative libfdt
+ * error number.
  */
 int add_dt_path_subnode(struct dt_descriptor *dt, const char *path,
 			const char *subnode);
@@ -297,7 +297,7 @@ int add_dt_path_subnode(struct dt_descriptor *dt, const char *path,
  * @pa:		Physical address of specific reserved memory region.
  * @size:	Size of specific reserved memory region.
  *
- * Returns 0 if succeeds, otherwise -1.
+ * Returns 0 if succeeds, otherwise a negative libfdt error number.
  */
 int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
 			paddr_t pa, size_t size);

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -4,6 +4,8 @@
  */
 
 #include <assert.h>
+#include <config.h>
+#include <initcall.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <kernel/interrupt.h>
@@ -11,8 +13,11 @@
 #include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <stdio.h>
 #include <string.h>
 #include <trace.h>
+
+static struct dt_descriptor external_dt __nex_bss;
 
 const struct dt_driver *dt_find_compatible_driver(const void *fdt, int offs)
 {
@@ -436,4 +441,285 @@ int dt_getprop_as_number(const void *fdt, int nodeoffset, const char *name,
 	default:
 		return -FDT_ERR_BADVALUE;
 	}
+}
+
+void *get_dt(void)
+{
+	void *fdt = get_embedded_dt();
+
+	if (!fdt)
+		fdt = get_external_dt();
+
+	return fdt;
+}
+
+void *get_secure_dt(void)
+{
+	void *fdt = get_embedded_dt();
+
+	if (!fdt && IS_ENABLED(CFG_MAP_EXT_DT_SECURE))
+		fdt = get_external_dt();
+
+	return fdt;
+}
+
+#if defined(CFG_EMBED_DTB)
+void *get_embedded_dt(void)
+{
+	static bool checked;
+
+	assert(cpu_mmu_enabled());
+
+	if (!checked) {
+		IMSG("Embedded DTB found");
+
+		if (fdt_check_header(embedded_secure_dtb))
+			panic("Invalid embedded DTB");
+
+		checked = true;
+	}
+
+	return embedded_secure_dtb;
+}
+#else
+void *get_embedded_dt(void)
+{
+	return NULL;
+}
+#endif /*CFG_EMBED_DTB*/
+
+#ifdef _CFG_USE_DTB_OVERLAY
+static int add_dt_overlay_fragment(struct dt_descriptor *dt, int ioffs)
+{
+	char frag[32];
+	int offs;
+	int ret;
+
+	snprintf(frag, sizeof(frag), "fragment@%d", dt->frag_id);
+	offs = fdt_add_subnode(dt->blob, ioffs, frag);
+	if (offs < 0)
+		return offs;
+
+	dt->frag_id += 1;
+
+	ret = fdt_setprop_string(dt->blob, offs, "target-path", "/");
+	if (ret < 0)
+		return -1;
+
+	return fdt_add_subnode(dt->blob, offs, "__overlay__");
+}
+
+static int init_dt_overlay(struct dt_descriptor *dt, int __maybe_unused dt_size)
+{
+	int fragment;
+
+	if (IS_ENABLED(CFG_EXTERNAL_DTB_OVERLAY)) {
+		if (!fdt_check_header(dt->blob)) {
+			fdt_for_each_subnode(fragment, dt->blob, 0)
+				dt->frag_id += 1;
+			return 0;
+		}
+	}
+
+	return fdt_create_empty_tree(dt->blob, dt_size);
+}
+#else
+static int add_dt_overlay_fragment(struct dt_descriptor *dt __unused, int offs)
+{
+	return offs;
+}
+
+static int init_dt_overlay(struct dt_descriptor *dt __unused,
+			   int dt_size __unused)
+{
+	return 0;
+}
+#endif /* _CFG_USE_DTB_OVERLAY */
+
+struct dt_descriptor *get_external_dt_desc(void)
+{
+	if (!IS_ENABLED(CFG_EXTERNAL_DT))
+		return NULL;
+
+	return &external_dt;
+}
+
+void init_external_dt(unsigned long phys_dt)
+{
+	struct dt_descriptor *dt = &external_dt;
+	void *fdt;
+	int ret;
+
+	if (!IS_ENABLED(CFG_EXTERNAL_DT))
+		return;
+
+	if (!phys_dt) {
+		/*
+		 * No need to panic as we're not using the DT in OP-TEE
+		 * yet, we're only adding some nodes for normal world use.
+		 * This makes the switch to using DT easier as we can boot
+		 * a newer OP-TEE with older boot loaders. Once we start to
+		 * initialize devices based on DT we'll likely panic
+		 * instead of returning here.
+		 */
+		IMSG("No non-secure external DT");
+		return;
+	}
+
+	fdt = core_mmu_add_mapping(MEM_AREA_EXT_DT, phys_dt, CFG_DTB_MAX_SIZE);
+	if (!fdt)
+		panic("Failed to map external DTB");
+
+	dt->blob = fdt;
+
+	ret = init_dt_overlay(dt, CFG_DTB_MAX_SIZE);
+	if (ret < 0) {
+		EMSG("Device Tree Overlay init fail @ %#lx: error %d", phys_dt,
+		     ret);
+		panic();
+	}
+
+	ret = fdt_open_into(fdt, fdt, CFG_DTB_MAX_SIZE);
+	if (ret < 0) {
+		EMSG("Invalid Device Tree at %#lx: error %d", phys_dt, ret);
+		panic();
+	}
+
+	IMSG("Non-secure external DT found");
+}
+
+void *get_external_dt(void)
+{
+	if (!IS_ENABLED(CFG_EXTERNAL_DT))
+		return NULL;
+
+	assert(cpu_mmu_enabled());
+	return external_dt.blob;
+}
+
+static TEE_Result release_external_dt(void)
+{
+	int ret = 0;
+
+	if (!IS_ENABLED(CFG_EXTERNAL_DT))
+		return TEE_SUCCESS;
+
+	if (!external_dt.blob)
+		return TEE_SUCCESS;
+
+	ret = fdt_pack(external_dt.blob);
+	if (ret < 0) {
+		EMSG("Failed to pack Device Tree at 0x%" PRIxPA ": error %d",
+		     virt_to_phys(external_dt.blob), ret);
+		panic();
+	}
+
+	if (core_mmu_remove_mapping(MEM_AREA_EXT_DT, external_dt.blob,
+				    CFG_DTB_MAX_SIZE))
+		panic("Failed to remove temporary Device Tree mapping");
+
+	/* External DTB no more reached, reset pointer to invalid */
+	external_dt.blob = NULL;
+
+	return TEE_SUCCESS;
+}
+
+boot_final(release_external_dt);
+
+int add_dt_path_subnode(struct dt_descriptor *dt, const char *path,
+			const char *subnode)
+{
+	int offs;
+
+	offs = fdt_path_offset(dt->blob, path);
+	if (offs < 0)
+		return -1;
+	offs = add_dt_overlay_fragment(dt, offs);
+	if (offs < 0)
+		return -1;
+	offs = fdt_add_subnode(dt->blob, offs, subnode);
+	if (offs < 0)
+		return -1;
+	return offs;
+}
+
+static void set_dt_val(void *data, uint32_t cell_size, uint64_t val)
+{
+	if (cell_size == 1) {
+		fdt32_t v = cpu_to_fdt32((uint32_t)val);
+
+		memcpy(data, &v, sizeof(v));
+	} else {
+		fdt64_t v = cpu_to_fdt64(val);
+
+		memcpy(data, &v, sizeof(v));
+	}
+}
+
+int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
+			paddr_t pa, size_t size)
+{
+	int offs = 0;
+	int ret = 0;
+	int addr_size = -1;
+	int len_size = -1;
+	bool found = true;
+	char subnode_name[80] = { 0 };
+
+	offs = fdt_path_offset(dt->blob, "/reserved-memory");
+
+	if (offs < 0) {
+		found = false;
+		offs = 0;
+	}
+
+	if (IS_ENABLED2(_CFG_USE_DTB_OVERLAY)) {
+		len_size = sizeof(paddr_t) / sizeof(uint32_t);
+		addr_size = sizeof(paddr_t) / sizeof(uint32_t);
+	} else {
+		len_size = fdt_size_cells(dt->blob, offs);
+		if (len_size < 0)
+			return -1;
+		addr_size = fdt_address_cells(dt->blob, offs);
+		if (addr_size < 0)
+			return -1;
+	}
+
+	if (!found) {
+		offs = add_dt_path_subnode(dt, "/", "reserved-memory");
+		if (offs < 0)
+			return -1;
+		ret = fdt_setprop_cell(dt->blob, offs, "#address-cells",
+				       addr_size);
+		if (ret < 0)
+			return -1;
+		ret = fdt_setprop_cell(dt->blob, offs, "#size-cells", len_size);
+		if (ret < 0)
+			return -1;
+		ret = fdt_setprop(dt->blob, offs, "ranges", NULL, 0);
+		if (ret < 0)
+			return -1;
+	}
+
+	ret = snprintf(subnode_name, sizeof(subnode_name),
+		       "%s@%" PRIxPA, name, pa);
+	if (ret < 0 || ret >= (int)sizeof(subnode_name))
+		DMSG("truncated node \"%s@%" PRIxPA"\"", name, pa);
+	offs = fdt_add_subnode(dt->blob, offs, subnode_name);
+	if (offs >= 0) {
+		uint32_t data[FDT_MAX_NCELLS * 2];
+
+		set_dt_val(data, addr_size, pa);
+		set_dt_val(data + addr_size, len_size, size);
+		ret = fdt_setprop(dt->blob, offs, "reg", data,
+				  sizeof(uint32_t) * (addr_size + len_size));
+		if (ret < 0)
+			return -1;
+		ret = fdt_setprop(dt->blob, offs, "no-map", NULL, 0);
+		if (ret < 0)
+			return -1;
+	} else {
+		return -1;
+	}
+	return 0;
 }


### PR DESCRIPTION
This PR is version 2 of https://github.com/OP-TEE/optee_os/pull/6147.
Since some existed device tree functions in ARM can also be used by other architectures,
we create `core/kernel/boot.c` to move those functions into it.

Now RISC-V can get the external device tree provided by early boot stage.
And invoke aforementioned device tree functions to utilize the DTB.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
