### PR TITLE
core: crypto_bignum_free(): add indirection and set pointer to NULL

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -528,9 +528,9 @@ void crypto_bignum_copy(struct bignum *to __unused,
 	bignum_cant_happen();
 }
 
-void crypto_bignum_free(struct bignum *a)
+void crypto_bignum_free(struct bignum **a)
 {
-	if (a)
+	if (a && *a)
 		panic();
 }
 

--- a/core/drivers/crypto/caam/acipher/caam_dh.c
+++ b/core/drivers/crypto/caam/acipher/caam_dh.c
@@ -195,10 +195,10 @@ static TEE_Result do_allocate_keypair(struct dh_keypair *key, size_t size_bits)
 err:
 	DH_TRACE("Allocation error");
 
-	crypto_bignum_free(key->g);
-	crypto_bignum_free(key->p);
-	crypto_bignum_free(key->x);
-	crypto_bignum_free(key->y);
+	crypto_bignum_free(&key->g);
+	crypto_bignum_free(&key->p);
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }

--- a/core/drivers/crypto/caam/acipher/caam_dsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_dsa.c
@@ -309,10 +309,10 @@ static TEE_Result do_allocate_keypair(struct dsa_keypair *key, size_t l_bits,
 err:
 	DSA_TRACE("Allocation error");
 
-	crypto_bignum_free(key->g);
-	crypto_bignum_free(key->p);
-	crypto_bignum_free(key->q);
-	crypto_bignum_free(key->x);
+	crypto_bignum_free(&key->g);
+	crypto_bignum_free(&key->p);
+	crypto_bignum_free(&key->q);
+	crypto_bignum_free(&key->x);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -358,9 +358,9 @@ static TEE_Result do_allocate_publickey(struct dsa_public_key *key,
 err:
 	DSA_TRACE("Allocation error");
 
-	crypto_bignum_free(key->g);
-	crypto_bignum_free(key->p);
-	crypto_bignum_free(key->q);
+	crypto_bignum_free(&key->g);
+	crypto_bignum_free(&key->p);
+	crypto_bignum_free(&key->q);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }

--- a/core/drivers/crypto/caam/acipher/caam_ecc.c
+++ b/core/drivers/crypto/caam/acipher/caam_ecc.c
@@ -171,8 +171,8 @@ static TEE_Result do_allocate_keypair(struct ecc_keypair *key,
 err:
 	ECC_TRACE("Allocation error");
 
-	crypto_bignum_free(key->d);
-	crypto_bignum_free(key->x);
+	crypto_bignum_free(&key->d);
+	crypto_bignum_free(&key->x);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -207,7 +207,7 @@ static TEE_Result do_allocate_publickey(struct ecc_public_key *key,
 err:
 	ECC_TRACE("Allocation error");
 
-	crypto_bignum_free(key->x);
+	crypto_bignum_free(&key->x);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -219,8 +219,8 @@ err:
  */
 static void do_free_publickey(struct ecc_public_key *key)
 {
-	crypto_bignum_free(key->x);
-	crypto_bignum_free(key->y);
+	crypto_bignum_free(&key->x);
+	crypto_bignum_free(&key->y);
 }
 
 /*

--- a/core/drivers/crypto/caam/acipher/caam_rsa.c
+++ b/core/drivers/crypto/caam/acipher/caam_rsa.c
@@ -86,14 +86,14 @@ static uint8_t caam_era;
  */
 static void do_free_keypair(struct rsa_keypair *key)
 {
-	crypto_bignum_free(key->e);
-	crypto_bignum_free(key->d);
-	crypto_bignum_free(key->n);
-	crypto_bignum_free(key->p);
-	crypto_bignum_free(key->q);
-	crypto_bignum_free(key->qp);
-	crypto_bignum_free(key->dp);
-	crypto_bignum_free(key->dq);
+	crypto_bignum_free(&key->e);
+	crypto_bignum_free(&key->d);
+	crypto_bignum_free(&key->n);
+	crypto_bignum_free(&key->p);
+	crypto_bignum_free(&key->q);
+	crypto_bignum_free(&key->qp);
+	crypto_bignum_free(&key->dp);
+	crypto_bignum_free(&key->dq);
 }
 
 /*
@@ -435,8 +435,8 @@ static TEE_Result do_allocate_publickey(struct rsa_public_key *key,
 err_alloc_publickey:
 	RSA_TRACE("Allocation error");
 
-	crypto_bignum_free(key->e);
-	crypto_bignum_free(key->n);
+	crypto_bignum_free(&key->e);
+	crypto_bignum_free(&key->n);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -448,8 +448,8 @@ err_alloc_publickey:
  */
 static void do_free_publickey(struct rsa_public_key *key)
 {
-	crypto_bignum_free(key->e);
-	crypto_bignum_free(key->n);
+	crypto_bignum_free(&key->e);
+	crypto_bignum_free(&key->n);
 }
 
 /*

--- a/core/drivers/crypto/se050/core/ecc.c
+++ b/core/drivers/crypto/se050/core/ecc.c
@@ -743,9 +743,9 @@ static TEE_Result do_alloc_keypair(struct ecc_keypair *s, uint32_t type,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->x);
-	crypto_bignum_free(s->y);
+	crypto_bignum_free(&s->d);
+	crypto_bignum_free(&s->x);
+	crypto_bignum_free(&s->y);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -764,8 +764,8 @@ static TEE_Result do_alloc_publickey(struct ecc_public_key *s, uint32_t type,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->x);
-	crypto_bignum_free(s->y);
+	crypto_bignum_free(&s->x);
+	crypto_bignum_free(&s->y);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -774,8 +774,8 @@ static void do_free_publickey(struct ecc_public_key *s)
 	if (!s)
 		return;
 
-	crypto_bignum_free(s->x);
-	crypto_bignum_free(s->y);
+	crypto_bignum_free(&s->x);
+	crypto_bignum_free(&s->y);
 }
 
 static struct drvcrypt_ecc driver_ecc = {

--- a/core/drivers/crypto/se050/core/rsa.c
+++ b/core/drivers/crypto/se050/core/rsa.c
@@ -537,14 +537,14 @@ static TEE_Result do_alloc_keypair(struct rsa_keypair *s,
 
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->e);
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->n);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->q);
-	crypto_bignum_free(s->qp);
-	crypto_bignum_free(s->dp);
-	crypto_bignum_free(s->dq);
+	crypto_bignum_free(&s->e);
+	crypto_bignum_free(&s->d);
+	crypto_bignum_free(&s->n);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->q);
+	crypto_bignum_free(&s->qp);
+	crypto_bignum_free(&s->dp);
+	crypto_bignum_free(&s->dq);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -556,7 +556,7 @@ static TEE_Result do_alloc_publickey(struct rsa_public_key *s,
 	if (!bn_alloc_max(&s->e))
 		return TEE_ERROR_OUT_OF_MEMORY;
 	if (!bn_alloc_max(&s->n)) {
-		crypto_bignum_free(s->e);
+		crypto_bignum_free(&s->e);
 		return TEE_ERROR_OUT_OF_MEMORY;
 	}
 
@@ -566,8 +566,8 @@ static TEE_Result do_alloc_publickey(struct rsa_public_key *s,
 static void do_free_publickey(struct rsa_public_key *s)
 {
 	if (s) {
-		crypto_bignum_free(s->n);
-		crypto_bignum_free(s->e);
+		crypto_bignum_free(&s->n);
+		crypto_bignum_free(&s->e);
 	}
 }
 
@@ -587,14 +587,14 @@ static void do_free_keypair(struct rsa_keypair *s)
 			sss_se05x_key_store_erase_key(se050_kstore, &k_object);
 	}
 
-	crypto_bignum_free(s->e);
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->n);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->q);
-	crypto_bignum_free(s->qp);
-	crypto_bignum_free(s->dp);
-	crypto_bignum_free(s->dq);
+	crypto_bignum_free(&s->e);
+	crypto_bignum_free(&s->d);
+	crypto_bignum_free(&s->n);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->q);
+	crypto_bignum_free(&s->qp);
+	crypto_bignum_free(&s->dp);
+	crypto_bignum_free(&s->dq);
 }
 
 static TEE_Result do_gen_keypair(struct rsa_keypair *key, size_t kb)

--- a/core/drivers/crypto/versal/ecc.c
+++ b/core/drivers/crypto/versal/ecc.c
@@ -271,9 +271,9 @@ static TEE_Result sign(uint32_t algo, struct ecc_keypair *key,
 
 	versal_mbox_alloc(bytes, NULL, &k);
 	crypto_bignum_bn2bin_eswap(key->curve, ephemeral.d, k.buf);
-	crypto_bignum_free(ephemeral.d);
-	crypto_bignum_free(ephemeral.x);
-	crypto_bignum_free(ephemeral.y);
+	crypto_bignum_free(&ephemeral.d);
+	crypto_bignum_free(&ephemeral.x);
+	crypto_bignum_free(&ephemeral.y);
 
 	/* Private key*/
 	versal_mbox_alloc(bytes, NULL, &d);

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -98,7 +98,7 @@ size_t crypto_bignum_num_bytes(struct bignum *a);
 size_t crypto_bignum_num_bits(struct bignum *a);
 void crypto_bignum_bn2bin(const struct bignum *from, uint8_t *to);
 void crypto_bignum_copy(struct bignum *to, const struct bignum *from);
-void crypto_bignum_free(struct bignum *a);
+void crypto_bignum_free(struct bignum **a);
 void crypto_bignum_clear(struct bignum *a);
 
 /* return -1 if a<b, 0 if a==b, +1 if a>b */

--- a/core/lib/libtomcrypt/dh.c
+++ b/core/lib/libtomcrypt/dh.c
@@ -28,10 +28,10 @@ TEE_Result crypto_acipher_alloc_dh_keypair(struct dh_keypair *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->g);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->y);
-	crypto_bignum_free(s->x);
+	crypto_bignum_free(&s->g);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->y);
+	crypto_bignum_free(&s->x);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 

--- a/core/lib/libtomcrypt/dsa.c
+++ b/core/lib/libtomcrypt/dsa.c
@@ -30,10 +30,10 @@ TEE_Result crypto_acipher_alloc_dsa_keypair(struct dsa_keypair *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->g);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->q);
-	crypto_bignum_free(s->y);
+	crypto_bignum_free(&s->g);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->q);
+	crypto_bignum_free(&s->y);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -52,9 +52,9 @@ TEE_Result crypto_acipher_alloc_dsa_public_key(struct dsa_public_key *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->g);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->q);
+	crypto_bignum_free(&s->g);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->q);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 

--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -18,8 +18,8 @@ static void _ltc_ecc_free_public_key(struct ecc_public_key *s)
 	if (!s)
 		return;
 
-	crypto_bignum_free(s->x);
-	crypto_bignum_free(s->y);
+	crypto_bignum_free(&s->x);
+	crypto_bignum_free(&s->y);
 }
 
 /*
@@ -460,8 +460,8 @@ TEE_Result crypto_asym_alloc_ecc_keypair(struct ecc_keypair *s,
 err:
 	s->ops = NULL;
 
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->x);
+	crypto_bignum_free(&s->d);
+	crypto_bignum_free(&s->x);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -536,7 +536,7 @@ TEE_Result crypto_asym_alloc_ecc_public_key(struct ecc_public_key *s,
 err:
 	s->ops = NULL;
 
-	crypto_bignum_free(s->x);
+	crypto_bignum_free(&s->x);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }

--- a/core/lib/libtomcrypt/mpi_desc.c
+++ b/core/lib/libtomcrypt/mpi_desc.c
@@ -763,10 +763,13 @@ struct bignum *crypto_bignum_allocate(size_t size_bits)
 	return (struct bignum *)bn;
 }
 
-void crypto_bignum_free(struct bignum *s)
+void crypto_bignum_free(struct bignum **s)
 {
-	mbedtls_mpi_free((mbedtls_mpi *)s);
-	free(s);
+	assert(s);
+
+	mbedtls_mpi_free((mbedtls_mpi *)*s);
+	free(*s);
+	*s = NULL;
 }
 
 void crypto_bignum_clear(struct bignum *s)

--- a/core/lib/libtomcrypt/rsa.c
+++ b/core/lib/libtomcrypt/rsa.c
@@ -133,7 +133,7 @@ TEE_Result sw_crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->e);
+	crypto_bignum_free(&s->e);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -145,8 +145,8 @@ void sw_crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 {
 	if (!s)
 		return;
-	crypto_bignum_free(s->n);
-	crypto_bignum_free(s->e);
+	crypto_bignum_free(&s->n);
+	crypto_bignum_free(&s->e);
 }
 
 
@@ -157,14 +157,14 @@ void sw_crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
 {
 	if (!s)
 		return;
-	crypto_bignum_free(s->e);
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->n);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->q);
-	crypto_bignum_free(s->qp);
-	crypto_bignum_free(s->dp);
-	crypto_bignum_free(s->dq);
+	crypto_bignum_free(&s->e);
+	crypto_bignum_free(&s->d);
+	crypto_bignum_free(&s->n);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->q);
+	crypto_bignum_free(&s->qp);
+	crypto_bignum_free(&s->dp);
+	crypto_bignum_free(&s->dq);
 }
 
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key,

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -899,8 +899,7 @@ static void op_attr_bignum_free(void *attr)
 {
 	struct bignum **bn = attr;
 
-	crypto_bignum_free(*bn);
-	*bn = NULL;
+	crypto_bignum_free(bn);
 }
 
 static TEE_Result op_attr_value_from_user(void *attr, const void *buffer,
@@ -3557,8 +3556,8 @@ TEE_Result syscall_cryp_derive_key(unsigned long state,
 		} else {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 		}
-		crypto_bignum_free(pub);
-		crypto_bignum_free(ss);
+		crypto_bignum_free(&pub);
+		crypto_bignum_free(&ss);
 	} else if (cs->algo == TEE_ALG_ECDH_DERIVE_SHARED_SECRET) {
 		uint32_t curve = ((struct ecc_keypair *)ko->attr)->curve;
 		struct ecc_public_key key_public = { };

--- a/lib/libmbedtls/core/bignum.c
+++ b/lib/libmbedtls/core/bignum.c
@@ -87,10 +87,13 @@ struct bignum *crypto_bignum_allocate(size_t size_bits)
 	return (struct bignum *)bn;
 }
 
-void crypto_bignum_free(struct bignum *s)
+void crypto_bignum_free(struct bignum **s)
 {
-	mbedtls_mpi_free((mbedtls_mpi *)s);
-	free(s);
+	assert(s);
+
+	mbedtls_mpi_free((mbedtls_mpi *)*s);
+	free(*s);
+	*s = NULL;
 }
 
 void crypto_bignum_clear(struct bignum *s)

--- a/lib/libmbedtls/core/dh.c
+++ b/lib/libmbedtls/core/dh.c
@@ -35,10 +35,10 @@ TEE_Result crypto_acipher_alloc_dh_keypair(struct dh_keypair *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->g);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->y);
-	crypto_bignum_free(s->x);
+	crypto_bignum_free(&s->g);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->y);
+	crypto_bignum_free(&s->x);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 

--- a/lib/libmbedtls/core/ecc.c
+++ b/lib/libmbedtls/core/ecc.c
@@ -40,8 +40,8 @@ static void ecc_free_public_key(struct ecc_public_key *s)
 	if (!s)
 		return;
 
-	crypto_bignum_free(s->x);
-	crypto_bignum_free(s->y);
+	crypto_bignum_free(&s->x);
+	crypto_bignum_free(&s->y);
 }
 
 static TEE_Result ecc_get_keysize(uint32_t curve, uint32_t algo,
@@ -461,8 +461,8 @@ TEE_Result crypto_asym_alloc_ecc_keypair(struct ecc_keypair *s,
 	return TEE_SUCCESS;
 
 err:
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->x);
+	crypto_bignum_free(&s->d);
+	crypto_bignum_free(&s->x);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
@@ -558,7 +558,7 @@ TEE_Result crypto_asym_alloc_ecc_public_key(struct ecc_public_key *s,
 	return TEE_SUCCESS;
 
 err:
-	crypto_bignum_free(s->x);
+	crypto_bignum_free(&s->x);
 
 	return TEE_ERROR_OUT_OF_MEMORY;
 }

--- a/lib/libmbedtls/core/rsa.c
+++ b/lib/libmbedtls/core/rsa.c
@@ -185,7 +185,7 @@ TEE_Result sw_crypto_acipher_alloc_rsa_public_key(struct rsa_public_key *s,
 		goto err;
 	return TEE_SUCCESS;
 err:
-	crypto_bignum_free(s->e);
+	crypto_bignum_free(&s->e);
 	return TEE_ERROR_OUT_OF_MEMORY;
 }
 
@@ -196,8 +196,8 @@ void sw_crypto_acipher_free_rsa_public_key(struct rsa_public_key *s)
 {
 	if (!s)
 		return;
-	crypto_bignum_free(s->n);
-	crypto_bignum_free(s->e);
+	crypto_bignum_free(&s->n);
+	crypto_bignum_free(&s->e);
 }
 
 void crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
@@ -207,14 +207,14 @@ void sw_crypto_acipher_free_rsa_keypair(struct rsa_keypair *s)
 {
 	if (!s)
 		return;
-	crypto_bignum_free(s->e);
-	crypto_bignum_free(s->d);
-	crypto_bignum_free(s->n);
-	crypto_bignum_free(s->p);
-	crypto_bignum_free(s->q);
-	crypto_bignum_free(s->qp);
-	crypto_bignum_free(s->dp);
-	crypto_bignum_free(s->dq);
+	crypto_bignum_free(&s->e);
+	crypto_bignum_free(&s->d);
+	crypto_bignum_free(&s->n);
+	crypto_bignum_free(&s->p);
+	crypto_bignum_free(&s->q);
+	crypto_bignum_free(&s->qp);
+	crypto_bignum_free(&s->dp);
+	crypto_bignum_free(&s->dq);
 }
 
 TEE_Result crypto_acipher_gen_rsa_key(struct rsa_keypair *key,


### PR DESCRIPTION
To prevent human mistake, crypto_bignum_free() sets the location of the bignum pointer to NULL after freeing it.



Reviewed-by: Jerome Forissier <jerome.forissier@linaro.org>
Reviewed-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
