### PR TITLE
mk/aosp_optee.mk: fix build dependency between a TA and its libraries

### DIFF
--- a/mk/aosp_optee.mk
+++ b/mk/aosp_optee.mk
@@ -103,14 +103,14 @@ endif
 ifneq (false,$(INCLUDE_FOR_BUILD_TA))
 include $(CLEAR_VARS)
 
+define ta_class
+$(if $(filter %.ta,$1),EXECUTABLES,STATIC_LIBRARIES)
+endef
+
 LOCAL_MODULE := $(local_module)
 LOCAL_PREBUILT_MODULE_FILE := $(OPTEE_TA_OUT_DIR)/$(LOCAL_MODULE)
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib/optee_armtz
-ifneq ($(filter %.ta, $(local_module)),)
-LOCAL_MODULE_CLASS := EXECUTABLES
-else
-LOCAL_MODULE_CLASS := STATIC_LIBRARIES
-endif
+LOCAL_MODULE_CLASS := $(call ta_class,$(local_module))
 LOCAL_MODULE_TAGS := optional
 LOCAL_REQUIRED_MODULES := $(local_module_deps)
 
@@ -120,6 +120,11 @@ $(LOCAL_PREBUILT_MODULE_FILE): $(TA_TMP_FILE)
 	@mkdir -p $(dir $@)
 	cp -vf $< $@
 
+TA_TMP_FILE_DEPS :=
+ifneq ($(local_module_deps),)
+$(foreach dep, $(local_module_deps), $(eval TA_TMP_FILE_DEPS += $(call intermediates-dir-for,$(call ta_class,$(dep)),$(dep))/$(dep)))
+endif
+$(TA_TMP_FILE): $(TA_TMP_FILE_DEPS)
 $(TA_TMP_FILE): PRIVATE_TA_SRC_DIR := $(LOCAL_PATH)
 $(TA_TMP_FILE): PRIVATE_TA_TMP_FILE := $(TA_TMP_FILE)
 $(TA_TMP_FILE): PRIVATE_TA_TMP_DIR := $(TA_TMP_DIR)


### PR DESCRIPTION
The LOCAL_REQUIRED_MODULES proposed by the commit [1] creates the dependency for the specified modules and product to make sure they are installed to the product image. But it doesn't create the dependency between a TA and its libraries for build process to correctly link them. Add the dependency back and change the depended file to the result file in the intermediate directory instead of the installation directory.

Fixes: fb66b364b5d2 ("mk/aosp_optee.mk: fix build dependency for static libraries")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
