### PR TITLE
crypto: add X448 algorithm framework code and rename struct x25519_keypair. 

### DIFF
--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -859,6 +859,31 @@ TEE_Result crypto_acipher_x25519_shared_secret(struct montgomery_keypair
 }
 #endif
 
+#if !defined(CFG_CRYPTO_X448)
+TEE_Result crypto_acipher_alloc_x448_keypair(struct montgomery_keypair *key
+						       __unused,
+					       size_t key_size_bits __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_gen_x448_key(struct montgomery_keypair *key __unused,
+				       size_t key_size __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result crypto_acipher_x448_shared_secret(struct montgomery_keypair
+					     *private_key __unused,
+					     void *public_key __unused,
+					     void *secret __unused,
+					     unsigned long
+					     *secret_len __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif
+
 #if !defined(CFG_CRYPTO_ED25519)
 TEE_Result crypto_acipher_alloc_ed25519_keypair(struct ed25519_keypair *key
 								 __unused,

--- a/core/crypto/crypto.c
+++ b/core/crypto/crypto.c
@@ -834,20 +834,21 @@ TEE_Result crypto_acipher_sm2_kep_derive(struct ecc_keypair *my_key __unused,
 #endif
 
 #if !defined(CFG_CRYPTO_X25519)
-TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *key
+TEE_Result crypto_acipher_alloc_x25519_keypair(struct montgomery_keypair *key
 								__unused,
 					       size_t key_size_bits __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
-TEE_Result crypto_acipher_gen_x25519_key(struct x25519_keypair *key __unused,
+TEE_Result crypto_acipher_gen_x25519_key(struct montgomery_keypair
+					 *key __unused,
 					 size_t key_size __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }
 
-TEE_Result crypto_acipher_x25519_shared_secret(struct x25519_keypair
+TEE_Result crypto_acipher_x25519_shared_secret(struct montgomery_keypair
 					       *private_key __unused,
 					       void *public_key __unused,
 					       void *secret __unused,

--- a/core/drivers/crypto/crypto_api/include/drvcrypt.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt.h
@@ -55,6 +55,8 @@ enum drvcrypt_algo_id {
 	CRYPTO_MATH,	 /* Mathematical driver */
 	CRYPTO_CIPHER,   /* Cipher driver */
 	CRYPTO_ECC,      /* Asymmetric ECC driver */
+	CRYPTO_X25519,   /* Asymmetric X25519 driver */
+	CRYPTO_X448,    /* Asymmetric X448 driver */
 	CRYPTO_DH,       /* Asymmetric DH driver */
 	CRYPTO_DSA,	 /* Asymmetric DSA driver */
 	CRYPTO_AUTHENC,  /* Authenticated Encryption driver */

--- a/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
+++ b/core/drivers/crypto/crypto_api/include/drvcrypt_acipher.h
@@ -234,4 +234,40 @@ static inline TEE_Result drvcrypt_register_dsa(struct drvcrypt_dsa *ops)
 	return drvcrypt_register(CRYPTO_DSA, (void *)ops);
 }
 
+/*
+ * Crypto Library Montgomery driver operations
+ */
+
+struct drvcrypt_montgomery {
+	/* Allocates the Montgomery key pair */
+	TEE_Result (*alloc_keypair)(struct montgomery_keypair *key,
+				    size_t size_bits);
+	/* Generates the Montgomery key pair */
+	TEE_Result (*gen_keypair)(struct montgomery_keypair *key,
+				  size_t key_size);
+	/* Montgomery Shared Secret */
+	TEE_Result (*shared_secret)(struct drvcrypt_secret_data *sdata);
+};
+
+/*
+ * Register a X25519 processing driver in the crypto API
+ *
+ * @ops - Driver operations in the HW layer
+ */
+static inline TEE_Result drvcrypt_register_x25519(struct drvcrypt_montgomery
+						  *ops)
+{
+	return drvcrypt_register(CRYPTO_X25519, (void *)ops);
+}
+
+/*
+ * Register a X448 processing driver in the crypto API
+ *
+ * @ops - Driver operations in the HW layer
+ */
+static inline TEE_Result drvcrypt_register_x448(struct drvcrypt_montgomery *ops)
+{
+	return drvcrypt_register(CRYPTO_X448, (void *)ops);
+}
+
 #endif /* __DRVCRYPT_ACIPHER_H__ */

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -210,6 +210,8 @@ TEE_Result crypto_acipher_alloc_ecc_keypair(struct ecc_keypair *s,
 void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s);
 TEE_Result crypto_acipher_alloc_x25519_keypair(struct montgomery_keypair *s,
 					       size_t key_size_bits);
+TEE_Result crypto_acipher_alloc_x448_keypair(struct montgomery_keypair *s,
+					     size_t key_size_bits);
 TEE_Result crypto_acipher_alloc_ed25519_keypair(struct ed25519_keypair *s,
 						size_t key_size_bits);
 TEE_Result
@@ -226,6 +228,8 @@ TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
 TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key, size_t key_size);
 TEE_Result crypto_acipher_gen_x25519_key(struct montgomery_keypair *key,
 					 size_t key_size);
+TEE_Result crypto_acipher_gen_x448_key(struct montgomery_keypair *key,
+				       size_t key_size);
 TEE_Result crypto_acipher_gen_ed25519_key(struct ed25519_keypair *key,
 					  size_t key_size);
 TEE_Result crypto_acipher_ed25519_sign(struct ed25519_keypair *key,
@@ -298,6 +302,10 @@ TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key,
 					  uint8_t *dst, size_t *dst_len);
 TEE_Result crypto_acipher_x25519_shared_secret(struct montgomery_keypair
 					       *private_key,
+					       void *public_key, void *secret,
+					       unsigned long *secret_len);
+TEE_Result crypto_acipher_x448_shared_secret(struct montgomery_keypair
+						       *private_key,
 					       void *public_key, void *secret,
 					       unsigned long *secret_len);
 

--- a/core/include/crypto/crypto.h
+++ b/core/include/crypto/crypto.h
@@ -168,7 +168,7 @@ struct ecc_keypair {
 	const struct crypto_ecc_keypair_ops *ops; /* Key Operations */
 };
 
-struct x25519_keypair {
+struct montgomery_keypair {
 	uint8_t *priv;	/* Private value */
 	uint8_t *pub;	/* Public value */
 };
@@ -208,7 +208,7 @@ TEE_Result crypto_acipher_alloc_ecc_keypair(struct ecc_keypair *s,
 					    uint32_t key_type,
 					    size_t key_size_bits);
 void crypto_acipher_free_ecc_public_key(struct ecc_public_key *s);
-TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *s,
+TEE_Result crypto_acipher_alloc_x25519_keypair(struct montgomery_keypair *s,
 					       size_t key_size_bits);
 TEE_Result crypto_acipher_alloc_ed25519_keypair(struct ed25519_keypair *s,
 						size_t key_size_bits);
@@ -224,7 +224,7 @@ TEE_Result crypto_acipher_gen_dsa_key(struct dsa_keypair *key, size_t key_size);
 TEE_Result crypto_acipher_gen_dh_key(struct dh_keypair *key, struct bignum *q,
 				     size_t xbits, size_t key_size);
 TEE_Result crypto_acipher_gen_ecc_key(struct ecc_keypair *key, size_t key_size);
-TEE_Result crypto_acipher_gen_x25519_key(struct x25519_keypair *key,
+TEE_Result crypto_acipher_gen_x25519_key(struct montgomery_keypair *key,
 					 size_t key_size);
 TEE_Result crypto_acipher_gen_ed25519_key(struct ed25519_keypair *key,
 					  size_t key_size);
@@ -296,7 +296,7 @@ TEE_Result crypto_acipher_sm2_pke_decrypt(struct ecc_keypair *key,
 TEE_Result crypto_acipher_sm2_pke_encrypt(struct ecc_public_key *key,
 					  const uint8_t *src, size_t src_len,
 					  uint8_t *dst, size_t *dst_len);
-TEE_Result crypto_acipher_x25519_shared_secret(struct x25519_keypair
+TEE_Result crypto_acipher_x25519_shared_secret(struct montgomery_keypair
 					       *private_key,
 					       void *public_key, void *secret,
 					       unsigned long *secret_len);

--- a/core/lib/libtomcrypt/x25519.c
+++ b/core/lib/libtomcrypt/x25519.c
@@ -16,7 +16,7 @@
 /* X25519 key is an octet string of 32 bytes */
 #define X25519_KEY_SIZE_BYTES UL(32)
 
-TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *key,
+TEE_Result crypto_acipher_alloc_x25519_keypair(struct montgomery_keypair *key,
 					       size_t key_size)
 {
 	size_t key_size_bytes = key_size / 8;
@@ -41,7 +41,7 @@ TEE_Result crypto_acipher_alloc_x25519_keypair(struct x25519_keypair *key,
 	return TEE_SUCCESS;
 }
 
-TEE_Result crypto_acipher_gen_x25519_key(struct x25519_keypair *key,
+TEE_Result crypto_acipher_gen_x25519_key(struct montgomery_keypair *key,
 					 size_t key_size)
 {
 	curve25519_key ltc_tmp_key = { };
@@ -65,7 +65,7 @@ TEE_Result crypto_acipher_gen_x25519_key(struct x25519_keypair *key,
 	return TEE_SUCCESS;
 }
 
-TEE_Result crypto_acipher_x25519_shared_secret(struct x25519_keypair
+TEE_Result crypto_acipher_x25519_shared_secret(struct montgomery_keypair
 					       *private_key,
 					       void *public_key,
 					       void *secret,

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -437,14 +437,14 @@ const struct tee_cryp_obj_type_attrs tee_cryp_obj_x25519_keypair_attrs[] = {
 	.attr_id = TEE_ATTR_X25519_PRIVATE_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
 	.ops_index = ATTR_OPS_INDEX_25519,
-	RAW_DATA(struct x25519_keypair, priv)
+	RAW_DATA(struct montgomery_keypair, priv)
 	},
 
 	{
 	.attr_id = TEE_ATTR_X25519_PUBLIC_VALUE,
 	.flags = TEE_TYPE_ATTR_REQUIRED,
 	.ops_index = ATTR_OPS_INDEX_25519,
-	RAW_DATA(struct x25519_keypair, pub)
+	RAW_DATA(struct montgomery_keypair, pub)
 	},
 };
 
@@ -635,7 +635,7 @@ static const struct tee_cryp_obj_type_props tee_cryp_obj_props[] = {
 	     tee_cryp_obj_sm2_keypair_attrs),
 
 	PROP(TEE_TYPE_X25519_KEYPAIR, 1, 256, 256,
-	     sizeof(struct x25519_keypair),
+	     sizeof(struct montgomery_keypair),
 	     tee_cryp_obj_x25519_keypair_attrs),
 
 	PROP(TEE_TYPE_ED25519_PUBLIC_KEY, 1, 256, 256,
@@ -2186,7 +2186,7 @@ tee_svc_obj_generate_key_x25519(struct tee_obj *o,
 				uint32_t param_count)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	struct x25519_keypair *tee_x25519_key = NULL;
+	struct montgomery_keypair *tee_x25519_key = NULL;
 
 	/* Copy the present attributes into the obj before starting */
 	res = tee_svc_cryp_obj_populate_type(o, type_props, params,
@@ -2194,7 +2194,7 @@ tee_svc_obj_generate_key_x25519(struct tee_obj *o,
 	if (res != TEE_SUCCESS)
 		return res;
 
-	tee_x25519_key = (struct x25519_keypair *)o->attr;
+	tee_x25519_key = (struct montgomery_keypair *)o->attr;
 
 	res = crypto_acipher_gen_x25519_key(tee_x25519_key, key_size);
 	if (res != TEE_SUCCESS)

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -46,7 +46,7 @@
 #define TEE_MAIN_ALGO_X25519     0x44 /* Not in v1.2 spec */
 #define TEE_MAIN_ALGO_SHAKE128   0xC3 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_SHAKE256   0xC4 /* OP-TEE extension */
-#define TEE_MAIN_ALGO_X448	0xC5 /* OP-TEE extension */
+#define TEE_MAIN_ALGO_X448	 0xC5 /* OP-TEE extension */
 
 
 #define TEE_CHAIN_MODE_ECB_NOPAD        0x0

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -46,6 +46,7 @@
 #define TEE_MAIN_ALGO_X25519     0x44 /* Not in v1.2 spec */
 #define TEE_MAIN_ALGO_SHAKE128   0xC3 /* OP-TEE extension */
 #define TEE_MAIN_ALGO_SHAKE256   0xC4 /* OP-TEE extension */
+#define TEE_MAIN_ALGO_X448	0xC5 /* OP-TEE extension */
 
 
 #define TEE_CHAIN_MODE_ECB_NOPAD        0x0
@@ -105,6 +106,8 @@ static inline uint32_t __tee_alg_get_main_alg(uint32_t algo)
 		return TEE_MAIN_ALGO_SHAKE128;
 	case TEE_ALG_SHAKE256:
 		return TEE_MAIN_ALGO_SHAKE256;
+	case TEE_ALG_X448:
+		return TEE_MAIN_ALGO_X448;
 	default:
 		break;
 	}


### PR DESCRIPTION
1.Refer to the X25519 algorithm, add the X448 algorithm framework code.
2.Design the montgomery keypair structure, to merge x25519 and x448 algorithm keypair structure.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
