### PR TITLE
plat-nuvoton: configuration change

### DIFF
--- a/core/arch/arm/plat-nuvoton/conf.mk
+++ b/core/arch/arm/plat-nuvoton/conf.mk
@@ -21,14 +21,15 @@ CFG_NPCM_DEBUG ?= n
 ifeq ($(PLATFORM_FLAVOR),npcm845x)
 CFG_TEE_CORE_NB_CORE ?= 4
 # [3000.0000 031f.ffff] is reserved to early boot
-CFG_TZDRAM_START ?= 0x36000000
-CFG_TZDRAM_SIZE  ?= 0x00f00000
+CFG_TZDRAM_START ?= 0x02100000
+CFG_TZDRAM_SIZE  ?= 0x03f00000
 # SHM chosen arbitrary, in a way that it does not interfere
 # with initial location of linux kernel, dtb and initrd.
-CFG_SHMEM_START ?= 0x2FD00000
+CFG_SHMEM_START ?= 0x06000000
 CFG_SHMEM_SIZE  ?= 0x00200000
 # When Secure Data Path is enable, last MByte of TZDRAM is SDP test memory.
-CFG_TEE_SDP_MEM_SIZE ?= 0x00400000
+CFG_TEE_SDP_MEM_BASE ?= 0x05F00000
+CFG_TEE_SDP_MEM_SIZE ?= 0x00100000
 $(call force,CFG_DT,y)
 CFG_DTB_MAX_SIZE ?= 0x100000
 $(call force,CFG_WITH_PAGER,n,Pager is not supported for NPCM845x)

--- a/core/arch/arm/plat-nuvoton/conf.mk
+++ b/core/arch/arm/plat-nuvoton/conf.mk
@@ -13,6 +13,9 @@ $(call force,CFG_ARM_GICV2,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_16550_UART,y)
 
+# Not used now for current platform
+$(call force,CFG_EXTERNAL_DT,n)
+
 CFG_WITH_STATS ?= y
 
 # To enable version printing with color in main

--- a/core/arch/arm/plat-nuvoton/main.c
+++ b/core/arch/arm/plat-nuvoton/main.c
@@ -10,7 +10,10 @@
 #include <drivers/ns16550.h>
 #include <kernel/boot.h>
 #include <kernel/linker.h>
+#include <kernel/tee_common_otp.h>
+#include <mm/core_memprot.h>
 #include <platform_config.h>
+#include <tee/tee_cryp_utl.h>
 #include <trace.h>
 
 #define COLOR_NORMAL	"\x1B[0m"
@@ -22,11 +25,21 @@
 #define COLOR_CYAN	"\x1B[36m"
 #define COLOR_WHITE	"\x1B[37m"
 
+#define NPCM_MEASURE_BASE	0xF0848000
+#define NPCM_MEASURE_DME	0x0E0
+#define NPCM_MEASURE_SIZE	64
+
 static struct ns16550_data console_data __nex_bss;
+
+static struct {
+	uint8_t data[HW_UNIQUE_KEY_LENGTH];
+	bool ready;
+} npcm_hwkey;
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, UART_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_RAM_NSEC, NPCM_MEASURE_BASE, SMALL_PAGE_SIZE);
 
 register_ddr(DRAM0_BASE, DRAM0_SIZE);
 
@@ -51,4 +64,40 @@ void console_init(void)
 {
 	ns16550_init(&console_data, CONSOLE_UART_BASE, IO_WIDTH_U32, 2);
 	register_serial_console(&console_data.chip);
+}
+
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
+{
+	void *vaddr = NULL;
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t bin[HW_UNIQUE_KEY_LENGTH / sizeof(uint32_t)] = {};
+	uint8_t *bin_val = (uint8_t *)(&bin[0]);
+
+	if (npcm_hwkey.ready)
+		goto out;
+
+	vaddr = phys_to_virt(NPCM_MEASURE_BASE + NPCM_MEASURE_DME,
+			     MEM_AREA_RAM_NSEC, NPCM_MEASURE_SIZE);
+	if (!vaddr) {
+		EMSG("Not enough memory mapped");
+		return TEE_ERROR_SECURITY;
+	}
+
+	res = tee_hash_createdigest(TEE_ALG_SHA256, (uint8_t *)vaddr,
+				    NPCM_MEASURE_SIZE, bin_val,
+				    HW_UNIQUE_KEY_LENGTH);
+	if (res != TEE_SUCCESS) {
+		EMSG("Can't create a digest for HUK");
+		return TEE_ERROR_SECURITY;
+	}
+
+	memcpy(&npcm_hwkey.data[0], bin, HW_UNIQUE_KEY_LENGTH);
+	npcm_hwkey.ready = true;
+
+	IMSG("HUK Initialized");
+
+out:
+	memcpy(hwkey->data, npcm_hwkey.data, HW_UNIQUE_KEY_LENGTH);
+
+	return res;
 }


### PR DESCRIPTION
Changes load address of OPTEE-OS from 0x36000000 to 0x02100000
Implements HUK reading from DME PCR0 located in PCI mailbox
Disables DT insecure warning
