### PR TITLE
drivers: imx_mu: read RX and TX buffer size from MU configuation register

### DIFF
--- a/core/drivers/imx/mu/imx_mu.c
+++ b/core/drivers/imx/mu/imx_mu.c
@@ -66,7 +66,7 @@ static TEE_Result imx_mu_receive_msg(vaddr_t base, struct imx_mu_msg *msg)
 		return TEE_ERROR_BAD_FORMAT;
 	}
 
-	nb_channel = imx_mu_plat_get_rx_channel();
+	nb_channel = imx_mu_plat_get_rx_channel(base);
 
 	for (count = 1; count < msg->header.size; count++) {
 		res = imx_mu_plat_receive(base, count % nb_channel,
@@ -103,7 +103,7 @@ static TEE_Result imx_mu_send_msg(vaddr_t base, struct imx_mu_msg *msg)
 	if (res)
 		return res;
 
-	nb_channel = imx_mu_plat_get_tx_channel();
+	nb_channel = imx_mu_plat_get_tx_channel(base);
 
 	for (count = 1; count < msg->header.size; count++) {
 		res = imx_mu_plat_send(base, count % nb_channel,

--- a/core/drivers/imx/mu/imx_mu_8q.c
+++ b/core/drivers/imx/mu/imx_mu_8q.c
@@ -42,12 +42,12 @@ static TEE_Result mu_wait_for(vaddr_t addr, uint32_t mask)
 	return TEE_SUCCESS;
 }
 
-unsigned int imx_mu_plat_get_rx_channel(void)
+unsigned int imx_mu_plat_get_rx_channel(vaddr_t base __unused)
 {
 	return MU_MAX_CHANNEL;
 }
 
-unsigned int imx_mu_plat_get_tx_channel(void)
+unsigned int imx_mu_plat_get_tx_channel(vaddr_t base __unused)
 {
 	return MU_MAX_CHANNEL;
 }

--- a/core/drivers/imx/mu/imx_mu_platform.h
+++ b/core/drivers/imx/mu/imx_mu_platform.h
@@ -9,12 +9,12 @@
 /*
  * Return the number of reception channels
  */
-unsigned int imx_mu_plat_get_rx_channel(void);
+unsigned int imx_mu_plat_get_rx_channel(vaddr_t base);
 
 /*
  * Return the number of transmission channels
  */
-unsigned int imx_mu_plat_get_tx_channel(void);
+unsigned int imx_mu_plat_get_tx_channel(vaddr_t base);
 
 /*
  * Send a 32bits word via the MU


### PR DESCRIPTION

On i.MX8ULP, there are multiple MUs with a different number of RX and TX buffer sizes. To make the driver generic for all MUs on this platform, get the RX and TX buffer size from the MU configuration register.

The configuration remains static for i.MX8Q.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
