### PR TITLE
pta: attestation: fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,8 @@ jobs:
           export LC_ALL=C
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0
+          export CFG_ATTESTATION_PTA=y
+          export CFG_ATTESTATION_PTA_KEY_SIZE=1024
           WD=$(pwd)
           cd ..
           TOP=$(pwd)/optee_repo_qemu_v8

--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -483,10 +483,11 @@ static TEE_Result sign_buffer(uint8_t *buf, size_t buf_sz, uint8_t *nonce,
  */
 static bool is_region_valid(struct vm_region *r)
 {
-	uint32_t skip_flags = VM_FLAG_EPHEMERAL | VM_FLAG_PERMANENT |
-			      VM_FLAG_LDELF;
+	uint32_t dontwant = VM_FLAG_EPHEMERAL | VM_FLAG_PERMANENT |
+			    VM_FLAG_LDELF;
+	uint32_t want = VM_FLAG_READONLY;
 
-	return !(r->flags & skip_flags || r->attr & TEE_MATTR_UW);
+	return ((r->flags & want) == want && !(r->flags & dontwant));
 }
 
 /*


### PR DESCRIPTION
Several fixes for the attestation PTA. One commit excludes a region that should not be hashed, which was introduced by a commit related to PAN. The other ones fix invalid accesses to user space memory (TA memory pages and memref parameters) when `CFG_PAN=y`. 