### PR TITLE
ta: pkcs11: remove redundant comment about start and end date

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -1351,9 +1351,6 @@ enum pkcs11_rc check_created_attrs_against_token(struct pkcs11_session *session,
 		return PKCS11_CKR_SESSION_READ_ONLY;
 	}
 
-	/*
-	 * TODO: START_DATE and END_DATE: complies with current time?
-	 */
 	return PKCS11_CKR_OK;
 }
 


### PR DESCRIPTION
PKCS#11 standard specifies that verification or usage of start and end date for certificate objects is responsibility of the application.

There is no other activity than storage needed for those.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
