### PR TITLE
libutils: fault_mitigation: fix panic on hash mismatch

### DIFF
--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
@@ -180,6 +180,16 @@ int rsa_verify_hash_ex(const unsigned char *sig,            unsigned long  sigle
       inc1 = 1;
     }
 
+    if (!*stat) {
+      /*
+       * The call to ftmn_set_check_res_memcmp() above might have failed,
+       * since memcmp() may set any non-zero result force it 1 to match the
+       * check with FTMN_CALLEE_DONE_CHECK() below.
+       */
+      FTMN_SET_CHECK_RES_NOT_ZERO(&ftmn, FTMN_INCR1, 1);
+      inc1++;
+    }
+
 #ifdef LTC_CLEAN_STACK
     zeromem(out, outlen);
 #endif


### PR DESCRIPTION
When running a test with CFG_FAULT_MITIGATION=y and with a corrupted message, hash verification fails and panic TEE core:

F/TC:? 0 trace_syscall:149 syscall #40 (syscall_asymm_verify) E/TC:2 0 Panic at lib/libutils/ext/fault_mitigation.c:87 <___ftmn_callee_done_check> E/TC:2 0 TEE load address @ 0x43200000
E/TC:2 0 Call stack:
E/TC:2 0  0x4320a9f0 print_kernel_stack at optee-os/core/arch/arm/kernel/unwind_arm64.c:91 E/TC:2 0  0x432203fc __do_panic at optee-os/core/kernel/panic.c:26 (discriminator 32) E/TC:2 0  0x4327d324 ___ftmn_callee_done_check at optee-os/lib/libutils/ext/fault_mitigation.c:87 E/TC:2 0  0x43263aac __ftmn_callee_done_check at optee-os/lib/libutils/ext/include/fault_mitigation.h:349 E/TC:2 0  0x43258408 sw_crypto_acipher_rsassa_verify at optee-os/core/lib/libtomcrypt/rsa.c:669 E/TC:2 0  0x43247ecc syscall_asymm_verify at optee-os/core/tee/tee_svc_cryp.c:4420 E/TC:2 0  0x43206d18 scall_do_call at optee-os/core/arch/arm/kernel/arch_scall_a64.S:140 E/TC:2 0  0x43206798 thread_scall_handler at optee-os/core/arch/arm/kernel/thread.c:1115 E/TC:2 0  0x432043e8 el0_svc at optee-os/core/arch/arm/kernel/thread_a64.S:850

Function ftmn_set_check_res_memcmp() is currently used on the verification of RSA hash. When CFG_FAULT_MITIGATION flag is enabled, ftmn.check.res is set with the return value of the hash comparison. This can be 0, when hash matches, or another number, positive or negativen, when hash does not match.

For fault mitigation purposes, the value stored on ftmn.check.res is later compared with the result of the signature comparison, which can assume only two values : 1==valid or 0==invalid.

With that, ftmn_set_check_res_memcmp() should set ftmn.check.res either with 0, when hash matches, or with 1, when hash does not match. Fix ___ftmn_set_check_res_memcmp() to have this behavior. Note that, the fault mitigation check is done between ftmn.check.res and !*stat.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
