### PR TITLE
core: arm: Rename xxx_init_intc() to boot_xxx_init_intc()

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -100,7 +100,7 @@ __weak void primary_init_intc(void)
 }
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void main_secondary_init_intc(void)
+__weak void boot_secondary_init_intc(void)
 {
 }
 
@@ -1227,7 +1227,7 @@ static void init_secondary_helper(unsigned long nsec_entry)
 	secondary_init_cntfrq();
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
-	main_secondary_init_intc();
+	boot_secondary_init_intc();
 	init_vfp_sec();
 	init_vfp_nsec();
 

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -95,7 +95,7 @@ __weak void plat_primary_init_early(void)
 DECLARE_KEEP_PAGER(plat_primary_init_early);
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void primary_init_intc(void)
+__weak void boot_primary_init_intc(void)
 {
 }
 
@@ -1199,7 +1199,7 @@ void __weak boot_init_primary_late(unsigned long fdt,
 			IMSG("WARNING: This ARM core does not have NMFI enabled, no need for workaround");
 	}
 
-	primary_init_intc();
+	boot_primary_init_intc();
 	init_vfp_nsec();
 	if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
 		IMSG("Initializing virtualization support");

--- a/core/arch/arm/plat-aspeed/platform_ast2600.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2600.c
@@ -60,7 +60,7 @@ register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
 
 static struct serial8250_uart_data console_data;
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-aspeed/platform_ast2600.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2600.c
@@ -65,7 +65,7 @@ void primary_init_intc(void)
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-aspeed/platform_ast2700.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2700.c
@@ -18,7 +18,7 @@ register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
 
 static struct serial8250_uart_data console_data;
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(0, GICD_BASE);
 }

--- a/core/arch/arm/plat-aspeed/platform_ast2700.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2700.c
@@ -23,7 +23,7 @@ void primary_init_intc(void)
 	gic_init(0, GICD_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-bcm/main.c
+++ b/core/arch/arm/plat-bcm/main.c
@@ -72,7 +72,7 @@ void console_init(void)
 		      CFG_BCM_ELOG_AP_UART_LOG_SIZE);
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(0, GICD_BASE);
 }

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -21,7 +21,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -26,7 +26,7 @@ void primary_init_intc(void)
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -106,7 +106,7 @@ void console_init(void)
 #endif
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 #ifdef GICD_BASE
 	gic_init(0, GICD_BASE);

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -116,7 +116,7 @@ void primary_init_intc(void)
 }
 
 #if CFG_TEE_CORE_NB_CORE > 1
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
+++ b/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
@@ -218,7 +218,7 @@ int imx7d_lowpower_idle(uint32_t power_state __unused,
 		gic_inited = 1;
 		DMSG("=== Back from Suspended ===\n");
 	} else {
-		main_secondary_init_intc();
+		boot_secondary_init_intc();
 		gic_inited = 0;
 	}
 

--- a/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
+++ b/core/arch/arm/plat-imx/pm/cpuidle-imx7d.c
@@ -214,7 +214,7 @@ int imx7d_lowpower_idle(uint32_t power_state __unused,
 		if (!get_core_pos())
 			plat_primary_init_early();
 
-		primary_init_intc();
+		boot_primary_init_intc();
 		gic_inited = 1;
 		DMSG("=== Back from Suspended ===\n");
 	} else {

--- a/core/arch/arm/plat-imx/pm/imx7_suspend.c
+++ b/core/arch/arm/plat-imx/pm/imx7_suspend.c
@@ -63,7 +63,7 @@ int imx7_cpu_suspend(uint32_t power_state __unused, uintptr_t entry,
 	/* Set entry for back to Linux */
 	nsec->mon_lr = (uint32_t)entry;
 
-	primary_init_intc();
+	boot_primary_init_intc();
 
 	DMSG("=== Back from Suspended ===\n");
 

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -37,7 +37,7 @@ void primary_init_intc(void)
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -32,7 +32,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, SEC_PROXY_RT_BASE, SEC_PROXY_RT_SIZE);
 register_ddr(DRAM0_BASE, DRAM0_SIZE);
 register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -215,7 +215,7 @@ void primary_init_intc(void)
 	gic_init(gic_base + gicc_offset, gic_base + gicd_offset);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -199,7 +199,7 @@ static void get_gic_offset(uint32_t *offsetc, uint32_t *offsetd)
 #endif
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	paddr_t gic_base = 0;
 	uint32_t gicc_offset = 0;

--- a/core/arch/arm/plat-marvell/main.c
+++ b/core/arch/arm/plat-marvell/main.c
@@ -71,7 +71,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, CORE_MMU_PGDIR_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, CORE_MMU_PGDIR_SIZE);
 #endif
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	paddr_t gicd_base = 0;
 	paddr_t gicc_base = 0;

--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -25,7 +25,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICD_OFFSET,
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE + GICC_OFFSET,
 			CORE_MMU_PGDIR_SIZE);
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-nuvoton/main.c
+++ b/core/arch/arm/plat-nuvoton/main.c
@@ -39,7 +39,7 @@ static void print_version(void)
 	IMSG(COLOR_NORMAL);
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	if (IS_ENABLED(CFG_NPCM_DEBUG))
 		print_version();

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -92,7 +92,7 @@ void primary_init_intc(void)
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -87,7 +87,7 @@ unsigned long plat_get_aslr_seed(void)
 }
 #endif
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -27,7 +27,7 @@ void primary_init_intc(void)
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -22,7 +22,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC,
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }

--- a/core/arch/arm/plat-rzn1/main.c
+++ b/core/arch/arm/plat-rzn1/main.c
@@ -45,7 +45,7 @@ void primary_init_intc(void)
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-rzn1/main.c
+++ b/core/arch/arm/plat-rzn1/main.c
@@ -40,7 +40,7 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }

--- a/core/arch/arm/plat-sam/main.c
+++ b/core/arch/arm/plat-sam/main.c
@@ -338,7 +338,7 @@ void plat_primary_init_early(void)
 	matrix_init();
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	if (atmel_saic_setup())
 		panic("Failed to init interrupts\n");

--- a/core/arch/arm/plat-sprd/main.c
+++ b/core/arch/arm/plat-sprd/main.c
@@ -45,7 +45,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC,
 			ROUNDDOWN(GIC_BASE + GICD_OFFSET, CORE_MMU_PGDIR_SIZE),
 			CORE_MMU_PGDIR_SIZE);
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -137,7 +137,7 @@ void primary_init_intc(void)
 	gic_init(GIC_CPU_BASE, GIC_DIST_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -132,7 +132,7 @@ void plat_primary_init_early(void)
 		io_write32(GIC_DIST_BASE + GIC_DIST_ISR1 + i, 0xFFFFFFFF);
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_CPU_BASE, GIC_DIST_BASE);
 }

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -158,7 +158,7 @@ void primary_init_intc(void)
 	stm32mp_register_online_cpu();
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -151,7 +151,7 @@ service_init_late(init_console_from_dt);
 /*
  * GIC init, used also for primary/secondary boot core wake completion
  */
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -123,7 +123,7 @@ static inline void tzpc_init(void)
 #endif /* SUNXI_TZPC_BASE */
 
 #ifndef CFG_WITH_ARM_TRUSTED_FW
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -128,7 +128,7 @@ void primary_init_intc(void)
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-synquacer/main.c
+++ b/core/arch/arm/plat-synquacer/main.c
@@ -35,7 +35,7 @@ void console_init(void)
 	register_serial_console(&console_data.chip);
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(0, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-ti/a9_plat_init.S
+++ b/core/arch/arm/plat-ti/a9_plat_init.S
@@ -82,7 +82,7 @@ after_resume:
 	mov	r0, r5
 	bl	init_sec_mon
 
-	bl	primary_init_intc
+	bl	boot_primary_init_intc
 
 	mov	r0, #TEESMC_OPTEED_RETURN_ENTRY_DONE
 	mov	r1, #0

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -34,7 +34,7 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GICD_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
 		  SERIAL8250_UART_REG_SIZE);
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GICC_BASE, GICD_BASE);
 }

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -39,7 +39,7 @@ void primary_init_intc(void)
 	gic_init(GICC_BASE, GICD_BASE);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-totalcompute/main.c
+++ b/core/arch/arm/plat-totalcompute/main.c
@@ -26,7 +26,7 @@ register_ddr(DRAM0_BASE, DRAM0_SIZE);
 register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
 #ifndef CFG_CORE_SEL2_SPMC
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICC_OFFSET);
 }

--- a/core/arch/arm/plat-uniphier/main.c
+++ b/core/arch/arm/plat-uniphier/main.c
@@ -35,7 +35,7 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 
 static struct serial8250_uart_data console_data;
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-versal/main.c
+++ b/core/arch/arm/plat-versal/main.c
@@ -46,7 +46,7 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 register_ddr(DRAM2_BASE, DRAM2_SIZE);
 #endif
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -47,7 +47,7 @@ register_ddr(DRAM1_BASE, DRAM1_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_DIST_REG_SIZE);
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
@@ -61,7 +61,7 @@ void boot_secondary_init_intc(void)
 #endif /*CFG_GIC*/
 
 #ifdef CFG_CORE_HAFNIUM_INTC
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	hfic_init();
 }

--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -53,7 +53,7 @@ void primary_init_intc(void)
 }
 
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -141,7 +141,7 @@ void arm_cl2_enable(vaddr_t pl310_base)
 		write_actlr(read_actlr() | (1 << 3));
 }
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -146,7 +146,7 @@ void primary_init_intc(void)
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }
 
-void main_secondary_init_intc(void)
+void boot_secondary_init_intc(void)
 {
 	gic_cpu_init();
 }

--- a/core/arch/arm/plat-zynqmp/main.c
+++ b/core/arch/arm/plat-zynqmp/main.c
@@ -75,7 +75,7 @@ register_ddr(DRAM1_BASE, CFG_DDR_SIZE - 0x80000000);
 register_ddr(DRAM0_BASE, CFG_DDR_SIZE);
 #endif
 
-void primary_init_intc(void)
+void boot_primary_init_intc(void)
 {
 	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
 }

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -115,7 +115,7 @@ __weak void plat_primary_init_early(void)
 }
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void primary_init_intc(void)
+__weak void boot_primary_init_intc(void)
 {
 }
 
@@ -144,7 +144,7 @@ void boot_init_primary_late(unsigned long fdt,
 		IMSG("WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html");
 	}
 	IMSG("Primary CPU initializing");
-	primary_init_intc();
+	boot_primary_init_intc();
 	init_tee_runtime();
 	call_finalcalls();
 	IMSG("Primary CPU initialized");

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -120,7 +120,7 @@ __weak void primary_init_intc(void)
 }
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
-__weak void secondary_init_intc(void)
+__weak void boot_secondary_init_intc(void)
 {
 }
 
@@ -171,7 +171,7 @@ static void init_secondary_helper(unsigned long nsec_entry)
 
 	thread_init_per_cpu();
 	init_sec_mon(nsec_entry);
-	secondary_init_intc();
+	boot_secondary_init_intc();
 
 	IMSG("Secondary CPU %zu initialized", pos);
 }

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -59,7 +59,7 @@ void boot_init_secondary(unsigned long nsec_entry);
 #endif
 
 void primary_init_intc(void);
-void main_secondary_init_intc(void);
+void boot_secondary_init_intc(void);
 
 void init_sec_mon(unsigned long nsec_entry);
 void init_tee_runtime(void);

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -58,7 +58,7 @@ unsigned long boot_cpu_on_handler(unsigned long a0, unsigned long a1);
 void boot_init_secondary(unsigned long nsec_entry);
 #endif
 
-void primary_init_intc(void);
+void boot_primary_init_intc(void);
 void boot_secondary_init_intc(void);
 
 void init_sec_mon(unsigned long nsec_entry);


### PR DESCRIPTION
main_secondary_*() is an ambiguous name since it conveys no meaning relative to the purpose of the function. Fix it by renameing to secondary_init_intc().

This PR tries to solve discussion in https://github.com/OP-TEE/optee_os/pull/6189.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
