### PR TITLE
Multiple Coverity fixes for CAAM Driver, Crypto API and Core

### DIFF
--- a/core/drivers/crypto/caam/mp/caam_mp.c
+++ b/core/drivers/crypto/caam/mp/caam_mp.c
@@ -135,8 +135,10 @@ TEE_Result caam_mp_export_publickey(uint8_t *pubkey, size_t *size)
 		pdb_sgt_flag = PROT_MP_PUBK_SGT;
 
 	desc = caam_calloc_desc(MP_PUB_DESC_ENTRIES);
-	if (!desc)
-		return TEE_ERROR_OUT_OF_MEMORY;
+	if (!desc) {
+		ret = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
 
 	caam_desc_init(desc);
 	caam_desc_add_word(desc, DESC_HEADER(0));
@@ -169,6 +171,7 @@ TEE_Result caam_mp_export_publickey(uint8_t *pubkey, size_t *size)
 		ret = job_status_to_tee_result(jobctx.status);
 	}
 
+out:
 	caam_dmaobj_free(&reskey);
 	caam_free_desc(&desc);
 

--- a/core/drivers/crypto/caam/utils/utils_dmaobj.c
+++ b/core/drivers/crypto/caam/utils/utils_dmaobj.c
@@ -878,9 +878,6 @@ size_t caam_dmaobj_copy_to_orig(struct caamdmaobj *obj)
 	for (idx = 0; idx < obj->sgtbuf.number; idx++) {
 		struct sgtdata *sgtdata = &priv->sgtdata[idx];
 
-		if (!sgtdata)
-			break;
-
 		copy_size = MIN(dst_rlen, sgtdata->length);
 		if (sgtdata->orig != sgtdata->dma && sgtdata->orig) {
 			copy_size = MIN(dst_rlen, sgtdata->length);
@@ -914,10 +911,7 @@ size_t caam_dmaobj_copy_ltrim_to_orig(struct caamdmaobj *obj)
 
 	/* Parse the SGT data list to discard leading zeros */
 	for (idx = 0; idx < obj->sgtbuf.number; idx++) {
-		struct sgtdata *sgtdata = priv->sgtdata + idx;
-
-		if (!sgtdata)
-			break;
+		struct sgtdata *sgtdata = &priv->sgtdata[idx];
 
 		if (!sgtdata->orig)
 			continue;

--- a/core/drivers/crypto/crypto_api/acipher/rsamgf.c
+++ b/core/drivers/crypto/crypto_api/acipher/rsamgf.c
@@ -29,7 +29,7 @@ TEE_Result drvcrypt_rsa_mgf1(struct drvcrypt_rsa_mgf *mgf_data)
 	lastBlock_size = mgf_data->mask.length % mgf_data->digest_size;
 	if (lastBlock_size) {
 		/* Allocate a digest buffer for the last block */
-		tmpdigest = malloc(mgf_data->digest_size);
+		tmpdigest = calloc(1, mgf_data->digest_size);
 		if (!tmpdigest)
 			return TEE_ERROR_OUT_OF_MEMORY;
 	}

--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -56,9 +56,11 @@ static TEE_Result generate_key(void)
 
 	res = allocate_key();
 	if (res)
-		return res;
+		goto err;
 
-	crypto_bignum_bin2bn((uint8_t *)&e, sizeof(e), key->e);
+	res = crypto_bignum_bin2bn((uint8_t *)&e, sizeof(e), key->e);
+	if (res)
+		goto err;
 
 	/*
 	 * For security reasons, the RSA modulus size has to be at least the
@@ -68,9 +70,12 @@ static TEE_Result generate_key(void)
 	COMPILE_TIME_ASSERT(CFG_ATTESTATION_PTA_KEY_SIZE >=
 			    TEE_SHA256_HASH_SIZE);
 	res = crypto_acipher_gen_rsa_key(key, CFG_ATTESTATION_PTA_KEY_SIZE);
-	if (res)
-		free_key();
+	if (!res)
+		goto out;
 
+err:
+	free_key();
+out:
 	return res;
 }
 

--- a/core/tee/entry_std.c
+++ b/core/tee/entry_std.c
@@ -351,13 +351,13 @@ static TEE_Result get_open_session_meta(size_t num_params,
 
 static void entry_open_session(struct optee_msg_arg *arg, uint32_t num_params)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_ErrorOrigin err_orig = TEE_ORIGIN_TEE;
 	struct tee_ta_session *s = NULL;
-	TEE_Identity clnt_id;
-	TEE_UUID uuid;
+	TEE_Identity clnt_id = { };
+	TEE_UUID uuid = { };
 	struct tee_ta_param param = { };
-	size_t num_meta;
+	size_t num_meta = 0;
 	uint64_t saved_attr[TEE_NUM_PARAMS] = { 0 };
 
 	res = get_open_session_meta(num_params, arg->params, &num_meta, &uuid,

--- a/core/tee/entry_std.c
+++ b/core/tee/entry_std.c
@@ -356,7 +356,7 @@ static void entry_open_session(struct optee_msg_arg *arg, uint32_t num_params)
 	struct tee_ta_session *s = NULL;
 	TEE_Identity clnt_id;
 	TEE_UUID uuid;
-	struct tee_ta_param param;
+	struct tee_ta_param param = { };
 	size_t num_meta;
 	uint64_t saved_attr[TEE_NUM_PARAMS] = { 0 };
 

--- a/core/tee/fs_dirfile.c
+++ b/core/tee/fs_dirfile.c
@@ -138,7 +138,7 @@ TEE_Result tee_fs_dirfile_open(bool create, uint8_t *hash,
 		goto out;
 
 	for (n = 0;; n++) {
-		struct dirfile_entry dent;
+		struct dirfile_entry dent = { };
 
 		res = read_dent(dirh, n, &dent);
 		if (res) {
@@ -289,7 +289,7 @@ TEE_Result tee_fs_dirfile_rename(struct tee_fs_dirfile_dirh *dirh,
 				 const void *oid, size_t oidlen)
 {
 	TEE_Result res;
-	struct dirfile_entry dent;
+	struct dirfile_entry dent = { };
 
 	if (oidlen > sizeof(dent.oid))
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -324,7 +324,7 @@ TEE_Result tee_fs_dirfile_remove(struct tee_fs_dirfile_dirh *dirh,
 				 const struct tee_fs_dirfile_fileh *dfh)
 {
 	TEE_Result res;
-	struct dirfile_entry dent;
+	struct dirfile_entry dent = { };
 	uint32_t file_number;
 
 	res = read_dent(dirh, dfh->idx, &dent);
@@ -350,7 +350,7 @@ TEE_Result tee_fs_dirfile_update_hash(struct tee_fs_dirfile_dirh *dirh,
 				      const struct tee_fs_dirfile_fileh *dfh)
 {
 	TEE_Result res;
-	struct dirfile_entry dent;
+	struct dirfile_entry dent = { };
 
 	res = read_dent(dirh, dfh->idx, &dent);
 	if (res)

--- a/core/tee/tadb.c
+++ b/core/tee/tadb.c
@@ -506,7 +506,7 @@ static TEE_Result find_ent(struct tee_tadb_dir *db, const TEE_UUID *uuid,
 	 * with TEE_ERROR_ITEM_NOT_FOUND.
 	 */
 	for (idx = 0;; idx++) {
-		struct tadb_entry entry;
+		struct tadb_entry entry = { };
 
 		res = read_ent(db, idx, &entry);
 		if (res) {

--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -131,6 +131,7 @@ enum user_ta_prop_type {
 	USER_TA_PROP_TYPE_STRING,	/* zero terminated string of char */
 	USER_TA_PROP_TYPE_BINARY_BLOCK,	/* zero terminated base64 coded string */
 	USER_TA_PROP_TYPE_U64,	/* uint64_t */
+	USER_TA_PROP_TYPE_INVALID,	/* invalid value */
 };
 
 struct user_ta_property {

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -754,12 +754,16 @@ static bool addr_is_in_no_share_heap(void *p)
 void *TEE_Realloc(void *buffer, size_t newSize)
 {
 	if (!newSize) {
-		TEE_Free(buffer);
+		void *ret = NULL;
 
 		if (addr_is_in_no_share_heap(buffer))
-			return TEE_NULL_SIZED_NO_SHARE_VA;
+			ret = TEE_NULL_SIZED_NO_SHARE_VA;
 		else
-			return TEE_NULL_SIZED_VA;
+			ret = TEE_NULL_SIZED_VA;
+
+		TEE_Free(buffer);
+
+		return ret;
 	}
 
 	if (buffer == TEE_NULL_SIZED_VA)

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -199,14 +199,14 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 				   const char *name, char *value,
 				   size_t *value_len)
 {
-	TEE_Result res;
-	size_t l;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t l = 0;
 	enum user_ta_prop_type type = USER_TA_PROP_TYPE_INVALID;
 	void *tmp_buf = 0;
-	uint32_t tmp_len;
-	uint32_t uint32_val;
-	bool bool_val;
-	TEE_Identity *p_identity_val;
+	uint32_t tmp_len = 0;
+	uint32_t uint32_val = 0;
+	bool bool_val = false;
+	TEE_Identity *p_identity_val = NULL;
 
 	if (is_propset_pseudo_handle(propsetOrEnumerator))
 		__utee_check_instring_annotation(name);

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -201,7 +201,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 {
 	TEE_Result res;
 	size_t l;
-	enum user_ta_prop_type type;
+	enum user_ta_prop_type type = USER_TA_PROP_TYPE_INVALID;
 	void *tmp_buf = 0;
 	uint32_t tmp_len;
 	uint32_t uint32_val;


### PR DESCRIPTION
Hello,
Our CI reported multiple Coverity issues in optee-os. The issues fixed in this pull-request are rated `High` and `Medium` impact. As a maintainer of the crypto driver API and the CAAM, I want to push 2878ec621 b3b05676a 1ba0f6dc6 d34d5c50b.

At the same time, I also fixed some issues in libutee, PTA attestation and the core. Feel free to comment regarding commits  d68119a17 dae33b69b a6c6ab0fe 726f19ea9 b98fa53d1

Thanks!