### PR TITLE
RISC-V: Refine TP restoring in trap handler

### DIFF
--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -52,6 +52,8 @@ DEFINES
 	       offsetof(struct thread_user_mode_rec, ctx_regs_ptr));
 	DEFINE(THREAD_USER_MODE_REC_X1,
 	       offsetof(struct thread_user_mode_rec, x[0]));
+	DEFINE(THREAD_USER_MODE_REC_X4,
+	       offsetof(struct thread_user_mode_rec, x[3]));
 	DEFINE(THREAD_USER_MODE_REC_X8,
 	       offsetof(struct thread_user_mode_rec, x[4]));
 	DEFINE(THREAD_USER_MODE_REC_X18,

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -29,7 +29,9 @@
 
 	/* Save user thread pointer and load kernel thread pointer */
 	store_xregs sp, THREAD_TRAP_REG_TP, REG_TP
-	load_xregs sp, (THREAD_TRAP_REGS_SIZE - RISCV_XLEN_BYTES), REG_TP
+	addi	tp, sp, THREAD_TRAP_REGS_SIZE
+	/* Now tp is at struct thread_user_mode_rec, which has kernel tp */
+	load_xregs tp, THREAD_USER_MODE_REC_X4, REG_TP
 
 	store_xregs sp, THREAD_TRAP_REG_GP, REG_GP
 
@@ -89,8 +91,6 @@
 
 .if \mode == TRAP_MODE_USER
 	addi	gp, sp, THREAD_TRAP_REGS_SIZE
-
-	store_xregs gp, REGOFF(-1), REG_TP
 	csrw	CSR_XSCRATCH, gp
 
 	load_xregs sp, THREAD_TRAP_REG_TP, REG_TP
@@ -221,13 +221,6 @@ FUNC __thread_enter_user_mode , :
 	 * thread_trap_vect() uses correct stack pointer.
 	 */
 	csrw	CSR_XSCRATCH, sp
-
-	/*
-	 * Save kernel thread pointer below of the kernel stack pointer
-	 * to enure that thread_trap_vect() uses correct tp when traps
-	 * come from user.
-	 */
-	store_xregs sp, REGOFF(-1), REG_TP
 
 	/* Set user status */
 	load_xregs a0, THREAD_CTX_REG_STATUS, REG_S0


### PR DESCRIPTION
RISC-V kernel uses TP register to store thread_core_local structure. When the thread enters user mode, the value of TP is used by user mode. Therefore, when CPU enters trap handler, it needs to restore TP to get thread_core_local structure.

In previous implementation, the value of TP is saved under kernel SP before entering user mode, and the trap handler restores TP from that stack location. However, the value of TP has already been saved into the thread_user_mode_rec structure (https://github.com/OP-TEE/optee_os/blob/master/core/arch/riscv/kernel/thread_rv.S#L202), which is also upon kernel SP, before entering user mode. So the value of TP can be restored just from thread_user_mode_rec, instead of saving into another location which is under the kernel SP.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
