### PR TITLE
plat-marvell: Add support for CN10K SoCs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,10 @@ jobs:
           _make PLATFORM=marvell-otx2t96
           _make PLATFORM=marvell-otx2f95
           _make PLATFORM=marvell-otx2t98
+          _make PLATFORM=marvell-cn10ka
+          _make PLATFORM=marvell-cn10kb
+          _make PLATFORM=marvell-cnf10ka
+          _make PLATFORM=marvell-cnf10kb
           _make PLATFORM=synquacer
           _make PLATFORM=sunxi-bpi_zero
           _make PLATFORM=sunxi-sun50i_a64

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -142,7 +142,7 @@ R:	Jerome Forissier <jerome.forissier@linaro.org> [@jforissier]
 S:	Maintained
 F:	core/arch/arm/plat-hisilicon
 
-Marvell Armada 70x0, Armada 80x0, Armada 3700, OcteonTX2 CN96XX, OcteonTX2 CFN95XX, OcteonTX2 CN98XX
+Marvell Armada 70x0, Armada 80x0, Armada 3700, OcteonTX2 CN96XX, OcteonTX2 CFN95XX, OcteonTX2 CN98XX, CN10K
 R:	Tao Lu <taolu@marvell.com> [@taovcu]
 S:	Maintained
 F:	core/arch/arm/plat-marvell/

--- a/core/arch/arm/plat-marvell/cn10k/core_pos.S
+++ b/core/arch/arm/plat-marvell/cn10k/core_pos.S
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2023 Marvell.
+ */
+
+#include <asm.S>
+#include <arm.h>
+#include <arm64_macros.S>
+
+FUNC get_core_pos_mpidr , :
+/* No clusters, core position is affinity2 of MPIDR_EL1 */
+	mov_imm x1, MPIDR_AFFLVL_MASK
+	and     x0, x1, x0, LSR #MPIDR_AFF2_SHIFT
+	ret
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-marvell/conf.mk
+++ b/core/arch/arm/plat-marvell/conf.mk
@@ -86,6 +86,74 @@ CFG_NUM_THREADS ?= CFG_TEE_CORE_NB_CORE
 CFG_CORE_HEAP_SIZE ?= 131072
 endif
 
+ifeq ($(PLATFORM_FLAVOR),cn10ka)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,24)
+$(call force,CFG_TZDRAM_START,0x00001000)
+$(call force,CFG_TZDRAM_SIZE,0x000a00000)
+$(call force,CFG_SHMEM_START,0x03400000)
+$(call force,CFG_SHMEM_SIZE,0x00800000)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,48)
+$(call force,CFG_LPAE_ADDR_SPACE_BITS,36)
+$(call force,CFG_PL011,y)
+$(call force,CFG_ARM_GICV3,y)
+CFG_USER_TA_TARGETS ?= ta_arm64
+CFG_NUM_THREADS ?= CFG_TEE_CORE_NB_CORE
+CFG_CORE_HEAP_SIZE ?= 131072
+endif
+
+ifeq ($(PLATFORM_FLAVOR),cn10kb)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+$(call force,CFG_TZDRAM_START,0x00001000)
+$(call force,CFG_TZDRAM_SIZE,0x000a00000)
+$(call force,CFG_SHMEM_START,0x03400000)
+$(call force,CFG_SHMEM_SIZE,0x00800000)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,48)
+$(call force,CFG_LPAE_ADDR_SPACE_BITS,36)
+$(call force,CFG_PL011,y)
+$(call force,CFG_ARM_GICV3,y)
+CFG_USER_TA_TARGETS ?= ta_arm64
+CFG_NUM_THREADS ?= CFG_TEE_CORE_NB_CORE
+CFG_CORE_HEAP_SIZE ?= 131072
+endif
+
+ifeq ($(PLATFORM_FLAVOR),cnf10ka)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,18)
+$(call force,CFG_TZDRAM_START,0x00001000)
+$(call force,CFG_TZDRAM_SIZE,0x000a00000)
+$(call force,CFG_SHMEM_START,0x03400000)
+$(call force,CFG_SHMEM_SIZE,0x00800000)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,48)
+$(call force,CFG_LPAE_ADDR_SPACE_BITS,36)
+$(call force,CFG_PL011,y)
+$(call force,CFG_ARM_GICV3,y)
+CFG_USER_TA_TARGETS ?= ta_arm64
+CFG_NUM_THREADS ?= CFG_TEE_CORE_NB_CORE
+CFG_CORE_HEAP_SIZE ?= 131072
+endif
+
+ifeq ($(PLATFORM_FLAVOR),cnf10kb)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,12)
+$(call force,CFG_TZDRAM_START,0x00001000)
+$(call force,CFG_TZDRAM_SIZE,0x000a00000)
+$(call force,CFG_SHMEM_START,0x03400000)
+$(call force,CFG_SHMEM_SIZE,0x00800000)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,48)
+$(call force,CFG_LPAE_ADDR_SPACE_BITS,36)
+$(call force,CFG_PL011,y)
+$(call force,CFG_ARM_GICV3,y)
+CFG_USER_TA_TARGETS ?= ta_arm64
+CFG_NUM_THREADS ?= CFG_TEE_CORE_NB_CORE
+CFG_CORE_HEAP_SIZE ?= 131072
+endif
+
 ifeq ($(platform-debugger-arm),1)
 # ARM debugger needs this
 platform-cflags-debug-info = -gdwarf-2

--- a/core/arch/arm/plat-marvell/platform_config.h
+++ b/core/arch/arm/plat-marvell/platform_config.h
@@ -131,6 +131,24 @@
 #define PLAT_MARVELL_FUSF_FUSE_BASE		0x87E004000000ll
 #define PLAT_MARVELL_FUSF_HUK_OFFSET		(0x90)
 
+#elif defined(PLATFORM_FLAVOR_cn10ka) || defined(PLATFORM_FLAVOR_cn10kb) || \
+	defined(PLATFORM_FLAVOR_cnf10ka) || defined(PLATFORM_FLAVOR_cnf10kb)
+/*
+ * cn10k specifics.
+ */
+
+/* GICv3 */
+#define GIC_BASE		0x801000000000ll
+#define GICD_OFFSET		0x0
+
+#define GICD_BASE		(GIC_BASE + GICD_OFFSET)
+
+/* UART */
+#define PLAT_MARVELL_BOOT_UART_BASE		0x87E028000000ll
+#define PLAT_MARVELL_BOOT_UART_CLK_IN_HZ	16666656
+#define MARVELL_CONSOLE_BAUDRATE		115200
+#define CONSOLE_UART_BASE			PLAT_MARVELL_BOOT_UART_BASE
+
 #else
 #error "Unknown platform flavor"
 #endif

--- a/core/arch/arm/plat-marvell/sub.mk
+++ b/core/arch/arm/plat-marvell/sub.mk
@@ -3,5 +3,8 @@ srcs-y += main.c
 ifneq (,$(filter $(PLATFORM_FLAVOR),otx2t96 otx2f95 otx2t98))
 srcs-$(CFG_ARM64_core) += otx2/core_pos.S
 endif
+ifneq (,$(filter $(PLATFORM_FLAVOR),cn10ka cn10kb cnf10ka cnf10kb))
+srcs-$(CFG_ARM64_core) += cn10k/core_pos.S
+endif
 srcs-$(PLATFORM_FLAVOR_armada7k8k) += armada7k8k/hal_sec_perf.c
 srcs-$(PLATFORM_FLAVOR_armada3700) += armada3700/hal_sec_perf.c


### PR DESCRIPTION
Add support for CN10K SoCs from Marvell.

Only tested 64-bit mode with default configurations:

1. Build command make PLATFORM=marvell-cn10ka
2. Passed xtest

Signed-off-by: Gowthami <gthiagarajan@marvell.com>
Reviewed-by: Anil Kumar Reddy <areddy3@marvell.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
