### PR TITLE
core: arm64: write_64bit_pair()

### DIFF
--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -355,6 +355,13 @@ static inline __noprof void tlbi_vale1is(uint64_t va)
 	asm volatile ("tlbi	vale1is, %0" : : "r" (va));
 }
 
+static inline void write_64bit_pair(uint64_t dst, uint64_t hi, uint64_t lo)
+{
+	/* 128bits should be written to hardware at one time */
+	asm volatile ("stp %1, %0, [%2]" : :
+		      "r" (hi), "r" (lo), "r" (dst) : "memory");
+}
+
 /*
  * Templates for register read/write functions based on mrs/msr
  */


### PR DESCRIPTION
Implement write_64bit_pair that write two 64 bits data together.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
