### PR TITLE
core: support larger values for CFG_TEE_CORE_NB_CORE

### DIFF
--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -116,6 +116,24 @@
 		movk    \_reg, :abs_g0_nc:\_val
 	.endm
 
+	.macro add_imm _reg, _val
+	.if ((\_val) > 0xfff)
+		add	\_reg, \_reg, ((\_val) >> 12), LSL #12
+	.endif
+	.if (((\_val) & 0xfff) > 0)
+		add	\_reg, \_reg, ((\_val) & 0xfff)
+	.endif
+	.endm
+
+	.macro sub_imm _reg, _val
+	.if ((\_val) > 0xfff)
+		sub	\_reg, \_reg, ((\_val) >> 12), LSL #12
+	.endif
+	.if (((\_val) & 0xfff) > 0)
+		sub	\_reg, \_reg, ((\_val) & 0xfff)
+	.endif
+	.endm
+
 	/*
 	 * Load address of <sym> into <reg>, <sym> being in the range
 	 * +/- 4GB of the PC (note that 'adr reg, sym' is limited to +/- 1MB).

--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -7,6 +7,7 @@
 #include <kernel/boot.h>
 #include <kernel/thread.h>
 #include <kernel/thread_private.h>
+#include <mm/core_mmu_arch.h>
 #include <sm/pm.h>
 #include <sm/sm.h>
 #include <types_ext.h>
@@ -157,4 +158,13 @@ DEFINES
 	       offsetof(struct boot_embdata, reloc_offset));
 	DEFINE(BOOT_EMBDATA_RELOC_LEN,
 	       offsetof(struct boot_embdata, reloc_len));
+
+#ifdef CORE_MMU_BASE_TABLE_OFFSET
+	/*
+	 * This define is too complex to be used as an argument for the
+	 * macros add_imm and sub_imm so evaluate it here.
+	 */
+	DEFINE(__CORE_MMU_BASE_TABLE_OFFSET, CORE_MMU_BASE_TABLE_OFFSET);
+#endif
+
 }

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -232,7 +232,7 @@ END_FUNC thread_unwind_user_mode
 
 		/* Update the mapping to use the full kernel mapping */
 		mrs	x0, ttbr0_el1
-		sub	x0, x0, #CORE_MMU_BASE_TABLE_OFFSET
+		sub_imm	x0, __CORE_MMU_BASE_TABLE_OFFSET
 		/* switch to kernel mode ASID */
 		bic	x0, x0, #BIT(TTBR_ASID_SHIFT)
 		msr	ttbr0_el1, x0
@@ -657,7 +657,7 @@ BTI(	bti	j)
 
 	/* Update the mapping to exclude the full kernel mapping */
 	mrs	x0, ttbr0_el1
-	add	x0, x0, #CORE_MMU_BASE_TABLE_OFFSET
+	add_imm	x0, __CORE_MMU_BASE_TABLE_OFFSET
 	orr	x0, x0, #BIT(TTBR_ASID_SHIFT) /* switch to user mode ASID */
 	msr	ttbr0_el1, x0
 	isb
@@ -729,8 +729,8 @@ icache_inv_user_range:
 BTI(	bti	j)
 	/* Update the mapping to exclude the full kernel mapping */
 	mrs	x5, ttbr0_el1	/* this register must be preserved */
-	add	x2, x5, #CORE_MMU_BASE_TABLE_OFFSET
-	orr	x2, x2, #BIT(TTBR_ASID_SHIFT) /* switch to user mode ASID */
+	orr	x2, x5, #BIT(TTBR_ASID_SHIFT) /* switch to user mode ASID */
+	add_imm	x2, __CORE_MMU_BASE_TABLE_OFFSET
 	msr	ttbr0_el1, x2
 	isb
 


### PR DESCRIPTION
With larger values of CFG_TEE_CORE_NB_CORE (for example, 18 on the marvell-cnf10ka platform) CORE_MMU_BASE_TABLE_OFFSET becomes to large to be used as an immediate value in add and sub assembly instructions. This is handled by populating a spare register using the mov_imm macro and use the spare register instead. But the mov_imm macro can handle complex defines so CORE_MMU_BASE_TABLE_OFFSET must be evaluated in asm-defines.c first.

This should fix errors like:
core/arch/arm/kernel/thread_a64.S: Assembler messages: core/arch/arm/kernel/thread_a64.S:339: Error: immediate out of range core/arch/arm/kernel/thread_a64.S:347: Error: immediate out of range core/arch/arm/kernel/thread_a64.S:355: Error: immediate out of range core/arch/arm/kernel/thread_a64.S:372: Error: immediate out of range core/arch/arm/kernel/thread_a64.S:379: Error: immediate out of range core/arch/arm/kernel/thread_a64.S:386: Error: immediate out of range core/arch/arm/kernel/thread_a64.S:660: Error: immediate out of range core/arch/arm/kernel/thread_a64.S:732: Error: immediate out of range make: *** [mk/compile.mk:165: out/core/arch/arm/kernel/thread_a64.o] Error 1

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
