### PR TITLE
plat-k3: Default to 2 core per cluster only for AM65x

### DIFF
--- a/core/arch/arm/plat-k3/conf.mk
+++ b/core/arch/arm/plat-k3/conf.mk
@@ -14,10 +14,13 @@ $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
 $(call force,CFG_GIC,y)
 $(call force,CFG_ARM_GICV3,y)
-$(call force,CFG_CORE_CLUSTER_SHIFT,1)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_K3_OTP_KEYWRITING,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
+
+ifneq (,$(filter ${PLATFORM_FLAVOR},am65x))
+$(call force,CFG_CORE_CLUSTER_SHIFT,1)
+endif
 
 ifneq (,$(filter ${PLATFORM_FLAVOR},am65x j721e j784s4 am64x am62x))
 CFG_WITH_SOFTWARE_PRNG ?= n


### PR DESCRIPTION
All other SoCs have 4 cores per cluster, which is the default, or they only have one cluster in which case this value is unimportant.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
