### PR TITLE
core: user_ta.c: promote panic message on abort from DMSG to EMSG_RAW

### DIFF
--- a/core/kernel/user_ta.c
+++ b/core/kernel/user_ta.c
@@ -201,8 +201,7 @@ static TEE_Result user_ta_enter(struct ts_session *session,
 
 	if (utc->ta_ctx.panicked) {
 		abort_print_current_ts();
-		DMSG("tee_user_ta_enter: TA panicked with code 0x%x",
-		     utc->ta_ctx.panic_code);
+		EMSG_RAW("TA panicked with code 0x%x", utc->ta_ctx.panic_code);
 		res = TEE_ERROR_TARGET_DEAD;
 	} else {
 		/*


### PR DESCRIPTION
When an abort condition happens in a TA (data abort, undefined instruction abort, etc.):
- A register dump is printed by the TEE core,
- Then the memory mappings and the call stack is displayed by ldelf,
- Finally the panic code is printed by the TEE core.

All the messages use the ERROR severity except the last one which is DEBUG. Therefore, switch from DMSG() to EMSG_RAW() for consistency with the register dump code.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
