### PR TITLE
core: pta: imx: disable access control for MP PTA

### DIFF
--- a/core/pta/imx/manufacturing_protection.c
+++ b/core/pta/imx/manufacturing_protection.c
@@ -95,6 +95,9 @@ pta_mp_open_session(uint32_t param_types __unused,
 {
 	struct ts_session *s = NULL;
 
+	if (IS_ENABLED(CFG_NXP_CAAM_MP_NO_ACCESS_CTRL))
+		return TEE_SUCCESS;
+
 	s = ts_get_calling_session();
 	if (!s || !is_user_ta_ctx(s->ctx))
 		return TEE_ERROR_ACCESS_DENIED;


### PR DESCRIPTION
Allow opening the PTA without a calling session.

Enabling CFG_NXP_CAAM_MP_NO_ACCESS_CTRL permits users to use the OP-TEE
client interface to retrieve the public key as well as to generate
signatures.

See OP-TEE/optee_client#352

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
