### PR TITLE
core: riscv: Add definitions of CLINT for platform spike

### DIFF
--- a/core/arch/riscv/plat-spike/platform_config.h
+++ b/core/arch/riscv/plat-spike/platform_config.h
@@ -14,4 +14,9 @@
 #define HTIF_BASE	0x40008000
 #endif
 
+/* CLINT */
+#ifndef CLINT_BASE
+#define CLINT_BASE	0x02000000
+#endif
+
 #endif


### PR DESCRIPTION
Add definitions for base address of CLINT, otherwise build failure occurs for platform spike.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
