### PR TITLE
libutils: mempool: fix unbalanced put_pool()

### DIFF
--- a/lib/libutils/ext/mempool.c
+++ b/lib/libutils/ext/mempool.c
@@ -180,6 +180,8 @@ void *mempool_calloc(struct mempool *pool, size_t nmemb, size_t size)
 
 void mempool_free(struct mempool *pool, void *ptr)
 {
-	raw_free(ptr, pool->mctx, false /*!wipe*/);
-	put_pool(pool);
+	if (ptr) {
+		raw_free(ptr, pool->mctx, false /*!wipe*/);
+		put_pool(pool);
+	}
 }


### PR DESCRIPTION
Prior to this patch mempool_free() unconditionally called put_pool(), but if the "ptr" argument is NULL it means that there hasn't been a corresponding call to get_pool(). Fix this only calling put_pool() for non-NULL pointers.

Fixes: a51d45b52503 ("libutils: mempool based raw malloc functions")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
