### PR TITLE
Fixing issues around FF-A direct message handling in SPMC

### DIFF
--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -555,8 +555,12 @@ static TEE_Result sp_open_session(struct sp_session **sess,
 		return TEE_ERROR_TARGET_DEAD;
 	}
 
-	/* Make the SP ready for its first run */
-	s->state = sp_idle;
+	/*
+	 * Make the SP ready for its first run.
+	 * Set state to busy to prevent other endpoints from sending messages to
+	 * the SP before its boot phase is done.
+	 */
+	s->state = sp_busy;
 	s->caller_id = 0;
 	sp_init_set_registers(ctx);
 	memcpy(&s->ffa_uuid, ffa_uuid, sizeof(*ffa_uuid));

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -27,7 +27,13 @@ void spmc_sp_start_thread(struct thread_smc_args *args)
 static void ffa_set_error(struct thread_smc_args *args, uint32_t error)
 {
 	args->a0 = FFA_ERROR;
+	args->a1 = FFA_PARAM_MBZ;
 	args->a2 = error;
+	args->a3 = FFA_PARAM_MBZ;
+	args->a4 = FFA_PARAM_MBZ;
+	args->a5 = FFA_PARAM_MBZ;
+	args->a6 = FFA_PARAM_MBZ;
+	args->a7 = FFA_PARAM_MBZ;
 }
 
 static void ffa_success(struct thread_smc_args *args)


### PR DESCRIPTION
There were multiple issues with FF-A direct message error handling in the SPMC component. This pull request introduces fixes in the following steps.
- Set initial SP state to busy which will prevent sending direct messages to uninitialized SPs.
- Clear MBZ registers of FFA_ERROR messages. This prevents sending back the reminiscence of the direct message in the error message.
- Cover all invalid cases in FF-A direct message request and response handlers. Also fix the logic behind determining the destination of the FFA_ERROR message.

I've extended the [SPMC test in trusted-services](https://review.trustedfirmware.org/c/TS/trusted-services/+/22959/1/components/service/spm_test/sp.c) by negative tests for covering all the error handler branches of FF-A direct message handlers.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
