### PR TITLE
drivers: caam: check OPTEE DDR location if the CAAM DMA is 32 bits width

### DIFF
--- a/core/drivers/crypto/caam/caam_ctrl.c
+++ b/core/drivers/crypto/caam/caam_ctrl.c
@@ -4,6 +4,7 @@
  *
  * Brief   CAAM Global Controller.
  */
+#include <assert.h>
 #include <caam_acipher.h>
 #include <caam_cipher.h>
 #include <caam_common.h>
@@ -20,6 +21,14 @@
 #include <initcall.h>
 #include <kernel/panic.h>
 #include <tee_api_types.h>
+
+/*
+ * If the CAAM DMA only supports 32 bits physical addresses, OPTEE must
+ * be located within the 32 bits address space.
+ */
+#ifndef CFG_CAAM_64BIT
+static_assert((CFG_TZDRAM_START + CFG_TZDRAM_SIZE) < UINT32_MAX);
+#endif
 
 /* Crypto driver initialization */
 static TEE_Result crypto_driver_init(void)


### PR DESCRIPTION
On i.MX platforms, the CAAM DMA width is limited to 32 bits. That limitation requires OPTEE to be located in the 32 bits DDR address space.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
