### PR TITLE
ta: pkcs11: raw data object attributes can be modified

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -2146,8 +2146,7 @@ static bool attribute_is_modifiable(struct pkcs11_session *session,
 			return true;
 		break;
 	case PKCS11_CKO_DATA:
-		/* None of the data object attributes are modifiable */
-		return false;
+		return true;
 	case PKCS11_CKO_CERTIFICATE:
 		return attr_is_modifiable_certificate(req_attr, session, obj);
 	default:


### PR DESCRIPTION
Fixes modification permissions for raw data object (PKCS11_CKO_DATA) attributes. These are modifiable, with exception of boolean attributes TOKEN, MODIFIABLE, DESTROYABLE and PRIVATE, that are already handled by attribute_is_modifiable() function.

Link: https://github.com/OP-TEE/optee_os/issues/6280

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
