### PR TITLE
crypto: stm32: fix SAES reset at probe time

### DIFF
--- a/core/drivers/crypto/stm32/stm32_saes.c
+++ b/core/drivers/crypto/stm32/stm32_saes.c
@@ -1388,8 +1388,8 @@ static TEE_Result stm32_saes_probe(const void *fdt, int node,
 	if (clk_enable(saes_pdata.clk))
 		panic();
 
-	/* External reset of SAES */
 	if (saes_pdata.reset) {
+		/* External reset of SAES */
 		if (rstctrl_assert_to(saes_pdata.reset, TIMEOUT_US_1MS))
 			panic();
 
@@ -1397,12 +1397,12 @@ static TEE_Result stm32_saes_probe(const void *fdt, int node,
 
 		if (rstctrl_deassert_to(saes_pdata.reset, TIMEOUT_US_1MS))
 			panic();
+	} else {
+		/* Internal reset of SAES */
+		io_setbits32(saes_pdata.base + _SAES_CR, _SAES_CR_IPRST);
+		udelay(SAES_RESET_DELAY);
+		io_clrbits32(saes_pdata.base + _SAES_CR, _SAES_CR_IPRST);
 	}
-
-	/* Internal reset of SAES */
-	io_setbits32(saes_pdata.base + _SAES_CR, _SAES_CR_IPRST);
-	udelay(SAES_RESET_DELAY);
-	io_clrbits32(saes_pdata.base + _SAES_CR, _SAES_CR_IPRST);
 
 	if (IS_ENABLED(CFG_CRYPTO_DRV_CIPHER)) {
 		res = stm32_register_cipher(SAES_IP);


### PR DESCRIPTION
Uses SAES internal reset sequence only when external reset controller is not available. This change fixes a non-systematic SAES error seen when SAES internal reset is triggered right after external reset sequence. Whereas a fixe could be to add a delay between external reset and internal reset sequences, this change simplifies the sequence as internal reset sequence is not needed when SAES instance is reset using its external reset controller.

Fixes: 4320f5cf30c5 ("crypto: stm32: SAES cipher support")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
