### PR TITLE
plat-k3: drivers: Open TRNG firewall for TIFS

### DIFF
--- a/core/arch/arm/plat-k3/drivers/sa2ul.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.c
@@ -28,6 +28,7 @@
 #define FW_ENABLE_REGION        0x0a
 #define FW_BACKGROUND_REGION    BIT(8)
 #define FW_BIG_ARM_PRIVID       0x01
+#define FW_TIFS_PRIVID          0xca
 #define FW_WILDCARD_PRIVID      0xc3
 #define FW_SECURE_ONLY          GENMASK_32(7, 0)
 #define FW_NON_SECURE           GENMASK_32(15, 0)
@@ -46,6 +47,7 @@ static TEE_Result sa2ul_init(void)
 	uint16_t owner_permission_bits = 0;
 	uint32_t control = 0;
 	uint32_t permissions[FWL_MAX_PRIVID_SLOTS] = { };
+	uint32_t num_perm = 0;
 	uint64_t start_address = 0;
 	uint64_t end_address = 0;
 	uint32_t val = 0;
@@ -116,10 +118,13 @@ static TEE_Result sa2ul_init(void)
 
 	/* Modify TRNG firewall to block all others access */
 	control = FW_ENABLE_REGION;
-	permissions[0] = (FW_BIG_ARM_PRIVID << 16) | FW_SECURE_ONLY;
 	start_address = RNG_BASE;
 	end_address = RNG_BASE + RNG_REG_SIZE - 1;
-	ret = ti_sci_set_fwl_region(fwl_id, rng_region, 1,
+	permissions[num_perm++] = (FW_BIG_ARM_PRIVID << 16) | FW_SECURE_ONLY;
+#if defined(PLATFORM_FLAVOR_am62x)
+	permissions[num_perm++] = (FW_TIFS_PRIVID << 16) | FW_NON_SECURE;
+#endif
+	ret = ti_sci_set_fwl_region(fwl_id, rng_region, num_perm,
 				    control, permissions,
 				    start_address, end_address);
 	if (ret) {

--- a/core/arch/arm/plat-k3/drivers/sa2ul.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.c
@@ -29,8 +29,8 @@
 #define FW_BACKGROUND_REGION    BIT(8)
 #define FW_BIG_ARM_PRIVID       0x01
 #define FW_WILDCARD_PRIVID      0xc3
-#define FW_SECURE_ONLY          GENMASK_32(8, 0)
-#define FW_NON_SECURE           GENMASK_32(16, 0)
+#define FW_SECURE_ONLY          GENMASK_32(7, 0)
+#define FW_NON_SECURE           GENMASK_32(15, 0)
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, SA2UL_BASE, SA2UL_REG_SIZE);
 


### PR DESCRIPTION
On devices with PLATFORM=k3-am62x, there is only one SA2UL instance, which is being shared between TIFS and OP-TEE.

Blocking access to TRNG from all other entities other than OP-TEE is causing firewall exception when being accessed by TIFS.

Allow access to TIFS to use SA2UL TRNG along with OP-TEE.

While at it, correct values for FW_SECURE_ONLY and FW_NON_SECURE.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
