### PR TITLE
core: io: IO_READ32_POLL_TIMEOUT()

### DIFF
--- a/core/include/io.h
+++ b/core/include/io.h
@@ -273,4 +273,31 @@ static inline void io_clrsetbits8(vaddr_t addr, uint8_t clear_mask,
 	io_write8(addr, (io_read8(addr) & ~clear_mask) | set_mask);
 }
 
+/*
+ * Poll on a IO memory content or timeout
+ *
+ * @_addr is the address of the memory cell accessed
+ * @_val represents the val of the memory cell accessed
+ * @_cond represents the condition to get the correct value
+ * @_delay_us represents the read interval in mircorseconds
+ * @_timeout_us represents the timeout period in microseconds
+ *
+ * @return nonzero value means timeout, 0 means got right value
+ */
+#define IO_READ32_POLL_TIMEOUT(_addr, _val, _cond, _delay_us, _timeout_us) \
+	({ \
+		uint32_t __timeout = 0; \
+		uint32_t __delay = (_delay_us); \
+		\
+		while (__timeout < (_timeout_us)) { \
+			(_val) = io_read32(_addr); \
+			if (_cond) \
+				break; \
+			__timeout += (__delay); \
+			udelay(__delay); \
+		} \
+		(_val) = io_read32(_addr); \
+		!(_cond); \
+	})
+
 #endif /*IO_H*/


### PR DESCRIPTION
Implement Polling Read Register Interface inspired by linux kernel.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
