### PR TITLE
zynqmp: remove redundant platform config code

### DIFF
--- a/core/arch/arm/plat-zynqmp/platform_config.h
+++ b/core/arch/arm/plat-zynqmp/platform_config.h
@@ -57,22 +57,8 @@
 	defined(PLATFORM_FLAVOR_zc1751_dc2) || \
 	defined(PLATFORM_FLAVOR_zcu102) || \
 	defined(PLATFORM_FLAVOR_zcu104) || \
-	defined(PLATFORM_FLAVOR_zcu106)
-
-#define GIC_BASE		0xF9010000
-#define UART0_BASE		0xFF000000
-#define UART1_BASE		0xFF010000
-
-#define IT_UART0		53
-#define IT_UART1		54
-
-#define UART0_CLK_IN_HZ		100000000
-#define UART1_CLK_IN_HZ		100000000
-
-#define GICD_OFFSET		0
-#define GICC_OFFSET		0x10000
-
-#elif defined(PLATFORM_FLAVOR_ultra96)
+	defined(PLATFORM_FLAVOR_zcu106) || \
+	defined(PLATFORM_FLAVOR_ultra96)
 
 #define GIC_BASE		0xF9010000
 #define UART0_BASE		0xFF000000


### PR DESCRIPTION
The hardware description is identical in all the platforms, there is no need for specific ultra96 code to define base addresses.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
