### PR TITLE
Firmware handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
           _make PLATFORM=vexpress-qemu_armv8a CFG_TA_GPROF_SUPPORT=y CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y CFG_ULIBS_MCOUNT=y
           _make PLATFORM=vexpress-qemu_armv8a CFG_NS_VIRTUALIZATION=y
           _make PLATFORM=vexpress-qemu_armv8a CFG_CORE_PREALLOC_EL0_TBLS=y
+          _make PLATFORM=vexpress-qemu_armv8a CFG_TRANSFER_LIST=y CFG_MAP_EXT_DT_SECURE=y
           _make PLATFORM=vexpress-qemu_armv8a CFG_CORE_SEL1_SPMC=y
           _make PLATFORM=vexpress-qemu_armv8a CFG_CORE_SEL2_SPMC=y CFG_CORE_PHYS_RELOCATABLE=y CFG_TZDRAM_START=0x0d304000 CFG_TZDRAM_SIZE=0x00cfc000
           _make PLATFORM=vexpress-qemu_armv8a CFG_{ATTESTATION,DEVICE_ENUM,RTC,SCMI,SECSTOR_TA_MGT}_PTA=y CFG_WITH_STATS=y CFG_TA_STATS=y

--- a/core/include/kernel/transfer_list.h
+++ b/core/include/kernel/transfer_list.h
@@ -1,0 +1,153 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023, Linaro Limited
+ */
+
+#ifndef __KERNEL_TRANSFER_LIST_H
+#define __KERNEL_TRANSFER_LIST_H
+
+#define TRANSFER_LIST_SIGNATURE		U(0x006ed0ff)
+#define TRANSFER_LIST_VERSION		U(0x0001)
+
+/*
+ * Init value of maximum alignment required by any transfer entry data in the TL
+ * specified as a power of two
+ */
+#define TRANSFER_LIST_INIT_MAX_ALIGN	U(3)
+
+/* Alignment required by transfer entry header start address, in bytes */
+#define TRANSFER_LIST_GRANULE		U(8)
+
+/*
+ * Version of the register convention used.
+ * Set to 1 for both AArch64 and AArch32 according to fw handoff spec v0.9
+ */
+#define REG_CONVENTION_VER_MASK BIT(24)
+
+/* Transfer list operation codes */
+#define TL_OPS_NONE	U(0) /* invalid for any operation */
+#define TL_OPS_ALL	U(1) /* valid for all operations */
+#define TL_OPS_RO	U(2) /* valid for read only */
+#define TL_OPS_CUS	U(3) /* either abort or special code to interpret */
+
+#ifndef __ASSEMBLER__
+
+#include <types_ext.h>
+
+/* Get alignment from a value specified as power of two */
+#define TL_ALIGNMENT_FROM_ORDER(a) BIT(a)
+
+enum transfer_list_tag_id {
+	TL_TAG_EMPTY = 0,
+	TL_TAG_FDT = 1,
+	TL_TAG_HOB_BLOCK = 2,
+	TL_TAG_HOB_LIST = 3,
+	TL_TAG_ACPI_TABLE_AGGREGATE = 4,
+	TL_TAG_OPTEE_PAGABLE_PART = 0x100,
+};
+
+struct transfer_list_header {
+	uint32_t signature;
+	uint8_t checksum;
+	uint8_t version;
+	uint8_t hdr_size;
+	uint8_t alignment;	/* max alignment of transfer entry data */
+	uint32_t size;		/* TL header + all transfer entries */
+	uint32_t max_size;
+	/*
+	 * Commented out element used to visualize dynamic part of the
+	 * data structure.
+	 *
+	 * Note that struct transfer_list_entry also is dynamic in size
+	 * so the elements can't be indexed directly but instead must be
+	 * traversed in order
+	 *
+	 * struct transfer_list_entry entries[];
+	 */
+};
+
+struct transfer_list_entry {
+	uint16_t tag_id;
+	uint8_t reserved0;	/* place holder for tag ID 3rd byte (MSB) */
+	uint8_t hdr_size;
+	uint32_t data_size;
+	/*
+	 * Commented out element used to visualize dynamic part of the
+	 * data structure.
+	 *
+	 * Note that padding is added at the end of @data to make it reach
+	 * a 8-byte boundary.
+	 *
+	 * uint8_t	data[ROUNDUP(data_size, 8)];
+	 */
+};
+
+struct transfer_list_header *transfer_list_map(paddr_t pa);
+void transfer_list_unmap_sync(struct transfer_list_header *tl);
+void transfer_list_unmap_nosync(struct transfer_list_header *tl);
+
+void transfer_list_dump(struct transfer_list_header *tl);
+struct transfer_list_header *transfer_list_init(paddr_t pa, size_t max_size);
+
+struct transfer_list_header *
+transfer_list_relocate(struct transfer_list_header *tl, paddr_t pa,
+		       size_t max_size);
+
+#if defined(CFG_TRANSFER_LIST)
+
+int transfer_list_check_header(const struct transfer_list_header *tl);
+
+struct transfer_list_entry *transfer_list_find(struct transfer_list_header *tl,
+					       uint16_t tag_id);
+
+void *transfer_list_entry_data(struct transfer_list_entry *tl_e);
+
+#else /* CFG_TRANSFER_LIST */
+
+static inline int
+transfer_list_check_header(const struct transfer_list_header *tl __unused)
+{
+	return TL_OPS_NONE;
+}
+
+static inline struct transfer_list_entry *
+transfer_list_find(struct transfer_list_header *tl __unused,
+		   uint16_t tag_id __unused)
+{
+	return NULL;
+}
+
+static inline void *
+transfer_list_entry_data(struct transfer_list_entry *tl_e __unused)
+{
+	return NULL;
+}
+
+#endif /* CFG_TRANSFER_LIST */
+
+void transfer_list_update_checksum(struct transfer_list_header *tl);
+bool transfer_list_verify_checksum(const struct transfer_list_header *tl);
+
+bool transfer_list_set_data_size(struct transfer_list_header *tl,
+				 struct transfer_list_entry *tl_e,
+				 uint32_t new_data_size);
+
+bool transfer_list_rem(struct transfer_list_header *tl,
+		       struct transfer_list_entry *tl_e);
+
+struct transfer_list_entry *transfer_list_add(struct transfer_list_header *tl,
+					      uint16_t tag_id,
+					      uint32_t data_size,
+					      const void *data);
+
+struct transfer_list_entry *
+transfer_list_add_with_align(struct transfer_list_header *tl, uint16_t tag_id,
+			     uint32_t data_size, const void *data,
+			     uint8_t alignment);
+
+struct transfer_list_entry *
+transfer_list_next(struct transfer_list_header *tl,
+		   struct transfer_list_entry *last);
+
+#endif /*__ASSEMBLER__*/
+#endif /*__TRANSFER_LIST_H*/

--- a/core/include/mm/core_mmu.h
+++ b/core/include/mm/core_mmu.h
@@ -77,6 +77,7 @@
  * MEM_AREA_IO_SEC:   Secure HW mapped registers
  * MEM_AREA_EXT_DT:   Memory loads external device tree
  * MEM_AREA_MANIFEST_DT: Memory loads manifest device tree
+ * MEM_AREA_TRANSFER_LIST: Memory area mapped for Transfer List
  * MEM_AREA_RES_VASPACE: Reserved virtual memory space
  * MEM_AREA_SHM_VASPACE: Virtual memory space for dynamic shared memory buffers
  * MEM_AREA_TS_VASPACE: TS va space, only used with phys_to_virt()
@@ -106,6 +107,7 @@ enum teecore_memtypes {
 	MEM_AREA_IO_SEC,
 	MEM_AREA_EXT_DT,
 	MEM_AREA_MANIFEST_DT,
+	MEM_AREA_TRANSFER_LIST,
 	MEM_AREA_RES_VASPACE,
 	MEM_AREA_SHM_VASPACE,
 	MEM_AREA_TS_VASPACE,
@@ -140,6 +142,7 @@ static inline const char *teecore_memtype_name(enum teecore_memtypes type)
 		[MEM_AREA_IO_SEC] = "IO_SEC",
 		[MEM_AREA_EXT_DT] = "EXT_DT",
 		[MEM_AREA_MANIFEST_DT] = "MANIFEST_DT",
+		[MEM_AREA_TRANSFER_LIST] = "TRANSFER_LIST",
 		[MEM_AREA_RES_VASPACE] = "RES_VASPACE",
 		[MEM_AREA_SHM_VASPACE] = "SHM_VASPACE",
 		[MEM_AREA_TS_VASPACE] = "TS_VASPACE",

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -51,6 +51,8 @@ endif
 srcs-$(CFG_EMBEDDED_TS) += embedded_ts.c
 srcs-y += pseudo_ta.c
 
+srcs-$(CFG_TRANSFER_LIST) += transfer_list.c
+
 ifeq ($(CFG_SYSCALL_FTRACE),y)
 # We would not like to profile spin_lock_debug.c file as it provides
 # common APIs that are needed for ftrace framework to trace syscalls.

--- a/core/kernel/transfer_list.c
+++ b/core/kernel/transfer_list.c
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023, Linaro Limited
+ */
+
+/*******************************************************************************
+ * Transfer list library compliant with the Firmware Handoff specification at:
+ * https://github.com/FirmwareHandoff/firmware_handoff
+ ******************************************************************************/
+
+#include <kernel/cache_helpers.h>
+#include <kernel/panic.h>
+#include <kernel/transfer_list.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <string.h>
+#include <util.h>
+
+/*******************************************************************************
+ * Adapt a physical address to match the maximum transfer entry data alignment
+ * required by an existing transfer list.
+ * Compliant with 2.4.6 of Firmware Handoff specification (v0.9).
+ * @pa: Physical address for adapting.
+ * @tl: Pointer to the existing transfer list.
+ * Return the adapted physical address.
+ ******************************************************************************/
+static paddr_t get_align_base_addr(paddr_t pa,
+				   struct transfer_list_header *tl)
+{
+	paddr_t align_mask = TL_ALIGNMENT_FROM_ORDER(tl->alignment) - 1;
+	paddr_t align_off = (paddr_t)tl & align_mask;
+	paddr_t new_addr = (pa & ~align_mask) + align_off;
+
+	if (new_addr < pa)
+		new_addr += TL_ALIGNMENT_FROM_ORDER(tl->alignment);
+
+	return new_addr;
+}
+
+static void unmap_list(struct transfer_list_header *tl, size_t sz)
+{
+	if (core_mmu_remove_mapping(MEM_AREA_TRANSFER_LIST, tl, sz))
+		panic("Failed to remove transfer list mapping");
+}
+
+struct transfer_list_header *transfer_list_map(paddr_t pa)
+{
+	struct transfer_list_header *tl = NULL;
+	size_t sz = SMALL_PAGE_SIZE;
+	size_t old_sz = 0;
+
+	while (true) {
+		tl = core_mmu_add_mapping(MEM_AREA_TRANSFER_LIST, pa, sz);
+		if (!tl) {
+			EMSG("Failed to map TL with PA %#"PRIxPA", size %#zx",
+			     pa, sz);
+			return NULL;
+		}
+		old_sz = sz;
+
+		if (transfer_list_check_header(tl) == TL_OPS_NONE) {
+			unmap_list(tl, sz);
+			return NULL;
+		}
+
+		if (tl->max_size <= sz)
+			return tl;
+
+		sz = ROUNDUP(tl->max_size, SMALL_PAGE_SIZE);
+		unmap_list(tl, old_sz);
+	}
+}
+
+void transfer_list_unmap_sync(struct transfer_list_header *tl)
+{
+	size_t sz = tl->max_size;
+
+	transfer_list_update_checksum(tl);
+	dcache_cleaninv_range(tl, sz);
+	unmap_list(tl, sz);
+}
+
+void transfer_list_unmap_nosync(struct transfer_list_header *tl)
+{
+	unmap_list(tl, tl->max_size);
+}
+
+void transfer_list_dump(struct transfer_list_header *tl)
+{
+	struct transfer_list_entry *tl_e = NULL;
+	int i __maybe_unused = 0;
+
+	if (!tl)
+		return;
+
+	DMSG("Dump transfer list:");
+	DMSG("signature  %#"PRIx32, tl->signature);
+	DMSG("checksum   %#"PRIx8, tl->checksum);
+	DMSG("version    %#"PRIx8, tl->version);
+	DMSG("hdr_size   %#"PRIx8, tl->hdr_size);
+	DMSG("alignment  %#"PRIx8, tl->alignment);
+	DMSG("size       %#"PRIx32, tl->size);
+	DMSG("max_size   %#"PRIx32, tl->max_size);
+	while (true) {
+		tl_e = transfer_list_next(tl, tl_e);
+		if (!tl_e)
+			break;
+
+		DMSG("Entry %d:", i++);
+		DMSG("tag_id     %#"PRIx16, tl_e->tag_id);
+		DMSG("hdr_size   %#"PRIx8, tl_e->hdr_size);
+		DMSG("data_size  %#"PRIx32, tl_e->data_size);
+		DMSG("data_addr  %#"PRIxVA,
+		     (vaddr_t)transfer_list_entry_data(tl_e));
+	}
+}
+
+/*******************************************************************************
+ * Creating a transfer list in a specified reserved memory region.
+ * Compliant with 2.4.5 of Firmware Handoff specification (v0.9).
+ * @pa: Physical address for residing the new transfer list.
+ * @max_size: Maximum size of the new transfer list.
+ * Return pointer to the created transfer list or NULL on error.
+ ******************************************************************************/
+struct transfer_list_header *transfer_list_init(paddr_t pa, size_t max_size)
+{
+	struct transfer_list_header *tl = NULL;
+	int align = TL_ALIGNMENT_FROM_ORDER(TRANSFER_LIST_INIT_MAX_ALIGN);
+
+	if (!pa || !max_size)
+		return NULL;
+
+	if (!IS_ALIGNED(pa, align) || !IS_ALIGNED(max_size, align) ||
+	    max_size < sizeof(*tl))
+		return NULL;
+
+	tl = core_mmu_add_mapping(MEM_AREA_TRANSFER_LIST, pa, max_size);
+	if (!tl)
+		return NULL;
+
+	memset(tl, 0, max_size);
+	tl->signature = TRANSFER_LIST_SIGNATURE;
+	tl->version = TRANSFER_LIST_VERSION;
+	tl->hdr_size = sizeof(*tl);
+	tl->alignment = TRANSFER_LIST_INIT_MAX_ALIGN; /* initial max align */
+	tl->size = sizeof(*tl); /* initial size is the size of header */
+	tl->max_size = max_size;
+
+	transfer_list_update_checksum(tl);
+
+	return tl;
+}
+
+/*******************************************************************************
+ * Relocating a transfer list to a specified reserved memory region.
+ * Compliant with 2.4.6 of Firmware Handoff specification (v0.9).
+ * @tl: Pointer to the transfer list for relocating.
+ * @pa: Physical address for relocating the transfer list.
+ * @max_size: Maximum size of the transfer list after relocating
+ * Return pointer to the relocated transfer list or NULL on error.
+ ******************************************************************************/
+struct transfer_list_header *
+transfer_list_relocate(struct transfer_list_header *tl, paddr_t pa,
+		       size_t max_size)
+{
+	paddr_t new_addr = 0;
+	struct transfer_list_header *new_tl = NULL;
+	size_t new_max_size = 0;
+
+	if (!tl || !pa || !max_size)
+		return NULL;
+
+	new_addr = get_align_base_addr(pa, tl);
+	new_max_size = max_size - (new_addr - pa);
+
+	/* The new space is not sufficient for the TL */
+	if (tl->size > new_max_size)
+		return NULL;
+
+	new_tl = core_mmu_add_mapping(MEM_AREA_TRANSFER_LIST, new_addr,
+				      new_max_size);
+	if (!new_tl)
+		return NULL;
+
+	memmove(new_tl, tl, tl->size);
+	new_tl->max_size = new_max_size;
+
+	transfer_list_update_checksum(new_tl);
+	transfer_list_unmap_nosync(tl);
+
+	return new_tl;
+}
+
+/*******************************************************************************
+ * Verifying the header of a transfer list.
+ * Compliant with 2.4.1 of Firmware Handoff specification (v0.9).
+ * @tl: Pointer to the transfer list.
+ * Return transfer list operation status code.
+ ******************************************************************************/
+int transfer_list_check_header(const struct transfer_list_header *tl)
+{
+	if (!tl)
+		return TL_OPS_NONE;
+
+	if (tl->signature != TRANSFER_LIST_SIGNATURE) {
+		EMSG("Bad transfer list signature %#"PRIx32, tl->signature);
+		return TL_OPS_NONE;
+	}
+
+	if (!tl->max_size) {
+		EMSG("Bad transfer list max size %#"PRIx32, tl->max_size);
+		return TL_OPS_NONE;
+	}
+
+	if (tl->size > tl->max_size) {
+		EMSG("Bad transfer list size %#"PRIx32, tl->size);
+		return TL_OPS_NONE;
+	}
+
+	if (tl->hdr_size != sizeof(struct transfer_list_header)) {
+		EMSG("Bad transfer list header size %#"PRIx8, tl->hdr_size);
+		return TL_OPS_NONE;
+	}
+
+	if (!transfer_list_verify_checksum(tl)) {
+		EMSG("Bad transfer list checksum %#"PRIx8, tl->checksum);
+		return TL_OPS_NONE;
+	}
+
+	if (tl->version == 0) {
+		EMSG("Transfer list version is invalid");
+		return TL_OPS_NONE;
+	} else if (tl->version == TRANSFER_LIST_VERSION) {
+		DMSG("Transfer list version is valid for all operations");
+		return TL_OPS_ALL;
+	} else if (tl->version > TRANSFER_LIST_VERSION) {
+		DMSG("Transfer list version is valid for read-only");
+		return TL_OPS_RO;
+	}
+
+	DMSG("Old transfer list version is detected");
+	return TL_OPS_CUS;
+}
+
+/*******************************************************************************
+ * Enumerate the next transfer entry.
+ * @tl: Pointer to the transfer list.
+ * @cur: Pointer to the current transfer entry where we want to search for the
+ *       next one.
+ * Return pointer to the next transfer entry or NULL on error or if @cur is the
+ * last entry.
+ ******************************************************************************/
+struct transfer_list_entry *transfer_list_next(struct transfer_list_header *tl,
+					       struct transfer_list_entry *cur)
+{
+	struct transfer_list_entry *tl_e = NULL;
+	vaddr_t tl_ev = 0;
+	vaddr_t va = 0;
+	vaddr_t ev = 0;
+	size_t sz = 0;
+
+	if (!tl)
+		return NULL;
+
+	tl_ev = (vaddr_t)tl + tl->size;
+
+	if (cur) {
+		va = (vaddr_t)cur;
+		/* check if the total size overflow */
+		if (ADD_OVERFLOW(cur->hdr_size, cur->data_size, &sz))
+			return NULL;
+		/* roundup to the next entry */
+		if (ADD_OVERFLOW(va, sz, &va) ||
+		    ROUNDUP_OVERFLOW(va, TRANSFER_LIST_GRANULE, &va))
+			return NULL;
+	} else {
+		va = (vaddr_t)tl + tl->hdr_size;
+	}
+
+	tl_e = (struct transfer_list_entry *)va;
+
+	if (va + sizeof(*tl_e) > tl_ev || tl_e->hdr_size < sizeof(*tl_e) ||
+	    ADD_OVERFLOW(tl_e->hdr_size, tl_e->data_size, &sz) ||
+	    ADD_OVERFLOW(va, sz, &ev) || ev > tl_ev)
+		return NULL;
+
+	return tl_e;
+}
+
+/*******************************************************************************
+ * Calculate the byte sum (modulo 256) of a transfer list.
+ * @tl: Pointer to the transfer list.
+ * Return byte sum of the transfer list.
+ ******************************************************************************/
+static uint8_t calc_byte_sum(const struct transfer_list_header *tl)
+{
+	uint8_t *b = (uint8_t *)tl;
+	uint8_t cs = 0;
+	size_t n = 0;
+
+	if (!tl)
+		return 0;
+
+	for (n = 0; n < tl->size; n++)
+		cs += b[n];
+
+	return cs;
+}
+
+/*******************************************************************************
+ * Update the checksum of a transfer list.
+ * @tl: Pointer to the transfer list.
+ * Return updated checksum of the transfer list.
+ ******************************************************************************/
+void transfer_list_update_checksum(struct transfer_list_header *tl)
+{
+	uint8_t cs = 0;
+
+	if (!tl)
+		return;
+
+	cs = calc_byte_sum(tl);
+	cs -= tl->checksum;
+	cs = 256 - cs;
+	tl->checksum = cs;
+	assert(transfer_list_verify_checksum(tl));
+}
+
+/*******************************************************************************
+ * Verify the checksum of a transfer list.
+ * @tl: Pointer to the transfer list.
+ * Return true if verified or false if not.
+ ******************************************************************************/
+bool transfer_list_verify_checksum(const struct transfer_list_header *tl)
+{
+	return !calc_byte_sum(tl);
+}
+
+/*******************************************************************************
+ * Update the data size of a transfer entry.
+ * @tl: Pointer to the transfer list.
+ * @tl_e: Pointer to the transfer entry.
+ * @new_data_size: New data size of the transfer entry.
+ * Return true on success or false on error.
+ ******************************************************************************/
+bool transfer_list_set_data_size(struct transfer_list_header *tl,
+				 struct transfer_list_entry *tl_e,
+				 uint32_t new_data_size)
+{
+	vaddr_t tl_old_ev = 0;
+	vaddr_t new_ev = 0;
+	vaddr_t old_ev = 0;
+	vaddr_t ru_new_ev = 0;
+	struct transfer_list_entry *dummy_te = NULL;
+	size_t gap = 0;
+	size_t mov_dis = 0;
+	size_t sz = 0;
+
+	if (!tl || !tl_e)
+		return false;
+
+	tl_old_ev = (vaddr_t)tl + tl->size;
+
+	/*
+	 * Calculate the old and new end of transfer entry
+	 * both must be roundup to align with TRANSFER_LIST_GRANULE
+	 */
+	if (ADD_OVERFLOW(tl_e->hdr_size, tl_e->data_size, &sz) ||
+	    ADD_OVERFLOW((vaddr_t)tl_e, sz, &old_ev) ||
+	    ROUNDUP_OVERFLOW(old_ev, TRANSFER_LIST_GRANULE, &old_ev))
+		return false;
+
+	if (ADD_OVERFLOW(tl_e->hdr_size, new_data_size, &sz) ||
+	    ADD_OVERFLOW((vaddr_t)tl_e, sz, &new_ev) ||
+	    ROUNDUP_OVERFLOW(new_ev, TRANSFER_LIST_GRANULE, &new_ev))
+		return false;
+
+	if (new_ev > old_ev) {
+		/*
+		 * Move distance should be roundup to meet the requirement of
+		 * transfer entry data max alignment.
+		 * Ensure that the increased size doesn't exceed the max size
+		 * of TL
+		 */
+		mov_dis = new_ev - old_ev;
+		if (ROUNDUP_OVERFLOW(mov_dis,
+				     TL_ALIGNMENT_FROM_ORDER(tl->alignment),
+				     &mov_dis) ||
+		    tl->size + mov_dis > tl->max_size) {
+			return false;
+		}
+		ru_new_ev = old_ev + mov_dis;
+		memmove((void *)ru_new_ev, (void *)old_ev, tl_old_ev - old_ev);
+		tl->size += mov_dis;
+		gap = ru_new_ev - new_ev;
+	} else {
+		gap = old_ev - new_ev;
+	}
+
+	if (gap >= sizeof(*dummy_te)) {
+		/* Create a dummy transfer entry to fill up the gap */
+		dummy_te = (struct transfer_list_entry *)new_ev;
+		dummy_te->tag_id = TL_TAG_EMPTY;
+		dummy_te->reserved0 = 0;
+		dummy_te->hdr_size = sizeof(*dummy_te);
+		dummy_te->data_size = gap - sizeof(*dummy_te);
+	}
+
+	tl_e->data_size = new_data_size;
+
+	transfer_list_update_checksum(tl);
+	return true;
+}
+
+/*******************************************************************************
+ * Remove a specified transfer entry from a transfer list.
+ * @tl: Pointer to the transfer list.
+ * @tl_e: Pointer to the transfer entry.
+ * Return true on success or false on error.
+ ******************************************************************************/
+bool transfer_list_rem(struct transfer_list_header *tl,
+		       struct transfer_list_entry *tl_e)
+{
+	if (!tl || !tl_e || (vaddr_t)tl_e > (vaddr_t)tl + tl->size)
+		return false;
+
+	tl_e->tag_id = TL_TAG_EMPTY;
+	tl_e->reserved0 = 0;
+	transfer_list_update_checksum(tl);
+	return true;
+}
+
+/*******************************************************************************
+ * Add a new transfer entry into a transfer list.
+ * Compliant with 2.4.3 of Firmware Handoff specification (v0.9).
+ * @tl: Pointer to the transfer list.
+ * @tag_id: Tag ID for the new transfer entry.
+ * @data_size: Data size of the new transfer entry.
+ * @data: Pointer to the data for the new transfer entry.
+ *        NULL to skip data copying.
+ * Return pointer to the added transfer entry or NULL on error.
+ ******************************************************************************/
+struct transfer_list_entry *transfer_list_add(struct transfer_list_header *tl,
+					      uint16_t tag_id,
+					      uint32_t data_size,
+					      const void *data)
+{
+	vaddr_t max_tl_ev = 0;
+	vaddr_t tl_ev = 0;
+	vaddr_t ev = 0;
+	struct transfer_list_entry *tl_e = NULL;
+	size_t sz = 0;
+
+	if (!tl)
+		return NULL;
+
+	max_tl_ev = (vaddr_t)tl + tl->max_size;
+	tl_ev = (vaddr_t)tl + tl->size;
+	ev = tl_ev;
+
+	/*
+	 * Skip the step 1 (optional step).
+	 * New transfer entry will be added into the tail
+	 */
+	if (ADD_OVERFLOW(sizeof(*tl_e), data_size, &sz) ||
+	    ADD_OVERFLOW(ev, sz, &ev) ||
+	    ROUNDUP_OVERFLOW(ev, TRANSFER_LIST_GRANULE, &ev) ||
+	    ev > max_tl_ev) {
+		return NULL;
+	}
+
+	tl_e = (struct transfer_list_entry *)tl_ev;
+	*tl_e = (struct transfer_list_entry){
+		.tag_id = tag_id,
+		.hdr_size = sizeof(*tl_e),
+		.data_size = data_size,
+	};
+
+	tl->size += ev - tl_ev;
+
+	if (data)
+		memmove(tl_e + tl_e->hdr_size, data, data_size);
+
+	transfer_list_update_checksum(tl);
+
+	return tl_e;
+}
+
+/*******************************************************************************
+ * Add a new transfer entry into a transfer list with specified new data
+ * alignment requirement.
+ * Compliant with 2.4.4 of Firmware Handoff specification (v0.9).
+ * @tl: Pointer to the transfer list.
+ * @tag_id: Tag ID for the new transfer entry.
+ * @data_size: Data size of the new transfer entry.
+ * @data: Pointer to the data for the new transfer entry.
+ * @alignment: New data alignment specified as a power of two.
+ * Return pointer to the added transfer entry or NULL on error.
+ ******************************************************************************/
+struct transfer_list_entry *
+transfer_list_add_with_align(struct transfer_list_header *tl, uint16_t tag_id,
+			     uint32_t data_size, const void *data,
+			     uint8_t alignment)
+{
+	struct transfer_list_entry *tl_e = NULL;
+	vaddr_t tl_ev = 0;
+	vaddr_t ev = 0;
+	vaddr_t new_tl_ev = 0;
+	size_t dummy_te_data_sz = 0;
+
+	if (!tl)
+		return NULL;
+
+	tl_ev = (vaddr_t)tl + tl->size;
+	ev = tl_ev + sizeof(struct transfer_list_entry);
+
+	if (!IS_ALIGNED(ev, TL_ALIGNMENT_FROM_ORDER(alignment))) {
+		/*
+		 * Transfer entry data address is not aligned to the new
+		 * alignment. Fill the gap with an empty transfer entry as a
+		 * placeholder before adding the desired transfer entry
+		 */
+		new_tl_ev = ROUNDUP(ev, TL_ALIGNMENT_FROM_ORDER(alignment)) -
+			    sizeof(struct transfer_list_entry);
+		assert(new_tl_ev - tl_ev > sizeof(struct transfer_list_entry));
+		dummy_te_data_sz = new_tl_ev - tl_ev -
+				   sizeof(struct transfer_list_entry);
+		if (!transfer_list_add(tl, TL_TAG_EMPTY, dummy_te_data_sz,
+				       NULL)) {
+			return NULL;
+		}
+	}
+
+	tl_e = transfer_list_add(tl, tag_id, data_size, data);
+
+	if (alignment > tl->alignment) {
+		tl->alignment = alignment;
+		transfer_list_update_checksum(tl);
+	}
+
+	return tl_e;
+}
+
+/*******************************************************************************
+ * Search for an existing transfer entry with the specified tag id from a
+ * transfer list.
+ * @tl: Pointer to the transfer list.
+ * @tag_id: Tag ID to match a transfer entry.
+ * Return pointer to the found transfer entry or NULL if not found.
+ ******************************************************************************/
+struct transfer_list_entry *transfer_list_find(struct transfer_list_header *tl,
+					       uint16_t tag_id)
+{
+	struct transfer_list_entry *tl_e = NULL;
+
+	do {
+		tl_e = transfer_list_next(tl, tl_e);
+	} while (tl_e && tl_e->tag_id != tag_id);
+
+	return tl_e;
+}
+
+/*******************************************************************************
+ * Retrieve the data pointer of a specified transfer entry.
+ * @tl_e: Pointer to the transfer entry.
+ * Return pointer to the transfer entry data or NULL on error.
+ ******************************************************************************/
+void *transfer_list_entry_data(struct transfer_list_entry *tl_e)
+{
+	if (!tl_e)
+		return NULL;
+
+	return (uint8_t *)tl_e + tl_e->hdr_size;
+}

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -759,6 +759,8 @@ uint32_t core_mmu_type_to_attr(enum teecore_memtypes t)
 		return attr | TEE_MATTR_PRW | cached;
 	case MEM_AREA_MANIFEST_DT:
 		return attr | TEE_MATTR_SECURE | TEE_MATTR_PR | cached;
+	case MEM_AREA_TRANSFER_LIST:
+		return attr | TEE_MATTR_SECURE | TEE_MATTR_PRW | cached;
 	case MEM_AREA_EXT_DT:
 		/*
 		 * If CFG_MAP_EXT_DT_SECURE is enabled map the external device
@@ -1434,6 +1436,7 @@ static void check_mem_map(struct tee_mmap_region *map)
 		case MEM_AREA_IO_NSEC:
 		case MEM_AREA_EXT_DT:
 		case MEM_AREA_MANIFEST_DT:
+		case MEM_AREA_TRANSFER_LIST:
 		case MEM_AREA_RAM_SEC:
 		case MEM_AREA_RAM_NSEC:
 		case MEM_AREA_RES_VASPACE:

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -495,6 +495,16 @@ ifeq ($(CFG_MAP_EXT_DT_SECURE),y)
 $(call force,CFG_DT,y)
 endif
 
+# This option enables OP-TEE to support boot arguments handover via Transfer
+# List defined in Firmware Handoff specification.
+# This feature requires the support of Device Tree.
+CFG_TRANSFER_LIST ?= n
+ifeq ($(CFG_TRANSFER_LIST),y)
+$(call force,CFG_DT,y)
+$(call force,CFG_EXTERNAL_DT,y)
+$(call force,CFG_MAP_EXT_DT_SECURE,y)
+endif
+
 # Maximum size of the Device Tree Blob, has to be large enough to allow
 # editing of the supplied DTB.
 CFG_DTB_MAX_SIZE ?= 0x10000


### PR DESCRIPTION
Add supports for Transfer List into core, which are compliant to the Firmware Handoff
specification v0.9 (https://github.com/FirmwareHandoff/firmware_handoff/releases/tag/v0.9).

The motivation for this patch set is to unify the way of arguments handoff between all boot stages (BL2/BL31/BL32/BL33).
In current practice, when the Transfer List is enabled between BL2 and BL33 (See the related patch sets for TF-A below for reference),
we need this patch to allow the DTB nodes appended by OP-TEE can be reflected into the Transfer List memory and passed to BL33.

Reference:
1. Patch to introduce Transfer List into TF-A: https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/22215
2. Patch to enable Transfer List between the handoff from BL2 to BL33 on qemu: https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/22178