### PR TITLE
Core: support fault mitigations in non-threaded code

### DIFF
--- a/core/arch/arm/include/kernel/thread_arch.h
+++ b/core/arch/arm/include/kernel/thread_arch.h
@@ -64,6 +64,9 @@ struct thread_core_local {
 #ifdef CFG_CORE_DEBUG_CHECK_STACKS
 	bool stackcheck_recursion;
 #endif
+#ifdef CFG_FAULT_MITIGATION
+	struct ftmn_func_arg *ftmn_arg;
+#endif
 } THREAD_CORE_LOCAL_ALIGNED;
 
 struct thread_vector_table {

--- a/lib/libutils/ext/include/fault_mitigation.h
+++ b/lib/libutils/ext/include/fault_mitigation.h
@@ -250,7 +250,10 @@ extern struct ftmn_func_arg *__ftmn_global_func_arg;
 static inline struct ftmn_func_arg **__ftmn_get_tsd_func_arg_pp(void)
 {
 #if defined(CFG_FAULT_MITIGATION) && defined(__KERNEL__)
-	return &thread_get_tsd()->ftmn_arg;
+    if (thread_get_id_may_fail() >= 0)
+		return &thread_get_tsd()->ftmn_arg;
+	else
+		return &thread_get_core_local()->ftmn_arg;
 #elif defined(CFG_FAULT_MITIGATION)
 	return &__ftmn_global_func_arg;
 #else


### PR DESCRIPTION
Fix the issue of fault mitigation that won't work in interrupt handler function.
assertion 'ct >= 0 && ct < CFG_NUM_THREADS' failed at core/arch/arm/kernel/thread.c:799 <thread_get_id>

The problem is in  __ftmn_get_tsd_func_arg_pp whhich call thread_get_tsd which thread_get_id. The reason is that interrupt handler is not associated with any thread, so the ct (current_thread_id) value is -1 that would cause assert problem.

The fix is to add ftmn_arg to thread_core_local and the new variable would be used when current thread is < 0.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
