### PR TITLE
scripts: sign_rproc_fw: clean up unused TLV method

### DIFF
--- a/scripts/sign_rproc_fw.py
+++ b/scripts/sign_rproc_fw.py
@@ -119,9 +119,6 @@ class TLV():
         self.buf = bytearray()
         self.tlvs = {}
 
-    def __len__(self):
-        return TLV_INFO_SIZE + len(self.buf)
-
     def add(self, kind, payload):
         """
         Add a TLV record. Argument type is either the type scalar ID or a


### PR DESCRIPTION
Remove the __len__ method of the TLV class. It is not being used and uses an undefined variable TLV_INFO_SIZE. This method is a remnant of code that was removed during upstream reviews.

Fixes: e8ef53536 ("scripts: add remote processor firmware signature tool")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
