### PR TITLE
drivers: ns16550: Implement RX related features

### DIFF
--- a/core/include/drivers/ns16550.h
+++ b/core/include/drivers/ns16550.h
@@ -33,6 +33,8 @@
 #include <io.h>
 #include <types_ext.h>
 
+#define NS16550_UART_REG_SIZE	0x1000
+
 #define IO_WIDTH_U8		0
 #define IO_WIDTH_U32		1
 


### PR DESCRIPTION
Implement ns16550_getchar() and ns16550_have_rx_data() for RX related serial operations into ns16550 UART driver.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
