### PR TITLE
RISC-V: Implement SBI based protocol

### DIFF
--- a/core/arch/riscv/include/sbi.h
+++ b/core/arch/riscv/include/sbi.h
@@ -22,6 +22,7 @@
 /* SBI Extension IDs */
 #define SBI_EXT_0_1_CONSOLE_PUTCHAR	0x01, 0
 #define SBI_EXT_HSM			0x48534D
+#define SBI_EXT_TEE			0x544545
 
 /* SBI function IDs for HSM extension */
 #define SBI_EXT_HSM_HART_START		U(0)

--- a/core/arch/riscv/include/tee/teeabi.h
+++ b/core/arch/riscv/include/tee/teeabi.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023 Andes Technology Corporation
+ */
+
+#ifndef TEEABI_H
+#define TEEABI_H
+
+#include <compiler.h>
+
+/*
+ * Implement based on the transport method used to communicate between
+ * untrusted domain and trusted domain. It could be an SBI/ECALL-based to
+ * a security monitor running in M-Mode and panic or messaging-based across
+ * domains where we return to a messaging callback which parses and handles
+ * messages.
+ */
+void __weak teeabi_return_to_ree(unsigned long arg0 __maybe_unused,
+				 unsigned long arg1 __maybe_unused,
+				 unsigned long arg2 __maybe_unused,
+				 unsigned long arg3 __maybe_unused,
+				 unsigned long arg4 __maybe_unused,
+				 unsigned long arg5 __maybe_unused);
+
+#endif /*TEEABI_H*/

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -86,4 +86,8 @@ DEFINES
 	DEFINE(CORE_MMU_CONFIG_SIZE, sizeof(struct core_mmu_config));
 	DEFINE(CORE_MMU_CONFIG_SATP,
 	       offsetof(struct core_mmu_config, satp));
+
+	/* struct thread_abi_args */
+	DEFINE(THREAD_ABI_ARGS_A0, offsetof(struct thread_abi_args, a0));
+	DEFINE(THREAD_ABI_ARGS_SIZE, sizeof(struct thread_abi_args));
 }

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -12,6 +12,9 @@
 #include <platform_config.h>
 #include <riscv.h>
 #include <riscv_macros.S>
+#include <tee/optee_abi.h>
+#include <tee/teeabi_opteed.h>
+#include <tee/teeabi_opteed_macros.h>
 
 .section .data
 .balign 4
@@ -219,7 +222,10 @@ UNWIND(	.cantunwind)
 	wait_secondary
 
 	jal	thread_clr_boot_thread
-	j	mu_service
+
+	li	a0, TEEABI_OPTEED_RETURN_ENTRY_DONE
+	la	a1, thread_vector_table
+	j	teeabi_return_to_ree
 END_FUNC reset_primary
 
 LOCAL_FUNC reset_secondary , : , .identity_map

--- a/core/arch/riscv/kernel/sbi.c
+++ b/core/arch/riscv/kernel/sbi.c
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
+ * Copyright (c) 2023 Andes Technology Corporation
  * Copyright 2022 NXP
  */
 
+#include <kernel/panic.h>
 #include <riscv.h>
 #include <sbi.h>
+#include <tee/optee_abi.h>
+#include <tee/teeabi.h>
+#include <tee/teeabi_opteed.h>
+#include <tee/teeabi_opteed_macros.h>
 
 struct sbiret {
 	long error;
@@ -41,4 +47,17 @@ int sbi_boot_hart(uint32_t hart_id, paddr_t start_addr, unsigned long arg)
 	ret = sbi_ecall(SBI_EXT_HSM, SBI_EXT_HSM_HART_START, hart_id, start_addr, arg);
 
 	return ret.error;
+}
+
+void __noreturn __naked teeabi_return_to_ree(unsigned long arg0,
+					     unsigned long arg1,
+					     unsigned long arg2,
+					     unsigned long arg3,
+					     unsigned long arg4,
+					     unsigned long arg5)
+{
+	_sbi_ecall(SBI_EXT_TEE, 0, arg0, arg1, arg2, arg3, arg4, arg5);
+
+	/* Should not be here. */
+	panic();
 }

--- a/core/arch/riscv/kernel/thread_optee_abi_rv.S
+++ b/core/arch/riscv/kernel/thread_optee_abi_rv.S
@@ -14,18 +14,6 @@
 #include <tee/teeabi_opteed.h>
 #include <tee/teeabi_opteed_macros.h>
 
-/*
- * Implement based on the transport method used to communicate between
- * untrusted domain and trusted domain. It could be an SBI/ECALL-based to
- * a security monitor running in M-Mode and panic or messaging-based across
- * domains where we return to a messaging callback which parses and handles
- * messages.
- */
-LOCAL_FUNC thread_return_from_nsec_call , :
-	/* Implement */
-	j	.
-END_FUNC thread_return_from_nsec_call
-
 FUNC thread_std_abi_entry , :
 	jal	__thread_std_abi_entry
 
@@ -53,7 +41,7 @@ FUNC thread_std_abi_entry , :
 	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
 
 	/* Return to untrusted domain */
-	jal	thread_return_from_nsec_call
+	jal	teeabi_return_to_ree
 END_FUNC thread_std_abi_entry
 
 /* void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]) */
@@ -107,7 +95,7 @@ FUNC thread_rpc , :
 	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
 
 	/* Return to untrusted domain */
-	jal	thread_return_from_nsec_call
+	jal	teeabi_return_to_ree
 .thread_rpc_return:
 	/*
 	 * Jumps here from thread_resume() above when RPC has returned.

--- a/core/arch/riscv/kernel/thread_optee_abi_rv.S
+++ b/core/arch/riscv/kernel/thread_optee_abi_rv.S
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2023 Andes Technology Corporation
  */
 
 #include <asm.S>
@@ -123,3 +124,67 @@ FUNC thread_rpc , :
 	addi	sp, sp, REGOFF(4)
 	ret
 END_FUNC thread_rpc
+
+LOCAL_FUNC vector_std_abi_entry, : , .identity_map
+	jal	thread_handle_std_abi
+	/*
+	 * Normally thread_handle_std_abi() should return via
+	 * thread_exit(), thread_rpc(), but if thread_handle_std_abi()
+	 * hasn't switched stack (error detected) it will do a normal "C"
+	 * return.
+	 */
+	/* Restore thread_handle_std_abi() return value */
+	mv	a1, a0
+	li	a2, 0
+	li	a3, 0
+	li	a4, 0
+	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
+
+	/* Return to untrusted domain */
+	j	teeabi_return_to_ree
+END_FUNC vector_std_abi_entry
+
+LOCAL_FUNC vector_fast_abi_entry , : , .identity_map
+	addi    sp, sp, -THREAD_ABI_ARGS_SIZE
+	store_xregs sp, THREAD_ABI_ARGS_A0, REG_A0, REG_A7
+	mv      a0, sp
+	jal	thread_handle_fast_abi
+	load_xregs sp, THREAD_ABI_ARGS_A0, REG_A1, REG_A7
+	addi    sp, sp, THREAD_ABI_ARGS_SIZE
+
+	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
+	/* Return to untrusted domain */
+	j	teeabi_return_to_ree
+END_FUNC vector_fast_abi_entry
+
+LOCAL_FUNC vector_fiq_entry , : , .identity_map
+	/* Secure Monitor received a FIQ and passed control to us. */
+	jal	interrupt_main_handler
+
+	li	a0, TEEABI_OPTEED_RETURN_FIQ_DONE
+	/* Return to untrusted domain */
+	j	teeabi_return_to_ree
+END_FUNC vector_fiq_entry
+
+/*
+ * Vector table supplied to M-mode secure monitor (e.g., openSBI) at
+ * initialization.
+ *
+ * Note that M-mode secure monitor depends on the layout of this vector table,
+ * any change in layout has to be synced with M-mode secure monitor.
+ */
+FUNC thread_vector_table , : , .identity_map, , nobti
+	.option push
+	.option norvc
+	j   vector_std_abi_entry
+	j   vector_fast_abi_entry
+	j   .
+	j   .
+	j   .
+	j   .
+	j   vector_fiq_entry
+	j   .
+	j   .
+	.option pop
+END_FUNC thread_vector_table
+DECLARE_KEEP_PAGER thread_vector_table

--- a/core/arch/riscv/tee/sub.mk
+++ b/core/arch/riscv/tee/sub.mk
@@ -1,2 +1,3 @@
 srcs-y += entry_fast.c
+srcs-y += teeabi.c
 cppflags-entry_fast.c-y += -DTEE_IMPL_GIT_SHA1=$(TEE_IMPL_GIT_SHA1)

--- a/core/arch/riscv/tee/teeabi.c
+++ b/core/arch/riscv/tee/teeabi.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023 Andes Technology Corporation
+ */
+
+#include <tee/teeabi.h>
+
+void __weak teeabi_return_to_ree(unsigned long arg0 __maybe_unused,
+				 unsigned long arg1 __maybe_unused,
+				 unsigned long arg2 __maybe_unused,
+				 unsigned long arg3 __maybe_unused,
+				 unsigned long arg4 __maybe_unused,
+				 unsigned long arg5 __maybe_unused)
+{
+}

--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -24,6 +24,9 @@
 #ifndef __noreturn
 #define __noreturn	__attribute__((__noreturn__))
 #endif
+#ifndef __naked
+#define __naked		__attribute__((naked))
+#endif
 #define __pure		__attribute__((pure))
 #define __aligned(x)	__attribute__((aligned(x)))
 #define __printf(a, b)	__attribute__((format(printf, a, b)))


### PR DESCRIPTION
Based on https://github.com/OP-TEE/optee_os/pull/6268
This PR implements SBI based protocol.

In SBI protocol, OP-TEE prepares function arguments in registers a0~a5.
The register a7 encodes SBI TEE extension ID, which is 0x544545(TEE), temporarily.
Then OP-TEE issues `ecall` to trap into higher privileged software, e.g., openSBI.
The higher privileged software will handle this call and execute OS context switch, etc.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
