### PR TITLE
ta: pkcs11: prevent user ID verification when user PIN is not set

### DIFF
--- a/ta/pkcs11/src/pkcs11_token.c
+++ b/ta/pkcs11/src/pkcs11_token.c
@@ -1192,12 +1192,14 @@ static enum pkcs11_rc check_user_pin(struct pkcs11_session *session,
 	struct token_persistent_main *db = token->db_main;
 	enum pkcs11_rc rc = PKCS11_CKR_OK;
 
+	if (!(db->flags & PKCS11_CKFT_USER_PIN_INITIALIZED))
+		return PKCS11_CKR_USER_PIN_NOT_INITIALIZED;
+
 	if (IS_ENABLED(CFG_PKCS11_TA_AUTH_TEE_IDENTITY) &&
 	    db->flags & PKCS11_CKFT_PROTECTED_AUTHENTICATION_PATH)
 		return verify_identity_auth(token, PKCS11_CKU_USER);
 
-	if (!db->user_pin_salt)
-		return PKCS11_CKR_USER_PIN_NOT_INITIALIZED;
+	assert(db->user_pin_salt);
 
 	if (db->flags & PKCS11_CKFT_USER_PIN_LOCKED)
 		return PKCS11_CKR_PIN_LOCKED;


### PR DESCRIPTION
Fixes User PIN verification in ACL mode (protected authentication) so that it always returns PKCS11_CKR_USER_PIN_NOT_INITIALIZED when User PIN has not been initialized yet by the Security Officer. Before this change, this was tested only in the standard PIN path, not for the authenticated TEE identity mode (CFG_PKCS11_TA_AUTH_TEE_IDENTITY=y).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
