### PR TITLE
drivers: regulator: register to dt_driver

### DIFF
--- a/core/drivers/regulator/regulator_dt.c
+++ b/core/drivers/regulator/regulator_dt.c
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022-2023, STMicroelectronics
+ */
+
+#include <assert.h>
+#include <compiler.h>
+#include <drivers/regulator.h>
+#include <initcall.h>
+#include <kernel/dt_driver.h>
+#include <kernel/panic.h>
+#include <libfdt.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <util.h>
+
+/*
+ * struct pending_regu - Regulators waiting for their supply to be ready
+ *
+ * @fdt: DT to work on
+ * @node: Node of the regulator in @fdt
+ * @supply_phandle: Phandle in @fdt of the regulator supply, or 0 if no supply
+ * @regulator_allocated: True if framework allocates and frees @regulator
+ * @regulator: Regulator device instance
+ * @link: Link in pending regulators list
+ *
+ * When calling regulator_dt_register(), either the regulator depends on a
+ * supply that is not initialized, or this dependency is resolved (there is
+ * no supply or the supply is ready to use).
+ *
+ * In the former case, the regulator is placed in a pending regulator list.
+ * Each time a new regulator is successfully registered, we process the
+ * pending regulator list in case some pending regulators find their
+ * supply and finalize their registration and initialization.
+ *
+ * In the latter case, the regulator registration and initialization
+ * are processed.
+ */
+struct pending_regu {
+	const void *fdt;
+	int node;
+	int supply_phandle;
+	bool regulator_allocated;
+	struct regulator *regulator;
+	SLIST_ENTRY(pending_regu) link;
+};
+
+static SLIST_HEAD(, pending_regu) pending_regu_list =
+	SLIST_HEAD_INITIALIZER(pending_regu);
+
+/* Helper to find the phandle of a regulator supply */
+static TEE_Result get_supply_phandle(const void *fdt, int node,
+				     const char *supply_name,
+				     uint32_t *supply_phandle)
+{
+	char *supply_prop = NULL;
+	size_t prop_len = 0;
+	const fdt32_t *cuint = NULL;
+	int len = 0;
+
+	prop_len = strlen(supply_name) + strlen("-supply") + 1;
+	supply_prop = calloc(1, prop_len);
+	if (!supply_prop)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	len = snprintf(supply_prop, prop_len, "%s-supply", supply_name);
+	assert(len > 0 && (size_t)len == prop_len - 1);
+
+	cuint = fdt_getprop(fdt, node, supply_prop, &len);
+	free(supply_prop);
+	if (!cuint || (size_t)len != sizeof(*cuint)) {
+		if (len != -FDT_ERR_NOTFOUND)
+			return TEE_ERROR_GENERIC;
+
+		*supply_phandle = 0;
+
+		return TEE_SUCCESS;
+	}
+
+	*supply_phandle = fdt32_to_cpu(*cuint);
+	assert(*supply_phandle);
+
+	return TEE_SUCCESS;
+}
+
+/* Helper function to register a regulator provider instance */
+static TEE_Result regulator_register_provider(const void *fdt, int node,
+					      struct regulator *regulator)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t phandle = 0;
+
+	phandle = fdt_get_phandle(fdt, node);
+	switch (phandle) {
+	case 0:
+		/* We can ignore regulators without any phandle */
+		return TEE_SUCCESS;
+	case (uint32_t)-1:
+		DMSG("Failed to find provider phandle");
+		return TEE_ERROR_GENERIC;
+	default:
+		res = dt_driver_register_provider(fdt, node, NULL, regulator,
+						  DT_DRIVER_REGULATOR);
+		if (res)
+			EMSG("Can't register regulator provider %s: %#"PRIx32,
+			     regulator_name(regulator), res);
+
+		return res;
+	}
+}
+
+static TEE_Result register_final(const void *fdt, int node,
+				 struct regulator *regulator)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	FMSG("Regulator: finalize %s registering", regulator_name(regulator));
+
+	res = regulator_register(regulator);
+	if (res)
+		return res;
+
+	if (regulator->ops->supplied_init) {
+		res = regulator->ops->supplied_init(regulator, fdt, node);
+		if (res)
+			return res;
+	}
+
+	return regulator_register_provider(fdt, node, regulator);
+}
+
+/*
+ * Pending regulators list: stores all regulator devices registered by their
+ * driver but not yet available to consumers as their dependency on their
+ * regulator supply is not yet resolved (supply has not been initialized yet).
+ */
+
+static void __maybe_unused print_pending_regulators(void)
+{
+	struct pending_regu *pending = NULL;
+
+	SLIST_FOREACH(pending, &pending_regu_list, link)
+		DMSG("Pending regulator %s",
+		     regulator_name(pending->regulator));
+}
+
+/*
+ * Returns true if at least 1 regulator found its supply and finalized its
+ * registration.
+ */
+static bool process_pending_list(void)
+{
+	struct dt_driver_provider *p = NULL;
+	struct pending_regu *pending = NULL;
+	struct pending_regu *next = NULL;
+	bool supplied = false;
+
+	SLIST_FOREACH_SAFE(pending, &pending_regu_list, link, next) {
+		p = dt_driver_get_provider_by_phandle(pending->supply_phandle,
+						      DT_DRIVER_REGULATOR);
+		if (!p)
+			continue;
+
+		pending->regulator->supply = dt_driver_provider_priv_data(p);
+
+		if (register_final(pending->fdt, pending->node,
+				   pending->regulator))
+			panic();
+
+		SLIST_REMOVE(&pending_regu_list, pending, pending_regu, link);
+		free(pending);
+
+		supplied = true;
+	}
+
+	return supplied;
+}
+
+/*
+ * Attempt to register pending regulators once their supply is found.
+ * Return true if pending regulator list is empty upon processing.
+ */
+static bool resolve_pending_list(void)
+{
+	while (process_pending_list())
+		;
+
+	return SLIST_EMPTY(&pending_regu_list);
+}
+
+/* Adds a regulator to the pending list: those waiting for their supply */
+static TEE_Result add_to_pending_list(const void *fdt, int node,
+				      struct regulator *regulator,
+				      uint32_t supply_phandle,
+				      bool regulator_allocated)
+{
+	struct pending_regu *pending = NULL;
+
+	pending = calloc(1, sizeof(*pending));
+	if (!pending)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	*pending = (struct pending_regu){
+		.fdt = fdt,
+		.node = node,
+		.supply_phandle = supply_phandle,
+		.regulator = regulator,
+		.regulator_allocated = regulator_allocated,
+	};
+
+	SLIST_INSERT_HEAD(&pending_regu_list, pending, link);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result parse_dt(const void *fdt, int node,
+			   struct regulator *regulator)
+{
+	const fdt32_t *cuint = NULL;
+	int len = 0;
+
+	FMSG("Regulator: parse DT node %s", fdt_get_name(fdt, node, NULL));
+
+	cuint = fdt_getprop(fdt, node, "regulator-name", NULL);
+	if (cuint) {
+		/* Replace name with the one found from the DT node */
+		char *name = (char *)cuint;
+
+		free(regulator->name);
+		regulator->name = strdup(name);
+		if (!regulator->name)
+			return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	cuint = fdt_getprop(fdt, node, "regulator-min-microvolt", &len);
+	if (cuint && len == sizeof(*cuint))
+		regulator->min_uv = fdt32_to_cpu(*cuint);
+	else if (cuint || len != -FDT_ERR_NOTFOUND)
+		panic();
+
+	cuint = fdt_getprop(fdt, node, "regulator-max-microvolt", &len);
+	if (cuint && len == sizeof(*cuint)) {
+		regulator->max_uv = fdt32_to_cpu(*cuint);
+
+		if (regulator->max_uv < regulator->min_uv) {
+			EMSG("Regulator %s max_uv %d < %d",
+			     regulator_name(regulator), regulator->max_uv,
+			     regulator->min_uv);
+
+			return TEE_ERROR_GENERIC;
+		}
+	} else if (cuint || len != -FDT_ERR_NOTFOUND) {
+		panic();
+	} else {
+		regulator->max_uv = INT_MAX;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * API function to register a DRIVER_REGULATOR provider instance.
+ * The registration can be deferred if the regulator supply (if any)
+ * is not yet registered, in which case the regulator is placed in
+ * a regulator pending list.
+ */
+TEE_Result regulator_dt_register(const void *fdt, int node, int provider_node,
+				 const struct regu_dt_desc *desc)
+{
+	TEE_Result res = TEE_ERROR_OUT_OF_MEMORY;
+	struct regulator *regulator = NULL;
+	uint32_t supply_phandle = 0;
+	char *name = NULL;
+
+	assert(desc);
+
+	if (!desc->regulator) {
+		regulator = calloc(1, sizeof(*regulator));
+		if (!regulator)
+			return TEE_ERROR_OUT_OF_MEMORY;
+	} else {
+		regulator = desc->regulator;
+		memset(regulator, 0, sizeof(*regulator));
+	}
+
+	if (desc->name) {
+		/* Will be freed if overridden by DT node content */
+		name = strdup(desc->name);
+		if (!name)
+			goto err_free;
+	}
+
+	*regulator = (struct regulator){
+		.name = name,
+		.ops = desc->ops,
+		.priv = desc->priv,
+	};
+
+	res = parse_dt(fdt, node, regulator);
+	if (res)
+		goto err_free;
+
+	if (desc->supply_name) {
+		res = get_supply_phandle(fdt, provider_node, desc->supply_name,
+					 &supply_phandle);
+		if (res)
+			goto err_free;
+	}
+
+	if (supply_phandle) {
+		res = add_to_pending_list(fdt, node, regulator, supply_phandle,
+					  !desc->regulator);
+		if (res)
+			goto err_free;
+	} else {
+		res = register_final(fdt, node, regulator);
+		if (res)
+			goto err_free;
+	}
+
+	resolve_pending_list();
+
+	return TEE_SUCCESS;
+
+err_free:
+	/* This function cannot return TEE_ERROR_DEFER_DRIVER_INIT */
+	assert(res != TEE_ERROR_DEFER_DRIVER_INIT);
+
+	free(regulator->name);
+	if (!desc->regulator)
+		free(regulator);
+
+	return res;
+}
+
+static TEE_Result release_regulator_pending_lists(void)
+{
+	struct pending_regu *pending = NULL;
+	struct pending_regu *next = NULL;
+
+	if (!SLIST_EMPTY(&pending_regu_list))
+		DMSG("Some regulators were not supplied:");
+
+	SLIST_FOREACH_SAFE(pending, &pending_regu_list, link, next) {
+		DMSG(" Unsupplied regulator %s",
+		     regulator_name(pending->regulator));
+
+		SLIST_REMOVE(&pending_regu_list, pending, pending_regu, link);
+		if (pending->regulator_allocated)
+			free(pending->regulator);
+		free(pending);
+	}
+
+	return TEE_SUCCESS;
+}
+
+release_init_resource(release_regulator_pending_lists);

--- a/core/drivers/regulator/sub.mk
+++ b/core/drivers/regulator/sub.mk
@@ -1,1 +1,2 @@
 srcs-y += regulator.c
+srcs-$(CFG_DT) += regulator_dt.c

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -24,6 +24,22 @@
 struct regulator_ops;
 
 /*
+ * struct regu_dt_desc - Regulator description passed to regulator_dt_register()
+ * @priv: Regulator driver private data
+ * @name: Regulator string name for debug purpose
+ * @supply_name: Regulator supply name for node property *-supply or NULL
+ * @ops: Operation handlers for the regulator
+ * @regulator: Pointer to preallocated regulator or NULL if none
+ */
+struct regu_dt_desc {
+	void *priv;
+	char *name;
+	const char *supply_name;
+	const struct regulator_ops *ops;
+	struct regulator *regulator;
+};
+
+/*
  * struct regulator - A regulator instance
  * @ops: Operation handlers for the regulator
  * @supply: Regulator supply reference or NULL if none
@@ -60,12 +76,15 @@ struct regulator {
  * @get_state: Get regulator effective state
  * @set_voltage: Set voltage level in microvolt (uV)
  * @get_voltage: Get current voltage in microvolt (uV)
+ * @supplied_init: Optional, finalize initialization once supply is ready
  */
 struct regulator_ops {
 	TEE_Result (*set_state)(struct regulator *r, bool enabled);
 	TEE_Result (*get_state)(struct regulator *r, bool *enabled);
 	TEE_Result (*set_voltage)(struct regulator *r, int level_uv);
 	TEE_Result (*get_voltage)(struct regulator *r, int *level_uv);
+	TEE_Result (*supplied_init)(struct regulator *r, const void *fdt,
+				    int node);
 };
 
 #ifdef CFG_DRIVERS_REGULATOR
@@ -134,6 +153,42 @@ static inline void regulator_print_state(const char *message __unused)
 {
 }
 #endif /*CFG_DRIVERS_REGULATOR*/
+
+#if defined(CFG_DRIVERS_REGULATOR) && defined(CFG_DT)
+/*
+ * regulator_dt_register() - Register a regulator to related to a DT node
+ * @fdt: FDT to work on
+ * @node: DT node of the regulator exposed by regulator driver
+ * @provider_node: Node where xxx-supply property is found or -1 if no supply.
+ * @desc: Description of the regulator to register
+ *
+ * This function registers and initializes a regulator instance once its supply
+ * if found, if any. Regulators registered with this function can be found by
+ * their consumer drivers using API function regulator_dt_get_supply() or like.
+ *
+ * Return TEE_SUCCESS in case of success
+ * Return TEE_ERROR_OUT_OF_MEMORY if failed on memory allocation
+ * Return any other TEE_Result compliant code in case of error
+ */
+TEE_Result regulator_dt_register(const void *fdt, int node, int provider_node,
+				 const struct regu_dt_desc *desc);
+#else
+static inline TEE_Result regulator_dt_get_supply(const void *fdt __unused,
+						 int node __unused,
+						 const char *supply __unused,
+						 struct regulator **r __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline TEE_Result
+regulator_dt_register(const void *fdt __unused, int node __unused,
+		      int provider_node __unused,
+		      const struct regu_dt_desc *d __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif /* CFG_DRIVERS_REGULATOR && CFG_DT */
 
 /*
  * regulator_name() - Return regulator name or NULL

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -24,6 +24,7 @@
  * DT_DRIVER_GPIO   GPIO controller using generic GPIO DT bindings
  * DT_DRIVER_PINCTRL Pin controller using generic reset DT bindings
  * DT_DRIVER_INTERRUPT Interrupt controller using generic DT bindings
+ * DT_DRIVER_REGULATOR Voltage regulator controller using generic DT bindings
  */
 enum dt_driver_type {
 	DT_DRIVER_NOTYPE,
@@ -34,6 +35,7 @@ enum dt_driver_type {
 	DT_DRIVER_GPIO,
 	DT_DRIVER_PINCTRL,
 	DT_DRIVER_INTERRUPT,
+	DT_DRIVER_REGULATOR,
 };
 
 /*

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -225,6 +225,11 @@ dt_driver_get_provider_by_phandle(uint32_t phandle, enum dt_driver_type type);
 unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv);
 
 /*
+ * Return provider private data registered by dt_driver_register_provider()
+ */
+void *dt_driver_provider_priv_data(struct dt_driver_provider *prv);
+
+/*
  * dt_driver_probe_device_by_node - Probe matching driver to create a device
  *	from a FDT node
  *

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -110,6 +110,7 @@ static void assert_type_is_valid(enum dt_driver_type type)
 	case DT_DRIVER_I2C:
 	case DT_DRIVER_PINCTRL:
 	case DT_DRIVER_INTERRUPT:
+	case DT_DRIVER_REGULATOR:
 		return;
 	default:
 		assert(0);
@@ -196,6 +197,7 @@ int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
 		cells_name = "#gpio-cells";
 		break;
 	case DT_DRIVER_I2C:
+	case DT_DRIVER_REGULATOR:
 		return 0;
 	default:
 		panic();

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -218,6 +218,11 @@ unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv)
 	return prv->provider_cells;
 }
 
+void *dt_driver_provider_priv_data(struct dt_driver_provider *prv)
+{
+	return prv->priv_data;
+}
+
 struct dt_driver_provider *
 dt_driver_get_provider_by_node(int nodeoffset, enum dt_driver_type type)
 {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -884,7 +884,8 @@ CFG_DRIVERS_I2C ?= n
 CFG_DRIVERS_PINCTRL ?= n
 
 # When enabled, CFG_DRIVERS_REGULATOR embeds a voltage regulator framework in
-# OP-TEE core to provide drivers a common regulator interface.
+# OP-TEE core to provide drivers a common regulator interface and describe
+# the regulators dependencies using an embedded device tree.
 CFG_DRIVERS_REGULATOR ?= n
 
 # The purpose of this flag is to show a print when booting up the device that


### PR DESCRIPTION
Adds `regulator_dt_register()` for regulator drivers to register regulator instances based on the DT description of the platform.