### PR TITLE
core: add support mtk wait timeout API

### DIFF
--- a/core/include/kernel/mutex.h
+++ b/core/include/kernel/mutex.h
@@ -95,10 +95,15 @@ void condvar_broadcast_debug(struct condvar *cv, const char *fname, int lineno);
 void condvar_wait_debug(struct condvar *cv, struct mutex *m,
 			const char *fname, int lineno);
 #define condvar_wait(cv, m) condvar_wait_debug((cv), (m), __FILE__, __LINE__)
+uint32_t condvar_wait_timeout_debug(struct condvar *cv, struct mutex *m, uint32_t tmo,
+			const char *fname, int lineno);
+#define condvar_wait_timeout(cv, m, tmo) \
+			condvar_wait_timeout_debug((cv), (m), tmo, __FILE__, __LINE__)
 #else
 void condvar_signal(struct condvar *cv);
 void condvar_broadcast(struct condvar *cv);
 void condvar_wait(struct condvar *cv, struct mutex *m);
+uint32_t condvar_wait_timeout(struct condvar *cv, struct mutex *m, uint32_t tmo);
 #endif
 
 #endif /*KERNEL_MUTEX_H*/

--- a/core/include/kernel/notif.h
+++ b/core/include/kernel/notif.h
@@ -107,6 +107,11 @@ void notif_free_async_value(uint32_t value);
 TEE_Result notif_wait(uint32_t value);
 
 /*
+ * Wait timeout in normal world for a value to be sent by notif_send()
+ */
+TEE_Result notif_wait_timeout(uint32_t value, uint32_t tmo);
+
+/*
  * Send an asynchronous value, note that it must be <= NOTIF_ASYNC_VALUE_MAX
  */
 #if defined(CFG_CORE_ASYNC_NOTIF)
@@ -123,6 +128,13 @@ static inline void notif_send_async(uint32_t value __unused)
  * asynchronous range.
  */
 TEE_Result notif_send_sync(uint32_t value);
+
+/*
+ * Send a sychronous value with timeout, note that it must be <= NOTIF_VALUE_MAX. The
+ * notification is synchronous even if the value happens to belong in the
+ * asynchronous range.
+ */
+TEE_Result notif_send_sync_timeout(uint32_t value, uint32_t tmo);
 
 /*
  * Called by device drivers.

--- a/core/include/kernel/wait_queue.h
+++ b/core/include/kernel/wait_queue.h
@@ -48,6 +48,11 @@ static inline void wq_wait_init(struct wait_queue *wq,
 void wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
 		   const void *sync_obj, const char *fname, int lineno);
 
+/* Waits for the wait queue element to the awakened or timed out */
+uint32_t wq_wait_final_timeout(struct wait_queue *wq, struct wait_queue_elem *wqe,
+			       uint32_t tmo, const void *sync_obj, const char *fname,
+			       int lineno);
+
 /* Wakes up the first wait queue element in the wait queue, if there is one */
 void wq_wake_next(struct wait_queue *wq, const void *sync_obj,
 		const char *fname, int lineno);

--- a/core/kernel/notif.c
+++ b/core/kernel/notif.c
@@ -203,19 +203,30 @@ out:
 }
 #endif /*CFG_CORE_ASYNC_NOTIF*/
 
-static TEE_Result notif_rpc(uint32_t func, uint32_t value)
+static TEE_Result notif_rpc(uint32_t func, uint32_t value, uint32_t tmo)
 {
-	struct thread_param params = THREAD_PARAM_VALUE(IN, func, value, 0);
+	struct thread_param params = THREAD_PARAM_VALUE(IN, func, value, tmo);
 
 	return thread_rpc_cmd(OPTEE_RPC_CMD_NOTIFICATION, 1, &params);
 }
 
+
 TEE_Result notif_wait(uint32_t value)
 {
-	return notif_rpc(OPTEE_RPC_NOTIFICATION_WAIT, value);
+	return notif_rpc(OPTEE_RPC_NOTIFICATION_WAIT, value, 0);
 }
 
 TEE_Result notif_send_sync(uint32_t value)
 {
-	return notif_rpc(OPTEE_RPC_NOTIFICATION_SEND, value);
+	return notif_rpc(OPTEE_RPC_NOTIFICATION_SEND, value, 0);
+}
+
+TEE_Result notif_wait_timeout(uint32_t value, uint32_t tmo)
+{
+        return notif_rpc(OPTEE_RPC_NOTIFICATION_WAIT, value, tmo);
+}
+
+TEE_Result notif_send_sync_timeout(uint32_t value, uint32_t tmo)
+{
+        return notif_rpc(OPTEE_RPC_NOTIFICATION_SEND, value, tmo);
 }


### PR DESCRIPTION
We introudce a timout mechanismof condvar implementation for some secure driver.
Add the timeout parameter passing in wait_queue implementation for condvar_wait_timeout. Since some secure driver need timeout mechanism for exception handler.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
