### PR TITLE
core: riscv: Fix condition of is_from_user()

### DIFF
--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -361,7 +361,7 @@ static void copy_a0_to_a3(struct thread_ctx_regs *regs, uint32_t a0,
 
 static bool is_from_user(unsigned long status)
 {
-	return status & CSR_XSTATUS_SPP;
+	return (status & CSR_XSTATUS_SPP) == 0;
 }
 
 #ifdef CFG_SYSCALL_FTRACE


### PR DESCRIPTION
RISC-V defines that xPP(previous privilege mode) field of CSR status indicates the previous privilege level prior to the trap. Since the encoding of user mode is 0, we should compare the xPP field with 0 here to know that the trap is from user mode.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
