### PR TITLE
drivers: regulator: DT bindings properties always-on & pull-down

### DIFF
--- a/core/drivers/regulator/regulator_dt.c
+++ b/core/drivers/regulator/regulator_dt.c
@@ -17,6 +17,23 @@
 #include <util.h>
 
 /*
+ * struct regulator_property - DT binding boolean property names
+ * @name: Property name in the regulator DT node
+ * @flag: Mask of the related REGULATOR_* boolean property
+ */
+struct regulator_property {
+	const char *name;
+	unsigned int flag;
+};
+
+static struct regulator_property flag_prop[] = {
+	{
+		.name = "regulator-always-on",
+		.flag = REGULATOR_ALWAYS_ON,
+	},
+};
+
+/*
  * struct pending_regu - Regulators waiting for their supply to be ready
  *
  * @fdt: DT to work on
@@ -218,6 +235,7 @@ static TEE_Result add_to_pending_list(const void *fdt, int node,
 static TEE_Result parse_dt(const void *fdt, int node,
 			   struct regulator *regulator)
 {
+	struct regulator_property *fp = NULL;
 	const fdt32_t *cuint = NULL;
 	int len = 0;
 
@@ -233,6 +251,10 @@ static TEE_Result parse_dt(const void *fdt, int node,
 		if (!regulator->name)
 			return TEE_ERROR_OUT_OF_MEMORY;
 	}
+
+	for (fp = flag_prop; fp < (flag_prop + ARRAY_SIZE(flag_prop)); fp++)
+		if (fdt_getprop(fdt, node, fp->name, NULL))
+			regulator->flags |= fp->flag;
 
 	cuint = fdt_getprop(fdt, node, "regulator-min-microvolt", &len);
 	if (cuint && len == sizeof(*cuint))

--- a/core/drivers/regulator/regulator_dt.c
+++ b/core/drivers/regulator/regulator_dt.c
@@ -31,6 +31,10 @@ static struct regulator_property flag_prop[] = {
 		.name = "regulator-always-on",
 		.flag = REGULATOR_ALWAYS_ON,
 	},
+	{
+		.name = "regulator-pull-down",
+		.flag = REGULATOR_PULL_DOWN,
+	},
 };
 
 /*

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -18,8 +18,10 @@
 
 /* Regulator should never be disabled. DT property: regulator-always-on */
 #define REGULATOR_ALWAYS_ON	BIT(0)
+/* Enables pull down mode. DT property: regulator-pull-down */
+#define REGULATOR_PULL_DOWN	BIT(1)
 
-#define REGULATOR_FLAGS_MASK	REGULATOR_ALWAYS_ON
+#define REGULATOR_FLAGS_MASK	(REGULATOR_ALWAYS_ON | REGULATOR_PULL_DOWN)
 
 struct regulator_ops;
 


### PR DESCRIPTION
Consider regulator DT binding properties `regulator-always-on` and `regulator-pull-down`.