### PR TITLE
drivers: regulator: add regulator_dt_get_supply()

### DIFF
--- a/core/drivers/regulator/regulator_dt.c
+++ b/core/drivers/regulator/regulator_dt.c
@@ -85,6 +85,29 @@ static TEE_Result get_supply_phandle(const void *fdt, int node,
 	return TEE_SUCCESS;
 }
 
+TEE_Result regulator_dt_get_supply(const void *fdt, int node,
+				   const char *supply_name,
+				   struct regulator **regulator)
+{
+	struct dt_driver_provider *provider = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t supply_phandle = 0;
+
+	res = get_supply_phandle(fdt, node, supply_name, &supply_phandle);
+	if (res)
+		return res;
+
+	provider = dt_driver_get_provider_by_phandle(supply_phandle,
+						     DT_DRIVER_REGULATOR);
+	if (!provider)
+		return TEE_ERROR_DEFER_DRIVER_INIT;
+
+	*regulator = dt_driver_provider_priv_data(provider);
+	assert(*regulator);
+
+	return TEE_SUCCESS;
+}
+
 /* Helper function to register a regulator provider instance */
 static TEE_Result regulator_register_provider(const void *fdt, int node,
 					      struct regulator *regulator)

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -156,6 +156,23 @@ static inline void regulator_print_state(const char *message __unused)
 
 #if defined(CFG_DRIVERS_REGULATOR) && defined(CFG_DT)
 /*
+ * regulator_dt_get_supply() - Get a regulator supply from name and DT node
+ * @fdt: FDT to work on
+ * @node: DT node of the regulator consumer
+ * @supply_name: Name of the supply in DT property xxx-supply
+ * @regulator: Output regulator upon success
+ *
+ * Upon success, this function provides the pointer to regulator
+ * defined by DT binding property @name-supply phandle reference.
+ *
+ * This function returns TEE_ERROR_DEFER_DRIVER_INIT if supply exists but is
+ * not yet initialized.
+ */
+TEE_Result regulator_dt_get_supply(const void *fdt, int node,
+				   const char *supply_name,
+				   struct regulator **regulator);
+
+/*
  * regulator_dt_register() - Register a regulator to related to a DT node
  * @fdt: FDT to work on
  * @node: DT node of the regulator exposed by regulator driver


### PR DESCRIPTION
Implements `regulator_dt_get_supply()` API function for consumer drivers to get a regulator supply using the driver device DT node data. The function returns `TEE_ERROR_DEFER_DRIVER_INIT` when the target supply exists but is yet not initialized.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
