### PR TITLE
core: riscv: Support fault mitigations in non-threaded code

### DIFF
--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -32,6 +32,9 @@ struct thread_core_local {
 #ifdef CFG_CORE_DEBUG_CHECK_STACKS
 	bool stackcheck_recursion;
 #endif
+#ifdef CFG_FAULT_MITIGATION
+	struct ftmn_func_arg *ftmn_arg;
+#endif
 } THREAD_CORE_LOCAL_ALIGNED;
 
 struct thread_user_vfp_state {


### PR DESCRIPTION
The previous commit
ce56605a0ede ("core: support fault mitigations in non-threaded code") supports fault mitigations in non-threaded code for ARM architecture.

This commit adds the related modification for RISC-V architecture to support it too.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
