### PR TITLE
drivers: regulator: include tee extensions

### DIFF
--- a/core/drivers/regulator/regulator_dt.c
+++ b/core/drivers/regulator/regulator_dt.c
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <tee_api_defines_extensions.h>
 #include <util.h>
 
 /*


### PR DESCRIPTION
Adds missing header file for TEE extension macro
TEE_ERROR_DEFER_DRIVER_INIT.

Fixes: 6558b5657faf ("drivers: regulator: register to dt_driver")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
