### PR TITLE
libutils: fault_mitigation.h: Fix indentation

### DIFF
--- a/lib/libutils/ext/include/fault_mitigation.h
+++ b/lib/libutils/ext/include/fault_mitigation.h
@@ -250,7 +250,7 @@ extern struct ftmn_func_arg *__ftmn_global_func_arg;
 static inline struct ftmn_func_arg **__ftmn_get_tsd_func_arg_pp(void)
 {
 #if defined(CFG_FAULT_MITIGATION) && defined(__KERNEL__)
-    if (thread_get_id_may_fail() >= 0)
+	if (thread_get_id_may_fail() >= 0)
 		return &thread_get_tsd()->ftmn_arg;
 	else
 		return &thread_get_core_local()->ftmn_arg;


### PR DESCRIPTION
Indentation with tab instead of space.

Fixes: ce56605a0ede ("core: support fault mitigations in non-threaded code")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
