### PR TITLE
core interrupt: use device tree data

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -14,6 +14,7 @@
 #include <keep.h>
 #include <kernel/asan.h>
 #include <kernel/boot.h>
+#include <kernel/interrupt.h>
 #include <kernel/linker.h>
 #include <kernel/lockdep.h>
 #include <kernel/misc.h>

--- a/core/drivers/atmel_piobu.c
+++ b/core/drivers/atmel_piobu.c
@@ -13,6 +13,7 @@
 #include <kernel/boot.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
+#include <kernel/interrupt.h>
 #include <kernel/pm.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>

--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -11,6 +11,7 @@
 #include <kernel/delay.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
+#include <kernel/interrupt.h>
 #include <kernel/pm.h>
 #include <matrix.h>
 #include <mm/core_mmu.h>

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -6,6 +6,7 @@
 
 #include <arm.h>
 #include <assert.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <config.h>
 #include <compiler.h>
 #include <drivers/gic.h>
@@ -208,10 +209,10 @@ static int gic_dt_get_irq(const uint32_t *properties, int count, uint32_t *type,
 	it_num = fdt32_to_cpu(properties[1]);
 
 	switch (fdt32_to_cpu(properties[0])) {
-	case 1:
+	case GIC_PPI:
 		it_num += 16;
 		break;
-	case 0:
+	case GIC_SPI:
 		it_num += 32;
 		break;
 	default:

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -7,7 +7,6 @@
 #define __KERNEL_DT_H
 
 #include <compiler.h>
-#include <kernel/interrupt.h>
 #include <kernel/panic.h>
 #include <scattered_array.h>
 #include <stdint.h>

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -102,7 +102,7 @@ struct dt_pargs {
  *
  * @parg: phandle argument(s) referencing the device in the FDT.
  * @data: driver private data registered in struct dt_driver.
- * @out_device: output device reference upon success, e.g. a struct clk
+ * @device_ref: output device reference upon success, e.g. a struct clk
  *	pointer for a clock driver.
  *
  * Return code:
@@ -111,7 +111,7 @@ struct dt_pargs {
  * Any TEE_Result compliant code in case of error.
  */
 typedef TEE_Result (*get_of_device_func)(struct dt_pargs *parg, void *data,
-					 void **out_device);
+					 void *device_ref);
 
 /**
  * dt_driver_register_provider - Register a driver provider
@@ -139,7 +139,7 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
  * @nodeoffset: node offset in the FDT
  * @prop_idx: index of the phandle data in the property
  * @type: Driver type
- * @out_device: output device opaque reference upon support, for example
+ * @device_ref: output device opaque reference upon support, for example
  *	a struct clk pointer for a clock driver.
 
  * Return code:
@@ -153,7 +153,7 @@ TEE_Result dt_driver_device_from_node_idx_prop(const char *prop_name,
 					       const void *fdt, int nodeoffset,
 					       unsigned int prop_idx,
 					       enum dt_driver_type type,
-					       void **out_device);
+					       void *device_ref);
 
 /*
  * dt_driver_device_from_parent - Return a device instance based on the parent.
@@ -163,7 +163,7 @@ TEE_Result dt_driver_device_from_node_idx_prop(const char *prop_name,
  * @fdt: FDT base address
  * @nodeoffset: node offset in the FDT
  * @type: Driver type
- * @out_device: output device opaque reference upon success, for example
+ * @device_ref: output device opaque reference upon success, for example
  *	a struct i2c_dev pointer for a I2C bus driver
  *
  * Return code:
@@ -173,7 +173,7 @@ TEE_Result dt_driver_device_from_node_idx_prop(const char *prop_name,
  */
 TEE_Result dt_driver_device_from_parent(const void *fdt, int nodeoffset,
 					enum dt_driver_type type,
-					void **out_device);
+					void *device_ref);
 
 /*
  * dt_driver_device_from_node_idx_prop_phandle() - Same as
@@ -190,7 +190,7 @@ TEE_Result dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
 						       unsigned int prop_index,
 						       enum dt_driver_type type,
 						       uint32_t phandle,
-						       void **out_device);
+						       void *device_ref);
 
 /*
  * dt_driver_get_crypto() - Request crypto support for driver initialization

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -346,6 +346,25 @@ static inline TEE_Result interrupt_add_handler(struct itr_handler *hdl)
 }
 
 /*
+ * interrupt_create_handler() - Allocate/register an interrupt callback handler
+ * @itr_chip Interrupt chip obtained from dt_get_interrupt_by_*()
+ * @itr_num Interrupt number obtained from dt_get_interrupt_by_*()
+ * @callback Callback handler function
+ * @priv Private dat to pssa to @callback
+ * @flags INTERRUPT_FLAGS_* or 0
+ * @out_hdl Output allocated and registered handler or NULL
+ *
+ * This function  differs from interrupt_add_handler() in that the
+ * interrupt is not reconfigured. interrupt_create_handler() expects
+ * @itr_desc was obtained from a call to dt_get_interrupt_by_index()
+ * or dt_get_interrupt_by_name(). That call configured the interrupt.
+ */
+TEE_Result interrupt_create_handler(struct itr_chip *itr_chip, size_t itr_num,
+				    itr_handler_t callback, void *priv,
+				    uint32_t flags,
+				    struct itr_handler **out_hdl);
+
+/*
  * interrupt_add_handler_with_chip() - Register an interrupt handler providing
  *	the interrupt chip reference in specific argument @chip.
  * @chip	Interrupt controller

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -264,7 +264,7 @@ static TEE_Result device_from_provider_prop(struct dt_driver_provider *prv,
 	pargs->phandle_node = phandle_node;
 	pargs->args_count = prv->provider_cells;
 	for (n = 0; n < prv->provider_cells; n++)
-		pargs->args[n] = fdt32_to_cpu(prop[n + 1]);
+		pargs->args[n] = fdt32_to_cpu(prop[n]);
 
 	res = prv->get_of_device(pargs, prv->priv_data, device);
 
@@ -394,6 +394,9 @@ TEE_Result dt_driver_device_from_node_idx_prop(const char *prop_name,
 			idx += sizeof(phandle) + prv_cells * sizeof(uint32_t);
 			continue;
 		}
+
+		/* Skip property cell with the phandle, already handled */
+		idx32++;
 
 		return device_from_provider_prop(prv, fdt, phandle_node,
 						 prop + idx32, device);

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -249,7 +249,8 @@ dt_driver_get_provider_by_phandle(uint32_t phandle, enum dt_driver_type type)
 
 static TEE_Result device_from_provider_prop(struct dt_driver_provider *prv,
 					    const void *fdt, int phandle_node,
-					    const uint32_t *prop, void **device)
+					    const uint32_t *prop,
+					    void *device_ref)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct dt_pargs *pargs = NULL;
@@ -266,7 +267,7 @@ static TEE_Result device_from_provider_prop(struct dt_driver_provider *prv,
 	for (n = 0; n < prv->provider_cells; n++)
 		pargs->args[n] = fdt32_to_cpu(prop[n]);
 
-	res = prv->get_of_device(pargs, prv->priv_data, device);
+	res = prv->get_of_device(pargs, prv->priv_data, device_ref);
 
 	free(pargs);
 
@@ -274,7 +275,8 @@ static TEE_Result device_from_provider_prop(struct dt_driver_provider *prv,
 }
 
 TEE_Result dt_driver_device_from_parent(const void *fdt, int nodeoffset,
-					enum dt_driver_type type, void **device)
+					enum dt_driver_type type,
+					void *device_ref)
 {
 	int parent = -1;
 	struct dt_driver_provider *prv = NULL;
@@ -291,7 +293,8 @@ TEE_Result dt_driver_device_from_parent(const void *fdt, int nodeoffset,
 		return TEE_ERROR_DEFER_DRIVER_INIT;
 	}
 
-	return device_from_provider_prop(prv, fdt, nodeoffset, NULL, device);
+	return device_from_provider_prop(prv, fdt, nodeoffset, NULL,
+					 device_ref);
 }
 
 TEE_Result dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
@@ -300,7 +303,7 @@ TEE_Result dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
 						       unsigned int prop_index,
 						       enum dt_driver_type type,
 						       uint32_t phandle,
-						       void **device)
+						       void *device_ref)
 {
 	int len = 0;
 	const uint32_t *prop = NULL;
@@ -328,14 +331,14 @@ TEE_Result dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
 		return TEE_ERROR_ITEM_NOT_FOUND;
 
 	return device_from_provider_prop(prv, fdt, phandle_node_unused,
-					 prop + prop_index, device);
+					 prop + prop_index, device_ref);
 }
 
 TEE_Result dt_driver_device_from_node_idx_prop(const char *prop_name,
 					       const void *fdt, int nodeoffset,
 					       unsigned int prop_idx,
 					       enum dt_driver_type type,
-					       void **device)
+					       void *device_ref)
 {
 	int len = 0;
 	int idx = 0;
@@ -399,7 +402,7 @@ TEE_Result dt_driver_device_from_node_idx_prop(const char *prop_name,
 		idx32++;
 
 		return device_from_provider_prop(prv, fdt, phandle_node,
-						 prop + idx32, device);
+						 prop + idx32, device_ref);
 	}
 
 	return TEE_ERROR_ITEM_NOT_FOUND;

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -196,3 +196,112 @@ void interrupt_remove_free_handler(struct itr_handler *hdl)
 		free(hdl);
 	}
 }
+
+#ifdef CFG_DT
+TEE_Result interrupt_register_provider(const void *fdt, int node,
+				       itr_dt_get_func dt_get_itr, void *data)
+{
+	return dt_driver_register_provider(fdt, node,
+					   (get_of_device_func)dt_get_itr,
+					   data, DT_DRIVER_INTERRUPT);
+}
+
+/*
+ * Fills an itr_desc reference based on "interrupts" property bindings.
+ * May return TEE_ERROR_DEFER_DRIVER_INIT if parent controller is found but
+ * not yet initialized.
+ */
+static TEE_Result get_legacy_interrupt_by_index(const void *fdt, int node,
+						unsigned int index,
+						struct itr_desc *itr_desc)
+{
+	const uint32_t *prop = NULL;
+	uint32_t phandle = 0;
+	int pnode = 0;
+	int len = 0;
+
+	prop = fdt_getprop(fdt, node, "interrupts", &len);
+	if (!prop)
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	/* Find "interrupt-parent" in node or its parents */
+	pnode = node;
+	prop = fdt_getprop(fdt, pnode, "interrupt-parent", &len);
+
+	while (!prop) {
+		pnode = fdt_parent_offset(fdt, pnode);
+		if (pnode < 0)
+			break;
+
+		prop = fdt_getprop(fdt, pnode, "interrupt-parent", &len);
+		if (!prop && len != -FDT_ERR_NOTFOUND)
+			break;
+	}
+	if (!prop) {
+		DMSG("No interrupt parent for node %s",
+		     fdt_get_name(fdt, node, NULL));
+		return TEE_ERROR_GENERIC;
+	}
+
+	/* "interrupt-parent" provides interrupt controller phandle */
+	phandle = fdt32_to_cpu(prop[0]);
+
+	/* Get interrupt chip/number from phandle and "interrupts" property */
+	return dt_driver_device_from_node_idx_prop_phandle("interrupts", fdt,
+							   node, index,
+							   DT_DRIVER_INTERRUPT,
+							   phandle,
+							   itr_desc);
+}
+
+/*
+ * Fills an itr_desc based on "interrupts-extended" property bindings.
+ * May return TEE_ERROR_DEFER_DRIVER_INIT if parent controller is found
+ * but not yet initialized.
+ */
+static TEE_Result get_extended_interrupt_by_index(const void *fdt, int node,
+						  unsigned int index,
+						  struct itr_desc *itr_desc)
+{
+	return dt_driver_device_from_node_idx_prop("interrupts-extended",
+						   fdt, node, index,
+						   DT_DRIVER_INTERRUPT,
+						   itr_desc);
+}
+
+TEE_Result interrupt_dt_get_by_index(const void *fdt, int node,
+				     unsigned int index, struct itr_chip **chip,
+				     size_t *itr_num)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct itr_desc desc = { };
+
+	assert(chip && itr_num);
+
+	/* "interrupts-extended" takes precedence over "interrupts" */
+	if (fdt_getprop(fdt, node, "interrupts-extended", NULL))
+		res = get_extended_interrupt_by_index(fdt, node, index, &desc);
+	else
+		res = get_legacy_interrupt_by_index(fdt, node, index, &desc);
+
+	if (!res) {
+		assert(desc.chip);
+		*chip = desc.chip;
+		*itr_num = desc.itr_num;
+	}
+
+	return res;
+}
+
+TEE_Result interrupt_dt_get_by_name(const void *fdt, int node, const char *name,
+				    struct itr_chip **chip, size_t *itr_num)
+{
+	int idx = 0;
+
+	idx = fdt_stringlist_search(fdt, node, "interrupt-names", name);
+	if (idx < 0)
+		return TEE_ERROR_GENERIC;
+
+	return interrupt_dt_get_by_index(fdt, node, idx, chip, itr_num);
+}
+#endif /*CFG_DT*/


### PR DESCRIPTION
Following changes done recently in the interrupt framework, this P-R is based on https://github.com/OP-TEE/optee_os/pull/6097. It provides means to use DT bindings to describe interrupts and their controllers.

2nd commit adds an API function (`dt_register_interrupt_provider()`)for interrupt controller drivers to register as itr_chip providers into the DT_DRIVER framework and few API functions for consumer driver to use DT info to find their interrupt (`interrupt_dt_get()`, `interrupt_dt_get_by_index()`, `interrupt_dt_get_by_name()`).

3rd commit Adds a API function to register a callback handler for an interrupt. 
`interrupt_create_handler()` differs from existing `interrupt_add_handler()` in that the former does not reconfigure the interrupt since already done by `interrupt_dt_get()` or friend. Maybe `interrupt_add_handler2()` would be a better label.

Last commit registers GIC driver as a `DT_DRIVER_INTERRUPT` driver so that interrupt consumer drivers can use `interrupt_dt_get_by_index()` and friends.