### PR TITLE
[PATCH v2] RISC-V: Implement SBI based protocol 

### DIFF
--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -59,6 +59,8 @@ void thread_init_tvec(void);
 void thread_trap_vect(void);
 void thread_trap_vect_end(void);
 
+void __panic_at_abi_return(void);
+
 /*
  * Assembly function as the first function in a thread.  Handles a stdcall,
  * a0-a3 holds the parameters. Hands over to __thread_std_abi_entry() when

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -59,6 +59,10 @@ void thread_init_tvec(void);
 void thread_trap_vect(void);
 void thread_trap_vect_end(void);
 
+void thread_return_to_ree(unsigned long arg0, unsigned long arg1,
+			  unsigned long arg2, unsigned long arg3,
+			  unsigned long arg4, unsigned long arg5);
+
 void __panic_at_abi_return(void);
 
 /*

--- a/core/arch/riscv/include/riscv_macros.S
+++ b/core/arch/riscv/include/riscv_macros.S
@@ -68,3 +68,11 @@
 		bnez	a1, 1b
 		add	\reg_res, \reg_res, a0
 	.endm
+
+	.macro panic_at_abi_return
+#if defined(CFG_TEE_CORE_DEBUG)
+		jal	__panic_at_abi_return
+#else
+		j	.
+#endif
+	.endm

--- a/core/arch/riscv/include/sbi.h
+++ b/core/arch/riscv/include/sbi.h
@@ -22,6 +22,7 @@
 /* SBI Extension IDs */
 #define SBI_EXT_0_1_CONSOLE_PUTCHAR	0x01, 0
 #define SBI_EXT_HSM			0x48534D
+#define SBI_EXT_TEE			0x544545
 
 /* SBI function IDs for HSM extension */
 #define SBI_EXT_HSM_HART_START		U(0)

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -86,4 +86,8 @@ DEFINES
 	DEFINE(CORE_MMU_CONFIG_SIZE, sizeof(struct core_mmu_config));
 	DEFINE(CORE_MMU_CONFIG_SATP,
 	       offsetof(struct core_mmu_config, satp));
+
+	/* struct thread_abi_args */
+	DEFINE(THREAD_ABI_ARGS_A0, offsetof(struct thread_abi_args, a0));
+	DEFINE(THREAD_ABI_ARGS_SIZE, sizeof(struct thread_abi_args));
 }

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -12,6 +12,9 @@
 #include <platform_config.h>
 #include <riscv.h>
 #include <riscv_macros.S>
+#include <tee/optee_abi.h>
+#include <tee/teeabi_opteed.h>
+#include <tee/teeabi_opteed_macros.h>
 
 .section .data
 .balign 4
@@ -219,7 +222,10 @@ UNWIND(	.cantunwind)
 	wait_secondary
 
 	jal	thread_clr_boot_thread
-	j	mu_service
+
+	li	a0, TEEABI_OPTEED_RETURN_ENTRY_DONE
+	la	a1, thread_vector_table
+	j	thread_return_to_ree
 END_FUNC reset_primary
 
 LOCAL_FUNC reset_secondary , : , .identity_map

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -32,6 +32,15 @@
 #include <trace.h>
 #include <util.h>
 
+/*
+ * This function is called as a guard after each ABI call which is not
+ * supposed to return.
+ */
+void __noreturn __panic_at_abi_return(void)
+{
+	panic();
+}
+
 uint32_t __nostackcheck thread_get_exceptions(void)
 {
 	return read_csr(CSR_XIE) & THREAD_EXCP_ALL;

--- a/core/arch/riscv/kernel/thread_optee_abi_rv.S
+++ b/core/arch/riscv/kernel/thread_optee_abi_rv.S
@@ -149,3 +149,67 @@ FUNC thread_rpc , :
 	addi	sp, sp, REGOFF(4)
 	ret
 END_FUNC thread_rpc
+
+LOCAL_FUNC vector_std_abi_entry, : , .identity_map
+	jal	thread_handle_std_abi
+	/*
+	 * Normally thread_handle_std_abi() should return via
+	 * thread_exit(), thread_rpc(), but if thread_handle_std_abi()
+	 * hasn't switched stack (error detected) it will do a normal "C"
+	 * return.
+	 */
+	/* Restore thread_handle_std_abi() return value */
+	mv	a1, a0
+	li	a2, 0
+	li	a3, 0
+	li	a4, 0
+	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
+
+	/* Return to untrusted domain */
+	j	thread_return_to_ree
+END_FUNC vector_std_abi_entry
+
+LOCAL_FUNC vector_fast_abi_entry , : , .identity_map
+	addi    sp, sp, -THREAD_ABI_ARGS_SIZE
+	store_xregs sp, THREAD_ABI_ARGS_A0, REG_A0, REG_A7
+	mv      a0, sp
+	jal	thread_handle_fast_abi
+	load_xregs sp, THREAD_ABI_ARGS_A0, REG_A1, REG_A7
+	addi    sp, sp, THREAD_ABI_ARGS_SIZE
+
+	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
+	/* Return to untrusted domain */
+	j	thread_return_to_ree
+END_FUNC vector_fast_abi_entry
+
+LOCAL_FUNC vector_fiq_entry , : , .identity_map
+	/* Secure Monitor received a FIQ and passed control to us. */
+	jal	interrupt_main_handler
+
+	li	a0, TEEABI_OPTEED_RETURN_FIQ_DONE
+	/* Return to untrusted domain */
+	j	thread_return_to_ree
+END_FUNC vector_fiq_entry
+
+/*
+ * Vector table supplied to M-mode secure monitor (e.g., openSBI) at
+ * initialization.
+ *
+ * Note that M-mode secure monitor depends on the layout of this vector table,
+ * any change in layout has to be synced with M-mode secure monitor.
+ */
+FUNC thread_vector_table , : , .identity_map, , nobti
+	.option push
+	.option norvc
+	j   vector_std_abi_entry
+	j   vector_fast_abi_entry
+	j   .
+	j   .
+	j   .
+	j   .
+	j   vector_fiq_entry
+	j   .
+	j   .
+	.option pop
+END_FUNC thread_vector_table
+DECLARE_KEEP_PAGER thread_vector_table

--- a/core/arch/riscv/kernel/thread_optee_abi_rv.S
+++ b/core/arch/riscv/kernel/thread_optee_abi_rv.S
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright 2023 NXP
+ * Copyright (c) 2023 Andes Technology Corporation
  */
 
 #include <asm.S>
@@ -10,6 +11,7 @@
 #include <kernel/thread_private.h>
 #include <riscv.h>
 #include <riscv_macros.S>
+#include <sbi.h>
 #include <tee/optee_abi.h>
 #include <tee/teeabi_opteed.h>
 #include <tee/teeabi_opteed_macros.h>
@@ -20,11 +22,23 @@
  * a security monitor running in M-Mode and panic or messaging-based across
  * domains where we return to a messaging callback which parses and handles
  * messages.
+ *
+ * void thread_return_to_ree(unsigned long arg0, unsigned long arg1,
+ *                           unsigned long arg2, unsigned long arg3,
+ *                           unsigned long arg4, unsigned long arg5);
  */
-LOCAL_FUNC thread_return_from_nsec_call , :
-	/* Implement */
-	j	.
-END_FUNC thread_return_from_nsec_call
+FUNC thread_return_to_ree , :
+	/* Caller should provide arguments in a0~a5 */
+#if defined(CFG_RISCV_SBI)
+	li	a7, SBI_EXT_TEE		/* extension ID */
+	li	a6, 0			/* function ID (unused) */
+	ecall
+#else
+	/* Other protocol */
+#endif
+	/* ABI to REE should not return */
+	panic_at_abi_return
+END_FUNC thread_return_to_ree
 
 FUNC thread_std_abi_entry , :
 	jal	__thread_std_abi_entry
@@ -53,7 +67,7 @@ FUNC thread_std_abi_entry , :
 	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
 
 	/* Return to untrusted domain */
-	jal	thread_return_from_nsec_call
+	jal	thread_return_to_ree
 END_FUNC thread_std_abi_entry
 
 /* void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]) */
@@ -107,7 +121,7 @@ FUNC thread_rpc , :
 	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
 
 	/* Return to untrusted domain */
-	jal	thread_return_from_nsec_call
+	jal	thread_return_to_ree
 .thread_rpc_return:
 	/*
 	 * Jumps here from thread_resume() above when RPC has returned.


### PR DESCRIPTION
Based on https://github.com/OP-TEE/optee_os/pull/6268
And apply recommendations from patch v1 https://github.com/OP-TEE/optee_os/pull/6323
This PR implements SBI based protocol.

In SBI protocol, OP-TEE prepares function arguments in registers a0~a5.
The register a7 encodes SBI TEE extension ID, which is 0x544545(TEE), temporarily.
Then OP-TEE issues ecall to trap into higher privileged software, e.g., openSBI.
The higher privileged software will handle this call and execute OS context switch, etc.

OP-TEE also registers its vector table, which has address of entry functions for service, into higher privileged software. The higher privileged software can jump into OP-TEE according to this vector table.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
