### PR TITLE
drivers: regulator: consider DT property regulator-boot-on

### DIFF
--- a/core/drivers/regulator/regulator_dt.c
+++ b/core/drivers/regulator/regulator_dt.c
@@ -36,6 +36,10 @@ static struct regulator_property flag_prop[] = {
 		.name = "regulator-pull-down",
 		.flag = REGULATOR_PULL_DOWN,
 	},
+	{
+		.name = "regulator-boot-on",
+		.flag = REGULATOR_BOOT_ON,
+	},
 };
 
 /*

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -20,8 +20,15 @@
 #define REGULATOR_ALWAYS_ON	BIT(0)
 /* Enables pull down mode. DT property: regulator-pull-down */
 #define REGULATOR_PULL_DOWN	BIT(1)
+/*
+ * It's expected that this regulator was left on by the bootloader.
+ * The core shouldn't prevent it from being turned off later.
+ * DT property: regulator-boot-on
+ */
+#define REGULATOR_BOOT_ON	BIT(2)
 
-#define REGULATOR_FLAGS_MASK	(REGULATOR_ALWAYS_ON | REGULATOR_PULL_DOWN)
+#define REGULATOR_FLAGS_MASK	(REGULATOR_ALWAYS_ON | REGULATOR_PULL_DOWN | \
+				 REGULATOR_BOOT_ON)
 
 struct regulator_ops;
 


### PR DESCRIPTION
Defines regulator flag `REGULATOR_BOOT_ON` for regulators with the `regulator-boot-on` property in their DT node.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
