### PR TITLE
RISC-V: Small modifications for PLIC driver

### DIFF
--- a/core/drivers/plic.c
+++ b/core/drivers/plic.c
@@ -275,7 +275,7 @@ void plic_it_handle(void)
 	struct plic_data *pd = &plic_data;
 	uint32_t id = plic_claim_interrupt(pd);
 
-	if (id <= pd->max_it)
+	if (id > 0 && id <= pd->max_it)
 		interrupt_call_handlers(&pd->chip, id);
 	else
 		DMSG("ignoring interrupt %" PRIu32, id);


### PR DESCRIPTION
1. Move `interrupt_main_handler()` from platform specific source file to PLIC driver.
2. Ignore interrupt source ID 0 since it means "no interrupt".

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    3. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    4. You should run checkpatch preferably before submitting the pull request.

    5. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
