### PR TITLE
RISC-V: Refactor thread control

### DIFF
--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -124,7 +124,7 @@ struct thread_trap_regs {
 	unsigned long t6;
 	unsigned long epc;
 	unsigned long status;
-	unsigned long satp;
+	unsigned long ie;
 } __aligned(16);
 
 struct thread_scall_regs {
@@ -175,7 +175,9 @@ struct thread_ctx_regs {
 	unsigned long t4;
 	unsigned long t5;
 	unsigned long t6;
+	unsigned long epc;
 	unsigned long status;
+	unsigned long ie;
 };
 
 struct user_mode_ctx;

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -107,7 +107,14 @@ void thread_alloc_and_run(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
 			  uint32_t a4, uint32_t a5);
 void thread_resume_from_rpc(uint32_t thread_id, uint32_t a0, uint32_t a1,
 			    uint32_t a2, uint32_t a3);
-void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]);
+void thread_rpc_xstatus(uint32_t rv[THREAD_RPC_NUM_ARGS], unsigned long status);
+void __thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]);
+
+static inline void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS])
+{
+	__thread_rpc(rv);
+}
+
 void thread_scall_handler(struct thread_scall_regs *regs);
 void thread_exit_user_mode(unsigned long a0, unsigned long a1,
 			   unsigned long a2, unsigned long a3,

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -65,6 +65,9 @@ void thread_return_to_udomain(unsigned long arg0, unsigned long arg1,
 
 void __panic_at_abi_return(void);
 
+/* Helper function to prepare CSR status for exception return */
+unsigned long xstatus_for_xret(uint8_t pie, uint8_t pp);
+
 /*
  * Assembly function as the first function in a thread.  Handles a stdcall,
  * a0-a3 holds the parameters. Hands over to __thread_std_abi_entry() when

--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -115,6 +115,14 @@ static inline __noprof void mb(void)
 	asm volatile ("fence" : : : "memory");
 }
 
+static inline __noprof unsigned long read_gp(void)
+{
+	unsigned long gp = 0;
+
+	asm volatile("mv %0, gp" : "=&r"(gp));
+	return gp;
+}
+
 static inline __noprof unsigned long read_tp(void)
 {
 	unsigned long tp = 0;

--- a/core/arch/riscv/kernel/abort.c
+++ b/core/arch/riscv/kernel/abort.c
@@ -238,7 +238,7 @@ static void handle_user_mode_panic(struct abort_info *ai)
 	ai->regs->a2 = 0xdeadbeef;
 	ai->regs->ra = (vaddr_t)thread_unwind_user_mode;
 	ai->regs->sp = thread_get_saved_thread_sp();
-	ai->regs->status = read_csr(CSR_XSTATUS);
+	ai->regs->status = xstatus_for_xret(true, PRV_S);
 
 	thread_exit_user_mode(ai->regs->a0, ai->regs->a1, ai->regs->a2,
 			      ai->regs->a3, ai->regs->sp, ai->regs->ra,

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -38,6 +38,8 @@ DEFINES
 
 	/* struct thread_ctx_regs */
 	DEFINE(THREAD_CTX_REG_STATUS, offsetof(struct thread_ctx_regs, status));
+	DEFINE(THREAD_CTX_REG_EPC, offsetof(struct thread_ctx_regs, epc));
+	DEFINE(THREAD_CTX_REG_IE, offsetof(struct thread_ctx_regs, ie));
 	DEFINE(THREAD_CTX_REG_RA, offsetof(struct thread_ctx_regs, ra));
 	DEFINE(THREAD_CTX_REG_SP, offsetof(struct thread_ctx_regs, sp));
 	DEFINE(THREAD_CTX_REG_T0, offsetof(struct thread_ctx_regs, t0));

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -32,7 +32,8 @@ DEFINES
 	       offsetof(struct thread_core_local, flags));
 	DEFINE(THREAD_CORE_LOCAL_ABT_STACK_VA_END,
 	       offsetof(struct thread_core_local, abt_stack_va_end));
-	DEFINE(THREAD_CORE_LOCAL_X10, offsetof(struct thread_core_local, x[0]));
+	DEFINE(THREAD_CORE_LOCAL_X0, offsetof(struct thread_core_local, x[0]));
+	DEFINE(THREAD_CORE_LOCAL_X1, offsetof(struct thread_core_local, x[1]));
 
 	DEFINE(STACK_TMP_GUARD, STACK_CANARY_SIZE / 2 + STACK_TMP_OFFS);
 
@@ -74,6 +75,7 @@ DEFINES
 	DEFINE(THREAD_TRAP_REG_EPC, offsetof(struct thread_trap_regs, epc));
 	DEFINE(THREAD_TRAP_REG_STATUS,
 	       offsetof(struct thread_trap_regs, status));
+	DEFINE(THREAD_TRAP_REG_IE, offsetof(struct thread_trap_regs, ie));
 	DEFINE(THREAD_TRAP_REGS_SIZE, sizeof(struct thread_trap_regs));
 
 	/* struct thread_scall_regs */

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -686,3 +686,8 @@ uint32_t thread_enter_user_mode(unsigned long a0, unsigned long a1,
 
 	return rc;
 }
+
+void __thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS])
+{
+	thread_rpc_xstatus(rv, xstatus_for_xret(false, PRV_S));
+}

--- a/core/arch/riscv/kernel/thread_optee_abi_rv.S
+++ b/core/arch/riscv/kernel/thread_optee_abi_rv.S
@@ -70,27 +70,35 @@ FUNC thread_std_abi_entry , :
 	jal	thread_return_to_udomain
 END_FUNC thread_std_abi_entry
 
-/* void thread_rpc(uint32_t rv[THREAD_RPC_NUM_ARGS]) */
-FUNC thread_rpc , :
+/*
+ * void thread_rpc_xstatus(uint32_t rv[THREAD_RPC_NUM_ARGS],
+ *                         unsigned long status);
+ */
+FUNC thread_rpc_xstatus , :
 	 /* Use stack for temporary storage */
-	addi	sp, sp, -REGOFF(4)
+	addi	sp, sp, -REGOFF(8)
 
 	/* Read xSTATUS */
-	csrr	a1, CSR_XSTATUS
+	csrr	a2, CSR_XSTATUS
 
 	/* Mask all maskable exceptions before switching to temporary stack */
-	csrc	CSR_XSTATUS, CSR_XSTATUS_IE
+	csrw	CSR_XIE, x0
 
 	/* Save return address xSTATUS and pointer to rv */
 	STR	a0, REGOFF(0)(sp)
 	STR	a1, REGOFF(1)(sp)
 	STR	s0, REGOFF(2)(sp)
 	STR	ra, REGOFF(3)(sp)
-	addi	s0, sp, REGOFF(4)
+	STR	a2, REGOFF(4)(sp)
+#ifdef CFG_UNWIND
+	addi	s0, sp, REGOFF(8)
+#endif
 
 	/* Save thread state */
 	jal	thread_get_ctx_regs
-	store_xregs a0, THREAD_CTX_REG_SP, REG_SP
+	LDR	ra, REGOFF(3)(sp)
+	/* Save ra, sp, gp, tp, and s0~s11 */
+	store_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_TP
 	store_xregs a0, THREAD_CTX_REG_S0, REG_S0, REG_S1
 	store_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
 
@@ -139,16 +147,16 @@ FUNC thread_rpc , :
 	sw	a3, 12(a4)
 
 	/* Pop saved XSTATUS from stack */
-	LDR	s0, REGOFF(1)(sp)
+	LDR	s0, REGOFF(4)(sp)
 	csrw	CSR_XSTATUS, s0
 
-	/* Pop return address and s0 from stack */
-	LDR	ra, REGOFF(3)(sp)
+	/* Pop s0 from stack */
 	LDR	s0, REGOFF(2)(sp)
 
-	addi	sp, sp, REGOFF(4)
+	addi	sp, sp, REGOFF(8)
 	ret
-END_FUNC thread_rpc
+END_FUNC thread_rpc_xstatus
+DECLARE_KEEP_PAGER thread_rpc_xstatus
 
 LOCAL_FUNC vector_std_abi_entry, : , .identity_map
 	jal	thread_handle_std_abi

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -29,15 +29,24 @@
 .endm
 
 .macro save_regs, mode
-	addi	sp, sp, -THREAD_TRAP_REGS_SIZE
 .if \mode == TRAP_MODE_USER
+	/* Save user sp, a0, a1 into temporary spaces of thread_core_local */
+	store_xregs tp, THREAD_CORE_LOCAL_X0, REG_SP
+	store_xregs tp, THREAD_CORE_LOCAL_X1, REG_A0, REG_A1
+	/* Load and set kernel sp from thread context */
+	get_thread_ctx a0, a1
+	load_xregs a0, THREAD_CTX_KERN_SP, REG_SP
+	/* Now sp is kernel sp, create stack frame to save user context */
+	addi	sp, sp, -THREAD_TRAP_REGS_SIZE
 
-	/* Save user thread pointer and load kernel thread pointer */
-	store_xregs sp, THREAD_TRAP_REG_TP, REG_TP
-	addi	tp, sp, THREAD_TRAP_REGS_SIZE
-	/* Now tp is at struct thread_user_mode_rec, which has kernel tp */
-	load_xregs tp, THREAD_USER_MODE_REC_X4, REG_TP
+	/* Save user sp */
+	load_xregs tp, THREAD_CORE_LOCAL_X0, REG_A0
+	store_xregs sp, THREAD_TRAP_REG_SP, REG_A0
 
+	/* Restore user a0, a1 which can be saved later */
+	load_xregs tp, THREAD_CORE_LOCAL_X1, REG_A0, REG_A1
+
+	/* Save user gp */
 	store_xregs sp, THREAD_TRAP_REG_GP, REG_GP
 
 	/*
@@ -45,11 +54,17 @@
 	 * exception thread_trap_vect() knows that it is emitted from kernel.
 	 */
 	csrrw	gp, CSR_XSCRATCH, zero
-	store_xregs sp, THREAD_TRAP_REG_SP, REG_GP
+	/* Save user tp we previously swapped into CSR_XSCRATCH */
+	store_xregs sp, THREAD_TRAP_REG_TP, REG_GP
 .option push
 .option norelax
 	la	gp, __global_pointer$
 .option pop
+.else
+	/* sp is kernel sp */
+	addi	sp, sp, -THREAD_TRAP_REGS_SIZE
+	store_xregs sp, THREAD_TRAP_REG_GP, REG_GP
+	store_xregs sp, THREAD_TRAP_REG_SP, REG_SP
 .endif
 	store_xregs sp, THREAD_TRAP_REG_T3, REG_T3, REG_T6
 	store_xregs sp, THREAD_TRAP_REG_T0, REG_T0, REG_T2
@@ -59,6 +74,12 @@
 	/* To unwind stack we need s0, which is frame pointer. */
 	store_xregs sp, THREAD_TRAP_REG_S0, REG_S0
 #endif
+
+	csrr	t0, CSR_XIE
+	store_xregs sp, THREAD_TRAP_REG_IE, REG_T0
+
+	/* Mask all interrupts */
+	csrw	CSR_XIE, x0
 
 	csrr	t0, CSR_XSTATUS
 	store_xregs sp, THREAD_TRAP_REG_STATUS, REG_T0
@@ -82,6 +103,9 @@
 	load_xregs sp, THREAD_TRAP_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
 
+	load_xregs sp, THREAD_TRAP_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
+
 	load_xregs sp, THREAD_TRAP_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
 
@@ -95,14 +119,16 @@
 #endif
 
 .if \mode == TRAP_MODE_USER
-	addi	gp, sp, THREAD_TRAP_REGS_SIZE
-	csrw	CSR_XSCRATCH, gp
+	/* Set scratch as thread_core_local */
+	csrw	CSR_XSCRATCH, tp
 
 	load_xregs sp, THREAD_TRAP_REG_TP, REG_TP
 	load_xregs sp, THREAD_TRAP_REG_GP, REG_GP
 	load_xregs sp, THREAD_TRAP_REG_SP, REG_SP
 
 .else
+	load_xregs sp, THREAD_TRAP_REG_GP, REG_GP
+	load_xregs sp, THREAD_TRAP_REG_SP, REG_SP
 	addi	sp, sp, THREAD_TRAP_REGS_SIZE
 .endif
 .endm
@@ -114,11 +140,13 @@ FUNC __get_core_pos , : , .identity_map
 END_FUNC __get_core_pos
 
 FUNC thread_trap_vect , :
-	csrrw	sp, CSR_XSCRATCH, sp
-	bnez	sp, 0f
-	csrrw	sp, CSR_XSCRATCH, sp
+	csrrw	tp, CSR_XSCRATCH, tp
+	bnez	tp, 0f
+	/* Read tp back */
+	csrrw	tp, CSR_XSCRATCH, tp
 	j	trap_from_kernel
 0:
+	/* Now tp is thread_core_local */
 	j	trap_from_user
 thread_trap_vect_end:
 END_FUNC thread_trap_vect

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -23,6 +23,11 @@
 2:
 .endm
 
+.macro b_if_prev_priv_is_u reg, label
+	andi	\reg, \reg, CSR_XSTATUS_SPP
+	beqz	\reg, \label
+.endm
+
 .macro save_regs, mode
 	addi	sp, sp, -THREAD_TRAP_REGS_SIZE
 .if \mode == TRAP_MODE_USER
@@ -249,16 +254,37 @@ END_FUNC __thread_enter_user_mode
 
 /* void thread_resume(struct thread_ctx_regs *regs) */
 FUNC thread_resume , :
-	/*
-	 * Restore all registers assuming that GP
-	 * and TP were not changed.
-	 */
-	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_SP
+	/* Disable global interrupts first */
+	csrc	CSR_XSTATUS, CSR_XSTATUS_IE
+
+	/* Restore epc */
+	load_xregs a0, THREAD_CTX_REG_EPC, REG_T0
+	csrw	CSR_XEPC, t0
+
+	/* Restore ie */
+	load_xregs a0, THREAD_CTX_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
+
+	/* Restore status */
+	load_xregs a0, THREAD_CTX_REG_STATUS, REG_T0
+	csrw	CSR_XSTATUS, t0
+
+	/* Check if previous privilege mode by status.SPP */
+	b_if_prev_priv_is_u t0, 1f
+	/* Set scratch as zero to indicate that we are in kernel mode */
+	csrw	CSR_XSCRATCH, zero
+	j	2f
+1:
+	/* Resume to U-mode, set scratch as tp to be used in the trap handler */
+	csrw	CSR_XSCRATCH, tp
+2:
+	/* Restore all general-purpose registers */
+	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_TP
 	load_xregs a0, THREAD_CTX_REG_T0, REG_T0, REG_T2
 	load_xregs a0, THREAD_CTX_REG_S0, REG_S0, REG_S1
 	load_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
 	load_xregs a0, THREAD_CTX_REG_T3, REG_T3, REG_T6
 	load_xregs a0, THREAD_CTX_REG_A0, REG_A0, REG_A7
-	store_xregs tp, THREAD_CORE_LOCAL_X10, REG_A0, REG_A1
-	ret
+
+	XRET
 END_FUNC thread_resume

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -159,17 +159,11 @@ FUNC thread_unwind_user_mode , :
 	/* Restore kernel callee regs */
 	mv	a1, sp
 
-	load_xregs a1, THREAD_USER_MODE_REC_X1, REG_RA, REG_TP
+	load_xregs a1, THREAD_USER_MODE_REC_X1, REG_RA, REG_GP
 	load_xregs a1, THREAD_USER_MODE_REC_X8, REG_S0, REG_S1
 	load_xregs a1, THREAD_USER_MODE_REC_X18, REG_S2, REG_S11
 
 	add	sp, sp, THREAD_USER_MODE_REC_SIZE
-
-	/*
-	 * Zeroize xSCRATCH to indicate to thread_trap_vect()
-	 * that we are executing in kernel.
-	 */
-	csrw	CSR_XSCRATCH, zero
 
 	/* Return from the call of thread_enter_user_mode() */
 	ret
@@ -188,9 +182,22 @@ FUNC thread_exit_user_mode , :
 	/* Set xSTATUS */
 	csrw	CSR_XSTATUS, a6
 
-	/* Set return address thread_unwind_user_mode() */
-	mv	ra, a5
-	ret
+	/*
+	 * Zeroize xSCRATCH to indicate to thread_trap_vect()
+	 * that we are executing in kernel.
+	 */
+	csrw	CSR_XSCRATCH, zero
+
+	/*
+	 * Mask all interrupts first. Interrupts will be unmasked after
+	 * returning from __thread_enter_user_mode().
+	 */
+	csrw	CSR_XIE, zero
+
+	/* Set epc as thread_unwind_user_mode() */
+	csrw	CSR_XEPC, a5
+
+	XRET
 END_FUNC thread_exit_user_mode
 
 /*
@@ -199,12 +206,15 @@ END_FUNC thread_exit_user_mode
  *				     uint32_t *exit_status1);
  */
 FUNC __thread_enter_user_mode , :
+	/* Disable kernel mode exceptions first */
+	csrc	CSR_XSTATUS, CSR_XSTATUS_IE
+
 	/*
 	 * Create and fill in the struct thread_user_mode_rec
 	 */
 	addi	sp, sp, -THREAD_USER_MODE_REC_SIZE
 	store_xregs sp, THREAD_USER_MODE_REC_CTX_REGS_PTR, REG_A0, REG_A2
-	store_xregs sp, THREAD_USER_MODE_REC_X1, REG_RA, REG_TP
+	store_xregs sp, THREAD_USER_MODE_REC_X1, REG_RA, REG_GP
 	store_xregs sp, THREAD_USER_MODE_REC_X8, REG_S0, REG_S1
 	store_xregs sp, THREAD_USER_MODE_REC_X18, REG_S2, REG_S11
 
@@ -222,20 +232,18 @@ FUNC __thread_enter_user_mode , :
 
 	store_xregs s0, THREAD_CTX_KERN_SP, REG_SP
 	/*
-	 * Save kernel stack pointer in xSCRATCH to ensure that
-	 * thread_trap_vect() uses correct stack pointer.
+	 * Save thread_core_local in xSCRATCH to ensure that thread_trap_vect()
+	 * uses correct core local structure.
 	 */
-	csrw	CSR_XSCRATCH, sp
+	csrw	CSR_XSCRATCH, tp
+
+	/* Set user ie */
+	load_xregs a0, THREAD_CTX_REG_IE, REG_S0
+	csrw	CSR_XIE, s0
 
 	/* Set user status */
 	load_xregs a0, THREAD_CTX_REG_STATUS, REG_S0
 	csrw	CSR_XSTATUS, s0
-
-	/*
-	 * Save the values for a1 and a2 in struct thread_core_local to be
-	 * restored later just before the xRET.
-	 */
-	store_xregs tp, THREAD_CORE_LOCAL_X10, REG_A1, REG_A2
 
 	/* Load the rest of the general purpose registers */
 	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_TP


### PR DESCRIPTION
This series include some refactoring for thread control and SMP fixes:
1. Apply exception return to `thread_resume()` and `thread_exit_user_mode()`.
2. Save thread_core_local into CSR scratch, instead of saving kernel stack pointer, when thread is in user mode.
3. Add missing `thread_{mask/unmask}_exceptions()` during operations on page table.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    3. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    4. You should run checkpatch preferably before submitting the pull request.

    5. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
