### PR TITLE
core: arm: rpc_alloc: remove size limit for kernel payload

### DIFF
--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -681,14 +681,6 @@ struct mobj *thread_rpc_alloc_payload(size_t size)
 
 struct mobj *thread_rpc_alloc_kernel_payload(size_t size)
 {
-	/*
-	 * Error out early since kernel private dynamic shared memory
-	 * allocations don't currently use the `OPTEE_MSG_ATTR_NONCONTIG` bit
-	 * and therefore cannot be larger than a page.
-	 */
-	if (IS_ENABLED(CFG_CORE_DYN_SHM) && size > SMALL_PAGE_SIZE)
-		return NULL;
-
 	return thread_rpc_alloc(size, 8, OPTEE_RPC_SHM_TYPE_KERNEL);
 }
 


### PR DESCRIPTION
Removes the size limit of 1 page imposed in
thread_rpc_alloc_kernel_payload(). The purpose of this limit was to error out early since the kernel doesn't supply a list of physical pages and the source of the error is not obvious at first glance. This is now about to change so remove the limit since the kernel now may supply the needed list of physical pages.

Link to corresponding kernel patch https://lore.kernel.org/lkml/20231026171650.515275-1-jens.wiklander@linaro.org/
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
