### PR TITLE
Introduce STM32MP25x platforms minimal support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
           _make PLATFORM=stm32mp1
           _make PLATFORM=stm32mp1-135F_DK
           if [ -d $HOME/scp-firmware ]; then _make PLATFORM=stm32mp1-157C_DK2 CFG_SCMI_SCPFW=y CFG_SCP_FIRMWARE=$HOME/scp-firmware; fi
+          _make PLATFORM=stm32mp2
           _make PLATFORM=vexpress-fvp
           _make PLATFORM=vexpress-fvp CFG_ARM64_core=y
           _make PLATFORM=vexpress-fvp CFG_ARM64_core=y CFG_CORE_SEL1_SPMC=y CFG_SECURE_PARTITION=y

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -267,13 +267,24 @@ R:	Etienne Carriere <etienne.carriere@foss.st.com> [@etienne-lms]
 S:	Maintained
 F:	core/arch/arm/plat-stm/
 
+STMicroelectronics drivers
+R:	Etienne Carriere <etienne.carriere@foss.st.com> [@etienne-lms]
+R:	Gatien Chevallier <gatien.chevallier@foss.st.com> [@GseoC]
+S:	Maintained
+F:	core/drivers/stm32_*
+
 STMicroelectronics stm32mp1
 R:	Etienne Carriere <etienne.carriere@foss.st.com> [@etienne-lms]
 S:	Maintained
 F:	core/arch/arm/plat-stm32mp1/
-F:	core/drivers/stm32_*
 F:	core/drivers/stm32mp15_huk.c
 F:	core/drivers/stpmic1.c
+
+STMicroelectronics stm32mp2
+R:	Etienne Carriere <etienne.carriere@foss.st.com> [@etienne-lms]
+R:	Gatien Chevallier <gatien.chevallier@foss.st.com> [@GseoC]
+S:	Maintained
+F:	core/arch/arm/plat-stm32mp2/*
 
 Texas Instruments AM43xx, AM57xx, DRA7xx, AM65x, J721E, J784S4, AM64x, AM62x
 R:	Andrew Davis <afd@ti.com> [@glneo]

--- a/core/arch/arm/dts/stm32mp25-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp25-pinctrl.dtsi
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+#include <dt-bindings/pinctrl/stm32-pinfunc.h>
+

--- a/core/arch/arm/dts/stm32mp251.dtsi
+++ b/core/arch/arm/dts/stm32mp251.dtsi
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+
+/ {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu0: cpu@0 {
+			compatible = "arm,cortex-a35";
+			device_type = "cpu";
+			reg = <0>;
+			enable-method = "psci";
+		};
+	};
+
+	psci {
+		compatible = "arm,psci-1.0";
+		method = "smc";
+	};
+
+	intc: interrupt-controller@4ac00000 {
+		compatible = "arm,cortex-a7-gic";
+		#interrupt-cells = <3>;
+		interrupt-controller;
+		reg = <0x0 0x4ac10000 0x0 0x1000>,
+		      <0x0 0x4ac20000 0x0 0x2000>,
+		      <0x0 0x4ac40000 0x0 0x2000>,
+		      <0x0 0x4ac60000 0x0 0x2000>;
+		#address-cells = <1>;
+	};
+
+	clocks {
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <24000000>;
+		};
+
+		clk_hsi: clk-hsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <64000000>;
+		};
+
+		clk_lse: clk-lse {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32768>;
+		};
+
+		clk_lsi: clk-lsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <32000>;
+		};
+
+		clk_msi: clk-msi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <4000000>;
+		};
+
+		clk_i2sin: clk-i2sin {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <0>;
+		};
+
+		clocks {
+			clk_rcbsec: clk-rcbsec {
+				#clock-cells = <0>;
+				compatible = "fixed-clock";
+				clock-frequency = <64000000>;
+			};
+		};
+	};
+
+	soc@0 {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		interrupt-parent = <&intc>;
+		ranges = <0x0 0x0 0x0 0x80000000>;
+
+		rifsc: rifsc@42080000 {
+			reg = <0x42080000 0x1000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			usart2: serial@400e0000 {
+				reg = <0x400e0000 0x400>;
+				status = "disabled";
+			};
+		};
+
+		pinctrl: pinctrl@44240000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "st,stm32mp257-pinctrl";
+			ranges = <0 0x44240000 0xa0400>;
+			pins-are-numbered;
+
+			gpioa: gpio@44240000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x0 0x400>;
+				st,bank-name = "GPIOA";
+				status = "disabled";
+			};
+
+			gpiob: gpio@44250000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x10000 0x400>;
+				st,bank-name = "GPIOB";
+				status = "disabled";
+			};
+
+			gpioc: gpio@44260000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x20000 0x400>;
+				st,bank-name = "GPIOC";
+				status = "disabled";
+			};
+
+			gpiod: gpio@44270000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x30000 0x400>;
+				st,bank-name = "GPIOD";
+				status = "disabled";
+			};
+
+			gpioe: gpio@44280000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x40000 0x400>;
+				st,bank-name = "GPIOE";
+				status = "disabled";
+			};
+
+			gpiof: gpio@44290000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x50000 0x400>;
+				st,bank-name = "GPIOF";
+				status = "disabled";
+			};
+
+			gpiog: gpio@442a0000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x60000 0x400>;
+				st,bank-name = "GPIOG";
+				status = "disabled";
+			};
+
+			gpioh: gpio@442b0000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x70000 0x400>;
+				st,bank-name = "GPIOH";
+				status = "disabled";
+			};
+
+			gpioi: gpio@442c0000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x80000 0x400>;
+				st,bank-name = "GPIOI";
+				status = "disabled";
+			};
+
+			gpioj: gpio@442d0000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0x90000 0x400>;
+				st,bank-name = "GPIOJ";
+				status = "disabled";
+			};
+
+			gpiok: gpio@442e0000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0xa0000 0x400>;
+				st,bank-name = "GPIOK";
+				status = "disabled";
+			};
+		};
+
+		pinctrl_z: pinctrl-z@46200000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "st,stm32mp257-z-pinctrl";
+			ranges = <0 0x46200000 0x400>;
+			pins-are-numbered;
+
+			gpioz: gpio@46200000 {
+				gpio-controller;
+				#gpio-cells = <2>;
+				interrupt-controller;
+				#interrupt-cells = <2>;
+				reg = <0 0x400>;
+				st,bank-name = "GPIOZ";
+				st,bank-ioport = <11>;
+				status = "disabled";
+			};
+		};
+	};
+};

--- a/core/arch/arm/dts/stm32mp253.dtsi
+++ b/core/arch/arm/dts/stm32mp253.dtsi
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+#include "stm32mp251.dtsi"
+
+/ {
+	cpus {
+		cpu1: cpu@1 {
+			compatible = "arm,cortex-a35";
+			device_type = "cpu";
+			reg = <1>;
+			enable-method = "psci";
+		};
+	};
+};

--- a/core/arch/arm/dts/stm32mp255.dtsi
+++ b/core/arch/arm/dts/stm32mp255.dtsi
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+#include "stm32mp253.dtsi"
+
+/ {
+};

--- a/core/arch/arm/dts/stm32mp257.dtsi
+++ b/core/arch/arm/dts/stm32mp257.dtsi
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+#include "stm32mp255.dtsi"
+
+/ {
+};

--- a/core/arch/arm/dts/stm32mp257f-ev1.dts
+++ b/core/arch/arm/dts/stm32mp257f-ev1.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+
+/dts-v1/;
+
+#include "stm32mp25-pinctrl.dtsi"
+#include "stm32mp257.dtsi"
+#include "stm32mp25xf.dtsi"
+#include "stm32mp25xxai-pinctrl.dtsi"
+
+/ {
+	model = "STMicroelectronics STM32MP257F-EV1 Evaluation Board";
+	compatible = "st,stm32mp257f-ev1", "st,stm32mp257";
+
+	aliases {
+		serial0 = &usart2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x1 0x00000000>;
+	};
+};

--- a/core/arch/arm/dts/stm32mp25xc.dtsi
+++ b/core/arch/arm/dts/stm32mp25xc.dtsi
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+
+/ {
+};

--- a/core/arch/arm/dts/stm32mp25xf.dtsi
+++ b/core/arch/arm/dts/stm32mp25xf.dtsi
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+
+/ {
+};

--- a/core/arch/arm/dts/stm32mp25xxai-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp25xxai-pinctrl.dtsi
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+
+&pinctrl {
+	gpioa: gpio@44240000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 0 16>;
+	};
+
+	gpiob: gpio@44250000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 16 16>;
+	};
+
+	gpioc: gpio@44260000 {
+		status = "okay";
+		ngpios = <14>;
+		gpio-ranges = <&pinctrl 0 32 14>;
+	};
+
+	gpiod: gpio@44270000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 48 16>;
+	};
+
+	gpioe: gpio@44280000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 64 16>;
+	};
+
+	gpiof: gpio@44290000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 80 16>;
+	};
+
+	gpiog: gpio@442a0000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 96 16>;
+	};
+
+	gpioh: gpio@442b0000 {
+		status = "okay";
+		ngpios = <12>;
+		gpio-ranges = <&pinctrl 2 114 12>;
+	};
+
+	gpioi: gpio@442c0000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 128 16>;
+	};
+
+	gpioj: gpio@442d0000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 144 16>;
+	};
+
+	gpiok: gpio@442e0000 {
+		status = "okay";
+		ngpios = <8>;
+		gpio-ranges = <&pinctrl 0 160 8>;
+	};
+};
+
+&pinctrl_z {
+	gpioz: gpio@46200000 {
+		status = "okay";
+		ngpios = <10>;
+		gpio-ranges = <&pinctrl_z 0 400 10>;
+	};
+};

--- a/core/arch/arm/dts/stm32mp25xxak-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp25xxak-pinctrl.dtsi
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+
+&pinctrl {
+	gpioa: gpio@44240000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 0 16>;
+	};
+
+	gpiob: gpio@44250000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 16 16>;
+	};
+
+	gpioc: gpio@44260000 {
+		status = "okay";
+		ngpios = <14>;
+		gpio-ranges = <&pinctrl 0 32 14>;
+	};
+
+	gpiod: gpio@44270000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 48 16>;
+	};
+
+	gpioe: gpio@44280000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 64 16>;
+	};
+
+	gpiof: gpio@44290000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 80 16>;
+	};
+
+	gpiog: gpio@442a0000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 96 16>;
+	};
+
+	gpioh: gpio@442b0000 {
+		status = "okay";
+		ngpios = <12>;
+		gpio-ranges = <&pinctrl 2 114 12>;
+	};
+
+	gpioi: gpio@442c0000 {
+		status = "okay";
+		ngpios = <12>;
+		gpio-ranges = <&pinctrl 0 128 12>;
+	};
+};
+
+&pinctrl_z {
+	gpioz: gpio@46200000 {
+		status = "okay";
+		ngpios = <10>;
+		gpio-ranges = <&pinctrl_z 0 400 10>;
+	};
+};

--- a/core/arch/arm/dts/stm32mp25xxal-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp25xxal-pinctrl.dtsi
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023 - All Rights Reserved
+ * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
+ */
+
+&pinctrl {
+	gpioa: gpio@44240000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 0 16>;
+	};
+
+	gpiob: gpio@44250000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 16 16>;
+	};
+
+	gpioc: gpio@44260000 {
+		status = "okay";
+		ngpios = <14>;
+		gpio-ranges = <&pinctrl 0 32 14>;
+	};
+
+	gpiod: gpio@44270000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 48 16>;
+	};
+
+	gpioe: gpio@44280000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 64 16>;
+	};
+
+	gpiof: gpio@44290000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 80 16>;
+	};
+
+	gpiog: gpio@442a0000 {
+		status = "okay";
+		ngpios = <16>;
+		gpio-ranges = <&pinctrl 0 96 16>;
+	};
+
+	gpioh: gpio@442b0000 {
+		status = "okay";
+		ngpios = <12>;
+		gpio-ranges = <&pinctrl 2 114 12>;
+	};
+
+	gpioi: gpio@442c0000 {
+		status = "okay";
+		ngpios = <12>;
+		gpio-ranges = <&pinctrl 0 128 12>;
+	};
+};
+
+&pinctrl_z {
+	gpioz: gpio@46200000 {
+		status = "okay";
+		ngpios = <10>;
+		gpio-ranges = <&pinctrl_z 0 400 10>;
+	};
+};

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -500,16 +500,6 @@ static bool __maybe_unused bank_is_valid(unsigned int bank)
 	panic();
 }
 
-unsigned int stm32_get_gpio_bank_offset(unsigned int bank)
-{
-	assert(bank_is_valid(bank));
-
-	if (bank == GPIO_BANK_Z)
-		return 0;
-
-	return bank * GPIO_BANK_OFFSET;
-}
-
 #ifdef CFG_STM32_IWDG
 TEE_Result stm32_get_iwdg_otp_config(paddr_t pbase,
 				     struct stm32_iwdg_otp_data *otp_data)

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -31,21 +31,6 @@ vaddr_t stm32_rcc_base(void);
 /* Platform util for the GIC */
 vaddr_t get_gicd_base(void);
 
-/*
- * Platform util functions for the GPIO driver
- * @bank: Target GPIO bank ID as per DT bindings
- *
- * Platform shall implement these functions to provide to stm32_gpio
- * driver the resource reference for a target GPIO bank. That are
- * memory mapped interface base address, interface offset (see below)
- * and clock identifier.
- *
- * stm32_get_gpio_bank_offset() returns a bank offset that is used to
- * check DT configuration matches platform implementation of the banks
- * description.
- */
-unsigned int stm32_get_gpio_bank_offset(unsigned int bank);
-
 /* Platform util for PMIC support */
 bool stm32mp_with_pmic(void);
 

--- a/core/arch/arm/plat-stm32mp2/conf.mk
+++ b/core/arch/arm/plat-stm32mp2/conf.mk
@@ -1,0 +1,59 @@
+flavor_dts_file-257F_EV1 = stm32mp257f-ev1.dts
+
+flavorlist-MP25 = $(flavor_dts_file-257F_EV1)
+
+ifneq ($(PLATFORM_FLAVOR),)
+ifeq ($(flavor_dts_file-$(PLATFORM_FLAVOR)),)
+$(error Invalid platform flavor $(PLATFORM_FLAVOR))
+endif
+CFG_EMBED_DTB_SOURCE_FILE ?= $(flavor_dts_file-$(PLATFORM_FLAVOR))
+endif
+CFG_EMBED_DTB_SOURCE_FILE ?= stm32mp257f-ev1.dts
+
+ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-MP25)),)
+$(call force,CFG_STM32MP25,y)
+endif
+
+ifneq ($(CFG_STM32MP25),y)
+$(error STM32 Platform must be defined)
+endif
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+supported-ta-targets ?= ta_arm64
+
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_DRIVERS_CLK,y)
+$(call force,CFG_DRIVERS_CLK_DT,y)
+$(call force,CFG_DRIVERS_GPIO,y)
+$(call force,CFG_DRIVERS_PINCTRL,y)
+$(call force,CFG_DT,y)
+$(call force,CFG_GIC,y)
+$(call force,CFG_INIT_CNTVOFF,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_WITH_LPAE,y)
+
+CFG_TZDRAM_START ?= 0x82000000
+CFG_TZDRAM_SIZE  ?= 0x02000000
+
+CFG_CORE_HEAP_SIZE ?= 262144
+CFG_CORE_RESERVED_SHM ?= n
+CFG_DTB_MAX_SIZE ?= 262144
+CFG_MMAP_REGIONS ?= 30
+CFG_NUM_THREADS ?= 5
+CFG_TEE_CORE_NB_CORE ?= 2
+
+CFG_STM32_GPIO ?= y
+CFG_STM32_UART ?= y
+
+# Default enable some test facitilites
+CFG_WITH_STATS ?= y
+
+# Default disable ASLR
+CFG_CORE_ASLR ?= n
+
+# UART instance used for early console (0 disables early console)
+CFG_STM32_EARLY_CONSOLE_UART ?= 2
+
+# Default disable external DT support
+CFG_EXTERNAL_DT ?= n

--- a/core/arch/arm/plat-stm32mp2/main.c
+++ b/core/arch/arm/plat-stm32mp2/main.c
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023, STMicroelectronics
+ */
+
+#include <config.h>
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/stm32_uart.h>
+#include <initcall.h>
+#include <kernel/boot.h>
+#include <kernel/dt.h>
+#include <kernel/interrupt.h>
+#include <kernel/misc.h>
+#include <kernel/spinlock.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stm32_util.h>
+#include <trace.h>
+
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, APB1_BASE, APB1_SIZE);
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, APB1_BASE, APB1_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, APB2_BASE, APB2_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, APB3_BASE, APB3_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, APB4_BASE, APB4_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, AHB2_BASE, AHB2_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, AHB3_BASE, AHB3_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, AHB4_BASE, AHB4_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, AHB5_BASE, AHB5_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SAPB_BASE, SAPB_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SAHB_BASE, SAHB_SIZE);
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
+
+#define _ID2STR(id)		(#id)
+#define ID2STR(id)		_ID2STR(id)
+
+static TEE_Result platform_banner(void)
+{
+	IMSG("Platform stm32mp2: flavor %s - DT %s", ID2STR(PLATFORM_FLAVOR),
+	     ID2STR(CFG_EMBED_DTB_SOURCE_FILE));
+
+	return TEE_SUCCESS;
+}
+
+service_init(platform_banner);
+
+/*
+ * Console
+ *
+ * CFG_STM32_EARLY_CONSOLE_UART specifies the ID of the UART used for
+ * trace console. Value 0 disables the early console.
+ *
+ * We cannot use the generic serial_console support since probing
+ * the console requires the platform clock driver to be already
+ * up and ready which is done only once service_init are completed.
+ */
+static struct stm32_uart_pdata console_data;
+
+void console_init(void)
+{
+#if CFG_STM32_UART
+	/* Early console initialization before MMU setup */
+	struct uart {
+		paddr_t pa;
+		bool secure;
+	} uarts[] = {
+		[0] = { .pa = 0 },
+		[1] = { .pa = USART1_BASE, .secure = true, },
+		[2] = { .pa = USART2_BASE, .secure = false, },
+		[3] = { .pa = USART3_BASE, .secure = false, },
+		[4] = { .pa = UART4_BASE, .secure = false, },
+		[5] = { .pa = UART5_BASE, .secure = false, },
+		[6] = { .pa = USART6_BASE, .secure = false, },
+		[7] = { .pa = UART7_BASE, .secure = false, },
+		[8] = { .pa = UART8_BASE, .secure = false, },
+		[9] = { .pa = UART9_BASE, .secure = false, },
+	};
+
+	static_assert(ARRAY_SIZE(uarts) > CFG_STM32_EARLY_CONSOLE_UART);
+
+	if (!uarts[CFG_STM32_EARLY_CONSOLE_UART].pa)
+		return;
+
+	/* No clock yet bound to the UART console */
+	console_data.clock = NULL;
+	console_data.secure = uarts[CFG_STM32_EARLY_CONSOLE_UART].secure;
+	stm32_uart_init(&console_data, uarts[CFG_STM32_EARLY_CONSOLE_UART].pa);
+	register_serial_console(&console_data.chip);
+
+	IMSG("Early console on UART#%u", CFG_STM32_EARLY_CONSOLE_UART);
+#endif
+}
+
+#ifdef CFG_STM32_UART
+static TEE_Result init_console_from_dt(void)
+{
+	struct stm32_uart_pdata *pd = NULL;
+	void *fdt = NULL;
+	int node = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	fdt = get_embedded_dt();
+	res = get_console_node_from_dt(fdt, &node, NULL, NULL);
+	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+		fdt = get_external_dt();
+		res = get_console_node_from_dt(fdt, &node, NULL, NULL);
+		if (res == TEE_ERROR_ITEM_NOT_FOUND)
+			return TEE_SUCCESS;
+		if (res != TEE_SUCCESS)
+			return res;
+	}
+
+	pd = stm32_uart_init_from_dt_node(fdt, node);
+	if (!pd) {
+		IMSG("DTB disables console");
+		register_serial_console(NULL);
+		return TEE_SUCCESS;
+	}
+
+	/* Replace early console with the new one */
+	console_flush();
+	console_data = *pd;
+	register_serial_console(&console_data.chip);
+	IMSG("DTB enables console (%ssecure)", pd->secure ? "" : "non-");
+	free(pd);
+
+	return TEE_SUCCESS;
+}
+
+/* Probe console from DT once clock inits (service init level) are completed */
+service_init_late(init_console_from_dt);
+#endif /*STM32_UART*/
+
+void boot_primary_init_intc(void)
+{
+	gic_init(GIC_BASE + GICC_OFFSET, GIC_BASE + GICD_OFFSET);
+}
+
+void boot_secondary_init_intc(void)
+{
+	gic_cpu_init();
+}

--- a/core/arch/arm/plat-stm32mp2/platform_config.h
+++ b/core/arch/arm/plat-stm32mp2/platform_config.h
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023, STMicroelectronics
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT			32
+
+/* SoC interface registers base address ranges */
+#define APB1_BASE			0x40000000
+#define APB1_SIZE			0x00200000
+#define APB2_BASE			0x40200000
+#define APB2_SIZE			0x00040000
+#define AHB2_BASE			0x40400000
+#define AHB2_SIZE			0x01c00000
+#define AHB3_BASE			0x42000000
+#define AHB3_SIZE			0x02000000
+#define APB3_BASE			0x44000000
+#define APB3_SIZE			0x001f0000
+#define AHB4_BASE			0x44200000
+#define AHB4_SIZE			0x01e00000
+#define SAPB_BASE			0x46000000
+#define SAPB_SIZE			0x00200000
+#define SAHB_BASE			0x46200000
+#define SAHB_SIZE			0x01e00000
+#define APB4_BASE			0x48000000
+#define APB4_SIZE			0x00200000
+#define AHB5_BASE			0x48200000
+#define AHB5_SIZE			0x01e00000
+
+/* SoC interface registers base address */
+#define UART2_BASE			0x400e0000
+#define UART3_BASE			0x400f0000
+#define UART4_BASE			0x40100000
+#define UART5_BASE			0x40110000
+#define I2C4_BASE			0x40150000
+#define I2C6_BASE			0x40170000
+#define UART6_BASE			0x40220000
+#define UART9_BASE			0x402c0000
+#define UART1_BASE			0x40330000
+#define SPI6_BASE			0x40350000
+#define UART7_BASE			0x40370000
+#define UART8_BASE			0x40380000
+#define OSPI1_BASE			0x40430000
+#define OSPI2_BASE			0x40440000
+#define HASH1_BASE			0x42010000
+#define RNG1_BASE			0x42020000
+#define CRYP1_BASE			0x42030000
+#define SAES_BASE			0x42050000
+#define PKA_BASE			0x42060000
+#define RIFSC_BASE			0x42080000
+#define RISAF5_BASE			0x420e0000
+#define RISAB6_BASE			0x42140000
+#define BSEC3_BASE			0x44000000
+#define IWDG2_BASE			0x44002000
+#define IWDG1_BASE			0x44010000
+#define RCC_BASE			0x44200000
+#define PWR_BASE			0x44210000
+#define SYSCFG_BASE			0x44230000
+#define GPIOA_BASE			0x44240000
+#define GPIOB_BASE			0x44250000
+#define GPIOC_BASE			0x44260000
+#define GPIOD_BASE			0x44270000
+#define GPIOE_BASE			0x44280000
+#define GPIOF_BASE			0x44290000
+#define GPIOG_BASE			0x442a0000
+#define GPIOH_BASE			0x442b0000
+#define GPIOI_BASE			0x442c0000
+#define GPIOJ_BASE			0x442d0000
+#define GPIOK_BASE			0x442e0000
+#define RTC_BASE			0x46000000
+#define TAMP_BASE			0x46010000
+#define GPIOZ_BASE			0x46200000
+#define STGEN_BASE			0x48080000
+#define FMC_BASE			0x48200000
+#define PCIE_BASE			0x48400000
+#define A35SSC_BASE			0x48800000
+#define GIC_BASE			0x4ac00000
+#define DDR_BASE			UL(0x80000000)
+
+#define SYSRAM_BASE			0x0e000000
+
+#define SRAM1_BASE			0x0e040000
+
+/* GIC resources */
+#define GIC_SIZE			0x80000
+#define GICC_OFFSET			0x20000
+#define GICD_OFFSET			0x10000
+
+/* Console configuration */
+#define GIC_SPI_UART4			126
+
+#define TARGET_CPU0_GIC_MASK		BIT(0)
+#define TARGET_CPU1_GIC_MASK		BIT(1)
+#define TARGET_CPUS_GIC_MASK		GENMASK_32(CFG_TEE_CORE_NB_CORE - 1, 0)
+
+/* USART/UART resources */
+#define USART1_BASE			UART1_BASE
+#define USART2_BASE			UART2_BASE
+#define USART3_BASE			UART3_BASE
+#define USART6_BASE			UART6_BASE
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-stm32mp2/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp2/stm32_util.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, STMicroelectronics
+ */
+
+#ifndef __STM32_UTIL_H__
+#define __STM32_UTIL_H__
+
+#include <kernel/spinlock.h>
+#include <stdint.h>
+#include <types_ext.h>
+
+static inline void stm32mp_register_secure_periph_iomem(vaddr_t base __unused)
+{
+}
+
+static inline void stm32mp_register_non_secure_periph_iomem(vaddr_t base
+							    __unused) { }
+
+static inline void stm32mp_register_gpioz_pin_count(size_t count __unused) { }
+
+#define may_spin_lock(lock)		  cpu_spin_lock_xsave(lock)
+#define may_spin_unlock(lock, exceptions) cpu_spin_unlock_xrestore(lock, \
+								   exceptions)
+#endif /*__STM32_UTIL_H__*/

--- a/core/arch/arm/plat-stm32mp2/sub.mk
+++ b/core/arch/arm/plat-stm32mp2/sub.mk
@@ -1,0 +1,3 @@
+global-incdirs-y += .
+
+srcs-y += main.c

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -736,33 +736,6 @@ static TEE_Result dt_stm32_gpio_pinctrl(const void *fdt, int node,
 	return TEE_SUCCESS;
 }
 
-
-int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank)
-{
-	int node = 0;
-	const fdt32_t *cuint = NULL;
-
-	fdt_for_each_subnode(node, fdt, pinctrl_node) {
-		if (!fdt_getprop(fdt, node, "gpio-controller", NULL))
-			continue;
-
-		cuint = fdt_getprop(fdt, node, "reg", NULL);
-		if (!cuint)
-			continue;
-
-		if (fdt32_to_cpu(*cuint) != stm32_get_gpio_bank_offset(bank))
-			continue;
-
-		cuint = fdt_getprop(fdt, node, "ngpios", NULL);
-		if (!cuint)
-			panic();
-
-		return (int)fdt32_to_cpu(*cuint);
-	}
-
-	return -1;
-}
-
 void stm32_gpio_set_secure_cfg(unsigned int bank_id, unsigned int pin,
 			       bool secure)
 {

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -8,6 +8,7 @@
 #include <drivers/clk.h>
 #include <drivers/clk_dt.h>
 #include <drivers/serial.h>
+#include <drivers/stm32_gpio.h>
 #include <drivers/stm32_uart.h>
 #include <io.h>
 #include <keep.h>
@@ -110,22 +111,31 @@ void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base)
 
 static void register_secure_uart(struct stm32_uart_pdata *pd)
 {
-	size_t __maybe_unused n = 0;
-
+#ifndef CFG_STM32MP25
 	stm32mp_register_secure_periph_iomem(pd->base.pa);
 	stm32mp_register_secure_pinctrl(pd->pinctrl);
 	if (pd->pinctrl_sleep)
 		stm32mp_register_secure_pinctrl(pd->pinctrl_sleep);
+#else
+	stm32_pinctrl_set_secure_cfg(pd->pinctrl, true);
+	if (pd->pinctrl_sleep)
+		stm32_pinctrl_set_secure_cfg(pd->pinctrl, true);
+#endif
 }
 
 static void register_non_secure_uart(struct stm32_uart_pdata *pd)
 {
-	size_t __maybe_unused n = 0;
-
+#ifndef CFG_STM32MP25
 	stm32mp_register_non_secure_periph_iomem(pd->base.pa);
 	stm32mp_register_non_secure_pinctrl(pd->pinctrl);
 	if (pd->pinctrl_sleep)
 		stm32mp_register_non_secure_pinctrl(pd->pinctrl_sleep);
+#else
+	stm32_pinctrl_set_secure_cfg(pd->pinctrl, false);
+	if (pd->pinctrl_sleep)
+		stm32_pinctrl_set_secure_cfg(pd->pinctrl, false);
+#endif
+
 }
 
 struct stm32_uart_pdata *stm32_uart_init_from_dt_node(void *fdt, int node)

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -27,16 +27,6 @@ void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin,
 			       bool secure);
 
 /*
- * Get the number of GPIO pins supported by a target GPIO bank
- *
- * @fdt: device tree reference
- * @pinctrl_node: pinctrl node which GPIO bank node belongs to
- * @bank: target GPIO bank ID
- * Return number of GPIO pins (>= 0) or a negative value on error
- */
-int stm32_get_gpio_count(void *fdt, int pinctrl_node, unsigned int bank);
-
-/*
  * Configure pin muxing access permission: can be secure or not
  *
  * @pinctrl: Pin control state where STM32_GPIO pin are to configure


### PR DESCRIPTION
This P-R aims to bring minimal platform support for STM32MP25x 64 bits platforms in OP-TEE.
You'll find a resume of the features in the first commit on this series.

This P-R cleans some code in GPIO and UART driver as well that blocked the compilation of another platform using STM32 drivers.

A weak platform-specific plat_panic() is added to add platform-specific behavior in case of panic().

@etienne-lms As discussed in private, I put you as maintainer of the platform as well as myself.

@etienne-lms @tbourgoi, can you please review this P-R?