### PR TITLE
libutee: TEE_AllocateOperation(): maxKeySize of digests may take any value

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -132,7 +132,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 		break;
 	}
 
-	/* Check algorithm mode (and maxKeySize for digests) */
+	/* Check algorithm mode */
 	switch (algorithm) {
 	case TEE_ALG_AES_CTS:
 	case TEE_ALG_AES_XTS:
@@ -276,8 +276,6 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_SHAKE256:
 	case TEE_ALG_SM3:
 		if (mode != TEE_MODE_DIGEST)
-			return TEE_ERROR_NOT_SUPPORTED;
-		if (maxKeySize)
 			return TEE_ERROR_NOT_SUPPORTED;
 		/* v1.1: flags always set for digest operations */
 		handle_state |= TEE_HANDLE_FLAG_KEY_SET;


### PR DESCRIPTION
Commit https://github.com/OP-TEE/optee_os/commit/cf5c060cec76 introduced a check to enforce the `maxKeySize` parameter of digest operations to always be zero. This is a violation of the Global Platform specification.

Revert commit https://github.com/OP-TEE/optee_os/commit/cf5c060cec76 to allow `maxKeySize` to take any value for digest operations.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
