### PR TITLE
mk/aosp_optee.mk: Allow building OPTEE_BIN with early TAs in one shot

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -32,6 +32,11 @@ basis (R:).
 
 ----------
 
+AOSP build
+R:	Tadd Kao <tadd.kao@mediatek.com> [@taddk]
+S:	Maintained
+F:	mk/aosp_optee.mk
+
 ARM Foundation FVP
 R:	Jens Wiklander <jens.wiklander@linaro.org> [@jenswi-linaro]
 S:	Maintained


### PR DESCRIPTION
This change adds OPTEE_TA_DEV_KIT_MK target to replace OPTEE_BIN target in TA build process. It helps to build OPTEE_BIN with early TAs in one shot since the cyclic dependency between TAs and OPTEE_BIN is removed. It also allows to build TA with a preferred TA_TARGET that is not included in the CFG_USER_TA_TARGETS when building OPTEE_BIN. An AOSP common module for TAs in stripped elf format is added to be referred as early TA files when building OPTEE_BIN. For example, we can setup dependency and use the argument below to build OPTEE_BIN with an early TA.

EARLY_TA_PATHS=$(abspath $(PRODUCT_OUT))/unsigned/<ta_uuid>.ta.unsigned

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
