### PR TITLE
plat-stm32mp1: enable async notif on stm32mp13

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -106,6 +106,8 @@ $(call force,CFG_REGULATOR_FIXED,y)
 
 ifeq ($(CFG_STM32MP13),y)
 $(call force,CFG_BOOT_SECONDARY_REQUEST,n)
+$(call force,CFG_CORE_ASYNC_NOTIF,y)
+$(call force,CFG_CORE_ASYNC_NOTIF_GIC_INTID,31)
 $(call force,CFG_CORE_RESERVED_SHM,n)
 $(call force,CFG_DRIVERS_CLK_FIXED,y)
 $(call force,CFG_SECONDARY_INIT_CNTFRQ,n)


### PR DESCRIPTION
Enables async notif using GIC PPI 15 as non-secure interrupt notifier for STM32MP13 variants.

This change depends on https://github.com/linaro-swg/linux/pull/116 and https://github.com/linaro-swg/linux/pull/115. It should not be merged before these 2 are merged unless what STM32MP13 kernel from linaro-swg/linux will fail to boot. This change is fine when using mainline kernel that already merges the changes from these 2 commits. 