### PR TITLE
riscv: virt: Update the configurations

### DIFF
--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -13,8 +13,8 @@ $(call force,CFG_WITH_STACK_CANARIES,n)
 $(call force,CFG_CORE_SANITIZE_KADDRESS,n)
 
 # Hart-related flags
-$(call force,CFG_TEE_CORE_NB_CORE,1)
-$(call force,CFG_NUM_THREADS,1)
+CFG_TEE_CORE_NB_CORE ?= 1
+CFG_NUM_THREADS ?= 1
 $(call force,CFG_BOOT_SYNC_CPU,y)
 
 # RISC-V-specific flags

--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -4,6 +4,8 @@ $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_TEE_CORE_DEBUG,n)
 $(call force,CFG_CORE_DYN_SHM,n)
 
+CFG_DT ?= y
+
 # Crypto flags
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
 

--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -20,11 +20,14 @@ $(call force,CFG_BOOT_SYNC_CPU,y)
 # RISC-V-specific flags
 rv64-platform-isa ?= rv64imafdc_zicsr_zifencei
 
+$(call force,CFG_RISCV_M_MODE,n)
+$(call force,CFG_RISCV_S_MODE,y)
 $(call force,CFG_RISCV_PLIC,y)
 $(call force,CFG_SBI_CONSOLE,n)
 $(call force,CFG_16550_UART,y)
 $(call force,CFG_RISCV_TIME_SOURCE_RDTIME,y)
 CFG_RISCV_MTIME_RATE ?= 10000000
+CFG_RISCV_SBI ?= y
 
 # TA-related flags
 supported-ta-targets = ta_rv64


### PR DESCRIPTION
This commit updates the configurations for QEMU RISC-V virtual platform:
1. Enable CFG_RISCV_S_MODE and CFG_RISCV_SBI to run OP-TEE on S-mode and utilize SBI to communicate with M-mode firmware.
2. Do not force CFG_TEE_CORE_NB_CORE and CFG_NUM_THREADS to be 1, since we may run SMP system.
3. Disable CFG_BOOT_SYNC_CPU and CFG_BOOT_SECONDARY_REQUEST, since the boot sequence is controlled by M-mode firmware.
4. Enable CFG_WITH_STAT to build PTA for debug and statistics information.
5. Enable CFG_DT to parse the external DTB passed by M-mode firmware.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
