### PR TITLE
core: fix calls to tee_pobj_get() for object opening

### DIFF
--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -663,7 +663,7 @@ static TEE_Result sec_storage_obj_read(unsigned long storage_id, char *obj_id,
 	sess = ts_get_current_session();
 
 	res = tee_pobj_get(&sess->ctx->uuid, obj_id, obj_id_len, flags,
-			   false, fops, &po);
+			   TEE_POBJ_USAGE_OPEN, fops, &po);
 	if (res != TEE_SUCCESS)
 		return res;
 
@@ -714,7 +714,7 @@ static TEE_Result sec_storage_obj_write(unsigned long storage_id, char *obj_id,
 	sess = ts_get_current_session();
 
 	res = tee_pobj_get(&sess->ctx->uuid, obj_id, obj_id_len, flags,
-			   false, fops, &po);
+			   TEE_POBJ_USAGE_OPEN, fops, &po);
 	if (res != TEE_SUCCESS)
 		return res;
 

--- a/core/pta/attestation.c
+++ b/core/pta/attestation.c
@@ -228,8 +228,8 @@ static TEE_Result sec_storage_obj_read(TEE_UUID *uuid, uint32_t storage_id,
 	if (obj_id_len > TEE_OBJECT_ID_MAX_LEN)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = tee_pobj_get(uuid, (void *)obj_id, obj_id_len, flags, false, fops,
-			   &po);
+	res = tee_pobj_get(uuid, (void *)obj_id, obj_id_len, flags,
+			   TEE_POBJ_USAGE_OPEN, fops, &po);
 	if (res)
 		return res;
 
@@ -272,8 +272,8 @@ static TEE_Result sec_storage_obj_write(TEE_UUID *uuid, uint32_t storage_id,
 	if (obj_id_len > TEE_OBJECT_ID_MAX_LEN)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = tee_pobj_get(uuid, (void *)obj_id, obj_id_len, flags, false,
-			   fops, &po);
+	res = tee_pobj_get(uuid, (void *)obj_id, obj_id_len, flags,
+			   TEE_POBJ_USAGE_OPEN, fops, &po);
 	if (res)
 		return res;
 


### PR DESCRIPTION
Fixes calls to tee_pobj_get() that use boolean false are argument where a enum tee_pobj_usage argument is expected.

Function tee_pobj_get() used to take a boolean @temporary argument between old 2.4.0 and 3.11.0 release tags. Since commit [1] merged in release tag 3.11.0, function prototype changed but the commit missed few calls that since still use value false (0), treated as enumerated value TEE_POBJ_USAGE_OPEN. This change replaces these occurrences with use of TEE_POBJ_USAGE_OPEN argument.

Link: 6885abf2f7ef ("core: tee_pobj_get() takes an enum tee_pobj_usage") [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
