### PR TITLE
core: riscv: Modify S-mode boot flow to compatible with M-mode firmware

### DIFF
--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -148,7 +148,12 @@ FUNC _start , :
 #else
 	mv	s1, a1		/* Save device tree address into s1 */
 #endif
-	bnez	a0, reset_secondary
+
+	/* Only first hart who wins lottery runs the primary boot sequence. */
+	la	a3, hart_lottery
+	li	a2, 1
+	amoadd.w a3, a2, (a3)
+	bnez	a3, reset_secondary
 	jal	reset_primary
 	j	.
 END_FUNC _start
@@ -245,6 +250,13 @@ LOCAL_FUNC unhandled_cpu , :
 	wfi
 	j	unhandled_cpu
 END_FUNC unhandled_cpu
+
+	.section .identity_map.data
+	.balign	8
+LOCAL_DATA hart_lottery , :
+	/* The hart who first increments this variable will be primary hart. */
+	.word	0
+END_DATA hart_lottery
 
 #ifdef CFG_BOOT_SYNC_CPU
 LOCAL_DATA sem_cpu_sync_start , :

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -243,6 +243,11 @@ UNWIND(	.cantunwind)
 	cpu_is_ready
 
 	jal	boot_init_secondary
+#ifdef CFG_RISCV_WITH_M_MODE_SM
+	/* Return to untrusted domain */
+	li	a0, TEEABI_OPTEED_RETURN_ON_DONE
+	j	thread_return_to_udomain
+#endif
 	j	.
 END_FUNC reset_secondary
 

--- a/core/arch/riscv/kernel/thread_optee_abi_rv.S
+++ b/core/arch/riscv/kernel/thread_optee_abi_rv.S
@@ -29,7 +29,7 @@
  */
 FUNC thread_return_to_udomain , :
 	/* Caller should provide arguments in a0~a5 */
-#if defined(CFG_RISCV_SBI)
+#if defined(CFG_RISCV_WITH_M_MODE_SM)
 	li	a7, SBI_EXT_TEE		/* extension ID */
 	li	a6, 0			/* function ID (unused) */
 	ecall

--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -30,6 +30,7 @@ $(call force,CFG_16550_UART,y)
 $(call force,CFG_RISCV_TIME_SOURCE_RDTIME,y)
 CFG_RISCV_MTIME_RATE ?= 10000000
 CFG_RISCV_SBI ?= y
+CFG_RISCV_WITH_M_MODE_SM ?= y
 
 # TA-related flags
 supported-ta-targets = ta_rv64

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -63,6 +63,13 @@ ifeq ($(CFG_RISCV_SBI_CONSOLE),y)
 $(call force,CFG_RISCV_SBI,y)
 endif
 
+# 'y' to let M-mode secure monitor handle the communication between OP-TEE OS
+# and untrusted domain.
+CFG_RISCV_WITH_M_MODE_SM ?= n
+ifeq ($(CFG_RISCV_WITH_M_MODE_SM),y)
+$(call force,CFG_RISCV_SBI,y)
+endif
+
 # Disable unsupported and other arch-specific flags
 $(call force,CFG_CORE_FFA,n)
 $(call force,CFG_SECURE_PARTITION,n)


### PR DESCRIPTION
In system of S-mode OP-TEE, M-mode firmware transfers control flow to OP-TEE during boot. M-mode runs one hart, which called boot hart, to executes system initialization and jumps into OP-TEE.

However, the ID of boot hart might not be always zero. That is, M-mode firmware may choose a hart, whose ID is non-zero, to jump into OP-TEE "_start" symbol to do OP-TEE initialization. Therefore, it is not feasible to let all harts enter "_start" symbol, and judge whether current hart is primary boot hart, by checking ID is zero or not. Fix it by letting non-boot hart enter "reset_secondary", in S-mode OP-TEE. So that all the harts can do their right things regardless of their hart ID.

Only OP-TEE runs in M-mode will judge primary hart by checking whether the hart ID is zero.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
