### PR TITLE
plat-stm32mp1: IO domains updates

### DIFF
--- a/core/arch/arm/dts/stm32mp131.dtsi
+++ b/core/arch/arm/dts/stm32mp131.dtsi
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
 /*
- * Copyright (C) STMicroelectronics 2021-2022 - All Rights Reserved
+ * Copyright (C) STMicroelectronics 2021-2023 - All Rights Reserved
  * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
  */
 
@@ -81,6 +81,18 @@
 			clock-frequency = <19000000>;
 		};
 
+	};
+
+	sdmmc1_io: sdmmc1_io {
+		compatible = "st,stm32mp13-iod";
+		regulator-name = "sdmmc1_io";
+		regulator-always-on;
+	};
+
+	sdmmc2_io: sdmmc2_io {
+		compatible = "st,stm32mp13-iod";
+		regulator-name = "sdmmc2_io";
+		regulator-always-on;
 	};
 
 	soc {

--- a/core/arch/arm/dts/stm32mp135f-dk.dts
+++ b/core/arch/arm/dts/stm32mp135f-dk.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
 /*
- * Copyright (C) STMicroelectronics 2021-2022 - All Rights Reserved
+ * Copyright (C) STMicroelectronics 2021-2023 - All Rights Reserved
  * Author: Alexandre Torgue <alexandre.torgue@foss.st.com> for STMicroelectronics.
  */
 
@@ -444,6 +444,14 @@
 
 &saes {
 	status = "okay";
+};
+
+&sdmmc1_io {
+	vddsd1-supply = <&vdd>;
+};
+
+&sdmmc2_io {
+	vddsd2-supply = <&vdd>;
 };
 
 &uart4 {

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -116,6 +116,7 @@ $(call force,CFG_STM32_VREFBUF,y)
 $(call force,CFG_STM32MP_CLK_CORE,y)
 $(call force,CFG_STM32MP1_SHARED_RESOURCES,n)
 $(call force,CFG_STM32MP13_CLK,y)
+$(call force,CFG_STM32MP13_REGULATOR_IOD,y)
 $(call force,CFG_TEE_CORE_NB_CORE,1)
 $(call force,CFG_WITH_NSEC_GPIOS,n)
 CFG_EXTERNAL_DT ?= n

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.c
@@ -271,14 +271,10 @@ static TEE_Result stm32mp1_pwr_regu_probe(const void *fdt, int node,
 			panic();
 		}
 
-		if (IS_ENABLED(CFG_DRIVERS_REGULATOR)) {
-			res = regulator_dt_register(fdt, subnode, node,
-						    dt_desc + n);
-			if (res) {
-				EMSG("Can't register %s: %#"PRIx32, node_name,
-				     res);
-				panic();
-			}
+		res = regulator_dt_register(fdt, subnode, node, dt_desc + n);
+		if (res) {
+			EMSG("Can't register %s: %#"PRIx32, node_name, res);
+			panic();
 		}
 	}
 

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pwr.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2018-2019, STMicroelectronics
+ * Copyright (c) 2018-2023, STMicroelectronics
  */
 
 #ifndef __STM32MP1_PWR_H
@@ -16,6 +16,14 @@
 #define PWR_MPUCR_OFF		0x10
 #define PWR_WKUPCR_OFF		0x20
 #define PWR_MPUWKUPENR_OFF	0x28
+
+/* CR3 register bitfield for STM32MP13 variants */
+#define PWR_CR3_VDDSD1EN	BIT(13)
+#define PWR_CR3_VDDSD1RDY	BIT(14)
+#define PWR_CR3_VDDSD2EN	BIT(15)
+#define PWR_CR3_VDDSD2RDY	BIT(16)
+#define PWR_CR3_VDDSD1VALID	BIT(22)
+#define PWR_CR3_VDDSD2VALID	BIT(23)
 
 #define PWR_OFFSET_MASK		0x3fUL
 

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
@@ -18,6 +18,7 @@
  */
 #define SYSCFG_CMPCR				U(0x20)
 #define SYSCFG_CMPENSETR			U(0x24)
+#define SYSCFG_IOSIZE				U(0x400)
 
 /*
  * SYSCFG_CMPCR Register
@@ -38,9 +39,9 @@
 
 static vaddr_t get_syscfg_base(void)
 {
-	struct io_pa_va base = { .pa = SYSCFG_BASE };
+	static struct io_pa_va base = { .pa = SYSCFG_BASE };
 
-	return io_pa_or_va(&base, 1);
+	return io_pa_or_va(&base, SYSCFG_IOSIZE);
 }
 
 void stm32mp_syscfg_enable_io_compensation(void)

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2019-2022, STMicroelectronics
+ * Copyright (c) 2019-2023, STMicroelectronics
  */
 
 #include <drivers/clk.h>
@@ -16,8 +16,8 @@
 /*
  * SYSCFG register offsets (base relative)
  */
-#define SYSCFG_CMPCR				0x20U
-#define SYSCFG_CMPENSETR			0x24U
+#define SYSCFG_CMPCR				U(0x20)
+#define SYSCFG_CMPENSETR			U(0x24)
 
 /*
  * SYSCFG_CMPCR Register
@@ -25,11 +25,11 @@
 #define SYSCFG_CMPCR_SW_CTRL			BIT(1)
 #define SYSCFG_CMPCR_READY			BIT(8)
 #define SYSCFG_CMPCR_RANSRC			GENMASK_32(19, 16)
-#define SYSCFG_CMPCR_RANSRC_SHIFT		16
+#define SYSCFG_CMPCR_RANSRC_SHIFT		U(16)
 #define SYSCFG_CMPCR_RAPSRC			GENMASK_32(23, 20)
-#define SYSCFG_CMPCR_ANSRC_SHIFT		24
+#define SYSCFG_CMPCR_ANSRC_SHIFT		U(24)
 
-#define SYSCFG_CMPCR_READY_TIMEOUT_US		1000U
+#define SYSCFG_CMPCR_READY_TIMEOUT_US		U(1000)
 
 /*
  * SYSCFG_CMPENSETR Register

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.c
@@ -18,11 +18,22 @@
 /*
  * SYSCFG register offsets (base relative)
  */
+#define SYSCFG_IOCTRLSETR			U(0x18)
 #define SYSCFG_CMPCR				U(0x20)
 #define SYSCFG_CMPENSETR			U(0x24)
 #define SYSCFG_CMPSD1CR				U(0x30)
 #define SYSCFG_CMPSD2CR				U(0x40)
+#define SYSCFG_HSLVEN0R				U(0x50)
 #define SYSCFG_IOSIZE				U(0x400)
+
+/*
+ * SYSCFG_IOCTRLSETR Register for STM32MP15 variants
+ */
+#define SYSCFG_IOCTRLSETR_HSLVEN_TRACE		BIT(0)
+#define SYSCFG_IOCTRLSETR_HSLVEN_QUADSPI	BIT(1)
+#define SYSCFG_IOCTRLSETR_HSLVEN_ETH		BIT(2)
+#define SYSCFG_IOCTRLSETR_HSLVEN_SDMMC		BIT(3)
+#define SYSCFG_IOCTRLSETR_HSLVEN_SPI		BIT(4)
 
 /*
  * SYSCFG_CMPCR Register
@@ -43,6 +54,12 @@
  * SYSCFG_CMPENSETR Register
  */
 #define SYSCFG_CMPENSETR_MPU_EN			BIT(0)
+
+/*
+ * HSLV definitions
+ */
+#define SYSCFG_HSLV_MASK			GENMASK_32(15, 0)
+#define SYSCFG_HSLV_KEY				U(0x1018)
 
 static vaddr_t get_syscfg_base(void)
 {
@@ -85,16 +102,16 @@ static __maybe_unused void disable_io_compensation(int cmpcr_offset)
 	      value_cmpcr2 & SYSCFG_CMPENSETR_MPU_EN))
 		return;
 
-	/* Copy apsrc / ansrc in ransrc /rapsrc */
+	/* Copy APSRC (resp. ANSRC) in RAPSRC (resp. RANSRC) */
 	apsrc_ansrc = value_cmpcr >> SYSCFG_CMPCR_ANSRC_SHIFT;
 	value_cmpcr &= ~(SYSCFG_CMPCR_RANSRC | SYSCFG_CMPCR_RAPSRC);
 	value_cmpcr |= SHIFT_U32(apsrc_ansrc, SYSCFG_CMPCR_RANSRC_SHIFT);
 
 	io_write32(cmpcr_base, value_cmpcr | SYSCFG_CMPCR_SW_CTRL);
 
-	DMSG("SYSCFG.cmpcr = %#"PRIx32, io_read32(cmpcr_base));
-
 	io_setbits32(cmpcr_base + CMPENCLRR_OFFSET, SYSCFG_CMPENSETR_MPU_EN);
+
+	DMSG("SYSCFG.cmpcr = %#"PRIx32, io_read32(cmpcr_base));
 }
 
 static TEE_Result stm32mp1_iocomp(void)
@@ -131,4 +148,52 @@ void stm32mp_set_vddsd_comp_state(enum stm32mp13_vddsd_comp_id id, bool enable)
 	else
 		disable_io_compensation(cmpcr_offset);
 }
+
+void stm32mp_set_hslv_state(enum stm32mp13_hslv_id id, bool enable)
+{
+	size_t hslvenxr_offset = 0;
+	uint32_t hlvs_value = 0;
+
+	assert(id < SYSCFG_HSLV_COUNT);
+
+	if (enable)
+		hlvs_value = SYSCFG_HSLV_KEY;
+
+	/* IDs are indices of SYSCFG_HSLVENxR registers */
+	hslvenxr_offset = SYSCFG_HSLVEN0R + id * sizeof(uint32_t);
+
+	io_write32(get_syscfg_base() + hslvenxr_offset, hlvs_value);
+
+	/* Value read shall be 1 on enable and 0 on disable */
+	hlvs_value = io_read32(get_syscfg_base() + hslvenxr_offset) &
+		     SYSCFG_HSLV_MASK;
+	if (enable != hlvs_value)
+		panic();
+}
+
+void stm32mp_enable_fixed_vdd_hslv(void)
+{
+	enum stm32mp13_hslv_id id = SYSCFG_HSLV_COUNT;
+
+	for (id = SYSCFG_HSLV_IDX_TPIU; id < SYSCFG_HSLV_COUNT; id++) {
+		/* SDMMCs domains may not be supplied by VDD */
+		if (id == SYSCFG_HSLV_IDX_SDMMC1 ||
+		    id == SYSCFG_HSLV_IDX_SDMMC2)
+			continue;
+
+		stm32mp_set_hslv_state(id, true);
+	}
+}
 #endif /* CFG_STM32MP13 */
+
+#ifdef CFG_STM32MP15
+void stm32mp_enable_fixed_vdd_hslv(void)
+{
+	io_write32(get_syscfg_base() + SYSCFG_IOCTRLSETR,
+		   SYSCFG_IOCTRLSETR_HSLVEN_TRACE |
+		   SYSCFG_IOCTRLSETR_HSLVEN_QUADSPI |
+		   SYSCFG_IOCTRLSETR_HSLVEN_ETH |
+		   SYSCFG_IOCTRLSETR_HSLVEN_SDMMC |
+		   SYSCFG_IOCTRLSETR_HSLVEN_SPI);
+}
+#endif

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.h
@@ -6,6 +6,23 @@
 #ifndef __DRIVERS_STM32MP1_SYSCFG_H
 #define __DRIVERS_STM32MP1_SYSCFG_H
 
+/* High Speed Low Voltage domains IDs for STM32MP13 variants */
+enum stm32mp13_hslv_id {
+	SYSCFG_HSLV_IDX_TPIU = 0,
+	SYSCFG_HSLV_IDX_QSPI,
+	SYSCFG_HSLV_IDX_ETH1,
+	SYSCFG_HSLV_IDX_ETH2,
+	SYSCFG_HSLV_IDX_SDMMC1,
+	SYSCFG_HSLV_IDX_SDMMC2,
+	SYSCFG_HSLV_IDX_SPI1,
+	SYSCFG_HSLV_IDX_SPI2,
+	SYSCFG_HSLV_IDX_SPI3,
+	SYSCFG_HSLV_IDX_SPI4,
+	SYSCFG_HSLV_IDX_SPI5,
+	SYSCFG_HSLV_IDX_LTDC,
+	SYSCFG_HSLV_COUNT
+};
+
 /* IO compensation domains IDs for STM32MP13 variants */
 enum stm32mp13_vddsd_comp_id {
 	SYSCFG_IO_COMP_IDX_SD1,
@@ -20,5 +37,15 @@ enum stm32mp13_vddsd_comp_id {
  * @enable: True to enable IO compensation, false to disable
  */
 void stm32mp_set_vddsd_comp_state(enum stm32mp13_vddsd_comp_id id, bool enable);
+
+/*
+ * Enable or disable High Speed Low Voltage mode of an IO domain
+ * @index: HSLV IO domain ID
+ * @enable: True to enable IO compensation, false to disable
+ */
+void stm32mp_set_hslv_state(enum stm32mp13_hslv_id id, bool enable);
 #endif /*CFG_STM32MP13*/
+
+/* Enable High Speed Low Voltage mode for domains fixed supplied VDD */
+void stm32mp_enable_fixed_vdd_hslv(void);
 #endif /*__DRIVERS_STM32MP1_SYSCFG_H*/

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_syscfg.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023, STMicroelectronics
+ */
+
+#ifndef __DRIVERS_STM32MP1_SYSCFG_H
+#define __DRIVERS_STM32MP1_SYSCFG_H
+
+/* IO compensation domains IDs for STM32MP13 variants */
+enum stm32mp13_vddsd_comp_id {
+	SYSCFG_IO_COMP_IDX_SD1,
+	SYSCFG_IO_COMP_IDX_SD2,
+	SYSCFG_IO_COMP_COUNT
+};
+
+#ifdef CFG_STM32MP13
+/*
+ * Enable or disable IO compensation for a VDDSD IO domains
+ * @id: VDDSD domain ID
+ * @enable: True to enable IO compensation, false to disable
+ */
+void stm32mp_set_vddsd_comp_state(enum stm32mp13_vddsd_comp_id id, bool enable);
+#endif /*CFG_STM32MP13*/
+#endif /*__DRIVERS_STM32MP1_SYSCFG_H*/

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -135,6 +135,8 @@
 #define HW2_OTP_IWDG_FZ_STOP_SHIFT	U(5)
 #define HW2_OTP_IWDG_FZ_STANDBY_SHIFT	U(7)
 
+#define HW2_OTP_PRODUCT_BELOW_2V5	BIT(13)
+
 /* GIC resources */
 #define GIC_SIZE			0x2000
 #define GICC_OFFSET			0x1000

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -18,13 +18,6 @@
 /* Backup registers and RAM utils */
 vaddr_t stm32mp_bkpreg(unsigned int idx);
 
-/*
- * SYSCFG IO compensation.
- * These functions assume non-secure world is suspended.
- */
-void stm32mp_syscfg_enable_io_compensation(void);
-void stm32mp_syscfg_disable_io_compensation(void);
-
 /* Platform util for the RCC drivers */
 vaddr_t stm32_rcc_base(void);
 

--- a/core/drivers/regulator/stm32mp13_regulator_iod.c
+++ b/core/drivers/regulator/stm32mp13_regulator_iod.c
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021-2023, STMicroelectronics
+ */
+
+#include <assert.h>
+#include <compiler.h>
+#include <drivers/regulator.h>
+#include <drivers/stm32mp1_pwr.h>
+#include <drivers/stm32mp1_syscfg.h>
+#include <drivers/stm32mp13_regulator_iod.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/dt.h>
+#include <kernel/panic.h>
+#include <kernel/pm.h>
+#include <libfdt.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stm32_util.h>
+#include <trace.h>
+
+#define TIMEOUT_US_10MS		U(10000)
+
+#define IO_VOLTAGE_THRESHOLD_UV	2700000
+
+/*
+ * struct iod_regul - IO domain regulator instance
+ *
+ * @enable_reg: PWR register offset for the IO domain
+ * @enable_mask: Domain enable register bit mask in PWR register
+ * @ready_mask: Domain ready bit mask in PWR register
+ * @valid_mask: Domain valid bit mask in PWR register
+ * @hslv_id: ID of the related HSLV domain
+ * @io_comp_id: ID of the related IO compensation domain
+ * @suspend_state: True if regulator is enabled before suspend, false otherwise
+ * @suspend_level_uv: Voltage level before suspend, in microvolts
+ */
+struct iod_regul {
+	uint32_t enable_reg;
+	uint32_t enable_mask;
+	uint32_t ready_mask;
+	uint32_t valid_mask;
+	enum stm32mp13_hslv_id hslv_id;
+	enum stm32mp13_vddsd_comp_id io_comp_id;
+	bool suspend_state;
+	int suspend_level_uv;
+};
+
+static struct iod_regul iod_regulator_priv[IOD_REGU_COUNT] = {
+	 [IOD_SDMMC1] = {
+		.enable_reg = PWR_CR3_OFF,
+		.enable_mask = PWR_CR3_VDDSD1EN,
+		.ready_mask = PWR_CR3_VDDSD1RDY,
+		.valid_mask = PWR_CR3_VDDSD1VALID,
+		.hslv_id = SYSCFG_HSLV_IDX_SDMMC1,
+		.io_comp_id = SYSCFG_IO_COMP_IDX_SD1,
+	 },
+	 [IOD_SDMMC2] = {
+		.enable_reg = PWR_CR3_OFF,
+		.enable_mask = PWR_CR3_VDDSD2EN,
+		.ready_mask = PWR_CR3_VDDSD2RDY,
+		.valid_mask = PWR_CR3_VDDSD2VALID,
+		.hslv_id = SYSCFG_HSLV_IDX_SDMMC2,
+		.io_comp_id = SYSCFG_IO_COMP_IDX_SD2,
+	 },
+};
+
+static struct regulator *iod_regulator[IOD_REGU_COUNT];
+
+struct regulator *stm32mp1_get_iod_regulator(enum iod_regulator_id index)
+{
+	assert(index >= IOD_SDMMC1 && index < IOD_REGU_COUNT);
+
+	return iod_regulator[index];
+}
+
+static TEE_Result iod_set_state(struct regulator *regu, bool enable)
+{
+	struct iod_regul *iod = regu->priv;
+	uintptr_t pwr_reg = stm32_pwr_base() + iod->enable_reg;
+
+	FMSG("%s: set state %u", regulator_name(regu), enable);
+
+	if (enable) {
+		uint32_t value = 0;
+
+		io_setbits32(pwr_reg, iod->enable_mask);
+
+		if (IO_READ32_POLL_TIMEOUT(pwr_reg, value,
+					   value & iod->ready_mask,
+					   0, TIMEOUT_US_10MS))
+			return TEE_ERROR_GENERIC;
+
+		io_setbits32(pwr_reg, iod->valid_mask);
+		io_clrbits32(pwr_reg, iod->enable_mask);
+
+		stm32mp_set_vddsd_comp_state(iod->io_comp_id, true);
+	} else {
+		stm32mp_set_vddsd_comp_state(iod->io_comp_id, false);
+
+		io_clrbits32(pwr_reg, iod->enable_mask | iod->valid_mask);
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result iod_get_state(struct regulator *regu, bool *enabled)
+{
+	struct iod_regul *iod = regu->priv;
+	uintptr_t pwr_reg = stm32_pwr_base() + iod->enable_reg;
+
+	*enabled = io_read32(pwr_reg) & (iod->enable_mask | iod->valid_mask);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result iod_get_voltage(struct regulator *regu, int *level_uv)
+{
+	*level_uv = regulator_get_voltage(regu->supply);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result iod_set_voltage(struct regulator *regu, int level_uv)
+{
+	struct iod_regul *iod = regu->priv;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	bool iod_enabled = false;
+
+	FMSG("%s: set voltage level to %duV", regulator_name(regu), level_uv);
+
+	res = iod_get_state(regu, &iod_enabled);
+	if (res)
+		return res;
+
+	/* Isolate IOs and disable IOs compensation when changing voltage */
+	if (iod_enabled) {
+		res = iod_set_state(regu, false);
+		if (res)
+			return res;
+	}
+
+	/*
+	 * Set IO to low speed.
+	 * Setting high voltage with IOs in high speed mode may damage the IOs.
+	 */
+	stm32mp_set_hslv_state(iod->hslv_id, false);
+
+	/* Forward set voltage request to the power supply */
+	res = regulator_set_voltage(regu->supply, level_uv);
+	if (res) {
+		EMSG("regulator %s set voltage failed: %#"PRIx32,
+		     regulator_name(regu), res);
+
+		/* Ensure IO domain consistency for current voltage level */
+		level_uv = regulator_get_voltage(regu->supply);
+	}
+
+	if (level_uv <= IO_VOLTAGE_THRESHOLD_UV)
+		stm32mp_set_hslv_state(iod->hslv_id, true);
+
+	if (iod_enabled) {
+		TEE_Result res2 = TEE_ERROR_GENERIC;
+
+		res2 = iod_set_state(regu, true);
+		if (res2)
+			return res2;
+	}
+
+	return res;
+}
+
+static TEE_Result iod_list_voltages(struct regulator *regu,
+				    struct regulator_voltages **voltages)
+{
+	/* Return supply voltage list */
+	return regulator_supported_voltages(regu->supply, voltages);
+}
+
+/*
+ * To protect the IOs, we disable High Speed Low Voltage mode before
+ * entering suspend state and restore the configuration when resuming.
+ */
+static TEE_Result iod_pm(enum pm_op op, unsigned int pm_hint __unused,
+			 const struct pm_callback_handle *hdl)
+{
+	struct regulator *regu = hdl->handle;
+	struct iod_regul *iod = regu->priv;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	assert(op == PM_OP_SUSPEND || op == PM_OP_RESUME);
+
+	if (op == PM_OP_SUSPEND) {
+		FMSG("%s: suspend", regulator_name(regu));
+
+		res = iod_get_state(regu, &iod->suspend_state);
+		if (res)
+			return res;
+
+		res = iod_get_voltage(regu, &iod->suspend_level_uv);
+		if (res)
+			return res;
+
+		stm32mp_set_hslv_state(iod->hslv_id, false);
+	} else {
+		FMSG("%s: resume", regulator_name(regu));
+
+		res = iod_set_voltage(regu, iod->suspend_level_uv);
+		if (res)
+			return res;
+
+		res = iod_set_state(regu, iod->suspend_state);
+		if (res)
+			return res;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result iod_supplied_init(struct regulator *regu,
+				    const void *fdt __unused, int node __unused)
+{
+	struct iod_regul *iod = regu->priv;
+	int index = iod - iod_regulator_priv;
+
+	assert(index >= 0 && index < IOD_REGU_COUNT);
+
+	if (regulator_get_voltage(regu) < IO_VOLTAGE_THRESHOLD_UV)
+		stm32mp_set_hslv_state(iod->hslv_id, true);
+
+	/* Save regulator reference */
+	iod_regulator[index] = regu;
+
+	register_pm_driver_cb(iod_pm, regu, "iod-regulator");
+
+	FMSG("IOD regulator %s intiialized", regulator_name(regu));
+
+	return TEE_SUCCESS;
+}
+
+static const struct regulator_ops iod_ops = {
+	.set_state = iod_set_state,
+	.get_state = iod_get_state,
+	.set_voltage = iod_set_voltage,
+	.get_voltage = iod_get_voltage,
+	.supported_voltages = iod_list_voltages,
+	.supplied_init = iod_supplied_init,
+};
+
+#define DEFINE_REG(_id, _name, _supply_name) { \
+	.name = (_name), \
+	.ops = &iod_ops, \
+	.priv = iod_regulator_priv + (_id), \
+	.supply_name = (_supply_name), \
+}
+
+static struct regu_dt_desc iod_regul_desc[IOD_REGU_COUNT] = {
+	[IOD_SDMMC1] = DEFINE_REG(IOD_SDMMC1, "sdmmc1_io", "vddsd1"),
+	[IOD_SDMMC2] = DEFINE_REG(IOD_SDMMC2, "sdmmc2_io", "vddsd2"),
+};
+
+static TEE_Result iod_regulator_probe(const void *fdt, int node,
+				      const void *compat_data __unused)
+{
+	const char *node_name = NULL;
+	size_t i = 0;
+
+	node_name = fdt_get_name(fdt, node, NULL);
+
+	FMSG("iod probe node '%s'", node_name);
+
+	/* Look up matching regulator name defined in SoC DTSI file */
+	for (i = 0; i < IOD_REGU_COUNT; i++)
+		if (!strcmp(iod_regul_desc[i].name, node_name))
+			break;
+
+	if (i == IOD_REGU_COUNT) {
+		EMSG("Unexpected IO domain node name '%s'", node_name);
+		return TEE_ERROR_GENERIC;
+	}
+
+	return regulator_dt_register(fdt, node, node, iod_regul_desc + i);
+}
+
+static const struct dt_device_match iod_regulator_match_table[] = {
+	{ .compatible = "st,stm32mp13-iod" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(stm32mp13_regulator_iod_dt_driver) = {
+	.name = "stm32mp13-iod-regulator",
+	.match_table = iod_regulator_match_table,
+	.probe = iod_regulator_probe,
+};

--- a/core/drivers/regulator/sub.mk
+++ b/core/drivers/regulator/sub.mk
@@ -3,3 +3,4 @@ srcs-$(CFG_DT) += regulator_dt.c
 srcs-$(CFG_REGULATOR_FIXED) += regulator_fixed.c
 srcs-$(CFG_REGULATOR_GPIO) += regulator_gpio.c
 srcs-$(CFG_STM32_VREFBUF) += stm32_vrefbuf.c
+srcs-$(CFG_STM32MP13_REGULATOR_IOD) += stm32mp13_regulator_iod.c

--- a/core/include/drivers/stm32mp13_regulator_iod.h
+++ b/core/include/drivers/stm32mp13_regulator_iod.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021-2023, STMicroelectronics
+ */
+
+#ifndef __DRIVERS_STM32MP13_REGULATOR_IOD_H
+#define __DRIVERS_STM32MP13_REGULATOR_IOD_H
+
+#include <drivers/regulator.h>
+
+enum iod_regulator_id {
+	IOD_SDMMC1,
+	IOD_SDMMC2,
+	IOD_REGU_COUNT
+};
+
+#ifdef CFG_STM32MP13_REGULATOR_IOD
+struct regulator *stm32mp1_get_iod_regulator(enum iod_regulator_id index);
+#else
+static inline struct regulator *
+stm32mp1_get_iod_regulator(enum iod_regulator_id id __unused) { return NULL; }
+#endif /* CFG_STM32MP13_REGULATOR_IOD */
+#endif /* __DRIVERS_STM32MP13_REGULATOR_IOD_H */


### PR DESCRIPTION
This series implements STM32MP1 variants IO domain feature.
- IO compensation for STM32MP13 variant
- High Speed Low Voltage for STM32MP13 and STM32MP15
- IO domain aware regulators for STM32MP13 variants

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
