### PR TITLE
TA dev kit: Export ftrace_format.py

### DIFF
--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -190,7 +190,8 @@ $(foreach f, $(ta-keys), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/keys)))
 
 # Copy the scripts
-ta-scripts = scripts/sign_encrypt.py scripts/symbolize.py scripts/sign_rproc_fw.py
+ta-scripts = scripts/sign_encrypt.py scripts/symbolize.py \
+       scripts/sign_rproc_fw.py scripts/ftrace_format.py
 $(foreach f, $(ta-scripts), \
 	$(eval $(call copy-file, $(f), $(out-dir)/export-$(sm)/scripts)))
 


### PR DESCRIPTION
Commit 5c2c0fb31efb ("ftrace: change implementation to use binary circular buffer") added script ftrace_format.py which is required to analyze ftrace logs. So export it as part of TA dev kit as well.
