### PR TITLE
tree wide: remove leftover references to libmap

### DIFF
--- a/lib/libutee/include/tee_arith_internal.h
+++ b/lib/libutee/include/tee_arith_internal.h
@@ -22,12 +22,6 @@
  */
 #define TEE_MATHAPI_EXPORT
 
-/*
- * The modes for String Conversion
- */
-#define TEE_STRING_MODE_HEX_UC MPA_STRING_MODE_HEX_UC
-#define TEE_STRING_MODE_HEX_LC MPA_STRING_MODE_HEX_UC
-
 /*------------------------------------------------------------
  *
  *  Define IN, OUT, INBUF and OUTBUF to keep format from the spec.

--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -726,10 +726,6 @@ out:
 	return res;
 }
 
-/*
- * Based on libmpa implementation __mpa_egcd(), modified to work with MPI
- * instead.
- */
 static void mpi_egcd(mbedtls_mpi *gcd, mbedtls_mpi *a, mbedtls_mpi *b,
 		     mbedtls_mpi *x_in, mbedtls_mpi *y_in)
 {


### PR DESCRIPTION
Removes references to libmpa removed since OP-TEE release tag 3.9.0, by commit 7fb525f1f8a6 ("Remove libmpa in favor of libmbedtls").

~~This change removes configuration switch CFG_TA_MBEDTLS_MPI and CFG_TA_MBEDTLS that are no more used by OP-TEE component.~~

(edited:  I removed to wrong stuf!!! Below is the expected commit message)

This change removes TEE_STRING_MODE_HEX_UC and TEE_STRING_MODE_HEX_LC
macros that relate to MPA_STRING_MODE_HEX_UC which is was removed
by the above mentioned commit.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
