### PR TITLE
core: print current guest ID in logs

### DIFF
--- a/core/kernel/trace_ext.c
+++ b/core/kernel/trace_ext.c
@@ -8,6 +8,7 @@
 #include <kernel/misc.h>
 #include <kernel/spinlock.h>
 #include <kernel/thread.h>
+#include <kernel/virtualization.h>
 #include <mm/core_mmu.h>
 
 const char trace_ext_prefix[] = "TC";
@@ -60,4 +61,9 @@ int trace_ext_get_core_id(void)
 		return get_core_pos();
 	else
 		return -1;
+}
+
+int trace_ext_get_guest_id(void)
+{
+	return virt_get_current_guest_id();
 }

--- a/lib/libutils/ext/include/trace.h
+++ b/lib/libutils/ext/include/trace.h
@@ -26,6 +26,7 @@ extern const char trace_ext_prefix[];
 void trace_ext_puts(const char *str);
 int trace_ext_get_thread_id(void);
 int trace_ext_get_core_id(void);
+int trace_ext_get_guest_id(void);
 void trace_set_level(int level);
 int trace_get_level(void);
 void plat_trace_ext_puts(const char *str);

--- a/scripts/symbolize.py
+++ b/scripts/symbolize.py
@@ -19,7 +19,7 @@ TEE_LOAD_ADDR_RE = re.compile(r'TEE load address @ (?P<load_addr>0x[0-9a-f]+)')
 # This gets the address from lines looking like this:
 # E/TC:0  0x001044a8
 STACK_ADDR_RE = re.compile(
-    r'[UEIDFM]/(TC|LD):(\?*|[0-9]*) [0-9]* +(?P<addr>0x[0-9a-f]+)')
+    r'[UEIDFM]/(TC|LD):([0-9]+ )?(\?*|[0-9]*) [0-9]* +(?P<addr>0x[0-9a-f]+)')
 ABORT_ADDR_RE = re.compile(r'-abort at address (?P<addr>0x[0-9a-f]+)')
 TA_PANIC_RE = re.compile(r'TA panicked with code (?P<code>0x[0-9a-f]+)')
 REGION_RE = re.compile(r'region +[0-9]+: va (?P<addr>0x[0-9a-f]+) '


### PR DESCRIPTION
If CFG_NS_VIRTUALIZATION is enabled include the current guest ID on each log line. A number is added before the core number identifying the currently set guest ID, for example:
D/TC:2 0 0 call_initcalls:40 level 1 teecore_init_pub_ram()

Where the "2" indicates that this is done with guest ID 2 active.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
