### PR TITLE
CFG_INSECURE deprecates CFG_WARN_INSECURE (+ stm32mp1 related change)

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1191,7 +1191,7 @@ void __weak boot_init_primary_late(unsigned long fdt __unused,
 	configure_console_from_dt();
 
 	IMSG("OP-TEE version: %s", core_v_str);
-	if (IS_ENABLED(CFG_WARN_INSECURE)) {
+	if (IS_ENABLED(CFG_INSECURE)) {
 		IMSG("WARNING: This OP-TEE configuration might be insecure!");
 		IMSG("WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html");
 	}

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -553,7 +553,7 @@ static TEE_Result init_debug(void)
 		return res;
 
 	if (state != BSEC_STATE_SEC_CLOSED && conf) {
-		if (IS_ENABLED(CFG_WARN_INSECURE))
+		if (IS_ENABLED(CFG_INSECURE))
 			IMSG("WARNING: All debug accesses are allowed");
 
 		res = stm32_bsec_write_debug_conf(conf | BSEC_DEBUG_ALL);

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -692,8 +692,12 @@ static void check_rcc_secure_configuration(void)
 		}
 	}
 
-	if (have_error)
-		panic();
+	if (have_error) {
+		if (IS_ENABLED(CFG_INSECURE))
+			EMSG("WARNING: CFG_INSECURE allows insecure RCC configuration");
+		else
+			panic();
+	}
 }
 
 static void set_gpio_secure_configuration(void)

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -138,7 +138,7 @@ void boot_init_primary_late(unsigned long fdt,
 	update_external_dt();
 
 	IMSG("OP-TEE version: %s", core_v_str);
-	if (IS_ENABLED(CFG_WARN_INSECURE)) {
+	if (IS_ENABLED(CFG_INSECURE)) {
 		IMSG("WARNING: This OP-TEE configuration might be insecure!");
 		IMSG("WARNING: Please check https://optee.readthedocs.io/en/latest/architecture/porting_guidelines.html");
 	}

--- a/core/arch/riscv/plat-spike/conf.mk
+++ b/core/arch/riscv/plat-spike/conf.mk
@@ -67,7 +67,7 @@ $(call force,CFG_SECSTOR_TA,n)
 $(call force,CFG_SHOW_CONF_ON_BOOT,n)
 $(call force,CFG_SYSCALL_WRAPPERS_MCOUNT,n)
 $(call force,CFG_BOOT_SYNC_CPU,y)
-$(call force,CFG_WARN_INSECURE,y)
+$(call force,CFG_INSECURE,y)
 $(call force,CFG_RISCV_TIME_SOURCE_RDTIME,y)
 CFG_RISCV_MTIME_RATE ?= 10000000
 CFG_TDDRAM_START ?= 0xbdb00000

--- a/core/tee/tee_ree_fs.c
+++ b/core/tee/tee_ree_fs.c
@@ -598,7 +598,7 @@ static TEE_Result open_dirh(struct tee_fs_dirfile_dirh **dirh)
 		static bool once;
 
 		if (res != TEE_ERROR_NOT_IMPLEMENTED ||
-		    !IS_ENABLED(CFG_WARN_INSECURE))
+		    !IS_ENABLED(CFG_INSECURE))
 			return res;
 
 		if (!once) {
@@ -633,7 +633,7 @@ static TEE_Result commit_dirh_writes(struct tee_fs_dirfile_dirh *dirh)
 	if (res)
 		return res;
 	res = nv_counter_incr_ree_fs_to(counter);
-	if (res == TEE_ERROR_NOT_IMPLEMENTED && IS_ENABLED(CFG_WARN_INSECURE)) {
+	if (res == TEE_ERROR_NOT_IMPLEMENTED && IS_ENABLED(CFG_INSECURE)) {
 		static bool once;
 
 		if (!once) {

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -909,15 +909,26 @@ CFG_REGULATOR_FIXED ?= n
 $(eval $(call cfg-enable-all-depends,CFG_REGULATOR_FIXED, \
 	 CFG_DRIVERS_REGULATOR CFG_DT))
 
-# The purpose of this flag is to show a print when booting up the device that
-# indicates whether the board runs a standard developer configuration or not.
-# A developer configuration doesn't necessarily has to be secure. The intention
+# When enabled, CFG_INSECURE permits insecure configuration of OP-TEE core
+# and shows a print (info level) when booting up the device that
+# indicates that the board runs a standard developer configuration.
+#
+# A developer configuration doesn't necessarily have to be secure. The intention
 # is that the one making products based on OP-TEE should override this flag in
 # plat-xxx/conf.mk for the platform they're basing their products on after
 # they've finalized implementing stubbed functionality (see OP-TEE
 # documentation/Porting guidelines) as well as vendor specific security
 # configuration.
-CFG_WARN_INSECURE ?= y
+#
+# CFG_WARN_INSECURE served the same purpose as CFG_INSECURE but is deprecated.
+ifneq (undefined,$(flavor CFG_WARN_INSECURE))
+$(info WARNING: CFG_WARN_INSECURE is deprecated, use CFG_INSECURE instead)
+CFG_INSECURE ?= $(CFG_WARN_INSECURE)
+ifneq ($(CFG_INSECURE),$(CFG_WARN_INSECURE))
+$(error Inconsistent CFG_INSECURE=$(CFG_INSECURE) and CFG_WARN_INSECURE=$(CFG_WARN_INSECURE))
+endif
+endif # CFG_WARN_INSECURE defined
+CFG_INSECURE ?= y
 
 # Enables warnings for declarations mixed with statements
 CFG_WARN_DECL_AFTER_STATEMENT ?= y


### PR DESCRIPTION
Changes STM32MP1 shared resources to allow insecure RCC protection with peripherals assigned to secure world when CFG_WARN_INSECURE is enabled. This means for example that some SoC resources can be assigned to OP-TEE without their clock and reset controllers being effectively protected from non-secure accesses. Such configuration can be useful for development and test purposes.

This change does not affect devices provisioned with secret that are in so-called SEC_CLOSED state (BSEC fuses). Indeed this device state currently requires RCC protection to be enabled as already implemented in function check_rcc_secure_configuration().

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
