### PR TITLE
core: ffa: fix mem reclaim error reporting

### DIFF
--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1302,7 +1302,7 @@ static void handle_mem_reclaim(struct thread_smc_args *args)
 	virt_unset_guest();
 
 out:
-	spmc_set_args(args, ret_fid, ret_val, 0, 0, 0, 0);
+	spmc_set_args(args, ret_fid, 0, ret_val, 0, 0, 0);
 }
 #endif
 


### PR DESCRIPTION
Until now handle_mem_reclaim() was incorrectly returning the error value in a1 instead of a2 as mandated by the specification. Successful returns are not affected by this since they use the FFA_SUCCESS_32 FID. So fix this by supplying the error value in the right register.

Fixes: 1b302ac09816 ("core: enable FF-A with SPM Core at S-EL1")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
