### PR TITLE
core: fixup of transfer list entry overriding

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1179,7 +1179,7 @@ static bool cpu_nmfi_enabled(void)
 void __weak boot_init_primary_late(unsigned long fdt __unused,
 				   unsigned long manifest __unused)
 {
-	init_external_dt(boot_arg_fdt);
+	init_external_dt(boot_arg_fdt, CFG_DTB_MAX_SIZE);
 	reinit_manifest_dt();
 #ifdef CFG_CORE_SEL1_SPMC
 	tpm_map_log_area(get_manifest_dt());

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -134,7 +134,7 @@ void boot_init_primary_early(void)
 void boot_init_primary_late(unsigned long fdt,
 			    unsigned long tos_fw_config __unused)
 {
-	init_external_dt(fdt);
+	init_external_dt(fdt, CFG_DTB_MAX_SIZE);
 	update_external_dt();
 
 	IMSG("OP-TEE version: %s", core_v_str);

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -267,13 +267,14 @@ struct dt_descriptor *get_external_dt_desc(void);
 /*
  * init_external_dt() - Initialize the external DTB located at given address.
  * @phys_dt:	Physical address where the external DTB located.
+ * @dt_sz:	Maximum size of the external DTB.
  *
  * Initialize the external DTB.
  *
  * 1. Add MMU mapping of the external DTB,
  * 2. Initialize device tree overlay
  */
-void init_external_dt(unsigned long phys_dt);
+void init_external_dt(unsigned long phys_dt, size_t dt_sz);
 
 /* Returns external DTB if present, otherwise NULL */
 void *get_external_dt(void);
@@ -420,7 +421,8 @@ static inline struct dt_descriptor *get_external_dt_desc(void)
 	return NULL;
 }
 
-static inline void init_external_dt(unsigned long phys_dt __unused)
+static inline void init_external_dt(unsigned long phys_dt __unused,
+				    size_t dt_sz __unused)
 {
 }
 


### PR DESCRIPTION
Expand the data size of DTB transfer list entry to the max allocable size to reserve sufficient space for new nodes.
This fixes a potential issue that the amended DTB transfer entry overrides other entries followed by, when inserting new nodes.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
