### PR TITLE
core: arm: fix inline comment on async notif interrupt

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -182,7 +182,8 @@ CFG_SM_NO_CYCLE_COUNTING ?= y
 # CFG_CORE_ASYNC_NOTIF_GIC_INTID is defined by the platform to some free
 # interrupt. Setting it to a non-zero number enables support for using an
 # Arm-GIC to notify normal world. This config variable should use a value
-# larger the 32 to make it of the type SPI.
+# larger or equal to 24 to make it of the type SPI or PPI (secure PPI
+# only).
 # Note that asynchronous notifactions must be enabled with
 # CFG_CORE_ASYNC_NOTIF=y for this variable to be used.
 CFG_CORE_ASYNC_NOTIF_GIC_INTID ?= 0


### PR DESCRIPTION
Fixes the inline comment that describes allowed values for CFG_CORE_ASYNC_NOTIF_GIC_INTID that can be a SPI or a secure PPI.

Fixes: 943972855082 ("core: notif: allow GIC_PPI usage for async notif")


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
