### PR TITLE
core: drivers: fix random number reading errors in hisi_trng

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,7 @@ jobs:
           _make PLATFORM=versal CFG_VERSAL_FPGA_DDR_ADDR=0x40000000
           _make PLATFORM=corstone1000
           _make PLATFORM=nuvoton
+          _make PLATFORM=d06
 
   QEMUv8_check:
     name: make check (QEMUv8)

--- a/core/drivers/hisi_trng.c
+++ b/core/drivers/hisi_trng.c
@@ -30,7 +30,7 @@ static TEE_Result trng_read(uint32_t *val)
 	exceptions = cpu_spin_lock_xsave(&trng_lock);
 	if (IO_READ32_POLL_TIMEOUT(trng_dev->base + HTRNG_RANDATA_REG,
 				   val, val, POLL_PERIOD, POLL_TIMEOUT)) {
-		EMSG("Hardware busy.");
+		EMSG("Hardware busy");
 		ret = TEE_ERROR_BUSY;
 	}
 	cpu_spin_unlock_xrestore(&trng_lock, exceptions);
@@ -45,12 +45,12 @@ TEE_Result hw_get_random_bytes(void *buf, size_t len)
 	uint32_t val = 0;
 
 	if (!trng_dev) {
-		EMSG("No valid TRNG device.");
+		EMSG("No valid TRNG device");
 		return TEE_ERROR_NOT_SUPPORTED;
 	}
 
 	if (!buf || !len) {
-		EMSG("Invalid input parameter.");
+		EMSG("Invalid input parameter");
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
@@ -71,22 +71,22 @@ static TEE_Result trng_init(void)
 {
 	TEE_Result ret = TEE_ERROR_GENERIC;
 
-	IMSG("TRNG driver init start.");
+	DMSG("TRNG driver init start");
 	trng_dev = calloc(1, sizeof(struct hisi_trng));
 	if (!trng_dev) {
-		EMSG("Fail to calloc trng device.");
+		EMSG("Fail to calloc trng device");
 		return TEE_ERROR_OUT_OF_MEMORY;
 	}
 
 	trng->base = (vaddr_t)phys_to_virt_io(HISI_TRNG_BASE, HISI_TRNG_SIZE);
 	if (!trng_dev->base) {
-		EMSG("Fail to get trng io_base.");
+		EMSG("Fail to get trng io_base");
 		free(trng_dev);
 		trng_dev = NULL;
 		return TEE_ERROR_ACCESS_DENIED;
 	}
 
-	DMSG("TRNG driver init done.");
+	DMSG("TRNG driver init done");
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Fixes error use of in IO_READ32_POLL_TIMEOUT() macro in hisi_trng

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
