### PR TITLE
plat-stm32mp1: scmi_server: fix case when regulator state is unchanged

### DIFF
--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -253,6 +253,7 @@
 			vdd_usb: ldo4 {
 				regulator-name = "vdd_usb";
 				interrupts = <IT_CURLIM_LDO4 0>;
+				regulator-always-on;
 			};
 
 			vdd_sd: ldo5 {

--- a/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
@@ -360,6 +360,7 @@
 			vdd_usb: ldo4 {
 				regulator-name = "vdd_usb";
 				interrupts = <IT_CURLIM_LDO4 0>;
+				regulator-always-on;
 			};
 
 			vdda: ldo5 {

--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -893,7 +893,7 @@ int32_t plat_scmi_voltd_set_config(unsigned int channel_id,
 			}
 			break;
 		default:
-			return SCMI_GENERIC_ERROR;
+			return SCMI_INVALID_PARAMETERS;
 		}
 
 		return SCMI_SUCCESS;


### PR DESCRIPTION
Fixes the return value when an SCMI regulator is already in the expected state. Prior this change the implementation returned SCMI_GENERIC_ERROR instead of SCMI_SUCCESS.

Changes also the SCMI return code in case of failure from SCMI_GENERIC_ERROR to SCMI_INVALID_PARAMETERS when the requested state is not one of the 2 supported SCMi voltage domain states supported (SCMI_VOLTAGE_DOMAIN_CONFIG_ARCH_ON or
SCMI_VOLTAGE_DOMAIN_CONFIG_ARCH_OFF).

Fixes: 23e200628dad ("plat-stm32mp1: scmi_server: use registered regulators")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
