### PR TITLE
core: arm: allow CFG_TZSRAM_START being defined when pager is disabled

### DIFF
--- a/core/arch/arm/include/mm/generic_ram_layout.h
+++ b/core/arch/arm/include/mm/generic_ram_layout.h
@@ -133,7 +133,7 @@
 #endif
 #endif
 
-#if defined(CFG_TZSRAM_START)
+#if defined(CFG_WITH_PAGER) && defined(CFG_TZSRAM_START)
 #define TZSRAM_BASE		CFG_TZSRAM_START
 #define TZSRAM_SIZE		CFG_TZSRAM_SIZE
 #endif


### PR DESCRIPTION
Fixes case when a platform configuration defines CFG_TZSRAM_START but does not use the pager. CFG_TZSRAM_START defines the based address of the memory used for resident memory and page pool when CFG_WITH_PAGER is enabled.

Since below mentioned commit, TZSRAM_BASE being defined makes core_mmu.c to assume there are 2 secure memories for OP-TEE core internal use. This change ensures that when CFG_WITH_PAGER is disabled, TZSRAM is not defined even if the platform configuration sets CFG_TZSRAM_START.

An example of such issues is when testing an STM32MP15 variant of platform stm32mp1 with pager being disabled. Before this change, OP-TEE boot sequence fails with a error trace message like: E/TC:0 0 Panic 'Unexpected TZC configuration on secure region' at core/arch/arm/plat-stm32mp1/plat_tzc400.c:102 <init_stm32mp1_tzc>

Indeed debug trace messages can show that an invalid physical memory area has been registered by core as TEE_RAM_RO, as shown below. Note that for that platform, internal secure SYSRAM range is [0x2ffc000 0x30000000]:
D/TC:0   add_phys_mem:667 ram_start type TEE_RAM_RO 0x2ffc0000 size 0xae040000

Fixes: e09739a8a6a1 (core: core_mmu.c: use secure_only[] where possible")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
