### PR TITLE
mk: config.mk: Explicitly warn about CFG_REE_FS_ALLOW_RESET

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -359,7 +359,9 @@ $(eval $(call cfg-depends-all,CFG_REE_FS_TA_BUFFERED,CFG_REE_FS_TA))
 # anti-rollback errors. That is, rm /data/tee/dirf.db or rm -rf /data/tee (or
 # whatever path is configured in tee-supplicant as CFG_TEE_FS_PARENT_PATH)
 # can be used to reset the secure storage to a clean, empty state.
-# Typically used for testing only since it weakens storage security.
+# Intended to be used for testing only since it weakens storage security.
+# Warning: If enabled for release build then it will break rollback protection
+# of TAs and the entire REE FS secure storage.
 CFG_REE_FS_ALLOW_RESET ?= n
 
 # Support for loading user TAs from a special section in the TEE binary.


### PR DESCRIPTION
CFG_REE_FS_ALLOW_RESET weakens rollback protection of REE FS secure storage and in turns breaks use-cases like rollback proteection of TAs etc. So explicitly warn user that CFG_REE_FS_ALLOW_RESET is intended for test purposes only and the added threat vectors if this option is enabled for release build.