### PR TITLE
drivers: clk: print clock tree summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           _make PLATFORM=stm-b2260
           _make PLATFORM=stm-cannes
           _make PLATFORM=stm32mp1
-          _make PLATFORM=stm32mp1-135F_DK
+          _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y
           if [ -d $HOME/scp-firmware ]; then _make PLATFORM=stm32mp1-157C_DK2 CFG_SCMI_SCPFW=y CFG_SCP_FIRMWARE=$HOME/scp-firmware; fi
           _make PLATFORM=stm32mp2
           _make PLATFORM=vexpress-fvp

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -8,6 +8,7 @@
 
 #include <kernel/refcount.h>
 #include <stdint.h>
+#include <sys/queue.h>
 #include <tee_api_types.h>
 
 /* Flags for clock */
@@ -26,6 +27,7 @@
  * @enabled_count: Enable/disable reference counter
  * @num_parents: Number of parents
  * @parents: Array of possible parents of the clock
+ * @link: Link the clock list
  */
 struct clk {
 	const char *name;
@@ -35,6 +37,9 @@ struct clk {
 	unsigned long rate;
 	unsigned int flags;
 	struct refcount enabled_count;
+#ifdef CFG_DRIVERS_CLK_PRINT_TREE
+	STAILQ_ENTRY(clk) link;
+#endif
 	size_t num_parents;
 	struct clk *parents[];
 };
@@ -193,5 +198,8 @@ TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
  */
 TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 			       unsigned long *rates, size_t *nb_elts);
+
+/* Print current clock tree summary on output console (info trace level) */
+void clk_print_tree(void);
 
 #endif /* __DRIVERS_CLK_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -886,10 +886,13 @@ CFG_PREALLOC_RPC_CACHE ?= y
 # CFG_DRIVERS_CLK_DT embeds devicetree clock parsing support
 # CFG_DRIVERS_CLK_FIXED add support for "fixed-clock" compatible clocks
 # CFG_DRIVERS_CLK_EARLY_PROBE makes clocks probed at early_init initcall level.
+# CFG_DRIVERS_CLK_PRINT_TREE embeds a helper function to print the clock tree
+# state on OP-TEE core console with the info trace level.
 CFG_DRIVERS_CLK ?= n
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
 CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
 CFG_DRIVERS_CLK_EARLY_PROBE ?= $(CFG_DRIVERS_CLK_DT)
+CFG_DRIVERS_CLK_PRINT_TREE ?= n
 
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
 $(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_FIXED,CFG_DRIVERS_CLK_DT))


### PR DESCRIPTION
Adds clk_print_summary() to print the clock tree current state on core console using the info trace level. Clock framework spinlock is help while clock tree is printed.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
