### PR TITLE
tree-wide: do not print a newline at the end of the *MSG() macros

### DIFF
--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -60,14 +60,14 @@ void spi_init(void)
 	vaddr_t pmx1_base = core_mmu_get_va(PMX1_BASE, MEM_AREA_IO_NSEC,
 					    PMX1_REG_SIZE);
 
-	DMSG("take SPI0 out of reset\n");
+	DMSG("take SPI0 out of reset");
 	shifted_val = PERI_RST3_SSP;
 	/*
 	 * no need to read PERI_SC_PERIPH_RSTDIS3 first
 	 * as all the bits are processed and cleared after writing
 	 */
 	io_write32(peri_base + PERI_SC_PERIPH_RSTDIS3, shifted_val);
-	DMSG("PERI_SC_PERIPH_RSTDIS3: 0x%x\n",
+	DMSG("PERI_SC_PERIPH_RSTDIS3: 0x%x",
 		io_read32(peri_base + PERI_SC_PERIPH_RSTDIS3));
 
 	/*
@@ -77,19 +77,19 @@ void spi_init(void)
 	do {
 		read_val = io_read32(peri_base + PERI_SC_PERIPH_RSTSTAT3);
 	} while (read_val & shifted_val);
-	DMSG("PERI_SC_PERIPH_RSTSTAT3: 0x%x\n", read_val);
+	DMSG("PERI_SC_PERIPH_RSTSTAT3: 0x%x", read_val);
 
-	DMSG("enable SPI clock\n");
+	DMSG("enable SPI clock");
 	/*
 	 * no need to read PERI_SC_PERIPH_CLKEN3 first
 	 * as all the bits are processed and cleared after writing
 	 */
 	shifted_val = PERI_CLK3_SSP;
 	io_write32(peri_base + PERI_SC_PERIPH_CLKEN3, shifted_val);
-	DMSG("PERI_SC_PERIPH_CLKEN3: 0x%x\n",
+	DMSG("PERI_SC_PERIPH_CLKEN3: 0x%x",
 		io_read32(peri_base + PERI_SC_PERIPH_CLKEN3));
 
-	DMSG("PERI_SC_PERIPH_CLKSTAT3: 0x%x\n",
+	DMSG("PERI_SC_PERIPH_CLKSTAT3: 0x%x",
 		io_read32(peri_base + PERI_SC_PERIPH_CLKSTAT3));
 
 	/*
@@ -101,13 +101,13 @@ void spi_init(void)
 	 * transfer.
 	 * ref: http://infocenter.arm.com/help/topic/com.arm.doc.ddi0194h/CJACFAFG.html
 	 */
-	DMSG("configure gpio6 pins 0-3 as SPI\n");
+	DMSG("configure gpio6 pins 0-3 as SPI");
 	io_write32(pmx0_base + PMX0_IOMG104, PINMUX_SPI);
 	io_write32(pmx0_base + PMX0_IOMG105, PINMUX_SPI);
 	io_write32(pmx0_base + PMX0_IOMG106, PINMUX_SPI);
 	io_write32(pmx0_base + PMX0_IOMG107, PINMUX_SPI);
 
-	DMSG("configure gpio6 pins 0-3 as nopull\n");
+	DMSG("configure gpio6 pins 0-3 as nopull");
 	io_write32(pmx1_base + PMX1_IOCG104, PINCFG_NOPULL);
 	io_write32(pmx1_base + PMX1_IOCG105, PINCFG_NOPULL);
 	io_write32(pmx1_base + PMX1_IOCG106, PINCFG_NOPULL);
@@ -124,7 +124,7 @@ static TEE_Result peripherals_init(void)
 	vaddr_t pmussi_base = core_mmu_get_va(PMUSSI_BASE, MEM_AREA_IO_NSEC,
 					      PMUSSI_REG_SIZE);
 
-	DMSG("enable LD021_1V8 source (pin 35) on LS connector\n");
+	DMSG("enable LD021_1V8 source (pin 35) on LS connector");
 	/*
 	 * Mezzanine cards usually use this to source level shifters for
 	 * UART, GPIO, SPI, I2C, etc so if not enabled, connected

--- a/core/arch/arm/plat-hikey/spi_test.c
+++ b/core/arch/arm/plat-hikey/spi_test.c
@@ -80,7 +80,7 @@ static void spi_test_with_manual_cs_control(void)
 	DMSG("Set CS callback");
 	pd.cs_control = PL022_CS_CTRL_MANUAL;
 
-	DMSG("spi_base: 0x%" PRIxVA "\n", spi_base);
+	DMSG("spi_base: 0x%" PRIxVA, spi_base);
 	DMSG("Configure SPI");
 	pd.base = spi_base;
 	pd.clk_hz = SPI_CLK_HZ;
@@ -170,7 +170,7 @@ static void spi_test_with_registered_cs_cb(void)
 	pd.cs_data.cs_cb = spi_cs_callback;
 	pd.cs_control = PL022_CS_CTRL_CB;
 
-	DMSG("spi_base: 0x%" PRIxVA "\n", spi_base);
+	DMSG("spi_base: 0x%" PRIxVA, spi_base);
 	DMSG("Configure SPI");
 	pd.base = spi_base;
 	pd.clk_hz = SPI_CLK_HZ;
@@ -215,7 +215,7 @@ static void spi_test_with_builtin_cs_control(void)
 
 	spi_set_cs_mux(PINMUX_GPIO);
 
-	DMSG("gpio6_base: 0x%" PRIxVA "\n", gpio6_base);
+	DMSG("gpio6_base: 0x%" PRIxVA, gpio6_base);
 	DMSG("Configure GPIO");
 	pl061_init(&pd061);
 	pl061_register(gpio6_base, 6);
@@ -226,7 +226,7 @@ static void spi_test_with_builtin_cs_control(void)
 	pd022.cs_data.gpio_data.pin_num = GPIO6_2;
 	pd022.cs_control = PL022_CS_CTRL_AUTO_GPIO;
 
-	DMSG("spi_base: 0x%" PRIxVA "\n", spi_base);
+	DMSG("spi_base: 0x%" PRIxVA, spi_base);
 	DMSG("Configure SPI");
 	pd022.base = spi_base;
 	pd022.clk_hz = SPI_CLK_HZ;

--- a/core/arch/arm/plat-rockchip/platform.c
+++ b/core/arch/arm/plat-rockchip/platform.c
@@ -19,7 +19,7 @@ int __weak platform_secure_ddr_region(int rgn __maybe_unused,
 				      paddr_t st __maybe_unused,
 				      size_t sz __maybe_unused)
 {
-	MSG("Not protecting region %d: 0x%lx-0x%lx\n", rgn, st, st + sz);
+	MSG("Not protecting region %d: 0x%lx-0x%lx", rgn, st, st + sz);
 
 	return 0;
 }

--- a/core/arch/arm/plat-rockchip/platform_px30.c
+++ b/core/arch/arm/plat-rockchip/platform_px30.c
@@ -38,7 +38,7 @@ int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
 	assert(st % SIZE_M(1) == 0);
 	assert(ed % SIZE_M(1) == 0);
 
-	DMSG("protecting region %d: 0x%lx-0x%lx\n", rgn, st, ed);
+	DMSG("protecting region %d: 0x%lx-0x%lx", rgn, st, ed);
 
 	/* Map top and base */
 	io_write32(fw_base + FIREWALL_DDR_FW_DDR_RGN(rgn),

--- a/core/arch/arm/plat-rockchip/platform_rk3399.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3399.c
@@ -32,7 +32,7 @@ int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
 	assert(st % SIZE_M(1) == 0);
 	assert(ed % SIZE_M(1) == 0);
 
-	DMSG("protecting region %d: 0x%lx-0x%lx\n", rgn, st, ed);
+	DMSG("protecting region %d: 0x%lx-0x%lx", rgn, st, ed);
 
 	/* Set ddr region addr start */
 	io_write32(sgrf_base + SGRF_DDRRGN_CON0_16(rgn),

--- a/core/drivers/atmel_saic.c
+++ b/core/drivers/atmel_saic.c
@@ -269,7 +269,7 @@ TEE_Result atmel_saic_setup(void)
 
 	ret = dt_map_dev(fdt, node, &saic.base, &size, DT_MAP_AUTO);
 	if (ret) {
-		EMSG("Failed to map SAIC\n");
+		EMSG("Failed to map SAIC");
 		return TEE_ERROR_GENERIC;
 	}
 

--- a/core/drivers/bcm_hwrng.c
+++ b/core/drivers/bcm_hwrng.c
@@ -76,7 +76,7 @@ static TEE_Result bcm_hwrng_init(void)
 
 	bcm_hwrng_reset();
 
-	DMSG("bcm_hwrng init done\n");
+	DMSG("bcm_hwrng init done");
 	return TEE_SUCCESS;
 }
 

--- a/core/drivers/crypto/caam/hal/common/hal_jr.c
+++ b/core/drivers/crypto/caam/hal/common/hal_jr.c
@@ -50,7 +50,7 @@ enum caam_status caam_hal_jr_reset(vaddr_t baseaddr)
 	} while ((reg_val == JRINTR_HALT_ONGOING) && --timeout);
 
 	if (!timeout || reg_val != JRINTR_HALT_DONE) {
-		EMSG("Failed to flush job ring\n");
+		EMSG("Failed to flush job ring");
 		return CAAM_FAILURE;
 	}
 
@@ -63,7 +63,7 @@ enum caam_status caam_hal_jr_reset(vaddr_t baseaddr)
 	} while ((reg_val & JRX_JRCR_RESET) && --timeout);
 
 	if (!timeout) {
-		EMSG("Failed to reset job ring\n");
+		EMSG("Failed to reset job ring");
 		return CAAM_FAILURE;
 	}
 

--- a/core/drivers/dra7_rng.c
+++ b/core/drivers/dra7_rng.c
@@ -92,7 +92,7 @@ static void dra7_rng_read64(uint32_t *low_word, uint32_t *high_word)
 			/* Clear the shutdown overflow event */
 			io_write32(rng + RNG_INTACK, SHUTDOWN_OFLO);
 
-			DMSG("Fixed FRO shutdown\n");
+			DMSG("Fixed FRO shutdown");
 		}
 	}
 	/* Read random value */

--- a/core/drivers/imx_wdog.c
+++ b/core/drivers/imx_wdog.c
@@ -47,7 +47,7 @@ void imx_wdog_restart(bool external_reset __maybe_unused)
 	uint32_t val = 0;
 
 	if (!wdog_base) {
-		EMSG("No wdog mapped\n");
+		EMSG("No wdog mapped");
 		panic();
 	}
 
@@ -67,7 +67,7 @@ void imx_wdog_restart(bool external_reset __maybe_unused)
 	else
 		val = 0x24;
 
-	DMSG("val %x\n", val);
+	DMSG("val %x", val);
 
 	io_write16(wdog_base + WDT_WCR, val);
 	dsb();
@@ -105,7 +105,7 @@ static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)
 
 	fdt = get_dt();
 	if (!fdt) {
-		EMSG("No DTB\n");
+		EMSG("No DTB");
 		return TEE_ERROR_NOT_SUPPORTED;
 	}
 
@@ -131,7 +131,7 @@ static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)
 	}
 
 	if (!found_off) {
-		EMSG("No Watchdog found in DTB\n");
+		EMSG("No Watchdog found in DTB");
 		return TEE_ERROR_ITEM_NOT_FOUND;
 	}
 
@@ -139,7 +139,7 @@ static TEE_Result imx_wdog_base(vaddr_t *wdog_vbase)
 					"fsl,ext-reset-output");
 
 	if (dt_map_dev(fdt, found_off, &vbase, &sz, DT_MAP_AUTO) < 0) {
-		EMSG("Failed to map Watchdog\n");
+		EMSG("Failed to map Watchdog");
 		return TEE_ERROR_ITEM_NOT_FOUND;
 	}
 

--- a/core/drivers/ls_dspi.c
+++ b/core/drivers/ls_dspi.c
@@ -547,7 +547,7 @@ static TEE_Result get_info_from_device_tree(struct ls_dspi_data *dspi_data)
 	 */
 	fdt = get_dt();
 	if (!fdt) {
-		EMSG("Unable to get DTB, DSPI init failed\n");
+		EMSG("Unable to get DTB, DSPI init failed");
 		return TEE_ERROR_ITEM_NOT_FOUND;
 	}
 

--- a/core/drivers/ls_gpio.c
+++ b/core/drivers/ls_gpio.c
@@ -187,7 +187,7 @@ static TEE_Result get_info_from_device_tree(struct ls_gpio_chip_data *gpio_data)
 	 */
 	fdt = get_embedded_dt();
 	if (!fdt) {
-		EMSG("Unable to get the Embedded DTB, GPIO init failed\n");
+		EMSG("Unable to get the Embedded DTB, GPIO init failed");
 		return TEE_ERROR_GENERIC;
 	}
 

--- a/core/drivers/ls_i2c.c
+++ b/core/drivers/ls_i2c.c
@@ -132,7 +132,7 @@ TEE_Result i2c_init(struct ls_i2c_data *i2c_data)
 	 */
 	fdt = get_embedded_dt();
 	if (!fdt) {
-		EMSG("Unable to get the Embedded DTB, I2C init failed\n");
+		EMSG("Unable to get the Embedded DTB, I2C init failed");
 		return TEE_ERROR_GENERIC;
 	}
 

--- a/core/drivers/regulator/regulator.c
+++ b/core/drivers/regulator/regulator.c
@@ -298,7 +298,7 @@ void regulator_print_state(const char *message __maybe_unused)
 	DMSG("name     use\ten\tuV\tmin\tmax\tflags\tsupply");
 
 	SLIST_FOREACH(regulator, &regulator_device_list, link)
-		DMSG("%8s %u\t%d\t%d\t%d\t%d\t%#x\t%s\n",
+		DMSG("%8s %u\t%d\t%d\t%d\t%d\t%#x\t%s",
 		     regulator->name, regulator->refcount,
 		     regulator_is_enabled(regulator),
 		     regulator_get_voltage(regulator),

--- a/core/drivers/smccc_trng.c
+++ b/core/drivers/smccc_trng.c
@@ -184,7 +184,7 @@ static void __maybe_unused smccc_trng_print_info(void)
 	thread_smccc(&args);
 	assert(args.a0 != ARM_SMCCC_RET_TRNG_NOT_SUPPORTED);
 
-	DMSG("SMCCC TRNG v%u.%u, UUID %08lx-%04lx-%04lx-%04lx-%04lx%08lx\n",
+	DMSG("SMCCC TRNG v%u.%u, UUID %08lx-%04lx-%04lx-%04lx-%04lx%08lx",
 	     major, minor, (unsigned long)args.a0, (unsigned long)args.a1 >> 16,
 	     (unsigned long)args.a1 & GENMASK_32(16, 0),
 	     (unsigned long)args.a2 >> 16,

--- a/core/drivers/xiphera_trng.c
+++ b/core/drivers/xiphera_trng.c
@@ -134,7 +134,7 @@ static TEE_Result xiphera_trng_probe(const void *fdt, int node,
 		udelay(200);
 		status = io_read32(xiphera_trng_base + STATUS_REG);
 		if (status != TRNG_ACK_RESET) {
-			EMSG("Failed to reset TRNG\n");
+			EMSG("Failed to reset TRNG");
 			return TEE_ERROR_GENERIC;
 		}
 	}
@@ -159,17 +159,17 @@ static TEE_Result xiphera_trng_probe(const void *fdt, int node,
 		 * in debugging TRNG implementation in FPGA
 		 */
 		if (status == TRNG_FAILED_STARTUP) {
-			EMSG("Startup tests have failed\n");
+			EMSG("Startup tests have failed");
 			return TEE_ERROR_GENERIC;
 		}
 
-		EMSG("Startup tests yielded no response -> TRNG stuck\n");
+		EMSG("Startup tests yielded no response -> TRNG stuck");
 		return TEE_ERROR_GENERIC;
 	}
 
 	io_write32(xiphera_trng_base + CONTROL_REG, HOST_TO_TRNG_ACK_ZEROIZE);
 
-	DMSG("TRNG initialized\n");
+	DMSG("TRNG initialized");
 
 	return TEE_SUCCESS;
 }

--- a/core/kernel/tpm.c
+++ b/core/kernel/tpm.c
@@ -51,7 +51,7 @@ static int read_dt_tpm_log_info(void *fdt, int node, paddr_t *buf,
 		err = fdt_setprop(fdt, node, dt_tpm_event_log_addr, &zero_addr,
 				  sizeof(uint32_t) * 2);
 		if (err < 0) {
-			EMSG("Error setting property DTB to zero\n");
+			EMSG("Error setting property DTB to zero");
 			return err;
 		}
 	}

--- a/core/pta/bcm/gpio.c
+++ b/core/pta/bcm/gpio.c
@@ -181,7 +181,7 @@ static TEE_Result invoke_command(void *session_context __unused,
 		res = pta_gpio_get(param_types, params);
 		break;
 	default:
-		EMSG("cmd: %d Not supported %s\n", cmd_id, GPIO_TA_NAME);
+		EMSG("cmd: %d Not supported %s", cmd_id, GPIO_TA_NAME);
 		res = TEE_ERROR_NOT_SUPPORTED;
 		break;
 	}

--- a/lib/libmbedtls/core/ecc.c
+++ b/lib/libmbedtls/core/ecc.c
@@ -228,7 +228,7 @@ static TEE_Result ecc_sign(uint32_t algo, struct ecc_keypair *key,
 					 mbedtls_mpi_size(&s));
 		res = TEE_SUCCESS;
 	} else {
-		FMSG("mbedtls_ecdsa_sign failed, returned 0x%x\n", -lmd_res);
+		FMSG("mbedtls_ecdsa_sign failed, returned 0x%x", -lmd_res);
 		res = TEE_ERROR_GENERIC;
 	}
 out:

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -711,7 +711,7 @@ static void gen_mdbg_check(struct malloc_ctx *ctx, int bufdump)
 			if (!fname)
 				fname = "unknown";
 
-			IMSG("buffer: %d bytes %s:%d\n",
+			IMSG("buffer: %d bytes %s:%d",
 				hdr->pl_size, fname, hdr->line);
 		}
 	}


### PR DESCRIPTION
The `*MSG()` macros take care of printing a newline. Adding a newline character '\n' is useless. Remove it.

The patch is mostly the result of this script:

```
git ls-files -z | xargs -0 sed -i -r 's/(MSG\(".*)\\n"/\1"/g'
```

with a bit of additional manual work to remove empty string literals. Example:

```c
	DMSG("spi_base: 0x%" PRIxVA "\n", spi_base);
```

get transform by the script into:

```c
	DMSG("spi_base: 0x%" PRIxVA "", spi_base);
```

and is then manually reworked into:

```c
	DMSG("spi_base: 0x%" PRIxVA, spi_base);
```

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
