### PR TITLE
core: kernel: tee_ta_manager.c: add uuid in open session error trace

### DIFF
--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -740,7 +740,7 @@ TEE_Result tee_ta_open_session(TEE_ErrorOrigin *err,
 	if (!res)
 		*sess = s;
 	else
-		EMSG("Failed. Return error 0x%x", res);
+		EMSG("Failed for TA %pUl. Return error %#"PRIx32, uuid, res);
 
 	return res;
 }


### PR DESCRIPTION
Adds the TA UUID in open session error trace to allow to identify witch TA cause the issue when debug trace are not acitvated.

By the way, fix specifier for res argument that is a uint32_t.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
