### PR TITLE
scmi-msg: fix voltage domains inline comment header file

### DIFF
--- a/core/include/drivers/scmi-msg.h
+++ b/core/include/drivers/scmi-msg.h
@@ -334,7 +334,7 @@ int32_t plat_scmi_rd_set_state(unsigned int channel_id, unsigned int scmi_id,
 size_t plat_scmi_voltd_count(unsigned int channel_id);
 
 /*
- * Get clock controller string ID (aka name)
+ * Get voltage domain string ID (aka name)
  * @channel_id: SCMI channel ID
  * @scmi_id: SCMI voltage domain ID
  * Return pointer to name or NULL
@@ -381,7 +381,7 @@ int32_t plat_scmi_voltd_get_level(unsigned int channel_id, unsigned int scmi_id,
 /*
  * Set voltage domain level voltage domain
  * @channel_id: SCMI channel ID
- * @scmi_id: SCMI clock ID
+ * @scmi_id: SCMI voltage domain ID
  * @level: Target voltage domain level in microvolt
  * Return a compliant SCMI error code
  */


### PR DESCRIPTION
Fix voltage domains inline comment header file.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
