### PR TITLE
drivers: regulator: print regulator tree summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           _make PLATFORM=stm-b2260
           _make PLATFORM=stm-cannes
           _make PLATFORM=stm32mp1
-          _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y
+          _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y CFG_DRIVERS_REGULATOR_PRINT_TREE=y
           if [ -d $HOME/scp-firmware ]; then _make PLATFORM=stm32mp1-157C_DK2 CFG_SCMI_SCPFW=y CFG_SCP_FIRMWARE=$HOME/scp-firmware; fi
           _make PLATFORM=stm32mp2
           _make PLATFORM=vexpress-fvp

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -303,6 +303,8 @@ endif
 # Default enable some test facitilites
 CFG_ENABLE_EMBEDDED_TESTS ?= y
 CFG_WITH_STATS ?= y
+CFG_DRIVERS_CLK_PRINT_TREE ?= $(CFG_WITH_STATS)
+CFG_DRIVERS_REGULATOR_PRINT_TREE ?= $(CFG_WITH_STATS)
 
 # Enable OTP update with BSEC driver
 CFG_STM32_BSEC_WRITE ?= y

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -398,7 +398,7 @@ static int cmp_int_value(const void *a, const void *b)
 static size_t refine_levels_array(struct regulator_voltages *voltages)
 {
 	int *levels_uv = voltages->entries;
-	size_t count = voltages->num_levels;
+	size_t count = voltages->hdr.num_levels;
 	size_t n = 0;
 	size_t m = 0;
 
@@ -443,7 +443,7 @@ static TEE_Result pmic_list_voltages(struct regulator *regulator,
 		for (n = 0; n < level_count; n++)
 			voltages->entries[n] = level_ref[n] * 1000;
 
-		voltages->num_levels = level_count;
+		voltages->hdr.num_levels = level_count;
 		level_count = refine_levels_array(voltages);
 
 		voltages_s = realloc(voltages,
@@ -454,8 +454,8 @@ static TEE_Result pmic_list_voltages(struct regulator *regulator,
 			return TEE_ERROR_OUT_OF_MEMORY;
 		}
 
-		voltages_s->type = VOLTAGE_TYPE_FULL_LIST;
-		voltages_s->num_levels = level_count;
+		voltages_s->hdr.type = VOLTAGE_TYPE_FULL_LIST;
+		voltages_s->hdr.num_levels = level_count;
 		priv->voltages = voltages_s;
 	}
 

--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -646,7 +646,8 @@ int32_t plat_scmi_voltd_levels_array(unsigned int channel_id,
 			return SCMI_NOT_SUPPORTED;
 		if (res)
 			return SCMI_GENERIC_ERROR;
-		if (!voltages || voltages->type != VOLTAGE_TYPE_FULL_LIST) {
+		if (!voltages ||
+		    voltages->hdr.type != VOLTAGE_TYPE_FULL_LIST) {
 			/*
 			 * Triplet min/max/step description. Caller should use
 			 * plat_scmi_voltd_levels_by_step().
@@ -655,7 +656,7 @@ int32_t plat_scmi_voltd_levels_array(unsigned int channel_id,
 		}
 
 		ref = voltages->entries;
-		ref_count = voltages->num_levels;
+		ref_count = voltages->hdr.num_levels;
 
 		/* Bound according to regulator registered min/max levels */
 		for (n = ref_count; n > 0; n--)
@@ -708,7 +709,8 @@ int32_t plat_scmi_voltd_levels_by_step(unsigned int channel_id,
 			return SCMI_NOT_SUPPORTED;
 		if (res)
 			return SCMI_GENERIC_ERROR;
-		if (!voltages || voltages->type != VOLTAGE_TYPE_INCREMENT) {
+		if (!voltages ||
+		    voltages->hdr.type != VOLTAGE_TYPE_INCREMENT) {
 			/*
 			 * Triplet min/max/step description. Caller should use
 			 * plat_scmi_voltd_levels_by_step().

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -200,6 +200,11 @@ TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 			       unsigned long *rates, size_t *nb_elts);
 
 /* Print current clock tree summary on output console (info trace level) */
+#ifdef CFG_DRIVERS_CLK
 void clk_print_tree(void);
-
+#else
+static inline void clk_print_tree(void)
+{
+}
+#endif /* CFG_DRIVERS_CLK */
 #endif /* __DRIVERS_CLK_H */

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -317,6 +317,11 @@ TEE_Result regulator_supported_voltages(struct regulator *regulator,
 					struct regulator_voltages **voltages);
 
 /* Print current regulator tree summary to output console  (info trace level) */
+#ifdef CFG_DRIVERS_REGULATOR
 void regulator_print_tree(void);
-
+#else
+static inline void regulator_print_tree(void)
+{
+}
+#endif /* CFG_DRIVERS_REGULATOR */
 #endif /* __DRIVERS_REGULATOR_H */

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -315,4 +315,8 @@ static inline void regulator_get_range(struct regulator *regulator, int *min_uv,
  */
 TEE_Result regulator_supported_voltages(struct regulator *regulator,
 					struct regulator_voltages **voltages);
+
+/* Print current regulator tree summary to output console  (info trace level) */
+void regulator_print_tree(void);
+
 #endif /* __DRIVERS_REGULATOR_H */

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -49,16 +49,16 @@ struct regu_dt_desc {
 };
 
 /*
- * Defines the format of struct voltages::entries
+ * Defines the format of struct regulator_voltages::entries
+ * and struct voltages_fallback::entries.
  *
- * If regulator_voltages::type is VOLTAGE_TYPE_FULL_LIST, then
- * regulator_voltages@entries stores regulator_voltages::num_levels cells,
+ * If regulator_voltages_desc::type is VOLTAGE_TYPE_FULL_LIST, then
+ * @entries cell stores regulator_voltages_desc::num_levels cells,
  * listing supported voltage levels in uV from lowest to highest value.
  *
- * If regulator_voltages::type is VOLTAGE_TYPE_INCREMENT, then
- * regulator_voltages::entries stores 3 cells: min level, max level and
- * level increment step, all in uV. When so, regulator_voltages::num_levels
- * is meaningless.
+ * If regulator_voltages_desc::type is VOLTAGE_TYPE_INCREMENT, then
+ * @entries stores 3 cells: min level, max level and level increment
+ * step, all in uV. When so, regulator_voltages::num_levels is meaningless.
  */
 enum voltage_type {
 	VOLTAGE_TYPE_INVALID = 0,
@@ -67,16 +67,33 @@ enum voltage_type {
 };
 
 /*
- * struct regulator_voltages - Voltage levels description
+ * struct regulator_voltages_hdr - Voltage levels description header
  * @type: Type of level description
- * @num_levels: Number of cells of @entries when @type is VOLTAGE_TYPE_FULL_LIST
- * @entries: Voltage level information in uV
- *
+ * @num_levels: Number levels described when @type is VOLTAGE_TYPE_FULL_LIST
  */
-struct regulator_voltages {
+struct regulator_voltages_hdr {
 	enum voltage_type type;
 	size_t num_levels;
+};
+
+/*
+ * struct regulator_voltages - Variable sized voltage levels description
+ * @hdr: Header of voltage levels description
+ * @entries: Voltage level information in uV
+ */
+struct regulator_voltages {
+	struct regulator_voltages_hdr hdr;
 	int entries[];
+};
+
+/*
+ * struct struct voltages_fallback - Default Voltage levels description
+ * @hdr: Header of fallback voltage levels description
+ * @entries: Voltage level information in uV
+ */
+struct voltages_fallback {
+	struct regulator_voltages_hdr hdr;
+	int entries[3];
 };
 
 /*
@@ -107,10 +124,7 @@ struct regulator {
 	unsigned int flags;
 	unsigned int refcount;
 	struct mutex lock;	/* Concurrent access protection */
-	struct voltages_fallback {
-		struct regulator_voltages desc;
-		int levels[3];
-	} voltages_fallback;
+	struct voltages_fallback voltages_fallback;
 	size_t levels_count_fallback;
 	SLIST_ENTRY(regulator) link;
 };

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -221,7 +221,7 @@ static TEE_Result get_system_time(uint32_t type,
 	return TEE_SUCCESS;
 }
 
-static TEE_Result get_drivers_info(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
+static TEE_Result print_drivers_info(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
 	if (TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 			    TEE_PARAM_TYPE_NONE,
@@ -263,7 +263,7 @@ static TEE_Result invoke_command(void *psess __unused,
 	case STATS_CMD_GET_TIME:
 		return get_system_time(ptypes, params);
 	case STATS_CMD_PRINT_DRIVERS_INFO:
-		return get_drivers_info(ptypes, params);
+		return print_drivers_info(ptypes, params);
 	default:
 		break;
 	}

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -54,11 +54,11 @@
 #define STATS_NB_POOLS			4
 
 /*
- * STATS_CMD_PRINT_DRIVERS_INFO - Print device drivers information to console
+ * STATS_CMD_PRINT_DRIVER_INFO - Print device drivers information to console
  *
  * [in]    value[0].a        Target driver, one of STATS_DRIVER_TYPE_*
  */
-#define STATS_CMD_PRINT_DRIVERS_INFO	5
+#define STATS_CMD_PRINT_DRIVER_INFO	5
 
 #define STATS_DRIVER_TYPE_CLOCK		0
 #define STATS_DRIVER_TYPE_REGULATOR	1
@@ -262,7 +262,7 @@ static TEE_Result invoke_command(void *psess __unused,
 		return get_user_ta_stats(ptypes, params);
 	case STATS_CMD_GET_TIME:
 		return get_system_time(ptypes, params);
-	case STATS_CMD_PRINT_DRIVERS_INFO:
+	case STATS_CMD_PRINT_DRIVER_INFO:
 		return print_drivers_info(ptypes, params);
 	default:
 		break;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -922,7 +922,11 @@ CFG_DRIVERS_PINCTRL ?= n
 #
 # When enabled, CFG_REGULATOR_GPIO embeds a voltage regulator driver for
 # DT compatible "regulator-gpio" devices.
+#
+# CFG_DRIVERS_REGULATOR_PRINT_TREE embeds a helper function to print the
+# regulator tree state on OP-TEE core console with the info trace level.
 CFG_DRIVERS_REGULATOR ?= n
+CFG_DRIVERS_REGULATOR_PRINT_TREE ?= n
 CFG_REGULATOR_FIXED ?= n
 CFG_REGULATOR_GPIO ?= n
 


### PR DESCRIPTION
Replaces existing `regulator_print_state()` with `regulator_print_summary()` on the model of what's been done for clocks (https://github.com/OP-TEE/optee_os/pull/6474).
The function is renamed for consistency.