### PR TITLE
dts: stm32mp15: harden RCC secure configuration on ST boards

### DIFF
--- a/core/arch/arm/dts/stm32mp157a-dk1.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1.dts
@@ -36,7 +36,3 @@
 		reg = <0xf0 0x10>;
 	};
 };
-
-&rcc {
-	status = "okay";
-};

--- a/core/arch/arm/dts/stm32mp157c-dk2.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2.dts
@@ -98,10 +98,6 @@
 	};
 };
 
-&rcc {
-	status = "okay";
-};
-
 &usart2 {
 	pinctrl-names = "default", "sleep", "idle";
 	pinctrl-0 = <&usart2_pins_c>;

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -338,6 +338,7 @@
 };
 
 &rcc {
+	compatible = "st,stm32mp1-rcc-secure";
 	status = "okay";
 };
 

--- a/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
@@ -489,6 +489,11 @@
 	vdd_3v3_usbfs-supply = <&vdd_usb>;
 };
 
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};
+
 &rng1 {
 	status = "okay";
 };


### PR DESCRIPTION
Enable STM32MP15 RCC secure hardening configuration on ST boards (DK1, DK2, ED1 and EV1) to assign SoC clocks, reset controllers and PWR regulators to OP-TEE secure world.

This change removes setting of &rcc node status property from stm32mp157a-dk1.dts, stm32mp157c-dk2.dts as the property is set from stm32mp15xx-dkx.dtsi that is included from the 2 former DTS files.

This change depends on https://github.com/OP-TEE/build/pull/701 for the OP-TEE distribution.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
