### PR TITLE
drivers: regulator: fix variable sized voltages fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
           _make PLATFORM=stm-cannes
           _make PLATFORM=stm32mp1
           _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y CFG_DRIVERS_REGULATOR_PRINT_TREE=y
+          _make PLATFORM=stm32mp1-135F_DK COMPILER=clang
           if [ -d $HOME/scp-firmware ]; then _make PLATFORM=stm32mp1-157C_DK2 CFG_SCMI_SCPFW=y CFG_SCP_FIRMWARE=$HOME/scp-firmware; fi
           _make PLATFORM=stm32mp2
           _make PLATFORM=vexpress-fvp

--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -626,7 +626,7 @@ const char *plat_scmi_voltd_get_name(unsigned int channel_id,
 
 int32_t plat_scmi_voltd_levels_array(unsigned int channel_id,
 				     unsigned int scmi_id, size_t start_index,
-				     long *levels, size_t *nb_elts)
+				     long *out_levels, size_t *nb_elts)
 
 {
 	struct stm32_scmi_voltd *voltd = find_voltd(channel_id, scmi_id);
@@ -635,18 +635,19 @@ int32_t plat_scmi_voltd_levels_array(unsigned int channel_id,
 		return SCMI_NOT_FOUND;
 
 	if (voltd->regulator) {
-		struct regulator_voltages *voltages = NULL;
+		struct regulator_voltages_desc *desc = NULL;
 		TEE_Result res = TEE_ERROR_GENERIC;
-		int *ref = NULL;
 		size_t ref_count = 0;
+		const int *levels = NULL;
 		size_t n = 0;
 
-		res = regulator_supported_voltages(voltd->regulator, &voltages);
+		res = regulator_supported_voltages(voltd->regulator, &desc,
+						   &levels);
 		if (res == TEE_ERROR_NOT_SUPPORTED)
 			return SCMI_NOT_SUPPORTED;
 		if (res)
 			return SCMI_GENERIC_ERROR;
-		if (!voltages || voltages->type != VOLTAGE_TYPE_FULL_LIST) {
+		if (!desc || desc->type != VOLTAGE_TYPE_FULL_LIST) {
 			/*
 			 * Triplet min/max/step description. Caller should use
 			 * plat_scmi_voltd_levels_by_step().
@@ -654,15 +655,14 @@ int32_t plat_scmi_voltd_levels_array(unsigned int channel_id,
 			return SCMI_NOT_SUPPORTED;
 		}
 
-		ref = voltages->entries;
-		ref_count = voltages->num_levels;
+		ref_count = desc->num_levels;
 
 		/* Bound according to regulator registered min/max levels */
 		for (n = ref_count; n > 0; n--)
-			if (voltages->entries[n - 1] > voltd->regulator->max_uv)
+			if (levels[n - 1] > voltd->regulator->max_uv)
 				ref_count--;
 		for (n = 0; n < ref_count; n++)
-			if (voltages->entries[n] >= voltd->regulator->min_uv)
+			if (levels[n] >= voltd->regulator->min_uv)
 				break;
 
 		if (n == ref_count) {
@@ -680,7 +680,7 @@ int32_t plat_scmi_voltd_levels_array(unsigned int channel_id,
 		}
 
 		for (n = 0; n < *nb_elts; n++)
-			levels[n] = ref[start_index + n];
+			out_levels[n] = levels[start_index + n];
 
 		return SCMI_SUCCESS;
 	}
@@ -697,18 +697,20 @@ int32_t plat_scmi_voltd_levels_by_step(unsigned int channel_id,
 		return SCMI_NOT_FOUND;
 
 	if (voltd->regulator) {
-		struct regulator_voltages *voltages = NULL;
+		struct regulator_voltages_desc *desc = NULL;
 		TEE_Result res = TEE_ERROR_GENERIC;
+		const int *levels = NULL;
 		int ref_min = 0;
 		int ref_max = 0;
 		int ref_step = 0;
 
-		res = regulator_supported_voltages(voltd->regulator, &voltages);
+		res = regulator_supported_voltages(voltd->regulator, &desc,
+						   &levels);
 		if (res == TEE_ERROR_NOT_SUPPORTED)
 			return SCMI_NOT_SUPPORTED;
 		if (res)
 			return SCMI_GENERIC_ERROR;
-		if (!voltages || voltages->type != VOLTAGE_TYPE_INCREMENT) {
+		if (!desc || desc->type != VOLTAGE_TYPE_INCREMENT) {
 			/*
 			 * Triplet min/max/step description. Caller should use
 			 * plat_scmi_voltd_levels_by_step().
@@ -716,9 +718,9 @@ int32_t plat_scmi_voltd_levels_by_step(unsigned int channel_id,
 			return SCMI_NOT_SUPPORTED;
 		}
 
-		ref_min = voltages->entries[0];
-		ref_max = voltages->entries[1];
-		ref_step = voltages->entries[2];
+		ref_min = levels[0];
+		ref_max = levels[1];
+		ref_step = levels[2];
 
 		if (ref_min < voltd->regulator->min_uv) {
 			int diff = voltd->regulator->min_uv - ref_min;

--- a/core/drivers/regulator/regulator.c
+++ b/core/drivers/regulator/regulator.c
@@ -213,21 +213,24 @@ TEE_Result regulator_set_voltage(struct regulator *regulator, int level_uv)
 }
 
 TEE_Result regulator_supported_voltages(struct regulator *regulator,
-					struct regulator_voltages **voltages)
+					struct regulator_voltages_desc **desc,
+					const int **levels)
 {
-	assert(regulator && voltages);
+	assert(regulator && desc && levels);
 
 	if (regulator->ops->supported_voltages) {
 		TEE_Result res = TEE_ERROR_GENERIC;
 
-		res = regulator->ops->supported_voltages(regulator, voltages);
+		res = regulator->ops->supported_voltages(regulator, desc,
+							 levels);
 		if (res == TEE_SUCCESS)
 			return TEE_SUCCESS;
 		if (res != TEE_ERROR_NOT_SUPPORTED)
 			return res;
 	}
 
-	*voltages = &regulator->voltages_fallback.desc;
+	*desc = &regulator->voltages_fallback.desc;
+	*levels = regulator->voltages_fallback.levels;
 
 	return TEE_SUCCESS;
 }

--- a/core/drivers/regulator/stm32mp13_regulator_iod.c
+++ b/core/drivers/regulator/stm32mp13_regulator_iod.c
@@ -173,10 +173,11 @@ static TEE_Result iod_set_voltage(struct regulator *regu, int level_uv)
 }
 
 static TEE_Result iod_list_voltages(struct regulator *regu,
-				    struct regulator_voltages **voltages)
+				    struct regulator_voltages_desc **desc,
+				    const int **levels)
 {
 	/* Return supply voltage list */
-	return regulator_supported_voltages(regu->supply, voltages);
+	return regulator_supported_voltages(regu->supply, desc, levels);
 }
 
 /*


### PR DESCRIPTION
drivers: regulator: fix variable sized voltages fallback

Fix build issue reported by Clang on variable size field `desc` not being located at the end of `struct voltages_fallback`. The error was reported with a trace message like below:
````
core/include/drivers/regulator.h:118:4: warning: field 'voltages_fallback' with variable sized type 'struct voltages_fallback' not at the end of a struct or class is a GNU extension [-Wgnu-variable-sized-type-not-at-end]
        } voltages_fallback;
          ^
core/drivers/regulator/regulator_fixed.c:27:19: warning: field 'regulator' with variable sized type 'struct regulator' not at the end of a struct or class is a GNU extension [-Wgnu-variable-sized-type-not-at-end]
        struct regulator regulator;
                         ^
2 warnings generated.
```

API function `regulator_supported_voltages()` asserts that `struct regulator_voltages` and `struct voltages_fallback` do match.

By the way, remove empty line in `struct regulator_voltages` inline  description comment.

Fixes: 43c155ba111d ("drivers: regulator: list supported levels")

A second change enabled CI build of STM32MP13 platform with Clang.