### PR TITLE
drivers: clk: limit print_clock_subtree() recursive calls

### DIFF
--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -14,6 +14,9 @@
 #include <stddef.h>
 #include <stdio.h>
 
+/* Max number of recursive calls to print_clock_subtree() */
+#define CLK_PRINT_TREE_MAX_RECURSION	32
+
 /* Global clock tree lock */
 static unsigned int clk_lock = SPINLOCK_UNLOCK;
 
@@ -391,6 +394,12 @@ static void print_clock_subtree(struct clk *clk_root __maybe_unused,
 {
 #ifdef CFG_DRIVERS_CLK_PRINT_TREE
 	struct clk *clk = NULL;
+
+	if (indent == CLK_PRINT_TREE_MAX_RECURSION) {
+		EMSG("Abort clk subtree loop, %d recursive calls reached",
+		     CLK_PRINT_TREE_MAX_RECURSION);
+		return;
+	}
 
 	STAILQ_FOREACH(clk, &clock_list, link) {
 		if (clk_get_parent(clk) == clk_root) {


### PR DESCRIPTION
Limit print_clock_subtree() recursive calls to 32.

Reported-by: Jens Wiklander <jens.wiklander@linaro.org>
Link: https://github.com/OP-TEE/optee_os/pull/6481#discussion_r1403208798

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
