### PR TITLE
drivers: regulator: fix getting gpio for level control

### DIFF
--- a/core/drivers/regulator/regulator_gpio.c
+++ b/core/drivers/regulator/regulator_gpio.c
@@ -148,6 +148,11 @@ static TEE_Result get_voltage_level_gpio(const void *fdt, int node,
 	void *gpio_ref = &gpio;
 	int len = 0;
 
+	res = dt_driver_device_from_node_idx_prop("gpios", fdt, node, 0,
+						  DT_DRIVER_GPIO, gpio_ref);
+	if (res)
+		return res;
+
 	/*
 	 * DT bindings allows more than 1 GPIO to control more than
 	 * 2 voltage levels. As it's not used so far in known platforms
@@ -160,11 +165,6 @@ static TEE_Result get_voltage_level_gpio(const void *fdt, int node,
 		EMSG("Multiple GPIOs not supported for level control");
 		return TEE_ERROR_GENERIC;
 	}
-
-	res = dt_driver_device_from_node_idx_prop("gpios", fdt, node, 0,
-						  DT_DRIVER_GPIO, gpio_ref);
-	if (res)
-		return res;
 
 	cuint = fdt_getprop(fdt, node, "states", &len);
 	if (!cuint || len != 4 * sizeof(fdt32_t)) {


### PR DESCRIPTION
Swap the 2 calls to find gpio property in "regulator-gpio" compiatble node. Obviously the first call expects to get the GPIO resource while the second check that the node does not define 2 or more GPIOs to control the regulator level as the implementation only supports one, as described in the inline comment.

Fixes: f164f0f83420 ("drivers: regulator: GPIO controlled regulator")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
