### PR TITLE
plat-stm32mp1: fix warning trace on TZC configuration check

### DIFF
--- a/core/arch/arm/plat-stm32mp1/plat_tzc400.c
+++ b/core/arch/arm/plat-stm32mp1/plat_tzc400.c
@@ -40,11 +40,12 @@ static struct itr_handler tzc_itr_handler = {
 };
 DECLARE_KEEP_PAGER(tzc_itr_handler);
 
-static bool tzc_region_is_non_secure(unsigned int i, vaddr_t base, size_t size)
+static bool tzc_region_is_non_secure(unsigned int i, uint64_t pa, size_t size)
 {
 	struct tzc_region_config region_cfg = { };
 	uint32_t ns_cpu_mask = TZC_REGION_ACCESS_RDWR(STM32MP1_TZC_A7_ID);
 	uint32_t filters_mask = TZC_FILTERS_MASK;
+	vaddr_t base = pa;
 
 	if (tzc_get_region_config(i, &region_cfg))
 		panic();


### PR DESCRIPTION
Fix build warning reported by recent toolchains when TZDRAM memory ends at the UINT32_MAX. This happends for example when building for the stm32mp1-157C_EV1 platform. In such case was GCC to emit the following warning trace:

core/arch/arm/plat-stm32mp1/plat_tzc400.c: In function ‘init_stm32mp1_tzc’: core/arch/arm/plat-stm32mp1/plat_tzc400.c:107:61: warning: conversion from ‘uint64_t’ {aka ‘long long unsigned int’} to ‘vaddr_t’ {aka ‘long unsigned int’} changes value from ‘4294967296’ to ‘0’ [-Woverflow]
  107 |                 if (!tzc_region_is_non_secure(region_index, tzdram_end,
      |                                                             ^~~~~~~~~~

Fixes: 59c253f92c6c ("plat-stm32mp1: check TZC400 configuration")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
