### PR TITLE
Add support of key check value CKA_CHECK_VALUE to PKCS11 TA

### DIFF
--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -352,6 +352,11 @@ enum pkcs11_rc entry_create_object(struct pkcs11_client *client,
 	if (rc)
 		goto out;
 
+	/* Set key check value attribute */
+	rc = set_check_value_attr(&head);
+	if (rc)
+		goto out;
+
 	/*
 	 * Check target object attributes match target processing
 	 * Check target object attributes match token state
@@ -1064,6 +1069,11 @@ enum pkcs11_rc entry_set_attribute_value(struct pkcs11_client *client,
 	if (rc)
 		goto out;
 
+	/* Set key check value attribute */
+	rc = set_check_value_attr(&obj->attributes);
+	if (rc)
+		goto out;
+
 	if (get_bool(obj->attributes, PKCS11_CKA_TOKEN)) {
 		rc = update_persistent_object_attributes(obj);
 		if (rc)
@@ -1213,6 +1223,11 @@ enum pkcs11_rc entry_copy_object(struct pkcs11_client *client, uint32_t ptypes,
 	 * given by the callee
 	 */
 	rc = modify_attributes_list(&head_new, head);
+	if (rc)
+		goto out;
+
+	/* Set key check value attribute */
+	rc = set_check_value_attr(&head_new);
 	if (rc)
 		goto out;
 

--- a/ta/pkcs11/src/pkcs11_attributes.h
+++ b/ta/pkcs11/src/pkcs11_attributes.h
@@ -11,6 +11,9 @@
 
 #include "serializer.h"
 
+/* The key check value (KCV) attribute for objects is 3 bytes */
+#define PKCS11_CKA_CHECK_VALUE_SIZE	U(3)
+
 struct obj_attrs;
 struct pkcs11_object;
 struct pkcs11_session;
@@ -214,5 +217,11 @@ enum pkcs11_rc alloc_key_data_to_wrap(struct obj_attrs *head, void **data,
  */
 enum pkcs11_rc add_missing_attribute_id(struct obj_attrs **pub_head,
 					struct obj_attrs **priv_head);
+/*
+ * Check an object's check value (Checksum)
+ * @head: Object attribute where to find KCV to be checked
+ * Return a pkcs11_rv compliant value
+ */
+enum pkcs11_rc set_check_value_attr(struct obj_attrs **head);
 
 #endif /*PKCS11_TA_PKCS11_ATTRIBUTES_H*/

--- a/ta/pkcs11/src/processing.c
+++ b/ta/pkcs11/src/processing.c
@@ -166,10 +166,10 @@ size_t get_object_key_bit_size(struct pkcs11_object *obj)
 static enum pkcs11_rc generate_random_key_value(struct obj_attrs **head)
 {
 	enum pkcs11_rc rc = PKCS11_CKR_GENERAL_ERROR;
-	void *data = NULL;
 	uint32_t data_size = 0;
 	uint32_t value_len = 0;
 	void *value = NULL;
+	void *data = NULL;
 
 	if (!*head)
 		return PKCS11_CKR_TEMPLATE_INCONSISTENT;
@@ -195,6 +195,9 @@ static enum pkcs11_rc generate_random_key_value(struct obj_attrs **head)
 	TEE_GenerateRandom(value, value_len);
 
 	rc = add_attribute(head, PKCS11_CKA_VALUE, value, value_len);
+
+	if (rc == PKCS11_CKR_OK)
+		rc = set_check_value_attr(head);
 
 	TEE_Free(value);
 

--- a/ta/pkcs11/sub.mk
+++ b/ta/pkcs11/sub.mk
@@ -10,6 +10,9 @@ CFG_PKCS11_TA_HEAP_SIZE ?= (32 * 1024)
 # Defines the number of PKCS11 token implemented by the PKCS11 TA
 CFG_PKCS11_TA_TOKEN_COUNT ?= 3
 
+# When enabled, embed support for object checksum value computation
+CFG_PKCS11_TA_CHECK_VALUE_ATTRIBUTE ?= n
+
 global-incdirs-y += include
 global-incdirs-y += src
 subdirs-y += src


### PR DESCRIPTION
An attempt to support CKA_CHECK_VALUE attribute in PKCS 11 TA. For AES, the value of this attribute is derived from the key object by taking the first three bytes of the ECB encryption of a single block of null (0x00) bytes, using the default cipher associated with the key type of the secret key object. This is useful to detect that a key object has not tampered with. 

For now, we try to calculate the value when a symmetric key is randomly generated. Still need to add for (Create, Unwarp, Derive and Copy) in incoming commits.

Related issues: https://github.com/OP-TEE/optee_os/issues/6453, https://github.com/OP-TEE/optee_os/issues/6431