### PR TITLE
drivers: clk: print clock tree without recursive call

### DIFF
--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -49,7 +49,7 @@ void clk_free(struct clk *clk)
 
 static bool __maybe_unused clk_check(struct clk *clk)
 {
-	if (!clk->ops)
+	if (!clk || !clk->ops)
 		return false;
 
 	if (clk->ops->set_parent && !clk->ops->get_parent)

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -18,7 +18,7 @@
 static unsigned int clk_lock = SPINLOCK_UNLOCK;
 
 #ifdef CFG_DRIVERS_CLK_PRINT_TREE
-static STAILQ_HEAD(, clk) clock_list = STAILQ_HEAD_INITIALIZER(clock_list);
+static SLIST_HEAD(, clk) clock_list = SLIST_HEAD_INITIALIZER(clock_list);
 #endif
 
 struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
@@ -109,7 +109,7 @@ TEE_Result clk_register(struct clk *clk)
 	clk_compute_rate_no_lock(clk);
 
 #ifdef CFG_DRIVERS_CLK_PRINT_TREE
-	STAILQ_INSERT_TAIL(&clock_list, clk, link);
+	SLIST_INSERT_HEAD(&clock_list, clk, link);
 #endif
 
 	DMSG("Registered clock %s, freq %lu", clk->name, clk_get_rate(clk));
@@ -392,7 +392,7 @@ static void print_clock_subtree(struct clk *clk_root __maybe_unused,
 #ifdef CFG_DRIVERS_CLK_PRINT_TREE
 	struct clk *clk = NULL;
 
-	STAILQ_FOREACH(clk, &clock_list, link) {
+	SLIST_FOREACH(clk, &clock_list, link) {
 		if (clk_get_parent(clk) == clk_root) {
 			print_clock(clk, indent + 1);
 			print_clock_subtree(clk, indent + 1);

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -436,7 +436,7 @@ out:
 	if (!msg)
 		snprintf(msg_end - 4, 4, "...");
 
-	IMSG("%s", msg_buf);
+	DMSG("%s", msg_buf);
 }
 
 static void print_tree(void)
@@ -448,7 +448,7 @@ static void print_tree(void)
 
 #ifdef CFG_DRIVERS_CLK_PRINT_TREE
 	if (SLIST_EMPTY(&clock_list)) {
-		IMSG("-- No registered clock");
+		DMSG("-- No registered clock");
 		return;
 	}
 #endif
@@ -481,8 +481,9 @@ static void print_tree(void)
 
 void clk_print_tree(void)
 {
-	if (IS_ENABLED(CFG_DRIVERS_CLK_PRINT_TREE)) {
-		IMSG("Clock tree summary (informative):");
+	if (IS_ENABLED(CFG_DRIVERS_CLK_PRINT_TREE) &&
+	    TRACE_LEVEL >= TRACE_DEBUG) {
+		DMSG("Clock tree summary (informative):");
 		print_tree();
 	}
 }

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -482,11 +482,7 @@ static void print_tree(void)
 void clk_print_tree(void)
 {
 	if (IS_ENABLED(CFG_DRIVERS_CLK_PRINT_TREE)) {
-		uint32_t exceptions = 0;
-
-		exceptions = cpu_spin_lock_xsave(&clk_lock);
-		IMSG("Clock tree summary:");
+		IMSG("Clock tree summary (informative):");
 		print_tree();
-		cpu_spin_unlock_xrestore(&clk_lock, exceptions);
 	}
 }

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -199,7 +199,7 @@ TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
 TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 			       unsigned long *rates, size_t *nb_elts);
 
-/* Print current clock tree summary on output console (info trace level) */
+/* Print current clock tree summary to output console with debug trace level */
 #ifdef CFG_DRIVERS_CLK
 void clk_print_tree(void);
 #else

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -200,6 +200,11 @@ TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 			       unsigned long *rates, size_t *nb_elts);
 
 /* Print current clock tree summary on output console (info trace level) */
+#ifdef CFG_DRIVERS_CLK
 void clk_print_tree(void);
-
+#else
+static inline void clk_print_tree(void)
+{
+}
+#endif /* CFG_DRIVERS_CLK */
 #endif /* __DRIVERS_CLK_H */

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -38,7 +38,7 @@ struct clk {
 	unsigned int flags;
 	struct refcount enabled_count;
 #ifdef CFG_DRIVERS_CLK_PRINT_TREE
-	STAILQ_ENTRY(clk) link;
+	SLIST_ENTRY(clk) link;
 #endif
 	size_t num_parents;
 	struct clk *parents[];

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -887,7 +887,7 @@ CFG_PREALLOC_RPC_CACHE ?= y
 # CFG_DRIVERS_CLK_FIXED add support for "fixed-clock" compatible clocks
 # CFG_DRIVERS_CLK_EARLY_PROBE makes clocks probed at early_init initcall level.
 # CFG_DRIVERS_CLK_PRINT_TREE embeds a helper function to print the clock tree
-# state on OP-TEE core console with the info trace level.
+# state on OP-TEE core console with the debug trace level.
 CFG_DRIVERS_CLK ?= n
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
 CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)


### PR DESCRIPTION
This series mainly replaces the implementation of `clk_print_tree()` to not use recursive calls:
commit "drivers: clk: print tree without recursion".

There are 3 other minor changes added:
* use of SLIST instead of STAILQ list in clock tree print implementation;
* assert `clk_register()` argument is not NULL;
* stub `clk_print_tree()` when `CFG_DRIVERS_CLK_PRINT_TREE` is disabled.

This is a follow up of @jenswi-linaro proposal https://github.com/OP-TEE/optee_os/pull/6481#discussion_r1404590521, applied to the clock tree. 
 