### PR TITLE
drivers: regualtor: print tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           _make PLATFORM=stm-b2260
           _make PLATFORM=stm-cannes
           _make PLATFORM=stm32mp1
-          _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y
+          _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y CFG_DRIVERS_REGULATOR_PRINT_TREE=y
           if [ -d $HOME/scp-firmware ]; then _make PLATFORM=stm32mp1-157C_DK2 CFG_SCMI_SCPFW=y CFG_SCP_FIRMWARE=$HOME/scp-firmware; fi
           _make PLATFORM=stm32mp2
           _make PLATFORM=vexpress-fvp

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -315,4 +315,13 @@ static inline void regulator_get_range(struct regulator *regulator, int *min_uv,
  */
 TEE_Result regulator_supported_voltages(struct regulator *regulator,
 					struct regulator_voltages **voltages);
+
+/* Print current regulator tree summary to console with debug trace level */
+#ifdef CFG_DRIVERS_REGULATOR
+void regulator_print_tree(void);
+#else
+static inline void regulator_print_tree(void)
+{
+}
+#endif /* CFG_DRIVERS_REGULATOR */
 #endif /* __DRIVERS_REGULATOR_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -887,7 +887,7 @@ CFG_PREALLOC_RPC_CACHE ?= y
 # CFG_DRIVERS_CLK_FIXED add support for "fixed-clock" compatible clocks
 # CFG_DRIVERS_CLK_EARLY_PROBE makes clocks probed at early_init initcall level.
 # CFG_DRIVERS_CLK_PRINT_TREE embeds a helper function to print the clock tree
-# state on OP-TEE core console with the info trace level.
+# state on OP-TEE core console with the debug trace level.
 CFG_DRIVERS_CLK ?= n
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
 CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
@@ -922,7 +922,11 @@ CFG_DRIVERS_PINCTRL ?= n
 #
 # When enabled, CFG_REGULATOR_GPIO embeds a voltage regulator driver for
 # DT compatible "regulator-gpio" devices.
+#
+# CFG_DRIVERS_REGULATOR_PRINT_TREE embeds a helper function to print the
+# regulator tree state on OP-TEE core console with the info trace level.
 CFG_DRIVERS_REGULATOR ?= n
+CFG_DRIVERS_REGULATOR_PRINT_TREE ?= n
 CFG_REGULATOR_FIXED ?= n
 CFG_REGULATOR_GPIO ?= n
 


### PR DESCRIPTION
Implementation of `regulator_print_tree()` as per @jenswi-linaro https://github.com/OP-TEE/optee_os/pull/6481#discussion_r1404590521 proposal.

Compared to #6481, this series only implements `regulator_print_tree()` and ensures it's built by CI. But not yet by CLang CI since it requires a fix as proposed by https://github.com/OP-TEE/optee_os/pull/6487.