### PR TITLE
core: pta: stats: export and clarify statistics PTA API/ABI

### DIFF
--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -112,7 +112,7 @@ bool tee_mm_addr_is_within_range(const tee_mm_pool_t *pool, paddr_t addr);
 bool tee_mm_is_empty(tee_mm_pool_t *pool);
 
 #ifdef CFG_WITH_STATS
-void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct malloc_stats *stats,
+void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct pta_stats_alloc *stats,
 			   bool reset);
 #endif
 

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -7,6 +7,7 @@
 #define __MM_TEE_MM_H
 
 #include <malloc.h>
+#include <pta_stats.h>
 #include <types_ext.h>
 
 /* Define to indicate default pool initiation */

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -41,7 +41,7 @@ struct tee_ta_dump_stats {
 	TEE_UUID uuid;
 	uint32_t panicked;	/* True if TA has panicked */
 	uint32_t sess_num;	/* Number of opened session */
-	struct malloc_stats heap;
+	struct pta_stats_alloc heap;
 };
 
 struct tee_ta_dump_ctx {

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -37,7 +37,7 @@
 
 #if defined(CFG_TA_STATS)
 #define MAX_DUMP_SESS_NUM	(16)
-struct tee_ta_dump_stats {
+struct pta_stats_ta {
 	TEE_UUID uuid;
 	uint32_t panicked;	/* True if TA has panicked */
 	uint32_t sess_num;	/* Number of opened session */
@@ -879,7 +879,7 @@ static void init_dump_ctx(struct tee_ta_dump_ctx *dump_ctx)
 }
 
 static TEE_Result dump_ta_stats(struct tee_ta_dump_ctx *dump_ctx,
-				struct tee_ta_dump_stats *dump_stats,
+				struct pta_stats_ta *dump_stats,
 				size_t ta_count)
 {
 	TEE_Result res = TEE_SUCCESS;
@@ -892,7 +892,7 @@ static TEE_Result dump_ta_stats(struct tee_ta_dump_ctx *dump_ctx,
 	nsec_sessions_list_head(&open_sessions);
 
 	for (i = 0; i < ta_count; i++) {
-		struct tee_ta_dump_stats *stats = &dump_stats[i];
+		struct pta_stats_ta *stats = &dump_stats[i];
 
 		memcpy(&stats->uuid, &dump_ctx[i].uuid,
 		       sizeof(dump_ctx[i].uuid));
@@ -932,7 +932,7 @@ static TEE_Result dump_ta_stats(struct tee_ta_dump_ctx *dump_ctx,
 TEE_Result tee_ta_instance_stats(void *buf, size_t *buf_size)
 {
 	TEE_Result res = TEE_SUCCESS;
-	struct tee_ta_dump_stats *dump_stats = NULL;
+	struct pta_stats_ta *dump_stats = NULL;
 	struct tee_ta_dump_ctx *dump_ctx = NULL;
 	struct tee_ta_ctx *ctx = NULL;
 	size_t sz = 0;
@@ -948,7 +948,7 @@ TEE_Result tee_ta_instance_stats(void *buf, size_t *buf_size)
 		if (is_user_ta_ctx(&ctx->ts_ctx))
 			ta_count++;
 
-	sz = sizeof(struct tee_ta_dump_stats) * ta_count;
+	sz = sizeof(struct pta_stats_ta) * ta_count;
 	if (!sz) {
 		/* sz = 0 means there is no UTA, return no item found. */
 		res = TEE_ERROR_ITEM_NOT_FOUND;
@@ -964,7 +964,7 @@ TEE_Result tee_ta_instance_stats(void *buf, size_t *buf_size)
 		DMSG("Data alignment");
 		res = TEE_ERROR_BAD_PARAMETERS;
 	} else {
-		dump_stats = (struct tee_ta_dump_stats *)buf;
+		dump_stats = (struct pta_stats_ta *)buf;
 		dump_ctx = malloc(sizeof(struct tee_ta_dump_ctx) * ta_count);
 		if (!dump_ctx)
 			res = TEE_ERROR_OUT_OF_MEMORY;

--- a/core/kernel/tee_ta_manager.c
+++ b/core/kernel/tee_ta_manager.c
@@ -21,6 +21,7 @@
 #include <mm/core_mmu.h>
 #include <mm/mobj.h>
 #include <mm/vm.h>
+#include <pta_stats.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,12 +38,6 @@
 
 #if defined(CFG_TA_STATS)
 #define MAX_DUMP_SESS_NUM	(16)
-struct pta_stats_ta {
-	TEE_UUID uuid;
-	uint32_t panicked;	/* True if TA has panicked */
-	uint32_t sess_num;	/* Number of opened session */
-	struct pta_stats_alloc heap;
-};
 
 struct tee_ta_dump_ctx {
 	TEE_UUID uuid;

--- a/core/mm/tee_mm.c
+++ b/core/mm/tee_mm.c
@@ -8,6 +8,7 @@
 #include <kernel/tee_common.h>
 #include <mm/tee_mm.h>
 #include <mm/tee_pager.h>
+#include <pta_stats.h>
 #include <trace.h>
 #include <util.h>
 

--- a/core/mm/tee_mm.c
+++ b/core/mm/tee_mm.c
@@ -104,7 +104,7 @@ static size_t tee_mm_stats_allocated(tee_mm_pool_t *pool)
 	return sz << pool->shift;
 }
 
-void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct malloc_stats *stats,
+void tee_mm_get_pool_stats(tee_mm_pool_t *pool, struct pta_stats_alloc *stats,
 			   bool reset)
 {
 	uint32_t exceptions;

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -8,48 +8,14 @@
 #include <malloc.h>
 #include <mm/tee_mm.h>
 #include <mm/tee_pager.h>
+#include <pta_stats.h>
 #include <stdio.h>
 #include <string.h>
 #include <string_ext.h>
+#include <tee_api_types.h>
 #include <trace.h>
 
 #define TA_NAME		"stats.ta"
-
-#define STATS_UUID \
-		{ 0xd96a5b40, 0xe2c7, 0xb1af, \
-			{ 0x87, 0x94, 0x10, 0x02, 0xa5, 0xd5, 0xc6, 0x1b } }
-
-#define STATS_CMD_PAGER_STATS		0
-#define STATS_CMD_ALLOC_STATS		1
-#define STATS_CMD_MEMLEAK_STATS		2
-/*
- * UTEE_ENTRY_FUNC_DUMP_MEMSTATS
- * [out]    memref[0]        Array of context information of loaded TAs
- *
- * Each cell of the TA information array contains:
- * TEE_UUID    TA UUID
- * uint32_t    Non zero if TA panicked, 0 otherwise
- * uint32_t    Number of sessions opened by the TA
- * uint32_t    Byte size currently allocated in TA heap
- * uint32_t    Max bytes allocated since last stats reset
- * uint32_t    TA heap pool byte size
- * uint32_t    Number of failed allocation requests
- * uint32_t    Biggest byte size which allocation failed
- * uint32_t    Biggest byte size which allocation succeeded
- */
-#define STATS_CMD_TA_STATS		3
-
-/*
- * STATS_CMD_GET_TIME - Get both REE time and TEE time
- *
- * [out]    value[0].a        REE time as seen by OP-TEE in seconds
- * [out]    value[0].b        REE time as seen by OP-TEE, milliseconds part
- * [out]    value[1].a        TEE system time in seconds
- * [out]    value[1].b        TEE system time, milliseconds part
- */
-#define STATS_CMD_GET_TIME		4
-
-#define STATS_NB_POOLS			4
 
 static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -53,7 +53,7 @@
 
 static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
-	struct malloc_stats *stats;
+	struct pta_stats_alloc *stats;
 	uint32_t size_to_retrieve;
 	uint32_t pool_id;
 	uint32_t i;
@@ -63,7 +63,7 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 	 *   - 0 means all the pools to be retrieved
 	 *   - 1..n means pool id
 	 * p[0].value.b = 0 if no reset of the stats
-	 * p[1].memref.buffer = output buffer to struct malloc_stats
+	 * p[1].memref.buffer = output buffer to struct pta_stats_alloc
 	 */
 	if (TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 			    TEE_PARAM_TYPE_MEMREF_OUTPUT,
@@ -76,7 +76,7 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 	if (pool_id > STATS_NB_POOLS)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	size_to_retrieve = sizeof(struct malloc_stats);
+	size_to_retrieve = sizeof(struct pta_stats_alloc);
 	if (!pool_id)
 		size_to_retrieve *= STATS_NB_POOLS;
 

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -53,10 +53,10 @@
 
 static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
-	struct pta_stats_alloc *stats;
-	uint32_t size_to_retrieve;
-	uint32_t pool_id;
-	uint32_t i;
+	struct pta_stats_alloc *stats = NULL;
+	uint32_t size_to_retrieve = 0;
+	uint32_t pool_id = 0;
+	uint32_t i = 0;
 
 	/*
 	 * p[0].value.a = pool id (from 0 to n)
@@ -130,7 +130,7 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 
 static TEE_Result get_pager_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
-	struct tee_pager_stats stats;
+	struct tee_pager_stats stats = { };
 
 	if (TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
 			    TEE_PARAM_TYPE_VALUE_OUTPUT,

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -15,8 +15,6 @@
 #include <tee_api_types.h>
 #include <trace.h>
 
-#define TA_NAME		"stats.ta"
-
 static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 {
 	struct pta_stats_alloc *stats = NULL;
@@ -200,6 +198,6 @@ static TEE_Result invoke_command(void *psess __unused,
 	return TEE_ERROR_BAD_PARAMETERS;
 }
 
-pseudo_ta_register(.uuid = STATS_UUID, .name = TA_NAME,
+pseudo_ta_register(.uuid = STATS_UUID, .name = "stats.pta",
 		   .flags = PTA_DEFAULT_FLAGS,
 		   .invoke_command_entry_point = invoke_command);

--- a/lib/libutee/include/pta_stats.h
+++ b/lib/libutee/include/pta_stats.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2023, STMicroelectronics
+ * Copyright (C) 2022, Microchip
+ */
+#ifndef __PTA_STATS_H
+#define __PTA_STATS_H
+
+#define STATS_UUID \
+		{ 0xd96a5b40, 0xe2c7, 0xb1af, \
+			{ 0x87, 0x94, 0x10, 0x02, 0xa5, 0xd5, 0xc6, 0x1b } }
+
+#define STATS_CMD_PAGER_STATS		0
+#define STATS_CMD_ALLOC_STATS		1
+#define STATS_CMD_MEMLEAK_STATS		2
+/*
+ * UTEE_ENTRY_FUNC_DUMP_MEMSTATS
+ * [out]    memref[0]        Array of context information of loaded TAs
+ *
+ * Each cell of the TA information array contains:
+ * TEE_UUID    TA UUID
+ * uint32_t    Non zero if TA panicked, 0 otherwise
+ * uint32_t    Number of sessions opened by the TA
+ * uint32_t    Byte size currently allocated in TA heap
+ * uint32_t    Max bytes allocated since last stats reset
+ * uint32_t    TA heap pool byte size
+ * uint32_t    Number of failed allocation requests
+ * uint32_t    Biggest byte size which allocation failed
+ * uint32_t    Biggest byte size which allocation succeeded
+ */
+#define STATS_CMD_TA_STATS		3
+
+/*
+ * STATS_CMD_GET_TIME - Get both REE time and TEE time
+ *
+ * [out]    value[0].a        REE time as seen by OP-TEE in seconds
+ * [out]    value[0].b        REE time as seen by OP-TEE, milliseconds part
+ * [out]    value[1].a        TEE system time in seconds
+ * [out]    value[1].b        TEE system time, milliseconds part
+ */
+#define STATS_CMD_GET_TIME		4
+
+#define STATS_NB_POOLS			4
+
+#endif /*__PTA_STATS_H*/

--- a/lib/libutee/include/pta_stats.h
+++ b/lib/libutee/include/pta_stats.h
@@ -6,29 +6,70 @@
 #ifndef __PTA_STATS_H
 #define __PTA_STATS_H
 
+#include <stdint.h>
+#include <tee_api_types.h>
+
 #define STATS_UUID \
 		{ 0xd96a5b40, 0xe2c7, 0xb1af, \
 			{ 0x87, 0x94, 0x10, 0x02, 0xa5, 0xd5, 0xc6, 0x1b } }
 
-#define STATS_CMD_PAGER_STATS		0
-#define STATS_CMD_ALLOC_STATS		1
-#define STATS_CMD_MEMLEAK_STATS		2
 /*
- * UTEE_ENTRY_FUNC_DUMP_MEMSTATS
- * [out]    memref[0]        Array of context information of loaded TAs
+ * STATS_CMD_PAGER_STATS - Get statistics on pager
  *
- * Each cell of the TA information array contains:
- * TEE_UUID    TA UUID
- * uint32_t    Non zero if TA panicked, 0 otherwise
- * uint32_t    Number of sessions opened by the TA
- * uint32_t    Byte size currently allocated in TA heap
- * uint32_t    Max bytes allocated since last stats reset
- * uint32_t    TA heap pool byte size
- * uint32_t    Number of failed allocation requests
- * uint32_t    Biggest byte size which allocation failed
- * uint32_t    Biggest byte size which allocation succeeded
+ * [out]    value[0].a        Number of unlocked pages
+ * [out]    value[0].b        Page pool size
+ * [out]    value[1].a        R/O faults since last stats dump
+ * [out]    value[1].b        R/W faults since last stats dump
+ * [out]    value[2].a        Hidden faults since last stats dump
+ * [out]    value[2].b        Zi pages released since last stats dump
+ */
+#define STATS_CMD_PAGER_STATS		0
+
+/*
+ * STATS_CMD_ALLOC_STATS - Get statistics on core heap allocations
+ *
+ * [in]     value[0].a       ID of allocator(s) to get stats from (ALLOC_ID_*)
+ * [out]    memref[0]        Array of struct pta_stats_alloc instances
+ */
+#define STATS_CMD_ALLOC_STATS		1
+
+#define ALLOC_ID_ALL		0	/* All allocators */
+#define ALLOC_ID_HEAP		1	/* Core heap allocator */
+#define ALLOC_ID_PUBLIC_DDR	2	/* Public DDR allocator (deprecated) */
+#define ALLOC_ID_TA_RAM		3	/* TA_RAM allocator */
+#define ALLOC_ID_NEXUS_HEAP	4	/* Nexus heap allocator */
+#define STATS_NB_POOLS		5
+
+#define TEE_ALLOCATOR_DESC_LENGTH 32
+
+struct pta_stats_alloc {
+	char desc[TEE_ALLOCATOR_DESC_LENGTH];
+	uint32_t allocated;               /* Bytes currently allocated */
+	uint32_t max_allocated;           /* Tracks max value of allocated */
+	uint32_t size;                    /* Total size for this allocator */
+	uint32_t num_alloc_fail;          /* Number of failed alloc requests */
+	uint32_t biggest_alloc_fail;      /* Size of biggest failed alloc */
+	uint32_t biggest_alloc_fail_used; /* Alloc bytes when above occurred */
+};
+
+/*
+ * STATS_CMD_MEMLEAK_STATS - Print memory leakage info to console
+ */
+#define STATS_CMD_MEMLEAK_STATS		2
+
+/*
+ * STATS_CMD_TA_STATS - Get information on TA instances
+ *
+ * [out]    memref[0]        Array of struct pta_stats_ta per loaded TA
  */
 #define STATS_CMD_TA_STATS		3
+
+struct pta_stats_ta {
+	TEE_UUID uuid;
+	uint32_t panicked;	/* True if TA has panicked */
+	uint32_t sess_num;	/* Number of opened session */
+	struct pta_stats_alloc heap;
+};
 
 /*
  * STATS_CMD_GET_TIME - Get both REE time and TEE time
@@ -39,7 +80,5 @@
  * [out]    value[1].b        TEE system time, milliseconds part
  */
 #define STATS_CMD_GET_TIME		4
-
-#define STATS_NB_POOLS			4
 
 #endif /*__PTA_STATS_H*/

--- a/lib/libutee/user_ta_entry.c
+++ b/lib/libutee/user_ta_entry.c
@@ -392,7 +392,7 @@ static TEE_Result entry_dump_memstats(unsigned long session_id __unused,
 {
 	uint32_t param_types = 0;
 	TEE_Param params[TEE_NUM_PARAMS] = { };
-	struct malloc_stats stats = { };
+	struct pta_stats_alloc stats = { };
 
 	from_utee_params(params, &param_types, up);
 	ta_header_save_params(param_types, params);

--- a/lib/libutils/ext/mempool.c
+++ b/lib/libutils/ext/mempool.c
@@ -146,7 +146,7 @@ void *mempool_alloc(struct mempool *pool, size_t size)
 	p = raw_malloc(0, 0, size, pool->mctx);
 	if (p) {
 #ifdef CFG_MEMPOOL_REPORT_LAST_OFFSET
-		struct malloc_stats stats = { };
+		struct pta_stats_alloc stats = { };
 
 		raw_malloc_get_stats(pool->mctx, &stats);
 		if (stats.max_allocated > pool->max_allocated) {

--- a/lib/libutils/ext/mempool.c
+++ b/lib/libutils/ext/mempool.c
@@ -9,6 +9,7 @@
 #include <compiler.h>
 #include <malloc.h>
 #include <mempool.h>
+#include <pta_stats.h>
 #include <string.h>
 #include <util.h>
 

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -82,6 +82,7 @@
 #include <config.h>
 #include <malloc.h>
 #include <memtag.h>
+#include <pta_stats.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib_ext.h>

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -135,7 +135,7 @@ struct malloc_ctx {
 	struct malloc_pool *pool;
 	size_t pool_len;
 #ifdef BufStats
-	struct malloc_stats mstats;
+	struct pta_stats_alloc mstats;
 #endif
 #ifdef __KERNEL__
 	unsigned int spinlock;
@@ -308,7 +308,7 @@ void malloc_reset_stats(void)
 }
 
 static void gen_malloc_get_stats(struct malloc_ctx *ctx,
-				 struct malloc_stats *stats)
+				 struct pta_stats_alloc *stats)
 {
 	uint32_t exceptions = malloc_lock(ctx);
 
@@ -316,7 +316,7 @@ static void gen_malloc_get_stats(struct malloc_ctx *ctx,
 	malloc_unlock(ctx, exceptions);
 }
 
-void malloc_get_stats(struct malloc_stats *stats)
+void malloc_get_stats(struct pta_stats_alloc *stats)
 {
 	gen_malloc_get_stats(&malloc_ctx, stats);
 }
@@ -996,7 +996,7 @@ bool raw_malloc_buffer_is_within_alloced(struct malloc_ctx *ctx,
 }
 
 #ifdef CFG_WITH_STATS
-void raw_malloc_get_stats(struct malloc_ctx *ctx, struct malloc_stats *stats)
+void raw_malloc_get_stats(struct malloc_ctx *ctx, struct pta_stats_alloc *stats)
 {
 	memcpy_unchecked(stats, &ctx->mstats, sizeof(*stats));
 	stats->allocated = ctx->poolset.totalloc;
@@ -1130,7 +1130,7 @@ void nex_malloc_reset_stats(void)
 	gen_malloc_reset_stats(&nex_malloc_ctx);
 }
 
-void nex_malloc_get_stats(struct malloc_stats *stats)
+void nex_malloc_get_stats(struct pta_stats_alloc *stats)
 {
 	gen_malloc_get_stats(&nex_malloc_ctx, stats);
 }

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -5,6 +5,7 @@
 #ifndef __MALLOC_H
 #define __MALLOC_H
 
+#include <pta_stats.h>
 #include <stddef.h>
 #include <types_ext.h>
 
@@ -80,21 +81,7 @@ bool malloc_buffer_overlaps_heap(void *buf, size_t len);
 void malloc_add_pool(void *buf, size_t len);
 
 #ifdef CFG_WITH_STATS
-/*
- * Get/reset allocation statistics
- */
-
-#define TEE_ALLOCATOR_DESC_LENGTH 32
-struct pta_stats_alloc {
-	char desc[TEE_ALLOCATOR_DESC_LENGTH];
-	uint32_t allocated;               /* Bytes currently allocated */
-	uint32_t max_allocated;           /* Tracks max value of allocated */
-	uint32_t size;                    /* Total size for this allocator */
-	uint32_t num_alloc_fail;          /* Number of failed alloc requests */
-	uint32_t biggest_alloc_fail;      /* Size of biggest failed alloc */
-	uint32_t biggest_alloc_fail_used; /* Alloc bytes when above occurred */
-};
-
+/* Get/reset allocation statistics */
 void malloc_get_stats(struct pta_stats_alloc *stats);
 void malloc_reset_stats(void);
 #endif /* CFG_WITH_STATS */

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -85,7 +85,7 @@ void malloc_add_pool(void *buf, size_t len);
  */
 
 #define TEE_ALLOCATOR_DESC_LENGTH 32
-struct malloc_stats {
+struct pta_stats_alloc {
 	char desc[TEE_ALLOCATOR_DESC_LENGTH];
 	uint32_t allocated;               /* Bytes currently allocated */
 	uint32_t max_allocated;           /* Tracks max value of allocated */
@@ -95,7 +95,7 @@ struct malloc_stats {
 	uint32_t biggest_alloc_fail_used; /* Alloc bytes when above occurred */
 };
 
-void malloc_get_stats(struct malloc_stats *stats);
+void malloc_get_stats(struct pta_stats_alloc *stats);
 void malloc_reset_stats(void);
 #endif /* CFG_WITH_STATS */
 
@@ -142,7 +142,7 @@ void nex_malloc_add_pool(void *buf, size_t len);
  * Get/reset allocation statistics
  */
 
-void nex_malloc_get_stats(struct malloc_stats *stats);
+void nex_malloc_get_stats(struct pta_stats_alloc *stats);
 void nex_malloc_reset_stats(void);
 
 #endif	/* CFG_WITH_STATS */
@@ -174,7 +174,8 @@ bool raw_malloc_buffer_overlaps_heap(struct malloc_ctx *ctx,
 bool raw_malloc_buffer_is_within_alloced(struct malloc_ctx *ctx,
 					 void *buf, size_t len);
 #ifdef CFG_WITH_STATS
-void raw_malloc_get_stats(struct malloc_ctx *ctx, struct malloc_stats *stats);
+void raw_malloc_get_stats(struct malloc_ctx *ctx,
+			  struct pta_stats_alloc *stats);
 #endif
 
 #endif /* __MALLOC_H */


### PR DESCRIPTION
Move definition of the statistics PTA API/ABI from various files (_pta/stats.c_, _tee_ta_manager.c_ and _malloc.h_) to a single header file (_lib/libutee/include/pta_stats.h_) exported to TA devkit. This changes make statistics PTA API definition more consistent regarding the definition of other the PTAs.