### PR TITLE
Remove git_cpu_init()

### DIFF
--- a/core/arch/arm/plat-aspeed/platform_ast2600.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2600.c
@@ -67,7 +67,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-aspeed/platform_ast2700.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2700.c
@@ -26,7 +26,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -28,7 +28,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-imx/main.c
+++ b/core/arch/arm/plat-imx/main.c
@@ -117,6 +117,6 @@ void boot_primary_init_intc(void)
 #if CFG_TEE_CORE_NB_CORE > 1
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 #endif

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -39,7 +39,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -215,9 +215,7 @@ void boot_primary_init_intc(void)
 	gic_init(gic_base + gicc_offset, gic_base + gicd_offset);
 }
 
-#if !defined(CFG_WITH_ARM_TRUSTED_FW)
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
-#endif

--- a/core/arch/arm/plat-rcar/main.c
+++ b/core/arch/arm/plat-rcar/main.c
@@ -94,5 +94,5 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -29,7 +29,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 void console_init(void)

--- a/core/arch/arm/plat-rzn1/main.c
+++ b/core/arch/arm/plat-rzn1/main.c
@@ -47,7 +47,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 static TEE_Result rzn1_tz_init(void)

--- a/core/arch/arm/plat-stm/main.c
+++ b/core/arch/arm/plat-stm/main.c
@@ -139,5 +139,5 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -160,7 +160,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 
 	stm32mp_register_online_cpu();
 }

--- a/core/arch/arm/plat-stm32mp2/main.c
+++ b/core/arch/arm/plat-stm32mp2/main.c
@@ -140,5 +140,5 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }

--- a/core/arch/arm/plat-sunxi/main.c
+++ b/core/arch/arm/plat-sunxi/main.c
@@ -130,7 +130,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 #endif
 

--- a/core/arch/arm/plat-ti/main.c
+++ b/core/arch/arm/plat-ti/main.c
@@ -41,7 +41,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 struct plat_nsec_ctx {

--- a/core/arch/arm/plat-zynq7k/main.c
+++ b/core/arch/arm/plat-zynq7k/main.c
@@ -148,7 +148,7 @@ void boot_primary_init_intc(void)
 
 void boot_secondary_init_intc(void)
 {
-	gic_cpu_init();
+	gic_init_per_cpu();
 }
 
 static vaddr_t slcr_access_range[] = {

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -342,20 +342,6 @@ void gic_init_per_cpu(void)
 	}
 }
 
-void gic_cpu_init(void)
-{
-	struct gic_data *gd = &gic_data;
-
-#if defined(CFG_ARM_GICV3)
-	assert(gd->gicd_base);
-#else
-	assert(gd->gicd_base && gd->gicc_base);
-#endif
-	IMSG("%s is deprecated, please use gic_init_per_cpu()", __func__);
-
-	init_gic_per_cpu(gd);
-}
-
 void gic_init_donate_sgi_to_ns(size_t it)
 {
 	struct gic_data *gd = &gic_data;

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -54,14 +54,6 @@ void gic_init_donate_sgi_to_ns(size_t it);
  */
 void gic_init_per_cpu(void);
 
-/*
- * Only initialize CPU GIC interface, mainly use for secondary CPUs in
- * non-TF-A configurations.
- *
- * This function is deprecated, please use gic_init_per_cpu() instead.
- */
-void gic_cpu_init(void);
-
 /* Print GIC state to console */
 void gic_dump_state(void);
 #endif /*__DRIVERS_GIC_H*/


### PR DESCRIPTION
@Amit-Radur, @b49020, @ChiaweiW, @clementfaure, @ememarar, @etienne-lms, @glneo, @grandpaul, @GseoC, @lorc, @MrVan, @Neal-liu, @pangupta, @sahilnxp, @sdininno 

Please check and ack your platforms. One difference for many platforms is that we rely on TF-A or the previous boot stage to initialize the GIC. I assume some unintended copy & paste error has led most platforms to reinitialize the GIC. If I'm wrong in that assumption, we'll see how we can fix it.