### PR TITLE
[RFC] core: handle underflow in msg_param_mobj_from_noncontig()

### DIFF
--- a/core/kernel/msg_param.c
+++ b/core/kernel/msg_param.c
@@ -125,6 +125,12 @@ struct mobj *msg_param_mobj_from_noncontig(paddr_t buf_ptr, size_t size,
 	page_offset = buf_ptr & SMALL_PAGE_MASK;
 	if (ADD_OVERFLOW(size, page_offset, &size_plus_offs))
 		return NULL;
+
+	if (!size_plus_offs) {
+		EMSG("Cannot allocate null-sized shared memory");
+		return NULL;
+	}
+
 	num_pages = (size_plus_offs - 1) / SMALL_PAGE_SIZE + 1;
 	if (MUL_OVERFLOW(num_pages, sizeof(paddr_t), &msize))
 		return NULL;


### PR DESCRIPTION
When page_offset and size are equal to zero, size_plus_offs will be null. Therefore, size_plus_offs - 1 operation will underflow and the malloc() operation will fail.

Explicitly fail when trying to register shared memory with a null-size.

This change does not solve the U-Boot crash issue in #6507 but explicitly state the error in OP-TEE

