### PR TITLE
core: arm: fix NS entrypoint for secondary cores

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -880,7 +880,7 @@ UNWIND(	.cantunwind)
 	bl	boot_core_hpen
 	ldm	r0, {r0, r6}
 #else
-	mov	r0, r5		/* ns-entry address */
+	mov	r0, r8		/* ns-entry address */
 	mov	r6, #0
 #endif
 	bl	boot_init_secondary


### PR DESCRIPTION
The NS entrypoint was originally backup from LR to R5. 
The commit f332e77c4b7c revises the register preservation to R8.
The way to retrieve the NS entrypoint for secondary cores should be updated as well.

Fixes: f332e77c4b7c ("core: arm: refactor boot argument handling")

