### PR TITLE
plat-aspeed: ast2700: use gic_init_v3()

### DIFF
--- a/core/arch/arm/plat-aspeed/platform_ast2700.c
+++ b/core/arch/arm/plat-aspeed/platform_ast2700.c
@@ -13,6 +13,7 @@
 
 register_phys_mem(MEM_AREA_IO_SEC, UART_BASE, SMALL_PAGE_SIZE);
 register_phys_mem(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem(MEM_AREA_IO_SEC, GICR_BASE, GICR_SIZE);
 
 register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
 
@@ -20,7 +21,7 @@ static struct serial8250_uart_data console_data;
 
 void boot_primary_init_intc(void)
 {
-	gic_init(0, GICD_BASE);
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
 }
 
 void boot_secondary_init_intc(void)

--- a/core/arch/arm/plat-aspeed/platform_config.h
+++ b/core/arch/arm/plat-aspeed/platform_config.h
@@ -26,6 +26,7 @@
 #elif defined(PLATFORM_FLAVOR_ast2700)
 #define GICD_BASE		0x12200000
 #define GICR_BASE		0x12280000
+#define GICR_SIZE		0x100000
 
 #define UART_BASE		0x14c33000
 #define UART12_BASE		(UART_BASE + 0xb00)


### PR DESCRIPTION
Use gic_init_v3() with the GICR base address.