### PR TITLE
plat-stm32mp1: increase default heap size when pager enabled

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -315,7 +315,7 @@ CFG_LOCKDEP ?= n
 CFG_TA_BGET_TEST ?= n
 # Default disable early TA compression to support a smaller HEAP size
 CFG_EARLY_TA_COMPRESS ?= n
-CFG_CORE_HEAP_SIZE ?= 49152
+CFG_CORE_HEAP_SIZE ?= 53248
 endif
 
 # Non-secure UART and GPIO/pinctrl for the output console


### PR DESCRIPTION
When pager is enabled on STM32MP15 variant, the default heap size was set 48kB (instead of default 64kB set from mk/config.mk) in order to relax pressure on pager page pool. Increase this platform default value to 52kB to pass some xtest regression test that may fail in recent OP-TEE release when RPMB_FS is enabled.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
