### PR TITLE
caam: provide plat_rng_init if CFG_WITH_SOFTWARE_PRNG=y 

### DIFF
--- a/core/drivers/crypto/caam/caam_rng.c
+++ b/core/drivers/crypto/caam/caam_rng.c
@@ -567,6 +567,27 @@ enum caam_status caam_rng_init(vaddr_t ctrl_addr)
 }
 
 #ifdef CFG_NXP_CAAM_RNG_DRV
+#ifdef CFG_WITH_SOFTWARE_PRNG
+void plat_rng_init(void)
+{
+	TEE_Result res = TEE_SUCCESS;
+	uint8_t buf[64] = { };
+
+	res = do_rng_read(buf, sizeof(buf));
+	if (res) {
+		EMSG("Failed to read RNG: %#" PRIx32, res);
+		panic();
+	}
+
+	res = crypto_rng_init(buf, sizeof(buf));
+	if (res) {
+		EMSG("Failed to initialize RNG: %#" PRIx32, res);
+		panic();
+	}
+
+	RNG_TRACE("PRNG seeded from CAAM");
+}
+#else /* !CFG_WITH_SOFTWARE_PRNG */
 TEE_Result hw_get_random_bytes(void *buf, size_t blen)
 {
 	if (!buf)
@@ -578,4 +599,5 @@ TEE_Result hw_get_random_bytes(void *buf, size_t blen)
 void plat_rng_init(void)
 {
 }
-#endif
+#endif /* CFG_WITH_SOFTWARE_PRNG */
+#endif /* CFG_NXP_CAAM_RNG_DRV */

--- a/core/drivers/crypto/caam/caam_rng.c
+++ b/core/drivers/crypto/caam/caam_rng.c
@@ -60,6 +60,7 @@ struct rngdata {
 struct rng_privdata {
 	vaddr_t baseaddr;                       /* RNG base address */
 	bool instantiated;                      /* RNG instantiated */
+	bool pr_enabled;			/* RNG prediction resistance */
 	struct rngdata databuf[RNG_DATABUF_NB]; /* RNG Data generation */
 	uint8_t dataidx;                        /* Current RNG Data buffer */
 };
@@ -158,6 +159,10 @@ static enum caam_status prepare_gen_desc(struct rngdata *rng)
 {
 	paddr_t paddr = 0;
 	uint32_t *desc = NULL;
+	uint32_t op = RNG_GEN_DATA;
+
+	if (rng_privdata->pr_enabled)
+		op |= ALGO_RNG_PR;
 
 	/* Convert the buffer virtual address to physical address */
 	paddr = virt_to_phys(rng->data);
@@ -168,7 +173,7 @@ static enum caam_status prepare_gen_desc(struct rngdata *rng)
 
 	caam_desc_init(desc);
 	caam_desc_add_word(desc, DESC_HEADER(0));
-	caam_desc_add_word(desc, RNG_GEN_DATA);
+	caam_desc_add_word(desc, op);
 	caam_desc_add_word(desc, FIFO_ST(RNG_TO_MEM, rng->size));
 	caam_desc_add_ptr(desc, paddr);
 
@@ -523,8 +528,14 @@ enum caam_status caam_rng_instantiation(void)
 	} while (retstatus == CAAM_NO_ERROR);
 
 end_inst:
-	if (retstatus == CAAM_NO_ERROR)
+	if (retstatus == CAAM_NO_ERROR) {
 		rng_privdata->instantiated = true;
+		rng_privdata->pr_enabled =
+			caam_hal_rng_pr_enabled(rng_privdata->baseaddr);
+
+		RNG_TRACE("RNG prediction resistance is %sabled",
+			  rng_privdata->pr_enabled ? "en" : "dis");
+	}
 
 	caam_free_desc(&desc);
 

--- a/core/drivers/crypto/caam/crypto.mk
+++ b/core/drivers/crypto/caam/crypto.mk
@@ -143,9 +143,9 @@ CFG_CAAM_JR_DISABLE_NODE ?= y
 # Enable CAAM non-crypto drivers
 $(foreach drv, $(caam-drivers), $(eval CFG_NXP_CAAM_$(drv)_DRV ?= y))
 
-# Disable software RNG if CAAM RNG driver is enabled
+# Prefer CAAM HWRNG over PRNG seeded by CAAM
 ifeq ($(CFG_NXP_CAAM_RNG_DRV), y)
-$(call force, CFG_WITH_SOFTWARE_PRNG,n,Mandated by CFG_NXP_CAAM_RNG_DRV)
+CFG_WITH_SOFTWARE_PRNG ?= n
 endif
 
 # DEK driver requires the SM driver to be enabled

--- a/core/drivers/crypto/caam/hal/common/hal_rng.c
+++ b/core/drivers/crypto/caam/hal/common/hal_rng.c
@@ -62,6 +62,16 @@ bool caam_hal_rng_key_loaded(vaddr_t baseaddr)
 	return io_caam_read32(baseaddr + RNG_STA) & RNG_STA_SKVN;
 }
 
+bool caam_hal_rng_pr_enabled(vaddr_t baseaddr)
+{
+	uint32_t bitmask = RNG_STA_PR0;
+
+	if (caam_hal_rng_get_nb_sh(baseaddr) > 1)
+		bitmask |= RNG_STA_PR1;
+
+	return (io_caam_read32(baseaddr + RNG_STA) & bitmask) == bitmask;
+}
+
 enum caam_status caam_hal_rng_kick(vaddr_t baseaddr, uint32_t inc_delay)
 {
 	uint32_t val = 0;

--- a/core/drivers/crypto/caam/hal/common/registers/rng_regs.h
+++ b/core/drivers/crypto/caam/hal/common/registers/rng_regs.h
@@ -115,5 +115,7 @@
 #define RNG_STA_SKVN		BIT32(30)
 #define RNG_STA_IF1			BIT32(1)
 #define RNG_STA_IF0			BIT32(0)
+#define RNG_STA_PR0			BIT32(4)
+#define RNG_STA_PR1			BIT32(5)
 
 #endif /* __RNG_REGS_H__ */

--- a/core/drivers/crypto/caam/include/caam_hal_rng.h
+++ b/core/drivers/crypto/caam/include/caam_hal_rng.h
@@ -40,6 +40,13 @@ uint32_t caam_hal_rng_get_sh_status(vaddr_t baseaddr);
 bool caam_hal_rng_key_loaded(vaddr_t baseaddr);
 
 /*
+ * Returns true if the RNG was initialized for prediction resistance
+ *
+ * @baseaddr  RNG Base Address
+ */
+bool caam_hal_rng_pr_enabled(vaddr_t baseaddr);
+
+/*
  * Configures the RNG entropy delay
  *
  * @baseaddr   RNG Base Address


### PR DESCRIPTION
With CFG_NXP_CAAM_RNG_DRV enabled, OP-TEE will use the CAAM
to generate random numbers. Normal world access to the RNG is still
possible as the CAAM is TrustZone aware and provides multiple separate
job rings.

For complete isolation, however, access to CAAM reset and clocks need to
be managed as well. This could be done in theory by restricting access
to the reset and clock controller peripherals to the secure world and
exporting limited access to some resources via SCMI. There is no such
support yet for the i.MX and thus some setups may prefer to avoid using
the CAAM in OP-TEE to stay safe from normal world inducing glitches.

These setups may still need random numbers in OP-TEE. Therefore, access
so have them
access the CAAM only once at startup to initialize OP-TEE's PRNG and
defer subsequent use of the CAAM to the normal world, whenever
CFG_WITH_SOFTWARE_PRNG=y.

To improve RNG quality, the preparatory patches enable prediction resistance if
possible: This instructs the CAAM to wait if low on entropy, which will also benefit
users with CFG_WITH_SOFTWARE_PRNG=n.

This PR can be considered a continuation of both PR #3721 and PR #5145.

---

Cc: @clementfaure
Cc: @emantor