### PR TITLE
core: ffa: fix FFA_NOTIFICATION_GET vm_id

### DIFF
--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1517,7 +1517,7 @@ static void handle_notification_get(struct thread_smc_args *args)
 		w2 = 0;
 		goto out;
 	}
-	vm_id = FFA_SRC(args->a1);
+	vm_id = FFA_DST(args->a1);
 
 	old_itr_status = cpu_spin_lock_xsave(&spmc_notif_lock);
 


### PR DESCRIPTION
handle_notification_get() has until now read the receiver endpoint ID from the upper 16 bits of w1, but the receiver endpoint ID is passed in the lower 16 bits of w1 passed to FFA_NOTIFICATION_GET. So fix the function to read the lower 16 bits instead.

Fixes: 2e02a7374b86 ("core: ffa: add notifications with SPMC at S-EL1")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
