### PR TITLE
plat-mediatek: disable console when CFG_TEE_CORE_LOG_LEVEL is 0

### DIFF
--- a/core/arch/arm/plat-mediatek/main.c
+++ b/core/arch/arm/plat-mediatek/main.c
@@ -12,8 +12,10 @@
 #include <platform_config.h>
 #include <stdint.h>
 
+#if (CFG_TEE_CORE_LOG_LEVEL != 0)
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC,
 			CONSOLE_UART_BASE, SERIAL8250_UART_REG_SIZE);
+#endif
 
 static struct serial8250_uart_data console_data;
 
@@ -33,7 +35,9 @@ void boot_primary_init_intc(void)
 
 void console_init(void)
 {
-	serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
-			     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
-	register_serial_console(&console_data.chip);
+	if (CFG_TEE_CORE_LOG_LEVEL != 0) {
+		serial8250_uart_init(&console_data, CONSOLE_UART_BASE,
+				     CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+		register_serial_console(&console_data.chip);
+	}
 }


### PR DESCRIPTION
Following our usage, it can be interesting to disable the console, typically for a final product.