### PR TITLE
scripts: checkpatch: fix word splitting in the command

### DIFF
--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -23,7 +23,7 @@ function _checkpatch() {
 				typedefs_opt="";
 		# Ignore NOT_UNIFIED_DIFF in case patch has no diff
 		# (e.g., all paths filtered out)
-		$CHECKPATCH $CHECKPATCH_OPT $typedefs_opt -
+		eval "$CHECKPATCH $CHECKPATCH_OPT $typedefs_opt -"
 }
 
 function checkpatch() {


### PR DESCRIPTION
The following would fail with Zsh instead of Bash : $ source ./scripts/checkpatch_inc.sh
$ checkpatch HEAD
Unknown option: typedefsfile typedefs.checkpatch
Usage: .../scripts/checkpatch.pl [OPTION]... [FILE]

By setting xtrace in the _checkpatch() function, we can see the built command is interpreted differently depending on the shell:
	$CHECKPATCH $CHECKPATCH_OPT $typedefs_opt -
In Zsh:
	/scripts/checkpatch.pl '--typedefsfile typedefs.checkpatch' -
In Bash:
	/scripts/checkpatch.pl --typedefsfile typedefs.checkpatch -

Bash differs from Zsh when it comes to word splitting for unquoted parameters expansions.
One solution is to use `eval` to execute the built command.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
