### PR TITLE
crypto: fix an issue of multiple tasks using the same qp

### DIFF
--- a/core/drivers/crypto/hisilicon/include/hisi_qm.h
+++ b/core/drivers/crypto/hisilicon/include/hisi_qm.h
@@ -134,6 +134,7 @@ struct hisi_qp {
 	uint16_t sq_tail;
 	uint16_t cq_head;
 	bool cqc_phase;
+	bool used;
 
 	void *sqe;
 	struct qm_cqe *cqe;


### PR DESCRIPTION
Flag in the qp structure is used to indicate whether the qp is occupied.The new task can find an unused qp and use it.

Fixes: c7f9abcee87f ("drivers: implement HiSilicon Queue Management (QM) module")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
