### PR TITLE
core: ffa: return fpi size from FFA_PARTITION_INFO_GET

### DIFF
--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -501,6 +501,7 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 {
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t ret_fid = FFA_ERROR;
+	uint32_t fpi_size = 0;
 	uint32_t rc = 0;
 	bool count_only = args->a5 & FFA_PARTITION_INFO_GET_COUNT_FLAG;
 
@@ -574,7 +575,11 @@ void spmc_handle_partition_info_get(struct thread_smc_args *args,
 	ret_fid = FFA_SUCCESS_32;
 
 out:
-	spmc_set_args(args, ret_fid, FFA_PARAM_MBZ, rc, FFA_PARAM_MBZ,
+	if (ret_fid == FFA_SUCCESS_32 && !count_only &&
+	    rxtx->ffa_vers >= FFA_VERSION_1_1)
+		fpi_size = sizeof(struct ffa_partition_info_x) + FFA_UUID_SIZE;
+
+	spmc_set_args(args, ret_fid, FFA_PARAM_MBZ, rc, fpi_size,
 		      FFA_PARAM_MBZ, FFA_PARAM_MBZ);
 	if (!count_only) {
 		rxtx->tx_is_mine = false;


### PR DESCRIPTION
Until now has FFA_PARTITION_INFO_GET always returned zero in w3, but FF-A v1.1 requires FFA_PARTITION_INFO_GET to return the size of each partition information descriptor returned if
FFA_PARTITION_INFO_GET_COUNT_FLAG isn't set. So fix this by returning the size of a FF-A v1.1 partition information descriptor in w3.

Fixes: a1c53023cc80 ("core: spmc: support FF-A 1.1")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
