### PR TITLE
core: arm: allow cache_op_outer() to operate on non-secure buffers

### DIFF
--- a/core/arch/arm/include/kernel/tz_ssvce_pl310.h
+++ b/core/arch/arm/include/kernel/tz_ssvce_pl310.h
@@ -11,6 +11,8 @@
 #include <types_ext.h>
 
 vaddr_t pl310_base(void);
+vaddr_t pl310_nsbase(void);
+
 /*
  * End address is included in the range (last address in range)
  */

--- a/core/arch/arm/kernel/tz_ssvce_pl310_a32.S
+++ b/core/arch/arm/kernel/tz_ssvce_pl310_a32.S
@@ -222,3 +222,14 @@ FUNC arm_cl2_cleaninvbypa , :
 	b	_arm_cl2_xxxbypa
 END_FUNC arm_cl2_cleaninvbypa
 
+/*
+ * __weak vaddr_t pl310_nsbase(void);
+ * return the non-secure PL310 base address
+ *
+ * Weak implementation to preserve the previous behavior where only the
+ * secure PL310 base address was returned. Up to the platform to map
+ * and return non-secure PL310 base address.
+ */
+WEAK_FUNC pl310_nsbase , :
+	b	pl310_base
+END_FUNC pl310_nsbase

--- a/core/arch/arm/plat-imx/imx_pl310.c
+++ b/core/arch/arm/plat-imx/imx_pl310.c
@@ -23,6 +23,7 @@
 #define PL310_PREFETCH_DOUBLE_LINEFILL		BIT(30)
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, PL310_BASE, CORE_MMU_PGDIR_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, PL310_BASE, CORE_MMU_PGDIR_SIZE);
 
 void arm_cl2_config(vaddr_t pl310_base)
 {
@@ -81,6 +82,11 @@ void arm_cl2_enable(vaddr_t pl310_base)
 vaddr_t pl310_base(void)
 {
 	return core_mmu_get_va(PL310_BASE, MEM_AREA_IO_SEC, 1);
+}
+
+vaddr_t pl310_nsbase(void)
+{
+	return core_mmu_get_va(PL310_BASE, MEM_AREA_IO_NSEC, 1);
 }
 
 #ifdef CFG_PL310_SIP_PROTOCOL


### PR DESCRIPTION
Hello!
I'm digging out an old issue with the PL310 cache controller : https://github.com/OP-TEE/optee_os/issues/4783
I'm not sure if I proceeded well for platform specific implementation.
Let me know what you think!