### PR TITLE
PKCS11: add the possibility of giving rights to a TA when we use ACL to manage PKCS11 acces

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -937,7 +937,7 @@ enum pkcs11_user_type {
  * - PIN value: group:<client UUID string>
  *   - TEE group login with client UUID matching group credentials
  * - PIN value: ta:<client UUID string>
- *   - TEE trusted app login with client UUID matching TA UUID
+ *   - TEE trusted application login with client UUID matching TA UUID
  */
 
 /* Keywords for protected authenticated path PIN parser */

--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -936,12 +936,15 @@ enum pkcs11_user_type {
  *   - TEE user login with client UUID matching user credentials
  * - PIN value: group:<client UUID string>
  *   - TEE group login with client UUID matching group credentials
+ * - PIN value: ta:<client UUID string>
+ *   - TEE trusted app login with client UUID matching TA UUID
  */
 
 /* Keywords for protected authenticated path PIN parser */
 #define PKCS11_AUTH_TEE_IDENTITY_PUBLIC	"public"
 #define PKCS11_AUTH_TEE_IDENTITY_USER	"user:"
 #define PKCS11_AUTH_TEE_IDENTITY_GROUP	"group:"
+#define PKCS11_AUTH_TEE_IDENTITY_TA 	"ta:"
 
 /*
  * Values for 32bit session flags argument to PKCS11_CMD_OPEN_SESSION

--- a/ta/pkcs11/src/persistent_token.c
+++ b/ta/pkcs11/src/persistent_token.c
@@ -193,6 +193,9 @@ enum pkcs11_rc setup_identity_auth_from_pin(struct ck_token *token,
 		} else if (strstr(acl_string, PKCS11_AUTH_TEE_IDENTITY_GROUP) ==
 			   acl_string) {
 			identity.login = TEE_LOGIN_GROUP;
+		} else if (strstr(acl_string, PKCS11_AUTH_TEE_IDENTITY_TA) ==
+			   acl_string) {
+			identity.login = TEE_LOGIN_TRUSTED_APP;
 		} else {
 			EMSG("Invalid PIN ACL string - login");
 			TEE_Free(acl_string);


### PR DESCRIPTION
We need to push RSA/ECC keys from a custom TA to PKCS11 TA
The custom TA will decrypt the secret based on chipset secret unique key and push it to PKCS11 TA

When we use ACL to manage access to PKCS11 slot, we must be able to give rigths
to the custom TA for  pushing the keys in the slot.
This is needed because it's not possible to pass from a pincode  to acl mode
