### PR TITLE
Fix some warnings on SAM platforms

### DIFF
--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -39,6 +39,9 @@ $(call force,CFG_CORE_HAS_GENERIC_TIMER,n)
 $(call force,CFG_TZDRAM_START,0x20000000)
 $(call force,CFG_TZDRAM_SIZE,0x800000)
 
+# This value is forced because this feature isn't used by SAM platforms.
+$(call force,CFG_EXTERNAL_DT,n)
+
 CFG_MMAP_REGIONS ?= 24
 
 CFG_SHMEM_START  ?= 0x21000000


### PR DESCRIPTION
Fully disable the support of external device tree on SAM platforms because it isn't used, to fix the following warning:
`I/TC: Non-secure external DT found`

<s>And disable by default insecure configurations, to remove the following warning:
`I/TC: WARNING: This OP-TEE configuration might be insecure!`</s>