### PR TITLE
dts: add stm32mp15*-scmi.dts files for when RCC is secure

### DIFF
--- a/core/arch/arm/dts/stm32mp157a-dk1-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1-scmi.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023
+ */
+
+/dts-v1/;
+
+#include "stm32mp157a-dk1.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157A-DK1 SCMI Discovery Board";
+	compatible = "st,stm32mp157a-dk1-scmi", "st,stm32mp157";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp157c-dk2-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2-scmi.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023
+ */
+
+/dts-v1/;
+
+#include "stm32mp157c-dk2.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157C-DK2 SCMI Discovery Board";
+	compatible = "st,stm32mp157c-dk2-scmi", "st,stm32mp157";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp157c-ed1-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1-scmi.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023
+ */
+/dts-v1/;
+
+#include "stm32mp157c-ed1.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157C SCMI eval daughter";
+	compatible = "st,stm32mp157c-ed1-scmi", "st,stm32mp157";
+};
+
+&iwdg1 {
+	timeout-sec = <32>;
+};
+
+&iwdg2 {
+	timeout-sec = <32>;
+	status = "okay";
+	secure-status = "disabled";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -338,7 +338,7 @@
 };
 
 &rcc {
-	compatible = "st,stm32mp1-rcc-secure";
+	compatible = "st,stm32mp1-rcc";
 	status = "okay";
 };
 

--- a/core/arch/arm/dts/stm32mp157c-ev1-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157c-ev1-scmi.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2023
+ */
+/dts-v1/;
+
+#include "stm32mp157c-ev1.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157C SCMI eval daughter on eval mother";
+	compatible = "st,stm32mp157c-ev1-scmi", "st,stm32mp157c-ed1-scmi", "st,stm32mp157";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
@@ -490,7 +490,7 @@
 };
 
 &rcc {
-	compatible = "st,stm32mp1-rcc-secure";
+	compatible = "st,stm32mp1-rcc";
 	status = "okay";
 };
 

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -5,17 +5,25 @@ flavor_dts_file-157C_DHCOM_PDK2 = stm32mp157c-dhcom-pdk2.dts
 flavor_dts_file-157C_DK2 = stm32mp157c-dk2.dts
 flavor_dts_file-157C_ED1 = stm32mp157c-ed1.dts
 flavor_dts_file-157C_EV1 = stm32mp157c-ev1.dts
+flavor_dts_file-157A_DK1_SCMI = stm32mp157a-dk1-scmi.dts
+flavor_dts_file-157C_DK2_SCMI = stm32mp157c-dk2-scmi.dts
+flavor_dts_file-157C_ED1_SCMI = stm32mp157c-ed1-scmi.dts
+flavor_dts_file-157F_EV1_SCMI = stm32mp157c-ev1-scmi.dts
 
 flavor_dts_file-135F_DK = stm32mp135f-dk.dts
 
 flavorlist-cryp-512M = $(flavor_dts_file-157C_DK2) \
+		       $(flavor_dts_file-157C_DK2_SCMI) \
 		       $(flavor_dts_file-135F_DK)
 
-flavorlist-no_cryp-512M = $(flavor_dts_file-157A_DK1)
+flavorlist-no_cryp-512M = $(flavor_dts_file-157A_DK1) \
+			  $(flavor_dts_file-157A_DK1_SCMI)
 
 flavorlist-cryp-1G = $(flavor_dts_file-157C_DHCOM_PDK2) \
 		     $(flavor_dts_file-157C_ED1) \
-		     $(flavor_dts_file-157C_EV1)
+		     $(flavor_dts_file-157C_EV1) \
+		     $(flavor_dts_file-157C_ED1_SCMI) \
+		     $(flavor_dts_file-157C_EV1_SCMI)
 
 flavorlist-no_cryp-1G = $(flavor_dts_file-157A_DHCOR_AVENGER96)
 
@@ -31,14 +39,22 @@ flavorlist-1G = $(flavorlist-cryp-1G) \
 flavorlist-MP15-HUK-DT = $(flavor_dts_file-157A_DK1) \
 			 $(flavor_dts_file-157C_DK2) \
 			 $(flavor_dts_file-157C_ED1) \
-			 $(flavor_dts_file-157C_EV1)
+			 $(flavor_dts_file-157C_EV1) \
+			 $(flavor_dts_file-157A_DK1_SCMI) \
+			 $(flavor_dts_file-157C_DK2_SCMI) \
+			 $(flavor_dts_file-157C_ED1_SCMI) \
+			 $(flavor_dts_file-157C_EV1_SCMI)
 
 flavorlist-MP15 = $(flavor_dts_file-157A_DHCOR_AVENGER96) \
 		  $(flavor_dts_file-157A_DK1) \
 		  $(flavor_dts_file-157C_DHCOM_PDK2) \
 		  $(flavor_dts_file-157C_DK2) \
 		  $(flavor_dts_file-157C_ED1) \
-		  $(flavor_dts_file-157C_EV1)
+		  $(flavor_dts_file-157C_EV1) \
+		  $(flavor_dts_file-157A_DK1_SCMI) \
+		  $(flavor_dts_file-157C_DK2_SCMI) \
+		  $(flavor_dts_file-157C_ED1_SCMI) \
+		  $(flavor_dts_file-157C_EV1_SCMI)
 
 flavorlist-MP13 = $(flavor_dts_file-135F_DK)
 


### PR DESCRIPTION
For legacy reason and compatibility with existing platforms embedding OP-TEE with RCC secure hardening being disabled, introduce _-scmi.dts_ for the 4 ST boards STM32MP15x: DK1, DK2, ED1 and EV1 where we enable RCC security require non-secure world to use SCMI resources. Add platform flavors `157x_XXX_SCMI` to ease DTS selection.

_stm32mp15*-<board>.dts_ applies an insecure RCC configuration. _stm32mp15*-<board>-scmi.dts_ applies the secure RCC configuration. This better reflects the configurations supported in the Linux kernel and U-Boot source trees.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
