### PR TITLE
core: arm: collect all .nex_nozi sections

### DIFF
--- a/core/arch/arm/kernel/kern.ld.S
+++ b/core/arch/arm/kernel/kern.ld.S
@@ -211,6 +211,7 @@ SECTIONS
 	.nex_nozi (NOLOAD) : {
 		ASSERT(!(ABSOLUTE(.) & (16 * 1024 - 1)), "align nozi to 16kB");
 		KEEP(*(.nozi.mmu.base_table .nozi.mmu.l2))
+		KEEP(*(.nex_nozi .nex_nozi.*))
 	}
 
 	. = ALIGN(SMALL_PAGE_SIZE);


### PR DESCRIPTION
.nex_nozi.xxx was prior to this patch not gathered together with the other no-zero-initialize sections used by the nexus in a ns-virtualisation configuration. Fix this by gathering .nex_nozi .nex_nozi.* in .nex_nozi.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
