### PR TITLE
core: fixup of transfer list header size

### DIFF
--- a/core/include/kernel/transfer_list.h
+++ b/core/include/kernel/transfer_list.h
@@ -57,6 +57,7 @@ struct transfer_list_header {
 	uint32_t size;		/* TL header + all transfer entries */
 	uint32_t max_size;
 	uint32_t flags;
+	uint32_t reserved;	/* spare bytes */
 	/*
 	 * Commented out element used to visualize dynamic part of the
 	 * data structure.


### PR DESCRIPTION
Add 4 reserved bytes at the tail of the transfer list header. This fixes a non-8-bytes aligned header when "flags" was introduced into the header.

Fixes: 508e2476b232 ("core: update transfer list header and signature")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
