### PR TITLE
ta: pkcs11: fixes for check value attribute

### DIFF
--- a/ta/pkcs11/src/object.c
+++ b/ta/pkcs11/src/object.c
@@ -988,6 +988,8 @@ enum pkcs11_rc entry_set_attribute_value(struct pkcs11_client *client,
 	size_t template_size = 0;
 	struct pkcs11_object *obj = NULL;
 	struct obj_attrs *head = NULL;
+	struct obj_attrs *head_new = NULL;
+	struct obj_attrs *head_old = NULL;
 	uint32_t object_handle = 0;
 	enum processing_func function = PKCS11_FUNCTION_MODIFY;
 
@@ -1061,30 +1063,50 @@ enum pkcs11_rc entry_set_attribute_value(struct pkcs11_client *client,
 	if (rc)
 		goto out;
 
+	/* Create new object attributes to modify */
+	template_size = sizeof(*obj->attributes) + obj->attributes->attrs_size;
+	head_new = TEE_Malloc(template_size, TEE_MALLOC_FILL_ZERO);
+	if (!head_new) {
+		rc = PKCS11_CKR_DEVICE_MEMORY;
+		goto out;
+	}
+
+	TEE_MemMove(head_new, obj->attributes, template_size);
+
 	/*
 	 * All checks complete. The attributes in @head have been checked and
 	 * can now be used to set/modify the object attributes.
 	 */
-	rc = modify_attributes_list(&obj->attributes, head);
+	rc = modify_attributes_list(&head_new, head);
 	if (rc)
 		goto out;
 
 	/* Set key check value attribute */
-	rc = set_check_value_attr(&obj->attributes);
+	rc = set_check_value_attr(&head_new);
 	if (rc)
 		goto out;
 
+	/* Update the object */
+	head_old = obj->attributes;
+	obj->attributes = head_new;
+	head_new = NULL;
+
 	if (get_bool(obj->attributes, PKCS11_CKA_TOKEN)) {
 		rc = update_persistent_object_attributes(obj);
-		if (rc)
+		if (rc) {
+			obj->attributes = head_old;
 			goto out;
+		}
 	}
+
+	TEE_Free(head_old);
 
 	DMSG("PKCS11 session %"PRIu32": set attributes %#"PRIx32,
 	     session->handle, object_handle);
 
 out:
 	TEE_Free(head);
+	TEE_Free(head_new);
 	TEE_Free(template);
 	return rc;
 }

--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -2979,7 +2979,7 @@ enum pkcs11_rc set_check_value_attr(struct obj_attrs **head)
 		return PKCS11_CKR_OK;
 
 	if (rc == PKCS11_CKR_OK && kcv2_len != PKCS11_CKA_CHECK_VALUE_SIZE)
-		return PKCS11_CKR_TEMPLATE_INCONSISTENT;
+		return PKCS11_CKR_ATTRIBUTE_VALUE_INVALID;
 
 	/* Get key CKA_VALUE */
 	rc = get_attribute_ptr(*head, PKCS11_CKA_VALUE, &val, &val_len);


### PR DESCRIPTION
Return `PKCS11_CKR_ATTRIBUTE_VALUE_INVALID` instead of a template inconsistency when the key check value attribute is wrong due to its size.

Preserve original object attributes when C_SetAttributeValue service fails instead of possibly changing object attributes before the whole new attribute set is validated.
