### PR TITLE
driver: crypto: hisilicon: Add the mailbox operation lock

### DIFF
--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -373,6 +373,19 @@ static inline void write_64bit_pair(uint64_t dst, uint64_t hi, uint64_t lo)
 		      "r" (hi), "r" (lo), "r" (dst) : "memory");
 }
 
+static inline void read_64bit_pair(uint64_t src, uint64_t *hi, uint64_t *lo)
+{
+	uint64_t tmp0 = 0;
+	uint64_t tmp1 = 0;
+
+	/* 128bits should be read from hardware at one time */
+	asm volatile ("ldp %0, %1, [%2]\n" : "=&r"(tmp0), "=&r"(tmp1) :
+		      "r"(src) : "memory");
+
+	*lo = tmp0;
+	*hi = tmp1;
+}
+
 /*
  * Templates for register read/write functions based on mrs/msr
  */

--- a/core/drivers/crypto/hisilicon/include/hisi_qm.h
+++ b/core/drivers/crypto/hisilicon/include/hisi_qm.h
@@ -34,9 +34,11 @@
 #define HISI_QM_REVISON_ID_MASK GENMASK_32(7, 0)
 #define POLL_PERIOD 10
 #define POLL_TIMEOUT 1000
-#define HISI_QM_RECV_SYNC_TIMEOUT 0xfffffff
+#define HISI_QM_RECV_SYNC_TIMEOUT 0xfffff
 #define HISI_QM_ALIGN128 128
 #define HISI_QM_ALIGN32 32
+#define QM_SINGLE_WAIT_TIME 5
+#define ADDR_U64(upper, lower) ((uint64_t)(upper) << 32 | (lower))
 
 enum qm_fun_type {
 	HISI_QM_HW_PF,
@@ -164,6 +166,7 @@ struct hisi_qm {
 	uint32_t qp_idx;
 	struct hisi_qp *qp_array;
 	struct mutex qp_lock; /* protect the qp instance */
+	struct mutex mailbox_lock;
 
 	enum hisi_drv_status (*dev_status_check)(struct hisi_qm *qm);
 };


### PR DESCRIPTION
1. mailbox operation need lock to ensure atomicity.
2. Optimize the mailbox read and write operations.

Fixes: c7f9abcee87f ("drivers: implement HiSilicon Queue Management (QM) module")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
