### PR TITLE
Add missing clk.h include in clk_dt.h

### DIFF
--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -6,6 +6,7 @@
 #ifndef __DRIVERS_CLK_DT_H
 #define __DRIVERS_CLK_DT_H
 
+#include <drivers/clk.h>
 #include <kernel/dt_driver.h>
 #include <scattered_array.h>
 #include <stdint.h>


### PR DESCRIPTION
This header file does not include clk.h. Just declare `struct clk;` so that the dependency is handled.