### PR TITLE
dts: add stm32mp15*-scmi.dts files for when RCC is secure [my proposal]

### DIFF
--- a/core/arch/arm/dts/stm32mp157a-dk1-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157a-dk1-scmi.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2019, 2023
+ */
+
+/dts-v1/;
+
+#include "stm32mp157a-dk1.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157A-DK1 SCMI Discovery Board";
+	compatible = "st,stm32mp157a-dk1-scmi", "st,stm32mp157";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp157c-dk2-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157c-dk2-scmi.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2019, 2023
+ */
+
+/dts-v1/;
+
+#include "stm32mp157c-dk2.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157C-DK2 SCMI Discovery Board";
+	compatible = "st,stm32mp157c-dk2-scmi", "st,stm32mp157";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp157c-ed1-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1-scmi.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2017, 2023
+ */
+/dts-v1/;
+
+#include "stm32mp157c-ed1.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157C SCMI eval daughter";
+	compatible = "st,stm32mp157c-ed1-scmi", "st,stm32mp157";
+};
+
+&iwdg1 {
+	timeout-sec = <32>;
+};
+
+&iwdg2 {
+	timeout-sec = <32>;
+	status = "okay";
+	secure-status = "disabled";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
 /*
- * Copyright (C) STMicroelectronics 2017 - All Rights Reserved
- * Author: Ludovic Barre <ludovic.barre@st.com> for STMicroelectronics.
+ * Copyright (C) STMicroelectronics 2017, 2023
  */
 /dts-v1/;
 
@@ -338,7 +337,7 @@
 };
 
 &rcc {
-	compatible = "st,stm32mp1-rcc-secure";
+	compatible = "st,stm32mp1-rcc";
 	status = "okay";
 };
 

--- a/core/arch/arm/dts/stm32mp157c-ev1-scmi.dts
+++ b/core/arch/arm/dts/stm32mp157c-ev1-scmi.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/*
+ * Copyright (C) STMicroelectronics 2017, 2023
+ */
+/dts-v1/;
+
+#include "stm32mp157c-ev1.dts"
+
+/ {
+	model = "STMicroelectronics STM32MP157C SCMI eval daughter on eval mother";
+	compatible = "st,stm32mp157c-ev1-scmi", "st,stm32mp157c-ed1-scmi", "st,stm32mp157";
+};
+
+&rcc {
+	compatible = "st,stm32mp1-rcc-secure";
+	status = "okay";
+};

--- a/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dkx.dtsi
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
 /*
- * Copyright (C) STMicroelectronics 2019 - All Rights Reserved
- * Author: Alexandre Torgue <alexandre.torgue@st.com> for STMicroelectronics.
+ * Copyright (C) STMicroelectronics 2019, 2023
  */
 
 #include <dt-bindings/gpio/gpio.h>
@@ -490,7 +489,7 @@
 };
 
 &rcc {
-	compatible = "st,stm32mp1-rcc-secure";
+	compatible = "st,stm32mp1-rcc";
 	status = "okay";
 };
 

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -2,11 +2,18 @@ PLATFORM_FLAVOR ?= 157C_DK2
 
 # 1GB and 512MB DDR targets do not locate secure DDR at the same place.
 flavor_dts_file-157A_DHCOR_AVENGER96 = stm32mp157a-dhcor-avenger96.dts
-flavor_dts_file-157A_DK1 = stm32mp157a-dk1.dts
 flavor_dts_file-157C_DHCOM_PDK2 = stm32mp157c-dhcom-pdk2.dts
+ifeq (y,$(CFG_STM32MP1_RCC_SECURE))
+flavor_dts_file-157A_DK1 = stm32mp157a-dk1-scmi.dts
+flavor_dts_file-157C_DK2 = stm32mp157c-dk2-scmi.dts
+flavor_dts_file-157C_ED1 = stm32mp157c-ed1-scmi.dts
+flavor_dts_file-157C_EV1 = stm32mp157c-ev1-scmi.dts
+else
+flavor_dts_file-157A_DK1 = stm32mp157a-dk1.dts
 flavor_dts_file-157C_DK2 = stm32mp157c-dk2.dts
 flavor_dts_file-157C_ED1 = stm32mp157c-ed1.dts
 flavor_dts_file-157C_EV1 = stm32mp157c-ev1.dts
+endif
 
 flavor_dts_file-135F_DK = stm32mp135f-dk.dts
 

--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -1,3 +1,5 @@
+PLATFORM_FLAVOR ?= 157C_DK2
+
 # 1GB and 512MB DDR targets do not locate secure DDR at the same place.
 flavor_dts_file-157A_DHCOR_AVENGER96 = stm32mp157a-dhcor-avenger96.dts
 flavor_dts_file-157A_DK1 = stm32mp157a-dk1.dts
@@ -8,68 +10,55 @@ flavor_dts_file-157C_EV1 = stm32mp157c-ev1.dts
 
 flavor_dts_file-135F_DK = stm32mp135f-dk.dts
 
-flavorlist-cryp-512M = $(flavor_dts_file-157C_DK2) \
-		       $(flavor_dts_file-135F_DK)
+flavorlist-cryp-512M = 157C_DK2 135F_DK
 
-flavorlist-no_cryp-512M = $(flavor_dts_file-157A_DK1)
+flavorlist-no_cryp-512M = 157A_DK1
 
-flavorlist-cryp-1G = $(flavor_dts_file-157C_DHCOM_PDK2) \
-		     $(flavor_dts_file-157C_ED1) \
-		     $(flavor_dts_file-157C_EV1)
+flavorlist-cryp-1G = 157C_DHCOM_PDK2 157C_ED1 157C_EV1
 
-flavorlist-no_cryp-1G = $(flavor_dts_file-157A_DHCOR_AVENGER96)
+flavorlist-no_cryp-1G = 157A_DHCOR_AVENGER96
 
 flavorlist-no_cryp = $(flavorlist-no_cryp-512M) \
-		  $(flavorlist-no_cryp-1G)
+		     $(flavorlist-no_cryp-1G)
 
 flavorlist-512M = $(flavorlist-cryp-512M) \
 		  $(flavorlist-no_cryp-512M)
 
 flavorlist-1G = $(flavorlist-cryp-1G) \
-		  $(flavorlist-no_cryp-1G)
+		$(flavorlist-no_cryp-1G)
 
-flavorlist-MP15-HUK-DT = $(flavor_dts_file-157A_DK1) \
-			 $(flavor_dts_file-157C_DK2) \
-			 $(flavor_dts_file-157C_ED1) \
-			 $(flavor_dts_file-157C_EV1)
+flavorlist-MP15-HUK-DT = 157A_DK1 157C_DK2 157C_ED1 157C_EV1
 
-flavorlist-MP15 = $(flavor_dts_file-157A_DHCOR_AVENGER96) \
-		  $(flavor_dts_file-157A_DK1) \
-		  $(flavor_dts_file-157C_DHCOM_PDK2) \
-		  $(flavor_dts_file-157C_DK2) \
-		  $(flavor_dts_file-157C_ED1) \
-		  $(flavor_dts_file-157C_EV1)
+flavorlist-MP15 = 157A_DHCOR_AVENGER96 157A_DK1 157C_DHCOM_PDK2 157C_DK2 \
+		  157C_ED1 157C_EV1
 
-flavorlist-MP13 = $(flavor_dts_file-135F_DK)
+flavorlist-MP13 = 135F_DK
 
-ifneq ($(PLATFORM_FLAVOR),)
 ifeq ($(flavor_dts_file-$(PLATFORM_FLAVOR)),)
 $(error Invalid platform flavor $(PLATFORM_FLAVOR))
 endif
 CFG_EMBED_DTB_SOURCE_FILE ?= $(flavor_dts_file-$(PLATFORM_FLAVOR))
-endif
-CFG_EMBED_DTB_SOURCE_FILE ?= stm32mp157c-dk2.dts
 
-ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-no_cryp)),)
+ifneq ($(filter $(PLATFORM_FLAVOR),$(flavorlist-no_cryp)),)
 $(call force,CFG_STM32_CRYP,n)
 $(call force,CFG_STM32_SAES,n)
 endif
 
-ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-no_rng)),)
+ifneq ($(filter $(PLATFORM_FLAVOR),$(flavorlist-no_rng)),)
 $(call force,CFG_HWRNG_PTA,n)
 $(call force,CFG_WITH_SOFTWARE_PRNG,y)
 endif
 
-ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-MP15-HUK-DT)),)
+ifneq ($(filter $(PLATFORM_FLAVOR),$(flavorlist-MP15-HUK-DT)),)
 CFG_STM32MP15_HUK ?= y
 CFG_STM32_HUK_FROM_DT ?= y
 endif
 
-ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-MP13)),)
+ifneq ($(filter $(PLATFORM_FLAVOR),$(flavorlist-MP13)),)
 $(call force,CFG_STM32MP13,y)
 endif
 
-ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-MP15)),)
+ifneq ($(filter $(PLATFORM_FLAVOR),$(flavorlist-MP15)),)
 $(call force,CFG_STM32MP15,y)
 endif
 
@@ -154,7 +143,7 @@ ifneq ($(CFG_WITH_LPAE),y)
 CFG_TEE_RAM_VA_SIZE ?= 0x00200000
 endif
 
-ifneq ($(filter $(CFG_EMBED_DTB_SOURCE_FILE),$(flavorlist-512M)),)
+ifneq ($(filter $(PLATFORM_FLAVOR),$(flavorlist-512M)),)
 CFG_TZDRAM_START ?= 0xde000000
 CFG_DRAM_SIZE    ?= 0x20000000
 endif


### PR DESCRIPTION
Alternative implementation of #6541.