### PR TITLE
drivers: stm32_iwdg: fix config + prepare for watchdog early interrupt

### DIFF
--- a/core/drivers/stm32_iwdg.c
+++ b/core/drivers/stm32_iwdg.c
@@ -90,8 +90,6 @@ struct stm32_iwdg_device {
 	SLIST_ENTRY(stm32_iwdg_device) link;
 };
 
-static unsigned int iwdg_lock = SPINLOCK_UNLOCK;
-
 static SLIST_HEAD(iwdg_dev_list_head, stm32_iwdg_device) iwdg_dev_list =
 	SLIST_HEAD_INITIALIZER(iwdg_dev_list_head);
 
@@ -250,18 +248,6 @@ static const struct wdt_ops stm32_iwdg_ops = {
 	.set_timeout = iwdg_wdt_set_timeout,
 };
 DECLARE_KEEP_PAGER(stm32_iwdg_ops);
-
-/* Refresh all registered watchdogs */
-void stm32_iwdg_refresh(void)
-{
-	struct stm32_iwdg_device *iwdg = NULL;
-	uint32_t exceptions = cpu_spin_lock_xsave(&iwdg_lock);
-
-	SLIST_FOREACH(iwdg, &iwdg_dev_list, link)
-		iwdg_refresh(iwdg);
-
-	cpu_spin_unlock_xrestore(&iwdg_lock, exceptions);
-}
 
 /* Driver initialization */
 static TEE_Result stm32_iwdg_parse_fdt(struct stm32_iwdg_device *iwdg,

--- a/core/drivers/stm32_iwdg.c
+++ b/core/drivers/stm32_iwdg.c
@@ -134,7 +134,7 @@ static TEE_Result iwdg_wait_sync(struct stm32_iwdg_device *iwdg)
 		if (timeout_elapsed(timeout_ref))
 			break;
 
-	if (!(io_read32(iwdg_base + IWDG_SR_OFFSET) & IWDG_SR_UPDATE_MASK))
+	if (io_read32(iwdg_base + IWDG_SR_OFFSET) & IWDG_SR_UPDATE_MASK)
 		return TEE_ERROR_GENERIC;
 
 	return TEE_SUCCESS;

--- a/core/include/drivers/stm32_iwdg.h
+++ b/core/include/drivers/stm32_iwdg.h
@@ -26,8 +26,4 @@ struct stm32_iwdg_otp_data {
  */
 TEE_Result stm32_get_iwdg_otp_config(paddr_t pbase,
 				     struct stm32_iwdg_otp_data *otp_data);
-
-/* Refresh all registered IWDG watchdog instance */
-void stm32_iwdg_refresh(void);
-
 #endif /*__DRIVERS_STM32_IWDG_H*/


### PR DESCRIPTION
Fix configuration of the watchdog + enable service to get STM32 IWDG timeout range + prepare for watch early interrupt.