### PR TITLE
core: fix #if CFG_xxx into #ifdef CFG_xxx

### DIFF
--- a/core/arch/arm/kernel/thread_spmc_a64.S
+++ b/core/arch/arm/kernel/thread_spmc_a64.S
@@ -14,7 +14,7 @@
 #include <kernel/thread.h>
 #include <optee_ffa.h>
 
-#if CFG_SECURE_PARTITION
+#ifdef CFG_SECURE_PARTITION
 LOCAL_FUNC thread_ffa_interrupt , :
 	mov_imm	x0, FFA_INTERRUPT		/* FID */
 	/* X1: Endpoint/vCPU IDs is set by caller */
@@ -197,7 +197,7 @@ FUNC thread_foreign_intr_exit , :
 	adr_l	x2, threads
 	madd	x2, x1, x0, x2
 	ldr	w1, [x2, #THREAD_CTX_TSD_RPC_TARGET_INFO]
-#if CFG_SECURE_PARTITION
+#ifdef CFG_SECURE_PARTITION
 	/* load threads[w0].flags into w2 */
 	ldr	w2, [x2, #THREAD_CTX_FLAGS]
 	and     w2, w2, #THREAD_FLAGS_FFA_ONLY

--- a/core/arch/arm/plat-stm32mp2/main.c
+++ b/core/arch/arm/plat-stm32mp2/main.c
@@ -60,7 +60,7 @@ static struct stm32_uart_pdata console_data;
 
 void console_init(void)
 {
-#if CFG_STM32_UART
+#ifdef CFG_STM32_UART
 	/* Early console initialization before MMU setup */
 	struct uart {
 		paddr_t pa;


### PR DESCRIPTION
* "core: arm: kernel_spmc: correct CFG_SECURE_PARTITION test"
Replace occurrences of `#if CFG_SECURE_PARTITION` to a `#ifdef` test as the
configuration switch is either defined or not defined.
* "plat-stm32mp2: fix test on CFG_STM32_UART"
Fix test directive on `CFG_STM32_UART` that is either defined or not defined.