### PR TITLE
ta: pkcs11: fixes for key check value + default enable its support

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -2897,8 +2897,8 @@ static enum pkcs11_rc compute_check_value_with_ecb(void *key, uint32_t key_size,
 	TEE_OperationHandle op = TEE_HANDLE_NULL;
 	TEE_ObjectHandle hkey = TEE_HANDLE_NULL;
 	TEE_Attribute attr = { };
-	uint8_t *buf = NULL;
-	size_t buf_size = 0;
+	uint8_t buf[TEE_AES_BLOCK_SIZE] = { };
+	size_t buf_size = sizeof(buf);
 
 	assert(key && kcv);
 
@@ -2929,13 +2929,6 @@ static enum pkcs11_rc compute_check_value_with_ecb(void *key, uint32_t key_size,
 
 	TEE_CipherInit(op, NULL, 0);
 
-	buf_size = key_size;
-	buf = TEE_Malloc(buf_size, TEE_MALLOC_FILL_ZERO);
-	if (!buf) {
-		rc = PKCS11_CKR_DEVICE_MEMORY;
-		goto out;
-	}
-
 	res = TEE_CipherDoFinal(op, buf, buf_size, buf, &buf_size);
 	rc = tee2pkcs_error(res);
 	if (rc != PKCS11_CKR_OK)
@@ -2944,7 +2937,6 @@ static enum pkcs11_rc compute_check_value_with_ecb(void *key, uint32_t key_size,
 	TEE_MemMove(kcv, buf, PKCS11_CKA_CHECK_VALUE_SIZE);
 
 out:
-	TEE_Free(buf);
 	TEE_FreeTransientObject(hkey);
 	TEE_FreeOperation(op);
 

--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -2962,7 +2962,8 @@ enum pkcs11_rc set_check_value_attr(struct obj_attrs **head)
 	case PKCS11_CKO_CERTIFICATE:
 		break;
 	default:
-		return PKCS11_CKR_ARGUMENTS_BAD;
+		/* Nothing to do */
+		return PKCS11_CKR_OK;
 	}
 
 	/* Check whether CKA_CHECK_VALUE has been provided in the template */

--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -2913,9 +2913,7 @@ static enum pkcs11_rc compute_check_value_with_ecb(void *key, uint32_t key_size,
 	if (rc != PKCS11_CKR_OK)
 		goto out;
 
-	attr.attributeID = TEE_ATTR_SECRET_VALUE;
-	attr.content.ref.buffer = key;
-	attr.content.ref.length = key_size;
+	TEE_InitRefAttribute(&attr, TEE_ATTR_SECRET_VALUE, key, key_size);
 
 	res = TEE_PopulateTransientObject(hkey, &attr, 1);
 	rc = tee2pkcs_error(res);

--- a/ta/pkcs11/sub.mk
+++ b/ta/pkcs11/sub.mk
@@ -11,7 +11,7 @@ CFG_PKCS11_TA_HEAP_SIZE ?= (32 * 1024)
 CFG_PKCS11_TA_TOKEN_COUNT ?= 3
 
 # When enabled, embed support for object checksum value computation
-CFG_PKCS11_TA_CHECK_VALUE_ATTRIBUTE ?= n
+CFG_PKCS11_TA_CHECK_VALUE_ATTRIBUTE ?= y
 
 global-incdirs-y += include
 global-incdirs-y += src


### PR DESCRIPTION
This series fixes PKCS11 key check value implementation and default enable its support.
With these changes, PKCS11 key check value is now tested by OP-TEE CI tests and should succeed.