### PR TITLE
driver: crypto: hisilicon: Fix temporary memory risk

### DIFF
--- a/core/drivers/crypto/hisilicon/include/hisi_qm.h
+++ b/core/drivers/crypto/hisilicon/include/hisi_qm.h
@@ -147,6 +147,13 @@ struct hisi_qp {
 	enum hisi_drv_status (*parse_sqe)(void *sqe, void *msg);
 };
 
+struct qm_xqc {
+	struct qm_sqc *sqc;
+	struct qm_cqc *cqc;
+	paddr_t sqc_dma;
+	paddr_t cqc_dma;
+};
+
 struct hisi_qm {
 	enum qm_fun_type fun_type;
 	vaddr_t io_base;
@@ -154,10 +161,8 @@ struct hisi_qm {
 	uint32_t vfs_num;
 	uint32_t version;
 
-	struct qm_sqc *sqc;
-	struct qm_cqc *cqc;
-	paddr_t sqc_dma;
-	paddr_t cqc_dma;
+	struct qm_xqc xqc;
+	struct qm_xqc cfg_xqc;
 	uint32_t sqe_size;
 	uint32_t sqe_log2_size;
 	uint32_t qp_base;


### PR DESCRIPTION
When the mailbox operation times out, the software will free the temporary memory. The hardware does not cancel the mailbox operation and may continue to read and write the free memory.
To solve the problem, we alloc buffer which has the same lifecycle with qm.

Fixes: c7f9abcee87f ("drivers: implement HiSilicon Queue Management (QM) module")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
