### PR TITLE
Clear FFA_MEM_RETRIEVE_RESP memory descriptor fields

### DIFF
--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2021-2023, Arm Limited
+ * Copyright (c) 2021-2024, Arm Limited
  */
 #include <assert.h>
 #include <bench.h>
@@ -500,6 +500,8 @@ static void create_retrieve_response(uint32_t ffa_vers, void *dst_buffer,
 	if (ffa_vers <= FFA_VERSION_1_0) {
 		struct ffa_mem_transaction_1_0 *d_ds = dst_buffer;
 
+		memset(d_ds, 0, sizeof(*d_ds));
+
 		off = sizeof(*d_ds);
 		mem_acc = d_ds->mem_access_array;
 
@@ -511,6 +513,8 @@ static void create_retrieve_response(uint32_t ffa_vers, void *dst_buffer,
 		d_ds->mem_access_count = 1;
 	} else {
 		struct ffa_mem_transaction_1_1 *d_ds = dst_buffer;
+
+		memset(d_ds, 0, sizeof(*d_ds));
 
 		off = sizeof(*d_ds);
 		mem_acc = (void *)(d_ds + 1);
@@ -533,6 +537,7 @@ static void create_retrieve_response(uint32_t ffa_vers, void *dst_buffer,
 	       sizeof(struct ffa_mem_access_perm));
 
 	/* Copy the mem_region_descr */
+	memset(dst_region, 0, sizeof(*dst_region));
 	dst_region->address_range_count = 0;
 	dst_region->total_page_count = 0;
 


### PR DESCRIPTION
Clear the memory descriptors in `FFA_MEM_RETRIEVE_RESP` calls in order to set the reserved fields to zero. The caller might check if the reserved fields are zero as it is stated in the FF-A spec. With FF-A v1.1 the memory transaction descriptor's 4 byte field at offset 24 has changed from reserved (MBZ) to Endpoint memory access descriptor size (non-zero). With the reserved field not cleared in the v1.0 descriptor, the caller cannot verify if it got the right version of the memory transaction descriptor.

This issue only affects the `FFA_MEM_RETRIEVE_RESP` call at the S-EL1 <-> S-EL0 interface, in all other cases the descriptors are cleared properly.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
