### PR TITLE
drivers: stm32_rng: update RNG driver and support MP25

### DIFF
--- a/core/arch/arm/plat-stm32mp2/conf.mk
+++ b/core/arch/arm/plat-stm32mp2/conf.mk
@@ -46,6 +46,7 @@ CFG_NUM_THREADS ?= 5
 CFG_TEE_CORE_NB_CORE ?= 2
 
 CFG_STM32_GPIO ?= y
+CFG_STM32_RNG ?= y
 CFG_STM32_UART ?= y
 
 # Default enable some test facitilites
@@ -59,3 +60,11 @@ CFG_STM32_EARLY_CONSOLE_UART ?= 2
 
 # Default disable external DT support
 CFG_EXTERNAL_DT ?= n
+
+# Default enable HWRNG PTA support
+CFG_HWRNG_PTA ?= y
+ifeq ($(CFG_HWRNG_PTA),y)
+$(call force,CFG_STM32_RNG,y,Required by CFG_HWRNG_PTA)
+$(call force,CFG_WITH_SOFTWARE_PRNG,n,Required by CFG_HWRNG_PTA)
+CFG_HWRNG_QUALITY ?= 1024
+endif

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -29,6 +29,7 @@
 #define RNG_DR			U(0x08)
 #define RNG_NSCR		U(0x0C)
 #define RNG_HTCR		U(0x10)
+#define RNG_VERR		U(0x3F4)
 
 #define RNG_CR_RNGEN		BIT(2)
 #define RNG_CR_IE		BIT(3)
@@ -51,6 +52,10 @@
 #define RNG_SR_SEIS		BIT(6)
 
 #define RNG_NSCR_MASK		GENMASK_32(17, 0)
+
+#define RNG_VERR_MINOR_MASK	GENMASK_32(3, 0)
+#define RNG_VERR_MAJOR_MASK	GENMASK_32(7, 4)
+#define RNG_VERR_MAJOR_SHIFT	U(4)
 
 #if TRACE_LEVEL > TRACE_DEBUG
 #define RNG_READY_TIMEOUT_US	U(100000)
@@ -608,6 +613,7 @@ static TEE_Result stm32_rng_probe(const void *fdt, int offs,
 				  const void *compat_data)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+	unsigned int __maybe_unused version = 0;
 
 	/* Expect a single RNG instance */
 	assert(!stm32_rng);
@@ -634,6 +640,11 @@ static TEE_Result stm32_rng_probe(const void *fdt, int offs,
 			goto err;
 		}
 	}
+
+	version = io_read32(get_base() + RNG_VERR);
+	DMSG("RNG version Major %u, Minor %u",
+	     (version & RNG_VERR_MAJOR_MASK) >> RNG_VERR_MAJOR_SHIFT,
+	     version & RNG_VERR_MINOR_MASK);
 
 	if (stm32_rng->rstctrl &&
 	    rstctrl_assert_to(stm32_rng->rstctrl, RNG_RESET_TIMEOUT_US)) {

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -64,9 +64,8 @@
 #define RNG_CONFIG_MASK		(RNG_CR_ENTROPY_SRC_MASK | RNG_CR_CED | \
 				 RNG_CR_CLKDIV)
 
-#define RNG_MAX_NOISE_CLK_FREQ	U(3000000)
-
 struct stm32_rng_driver_data {
+	unsigned long max_noise_clk_freq;
 	unsigned long nb_clock;
 	uint32_t cr;
 	uint32_t nscr;
@@ -272,7 +271,7 @@ static uint32_t stm32_rng_clock_freq_restrain(void)
 	 * No need to handle the case when clock-div > 0xF as it is physically
 	 * impossible
 	 */
-	while ((clock_rate >> clock_div) > RNG_MAX_NOISE_CLK_FREQ)
+	while ((clock_rate >> clock_div) > dev->ddata->max_noise_clk_freq)
 		clock_div++;
 
 	DMSG("RNG clk rate : %lu", clk_get_rate(dev->clock) >> clock_div);
@@ -682,6 +681,7 @@ err:
 
 static const struct stm32_rng_driver_data mp13_data[] = {
 	{
+		.max_noise_clk_freq = U(48000000),
 		.nb_clock = 1,
 		.has_cond_reset = true,
 		.has_power_optim = true,
@@ -693,6 +693,7 @@ static const struct stm32_rng_driver_data mp13_data[] = {
 
 static const struct stm32_rng_driver_data mp15_data[] = {
 	{
+		.max_noise_clk_freq = U(48000000),
 		.nb_clock = 1,
 		.has_cond_reset = false,
 		.has_power_optim = false,
@@ -702,6 +703,7 @@ DECLARE_KEEP_PAGER(mp15_data);
 
 static const struct stm32_rng_driver_data mp25_data[] = {
 	{
+		.max_noise_clk_freq = U(48000000),
 		.nb_clock = 2,
 		.has_cond_reset = true,
 		.has_power_optim = true,


### PR DESCRIPTION
This P-R adds support for the hardware RNG of the STM32MP25.

It also reworks the way the RNG configuration is applied, as register values shouldn't be present in the device tree.
Having it in the compatible data seems acceptable as changing the RNG configuration would be uncommon.