### PR TITLE
riscv: mm: Set A/D bits of PTE(page table entry) by default

### DIFF
--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -213,6 +213,12 @@ static uint8_t mattr_to_perms(unsigned level __maybe_unused,
 	if (attr & TEE_MATTR_PX)
 		perms |= PTE_X | PTE_R;
 
+	if (attr & (TEE_MATTR_UR | TEE_MATTR_PR))
+		perms |= PTE_A;
+
+	if (attr & (TEE_MATTR_UW | TEE_MATTR_PW))
+		perms |= PTE_D;
+
 	if (attr & TEE_MATTR_GLOBAL)
 		perms |= PTE_G;
 


### PR DESCRIPTION
According to RISC-V privileged ISA manual:
Each leaf PTE contains an accessed (A) and dirty (D) bit. The A bit indicates the virtual page has been read, written, or fetched from since the last time the A bit was cleared. The D bit indicates the virtual page has been written since the last time the D bit was cleared. When a virtual page is accessed and the A bit is clear, or is written and the D bit is clear, a page-fault exception is raised.

And the manual also suggests:
If the supervisor software does not rely on accessed and/or dirty bits, it should always set them to 1 in the PTE to improve performance.

Since OP-TEE does not rely on A/D bits, we by default set them to 1 to avoid unnecessary page-fault exceptions when OP-TEE touches those pages.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
