### PR TITLE
Fix: replace deprecated register_dynamic_shm() with register_ddr()

### DIFF
--- a/core/arch/arm/plat-hikey/main.c
+++ b/core/arch/arm/plat-hikey/main.c
@@ -33,12 +33,12 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC, PMX1_BASE, PMX1_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, GPIO6_BASE, PL061_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, SPI_BASE, PL022_REG_SIZE);
 #endif
-register_dynamic_shm(DRAM0_BASE, DRAM0_SIZE_NSEC);
+register_ddr(DRAM0_BASE, DRAM0_SIZE_NSEC);
 #ifdef DRAM1_SIZE_NSEC
-register_dynamic_shm(DRAM1_BASE, DRAM1_SIZE_NSEC);
+register_ddr(DRAM1_BASE, DRAM1_SIZE_NSEC);
 #endif
 #ifdef DRAM2_SIZE_NSEC
-register_dynamic_shm(DRAM2_BASE, DRAM2_SIZE_NSEC);
+register_ddr(DRAM2_BASE, DRAM2_SIZE_NSEC);
 #endif
 
 void console_init(void)


### PR DESCRIPTION
Replace the deprecated register_dynamic_shm() with register_ddr(), as the function register_dynamic_shm is deprecated.
Signed-off-by: Loonloon <cloudiot@126.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
