### PR TITLE
ldelf: aarch32: Accept ELFOSABI_ARM as OS ABI

### DIFF
--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -104,14 +104,22 @@ static TEE_Result e32_parse_ehdr(struct ta_elf *elf, Elf32_Ehdr *ehdr)
 	if (ehdr->e_ident[EI_VERSION] != EV_CURRENT ||
 	    ehdr->e_ident[EI_CLASS] != ELFCLASS32 ||
 	    ehdr->e_ident[EI_DATA] != ELFDATA2LSB ||
-	    ehdr->e_ident[EI_OSABI] != ELFOSABI_NONE ||
+	    (ehdr->e_ident[EI_OSABI] != ELFOSABI_NONE &&
+	     ehdr->e_ident[EI_OSABI] != ELFOSABI_ARM) ||
 	    ehdr->e_type != ET_DYN || ehdr->e_machine != EM_ARM ||
-	    (ehdr->e_flags & EF_ARM_ABIMASK) != EF_ARM_ABI_VERSION ||
 #ifndef CFG_WITH_VFP
 	    (ehdr->e_flags & EF_ARM_ABI_FLOAT_HARD) ||
 #endif
 	    ehdr->e_phentsize != sizeof(Elf32_Phdr) ||
 	    ehdr->e_shentsize != sizeof(Elf32_Shdr))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ehdr->e_ident[EI_OSABI] == ELFOSABI_NONE &&
+	    (ehdr->e_flags & EF_ARM_ABIMASK) != EF_ARM_ABI_V5)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ehdr->e_ident[EI_OSABI] == ELFOSABI_ARM &&
+	    (ehdr->e_flags & EF_ARM_ABIMASK) != EF_ARM_ABI_UNKNOWN)
 		return TEE_ERROR_BAD_FORMAT;
 
 	elf->is_32bit = true;

--- a/lib/libutee/include/elf_common.h
+++ b/lib/libutee/include/elf_common.h
@@ -260,7 +260,8 @@ typedef struct {
 #define	EM_ALPHA	0x9026	/* Alpha (written in the absence of an ABI) */
 
 /* e_flags for EM_ARM */
-#define EF_ARM_ABI_VERSION	0x05000000	/* ABI version 5 */
+#define EF_ARM_ABI_UNKNOWN	0x00000000
+#define EF_ARM_ABI_V5		0x05000000	/* ABI version 5 */
 #define EF_ARM_ABIMASK		0xFF000000
 #define EF_ARM_BE8		0x00800000
 #define EF_ARM_ABI_FLOAT_HARD	0x00000400	/* ABI version 5 and later */


### PR DESCRIPTION
Rust TAs built for no-std mode targeting 32-bit Arm architecture use ELFOSABI_ARM as the OS ABI within ELF header. So allow ldelf to load those Rust TAs built for 32-bit Arm.