### PR TITLE
plat-stm32mp1: shared_resource: disable MCKPROT if not needed

### DIFF
--- a/core/include/drivers/stm32mp1_rcc.h
+++ b/core/include/drivers/stm32mp1_rcc.h
@@ -561,6 +561,17 @@ static inline bool stm32_rcc_is_mckprot(void)
 {
 	return io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_MCKPROT;
 }
+
+static inline void stm32_rcc_set_mckprot(bool enable)
+{
+	vaddr_t tzcr_reg = stm32_rcc_base() + RCC_TZCR;
+
+	if (enable)
+		io_setbits32(tzcr_reg, RCC_TZCR_MCKPROT);
+	else
+		io_clrbits32(tzcr_reg, RCC_TZCR_MCKPROT);
+}
+
 #endif /*__ASSEMBLER__*/
 
 #endif /*__DRIVERS_STM32MP1_RCC_H__*/


### PR DESCRIPTION
Disable RCC MCKPROT if not needed on STM32MP15 platforms to allow non-secure world to control Cortex-M coprocessor. This change is needed when RCC secure hardening is enabled (RCC[TZEN] control bit) as it also default enable RCC MCKPROT preventing non-secure world from accessing some coprocessor SoC resources.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
