### PR TITLE
drivers: stm32_i2c: apply pinctrl config at init

### DIFF
--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -821,6 +821,9 @@ int stm32_i2c_init(struct i2c_handle_s *hi2c,
 
 	clk_disable(hi2c->clock);
 
+	if (hi2c->pinctrl && pinctrl_apply_state(hi2c->pinctrl))
+		return -1;
+
 	return 0;
 }
 

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -1645,8 +1645,7 @@ static TEE_Result stm32_i2c_probe(const void *fdt, int node,
 	init_data.analog_filter = true;
 	init_data.digital_filter_coef = 0;
 
-	res = stm32_i2c_init(i2c_handle_p, &init_data);
-	if (res)
+	if (stm32_i2c_init(i2c_handle_p, &init_data))
 		panic("Couldn't initialise I2C");
 
 	res = i2c_register_provider(fdt, node, stm32_get_i2c_dev, i2c_handle_p);


### PR DESCRIPTION
Main change: add missing load of stm32_i2c pinctrl state at driver init.
(Fixes: 73ba32eb0f6c ("drivers: stm32_i2c: support CFG_DRIVERS_PINCTRL"))

An preparatory commit simplifies local function `i2c_config_analog_filter()`.


