### PR TITLE
core: scmi-server: sync makefile with changes on SCP-firmware

### DIFF
--- a/core/lib/scmi-server/sub.mk
+++ b/core/lib/scmi-server/sub.mk
@@ -209,7 +209,13 @@ $(eval $(call scpfw-embed-optee-module,reset))
 $(eval $(call scpfw-embed-optee-module,smt))
 
 srcs-$(CFG_SCPFW_MOD_CLOCK) += $(scpfw-path)/module/clock/src/clock_tree_management.c
-srcs-$(CFG_SCPFW_MOD_POWER_DOMAIN) += $(scpfw-path)/module/power_domain/src/power_domain_utils.c
+srcs-$(CFG_SCPFW_MOD_POWER_DOMAIN) += \
+	$(scpfw-path)/module/power_domain/src/power_domain_utils.c \
+	$(scpfw-path)/module/power_domain/src/power_domain_state_checks.c
+ifeq ($(CFG_SCPFW_NOTIFICATION),y)
+srcs-$(CFG_SCPFW_MOD_POWER_DOMAIN) += \
+	$(scpfw-path)/module/power_domain/src/power_domain_notifications.c
+endif
 srcs-$(CFG_SCPFW_MOD_SCMI) += $(scpfw-path)/module/scmi/src/mod_scmi_base.c
 srcs-$(CFG_SCPFW_MOD_SCMI_SENSOR) += $(scpfw-path)/module/scmi_sensor/src/mod_scmi_ext_attrib.c
 srcs-$(CFG_SCPFW_MOD_SENSOR) += $(scpfw-path)/module/sensor/src/sensor_extended.c


### PR DESCRIPTION
On SCP-firmware, extra two files, power_domain_state_checks.c and power_domain_notifications.c, have been added to power-domain module. So sub.mk should be aligned with these changes.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
