### PR TITLE
core: imx: disable ELE support on imx8ulp, imx93 by default

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -217,7 +217,7 @@ CFG_TEE_CORE_NB_CORE ?= 2
 $(call force,CFG_NXP_SNVS,n)
 $(call force,CFG_IMX_OCOTP,n)
 CFG_IMX_MU ?= y
-CFG_IMX_ELE ?= y
+CFG_IMX_ELE ?= n
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx93-flavorlist)))
 $(call force,CFG_MX93,y)
 $(call force,CFG_ARM64_core,y)
@@ -230,7 +230,7 @@ $(call force,CFG_TZC380,n)
 $(call force,CFG_CRYPTO_DRIVER,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
-CFG_IMX_ELE ?= y
+CFG_IMX_ELE ?= n
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif


### PR DESCRIPTION
On imx8ulp and imx93, there is only one MU to comunicate with
ELE, which cannot be dedicated on OP-TEE side all the time.
There may be ELE services running on Linux side, which can
cause conflict with OP-TEE. So disablig ELE by default for now.