### PR TITLE
plat-stm32mp1: fix misnamed 157C_EV1_SCMI flavor

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -8,7 +8,7 @@ flavor_dts_file-157C_EV1 = stm32mp157c-ev1.dts
 flavor_dts_file-157A_DK1_SCMI = stm32mp157a-dk1-scmi.dts
 flavor_dts_file-157C_DK2_SCMI = stm32mp157c-dk2-scmi.dts
 flavor_dts_file-157C_ED1_SCMI = stm32mp157c-ed1-scmi.dts
-flavor_dts_file-157F_EV1_SCMI = stm32mp157c-ev1-scmi.dts
+flavor_dts_file-157C_EV1_SCMI = stm32mp157c-ev1-scmi.dts
 
 flavor_dts_file-135F_DK = stm32mp135f-dk.dts
 


### PR DESCRIPTION
Correct platform flavor name 157C_EV1_SCMI, not 157F_EV1_SCMI.

Fixes: 36f1fd6d4930 ("dts: add stm32mp15*-scmi.dts files for when RCC is secure")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
