### PR TITLE
arm: virtualization: don't allow hypervisor to issue std calls

### DIFF
--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -34,7 +34,7 @@ void thread_handle_fast_smc(struct thread_smc_args *args)
 	thread_check_canaries();
 
 	if (IS_ENABLED(CFG_NS_VIRTUALIZATION) &&
-	    virt_set_guest(args->a7)) {
+	    virt_set_guest(args->a7) && args->a7 != HYP_CLNT_ID) {
 		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
 		goto out;
 	}

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -382,8 +382,6 @@ TEE_Result virt_set_guest(uint16_t guest_id)
 	}
 	cpu_spin_unlock_xrestore(&prtn_list_lock, exceptions);
 
-	if (guest_id == HYP_CLNT_ID)
-		return TEE_SUCCESS;
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }
 


### PR DESCRIPTION
There is standing issue with having two versions of OP-TEE binary: with virtualization enabled and without it. Correct variant needs to be present on board before booting rest of the system.

If non-virtualized variant is present and user tries to boot a hypervisor, hypervisor can (and should) detect that OP-TEE does not provide OPTEE_SMC_SEC_CAP_VIRTUALIZATION capability and fail gracefully.

On other hand, when virtualized variant of OP-TEE is booted, but user then boots directly into Linux (or any other OS), OP-TEE crashes:

E/TC:0 0 0 Core data-abort at address 0xffffffffffffffa0 (translation fault)
E/TC:0 0 0  esr 0x96000044  ttbr0 0x4418d000   ttbr1 0x00000000   cidr 0x0
E/TC:0 0 0  cpu #0          cpsr 0x00000184
E/TC:0 0 0  x0  0000000032000004 x1  0000000000000004
E/TC:0 0 0  x2  000000008183c000 x3  0000000000000000
E/TC:0 0 0  x4  0000000000000000 x5  0000000000000000
E/TC:0 0 0  x6  0000000000000000 x7  0000000000000000
E/TC:0 0 0  x8  0000000000000000 x9  0000000000000000
E/TC:0 0 0  x10 0000000000000000 x11 0000000000000000
E/TC:0 0 0  x12 0000000000000000 x13 0000000000000000
E/TC:0 0 0  x14 0000000000000000 x15 0000000000000000
E/TC:0 0 0  x16 0000000000000000 x17 0000000000000000
E/TC:0 0 0  x18 0000000000000000 x19 0000000000000000
E/TC:0 0 0  x20 0000000000000000 x21 0000000000000000
E/TC:0 0 0  x22 0000000000000000 x23 0000000000000000
E/TC:0 0 0  x24 0000000000000000 x25 0000000000000000
E/TC:0 0 0  x26 0000000000000000 x27 0000000000000000
E/TC:0 0 0  x28 0000000000000000 x29 0000000000000000
E/TC:0 0 0  x30 0000000044103ce4 elr 0000000044106314
E/TC:0 0 0  sp_el0 0000000000000000
E/TC:0 0 0 TEE load address @ 0x44100000
E/TC:0 0 0 Call stack:
E/TC:0 0 0  0x44106314 thread_handle_std_smc at core/arch/arm/kernel/thread_optee_smc.c:62
E/TC:0 0 0 Panic 'unhandled pageable abort' at core/arch/arm/kernel/abort.c:584 <abort_handler>
E/TC:0 0 0 TEE load address @ 0x44100000
E/TC:0 0 0 Call stack:
E/TC:0 0 0  0x44107e14 print_kernel_stack at core/arch/arm/kernel/unwind_arm64.c:89
E/TC:0 0 0  0x44114ffc __do_panic at core/kernel/panic.c:73
E/TC:0 0 0  0x44107050 get_fault_type at core/arch/arm/kernel/abort.c:500

This crash happens because virtualization code has special case for guest_id == HYP_CLNT_ID. This case is needed to allow hypervisor to call fast SMCs, so it can check OP-TEE version, capabilities and ask OP-TEE to create/destroy guest partitions. Problem is that thread_handle_std_smc() assumes that virt_set_guest() really sets the guest partition, which does not happen in this special case.

This patch removes this special case from virt_set_guest(). Instead thread_handle_fast_smc() function checks for HYP_CLNT_ID explicitly.

If hypervisor really want to be able to issue STD calls, it should create a partition for itself using OPTEE_SMC_VM_CREATED call.

With this patch applied, virtualized variant of OP-TEE does not crash anymore when users tries to boot into a baremetal setup.

---

Sidenote: it would be great to allow virtualized OP-TEE build to work with baremetal OS. This can be achieved by automatically creating a partition if we are receiving STD call with `HYP_CLNT_ID`.  Problem is IIRC value of `a7` is not specified in non-virtualized environment, so there can be any garbage in general case. For example, U-Boot may use one value when Linux will try to use something different.



<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
