### PR TITLE
core: riscv: Add .sbss and .sdata sections to linker script

### DIFF
--- a/core/arch/riscv/kernel/kern.ld.S
+++ b/core/arch/riscv/kernel/kern.ld.S
@@ -152,12 +152,15 @@ SECTIONS
 		 * from __global_pointer$.
 		 */
 		PROVIDE(__global_pointer$ = . + 0x800 );
+		*(.sdata .sdata.* .gnu.linkonce.s.*)
 	}
 
 	/* uninitialized data */
 	.bss : {
 		__data_end = .;
 		__bss_start = .;
+		*(.sbss .sbss.*)
+		*(.gnu.linkonce.sb.*)
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)


### PR DESCRIPTION
Currently, the unclean .sbss section in RISC-V binary could be
problematic. This is because variables such as puts_lock may have
non-zero initial values, leading to failures in cpu_spin_trylock().
To address this issue, merge .sbss into .bss so that it is properly
cleared on boot. Both OpenSBI [1] and Linux [2] follow this approach.

Also, to benefit from global pointer relaxation, add .sdata after the
__global_pointer$ symbol.

Link: https://github.com/riscv-software-src/opensbi/blob/bb90a9ebf6d9a2fe7726978d594e82cdbaad7799/firmware/fw_base.ldS#L84 [1]
Link: https://github.com/torvalds/linux/blob/296455ade1fdcf5f8f8c033201633b60946c589a/include/asm-generic/vmlinux.lds.h#L1146 [2]
Signed-off-by: Yu Chien Peter Lin <peterlin@andestech.com>
Reviewed-by: Alvin Chang <alvinga@andestech.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
