### PR TITLE
arm: plat: rcar: gen4: adjust memory map

### DIFF
--- a/core/arch/arm/plat-rcar/conf.mk
+++ b/core/arch/arm/plat-rcar/conf.mk
@@ -37,6 +37,7 @@ endif
 ifeq ($(CFG_RCAR_GEN4), y)
 # 1xx - for SCIFxx
 # 2xx - for HSCIFxx
+CFG_TZDRAM_SIZE	= 0x2200000
 CFG_RCAR_UART ?= 200
 $(call force,CFG_RCAR_ROMAPI, n)
 $(call force,CFG_CORE_CLUSTER_SHIFT, 1)


### PR DESCRIPTION
Adjust the OP-TEE memory map for Gen4/S4 SoC to reflect changes of IPL layout made by Renesas. Now BL31 starts at 0x46400000, so we have less memory for OP-TEE.


(Rcar S4 is still not available for general public, so Renesas have time to experiments with IPL layouts. We are expecting S4SK board to be available soon, so I hope this is the last change to memory layout...  )
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
