### PR TITLE
ci: do not add $HOME/.cargo/bin to $PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,6 @@ jobs:
           # make check task
           set -e -v
           export LC_ALL=C
-          export PATH=/github/home/.cargo/bin:$PATH
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0
           export CFG_ATTESTATION_PTA=y
@@ -320,7 +319,6 @@ jobs:
           # make check task
           set -e -v
           export LC_ALL=C
-          export PATH=/github/home/.cargo/bin:$PATH
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
@@ -354,7 +352,6 @@ jobs:
           # make check task
           set -e -v
           export LC_ALL=C
-          export PATH=/github/home/.cargo/bin:$PATH
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           WD=$(pwd)
@@ -388,7 +385,6 @@ jobs:
           export LC_ALL=C
           # The BTI-enabled toolchain is aarch64-unknown-linux-uclibc-gcc in /usr/local/bin
           export PATH=/usr/local/bin:$PATH
-          export PATH=/github/home/.cargo/bin:$PATH
           export AARCH64_CROSS_COMPILE=aarch64-unknown-linux-uclibc-
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
           export CFG_TEE_CORE_LOG_LEVEL=0


### PR DESCRIPTION
Since [1] there is no need to add $HOME/.cargo/bin to the user's PATH anymore. Therefore remove the corresponding lines from the CI scripts.

Link: https://github.com/OP-TEE/build/commit/xxxx [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
