### PR TITLE
drivers: caam: add caam_hal_rng_pr_enabled() for 8QX, 8DX platforms

### DIFF
--- a/core/drivers/crypto/caam/hal/common/hal_rng.c
+++ b/core/drivers/crypto/caam/hal/common/hal_rng.c
@@ -62,7 +62,10 @@ bool caam_hal_rng_key_loaded(vaddr_t baseaddr)
 	return io_caam_read32(baseaddr + RNG_STA) & RNG_STA_SKVN;
 }
 
-bool caam_hal_rng_pr_enabled(vaddr_t baseaddr)
+/*
+ * This function will be overridden for i.MX8QX and i.MX8DX platforms.
+ */
+bool __weak caam_hal_rng_pr_enabled(vaddr_t baseaddr)
 {
 	uint32_t bitmask = RNG_STA_PR0;
 

--- a/core/drivers/crypto/caam/hal/imx_8q/hal_rng.c
+++ b/core/drivers/crypto/caam/hal/imx_8q/hal_rng.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2020-2021 NXP
+ * Copyright 2020-2021, 2024 NXP
  */
 #include <caam_hal_rng.h>
 #include <caam_status.h>
@@ -17,4 +17,13 @@ enum caam_status caam_hal_rng_instantiated(vaddr_t baseaddr __unused)
 		return CAAM_FAILURE;
 	else
 		return CAAM_NO_ERROR;
+}
+
+bool caam_hal_rng_pr_enabled(vaddr_t baseaddr __unused)
+{
+	/*
+	 * On platforms i.MX8Q and i.MX8DXL CAAM RNG Prediction
+	 * resistance is enabled by default. So returning true.
+	 */
+	return true;
 }


### PR DESCRIPTION
The SECO firmware enables the RNG prediction resistance by default. There is no need to read the CAAM RNG status registers.