### PR TITLE
plat-k3: drivers: sec_proxy: increment while reading trail bytes

### DIFF
--- a/core/arch/arm/plat-k3/drivers/sec_proxy.c
+++ b/core/arch/arm/plat-k3/drivers/sec_proxy.c
@@ -213,7 +213,7 @@ TEE_Result k3_sec_proxy_recv(struct k3_sec_proxy_msg *msg)
 
 		i = msg->len - trail_bytes;
 		while (trail_bytes--) {
-			msg->buf[i] = data_trail & 0xff;
+			msg->buf[i++] = data_trail & 0xff;
 			data_trail >>= 8;
 		}
 	}


### PR DESCRIPTION
The trail bytes from the secure proxy driver were being overwritten, increase the count each time to not overwrite the existing data and not get the end data corrupted from secure proxy.

Fixes: cf20f0a4f77e ("plat-k3: drivers: Add secure proxy driver for communication with System Controller")