### PR TITLE
add support timeout for notify and condvar

### DIFF
--- a/core/include/kernel/mutex.h
+++ b/core/include/kernel/mutex.h
@@ -95,10 +95,26 @@ void condvar_broadcast_debug(struct condvar *cv, const char *fname, int lineno);
 void condvar_wait_debug(struct condvar *cv, struct mutex *m,
 			const char *fname, int lineno);
 #define condvar_wait(cv, m) condvar_wait_debug((cv), (m), __FILE__, __LINE__)
+
+/*
+ * Return TEE_ERROR_TIMEOUT if the normal world returns before
+ * the condvar has been signaled.
+ */
+TEE_Result condvar_wait_timeout_debug(struct condvar *cv, struct mutex *m,
+				      uint32_t timeout_ms, const char *fname,
+				      int lineno);
+#define condvar_wait_timeout(cv, m, timeout_ms) \
+	condvar_wait_timeout_debug((cv), (m), (timeout_ms), __FILE__, __LINE__)
 #else
 void condvar_signal(struct condvar *cv);
 void condvar_broadcast(struct condvar *cv);
 void condvar_wait(struct condvar *cv, struct mutex *m);
+/*
+ * Return TEE_ERROR_TIMEOUT if the normal world returns before
+ * the condvar has been signaled.
+ */
+TEE_Result condvar_wait_timeout(struct condvar *cv, struct mutex *m,
+				uint32_t timeout_ms);
 #endif
 
 #endif /*__KERNEL_MUTEX_H*/

--- a/core/include/kernel/notif.h
+++ b/core/include/kernel/notif.h
@@ -107,6 +107,11 @@ void notif_free_async_value(uint32_t value);
 TEE_Result notif_wait(uint32_t value);
 
 /*
+ * Wait timeout in normal world for a value to be sent by notif_send()
+ */
+TEE_Result notif_wait_timeout(uint32_t value, uint32_t timeout_ms);
+
+/*
  * Send an asynchronous value, note that it must be <= NOTIF_ASYNC_VALUE_MAX
  */
 #if defined(CFG_CORE_ASYNC_NOTIF)

--- a/core/include/kernel/wait_queue.h
+++ b/core/include/kernel/wait_queue.h
@@ -5,6 +5,7 @@
 #ifndef __KERNEL_WAIT_QUEUE_H
 #define __KERNEL_WAIT_QUEUE_H
 
+#include <tee_api_types.h>
 #include <types_ext.h>
 #include <sys/queue.h>
 
@@ -44,9 +45,10 @@ static inline void wq_wait_init(struct wait_queue *wq,
 	wq_wait_init_condvar(wq, wqe, NULL, wait_read);
 }
 
-/* Waits for the wait queue element to the awakened. */
-void wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
-		   const void *sync_obj, const char *fname, int lineno);
+/* Waits for the wait queue element to be awakened or timed out */
+TEE_Result wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
+			 uint32_t timeout_ms, const void *sync_obj,
+			 const char *fname, int lineno);
 
 /* Wakes up the first wait queue element in the wait queue, if there is one */
 void wq_wake_next(struct wait_queue *wq, const void *sync_obj,

--- a/core/include/optee_rpc_cmd.h
+++ b/core/include/optee_rpc_cmd.h
@@ -65,10 +65,12 @@
  * Waiting on notification
  * [in]    value[0].a	    OPTEE_RPC_NOTIFICATION_WAIT
  * [in]    value[0].b	    notification value
+ * [in]    value[0].c	    timeout in millisecond or 0 if no timeout
  *
  * Sending a synchronous notification
  * [in]    value[0].a	    OPTEE_RPC_NOTIFICATION_SEND
  * [in]    value[0].b	    notification value
+ * [in]    value[0].c	    shall be 0, reserved for future evolution
  */
 #define OPTEE_RPC_CMD_NOTIFICATION	U(4)
 #define OPTEE_RPC_NOTIFICATION_WAIT	U(0)

--- a/core/kernel/mutex.c
+++ b/core/kernel/mutex.c
@@ -60,7 +60,7 @@ static void __mutex_lock(struct mutex *m, const char *fname, int lineno)
 			 * Someone else is holding the lock, wait in normal
 			 * world for the lock to become available.
 			 */
-			wq_wait_final(&m->wq, &wqe, m, fname, lineno);
+			wq_wait_final(&m->wq, &wqe, 0, m, fname, lineno);
 		} else
 			return;
 	}
@@ -205,7 +205,7 @@ static void __mutex_read_lock(struct mutex *m, const char *fname, int lineno)
 			 * Someone else is holding the lock, wait in normal
 			 * world for the lock to become available.
 			 */
-			wq_wait_final(&m->wq, &wqe, m, fname, lineno);
+			wq_wait_final(&m->wq, &wqe, 0, m, fname, lineno);
 		} else
 			return;
 	}
@@ -393,13 +393,15 @@ void condvar_broadcast(struct condvar *cv)
 }
 #endif /*CFG_MUTEX_DEBUG*/
 
-static void __condvar_wait(struct condvar *cv, struct mutex *m,
-			const char *fname, int lineno)
+static TEE_Result __condvar_wait_timeout(struct condvar *cv, struct mutex *m,
+					 uint32_t timeout_ms, const char *fname,
+					 int lineno)
 {
-	uint32_t old_itr_status;
-	struct wait_queue_elem wqe;
-	short old_state;
-	short new_state;
+	TEE_Result res = TEE_SUCCESS;
+	uint32_t old_itr_status = 0;
+	struct wait_queue_elem wqe = { };
+	short old_state = 0;
+	short new_state = 0;
 
 	mutex_unlock_check(m);
 
@@ -434,23 +436,38 @@ static void __condvar_wait(struct condvar *cv, struct mutex *m,
 	if (!new_state)
 		wq_wake_next(&m->wq, m, fname, lineno);
 
-	wq_wait_final(&m->wq, &wqe, m, fname, lineno);
+	res = wq_wait_final(&m->wq, &wqe, timeout_ms, m, fname, lineno);
 
 	if (old_state > 0)
 		mutex_read_lock(m);
 	else
 		mutex_lock(m);
+
+	return res;
 }
 
 #ifdef CFG_MUTEX_DEBUG
 void condvar_wait_debug(struct condvar *cv, struct mutex *m,
 			const char *fname, int lineno)
 {
-	__condvar_wait(cv, m, fname, lineno);
+	__condvar_wait_timeout(cv, m, 0, fname, lineno);
+}
+
+TEE_Result condvar_wait_timeout_debug(struct condvar *cv, struct mutex *m,
+				      uint32_t timeout_ms, const char *fname,
+				      int lineno)
+{
+	return __condvar_wait_timeout(cv, m, timeout_ms, fname, lineno);
 }
 #else
 void condvar_wait(struct condvar *cv, struct mutex *m)
 {
-	__condvar_wait(cv, m, NULL, -1);
+	__condvar_wait_timeout(cv, m, 0, NULL, -1);
+}
+
+TEE_Result condvar_wait_timeout(struct condvar *cv, struct mutex *m,
+				uint32_t timeout_ms)
+{
+	return __condvar_wait_timeout(cv, m, timeout_ms, NULL, -1);
 }
 #endif

--- a/core/kernel/notif.c
+++ b/core/kernel/notif.c
@@ -117,19 +117,25 @@ out:
 }
 #endif /*CFG_CORE_ASYNC_NOTIF*/
 
-static TEE_Result notif_rpc(uint32_t func, uint32_t value)
+static TEE_Result notif_rpc(uint32_t func, uint32_t value1, uint32_t value2)
 {
-	struct thread_param params = THREAD_PARAM_VALUE(IN, func, value, 0);
+	struct thread_param params =
+		THREAD_PARAM_VALUE(IN, func, value1, value2);
 
 	return thread_rpc_cmd(OPTEE_RPC_CMD_NOTIFICATION, 1, &params);
 }
 
 TEE_Result notif_wait(uint32_t value)
 {
-	return notif_rpc(OPTEE_RPC_NOTIFICATION_WAIT, value);
+	return notif_rpc(OPTEE_RPC_NOTIFICATION_WAIT, value, 0);
 }
 
 TEE_Result notif_send_sync(uint32_t value)
 {
-	return notif_rpc(OPTEE_RPC_NOTIFICATION_SEND, value);
+	return notif_rpc(OPTEE_RPC_NOTIFICATION_SEND, value, 0);
+}
+
+TEE_Result notif_wait_timeout(uint32_t value, uint32_t timeout_ms)
+{
+	return notif_rpc(OPTEE_RPC_NOTIFICATION_WAIT, value, timeout_ms);
 }

--- a/core/kernel/wait_queue.c
+++ b/core/kernel/wait_queue.c
@@ -20,10 +20,10 @@ void wq_init(struct wait_queue *wq)
 	*wq = (struct wait_queue)WAIT_QUEUE_INITIALIZER;
 }
 
-static void do_notif(TEE_Result (*fn)(uint32_t), int id,
-		     const char *cmd_str __maybe_unused,
-		     const void *sync_obj __maybe_unused,
-		     const char *fname, int lineno __maybe_unused)
+static TEE_Result do_notif(bool wait, int id, uint32_t timeout_ms,
+			   const char *cmd_str __maybe_unused,
+			   const void *sync_obj __maybe_unused,
+			   const char *fname, int lineno __maybe_unused)
 {
 	TEE_Result res = TEE_SUCCESS;
 
@@ -33,9 +33,15 @@ static void do_notif(TEE_Result (*fn)(uint32_t), int id,
 	else
 		DMSG("%s thread %d %p", cmd_str, id, sync_obj);
 
-	res = fn(id + NOTIF_SYNC_VALUE_BASE);
+	if (wait)
+		res = notif_wait_timeout(id + NOTIF_SYNC_VALUE_BASE,
+					 timeout_ms);
+	else
+		res = notif_send_sync(id + NOTIF_SYNC_VALUE_BASE);
 	if (res)
 		DMSG("%s thread %d res %#"PRIx32, cmd_str, id, res);
+
+	return res;
 }
 
 static void slist_add_tail(struct wait_queue *wq, struct wait_queue_elem *wqe)
@@ -69,24 +75,33 @@ void wq_wait_init_condvar(struct wait_queue *wq, struct wait_queue_elem *wqe,
 	cpu_spin_unlock_xrestore(&wq_spin_lock, old_itr_status);
 }
 
-void wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
-		   const void *sync_obj, const char *fname, int lineno)
+static TEE_Result wq_wait_final_helper(struct wait_queue *wq,
+				       struct wait_queue_elem *wqe,
+				       uint32_t timeout_ms,
+				       const void *sync_obj, const char *fname,
+				       int lineno)
 {
-	uint32_t old_itr_status;
-	unsigned done;
+	uint32_t old_itr_status = 0;
 
-	do {
-		do_notif(notif_wait, wqe->handle,
-			 "sleep", sync_obj, fname, lineno);
+	do_notif(true, wqe->handle, timeout_ms, "sleep", sync_obj, fname,
+		 lineno);
 
-		old_itr_status = cpu_spin_lock_xsave(&wq_spin_lock);
+	old_itr_status = cpu_spin_lock_xsave(&wq_spin_lock);
+	SLIST_REMOVE(wq, wqe, wait_queue_elem, link);
+	cpu_spin_unlock_xrestore(&wq_spin_lock, old_itr_status);
 
-		done = wqe->done;
-		if (done)
-			SLIST_REMOVE(wq, wqe, wait_queue_elem, link);
+	if (wqe->done)
+		return TEE_SUCCESS;
+	else
+		return TEE_ERROR_TIMEOUT;
+}
 
-		cpu_spin_unlock_xrestore(&wq_spin_lock, old_itr_status);
-	} while (!done);
+TEE_Result wq_wait_final(struct wait_queue *wq, struct wait_queue_elem *wqe,
+			 uint32_t timeout_ms, const void *sync_obj,
+			 const char *fname, int lineno)
+{
+	return wq_wait_final_helper(wq, wqe, timeout_ms, sync_obj, fname,
+				    lineno);
 }
 
 void wq_wake_next(struct wait_queue *wq, const void *sync_obj,
@@ -130,7 +145,7 @@ void wq_wake_next(struct wait_queue *wq, const void *sync_obj,
 		cpu_spin_unlock_xrestore(&wq_spin_lock, old_itr_status);
 
 		if (do_wakeup)
-			do_notif(notif_send_sync, handle,
+			do_notif(false, handle, 0,
 				 "wake ", sync_obj, fname, lineno);
 
 		if (!do_wakeup || !wake_read)


### PR DESCRIPTION
We have added a timeout parameter to the rpc notify for greater flexibility. The tee driver checks this parameter to decide which wait_for_completion will use. If the timeout is set to 0, it means waiting MAX_SCHEDULE_TIMEOUT.
The corresponding patch is here. [optee: support wq_sleep_timeout
](https://patchwork.kernel.org/project/linux-mediatek/patch/20240125052744.18866-1-gavin.liu@mediatek.com/)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
