### PR TITLE
drivers: crypto: stm32: fix SAES key selection

### DIFF
--- a/core/drivers/crypto/stm32/stm32_saes.c
+++ b/core/drivers/crypto/stm32/stm32_saes.c
@@ -620,7 +620,8 @@ TEE_Result stm32_saes_init(struct stm32_saes_context *ctx, bool is_dec,
 	switch (key_select) {
 	case STM32_SAES_KEY_SOFT:
 		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 _SAES_CR_KEYSEL_SOFT);
+					 SHIFT_U32(_SAES_CR_KEYSEL_SOFT,
+						   _SAES_CR_KEYSEL_SHIFT));
 		/* Save key */
 		switch (key_size) {
 		case AES_KEYSIZE_128:
@@ -652,19 +653,23 @@ TEE_Result stm32_saes_init(struct stm32_saes_context *ctx, bool is_dec,
 		break;
 	case STM32_SAES_KEY_DHU:
 		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 _SAES_CR_KEYSEL_DHUK);
+					 SHIFT_U32(_SAES_CR_KEYSEL_DHUK,
+						   _SAES_CR_KEYSEL_SHIFT));
 		break;
 	case STM32_SAES_KEY_BH:
 		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 _SAES_CR_KEYSEL_BHK);
+					 SHIFT_U32(_SAES_CR_KEYSEL_BHK,
+						   _SAES_CR_KEYSEL_SHIFT));
 		break;
 	case STM32_SAES_KEY_BHU_XOR_BH:
 		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 _SAES_CR_KEYSEL_BHU_XOR_BH_K);
+					 SHIFT_U32(_SAES_CR_KEYSEL_BHU_XOR_BH_K,
+						   _SAES_CR_KEYSEL_SHIFT));
 		break;
 	case STM32_SAES_KEY_WRAPPED:
 		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 _SAES_CR_KEYSEL_SOFT);
+					 SHIFT_U32(_SAES_CR_KEYSEL_SOFT,
+						   _SAES_CR_KEYSEL_SHIFT));
 		break;
 
 	default:


### PR DESCRIPTION
Correction selection of key in STM32 SAES driver that missed a left bit shift operation. The bug was not experienced before as current platform tests involve only the software key selection (_SAES_CR_KEYSEL_SOFT) which value is 0 and matches the SoC default key selection register value.

Fixes: 4320f5cf30c5 ("crypto: stm32: SAES cipher support")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
