### PR TITLE
core: arm: generic_ram_layout.h: add TEE_SCMI_SHMEM_*

### DIFF
--- a/core/arch/arm/include/mm/generic_ram_layout.h
+++ b/core/arch/arm/include/mm/generic_ram_layout.h
@@ -18,6 +18,9 @@
  * CFG_SHMEM_SIZE
  *
  * Optional directives:
+ * CFG_SCMI_SHMEM_START Sets the address of SCMI static shared memory.
+ * CFG_SCMI_SHMEM_SIZE  Sets the byte size of SCMI static shared memory.
+ *
  * CFG_TEE_LOAD_ADDR	If defined sets TEE_LOAD_ADDR. If not, TEE_LOAD_ADDR
  *			is set by the platform or defaults to TEE_RAM_START.
  * CFG_TEE_RAM_VA_SIZE	Some platforms may have specific needs
@@ -40,6 +43,9 @@
  * TA_RAM_SIZE		TA contexts/pagestore RAM byte size
  * TEE_SHMEM_START	Non-secure static shared memory physical base address
  * TEE_SHMEM_SIZE	Non-secure static shared memory byte size
+ * TEE_SCMI_SHMEM_START	Non-secure SCMI static shared memory physical base
+ *                      address
+ * TEE_SCMI_SHMEM_SIZE	Non-secure SCMI static shared memory byte size
  *
  * TZDRAM_BASE		Main/external secure RAM base address
  * TZDRAM_SIZE		Main/external secure RAM byte size
@@ -73,6 +79,11 @@
  *  | Non-secure static SHM            |
  *  +----------------------------------+ <-- CFG_SHMEM_START + CFG_SHMEM_SIZE
  *
+ *  +----------------------------------+ <-- CFG_SCMI_SHMEM_START
+ *  | Non-secure static SCMI SHM       |
+ *  +----------------------------------+ <-- CFG_SCMI_SHMEM_START
+ *                                           + CFG_SCMI_SHMEM_SIZE
+ *
  * ----------------------------------------------------------------------------
  * TEE RAM layout with CFG_WITH_PAGER=y and undefined CFG_TZSRAM_START/_SIZE
  *
@@ -91,6 +102,10 @@
  *  | Non-secure static SHM            |   |
  *  +----------------------------------+   v CFG_SHMEM_SIZE
  *
+ *  +----------------------------------+ <-- CFG_SCMI_SHMEM_START
+ *  | Non-secure static SCMI SHM       |   |
+ *  +----------------------------------+   v CFG_SCMI_SHMEM_SIZE
+ *
  * ----------------------------------------------------------------------------
  * TEE RAM layout with CFG_WITH_PAGER=y and define CFG_TZSRAM_START/_SIZE
  *
@@ -108,6 +123,11 @@
  *  +----------------------------------+ <-- CFG_SHMEM_START
  *  | Non-secure static SHM            |   |
  *  +----------------------------------+   v CFG_SHMEM_SIZE
+ *
+ *  +----------------------------------+ <-- CFG_SCMI_SHMEM_START
+ *  | Non-secure static SCMI SHM       |   |
+ *  +----------------------------------+   v CFG_SCMI_SHMEM_SIZE
+ *
  */
 
 #ifdef CFG_TEE_LOAD_ADDR
@@ -130,6 +150,17 @@
 #define TEE_SHMEM_START		CFG_SHMEM_START
 #ifndef CFG_SHMEM_SIZE
 #error CFG_SHMEM_START mandates CFG_SHMEM_SIZE
+#endif
+#endif
+
+#ifdef CFG_SCMI_SHMEM_SIZE
+#define TEE_SCMI_SHMEM_SIZE		CFG_SCMI_SHMEM_SIZE
+#endif
+
+#ifdef CFG_SCMI_SHMEM_START
+#define TEE_SCMI_SHMEM_START		CFG_SCMI_SHMEM_START
+#ifndef CFG_SCMI_SHMEM_SIZE
+#error CFG_SCMI_SHMEM_START mandates CFG_SCMI_SHMEM_SIZE
 #endif
 #endif
 
@@ -181,4 +212,3 @@
 #endif
 
 #endif /*__MM_GENERIC_RAM_LAYOUT_H*/
-

--- a/core/arch/arm/plat-sam/scmi_server.c
+++ b/core/arch/arm/plat-sam/scmi_server.c
@@ -12,9 +12,9 @@
 #include <initcall.h>
 #include <tee_api_defines.h>
 
-static_assert(SMT_BUF_SLOT_SIZE <= CFG_SCMI_SHMEM_SIZE);
+static_assert(SMT_BUF_SLOT_SIZE <= TEE_SCMI_SHMEM_SIZE);
 
-register_phys_mem(MEM_AREA_IO_NSEC, CFG_SCMI_SHMEM_START, CFG_SCMI_SHMEM_SIZE);
+register_phys_mem(MEM_AREA_IO_NSEC, TEE_SCMI_SHMEM_START, TEE_SCMI_SHMEM_SIZE);
 
 struct channel_resources {
 	struct scmi_msg_channel *channel;
@@ -23,7 +23,7 @@ struct channel_resources {
 static const struct channel_resources scmi_channel[] = {
 	[0] = {
 		.channel = &(struct scmi_msg_channel){
-			.shm_addr = { .pa = CFG_SCMI_SHMEM_START },
+			.shm_addr = { .pa = TEE_SCMI_SHMEM_START },
 			.shm_size = SMT_BUF_SLOT_SIZE,
 		},
 	},


### PR DESCRIPTION
To get TEE_SCMI_SHMEM_* defined from generic configuration directives.