### PR TITLE
drivers: clk: duty cycle, reparent pre-enable, linear rates description

### DIFF
--- a/core/drivers/clk/clk-stm32mp13.c
+++ b/core/drivers/clk/clk-stm32mp13.c
@@ -2046,7 +2046,7 @@ static struct clk ck_pll1p = {
 		.mux_id		= NO_MUX,
 	},
 	.name		= "ck_pll1p",
-	.flags		= 0,
+	.flags		= CLK_SET_RATE_PARENT,
 	.num_parents	= 1,
 	.parents	= { &ck_pll1_vco },
 };
@@ -2061,7 +2061,7 @@ static struct clk ck_pll1p_div = {
 		.div_id	= DIV_MPU,
 	},
 	.name	= "ck_pll1p_div",
-	.flags	= 0,
+	.flags	= CLK_SET_RATE_PARENT,
 	.num_parents	= 1,
 	.parents	= { &ck_pll1p },
 };
@@ -2112,7 +2112,7 @@ static struct clk ck_mpu = {
 		.mux_id	= MUX_MPU,
 	},
 	.name		= "ck_mpu",
-	.flags		= 0,
+	.flags		= CLK_SET_PARENT_PRE_ENABLE | CLK_SET_RATE_PARENT,
 	.num_parents	= 4,
 	.parents	= { &ck_hsi, &ck_hse, &ck_pll1p, &ck_pll1p_div },
 };
@@ -2124,7 +2124,7 @@ static struct clk ck_axi = {
 		.div_id	= DIV_AXI,
 	},
 	.name		= "ck_axi",
-	.flags		= 0,
+	.flags		= CLK_SET_PARENT_PRE_ENABLE | CLK_SET_RATE_PARENT,
 	.num_parents	= 3,
 	.parents	= { &ck_hsi, &ck_hse, &ck_pll2p },
 };
@@ -2136,7 +2136,7 @@ static struct clk ck_mlahb = {
 		.div_id	= DIV_MLAHB,
 	},
 	.name		= "ck_mlahb",
-	.flags		= 0,
+	.flags		= CLK_SET_PARENT_PRE_ENABLE | CLK_SET_RATE_PARENT,
 	.num_parents	= 4,
 	.parents	= { &ck_hsi, &ck_hse, &ck_csi, &ck_pll3p },
 };

--- a/core/drivers/clk/clk-stm32mp13.c
+++ b/core/drivers/clk/clk-stm32mp13.c
@@ -1793,6 +1793,29 @@ static const struct clk_ops clk_stm32_pll_ops = {
 	.disable	= clk_stm32_pll_disable,
 };
 
+static TEE_Result
+clk_stm32_composite_get_duty_cycle(struct clk *clk,
+				   struct clk_duty_cycle *duty_cycle)
+{
+	struct clk_stm32_composite_cfg *cfg = clk->priv;
+	uint32_t val = stm32_div_get_value(cfg->div_id);
+
+	duty_cycle->num = (val + 1) / 2;
+	duty_cycle->den = val + 1;
+
+	return TEE_SUCCESS;
+}
+
+static const struct clk_ops clk_stm32_composite_duty_cycle_ops = {
+	.get_parent	= clk_stm32_composite_get_parent,
+	.set_parent	= clk_stm32_composite_set_parent,
+	.get_rate	= clk_stm32_composite_get_rate,
+	.set_rate	= clk_stm32_composite_set_rate,
+	.enable		= clk_stm32_composite_gate_enable,
+	.disable	= clk_stm32_composite_gate_disable,
+	.get_duty_cycle	= clk_stm32_composite_get_duty_cycle,
+};
+
 static struct
 stm32_clk_opp_cfg *clk_stm32_get_opp_config(struct stm32_clk_opp_cfg *opp_cfg,
 					    unsigned long rate)
@@ -1963,7 +1986,7 @@ const struct clk_ops ck_timer_ops = {
 #define STM32_PLL_OUPUT(_name, _nb_parents, _parents, _flags,\
 			_gate_id, _div_id, _mux_id)\
 	struct clk _name = {\
-		.ops	= &clk_stm32_composite_ops,\
+		.ops	= &clk_stm32_composite_duty_cycle_ops,\
 		.priv	= &(struct clk_stm32_composite_cfg) {\
 			.gate_id	= (_gate_id),\
 			.div_id		= (_div_id),\

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -338,6 +338,15 @@ TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 	return clk->ops->get_rates_array(clk, start_index, rates, nb_elts);
 }
 
+TEE_Result clk_get_rates_steps(struct clk *clk, unsigned long *min,
+			       unsigned long *max, unsigned long *step)
+{
+	if (!clk->ops->get_rates_steps)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	return clk->ops->get_rates_steps(clk, min, max, step);
+}
+
 TEE_Result clk_get_duty_cycle(struct clk *clk,
 			      struct clk_duty_cycle *duty_cycle)
 {

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -321,6 +321,19 @@ TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 	return clk->ops->get_rates_array(clk, start_index, rates, nb_elts);
 }
 
+TEE_Result clk_get_duty_cycle(struct clk *clk,
+			      struct clk_duty_cycle *duty_cycle)
+{
+	if (clk->ops->get_duty_cycle)
+		return clk->ops->get_duty_cycle(clk, duty_cycle);
+
+	/* Default set 50% duty cycle */
+	duty_cycle->num = 1;
+	duty_cycle->den = 2;
+
+	return TEE_SUCCESS;
+}
+
 /* Return updated message buffer position of NULL on failure */
 static __printf(3, 4) char *add_msg(char *cur, char *end, const char *fmt, ...)
 {

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -214,7 +214,17 @@ static TEE_Result clk_set_rate_no_lock(struct clk *clk, unsigned long rate)
 	}
 
 	if (clk->ops->set_rate) {
+		if (clk->flags & CLK_SET_RATE_UNGATE) {
+			res = clk_enable_no_lock(clk);
+			if (res)
+				return res;
+		}
+
 		res = clk->ops->set_rate(clk, rate, parent_rate);
+
+		if (clk->flags & CLK_SET_RATE_UNGATE)
+			clk_disable_no_lock(clk);
+
 		if (res)
 			return res;
 	}

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -327,6 +327,9 @@ TEE_Result clk_get_duty_cycle(struct clk *clk,
 	if (clk->ops->get_duty_cycle)
 		return clk->ops->get_duty_cycle(clk, duty_cycle);
 
+	if (clk->parent && (clk->flags & CLK_DUTY_CYCLE_PARENT))
+		return clk_get_duty_cycle(clk->parent, duty_cycle);
+
 	/* Default set 50% duty cycle */
 	duty_cycle->num = 1;
 	duty_cycle->den = 2;

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -15,6 +15,7 @@
 #define CLK_SET_RATE_GATE	BIT(0) /* must be gated across rate change */
 #define CLK_SET_PARENT_GATE	BIT(1) /* must be gated across re-parent */
 #define CLK_DUTY_CYCLE_PARENT	BIT(2) /* forward duty cycle call to parent */
+#define CLK_SET_RATE_PARENT	BIT(3) /* propagate rate change up to parent */
 
 /**
  * struct clk - Clock structure

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -17,6 +17,7 @@
 #define CLK_DUTY_CYCLE_PARENT	BIT(2) /* forward duty cycle call to parent */
 #define CLK_SET_RATE_PARENT	BIT(3) /* propagate rate change up to parent */
 #define CLK_SET_RATE_UNGATE	BIT(4) /* clock needs to run to set rate */
+#define CLK_SET_PARENT_PRE_ENABLE	BIT(5) /* enable new parent if needed */
 
 /**
  * struct clk - Clock structure

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -60,7 +60,7 @@ struct clk_duty_cycle {
 };
 
 /**
- * struct clk_ops
+ * struct clk_ops - Clock operations
  *
  * @enable: Enable the clock
  * @disable: Disable the clock
@@ -90,7 +90,7 @@ struct clk_ops {
 };
 
 /**
- * Return the clock name
+ * clk_get_name() - Return the clock name
  *
  * @clk: Clock for which the name is needed
  * Return a const char * pointing to the clock name
@@ -101,7 +101,7 @@ static inline const char *clk_get_name(struct clk *clk)
 }
 
 /**
- * clk_alloc - Allocate a clock structure
+ * clk_alloc() - Allocate a clock structure
  *
  * @name: Clock name
  * @ops: Clock operations
@@ -114,14 +114,14 @@ struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
 		      struct clk **parent_clks, size_t parent_count);
 
 /**
- * clk_free - Free a clock structure
+ * clk_free() - Free a clock structure
  *
  * @clk: Clock to be freed or NULL
  */
 void clk_free(struct clk *clk);
 
 /**
- * clk_register - Register a clock within the clock framework
+ * clk_register() - Register a clock within the clock framework
  *
  * @clk: Clock struct to be registered
  * Return a TEE_Result compliant value
@@ -129,7 +129,7 @@ void clk_free(struct clk *clk);
 TEE_Result clk_register(struct clk *clk);
 
 /**
- * clk_get_rate - Get clock rate
+ * clk_get_rate() - Get clock rate
  *
  * @clk: Clock for which the rate is needed
  * Return the clock rate in Hz
@@ -137,7 +137,7 @@ TEE_Result clk_register(struct clk *clk);
 unsigned long clk_get_rate(struct clk *clk);
 
 /**
- * clk_set_rate - Set a clock rate
+ * clk_set_rate() - Set a clock rate
  *
  * @clk: Clock to be set with the rate
  * @rate: Rate to set in Hz
@@ -146,7 +146,7 @@ unsigned long clk_get_rate(struct clk *clk);
 TEE_Result clk_set_rate(struct clk *clk, unsigned long rate);
 
 /**
- * clk_enable - Enable a clock and its ascendance
+ * clk_enable() - Enable a clock and its ascendance
  *
  * @clk: Clock to be enabled
  * Return a TEE_Result compliant value
@@ -154,14 +154,14 @@ TEE_Result clk_set_rate(struct clk *clk, unsigned long rate);
 TEE_Result clk_enable(struct clk *clk);
 
 /**
- * clk_disable - Disable a clock
+ * clk_disable() - Disable a clock
  *
  * @clk: Clock to be disabled
  */
 void clk_disable(struct clk *clk);
 
 /**
- * clk_is_enabled - Informative state on the clock
+ * clk_is_enabled() - Informative state on the clock
  *
  * This function is useful during specific system sequences where core
  * executes atomically (primary core boot, some low power sequences).
@@ -171,7 +171,7 @@ void clk_disable(struct clk *clk);
 bool clk_is_enabled(struct clk *clk);
 
 /**
- * clk_get_parent - Get the current clock parent
+ * clk_get_parent() - Get the current clock parent
  *
  * @clk: Clock for which the parent is needed
  * Return the clock parent or NULL if there is no parent
@@ -179,7 +179,7 @@ bool clk_is_enabled(struct clk *clk);
 struct clk *clk_get_parent(struct clk *clk);
 
 /**
- * clk_get_num_parents - Get the number of parents for a clock
+ * clk_get_num_parents() - Get the number of parents for a clock
  *
  * @clk: Clock for which the number of parents is needed
  * Return the number of parents
@@ -190,7 +190,7 @@ static inline size_t clk_get_num_parents(struct clk *clk)
 }
 
 /**
- * Get a clock parent by its index
+ * clk_get_parent_by_index() - Get a clock parent by its index
  *
  * @clk: Clock for which the parent is needed
  * @pidx: Parent index for the clock
@@ -199,7 +199,7 @@ static inline size_t clk_get_num_parents(struct clk *clk)
 struct clk *clk_get_parent_by_index(struct clk *clk, size_t pidx);
 
 /**
- * clk_set_parent - Set the current clock parent
+ * clk_set_parent() - Set the current clock parent
  *
  * @clk: Clock for which the parent should be set
  * @parent: Parent clock to set
@@ -208,7 +208,7 @@ struct clk *clk_get_parent_by_index(struct clk *clk, size_t pidx);
 TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
 
 /**
- * clk_get_rates_array - Get supported rates as an array
+ * clk_get_rates_array() - Get supported rates as an array
  *
  * @clk: Clock for which the rates are requested
  * @start_index: start index of requested rates
@@ -221,7 +221,7 @@ TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 			       unsigned long *rates, size_t *nb_elts);
 
 /**
- * clk_get_rates_steps - Get supported rates as min/max/step triplet
+ * clk_get_rates_steps() - Get supported rates as min/max/step triplet
  *
  * @clk: Clock for which the rates are requested
  * @min: Output min supported rate in Hz
@@ -233,7 +233,7 @@ TEE_Result clk_get_rates_steps(struct clk *clk, unsigned long *min,
 			       unsigned long *max, unsigned long *step);
 
 /**
- * clk_get_duty_cycle - Get clock duty cycle
+ * clk_get_duty_cycle() - Get clock duty cycle
  *
  * @clk: Clock for which the duty cycle is requested
  * @duty: Output duty cycle info
@@ -242,8 +242,12 @@ TEE_Result clk_get_rates_steps(struct clk *clk, unsigned long *min,
 TEE_Result clk_get_duty_cycle(struct clk *clk,
 			      struct clk_duty_cycle *duty_cycle);
 
-/* Print current clock tree summary to output console with debug trace level */
 #ifdef CFG_DRIVERS_CLK
+/**
+ * clk_print_tree() - Print current clock tree summary to output console
+ *
+ * The clock is printed with the debug trace level.
+ */
 void clk_print_tree(void);
 #else
 static inline void clk_print_tree(void)

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -16,6 +16,7 @@
 #define CLK_SET_PARENT_GATE	BIT(1) /* must be gated across re-parent */
 #define CLK_DUTY_CYCLE_PARENT	BIT(2) /* forward duty cycle call to parent */
 #define CLK_SET_RATE_PARENT	BIT(3) /* propagate rate change up to parent */
+#define CLK_SET_RATE_UNGATE	BIT(4) /* clock needs to run to set rate */
 
 /**
  * struct clk - Clock structure

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -45,6 +45,17 @@ struct clk {
 };
 
 /**
+ * struct clk_duty_cycle - Encoding the duty cycle ratio of a clock
+ *
+ * @num:	Numerator of the duty cycle ratio
+ * @den:	Denominator of the duty cycle ratio
+ */
+struct clk_duty_cycle {
+	unsigned int num;
+	unsigned int den;
+};
+
+/**
  * struct clk_ops
  *
  * @enable: Enable the clock
@@ -54,6 +65,7 @@ struct clk {
  * @set_rate: Set the clock rate
  * @get_rate: Get the clock rate
  * @get_rates_array: Get the supported clock rates as array
+ * @get_duty_cycle: Get duty cytcle of the clock
  */
 struct clk_ops {
 	TEE_Result (*enable)(struct clk *clk);
@@ -66,6 +78,8 @@ struct clk_ops {
 				  unsigned long parent_rate);
 	TEE_Result (*get_rates_array)(struct clk *clk, size_t start_index,
 				      unsigned long *rates, size_t *nb_elts);
+	TEE_Result (*get_duty_cycle)(struct clk *clk,
+				     struct clk_duty_cycle *duty_cycle);
 };
 
 /**
@@ -198,6 +212,16 @@ TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
  */
 TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 			       unsigned long *rates, size_t *nb_elts);
+
+/**
+ * clk_get_duty_cycle - Get clock duty cycle
+ *
+ * @clk: Clock for which the duty cycle is requested
+ * @duty: Output duty cycle info
+ * Return a TEE_Result compliant value
+ */
+TEE_Result clk_get_duty_cycle(struct clk *clk,
+			      struct clk_duty_cycle *duty_cycle);
 
 /* Print current clock tree summary to output console with debug trace level */
 #ifdef CFG_DRIVERS_CLK

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -68,6 +68,7 @@ struct clk_duty_cycle {
  * @set_rate: Set the clock rate
  * @get_rate: Get the clock rate
  * @get_rates_array: Get the supported clock rates as array
+ * @get_rates_steps: Get support clock rates by min/max/step representation
  * @get_duty_cycle: Get duty cytcle of the clock
  */
 struct clk_ops {
@@ -81,6 +82,8 @@ struct clk_ops {
 				  unsigned long parent_rate);
 	TEE_Result (*get_rates_array)(struct clk *clk, size_t start_index,
 				      unsigned long *rates, size_t *nb_elts);
+	TEE_Result (*get_rates_steps)(struct clk *clk, unsigned long *min,
+				      unsigned long *max, unsigned long *step);
 	TEE_Result (*get_duty_cycle)(struct clk *clk,
 				     struct clk_duty_cycle *duty_cycle);
 };
@@ -215,6 +218,18 @@ TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
  */
 TEE_Result clk_get_rates_array(struct clk *clk, size_t start_index,
 			       unsigned long *rates, size_t *nb_elts);
+
+/**
+ * clk_get_rates_steps - Get supported rates as min/max/step triplet
+ *
+ * @clk: Clock for which the rates are requested
+ * @min: Output min supported rate in Hz
+ * @max: Output max supported rate in Hz
+ * @step: Output rate step in Hz
+ * Returns a TEE_Result compliant value
+ */
+TEE_Result clk_get_rates_steps(struct clk *clk, unsigned long *min,
+			       unsigned long *max, unsigned long *step);
 
 /**
  * clk_get_duty_cycle - Get clock duty cycle

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -14,6 +14,7 @@
 /* Flags for clock */
 #define CLK_SET_RATE_GATE	BIT(0) /* must be gated across rate change */
 #define CLK_SET_PARENT_GATE	BIT(1) /* must be gated across re-parent */
+#define CLK_DUTY_CYCLE_PARENT	BIT(2) /* forward duty cycle call to parent */
 
 /**
  * struct clk - Clock structure

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -13,7 +13,7 @@
 #include <sys/queue.h>
 
 /**
- * CLK_DT_DECLARE - Declare a clock driver
+ * CLK_DT_DECLARE() - Declare a clock driver
  * @__name: Clock driver name
  * @__compat: Compatible string
  * @__probe: Clock probe function
@@ -31,7 +31,7 @@
 	}
 
 /**
- * clk_dt_get_by_index - Get a clock at a specific index in "clocks" property
+ * clk_dt_get_by_index() - Get a clock at a specific index in "clocks" property
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the subnode containing a clock property
@@ -47,7 +47,7 @@ TEE_Result clk_dt_get_by_index(const void *fdt, int nodeoffset,
 			       unsigned int clk_idx, struct clk **clk);
 
 /**
- * clk_dt_get_by_name - Get a clock matching a name in "clock-names" property
+ * clk_dt_get_by_name() - Get a clock matching a name in "clock-names" property
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the subnode containing a clock property
@@ -73,7 +73,7 @@ typedef TEE_Result (*clk_dt_get_func)(struct dt_pargs *args, void *data,
 				      struct clk **out_clk);
 
 /**
- * clk_dt_register_clk_provider - Register a clock provider
+ * clk_dt_register_clk_provider() - Register a clock provider
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the clock
@@ -92,8 +92,12 @@ static inline TEE_Result clk_dt_register_clk_provider(const void *fdt,
 }
 
 /**
- * clk_dt_get_simple_clk: simple clock matching function for single clock
+ * clk_dt_get_simple_clk() - Simple clock matching function for single clock
  * providers
+ *
+ * @args: Unused argument as there is no description to parse
+ * @data: Pointer to data given at clk_dt_register_clk_provider() call
+ * @out_clk: Output clock reference filled with @data
  */
 static inline TEE_Result clk_dt_get_simple_clk(struct dt_pargs *args __unused,
 					       void *data, struct clk **out_clk)


### PR DESCRIPTION
Add an API function to get a clock duty cycle ratio.
Add an API function to get clock linear supported rates description.
Add a clock flag to pre-enable a parent clock before a clock a re-parented.
Update STM32MP13 clock driver.
