### PR TITLE
plat-sam: fix static shared memory address and size

### DIFF
--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -39,8 +39,9 @@ $(call force,CFG_CORE_HAS_GENERIC_TIMER,n)
 $(call force,CFG_TZDRAM_START,0x20000000)
 $(call force,CFG_TZDRAM_SIZE,0x800000)
 
-# This value is forced because this feature isn't used by SAM platforms.
+# This value is forced because these feature aren't used by SAM platforms.
 $(call force,CFG_EXTERNAL_DT,n)
+$(call force,CFG_CORE_DYN_SHM,n)
 
 CFG_MMAP_REGIONS ?= 24
 


### PR DESCRIPTION
Disable the dynamic shared memory allocation that isn't used on SAM
platforms, otherwise the following issue occurs, since the commit
https://github.com/OP-TEE/optee_os/commit/8a6ca1480ddce97894e19bc3bcb57c79967e161c ("core: arm: get DDR range from embedded DTB"):

```
I/TC: Embedded DTB found
E/TC:0 0 check_phys_mem_is_outside:409 Non-sec mem (0x20800000:0x1f800000) overlaps map (type 18 0x21400000:0x1000)
E/TC:0 0 Panic at core/mm/core_mmu.c:413 <check_phys_mem_is_outside>
E/TC:0 0 TEE load address @ 0x20000000
E/TC:0 0 Call stack:
E/TC:0 0  0x20005655 print_kernel_stack at core/arch/arm/kernel/unwind_arm32.c:109
E/TC:0 0  0x2001c52d __do_panic at core/kernel/panic.c:80
E/TC:0 0  0x200276c1 check_phys_mem_is_outside at core/mm/core_mmu.c:413
E/TC:0 0  0x2002780f core_mmu_set_discovered_nsec_ddr at core/mm/core_mmu.c:481
E/TC:0 0  0x200050b3 discover_nsec_memory at core/arch/arm/kernel/boot.c:1055
E/TC:0 0  0x20005247 boot_init_primary_late at core/arch/arm/kernel/boot.c:1210
E/TC:0 0  0x200001fc reset_primary at core/arch/arm/kernel/entry_a32.S:532
```