### PR TITLE
core: dt: provide stubbed dt_getprop_as_number()

### DIFF
--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -86,6 +86,7 @@ struct dt_descriptor {
 
 extern uint8_t embedded_secure_dtb[];
 
+#ifdef CFG_DT
 /*
  * dt_getprop_as_number() - get a DT property a unsigned number
  * @fdt: DT base address
@@ -100,7 +101,6 @@ extern uint8_t embedded_secure_dtb[];
 int dt_getprop_as_number(const void *fdt, int nodeoffset, const char *name,
 			 uint64_t *num);
 
-#ifdef CFG_DT
 /*
  * Find a driver that is suitable for the given DT node, that is, with
  * a matching "compatible" property.
@@ -391,6 +391,14 @@ static inline int fdt_get_reg_props_by_name(const void *fdt __unused,
 					    const char *name __unused,
 					    paddr_t *base __unused,
 					    size_t *size __unused)
+{
+	return -1;
+}
+
+static inline int dt_getprop_as_number(const void *fdt __unused,
+				       int nodeoffset __unused,
+				       const char *name __unused,
+				       uint64_t *num __unused)
 {
 	return -1;
 }


### PR DESCRIPTION
When compiled with CFG_DT=n link the following error can occur: aarch64-linux-gnu-ld.bfd: out/arm/core/arch/arm/kernel/boot.o: in function `get_sec_mem_from_manifest': core/arch/arm/kernel/boot.c:1511: undefined reference to `dt_getprop_as_number' aarch64-linux-gnu-ld.bfd: core/arch/arm/kernel/boot.c:1519: undefined reference to `dt_getprop_as_number' aarch64-linux-gnu-ld.bfd: out/arm/core/mm/core_mmu.o: in function `collect_device_mem_ranges': core/mm/core_mmu.c:982: undefined reference to `dt_getprop_as_number' aarch64-linux-gnu-ld.bfd: core/mm/core_mmu.c:993: undefined reference to `dt_getprop_as_number'

Fix this by adding a stubbed version of dt_getprop_as_number() when CFG_DT=n.

Link: https://github.com/OP-TEE/optee_os/issues/6537
Fixes: 4e45454a85d3 ("core: add dt_getprop_as_number()")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
