### PR TITLE
drivers: regulator: read current level from the device

### DIFF
--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -85,7 +85,6 @@ struct regulator_voltages_desc {
  * @name: Regulator string name for debug purpose or NULL
  * @min_uv: Min possible voltage level in microvolt (uV)
  * @max_uv: Max possible voltage level in microvolt (uV)
- * @cur_uv: Current voltage level in microvolt (uV)
  * @flags: REGULATOR_* property flags
  * @refcount: Regulator enable request reference counter
  * @lock: Mutex for concurrent access protection
@@ -101,7 +100,6 @@ struct regulator {
 	int min_uv;
 	int max_uv;
 	/* Fields internal to regulator framework */
-	int cur_uv;
 	unsigned int flags;
 	unsigned int refcount;
 	struct mutex lock;	/* Concurrent access protection */
@@ -283,13 +281,10 @@ static inline TEE_Result regulator_set_min_voltage(struct regulator *regulator)
 }
 
 /*
- * regulator_get_voltage() - Get regulator current level in microvolt
+ * regulator_get_voltage() - Get regulator effective voltage level in microvolt
  * @regulator: Regulator reference
  */
-static inline int regulator_get_voltage(struct regulator *regulator)
-{
-	return regulator->cur_uv;
-}
+int regulator_get_voltage(struct regulator *regulator);
 
 /*
  * regulator_get_range() - Get regulator min and/or max support levels


### PR DESCRIPTION
Always read current voltage level from the device instead of caching the level in struct regulator. This fixes issues for when the regulator level value depends on the parent regulator (supply). It is up the regulator driver to cache or not this value in their private data if applicable.

