### PR TITLE
core: arm: fix integer overflow in generic_timer_handler()

### DIFF
--- a/core/arch/arm/kernel/timer_a64.c
+++ b/core/arch/arm/kernel/timer_a64.c
@@ -13,7 +13,7 @@ static bool timer_running;
 void generic_timer_start(uint32_t time_ms)
 {
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
-	uint32_t timer_ticks;
+	uint32_t timer_ticks = 0;
 
 	cpu_spin_lock(&timer_lock);
 
@@ -21,7 +21,7 @@ void generic_timer_start(uint32_t time_ms)
 		goto exit;
 
 	/* The timer will fire time_ms from now */
-	timer_ticks = (read_cntfrq() * time_ms) / 1000;
+	timer_ticks = ((uint64_t)read_cntfrq() * time_ms) / 1000;
 	write_cntps_tval(timer_ticks);
 
 	/* Enable the secure physical timer */
@@ -51,7 +51,7 @@ void generic_timer_stop(void)
 
 void generic_timer_handler(uint32_t time_ms)
 {
-	uint32_t timer_ticks;
+	uint32_t timer_ticks = 0;
 
 	/* Ensure that the timer did assert the interrupt */
 	assert((read_cntps_ctl() >> 2));
@@ -60,7 +60,7 @@ void generic_timer_handler(uint32_t time_ms)
 	write_cntps_ctl(0);
 
 	/* Reconfigure timer to fire time_ms from now */
-	timer_ticks = (read_cntfrq() * time_ms) / 1000;
+	timer_ticks = ((uint64_t)read_cntfrq() * time_ms) / 1000;
 	write_cntps_tval(timer_ticks);
 
 	/* Enable the secure physical timer */


### PR DESCRIPTION
read_cntfrq() can return a pretty large 32-bit number, multiplying that with a dealy of 1000 ms can overflow. Fix that by casting the result from read_cntfrq() to a uint64_t to avoid overflow during the calculation.

Fixes: ba6b29591828 ("core: arm64: Add Secure EL1 physical timer framework")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
