### PR TITLE
drivers: crypto: stm32_saes: fallback to software on 192bit AES keys

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -332,6 +332,9 @@ endif
 CFG_ENABLE_EMBEDDED_TESTS ?= y
 CFG_WITH_STATS ?= y
 
+# Default enable software fallback on crypto drivers
+CFG_STM32_SAES_SW_FALLBACK ?= y
+
 # Enable OTP update with BSEC driver
 CFG_STM32_BSEC_WRITE ?= y
 

--- a/core/drivers/crypto/stm32/authenc.c
+++ b/core/drivers/crypto/stm32/authenc.c
@@ -355,15 +355,15 @@ static TEE_Result stm32_ae_allocate(void **ctx, uint32_t algo)
  * Registration of the Authenc Driver
  */
 static struct drvcrypt_authenc driver_authenc = {
-	.alloc_ctx = &stm32_ae_allocate,
-	.free_ctx = &stm32_ae_free,
-	.init = &stm32_ae_initialize,
-	.update_aad = &stm32_ae_update_aad,
-	.update_payload = &stm32_ae_update_payload,
-	.enc_final = &stm32_ae_enc_final,
-	.dec_final = &stm32_ae_dec_final,
-	.final = &stm32_ae_final,
-	.copy_state = &stm32_ae_copy_state,
+	.alloc_ctx = stm32_ae_allocate,
+	.free_ctx = stm32_ae_free,
+	.init = stm32_ae_initialize,
+	.update_aad = stm32_ae_update_aad,
+	.update_payload = stm32_ae_update_payload,
+	.enc_final = stm32_ae_enc_final,
+	.dec_final = stm32_ae_dec_final,
+	.final = stm32_ae_final,
+	.copy_state = stm32_ae_copy_state,
 };
 
 TEE_Result stm32_register_authenc(void)

--- a/core/drivers/crypto/stm32/cipher.c
+++ b/core/drivers/crypto/stm32/cipher.c
@@ -87,6 +87,11 @@ static TEE_Result cryp_update(union ip_ctx *ip_ctx, bool last_block,
 	return stm32_cryp_update(&ip_ctx->cryp.ctx, last_block, src, dst, len);
 }
 
+static const struct ip_cipher_ops cryp_ops = {
+	.init = cryp_init,
+	.update = cryp_update,
+};
+
 static TEE_Result saes_init(union ip_ctx *ip_ctx, bool is_decrypt,
 			    const uint8_t *key, size_t key_len,
 			    const uint8_t *iv, size_t iv_len)
@@ -109,12 +114,7 @@ static TEE_Result saes_update(union ip_ctx *ip_ctx, bool last_block,
 	return stm32_saes_update(&ip_ctx->saes.ctx, last_block, src, dst, len);
 }
 
-const struct ip_cipher_ops cryp_ops = {
-	.init = cryp_init,
-	.update = cryp_update,
-};
-
-const struct ip_cipher_ops saes_ops = {
+static const struct ip_cipher_ops saes_ops = {
 	.init = saes_init,
 	.update = saes_update,
 };

--- a/core/drivers/crypto/stm32/cipher.c
+++ b/core/drivers/crypto/stm32/cipher.c
@@ -27,6 +27,9 @@ struct cryp_ctx {
 struct saes_ctx {
 	struct stm32_saes_context ctx;
 	enum stm32_saes_chaining_mode algo;
+	/* Fallback to software implementation on 192bit AES key */
+	bool use_fallback;
+	struct crypto_cipher_ctx *fallback_ctx;
 };
 
 /*
@@ -47,6 +50,8 @@ struct ip_cipher_ops {
 			   const uint8_t *iv, size_t iv_len);
 	TEE_Result (*update)(union ip_ctx *ctx, bool last_block, uint8_t *src,
 			     uint8_t *dst, size_t len);
+	void (*final)(union ip_ctx *ctx);
+	void (*copy_state)(union ip_ctx *dst_ctx, union ip_ctx *src_ctx);
 };
 
 struct stm32_cipher_ctx {
@@ -87,9 +92,17 @@ static TEE_Result cryp_update(union ip_ctx *ip_ctx, bool last_block,
 	return stm32_cryp_update(&ip_ctx->cryp.ctx, last_block, src, dst, len);
 }
 
+static void cryp_copy_state(union ip_ctx *dst_ip_ctx, union ip_ctx *src_ip_ctx)
+{
+	assert(IS_ENABLED(CFG_STM32_CRYP));
+
+	memcpy(&dst_ip_ctx->cryp, &src_ip_ctx->cryp, sizeof(dst_ip_ctx->cryp));
+}
+
 static const struct ip_cipher_ops cryp_ops = {
 	.init = cryp_init,
 	.update = cryp_update,
+	.copy_state = cryp_copy_state,
 };
 
 static TEE_Result saes_init(union ip_ctx *ip_ctx, bool is_decrypt,
@@ -101,6 +114,34 @@ static TEE_Result saes_init(union ip_ctx *ip_ctx, bool is_decrypt,
 	if (!IS_ENABLED(CFG_STM32_SAES))
 		return TEE_ERROR_NOT_IMPLEMENTED;
 
+	if (key_len == AES_KEYSIZE_192) {
+		struct crypto_cipher_ctx *ctx = ip_ctx->saes.fallback_ctx;
+		TEE_OperationMode mode = TEE_MODE_ILLEGAL_VALUE;
+		TEE_Result res = TEE_ERROR_GENERIC;
+
+		if (!IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK)) {
+			EMSG("STM32 SAES does not support 192bit keys");
+
+			return TEE_ERROR_NOT_IMPLEMENTED;
+		}
+
+		if (is_decrypt)
+			mode = TEE_MODE_DECRYPT;
+		else
+			mode = TEE_MODE_ENCRYPT;
+
+		res = ctx->ops->init(ctx, mode, key, key_len, NULL, 0, iv,
+				     iv_len);
+		if (res)
+			return res;
+
+		ip_ctx->saes.use_fallback = true;
+
+		return TEE_SUCCESS;
+	}
+
+	ip_ctx->saes.use_fallback = false;
+
 	return stm32_saes_init(&ip_ctx->saes.ctx, is_decrypt, ip_ctx->saes.algo,
 			       key_sel, key, key_len, iv, iv_len);
 }
@@ -111,12 +152,52 @@ static TEE_Result saes_update(union ip_ctx *ip_ctx, bool last_block,
 	if (!IS_ENABLED(CFG_STM32_SAES))
 		return TEE_ERROR_NOT_IMPLEMENTED;
 
+	if (ip_ctx->saes.use_fallback) {
+		struct crypto_cipher_ctx *ctx = ip_ctx->saes.fallback_ctx;
+
+		assert(IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK));
+
+		return ctx->ops->update(ctx, last_block, src, len, dst);
+	}
+
 	return stm32_saes_update(&ip_ctx->saes.ctx, last_block, src, dst, len);
+}
+
+static void saes_final(union ip_ctx *ip_ctx)
+{
+	struct crypto_cipher_ctx *ctx = ip_ctx->saes.fallback_ctx;
+
+	assert(IS_ENABLED(CFG_STM32_SAES));
+
+	if (ip_ctx->saes.use_fallback) {
+		assert(IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK));
+		ctx->ops->final(ctx);
+	}
+}
+
+static void saes_copy_state(union ip_ctx *dst_ip_ctx, union ip_ctx *src_ip_ctx)
+{
+	struct saes_ctx *src_ctx = &src_ip_ctx->saes;
+	struct crypto_cipher_ctx *fb_ctx = src_ctx->fallback_ctx;
+
+	assert(IS_ENABLED(CFG_STM32_SAES));
+
+	memcpy(&dst_ip_ctx->saes.ctx, &src_ctx->ctx, sizeof(src_ctx->ctx));
+
+	dst_ip_ctx->saes.algo = src_ctx->algo;
+	dst_ip_ctx->saes.use_fallback = src_ctx->use_fallback;
+
+	if (src_ctx->use_fallback) {
+		assert(IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK));
+		fb_ctx->ops->copy_state(dst_ip_ctx->saes.fallback_ctx, fb_ctx);
+	}
 }
 
 static const struct ip_cipher_ops saes_ops = {
 	.init = saes_init,
 	.update = saes_update,
+	.final = saes_final,
+	.copy_state = saes_copy_state,
 };
 
 static struct stm32_cipher_ctx *
@@ -147,14 +228,18 @@ static TEE_Result stm32_cipher_update(struct drvcrypt_cipher_update *dupdate)
 
 static void stm32_cipher_final(void *ctx __unused)
 {
+	struct stm32_cipher_ctx *c = to_stm32_cipher_ctx(ctx);
+
+	if (c->ops->final)
+		c->ops->final(&c->ip_ctx);
 }
 
 static void stm32_cipher_copy_state(void *dst_ctx, void *src_ctx)
 {
-	struct stm32_cipher_ctx *src = to_stm32_cipher_ctx(src_ctx);
-	struct stm32_cipher_ctx *dst = to_stm32_cipher_ctx(dst_ctx);
+	struct stm32_cipher_ctx *src_c = to_stm32_cipher_ctx(src_ctx);
+	struct stm32_cipher_ctx *dst_c = to_stm32_cipher_ctx(dst_ctx);
 
-	memcpy(dst, src, sizeof(*dst));
+	src_c->ops->copy_state(&dst_c->ip_ctx, &src_c->ip_ctx);
 }
 
 static TEE_Result alloc_cryp_ctx(void **ctx, enum stm32_cryp_algo_mode algo)
@@ -197,48 +282,75 @@ static TEE_Result stm32_cryp_cipher_allocate(void **ctx, uint32_t algo)
 	}
 }
 
-static TEE_Result alloc_saes_ctx(void **ctx, enum stm32_saes_chaining_mode algo)
-{
-	struct stm32_cipher_ctx *c = calloc(1, sizeof(*c));
-
-	if (!c)
-		return TEE_ERROR_OUT_OF_MEMORY;
-
-	FMSG("Using SAES %d", algo);
-	c->ip_ctx.saes.algo = algo;
-	c->ops = &saes_ops;
-	*ctx = &c->c_ctx;
-
-	return TEE_SUCCESS;
-}
-
-static TEE_Result stm32_saes_cipher_allocate(void **ctx, uint32_t algo)
-{
-	/*
-	 * Convert TEE_ALGO id to internal id
-	 */
-	switch (algo) {
-	case TEE_ALG_AES_ECB_NOPAD:
-		return alloc_saes_ctx(ctx, STM32_SAES_MODE_ECB);
-	case TEE_ALG_AES_CBC_NOPAD:
-		return alloc_saes_ctx(ctx, STM32_SAES_MODE_CBC);
-	case TEE_ALG_AES_CTR:
-		return alloc_saes_ctx(ctx, STM32_SAES_MODE_CTR);
-	default:
-		return TEE_ERROR_NOT_IMPLEMENTED;
-	}
-}
-
-static void stm32_cipher_free(void *ctx)
+static void stm32_cryp_cipher_free(void *ctx)
 {
 	struct stm32_cipher_ctx *c = to_stm32_cipher_ctx(ctx);
 
 	free(c);
 }
 
+static TEE_Result stm32_saes_cipher_allocate(void **ctx, uint32_t algo)
+{
+	enum stm32_saes_chaining_mode saes_algo = STM32_SAES_MODE_ECB;
+	struct crypto_cipher_ctx *fallback_ctx = NULL;
+	struct stm32_cipher_ctx *saes_ctx = NULL;
+	TEE_Result res = TEE_SUCCESS;
+
+	switch (algo) {
+	case TEE_ALG_AES_ECB_NOPAD:
+		saes_algo = STM32_SAES_MODE_ECB;
+		if (IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK))
+			res = crypto_aes_ecb_alloc_ctx(&fallback_ctx);
+		break;
+	case TEE_ALG_AES_CBC_NOPAD:
+		saes_algo = STM32_SAES_MODE_CBC;
+		if (IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK))
+			res = crypto_aes_cbc_alloc_ctx(&fallback_ctx);
+		break;
+	case TEE_ALG_AES_CTR:
+		saes_algo = STM32_SAES_MODE_CTR;
+		if (IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK))
+			res = crypto_aes_ctr_alloc_ctx(&fallback_ctx);
+		break;
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+	if (res)
+		return res;
+
+	saes_ctx = calloc(1, sizeof(*saes_ctx));
+	if (!saes_ctx) {
+		if (IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK))
+			fallback_ctx->ops->free_ctx(fallback_ctx);
+
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	FMSG("Using SAES %d", saes_algo);
+	saes_ctx->ip_ctx.saes.algo = saes_algo;
+	saes_ctx->ops = &saes_ops;
+	saes_ctx->ip_ctx.saes.fallback_ctx = fallback_ctx;
+	*ctx = &saes_ctx->c_ctx;
+
+	return TEE_SUCCESS;
+}
+
+static void stm32_saes_cipher_free(void *ctx)
+{
+	struct stm32_cipher_ctx *c = to_stm32_cipher_ctx(ctx);
+
+	if (IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK)) {
+		struct crypto_cipher_ctx *fb_ctx = c->ip_ctx.saes.fallback_ctx;
+
+		fb_ctx->ops->free_ctx(fb_ctx);
+	}
+
+	free(c);
+}
+
 static struct drvcrypt_cipher driver_cipher_cryp = {
 	.alloc_ctx = stm32_cryp_cipher_allocate,
-	.free_ctx = stm32_cipher_free,
+	.free_ctx = stm32_cryp_cipher_free,
 	.init = stm32_cipher_initialize,
 	.update = stm32_cipher_update,
 	.final = stm32_cipher_final,
@@ -247,7 +359,7 @@ static struct drvcrypt_cipher driver_cipher_cryp = {
 
 static struct drvcrypt_cipher driver_cipher_saes = {
 	.alloc_ctx = stm32_saes_cipher_allocate,
-	.free_ctx = stm32_cipher_free,
+	.free_ctx = stm32_saes_cipher_free,
 	.init = stm32_cipher_initialize,
 	.update = stm32_cipher_update,
 	.final = stm32_cipher_final,

--- a/core/drivers/crypto/stm32/cipher.c
+++ b/core/drivers/crypto/stm32/cipher.c
@@ -249,21 +249,21 @@ static TEE_Result stm32_saes_cipher_allocate(void **ctx, uint32_t algo)
 }
 
 static struct drvcrypt_cipher driver_cipher_cryp = {
-	.alloc_ctx = &stm32_cryp_cipher_allocate,
-	.free_ctx = &stm32_cipher_free,
-	.init = &stm32_cipher_initialize,
-	.update = &stm32_cipher_update,
-	.final = &stm32_cipher_final,
-	.copy_state = &stm32_cipher_copy_state,
+	.alloc_ctx = stm32_cryp_cipher_allocate,
+	.free_ctx = stm32_cipher_free,
+	.init = stm32_cipher_initialize,
+	.update = stm32_cipher_update,
+	.final = stm32_cipher_final,
+	.copy_state = stm32_cipher_copy_state,
 };
 
 static struct drvcrypt_cipher driver_cipher_saes = {
-	.alloc_ctx = &stm32_saes_cipher_allocate,
-	.free_ctx = &stm32_cipher_free,
-	.init = &stm32_cipher_initialize,
-	.update = &stm32_cipher_update,
-	.final = &stm32_cipher_final,
-	.copy_state = &stm32_cipher_copy_state,
+	.alloc_ctx = stm32_saes_cipher_allocate,
+	.free_ctx = stm32_cipher_free,
+	.init = stm32_cipher_initialize,
+	.update = stm32_cipher_update,
+	.final = stm32_cipher_final,
+	.copy_state = stm32_cipher_copy_state,
 };
 
 TEE_Result stm32_register_cipher(enum stm32_cipher_ip_id cipher_ip)

--- a/core/drivers/crypto/stm32/stm32_saes.c
+++ b/core/drivers/crypto/stm32/stm32_saes.c
@@ -1428,5 +1428,5 @@ static const struct dt_device_match saes_match_table[] = {
 DEFINE_DT_DRIVER(stm32_saes_dt_driver) = {
 	.name = "stm32-saes",
 	.match_table = saes_match_table,
-	.probe = &stm32_saes_probe,
+	.probe = stm32_saes_probe,
 };


### PR DESCRIPTION
Implement AES software operation for when AES key is 192 bit that is not supported by the STM32 SAES engine.
This P-R includes cleanup and preparatory patches followed by the above mentioned AES-192b software fallback implementation.