### PR TITLE
ci: update actions/checkout@v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     container: jforissier/optee_os_ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history so checkpatch can check commit IDs in commit messages
       - name: Update Git config
@@ -67,7 +67,7 @@ jobs:
           restore-keys: |
             builds-cache-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - shell: bash
         run: |
           # build task
@@ -276,7 +276,7 @@ jobs:
           restore-keys: |
             qemuv8_check-cache-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - shell: bash
         run: |
           # make check task
@@ -315,7 +315,7 @@ jobs:
           restore-keys: |
             qemuv8_xen_check-cache-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - shell: bash
         run: |
           # make check task
@@ -348,7 +348,7 @@ jobs:
           restore-keys: |
             qemuv8_hafnium_check-cache-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - shell: bash
         run: |
           # make check task
@@ -379,7 +379,7 @@ jobs:
           restore-keys: |
             qemuv8_check_bti_mte_pac-cache-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - shell: bash
         run: |
           # make check task


### PR DESCRIPTION
Updatate the "checkout" action to fix the following warning:

 Node.js 16 actions are deprecated. Please update the following
 actions to use Node.js 20: actions/checkout@v3. [...]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
