### PR TITLE
core: dts: lx2160a: add memory region

### DIFF
--- a/core/arch/arm/dts/fsl-lx2160a.dtsi
+++ b/core/arch/arm/dts/fsl-lx2160a.dtsi
@@ -416,6 +416,12 @@
 		reg = <0x00000000 0x80000000 0 0x80000000>;
 	};
 
+	memory@2080000000 {
+		// DRAM space - 1, size : 126 GB DRAM
+		device_type = "memory";
+		reg = <0x00000020 0x80000000 0x0000001F 0x80000000>;
+	};
+
 	ddr1: memory-controller@1080000 {
 		compatible = "fsl,qoriq-memory-controller";
 		reg = <0x0 0x1080000 0x0 0x1000>;


### PR DESCRIPTION
With patch 8a6ca14 (core: arm: get DDR range from embedded DTB) now DDR ranges are taken from Embedded DTB if enabled and will ignore DDR ranges defined by register_ddr().
Since Dynamic shared memory and Embedded DTB config is enabled on LX2160A platforms, need to add the DDR ranges to the DTS.