### PR TITLE
ci: qemuv8: preventively avoid "no space left on device" error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,8 @@ jobs:
     runs-on: ubuntu-latest
     container: jforissier/optee_os_ci:qemuv8_check2
     steps:
+      - name: Remove /__t/*
+        run: rm -rf /__t/*
       - name: Restore build cache
         uses: actions/cache@v3
         with:
@@ -371,6 +373,8 @@ jobs:
     runs-on: ubuntu-latest
     container: jforissier/optee_os_ci:qemuv8_check2
     steps:
+      - name: Remove /__t/*
+        run: rm -rf /__t/*
       - name: Restore build cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
During my testing of build.git PR 731 ("optee_rust_examples_ext: Fix Rust toolchain conflicts"), I noticed that the "no space left on device" error was triggered yet again (obviously due to more size being taken on the disk by the Rust toolchain and the OP-TEE Rust examples).

Therefore, preventively apply the same fix as for other jobs. This way the CI should pass when 731 is merged.

Link: https://github.com/OP-TEE/build

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
