### PR TITLE
core: crypto: fix crypto_asym_get_ecc_keypair_ops() stub

### DIFF
--- a/core/include/crypto/crypto_impl.h
+++ b/core/include/crypto/crypto_impl.h
@@ -463,7 +463,7 @@ crypto_asym_alloc_ecc_public_key(struct ecc_public_key *key __unused,
 }
 
 static inline const struct crypto_ecc_keypair_ops *
-crypto_asym_get_keypair_ops(uint32_t key_type __unused)
+crypto_asym_get_ecc_keypair_ops(uint32_t key_type __unused)
 {
 	return NULL;
 }


### PR DESCRIPTION
Correct definition of crypto_asym_get_ecc_keypair_ops() stub inline function when CFG_CRYPTO_ECC is disabled. The definition used a wrong function label.

Fixes: 5516c6cd78da ("core: ecc: support the crypto driver")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
