### PR TITLE
ta: pkcs11: Clarify context reference in step_symm_operation()

### DIFF
--- a/ta/pkcs11/src/processing_symm.c
+++ b/ta/pkcs11/src/processing_symm.c
@@ -841,7 +841,7 @@ enum pkcs11_rc step_symm_operation(struct pkcs11_session *session,
 	/*
 	 * Finalize (PKCS11_FUNC_STEP_ONESHOT/_FINAL) operation
 	 */
-	switch (session->processing->mecha_type) {
+	switch (proc->mecha_type) {
 	case PKCS11_CKM_AES_CMAC:
 	case PKCS11_CKM_MD5_HMAC:
 	case PKCS11_CKM_SHA_1_HMAC:
@@ -880,8 +880,8 @@ enum pkcs11_rc step_symm_operation(struct pkcs11_session *session,
 	case PKCS11_CKM_SHA256_HMAC_GENERAL:
 	case PKCS11_CKM_SHA384_HMAC_GENERAL:
 	case PKCS11_CKM_SHA512_HMAC_GENERAL:
-		assert(session->processing->extra_ctx);
-		hmac_len = *(uint32_t *)session->processing->extra_ctx;
+		assert(proc->extra_ctx);
+		hmac_len = *(uint32_t *)proc->extra_ctx;
 
 		switch (function) {
 		case PKCS11_FUNCTION_SIGN:


### PR DESCRIPTION
Function step_symm_operation() defines a local variable to reference the session processing context but uses both session reference and this local variable which can be confusing when reading the code. Change the implementation to only use the local variable for consistency. No functional changes.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
