### PR TITLE
Memtag fix

### DIFF
--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -353,6 +353,10 @@ clear_nex_bss:
 	bl	console_init
 #endif
 
+#ifdef CFG_MEMTAG
+	bl	boot_clear_memtag
+#endif
+
 #ifdef CFG_NS_VIRTUALIZATION
 	/*
 	 * Initialize partition tables for each partition to

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -45,6 +45,7 @@ extern const struct core_mmu_config boot_mmu_config;
 void boot_init_primary_early(void);
 void boot_init_primary_late(unsigned long fdt, unsigned long manifest);
 void boot_init_memtag(void);
+void boot_clear_memtag(void);
 void boot_save_args(unsigned long a0, unsigned long a1, unsigned long a2,
 		    unsigned long a3, unsigned long a4);
 


### PR DESCRIPTION
I wasn't able to reproduce the problem reported in https://github.com/OP-TEE/optee_os/issues/6649 with the FVP Foundation model or Base model. In the Foundation model, MTE was disabled, so not much to test. With the Base model, I was able to enable MTE with `-C cluster0.memory_tagging_support_level=2`, but it still didn't abort when clearing tags without MMU enabled.

I'm fixing the issue differently here since we're mapping the RO/RX parts with tags also. I'm not sure if that makes sense, but we don't want to risk having garbage in the memory tags or we could have problems.

@odeprez, @sichunqin does this fix the memtag issue for you?