### PR TITLE
ta: pkcs11: fix build warning on unused variable

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -258,8 +258,8 @@ static enum pkcs11_rc set_mandatory_attributes(struct obj_attrs **out,
 	return rc;
 }
 
-static enum pkcs11_rc get_default_value(enum pkcs11_attr_id id, void **value,
-					uint32_t *size)
+static enum pkcs11_rc get_default_value(enum pkcs11_attr_id id __maybe_unused,
+					void **value, uint32_t *size)
 {
 	/* should have been taken care of already */
 	assert(!pkcs11_attr_is_boolean(id));
@@ -1643,8 +1643,9 @@ static bool __maybe_unused check_attr_bval(uint32_t proc_id __maybe_unused,
  * @proc_id - PKCS11_CKM_xxx
  * @head - head of the attributes of the to-be-created object.
  */
-enum pkcs11_rc check_created_attrs_against_processing(uint32_t proc_id,
-						      struct obj_attrs *head)
+enum pkcs11_rc
+check_created_attrs_against_processing(uint32_t proc_id,
+				       struct obj_attrs *head __maybe_unused)
 {
 	/*
 	 * Processings that do not create secrets are not expected to call


### PR DESCRIPTION
Add missing __maybe_unused attribute for function arguments not used when the pkcs11 TA is built with NDEBUG directive.

Fixes: 63f89caa9022 ("ta: pkcs11: attribute helper functions")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
