### PR TITLE
core: reset cancellation mask on TA entry

### DIFF
--- a/core/kernel/user_ta.c
+++ b/core/kernel/user_ta.c
@@ -223,11 +223,12 @@ out:
 	dec_recursion();
 out_clr_cancel:
 	/*
-	 * Clear the cancel state now that the user TA has returned. The next
+	 * Reset the cancel state now that the user TA has returned. The next
 	 * time the TA will be invoked will be with a new operation and should
 	 * not have an old cancellation pending.
 	 */
 	ta_sess->cancel = false;
+	ta_sess->cancel_mask = true;
 
 	return res;
 }


### PR DESCRIPTION
Before this patch, the TA cancellation mask was only reset when the session was created, but the GP spec requires the cancellation mask to be reset each time a TA is entered via one of its entry points. So fix this by resetting the cancellation mask at the same time as when setting the cancellation request timeout.

Link: https://github.com/OP-TEE/optee_test/issues/731
Fixes: b01047730e77 ("Open-source the TEE Core")

Depends on https://github.com/OP-TEE/optee_test/pull/732

@bvalliere @c-auger please provide your email addresses if you want a `Reported-by:` tag for this patch.