### PR TITLE
core: io: fix IO_READ32_POLL_TIMEOUT() when delay is 0us

### DIFF
--- a/core/include/io.h
+++ b/core/include/io.h
@@ -7,6 +7,7 @@
 
 #include <compiler.h>
 #include <kernel/delay.h>
+#include <kernel/delay_arch.h>
 #include <stdint.h>
 #include <types_ext.h>
 #include <utee_defines.h>
@@ -287,14 +288,13 @@ static inline void io_clrsetbits8(vaddr_t addr, uint8_t clear_mask,
  */
 #define IO_READ32_POLL_TIMEOUT(_addr, _val, _cond, _delay_us, _timeout_us) \
 	({ \
-		uint32_t __timeout = 0; \
+		uint64_t __timeout = timeout_init_us(_timeout_us); \
 		uint32_t __delay = (_delay_us); \
 		\
-		while (__timeout < (_timeout_us)) { \
+		while (!timeout_elapsed(__timeout)) { \
 			(_val) = io_read32(_addr); \
 			if (_cond) \
 				break; \
-			__timeout += (__delay); \
 			udelay(__delay); \
 		} \
 		(_val) = io_read32(_addr); \


### PR DESCRIPTION
Fix detection of timeout condition in IO_READ32_POLL_TIMEOUT() that was never triggered when delay argument is 0us. Indeed 0 is not a useful increment value for a timeout counter.

Fixes: 97ea199a2ae8 ("core: io: IO_READ32_POLL_TIMEOUT()")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
