### PR TITLE
plat-stm32mp2: add pm support on stm32mp25 

### DIFF
--- a/core/arch/arm/plat-stm32mp2/stm32mp_pm.c
+++ b/core/arch/arm/plat-stm32mp2/stm32mp_pm.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023-2024, STMicroelectronics
+ */
+
+#include <kernel/misc.h>
+#include <kernel/pm.h>
+#include <kernel/thread.h>
+#include <sm/psci.h>
+#include <stm32mp_pm.h>
+
+/**
+ * @brief   Handler for system off
+ *
+ * @param[in] a0   Unused
+ * @param[in] a1   Unused
+ *
+ * @retval 0       if OK, other value else and TF-A will panic
+ */
+unsigned long thread_system_off_handler(unsigned long a0 __unused,
+					unsigned long a1 __unused)
+{
+	/*
+	 * configure targeted mode in PMIC for system OFF,
+	 * no need to save context
+	 */
+	uint32_t pm_hint = PM_HINT_CLOCK_STATE |
+		((PM_MAX_LEVEL << PM_HINT_PLATFORM_STATE_SHIFT) &
+		  PM_HINT_PLATFORM_STATE_MASK);
+
+	return pm_change_state(PM_OP_SUSPEND, pm_hint);
+}
+
+static uint32_t get_pm_hint(unsigned long a0)
+{
+	uint32_t pm_hint = 0U;
+
+	/* a0 is the highest power level which was powered down. */
+	if (a0 < PM_D2_LPLV_LEVEL)
+		pm_hint = PM_HINT_CLOCK_STATE;
+	else
+		pm_hint = PM_HINT_CONTEXT_STATE;
+
+	pm_hint |= ((a0 << PM_HINT_PLATFORM_STATE_SHIFT) &
+		    PM_HINT_PLATFORM_STATE_MASK);
+
+	return pm_hint;
+}
+
+/**
+ * @brief   Handler for cpu resume
+ *
+ * @param[in] a0   Max power level powered down
+ * @param[in] a1   Unused
+ *
+ * @retval 0       if OK, other value else and TF-A will panic
+ */
+unsigned long thread_cpu_resume_handler(unsigned long a0,
+					unsigned long a1 __unused)
+{
+	TEE_Result retstatus = TEE_SUCCESS;
+
+	retstatus = pm_change_state(PM_OP_RESUME, get_pm_hint(a0));
+
+	/*
+	 * Returned value to the TF-A.
+	 * If it is not 0, the system will panic
+	 */
+	if (retstatus == TEE_SUCCESS)
+		return 0;
+	else
+		return 1;
+}
+
+/**
+ * @brief   Handler for cpu suspend
+ *
+ * @param[in] a0   Max power level to power down
+ * @param[in] a1   Unused
+ *
+ * @retval 0       if OK, other value else and TF-A will panic
+ */
+unsigned long thread_cpu_suspend_handler(unsigned long a0,
+					 unsigned long a1 __unused)
+{
+	TEE_Result retstatus = TEE_SUCCESS;
+
+	retstatus = pm_change_state(PM_OP_SUSPEND, get_pm_hint(a0));
+
+	/*
+	 * Returned value to the TF-A.
+	 * If it is not 0, the system will panic
+	 */
+	if (retstatus == TEE_SUCCESS)
+		return 0;
+	else
+		return 1;
+}

--- a/core/arch/arm/plat-stm32mp2/stm32mp_pm.h
+++ b/core/arch/arm/plat-stm32mp2/stm32mp_pm.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023-2024, STMicroelectronics
+ */
+
+#ifndef __STM32MP_PM_H__
+#define __STM32MP_PM_H__
+
+/*
+ * The PSCI topology is defined in TF-A, with 5 power levels supported in
+ * the first parameter a0="Max power level powered down" of TF-A SPD hooks
+ *
+ * power level                (associated low power mode for a0)
+ * 0: CPU1 core#0 or core#1   (Stop1 or LP-Stop1)
+ * 1: D1 domain               (LPLV-Stop1)
+ * 2: LPLV D1                 (Stop2 or LP-Stop2)
+ * 3: D2                      (LPLV-Stop1)
+ * 4: LPLV D2                 (Standby)
+ * 5: MAX                     (PowerOff)
+ *
+ * these power level are only managed in power driver (PMIC), for pm function
+ * use the 2 associated parameters:
+ * - PM_HINT_CONTEXT_STATE : advertise driver to save all their context in DDR
+ *                           (self refresh) for standby mode
+ * - PM_HINT_CLOCK_STATE : advertise driver to interrupt operation when clock
+ *                         are stalled for the other low power modes
+ */
+#define PM_CORE_LEVEL           0
+#define PM_D1_LEVEL             1
+#define PM_D1_LPLV_LEVEL        2
+#define PM_D2_LEVEL             3
+#define PM_D2_LPLV_LEVEL        4
+#define PM_MAX_LEVEL            5
+
+#endif /*__STM32MP_PM_H__*/

--- a/core/arch/arm/plat-stm32mp2/sub.mk
+++ b/core/arch/arm/plat-stm32mp2/sub.mk
@@ -1,3 +1,4 @@
 global-incdirs-y += .
 
 srcs-y += main.c
+srcs-y += stm32mp_pm.c

--- a/core/include/kernel/pm.h
+++ b/core/include/kernel/pm.h
@@ -30,6 +30,12 @@
 #define PM_HINT_PLATFORM_STATE_MASK	GENMASK_32(31, 16)
 #define PM_HINT_PLATFORM_STATE_SHIFT	U(16)
 
+#define PM_HINT_STATE(_x)		((_x) & ~PM_HINT_PLATFORM_STATE_MASK)
+#define PM_HINT_PLATFORM_STATE(_x) \
+	(((_x) & PM_HINT_PLATFORM_STATE_MASK) >> PM_HINT_PLATFORM_STATE_SHIFT)
+
+#define PM_HINT_IS_STATE(_x, _name) ((_x) & PM_HINT_ ## _name ## _STATE)
+
 /*
  * PM_OP_SUSPEND: platform is suspending to a target low power state
  * PM_OP_RESUME: platform is resuming from low power state


### PR DESCRIPTION
This series add a preliminary support of low power mode on STM32MP25 SoC, including power off,
and perform the needed OP-TEE bookkeeping before PSCI stack in TF-A BL31 executes a power management sequence.

The pm function for STM32MP25 drivers  will use the generic HINTs to save the IP configuration 
(PM_HINT_CONTEXT_STATE) or stop their clock (PM_HINT_CLOCK_STATE).

Only the STPMIC25 driver should use the power level information, saved in the PLATFORM_STATE part of HINT 
(bit 16:31), to configure in the PMIC the requested supply configuration for the select low power mode.

So this series provide the needed macros, PM_HINT_IS_STATE()  and defines PM_.*_LEVEL
to implement the pm functions in STM32MP25 driver and in PMIC (STPMIC25) driver in next patches.

Regards

Patrick.