### PR TITLE
RISC-V: Fix creation of PTE when OP-TEE frees the pages

### DIFF
--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -188,41 +188,40 @@ static unsigned long pte_to_mattr(unsigned level __maybe_unused,
 	return mattr;
 }
 
-static uint8_t mattr_to_perms(unsigned level __maybe_unused,
-			      uint32_t attr)
+static uint8_t mattr_to_pte_bits(unsigned level __maybe_unused, uint32_t attr)
 {
-	unsigned long perms = 0;
+	unsigned long pte_bits = 0;
 
 	if (attr & TEE_MATTR_TABLE)
 		return PTE_V;
 
 	if (attr & TEE_MATTR_VALID_BLOCK)
-		perms |= PTE_V;
+		pte_bits |= PTE_V;
 
 	if (attr & TEE_MATTR_UR)
-		perms |= PTE_R | PTE_U;
+		pte_bits |= PTE_R | PTE_U;
 	if (attr & TEE_MATTR_UW)
-		perms |= PTE_W | PTE_U;
+		pte_bits |= PTE_W | PTE_U;
 	if (attr & TEE_MATTR_UX)
-		perms |= PTE_X | PTE_U;
+		pte_bits |= PTE_X | PTE_U;
 
 	if (attr & TEE_MATTR_PR)
-		perms |= PTE_R;
+		pte_bits |= PTE_R;
 	if (attr & TEE_MATTR_PW)
-		perms |= PTE_W | PTE_R;
+		pte_bits |= PTE_W | PTE_R;
 	if (attr & TEE_MATTR_PX)
-		perms |= PTE_X | PTE_R;
+		pte_bits |= PTE_X | PTE_R;
 
 	if (attr & (TEE_MATTR_UR | TEE_MATTR_PR))
-		perms |= PTE_A;
+		pte_bits |= PTE_A;
 
 	if (attr & (TEE_MATTR_UW | TEE_MATTR_PW))
-		perms |= PTE_D;
+		pte_bits |= PTE_D;
 
 	if (attr & TEE_MATTR_GLOBAL)
-		perms |= PTE_G;
+		pte_bits |= PTE_G;
 
-	return perms;
+	return pte_bits;
 }
 
 static unsigned int core_mmu_pgt_idx(vaddr_t va, unsigned int level)
@@ -554,9 +553,9 @@ void core_mmu_set_entry_primitive(void *table, size_t level, size_t idx,
 {
 	struct mmu_pgt *pgt = (struct mmu_pgt *)table;
 	struct mmu_pte *pte = core_mmu_table_get_entry(pgt, idx);
-	uint8_t perms = mattr_to_perms(level, attr);
+	uint8_t pte_bits = mattr_to_pte_bits(level, attr);
 
-	core_mmu_entry_set(pte, core_mmu_pte_create(pa_to_ppn(pa), perms));
+	core_mmu_entry_set(pte, core_mmu_pte_create(pa_to_ppn(pa), pte_bits));
 }
 
 static void set_user_va_idx(struct mmu_partition *prtn)


### PR DESCRIPTION
In current implementation, we always set `PTE_V` bit when we create PTE by `core_mmu_pte_create()`.
But when OP-TEE wants to free the pages, we should set zero value into PTE.

This PR fixes this behavior.
The desired PTE bits are already translated from the memory attributes.
Therefore, it is unnecessary to explicitly set `PTE_V` bit in `core_mmu_pte_create()`.


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
