### PR TITLE
[RFC] Make OP-TEE physically relocatable when S-EL2 SPMC is not enabled

### DIFF
--- a/core/arch/arm/arm.mk
+++ b/core/arch/arm/arm.mk
@@ -99,6 +99,10 @@ ifeq ($(CFG_CORE_LARGE_PHYS_ADDR),y)
 $(call force,CFG_WITH_LPAE,y)
 endif
 
+# Enable or not support in OP-TEE to relocate itself to allow it to run from a
+# physical address that differs from the link address
+CFG_CORE_PHYS_RELOCATABLE ?= n
+
 # SPMC configuration "S-EL1 SPMC" where SPM Core is implemented at S-EL1,
 # that is, OP-TEE.
 ifeq ($(CFG_CORE_SEL1_SPMC),y)
@@ -136,11 +140,6 @@ endif
 
 ifeq ($(CFG_CORE_PHYS_RELOCATABLE)-$(CFG_WITH_PAGER),y-y)
 $(error CFG_CORE_PHYS_RELOCATABLE and CFG_WITH_PAGER are not compatible)
-endif
-ifeq ($(CFG_CORE_PHYS_RELOCATABLE),y)
-ifneq ($(CFG_CORE_SEL2_SPMC),y)
-$(error CFG_CORE_PHYS_RELOCATABLE depends on CFG_CORE_SEL2_SPMC)
-endif
 endif
 
 ifeq ($(CFG_CORE_FFA)-$(CFG_WITH_PAGER),y-y)

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1691,6 +1691,9 @@ void __weak boot_save_args(unsigned long a0, unsigned long a1,
 			boot_arg_nsec_entry = a4;
 #endif
 		}
+		if (IS_ENABLED(CFG_CORE_PHYS_RELOCATABLE))
+			core_mmu_set_secure_memory(TRUSTED_DRAM_BASE,
+						   TRUSTED_DRAM_SIZE);
 	}
 }
 

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -518,7 +518,7 @@ static TEE_Result load_binary_sp(struct ts_session *s,
 	bin_page_count = bin_size_rounded / SMALL_PAGE_SIZE;
 
 	/* Allocate memory */
-	mm = tee_mm_alloc(&tee_mm_sec_ddr, bin_size_rounded);
+	mm = tee_mm_alloc_sec_mem(bin_size_rounded);
 	if (!mm) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto err;
@@ -901,7 +901,7 @@ static TEE_Result handle_fdt_load_relative_mem_regions(struct sp_ctx *ctx,
 			struct mobj *m = NULL;
 			unsigned int idx = 0;
 
-			mm = tee_mm_alloc(&tee_mm_sec_ddr, size);
+			mm = tee_mm_alloc_sec_mem(size);
 			if (!mm)
 				return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -1225,7 +1225,7 @@ static TEE_Result handle_fdt_mem_regions(struct sp_ctx *ctx, void *fdt)
 
 		if (alloc_needed) {
 			/* Base address is missing, we have to allocate */
-			mm = tee_mm_alloc(&tee_mm_sec_ddr, size);
+			mm = tee_mm_alloc_sec_mem(size);
 			if (!mm)
 				return TEE_ERROR_OUT_OF_MEMORY;
 

--- a/core/include/mm/tee_mm.h
+++ b/core/include/mm/tee_mm.h
@@ -41,6 +41,9 @@ typedef struct _tee_mm_pool_t tee_mm_pool_t;
 /* Physical Secure DDR pool */
 extern tee_mm_pool_t tee_mm_sec_ddr;
 
+/* Extra physical Secure DDR pool */
+extern tee_mm_pool_t tee_mm_sec_ddr_extra;
+
 /* Virtual eSRAM pool */
 extern tee_mm_pool_t tee_mm_vcore;
 
@@ -83,6 +86,9 @@ void tee_mm_final(tee_mm_pool_t *pool);
  * the tee_mm_free function.
  */
 tee_mm_entry_t *tee_mm_alloc(tee_mm_pool_t *pool, size_t size);
+
+/* Allocate memory from secure memory */
+tee_mm_entry_t *tee_mm_alloc_sec_mem(size_t size);
 
 /* Allocate supplied memory range if it's free */
 tee_mm_entry_t *tee_mm_alloc2(tee_mm_pool_t *pool, paddr_t base, size_t size);

--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -719,7 +719,7 @@ static TEE_Result buf_ta_open(const TEE_UUID *uuid,
 	if (res)
 		goto err;
 
-	handle->mm = tee_mm_alloc(&tee_mm_sec_ddr, handle->ta_size);
+	handle->mm = tee_mm_alloc_sec_mem(handle->ta_size);
 	if (!handle->mm) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
 		goto err;

--- a/core/mm/fobj.c
+++ b/core/mm/fobj.c
@@ -759,7 +759,7 @@ struct fobj *fobj_sec_mem_alloc(unsigned int num_pages)
 	if (MUL_OVERFLOW(num_pages, SMALL_PAGE_SIZE, &size))
 		goto err;
 
-	f->mm = tee_mm_alloc(&tee_mm_sec_ddr, size);
+	f->mm = tee_mm_alloc_sec_mem(size);
 	if (!f->mm)
 		goto err;
 

--- a/core/mm/mobj.c
+++ b/core/mm/mobj.c
@@ -22,6 +22,7 @@
 #include <util.h>
 
 struct mobj *mobj_sec_ddr;
+struct mobj *mobj_sec_ddr_extra;
 struct mobj *mobj_tee_ram_rx;
 struct mobj *mobj_tee_ram_rw;
 
@@ -504,6 +505,15 @@ static TEE_Result mobj_init(void)
 				       CORE_MEM_TA_RAM);
 	if (!mobj_sec_ddr)
 		panic("Failed to register secure ta ram");
+
+	if (tee_mm_sec_ddr_extra.lo) {
+		mobj_sec_ddr_extra = mobj_phys_alloc(tee_mm_sec_ddr_extra.lo,
+						     tee_mm_sec_ddr_extra.size,
+						     TEE_MATTR_MEM_TYPE_CACHED,
+						     CORE_MEM_TA_RAM);
+		if (!mobj_sec_ddr_extra)
+			panic("Failed to register extra TA ram");
+	}
 
 	if (IS_ENABLED(CFG_CORE_RWDATA_NOEXEC)) {
 		mobj_tee_ram_rx = mobj_phys_init(0,

--- a/core/mm/tee_mm.c
+++ b/core/mm/tee_mm.c
@@ -225,6 +225,17 @@ err:
 	return NULL;
 }
 
+tee_mm_entry_t* tee_mm_alloc_sec_mem(size_t size)
+{
+	tee_mm_entry_t *mm = NULL;
+
+	mm = tee_mm_alloc(&tee_mm_sec_ddr, size);
+	if (!mm)
+		return tee_mm_alloc(&tee_mm_sec_ddr_extra, size);
+
+	return mm;
+}
+
 static inline bool fit_in_gap(tee_mm_pool_t *pool, tee_mm_entry_t *e,
 			      paddr_t offslo, paddr_t offshi)
 {
@@ -356,6 +367,9 @@ bool tee_mm_is_empty(tee_mm_pool_t *pool)
 
 /* Physical Secure DDR pool */
 tee_mm_pool_t tee_mm_sec_ddr;
+
+/* Extra physical Secure DDR pool */
+tee_mm_pool_t tee_mm_sec_ddr_extra;
 
 /* Virtual eSRAM pool */
 tee_mm_pool_t tee_mm_vcore;


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

This patch series try to dissociate `CFG_CORE_PHYS_RELOCATABLE` from `CFG_CORE_SEL2_SPMC`.

First, this patch allows OP-TEE to register ` [TZDRAM_BASE, TZDRAM_BASE + TZDRAM_SIZE)` as secure memory (i.e., `secure_only[0]`) when it cannot get secure memory information via FF-A manifest.

Then, this patch also tries to make use of memory regions below the physical offset. With certain scenarios such as physical ASLR, the physical offset can be large and it's not desirable to ignore that region.

Lastly, to make memory monitor remain honest, this patch introduce a mechanism to invalidate certain region within the memory pool. In particular, it invalidates overlapping region between the TEE RAM and the TA RAM so that this region is excluded from memory usage statistics.

Known remaining issue is that there remains redundant mappings, i.e., TA RAM mapping from some VA to PA that belongs to overlapped regions b/w TEE RAM and TA RAM, which I plan to address soon.

Looking forward to feedback from the community.