### PR TITLE
RISC-V: Allocate root page tables for multiple hart environment

### DIFF
--- a/core/arch/riscv/include/mm/core_mmu_arch.h
+++ b/core/arch/riscv/include/mm/core_mmu_arch.h
@@ -105,7 +105,7 @@
 #ifndef __ASSEMBLER__
 
 struct core_mmu_config {
-	unsigned long satp;
+	unsigned long satp[CFG_TEE_CORE_NB_CORE];
 	uint32_t map_offset;
 };
 

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -89,7 +89,8 @@ DEFINES
 	/* struct core_mmu_config */
 	DEFINE(CORE_MMU_CONFIG_SIZE, sizeof(struct core_mmu_config));
 	DEFINE(CORE_MMU_CONFIG_SATP,
-	       offsetof(struct core_mmu_config, satp));
+	       offsetof(struct core_mmu_config, satp[0]));
+	DEFINE(CORE_MMU_CONFIG_SATP_SIZE, sizeof(unsigned long));
 
 	/* struct thread_abi_args */
 	DEFINE(THREAD_ABI_ARGS_A0, offsetof(struct thread_abi_args, a0));

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -71,9 +71,21 @@
 .endm
 
 .macro set_satp
+	/*
+	 * a0 = hartid
+	 * a1 = address of boot_mmu_config.satp[0]
+	 * a2 = size of CSR SATP
+	 *
+	 * This hart's SATP is of value (a1 + (a0 * a2)).
+	 */
+	csrr	a0, CSR_XSCRATCH
 	la	a1, boot_mmu_config
-	LDR	a0, CORE_MMU_CONFIG_SATP(a1)
-	csrw	CSR_SATP, a0
+	addi	a1, a1, CORE_MMU_CONFIG_SATP
+	li	a2, CORE_MMU_CONFIG_SATP_SIZE
+	mul	a0, a0, a2
+	add	a1, a1, a0
+	LDR	a2, 0(a1)
+	csrw	CSR_SATP, a2
 	sfence.vma	zero, zero
 .endm
 

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -738,10 +738,11 @@ void core_init_mmu(struct tee_mmap_region *mm)
 
 void core_init_mmu_regs(struct core_mmu_config *cfg)
 {
-	struct mmu_partition *prtn = core_mmu_get_prtn();
+	struct mmu_partition *p = core_mmu_get_prtn();
+	unsigned int n = 0;
 
-	cfg->satp = core_mmu_pgt_to_satp(prtn->asid,
-					 core_mmu_get_root_pgt_va(prtn));
+	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
+		cfg->satp[n] = core_mmu_pgt_to_satp(p->asid, p->root_pgt + n);
 }
 
 enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)


### PR DESCRIPTION
To support multiple hart environment, each hart must have its dedicated root page table.
This series enlarges the root page table to be array, and allocates each root page for each hart.
Besides, the value of CSR SATP, which holds the base address of the root page table, is also prepared for each hart.
Each hart configures its SATP in `set_satp` macro at boot time, by getting value of SATP from `struct core_mmu_config`.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
