### PR TITLE
.gitignore: Ignore all dot files and folder except the existing ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
-/.cproject
 /compile_commands.json
 /cscope.*
 /tags
 /TAGS
 /out
 /.project
-*.swp
+# Ignore all dot files and folder
+.*
+# But not those
+!.clang-format
+!.checkpatch.conf
+!.gitattributes
+!.gitignore
+!.github

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-.cproject
-compile_commands.json
-cscope.*
-tags
-TAGS
-out
-.project
+/.cproject
+/compile_commands.json
+/cscope.*
+/tags
+/TAGS
+/out
+/.project
 *.swp


### PR DESCRIPTION
Hello,
While coding, some IDE creates folder to stores tags or project settings.
Some developers even have development tools that can be configured by project once they find a specific dot file in the project source directory.
This patch aims to leave developer do what they want to do with their tools and project configuration by ignoring all dot files and dot folders.

