### PR TITLE
drivers: clk: replace clock main spinlock with a mutex

### DIFF
--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -71,6 +71,10 @@ struct clk_duty_cycle {
  * @get_rates_array: Get the supported clock rates as array
  * @get_rates_steps: Get support clock rates by min/max/step representation
  * @get_duty_cycle: Get duty cytcle of the clock
+ *
+ * All clock operations are expected to execute in a interruptible thread
+ * context at the exclusion of power management sequence where non secure
+ * world is not operating (power off, suspend, resume).
  */
 struct clk_ops {
 	TEE_Result (*enable)(struct clk *clk);


### PR DESCRIPTION
Change clock framework lock from an interrupts masked spinlock to a mutex. This allows the clock framework to better handle slow stabilizing clocks as PLLs without masking the system interrupt which can have side effects on the REE or even the TEE.

To support clock accesses during low power state transition sequences while non-secure world is no operating, the lock is not taken when the execution is not in the scope of a TEE thread.

This change is not expected to impact supported platforms that currently only access clock operation from thread contexts or atomic PM sequences.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
