### PR TITLE
core: kernel: add timeout_elapsed_us()

### DIFF
--- a/core/arch/arm/include/kernel/delay_arch.h
+++ b/core/arch/arm/include/kernel/delay_arch.h
@@ -30,23 +30,18 @@
 #ifndef __KERNEL_DELAY_ARCH_H
 #define __KERNEL_DELAY_ARCH_H
 
+#ifdef CFG_CORE_HAS_GENERIC_TIMER
 #include <arm.h>
-#include <stdbool.h>
 #include <stdint.h>
 
-static inline uint64_t arm_cnt_us2cnt(uint32_t us)
+static inline unsigned int delay_cnt_freq(void)
 {
-	return ((uint64_t)us * (uint64_t)read_cntfrq()) / 1000000ULL;
+	return read_cntfrq();
 }
 
-static inline uint64_t timeout_init_us(uint32_t us)
+static inline uint64_t delay_cnt_read(void)
 {
-	return barrier_read_counter_timer() + arm_cnt_us2cnt(us);
+	return barrier_read_counter_timer();
 }
-
-static inline bool timeout_elapsed(uint64_t expire)
-{
-	return barrier_read_counter_timer() > expire;
-}
-
+#endif /* CFG_CORE_HAS_GENERIC_TIMER */
 #endif

--- a/core/arch/riscv/include/kernel/delay_arch.h
+++ b/core/arch/riscv/include/kernel/delay_arch.h
@@ -6,19 +6,16 @@
 #ifndef __KERNEL_DELAY_ARCH_H
 #define __KERNEL_DELAY_ARCH_H
 
-#include <platform_config.h>
 #include <riscv.h>
-#include <stdbool.h>
 #include <stdint.h>
 
-static inline uint64_t timeout_init_us(uint32_t us)
+static inline unsigned int delay_cnt_freq(void)
 {
-	return read_time() + ((uint64_t)us * read_cntfrq()) / 1000000ULL;
+	return read_cntfrq();
 }
 
-static inline bool timeout_elapsed(uint64_t expire)
+static inline uint64_t delay_cnt_read(void)
 {
-	return read_time() > expire;
+	return read_time();
 }
-
 #endif /*__KERNEL_DELAY_ARCH_H*/

--- a/core/arch/riscv/riscv.mk
+++ b/core/arch/riscv/riscv.mk
@@ -74,6 +74,9 @@ $(call force,CFG_WITH_VFP,n)
 $(call force,CFG_WITH_STMM_SP,n)
 $(call force,CFG_TA_BTI,n)
 
+# Enable generic timer
+$(call force,CFG_CORE_HAS_GENERIC_TIMER,y)
+
 core-platform-cppflags	+= -I$(arch-dir)/include
 core-platform-subdirs += \
 	$(addprefix $(arch-dir)/, kernel mm tee) $(platform-dir)

--- a/core/include/kernel/delay.h
+++ b/core/include/kernel/delay.h
@@ -54,6 +54,13 @@ static inline bool timeout_elapsed(uint64_t expire)
 {
 	return delay_cnt_read() > expire;
 }
+
+/*
+ * Return the time in microseconds since/until timeout tick counter @expired,
+ * that was initialized with timeout_init_us() or like, has/will expire.
+ * A positive value means the timeout has expired and a negative one it has not.
+ */
+int timeout_elapsed_us(uint64_t expire);
 #endif /*CFG_CORE_HAS_GENERIC_TIMER*/
 
 /* Wait @us microseconds actively polling on architecture timer */

--- a/core/include/kernel/delay.h
+++ b/core/include/kernel/delay.h
@@ -34,7 +34,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* Wait @us microseconds actively polling on architecture timer */
 void udelay(uint32_t us);
-void mdelay(uint32_t ms);
 
+/* Wait @ms milliseconds actively polling on architecture timer */
+void mdelay(uint32_t ms);
 #endif

--- a/core/include/kernel/delay.h
+++ b/core/include/kernel/delay.h
@@ -33,6 +33,28 @@
 #include <kernel/delay_arch.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <util.h>
+
+#ifdef CFG_CORE_HAS_GENERIC_TIMER
+/* Convert microsecond base delay @us into architecture time tick counts */
+static inline uint64_t delay_us2cnt(uint32_t us)
+{
+	return ((uint64_t)us * (uint64_t)delay_cnt_freq()) / ULL(1000000);
+}
+
+/* Return delay tick counter for a timeout expiration in @us microseconds */
+static inline uint64_t timeout_init_us(uint32_t us)
+{
+	return delay_cnt_read() + delay_us2cnt(us);
+}
+
+/* Check if timeout tick counter @expire from timeout_init_us() has expired */
+
+static inline bool timeout_elapsed(uint64_t expire)
+{
+	return delay_cnt_read() > expire;
+}
+#endif /*CFG_CORE_HAS_GENERIC_TIMER*/
 
 /* Wait @us microseconds actively polling on architecture timer */
 void udelay(uint32_t us);

--- a/core/kernel/delay.c
+++ b/core/kernel/delay.c
@@ -32,6 +32,21 @@
 #include <kernel/misc.h>
 
 #ifdef CFG_CORE_HAS_GENERIC_TIMER
+int timeout_elapsed_us(uint64_t expire)
+{
+	int64_t diff = delay_cnt_read() - expire;
+
+	if (MUL_OVERFLOW(diff, 1000000, &diff) ||
+	    diff < INT_MIN || diff > INT_MAX) {
+		if (timeout_elapsed(expire))
+			return INT_MAX;
+		else
+			return INT_MIN;
+	}
+
+	return diff / delay_cnt_freq();
+}
+
 void udelay(uint32_t us)
 {
 	uint64_t target = timeout_init_us(us);


### PR DESCRIPTION
This P-R adds API function `timeout_elapsed_us()` to measure the time since or until an initialized timeout reference is elapsing. This function relies on other `timeout_*()` API functions and therefore depends on `CFG_CORE_HAS_GENERIC_TIMER` being enabled.

While at it, I factorize the `timeout_*()` function between `arm` and `riscv` architectures and slightly touched `mdelay()`.
I also changed _arch/risc/risc.mk_ to force `CFG_CORE_HAS_GENERIC_TIMER` instead of relying on _mk/config.mk_ default enabling that switch.