### PR TITLE
lib: bget_malloc: wipe content outside critical section

### DIFF
--- a/lib/libutils/isoc/bget.h
+++ b/lib/libutils/isoc/bget.h
@@ -36,7 +36,7 @@ void   *bget	    _((bufsize align, bufsize hdr_size, bufsize size, struct bpools
 void   *bgetz	    _((bufsize align, bufsize hdr_size, bufsize size, struct bpoolset *poolset));
 void   *bgetr	    _((void *buffer, bufsize align, bufsize hdr_size, bufsize newsize,
 		       struct bpoolset *poolset));
-void	brel	    _((void *buf, struct bpoolset *poolset, int wipe));
+void	brel	    _((void *buf, struct bpoolset *poolset, int wipe, int wipe_only));
 void	bectl	    _((int (*compact)(bufsize sizereq, int sequence),
 		       void *(*acquire)(bufsize size),
 		       void (*release)(void *buf), bufsize pool_incr,

--- a/lib/libutils/isoc/include/malloc.h
+++ b/lib/libutils/isoc/include/malloc.h
@@ -149,6 +149,7 @@ void *raw_memalign(size_t hdr_size, size_t ftr_size, size_t alignment,
 void *raw_malloc(size_t hdr_size, size_t ftr_size, size_t pl_size,
 		 struct malloc_ctx *ctx);
 void raw_free(void *ptr, struct malloc_ctx *ctx, bool wipe);
+void raw_wipe(void *ptr, struct malloc_ctx *ctx);
 void *raw_calloc(size_t hdr_size, size_t ftr_size, size_t pl_nmemb,
 		 size_t pl_size, struct malloc_ctx *ctx);
 void *raw_realloc(void *ptr, size_t hdr_size, size_t ftr_size,


### PR DESCRIPTION
Changes **bget** integration in OP-TEE to wipe data before core heap spinlock is locked for safe heap management. This change prevents interrupts from being masked for a long time when the wiped buffer is somewhat large (few kilobytes).

`brel()` from _bget.c_ gets an extra argument boolean `wipe_only` argument, set to true together with argument `wipe` when we only request to wipe data content.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
