### PR TITLE
core: kernel: allow not locking output console

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -86,6 +86,14 @@ CFG_TEE_TA_LOG_LEVEL ?= 1
 # CFG_TEE_TA_LOG_LEVEL. Otherwise, they are not output at all
 CFG_TEE_CORE_TA_TRACE ?= y
 
+# If y, TEE core console is not locked when emitting trace messages.
+# Using a locked console makes any trace message to mask interrupt during a
+# relatively long period of time possibly affecting the latency of TEE and
+# REE interrupts handling. The drawback of not locking the console is that
+# cocurrent trace messages will printed simultenaously making it hard to
+# read messages.
+CFG_TEE_CONSOLE_UNLOCKED ?= n
+
 # If y, enable the memory leak detection feature in the bget memory allocator.
 # When this feature is enabled, calling mdbg_check(1) will print a list of all
 # the currently allocated buffers and the location of the allocation (file and


### PR DESCRIPTION
Add configuration switch `CFG_TEE_CONSOLE_UNLOCKED` to evacuate trace messages without a=hold the contention lock.

This configuration can be handy to still benefit from OP-TEE output console support while to affecting native and foreign interrupts handling latency due to OP-TEE output console traces for example when playing with a real time sensitive system. Enabling the configuration permits collision of trace messages but is worth it instead of fully disabling OP-TEE console for example with `CFG_TEE_CORE_LOG_LEVEL=0`.

Enabling the switch does not guarantee trace messages are printed in a thread context with interrupts not being masked. At least OP-TEE generic trace support will not add constraints on the interrupts and scheduling latency.

By the way, add an initial value to local variable in `trace_ext_puts()`.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
