### PR TITLE
[RFC] core: arm: mm: relax interrupt on dynamic shm mapping

### DIFF
--- a/core/arch/arm/mm/mobj_dyn_shm.c
+++ b/core/arch/arm/mm/mobj_dyn_shm.c
@@ -25,9 +25,18 @@ static struct condvar shm_cv = CONDVAR_INITIALIZER;
 static size_t shm_release_waiters;
 
 /*
- * mobj_reg_shm implementation. Describes shared memory provided by normal world
+ * struct mobj_reg_shm - Describe a shared memory registered by normal world
+ * @mobj: Memory object instance
+ * @next: Reference in mobj_reg_shm list
+ * @cookie: Non-secure world reference for the memory object
+ * @mm: Active memory mapping (upon ::releasing) or NULL (lock protected)
+ * @page_offset: Byte offset in first mapped page.
+ * @mapcount: Mapping/unmapping requests reference counter
+ * @guarded: Set at instance very creation, released once object is finalized
+ * @releasing: When set, final object release under process
+ * @release_frees: When set, release by cookie can operate/complete
+ * @pages: Array of the registered shared memory physical pages list
  */
-
 struct mobj_reg_shm {
 	struct mobj mobj;
 	SLIST_ENTRY(mobj_reg_shm) next;

--- a/core/include/kernel/spinlock.h
+++ b/core/include/kernel/spinlock.h
@@ -42,6 +42,18 @@ static inline void cpu_spin_lock_no_dldetect(unsigned int *lock)
 	spinlock_count_incr();
 }
 
+static inline void thread_spin_lock(unsigned int *lock)
+{
+	assert(thread_get_id_may_fail() != THREAD_ID_INVALID);
+	__cpu_spin_lock(lock);
+}
+
+static inline void thread_spin_unlock(unsigned int *lock)
+{
+	assert(thread_get_id_may_fail() != THREAD_ID_INVALID);
+	__cpu_spin_unlock(lock);
+}
+
 #ifdef CFG_TEE_CORE_DEBUG
 #define cpu_spin_lock(lock) \
 	cpu_spin_lock_dldetect(__func__, __LINE__, lock)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1078,6 +1078,11 @@ CFG_WDT_SM_HANDLER_ID ?= 0x82003D06
 # the platform code
 CFG_CORE_HAS_GENERIC_TIMER ?= y
 
+# CFG_DYN_SHM_INTERRUPTIBLE_LOCK, when enabled, prevent potentially long
+# time windows during which interrupts are masked for dynamic shared memory
+# management.
+CFG_DYN_SHM_INTERRUPTIBLE_LOCK ?= n
+
 # Enable RTC API
 CFG_DRIVERS_RTC ?= n
 


### PR DESCRIPTION
Add `CFG_DYN_SHM_INTERRUPTIBLE_LOCK` configuration switch to lower the time during which interrupts are masked for dynamic shared memory registration and mapping operations.

The configuration is intended to be used when OP-TEE OS is executing with as non-secure OS that is sensitive to interrupt and scheduling latency. Indeed playing with a Cortex-A7 clocked at 1GHz, mapping and especially unmapping a shared memory buffer of several MBytes makes OP-TEE to mask interrupts during several hundreds of milliseconds.

When CFG_DYN_SHM_INTERRUPTIBLE_LOCK is enabled, the lock used to protect dynamic shared memory reference is still used but without masking interrupts hence at a cost of potentially high CPU load picks. The memory is mapped page per page because to ensure `core_mmu_map_pages()` and `core_mmu_unmap_pages()` mask interrupts only for the duration of processing a single page.