### PR TITLE
core: imx: enable TZC380 driver for all i.mx8m socs

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -164,24 +164,28 @@ else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mq-flavorlist)))
 $(call force,CFG_MX8MQ,y)
 $(call force,CFG_MX8M,y)
 $(call force,CFG_ARM64_core,y)
+$(call force,CFG_TZC380,y)
 CFG_DRAM_BASE ?= 0x40000000
 CFG_TEE_CORE_NB_CORE ?= 4
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mm-flavorlist)))
 $(call force,CFG_MX8MM,y)
 $(call force,CFG_MX8M,y)
 $(call force,CFG_ARM64_core,y)
+$(call force,CFG_TZC380,y)
 CFG_DRAM_BASE ?= 0x40000000
 CFG_TEE_CORE_NB_CORE ?= 4
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mn-flavorlist)))
 $(call force,CFG_MX8MN,y)
 $(call force,CFG_MX8M,y)
 $(call force,CFG_ARM64_core,y)
+$(call force,CFG_TZC380,y)
 CFG_DRAM_BASE ?= 0x40000000
 CFG_TEE_CORE_NB_CORE ?= 4
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8mp-flavorlist)))
 $(call force,CFG_MX8MP,y)
 $(call force,CFG_MX8M,y)
 $(call force,CFG_ARM64_core,y)
+$(call force,CFG_TZC380,y)
 CFG_DRAM_BASE ?= 0x40000000
 CFG_TEE_CORE_NB_CORE ?= 4
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx8qm-flavorlist)))
@@ -534,4 +538,3 @@ CFG_IMX_CAAM ?= y
 endif
 
 endif
-


### PR DESCRIPTION
This enables the TrustZone Address Space Controller (TZ380) driver for all members of the i.MX8M soc family. Enabling the driver ensures protection of the OP-TEE memory regions, so that only the secure world can access it.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
