### PR TITLE
core: add __must_check attribute to cpu_spin_lock_xsave()

### DIFF
--- a/core/include/kernel/spinlock.h
+++ b/core/include/kernel/spinlock.h
@@ -93,7 +93,8 @@ static inline void cpu_spin_unlock(unsigned int *lock)
 	spinlock_count_decr();
 }
 
-static inline uint32_t cpu_spin_lock_xsave_no_dldetect(unsigned int *lock)
+static inline uint32_t __must_check
+cpu_spin_lock_xsave_no_dldetect(unsigned int *lock)
 {
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
@@ -105,9 +106,9 @@ static inline uint32_t cpu_spin_lock_xsave_no_dldetect(unsigned int *lock)
 #define cpu_spin_lock_xsave(lock) \
 	cpu_spin_lock_xsave_dldetect(__func__, __LINE__, lock)
 
-static inline uint32_t cpu_spin_lock_xsave_dldetect(const char *func,
-						    const int line,
-						    unsigned int *lock)
+static inline uint32_t __must_check
+cpu_spin_lock_xsave_dldetect(const char *func, const int line,
+			     unsigned int *lock)
 {
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_ALL);
 
@@ -115,7 +116,7 @@ static inline uint32_t cpu_spin_lock_xsave_dldetect(const char *func,
 	return exceptions;
 }
 #else
-static inline uint32_t cpu_spin_lock_xsave(unsigned int *lock)
+static inline uint32_t __must_check cpu_spin_lock_xsave(unsigned int *lock)
 {
 	return cpu_spin_lock_xsave_no_dldetect(lock);
 }


### PR DESCRIPTION
cpu_spin_lock_xsave() masks exceptions, takes the spinlock and returns previous exception state to be restored by cpu_spin_unlock_xrestore(). The previously returned exception state must always be supplied so add the __must_check attribute to cpu_spin_lock_xsave() and its debug variants.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
