### PR TITLE
drivers: clk: clk-stm32mp13: fix memory corruption on oscillator parent

### DIFF
--- a/core/drivers/clk/clk-stm32mp13.c
+++ b/core/drivers/clk/clk-stm32mp13.c
@@ -2026,6 +2026,10 @@ static const struct clk_ops clk_stm32_oscillator_ops = {
 	.disable	= clk_stm32_oscillator_disable,
 };
 
+/*
+ * Each oscillator has 1 parent which reference is NULL here
+ * but set during initialization.
+ */
 #define STM32_OSCILLATOR(_name, _gate_id)\
 	struct clk _name = {\
 		.ops = &clk_stm32_oscillator_ops,\
@@ -2033,6 +2037,8 @@ static const struct clk_ops clk_stm32_oscillator_ops = {
 			.gate_id = (_gate_id),\
 		},\
 		.name = #_name,\
+		.num_parents = 1, \
+		.parents = { NULL }, \
 	}
 
 static STM32_OSCILLATOR(ck_hsi, GATE_HSI);


### PR DESCRIPTION
Fix oscillators struct clk instances for STM32MP13 clock driver. These clocks have 1 parent that is set during driver initialization, based on device tree content, whereas referred bugged commit defined 0 parents and did not allocate memory for the parent reference.

Fixes: 95f2142bf848 ("drivers: clk: clk-stm32mp13: don't gate/ungate oscillators not wired")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
