### PR TITLE
drivers: mutex for clock and regulator valid during PM suspend/resume sequences

### DIFF
--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -71,6 +71,10 @@ struct clk_duty_cycle {
  * @get_rates_array: Get the supported clock rates as array
  * @get_rates_steps: Get support clock rates by min/max/step representation
  * @get_duty_cycle: Get duty cytcle of the clock
+ *
+ * All clock operations are expected to execute in a interruptible thread
+ * context at the exclusion of power management sequence where non secure
+ * world is not operating (power off, suspend, resume).
  */
 struct clk_ops {
 	TEE_Result (*enable)(struct clk *clk);

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -7,7 +7,7 @@
 
 #include <assert.h>
 #include <bitstring.h>
-#include <kernel/mutex.h>
+#include <kernel/mutex_pm_aware.h>
 #include <sys/queue.h>
 #include <tee_api_types.h>
 #include <stdbool.h>
@@ -87,7 +87,7 @@ struct regulator_voltages_desc {
  * @max_uv: Max possible voltage level in microvolt (uV)
  * @flags: REGULATOR_* property flags
  * @refcount: Regulator enable request reference counter
- * @lock: Mutex for concurrent access protection
+ * @mutex: Concurrent access protection considering PM context sequences
  * @voltages_fallback: Default supported voltage range description
  * @link: Link in initialized regulator list
  */
@@ -102,7 +102,7 @@ struct regulator {
 	/* Fields internal to regulator framework */
 	unsigned int flags;
 	unsigned int refcount;
-	struct mutex lock;	/* Concurrent access protection */
+	struct mutex_pm_aware mutex;
 	struct voltages_fallback {
 		struct regulator_voltages_desc desc;
 		int levels[3];

--- a/core/include/kernel/mutex_pm_aware.h
+++ b/core/include/kernel/mutex_pm_aware.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, STMicroelectronics
+ */
+#ifndef __KERNEL_MUTEX_PM_AWARE_H
+#define __KERNEL_MUTEX_PM_AWARE_H
+
+#include <kernel/mutex.h>
+#include <kernel/spinlock.h>
+
+/*
+ * struct mutex_pm_aware - Mutex usable in PM atomic sequence
+ *
+ * Some resources need a mutex protection for runtime operations but are
+ * also accessed during specific system power transition (PM power off,
+ * suspend and resume) that operate in atomic execution environment where
+ * non-secure world is not operational, for example in fastcall SMC entries
+ * of the PSCI services. In such case we cannot take a mutex and we expect
+ * the mutex is unlocked. Additionally a spinning lock is attempted to be
+ * locked to check the resource access consistency.
+ *
+ * Core intentionally panics in case of unexpected resource access contention:
+ * - When a thread requests a mutex held by a non-thread context;
+ * - When a non-thread context requests a mutex held by a thread;
+ * - When a non-thread context requests a mutex held by a non-thread context.
+ */
+struct mutex_pm_aware {
+	struct mutex mutex;	/* access protection in thread context */
+	unsigned int lock;	/* access consistency in PM context */
+};
+
+#define MUTEX_PM_AWARE_INITIALIZER { \
+		.mutex = MUTEX_INITIALIZER, \
+		.lock = SPINLOCK_UNLOCK, \
+	}
+
+void mutex_pm_aware_init(struct mutex_pm_aware *m);
+void mutex_pm_aware_destroy(struct mutex_pm_aware *m);
+void mutex_pm_aware_lock(struct mutex_pm_aware *m);
+void mutex_pm_aware_unlock(struct mutex_pm_aware *m);
+
+#endif /*__KERNEL_MUTEX_PM_AWARE_H*/
+

--- a/core/include/kernel/spinlock.h
+++ b/core/include/kernel/spinlock.h
@@ -42,6 +42,28 @@ static inline void cpu_spin_lock_no_dldetect(unsigned int *lock)
 	spinlock_count_incr();
 }
 
+static inline bool thread_spin_trylock(unsigned int *lock)
+{
+	assert(thread_get_id_may_fail() != THREAD_ID_INVALID);
+	return !__cpu_spin_trylock(lock);
+}
+
+/*
+ * To be used with lot of care: it is not recommended to spin in a thread
+ * context without masking foreign interrupts
+ */
+static inline void thread_spin_lock(unsigned int *lock)
+{
+	assert(thread_get_id_may_fail() != THREAD_ID_INVALID);
+	__cpu_spin_lock(lock);
+}
+
+static inline void thread_spin_unlock(unsigned int *lock)
+{
+	assert(thread_get_id_may_fail() != THREAD_ID_INVALID);
+	__cpu_spin_unlock(lock);
+}
+
 #ifdef CFG_TEE_CORE_DEBUG
 #define cpu_spin_lock(lock) \
 	cpu_spin_lock_dldetect(__func__, __LINE__, lock)


### PR DESCRIPTION
New proposal for the change posted in https://github.com/OP-TEE/optee_os/pull/6724.

This P-R propose a (somewhat) generic implementation for the "PM aware" mutex and apply it the the clock framework (to replace current spinning lock) and in the regulator framework (which already implements the sequence that was seen to weak during https://github.com/OP-TEE/optee_os/pull/6724 review.