### PR TITLE
drivers: atmel_wdt: upgrade to support sama7g5 watchdog

### DIFF
--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -110,7 +110,6 @@ struct atmel_wdt {
 	enum wdt_type type;
 	uint32_t dis_mask;
 	vaddr_t base;
-	unsigned long rate;
 	uint32_t mr;
 	bool enabled;
 };

--- a/core/drivers/atmel_wdt.c
+++ b/core/drivers/atmel_wdt.c
@@ -4,19 +4,17 @@
  */
 
 #include <assert.h>
-#include <drivers/clk.h>
-#include <drivers/clk_dt.h>
 #include <drivers/wdt.h>
 #include <io.h>
 #include <kernel/delay.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
 #include <kernel/interrupt.h>
+#include <kernel/panic.h>
 #include <kernel/pm.h>
 #include <matrix.h>
 #include <mm/core_mmu.h>
-#include <platform_config.h>
-#include <tee_api_types.h>
+#include <tee_api_defines.h>
 
 #define WDT_CR			0x0
 #define WDT_CR_KEY		SHIFT_U32(0xA5, 24)


### PR DESCRIPTION
In sama7g5 there's a DWDT (Dual Watchdog Timer) and the registers are not the same as the wdt for sama5d2. Here the DWD is handled as 2 watchdogs.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
