### PR TITLE
core: spmc, sp: cleanup FF-A ID handling

### DIFF
--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2024, Arm Limited.
  * Copyright (c) 2023, Linaro Limited
  */
 #ifndef __KERNEL_THREAD_SPMC_H
@@ -11,8 +11,28 @@
 #include <kernel/panic.h>
 #include <kernel/thread.h>
 
-/* FF-A endpoint base ID when OP-TEE is used as a S-EL1 endpoint */
-#define SPMC_ENDPOINT_ID        0x8001
+/* The FF-A ID of Secure World components should be between these limits */
+#define FFA_SWD_ID_MIN	0x8000
+#define FFA_SWD_ID_MAX	UINT16_MAX
+
+/*
+ * OP-TEE FF-A partition ID. This is valid both when
+ * - the SPMC is implemented by OP-TEE and the core OP-TEE functionality runs
+ *   in a logical SP that resides at the same exception level as the SPMC, or,
+ * - the SPMC is at a higher EL and OP-TEE is running as a standalone S-EL1 SP.
+ */
+extern uint16_t optee_endpoint_id;
+
+/*
+ * FF-A ID of the SPMC. This is valid both when the SPMC is implemented in
+ * OP-TEE or at a higher EL.
+ */
+extern uint16_t spmc_id;
+
+#if defined(CFG_CORE_SEL1_SPMC)
+/* FF-A ID of the SPMD. This is only valid when OP-TEE is the S-EL1 SPMC. */
+extern uint16_t spmd_id;
+#endif
 
 #define SPMC_CORE_SEL1_MAX_SHM_COUNT	64
 
@@ -25,6 +45,7 @@ struct ffa_rxtx {
 	bool tx_is_mine;
 };
 
+void spmc_handle_spm_id_get(struct thread_smc_args *args);
 void spmc_handle_rxtx_map(struct thread_smc_args *args, struct ffa_rxtx *buf);
 void spmc_handle_rxtx_unmap(struct thread_smc_args *args, struct ffa_rxtx *buf);
 void spmc_handle_rx_release(struct thread_smc_args *args, struct ffa_rxtx *buf);

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -983,12 +983,6 @@ static void handle_features(struct thread_smc_args *args)
 		      FFA_PARAM_MBZ, FFA_PARAM_MBZ);
 }
 
-static void handle_spm_id_get(struct thread_smc_args *args)
-{
-	spmc_set_args(args, FFA_SUCCESS_32, FFA_PARAM_MBZ, SPMC_ENDPOINT_ID,
-		      FFA_PARAM_MBZ, FFA_PARAM_MBZ, FFA_PARAM_MBZ);
-}
-
 static void handle_mem_perm_get(struct thread_smc_args *args,
 				struct sp_session *sp_s)
 {
@@ -1219,7 +1213,7 @@ void spmc_sp_msg_handler(struct thread_smc_args *args,
 			sp_enter(args, caller_sp);
 			break;
 		case FFA_SPM_ID_GET:
-			handle_spm_id_get(args);
+			spmc_handle_spm_id_get(args);
 			sp_enter(args, caller_sp);
 			break;
 		case FFA_PARTITION_INFO_GET:


### PR DESCRIPTION
When OP-TEE implements the S-EL1 SPMC, from an FF-A point-of-view the core OP-TEE functionality is running in a logical SP that resides at the same exception level as the SPMC. This means that the SPMC and the SP should have separate FF-A IDs, i.e. the SPMC ID and a normal endpoint ID for the SP. The SPMC ID is described in the SPMC manifest which gets parsed by the SPMD, so this ID should be queried from the SPMD. OP-TEE's endpoint ID is assigned by the SPMC.

Currently OP-TEE's FF-A endpoint ID and the SPMC ID are mixed together and hardcoded, this patch implements the correct ID handling mechanism as described above.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
