### PR TITLE
core: arm64: increase STACK_ABT_SIZE from 1024 to 3072 when log level is 0

### DIFF
--- a/core/arch/arm/include/kernel/thread_private_arch.h
+++ b/core/arch/arm/include/kernel/thread_private_arch.h
@@ -49,11 +49,7 @@
 #define STACK_THREAD_SIZE	(8192 + CFG_STACK_THREAD_EXTRA)
 #endif
 
-#if TRACE_LEVEL > 0
 #define STACK_ABT_SIZE		3072
-#else
-#define STACK_ABT_SIZE		1024
-#endif
 #endif /*ARM64*/
 
 #ifdef CFG_CORE_DEBUG_CHECK_STACKS


### PR DESCRIPTION
When adding "make check CFG_WITH_PAGER=y CFG_TEE_CORE_LOG_LEVEL=0" to the QEMUv8 CI job, I noticed that OP-TEE fails to boot and hangs with no message printed on the console. The root cause is memory corruption of the translation tables triggered by a stack overflow. Fix this by removing the particular case for log level 0.

Suggested-by: Jens Wikander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
