### PR TITLE
ci: add QEMUv7 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,39 @@ jobs:
 
           _make PLATFORM=virt
 
+  QEMUv7_check:
+    name: make check (QEMUv7)
+    runs-on: ubuntu-latest
+    container: jforissier/optee_os_ci:qemu_check
+    steps:
+      - name: Remove /__t/*
+        run: rm -rf /__t/*
+      - name: Restore build cache
+        uses: actions/cache@v3
+        with:
+          path: /github/home/.cache/ccache
+          key: qemuv7_check-cache-${{ github.sha }}
+          restore-keys: |
+            qemuv7_check-cache-
+      - name: Checkout
+        uses: actions/checkout@v4
+      - shell: bash
+        run: |
+          # make check task
+          set -e -v
+          export LC_ALL=C
+          export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export CFG_TEE_CORE_LOG_LEVEL=0
+          WD=$(pwd)
+          cd ..
+          TOP=$(pwd)/optee
+          /root/get_optee.sh default ${TOP}
+          mv ${TOP}/optee_os ${TOP}/optee_os_old
+          ln -s ${WD} ${TOP}/optee_os
+          cd ${TOP}/build
+
+          make -j$(nproc) check CFG_LOCKDEP=y CFG_LOCKDEP_RECORD_STACK=n CFG_IN_TREE_EARLY_TAS=pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee CFG_PKCS11_TA=y
+
   QEMUv8_check:
     name: make check (QEMUv8)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a job to build and run tests with QEMU for Arm v7 (32-bit). The build flags are imported from the IBART job definition [1] since IBART is being deprecated.

Link: https://github.com/jbech-linaro/ibart/blob/b585163626341864790398df6489c9556e0b20f1/jobdefs/examples/optee_qemu.yaml#L40C26-L40C176 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
