### PR TITLE
stm32 drivers: remove use of undefined CFG_PM

### DIFF
--- a/core/drivers/firewall/stm32_rifsc.c
+++ b/core/drivers/firewall/stm32_rifsc.c
@@ -543,9 +543,8 @@ static TEE_Result stm32_rifsc_probe(const void *fdt, int node,
 	if (res)
 		panic("Couldn't lock RIFSC configuration");
 
-	if (IS_ENABLED(CFG_PM))
-		register_pm_core_service_cb(stm32_rifsc_sem_pm, NULL,
-					    "stm32-rifsc-semaphores");
+	register_pm_core_service_cb(stm32_rifsc_sem_pm, NULL,
+				    "stm32-rifsc-semaphores");
 
 	return TEE_SUCCESS;
 }

--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -594,9 +594,8 @@ static TEE_Result stm32_rng_parse_fdt(const void *fdt, int node)
 	if (fdt_getprop(fdt, node, "clock-error-detect", NULL))
 		stm32_rng->clock_error = true;
 
-	/* Release device if not used at runtime or for pm transitions */
-	stm32_rng->release_post_boot = IS_ENABLED(CFG_WITH_SOFTWARE_PRNG) &&
-				       !IS_ENABLED(CFG_PM);
+	/* Release device if not used after initialization */
+	stm32_rng->release_post_boot = IS_ENABLED(CFG_WITH_SOFTWARE_PRNG);
 
 	stm32_rng->rng_config = stm32_rng->ddata->cr;
 	if (stm32_rng->rng_config & ~RNG_CR_ENTROPY_SRC_MASK)


### PR DESCRIPTION
Remove use of `CFG_PM` config switch that is not defined in OP-TEE OS.