### PR TITLE
drivers: stm32_i2c: protect bus access with a mutex

### DIFF
--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause)
 /*
- * Copyright (c) 2017-2019, STMicroelectronics
+ * Copyright (c) 2017-2024, STMicroelectronics
  *
  * The driver API is defined in header file stm32_i2c.h.
  *
@@ -20,6 +20,7 @@
 #include <kernel/delay.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
+#include <kernel/mutex_pm_aware.h>
 #include <kernel/panic.h>
 #include <libfdt.h>
 #include <stdbool.h>
@@ -753,6 +754,8 @@ int stm32_i2c_init(struct i2c_handle_s *hi2c,
 	vaddr_t base = 0;
 	uint32_t val = 0;
 
+	mutex_pm_aware_init(&hi2c->mu);
+
 	rc = i2c_setup_timing(hi2c, init_data, &timing);
 	if (rc)
 		return rc;
@@ -1071,11 +1074,15 @@ static int do_write(struct i2c_handle_s *hi2c, struct i2c_request *request,
 	if (request->mode != I2C_MODE_MASTER && request->mode != I2C_MODE_MEM)
 		return -1;
 
-	if (hi2c->i2c_state != I2C_STATE_READY)
-		return -1;
-
 	if (!p_data || !size)
 		return -1;
+
+	mutex_pm_aware_lock(&hi2c->mu);
+
+	if (hi2c->i2c_state != I2C_STATE_READY) {
+		mutex_pm_aware_unlock(&hi2c->mu);
+		return -1;
+	}
 
 	clk_enable(hi2c->clock);
 
@@ -1165,6 +1172,7 @@ static int do_write(struct i2c_handle_s *hi2c, struct i2c_request *request,
 
 bail:
 	clk_disable(hi2c->clock);
+	mutex_pm_aware_unlock(&hi2c->mu);
 
 	return rc;
 }
@@ -1207,8 +1215,12 @@ int stm32_i2c_read_write_membyte(struct i2c_handle_s *hi2c, uint16_t dev_addr,
 	uint8_t *p_buff = p_data;
 	uint32_t event_mask = 0;
 
-	if (hi2c->i2c_state != I2C_STATE_READY || !p_data)
+	mutex_pm_aware_lock(&hi2c->mu);
+
+	if (hi2c->i2c_state != I2C_STATE_READY || !p_data) {
+		mutex_pm_aware_unlock(&hi2c->mu);
 		return -1;
+	}
 
 	clk_enable(hi2c->clock);
 
@@ -1268,6 +1280,7 @@ int stm32_i2c_read_write_membyte(struct i2c_handle_s *hi2c, uint16_t dev_addr,
 
 bail:
 	clk_disable(hi2c->clock);
+	mutex_pm_aware_unlock(&hi2c->mu);
 
 	return rc;
 }
@@ -1294,11 +1307,15 @@ static int do_read(struct i2c_handle_s *hi2c, struct i2c_request *request,
 	if (request->mode != I2C_MODE_MASTER && request->mode != I2C_MODE_MEM)
 		return -1;
 
-	if (hi2c->i2c_state != I2C_STATE_READY)
-		return -1;
-
 	if (!p_data || !size)
 		return -1;
+
+	mutex_pm_aware_lock(&hi2c->mu);
+
+	if (hi2c->i2c_state != I2C_STATE_READY) {
+		mutex_pm_aware_unlock(&hi2c->mu);
+		return -1;
+	}
 
 	clk_enable(hi2c->clock);
 
@@ -1383,6 +1400,7 @@ static int do_read(struct i2c_handle_s *hi2c, struct i2c_request *request,
 
 bail:
 	clk_disable(hi2c->clock);
+	mutex_pm_aware_unlock(&hi2c->mu);
 
 	return rc;
 }
@@ -1464,8 +1482,12 @@ bool stm32_i2c_is_device_ready(struct i2c_handle_s *hi2c, uint32_t dev_addr,
 	unsigned int i2c_trials = 0U;
 	bool rc = false;
 
-	if (hi2c->i2c_state != I2C_STATE_READY)
+	mutex_pm_aware_lock(&hi2c->mu);
+
+	if (hi2c->i2c_state != I2C_STATE_READY) {
+		mutex_pm_aware_unlock(&hi2c->mu);
 		return rc;
+	}
 
 	clk_enable(hi2c->clock);
 
@@ -1540,6 +1562,7 @@ bool stm32_i2c_is_device_ready(struct i2c_handle_s *hi2c, uint32_t dev_addr,
 
 bail:
 	clk_disable(hi2c->clock);
+	mutex_pm_aware_unlock(&hi2c->mu);
 
 	return rc;
 }

--- a/core/include/drivers/stm32_i2c.h
+++ b/core/include/drivers/stm32_i2c.h
@@ -11,6 +11,7 @@
 #include <drivers/pinctrl.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
+#include <kernel/mutex_pm_aware.h>
 #include <mm/core_memprot.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -114,6 +115,7 @@ struct i2c_cfg {
  * @sec_cfg: I2C registers configuration storage
  * @pinctrl: Pin control configuration for the I2C bus in active state
  * @pinctrl_sleep: Pin control configuration for the I2C bus in standby state
+ * @mu: Protection on concurrent access to the I2C bus considering PM context
  */
 struct i2c_handle_s {
 	struct io_pa_va base;
@@ -127,6 +129,7 @@ struct i2c_handle_s {
 	struct i2c_cfg sec_cfg;
 	struct pinctrl_state *pinctrl;
 	struct pinctrl_state *pinctrl_sleep;
+	struct mutex_pm_aware mu;
 };
 
 /*


### PR DESCRIPTION
Protect concurrent accesses to an STM32 I2C bus with a PM aware mutex.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
