### PR TITLE
core: kernel: Fix typo in __do_panic()

### DIFF
--- a/core/kernel/panic.c
+++ b/core/kernel/panic.c
@@ -65,7 +65,7 @@ void __do_panic(const char *file __maybe_unused,
 		const char *func __maybe_unused,
 		const char *msg __maybe_unused)
 {
-	/* disable prehemption */
+	/* disable preemption */
 	(void)thread_mask_exceptions(THREAD_EXCP_ALL);
 
 	/* trace: Panic ['panic-string-message' ]at FILE:LINE [<FUNCTION>]" */


### PR DESCRIPTION
Must be "preemption" instead of "prehemption".

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
