### PR TITLE
drivers: Add RISC-V Zkr hardware random number generator support

### DIFF
--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -8,6 +8,7 @@
 
 #include <compiler.h>
 #include <encoding.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/cdefs.h>
 #include <util.h>
@@ -394,6 +395,8 @@ static inline __noprof uint32_t read_cntfrq(void)
 {
 	return CFG_RISCV_MTIME_RATE;
 }
+
+__noprof bool riscv_detect_csr_seed(void);
 
 #endif /*__ASSEMBLER__*/
 

--- a/core/arch/riscv/kernel/csr_detect.S
+++ b/core/arch/riscv/kernel/csr_detect.S
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024 Andes Technology Corporation
+ */
+
+#include <asm.S>
+#include <riscv.h>
+
+#define DETECT_OP_CSRR		0
+#define DETECT_OP_CSRRW		1
+
+.macro save_and_disable_xie reg
+	csrrw	\reg, CSR_XIE, zero
+.endm
+
+.macro restore_xie reg
+	csrw	CSR_XIE, \reg
+.endm
+
+.macro save_and_replace_xtvec reg, label
+	la	\reg, \label
+	csrrw	\reg, CSR_XTVEC, \reg
+.endm
+
+.macro restore_xtvec reg
+	csrw	CSR_XTVEC, \reg
+.endm
+
+/**
+ * @brief A temporary trap handler to handle an exception during csr detection.
+ *        If csr read/write instruction leads to a trap, CPU will enter this
+ *        function and XRET with a0 = 0, which means the csr is not detected.
+ *        The caller must expect that a0 is used in this function.
+ */
+FUNC csr_detect_trap_vect , :
+	csrr	a0, CSR_XEPC
+	addi	a0, a0, 4
+	csrw	CSR_XEPC, a0
+	mv	a0, zero
+	XRET
+END_FUNC csr_detect_trap_vect
+
+/* Detect CSR by csrr/csrrw instruction. a0=1 if detected, otherwise a0=0 */
+.macro detect_csr csr, op, reg0, reg1, reg2
+	addi	a0, a0, 1
+	save_and_disable_xie \reg0
+	save_and_replace_xtvec \reg1, csr_detect_trap_vect
+.if \op == DETECT_OP_CSRR
+	csrr	\reg2, \csr
+.elseif \op == DETECT_OP_CSRRW
+	csrrw	\reg2, \csr, zero
+.endif
+	restore_xtvec \reg1
+	restore_xie \reg0
+.endm
+
+.macro detect_csr_by_csrr csr, reg0, reg1, reg2
+	detect_csr \csr, DETECT_OP_CSRR, \reg0, \reg1, \reg2
+.endm
+
+.macro detect_csr_by_csrrw csr, reg0, reg1, reg2
+	detect_csr \csr, DETECT_OP_CSRRW, \reg0, \reg1, \reg2
+.endm
+
+/**
+ * bool riscv_detect_csr_seed(void);
+ * @brief A helper function to detect if CSR seed is accessible. The value of a0
+ *        will be cleared by csr_detect_trap_vect() if exception occurs.
+ * @retval 1 if CSR seed is detected, otherwise 0
+ */
+FUNC riscv_detect_csr_seed , :
+	detect_csr_by_csrrw seed, a1, a2, a3
+	ret
+END_FUNC riscv_detect_csr_seed

--- a/core/arch/riscv/kernel/sub.mk
+++ b/core/arch/riscv/kernel/sub.mk
@@ -1,5 +1,6 @@
 srcs-y += spinlock.S
 srcs-y += cache_helpers_rv.S
+srcs-y += csr_detect.S
 srcs-y += idle.c
 srcs-$(CFG_RISCV_TIME_SOURCE_RDTIME) += tee_time_rdtime.c
 srcs-$(CFG_RISCV_SBI) += sbi.c

--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -7,7 +7,10 @@ $(call force,CFG_CORE_DYN_SHM,n)
 CFG_DT ?= y
 
 # Crypto flags
-$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+$(call force,CFG_WITH_SOFTWARE_PRNG,n)
+$(call force,CFG_HWRNG_PTA,y)
+$(call force,CFG_HWRNG_QUALITY,1024)
+$(call force,CFG_RISCV_ZKR_RNG,y)
 
 # Protection flags
 $(call force,CFG_CORE_ASLR,n)

--- a/core/drivers/riscv_zkr_rng.c
+++ b/core/drivers/riscv_zkr_rng.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024 Andes Technology Corporation
+ */
+
+#include <crypto/crypto.h>
+#include <kernel/panic.h>
+#include <riscv.h>
+#include <rng_support.h>
+#include <tee/tee_cryp_utl.h>
+
+#define OPST_BIST 0b00
+#define OPST_WAIT 0b01
+#define OPST_ES16 0b10
+#define OPST_DEAD 0b11
+
+TEE_Result hw_get_random_bytes(void *buf, size_t len)
+{
+	uint8_t *ptr = buf;
+	uint32_t val = 0;
+
+	while (len > 0) {
+		/*
+		 * The seed register must be accessed using CSR read-write
+		 * instructions. The write operation is ignored and serves
+		 * to indicate polling and flushing.
+		 */
+		val = swap_csr(CSR_SEED, val);
+
+		switch (val >> 30) {
+		case OPST_BIST:
+		case OPST_WAIT:
+			continue;
+		case OPST_ES16:
+			*ptr++ = val & 0xff;
+			len--;
+			if (len > 0) {
+				*ptr++ = val >> 8;
+				len--;
+			}
+			break;
+		case OPST_DEAD:
+			/* Unrecoverable self-test error */
+			return TEE_ERROR_BAD_STATE;
+		default:
+			break; /* can't happen */
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+void plat_rng_init(void)
+{
+	if (!riscv_detect_csr_seed())
+		panic("RISC-V Zkr is not supported or unavailable in S-mode");
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -77,6 +77,7 @@ srcs-$(CFG_VERSAL_PUF) += versal_puf.c
 srcs-$(CFG_VERSAL_HUK) += versal_huk.c
 srcs-$(CFG_CBMEM_CONSOLE) += cbmem_console.c
 srcs-$(CFG_RISCV_PLIC) += plic.c
+srcs-$(CFG_RISCV_ZKR_RNG) += riscv_zkr_rng.c
 srcs-$(CFG_HISILICON_CRYPTO_DRIVER) += hisi_trng.c
 srcs-$(CFG_WIDEVINE_HUK) += widevine_huk.c
 srcs-$(CFG_SEMIHOSTING_CONSOLE) += semihosting_console.c


### PR DESCRIPTION
The RISC-V Zkr entropy source extension provides NIST SP 800-90B or BSI AIS-31 compliant physical entropy source via seed CSR.

To allow OP-TEE OS (S-mode) to read the CSR, mseccfg.SSEED bit is expected to be set by M-mode. As we cannot read mseccfg here, use a test trap handler to verify the accessibility of seed.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
