### PR TITLE
Add support of power management for stm32 SAES peripheral

### DIFF
--- a/core/arch/arm/dts/stm32mp13xc.dtsi
+++ b/core/arch/arm/dts/stm32mp13xc.dtsi
@@ -18,7 +18,8 @@
 		compatible = "st,stm32mp13-saes";
 		reg = <0x54005000 0x400>;
 		interrupts = <GIC_SPI 82 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&rcc SAES_K>;
+		clocks = <&rcc SAES_K>, <&rcc RNG1_K>;
+		clock-names = "bus", "rng";
 		resets = <&rcc SAES_R>;
 		status = "disabled";
 	};

--- a/core/arch/arm/dts/stm32mp13xf.dtsi
+++ b/core/arch/arm/dts/stm32mp13xf.dtsi
@@ -18,7 +18,8 @@
 		compatible = "st,stm32mp13-saes";
 		reg = <0x54005000 0x400>;
 		interrupts = <GIC_SPI 82 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&rcc SAES_K>;
+		clocks = <&rcc SAES_K>, <&rcc RNG1_K>;
+		clock-names = "bus", "rng";
 		resets = <&rcc SAES_R>;
 		status = "disabled";
 	};

--- a/core/drivers/crypto/stm32/cipher.c
+++ b/core/drivers/crypto/stm32/cipher.c
@@ -362,6 +362,16 @@ static struct drvcrypt_cipher driver_cipher_saes = {
 
 TEE_Result stm32_register_cipher(enum stm32_cipher_ip_id cipher_ip)
 {
+	void *op = drvcrypt_get_ops(CRYPTO_CIPHER);
+
+	if (op) {
+		EMSG("%s already registered for CRYPTO_CIPHER",
+		     op == &driver_cipher_cryp ? "CRYP peripheral" :
+		     op == &driver_cipher_saes ? "SAES peripheral" :
+		     "Other cipher driver");
+		return TEE_ERROR_GENERIC;
+	}
+
 	if (cipher_ip == SAES_IP)
 		return drvcrypt_register_cipher(&driver_cipher_saes);
 	else if (cipher_ip == CRYP_IP)


### PR DESCRIPTION
This PR adds support of power management in stm32 SAES driver.
We also properly manage the dependency between SAES and RNG.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
