### PR TITLE
drivers: crypto: remove assertions on device handlers

### DIFF
--- a/core/drivers/crypto/stm32/cipher.c
+++ b/core/drivers/crypto/stm32/cipher.c
@@ -94,8 +94,6 @@ static TEE_Result cryp_update(union ip_ctx *ip_ctx, bool last_block,
 
 static void cryp_copy_state(union ip_ctx *dst_ip_ctx, union ip_ctx *src_ip_ctx)
 {
-	assert(IS_ENABLED(CFG_STM32_CRYP));
-
 	memcpy(&dst_ip_ctx->cryp, &src_ip_ctx->cryp, sizeof(dst_ip_ctx->cryp));
 }
 
@@ -167,8 +165,6 @@ static void saes_final(union ip_ctx *ip_ctx)
 {
 	struct crypto_cipher_ctx *ctx = ip_ctx->saes.fallback_ctx;
 
-	assert(IS_ENABLED(CFG_STM32_SAES));
-
 	if (ip_ctx->saes.use_fallback) {
 		assert(IS_ENABLED(CFG_STM32_SAES_SW_FALLBACK));
 		ctx->ops->final(ctx);
@@ -179,8 +175,6 @@ static void saes_copy_state(union ip_ctx *dst_ip_ctx, union ip_ctx *src_ip_ctx)
 {
 	struct saes_ctx *src_ctx = &src_ip_ctx->saes;
 	struct crypto_cipher_ctx *fb_ctx = src_ctx->fallback_ctx;
-
-	assert(IS_ENABLED(CFG_STM32_SAES));
 
 	memcpy(&dst_ip_ctx->saes.ctx, &src_ctx->ctx, sizeof(src_ctx->ctx));
 


### PR DESCRIPTION
Remove assertions added by the commit referred below. They are useless since the handlers are registered only if the related device (stm32_cryp or stm32_saes) has its driver successfully probed. These assertion also prevent enabling both CFG_STM32_SAES and CFG_STM32_CRYP for a platform which is a valid configuration for when we rely on the DT to state which of both is enabled.

Fixes: 03de2c7bb316 ("drivers: crypto: stm32_saes: fallback to software on 192bit AES keys")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
