### PR TITLE
drivers: regulator: fix error case in regulator_supported_voltages() + split asserts

### DIFF
--- a/core/drivers/regulator/regulator.c
+++ b/core/drivers/regulator/regulator.c
@@ -216,18 +216,18 @@ TEE_Result regulator_supported_voltages(struct regulator *regulator,
 					struct regulator_voltages_desc **desc,
 					const int **levels)
 {
+	TEE_Result res = TEE_ERROR_NOT_SUPPORTED;
+
 	assert(regulator && desc && levels);
 
-	if (regulator->ops->supported_voltages) {
-		TEE_Result res = TEE_ERROR_GENERIC;
-
+	if (regulator->ops->supported_voltages)
 		res = regulator->ops->supported_voltages(regulator, desc,
 							 levels);
-		if (res != TEE_ERROR_NOT_SUPPORTED)
-			return res;
-	} else {
+	if (res == TEE_ERROR_NOT_SUPPORTED) {
 		*desc = &regulator->voltages_fallback.desc;
 		*levels = regulator->voltages_fallback.levels;
+	} else if (res) {
+		return res;
 	}
 
 	assert(((*desc)->type == VOLTAGE_TYPE_FULL_LIST &&

--- a/core/drivers/regulator/regulator.c
+++ b/core/drivers/regulator/regulator.c
@@ -230,12 +230,16 @@ TEE_Result regulator_supported_voltages(struct regulator *regulator,
 		return res;
 	}
 
-	assert(((*desc)->type == VOLTAGE_TYPE_FULL_LIST &&
-		(*levels)[0] >= regulator->min_uv && (*desc)->num_levels &&
-		(*levels)[(*desc)->num_levels - 1] <= regulator->max_uv) ||
-	       ((*desc)->type == VOLTAGE_TYPE_INCREMENT &&
-		(*levels)[0] >= regulator->min_uv &&
-		(*levels)[1] <= regulator->max_uv));
+	if ((*desc)->type == VOLTAGE_TYPE_FULL_LIST) {
+		assert((*desc)->num_levels);
+		assert((*levels)[0] >= regulator->min_uv);
+		assert((*levels)[(*desc)->num_levels - 1] <= regulator->max_uv);
+	} else if ((*desc)->type == VOLTAGE_TYPE_INCREMENT) {
+		assert((*levels)[0] >= regulator->min_uv);
+		assert((*levels)[1] <= regulator->max_uv);
+	} else {
+		assert(0);
+	}
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
2 changes:
* Fix case when `.supported_voltages()` handler is supported to assert voltage description when the handler succeeds and to use pre-filled fallback description when the handler returns `TEE_ERROR_NOT_SUPPORTED` instead of asserting @*desc content while that pointer was likely not initialized with a valid address.
Fixes: af5b9881111c ("drivers: regulator: supported voltage consider levels bounds")
* Split assertions in `regulator_supported_voltages()` to ease debugging, providing a better indication of which condition is not fulfilled.
