### PR TITLE
core: make sure tee_entry_get_os_revision() uses a proper TEE_IMPL_GIT_SHA1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         run: |
           # checkpatch task
           set -e
-          git config --global --add safe.directory /__w/optee_os/optee_os
           pushd . >/dev/null
           mkdir -p /tmp/linux/scripts
           cd /tmp/linux/scripts
@@ -68,6 +67,8 @@ jobs:
             builds-cache-
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Update Git config
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - shell: bash
         run: |
           # build task
@@ -287,6 +288,8 @@ jobs:
             qemuv7_check-cache-
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Update Git config
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - shell: bash
         run: |
           # make check task
@@ -320,6 +323,8 @@ jobs:
             qemuv8_check-cache-
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Update Git config
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - shell: bash
         run: |
           # make check task
@@ -360,6 +365,8 @@ jobs:
             qemuv8_xen_check-cache-
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Update Git config
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - shell: bash
         run: |
           # make check task
@@ -393,6 +400,8 @@ jobs:
             qemuv8_hafnium_check-cache-
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Update Git config
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - shell: bash
         run: |
           # make check task
@@ -426,6 +435,8 @@ jobs:
             qemuv8_check_bti_mte_pac-cache-
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Update Git config
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - shell: bash
         run: |
           # make check task

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -748,7 +748,8 @@ static void handle_blocking_call(struct thread_smc_args *args,
 	case OPTEE_FFA_GET_OS_VERSION:
 		spmc_set_args(args, direct_resp_fid, swap_src_dst(args->a1), 0,
 			      CFG_OPTEE_REVISION_MAJOR,
-			      CFG_OPTEE_REVISION_MINOR, TEE_IMPL_GIT_SHA1);
+			      CFG_OPTEE_REVISION_MINOR,
+			      TEE_IMPL_GIT_SHA1 >> 32);
 		break;
 	case OPTEE_FFA_EXCHANGE_CAPABILITIES:
 		sec_caps = OPTEE_FFA_SEC_CAP_ARG_OFFSET;

--- a/core/core.mk
+++ b/core/core.mk
@@ -11,6 +11,17 @@ include mk/config.mk
 # $(ARCH).mk also sets the compiler for the core module
 include core/arch/$(ARCH)/$(ARCH).mk
 
+ifeq ($(CFG_OS_REV_REPORTS_GIT_SHA1),y)
+ifeq ($(arch-bits-core),64)
+git-sha1-len := 16
+else
+git-sha1-len := 8
+endif
+TEE_IMPL_GIT_SHA1 := 0x$(shell git rev-parse --short=$(git-sha1-len) HEAD 2>/dev/null || echo 0 | cut -c -$(git-sha1-len))
+else
+TEE_IMPL_GIT_SHA1 := 0x0
+endif
+
 PLATFORM_$(PLATFORM) := y
 PLATFORM_FLAVOR_$(PLATFORM_FLAVOR) := y
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -133,11 +133,6 @@ CFG_OPTEE_REVISION_EXTRA ?=
 # Trusted OS implementation version
 TEE_IMPL_VERSION ?= $(shell git describe --always --dirty=-dev 2>/dev/null || \
 		      echo Unknown_$(CFG_OPTEE_REVISION_MAJOR).$(CFG_OPTEE_REVISION_MINOR))$(CFG_OPTEE_REVISION_EXTRA)
-ifeq ($(CFG_OS_REV_REPORTS_GIT_SHA1),y)
-TEE_IMPL_GIT_SHA1 := 0x$(shell git rev-parse --short=8 HEAD 2>/dev/null || echo 0)
-else
-TEE_IMPL_GIT_SHA1 := 0x0
-endif
 
 # Trusted OS implementation manufacturer name
 CFG_TEE_MANUFACTURER ?= LINARO


### PR DESCRIPTION

tee_entry_get_os_revision() stores TEE_IMPL_GIT_SHA1 into a 32 or 64-bit register, depending on the platform. Unfortunately the command that creates TEE_IMPL_GIT_SHA1 does not provide any guarantee that the value will fit. For instance it can happen that 8 characters are not enough to disambiguate two commits in the repository, in which case git rev-parse --short=8 will happily return 9 or more characters. In this case a 32-bit build would display a warning and TEE_IMPL_GIT_SHA1 would be truncated in a way we don't want (discarding the most significant bits).

Therefore, make sure TEE_IMPL_GIT_SHA1 is exactly 8 or 16 hexadecimal characters (plus the leading 0x).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
