### PR TITLE
Fixes for SCP-firmware support

### DIFF
--- a/core/include/drivers/stpmic1_regulator.h
+++ b/core/include/drivers/stpmic1_regulator.h
@@ -1,11 +1,13 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2021-2022, STMicroelectronics
+ * Copyright (c) 2021-2024, STMicroelectronics
  */
 
 #ifndef __DRIVERS_STPMIC1_REGULATOR_H
 #define __DRIVERS_STPMIC1_REGULATOR_H
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /*

--- a/core/lib/scmi-server/sub.mk
+++ b/core/lib/scmi-server/sub.mk
@@ -30,6 +30,11 @@ scpfw-cmake-flags-y = -DSCP_FIRMWARE_SOURCE_DIR:PATH=$(scpfw-product)/fw \
 		      -DSCP_OPTEE_DIR:PATH=$(CURDIR) \
 		      -DCFG_CROSS_COMPILE=$(lastword $(CROSS_COMPILE_core))
 
+# CMake does not need to check the cross compilation toolchain since we do not
+# compile any source file with CMake, we only generate some SCP-firmware
+# files.
+scpfw-cmake-flags-y += -DCMAKE_C_COMPILER_WORKS=1
+
 ifeq ($(cmd-echo-silent),true)
 scpfw-cmake-redirect = >/dev/null
 endif


### PR DESCRIPTION
These changes apply to the SCP-firmware OP-TEE currently points to (v2.13.0). They'll need to be considered also when we'll upgrade to a more recent version of SCP-firmware, as proposed in P-R #6769.