### PR TITLE
Make libutee buffering AOSP compatible

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1118,6 +1118,12 @@ static TEE_Result tee_buffer_update(
 		l = ROUNDUP(op->buffer_offs + slen - buffer_size,
 				op->block_size);
 		l = MIN(op->buffer_offs, l);
+		/*
+		 * If we're buffering only a single block, process it
+		 * immediately.
+		 */
+		if (!op->buffer_two_blocks)
+			l = op->block_size;
 		tmp_dlen = dlen;
 		res = update_func(op->state, op->buffer, l, dst, &tmp_dlen);
 		if (res != TEE_SUCCESS)


### PR DESCRIPTION
In tee_buffer_update, libutee currently delays processing an input block until more space is needed in the buffer, which is perfectly valid behavior, but doesn't match AOSP compatibility requirements.

Specifically, both CTS ([testKatEncryptOneByteAtATime](https://android.googlesource.com/platform/cts/+/refs/heads/main/tests/tests/keystore/src/android/keystore/cts/BlockCipherTestBase.java#779)) and VTS ([EncryptionOperationsTest.*OneByteAtATime](https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/vts/functional/KeyMintAidlTestBase.cpp#827)) expect block cipher implementations to produce an output block as soon as a full block of input has been received. Change libutee behavior to be AOSP compatible.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
