### PR TITLE
plat-sam: remove CFG_PL310_LOCKED

### DIFF
--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -25,7 +25,6 @@ include core/arch/arm/cpu/cortex-a5.mk
 $(call force,CFG_SAMA5D2,y)
 $(call force,CFG_ATMEL_SAIC,y)
 $(call force,CFG_PL310,y)
-$(call force,CFG_PL310_LOCKED,y)
 endif
 
 $(call force,CFG_TEE_CORE_NB_CORE,1)


### PR DESCRIPTION
When locking the PL310 cache, it behaves as disable which lead to poor performances in Linux.

The commit is cherry-picked and updated from https://github.com/linux4sam/optee_os-at91/commit/dfacffeb90f03c12dc3b2bbb13fbae6a154f8beb
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
