### PR TITLE
core: riscv: Fix store 32-bit thread_core_local flags

### DIFF
--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -220,7 +220,7 @@ UNWIND(	.cantunwind)
 	mv	sp, a0
 	jal	thread_get_core_local
 	mv	s3, a0
-	STR	x0, THREAD_CORE_LOCAL_FLAGS(s3)
+	sw	zero, THREAD_CORE_LOCAL_FLAGS(s3)
 
 	mv	a0, s1		/* s1 contains saved device tree address */
 	mv	a1, x0		/* unused */
@@ -231,7 +231,7 @@ UNWIND(	.cantunwind)
 	 * restored.
 	 */
 	li	a0, THREAD_CLF_TMP
-	STR	a0, THREAD_CORE_LOCAL_FLAGS(s3)
+	sw	a0, THREAD_CORE_LOCAL_FLAGS(s3)
 	mv	sp, s2
 
 	cpu_is_ready


### PR DESCRIPTION
The thread_core_local flags is a 32-bit variable.
Thus, we must explicitly use "lw" and "sw" instructions, which mean load and store 32-bit value from specific memory address, to operate the thread_core_local flags.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
