### PR TITLE
core: callout: disable obsolete timeouts

### DIFF
--- a/core/kernel/callout.c
+++ b/core/kernel/callout.c
@@ -158,10 +158,13 @@ void callout_service_cb(void)
 		 * schedule_next_timeout() saves the core it was last
 		 * called on. If there's a mismatch here it means that
 		 * another core has been scheduled for the next callout, so
-		 * there's no work to be done for this core.
+		 * there's no work to be done for this core and we can
+		 * disable the timeout on this CPU.
 		 */
 		cpu_spin_lock(&callout_sched_lock);
 		do_callout = (get_core_pos() == callout_sched_core);
+		if (!do_callout)
+			desc->disable_timeout(desc);
 		cpu_spin_unlock(&callout_sched_lock);
 		if (!do_callout)
 			return;


### PR DESCRIPTION
In callout_service_cb() when a timeout interrupt is received there's a check to see if this is the last scheduled CPU. If not the interrupt is ignored, but not disabled causing it to trigger again and again. So fix this by disabling the timeout too.

Fixes: cf707bd0d695 ("core: add callout service")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
