### PR TITLE
ta: pkcs11: correct RSA keys extended attributes sanitation

### DIFF
--- a/ta/pkcs11/src/processing_rsa.c
+++ b/ta/pkcs11/src/processing_rsa.c
@@ -569,6 +569,8 @@ enum pkcs11_rc load_tee_rsa_key_attrs(TEE_Attribute **tee_attrs,
 			break;
 		}
 
+		rc = PKCS11_CKR_GENERAL_ERROR;
+
 		if (pkcs2tee_load_attr(&attrs[count], TEE_ATTR_RSA_PRIME1, obj,
 				       PKCS11_CKA_PRIME_1))
 			count++;


### PR DESCRIPTION
Fix RSA key attributes function load_tee_rsa_key_attrs() that badly checks that the 5 extended RSA attributes are found in the key object.

Link: https://github.com/OP-TEE/optee_test/issues/721#issuecomment-2068055537
Link: https://github.com/OP-TEE/optee_test/issues/721#issuecomment-2072064963
Fixes: 0442c956edfb ("ta: pkcs11: Add support for RSA signing & verification")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
