### PR TITLE
core: spmc: fix direct request handler

### DIFF
--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -836,6 +836,7 @@ static void handle_direct_request(struct thread_smc_args *args,
 	uint32_t direct_resp_fid = 0;
 
 	if (IS_ENABLED(CFG_SECURE_PARTITION) &&
+	    FFA_DST(args->a1) != spmc_id &&
 	    FFA_DST(args->a1) != optee_endpoint_id) {
 		spmc_sp_start_thread(args);
 		return;


### PR DESCRIPTION
The FF-A direct request handling has an error: if the destination ID is the SPMC ID, the handler is trying to forward the message to an SP with this ID, which is obviously non-existent so this gives an error.
