### PR TITLE
core: fix race condition on single instance TA loading

### DIFF
--- a/core/arch/arm/include/kernel/stmm_sp.h
+++ b/core/arch/arm/include/kernel/stmm_sp.h
@@ -137,7 +137,6 @@ struct stmm_ctx {
 	struct thread_ctx_regs regs;
 	vaddr_t ns_comm_buf_addr;
 	unsigned int ns_comm_buf_size;
-	bool is_initializing;
 };
 
 extern const struct ts_ops stmm_sp_ops;

--- a/core/arch/arm/include/kernel/stmm_sp.h
+++ b/core/arch/arm/include/kernel/stmm_sp.h
@@ -153,14 +153,33 @@ static inline struct stmm_ctx *to_stmm_ctx(struct ts_ctx *ctx)
 }
 
 #ifdef CFG_WITH_STMM_SP
+/*
+ * Setup session context for the StMM application
+ * @uuid: TA UUID
+ * @sess: Session for which to setup the StMM context
+ *
+ * This function must be called with tee_ta_mutex locked.
+ */
 TEE_Result stmm_init_session(const TEE_UUID *uuid,
 			     struct tee_ta_session *s);
+
+/*
+ * Finalize session context initialization the StMM application
+ * @sess: Session for which to finalize StMM context
+ */
+TEE_Result stmm_complete_session(struct tee_ta_session *s);
 #else
 static inline TEE_Result
 stmm_init_session(const TEE_UUID *uuid __unused,
 		  struct tee_ta_session *s __unused)
 {
 	return TEE_ERROR_ITEM_NOT_FOUND;
+}
+
+static inline TEE_Result
+stmm_complete_session(struct tee_ta_session *s __unused)
+{
+	return TEE_ERROR_GENERIC;
 }
 #endif
 

--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -343,7 +343,7 @@ TEE_Result stmm_init_session(const TEE_UUID *uuid, struct tee_ta_session *sess)
 	if (!spc)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	spc->is_initializing = true;
+	spc->ta_ctx.is_initializing = true;
 
 	mutex_lock(&tee_ta_mutex);
 	sess->ts_sess.ctx = &spc->ta_ctx.ts_ctx;
@@ -362,7 +362,7 @@ TEE_Result stmm_init_session(const TEE_UUID *uuid, struct tee_ta_session *sess)
 	}
 
 	mutex_lock(&tee_ta_mutex);
-	spc->is_initializing = false;
+	spc->ta_ctx.is_initializing = false;
 	TAILQ_INSERT_TAIL(&tee_ctxes, &spc->ta_ctx, link);
 	mutex_unlock(&tee_ta_mutex);
 
@@ -381,7 +381,7 @@ static TEE_Result stmm_enter_open_session(struct ts_session *s)
 	if (ta_sess->param->types != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (spc->is_initializing) {
+	if (spc->ta_ctx.is_initializing) {
 		/* StMM is initialized in stmm_init_session() */
 		ta_sess->err_origin = TEE_ORIGIN_TEE;
 		return TEE_ERROR_BAD_STATE;

--- a/core/arch/riscv/include/kernel/stmm_sp.h
+++ b/core/arch/riscv/include/kernel/stmm_sp.h
@@ -35,6 +35,12 @@ stmm_init_session(const TEE_UUID *uuid __unused,
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }
 
+static inline TEE_Result
+stmm_complete_session(struct tee_ta_session *s __unused)
+{
+	return TEE_ERROR_GENERIC;
+}
+
 static inline const TEE_UUID *stmm_get_uuid(void) { return NULL; }
 
 #endif /*__KERNEL_STMM_SP_H*/

--- a/core/include/kernel/mutex.h
+++ b/core/include/kernel/mutex.h
@@ -118,13 +118,13 @@ TEE_Result condvar_wait_timeout(struct condvar *cv, struct mutex *m,
 #endif
 
 /*
- * Helper for testing that a given mutex is locked. This helper is to be used
- * with caution since it does not enforce that the executing thread is holding
- * the mutex.
+ * Helper for testing that a given mutex is locked for writing. This helper
+ * is to be used with caution since it does not guarantee that the executing
+ * thread is holding the mutex.
  */
 static inline bool mutex_is_locked(struct mutex *m)
 {
-	return m->state;
+	return m->state == -1; /* write locked */
 }
 #endif /*__KERNEL_MUTEX_H*/
 

--- a/core/include/kernel/mutex.h
+++ b/core/include/kernel/mutex.h
@@ -117,5 +117,14 @@ TEE_Result condvar_wait_timeout(struct condvar *cv, struct mutex *m,
 				uint32_t timeout_ms);
 #endif
 
+/*
+ * Helper for testing that a given mutex is locked. This helper is to be used
+ * with caution since it does not enforce that the executing thread is holding
+ * the mutex.
+ */
+static inline bool mutex_is_locked(struct mutex *m)
+{
+	return m->state;
+}
 #endif /*__KERNEL_MUTEX_H*/
 

--- a/core/include/kernel/pseudo_ta.h
+++ b/core/include/kernel/pseudo_ta.h
@@ -59,6 +59,13 @@ static inline struct pseudo_ta_ctx *to_pseudo_ta_ctx(struct ts_ctx *ctx)
 	return container_of(ctx, struct pseudo_ta_ctx, ctx.ts_ctx);
 }
 
+/*
+ * Setup session context for a pseudo TA
+ * @uuid: Pseudo TA UUID
+ * @s: Session for which to setup a pseudo TA context
+ *
+ * This function must be called with tee_ta_mutex locked.
+ */
 TEE_Result tee_ta_init_pseudo_ta_session(const TEE_UUID *uuid,
 			struct tee_ta_session *s);
 

--- a/core/include/kernel/tee_ta_manager.h
+++ b/core/include/kernel/tee_ta_manager.h
@@ -73,6 +73,7 @@ struct tee_ta_ctx {
 	uint32_t panic_code;	/* Code supplied for panic */
 	uint32_t ref_count;	/* Reference counter for multi session TA */
 	bool busy;		/* Context is busy and cannot be entered */
+	bool is_initializing;	/* Context initialization is not completed */
 	bool is_releasing;	/* Context is about to be released */
 	struct condvar busy_cv;	/* CV used when context is busy */
 };

--- a/core/include/kernel/user_mode_ctx_struct.h
+++ b/core/include/kernel/user_mode_ctx_struct.h
@@ -26,7 +26,6 @@
  * @ldelf_stack_ptr:	Stack pointer used for dumping address mappings and
  *			stack trace
  * @is_32bit:		True if 32-bit TS, false if 64-bit TS
- * @is_initializing:	True if TS is not fully loaded
  * @stack_ptr:		Stack pointer
  * @bbuf:		Bounce buffer for user buffers
  * @bbuf_size:		Size of bounce buffer
@@ -52,7 +51,6 @@ struct user_mode_ctx {
 	uaddr_t dl_entry_func;
 	uaddr_t ldelf_stack_ptr;
 	bool is_32bit;
-	bool is_initializing;
 	vaddr_t stack_ptr;
 	uint8_t *bbuf;
 	size_t bbuf_size;

--- a/core/include/kernel/user_ta.h
+++ b/core/include/kernel/user_ta.h
@@ -56,16 +56,33 @@ static inline struct user_ta_ctx *to_user_ta_ctx(struct ts_ctx *ctx)
 }
 
 #ifdef CFG_WITH_USER_TA
+/*
+ * Setup session context for a user TA
+ * @uuid: TA UUID
+ * @s: Session for which to setup a user TA context
+ *
+ * This function must be called with tee_ta_mutex locked.
+ */
 TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
-			struct tee_ta_session *s);
+				       struct tee_ta_session *s);
+
+/*
+ * Finalize session context initialization for a user TA
+ * @sess: Session for which to finalize user TA context
+ */
+TEE_Result tee_ta_complete_user_ta_session(struct tee_ta_session *s);
 #else
-static inline TEE_Result tee_ta_init_user_ta_session(
-			const TEE_UUID *uuid __unused,
-			struct tee_ta_session *s __unused)
+static inline TEE_Result
+tee_ta_init_user_ta_session(const TEE_UUID *uuid __unused,
+			    struct tee_ta_session *s __unused)
 {
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }
-#endif
 
-
+static inline TEE_Result
+tee_ta_complete_user_ta_session(struct tee_ta_session *s __unused)
+{
+	return TEE_ERROR_GENERIC;
+}
+#endif /*CFG_WITH_USER_TA*/
 #endif /*__KERNEL_USER_TA_H*/

--- a/core/kernel/user_ta.c
+++ b/core/kernel/user_ta.c
@@ -246,7 +246,7 @@ static TEE_Result user_ta_enter_invoke_cmd(struct ts_session *s, uint32_t cmd)
 static void user_ta_enter_close_session(struct ts_session *s)
 {
 	/* Only if the TA was fully initialized by ldelf */
-	if (!to_user_ta_ctx(s->ctx)->uctx.is_initializing)
+	if (!to_user_ta_ctx(s->ctx)->ta_ctx.is_initializing)
 		user_ta_enter(s, UTEE_ENTRY_FUNC_CLOSE_SESSION, 0);
 }
 
@@ -479,7 +479,7 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 	res = vm_info_init(&utc->uctx, &utc->ta_ctx.ts_ctx);
 	if (res)
 		goto out;
-	utc->uctx.is_initializing = true;
+	utc->ta_ctx.is_initializing = true;
 
 #ifdef CFG_TA_PAUTH
 	crypto_rng_read(&utc->uctx.keys, sizeof(utc->uctx.keys));
@@ -511,7 +511,7 @@ TEE_Result tee_ta_init_user_ta_session(const TEE_UUID *uuid,
 	mutex_lock(&tee_ta_mutex);
 
 	if (!res) {
-		utc->uctx.is_initializing = false;
+		utc->ta_ctx.is_initializing = false;
 	} else {
 		s->ts_sess.ctx = NULL;
 		TAILQ_REMOVE(&tee_ctxes, &utc->ta_ctx, link);


### PR DESCRIPTION
Fix race condition on single instance TA creation where several instances of a single instance TA could be created if invoked close enough that they are both created after tee_ta_init_session() calls tee_ta_init_session_with_context().

Closes: https://github.com/OP-TEE/optee_os/issues/6801

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
