### PR TITLE
drivers: Add FFA_CONSOLE based console driver for log

### DIFF
--- a/core/arch/arm/plat-vexpress/main.c
+++ b/core/arch/arm/plat-vexpress/main.c
@@ -92,7 +92,8 @@ void plat_console_init(void)
 	defined(IT_CONSOLE_UART) && \
 	!defined(CFG_NS_VIRTUALIZATION) && \
 	!(defined(CFG_WITH_ARM_TRUSTED_FW) && defined(CFG_ARM_GICV2)) && \
-	!defined(CFG_SEMIHOSTING_CONSOLE)
+	!defined(CFG_SEMIHOSTING_CONSOLE) && \
+	!defined(CFG_FFA_CONSOLE)
 /*
  * This cannot be enabled with TF-A and GICv3 because TF-A then need to
  * assign the interrupt number of the UART to OP-TEE (S-EL1). Currently

--- a/core/drivers/ffa_console.c
+++ b/core/drivers/ffa_console.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION
+ */
+
+#include <compiler.h>
+#include <console.h>
+#include <drivers/ffa_console.h>
+#include <drivers/serial.h>
+#include <kernel/thread_arch.h>
+
+#define FFA_CONSOLE_LOG_32		(0x8400008A)
+
+static void ffa_console_putc(struct serial_chip *chip __unused, int ch)
+{
+	thread_hvc(FFA_CONSOLE_LOG_32, 1, ch, 0);
+}
+
+static const struct serial_ops ffa_console_ops = {
+	.putc = ffa_console_putc,
+};
+DECLARE_KEEP_PAGER(ffa_console_ops);
+
+static struct serial_chip ffa_console = {
+	.ops = &ffa_console_ops
+};
+
+void ffa_console_init(void)
+{
+	register_serial_console(&ffa_console);
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -85,6 +85,7 @@ srcs-$(CFG_RISCV_ZKR_RNG) += riscv_zkr_rng.c
 srcs-$(CFG_HISILICON_CRYPTO_DRIVER) += hisi_trng.c
 srcs-$(CFG_WIDEVINE_HUK) += widevine_huk.c
 srcs-$(CFG_SEMIHOSTING_CONSOLE) += semihosting_console.c
+srcs-$(CFG_FFA_CONSOLE) += ffa_console.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt

--- a/core/include/drivers/ffa_console.h
+++ b/core/include/drivers/ffa_console.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION
+ */
+
+#ifndef FFA_CONSOLE_H
+#define FFA_CONSOLE_H
+
+#ifdef CFG_FFA_CONSOLE
+/*
+ * Initialize console which uses FFA_CONSOLE_LOG of hafnium.
+ */
+void ffa_console_init(void);
+#else
+static inline void ffa_console_init(void)
+{
+}
+#endif
+
+#endif /* FFA_CONSOLE_H */

--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -7,6 +7,7 @@
 #include <console.h>
 #include <drivers/cbmem_console.h>
 #include <drivers/semihosting_console.h>
+#include <drivers/ffa_console.h>
 #include <drivers/serial.h>
 #include <kernel/dt.h>
 #include <kernel/dt_driver.h>
@@ -27,6 +28,8 @@ void console_init(void)
 {
 	if (IS_ENABLED(CFG_SEMIHOSTING_CONSOLE))
 		semihosting_console_init(CFG_SEMIHOSTING_CONSOLE_FILE);
+	else if (IS_ENABLED(CFG_FFA_CONSOLE))
+		ffa_console_init();
 	else
 		plat_console_init();
 }

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1189,3 +1189,8 @@ endif
 # system (also called the target) to communicate with and use the I/O of the
 # host computer.
 CFG_SEMIHOSTING ?= n
+
+# CFG_FFA_CONSOLE, when enabled, embeds a FFA console driver. OP-TEE console
+# writes trace messages via FFA interface to the SPM (Secure Partition Manager)
+# like hafnium.
+CFG_FFA_CONSOLE ?= n


### PR DESCRIPTION
This console driver uses FFA_CONSOLE ABI to write the trace logs.

If CFG_FFA_CONSOLE is enabled, OP-TEE will try to initialize the FFA console driver.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
