### PR TITLE
core: fix possible overflow in shdr_alloc_and_copy()

### DIFF
--- a/core/crypto/signed_hdr.c
+++ b/core/crypto/signed_hdr.c
@@ -29,7 +29,7 @@ struct shdr *shdr_alloc_and_copy(size_t offs, const void *img, size_t img_size)
 		return NULL;
 
 	shdr_size = SHDR_GET_SIZE((const struct shdr *)(img_va + offs));
-	if (ADD_OVERFLOW(offs, shdr_size, &end) || end > img_size)
+	if (!shdr_size || ADD_OVERFLOW(offs, shdr_size, &end) || end > img_size)
 		return NULL;
 
 	if (ADD_OVERFLOW(img_va, shdr_size, &tmp))


### PR DESCRIPTION
Prior to this patch, if SHDR_GET_SIZE() overflows it will return 0 and further down in the function lead to an out-of-bounds access. So fix this with an explicit test before using shdr_size in shdr_alloc_and_copy().

Fixes: 064663e8bd27 ("core: crypto: add struct shdr helper functions")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
