### PR TITLE
core: pager: fix arguments passed to calloc in alloc_merged_pgt_array()

### DIFF
--- a/core/arch/arm/mm/tee_pager.c
+++ b/core/arch/arm/mm/tee_pager.c
@@ -931,7 +931,7 @@ static struct pgt **alloc_merged_pgt_array(struct vm_paged_region *a,
 	    a->pgt_array[a_pgt_count - 1] != a_next->pgt_array[0])
 		return NULL;
 
-	pgt_array = calloc(sizeof(struct pgt *), pgt_count);
+	pgt_array = calloc(pgt_count, sizeof(struct pgt *));
 	if (!pgt_array)
 		return NULL;
 


### PR DESCRIPTION
It seems that the parameters are inverted. More of these are present in libtomcrypt.

Note: I haven't been able to test this patch yet as I don't have a board with me this week. Therefore, I didn't add the `Fixes:` yet.
