### PR TITLE
ftrace: ftrace_format.py: display seconds

### DIFF
--- a/scripts/ftrace_format.py
+++ b/scripts/ftrace_format.py
@@ -31,9 +31,12 @@ def format_time(ns):
     if ns < 1000000:
         us = ns / 1000
         return f"{us:7.3f} us"
-    else:
+    elif ns < 1000000000:
         ms = ns / 1000000
         return f"{ms:7.3f} ms"
+    else:
+        s = ns / 1000000000
+        return f"{s:7.3f} s "
 
 
 def display(depth, val):


### PR DESCRIPTION
When the time spent in a function is 1 second or more, display it as seconds not milliseconds in order to keep the output nicely aligned.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
