### PR TITLE
core: ltc: Fix building with mbedtls

### DIFF
--- a/core/lib/libtomcrypt/aes_accel.c
+++ b/core/lib/libtomcrypt/aes_accel.c
@@ -170,6 +170,7 @@ static int aes_cbc_decrypt_nblocks(const unsigned char *ct, unsigned char *pt,
 	return CRYPT_OK;
 }
 
+#ifdef LTC_CTR_MODE
 static int aes_ctr_encrypt_nblocks(const unsigned char *pt, unsigned char *ct,
 				   unsigned long blocks, unsigned char *IV,
 				   int mode, symmetric_key *skey)
@@ -189,6 +190,7 @@ static int aes_ctr_encrypt_nblocks(const unsigned char *pt, unsigned char *ct,
 
 	return CRYPT_OK;
 }
+#endif
 
 static int aes_xts_encrypt_nblocks(const unsigned char *pt, unsigned char *ct,
 				   unsigned long blocks, unsigned char *tweak,
@@ -245,7 +247,9 @@ const struct ltc_cipher_descriptor aes_desc = {
 	.accel_ecb_decrypt = aes_ecb_decrypt_nblocks,
 	.accel_cbc_encrypt = aes_cbc_encrypt_nblocks,
 	.accel_cbc_decrypt = aes_cbc_decrypt_nblocks,
+#ifdef LTC_CTR_MODE
 	.accel_ctr_encrypt = aes_ctr_encrypt_nblocks,
+#endif
 	.accel_xts_encrypt = aes_xts_encrypt_nblocks,
 	.accel_xts_decrypt = aes_xts_decrypt_nblocks,
 };


### PR DESCRIPTION
Fix building OP-TEE with:

make PLATFORM=vexpress \
     PLATFORM_FLAVOR=juno \
     CFG_CRYPTOLIB_NAME=mbedtls \
     CFG_CRYPTOLIB_DIR=lib/libmbedtls
...
core/lib/libtomcrypt/aes_accel.c: In function ‘aes_ctr_encrypt_nblocks’: core/lib/libtomcrypt/aes_accel.c:182:21: error: ‘CTR_COUNTER_LITTLE_ENDIAN’ undeclared (first use in this function)
  182 |         if (mode == CTR_COUNTER_LITTLE_ENDIAN) {

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
