### PR TITLE
core: kernel: Remove unused ta_time_offs in user_ta_ctx

### DIFF
--- a/core/include/kernel/user_ta.h
+++ b/core/include/kernel/user_ta.h
@@ -28,7 +28,6 @@ SLIST_HEAD(load_seg_head, load_seg);
  * @cryp_states:	List of cryp states created by this TA
  * @objects:		List of storage objects opened by this TA
  * @storage_enums:	List of storage enumerators opened by this TA
- * @ta_time_offs:	Time reference used by the TA
  * @uctx:		Generic user mode context
  * @ctx:		Generic TA context
  */
@@ -37,7 +36,6 @@ struct user_ta_ctx {
 	struct tee_cryp_state_head cryp_states;
 	struct tee_obj_head objects;
 	struct tee_storage_enum_head storage_enums;
-	void *ta_time_offs;
 	struct user_mode_ctx uctx;
 	struct tee_ta_ctx ta_ctx;
 };


### PR DESCRIPTION
It seems that "ta_time_offs" member is unused now. Thus, remove it from user_ta_ctx structure.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
