### PR TITLE
core: drivers: relicense hisi_trng.c as BSD-2-Clause

### DIFF
--- a/core/drivers/hisi_trng.c
+++ b/core/drivers/hisi_trng.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: BSD-2-Clause
 /* Copyright (c) 2023 HiSilicon Limited. */
 
 #include <initcall.h>


### PR DESCRIPTION
The file core/drivers/hisi_trng.c should not have been committed with a GPL-2.0 license. Relicense it as BSD-2-Clause.


Reported-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Closes: https://github.com/OP-TEE/optee_os/issues/6834

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
