### PR TITLE
checkconf.mk: do not use full path to generate guard symbol in conf.h

### DIFF
--- a/mk/checkconf.mk
+++ b/mk/checkconf.mk
@@ -17,7 +17,8 @@ define check-conf-h
 	cnf='$(strip $(foreach var,				\
 		$(call cfg-vars-by-prefix,$1),			\
 		$(call cfg-make-define,$(var))))';		\
-	guard="_`echo $@ | tr -- -/.+ _`_";			\
+	guardpath="$(patsubst $(out-dir)/%,%,$@)"		\
+	guard="_`echo "$${guardpath}" | tr -- -/.+ _`_";	\
 	mkdir -p $(dir $@);					\
 	echo "#ifndef $${guard}" >$@.tmp;			\
 	echo "#define $${guard}" >>$@.tmp;			\


### PR DESCRIPTION
The combination of building with -g3 (which emits definitions of all defined preprocessor macros to the debug info) and using a full path to define the name of this preprocessor guard means that the output is not binary reproducible across different build hosts. For example, in my Yocto build, the string

  __home_ravi_yocto_tmp_glibc_work_stm32mp135fdk_oe_linux_gnueabi_optee_os_stm32mp_3_19_0_stm32mp_r1_1_build_stm32mp135f_dk_include_generated_conf_h_

appears in several build artifacts. Another developer or buildbot would not build in some /home/ravi/... directory.

In order to increase binary reproducibility, only use the path sans the $(out-dir)/ prefix of the conf.h file.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
