### PR TITLE
core: ffa: Improve FF-A memory sharing compliance

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
  * Copyright (c) 2020, Linaro Limited
- * Copyright (c) 2018-2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2024, Arm Limited. All rights reserved.
  */
 
 #ifndef __FFA_H
@@ -222,6 +222,12 @@
 #define FFA_CONSOLE_LOG_CHAR_COUNT_MASK	GENMASK_32(7, 0)
 #define FFA_CONSOLE_LOG_32_MAX_MSG_LEN	U(24)
 #define FFA_CONSOLE_LOG_64_MAX_MSG_LEN	U(48)
+
+/* Memory transaction type in FFA_MEM_RETRIEVE_RESP flags */
+#define FFA_MEMORY_TRANSACTION_TYPE_MASK	GENMASK_32(4, 3)
+#define FFA_MEMORY_TRANSACTION_TYPE_SHARE	SHIFT_U32(1, 3)
+#define FFA_MEMORY_TRANSACTION_TYPE_LEND	SHIFT_U32(2, 3)
+#define FFA_MEMORY_TRANSACTION_TYPE_DONATE	SHIFT_U32(3, 3)
 
 #ifndef __ASSEMBLER__
 /* Constituent memory region descriptor */

--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -23,7 +23,7 @@ bool ffa_mem_reclaim(struct thread_smc_args *args,
 #ifdef CFG_SECURE_PARTITION
 void spmc_sp_start_thread(struct thread_smc_args *args);
 int spmc_sp_add_share(struct ffa_mem_transaction_x *mem_trans,
-		      struct ffa_rxtx *rxtx, size_t blen,
+		      struct ffa_rxtx *rxtx, size_t blen, size_t flen,
 		      uint64_t *global_handle, struct sp_session *owner_sp);
 void spmc_sp_set_to_preempted(struct ts_session *ts_sess);
 int spmc_sp_resume_from_preempted(uint16_t endpoint_id);
@@ -35,7 +35,7 @@ static inline void spmc_sp_start_thread(struct thread_smc_args *args __unused)
 static inline int
 spmc_sp_add_share(struct ffa_mem_transaction_x *mem_trans __unused,
 		  struct ffa_rxtx *rxtx __unused, size_t blen __unused,
-		  uint64_t *global_handle __unused,
+		  size_t flen __unused, uint64_t *global_handle __unused,
 		  struct sp_session *owner_sp __unused)
 {
 	return FFA_NOT_SUPPORTED;

--- a/core/arch/arm/kernel/spmc_sp_handler.c
+++ b/core/arch/arm/kernel/spmc_sp_handler.c
@@ -507,7 +507,7 @@ static void create_retrieve_response(uint32_t ffa_vers, void *dst_buffer,
 		/* copy the mem_transaction_descr */
 		d_ds->sender_id = receiver->smem->sender_id;
 		d_ds->mem_reg_attr = receiver->smem->mem_reg_attr;
-		d_ds->flags = receiver->smem->flags;
+		d_ds->flags = FFA_MEMORY_TRANSACTION_TYPE_SHARE;
 		d_ds->tag = receiver->smem->tag;
 		d_ds->mem_access_count = 1;
 	} else {
@@ -520,7 +520,7 @@ static void create_retrieve_response(uint32_t ffa_vers, void *dst_buffer,
 
 		d_ds->sender_id = receiver->smem->sender_id;
 		d_ds->mem_reg_attr = receiver->smem->mem_reg_attr;
-		d_ds->flags = receiver->smem->flags;
+		d_ds->flags = FFA_MEMORY_TRANSACTION_TYPE_SHARE;
 		d_ds->tag = receiver->smem->tag;
 		d_ds->mem_access_size = sizeof(*mem_acc);
 		d_ds->mem_access_count = 1;

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1098,6 +1098,9 @@ static int add_mem_share(struct ffa_mem_transaction_x *mem_trans,
 	if (rc)
 		return rc;
 
+	if (!share.page_count || !share.region_count)
+		return FFA_INVALID_PARAMETERS;
+
 	if (MUL_OVERFLOW(share.region_count,
 			 sizeof(struct ffa_address_range), &n) ||
 	    ADD_OVERFLOW(n, addr_range_offs, &n) || n > blen)


### PR DESCRIPTION
* Deny memory regions with zero pages
* Validate total page count field
* Validate total descriptor size including memory regions descriptors
* Deny unsupported fragmented operations
* Fix incorrect FFA_ERROR status codes
* Return transaction type flag in retrieve response

Added test cases to SPMC test SPs to cover error handling branches in the memory sharing related functions: https://review.trustedfirmware.org/c/TS/trusted-services/+/28384

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
