### PR TITLE
ci: set FORCE_UNSAFE_CONFIGURE=1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           set -e -v
           export LC_ALL=C
           export PATH=/usr/local/bin:$PATH  # clang
+          export FORCE_UNSAFE_CONFIGURE=1 # Prevent Buildroot error when building as root
           export CFG_DEBUG_INFO=n
           export CFG_WERROR=y
 
@@ -296,6 +297,7 @@ jobs:
           set -e -v
           export LC_ALL=C
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export FORCE_UNSAFE_CONFIGURE=1 # Prevent Buildroot error when building as root
           export CFG_TEE_CORE_LOG_LEVEL=0
           WD=$(pwd)
           cd ..
@@ -331,6 +333,7 @@ jobs:
           set -e -v
           export LC_ALL=C
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export FORCE_UNSAFE_CONFIGURE=1 # Prevent Buildroot error when building as root
           export CFG_TEE_CORE_LOG_LEVEL=0
           export CFG_ATTESTATION_PTA=y
           export CFG_ATTESTATION_PTA_KEY_SIZE=1024
@@ -374,6 +377,7 @@ jobs:
           export LC_ALL=C
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export FORCE_UNSAFE_CONFIGURE=1 # Prevent Buildroot error when building as root
           OPTEE_OS_TO_TEST=$(pwd)
           cd ..
           TOP=$(pwd)/optee_repo_qemu_v8
@@ -409,6 +413,7 @@ jobs:
           export LC_ALL=C
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export FORCE_UNSAFE_CONFIGURE=1 # Prevent Buildroot error when building as root
           OPTEE_OS_TO_TEST=$(pwd)
           cd ..
           TOP=$(pwd)/optee_repo_qemu_v8
@@ -444,6 +449,7 @@ jobs:
           export LC_ALL=C
           export CFG_TEE_CORE_LOG_LEVEL=0
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export FORCE_UNSAFE_CONFIGURE=1 # Prevent Buildroot error when building as root
           OPTEE_OS_TO_TEST=$(pwd)
           cd ..
           TOP=$(pwd)/optee_repo_qemu_v8
@@ -481,6 +487,7 @@ jobs:
           export PATH=/usr/local/bin:$PATH
           export AARCH64_CROSS_COMPILE=aarch64-unknown-linux-uclibc-
           export BR2_CCACHE_DIR=/github/home/.cache/ccache
+          export FORCE_UNSAFE_CONFIGURE=1 # Prevent Buildroot error when building as root
           export CFG_TEE_CORE_LOG_LEVEL=0
           export CFG_USER_TA_TARGETS=ta_arm64
           OPTEE_OS_TO_TEST=$(pwd)


### PR DESCRIPTION
The newer version of Buildroot recently selected in the OP-TEE manifest [1] does not allow building as root by default (apparently this is not a Buildroot policy but rather defined in some packages included in Buildroot). While this makes sense in general, we could not care less in a CI container. Therefore set the appropriate environment variable to bypass this check. We could as well change the Docker image to build as a non-root user but let's just pick the easiest way for now.

Link: https://github.com/OP-TEE/manifest/pull/281 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
