### PR TITLE
Clang fixes

### DIFF
--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -452,8 +452,15 @@ static inline __noprof void write_##reg(type val)		\
 
 DEFINE_U32_REG_READWRITE_FUNCS(cpacr_el1)
 DEFINE_U32_REG_READWRITE_FUNCS(daif)
+#ifdef __clang__
+DEFINE_REG_READ_FUNC_(fpcr, uint32_t, S3_3_c4_c4_0)
+DEFINE_REG_WRITE_FUNC_(fpcr, uint32_t, S3_3_c4_c4_0)
+DEFINE_REG_READ_FUNC_(fpsr, uint32_t, S3_3_c4_c4_1)
+DEFINE_REG_WRITE_FUNC_(fpsr, uint32_t, S3_3_c4_c4_1)
+#else
 DEFINE_U32_REG_READWRITE_FUNCS(fpcr)
 DEFINE_U32_REG_READWRITE_FUNCS(fpsr)
+#endif
 
 DEFINE_U32_REG_READ_FUNC(ctr_el0)
 #define read_ctr() read_ctr_el0()

--- a/core/lib/zlib/sub.mk
+++ b/core/lib/zlib/sub.mk
@@ -6,3 +6,5 @@ srcs-y += inftrees.c
 srcs-y += zutil.c
 cflags-remove-y += -Wold-style-definition
 cflags-remove-y += -Wswitch-default
+cflags-remove-y += -Wstrict-prototypes
+cflags-y += $(call cc-option,-Wno-deprecated-non-prototype)

--- a/lib/libutils/isoc/sub.mk
+++ b/lib/libutils/isoc/sub.mk
@@ -3,6 +3,7 @@ global-incdirs-y += include
 srcs-y += bget_malloc.c
 cflags-remove-bget_malloc.c-y += -Wold-style-definition -Wredundant-decls
 cflags-bget_malloc.c-y += -Wno-sign-compare -Wno-cast-align
+cflags-bget_malloc.c-y += $(call cc-option,-Wno-deprecated-non-prototype)
 ifeq ($(sm),core)
 cflags-remove-bget_malloc.c-y += $(cflags_kasan)
 endif


### PR DESCRIPTION
Small fixes required with Clang 18.1.6. To build OP-TEE with that version, please see https://github.com/OP-TEE/build/pull/762.