### PR TITLE
plat-mediatek: add support to extend MAX_XLAT_TABLE

### DIFF
--- a/core/arch/arm/plat-mediatek/conf.mk
+++ b/core/arch/arm/plat-mediatek/conf.mk
@@ -14,6 +14,10 @@ CFG_DRAM_BASE ?= 0x40000000
 # default DRAM size 1 GiB
 CFG_DRAM_SIZE ?= 0x40000000
 
+# When need to create a virtual memory pool for mapping other
+# physical address, enable the config to increase MAX_XLAT_TABLES.
+CFG_MTK_RESERVED_VA ?= n
+
 ifeq ($(PLATFORM_FLAVOR),mt8173)
 # 2**1 = 2 cores per cluster
 $(call force,CFG_TEE_CORE_NB_CORE,4)

--- a/core/arch/arm/plat-mediatek/platform_config.h
+++ b/core/arch/arm/plat-mediatek/platform_config.h
@@ -123,8 +123,9 @@
 #error "Unknown platform flavor"
 #endif
 
-#ifdef CFG_WITH_LPAE
-#define MAX_XLAT_TABLES		5
+#ifdef CFG_MTK_RESERVED_VA
+#define MAX_XLAT_TABLES		(30 + (CFG_RESERVED_VASPACE_SIZE) / \
+				 (CORE_MMU_PGDIR_SIZE) + 1)
 #endif
 
 #endif /*PLATFORM_CONFIG_H*/


### PR DESCRIPTION
We will create the memory pool from MEM_AREA_RES_VASPACE.
When using the reserved virtual memory space, it is necessary to increase MAX_XLAT_TABLE based on its size.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
