### PR TITLE
drivers: gic: Dynamically assign interrupts to non-secure world

### DIFF
--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -17,6 +17,7 @@
 #include <kernel/dt_driver.h>
 #include <kernel/interrupt.h>
 #include <kernel/misc.h>
+#include <kernel/mutex.h>
 #include <kernel/panic.h>
 #include <libfdt.h>
 #include <mm/core_memprot.h>
@@ -138,6 +139,7 @@ struct gic_data {
 
 static bool gic_primary_done __nex_bss;
 static struct gic_data gic_data __nex_bss;
+static struct mutex gic_mutex = MUTEX_INITIALIZER;
 
 static void gic_op_add(struct itr_chip *chip, size_t it, uint32_t type,
 		       uint32_t prio);
@@ -856,6 +858,36 @@ void gic_dump_state(void)
 			     gic_it_get_group(gd, i), gic_it_get_target(gd, i));
 		}
 	}
+}
+
+TEE_Result gic_spi_release_to_ns(size_t it)
+{
+	struct gic_data *gd = &gic_data;
+	size_t idx = it / NUM_INTS_PER_REG;
+	uint32_t mask = BIT32(it % NUM_INTS_PER_REG);
+
+	if (it >= gd->max_it || it < GIC_SPI_BASE)
+		return TEE_ERROR_BAD_PARAMETERS;
+	/* Make sure it's already disabled */
+	if (!gic_it_is_enabled(gd, it))
+		return TEE_ERROR_BAD_STATE;
+	/* Assert it's secure to start with */
+	if (!gic_it_get_group(gd, it))
+		return TEE_ERROR_BAD_STATE;
+
+	mutex_lock(&gic_mutex);
+	gic_it_set_cpu_mask(gd, it, 0);
+	gic_it_set_prio(gd, it, GIC_SPI_PRI_NS_EL1);
+
+	/* Clear pending status */
+	io_write32(gd->gicd_base + GICD_ICPENDR(idx), mask);
+	/* Assign it to NS Group1 */
+	io_setbits32(gd->gicd_base + GICD_IGROUPR(idx), mask);
+#if defined(CFG_ARM_GICV3)
+	io_clrbits32(gd->gicd_base + GICD_IGROUPMODR(idx), mask);
+#endif
+	mutex_unlock(&gic_mutex);
+	return TEE_SUCCESS;
 }
 
 static void __maybe_unused gic_native_itr_handler(void)

--- a/core/include/drivers/gic.h
+++ b/core/include/drivers/gic.h
@@ -31,6 +31,8 @@
 #define GIC_SGI_SEC_BASE	8
 /* Max ID for secure SGIs */
 #define GIC_SGI_SEC_MAX		15
+/* Default IRQ priority for SPIs in Non-Sec EL1 */
+#define GIC_SPI_PRI_NS_EL1	0x50
 
 /*
  * The two gic_init() and gic_init_v3() functions initializes the struct
@@ -56,4 +58,11 @@ void gic_init_per_cpu(void);
 
 /* Print GIC state to console */
 void gic_dump_state(void);
+
+/*
+ * Reassign one of the SPIs to normal world and set its priority to
+ * GIC_SPI_PRI_NS_EL1. Ensure that the interrupt is currently
+ * assigned to secure world and disabled when this function is called.
+ */
+TEE_Result gic_spi_release_to_ns(size_t it);
 #endif /*__DRIVERS_GIC_H*/


### PR DESCRIPTION
Add gic_spi_release_to_ns() API function in GIC driver to release an interrupt to Non secure settings. This functionality is essential for scenarios where a specific interrupt needs to be dynamically set to either Group 1 Secure (G1S) or Group 1 Non-Secure (G1NS) at different times.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
