### PR TITLE
core: mm: add CFG_PGT_CACHE_ENTRIES

### DIFF
--- a/core/include/mm/pgt_cache.h
+++ b/core/include/mm/pgt_cache.h
@@ -5,6 +5,12 @@
 #ifndef __MM_PGT_CACHE_H
 #define __MM_PGT_CACHE_H
 
+#include <assert.h>
+#include <kernel/tee_ta_manager.h>
+#include <sys/queue.h>
+#include <types_ext.h>
+#include <util.h>
+
 #ifdef CFG_WITH_LPAE
 #define PGT_SIZE	(4 * 1024)
 #define PGT_NUM_PGT_PER_PAGE	1
@@ -12,12 +18,6 @@
 #define PGT_SIZE	(1 * 1024)
 #define PGT_NUM_PGT_PER_PAGE	4
 #endif
-
-#include <assert.h>
-#include <kernel/tee_ta_manager.h>
-#include <sys/queue.h>
-#include <types_ext.h>
-#include <util.h>
 
 struct ts_ctx;
 
@@ -37,20 +37,6 @@ struct pgt {
 #endif
 	SLIST_ENTRY(pgt) link;
 };
-
-/*
- * A proper value for PGT_CACHE_SIZE depends on many factors: CFG_WITH_LPAE,
- * CFG_TA_ASLR, size of TA, size of memrefs passed to TA, CFG_ULIBS_SHARED and
- * possibly others. The value is based on the number of threads as an indicator
- * on how large the system might be.
- */
-#if CFG_NUM_THREADS < 2
-#define PGT_CACHE_SIZE	4
-#elif (CFG_NUM_THREADS == 2 && !defined(CFG_WITH_LPAE))
-#define PGT_CACHE_SIZE	8
-#else
-#define PGT_CACHE_SIZE	ROUNDUP(CFG_NUM_THREADS * 2, PGT_NUM_PGT_PER_PAGE)
-#endif
 
 SLIST_HEAD(pgt_cache, pgt);
 struct user_mode_ctx;

--- a/core/mm/pgt_cache.c
+++ b/core/mm/pgt_cache.c
@@ -338,6 +338,8 @@ prune_done:
 }
 #else /* !CFG_CORE_PREALLOC_EL0_TBLS */
 
+#define PGT_CACHE_SIZE	ROUNDUP(CFG_PGT_CACHE_ENTRIES, PGT_NUM_PGT_PER_PAGE)
+
 #if defined(CFG_WITH_PAGER) && !defined(CFG_WITH_LPAE)
 static struct pgt_parent pgt_parents[PGT_CACHE_SIZE / PGT_NUM_PGT_PER_PAGE];
 #else

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1097,6 +1097,26 @@ ifeq (y-y,$(CFG_CORE_PREALLOC_EL0_TBLS)-$(CFG_WITH_PAGER))
 $(error "CFG_WITH_PAGER can't support CFG_CORE_PREALLOC_EL0_TBLS")
 endif
 
+# CFG_PGT_CACHE_ENTRIES defines the number of entries on the memory
+# mapping page table cache used for Trusted Application mapping.
+# CFG_PGT_CACHE_ENTRIES is ignored when CFG_CORE_PREALLOC_EL0_TBLS
+# is enabled.
+#
+# A proper value for CFG_PGT_CACHE_ENTRIES depends on many factors:
+# CFG_WITH_LPAE, CFG_TA_ASLR, size of TAs, size of memrefs passed
+# to TA, CFG_ULIBS_SHARED and possibly others. The default value
+# is based on the number of threads as an indicator on how large
+# the system might be.
+ifeq ($(CFG_NUM_THREADS),1)
+CFG_PGT_CACHE_ENTRIES ?= 4
+endif
+ifeq ($(CFG_NUM_THREADS),2)
+ifneq ($(CFG_WITH_LPAE),y)
+CFG_PGT_CACHE_ENTRIES ?= 8
+endif
+endif
+CFG_PGT_CACHE_ENTRIES ?= ($(CFG_NUM_THREADS) * 2)
+
 # User TA runtime context dump.
 # When this option is enabled, OP-TEE provides a debug method for
 # developer to dump user TA's runtime context, including TA's heap stats.


### PR DESCRIPTION
Add CFG_PGT_CACHE_ENTRIES to allow platforms to customize the page table cache size. This is needed for example when a platform is to support very large TAs of several dozen of Mbytes of private memory (code/data).

By the way, fix pgt_cache.h layout to have header files includes first followed by macro definitions.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
