### PR TITLE
fix use of calloc() against GCC 14.1 directive -Wcalloc-transposed-args

### DIFF
--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -1109,7 +1109,7 @@ static int add_mem_share(struct ffa_mem_transaction_x *mem_trans,
 		return FFA_NO_MEMORY;
 
 	if (flen != blen) {
-		struct mem_frag_state *s = calloc(sizeof(*s), 1);
+		struct mem_frag_state *s = calloc(1, sizeof(*s));
 
 		if (!s) {
 			rc = FFA_NO_MEMORY;

--- a/core/arch/arm/mm/sp_mem.c
+++ b/core/arch/arm/mm/sp_mem.c
@@ -224,7 +224,7 @@ struct sp_mem *sp_mem_new(void)
 	uint32_t exceptions = 0;
 	int i = 0;
 
-	smem = calloc(sizeof(*smem), 1);
+	smem = calloc(1, sizeof(*smem));
 	if (!smem)
 		return NULL;
 

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_flexi.c
@@ -268,7 +268,7 @@ static int s_der_decode_sequence_flexi(const unsigned char *in, unsigned long *i
             }
             l->size = len;
 
-            if ((l->data = XCALLOC(sizeof(wchar_t), l->size)) == NULL) {
+            if ((l->data = XCALLOC(l->size, sizeof(wchar_t))) == NULL) {
                err = CRYPT_MEM;
                goto error;
             }

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_decode_sequence_multi.c
@@ -78,7 +78,7 @@ static int s_der_decode_sequence_va(const unsigned char *in, unsigned long inlen
       return CRYPT_NOP;
    }
 
-   list = XCALLOC(sizeof(*list), x);
+   list = XCALLOC(x, sizeof(*list));
    if (list == NULL) {
       return CRYPT_MEM;
    }

--- a/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
+++ b/core/lib/libtomcrypt/src/pk/asn1/der/sequence/der_encode_sequence_multi.c
@@ -81,7 +81,7 @@ int der_encode_sequence_multi(unsigned char *out, unsigned long *outlen, ...)
       return CRYPT_NOP;
    }
 
-   list = XCALLOC(sizeof(*list), x);
+   list = XCALLOC(x, sizeof(*list));
    if (list == NULL) {
       return CRYPT_MEM;
    }


### PR DESCRIPTION
This change complements https://github.com/OP-TEE/optee_os/pull/6853.
Changes in libtomcrypt are under review in https://github.com/libtom/libtomcrypt/pull/647.
No functional changes.