### PR TITLE
core: mm: core_mmu: skip unmapped regions when searching by PA

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -286,7 +286,9 @@ static struct tee_mmap_region *find_map_by_pa(unsigned long pa)
 	struct tee_mmap_region *map = get_memory_map();
 
 	while (!core_mmap_is_end_of_table(map)) {
-		if (pa >= map->pa && pa <= (map->pa + map->size - 1))
+		/* Skip unmapped regions */
+		if ((map->attr & TEE_MATTR_VALID_BLOCK) &&
+		    pa >= map->pa && pa <= (map->pa + map->size - 1))
 			return map;
 		map++;
 	}


### PR DESCRIPTION
Currently, OP-TEE OS on RISC-V platforms uses external device-tree located at 'Domain1 Next Arg1' passed by previous boot stages (i.e. U-Boot SPL and OpenSBI). For example:

  Domain1 Name              : trusted-domain
  ...
  Domain1 Next Address      : 0x0000000010000000 // OP-TEE OS
> Domain1 Next Arg1         : 0x000000000187f760 // device-tree
  Domain1 Next Mode         : S-mode

In this case, 0x0187f760 lies in SHM_VASPACE, which is not yet mapped and not intended to load an external DT:

  type TEE_RAM_RX   va 0x10000000..0x10092fff pa 0x10000000..0x10092fff
  type TEE_RAM_RW   va 0x10093000..0x101fffff pa 0x10093000..0x101fffff
  type RES_VASPACE  va 0x10200000..0x10bfffff pa 0x00000000..0x009fffff
> type SHM_VASPACE  va 0x10c00000..0x12bfffff pa 0x00000000..0x01ffffff
  type TA_RAM       va 0x12c00000..0x139fffff pa 0x10200000..0x10ffffff
  type IO_SEC       va 0x13a00000..0x13bfffff pa 0xf0200000..0xf03fffff

To address this issue, add a memory region attribute check to skip such regions. In this way, when init_external_dt() calls core_mmu_get_type_by_pa(), it can properly return MEM_AREA_MAXTYPE (i.e. valid region not found) and map a MEM_AREA_EXT_DT region.

Note that this bug cannot be reproduced on QEMU virt machine, as its memory regions have no overlapping with the external DT.


Reviewed-by: Alvin Chang <alvinga@andestech.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
