### PR TITLE
dt-bindings: mfd: dual licensing for st,stpmic1 bindings

### DIFF
--- a/core/include/dt-bindings/mfd/st,stpmic1.h
+++ b/core/include/dt-bindings/mfd/st,stpmic1.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 */
+/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
 /*
  * Copyright (C) STMicroelectronics 2018 - All Rights Reserved
  * Author: Philippe Peurichard <philippe.peurichard@st.com>,


### PR DESCRIPTION
Change include/dt-bindings/mfd/st,stpmic1.h license model from GPLv2.0 only to dual GPLv2.0 or BSD-2-Clause. This change clarifies that this DT binding header file can be shared with software components as bootloaders and OSes that are not published under GPLv2 terms as OP-TEE OS is.

This change has been discussed and acked in the LKML [1].

Fixes: 1183a0aa2af0 ("stm32mp1: update DTS files to Linux kernel 5.2-rc1")
Link: https://lore.kernel.org/lkml/171941721004.2530174.778562710266249921.b4-ty@kernel.org/ [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
