### PR TITLE
plat-stm32mp1: conf: restore generic default heap size

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -346,9 +346,6 @@ CFG_TEE_CORE_DEBUG ?= n
 CFG_UNWIND ?= n
 CFG_LOCKDEP ?= n
 CFG_TA_BGET_TEST ?= n
-# Default disable early TA compression to support a smaller HEAP size
-CFG_EARLY_TA_COMPRESS ?= n
-CFG_CORE_HEAP_SIZE ?= 49152
 endif
 
 # Non-secure UART and GPIO/pinctrl for the output console


### PR DESCRIPTION
Remove reduced default heap size configuration of 48kB when pager is enabled on stm32mp1 platforms. 48kB of core heap may not always be enough to pass OP-TEE Test regression test 4011 related to Bleichenbacher attack since it consumes 4.5kB more memory on in OP-TEE core since we upgraded to Mbed TLS library 3.6.0. The platform now default uses the generic 64kB default heap size set from mk/config.mk.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
