### PR TITLE
drivers: stm32_rstctrl: fix unpaged resource

### DIFF
--- a/core/drivers/rstctrl/stm32mp1_rstctrl.c
+++ b/core/drivers/rstctrl/stm32mp1_rstctrl.c
@@ -140,6 +140,7 @@ static const struct rstctrl_ops *stm32_reset_get_ops(unsigned int id __unused)
 static const struct stm32_reset_data stm32mp1_reset_data = {
 	.get_rstctrl_ops = stm32_reset_get_ops
 };
+DECLARE_KEEP_PAGER(stm32mp1_reset_data);
 
 static const struct dt_device_match stm32_rstctrl_match_table[] = {
 	{


### PR DESCRIPTION
Fixes missing declaration of STM32MP1 reset controller compat data as unpaged resource since it is used  by stm32mp_rcc_reset_id_to_rstctrl() function called by fastcall service psci_system_reset() that requires to resized in the unpaged segment on STM32MP15 variant where pager is enabled.

Fixes: 3ef177b4f153 ("drivers: stm32_rstctrl: move stm32mp1x controller in stm32mp1_rstcrl.c")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
