### PR TITLE
core: firewall: fix warning when compiling with no trace.

### DIFF
--- a/core/drivers/firewall/firewall.c
+++ b/core/drivers/firewall/firewall.c
@@ -167,8 +167,9 @@ TEE_Result firewall_dt_controller_register(const void *fdt, int node,
 					   ctrl, DT_DRIVER_FIREWALL);
 }
 
-TEE_Result firewall_dt_probe_bus(const void *fdt, int node,
-				 struct firewall_controller *ctrl)
+TEE_Result
+firewall_dt_probe_bus(const void *fdt, int node,
+		      struct firewall_controller *ctrl __maybe_unused)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct firewall_query *fw = NULL;


### PR DESCRIPTION
When compiling with CFG_TEE_CORE_LOG_LEVEL=0 this warning is raised : core/drivers/firewall/firewall.c: In function ‘firewall_dt_probe_bus’: core/drivers/firewall/firewall.c:297:62: error: unused parameter ‘ctrl’ [-Werror=unused-parameter]
  297 |                                  struct firewall_controller *ctrl)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
