### PR TITLE
core: arm64: fix compiling warning when enable BTI.

### DIFF
--- a/core/arch/arm/crypto/sm4_armv8a_ce_a64.S
+++ b/core/arch/arm/crypto/sm4_armv8a_ce_a64.S
@@ -1028,3 +1028,5 @@ FUNC ce_sm4_xts_decrypt , :
 	frame_pop
 	ret
 END_FUNC ce_sm4_xts_decrypt
+
+BTI(emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI)


### PR DESCRIPTION
Fix compiling warning in sm4_armv8a_ce_a64.S when CFG_CORE_BTI=y:
aarch64-none-linux-gnu-ld.bfd: out/core/arch/arm/crypto/sm4_armv8a_ce_a64.o: warning:
BTI turned on by -z force-bti when all inputs do not have BTI in NOTE section.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
