### PR TITLE
Fix TA_FLAGS_MASK

### DIFF
--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -35,7 +35,7 @@
 #define TA_FLAG_DONT_CLOSE_HANDLE_ON_CORRUPT_OBJECT \
 					BIT32(11)
 
-#define TA_FLAGS_MASK			GENMASK_32(10, 0)
+#define TA_FLAGS_MASK			GENMASK_32(11, 0)
 
 struct ta_head {
 	TEE_UUID uuid;


### PR DESCRIPTION
Add missing TA_FLAG_DONT_CLOSE_HANDLE_ON_CORRUPT_OBJECT to TA_FLAGS_MASK.

Fixes: 138c5102ef4c ("GP131: Add TA property gpd.ta.doesNotCloseHandleOnCorruptObject")
Reported-by: Mikko Rapeli <mikko.rapeli@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
