### PR TITLE
arm32: ftrace: skip profiling of __aeabi functions

### DIFF
--- a/lib/libutils/isoc/arch/arm/sub.mk
+++ b/lib/libutils/isoc/arch/arm/sub.mk
@@ -7,7 +7,6 @@ srcs-$(CFG_ARM32_$(sm)) += arm32_aeabi_ldivmod_a32.S
 srcs-$(CFG_ARM32_$(sm)) += arm32_aeabi_ldivmod.c
 srcs-$(CFG_ARM32_$(sm)) += arm32_aeabi_shift.c
 
-ifeq ($(CFG_ULIBS_MCOUNT),y)
 # We would not like to profile __aeabi functions as these provide
 # internal implementations for "/ %" operations. Also, "/ %" operations
 # could be used inside profiling code which could create an incorrect
@@ -15,7 +14,6 @@ ifeq ($(CFG_ULIBS_MCOUNT),y)
 cflags-remove-arm32_aeabi_divmod.c-y += -pg
 cflags-remove-arm32_aeabi_ldivmod.c-y += -pg
 cflags-remove-arm32_aeabi_shift.c-y += -pg
-endif
 
 srcs-$(CFG_ARM32_$(sm)) += setjmp_a32.S
 srcs-$(CFG_ARM64_$(sm)) += setjmp_a64.S


### PR DESCRIPTION
When compiling the __aeabi functions, skip profiling if CFG_FTRACE_SUPPORT is enabled to avoid recursive calls.

Reported-by: Jerome Forissier <jerome.forissier@linaro.org>
Closes: https://github.com/OP-TEE/optee_os/issues/6870

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
