### PR TITLE
core: fix undefined behavior aborts during xtest

### DIFF
--- a/core/kernel/user_access.c
+++ b/core/kernel/user_access.c
@@ -51,7 +51,7 @@ TEE_Result copy_from_user(void *kaddr, const void *uaddr, size_t len)
 
 	uaddr = memtag_strip_tag_const(uaddr);
 	res = check_user_access(flags, uaddr, len);
-	if (!res) {
+	if (!res && kaddr && uaddr) {
 		enter_user_access();
 		memcpy(kaddr, uaddr, len);
 		exit_user_access();
@@ -67,7 +67,7 @@ TEE_Result copy_to_user(void *uaddr, const void *kaddr, size_t len)
 
 	uaddr = memtag_strip_tag(uaddr);
 	res = check_user_access(flags, uaddr, len);
-	if (!res) {
+	if (!res && kaddr && uaddr) {
 		enter_user_access();
 		memcpy(uaddr, kaddr, len);
 		exit_user_access();
@@ -83,7 +83,7 @@ TEE_Result copy_from_user_private(void *kaddr, const void *uaddr, size_t len)
 
 	uaddr = memtag_strip_tag_const(uaddr);
 	res = check_user_access(flags, uaddr, len);
-	if (!res) {
+	if (!res && kaddr && uaddr) {
 		enter_user_access();
 		memcpy(kaddr, uaddr, len);
 		exit_user_access();
@@ -99,7 +99,7 @@ TEE_Result copy_to_user_private(void *uaddr, const void *kaddr, size_t len)
 
 	uaddr = memtag_strip_tag(uaddr);
 	res = check_user_access(flags, uaddr, len);
-	if (!res) {
+	if (!res && kaddr && uaddr) {
 		enter_user_access();
 		memcpy(uaddr, kaddr, len);
 		exit_user_access();
@@ -282,7 +282,7 @@ TEE_Result bb_strndup_user(const char *src, size_t maxlen, char **dst,
 	if (!d)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	if (l) {
+	if (l && src && d) {
 		enter_user_access();
 		memcpy(d, src, l);
 		exit_user_access();

--- a/core/lib/libtomcrypt/src/pk/ec25519/tweetnacl.c
+++ b/core/lib/libtomcrypt/src/pk/ec25519/tweetnacl.c
@@ -47,7 +47,7 @@ sv set25519(gf r, const gf a)
 sv car25519(gf o)
 {
   int i;
-  i64 c;
+  u64 c;
   FOR(i,16) {
     o[i]+=(1LL<<16);
     c=o[i]>>16;
@@ -109,7 +109,7 @@ static u8 par25519(const gf a)
 sv unpack25519(gf o, const u8 *n)
 {
   int i;
-  FOR(i,16) o[i]=n[2*i]+((i64)n[2*i+1]<<8);
+  FOR(i,16) o[i]=n[2*i]+((u64)n[2*i+1]<<8);
   o[15]&=0x7fff;
 }
 
@@ -348,7 +348,8 @@ static const u64 L[32] = {0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 
 
 sv modL(u8 *r,i64 x[64])
 {
-  i64 carry,i,j;
+  i64 i,j;
+  u64 carry;
   for (i = 63;i >= 32;--i) {
     carry = 0;
     for (j = i - 32;j < i - 12;++j) {


### PR DESCRIPTION
1. Replace i64 with u64 in `lib/libtomcrypt/tweetnacl.c` to avoid `shift_out_of_bounds` 
error by UBSan.

2. Add null pointer checks in `kernel/user_access.c` before memcpy to avoid 
`nonnull_args` error by UBSan.

Signed-off-by: Abhishek Revadekar [abhishek.rvdkr@yahoo.com](mailto:abhishek.rvdkr@yahoo.com)
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    4. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    5. You should run checkpatch preferably before submitting the pull request.

    6. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
