### PR TITLE
TEE core will crash when CFG_TEE_CORE_DEBUG=y and CFG_MEMTAG=y

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -18,6 +18,7 @@
 #include <kernel/user_mode_ctx.h>
 #include <kernel/virtualization.h>
 #include <libfdt.h>
+#include <memtag.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <mm/mobj.h>
@@ -2339,7 +2340,7 @@ paddr_t virt_to_phys(void *va)
 
 	if (!arch_va2pa_helper(va, &pa))
 		pa = 0;
-	check_pa_matches_va(va, pa);
+	check_pa_matches_va(memtag_strip_tag(va), pa);
 	return pa;
 }
 


### PR DESCRIPTION
When CFG_TEE_CORE_DEBUG=y and CFG_MEMTAG=y, core will crash, if there are some modules call virt_to_phys() or core_vbuf_is() and so on. Because the MM can not find map by the tagged VA, so strip the tag of VA when check_pa_matches_va().


Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
