### PR TITLE
Add NVMEM improvements and fixes

### DIFF
--- a/core/arch/arm/dts/sama5d2.dtsi
+++ b/core/arch/arm/dts/sama5d2.dtsi
@@ -746,25 +746,24 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
-				sfc_kr: cell@0 {
-					reg = <0x0 0x4>;
-					bits = <0 7>;
+				sfc_dr0: cell@20 {
+					reg = <0x20 0x20>;
 				};
 
-				sfc_dr0: cell@20 {
-					reg = <0x20 0x4>;
+				sfc_dr1: cell@24 {
+					reg = <0x24 0x20>;
 				};
 			};
 
 			die_id: die_id {
 				compatible = "optee,nvmem-die-id";
-				nvmem-cells = <&sfc_kr>;
+				nvmem-cells = <&sfc_dr0>;
 				nvmem-cell-names = "die_id";
 			};
 
 			huk: huk {
 				compatible = "optee,nvmem-huk";
-				nvmem-cells = <&sfc_dr0>;
+				nvmem-cells = <&sfc_dr1>;
 				nvmem-cell-names = "hw_unique_key";
 			};
 

--- a/core/drivers/nvmem/atmel_sfc.c
+++ b/core/drivers/nvmem/atmel_sfc.c
@@ -32,6 +32,9 @@ static TEE_Result atmel_sfc_read_cell(struct nvmem_cell *cell, uint8_t *data)
 {
 	struct atmel_sfc *atmel_sfc = cell->drv_data;
 
+	if (cell->offset + cell->len > ATMEL_SFC_CELLS_8)
+		return TEE_ERROR_GENERIC;
+
 	memcpy(data, &atmel_sfc->fuses[cell->offset], cell->len);
 
 	return TEE_SUCCESS;

--- a/core/drivers/nvmem/nvmem_die_id.c
+++ b/core/drivers/nvmem/nvmem_die_id.c
@@ -41,8 +41,10 @@ static TEE_Result nvmem_die_id_probe(const void *fdt, int node,
 		return res;
 
 	res = nvmem_cell_malloc_and_read(cell, &data);
-	if (!res)
+	if (!res) {
 		die_id = data;
+		die_id_len = cell->len;
+	}
 
 	nvmem_put_cell(cell);
 

--- a/core/drivers/nvmem/nvmem_huk.c
+++ b/core/drivers/nvmem/nvmem_huk.c
@@ -8,45 +8,55 @@
 #include <kernel/dt.h>
 #include <kernel/huk_subkey.h>
 #include <kernel/tee_common_otp.h>
+#include <libfdt.h>
 #include <malloc.h>
 #include <tee_api_defines.h>
 #include <tee_api_types.h>
+#include <trace.h>
 #include <types_ext.h>
 
-static struct nvmem_cell *huk_cell;
+static uint8_t *huk;
 
 TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
-	TEE_Result res = TEE_ERROR_GENERIC;
-	uint8_t *huk = NULL;
-	size_t len = 0;
-
-	res = nvmem_cell_malloc_and_read(huk_cell, &huk);
-	if (res)
-		goto out_free_cell;
-
-	if (len != HW_UNIQUE_KEY_LENGTH) {
-		res = TEE_ERROR_GENERIC;
-		goto out_free_cell;
+	if (!huk) {
+		EMSG("no HUK");
+		return TEE_ERROR_GENERIC;
 	}
 
 	memcpy(hwkey->data, huk, HW_UNIQUE_KEY_LENGTH);
 
-out_free_cell:
-	nvmem_put_cell(huk_cell);
-
-	return res;
-}
-
-static TEE_Result nvmem_huk_get_cell(const void *fdt, int node)
-{
-	return nvmem_get_cell_by_name(fdt, node, "hw_unique_key", &huk_cell);
+	return TEE_SUCCESS;
 }
 
 static TEE_Result nvmem_huk_probe(const void *fdt, int node,
 				  const void *compat_data __unused)
 {
-	return nvmem_huk_get_cell(fdt, node);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct nvmem_cell *cell = NULL;
+	uint8_t *data = NULL;
+
+	res = nvmem_get_cell_by_name(fdt, node, "hw_unique_key", &cell);
+	if (res)
+		return res;
+
+	if (cell->len < HW_UNIQUE_KEY_LENGTH) {
+		EMSG("cell %s is too small", fdt_get_name(fdt, node, NULL));
+		nvmem_put_cell(cell);
+		return TEE_ERROR_GENERIC;
+	}
+
+	if (cell->len > HW_UNIQUE_KEY_LENGTH)
+		IMSG("nvmem_huk: HUK truncated from %zu to %u bytes",
+		     cell->len, HW_UNIQUE_KEY_LENGTH);
+
+	res = nvmem_cell_malloc_and_read(cell, &data);
+	if (!res)
+		huk = data;
+
+	nvmem_put_cell(cell);
+
+	return res;
 }
 
 static const struct dt_device_match nvmem_huk_match_table[] = {


### PR DESCRIPTION
- Fix the length of the HUK and die-id NVMEM cell.
- Allow the use of a larger NVMEM cell for the HUK.
- Redefine HUK and die id cells in sama5d2.dtsi.
- Fix the regression test 4013.