### PR TITLE
libutils: qsort helper for standard types

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -389,14 +389,6 @@ static TEE_Result pmic_set_voltage(struct regulator *regulator, int level_uv)
 	return TEE_SUCCESS;
 }
 
-static int cmp_int_value(const void *a, const void *b)
-{
-	const int *ia = a;
-	const int *ib = b;
-
-	return CMP_TRILEAN(*ia, *ib);
-}
-
 static size_t refine_levels_array(size_t count, int *levels_uv,
 				  int min_uv, int max_uv)
 {
@@ -404,7 +396,7 @@ static size_t refine_levels_array(size_t count, int *levels_uv,
 	size_t m = 0;
 
 	/* We need to sort the array has STPMIC1 driver does not */
-	qsort(levels_uv, count, sizeof(*levels_uv), cmp_int_value);
+	qsort_int(levels_uv, count);
 
 	/* Remove duplicates and return optimized count */
 	for (n = 1; n < count; n++) {

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -8,6 +8,10 @@
 #include <compiler.h>
 #include <inttypes.h>
 
+#ifndef __ASSEMBLER__
+#include <stddef.h>
+#endif
+
 #define SIZE_4K	UINTPTR_C(0x1000)
 #define SIZE_1M	UINTPTR_C(0x100000)
 #define SIZE_2M	UINTPTR_C(0x200000)
@@ -204,6 +208,22 @@ static inline uint64_t set_field_u64(uint64_t reg, uint64_t mask, uint64_t val)
 {
 	return (reg & ~mask) | (val * (mask & ~(mask - 1)));
 }
+
+/* Helper function for qsort with standard types */
+void qsort_int(int *aa, size_t n);
+void qsort_uint(unsigned int *aa, size_t n);
+void qsort_long(long int *aa, size_t n);
+void qsort_ul(unsigned long int *aa, size_t n);
+void qsort_ll(long long int *aa, size_t n);
+void qsort_ull(unsigned long long int *aa, size_t n);
+void qsort_s8(int8_t *aa, size_t n);
+void qsort_u8(uint8_t *aa, size_t n);
+void qsort_s16(int16_t *aa, size_t n);
+void qsort_u16(uint16_t *aa, size_t n);
+void qsort_s32(int32_t *aa, size_t n);
+void qsort_u32(uint32_t *aa, size_t n);
+void qsort_s64(int64_t *aa, size_t n);
+void qsort_u64(uint64_t *aa, size_t n);
 #endif
 
 #endif /*UTIL_H*/

--- a/lib/libutils/ext/qsort_helpers.c
+++ b/lib/libutils/ext/qsort_helpers.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024, STMicroelectronics
+ */
+
+#include <stdlib.h>
+#include <util.h>
+
+#define QSORT_HELPER(name, type)				\
+static int cmp_ ## name(const void *a, const void *b)		\
+{								\
+	const type *ia = a;					\
+	const type *ib = b;					\
+								\
+	return CMP_TRILEAN(*ia, *ib);				\
+}								\
+								\
+void qsort_ ## name(type *aa, size_t n)				\
+{								\
+	qsort(aa, n, sizeof(*aa), cmp_ ## name);		\
+}
+
+QSORT_HELPER(int, int);
+QSORT_HELPER(uint, unsigned int);
+QSORT_HELPER(long, long int);
+QSORT_HELPER(ul, unsigned long int);
+QSORT_HELPER(ll, long long int);
+QSORT_HELPER(ull, unsigned long long int);
+QSORT_HELPER(s8, int8_t);
+QSORT_HELPER(u8, uint8_t);
+QSORT_HELPER(s16, int16_t);
+QSORT_HELPER(u16, uint16_t);
+QSORT_HELPER(s32, int32_t);
+QSORT_HELPER(u32, uint32_t);
+QSORT_HELPER(s64, int64_t);
+QSORT_HELPER(u64, uint64_t);

--- a/lib/libutils/ext/sub.mk
+++ b/lib/libutils/ext/sub.mk
@@ -9,6 +9,7 @@ srcs-y += nex_strdup.c
 srcs-y += consttime_memcmp.c
 srcs-y += memzero_explicit.c
 srcs-y += fault_mitigation.c
+srcs-y += qsort_helpers.c
 
 ifneq (,$(filter ta_%,$(sm)))
 srcs-y += pthread_stubs.c


### PR DESCRIPTION
Add `qsort_int()`, `qsort_uint()`, `qsort_u32()` and friends as `qsort()` helper functions to sort standard typed arrays.

I needed to use `qsort()` in few separated source files and needed to redefine locally the `cmp_xxx()` callback so I think it's worth having some generic helper functions.