### PR TITLE
Required changes for PACBTI enablement in Trusted Services

### DIFF
--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -1400,6 +1400,22 @@ static TEE_Result handle_hw_features(void *fdt)
 			return res;
 	}
 
+	/* Modify the property only if it's already present */
+	if (!sp_dt_get_u32(fdt, node, "bti", &val)) {
+		res = fdt_setprop_u32(fdt, node, "bti",
+				      feat_bti_is_implemented());
+		if (res)
+			return res;
+	}
+
+	/* Modify the property only if it's already present */
+	if (!sp_dt_get_u32(fdt, node, "pauth", &val)) {
+		res = fdt_setprop_u32(fdt, node, "pauth",
+				      feat_pauth_is_implemented());
+		if (res)
+			return res;
+	}
+
 	return TEE_SUCCESS;
 }
 

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -215,6 +215,10 @@ static TEE_Result sp_create_ctx(const TEE_UUID *bin_uuid, struct sp_session *s)
 
 	set_sp_ctx_ops(&spc->ts_ctx);
 
+#ifdef CFG_TA_PAUTH
+	crypto_rng_read(&spc->uctx.keys, sizeof(spc->uctx.keys));
+#endif
+
 	return TEE_SUCCESS;
 
 err:
@@ -1583,6 +1587,10 @@ TEE_Result sp_enter(struct thread_smc_args *args, struct sp_session *sp)
 	ctx->sp_regs.x[5] = args->a5;
 	ctx->sp_regs.x[6] = args->a6;
 	ctx->sp_regs.x[7] = args->a7;
+#ifdef CFG_TA_PAUTH
+	ctx->sp_regs.apiakey_hi = ctx->uctx.keys.apia_hi;
+	ctx->sp_regs.apiakey_lo = ctx->uctx.keys.apia_lo;
+#endif
 
 	res = sp->ts_sess.ctx->ops->enter_invoke_cmd(&sp->ts_sess, 0);
 

--- a/core/arch/arm/kernel/secure_partition.c
+++ b/core/arch/arm/kernel/secure_partition.c
@@ -37,6 +37,7 @@
 #define SP_MANIFEST_ATTR_WRITE		BIT(1)
 #define SP_MANIFEST_ATTR_EXEC		BIT(2)
 #define SP_MANIFEST_ATTR_NSEC		BIT(3)
+#define SP_MANIFEST_ATTR_GP		BIT(4)
 
 #define SP_MANIFEST_ATTR_RO		(SP_MANIFEST_ATTR_READ)
 #define SP_MANIFEST_ATTR_RW		(SP_MANIFEST_ATTR_READ | \
@@ -880,6 +881,15 @@ static TEE_Result handle_fdt_load_relative_mem_regions(struct sp_ctx *ctx,
 			return TEE_ERROR_BAD_FORMAT;
 		}
 
+		if (IS_ENABLED(CFG_TA_BTI) &&
+		    attributes & SP_MANIFEST_ATTR_GP) {
+			if (!(attributes & SP_MANIFEST_ATTR_RX)) {
+				EMSG("Guard only executable region");
+				return TEE_ERROR_BAD_FORMAT;
+			}
+			perm |= TEE_MATTR_GUARDED;
+		}
+
 		res = sp_dt_get_u32(fdt, subnode, "load-flags", &flags);
 		if (res != TEE_SUCCESS && res != TEE_ERROR_ITEM_NOT_FOUND) {
 			EMSG("Optional field with invalid value: flags");
@@ -1207,6 +1217,15 @@ static TEE_Result handle_fdt_mem_regions(struct sp_ctx *ctx, void *fdt)
 		default:
 			EMSG("Invalid memory access permissions");
 			return TEE_ERROR_BAD_FORMAT;
+		}
+
+		if (IS_ENABLED(CFG_TA_BTI) &&
+		    attributes & SP_MANIFEST_ATTR_GP) {
+			if (!(attributes & SP_MANIFEST_ATTR_RX)) {
+				EMSG("Guard only executable region");
+				return TEE_ERROR_BAD_FORMAT;
+			}
+			perm |= TEE_MATTR_GUARDED;
 		}
 
 		/*

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -1008,10 +1008,18 @@ static struct thread_pauth_keys *thread_get_pauth_keys(void)
 {
 #if defined(CFG_TA_PAUTH)
 	struct ts_session *s = ts_get_current_session();
-	/* Only user TA's support the PAUTH keys */
-	struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
 
-	return &utc->uctx.keys;
+	if  (is_user_ta_ctx(s->ctx)) {
+		struct user_ta_ctx *utc = to_user_ta_ctx(s->ctx);
+
+		return &utc->uctx.keys;
+	} else if (is_sp_ctx(s->ctx)) {
+		struct sp_ctx *spc = to_sp_ctx(s->ctx);
+
+		return &spc->uctx.keys;
+	}
+
+	panic("[abort] Only user TAs and SPs support PAUTH keys");
 #else
 	return NULL;
 #endif


### PR DESCRIPTION
- Enable BTI for binary SP-s via manifest (and provide info to the SP whether BTI/PAC are enabled by the OS)
- Enable PAC for SP-s (similar way as it is implemented for TA-s)
- Enable PAC before SP initialization and se atomic pauth keys at init, so the used keys will not change between the first SEL1->SEL0->SEL1 transition resulting in error