### PR TITLE
core: firewall: add dedicated firewall configuration APIs

### DIFF
--- a/core/drivers/firewall/firewall.c
+++ b/core/drivers/firewall/firewall.c
@@ -90,16 +90,6 @@ TEE_Result firewall_set_configuration(struct firewall_query *fw)
 	return fw->ctrl->ops->set_conf(fw);
 }
 
-TEE_Result firewall_check_access(struct firewall_query *fw)
-{
-	assert(fw && fw->ctrl && fw->ctrl->ops);
-
-	if (!fw->ctrl->ops->check_access)
-		return TEE_ERROR_NOT_SUPPORTED;
-
-	return fw->ctrl->ops->check_access(fw);
-}
-
 TEE_Result firewall_acquire_access(struct firewall_query *fw)
 {
 	assert(fw && fw->ctrl && fw->ctrl->ops);
@@ -108,18 +98,6 @@ TEE_Result firewall_acquire_access(struct firewall_query *fw)
 		return TEE_ERROR_NOT_SUPPORTED;
 
 	return fw->ctrl->ops->acquire_access(fw);
-}
-
-TEE_Result firewall_check_memory_access(struct firewall_query *fw,
-					paddr_t paddr, size_t size, bool read,
-					bool write)
-{
-	assert(fw && fw->ctrl && fw->ctrl->ops);
-
-	if (!fw->ctrl->ops->check_memory_access)
-		return TEE_ERROR_NOT_SUPPORTED;
-
-	return fw->ctrl->ops->check_memory_access(fw, paddr, size, read, write);
 }
 
 TEE_Result firewall_acquire_memory_access(struct firewall_query *fw,

--- a/core/include/drivers/firewall.h
+++ b/core/include/drivers/firewall.h
@@ -35,14 +35,10 @@ struct firewall_controller {
  * struct firewall_controller_ops - Firewall controller operation handlers
  *
  * @set_conf: Callback used to set given firewall configuration
- * @check_access: Callback used to check access for a consumer on a resource
- * against a firewall controller
  * @acquire_access: Callback used to acquire access for OP-TEE on a resource
  * against a firewall controller
  * @release_access: Callback used to release resources taken by a consumer when
  * the access was acquired with @acquire_access
- * @check_memory_access: Callback used to check access for a consumer to a
- * memory range covered by a firewall controller, for read and/or write accesses
  * @acquire_memory_access: Callback used to acquire access for OP-TEE to a
  * memory range covered by a firewall controller, for read and/or write accesses
  * @release_memory_access: Callback used to release resources taken by a
@@ -50,12 +46,8 @@ struct firewall_controller {
  */
 struct firewall_controller_ops {
 	TEE_Result (*set_conf)(struct firewall_query *conf);
-	TEE_Result (*check_access)(struct firewall_query *conf);
 	TEE_Result (*acquire_access)(struct firewall_query *conf);
 	void (*release_access)(struct firewall_query *conf);
-	TEE_Result (*check_memory_access)(struct firewall_query *fw,
-					  paddr_t paddr, size_t size,
-					  bool read, bool write);
 	TEE_Result (*acquire_memory_access)(struct firewall_query *fw,
 					    paddr_t paddr, size_t size,
 					    bool read, bool write);

--- a/core/include/drivers/firewall.h
+++ b/core/include/drivers/firewall.h
@@ -34,11 +34,13 @@ struct firewall_controller {
 /**
  * struct firewall_controller_ops - Firewall controller operation handlers
  *
- * @set_conf: Callback used to set given firewall configuration
+ * @set_conf: Callback used to set given firewall configuration from a query
  * @acquire_access: Callback used to acquire access for OP-TEE on a resource
  * against a firewall controller
  * @release_access: Callback used to release resources taken by a consumer when
  * the access was acquired with @acquire_access
+ * @set_memory_conf: Callback used to set given firewall configuration for a
+ * memory range covered by a firewall controller from a query
  * @acquire_memory_access: Callback used to acquire access for OP-TEE to a
  * memory range covered by a firewall controller, for read and/or write accesses
  * @release_memory_access: Callback used to release resources taken by a
@@ -48,6 +50,8 @@ struct firewall_controller_ops {
 	TEE_Result (*set_conf)(struct firewall_query *conf);
 	TEE_Result (*acquire_access)(struct firewall_query *conf);
 	void (*release_access)(struct firewall_query *conf);
+	TEE_Result (*set_memory_conf)(struct firewall_query *fw, paddr_t paddr,
+				      size_t size);
 	TEE_Result (*acquire_memory_access)(struct firewall_query *fw,
 					    paddr_t paddr, size_t size,
 					    bool read, bool write);

--- a/core/include/drivers/firewall_device.h
+++ b/core/include/drivers/firewall_device.h
@@ -72,16 +72,6 @@ TEE_Result firewall_dt_get_by_name(const void *fdt, int node, const char *name,
 TEE_Result firewall_set_configuration(struct firewall_query *fw);
 
 /**
- * firewall_check_access() - Check if the access is authorized for a consumer
- * and the given firewall configuration according to the settings of its
- * firewall controller
- *
- * @fw:	Firewall query containing the configuration to check against its
- * firewall controller
- */
-TEE_Result firewall_check_access(struct firewall_query *fw);
-
-/**
  * firewall_acquire_access() - Check if OP-TEE can access the consumer and
  * acquire potential resources to allow the access
  *
@@ -89,22 +79,6 @@ TEE_Result firewall_check_access(struct firewall_query *fw);
  * firewall controller
  */
 TEE_Result firewall_acquire_access(struct firewall_query *fw);
-
-/**
- * firewall_check_memory_access() - Check if a consumer can access the memory
- * address range, in read and/or write mode and given the firewall
- * configuration, against a firewall controller
- *
- * @fw: Firewall query containing the configuration to check against its
- * firewall controller
- * @paddr: Physical base address of the memory range to check
- * @size: Size of the memory range to check
- * @read: If true, check rights for a read access
- * @write: If true, check rights for a write access
- */
-TEE_Result firewall_check_memory_access(struct firewall_query *fw,
-					paddr_t paddr, size_t size, bool read,
-					bool write);
 
 /**
  * firewall_acquire_memory_access() - Request OP-TEE access, in read and/or
@@ -170,21 +144,7 @@ firewall_dt_get_by_name(const void *fdt __unused, int node __unused,
 }
 
 static inline TEE_Result
-firewall_check_access(struct firewall_query *fw __unused)
-{
-	return TEE_ERROR_NOT_IMPLEMENTED;
-}
-
-static inline TEE_Result
 firewall_acquire_access(struct firewall_query *fw __unused)
-{
-	return TEE_ERROR_NOT_IMPLEMENTED;
-}
-
-static inline TEE_Result
-firewall_check_memory_access(struct firewall_query *fw __unused,
-			     paddr_t paddr __unused, size_t size __unused,
-			     bool read __unused, bool write __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -197,6 +197,27 @@ TEE_Result dt_driver_device_from_node_idx_prop_phandle(const char *prop_name,
 						       void *device_ref);
 
 /*
+ * dt_driver_count_devices() - Get the number of elements of a given type
+ * referring to a provider in a property.
+ *
+ * @prop_name: DT property name, e.g. "clocks" for clock resources
+ * @fdt: FDT base address
+ * @nodeoffs: Node offset in the FDT
+ * @type: Driver type
+ * @nb_element: Output number of elements referenced by the property
+
+ * Return code:
+ * TEE_SUCCESS in case of success.
+ * TEE_ERROR_ITEM_NOT_FOUND if @prop_name does not match a property name
+ * TEE_ERROR_DEFER_DRIVER_INIT if at least one of the provider driver
+ * referenced in the property is not yet initialized.
+ * Any TEE_Result compliant code in case of error.
+ */
+TEE_Result dt_driver_count_devices(const char *prop_name, const void *fdt,
+				   int nodeoffs, enum dt_driver_type type,
+				   size_t *nb_element);
+
+/*
  * dt_driver_get_crypto() - Request crypto support for driver initialization
  *
  * Return TEE_SUCCESS if cryptography services are initialized, otherwise return


### PR DESCRIPTION
Add dedicated firewall device APIs for handling firewall configurations from the device tree. Firewall configurations are inseparable sets of one or more firewall queries.
These APIs are based on the ".*(?<=)-access-conf$" property. This property will be proposed in the Linux kernel.

While there, remove the check for foreign entities API as it seems unlikely it'll be used.

Edit: Link to kernel patch: https://lkml.org/lkml/2024/7/16/849