### PR TITLE
drivers: scmi-msg: correct voltage domain protocol version & clock rates enumeration

### DIFF
--- a/core/drivers/scmi-msg/clock.c
+++ b/core/drivers/scmi-msg/clock.c
@@ -321,7 +321,7 @@ static void scmi_clock_describe_rates(struct scmi_msg *msg)
 		}
 
 		out_count = rate_index - in_args->rate_index;
-		remaining = nb_rates - in_args->rate_index;
+		remaining = nb_rates - rate_index;
 		p2a.num_rates_flags = SCMI_RATES_BY_ARRAY(out_count, remaining);
 	} else if (status == SCMI_NOT_SUPPORTED) {
 		unsigned long triplet[3] = { 0, 0, 0 };

--- a/core/drivers/scmi-msg/voltage_domain.h
+++ b/core/drivers/scmi-msg/voltage_domain.h
@@ -12,7 +12,7 @@
 
 #include "common.h"
 
-#define SCMI_PROTOCOL_VERSION_VOLTAGE_DOMAIN	0x30000
+#define SCMI_PROTOCOL_VERSION_VOLTAGE_DOMAIN	0x20000
 
 /*
  * Identifiers of the SCMI Clock Management Protocol commands


### PR DESCRIPTION
Fix the version ID of the implemented SCMI voltage domain protocol that is v2.0 (ID 0x20000), not v3.0 (ID 0x30000).
(Fixes: 006d89b8f49f ("drivers: scmi-msg: add SCMI Voltage Domain protocol"))

Fix value of remaining clocks to describe on SCMI clock protocol message CLOCK_DESCRIBE_RATES that does not take into account the number of returned clock in the response.
(Fixes: 90252e2a52c7 ("drivers: scmi-msg: clock adapts to output buffer size"))


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
