### PR TITLE
drivers: clk: clk_get_rates_array() returns ordered rates

### DIFF
--- a/core/drivers/clk/sam/at91_cpu_opp.c
+++ b/core/drivers/clk/sam/at91_cpu_opp.c
@@ -118,6 +118,10 @@ static TEE_Result opp_rates_setup(const void *fdt, int node)
 
 		rate_num++;
 	}
+
+	/* Ensure rates are in ascending order */
+	qsort_ul(opp_rates->rates, rate_num);
+
 	opp_rates->rate_num = rate_num;
 
 	return TEE_SUCCESS;

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -68,7 +68,7 @@ struct clk_duty_cycle {
  * @get_parent: Get the current parent index of the clock
  * @set_rate: Set the clock rate
  * @get_rate: Get the clock rate
- * @get_rates_array: Get the supported clock rates as array
+ * @get_rates_array: Get the supported clock rates as array in ascending order
  * @get_rates_steps: Get support clock rates by min/max/step representation
  * @get_duty_cycle: Get duty cytcle of the clock
  *
@@ -212,7 +212,7 @@ struct clk *clk_get_parent_by_index(struct clk *clk, size_t pidx);
 TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
 
 /**
- * clk_get_rates_array() - Get supported rates as an array
+ * clk_get_rates_array() - Get supported rates in ascending order
  *
  * @clk: Clock for which the rates are requested
  * @start_index: start index of requested rates


### PR DESCRIPTION
Explicitly state in clk_get_rates_array() inline description comment that the output rates arrays is ordered by increasing frequency values. This change allows to better fit the sole consumer of this API function that is the SCMI server implementation. SCMI specification states that discrete clock rates list shall follow this order.

Update at91_cpu_opp clock driver to ensure it satisfy this constraint. The SAM platforms that embed this driver (sama7g5) already satisfy this constraints but only at its DTS level. This change ensures the driver will always.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
