### PR TITLE
RK3566 port

### DIFF
--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -74,6 +74,29 @@ CFG_EARLY_CONSOLE_BAUDRATE ?= 1500000
 CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
 endif
 
+ifeq ($(PLATFORM_FLAVOR),rk3566)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+arm32-platform-cpuarch  := cortex-a55
+
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+# cortex-a55 sopports GICv3 or GICv4. There is no support for GICv4 in OP-TEE,
+# so use GICv3:
+$(call force,CFG_ARM_GICV3,y)
+
+CFG_TZDRAM_START ?= 0x08400000
+CFG_TZDRAM_SIZE  ?= 0x02000000
+CFG_SHMEM_START  ?= 0x0A400000
+CFG_SHMEM_SIZE   ?= 0x00400000
+
+CFG_EARLY_CONSOLE ?= y
+CFG_EARLY_CONSOLE_BASE ?= UART2_BASE
+CFG_EARLY_CONSOLE_SIZE ?= UART2_SIZE
+CFG_EARLY_CONSOLE_BAUDRATE ?= 1500000
+CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
+
+CFG_WITH_ARM_TRUSTED_FW ?= y
+endif
+
 ifeq ($(platform-flavor-armv8),1)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)

--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -31,7 +31,11 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
 
 void boot_primary_init_intc(void)
 {
+	#ifdef PLATFORM_FLAVOR_rk3566
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
+	#else
 	gic_init(GICC_BASE, GICD_BASE);
+	#endif
 }
 
 void boot_secondary_init_intc(void)

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -67,6 +67,34 @@
 #define SGRF_BASE		(MMIO_BASE + 0x07330000)
 #define SGRF_SIZE		SIZE_K(64)
 
+#elif defined(PLATFORM_FLAVOR_rk3566)
+
+/* This information is from Technical Reference Manual for RK3568, which is said
+ * to be very close in configuration to RK3566. RTM for RK3566 has net been
+ * found. */
+
+#define MMIO_BASE		0xF0000000
+
+#define UART0_BASE		(MMIO_BASE + 0x0DD50000)
+#define UART0_SIZE		SIZE_K(64)
+
+#define UART1_BASE		(MMIO_BASE + 0x0E650000)
+#define UART1_SIZE		SIZE_K(64)
+
+#define UART2_BASE		(MMIO_BASE + 0x0E660000)
+#define UART2_SIZE		SIZE_K(64)
+
+#define UART3_BASE		(MMIO_BASE + 0x0E670000)
+#define UART3_SIZE		SIZE_K(64)
+
+#define SGRF_BASE		(MMIO_BASE + 0x0DC60000)
+#define SGRF_SIZE		SIZE_K(64)
+
+#define GIC_BASE		(MMIO_BASE + 0x0d400000)
+#define GIC_SIZE		SIZE_M(4)
+#define GICD_BASE		(GIC_BASE)
+#define GICR_BASE		(GIC_BASE + 0x60000)
+
 #elif defined(PLATFORM_FLAVOR_px30)
 
 #define GIC_BASE		0xff130000

--- a/core/arch/arm/plat-rockchip/platform_rk3566.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3566.c
@@ -1,0 +1,44 @@
+#include <common.h>
+#include <io.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <platform.h>
+#include <platform_config.h>
+
+#define SGRF_DDRRGN_CON0_16(n)		((n) * 4)
+#define SGRF_DDR_RGN_0_16_WMSK		GENMASK_32(11, 0)
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SGRF_BASE, SGRF_SIZE);
+
+int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
+{
+	vaddr_t sgrf_base = (vaddr_t)phys_to_virt_io(SGRF_BASE, SGRF_SIZE);
+	paddr_t ed = st + sz;
+	uint32_t st_mb = st / SIZE_M(1);
+	uint32_t ed_mb = ed / SIZE_M(1);
+
+	if (!sgrf_base)
+		panic();
+
+	assert(rgn <= 7);
+	assert(st < ed);
+
+	/* Check aligned 1MB */
+	assert(st % SIZE_M(1) == 0);
+	assert(ed % SIZE_M(1) == 0);
+
+	DMSG("protecting region %d: 0x%lx-0x%lx", rgn, st, ed);
+
+	/* Set ddr region addr start */
+	io_write32(sgrf_base + SGRF_DDRRGN_CON0_16(rgn),
+		   BITS_WITH_WMASK(st_mb, SGRF_DDR_RGN_0_16_WMSK, 0));
+
+	/* Set ddr region addr end */
+	io_write32(sgrf_base + SGRF_DDRRGN_CON0_16(rgn + 8),
+		   BITS_WITH_WMASK((ed_mb - 1), SGRF_DDR_RGN_0_16_WMSK, 0));
+
+	io_write32(sgrf_base + SGRF_DDRRGN_CON0_16(16),
+		   BIT_WITH_WMSK(rgn));
+
+	return 0;
+}

--- a/core/arch/arm/plat-rockchip/sub.mk
+++ b/core/arch/arm/plat-rockchip/sub.mk
@@ -5,6 +5,7 @@ srcs-$(PLATFORM_FLAVOR_px30) += platform_px30.c
 srcs-$(PLATFORM_FLAVOR_rk322x) += platform_rk322x.c
 srcs-$(PLATFORM_FLAVOR_rk3399) += platform_rk3399.c
 srcs-$(PLATFORM_FLAVOR_rk3588) += platform_rk3588.c
+srcs-$(PLATFORM_FLAVOR_rk3566) += platform_rk3566.c
 
 ifeq ($(PLATFORM_FLAVOR),rk322x)
 srcs-y += plat_init.S

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -2542,10 +2542,19 @@ void *phys_to_virt(paddr_t pa, enum teecore_memtypes m, size_t len)
 		va = NULL;
 		break;
 	default:
+		if ( m == MEM_AREA_IO_SEC )
+			IMSG("Getting virtual address for physical address %lx", pa);
 		va = map_pa2va(find_map_by_type_and_pa(m, pa, len), pa, len);
+		if ( m ==  MEM_AREA_IO_SEC)
+			IMSG("The virtual address is %lx", pa);
 	}
-	if (m != MEM_AREA_SEC_RAM_OVERALL)
+	if (m != MEM_AREA_SEC_RAM_OVERALL){
+		if ( m == MEM_AREA_IO_SEC )
+			IMSG("Checking virtual address...");
 		check_va_matches_pa(pa, va);
+	}
+	if ( m == MEM_AREA_IO_SEC )
+		IMSG("Returning virtual address...");
 	return va;
 }
 
@@ -2566,9 +2575,12 @@ void *phys_to_virt_io(paddr_t pa, size_t len)
 
 vaddr_t core_mmu_get_va(paddr_t pa, enum teecore_memtypes type, size_t len)
 {
-	if (cpu_mmu_enabled())
+	if (cpu_mmu_enabled()){
+		IMSG("MMU is enabled, returning virtal address...");
 		return (vaddr_t)phys_to_virt(pa, type, len);
+	}
 
+	IMSG("MMU is not enbaled, returning real address");
 	return (vaddr_t)pa;
 }
 


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

This port is a part of integration of safety features into [Zarhus project](https://github.com/zarhus), the main effort can be found in the following PR: https://github.com/zarhus/meta-zarhus-bsp-rockchip/pull/5, so the precise hardware and software configuration being used can be checked there. Though the project uses Yocto Project as a build environment, all the test binaries are built manually using several tools, so the configuration and changes in the PR may not be up to date.

---

Brief description of test environment.

Hardware:
* Radxa CM3 SoM based on RK3566 SoC;
* Radxa CM3 IO extention board.

Software:

I think this image explains software stack in the best way:

![Rockchip_bootflow20181122](https://github.com/user-attachments/assets/8a61dc40-328f-4c67-b899-1865ddee3a42)

> Source: [`opensource.rock-chips.com`](https://opensource.rock-chips.com/wiki_Boot_option#Boot_introduce).

**The red** boot flow is being used for tests.

This is my first interaction with OPTEE and Trust Zone stuff, so I will be grateful for any help here!