### PR TITLE
plat-stm32mp1: fix use after free in PMIC driver

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -542,8 +542,10 @@ static TEE_Result release_voltage_lists(void)
 	for (n = 0; n < ARRAY_SIZE(pmic_regulators); n++) {
 		struct pmic_regulator_data *priv = pmic_regulators[n].priv;
 
-		if (priv && priv->voltages_level)
+		if (priv && priv->voltages_level) {
 			free(priv->voltages_level);
+			priv->voltages_level = NULL;
+		}
 	}
 
 	return TEE_SUCCESS;


### PR DESCRIPTION
Fix PMIC regulator levels arrays handling that missed a pointer reset after the buffer is freed. At runtime, pmic_list_voltages() handler function uses that reference and is expected to allocate back the buffer in case non-secure world requests voltage enumeration for the related regulator.

Fixes: a7990eb02b82 ("plat-stm32mp1: set voltage list at pmic driver init")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
