### PR TITLE
core: riscv: core_mmu_arch: fix PPN field extraction from PTE

### DIFF
--- a/core/arch/riscv/include/encoding.h
+++ b/core/arch/riscv/include/encoding.h
@@ -291,6 +291,7 @@
 #define PTE_A     0x040 /* Accessed */
 #define PTE_D     0x080 /* Dirty */
 #define PTE_SOFT  0x300 /* Reserved for Software */
+#define PTE_PPN   0x003FFFFFFFFFFC00 /* PPN */
 #define PTE_RSVD  0x1FC0000000000000 /* Reserved for future standard use */
 #define PTE_PBMT  0x6000000000000000 /* Svpbmt: Page-based memory types */
 #define PTE_N     0x8000000000000000 /* Svnapot: NAPOT translation contiguity */

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -135,7 +135,7 @@ static unsigned long core_mmu_ptp_create(unsigned long ppn)
 
 static unsigned long core_mmu_pte_ppn(struct mmu_pte *pte)
 {
-	return pte->entry >> PTE_PPN_SHIFT;
+	return (pte->entry & PTE_PPN) >> PTE_PPN_SHIFT;
 }
 
 static unsigned long pa_to_ppn(paddr_t pa)


### PR DESCRIPTION

The upper bits of page table entry may contain other fields such as PBMT and N bits, thus PPN field should be masked out with PTE_PPN.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
