### PR TITLE
Add type of suspend operation

### DIFF
--- a/core/drivers/pm/sam/at91_pm.c
+++ b/core/drivers/pm/sam/at91_pm.c
@@ -280,6 +280,21 @@ static TEE_Result at91_write_backup_data(void)
 	return TEE_SUCCESS;
 }
 
+static void at91_pm_change_state(enum pm_op op)
+{
+	int type = 0;
+	uint32_t hint = 0;
+
+	if (soc_pm.mode == AT91_PM_STANDBY)
+		type = PM_SUSPEND_STANDBY;
+	else
+		type = PM_SUSPEND_TO_MEM;
+
+	hint = SHIFT_U32(type, PM_HINT_SUSPEND_TYPE_SHIFT);
+
+	pm_change_state(op, hint);
+}
+
 static TEE_Result at91_enter_backup(void)
 {
 	int ret = -1;
@@ -289,7 +304,7 @@ static TEE_Result at91_enter_backup(void)
 	if (res)
 		return res;
 
-	pm_change_state(PM_OP_SUSPEND, 0);
+	at91_pm_change_state(PM_OP_SUSPEND);
 	ret = sm_pm_cpu_suspend((uint32_t)&soc_pm,
 				(void *)at91_suspend_sram_fn);
 	if (ret < 0) {
@@ -299,7 +314,7 @@ static TEE_Result at91_enter_backup(void)
 		res = TEE_SUCCESS;
 	}
 
-	pm_change_state(PM_OP_RESUME, 0);
+	at91_pm_change_state(PM_OP_RESUME);
 	if (res)
 		return res;
 

--- a/core/include/kernel/pm.h
+++ b/core/include/kernel/pm.h
@@ -20,6 +20,7 @@
  * PM_HINT_POWER_STATE - When set device power shall be suspended/restored
  * PM_HINT_IO_STATE - When set IO pins shall be suspended/restored
  * PM_HINT_CONTEXT_STATE - When set the full context be suspended/restored
+ * PM_HINT_SUSPEND_TYPE - Contains the type of suspend operation
  * PM_HINT_PLATFORM_STATE_MASK - Bit mask reserved for platform specific hints
  * PM_HINT_PLATFORM_STATE_SHIFT - LSBit position of platform specific hints mask
  */
@@ -27,8 +28,18 @@
 #define PM_HINT_POWER_STATE		BIT(1)
 #define PM_HINT_IO_STATE		BIT(2)
 #define PM_HINT_CONTEXT_STATE		BIT(3)
+#define PM_HINT_SUSPEND_TYPE_MASK       GENMASK_32(5, 4)
+#define PM_HINT_SUSPEND_TYPE_SHIFT      U(4)
 #define PM_HINT_PLATFORM_STATE_MASK	GENMASK_32(31, 16)
 #define PM_HINT_PLATFORM_STATE_SHIFT	U(16)
+
+enum pm_suspend_type {
+	PM_SUSPEND_STANDBY,
+	PM_SUSPEND_TO_MEM,
+};
+
+#define PM_HINT_SUSPEND_TYPE(__hint) \
+	(((__hint) & PM_HINT_SUSPEND_TYPE_MASK) >> PM_HINT_SUSPEND_TYPE_SHIFT)
 
 #define PM_HINT_STATE(_x)		((_x) & ~PM_HINT_PLATFORM_STATE_MASK)
 #define PM_HINT_PLATFORM_STATE(_x) \


### PR DESCRIPTION
The suspend level is platform dependent and can be set to various values depending on these platforms. In order to
allow platforms setting it in a generic way when entering suspend, reserve some bits in the suspend/resume hint to pass this information.

Also update sama5d2 platforms suspend mode to enter different levels of low power mode according to the suspend/resume hint to pass this information.
