### PR TITLE
ci: upgrade actions/cache@v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     container: jforissier/optee_os_ci
     steps:
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
           key: builds-cache-${{ github.sha }}
@@ -281,7 +281,7 @@ jobs:
       - name: Remove /__t/*
         run: rm -rf /__t/*
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
           key: qemuv7_check-cache-${{ github.sha }}
@@ -317,7 +317,7 @@ jobs:
       - name: Remove /__t/*
         run: rm -rf /__t/*
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
           key: qemuv8_check-cache-${{ github.sha }}
@@ -360,7 +360,7 @@ jobs:
       - name: Remove /__t/*
         run: rm -rf /__t/*
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
           key: qemuv8_xen_check-cache-${{ github.sha }}
@@ -396,7 +396,7 @@ jobs:
       - name: Remove /__t/*
         run: rm -rf /__t/*
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
           key: qemuv8_xen_ffa_check-cache-${{ github.sha }}
@@ -432,7 +432,7 @@ jobs:
       - name: Remove /__t/*
         run: rm -rf /__t/*
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
           key: qemuv8_hafnium_check-cache-${{ github.sha }}
@@ -468,7 +468,7 @@ jobs:
       - name: Remove /__t/*
         run: rm -rf /__t/*
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /github/home/.cache/ccache
           key: qemuv8_check_bti_mte_pac-cache-${{ github.sha }}


### PR DESCRIPTION
Upgrade the "cache" action to address the CI warning:

"""
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/cache@v3. For more info: [1] """

Link: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
