### PR TITLE
Remove build time paths from version.o, use CFLAGS from build environment

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -151,7 +151,7 @@ define update-buildcount
 endef
 
 # filter-out to workaround objdump warning
-version-o-cflags = $(filter-out -g3,$(core-platform-cflags) \
+version-o-cflags = $(filter-out -g3,$(CFLAGS) $(core-platform-cflags) \
 			$(platform-cflags) $(cflagscore))
 # SOURCE_DATE_EPOCH defined for reproducible builds
 ifneq ($(SOURCE_DATE_EPOCH),)

--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -163,14 +163,15 @@ CORE_CC_VERSION = `$(CCcore) -v 2>&1 | grep "version " | sed 's/ *$$//'`
 define gen-version-o
 	$(call update-buildcount,$(link-out-dir)/.buildcount)
 	@$(cmd-echo-silent) '  GEN     $(link-out-dir)/version.o'
-	$(q)echo -e "const char core_v_str[] =" \
+	$(q)cd $(link-out-dir) && \
+		echo -e "const char core_v_str[] =" \
 		"\"$(TEE_IMPL_VERSION) \"" \
 		"\"($(CORE_CC_VERSION)) \"" \
 		"\"#$(BUILD_COUNT_STR) \"" \
 		"\"$(DATE_STR) \"" \
 		"\"$(CFG_KERN_LINKER_ARCH)\";\n" \
 		| $(CCcore) $(version-o-cflags) \
-			-xc - -c -o $(link-out-dir)/version.o
+			-xc - -c -o version.o
 endef
 $(link-out-dir)/version.o:
 	$(call gen-version-o)

--- a/core/arch/riscv/kernel/link.mk
+++ b/core/arch/riscv/kernel/link.mk
@@ -74,14 +74,15 @@ CORE_CC_VERSION = `$(CCcore) -v 2>&1 | grep "version " | sed 's/ *$$//'`
 define gen-version-o
 	$(call update-buildcount,$(link-out-dir)/.buildcount)
 	@$(cmd-echo-silent) '  GEN     $(link-out-dir)/version.o'
-	$(q)echo -e "const char core_v_str[] =" \
+	$(q)cd $(link-out-dir) && \
+		echo -e "const char core_v_str[] =" \
 		"\"$(TEE_IMPL_VERSION) \"" \
 		"\"($(CORE_CC_VERSION)) \"" \
 		"\"#$(BUILD_COUNT_STR) \"" \
 		"\"$(DATE_STR) \"" \
 		"\"$(CFG_KERN_LINKER_ARCH)\";\n" \
 		| $(CCcore) $(version-o-cflags) \
-			-xc - -c -o $(link-out-dir)/version.o
+			-xc - -c -o version.o
 endef
 
 $(link-out-dir)/version.o:

--- a/core/arch/riscv/kernel/link.mk
+++ b/core/arch/riscv/kernel/link.mk
@@ -62,7 +62,7 @@ define update-buildcount
 endef
 
 # filter-out to workaround objdump warning
-version-o-cflags = $(filter-out -g3,$(core-platform-cflags) \
+version-o-cflags = $(filter-out -g3,$(CFLAGS) $(core-platform-cflags) \
 			$(platform-cflags) $(cflagscore))
 # SOURCE_DATE_EPOCH defined for reproducible builds
 ifneq ($(SOURCE_DATE_EPOCH),)

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -80,7 +80,8 @@ comp-compiler-$2 := $$(CC$(sm))
 comp-flags-$2 = $$(filter-out $$(CFLAGS_REMOVE) $$(cflags-remove) \
 			      $$(cflags-remove-$$(comp-sm-$2)) \
 			      $$(cflags-remove-$2), \
-		   $$(CFLAGS$$(arch-bits-$$(comp-sm-$2))) $$(CFLAGS_WARNS) \
+		   $$(CFLAGS$$(arch-bits-$$(comp-sm-$2))) $$(CFLAGS) \
+		   $$(CFLAGS_WARNS) \
 		   $$(comp-cflags$$(comp-sm-$2)) $$(cflags$$(comp-sm-$2)) \
 		   $$(cflags-lib$$(comp-lib-$2)) $$(cflags-$2))
 ifeq ($C,1)


### PR DESCRIPTION
Default debug flag -g3 was already getting removed from version-o-cflags but on corstone1000 platform-cflags-debug-info is set to -gdwarf-2 and thus debug info was included in the generated version.o. This then included full absolute build time path which breaks "buildpaths" yocto QA check since the path is also in final tee.elf binary. Remove all debug flags from version-o-cflags as a fix/workaround.

Fixes yocto build reproducibility issues on corstone1000:

https://gitlab.com/jonmason00/meta-arm/-/jobs/7472950196

Cc: Jon Mason <jon.mason@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
