### PR TITLE
core: rstctrl: Fix function description

### DIFF
--- a/core/include/drivers/rstctrl.h
+++ b/core/include/drivers/rstctrl.h
@@ -203,14 +203,14 @@ TEE_Result rstctrl_dt_get_by_name(const void *fdt, int nodeoffset,
  * devicetree properties
  *
  * @args: Pointer to devicetree description of the reset controller to parse
- * @data: Pointer to data given at rstctrl_dt_register_provider() call
+ * @data: Pointer to data given at rstctrl_register_provider() call
  * @rstctrl: Output reset controller reference upon success
  */
 typedef TEE_Result (*rstctrl_dt_get_func)(struct dt_pargs *args, void *data,
 					  struct rstctrl **out_rstctrl);
 
 /**
- * rstctrl_dt_register_provider - Register a reset controller provider
+ * rstctrl_register_provider - Register a reset controller provider
  *
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the reset controller


### PR DESCRIPTION
Fix the description of functions rstctrl_dt_get_func() and rstctrl_register_provider().

minor error in fucntion description as the fucntion rstctrl_dt_register_provider() don't exist
=> the correct name of the fucntion is "rstctrl_register_provider()"

Change-Id: Ic0eb7b83125b6c50153e597d83522967ac616159

