### PR TITLE
RISC-V: Implement foreign interrupt handler

### DIFF
--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -8,9 +8,21 @@
 
 #ifndef __ASSEMBLER__
 #include <compiler.h>
-#include <riscv.h>
 #include <types_ext.h>
 #endif
+
+#include <platform_config.h>
+#include <riscv.h>
+
+/*
+ * Each RISC-V platform must define their own values.
+ * See core/arch/riscv/plat-virt/platform_config.h for example.
+ */
+#define THREAD_EXCP_FOREIGN_INTR	PLAT_THREAD_EXCP_FOREIGN_INTR
+#define THREAD_EXCP_NATIVE_INTR		PLAT_THREAD_EXCP_NATIVE_INTR
+
+#define THREAD_EXCP_ALL			(THREAD_EXCP_FOREIGN_INTR |\
+					 THREAD_EXCP_NATIVE_INTR)
 
 #ifndef __ASSEMBLER__
 
@@ -153,20 +165,6 @@ struct thread_ctx_regs {
 };
 
 struct user_mode_ctx;
-
-/*
- * These flags should vary according to the privilege mode selected
- * to run OP-TEE core on (M/HS/S). For now default to S-Mode.
- */
-
-#define CSR_XIE_SIE	BIT64(IRQ_XSOFT)
-#define CSR_XIE_TIE	BIT64(IRQ_XTIMER)
-#define CSR_XIE_EIE	BIT64(IRQ_XEXT)
-
-#define THREAD_EXCP_FOREIGN_INTR	CSR_XIE_EIE
-#define THREAD_EXCP_NATIVE_INTR	        (CSR_XIE_SIE | CSR_XIE_TIE)
-#define THREAD_EXCP_ALL			(THREAD_EXCP_FOREIGN_INTR |\
-					 THREAD_EXCP_NATIVE_INTR)
 
 #ifdef CFG_WITH_VFP
 uint32_t thread_kernel_enable_vfp(void);

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -60,8 +60,8 @@ struct thread_user_mode_rec {
 
 extern long thread_user_kcode_offset;
 
-void thread_interrupt_handler(unsigned long cause,
-			      struct thread_ctx_regs *regs);
+void thread_native_interrupt_handler(struct thread_ctx_regs *regs,
+				     unsigned long cause);
 /*
  * Initializes TVEC for current hart. Called by thread_init_per_cpu()
  */

--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -62,6 +62,8 @@ extern long thread_user_kcode_offset;
 
 void thread_native_interrupt_handler(struct thread_ctx_regs *regs,
 				     unsigned long cause);
+void thread_foreign_interrupt_handler(struct thread_ctx_regs *regs);
+
 /*
  * Initializes TVEC for current hart. Called by thread_init_per_cpu()
  */

--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -69,6 +69,8 @@
 #define CSR_XSTATUS_SUM		BIT(18)
 #define CSR_XSTATUS_MXR		BIT(19)
 
+#define CSR_XCAUSE_INTR_FLAG	BIT64(__riscv_xlen - 1)
+
 #ifndef __ASSEMBLER__
 
 #define read_csr(csr)							\

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -109,8 +109,8 @@ static void setup_unwind_user_mode(struct thread_scall_regs *regs)
 	regs->sp = (uintptr_t)(regs + 1);
 }
 
-static void thread_unhandled_trap(unsigned long cause __unused,
-				  struct thread_ctx_regs *regs __unused)
+static void thread_unhandled_trap(struct thread_ctx_regs *regs __unused,
+				  unsigned long cause __unused)
 {
 	DMSG("Unhandled trap xepc:0x%016lx xcause:0x%016lx xtval:0x%016lx",
 	     read_csr(CSR_XEPC), read_csr(CSR_XCAUSE), read_csr(CSR_XTVAL));
@@ -148,20 +148,21 @@ static void thread_irq_handler(void)
 	interrupt_main_handler();
 }
 
-void thread_interrupt_handler(unsigned long cause, struct thread_ctx_regs *regs)
+void thread_native_interrupt_handler(struct thread_ctx_regs *regs,
+				     unsigned long cause)
 {
 	switch (cause & LONG_MAX) {
 	case IRQ_XTIMER:
 		clear_csr(CSR_XIE, CSR_XIE_TIE);
 		break;
 	case IRQ_XSOFT:
-		thread_unhandled_trap(cause, regs);
+		thread_unhandled_trap(regs, cause);
 		break;
 	case IRQ_XEXT:
 		thread_irq_handler();
 		break;
 	default:
-		thread_unhandled_trap(cause, regs);
+		thread_unhandled_trap(regs, cause);
 	}
 }
 

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -88,12 +88,11 @@ interrupt_from_kernel:
 	store_xregs sp, THREAD_CTX_REG_EPC, REG_T0
 
 	/*
-	 * a0 = cause
-	 * a1 = sp
-	 * Call thread_interrupt_handler(cause, regs)
+	 * a0 = struct thread_ctx_regs *regs
+	 * a1 = cause
 	 */
-	csrr	a0, CSR_XCAUSE
-	mv	a1, sp
+	mv	a0, sp
+	csrr	a1, CSR_XCAUSE
 	/* Load tmp_stack_va_end as current sp. */
 	load_xregs tp, THREAD_CORE_LOCAL_TMP_STACK_VA_END, REG_SP
 	call	thread_interrupt_handler
@@ -283,12 +282,11 @@ interrupt_from_user:
 	store_xregs sp, THREAD_CTX_REG_EPC, REG_T0
 
 	/*
-	 * a0 = cause
-	 * a1 = sp
-	 * Call thread_interrupt_handler(cause, regs)
+	 * a0 = struct thread_ctx_regs *regs
+	 * a1 = cause
 	 */
-	csrr	a0, CSR_XCAUSE
-	mv	a1, sp
+	mv	a0, sp
+	csrr	a1, CSR_XCAUSE
 	/* Load tmp_stack_va_end as current sp. */
 	load_xregs tp, THREAD_CORE_LOCAL_TMP_STACK_VA_END, REG_SP
 	call	thread_interrupt_handler

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -12,6 +12,9 @@
 #include <mm/core_mmu.h>
 #include <riscv.h>
 #include <riscv_macros.S>
+#include <tee/optee_abi.h>
+#include <tee/teeabi_opteed.h>
+#include <tee/teeabi_opteed_macros.h>
 
 .macro get_thread_ctx res, tmp0
 	lw	\tmp0, THREAD_CORE_LOCAL_CURR_THREAD(tp)
@@ -675,3 +678,40 @@ FUNC thread_resume , :
 
 	XRET
 END_FUNC thread_resume
+
+/* void thread_foreign_interrupt_handler(struct thread_ctx_regs *regs) */
+FUNC thread_foreign_interrupt_handler , :
+	/* Update 32-bit core local flags */
+	lw	s1, THREAD_CORE_LOCAL_FLAGS(tp)
+	slli	s1, s1, THREAD_CLF_SAVED_SHIFT
+	ori	s1, s1, (THREAD_CLF_TMP | THREAD_CLF_FIQ)
+	sw	s1, THREAD_CORE_LOCAL_FLAGS(tp)
+
+	/*
+	 * Mark current thread as suspended.
+	 * a0 = THREAD_FLAGS_EXIT_ON_FOREIGN_INTR
+	 * a1 = status
+	 * a2 = epc
+	 * thread_state_suspend(flags, status, pc)
+	 */
+	LDR	a1, THREAD_CTX_REG_STATUS(a0)
+	LDR	a2, THREAD_CTX_REG_EPC(a0)
+	li	a0, THREAD_FLAGS_EXIT_ON_FOREIGN_INTR
+	call	thread_state_suspend
+	/* Now return value a0 contains suspended thread ID. */
+
+	/* Update core local flags */
+	lw	s1, THREAD_CORE_LOCAL_FLAGS(tp)
+	srli	s1, s1, THREAD_CLF_SAVED_SHIFT
+	ori	s1, s1, THREAD_CLF_TMP
+	sw	s1, THREAD_CORE_LOCAL_FLAGS(tp)
+
+	/* Passing thread index in a0, and return to untrusted domain. */
+	mv	a4, a0
+	li	a0, TEEABI_OPTEED_RETURN_CALL_DONE
+	li	a1, OPTEE_ABI_RETURN_RPC_FOREIGN_INTR
+	li	a2, 0
+	li	a3, 0
+	li	a5, 0
+	j	thread_return_to_udomain
+END_FUNC thread_foreign_interrupt_handler

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -125,12 +125,23 @@ foreign_interrupt_from_kernel:
 	tail	thread_foreign_interrupt_handler
 
 native_interrupt_from_kernel:
+	/* Update 32-bit core local flags */
+	lw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
+	slli	a2, a2, THREAD_CLF_SAVED_SHIFT
+	ori	a2, a2, (THREAD_CLF_TMP | THREAD_CLF_IRQ)
+	sw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
+
 	/*
 	 * a0 = struct thread_ctx_regs *regs
 	 * a1 = cause
 	 * Call thread_native_interrupt_handler(regs, cause)
 	 */
 	call	thread_native_interrupt_handler
+
+	/* Update 32-bit core local flags */
+	lw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
+	srli	a2, a2, THREAD_CLF_SAVED_SHIFT
+	sw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
 
 	/* Get thread context as sp */
 	get_thread_ctx sp, t0
@@ -351,12 +362,23 @@ foreign_interrupt_from_user:
 	tail	thread_foreign_interrupt_handler
 
 native_interrupt_from_user:
+	/* Update 32-bit core local flags */
+	lw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
+	slli	a2, a2, THREAD_CLF_SAVED_SHIFT
+	ori	a2, a2, (THREAD_CLF_TMP | THREAD_CLF_IRQ)
+	sw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
+
 	/*
 	 * a0 = struct thread_ctx_regs *regs
 	 * a1 = cause
 	 * Call thread_native_interrupt_handler(regs, cause)
 	 */
 	call	thread_native_interrupt_handler
+
+	/* Update 32-bit core local flags */
+	lw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
+	srli	a2, a2, THREAD_CLF_SAVED_SHIFT
+	sw	a2, THREAD_CORE_LOCAL_FLAGS(tp)
 
 	/* Get thread context as sp */
 	get_thread_ctx sp, t0

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -98,7 +98,39 @@ interrupt_from_kernel:
 	csrr	a1, CSR_XCAUSE
 	/* Load tmp_stack_va_end as current sp. */
 	load_xregs tp, THREAD_CORE_LOCAL_TMP_STACK_VA_END, REG_SP
-	call	thread_interrupt_handler
+
+	/*
+	 * Get interrupt code from XCAUSE and build XIP. For example, if the
+	 * value of XCAUSE is 0x8000000000000005 (supervisor timer interrupt),
+	 * we build 0x20, which is (1 << 5) and indicates the sip.STIP signal.
+	 */
+	li	a2, CSR_XCAUSE_INTR_FLAG
+	sub	a2, a1, a2
+	li	a3, 1
+	sll	a3, a3, a2
+	/*
+	 * Compare built XIP with THREAD_EXCP_FOREIGN_INTR. If XIP is one of
+	 * THREAD_EXCP_FOREIGN_INTR, we call thread_foreign_interrupt_handler().
+	 */
+	li	a2, THREAD_EXCP_FOREIGN_INTR
+	and	a2, a3, a2
+	beqz	a2, native_interrupt_from_kernel
+
+foreign_interrupt_from_kernel:
+	/*
+	 * a0 = struct thread_ctx_regs *regs
+	 * Tail call thread_foreign_interrupt_handler(regs) since we will not
+	 * return to here.
+	 */
+	tail	thread_foreign_interrupt_handler
+
+native_interrupt_from_kernel:
+	/*
+	 * a0 = struct thread_ctx_regs *regs
+	 * a1 = cause
+	 * Call thread_native_interrupt_handler(regs, cause)
+	 */
+	call	thread_native_interrupt_handler
 
 	/* Get thread context as sp */
 	get_thread_ctx sp, t0
@@ -292,7 +324,39 @@ interrupt_from_user:
 	csrr	a1, CSR_XCAUSE
 	/* Load tmp_stack_va_end as current sp. */
 	load_xregs tp, THREAD_CORE_LOCAL_TMP_STACK_VA_END, REG_SP
-	call	thread_interrupt_handler
+
+	/*
+	 * Get interrupt code from XCAUSE and build XIP. For example, if the
+	 * value of XCAUSE is 0x8000000000000005 (supervisor timer interrupt),
+	 * we build 0x20, which is (1 << 5) and indicates the sip.STIP signal.
+	 */
+	li	a2, CSR_XCAUSE_INTR_FLAG
+	sub	a2, a1, a2
+	li	a3, 1
+	sll	a3, a3, a2
+	/*
+	 * Compare built XIP with THREAD_EXCP_FOREIGN_INTR. If XIP is one of
+	 * THREAD_EXCP_FOREIGN_INTR, call thread_foreign_interrupt_handler().
+	 */
+	li	a2, THREAD_EXCP_FOREIGN_INTR
+	and	a2, a3, a2
+	beqz	a2, native_interrupt_from_user
+
+foreign_interrupt_from_user:
+	/*
+	 * a0 = struct thread_ctx_regs *regs
+	 * Tail call thread_foreign_interrupt_handler(regs) since we will not
+	 * return to here.
+	 */
+	tail	thread_foreign_interrupt_handler
+
+native_interrupt_from_user:
+	/*
+	 * a0 = struct thread_ctx_regs *regs
+	 * a1 = cause
+	 * Call thread_native_interrupt_handler(regs, cause)
+	 */
+	call	thread_native_interrupt_handler
 
 	/* Get thread context as sp */
 	get_thread_ctx sp, t0

--- a/core/arch/riscv/plat-spike/platform_config.h
+++ b/core/arch/riscv/plat-spike/platform_config.h
@@ -9,6 +9,7 @@
 #define PLATFORM_CONFIG_H
 
 #include <mm/generic_ram_layout.h>
+#include <riscv.h>
 
 #ifndef HTIF_BASE
 #define HTIF_BASE	0x40008000
@@ -18,5 +19,8 @@
 #ifndef CLINT_BASE
 #define CLINT_BASE	0x02000000
 #endif
+
+#define PLAT_THREAD_EXCP_FOREIGN_INTR	(CSR_XIE_EIE)
+#define PLAT_THREAD_EXCP_NATIVE_INTR	(CSR_XIE_SIE | CSR_XIE_TIE)
 
 #endif

--- a/core/arch/riscv/plat-virt/platform_config.h
+++ b/core/arch/riscv/plat-virt/platform_config.h
@@ -9,6 +9,7 @@
 #define PLATFORM_CONFIG_H
 
 #include <mm/generic_ram_layout.h>
+#include <riscv.h>
 
 /* The stack pointer is always kept 16-byte aligned */
 #define STACK_ALIGNMENT		16
@@ -91,5 +92,9 @@
 #else
 #define RISCV_MTIME_RATE 1000000
 #endif
+
+#define PLAT_THREAD_EXCP_FOREIGN_INTR	\
+	(CSR_XIE_EIE | CSR_XIE_TIE | CSR_XIE_SIE)
+#define PLAT_THREAD_EXCP_NATIVE_INTR	(0)
 
 #endif /*PLATFORM_CONFIG_H*/


### PR DESCRIPTION
Foreign interrupts are interrupts that assert during OP-TEE execution, but are not owned and handled by OP-TEE.
For example, in SMP system, if an Linux side interrupt assert during TA execution, OP-TEE can suspend current TA and yield the execution to Linux to handle that interrupt.
This PR implements such foreign interrupt handler for RISC-V architecture.

To determine whether the incoming interrupt is foreign interrupt or not, we leverage `THREAD_EXCP_FOREIGN_INTR`, which aliases bits of `mip` or `sip`.
The type of incoming taken interrupt can be determined by value of `XCAUSE` CSR.
First, we translate `XCAUSE` to corresponding `mip` or `sip` bit.
Then we compare it with `THREAD_EXCP_FOREIGN_INTR` to determine whether the incoming interrupt is foreign interrupt or not.
If yes, we call `thread_foreign_interrupt_handler()` to suspend current thread and return to udomain.

Besides, we let each platform choose their own type of foreign interrupts.
By default, only external interrupt are regarded as foreign interrupt.
For RISC-V virt machine, all external/timer/software interrupts are regarded as foreign interrupts.