### PR TITLE
Secure interrupt handling in S-EL0 SPs

### DIFF
--- a/core/arch/arm/include/arm64_macros.S
+++ b/core/arch/arm/include/arm64_macros.S
@@ -181,3 +181,10 @@
 	/* msr pan, #0 */
 	msr	S0_0_c4_c0_4, xzr
 	.endm
+
+	.macro return_from_exception
+		eret
+		/* Guard against speculation past ERET */
+		dsb nsh
+		isb
+	.endm

--- a/core/arch/arm/include/kernel/spmc_sp_handler.h
+++ b/core/arch/arm/include/kernel/spmc_sp_handler.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2021, Arm Limited.
+ * Copyright (c) 2021-2024, Arm Limited.
  */
 #ifndef __KERNEL_SPMC_SP_HANDLER_H
 #define __KERNEL_SPMC_SP_HANDLER_H
@@ -15,6 +15,8 @@
 #define FFA_SRC(x)	(((x) >> 16) & UINT16_MAX)
 
 void spmc_sp_thread_entry(uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3);
+void spmc_sp_interrupt_handler_entry(struct thread_smc_args *args,
+				     uint64_t *lr_sp);
 void spmc_sp_msg_handler(struct thread_smc_args *args,
 			 struct sp_session *caller_sp);
 bool ffa_mem_reclaim(struct thread_smc_args *args,

--- a/core/arch/arm/include/kernel/thread_private_arch.h
+++ b/core/arch/arm/include/kernel/thread_private_arch.h
@@ -130,6 +130,8 @@ uint32_t __thread_std_smc_entry(uint32_t a0, uint32_t a1, uint32_t a2,
 				uint32_t a3, uint32_t a4, uint32_t a5);
 
 void thread_sp_alloc_and_run(struct thread_smc_args *args);
+void thread_sp_alloc_and_run_interrupt_handler(struct thread_smc_args *args,
+					       uint64_t *lr_sp);
 
 /*
  * Resumes execution of currently active thread by restoring context and

--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2016-2022, Linaro Limited
  * Copyright (c) 2014, STMicroelectronics International N.V.
- * Copyright (c) 2020-2021, Arm Limited
+ * Copyright (c) 2020-2024, Arm Limited
  */
 
 #include <platform_config.h>
@@ -276,6 +276,14 @@ void thread_sp_alloc_and_run(struct thread_smc_args *args __maybe_unused)
 	__thread_alloc_and_run(args->a0, args->a1, args->a2, args->a3, args->a4,
 			       args->a5, args->a6, args->a7,
 			       spmc_sp_thread_entry, THREAD_FLAGS_FFA_ONLY);
+}
+
+void thread_sp_alloc_and_run_interrupt_handler(struct thread_smc_args *args,
+					       uint64_t *lr_sp)
+{
+	__thread_alloc_and_run((uintptr_t)args, (uintptr_t)lr_sp, 0, 0, 0, 0, 0,
+			       0, spmc_sp_interrupt_handler_entry,
+			       THREAD_FLAGS_FFA_ONLY);
 }
 #endif
 

--- a/core/arch/arm/kernel/thread_a64.S
+++ b/core/arch/arm/kernel/thread_a64.S
@@ -22,13 +22,6 @@
 		madd	x\res, x\tmp0, x\tmp1, x\res
 	.endm
 
-	.macro return_from_exception
-		eret
-		/* Guard against speculation past ERET */
-		dsb nsh
-		isb
-	.endm
-
 	.macro b_if_spsr_is_el0 reg, label
 		tbnz	\reg, #(SPSR_MODE_RW_32 << SPSR_MODE_RW_SHIFT), \label
 		tst	\reg, #(SPSR_64_MODE_EL_MASK << SPSR_64_MODE_EL_SHIFT)
@@ -1312,8 +1305,12 @@ END_FUNC el0_sync_abort
 	/* Restore x0..x1 */
 	load_xregs sp, THREAD_CORE_LOCAL_X0, 0, 1
 
+#if defined(CFG_SECURE_PARTITION)
+	b thread_return_to_sp_interrupt_handler
+#else /* CFG_SECURE_PARTITION */
 	/* Return from exception */
 	return_from_exception
+#endif /* CFG_SECURE_PARTITION */
 1:	b	eret_to_el0
 .endm
 

--- a/core/arch/arm/kernel/thread_spmc_a64.S
+++ b/core/arch/arm/kernel/thread_spmc_a64.S
@@ -120,6 +120,110 @@ FUNC spmc_sp_thread_entry , :
 	mov     w7, w27
 	b .ffa_msg_loop
 END_FUNC spmc_sp_thread_entry
+
+FUNC thread_return_to_sp_interrupt_handler , :
+	/* Save interrupt ELR as LR */
+	mrs	lr, elr_el1
+
+	/* Push X0 */
+	str	x0, [sp, #8]
+
+	/* Set ELR_EL1 to point to thread_native_intr_sp_handler */
+	adr_l	x0, thread_sp_interrupt_handler_starter
+	msr	elr_el1, x0
+
+	/* Pop X0 */
+	ldr	x0, [sp, #8]
+
+	return_from_exception
+
+thread_sp_interrupt_handler_starter:
+	/* Disable native interrupts */
+	msr	daifset, #DAIFBIT_NATIVE_INTR
+
+	/* Store original FF-A call arguments */
+	sub	sp, sp, #THREAD_SMC_ARGS_SIZE
+	store_xregs sp, THREAD_SMC_ARGS_X0, 0, 7
+
+	/* Store original ELR_EL1 and SP to thread stack */
+	add x0, sp, #THREAD_SMC_ARGS_SIZE
+	sub	sp, sp, #16
+	stp lr, x0, [sp]
+
+	/* Set function arguments */
+	add	x0, sp, #16
+	mov x1, sp
+
+	b thread_sp_alloc_and_run_interrupt_handler
+END_FUNC thread_return_to_sp_interrupt_handler
+
+/**
+ * void spmc_sp_interrupt_handler_entry(struct thread_smc_args *args,
+ * 					uint64_t *lr_sp)
+ */
+FUNC spmc_sp_interrupt_handler_entry , :
+	/* Copy interrupted call parameters to thread stack */
+	sub	sp, sp, #THREAD_SMC_ARGS_SIZE
+	load_xregs x0, THREAD_SMC_ARGS_X0, 20, 27
+	store_xregs sp, THREAD_SMC_ARGS_X0, 20, 27
+
+	/* Copy interrupted LR and SP to thread_stack */
+	sub	sp, sp, #16
+	ldp	x0, x1, [x1]
+	stp	x0, x1, [sp]
+
+	/* Create FFA_INTERRUPT request parameters */
+	mov_imm	x0, FFA_INTERRUPT
+	mov	x1, xzr
+	mov	x2, xzr
+	mov	x3, xzr
+	mov	x4, xzr
+	mov	x5, xzr
+	mov	x6, xzr
+	mov	x7, xzr
+
+	/* Store the parameters as struct thread_smc_args on stack */
+	sub	sp, sp, #THREAD_SMC_ARGS_SIZE
+	store_xregs sp, THREAD_SMC_ARGS_X0, 0, 7
+	mov	x0, sp
+	mov	x1, #0 /* Pass NULL pointer for caller_sp */
+	bl	spmc_sp_msg_handler
+
+	/* Discard call parameters */
+	add	sp, sp, #THREAD_SMC_ARGS_SIZE
+
+	/* Mask all maskable exceptions before switching to temporary stack */
+	msr     daifset, #DAIFBIT_ALL
+
+	/* Restore original LR and SP */
+	ldp	x0, x1, [sp]
+	add	sp, sp, #16
+
+	/* Restore interrupted call parameters to X20-X27 */
+	load_xregs sp, THREAD_SMC_ARGS_X0, 20, 27
+	add	sp, sp, #THREAD_SMC_ARGS_SIZE
+
+	mov	sp, x1
+	sub	sp, sp, #16
+	str	x0, [sp]
+
+	bl	thread_state_free
+
+	ldr	lr, [sp]
+	add	sp, sp, #16
+
+	/* Restore the FF-A arguments before the SMC instruction. */
+	mov	x0, x20
+	mov	x1, x21
+	mov	x2, x22
+	mov	x3, x23
+	mov	x4, x24
+	mov	x5, x25
+	mov	x6, x26
+	mov	x7, x27
+
+	ret
+END_FUNC spmc_sp_interrupt_handler_entry
 #endif
 
 /* void thread_rpc_spsr(uint32_t rv[THREAD_RPC_NUM_ARGS], uint64_t spsr) */


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
The FF-A spec allows secure partitions to receive interrupts. This PR enables the SPMC to configure interrupts based on the SP manifest and forward them to the SPs.

When an interrupt is triggered which targets the secure world, the SPMD will catch it in EL3 and then it sends an FFA_INTERRUPT message to the SPMC. In OP-TEE we continue running in `ffa_msg_loop` disable native interrupts in the [first instruction](https://github.com/OP-TEE/optee_os/blob/master/core/arch/arm/kernel/thread_spmc_a64.S#L57). However the active secure interrupt will trigger an exception just before this instruction. OP-TEE handles this exception and clears the interrupt flag and returns from the exception. After this, point the FFA_INTERRUPT message is handled normally, in `thread_spmc_msg_recv`.

The difficult part of this feature is that the SP has to handle the interrupt and clear the peripheral interrupt flag, before we clear the interrupt flag in the interrupt controller (i.e. in the GIC) from OP-TEE. After approaching the problem from several different directions I ended up with this solution, where the native interrupt handler is diverted before exiting from the interrupt context to the point where the SPs can handle the interrupt.

Related patches:

- [optee_test](https://github.com/OP-TEE/optee_test/pull/753)
- [Trusted Service](https://review.trustedfirmware.org/c/TS/trusted-services/+/26669)