### PR TITLE
core: arm32: update core local flags in  native_intr_handler

### DIFF
--- a/core/arch/arm/kernel/thread_a32.S
+++ b/core/arch/arm/kernel/thread_a32.S
@@ -467,8 +467,42 @@ END_FUNC thread_unwind_user_mode
 	push	{r0-r3, r12, lr}
 	.endif
 
+	/*
+	 * Use SP_abt to update core local flags.
+	 * flags = (flags << THREAD_CLF_SAVED_SHIFT) | THREAD_CLF_TMP |
+	 *         THREAD_CLF_{FIQ|IRQ};
+	 */
+	cps     #CPSR_MODE_ABT
+	ldr     r1, [sp, #THREAD_CORE_LOCAL_FLAGS]
+	lsl     r1, r1, #THREAD_CLF_SAVED_SHIFT
+	.ifc    \mode\(),fiq
+	orr     r1, r1, #(THREAD_CLF_TMP | THREAD_CLF_FIQ)
+	.else
+	orr     r1, r1, #(THREAD_CLF_TMP | THREAD_CLF_IRQ)
+	.endif
+	str     r1, [sp, #THREAD_CORE_LOCAL_FLAGS]
+	.ifc    \mode\(),fiq
+	cps     #CPSR_MODE_FIQ
+	.else
+	cps     #CPSR_MODE_IRQ
+	.endif
+
 	bl	thread_check_canaries
 	bl	interrupt_main_handler
+
+	/*
+	 * Use SP_abt to update core local flags.
+	 * flags >>= THREAD_CLF_SAVED_SHIFT;
+	 */
+	cps     #CPSR_MODE_ABT
+	ldr     r1, [sp, #THREAD_CORE_LOCAL_FLAGS]
+	lsr     r1, r1, #THREAD_CLF_SAVED_SHIFT
+	str     r1, [sp, #THREAD_CORE_LOCAL_FLAGS]
+	.ifc    \mode\(),fiq
+	cps     #CPSR_MODE_FIQ
+	.else
+	cps     #CPSR_MODE_IRQ
+	.endif
 
 	mrs	r0, spsr
 	cmp_spsr_user_mode r0


### PR DESCRIPTION
The AArch32 version of the native_intr_handler() macro has until now called C function without updating the core local flags to indicate that the temporary stack is in use. The can lead to errors with CFG_CORE_DEBUG_CHECK_STACKS=y so fix this by setting THREAD_CLF_TMP and THREAD_CLF_FIQ or THREAD_CLF_IRQ as needed.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
