### PR TITLE
core: riscv: Simplify SP setup in setup_unwind_user_mode()

### DIFF
--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -100,7 +100,13 @@ static void setup_unwind_user_mode(struct thread_scall_regs *regs)
 {
 	regs->ra = (uintptr_t)thread_unwind_user_mode;
 	regs->status = xstatus_for_xret(true, PRV_S);
-	regs->sp = thread_get_saved_thread_sp();
+	/*
+	 * We are going to exit user mode. The stack pointer must be set as the
+	 * original value it had before allocating space of scall "regs" and
+	 * calling thread_scall_handler(). Thus, we can simply set stack pointer
+	 * as (regs + 1) value.
+	 */
+	regs->sp = (uintptr_t)(regs + 1);
 }
 
 static void thread_unhandled_trap(unsigned long cause __unused,


### PR DESCRIPTION
The parameter "regs" is the stack pointer which is allocated to store system call registers when calling thread_scall_handler().
Thus, we can simply get the original stack pointer by "regs + 1" equation, and use when exiting user mode.

The code is referenced from ARM's [setup_unwind_user_mode()](https://github.com/OP-TEE/optee_os/blob/9cb4152f1b0c297b964bdb7bd84b49615afd73fb/core/arch/arm/kernel/thread.c#L1099).