### PR TITLE
core: mbedtls: Fix build

### DIFF
--- a/lib/libmbedtls/core/hash.c
+++ b/lib/libmbedtls/core/hash.c
@@ -202,11 +202,6 @@ TEE_Result hash_sha256_check(const uint8_t *hash, const uint8_t *data,
 int mbedtls_internal_sha1_process(mbedtls_sha1_context *ctx,
 				  const unsigned char data[64])
 {
-	MBEDTLS_INTERNAL_VALIDATE_RET(ctx != NULL,
-				      MBEDTLS_ERR_SHA1_BAD_INPUT_DATA);
-	MBEDTLS_INTERNAL_VALIDATE_RET((const unsigned char *)data != NULL,
-				      MBEDTLS_ERR_SHA1_BAD_INPUT_DATA);
-
 	crypto_accel_sha1_compress(ctx->state, data, 1);
 
 	return 0;
@@ -217,11 +212,6 @@ int mbedtls_internal_sha1_process(mbedtls_sha1_context *ctx,
 int mbedtls_internal_sha256_process(mbedtls_sha256_context *ctx,
 				    const unsigned char data[64])
 {
-	MBEDTLS_INTERNAL_VALIDATE_RET(ctx != NULL,
-				      MBEDTLS_ERR_SHA256_BAD_INPUT_DATA);
-	MBEDTLS_INTERNAL_VALIDATE_RET((const unsigned char *)data != NULL,
-				      MBEDTLS_ERR_SHA256_BAD_INPUT_DATA);
-
 	crypto_accel_sha256_compress(ctx->state, data, 1);
 
 	return 0;
@@ -232,11 +222,6 @@ int mbedtls_internal_sha256_process(mbedtls_sha256_context *ctx,
 int mbedtls_internal_sha512_process(mbedtls_sha512_context *ctx,
 				    const unsigned char data[64])
 {
-	MBEDTLS_INTERNAL_VALIDATE_RET(ctx != NULL,
-				      MBEDTLS_ERR_SHA512_BAD_INPUT_DATA);
-	MBEDTLS_INTERNAL_VALIDATE_RET((const unsigned char *)data != NULL,
-				      MBEDTLS_ERR_SHA512_BAD_INPUT_DATA);
-
 	crypto_accel_sha512_compress(ctx->state, data, 1);
 
 	return 0;


### PR DESCRIPTION
The macro 'MBEDTLS_INTERNAL_VALIDATE_RET()' was removed in upstream commit https://github.com/Mbed-TLS/mbedtls/commit/cc0fd47531ffeffb3185db77a17ee113ce874ea6

The macro was a no-op, so just remove the checks.

This fixes building OP-TEE with:

make PLATFORM=vexpress \
     PLATFORM_FLAVOR=juno \
     CFG_CRYPTOLIB_NAME=mbedtls \
     CFG_CRYPTOLIB_DIR=lib/libmbedtls
...
lib/libmbedtls/core/hash.c: In function 'mbedtls_internal_sha1_process': lib/libmbedtls/core/hash.c:205:9: error: implicit declaration of function 'MBEDTLS_INTERNAL_VALIDATE_RET'

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
