### PR TITLE
plat-sam: implement PL310 SMC protocol

### DIFF
--- a/core/arch/arm/plat-sam/conf.mk
+++ b/core/arch/arm/plat-sam/conf.mk
@@ -25,6 +25,7 @@ include core/arch/arm/cpu/cortex-a5.mk
 $(call force,CFG_SAMA5D2,y)
 $(call force,CFG_ATMEL_SAIC,y)
 $(call force,CFG_PL310,y)
+$(call force,CFG_PL310_SIP_PROTOCOL,y)
 endif
 
 $(call force,CFG_TEE_CORE_NB_CORE,1)

--- a/core/arch/arm/plat-sam/nsec-service/sm_platform_handler.c
+++ b/core/arch/arm/plat-sam/nsec-service/sm_platform_handler.c
@@ -10,13 +10,34 @@
 #include <kernel/tee_misc.h>
 #include <mm/core_memprot.h>
 #include <sam_sfr.h>
+#include <sam_pl310.h>
 #include <sm/optee_smc.h>
 #include <sm/sm.h>
 #include <smc_ids.h>
 
 static enum sm_handler_ret sam_sip_handler(struct thread_smc_args *args)
 {
+	/*
+	 * As all sama5 SoCs are single-core ones, check the code compiled for a
+	 * single core. No serializations done to protect against concurrency.
+	 */
+	static_assert(CFG_TEE_CORE_NB_CORE == 1);
+
 	switch (OPTEE_SMC_FUNC_NUM(args->a0)) {
+#ifdef CFG_PL310_SIP_PROTOCOL
+	case SAM_SMC_SIP_PL310_ENABLE:
+		args->a0 = pl310_enable();
+		break;
+	case SAM_SMC_SIP_PL310_DISABLE:
+		args->a0 = pl310_disable();
+		break;
+	case SAM_SMC_SIP_PL310_EN_WRITEBACK:
+		args->a0 = pl310_enable_writeback();
+		break;
+	case SAM_SMC_SIP_PL310_DIS_WRITEBACK:
+		args->a0 = pl310_disable_writeback();
+		break;
+#endif
 	case SAMA5_SMC_SIP_SFR_SET_USB_SUSPEND:
 		atmel_sfr_set_usb_suspend(args->a1);
 		args->a0 = SAMA5_SMC_SIP_RETURN_SUCCESS;

--- a/core/arch/arm/plat-sam/nsec-service/smc_ids.h
+++ b/core/arch/arm/plat-sam/nsec-service/smc_ids.h
@@ -8,6 +8,11 @@
 #include <optee_msg.h>
 #include <sm/optee_smc.h>
 
+#define SAM_SMC_SIP_PL310_ENABLE	1
+#define SAM_SMC_SIP_PL310_DISABLE	2
+#define SAM_SMC_SIP_PL310_EN_WRITEBACK	3
+#define SAM_SMC_SIP_PL310_DIS_WRITEBACK	4
+
 #define SAMA5_SMC_SIP_SCMI_CALL_ID	0x200
 
 #define SAMA5_SMC_SIP_SFR_SET_USB_SUSPEND	0x300

--- a/core/arch/arm/plat-sam/sam_pl310.h
+++ b/core/arch/arm/plat-sam/sam_pl310.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Microchip Technology Inc. and its subsidiaries.
+ */
+
+#ifndef __SAM_PL310_H__
+#define __SAM_PL310_H__
+
+TEE_Result pl310_enable(void);
+TEE_Result pl310_disable(void);
+TEE_Result pl310_enable_writeback(void);
+TEE_Result pl310_disable_writeback(void);
+
+#endif /* __SAM_PL310_H__ */


### PR DESCRIPTION
When Linux runs in normal world, it expects the PL310 to be initially disabled, and then invokes SMCs to enable it.
Let CFG_PL310_SIP_PROTOCOL=y, and the L2 cache will be left untouched until the OS enables it.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
