### PR TITLE
core: fix error handling in tee_svc_storage_read_head()

### DIFF
--- a/core/tee/tee_svc_storage.c
+++ b/core/tee/tee_svc_storage.c
@@ -135,12 +135,12 @@ static TEE_Result tee_svc_storage_read_head(struct tee_obj *o)
 		bytes = head.attr_size;
 		res = fops->read(o->fh, sizeof(struct tee_svc_storage_head),
 				 attr, NULL, &bytes);
-		if (res == TEE_ERROR_OUT_OF_MEMORY)
+		if (res != TEE_SUCCESS)
 			goto exit;
-		if (res != TEE_SUCCESS || bytes != head.attr_size)
+		if (bytes != head.attr_size) {
 			res = TEE_ERROR_CORRUPT_OBJECT;
-		if (res)
 			goto exit;
+		}
 	}
 
 	res = tee_obj_attr_from_binary(o, attr, head.attr_size);


### PR DESCRIPTION
Prior to this all errors except TEE_ERROR_OUT_OF_MEMORY from fops->read() was reported as TEE_ERROR_CORRUPT_OBJECT leading to removal of the object.
We should not treat all errors as corrupt, so remove the error code translation.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
