### PR TITLE
Move base64.{c,h} from libutee to libutils

### DIFF
--- a/lib/libutee/sub.mk
+++ b/lib/libutee/sub.mk
@@ -6,7 +6,6 @@ srcs-y += tee_uuid_from_str.c
 srcs-y += trace_ext.c
 
 ifneq ($(sm),ldelf)
-srcs-y += base64.c
 srcs-y += tee_api.c
 srcs-y += tee_api_arith_mpi.c
 cppflags-tee_api_arith_mpi.c-y += -DMBEDTLS_ALLOW_PRIVATE_ACCESS

--- a/lib/libutee/tee_api_property.c
+++ b/lib/libutee/tee_api_property.c
@@ -3,12 +3,14 @@
  * Copyright (c) 2014, STMicroelectronics International N.V.
  * Copyright (c) 2017-2020, Linaro Limited
  */
+#include <base64.h>
 #include <printk.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <tee_api_defines.h>
+#include <string_ext.h>
 #include <tee_api.h>
+#include <tee_api_defines.h>
 #include <tee_api_types.h>
 #include <tee_arith_internal.h>
 #include <tee_internal_api_extensions.h>
@@ -17,8 +19,6 @@
 #include <utee_syscalls.h>
 #include <util.h>
 
-#include "base64.h"
-#include "string_ext.h"
 #include "tee_api_private.h"
 
 #define PROP_STR_MAX    80
@@ -108,7 +108,7 @@ static TEE_Result propget_get_ext_prop(const struct user_ta_property *ep,
 		 * string
 		 */
 		l = *len;
-		if (!_base64_dec(ep->value, strlen(ep->value), buf, &l) &&
+		if (!base64_dec(ep->value, strlen(ep->value), buf, &l) &&
 		    l <= *len)
 			return TEE_ERROR_GENERIC;
 		if (*len < l) {
@@ -231,7 +231,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 				 * with the size of the of the base64 encoded
 				 * see base64_enc() function
 				 */
-				tmp_len = _base64_enc_len(tmp_len);
+				tmp_len = base64_enc_len(tmp_len);
 			}
 			*value_len = tmp_len;
 		}
@@ -266,7 +266,7 @@ TEE_Result TEE_GetPropertyAsString(TEE_PropSetHandle propsetOrEnumerator,
 
 	case USER_TA_PROP_TYPE_BINARY_BLOCK:
 		l = *value_len;	/* l includes the zero-termination */
-		if (!_base64_enc(tmp_buf, tmp_len, value, &l) &&
+		if (!base64_enc(tmp_buf, tmp_len, value, &l) &&
 		    l <= *value_len) {
 			res = TEE_ERROR_GENERIC;
 			goto out;

--- a/lib/libutils/ext/base64.c
+++ b/lib/libutils/ext/base64.c
@@ -8,18 +8,18 @@
 static const char base64_table[] =
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-size_t _base64_enc_len(size_t size)
+size_t base64_enc_len(size_t size)
 {
 	return 4 * ((size + 2) / 3) + 1;
 }
 
-bool _base64_enc(const void *data, size_t dlen, char *buf, size_t *blen)
+bool base64_enc(const void *data, size_t dlen, char *buf, size_t *blen)
 {
 	size_t n = 0;
 	size_t boffs = 0;
 	const unsigned char *d = data;
 
-	n = _base64_enc_len(dlen);
+	n = base64_enc_len(dlen);
 	if (*blen < n) {
 		*blen = n;
 		return false;
@@ -70,7 +70,7 @@ static bool get_idx(char ch, uint8_t *idx)
 	return false;
 }
 
-bool _base64_dec(const char *data, size_t size, void *buf, size_t *blen)
+bool base64_dec(const char *data, size_t size, void *buf, size_t *blen)
 {
 	bool ret = false;
 	size_t n = 0;

--- a/lib/libutils/ext/include/base64.h
+++ b/lib/libutils/ext/include/base64.h
@@ -9,8 +9,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-bool _base64_enc(const void *data, size_t size, char *buf, size_t *blen);
-bool _base64_dec(const char *data, size_t size, void *buf, size_t *blen);
-size_t _base64_enc_len(size_t size);
+bool base64_enc(const void *data, size_t size, char *buf, size_t *blen);
+bool base64_dec(const char *data, size_t size, void *buf, size_t *blen);
+size_t base64_enc_len(size_t size);
 
 #endif /* BASE64_H */

--- a/lib/libutils/ext/sub.mk
+++ b/lib/libutils/ext/sub.mk
@@ -11,6 +11,7 @@ srcs-y += memzero_explicit.c
 srcs-y += fault_mitigation.c
 srcs-y += qsort_helpers.c
 srcs-y += array.c
+srcs-y += base64.c
 
 ifneq (,$(filter ta_%,$(sm)))
 srcs-y += pthread_stubs.c


### PR DESCRIPTION
Make the base64 routines publicly available by moving them from libutee to libutils. The _ prefix is removed from the public functions since they aren't internal to libutee any longer.

