### PR TITLE
plat-k3: drivers: Change SA2UL_init service to service_init_crypto

### DIFF
--- a/core/arch/arm/plat-k3/drivers/sa2ul.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.c
@@ -150,4 +150,4 @@ static TEE_Result sa2ul_init(void)
 
 	return TEE_SUCCESS;
 }
-driver_init(sa2ul_init);
+service_init_crypto(sa2ul_init);

--- a/core/arch/arm/plat-k3/main.c
+++ b/core/arch/arm/plat-k3/main.c
@@ -64,7 +64,13 @@ static TEE_Result init_ti_sci(void)
 	return TEE_SUCCESS;
 }
 
-service_init(init_ti_sci);
+/*
+ * TISCI services are required for initialization of TRNG service that gets
+ * initialized during service_init_crypto.
+ *
+ * Initialize TISCI service just before service_init_crypto.
+ */
+early_init_late(init_ti_sci);
 
 static TEE_Result secure_boot_information(void)
 {


### PR DESCRIPTION
Since commit https://github.com/OP-TEE/optee_os/commit/11d8578d93f0aee793b28221b06187f62bb7b24b ("core: arm: call call_driver_initcalls()
late"), driver_init is deferred and thread_update_canaries tries to get
random_stack_canaries which requires the TRNG driver to be setup. Since
it was being setup as part of driver_init, it lead to crash on K3
platforms.

Change driver_init to service_init_crypto which is meant to be used for
initialization of crypto operations. Also, for the TISCI services to be
available before service_init_crypto, change init_ti_sci invocation to
early_init_late.

Some other driver vendors using driver_init for RNG initialization might 
also be affected.

Signed-off-by: Kamlesh Gurudasani <kamlesh@ti.com>
Signed-off-by: Manorit Chawdhry <m-chawdhry@ti.com>