### PR TITLE
mk/compile.mk: fix pre-processed device tree dependencies file target

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -272,7 +272,7 @@ cleanfiles := $$(cleanfiles) $2 \
 
 dtb-cppflags-$2 := -Icore/include/ -x assembler-with-cpp -Ulinux -Uunix \
 		   -E -ffreestanding $$(CPPFLAGS) \
-		   -MD -MF $$(dtb-predep-$2) -MT $2
+		   -MD -MF $$(dtb-predep-$2) -MT $$(dtb-predts-$2)
 
 dtb-dtcflags-$2	:= $$(DTC_FLAGS) -I dts -O dtb -Wno-unit_address_vs_reg \
 		   -d $$(dtb-dep-$2)


### PR DESCRIPTION
Fixes the target in the pre-processed device tree dependency file