### PR TITLE
riscv: plat-virt: Set CFG_BOOT_SYNC_CPU=n

### DIFF
--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -25,7 +25,7 @@ $(call force,CFG_CORE_SANITIZE_KADDRESS,n)
 # Hart-related flags
 CFG_TEE_CORE_NB_CORE ?= 1
 CFG_NUM_THREADS ?= 1
-$(call force,CFG_BOOT_SYNC_CPU,y)
+$(call force,CFG_BOOT_SYNC_CPU,n)
 
 $(call force,CFG_RISCV_M_MODE,n)
 $(call force,CFG_RISCV_S_MODE,y)


### PR DESCRIPTION
On RISC-V QEMU virt platform, OP-TEE OS runs as S-mode.
There is a secure monitor runs as M-mode and controls the hart state of the secondary CPUs in SMP system (e.g., by SBI HSM extension) during OP-TEE OS secondary CPUs booting.

Thus, RISC-V virt platform does not need CFG_BOOT_SYNC_CPU.