### PR TITLE
Remoteproc:  add command to release fw resources

### DIFF
--- a/core/drivers/remoteproc/stm32_remoteproc.c
+++ b/core/drivers/remoteproc/stm32_remoteproc.c
@@ -315,6 +315,35 @@ err:
 	return res;
 }
 
+TEE_Result stm32_rproc_clean_up_memories(uint32_t rproc_id)
+{
+	struct stm32_rproc_instance *rproc = stm32_rproc_get(rproc_id);
+	struct stm32_rproc_mem *mems = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	unsigned int i = 0;
+	void *va = NULL;
+	size_t size = 0;
+	paddr_t pa = 0;
+
+	if (!rproc)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mems = rproc->regions;
+	for (i = 0; i < rproc->n_regions; i++) {
+		pa = mems[i].addr;
+		size = mems[i].size;
+		res = stm32_rproc_map(rproc_id, pa, size, &va);
+		if (res)
+			break;
+		memset(va, 0, size);
+		res = stm32_rproc_unmap(rproc_id, va, size);
+		if (res)
+			break;
+	}
+
+	return res;
+}
+
 static void stm32_rproc_cleanup(struct stm32_rproc_instance *rproc)
 {
 	free(rproc->regions);

--- a/core/include/drivers/stm32_remoteproc.h
+++ b/core/include/drivers/stm32_remoteproc.h
@@ -67,4 +67,11 @@ TEE_Result stm32_rproc_start(uint32_t rproc_id);
  */
 TEE_Result stm32_rproc_stop(uint32_t rproc_id);
 
+/*
+ * stm32_rproc_clean_up_memories() - clear remote processor memory regions
+ * @rproc_id	unique identifier of the remote processor
+ * Return TEE_SUCCESS or appropriate error.
+ */
+TEE_Result stm32_rproc_clean_up_memories(uint32_t rproc_id);
+
 #endif /* __DRIVERS_STM32_REMOTEPROC_H */

--- a/core/pta/stm32mp/remoteproc_pta.c
+++ b/core/pta/stm32mp/remoteproc_pta.c
@@ -293,6 +293,24 @@ static TEE_Result rproc_pta_verify_digest(uint32_t pt,
 					      keyinfo->algo);
 }
 
+static TEE_Result rproc_pta_release_resources(uint32_t pt,
+					      TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+
+	if (pt != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (rproc_ta_state != REMOTEPROC_OFF)
+		return TEE_ERROR_BAD_STATE;
+
+	/* Clean the resources */
+	return stm32_rproc_clean_up_memories(params[0].value.a);
+}
+
 static TEE_Result rproc_pta_invoke_command(void *session __unused,
 					   uint32_t cmd_id,
 					   uint32_t param_types,
@@ -313,6 +331,8 @@ static TEE_Result rproc_pta_invoke_command(void *session __unused,
 		return rproc_pta_da_to_pa(param_types, params);
 	case PTA_RPROC_VERIFY_DIGEST:
 		return rproc_pta_verify_digest(param_types, params);
+	case PTA_REMOTEPROC_RELEASE:
+		return rproc_pta_release_resources(param_types, params);
 	default:
 		return TEE_ERROR_NOT_IMPLEMENTED;
 	}

--- a/lib/libutee/include/remoteproc_pta.h
+++ b/lib/libutee/include/remoteproc_pta.h
@@ -147,4 +147,13 @@ static inline size_t rproc_pta_keyinfo_size(struct rproc_pta_key_info *keyinf)
  */
 #define PTA_RPROC_VERIFY_DIGEST		8
 
+/*
+ * Remote processor resources release.
+ *
+ * Release the resources associated to the remote processor.
+ *
+ * [in]  params[0].value.a:	Unique 32bit remote processor identifier
+ */
+#define PTA_REMOTEPROC_RELEASE		9
+
 #endif /* __REMOTEPROC_PTA_H */

--- a/ta/remoteproc/include/ta_remoteproc.h
+++ b/ta/remoteproc/include/ta_remoteproc.h
@@ -61,4 +61,14 @@
  */
 #define TA_RPROC_CMD_GET_COREDUMP	5
 
+/*
+ * Release remote processor firmware images and associated resources.
+ * This command should be used in case an error occurs between the loading of
+ * the firmware images (TA_RPROC_CMD_LOAD_FW) and the starting of the remote
+ * processor (TA_RPROC_CMD_START_FW) or after stopping the remote processor
+ * to release associated resources (TA_RPROC_CMD_STOP_FW).
+ *
+ * [in]  params[0].value.a: Unique 32-bit remote processor identifier
+ */
+#define TA_RPROC_CMD_RELEASE_FW		6
 #endif /*TA_REMOTEPROC_H*/


### PR DESCRIPTION
The sequence to start the remote processor consists of calling `TA_RPROC_CMD_LOAD_FW` to load the firmware and then starting the remote processor using the `TA_RPROC_CMD_START_FW` command.

Between the calls of these two commands, the user can perform several actions that may result in an error. In such cases, we need to revert from the `REMOTEPROC_LOADED` state to the `REMOTEPROC_OFF` state.

To address this issue, this pull request proposes implementing the `TA_RPROC_CMD_RELEASE_FW` command. This command can be called in case of an error or after stopping the remote processor to clean up the associated resources.

At the platform level, the `PTA_REMOTEPROC_RELEASE` command is introduced to implement the service. For the stm32mp1 platform, this service consists of cleaning the memory regions reserved for the remote processor.

This PR is the result of a discussion with @mathieupoirier on the Linux remoteproc mailing list :

 https://patchew.org/linux/20240621143759.547793-1-arnaud.pouliquen@foss.st.com/20240621143759.547793-3-arnaud.pouliquen@foss.st.com/#


This PR is associated to the Linux series: [PATCH v9 0/7] Introduction of a remoteproc tee to load signed firmware

https://lore.kernel.org/lkml/202409010034.Tln3soEY-lkp@intel.com/T/


