### PR TITLE
core: add CFG_CORE_STATIC_ASLR_SEED

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -473,6 +473,9 @@ shadow_stack_access_ok:
 
 #ifdef CFG_CORE_ASLR
 	bl	get_aslr_seed
+#ifdef CFG_CORE_ASLR_SEED
+	mov_imm	r0, CFG_CORE_ASLR_SEED
+#endif
 #else
 	mov	r0, #0
 #endif

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -314,6 +314,9 @@ clear_nex_bss:
 
 #ifdef CFG_CORE_ASLR
 	bl	get_aslr_seed
+#ifdef CFG_CORE_ASLR_SEED
+	mov_imm	x0, CFG_CORE_ASLR_SEED
+#endif
 #else
 	mov	x0, #0
 #endif

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -957,6 +957,12 @@ endif
 endif # CFG_WARN_INSECURE defined
 CFG_INSECURE ?= y
 
+ifneq ($(CFG_INSECURE),y)
+ifneq ($(CFG_CORE_ASLR_SEED),)
+$(error CFG_CORE_ASLR_SEED requires CFG_INSECURE=y)
+endif
+endif
+
 # Enables warnings for declarations mixed with statements
 CFG_WARN_DECL_AFTER_STATEMENT ?= y
 


### PR DESCRIPTION
Add CFG_CORE_STATIC_ASLR_SEED to override the used seed if CFG_CORE_ASLR=y. CFG_CORE_STATIC_ASLR_SEED is intended to help debugging ASLR related issues by using the same address layout each time.

CFG_CORE_STATIC_ASLR_SEED requires CFG_INSECURE=y.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
