### PR TITLE
core: virt: initialize heap from virt_guest_created()

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -912,17 +912,6 @@ static void update_external_dt(void)
 }
 #endif /*!CFG_DT*/
 
-#ifdef CFG_NS_VIRTUALIZATION
-static TEE_Result virt_init_heap(void)
-{
-	/* We need to initialize pool for every virtual guest partition */
-	malloc_add_pool(__heap1_start, __heap1_end - __heap1_start);
-
-	return TEE_SUCCESS;
-}
-preinit_early(virt_init_heap);
-#endif
-
 void init_tee_runtime(void)
 {
 #ifndef CFG_WITH_PAGER

--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -361,6 +361,7 @@ TEE_Result virt_guest_created(uint16_t guest_id)
 
 	set_current_prtn(prtn);
 
+	malloc_add_pool(__heap1_start, __heap1_end - __heap1_start);
 	/* Initialize threads */
 	thread_init_threads();
 	/* Do the preinitcalls */


### PR DESCRIPTION
Replace the preinit_early() guest heap initialization with function call in virt_guest_created().

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
