### PR TITLE
[RISC-V] Allow enabling CFG_TEE_CORE_DEBUG

### DIFF
--- a/core/arch/arm/include/mm/core_mmu_arch.h
+++ b/core/arch/arm/include/mm/core_mmu_arch.h
@@ -137,15 +137,6 @@ struct core_mmu_user_map {
 };
 #endif
 
-#ifdef CFG_WITH_LPAE
-bool core_mmu_user_va_range_is_defined(void);
-#else
-static inline bool __noprof core_mmu_user_va_range_is_defined(void)
-{
-	return true;
-}
-#endif
-
 /* Cache maintenance operation type */
 enum cache_op {
 	DCACHE_CLEAN,

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -693,6 +693,11 @@ bool core_mmu_user_mapping_is_active(void)
 	return ret;
 }
 
+bool __noprof core_mmu_user_va_range_is_defined(void)
+{
+	return true;
+}
+
 void core_init_mmu_prtn(struct mmu_partition *prtn, struct memory_map *mem_map)
 {
 	void *ttb1 = (void *)core_mmu_get_main_ttb_va(prtn);

--- a/core/arch/riscv/include/mm/core_mmu_arch.h
+++ b/core/arch/riscv/include/mm/core_mmu_arch.h
@@ -84,6 +84,14 @@
 					(level) + \
 					RISCV_PGSHIFT)
 
+#ifdef RV64
+#define CORE_MMU_PAGE_OFFSET_MASK(level) \
+		GENMASK_64(CORE_MMU_SHIFT_OF_LEVEL(level) - 1, 0)
+#else
+#define CORE_MMU_PAGE_OFFSET_MASK(level) \
+		GENMASK_32(CORE_MMU_SHIFT_OF_LEVEL(level) - 1, 0)
+#endif
+
 #define CORE_MMU_USER_CODE_SHIFT	SMALL_PAGE_SHIFT
 #define CORE_MMU_USER_PARAM_SHIFT	SMALL_PAGE_SHIFT
 

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -450,7 +450,7 @@ void asid_free(unsigned int asid)
 	if (asid) {
 		int i = asid - 1;
 
-		assert(i < RISCV_MMU_ASID_WIDTH && bit_test(&g_asid, i));
+		assert(i < RISCV_MMU_ASID_WIDTH && bit_test(g_asid, i));
 		bit_clear(g_asid, i);
 	}
 

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -289,7 +289,7 @@ static void core_init_mmu_prtn_ta(struct mmu_partition *prtn)
 {
 	unsigned int core = 0;
 
-	assert(user_va_idx != -1);
+	assert(core_mmu_user_va_range_is_defined());
 
 	memset(prtn->user_pgts, 0, CFG_NUM_THREADS * RISCV_MMU_PGT_SIZE);
 	for (core = 0; core < CFG_TEE_CORE_NB_CORE; core++)
@@ -637,7 +637,7 @@ core_mmu_get_user_mapping_entry(struct mmu_partition *prtn)
 {
 	struct mmu_pgt *pgt = core_mmu_get_root_pgt_va(prtn);
 
-	assert(user_va_idx != -1);
+	assert(core_mmu_user_va_range_is_defined());
 
 	return core_mmu_table_get_entry(pgt, user_va_idx);
 }
@@ -669,9 +669,14 @@ void core_mmu_set_user_map(struct core_mmu_user_map *map)
 	thread_unmask_exceptions(exceptions);
 }
 
+bool core_mmu_user_va_range_is_defined(void)
+{
+	return user_va_idx != -1;
+}
+
 void core_mmu_get_user_va_range(vaddr_t *base, size_t *size)
 {
-	assert(user_va_idx != -1);
+	assert(core_mmu_user_va_range_is_defined());
 
 	if (base)
 		*base = SHIFT_U64(user_va_idx, CORE_MMU_BASE_TABLE_SHIFT);

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -466,6 +466,7 @@ bool arch_va2pa_helper(void *va, paddr_t *pa)
 	int level = 0;
 	unsigned int idx = 0;
 	struct mmu_partition *prtn = core_mmu_get_prtn();
+	vaddr_t offset_mask = 0;
 
 	assert(pa);
 
@@ -479,8 +480,8 @@ bool arch_va2pa_helper(void *va, paddr_t *pa)
 			thread_unmask_exceptions(exceptions);
 			return false;
 		} else if (core_mmu_entry_is_leaf(pte)) {
-			*pa = pte_to_pa(pte) |
-			      (vaddr & (BIT64(RISCV_PGSHIFT) - 1));
+			offset_mask = CORE_MMU_PAGE_OFFSET_MASK(level);
+			*pa = pte_to_pa(pte) | (vaddr & offset_mask);
 			thread_unmask_exceptions(exceptions);
 			return true;
 		}

--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -5,7 +5,6 @@ $(call force,CFG_RISCV_ISA_C,y)
 $(call force,CFG_RISCV_FPU,y)
 
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
-$(call force,CFG_TEE_CORE_DEBUG,n)
 $(call force,CFG_CORE_RESERVED_SHM,n)
 $(call force,CFG_CORE_DYN_SHM,y)
 

--- a/core/include/mm/core_mmu.h
+++ b/core/include/mm/core_mmu.h
@@ -552,6 +552,12 @@ void core_mmu_unmap_pages(vaddr_t vstart, size_t num_pages);
 bool core_mmu_user_mapping_is_active(void);
 
 /*
+ * core_mmu_user_va_range_is_defined() - check if user va range is defined
+ * @returns true if a user VA space is defined, false if not.
+ */
+bool core_mmu_user_va_range_is_defined(void);
+
+/*
  * core_mmu_mattr_is_ok() - Check that supplied mem attributes can be used
  * @returns true if the attributes can be used, false if not.
  */

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -2381,7 +2381,14 @@ paddr_t virt_to_phys(void *va)
 	return pa;
 }
 
-#if defined(CFG_TEE_CORE_DEBUG)
+/*
+ * Don't use check_va_matches_pa() for RISC-V, as its callee
+ * arch_va2pa_helper() will call it eventually, this creates
+ * indirect recursion and can lead to a stack overflow.
+ * Moreover, if arch_va2pa_helper() returns true, it implies
+ * the va2pa mapping is matched, no need to check it again.
+ */
+#if defined(CFG_TEE_CORE_DEBUG) && !defined(__riscv)
 static void check_va_matches_pa(paddr_t pa, void *va)
 {
 	paddr_t p = 0;


### PR DESCRIPTION
This series enables CFG_TEE_CORE_DEBUG, a crucial feature for early error detection on RISC-V platforms, such as assertions.