### PR TITLE
ta: pkcs11: Build time option for controlling pin locking

### DIFF
--- a/ta/pkcs11/sub.mk
+++ b/ta/pkcs11/sub.mk
@@ -13,6 +13,10 @@ CFG_PKCS11_TA_TOKEN_COUNT ?= 3
 # When enabled, embed support for object checksum value computation
 CFG_PKCS11_TA_CHECK_VALUE_ATTRIBUTE ?= y
 
+# Locks correspondingly User or SO PIN when reaching maximum
+# failed authentication attemps (continous) limit
+CFG_PKCS11_TA_LOCK_PIN_AFTER_FAILED_LOGIN_ATTEMPTS ?= y
+
 global-incdirs-y += include
 global-incdirs-y += src
 subdirs-y += src


### PR DESCRIPTION
Proposing a new build time option for pkcs11 TA. Proposed option would enable or disable pin locking after failed authentication attempts. Option would control both pins (User and SO). Default value is 'y'/enabled.

In other worlds option would allow unlimited authentication attempts, but in certain specific scenarios it is desirable. As an example scenario would be pkcs11 token proxy access. A malicious actor could execute DDOS attack and could lock pin after 2³32 attempts (pin count stored uint32_t). A mitigation could be unlimited login attempts and using a long pin (mitigate against brute force attack). 