### PR TITLE
drivers: se050: Avoid calling i2c functions

### DIFF
--- a/core/drivers/crypto/se050/adaptors/apis/sss.c
+++ b/core/drivers/crypto/se050/adaptors/apis/sss.c
@@ -162,7 +162,7 @@ sss_status_t se050_enable_scp03(sss_se05x_session_t *session)
 		if (status != kStatus_SSS_Success)
 			continue;
 
-		if (session->subsystem)
+		if (session && session->subsystem)
 			sss_se05x_session_close(session);
 
 		if (!se050_core_early_init(&keys)) {

--- a/core/drivers/crypto/se050/core/apdu.c
+++ b/core/drivers/crypto/se050/core/apdu.c
@@ -16,6 +16,11 @@ TEE_Result crypto_se_do_apdu(enum crypto_apdu_type type,
 {
 	sss_status_t status = kStatus_SSS_Fail;
 
+	if (IS_ENABLED(CFG_CORE_SE05X_I2C_TRAMPOLINE_ONLY) && !se050_session) {
+		/* Defer until REE is ready */
+		return TEE_ERROR_COMMUNICATION;
+	}
+
 	status = sss_se05x_do_apdu(&se050_session->s_ctx, type,
 				   hdr, hdr_len, src_data, src_len,
 				   dst_data, dst_len);

--- a/core/drivers/crypto/se050/crypto.mk
+++ b/core/drivers/crypto/se050/crypto.mk
@@ -37,6 +37,8 @@ CFG_CORE_SE05X_BAUDRATE ?= 3400000
 CFG_CORE_SE05X_I2C_BUS ?= 2
 # I2C access via REE after TEE boot
 CFG_CORE_SE05X_I2C_TRAMPOLINE ?= y
+# TEE has no native I2C driver - all I2C access done via REE
+CFG_CORE_SE05X_I2C_TRAMPOLINE_ONLY ?= n
 
 # Extra stacks required to support the Plug and Trust external library
 ifeq ($(shell test $(CFG_STACK_THREAD_EXTRA) -lt 8192; echo $$?), 0)

--- a/core/drivers/crypto/se050/glue/i2c.c
+++ b/core/drivers/crypto/se050/glue/i2c.c
@@ -47,7 +47,8 @@ int glue_i2c_write(uint8_t *buffer, int len)
 
 int glue_i2c_init(void)
 {
-	if (transfer == rpc_io_i2c_transfer)
+	if (transfer == rpc_io_i2c_transfer ||
+	    IS_ENABLED(CFG_CORE_SE05X_I2C_TRAMPOLINE_ONLY))
 		return 0;
 
 	transfer = native_i2c_transfer;

--- a/core/drivers/crypto/se050/glue/include/i2c_native.h
+++ b/core/drivers/crypto/se050/glue/include/i2c_native.h
@@ -9,8 +9,24 @@
 
 #include <kernel/rpc_io_i2c.h>
 
+#ifdef CFG_CORE_SE05X_I2C_TRAMPOLINE_ONLY
+static inline TEE_Result
+native_i2c_transfer(struct rpc_i2c_request *req __unused,
+		    size_t *bytes __unused)
+{
+	/* Stub only */
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+static inline int native_i2c_init(void)
+{
+	/* Stub only */
+	return 0;
+}
+#else
 TEE_Result native_i2c_transfer(struct rpc_i2c_request *req,
 			       size_t *bytes);
 int native_i2c_init(void);
+#endif
 
 #endif

--- a/core/drivers/crypto/se050/session.c
+++ b/core/drivers/crypto/se050/session.c
@@ -120,6 +120,11 @@ static TEE_Result se050_early_init_scp03(void)
 
 static TEE_Result se050_session_init(void)
 {
+	if (IS_ENABLED(CFG_CORE_SE05X_I2C_TRAMPOLINE_ONLY)) {
+		/* Nothing to do */
+		return TEE_SUCCESS;
+	}
+
 	if (IS_ENABLED(CFG_CORE_SCP03_ONLY))
 		return se050_early_init_scp03();
 


### PR DESCRIPTION
Create a new option called `CFG_CORE_SE05X_I2C_TRAMPOLINE_ONLY` indicating
there is no native I2C driver inside TEE and all I2C access are done through
the I2C trampoline.

As a result some of the native I2C calls are either stubbed or skipped.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
