### PR TITLE
Miscellaneous fixes and improvements for RISC-V

### DIFF
--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -502,7 +502,7 @@ static void set_ctx_regs(struct thread_ctx_regs *regs, unsigned long a0,
 		.a3 = a3,
 		.s0 = 0,
 		.sp = user_sp,
-		.ra = entry_func,
+		.epc = entry_func,
 		.status = status,
 		.ie = ie,
 	};

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -705,22 +705,28 @@ FUNC __thread_enter_user_mode , :
 	 */
 	csrw	CSR_XSCRATCH, tp
 
+	/* Move struct thread_ctx_regs *regs to sp to reduce code size */
+	mv	sp, a0
+
 	/* Set exception return PC */
-	load_xregs a0, THREAD_CTX_REG_EPC, REG_S0
+	load_xregs sp, THREAD_CTX_REG_EPC, REG_S0
 	csrw	CSR_XEPC, s0
 	/* Set user ie */
-	load_xregs a0, THREAD_CTX_REG_IE, REG_S0
+	load_xregs sp, THREAD_CTX_REG_IE, REG_S0
 	csrw	CSR_XIE, s0
 	/* Set user status */
-	load_xregs a0, THREAD_CTX_REG_STATUS, REG_S0
+	load_xregs sp, THREAD_CTX_REG_STATUS, REG_S0
 	csrw	CSR_XSTATUS, s0
 	/* Load the rest of the general purpose registers */
-	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_TP
-	load_xregs a0, THREAD_CTX_REG_T0, REG_T0, REG_T2
-	load_xregs a0, THREAD_CTX_REG_S0, REG_S0, REG_S1
-	load_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
-	load_xregs a0, THREAD_CTX_REG_T3, REG_T3, REG_T6
-	load_xregs a0, THREAD_CTX_REG_A0, REG_A0, REG_A7
+	load_xregs sp, THREAD_CTX_REG_RA, REG_RA
+	load_xregs sp, THREAD_CTX_REG_GP, REG_GP
+	load_xregs sp, THREAD_CTX_REG_TP, REG_TP
+	load_xregs sp, THREAD_CTX_REG_T0, REG_T0, REG_T2
+	load_xregs sp, THREAD_CTX_REG_S0, REG_S0, REG_S1
+	load_xregs sp, THREAD_CTX_REG_A0, REG_A0, REG_A7
+	load_xregs sp, THREAD_CTX_REG_S2, REG_S2, REG_S11
+	load_xregs sp, THREAD_CTX_REG_T3, REG_T3, REG_T6
+	load_xregs sp, THREAD_CTX_REG_SP, REG_SP /* sp must be last one */
 
 	/* Jump into user mode */
 	XRET
@@ -731,16 +737,17 @@ FUNC thread_resume , :
 	/* Disable global interrupts first */
 	csrc	CSR_XSTATUS, CSR_XSTATUS_IE
 
+	/* Move struct thread_ctx_regs *regs to sp to reduce code size */
+	mv	sp, a0
+
 	/* Restore epc */
-	load_xregs a0, THREAD_CTX_REG_EPC, REG_T0
+	load_xregs sp, THREAD_CTX_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
-
 	/* Restore ie */
-	load_xregs a0, THREAD_CTX_REG_IE, REG_T0
+	load_xregs sp, THREAD_CTX_REG_IE, REG_T0
 	csrw	CSR_XIE, t0
-
 	/* Restore status */
-	load_xregs a0, THREAD_CTX_REG_STATUS, REG_T0
+	load_xregs sp, THREAD_CTX_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
 
 	/* Check if previous privilege mode by status.SPP */
@@ -753,12 +760,15 @@ FUNC thread_resume , :
 	csrw	CSR_XSCRATCH, tp
 2:
 	/* Restore all general-purpose registers */
-	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_TP
-	load_xregs a0, THREAD_CTX_REG_T0, REG_T0, REG_T2
-	load_xregs a0, THREAD_CTX_REG_S0, REG_S0, REG_S1
-	load_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
-	load_xregs a0, THREAD_CTX_REG_T3, REG_T3, REG_T6
-	load_xregs a0, THREAD_CTX_REG_A0, REG_A0, REG_A7
+	load_xregs sp, THREAD_CTX_REG_RA, REG_RA
+	load_xregs sp, THREAD_CTX_REG_GP, REG_GP
+	load_xregs sp, THREAD_CTX_REG_TP, REG_TP
+	load_xregs sp, THREAD_CTX_REG_T0, REG_T0, REG_T2
+	load_xregs sp, THREAD_CTX_REG_S0, REG_S0, REG_S1
+	load_xregs sp, THREAD_CTX_REG_A0, REG_A0, REG_A7
+	load_xregs sp, THREAD_CTX_REG_S2, REG_S2, REG_S11
+	load_xregs sp, THREAD_CTX_REG_T3, REG_T3, REG_T6
+	load_xregs sp, THREAD_CTX_REG_SP, REG_SP /* sp must be last one */
 
 	XRET
 END_FUNC thread_resume

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -705,14 +705,15 @@ FUNC __thread_enter_user_mode , :
 	 */
 	csrw	CSR_XSCRATCH, tp
 
+	/* Set exception return PC */
+	load_xregs a0, THREAD_CTX_REG_EPC, REG_S0
+	csrw	CSR_XEPC, s0
 	/* Set user ie */
 	load_xregs a0, THREAD_CTX_REG_IE, REG_S0
 	csrw	CSR_XIE, s0
-
 	/* Set user status */
 	load_xregs a0, THREAD_CTX_REG_STATUS, REG_S0
 	csrw	CSR_XSTATUS, s0
-
 	/* Load the rest of the general purpose registers */
 	load_xregs a0, THREAD_CTX_REG_RA, REG_RA, REG_TP
 	load_xregs a0, THREAD_CTX_REG_T0, REG_T0, REG_T2
@@ -720,9 +721,6 @@ FUNC __thread_enter_user_mode , :
 	load_xregs a0, THREAD_CTX_REG_S2, REG_S2, REG_S11
 	load_xregs a0, THREAD_CTX_REG_T3, REG_T3, REG_T6
 	load_xregs a0, THREAD_CTX_REG_A0, REG_A0, REG_A7
-
-	/* Set exception program counter */
-	csrw		CSR_XEPC, ra
 
 	/* Jump into user mode */
 	XRET

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -154,8 +154,8 @@ native_interrupt_from_kernel:
 	/* Restore XSTATUS */
 	load_xregs sp, THREAD_CTX_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
-	/* Set scratch as thread_core_local */
-	csrw	CSR_XSCRATCH, tp
+	/* We are going to XRET to kernel mode. Set XSCRATCH as 0 */
+	csrw	CSR_XSCRATCH, 0
 	/* Restore all GPRs */
 	load_xregs sp, THREAD_CTX_REG_RA, REG_RA
 	load_xregs sp, THREAD_CTX_REG_GP, REG_GP
@@ -252,8 +252,8 @@ set_sp:
 	/* Restore XSTATUS */
 	load_xregs sp, THREAD_ABT_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
-	/* Set scratch as thread_core_local */
-	csrw	CSR_XSCRATCH, tp
+	/* We are going to XRET to kernel mode. Set XSCRATCH as 0 */
+	csrw	CSR_XSCRATCH, 0
 
 	/* Update core local flags */
 	lw	a0, THREAD_CORE_LOCAL_FLAGS(tp)


### PR DESCRIPTION
- Commit "core: riscv: Set exception return PC into XEPC for entering user mode"
removes redundant usage of "ra" register.
- Commit "core: riscv: Fix misconfiguration of XSCRATCH when XRET to kernel mode"
fixes the value of XSCRATCH when XRET to kernel mode.
- Commit "core: riscv: Use sp as base register of load instructions"
uses "sp" as base register for load instructions to reduce the code size.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
