### PR TITLE
core: delay: fix timeout expiration threshold

### DIFF
--- a/core/include/kernel/delay.h
+++ b/core/include/kernel/delay.h
@@ -52,7 +52,7 @@ static inline uint64_t timeout_init_us(uint32_t us)
 
 static inline bool timeout_elapsed(uint64_t expire)
 {
-	return delay_cnt_read() > expire;
+	return delay_cnt_read() >= expire;
 }
 
 /*


### PR DESCRIPTION
Fix timeout threshold that should return once the time expires, not 1 tick after it has expired. This change makes udelay(0) to immediately return and not wait a generic timer counter increment.

This change fixes an issue where a driver stops the counter feeding Arm generic timer counter and indirectly calls IO_READ32_POLL_TIMEOUT() with a delay of 0us. It that case, since counter never increments, the udelay(0) call in IO_READ32_POLL_TIMEOUT() never returns while we expect the macro to endlessly poll (as timeout would never be detected) until poll condition is met or system watchdog is triggered.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
