### PR TITLE
crypto: stm32: fix SAES driver set_field_u32 usage

### DIFF
--- a/core/drivers/crypto/stm32/stm32_saes.c
+++ b/core/drivers/crypto/stm32/stm32_saes.c
@@ -567,28 +567,28 @@ TEE_Result stm32_saes_init(struct stm32_saes_context *ctx, bool is_dec,
 	}
 
 	if (is_dec)
-		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_MODE_MASK,
-					 _SAES_CR_MODE_DEC);
+		ctx->cr = set_field_u32(ctx->cr, _SAES_CR_MODE_MASK,
+					_SAES_CR_MODE_DEC);
 	else
-		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_MODE_MASK,
-					 _SAES_CR_MODE_ENC);
+		ctx->cr = set_field_u32(ctx->cr, _SAES_CR_MODE_MASK,
+					_SAES_CR_MODE_ENC);
 
 	/* Save chaining mode */
 	switch (ch_mode) {
 	case STM32_SAES_MODE_ECB:
-		ctx->cr |= SET_CHAINING_MODE(ECB, ctx->cr);
+		ctx->cr = SET_CHAINING_MODE(ECB, ctx->cr);
 		break;
 	case STM32_SAES_MODE_CBC:
-		ctx->cr |= SET_CHAINING_MODE(CBC, ctx->cr);
+		ctx->cr = SET_CHAINING_MODE(CBC, ctx->cr);
 		break;
 	case STM32_SAES_MODE_CTR:
-		ctx->cr |= SET_CHAINING_MODE(CTR, ctx->cr);
+		ctx->cr = SET_CHAINING_MODE(CTR, ctx->cr);
 		break;
 	case STM32_SAES_MODE_GCM:
-		ctx->cr |= SET_CHAINING_MODE(GCM, ctx->cr);
+		ctx->cr = SET_CHAINING_MODE(GCM, ctx->cr);
 		break;
 	case STM32_SAES_MODE_CCM:
-		ctx->cr |= SET_CHAINING_MODE(CCM, ctx->cr);
+		ctx->cr = SET_CHAINING_MODE(CCM, ctx->cr);
 		break;
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -603,8 +603,8 @@ TEE_Result stm32_saes_init(struct stm32_saes_context *ctx, bool is_dec,
 	 *
 	 * But note that wrap key only accept _SAES_CR_DATATYPE_NONE.
 	 */
-	ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_DATATYPE_MASK,
-				 _SAES_CR_DATATYPE_BYTE);
+	ctx->cr = set_field_u32(ctx->cr, _SAES_CR_DATATYPE_MASK,
+				_SAES_CR_DATATYPE_BYTE);
 
 	/* Configure keysize */
 	switch (key_size) {
@@ -621,9 +621,8 @@ TEE_Result stm32_saes_init(struct stm32_saes_context *ctx, bool is_dec,
 	/* Configure key */
 	switch (key_select) {
 	case STM32_SAES_KEY_SOFT:
-		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 SHIFT_U32(_SAES_CR_KEYSEL_SOFT,
-						   _SAES_CR_KEYSEL_SHIFT));
+		ctx->cr = set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
+					_SAES_CR_KEYSEL_SOFT);
 		/* Save key */
 		switch (key_size) {
 		case AES_KEYSIZE_128:
@@ -654,24 +653,20 @@ TEE_Result stm32_saes_init(struct stm32_saes_context *ctx, bool is_dec,
 		}
 		break;
 	case STM32_SAES_KEY_DHU:
-		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 SHIFT_U32(_SAES_CR_KEYSEL_DHUK,
-						   _SAES_CR_KEYSEL_SHIFT));
+		ctx->cr = set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
+					_SAES_CR_KEYSEL_DHUK);
 		break;
 	case STM32_SAES_KEY_BH:
-		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 SHIFT_U32(_SAES_CR_KEYSEL_BHK,
-						   _SAES_CR_KEYSEL_SHIFT));
+		ctx->cr = set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
+					_SAES_CR_KEYSEL_BHK);
 		break;
 	case STM32_SAES_KEY_BHU_XOR_BH:
-		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 SHIFT_U32(_SAES_CR_KEYSEL_BHU_XOR_BH_K,
-						   _SAES_CR_KEYSEL_SHIFT));
+		ctx->cr = set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
+					_SAES_CR_KEYSEL_BHU_XOR_BH_K);
 		break;
 	case STM32_SAES_KEY_WRAPPED:
-		ctx->cr |= set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
-					 SHIFT_U32(_SAES_CR_KEYSEL_SOFT,
-						   _SAES_CR_KEYSEL_SHIFT));
+		ctx->cr = set_field_u32(ctx->cr, _SAES_CR_KEYSEL_MASK,
+					_SAES_CR_KEYSEL_SOFT);
 		break;
 
 	default:


### PR DESCRIPTION
set_field_u32() is a function that allows you to change a specific bit in a register by using a mask. The function returns the full value of the register, which means that the use of bitwise OR here is a mistake. The current code works here only because the modified registers are initialized. Moreover, there is no need to shift the value as the function already doing it.

Fix the usage of the function in the SAES driver by replacing bitwise OR assignments with simple assignments.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
