### PR TITLE
More improvements for RISC-V

### DIFF
--- a/core/arch/riscv/include/kernel/thread_private_arch.h
+++ b/core/arch/riscv/include/kernel/thread_private_arch.h
@@ -51,11 +51,11 @@ struct thread_user_mode_rec {
 	unsigned long pad;
 	/*
 	 * x[] is used to save registers for user/kernel context-switching
-	 * 0-3: ra-tp
-	 * 4-6: s0-s1
-	 * 6-15: s2-s11
+	 * 0: ra
+	 * 1-2: s0-s1
+	 * 3-12: s2-s11
 	 */
-	unsigned long x[16];
+	unsigned long x[13];
 };
 
 extern long thread_user_kcode_offset;

--- a/core/arch/riscv/kernel/asm-defines.c
+++ b/core/arch/riscv/kernel/asm-defines.c
@@ -55,14 +55,12 @@ DEFINES
 	/* struct thread_user_mode_rec */
 	DEFINE(THREAD_USER_MODE_REC_CTX_REGS_PTR,
 	       offsetof(struct thread_user_mode_rec, ctx_regs_ptr));
-	DEFINE(THREAD_USER_MODE_REC_X1,
+	DEFINE(THREAD_USER_MODE_REC_RA,
 	       offsetof(struct thread_user_mode_rec, x[0]));
-	DEFINE(THREAD_USER_MODE_REC_X4,
+	DEFINE(THREAD_USER_MODE_REC_S0,
+	       offsetof(struct thread_user_mode_rec, x[1]));
+	DEFINE(THREAD_USER_MODE_REC_S2,
 	       offsetof(struct thread_user_mode_rec, x[3]));
-	DEFINE(THREAD_USER_MODE_REC_X8,
-	       offsetof(struct thread_user_mode_rec, x[4]));
-	DEFINE(THREAD_USER_MODE_REC_X18,
-	       offsetof(struct thread_user_mode_rec, x[6]));
 	DEFINE(THREAD_USER_MODE_REC_SIZE, sizeof(struct thread_user_mode_rec));
 
 	/* struct thread_abort_regs */

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -148,12 +148,12 @@ native_interrupt_from_kernel:
 	/* Restore XEPC */
 	load_xregs sp, THREAD_CTX_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
-	/* Restore XIE */
-	load_xregs sp, THREAD_CTX_REG_IE, REG_T0
-	csrw	CSR_XIE, t0
 	/* Restore XSTATUS */
 	load_xregs sp, THREAD_CTX_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
+	/* Restore XIE */
+	load_xregs sp, THREAD_CTX_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
 	/* We are going to XRET to kernel mode. Set XSCRATCH as 0 */
 	csrw	CSR_XSCRATCH, 0
 	/* Restore all GPRs */
@@ -246,12 +246,12 @@ set_sp:
 	/* Restore XEPC */
 	load_xregs sp, THREAD_ABT_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
-	/* Restore XIE */
-	load_xregs sp, THREAD_ABT_REG_IE, REG_T0
-	csrw	CSR_XIE, t0
 	/* Restore XSTATUS */
 	load_xregs sp, THREAD_ABT_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
+	/* Restore XIE */
+	load_xregs sp, THREAD_ABT_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
 	/* We are going to XRET to kernel mode. Set XSCRATCH as 0 */
 	csrw	CSR_XSCRATCH, 0
 
@@ -385,12 +385,12 @@ native_interrupt_from_user:
 	/* Restore XEPC */
 	load_xregs sp, THREAD_CTX_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
-	/* Restore XIE */
-	load_xregs sp, THREAD_CTX_REG_IE, REG_T0
-	csrw	CSR_XIE, t0
 	/* Restore XSTATUS */
 	load_xregs sp, THREAD_CTX_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
+	/* Restore XIE */
+	load_xregs sp, THREAD_CTX_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
 	/* Set scratch as thread_core_local */
 	csrw	CSR_XSCRATCH, tp
 	/* Restore all GPRs */
@@ -475,13 +475,14 @@ ecall_from_user:
 	/* Restore XEPC */
 	load_xregs sp, THREAD_SCALL_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
-	/* Restore XIE */
-	load_xregs sp, THREAD_SCALL_REG_IE, REG_T0
-	csrw	CSR_XIE, t0
 	/* Restore XSTATUS */
 	load_xregs sp, THREAD_SCALL_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
+	/* Restore XIE */
+	load_xregs sp, THREAD_SCALL_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
 	/* Check previous privilege mode by status.SPP */
+	csrr	t0, CSR_XSTATUS
 	b_if_prev_priv_is_u t0, 1f
 	/*
 	 * We are going to XRET to kernel mode.
@@ -588,12 +589,12 @@ abort_from_user:
 	/* Restore XEPC */
 	load_xregs sp, THREAD_ABT_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
-	/* Restore XIE */
-	load_xregs sp, THREAD_ABT_REG_IE, REG_T0
-	csrw	CSR_XIE, t0
 	/* Restore XSTATUS */
 	load_xregs sp, THREAD_ABT_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
+	/* Restore XIE */
+	load_xregs sp, THREAD_ABT_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
 
 	/* Update core local flags */
 	lw	a0, THREAD_CORE_LOCAL_FLAGS(tp)
@@ -601,6 +602,7 @@ abort_from_user:
 	sw	a0, THREAD_CORE_LOCAL_FLAGS(tp)
 
 	/* Check previous privilege mode by status.SPP */
+	csrr	t0, CSR_XSTATUS
 	b_if_prev_priv_is_u t0, 1f
 	/*
 	 * We are going to XRET to kernel mode.
@@ -665,9 +667,6 @@ END_FUNC thread_unwind_user_mode
  *				     uint32_t *exit_status1);
  */
 FUNC __thread_enter_user_mode , :
-	/* Disable kernel mode exceptions first */
-	csrc	CSR_XSTATUS, CSR_XSTATUS_IE
-
 	/*
 	 * Create and fill in the struct thread_user_mode_rec
 	 */
@@ -702,12 +701,12 @@ FUNC __thread_enter_user_mode , :
 	/* Set exception return PC */
 	load_xregs sp, THREAD_CTX_REG_EPC, REG_S0
 	csrw	CSR_XEPC, s0
-	/* Set user ie */
-	load_xregs sp, THREAD_CTX_REG_IE, REG_S0
-	csrw	CSR_XIE, s0
 	/* Set user status */
 	load_xregs sp, THREAD_CTX_REG_STATUS, REG_S0
 	csrw	CSR_XSTATUS, s0
+	/* Set user ie */
+	load_xregs sp, THREAD_CTX_REG_IE, REG_S0
+	csrw	CSR_XIE, s0
 	/* Load the rest of the general purpose registers */
 	load_xregs sp, THREAD_CTX_REG_RA, REG_RA
 	load_xregs sp, THREAD_CTX_REG_GP, REG_GP
@@ -725,23 +724,21 @@ END_FUNC __thread_enter_user_mode
 
 /* void thread_resume(struct thread_ctx_regs *regs) */
 FUNC thread_resume , :
-	/* Disable global interrupts first */
-	csrc	CSR_XSTATUS, CSR_XSTATUS_IE
-
 	/* Move struct thread_ctx_regs *regs to sp to reduce code size */
 	mv	sp, a0
 
 	/* Restore epc */
 	load_xregs sp, THREAD_CTX_REG_EPC, REG_T0
 	csrw	CSR_XEPC, t0
-	/* Restore ie */
-	load_xregs sp, THREAD_CTX_REG_IE, REG_T0
-	csrw	CSR_XIE, t0
 	/* Restore status */
 	load_xregs sp, THREAD_CTX_REG_STATUS, REG_T0
 	csrw	CSR_XSTATUS, t0
+	/* Restore ie */
+	load_xregs sp, THREAD_CTX_REG_IE, REG_T0
+	csrw	CSR_XIE, t0
 
 	/* Check if previous privilege mode by status.SPP */
+	csrr	t0, CSR_XSTATUS
 	b_if_prev_priv_is_u t0, 1f
 	/* Set scratch as zero to indicate that we are in kernel mode */
 	csrw	CSR_XSCRATCH, zero

--- a/core/arch/riscv/kernel/thread_rv.S
+++ b/core/arch/riscv/kernel/thread_rv.S
@@ -633,30 +633,22 @@ END_FUNC trap_from_user
 
 /*
  * void thread_unwind_user_mode(uint32_t ret, uint32_t exit_status0,
- * 		uint32_t exit_status1);
+ * 				uint32_t exit_status1);
  * See description in thread.h
  */
 FUNC thread_unwind_user_mode , :
-
 	/* Store the exit status */
 	load_xregs sp, THREAD_USER_MODE_REC_CTX_REGS_PTR, REG_A3, REG_A5
 	sw	a1, (a4)
 	sw	a2, (a5)
-
-	/* Save user callee regs */
+	/* Save user callee-saved regs */
 	store_xregs a3, THREAD_CTX_REG_S0, REG_S0, REG_S1
 	store_xregs a3, THREAD_CTX_REG_S2, REG_S2, REG_S11
-	store_xregs a3, THREAD_CTX_REG_SP, REG_SP, REG_TP
-
-	/* Restore kernel callee regs */
-	mv	a1, sp
-
-	load_xregs a1, THREAD_USER_MODE_REC_X1, REG_RA, REG_GP
-	load_xregs a1, THREAD_USER_MODE_REC_X8, REG_S0, REG_S1
-	load_xregs a1, THREAD_USER_MODE_REC_X18, REG_S2, REG_S11
-
+	/* Restore kernel ra(thread_enter_user_mode()) & callee-saved regs */
+	load_xregs sp, THREAD_USER_MODE_REC_RA, REG_RA
+	load_xregs sp, THREAD_USER_MODE_REC_S0, REG_S0, REG_S1
+	load_xregs sp, THREAD_USER_MODE_REC_S2, REG_S2, REG_S11
 	add	sp, sp, THREAD_USER_MODE_REC_SIZE
-
 	/* Return from the call of thread_enter_user_mode() */
 	ret
 END_FUNC thread_unwind_user_mode
@@ -672,9 +664,9 @@ FUNC __thread_enter_user_mode , :
 	 */
 	addi	sp, sp, -THREAD_USER_MODE_REC_SIZE
 	store_xregs sp, THREAD_USER_MODE_REC_CTX_REGS_PTR, REG_A0, REG_A2
-	store_xregs sp, THREAD_USER_MODE_REC_X1, REG_RA, REG_GP
-	store_xregs sp, THREAD_USER_MODE_REC_X8, REG_S0, REG_S1
-	store_xregs sp, THREAD_USER_MODE_REC_X18, REG_S2, REG_S11
+	store_xregs sp, THREAD_USER_MODE_REC_RA, REG_RA
+	store_xregs sp, THREAD_USER_MODE_REC_S0, REG_S0, REG_S1
+	store_xregs sp, THREAD_USER_MODE_REC_S2, REG_S2, REG_S11
 
 	/*
 	 * Save the kernel stack pointer in the thread context


### PR DESCRIPTION
- Commit "core: riscv: Ensure XSTATUS is restored before XIE"
avoids accidental interrupt during register restoring.
- Commit "core: riscv: Improve thread user mode record"
improves register save/restore during entering/existing user mode. 

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
