### PR TITLE
Add support for NanoPC-T6

### DIFF
--- a/core/arch/arm/plat-rockchip/conf.mk
+++ b/core/arch/arm/plat-rockchip/conf.mk
@@ -56,6 +56,24 @@ CFG_SHMEM_SIZE   ?= 0x00400000
 CFG_EARLY_CONSOLE ?= n
 endif
 
+ifeq ($(PLATFORM_FLAVOR),rk3588)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,8)  # Number of cores in the platform
+$(call force,CFG_ARM_GICV3,y)
+$(call force,CFG_CRYPTO_WITH_CE,y)
+
+CFG_TZDRAM_START ?= 0x08400000
+CFG_TZDRAM_SIZE ?= 0x02000000
+CFG_SHMEM_START ?= 0x0a4000000
+CFG_SHMEM_SIZE ?= 0x00400000
+
+CFG_EARLY_CONSOLE ?= y
+CFG_EARLY_CONSOLE_BASE ?= UART2_BASE
+CFG_EARLY_CONSOLE_SIZE ?= UART2_SIZE
+CFG_EARLY_CONSOLE_BAUDRATE ?= 1500000
+CFG_EARLY_CONSOLE_CLK_IN_HZ ?= 24000000
+endif
+
 ifeq ($(platform-flavor-armv8),1)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)

--- a/core/arch/arm/plat-rockchip/platform_config.h
+++ b/core/arch/arm/plat-rockchip/platform_config.h
@@ -85,6 +85,32 @@
 #define FIREWALL_DDR_BASE	0xff534000
 #define FIREWALL_DDR_SIZE	SIZE_K(16)
 
+#elif defined(PLATFORM_FLAVOR_rk3588)
+
+#define GIC_BASE		0xfe600000
+#define GIC_SIZE		SIZE_K(64)
+#define GICC_BASE		0
+#define GICD_BASE		GIC_BASE
+#define GICR_BASE		(GIC_BASE + 0x80000)
+
+#define UART0_BASE		0xfd890000
+#define UART0_SIZE		SIZE_K(64)
+
+#define UART1_BASE		0xfeb40000
+#define UART1_SIZE		SIZE_K(64)
+
+#define UART2_BASE		0xfeb50000
+#define UART2_SIZE		SIZE_K(64)
+
+#define UART3_BASE		0xfeb60000
+#define UART3_SIZE		SIZE_K(64)
+
+#define SGRF_BASE		0xfd58c000
+#define SGRF_SIZE		SIZE_K(64)
+
+#define FIREWALL_DDR_BASE	0xfe030000
+#define FIREWALL_DDR_SIZE	SIZE_K(32)
+
 #else
 #error "Unknown platform flavor"
 #endif

--- a/core/arch/arm/plat-rockchip/platform_rk3588.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3588.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2019, Theobroma Systems Design und Consulting GmbH
+ */
+
+#include <common.h>
+#include <io.h>
+#include <kernel/panic.h>
+#include <mm/core_memprot.h>
+#include <platform.h>
+#include <platform_config.h>
+
+#define SGRF_DDRRGN_CON0_16(n)		((n) * 4)
+#define SGRF_DDR_RGN_0_16_WMSK		GENMASK_32(11, 0)
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, SGRF_BASE, SGRF_SIZE);
+
+int platform_secure_ddr_region(int rgn, paddr_t st, size_t sz)
+{
+	vaddr_t sgrf_base = (vaddr_t)phys_to_virt_io(SGRF_BASE, SGRF_SIZE);
+	paddr_t ed = st + sz;
+	uint32_t st_mb = st / SIZE_M(1);
+	uint32_t ed_mb = ed / SIZE_M(1);
+
+	if (!sgrf_base)
+		panic();
+
+	assert(rgn <= 7);
+	assert(st < ed);
+
+	/* Check aligned 1MB */
+	assert(st % SIZE_M(1) == 0);
+	assert(ed % SIZE_M(1) == 0);
+
+	DMSG("protecting region %d: 0x%lx-0x%lx", rgn, st, ed);
+
+	/* Set ddr region addr start */
+	io_write32(sgrf_base + SGRF_DDRRGN_CON0_16(rgn),
+		   BITS_WITH_WMASK(st_mb, SGRF_DDR_RGN_0_16_WMSK, 0));
+
+	/* Set ddr region addr end */
+	io_write32(sgrf_base + SGRF_DDRRGN_CON0_16(rgn + 8),
+		   BITS_WITH_WMASK((ed_mb - 1), SGRF_DDR_RGN_0_16_WMSK, 0));
+
+	io_write32(sgrf_base + SGRF_DDRRGN_CON0_16(16),
+		   BIT_WITH_WMSK(rgn));
+
+	return 0;
+}

--- a/core/arch/arm/plat-rockchip/sub.mk
+++ b/core/arch/arm/plat-rockchip/sub.mk
@@ -4,6 +4,7 @@ srcs-y += platform.c
 srcs-$(PLATFORM_FLAVOR_px30) += platform_px30.c
 srcs-$(PLATFORM_FLAVOR_rk322x) += platform_rk322x.c
 srcs-$(PLATFORM_FLAVOR_rk3399) += platform_rk3399.c
+srcs-$(PLATFORM_FLAVOR_rk3588) += platform_rk3588.c
 
 ifeq ($(PLATFORM_FLAVOR),rk322x)
 srcs-y += plat_init.S


### PR DESCRIPTION
Added support for the RK3588 to enable NanoPC-T6, based on the ROCK4 platform. NanoPC-T6 will also be added to the manifest and build repositories:
https://github.com/edtubbs/manifest/tree/nanopc-t6
https://github.com/edtubbs/build/tree/nanopc-t6