### PR TITLE
notif: fix build when NS_VIRTIALIZATION is enabled

### DIFF
--- a/core/kernel/notif.c
+++ b/core/kernel/notif.c
@@ -154,6 +154,16 @@ out:
 	mutex_unlock(&notif_mutex);
 	virt_put_guest(prtn);
 }
+
+#ifdef CFG_NS_VIRTUALIZATION
+static TEE_Result nex_init_notif(void)
+{
+	return virt_add_guest_spec_data(&notif_data_id,
+					sizeof(struct notif_data), NULL);
+}
+nex_early_init(nex_init_notif);
+#endif
+
 #endif /*CFG_CORE_ASYNC_NOTIF*/
 
 static TEE_Result notif_rpc(uint32_t func, uint32_t value1, uint32_t value2)
@@ -179,11 +189,3 @@ TEE_Result notif_wait_timeout(uint32_t value, uint32_t timeout_ms)
 	return notif_rpc(OPTEE_RPC_NOTIFICATION_WAIT, value, timeout_ms);
 }
 
-#ifdef CFG_NS_VIRTUALIZATION
-static TEE_Result nex_init_notif(void)
-{
-	return virt_add_guest_spec_data(&notif_data_id,
-					sizeof(struct notif_data), NULL);
-}
-nex_early_init(nex_init_notif);
-#endif


### PR DESCRIPTION
Right now OP-TEE build fails if CFG_NS_VIRTUALIZATION=y and CFG_CORE_ASYNC_NOTIF=n with the following error:

core/kernel/notif.c: In function 'nex_init_notif': core/kernel/notif.c:185:42: error: 'notif_data_id' undeclared (first use in this function); did you mean 'notif_wait'?
  185 |         return virt_add_guest_spec_data(&notif_data_id,
      |                                          ^~~~~~~~~~~~~
      |                                          notif_wait
core/kernel/notif.c:185:42: note: each undeclared identifier is reported only once for each function it appears in
core/kernel/notif.c:186:48: error: invalid application of 'sizeof' to incomplete type 'struct notif_data'
  186 |                                         sizeof(struct notif_data), NULL);
      |                                                ^~~~~~
core/kernel/notif.c:187:1: warning: control reaches end of non-void function [-Wreturn-type]
  187 | }
      | ^

Move `#ifdef CFG_NS_VIRTUALIZATION` section under
`#ifdef CFG_CORE_ASYNC_NOTIF` to fix this.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
