### PR TITLE
ci: qemuv7: exclude xtest pkcs11_1007

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
           ln -s ${WD} ${TOP}/optee_os
           cd ${TOP}/build
 
-          make -j$(nproc) check CFG_LOCKDEP=y CFG_LOCKDEP_RECORD_STACK=n CFG_IN_TREE_EARLY_TAS=pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee CFG_PKCS11_TA=y
+          make -j$(nproc) check CFG_LOCKDEP=y CFG_LOCKDEP_RECORD_STACK=n CFG_IN_TREE_EARLY_TAS=pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee CFG_PKCS11_TA=y XTEST_ARGS="-x pkcs11_1007"
 
   QEMUv8_check:
     name: make check (QEMUv8)


### PR DESCRIPTION
Exclude xtest case pkcs11_1007 from qemuv7 CI tests since we're facing sporadic failures on this test on PKCS#11 sessions opening and release. Occurrences of this issue have been found only on this Armv7-A platform. Once the issue is solved, we be able to restore this test.

Link: https://github.com/OP-TEE/optee_os/issues/6952

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
