### PR TITLE
Introduce RD-1 AE Platform

### DIFF
--- a/core/arch/arm/cpu/cortex-armv9.mk
+++ b/core/arch/arm/cpu/cortex-armv9.mk
@@ -1,0 +1,14 @@
+$(call force,CFG_HWSUPP_MEM_PERM_WXN,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_ENABLE_SCTLR_RR,n)
+$(call force,CFG_ENABLE_SCTLR_Z,n)
+
+arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-aflags 	+= -mcpu=$(arm32-platform-cpuarch)
+arm32-platform-cxxflags	+= -mcpu=$(arm32-platform-cpuarch)
+
+arm64-platform-cflags 	+= -mcpu=$(arm64-platform-cpuarch)
+arm64-platform-aflags 	+= -mcpu=$(arm64-platform-cpuarch)
+arm64-platform-cxxflags	+= -mcpu=$(arm64-platform-cpuarch)
+
+platform-flavor-armv9 	:= 1

--- a/core/arch/arm/cpu/neoverse-v2.mk
+++ b/core/arch/arm/cpu/neoverse-v2.mk
@@ -1,0 +1,4 @@
+arm32-platform-cpuarch 	:= neoverse-v2
+arm64-platform-cpuarch 	:= neoverse-v2
+
+include core/arch/arm/cpu/cortex-armv9.mk

--- a/core/arch/arm/plat-rd1ae/conf.mk
+++ b/core/arch/arm/plat-rd1ae/conf.mk
@@ -1,0 +1,27 @@
+# RD-1 AE is based on Neoverse V3AE CPU, but there is
+# no compiler support for it yet. Use Neoverse V2 until
+# it becomes available.
+include core/arch/arm/cpu/neoverse-v2.mk
+
+# ARM debugger needs this
+platform-cflags-debug-info = -gdwarf-4
+platform-aflags-debug-info = -gdwarf-4
+
+$(call force,CFG_ARM64_core,y)
+
+$(call force,CFG_ARM_GICV3,y)
+
+CFG_CORE_SEL1_SPMC      ?= y
+CFG_WITH_ARM_TRUSTED_FW	?= y
+CFG_CORE_RESERVED_SHM   ?= n
+
+$(call force,CFG_GIC,y)
+$(call force,CFG_PL011,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,42)
+$(call force,CFG_TEE_CORE_NB_CORE,16)
+
+CFG_CORE_HEAP_SIZE ?= 0x32000
+
+CFG_TZDRAM_START ?= 0xFFC00000
+CFG_TZDRAM_SIZE  ?= 0x00400000

--- a/core/arch/arm/plat-rd1ae/main.c
+++ b/core/arch/arm/plat-rd1ae/main.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024, Arm Limited
+ */
+
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/pl011.h>
+#include <kernel/boot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <trace.h>
+
+static struct pl011_data console_data __nex_bss;
+
+register_ddr(DRAM0_BASE, DRAM0_SIZE);
+register_ddr(DRAM1_BASE, DRAM1_SIZE);
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
+
+void boot_primary_init_intc(void)
+{
+	gic_init(GICC_BASE, GICD_BASE);
+}
+
+void boot_secondary_init_intc(void)
+{
+	gic_init_per_cpu();
+}
+
+void plat_console_init(void)
+{
+	pl011_init(&console_data, CONSOLE_UART_BASE, CONSOLE_UART_CLK_IN_HZ,
+		   CONSOLE_BAUDRATE);
+	register_serial_console(&console_data.chip);
+}

--- a/core/arch/arm/plat-rd1ae/platform_config.h
+++ b/core/arch/arm/plat-rd1ae/platform_config.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Arm Limited
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT			64
+
+#define DRAM0_BASE			UL(0x80000000)
+#define DRAM0_SIZE			UL(0x80000000)
+
+#define DRAM1_BASE			ULL(0x8080000000)
+#define DRAM1_SIZE			ULL(0x80000000)
+
+#define SYS_COUNTER_FREQ_IN_TICKS	UL(7372800)
+
+#define UART0_BASE			UL(0x2A400000)
+#define UART1_BASE			UL(0x2A410000)
+#define CONSOLE_UART_BASE		UART1_BASE
+#define UART_BAUDRATE			115200
+#define CONSOLE_BAUDRATE		UART_BAUDRATE
+#define CONSOLE_UART_CLK_IN_HZ		UL(7372800)
+
+/* GIC related constants */
+#define GICD_BASE			UL(0x30000000)
+#define GICC_BASE			UL(0x2C000000)
+
+ /* RD-1 AE topology related constants */
+#define RD1AE_MAX_CPUS_PER_CLUSTER	U(1)
+#define PLAT_ARM_CLUSTER_COUNT		U(1)
+#define PLAT_RD1AE_CHIP_COUNT		U(1)
+#define RD1AE_MAX_CLUSTERS_PER_CHIP	U(16)
+#define RD1AE_MAX_PE_PER_CPU		U(1)
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-rd1ae/rd1ae_core_pos.S
+++ b/core/arch/arm/plat-rd1ae/rd1ae_core_pos.S
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Arm Limited
+ */
+
+#include <asm.S>
+#include <arm.h>
+#include "platform_config.h"
+
+FUNC get_core_pos_mpidr , :
+        mov     x4, x0
+
+        /*
+         * The MT bit in MPIDR is always set for n1sdp and the
+         * affinity level 0 corresponds to thread affinity level.
+         */
+
+        /* Extract individual affinity fields from MPIDR */
+        ubfx    x0, x4, #MPIDR_AFF0_SHIFT, #MPIDR_AFFINITY_BITS
+        ubfx    x1, x4, #MPIDR_AFF1_SHIFT, #MPIDR_AFFINITY_BITS
+        ubfx    x2, x4, #MPIDR_AFF2_SHIFT, #MPIDR_AFFINITY_BITS
+        ubfx    x3, x4, #MPIDR_AFF3_SHIFT, #MPIDR_AFFINITY_BITS
+
+        /* Compute linear position */
+        mov     x4, #RD1AE_MAX_CLUSTERS_PER_CHIP
+        madd    x2, x3, x4, x2
+        mov     x4, #RD1AE_MAX_CPUS_PER_CLUSTER
+        madd    x1, x2, x4, x1
+        mov     x4, #RD1AE_MAX_PE_PER_CPU
+        madd    x0, x1, x4, x0
+        ret
+END_FUNC get_core_pos_mpidr

--- a/core/arch/arm/plat-rd1ae/sub.mk
+++ b/core/arch/arm/plat-rd1ae/sub.mk
@@ -1,0 +1,3 @@
+global-incdirs-y += .
+srcs-y += main.c
+srcs-y	+= rd1ae_core_pos.S

--- a/core/drivers/gic.c
+++ b/core/drivers/gic.c
@@ -508,7 +508,7 @@ static void gic_init_base_addr(paddr_t gicc_base_pa, paddr_t gicd_base_pa,
 	vers &= GICD_PIDR2_ARCHREV_MASK;
 
 	if (IS_ENABLED(CFG_ARM_GICV3)) {
-		assert(vers == 3);
+		assert(vers == 4 || vers == 3);
 	} else {
 		assert(vers == 2 || vers == 1);
 		gicc_base = core_mmu_get_va(gicc_base_pa, MEM_AREA_IO_SEC,


### PR DESCRIPTION
1- Add initial support for RD-1 AE platform, this includes:
a- GIC and console initialization functions.
b- Memory layout.
c- Make files.
d- Assembly function get_core_pos_mpidr to compute the linear core position from MPIDR.

2- Accept GIC version 4 if CFG_ARM_GICV3 is enabled