### PR TITLE
core: cache some embedded DT info + generic bisect helper function

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -411,3 +411,7 @@ CFG_STM32_DEBUG_ACCESS ?= $(CFG_TEE_CORE_DEBUG)
 ifeq ($(call cfg-all-enabled,CFG_STM32MP15 CFG_STM32MP13),y)
 $(error CFG_STM32MP13_CLK and CFG_STM32MP15_CLK are exclusive)
 endif
+
+# Enabling CFG_DT_CACHED_NODE_INFO saves few hundreds of millisecond
+# at boot time.
+CFG_DT_CACHED_NODE_INFO ?= y

--- a/core/arch/arm/plat-stm32mp2/conf.mk
+++ b/core/arch/arm/plat-stm32mp2/conf.mk
@@ -104,3 +104,8 @@ endif
 
 # Default enable firewall support
 CFG_DRIVERS_FIREWALL ?= y
+
+# Enabling CFG_DT_CACHED_NODE_INFO saves few hundreds of millisecond
+# at boot time.
+CFG_DT_CACHED_NODE_INFO ?= y
+

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -511,6 +511,15 @@ int fdt_find_cached_parent_node(const void *fdt, int node_offset,
  */
 int fdt_find_cached_parent_reg_cells(const void *fdt, int node_offset,
 				     int *address_cells, int *size_cells);
+/*
+ * Find the node offset from its phandle in the phandle cache
+ * @fdt: FDT to work on
+ * @phandle: Node phandle
+ * @node_offset: Pointer to output node offset upon success
+ * @return 0 on success and -FDT_ERR_NOTFOUND on failure
+ */
+int fdt_find_cached_node_phandle(const void *fdt, uint32_t phandle,
+				 int *node_offset);
 #else
 static inline int fdt_find_cached_parent_node(const void *fdt __unused,
 					      int node_offset __unused,
@@ -523,6 +532,13 @@ static inline int fdt_find_cached_parent_reg_cells(const void *fdt __unused,
 						   int node_offset __unused,
 						   int *address_cells __unused,
 						   int *size_cells __unused)
+{
+	return -1;
+}
+
+static inline int fdt_find_cached_node_phandle(const void *fdt __unused,
+					       uint32_t phandle __unused,
+					       int *node_offset __unused)
 {
 	return -1;
 }

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -489,4 +489,42 @@ static inline void *get_manifest_dt(void)
 }
 
 #endif /* !CFG_DT */
+
+#ifdef CFG_DT_CACHED_NODE_INFO
+/*
+ * Find the offset of a parent node in the parent node cache
+ * @fdt: FDT to work on
+ * @node_offset: Offset of the node we look for its parent
+ * @parent_offset: Output parent node offset upon success
+ * @return 0 on success and -1 on failure
+ */
+int fdt_find_cached_parent_node(const void *fdt, int node_offset,
+				int *parent_offset);
+
+/*
+ * Find the address/size cells value of a parent node in the parent node cache
+ * @fdt: FDT to work on
+ * @node_offset: Offset of the node we look for its parent
+ * @address_cells: Pointer to output #address-cells value upon success or NULL
+ * @size_cells: Pointer to output #size-cells value upon success or NULL
+ * @return 0 on success and -FDT_ERR_NOTFOUND on failure
+ */
+int fdt_find_cached_parent_reg_cells(const void *fdt, int node_offset,
+				     int *address_cells, int *size_cells);
+#else
+static inline int fdt_find_cached_parent_node(const void *fdt __unused,
+					      int node_offset __unused,
+					      int *parent_offset __unused)
+{
+	return -1;
+}
+
+static inline int fdt_find_cached_parent_reg_cells(const void *fdt __unused,
+						   int node_offset __unused,
+						   int *address_cells __unused,
+						   int *size_cells __unused)
+{
+	return -1;
+}
+#endif /* CFG_DT_CACHED_NODE_INFO */
 #endif /* __KERNEL_DT_H */

--- a/core/kernel/dt.c
+++ b/core/kernel/dt.c
@@ -496,8 +496,12 @@ void *get_secure_dt(void)
 	return fdt;
 }
 
+#if defined(CFG_EMBED_DTB)
 #ifdef CFG_DT_CACHED_NODE_INFO
-/* Reference to the FDT for which node information are cached */
+/*
+ * Reference to the embedded DT for which node information are cached
+ * when CFG_DT_CACHED_NODE_INFO is enabled.
+ */
 static const void *cached_node_info_fdt;
 
 /*
@@ -796,7 +800,6 @@ static void init_cached_node_info(const void *fdt __unused)
 }
 #endif /* CFG_DT_CACHED_NODE_INFO */
 
-#if defined(CFG_EMBED_DTB)
 void *get_embedded_dt(void)
 {
 	static bool checked;

--- a/core/lib/libfdt/fdt_ro.c
+++ b/core/lib/libfdt/fdt_ro.c
@@ -677,12 +677,31 @@ int fdt_node_offset_by_prop_value(const void *fdt, int startoffset,
 	return offset; /* error from fdt_next_node() */
 }
 
+#ifdef CFG_DT_CACHED_NODE_INFO
+/* This function is OP-TEE specific, outside of libfdt */
+int fdt_find_cached_node_phandle(const void *fdt, uint32_t phandle,
+				 int *node_offset);
+#else
+static int fdt_find_cached_node_phandle(const void *fdt, uint32_t phandle,
+					int *node_offset)
+{
+	(void)fdt;
+	(void)phandle;
+	(void)node_offset;
+
+	return -1;
+}
+#endif
+
 int fdt_node_offset_by_phandle(const void *fdt, uint32_t phandle)
 {
 	int offset;
 
 	if ((phandle == 0) || (phandle == -1))
 		return -FDT_ERR_BADPHANDLE;
+
+	if (fdt_find_cached_node_phandle(fdt, phandle, &offset) == 0)
+		return offset;
 
 	FDT_RO_PROBE(fdt);
 

--- a/core/lib/libfdt/fdt_ro.c
+++ b/core/lib/libfdt/fdt_ro.c
@@ -489,6 +489,7 @@ uint32_t fdt_get_phandle(const void *fdt, int nodeoffset)
 	const fdt32_t *php;
 	int len;
 
+
 	/* FIXME: This is a bit sub-optimal, since we potentially scan
 	 * over all the properties twice. */
 	php = fdt_getprop(fdt, nodeoffset, "phandle", &len);
@@ -617,9 +618,31 @@ int fdt_node_depth(const void *fdt, int nodeoffset)
 	return nodedepth;
 }
 
+#ifdef CFG_DT_CACHED_NODE_INFO
+/* This function is OP-TEE specific, outside of libfdt */
+int fdt_find_cached_parent_node(const void *fdt, int node_offset,
+				int *parent_offset);
+#else
+static int fdt_find_cached_parent_node(const void *fdt, int node_offset,
+				       int *parent_offset)
+{
+	(void)fdt;
+	(void)node_offset;
+	(void)parent_offset;
+
+	return -1;
+}
+#endif
+
 int fdt_parent_offset(const void *fdt, int nodeoffset)
 {
-	int nodedepth = fdt_node_depth(fdt, nodeoffset);
+	int parent_offset = 0;
+	int nodedepth = 0;
+
+	if (fdt_find_cached_parent_node(fdt, nodeoffset, &parent_offset) == 0)
+		return parent_offset;
+
+	nodedepth = fdt_node_depth(fdt, nodeoffset);
 
 	if (nodedepth < 0)
 		return nodedepth;

--- a/lib/libutils/isoc/bisect.c
+++ b/lib/libutils/isoc/bisect.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024, STMicroelectronics
+ */
+
+#include <bisect.h>
+
+void *bisect_equal(const void *array, size_t n, size_t cell_size,
+		   const void *target, int (*cmp)(const void *, const void *))
+{
+	const uint8_t *array_base = array;
+	size_t high_index = 0;
+	size_t low_index = 0;
+
+	if (!array || !n)
+		return NULL;
+
+	high_index = n - 1;
+
+	if (cmp(array_base + high_index * cell_size, target) < 0)
+		return NULL;
+	if (cmp(array_base + low_index * cell_size, target) > 0)
+		return NULL;
+
+	while (high_index > low_index) {
+		size_t index = (high_index + low_index) / 2;
+		int diff = cmp(array_base + index * cell_size, target);
+
+		if (!diff)
+			return (void *)(array_base + index * cell_size);
+
+		if (diff > 0)
+			high_index = index - 1;
+		else
+			low_index = index + 1;
+	}
+
+	if (cmp(array_base + low_index * cell_size, target) == 0)
+		return (void *)(array_base + low_index * cell_size);
+
+	return NULL;
+}

--- a/lib/libutils/isoc/include/bisect.h
+++ b/lib/libutils/isoc/include/bisect.h
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, STMicroelectronics
+ */
+#ifndef __BISECT_H
+#define __BISECT_H
+
+#include <stddef.h>
+#include <stdlib.h>
+
+/*
+ * Sort array in increasing order according to @cmp rule
+ * @array: Array to sort for bisect support
+ * @n: Number of cells in @array
+ * @cell_size: Byte size of a single cell of @array
+ * @cmp: Trilean comparision helper function applicable to @array
+ */
+static inline void bisect_sort(void *array, size_t n, size_t cell_size,
+			       int (*cmp)(const void *, const void *))
+{
+	qsort(array, n, cell_size, cmp);
+}
+
+/*
+ * Bisect into array to find the cell that matches an entry
+ * @array: Sorted array (according the @cmp) to bisect in
+ * @n: Number of cells in @array
+ * @cell_size: Byte size of a single cell of @array
+ * @target: Entry for which we find an equal entry (with @cmp) in sorted @array
+ * @cmp: Trilean comparision helper function applicable to @array
+ * @return: Pointer to the cell in @array matching @target, NULL if none found
+ */
+void *bisect_equal(const void *array, size_t n, size_t cell_size,
+		   const void *target, int (*cmp)(const void *, const void *));
+
+#endif /*__BISECT_H*/

--- a/lib/libutils/isoc/sub.mk
+++ b/lib/libutils/isoc/sub.mk
@@ -28,6 +28,7 @@ srcs-y += islower.c
 srcs-y += isprint.c
 srcs-y += ispunct.c
 srcs-y += toupper.c
+srcs-y += bisect.c
 
 ifneq (,$(filter ta_%,$(sm)))
 srcs-y += fp.c

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -523,6 +523,13 @@ endif
 # editing of the supplied DTB.
 CFG_DTB_MAX_SIZE ?= 0x10000
 
+# CFG_DT_CACHED_NODE_INFO, when enabled, parses the embedded DT at boot
+# time and caches some information to speed up retrieve of DT node data,
+# more specifically those for which libfdt parses the full DTB to find
+# the target node information.
+CFG_DT_CACHED_NODE_INFO ?= $(CFG_EMBED_DTB)
+$(eval $(call cfg-depends-all,CFG_DT_CACHED_NODE_INFO,CFG_EMBED_DTB))
+
 # Maximum size of the init info data passed to Secure Partitions.
 CFG_SP_INIT_INFO_MAX_SIZE ?= 0x1000
 


### PR DESCRIPTION
Parse the embedded DTB prior using it and cache information that can take time for libdft functions to find. Cached info is stored in sorted arrays so that we can bisect to find the target info. Cached information are:
- parent node of a node (see [`fdt_parent_offset()`](https://github.com/OP-TEE/optee_os/blob/master/core/lib/libfdt/include/libfdt.h#L924-L925)).
- possibly heavily used `#address-cells` and `#size-cells` properties of a parent node.
- phandle of a node (see [`fdt_node_offset_by_phandle()`](https://github.com/OP-TEE/optee_os/blob/master/core/lib/libfdt/fdt_ro.c#L666-L671)).

The feature saves from few dozen to few hundreds of milliseconds of boot time depending on the DTB size (more specifically depending on the number of nodes in the DTB), for example, about 400ms boot time saved on STM32MP15/pager, and about 600ms saved on our STM32MP25 downstream config.

The patch series adds a generic bisect helper function and a test case in PTA test selftests. The test is proceed by CI on qemuv7 and qemuv8 paltform. These both platforms also embed a very small DTB in OP-TEE core so the DT cached info are also slightly tested (their embedded DTB only contains 7 nodes and 1 phandle).