### PR TITLE
drivers: clk: stm32: fix stm32mp13 clock gates initialization

### DIFF
--- a/core/drivers/clk/clk-stm32-core.c
+++ b/core/drivers/clk/clk-stm32-core.c
@@ -87,6 +87,14 @@ static void stm32_gate_endisable(uint16_t gate_id, bool enable)
 	}
 }
 
+void stm32_gate_set_init_state(uint16_t gate_id, bool enable)
+{
+	struct clk_stm32_priv __maybe_unused *priv = clk_stm32_get_priv();
+
+	assert(!priv->gate_cpt[gate_id]);
+	stm32_gate_endisable(gate_id, enable);
+}
+
 void stm32_gate_disable(uint16_t gate_id)
 {
 	struct clk_stm32_priv *priv = clk_stm32_get_priv();

--- a/core/drivers/clk/clk-stm32-core.h
+++ b/core/drivers/clk/clk-stm32-core.h
@@ -120,6 +120,13 @@ TEE_Result stm32_gate_wait_ready(uint16_t gate_id, bool ready_on);
 TEE_Result stm32_gate_rdy_enable(uint16_t gate_id);
 TEE_Result stm32_gate_rdy_disable(uint16_t gate_id);
 
+/*
+ * Set gate to an enable or disable state without updating its
+ * refcount. This is exclusively intended to be used during initialization
+ * where refcount value are 0.
+ */
+void stm32_gate_set_init_state(uint16_t gate_id, bool enable);
+
 size_t stm32_mux_get_parent(uint32_t mux_id);
 TEE_Result stm32_mux_set_parent(uint16_t pid, uint8_t sel);
 

--- a/core/drivers/clk/clk-stm32mp13.c
+++ b/core/drivers/clk/clk-stm32mp13.c
@@ -964,10 +964,7 @@ static int stm32_clk_configure_clk(struct clk_stm32_priv *priv __maybe_unused,
 	if (stm32_mux_set_parent(mux, sel))
 		return -1;
 
-	if (enable)
-		stm32_gate_enable(gate);
-	else
-		stm32_gate_disable(gate);
+	stm32_gate_set_init_state(gate, enable);
 
 	return 0;
 }


### PR DESCRIPTION
Correct STM32MP13 clock gates initialization regarding the enable reference counting. The fixed commit introduced side effect where clock gates with a disable init state overflow the gate refcount to -1 and clock gates with a enable init state take a refcount that is never released.

For this purpose, add stm32_gate_set_init_state() function in stm32 clock core driver for STM32MP13 gate clocks initialization expects to set some clock gate hardware state (enabled or disabled) before any refcount is considered.

Fixes: 2b028a2ba197 ("clk: implement multi-gate management at core level")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
