### PR TITLE
Default enable CFG_NOTIF_TEST_WD only when dependencies are enabled

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1035,7 +1035,8 @@ endif
 CFG_CALLOUT ?= $(CFG_CORE_ASYNC_NOTIF)
 
 # Enable notification based test watchdog
-CFG_NOTIF_TEST_WD ?= $(CFG_ENABLE_EMBEDDED_TESTS)
+CFG_NOTIF_TEST_WD ?= $(call cfg-all-enabled,CFG_ENABLE_EMBEDDED_TESTS \
+		       CFG_CALLOUT CFG_CORE_ASYNC_NOTIF)
 $(eval $(call cfg-depends-all,CFG_NOTIF_TEST_WD,CFG_CALLOUT \
 	 CFG_CORE_ASYNC_NOTIF))
 


### PR DESCRIPTION
Set CFG_NOTIF_TEST_WD ?= y only when the features it needs are enabled. Fixes the following warning on platforms that enable CFG_ENABLE_EMBEDDED_TESTS but not CFG_CORE_ASYNC_NOTIF or CFG_CALLOUT:

 mk/config.mk:1039: Warning: Disabling CFG_NOTIF_TEST_WD [requires CFG_CALLOUT CFG_CORE_ASYNC_NOTIF]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
