### PR TITLE
Miscellaneous patches

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -542,6 +542,7 @@ CFG_SHMEM_START ?= ($(CFG_TZDRAM_START) + $(CFG_TZDRAM_SIZE))
 
 # Enable embedded tests by default
 CFG_ENABLE_EMBEDDED_TESTS ?= y
+CFG_ATTESTATION_PTA ?= y
 
 # Set default heap size for imx platforms to 128k
 CFG_CORE_HEAP_SIZE ?= 131072

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -557,6 +557,7 @@ endif
 CFG_IMX_OCOTP ?= y
 CFG_IMX_DIGPROG ?= y
 CFG_PKCS11_TA ?= y
+CFG_CORE_HUK_SUBKEY_COMPAT_USE_OTP_DIE_ID ?= y
 
 # Almost all platforms include CAAM HW Modules, except the
 # ones forced to be disabled


### PR DESCRIPTION
This pull request enable support for Attestation PTA and OTP DIE ID by default for i.MX platforms