### PR TITLE
core: cache some embedded DT info (take 2)

### DIFF
--- a/core/arch/arm/plat-ls/main.c
+++ b/core/arch/arm/plat-ls/main.c
@@ -141,20 +141,13 @@ static TEE_Result get_gic_base_addr_from_dt(paddr_t *gic_addr)
 		gic_offset = fdt_path_offset(fdt,
 					     "/interrupt-controller@6000000");
 
-	if (gic_offset > 0) {
-		paddr = fdt_reg_base_address(fdt, gic_offset);
-		if (paddr == DT_INFO_INVALID_REG) {
-			EMSG("GIC: Unable to get base addr from DT");
-			return TEE_ERROR_ITEM_NOT_FOUND;
-		}
-
-		size = fdt_reg_size(fdt, gic_offset);
-		if (size == DT_INFO_INVALID_REG_SIZE) {
-			EMSG("GIC: Unable to get size of base addr from DT");
-			return TEE_ERROR_ITEM_NOT_FOUND;
-		}
-	} else {
+	if (gic_offset < 0) {
 		EMSG("Unable to get gic offset node");
+		return TEE_ERROR_ITEM_NOT_FOUND;
+	}
+
+	if (fdt_reg_info(fdt, gic_offset, &paddr, &size)) {
+		EMSG("GIC: Unable to get base addr or size from DT");
 		return TEE_ERROR_ITEM_NOT_FOUND;
 	}
 

--- a/core/drivers/cbmem_console.c
+++ b/core/drivers/cbmem_console.c
@@ -157,8 +157,8 @@ bool cbmem_console_init_from_dt(void *fdt)
 	if (offset < 0)
 		return false;
 
-	cb_addr = fdt_reg_base_address(fdt, offset);
-	cb_size = fdt_reg_size(fdt, offset);
+	if (fdt_reg_info(fdt, offset, &cb_addr, &cb_size))
+		return false;
 
 	cbmem_console_base = get_cbmem_console_from_coreboot_table(cb_addr,
 								   cb_size);

--- a/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg_dt.c
@@ -69,15 +69,8 @@ void caam_hal_cfg_get_ctrl_dt(void *fdt, vaddr_t *ctrl_base)
 	 * already present in the MMU table.
 	 * Then get the virtual address of the CAAM controller
 	 */
-	pctrl_base = fdt_reg_base_address(fdt, node);
-	if (pctrl_base == DT_INFO_INVALID_REG) {
-		HAL_TRACE("CAAM control base address not defined");
-		return;
-	}
-
-	size = fdt_reg_size(fdt, node);
-	if (size == DT_INFO_INVALID_REG_SIZE) {
-		HAL_TRACE("CAAM control base address size not defined");
+	if (fdt_reg_info(fdt, node, &pctrl_base, &size)) {
+		HAL_TRACE("CAAM control base address or size not defined");
 		return;
 	}
 

--- a/core/drivers/firewall/stm32_rifsc.c
+++ b/core/drivers/firewall/stm32_rifsc.c
@@ -293,12 +293,7 @@ static TEE_Result stm32_rifsc_parse_fdt(const void *fdt, int node,
 	struct io_pa_va base = { };
 	size_t reg_size = 0;
 
-	base.pa = fdt_reg_base_address(fdt, node);
-	if (base.pa == DT_INFO_INVALID_REG)
-		return TEE_ERROR_BAD_PARAMETERS;
-
-	reg_size = fdt_reg_size(fdt, node);
-	if (reg_size == DT_INFO_INVALID_REG_SIZE)
+	if (fdt_reg_info(fdt, node, &base.pa, &reg_size))
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	pdata->base = io_pa_or_va_secure(&base, reg_size);

--- a/core/drivers/firewall/stm32_risaf.c
+++ b/core/drivers/firewall/stm32_risaf.c
@@ -652,8 +652,12 @@ static TEE_Result stm32_risaf_probe(const void *fdt, int node,
 		if (pnode < 0)
 			continue;
 
-		regions[i].addr = fdt_reg_base_address(fdt, pnode);
-		regions[i].len = fdt_reg_size(fdt, pnode);
+		if (fdt_reg_info(fdt, pnode, &regions[i].addr,
+				 &regions[i].len)) {
+			EMSG("Invalid config in node %s",
+			     fdt_get_name(fdt, pnode, NULL));
+			panic();
+		}
 
 		if (!regions[i].len)
 			continue;

--- a/core/drivers/nvmem/nvmem.c
+++ b/core/drivers/nvmem/nvmem.c
@@ -10,19 +10,8 @@
 TEE_Result nvmem_cell_parse_dt(const void *fdt, int nodeoffset,
 			       struct nvmem_cell *cell)
 {
-	size_t buf_len = 0;
-	paddr_t offset = 0;
-
-	buf_len = fdt_reg_size(fdt, nodeoffset);
-	if (buf_len == DT_INFO_INVALID_REG_SIZE)
+	if (fdt_reg_info(fdt, nodeoffset, &cell->offset, &cell->len))
 		return TEE_ERROR_GENERIC;
-
-	offset = fdt_reg_base_address(fdt, nodeoffset);
-	if (offset == DT_INFO_INVALID_REG)
-		return TEE_ERROR_GENERIC;
-
-	cell->len = buf_len;
-	cell->offset = offset;
 
 	return TEE_SUCCESS;
 }

--- a/core/drivers/regulator/stm32_vrefbuf.c
+++ b/core/drivers/regulator/stm32_vrefbuf.c
@@ -343,10 +343,7 @@ static TEE_Result stm32_vrefbuf_regulator_probe(const void *fdt, int node,
 	if (!regu_name)
 		panic();
 
-	reg_base = fdt_reg_base_address(fdt, node);
-	reg_size = fdt_reg_size(fdt, node);
-	if (reg_base == DT_INFO_INVALID_REG ||
-	    reg_size == DT_INFO_INVALID_REG_SIZE)
+	if (fdt_reg_info(fdt, node, &reg_base, &reg_size))
 		panic();
 
 	vr->base = (vaddr_t)phys_to_virt(reg_base, MEM_AREA_IO_SEC, reg_size);

--- a/core/drivers/remoteproc/stm32_remoteproc.c
+++ b/core/drivers/remoteproc/stm32_remoteproc.c
@@ -283,10 +283,8 @@ static TEE_Result stm32_rproc_parse_mems(struct stm32_rproc_instance *rproc,
 			goto err;
 		}
 
-		regions[i].addr = fdt_reg_base_address(fdt, pnode);
-		regions[i].size = fdt_reg_size(fdt, pnode);
-
-		if (regions[i].addr <= 0 || regions[i].size <= 0) {
+		if (fdt_reg_info(fdt, pnode, &regions[i].addr,
+				 &regions[i].size)) {
 			res = TEE_ERROR_GENERIC;
 			goto err;
 		}

--- a/core/drivers/stm32_bsec.c
+++ b/core/drivers/stm32_bsec.c
@@ -736,17 +736,14 @@ static void bsec_dt_otp_nsec_access(void *fdt, int bsec_node)
 		panic();
 
 	fdt_for_each_subnode(bsec_subnode, fdt, bsec_node) {
-		unsigned int reg_offset = 0;
-		unsigned int reg_size = 0;
+		paddr_t reg_offset = 0;
+		size_t reg_size = 0;
 		unsigned int otp_id = 0;
 		unsigned int i = 0;
 		size_t size = 0;
 
-		reg_offset = fdt_reg_base_address(fdt, bsec_subnode);
-		reg_size = fdt_reg_size(fdt, bsec_subnode);
-
-		assert(reg_offset != DT_INFO_INVALID_REG &&
-		       reg_size != DT_INFO_INVALID_REG_SIZE);
+		if (fdt_reg_info(fdt, bsec_subnode, &reg_offset, &reg_size))
+			panic();
 
 		otp_id = reg_offset / sizeof(uint32_t);
 
@@ -837,8 +834,8 @@ static void save_dt_nvmem_layout(void *fdt, int bsec_node)
 		panic();
 
 	fdt_for_each_subnode(node, fdt, bsec_node) {
-		unsigned int reg_offset = 0;
-		unsigned int reg_length = 0;
+		paddr_t reg_offset = 0;
+		size_t reg_length = 0;
 		const char *string = NULL;
 		const char *s = NULL;
 		int len = 0;
@@ -852,11 +849,7 @@ static void save_dt_nvmem_layout(void *fdt, int bsec_node)
 		layout_cell->phandle = fdt_get_phandle(fdt, node);
 		assert(layout_cell->phandle != (uint32_t)-1);
 
-		reg_offset = fdt_reg_base_address(fdt, node);
-		reg_length = fdt_reg_size(fdt, node);
-
-		if (reg_offset == DT_INFO_INVALID_REG ||
-		    reg_length == DT_INFO_INVALID_REG_SIZE) {
+		if (fdt_reg_info(fdt, node, &reg_offset, &reg_length)) {
 			DMSG("Malformed nvmem %s: ignored", string);
 			continue;
 		}

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -941,15 +941,10 @@ static TEE_Result dt_stm32_gpio_bank(const void *fdt, int node,
 	 * Do not rely *only* on the "reg" property to get the address,
 	 * but consider also the "ranges" translation property
 	 */
-	pa = fdt_reg_base_address(fdt, node);
-	if (pa == DT_INFO_INVALID_REG)
-		panic("missing reg property");
+	if (fdt_reg_info(fdt, node, &pa, &blen))
+		panic("missing reg or reg size property");
 
 	pa_va.pa = pa + range_offset;
-
-	blen = fdt_reg_size(fdt, node);
-	if (blen == DT_INFO_INVALID_REG_SIZE)
-		panic("missing reg size property");
 
 	DMSG("Bank name %s", fdt_get_name(fdt, node, NULL));
 	bank->bank_id = dt_get_bank_id(fdt, node);

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -175,6 +175,17 @@ paddr_t fdt_reg_base_address(const void *fdt, int offs);
 size_t fdt_reg_size(const void *fdt, int offs);
 
 /*
+ * Read the base address and/or reg size for the "reg" property of the
+ * specified node.
+ * @fdt: Reference to the Device Tree
+ * @offs: Offset to the node to read "reg" property from
+ * @base: Pointer to the output base address value, or NULL
+ * @size: Pointer to the output size value, or NULL
+ * Returns 0 on success and a negative FDT error value in case of failure
+ */
+int fdt_reg_info(const void *fdt, int offs, paddr_t *base, size_t *size);
+
+/*
  * Read the status and secure-status properties into a bitfield.
  * Return -1 on failure, DT_STATUS_DISABLED if the node is disabled,
  * otherwise return a combination of DT_STATUS_OK_NSEC and DT_STATUS_OK_SEC.
@@ -350,6 +361,12 @@ static inline size_t fdt_reg_size(const void *fdt __unused,
 				  int offs __unused)
 {
 	return (size_t)-1;
+}
+
+static inline int fdt_reg_info(const void *fdt __unused, int offs __unused,
+			       paddr_t *base __unused, size_t *size __unused)
+{
+	return -1;
 }
 
 static inline int fdt_get_status(const void *fdt __unused, int offs __unused)

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -489,4 +489,58 @@ static inline void *get_manifest_dt(void)
 }
 
 #endif /* !CFG_DT */
+
+#ifdef CFG_DT_CACHED_NODE_INFO
+/*
+ * Find the offset of a parent node in the parent node cache
+ * @fdt: FDT to work on
+ * @node_offset: Offset of the node we look for its parent
+ * @parent_offset: Output parent node offset upon success
+ * @return 0 on success and -1 on failure
+ */
+int fdt_find_cached_parent_node(const void *fdt, int node_offset,
+				int *parent_offset);
+
+/*
+ * Find the address/size cells value of a parent node in the parent node cache
+ * @fdt: FDT to work on
+ * @node_offset: Offset of the node we look for its parent
+ * @address_cells: Pointer to output #address-cells value upon success or NULL
+ * @size_cells: Pointer to output #size-cells value upon success or NULL
+ * @return 0 on success and -FDT_ERR_NOTFOUND on failure
+ */
+int fdt_find_cached_parent_reg_cells(const void *fdt, int node_offset,
+				     int *address_cells, int *size_cells);
+/*
+ * Find the node offset from its phandle in the phandle cache
+ * @fdt: FDT to work on
+ * @phandle: Node phandle
+ * @node_offset: Pointer to output node offset upon success
+ * @return 0 on success and -FDT_ERR_NOTFOUND on failure
+ */
+int fdt_find_cached_node_phandle(const void *fdt, uint32_t phandle,
+				 int *node_offset);
+#else
+static inline int fdt_find_cached_parent_node(const void *fdt __unused,
+					      int node_offset __unused,
+					      int *parent_offset __unused)
+{
+	return -1;
+}
+
+static inline int fdt_find_cached_parent_reg_cells(const void *fdt __unused,
+						   int node_offset __unused,
+						   int *address_cells __unused,
+						   int *size_cells __unused)
+{
+	return -1;
+}
+
+static inline int fdt_find_cached_node_phandle(const void *fdt __unused,
+					       uint32_t phandle __unused,
+					       int *node_offset __unused)
+{
+	return -1;
+}
+#endif /* CFG_DT_CACHED_NODE_INFO */
 #endif /* __KERNEL_DT_H */

--- a/core/lib/libfdt/fdt_ro.c
+++ b/core/lib/libfdt/fdt_ro.c
@@ -6,6 +6,7 @@
 #include "libfdt_env.h"
 
 #include <fdt.h>
+#include <kernel/dt.h>	/* fdt_find_cached_xxx() */
 #include <libfdt.h>
 
 #include "libfdt_internal.h"
@@ -619,7 +620,13 @@ int fdt_node_depth(const void *fdt, int nodeoffset)
 
 int fdt_parent_offset(const void *fdt, int nodeoffset)
 {
-	int nodedepth = fdt_node_depth(fdt, nodeoffset);
+	int parent_offset = 0;
+	int nodedepth = 0;
+
+	if (fdt_find_cached_parent_node(fdt, nodeoffset, &parent_offset) == 0)
+		return parent_offset;
+
+	nodedepth = fdt_node_depth(fdt, nodeoffset);
 
 	if (nodedepth < 0)
 		return nodedepth;
@@ -660,6 +667,9 @@ int fdt_node_offset_by_phandle(const void *fdt, uint32_t phandle)
 
 	if ((phandle == 0) || (phandle == -1))
 		return -FDT_ERR_BADPHANDLE;
+
+	if (fdt_find_cached_node_phandle(fdt, phandle, &offset) == 0)
+		return offset;
 
 	FDT_RO_PROBE(fdt);
 

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -362,15 +362,8 @@ static bool dtb_get_sdp_region(void)
 			     fdt_get_name(fdt, tmp_node, NULL));
 	}
 
-	tmp_addr = fdt_reg_base_address(fdt, node);
-	if (tmp_addr == DT_INFO_INVALID_REG) {
-		EMSG("%s: Unable to get base addr from DT", tz_sdp_match);
-		return false;
-	}
-
-	tmp_size = fdt_reg_size(fdt, node);
-	if (tmp_size == DT_INFO_INVALID_REG_SIZE) {
-		EMSG("%s: Unable to get size of base addr from DT",
+	if (fdt_reg_info(fdt, node, &tmp_addr, &tmp_size)) {
+		EMSG("%s: Unable to get base addr or size from DT",
 		     tz_sdp_match);
 		return false;
 	}

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -523,6 +523,13 @@ endif
 # editing of the supplied DTB.
 CFG_DTB_MAX_SIZE ?= 0x10000
 
+# CFG_DT_CACHED_NODE_INFO, when enabled, parses the embedded DT at boot
+# time and caches some information to speed up retrieve of DT node data,
+# more specifically those for which libfdt parses the full DTB to find
+# the target node information.
+CFG_DT_CACHED_NODE_INFO ?= $(CFG_EMBED_DTB)
+$(eval $(call cfg-depends-all,CFG_DT_CACHED_NODE_INFO,CFG_EMBED_DTB))
+
 # Maximum size of the init info data passed to Secure Partitions.
 CFG_SP_INIT_INFO_MAX_SIZE ?= 0x1000
 


### PR DESCRIPTION
This change supersedes https://github.com/OP-TEE/optee_os/pull/7067. Main difference is that we no more bisect into the cached node structure (since it does not speeds up boot time) and this change proposes a new helper function: `fdt_reg_info()` to look-up parent node once when retrieving the `reg` property base address and size.

Parse the embedded DTB prior using it and cache information that can take time for libdft functions to find. Cached info is stored in an array so that we can find the target info without parsing through the DTB. Cached information are:
- parent node of a node (see [`fdt_parent_offset()`](https://github.com/OP-TEE/optee_os/blob/master/core/lib/libfdt/include/libfdt.h#L924-L925)).
- possibly heavily used `#address-cells` and `#size-cells` properties of a parent node.
- phandle of a node (see [`fdt_node_offset_by_phandle()`](https://github.com/OP-TEE/optee_os/blob/master/core/lib/libfdt/fdt_ro.c#L666-L671)).

The feature saves from a few dozen to several hundreds of milliseconds of boot time depending on the DTB size (more specifically depending on the number of nodes in the DTB), for example, about 400ms boot time saved on STM32MP15/pager, and more than 1sec saved on our STM32MP25 downstream config.

These changes are processed by CI on qemuv7 and qemuv8 platforms since both embed a very small DTB in OP-TEE core (their embedded DTBs only contains 7 nodes and 1 phandle).