### PR TITLE
drivers: change tree trace level

### DIFF
--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -495,7 +495,7 @@ out:
 	if (!msg)
 		snprintf(msg_end - 4, 4, "...");
 
-	DMSG("%s", msg_buf);
+	IMSG("%s", msg_buf);
 }
 
 static void print_tree(void)
@@ -507,7 +507,7 @@ static void print_tree(void)
 
 #ifdef CFG_DRIVERS_CLK_PRINT_TREE
 	if (SLIST_EMPTY(&clock_list)) {
-		DMSG("-- No registered clock");
+		IMSG("-- No registered clock");
 		return;
 	}
 #endif
@@ -541,8 +541,8 @@ static void print_tree(void)
 void clk_print_tree(void)
 {
 	if (IS_ENABLED(CFG_DRIVERS_CLK_PRINT_TREE) &&
-	    TRACE_LEVEL >= TRACE_DEBUG) {
-		DMSG("Clock tree summary (informative):");
+	    TRACE_LEVEL >= TRACE_INFO) {
+		IMSG("Clock tree summary (informative):");
 		print_tree();
 	}
 }

--- a/core/drivers/regulator/regulator.c
+++ b/core/drivers/regulator/regulator.c
@@ -310,7 +310,8 @@ static TEE_Result regulator_core_cleanup(void)
 		}
 	}
 
-	regulator_print_tree();
+	if (TRACE_LEVEL >= TRACE_DEBUG)
+		regulator_print_tree();
 
 	return TEE_SUCCESS;
 }
@@ -447,7 +448,7 @@ out:
 	if (!msg)
 		snprintf(msg_end - 4, 4, "...");
 
-	DMSG("%s", msg_buf);
+	IMSG("%s", msg_buf);
 }
 
 static void print_tree(void)
@@ -486,10 +487,10 @@ static void print_tree(void)
 void regulator_print_tree(void)
 {
 	if (IS_ENABLED(CFG_DRIVERS_REGULATOR_PRINT_TREE) &&
-	    TRACE_LEVEL >= TRACE_DEBUG) {
-		DMSG("Regulator tree summary");
+	    TRACE_LEVEL >= TRACE_INFO) {
+		IMSG("Regulator tree summary");
 		if (SLIST_EMPTY(&regulator_device_list))
-			DMSG("-- No registered regulator");
+			IMSG("-- No registered regulator");
 		else
 			print_tree();
 	}

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -250,7 +250,7 @@ TEE_Result clk_get_duty_cycle(struct clk *clk,
 /**
  * clk_print_tree() - Print current clock tree summary to output console
  *
- * The clock is printed with the debug trace level.
+ * The clock is printed with the info trace level.
  */
 void clk_print_tree(void);
 #else

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -318,7 +318,7 @@ TEE_Result regulator_supported_voltages(struct regulator *regulator,
 					struct regulator_voltages_desc **desc,
 					const int **levels);
 
-/* Print current regulator tree summary to console with debug trace level */
+/* Print current regulator tree summary to console with info trace level */
 #ifdef CFG_DRIVERS_REGULATOR
 void regulator_print_tree(void);
 #else

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -892,7 +892,7 @@ CFG_PREALLOC_RPC_CACHE ?= y
 # CFG_DRIVERS_CLK_FIXED add support for "fixed-clock" compatible clocks
 # CFG_DRIVERS_CLK_EARLY_PROBE makes clocks probed at early_init initcall level.
 # CFG_DRIVERS_CLK_PRINT_TREE embeds a helper function to print the clock tree
-# state on OP-TEE core console with the debug trace level.
+# state on OP-TEE core console with the info trace level.
 CFG_DRIVERS_CLK ?= n
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
 CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
Change the clock and regulator trace level of the print tree functions so that they can be seen when requested by xtest without needing to activate all debug traces.
