### PR TITLE
core: imx: disable ELE support on i.MX91 by default

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -262,7 +262,7 @@ $(call force,CFG_IMX_OCOTP,n)
 $(call force,CFG_TZC380,n)
 $(call force,CFG_NXP_CAAM,n)
 CFG_IMX_MU ?= y
-CFG_IMX_ELE ?= y
+CFG_IMX_ELE ?= n
 else
 $(error Unsupported PLATFORM_FLAVOR "$(PLATFORM_FLAVOR)")
 endif


### PR DESCRIPTION
On i.MX91, there is only one MU to communicate with ELE, which cannot be dedicated on OP-TEE side all the time. There may be ELE services running on Linux side, which can cause conflict with OP-TEE.
So disabling ELE by default for now.
