### PR TITLE
ci: bump scp-firmware to release tag v2.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           function _make() { make -j$(nproc) -s O=out $*; }
           function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.4.2 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
 
-          function download_scp_firmware() { git clone --single-branch https://git.gitlab.arm.com/firmware/SCP-firmware.git $HOME/scp-firmware &&  git -C $HOME/scp-firmware checkout d80521fb511c6b377e41de62e20556fcbb4355f4 || (rm -rf $HOME/scp-firmware ; echo Nervermind); }
+          function download_scp_firmware() { git clone --single-branch -b v2.15.0 --depth 1 https://git.gitlab.arm.com/firmware/SCP-firmware.git $HOME/scp-firmware || (rm -rf $HOME/scp-firmware ; echo Nervermind); }
 
           ccache -s -v
           download_plug_and_trust


### PR DESCRIPTION
Sync CI test SCP-firmware source tree with latest release tag v2.15.0 instead of the previously selected commit SHA1 that we synced on before a release tag integrating OP-TEE support latest changes was available in that repository.

By the way, clone the repo with a depth of 1 as since is enough for CI tests needs.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
