### PR TITLE
drivers: stm32_rng: MP15 RNG is non-secure when PRNG is enable

### DIFF
--- a/core/drivers/stm32_rng.c
+++ b/core/drivers/stm32_rng.c
@@ -672,7 +672,7 @@ static TEE_Result stm32_rng_probe(const void *fdt, int offs,
 
 #if defined(CFG_STM32MP15)
 	/* Only STM32MP15 requires a software registering of RNG secure state */
-	if (etzpc_get_decprot(STM32MP1_ETZPC_RNG1_ID) == ETZPC_DECPROT_NS_RW)
+	if (IS_ENABLED(CFG_WITH_SOFTWARE_PRNG))
 		stm32mp_register_non_secure_periph_iomem(stm32_rng->base.pa);
 	else
 		stm32mp_register_secure_periph_iomem(stm32_rng->base.pa);


### PR DESCRIPTION
Register stm32_rng device as non-secure when software PRNG is enabled instead of testing the firewall configuration that is applied from stm32mp1_init_final_shres() at driver_init_late initcall level, far after RNG initialization.

Fixes: d773ec0baf4c ("drivers: stm32_rng: update clock and power management")
