### PR TITLE
ci: qemuv8: add configurations with CFG_ULIBS_SHARED=y

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,7 @@ jobs:
           make -j$(nproc) check CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y XTEST_ARGS=regression_1001 RUST_ENABLE=n
           make -j$(nproc) check CFG_PAN=y
           make -j$(nproc) check CFG_WITH_PAGER=y
+          make -j$(nproc) check CFG_ULIBS_SHARED=y
 
   QEMUv8_clang_check:
     name: make check (QEMUv8, Clang)
@@ -394,6 +395,7 @@ jobs:
           cd ${TOP}/build
 
           make -j$(nproc) check
+          make -j$(nproc) check CFG_ULIBS_SHARED=y
 
   QEMUv8_Xen_check:
     name: make check (QEMUv8, Xen)


### PR DESCRIPTION
Add configurations to the QEMUv8 job to test shared library support with GCC as well as Clang. Shared libraries are somewhat already tested by xtest 1022 which performs dlopen()/dlsym() on a custom library, but CFG_ULIBS_SHARED=y will thoroughly test the loading and symbol resolution at TA load time.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
