### PR TITLE
mk: add global-cppflags-y

### DIFF
--- a/mk/subdir.mk
+++ b/mk/subdir.mk
@@ -140,6 +140,7 @@ endif
 
 include $1/sub.mk
 sub-subdirs := $$(addprefix $1/,$$(subdirs-y)) $$(subdirs_ext-y)
+cppflags$(sm) := $$(cppflags$(sm)) $$(global-cppflags-y)
 incdirs$(sm) := $(incdirs$(sm)) $$(addprefix $1/,$$(global-incdirs-y))
 thissubdir-incdirs := $(out-dir)/$(base-prefix)$1 $$(addprefix $1/,$$(incdirs-y)) $$(incdirs_ext-y)
 ifneq ($$(libname),)
@@ -168,6 +169,7 @@ aflags-remove-y :=
 subdirs-y :=
 subdirs_ext-y :=
 global-incdirs-y :=
+global-cppflags-y :=
 incdirs-lib-y :=
 incdirs-y :=
 incdirs_ext-y :=


### PR DESCRIPTION
Add global-cppflags-y as a new sub.mk variable. The content of the variable is added to the C preprocessor flags passed to all files compiled in the current submodule, $(sm), similarly to how the content of global-incdirs-y is passed on.

This flag is intended for libraries that in addition to exporting an include path also need certain defines set.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
