### PR TITLE
core: add HOB creation and Apply FF-A v1.2 in stmm_sp.

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -168,6 +168,12 @@ libdir = core/lib/zlib
 include mk/lib.mk
 endif
 
+ifeq ($(CFG_EFILIB),y)
+libname = efi
+libdir = core/lib/libefi
+include mk/lib.mk
+endif
+
 libname = unw
 libdir = lib/libunw
 include mk/lib.mk

--- a/core/lib/libefi/hob.c
+++ b/core/lib/libefi/hob.c
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024, Arm Limited and Contributors. All rights reserved.
+ *
+ * @par Reference(s):
+ * - UEFI Platform Initialization Specification
+ *   (https://uefi.org/specs/PI/1.8/index.html)
+ */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <string.h>
+#include <tee_api_defines.h>
+#include <trace.h>
+#include <util.h>
+
+#include <efi/hob.h>
+
+static void *create_hob(struct efi_hob_handoff_info_table *hob_table,
+			uint16_t hob_type, uint16_t hob_length)
+{
+	size_t free_mem_size = 0;
+	struct efi_hob_generic_header *new_hob = NULL;
+	struct efi_hob_generic_header *hob_end = NULL;
+
+	hob_length = ROUNDUP(hob_length, HOB_ALIGN);
+
+	assert(hob_table && hob_length);
+
+	free_mem_size = hob_table->efi_free_memory_top -
+			hob_table->efi_free_memory_bottom;
+
+	/*
+	 * hob_length already including sizeof(efi_hob_generic_header).
+	 * See the each export interface create_xxx_hob.
+	 */
+	if (hob_length > free_mem_size)
+		return NULL;
+
+	new_hob = (void *)hob_table->efi_end_of_hob_list;
+	new_hob->hob_type = hob_type;
+	new_hob->hob_length = hob_length;
+	new_hob->reserved = 0;
+
+	hob_end = (void *)((vaddr_t)new_hob + hob_length);
+	hob_end->hob_type = EFI_HOB_TYPE_END_OF_HOB_LIST;
+	hob_end->hob_length = sizeof(struct efi_hob_generic_header);
+	hob_end->reserved = 0;
+
+	hob_table->efi_end_of_hob_list = (vaddr_t)hob_end;
+	hob_table->efi_free_memory_bottom = (vaddr_t)(hob_end + 1);
+
+	return new_hob;
+}
+
+struct efi_hob_handoff_info_table *
+efi_create_hob_list(vaddr_t mem_begin, size_t mem_len,
+		    vaddr_t mem_free_begin, size_t mem_free_len)
+{
+	struct efi_hob_handoff_info_table *hob_table = NULL;
+	struct efi_hob_generic_header *hob_end = NULL;
+
+	if (!mem_begin || !mem_free_begin || !mem_len || !mem_free_len)
+		return NULL;
+
+	hob_table = (void *)mem_free_begin;
+	hob_end = (void *)(hob_table + 1);
+
+	hob_table->header.hob_type = EFI_HOB_TYPE_HANDOFF;
+	hob_table->header.hob_length =
+		sizeof(struct efi_hob_handoff_info_table);
+	hob_table->header.reserved = 0;
+
+	hob_end->hob_type = EFI_HOB_TYPE_END_OF_HOB_LIST;
+	hob_end->hob_length = sizeof(struct efi_hob_generic_header);
+	hob_end->reserved = 0;
+
+	hob_table->version = EFI_HOB_HANDOFF_TABLE_VERSION;
+	hob_table->boot_mode = BOOT_WITH_FULL_CONFIGURATION;
+
+	hob_table->efi_memory_top = (vaddr_t)(mem_begin + mem_len);
+	hob_table->efi_memory_bottom = (vaddr_t)mem_begin;
+	hob_table->efi_free_memory_top = (vaddr_t)mem_begin + mem_free_len;
+	hob_table->efi_free_memory_bottom = (vaddr_t)(hob_end + 1);
+	hob_table->efi_end_of_hob_list = (vaddr_t)hob_end;
+
+	return hob_table;
+}
+
+TEE_Result
+efi_create_resource_desc_hob(struct efi_hob_handoff_info_table *hob_table,
+			     efi_resource_type_t resource_type,
+			     efi_resource_attribute_type_t resource_attribute,
+			     efi_physical_address_t phy_addr_start,
+			     uint64_t resource_length)
+{
+	struct efi_hob_resource_descriptor *rd_hop = NULL;
+
+	rd_hop = create_hob(hob_table, EFI_HOB_TYPE_RESOURCE_DESCRIPTOR,
+			    sizeof(struct efi_hob_resource_descriptor));
+
+	if (!rd_hop)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	rd_hop->resource_type = resource_type;
+	rd_hop->resource_attribute = resource_attribute;
+	rd_hop->physical_start = phy_addr_start;
+	rd_hop->resource_length = resource_length;
+	memset(&rd_hop->owner, 0, sizeof(TEE_UUID));
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result efi_create_guid_hob(struct efi_hob_handoff_info_table *hob_table,
+			       TEE_UUID *guid, uint16_t data_length,
+			       void **data)
+{
+	struct efi_hob_guid_type *guid_hob = NULL;
+	uint16_t hob_length = 0;
+
+	hob_length = data_length + sizeof(struct efi_hob_guid_type);
+
+	if (!guid || !data || hob_length < data_length)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	guid_hob = create_hob(hob_table,
+			      EFI_HOB_TYPE_GUID_EXTENSION, hob_length);
+	if (!guid_hob) {
+		*data = NULL;
+
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	memcpy(&guid_hob->name, guid, sizeof(TEE_UUID));
+
+	*data = (void *)(guid_hob + 1);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result efi_create_fv_hob(struct efi_hob_handoff_info_table *hob_table,
+			     efi_physical_address_t base_addr, uint64_t size)
+{
+	struct efi_hob_firmware_volume *fv_hob = NULL;
+
+	fv_hob = create_hob(hob_table, EFI_HOB_TYPE_FV,
+			    sizeof(struct efi_hob_firmware_volume));
+	if (!fv_hob)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	fv_hob->base_address = base_addr;
+	fv_hob->length = size;
+
+	return TEE_SUCCESS;
+}

--- a/core/lib/libefi/include/efi/efi_types.h
+++ b/core/lib/libefi/include/efi/efi_types.h
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Arm Limited and Contributors. All rights reserved.
+ */
+
+#ifndef __EFI_TYPES_H
+#define __EFI_TYPES_H
+
+#include <stdint.h>
+
+typedef uint64_t efi_physical_address_t;
+
+/*****************************************************************************
+ *                            EFI_BOOT_MODE                                  *
+ *****************************************************************************/
+
+typedef uint32_t efi_boot_mode_t;
+/**
+ * EFI boot mode.
+ */
+#define BOOT_WITH_FULL_CONFIGURATION                   0x00
+#define BOOT_WITH_MINIMAL_CONFIGURATION                0x01
+#define BOOT_ASSUMING_NO_CONFIGURATION_CHANGES         0x02
+#define BOOT_WITH_FULL_CONFIGURATION_PLUS_DIAGNOSTICS  0x03
+#define BOOT_WITH_DEFAULT_SETTINGS                     0x04
+#define BOOT_ON_S4_RESUME                              0x05
+#define BOOT_ON_S5_RESUME                              0x06
+#define BOOT_WITH_MFG_MODE_SETTINGS                    0x07
+#define BOOT_ON_S2_RESUME                              0x10
+#define BOOT_ON_S3_RESUME                              0x11
+#define BOOT_ON_FLASH_UPDATE                           0x12
+#define BOOT_IN_RECOVERY_MODE                          0x20
+
+/*****************************************************************************
+ *                            EFI_RESOURCE_TYPE                              *
+ *****************************************************************************/
+
+typedef uint32_t efi_resource_type_t;
+
+/**
+ * Value of EFI_RESOURCE_TYPE used in EFI_HOB_RESOURCE_DESCRIPTOR.
+ */
+#define EFI_RESOURCE_SYSTEM_MEMORY          0x00000000
+#define EFI_RESOURCE_MEMORY_MAPPED_IO       0x00000001
+#define EFI_RESOURCE_IO                     0x00000002
+#define EFI_RESOURCE_FIRMWARE_DEVICE        0x00000003
+#define EFI_RESOURCE_MEMORY_MAPPED_IO_PORT  0x00000004
+#define EFI_RESOURCE_MEMORY_RESERVED        0x00000005
+#define EFI_RESOURCE_IO_RESERVED            0x00000006
+
+/*****************************************************************************
+ *                       EFI_RESOURCE_ATTRIBUTE_TYPE                         *
+ *****************************************************************************/
+
+typedef uint32_t efi_resource_attribute_type_t;
+
+#define EFI_RESOURCE_ATTR_PRESENT                  0x00000001
+#define EFI_RESOURCE_ATTR_INITIALIZED              0x00000002
+#define EFI_RESOURCE_ATTR_TESTED                   0x00000004
+#define EFI_RESOURCE_ATTR_RD_PROTECTED             0x00000080
+#define EFI_RESOURCE_ATTR_WR_PROTECTED             0x00000100
+#define EFI_RESOURCE_ATTR_EXECUTION_PROTECTED      0x00000200
+#define EFI_RESOURCE_ATTR_PERSISTENT               0x00800000
+#define EFI_RESOURCE_ATTR_SINGLE_BIT_ECC           0x00000008
+#define EFI_RESOURCE_ATTR_MULTIPLE_BIT_ECC         0x00000010
+#define EFI_RESOURCE_ATTR_ECC_RESERVED_1           0x00000020
+#define EFI_RESOURCE_ATTR_ECC_RESERVED_2           0x00000040
+#define EFI_RESOURCE_ATTR_UNCACHEABLE              0x00000400
+#define EFI_RESOURCE_ATTR_WR_COMBINEABLE           0x00000800
+#define EFI_RESOURCE_ATTR_WR_THROUGH_CACHEABLE     0x00001000
+#define EFI_RESOURCE_ATTR_WR_BACK_CACHEABLE        0x00002000
+#define EFI_RESOURCE_ATTR_16_BIT_IO                0x00004000
+#define EFI_RESOURCE_ATTR_32_BIT_IO                0x00008000
+#define EFI_RESOURCE_ATTR_64_BIT_IO                0x00010000
+#define EFI_RESOURCE_ATTR_UNCACHED_EXPORTED        0x00020000
+#define EFI_RESOURCE_ATTR_RD_PROTECTABLE           0x00100000
+#define EFI_RESOURCE_ATTR_WR_PROTECTABLE           0x00200000
+#define EFI_RESOURCE_ATTR_EXECUTION_PROTECTABLE    0x00400000
+#define EFI_RESOURCE_ATTR_PERSISTABLE              0x01000000
+#define EFI_RESOURCE_ATTR_RD_ONLY_PROTECTED        0x00040000
+#define EFI_RESOURCE_ATTR_RD_ONLY_PROTECTABLE      0x00080000
+#define EFI_RESOURCE_ATTR_MORE_RELIABLE            0x02000000
+
+#endif

--- a/core/lib/libefi/include/efi/hob.h
+++ b/core/lib/libefi/include/efi/hob.h
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Arm Limited and Contributors. All rights reserved.
+ *
+ * @par Reference(s):
+ * - UEFI Platform Initialization Specification
+ *   (https://uefi.org/specs/PI/1.8/index.html)
+ */
+
+#ifndef __HOB_H
+#define __HOB_H
+
+#include <efi/efi_types.h>
+#include <efi/hob_guid.h>
+#include <efi/mmram.h>
+#include <efi/mpinfo.h>
+
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+#define HOB_ALIGN 8
+
+/*****************************************************************************
+ *                            Hob Generic Header                             *
+ *****************************************************************************/
+
+/**
+ * HobType values of EFI_HOB_GENERIC_HEADER.
+ */
+#define EFI_HOB_TYPE_HANDOFF              0x0001
+#define EFI_HOB_TYPE_MEMORY_ALLOCATION    0x0002
+#define EFI_HOB_TYPE_RESOURCE_DESCRIPTOR  0x0003
+#define EFI_HOB_TYPE_GUID_EXTENSION       0x0004
+#define EFI_HOB_TYPE_FV                   0x0005
+#define EFI_HOB_TYPE_CPU                  0x0006
+#define EFI_HOB_TYPE_MEMORY_POOL          0x0007
+#define EFI_HOB_TYPE_FV2                  0x0009
+#define EFI_HOB_TYPE_LOAD_PEIM_UNUSED     0x000A
+#define EFI_HOB_TYPE_UEFI_CAPSULE         0x000B
+#define EFI_HOB_TYPE_FV3                  0x000C
+#define EFI_HOB_TYPE_UNUSED               0xFFFE
+#define EFI_HOB_TYPE_END_OF_HOB_LIST      0xFFFF
+
+struct efi_hob_generic_header {
+	uint16_t hob_type;
+	uint16_t hob_length;
+	uint32_t reserved;
+};
+
+/*****************************************************************************
+ *                               PHIT Hob.                                   *
+ *****************************************************************************/
+
+#define EFI_HOB_HANDOFF_TABLE_VERSION     0x000a
+
+struct efi_hob_handoff_info_table {
+	struct efi_hob_generic_header header;
+	uint32_t version;
+	efi_boot_mode_t  boot_mode;
+	efi_physical_address_t efi_memory_top;
+	efi_physical_address_t efi_memory_bottom;
+	efi_physical_address_t efi_free_memory_top;
+	efi_physical_address_t efi_free_memory_bottom;
+	efi_physical_address_t efi_end_of_hob_list;
+};
+
+/*****************************************************************************
+ *                       Resource Descriptor Hob.                            *
+ *****************************************************************************/
+
+struct efi_hob_resource_descriptor {
+	struct efi_hob_generic_header header;
+	TEE_UUID owner;
+	efi_resource_type_t resource_type;
+	efi_resource_attribute_type_t resource_attribute;
+	efi_physical_address_t physical_start;
+	uint64_t resource_length;
+};
+
+/*****************************************************************************
+ *                           Guid Extension Hob.                             *
+ *****************************************************************************/
+struct efi_hob_guid_type {
+	struct efi_hob_generic_header header;
+	TEE_UUID name;
+	/**
+	 * Guid specific data goes here.
+	 */
+};
+
+/*****************************************************************************
+ *                           Firmware Volume Hob.                            *
+ *****************************************************************************/
+struct efi_hob_firmware_volume {
+	struct efi_hob_generic_header header;
+	efi_physical_address_t base_address;
+	uint64_t length;
+	/**
+	 * Guid specific data goes here.
+	 */
+};
+
+/*****************************************************************************
+ *                              Interfaces.                                  *
+ *****************************************************************************/
+struct efi_hob_handoff_info_table *
+efi_create_hob_list(vaddr_t mem_begin, size_t mem_len,
+		    vaddr_t mem_free_begin, size_t mem_free_len);
+
+TEE_Result
+efi_create_resource_desc_hob(struct efi_hob_handoff_info_table *hob_table,
+			     efi_resource_type_t resource_type,
+			     efi_resource_attribute_type_t resource_attribute,
+			     efi_physical_address_t phy_addr_start,
+			     uint64_t resource_length);
+
+TEE_Result efi_create_guid_hob(struct efi_hob_handoff_info_table *hob_table,
+			       TEE_UUID *guid, uint16_t data_length,
+			       void **data);
+
+TEE_Result efi_create_fv_hob(struct efi_hob_handoff_info_table *hob_table,
+			     efi_physical_address_t base_addr, uint64_t size);
+
+#endif /*__HOB_H */

--- a/core/lib/libefi/include/efi/hob_guid.h
+++ b/core/lib/libefi/include/efi/hob_guid.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Arm Limited and Contributors. All rights reserved.
+ */
+
+#ifndef __HOB_GUID_H
+#define __HOB_GUID_H
+
+#include <efi/efi_types.h>
+
+/**
+ * Guid used for creating StandaloneMm relalted information.
+ */
+
+#define MM_PEI_MMRAM_MEMORY_RESERVE_GUID	\
+{	\
+	0x0703f912, 0xbf8d, 0x4e2a,	\
+	{0xbe, 0x07, 0xab, 0x27, 0x25, 0x25, 0xc5, 0x92 }	\
+}
+
+#define MM_NS_BUFFER_GUID	\
+{	\
+	0xf00497e3, 0xbfa2, 0x41a1,	\
+	{0x9d, 0x29, 0x54, 0xc2, 0xe9, 0x37, 0x21, 0xc5 }	\
+}
+
+#define MM_MP_INFORMATION_GUID	\
+{	\
+	0xba33f15d, 0x4000, 0x45c1,	\
+	{0x8e, 0x88, 0xf9, 0x16, 0x92, 0xd4, 0x57, 0xe3}	\
+}
+
+#endif /* __HOB_GUID_H */

--- a/core/lib/libefi/include/efi/mmram.h
+++ b/core/lib/libefi/include/efi/mmram.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Arm Limited and Contributors. All rights reserved.
+ *
+ * @par Reference(s):
+ * - UEFI Platform Initialization Specification
+ *   (https://uefi.org/specs/PI/1.8/index.html)
+ */
+
+#ifndef __MMRAM_H
+#define __MMRAM_H
+
+#include "efi_types.h"
+
+/**
+ * MMRAM states and capabilities
+ * Cf) UEFI Platform Initialization Specification Version 1.8, IV-5.3.5
+ */
+#define EFI_MMRAM_OPEN                0x00000001
+#define EFI_MMRAM_CLOSED              0x00000002
+#define EFI_MMRAM_LOCKED              0x00000004
+#define EFI_CACHEABLE                 0x00000008
+#define EFI_ALLOCATED                 0x00000010
+#define EFI_NEEDS_TESTING             0x00000020
+#define EFI_NEEDS_ECC_INITIALIZATION  0x00000040
+
+#define EFI_SMRAM_OPEN    EFI_MMRAM_OPEN
+#define EFI_SMRAM_CLOSED  EFI_MMRAM_CLOSED
+#define EFI_SMRAM_LOCKED  EFI_MMRAM_LOCKED
+
+struct efi_mmram_descriptor {
+	efi_physical_address_t physical_start;
+	efi_physical_address_t cpu_start;
+	uint64_t physical_size;
+	uint64_t region_state;
+};
+
+/**
+ * MMRAM block descriptor
+ * This definition comes from
+ *     https://github.com/samimujawar/edk2/blob/master/StandaloneMmPkg/Include/Guid/MmramMemoryReserve.h
+ */
+struct efi_mmram_hob_descriptor_block {
+	uint32_t number_of_mm_reserved_regions;
+	struct efi_mmram_descriptor descriptor[];
+};
+
+#endif

--- a/core/lib/libefi/include/efi/mpinfo.h
+++ b/core/lib/libefi/include/efi/mpinfo.h
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Arm Limited and Contributors. All rights reserved.
+ *
+ * * @par Reference(s):
+ * - UEFI Platform Initialization Specification
+ *   (https://uefi.org/specs/PI/1.8/index.html)
+ */
+
+#ifndef __MPINFO_H
+#define __MPINFO_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <util.h>
+
+/*
+ * Value used in the NumberProcessors parameter of
+ * the GetProcessorInfo function
+ */
+#define CPU_V2_EXTENDED_TOPOLOGY  BIT(24)
+
+/*
+ * This bit is used in the StatusFlag field of EFI_PROCESSOR_INFORMATION and
+ * indicates whether the processor is playing the role of BSP.
+ * If the bit is 1, then the processor is BSP. Otherwise, it is AP.
+ */
+#define PROCESSOR_AS_BSP_BIT  BIT(0)
+
+/*
+ * This bit is used in the StatusFlag field of EFI_PROCESSOR_INFORMATION and
+ * indicates whether the processor is enabled. If the bit is 1,
+ * then the processor is enabled. Otherwise, it is disabled.
+ */
+#define PROCESSOR_ENABLED_BIT  BIT(1)
+
+/*
+ * This bit is used in the StatusFlag field of EFI_PROCESSOR_INFORMATION and
+ * indicates whether the processor is healthy. If the bit is 1, then the
+ * processor is healthy. Otherwise,
+ * some fault has been detected for the processor.
+ */
+#define PROCESSOR_HEALTH_STATUS_BIT  BIT(2)
+
+/*
+ * Structure that describes the pyhiscal location of a logical CPU.
+ */
+struct efi_cpu_physical_location {
+	uint32_t package;
+	uint32_t core;
+	uint32_t thread;
+};
+
+/*
+ * Structure that defines the 6-level physical location of the processor
+ */
+struct efi_cpu_physical_location2 {
+	uint32_t package;
+	uint32_t module;
+	uint32_t tile;
+	uint32_t die;
+	uint32_t core;
+	uint32_t thread;
+};
+
+union extended_processor_information {
+	/*
+	 * The 6-level physical location of the processor, including
+	 * the physical package number that identifies the cartridge,
+	 * the physical module number within package,
+	 * the physical tile number within the module,
+	 * the physical die number within the tile,
+	 * the physical core number within package, and
+	 * logical thread number within core.
+	 */
+	struct efi_cpu_physical_location2 location2;
+};
+
+/*
+ * Structure that describes information about a logical CPU.
+ */
+struct efi_processor_information {
+	/*
+	 * The unique processor ID determined by system hardware.
+	 */
+	uint64_t processor_id;
+
+	/*
+	 * Flags indicating if the processor is BSP or AP,
+	 * if the processor is enabled or disabled, and
+	 * if the processor is healthy.
+	 * Bits 3..31 are reserved and must be 0.
+	 *
+	 * BSP  ENABLED  HEALTH  Description
+	 * ===  =======  ======  ===============================================
+	 * 0    0       0   Unhealthy Disabled AP.
+	 * 0    0       1   Healthy Disabled AP.
+	 * 0    1       0   Unhealthy Enabled AP.
+	 * 0    1       1   Healthy Enabled AP.
+	 * 1    0       0   Invalid. The BSP can never be in the disabled state.
+	 * 1    0       1   Invalid. The BSP can never be in the disabled state.
+	 * 1    1       0   Unhealthy Enabled BSP.
+	 * 1    1       1   Healthy Enabled BSP.
+	 */
+	uint32_t status_flags;
+
+	/*
+	 * The physical location of the processor, including
+	 * the physical package number that identifies the cartridge,
+	 * the physical core number within package, and logical thread number
+	 * within core.
+	 */
+	struct efi_cpu_physical_location location;
+
+	/*
+	 * The extended information of the processor.
+	 * This field is filled only when CPU_V2_EXTENDED_TOPOLOGY is set
+	 * in parameter ProcessorNumber.
+	 */
+	union extended_processor_information extended_information;
+};
+
+struct efi_mp_information_hob_data {
+	uint64_t number_of_processors;
+	uint64_t number_of_enabled_processors;
+	struct efi_processor_information processor_info[];
+};
+
+#endif
+

--- a/core/lib/libefi/sub.mk
+++ b/core/lib/libefi/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += hob.c

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -870,6 +870,7 @@ endif
 
 ifneq ($(CFG_STMM_PATH),)
 $(call force,CFG_WITH_STMM_SP,y)
+$(call force,CFG_EFILIB,y)
 else
 CFG_WITH_STMM_SP ?= n
 endif


### PR DESCRIPTION
According to Platform Initialization (PI) Specification [1] and
Discussion on edk2 mailing list [2],
StandaloneMm shouldn't create Hob but it should be passed from TF-A.
That's why StandaloneMm in Arm wouldn't produce Hob by itself [3] but
other software stack should pass boot information via PHIT Hob.

To make compatible with edk2 patches [3], 
add HOB creation to load StandaloneMm properly.

Also, StandaloneMm doesn't support under FF-A v1.2 version ABI.
For this, update syscall handler with FF-A v1.2 compatiblity.

Links: https://uefi.org/sites/default/files/resources/PI_Spec_1_6.pdf [1]
Links: https://edk2.groups.io/g/devel/topic/103675962#114283 [2]
Links: https://github.com/tianocore/edk2/pull/6116 [3]

Tested-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
Acked-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
Acked-by: Jens Wiklander <jens.wiklander@linaro.org>