### PR TITLE
core: mm: fix mobj_tee_ram_rw initialization

### DIFF
--- a/core/mm/mobj.c
+++ b/core/mm/mobj.c
@@ -511,7 +511,7 @@ static TEE_Result mobj_init(void)
 		mobj_tee_ram_rw = mobj_phys_init(TEE_RAM_START,
 						 VCORE_UNPG_RW_PA +
 						 VCORE_UNPG_RW_SZ -
-						 TEE_RAM_START,
+						 VCORE_START_VA,
 						 TEE_MATTR_MEM_TYPE_CACHED,
 						 CORE_MEM_TEE_RAM,
 						 MEM_AREA_TEE_RAM_RW_DATA);


### PR DESCRIPTION
Until this patch, for CFG_CORE_RWDATA_NOEXEC=n and CFG_CORE_ASLR=y there's an error in mobj_init() when the length of the combined TEE_RAM_RWX is calculated.

The relocatable address VCORE_UNPG_RW_PA is mixed with the absolute address TEE_RAM_START. Relocated addresses only changes with CFG_CORE_ASLR=y so before ASLR this expression was correct.

The combined TEE_RAM_RWX is only used with CFG_CORE_RWDATA_NOEXEC=n so that is also a perquisite for the error. The calculated length field is usually not more wrong than code depending on
mobj_tee_ram_rw/mobj_tee_ram_rx still works. So the error wasn't visible until length checks for phys_to_virt() was introduced with the commit c2e4eb43b7b7 ("core_mmu: fix phys_to_virt() to check length").

Fix this by using VCORE_START_VA instead of TEE_RAM_START since the former is a relocated address.

Fixes: c2e4eb43b7b7 ("core_mmu: fix phys_to_virt() to check length")
Fixes: 170e9084a84f ("core: add support for CFG_CORE_ASLR")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
