### PR TITLE
plat-k3: Add locks for TI-SCI protocol

### DIFF
--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -109,6 +109,9 @@ static int ti_sci_do_xfer(struct ti_sci_xfer *xfer)
 		goto unlock;
 	}
 
+	FMSG("Sending %"PRIx16" with seq %"PRIu8" host %"PRIu8,
+	     txhdr->type, txhdr->seq, txhdr->host);
+
 	/* Get the response */
 	for (; retry > 0; retry--) {
 		/* Receive the response */
@@ -134,7 +137,11 @@ static int ti_sci_do_xfer(struct ti_sci_xfer *xfer)
 	if (!(rxhdr->flags & TI_SCI_FLAG_RESP_GENERIC_ACK)) {
 		DMSG("Message not acknowledged");
 		ret = TEE_ERROR_ACCESS_DENIED;
+		goto unlock;
 	}
+
+	FMSG("Receive %"PRIx16" with seq %"PRIu8" host %"PRIu8,
+	     rxhdr->type, rxhdr->seq, rxhdr->host);
 
 unlock:
 	mutex_unlock(&ti_sci_mutex_lock);

--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -20,8 +20,6 @@
 #include "ti_sci.h"
 #include "ti_sci_protocol.h"
 
-static uint8_t message_sequence;
-static struct mutex ti_sci_mutex_lock = MUTEX_INITIALIZER;
 
 /**
  * struct ti_sci_xfer - Structure representing a message flow
@@ -82,80 +80,60 @@ static int ti_sci_setup_xfer(uint16_t msg_type, uint32_t msg_flags,
 }
 
 /**
- * ti_sci_get_response() - Receive response from mailbox channel
- *
- * @xfer:	Transfer to initiate and wait for response
- *
- * Return: 0 if all goes well, else appropriate error message
- */
-static inline int ti_sci_get_response(struct ti_sci_xfer *xfer)
-{
-	struct k3_sec_proxy_msg *msg = &xfer->rx_message;
-	struct ti_sci_msg_hdr *hdr = NULL;
-	unsigned int retry = 5;
-	int ret = 0;
-
-	for (; retry > 0; retry--) {
-		/* Receive the response */
-		ret = k3_sec_proxy_recv(msg);
-		if (ret) {
-			EMSG("Message receive failed (%d)", ret);
-			return ret;
-		}
-
-		/* msg is updated by Secure Proxy driver */
-		hdr = (struct ti_sci_msg_hdr *)msg->buf;
-
-		/* Sanity check for message response */
-		if (hdr->seq == message_sequence)
-			break;
-
-		IMSG("Message with sequence ID %u is not expected", hdr->seq);
-	}
-	if (!retry) {
-		EMSG("Timed out waiting for message");
-		return TEE_ERROR_BUSY;
-	}
-
-	if (!(hdr->flags & TI_SCI_FLAG_RESP_GENERIC_ACK)) {
-		DMSG("Message not acknowledged");
-		return TEE_ERROR_ACCESS_DENIED;
-	}
-
-	return 0;
-}
-
-/**
  * ti_sci_do_xfer() - Do one transfer
  *
  * @xfer: Transfer to initiate and wait for response
  *
  * Return: 0 if all goes well, else appropriate error message
  */
-static inline int ti_sci_do_xfer(struct ti_sci_xfer *xfer)
+static int ti_sci_do_xfer(struct ti_sci_xfer *xfer)
 {
-	struct k3_sec_proxy_msg *msg = &xfer->tx_message;
-	struct ti_sci_msg_hdr *hdr = NULL;
+	struct k3_sec_proxy_msg *txmsg = &xfer->tx_message;
+	struct k3_sec_proxy_msg *rxmsg = &xfer->rx_message;
+	struct ti_sci_msg_hdr *txhdr = (struct ti_sci_msg_hdr *)txmsg->buf;
+	struct ti_sci_msg_hdr *rxhdr = (struct ti_sci_msg_hdr *)rxmsg->buf;
+	static uint8_t message_sequence;
+	static struct mutex ti_sci_mutex_lock = MUTEX_INITIALIZER;
+	unsigned int retry = 5;
 	int ret = 0;
 
 	mutex_lock(&ti_sci_mutex_lock);
 
-	hdr = (struct ti_sci_msg_hdr *)msg->buf;
-	hdr->seq = ++message_sequence;
+	message_sequence++;
+	txhdr->seq = message_sequence;
 
 	/* Send the message */
-	ret = k3_sec_proxy_send(msg);
+	ret = k3_sec_proxy_send(txmsg);
 	if (ret) {
 		EMSG("Message sending failed (%d)", ret);
 		goto unlock;
 	}
 
 	/* Get the response */
-	ret = ti_sci_get_response(xfer);
-	if (ret) {
-		if ((TEE_Result)ret != TEE_ERROR_ACCESS_DENIED)
-			EMSG("Failed to get response (%d)", ret);
+	for (; retry > 0; retry--) {
+		/* Receive the response */
+		ret = k3_sec_proxy_recv(rxmsg);
+		if (ret) {
+			EMSG("Message receive failed (%d)", ret);
+			goto unlock;
+		}
+
+		/* Sanity check for message response */
+		if (rxhdr->seq == message_sequence)
+			break;
+
+		IMSG("Message with sequence ID %"PRIu8" is not expected",
+		     rxhdr->seq);
+	}
+	if (!retry) {
+		EMSG("Timed out waiting for message");
+		ret = TEE_ERROR_BUSY;
 		goto unlock;
+	}
+
+	if (!(rxhdr->flags & TI_SCI_FLAG_RESP_GENERIC_ACK)) {
+		DMSG("Message not acknowledged");
+		ret = TEE_ERROR_ACCESS_DENIED;
 	}
 
 unlock:

--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -68,7 +68,6 @@ static int ti_sci_setup_xfer(uint16_t msg_type, uint32_t msg_flags,
 	}
 
 	hdr = (struct ti_sci_msg_hdr *)tx_buf;
-	hdr->seq = ++message_sequence;
 	hdr->type = msg_type;
 	hdr->host = OPTEE_HOST_ID;
 	hdr->flags = msg_flags | TI_SCI_FLAG_REQ_ACK_ON_PROCESSED;
@@ -136,9 +135,13 @@ static inline int ti_sci_get_response(struct ti_sci_xfer *xfer)
 static inline int ti_sci_do_xfer(struct ti_sci_xfer *xfer)
 {
 	struct k3_sec_proxy_msg *msg = &xfer->tx_message;
+	struct ti_sci_msg_hdr *hdr = NULL;
 	int ret = 0;
 
 	mutex_lock(&ti_sci_mutex_lock);
+
+	hdr = (struct ti_sci_msg_hdr *)msg->buf;
+	hdr->seq = ++message_sequence;
 
 	/* Send the message */
 	ret = k3_sec_proxy_send(msg);


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
Currently TI-SCI layer doesn't have any locks that can lead to race conditions, add locks in appropriate places to avoid race conditions.

Signed-off-by: Manorit Chawdhry <m-chawdhry@ti.com>