### PR TITLE
drivers: caam: skip JR init of CFG_JR_HAB_INDEX

### DIFF
--- a/core/drivers/crypto/caam/hal/common/hal_cfg.c
+++ b/core/drivers/crypto/caam/hal/common/hal_cfg.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright 2017-2019, 2021 NXP
+ * Copyright 2017-2019, 2021, 2024 NXP
  *
  * Brief   CAAM Configuration.
  */
@@ -66,6 +66,12 @@ enum caam_status caam_hal_cfg_get_conf(struct caam_jrcfg *jrcfg)
 
 	retstatus = CAAM_NO_ERROR;
 
+#ifdef CFG_NXP_CAAM_RUNTIME_JR
+	caam_hal_jr_prepare_backup(jrcfg->base, jrcfg->offset);
+#endif
+
+	caam_hal_cfg_hab_jr_mgmt(jrcfg);
+
 exit_get_conf:
 	HAL_TRACE("HAL CFG Get CAAM config ret (0x%x)\n", retstatus);
 	return retstatus;
@@ -79,6 +85,12 @@ void __weak caam_hal_cfg_setup_nsjobring(struct caam_jrcfg *jrcfg)
 
 	for (jrnum = caam_hal_ctrl_jrnum(jrcfg->base); jrnum; jrnum--) {
 		jr_offset = jrnum * JRX_BLOCK_SIZE;
+
+		/*
+		 * Skip configuration for the JR used by the HAB
+		 */
+		if (caam_hal_cfg_is_hab_jr(jr_offset))
+			continue;
 
 #ifdef CFG_NXP_CAAM_RUNTIME_JR
 		/*
@@ -97,4 +109,13 @@ void __weak caam_hal_cfg_setup_nsjobring(struct caam_jrcfg *jrcfg)
 		if (status == CAAM_NO_ERROR)
 			caam_hal_jr_prepare_backup(jrcfg->base, jr_offset);
 	}
+}
+
+__weak void caam_hal_cfg_hab_jr_mgmt(struct caam_jrcfg *jrcfg __unused)
+{
+}
+
+__weak bool caam_hal_cfg_is_hab_jr(paddr_t jr_offset __unused)
+{
+	return false;
 }

--- a/core/drivers/crypto/caam/hal/imx_8m/hal_cfg.c
+++ b/core/drivers/crypto/caam/hal/imx_8m/hal_cfg.c
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2024 NXP
+ *
+ * Brief   CAAM Configuration.
+ */
+#include <caam_hal_cfg.h>
+#include <caam_hal_jr.h>
+#include <kernel/dt.h>
+#include <registers/jr_regs.h>
+
+void caam_hal_cfg_hab_jr_mgmt(struct caam_jrcfg *jrcfg)
+{
+	void *fdt = NULL;
+	struct caam_jrcfg tmp_jrcfg = {
+		.offset = (CFG_JR_HAB_INDEX + 1) * JRX_BLOCK_SIZE,
+	};
+
+	fdt = get_dt();
+	if (fdt) {
+		/* Ensure Secure Job Ring is secure only into DTB */
+		caam_hal_cfg_disable_jobring_dt(fdt, &tmp_jrcfg);
+	}
+
+	caam_hal_jr_prepare_backup(jrcfg->base, tmp_jrcfg.offset);
+}
+
+bool caam_hal_cfg_is_hab_jr(paddr_t jr_offset)
+{
+	unsigned int jr_idx = JRX_IDX(jr_offset);
+
+	return jr_idx == CFG_JR_HAB_INDEX;
+}

--- a/core/drivers/crypto/caam/hal/imx_8m/sub.mk
+++ b/core/drivers/crypto/caam/hal/imx_8m/sub.mk
@@ -5,3 +5,4 @@ incdirs-y += .
 srcs-y += hal_clk.c
 srcs-y += hal_ctrl.c
 srcs-y += hal_jr.c
+srcs-y += hal_cfg.c

--- a/core/drivers/crypto/caam/include/caam_hal_cfg.h
+++ b/core/drivers/crypto/caam/include/caam_hal_cfg.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright 2018-2019 NXP
+ * Copyright 2018-2019, 2024 NXP
  *
  * Brief   CAAM Configuration header.
  */
@@ -26,6 +26,20 @@ enum caam_status caam_hal_cfg_get_conf(struct caam_jrcfg *jrcfg);
  * @jrcfg   Job Ring configuration
  */
 void caam_hal_cfg_setup_nsjobring(struct caam_jrcfg *jrcfg);
+
+/*
+ * Removes the JR used by HAB from dtb and backup its DID
+ *
+ * @jrcfg   Job Ring configuration of HAB JR
+ */
+void caam_hal_cfg_hab_jr_mgmt(struct caam_jrcfg *jrcfg);
+
+/*
+ * Indicate if the job ring is used by the HAB
+ *
+ * @jr_offset   Job Ring offset
+ */
+bool caam_hal_cfg_is_hab_jr(paddr_t jr_offset);
 
 #ifdef CFG_DT
 /*


### PR DESCRIPTION
On iMX8M SoC, the HAB requires the JR0 to be set to secure world to decrypt the kernel image when loading the image in U-boot.

Before reaching u-boot, OPTEE and ATF set the JR0 to the non-secure domain that leads to a HAB failure when trying to decrypt the kernel.

To fix the issue, this commit introduces CFG_JR_HAB_INDEX that specifies which JR the HAB uses. OPTEE will skip the initialization of CFG_JR_HAB_INDEX and leave it as secure.

It will also disable its usage in the device tree to inform the kernel.