### PR TITLE
core: fix race in mobj_reg_shm_get_by_cookie()

### DIFF
--- a/core/mm/mobj_dyn_shm.c
+++ b/core/mm/mobj_dyn_shm.c
@@ -366,14 +366,17 @@ static struct mobj_reg_shm *reg_shm_find_unlocked(uint64_t cookie)
 
 struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie)
 {
-	uint32_t exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
-	struct mobj_reg_shm *r = reg_shm_find_unlocked(cookie);
+	struct mobj_reg_shm *r = NULL;
+	uint32_t exceptions = 0;
+	struct mobj *m = NULL;
 
+	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+	r = reg_shm_find_unlocked(cookie);
+	if (r)
+		m = mobj_get(&r->mobj);
 	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
-	if (!r)
-		return NULL;
 
-	return mobj_get(&r->mobj);
+	return m;
 }
 
 TEE_Result mobj_reg_shm_release_by_cookie(uint64_t cookie)


### PR DESCRIPTION
Until this patch in mobj_reg_shm_get_by_cookie() there's a small window after cpu_spin_unlock_xrestore() before the reference counter is increased with mobj_get(). Fix that by calling mobj_get() before unlocking reg_shm_slist_lock.

Fixes: b96514926b8e ("core: reference count struct mobj")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
