### PR TITLE
refine code comments: clarify misleading names and comments for `thread_rpc_alloc_*_payload` APIs

### DIFF
--- a/core/include/kernel/thread.h
+++ b/core/include/kernel/thread.h
@@ -244,7 +244,9 @@ bool thread_is_in_normal_mode(void);
 bool thread_is_from_abort_mode(void);
 
 /**
- * Allocates data for payload buffers.
+ * Allocates data for payload buffers shared with a non-secure user space
+ * application. Ensure consistency with the enumeration
+ * THREAD_SHM_TYPE_APPLICATION.
  *
  * @size:	size in bytes of payload buffer
  *
@@ -260,7 +262,8 @@ struct mobj *thread_rpc_alloc_payload(size_t size);
 void thread_rpc_free_payload(struct mobj *mobj);
 
 /**
- * Allocate data for payload buffers only shared with the non-secure kernel
+ * Allocate data for payload buffers shared with the non-secure kernel.
+ * Ensure consistency with the enumeration THREAD_SHM_TYPE_KERNEL_PRIVATE.
  *
  * @size:	size in bytes of payload buffer
  *
@@ -333,8 +336,9 @@ uint32_t thread_rpc_cmd(uint32_t cmd, size_t num_params,
 		struct thread_param *params);
 
 /**
- * Allocate data for payload buffers.
- * Buffer is exported to user mode applications.
+ * Allocate data for payload buffers shared with both user space applications
+ * and the non-secure kernel. Ensure consistency with the enumeration
+ * THREAD_SHM_TYPE_GLOBAL.
  *
  * @size:	size in bytes of payload buffer
  *


### PR DESCRIPTION


The `thread_rpc_alloc_*_payload` APIs are consistent with the `thread_shm_type` enumerations, as seen in the `alloc_shm` function. However, the name and comments of `thread_rpc_alloc_payload` might be misleading, suggesting it is a universal API. To maintain backward compatibility, only the code comments have been updated for clarity.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
