### PR TITLE
core: change get_core_pos_mpidr() to support hypervisor

### DIFF
--- a/core/arch/arm/include/arm.h
+++ b/core/arch/arm/include/arm.h
@@ -76,6 +76,9 @@
 #define MPIDR_AARCH32_AFF_MASK	(MPIDR_AFF0_MASK | MPIDR_AFF1_MASK | \
 				 MPIDR_AFF2_MASK)
 
+/* MPIDR definitions for VCPU */
+#define MPIDR_VCPU_MASK		ULL(0xffffff)
+
 /* ID_ISAR5 Cryptography Extension masks */
 #define ID_ISAR5_AES		GENMASK_32(7, 4)
 #define ID_ISAR5_SHA1		GENMASK_32(11, 8)

--- a/core/arch/arm/kernel/misc_a64.S
+++ b/core/arch/arm/kernel/misc_a64.S
@@ -17,6 +17,10 @@ END_FUNC __get_core_pos
 /* size_t get_core_pos_mpidr(uint32_t mpidr); */
 /* Let platforms override this if needed */
 WEAK_FUNC get_core_pos_mpidr , :
+#if CFG_CORE_SEL2_SPMC
+	mov	x1, #MPIDR_VCPU_MASK
+	and	x0, x0, x1
+#else /* CFG_CORE_SEL2_SPMC */
 	/*
 	 * Shift MPIDR value if it's not already shifted.
 	 * Using logical shift ensures AFF0 to be filled with zeroes.
@@ -47,6 +51,7 @@ WEAK_FUNC get_core_pos_mpidr , :
 	ubfx	x2, x3, #MPIDR_AFF2_SHIFT, #MPIDR_AFFINITY_BITS
 	add	x1, x1, x2, LSL #(CFG_CORE_CLUSTER_SHIFT)
 	add	x0, x0, x1, LSL #(CFG_CORE_THREAD_SHIFT)
+#endif
 #endif
 
 	ret


### PR DESCRIPTION
Secure hypervisor such as Hafnium can manipulate
MPIDR_EL1 to indicate VCPU ID.

This commit makes get_core_pos_mpidr() not calculate CPU ID with affinity bitfields of MPIDR_EL1 when
there is hypervisor in SEL2.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
