### PR TITLE
core: stm32_gpio: register firewall controllers for GPIO access rights

### DIFF
--- a/core/arch/arm/dts/stm32mp13-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp13-pinctrl.dtsi
@@ -27,13 +27,13 @@
 
 	uart4_pins_a: uart4-0 {
 		pins1 {
-			pinmux = <STM32_PINMUX('D', 6, AF8)>; /* UART4_TX */
+			pinmux = <STM32_PINMUX_NSEC('D', 6, AF8)>; /* UART4_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('D', 8, AF8)>; /* UART4_RX */
+			pinmux = <STM32_PINMUX_NSEC('D', 8, AF8)>; /* UART4_RX */
 			bias-disable;
 		};
 	};

--- a/core/arch/arm/dts/stm32mp131.dtsi
+++ b/core/arch/arm/dts/stm32mp131.dtsi
@@ -291,6 +291,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOA>;
 				reg = <0x0 0x400>;
 				st,bank-name = "GPIOA";
@@ -303,6 +304,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOB>;
 				reg = <0x1000 0x400>;
 				st,bank-name = "GPIOB";
@@ -315,6 +317,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOC>;
 				reg = <0x2000 0x400>;
 				st,bank-name = "GPIOC";
@@ -327,6 +330,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOD>;
 				reg = <0x3000 0x400>;
 				st,bank-name = "GPIOD";
@@ -339,6 +343,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOE>;
 				reg = <0x4000 0x400>;
 				st,bank-name = "GPIOE";
@@ -351,6 +356,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOF>;
 				reg = <0x5000 0x400>;
 				st,bank-name = "GPIOF";
@@ -363,6 +369,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOG>;
 				reg = <0x6000 0x400>;
 				st,bank-name = "GPIOG";
@@ -375,6 +382,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOH>;
 				reg = <0x7000 0x400>;
 				st,bank-name = "GPIOH";
@@ -387,6 +395,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				clocks = <&rcc GPIOI>;
 				reg = <0x8000 0x400>;
 				st,bank-name = "GPIOI";

--- a/core/arch/arm/dts/stm32mp15-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp15-pinctrl.dtsi
@@ -2215,6 +2215,23 @@
 
 	i2c4_pins_a: i2c4-0 {
 		pins {
+			pinmux = <STM32_PINMUX_NSEC('Z', 4, AF6)>, /* I2C4_SCL */
+				 <STM32_PINMUX_NSEC('Z', 5, AF6)>; /* I2C4_SDA */
+			bias-disable;
+			drive-open-drain;
+			slew-rate = <0>;
+		};
+	};
+
+	i2c4_sleep_pins_a: i2c4-sleep-0 {
+		pins {
+			pinmux = <STM32_PINMUX_NSEC('Z', 4, ANALOG)>, /* I2C4_SCL */
+				 <STM32_PINMUX_NSEC('Z', 5, ANALOG)>; /* I2C4_SDA */
+		};
+	};
+
+	i2c4_secure_pins_a: i2c4-sec-0 {
+		pins {
 			pinmux = <STM32_PINMUX('Z', 4, AF6)>, /* I2C4_SCL */
 				 <STM32_PINMUX('Z', 5, AF6)>; /* I2C4_SDA */
 			bias-disable;
@@ -2223,7 +2240,7 @@
 		};
 	};
 
-	i2c4_sleep_pins_a: i2c4-sleep-0 {
+	i2c4_secure_sleep_pins_a: i2c4-sec-sleep-0 {
 		pins {
 			pinmux = <STM32_PINMUX('Z', 4, ANALOG)>, /* I2C4_SCL */
 				 <STM32_PINMUX('Z', 5, ANALOG)>; /* I2C4_SDA */

--- a/core/arch/arm/dts/stm32mp15-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp15-pinctrl.dtsi
@@ -1830,356 +1830,356 @@
 
 	uart4_pins_a: uart4-0 {
 		pins1 {
-			pinmux = <STM32_PINMUX('G', 11, AF6)>; /* UART4_TX */
+			pinmux = <STM32_PINMUX_NSEC('G', 11, AF6)>; /* UART4_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('B', 2, AF8)>; /* UART4_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 2, AF8)>; /* UART4_RX */
 			bias-disable;
 		};
 	};
 
 	uart4_idle_pins_a: uart4-idle-0 {
 		pins1 {
-			pinmux = <STM32_PINMUX('G', 11, ANALOG)>; /* UART4_TX */
+			pinmux = <STM32_PINMUX_NSEC('G', 11, ANALOG)>; /* UART4_TX */
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('B', 2, AF8)>; /* UART4_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 2, AF8)>; /* UART4_RX */
 			bias-disable;
 		};
 	};
 
 	uart4_sleep_pins_a: uart4-sleep-0 {
 		pins {
-			pinmux = <STM32_PINMUX('G', 11, ANALOG)>, /* UART4_TX */
-				 <STM32_PINMUX('B', 2, ANALOG)>; /* UART4_RX */
+			pinmux = <STM32_PINMUX_NSEC('G', 11, ANALOG)>, /* UART4_TX */
+				 <STM32_PINMUX_NSEC('B', 2, ANALOG)>; /* UART4_RX */
 		};
 	};
 
 	uart4_pins_b: uart4-1 {
 		pins1 {
-			pinmux = <STM32_PINMUX('D', 1, AF8)>; /* UART4_TX */
+			pinmux = <STM32_PINMUX_NSEC('D', 1, AF8)>; /* UART4_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('B', 2, AF8)>; /* UART4_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 2, AF8)>; /* UART4_RX */
 			bias-disable;
 		};
 	};
 
 	uart4_pins_c: uart4-2 {
 		pins1 {
-			pinmux = <STM32_PINMUX('G', 11, AF6)>; /* UART4_TX */
+			pinmux = <STM32_PINMUX_NSEC('G', 11, AF6)>; /* UART4_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('B', 2, AF8)>; /* UART4_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 2, AF8)>; /* UART4_RX */
 			bias-disable;
 		};
 	};
 
 	uart7_pins_a: uart7-0 {
 		pins1 {
-			pinmux = <STM32_PINMUX('E', 8, AF7)>; /* UART7_TX */
+			pinmux = <STM32_PINMUX_NSEC('E', 8, AF7)>; /* UART7_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('E', 7, AF7)>, /* UART7_RX */
-				 <STM32_PINMUX('E', 10, AF7)>, /* UART7_CTS */
-				 <STM32_PINMUX('E', 9, AF7)>; /* UART7_RTS */
+			pinmux = <STM32_PINMUX_NSEC('E', 7, AF7)>, /* UART7_RX */
+				 <STM32_PINMUX_NSEC('E', 10, AF7)>, /* UART7_CTS */
+				 <STM32_PINMUX_NSEC('E', 9, AF7)>; /* UART7_RTS */
 			bias-disable;
 		};
 	};
 
 	uart7_pins_b: uart7-1 {
 		pins1 {
-			pinmux = <STM32_PINMUX('F', 7, AF7)>; /* UART7_TX */
+			pinmux = <STM32_PINMUX_NSEC('F', 7, AF7)>; /* UART7_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('F', 6, AF7)>; /* UART7_RX */
+			pinmux = <STM32_PINMUX_NSEC('F', 6, AF7)>; /* UART7_RX */
 			bias-disable;
 		};
 	};
 
 	uart7_pins_c: uart7-2 {
 		pins1 {
-			pinmux = <STM32_PINMUX('E', 8, AF7)>; /* UART7_TX */
+			pinmux = <STM32_PINMUX_NSEC('E', 8, AF7)>; /* UART7_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('E', 7, AF7)>; /* UART7_RX */
+			pinmux = <STM32_PINMUX_NSEC('E', 7, AF7)>; /* UART7_RX */
 			bias-pull-up;
 		};
 	};
 
 	uart7_idle_pins_c: uart7-idle-2 {
 		pins1 {
-			pinmux = <STM32_PINMUX('E', 8, ANALOG)>; /* UART7_TX */
+			pinmux = <STM32_PINMUX_NSEC('E', 8, ANALOG)>; /* UART7_TX */
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('E', 7, AF7)>; /* UART7_RX */
+			pinmux = <STM32_PINMUX_NSEC('E', 7, AF7)>; /* UART7_RX */
 			bias-pull-up;
 		};
 	};
 
 	uart7_sleep_pins_c: uart7-sleep-2 {
 		pins {
-			pinmux = <STM32_PINMUX('E', 8, ANALOG)>, /* UART7_TX */
-				 <STM32_PINMUX('E', 7, ANALOG)>; /* UART7_RX */
+			pinmux = <STM32_PINMUX_NSEC('E', 8, ANALOG)>, /* UART7_TX */
+				 <STM32_PINMUX_NSEC('E', 7, ANALOG)>; /* UART7_RX */
 		};
 	};
 
 	uart8_pins_a: uart8-0 {
 		pins1 {
-			pinmux = <STM32_PINMUX('E', 1, AF8)>; /* UART8_TX */
+			pinmux = <STM32_PINMUX_NSEC('E', 1, AF8)>; /* UART8_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('E', 0, AF8)>; /* UART8_RX */
+			pinmux = <STM32_PINMUX_NSEC('E', 0, AF8)>; /* UART8_RX */
 			bias-disable;
 		};
 	};
 
 	uart8_rtscts_pins_a: uart8rtscts-0 {
 		pins {
-			pinmux = <STM32_PINMUX('G', 7, AF8)>, /* UART8_RTS */
-				 <STM32_PINMUX('G', 10, AF8)>; /* UART8_CTS */
+			pinmux = <STM32_PINMUX_NSEC('G', 7, AF8)>, /* UART8_RTS */
+				 <STM32_PINMUX_NSEC('G', 10, AF8)>; /* UART8_CTS */
 			bias-disable;
 		};
 	};
 
 	usart2_pins_a: usart2-0 {
 		pins1 {
-			pinmux = <STM32_PINMUX('F', 5, AF7)>, /* USART2_TX */
-				 <STM32_PINMUX('D', 4, AF7)>; /* USART2_RTS */
+			pinmux = <STM32_PINMUX_NSEC('F', 5, AF7)>, /* USART2_TX */
+				 <STM32_PINMUX_NSEC('D', 4, AF7)>; /* USART2_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('D', 6, AF7)>, /* USART2_RX */
-				 <STM32_PINMUX('D', 3, AF7)>; /* USART2_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('D', 6, AF7)>, /* USART2_RX */
+				 <STM32_PINMUX_NSEC('D', 3, AF7)>; /* USART2_CTS_NSS */
 			bias-disable;
 		};
 	};
 
 	usart2_sleep_pins_a: usart2-sleep-0 {
 		pins {
-			pinmux = <STM32_PINMUX('F', 5, ANALOG)>, /* USART2_TX */
-				 <STM32_PINMUX('D', 4, ANALOG)>, /* USART2_RTS */
-				 <STM32_PINMUX('D', 6, ANALOG)>, /* USART2_RX */
-				 <STM32_PINMUX('D', 3, ANALOG)>; /* USART2_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('F', 5, ANALOG)>, /* USART2_TX */
+				 <STM32_PINMUX_NSEC('D', 4, ANALOG)>, /* USART2_RTS */
+				 <STM32_PINMUX_NSEC('D', 6, ANALOG)>, /* USART2_RX */
+				 <STM32_PINMUX_NSEC('D', 3, ANALOG)>; /* USART2_CTS_NSS */
 		};
 	};
 
 	usart2_pins_b: usart2-1 {
 		pins1 {
-			pinmux = <STM32_PINMUX('F', 5, AF7)>, /* USART2_TX */
-				 <STM32_PINMUX('A', 1, AF7)>; /* USART2_RTS */
+			pinmux = <STM32_PINMUX_NSEC('F', 5, AF7)>, /* USART2_TX */
+				 <STM32_PINMUX_NSEC('A', 1, AF7)>; /* USART2_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('F', 4, AF7)>, /* USART2_RX */
-				 <STM32_PINMUX('E', 15, AF7)>; /* USART2_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('F', 4, AF7)>, /* USART2_RX */
+				 <STM32_PINMUX_NSEC('E', 15, AF7)>; /* USART2_CTS_NSS */
 			bias-disable;
 		};
 	};
 
 	usart2_sleep_pins_b: usart2-sleep-1 {
 		pins {
-			pinmux = <STM32_PINMUX('F', 5, ANALOG)>, /* USART2_TX */
-				 <STM32_PINMUX('A', 1, ANALOG)>, /* USART2_RTS */
-				 <STM32_PINMUX('F', 4, ANALOG)>, /* USART2_RX */
-				 <STM32_PINMUX('E', 15, ANALOG)>; /* USART2_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('F', 5, ANALOG)>, /* USART2_TX */
+				 <STM32_PINMUX_NSEC('A', 1, ANALOG)>, /* USART2_RTS */
+				 <STM32_PINMUX_NSEC('F', 4, ANALOG)>, /* USART2_RX */
+				 <STM32_PINMUX_NSEC('E', 15, ANALOG)>; /* USART2_CTS_NSS */
 		};
 	};
 
 	usart2_pins_c: usart2-2 {
 		pins1 {
-			pinmux = <STM32_PINMUX('D', 5, AF7)>, /* USART2_TX */
-				 <STM32_PINMUX('D', 4, AF7)>; /* USART2_RTS */
+			pinmux = <STM32_PINMUX_NSEC('D', 5, AF7)>, /* USART2_TX */
+				 <STM32_PINMUX_NSEC('D', 4, AF7)>; /* USART2_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('D', 6, AF7)>, /* USART2_RX */
-				 <STM32_PINMUX('D', 3, AF7)>; /* USART2_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('D', 6, AF7)>, /* USART2_RX */
+				 <STM32_PINMUX_NSEC('D', 3, AF7)>; /* USART2_CTS_NSS */
 			bias-disable;
 		};
 	};
 
 	usart2_idle_pins_c: usart2-idle-2 {
 		pins1 {
-			pinmux = <STM32_PINMUX('D', 5, ANALOG)>, /* USART2_TX */
-				 <STM32_PINMUX('D', 3, ANALOG)>; /* USART2_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('D', 5, ANALOG)>, /* USART2_TX */
+				 <STM32_PINMUX_NSEC('D', 3, ANALOG)>; /* USART2_CTS_NSS */
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('D', 4, AF7)>; /* USART2_RTS */
+			pinmux = <STM32_PINMUX_NSEC('D', 4, AF7)>; /* USART2_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins3 {
-			pinmux = <STM32_PINMUX('D', 6, AF7)>; /* USART2_RX */
+			pinmux = <STM32_PINMUX_NSEC('D', 6, AF7)>; /* USART2_RX */
 			bias-disable;
 		};
 	};
 
 	usart2_sleep_pins_c: usart2-sleep-2 {
 		pins {
-			pinmux = <STM32_PINMUX('D', 5, ANALOG)>, /* USART2_TX */
-				 <STM32_PINMUX('D', 4, ANALOG)>, /* USART2_RTS */
-				 <STM32_PINMUX('D', 6, ANALOG)>, /* USART2_RX */
-				 <STM32_PINMUX('D', 3, ANALOG)>; /* USART2_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('D', 5, ANALOG)>, /* USART2_TX */
+				 <STM32_PINMUX_NSEC('D', 4, ANALOG)>, /* USART2_RTS */
+				 <STM32_PINMUX_NSEC('D', 6, ANALOG)>, /* USART2_RX */
+				 <STM32_PINMUX_NSEC('D', 3, ANALOG)>; /* USART2_CTS_NSS */
 		};
 	};
 
 	usart3_pins_a: usart3-0 {
 		pins1 {
-			pinmux = <STM32_PINMUX('B', 10, AF7)>; /* USART3_TX */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, AF7)>; /* USART3_TX */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('B', 12, AF8)>; /* USART3_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 12, AF8)>; /* USART3_RX */
 			bias-disable;
 		};
 	};
 
 	usart3_pins_b: usart3-1 {
 		pins1 {
-			pinmux = <STM32_PINMUX('B', 10, AF7)>, /* USART3_TX */
-				 <STM32_PINMUX('G', 8, AF8)>; /* USART3_RTS */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, AF7)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('G', 8, AF8)>; /* USART3_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('B', 12, AF8)>, /* USART3_RX */
-				 <STM32_PINMUX('I', 10, AF8)>; /* USART3_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('B', 12, AF8)>, /* USART3_RX */
+				 <STM32_PINMUX_NSEC('I', 10, AF8)>; /* USART3_CTS_NSS */
 			bias-pull-up;
 		};
 	};
 
 	usart3_idle_pins_b: usart3-idle-1 {
 		pins1 {
-			pinmux = <STM32_PINMUX('B', 10, ANALOG)>, /* USART3_TX */
-				 <STM32_PINMUX('I', 10, ANALOG)>; /* USART3_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, ANALOG)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('I', 10, ANALOG)>; /* USART3_CTS_NSS */
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('G', 8, AF8)>; /* USART3_RTS */
+			pinmux = <STM32_PINMUX_NSEC('G', 8, AF8)>; /* USART3_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins3 {
-			pinmux = <STM32_PINMUX('B', 12, AF8)>; /* USART3_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 12, AF8)>; /* USART3_RX */
 			bias-pull-up;
 		};
 	};
 
 	usart3_sleep_pins_b: usart3-sleep-1 {
 		pins {
-			pinmux = <STM32_PINMUX('B', 10, ANALOG)>, /* USART3_TX */
-				 <STM32_PINMUX('G', 8, ANALOG)>, /* USART3_RTS */
-				 <STM32_PINMUX('I', 10, ANALOG)>, /* USART3_CTS_NSS */
-				 <STM32_PINMUX('B', 12, ANALOG)>; /* USART3_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, ANALOG)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('G', 8, ANALOG)>, /* USART3_RTS */
+				 <STM32_PINMUX_NSEC('I', 10, ANALOG)>, /* USART3_CTS_NSS */
+				 <STM32_PINMUX_NSEC('B', 12, ANALOG)>; /* USART3_RX */
 		};
 	};
 
 	usart3_pins_c: usart3-2 {
 		pins1 {
-			pinmux = <STM32_PINMUX('B', 10, AF7)>, /* USART3_TX */
-				 <STM32_PINMUX('G', 8, AF8)>; /* USART3_RTS */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, AF7)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('G', 8, AF8)>; /* USART3_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('B', 12, AF8)>, /* USART3_RX */
-				 <STM32_PINMUX('B', 13, AF7)>; /* USART3_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('B', 12, AF8)>, /* USART3_RX */
+				 <STM32_PINMUX_NSEC('B', 13, AF7)>; /* USART3_CTS_NSS */
 			bias-pull-up;
 		};
 	};
 
 	usart3_idle_pins_c: usart3-idle-2 {
 		pins1 {
-			pinmux = <STM32_PINMUX('B', 10, ANALOG)>, /* USART3_TX */
-				 <STM32_PINMUX('B', 13, ANALOG)>; /* USART3_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, ANALOG)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('B', 13, ANALOG)>; /* USART3_CTS_NSS */
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('G', 8, AF8)>; /* USART3_RTS */
+			pinmux = <STM32_PINMUX_NSEC('G', 8, AF8)>; /* USART3_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins3 {
-			pinmux = <STM32_PINMUX('B', 12, AF8)>; /* USART3_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 12, AF8)>; /* USART3_RX */
 			bias-pull-up;
 		};
 	};
 
 	usart3_sleep_pins_c: usart3-sleep-2 {
 		pins {
-			pinmux = <STM32_PINMUX('B', 10, ANALOG)>, /* USART3_TX */
-				 <STM32_PINMUX('G', 8, ANALOG)>, /* USART3_RTS */
-				 <STM32_PINMUX('B', 13, ANALOG)>, /* USART3_CTS_NSS */
-				 <STM32_PINMUX('B', 12, ANALOG)>; /* USART3_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, ANALOG)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('G', 8, ANALOG)>, /* USART3_RTS */
+				 <STM32_PINMUX_NSEC('B', 13, ANALOG)>, /* USART3_CTS_NSS */
+				 <STM32_PINMUX_NSEC('B', 12, ANALOG)>; /* USART3_RX */
 		};
 	};
 
 	usart3_pins_d: usart3-3 {
 		pins1 {
-			pinmux = <STM32_PINMUX('B', 10, AF7)>, /* USART3_TX */
-				 <STM32_PINMUX('G', 8, AF8)>; /* USART3_RTS */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, AF7)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('G', 8, AF8)>; /* USART3_RTS */
 			bias-disable;
 			drive-push-pull;
 			slew-rate = <0>;
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('D', 9, AF7)>, /* USART3_RX */
-				 <STM32_PINMUX('D', 11, AF7)>; /* USART3_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('D', 9, AF7)>, /* USART3_RX */
+				 <STM32_PINMUX_NSEC('D', 11, AF7)>; /* USART3_CTS_NSS */
 			bias-disable;
 		};
 	};
 
 	usart3_idle_pins_d: usart3-idle-3 {
 		pins1 {
-			pinmux = <STM32_PINMUX('B', 10, ANALOG)>, /* USART3_TX */
-				 <STM32_PINMUX('G', 8, ANALOG)>, /* USART3_RTS */
-				 <STM32_PINMUX('D', 11, ANALOG)>; /* USART3_CTS_NSS */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, ANALOG)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('G', 8, ANALOG)>, /* USART3_RTS */
+				 <STM32_PINMUX_NSEC('D', 11, ANALOG)>; /* USART3_CTS_NSS */
 		};
 		pins2 {
-			pinmux = <STM32_PINMUX('D', 9, AF7)>; /* USART3_RX */
+			pinmux = <STM32_PINMUX_NSEC('D', 9, AF7)>; /* USART3_RX */
 			bias-disable;
 		};
 	};
 
 	usart3_sleep_pins_d: usart3-sleep-3 {
 		pins {
-			pinmux = <STM32_PINMUX('B', 10, ANALOG)>, /* USART3_TX */
-				 <STM32_PINMUX('G', 8, ANALOG)>, /* USART3_RTS */
-				 <STM32_PINMUX('D', 11, ANALOG)>, /* USART3_CTS_NSS */
-				 <STM32_PINMUX('D', 9, ANALOG)>; /* USART3_RX */
+			pinmux = <STM32_PINMUX_NSEC('B', 10, ANALOG)>, /* USART3_TX */
+				 <STM32_PINMUX_NSEC('G', 8, ANALOG)>, /* USART3_RTS */
+				 <STM32_PINMUX_NSEC('D', 11, ANALOG)>, /* USART3_CTS_NSS */
+				 <STM32_PINMUX_NSEC('D', 9, ANALOG)>; /* USART3_RX */
 		};
 	};
 

--- a/core/arch/arm/dts/stm32mp151.dtsi
+++ b/core/arch/arm/dts/stm32mp151.dtsi
@@ -517,6 +517,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0 0x400>;
 				clocks = <&rcc GPIOZ>;
 				st,bank-name = "GPIOZ";

--- a/core/arch/arm/dts/stm32mp25-pinctrl.dtsi
+++ b/core/arch/arm/dts/stm32mp25-pinctrl.dtsi
@@ -8,6 +8,19 @@
 &pinctrl {
 	usart2_pins_a: usart2-0 {
 		pins1 {
+			pinmux = <STM32_PINMUX_NSEC('A', 4, AF6)>; /* USART2_TX */
+			bias-disable;
+			drive-push-pull;
+			slew-rate = <0>;
+		};
+		pins2 {
+			pinmux = <STM32_PINMUX_NSEC('A', 8, AF8)>; /* USART2_RX */
+			bias-disable;
+		};
+	};
+
+	usart2_secure_pins_a: usart2-sec-0 {
+		pins1 {
 			pinmux = <STM32_PINMUX('A', 4, AF6)>; /* USART2_TX */
 			bias-disable;
 			drive-push-pull;

--- a/core/arch/arm/dts/stm32mp251.dtsi
+++ b/core/arch/arm/dts/stm32mp251.dtsi
@@ -286,6 +286,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x0 0x400>;
 				clocks = <&rcc CK_BUS_GPIOA>;
 				st,bank-name = "GPIOA";
@@ -297,6 +298,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x10000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOB>;
 				st,bank-name = "GPIOB";
@@ -308,6 +310,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x20000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOC>;
 				st,bank-name = "GPIOC";
@@ -319,6 +322,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x30000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOD>;
 				st,bank-name = "GPIOD";
@@ -330,6 +334,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x40000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOE>;
 				st,bank-name = "GPIOE";
@@ -341,6 +346,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x50000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOF>;
 				st,bank-name = "GPIOF";
@@ -352,6 +358,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x60000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOG>;
 				st,bank-name = "GPIOG";
@@ -363,6 +370,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x70000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOH>;
 				st,bank-name = "GPIOH";
@@ -374,6 +382,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x80000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOI>;
 				st,bank-name = "GPIOI";
@@ -385,6 +394,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0x90000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOJ>;
 				st,bank-name = "GPIOJ";
@@ -396,6 +406,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0xa0000 0x400>;
 				clocks = <&rcc CK_BUS_GPIOK>;
 				st,bank-name = "GPIOK";
@@ -415,6 +426,7 @@
 				#gpio-cells = <2>;
 				interrupt-controller;
 				#interrupt-cells = <2>;
+				#access-controller-cells = <1>;
 				reg = <0 0x400>;
 				clocks = <&rcc CK_BUS_GPIOZ>;
 				st,bank-name = "GPIOZ";

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -676,19 +676,11 @@ static void register_non_secure_pmic(void)
 	if (!i2c_handle->base.pa)
 		return;
 
-	stm32mp_register_non_secure_pinctrl(i2c_handle->pinctrl);
-	if (i2c_handle->pinctrl_sleep)
-		stm32mp_register_non_secure_pinctrl(i2c_handle->pinctrl_sleep);
-
 	stm32mp_register_non_secure_periph_iomem(i2c_handle->base.pa);
 }
 
 static void register_secure_pmic(void)
 {
-	stm32mp_register_secure_pinctrl(i2c_handle->pinctrl);
-	if (i2c_handle->pinctrl_sleep)
-		stm32mp_register_secure_pinctrl(i2c_handle->pinctrl_sleep);
-
 	stm32mp_register_secure_periph_iomem(i2c_handle->base.pa);
 	register_pm_driver_cb(pmic_pm, NULL, "stm32mp1-pmic");
 }

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -586,28 +586,6 @@ static void rcc_secure_configuration(void)
 	}
 }
 
-static void set_gpio_secure_configuration(void)
-{
-	unsigned int pin = 0;
-
-	for (pin = 0; pin < get_gpioz_nbpin(); pin++) {
-		enum stm32mp_shres shres = STM32MP1_SHRES_GPIOZ(pin);
-		bool secure = stm32mp_periph_is_secure(shres);
-
-		stm32_gpio_set_secure_cfg(GPIO_BANK_Z, pin, secure);
-	}
-}
-
-static TEE_Result gpioz_pm(enum pm_op op, uint32_t pm_hint __unused,
-			   const struct pm_callback_handle *hdl __unused)
-{
-	if (op == PM_OP_RESUME)
-		set_gpio_secure_configuration();
-
-	return TEE_SUCCESS;
-}
-DECLARE_KEEP_PAGER(gpioz_pm);
-
 static TEE_Result stm32mp1_init_final_shres(void)
 {
 	enum stm32mp_shres id = STM32MP1_SHRES_COUNT;
@@ -621,11 +599,6 @@ static TEE_Result stm32mp1_init_final_shres(void)
 		     shres2str_id(id), id, shres2str_state(*state));
 	}
 
-	if (IS_ENABLED(CFG_STM32_GPIO)) {
-		set_gpio_secure_configuration();
-		register_pm_driver_cb(gpioz_pm, NULL,
-				      "stm32mp1-shared-resources");
-	}
 	rcc_secure_configuration();
 
 	return TEE_SUCCESS;

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -235,45 +235,8 @@ void stm32mp_register_secure_periph_iomem(vaddr_t base);
  */
 void stm32mp_register_non_secure_periph_iomem(vaddr_t base);
 
-/*
- * Register GPIO resource as a secure peripheral
- * @bank: Bank of the target GPIO
- * @pin: Bit position of the target GPIO in the bank
- */
-void stm32mp_register_secure_gpio(unsigned int bank, unsigned int pin);
-
-/*
- * Register GPIO resource as a non-secure peripheral
- * @bank: Bank of the target GPIO
- * @pin: Bit position of the target GPIO in the bank
- */
-void stm32mp_register_non_secure_gpio(unsigned int bank, unsigned int pin);
-
-/*
- * Register pin resource of a pin control state as a secure peripheral
- * @bank: Bank of the target GPIO
- * @pin: Bit position of the target GPIO in the bank
- */
-void stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl);
-
-/*
- * Register pin resource of a pin control state as a non-secure peripheral
- * @bank: Bank of the target GPIO
- * @pin: Bit position of the target GPIO in the bank
- */
-void stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl);
-
 /* Return true if and only if resource @id is registered as secure */
 bool stm32mp_periph_is_secure(enum stm32mp_shres id);
-
-/* Return true if and only if GPIO bank @bank is registered as secure */
-bool stm32mp_gpio_bank_is_secure(unsigned int bank);
-
-/* Return true if and only if GPIO bank @bank is registered as non-secure */
-bool stm32mp_gpio_bank_is_non_secure(unsigned int bank);
-
-/* Register number of pins in the GPIOZ bank */
-void stm32mp_register_gpioz_pin_count(size_t count);
 
 #else /* CFG_STM32MP1_SHARED_RESOURCES */
 
@@ -296,43 +259,9 @@ static inline void stm32mp_register_non_secure_periph_iomem(vaddr_t base
 {
 }
 
-static inline void stm32mp_register_secure_gpio(unsigned int bank __unused,
-						unsigned int pin __unused)
-{
-}
-
-static inline void stm32mp_register_non_secure_gpio(unsigned int bank __unused,
-						    unsigned int pin __unused)
-{
-}
-
-static inline void
-stm32mp_register_secure_pinctrl(struct pinctrl_state *pinctrl __unused)
-{
-}
-
-static inline void
-stm32mp_register_non_secure_pinctrl(struct pinctrl_state *pinctrl __unused)
-{
-}
-
 static inline bool stm32mp_periph_is_secure(enum stm32mp_shres id __unused)
 {
 	return true;
-}
-
-static inline bool stm32mp_gpio_bank_is_secure(unsigned int bank __unused)
-{
-	return true;
-}
-
-static inline bool stm32mp_gpio_bank_is_non_secure(unsigned int bank __unused)
-{
-	return false;
-}
-
-static inline void stm32mp_register_gpioz_pin_count(size_t count __unused)
-{
 }
 #endif /* CFG_STM32MP1_SHARED_RESOURCES */
 #endif /*__STM32_UTIL_H__*/

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -1266,9 +1266,6 @@ static TEE_Result dt_stm32_gpio_bank(const void *fdt, int node,
 		bank->base = io_pa_or_va_nsec(&pa_va, blen);
 	}
 
-	if (compat->gpioz)
-		stm32mp_register_gpioz_pin_count(bank->ngpios);
-
 	*out_bank = bank;
 
 	return TEE_SUCCESS;

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -819,9 +819,6 @@ int stm32_i2c_init(struct i2c_handle_s *hi2c,
 
 	i2c_config_analog_filter(hi2c, init_data->analog_filter);
 
-	if (IS_ENABLED(CFG_STM32MP13))
-		stm32_pinctrl_set_secure_cfg(hi2c->pinctrl, true);
-
 	clk_disable(hi2c->clock);
 
 	if (hi2c->pinctrl && pinctrl_apply_state(hi2c->pinctrl))
@@ -1585,9 +1582,6 @@ void stm32_i2c_resume(struct i2c_handle_s *hi2c)
 	}
 
 	restore_cfg(hi2c, &hi2c->sec_cfg);
-
-	if (IS_ENABLED(CFG_STM32MP13))
-		stm32_pinctrl_set_secure_cfg(hi2c->pinctrl, true);
 
 	hi2c->i2c_state = I2C_STATE_READY;
 }

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -109,31 +109,23 @@ void stm32_uart_init(struct stm32_uart_pdata *pd, vaddr_t base)
 	pd->chip.ops = &stm32_uart_serial_ops;
 }
 
-static void register_secure_uart(struct stm32_uart_pdata *pd)
+static void register_secure_uart(struct stm32_uart_pdata *pd __maybe_unused)
 {
 #ifndef CFG_STM32MP25
 	stm32mp_register_secure_periph_iomem(pd->base.pa);
 	stm32mp_register_secure_pinctrl(pd->pinctrl);
 	if (pd->pinctrl_sleep)
 		stm32mp_register_secure_pinctrl(pd->pinctrl_sleep);
-#else
-	stm32_pinctrl_set_secure_cfg(pd->pinctrl, true);
-	if (pd->pinctrl_sleep)
-		stm32_pinctrl_set_secure_cfg(pd->pinctrl, true);
 #endif
 }
 
-static void register_non_secure_uart(struct stm32_uart_pdata *pd)
+static void register_non_secure_uart(struct stm32_uart_pdata *pd __maybe_unused)
 {
 #ifndef CFG_STM32MP25
 	stm32mp_register_non_secure_periph_iomem(pd->base.pa);
 	stm32mp_register_non_secure_pinctrl(pd->pinctrl);
 	if (pd->pinctrl_sleep)
 		stm32mp_register_non_secure_pinctrl(pd->pinctrl_sleep);
-#else
-	stm32_pinctrl_set_secure_cfg(pd->pinctrl, false);
-	if (pd->pinctrl_sleep)
-		stm32_pinctrl_set_secure_cfg(pd->pinctrl, false);
 #endif
 
 }

--- a/core/drivers/stm32_uart.c
+++ b/core/drivers/stm32_uart.c
@@ -113,9 +113,6 @@ static void register_secure_uart(struct stm32_uart_pdata *pd __maybe_unused)
 {
 #ifndef CFG_STM32MP25
 	stm32mp_register_secure_periph_iomem(pd->base.pa);
-	stm32mp_register_secure_pinctrl(pd->pinctrl);
-	if (pd->pinctrl_sleep)
-		stm32mp_register_secure_pinctrl(pd->pinctrl_sleep);
 #endif
 }
 
@@ -123,9 +120,6 @@ static void register_non_secure_uart(struct stm32_uart_pdata *pd __maybe_unused)
 {
 #ifndef CFG_STM32MP25
 	stm32mp_register_non_secure_periph_iomem(pd->base.pa);
-	stm32mp_register_non_secure_pinctrl(pd->pinctrl);
-	if (pd->pinctrl_sleep)
-		stm32mp_register_non_secure_pinctrl(pd->pinctrl_sleep);
 #endif
 
 }

--- a/core/include/drivers/stm32_gpio.h
+++ b/core/include/drivers/stm32_gpio.h
@@ -17,24 +17,6 @@ struct stm32_pinctrl;
 
 #ifdef CFG_STM32_GPIO
 /*
- * Configure pin muxing access permission: can be secure or not
- *
- * @bank: GPIO bank identifier as assigned by the platform
- * @pin: Pin number in the GPIO bank
- * @secure: True if pin is secure, false otherwise
- */
-void stm32_gpio_set_secure_cfg(unsigned int bank, unsigned int pin,
-			       bool secure);
-
-/*
- * Configure pin muxing access permission: can be secure or not
- *
- * @pinctrl: Pin control state where STM32_GPIO pin are to configure
- * @secure: True if pin is secure, false otherwise
- */
-void stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl, bool secure);
-
-/*
  * Get the bank and pin indices related to a pin control state
  * @pinctrl: Pinctrl state
  * @bank: Output bank indices array or NULL
@@ -45,12 +27,6 @@ void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *pinctrl,
 				 unsigned int *bank, unsigned int *pin,
 				 unsigned int *count);
 #else
-static inline void
-stm32_pinctrl_set_secure_cfg(struct pinctrl_state *pinctrl __unused,
-			     bool secure __unused)
-{
-}
-
 static inline void stm32_gpio_pinctrl_bank_pin(struct pinctrl_state *p __unused,
 					       unsigned int *bank __unused,
 					       unsigned int *pin __unused,

--- a/core/include/dt-bindings/gpio/stm32mp_gpio.h
+++ b/core/include/dt-bindings/gpio/stm32mp_gpio.h
@@ -15,4 +15,11 @@
 #define TZPROT(id)	(UINT32_C(1) << (id))
 #endif
 
+/* GPIO phandle argument bitmask for a non-secure GPIO */
+#ifdef __ASSEMBLER__
+#define GPIO_STM32_NSEC	(1 << 31)
+#else
+#define GPIO_STM32_NSEC	(UINT32_C(1) << 31)
+#endif
+
 #endif

--- a/core/include/dt-bindings/pinctrl/stm32-pinfunc.h
+++ b/core/include/dt-bindings/pinctrl/stm32-pinfunc.h
@@ -33,6 +33,11 @@
 
 #define STM32_PINMUX(port, line, mode) (((PIN_NO(port, line)) << 8) | (mode))
 
+#define STM32_PIN_NSEC		(1 << 31)
+
+#define STM32_PINMUX_NSEC(port, line, mode) \
+	(STM32_PIN_NSEC | STM32_PINMUX((port), (line), (mode)))
+
 /*  package information */
 #define STM32MP_PKG_AA	0x1
 #define STM32MP_PKG_AB	0x2


### PR DESCRIPTION
This P-R makes stm32mp platforms to OP-TEE secure DTB to manage STM32 GPIO access rights. It tried to nicely split changes but it now spreads on almost 20 commits.

* The series start with 7 patches in stm32mp platform DT source files to explicitly describe GPIOs and pins used by OP-TEE but accessible from non-secure world.
  *"dt-bindings: gpio: stm32mp: flags for non-secure GPIOs"*
  *"dt-bindings: pinctrl: stm32mp: flags for non-secure pins"*
  *"dts: stm32: ..."*
* Follows 5 patches  to implement firewall support in stm32_gpio driver, for stm32mp1 and stm32mp2 platforms.
  *"drivers: stm32_gpio: check GPIO is not already consumed"*
  *"drivers: stm32_gpio: factorize apply_rif_config()"*
  *"drivers: stm32_gpio: register to firewall framework"*
  *"drivers: stm32_gpio: check secure state of consumed GPIOs"*
  *"drivers: stm32_gpio: check secure state of pinctrl states"*
* The series ends with 7 patches that removes deprecated shared_resource driver implementation related to STM32 pin muxing.
  *"drivers: stm32_xxx: remove use of xxx() ..."*
  *"plat-stm32mp1: remove use of xxx() ..."*
