### PR TITLE
plat-stm32: SCMI reset controllers on remoteproc are disabled on secure fmw loading

### DIFF
--- a/core/arch/arm/plat-stm32mp1/scmi_server.c
+++ b/core/arch/arm/plat-stm32mp1/scmi_server.c
@@ -536,7 +536,6 @@ int32_t plat_scmi_rd_autonomous(unsigned int channel_id, unsigned int scmi_id,
 
 	if (!rd->rstctrl || !stm32mp_nsec_can_access_reset(rd->reset_id))
 		return SCMI_DENIED;
-	assert(rd->rstctrl);
 
 #ifdef CFG_STM32MP15
 	/* Reset cycle on MCU hold boot is not supported */
@@ -573,7 +572,6 @@ int32_t plat_scmi_rd_set_state(unsigned int channel_id, unsigned int scmi_id,
 
 	if (!rd->rstctrl || !stm32mp_nsec_can_access_reset(rd->reset_id))
 		return SCMI_DENIED;
-	assert(rd->rstctrl);
 
 #ifdef CFG_STM32MP15
 	/* Remoteproc driver may handle all MCU reset controllers */

--- a/core/drivers/remoteproc/stm32_remoteproc.c
+++ b/core/drivers/remoteproc/stm32_remoteproc.c
@@ -39,6 +39,7 @@ struct stm32_rproc_mem {
  * @regions:	memory regions used
  * @mcu_rst:	remote processor reset control
  * @hold_boot:	remote processor hold boot control
+ * @ns_loading: True if supports non-secure firmware loading, false otherwise
  */
 struct stm32_rproc_instance {
 	const struct stm32_rproc_compat_data *cdata;
@@ -47,6 +48,7 @@ struct stm32_rproc_instance {
 	struct stm32_rproc_mem *regions;
 	struct rstctrl *mcu_rst;
 	struct rstctrl *hold_boot;
+	bool ns_loading;
 };
 
 /**
@@ -70,6 +72,16 @@ void *stm32_rproc_get(uint32_t rproc_id)
 			break;
 
 	return rproc;
+}
+
+bool stm32_rproc_is_secure(uint32_t rproc_id)
+{
+	struct stm32_rproc_instance *rproc = stm32_rproc_get(rproc_id);
+
+	if (rproc)
+		return !rproc->cdata->ns_loading;
+
+	return false;
 }
 
 TEE_Result stm32_rproc_start(uint32_t rproc_id)
@@ -400,6 +412,7 @@ err:
 
 static const struct stm32_rproc_compat_data stm32_rproc_m4_compat = {
 	.rproc_id = STM32_M4_RPROC_ID,
+	.ns_loading = false,
 };
 
 static const struct dt_device_match stm32_rproc_match_table[] = {

--- a/core/include/drivers/stm32_remoteproc.h
+++ b/core/include/drivers/stm32_remoteproc.h
@@ -74,4 +74,14 @@ TEE_Result stm32_rproc_stop(uint32_t rproc_id);
  */
 TEE_Result stm32_rproc_clean_up_memories(uint32_t rproc_id);
 
+#ifdef CFG_STM32MP_REMOTEPROC
+/* Return true is secure loading of remoteproc firmware is enabled */
+bool stm32_rproc_is_secure(uint32_t rproc_id);
+#else
+static inline bool stm32_rproc_is_secure(uint32_t rproc_id __unused)
+{
+	return false;
+}
+#endif
+
 #endif /* __DRIVERS_STM32_REMOTEPROC_H */


### PR DESCRIPTION
Changes for STM32 remote proc driver and SCMI server to expose remoteproc reset controllers through SCMI only when the secure loading of remoteproc firmware is disabled. When so, remoteproc reset and power sequence shall go through OP-TEE remoteproc services, not SCMI platform services.