### PR TITLE
plat-stm32mp1: use the firewall framework to secufre or not SRAMs

### DIFF
--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -557,4 +557,12 @@ paddr_t stm32mp1_pa_or_sram_alias_pa(paddr_t pa)
 
 	return pa;
 }
+
+bool stm32mp1_ram_intersect_pager_ram(paddr_t base, size_t size)
+{
+	base = stm32mp1_pa_or_sram_alias_pa(base);
+
+	return core_is_buffer_intersect(base, size, CFG_TZSRAM_START,
+					CFG_TZSRAM_SIZE);
+}
 #endif

--- a/core/arch/arm/plat-stm32mp1/main.c
+++ b/core/arch/arm/plat-stm32mp1/main.c
@@ -536,3 +536,25 @@ bool stm32mp_allow_probe_shared_device(const void *fdt, int node)
 
 	return false;
 }
+
+#if defined(CFG_STM32MP15) && defined(CFG_WITH_PAGER)
+paddr_t stm32mp1_pa_or_sram_alias_pa(paddr_t pa)
+{
+	/*
+	 * OP-TEE uses the alias physical addresses of SRAM1/2/3/4,
+	 * not the standard physical addresses. This choice was initially
+	 * driven by pager that needs physically contiguous memories
+	 * for internal secure memories.
+	 */
+	if (core_is_buffer_inside(pa, 1, SRAM1_ALT_BASE, SRAM1_SIZE))
+		pa += SRAM1_BASE - SRAM1_ALT_BASE;
+	else if (core_is_buffer_inside(pa, 1, SRAM2_ALT_BASE, SRAM2_SIZE))
+		pa += SRAM2_BASE - SRAM2_ALT_BASE;
+	else if (core_is_buffer_inside(pa, 1, SRAM3_ALT_BASE, SRAM3_SIZE))
+		pa += SRAM3_BASE - SRAM3_ALT_BASE;
+	else if (core_is_buffer_inside(pa, 1, SRAM4_ALT_BASE, SRAM4_SIZE))
+		pa += SRAM4_BASE - SRAM4_ALT_BASE;
+
+	return pa;
+}
+#endif

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -79,12 +79,6 @@
 #endif
 #define RTC_BASE			0x5c004000
 #define SPI6_BASE			0x5c001000
-#ifdef CFG_STM32MP15
-#define SRAM1_BASE			0x30000000
-#define SRAM2_BASE			0x30020000
-#define SRAM3_BASE			0x30040000
-#define SRAM4_BASE			0x30050000
-#endif
 #define SYSCFG_BASE			0x50020000
 #ifdef CFG_STM32MP13
 #define SYSRAM_BASE			0x2ffe0000
@@ -235,6 +229,10 @@
 #endif
 
 #ifdef CFG_STM32MP15
+#define SRAM1_BASE			0x30000000
+#define SRAM2_BASE			0x30020000
+#define SRAM3_BASE			0x30040000
+#define SRAM4_BASE			0x30050000
 /* Alternate SRAM base address possibly used by remoteproc firmware */
 #define SRAM1_ALT_BASE			0x10000000
 #define SRAM2_ALT_BASE			0x10020000
@@ -245,6 +243,19 @@
 #define SRAM2_SIZE			0x20000
 #define SRAM3_SIZE			0x10000
 #define SRAM4_SIZE			0x10000
+
+#define RETRAM_BASE			0x38000000
+#define RETRAM_SIZE			0x10000
+#endif
+
+#ifdef CFG_STM32MP13
+/* SRAM layout*/
+#define SRAM1_BASE			0x30000000
+#define SRAM1_SIZE			0x4000
+#define SRAM2_BASE			0x30004000
+#define SRAM2_SIZE			0x2000
+#define SRAM3_BASE			0x30006000
+#define SRAM3_SIZE			0x2000
 #endif
 
 #endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-stm32mp1/platform_config.h
+++ b/core/arch/arm/plat-stm32mp1/platform_config.h
@@ -235,6 +235,12 @@
 #endif
 
 #ifdef CFG_STM32MP15
+/* Alternate SRAM base address possibly used by remoteproc firmware */
+#define SRAM1_ALT_BASE			0x10000000
+#define SRAM2_ALT_BASE			0x10020000
+#define SRAM3_ALT_BASE			0x10040000
+#define SRAM4_ALT_BASE			0x10050000
+
 #define SRAM1_SIZE			0x20000
 #define SRAM2_SIZE			0x20000
 #define SRAM3_SIZE			0x10000

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -194,6 +194,19 @@ enum stm32mp_shres {
 
 bool stm32mp_allow_probe_shared_device(const void *fdt, int node);
 
+#if defined(CFG_STM32MP15) && defined(CFG_WITH_PAGER)
+/*
+ * Return the SRAM alias physical address related to @pa when applicable or
+ * @pa if it does not relate to an SRAMx non-aliased memory address.
+ */
+paddr_t stm32mp1_pa_or_sram_alias_pa(paddr_t pa);
+#else
+static inline paddr_t stm32mp1_pa_or_sram_alias_pa(paddr_t pa)
+{
+	return pa;
+}
+#endif /*CFG_STM32MP15 && CFG_WITH_PAGER*/
+
 #ifdef CFG_STM32MP1_SHARED_RESOURCES
 /* Register resource @id as a secure peripheral */
 void stm32mp_register_secure_periph(enum stm32mp_shres id);

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -200,10 +200,19 @@ bool stm32mp_allow_probe_shared_device(const void *fdt, int node);
  * @pa if it does not relate to an SRAMx non-aliased memory address.
  */
 paddr_t stm32mp1_pa_or_sram_alias_pa(paddr_t pa);
+
+/* Return whether or not the physical address range intersec pager secure RAM */
+bool stm32mp1_ram_intersect_pager_ram(paddr_t base, size_t size);
 #else
 static inline paddr_t stm32mp1_pa_or_sram_alias_pa(paddr_t pa)
 {
 	return pa;
+}
+
+static inline bool stm32mp1_ram_intersect_pager_ram(paddr_t base __unused,
+						    size_t size __unused)
+{
+	return false;
 }
 #endif /*CFG_STM32MP15 && CFG_WITH_PAGER*/
 

--- a/core/drivers/firewall/firewall.c
+++ b/core/drivers/firewall/firewall.c
@@ -90,6 +90,17 @@ TEE_Result firewall_set_configuration(struct firewall_query *fw)
 	return fw->ctrl->ops->set_conf(fw);
 }
 
+TEE_Result firewall_set_memory_configuration(struct firewall_query *fw,
+					     paddr_t paddr, size_t size)
+{
+	assert(fw && fw->ctrl && fw->ctrl->ops);
+
+	if (!fw->ctrl->ops->set_memory_conf)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	return fw->ctrl->ops->set_memory_conf(fw, paddr, size);
+}
+
 TEE_Result firewall_check_access(struct firewall_query *fw)
 {
 	assert(fw && fw->ctrl && fw->ctrl->ops);

--- a/core/drivers/firewall/stm32_etzpc.c
+++ b/core/drivers/firewall/stm32_etzpc.c
@@ -170,17 +170,17 @@ sanitize_decprot_config(uint32_t decprot_id __maybe_unused,
 	case DECPROT_S_RW:
 	case DECPROT_NS_R_S_W:
 		if (!stm32_rcc_is_secure()) {
-			IMSG("WARNING: RCC tzen:0, insecure ETZPC hardening %"PRIu32":%u",
-			     decprot_id, attr);
+			IMSG("WARNING: RCC tzen:0, insecure ETZPC hardening %"PRIu32":%s",
+			     decprot_id, etzpc_decprot_strings[attr]);
 			if (!IS_ENABLED(CFG_INSECURE))
 				panic();
 		}
 		break;
 	case DECPROT_MCU_ISOLATION:
 		if (!stm32_rcc_is_secure() || !stm32_rcc_is_mckprot()) {
-			IMSG("WARNING: RCC tzen:%u mckprot:%u, insecure ETZPC hardening %"PRIu32":%u",
+			IMSG("WARNING: RCC tzen:%u mckprot:%u, insecure ETZPC hardening %"PRIu32":%s",
 			     stm32_rcc_is_secure(), stm32_rcc_is_mckprot(),
-			     decprot_id, attr);
+			     decprot_id, etzpc_decprot_strings[attr]);
 			if (!IS_ENABLED(CFG_INSECURE))
 				panic();
 		}

--- a/core/drivers/firewall/stm32_etzpc.c
+++ b/core/drivers/firewall/stm32_etzpc.c
@@ -112,10 +112,10 @@ struct etzpc_device {
 static struct etzpc_device *etzpc_device;
 
 static const char *const etzpc_decprot_strings[] __maybe_unused = {
-	"ETZPC_DECPROT_S_RW",
-	"ETZPC_DECPROT_NS_R_S_W",
-	"ETZPC_DECPROT_MCU_ISOLATION",
-	"ETZPC_DECPROT_NS_RW",
+	[ETZPC_DECPROT_S_RW] = "ETZPC_DECPROT_S_RW",
+	[ETZPC_DECPROT_NS_R_S_W] = "ETZPC_DECPROT_NS_R_S_W",
+	[ETZPC_DECPROT_MCU_ISOLATION] = "ETZPC_DECPROT_MCU_ISOLATION",
+	[ETZPC_DECPROT_NS_RW] = "ETZPC_DECPROT_NS_RW",
 };
 
 static uint32_t etzpc_lock(void)

--- a/core/drivers/firewall/stm32_etzpc.c
+++ b/core/drivers/firewall/stm32_etzpc.c
@@ -485,8 +485,15 @@ static TEE_Result stm32_etzpc_configure(struct firewall_query *firewall)
 		attr = etzpc_binding2decprot(mode);
 
 		if (decprot_is_locked(id)) {
-			EMSG("Peripheral configuration locked");
-			return TEE_ERROR_ACCESS_DENIED;
+			if (etzpc_get_decprot(id) != attr) {
+				EMSG("Peripheral configuration locked");
+				return TEE_ERROR_ACCESS_DENIED;
+			}
+
+			DMSG("Compliant locked config for periph %"PRIu32" - attr %s",
+			     id, etzpc_decprot_strings[attr]);
+
+			return TEE_SUCCESS;
 		}
 
 #ifdef CFG_STM32MP15

--- a/core/drivers/firewall/stm32_etzpc.c
+++ b/core/drivers/firewall/stm32_etzpc.c
@@ -167,8 +167,8 @@ sanitize_decprot_config(uint32_t decprot_id __maybe_unused,
 	 * coprocessor.
 	 */
 	switch (attr) {
-	case DECPROT_S_RW:
-	case DECPROT_NS_R_S_W:
+	case ETZPC_DECPROT_S_RW:
+	case ETZPC_DECPROT_NS_R_S_W:
 		if (!stm32_rcc_is_secure()) {
 			IMSG("WARNING: RCC tzen:0, insecure ETZPC hardening %"PRIu32":%s",
 			     decprot_id, etzpc_decprot_strings[attr]);
@@ -176,7 +176,7 @@ sanitize_decprot_config(uint32_t decprot_id __maybe_unused,
 				panic();
 		}
 		break;
-	case DECPROT_MCU_ISOLATION:
+	case ETZPC_DECPROT_MCU_ISOLATION:
 		if (!stm32_rcc_is_secure() || !stm32_rcc_is_mckprot()) {
 			IMSG("WARNING: RCC tzen:%u mckprot:%u, insecure ETZPC hardening %"PRIu32":%s",
 			     stm32_rcc_is_secure(), stm32_rcc_is_mckprot(),
@@ -185,7 +185,7 @@ sanitize_decprot_config(uint32_t decprot_id __maybe_unused,
 				panic();
 		}
 		break;
-	case DECPROT_NS_RW:
+	case ETZPC_DECPROT_NS_RW:
 		break;
 	default:
 		assert(0);

--- a/core/drivers/remoteproc/stm32_remoteproc.c
+++ b/core/drivers/remoteproc/stm32_remoteproc.c
@@ -16,6 +16,7 @@
 #include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <stm32_util.h>
 
 #define TIMEOUT_US_1MS	U(1000)
 
@@ -303,6 +304,16 @@ static TEE_Result stm32_rproc_parse_mems(struct stm32_rproc_instance *rproc,
 			res = TEE_ERROR_GENERIC;
 			goto err;
 		}
+
+#if defined(CFG_STM32MP15)
+		if (stm32mp1_ram_intersect_pager_ram(regions[i].addr,
+						     regions[i].size)) {
+			EMSG("Region %#"PRIxPA"..%#"PRIxPA" intersects pager secure memory",
+			     regions[i].addr,
+			     regions[i].addr + regions[i].size);
+			return TEE_ERROR_GENERIC;
+		}
+#endif
 
 		res = stm32_rproc_get_dma_range(&regions[i], fdt, node);
 		if (res)

--- a/core/include/drivers/firewall.h
+++ b/core/include/drivers/firewall.h
@@ -47,6 +47,7 @@ struct firewall_controller {
  * memory range covered by a firewall controller, for read and/or write accesses
  * @release_memory_access: Callback used to release resources taken by a
  * consumer when the memory access was acquired with @acquire_memory_access
+ * @set_memory_conf: Callback to set access rights to a physical memory range
  */
 struct firewall_controller_ops {
 	TEE_Result (*set_conf)(struct firewall_query *conf);
@@ -62,6 +63,8 @@ struct firewall_controller_ops {
 	void (*release_memory_access)(struct firewall_query *fw,
 				      paddr_t paddr, size_t size, bool read,
 				      bool write);
+	TEE_Result (*set_memory_conf)(struct firewall_query *fw, paddr_t paddr,
+				      size_t size);
 };
 
 #ifdef CFG_DRIVERS_FIREWALL

--- a/core/include/drivers/firewall_device.h
+++ b/core/include/drivers/firewall_device.h
@@ -144,6 +144,17 @@ void firewall_release_memory_access(struct firewall_query *fw, paddr_t paddr,
 				    size_t size, bool read, bool write);
 
 /**
+ * firewall_set_memory_configuration() - Reconfigure a memory range with
+ * the given firewall configuration
+ *
+ * @fw: Firewall query containing the configuration to set
+ * @paddr: Physical base address of the memory range
+ * @size: Size of the memory range
+ */
+TEE_Result firewall_set_memory_configuration(struct firewall_query *fw,
+					     paddr_t paddr, size_t size);
+
+/**
  * firewall_put() - Release a firewall_query structure allocated by
  * firewall_dt_get_by_index() or firewall_dt_get_by_name()
  *
@@ -211,6 +222,13 @@ firewall_release_memory_access(struct firewall_query *fw __unused,
 
 static inline TEE_Result
 firewall_set_configuration(struct firewall_query *fw __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static inline TEE_Result
+firewall_set_memory_configuration(struct firewall_query *fw __unused,
+				  paddr_t paddr __unused, size_t size __unused)
 {
 	return TEE_ERROR_NOT_IMPLEMENTED;
 }


### PR DESCRIPTION
Add `firewall_set_memory_config()` to STM32 ETZPC memory firewalls drivers and let platform use the firewall framework to configure SoC SYSRAM/SRAMs secure hardening.

This change add several changes the platform drivers:
- ensure SYSRAM/SRAMs used by MP15 pager is assigned to secure world
- check consistency of the STM32 ETZPC / RCC secure configurations
- permit ETZPC valid locked configuration
