### PR TITLE
plat-stm32mp1: secure remoteproc dependancies on RCC-MCKPROT

### DIFF
--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -186,57 +186,14 @@ static void register_periph(enum stm32mp_shres id, enum shres_state state)
 			panic();
 		}
 		break;
+	case STM32MP1_SHRES_PLL3:
+		panic("Deprecated registering of PLL3 resources");
+		break;
 	default:
 		break;
 	}
 
 	shres_state[id] = state;
-
-	/* Explore clock tree to lock secure clock dependencies */
-	if (state == SHRES_SECURE) {
-		switch (id) {
-		case STM32MP1_SHRES_GPIOZ(0):
-		case STM32MP1_SHRES_GPIOZ(1):
-		case STM32MP1_SHRES_GPIOZ(2):
-		case STM32MP1_SHRES_GPIOZ(3):
-		case STM32MP1_SHRES_GPIOZ(4):
-		case STM32MP1_SHRES_GPIOZ(5):
-		case STM32MP1_SHRES_GPIOZ(6):
-		case STM32MP1_SHRES_GPIOZ(7):
-			stm32mp_register_clock_parents_secure(GPIOZ);
-			break;
-		case STM32MP1_SHRES_IWDG1:
-			stm32mp_register_clock_parents_secure(IWDG1);
-			break;
-		case STM32MP1_SHRES_USART1:
-			stm32mp_register_clock_parents_secure(USART1_K);
-			break;
-		case STM32MP1_SHRES_SPI6:
-			stm32mp_register_clock_parents_secure(SPI6_K);
-			break;
-		case STM32MP1_SHRES_I2C4:
-			stm32mp_register_clock_parents_secure(I2C4_K);
-			break;
-		case STM32MP1_SHRES_RNG1:
-			stm32mp_register_clock_parents_secure(RNG1_K);
-			break;
-		case STM32MP1_SHRES_HASH1:
-			stm32mp_register_clock_parents_secure(HASH1);
-			break;
-		case STM32MP1_SHRES_CRYP1:
-			stm32mp_register_clock_parents_secure(CRYP1);
-			break;
-		case STM32MP1_SHRES_I2C6:
-			stm32mp_register_clock_parents_secure(I2C6_K);
-			break;
-		case STM32MP1_SHRES_RTC:
-			stm32mp_register_clock_parents_secure(RTC);
-			break;
-		default:
-			/* No expected resource dependency */
-			break;
-		}
-	}
 }
 
 /* Register resource by ID */

--- a/core/arch/arm/plat-stm32mp1/shared_resources.c
+++ b/core/arch/arm/plat-stm32mp1/shared_resources.c
@@ -634,11 +634,6 @@ static void rcc_secure_configuration(void)
 		else
 			panic();
 	}
-
-	if (!need_mckprot && mckprot) {
-		DMSG("Disable RCC MCKPROT");
-		stm32_rcc_set_mckprot(false);
-	}
 }
 
 static void set_gpio_secure_configuration(void)

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -260,9 +260,6 @@ bool stm32mp_gpio_bank_is_secure(unsigned int bank);
 /* Return true if and only if GPIO bank @bank is registered as non-secure */
 bool stm32mp_gpio_bank_is_non_secure(unsigned int bank);
 
-/* Register parent clocks of @clock (ID used in clock DT bindings) as secure */
-void stm32mp_register_clock_parents_secure(unsigned long clock_id);
-
 /* Register number of pins in the GPIOZ bank */
 void stm32mp_register_gpioz_pin_count(size_t count);
 
@@ -320,11 +317,6 @@ static inline bool stm32mp_gpio_bank_is_secure(unsigned int bank __unused)
 static inline bool stm32mp_gpio_bank_is_non_secure(unsigned int bank __unused)
 {
 	return false;
-}
-
-static inline void stm32mp_register_clock_parents_secure(unsigned long clock_id
-							 __unused)
-{
 }
 
 static inline void stm32mp_register_gpioz_pin_count(size_t count __unused)

--- a/core/drivers/clk/clk-stm32mp15.c
+++ b/core/drivers/clk/clk-stm32mp15.c
@@ -1539,6 +1539,12 @@ static TEE_Result stm32mp1_clock_provider_probe(const void *fdt, int offs,
 	else
 		enable_rcc_tzen();
 
+	/*
+	 * Default disable MCKPROT, it may be enabled later from
+	 * STM32 remoteproc driver.
+	 */
+	stm32_rcc_set_mckprot(false);
+
 	res = stm32mp1_clk_fdt_init(fdt, offs);
 	if (res) {
 		EMSG("Failed to initialize clocks from DT: %#"PRIx32, res);

--- a/core/drivers/remoteproc/stm32_remoteproc.c
+++ b/core/drivers/remoteproc/stm32_remoteproc.c
@@ -7,6 +7,9 @@
 #include <config.h>
 #include <drivers/rstctrl.h>
 #include <drivers/stm32_remoteproc.h>
+#ifdef CFG_STM32MP15
+#include <drivers/stm32mp1_rcc.h>
+#endif
 #include <kernel/cache_helpers.h>
 #include <kernel/dt_driver.h>
 #include <kernel/tee_misc.h>
@@ -379,6 +382,14 @@ static TEE_Result stm32_rproc_probe(const void *fdt, int node,
 		res = rproc_stop(rproc);
 		if (res)
 			goto err;
+	}
+
+	if (!stm32_rcc_is_secure()) {
+		IMSG("WARNING: insecure rproc isolation, RCC is not secure");
+		if (!IS_ENABLED(CFG_INSECURE))
+			panic();
+	} else {
+		stm32_rcc_set_mckprot(true);
 	}
 
 	/*


### PR DESCRIPTION
Refine configuration consistency of remoteproc firmware isolation on stm32mp15:
- stm32_etzpc firewall driver ensure MCKPROT isolation consistency vs RCC[MCKPROT],
- stm32_remoteproc driver ensures RCC[MCKPROT] is enabled when needed,
- remove useless verification of parent clock secure hardening since the remoteproc driver ensures MCKPROT is enabled.