### PR TITLE
crypto: se05x: improve object deletion logs

### DIFF
--- a/core/drivers/crypto/se050/core/storage.c
+++ b/core/drivers/crypto/se050/core/storage.c
@@ -71,21 +71,21 @@ TEE_Result crypto_storage_obj_del(struct tee_obj *o)
 		return TEE_SUCCESS;
 
 	status = sss_se05x_key_object_init(&k_object, se050_kstore);
-	if (status != kStatus_SSS_Success) {
-		ret = TEE_ERROR_BAD_STATE;
-		goto out;
-	}
+	if (status != kStatus_SSS_Success)
+		return TEE_ERROR_BAD_STATE;
 
 	status = sss_se05x_key_object_get_handle(&k_object, val);
 	if (status != kStatus_SSS_Success) {
-		EMSG("se05x: can not communicate with the secure element");
+		if (IS_ENABLED(CFG_CORE_SE05X_BLOCK_OBJ_DEL_ON_ERROR))
+			EMSG("se05x: key not found in secure element");
 		ret = TEE_ERROR_BAD_STATE;
 		goto out;
 	}
 
 	status = sss_se05x_key_store_erase_key(se050_kstore, &k_object);
 	if (status != kStatus_SSS_Success) {
-		EMSG("se05x: can not communicate with the secure element");
+		if (IS_ENABLED(CFG_CORE_SE05X_BLOCK_OBJ_DEL_ON_ERROR))
+			EMSG("se05x: key can't be removed from secure element");
 		ret = TEE_ERROR_BAD_STATE;
 		goto out;
 	}


### PR DESCRIPTION
For SE05x, only private keys are stored in the secure element: the OP-TEE secure storage REE/RPMB retains the full public key but just a handle to the private key.

If the secure element's persistent storage is erased, but OP-TEE's secure storage remains, the public key can still be accessed while the private key is inaccessible. However, in such cases, the 'key' will still appear as present in the PKCS#11 database.

When CFG_CORE_SE05X_BLOCK_OBJ_DEL_ON_ERROR is enabled (not by default) and the key pointed to by the handle is not present in the secure element, OP-TEE PKCS#11 clients will encounter an error when attempting to delete the private key information held in the OP-TEE secure storage.

If the setting is disabled, the PKCS#11 storage clears the private key handle without errors.

This commit removes some ambiguity, so users do not see error messages when operations complete successfully.

It also fails on sss_se05x_key_object_init errors unconditionally since a failure on this function can only signify some form of stack corruption.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
