### PR TITLE
plat-stm32mp1: remove unused stm32mp_nsec_can_access_pmic_regu()

### DIFF
--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -59,16 +59,6 @@ static inline bool stm32mp_nsec_can_access_clock(unsigned long clock_id
 
 extern const struct clk_ops stm32mp1_clk_ops;
 
-#if defined(CFG_STPMIC1)
-/* Return true if non-secure world can manipulate regulator @pmic_regu_name */
-bool stm32mp_nsec_can_access_pmic_regu(const char *pmic_regu_name);
-#else
-static inline bool stm32mp_nsec_can_access_pmic_regu(const char *name __unused)
-{
-	return false;
-}
-#endif
-
 #ifdef CFG_STM32MP1_SHARED_RESOURCES
 /* Return true if and only if @reset_id relates to a non-secure peripheral */
 bool stm32mp_nsec_can_access_reset(unsigned int reset_id);


### PR DESCRIPTION
Remove unused platform function stm32mp_nsec_can_access_pmic_regu().

Change-Id: I89a300e5f09ec1ab6e55bb10b06de306f094cbec

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
