### PR TITLE
plat-rockchip: allow specifying DRAM via CFG options

### DIFF
--- a/core/arch/arm/plat-rockchip/main.c
+++ b/core/arch/arm/plat-rockchip/main.c
@@ -20,6 +20,13 @@ register_phys_mem_pgdir(MEM_AREA_IO_NSEC,
 			CFG_EARLY_CONSOLE_BASE, CFG_EARLY_CONSOLE_SIZE);
 #endif
 
+#ifdef CFG_DRAM_BASE
+register_ddr(CFG_DRAM_BASE, CFG_DRAM_SIZE);
+#endif
+#ifdef CFG_NSEC_DDR_1_BASE
+register_ddr(CFG_NSEC_DDR_1_BASE, CFG_NSEC_DDR_1_SIZE);
+#endif
+
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GIC_BASE, GIC_SIZE);
 
 void boot_primary_init_intc(void)


### PR DESCRIPTION
It's currently not possible to use `CFG_CORE_DYN_SHM` with the Rockchip platforms, because OP-TEE doesn't know what non-secure memory is available; Device tree is not used and no DDR ranges are registered.

This precludes interacting with OP-TEE from barebox and U-Boot, which currently only implement OP-TEE communication with dynamic shared memory.

Make it possible to use `CFG_CORE_DYN_SHM=y` by adding two sets of config variables to register memory:

 * `CFG_DRAM_BASE, CFG_DRAM_SIZE`: For the main memory in the first 4G up to the MMIO range at the end of RAM

 * `CFG_NSEC_DDR_1_BASE, CFG_NSEC_DDR_1_SIZE`: For the remainder of the main memory above the MMIO regions.

OP-TEE will take care to carve out the secure memory ranges.

This has been tested on an RK3399 with barebox using OP-TEE's HWRNG TA.