### PR TITLE
compiler.h: only use __no_stack_protector if supported by the compiler

### DIFF
--- a/lib/libutils/ext/include/compiler.h
+++ b/lib/libutils/ext/include/compiler.h
@@ -15,6 +15,11 @@
  * the conflicting defines has the same meaning in that environment.
  * Surrounding the troublesome defines with #ifndef should be enough.
  */
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
 #define __deprecated	__attribute__((deprecated))
 #ifndef __packed
 #define __packed	__attribute__((packed))
@@ -24,9 +29,15 @@
 #ifndef __noreturn
 #define __noreturn	__attribute__((__noreturn__))
 #endif
+
 #ifndef __no_stack_protector
+#if __has_attribute(no_stack_protector)
 #define __no_stack_protector __attribute__((no_stack_protector))
+#else
+#define __no_stack_protector
 #endif
+#endif
+
 #define __pure		__attribute__((pure))
 #define __aligned(x)	__attribute__((aligned(x)))
 #define __printf(a, b)	__attribute__((format(printf, a, b)))


### PR DESCRIPTION
The `__attribute__((no_stack_protector))` was introduced in GCC 11. Building a TA with an older version of GCC would trigger a `-Wattributes` warning on the `ta/user_ta_header.c` file.

Use `__has_attribute()` to check for the support of the `no_stack_protector` attribute before using it. If not supported, define the `__no_stack_protector` alias as a NOP.

Fixes: e3fb2bd005f ("compiler.h: add __no_stack_protector")

**Note:** This `no_stack_protector` is the only troublesome attribute in my set up (GCC 9.4.0). Let me know if you want to also add a `__has_attribute()` guard to the other attributes and I will do so.