### PR TITLE
drivers: caam: fix CFG_CORE_BIGNUM_MAX_BITS

### DIFF
--- a/core/drivers/crypto/caam/crypto.mk
+++ b/core/drivers/crypto/caam/crypto.mk
@@ -148,8 +148,10 @@ CFG_CAAM_JR_DISABLE_NODE ?= y
 # Define the default CAAM private key encryption generation and the bignum
 # maximum size needed.
 # CAAM_KEY_PLAIN_TEXT    -> 4096 bits
-# CAAM_KEY_BLACK_ECB|CCM -> 4156 bits
-CFG_CORE_BIGNUM_MAX_BITS ?= 4156
+# CAAM_KEY_BLACK_ECB|CCM -> 4576 bits
+# 4096 (RSA Max key size) +  12 * 8 (Header serialization) +
+# 48 * 8 (Black blob overhead in bytes) = 4576 bits
+CFG_CORE_BIGNUM_MAX_BITS ?= 4576
 
 # Enable CAAM non-crypto drivers
 $(foreach drv, $(caam-drivers), $(eval CFG_NXP_CAAM_$(drv)_DRV ?= y))


### PR DESCRIPTION
CFG_CORE_BIGNUM_MAX_BITS should be 4576
4096 (RSA Max key size) +
8 * 60 (Header serialization and Black blob overhead in bytes)

