### PR TITLE
Rework RNG driver design to get RNG from CAAM and introduce CONFIG flag for Prediction Resistance

### DIFF
--- a/core/drivers/crypto/caam/caam_rng.c
+++ b/core/drivers/crypto/caam/caam_rng.c
@@ -107,7 +107,7 @@ static TEE_Result do_rng_read(uint8_t *buf, size_t len)
 		goto exit;
 	}
 
-	if (rng_privdata->pr_enabled)
+	if (IS_ENABLED(CFG_CAAM_RNG_RUNTIME_PR) && rng_privdata->pr_enabled)
 		op |= ALGO_RNG_PR;
 
 	caam_desc_init(desc);
@@ -310,7 +310,8 @@ end_inst:
 	if (retstatus == CAAM_NO_ERROR) {
 		rng_privdata->instantiated = true;
 		rng_privdata->pr_enabled =
-			caam_hal_rng_pr_enabled(rng_privdata->baseaddr);
+			caam_hal_rng_pr_enabled(rng_privdata->baseaddr) &
+			IS_ENABLED(CFG_CAAM_RNG_RUNTIME_PR);
 
 		RNG_TRACE("RNG prediction resistance is %sabled",
 			  rng_privdata->pr_enabled ? "en" : "dis");

--- a/core/drivers/crypto/caam/crypto.mk
+++ b/core/drivers/crypto/caam/crypto.mk
@@ -153,6 +153,11 @@ CFG_CAAM_JR_DISABLE_NODE ?= y
 # 48 * 8 (Black blob overhead in bytes) = 4576 bits
 CFG_CORE_BIGNUM_MAX_BITS ?= 4576
 
+# CAAM RNG Prediction Resistance
+# When this flag is y, the CAAM RNG is reseeded on every random number request.
+# In this case the performance is drastically reduced.
+CFG_CAAM_RNG_RUNTIME_PR ?= n
+
 # Enable CAAM non-crypto drivers
 $(foreach drv, $(caam-drivers), $(eval CFG_NXP_CAAM_$(drv)_DRV ?= y))
 


### PR DESCRIPTION
Previous design of keeping RNG data in a buffer and giving random number
to user from that buffer is vulnerable to attacks and also not NIST/FIPS compliant.
So, to make it more secure and NIST/FIPS compliant, will get random
number from CAAM on each user request.

With prediction resistance enabled, on every random number request
CAAM is forced to do reseeding of DRBG, which is time taking process
which leads to lower Random number generation performance.
So to give use the flexibility to enable/disable this feature a flag
CFG_CAAM_RNG_RUNTIME_PR is introduced.
By default it will be disabled and user can enable it as per its
requirement.