### PR TITLE
libutee: fix TEE_MemMove()'s return type

### DIFF
--- a/lib/libutee/include/tee_internal_api.h
+++ b/lib/libutee/include/tee_internal_api.h
@@ -125,8 +125,8 @@ void *__GP11_TEE_Realloc(void *buffer, uint32_t newSize);
 
 void TEE_Free(void *buffer);
 
-void *TEE_MemMove(void *dest, const void *src, size_t size);
-void *__GP11_TEE_MemMove(void *dest, const void *src, uint32_t size);
+void TEE_MemMove(void *dest, const void *src, size_t size);
+void __GP11_TEE_MemMove(void *dest, const void *src, uint32_t size);
 
 /*
  * Note: TEE_MemCompare() has a constant-time implementation (execution time

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -607,14 +607,14 @@ const void *TEE_GetInstanceData(void)
 	return tee_api_instance_data;
 }
 
-void *TEE_MemMove(void *dest, const void *src, size_t size)
+void TEE_MemMove(void *dest, const void *src, size_t size)
 {
-	return memmove(dest, src, size);
+	memmove(dest, src, size);
 }
 
-void *__GP11_TEE_MemMove(void *dest, const void *src, uint32_t size)
+void __GP11_TEE_MemMove(void *dest, const void *src, uint32_t size)
 {
-	return TEE_MemMove(dest, src, size);
+	TEE_MemMove(dest, src, size);
 }
 
 int32_t TEE_MemCompare(const void *buffer1, const void *buffer2, size_t size)


### PR DESCRIPTION
In all the published versions of the TEE Internal API Specification, the return type of `TEE_MemMove()` has always been `void`, not `void *`.