### PR TITLE
plat-versal2: add support for AMD Versal Gen 2

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -62,6 +62,12 @@ R:	Amit Singh Tomar <amittomer25@gmail.com> [@Amit-Radur]
 S:	Maintained
 F:	core/arch/arm/plat-sunxi/
 
+AMD Versal Gen 2
+R:	Michal Simek <michal.simek@amd.com> [@michalsimek]
+R:	Akshay Belsare <akshay.belsare@amd.com> [@Akshay-Belsare]
+S:	Maintained
+F:	core/arch/arm/plat-versal2/
+
 AmLogic AXG (A113D)
 R:	Carlo Caione <ccaione@baylibre.com> [@carlocaione]
 S:	Maintained

--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+#
+#
+
+PLATFORM_FLAVOR ?= generic
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+CFG_MMAP_REGIONS ?= 24
+
+# Disable Non-Standard Crypto Algorithms
+$(call force,CFG_CRYPTO_SM2_PKE,n)
+$(call force,CFG_CRYPTO_SM2_DSA,n)
+$(call force,CFG_CRYPTO_SM2_KEP,n)
+$(call force,CFG_CRYPTO_SM3,n)
+$(call force,CFG_CRYPTO_SM4,n)
+
+# platform does not support paging; explicitly disable CFG_WITH_PAGER
+$(call force,CFG_WITH_PAGER,n)
+
+# Platform specific configurations
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+$(call force,CFG_ARM_GICV3,y)
+$(call force,CFG_PL011,y)
+$(call force,CFG_GIC,y)
+
+CFG_CORE_RESERVED_SHM	?= n
+CFG_CORE_DYN_SHM	?= y
+CFG_WITH_STATS		?= y
+CFG_ARM64_core		?= y
+
+# Enable ARM Crypto Extensions(CE)
+$(call force,CFG_CRYPTO_WITH_CE,y)
+$(call force,CFG_CRYPTO_WITH_CE82,y)
+
+# Define the number of cores per cluster used in calculating core position.
+# The cluster number is shifted by this value and added to the core ID,
+# so its value represents log2(cores/cluster).
+# For AMD Versal Gen 2 there are 4 clusters and 2 cores per cluster.
+$(call force,CFG_CORE_CLUSTER_SHIFT,1)
+
+# By default optee_os is located at the following location.
+# This range to contain optee_os, TEE RAM and TA RAM.
+# Default size is 128MB.
+CFG_TZDRAM_START   ?= 0x1800000
+CFG_TZDRAM_SIZE    ?= 0x8000000
+
+ifeq ($(CFG_ARM64_core),y)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,43)
+endif
+
+CFG_CORE_HEAP_SIZE ?= 262144

--- a/core/arch/arm/plat-versal2/main.c
+++ b/core/arch/arm/plat-versal2/main.c
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <arm.h>
+#include <assert.h>
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/pl011.h>
+#include <drivers/versal_pm.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <kernel/misc.h>
+#include <kernel/tee_time.h>
+#include <mm/core_memprot.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <string.h>
+#include <tee/tee_fs.h>
+#include <trace.h>
+
+static struct pl011_data console_data;
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC,
+			ROUNDDOWN(CONSOLE_UART_BASE, CORE_MMU_PGDIR_SIZE),
+			CORE_MMU_PGDIR_SIZE);
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE, GIC_DIST_REG_SIZE);
+
+register_ddr(DRAM0_BASE, DRAM0_SIZE);
+
+void boot_primary_init_intc(void)
+{
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
+}
+
+void plat_console_init(void)
+{
+	pl011_init(&console_data, CONSOLE_UART_BASE,
+		   CONSOLE_UART_CLK_IN_HZ, CONSOLE_BAUDRATE);
+	register_serial_console(&console_data.chip);
+}
+
+static TEE_Result platform_banner(void)
+{
+	IMSG("OP-TEE OS Running on Platform AMD Versal Gen 2");
+
+	return TEE_SUCCESS;
+}
+
+service_init(platform_banner);

--- a/core/arch/arm/plat-versal2/platform_config.h
+++ b/core/arch/arm/plat-versal2/platform_config.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define CACHELINE_LEN		64
+#define STACK_ALIGNMENT		CACHELINE_LEN
+
+#if defined(PLATFORM_FLAVOR_generic)
+
+#define PLM_RTCA		0xF2014000
+#define PLM_RTCA_LEN		0x1000
+
+#define GICD_BASE		U(0xE2000000)
+#define GICR_BASE		U(0xE2060000)
+
+#define UART0_BASE		U(0xF1920000)
+#define UART1_BASE		U(0xF1930000)
+
+#define IT_UART0		50
+#define IT_UART1		51
+
+#define UART0_CLK_IN_HZ		100000000
+#define UART1_CLK_IN_HZ		100000000
+
+#define CONSOLE_UART_BASE	UART0_BASE
+
+#define IT_CONSOLE_UART		IT_UART0
+
+#define CONSOLE_UART_CLK_IN_HZ	UART0_CLK_IN_HZ
+
+#define DRAM0_BASE		0
+#define DRAM0_SIZE		0x80000000
+
+#ifndef ARM64
+#error "Only ARM64 is supported!"
+#endif
+
+#else
+#error "Unknown platform flavor"
+#endif
+
+#ifndef UART_BAUDRATE
+#define UART_BAUDRATE		115200
+#endif
+
+#ifndef CONSOLE_BAUDRATE
+#define CONSOLE_BAUDRATE	UART_BAUDRATE
+#endif
+
+#endif /* PLATFORM_CONFIG_H */

--- a/core/arch/arm/plat-versal2/sub.mk
+++ b/core/arch/arm/plat-versal2/sub.mk
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+#
+#
+
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
Add support for AMD Versal Gen 2 platform.
AMD Versal Gen 2 is a new SoC based on ARM A78AE with GICv3 and UART over pl011.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
