### PR TITLE
[RFC] Prototype/sdp v3

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -153,6 +153,8 @@
 
 /* Share memory transaction */
 #define FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE SHIFT_U32(1, 3)
+/* Lend memory transaction */
+#define FFA_MEMORY_REGION_TRANSACTION_TYPE_LEND SHIFT_U32(2, 3)
 /* Relayer must choose the alignment boundary */
 #define FFA_MEMORY_REGION_FLAG_ANY_ALIGNMENT	0
 

--- a/core/arch/arm/include/kernel/thread_spmc.h
+++ b/core/arch/arm/include/kernel/thread_spmc.h
@@ -10,6 +10,7 @@
 #include <ffa.h>
 #include <kernel/panic.h>
 #include <kernel/thread.h>
+#include <mm/mobj.h>
 
 /* The FF-A ID of Secure World components should be between these limits */
 #define FFA_SWD_ID_MIN	0x8000
@@ -71,8 +72,14 @@ thread_spmc_set_async_notif_intid(int intid __unused)
 {
 	panic();
 }
-struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie);
+
+struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie,
+						   enum mobj_use_case use_case);
 void thread_spmc_relinquish(uint64_t memory_region_handle);
 #endif
+
+TEE_Result thread_spmc_get_rstmem_config(uint64_t use_case, void *buf,
+					 size_t *buf_sz, size_t *min_mem_sz,
+					 size_t *min_mem_align);
 
 #endif /* __KERNEL_THREAD_SPMC_H */

--- a/core/arch/arm/include/optee_ffa.h
+++ b/core/arch/arm/include/optee_ffa.h
@@ -95,6 +95,8 @@
 #define OPTEE_FFA_SEC_CAP_ASYNC_NOTIF	BIT(1)
 /* OP-TEE supports probing for RPMB device if needed */
 #define OPTEE_FFA_SEC_CAP_RPMB_PROBE	BIT(2)
+/* OP-TEE supports Restricted Memory for secure data path */
+#define OPTEE_FFA_SEC_CAP_RSTMEM	BIT(3)
 
 #define OPTEE_FFA_EXCHANGE_CAPABILITIES OPTEE_FFA_BLOCKING_CALL(2)
 
@@ -130,6 +132,21 @@
 #define OPTEE_FFA_ENABLE_ASYNC_NOTIF	OPTEE_FFA_BLOCKING_CALL(5)
 
 #define OPTEE_FFA_MAX_ASYNC_NOTIF_VALUE	64
+
+/*
+ * Release Restricted memory
+ *
+ * Call register usage:
+ * w3:    Service ID, OPTEE_FFA_RECLAIM_RSTMEM
+ * w4:    Shared memory handle, lower bits
+ * w5:    Shared memory handle, higher bits
+ * w6-w7: Not used (MBZ)
+ *
+ * Return register usage:
+ * w3:    Error code, 0 on success
+ * w4-w7: Note used (MBZ)
+ */
+#define OPTEE_FFA_RELEASE_RSTMEM	OPTEE_FFA_BLOCKING_CALL(8)
 
 /*
  * Call with struct optee_msg_arg as argument in the supplied shared memory

--- a/core/arch/arm/include/optee_ffa.h
+++ b/core/arch/arm/include/optee_ffa.h
@@ -87,7 +87,7 @@
  * w7:	  Not used (MBZ)
  */
 /*
- * Secure world supports using an offset into the argument shared memory
+ * Secure world supports giving an offset into the argument shared memory
  * object, see also OPTEE_FFA_YIELDING_CALL_WITH_ARG
  */
 #define OPTEE_FFA_SEC_CAP_ARG_OFFSET	BIT(0)
@@ -114,7 +114,7 @@
 #define OPTEE_FFA_UNREGISTER_SHM	OPTEE_FFA_BLOCKING_CALL(3)
 
 /*
- * Inform OP-TEE that normal world is able to receive asynchronous
+ * Inform OP-TEE that the normal world is able to receive asynchronous
  * notifications.
  *
  * Call register usage:

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -318,6 +318,8 @@
 #define OPTEE_SMC_SEC_CAP_RPC_ARG		BIT(6)
 /* Secure world supports probing for RPMB device if needed */
 #define OPTEE_SMC_SEC_CAP_RPMB_PROBE		BIT(7)
+/* Secure world supports Secure Data Path */
+#define OPTEE_SMC_SEC_CAP_SDP			BIT(8)
 
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	U(9)
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
@@ -560,6 +562,32 @@
 
 /* See OPTEE_SMC_CALL_WITH_REGD_ARG above */
 #define OPTEE_SMC_FUNCID_CALL_WITH_REGD_ARG	U(19)
+
+/*
+ * Get Secure Data Path memory config
+ *
+ * Returns the Secure Data Path memory config.
+ *
+ * Call register usage:
+ * a0   SMC Function ID, OPTEE_SMC_GET_SDP_CONFIG
+ * a2-6	Not used, must be zero
+ * a7	Hypervisor Client ID register
+ *
+ * Have config return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1	Physical address of start of SDP memory
+ * a2	Size of SDP memory
+ * a3	Not used
+ * a4-7	Preserved
+ *
+ * Not available register usage:
+ * a0	OPTEE_SMC_RETURN_ENOTAVAIL
+ * a1-3 Not used
+ * a4-7	Preserved
+ */
+#define OPTEE_SMC_FUNCID_GET_SDP_CONFIG		U(20)
+#define OPTEE_SMC_GET_SDP_CONFIG \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_SDP_CONFIG)
 
 /*
  * Resume from RPC (for example after processing a foreign interrupt)

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -320,6 +320,8 @@
 #define OPTEE_SMC_SEC_CAP_RPMB_PROBE		BIT(7)
 /* Secure world supports Secure Data Path */
 #define OPTEE_SMC_SEC_CAP_SDP			BIT(8)
+/* Secure world supports dynamic restricted memory */
+#define OPTEE_SMC_SEC_CAP_DYNAMIC_RSTMEM	BIT(9)
 
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	U(9)
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
@@ -588,6 +590,33 @@
 #define OPTEE_SMC_FUNCID_GET_SDP_CONFIG		U(20)
 #define OPTEE_SMC_GET_SDP_CONFIG \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_SDP_CONFIG)
+
+/*
+ * Get Secure Data Path dynamic memory config
+ *
+ * Returns the Secure Data Path dynamic memory config.
+ *
+ * Call register usage:
+ * a0	SMC Function ID, OPTEE_SMC_GET_DYN_SHM_CONFIG
+ * a2-6	Not used, must be zero
+ * a7	Hypervisor Client ID register
+ *
+ * Have config return register usage:
+ * a0	OPTEE_SMC_RETURN_OK
+ * a1	Minamal size of SDP memory
+ * a2	Required alignment of size and start of registered SDP memory
+ * a3	Not used
+ * a4-7	Preserved
+ *
+ * Not available register usage:
+ * a0	OPTEE_SMC_RETURN_ENOTAVAIL
+ * a1-3 Not used
+ * a4-7	Preserved
+ */
+
+#define OPTEE_SMC_FUNCID_GET_DYN_SDP_CONFIG	U(21)
+#define OPTEE_SMC_GET_DYN_SDP_CONFIG \
+	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_DYN_SDP_CONFIG)
 
 /*
  * Resume from RPC (for example after processing a foreign interrupt)

--- a/core/arch/arm/include/sm/optee_smc.h
+++ b/core/arch/arm/include/sm/optee_smc.h
@@ -141,7 +141,7 @@
  * optee_msg_arg has reserved space for the number of RPC parameters as
  * returned by OPTEE_SMC_EXCHANGE_CAPABILITIES.
  *
- * When calling these functions normal world has a few responsibilities:
+ * When calling these functions, normal world has a few responsibilities:
  * 1. It must be able to handle eventual RPCs
  * 2. Non-secure interrupts should not be masked
  * 3. If asynchronous notifications has been negotiated successfully, then
@@ -217,7 +217,7 @@
  * Have config return register usage:
  * a0	OPTEE_SMC_RETURN_OK
  * a1	Physical address of start of SHM
- * a2	Size of of SHM
+ * a2	Size of SHM
  * a3	Cache settings of memory, as defined by the
  *	OPTEE_SMC_SHM_* values above
  * a4-7	Preserved
@@ -290,7 +290,7 @@
  *		  as the second MSG arg struct for
  *		  OPTEE_SMC_CALL_WITH_ARG
  *	Bit[31:8]: Reserved (MBZ)
- * a3-7	Preserved
+ * a4-7	Preserved
  *
  * Error return register usage:
  * a0	OPTEE_SMC_RETURN_ENOTAVAIL, can't use the capabilities from normal world
@@ -532,7 +532,7 @@
  * a0	OPTEE_SMC_RETURN_OK
  * a1	value
  * a2	Bit[0]: OPTEE_SMC_ASYNC_NOTIF_VALUE_VALID if the value in a1 is
- *		valid, else 0 if no values were pending
+ *		valid, else 0 if no values where pending
  * a2	Bit[1]: OPTEE_SMC_ASYNC_NOTIF_VALUE_PENDING if another value is
  *		pending, else 0.
  *	Bit[31:2]: MBZ

--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -32,7 +32,8 @@
 #include <util.h>
 
 #if defined(CFG_CORE_SEL1_SPMC)
-struct mem_share_state {
+struct mem_op_state {
+	bool mem_share;
 	struct mobj_ffa *mf;
 	unsigned int page_count;
 	unsigned int region_count;
@@ -40,7 +41,7 @@ struct mem_share_state {
 };
 
 struct mem_frag_state {
-	struct mem_share_state share;
+	struct mem_op_state op;
 	tee_mm_entry_t *mm;
 	unsigned int frag_offset;
 	SLIST_ENTRY(mem_frag_state) link;
@@ -800,6 +801,8 @@ static void handle_blocking_call(struct thread_smc_args *args,
 			sec_caps |= OPTEE_FFA_SEC_CAP_ASYNC_NOTIF;
 		if (IS_ENABLED(CFG_RPMB_ANNOUNCE_PROBE_CAP))
 			sec_caps |= OPTEE_FFA_SEC_CAP_RPMB_PROBE;
+		if (IS_ENABLED(CFG_CORE_DYN_RSTMEM))
+			sec_caps |= OPTEE_FFA_SEC_CAP_RSTMEM;
 		spmc_set_args(args, direct_resp_fid,
 			      swap_src_dst(args->a1), 0, 0,
 			      THREAD_RPC_MAX_NUM_PARAMS, sec_caps);
@@ -815,6 +818,12 @@ static void handle_blocking_call(struct thread_smc_args *args,
 						      FFA_SRC(args->a1)),
 			      0, 0);
 		break;
+#ifdef CFG_CORE_DYN_RSTMEM
+	case OPTEE_FFA_RELEASE_RSTMEM:
+		spmc_set_args(args, direct_resp_fid, swap_src_dst(args->a1), 0,
+			      handle_unregister_shm(args->a4, args->a5), 0, 0);
+		break;
+#endif
 	default:
 		EMSG("Unhandled blocking service ID %#"PRIx32,
 		     (uint32_t)args->a3);
@@ -1005,17 +1014,19 @@ static int get_acc_perms(vaddr_t mem_acc_base, unsigned int mem_access_size,
 	return FFA_INVALID_PARAMETERS;
 }
 
-static int mem_share_init(struct ffa_mem_transaction_x *mem_trans, void *buf,
-			  size_t blen, unsigned int *page_count,
-			  unsigned int *region_count, size_t *addr_range_offs)
+static int mem_op_init(bool mem_share, struct ffa_mem_transaction_x *mem_trans,
+		       void *buf, size_t blen, unsigned int *page_count,
+		       unsigned int *region_count, size_t *addr_range_offs)
 {
-	const uint16_t exp_mem_reg_attr = FFA_NORMAL_MEM_REG_ATTR;
 	const uint8_t exp_mem_acc_perm = FFA_MEM_ACC_RW;
 	struct ffa_mem_region *region_descr = NULL;
 	unsigned int region_descr_offs = 0;
+	uint16_t exp_mem_reg_attr = 0;
 	uint8_t mem_acc_perm = 0;
 	size_t n = 0;
 
+	if (mem_share)
+		exp_mem_reg_attr = FFA_NORMAL_MEM_REG_ATTR;
 	if (mem_trans->mem_reg_attr != exp_mem_reg_attr)
 		return FFA_INVALID_PARAMETERS;
 
@@ -1044,8 +1055,7 @@ static int mem_share_init(struct ffa_mem_transaction_x *mem_trans, void *buf,
 	return 0;
 }
 
-static int add_mem_share_helper(struct mem_share_state *s, void *buf,
-				size_t flen)
+static int add_mem_op_helper(struct mem_op_state *s, void *buf, size_t flen)
 {
 	unsigned int region_count = flen / sizeof(struct ffa_address_range);
 	struct ffa_address_range *arange = NULL;
@@ -1077,15 +1087,15 @@ static int add_mem_share_helper(struct mem_share_state *s, void *buf,
 	return 0;
 }
 
-static int add_mem_share_frag(struct mem_frag_state *s, void *buf, size_t flen)
+static int add_mem_op_frag(struct mem_frag_state *s, void *buf, size_t flen)
 {
 	int rc = 0;
 
-	rc = add_mem_share_helper(&s->share, buf, flen);
+	rc = add_mem_op_helper(&s->op, buf, flen);
 	if (rc >= 0) {
 		if (!ADD_OVERFLOW(s->frag_offset, rc, &s->frag_offset)) {
 			/* We're not at the end of the descriptor yet */
-			if (s->share.region_count)
+			if (s->op.region_count)
 				return s->frag_offset;
 
 			/* We're done */
@@ -1096,17 +1106,20 @@ static int add_mem_share_frag(struct mem_frag_state *s, void *buf, size_t flen)
 	}
 
 	SLIST_REMOVE(&frag_state_head, s, mem_frag_state, link);
-	if (rc < 0)
-		mobj_ffa_sel1_spmc_delete(s->share.mf);
-	else
-		mobj_ffa_push_to_inactive(s->share.mf);
+	if (rc < 0) {
+		mobj_ffa_sel1_spmc_delete(s->op.mf);
+	} else {
+		if (mobj_ffa_push_to_inactive(s->op.mf)) {
+			rc = FFA_INVALID_PARAMETERS;
+			mobj_ffa_sel1_spmc_delete(s->op.mf);
+		}
+	}
 	free(s);
 
 	return rc;
 }
 
-static bool is_sp_share(struct ffa_mem_transaction_x *mem_trans,
-			void *buf)
+static bool is_sp_op(struct ffa_mem_transaction_x *mem_trans, void *buf)
 {
 	struct ffa_mem_access_perm *perm = NULL;
 	struct ffa_mem_access *mem_acc = NULL;
@@ -1128,33 +1141,36 @@ static bool is_sp_share(struct ffa_mem_transaction_x *mem_trans,
 	return READ_ONCE(perm->endpoint_id) != optee_endpoint_id;
 }
 
-static int add_mem_share(struct ffa_mem_transaction_x *mem_trans,
-			 tee_mm_entry_t *mm, void *buf, size_t blen,
-			 size_t flen, uint64_t *global_handle)
+static int add_mem_op(bool mem_share, struct ffa_mem_transaction_x *mem_trans,
+		      tee_mm_entry_t *mm, void *buf, size_t blen, size_t flen,
+		      uint64_t *global_handle)
 {
 	int rc = 0;
-	struct mem_share_state share = { };
+	struct mem_op_state op = { .mem_share = mem_share, };
 	size_t addr_range_offs = 0;
 	uint64_t cookie = OPTEE_MSG_FMEM_INVALID_GLOBAL_ID;
+	enum mobj_use_case use_case = MOBJ_USE_CASE_NS_SHM;
 	size_t n = 0;
 
-	rc = mem_share_init(mem_trans, buf, flen, &share.page_count,
-			    &share.region_count, &addr_range_offs);
+	rc = mem_op_init(mem_share, mem_trans, buf, flen, &op.page_count,
+			 &op.region_count, &addr_range_offs);
 	if (rc)
 		return rc;
 
-	if (!share.page_count || !share.region_count)
+	if (!op.page_count || !op.region_count)
 		return FFA_INVALID_PARAMETERS;
 
-	if (MUL_OVERFLOW(share.region_count,
+	if (MUL_OVERFLOW(op.region_count,
 			 sizeof(struct ffa_address_range), &n) ||
 	    ADD_OVERFLOW(n, addr_range_offs, &n) || n > blen)
 		return FFA_INVALID_PARAMETERS;
 
 	if (mem_trans->global_handle)
 		cookie = mem_trans->global_handle;
-	share.mf = mobj_ffa_sel1_spmc_new(cookie, share.page_count);
-	if (!share.mf)
+	if (!mem_share)
+		use_case = mem_trans->tag;
+	op.mf = mobj_ffa_sel1_spmc_new(cookie, op.page_count, use_case);
+	if (!op.mf)
 		return FFA_NO_MEMORY;
 
 	if (flen != blen) {
@@ -1164,22 +1180,22 @@ static int add_mem_share(struct ffa_mem_transaction_x *mem_trans,
 			rc = FFA_NO_MEMORY;
 			goto err;
 		}
-		s->share = share;
+		s->op = op;
 		s->mm = mm;
 		s->frag_offset = addr_range_offs;
 
 		SLIST_INSERT_HEAD(&frag_state_head, s, link);
-		rc = add_mem_share_frag(s, (char *)buf + addr_range_offs,
-					flen - addr_range_offs);
+		rc = add_mem_op_frag(s, (char *)buf + addr_range_offs,
+				     flen - addr_range_offs);
 
 		if (rc >= 0)
-			*global_handle = mobj_ffa_get_cookie(share.mf);
+			*global_handle = mobj_ffa_get_cookie(op.mf);
 
 		return rc;
 	}
 
-	rc = add_mem_share_helper(&share, (char *)buf + addr_range_offs,
-				  flen - addr_range_offs);
+	rc = add_mem_op_helper(&op, (char *)buf + addr_range_offs,
+			       flen - addr_range_offs);
 	if (rc) {
 		/*
 		 * Number of consumed bytes may be returned instead of 0 for
@@ -1189,17 +1205,21 @@ static int add_mem_share(struct ffa_mem_transaction_x *mem_trans,
 		goto err;
 	}
 
-	*global_handle = mobj_ffa_push_to_inactive(share.mf);
+	if (mobj_ffa_push_to_inactive(op.mf)) {
+		rc = FFA_INVALID_PARAMETERS;
+		goto err;
+	}
+	*global_handle = mobj_ffa_get_cookie(op.mf);
 
 	return 0;
 err:
-	mobj_ffa_sel1_spmc_delete(share.mf);
+	mobj_ffa_sel1_spmc_delete(op.mf);
 	return rc;
 }
 
-static int handle_mem_share_tmem(paddr_t pbuf, size_t blen, size_t flen,
-				 unsigned int page_count,
-				 uint64_t *global_handle, struct ffa_rxtx *rxtx)
+static int handle_mem_op_tmem(bool share_mem, paddr_t pbuf, size_t blen,
+			      size_t flen, unsigned int page_count,
+			      uint64_t *global_handle, struct ffa_rxtx *rxtx)
 {
 	struct ffa_mem_transaction_x mem_trans = { };
 	int rc = 0;
@@ -1236,7 +1256,11 @@ static int handle_mem_share_tmem(paddr_t pbuf, size_t blen, size_t flen,
 	if (rc)
 		goto unlock;
 
-	if (is_sp_share(&mem_trans, buf)) {
+	if (is_sp_op(&mem_trans, buf)) {
+		if (!share_mem) {
+			rc = FFA_DENIED;
+			goto unlock;
+		}
 		rc = spmc_sp_add_share(&mem_trans, buf, blen, flen,
 				       global_handle, NULL);
 		goto unlock;
@@ -1248,7 +1272,8 @@ static int handle_mem_share_tmem(paddr_t pbuf, size_t blen, size_t flen,
 		goto unlock;
 	}
 
-	rc = add_mem_share(&mem_trans, mm, buf, blen, flen, global_handle);
+	rc = add_mem_op(share_mem, &mem_trans, mm, buf, blen, flen,
+			global_handle);
 
 	if (IS_ENABLED(CFG_NS_VIRTUALIZATION))
 		virt_unset_guest();
@@ -1264,9 +1289,8 @@ out:
 	return rc;
 }
 
-static int handle_mem_share_rxbuf(size_t blen, size_t flen,
-				  uint64_t *global_handle,
-				  struct ffa_rxtx *rxtx)
+static int handle_mem_op_rxbuf(bool share_mem, size_t blen, size_t flen,
+			       uint64_t *global_handle, struct ffa_rxtx *rxtx)
 {
 	struct ffa_mem_transaction_x mem_trans = { };
 	int rc = FFA_DENIED;
@@ -1280,7 +1304,11 @@ static int handle_mem_share_rxbuf(size_t blen, size_t flen,
 				       &mem_trans);
 	if (rc)
 		goto out;
-	if (is_sp_share(&mem_trans, rxtx->rx)) {
+	if (is_sp_op(&mem_trans, rxtx->rx)) {
+		if (!share_mem) {
+			rc = FFA_DENIED;
+			goto out;
+		}
 		rc = spmc_sp_add_share(&mem_trans, rxtx, blen, flen,
 				       global_handle, NULL);
 		goto out;
@@ -1290,8 +1318,8 @@ static int handle_mem_share_rxbuf(size_t blen, size_t flen,
 	    virt_set_guest(mem_trans.sender_id))
 		goto out;
 
-	rc = add_mem_share(&mem_trans, NULL, rxtx->rx, blen, flen,
-			   global_handle);
+	rc = add_mem_op(share_mem, &mem_trans, NULL, rxtx->rx, blen, flen,
+			global_handle);
 
 	if (IS_ENABLED(CFG_NS_VIRTUALIZATION))
 		virt_unset_guest();
@@ -1302,8 +1330,7 @@ out:
 	return rc;
 }
 
-static void handle_mem_share(struct thread_smc_args *args,
-			     struct ffa_rxtx *rxtx)
+static void handle_mem_op(struct thread_smc_args *args, struct ffa_rxtx *rxtx)
 {
 	uint32_t tot_len = args->a1;
 	uint32_t frag_len = args->a2;
@@ -1314,6 +1341,7 @@ static void handle_mem_share(struct thread_smc_args *args,
 	uint32_t ret_w3 = 0;
 	uint32_t ret_fid = FFA_ERROR;
 	uint64_t global_handle = 0;
+	bool share_mem = false;
 	int rc = 0;
 
 	/* Check that the MBZs are indeed 0 */
@@ -1325,8 +1353,13 @@ static void handle_mem_share(struct thread_smc_args *args,
 		goto out;
 
 	/* Check for 32-bit calling convention */
-	if (args->a0 == FFA_MEM_SHARE_32)
+	if (!OPTEE_SMC_IS_64(args->a0))
 		addr &= UINT32_MAX;
+
+	if (args->a0 == FFA_MEM_SHARE_32 || args->a0 == FFA_MEM_SHARE_64)
+		share_mem = true;
+	else
+		share_mem = false;
 
 	if (!addr) {
 		/*
@@ -1335,11 +1368,11 @@ static void handle_mem_share(struct thread_smc_args *args,
 		 */
 		if (page_count)
 			goto out;
-		rc = handle_mem_share_rxbuf(tot_len, frag_len, &global_handle,
-					    rxtx);
+		rc = handle_mem_op_rxbuf(share_mem, tot_len, frag_len,
+					 &global_handle, rxtx);
 	} else {
-		rc = handle_mem_share_tmem(addr, tot_len, frag_len, page_count,
-					   &global_handle, rxtx);
+		rc = handle_mem_op_tmem(share_mem, addr, tot_len, frag_len,
+					page_count, &global_handle, rxtx);
 	}
 	if (rc < 0) {
 		ret_w2 = rc;
@@ -1360,7 +1393,7 @@ static struct mem_frag_state *get_frag_state(uint64_t global_handle)
 	struct mem_frag_state *s = NULL;
 
 	SLIST_FOREACH(s, &frag_state_head, link)
-		if (mobj_ffa_get_cookie(s->share.mf) == global_handle)
+		if (mobj_ffa_get_cookie(s->op.mf) == global_handle)
 			return s;
 
 	return NULL;
@@ -1410,7 +1443,7 @@ static void handle_mem_frag_tx(struct thread_smc_args *args,
 			rc = FFA_INVALID_PARAMETERS;
 			goto out;
 		}
-		page_count = s->share.page_count;
+		page_count = s->op.page_count;
 		buf = (void *)tee_mm_get_smem(mm);
 	} else {
 		if (flen > rxtx->size) {
@@ -1420,7 +1453,7 @@ static void handle_mem_frag_tx(struct thread_smc_args *args,
 		buf = rxtx->rx;
 	}
 
-	rc = add_mem_share_frag(s, buf, flen);
+	rc = add_mem_op_frag(s, buf, flen);
 out:
 	if (IS_ENABLED(CFG_NS_VIRTUALIZATION))
 		virt_unset_guest();
@@ -1980,7 +2013,11 @@ void thread_spmc_msg_recv(struct thread_smc_args *args)
 	case FFA_MEM_SHARE_64:
 #endif
 	case FFA_MEM_SHARE_32:
-		handle_mem_share(args, &my_rxtx);
+#ifdef ARM64
+	case FFA_MEM_LEND_64:
+#endif
+	case FFA_MEM_LEND_32:
+		handle_mem_op(args, &my_rxtx);
 		break;
 	case FFA_MEM_RECLAIM:
 		if (!IS_ENABLED(CFG_SECURE_PARTITION) ||
@@ -2390,6 +2427,39 @@ static uint16_t ffa_spm_id_get(void)
 	return args.a2;
 }
 
+TEE_Result thread_spmc_get_rstmem_config(uint64_t use_case, void *buf,
+					 size_t *buf_sz, size_t *min_mem_sz,
+					 size_t *min_mem_align)
+{
+	uint16_t end_point_list[] = {
+		optee_endpoint_id,
+	};
+
+	switch (use_case) {
+	case OPTEE_MSG_RSTMEM_SECURE_VIDEO_PLAY:
+		break;
+	case OPTEE_MSG_RSTMEM_TRUSTED_UI:
+	case OPTEE_MSG_RSTMEM_SECURE_VIDEO_RECORD:
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/*
+	 * Only shared with OP-TEE and TAs, a dummy configuration for now.
+	 * This might later be configured via a manifest or DT.
+	 */
+	*min_mem_sz = SIZE_1M;
+	*min_mem_align = SMALL_PAGE_SIZE;
+	if (!buf || *buf_sz < sizeof(end_point_list)) {
+		*buf_sz = sizeof(end_point_list);
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	memcpy(buf, end_point_list, sizeof(end_point_list));
+	*buf_sz = sizeof(end_point_list);
+	return TEE_SUCCESS;
+}
+
 #if defined(CFG_CORE_SEL1_SPMC)
 static TEE_Result spmc_init(void)
 {
@@ -2463,9 +2533,9 @@ static uint32_t get_ffa_version(uint32_t my_version)
 	return args.a0;
 }
 
-static void *spmc_retrieve_req(uint64_t cookie,
-			       struct ffa_mem_transaction_x *trans)
+static void *spmc_retrieve_req(struct ffa_mem_transaction_x *trans)
 {
+	uint64_t cookie __maybe_unused = trans->global_handle;
 	struct ffa_mem_access *acc_descr_array = NULL;
 	struct ffa_mem_access_perm *perm_descr = NULL;
 	struct thread_smc_args args = {
@@ -2481,11 +2551,11 @@ static void *spmc_retrieve_req(uint64_t cookie,
 
 		size = sizeof(*trans_descr) + 1 * sizeof(struct ffa_mem_access);
 		memset(trans_descr, 0, size);
-		trans_descr->sender_id = thread_get_tsd()->rpc_target_info;
-		trans_descr->mem_reg_attr = FFA_NORMAL_MEM_REG_ATTR;
-		trans_descr->global_handle = cookie;
-		trans_descr->flags = FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE |
-				     FFA_MEMORY_REGION_FLAG_ANY_ALIGNMENT;
+		trans_descr->sender_id = trans->sender_id;
+		trans_descr->mem_reg_attr = trans->mem_reg_attr;
+		trans_descr->global_handle = trans->global_handle;
+		trans_descr->tag = trans->tag;
+		trans_descr->flags = trans->flags;
 		trans_descr->mem_access_count = 1;
 		acc_descr_array = trans_descr->mem_access_array;
 	} else {
@@ -2493,11 +2563,11 @@ static void *spmc_retrieve_req(uint64_t cookie,
 
 		size = sizeof(*trans_descr) + 1 * sizeof(struct ffa_mem_access);
 		memset(trans_descr, 0, size);
-		trans_descr->sender_id = thread_get_tsd()->rpc_target_info;
-		trans_descr->mem_reg_attr = FFA_NORMAL_MEM_REG_ATTR;
-		trans_descr->global_handle = cookie;
-		trans_descr->flags = FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE |
-				     FFA_MEMORY_REGION_FLAG_ANY_ALIGNMENT;
+		trans_descr->sender_id = trans->sender_id;
+		trans_descr->mem_reg_attr = trans->mem_reg_attr;
+		trans_descr->global_handle = trans->global_handle;
+		trans_descr->tag = trans->tag;
+		trans_descr->flags = trans->flags;
 		trans_descr->mem_access_count = 1;
 		trans_descr->mem_access_offs = sizeof(*trans_descr);
 		trans_descr->mem_access_size = sizeof(struct ffa_mem_access);
@@ -2572,10 +2642,11 @@ static int set_pages(struct ffa_address_range *regions,
 	return 0;
 }
 
-struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie)
+struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie,
+						   enum mobj_use_case use_case)
 {
 	struct mobj_ffa *ret = NULL;
-	struct ffa_mem_transaction_x retrieve_desc = { };
+	struct ffa_mem_transaction_x retrieve_desc = { .tag = use_case};
 	struct ffa_mem_access *descr_array = NULL;
 	struct ffa_mem_region *descr = NULL;
 	struct mobj_ffa *mf = NULL;
@@ -2586,11 +2657,20 @@ struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie)
 		.a0 = FFA_RX_RELEASE
 	};
 
+	if (use_case == MOBJ_USE_CASE_NS_SHM)
+		retrieve_desc.flags = FFA_MEMORY_REGION_TRANSACTION_TYPE_SHARE;
+	else
+		retrieve_desc.flags = FFA_MEMORY_REGION_TRANSACTION_TYPE_LEND;
+	retrieve_desc.flags |= FFA_MEMORY_REGION_FLAG_ANY_ALIGNMENT;
+	retrieve_desc.global_handle = cookie;
+	retrieve_desc.sender_id = thread_get_tsd()->rpc_target_info;
+	retrieve_desc.mem_reg_attr = FFA_NORMAL_MEM_REG_ATTR;
+
 	/*
 	 * OP-TEE is only supporting a single mem_region while the
 	 * specification allows for more than one.
 	 */
-	buf = spmc_retrieve_req(cookie, &retrieve_desc);
+	buf = spmc_retrieve_req(&retrieve_desc);
 	if (!buf) {
 		EMSG("Failed to retrieve cookie from rx buffer %#"PRIx64,
 		     cookie);
@@ -2602,7 +2682,7 @@ struct mobj_ffa *thread_spmc_populate_mobj_from_rx(uint64_t cookie)
 	descr = (struct ffa_mem_region *)((vaddr_t)buf + offs);
 
 	num_pages = READ_ONCE(descr->total_page_count);
-	mf = mobj_ffa_spmc_new(cookie, num_pages);
+	mf = mobj_ffa_spmc_new(cookie, num_pages, use_case);
 	if (!mf)
 		goto out;
 

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -78,13 +78,17 @@ struct mobj_ffa {
 	struct mobj mobj;
 	SLIST_ENTRY(mobj_ffa) link;
 	uint64_t cookie;
-	tee_mm_entry_t *mm;
-	struct refcount mapcount;
 	unsigned int inactive_refs;
-	uint16_t page_offset;
 #ifdef CFG_CORE_SEL1_SPMC
 	bool registered_by_cookie;
 #endif
+};
+
+struct mobj_ffa_shm {
+	struct mobj_ffa mf;
+	tee_mm_entry_t *mm;
+	struct refcount mapcount;
+	uint16_t page_offset;
 	paddr_t pages[];
 };
 
@@ -112,12 +116,17 @@ static struct mobj_ffa_head shm_inactive_head =
 
 static unsigned int shm_lock = SPINLOCK_UNLOCK;
 
-static const struct mobj_ops mobj_ffa_ops;
+static const struct mobj_ops mobj_ffa_shm_ops;
 
-static struct mobj_ffa *to_mobj_ffa(struct mobj *mobj)
+static bool __maybe_unused is_mobj_ffa_shm(struct mobj *mobj)
 {
-	assert(mobj->ops == &mobj_ffa_ops);
-	return container_of(mobj, struct mobj_ffa, mobj);
+	return mobj->ops == &mobj_ffa_shm_ops;
+}
+
+static struct mobj_ffa_shm *to_mobj_ffa_shm(struct mobj *mobj)
+{
+	assert(is_mobj_ffa_shm(mobj));
+	return container_of(mobj, struct mobj_ffa_shm, mf.mobj);
 }
 
 static size_t shm_size(size_t num_pages)
@@ -126,14 +135,14 @@ static size_t shm_size(size_t num_pages)
 
 	if (MUL_OVERFLOW(sizeof(paddr_t), num_pages, &s))
 		return 0;
-	if (ADD_OVERFLOW(sizeof(struct mobj_ffa), s, &s))
+	if (ADD_OVERFLOW(sizeof(struct mobj_ffa_shm), s, &s))
 		return 0;
 	return s;
 }
 
-static struct mobj_ffa *ffa_new(unsigned int num_pages)
+static struct mobj_ffa_shm *ffa_shm_new(unsigned int num_pages)
 {
-	struct mobj_ffa *mf = NULL;
+	struct mobj_ffa_shm *m = NULL;
 	size_t s = 0;
 
 	if (!num_pages)
@@ -142,24 +151,24 @@ static struct mobj_ffa *ffa_new(unsigned int num_pages)
 	s = shm_size(num_pages);
 	if (!s)
 		return NULL;
-	mf = calloc(1, s);
-	if (!mf)
+	m = calloc(1, s);
+	if (!m)
 		return NULL;
 
-	mf->mobj.ops = &mobj_ffa_ops;
-	mf->mobj.size = num_pages * SMALL_PAGE_SIZE;
-	mf->mobj.phys_granule = SMALL_PAGE_SIZE;
-	refcount_set(&mf->mobj.refc, 0);
-	mf->inactive_refs = 0;
+	m->mf.mobj.ops = &mobj_ffa_shm_ops;
+	m->mf.mobj.size = num_pages * SMALL_PAGE_SIZE;
+	m->mf.mobj.phys_granule = SMALL_PAGE_SIZE;
+	refcount_set(&m->mf.mobj.refc, 0);
+	m->mf.inactive_refs = 0;
 
-	return mf;
+	return m;
 }
 
 #ifdef CFG_CORE_SEL1_SPMC
 struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
 					unsigned int num_pages)
 {
-	struct mobj_ffa *mf = NULL;
+	struct mobj_ffa_shm *m = NULL;
 	bitstr_t *shm_bits = NULL;
 	uint32_t exceptions = 0;
 	int i = 0;
@@ -171,16 +180,16 @@ struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
 			return NULL;
 	}
 
-	mf = ffa_new(num_pages);
-	if (!mf) {
+	m = ffa_shm_new(num_pages);
+	if (!m) {
 		if (cookie != OPTEE_MSG_FMEM_INVALID_GLOBAL_ID)
 			virt_remove_cookie(cookie);
 		return NULL;
 	}
 
 	if (cookie != OPTEE_MSG_FMEM_INVALID_GLOBAL_ID) {
-		mf->cookie = cookie;
-		return mf;
+		m->mf.cookie = cookie;
+		return &m->mf;
 	}
 
 	shm_bits = get_shm_bits();
@@ -188,29 +197,29 @@ struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
 	bit_ffc(shm_bits, SPMC_CORE_SEL1_MAX_SHM_COUNT, &i);
 	if (i != -1) {
 		bit_set(shm_bits, i);
-		mf->cookie = i;
-		mf->cookie |= FFA_MEMORY_HANDLE_NON_SECURE_BIT;
+		m->mf.cookie = i;
+		m->mf.cookie |= FFA_MEMORY_HANDLE_NON_SECURE_BIT;
 		/*
 		 * Encode the partition ID into the handle so we know which
 		 * partition to switch to when reclaiming a handle.
 		 */
-		mf->cookie |= SHIFT_U64(virt_get_current_guest_id(),
-					FFA_MEMORY_HANDLE_PRTN_SHIFT);
+		m->mf.cookie |= SHIFT_U64(virt_get_current_guest_id(),
+					  FFA_MEMORY_HANDLE_PRTN_SHIFT);
 	}
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 
 	if (i == -1) {
-		free(mf);
+		free(m);
 		return NULL;
 	}
 
-	return mf;
+	return &m->mf;
 }
 #endif /*CFG_CORE_SEL1_SPMC*/
 
-static size_t get_page_count(struct mobj_ffa *mf)
+static size_t get_page_count(struct mobj_ffa_shm *m)
 {
-	return ROUNDUP(mf->mobj.size, SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE;
+	return ROUNDUP(m->mf.mobj.size, SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE;
 }
 
 static bool cmp_cookie(struct mobj_ffa *mf, uint64_t cookie)
@@ -268,6 +277,7 @@ static struct mobj_ffa *find_in_list(struct mobj_ffa_head *head,
 #if defined(CFG_CORE_SEL1_SPMC)
 void mobj_ffa_sel1_spmc_delete(struct mobj_ffa *mf)
 {
+	struct mobj_ffa_shm *m = NULL;
 
 	if (!IS_ENABLED(CFG_NS_VIRTUALIZATION) ||
 	    !(mf->cookie & FFA_MEMORY_HANDLE_HYPERVISOR_BIT)) {
@@ -288,33 +298,37 @@ void mobj_ffa_sel1_spmc_delete(struct mobj_ffa *mf)
 		cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 	}
 
-	assert(!mf->mm);
-	free(mf);
+	m = to_mobj_ffa_shm(&mf->mobj);
+	assert(!m->mm);
+	free(m);
 }
 #else /* !defined(CFG_CORE_SEL1_SPMC) */
 struct mobj_ffa *mobj_ffa_spmc_new(uint64_t cookie, unsigned int num_pages)
 {
-	struct mobj_ffa *mf = NULL;
+	struct mobj_ffa_shm *m = NULL;
 
 	assert(cookie != OPTEE_MSG_FMEM_INVALID_GLOBAL_ID);
-	mf = ffa_new(num_pages);
-	if (mf)
-		mf->cookie = cookie;
-	return mf;
+	m = ffa_shm_new(num_pages);
+	if (m)
+		m->mf.cookie = cookie;
+	return &m->mf;
 }
 
 void mobj_ffa_spmc_delete(struct mobj_ffa *mf)
 {
-	free(mf);
+	free(to_mobj_ffa_shm(&mf->mobj));
 }
 #endif /* !defined(CFG_CORE_SEL1_SPMC) */
 
 TEE_Result mobj_ffa_add_pages_at(struct mobj_ffa *mf, unsigned int *idx,
 				 paddr_t pa, unsigned int num_pages)
 {
+	struct mobj_ffa_shm *mfs = NULL;
+	size_t tot_page_count = 0;
 	unsigned int n = 0;
-	size_t tot_page_count = get_page_count(mf);
 
+	mfs = to_mobj_ffa_shm(&mf->mobj);
+	tot_page_count = get_page_count(mfs);
 	if (ADD_OVERFLOW(*idx, num_pages, &n) || n > tot_page_count)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -323,7 +337,7 @@ TEE_Result mobj_ffa_add_pages_at(struct mobj_ffa *mf, unsigned int *idx,
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	for (n = 0; n < num_pages; n++)
-		mf->pages[n + *idx] = pa + n * SMALL_PAGE_SIZE;
+		mfs->pages[n + *idx] = pa + n * SMALL_PAGE_SIZE;
 
 	(*idx) += n;
 	return TEE_SUCCESS;
@@ -348,13 +362,13 @@ uint64_t mobj_ffa_push_to_inactive(struct mobj_ffa *mf)
 	return mf->cookie;
 }
 
-static void unmap_helper(struct mobj_ffa *mf)
+static void unmap_helper(struct mobj_ffa_shm *m)
 {
-	if (mf->mm) {
-		core_mmu_unmap_pages(tee_mm_get_smem(mf->mm),
-				     get_page_count(mf));
-		tee_mm_free(mf->mm);
-		mf->mm = NULL;
+	if (m->mm) {
+		core_mmu_unmap_pages(tee_mm_get_smem(m->mm),
+				     get_page_count(m));
+		tee_mm_free(m->mm);
+		m->mm = NULL;
 	}
 }
 
@@ -475,21 +489,25 @@ out:
 struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 				    unsigned int internal_offs)
 {
+	struct mobj_ffa_shm *mfs = NULL;
 	struct mobj_ffa *mf = NULL;
 	uint32_t exceptions = 0;
+	uint16_t offs = 0;
 
 	if (internal_offs >= SMALL_PAGE_SIZE)
 		return NULL;
 	exceptions = cpu_spin_lock_xsave(&shm_lock);
 	mf = find_in_list(&shm_head, cmp_cookie, cookie);
 	if (mf) {
-		if (mf->page_offset == internal_offs) {
+		mfs = to_mobj_ffa_shm(&mf->mobj);
+		offs = mfs->page_offset;
+		if (offs == internal_offs) {
 			if (!refcount_inc(&mf->mobj.refc)) {
 				/*
 				 * If refcount is 0 some other thread has
 				 * called mobj_put() on this reached 0 and
-				 * before ffa_inactivate() got the lock we
-				 * found it. Let's reinitialize it.
+				 * before ffa_shm_inactivate() got the lock
+				 * we found it. Let's reinitialize it.
 				 */
 				refcount_set(&mf->mobj.refc, 1);
 				mf->inactive_refs++;
@@ -499,7 +517,7 @@ struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 			     mf->inactive_refs);
 		} else {
 			EMSG("cookie %#"PRIx64" mismatching internal_offs got %#"PRIx16" expected %#x",
-			     cookie, mf->page_offset, internal_offs);
+			     cookie, offs, internal_offs);
 			mf = NULL;
 		}
 	} else {
@@ -523,8 +541,9 @@ struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 #endif
 			assert(refcount_val(&mf->mobj.refc) == 0);
 			refcount_set(&mf->mobj.refc, 1);
-			refcount_set(&mf->mapcount, 0);
 			mf->inactive_refs++;
+			mfs = to_mobj_ffa_shm(&mf->mobj);
+			refcount_set(&mfs->mapcount, 0);
 
 			/*
 			 * mf->page_offset is offset into the first page.
@@ -539,10 +558,10 @@ struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 			 * mf->page_offset and then assigning a new from
 			 * internal_offset.
 			 */
-			mf->mobj.size += mf->page_offset;
+			mf->mobj.size += mfs->page_offset;
 			assert(!(mf->mobj.size & SMALL_PAGE_MASK));
 			mf->mobj.size -= internal_offs;
-			mf->page_offset = internal_offs;
+			mfs->page_offset = internal_offs;
 
 			SLIST_INSERT_HEAD(&shm_head, mf, link);
 		}
@@ -558,10 +577,10 @@ struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 	return &mf->mobj;
 }
 
-static TEE_Result ffa_get_pa(struct mobj *mobj, size_t offset,
-			     size_t granule, paddr_t *pa)
+static TEE_Result ffa_shm_get_pa(struct mobj *mobj, size_t offset,
+				 size_t granule, paddr_t *pa)
 {
-	struct mobj_ffa *mf = to_mobj_ffa(mobj);
+	struct mobj_ffa_shm *m = to_mobj_ffa_shm(mobj);
 	size_t full_offset = 0;
 	paddr_t p = 0;
 
@@ -571,14 +590,14 @@ static TEE_Result ffa_get_pa(struct mobj *mobj, size_t offset,
 	if (offset >= mobj->size)
 		return TEE_ERROR_GENERIC;
 
-	full_offset = offset + mf->page_offset;
+	full_offset = offset + m->page_offset;
 	switch (granule) {
 	case 0:
-		p = mf->pages[full_offset / SMALL_PAGE_SIZE] +
+		p = m->pages[full_offset / SMALL_PAGE_SIZE] +
 		    (full_offset & SMALL_PAGE_MASK);
 		break;
 	case SMALL_PAGE_SIZE:
-		p = mf->pages[full_offset / SMALL_PAGE_SIZE];
+		p = m->pages[full_offset / SMALL_PAGE_SIZE];
 		break;
 	default:
 		return TEE_ERROR_GENERIC;
@@ -588,27 +607,27 @@ static TEE_Result ffa_get_pa(struct mobj *mobj, size_t offset,
 	return TEE_SUCCESS;
 }
 
-static size_t ffa_get_phys_offs(struct mobj *mobj,
-				size_t granule __maybe_unused)
+static size_t ffa_shm_get_phys_offs(struct mobj *mobj,
+				    size_t granule __maybe_unused)
 {
 	assert(granule >= mobj->phys_granule);
 
-	return to_mobj_ffa(mobj)->page_offset;
+	return to_mobj_ffa_shm(mobj)->page_offset;
 }
 
-static void *ffa_get_va(struct mobj *mobj, size_t offset, size_t len)
+static void *ffa_shm_get_va(struct mobj *mobj, size_t offset, size_t len)
 {
-	struct mobj_ffa *mf = to_mobj_ffa(mobj);
+	struct mobj_ffa_shm *m = to_mobj_ffa_shm(mobj);
 
-	if (!mf->mm || !mobj_check_offset_and_len(mobj, offset, len))
+	if (!m->mm || !mobj_check_offset_and_len(mobj, offset, len))
 		return NULL;
 
-	return (void *)(tee_mm_get_smem(mf->mm) + offset + mf->page_offset);
+	return (void *)(tee_mm_get_smem(m->mm) + offset + m->page_offset);
 }
 
-static void ffa_inactivate(struct mobj *mobj)
+static void ffa_shm_inactivate(struct mobj *mobj)
 {
-	struct mobj_ffa *mf = to_mobj_ffa(mobj);
+	struct mobj_ffa_shm *m = to_mobj_ffa_shm(mobj);
 	uint32_t exceptions = 0;
 
 	exceptions = cpu_spin_lock_xsave(&shm_lock);
@@ -618,7 +637,7 @@ static void ffa_inactivate(struct mobj *mobj)
 	 * the lock.
 	 */
 	if (refcount_val(&mobj->refc)) {
-		DMSG("cookie %#"PRIx64" was resurrected", mf->cookie);
+		DMSG("cookie %#"PRIx64" was resurrected", m->mf.cookie);
 		goto out;
 	}
 
@@ -633,18 +652,18 @@ static void ffa_inactivate(struct mobj *mobj)
 	 * that the mobj can't be freed until it reaches 0.
 	 * At this point the mobj is in the inactive list.
 	 */
-	if (pop_from_list(&shm_head, cmp_ptr, (vaddr_t)mf)) {
-		unmap_helper(mf);
-		SLIST_INSERT_HEAD(&shm_inactive_head, mf, link);
+	if (pop_from_list(&shm_head, cmp_ptr, (vaddr_t)&m->mf)) {
+		unmap_helper(m);
+		SLIST_INSERT_HEAD(&shm_inactive_head, &m->mf, link);
 	}
 out:
-	if (!mf->inactive_refs)
+	if (!m->mf.inactive_refs)
 		panic();
-	mf->inactive_refs--;
+	m->mf.inactive_refs--;
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 }
 
-static TEE_Result ffa_get_mem_type(struct mobj *mobj __unused, uint32_t *mt)
+static TEE_Result ffa_shm_get_mem_type(struct mobj *mobj __unused, uint32_t *mt)
 {
 	if (!mt)
 		return TEE_ERROR_GENERIC;
@@ -654,32 +673,33 @@ static TEE_Result ffa_get_mem_type(struct mobj *mobj __unused, uint32_t *mt)
 	return TEE_SUCCESS;
 }
 
-static bool ffa_matches(struct mobj *mobj __maybe_unused, enum buf_is_attr attr)
+static bool ffa_shm_matches(struct mobj *mobj __maybe_unused,
+			    enum buf_is_attr attr)
 {
-	assert(mobj->ops == &mobj_ffa_ops);
+	assert(is_mobj_ffa_shm(mobj));
 
 	return attr == CORE_MEM_NON_SEC || attr == CORE_MEM_REG_SHM;
 }
 
-static uint64_t ffa_get_cookie(struct mobj *mobj)
+static uint64_t ffa_shm_get_cookie(struct mobj *mobj)
 {
-	return to_mobj_ffa(mobj)->cookie;
+	return to_mobj_ffa_shm(mobj)->mf.cookie;
 }
 
-static TEE_Result ffa_inc_map(struct mobj *mobj)
+static TEE_Result ffa_shm_inc_map(struct mobj *mobj)
 {
+	struct mobj_ffa_shm *m = to_mobj_ffa_shm(mobj);
 	TEE_Result res = TEE_SUCCESS;
-	struct mobj_ffa *mf = to_mobj_ffa(mobj);
 	uint32_t exceptions = 0;
 	size_t sz = 0;
 
 	while (true) {
-		if (refcount_inc(&mf->mapcount))
+		if (refcount_inc(&m->mapcount))
 			return TEE_SUCCESS;
 
 		exceptions = cpu_spin_lock_xsave(&shm_lock);
 
-		if (!refcount_val(&mf->mapcount))
+		if (!refcount_val(&m->mapcount))
 			break; /* continue to reinitialize */
 		/*
 		 * If another thread beat us to initialize mapcount,
@@ -692,42 +712,42 @@ static TEE_Result ffa_inc_map(struct mobj *mobj)
 	 * If we have beated another thread calling ffa_dec_map()
 	 * to get the lock we need only to reinitialize mapcount to 1.
 	 */
-	if (!mf->mm) {
-		sz = ROUNDUP(mobj->size + mf->page_offset, SMALL_PAGE_SIZE);
-		mf->mm = tee_mm_alloc(&core_virt_shm_pool, sz);
-		if (!mf->mm) {
+	if (!m->mm) {
+		sz = ROUNDUP(mobj->size + m->page_offset, SMALL_PAGE_SIZE);
+		m->mm = tee_mm_alloc(&core_virt_shm_pool, sz);
+		if (!m->mm) {
 			res = TEE_ERROR_OUT_OF_MEMORY;
 			goto out;
 		}
 
-		res = core_mmu_map_pages(tee_mm_get_smem(mf->mm), mf->pages,
+		res = core_mmu_map_pages(tee_mm_get_smem(m->mm), m->pages,
 					 sz / SMALL_PAGE_SIZE,
 					 MEM_AREA_NSEC_SHM);
 		if (res) {
-			tee_mm_free(mf->mm);
-			mf->mm = NULL;
+			tee_mm_free(m->mm);
+			m->mm = NULL;
 			goto out;
 		}
 	}
 
-	refcount_set(&mf->mapcount, 1);
+	refcount_set(&m->mapcount, 1);
 out:
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 
 	return res;
 }
 
-static TEE_Result ffa_dec_map(struct mobj *mobj)
+static TEE_Result ffa_shm_dec_map(struct mobj *mobj)
 {
-	struct mobj_ffa *mf = to_mobj_ffa(mobj);
+	struct mobj_ffa_shm *m = to_mobj_ffa_shm(mobj);
 	uint32_t exceptions = 0;
 
-	if (!refcount_dec(&mf->mapcount))
+	if (!refcount_dec(&m->mapcount))
 		return TEE_SUCCESS;
 
 	exceptions = cpu_spin_lock_xsave(&shm_lock);
-	if (!refcount_val(&mf->mapcount))
-		unmap_helper(mf);
+	if (!refcount_val(&m->mapcount))
+		unmap_helper(m);
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 
 	return TEE_SUCCESS;
@@ -752,16 +772,16 @@ static TEE_Result mapped_shm_init(void)
 	return TEE_SUCCESS;
 }
 
-static const struct mobj_ops mobj_ffa_ops = {
-	.get_pa = ffa_get_pa,
-	.get_phys_offs = ffa_get_phys_offs,
-	.get_va = ffa_get_va,
-	.get_mem_type = ffa_get_mem_type,
-	.matches = ffa_matches,
-	.free = ffa_inactivate,
-	.get_cookie = ffa_get_cookie,
-	.inc_map = ffa_inc_map,
-	.dec_map = ffa_dec_map,
+static const struct mobj_ops mobj_ffa_shm_ops = {
+	.get_pa = ffa_shm_get_pa,
+	.get_phys_offs = ffa_shm_get_phys_offs,
+	.get_va = ffa_shm_get_va,
+	.get_mem_type = ffa_shm_get_mem_type,
+	.matches = ffa_shm_matches,
+	.free = ffa_shm_inactivate,
+	.get_cookie = ffa_shm_get_cookie,
+	.inc_map = ffa_shm_inc_map,
+	.dec_map = ffa_shm_dec_map,
 };
 
 preinit(mapped_shm_init);

--- a/core/arch/arm/mm/mobj_ffa.c
+++ b/core/arch/arm/mm/mobj_ffa.c
@@ -10,6 +10,7 @@
 #include <initcall.h>
 #include <kernel/refcount.h>
 #include <kernel/spinlock.h>
+#include <kernel/tee_misc.h>
 #include <kernel/thread_spmc.h>
 #include <kernel/virtualization.h>
 #include <mm/mobj.h>
@@ -92,6 +93,13 @@ struct mobj_ffa_shm {
 	paddr_t pages[];
 };
 
+struct mobj_ffa_rsm {
+	struct mobj_ffa mf;
+	paddr_t pa;
+	enum mobj_use_case use_case;
+	bool assigned_use_case;
+};
+
 SLIST_HEAD(mobj_ffa_head, mobj_ffa);
 
 #ifdef CFG_CORE_SEL1_SPMC
@@ -117,8 +125,9 @@ static struct mobj_ffa_head shm_inactive_head =
 static unsigned int shm_lock = SPINLOCK_UNLOCK;
 
 static const struct mobj_ops mobj_ffa_shm_ops;
+static const struct mobj_ops mobj_ffa_rsm_ops;
 
-static bool __maybe_unused is_mobj_ffa_shm(struct mobj *mobj)
+static bool is_mobj_ffa_shm(struct mobj *mobj)
 {
 	return mobj->ops == &mobj_ffa_shm_ops;
 }
@@ -127,6 +136,17 @@ static struct mobj_ffa_shm *to_mobj_ffa_shm(struct mobj *mobj)
 {
 	assert(is_mobj_ffa_shm(mobj));
 	return container_of(mobj, struct mobj_ffa_shm, mf.mobj);
+}
+
+static bool is_mobj_ffa_rsm(struct mobj *mobj)
+{
+	return mobj->ops == &mobj_ffa_rsm_ops;
+}
+
+static struct mobj_ffa_rsm *to_mobj_ffa_rsm(struct mobj *mobj)
+{
+	assert(is_mobj_ffa_rsm(mobj));
+	return container_of(mobj, struct mobj_ffa_rsm, mf.mobj);
 }
 
 static size_t shm_size(size_t num_pages)
@@ -140,7 +160,7 @@ static size_t shm_size(size_t num_pages)
 	return s;
 }
 
-static struct mobj_ffa_shm *ffa_shm_new(unsigned int num_pages)
+static struct mobj_ffa *ffa_shm_new(unsigned int num_pages)
 {
 	struct mobj_ffa_shm *m = NULL;
 	size_t s = 0;
@@ -161,14 +181,38 @@ static struct mobj_ffa_shm *ffa_shm_new(unsigned int num_pages)
 	refcount_set(&m->mf.mobj.refc, 0);
 	m->mf.inactive_refs = 0;
 
-	return m;
+	return &m->mf;
+}
+
+static struct mobj_ffa *ffa_rsm_new(unsigned int num_pages,
+				    enum mobj_use_case use_case)
+{
+	struct mobj_ffa_rsm *m = NULL;
+	size_t sz = 0;
+
+	if (!num_pages || MUL_OVERFLOW(num_pages, SMALL_PAGE_SIZE, &sz))
+		return NULL;
+
+	m = calloc(1, sizeof(*m));
+	if (!m)
+		return NULL;
+
+	m->mf.mobj.ops = &mobj_ffa_rsm_ops;
+	m->mf.mobj.size = sz;
+	m->mf.mobj.phys_granule = SMALL_PAGE_SIZE;
+	refcount_set(&m->mf.mobj.refc, 0);
+	m->mf.inactive_refs = 0;
+	m->use_case = use_case;
+
+	return &m->mf;
 }
 
 #ifdef CFG_CORE_SEL1_SPMC
 struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
-					unsigned int num_pages)
+					unsigned int num_pages,
+					enum mobj_use_case use_case)
 {
-	struct mobj_ffa_shm *m = NULL;
+	struct mobj_ffa *m = NULL;
 	bitstr_t *shm_bits = NULL;
 	uint32_t exceptions = 0;
 	int i = 0;
@@ -180,7 +224,17 @@ struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
 			return NULL;
 	}
 
-	m = ffa_shm_new(num_pages);
+	switch (use_case) {
+	case MOBJ_USE_CASE_NS_SHM:
+		m = ffa_shm_new(num_pages);
+		break;
+	case MOBJ_USE_CASE_SEC_VIDEO_PLAY:
+	case MOBJ_USE_CASE_TRUSED_UI:
+		m = ffa_rsm_new(num_pages, use_case);
+		break;
+	default:
+		break;
+	}
 	if (!m) {
 		if (cookie != OPTEE_MSG_FMEM_INVALID_GLOBAL_ID)
 			virt_remove_cookie(cookie);
@@ -188,8 +242,8 @@ struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
 	}
 
 	if (cookie != OPTEE_MSG_FMEM_INVALID_GLOBAL_ID) {
-		m->mf.cookie = cookie;
-		return &m->mf;
+		m->cookie = cookie;
+		return m;
 	}
 
 	shm_bits = get_shm_bits();
@@ -197,29 +251,29 @@ struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
 	bit_ffc(shm_bits, SPMC_CORE_SEL1_MAX_SHM_COUNT, &i);
 	if (i != -1) {
 		bit_set(shm_bits, i);
-		m->mf.cookie = i;
-		m->mf.cookie |= FFA_MEMORY_HANDLE_NON_SECURE_BIT;
+		m->cookie = i;
+		m->cookie |= FFA_MEMORY_HANDLE_NON_SECURE_BIT;
 		/*
 		 * Encode the partition ID into the handle so we know which
 		 * partition to switch to when reclaiming a handle.
 		 */
-		m->mf.cookie |= SHIFT_U64(virt_get_current_guest_id(),
-					  FFA_MEMORY_HANDLE_PRTN_SHIFT);
+		m->cookie |= SHIFT_U64(virt_get_current_guest_id(),
+				       FFA_MEMORY_HANDLE_PRTN_SHIFT);
 	}
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 
 	if (i == -1) {
-		free(m);
+		mobj_ffa_sel1_spmc_delete(m);
 		return NULL;
 	}
 
-	return &m->mf;
+	return m;
 }
 #endif /*CFG_CORE_SEL1_SPMC*/
 
-static size_t get_page_count(struct mobj_ffa_shm *m)
+static size_t get_page_count(struct mobj_ffa *mf)
 {
-	return ROUNDUP(m->mf.mobj.size, SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE;
+	return ROUNDUP(mf->mobj.size, SMALL_PAGE_SIZE) / SMALL_PAGE_SIZE;
 }
 
 static bool cmp_cookie(struct mobj_ffa *mf, uint64_t cookie)
@@ -230,6 +284,47 @@ static bool cmp_cookie(struct mobj_ffa *mf, uint64_t cookie)
 static bool cmp_ptr(struct mobj_ffa *mf, uint64_t ptr)
 {
 	return mf == (void *)(vaddr_t)ptr;
+}
+
+static bool check_shm_overlaps_rsm(struct mobj_ffa_shm *shm,
+				   struct mobj_ffa_rsm *rsm)
+{
+	size_t n = 0;
+
+	for (n = 0; n < shm->mf.mobj.size / SMALL_PAGE_SIZE; n++)
+		if (core_is_buffer_intersect(rsm->pa, rsm->mf.mobj.size,
+					     shm->pages[n], SMALL_PAGE_SIZE))
+			return true;
+
+	return false;
+}
+
+static bool cmp_pa_overlap(struct mobj_ffa *mf, uint64_t ptr)
+{
+	struct mobj_ffa *mf2 = (void *)(vaddr_t)ptr;
+	bool mf_is_shm = is_mobj_ffa_shm(&mf->mobj);
+	bool mf2_is_shm = is_mobj_ffa_shm(&mf2->mobj);
+
+	if (mf_is_shm && mf2_is_shm) {
+		/*
+		 * Not a security issue and might be too expensive to check
+		 * if we have many pages in each registered shared memory
+		 * object.
+		 */
+		return false;
+	}
+
+	if (mf_is_shm)
+		return check_shm_overlaps_rsm(to_mobj_ffa_shm(&mf->mobj),
+					      to_mobj_ffa_rsm(&mf2->mobj));
+	if (mf2_is_shm)
+		return check_shm_overlaps_rsm(to_mobj_ffa_shm(&mf2->mobj),
+					      to_mobj_ffa_rsm(&mf->mobj));
+
+	return core_is_buffer_intersect(to_mobj_ffa_rsm(&mf->mobj)->pa,
+					mf->mobj.size,
+					to_mobj_ffa_rsm(&mf2->mobj)->pa,
+					mf2->mobj.size);
 }
 
 static struct mobj_ffa *pop_from_list(struct mobj_ffa_head *head,
@@ -277,8 +372,6 @@ static struct mobj_ffa *find_in_list(struct mobj_ffa_head *head,
 #if defined(CFG_CORE_SEL1_SPMC)
 void mobj_ffa_sel1_spmc_delete(struct mobj_ffa *mf)
 {
-	struct mobj_ffa_shm *m = NULL;
-
 	if (!IS_ENABLED(CFG_NS_VIRTUALIZATION) ||
 	    !(mf->cookie & FFA_MEMORY_HANDLE_HYPERVISOR_BIT)) {
 		uint64_t mask = FFA_MEMORY_HANDLE_NON_SECURE_BIT;
@@ -298,37 +391,47 @@ void mobj_ffa_sel1_spmc_delete(struct mobj_ffa *mf)
 		cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 	}
 
-	m = to_mobj_ffa_shm(&mf->mobj);
-	assert(!m->mm);
-	free(m);
+	if (is_mobj_ffa_shm(&mf->mobj)) {
+		struct mobj_ffa_shm *m = to_mobj_ffa_shm(&mf->mobj);
+
+		assert(!m->mm);
+		free(m);
+	} else {
+		free(to_mobj_ffa_rsm(&mf->mobj));
+	}
 }
 #else /* !defined(CFG_CORE_SEL1_SPMC) */
-struct mobj_ffa *mobj_ffa_spmc_new(uint64_t cookie, unsigned int num_pages)
+struct mobj_ffa *mobj_ffa_spmc_new(uint64_t cookie, unsigned int num_pages,
+				   enum mobj_use_case use_case)
 {
-	struct mobj_ffa_shm *m = NULL;
+	struct mobj_ffa *mf = NULL;
 
 	assert(cookie != OPTEE_MSG_FMEM_INVALID_GLOBAL_ID);
-	m = ffa_shm_new(num_pages);
-	if (m)
-		m->mf.cookie = cookie;
-	return &m->mf;
+	if (use_case == MOBJ_USE_CASE_NS_SHM)
+		mf = ffa_shm_new(num_pages);
+	else
+		mf = ffa_rsm_new(num_pages, use_case);
+	if (mf)
+		mf->cookie = cookie;
+	return mf;
 }
 
 void mobj_ffa_spmc_delete(struct mobj_ffa *mf)
 {
-	free(to_mobj_ffa_shm(&mf->mobj));
+	if (is_mobj_ffa_shm(&mf->mobj))
+		free(to_mobj_ffa_shm(&mf->mobj));
+	else
+		free(to_mobj_ffa_rsm(&mf->mobj));
 }
 #endif /* !defined(CFG_CORE_SEL1_SPMC) */
 
 TEE_Result mobj_ffa_add_pages_at(struct mobj_ffa *mf, unsigned int *idx,
 				 paddr_t pa, unsigned int num_pages)
 {
-	struct mobj_ffa_shm *mfs = NULL;
 	size_t tot_page_count = 0;
 	unsigned int n = 0;
 
-	mfs = to_mobj_ffa_shm(&mf->mobj);
-	tot_page_count = get_page_count(mfs);
+	tot_page_count = get_page_count(mf);
 	if (ADD_OVERFLOW(*idx, num_pages, &n) || n > tot_page_count)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -336,10 +439,22 @@ TEE_Result mobj_ffa_add_pages_at(struct mobj_ffa *mf, unsigned int *idx,
 	    !core_pbuf_is(CORE_MEM_NON_SEC, pa, num_pages * SMALL_PAGE_SIZE))
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	for (n = 0; n < num_pages; n++)
-		mfs->pages[n + *idx] = pa + n * SMALL_PAGE_SIZE;
+	if (is_mobj_ffa_shm(&mf->mobj)) {
+		struct mobj_ffa_shm *mfs = to_mobj_ffa_shm(&mf->mobj);
+
+		for (n = 0; n < num_pages; n++)
+			mfs->pages[n + *idx] = pa + n * SMALL_PAGE_SIZE;
+	} else {
+		struct mobj_ffa_rsm *mfr = to_mobj_ffa_rsm(&mf->mobj);
+
+		if (!*idx)
+			mfr->pa = pa;
+		else if (mfr->pa != pa + *idx * SMALL_PAGE_SIZE)
+			return TEE_ERROR_BAD_PARAMETERS;
+	}
 
 	(*idx) += n;
+
 	return TEE_SUCCESS;
 }
 
@@ -348,25 +463,55 @@ uint64_t mobj_ffa_get_cookie(struct mobj_ffa *mf)
 	return mf->cookie;
 }
 
-uint64_t mobj_ffa_push_to_inactive(struct mobj_ffa *mf)
+static TEE_Result restrict_mem(struct mobj_ffa_rsm *m __maybe_unused)
 {
+	DMSG("use_case %d pa %#"PRIxPA", size %#zx",
+	     m->use_case, m->pa, m->mf.mobj.size);
+	return TEE_SUCCESS;
+}
+
+static TEE_Result __maybe_unused
+restore_mem(struct mobj_ffa_rsm *m __maybe_unused)
+{
+	DMSG("use_case %d pa %#" PRIxPA ", size %#zx",
+	     m->use_case, m->pa, m->mf.mobj.size);
+	return TEE_SUCCESS;
+}
+
+TEE_Result mobj_ffa_push_to_inactive(struct mobj_ffa *mf)
+{
+	TEE_Result res = TEE_SUCCESS;
 	uint32_t exceptions = 0;
 
 	exceptions = cpu_spin_lock_xsave(&shm_lock);
 	assert(!find_in_list(&shm_inactive_head, cmp_ptr, (vaddr_t)mf));
 	assert(!find_in_list(&shm_inactive_head, cmp_cookie, mf->cookie));
 	assert(!find_in_list(&shm_head, cmp_cookie, mf->cookie));
+
+	if (find_in_list(&shm_inactive_head, cmp_pa_overlap, (vaddr_t)mf) ||
+	    find_in_list(&shm_head, cmp_pa_overlap, (vaddr_t)mf)) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+	if (is_mobj_ffa_rsm(&mf->mobj)) {
+		res = restrict_mem(to_mobj_ffa_rsm(&mf->mobj));
+		if (res)
+			goto out;
+	}
+
 	SLIST_INSERT_HEAD(&shm_inactive_head, mf, link);
+
+out:
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 
-	return mf->cookie;
+	return res;
 }
 
 static void unmap_helper(struct mobj_ffa_shm *m)
 {
 	if (m->mm) {
 		core_mmu_unmap_pages(tee_mm_get_smem(m->mm),
-				     get_page_count(m));
+				     get_page_count(&m->mf));
 		tee_mm_free(m->mm);
 		m->mm = NULL;
 	}
@@ -410,7 +555,10 @@ TEE_Result mobj_ffa_sel1_spmc_reclaim(uint64_t cookie)
 
 	if (!pop_from_list(&shm_inactive_head, cmp_ptr, (vaddr_t)mf))
 		panic();
-	res = TEE_SUCCESS;
+	if (is_mobj_ffa_rsm(&mf->mobj))
+		res = restore_mem(to_mobj_ffa_rsm(&mf->mobj));
+	else
+		res = TEE_SUCCESS;
 out:
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
 	if (!res) {
@@ -499,8 +647,10 @@ struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 	exceptions = cpu_spin_lock_xsave(&shm_lock);
 	mf = find_in_list(&shm_head, cmp_cookie, cookie);
 	if (mf) {
-		mfs = to_mobj_ffa_shm(&mf->mobj);
-		offs = mfs->page_offset;
+		if (is_mobj_ffa_shm(&mf->mobj))
+			offs = to_mobj_ffa_shm(&mf->mobj)->page_offset;
+		else
+			offs = 0;
 		if (offs == internal_offs) {
 			if (!refcount_inc(&mf->mobj.refc)) {
 				/*
@@ -527,9 +677,11 @@ struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 		if (mf) {
 			DMSG("cookie %#"PRIx64" resurrecting", cookie);
 		} else {
+			enum mobj_use_case uc = MOBJ_USE_CASE_NS_SHM;
+
 			DMSG("Populating mobj from rx buffer, cookie %#"PRIx64,
 			     cookie);
-			mf = thread_spmc_populate_mobj_from_rx(cookie);
+			mf = thread_spmc_populate_mobj_from_rx(cookie, uc);
 		}
 #endif
 		if (mf) {
@@ -542,26 +694,33 @@ struct mobj *mobj_ffa_get_by_cookie(uint64_t cookie,
 			assert(refcount_val(&mf->mobj.refc) == 0);
 			refcount_set(&mf->mobj.refc, 1);
 			mf->inactive_refs++;
-			mfs = to_mobj_ffa_shm(&mf->mobj);
-			refcount_set(&mfs->mapcount, 0);
+			if (is_mobj_ffa_shm(&mf->mobj)) {
+				mfs = to_mobj_ffa_shm(&mf->mobj);
+				refcount_set(&mfs->mapcount, 0);
 
-			/*
-			 * mf->page_offset is offset into the first page.
-			 * This offset is assigned from the internal_offs
-			 * parameter to this function.
-			 *
-			 * While a mobj_ffa is active (ref_count > 0) this
-			 * will not change, but when being pushed to the
-			 * inactive list it can be changed again.
-			 *
-			 * So below we're backing out the old
-			 * mf->page_offset and then assigning a new from
-			 * internal_offset.
-			 */
-			mf->mobj.size += mfs->page_offset;
-			assert(!(mf->mobj.size & SMALL_PAGE_MASK));
-			mf->mobj.size -= internal_offs;
-			mfs->page_offset = internal_offs;
+				/*
+				 * mfs->page_offset is offset into the
+				 * first page.  This offset is assigned
+				 * from the internal_offs parameter to this
+				 * function.
+				 *
+				 * While a mobj_ffa is active (ref_count >
+				 * 0) this will not change, but when being
+				 * pushed to the inactive list it can be
+				 * changed again.
+				 *
+				 * So below we're backing out the old
+				 * mfs->page_offset and then assigning a
+				 * new from internal_offset.
+				 */
+				mf->mobj.size += mfs->page_offset;
+				assert(!(mf->mobj.size & SMALL_PAGE_MASK));
+				mf->mobj.size -= internal_offs;
+				mfs->page_offset = internal_offs;
+			} else if (is_mobj_ffa_rsm(&mf->mobj) &&
+				   internal_offs) {
+				mf = NULL;
+			}
 
 			SLIST_INSERT_HEAD(&shm_head, mf, link);
 		}
@@ -625,9 +784,8 @@ static void *ffa_shm_get_va(struct mobj *mobj, size_t offset, size_t len)
 	return (void *)(tee_mm_get_smem(m->mm) + offset + m->page_offset);
 }
 
-static void ffa_shm_inactivate(struct mobj *mobj)
+static void ffa_inactivate(struct mobj_ffa *mf)
 {
-	struct mobj_ffa_shm *m = to_mobj_ffa_shm(mobj);
 	uint32_t exceptions = 0;
 
 	exceptions = cpu_spin_lock_xsave(&shm_lock);
@@ -636,8 +794,8 @@ static void ffa_shm_inactivate(struct mobj *mobj)
 	 * shm_head after the mobj_put() that put us here and before we got
 	 * the lock.
 	 */
-	if (refcount_val(&mobj->refc)) {
-		DMSG("cookie %#"PRIx64" was resurrected", m->mf.cookie);
+	if (refcount_val(&mf->mobj.refc)) {
+		DMSG("cookie %#"PRIx64" was resurrected", mf->cookie);
 		goto out;
 	}
 
@@ -652,15 +810,21 @@ static void ffa_shm_inactivate(struct mobj *mobj)
 	 * that the mobj can't be freed until it reaches 0.
 	 * At this point the mobj is in the inactive list.
 	 */
-	if (pop_from_list(&shm_head, cmp_ptr, (vaddr_t)&m->mf)) {
-		unmap_helper(m);
-		SLIST_INSERT_HEAD(&shm_inactive_head, &m->mf, link);
+	if (pop_from_list(&shm_head, cmp_ptr, (vaddr_t)mf)) {
+		if (is_mobj_ffa_shm(&mf->mobj))
+			unmap_helper(to_mobj_ffa_shm(&mf->mobj));
+		SLIST_INSERT_HEAD(&shm_inactive_head, mf, link);
 	}
 out:
-	if (!m->mf.inactive_refs)
+	if (!mf->inactive_refs)
 		panic();
-	m->mf.inactive_refs--;
+	mf->inactive_refs--;
 	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
+}
+
+static void ffa_shm_inactivate(struct mobj *mobj)
+{
+	ffa_inactivate(&to_mobj_ffa_shm(mobj)->mf);
 }
 
 static TEE_Result ffa_shm_get_mem_type(struct mobj *mobj __unused, uint32_t *mt)
@@ -785,3 +949,162 @@ static const struct mobj_ops mobj_ffa_shm_ops = {
 };
 
 preinit(mapped_shm_init);
+
+#ifdef CFG_CORE_DYN_RSTMEM
+static TEE_Result ffa_rsm_get_pa(struct mobj *mobj, size_t offset,
+				 size_t granule, paddr_t *pa)
+{
+	struct mobj_ffa_rsm *m = to_mobj_ffa_rsm(mobj);
+	paddr_t p;
+
+	if (!pa || offset >= mobj->size)
+		return TEE_ERROR_GENERIC;
+
+	p = m->pa + offset;
+
+	if (granule) {
+		if (granule != SMALL_PAGE_SIZE &&
+		    granule != CORE_MMU_PGDIR_SIZE)
+			return TEE_ERROR_GENERIC;
+		p &= ~(granule - 1);
+	}
+
+	*pa = p;
+	return TEE_SUCCESS;
+}
+
+static TEE_Result ffa_rsm_get_mem_type(struct mobj *mobj __maybe_unused,
+				       uint32_t *mt)
+{
+	assert(is_mobj_ffa_rsm(mobj));
+
+	if (!mt)
+		return TEE_ERROR_GENERIC;
+
+	*mt = TEE_MATTR_MEM_TYPE_CACHED;
+
+	return TEE_SUCCESS;
+}
+
+static bool ffa_rsm_matches(struct mobj *mobj __maybe_unused,
+			    enum buf_is_attr attr)
+{
+	assert(is_mobj_ffa_rsm(mobj));
+
+	return attr == CORE_MEM_SEC || attr == CORE_MEM_SDP_MEM;
+}
+
+static void ffa_rsm_inactivate(struct mobj *mobj)
+{
+	ffa_inactivate(&to_mobj_ffa_rsm(mobj)->mf);
+}
+
+static uint64_t ffa_rsm_get_cookie(struct mobj *mobj)
+{
+	return to_mobj_ffa_rsm(mobj)->mf.cookie;
+}
+
+static TEE_Result ffa_rsm_no_map(struct mobj *mobj __maybe_unused)
+{
+	assert(is_mobj_ffa_rsm(mobj));
+
+	return TEE_ERROR_GENERIC;
+}
+
+static const struct mobj_ops mobj_ffa_rsm_ops = {
+	.get_pa = ffa_rsm_get_pa,
+	.get_mem_type = ffa_rsm_get_mem_type,
+	.matches = ffa_rsm_matches,
+	.free = ffa_rsm_inactivate,
+	.get_cookie = ffa_rsm_get_cookie,
+	.inc_map = ffa_rsm_no_map,
+	.dec_map = ffa_rsm_no_map,
+};
+
+static bool cmp_rstmem_pa(struct mobj_ffa *mf, uint64_t pa)
+{
+	struct mobj_ffa_rsm *m = NULL;
+
+	if (!is_mobj_ffa_rsm(&mf->mobj))
+		return false;
+
+	m = to_mobj_ffa_rsm(&mf->mobj);
+	return pa >= m->pa && pa < m->pa + m->mf.mobj.size;
+}
+
+struct mobj *mobj_ffa_rstmem_get_by_pa(paddr_t pa, paddr_size_t size)
+{
+	struct mobj_ffa_rsm *m = NULL;
+	struct mobj_ffa *mf = NULL;
+	struct mobj *mobj = NULL;
+	uint32_t exceptions = 0;
+
+	if (!size)
+		size = 1;
+
+	exceptions = cpu_spin_lock_xsave(&shm_lock);
+
+	mf = find_in_list(&shm_head, cmp_rstmem_pa, pa);
+	if (mf) {
+		m = to_mobj_ffa_rsm(&mf->mobj);
+		if (core_is_buffer_inside(pa, size, m->pa, m->mf.mobj.size))
+			mobj = mobj_get(&mf->mobj);
+	}
+
+	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
+	return mobj;
+}
+
+TEE_Result mobj_ffa_assign_rstmem(uint64_t cookie, enum mobj_use_case use_case)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct mobj_ffa_rsm *m = NULL;
+	struct mobj_ffa *mf = NULL;
+	uint32_t exceptions = 0;
+
+	exceptions = cpu_spin_lock_xsave(&shm_lock);
+	mf = find_in_list(&shm_inactive_head, cmp_cookie, cookie);
+	if (mf) {
+		if (!is_mobj_ffa_rsm(&mf->mobj)) {
+			res = TEE_ERROR_ITEM_NOT_FOUND;
+			goto out;
+		}
+		m = to_mobj_ffa_rsm(&mf->mobj);
+		if (m->assigned_use_case) {
+			res = TEE_ERROR_BUSY;
+			goto out;
+		}
+		if (m->use_case != use_case) {
+			res = TEE_ERROR_BAD_PARAMETERS;
+			goto out;
+		}
+		m->assigned_use_case = true;
+		goto out;
+	}
+	mf = find_in_list(&shm_head, cmp_cookie, cookie);
+	if (mf) {
+		if (!is_mobj_ffa_rsm(&mf->mobj))
+			res = TEE_ERROR_BUSY;
+		else
+			res = TEE_ERROR_ITEM_NOT_FOUND;
+		goto out;
+	}
+#if !defined(CFG_CORE_SEL1_SPMC)
+	/* Try to retrieve it from the SPM at S-EL2 */
+	DMSG("Populating mobj from rx buffer, cookie %#"PRIx64" use-case %d",
+	     cookie, use_case);
+	mf = thread_spmc_populate_mobj_from_rx(cookie, use_case);
+	if (mf) {
+		SLIST_INSERT_HEAD(&shm_inactive_head, mf, link);
+	} else {
+		EMSG("Failed to assign use-case %d to cookie %#"PRIx64"",
+		     use_case, cookie);
+		res = TEE_ERROR_ITEM_NOT_FOUND;
+		goto out;
+	}
+#endif
+out:
+	cpu_spin_unlock_xrestore(&shm_lock, exceptions);
+	return res;
+}
+#endif /*CFG_CORE_DYN_RSTMEM*/

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -26,7 +26,7 @@ static void tee_entry_get_shm_config(struct thread_smc_args *args)
 }
 #endif
 
-#ifdef CFG_SECURE_DATA_PATH
+#if defined(CFG_SECURE_DATA_PATH) && !defined(CFG_CORE_DYN_RSTMEM)
 static void tee_entry_get_sdp_config(struct thread_smc_args *args)
 {
 #if defined(CFG_TEE_SDP_MEM_BASE)
@@ -135,8 +135,12 @@ static void tee_entry_exchange_capabilities(struct thread_smc_args *args)
 	IMSG("Asynchronous notifications are %sabled",
 	     IS_ENABLED(CFG_CORE_ASYNC_NOTIF) ? "en" : "dis");
 
-	if (IS_ENABLED(CFG_SECURE_DATA_PATH))
-		args->a1 |= OPTEE_SMC_SEC_CAP_SDP;
+	if (IS_ENABLED(CFG_SECURE_DATA_PATH)) {
+		if (IS_ENABLED(CFG_CORE_DYN_RSTMEM))
+			args->a1 |= OPTEE_SMC_SEC_CAP_DYNAMIC_RSTMEM;
+		else
+			args->a1 |= OPTEE_SMC_SEC_CAP_SDP;
+	}
 
 	args->a1 |= OPTEE_SMC_SEC_CAP_RPC_ARG;
 	args->a3 = THREAD_RPC_MAX_NUM_PARAMS;
@@ -284,7 +288,7 @@ void __tee_entry_fast(struct thread_smc_args *args)
 		tee_entry_get_shm_config(args);
 		break;
 #endif
-#ifdef CFG_SECURE_DATA_PATH
+#if defined(CFG_SECURE_DATA_PATH) && !defined(CFG_CORE_DYN_RSTMEM)
 	case OPTEE_SMC_GET_SDP_CONFIG:
 		tee_entry_get_sdp_config(args);
 		break;

--- a/core/include/mm/mobj.h
+++ b/core/include/mm/mobj.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2016-2017, 2022 Linaro Limited
+ * Copyright (c) 2016-2024 Linaro Limited
  */
 
 #ifndef __MM_MOBJ_H
@@ -16,6 +16,12 @@
 #include <types_ext.h>
 
 #include <optee_msg.h>
+
+enum mobj_use_case {
+	MOBJ_USE_CASE_NS_SHM,
+	MOBJ_USE_CASE_SEC_VIDEO_PLAY,
+	MOBJ_USE_CASE_TRUSED_UI,
+};
 
 struct mobj {
 	const struct mobj_ops *ops;
@@ -237,18 +243,25 @@ TEE_Result mobj_ffa_unregister_by_cookie(uint64_t cookie);
 /* Functions for SPMC */
 #ifdef CFG_CORE_SEL1_SPMC
 struct mobj_ffa *mobj_ffa_sel1_spmc_new(uint64_t cookie,
-					unsigned int num_pages);
+					unsigned int num_pages,
+					enum mobj_use_case use_case);
 void mobj_ffa_sel1_spmc_delete(struct mobj_ffa *mobj);
 TEE_Result mobj_ffa_sel1_spmc_reclaim(uint64_t cookie);
 #else
-struct mobj_ffa *mobj_ffa_spmc_new(uint64_t cookie, unsigned int num_pages);
+struct mobj_ffa *mobj_ffa_spmc_new(uint64_t cookie, unsigned int num_pages,
+				   enum mobj_use_case use_case);
 void mobj_ffa_spmc_delete(struct mobj_ffa *mobj);
 #endif
 
 uint64_t mobj_ffa_get_cookie(struct mobj_ffa *mobj);
 TEE_Result mobj_ffa_add_pages_at(struct mobj_ffa *mobj, unsigned int *idx,
 				 paddr_t pa, unsigned int num_pages);
-uint64_t mobj_ffa_push_to_inactive(struct mobj_ffa *mobj);
+TEE_Result mobj_ffa_push_to_inactive(struct mobj_ffa *mobj);
+
+#ifdef CFG_CORE_DYN_RSTMEM
+TEE_Result mobj_ffa_assign_rstmem(uint64_t cookie, enum mobj_use_case use_case);
+struct mobj *mobj_ffa_rstmem_get_by_pa(paddr_t pa, paddr_size_t size);
+#endif
 
 #elif defined(CFG_CORE_DYN_SHM)
 /* reg_shm represents TEE shared memory */
@@ -286,6 +299,14 @@ void mobj_reg_shm_unguard(struct mobj *mobj);
  */
 struct mobj *mobj_mapped_shm_alloc(paddr_t *pages, size_t num_pages,
 				   paddr_t page_offset, uint64_t cookie);
+
+#if defined(CFG_CORE_DYN_RSTMEM)
+struct mobj *mobj_rstmem_alloc(paddr_t pa, paddr_size_t size, uint64_t cookie,
+			       enum mobj_use_case use_case);
+TEE_Result mobj_rstmem_release_by_cookie(uint64_t cookie);
+struct mobj *mobj_rstmem_get_by_pa(paddr_t pa, paddr_size_t size);
+#endif /*CFG_CORE_DYN_RSTMEM*/
+
 #endif /*CFG_CORE_DYN_SHM*/
 
 #if !defined(CFG_CORE_DYN_SHM)
@@ -298,6 +319,51 @@ static inline struct mobj *mobj_mapped_shm_alloc(paddr_t *pages __unused,
 }
 
 static inline struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie __unused)
+{
+	return NULL;
+}
+#endif
+
+#if !defined(CFG_CORE_DYN_RSTMEM) || defined(CFG_CORE_FFA)
+static inline struct mobj *
+mobj_rstmem_alloc(paddr_t pa __unused, paddr_size_t size __unused,
+		  uint64_t cookie __unused,
+		  enum mobj_use_case use_case __unused)
+{
+	return NULL;
+}
+
+static inline TEE_Result mobj_rstmem_release_by_cookie(uint64_t cookie __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static inline struct mobj *mobj_rstmem_get_by_pa(paddr_t pa __unused,
+						 paddr_size_t size __unused)
+{
+	return NULL;
+}
+#endif
+
+#if !defined(CFG_CORE_DYN_RSTMEM) || !defined(CFG_CORE_FFA)
+static inline struct mobj *mobj_ffa_rstmem_get_by_pa(paddr_t pa __unused,
+						     paddr_size_t size __unused)
+{
+	return NULL;
+}
+
+static inline TEE_Result
+mobj_ffa_assign_rstmem(uint64_t cookie __unused,
+		       enum mobj_use_case use_case __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+#endif
+
+#if !defined(CFG_CORE_FFA)
+static inline struct mobj *
+mobj_ffa_get_by_cookie(uint64_t cookie __unused,
+		       unsigned int internal_offs __unused)
 {
 	return NULL;
 }

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -10,8 +10,12 @@
 #include <util.h>
 
 /*
- * This file defines the OP-TEE message protocol used to communicate
+ * This file defines the OP-TEE message protocol (ABI) used to communicate
  * with an instance of OP-TEE running in secure world.
+ *
+ * This file is divided into two sections.
+ * 1. Formatting of messages.
+ * 2. Requests from normal world
  */
 
 /*****************************************************************************
@@ -165,9 +169,10 @@ struct optee_msg_param_value {
  * @rmem:	parameter by registered memory reference
  * @fmem:	parameter by FF-A registered memory reference
  * @value:	parameter by opaque value
+ * @octets:	parameter by octet string
  *
  * @attr & OPTEE_MSG_ATTR_TYPE_MASK indicates if tmem, rmem or value is used in
- * the union. OPTEE_MSG_ATTR_TYPE_VALUE_* indicates value,
+ * the union. OPTEE_MSG_ATTR_TYPE_VALUE_* indicates value or octets,
  * OPTEE_MSG_ATTR_TYPE_TMEM_* indicates @tmem and
  * OPTEE_MSG_ATTR_TYPE_RMEM_* or the alias PTEE_MSG_ATTR_TYPE_FMEM_* indicates
  * @rmem or @fmem depending on the conduit.
@@ -180,6 +185,7 @@ struct optee_msg_param {
 		struct optee_msg_param_rmem rmem;
 		struct optee_msg_param_fmem fmem;
 		struct optee_msg_param_value value;
+		uint8_t octets[24];
 	} u;
 };
 
@@ -318,7 +324,7 @@ struct optee_msg_arg {
  * [in] param[0].u.tmem.size		size (of first fragment)
  * [in] param[0].u.tmem.shm_ref		holds shared memory reference
  *
- * OPTEE_MSG_CMD_UNREGISTER_SHM unregisteres a previously registered shared
+ * OPTEE_MSG_CMD_UNREGISTER_SHM unregisters a previously registered shared
  * memory reference. The information is passed as:
  * [in] param[0].attr			OPTEE_MSG_ATTR_TYPE_RMEM_INPUT
  * [in] param[0].u.rmem.shm_ref		holds shared memory reference

--- a/core/include/optee_msg.h
+++ b/core/include/optee_msg.h
@@ -297,6 +297,18 @@ struct optee_msg_arg {
 #define OPTEE_MSG_FUNCID_GET_OS_REVISION	U(0x0001)
 
 /*
+ * Values used in OPTEE_MSG_CMD_LEND_RSTMEM below
+ * OPTEE_MSG_RSTMEM_RESERVED		Reserved
+ * OPTEE_MSG_RSTMEM_SECURE_VIDEO_PLAY	Secure Video Playback
+ * OPTEE_MSG_RSTMEM_TRUSTED_UI		Trused UI
+ * OPTEE_MSG_RSTMEM_SECURE_VIDEO_RECORD	Secure Video Recording
+ */
+#define OPTEE_MSG_RSTMEM_RESERVED		U(0)
+#define OPTEE_MSG_RSTMEM_SECURE_VIDEO_PLAY	U(1)
+#define OPTEE_MSG_RSTMEM_TRUSTED_UI		U(2)
+#define OPTEE_MSG_RSTMEM_SECURE_VIDEO_RECORD	U(3)
+
+/*
  * Do a secure call with struct optee_msg_arg as argument
  * The OPTEE_MSG_CMD_* below defines what goes in struct optee_msg_arg::cmd
  *
@@ -337,15 +349,62 @@ struct optee_msg_arg {
  * OPTEE_MSG_CMD_STOP_ASYNC_NOTIF informs secure world that from now is
  * normal world unable to process asynchronous notifications. Typically
  * used when the driver is shut down.
+ *
+ * OPTEE_MSG_CMD_LEND_RSTMEM lends restricted memory. The passed normal
+ * physical memory is restricted from normal world access. The memory
+ * should be unmapped prior to this call since it becomes inaccessible
+ * during the request.
+ * Parameters are passed as:
+ * [in] param[0].attr			OPTEE_MSG_ATTR_TYPE_VALUE_INPUT
+ * [in] param[0].u.value.a		OPTEE_MSG_RSTMEM_* defined above
+ * [in] param[1].attr			OPTEE_MSG_ATTR_TYPE_TMEM_INPUT
+ * [in] param[1].u.tmem.buf_ptr		physical address
+ * [in] param[1].u.tmem.size		size
+ * [in] param[1].u.tmem.shm_ref		holds restricted memory reference
+ *
+ * OPTEE_MSG_CMD_RECLAIM_RSTMEM reclaims a previously lent restricted
+ * memory reference. The physical memory is accessible by the normal world
+ * after this function has return and can be mapped again. The information
+ * is passed as:
+ * [in] param[0].attr			OPTEE_MSG_ATTR_TYPE_VALUE_INPUT
+ * [in] param[0].u.value.a		holds restricted memory cookie
+ *
+ * OPTEE_MSG_CMD_GET_RSTMEM_CONFIG get configuration for a specific
+ * restricted memory use case. Parameters are passed as:
+ * [in] param[0].attr			OPTEE_MSG_ATTR_TYPE_VALUE_INOUT
+ * [in] param[0].value.a		OPTEE_MSG_RSTMEM_*
+ * [in] param[1].attr			OPTEE_MSG_ATTR_TYPE_{R,F}MEM_OUTPUT
+ * [in] param[1].u.{r,f}mem		Buffer or NULL
+ * [in] param[1].u.{r,f}mem.size	Provided size of buffer or 0 for query
+ * output for the restricted use case:
+ * [out] param[0].value.a		Minimal size of SDP memory
+ * [out] param[0].value.b		Required alignment of size and start of
+ *					restricted memory
+ * [out] param[1].{r,f}mem.size		Size of output data
+ * [out] param[1].{r,f}mem		If non-NULL, contains an array of
+ *					uint16_t holding endpoints that
+ *					must be included when lending
+ *					memory for this use case
+ *
+ * OPTEE_MSG_CMD_ASSIGN_RSTMEM assigns use-case to restricted memory
+ * previously lent using the FFA_LEND framework ABI. Parameters are passed
+ * as:
+ * [in] param[0].attr			OPTEE_MSG_ATTR_TYPE_VALUE_INPUT
+ * [in] param[0].u.value.a		holds restricted memory cookie
+ * [in] param[0].u.value.b		OPTEE_MSG_RSTMEM_* defined above
  */
-#define OPTEE_MSG_CMD_OPEN_SESSION	U(0)
-#define OPTEE_MSG_CMD_INVOKE_COMMAND	U(1)
-#define OPTEE_MSG_CMD_CLOSE_SESSION	U(2)
-#define OPTEE_MSG_CMD_CANCEL		U(3)
-#define OPTEE_MSG_CMD_REGISTER_SHM	U(4)
-#define OPTEE_MSG_CMD_UNREGISTER_SHM	U(5)
-#define OPTEE_MSG_CMD_DO_BOTTOM_HALF	U(6)
-#define OPTEE_MSG_CMD_STOP_ASYNC_NOTIF	U(7)
-#define OPTEE_MSG_FUNCID_CALL_WITH_ARG	U(0x0004)
+#define OPTEE_MSG_CMD_OPEN_SESSION		U(0)
+#define OPTEE_MSG_CMD_INVOKE_COMMAND		U(1)
+#define OPTEE_MSG_CMD_CLOSE_SESSION		U(2)
+#define OPTEE_MSG_CMD_CANCEL			U(3)
+#define OPTEE_MSG_CMD_REGISTER_SHM		U(4)
+#define OPTEE_MSG_CMD_UNREGISTER_SHM		U(5)
+#define OPTEE_MSG_CMD_DO_BOTTOM_HALF		U(6)
+#define OPTEE_MSG_CMD_STOP_ASYNC_NOTIF		U(7)
+#define OPTEE_MSG_CMD_LEND_RSTMEM		U(8)
+#define OPTEE_MSG_CMD_RECLAIM_RSTMEM		U(9)
+#define OPTEE_MSG_CMD_GET_RSTMEM_CONFIG		U(10)
+#define OPTEE_MSG_CMD_ASSIGN_RSTMEM		U(11)
+#define OPTEE_MSG_FUNCID_CALL_WITH_ARG		U(0x0004)
 
 #endif /* __OPTEE_MSG_H */

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -590,6 +590,17 @@ static bool pbuf_is_sdp_mem(paddr_t pbuf, size_t len)
 		is_sdp_mem = pbuf_is_special_mem(pbuf, len, phys_sdp_mem_begin,
 						 phys_sdp_mem_end);
 
+	if (!is_sdp_mem) {
+		struct mobj *m = mobj_rstmem_get_by_pa(pbuf, len);
+
+		if (!m)
+			m = mobj_ffa_rstmem_get_by_pa(pbuf, len);
+		if (m) {
+			mobj_put(m);
+			is_sdp_mem = true;
+		}
+	}
+
 	return is_sdp_mem;
 }
 

--- a/core/mm/mobj_dyn_shm.c
+++ b/core/mm/mobj_dyn_shm.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2016-2017, Linaro Limited
+ * Copyright (c) 2016-2024, Linaro Limited
  */
 
 #include <assert.h>
@@ -11,6 +11,7 @@
 #include <kernel/panic.h>
 #include <kernel/refcount.h>
 #include <kernel/spinlock.h>
+#include <kernel/tee_misc.h>
 #include <mm/core_mmu.h>
 #include <mm/mobj.h>
 #include <mm/tee_pager.h>
@@ -41,6 +42,19 @@ struct mobj_reg_shm {
 	paddr_t pages[];
 };
 
+/*
+ * struct mobj_rstmem - describes restricted memory lent by normal world
+ */
+struct mobj_rstmem {
+	struct mobj mobj;
+	SLIST_ENTRY(mobj_rstmem) next;
+	uint64_t cookie;
+	paddr_t pa;
+	enum mobj_use_case use_case;
+	bool releasing;
+	bool release_frees;
+};
+
 static size_t mobj_reg_shm_size(size_t nr_pages)
 {
 	size_t s = 0;
@@ -57,6 +71,10 @@ static SLIST_HEAD(reg_shm_head, mobj_reg_shm) reg_shm_list =
 
 static unsigned int reg_shm_slist_lock = SPINLOCK_UNLOCK;
 static unsigned int reg_shm_map_lock = SPINLOCK_UNLOCK;
+
+/* Access is serialized with reg_shm_slist_lock */
+static SLIST_HEAD(rstmem_head, mobj_rstmem) rstmem_list =
+	SLIST_HEAD_INITIALIZER(rstmem_head);
 
 static struct mobj_reg_shm *to_mobj_reg_shm(struct mobj *mobj);
 
@@ -297,10 +315,38 @@ static struct mobj_reg_shm *to_mobj_reg_shm(struct mobj *mobj)
 	return container_of(mobj, struct mobj_reg_shm, mobj);
 }
 
+static TEE_Result check_reg_shm_conflict(struct mobj_reg_shm *r, paddr_t pa,
+					 paddr_size_t size)
+{
+	size_t n = 0;
+
+	for (n = 0; n < r->mobj.size / SMALL_PAGE_SIZE; n++)
+		if (core_is_buffer_intersect(pa, size, r->pages[n],
+					     SMALL_PAGE_SIZE))
+			return TEE_ERROR_BAD_PARAMETERS;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result check_rstmem_conflict(struct mobj_reg_shm *r)
+{
+	struct mobj_rstmem *m = NULL;
+	TEE_Result res = TEE_SUCCESS;
+
+	SLIST_FOREACH(m, &rstmem_list, next) {
+		res = check_reg_shm_conflict(r, m->pa, m->mobj.size);
+		if (res)
+			break;
+	}
+
+	return res;
+}
+
 struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 				paddr_t page_offset, uint64_t cookie)
 {
 	struct mobj_reg_shm *mobj_reg_shm = NULL;
+	TEE_Result res = TEE_SUCCESS;
 	size_t i = 0;
 	uint32_t exceptions = 0;
 	size_t s = 0;
@@ -336,8 +382,13 @@ struct mobj *mobj_reg_shm_alloc(paddr_t *pages, size_t num_pages,
 	}
 
 	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
-	SLIST_INSERT_HEAD(&reg_shm_list, mobj_reg_shm, next);
+	res = check_rstmem_conflict(mobj_reg_shm);
+	if (!res)
+		SLIST_INSERT_HEAD(&reg_shm_list, mobj_reg_shm, next);
 	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+	if (res)
+		goto err;
 
 	return &mobj_reg_shm->mobj;
 err:
@@ -364,16 +415,35 @@ static struct mobj_reg_shm *reg_shm_find_unlocked(uint64_t cookie)
 	return NULL;
 }
 
+static struct mobj_rstmem *rstmem_find_unlocked(uint64_t cookie)
+{
+	struct mobj_rstmem *m = NULL;
+
+	SLIST_FOREACH(m, &rstmem_list, next)
+		if (m->cookie == cookie)
+			return m;
+
+	return NULL;
+}
+
 struct mobj *mobj_reg_shm_get_by_cookie(uint64_t cookie)
 {
-	struct mobj_reg_shm *r = NULL;
+	struct mobj_reg_shm *rs = NULL;
+	struct mobj_rstmem *rm = NULL;
 	uint32_t exceptions = 0;
 	struct mobj *m = NULL;
 
 	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
-	r = reg_shm_find_unlocked(cookie);
-	if (r)
-		m = mobj_get(&r->mobj);
+	rs = reg_shm_find_unlocked(cookie);
+	if (rs) {
+		m = mobj_get(&rs->mobj);
+		goto out;
+	}
+	rm = rstmem_find_unlocked(cookie);
+	if (rm)
+		m = mobj_get(&rm->mobj);
+
+out:
 	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
 
 	return m;
@@ -473,3 +543,278 @@ static TEE_Result mobj_mapped_shm_init(void)
 }
 
 preinit(mobj_mapped_shm_init);
+
+#ifdef CFG_CORE_DYN_RSTMEM
+static struct mobj_rstmem *to_mobj_rstmem(struct mobj *mobj);
+
+static TEE_Result check_reg_shm_list_conflict(paddr_t pa, paddr_size_t size)
+{
+	struct mobj_reg_shm *r = NULL;
+	TEE_Result res = TEE_SUCCESS;
+
+	SLIST_FOREACH(r, &reg_shm_list, next) {
+		res = check_reg_shm_conflict(r, pa, size);
+		if (res)
+			break;
+	}
+
+	return res;
+}
+
+static TEE_Result restrict_mem(struct mobj_rstmem *m)
+{
+	/* TODO restrict non-secure access to memory range */
+	if ((m->pa | m->mobj.size) & SMALL_PAGE_MASK)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	DMSG("use_case %d pa %#"PRIxPA", size %#zx",
+	     m->use_case, m->pa, m->mobj.size);
+	return TEE_SUCCESS;
+}
+
+static TEE_Result restore_mem(struct mobj_rstmem *m)
+{
+	/* TODO restore non-secure access to memory range */
+	DMSG("use_case %d pa %#"PRIxPA", size %#zx",
+	     m->use_case, m->pa, m->mobj.size);
+	return TEE_SUCCESS;
+}
+
+static TEE_Result mobj_rstmem_get_pa(struct mobj *mobj, size_t offs,
+				     size_t granule, paddr_t *pa)
+{
+	struct mobj_rstmem *m = to_mobj_rstmem(mobj);
+	paddr_t p = 0;
+
+	if (!pa)
+		return TEE_ERROR_GENERIC;
+
+	if (offs >= mobj->size)
+		return TEE_ERROR_GENERIC;
+
+	p = m->pa + offs;
+	if (granule) {
+		if (granule != SMALL_PAGE_SIZE)
+			return TEE_ERROR_GENERIC;
+		p &= ~(granule - 1);
+	}
+	*pa = p;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result mobj_rstmem_get_mem_type(struct mobj *mobj __unused,
+					   uint32_t *mt)
+{
+	if (!mt)
+		return TEE_ERROR_GENERIC;
+
+	*mt = TEE_MATTR_MEM_TYPE_CACHED;
+
+	return TEE_SUCCESS;
+}
+
+static bool mobj_rstmem_matches(struct mobj *mobj __unused,
+				enum buf_is_attr attr)
+{
+	return attr == CORE_MEM_SEC || attr == CORE_MEM_SDP_MEM;
+}
+
+static void rstmem_free_helper(struct mobj_rstmem *mobj_rstmem)
+{
+	uint32_t exceptions = 0;
+
+	exceptions = cpu_spin_lock_xsave(&reg_shm_map_lock);
+	SLIST_REMOVE(&rstmem_list, mobj_rstmem, mobj_rstmem, next);
+	cpu_spin_unlock_xrestore(&reg_shm_map_lock, exceptions);
+
+	restore_mem(mobj_rstmem);
+	free(mobj_rstmem);
+}
+
+static void mobj_rstmem_free(struct mobj *mobj)
+{
+	struct mobj_rstmem *r = to_mobj_rstmem(mobj);
+	uint32_t exceptions = 0;
+
+	if (!r->releasing) {
+		exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+		rstmem_free_helper(r);
+		cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+	} else {
+		exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+		r->release_frees = true;
+		cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+		mutex_lock(&shm_mu);
+		if (shm_release_waiters)
+			condvar_broadcast(&shm_cv);
+		mutex_unlock(&shm_mu);
+	}
+}
+
+static uint64_t mobj_rstmem_get_cookie(struct mobj *mobj)
+{
+	return to_mobj_rstmem(mobj)->cookie;
+}
+
+static TEE_Result mobj_rstmem_inc_map(struct mobj *mobj __maybe_unused)
+{
+	assert(to_mobj_rstmem(mobj));
+	return TEE_ERROR_BAD_PARAMETERS;
+}
+
+static TEE_Result mobj_rstmem_dec_map(struct mobj *mobj __maybe_unused)
+{
+	assert(to_mobj_rstmem(mobj));
+	return TEE_ERROR_BAD_PARAMETERS;
+}
+
+const struct mobj_ops mobj_rstmem_ops __relrodata_unpaged("mobj_rstmem_ops") = {
+	.get_pa = mobj_rstmem_get_pa,
+	.get_mem_type = mobj_rstmem_get_mem_type,
+	.matches = mobj_rstmem_matches,
+	.free = mobj_rstmem_free,
+	.get_cookie = mobj_rstmem_get_cookie,
+	.inc_map = mobj_rstmem_inc_map,
+	.dec_map = mobj_rstmem_dec_map,
+};
+
+static struct mobj_rstmem *to_mobj_rstmem(struct mobj *mobj)
+{
+	assert(mobj->ops == &mobj_rstmem_ops);
+	return container_of(mobj, struct mobj_rstmem, mobj);
+}
+
+struct mobj *mobj_rstmem_alloc(paddr_t pa, paddr_size_t size, uint64_t cookie,
+			       enum mobj_use_case use_case)
+{
+	TEE_Result res = TEE_SUCCESS;
+	struct mobj_rstmem *m = NULL;
+	uint32_t exceptions = 0;
+
+	if (!core_pbuf_is(CORE_MEM_NON_SEC, pa, size))
+		return NULL;
+
+	m = calloc(1, sizeof(*m));
+	if (!m)
+		return NULL;
+
+	m->mobj.ops = &mobj_rstmem_ops;
+	m->use_case = use_case;
+	m->mobj.size = size;
+	m->mobj.phys_granule = SMALL_PAGE_SIZE;
+	refcount_set(&m->mobj.refc, 1);
+	m->cookie = cookie;
+	m->pa = pa;
+
+	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+	res = check_reg_shm_list_conflict(pa, size);
+	if (res)
+		goto out;
+
+	res = restrict_mem(m);
+	if (res)
+		goto out;
+	SLIST_INSERT_HEAD(&rstmem_list, m, next);
+out:
+	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+	if (res) {
+		free(m);
+		return NULL;
+	}
+
+	return &m->mobj;
+}
+
+TEE_Result mobj_rstmem_release_by_cookie(uint64_t cookie)
+{
+	uint32_t exceptions = 0;
+	struct mobj_rstmem *rm = NULL;
+
+	/*
+	 * Try to find m and see can be released by this function, if so
+	 * call mobj_put(). Otherwise this function is called either by
+	 * wrong cookie and perhaps a second time, regardless return
+	 * TEE_ERROR_BAD_PARAMETERS.
+	 */
+	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+	rm = rstmem_find_unlocked(cookie);
+	if (!rm || rm->releasing)
+		rm = NULL;
+	else
+		rm->releasing = true;
+
+	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+	if (!rm)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mobj_put(&rm->mobj);
+
+	/*
+	 * We've established that this function can release the cookie.
+	 * Now we wait until mobj_reg_shm_free() is called by the last
+	 * mobj_put() needed to free this mobj. Note that the call to
+	 * mobj_put() above could very well be that call.
+	 *
+	 * Once mobj_reg_shm_free() is called it will set r->release_frees
+	 * to true and we can free the mobj here.
+	 */
+	mutex_lock(&shm_mu);
+	shm_release_waiters++;
+	assert(shm_release_waiters);
+
+	while (true) {
+		exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+		if (rm->release_frees) {
+			rstmem_free_helper(rm);
+			rm = NULL;
+		}
+		cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+		if (!rm)
+			break;
+		condvar_wait(&shm_cv, &shm_mu);
+	}
+
+	assert(shm_release_waiters);
+	shm_release_waiters--;
+	mutex_unlock(&shm_mu);
+
+	return TEE_SUCCESS;
+}
+
+static struct mobj_rstmem *rstmem_find_by_pa_unlocked(paddr_t pa,
+						      paddr_size_t sz)
+{
+	struct mobj_rstmem *m = NULL;
+
+	if (!sz)
+		sz = 1;
+
+	SLIST_FOREACH(m, &rstmem_list, next)
+		if (core_is_buffer_inside(pa, sz, m->pa, m->mobj.size))
+			return m;
+
+	return NULL;
+}
+
+struct mobj *mobj_rstmem_get_by_pa(paddr_t pa, paddr_size_t size)
+{
+	struct mobj_rstmem *rm = NULL;
+	struct mobj *mobj = NULL;
+	uint32_t exceptions = 0;
+
+	exceptions = cpu_spin_lock_xsave(&reg_shm_slist_lock);
+
+	rm = rstmem_find_by_pa_unlocked(pa, size);
+	if (rm && !rm->releasing)
+		mobj = mobj_get(&rm->mobj);
+
+	cpu_spin_unlock_xrestore(&reg_shm_slist_lock, exceptions);
+
+	return mobj;
+}
+#endif /*CFG_CORE_DYN_RSTMEM*/

--- a/core/tee/entry_std.c
+++ b/core/tee/entry_std.c
@@ -13,6 +13,7 @@
 #include <kernel/notif.h>
 #include <kernel/panic.h>
 #include <kernel/tee_misc.h>
+#include <kernel/thread_spmc.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <mm/mobj.h>
@@ -97,9 +98,10 @@ static TEE_Result set_fmem_param(const struct optee_msg_param_fmem *fmem,
 static TEE_Result set_tmem_param(const struct optee_msg_param_tmem *tmem,
 				 uint32_t attr, struct param_mem *mem)
 {
-	struct mobj __maybe_unused **mobj;
+	struct mobj __maybe_unused **mobj = NULL;
 	paddr_t pa = READ_ONCE(tmem->buf_ptr);
 	size_t sz = READ_ONCE(tmem->size);
+	struct mobj *rmobj = NULL;
 
 	/*
 	 * Handle NULL memory reference
@@ -136,6 +138,14 @@ static TEE_Result set_tmem_param(const struct optee_msg_param_tmem *tmem,
 		if (param_mem_from_mobj(mem, *mobj, pa, sz))
 			return TEE_SUCCESS;
 #endif
+	rmobj = mobj_rstmem_get_by_pa(pa, sz);
+	if (rmobj) {
+		bool rc = param_mem_from_mobj(mem, rmobj, pa, sz);
+
+		mobj_put(rmobj);
+		if (rc)
+			return TEE_SUCCESS;
+	}
 
 	return TEE_ERROR_BAD_PARAMETERS;
 }
@@ -515,6 +525,153 @@ static void unregister_shm(struct optee_msg_arg *arg, uint32_t num_params)
 #endif /*CFG_CORE_DYN_SHM*/
 #endif
 
+static void __maybe_unused lend_rstmem(struct optee_msg_arg *arg,
+				       uint32_t num_params)
+{
+	TEE_Result res = TEE_ERROR_BAD_PARAMETERS;
+	struct optee_msg_param_tmem *tmem = NULL;
+	struct mobj *mobj = NULL;
+	uint64_t use_case = 0;
+	uint64_t cookie = 0;
+	paddr_size_t sz = 0;
+	paddr_t pa = 0;
+
+	if (num_params != 2 ||
+	    READ_ONCE(arg->params[0].attr) != OPTEE_MSG_ATTR_TYPE_VALUE_INPUT ||
+	    READ_ONCE(arg->params[1].attr) != OPTEE_MSG_ATTR_TYPE_TMEM_INPUT)
+		goto out;
+
+	use_case = READ_ONCE(arg->params[0].u.value.a);
+	tmem = &arg->params[1].u.tmem;
+	cookie = READ_ONCE(tmem->shm_ref);
+	pa = READ_ONCE(tmem->buf_ptr);
+	sz = READ_ONCE(tmem->size);
+
+	switch (use_case) {
+	case MOBJ_USE_CASE_SEC_VIDEO_PLAY:
+	case MOBJ_USE_CASE_TRUSED_UI:
+		break;
+	default:
+		goto out;
+	}
+	mobj = mobj_rstmem_alloc(pa, sz, cookie, use_case);
+	if (mobj)
+		res = TEE_SUCCESS;
+out:
+	arg->ret = res;
+}
+
+static void __maybe_unused assign_rstmem(struct optee_msg_arg *arg,
+					 uint32_t num_params)
+{
+	TEE_Result res = TEE_ERROR_BAD_PARAMETERS;
+	uint64_t use_case = 0;
+	uint64_t cookie = 0;
+
+	if (num_params != 1 ||
+	    READ_ONCE(arg->params[0].attr) != OPTEE_MSG_ATTR_TYPE_VALUE_INPUT)
+		goto out;
+
+	cookie = READ_ONCE(arg->params[0].u.value.a);
+	use_case = READ_ONCE(arg->params[0].u.value.b);
+	res = mobj_ffa_assign_rstmem(cookie, use_case);
+out:
+	arg->ret = res;
+}
+
+static void __maybe_unused reclaim_rstmem(struct optee_msg_arg *arg,
+					  uint32_t num_params)
+{
+	if (num_params == 1 &&
+	    READ_ONCE(arg->params[0].attr) == OPTEE_MSG_ATTR_TYPE_RMEM_INPUT) {
+		uint64_t cookie = READ_ONCE(arg->params[0].u.rmem.shm_ref);
+		TEE_Result res = mobj_rstmem_release_by_cookie(cookie);
+
+		if (res)
+			EMSG("Can't find mapping with cookie %#"PRIx64,
+			     cookie);
+		arg->ret = res;
+	} else {
+		arg->ret = TEE_ERROR_BAD_PARAMETERS;
+		arg->ret_origin = TEE_ORIGIN_TEE;
+	}
+}
+
+static void __maybe_unused get_rstmem_config(struct optee_msg_arg *arg,
+					     uint32_t num_params)
+{
+	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INOUT,
+					  TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					  TEE_PARAM_TYPE_NONE,
+					  TEE_PARAM_TYPE_NONE);
+	uint64_t saved_attr[TEE_NUM_PARAMS] = { 0 };
+	TEE_Result res = TEE_ERROR_BAD_PARAMETERS;
+	struct tee_ta_param param = { 0 };
+	size_t min_mem_align = 0;
+	size_t min_mem_sz = 0;
+	uint64_t use_case = 0;
+	void *buf = NULL;
+	size_t sz = 0;
+
+	arg->ret_origin = TEE_ORIGIN_TEE;
+
+	if (num_params != 2)
+		goto out;
+	res = copy_in_params(arg->params, num_params, &param, saved_attr);
+	if (res)
+		goto out;
+	if (param.types != exp_pt) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+		goto out_cleanup;
+	}
+
+	use_case = param.u[0].val.a;
+	sz = param.u[1].mem.size;
+	if (param.u[1].mem.mobj) {
+		res = mobj_inc_map(param.u[1].mem.mobj);
+		if (res)
+			goto out_cleanup;
+		buf = mobj_get_va(param.u[1].mem.mobj, param.u[1].mem.offs, sz);
+		if (!buf) {
+			res = TEE_ERROR_BAD_PARAMETERS;
+			goto out_dec_map;
+		}
+	}
+
+	if (IS_ENABLED(CFG_CORE_FFA)) {
+		res = thread_spmc_get_rstmem_config(use_case, buf, &sz,
+						    &min_mem_sz,
+						    &min_mem_align);
+	} else {
+		if (IS_ENABLED(CFG_CORE_DYN_RSTMEM) &&
+		    use_case == OPTEE_MSG_RSTMEM_SECURE_VIDEO_PLAY) {
+			/*
+			 * Only shared with OP-TEE and TAs, a dummy
+			 * configuration for now.  This might later be
+			 * configured.
+			 */
+			min_mem_sz = SIZE_1M;
+			min_mem_align = SMALL_PAGE_SIZE;
+			res = TEE_SUCCESS;
+		} else {
+			res = TEE_ERROR_BAD_PARAMETERS;
+		}
+	}
+	if (!res || res == TEE_ERROR_SHORT_BUFFER) {
+		param.u[1].mem.size = sz;
+		param.u[0].val.a = min_mem_sz;
+		param.u[0].val.b = min_mem_align;
+	}
+	copy_out_param(&param, num_params, arg->params, saved_attr);
+
+out_dec_map:
+	mobj_dec_map(param.u[1].mem.mobj);
+out_cleanup:
+	cleanup_shm_refs(saved_attr, &param, num_params);
+out:
+	arg->ret = res;
+}
+
 void nsec_sessions_list_head(struct tee_ta_session_head **open_sessions)
 {
 	*open_sessions = &tee_open_sessions;
@@ -549,8 +706,7 @@ TEE_Result __tee_entry_std(struct optee_msg_arg *arg, uint32_t num_params)
 	case OPTEE_MSG_CMD_CANCEL:
 		entry_cancel(arg, num_params);
 		break;
-#ifndef CFG_CORE_FFA
-#ifdef CFG_CORE_DYN_SHM
+#if defined(CFG_CORE_DYN_SHM) && !defined(CFG_CORE_FFA)
 	case OPTEE_MSG_CMD_REGISTER_SHM:
 		register_shm(arg, num_params);
 		break;
@@ -558,8 +714,6 @@ TEE_Result __tee_entry_std(struct optee_msg_arg *arg, uint32_t num_params)
 		unregister_shm(arg, num_params);
 		break;
 #endif
-#endif
-
 	case OPTEE_MSG_CMD_DO_BOTTOM_HALF:
 		if (IS_ENABLED(CFG_CORE_ASYNC_NOTIF))
 			notif_deliver_event(NOTIF_EVENT_DO_BOTTOM_HALF);
@@ -572,7 +726,23 @@ TEE_Result __tee_entry_std(struct optee_msg_arg *arg, uint32_t num_params)
 		else
 			goto err;
 		break;
-
+#ifdef CFG_CORE_DYN_RSTMEM
+	case OPTEE_MSG_CMD_GET_RSTMEM_CONFIG:
+		get_rstmem_config(arg, num_params);
+		break;
+#ifdef CFG_CORE_FFA
+	case OPTEE_MSG_CMD_ASSIGN_RSTMEM:
+		assign_rstmem(arg, num_params);
+		break;
+#else
+	case OPTEE_MSG_CMD_LEND_RSTMEM:
+		lend_rstmem(arg, num_params);
+		break;
+	case OPTEE_MSG_CMD_RECLAIM_RSTMEM:
+		reclaim_rstmem(arg, num_params);
+		break;
+#endif /*!CFG_CORE_FFA*/
+#endif /*CFG_CORE_DYN_RSTMEM*/
 	default:
 err:
 		EMSG("Unknown cmd 0x%x", arg->cmd);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1263,3 +1263,8 @@ CFG_CORE_UNSAFE_MODEXP ?= n
 # when enabled, makes MBedTLS library for TAs use 'unsafe' modular
 # exponentiation algorithm.
 CFG_TA_MEBDTLS_UNSAFE_MODEXP ?= n
+
+# CFG_CORE_DYN_RSTMEM, enables dynamic restricted memory lending from
+# normal world.
+CFG_CORE_DYN_RSTMEM ?= n
+$(eval $(call cfg-depends-all,CFG_CORE_DYN_RSTMEM,CFG_CORE_DYN_SHM,CFG_SECURE_DATA_PATH))


### PR DESCRIPTION
This is the OP-TEE OS counterpart of https://lore.kernel.org/lkml/20241128150927.1377981-1-jens.wiklander@linaro.org/

I've added dynamic registration of SDP buffers. The buffers can be registered for different use-cases so they will require different access permissions for the hardware.

The implementation in OP-TEE is RFC, but we should be able to finalize the ABI towards the normal world. With the direction this PR has taken it would be nice to get rid of matching SDP buffers against physical addresses and instead only rely on the struct mobj to report the status of the memory range.