### PR TITLE
ci: check EL3 SPMC in QEMUv8_check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,7 @@ jobs:
           make -j$(nproc) check CFG_PAN=y
           make -j$(nproc) check CFG_WITH_PAGER=y
           make -j$(nproc) check CFG_ULIBS_SHARED=y
+          make -j$(nproc) arm-tf-clean SPMC_AT_EL=3 && make -j$(nproc) check SPMC_AT_EL=3
 
   QEMUv8_clang_check:
     name: make check (QEMUv8, Clang)


### PR DESCRIPTION
Add a test for EL3 SPMC with SPMC_AT_EL=3 in the QEMUv8_check target. Note that the TF-A build must be removed before building with SPMC_AT_EL=3 since TF-A doesn't rebuild due to changed configuration flags.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
