### PR TITLE
Ed25519 sign correctly returns TEE_ERROR_SHORT_BUFFER

### DIFF
--- a/core/lib/libtomcrypt/ed25519.c
+++ b/core/lib/libtomcrypt/ed25519.c
@@ -89,6 +89,11 @@ TEE_Result crypto_acipher_ed25519_sign(struct ed25519_keypair *key,
 	if (!key || !sig_len)
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	if (*sig_len < UL(64)) {
+		*sig_len = UL(64);
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
 	siglen = *sig_len;
 
 	memcpy(private_key.priv, key->priv, sizeof(private_key.priv));
@@ -119,6 +124,11 @@ TEE_Result crypto_acipher_ed25519ctx_sign(struct ed25519_keypair *key,
 
 	if (!key || !sig_len)
 		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (*sig_len < UL(64)) {
+		*sig_len = UL(64);
+		return TEE_ERROR_SHORT_BUFFER;
+	}
 
 	siglen = *sig_len;
 


### PR DESCRIPTION
I was getting following errors when using pkcs11 library which determines the signature buffer length by first supplying nullpointer to signature buffer and 0 as size of that buffer in C_Sign and then calling C_Sign again without calling C_SignInit:

```
D/TA:  TA_InvokeCommandEntryPoint:143 PKCS11_CMD_SIGN_INIT p#0 24@0x200000, p#1 --- 0@0x0, p#2 --- 0@0x0
D/TA:  entry_processing_init:674 PKCS11 session 1: init processing EDDSA SIGN
D/TA:  TA_InvokeCommandEntryPoint:364 PKCS11_CMD_SIGN_INIT rc 0/OK
D/TA:  TA_InvokeCommandEntryPoint:143 PKCS11_CMD_SIGN_ONESHOT p#0 4@0x202000, p#1 in 327@0x201d60, p#2 out 0@0x200000
D/TA:  TA_InvokeCommandEntryPoint:364 PKCS11_CMD_SIGN_ONESHOT **rc 0/OK**
D/TA:  TA_InvokeCommandEntryPoint:143 PKCS11_CMD_SIGN_ONESHOT p#0 4@0x202000, p#1 in 327@0x201d60, p#2 out 64@0x200f68
D/TA:  TA_InvokeCommandEntryPoint:364 PKCS11_CMD_SIGN_ONESHOT rc 0x91/OPERATION_NOT_INITIALIZED
```

After investigation I found out that in ed25519.c there was no handling of CRYPT_BUFFER_OVERFLOW.

So I translated tomcrypt CRYPT_BUFFER_OVERFLOW to TEE_ERROR_SHORT_BUFFER so applications using the API can determine the required signature buffer size when supplying 0 sized signature buffer.

After I'm getting what I would call expected behaviour:

```
D/TA:  TA_InvokeCommandEntryPoint:143 PKCS11_CMD_SIGN_INIT p#0 24@0x200000, p#1 --- 0@0x0, p#2 --- 0@0x0
D/TA:  entry_processing_init:674 PKCS11 session 1: init processing EDDSA SIGN
D/TA:  TA_InvokeCommandEntryPoint:364 PKCS11_CMD_SIGN_INIT rc 0/OK
D/TA:  TA_InvokeCommandEntryPoint:143 PKCS11_CMD_SIGN_ONESHOT p#0 4@0x202000, p#1 in 327@0x201d60, p#2 out 0@0x200000
D/TA:  TA_InvokeCommandEntryPoint:364 PKCS11_CMD_SIGN_ONESHOT **rc 0x150/BUFFER_TOO_SMALL**
D/TA:  TA_InvokeCommandEntryPoint:143 PKCS11_CMD_SIGN_ONESHOT p#0 4@0x202000, p#1 in 327@0x201d60, p#2 out 64@0x200f68
D/TA:  TA_InvokeCommandEntryPoint:364 PKCS11_CMD_SIGN_ONESHOT rc 0/OK
```

Note: I added **rc ** to the logs to highlight the difference

If I missed something just let me know.