### PR TITLE
core: riscv: Improve macros for set/clear bits CSR operations

### DIFF
--- a/core/arch/riscv/include/riscv.h
+++ b/core/arch/riscv/include/riscv.h
@@ -93,20 +93,30 @@
 		__tmp;							\
 	})
 
-#define set_csr(csr, bit)						\
+#define read_set_csr(csr, val)						\
 	({								\
 		unsigned long __tmp;					\
 		asm volatile ("csrrs %0, %1, %2"			\
-			      : "=r"(__tmp) : "i"(csr), "rK"(bit));	\
+			      : "=r"(__tmp) : "i"(csr), "rK"(val));	\
 		__tmp;							\
 	})
 
-#define clear_csr(csr, bit)						\
+#define set_csr(csr, val)						\
+	({								\
+		asm volatile ("csrs %0, %1" : : "i"(csr), "rK"(val));	\
+	})
+
+#define read_clear_csr(csr, val)					\
 	({								\
 		unsigned long __tmp;					\
 		asm volatile ("csrrc %0, %1, %2"			\
-			      : "=r"(__tmp) : "i"(csr), "rK"(bit));	\
+			      : "=r"(__tmp) : "i"(csr), "rK"(val));	\
 		__tmp;							\
+	})
+
+#define clear_csr(csr, val)						\
+	({								\
+		asm volatile ("csrc %0, %1" : : "i"(csr), "rK"(val));	\
 	})
 
 #define rdtime() read_csr(CSR_TIME)


### PR DESCRIPTION
Rename `set_csr` to `read_set_csr` and `clear_csr` to `read_clear_csr` because they perform atomic reads and set/clear bits in the CSR. These two macros will return the previous value of the CSR.

Introduce new macros `set_csr` and `clear_csr`: `set_csr` uses the RISC-V `csrs` assembler pseudoinstruction to set bits in the CSR when the old value is not needed, while `clear_csr` uses the `csrc` pseudoinstruction to clear bits in the CSR, also discarding the old value.