### PR TITLE
dts: stm32: disable stm32mp15 SD switch regulator node

### DIFF
--- a/core/arch/arm/dts/stm32mp157c-ed1.dts
+++ b/core/arch/arm/dts/stm32mp157c-ed1.dts
@@ -94,6 +94,7 @@
 		gpios-states = <0>;
 		states = <1800000 0x1>,
 			 <2900000 0x0>;
+		status = "disabled";
 	};
 
 	vin: vin {

--- a/core/arch/arm/dts/stm32mp15xx-dhcor-avenger96.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dhcor-avenger96.dtsi
@@ -84,6 +84,7 @@
 		gpios-states = <0>;
 		states = <1800000 0x1>,
 			 <2900000 0x0>;
+		status = "disabled";
 	};
 
 	sound {


### PR DESCRIPTION
SD switch regulator is not used by OP-TEE on STM32MP15 based boards hence disable this node in the OP-TEE secure device tree for boards DHCOR Avenger96 (stm32mp15xx-dhcor-avenger96.dtsi) ST ED1/EV1 (stm32mp157c-ed1.dts).

This change fixes a issue related to the integration of stm32_gpio driver as a firewall controller, which is highlighted by ab error trace message like:

E/TC:0 0 stm32_gpio_get_dt:837 node regulator-sd_switch requests secure GPIO F14 that cannot be secured E/TC:0 0 Panic

Fixes: 4675225ed84f ("drivers: stm32_gpio: check secure state of consumed GPIOs")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
