### PR TITLE
drivers: stm32_i2c: use compatible st,stm32mp15-i2c-non-secure

### DIFF
--- a/core/arch/arm/dts/stm32mp15xx-dhcom-som.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dhcom-som.dtsi
@@ -257,6 +257,7 @@
 };
 
 &i2c4 {
+	compatible = "st,stm32mp15-i2c-non-secure";
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c4_pins_a>;
 	i2c-scl-rising-time-ns = <185>;

--- a/core/arch/arm/dts/stm32mp15xx-dhcor-som.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dhcor-som.dtsi
@@ -89,6 +89,7 @@
 };
 
 &i2c4 {
+	compatible = "st,stm32mp15-i2c-non-secure";
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c4_pins_a>;
 	i2c-scl-rising-time-ns = <185>;

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_pmic.c
@@ -77,8 +77,7 @@ static void init_pmic_state(const void *fdt, int pmic_node)
 
 static bool dt_pmic_is_secure(void)
 {
-	return stm32mp_with_pmic() &&
-	       i2c_handle->dt_status == DT_STATUS_OK_SEC;
+	return stm32mp_with_pmic() && i2c_is_secure(i2c_handle);
 }
 
 static void priv_dt_properties(const void *fdt, int regu_node,

--- a/core/drivers/stm32_i2c.c
+++ b/core/drivers/stm32_i2c.c
@@ -297,6 +297,9 @@ struct i2c_request {
 	unsigned int timeout_ms;
 };
 
+/* Place holder for STM32MP15 non-secure I2C bus compat data */
+static const int non_secure_bus;
+
 static vaddr_t get_base(struct i2c_handle_s *hi2c)
 {
 	return io_pa_or_va_secure(&hi2c->base, hi2c->reg_size);
@@ -695,7 +698,6 @@ TEE_Result stm32_i2c_get_setup_from_fdt(void *fdt, int node,
 	assert(info.reg != DT_INFO_INVALID_REG &&
 	       info.reg_size != DT_INFO_INVALID_REG_SIZE);
 
-	init->dt_status = info.status;
 	init->pbase = info.reg;
 	init->reg_size = info.reg_size;
 
@@ -1629,7 +1631,7 @@ static TEE_Result stm32_get_i2c_dev(struct dt_pargs *args, void *data,
 }
 
 static TEE_Result stm32_i2c_probe(const void *fdt, int node,
-				  const void *compat_data __unused)
+				  const void *compat_data)
 {
 	TEE_Result res = TEE_SUCCESS;
 	int subnode = 0;
@@ -1647,7 +1649,6 @@ static TEE_Result stm32_i2c_probe(const void *fdt, int node,
 	if (!i2c_handle_p)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	i2c_handle_p->dt_status = init_data.dt_status;
 	i2c_handle_p->reg_size = init_data.reg_size;
 	i2c_handle_p->clock = init_data.clock;
 	i2c_handle_p->base.pa = init_data.pbase;
@@ -1658,6 +1659,9 @@ static TEE_Result stm32_i2c_probe(const void *fdt, int node,
 	i2c_handle_p->i2c_state = I2C_STATE_RESET;
 	i2c_handle_p->pinctrl = pinctrl_active;
 	i2c_handle_p->pinctrl_sleep = pinctrl_idle;
+
+	if (compat_data != &non_secure_bus)
+		i2c_handle_p->i2c_secure = true;
 
 	init_data.analog_filter = true;
 	init_data.digital_filter_coef = 0;
@@ -1684,7 +1688,10 @@ static TEE_Result stm32_i2c_probe(const void *fdt, int node,
 static const struct dt_device_match stm32_i2c_match_table[] = {
 	{ .compatible = "st,stm32mp15-i2c" },
 	{ .compatible = "st,stm32mp13-i2c" },
-	{ .compatible = "st,stm32mp15-i2c-non-secure" },
+	{
+		.compatible = "st,stm32mp15-i2c-non-secure",
+		.compat_data = &non_secure_bus,
+	},
 	{ }
 };
 

--- a/core/include/drivers/stm32_i2c.h
+++ b/core/include/drivers/stm32_i2c.h
@@ -32,7 +32,6 @@
 /*
  * struct stm32_i2c_init_s - STM32 I2C configuration data
  *
- * @dt_status: non-secure/secure status read from DT
  * @pbase: I2C interface base address
  * @reg_size: I2C interface register map size
  * @clock: I2C bus/interface clock
@@ -50,7 +49,6 @@
  * @digital_filter_coef: filter coef (below STM32_I2C_DIGITAL_FILTER_MAX)
  */
 struct stm32_i2c_init_s {
-	unsigned int dt_status;
 	paddr_t pbase;
 	size_t reg_size;
 	struct clk *clock;
@@ -106,7 +104,6 @@ struct i2c_cfg {
  * I2C bus device
  * @base: I2C SoC registers base address
  * @reg_size: I2C SoC registers address map size
- * @dt_status: non-secure/secure status read from DT
  * @clock: clock ID
  * @i2c_state: Driver state ID I2C_STATE_*
  * @i2c_err: Last error code I2C_ERROR_*
@@ -120,7 +117,6 @@ struct i2c_cfg {
 struct i2c_handle_s {
 	struct io_pa_va base;
 	size_t reg_size;
-	unsigned int dt_status;
 	struct clk *clock;
 	enum i2c_state_e i2c_state;
 	uint32_t i2c_err;
@@ -130,6 +126,7 @@ struct i2c_handle_s {
 	struct pinctrl_state *pinctrl;
 	struct pinctrl_state *pinctrl_sleep;
 	struct mutex_pm_aware mu;
+	bool i2c_secure;
 };
 
 /*
@@ -278,7 +275,7 @@ void stm32_i2c_resume(struct i2c_handle_s *hi2c);
  */
 static inline bool i2c_is_secure(struct i2c_handle_s *hi2c)
 {
-	return hi2c->dt_status == DT_STATUS_OK_SEC;
+	return hi2c->i2c_secure;
 }
 
 #endif /* __DRIVERS_STM32_I2C_H*/


### PR DESCRIPTION
Update STM32 I2C driver use st,stm32mp15-i2c-non-secure specific DT compatible property for when the I2C bus is non-secure. Update STM32MP15 based DH boards accordingly.