### PR TITLE
ta: pkcs11: default disable raw RSA mechanism, default enable in plat-vexpress

### DIFF
--- a/core/arch/arm/plat-vexpress/conf.mk
+++ b/core/arch/arm/plat-vexpress/conf.mk
@@ -172,3 +172,4 @@ endif
 endif
 
 CFG_PKCS11_TA ?= y
+CFG_PKCS11_TA_RSA_X_509 ?= y

--- a/ta/pkcs11/sub.mk
+++ b/ta/pkcs11/sub.mk
@@ -16,7 +16,7 @@ CFG_PKCS11_TA_CHECK_VALUE_ATTRIBUTE ?= y
 # When enabled, embed support for CKM_RSA_X_509 (a.k.a. Raw RSA) ciphering
 # and authentication. The feature can be needed for some TLS v1.2 connections.
 # Raw RSA can be unsafe if client uses a weak clear data padding scheme.
-CFG_PKCS11_TA_RSA_X_509 ?= y
+CFG_PKCS11_TA_RSA_X_509 ?= n
 
 global-incdirs-y += include
 global-incdirs-y += src


### PR DESCRIPTION
Raw RSA signature (PKCS#11 mechanism CKM_RSA_X_509) is not a recommended scheme because unsafe when used with unsafe padding schemes. It's been added in the pkcs11 TA because needed for some TLS v1.2  scenario. I propose to disable it in the pkcs11 TA default config to prevent confusion but enable it in **plat-vexpress** default config so that it is tested (build + xtest).