### PR TITLE
core: arm: add guest id check at VM creation

### DIFF
--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -304,6 +304,10 @@ TEE_Result virt_guest_created(uint16_t guest_id)
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t exceptions = 0;
 
+        if(guest_id == HYP_CLNT_ID){
+                 return OPTEE_SMC_RETURN_ENOTAVAIL;
+        }
+
 	prtn = nex_calloc(1, sizeof(*prtn));
 	if (!prtn)
 		return TEE_ERROR_OUT_OF_MEMORY;

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -296,11 +296,11 @@ void __tee_entry_fast(struct thread_smc_args *args)
 
 	case OPTEE_SMC_ENABLE_ASYNC_NOTIF:
 		if (IS_ENABLED(CFG_CORE_ASYNC_NOTIF)) {
-#if defined(CFG_NS_VIRTUALIZATION)
-			notif_deliver_atomic_event(NOTIF_EVENT_STARTED, args->a7);
-#else
-			notif_deliver_atomic_event(NOTIF_EVENT_STARTED, 0);
-#endif
+			if(IS_ENABLED(CFG_NS_VIRTUALIZATION)){
+				notif_deliver_atomic_event(NOTIF_EVENT_STARTED, args->a7);
+			}else{
+				notif_deliver_atomic_event(NOTIF_EVENT_STARTED, 0);
+			}
 			args->a0 = OPTEE_SMC_RETURN_OK;
 		} else {
 			args->a0 = OPTEE_SMC_RETURN_UNKNOWN_FUNCTION;

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -171,12 +171,7 @@ static void tee_entry_get_thread_count(struct thread_smc_args *args)
 static void tee_entry_vm_created(struct thread_smc_args *args)
 {
 	uint16_t guest_id = args->a1;
-
-	if(guest_id == HYP_CLNT_ID){
-		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
-		return;
-	}
-
+	
 	/* Only hypervisor can issue this request */
 	if (args->a7 != HYP_CLNT_ID) {
 		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -296,7 +296,11 @@ void __tee_entry_fast(struct thread_smc_args *args)
 
 	case OPTEE_SMC_ENABLE_ASYNC_NOTIF:
 		if (IS_ENABLED(CFG_CORE_ASYNC_NOTIF)) {
+#if defined(CFG_NS_VIRTUALIZATION)
+			notif_deliver_atomic_event(NOTIF_EVENT_STARTED, args->a7);
+#else
 			notif_deliver_atomic_event(NOTIF_EVENT_STARTED, 0);
+#endif
 			args->a0 = OPTEE_SMC_RETURN_OK;
 		} else {
 			args->a0 = OPTEE_SMC_RETURN_UNKNOWN_FUNCTION;

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -172,6 +172,11 @@ static void tee_entry_vm_created(struct thread_smc_args *args)
 {
 	uint16_t guest_id = args->a1;
 
+	if(guest_id == HYP_CLNT_ID){
+		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
+		return;
+	}
+
 	/* Only hypervisor can issue this request */
 	if (args->a7 != HYP_CLNT_ID) {
 		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;

--- a/core/kernel/notif_default.c
+++ b/core/kernel/notif_default.c
@@ -87,7 +87,7 @@ void notif_send_async(uint32_t value, uint16_t guest_id __maybe_unused)
 	uint32_t old_itr_status = 0;
 	struct itr_chip *itr_chip = interrupt_get_main_chip();
 
-	assert(value <= NOTIF_ASYNC_VALUE_MAX && !guest_id);
+	assert(value <= NOTIF_ASYNC_VALUE_MAX);
 	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
 
 	bit_set(notif_values, value);


### PR DESCRIPTION
These 3 commits fix OPTEE going into panic under certain SMCs from NW when CONFIG_NS_VIRTUALIZATION is enabled.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
