### PR TITLE
core: check guest_id param passed when recieving SMC from NW

### DIFF
--- a/core/arch/arm/kernel/virtualization.c
+++ b/core/arch/arm/kernel/virtualization.c
@@ -304,6 +304,9 @@ TEE_Result virt_guest_created(uint16_t guest_id)
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t exceptions = 0;
 
+	if (guest_id == HYP_CLNT_ID)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	prtn = nex_calloc(1, sizeof(*prtn));
 	if (!prtn)
 		return TEE_ERROR_OUT_OF_MEMORY;

--- a/core/arch/arm/tee/entry_fast.c
+++ b/core/arch/arm/tee/entry_fast.c
@@ -291,7 +291,13 @@ void __tee_entry_fast(struct thread_smc_args *args)
 
 	case OPTEE_SMC_ENABLE_ASYNC_NOTIF:
 		if (IS_ENABLED(CFG_CORE_ASYNC_NOTIF)) {
-			notif_deliver_atomic_event(NOTIF_EVENT_STARTED, 0);
+			uint16_t g_id = 0;
+
+			if (IS_ENABLED(CFG_NS_VIRTUALIZATION))
+				g_id = args->a7;
+
+			notif_deliver_atomic_event(NOTIF_EVENT_STARTED, g_id);
+
 			args->a0 = OPTEE_SMC_RETURN_OK;
 		} else {
 			args->a0 = OPTEE_SMC_RETURN_UNKNOWN_FUNCTION;

--- a/core/kernel/notif_default.c
+++ b/core/kernel/notif_default.c
@@ -1,97 +1,168 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2021-2023, Linaro Limited
+ * Copyright (c) 2021-2024, Linaro Limited
  */
 
 #include <assert.h>
 #include <bitstring.h>
+#include <config.h>
+#include <initcall.h>
 #include <kernel/interrupt.h>
 #include <kernel/notif.h>
 #include <kernel/spinlock.h>
+#include <kernel/virtualization.h>
 #include <trace.h>
 #include <types_ext.h>
 
-static bitstr_t bit_decl(notif_values, NOTIF_ASYNC_VALUE_MAX + 1);
-static bitstr_t bit_decl(notif_alloc_values, NOTIF_ASYNC_VALUE_MAX + 1);
+struct notif_vm_bitmap {
+	bool alloc_values_inited;
+	bitstr_t bit_decl(values, NOTIF_ASYNC_VALUE_MAX + 1);
+	bitstr_t bit_decl(alloc_values, NOTIF_ASYNC_VALUE_MAX + 1);
+};
+
 static unsigned int notif_default_lock = SPINLOCK_UNLOCK;
+/* Id used to look up the guest specific struct notif_vm_bitmap */
+static unsigned int notif_vm_bitmap_id __nex_bss;
+/* Notification state when ns-virtualization isn't enabled */
+static struct notif_vm_bitmap default_notif_vm_bitmap;
+
+static struct notif_vm_bitmap *get_notif_vm_bitmap(struct guest_partition *prtn)
+{
+	if (IS_ENABLED(CFG_NS_VIRTUALIZATION)) {
+		if (!prtn)
+			return NULL;
+		return virt_get_guest_spec_data(prtn, notif_vm_bitmap_id);
+	}
+	return &default_notif_vm_bitmap;
+}
 
 TEE_Result notif_alloc_async_value(uint32_t *val)
 {
-	static bool alloc_values_inited;
+	struct guest_partition *prtn = NULL;
+	struct notif_vm_bitmap *nvb = NULL;
+	TEE_Result res = TEE_SUCCESS;
 	uint32_t old_itr_status = 0;
 	int bit = 0;
 
 	assert(interrupt_can_raise_pi(interrupt_get_main_chip()));
 
-	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
-
-	if (!alloc_values_inited) {
-		bit_set(notif_alloc_values, NOTIF_VALUE_DO_BOTTOM_HALF);
-		alloc_values_inited = true;
-	}
-
-	bit_ffc(notif_alloc_values, (int)NOTIF_ASYNC_VALUE_MAX + 1, &bit);
-	if (bit >= 0) {
-		*val = bit;
-		bit_set(notif_alloc_values, bit);
-	}
-
-	cpu_spin_unlock_xrestore(&notif_default_lock, old_itr_status);
-
-	if (bit < 0)
-		return TEE_ERROR_OUT_OF_MEMORY;
-
-	return TEE_SUCCESS;
-}
-
-void notif_free_async_value(uint32_t val)
-{
-	uint32_t old_itr_status = 0;
-
-	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
-
-	assert(val < NOTIF_ASYNC_VALUE_MAX);
-	assert(bit_test(notif_alloc_values, val));
-	bit_clear(notif_alloc_values, val);
-
-	cpu_spin_unlock_xrestore(&notif_default_lock, old_itr_status);
-}
-
-uint32_t notif_get_value(bool *value_valid, bool *value_pending)
-{
-	uint32_t old_itr_status = 0;
-	uint32_t res = 0;
-	int bit = 0;
-
-	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
-
-	bit_ffs(notif_values, (int)NOTIF_ASYNC_VALUE_MAX + 1, &bit);
-	*value_valid = (bit >= 0);
-	if (!*value_valid) {
-		*value_pending = false;
+	prtn = virt_get_current_guest();
+	nvb = get_notif_vm_bitmap(prtn);
+	if (!nvb) {
+		res = TEE_ERROR_BAD_PARAMETERS;
 		goto out;
 	}
 
-	res = bit;
-	bit_clear(notif_values, res);
-	bit_ffs(notif_values, (int)NOTIF_ASYNC_VALUE_MAX + 1, &bit);
-	*value_pending = (bit >= 0);
-out:
+	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
+
+	if (!nvb->alloc_values_inited) {
+		bit_set(nvb->alloc_values, NOTIF_VALUE_DO_BOTTOM_HALF);
+		nvb->alloc_values_inited = true;
+	}
+
+	bit_ffc(nvb->alloc_values, (int)NOTIF_ASYNC_VALUE_MAX + 1, &bit);
+	if (bit < 0) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out_unlock;
+	}
+	*val = bit;
+	bit_set(nvb->alloc_values, bit);
+
+out_unlock:
 	cpu_spin_unlock_xrestore(&notif_default_lock, old_itr_status);
+out:
+	virt_put_guest(prtn);
 
 	return res;
 }
 
-void notif_send_async(uint32_t value, uint16_t guest_id __maybe_unused)
+void notif_free_async_value(uint32_t val)
 {
+	struct guest_partition *prtn = NULL;
+	struct notif_vm_bitmap *nvb = NULL;
+	uint32_t old_itr_status = 0;
+
+	prtn = virt_get_current_guest();
+	nvb = get_notif_vm_bitmap(prtn);
+	if (!nvb)
+		goto out;
+
+	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
+
+	assert(val < NOTIF_ASYNC_VALUE_MAX);
+	assert(bit_test(nvb->alloc_values, val));
+	bit_clear(nvb->alloc_values, val);
+
+	cpu_spin_unlock_xrestore(&notif_default_lock, old_itr_status);
+out:
+	virt_put_guest(prtn);
+}
+
+uint32_t notif_get_value(bool *value_valid, bool *value_pending)
+{
+	struct guest_partition *prtn = NULL;
+	struct notif_vm_bitmap *nvb = NULL;
+	uint32_t old_itr_status = 0;
+	uint32_t res = 0;
+	int bit = -1;
+
+	prtn = virt_get_current_guest();
+	nvb = get_notif_vm_bitmap(prtn);
+	if (!nvb) {
+		*value_valid = false;
+		goto out;
+	}
+
+	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
+
+	bit_ffs(nvb->values, (int)NOTIF_ASYNC_VALUE_MAX + 1, &bit);
+	*value_valid = (bit >= 0);
+	if (!*value_valid)
+		goto out_unlock;
+
+	res = bit;
+	bit_clear(nvb->values, res);
+	bit_ffs(nvb->values, (int)NOTIF_ASYNC_VALUE_MAX + 1, &bit);
+
+out_unlock:
+	cpu_spin_unlock_xrestore(&notif_default_lock, old_itr_status);
+out:
+	virt_put_guest(prtn);
+	*value_pending = (bit >= 0);
+
+	return res;
+}
+
+void notif_send_async(uint32_t value, uint16_t guest_id)
+{
+	struct guest_partition *prtn = NULL;
+	struct notif_vm_bitmap *nvb = NULL;
 	uint32_t old_itr_status = 0;
 	struct itr_chip *itr_chip = interrupt_get_main_chip();
 
-	assert(value <= NOTIF_ASYNC_VALUE_MAX && !guest_id);
+	assert(value <= NOTIF_ASYNC_VALUE_MAX);
+
+	prtn = virt_get_guest(guest_id);
+	nvb = get_notif_vm_bitmap(prtn);
+	if (!nvb)
+		goto out;
+
 	old_itr_status = cpu_spin_lock_xsave(&notif_default_lock);
 
-	bit_set(notif_values, value);
+	bit_set(nvb->values, value);
 	interrupt_raise_pi(itr_chip, CFG_CORE_ASYNC_NOTIF_GIC_INTID);
 
 	cpu_spin_unlock_xrestore(&notif_default_lock, old_itr_status);
+out:
+	virt_put_guest(prtn);
 }
+
+static TEE_Result notif_init(void)
+{
+	if (IS_ENABLED(CFG_NS_VIRTUALIZATION) &&
+	    virt_add_guest_spec_data(&notif_vm_bitmap_id,
+				     sizeof(struct notif_vm_bitmap), NULL))
+		panic("virt_add_guest_spec_data");
+	return TEE_SUCCESS;
+}
+nex_service_init(notif_init);


### PR DESCRIPTION
Certain SMCs such as OPTEE_SMC_VM_CREATED can send OPTEE to panic if guest ID passed is 0. 

P.S. sorry for the second PR, there was something really wrong with my branch.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
