### PR TITLE
ci: QEMUv8: disable fTPM with pager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,8 @@ jobs:
           # Rust is disabled because signature_verification-rs hangs with this OP-TEE configuration
           # fTPM is disabled because it takes too long to probe with this OP-TEE configuration
           make -j$(nproc) check CFG_FTRACE_SUPPORT=y CFG_SYSCALL_FTRACE=y XTEST_ARGS=regression_1001 RUST_ENABLE=n MEASURED_BOOT_FTPM=n
-          make -j$(nproc) check CFG_WITH_PAGER=y
+          # fTPM is disabled because tests are too slow otherwise (lots of paging)
+          make -j$(nproc) check CFG_WITH_PAGER=y MEASURED_BOOT_FTPM=n
 
   QEMUv8_check2:
     name: make check (QEMUv8) 2 / 2


### PR DESCRIPTION
Disable fTPM when testing with pager enabled, because execution is too slow otherwise and sometimes fails with a timeout error. For example I noticed that the execution time of "xtest regression 1006" may be increased from 5 to 10 minutes.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
