### PR TITLE
Fix linking problems/warnings in ubsan

### DIFF
--- a/core/kernel/ubsan.c
+++ b/core/kernel/ubsan.c
@@ -63,6 +63,11 @@ struct nonnull_arg_data {
 	struct source_location loc;
 };
 
+struct invalid_builtin_data {
+	struct source_location loc;
+	unsigned char kind;
+};
+
 /*
  * When compiling with -fsanitize=undefined the compiler expects functions
  * with the following signatures. The functions are never called directly,
@@ -99,6 +104,7 @@ void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data
 				, size_t arg_no
 #endif
 			       );
+void __ubsan_handle_invalid_builtin(struct invalid_builtin_data *data);
 
 static void print_loc(const char *func, struct source_location *loc)
 {
@@ -235,6 +241,13 @@ void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data
 				, size_t arg_no __unused
 #endif
 			       )
+{
+	print_loc(__func__, &data->loc);
+	if (ubsan_panic)
+		panic();
+}
+
+void __ubsan_handle_invalid_builtin(struct invalid_builtin_data *data)
 {
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)

--- a/core/kernel/ubsan.c
+++ b/core/kernel/ubsan.c
@@ -75,36 +75,25 @@ struct invalid_builtin_data {
  */
 void __ubsan_handle_type_mismatch(struct type_mismatch_data *data,
 				  unsigned long ptr);
-void __ubsan_handle_type_mismatch_v1(struct type_mismatch_data *data,
-				     unsigned long ptr);
-void __ubsan_handle_add_overflow(struct overflow_data *data,
-				  unsigned long lhs, unsigned long rhs);
-void __ubsan_handle_sub_overflow(struct overflow_data *data,
-				  unsigned long lhs, unsigned long rhs);
-void __ubsan_handle_mul_overflow(struct overflow_data *data,
-				  unsigned long lhs, unsigned long rhs);
-void __ubsan_handle_negate_overflow(struct overflow_data *data,
-				    unsigned long old_val);
-void __ubsan_handle_divrem_overflow(struct overflow_data *data,
-				    unsigned long lhs, unsigned long rhs);
-void __ubsan_handle_pointer_overflow(struct overflow_data *data,
-				     unsigned long lhs, unsigned long rhs);
-void __ubsan_handle_shift_out_of_bounds(struct shift_out_of_bounds_data *data,
-					unsigned long lhs, unsigned long rhs);
-void __ubsan_handle_out_of_bounds(struct out_of_bounds_data *data,
-				  unsigned long idx);
+void __ubsan_handle_type_mismatch_v1(void *data_, void *ptr);
+void __ubsan_handle_add_overflow(void *data_, void *lhs, void *rhs);
+void __ubsan_handle_sub_overflow(void *data_, void *lhs, void *rhs);
+void __ubsan_handle_mul_overflow(void *data_, void *lhs, void *rhs);
+void __ubsan_handle_negate_overflow(void *data_, void *old_val);
+void __ubsan_handle_divrem_overflow(void *data_, void *lhs, void *rhs);
+void __ubsan_handle_pointer_overflow(void *data_, void *lhs, void *rhs);
+void __ubsan_handle_shift_out_of_bounds(void *data_, void *lhs, void *rhs);
+void __ubsan_handle_out_of_bounds(void *data_, void *idx);
 void __ubsan_handle_unreachable(struct unreachable_data *data);
-void __ubsan_handle_missing_return(struct unreachable_data *data);
-void __ubsan_handle_vla_bound_not_positive(struct vla_bound_data *data,
-					   unsigned long bound);
-void __ubsan_handle_load_invalid_value(struct invalid_value_data *data,
-				       unsigned long val);
-void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data
+void __ubsan_handle_missing_return(void *data_);
+void __ubsan_handle_vla_bound_not_positive(void *data_, void *bound);
+void __ubsan_handle_load_invalid_value(void *data_, void *val);
+void __ubsan_handle_nonnull_arg(void *data_
 #if __GCC_VERSION < 60000
 				, size_t arg_no
 #endif
 			       );
-void __ubsan_handle_invalid_builtin(struct invalid_builtin_data *data);
+void __ubsan_handle_invalid_builtin(void *data_);
 
 static void print_loc(const char *func, struct source_location *loc)
 {
@@ -129,79 +118,79 @@ void __ubsan_handle_type_mismatch(struct type_mismatch_data *data,
 		panic();
 }
 
-void __ubsan_handle_type_mismatch_v1(struct type_mismatch_data *data,
-				     unsigned long ptr __unused)
+void __ubsan_handle_type_mismatch_v1(void *data_, void *ptr __unused)
 {
+	struct type_mismatch_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_add_overflow(struct overflow_data *data,
-				 unsigned long lhs __unused,
-				 unsigned long rhs __unused)
+void __ubsan_handle_add_overflow(void *data_, void *lhs __unused,
+				 void *rhs __unused)
 {
+	struct overflow_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_sub_overflow(struct overflow_data *data,
-				 unsigned long lhs __unused,
-				 unsigned long rhs __unused)
+void __ubsan_handle_sub_overflow(void *data_, void *lhs __unused,
+				 void *rhs __unused)
 {
+	struct overflow_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_mul_overflow(struct overflow_data *data,
-				 unsigned long lhs __unused,
-				 unsigned long rhs __unused)
+void __ubsan_handle_mul_overflow(void *data_, void *lhs __unused,
+				 void *rhs __unused)
 {
+	struct overflow_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_negate_overflow(struct overflow_data *data,
-				    unsigned long old_val __unused)
+void __ubsan_handle_negate_overflow(void *data_, void *old_val __unused)
 {
+	struct overflow_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_divrem_overflow(struct overflow_data *data,
-				    unsigned long lhs __unused,
-				    unsigned long rhs __unused)
+void __ubsan_handle_divrem_overflow(void *data_, void *lhs __unused,
+				    void *rhs __unused)
 {
+	struct overflow_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_pointer_overflow(struct overflow_data *data,
-				     unsigned long lhs __unused,
-				     unsigned long rhs __unused)
+void __ubsan_handle_pointer_overflow(void *data_, void *lhs __unused,
+				     void *rhs __unused)
 {
+	struct overflow_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_shift_out_of_bounds(struct shift_out_of_bounds_data *data,
-					unsigned long lhs __unused,
-					unsigned long rhs __unused)
+void __ubsan_handle_shift_out_of_bounds(void *data_, void *lhs __unused,
+					void *rhs __unused)
 {
+	struct shift_out_of_bounds_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_out_of_bounds(struct out_of_bounds_data *data,
-				  unsigned long idx __unused)
+void __ubsan_handle_out_of_bounds(void *data_, void *idx __unused)
 {
+	struct out_of_bounds_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
@@ -214,41 +203,44 @@ void __ubsan_handle_unreachable(struct unreachable_data *data)
 		panic();
 }
 
-void __noreturn __ubsan_handle_missing_return(struct unreachable_data *data)
+void __noreturn __ubsan_handle_missing_return(void *data_)
 {
+	struct unreachable_data *data = data_;
 	print_loc(__func__, &data->loc);
 	panic();
 }
 
-void __ubsan_handle_vla_bound_not_positive(struct vla_bound_data *data,
-					   unsigned long bound __unused)
+void __ubsan_handle_vla_bound_not_positive(void *data_, void *bound __unused)
 {
+	struct vla_bound_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_load_invalid_value(struct invalid_value_data *data,
-				       unsigned long val __unused)
+void __ubsan_handle_load_invalid_value(void *data_, void *val __unused)
 {
+	struct invalid_value_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_nonnull_arg(struct nonnull_arg_data *data
+void __ubsan_handle_nonnull_arg(void *data_
 #if __GCC_VERSION < 60000
 				, size_t arg_no __unused
 #endif
 			       )
 {
+	struct nonnull_arg_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();
 }
 
-void __ubsan_handle_invalid_builtin(struct invalid_builtin_data *data)
+void __ubsan_handle_invalid_builtin(void *data_)
 {
+	struct invalid_builtin_data *data = data_;
 	print_loc(__func__, &data->loc);
 	if (ubsan_panic)
 		panic();

--- a/core/kernel/ubsan.c
+++ b/core/kernel/ubsan.c
@@ -95,7 +95,10 @@ void __ubsan_handle_nonnull_arg(void *data_
 			       );
 void __ubsan_handle_invalid_builtin(void *data_);
 
-static void print_loc(const char *func, struct source_location *loc)
+static bool ubsan_panic = true;
+
+static void ubsan_handle_error(const char *func, struct source_location *loc,
+			       bool should_panic)
 {
 	const char *f = func;
 	const char func_prefix[] = "__ubsan_handle";
@@ -105,125 +108,114 @@ static void print_loc(const char *func, struct source_location *loc)
 
 	EMSG_RAW("Undefined behavior %s at %s:%" PRIu32 " col %" PRIu32,
 		 f, loc->file_name, loc->line, loc->column);
+
+	if (should_panic)
+		panic();
 }
-
-
-static volatile bool ubsan_panic = true;
 
 void __ubsan_handle_type_mismatch(struct type_mismatch_data *data,
 				  unsigned long ptr __unused)
 {
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_type_mismatch_v1(void *data_, void *ptr __unused)
 {
 	struct type_mismatch_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_add_overflow(void *data_, void *lhs __unused,
 				 void *rhs __unused)
 {
 	struct overflow_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_sub_overflow(void *data_, void *lhs __unused,
 				 void *rhs __unused)
 {
 	struct overflow_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_mul_overflow(void *data_, void *lhs __unused,
 				 void *rhs __unused)
 {
 	struct overflow_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_negate_overflow(void *data_, void *old_val __unused)
 {
 	struct overflow_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_divrem_overflow(void *data_, void *lhs __unused,
 				    void *rhs __unused)
 {
 	struct overflow_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_pointer_overflow(void *data_, void *lhs __unused,
 				     void *rhs __unused)
 {
 	struct overflow_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_shift_out_of_bounds(void *data_, void *lhs __unused,
 					void *rhs __unused)
 {
 	struct shift_out_of_bounds_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_out_of_bounds(void *data_, void *idx __unused)
 {
 	struct out_of_bounds_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_builtin_unreachable(void *data_)
 {
 	struct unreachable_data *data = data_;
-	print_loc(__func__, &data->loc);
+
+	ubsan_handle_error(__func__, &data->loc, false);
 	panic();
 }
 
 void __noreturn __ubsan_handle_missing_return(void *data_)
 {
 	struct unreachable_data *data = data_;
-	print_loc(__func__, &data->loc);
+
+	ubsan_handle_error(__func__, &data->loc, false);
 	panic();
 }
 
 void __ubsan_handle_vla_bound_not_positive(void *data_, void *bound __unused)
 {
 	struct vla_bound_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_load_invalid_value(void *data_, void *val __unused)
 {
 	struct invalid_value_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_nonnull_arg(void *data_
@@ -233,15 +225,13 @@ void __ubsan_handle_nonnull_arg(void *data_
 			       )
 {
 	struct nonnull_arg_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }
 
 void __ubsan_handle_invalid_builtin(void *data_)
 {
 	struct invalid_builtin_data *data = data_;
-	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+
+	ubsan_handle_error(__func__, &data->loc, ubsan_panic);
 }

--- a/core/kernel/ubsan.c
+++ b/core/kernel/ubsan.c
@@ -84,7 +84,7 @@ void __ubsan_handle_divrem_overflow(void *data_, void *lhs, void *rhs);
 void __ubsan_handle_pointer_overflow(void *data_, void *lhs, void *rhs);
 void __ubsan_handle_shift_out_of_bounds(void *data_, void *lhs, void *rhs);
 void __ubsan_handle_out_of_bounds(void *data_, void *idx);
-void __ubsan_handle_unreachable(struct unreachable_data *data);
+void __ubsan_handle_builtin_unreachable(void *data_);
 void __ubsan_handle_missing_return(void *data_);
 void __ubsan_handle_vla_bound_not_positive(void *data_, void *bound);
 void __ubsan_handle_load_invalid_value(void *data_, void *val);
@@ -196,11 +196,11 @@ void __ubsan_handle_out_of_bounds(void *data_, void *idx __unused)
 		panic();
 }
 
-void __ubsan_handle_unreachable(struct unreachable_data *data)
+void __ubsan_handle_builtin_unreachable(void *data_)
 {
+	struct unreachable_data *data = data_;
 	print_loc(__func__, &data->loc);
-	if (ubsan_panic)
-		panic();
+	panic();
 }
 
 void __noreturn __ubsan_handle_missing_return(void *data_)


### PR DESCRIPTION
The following changes are done in ubsan subsystem:

1) `__ubsan_handle_invalid_builtin` callback was added. This ubsan handler
will be invoked when undefined behavior appears in `__builtin_*`
functions. That could happen if invalid arguments were provided.
E.g. passing 0 as the argument to `__builtin_ctz_` or `__builtin_clz_` invokes
undefined behavior and could be potentially caught by ubsan.
I was not able to build latest optee for **vexpress-qemu_armv8a** 
(CFG_CORE_SANITIZE_UNDEFINED=y)
without this change, because this callback was generated in
[libmbedtls code](https://github.com/OP-TEE/optee_os/blame/master/lib/libmbedtls/mbedtls/library/bignum_core.c#L36C23-L36C23)
2) It seems that signatures of ubsan functions are not compatible
with latest (or more or less fresh) gcc ubsan interfaces. That creates
warnings during compilation. These warnings were fixed.
3) It seems `__ubsan_handle_unreachable` should be `__ubsan_handle_builtin_unreachable`.
At least that corresponds to latest gcc and to what was there since version 4.9.0
4) Small refactoring to reduce code size

