### PR TITLE
ta: pkcs11: set TA version ID to 1.0.0

### DIFF
--- a/ta/pkcs11/include/pkcs11_ta.h
+++ b/ta/pkcs11/include/pkcs11_ta.h
@@ -13,8 +13,8 @@
 			 { 0xa4, 0x9c, 0xbb, 0xd8, 0x27, 0xae, 0x86, 0xee } }
 
 /* PKCS11 trusted application version information */
-#define PKCS11_TA_VERSION_MAJOR			0
-#define PKCS11_TA_VERSION_MINOR			1
+#define PKCS11_TA_VERSION_MAJOR			1
+#define PKCS11_TA_VERSION_MINOR			0
 #define PKCS11_TA_VERSION_PATCH			0
 
 /* Attribute specific values */


### PR DESCRIPTION
PKCS#11 TA version ID is 0.1.0 since its early integration. Let's set it 1.0.0 since it now mature enough to deserve a non-zero major version number.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
