### PR TITLE
core: mm: add memory area type of transfer list

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -524,6 +524,7 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 		case MEM_AREA_SHM_VASPACE:
 		case MEM_AREA_TS_VASPACE:
 		case MEM_AREA_PAGER_VASPACE:
+		case MEM_AREA_TRANSFER_LIST:
 			break;
 		default:
 			check_phys_mem_is_outside(m, num_elems,


### PR DESCRIPTION
Add memory area type of transfer list in switch case. During early boot in OP-TEE OS, the transfer list is mapped into secure memory by the transfer_list_map function. However, when mapping non-secure memory from the DTB memory node, OP-TEE panics if the transfer list is located within non-secure memory ranges.
To address this issue, the OP-TEE memory type for the transfer list has been added to the core_mmu_set_discovered_nsec_ddr function.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
