### PR TITLE
libtuee: allow NULL output coefficients in TEE_BigIntComputeExtendedGcd()

### DIFF
--- a/lib/libutee/tee_api_arith_mpi.c
+++ b/lib/libutee/tee_api_arith_mpi.c
@@ -864,8 +864,10 @@ void TEE_BigIntComputeExtendedGcd(TEE_BigInt *gcd, TEE_BigInt *u,
 		mpi_u.s *= s1;
 		mpi_v.s *= s2;
 
-		MPI_CHECK(copy_mpi_to_bigint(&mpi_u, u));
-		MPI_CHECK(copy_mpi_to_bigint(&mpi_v, v));
+		if (u)
+			MPI_CHECK(copy_mpi_to_bigint(&mpi_u, u));
+		if (v)
+			MPI_CHECK(copy_mpi_to_bigint(&mpi_v, v));
 		mbedtls_mpi_free(&mpi_u);
 		mbedtls_mpi_free(&mpi_v);
 	}


### PR DESCRIPTION
Fix TEE_BigIntComputeExtendedGcd() for when only one of u and v output coefficients reference if NULL as allowed by the GP TEE Internal Core API specification.

Reported-by: Stefan Schmidt <snst@meek.de>
Closes: https://github.com/OP-TEE/optee_os/issues/7217

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
