### PR TITLE
core: pta: device: fix enumeration for PTA_CMD_GET_DEVICES_SUPP

### DIFF
--- a/core/pta/device.c
+++ b/core/pta/device.c
@@ -88,6 +88,11 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 {
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t rflags = 0;
+	/*
+	 * This should also be true if CFG_RPMB_ANNOUNCE_PROBE_CAP is
+	 * enabled when the kernel does not support OP-TEE RPMB operations.
+	 */
+	bool rpmb_needs_supp = !IS_ENABLED(CFG_RPMB_ANNOUNCE_PROBE_CAP);
 
 	switch (nCommandID) {
 	case PTA_CMD_GET_DEVICES:
@@ -95,7 +100,8 @@ static TEE_Result invoke_command(void *pSessionContext __unused,
 		break;
 	case PTA_CMD_GET_DEVICES_SUPP:
 		rflags = TA_FLAG_DEVICE_ENUM_SUPP;
-		if (IS_ENABLED(CFG_REE_FS))
+		if (IS_ENABLED(CFG_REE_FS) ||
+		    (IS_ENABLED(CFG_RPMB_FS) && rpmb_needs_supp))
 			rflags |= TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE;
 		break;
 	case PTA_CMD_GET_DEVICES_RPMB:


### PR DESCRIPTION
TAs which depend on TEE_STORAGE_PRIVATE do need the TEE supplicant if REE FS is disabled (in which case secure storage can only be RPMB) and RPMB is not routed via the kernel.

Fixes: a96033ca7bee ("core: add flag to enumerate TAs when secure storage is ready")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
