### PR TITLE
core: rpmb: fix mutex in directory populate

### DIFF
--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -2938,8 +2938,8 @@ static TEE_Result rpmb_fs_dir_populate(const char *path,
 		res = TEE_ERROR_ITEM_NOT_FOUND; /* No directories were found. */
 
 out:
-	mutex_unlock(&rpmb_mutex);
 	fat_entry_dir_deinit();
+	mutex_unlock(&rpmb_mutex);
 	if (res)
 		rpmb_fs_dir_free(dir);
 


### PR DESCRIPTION
Fix mutex unlocking in rpmb_fs_dir_populate() that should protect fat_entry_dir_deinit() execution.

Fixes: 5f68d7848fe8 ("core: RPMB FS: Caching for FAT FS entries")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
