### PR TITLE
core: mm: zero initialize phys_mem pool instances

### DIFF
--- a/core/mm/tee_mm.c
+++ b/core/mm/tee_mm.c
@@ -51,12 +51,14 @@ bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_size_t size,
 
 	assert(((uint64_t)size >> shift) < (uint64_t)UINT32_MAX);
 
-	pool->lo = lo;
-	pool->size = size;
-	pool->shift = shift;
-	pool->flags = flags;
-	pool->entry = pcalloc(pool, 1, sizeof(tee_mm_entry_t));
+	*pool = (tee_mm_pool_t){
+		.lo = lo,
+		.size = size,
+		.shift = shift,
+		.flags = flags,
+	};
 
+	pool->entry = pcalloc(pool, 1, sizeof(tee_mm_entry_t));
 	if (pool->entry == NULL)
 		return false;
 


### PR DESCRIPTION
Ensure phys_mem pool instance structure is zero initialized when created. This change fixes an issue where phys_mem pool max_allocated field may contain a fuzzy value.

Fixes: c596d8359eb3 ("core: add phys_mem allocation functions")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
