### PR TITLE
core: get RPMB secure storage allocation stats + PTA stats minor changes

### DIFF
--- a/core/include/tee/tee_fs.h
+++ b/core/include/tee/tee_fs.h
@@ -6,6 +6,8 @@
 #ifndef __TEE_TEE_FS_H
 #define __TEE_TEE_FS_H
 
+#include <pta_stats.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <tee_api_defines_extensions.h>
@@ -62,6 +64,9 @@ TEE_Result tee_rpmb_fs_raw_open(const char *fname, bool create,
 				struct tee_file_handle **fh);
 TEE_Result tee_rpmb_reinit(void);
 
+/* Ger RPMB memory allocation statistics */
+TEE_Result rpmb_mem_stats(struct pta_stats_alloc *stats, bool reset);
+
 /**
  * Weak function which can be overridden by platforms to indicate that the RPMB
  * key is ready to be written. Defaults to true, platforms can return false to
@@ -70,6 +75,12 @@ TEE_Result tee_rpmb_reinit(void);
 bool plat_rpmb_key_is_ready(void);
 #else
 static inline TEE_Result tee_rpmb_reinit(void)
+{
+	return TEE_ERROR_STORAGE_NOT_AVAILABLE;
+}
+
+static inline TEE_Result rpmb_mem_stats(struct pta_stats_alloc *stats __unused,
+					bool reset __unused)
 {
 	return TEE_ERROR_STORAGE_NOT_AVAILABLE;
 }

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -77,14 +77,17 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 				sizeof(stats->desc));
 			break;
 
-#ifdef CFG_NS_VIRTUALIZATION
 		case ALLOC_ID_NEXUS_HEAP:
+#ifdef CFG_NS_VIRTUALIZATION
 			nex_malloc_get_stats(stats);
 			strlcpy(stats->desc, "KHeap", sizeof(stats->desc));
 			if (p[0].value.b)
 				nex_malloc_reset_stats();
-			break;
+#else
+			strlcpy(stats->desc, "KHeap (disabled)",
+				sizeof(stats->desc));
 #endif
+			break;
 		case ALLOC_ID_RPMB:
 			if (rpmb_mem_stats(stats, p[0].value.b))
 				strlcpy(stats->desc,

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <string_ext.h>
 #include <tee_api_types.h>
+#include <tee/tee_fs.h>
 #include <trace.h>
 
 static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
@@ -52,6 +53,7 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 	}
 	p[1].memref.size = size_to_retrieve;
 	stats = p[1].memref.buffer;
+	memset(stats, 0, size_to_retrieve);
 
 	for (i = ALLOC_ID_HEAP; i <= STATS_NB_POOLS; i++) {
 		if (pool_id != ALLOC_ID_ALL && i != pool_id)
@@ -83,6 +85,15 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 				nex_malloc_reset_stats();
 			break;
 #endif
+		case ALLOC_ID_RPMB:
+			if (rpmb_mem_stats(stats, p[0].value.b))
+				strlcpy(stats->desc,
+					"RPMB secure storage (no data)",
+					sizeof(stats->desc));
+			else
+				strlcpy(stats->desc, "RPMB secure storage",
+					sizeof(stats->desc));
+			break;
 		default:
 			EMSG("Wrong pool id");
 			break;

--- a/core/pta/stats.c
+++ b/core/pta/stats.c
@@ -69,6 +69,8 @@ static TEE_Result get_alloc_stats(uint32_t type, TEE_Param p[TEE_NUM_PARAMS])
 
 		case ALLOC_ID_PUBLIC_DDR:
 			EMSG("public DDR not managed by secure side anymore");
+			strlcpy(stats->desc, "Public DDR (deprecated)",
+				sizeof(stats->desc));
 			break;
 
 		case ALLOC_ID_TA_RAM:

--- a/core/tee/tee_rpmb_fs.c
+++ b/core/tee/tee_rpmb_fs.c
@@ -25,6 +25,7 @@
 #include <string_ext.h>
 #include <string.h>
 #include <sys/queue.h>
+#include <string_ext.h>
 #include <tee/tee_fs.h>
 #include <tee/tee_fs_key_manager.h>
 #include <tee/tee_pobj.h>
@@ -3173,3 +3174,67 @@ bool __weak plat_rpmb_key_is_ready(void)
 {
 	return true;
 }
+
+#ifdef CFG_WITH_STATS
+TEE_Result rpmb_mem_stats(struct pta_stats_alloc *stats, bool reset)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct rpmb_fat_entry *fe = NULL;
+	tee_mm_entry_t *mm = NULL;
+	tee_mm_pool_t pool = { };
+	bool pool_result = false;
+	paddr_size_t pool_sz = 0;
+
+	mutex_lock(&rpmb_mutex);
+
+	res = rpmb_fs_setup();
+	if (res)
+		goto out;
+
+	pool_sz = fs_par->max_rpmb_address - RPMB_STORAGE_START_ADDRESS;
+	pool_result = tee_mm_init(&pool, RPMB_STORAGE_START_ADDRESS,
+				  pool_sz, RPMB_BLOCK_SIZE_SHIFT,
+				  TEE_MM_POOL_HI_ALLOC);
+	if (!pool_result) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
+	}
+
+	res = fat_entry_dir_init();
+	if (res)
+		goto out;
+
+	/*
+	 * The pool is used to represent the current RPMB layout. To find
+	 * a slot for the file tee_mm_alloc is called on the pool. Thus
+	 * if it is not NULL the entire FAT must be traversed to fill in
+	 * the pool.
+	 */
+	while (true) {
+		res = fat_entry_dir_get_next(&fe, NULL);
+		if (res || !fe)
+			break;
+
+		if (!(fe->flags & FILE_IS_ACTIVE) || !fe->data_size)
+			continue;
+
+		mm = tee_mm_alloc2(&pool, fe->start_address, fe->data_size);
+		if (!mm) {
+			res = TEE_ERROR_GENERIC;
+			break;
+		}
+	}
+
+	fat_entry_dir_deinit();
+
+out:
+	mutex_unlock(&rpmb_mutex);
+
+	if (!res)
+		tee_mm_get_pool_stats(&pool, stats, reset);
+
+	tee_mm_final(&pool);
+
+	return res;
+}
+#endif /*CFG_WITH_STATS*/

--- a/lib/libutee/include/pta_stats.h
+++ b/lib/libutee/include/pta_stats.h
@@ -38,6 +38,7 @@
 #define ALLOC_ID_PUBLIC_DDR	2	/* Public DDR allocator (deprecated) */
 #define ALLOC_ID_TA_RAM		3	/* TA_RAM allocator */
 #define ALLOC_ID_NEXUS_HEAP	4	/* Nexus heap allocator */
+#define ALLOC_ID_RPMB		5	/* RPMB secure storage */
 #define STATS_NB_POOLS		5
 
 #define TEE_ALLOCATOR_DESC_LENGTH 32


### PR DESCRIPTION
Retrieve RPMB secure storage space allocation statistics from the stats PTA `STATS_CMD_ALLOC_STATS` command.

Provide explicit pool string IDs to reflect when pool statistics that meaningless (deprecated public DDR pool, possibly disabled nexus heap).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
