### PR TITLE
core: fix potential panic when setting transfer entry size

### DIFF
--- a/core/kernel/transfer_list.c
+++ b/core/kernel/transfer_list.c
@@ -407,7 +407,8 @@ bool transfer_list_set_data_size(struct transfer_list_header *tl,
 		tl->size -= mov_dis;
 	}
 	/* Move all following entries to fit in the expanded or shrunk space */
-	memmove((void *)r_new_ev, (void *)old_ev, tl_old_ev - old_ev);
+	if (tl_old_ev > old_ev)
+		memmove((void *)r_new_ev, (void *)old_ev, tl_old_ev - old_ev);
 
 	/*
 	 * Fill the gap due to round up/down with a void entry if the size of


### PR DESCRIPTION
Fix a potential panic when the roundup end-of-entry exceeds the boundary of the old end-of-transfer-list when setting the size of a transfer entry.