### PR TITLE
drivers: dra7_rng: Change dra7_rng_init to service_init_crypto

### DIFF
--- a/core/drivers/dra7_rng.c
+++ b/core/drivers/dra7_rng.c
@@ -112,6 +112,8 @@ TEE_Result hw_get_random_bytes(void *buf, size_t len)
 	uint8_t *buffer = buf;
 	size_t buffer_pos = 0;
 
+	assert(rng);
+
 	while (buffer_pos < len) {
 		uint32_t exceptions = cpu_spin_lock_xsave(&rng_lock);
 
@@ -186,4 +188,4 @@ static TEE_Result dra7_rng_init(void)
 
 	return TEE_SUCCESS;
 }
-driver_init(dra7_rng_init);
+service_init_crypto(dra7_rng_init);


### PR DESCRIPTION
Since commit 11d8578d93f0 ("core: arm: call call_driver_initcalls() late"), driver_init is deferred and thread_update_canaries tries to get random_stack_canaries which requires the TRNG driver to be setup. Since it was being setup as part of driver_init, it lead to crash on DRA7 platforms.

Change driver_init to service_init_crypto which is meant to be used for initialization of crypto operations.

While here, add an assert that checks for DRA7 TRNG being used before initialization is complete.
