### PR TITLE
core: mmu: fix memory regions found from ff-a manifest

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1069,7 +1069,7 @@ static void collect_device_mem_ranges(struct memory_map *mem_map)
 		}
 
 		add_phys_mem(mem_map, name, MEM_AREA_IO_SEC,
-			     base, base + page_count * SMALL_PAGE_SIZE);
+			     base, page_count * SMALL_PAGE_SIZE);
 	}
 }
 


### PR DESCRIPTION
Fix the 5th parameter of add_phys_mem() in collect_device_mem_ranges() that has to be the size of memory region and not the end address of the region.

Fixes: b8ef8d0 ("core: mm: introduce struct memory_map")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
