### PR TITLE
core: fix partially unmapped MEM_AREA_TEE_RAM_RW

### DIFF
--- a/core/pta/tests/misc.c
+++ b/core/pta/tests/misc.c
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright (c) 2025, Linaro Limited.
  */
 #include <assert.h>
 #include <config.h>
 #include <kernel/dt_driver.h>
+#include <kernel/linker.h>
+#include <kernel/panic.h>
 #include <malloc.h>
+#include <mm/core_memprot.h>
 #include <stdbool.h>
 #include <trace.h>
-#include <kernel/panic.h>
 #include <util.h>
 
 #include "misc.h"
@@ -551,6 +554,72 @@ static int self_test_nex_malloc(void)
 }
 #endif
 
+static int check_virt_to_phys(vaddr_t va, paddr_t exp_pa,
+			      enum teecore_memtypes m)
+{
+	paddr_t pa = 0;
+	void *v = NULL;
+
+	pa = virt_to_phys((void *)va);
+	LOG("virt_to_phys(%#"PRIxVA") => %#"PRIxPA" (expect %#"PRIxPA")",
+	    va, pa, exp_pa);
+	if (pa != exp_pa)
+		goto fail;
+
+	if (!exp_pa)
+		return 0;
+
+	v = phys_to_virt(pa, m, 1);
+	LOG("phys_to_virt(%#"PRIxPA") => %p (expect %#"PRIxVA")",
+	    pa, v, va);
+	if ((vaddr_t)v != va)
+		goto fail;
+	return 0;
+
+fail:
+	LOG("Fail");
+	return -1;
+}
+
+static int self_test_va2pa(void)
+{
+	int ret = 0;
+
+	if (VCORE_FREE_SZ) {
+		vaddr_t va_base = VCORE_FREE_PA;
+		paddr_t pa_base = 0;
+
+		pa_base = virt_to_phys((void *)va_base);
+		if (!pa_base) {
+			LOG("virt_to_phys(%#"PRIxVA") => 0 Fail!", va_base);
+			return -1;
+		}
+
+		/*
+		 * boot_mem_release_unused() and
+		 * boot_mem_release_tmp_alloc() has been called during
+		 * boot.
+		 *
+		 * First pages of VCORE_FREE are expected to be allocated
+		 * with boot_mem_alloc() while the end of VCORE_FREE should
+		 * have been freed by the two mentioned release functions.
+		 */
+		if (check_virt_to_phys(va_base, pa_base, MEM_AREA_TEE_RAM))
+			ret = -1;
+		if (check_virt_to_phys(va_base + 16, pa_base + 16,
+				       MEM_AREA_TEE_RAM))
+			ret = -1;
+		if (check_virt_to_phys(va_base + VCORE_FREE_SZ -
+				       SMALL_PAGE_SIZE, 0, MEM_AREA_TEE_RAM))
+			ret = -1;
+		if (check_virt_to_phys(va_base + VCORE_FREE_SZ - 16, 0,
+				       MEM_AREA_TEE_RAM))
+			ret = -1;
+	}
+
+	return ret;
+}
+
 /* exported entry points for some basic test */
 TEE_Result core_self_tests(uint32_t nParamTypes __unused,
 		TEE_Param pParams[TEE_NUM_PARAMS] __unused)
@@ -558,7 +627,7 @@ TEE_Result core_self_tests(uint32_t nParamTypes __unused,
 	if (self_test_mul_signed_overflow() || self_test_add_overflow() ||
 	    self_test_sub_overflow() || self_test_mul_unsigned_overflow() ||
 	    self_test_division() || self_test_malloc() ||
-	    self_test_nex_malloc()) {
+	    self_test_nex_malloc() || self_test_va2pa()) {
 		EMSG("some self_test_xxx failed! you should enable local LOG");
 		return TEE_ERROR_GENERIC;
 	}


### PR DESCRIPTION
The commit 06a258064a92 ("core: mm: allow unmapping VCORE_FREE") allows unmapping page from the VCORE_FREE virtual memory range, but no bookkeeping is added apart from what's recorded in the translation tables. Later, the commit 7c9b85432343 ("core: allow partially unmapped MEM_AREA_TEE_RAM_RW") does lookups the translation tables using arch_va2pa_helper() to find out if pages in the VCORE_FREE virtual memory range are mapped. This works well on arm, but not on riscv which must traverse the translation tables in software and then is caught in an infinite recursive loop.

Fix this problem by using explicit bookkeeping in a bitstring representing each page in the VCORE_FREE virtual memory range with a bit and update the bits as needed.

Reported-by: Huang Borong <huangborong@bosc.ac.cn>
Fixes: https://github.com/OP-TEE/optee_os/issues/7237
Fixes: 06a258064a92 ("core: mm: allow unmapping VCORE_FREE")
Fixes: 7c9b85432343 ("core: allow partially unmapped MEM_AREA_TEE_RAM_RW")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
