### PR TITLE
drivers: stm32_stgen: fix type in debug trace

### DIFF
--- a/core/drivers/counter/stm32_stgen.c
+++ b/core/drivers/counter/stm32_stgen.c
@@ -154,7 +154,7 @@ static void stm32_stgen_pm_resume(void)
 
 	io_setbits32(stgen_d.base + STGENC_CNTCR, STGENC_CNTCR_EN);
 
-	DMSG("Time spent in low-power: %"PRIu64"ms",
+	DMSG("Time spent in low-power: %lld ms",
 	     (nb_pm_count_ticks * 1000) / clock_src_rate);
 }
 


### PR DESCRIPTION
Cast the result of an operation in stm32_stgen_pm_resume() to fix a compilation warning.

