### PR TITLE
ltc: ctr: fix counter increment when LTC_FAST is defined

### DIFF
--- a/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
+++ b/core/lib/libtomcrypt/src/modes/ctr/ctr_encrypt.c
@@ -61,6 +61,7 @@ static int s_ctr_encrypt(const unsigned char *pt, unsigned char *ct, unsigned lo
        ct         += ctr->blocklen;
        len        -= ctr->blocklen;
        ctr->padlen = ctr->blocklen;
+       s_ctr_increment_counter(ctr);
        continue;
       }
 #endif


### PR DESCRIPTION
In CTR mode the counter needs to be incremented upon completion of each block. Unfortunately, if there is no crypto acceleration (accel_ctr_encrypt == NULL) and if LTC_FAST is defined, this does not happen. Add the missing call to fix the issue.

Reported-by: Jork Loeser <jork.loeser@microsoft.com>
Closes: https://lists.trustedfirmware.org/archives/list/op-tee@lists.trustedfirmware.org/thread/J4MMZPCM2MNKC2KWAXZUMTVEJP56U6OI/

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
