### PR TITLE
scmi: Fix qemu_v8 configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           function _make() { make -j$(nproc) -s O=out $*; }
           function download_plug_and_trust() { mkdir -p $HOME/se050 && git clone --single-branch -b v0.4.2 https://github.com/foundriesio/plug-and-trust $HOME/se050/plug-and-trust || (rm -rf $HOME/se050 ; echo Nervermind); }
 
-          function download_scp_firmware() { git clone --single-branch -b v2.15.0 --depth 1 https://git.gitlab.arm.com/firmware/SCP-firmware.git $HOME/scp-firmware || (rm -rf $HOME/scp-firmware ; echo Nervermind); }
+          function download_scp_firmware() { git clone --single-branch https://git.gitlab.arm.com/firmware/SCP-firmware.git $HOME/scp-firmware &&  git -C $HOME/scp-firmware checkout 22aecaa9cee258d707880c5b8823dd7974b66717 || (rm -rf $HOME/scp-firmware ; echo Nervermind); }
 
           ccache -s -v
           download_plug_and_trust

--- a/core/lib/scmi-server/conf-optee-fvp.mk
+++ b/core/lib/scmi-server/conf-optee-fvp.mk
@@ -18,6 +18,6 @@ $(call force,CFG_SCPFW_MOD_SYSTEM_PLL,y)
 $(call force,CFG_SCPFW_MOD_SENSOR,y)
 $(call force,CFG_SCPFW_MOD_VPLL,y)
 
-$(call force,CFG_SCPFW_NOTIFICATION,y)
-$(call force,CFG_SCPFW_SCMI_SENSOR_EVENTS,y)
+$(call force,CFG_SCPFW_NOTIFICATION,n)
+$(call force,CFG_SCPFW_SCMI_SENSOR_EVENTS,n)
 $(call force,CFG_SCPFW_FAST_CHANNEL,n)


### PR DESCRIPTION
OP-TEE scmi server on qemu_v8 doesn't boot with latest SCP-firmware when notification is enabled since the addition of clock notification in SCP. This come from that there is no notification channel supported yet for optee scmi server. Disable notification until notification support is added.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
