### PR TITLE
Allow NIST curves on all ECDSA algorithms in libtomcrypt and libutee

### DIFF
--- a/core/lib/libtomcrypt/ecc.c
+++ b/core/lib/libtomcrypt/ecc.c
@@ -51,7 +51,8 @@ static TEE_Result ecc_get_curve_info(uint32_t curve, uint32_t algo,
 		size_bits = 192;
 		size_bytes = 24;
 		name = "NISTP192";
-		if ((algo != 0) && (algo != TEE_ALG_ECDSA_SHA1) &&
+		if ((algo != 0) &&
+		    (__tee_alg_get_main_alg(algo) != TEE_MAIN_ALGO_ECDSA) &&
 		    (algo != TEE_ALG_ECDH_DERIVE_SHARED_SECRET))
 			return TEE_ERROR_BAD_PARAMETERS;
 		break;
@@ -59,7 +60,8 @@ static TEE_Result ecc_get_curve_info(uint32_t curve, uint32_t algo,
 		size_bits = 224;
 		size_bytes = 28;
 		name = "NISTP224";
-		if ((algo != 0) && (algo != TEE_ALG_ECDSA_SHA224) &&
+		if ((algo != 0) &&
+		    (__tee_alg_get_main_alg(algo) != TEE_MAIN_ALGO_ECDSA) &&
 		    (algo != TEE_ALG_ECDH_DERIVE_SHARED_SECRET))
 			return TEE_ERROR_BAD_PARAMETERS;
 		break;
@@ -67,7 +69,8 @@ static TEE_Result ecc_get_curve_info(uint32_t curve, uint32_t algo,
 		size_bits = 256;
 		size_bytes = 32;
 		name = "NISTP256";
-		if ((algo != 0) && (algo != TEE_ALG_ECDSA_SHA256) &&
+		if ((algo != 0) &&
+		    (__tee_alg_get_main_alg(algo) != TEE_MAIN_ALGO_ECDSA) &&
 		    (algo != TEE_ALG_ECDH_DERIVE_SHARED_SECRET))
 			return TEE_ERROR_BAD_PARAMETERS;
 		break;
@@ -75,7 +78,8 @@ static TEE_Result ecc_get_curve_info(uint32_t curve, uint32_t algo,
 		size_bits = 384;
 		size_bytes = 48;
 		name = "NISTP384";
-		if ((algo != 0) && (algo != TEE_ALG_ECDSA_SHA384) &&
+		if ((algo != 0) &&
+		    (__tee_alg_get_main_alg(algo) != TEE_MAIN_ALGO_ECDSA) &&
 		    (algo != TEE_ALG_ECDH_DERIVE_SHARED_SECRET))
 			return TEE_ERROR_BAD_PARAMETERS;
 		break;
@@ -83,7 +87,8 @@ static TEE_Result ecc_get_curve_info(uint32_t curve, uint32_t algo,
 		size_bits = 521;
 		size_bytes = 66;
 		name = "NISTP521";
-		if ((algo != 0) && (algo != TEE_ALG_ECDSA_SHA512) &&
+		if ((algo != 0) &&
+		    (__tee_alg_get_main_alg(algo) != TEE_MAIN_ALGO_ECDSA) &&
 		    (algo != TEE_ALG_ECDH_DERIVE_SHARED_SECRET))
 			return TEE_ERROR_BAD_PARAMETERS;
 		break;

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -75,21 +75,18 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA1:
 	case __OPTEE_ALG_ECDSA_P192:
 	case __OPTEE_ALG_ECDH_P192:
 		if (maxKeySize != 192)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA224:
 	case __OPTEE_ALG_ECDSA_P224:
 	case __OPTEE_ALG_ECDH_P224:
 		if (maxKeySize != 224)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA256:
 	case __OPTEE_ALG_ECDSA_P256:
 	case __OPTEE_ALG_ECDH_P256:
 	case TEE_ALG_SM2_PKE:
@@ -104,20 +101,23 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA384:
 	case __OPTEE_ALG_ECDSA_P384:
 	case __OPTEE_ALG_ECDH_P384:
 		if (maxKeySize != 384)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
-	case TEE_ALG_ECDSA_SHA512:
 	case __OPTEE_ALG_ECDSA_P521:
 	case __OPTEE_ALG_ECDH_P521:
 		if (maxKeySize != 521)
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
+	case TEE_ALG_ECDSA_SHA1:
+	case TEE_ALG_ECDSA_SHA224:
+	case TEE_ALG_ECDSA_SHA256:
+	case TEE_ALG_ECDSA_SHA384:
+	case TEE_ALG_ECDSA_SHA512:
 	case TEE_ALG_ECDH_DERIVE_SHARED_SECRET:
 		if (maxKeySize > 521)
 			return TEE_ERROR_NOT_SUPPORTED;
@@ -2660,36 +2660,53 @@ TEE_Result TEE_IsAlgorithmSupported(uint32_t alg, uint32_t element)
 			goto check_element_none;
 	}
 	if (IS_ENABLED(CFG_CRYPTO_ECC)) {
-		if ((alg == __OPTEE_ALG_ECDH_P192 ||
-		     alg == __OPTEE_ALG_ECDSA_P192 ||
-		     alg == TEE_ALG_ECDH_DERIVE_SHARED_SECRET ||
-		     alg == TEE_ALG_ECDSA_SHA1) &&
-		    element == TEE_ECC_CURVE_NIST_P192)
-			return TEE_SUCCESS;
-		if ((alg == __OPTEE_ALG_ECDH_P224 ||
-		     alg == __OPTEE_ALG_ECDSA_P224 ||
-		     alg == TEE_ALG_ECDH_DERIVE_SHARED_SECRET ||
-		     alg == TEE_ALG_ECDSA_SHA224) &&
-		    element == TEE_ECC_CURVE_NIST_P224)
-			return TEE_SUCCESS;
-		if ((alg == __OPTEE_ALG_ECDH_P256 ||
-		     alg == __OPTEE_ALG_ECDSA_P256 ||
-		     alg == TEE_ALG_ECDH_DERIVE_SHARED_SECRET ||
-		     alg == TEE_ALG_ECDSA_SHA256) &&
-		    element == TEE_ECC_CURVE_NIST_P256)
-			return TEE_SUCCESS;
-		if ((alg == __OPTEE_ALG_ECDH_P384 ||
-		     alg == __OPTEE_ALG_ECDSA_P384 ||
-		     alg == TEE_ALG_ECDH_DERIVE_SHARED_SECRET ||
-		     alg == TEE_ALG_ECDSA_SHA384) &&
-		    element == TEE_ECC_CURVE_NIST_P384)
-			return TEE_SUCCESS;
-		if ((alg == __OPTEE_ALG_ECDH_P521 ||
-		     alg == __OPTEE_ALG_ECDSA_P521 ||
-		     alg == TEE_ALG_ECDH_DERIVE_SHARED_SECRET ||
-		     alg == TEE_ALG_ECDSA_SHA512) &&
-		    element == TEE_ECC_CURVE_NIST_P521)
-			return TEE_SUCCESS;
+		switch (alg) {
+		case __OPTEE_ALG_ECDSA_P192:
+		case __OPTEE_ALG_ECDH_P192:
+			if (element == TEE_ECC_CURVE_NIST_P192)
+				return TEE_SUCCESS;
+			break;
+		case __OPTEE_ALG_ECDSA_P224:
+		case __OPTEE_ALG_ECDH_P224:
+			if (element == TEE_ECC_CURVE_NIST_P224)
+				return TEE_SUCCESS;
+			break;
+		case __OPTEE_ALG_ECDSA_P256:
+		case __OPTEE_ALG_ECDH_P256:
+			if (element == TEE_ECC_CURVE_NIST_P256)
+				return TEE_SUCCESS;
+			break;
+		case __OPTEE_ALG_ECDSA_P384:
+		case __OPTEE_ALG_ECDH_P384:
+			if (element == TEE_ECC_CURVE_NIST_P384)
+				return TEE_SUCCESS;
+			break;
+		case __OPTEE_ALG_ECDSA_P521:
+		case __OPTEE_ALG_ECDH_P521:
+			if (element == TEE_ECC_CURVE_NIST_P521)
+				return TEE_SUCCESS;
+			break;
+		case TEE_ALG_ECDSA_SHA1:
+		case TEE_ALG_ECDSA_SHA224:
+		case TEE_ALG_ECDSA_SHA256:
+		case TEE_ALG_ECDSA_SHA384:
+		case TEE_ALG_ECDSA_SHA512:
+		case TEE_ALG_ECDH_DERIVE_SHARED_SECRET:
+			switch (element) {
+			case TEE_ECC_CURVE_NIST_P192:
+			case TEE_ECC_CURVE_NIST_P224:
+			case TEE_ECC_CURVE_NIST_P256:
+			case TEE_ECC_CURVE_NIST_P384:
+			case TEE_ECC_CURVE_NIST_P521:
+				return TEE_SUCCESS;
+			default:
+				break;
+			}
+			break;
+		default:
+			break;
+		}
+		return TEE_ERROR_NOT_SUPPORTED;
 	}
 	if (IS_ENABLED(CFG_CRYPTO_SM2_DSA)) {
 		if (alg == TEE_ALG_SM2_DSA_SM3 && element == TEE_ECC_CURVE_SM2)
@@ -2713,6 +2730,7 @@ TEE_Result TEE_IsAlgorithmSupported(uint32_t alg, uint32_t element)
 	}
 
 	return TEE_ERROR_NOT_SUPPORTED;
+
 check_element_none:
 	if (element == TEE_CRYPTO_ELEMENT_NONE)
 		return TEE_SUCCESS;


### PR DESCRIPTION
According to GP TEE specification *"ECDSA algorithm identifiers should be tied to the size of the digest, not the key."*. Therefore allow use of any `TEE_ALG_ECDSA_SHA*` algorithm for any of the supported NIST curve.

The constraint removed by these changes are present only in libutee and libtomcrypt.