### PR TITLE
libutee: add TEE_ALG_ECDSA_RAW

### DIFF
--- a/core/crypto.mk
+++ b/core/crypto.mk
@@ -313,3 +313,7 @@ _CFG_CORE_LTC_EC25519 := $(call ltc-one-enabled, ED25519 X25519)
 ifeq ($(CFG_CRYPTOLIB_NAME),tomcrypt)
 CFG_CRYPTO_RSASSA_NA1 ?= y
 endif
+
+# Enable TEE_ALG_ECDSA_RAW algorithm for ECDSA signature without an explicit
+# message digest hashing algorithm.
+CFG_CRYPTO_ECDSA_NOHASH ?= y

--- a/core/tee/tee_svc_cryp.c
+++ b/core/tee/tee_svc_cryp.c
@@ -2860,8 +2860,10 @@ TEE_Result syscall_cryp_state_alloc(unsigned long algo, unsigned long mode,
 		break;
 	case TEE_OPERATION_ASYMMETRIC_CIPHER:
 	case TEE_OPERATION_ASYMMETRIC_SIGNATURE:
-		if (algo == TEE_ALG_RSASSA_PKCS1_V1_5 &&
-		    !IS_ENABLED(CFG_CRYPTO_RSASSA_NA1)) {
+		if ((algo == TEE_ALG_RSASSA_PKCS1_V1_5 &&
+		     IS_ENABLED(CFG_CRYPTO_RSASSA_NA1)) ||
+		    (algo == TEE_ALG_ECDSA_RAW &&
+		     IS_ENABLED(CFG_CRYPTO_ECDSA_NOHASH))) {
 			res = TEE_ERROR_NOT_SUPPORTED;
 			break;
 		}
@@ -4613,6 +4615,9 @@ TEE_Result syscall_asymm_operate(unsigned long state,
 		exit_user_access();
 		break;
 
+#if defined(CFG_CRYPTO_ECDSA_NOHASH)
+	case TEE_ALG_ECDSA_RAW:
+#endif
 	case TEE_ALG_ECDSA_SHA1:
 	case TEE_ALG_ECDSA_SHA224:
 	case TEE_ALG_ECDSA_SHA256:

--- a/lib/libutee/include/tee_api_defines_extensions.h
+++ b/lib/libutee/include/tee_api_defines_extensions.h
@@ -104,6 +104,11 @@
 #define TEE_ALG_SM4_XTS 0xF0000414
 
 /*
+ * ECDSA pre-hashed sign/verify
+ */
+#define TEE_ALG_ECDSA_RAW		0xF0000042
+
+/*
  * Implementation-specific object storage constants
  */
 

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -78,6 +78,8 @@ static inline uint32_t __tee_alg_get_class(uint32_t algo)
 		return TEE_OPERATION_ASYMMETRIC_SIGNATURE;
 	if (algo == TEE_ALG_RSAES_PKCS1_OAEP_MGF1_MD5)
 		return TEE_OPERATION_ASYMMETRIC_CIPHER;
+	if (algo == TEE_ALG_ECDSA_RAW)
+		return TEE_OPERATION_ASYMMETRIC_SIGNATURE;
 
 	/* Implementation defined algorithm IDs must be specifically handled */
 	assert(((algo >> 28) & 0xF) != 0xF);
@@ -103,6 +105,7 @@ static inline uint32_t __tee_alg_get_main_alg(uint32_t algo)
 	case TEE_ALG_ECDSA_SHA256:
 	case TEE_ALG_ECDSA_SHA384:
 	case TEE_ALG_ECDSA_SHA512:
+	case TEE_ALG_ECDSA_RAW:
 		return TEE_MAIN_ALGO_ECDSA;
 	case TEE_ALG_HKDF:
 		return TEE_MAIN_ALGO_HKDF;

--- a/lib/libutee/include/utee_defines.h
+++ b/lib/libutee/include/utee_defines.h
@@ -6,6 +6,7 @@
 #ifndef UTEE_DEFINES_H
 #define UTEE_DEFINES_H
 
+#include <assert.h>
 #include <compiler.h>
 #include <tee_api_defines.h>
 #include <tee_api_defines_extensions.h>
@@ -77,6 +78,9 @@ static inline uint32_t __tee_alg_get_class(uint32_t algo)
 		return TEE_OPERATION_ASYMMETRIC_SIGNATURE;
 	if (algo == TEE_ALG_RSAES_PKCS1_OAEP_MGF1_MD5)
 		return TEE_OPERATION_ASYMMETRIC_CIPHER;
+
+	/* Implementation defined algorithm IDs must be specifically handled */
+	assert(((algo >> 28) & 0xF) != 0xF);
 
 	return (algo >> 28) & 0xF; /* Bits [31:28] */
 }

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -118,6 +118,9 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 			return TEE_ERROR_NOT_SUPPORTED;
 		break;
 
+#if defined(CFG_CRYPTO_ECDSA_NOHASH)
+	case TEE_ALG_ECDSA_RAW:
+#endif
 	case TEE_ALG_ECDH_DERIVE_SHARED_SECRET:
 		if (maxKeySize > 521)
 			return TEE_ERROR_NOT_SUPPORTED;
@@ -184,6 +187,9 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	case TEE_ALG_DSA_SHA1:
 	case TEE_ALG_DSA_SHA224:
 	case TEE_ALG_DSA_SHA256:
+#if defined(CFG_CRYPTO_ECDSA_NOHASH)
+	case TEE_ALG_ECDSA_RAW:
+#endif
 	case TEE_ALG_ECDSA_SHA1:
 	case TEE_ALG_ECDSA_SHA224:
 	case TEE_ALG_ECDSA_SHA256:
@@ -2656,6 +2662,20 @@ TEE_Result TEE_IsAlgorithmSupported(uint32_t alg, uint32_t element)
 			goto check_element_none;
 	}
 	if (IS_ENABLED(CFG_CRYPTO_ECC)) {
+		if (alg == TEE_ALG_ECDSA_RAW &&
+		    IS_ENABLED(CFG_CRYPTO_ECDSA_NOHASH)) {
+			switch (element) {
+			case TEE_ECC_CURVE_NIST_P192:
+			case TEE_ECC_CURVE_NIST_P224:
+			case TEE_ECC_CURVE_NIST_P256:
+			case TEE_ECC_CURVE_NIST_P384:
+			case TEE_ECC_CURVE_NIST_P521:
+				return TEE_SUCCESS;
+			default:
+				return TEE_ERROR_NOT_SUPPORTED;
+			}
+		}
+
 		if ((alg == __OPTEE_ALG_ECDH_P192 ||
 		     alg == __OPTEE_ALG_ECDSA_P192 ||
 		     alg == TEE_ALG_ECDH_DERIVE_SHARED_SECRET ||

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -316,10 +316,6 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 
 	op->info.algorithm = algorithm;
 	op->info.operationClass = TEE_ALG_GET_CLASS(algorithm);
-#ifdef CFG_CRYPTO_RSASSA_NA1
-	if (algorithm == TEE_ALG_RSASSA_PKCS1_V1_5)
-		op->info.operationClass = TEE_OPERATION_ASYMMETRIC_SIGNATURE;
-#endif
 	op->info.mode = mode;
 	op->info.digestLength = TEE_ALG_GET_DIGEST_SIZE(algorithm);
 	op->info.maxKeySize = maxKeySize;
@@ -349,7 +345,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	op->block_size = block_size;
 	op->buffer_two_blocks = buffer_two_blocks;
 
-	if (TEE_ALG_GET_CLASS(algorithm) != TEE_OPERATION_DIGEST) {
+	if (op->info.operationClass != TEE_OPERATION_DIGEST) {
 		uint32_t mks = maxKeySize;
 		TEE_ObjectType key_type = TEE_ALG_GET_KEY_TYPE(algorithm,
 						       with_private_key);
@@ -383,7 +379,7 @@ TEE_Result TEE_AllocateOperation(TEE_OperationHandle *operation,
 	 * Other multi-stage operations initialized w/ TEE_xxxInit functions
 	 * Non-applicable on asymmetric operations
 	 */
-	if (TEE_ALG_GET_CLASS(algorithm) == TEE_OPERATION_DIGEST) {
+	if (op->info.operationClass == TEE_OPERATION_DIGEST) {
 		res = _utee_hash_init(op->state, NULL, 0);
 		if (res != TEE_SUCCESS)
 			goto out;


### PR DESCRIPTION
Add GP TEE Internal Core API extension algorithm ID `TEE_ALG_ECDSA_RAW` for ECDSA signature computation and verification operations when the digest algorithm is not specified. This algorithm ID is supported upon build configuration switch `CFG_CRYPTO_ECDSA_NOHASH`.
