### PR TITLE
Core: add platform abort handler + stm32 SERC usage

### DIFF
--- a/core/arch/arm/include/arm64.h
+++ b/core/arch/arm/include/arm64.h
@@ -215,7 +215,14 @@
 #define ESR_FSC_PERMF_L1	U(0x0d)
 #define ESR_FSC_PERMF_L2	U(0x0e)
 #define ESR_FSC_PERMF_L3	U(0x0f)
+#define ESR_FSC_SEA_NTT		U(0x10)
 #define ESR_FSC_TAG_CHECK	U(0x11)
+#define ESR_FSC_SEA_TT_SUB_L2	U(0x12)
+#define ESR_FSC_SEA_TT_SUB_L1	U(0x13)
+#define ESR_FSC_SEA_TT_L0	U(0x14)
+#define ESR_FSC_SEA_TT_L1	U(0x15)
+#define ESR_FSC_SEA_TT_L2	U(0x16)
+#define ESR_FSC_SEA_TT_L3	U(0x17)
 #define ESR_FSC_ALIGN		U(0x21)
 
 /* WnR for DABT and RES0 for IABT */

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -1452,7 +1452,7 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 		return CORE_MMU_FAULT_ASYNC_EXTERNAL;
 	case 0x21: /* b100001 Alignment fault */
 		return CORE_MMU_FAULT_ALIGNMENT;
-	case 0x12: /* b100010 Debug event */
+	case 0x22: /* b100010 Debug event */
 		return CORE_MMU_FAULT_DEBUG_EVENT;
 	default:
 		break;

--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -1443,10 +1443,15 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 	assert(fault_descr & FSR_LPAE);
 
 	switch (fault_descr & FSR_STATUS_MASK) {
-	case 0x21: /* b100001 Alignment fault */
-		return CORE_MMU_FAULT_ALIGNMENT;
+	case 0x10: /* b010000 Synchronous extern abort, not on table walk */
+	case 0x15: /* b010101 Synchronous extern abort, on table walk L1 */
+	case 0x16: /* b010110 Synchronous extern abort, on table walk L2 */
+	case 0x17: /* b010111 Synchronous extern abort, on table walk L3 */
+		return CORE_MMU_FAULT_SYNC_EXTERNAL;
 	case 0x11: /* b010001 Asynchronous extern abort (DFSR only) */
 		return CORE_MMU_FAULT_ASYNC_EXTERNAL;
+	case 0x21: /* b100001 Alignment fault */
+		return CORE_MMU_FAULT_ALIGNMENT;
 	case 0x12: /* b100010 Debug event */
 		return CORE_MMU_FAULT_DEBUG_EVENT;
 	default:
@@ -1558,6 +1563,14 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fault_descr)
 			return CORE_MMU_FAULT_ALIGNMENT;
 		case ESR_FSC_TAG_CHECK:
 			return CORE_MMU_FAULT_TAG_CHECK;
+		case ESR_FSC_SEA_NTT:
+		case ESR_FSC_SEA_TT_SUB_L2:
+		case ESR_FSC_SEA_TT_SUB_L1:
+		case ESR_FSC_SEA_TT_L0:
+		case ESR_FSC_SEA_TT_L1:
+		case ESR_FSC_SEA_TT_L2:
+		case ESR_FSC_SEA_TT_L3:
+			return CORE_MMU_FAULT_SYNC_EXTERNAL;
 		default:
 			return CORE_MMU_FAULT_OTHER;
 		}

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -853,7 +853,10 @@ enum core_mmu_fault core_mmu_get_fault_type(uint32_t fsr)
 	case (1 << 10) | 0x6:
 		/* DFSR[10,3:0] 0b10110 Async external abort (DFSR only) */
 		return CORE_MMU_FAULT_ASYNC_EXTERNAL;
-
+	case 0x8: /* DFSR[10,3:0] 0b01000 Sync external abort, not on table */
+	case 0xc: /* DFSR[10,3:0] 0b01100 Sync external abort, on table, L1 */
+	case 0xe: /* DFSR[10,3:0] 0b01110 Sync external abort, on table, L2 */
+		return CORE_MMU_FAULT_SYNC_EXTERNAL;
 	default:
 		return CORE_MMU_FAULT_OTHER;
 	}

--- a/core/arch/arm/plat-stm32mp2/conf.mk
+++ b/core/arch/arm/plat-stm32mp2/conf.mk
@@ -116,3 +116,7 @@ endif
 ifeq ($(CFG_STM32_RTC),y)
 $(call force,CFG_DRIVERS_RTC,y)
 endif
+
+ifeq ($(CFG_STM32_SERC),y)
+$(call force,CFG_EXTERNAL_ABORT_PLAT_HANDLER,y)
+endif

--- a/core/arch/arm/plat-stm32mp2/main.c
+++ b/core/arch/arm/plat-stm32mp2/main.c
@@ -7,8 +7,10 @@
 #include <console.h>
 #include <drivers/gic.h>
 #include <drivers/stm32_rif.h>
+#include <drivers/stm32_serc.h>
 #include <drivers/stm32_uart.h>
 #include <initcall.h>
+#include <kernel/abort.h>
 #include <kernel/boot.h>
 #include <kernel/dt.h>
 #include <kernel/interrupt.h>
@@ -171,4 +173,10 @@ bool stm32mp_allow_probe_shared_device(const void *fdt, int node)
 		return true;
 
 	return false;
+}
+
+void plat_external_abort_handler(struct abort_info *ai __unused)
+{
+	/* External abort may be due to SERC events */
+	stm32_serc_handle_ilac();
 }

--- a/core/include/drivers/stm32_serc.h
+++ b/core/include/drivers/stm32_serc.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022-2025, STMicroelectronics
+ */
+#ifndef __DRIVERS_STM32_SERC_H__
+#define __DRIVERS_STM32_SERC_H__
+
+/* Helper to print and handle SERC ILACs */
+#ifdef CFG_STM32_SERC
+void stm32_serc_handle_ilac(void);
+#else /* CFG_STM32_SERC */
+static inline void stm32_serc_handle_ilac(void) { };
+#endif /* CFG_STM32_SERC */
+
+#endif /* __DRIVERS_STM32_SERC_H__ */

--- a/core/include/kernel/abort.h
+++ b/core/include/kernel/abort.h
@@ -27,10 +27,18 @@ struct abort_info {
 
 /* Print abort info to the console */
 void abort_print(struct abort_info *ai);
+
 /* Print abort info + stack dump to the console */
 void abort_print_error(struct abort_info *ai);
 
 void abort_handler(uint32_t abort_type, struct thread_abort_regs *regs);
+
+/*
+ * Platform specific handler for external abort exceptions.
+ * CFG_EXTERNAL_ABORT_PLAT_HANDLER must be enabled to have the platform handler
+ * be called.
+ */
+void plat_external_abort_handler(struct abort_info *ai);
 
 bool abort_is_user_exception(struct abort_info *ai);
 

--- a/core/include/mm/core_mmu.h
+++ b/core/include/mm/core_mmu.h
@@ -335,6 +335,7 @@ void core_mmu_get_user_va_range(vaddr_t *base, size_t *size);
  * @CORE_MMU_FAULT_ASYNC_EXTERNAL:	asynchronous external abort
  * @CORE_MMU_FAULT_ACCESS_BIT:		access bit fault
  * @CORE_MMU_FAULT_TAG_CHECK:		tag check fault
+ * @CORE_MMU_FAULT_SYNC_EXTERNAL:	synchronous external abort
  * @CORE_MMU_FAULT_OTHER:		Other/unknown fault
  */
 enum core_mmu_fault {
@@ -346,6 +347,7 @@ enum core_mmu_fault {
 	CORE_MMU_FAULT_ASYNC_EXTERNAL,
 	CORE_MMU_FAULT_ACCESS_BIT,
 	CORE_MMU_FAULT_TAG_CHECK,
+	CORE_MMU_FAULT_SYNC_EXTERNAL,
 	CORE_MMU_FAULT_OTHER,
 };
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1282,3 +1282,8 @@ $(call force,CFG_DYN_CONFIG,n,conflicts with CFG_WITH_PAGER)
 else
 CFG_DYN_CONFIG ?= $(CFG_BOOT_MEM)
 endif
+
+# CFG_EXTERNAL_ABORT_PLAT_HANDLER is used to implement platform-specific
+# handling of external abort implementing the plat_external_abort_handler()
+# function.
+CFG_EXTERNAL_ABORT_PLAT_HANDLER ?= n


### PR DESCRIPTION
Implement a platform abort handler to handle use cases such as data aborts generated by peripherals on the bus.

These kinds of abort could be caused by platform-specific features, hence the weak function.