### PR TITLE
print warnings on insecure configurations

### DIFF
--- a/core/kernel/otp_stubs.c
+++ b/core/kernel/otp_stubs.c
@@ -14,14 +14,17 @@
  * Override these in your platform code to really fetch device-unique
  * bits from e-fuses or whatever.
  *
- * The default implementation just sets it to a constant.
+ * The default implementation just sets it to a constant and cannot be
+ * used in a secure environment.
  */
 
+#ifdef CFG_INSECURE
 __weak TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *hwkey)
 {
 	memset(&hwkey->data[0], 0, sizeof(hwkey->data));
 	return TEE_SUCCESS;
 }
+#endif
 
 __weak int tee_otp_get_die_id(uint8_t *buffer, size_t len)
 {

--- a/core/tee/tee_cryp_utl.c
+++ b/core/tee/tee_cryp_utl.c
@@ -200,7 +200,14 @@ void __plat_rng_init(void)
 	}
 }
 
+/*
+ * Override this in your platform code. This default implementation only seeds
+ * the random number generator from an easily predictable timestamp value or a
+ * constant value. It is not suitable for a secure environment.
+ */
+#ifdef CFG_INSECURE
 void plat_rng_init(void) __weak __alias("__plat_rng_init");
+#endif
 
 static TEE_Result tee_cryp_init(void)
 {


### PR DESCRIPTION
The weak functions plat_rng_init() and tee_otp_get_hw_unique_key() must be overwritten in a secure product, but it's easy
to forget this either by misconfiguration or lack of knowledge. Add some warnings in these functions to avoid this pitfall