### PR TITLE
plat-versal2: disable ARM CE v8.2

### DIFF
--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -34,8 +34,7 @@ CFG_WITH_STATS		?= y
 CFG_ARM64_core		?= y
 
 # Enable ARM Crypto Extensions(CE)
-$(call force,CFG_CRYPTO_WITH_CE,y)
-$(call force,CFG_CRYPTO_WITH_CE82,y)
+CFG_CRYPTO_WITH_CE ?= y
 
 # Define the number of cores per cluster used in calculating core position.
 # The cluster number is shifted by this value and added to the core ID,


### PR DESCRIPTION
Disable ARM CE configs for SHA-512 and SHA3 as those are not available on the SoC.
Ensure that the ARM CE configuration can be overridden at runtime while the default value remains enabled.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
