### PR TITLE
core: interrupt: rename .add handler to .configure + minor inline comment changes

### DIFF
--- a/core/drivers/atmel_saic.c
+++ b/core/drivers/atmel_saic.c
@@ -104,8 +104,8 @@ static TEE_Result saic_get_src_type(uint32_t dt_level, size_t it,
 	return TEE_SUCCESS;
 }
 
-static void saic_add(struct itr_chip *chip __unused, size_t it,
-		     uint32_t type, uint32_t prio)
+static void saic_configure(struct itr_chip *chip __unused, size_t it,
+			   uint32_t type, uint32_t prio)
 {
 	uint32_t src_type = AT91_AIC_SMR_HIGH_LEVEL;
 
@@ -131,7 +131,7 @@ static void saic_disable(struct itr_chip *chip __unused, size_t it)
 }
 
 static const struct itr_ops saic_ops = {
-	.add = saic_add,
+	.configure = saic_configure,
 	.mask = saic_disable,
 	.unmask = saic_enable,
 	.enable = saic_enable,

--- a/core/drivers/hfic.c
+++ b/core/drivers/hfic.c
@@ -37,8 +37,8 @@ struct hfic_data {
 
 static struct hfic_data hfic_data __nex_bss;
 
-static void hfic_op_add(struct itr_chip *chip __unused, size_t it,
-			uint32_t type __unused, uint32_t prio __unused)
+static void hfic_op_configure(struct itr_chip *chip __unused, size_t it,
+			      uint32_t type __unused, uint32_t prio __unused)
 {
 	uint32_t res __maybe_unused = 0;
 
@@ -66,7 +66,7 @@ static void hfic_op_disable(struct itr_chip *chip __unused, size_t it)
 }
 
 static const struct itr_ops hfic_ops = {
-	.add = hfic_op_add,
+	.configure = hfic_op_configure,
 	.mask = hfic_op_disable,
 	.unmask = hfic_op_enable,
 	.enable = hfic_op_enable,

--- a/core/drivers/plic.c
+++ b/core/drivers/plic.c
@@ -153,9 +153,8 @@ static void plic_complete_interrupt(struct plic_data *pd, uint32_t source)
 	io_write32(PLIC_CLAIM(pd->plic_base, context), source);
 }
 
-static void plic_op_add(struct itr_chip *chip, size_t it,
-			uint32_t type __unused,
-			uint32_t prio)
+static void plic_op_configure(struct itr_chip *chip, size_t it,
+			      uint32_t type __unused, uint32_t prio)
 {
 	struct plic_data *pd = container_of(chip, struct plic_data, chip);
 
@@ -219,7 +218,7 @@ static size_t probe_max_it(vaddr_t plic_base __unused)
 }
 
 static const struct itr_ops plic_ops = {
-	.add = plic_op_add,
+	.configure = plic_op_configure,
 	.mask = plic_op_disable,
 	.unmask = plic_op_enable,
 	.enable = plic_op_enable,

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -305,7 +305,7 @@ static inline void interrupt_raise_sgi(struct itr_chip *chip, size_t itr_num,
 /*
  * interrupt_set_affinity() - Set CPU affinity for a controller interrupt
  * @chip	Interrupt controller
- * @itr_num	Interrupt number to raise
+ * @itr_num	Interrupt number
  * @cpu_mask	Mask of the CPUs targeted by the interrupt
  */
 static inline void interrupt_set_affinity(struct itr_chip *chip, size_t itr_num,

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -50,7 +50,7 @@ struct itr_chip {
 
 /*
  * struct itr_ops - Interrupt controller operations
- * @add		Register and configure an interrupt
+ * @configure	Configure an interrupt
  * @enable	Enable an interrupt
  * @disable	Disable an interrupt
  * @mask	Mask an interrupt, may be called from an interrupt context
@@ -59,12 +59,13 @@ struct itr_chip {
  * @raise_sgi	Raise a SGI or NULL if not applicable to that controller
  * @set_affinity Set interrupt/cpu affinity or NULL if not applicable
  *
- * Handlers @enable, @disable, @mask, @unmask and @add are mandated. Handlers
- * @mask and @unmask have unpaged memory contrainsts. See itr_chip_is_valid().
+ * Handlers @enable, @disable, @mask, @unmask and @configure are mandated.
+ * Handlers @mask and @unmask have unpaged memory constraints.
+ * See itr_chip_is_valid().
  */
 struct itr_ops {
-	void (*add)(struct itr_chip *chip, size_t it, uint32_t type,
-		    uint32_t prio);
+	void (*configure)(struct itr_chip *chip, size_t it, uint32_t type,
+			  uint32_t prio);
 	void (*enable)(struct itr_chip *chip, size_t it);
 	void (*disable)(struct itr_chip *chip, size_t it);
 	void (*mask)(struct itr_chip *chip, size_t it);
@@ -133,7 +134,7 @@ static inline bool itr_chip_is_valid(struct itr_chip *chip)
 	       chip->ops->mask && is_unpaged(chip->ops->mask) &&
 	       chip->ops->unmask && is_unpaged(chip->ops->unmask) &&
 	       chip->ops->enable && chip->ops->disable &&
-	       chip->ops->add;
+	       chip->ops->configure;
 }
 
 /*

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -43,6 +43,10 @@ struct itr_chip {
 	 * @type If not NULL, output interrupt type (IRQ_TYPE_* defines)
 	 * or IRQ_TYPE_NONE if unknown
 	 * @prio If not NULL, output interrupt priority value or 0 if unknown
+	 *
+	 * This handler is required to support dt_get_irq_type_prio() and
+	 * dt_get_irq() API function for interrupt consumers manually
+	 * retrieving trigger type and/or priority from the device tree.
 	 */
 	int (*dt_get_irq)(const uint32_t *properties, int count, uint32_t *type,
 			  uint32_t *prio);

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -105,7 +105,7 @@ void interrupt_call_handlers(struct itr_chip *chip, size_t itr_num)
 TEE_Result interrupt_configure(struct itr_chip *chip, size_t itr_num,
 			       uint32_t type, uint32_t prio)
 {
-	chip->ops->add(chip, itr_num, type, prio);
+	chip->ops->configure(chip, itr_num, type, prio);
 
 	return TEE_SUCCESS;
 }

--- a/core/kernel/interrupt.c
+++ b/core/kernel/interrupt.c
@@ -200,7 +200,7 @@ TEE_Result interrupt_create_handler(struct itr_chip *itr_chip, size_t itr_num,
 		.data = priv,
 	};
 
-	res = add_configure_handler(itr_hdl, 0, 0, false /* configure */);
+	res = add_configure_handler(itr_hdl, 0, 0, false /* !configure */);
 	if (res) {
 		free(itr_hdl);
 		return res;


### PR DESCRIPTION
Rename field `add` of `struct itr_ops` to `configure` for consistency since that handler is used the configure the interrupt. Update existing interrupt drivers accordingly.

That `configure` handler is not required for interrupt providers which consumer only use the DT to get and configure their interrupts (with `interrupt_dt_get_by_*()` and `interrupt_create_handler()`). Therefore change `itr_chip_is_valid()` to not enforce its support but add back that constraint for the interrupt main controller.

Plus few minor changes in inline comments in interrupt.h and interrupt.c.