### PR TITLE
core: mm: initialize max_allocated size in pool init function

### DIFF
--- a/core/mm/tee_mm.c
+++ b/core/mm/tee_mm.c
@@ -68,6 +68,10 @@ bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_size_t size,
 	pool->entry->pool = pool;
 	pool->lock = SPINLOCK_UNLOCK;
 
+#ifdef CFG_WITH_STATS
+	pool->max_allocated = 0;
+#endif
+
 	return true;
 }
 


### PR DESCRIPTION
The TA max_allocated size obtained from stat PTA is incorrect. Pool max_allocated size is not initialized.
Initialize max_allocated size in pool init function.

Change-Id: Ia26c2a9dcc9692d6b4201b9aaea59c24de4a70f4

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
