### PR TITLE
AMD mailbox driver support

### DIFF
--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -53,6 +53,13 @@ CFG_TZDRAM_SIZE    ?= 0x8000000
 # 1 : UART1[pl011_1]
 CFG_CONSOLE_UART ?= 0
 
+# MailBox Service configurations
+CFG_MAILBOX_DRIVER ?= n
+
+ifeq ($(CFG_MAILBOX_DRIVER),y)
+CFG_MAILBOX_LOCAL_ID ?= 3
+endif
+
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,43)

--- a/core/arch/arm/plat-versal2/plat_ipi.h
+++ b/core/arch/arm/plat-versal2/plat_ipi.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+#ifndef PLAT_IPI_H
+#define PLAT_IPI_H
+
+#define PLAT_IPI_BASE_ADDR	0xEB3F0000
+
+#define PLAT_SMC_SIP_IPI	0xC2001000
+
+#endif /* PLAT_IPI_H */

--- a/core/arch/arm/plat-versal2/platform_config.h
+++ b/core/arch/arm/plat-versal2/platform_config.h
@@ -7,6 +7,7 @@
 #define PLATFORM_CONFIG_H
 
 #include <mm/generic_ram_layout.h>
+#include "plat_ipi.h"
 
 /* Make stacks aligned to data cache line length */
 #define CACHELINE_LEN		64

--- a/core/drivers/amd/include/mailbox_private.h
+++ b/core/drivers/amd/include/mailbox_private.h
@@ -7,6 +7,43 @@
 #ifndef __AMD_MAILBOX_PRIVATE_H__
 #define __AMD_MAILBOX_PRIVATE_H__
 
+#include <kernel/mutex.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+#include <util.h>
+
+#define IPI_BASE_MULTIPLIER             U(0x200)
+#define IPI_OFFSET_MULTIPLIER           U(0x40)
+
+#define IPI_BUFFER_MAX_WORDS            8
+
+#define IPI_REQ_OFFSET                  U(0x0)
+#define IPI_RESP_OFFSET                 U(0x20)
+
+enum mailbox_api {
+	/* IPI mailbox operations functions: */
+	IPI_MAILBOX_OPEN = 0,
+	IPI_MAILBOX_RELEASE,
+	IPI_MAILBOX_STATUS_ENQUIRY,
+	IPI_MAILBOX_NOTIFY,
+	IPI_MAILBOX_ACK,
+	IPI_MAILBOX_ENABLE_IRQ,
+	IPI_MAILBOX_DISABLE_IRQ
+};
+
+struct ipi_info {
+	uint32_t local;
+	uint32_t remote;
+
+	paddr_t buf;
+
+	/* Exclusive access to the IPI shared buffer */
+	struct mutex lock;
+
+	void *rsp;
+	void *req;
+};
+
 #define IPI_BASE_MULTIPLIER             U(0x200)
 #define IPI_OFFSET_MULTIPLIER           U(0x40)
 

--- a/core/drivers/amd/include/mailbox_private.h
+++ b/core/drivers/amd/include/mailbox_private.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#ifndef __MAILBOX_PRIVATE_H__
+#define __MAILBOX_PRIVATE_H__
+
+#define IPI_BASE_MULTIPLIER             0x200U
+#define IPI_OFFSET_MULTIPLIER           0x40U
+
+#define IPI_BUFFER_MAX_WORDS            8
+
+#define IPI_REQ_OFFSET                  0x0U
+#define IPI_RESP_OFFSET                 0x20U
+
+#endif /* __MAILBOX_PRIVATE_H__ */

--- a/core/drivers/amd/include/mailbox_private.h
+++ b/core/drivers/amd/include/mailbox_private.h
@@ -4,15 +4,15 @@
  *
  */
 
-#ifndef __MAILBOX_PRIVATE_H__
-#define __MAILBOX_PRIVATE_H__
+#ifndef __AMD_MAILBOX_PRIVATE_H__
+#define __AMD_MAILBOX_PRIVATE_H__
 
-#define IPI_BASE_MULTIPLIER             0x200U
-#define IPI_OFFSET_MULTIPLIER           0x40U
+#define IPI_BASE_MULTIPLIER             U(0x200)
+#define IPI_OFFSET_MULTIPLIER           U(0x40)
 
 #define IPI_BUFFER_MAX_WORDS            8
 
-#define IPI_REQ_OFFSET                  0x0U
-#define IPI_RESP_OFFSET                 0x20U
+#define IPI_REQ_OFFSET                  U(0x0)
+#define IPI_RESP_OFFSET                 U(0x20)
 
-#endif /* __MAILBOX_PRIVATE_H__ */
+#endif /* __AMD_MAILBOX_PRIVATE_H__ */

--- a/core/drivers/amd/mailbox_driver.c
+++ b/core/drivers/amd/mailbox_driver.c
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+#include <initcall.h>
+#include <kernel/delay.h>
+#include <kernel/panic.h>
+#include <malloc.h>
+#include <mm/core_mmu.h>
+#include <string.h>
+#include <tee/cache.h>
+
+#include <mailbox_private.h>
+
+#include <drivers/amd/mailbox_driver.h>
+
+static struct ipi_info_t ipi_info;
+
+static TEE_Result mailbox_call(enum mailbox_api ipi_api, uint32_t blocking)
+{
+	struct thread_smc_args args = {
+		.a0 = PLAT_SMC_SIP_IPI | ipi_api,
+		.a1 = reg_pair_to_64(0, ipi_info.local),
+		.a2 = reg_pair_to_64(0, ipi_info.remote),
+		.a3 = reg_pair_to_64(0, blocking),
+	};
+
+	thread_smccc(&args);
+
+	if (args.a0) {
+		EMSG("Mailbox Call returned with error 0x%lx", args.a0);
+		return TEE_ERROR_GENERIC;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result mailbox_open(uint32_t remote_id, size_t payload_size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	ipi_info.remote = remote_id;
+
+	paddr_t req_addr = (ipi_info.buf + (remote_id * IPI_OFFSET_MULTIPLIER) +
+			IPI_REQ_OFFSET);
+
+	paddr_t rsp_addr = (ipi_info.buf + (remote_id * IPI_OFFSET_MULTIPLIER) +
+			IPI_RESP_OFFSET);
+
+	ipi_info.req = core_mmu_add_mapping(MEM_AREA_RAM_SEC,
+					    req_addr,
+					    payload_size);
+
+	ipi_info.rsp = core_mmu_add_mapping(MEM_AREA_RAM_SEC,
+					    rsp_addr,
+					    payload_size);
+	if (!ipi_info.req || !ipi_info.rsp)
+		panic();
+
+	mutex_lock(&ipi_info.lock);
+
+	res = mailbox_call(IPI_MAILBOX_OPEN, IPI_BLOCK);
+	if (res != TEE_SUCCESS)
+		EMSG("Failed to open Mailbox for remote id %d", remote_id);
+
+	mutex_unlock(&ipi_info.lock);
+
+	return res;
+}
+
+TEE_Result mailbox_release(uint32_t remote_id, size_t payload_size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (ipi_info.remote != remote_id) {
+		EMSG("Mailbox not available for remote id %d", remote_id);
+		return res;
+	}
+
+	mutex_lock(&ipi_info.lock);
+
+	res = mailbox_call(IPI_MAILBOX_RELEASE, IPI_BLOCK);
+	if (res != TEE_SUCCESS) {
+		EMSG("Mailbox release failed for remote id %d", remote_id);
+		goto err;
+	}
+
+	res = core_mmu_remove_mapping(MEM_AREA_RAM_SEC,
+				      ipi_info.req,
+				      payload_size);
+	res |= core_mmu_remove_mapping(MEM_AREA_RAM_SEC,
+				       ipi_info.rsp,
+				       payload_size);
+	if (res != TEE_SUCCESS) {
+		EMSG("Failed to remove memory mappings for remote id %d",
+		     remote_id);
+	}
+
+err:
+	mutex_unlock(&ipi_info.lock);
+	return res;
+}
+
+static TEE_Result mailbox_write(uint32_t remote_id,
+				void *payload,
+				size_t payload_size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (ipi_info.remote != remote_id) {
+		EMSG("Mailbox not available for remote id %d", remote_id);
+		goto err;
+	}
+
+	if (!IS_ALIGNED((uintptr_t)payload, CACHELINE_LEN)) {
+		EMSG("payload address not aligned");
+		goto err;
+	}
+
+	if (!IS_ALIGNED(payload_size, CACHELINE_LEN)) {
+		EMSG("payload size not aligned");
+		goto err;
+	}
+
+	memcpy(ipi_info.req, payload, payload_size);
+
+	cache_operation(TEE_CACHEFLUSH, ipi_info.req, payload_size);
+
+	res = TEE_SUCCESS;
+err:
+	return res;
+}
+
+static TEE_Result mailbox_read(uint32_t remote_id,
+			       void *payload,
+			       size_t payload_size,
+			       uint32_t *status)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	cache_operation(TEE_CACHEINVALIDATE, ipi_info.rsp, payload_size);
+
+	*status = *(uint32_t *)ipi_info.rsp;
+
+	if (*status)
+		goto err;
+
+	if (ipi_info.rsp) {
+		memcpy(ipi_info.rsp, payload, payload_size);
+		res = TEE_SUCCESS;
+	}
+
+err:
+	return res;
+}
+
+TEE_Result mailbox_notify(uint32_t remote_id,
+			  void *payload,
+			  size_t payload_size,
+			  uint32_t blocking)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t remote_status = 0;
+
+	if (ipi_info.remote != remote_id) {
+		EMSG("Mailbox not available for remote id %d", remote_id);
+		return res;
+	}
+
+	mutex_lock(&ipi_info.lock);
+
+	res = mailbox_write(ipi_info.remote, payload, payload_size);
+	if (res) {
+		EMSG("Can't write the request command");
+		goto out;
+	}
+
+	res = mailbox_call(IPI_MAILBOX_NOTIFY, blocking);
+	if (res) {
+		EMSG("IPI error");
+		goto out;
+	}
+
+	res = mailbox_read(ipi_info.remote, payload,
+			   payload_size, &remote_status);
+	if (res)
+		EMSG("Can't read the remote response");
+
+	if (remote_status)
+		res = TEE_ERROR_GENERIC;
+
+out:
+	mutex_unlock(&ipi_info.lock);
+	return res;
+}
+
+static TEE_Result mailbox_init(void)
+{
+	ipi_info.local = CFG_MAILBOX_LOCAL_ID;
+	ipi_info.buf = (PLAT_IPI_BASE_ADDR +
+			(CFG_MAILBOX_LOCAL_ID * IPI_BASE_MULTIPLIER));
+
+	mutex_init(&ipi_info.lock);
+
+	DMSG("Initialized AMD Mailbox Service for Local ID %d", ipi_info.local);
+
+	return TEE_SUCCESS;
+}
+
+service_init_late(mailbox_init);

--- a/core/drivers/amd/sub.mk
+++ b/core/drivers/amd/sub.mk
@@ -1,0 +1,10 @@
+
+incdirs-y += include
+
+ifeq ($(CFG_MAILBOX_DRIVER),y)
+ifeq ($(CFG_MAILBOX_LOCAL_ID),)
+$(error error: CFG_MAILBOX_LOCAL_ID not set for $(PLATFORM) $(PLATFORM_FLAVOR))
+endif
+endif
+
+srcs-$(CFG_MAILBOX_DRIVER) += mailbox_driver.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -107,3 +107,4 @@ subdirs-y += wdt
 subdirs-y += rtc
 subdirs-y += firewall
 subdirs-y += counter
+subdirs-y += amd

--- a/core/include/drivers/amd/mailbox_driver.h
+++ b/core/include/drivers/amd/mailbox_driver.h
@@ -4,11 +4,12 @@
  *
  */
 
-#ifndef __MAILBOX_DRIVER_H__
-#define __MAILBOX_DRIVER_H__
+#ifndef __AMD_MAILBOX_DRIVER_H__
+#define __AMD_MAILBOX_DRIVER_H__
 
-#include <platform_config.h>
+#include <kernel/mutex.h>
 #include <tee_api_types.h>
+#include <types_ext.h>
 #include <util.h>
 
 enum mailbox_api {
@@ -22,8 +23,8 @@ enum mailbox_api {
 	IPI_MAILBOX_DISABLE_IRQ
 };
 
-#define IPI_NON_BLOCK	0x0U
-#define IPI_BLOCK	0x1U
+#define IPI_NON_BLOCK	U(0x0)
+#define IPI_BLOCK	U(0x1)
 
 struct ipi_info_t {
 	uint32_t local;
@@ -43,4 +44,4 @@ TEE_Result mailbox_release(uint32_t remote_id, size_t payload_size);
 TEE_Result mailbox_notify(uint32_t remote_id, void *payload,
 			  size_t payload_size, uint32_t blocking);
 
-#endif /* __MAILBOX_DRIVER_H__ */
+#endif /* __AMD_MAILBOX_DRIVER_H__ */

--- a/core/include/drivers/amd/mailbox_driver.h
+++ b/core/include/drivers/amd/mailbox_driver.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#ifndef __MAILBOX_DRIVER_H__
+#define __MAILBOX_DRIVER_H__
+
+#include <platform_config.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+enum mailbox_api {
+	/* IPI mailbox operations functions: */
+	IPI_MAILBOX_OPEN = 0x1000,
+	IPI_MAILBOX_RELEASE,
+	IPI_MAILBOX_STATUS_ENQUIRY,
+	IPI_MAILBOX_NOTIFY,
+	IPI_MAILBOX_ACK,
+	IPI_MAILBOX_ENABLE_IRQ,
+	IPI_MAILBOX_DISABLE_IRQ
+};
+
+#define IPI_NON_BLOCK	0x0U
+#define IPI_BLOCK	0x1U
+
+struct ipi_info_t {
+	uint32_t local;
+	uint32_t remote;
+
+	paddr_t buf;
+
+	/* Exclusive access to the IPI shared buffer */
+	struct mutex lock;
+
+	void *rsp;
+	void *req;
+};
+
+TEE_Result mailbox_open(uint32_t remote_id, size_t payload_size);
+TEE_Result mailbox_release(uint32_t remote_id, size_t payload_size);
+TEE_Result mailbox_notify(uint32_t remote_id, void *payload,
+			  size_t payload_size, uint32_t blocking);
+
+#endif /* __MAILBOX_DRIVER_H__ */

--- a/core/include/drivers/amd/mailbox_driver.h
+++ b/core/include/drivers/amd/mailbox_driver.h
@@ -7,37 +7,12 @@
 #ifndef __AMD_MAILBOX_DRIVER_H__
 #define __AMD_MAILBOX_DRIVER_H__
 
-#include <kernel/mutex.h>
 #include <tee_api_types.h>
 #include <types_ext.h>
 #include <util.h>
 
-enum mailbox_api {
-	/* IPI mailbox operations functions: */
-	IPI_MAILBOX_OPEN = 0x1000,
-	IPI_MAILBOX_RELEASE,
-	IPI_MAILBOX_STATUS_ENQUIRY,
-	IPI_MAILBOX_NOTIFY,
-	IPI_MAILBOX_ACK,
-	IPI_MAILBOX_ENABLE_IRQ,
-	IPI_MAILBOX_DISABLE_IRQ
-};
-
 #define IPI_NON_BLOCK	U(0x0)
 #define IPI_BLOCK	U(0x1)
-
-struct ipi_info_t {
-	uint32_t local;
-	uint32_t remote;
-
-	paddr_t buf;
-
-	/* Exclusive access to the IPI shared buffer */
-	struct mutex lock;
-
-	void *rsp;
-	void *req;
-};
 
 TEE_Result mailbox_open(uint32_t remote_id, size_t payload_size);
 TEE_Result mailbox_release(uint32_t remote_id, size_t payload_size);


### PR DESCRIPTION
Add support for the AMD Mailbox Service for use on AMD platforms.
The Mailbox Service requires the Local IPI ID as a mandatory input,
provided via CFG_MAILBOX_LOCAL_ID.
Mailbox initialization for CFG_MAILBOX_LOCAL_ID occurs as a late init
service and will be utilized by various drivers to communicate with other
firmware.
The remote ID will be supplied by different drivers using the mailbox
service.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
