### PR TITLE
mk/compile.mk: fix dependency in .d file when removing a header file

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -123,7 +123,7 @@ comp-cppflags-$2 = $$(filter-out $$(CPPFLAGS_REMOVE) $$(cppflags-remove) \
 		      $$(cppflags-lib$$(comp-lib-$2)) $$(cppflags-$2)) \
 		      -D__FILE_ID__=$$(subst -,_,$$(subst /,_,$$(subst .,_,$$(patsubst $$(out-dir)/%,%,$1))))
 
-comp-flags-$2 += -MD -MF $$(comp-dep-$2) -MT $$@
+comp-flags-$2 += -MD -MF $$(comp-dep-$2) -MP -MT $$@
 comp-flags-$2 += $$(comp-cppflags-$2)
 
 comp-cmd-$2 = $$(comp-compiler-$2) $$(comp-flags-$2) -c $$< -o $$@


### PR DESCRIPTION
Hello,

During tests in our CI we found that the dependency for header file is not correctly managed.
When we remove a header file and it's include from a source file without deleting the build directory the build fails.

You can reproduce the use case by building stm32mp135f-dk on `539836f97 core: arm: virt-aware FF-A thread_foreign_intr_exit()`
And then build `7d9d593df drivers: firewall: stm32_etzpc: remove header file` which remove `stm32_etzpc.h`

With @etienne-lms we found the option `-MP` in gcc and it fix the issue (you need to have the patch for the first build)
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
