### PR TITLE
core: fix panic with TEE_SDP_TEST_MEM

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -681,6 +681,16 @@ static void verify_special_mem_areas(struct memory_map *mem_map,
 	 */
 	for (mem = start; mem < end; mem++) {
 		for (n = 0; n < mem_map->count; n++) {
+#ifdef TEE_SDP_TEST_MEM_BASE
+			/*
+			 * Ignore MEM_AREA_SEC_RAM_OVERALL since it covers
+			 * TEE_SDP_TEST_MEM too.
+			 */
+			if (mem->addr == TEE_SDP_TEST_MEM_BASE &&
+			    mem->size == TEE_SDP_TEST_MEM_SIZE &&
+			    mem_map->map[n].type == MEM_AREA_SEC_RAM_OVERALL)
+				continue;
+#endif
 			if (core_is_buffer_intersect(mem->addr, mem->size,
 						     mem_map->map[n].pa,
 						     mem_map->map[n].size)) {
@@ -2776,7 +2786,7 @@ void core_mmu_init_phys_mem(void)
 		/* Carve out test SDP memory */
 #ifdef TEE_SDP_TEST_MEM_BASE
 		if (TEE_SDP_TEST_MEM_SIZE) {
-			pa = vaddr_to_phys(TEE_SDP_TEST_MEM_BASE);
+			pa = TEE_SDP_TEST_MEM_BASE;
 			carve_out_core_mem(pa, pa + TEE_SDP_TEST_MEM_SIZE);
 		}
 #endif


### PR DESCRIPTION
The commit 2f2f69df5afe ("core: mm: replace MEM_AREA_TA_RAM") uses MEM_AREA_SEC_RAM_OVERALL to map practically all secure memory. This conflicts with TEE_SDP_TEST_MEM:
1. MEM_AREA_SEC_RAM_OVERALL covers TEE_SDP_TEST_MEM and triggers a panic in verify_special_mem_areas().
2. TEE_SDP_TEST_MEM_BASE refers to physical memory only since it's only mapped in MEM_AREA_SEC_RAM_OVERALL.

So fix these problems.

Fixes: 2f2f69df5afe ("core: mm: replace MEM_AREA_TA_RAM")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
