### PR TITLE
core: mmu: Add dynamic VA regions' mapping to page table

### DIFF
--- a/core/arch/arm/mm/core_mmu_lpae.c
+++ b/core/arch/arm/mm/core_mmu_lpae.c
@@ -803,8 +803,7 @@ static void core_init_mmu_prtn_tee(struct mmu_partition *prtn,
 	memset(prtn->base_tables, 0, BASE_TABLE_SIZE * CFG_TEE_CORE_NB_CORE);
 
 	for (n = 0; n < mem_map->count; n++)
-		if (!core_mmu_is_dynamic_vaspace(mem_map->map + n))
-			core_mmu_map_region(prtn, mem_map->map + n);
+		core_mmu_map_region(prtn, mem_map->map + n);
 
 	/*
 	 * Primary mapping table is ready at index `get_core_pos()`

--- a/core/arch/arm/mm/core_mmu_v7.c
+++ b/core/arch/arm/mm/core_mmu_v7.c
@@ -781,8 +781,7 @@ void core_init_mmu_prtn(struct mmu_partition *prtn, struct memory_map *mem_map)
 	memset(ttb1, 0, L1_TBL_SIZE);
 
 	for (n = 0; n < mem_map->count; n++)
-		if (!core_mmu_is_dynamic_vaspace(mem_map->map + n))
-			core_mmu_map_region(prtn, mem_map->map + n);
+		core_mmu_map_region(prtn, mem_map->map + n);
 }
 
 void core_init_mmu(struct memory_map *mem_map)

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -308,8 +308,7 @@ static void core_init_mmu_prtn_tee(struct mmu_partition *prtn,
 	memset(prtn->pool_pgts, 0, RISCV_MMU_MAX_PGTS * RISCV_MMU_PGT_SIZE);
 
 	for (n = 0; n < mem_map->count; n++)
-		if (!core_mmu_is_dynamic_vaspace(mem_map->map + n))
-			core_mmu_map_region(prtn, mem_map->map + n);
+		core_mmu_map_region(prtn, mem_map->map + n);
 
 	/*
 	 * Primary mapping table is ready at index `get_core_pos()`

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1976,7 +1976,14 @@ void core_mmu_map_region(struct mmu_partition *prtn, struct tee_mmap_region *mm)
 				panic("Page is already mapped");
 
 			core_mmu_set_entry(&tbl_info, idx, paddr, mm->attr);
-			paddr += block_size;
+			/*
+			 * Dynamic vaspace regions don't have a physical
+			 * address initially but we need to allocate and
+			 * initialize the translation tables now for later
+			 * updates to work properly.
+			 */
+			if (paddr)
+				paddr += block_size;
 			vaddr += block_size;
 			size_left -= block_size;
 


### PR DESCRIPTION
When optee boots, the initial mapping for MEM_AREA_RES_VASPACE and MEM_AREA_SHM_VASPACE should be added into page tables and replicated to all CPU cores too. This fixes an issue when the VA of MEM_AREA_RES_VASPACE or MEM_AREA_SHM_VASPACE is not in a same 1GB region with other memory regions.

Link: https://github.com/OP-TEE/optee_os/issues/7275


<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
