### PR TITLE
riscv: plat-virt: Let CFG_RISCV_PLIC be build time configurable

### DIFF
--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -26,9 +26,11 @@ CFG_TEE_CORE_NB_CORE ?= 1
 CFG_NUM_THREADS ?= 1
 $(call force,CFG_BOOT_SYNC_CPU,n)
 
+# Interrupt controller
+CFG_RISCV_PLIC ?= y
+
 $(call force,CFG_RISCV_M_MODE,n)
 $(call force,CFG_RISCV_S_MODE,y)
-$(call force,CFG_RISCV_PLIC,y)
 $(call force,CFG_SBI_CONSOLE,n)
 $(call force,CFG_16550_UART,y)
 $(call force,CFG_RISCV_TIME_SOURCE_RDTIME,y)


### PR DESCRIPTION
RISC-V has several standard interrupt controllers supported by QEMU virtual platform. For example: PLIC, APLIC, IMSIC, etc.
This commit removes enforcement of `CFG_RISCV_PLIC` so that `CFG_RISCV_PLIC` can be build time configurable for developer.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
