### PR TITLE
riscv: plat-virt: Let console devices be build time configurable

### DIFF
--- a/core/arch/riscv/plat-virt/conf.mk
+++ b/core/arch/riscv/plat-virt/conf.mk
@@ -29,10 +29,12 @@ $(call force,CFG_BOOT_SYNC_CPU,n)
 # Interrupt controller
 CFG_RISCV_PLIC ?= y
 
+# Console device
+CFG_RISCV_SBI_CONSOLE ?= n
+CFG_16550_UART ?= y
+
 $(call force,CFG_RISCV_M_MODE,n)
 $(call force,CFG_RISCV_S_MODE,y)
-$(call force,CFG_SBI_CONSOLE,n)
-$(call force,CFG_16550_UART,y)
 $(call force,CFG_RISCV_TIME_SOURCE_RDTIME,y)
 CFG_RISCV_MTIME_RATE ?= 10000000
 CFG_RISCV_SBI ?= y

--- a/core/arch/riscv/plat-virt/main.c
+++ b/core/arch/riscv/plat-virt/main.c
@@ -10,12 +10,12 @@
 #include <kernel/tee_common_otp.h>
 #include <platform_config.h>
 
+#ifdef CFG_16550_UART
 static struct ns16550_data console_data __nex_bss;
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, UART0_BASE, CORE_MMU_PGDIR_SIZE);
+#endif
 
 register_ddr(DRAM_BASE, DRAM_SIZE);
-
-register_phys_mem_pgdir(MEM_AREA_IO_NSEC, UART0_BASE,
-			CORE_MMU_PGDIR_SIZE);
 
 #ifdef CFG_RISCV_PLIC
 void boot_primary_init_intc(void)
@@ -29,11 +29,13 @@ void boot_secondary_init_intc(void)
 }
 #endif /* CFG_RISCV_PLIC */
 
+#ifdef CFG_16550_UART
 void plat_console_init(void)
 {
 	ns16550_init(&console_data, UART0_BASE, IO_WIDTH_U8, 0);
 	register_serial_console(&console_data.chip);
 }
+#endif
 
 void interrupt_main_handler(void)
 {


### PR DESCRIPTION
Currently RISC-V virtual platform enforces 16550 UART to be console device. However, there are other console devices which can be chose by developer. Thus, we allow the configurations for console device to be overridden at build time while keeping the default value enabled.

Besides, fix CFG_SBI_CONSOLE to be CFG_RISCV_SBI_CONSOLE.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
