### PR TITLE
drivers: stm32_remote_proc: fix definition of stm32_rproc_compat_data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,7 @@ jobs:
           _make PLATFORM=stm32mp1
           _make PLATFORM=stm32mp1-135F_DK CFG_DRIVERS_CLK_PRINT_TREE=y CFG_DRIVERS_REGULATOR_PRINT_TREE=y
           _make PLATFORM=stm32mp1-135F_DK COMPILER=clang
+          _make PLATFORM=stm32mp1 CFG_STM32MP1_OPTEE_IN_SYSRAM=y CFG_STM32MP_REMOTEPROC=y
           if [ -d $HOME/scp-firmware ]; then _make PLATFORM=stm32mp1-157C_DK2 CFG_SCMI_SCPFW=y CFG_SCP_FIRMWARE=$HOME/scp-firmware; fi
           _make PLATFORM=stm32mp2
           _make PLATFORM=vexpress-fvp

--- a/core/drivers/remoteproc/stm32_remoteproc.c
+++ b/core/drivers/remoteproc/stm32_remoteproc.c
@@ -43,7 +43,6 @@ struct stm32_rproc_mem {
  * @regions:	memory regions used
  * @mcu_rst:	remote processor reset control
  * @hold_boot:	remote processor hold boot control
- * @ns_loading: True if supports non-secure firmware loading, false otherwise
  */
 struct stm32_rproc_instance {
 	const struct stm32_rproc_compat_data *cdata;
@@ -52,16 +51,17 @@ struct stm32_rproc_instance {
 	struct stm32_rproc_mem *regions;
 	struct rstctrl *mcu_rst;
 	struct rstctrl *hold_boot;
-	bool ns_loading;
 };
 
 /**
  * struct stm32_rproc_compat_data - rproc associated data for compatible list
  *
  * @rproc_id:	identifies the remote processor
+ * @ns_loading: True if supports non-secure firmware loading, false otherwise
  */
 struct stm32_rproc_compat_data {
 	uint32_t rproc_id;
+	bool ns_loading;
 };
 
 static SLIST_HEAD(, stm32_rproc_instance) rproc_list =


### PR DESCRIPTION
Fix compilation error of core/drivers/remoteproc/stm32_remoteproc.c Move bool ns_loading from "struct stm32_rproc_instance" to "struct stm32_rproc_compat_data".

Fixes: a03044318866 ("drivers: stm32_remote_proc: add stm32_rproc_is_secure()")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
