### PR TITLE
RISC-V: Minor update RISC-V boot stages

### DIFF
--- a/core/arch/arm/kernel/link_dummies_paged.c
+++ b/core/arch/arm/kernel/link_dummies_paged.c
@@ -31,10 +31,6 @@ void __section(".text.dummy.call_driver_initcalls") call_driver_initcalls(void)
 {
 }
 
-void __section(".text.dummy.call_initcalls") call_initcalls(void)
-{
-}
-
 void __section(".text.dummy.call_finalcalls") call_finalcalls(void)
 {
 }

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -91,7 +91,8 @@ void init_tee_runtime(void)
 {
 	core_mmu_init_phys_mem();
 	call_preinitcalls();
-	call_initcalls();
+	call_early_initcalls();
+	call_service_initcalls();
 }
 
 static void init_primary(unsigned long nsec_entry)
@@ -155,6 +156,7 @@ void boot_init_primary_late(unsigned long fdt,
 
 void __weak boot_init_primary_final(void)
 {
+	call_driver_initcalls();
 	call_finalcalls();
 	IMSG("Primary CPU initialized");
 

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -151,6 +151,10 @@ void boot_init_primary_late(unsigned long fdt,
 	IMSG("Primary CPU initializing");
 	boot_primary_init_intc();
 	init_tee_runtime();
+}
+
+void __weak boot_init_primary_final(void)
+{
 	call_finalcalls();
 	IMSG("Primary CPU initialized");
 

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -225,6 +225,7 @@ UNWIND(	.cantunwind)
 	mv	a0, s1		/* s1 contains saved device tree address */
 	mv	a1, x0		/* unused */
 	jal	boot_init_primary_late
+	jal	boot_init_primary_final
 
 	/*
 	 * After returning from boot_init_primary_late(), the flag and sp are

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -143,7 +143,6 @@ void call_preinitcalls(void);
 void call_early_initcalls(void);
 void call_service_initcalls(void);
 void call_driver_initcalls(void);
-void call_initcalls(void);
 void call_finalcalls(void);
 
 #endif

--- a/core/kernel/initcall.c
+++ b/core/kernel/initcall.c
@@ -68,17 +68,6 @@ void __weak call_driver_initcalls(void)
  * Note: this function is weak just to make it possible to exclude it from
  * the unpaged area.
  */
-void __weak call_initcalls(void)
-{
-	call_early_initcalls();
-	call_service_initcalls();
-	call_driver_initcalls();
-}
-
-/*
- * Note: this function is weak just to make it possible to exclude it from
- * the unpaged area.
- */
 void __weak call_finalcalls(void)
 {
 	DO_INIT_CALLS(finalcall);


### PR DESCRIPTION
This PR aims to update RISC-V boot stages to be aligned with ARM, introduced in https://github.com/OP-TEE/optee_os/pull/6988.
- Introduce boot_init_primary_final() for RISC-V
- Remove unused call_initcalls()

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
