### PR TITLE
RISC-V: Support boot mem and dynamic allocation of MMU translation tables

### DIFF
--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -87,6 +87,12 @@ void init_tee_runtime(void)
 	call_service_initcalls();
 }
 
+static bool add_padding_to_pool(vaddr_t va, size_t len, void *ptr __unused)
+{
+	malloc_add_pool((void *)va, len);
+	return true;
+}
+
 static void init_primary(unsigned long nsec_entry)
 {
 	vaddr_t va __maybe_unused = 0;
@@ -107,6 +113,7 @@ static void init_primary(unsigned long nsec_entry)
 
 	core_mmu_save_mem_map();
 	core_mmu_init_phys_mem();
+	boot_mem_foreach_padding(add_padding_to_pool, NULL);
 	va = boot_mem_release_unused();
 
 	thread_init_boot_thread();

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -200,6 +200,11 @@ UNWIND(	.cantunwind)
 	jal	plat_primary_init_early
 	jal	console_init
 
+	la	a0, __vcore_free_start
+	la	a1, __vcore_free_end
+	la	a2, __vcore_free_end
+	jal	boot_mem_init
+
 	mv	a0, x0
 	la	a1, boot_mmu_config
 	jal	core_init_mmu_map

--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <bitstring.h>
 #include <config.h>
+#include <kernel/boot.h>
 #include <kernel/cache_helpers.h>
 #include <kernel/misc.h>
 #include <kernel/panic.h>
@@ -15,8 +16,10 @@
 #include <kernel/tlb_helpers.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <mm/phys_mem.h>
 #include <platform_config.h>
 #include <riscv.h>
+#include <stdalign.h>
 #include <stdlib.h>
 #include <string.h>
 #include <trace.h>
@@ -51,6 +54,7 @@ struct mmu_pgt {
 
 #define RISCV_MMU_PGT_SIZE	(sizeof(struct mmu_pgt))
 
+#ifndef CFG_DYN_CONFIG
 static struct mmu_pgt root_pgt[CFG_TEE_CORE_NB_CORE]
 	__aligned(RISCV_PGSIZE)
 	__section(".nozi.mmu.root_pgt");
@@ -60,6 +64,7 @@ static struct mmu_pgt pool_pgts[RISCV_MMU_MAX_PGTS]
 
 static struct mmu_pgt user_pgts[CFG_NUM_THREADS]
 	__aligned(RISCV_PGSIZE) __section(".nozi.mmu.usr_pgts");
+#endif
 
 static int user_va_idx __nex_data = -1;
 
@@ -71,6 +76,9 @@ struct mmu_partition {
 	unsigned int asid;
 };
 
+#ifdef CFG_DYN_CONFIG
+static struct mmu_partition default_partition __nex_bss;
+#else
 static struct mmu_partition default_partition __nex_data  = {
 	.root_pgt = root_pgt,
 	.pool_pgts = pool_pgts,
@@ -78,6 +86,7 @@ static struct mmu_partition default_partition __nex_data  = {
 	.pgts_used = 0,
 	.asid = 0
 };
+#endif
 
 static struct mmu_pte *core_mmu_table_get_entry(struct mmu_pgt *pgt,
 						unsigned int idx)
@@ -265,17 +274,55 @@ static struct mmu_pgt *core_mmu_pgt_alloc(struct mmu_partition *prtn)
 {
 	struct mmu_pgt *pgt = NULL;
 
-	if (prtn->pgts_used >= RISCV_MMU_MAX_PGTS) {
-		debug_print("%u pgts exhausted", RISCV_MMU_MAX_PGTS);
-		panic();
-		return NULL;
+	if (IS_ENABLED(CFG_DYN_CONFIG)) {
+		if (cpu_mmu_enabled()) {
+			tee_mm_entry_t *mm = NULL;
+			paddr_t pa = 0;
+			size_t size = RISCV_MMU_PGT_SIZE;
+
+			if (prtn == core_mmu_get_prtn()) {
+				mm = phys_mem_core_alloc(size);
+				if (!mm)
+					EMSG("Phys mem exhausted");
+			} else {
+				mm = nex_phys_mem_core_alloc(size);
+				if (!mm)
+					EMSG("Phys nex mem exhausted");
+			}
+			if (!mm)
+				return NULL;
+			pa = tee_mm_get_smem(mm);
+
+			pgt = phys_to_virt(pa, MEM_AREA_SEC_RAM_OVERALL,
+					   RISCV_MMU_PGT_SIZE);
+			assert(pgt);
+		} else {
+			pgt = boot_mem_alloc(RISCV_MMU_PGT_SIZE,
+					     RISCV_MMU_PGT_SIZE);
+			if (prtn->pool_pgts) {
+				assert((vaddr_t)prtn->pool_pgts +
+				       prtn->pgts_used *
+				       RISCV_MMU_PGT_SIZE == (vaddr_t)pgt);
+			} else {
+				boot_mem_add_reloc(&prtn->pool_pgts);
+				prtn->pool_pgts = pgt;
+			}
+		}
+		prtn->pgts_used++;
+		DMSG("pgts used %u", prtn->pgts_used);
+	} else {
+		if (prtn->pgts_used >= RISCV_MMU_MAX_PGTS) {
+			debug_print("%u pgts exhausted", RISCV_MMU_MAX_PGTS);
+			return NULL;
+		}
+
+		pgt = &prtn->pool_pgts[prtn->pgts_used++];
+
+		memset(pgt, 0, RISCV_MMU_PGT_SIZE);
+
+		DMSG("pgts used %u / %u", prtn->pgts_used,
+		     RISCV_MMU_MAX_PGTS);
 	}
-
-	pgt = &prtn->pool_pgts[prtn->pgts_used++];
-
-	memset(pgt, 0, RISCV_MMU_PGT_SIZE);
-
-	debug_print("pgts used %u / %u", prtn->pgts_used, RISCV_MMU_MAX_PGTS);
 
 	return pgt;
 }
@@ -347,6 +394,8 @@ static void core_init_mmu_prtn_tee(struct mmu_partition *prtn,
 static struct mmu_pgt *core_mmu_xlat_table_entry_pa2va(struct mmu_pte *pte,
 						       struct mmu_pgt *pgt)
 {
+	struct mmu_pgt *va = NULL;
+
 	if (core_mmu_entry_is_invalid(pte) ||
 	    core_mmu_entry_is_leaf(pte))
 		return NULL;
@@ -354,9 +403,13 @@ static struct mmu_pgt *core_mmu_xlat_table_entry_pa2va(struct mmu_pte *pte,
 	if (!cpu_mmu_enabled())
 		return (struct mmu_pgt *)pte_to_pa(pte);
 
-	return phys_to_virt(pte_to_pa(pte),
-			    MEM_AREA_TEE_RAM_RW_DATA,
-			    sizeof(*pgt));
+	va = phys_to_virt(pte_to_pa(pte), MEM_AREA_TEE_RAM_RW_DATA,
+			  sizeof(*pgt));
+	if (!va)
+		va = phys_to_virt(pte_to_pa(pte), MEM_AREA_SEC_RAM_OVERALL,
+				  sizeof(*pgt));
+
+	return va;
 }
 
 void tlbi_va_range(vaddr_t va, size_t len,
@@ -760,14 +813,24 @@ void core_init_mmu_prtn(struct mmu_partition *prtn, struct memory_map *mem_map)
 
 void core_init_mmu(struct memory_map *mem_map)
 {
+	struct mmu_partition *prtn = &default_partition;
 	uint64_t max_va = 0;
 	size_t n = 0;
 
-	static_assert((RISCV_MMU_MAX_PGTS * RISCV_MMU_PGT_SIZE) ==
-			    sizeof(pool_pgts));
+	if (IS_ENABLED(CFG_DYN_CONFIG)) {
+		prtn->root_pgt = boot_mem_alloc(RISCV_MMU_PGT_SIZE *
+						CFG_TEE_CORE_NB_CORE,
+						RISCV_MMU_PGT_SIZE);
+		boot_mem_add_reloc(&prtn->root_pgt);
+
+		prtn->user_pgts = boot_mem_alloc(RISCV_MMU_PGT_SIZE *
+						 CFG_NUM_THREADS,
+						 RISCV_MMU_PGT_SIZE);
+		boot_mem_add_reloc(&prtn->user_pgts);
+	}
 
 	/* Initialize default pagetables */
-	core_init_mmu_prtn_tee(&default_partition, mem_map);
+	core_init_mmu_prtn_tee(prtn, mem_map);
 
 	for (n = 0; n < mem_map->count; n++) {
 		vaddr_t va_end = mem_map->map[n].va + mem_map->map[n].size - 1;
@@ -776,9 +839,9 @@ void core_init_mmu(struct memory_map *mem_map)
 			max_va = va_end;
 	}
 
-	set_user_va_idx(&default_partition);
+	set_user_va_idx(prtn);
 
-	core_init_mmu_prtn_ta(&default_partition);
+	core_init_mmu_prtn_ta(prtn);
 
 	assert(max_va < BIT64(RISCV_MMU_VA_WIDTH));
 }

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -105,7 +105,6 @@ void discover_nsec_memory(void);
 /* Add reserved memory for static shared memory in the device-tree */
 int mark_static_shm_as_reserved(struct dt_descriptor *dt);
 
-#ifdef CFG_BOOT_MEM
 /*
  * Stack-like memory allocations during boot before a heap has been
  * configured. boot_mem_relocate() performs relocation of the boot memory
@@ -122,19 +121,5 @@ void *boot_mem_alloc(size_t len, size_t align);
 void *boot_mem_alloc_tmp(size_t len, size_t align);
 vaddr_t boot_mem_release_unused(void);
 void boot_mem_release_tmp_alloc(void);
-#else
-static inline void boot_mem_add_reloc(void *ptr __unused) { }
-static inline void
-boot_mem_foreach_padding(bool (*func)(vaddr_t va, size_t len,
-				      void *ptr) __unused,
-			 void *ptr __unused) { }
-static inline void *boot_mem_alloc(size_t len __unused, size_t align __unused)
-{ return NULL; }
-static inline void *boot_mem_alloc_tmp(size_t len __unused,
-				       size_t align __unused)
-{ return NULL; }
-static inline vaddr_t boot_mem_release_unused(void) { return 0; }
-static inline void boot_mem_release_tmp_alloc(void) { }
-#endif
 
 #endif /* __KERNEL_BOOT_H */

--- a/core/include/mm/core_mmu.h
+++ b/core/include/mm/core_mmu.h
@@ -295,10 +295,7 @@ extern const unsigned long core_mmu_tee_load_pa;
 
 void core_init_mmu_map(unsigned long seed, struct core_mmu_config *cfg);
 void core_init_mmu_regs(struct core_mmu_config *cfg);
-/*
- * Copy static memory map from temporary boot_mem to heap when CFG_BOOT_MEM
- * is enabled.
- */
+/* Copy static memory map from temporary boot_mem to heap */
 void core_mmu_save_mem_map(void);
 
 /* Arch specific function to help optimizing 1 MMU xlat table */

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -62,19 +62,7 @@ unsigned long default_nsec_shm_size __nex_bss;
 unsigned long default_nsec_shm_paddr __nex_bss;
 #endif
 
-#ifdef CFG_BOOT_MEM
 static struct memory_map static_memory_map __nex_bss;
-#else
-static struct tee_mmap_region static_mmap_regions[CFG_MMAP_REGIONS
-#if defined(CFG_CORE_ASLR) || defined(CFG_CORE_PHYS_RELOCATABLE)
-						+ 1
-#endif
-						+ 4] __nex_bss;
-static struct memory_map static_memory_map __nex_data = {
-	.map = static_mmap_regions,
-	.alloc_count = ARRAY_SIZE(static_mmap_regions),
-};
-#endif
 void (*memory_map_realloc_func)(struct memory_map *mem_map) __nex_bss;
 
 /* Offset of the first TEE RAM mapping from start of secure RAM */
@@ -1609,15 +1597,11 @@ void __weak core_init_mmu_map(unsigned long seed, struct core_mmu_config *cfg)
 
 	check_sec_nsec_mem_config();
 
-	if (IS_ENABLED(CFG_BOOT_MEM)) {
-		mem_map.alloc_count = CFG_MMAP_REGIONS;
-		mem_map.map = boot_mem_alloc_tmp(mem_map.alloc_count *
-							sizeof(*mem_map.map),
-						 alignof(*mem_map.map));
-		memory_map_realloc_func = boot_mem_realloc_memory_map;
-	} else {
-		mem_map = static_memory_map;
-	}
+	mem_map.alloc_count = CFG_MMAP_REGIONS;
+	mem_map.map = boot_mem_alloc_tmp(mem_map.alloc_count *
+						sizeof(*mem_map.map),
+					 alignof(*mem_map.map));
+	memory_map_realloc_func = boot_mem_realloc_memory_map;
 
 	static_memory_map = (struct memory_map){
 		.map = &tmp_mmap_region,
@@ -1650,20 +1634,17 @@ void __weak core_init_mmu_map(unsigned long seed, struct core_mmu_config *cfg)
 
 void core_mmu_save_mem_map(void)
 {
-	if (IS_ENABLED(CFG_BOOT_MEM)) {
-		size_t alloc_count = static_memory_map.count + 5;
-		size_t elem_sz = sizeof(*static_memory_map.map);
-		void *p = NULL;
+	size_t alloc_count = static_memory_map.count + 5;
+	size_t elem_sz = sizeof(*static_memory_map.map);
+	void *p = NULL;
 
-		p = nex_calloc(alloc_count, elem_sz);
-		if (!p)
-			panic();
-		memcpy(p, static_memory_map.map,
-		       static_memory_map.count * elem_sz);
-		static_memory_map.map = p;
-		static_memory_map.alloc_count = alloc_count;
-		memory_map_realloc_func = heap_realloc_memory_map;
-	}
+	p = nex_calloc(alloc_count, elem_sz);
+	if (!p)
+		panic();
+	memcpy(p, static_memory_map.map, static_memory_map.count * elem_sz);
+	static_memory_map.map = p;
+	static_memory_map.alloc_count = alloc_count;
+	memory_map_realloc_func = heap_realloc_memory_map;
 }
 
 bool core_mmu_mattr_is_ok(uint32_t mattr)

--- a/core/mm/sub.mk
+++ b/core/mm/sub.mk
@@ -10,4 +10,4 @@ srcs-y += phys_mem.c
 ifneq ($(CFG_CORE_FFA),y)
 srcs-$(CFG_CORE_DYN_SHM) += mobj_dyn_shm.c
 endif
-srcs-$(CFG_BOOT_MEM) += boot_mem.c
+srcs-y += boot_mem.c

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1264,14 +1264,11 @@ CFG_CORE_UNSAFE_MODEXP ?= n
 # exponentiation algorithm.
 CFG_TA_MEBDTLS_UNSAFE_MODEXP ?= n
 
-# CFG_BOOT_MEM, when enabled, adds stack like memory allocation during boot.
 # CFG_BOOT_INIT_THREAD_CORE_LOCAL0, when enabled, initializes
 # thread_core_local[0] before calling C code.
 ifeq ($(ARCH),arm)
-$(call force,CFG_BOOT_MEM,y)
 $(call force,CFG_BOOT_INIT_THREAD_CORE_LOCAL0,y)
 else
-CFG_BOOT_MEM ?= n
 CFG_BOOT_INIT_THREAD_CORE_LOCAL0 ?= n
 endif
 
@@ -1280,7 +1277,7 @@ endif
 ifeq ($(CFG_WITH_PAGER),y)
 $(call force,CFG_DYN_CONFIG,n,conflicts with CFG_WITH_PAGER)
 else
-CFG_DYN_CONFIG ?= $(CFG_BOOT_MEM)
+CFG_DYN_CONFIG ?= y
 endif
 
 # CFG_EXTERNAL_ABORT_PLAT_HANDLER is used to implement platform-specific


### PR DESCRIPTION
Refer to https://github.com/OP-TEE/optee_os/pull/7039 and https://github.com/OP-TEE/optee_os/pull/7192.
This PR supports boot mem and dynamic allocation of MMU translation tables for RISC-V architecture.

Also remove `CFG_BOOT_MEM` and relevant dead code, since both ARM and RISC-V explicitly support boot mem now.