### PR TITLE
ci: add S-EL0 SP tests to the BTI+MTE+PAC job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,7 +597,7 @@ jobs:
 
           # xtest 1031 is excluded because 1031.4 (C++ exception from shared library) fails with this cross-compiler
           # Rust is disabled because of a link error in the examples with this toolchain
-          make -j$(nproc) CFG_CORE_BTI=y CFG_TA_BTI=y MEMTAG=y PAUTH=y RUST_ENABLE=n XTEST_ARGS="-x 1031" check
+          make -j$(nproc) CFG_CORE_BTI=y CFG_TA_BTI=y SEL0_SPS=y MEMTAG=y PAUTH=y RUST_ENABLE=n XTEST_ARGS="-x n_1031" check
 
   QEMUv8_check_arm64_host:
     name: make check (QEMUv8) (arm64 host)

--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1041,7 +1041,7 @@ void __weak boot_init_primary_late(unsigned long fdt __unused,
 	}
 }
 
-void __weak boot_init_primary_final(void)
+void __weak boot_init_primary_runtime(void)
 {
 	IMSG("OP-TEE version: %s", core_v_str);
 	if (IS_ENABLED(CFG_INSECURE)) {
@@ -1087,7 +1087,10 @@ void __weak boot_init_primary_final(void)
 
 	if (!IS_ENABLED(CFG_WITH_PAGER))
 		boot_mem_release_tmp_alloc();
+}
 
+void __weak boot_init_primary_final(void)
+{
 	if (!IS_ENABLED(CFG_NS_VIRTUALIZATION))
 		call_driver_initcalls();
 

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -636,6 +636,7 @@ shadow_stack_access_ok:
 	mov	r0, #0
 	str	r0, [r8, #THREAD_CORE_LOCAL_FLAGS]
 #endif
+	bl	boot_init_primary_runtime
 	bl	boot_init_primary_final
 #ifndef CFG_NS_VIRTUALIZATION
 	mov	r0, #THREAD_CLF_TMP

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -441,6 +441,7 @@ clear_nex_bss:
 	mov	x24, x0
 	str	wzr, [x24, #THREAD_CORE_LOCAL_FLAGS]
 #endif
+	bl	boot_init_primary_runtime
 #ifdef CFG_CORE_PAUTH
 	adr_l	x0, threads
 	ldp	x1, x2, [x0, #THREAD_CTX_KEYS]

--- a/core/include/kernel/boot.h
+++ b/core/include/kernel/boot.h
@@ -45,6 +45,7 @@ extern const struct core_mmu_config boot_mmu_config;
 
 void boot_init_primary_early(void);
 void boot_init_primary_late(unsigned long fdt, unsigned long manifest);
+void boot_init_primary_runtime(void);
 void boot_init_primary_final(void);
 void boot_init_memtag(void);
 void boot_clear_memtag(void);


### PR DESCRIPTION
Enable S-EL0 SP tests for the S-EL1 SPMC with BTI+MTE+PAC enabled.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
