### PR TITLE
mk/compile.mk: add -undef and -D__DTS__ in dtb-cppflags

### DIFF
--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -269,7 +269,7 @@ cleanfiles := $$(cleanfiles) $2 \
 		$$(dtb-predts-$2) $$(dtb-predep-$2) \
 		$$(dtb-dep-$2) $$(dtb-cmd-file-$2)
 
-dtb-cppflags-$2 := -Icore/include/ -x assembler-with-cpp -Ulinux -Uunix \
+dtb-cppflags-$2 := -Icore/include/ -x assembler-with-cpp -undef -D__DTS__ \
 		   -E -ffreestanding $$(CPPFLAGS) \
 		   -MD -MF $$(dtb-predep-$2) -MT $$(dtb-predts-$2)
 


### PR DESCRIPTION
Commit 61b2d6e460f7 ("mk/compile.mk: add -Ulinux -Uunix to dtb-cppflags") addresses some macro enabled by default by the compiler that could impact the pre-processing of the DTS files.

Instead of un-defining each of such macros, use the flag '-undef' and get rid of all of them in one shot.

Add the macro '__DTS__' specific for DTS pre-processing, as it is done in Linux and later ported to U-Boot with [1]. This could help sharing include files between DTS and C code.

Link: https://github.com/u-boot/u-boot/commit/f53932addd31 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
