### PR TITLE
sign_encrypt.py: Fix typo from 'Unkown' to 'Unknown'

### DIFF
--- a/scripts/sign_encrypt.py
+++ b/scripts/sign_encrypt.py
@@ -593,7 +593,7 @@ class BinaryImage:
                  tag_len] = struct.unpack('<IIHH', ehdr)
 
                 print(' struct shdr_encrypted_ta')
-                enc_algo_name = 'Unkown'
+                enc_algo_name = 'Unknown'
                 if enc_algo in enc_tee_alg.values():
                     enc_algo_name = value_to_key(enc_tee_alg, enc_algo)
                 print('  enc_algo:   0x{:08x} ({})'
@@ -603,7 +603,7 @@ class BinaryImage:
                     raise Exception('Unrecognized encrypt algorithm: 0x{:08x}'
                                     .format(enc_algo))
 
-                flags_name = 'Unkown'
+                flags_name = 'Unknown'
                 if flags in enc_key_type.values():
                     flags_name = value_to_key(enc_key_type, flags)
                 print('  flags:      0x{:x} ({})'.format(flags, flags_name))


### PR DESCRIPTION
The value of enc_algo_name and flags_name was set to 'Unkown', should be 'Unknown' instead.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
