### PR TITLE
drivers: amd: Add PS GPIO Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,8 @@ jobs:
           _make PLATFORM=d06
           _make PLATFORM=d06 CFG_HISILICON_ACC_V3=y
           _make PLATFORM=telechips-tcc805x
+          _make PLATFORM=versal2
+          _make PLATFORM=versal2 CFG_AMD_PS_GPIO=y
 
           export ARCH=riscv
           unset CROSS_COMPILE32

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -67,6 +67,7 @@ R:	Michal Simek <michal.simek@amd.com> [@michalsimek]
 R:	Akshay Belsare <akshay.belsare@amd.com> [@Akshay-Belsare]
 S:	Maintained
 F:	core/arch/arm/plat-versal2/
+F:	core/drivers/amd/
 
 AmLogic AXG (A113D)
 R:	Carlo Caione <ccaione@baylibre.com> [@carlocaione]

--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -27,6 +27,7 @@ $(call force,CFG_TEE_CORE_NB_CORE,8)
 $(call force,CFG_ARM_GICV3,y)
 $(call force,CFG_PL011,y)
 $(call force,CFG_GIC,y)
+$(call force,CFG_DT,y)
 
 CFG_CORE_RESERVED_SHM	?= n
 CFG_CORE_DYN_SHM	?= y
@@ -52,6 +53,14 @@ CFG_TZDRAM_SIZE    ?= 0x8000000
 # 0 : UART0[pl011, pl011_0] (default)
 # 1 : UART1[pl011_1]
 CFG_CONSOLE_UART ?= 0
+
+# PS GPIO Controller configuration.
+CFG_AMD_PS_GPIO ?= n
+
+ifeq ($(CFG_AMD_PS_GPIO),y)
+$(call force,CFG_MAP_EXT_DT_SECURE,y)
+$(call force,CFG_DRIVERS_GPIO,y)
+endif
 
 ifeq ($(CFG_ARM64_core),y)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)

--- a/core/drivers/amd/gpio_common.c
+++ b/core/drivers/amd/gpio_common.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2002-2021 Xilinx, Inc.  All rights reserved.
+ * Copyright (c) 2022 Foundries.io Ltd. (jorge@foundries.io)
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#include <assert.h>
+#include <kernel/panic.h>
+#include <malloc.h>
+#include <trace.h>
+
+#include "gpio_private.h"
+
+void amd_gpio_get_bank_and_pin(struct amd_gbank_data *bdata, uint32_t gpio,
+			       uint32_t *bank, uint32_t *pin)
+{
+	uint32_t i = 0;
+
+	assert(gpio < bdata->ngpio);
+
+	for (i = 0; i < bdata->max_bank; i++) {
+		if (gpio >= bdata->bank_min[i] &&
+		    gpio <= bdata->bank_max[i]) {
+			*bank = i;
+			*pin = gpio - bdata->bank_min[i];
+			return;
+		}
+	}
+
+	/* Ideally, should never reach over here */
+	EMSG("Invalid GPIO pin number: %"PRIu32, gpio);
+	panic();
+}
+
+TEE_Result amd_gpio_get_dt(struct dt_pargs *pargs, void *data,
+			   struct gpio **out_gpio)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct amd_gpio_info *amd = (struct amd_gpio_info *)data;
+	struct gpio *gpio = NULL;
+
+	res = gpio_dt_alloc_pin(pargs, &gpio);
+	if (res)
+		return res;
+
+	if (gpio->pin >= amd->bdata->ngpio) {
+		DMSG("GPIO is outside of GPIO Range");
+		free(gpio);
+		return TEE_ERROR_GENERIC;
+	}
+
+	gpio->chip = &amd->chip;
+	*out_gpio = gpio;
+
+	return TEE_SUCCESS;
+}

--- a/core/drivers/amd/gpio_private.h
+++ b/core/drivers/amd/gpio_private.h
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2002-2021 Xilinx, Inc.  All rights reserved.
+ * Copyright (c) 2022 Foundries.io Ltd. (jorge@foundries.io)
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#ifndef __GPIO_PRIVATE_H__
+#define __GPIO_PRIVATE_H__
+
+#include <drivers/gpio.h>
+#include <kernel/dt.h>
+#include <stdlib.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+#define GPIO_MAX_BANK		6
+
+#define PS_BANK_MAX		4
+
+#define GPIO_NUM_MAX		16
+
+#define GPIO_UPPER_MASK		GENMASK_32(31, 16)
+
+#define DATA_LSW_OFFSET(__bank)	(0x000 + 0x8 * (__bank))
+#define DATA_MSW_OFFSET(__bank)	(0x004 + 0x8 * (__bank))
+#define DATA_RO_OFFSET(__bank)	(0x060 + 0x4 * (__bank))
+#define DIRM_OFFSET(__bank)	(0x204 + 0x40 * (__bank))
+#define OUTEN_OFFSET(__bank)	(0x208 + 0x40 * (__bank))
+#define INTMASK_OFFSET(__bank)	(0x20c + 0x40 * (__bank))
+#define INTEN_OFFSET(__bank)	(0x210 + 0x40 * (__bank))
+#define INTDIS_OFFSET(__bank)	(0x214 + 0x40 * (__bank))
+
+struct amd_gbank_data {
+	const char *label;
+	uint16_t ngpio;
+	uint32_t max_bank;
+	uint32_t bank_min[GPIO_MAX_BANK];
+	uint32_t bank_max[GPIO_MAX_BANK];
+};
+
+struct amd_gpio_info {
+	struct amd_gbank_data *bdata;
+	struct gpio_chip chip;
+	vaddr_t vbase;
+};
+
+void amd_gpio_get_bank_and_pin(struct amd_gbank_data *bdata, uint32_t gpio,
+			       uint32_t *bank, uint32_t *pin);
+TEE_Result amd_gpio_get_dt(struct dt_pargs *pargs, void *data,
+			   struct gpio **out_gpio);
+
+#endif /* __GPIO_PRIVATE_H__  */

--- a/core/drivers/amd/ps_gpio_driver.c
+++ b/core/drivers/amd/ps_gpio_driver.c
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (C) 2002-2021 Xilinx, Inc.  All rights reserved.
+ * Copyright (c) 2022 Foundries.io Ltd. (jorge@foundries.io)
+ * Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#include <assert.h>
+#include <drivers/gpio.h>
+#include <io.h>
+#include <kernel/dt.h>
+#include <kernel/panic.h>
+#include <libfdt.h>
+#include <malloc.h>
+#include <mm/core_mmu.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <trace.h>
+#include <util.h>
+
+#include "gpio_private.h"
+
+static struct amd_gbank_data ps_bank = {
+	.label = "ps_gpio",
+	.ngpio = 58,
+	.max_bank = PS_BANK_MAX,
+	.bank_min[0] = 0,
+	.bank_max[0] = 25,
+	.bank_min[3] = 26,
+	.bank_max[3] = 57,
+};
+
+/* Standard GPIO Operations */
+static enum gpio_level ps_gpio_get_value(struct gpio_chip *chip,
+					 unsigned int gpio_pin)
+{
+	uint32_t bank = 0;
+	uint32_t pin = 0;
+	struct amd_gpio_info *ps = container_of(chip, struct amd_gpio_info,
+						chip);
+
+	amd_gpio_get_bank_and_pin(ps->bdata, gpio_pin, &bank, &pin);
+
+	if (io_read32(ps->vbase + DATA_RO_OFFSET(bank)) & BIT(pin))
+		return GPIO_LEVEL_HIGH;
+
+	return GPIO_LEVEL_LOW;
+}
+
+static void ps_gpio_set_value(struct gpio_chip *chip,
+			      unsigned int gpio_pin,
+			      enum gpio_level level)
+{
+	uint32_t bank = 0;
+	uint32_t pin = 0;
+	uint32_t offset = 0;
+	uint32_t lvl = 0;
+	struct amd_gpio_info *ps = container_of(chip, struct amd_gpio_info,
+						chip);
+
+	amd_gpio_get_bank_and_pin(ps->bdata, gpio_pin, &bank, &pin);
+
+	if (pin < GPIO_NUM_MAX) {
+		offset = DATA_LSW_OFFSET(bank);
+	} else {
+		pin -= GPIO_NUM_MAX;
+		offset = DATA_MSW_OFFSET(bank);
+	}
+
+	/* Explicitly compare the enum value */
+	if (level == GPIO_LEVEL_HIGH)
+		lvl = 1;
+	else
+		lvl = 0;
+
+	lvl = ~BIT32(pin + GPIO_NUM_MAX) &
+		(SHIFT_U32(lvl, pin) | GPIO_UPPER_MASK);
+
+	io_write32(ps->vbase + offset, lvl);
+}
+
+static enum gpio_dir ps_gpio_get_dir(struct gpio_chip *chip,
+				     unsigned int gpio_pin)
+{
+	uint32_t bank = 0;
+	uint32_t pin = 0;
+	struct amd_gpio_info *ps = container_of(chip, struct amd_gpio_info,
+						chip);
+
+	amd_gpio_get_bank_and_pin(ps->bdata, gpio_pin, &bank, &pin);
+
+	if (io_read32(ps->vbase + DIRM_OFFSET(bank)) & BIT(pin))
+		return GPIO_DIR_OUT;
+
+	return GPIO_DIR_IN;
+}
+
+static void ps_gpio_set_dir(struct gpio_chip *chip,
+			    unsigned int gpio_pin,
+			    enum gpio_dir direction)
+{
+	uint32_t bank = 0;
+	uint32_t pin = 0;
+	struct amd_gpio_info *ps = container_of(chip, struct amd_gpio_info,
+						chip);
+
+	amd_gpio_get_bank_and_pin(ps->bdata, gpio_pin, &bank, &pin);
+
+	if (direction == GPIO_DIR_OUT) {
+		/* set the GPIO pin as output */
+		io_setbits32(ps->vbase + DIRM_OFFSET(bank), BIT(pin));
+
+		/* configure the output enable reg for the pin */
+		io_setbits32(ps->vbase + OUTEN_OFFSET(bank), BIT(pin));
+
+		/* set the state of the pin */
+		ps_gpio_set_value(chip, gpio_pin, GPIO_LEVEL_LOW);
+	} else {
+		/* Set the GPIO pin as input */
+		io_clrbits32(ps->vbase + DIRM_OFFSET(bank), BIT(pin));
+	}
+}
+
+static enum gpio_interrupt ps_gpio_get_intr(struct gpio_chip *chip,
+					    unsigned int gpio_pin)
+{
+	uint32_t bank = 0;
+	uint32_t pin = 0;
+	struct amd_gpio_info *ps = container_of(chip, struct amd_gpio_info,
+						chip);
+
+	amd_gpio_get_bank_and_pin(ps->bdata, gpio_pin, &bank, &pin);
+
+	if ((io_read32(ps->vbase + INTMASK_OFFSET(bank)) & BIT(pin)))
+		return GPIO_INTERRUPT_DISABLE;
+
+	return GPIO_INTERRUPT_ENABLE;
+}
+
+static void ps_gpio_set_intr(struct gpio_chip *chip,
+			     unsigned int gpio_pin,
+			     enum gpio_interrupt interrupt)
+{
+	uint32_t bank = 0;
+	uint32_t pin = 0;
+	uint32_t offset = 0;
+	uint32_t mask = 0;
+	struct amd_gpio_info *ps = container_of(chip, struct amd_gpio_info,
+						chip);
+
+	amd_gpio_get_bank_and_pin(ps->bdata, gpio_pin, &bank, &pin);
+
+	mask = io_read32(ps->vbase + INTMASK_OFFSET(bank)) & BIT(pin);
+
+	/*
+	 * mask = 1 --> Interrupt is masked/disabled.
+	 * mask = 0 --> Interrupt is un-masked/enabled.
+	 */
+	if (mask && interrupt == GPIO_INTERRUPT_ENABLE) {
+		offset = INTEN_OFFSET(bank);
+	} else if (!mask && interrupt == GPIO_INTERRUPT_DISABLE) {
+		offset = INTDIS_OFFSET(bank);
+	} else {
+		DMSG("No change, interrupt already %s",
+		     interrupt ? "Enabled" : "Disabled");
+		return;
+	}
+
+	io_setbits32(ps->vbase + offset, BIT(pin));
+}
+
+static const struct gpio_ops ps_gpio_ops = {
+	.get_direction = ps_gpio_get_dir,
+	.set_direction = ps_gpio_set_dir,
+	.get_value = ps_gpio_get_value,
+	.set_value = ps_gpio_set_value,
+	.get_interrupt = ps_gpio_get_intr,
+	.set_interrupt = ps_gpio_set_intr,
+};
+
+static TEE_Result amd_ps_gpio_probe(const void *fdt, int node,
+				    const void *compat_data __unused)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int status = DT_STATUS_DISABLED;
+	struct amd_gpio_info *ps_gpio = NULL;
+	paddr_t base = 0;
+	size_t len = 0;
+
+	/* Status Check */
+	status = fdt_get_status(fdt, node);
+
+	/* PS GPIO Controller to be in Non Secure World */
+	if (status & DT_STATUS_OK_NSEC) {
+		DMSG("PS GPIO controller configured for NS world");
+		return TEE_SUCCESS;
+	}
+
+	/* PS GPIO Controller is disabled for Secure World as well */
+	if (!(status & DT_STATUS_OK_SEC)) {
+		DMSG("PS GPIO Controller is disabled");
+		return TEE_SUCCESS;
+	}
+
+	ps_gpio = calloc(1, sizeof(*ps_gpio));
+	if (!ps_gpio) {
+		EMSG("Failed to allocate memory for ps_gpio");
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	if (fdt_reg_info(fdt, node, &base, &len) != 0) {
+		EMSG("Failed to get Register Base and Size");
+		free(ps_gpio);
+		return TEE_ERROR_GENERIC;
+	}
+
+	/* Populate GPIO ops */
+	ps_gpio->chip.ops = &ps_gpio_ops;
+	/* Populate Bank information */
+	ps_gpio->bdata = &ps_bank;
+
+	/* Validate node entries */
+	assert(base);
+	assert(len);
+
+	ps_gpio->vbase = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC, base,
+						       len);
+	if (!ps_gpio->vbase) {
+		EMSG("AMD PS GPIO initialization Failed");
+		free(ps_gpio);
+		return TEE_ERROR_GENERIC;
+	}
+
+	res = gpio_register_provider(fdt, node, amd_gpio_get_dt, ps_gpio);
+	if (res) {
+		EMSG("Failed to register PS GPIO Provider");
+		/* Ignoring return value */
+		core_mmu_remove_mapping(MEM_AREA_IO_SEC,
+					(void *)ps_gpio->vbase, len);
+		free(ps_gpio);
+		return res;
+	}
+
+	DMSG("AMD PS GPIO initialized");
+
+	return TEE_SUCCESS;
+}
+
+GPIO_DT_DECLARE(amd_ps_gpio, "xlnx,versal-gpio-1.0", amd_ps_gpio_probe);

--- a/core/drivers/amd/sub.mk
+++ b/core/drivers/amd/sub.mk
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+#
+
+srcs-$(CFG_AMD_PS_GPIO) += gpio_common.c ps_gpio_driver.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -109,3 +109,4 @@ subdirs-y += wdt
 subdirs-y += rtc
 subdirs-y += firewall
 subdirs-y += counter
+subdirs-y += amd


### PR DESCRIPTION
Add PS GPIO Driver support for AMD Platforms.

The PS GPIO Controller is managed through the PS subsystem and can operate in either the Secure World or the Non-Secure World. The driver utilizes the Device Tree Blob (DTB) to determine whether the PS GPIO Controller should be supported in the Secure World.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
