### PR TITLE
dts: stm32: disable unused i2c1 and i2c2

### DIFF
--- a/core/arch/arm/dts/stm32mp15xx-dhcor-avenger96.dtsi
+++ b/core/arch/arm/dts/stm32mp15xx-dhcor-avenger96.dtsi
@@ -204,7 +204,7 @@
 	pinctrl-0 = <&i2c1_pins_b>;
 	i2c-scl-rising-time-ns = <185>;
 	i2c-scl-falling-time-ns = <20>;
-	status = "okay";
+	status = "disabled";
 	/delete-property/dmas;
 	/delete-property/dma-names;
 };
@@ -214,7 +214,7 @@
 	pinctrl-0 = <&i2c2_pins_c>;
 	i2c-scl-rising-time-ns = <185>;
 	i2c-scl-falling-time-ns = <20>;
-	status = "okay";
+	status = "disabled";
 	/delete-property/dmas;
 	/delete-property/dma-names;
 };


### PR DESCRIPTION
As discussed in #7296, i2c1 and i2c2 on the STM32MP157a Avenger96 board are enabled because the device tree was copied from the linux kernel.
Both i2c interfaces are not consumed in OP-TEE and the clock tree is missing resulting in a panic on boot when the driver is probed.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
