### PR TITLE
libmbedtls: fix compilation warning with GCC14

### DIFF
--- a/lib/libmbedtls/mbedtls/library/common.h
+++ b/lib/libmbedtls/mbedtls/library/common.h
@@ -209,11 +209,13 @@ static inline void mbedtls_xor(unsigned char *r,
         uint8x16_t x = veorq_u8(v1, v2);
         vst1q_u8(r + i, x);
     }
-#if defined(__IAR_SYSTEMS_ICC__)
+#if defined(__IAR_SYSTEMS_ICC__) || defined(MBEDTLS_COMPILER_IS_GCC)
     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
      * where n is a constant multiple of 16.
      * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time
-     * constant, and is a very small perf regression if n is not a compile-time constant. */
+     * constant, and is a very small perf regression if n is not a compile-time constant.
+     * GCC 14.2 outputs a warning "array subscript 48 is outside array bounds" if we don't return
+     * early. */
     if (n % 16 == 0) {
         return;
     }


### PR DESCRIPTION
GCC 14.2 outputs the following compilation warning:

  CC out/arm-plat-imx/ta_arm64-lib/libmbedtls/mbedtls/library/ecp.o
  In file included from lib/libmbedtls/mbedtls/library/ctr_drbg.c:13:
  In function ‘mbedtls_xor’,
  inlined from ‘ctr_drbg_update_internal’ at lib/libmbedtls/mbedtls/library/ctr_drbg.c:372:5:
  lib/libmbedtls/mbedtls/library/common.h:245:17: warning: array subscript 48 is outside array bounds of ‘unsigned char[48]’ [-Warray-bounds=]
  245 | r[i] = a[i] ^ b[i];
  | ~^~~
  lib/libmbedtls/mbedtls/library/ctr_drbg.c: In function ‘ctr_drbg_update_internal’:
  lib/libmbedtls/mbedtls/library/ctr_drbg.c:335:19: note: at offset 48 into object ‘tmp’ of size 48
  335 | unsigned char tmp[MBEDTLS_CTR_DRBG_SEEDLEN];
  | ^~~

Fix it by returning early in mbedtls_xor() if the compiler is GCC. This fix is not in MBed TLS upstream yet but the issue and the fix have been reported [1].

Link: https://github.com/Mbed-TLS/mbedtls/issues/9003#issuecomment-2108239255 [1]
Reported-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Closes: https://github.com/OP-TEE/optee_os/issues/7295

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
