### PR TITLE
Deprecate libgcc

### DIFF
--- a/core/arch/arm/kernel/link.mk
+++ b/core/arch/arm/kernel/link.mk
@@ -52,7 +52,7 @@ link-objs-init := $(filter-out \
 		    $(out-dir)/$(arch-dir)/kernel/link_dummies_init.o, \
 		    $(objs))
 ldargs-tee.elf := $(link-ldflags) $(link-objs) $(link-out-dir)/version.o \
-		  $(link-ldadd) $(libgcccore)
+		  $(link-ldadd)
 
 link-script-cppflags := \
 	$(filter-out $(CPPFLAGS_REMOVE) $(cppflags-remove), \

--- a/ldelf/link.mk
+++ b/ldelf/link.mk
@@ -27,7 +27,7 @@ link-ldflags += $(link-ldflags$(sm))
 
 link-ldadd  = $(addprefix -L,$(libdirs))
 link-ldadd += --start-group $(addprefix -l,$(libnames)) --end-group
-ldargs-ldelf.elf := $(link-ldflags) $(objs) $(link-ldadd) $(libgcc$(sm))
+ldargs-ldelf.elf := $(link-ldflags) $(objs) $(link-ldadd)
 
 link-script-cppflags-$(sm) := \
 	$(filter-out $(CPPFLAGS_REMOVE) $(cppflags-remove), \

--- a/lib/libmbedtls/include/mbedtls_config_kernel.h
+++ b/lib/libmbedtls/include/mbedtls_config_kernel.h
@@ -9,6 +9,7 @@
 #ifdef ARM64
 #define MBEDTLS_HAVE_INT64
 #endif
+#define MBEDTLS_NO_UDBL_DIVISION
 #define MBEDTLS_BIGNUM_C
 #define MBEDTLS_GENPRIME
 

--- a/lib/libmbedtls/include/mbedtls_config_uta.h
+++ b/lib/libmbedtls/include/mbedtls_config_uta.h
@@ -8,6 +8,7 @@
  * use 32-bit arithmetics.
  */
 #define MBEDTLS_HAVE_INT32
+#define MBEDTLS_NO_UDBL_DIVISION
 
 #define MBEDTLS_CIPHER_MODE_CBC
 #define MBEDTLS_PKCS1_V15

--- a/lib/libutils/ext/include/asm.S
+++ b/lib/libutils/ext/include/asm.S
@@ -10,8 +10,9 @@
 #include <riscv.S>
 #endif
 
-#if defined(__aarch64__) && ((defined(__KERNEL__) && defined(CFG_CORE_BTI)) || \
-			     (!defined(__KERNEL__) && defined(CFG_TA_BTI)))
+#if defined(__aarch64__) && \
+    (((defined(__KERNEL__) || defined(__LDELF__)) && defined(CFG_CORE_BTI)) || \
+     (!(defined(__KERNEL__) || defined(__LDELF__)) && defined(CFG_TA_BTI)))
 #define BTI(...) __VA_ARGS__
 #else
 #define BTI(...)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1284,3 +1284,8 @@ endif
 # handling of external abort implementing the plat_external_abort_handler()
 # function.
 CFG_EXTERNAL_ABORT_PLAT_HANDLER ?= n
+
+# CFG_TA_LIBGCC, when enabled, links user mode TAs with libgcc. Linking
+# TAs with libgcc is deprecated, but keep this flag while sorting out the
+# out remaining issues with supporting C++.
+CFG_TA_LIBGCC ?= y

--- a/ta/link.mk
+++ b/ta/link.mk
@@ -58,15 +58,21 @@ link-ldadd  = $(user-ta-ldadd) $(addprefix -L,$(libdirs))
 link-ldadd += --start-group
 link-ldadd += $(addprefix -l,$(libnames))
 ifneq (,$(filter %.cpp,$(srcs)))
+ifneq ($(CFG_TA_LIBGCC),y)
+$(error C++ code depends on CFG_TA_LIBGCC=y)
+endif
 link-ldflags += --eh-frame-hdr
 link-ldadd += $(libstdc++$(sm)) $(libgcc_eh$(sm))
 endif
 link-ldadd += --end-group
+ifeq ($(CFG_TA_LIBGCC),y)
+link-ldadd += $(libgcc$(sm))
+endif
 
 link-ldadd-after-libgcc += $(addprefix -l,$(libnames-after-libgcc))
 
 ldargs-$(user-ta-uuid).elf := $(link-ldflags) $(objs) $(link-ldadd) \
-				$(libgcc$(sm)) $(link-ldadd-after-libgcc)
+				$(link-ldadd-after-libgcc)
 
 link-script-cppflags-$(sm) := \
 	$(filter-out $(CPPFLAGS_REMOVE) $(cppflags-remove), \

--- a/ta/link_shlib.mk
+++ b/ta/link_shlib.mk
@@ -28,7 +28,10 @@ shlink-ldflags += --as-needed # Do not add dependency on unused shlib
 shlink-ldadd  = $(LDADD)
 shlink-ldadd += $(addprefix -L,$(libdirs))
 shlink-ldadd += --start-group $(addprefix -l,$(libnames)) --end-group
-ldargs-$(shlibname).so := $(shlink-ldflags) $(objs) $(shlink-ldadd) $(libgcc$(sm))
+ifeq ($(CFG_TA_LIBGCC),y)
+shlink-ldadd += $(libgcc$(sm))
+endif
+ldargs-$(shlibname).so := $(shlink-ldflags) $(objs) $(shlink-ldadd)
 
 
 $(link-out-dir)/$(shlibname).so: $(objs) $(libdeps)

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -45,6 +45,7 @@ ta-mk-file-export-add-$(sm) += CFG_TEE_TA_LOG_LEVEL ?= $(CFG_TEE_TA_LOG_LEVEL)_n
 ta-mk-file-export-vars-$(sm) += CFG_TA_BGET_TEST
 ta-mk-file-export-vars-$(sm) += CFG_ATTESTATION_PTA
 ta-mk-file-export-vars-$(sm) += CFG_MEMTAG
+ta-mk-file-export-vars-$(sm) += CFG_TA_LIBGCC
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.


### PR DESCRIPTION
Linking with libgcc makes it harder than necessary to test BTI, so make libgcc optional.