### PR TITLE
drivers: stm32_gpio: remove test on CFG_DRIVERS_GPIO

### DIFF
--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -31,10 +31,6 @@
 #include <trace.h>
 #include <util.h>
 
-#ifndef CFG_DRIVERS_GPIO
-#error stm32_gpio driver expects CFG_DRIVERS_GPIO
-#endif
-
 #define GPIO_PIN_MAX		15
 
 #define GPIO_MODER_OFFSET	U(0x00)


### PR DESCRIPTION
Remove test on CFG_DRIVERS_GPIO inside stm32_gpio.c C source file. CFG_* dependencies are addressed in makefile file (e.g. plat-*/conf.mk), not in the driver source file.

Fixes: 1001585e2e56 ("drivers: stm32_gpio: remove GPIO access specific API functions")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
