### PR TITLE
core: fix CFG_BOOT_INIT_THREAD_CORE_LOCAL0

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -449,7 +449,7 @@ shadow_stack_access_ok:
 
 	set_sp
 
-	/* Initialize thread_core_local[0] for early boot */
+	/* Initialize thread_core_local[current_cpu_id] for early boot */
 	bl	thread_get_core_local
 	push	{r0,r1}
 	bl	thread_get_abt_stack
@@ -602,8 +602,8 @@ shadow_stack_access_ok:
 
 #if defined(CFG_CORE_DEBUG_CHECK_STACKS)
 	/*
-	 * Clear thread_core_local[0].stackcheck_recursion now that the
-	 * stack pointer matches recorded information.
+	 * Clear thread_core_local[current_cpu_id].stackcheck_recursion now
+	 * that the stack pointer matches recorded information.
 	 */
 	mov	r2, #0
 	strb	r2, [r4, #THREAD_CORE_LOCAL_STACKCHECK_RECURSION]

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -285,7 +285,7 @@ clear_nex_bss:
 	/* Setup SP_EL0 and SP_EL1, SP will be set to SP_EL0 */
 	set_sp
 
-	/* Initialize thread_core_local[0] for early boot */
+	/* Initialize thread_core_local[current_cpu_id] for early boot */
 	bl	thread_get_abt_stack
 	mov	x1, sp
 	msr	spsel, #1

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -538,14 +538,17 @@ vaddr_t __nostackcheck thread_get_abt_stack(void)
 	return GET_STACK_BOTTOM(stack_abt, get_core_pos());
 }
 
-#ifdef CFG_BOOT_INIT_THREAD_CORE_LOCAL0
+#ifdef CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL
 void thread_init_thread_core_local(void)
 {
 	struct thread_core_local *tcl = thread_core_local;
+	const size_t core_pos = get_core_pos();
 	vaddr_t va = 0;
 	size_t n = 0;
 
-	for (n = 1; n < CFG_TEE_CORE_NB_CORE; n++) {
+	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++) {
+		if (n == core_pos)
+			continue;	/* Already initialized */
 		tcl[n].curr_thread = THREAD_ID_INVALID;
 		tcl[n].flags = THREAD_CLF_TMP;
 
@@ -583,7 +586,7 @@ void __nostackcheck thread_init_core_local_stacks(void)
 		tcl[n].abt_stack_va_end = GET_STACK_BOTTOM(stack_abt, n);
 	}
 }
-#endif /*CFG_BOOT_INIT_THREAD_CORE_LOCAL0*/
+#endif /*CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL*/
 
 #if defined(CFG_CORE_PAUTH)
 void thread_init_thread_pauth_keys(void)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1264,12 +1264,12 @@ CFG_CORE_UNSAFE_MODEXP ?= n
 # exponentiation algorithm.
 CFG_TA_MEBDTLS_UNSAFE_MODEXP ?= n
 
-# CFG_BOOT_INIT_THREAD_CORE_LOCAL0, when enabled, initializes
-# thread_core_local[0] before calling C code.
+# CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL, when enabled, initializes
+# thread_core_local[current_core_pos] before calling C code.
 ifeq ($(ARCH),arm)
-$(call force,CFG_BOOT_INIT_THREAD_CORE_LOCAL0,y)
+$(call force,CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL,y)
 else
-CFG_BOOT_INIT_THREAD_CORE_LOCAL0 ?= n
+CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL ?= n
 endif
 
 # CFG_DYN_CONFIG, when enabled, use dynamic memory allocation for translation


### PR DESCRIPTION
CFG_BOOT_INIT_THREAD_CORE_LOCAL0 is misleading since it's concerning the core id of the boot CPU. So rename the configuration flag to CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL and update the code as needed. Only thread_init_thread_core_local() has a change of behaviour where the boot CPU now can have any core id.

Fixes: b5ec8152f3e5 ("core: arm: refactor boot")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
