### PR TITLE
Initial Qualcomm platform support

### DIFF
--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -1,0 +1,35 @@
+# Qualcomm platform support
+
+PLATFORM_FLAVOR ?= sc7280
+
+$(call force,CFG_GIC,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,40)
+$(call force,CFG_DRIVERS_CLK,y)
+$(call force,CFG_DRIVERS_CLK_DT,y)
+$(call force,CFG_DRIVERS_QCOM_CLK,y)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+ta-targets = ta_arm64
+supported-ta-targets ?= ta_arm64
+
+CFG_DT ?= n
+CFG_DTB_MAX_SIZE ?= 0x40000
+CFG_NUM_THREADS ?= 8
+
+ifeq ($(PLATFORM_FLAVOR),sc7280)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+$(call force,CFG_ARM_GICV3,y)
+$(call force,CFG_GENI_UART,y)
+
+CFG_TZDRAM_START ?= 0x1c120000
+CFG_TZDRAM_SIZE  ?= 0x00ee0000
+CFG_SHMEM_START  ?= 0x1d000000
+CFG_SHMEM_SIZE   ?= 0x00400000
+
+CFG_EARLY_CONSOLE ?= y
+
+CFG_TEE_CORE_LOG_LEVEL ?= 2
+endif

--- a/core/arch/arm/plat-qcom/main.c
+++ b/core/arch/arm/plat-qcom/main.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Linaro Limited
+ */
+
+#include <console.h>
+#include <drivers/geni_uart.h>
+#include <drivers/clk_qcom.h>
+#include <kernel/boot.h>
+#include <kernel/panic.h>
+#include <io.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/entry_fast.h>
+#include <tee/entry_std.h>
+#include <drivers/gic.h>
+#include <sm/optee_smc.h>
+#include <kernel/delay.h>
+
+#include "q6dsp.h"
+
+/*
+ * Register the physical memory area for peripherals etc. Here we are
+ * registering the UART console.
+ */
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE,
+			GENI_UART_REG_SIZE);
+register_phys_mem(MEM_AREA_IO_NSEC, GCC_BASE, 0x100000);
+register_phys_mem(MEM_AREA_IO_NSEC, WPSS_BASE, 0x1000);
+register_phys_mem(MEM_AREA_IO_NSEC, ADSP_BASE, 0x1000);
+#ifdef ADSP_LPASS_EFUSE
+/* We only need the one 32-bit register... */
+register_phys_mem(MEM_AREA_IO_NSEC, ADSP_LPASS_EFUSE, 0x1000);
+#endif
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE, 0x100000);
+
+register_ddr(DRAM0_BASE, DRAM0_SIZE);
+register_ddr(DRAM1_BASE, DRAM1_SIZE);
+register_ddr(DRAM2_BASE, DRAM2_SIZE);
+register_ddr(DRAM3_BASE, DRAM3_SIZE);
+
+static struct geni_uart_data console_data;
+
+void plat_console_init(void)
+{
+	geni_uart_init(&console_data, CONSOLE_UART_BASE);
+	register_serial_console(&console_data.chip);
+}
+
+void boot_primary_init_intc(void)
+{
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
+}
+
+void boot_secondary_init_intc(void)
+{
+	gic_init_per_cpu();
+}
+
+#define SMC_SVC_PIL 0x02
+#define QTI_SIP_SVC_AVAILABLE_ID	U(0xc2000601)
+#define QCOM_SCM_PIL_PAS_INIT_IMAGE	U(0xc2000201)
+#define QCOM_SCM_PIL_PAS_MEM_SETUP	U(0xc2000202)
+#define QCOM_SCM_PIL_PAS_AUTH_AND_RESET	U(0xc2000205)
+#define QCOM_SCM_PIL_PAS_SHUTDOWN	U(0xc2000206)
+#define QCOM_SCM_PIL_PAS_IS_SUPPORTED	U(0xc2000207)
+
+static bool qti_check_syscall_availability(uint64_t smc_fid)
+{
+	/*
+	 * Ignore the top two bytes when checking if an SMC call
+	 * is supported since those aren't set.
+	 */
+	smc_fid = (smc_fid & 0x3fffffff) | 0xc0000000;
+	switch (smc_fid) {
+	case QTI_SIP_SVC_AVAILABLE_ID:
+	case QCOM_SCM_PIL_PAS_INIT_IMAGE:
+	case QCOM_SCM_PIL_PAS_MEM_SETUP:
+	case QCOM_SCM_PIL_PAS_AUTH_AND_RESET:
+	case QCOM_SCM_PIL_PAS_SHUTDOWN:
+	case QCOM_SCM_PIL_PAS_IS_SUPPORTED:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/* Add handlers for DSP init */
+void tee_entry_fast(struct thread_smc_args *args)
+{
+	/* Mask off the function ID */
+	uint32_t smc = args->a0 & 0xFFFFFF00;
+
+	if (args->a0 == QTI_SIP_SVC_AVAILABLE_ID) {
+		args->a0 = OPTEE_SMC_RETURN_OK;
+		args->a1 = qti_check_syscall_availability(args->a2) ? 1 : 0;
+		return;
+	}
+
+	/* SIP call for PIL svc */
+	if (smc == 0xc2000200)
+		qcom_handle_pil_smc(args);
+	else
+		__tee_entry_fast(args);
+}

--- a/core/arch/arm/plat-qcom/platform_config.h
+++ b/core/arch/arm/plat-qcom/platform_config.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Linaro Limited
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT			64
+
+#if defined(PLATFORM_FLAVOR_sc7280)
+
+#define DRAM0_BASE			UL(0x80000000)
+#define DRAM0_SIZE			UL(0x3a800000)
+
+#define DRAM1_BASE			ULL(0xc0000000)
+#define DRAM1_SIZE			ULL(0x01800000)
+
+#define DRAM2_BASE			ULL(0xc3400000)
+#define DRAM2_SIZE			ULL(0x3cc00000)
+
+#define DRAM3_BASE			ULL(0x100000000)
+#define DRAM3_SIZE			ULL(0x100000000)
+
+#define SYS_COUNTER_FREQ_IN_TICKS	UL(19200000)
+
+#define UART0_BASE			UL(0x994000)
+#define CONSOLE_UART_BASE		UART0_BASE
+
+/* GIC related constants */
+#define GICD_BASE			UL(0x17a00000)
+#define GICR_BASE			UL(0x17a60000)
+
+#define GCC_BASE UL(0x100000)
+#define WPSS_BASE UL(0x08a00000)
+#define ADSP_BASE UL(0x03000000)
+#define ADSP_LPASS_EFUSE UL(0x0355b000)
+
+#endif
+
+/* common error codes */
+#define QCOM_SCM_V2_EBUSY	-12
+#define QCOM_SCM_ENOMEM		-5
+#define QCOM_SCM_EOPNOTSUPP	-4
+#define QCOM_SCM_EINVAL_ADDR	-3
+#define QCOM_SCM_EINVAL_ARG	-2
+#define QCOM_SCM_ERROR		-1
+#define QCOM_SCM_INTERRUPTED	1
+#define QCOM_SCM_WAITQ_SLEEP	2
+
+#define PLAT_ARM_CLUSTER_COUNT		U(2)
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-qcom/q6dsp.c
+++ b/core/arch/arm/plat-qcom/q6dsp.c
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Linaro Limited
+ */
+
+#include <console.h>
+#include <drivers/geni_uart.h>
+#include <drivers/clk_qcom.h>
+#include <kernel/boot.h>
+#include <kernel/panic.h>
+#include <io.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <stdint.h>
+#include <tee/entry_fast.h>
+#include <drivers/gic.h>
+#include <sm/optee_smc.h>
+#include <kernel/delay.h>
+
+#include "q6dsp.h"
+
+#define WPSS_MEM_PHYS 0x84800000
+
+/*QDSP6SS register offsets*/
+#define RST_EVB_REG			0x10
+#define CORE_START_REG			0x400
+#define BOOT_CMD_REG			0x404
+#define BOOT_STATUS_REG			0x408
+#define RET_CFG_REG			0x1C
+
+#define QDSP6SS_XO_CBCR		0x38
+#define QDSP6SS_CORE_CBCR	0x20
+#define QDSP6SS_SLEEP_CBCR	0x3c
+#define LPASS_BOOT_CORE_START	BIT(0)
+#define LPASS_BOOT_CMD_START	BIT(0)
+#define LPASS_EFUSE_Q6SS_EVB_SEL 0x0
+
+#define BOOT_FSM_TIMEOUT		10000
+
+#if defined(PLATFORM_FLAVOR_sc7280)
+#define PAS_ID_WPSS 0x06
+static struct qcom_q6dsp_data wpss_dsp_data = {
+	.pas_id = PAS_ID_WPSS,
+	.base.pa = WPSS_BASE,
+	.clk_group = QCOM_CLKS_WPSS,
+};
+#endif
+
+static void sc7280_dsp_start(struct thread_smc_args *args,
+			     struct qcom_q6dsp_data *selected)
+{
+	uint32_t val;
+	uint64_t timer;
+	vaddr_t base = io_pa_or_va(&selected->base, 0x500);
+	vaddr_t lpass_efuse = 0;
+
+	if (selected->lpass_efuse_base.pa)
+		lpass_efuse = io_pa_or_va(&selected->lpass_efuse_base, 0x10);
+
+	/* Enable the XO clock */
+	io_write32(base + QDSP6SS_XO_CBCR, 1);
+
+	/* Enable the QDSP6SS sleep clock */
+	io_write32(base + QDSP6SS_SLEEP_CBCR, 1);
+
+	/* Enable the QDSP6 core clock */
+	io_write32(base + QDSP6SS_CORE_CBCR, 1);
+
+	/* Program boot address */
+	io_write32(base + RST_EVB_REG, selected->firmware_base >> 4);
+
+	if (lpass_efuse)
+		io_write32(lpass_efuse, LPASS_EFUSE_Q6SS_EVB_SEL);
+
+	/* Flush configuration */
+	dsb();
+
+	/* De-assert QDSP6 stop core. QDSP6 will execute after out of reset */
+	io_write32(base + CORE_START_REG, LPASS_BOOT_CORE_START);
+
+	/* Trigger boot FSM to start QDSP6 */
+	io_write32(base + BOOT_CMD_REG, LPASS_BOOT_CMD_START);
+
+	/* Wait for core to come out of reset */
+	timer = timeout_init_us(BOOT_FSM_TIMEOUT);
+	do {
+		val = io_read32(base + BOOT_STATUS_REG);
+		if (val & BIT(0))
+			break;
+		if (timeout_elapsed(timer))
+			break;
+		udelay(10);
+	} while (1);
+
+	if ((val & BIT(0)) == 0) {
+		EMSG("Timed out waiting for DSP to boot :(");
+		args->a0 = QCOM_SCM_ERROR;
+		return;
+	}
+
+	args->a0 = OPTEE_SMC_RETURN_OK;
+	args->a1 = 0;
+	args->a2 = 0;
+	args->a3 = 0;
+	args->a4 = 0;
+	args->a5 = 0;
+}
+
+#define QCOM_SCM_PIL_PAS_INIT_IMAGE	0x0201
+#define QCOM_SCM_PIL_PAS_MEM_SETUP	0x0202
+#define QCOM_SCM_PIL_PAS_AUTH_AND_RESET	0x0205
+#define QCOM_SCM_PIL_PAS_SHUTDOWN	0x0206
+#define QCOM_SCM_PIL_PAS_IS_SUPPORTED	0x0207
+#define QCOM_SCM_PIL_PAS_MSS_RESET	0x020a
+
+static inline const char *smc_decode_pil_cmd(uint32_t cmd)
+{
+	switch (cmd) {
+	case QCOM_SCM_PIL_PAS_INIT_IMAGE:
+		return "init_image";
+	case QCOM_SCM_PIL_PAS_MEM_SETUP:
+		return "mem_setup";
+	case QCOM_SCM_PIL_PAS_AUTH_AND_RESET:
+		return "auth_and_reset";
+	case QCOM_SCM_PIL_PAS_SHUTDOWN:
+		return "shutdown";
+	case QCOM_SCM_PIL_PAS_MSS_RESET:
+		return "mss_reset";
+	default:
+		return "???";
+	}
+}
+
+static inline const char *pas_id_name(uint32_t pas_id)
+{
+	switch (pas_id) {
+	case PAS_ID_WPSS:
+		return "wpss";
+	default:
+		return "???";
+	}
+}
+
+void qcom_handle_pil_smc(struct thread_smc_args *args)
+{
+	uint32_t sv_cmd = args->a0 & 0xffff;
+	struct qcom_q6dsp_data *selected;
+	TEE_Result res;
+
+	DMSG("Handling %s cmd for %s", smc_decode_pil_cmd(sv_cmd),
+	     pas_id_name(args->a2));
+
+	switch (args->a2) {
+	case PAS_ID_WPSS:
+		selected = &wpss_dsp_data;
+		break;
+	default:
+		DMSG("Ignoring request for unsupported DSP 0x%lx", args->a2);
+		/*
+		 * If this was an IS_SUPPORTED request,
+		 * then it's not an error.
+		 */
+		if (sv_cmd == QCOM_SCM_PIL_PAS_IS_SUPPORTED) {
+			args->a0 = OPTEE_SMC_RETURN_OK;
+			args->a1 = 0;
+		} else {
+			args->a0 = OPTEE_SMC_RETURN_EBADCMD;
+		}
+		return;
+	}
+
+	switch (sv_cmd) {
+	case QCOM_SCM_PIL_PAS_IS_SUPPORTED:
+		/*
+		 * We already handled the unsupported case above, so if we got
+		 * here then this peripheral is supported.
+		 */
+		args->a0 = OPTEE_SMC_RETURN_OK;
+		args->a1 = 1;
+		return;
+	case QCOM_SCM_PIL_PAS_INIT_IMAGE:
+		break;
+	case QCOM_SCM_PIL_PAS_MEM_SETUP:
+		/* Save base address of firmware */
+		selected->firmware_base = args->a3;
+		IMSG("Got firmware base: 0x%lx\n", selected->firmware_base);
+		break;
+	case QCOM_SCM_PIL_PAS_AUTH_AND_RESET: {
+		/*
+		 * Can't boot the DSP if we didn't get the firmware
+		 * address yet!
+		 */
+		if (!selected->firmware_base) {
+			args->a0 = QCOM_SCM_EINVAL_ADDR;
+			return;
+		}
+		res = qcom_clock_enable(selected->clk_group);
+		if (res != TEE_SUCCESS) {
+			EMSG("Failed to enable clocks: %d", res);
+			args->a0 = QCOM_SCM_EINVAL_ADDR;
+			return;
+		}
+		sc7280_dsp_start(args, selected);
+		DMSG("DSP start done!\n");
+		selected = NULL;
+	} break;
+	case QCOM_SCM_PIL_PAS_SHUTDOWN:
+		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
+		return;
+	default:
+		DMSG("Unsupported command 0x%x", sv_cmd);
+		args->a0 = OPTEE_SMC_RETURN_EBADCMD;
+		return;
+	}
+
+	args->a0 = OPTEE_SMC_RETURN_OK;
+	args->a1 = 0;
+	args->a2 = 0;
+	args->a3 = 0;
+	args->a4 = 0;
+}

--- a/core/arch/arm/plat-qcom/q6dsp.h
+++ b/core/arch/arm/plat-qcom/q6dsp.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Linaro Limited
+ */
+
+#ifndef _Q6DSP_H_
+#define _Q6DSP_H_
+
+#include <kernel/thread_arch.h>
+#include <mm/core_memprot.h>
+#include <drivers/clk_qcom.h>
+
+struct qcom_q6dsp_data {
+	int pas_id;
+	struct io_pa_va base;
+	struct io_pa_va lpass_efuse_base;
+	paddr_t firmware_base;
+	enum qcom_clk_group clk_group;
+};
+
+void qcom_handle_pil_smc(struct thread_smc_args *args);
+
+#endif /* _Q6DSP_H_ */

--- a/core/arch/arm/plat-qcom/sub.mk
+++ b/core/arch/arm/plat-qcom/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c q6dsp.c

--- a/core/drivers/clk/qcom/clock-qcom.c
+++ b/core/drivers/clk/qcom/clock-qcom.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Linaro Ltd
+ */
+
+#include <drivers/clk.h>
+#include <drivers/clk_qcom.h>
+#include <libfdt.h>
+#include <malloc.h>
+#include <stdint.h>
+#include <io.h>
+#include <mm/core_memprot.h>
+#include <trace.h>
+#include <platform_config.h>
+
+/* CBCR register fields */
+#define CBCR_BRANCH_ENABLE_BIT  BIT(0)
+#define CBCR_BRANCH_OFF_BIT     BIT(31)
+
+/* Enable clock controlled by CBC soft macro */
+static void clk_enable_cbc(paddr_t cbcr)
+{
+	io_write32(cbcr, CBCR_BRANCH_ENABLE_BIT);
+
+	while (io_read32(cbcr) & CBCR_BRANCH_OFF_BIT)
+		;
+}
+
+/* SC7280 clock offsets */
+#define GCC_WPSS_AHB_CLK 0x9d154
+#define GCC_WPSS_AHB_BDG_MST_CLK 0x9d158
+#define GCC_WPSS_RSCP_CLK 0x9d16c
+
+TEE_Result qcom_clock_enable(enum qcom_clk_group group)
+{
+	struct io_pa_va base = { .pa = GCC_BASE };
+	vaddr_t gcc_base = io_pa_or_va(&base, 0x100000);
+
+	switch (group) {
+	case QCOM_CLKS_WPSS:
+		clk_enable_cbc(gcc_base + GCC_WPSS_AHB_CLK);
+		clk_enable_cbc(gcc_base + GCC_WPSS_AHB_BDG_MST_CLK);
+		clk_enable_cbc(gcc_base + GCC_WPSS_RSCP_CLK);
+		break;
+	default:
+		EMSG("Unsupported clock group %d\n", group);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+	return TEE_SUCCESS;
+}

--- a/core/drivers/clk/qcom/sub.mk
+++ b/core/drivers/clk/qcom/sub.mk
@@ -1,0 +1,3 @@
+global-incdirs-y += .
+
+srcs-y += clock-qcom.c

--- a/core/drivers/clk/sub.mk
+++ b/core/drivers/clk/sub.mk
@@ -7,3 +7,4 @@ srcs-$(CFG_STM32MP15_CLK) += clk-stm32mp15.c
 srcs-$(CFG_STM32MP25_CLK) += clk-stm32mp25.c
 
 subdirs-$(CFG_DRIVERS_SAM_CLK) += sam
+subdirs-$(CFG_DRIVERS_QCOM_CLK) += qcom

--- a/core/drivers/geni_uart.c
+++ b/core/drivers/geni_uart.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Qualcomm GENI serial engine UART driver
+ *
+ * Copyright (c) 2025, Linaro Limited
+ *
+ * Register values taken from TF-A UART driver written in assembly.
+ */
+
+#include <console.h>
+#include <drivers/geni_uart.h>
+#include <io.h>
+#include <keep.h>
+
+#define GENI_STATUS_REG			0x40
+#define GENI_STATUS_REG_CMD_ACTIVE	BIT(0)
+#define GENI_TX_FIFO_REG		0x700
+#define GENI_TX_TRANS_LEN_REG		0x270
+#define GENI_M_CMD0_REG			0x600
+
+#define GENI_M_CMD_TX			(0x8000000)
+
+static vaddr_t chip_to_base(struct serial_chip *chip)
+{
+	struct geni_uart_data *pd =
+		container_of(chip, struct geni_uart_data, chip);
+
+	return io_pa_or_va(&pd->base, GENI_UART_REG_SIZE);
+}
+
+static void wait_tx_done(vaddr_t base)
+{
+	uint64_t timer = timeout_init_us(1000 * 1000);
+	while (io_read32(base + GENI_STATUS_REG) & GENI_STATUS_REG_CMD_ACTIVE) {
+		udelay(10);
+		if (timeout_elapsed(timer))
+			break;
+	}
+}
+
+static void geni_uart_putc(struct serial_chip *chip, int ch)
+{
+	vaddr_t base = chip_to_base(chip);
+
+	wait_tx_done(base);
+	io_write32(base + GENI_TX_TRANS_LEN_REG, 1);
+	io_write32(base + GENI_M_CMD0_REG, GENI_M_CMD_TX);
+	io_write32(base + GENI_TX_FIFO_REG, ch);
+}
+
+static const struct serial_ops geni_uart_ops = {
+	.putc = geni_uart_putc,
+};
+DECLARE_KEEP_PAGER(geni_uart_ops);
+
+void geni_uart_init(struct geni_uart_data *pd, vaddr_t base)
+{
+	pd->base.pa = base;
+	pd->chip.ops = &geni_uart_ops;
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -11,6 +11,7 @@ srcs-$(CFG_PL022) += pl022_spi.c
 srcs-$(CFG_SP805_WDT) += sp805_wdt.c
 srcs-$(CFG_8250_UART) += serial8250_uart.c
 srcs-$(CFG_16550_UART) += ns16550.c
+srcs-$(CFG_GENI_UART) += geni_uart.c
 srcs-$(CFG_IMX_SNVS) += imx_snvs.c
 srcs-$(CFG_IMX_UART) += imx_uart.c
 srcs-$(CFG_IMX_I2C) += imx_i2c.c

--- a/core/include/drivers/clk_qcom.h
+++ b/core/include/drivers/clk_qcom.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Linaro Limited
+ */
+
+#ifndef _CLK_QCOM_H_
+#define _CLK_QCOM_H_
+
+#include <stdint.h>
+#include <tee_api_types.h>
+
+enum qcom_clk_group {
+	QCOM_CLKS_WPSS,
+
+	QCOM_CLKS_MAX,
+};
+
+TEE_Result qcom_clock_enable(enum qcom_clk_group group);
+
+#endif /* _CLK_QCOM_H_ */

--- a/core/include/drivers/geni_uart.h
+++ b/core/include/drivers/geni_uart.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Linaro Limited
+ */
+#ifndef __DRIVERS_GENI_UART_H
+#define __DRIVERS_GENI_UART_H
+
+#include <types_ext.h>
+#include <drivers/serial.h>
+
+#define GENI_UART_REG_SIZE 0x4000
+
+struct geni_uart_data {
+	struct io_pa_va base;
+	struct serial_chip chip;
+};
+
+void geni_uart_init(struct geni_uart_data *pd, paddr_t base);
+
+#endif /* __DRIVERS_GENI_UART_H */
+


### PR DESCRIPTION
Introduce initial support for running OP-TEE on Qualcomm platforms, starting with the RB3 Gen 2 which is based on SC7280.

Included is basic support as well as initial support for starting up one of the DSPs using the same SMC API as Qualcomms proprietary secure world.

The TF-A patches for RB3 Gen 2 and OP-TEE support can be found here: https://review.trustedfirmware.org/q/topic:%22caleb/bringup%22
