### PR TITLE
core: arm: boot: fix calling page_alloc_init()

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -956,7 +956,9 @@ static void init_primary(unsigned long pageable_part)
 		 */
 		assert(va && va <= boot_cached_mem_end);
 		boot_cached_mem_end = va;
+	}
 
+	if (IS_ENABLED(CFG_DYN_CONFIG)) {
 		/*
 		 * This is needed to enable virt_page_alloc() now that
 		 * boot_mem_alloc() can't be used any longer.


### PR DESCRIPTION
The functions page_alloc_init() and nex_page_alloc_init() depends on MEM_AREA_TEE_DYN_VASPACE and MEM_AREA_NEX_DYN_VASPACE, but the memory areas are only available with CFG_DYN_CONFIG so check that before calling the functions.

Fixes: 0e12fb0c2d75 ("core: arm: boot: call page_alloc_init()")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
