### PR TITLE
libmbedtls: Fix typo of CFG_TA_MBEDTLS_UNSAFE_MODEXP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,5 +638,5 @@ jobs:
 
           # CFG_CORE_UNSAFE_MODEXP=y to speed up regression_4011
           # See commit cb03400251f9 ("Squashed commit upgrading to mbedtls-3.6.2")
-          # and commit 85df256c4a67 ("libmbedtls: add CFG_CORE_UNSAFE_MODEXP and CFG_TA_MEBDTLS_UNSAFE_MODEXP")
+          # and commit 85df256c4a67 ("libmbedtls: add CFG_CORE_UNSAFE_MODEXP and CFG_TA_MBEDTLS_UNSAFE_MODEXP")
           make -j$(nproc) check CFG_CORE_UNSAFE_MODEXP=y

--- a/lib/libmbedtls/mbedtls/library/bignum.c
+++ b/lib/libmbedtls/mbedtls/library/bignum.c
@@ -1846,7 +1846,7 @@ int mbedtls_mpi_exp_mod(mbedtls_mpi *X, const mbedtls_mpi *A,
                         mbedtls_mpi *prec_RR)
 {
 #if (defined(__KERNEL__) && defined(CFG_CORE_UNSAFE_MODEXP)) || \
-    (!defined(__KERNEL__) && defined(CFG_TA_MEBDTLS_UNSAFE_MODEXP))
+    (!defined(__KERNEL__) && defined(CFG_TA_MBEDTLS_UNSAFE_MODEXP))
     return mbedtls_mpi_exp_mod_unsafe(X, A, E, N, prec_RR);
 #else
     return mbedtls_mpi_exp_mod_optionally_safe(X, A, E, MBEDTLS_MPI_IS_SECRET, N, prec_RR);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1262,7 +1262,7 @@ CFG_CORE_UNSAFE_MODEXP ?= n
 # CFG_TA_MBEDTLS_UNSAFE_MODEXP, similar to CFG_CORE_UNSAFE_MODEXP,
 # when enabled, makes MBedTLS library for TAs use 'unsafe' modular
 # exponentiation algorithm.
-CFG_TA_MEBDTLS_UNSAFE_MODEXP ?= n
+CFG_TA_MBEDTLS_UNSAFE_MODEXP ?= n
 
 # CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL, when enabled, initializes
 # thread_core_local[current_core_pos] before calling C code.


### PR DESCRIPTION
CFG_TA_"MEBDTLS"_UNSAFE_MODEXP is typo. This commit fixes it.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
