### PR TITLE
RISC-V: Keep boot stage up-to-date

### DIFF
--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -62,12 +62,6 @@ static void update_external_dt(void)
 }
 #endif /*!CFG_DT*/
 
-void init_sec_mon(unsigned long nsec_entry __maybe_unused)
-{
-	assert(nsec_entry == PADDR_INVALID);
-	/* Do nothing as we don't have a secure monitor */
-}
-
 #ifdef CFG_RISCV_S_MODE
 static void start_secondary_cores(void)
 {
@@ -122,7 +116,7 @@ static bool add_padding_to_pool(vaddr_t va, size_t len, void *ptr __unused)
 	return true;
 }
 
-static void init_primary(unsigned long nsec_entry)
+static void init_primary(void)
 {
 	vaddr_t va __maybe_unused = 0;
 
@@ -149,7 +143,6 @@ static void init_primary(unsigned long nsec_entry)
 	thread_init_boot_thread();
 	thread_init_primary();
 	thread_init_per_cpu();
-	init_sec_mon(nsec_entry);
 }
 
 /* May be overridden in plat-$(PLATFORM)/main.c */
@@ -206,9 +199,7 @@ __weak void boot_secondary_init_intc(void)
 
 void boot_init_primary_early(void)
 {
-	unsigned long e = PADDR_INVALID;
-
-	init_primary(e);
+	init_primary();
 }
 
 void boot_init_primary_late(unsigned long fdt,
@@ -251,7 +242,7 @@ void __weak boot_init_primary_final(void)
 #endif
 }
 
-static void init_secondary_helper(unsigned long nsec_entry)
+static void init_secondary_helper(void)
 {
 	size_t pos = get_core_pos();
 
@@ -268,7 +259,6 @@ static void init_secondary_helper(unsigned long nsec_entry)
 	thread_set_exceptions(THREAD_EXCP_ALL);
 
 	thread_init_per_cpu();
-	init_sec_mon(nsec_entry);
 	boot_secondary_init_intc();
 
 	IMSG("Secondary CPU%zu (hart%"PRIu32") initialized",
@@ -277,5 +267,5 @@ static void init_secondary_helper(unsigned long nsec_entry)
 
 void boot_init_secondary(unsigned long nsec_entry __unused)
 {
-	init_secondary_helper(PADDR_INVALID);
+	init_secondary_helper();
 }

--- a/core/arch/riscv/kernel/boot.c
+++ b/core/arch/riscv/kernel/boot.c
@@ -18,6 +18,7 @@
 #include <libfdt.h>
 #include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
+#include <mm/page_alloc.h>
 #include <mm/tee_mm.h>
 #include <mm/tee_pager.h>
 #include <platform_config.h>
@@ -136,6 +137,8 @@ static void init_primary(void)
 	core_mmu_init_phys_mem();
 	boot_mem_foreach_padding(add_padding_to_pool, NULL);
 	va = boot_mem_release_unused();
+	if (IS_ENABLED(CFG_DYN_CONFIG))
+		page_alloc_init();
 
 	thread_init_threads(CFG_NUM_THREADS);
 	thread_init_primary();

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -7,6 +7,7 @@
 #include <asm.S>
 #include <generated/asm-defines.h>
 #include <keep.h>
+#include <kernel/thread.h>
 #include <kernel/thread_private.h>
 #include <mm/core_mmu.h>
 #include <platform_config.h>
@@ -178,8 +179,16 @@ UNWIND(	.cantunwind)
 	set_sp
 	set_tp
 
-	li	a0, CFG_TEE_CORE_NB_CORE
-	jal	thread_init_thread_core_local
+	/* Initialize thread_core_local[hart_index] for early boot */
+	jal	thread_get_abt_stack
+	mv	a1, sp
+	STR	a1, THREAD_CORE_LOCAL_TMP_STACK_VA_END(tp)
+	STR	a0, THREAD_CORE_LOCAL_ABT_STACK_VA_END(tp)
+	li	a0, THREAD_ID_INVALID
+	sh	a0, THREAD_CORE_LOCAL_CURR_THREAD(tp)
+	li	a0, THREAD_CLF_TMP
+	sw	a0, THREAD_CORE_LOCAL_FLAGS(tp)
+
 	jal	plat_primary_init_early
 	jal	console_init
 
@@ -196,8 +205,12 @@ UNWIND(	.cantunwind)
 
 	jal	boot_init_primary_early
 
+	mv	a0, s1		/* s1 contains saved device tree address */
+	mv	a1, x0		/* unused */
+	jal	boot_init_primary_late
+
 	/*
-	 * Before entering boot_init_primary_late(), we do these two steps:
+	 * Before entering boot_init_primary_runtime(), we do these two steps:
 	 * 1. Save current sp to s2, and set sp as threads[0].stack_va_end
 	 * 2. Clear the flag which indicates usage of the temporary stack in the
 	 *    current hart's thread_core_local structure.
@@ -211,9 +224,7 @@ UNWIND(	.cantunwind)
 	mv	s3, a0
 	sw	zero, THREAD_CORE_LOCAL_FLAGS(s3)
 
-	mv	a0, s1		/* s1 contains saved device tree address */
-	mv	a1, x0		/* unused */
-	jal	boot_init_primary_late
+	jal	boot_init_primary_runtime
 	jal	boot_init_primary_final
 
 	/*

--- a/core/include/kernel/thread.h
+++ b/core/include/kernel/thread.h
@@ -85,7 +85,6 @@ vaddr_t thread_get_abt_stack(void);
  * CFG_DYN_CONFIG=y, else @core_count must equal CFG_TEE_CORE_NB_CORE.
  */
 void thread_init_thread_core_local(size_t core_count);
-void thread_init_core_local_stacks(void);
 
 #if defined(CFG_CORE_PAUTH)
 void thread_init_thread_pauth_keys(void);

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -263,9 +263,8 @@ get_core_local(unsigned int pos)
 	assert(thread_get_exceptions() & THREAD_EXCP_FOREIGN_INTR);
 
 	/*
-	 * With CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL, we boot on a
-	 * single core and have allocated only one struct thread_core_local
-	 * so we return that regardless of pos.
+	 * We boot on a single core and have allocated only one struct
+	 * thread_core_local so we return that regardless of pos.
 	 */
 	if (IS_ENABLED(CFG_DYN_STACK_CONFIG) &&
 	    thread_core_local != __thread_core_local_new)
@@ -612,7 +611,6 @@ vaddr_t __nostackcheck thread_get_abt_stack(void)
 }
 #endif
 
-#ifdef CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL
 void thread_init_thread_core_local(size_t core_count)
 {
 	struct thread_core_local *tcl = NULL;
@@ -667,33 +665,6 @@ void thread_init_thread_core_local(size_t core_count)
 		tcl[n].abt_stack_va_end = va;
 	}
 }
-#else
-void __nostackcheck
-thread_init_thread_core_local(size_t core_count __maybe_unused)
-{
-	size_t n = 0;
-	struct thread_core_local *tcl = thread_core_local;
-
-	assert(core_count == CFG_TEE_CORE_NB_CORE);
-	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++) {
-		tcl[n].curr_thread = THREAD_ID_INVALID;
-		tcl[n].flags = THREAD_CLF_TMP;
-	}
-	tcl[0].tmp_stack_va_end = GET_STACK_BOTTOM(stack_tmp, 0);
-}
-
-void __nostackcheck thread_init_core_local_stacks(void)
-{
-	size_t n = 0;
-	struct thread_core_local *tcl = thread_core_local;
-
-	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++) {
-		tcl[n].tmp_stack_va_end = GET_STACK_BOTTOM(stack_tmp, n) -
-					  STACK_TMP_OFFS;
-		tcl[n].abt_stack_va_end = GET_STACK_BOTTOM(stack_abt, n);
-	}
-}
-#endif /*CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL*/
 
 #if defined(CFG_CORE_PAUTH)
 void thread_init_thread_pauth_keys(void)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1283,14 +1283,6 @@ CFG_CORE_UNSAFE_MODEXP ?= n
 # exponentiation algorithm.
 CFG_TA_MBEDTLS_UNSAFE_MODEXP ?= n
 
-# CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL, when enabled, initializes
-# thread_core_local[current_core_pos] before calling C code.
-ifeq ($(ARCH),arm)
-$(call force,CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL,y)
-else
-CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL ?= n
-endif
-
 # CFG_DYN_CONFIG, when enabled, use dynamic memory allocation for translation
 # tables. Not supported with pager.
 # CFG_DYN_STACK_CONFIG, when enabled, use dynamic memory allocation for


### PR DESCRIPTION
This PR tries to keep RISC-V's boot stage up-to-date with ARM's.
- Initialize `thread_core_local[primary_cpu_id]` in assembly code before calling C code
- Remove `CFG_BOOT_INIT_CURRENT_THREAD_CORE_LOCAL` since both architectures explicitly support this feature.
- Call `page_alloc_init()`

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
