### PR TITLE
core: arm: remove THREAD_CORE_LOCAL_STACKCHECK_RECURSION

### DIFF
--- a/core/arch/arm/kernel/asm-defines.c
+++ b/core/arch/arm/kernel/asm-defines.c
@@ -147,10 +147,6 @@ DEFINES
 	DEFINE(THREAD_CORE_LOCAL_DIRECT_RESP_FID,
 	       offsetof(struct thread_core_local, direct_resp_fid));
 #endif
-#if defined(CFG_CORE_DEBUG_CHECK_STACKS)
-	DEFINE(THREAD_CORE_LOCAL_STACKCHECK_RECURSION,
-	       offsetof(struct thread_core_local, stackcheck_recursion));
-#endif
 
 	DEFINE(STACK_TMP_GUARD, STACK_CANARY_SIZE / 2 + STACK_TMP_OFFS);
 

--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -466,11 +466,6 @@ shadow_stack_access_ok:
 	mov	sp, r1
 	cps	#CPSR_MODE_SVC
 
-#ifdef CFG_CORE_DEBUG_CHECK_STACKS
-	mov	r2, #1
-	strb	r2, [r1, #THREAD_CORE_LOCAL_STACKCHECK_RECURSION]
-#endif
-
 	str	sp, [r1, #THREAD_CORE_LOCAL_TMP_STACK_VA_END]
 	str	r0, [r1, #THREAD_CORE_LOCAL_ABT_STACK_VA_END]
 	mov	r0, #THREAD_ID_INVALID
@@ -600,14 +595,6 @@ shadow_stack_access_ok:
 	mov	sp, r4
 	cps	#CPSR_MODE_SVC
 
-#if defined(CFG_CORE_DEBUG_CHECK_STACKS)
-	/*
-	 * Clear thread_core_local[current_cpu_id].stackcheck_recursion now
-	 * that the stack pointer matches recorded information.
-	 */
-	mov	r2, #0
-	strb	r2, [r4, #THREAD_CORE_LOCAL_STACKCHECK_RECURSION]
-#endif
 	/*
 	 * Reinitialize console, since register_serial_console() has
 	 * previously registered a PA and with ASLR the VA is different

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -291,10 +291,6 @@ clear_nex_bss:
 	msr	spsel, #1
 	str	x1, [sp, #THREAD_CORE_LOCAL_TMP_STACK_VA_END]
 	str	x0, [sp, #THREAD_CORE_LOCAL_ABT_STACK_VA_END]
-#ifdef CFG_CORE_DEBUG_CHECK_STACKS
-	mov	x0, #1
-	strb	w0, [sp, #THREAD_CORE_LOCAL_STACKCHECK_RECURSION]
-#endif
 	mov	x0, #THREAD_ID_INVALID
 	str	x0, [sp, #THREAD_CORE_LOCAL_CURR_THREAD]
 	mov	w0, #THREAD_CLF_TMP
@@ -402,9 +398,6 @@ clear_nex_bss:
 	ldr	x1, [sp, #THREAD_CORE_LOCAL_ABT_STACK_VA_END]
 	add	x1, x1, x0
 	str	x1, [sp, #THREAD_CORE_LOCAL_ABT_STACK_VA_END]
-#ifdef CFG_CORE_DEBUG_CHECK_STACKS
-	strb	wzr, [sp, #THREAD_CORE_LOCAL_STACKCHECK_RECURSION]
-#endif
 	msr	spsel, #0
 	/*
 	 * Reinitialize console, since register_serial_console() has


### PR DESCRIPTION
THREAD_CORE_LOCAL_STACKCHECK_RECURSION was introduced in the commit b5ec8152f3e5 ("core: arm: refactor boot"). However, clearing the stackcheck_recursion flag from assembly during boot isn't needed since the stack pointer is set up in synch with the recorded information in thread_core_local. So remove the unnecessary clearing and remove THREAD_CORE_LOCAL_STACKCHECK_RECURSION.

Reported-by: Alvin Chang <alvinga@andestech.com>
Closes: https://github.com/OP-TEE/optee_os/commit/b5ec8152f3e5ad8cc111952f0483f5cf903aac7c#r154088026

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
