### PR TITLE
Export _CFG_TA_STACK_PROTECTOR for TA random stack canary

### DIFF
--- a/ta/mk/ta_dev_kit.mk
+++ b/ta/mk/ta_dev_kit.mk
@@ -105,9 +105,9 @@ libdeps += $(ta-dev-kit-dir$(sm))/lib/libdl.a
 libnames-after-libgcc += utils
 libdeps-after-libgcc += $(ta-dev-kit-dir$(sm))/lib/libutils.a
 
-# Pass config variable (CFG_) from conf.mk on the command line
+# Pass config variable (CFG_) and (_CFG_) from conf.mk on the command line
 cppflags$(sm) += $(strip \
-	$(foreach var, $(filter CFG_%,$(.VARIABLES)), \
+	$(foreach var, $(filter CFG_% _CFG_%,$(.VARIABLES)), \
 		$(if $(filter y,$($(var))), \
 			-D$(var)=1, \
 			$(if $(filter xn x,x$($(var))),,-D$(var)='$($(var))'))))

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -47,6 +47,7 @@ ta-mk-file-export-vars-$(sm) += CFG_ATTESTATION_PTA
 ta-mk-file-export-vars-$(sm) += CFG_MEMTAG
 ta-mk-file-export-vars-$(sm) += CFG_TA_LIBGCC
 ta-mk-file-export-vars-$(sm) += CFG_TA_SANITIZE_UNDEFINED
+ta-mk-file-export-vars-$(sm) += _CFG_TA_STACK_PROTECTOR
 
 # Expand platform flags here as $(sm) will change if we have several TA
 # targets. Platform flags should not change after inclusion of ta/ta.mk.

--- a/ta/ta.mk
+++ b/ta/ta.mk
@@ -12,9 +12,13 @@ include mk/$(COMPILER_$(sm)).mk
 # Config flags from mk/config.mk
 #
 
+ifeq ($(_CFG_TA_STACK_PROTECTOR),y)
 ta-stackp-cflags-$(CFG_TA_STACK_PROTECTOR) := -fstack-protector
 ta-stackp-cflags-$(CFG_TA_STACK_PROTECTOR_STRONG) := -fstack-protector-strong
 ta-stackp-cflags-$(CFG_TA_STACK_PROTECTOR_ALL) := -fstack-protector-all
+else
+ta-stackp-cflags-y := -fno-stack-protector
+endif
 $(sm)-platform-cflags += $(ta-stackp-cflags-y)
 
 ifeq ($(CFG_TA_MBEDTLS_SELF_TEST),y)


### PR DESCRIPTION
Even though the `CFG_TA_STACK_PROTECTOR_STRONG` is default to `y`, the TA's random stack canary is not generated in `__ta_entry()`.
Issue is caused by `_CFG_TA_STACK_PROTECTOR` not exported to TA compilation.
This PR fixes this issue.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
