### PR TITLE
scripts: use /usr/bin/env bash

### DIFF
--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="${BASH_SOURCE%/*}"
 

--- a/scripts/checkpatch_inc.sh
+++ b/scripts/checkpatch_inc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CHECKPATCH="${CHECKPATCH:-checkpatch.pl}"
 CHECKPATCH_OPT="${CHECKPATCH_OPT:-}"

--- a/ta/pkcs11/scripts/dump_ec_curve_params.sh
+++ b/ta/pkcs11/scripts/dump_ec_curve_params.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 EC_CURVES="prime192v1 secp224r1 prime256v1 secp384r1 secp521r1"

--- a/ta/pkcs11/scripts/verify-helpers.sh
+++ b/ta/pkcs11/scripts/verify-helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-2-Clause
 
 SHOW_DETAILS=1


### PR DESCRIPTION
Some distributions don't install bash inside of bash since the only program thats required to be available in /bin according to POSIX is sh. Consequently running scripts with #!/bin/bash fails on such systems. Use /usr/bin/env (which is required to be available according to POSIX) to run the correct bash binary.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
