### PR TITLE
drivers: imx_csu: add SA settings for i.MX6ULL

### DIFF
--- a/core/drivers/imx_csu.c
+++ b/core/drivers/imx_csu.c
@@ -79,7 +79,7 @@ const struct csu_sa_setting csu_sa_imx7ds = { 0x15554554, 0x2aaa8aaa };
 
 const struct csu_config csu_imx6 = { &csu_sa_imx6, csu_setting_imx6 };
 const struct csu_config csu_imx6ul = { &csu_sa_imx6ul, csu_setting_imx6ul };
-const struct csu_config csu_imx6ull = { NULL, csu_setting_imx6ull };
+const struct csu_config csu_imx6ull = { &csu_sa_imx6ul, csu_setting_imx6ull };
 const struct csu_config csu_imx6sl = { NULL, csu_setting_imx6sl };
 const struct csu_config csu_imx6sx = { NULL, csu_setting_imx6sx };
 const struct csu_config csu_imx7ds = { &csu_sa_imx7ds, csu_setting_imx7ds };


### PR DESCRIPTION
Add the CSU SA settings for i.MX6ULL. The i.MX6ULL implements the same non-Trustzone aware masters as the i.MX6UL, so the same settings can be used. This setting ensures that no non-TrustZone aware master is able to read secure memory. Information on the CSU SA register values were taken from i.MX6ULL Security Reference Manual rev 0.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
