### PR TITLE
core: fs_htee: Fix wrong aad length in authenc_init()

### DIFF
--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <config.h>
 #include <crypto/crypto.h>
 #include <initcall.h>
 #include <kernel/tee_common_otp.h>
@@ -473,8 +474,13 @@ static TEE_Result authenc_init(void **ctx_ret, TEE_OperationMode mode,
 		goto err_free;
 
 	if (!ni) {
+		size_t hash_size = TEE_FS_HTREE_HASH_SIZE;
+
+		if (IS_ENABLED(CFG_REE_FS_HTREE_HASH_SIZE_COMPAT))
+			hash_size = TEE_FS_HTREE_FEK_SIZE;
+
 		res = crypto_authenc_update_aad(ctx, mode, ht->root.node.hash,
-						TEE_FS_HTREE_FEK_SIZE);
+						hash_size);
 		if (res != TEE_SUCCESS)
 			goto err;
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -149,6 +149,12 @@ CFG_TEE_FW_MANUFACTURER ?= FW_MAN_UNDEF
 # TEE_STORAGE_PRIVATE is passed to the trusted storage API)
 CFG_REE_FS ?= y
 
+# CFG_REE_FS_HTREE_HASH_SIZE_COMPAT, when enabled, supports the legacy
+# REE FS hash tree tagging implementation that uses a truncated hash.
+# Be warned that disabling this config could break accesses to existing
+# REE FS content.
+CFG_REE_FS_HTREE_HASH_SIZE_COMPAT ?= y
+
 # RPMB file system support
 CFG_RPMB_FS ?= n
 


### PR DESCRIPTION
In authenc_init(), aad length field passed to
crypto_authenc_init() does not match with the total aad data passed via crypto_authenc_update_aad() for lower layer crypto computation. This fixes the issue.

Link: https://github.com/OP-TEE/optee_os/issues/7331

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
