### PR TITLE
libutils: merge malloc pools if possible

### DIFF
--- a/lib/libutils/isoc/bget.c
+++ b/lib/libutils/isoc/bget.c
@@ -1125,7 +1125,7 @@ void bpool(buf, len, poolset)
        it  had	better	not  be  (much) larger than the largest buffer
        whose size we can store in bhead.bsize. */
 
-    assert(len - sizeof(struct bhead) <= -((bufsize) ESent + 1));
+    assert(len - sizeof(struct bfhead) <= -((bufsize) ESent + 1));
 
     /* Clear  the  backpointer at  the start of the block to indicate that
        there  is  no  free  block  prior  to  this   one.    That   blocks
@@ -1150,7 +1150,7 @@ void bpool(buf, len, poolset)
        routines (this specific value is  not  counted  on  by  the  actual
        allocation and release functions). */
 
-    len -= sizeof(struct bhead);
+    len -= sizeof(struct bfhead);
     b->bh.bsize = (bufsize) len;
 #ifdef FreeWipe
     V memset_unchecked(((char *) b) + sizeof(struct bfhead), 0x55,


### PR DESCRIPTION
When adding pools with for instance malloc_add_pool(), check if the pool can be merged with other pools. This decreases fragmentation by removing unneeded allocated end of pool sentinels between merged pools.

The end of pool sentinel is changed from a struct bhead to a struct bfhead, increasing it by two pointers, to allow it to be freed using brel() once it has been turned into a regular allocated block.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
