### PR TITLE
core: imx: disable ELE on i.MX8ULP by default

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -228,7 +228,7 @@ CFG_TEE_CORE_NB_CORE ?= 2
 $(call force,CFG_NXP_SNVS,n)
 $(call force,CFG_IMX_OCOTP,n)
 CFG_IMX_MU ?= y
-CFG_IMX_ELE ?= y
+CFG_IMX_ELE ?= n
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx93-flavorlist)))
 $(call force,CFG_MX93,y)
 $(call force,CFG_ARM64_core,y)


### PR DESCRIPTION
Sorry for back and forth about the ELE support enablement.
On i.MX8ULP, there is only one MU to communicate with ELE,
which cannot be dedicated on OP-TEE side all the time.
There may be ELE services running on Linux side, which can
cause conflict with OP-TEE, So disabling ELE by default.
Moreover i.MX8ULP also has CAAM, so HUK and Random
number are coming from CAAM.

