### PR TITLE
core: arm: ffa: enable FF-A version 1.2 for virtualization

### DIFF
--- a/core/arch/arm/kernel/thread_spmc.c
+++ b/core/arch/arm/kernel/thread_spmc.c
@@ -168,15 +168,6 @@ uint32_t spmc_exchange_version(uint32_t vers, struct ffa_rxtx *rxtx)
 	uint32_t my_major_vers = 0;
 	uint32_t my_minor_vers = 0;
 
-	/*
-	 * Holding back the FF-A version if we use Xen or S-EL0 SPs.
-	 * - Xen doesn't handle negotiating with version 1.2.
-	 * - S-EL0 SPs are limited to x0-x7 for normal world requests.
-	 * We'll remove this when the obstacles are cleared.
-	 */
-	if (IS_ENABLED(CFG_NS_VIRTUALIZATION))
-		my_vers = FFA_VERSION_1_1;
-
 	my_major_vers = FFA_GET_MAJOR_VERSION(my_vers);
 	my_minor_vers = FFA_GET_MINOR_VERSION(my_vers);
 


### PR DESCRIPTION
With Xen version 4.20 released we can announce version 1.2 for OP-TEE when negotiating the version to use. So remove the special check for CFG_NS_VIRTUALIZATION=y when exchanging versions.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
