### PR TITLE
Core + stm32: Add external device tree repository support

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -61,6 +61,19 @@ flavorlist-MP13 = $(flavor_dts_file-135F_DK)
 flavorlist-dh-platforms = $(flavor_dts_file-157A_DHCOR_AVENGER96) \
 			  $(flavor_dts_file-157C_DHCOM_PDK2)
 
+# Check if device-tree exist in OP-TEE source code, else search it in external
+# device tree repository
+ifeq ($(wildcard $(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE)),)
+# External device tree default path
+CFG_EXT_DTS ?= $(arch-dir)/dts/external-dt/optee
+ifneq ($(wildcard $(CFG_EXT_DTS)/$(CFG_EMBED_DTB_SOURCE_FILE)),)
+override dts-source-path := $(CFG_EXT_DTS)
+-include $(CFG_EXT_DTS)/conf.mk
+else
+$(error Cannot find DTS file $(CFG_EXT_DTS)/$(CFG_EMBED_DTB_SOURCE_FILE))
+endif
+endif
+
 ifneq ($(PLATFORM_FLAVOR),)
 ifeq ($(flavor_dts_file-$(PLATFORM_FLAVOR)),)
 $(error Invalid platform flavor $(PLATFORM_FLAVOR))

--- a/core/arch/arm/plat-stm32mp2/conf.mk
+++ b/core/arch/arm/plat-stm32mp2/conf.mk
@@ -2,6 +2,19 @@ flavor_dts_file-257F_EV1 = stm32mp257f-ev1.dts
 
 flavorlist-MP25 = $(flavor_dts_file-257F_EV1)
 
+# Check if device-tree exist in OP-TEE source code, else search it in external
+# device tree repository
+ifeq ($(wildcard $(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE)),)
+# External device tree default path
+CFG_EXT_DTS ?= $(arch-dir)/dts/external-dt/optee
+ifneq ($(wildcard $(CFG_EXT_DTS)/$(CFG_EMBED_DTB_SOURCE_FILE)),)
+override dts-source-path := $(CFG_EXT_DTS)
+-include $(CFG_EXT_DTS)/conf.mk
+else
+$(error Cannot find DTS file $(CFG_EXT_DTS)/$(CFG_EMBED_DTB_SOURCE_FILE))
+endif
+endif
+
 ifneq ($(PLATFORM_FLAVOR),)
 ifeq ($(flavor_dts_file-$(PLATFORM_FLAVOR)),)
 $(error Invalid platform flavor $(PLATFORM_FLAVOR))

--- a/core/sub.mk
+++ b/core/sub.mk
@@ -51,7 +51,8 @@ endef
 $(foreach f, $(SP_PATHS), $(eval $(call process_secure_partition,$(f))))
 
 ifeq ($(CFG_EMBED_DTB),y)
-core-embed-fdt-dts = $(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE)
+dts-source-path = $(arch-dir)/dts
+core-embed-fdt-dts = $(dts-source-path)/$(CFG_EMBED_DTB_SOURCE_FILE)
 core-embed-fdt-dtb = $(out-dir)/$(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.dtb)
 core-embed-fdt-c = $(out-dir)/$(arch-dir)/dts/$(CFG_EMBED_DTB_SOURCE_FILE:.dts=.c)
 gensrcs-y += embedded_secure_dtb

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -269,8 +269,8 @@ cleanfiles := $$(cleanfiles) $2 \
 		$$(dtb-predts-$2) $$(dtb-predep-$2) \
 		$$(dtb-dep-$2) $$(dtb-cmd-file-$2)
 
-dtb-cppflags-$2 := -Icore/include/ -x assembler-with-cpp -undef -D__DTS__ \
-		   -E -ffreestanding $$(CPPFLAGS) \
+dtb-cppflags-$2 := -Icore/include/ -I$(arch-dir)/dts -x assembler-with-cpp \
+		   -undef -D__DTS__ -E -ffreestanding $$(CPPFLAGS) \
 		   -MD -MF $$(dtb-predep-$2) -MT $$(dtb-predts-$2)
 
 dtb-dtcflags-$2	:= $$(DTC_FLAGS) -I dts -O dtb -Wno-unit_address_vs_reg \


### PR DESCRIPTION
This P-R adds the support for specifying an external repository for the device tree sources.
