### PR TITLE
core: ffa: reserve physical memory for manifest

### DIFF
--- a/core/arch/arm/kernel/boot.c
+++ b/core/arch/arm/kernel/boot.c
@@ -1346,7 +1346,8 @@ static void *get_fdt_from_boot_info(struct ffa_boot_info_header_1_1 *hdr)
 	return fdt;
 }
 
-static void get_sec_mem_from_manifest(void *fdt, paddr_t *base, size_t *size)
+static void get_sec_mem_from_manifest(void *fdt, paddr_t *base,
+				      paddr_size_t *size)
 {
 	int ret = 0;
 	uint64_t num = 0;
@@ -1441,20 +1442,30 @@ void __weak boot_save_args(unsigned long a0, unsigned long a1,
 	}
 
 	if (IS_ENABLED(CFG_CORE_FFA)) {
+		size_t fdt_max_size = CFG_DTB_MAX_SIZE;
+		void *fdt = NULL;
+
 		if (IS_ENABLED(CFG_CORE_SEL2_SPMC) ||
 		    IS_ENABLED(CFG_CORE_EL3_SPMC))
-			init_manifest_dt(get_fdt_from_boot_info((void *)a0));
+			fdt = get_fdt_from_boot_info((void *)a0);
 		else
-			init_manifest_dt((void *)a0);
-		if (IS_ENABLED(CFG_CORE_SEL2_SPMC) &&
-		    IS_ENABLED(CFG_CORE_PHYS_RELOCATABLE)) {
+			fdt = (void *)a0;
+		if (IS_ENABLED(CFG_CORE_SEL2_SPMC)) {
+			paddr_size_t size = 0;
 			paddr_t base = 0;
-			size_t size = 0;
 
-			get_sec_mem_from_manifest(get_manifest_dt(),
-						  &base, &size);
-			core_mmu_set_secure_memory(base, size);
+			if (IS_ENABLED(CFG_CORE_PHYS_RELOCATABLE)) {
+				get_sec_mem_from_manifest(fdt, &base, &size);
+				core_mmu_set_secure_memory(base, size);
+			} else {
+				core_mmu_get_secure_memory(&base, &size);
+			}
+			assert((unsigned long)fdt >= base);
+			assert((unsigned long)fdt <= base + size);
+			assert((unsigned long)fdt < VCORE_START_VA);
+			fdt_max_size = VCORE_START_VA - (unsigned long)fdt;
 		}
+		init_manifest_dt(fdt, fdt_max_size);
 	} else {
 		if (IS_ENABLED(CFG_WITH_PAGER)) {
 #if defined(CFG_PAGEABLE_ADDR)

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -320,15 +320,17 @@ int add_res_mem_dt_node(struct dt_descriptor *dt, const char *name,
 /*
  * init_manifest_dt() - Initialize the manifest DTB to given address.
  * @fdt:	Physical address where the manifest DTB located.
+ * @max_size:	Maximum size of the DTB
  *
  * Initialize the manifest DTB to physical address
  */
-void init_manifest_dt(void *fdt);
+void init_manifest_dt(void *fdt, size_t max_size);
 
 /*
  * reinit_manifest_dt() - Reinitialize the manifest DTB
  *
- * Add MMU mapping of the manifest DTB and initialize device tree overlay
+ * Reserve used physical memory, add MMU mapping of the manifest DTB, and
+ * initialize device tree overlay
  */
 void reinit_manifest_dt(void);
 
@@ -492,7 +494,8 @@ static inline int add_res_mem_dt_node(struct dt_descriptor *dt __unused,
 	return -1;
 }
 
-static inline void init_manifest_dt(void *fdt __unused)
+static inline void init_manifest_dt(void *fdt __unused,
+				    size_t max_size __unused)
 {
 }
 


### PR DESCRIPTION
With CFG_CORE_SEL2_SPMC=y (Hafnium as SPMC at S-EL2), the FF-A manifest passed to OP-TEE resides in the memory reserved for OP-TEE just before the load address. The physical memory pool is initialized with the entire range of secure memory, with holes carved out for already used memory.

Temporarily allocate the physical memory used by the manifest until it's not needed any longer and released by release_manifest_dt().

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
