### PR TITLE
ta: pkcs11: Increase destination key size for TEE_AsymmetricDecrypt

### DIFF
--- a/ta/pkcs11/src/processing_asymm.c
+++ b/ta/pkcs11/src/processing_asymm.c
@@ -1179,7 +1179,7 @@ static enum pkcs11_rc unwrap_rsa_aes_key(struct active_processing *proc,
 	struct rsa_aes_key_wrap_processing_ctx *ctx = proc->extra_ctx;
 	mbedtls_nist_kw_context kw_ctx = { };
 	uint8_t aes_key_value[32] = { };
-	size_t aes_key_size = ctx->aes_key_bits / 8;
+	size_t aes_key_size = 0;
 	uint32_t wrapped_key_size = 0;
 	uint32_t rsa_key_size = 0;
 	size_t target_key_size = 0;
@@ -1193,6 +1193,7 @@ static enum pkcs11_rc unwrap_rsa_aes_key(struct active_processing *proc,
 	rsa_key_size = info.keySize / 8;
 	wrapped_key_size = data_sz - rsa_key_size;
 	target_key_size = wrapped_key_size - 8;
+	aes_key_size = rsa_key_size;
 
 	*out_buf = TEE_Malloc(target_key_size, TEE_MALLOC_FILL_ZERO);
 	if (!*out_buf)


### PR DESCRIPTION
This update increases the destination key size for the TEE_AsymmetricDecrypt function within the unwrap_rsa_aes_key function. According to the GP specification, the destination size must be greater than or equal to the source length.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
