### PR TITLE
core: fix discovered ns-mem check

### DIFF
--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -523,6 +523,8 @@ void core_mmu_set_discovered_nsec_ddr(struct core_mmu_phys_mem *start,
 		case MEM_AREA_SHM_VASPACE:
 		case MEM_AREA_TS_VASPACE:
 		case MEM_AREA_PAGER_VASPACE:
+		case MEM_AREA_NEX_DYN_VASPACE:
+		case MEM_AREA_TEE_DYN_VASPACE:
 			break;
 		default:
 			check_phys_mem_is_outside(m, num_elems,


### PR DESCRIPTION
When discovering or assigning available non-secure physical memory it's checked against overlaps with other memory types. Memory types reserving virtual memory space should be excluded including the two recently added types MEM_AREA_NEX_DYN_VASPACE and MEM_AREA_TEE_DYN_VASPACE. This was missed when the memory types where added so add the check to exclude them now.

This fixes an error like:
E/TC:0   check_phys_mem_is_outside:455 Non-sec mem (0:0x60000000) overlaps map (type 10 0:0x100000) E/TC:0   Panic at core/mm/core_mmu.c:459 <check_phys_mem_is_outside>

Fixes: 96f43358c593 ("core: add nex_dyn_vaspace and tee_dyn_vaspace areas")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
