### PR TITLE
libmbedtls: sync with DTLS connect ID build fix

### DIFF
--- a/lib/libmbedtls/mbedtls/include/mbedtls/ssl.h
+++ b/lib/libmbedtls/mbedtls/include/mbedtls/ssl.h
@@ -657,7 +657,7 @@
 #define MBEDTLS_TLS_EXT_KEY_SHARE                   51 /* RFC 8446 TLS 1.3 */
 
 /*
- * MBEDTLS_TLS_EXT_CID is required only when deprecated
+ * MBEDTLS_TLS_EXT_CID is required only when
  * MBEDTLS_SSL_DTLS_CONNECTION_ID is defined.
  */
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)


### PR DESCRIPTION
Sync with the build warning fix related to DTLS connect ID that has been approved in Mbed TLS [1].

Link: https://github.com/Mbed-TLS/mbedtls/pull/10113 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
