### PR TITLE
Update CHANGELOG for 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# OP-TEE - version 4.6.0 (2025-04-25)
+
+- Links to the release pages, commits and pull requests merged into this release for:
+  - OP-TEE/optee_os: [release page][OP_TEE_optee_os_release_4_6_0], [commits][OP_TEE_optee_os_commits_4_6_0] and [pull requests][OP_TEE_optee_os_pr_4_6_0]
+  - OP-TEE/optee_client: [release page][OP_TEE_optee_client_release_4_6_0], [commits][OP_TEE_optee_client_commits_4_6_0] and [pull requests][OP_TEE_optee_client_pr_4_6_0]
+  - OP-TEE/optee_test: [release page][OP_TEE_optee_test_release_4_6_0], [commits][OP_TEE_optee_test_commits_4_6_0] and [pull requests][OP_TEE_optee_test_pr_4_6_0]
+  - OP-TEE/build: [release page][OP_TEE_build_release_4_6_0], [commits][OP_TEE_build_commits_4_6_0] and [pull requests][OP_TEE_build_pr_4_6_0]
+  - linaro-swg/optee_examples: [release page][linaro_swg_optee_examples_release_4_6_0], [commits][linaro_swg_optee_examples_commits_4_6_0] and [pull requests][linaro_swg_optee_examples_pr_4_6_0]
+
+
+[OP_TEE_optee_os_release_4_6_0]: https://github.com/OP-TEE/optee_os/releases/tag/4.6.0
+[OP_TEE_optee_os_commits_4_6_0]: https://github.com/OP-TEE/optee_os/compare/4.5.0...4.6.0
+[OP_TEE_optee_os_pr_4_6_0]: https://github.com/OP-TEE/optee_os/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2024-01-17..2025-04-25
+
+[OP_TEE_optee_client_release_4_6_0]: https://github.com/OP-TEE/optee_client/releases/tag/4.6.0
+[OP_TEE_optee_client_commits_4_6_0]: https://github.com/OP-TEE/optee_client/compare/4.5.0...4.6.0
+[OP_TEE_optee_client_pr_4_6_0]: https://github.com/OP-TEE/optee_client/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2024-01-17..2025-04-25
+
+[OP_TEE_optee_test_release_4_6_0]: https://github.com/OP-TEE/optee_test/releases/tag/4.6.0
+[OP_TEE_optee_test_commits_4_6_0]: https://github.com/OP-TEE/optee_test/compare/4.5.0...4.6.0
+[OP_TEE_optee_test_pr_4_6_0]: https://github.com/OP-TEE/optee_test/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2024-01-17..2025-04-25
+
+[OP_TEE_build_release_4_6_0]: https://github.com/OP-TEE/build/releases/tag/4.6.0
+[OP_TEE_build_commits_4_6_0]: https://github.com/OP-TEE/build/compare/4.5.0...4.6.0
+[OP_TEE_build_pr_4_6_0]: https://github.com/OP-TEE/build/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2024-01-17..2025-04-25
+
+[linaro_swg_optee_examples_release_4_6_0]: https://github.com/linaro-swg/optee_examples/releases/tag/4.6.0
+[linaro_swg_optee_examples_commits_4_6_0]: https://github.com/linaro-swg/optee_examples/compare/4.5.0...4.6.0
+[linaro_swg_optee_examples_pr_4_6_0]: https://github.com/linaro-swg/optee_examples/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2024-01-17..2025-04-25
+
 # OP-TEE - version 4.5.0 (2025-01-17)
 
 - Links to the release pages, commits and pull requests merged into this release for:

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -127,7 +127,7 @@ CFG_OS_REV_REPORTS_GIT_SHA1 ?= y
 # with limited depth not including any tag, so there is really no guarantee
 # that TEE_IMPL_VERSION contains the major and minor revision numbers.
 CFG_OPTEE_REVISION_MAJOR ?= 4
-CFG_OPTEE_REVISION_MINOR ?= 5
+CFG_OPTEE_REVISION_MINOR ?= 6
 CFG_OPTEE_REVISION_EXTRA ?=
 
 # Trusted OS implementation version


### PR DESCRIPTION
Update CHANGELOG for 4.6.0 and collect Tested-by tags.

The 4.6.0-rc1 tag will be created on Friday, April 11, and the 4.6.0 release is expected on April 25.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
