### PR TITLE
core: arm: update recorded SP first after MMU is enabled

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -568,12 +568,12 @@ shadow_stack_access_ok:
 	bl	__get_core_pos
 	bl	enable_mmu
 #ifdef CFG_CORE_ASLR
-	ldr	r0, =boot_mmu_config
-	ldr	r0, [r0, #CORE_MMU_CONFIG_MAP_OFFSET]
-	bl	boot_mem_relocate
 	/*
 	 * Update recorded end_va, we depend on r4 pointing to the
 	 * pre-relocated thread_core_local[core_pos].
+	 *
+	 * This must be done before calling into C code to make sure that
+	 * the stack pointer matches what we have in thread_core_local[].
 	 */
 	ldr	r1, =boot_mmu_config
 	ldr	r1, [r1, #CORE_MMU_CONFIG_MAP_OFFSET]
@@ -595,6 +595,10 @@ shadow_stack_access_ok:
 	mov	sp, r4
 	cps	#CPSR_MODE_SVC
 
+	/* Update relocations recorded with boot_mem_add_reloc() */
+	ldr	r0, =boot_mmu_config
+	ldr	r0, [r0, #CORE_MMU_CONFIG_MAP_OFFSET]
+	bl	boot_mem_relocate
 	/*
 	 * Reinitialize console, since register_serial_console() has
 	 * previously registered a PA and with ASLR the VA is different

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -383,11 +383,10 @@ clear_nex_bss:
 	bl	__get_core_pos
 	bl	enable_mmu
 #ifdef CFG_CORE_ASLR
-	adr_l	x0, boot_mmu_config
-	ldr	x0, [x0, #CORE_MMU_CONFIG_MAP_OFFSET]
-	bl	boot_mem_relocate
 	/*
-	 * Update recorded end_va.
+	 * Update recorded end_va. This must be done before calling into C
+	 * code to make sure that the stack pointer matches what we have in
+	 * thread_core_local[].
 	 */
 	adr_l	x0, boot_mmu_config
 	ldr	x0, [x0, #CORE_MMU_CONFIG_MAP_OFFSET]
@@ -399,6 +398,11 @@ clear_nex_bss:
 	add	x1, x1, x0
 	str	x1, [sp, #THREAD_CORE_LOCAL_ABT_STACK_VA_END]
 	msr	spsel, #0
+
+	/* Update relocations recorded with boot_mem_add_reloc() */
+	adr_l	x0, boot_mmu_config
+	ldr	x0, [x0, #CORE_MMU_CONFIG_MAP_OFFSET]
+	bl	boot_mem_relocate
 	/*
 	 * Reinitialize console, since register_serial_console() has
 	 * previously registered a PA and with ASLR the VA is different


### PR DESCRIPTION
With CFG_CORE_ASLR=y, stored addresses must be updated after MMU has been enabled to match the map offset. In particular the recorded stack pointers in thread_core_local[] must be updated to match the new offset before any calls can be done into C code or check_stack_limits() with CFG_CORE_DEBUG_CHECK_STACKS=y might catch an inconsistent stack pointer.

Currently, boot_mem_relocate() is called before the recorded stack pointers have been updated and causes a crash with CFG_CORE_ASLR=y and CFG_CORE_DEBUG_CHECK_STACKS=y. So fix this by calling delaying the call to boot_mem_relocate() to after the stack pointers in thread_core_local[] has been updated.

Reported-by: Jerome Forissier <jerome.forissier@linaro.org>
Closes: https://github.com/OP-TEE/optee_os/issues/7363
Fixes: ea991d7459f6 ("core: arm: remove THREAD_CORE_LOCAL_STACKCHECK_RECURSION")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
