### PR TITLE
core: fix crash during syscall ftrace

### DIFF
--- a/core/arch/arm/kernel/thread.c
+++ b/core/arch/arm/kernel/thread.c
@@ -439,7 +439,7 @@ vaddr_t thread_get_saved_thread_sp(void)
 #endif /*ARM64*/
 
 #ifdef ARM32
-bool thread_is_in_normal_mode(void)
+bool __noprof thread_is_in_normal_mode(void)
 {
 	return (read_cpsr() & ARM32_CPSR_MODE_MASK) == ARM32_CPSR_MODE_SVC;
 }

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -426,7 +426,7 @@ bool thread_is_from_abort_mode(void)
  * This function should always be accurate, but it might be possible to
  * implement a more efficient depending on cpu architecture.
  */
-bool __weak thread_is_in_normal_mode(void)
+bool __weak __noprof thread_is_in_normal_mode(void)
 {
 	uint32_t exceptions = thread_mask_exceptions(THREAD_EXCP_FOREIGN_INTR);
 	struct thread_core_local *l = thread_get_core_local();

--- a/lib/libutils/ext/ftrace/ftrace.c
+++ b/lib/libutils/ext/ftrace/ftrace.c
@@ -37,11 +37,10 @@
 static __noprof struct ftrace_buf *get_fbuf(void)
 {
 #if defined(__KERNEL__)
-	short int ct = thread_get_id_may_fail();
 	struct ts_session *s = NULL;
 	struct thread_specific_data *tsd = NULL;
 
-	if (ct == -1)
+	if (!thread_is_in_normal_mode())
 		return NULL;
 
 	if (!(core_mmu_user_va_range_is_defined() &&


### PR DESCRIPTION
Syscall ftrace collects data during a syscall. get_fbuf() checks if thread_get_id_may_fail() != -1 to see if a function is called under normal thread execution. This can lead to an inconsistent state if a native interrupt occur while ftrace_enter() or ftrace_return() is recording data in the ftrace buffer. So fix this by using thread_is_in_normal_mode() to exclude ftrace during interrupt processing.

Reported-by: Jerome Forissier <jerome.forissier@linaro.org>
Closes: https://github.com/OP-TEE/optee_os/issues/7216
Fixes: 099918f6744c ("ftrace: Add support for syscall function tracer")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
