### PR TITLE
core: fs_htree: Fix AAD length when CFG_REE_FS_HTREE_HASH_SIZE_COMPAT=y

### DIFF
--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -454,7 +454,17 @@ static TEE_Result authenc_init(void **ctx_ret, TEE_OperationMode mode,
 		iv = ni->iv;
 	} else {
 		iv = ht->head.iv;
-		aad_len += TEE_FS_HTREE_HASH_SIZE + sizeof(ht->head.counter);
+		aad_len += sizeof(ht->head.counter);
+
+		/*
+		 * With CFG_REE_FS_HTREE_HASH_SIZE_COMPAT, hash data passed
+		 * for AAD is truncated to TEE_FS_HTREE_FEK_SIZE bytes so
+		 * use the correct size aad_len computation.
+		 */
+		if (IS_ENABLED(CFG_REE_FS_HTREE_HASH_SIZE_COMPAT))
+			aad_len += TEE_FS_HTREE_FEK_SIZE;
+		else
+			aad_len += TEE_FS_HTREE_HASH_SIZE;
 	}
 
 	if (mode == TEE_MODE_ENCRYPT) {


### PR DESCRIPTION
Correct the hash size declared in AAD length declared in REE FS hash tree authentication sequence when CFG_REE_FS_HTREE_HASH_SIZE_COMPAT is enabled in which case the hash is truncated to the size of the FEK key (TEE_FS_HTREE_FEK_SIZE).

The issue has currently no impact since REE FS hash tree authentication is based on AES-GCM but it would be of importance if, for example, one moves to an AES-CCM scheme while still enabling
CFG_REE_FS_HTREE_HASH_SIZE_COMPAT (even if unlikely to happen). To prevent such issue in the future, let's declare the effectively used hash size.

Suggested-by: Jens Wiklander <jens.wiklander@linaro.org>
Link: https://github.com/OP-TEE/optee_os/pull/7340/commits/087325faec7c057a638cca80f0549e9abe49f190#r2024716984

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
