### PR TITLE
plat-k3: drivers: add platform flavors for 62A and 62P devices

### DIFF
--- a/core/arch/arm/plat-k3/drivers/sa2ul.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.c
@@ -121,7 +121,10 @@ static TEE_Result sa2ul_init(void)
 	start_address = RNG_BASE;
 	end_address = RNG_BASE + RNG_REG_SIZE - 1;
 	permissions[num_perm++] = (FW_BIG_ARM_PRIVID << 16) | FW_SECURE_ONLY;
-#if defined(PLATFORM_FLAVOR_am62x)
+#if defined(PLATFORM_FLAVOR_am62x) || \
+	defined(PLATFORM_FLAVOR_am62ax) || \
+	defined(PLATFORM_FLAVOR_am62px)
+
 	permissions[num_perm++] = (FW_TIFS_PRIVID << 16) | FW_NON_SECURE;
 #endif
 	ret = ti_sci_set_fwl_region(fwl_id, rng_region, num_perm,

--- a/core/arch/arm/plat-k3/platform_config.h
+++ b/core/arch/arm/plat-k3/platform_config.h
@@ -79,18 +79,29 @@
 #define SA2UL_TI_SCI_DEV_ID	133
 #define SA2UL_TI_SCI_FW_ID	35
 #define SA2UL_TI_SCI_FW_RGN_ID	0
-#elif defined(PLATFORM_FLAVOR_am62x)
+#elif defined(PLATFORM_FLAVOR_am62x) || \
+	defined(PLATFORM_FLAVOR_am62ax) || \
+	defined(PLATFORM_FLAVOR_am62px)
 #define SA2UL_BASE		0x40900000
 #define SA2UL_TI_SCI_DEV_ID	-1
 #define SA2UL_TI_SCI_FW_ID	66
 #define SA2UL_TI_SCI_FW_RGN_ID	1
+#elif !defined(CFG_WITH_SOFTWARE_PRNG)
+/*
+ * If we got here we're trying to build a hardware based RNG driver
+ * but are missing some crticial definitions. This is usually because
+ * we're using the wrong platform flavor.
+ */
+#error "Unknown platform flavor! No SA2UL_BASE address is defined"
 #endif
 #define SA2UL_REG_SIZE		0x1000
 
 /* RNG */
 #define RNG_BASE		(SA2UL_BASE + 0x10000)
 #define RNG_REG_SIZE		0x1000
-#if defined(PLATFORM_FLAVOR_am62x)
+#if defined(PLATFORM_FLAVOR_am62x) || \
+	defined(PLATFORM_FLAVOR_am62ax) || \
+	defined(PLATFORM_FLAVOR_am62px)
 #define RNG_TI_SCI_FW_RGN_ID	2
 #else
 #define RNG_TI_SCI_FW_RGN_ID	3


### PR DESCRIPTION
Even though the SA2UL integration on the AM62Ax and AM62Px platforms are functionally identical to the AM62x platforms many, when building OP-TEE manually, are using the platform name they are building for and not 'am62x' which leaves SA2UL_BASE undefined and to failed builds:

    In file included from core/include/mm/core_memprot.h:9,
                     from core/include/kernel/interrupt.h:10,
                     from core/arch/arm/plat-k3/drivers/sa2ul_rng.c:12:
    core/arch/arm/plat-k3/./platform_config.h:91:34: error: ‘SA2UL_BASE’ undeclared here (not in a function); did you mean ‘SCU_BASE’?
       91 | #define RNG_BASE                (SA2UL_BASE + 0x10000)
          |                                  ^~~~~~~~~~

For now let's just define the AM62Ax and AM62Px platform flavors identical to how AM62x is defined and include an #else statement to catch when a undefined platform flavor tries to build the SA2UL driver

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
