### PR TITLE
clang: do not link against the compiler's compiler-rt library

### DIFF
--- a/mk/clang.mk
+++ b/mk/clang.mk
@@ -29,11 +29,6 @@ comp-cflags-warns-clang := -Wno-language-extension-token \
 			 -Wno-gnu-zero-variadic-macro-arguments \
 			 -Wno-gnu-alignof-expression
 
-# Note, use the compiler runtime library (libclang_rt.builtins.*.a) instead of
-# libgcc for clang
-libgcc$(sm)	:= $(shell $(CC$(sm)) $(CFLAGS$(arch-bits-$(sm))) \
-			-rtlib=compiler-rt -print-libgcc-file-name 2> /dev/null)
-
 # Core ASLR relies on the executable being ready to run from its preferred load
 # address, because some symbols are used before the MMU is enabled and the
 # relocations are applied.


### PR DESCRIPTION
Since commit 45fecab08117 ("Deprecate libgcc for OP-TEE core and ldelf") libgcc is not needed to link the TEE core and ldelf. Therefore, its Clang counterpart (compiler-rt) is not needed anymore either. Note that C++ in TAs has never been supported with Clang, therefore there is nothing to worry about in this regard (while we still have CFG_TA_LIBGCC for GCC).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
