### PR TITLE
ci: QEMUv8: check Firmware Handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,7 @@ jobs:
           # fTPM is disabled because tests are too slow otherwise (lots of paging)
           make -j$(nproc) check CFG_WITH_PAGER=y MEASURED_BOOT_FTPM=n
           make -j$(nproc) check CFG_DYN_CONFIG=n
+          make arm-tf-clean && make -j$(nproc) check ARM_FIRMWARE_HANDOFF=y
 
   QEMUv8_check2:
     name: make check (QEMUv8) 2 / 2


### PR DESCRIPTION
Add a check entry for Arm Firmware Handoff.

This patch depends on:
https://github.com/OP-TEE/build/pull/821
https://github.com/OP-TEE/manifest/pull/321
https://github.com/OP-TEE/manifest/pull/325

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
