### PR TITLE
Add K3 TI-SCI call functions for writing Software and Key Revision Counters

### DIFF
--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -425,6 +425,31 @@ int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
 	return 0;
 }
 
+int ti_sci_set_swrev(uint8_t identifier, uint32_t swrev)
+{
+	struct ti_sci_msq_req_set_swrev req = { };
+	struct ti_sci_msq_resp_set_swrev resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret = 0;
+
+	ret = ti_sci_setup_xfer(TI_SCI_MSG_WRITE_SWREV, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret)
+		return ret;
+
+	req.identifier = identifier;
+	req.swrev = swrev;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		return ret;
+
+	memzero_explicit(&req, sizeof(req));
+	return 0;
+}
+
 int ti_sci_get_swrev(uint32_t *swrev)
 {
 	struct ti_sci_msq_req_get_swrev req = { };

--- a/core/arch/arm/plat-k3/drivers/ti_sci.c
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.c
@@ -495,6 +495,34 @@ int ti_sci_get_keycnt_keyrev(uint32_t *key_cnt, uint32_t *key_rev)
 	return 0;
 }
 
+int ti_sci_set_keyrev(uint32_t keyrev,
+		      uint32_t cert_addr_lo,
+		      uint32_t cert_addr_hi)
+{
+	struct ti_sci_msq_req_set_keyrev req = { };
+	struct ti_sci_msq_resp_set_keyrev resp = { };
+	struct ti_sci_xfer xfer = { };
+	int ret = 0;
+
+	ret = ti_sci_setup_xfer(TI_SCI_MSG_WRITE_KEYREV, 0,
+				&req, sizeof(req),
+				&resp, sizeof(resp),
+				&xfer);
+	if (ret)
+		return ret;
+
+	req.value = keyrev;
+	req.cert_addr_lo = cert_addr_lo;
+	req.cert_addr_hi = cert_addr_hi;
+
+	ret = ti_sci_do_xfer(&xfer);
+	if (ret)
+		return ret;
+
+	memzero_explicit(&req, sizeof(req));
+	return 0;
+}
+
 int ti_sci_init(void)
 {
 	struct ti_sci_msg_resp_version rev_info = { };

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -162,6 +162,17 @@ int ti_sci_lock_otp_row(uint8_t row_idx, uint8_t hw_write_lock,
 			uint8_t hw_read_lock, uint8_t row_soft_lock);
 
 /**
+ * ti_sci_set_swrev - Write Software Revision
+ * @identifier: One of the entries from enum tisci_otp_revision_identifier
+ * @swrev:	Software Revision
+ *
+ * Writes the Software Revision in OTP for the specified identifier
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_set_swrev(uint8_t identifier, uint32_t swrev);
+
+/**
  * ti_sci_get_swrev - Read Software Revision
  * @swrev:	Software Revision
  *

--- a/core/arch/arm/plat-k3/drivers/ti_sci.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci.h
@@ -195,6 +195,20 @@ int ti_sci_get_swrev(uint32_t *swrev);
 int ti_sci_get_keycnt_keyrev(uint32_t *key_cnt, uint32_t *key_rev);
 
 /**
+ * ti_sci_set_keyrev - Write Key Revision
+ * @keyrev:		Key Revision
+ * @cert_addr_lo:	Lower 32 bit address of the dual signed certificate
+ * @cert_addr_hi:	Higher 32 bit address of the dual signed certificate
+ *
+ * Writes the Key Revision in OTP
+ *
+ * Return: 0 if all goes well, else appropriate error message
+ */
+int ti_sci_set_keyrev(uint32_t keyrev,
+		      uint32_t cert_addr_lo,
+		      uint32_t cert_addr_hi);
+
+/**
  * ti_sci_init() - Basic initialization
  *
  * Return: 0 if all goes well, else appropriate error message

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -412,7 +412,7 @@ struct ti_sci_msq_req_get_swrev {
 } __packed;
 
 /**
- * struct ti_sci_msq_req_get_swrev - Response for reading the Software Revision
+ * struct ti_sci_msq_resp_get_swrev - Response for reading the Software Revision
  * in OTP
  * @hdr:	Generic header
  * @swrev:	Decoded Sofrware Revision value from efuses
@@ -436,13 +436,14 @@ struct ti_sci_msq_req_get_keycnt_keyrev {
 } __packed;
 
 /**
- * struct ti_sci_msq_req_get_swrev - Response for reading the Key Count and Key
+ * struct ti_sci_msq_resp_get_keycnt_keyrev - Response for reading the Key Count
+ * and Key Revision in OTP
  * Revision in OTP
  * @hdr:	Generic header
  * @keycnt:	Key Count integer value
  * @keyrev:	Key Revision integer value
  *
- * Response for TI_SCI_MSG_READ_SWREV
+ * Response for TI_SCI_MSG_READ_KEYCNT_KEYREV
  */
 struct ti_sci_msq_resp_get_keycnt_keyrev {
 	struct ti_sci_msg_hdr hdr;

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -398,6 +398,32 @@ enum tisci_otp_revision_identifier {
 };
 
 /**
+ * struct ti_sci_msq_req_set_swrev - Request for writing the Software Revision
+ * in OTP
+ * @hdr:	Generic header
+ * @identifier: One of the entries from enum tisci_otp_revision_identifier
+ * @swrev:	Revision value (integer) to be bit encoded, and programmed
+ *
+ * Request for TI_SCI_MSG_WRITE_SWREV
+ */
+struct ti_sci_msq_req_set_swrev {
+	struct ti_sci_msg_hdr hdr;
+	uint8_t identifier;
+	uint32_t swrev;
+} __packed;
+
+/**
+ * struct ti_sci_msq_resp_set_swrev - Response for writing the Software Revision
+ * in OTP
+ * @hdr:	Generic header
+ *
+ * Response for TI_SCI_MSG_WRITE_SWREV
+ */
+struct ti_sci_msq_resp_set_swrev {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
+/**
  * struct ti_sci_msq_req_get_swrev - Request for reading the Software Revision
  * in OTP
  * @hdr:	Generic header

--- a/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
+++ b/core/arch/arm/plat-k3/drivers/ti_sci_protocol.h
@@ -476,4 +476,33 @@ struct ti_sci_msq_resp_get_keycnt_keyrev {
 	uint32_t keycnt;
 	uint32_t keyrev;
 } __packed;
+
+/**
+ * struct ti_sci_msq_req_set_keyrev - Request for writing the Key Revision
+ * in OTP
+ * @hdr:		Generic header
+ * @value:		Key Revision value to be written
+ * @cert_addr_lo:	Lower 32 bit address of the dual signed certificate
+ * @cert_addr_hi:	Higher 32 bit address of the dual signed certificate
+ *
+ * Request for TI_SCI_MSG_WRITE_KEYREV
+ */
+struct ti_sci_msq_req_set_keyrev {
+	struct ti_sci_msg_hdr hdr;
+	uint32_t value;
+	uint32_t cert_addr_lo;
+	uint32_t cert_addr_hi;
+} __packed;
+
+/**
+ * struct ti_sci_msq_resp_set_keyrev - Response for writing the Key Revision
+ * in OTP
+ * @hdr:	Generic header
+ *
+ * Response for TI_SCI_MSG_WRITE_KEYREV
+ */
+struct ti_sci_msq_resp_set_keyrev {
+	struct ti_sci_msg_hdr hdr;
+} __packed;
+
 #endif


### PR DESCRIPTION
These are added for completeness with the full set of TI-SCI OTP revision calls[0]. These can be used from a TA should modifying these counters need be done in OP-TEE.

[0] https://software-dl.ti.com/tisci/esd/latest/2_tisci_msgs/security/otp_revision.html
