### PR TITLE
core: riscv: replace get_core_pos() with thread_get_current_hartindex

### DIFF
--- a/core/arch/riscv/include/kernel/clint.h
+++ b/core/arch/riscv/include/kernel/clint.h
@@ -35,12 +35,12 @@ static inline void clint_ipi_clear(unsigned long hart)
 static inline void clint_set_mtimecmp(uint64_t timecmp)
 {
 	/* Each hart has a separate source of timer interrupts */
-	io_write64(CLINT_MTIMECMP(get_core_pos()), timecmp);
+	io_write64(CLINT_MTIMECMP(thread_get_current_hartid()), timecmp);
 }
 
 static inline uint64_t clint_get_mtimecmp(void)
 {
-	return io_read64(CLINT_MTIMECMP(get_core_pos()));
+	return io_read64(CLINT_MTIMECMP(thread_get_current_hartid()));
 }
 
 static inline uint64_t clint_get_mtime(void)

--- a/core/arch/riscv/include/kernel/thread_arch.h
+++ b/core/arch/riscv/include/kernel/thread_arch.h
@@ -198,7 +198,8 @@ static inline void thread_user_clear_vfp(struct user_mode_ctx *uctx __unused)
 #endif
 
 vaddr_t thread_get_saved_thread_sp(void);
-uint32_t thread_get_hartid_by_hartindex(uint32_t hartidx);
+uint32_t thread_get_current_hartindex(void);
+uint32_t thread_get_current_hartid(void);
 
 static inline void thread_get_user_kcode(struct mobj **mobj, size_t *offset,
 					 vaddr_t *va, size_t *sz)

--- a/core/arch/riscv/kernel/abort.c
+++ b/core/arch/riscv/kernel/abort.c
@@ -85,7 +85,7 @@ __print_abort_info(struct abort_info *ai __maybe_unused,
 	if (abort_is_user_exception(ai))
 		core_pos = thread_get_tsd()->abort_core;
 	else
-		core_pos = get_core_pos();
+		core_pos = thread_get_current_hartindex();
 
 	EMSG_RAW("");
 	EMSG_RAW("%s %s-abort at address 0x%" PRIxVA "%s",
@@ -193,7 +193,7 @@ static void save_abort_info_in_tsd(struct abort_info *ai)
 	tsd->abort_descr = ai->fault_descr;
 	tsd->abort_va = ai->va;
 	tsd->abort_regs = *ai->regs;
-	tsd->abort_core = get_core_pos();
+	tsd->abort_core = thread_get_current_hartindex();
 }
 
 static void set_abort_info(uint32_t abort_type __unused,

--- a/core/arch/riscv/kernel/thread_arch.c
+++ b/core/arch/riscv/kernel/thread_arch.c
@@ -326,11 +326,18 @@ vaddr_t thread_get_saved_thread_sp(void)
 	return threads[ct].kern_sp;
 }
 
-uint32_t thread_get_hartid_by_hartindex(uint32_t hartidx)
+uint32_t thread_get_current_hartindex(void)
 {
+	uint32_t hartidx = get_core_pos();
+
 	assert(hartidx < CFG_TEE_CORE_NB_CORE);
 
-	return thread_core_local[hartidx].hart_id;
+	return hartidx;
+}
+
+uint32_t thread_get_current_hartid(void)
+{
+	return thread_get_core_local()->hart_id;
 }
 
 void thread_resume_from_rpc(uint32_t thread_id, uint32_t a0, uint32_t a1,


### PR DESCRIPTION
Replace get_core_pos() with more descriptive
thread_get_current_{hartid,hartindex}() on RISC-V, 
and handle range checks in one place
(i.e. assert(hartidx < CFG_TEE_CORE_NB_CORE)),
also fix CLINT_MTIMECMP accesses where should
use hartid instead of hartindex.

Drop thread_get_hartid_by_hartindex() as we
only need to access local hart information.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
