### PR TITLE
ci: do not override QEMU version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,9 +592,6 @@ jobs:
           # TF-A v2.6 fails to build with the above toolchain so override it
           export TF_A_EXPORTS="CROSS_COMPILE=${TOP}/toolchains/aarch64/bin/aarch64-linux-gnu-"
           /root/get_optee.sh qemu_v8 ${TOP}
-          # QEMU v7.2.0 has an issue with MTE
-          # https://github.com/OP-TEE/optee_os/issues/5759#issuecomment-1380590951
-          cd ${TOP}/qemu && git fetch github && git checkout 13356edb87
           mv ${TOP}/optee_os ${TOP}/optee_os_old
           ln -s ${OPTEE_OS_TO_TEST} ${TOP}/optee_os
           cd ${TOP}/build


### PR DESCRIPTION
The "make check (QEMUv8, BTI+MTE+PAC)" CI job currently checks out an old version of QEMU. Not only is this workaround not necessary anymore, but worse it makes the check fail with the following output (from out/bin/serial0.log):

 Starting kernel ...

 **
 ERROR:../target/arm/internals.h:742:regime_is_user: code should not be reached
 Bail out! ERROR:../target/arm/internals.h:742:regime_is_user: code should not be reached
 Aborted (core dumped)
 send: spawn id exp9 not open
     while executing
 "send -- "root\r\r""
     (file "/root/optee/build/../build/qemu-check.exp" line 129

Therefore, let the QEMU version from the manifest be used.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
