### PR TITLE
(STM32) drivers: Implement AHB RISAB3/4/5 illegal access due to ghost CID0 detection errata

### DIFF
--- a/core/drivers/firewall/stm32_rifsc.c
+++ b/core/drivers/firewall/stm32_rifsc.c
@@ -370,7 +370,7 @@ static TEE_Result stm32_rifsc_dt_conf_rimu(const void *fdt, int node,
 		return TEE_ERROR_OUT_OF_MEMORY;
 
 	for (i = 0; i < pdata->nrimu; i++) {
-		uint32_t value = fdt32_to_cpu(*conf_list);
+		uint32_t value = fdt32_to_cpu(conf_list[i]);
 		struct rimu_cfg *rimu = pdata->rimu + i;
 
 		rimu->id = _RIF_FLD_GET(RIMUPROT_RIMC_M_ID, value) -

--- a/core/drivers/firewall/stm32_rifsc.c
+++ b/core/drivers/firewall/stm32_rifsc.c
@@ -449,7 +449,7 @@ static TEE_Result stm32_rifsc_parse_fdt(const void *fdt, int node,
 	rifsc_pdata.errata_ahbrisab = fdt_getprop(fdt, node,
 						  "st,errata-ahbrisab", NULL);
 
-	return stm32_rifsc_dt_conf_rimu(fdt, node, pdata);
+	return TEE_SUCCESS;
 }
 
 static TEE_Result stm32_risup_cfg(struct rifsc_platdata *pdata,


### PR DESCRIPTION
When an AHB busy signal is inserted during a transaction, a ghost CID0 is generated on the bus. If the
compartment filtering is enabled on RISAB3/4/5, this transient CID0 is interpreted as a fault access by
RISAB3/4/5 which aborts current access and returns an IAC.

Link to errata (section 2.3.21): [https://www.st.com/resource/en/errata_sheet/es0598-stm32mp23xx25xx-device-errata-stmicroelectronics.pdf](url)
