### PR TITLE
caam: fix compilation when CFG_NXP_CAAM_AE_* is not enabled

### DIFF
--- a/core/drivers/crypto/caam/include/caam_ae.h
+++ b/core/drivers/crypto/caam/include/caam_ae.h
@@ -7,11 +7,17 @@
 
 #include <caam_common.h>
 
+#if defined(CFG_NXP_CAAM_AE_CCM_DRV) || defined(CFG_NXP_CAAM_AE_GCM_DRV)
 /*
  * Initialize the Authentication Encryption module
  *
  * @ctrl_addr   Controller base address
  */
 enum caam_status caam_ae_init(vaddr_t ctrl_addr __unused);
-
+#else
+static inline enum caam_status caam_ae_init(vaddr_t ctrl_addr __unused)
+{
+	return CAAM_NO_ERROR;
+}
+#endif /* CFG_NXP_CAAM_AE_CCM_DRV || CFG_NXP_CAAM_AE_GCM_DRV */
 #endif /* __CAAM_AE_H__ */


### PR DESCRIPTION
Fix undefined reference to `caam_ae_init` for CAAM enabled targets which do not use CAAM AE.