### PR TITLE
ci: disable QEMUv8 Xen FF-A job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,6 +488,7 @@ jobs:
     name: make check (QEMUv8, Xen FF-A)
     runs-on: ubuntu-latest
     container: jforissier/optee_os_ci:qemu_check
+    if: false # Disabled until https://github.com/OP-TEE/optee_os/issues/7394 is fixed
     steps:
       - name: Remove /__t/*
         run: rm -rf /__t/*


### PR DESCRIPTION
Diaable the "make check (QEMUv8, Xem FF-A)" job until an issue is fixed in the OP-TEE and FF-A kernel drivers [1].

Link: https://github.com/OP-TEE/optee_os/issues/7394 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
