### PR TITLE
mk: core: relax rules around CFG_TRANSFER_LIST

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -529,8 +529,6 @@ endif
 # has a stable release.
 # This feature requires the support of Device Tree.
 CFG_TRANSFER_LIST ?= n
-$(eval $(call cfg-enable-all-depends,CFG_TRANSFER_LIST, \
-	 CFG_DT CFG_EXTERNAL_DT CFG_MAP_EXT_DT_SECURE))
 
 # Maximum size of the Device Tree Blob, has to be large enough to allow
 # editing of the supplied DTB.


### PR DESCRIPTION
`CFG_TRANSFER_LIST` forces DT-based console init, even though `CFG_DT` might not be explicitly enabled or needed on the platform otherwise. Relax the rules around `CFG_TRANSFER_LIST` to allow for a platform to receive boot arguments via Firmware Handoff without enabling `CFG_DT`.

Fixes: #7402

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
