### PR TITLE
libmbedtls: fix compilation warning with GCC14 (2)

### DIFF
--- a/lib/libmbedtls/mbedtls/library/common.h
+++ b/lib/libmbedtls/mbedtls/library/common.h
@@ -209,11 +209,13 @@ static inline void mbedtls_xor(unsigned char *r,
         uint8x16_t x = veorq_u8(v1, v2);
         vst1q_u8(r + i, x);
     }
-#if defined(__IAR_SYSTEMS_ICC__)
+#if defined(__IAR_SYSTEMS_ICC__) || defined(MBEDTLS_COMPILER_IS_GCC)
     /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
      * where n is a constant multiple of 16.
      * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time
-     * constant, and is a very small perf regression if n is not a compile-time constant. */
+     * constant, and is a very small perf regression if n is not a compile-time constant.
+     * GCC 14.2 outputs a warning "array subscript 48 is outside array bounds" if we don't return
+     * early. */
     if (n % 16 == 0) {
         return;
     }


### PR DESCRIPTION
Cherry-picking commit 7505c3588f44 ("libmbedtls: fix compilation warning with GCC14") which was lost in commit c3deb3d6f3b1 ("Squashed commit upgrading to mbedtls-3.6.3"). It should have been pushed onto the import/mbedtls-3.6.2 branch when it was accepted in master but that didn't happen and therefore it was unfortunately left aside when upgrading. This time it has been applied to import/mbedtls-3.6.3 [1] so it will hopefully not be forgotten in the next upgrade.

Link: https://github.com/OP-TEE/optee_os/commit/b526c146f87 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
