### PR TITLE
core: replace CFG_DYN_STACK_CONFIG with CFG_DYN_CONFIG

### DIFF
--- a/core/arch/arm/kernel/entry_a32.S
+++ b/core/arch/arm/kernel/entry_a32.S
@@ -448,7 +448,7 @@ shadow_stack_access_ok:
 	bls	shadow_stack_access_ok
 #endif
 
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	ldr	r0, =boot_embdata_ptr
 	ldr	r0, [r0]
 	sub	r1, r0, #THREAD_BOOT_INIT_TMP_ALLOC
@@ -545,7 +545,7 @@ shadow_stack_access_ok:
 	ldr	r0, =__vcore_free_start
 	ldr	r1, =boot_embdata_ptr
 	ldr	r1, [r1]
-#ifdef CFG_DYN_STACK_CONFIG
+#ifdef CFG_DYN_CONFIG
 	sub	r1, r1, #THREAD_BOOT_INIT_TMP_ALLOC
 #endif
 	ldr	r2, =__vcore_free_end
@@ -630,7 +630,7 @@ shadow_stack_access_ok:
 	 */
 	ldr	r1, =boot_mmu_config
 	ldr	r1, [r1, #CORE_MMU_CONFIG_MAP_OFFSET]
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	ldr	r0, =thread_core_local
 	add	r2, r4, r1
 	str	r2, [r0]
@@ -676,7 +676,7 @@ shadow_stack_access_ok:
 	bl	boot_init_primary_early
 	bl	boot_init_primary_late
 
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 #if !defined(CFG_WITH_ARM_TRUSTED_FW)
 	/* Update thread_core_local_pa with a new physical address */
 	ldr	r0, =__thread_core_local_new
@@ -1021,7 +1021,7 @@ LOCAL_FUNC enable_mmu , : , .identity_map
 	bx	lr
 END_FUNC enable_mmu
 
-#if !defined(CFG_DYN_STACK_CONFIG)
+#if !defined(CFG_DYN_CONFIG)
 LOCAL_DATA stack_tmp_rel , :
 	.word	stack_tmp - stack_tmp_rel - STACK_TMP_GUARD
 END_DATA stack_tmp_rel

--- a/core/arch/arm/kernel/entry_a64.S
+++ b/core/arch/arm/kernel/entry_a64.S
@@ -283,7 +283,7 @@ clear_nex_bss:
 #endif
 
 	/* Setup SP_EL0 and SP_EL1, SP will be set to SP_EL0 */
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	/*
 	 * Point SP_EL0 to a temporary stack with the at the end of mapped
 	 * core memory.
@@ -374,7 +374,7 @@ clear_nex_bss:
 	adr_l	x0, __vcore_free_start
 	adr_l	x1, boot_embdata_ptr
 	ldr	x1, [x1]
-#ifdef CFG_DYN_STACK_CONFIG
+#ifdef CFG_DYN_CONFIG
 	sub	x1, x1, #THREAD_BOOT_INIT_TMP_ALLOC
 #endif
 	adr_l	x2, __vcore_free_end;
@@ -426,7 +426,7 @@ clear_nex_bss:
 	bl	__get_core_pos
 	bl	enable_mmu
 #ifdef CFG_CORE_ASLR
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	/*
 	 * thread_core_local holds only one core and thread_core_count is 1
 	 * so SP_EL1 points to the updated pointer for thread_core_local.
@@ -485,7 +485,7 @@ clear_nex_bss:
 #endif
 	bl	boot_init_primary_late
 
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	bl	__get_core_pos
 
 	/*
@@ -777,7 +777,7 @@ FUNC cpu_on_handler , :
 	bl	__get_core_pos
 	bl	enable_mmu
 
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	/*
 	 * Update SP_EL0 to use the new tmp stack and update SP_EL1 to
 	 * point the new thread_core_local.
@@ -822,7 +822,7 @@ LOCAL_FUNC unhandled_cpu , :
 	b	unhandled_cpu
 END_FUNC unhandled_cpu
 
-#if !defined(CFG_DYN_STACK_CONFIG)
+#if !defined(CFG_DYN_CONFIG)
 LOCAL_DATA stack_tmp_rel , :
 	.word	stack_tmp - stack_tmp_rel - STACK_TMP_GUARD
 END_DATA stack_tmp_rel

--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -179,7 +179,7 @@ UNWIND(	.cantunwind)
 	csrw	CSR_SATP, zero
 
 	/* Setup sp and tp */
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	/*
 	 * Point sp to a temporary stack at the end of mapped core memory.
 	 * Point tp to a temporary struct thread_core_local before the temporary
@@ -240,7 +240,7 @@ UNWIND(	.cantunwind)
 
 	la	a0, __vcore_free_start
 	la	a1, __vcore_free_end
-#ifdef CFG_DYN_STACK_CONFIG
+#ifdef CFG_DYN_CONFIG
 	li	a2, THREAD_BOOT_INIT_TMP_ALLOC
 	sub	a1, a1, a2
 #endif
@@ -254,7 +254,7 @@ UNWIND(	.cantunwind)
 	set_satp
 
 #ifdef CFG_CORE_ASLR
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	/*
 	 * thread_core_local holds only one core and thread_core_count is 1
 	 * so tp points to the updated pointer for thread_core_local.
@@ -270,7 +270,7 @@ UNWIND(	.cantunwind)
 	mv	a1, x0		/* unused */
 	jal	boot_init_primary_late
 
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	/* Get hart index */
 	jal	__get_core_pos
 
@@ -358,7 +358,7 @@ LOCAL_FUNC reset_secondary , : , .identity_map
 UNWIND(	.cantunwind)
 	wait_primary
 	csrw	CSR_SATP, zero
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 	/*
 	 * Update tp to point the new thread_core_local.
 	 * Update sp to use the new tmp stack.
@@ -415,7 +415,7 @@ LOCAL_DATA sem_cpu_sync_end , :
 END_DATA sem_cpu_sync_end
 #endif
 
-#if !defined(CFG_DYN_STACK_CONFIG)
+#if !defined(CFG_DYN_CONFIG)
 LOCAL_DATA stack_tmp_rel , :
 	.word	stack_tmp - stack_tmp_rel - STACK_TMP_GUARD
 END_DATA stack_tmp_rel

--- a/core/include/kernel/thread.h
+++ b/core/include/kernel/thread.h
@@ -68,7 +68,7 @@ struct thread_core_local *thread_get_core_local(void);
  * virtualization is disabled. Virtualization subsystem calls it for every
  * new guest otherwise. @thread_count must be <= CFG_NUM_THREADS, and will
  * initialize the number of threads to @thread_count if configured with
- * CFG_DYN_STACK_CONFIG=y, else @thread_count must equal CFG_NUM_THREADS.
+ * CFG_DYN_CONFIG=y, else @thread_count must equal CFG_NUM_THREADS.
  */
 void thread_init_threads(size_t thread_count);
 

--- a/core/kernel/thread.c
+++ b/core/kernel/thread.c
@@ -19,7 +19,7 @@
 #include <mm/page_alloc.h>
 #include <stdalign.h>
 
-#if defined(CFG_DYN_STACK_CONFIG)
+#if defined(CFG_DYN_CONFIG)
 struct thread_core_local *thread_core_local __nex_bss;
 size_t thread_core_count __nex_bss;
 struct thread_ctx *threads;
@@ -57,7 +57,7 @@ linkage uint32_t name[num_stacks] \
 		__attribute__((section(".nozi_stack." # name), \
 			       aligned(STACK_ALIGNMENT)))
 
-#ifndef CFG_DYN_STACK_CONFIG
+#ifndef CFG_DYN_CONFIG
 DECLARE_STACK(stack_tmp, CFG_TEE_CORE_NB_CORE, STACK_TMP_SIZE,
 	      /* global linkage */);
 DECLARE_STACK(stack_abt, CFG_TEE_CORE_NB_CORE, STACK_ABT_SIZE, static);
@@ -68,7 +68,7 @@ DECLARE_STACK(stack_abt, CFG_TEE_CORE_NB_CORE, STACK_ABT_SIZE, static);
 #define GET_STACK_BOTTOM(stack, n) 0
 #endif
 
-#if defined(CFG_DYN_STACK_CONFIG) || defined(CFG_WITH_PAGER)
+#if defined(CFG_DYN_CONFIG) || defined(CFG_WITH_PAGER)
 /* Not used */
 #define GET_STACK_THREAD_BOTTOM(n) 0
 #else
@@ -78,7 +78,7 @@ DECLARE_STACK(stack_thread, CFG_NUM_THREADS, STACK_THREAD_SIZE, static);
 	 STACK_CANARY_SIZE / 2)
 #endif
 
-#ifndef CFG_DYN_STACK_CONFIG
+#ifndef CFG_DYN_CONFIG
 const uint32_t stack_tmp_stride __section(".identity_map.stack_tmp_stride") =
 	sizeof(stack_tmp[0]);
 
@@ -266,7 +266,7 @@ get_core_local(unsigned int pos)
 	 * We boot on a single core and have allocated only one struct
 	 * thread_core_local so we return that regardless of pos.
 	 */
-	if (IS_ENABLED(CFG_DYN_STACK_CONFIG) &&
+	if (IS_ENABLED(CFG_DYN_CONFIG) &&
 	    thread_core_local != __thread_core_local_new)
 		return thread_core_local;
 
@@ -569,7 +569,7 @@ static void init_thread_stacks(void)
 
 	/* Assign the thread stacks */
 	for (n = 0; n < thread_count; n++) {
-		if (IS_ENABLED(CFG_DYN_STACK_CONFIG))
+		if (IS_ENABLED(CFG_DYN_CONFIG))
 			va = alloc_stack(STACK_THREAD_SIZE, false);
 		else
 			va = GET_STACK_THREAD_BOTTOM(n);
@@ -584,7 +584,7 @@ void thread_init_threads(size_t count)
 {
 	size_t n = 0;
 
-	if (IS_ENABLED(CFG_DYN_STACK_CONFIG)) {
+	if (IS_ENABLED(CFG_DYN_CONFIG)) {
 		assert(count <= CFG_NUM_THREADS);
 		threads = calloc(count, sizeof(*threads));
 		if (!threads)
@@ -604,7 +604,7 @@ void thread_init_threads(size_t count)
 		TAILQ_INIT(&threads[n].tsd.sess_stack);
 }
 
-#ifndef CFG_DYN_STACK_CONFIG
+#ifndef CFG_DYN_CONFIG
 vaddr_t __nostackcheck thread_get_abt_stack(void)
 {
 	return GET_STACK_BOTTOM(stack_abt, get_core_pos());
@@ -618,7 +618,7 @@ void thread_init_thread_core_local(size_t core_count)
 	vaddr_t va = 0;
 	size_t n = 0;
 
-	if (IS_ENABLED(CFG_DYN_STACK_CONFIG)) {
+	if (IS_ENABLED(CFG_DYN_CONFIG)) {
 		assert(core_count <= CFG_TEE_CORE_NB_CORE);
 		tcl = nex_calloc(core_count, sizeof(*tcl));
 		if (!tcl)
@@ -639,7 +639,7 @@ void thread_init_thread_core_local(size_t core_count)
 
 	for (n = 0; n < core_count; n++) {
 		if (n == core_pos) {
-			if (IS_ENABLED(CFG_DYN_STACK_CONFIG))
+			if (IS_ENABLED(CFG_DYN_CONFIG))
 				tcl[n] = thread_core_local[0];
 			else
 				continue;
@@ -648,7 +648,7 @@ void thread_init_thread_core_local(size_t core_count)
 			tcl[n].flags = THREAD_CLF_TMP;
 		}
 
-		if (IS_ENABLED(CFG_DYN_STACK_CONFIG))
+		if (IS_ENABLED(CFG_DYN_CONFIG))
 			va = alloc_stack(STACK_TMP_SIZE, true);
 		else
 			va = GET_STACK_BOTTOM(stack_tmp, n);
@@ -658,7 +658,7 @@ void thread_init_thread_core_local(size_t core_count)
 			vaddr_to_phys(tcl[n].tmp_stack_va_end);
 #endif
 
-		if (IS_ENABLED(CFG_DYN_STACK_CONFIG))
+		if (IS_ENABLED(CFG_DYN_CONFIG))
 			va = alloc_stack(STACK_ABT_SIZE, true);
 		else
 			va = GET_STACK_BOTTOM(stack_abt, n);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1292,20 +1292,11 @@ CFG_CORE_UNSAFE_MODEXP ?= n
 CFG_TA_MBEDTLS_UNSAFE_MODEXP ?= n
 
 # CFG_DYN_CONFIG, when enabled, use dynamic memory allocation for translation
-# tables. Not supported with pager.
-# CFG_DYN_STACK_CONFIG, when enabled, use dynamic memory allocation for
-# stacks. Not supported with pager.
+# tables and stacks. Not supported with pager.
 ifeq ($(CFG_WITH_PAGER),y)
 $(call force,CFG_DYN_CONFIG,n,conflicts with CFG_WITH_PAGER)
-$(call force,CFG_DYN_STACK_CONFIG,n,conflicts with CFG_WITH_PAGER)
 else
 CFG_DYN_CONFIG ?= y
-ifeq ($(ARCH),arm)
-# CFG_DYN_CONFIG can replace CFG_DYN_STACK_CONFIG once riscv support it
-$(call force,CFG_DYN_STACK_CONFIG,$(CFG_DYN_CONFIG))
-else
-CFG_DYN_STACK_CONFIG ?= n
-endif
 endif
 
 # CFG_EXTERNAL_ABORT_PLAT_HANDLER is used to implement platform-specific


### PR DESCRIPTION
This commit replaces CFG_DYN_STACK_CONFIG with CFG_DYN_CONFIG since now RISC-V also supports CFG_DYN_STACK_CONFIG.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
