### PR TITLE
core: kernel: dt_driver: fix copy/paste comment

### DIFF
--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -22,7 +22,7 @@
  * DT_DRIVER_RSTCTRL Reset controller using generic reset DT bindings
  * DT_DRIVER_I2C    I2C bus controller using generic I2C bus DT bindings
  * DT_DRIVER_GPIO   GPIO controller using generic GPIO DT bindings
- * DT_DRIVER_PINCTRL Pin controller using generic reset DT bindings
+ * DT_DRIVER_PINCTRL Pin controller using generic DT bindings
  * DT_DRIVER_INTERRUPT Interrupt controller using generic DT bindings
  * DT_DRIVER_REGULATOR Voltage regulator controller using generic DT bindings
  * DT_DRIVER_NVMEM NVMEM controller using generic NVMEM DT bindings


### PR DESCRIPTION
While adding DT_DRIVER_PINCTRL, an incorrect word was reported by copy/paste from the existing comment for DT_DRIVER_RSTCTRL.

Drop the word 'reset' from the comment for DT_DRIVER_PINCTRL.

Fixes: b5aff6de7052 ("core: dt_driver: add support for DT_DRIVER_PINCTRL")
