### PR TITLE
riscv: mm: fix relocation of pointers in user_vpn2_table_va[]

### DIFF
--- a/core/arch/riscv/mm/core_mmu_arch.c
+++ b/core/arch/riscv/mm/core_mmu_arch.c
@@ -1054,6 +1054,11 @@ void core_init_mmu(struct memory_map *mem_map)
 #endif
 	}
 
+#if (RISCV_SATP_MODE >= SATP_MODE_SV48)
+	for (n = 0; n < CFG_TEE_CORE_NB_CORE; n++)
+		boot_mem_add_reloc(&prtn->user_vpn2_table_va[n]);
+#endif
+
 	/* Initialize default pagetables */
 	core_init_mmu_prtn_tee(prtn, mem_map);
 


### PR DESCRIPTION
The user_vpn2_table_va[] stores several pointers pointing to the level 2 page tables used by user TA. When CFG_CORE_ASLR=y, these pointers must be relocated to ASLR VA as well. To fix this issue, we call boot_mem_add_reloc() onto each element of user_vpn2_table_va[], so that the pointers have a chance to be relocated by boot_mem_relocate() later.

Discussed in https://github.com/OP-TEE/optee_os/pull/7371#discussion_r2107604866

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
