### PR TITLE
mk/config.mk: disable CFG_CALLOUT for CFG_CORE_SEL2_SPMC=y

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1065,6 +1065,10 @@ CFG_CORE_ASYNC_NOTIF ?= n
 $(call force,_CFG_CORE_ASYNC_NOTIF_DEFAULT_IMPL,$(CFG_CORE_ASYNC_NOTIF))
 endif
 
+ifeq ($(CFG_CORE_SEL2_SPMC),y)
+$(call force,CFG_CALLOUT,n)
+endif
+
 # Enable callout service
 CFG_CALLOUT ?= $(CFG_CORE_ASYNC_NOTIF)
 


### PR DESCRIPTION
With Hafnium at S-EL1 (CFG_CORE_SEL2_SPMC=y) the callout service isn't initialized. To avoid unexpected aborts and errors, set CFG_CALLOUT=n.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
