### PR TITLE
KASAN: several minor fixes / selftests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,7 @@ jobs:
 
           make -j$(nproc) check CFG_LOCKDEP=y CFG_LOCKDEP_RECORD_STACK=n CFG_IN_TREE_EARLY_TAS=pkcs11/fd02c9da-306c-48c7-a49c-bbd827ae86ee CFG_PKCS11_TA=y CFG_CORE_UNSAFE_MODEXP=y XTEST_ARGS="-x pkcs11_1007"
           make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n XTEST_ARGS="n_1001 n_1003 n_1004"
+          make -j$(nproc) check CFG_CORE_SANITIZE_KADDRESS=y CFG_CORE_ASLR=n CFG_ATTESTATION_PTA=n CFG_DYN_CONFIG=n XTEST_ARGS="n_1001 n_1003 n_1004"
 
   QEMUv8_check1:
     name: make check (QEMUv8) 1 / 4

--- a/core/include/kernel/asan.h
+++ b/core/include/kernel/asan.h
@@ -19,8 +19,12 @@
 #include <string.h>
 #include <types_ext.h>
 
+typedef void (*asan_panic_cb_t)(void);
+
 void asan_set_shadowed(const void *va_begin, const void *va_end);
 void asan_start(void);
+void asan_panic(void);
+void asan_set_panic_cb(asan_panic_cb_t panic_cb);
 
 #ifdef CFG_CORE_SANITIZE_KADDRESS
 void asan_tag_no_access(const void *begin, const void *end);

--- a/core/kernel/asan.c
+++ b/core/kernel/asan.c
@@ -9,6 +9,7 @@
 #include <kernel/asan.h>
 #include <kernel/panic.h>
 #include <printk.h>
+#include <setjmp.h>
 #include <string.h>
 #include <trace.h>
 #include <types_ext.h>
@@ -326,4 +327,13 @@ void __asan_unregister_globals(struct asan_global *globals, size_t size);
 void __asan_unregister_globals(struct asan_global *globals __unused,
 			       size_t size __unused)
 {
+}
+
+void asan_handle_longjmp(void *old_sp)
+{
+	void *top = old_sp;
+	void *bottom = (void *)ROUNDDOWN((vaddr_t)&top,
+					 ASAN_BLOCK_SIZE);
+
+	asan_tag_access(bottom, top);
 }

--- a/lib/libutils/isoc/arch/arm/setjmp_a32.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a32.S
@@ -252,6 +252,18 @@ SYM (\name):
 	bl		ftrace_longjmp
 	ldmia		sp!, { a1, a2, lr }
 #endif
+#if defined(__KERNEL__) && defined(CFG_CORE_SANITIZE_KADDRESS) && \
+    !defined(CFG_DYN_CONFIG)
+	stmdb		sp!, { a1, a2, a3, lr }
+
+#ifdef __thumb2__
+	ldr		a1, [a1, #32]
+#else
+	ldr		a1, [a1, #36]
+#endif
+	bl		asan_handle_longjmp
+	ldmia		sp!, { a1, a2, a3, lr }
+#endif
 
 	/* Restore the registers, retrieving the state when setjmp() was called.  */
 #ifdef __thumb2__

--- a/lib/libutils/isoc/arch/arm/setjmp_a64.S
+++ b/lib/libutils/isoc/arch/arm/setjmp_a64.S
@@ -83,6 +83,13 @@ BTI(	bti	c)
 	ldp	x29, x30, [sp], #16
 	ldp	x0, x1, [sp], #16
 #endif
+#if defined(__KERNEL__) && defined(CFG_CORE_SANITIZE_KADDRESS) && \
+    !defined(CFG_DYN_CONFIG)
+	stp	x0, x1, [sp, #-16]!
+	ldr	x0, [x0, 96]
+	bl	asan_handle_longjmp
+	ldp	x0, x1, [sp], #16
+#endif
 	GPR_LAYOUT
 	FPR_LAYOUT
 #undef REG_PAIR

--- a/lib/libutils/isoc/arch/riscv/setjmp_rv.S
+++ b/lib/libutils/isoc/arch/riscv/setjmp_rv.S
@@ -63,6 +63,10 @@ FUNC longjmp , :
 	LDR	ra, REGOFF(3)(sp)
 	addi	sp, sp, REGOFF(4)
 #endif
+#if defined(__KERNEL__) && defined(CFG_CORE_SANITIZE_KADDRESS) && \
+    !defined(CFG_DYN_CONFIG)
+#error longjmp() stack unpoisoning not implemented for RISC-V with ASAN
+#endif
 	LDR	s0, REGOFF(0)(a0)
 	LDR	s1, REGOFF(1)(a0)
 	LDR	s2, REGOFF(2)(a0)

--- a/lib/libutils/isoc/bget_malloc.c
+++ b/lib/libutils/isoc/bget_malloc.c
@@ -240,8 +240,7 @@ static void *maybe_tag_buf(uint8_t *buf, size_t hdr_size, size_t requested_size)
 	}
 
 #if defined(__KERNEL__)
-	if (IS_ENABLED(CFG_CORE_SANITIZE_KADDRESS))
-		asan_tag_access(buf, buf + hdr_size + requested_size);
+	asan_tag_access(buf, buf + hdr_size + requested_size);
 #endif
 	return buf;
 }
@@ -260,8 +259,7 @@ static void *maybe_untag_buf(void *buf)
 	}
 
 #if defined(__KERNEL__)
-	if (IS_ENABLED(CFG_CORE_SANITIZE_KADDRESS))
-		asan_tag_heap_free(buf, (uint8_t *)buf + bget_buf_size(buf));
+	asan_tag_heap_free(buf, (uint8_t *)buf + bget_buf_size(buf));
 #endif
 	return buf;
 }

--- a/lib/libutils/isoc/include/setjmp.h
+++ b/lib/libutils/isoc/include/setjmp.h
@@ -75,5 +75,7 @@ int setjmp(jmp_buf env);
 void ftrace_longjmp(unsigned int *ret_idx);
 void ftrace_setjmp(unsigned int *ret_idx);
 #endif
-
+#ifdef CFG_CORE_SANITIZE_KADDRESS
+void asan_handle_longjmp(void *old_sp);
+#endif
 #endif /*__SETJMP_H*/


### PR DESCRIPTION
Hi,

this MR proposes several improvements for **KASAN**.

**Adds runtime KASAN tests**
Added a dedicated KASAN self-test suite covering:
- Stack overflow
- Global buffer overflow
- Heap overflow
- Use-after-free
- Invalid accesses using memcpy / memset

These tests could help to track potential regression in KASAN functionality.

**Fixes check_access()**

It seems implementation didn't cover some corner cases, please see commit msg for details.
I borrowed some [freebsd code](https://github.com/freebsd/freebsd-src/blob/main/sys/kern/subr_asan.c) to rewrite [check_access](https://github.com/OP-TEE/optee_os/blob/master/core/kernel/asan.c#L169) in correct/optimized way.

 **Some changes in heap tagging**

It seems in some cases it tag more memory as available than it should.

**Adds support for unpoisoning stack on longjmp**

KASAN tests use **setjmp/longjmp** , to utilize it alongside with **KASAN**
some additional support is needed.

Please let me know if these changes would be useful for you.

