### PR TITLE
drivers: ffa_console: add support for multiple character at once

### DIFF
--- a/core/drivers/ffa_console.c
+++ b/core/drivers/ffa_console.c
@@ -5,37 +5,121 @@
 
 #include <compiler.h>
 #include <console.h>
-#include <drivers/ffa_console.h>
+#include <ffa.h>
+#include <string.h>
 #include <drivers/serial.h>
+#include <drivers/ffa_console.h>
 #include <kernel/dt_driver.h>
 #include <kernel/thread_arch.h>
 
-#define FFA_CONSOLE_LOG_32		(0x8400008A)
+struct ffa_console_data {
+	struct serial_chip chip;
+	char buf[FFA_CONSOLE_LOG_64_MAX_MSG_LEN];
+	size_t pos;
+};
 
-static void ffa_console_putc(struct serial_chip *chip __unused, int ch)
+static struct ffa_console_data ffa_console __nex_bss;
+
+static void copy_buf_to_args(struct thread_smc_args *args,
+			     const char *buf, size_t len,
+			     size_t reg_size)
 {
-	thread_hvc(FFA_CONSOLE_LOG_32, 1, ch, 0);
+	size_t i = 0;
+	size_t j = 0;
+
+	args->a1 = len;
+
+	for (i = 0, j = 0; j < len; i++, j += reg_size)
+		memcpy(&args->a2 + i, buf + j, MIN(len - j, reg_size));
 }
 
-static const struct serial_ops ffa_console_ops = {
-	.putc = ffa_console_putc,
-};
-DECLARE_KEEP_PAGER(ffa_console_ops);
+static void ffa_console_32_flush(struct serial_chip *chip)
+{
+	struct ffa_console_data *pd =
+		container_of(chip, struct ffa_console_data, chip);
+	struct thread_smc_args args = {
+		.a0 = FFA_CONSOLE_LOG_32
+	};
 
-static struct serial_chip ffa_console = {
-	.ops = &ffa_console_ops
+	copy_buf_to_args(&args, pd->buf, pd->pos, sizeof(uint32_t));
+	thread_smccc(&args);
+	pd->pos = 0;
+}
+
+static void ffa_console_32_putc(struct serial_chip *chip, int ch)
+{
+	struct ffa_console_data *pd =
+		container_of(chip, struct ffa_console_data, chip);
+
+	pd->buf[pd->pos++] = ch;
+
+	if (pd->pos == FFA_CONSOLE_LOG_32_MAX_MSG_LEN)
+		ffa_console_32_flush(chip);
+}
+
+static const struct serial_ops ffa_console_32_ops = {
+	.putc = ffa_console_32_putc,
+	.flush = ffa_console_32_flush,
 };
+
+static void ffa_console_64_flush(struct serial_chip *chip)
+{
+	struct ffa_console_data *pd =
+		container_of(chip, struct ffa_console_data, chip);
+	struct thread_smc_args args = {
+		.a0 = FFA_CONSOLE_LOG_64
+	};
+
+	copy_buf_to_args(&args, pd->buf, pd->pos, sizeof(uint64_t));
+	thread_smccc(&args);
+	pd->pos = 0;
+}
+
+static void ffa_console_64_putc(struct serial_chip *chip, int ch)
+{
+	struct ffa_console_data *pd =
+		container_of(chip, struct ffa_console_data, chip);
+
+	pd->buf[pd->pos++] = ch;
+
+	if (pd->pos == FFA_CONSOLE_LOG_64_V1_1_MAX_MSG_LEN)
+		ffa_console_64_flush(chip);
+}
+
+static const struct serial_ops ffa_console_64_ops = {
+	.putc = ffa_console_64_putc,
+	.flush = ffa_console_64_flush,
+};
+
+static bool ffa_feature_console_64bit(void)
+{
+	struct thread_smc_args args = {
+		.a0 = FFA_FEATURES,
+		.a1 = FFA_CONSOLE_LOG_64
+	};
+
+	thread_smccc(&args);
+
+	return args.a0 == FFA_SUCCESS_64 || args.a0 == FFA_SUCCESS_32;
+}
 
 void ffa_console_init(void)
 {
-	register_serial_console(&ffa_console);
+	if (ffa_feature_console_64bit())
+		ffa_console.chip.ops = &ffa_console_64_ops;
+	else
+		ffa_console.chip.ops = &ffa_console_32_ops;
+
+	ffa_console.pos = 0;
+
+	register_serial_console(&ffa_console.chip);
 }
 
 #ifdef CFG_DT
 
 static struct serial_chip *ffa_console_dev_alloc(void)
 {
-	return &ffa_console;
+	return &ffa_console.chip;
 }
 
 static int ffa_console_dev_init(struct serial_chip *chip __unused,


### PR DESCRIPTION
Some Hypervisor (including Hafnium under v2.9) does not support FFA_CONSOLE_LOG_64
so this change makes FFA console uses FFA_CONSOLE_LOG_32 when FFA_CONSOLE_LOG_64 isn't supported.
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
