### PR TITLE
Revert "ci: disable QEMUv8 Xen FF-A job"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,7 +570,6 @@ jobs:
     name: make check (QEMUv8, Xen FF-A)
     runs-on: ubuntu-latest
     container: jforissier/optee_os_ci:qemu_check
-    if: false # Disabled until https://github.com/OP-TEE/optee_os/issues/7394 is fixed
     steps:
       - name: Remove /__t/*
         run: rm -rf /__t/*


### PR DESCRIPTION
This reverts commit 5297f233bb222febf97a33c4aebff2ecb48a43a4. The Linux repository that is used in the OP-TEE OS CI has temporary fixes [1] and the proper fixes are on their way upstream [2] [3].


Link: https://github.com/linaro-swg/linux/pull/122 [1]
Link: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/drivers/tee?h=next-20250617&id=312d02adb959ea199372f375ada06e0186f651e4 [2]
Link: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/drivers?h=next-20250617&id=9ca7a421229bbdfbe2e1e628cff5cfa782720a10 [3]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
