### PR TITLE
[RFC] ta: pkcs11: Panic on init failure

### DIFF
--- a/ta/pkcs11/src/entry.c
+++ b/ta/pkcs11/src/entry.c
@@ -17,7 +17,13 @@
 
 TEE_Result TA_CreateEntryPoint(void)
 {
-	return pkcs11_init();
+	TEE_Result ret;
+
+	ret = pkcs11_init();
+	if (ret)
+		TEE_Panic(0);
+
+	return TEE_SUCCESS;
 }
 
 void TA_DestroyEntryPoint(void)


### PR DESCRIPTION
How should I deal with failures in `TA_CreateEntryPoint()` for `keep-alive` TAs? If my understanding is correct, that the initialization is only run once (regardless of failure), then it seems to me we need to tear down the TA (and session+ctx?).

What I'm observing is that the first client fails as expected (the session won't open) if initialization fails, but for the next client the initialization is always skipped, and in turn it ends up causing an abort as it tries to access uninitialized memory.

The commit in this PR is just to highlight the issue - I realize it's not a solution (if there's even a problem). If it turns out there is a problem though, I'd be be more than happy to look into a proper fix. 

I'm running OP-TEE 4.2.0 with customization.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
