### PR TITLE
core: ree_fs: initialize ta_ver.db in one operation

### DIFF
--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -111,12 +111,8 @@ static TEE_Result check_update_version(const char *db_name,
 		goto out;
 
 	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
-		res = ops->create(&pobj, false, NULL, 0, NULL, 0, NULL, NULL,
-				   0, &fh);
-		if (res != TEE_SUCCESS)
-			goto out;
-
-		res = ops->write(fh, 0, &db_hdr, NULL, sizeof(db_hdr));
+		res = ops->create(&pobj, false, NULL, 0, NULL, 0, &db_hdr, NULL,
+				   sizeof(db_hdr), &fh);
 		if (res != TEE_SUCCESS)
 			goto out;
 	} else {


### PR DESCRIPTION
Combined the object creation and data writing operations into a single step to enhance reliability. This change addresses the situation where, if object creation occurs but the data writing fails, an empty object would be left behind, leading to potential issues during the next boot.

Fixes: OP-TEE#7438

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
