### PR TITLE
core: riscv: fix hartid for primary hart when CFG_DYN_CONFIG=y

### DIFF
--- a/core/arch/riscv/kernel/entry.S
+++ b/core/arch/riscv/kernel/entry.S
@@ -195,7 +195,7 @@ UNWIND(	.cantunwind)
 	sub	t2, t0, t2
 	STR	t2, THREAD_CORE_LOCAL_ABT_STACK_VA_END(t1)
 	csrr	t2, CSR_XSCRATCH /* t2: hart_index */
-	sw	a0, THREAD_CORE_LOCAL_HART_ID(t1)
+	sw	s0, THREAD_CORE_LOCAL_HART_ID(t1)
 	sw	t2, THREAD_CORE_LOCAL_HART_INDEX(t1)
 
 	mv	sp, t0


### PR DESCRIPTION
The hart ID is stored in s0 register not a0 register. This fixes multi-hart boot hang issue.

Fixes: 29661368f51d ("core: riscv: preserve hartid in s0 register at entry point")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
