### PR TITLE
plat-versal2: conf: Add maximum size of the DTB

### DIFF
--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -49,6 +49,10 @@ $(call force,CFG_CORE_CLUSTER_SHIFT,1)
 CFG_TZDRAM_START   ?= 0x1800000
 CFG_TZDRAM_SIZE    ?= 0x8000000
 
+# Maximum size of the Device Tree Blob to accommodate
+# device tree with additional nodes.
+CFG_DTB_MAX_SIZE ?= 0x200000
+
 # Console selection
 # 0 : UART0[pl011, pl011_0] (default)
 # 1 : UART1[pl011_1]


### PR DESCRIPTION
The DTB size for the AMD platform is larger and does not fit into the default size, leading to failure or panic at boot time due to size issues.

Thus setting an explicit maximum size for the Device Tree Blob to allow safe modifications. This ensures there is enough space when appending or editing nodes/properties in the DTB.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
