### PR TITLE
i.MX TZASC improvements

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -525,6 +525,12 @@ ifneq (,$(filter y, $(CFG_MX6) $(CFG_MX7)))
 CFG_IMX_CSU ?= y
 endif
 
+ifneq (,$(filter y, $(CFG_MX8M)))
+ifneq ($(CFG_INSECURE),y)
+$(call force,CFG_TZASC_REGION0_SECURE,y)
+endif
+endif
+
 ifeq ($(filter y, $(CFG_PSCI_ARM32)), y)
 CFG_HWSUPP_MEM_PERM_WXN = n
 CFG_IMX_WDOG ?= y

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -531,6 +531,15 @@ $(call force,CFG_TZASC_REGION0_SECURE,y)
 endif
 endif
 
+# We can't make it default since due to missing i.MX7 and i.MX9 support.
+# Once all plattforms are supported we can remove the CFG_TZASC_CHECK_ENABLED
+# and perform the check always.
+ifneq (,$(filter y, $(CFG_MX6) $(CFG_MX8M)))
+ifneq ($(CFG_INSECURE),y)
+$(call force,CFG_TZASC_CHECK_ENABLED,y)
+endif
+endif
+
 ifeq ($(filter y, $(CFG_PSCI_ARM32)), y)
 CFG_HWSUPP_MEM_PERM_WXN = n
 CFG_IMX_WDOG ?= y

--- a/core/arch/arm/plat-imx/registers/imx8m.h
+++ b/core/arch/arm/plat-imx/registers/imx8m.h
@@ -8,6 +8,8 @@
 
 #include <registers/imx8m-crm.h>
 
+#define IOMUXC_GPR_BASE	0x30340000
+#define IOMUXC_SIZE	0x10000
 #define GICD_BASE	0x38800000
 #define GICR_BASE	0x38880000
 #define UART1_BASE	0x30860000
@@ -63,5 +65,7 @@
 #define IOMUXC_I2C1_SCL_MUX_OFF	0x200
 #define IOMUXC_I2C1_SDA_MUX_OFF	0x204
 #endif
+
+#define IOMUXC_GPR_GPR10_OFFSET		0x28
 
 #endif /* __IMX8M_H__ */

--- a/core/arch/arm/plat-imx/tzc380.c
+++ b/core/arch/arm/plat-imx/tzc380.c
@@ -67,6 +67,20 @@ static TEE_Result imx_configure_tzasc(void)
 
 		tzc_init(addr[i]);
 
+		/*
+		 * TZC380 is not memory alias aware so an attacker could read
+		 * the OP-TEE core memory if the system does support memory
+		 * aliasing.
+		 *
+		 * To fix this region0 needs to be configured as secure access
+		 * only (0xc). This is the default if not changed by the
+		 * previous running firmware. Region0 covers the complete
+		 * platform AXI address space.
+		 */
+		if (IS_ENABLED(CFG_TZASC_REGION0_SECURE) &&
+		    tzc_verify_region0_secure() != TEE_SUCCESS)
+			panic("region0 is not secure configured, non-secure memory alias access possible!");
+
 		region = imx_tzc_auto_configure(CFG_DRAM_BASE, CFG_DDR_SIZE,
 						TZC_ATTR_SP_NS_RW, region);
 		region = imx_tzc_auto_configure(CFG_TZDRAM_START,

--- a/core/arch/arm/plat-imx/tzc380.c
+++ b/core/arch/arm/plat-imx/tzc380.c
@@ -11,6 +11,7 @@
 #include <drivers/tzc380.h>
 #include <imx-regs.h>
 #include <initcall.h>
+#include <io.h>
 #include <kernel/panic.h>
 #include <kernel/pm.h>
 #include <mm/core_memprot.h>
@@ -28,6 +29,99 @@ register_phys_mem(MEM_AREA_IO_SEC, TZASC2_BASE, TZASC_SIZE);
 #endif
 
 register_phys_mem(MEM_AREA_IO_SEC, TZASC_BASE, TZASC_SIZE);
+
+/*
+ * i.MX6 needs special handling due to the different GPR locations.
+ */
+#if defined(CFG_MX6)
+#if defined(CFG_MX6UL) || defined(CFG_MX6ULL) || defined (CFG_MX6SLL) || defined (CFG_MX6SX)
+register_phys_mem(MEM_AREA_IO_SEC, IOMUXC_GPR_BASE, IOMUXC_SIZE);
+#else
+register_phys_mem(MEM_AREA_IO_SEC, IOMUXC_BASE, IOMUXC_SIZE);
+#endif
+#elif defined(IOMUXC_GPR_BASE)
+register_phys_mem(MEM_AREA_IO_SEC, IOMUXC_GPR_BASE, IOMUXC_SIZE);
+#endif
+
+/* Not all platforms support the GPR offsets yet */
+#ifndef IOMUXC_GPR9_OFFSET
+#define IOMUXC_GPR9_OFFSET		0
+#endif
+
+#ifndef IOMUXC_GPR_GPR10_OFFSET
+#define IOMUXC_GPR_GPR10_OFFSET		0
+#endif
+
+#define IMX6_TZASC2_BYP			BIT(1)
+#define IMX6_TZASC1_BYP			BIT(0)
+
+#define IMX8M_LOCK_GPR_TZASC_EN		BIT(16)
+#define IMX8M_TZASC_ID_SWAP_BYPASS	BIT(1)
+#define IMX8M_TZASC_EN			BIT(1)
+
+static bool imx6_tzasc_is_enabled(void)
+{
+	uint32_t mask = 0;
+	vaddr_t addr = 0;
+	paddr_t base = 0;
+
+	assert(IOMUXC_GPR9_OFFSET != 0);
+
+	if (IS_ENABLED(CFG_MX6UL) || IS_ENABLED(CFG_MX6ULL) ||
+	    IS_ENABLED(CFG_MX6SLL) || IS_ENABLED(CFG_MX6SX))
+		base = IOMUXC_GPR_BASE;
+	else
+		base = IOMUXC_BASE;
+
+	addr = core_mmu_get_va(base, MEM_AREA_IO_SEC, IOMUXC_SIZE);
+	if (!addr) {
+		EMSG("Failed to get GPR");
+		return false;
+	}
+
+	mask = IMX6_TZASC1_BYP;
+	if (IS_ENABLED(CFG_MX6Q) || IS_ENABLED(CFG_MX6D) ||
+	    IS_ENABLED(CFG_MX6DL) || IS_ENABLED(CFG_MX6QP))
+		mask |= IMX6_TZASC2_BYP;
+
+	return (io_read32(addr + IOMUXC_GPR9_OFFSET) & mask) == mask;
+}
+
+static bool imx8m_tzasc_is_enabled(void)
+{
+	uint32_t mask = 0;
+	vaddr_t addr = 0;
+
+	assert(IOMUXC_GPR_GPR10_OFFSET != 0);
+
+	addr = core_mmu_get_va(IOMUXC_GPR_BASE, MEM_AREA_IO_SEC, IOMUXC_SIZE);
+	if (!addr) {
+		EMSG("Failed to get GPR");
+		return false;
+	}
+
+	mask = IMX8M_LOCK_GPR_TZASC_EN | IMX8M_TZASC_ID_SWAP_BYPASS |
+	       IMX8M_TZASC_EN;
+
+	return (io_read32(addr + IOMUXC_GPR_GPR10_OFFSET) & mask) == mask;
+}
+
+static bool imx_tzasc_is_enabled(void)
+{
+
+	if (!IS_ENABLED(CFG_TZASC_CHECK_ENABLED)) {
+		IMSG("CFG_TZASC_CHECK_ENABLED disabled, please enable");
+		return true;
+	}
+
+	if (IS_ENABLED(CFG_MX6))
+		return imx6_tzasc_is_enabled();
+	else if (IS_ENABLED(CFG_MX8M))
+		return imx8m_tzasc_is_enabled();
+
+	IMSG("Checking TZASC enable is not supported yet for this platform");
+	return false;
+}
 
 static int imx_tzc_auto_configure(vaddr_t addr, vaddr_t rsize, uint32_t attr,
 				  uint8_t region)
@@ -52,6 +146,9 @@ static TEE_Result imx_configure_tzasc(void)
 	vaddr_t addr[2] = {0};
 	int end = 1;
 	int i = 0;
+
+	if (!imx_tzasc_is_enabled())
+		panic("TZC380 must be enabled before starting OP-TEE");
 
 	addr[0] = core_mmu_get_va(TZASC_BASE, MEM_AREA_IO_SEC, 1);
 

--- a/core/arch/arm/plat-imx/tzc380.c
+++ b/core/arch/arm/plat-imx/tzc380.c
@@ -56,7 +56,7 @@ static TEE_Result imx_configure_tzasc(void)
 	addr[0] = core_mmu_get_va(TZASC_BASE, MEM_AREA_IO_SEC, 1);
 
 	if (IS_ENABLED(CFG_MX6Q) || IS_ENABLED(CFG_MX6D) ||
-	    IS_ENABLED(CFG_MX6DL)) {
+	    IS_ENABLED(CFG_MX6DL) || IS_ENABLED(CFG_MX6QP)) {
 		assert(TZASC2_BASE != 0);
 		addr[1] = core_mmu_get_va(TZASC2_BASE, MEM_AREA_IO_SEC, 1);
 		end = 2;

--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -315,6 +315,29 @@ TEE_Result tzc_regions_lockdown(void)
 	return TEE_SUCCESS;
 }
 
+/*
+ * `tzc_verify_region0_secure` verifies that default region0 only permitts
+ * secure-world access to overcome memory alias access breaches.
+ *
+ * Return
+ *  - TEE_SUCCESS if region0 is secure world only access
+ *  - TEE_ERROR_SECURITY if region0 can be accessed be non-secure world
+ */
+TEE_Result tzc_verify_region0_secure(void)
+{
+	uint32_t val = 0;
+
+	assert(tzc.base);
+
+	val = tzc_read_region_attributes(tzc.base, 0);
+	val &= TZC_ATTR_SP_ALL;
+
+	if (val != TZC_ATTR_SP_S_RW)
+		return TEE_ERROR_SECURITY;
+
+	return TEE_SUCCESS;
+}
+
 #if TRACE_LEVEL >= TRACE_DEBUG
 
 static uint32_t tzc_read_region_base_low(vaddr_t base, uint32_t region)

--- a/core/drivers/tzc380.c
+++ b/core/drivers/tzc380.c
@@ -338,7 +338,9 @@ void tzc_dump_state(void)
 	     io_read32(tzc.base + SECURITY_INV_EN_OFF));
 	for (n = 0; n <= REGION_MAX; n++) {
 		temp_32reg = tzc_read_region_attributes(tzc.base, n);
-		if (!(temp_32reg & TZC_ATTR_REGION_EN_MASK))
+
+		/* region0 is always enabled */
+		if (n && !(temp_32reg & TZC_ATTR_REGION_EN_MASK))
 			continue;
 
 		DMSG("");
@@ -348,6 +350,9 @@ void tzc_dump_state(void)
 		DMSG("region_base: 0x%08x%08x", temp_32reg_h, temp_32reg);
 		temp_32reg = tzc_read_region_attributes(tzc.base, n);
 		DMSG("region sp: %x", temp_32reg >> TZC_ATTR_SP_SHIFT);
+		/* Skip printing the size for region0 */
+		if (!n)
+			continue;
 		DMSG("region size: %x", (temp_32reg & TZC_REGION_SIZE_MASK) >>
 				TZC_REGION_SIZE_SHIFT);
 	}

--- a/core/include/drivers/tzc380.h
+++ b/core/include/drivers/tzc380.h
@@ -219,6 +219,7 @@ void tzc_int_clear(void);
 int tzc_auto_configure(vaddr_t addr, vaddr_t rsize, uint32_t attr,
 		       uint8_t region);
 TEE_Result tzc_regions_lockdown(void);
+TEE_Result tzc_verify_region0_secure(void);
 
 #if TRACE_LEVEL >= TRACE_DEBUG
 void tzc_dump_state(void);


### PR DESCRIPTION
This PR is to hardening the TZASC configuration on i.MX SoCs.

First patch fixes the missing TZASC setup for i.MX6QP platforms.

Patch2 adds the support to dump the very important region0 which covers the complete SoC AXI space incl. memory alias addresses.

Patches 3-4 add the support to verify that the prev. running firmware doesn't re-configure region0 to secure + non-secure RW access. For more information see: https://lore.kernel.org/barebox/20250626144527.416697-1-m.felsch@pengutronix.de/T/#m9efb0988a0b594ba23fc8622671f2828c07a1e0f

Patch 5 ensures that the TZASC is enabled.