### PR TITLE
core: riscv: add initial support for CVA6 APU on Genesys2

### DIFF
--- a/core/arch/riscv/plat-cva6apu/conf.mk
+++ b/core/arch/riscv/plat-cva6apu/conf.mk
@@ -1,0 +1,53 @@
+PLATFORM_FLAVOR ?= cv64a6_genesys_2
+
+ifeq ($(PLATFORM_FLAVOR),cv64a6_genesys_2)
+$(call force,CFG_RV64_core,y)
+$(call force,CFG_RISCV_FPU,y)
+$(call force,CFG_RISCV_MMU_MODE,39)
+supported-ta-targets = ta_rv64
+endif
+
+ifeq ($(PLATFORM_FLAVOR),cv32a6_genesys_2)
+$(call force,CFG_RV32_core,y)
+$(call force,CFG_RISCV_FPU,n)
+$(call force,CFG_RISCV_MMU_MODE,32)
+supported-ta-targets = ta_rv32
+endif
+
+$(call force,CFG_RISCV_ISA_C,y)
+
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_RESERVED_SHM,n)
+$(call force,CFG_CORE_DYN_SHM,y)
+
+$(call force,CFG_DYN_CONFIG,n)
+
+CFG_DT ?= y
+
+$(call force,CFG_WITH_SOFTWARE_PRNG,y)
+
+$(call force,CFG_CORE_ASLR,n)
+$(call force,CFG_CORE_SANITIZE_KADDRESS,n)
+
+$(call force,CFG_TEE_CORE_NB_CORE, 1)
+$(call force,CFG_NUM_THREADS, 1)
+$(call force,CFG_BOOT_SYNC_CPU,n)
+
+CFG_RISCV_PLIC ?= y
+$(call force,CFG_RISCV_APLIC,n)
+$(call force,CFG_RISCV_APLIC_MSI,n)
+$(call force,CFG_RISCV_IMSIC,n)
+
+CFG_RISCV_SBI_CONSOLE ?= n
+CFG_16550_UART ?= y
+
+$(call force,CFG_RISCV_M_MODE,n)
+$(call force,CFG_RISCV_S_MODE,y)
+$(call force,CFG_RISCV_TIME_SOURCE_RDTIME,y)
+CFG_RISCV_MTIME_RATE ?= 10000000
+CFG_RISCV_SBI ?= y
+CFG_RISCV_WITH_M_MODE_SM ?= y
+
+CFG_TDDRAM_START ?= 0xBE000000
+CFG_TDDRAM_SIZE  ?= 0x01000000
+CFG_TEE_RAM_VA_SIZE ?= 0x00200000

--- a/core/arch/riscv/plat-cva6apu/main.c
+++ b/core/arch/riscv/plat-cva6apu/main.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright 2025 NXP
+ */
+
+#include <console.h>
+#include <drivers/ns16550.h>
+#include <drivers/plic.h>
+#include <kernel/boot.h>
+#include <platform_config.h>
+
+#ifdef CFG_16550_UART
+static struct ns16550_data console_data __nex_bss;
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, UART0_BASE, NS16550_UART_REG_SIZE);
+#endif
+
+register_ddr(DRAM_BASE, DRAM_SIZE);
+
+#ifdef CFG_RISCV_PLIC
+void boot_primary_init_intc(void)
+{
+	plic_init(PLIC_BASE);
+}
+#endif /* CFG_RISCV_PLIC */
+
+#ifdef CFG_16550_UART
+void plat_console_init(void)
+{
+	ns16550_init(&console_data, UART0_BASE, IO_WIDTH_U32, 2);
+	register_serial_console(&console_data.chip);
+}
+#endif
+
+void interrupt_main_handler(void)
+{
+	if (IS_ENABLED(CFG_RISCV_PLIC))
+		plic_it_handle();
+}

--- a/core/arch/riscv/plat-cva6apu/platform_config.h
+++ b/core/arch/riscv/plat-cva6apu/platform_config.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright 2025 NXP
+ *
+ * Brief CVA6 APU platform configuration.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+#include <riscv.h>
+
+/* DRAM */
+#ifndef DRAM_BASE
+#define DRAM_BASE		0x80000000
+#define DRAM_SIZE		0x40000000
+#endif
+
+/* CLINT */
+#ifndef CLINT_BASE
+#define CLINT_BASE		0x02000000
+#endif
+
+/* PLIC */
+#ifndef PLIC_BASE
+#define PLIC_BASE		0x0c000000
+#define PLIC_REG_SIZE   0x4000000
+#define PLIC_NUM_SOURCES	30
+#endif
+
+/* UART */
+#ifndef UART0_BASE
+#define UART0_BASE		0x10000000
+#endif
+
+#ifdef CFG_RISCV_MTIME_RATE
+#define RISCV_MTIME_RATE CFG_RISCV_MTIME_RATE
+#else
+#define RISCV_MTIME_RATE 1000000
+#endif
+
+#define PLAT_THREAD_EXCP_FOREIGN_INTR	\
+	(CSR_XIE_EIE | CSR_XIE_TIE | CSR_XIE_SIE)
+#define PLAT_THREAD_EXCP_NATIVE_INTR	(0)
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/riscv/plat-cva6apu/sub.mk
+++ b/core/arch/riscv/plat-cva6apu/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c


### PR DESCRIPTION
Add initial support for the CVA6 APU on the Genesys2 board.

This includes two build flavors:

  - `cv64a6_genesys_2`: 64-bit variant, RV64IMAFDC ISA with Sv39 MMU.
  - `cv32a6_genesys_2`: 32-bit variant, RV32IMAC ISA with Sv32 MMU.

Main platform specification:

  - CPU: Single-core OpenHW Group CVA6 CPU
  - ISA: RV64IMAFDC (64-bit) or RV32IMAC (32-bit)
  - MMU: Sv39 (64-bit), Sv32 (32-bit)
  - Timer: APB timer mapped at 0x18000000 with 4 interrupts
  - UART: ns16550 compatible, base 0x10000000
  - CLINT: at 0x2000000 for timer and software interrupts
  - PLIC: at 0xc000000 with 30 devices
  - Memory: 1 GB DDR3 DRAM at 0x80000000

The secure memory region reserved for OP-TEE starts at address 0xBE000000 and is 16MB in size, placed near the top of the 1GB DRAM.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
