### PR TITLE
Add optee.ta.instanceKeepCrashed property

### DIFF
--- a/lib/libutee/include/user_ta_header.h
+++ b/lib/libutee/include/user_ta_header.h
@@ -52,8 +52,13 @@
 					BIT32(11)
 #define TA_FLAG_DEVICE_ENUM_TEE_STORAGE_PRIVATE	\
 					BIT32(12) /* with TEE_STORAGE_PRIVATE */
+/*
+ * Don't restart a TA with TA_FLAG_INSTANCE_KEEP_ALIVE set if it has
+ * crashed.
+ */
+#define TA_FLAG_INSTANCE_KEEP_CRASHED	BIT32(13)
 
-#define TA_FLAGS_MASK			GENMASK_32(12, 0)
+#define TA_FLAGS_MASK			GENMASK_32(13, 0)
 
 struct ta_head {
 	TEE_UUID uuid;
@@ -133,6 +138,7 @@ extern struct __elf_phdr_info __elf_phdr_info;
 #define TA_PROP_STR_SINGLE_INSTANCE	"gpd.ta.singleInstance"
 #define TA_PROP_STR_MULTI_SESSION	"gpd.ta.multiSession"
 #define TA_PROP_STR_KEEP_ALIVE		"gpd.ta.instanceKeepAlive"
+#define TA_PROP_STR_KEEP_CRASHED	"optee.ta.instanceKeepCrashed"
 #define TA_PROP_STR_DATA_SIZE		"gpd.ta.dataSize"
 #define TA_PROP_STR_STACK_SIZE		"gpd.ta.stackSize"
 #define TA_PROP_STR_VERSION		"gpd.ta.version"

--- a/ta/user_ta_header.c
+++ b/ta/user_ta_header.c
@@ -142,6 +142,9 @@ const struct user_ta_property ta_props[] = {
 	{TA_PROP_STR_KEEP_ALIVE, USER_TA_PROP_TYPE_BOOL,
 	 &(const bool){(TA_FLAGS & TA_FLAG_INSTANCE_KEEP_ALIVE) != 0}},
 
+	{TA_PROP_STR_KEEP_CRASHED, USER_TA_PROP_TYPE_BOOL,
+	 &(const bool){(TA_FLAGS & TA_FLAG_INSTANCE_KEEP_CRASHED) != 0}},
+
 	{TA_PROP_STR_DATA_SIZE, USER_TA_PROP_TYPE_U32,
 	 &(const uint32_t){TA_DATA_SIZE}},
 


### PR DESCRIPTION
Add the optee.ta.instanceKeepCrashed property to prevent a TA with gpd.ta.instanceKeepAlive=true to be restarted. This prevents unexpected resetting of the state of the TA.


Reviewed-by: Jerome Forissier <jerome.forissier@linaro.org>
Reviewed-by: Alex Lewontin <alex.lewontin@canonical.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
