### PR TITLE
ta/link.mk: update the default TA encryption key

### DIFF
--- a/ta/link.mk
+++ b/ta/link.mk
@@ -8,12 +8,13 @@ TA_SIGN_KEY ?= $(ta-dev-kit-dir$(sm))/keys/default_ta.pem
 ifeq ($(CFG_ENCRYPT_TA),y)
 # Default TA encryption key is a dummy key derived from default
 # hardware unique key (an array of 16 zero bytes) to demonstrate
-# usage of REE-FS TAs encryption feature.
+# usage of REE-FS TAs encryption feature. It should match the key
+# returned by tee_otp_get_ta_enc_key().
 #
 # Note that a user of this TA encryption feature needs to provide
 # encryption key and its handling corresponding to their security
 # requirements.
-TA_ENC_KEY ?= 'b64d239b1f3c7d3b06506229cd8ff7c8af2bb4db2168621ac62c84948468c4f4'
+TA_ENC_KEY ?= 'e3ff381eb7859bb961c52f9b78b693f725c261e75eb488ef5893d6de5d097e6a'
 endif
 
 all: $(link-out-dir$(sm))/$(user-ta-uuid).dmp \


### PR DESCRIPTION
When the TA signing key for OP-TEE was changed [1], the TA encryption key (which is a derived key) was not updated. As a result, CFG_ENCRYPT_TA=y is broken. Fix that by updating TA_ENC_KEY to reflect the output of tee_otp_get_ta_enc_key().

Fixes: 5d5d7d0b1c03 ("keys: increase default RSA key size to 4096 bits") [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
