### PR TITLE
Fix GPIO framework to prevent glitch when requesting an output GPIO

### DIFF
--- a/core/drivers/gpio/gpio.c
+++ b/core/drivers/gpio/gpio.c
@@ -10,6 +10,9 @@
 #include <tee_api_types.h>
 #include <util.h>
 
+/* gpio suffixes used for device tree lookup */
+static const char * const gpio_suffixes[] = { "gpios", "gpio" };
+
 TEE_Result gpio_dt_alloc_pin(struct dt_pargs *pargs, struct gpio **out_gpio)
 {
 	struct gpio *gpio = NULL;
@@ -29,41 +32,33 @@ TEE_Result gpio_dt_alloc_pin(struct dt_pargs *pargs, struct gpio **out_gpio)
 	return TEE_SUCCESS;
 }
 
-static char *gpio_get_dt_prop_name(const char *gpio_name)
-{
-	int ret = 0;
-	char *prop_name = NULL;
-	size_t max_len = strlen(gpio_name) + strlen("-gpios") + 1;
-
-	prop_name = calloc(1, max_len);
-	if (!prop_name)
-		return NULL;
-
-	ret = snprintf(prop_name, max_len, "%s-gpios", gpio_name);
-	if (ret < 0 || (size_t)ret >= max_len) {
-		free(prop_name);
-		return NULL;
-	}
-
-	return prop_name;
-}
-
 TEE_Result gpio_dt_get_by_index(const void *fdt, int nodeoffset,
 				unsigned int index, const char *gpio_name,
 				struct gpio **gpio)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	char *prop_name = NULL;
+	char prop_name[32]; /* 32 is max size of property name in DT */
 	void *out_gpio = NULL;
+	unsigned int i = 0;
 
-	prop_name = gpio_get_dt_prop_name(gpio_name);
-	if (!prop_name)
-		return TEE_ERROR_OUT_OF_MEMORY;
+	/* Try GPIO properties "foo-gpios" and "foo-gpio" */
+	for (i = 0; i < ARRAY_SIZE(gpio_suffixes); i++) {
+		if (gpio_name)
+			snprintf(prop_name, sizeof(prop_name), "%s-%s",
+				 gpio_name, gpio_suffixes[i]);
+		else
+			snprintf(prop_name, sizeof(prop_name), "%s",
+				 gpio_suffixes[i]);
 
-	res = dt_driver_device_from_node_idx_prop(prop_name, fdt, nodeoffset,
-						  index, DT_DRIVER_GPIO,
-						  &out_gpio);
-	free(prop_name);
+		res = dt_driver_device_from_node_idx_prop(prop_name, fdt,
+							  nodeoffset,
+							  index, DT_DRIVER_GPIO,
+							  &out_gpio);
+
+		if (res != TEE_ERROR_ITEM_NOT_FOUND)
+			break;
+	}
+
 	if (!res)
 		*gpio = out_gpio;
 

--- a/core/drivers/gpio/gpio.c
+++ b/core/drivers/gpio/gpio.c
@@ -69,6 +69,12 @@ TEE_Result gpio_configure(struct gpio *gpio, enum gpio_flags flags)
 {
 	enum gpio_level value = GPIO_LEVEL_LOW;
 
+	assert(!gpio || (gpio->chip && gpio->chip->ops));
+
+	/* Configure GPIO with DT flags */
+	if (gpio && gpio->chip->ops->configure)
+		gpio->chip->ops->configure(gpio->chip, gpio);
+
 	/* Process requester flags */
 	if (flags & GPIO_FLAGS_BIT_DIR_SET) {
 		if (flags & GPIO_FLAGS_BIT_DIR_OUT) {

--- a/core/drivers/gpio/gpio.c
+++ b/core/drivers/gpio/gpio.c
@@ -64,3 +64,34 @@ TEE_Result gpio_dt_get_by_index(const void *fdt, int nodeoffset,
 
 	return res;
 }
+
+TEE_Result gpio_configure(struct gpio *gpio, enum gpio_flags flags)
+{
+	enum gpio_level value = GPIO_LEVEL_LOW;
+
+	/* Process requester flags */
+	if (flags & GPIO_FLAGS_BIT_DIR_SET) {
+		if (flags & GPIO_FLAGS_BIT_DIR_OUT) {
+			if (flags & GPIO_FLAGS_BIT_DIR_VAL)
+				value = GPIO_LEVEL_HIGH;
+			gpio_set_value(gpio, value);
+			gpio_set_direction(gpio, GPIO_DIR_OUT);
+		} else {
+			gpio_set_direction(gpio, GPIO_DIR_IN);
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result gpio_dt_cfg_by_index(const void *fdt, int nodeoffset,
+				unsigned int index, const char *gpio_name,
+				enum gpio_flags flags, struct gpio **gpio)
+{
+	TEE_Result res = gpio_dt_get_by_index(fdt, nodeoffset, index, gpio_name,
+					      gpio);
+	if (!res)
+		gpio_configure(*gpio, flags);
+
+	return res;
+}

--- a/core/drivers/regulator/regulator_fixed.c
+++ b/core/drivers/regulator/regulator_fixed.c
@@ -78,14 +78,8 @@ static TEE_Result get_enable_gpio(const void *fdt, int node,
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const fdt32_t *cuint = NULL;
 	struct gpio *gpio = NULL;
-	void *gpio_ref = &gpio;
 
-	res = dt_driver_device_from_node_idx_prop("gpios", fdt, node, 0,
-						  DT_DRIVER_GPIO, gpio_ref);
-	if (res == TEE_ERROR_ITEM_NOT_FOUND)
-		res = dt_driver_device_from_node_idx_prop("gpio", fdt, node, 0,
-							  DT_DRIVER_GPIO,
-							  gpio_ref);
+	res = gpio_dt_get_by_index(fdt, node, 0, NULL, &gpio);
 	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
 		regu->enable_gpio = NULL;
 

--- a/core/drivers/regulator/regulator_fixed.c
+++ b/core/drivers/regulator/regulator_fixed.c
@@ -108,6 +108,10 @@ static TEE_Result get_enable_gpio(const void *fdt, int node,
 	if (cuint)
 		regu->off_on_delay = fdt32_to_cpu(*cuint);
 
+	/* Low level initialisation with updated dt_flags */
+	gpio_configure(gpio, GPIO_ASIS);
+
+	/* Configure output, don't change level */
 	gpio_set_direction(gpio, GPIO_DIR_OUT);
 
 	regu->enable_gpio = gpio;

--- a/core/drivers/regulator/regulator_gpio.c
+++ b/core/drivers/regulator/regulator_gpio.c
@@ -170,13 +170,11 @@ static TEE_Result get_voltage_level_gpio(const void *fdt, int node,
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const fdt32_t *cuint = NULL;
 	struct gpio *gpio = NULL;
-	void *gpio_ref = &gpio;
 	int level0 = 0;
 	int level1 = 0;
 	int len = 0;
 
-	res = dt_driver_device_from_node_idx_prop("gpios", fdt, node, 0,
-						  DT_DRIVER_GPIO, gpio_ref);
+	res = gpio_dt_get_by_index(fdt, node, 0, NULL, &gpio);
 	if (res)
 		return res;
 
@@ -186,8 +184,7 @@ static TEE_Result get_voltage_level_gpio(const void *fdt, int node,
 	 * this implementation is simplified to support only 2 voltage
 	 * levels controlled with a single GPIO.
 	 */
-	if (dt_driver_device_from_node_idx_prop("gpios", fdt, node, 1,
-						DT_DRIVER_GPIO, gpio_ref) !=
+	if (gpio_dt_get_by_index(fdt, node, 1, NULL, &gpio) !=
 	    TEE_ERROR_ITEM_NOT_FOUND) {
 		EMSG("Multiple GPIOs not supported for level control");
 		return TEE_ERROR_GENERIC;

--- a/core/drivers/regulator/regulator_gpio.c
+++ b/core/drivers/regulator/regulator_gpio.c
@@ -157,6 +157,10 @@ static TEE_Result get_enable_gpio(const void *fdt, int node,
 	if (cuint)
 		regu->enable_delay = fdt32_to_cpu(*cuint);
 
+	/* Low level initialisation with updated dt_flags */
+	gpio_configure(gpio, GPIO_ASIS);
+
+	/* Configure output, don't change level */
 	gpio_set_direction(gpio, GPIO_DIR_OUT);
 
 	regu->enable_gpio = gpio;
@@ -174,7 +178,8 @@ static TEE_Result get_voltage_level_gpio(const void *fdt, int node,
 	int level1 = 0;
 	int len = 0;
 
-	res = gpio_dt_get_by_index(fdt, node, 0, NULL, &gpio);
+	/* GPIO to high per specification or "gpios-states" (not supported) */
+	res = gpio_dt_cfg_by_index(fdt, node, 0, NULL, GPIO_OUT_HIGH, &gpio);
 	if (res)
 		return res;
 
@@ -184,7 +189,7 @@ static TEE_Result get_voltage_level_gpio(const void *fdt, int node,
 	 * this implementation is simplified to support only 2 voltage
 	 * levels controlled with a single GPIO.
 	 */
-	if (gpio_dt_get_by_index(fdt, node, 1, NULL, &gpio) !=
+	if (gpio_dt_cfg_by_index(fdt, node, 1, NULL, GPIO_OUT_HIGH, &gpio) !=
 	    TEE_ERROR_ITEM_NOT_FOUND) {
 		EMSG("Multiple GPIOs not supported for level control");
 		return TEE_ERROR_GENERIC;
@@ -219,8 +224,6 @@ static TEE_Result get_voltage_level_gpio(const void *fdt, int node,
 		regu->voltage_levels_uv[1] = level0;
 		regu->voltage_level_high = false;
 	}
-
-	gpio_set_direction(gpio, GPIO_DIR_OUT);
 
 	regu->voltage_gpio = gpio;
 

--- a/core/drivers/stm32_gpio.c
+++ b/core/drivers/stm32_gpio.c
@@ -283,9 +283,6 @@ static void stm32_gpio_set_level(struct gpio_chip *chip, unsigned int gpio_pin,
 	if (clk_enable(bank->clock))
 		panic();
 
-	assert(((io_read32(bank->base + GPIO_MODER_OFFSET) >>
-		 (gpio_pin << 1)) & GPIO_MODE_MASK) == GPIO_MODE_OUTPUT);
-
 	if (level == GPIO_LEVEL_HIGH)
 		io_write32(bank->base + GPIO_BSRR_OFFSET, BIT(gpio_pin));
 	else
@@ -353,6 +350,45 @@ static TEE_Result consumed_gpios_pm(enum pm_op op, unsigned int pm_hint,
 static void release_rif_semaphore_if_acquired(struct stm32_gpio_bank *bank,
 					      unsigned int pin);
 
+static void stm32_gpio_configure(struct gpio_chip *chip, struct gpio *gpio)
+{
+	struct stm32_gpio_bank *bank = gpio_chip_to_bank(chip);
+	uint32_t exceptions = 0;
+	uint32_t otype = 0;
+	uint32_t pupd = 0;
+	unsigned int shift_1b = gpio->pin;
+	unsigned int shift_2b = SHIFT_U32(gpio->pin, 1);
+
+	assert(is_stm32_gpio_chip(chip));
+
+	if (gpio->dt_flags & GPIO_PULL_UP)
+		pupd = GPIO_PUPD_PULL_UP;
+	else if (gpio->dt_flags & GPIO_PULL_DOWN)
+		pupd = GPIO_PUPD_PULL_DOWN;
+	else
+		pupd = GPIO_PUPD_NO_PULL;
+
+	if (gpio->dt_flags & GPIO_LINE_OPEN_DRAIN)
+		otype = GPIO_OTYPE_OPEN_DRAIN;
+	else
+		otype = GPIO_OTYPE_PUSH_PULL;
+
+	if (clk_enable(bank->clock))
+		panic();
+	exceptions = cpu_spin_lock_xsave(&gpio_lock);
+
+	io_clrsetbits32(bank->base + GPIO_OTYPER_OFFSET,
+			SHIFT_U32(GPIO_OTYPE_OPEN_DRAIN, shift_1b),
+			SHIFT_U32(otype, shift_1b));
+
+	io_clrsetbits32(bank->base + GPIO_PUPDR_OFFSET,
+			SHIFT_U32(GPIO_PUPD_PULL_MASK, shift_2b),
+			SHIFT_U32(pupd, shift_2b));
+
+	cpu_spin_unlock_xrestore(&gpio_lock, exceptions);
+	clk_disable(bank->clock);
+}
+
 static void stm32_gpio_put_gpio(struct gpio_chip *chip, struct gpio *gpio)
 {
 	struct stm32_gpio_bank *bank = gpio_chip_to_bank(chip);
@@ -386,6 +422,7 @@ static const struct gpio_ops stm32_gpio_ops = {
 	.set_direction = stm32_gpio_set_direction,
 	.get_value = stm32_gpio_get_level,
 	.set_value = stm32_gpio_set_level,
+	.configure = stm32_gpio_configure,
 	.put = stm32_gpio_put_gpio,
 };
 
@@ -782,13 +819,7 @@ static TEE_Result stm32_gpio_get_dt(struct dt_pargs *pargs, void *data,
 	struct stm32_gpio_pm_state *state = NULL;
 	struct stm32_gpio_bank *bank = data;
 	struct gpio *gpio = NULL;
-	unsigned int shift_1b = 0;
-	unsigned int shift_2b = 0;
 	bool gpio_secure = true;
-	uint32_t exceptions = 0;
-	uint32_t otype = 0;
-	uint32_t pupd = 0;
-	uint32_t mode = 0;
 
 	consumer_name = fdt_get_name(pargs->fdt, pargs->consumer_node,
 				     NULL);
@@ -857,40 +888,6 @@ static TEE_Result stm32_gpio_get_dt(struct dt_pargs *pargs, void *data,
 	SLIST_INSERT_HEAD(&consumed_gpios_head, state, link);
 
 	register_pm_driver_cb(consumed_gpios_pm, state, "stm32-gpio-state");
-
-	shift_1b = gpio->pin;
-	shift_2b = SHIFT_U32(gpio->pin, 1);
-
-	if (gpio->dt_flags & GPIO_PULL_UP)
-		pupd = GPIO_PUPD_PULL_UP;
-	else if (gpio->dt_flags & GPIO_PULL_DOWN)
-		pupd = GPIO_PUPD_PULL_DOWN;
-	else
-		pupd = GPIO_PUPD_NO_PULL;
-
-	if (gpio->dt_flags & GPIO_LINE_OPEN_DRAIN)
-		otype = GPIO_OTYPE_OPEN_DRAIN;
-	else
-		otype = GPIO_OTYPE_PUSH_PULL;
-
-	if (clk_enable(bank->clock))
-		panic();
-	exceptions = cpu_spin_lock_xsave(&gpio_lock);
-
-	io_clrsetbits32(bank->base + GPIO_MODER_OFFSET,
-			SHIFT_U32(GPIO_MODE_MASK, shift_2b),
-			SHIFT_U32(mode, shift_2b));
-
-	io_clrsetbits32(bank->base + GPIO_OTYPER_OFFSET,
-			SHIFT_U32(GPIO_OTYPE_OPEN_DRAIN, shift_1b),
-			SHIFT_U32(otype, shift_1b));
-
-	io_clrsetbits32(bank->base + GPIO_PUPDR_OFFSET,
-			SHIFT_U32(GPIO_PUPD_PULL_MASK, shift_2b),
-			SHIFT_U32(pupd, shift_2b));
-
-	cpu_spin_unlock_xrestore(&gpio_lock, exceptions);
-	clk_disable(bank->clock);
 
 	gpio->chip = &bank->gpio_chip;
 

--- a/core/drivers/stm32_tamp.c
+++ b/core/drivers/stm32_tamp.c
@@ -1653,7 +1653,7 @@ stm32_tamp_configure_pin_from_dt(const void *fdt, int node,
 	 * If only one GPIO is defined, the tamper control is a passive tamper.
 	 * Else, it is an active tamper.
 	 */
-	res = gpio_dt_get_by_index(fdt, node, 1, "tamper", &gpio_out);
+	res = gpio_dt_cfg_by_index(fdt, node, 1, "tamper", GPIO_IN, &gpio_out);
 	if (res && res != TEE_ERROR_ITEM_NOT_FOUND)
 		return res;
 
@@ -1668,7 +1668,7 @@ stm32_tamp_configure_pin_from_dt(const void *fdt, int node,
 		stm32_tamp_configure_pin(out_id, gpio_out, true, pdata);
 	}
 
-	res = gpio_dt_get_by_index(fdt, node, 0, "tamper", &gpio_ext);
+	res = gpio_dt_cfg_by_index(fdt, node, 0, "tamper", GPIO_IN, &gpio_ext);
 	if (res) {
 		gpio_put(gpio_out);
 		return res;

--- a/core/include/drivers/gpio.h
+++ b/core/include/drivers/gpio.h
@@ -73,6 +73,8 @@ struct gpio_ops {
 	/* Enable or disable a GPIO interrupt */
 	void (*set_interrupt)(struct gpio_chip *chip, unsigned int gpio_pin,
 			      enum gpio_interrupt enable_disable);
+	/* Configure GPIO resources, based on dt_flags */
+	void (*configure)(struct gpio_chip *chip, struct gpio *gpio);
 	/* Release GPIO resources */
 	void (*put)(struct gpio_chip *chip, struct gpio *gpio);
 };

--- a/core/include/drivers/gpio.h
+++ b/core/include/drivers/gpio.h
@@ -156,7 +156,7 @@ TEE_Result gpio_dt_alloc_pin(struct dt_pargs *pargs, struct gpio **gpio);
  * @fdt: Device tree to work on
  * @nodeoffset: Node offset of the subnode containing a 'gpios' property
  * @index: GPIO pin index in '*-gpios' property
- * @gpio_name: Name of the GPIO pin
+ * @gpio_name: Prefix of the GPIO properties in device tree, can be NULL
  * @gpio: Output GPIO pin reference upon success
  *
  * Return TEE_SUCCESS in case of success

--- a/core/include/drivers/gpio.h
+++ b/core/include/drivers/gpio.h
@@ -133,6 +133,39 @@ static inline void gpio_put(struct gpio *gpio)
 		gpio->chip->ops->put(gpio->chip, gpio);
 }
 
+#define GPIO_FLAGS_BIT_DIR_SET		BIT(0)
+#define GPIO_FLAGS_BIT_DIR_OUT		BIT(1)
+#define GPIO_FLAGS_BIT_DIR_VAL		BIT(2)
+
+/**
+ * enum gpio_flags - Optional flags that used to configure direction and output
+ *                   value. These values cannot be OR'd.
+ *
+ * @GPIOD_ASIS:		Don't change anything
+ * @GPIO_IN:		Set lines to input mode
+ * @GPIO_OUT_LOW:	Set lines to output and drive them low
+ * @GPIO_OUT_HIGH:	Set lines to output and drive them high
+
+ */
+enum gpio_flags {
+	GPIO_ASIS	= 0,
+	GPIO_IN		= GPIO_FLAGS_BIT_DIR_SET,
+	GPIO_OUT_LOW	= GPIO_FLAGS_BIT_DIR_SET | GPIO_FLAGS_BIT_DIR_OUT,
+	GPIO_OUT_HIGH	= GPIO_FLAGS_BIT_DIR_SET | GPIO_FLAGS_BIT_DIR_OUT |
+			  GPIO_FLAGS_BIT_DIR_VAL,
+};
+
+/**
+ * gpio_configure() - Configure a GPIO controller
+ *
+ * @gpio: GPIO pin reference upon success
+ * @flags: requester flags of GPIO
+ *
+ * Return TEE_SUCCESS in case of success
+ * Return a TEE_Result compliant code in case of error
+ */
+TEE_Result gpio_configure(struct gpio *gpio, enum gpio_flags mode);
+
 #if defined(CFG_DT) && defined(CFG_DRIVERS_GPIO)
 /**
  * gpio_dt_alloc_pin() - Get an allocated GPIO instance from its DT phandle
@@ -166,15 +199,38 @@ TEE_Result gpio_dt_alloc_pin(struct dt_pargs *pargs, struct gpio **gpio);
 TEE_Result gpio_dt_get_by_index(const void *fdt, int nodeoffset,
 				unsigned int index, const char *gpio_name,
 				struct gpio **gpio);
+
+/**
+ * gpio_dt_cfg_by_index() - Get a GPIO controller at a specific index in
+ * 'gpios' property and configure with provided flags
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the subnode containing a 'gpios' property
+ * @index: GPIO pin index in '*-gpios' property
+ * @gpio_name: Prefix of the GPIO properties in device tree, can be NULL
+ * @flags: requester flags of GPIO
+ * @gpio: Output GPIO pin reference upon success
+ *
+ * Return TEE_SUCCESS in case of success
+ * Return TEE_ERROR_DEFER_DRIVER_INIT if GPIO controller is not initialized
+ * Return a TEE_Result compliant code in case of error
+ */
+TEE_Result gpio_dt_cfg_by_index(const void *fdt, int nodeoffset,
+				unsigned int index, const char *gpio_name,
+				enum gpio_flags mode,
+				struct gpio **gpio);
 #else
-static inline TEE_Result gpio_dt_get_by_index(const void *fdt __unused,
+static inline TEE_Result gpio_dt_cfg_by_index(const void *fdt __unused,
 					      int nodeoffset __unused,
 					      unsigned int index  __unused,
 					      const char *gpio_name  __unused,
+					      enum gpio_flags mode __unused,
 					      struct gpio **gpio __unused)
 {
 	return TEE_ERROR_NOT_SUPPORTED;
 }
+
+static inline gpio_configure(struct gpio *gpio, enum gpio_flags mode);
 
 static inline TEE_Result gpio_dt_alloc_pin(struct dt_pargs *pargs __unused,
 					   struct gpio **gpio __unused)

--- a/core/pta/tests/dt_driver_test.c
+++ b/core/pta/tests/dt_driver_test.c
@@ -282,7 +282,7 @@ static TEE_Result probe_test_gpios(const void *fdt, int node)
 	DT_TEST_MSG("Probe GPIO controllers");
 	dt_test_state.probe_gpios = IN_PROGRESS;
 
-	res = gpio_dt_get_by_index(fdt, node, 0, "test", &gpio);
+	res = gpio_dt_cfg_by_index(fdt, node, 0, "test", GPIO_IN, &gpio);
 	if (res)
 		goto err;
 
@@ -299,7 +299,7 @@ static TEE_Result probe_test_gpios(const void *fdt, int node)
 		goto err;
 	}
 
-	res = gpio_dt_get_by_index(fdt, node, 1, "test", &gpio);
+	res = gpio_dt_cfg_by_index(fdt, node, 1, "test", GPIO_IN, &gpio);
 	if (res)
 		goto err;
 


### PR DESCRIPTION
Hello,

During internal test I discovered that a voltage glitch appeared on boards with discrete regulators.
After further investigation I find out that when a GPIO is retrieved from the device tree it's configured as input and then the function gpio_set_direction() is called to configure the GPIO as output.
This intermediate configuration creates a glitch on the voltage line, we should only configure once a GPIO. Especially since the configuration might already be set by the previous bootloader.

When discussing the issue with @patrickdelaunay we found another bug in the `regulator_gpio` and `regulator_fixed` drivers.
The properties `enable-active-high`, `gpio-open-drain` from the device tree are not taken into account. The device tree is parsed and variable `gpio->dt_flags` is updated but the configuration of the GPIO with the device tree flags is done in function `gpio_dt_get_by_index()` which is called before parsing the custom options.

So this PR does the following :
- Update `gpio_dt_get_by_index()` to search for properties with and without suffixes
- Add `.configure()` ops in GPIO framework configure a GPIO after the parsing of custom properties.
- Add function `gpio_dt_cfg_by_index()` to request a GPIO from the DT and configure it.

Thomas

