### PR TITLE
Several ASan fixes

### DIFF
--- a/lib/libutils/isoc/newlib/strchr.c
+++ b/lib/libutils/isoc/newlib/strchr.c
@@ -99,7 +99,8 @@ _DEFUN (strchr, (s1, i),
   _CONST unsigned char *s = (_CONST unsigned char *)s1;
   unsigned char c = i;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(CFG_CORE_SANITIZE_KADDRESS)
   unsigned long mask,j;
   unsigned long *aligned_addr;
 

--- a/lib/libutils/isoc/newlib/strcmp.c
+++ b/lib/libutils/isoc/newlib/strcmp.c
@@ -95,7 +95,8 @@ QUICKREF
 
 int _DEFUN(strcmp, (s1, s2), _CONST char *s1 _AND _CONST char *s2)
 {
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(CFG_CORE_SANITIZE_KADDRESS)
 	while (*s1 != '\0' && *s1 == *s2) {
 		s1++;
 		s2++;

--- a/lib/libutils/isoc/newlib/strcpy.c
+++ b/lib/libutils/isoc/newlib/strcpy.c
@@ -95,7 +95,8 @@ _DEFUN (strcpy, (dst0, src0),
 	char *dst0 _AND
 	_CONST char *src0)
 {
-#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+#if defined(PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__) || \
+    defined(CFG_CORE_SANITIZE_KADDRESS)
   char *s = dst0;
 
   while (*dst0++ = *src0++)

--- a/lib/libutils/isoc/newlib/strlen.c
+++ b/lib/libutils/isoc/newlib/strlen.c
@@ -92,7 +92,8 @@ size_t _DEFUN(strlen, (str), _CONST char *str)
 {
 	_CONST char *start = str;
 
-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__) && \
+    !defined(CFG_CORE_SANITIZE_KADDRESS)
 	unsigned long *aligned_addr;
 
 	/* Align the pointer, so we can search a word at a time.  */


### PR DESCRIPTION
Hi,

This PR introduces two improvements related to AddressSanitizer (ASan) support:

- Redzones after global variables
Adds redzones after global variables, particularly benefiting `.rodata` variables. The shadow memory related to `.rodata` section is zeroed out in `init_asan()` (what is not true for `.data` or `.bss`), which can hide certain read overflows for constant variables whose size is aligned to `ASAN_BLOCK`. (see test-case)

- Disables certain optimized string functions in newlib under ASan
Disables the use of some optimized string manipulation functions from newlib when ASan is enabled. These versions use the `DETECTNULL` macro, which performs out-of-bounds reads. While this is generally safe due to word-aligned buffer starts, it causes ASan to panic. Notably, the issue was reproducible only with `-O0` builds (no optimization).

