### PR TITLE
Imx8m phytec boards

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -64,7 +64,9 @@ mx8mq-flavorlist = \
 
 mx8mm-flavorlist = \
 	mx8mmevk \
-	mx8mm_cl_iot_gate
+	mx8mm_cl_iot_gate \
+	mx8mm_phyboard_polis \
+	mx8mm_phygate_tauri_l
 
 mx8mn-flavorlist = \
 	mx8mnevk
@@ -402,6 +404,20 @@ CFG_DDR_SIZE ?= 0x40000000
 CFG_UART_BASE ?= UART3_BASE
 CFG_NSEC_DDR_1_BASE ?= 0x80000000UL
 CFG_NSEC_DDR_1_SIZE ?= 0x40000000UL
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mm_phyboard_polis))
+CFG_DDR_SIZE ?= 0x40000000
+CFG_UART_BASE ?= UART3_BASE
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mm_phygate_tauri_l))
+CFG_DDR_SIZE ?= 0x80000000
+CFG_UART_BASE ?= UART3_BASE
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mnevk))

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -74,7 +74,8 @@ mx8mn-flavorlist = \
 mx8mp-flavorlist = \
 	mx8mpevk \
 	mx8mp_rsb3720_6g \
-	mx8mp_phyboard_pollux
+	mx8mp_phyboard_pollux \
+	mx8mp_libra_fpsc
 
 mx8qm-flavorlist = \
 	mx8qmmek \
@@ -428,6 +429,13 @@ endif
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mpevk))
 CFG_DDR_SIZE ?= UL(0x180000000)
 CFG_UART_BASE ?= UART2_BASE
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,36)
+endif
+
+ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mp_libra_fpsc))
+CFG_DDR_SIZE ?= 0x40000000
+CFG_UART_BASE ?= UART4_BASE
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)
 endif

--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -441,7 +441,7 @@ $(call force,CFG_CORE_ARM64_PA_BITS,36)
 endif
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),mx8mp_phyboard_pollux))
-CFG_DDR_SIZE ?= 0x80000000
+CFG_DDR_SIZE ?= 0x40000000
 CFG_UART_BASE ?= UART1_BASE
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_ARM64_PA_BITS,36)


### PR DESCRIPTION
This PR adds support for (remaining) PHYTEC i.MX 8M family based boards.
Mainly, their board flavour is added and CONFIG options deviating from the default are specified.
For the existing PHYTEC phyBOARD-Pollux i.MX 8M  board, the DDR_SIZE is brought in line with the newly introduced boards; i.e. use min RAM of each variant.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
