### PR TITLE
Fix potential panic in trace / print handler

### DIFF
--- a/core/kernel/console.c
+++ b/core/kernel/console.c
@@ -36,7 +36,8 @@ void console_init(void)
 
 void __weak console_putc(int ch)
 {
-	if (!serial_console)
+	if (!serial_console || !serial_console->ops ||
+	    !serial_console->ops->putc)
 		return;
 
 	if (ch == '\n')
@@ -46,7 +47,8 @@ void __weak console_putc(int ch)
 
 void __weak console_flush(void)
 {
-	if (!serial_console || !serial_console->ops->flush)
+	if (!serial_console || !serial_console->ops ||
+	    !serial_console->ops->flush)
 		return;
 
 	serial_console->ops->flush(serial_console);


### PR DESCRIPTION
Hi, I have not contributed to this work in the past, so this is a relatively simple patch to get used to any project
specific style or procedure requirements. I did run checkpatch from a recent linux kernel tree and I am familiar with
DCO. The code builds and works for me.

While porting to a new platform I ended up with some broken mappings during dom0less NS init and serial_console->ops ended up unmapped. This meant the DMSG() in do_init_calls() would invariably panic at that time. This adds a check to avoid trying to call the unmapped ops vector.

Without this check the result is a recursive panic in the console output code with no output, which can be tedious to debug on actual hardware.

If everything is located in the right place and there is sufficient VA available, this should never happen. So this is really just a quality of life improvement for someone getting optee to work in a new situation.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
