### PR TITLE
remoteproc: fix potential overflows in TLV parsing

### DIFF
--- a/ta/remoteproc/src/remoteproc_core.c
+++ b/ta/remoteproc/src/remoteproc_core.c
@@ -232,28 +232,32 @@ static TEE_Result remoteproc_get_tlv(void *tlv_chunk, size_t tlv_size,
 	uint32_t tlv_type = 0;
 	uint32_t tlv_length = 0;
 	uint32_t tlv_v = 0;
+	uintptr_t tmp_p_tlv;
 
 	*value = NULL;
 	*length = 0;
 
 	/* Parse the TLV area */
-	while (p_tlv < p_end_tlv) {
+	while (p_tlv + RPROC_TLV_VALUE_OF < p_end_tlv) {
 		memcpy(&tlv_v, p_tlv, sizeof(tlv_v));
 		tlv_type = TEE_U32_FROM_LITTLE_ENDIAN(tlv_v);
 		memcpy(&tlv_v, p_tlv + RPROC_TLV_LENGTH_OF, sizeof(tlv_v));
+		p_tlv += RPROC_TLV_VALUE_OF;
 		tlv_length = TEE_U32_FROM_LITTLE_ENDIAN(tlv_v);
-		if (tlv_type == type) {
+		if (ADD_OVERFLOW((uintptr_t)p_tlv, tlv_length, &tmp_p_tlv))
+			break;
+		if (tmp_p_tlv <= (uintptr_t)p_end_tlv && tlv_type == type) {
 			/* The specified TLV has been found */
 			DMSG("TLV type %#"PRIx32" found, size %#"PRIx32,
 			     type, tlv_length);
-			*value = &p_tlv[RPROC_TLV_VALUE_OF];
+			*value = p_tlv;
 			*length = tlv_length;
 			if (tlv_length)
 				return TEE_SUCCESS;
 			else
 				return TEE_ERROR_NO_DATA;
 		}
-		p_tlv += ROUNDUP_64(sizeof(struct remoteproc_tlv) + tlv_length);
+		p_tlv += ROUNDUP_64(tlv_length);
 	}
 
 	return TEE_ERROR_NO_DATA;


### PR DESCRIPTION
This commit is fixing two issues:
- Verify that the end of the buffer is not reached before reading the tag and value.
- Verify that the entire TLV fits into the TLV chunk

https://github.com/OP-TEE/optee_os/issues/7496

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
