### PR TITLE
core: imx: Fix TZDRAM_START address for imx93evk

### DIFF
--- a/core/arch/arm/plat-imx/conf.mk
+++ b/core/arch/arm/plat-imx/conf.mk
@@ -232,6 +232,7 @@ CFG_IMX_ELE ?= n
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(mx93-flavorlist)))
 $(call force,CFG_MX93,y)
 $(call force,CFG_ARM64_core,y)
+CFG_TZDRAM_START ?= 0x96000000
 CFG_IMX_LPUART ?= y
 CFG_DRAM_BASE ?= 0x80000000
 CFG_TEE_CORE_NB_CORE ?= 2


### PR DESCRIPTION
According to the imx-mkimage tool, the TZDRAM_START address should be set to 0x96000000 for the imx93evk
(see: https://github.com/nxp-imx/imx-mkimage/blob/lf-6.12.20_2.0.0/iMX93/soc.mak#L44C1-L44C28).

This is also true for the mainline mkimage U-Boot (see: https://github.com/u-boot/u-boot/blob/master/arch/arm/mach-imx/imx9/container.cfg#L16)

Currently, the computed TZDRAM address is wrong and is equal to 0xfe000000 (see:
https://github.com/OP-TEE/optee_os/blob/master/core/arch/arm/plat-imx/conf.mk#L548)
