### PR TITLE
core: arm: stmm_sp: return FFA_NOT_SUPPORTED for undefined FFA function

### DIFF
--- a/core/arch/arm/kernel/stmm_sp.c
+++ b/core/arch/arm/kernel/stmm_sp.c
@@ -975,10 +975,14 @@ static bool spm_handle_scall(struct thread_scall_regs *regs)
 		DMSG("Received FFA mem perm set");
 		spm_handle_set_mem_attr(regs);
 		return true;
-	default:
-		EMSG("Undefined syscall %#"PRIx32, (uint32_t)*a0);
+	case FFA_ERROR:
+		EMSG("Received FFA error");
 		return_from_sp_helper(true /*panic*/, 0xabcd, regs);
 		return false;
+	default:
+		DMSG("Undefined syscall %#"PRIx32, (uint32_t)*a0);
+		spm_eret_error(FFA_NOT_SUPPORTED, regs);
+		return true;
 	}
 }
 


### PR DESCRIPTION
edk2's patch ("ArmFfaLib: Add Rx/Tx support for Stmm secure partition") [0]
added Rx/Tx buffer mapping support to ArmFfaStandaloneMm(Core)Lib.

However, stmm_sp does not require Rx/Tx buffer mapping and
its SVC handler is lightweight. Therefore, when it receives
an undefined FFA function, it is sufficient to return FFA_NOT_SUPPORTED to
StandaloneMm instead of panicking.

This also aligns with the FF-A specification, which requires returning
FFA_NOT_SUPPORTED when an unimplemented function ID is received.

If StandaloneMm fails to initialize, it will return FFA_ERROR.
In this case, there is no way to keep the stmm_sp TA alive,
so panic is called.
Otherwise, StandaloneMm will return with DIRECT_MSG_RESP.

Link: https://github.com/tianocore/edk2/commit/75ca159e57dbe081b89373046280f34d67571852 [0]
Signed-off-by: Yeoreum Yun <yeoreum.yun@arm.com>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
Tested-by: Mikko Rapeli <mikko.rapeli@linaro.org>