### PR TITLE
plat-rockchip: rk3588: cache HUK in memory

### DIFF
--- a/core/arch/arm/plat-rockchip/platform_rk3588.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3588.c
@@ -174,11 +174,21 @@ static TEE_Result generate_huk(struct tee_hw_unique_key *hwkey)
 {
 	TEE_Result res = TEE_SUCCESS;
 	uint8_t buffer[HW_UNIQUE_KEY_LENGTH] = { };
+	size_t i = 0;
+	bool key_is_zero = true;
 
 	/* Generate random 128-bit key from TRNG */
 	res = hw_get_random_bytes(buffer, sizeof(buffer));
 	if (res)
 		return res;
+
+	/* All zero HUK cannot be written to OTP and indicates TRNG failure */
+	for (i = 0; i < ARRAY_SIZE(buffer); i++) {
+		if (buffer[i] != 0)
+			key_is_zero = false;
+	}
+	if (key_is_zero)
+		return TEE_ERROR_NO_DATA;
 
 	memcpy(hwkey->data, buffer, HW_UNIQUE_KEY_LENGTH);
 


### PR DESCRIPTION
I observed timeout errors when OP-TEE reads the HUK from the OTP area
while running the optee-xtests (tests 1006 and 4013) or using the
pkcs#11 TA.

This issue is circumvented by reading the HUK once and caching it in
memory for later use. As a side effect, this reduces the accesses/reads
from the OTP area.

Unfortunately, I don't know the root cause for the timeout while reading
the fuses. I guess that there is a disabled clock which prevents the
read, but I didn't look further, since caching works fine.

While the documentation recommends to never process the HUK in software,
it is read and processed anyway if it can be read from the fuses. Thus,
I don't think that caching has an effect on the security of the HUK.
The caching is inspired by the HUK handling implemented in the nvmem
driver.