### PR TITLE
AMD ASU Support

### DIFF
--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
-#
+# Copyright (c) 2023-2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 
 PLATFORM_FLAVOR ?= generic
@@ -61,6 +60,10 @@ CFG_CONSOLE_UART ?= 0
 
 # PS GPIO Controller configuration.
 CFG_AMD_PS_GPIO ?= n
+
+# AMD ASU Specific configs
+CFG_AMD_ASU_SUPPORT ?= y
+CFG_AMD_APU_LCL_IPI_ID ?= 0x0004
 
 ifeq ($(CFG_AMD_PS_GPIO),y)
 $(call force,CFG_MAP_EXT_DT_SECURE,y)

--- a/core/arch/arm/plat-versal2/conf.mk
+++ b/core/arch/arm/plat-versal2/conf.mk
@@ -64,6 +64,15 @@ CFG_AMD_PS_GPIO ?= n
 # AMD ASU Specific configs
 CFG_AMD_ASU_SUPPORT ?= y
 CFG_AMD_APU_LCL_IPI_ID ?= 0x0004
+# Current HASH engine does not support partial state copy operation. Any
+# operation from REE involving state copy can crash the OS when driver
+# is enabled.
+CFG_AMD_ASU_HASH ?= n
+ifeq ($(CFG_AMD_ASU_HASH),y)
+$(warning WARNING: ASU HASH engine do not support partial state copy operations)
+$(warning WARNING: Any attempt by the REE to perform a state copy operation \
+  will result in a crash of the TEE.)
+endif
 
 ifeq ($(CFG_AMD_PS_GPIO),y)
 $(call force,CFG_MAP_EXT_DT_SECURE,y)

--- a/core/drivers/amd/asu/asu_doorbell.h
+++ b/core/drivers/amd/asu/asu_doorbell.h
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ */
+
+#ifndef __ASU_DOORBELL_H__
+#define __ASU_DOORBELL_H__
+
+#include <stdint.h>
+
+#define PAR_IPIPSU_NUM_INSTANCES	1U
+
+/* Parameter definitions for peripheral ASU IPI */
+#define PAR_IPIPSU_0_DEVICE_ID		0U
+#define PAR_IPIPSU_0_BASEADDR		0xEB330000U
+#define PAR_IPIPSU_0_BIT_MASK		0x00000001U
+#define PAR_IPIPSU_0_INT_ID		0x59U
+#define PAR_IPIPSU_NUM_TARGETS		16U
+#define PAR_PSV_IPI_PMC_BIT_MASK	0x2U
+#define PAR_PSV_IPI_0_BIT_MASK		0x4U
+#define PAR_PSV_IPI_1_BIT_MASK		0x8U
+#define PAR_PSV_IPI_2_BIT_MASK		0x10U
+#define PAR_PSV_IPI_3_BIT_MASK		0x20U
+#define PAR_PSV_IPI_4_BIT_MASK		0x40U
+#define PAR_PSV_IPI_5_BIT_MASK		0x80U
+#define PAR_PSV_IPI_PMC_NOBUF_BIT_MASK	0x100U
+#define PAR_PSV_IPI_6_BIT_MASK		0x200U
+#define IPIPSU_ALL_MASK			0xFFFFU
+
+#define IPIPSU_TRIG_OFFSET	0x00U
+#define IPIPSU_OBS_OFFSET	0x04U
+#define IPIPSU_ISR_OFFSET	0x10U
+#define IPIPSU_IMR_OFFSET	0x14U
+#define IPIPSU_IER_OFFSET	0x18U
+
+struct asu_doorbell_config {
+	uint32_t deviceid;
+	uintptr_t baseaddr;
+	uint32_t bitmask;
+	uint32_t intrid;
+	uintptr_t intrparent;
+	uint32_t target_count;
+	uint32_t target_mask[PAR_IPIPSU_NUM_TARGETS];
+};
+
+struct asu_doorbell_config asu_configtable = {
+	.deviceid = PAR_IPIPSU_0_DEVICE_ID,
+	.baseaddr = PAR_IPIPSU_0_BASEADDR,
+	.bitmask = PAR_IPIPSU_0_BIT_MASK,
+	.intrid = PAR_IPIPSU_0_INT_ID,
+	.target_count = PAR_IPIPSU_NUM_TARGETS,
+	.target_mask = {
+		PAR_PSV_IPI_PMC_BIT_MASK,
+		PAR_PSV_IPI_0_BIT_MASK,
+		PAR_PSV_IPI_1_BIT_MASK,
+		PAR_PSV_IPI_2_BIT_MASK,
+		PAR_PSV_IPI_3_BIT_MASK,
+		PAR_PSV_IPI_4_BIT_MASK,
+		PAR_PSV_IPI_5_BIT_MASK,
+		PAR_PSV_IPI_PMC_NOBUF_BIT_MASK,
+		PAR_PSV_IPI_6_BIT_MASK,
+	}
+};
+
+#endif /* __ASU_DOORBELL_H__ */

--- a/core/drivers/amd/asu/asu_main.c
+++ b/core/drivers/amd/asu/asu_main.c
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#include <assert.h>
+#include <drivers/amd/asu_client.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/delay.h>
+#include <kernel/dt.h>
+#include <kernel/interrupt.h>
+#include <kernel/panic.h>
+#include <kernel/spinlock.h>
+#include <libfdt.h>
+#include <mm/core_mmu.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <trace.h>
+#include <util.h>
+
+#include "asu_doorbell.h"
+
+#define ASU_QUEUE_BUFFER_FULL		0xFFU
+#define ASU_CLIENT_READY		0xFFFFFFFFU
+#define ASU_TARGET_IPI_INT_MASK		1U
+
+#define ASU_BASEADDR			0xEBF80000U
+#define ASU_GLOBAL_CNTRL		(ASU_BASEADDR + 0x00000000U)
+
+#define ASU_BASEADDR_SIZE		0x10000U
+#define ASU_GLOBAL_ADDR_LIMIT		0x1000U
+
+#define ASU_GLOBAL_CNTRL_FW_IS_PRESENT_MASK	0x10U
+#define ASU_ASUFW_BIT_CHECK_TIMEOUT_VALUE	0xFFFFFU
+
+#define ASU_CHNL_IPI_BITMASK		GENMASK_32(31, 16)
+
+struct asu_client {
+	struct asu_channel_memory *chnl_memptr;
+	uint32_t is_ready;
+	unsigned int slock;          /* chnl_memptr spin lock */
+	void *global_ctrl;
+	void *doorbell;
+};
+
+struct asu_ids {
+	uint8_t ids[ASU_UNIQUE_ID_MAX];
+	unsigned int slock;          /* id array spin lock */
+};
+
+static struct asu_ids asuid;
+static struct asu_client *asu;
+
+/*
+ * asu_fwcheck() - Check if ASU firmware is present and ready
+ * Polls the ASU global control register to verify if the HSM firmware
+ * is present and ready for interaction. Uses a timeout of approximately
+ * 1 second for the check.
+ *
+ * Return: TEE_SUCCESS if firmware is ready, TEE_ERROR_BAD_STATE if not present
+ */
+static TEE_Result asu_fwcheck(void)
+{
+	uint64_t timeout = 0;
+
+	/*
+	 * Timeout is set to ~1sec.
+	 * This is the worst case time within which ASUFW ready for interaction
+	 * with components requests.
+	 */
+	timeout = timeout_init_us(ASU_ASUFW_BIT_CHECK_TIMEOUT_VALUE);
+
+	do {
+		if (io_read32((vaddr_t)asu->global_ctrl) &
+		    ASU_GLOBAL_CNTRL_FW_IS_PRESENT_MASK) {
+			DMSG("ASU FW is ready!");
+			return TEE_SUCCESS;
+		}
+	} while (!timeout_elapsed(timeout));
+
+	EMSG("ASU FW is not present!");
+
+	return TEE_ERROR_BAD_STATE;
+}
+
+/*
+ * asu_get_channelID() - Determine the ASU channel ID for APU communication
+ *
+ * Maps the Runtime Configuration Area (RTCA) to find which ASU channel
+ * should be used by the APU for communication. Searches through available
+ * channels to find one matching the APU's local IPI ID.
+ *
+ * Return: Channel ID (0 to ASU_MAX_IPI_CHANNELS-1) or ASU_MAX_IPI_CHANNELS on
+ *	   failure
+ */
+static uint32_t asu_get_channelID(void)
+{
+	TEE_Result ret = TEE_ERROR_GENERIC;
+	void *comm_chnl_info = NULL;
+	uint32_t channel_id = ASU_MAX_IPI_CHANNELS;
+	vaddr_t membase = 0;
+	uint32_t id = 0;
+
+	/*
+	 * RTCA is mapped only to find the ASU Channel ID
+	 * to be used by APU.
+	 * After reading the information RTCA region is unmapped.
+	 */
+	comm_chnl_info = core_mmu_add_mapping(MEM_AREA_IO_SEC,
+					      ASU_RTCA_BASEADDR,
+					      ASU_GLOBAL_ADDR_LIMIT);
+	if (!comm_chnl_info) {
+		EMSG("Failed to map runtime config area");
+		return channel_id;
+	}
+
+	for (id = 0; id < ASU_MAX_IPI_CHANNELS; id++) {
+		membase = (vaddr_t)comm_chnl_info +
+			  ASU_RTCA_CHANNEL_BASE_OFFSET +
+			  ASU_RTCA_CHANNEL_INFO_LEN * id;
+		if ((io_read32(membase) & ASU_CHNL_IPI_BITMASK) ==
+		    (CFG_AMD_APU_LCL_IPI_ID << 16)) {
+			channel_id = id;
+			DMSG("Use ASU channel ID %"PRIu32, channel_id);
+			break;
+		}
+	}
+
+	if (channel_id == ASU_MAX_IPI_CHANNELS)
+		EMSG("Failed to identify ASU channel ID for APU");
+
+	ret = core_mmu_remove_mapping(MEM_AREA_IO_SEC,
+				      comm_chnl_info, ASU_GLOBAL_ADDR_LIMIT);
+	if (ret)
+		EMSG("Failed to unmap RTCA");
+
+	return channel_id;
+}
+
+/*
+ * asu_alloc_unique_id() - Generate a unique identifier for ASU operations
+ *
+ * Creates a unique ID by cycling through available IDs in the callback
+ * reference array. Ensures no ID collision by checking if the slot is
+ * already in use.
+ *
+ * Return: Unique ID (1 to ASU_UNIQUE_ID_MAX-1) or ASU_UNIQUE_ID_MAX if none
+ *	   available
+ */
+uint8_t asu_alloc_unique_id(void)
+{
+	uint8_t unqid = 0;
+	uint32_t state = 0;
+
+	state = cpu_spin_lock_xsave(&asuid.slock);
+	while (unqid < ASU_UNIQUE_ID_MAX) {
+		if (asuid.ids[unqid] == ASU_UNIQUE_ID_MAX) {
+			asuid.ids[unqid] = unqid;
+			DMSG("Got unique ID %"PRIu8, unqid);
+			break;
+		}
+		unqid++;
+	};
+	cpu_spin_unlock_xrestore(&asuid.slock, state);
+
+	return unqid;
+}
+
+/**
+ * asu_free_unique_id() - Release a previously allocated unique ID
+ * @uniqueid: The unique ID to be freed
+ *
+ * Marks the specified unique ID as available for reuse.
+ * The released ID is set to ASU_UNIQUE_ID_MAX
+ * to indicate its availability. Intended to be used in environments where
+ * concurrent access to the unique ID pool occurs.
+ */
+void asu_free_unique_id(uint8_t uniqueid)
+{
+	uint32_t state = 0;
+
+	state = cpu_spin_lock_xsave(&asuid.slock);
+	asuid.ids[uniqueid] = ASU_UNIQUE_ID_MAX;
+	cpu_spin_unlock_xrestore(&asuid.slock, state);
+}
+
+/*
+ * get_free_index() - Find a free buffer index in the specified priority queue
+ * @priority: Priority level (ASU_PRIORITY_HIGH or ASU_PRIORITY_LOW)
+ *
+ * Searches for an available buffer slot in either the high priority (P0) or
+ * low priority (P1) channel queue. Updates the next free index pointer.
+ *
+ * Return: Buffer index (0 to ASU_MAX_BUFFERS-1) or ASU_MAX_BUFFERS if queue
+ *	   is full
+ */
+static uint8_t get_free_index(uint8_t priority)
+{
+	struct asu_channel_queue *qptr = NULL;
+	uint8_t index = 0;
+	uint32_t state = 0;
+
+	state = cpu_spin_lock_xsave(&asu->slock);
+
+	if (priority == ASU_PRIORITY_HIGH)
+		qptr = &asu->chnl_memptr->p0_chnl_q;
+	else
+		qptr = &asu->chnl_memptr->p1_chnl_q;
+
+	while (index < ASU_MAX_BUFFERS) {
+		if (qptr->queue_bufs[index].reqbufstatus == 0U ||
+		    qptr->queue_bufs[index].respbufstatus == 0U)
+			break;
+
+		index++;
+	}
+
+	if (index < ASU_MAX_BUFFERS)
+		qptr->queue_bufs[index].reqbufstatus = ASU_COMMAND_IS_PRESENT;
+
+	cpu_spin_unlock_xrestore(&asu->slock, state);
+
+	return index;
+}
+
+static void put_free_index(struct asu_channel_queue_buf *bufptr)
+{
+	uint32_t state = 0;
+
+	state = cpu_spin_lock_xsave(&asu->slock);
+	bufptr->reqbufstatus = 0;
+	bufptr->respbufstatus = 0;
+	cpu_spin_unlock_xrestore(&asu->slock, state);
+}
+
+/*
+ * send_doorbell() - Send IPI doorbell interrupt to ASU
+ *
+ * Triggers an Inter-Processor Interrupt (IPI) to notify the ASU
+ * that a new command is available in the shared memory queue.
+ *
+ * Return: TEE_SUCCESS on successful doorbell trigger
+ */
+static TEE_Result send_doorbell(void)
+{
+	io_write32((vaddr_t)asu->doorbell + IPIPSU_TRIG_OFFSET,
+		   ASU_TARGET_IPI_INT_MASK);
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * asu_update_queue_buffer_n_send_ipi() - Queue command and send IPI
+ * @param: Client parameters including priority
+ * @req_buffer: Request buffer containing command data
+ * @size: Size of request data
+ * @header: Command header information
+ * @status: FW return status
+ *
+ * Places a command in the appropriate priority queue buffer, updates
+ * queue status, and sends an IPI to notify ASU of the pending command.
+ *
+ * Return: TEE_SUCCESS on success, appropriate error code on failure
+ */
+TEE_Result asu_update_queue_buffer_n_send_ipi(struct asu_client_params *param,
+					      void *req_buffer,
+					      uint32_t size,
+					      uint32_t header,
+					      uint32_t *status)
+{
+	TEE_Result ret = TEE_ERROR_GENERIC;
+	uint8_t freeindex = 0;
+	struct asu_channel_queue_buf *bufptr = NULL;
+	struct asu_channel_queue *qptr = NULL;
+
+	if (!param) {
+		EMSG("Invalid parameters provided");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (asu->is_ready != ASU_CLIENT_READY) {
+		EMSG("ASU client is not ready");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	freeindex = get_free_index(param->priority);
+	if (freeindex == ASU_MAX_BUFFERS) {
+		EMSG("ASU buffers full");
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	if (param->priority == ASU_PRIORITY_HIGH) {
+		bufptr = &asu->chnl_memptr->p0_chnl_q.queue_bufs[freeindex];
+		qptr = &asu->chnl_memptr->p0_chnl_q;
+	} else {
+		bufptr = &asu->chnl_memptr->p1_chnl_q.queue_bufs[freeindex];
+		qptr = &asu->chnl_memptr->p1_chnl_q;
+	}
+
+	bufptr->req.header = header;
+	if (req_buffer && size != 0U)
+		memcpy(bufptr->req.arg, req_buffer, size);
+
+	bufptr->respbufstatus = 0;
+
+	qptr->cmd_is_present = true;
+	qptr->req_sent++;
+	ret = send_doorbell();
+	if (ret != TEE_SUCCESS) {
+		EMSG("Failed to communicate to ASU");
+		return TEE_ERROR_COMMUNICATION;
+	}
+	while (io_read8((vaddr_t)&bufptr->respbufstatus) !=
+	       ASU_RESPONSE_IS_PRESENT) {
+		/*
+		 * WFE will return on SEV generated by the
+		 * interrupt handler or by a spin_unlock
+		 */
+		wfe();
+	}
+
+	*status = bufptr->resp.arg[ASU_RESPONSE_STATUS_INDEX];
+	if (param->cbhandler && !*status)
+		ret = param->cbhandler(param->cbptr, &bufptr->resp);
+	put_free_index(bufptr);
+
+	return ret;
+}
+
+static void asu_clear_intr(void)
+{
+	uint32_t status = 0;
+
+	status = io_read32((vaddr_t)asu->doorbell + IPIPSU_ISR_OFFSET);
+	io_write32((vaddr_t)asu->doorbell + IPIPSU_ISR_OFFSET,
+		   status & IPIPSU_ALL_MASK);
+}
+
+/*
+ * asu_resp_handler() - Interrupt handler for ASU responses
+ * @handler: Interrupt handler structure (unused)
+ *
+ * Interrupt service routine that processes responses from both high
+ * priority (P0) and low priority (P1) queues when ASU completes
+ * command processing.
+ *
+ * Return: ITRR_HANDLED indicating interrupt was handled
+ */
+static enum itr_return asu_resp_handler(struct itr_handler *handler __unused)
+{
+	sev();
+	asu_clear_intr();
+
+	return ITRR_HANDLED;
+}
+
+static struct itr_handler doorbell_handler = {
+	.it = PAR_IPIPSU_0_INT_ID,
+	.handler = asu_resp_handler,
+};
+
+/*
+ * setup_doorbell() - Initialize doorbell interrupt handling
+ *
+ * Maps the doorbell register region, configures interrupt settings,
+ * registers the interrupt handler, and enables the interrupt for
+ * receiving ASU response notifications.
+ *
+ * Return: Pointer to mapped doorbell region or NULL on failure
+ */
+static void *setup_doorbell(void)
+{
+	void *dbell = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	dbell = core_mmu_add_mapping(MEM_AREA_IO_SEC,
+				     asu_configtable.baseaddr,
+				     ASU_BASEADDR_SIZE);
+	if (!dbell) {
+		EMSG("Failed to map doorbell register");
+		return dbell;
+	}
+
+	io_write32((vaddr_t)dbell + IPIPSU_IER_OFFSET, IPIPSU_ALL_MASK);
+	io_write32((vaddr_t)dbell + IPIPSU_ISR_OFFSET, IPIPSU_ALL_MASK);
+
+	doorbell_handler.chip = interrupt_get_main_chip();
+
+	res = interrupt_add_configure_handler(&doorbell_handler,
+					      IRQ_TYPE_LEVEL_HIGH, 7);
+	if (res)
+		panic();
+
+	interrupt_enable(doorbell_handler.chip, doorbell_handler.it);
+
+	return dbell;
+}
+
+static void asu_init_unique_id(void)
+{
+	uint32_t idx = 0;
+
+	asuid.slock = SPINLOCK_UNLOCK;
+	for (idx = 0; idx < ARRAY_SIZE(asuid.ids); idx++)
+		asuid.ids[idx] = ASU_UNIQUE_ID_MAX;
+}
+
+/*
+ * asu_init() - Initialize the ASU driver and communication channel
+ *
+ * Performs complete ASU driver initialization including memory allocation,
+ * firmware readiness check, channel ID discovery, shared memory mapping,
+ * doorbell setup, and marking the client as ready for operation.
+ *
+ * Return: TEE_SUCCESS on successful initialization, appropriate error code on
+ *	   failure
+ */
+static TEE_Result asu_init(void)
+{
+	uint32_t channel_id = 0;
+	void *asu_shmem = NULL;
+	uint64_t membase = 0;
+
+	asu = calloc(1, sizeof(struct asu_client));
+	if (!asu) {
+		EMSG("Failed to allocate memory for ASU");
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	asu->global_ctrl = core_mmu_add_mapping(MEM_AREA_IO_SEC,
+						ASU_BASEADDR,
+						ASU_BASEADDR_SIZE);
+	if (!asu->global_ctrl) {
+		EMSG("Failed to initialize ASU");
+		goto free;
+	}
+
+	if (asu_fwcheck() != TEE_SUCCESS) {
+		EMSG("ASU FW check failed");
+		goto global_unmap;
+	}
+
+	channel_id = asu_get_channelID();
+
+	if (channel_id == ASU_MAX_IPI_CHANNELS) {
+		EMSG("ASU channel for APU not configured");
+		goto global_unmap;
+	}
+
+	membase = ASU_CHANNEL_MEMORY_BASEADDR +
+			ASU_GLOBAL_ADDR_LIMIT * channel_id;
+	asu_shmem = core_mmu_add_mapping(MEM_AREA_IO_SEC,
+					 membase,
+					 ASU_GLOBAL_ADDR_LIMIT);
+	if (!asu_shmem) {
+		EMSG("Failed to map ASU SHM");
+		goto global_unmap;
+	}
+	asu_init_unique_id();
+	asu->doorbell = setup_doorbell();
+	if (!asu->doorbell) {
+		EMSG("Failed to set up ASU doorbell");
+		goto sh_unmap;
+	}
+
+	asu->chnl_memptr = asu_shmem;
+	asu->is_ready = ASU_CLIENT_READY;
+	asu->slock = SPINLOCK_UNLOCK;
+
+	IMSG("ASU initialization complete");
+
+	return TEE_SUCCESS;
+
+sh_unmap:
+	core_mmu_remove_mapping(MEM_AREA_IO_SEC, asu_shmem,
+				ASU_GLOBAL_ADDR_LIMIT);
+global_unmap:
+	core_mmu_remove_mapping(MEM_AREA_IO_SEC, asu->global_ctrl,
+				ASU_BASEADDR_SIZE);
+free:
+	free(asu);
+
+	EMSG("Failed to initialize ASU");
+
+	return TEE_ERROR_GENERIC;
+}
+
+service_init(asu_init);

--- a/core/drivers/amd/asu/sub.mk
+++ b/core/drivers/amd/asu/sub.mk
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+#
+
+srcs-y += asu_main.c

--- a/core/drivers/amd/sub.mk
+++ b/core/drivers/amd/sub.mk
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Copyright (c) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 #
+
+subdirs-$(CFG_AMD_ASU_SUPPORT) += asu
 
 srcs-$(CFG_AMD_PS_GPIO) += gpio_common.c ps_gpio_driver.c

--- a/core/drivers/crypto/asu_driver/asu_hash.c
+++ b/core/drivers/crypto/asu_driver/asu_hash.c
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#include <assert.h>
+#include <drivers/amd/asu_client.h>
+#include <drvcrypt_hash.h>
+#include <initcall.h>
+#include <io.h>
+#include <kernel/mutex.h>
+#include <kernel/panic.h>
+#include <kernel/unwind.h>
+#include <mm/core_memprot.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <tee/cache.h>
+#include <trace.h>
+#include <util.h>
+
+#define ASU_SHA_OPERATION_CMD_ID		0U
+/* SHA modes */
+#define ASU_SHA_MODE_SHA256			0U
+#define ASU_SHA_MODE_SHA384			1U
+#define ASU_SHA_MODE_SHA512			2U
+#define ASU_SHA_MODE_SHAKE256			4U
+
+/* SHA operation mode */
+#define ASU_SHA_START				0x1U
+#define ASU_SHA_UPDATE				0x2U
+#define ASU_SHA_FINISH				0x4U
+
+/* SHA hash lengths */
+#define ASU_SHA_256_HASH_LEN			32U
+#define ASU_SHA_384_HASH_LEN			48U
+#define ASU_SHA_512_HASH_LEN			64U
+#define ASU_SHAKE_256_HASH_LEN			32U
+#define ASU_SHAKE_256_MAX_HASH_LEN		136U
+#define ASU_DATA_CHUNK_LEN			4096U
+
+struct asu_shadev {
+	bool sha2_available;
+	bool sha3_available;
+	/* Control access to engine*/
+	struct mutex engine_lock;
+};
+
+struct asu_sha_op_cmd {
+	uint64_t dataaddr;
+	uint64_t hashaddr;
+	uint32_t datasize;
+	uint32_t hashbufsize;
+	uint8_t shamode;
+	uint8_t islast;
+	uint8_t opflags;
+	uint8_t shakereserved;
+};
+
+struct asu_hash_ctx {
+	struct crypto_hash_ctx hash_ctx; /* Crypto Hash API context */
+	struct asu_client_params cparam;
+	uint32_t shamode;
+	uint32_t shastart;
+	uint8_t uniqueid;
+	uint8_t module;
+};
+
+struct asu_hash_cbctx {
+	uint8_t *digest;
+	size_t len;
+};
+
+static const struct crypto_hash_ops asu_hash_ops;
+static struct asu_shadev *asu_shadev;
+static struct asu_hash_ctx *to_hash_ctx(struct crypto_hash_ctx *ctx);
+
+/**
+ * asu_hash_get_alg() - Get fw engine module ID and Hash mode.
+ * @algo:	TEE algo type.
+ * @module:	Engine module ID
+ * @mode:	Hash operation mode
+ * Map TEE algo type to fw module ID amd mode.
+ *
+ * Return: TEE_SUCCESS or TEE_ERROR_NOT_IMPLEMENTED
+ */
+
+static TEE_Result asu_hash_get_alg(uint32_t algo,
+				   uint32_t *module,
+				   uint32_t *mode)
+{
+	TEE_Result ret = TEE_SUCCESS;
+
+	switch (algo) {
+	case TEE_ALG_SHA256:
+		*module = ASU_MODULE_SHA2_ID;
+		*mode = ASU_SHA_MODE_SHA256;
+		break;
+	case TEE_ALG_SHA384:
+		*module = ASU_MODULE_SHA2_ID;
+		*mode = ASU_SHA_MODE_SHA384;
+		break;
+	case TEE_ALG_SHA512:
+		*module = ASU_MODULE_SHA2_ID;
+		*mode = ASU_SHA_MODE_SHA512;
+		break;
+	case TEE_ALG_SHA3_256:
+		*module = ASU_MODULE_SHA3_ID;
+		*mode = ASU_SHA_MODE_SHA256;
+		break;
+	case TEE_ALG_SHA3_384:
+		*module = ASU_MODULE_SHA3_ID;
+		*mode = ASU_SHA_MODE_SHA384;
+		break;
+	case TEE_ALG_SHA3_512:
+		*module = ASU_MODULE_SHA3_ID;
+		*mode = ASU_SHA_MODE_SHA512;
+		break;
+	default:
+		ret = TEE_ERROR_NOT_IMPLEMENTED;
+		break;
+	}
+
+	return ret;
+}
+
+/**
+ * asu_hash_initialize() - Initialize private asu_hash_ctx for hash operation.
+ * @ctx: crypto context used by the crypto_hash_*() functions
+ * Initialize hash operation request
+ *
+ * Return: TEE_SUCCESS or TEE_ERROR_BAD_PARAMETERS
+ */
+
+static TEE_Result asu_hash_initialize(struct crypto_hash_ctx *ctx)
+{
+	to_hash_ctx(ctx)->shastart = ASU_SHA_START;
+
+	return TEE_SUCCESS;
+}
+
+/**
+ * asu_sha_op() - Perform hash operation.
+ * @asu_hashctx:Request private hash context
+ * @op:		asu_sha_op_cmd parameters for fw engine
+ * @module:	Engine module ID
+ * @data:	Output digest received from engine
+ * Create request header, send and wait for result
+ * from engine.
+ *
+ * Return: TEE_SUCCESS or TEE_ERROR_GENERIC
+ */
+
+static TEE_Result asu_sha_op(struct asu_hash_ctx *asu_hashctx,
+			     struct asu_sha_op_cmd *op,
+			     uint8_t module)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	uint32_t header = 0;
+	uint32_t status = 0;
+
+	header = asu_create_header(ASU_SHA_OPERATION_CMD_ID,
+				   asu_hashctx->uniqueid, module, 0U);
+	ret = asu_update_queue_buffer_n_send_ipi(&asu_hashctx->cparam, op,
+						 sizeof(*op), header,
+						 &status);
+	if (status) {
+		EMSG("FW error 0x%x\n", status);
+		ret = TEE_ERROR_GENERIC;
+	}
+
+	return ret;
+}
+
+/**
+ * asu_hash_update() - Send update request to engine.
+ * @asu_hashctx:Request private hash context
+ * @data:	Input data buffer
+ * @len:	Size of data buffer
+ * Send update request to engine
+ * from engine.
+ *
+ * Return: TEE_SUCCESS or TEE_ERROR_GENERIC
+ */
+
+static TEE_Result asu_hash_update(struct asu_hash_ctx *asu_hashctx,
+				  uint8_t *data, size_t len)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	struct asu_sha_op_cmd op = {};
+	struct asu_client_params *cparam = NULL;
+	uint32_t remaining = 0;
+
+	/* Inputs of client request */
+	cparam = &asu_hashctx->cparam;
+	cparam->priority = ASU_PRIORITY_HIGH;
+	cparam->cbhandler = NULL;
+
+	/* Inputs of SHA request */
+	cache_operation(TEE_CACHEFLUSH, data, len);
+	op.hashaddr = 0;
+	op.hashbufsize = 0;
+	op.shamode = asu_hashctx->shamode;
+	op.islast = 0;
+	remaining = len;
+	while (remaining) {
+		op.datasize = MIN(remaining, ASU_DATA_CHUNK_LEN);
+		op.opflags = ASU_SHA_UPDATE | asu_hashctx->shastart;
+		op.dataaddr = virt_to_phys(data);
+		remaining -= op.datasize;
+		data += op.datasize;
+		ret = asu_sha_op(asu_hashctx, &op, asu_hashctx->module);
+		if (ret)
+			break;
+		asu_hashctx->shastart = 0;
+	}
+
+	return ret;
+}
+
+static TEE_Result asu_hash_do_update(struct crypto_hash_ctx *ctx,
+				     const uint8_t *data, size_t len)
+{
+	struct asu_hash_ctx *asu_hashctx = NULL;
+
+	if (!len) {
+		DMSG("This is 0 len task, skip");
+		return TEE_SUCCESS;
+	}
+
+	if (!data && len) {
+		EMSG("Invalid input parameters");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	asu_hashctx = to_hash_ctx(ctx);
+	if (asu_hashctx->uniqueid == ASU_UNIQUE_ID_MAX)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return asu_hash_update(asu_hashctx, (uint8_t *)data, len);
+}
+
+static TEE_Result asu_hash_cb(void *cbrefptr, struct asu_resp_buf *resp_buf)
+{
+	struct asu_hash_cbctx *cbctx = NULL;
+	uint8_t *src_addr = NULL;
+
+	cbctx = cbrefptr;
+	src_addr = (uint8_t *)&resp_buf->arg[ASU_RESPONSE_BUFF_ADDR_INDEX];
+	memcpy(cbctx->digest, src_addr, cbctx->len);
+
+	return TEE_SUCCESS;
+}
+
+/**
+ * asu_hash_final() - Send final request to engine.
+ * @asu_hashctx:Request private hash context
+ * @digest:	Output digest buffer
+ * @len:	Size of digest buffer
+ *
+ * Send final request to engine and populate digest result
+ *
+ * Return: TEE_SUCCESS, TEE_ERROR_BAD_PARAMETERS or TEE_ERROR_GENERIC
+ */
+
+static TEE_Result asu_hash_final(struct asu_hash_ctx *asu_hashctx,
+				 uint8_t *digest, size_t len)
+{
+	TEE_Result ret = TEE_SUCCESS;
+	struct asu_sha_op_cmd op = {};
+	struct asu_client_params *cparam = NULL;
+	struct asu_hash_cbctx cbctx = {};
+
+	if (!digest || len == 0)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	cbctx.digest = digest;
+	cbctx.len = len;
+	cparam = &asu_hashctx->cparam;
+	cparam->priority = ASU_PRIORITY_HIGH;
+	cparam->cbptr = &cbctx;
+	cparam->cbhandler = asu_hash_cb;
+
+	/* Inputs of SHA request */
+	op.dataaddr = 0;
+	op.datasize = 0;
+	op.hashaddr = UINT64_MAX;
+	op.hashbufsize = len;
+	if (asu_hashctx->shamode == ASU_SHA_MODE_SHA256)
+		op.hashbufsize = ASU_SHA_256_HASH_LEN;
+	else if (asu_hashctx->shamode == ASU_SHA_MODE_SHA384)
+		op.hashbufsize = ASU_SHA_384_HASH_LEN;
+	else if (asu_hashctx->shamode == ASU_SHA_MODE_SHA512)
+		op.hashbufsize = ASU_SHA_512_HASH_LEN;
+
+	op.shamode = asu_hashctx->shamode;
+	op.islast = 1;
+	op.opflags = ASU_SHA_FINISH | asu_hashctx->shastart;
+	ret = asu_sha_op(asu_hashctx, &op, asu_hashctx->module);
+	cache_operation(TEE_CACHEFLUSH, digest, op.hashbufsize);
+
+	return ret;
+}
+
+static TEE_Result asu_hash_do_final(struct crypto_hash_ctx *ctx,
+				    uint8_t *digest, size_t len)
+{
+	struct asu_hash_ctx *asu_hashctx = NULL;
+
+	asu_hashctx = to_hash_ctx(ctx);
+
+	return asu_hash_final(asu_hashctx, digest, len);
+}
+
+/**
+ * asu_hash_ctx_free() - Free Private context.
+ * @crypto_hash_ctx: crypto context used by the crypto_hash_*() functions
+ * Release crypto engine and free private context memory.
+ *
+ * Return: void
+ */
+
+static void asu_hash_ctx_free(struct crypto_hash_ctx *ctx)
+{
+	struct asu_hash_ctx *asu_hashctx = NULL;
+
+	asu_hashctx = to_hash_ctx(ctx);
+	asu_free_unique_id(asu_hashctx->uniqueid);
+	asu_hashctx->uniqueid = ASU_UNIQUE_ID_MAX;
+	mutex_lock(&asu_shadev->engine_lock);
+	if (asu_hashctx->module == ASU_MODULE_SHA2_ID) {
+		assert(!asu_shadev->sha2_available);
+		asu_shadev->sha2_available = true;
+	} else if (asu_hashctx->module == ASU_MODULE_SHA3_ID) {
+		assert(!asu_shadev->sha3_available);
+		asu_shadev->sha3_available = true;
+	}
+	mutex_unlock(&asu_shadev->engine_lock);
+	free(asu_hashctx);
+}
+
+static const struct crypto_hash_ops asu_hash_ops = {
+	.init = asu_hash_initialize,
+	.update = asu_hash_do_update,
+	.final = asu_hash_do_final,
+	.free_ctx = asu_hash_ctx_free,
+	/*
+	 * Current engine does not support partial state copy operation.
+	 */
+	.copy_state = NULL,
+};
+
+/*
+ * Returns the reference to the driver context
+ *
+ * @ctx  API Context
+ */
+static struct asu_hash_ctx *to_hash_ctx(struct crypto_hash_ctx *ctx)
+{
+	assert(ctx && ctx->ops == &asu_hash_ops);
+
+	return container_of(ctx, struct asu_hash_ctx, hash_ctx);
+}
+
+/**
+ * asu_hash_ctx_allocate() - Allocate Private context.
+ * @crypto_hash_ctx: crypto context used by the crypto_hash_*() functions
+ * @algo:	TEE algo type.
+ * Grab crypto engine and free private context memory.
+ *
+ * Return: TEE_SUCCESS, TEE_ERROR_BAD_PARAMETERS or TEE_ERROR_OUT_OF_MEMORY
+ */
+
+static TEE_Result asu_hash_ctx_allocate(struct crypto_hash_ctx **ctx,
+					uint32_t algo)
+{
+	struct asu_hash_ctx *asu_hashctx = NULL;
+	uint32_t module = 0;
+	uint32_t shamode = 0;
+	TEE_Result ret = TEE_SUCCESS;
+
+	ret = asu_hash_get_alg(algo, &module, &shamode);
+	if (ret)
+		return ret;
+	mutex_lock(&asu_shadev->engine_lock);
+	if (module == ASU_MODULE_SHA2_ID && asu_shadev->sha2_available) {
+		asu_shadev->sha2_available = false;
+	} else if (module == ASU_MODULE_SHA3_ID && asu_shadev->sha3_available) {
+		asu_shadev->sha3_available = false;
+	} else {
+		mutex_unlock(&asu_shadev->engine_lock);
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+	mutex_unlock(&asu_shadev->engine_lock);
+
+	asu_hashctx = calloc(1, sizeof(*asu_hashctx));
+	if (!asu_hashctx) {
+		EMSG("Fail to alloc hash");
+		ret = TEE_ERROR_OUT_OF_MEMORY;
+		goto free_dev_mem;
+	}
+
+	asu_hashctx->module = module;
+	asu_hashctx->shamode = shamode;
+	asu_hashctx->uniqueid = asu_alloc_unique_id();
+
+	if (asu_hashctx->uniqueid == ASU_UNIQUE_ID_MAX) {
+		EMSG("Fail to get unique ID");
+		ret = TEE_ERROR_BAD_PARAMETERS;
+		goto free_dev_mem;
+	}
+	asu_hashctx->hash_ctx.ops = &asu_hash_ops;
+	*ctx = &asu_hashctx->hash_ctx;
+
+	return ret;
+
+free_dev_mem:
+	mutex_lock(&asu_shadev->engine_lock);
+	if (asu_hashctx->module == ASU_MODULE_SHA2_ID &&
+	    !asu_shadev->sha2_available)
+		asu_shadev->sha2_available = true;
+	else if (asu_hashctx->module == ASU_MODULE_SHA3_ID &&
+		 !asu_shadev->sha3_available)
+		asu_shadev->sha3_available = true;
+	mutex_unlock(&asu_shadev->engine_lock);
+
+	if (asu_hashctx)
+		free(asu_hashctx);
+
+	return ret;
+}
+
+static TEE_Result asu_hash_init(void)
+{
+	TEE_Result ret = TEE_SUCCESS;
+
+	asu_shadev = calloc(1, sizeof(*asu_shadev));
+	mutex_init(&asu_shadev->engine_lock);
+	asu_shadev->sha2_available = true;
+	asu_shadev->sha3_available = true;
+	ret = drvcrypt_register_hash(&asu_hash_ctx_allocate);
+	if (ret)
+		EMSG("ASU hash register to crypto fail ret=%#"PRIx32, ret);
+
+	return ret;
+}
+driver_init(asu_hash_init);

--- a/core/drivers/crypto/asu_driver/crypto.mk
+++ b/core/drivers/crypto/asu_driver/crypto.mk
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+#
+
+ifeq ($(CFG_AMD_ASU_SUPPORT),y)
+# Enable the crypto driver
+$(call force,CFG_CRYPTO_DRIVER,y)
+CFG_CRYPTO_DRIVER_DEBUG ?= 0
+$(call force,CFG_CRYPTO_DRV_HASH,y)
+
+endif

--- a/core/drivers/crypto/asu_driver/sub.mk
+++ b/core/drivers/crypto/asu_driver/sub.mk
@@ -1,0 +1,8 @@
+ # SPDX-License-Identifier: BSD-2-Clause
+ #
+ # Copyright (c) 2025-2026, Advanced Micro Devices, Inc. All rights reserved.
+ #
+ #
+
+
+srcs-$(CFG_AMD_ASU_HASH) += asu_hash.c

--- a/core/drivers/crypto/sub.mk
+++ b/core/drivers/crypto/sub.mk
@@ -12,6 +12,8 @@ subdirs-$(CFG_ASPEED_CRYPTO_DRIVER) += aspeed
 
 subdirs-$(CFG_VERSAL_CRYPTO_DRIVER) += versal
 
+subdirs-$(CFG_AMD_ASU_SUPPORT) += asu_driver
+
 subdirs-$(CFG_HISILICON_CRYPTO_DRIVER) += hisilicon
 
 subdirs-$(CFG_IMX_ELE) += ele

--- a/core/include/drivers/amd/asu_client.h
+++ b/core/include/drivers/amd/asu_client.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ */
+
+#ifndef __ASU_CLIENT_H_
+#define __ASU_CLIENT_H_
+
+#include <drivers/amd/asu_sharedmem.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+#define ASU_PRIORITY_LOW		1
+#define ASU_PRIORITY_HIGH		0
+#define ASU_MODULE_SHA2_ID		1U
+#define ASU_MODULE_SHA3_ID		2U
+
+struct asu_client_params {
+	TEE_Result (*cbhandler)(void *cbrefptr, struct asu_resp_buf *resp);
+	void *cbptr;
+	uint8_t priority;
+};
+
+static inline uint8_t asu_get_unique_id(uint32_t header)
+{
+	return (uint8_t)((header & ASU_UNIQUE_REQ_ID_MASK) >>
+			 ASU_UNIQUE_REQ_ID_SHIFT);
+}
+
+static inline uint32_t asu_create_header(uint8_t cmd_id,
+					 uint8_t unique_id,
+					 uint8_t module_id,
+					 uint8_t command_len)
+{
+	uint32_t header = 0;
+
+	header = (cmd_id & ASU_COMMAND_ID_MASK) |
+		 SHIFT_U32(unique_id, ASU_UNIQUE_REQ_ID_SHIFT) |
+		 SHIFT_U32(module_id, ASU_MODULE_ID_SHIFT) |
+		 SHIFT_U32(command_len, ASU_COMMAND_LENGTH_SHIFT);
+
+	return header;
+}
+
+TEE_Result asu_update_queue_buffer_n_send_ipi(struct asu_client_params *param,
+					      void *req_buffer,
+					      uint32_t size,
+					      uint32_t header,
+					      uint32_t *status);
+uint8_t asu_reg_callback_n_get_unique_id(struct asu_client_params *param,
+					 uint8_t *resp_buffer_ptr,
+					 uint32_t size);
+void asu_update_callback_details(uint8_t unique_id,
+				 uint8_t *resp_buffer_ptr,
+				 uint32_t size);
+uint8_t asu_alloc_unique_id(void);
+void asu_free_unique_id(uint8_t uniqueid);
+#endif /* __ASU_CLIENT_H_ */

--- a/core/include/drivers/amd/asu_sharedmem.h
+++ b/core/include/drivers/amd/asu_sharedmem.h
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ */
+
+#ifndef __ASU_SHAREDMEM_H_
+#define __ASU_SHAREDMEM_H_
+
+#include <stdint.h>
+#include <util.h>
+
+#define ASU_MAX_BUFFERS			8U
+#define ASU_CHANNEL_RESERVED_MEM	1188U
+#define ASU_COMMAND_IS_PRESENT		0x1U
+#define ASU_RESPONSE_IS_PRESENT		0x1U
+#define ASU_RESPONSE_STATUS_INDEX	0U
+#define ASU_RESPONSE_BUFF_ADDR_INDEX	1U
+#define ASU_COMMAND_ID_MASK		0x0000003FU
+#define ASU_UNIQUE_REQ_ID_MASK		0x00000FC0U
+#define ASU_UNIQUE_REQ_ID_SHIFT		6U
+#define ASU_UNIQUE_ID_MAX		SHIFT_U32(ASU_MAX_BUFFERS, 1U)
+#define ASU_MODULE_ID_MASK		0x0003F000U
+#define ASU_MODULE_ID_SHIFT		12U
+#define ASU_COMMAND_LENGTH_SHIFT	18U
+#define ASU_COMMAND_REQ_ARGS		22U
+#define ASU_COMMAND_RESP_ARGS		17U
+#define ASU_RTCA_BASEADDR		0xEBE40000U
+#define ASU_RTCA_COMM_CHANNEL_INFO_ADDR	(ASU_RTCA_BASEADDR + 0x10U)
+#define ASU_RTCA_CHANNEL_BASE_OFFSET	0x18U
+#define ASU_RTCA_CHANNEL_INFO_LEN	0x8U
+#define ASU_MAX_IPI_CHANNELS		8U
+#define ASU_CHANNEL_MEMORY_OFFSET	0x1000U
+#define ASU_CHANNEL_MEMORY_BASEADDR	(ASU_RTCA_BASEADDR + \
+					 ASU_CHANNEL_MEMORY_OFFSET)
+
+struct asu_req_buf {
+	uint32_t header;
+	uint32_t arg[ASU_COMMAND_REQ_ARGS];
+	uint32_t reserved;
+};
+
+struct asu_resp_buf {
+	uint32_t header;
+	uint32_t arg[ASU_COMMAND_RESP_ARGS];
+	uint32_t additionalstatus;
+	uint32_t reserved;
+};
+
+struct asu_channel_queue_buf {
+	uint8_t reqbufstatus;
+	uint8_t respbufstatus;
+	uint16_t reserved;
+	struct asu_req_buf req;
+	struct asu_resp_buf resp;
+};
+
+struct asu_channel_queue {
+	bool cmd_is_present;
+	uint32_t req_sent;
+	uint32_t req_served;
+	struct asu_channel_queue_buf queue_bufs[ASU_MAX_BUFFERS];
+};
+
+struct asu_channel_memory {
+	uint32_t version;
+	uint8_t reserved[ASU_CHANNEL_RESERVED_MEM];
+	struct asu_channel_queue p0_chnl_q;
+	struct asu_channel_queue p1_chnl_q;
+};
+
+#endif /* __ASU_SHAREDMEM_H_ */


### PR DESCRIPTION
Add support for the AMD Application Security Unit (ASU), the on-chip
    Hardware Security Module (HSM) for Versal Gen 2.
    The ASU manages all device-level security services for user
    applications, extending beyond accelerator-centric tasks.
    Its firmware also exposes several software-based cryptographic
    primitives, including:
    - Key transfer
    - RSA authentication (multiple padding schemes)
    - HMAC
    - Key Derivation Function (KDF)
    - Key wrap / unwrap

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
