### PR TITLE
ta: remoteproc: Fix case empty key info is last TLV cell

### DIFF
--- a/ta/remoteproc/src/remoteproc_core.c
+++ b/ta/remoteproc/src/remoteproc_core.c
@@ -238,7 +238,7 @@ static TEE_Result remoteproc_get_tlv(void *tlv_chunk, size_t tlv_size,
 	*length = 0;
 
 	/* Parse the TLV area */
-	while (p_tlv + RPROC_TLV_VALUE_OF < p_end_tlv) {
+	while (p_tlv + RPROC_TLV_VALUE_OF <= p_end_tlv) {
 		memcpy(&tlv_v, p_tlv, sizeof(tlv_v));
 		tlv_type = TEE_U32_FROM_LITTLE_ENDIAN(tlv_v);
 		memcpy(&tlv_v, p_tlv + RPROC_TLV_LENGTH_OF, sizeof(tlv_v));


### PR DESCRIPTION
Fix case when remote processor firmware key info TLV RPROC_TLV_PKEYINFO is present but empty (size = 0) and is placed last in the TLVs memory area hence its value cell start address matches the TLV area end address.

Fixes: 07917406b106 ("remoteproc: fix potential overflows in TLV parsing")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
