### PR TITLE
core: ree_fs: initialize ta_ver.db when its size is zero

### DIFF
--- a/core/kernel/ree_fs_ta.c
+++ b/core/kernel/ree_fs_ta.c
@@ -119,8 +119,12 @@ static TEE_Result check_update_version(const char *db_name,
 		len = sizeof(db_hdr);
 
 		res = ops->read(fh, 0, &db_hdr, NULL, &len);
-		if (res != TEE_SUCCESS) {
+		if (res != TEE_SUCCESS)
 			goto out;
+		if (len == 0) {
+			res = ops->write(fh, 0, &db_hdr, sizeof(db_hdr));
+			if (res != TEE_SUCCESS)
+				goto out;
 		} else if (len != sizeof(db_hdr)) {
 			res = TEE_ERROR_BAD_STATE;
 			goto out;


### PR DESCRIPTION
Creating and writing db_hdr involves several RPC commands. If a power loss occurs during the creation flow, it may result in a db file with an empty db_hdr. Attempting to read this file subsequently leads to a TEE_ERROR_BAD_STATE error.

Instead of returning TEE_ERROR_BAD_STATE, continue the db_hdr initialization flow to support subsequent functionality.

Link: https://github.com/OP-TEE/optee_os/issues/7513
Fixes: 183398139c9c ("core: enable rollback protection for REE-FS TAs")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
