### PR TITLE
ci: xen: disable Rust to workaround "no space left on device"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,7 +567,8 @@ jobs:
           ln -s ${OPTEE_OS_TO_TEST} ${TOP}/optee_os
           cd ${TOP}/build
 
-          make -j$(nproc) check XEN_BOOT=y
+          # Rust disabled due to disk space limitations
+          make -j$(nproc) check XEN_BOOT=y RUST_ENABLE=n
 
   QEMUv8_Xen_ffa_check:
     name: make check (QEMUv8, Xen FF-A)
@@ -603,7 +604,8 @@ jobs:
           ln -s ${OPTEE_OS_TO_TEST} ${TOP}/optee_os
           cd ${TOP}/build
 
-          make -j$(nproc) check XEN_BOOT=y SPMC_AT_EL=1
+          # Rust disabled due to disk space limitations
+          make -j$(nproc) check XEN_BOOT=y SPMC_AT_EL=1 RUST_ENABLE=n
 
   QEMUv8_Hafnium_check:
     name: make check (QEMUv8, Hafnium)


### PR DESCRIPTION
The GitHub Actions CI recently started to fail with a disk space error:

[...]
2025-09-25T09:24:51.2006517Z >>>   Finalizing host directory
2025-09-25T09:24:51.2007142Z mkdir -p /__w/optee_os/optee_repo_qemu_v8/out-br/host
2025-09-25T09:24:51.2028001Z printf "%s/host/\n" bash busybox dtc host-acl host-attr host-autoconf host-automake host-blake3 host-ccache host-e2fsprogs host-fakeroot host-hiredis host-libtool host-m4 host-makedevs host-mkpasswd host-patchelf host-pkgconf host-skeleton host-util-linux host-xxhash host-zstd ifupdown-scripts initscripts keyutils libaio libcurl libffi libglib2 libopenssl libzlib mmc-utils ncurses opensc openssl optee_client_ext optee_examples_ext optee_os_ext optee_rust_examples_ext optee_test_ext pcre2 pcsc-lite pixman qemu readline skeleton skeleton-init-common skeleton-init-sysv slirp strace toolchain toolchain-external toolchain-external-custom tpm2-tools tpm2-tss urandom-scripts util-linux util-linux-libs xen_ext yajl zlib | tac | rsync -a --hard-links --files-from=- --no-R -r /__w/optee_os/optee_repo_qemu_v8/out-br/per-package /__w/optee_os/optee_repo_qemu_v8/out-br/host
2025-09-25T09:24:56.6942688Z rsync: [receiver] write failed on "/__w/optee_os/optee_repo_qemu_v8/out-br/host/lib/libLLVM.so.19.1-rust-1.86.0-stable": No space left on device (28)
2025-09-25T09:24:56.6943698Z rsync error: error in file IO (code 11) at receiver.c(381) [receiver=3.2.7]
2025-09-25T09:24:56.7952984Z rsync: [sender] write error: Broken pipe (32)
2025-09-25T09:24:56.7962889Z make[2]: *** [Makefile:717: host-finalize] Error 11
2025-09-25T09:24:56.7997049Z make[1]: *** [Makefile:23: _all] Error 2
2025-09-25T09:24:56.7998137Z make[1]: Leaving directory '/__w/optee_os/optee_repo_qemu_v8/out-br'
2025-09-25T09:24:56.7999290Z make: *** [common.mk:354: buildroot] Error 2

I could not identify which change exactly caused the limit to be reached, and I didn't manage to identify any obvious waste of disk space in the build. I noticed however that building with RUST_ENABLE=y (the default) uses approximately 6 GB more than with RUST_ENABLE=n (27 GB vs 21 GB, that's the size of the whole OP-TEE tree in the end). The two "nightly" Rust toolchains that are downloaded when optee_rust is built account for 1.6 GB on their own.

Therefore, and until we find a better solution or GitHub increases the disk space allocated to CI jobs, disable Rust in the Xen and Xen FF-A jobs. This allows the Xen jobs to pass again.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
