### PR TITLE
Add support of ramp delay and over current protection in regulator framework

### DIFF
--- a/core/drivers/regulator/regulator.c
+++ b/core/drivers/regulator/regulator.c
@@ -73,6 +73,8 @@ static TEE_Result regulator_refcnt_enable(struct regulator *regulator)
 
 			return res;
 		}
+
+		udelay(regulator->enable_ramp_delay_us);
 	}
 
 	regulator->refcount++;

--- a/core/drivers/regulator/regulator_dt.c
+++ b/core/drivers/regulator/regulator_dt.c
@@ -323,6 +323,14 @@ static TEE_Result parse_dt(const void *fdt, int node,
 		     regulator->ramp_delay_uv_per_us);
 	}
 
+	cuint = fdt_getprop(fdt, node, "regulator-enable-ramp-delay", NULL);
+	if (cuint) {
+		regulator->enable_ramp_delay_us = fdt32_to_cpu(*cuint);
+		FMSG("%s: enable ramp delay = %u (us)",
+		     regulator_name(regulator),
+		     regulator->enable_ramp_delay_us);
+	}
+
 	return TEE_SUCCESS;
 }
 

--- a/core/include/drivers/regulator.h
+++ b/core/include/drivers/regulator.h
@@ -91,6 +91,7 @@ struct regulator_voltages_desc {
  * @min_uv: Min possible voltage level in microvolt (uV)
  * @max_uv: Max possible voltage level in microvolt (uV)
  * @ramp_delay_uv_per_us: Voltage level change delay in uV/s
+ * @enable_ramp_delay_us: Delay after enable, in microseconds (us)
  * @flags: REGULATOR_* property flags
  * @refcount: Regulator enable request reference counter
  * @mutex: Concurrent access protection considering PM context sequences
@@ -106,6 +107,7 @@ struct regulator {
 	int min_uv;
 	int max_uv;
 	unsigned int ramp_delay_uv_per_us;
+	unsigned int enable_ramp_delay_us;
 	/* Fields internal to regulator framework */
 	unsigned int flags;
 	unsigned int refcount;


### PR DESCRIPTION
Hello,

This PR add the support of 3 device trees properties : 
- regulator-ramp-delay
- regulator-enable-ramp-delay
- regulator-over-current-protection

The implementation is based on Linux bindings definition

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
