### PR TITLE
fs_htree: re-initialize hash tree when counter is zero

### DIFF
--- a/core/tee/fs_htree.c
+++ b/core/tee/fs_htree.c
@@ -361,7 +361,7 @@ static TEE_Result init_head_from_data(struct tee_fs_htree *ht,
 		ht->head = head[idx];
 	}
 
-	if (ht->head.counter < min_counter)
+	if (ht->head.counter != 0 && ht->head.counter < min_counter)
 		return TEE_ERROR_SECURITY;
 
 	ht->root.id = 1;
@@ -630,6 +630,40 @@ static TEE_Result init_root_node(struct tee_fs_htree *ht)
 	return res;
 }
 
+static TEE_Result tee_fs_htree_create_and_sync(struct tee_fs_htree *ht,
+					       uint8_t *hash,
+					       uint32_t min_counter)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const struct tee_fs_htree_image dummy_head = {
+		.counter = min_counter,
+	};
+
+	if (!ht)
+		return TEE_ERROR_GENERIC;
+
+	res = crypto_rng_read(ht->fek, sizeof(ht->fek));
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = tee_fs_fek_crypt(ht->uuid, TEE_MODE_ENCRYPT, ht->fek,
+			       sizeof(ht->fek), ht->head.enc_fek);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = init_root_node(ht);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	ht->dirty = true;
+	res = tee_fs_htree_sync_to_storage(&ht, hash, NULL);
+	if (res != TEE_SUCCESS)
+		return res;
+	res = rpc_write_head(ht, 0, &dummy_head);
+
+	return res;
+}
+
 TEE_Result tee_fs_htree_open(bool create, uint8_t *hash, uint32_t min_counter,
 			     const TEE_UUID *uuid,
 			     const struct tee_fs_htree_storage *stor,
@@ -646,32 +680,23 @@ TEE_Result tee_fs_htree_open(bool create, uint8_t *hash, uint32_t min_counter,
 	ht->stor_aux = stor_aux;
 
 	if (create) {
-		const struct tee_fs_htree_image dummy_head = {
-			.counter = min_counter,
-		};
-
-		res = crypto_rng_read(ht->fek, sizeof(ht->fek));
-		if (res != TEE_SUCCESS)
-			goto out;
-
-		res = tee_fs_fek_crypt(ht->uuid, TEE_MODE_ENCRYPT, ht->fek,
-				       sizeof(ht->fek), ht->head.enc_fek);
-		if (res != TEE_SUCCESS)
-			goto out;
-
-		res = init_root_node(ht);
-		if (res != TEE_SUCCESS)
-			goto out;
-
-		ht->dirty = true;
-		res = tee_fs_htree_sync_to_storage(&ht, hash, NULL);
-		if (res != TEE_SUCCESS)
-			goto out;
-		res = rpc_write_head(ht, 0, &dummy_head);
+		/* This flow need to resislience to power loss */
+		res = tee_fs_htree_create_and_sync(ht, hash, min_counter);
 	} else {
 		res = init_head_from_data(ht, hash, min_counter);
 		if (res != TEE_SUCCESS)
 			goto out;
+		/*
+		 * If a power loss occurred during hash tree creation, the
+		 * head may not have been written and counter is still 0.
+		 * Re-initialze the hash tree.
+		 */
+		if (ht->head.counter == 0) {
+			res = tee_fs_htree_create_and_sync(ht, hash,
+					min_counter);
+			if (res != TEE_SUCCESS)
+				goto out;
+		}
 
 		res = verify_root(ht);
 		if (res != TEE_SUCCESS)


### PR DESCRIPTION
When using the API TEE_OpenPersistentObject for REE-FS secure storage, the system may initiate the creation of the dirf.db file. If a power loss occurs during this process, the resulting dirf.db file may become corrupted, which can block subsequent REE-FS database operations until the corrupted file is removed. We have identified real-world power loss scenarios and implemented a re-initialization flow to enable recovery from such cases.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
