### PR TITLE
mm: fix zero-length access check inconsistency

### DIFF
--- a/core/mm/vm.c
+++ b/core/mm/vm.c
@@ -1262,6 +1262,9 @@ TEE_Result vm_check_access_rights(const struct user_mode_ctx *uctx,
 	    (flags & TEE_MEMORY_ACCESS_SECURE))
 		return TEE_ERROR_ACCESS_DENIED;
 
+	if (len == 0)
+		return TEE_SUCCESS;
+
 	/*
 	 * Rely on TA private memory test to check if address range is private
 	 * to TA or not.


### PR DESCRIPTION
Fix vm_check_access_rights() so it handles zero-length memory ranges consistently. Previously, the function had inconsistent behavior for zero-length checks:
- For page-aligned addresses: Would skip the page checking loop entirely and return TEE_SUCCESS.
- For unaligned addresses: Would round uaddr down to page boundary and return a result based on that page.

With this change flags = SECURE | NON_SECURE will still fail to preserve the sanity checking, but all other zero-length ranges result in TEE_SUCCESS.

Specifically this was required due to an interaction between OP-TEE and Rust where Keymint [0] would call the Teaclave [1] wrapper around TEE_MACComputeFinal with an empty temporary slice (pointer + length pair) as the final message (&[]). Rust always requires the pointer to be non-null, but allows it to dangle when length is zero. As a result the arguments passed to TEE_MACComputeFinal were message=(void *)1, messageLen=0. These arguments are passed unmodified to vm_check_access_rights regardless of the length and presumably relied on the page-aligned case to handle NULL + 0.

[0] https://android.googlesource.com/tee/optee/ta/keymint/
[1] https://github.com/apache/teaclave-trustzone-sdk