### PR TITLE
plat-rockchip: rk3588: assert buffer is size of HUK

### DIFF
--- a/core/arch/arm/plat-rockchip/platform_rk3588.c
+++ b/core/arch/arm/plat-rockchip/platform_rk3588.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2024, Rockchip, Inc. All rights reserved.
  */
 
+#include <assert.h>
 #include <common.h>
 #include <drivers/rockchip_otp.h>
 #include <io.h>
@@ -200,6 +201,8 @@ static TEE_Result persist_huk(struct tee_hw_unique_key *hwkey)
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t buffer[ROCKCHIP_OTP_HUK_SIZE] = { };
 
+	static_assert(sizeof(buffer) == sizeof(hwkey->data));
+
 	memcpy(buffer, hwkey->data, HW_UNIQUE_KEY_LENGTH);
 
 	/* Write the new HUK into OTP at ROCKCHIP_OTP_HUK_INDEX */
@@ -218,6 +221,8 @@ static TEE_Result read_huk(struct tee_hw_unique_key *hwkey)
 	uint32_t buffer[ROCKCHIP_OTP_HUK_SIZE] = { };
 	bool key_is_empty = true;
 	size_t i = 0;
+
+	static_assert(sizeof(buffer) == sizeof(hwkey->data));
 
 	/* Read 4 words (16 bytes) from OTP at ROCKCHIP_OTP_HUK_INDEX */
 	res = rockchip_otp_read_secure(buffer,


### PR DESCRIPTION
The size of the buffer that is used to persist the HUK in the OTP and the size of the buffer that is used to read the HUK from the OTP must have the same size as the HUK key data.

Add a static_assert to ensure that this is actually the case.

Suggested by @etienne-lms in https://github.com/OP-TEE/optee_os/pull/7545#discussion_r2410068091.