### PR TITLE
Update CHANGELOG for 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# OP-TEE - version 4.8.0 (2025-10-24)
+
+- Links to the release pages, commits and pull requests merged into this release for:
+  - OP-TEE/optee_os: [release page][OP_TEE_optee_os_release_4_8_0], [commits][OP_TEE_optee_os_commits_4_8_0] and [pull requests][OP_TEE_optee_os_pr_4_8_0]
+  - OP-TEE/optee_client: [release page][OP_TEE_optee_client_release_4_8_0], [commits][OP_TEE_optee_client_commits_4_8_0] and [pull requests][OP_TEE_optee_client_pr_4_8_0]
+  - OP-TEE/optee_test: [release page][OP_TEE_optee_test_release_4_8_0], [commits][OP_TEE_optee_test_commits_4_8_0] and [pull requests][OP_TEE_optee_test_pr_4_8_0]
+  - OP-TEE/build: [release page][OP_TEE_build_release_4_8_0], [commits][OP_TEE_build_commits_4_8_0] and [pull requests][OP_TEE_build_pr_4_8_0]
+  - linaro-swg/optee_examples: [release page][linaro_swg_optee_examples_release_4_8_0], [commits][linaro_swg_optee_examples_commits_4_8_0] and [pull requests][linaro_swg_optee_examples_pr_4_8_0]
+
+
+[OP_TEE_optee_os_release_4_8_0]: https://github.com/OP-TEE/optee_os/releases/tag/4.8.0
+[OP_TEE_optee_os_commits_4_8_0]: https://github.com/OP-TEE/optee_os/compare/4.7.0...4.8.0
+[OP_TEE_optee_os_pr_4_8_0]: https://github.com/OP-TEE/optee_os/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2025-07-11..2025-10-24
+
+[OP_TEE_optee_client_release_4_8_0]: https://github.com/OP-TEE/optee_client/releases/tag/4.8.0
+[OP_TEE_optee_client_commits_4_8_0]: https://github.com/OP-TEE/optee_client/compare/4.7.0...4.8.0
+[OP_TEE_optee_client_pr_4_8_0]: https://github.com/OP-TEE/optee_client/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2025-07-11..2025-10-24
+
+[OP_TEE_optee_test_release_4_8_0]: https://github.com/OP-TEE/optee_test/releases/tag/4.8.0
+[OP_TEE_optee_test_commits_4_8_0]: https://github.com/OP-TEE/optee_test/compare/4.7.0...4.8.0
+[OP_TEE_optee_test_pr_4_8_0]: https://github.com/OP-TEE/optee_test/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2025-07-11..2025-10-24
+
+[OP_TEE_build_release_4_8_0]: https://github.com/OP-TEE/build/releases/tag/4.8.0
+[OP_TEE_build_commits_4_8_0]: https://github.com/OP-TEE/build/compare/4.7.0...4.8.0
+[OP_TEE_build_pr_4_8_0]: https://github.com/OP-TEE/build/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2025-07-11..2025-10-24
+
+[linaro_swg_optee_examples_release_4_8_0]: https://github.com/linaro-swg/optee_examples/releases/tag/4.8.0
+[linaro_swg_optee_examples_commits_4_8_0]: https://github.com/linaro-swg/optee_examples/compare/4.7.0...4.8.0
+[linaro_swg_optee_examples_pr_4_8_0]: https://github.com/linaro-swg/optee_examples/pulls?q=is%3Apr+is%3Amerged+base%3Amaster+merged%3A2025-07-11..2025-10-24
+
 # OP-TEE - version 4.7.0 (2025-07-11)
 
 - Links to the release pages, commits and pull requests merged into this release for:

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -130,7 +130,7 @@ CFG_OS_REV_REPORTS_GIT_SHA1 ?= y
 # with limited depth not including any tag, so there is really no guarantee
 # that TEE_IMPL_VERSION contains the major and minor revision numbers.
 CFG_OPTEE_REVISION_MAJOR ?= 4
-CFG_OPTEE_REVISION_MINOR ?= 7
+CFG_OPTEE_REVISION_MINOR ?= 8
 CFG_OPTEE_REVISION_EXTRA ?=
 
 # Trusted OS implementation version


### PR DESCRIPTION
Update CHANGELOG for 4.8.0 and collect Tested-by tags.

The 4.8.0-rc1 tag will be created on Friday, October 17, and the 4.8.0 release is expected on October 24.
