### PR TITLE
ci: hafnium: disable Rust to workaround "no space left on device"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,8 @@ jobs:
           ln -s ${OPTEE_OS_TO_TEST} ${TOP}/optee_os
           cd ${TOP}/build
 
-          make -j$(nproc) check SPMC_AT_EL=2
+          # Rust disabled due to disk space limitations
+          make -j$(nproc) check SPMC_AT_EL=2 RUST_ENABLE=n
 
   QEMUv8_check_BTI_MTE_PAC:
     name: make check (QEMUv8, BTI+MTE+PAC)


### PR DESCRIPTION
The GitHub Actions CI recently started to fail with a disk space error:

System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251015-153857-utc.log'

Apply the same workaround as in commit a4b310d68bf8 ("ci: xen: disable Rust to workaround "no space left on device"").

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
