### PR TITLE
ci: disable Rust globally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 on: [push, pull_request]
 permissions:
   contents: read # to fetch code (actions/checkout)
+env:
+  # Workaround disk space limitations ("no space left on device...")
+  RUST_ENABLE: "n"
 jobs:
   code_style:
     name: Code style
@@ -568,8 +571,7 @@ jobs:
           ln -s ${OPTEE_OS_TO_TEST} ${TOP}/optee_os
           cd ${TOP}/build
 
-          # Rust disabled due to disk space limitations
-          make -j$(nproc) check XEN_BOOT=y RUST_ENABLE=n
+          make -j$(nproc) check XEN_BOOT=y
 
   QEMUv8_Xen_ffa_check:
     name: make check (QEMUv8, Xen FF-A)
@@ -605,8 +607,7 @@ jobs:
           ln -s ${OPTEE_OS_TO_TEST} ${TOP}/optee_os
           cd ${TOP}/build
 
-          # Rust disabled due to disk space limitations
-          make -j$(nproc) check XEN_BOOT=y SPMC_AT_EL=1 RUST_ENABLE=n
+          make -j$(nproc) check XEN_BOOT=y SPMC_AT_EL=1
 
   QEMUv8_Hafnium_check:
     name: make check (QEMUv8, Hafnium)
@@ -642,8 +643,7 @@ jobs:
           ln -s ${OPTEE_OS_TO_TEST} ${TOP}/optee_os
           cd ${TOP}/build
 
-          # Rust disabled due to disk space limitations
-          make -j$(nproc) check SPMC_AT_EL=2 RUST_ENABLE=n
+          make -j$(nproc) check SPMC_AT_EL=2
 
   QEMUv8_check_BTI_MTE_PAC:
     name: make check (QEMUv8, BTI+MTE+PAC)


### PR DESCRIPTION
There has been several job failures due to insufficient disk space on the CI runners recently. Commit a4b310d68bf8 ("ci: xen: disable Rust to workaround "no space left on device"") and commit 3d0429ac12cd ("ci: hafnium: disable Rust to workaround "no space left on device"") fixed individual jobs. Now other QEMUv8 jobs are failing too, probably because of the upgrade of the optee_rust project [1]. Therefore, disable Rust globally until a better solution is found.

Link: https://github.com/OP-TEE/manifest/commit/2987d8edf188 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
