### PR TITLE
plat-k3: drivers: Open TRNG firewall for TIFS for Jacinto devices

### DIFF
--- a/core/arch/arm/plat-k3/drivers/sa2ul.c
+++ b/core/arch/arm/plat-k3/drivers/sa2ul.c
@@ -121,12 +121,7 @@ static TEE_Result sa2ul_init(void)
 	start_address = RNG_BASE;
 	end_address = RNG_BASE + RNG_REG_SIZE - 1;
 	permissions[num_perm++] = (FW_BIG_ARM_PRIVID << 16) | FW_SECURE_ONLY;
-#if defined(PLATFORM_FLAVOR_am62x) || \
-	defined(PLATFORM_FLAVOR_am62ax) || \
-	defined(PLATFORM_FLAVOR_am62px)
-
 	permissions[num_perm++] = (FW_TIFS_PRIVID << 16) | FW_NON_SECURE;
-#endif
 	ret = ti_sci_set_fwl_region(fwl_id, rng_region, num_perm,
 				    control, permissions,
 				    start_address, end_address);


### PR DESCRIPTION
On devices with platform flavours of j721e and j784s4, the TRNG is firewalled to be accessed only by OPTEE.

TIFS needs this for the encryption and decryption services to support different low power modes. So, open firewall to TIFS as well.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
