### PR TITLE
ci: mention reviewers/maintainers from MAINTAINERS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,28 @@ name: CI
 on: [push, pull_request]
 permissions:
   contents: read
+  pull-requests: write # to post comments to the PR (notify_maintainers.py)
 concurrency:
   group: ci-${{ github.ref }}  # unique per branch
   cancel-in-progress: true     # cancel previous runs on the same branch
 jobs:
+  notify_maintainers:
+    name: Notify maintainers
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.repository == 'OP-TEE/optee_os'
+    steps:
+      - name: Install python3-github
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3-github
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run scripts/notify_maintainers.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: scripts/notify_maintainers.py
   code_style:
     name: Code style
     runs-on: ubuntu-latest

--- a/scripts/notify_maintainers.py
+++ b/scripts/notify_maintainers.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright 2025, Linaro Ltd.
+#
+
+import os
+import subprocess
+import argparse
+import re
+from github import Github
+
+
+def parse_get_maintainer_output(output: str):
+    """Parse get_maintainer.py output and return GitHub handles to notify.
+
+    All entries are parsed, but handles listed for 'THE REST' are removed
+    from the final notification set.
+    """
+    handles = set()
+    the_rest_handles = set()
+
+    for line in output.splitlines():
+        handle_start = line.find("[@")
+        handle_end = line.find("]", handle_start)
+        if handle_start == -1 or handle_end == -1:
+            continue
+        handle = line[handle_start + 2:handle_end].strip()
+
+        paren_start = line.find("(", handle_end)
+        paren_end = line.rfind(")")
+        target = None
+        if paren_start != -1 and paren_end != -1:
+            content = line[paren_start + 1:paren_end].strip()
+            if ":" in content:
+                _, target = content.split(":", 1)
+                target = target.strip()
+
+        if target and target.upper() == "THE REST":
+            the_rest_handles.add(handle)
+        else:
+            handles.add(handle)
+
+    allh = set()
+    allh.update(handles)
+    allh.update(the_rest_handles)
+
+    if allh:
+        print("For information: all relevant maintainers/reviewers: " +
+              " ".join(f"@{h}" for h in allh))
+    if handles:
+        print("Subsystem/platform maintainers/reviewers: " +
+              " ".join(f"@{h}" for h in handles))
+    if the_rest_handles:
+        print("Excluding handles from THE REST: " +
+              " ".join(f"@{h}" for h in the_rest_handles))
+
+    # Remove any handle that was marked as THE REST
+    handles_to_mention = handles - the_rest_handles
+    return handles_to_mention
+
+
+def get_handles_for_pr(pr_number: str):
+    """Run get_maintainer.py with -g PR_NUMBER and parse handles."""
+    cmd = [
+        os.path.join(os.getcwd(), "scripts/get_maintainer.py"),
+        "-g", pr_number
+    ]
+    output = subprocess.check_output(cmd, text=True)
+    return parse_get_maintainer_output(output)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Notify maintainers/reviewers for a PR using "
+            "get_maintainer.py.\n"
+            "If run in a GitHub environment (GITHUB_TOKEN and REPO set), "
+            "the notification message is posted directly to the PR. "
+            "Otherwise, the script outputs the message to the console.\n"
+            "The message lists the GitHub handles of all reviewers and "
+            "maintainers responsible for the modified files. Handles "
+            "already mentioned in the PR are not repeated, nor are "
+            "requested reviewers, assignees and maintainers for 'THE REST' "
+        )
+    )
+    parser.add_argument(
+        "--pr",
+        help="GitHub PR number (required outside GitHub environment)."
+    )
+    args = parser.parse_args()
+
+    github_env = all(os.getenv(var) for var in ("GITHUB_TOKEN", "REPO"))
+
+    if github_env:
+        pr_number = args.pr or os.getenv("PR_NUMBER")
+        repo_name = os.getenv("REPO")
+        token = os.getenv("GITHUB_TOKEN")
+        if not pr_number:
+            print(
+                "Running in GitHub environment but no PR_NUMBER found. "
+                "Doing nothing."
+            )
+            return
+    else:
+        pr_number = args.pr
+        if not pr_number:
+            print("Error: --pr must be provided outside GitHub environment.")
+            return
+        repo_name = None
+        token = None
+
+    handles_to_mention = get_handles_for_pr(pr_number)
+    if not handles_to_mention:
+        print("No maintainers or reviewers to mention.")
+        return
+    else:
+        print("Final list of subsystem/platform maintainers/reviewers: " +
+              " ".join(f"@{h}" for h in handles_to_mention))
+
+    if github_env:
+        g = Github(token)
+        repo = g.get_repo(repo_name)
+        pr = repo.get_pull(int(pr_number))
+
+        # Gather existing handles mentioned in previous comments
+        existing_handles = set()
+        for comment in pr.get_issue_comments():
+            existing_handles.update(re.findall(r"@(\w+)", comment.body))
+        if existing_handles:
+            print("Already mentioned: " +
+                  " ".join(f"@{h}" for h in new_handles))
+
+        # Skip PR author, assignees, and requested reviewers
+        skip_handles = {pr.user.login}
+        skip_handles.update(a.login for a in pr.assignees)
+        requested_reviewers, _ = pr.get_review_requests()
+        skip_handles.update(r.login for r in requested_reviewers)
+        if skip_handles:
+            print("Excluding author, assignees and requested reviewers: " +
+                  " ".join(f"@{h}" for h in skip_handles))
+
+        # Exclude all these from new notifications
+        new_handles = handles_to_mention - existing_handles - skip_handles
+        if not new_handles:
+            print("All relevant handles have already been mentioned "
+                  "or are already notified by GitHub.")
+            return
+
+        message = ("FYI " + " ".join(f"@{h}" for h in new_handles))
+        pr.create_issue_comment(message)
+        print(f"Comment added to PR: '{message}'")
+    else:
+        message = ("FYI " + " ".join(f"@{h}" for h in handles_to_mention))
+        print(f"Comment added to PR would be: '{message}'")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduce a new Python script: notify_maintainers.py and run it in CI as part of a new job. When invoked in the context of a pull request against the OP-TEE OS official project, it invokes get_maintainer.py to find out the GitHub handles of the people to whom the change in the PR is relevant. It then posts a comment so that these people may be notified via email. People are mentioned only once per PR (they normally receive subsequent messages automatically). The PR author, assignees and requested reviewers (if any) are skipped since they are already notified, as well as the default maintainers ("THE REST") who are assumed to receive all PRs. The format of the comment is:

  github-actions (bot) commented ...

  FYI \<handle1> \<handle2>...

Note: Subsystem/platform maintainers who have their GitHub handle in MAINTAINERS and who already "watch" the project will receive two emails upon creation of a PR that touches their area of expertise: one when the PR is created, and one shortly after when the script runs and the GitHub bot tags them in a comment. Hopefully it is only a minor inconvenience.

Note 2: The script was written with the help of generative AI. It was reviewed, tested and modified by me.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
