### PR TITLE
ci: qemuv8: test RPMB via kernel interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,9 @@ jobs:
           - name: PAN=y
             make_commands: |
               make -j$(nproc) check CFG_PAN=y
+          - name: RPMB
+            make_commands: |
+              make -j$(nproc) check CFG_REE_FS=n CFG_RPMB_FS=y CFG_RPMB_TESTKEY=y CHECK_TESTS=xtest XTEST_ARGS="regression_6"
           - name: SPMC_AT_EL=1
             make_commands: |
               make -j$(nproc) check SPMC_AT_EL=1 CFG_SECURE_PARTITION=y CFG_SPMC_TESTS=y


### PR DESCRIPTION
Add a test with the RPMB FS enabled and the REE FS disabled. The RPMB device is emulated by QEMU and the data go via the Linux kernel driver and RPMB subsystem (i.e., this is testing the newer code, not the legacy one which involves tee-supplicant).

Depends on https://github.com/OP-TEE/build/pull/851.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
