### PR TITLE
scripts/gen_ldelf_hex.py: account for BSS in last load segment mapping

### DIFF
--- a/scripts/gen_ldelf_hex.py
+++ b/scripts/gen_ldelf_hex.py
@@ -78,7 +78,10 @@ def emit_load_segments(elffile, outf):
             pad_size.append(pad)
         prev_segment = segment
         n = n + 1
-    pad_size.append(0)
+    # Last padding is actual memsz and filesz difference
+    # The .bss section may typically be here
+    last_pad = segment['p_memsz'] - segment['p_filesz']
+    pad_size.append(last_pad)
     n = 0
     # Compute code_size, data_size and load_size
     for segment in load_segments:


### PR DESCRIPTION
Hi,

In `gen_ldelf_hex.py`, the code and data segment sizes are [calculated](https://github.com/OP-TEE/optee_os/blob/master/scripts/gen_ldelf_hex.py#L85) using each segment’s `p_filesz` field, with padding also taken into account. These sizes are later used by the core to [create](https://github.com/OP-TEE/optee_os/blob/master/core/kernel/ldelf_loader.c#L86) memory mappings.

However, in my understanding, the RW segment in ldelf does not account for `.bss`-like sections - areas that exist in memory `(p_memsz > p_filesz)` but are not present in the ELF file. The size of these sections should likely be included when creating the RW segment mapping in the kernel; otherwise, writes to `.bss` variables might go beyond the mapped region.

To reproduce the problem, one can add a large` .bss` array in ldelf/main.c, for example:

```
diff --git a/ldelf/main.c b/ldelf/main.c
index 032b328d2..7e55710ad 100644
--- a/ldelf/main.c
+++ b/ldelf/main.c
@@ -127,6 +127,9 @@ static void __noreturn dl_entry(struct dl_entry_arg *arg)
        sys_return_cleanup();
 }
 
+#define TEST_ARR_SZ 4096
+static char bigarr[TEST_ARR_SZ];
+
 /*
  * ldelf()- Loads ELF into memory
  * @arg:       Argument passing to/from TEE Core
@@ -151,6 +154,7 @@ void ldelf(struct ldelf_arg *arg)
        ta_elf_load_main(&arg->uuid, &arg->is_32bit, &arg->stack_ptr,
                         &arg->flags);
 
+       memset(bigarr, 0, TEST_ARR_SZ);
        /*
         * Load binaries, ta_elf_load() may add external libraries to the
         * list, so the loop will end when all the dependencies are
```

