### PR TITLE
core: ltc: rsa_verify_hash: fix panic on hash length difference

### DIFF
--- a/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
+++ b/core/lib/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
@@ -164,20 +164,23 @@ int rsa_verify_hash_ex(const unsigned char *sig,            unsigned long  sigle
       if ((reallen == outlen) &&
           (digestinfo[0].size == hash_descriptor[hash_idx]->OIDlen) &&
         (XMEMCMP(digestinfo[0].data, hash_descriptor[hash_idx]->OID, sizeof(unsigned long) * hash_descriptor[hash_idx]->OIDlen) == 0) &&
-          (siginfo[1].size == hashlen) &&
-        (ftmn_set_check_res_memcmp(&ftmn, FTMN_INCR1, XMEMCMP,
-				   siginfo[1].data, hash, hashlen) == 0)) {
-         *stat = 1;
+          (siginfo[1].size == hashlen)) {
+
+        if (ftmn_set_check_res_memcmp(&ftmn, FTMN_INCR1, XMEMCMP,
+            siginfo[1].data, hash, hashlen) == 0) {
+          *stat = 1;
+        }
+        inc1 = 1;
       }
-      inc1 = 1;
     } else {
       /* only check if the hash is equal */
-      if ((hashlen == outlen) &&
-          (ftmn_set_check_res_memcmp(&ftmn, FTMN_INCR1, XMEMCMP,
-				     out, hash, hashlen) == 0)) {
-        *stat = 1;
+      if (hashlen == outlen) {
+        if (ftmn_set_check_res_memcmp(&ftmn, FTMN_INCR1, XMEMCMP,
+				     out, hash, hashlen) == 0) {
+          *stat = 1;
+        }
+        inc1 = 1;
       }
-      inc1 = 1;
     }
 
     if (!*stat) {


### PR DESCRIPTION
Fixing coupled conditions in rsa_verify_hash_ex(): inc1 was set to 1 in situations when ftmn_set_check_res_memcmp() was not executed and leading to a panic in FTMN_CALLEE_DONE_CHECK()

```bash
Using slot 0 with a present token (0x0)
I/TA: PKCS11 session 1: login
Using signature algorithm RSA-PKCS
E/TC:1 0 Panic at /usr/src/debug/optee-os/4.2.0.imx/lib/libutils/ext/fault_mitigation.c:89 <___ftmn_callee_done_check>
E/TC:1 0 TEE load address @ 0xa4fb7000
E/TC:1 0 Call stack:
E/TC:1 0  0xa4fbf75c
E/TC:1 0  0xa4fd87cc
E/TC:1 0  0xa501f404
E/TC:1 0  0xa500c390
E/TC:1 0  0xa50015a8
E/TC:1 0  0xa4ff09d8
E/TC:1 0  0xa4fbd060
E/TC:1 0  0xa4fbcd28
E/TC:1 0  0xa4fbb948
```

More details and explanations can be found in related Issue (https://github.com/OP-TEE/optee_os/issues/7589).

***Note***: corrupting messages in the same way as described in the linked issue in xtest's pcks11 tests does but with `LTC_PKCS_1_V1_5` padding doesn't cause same panic. However, I still think it'd make sense to decouple the conditions there (lines 167-172).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
