### PR TITLE
ci: add 'issues: write' permission for notify_maintainers.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 permissions:
   contents: read
-  pull-requests: write # to post comments to the PR (notify_maintainers.py)
+  issues: write # to post comments to the PR (notify_maintainers.py)
 concurrency:
   group: ci-${{ github.ref }}  # unique per branch
   cancel-in-progress: true     # cancel previous runs on the same branch


### PR DESCRIPTION
Add the write permission to issues to the CI workflow so that the maintainer notification script is allowed to post comments. This should fix a 403 error [1]. In principle, 'pull-requests: write' should not be needed.

Link: https://github.com/OP-TEE/optee_os/actions/runs/19324768252/job/55273243282?pr=7603 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
