### PR TITLE
core: riscv: spinlock.S: use REGOFF for stack push and pop

### DIFF
--- a/core/arch/riscv/kernel/spinlock.S
+++ b/core/arch/riscv/kernel/spinlock.S
@@ -10,16 +10,16 @@
 /* void __cpu_spin_lock(unsigned int *lock) */
 FUNC __cpu_spin_lock , :
 	addi	sp, sp, -(RISCV_XLEN_BYTES * 2)
-	STR	s0, 0(sp)
-	STR	ra, 8(sp)
+	STR	s0, REGOFF(0)(sp)
+	STR	ra, REGOFF(1)(sp)
 	mv	s0, a0
 1:
 	mv	a0, s0
 	jal	__cpu_spin_trylock
 	addiw	a0, a0, 0
 	bnez	a0, 1b
-	LDR	ra, 8(sp)
-	LDR	s0, 0(sp)
+	LDR	ra, REGOFF(1)(sp)
+	LDR	s0, REGOFF(0)(sp)
 	addi	sp, sp, (RISCV_XLEN_BYTES * 2)
 	ret
 END_FUNC __cpu_spin_lock


### PR DESCRIPTION
In __cpu_spin_lock(), using STR/LDR and RISCV_XLEN_BYTES, it seems that it wants to adopt the RV64 or RV32 environment, but missing the shift byte for differ environmnt. therefore remove the const value and using REGOFF() macro to fit the RV32/RV64 environment.
