### PR TITLE
macros.mk: fix version string generation for clang

### DIFF
--- a/mk/macros.mk
+++ b/mk/macros.mk
@@ -26,7 +26,7 @@ ifneq ($(SOURCE_DATE_EPOCH),)
 date-opts = -d @$(SOURCE_DATE_EPOCH)
 endif
 DATE_STR = `LC_ALL=C date -u $(date-opts)`
-CORE_CC_VERSION = `$(CCcore) -v 2>&1 | grep "version " | sed 's/ *$$//'`
+CORE_CC_VERSION = `$(CCcore) -v 2>&1 | grep -m1 "version " | sed 's/ *$$//'`
 define gen-version-o
 	$(call update-buildcount,$(link-out-dir)/.buildcount)
 	@$(cmd-echo-silent) '  GEN     $(link-out-dir)/version.o'


### PR DESCRIPTION
When the clang supports HIP and detects its installed it will print its version as part of the `-v` command, which makes the grep return two matched lines, one of which is unrelated to the clang version. Fix by only taking the first match, which for clang its always the version, this should not affect GCC builds as they return a single match anyways.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
