### PR TITLE
ci: update tj-actions/changed-files to version v46

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -40,8 +40,9 @@ jobs:
         id: files
         uses: tj-actions/changed-files@v46
         with:
-          # Compare the base SHA (trusted) against the PR head SHA (untrusted)
-          base_sha: ${{ github.event.pull_request.base.sha }}
+          # Compare the checked out version (PR target branch, trusted) against
+          # the PR head SHA (untrusted)
+          base_sha: ${{ github.event.pull_request.head.sha }}
           files: |
             .github/workflows/notify.yml
             scripts/notify_maintainers.py


### PR DESCRIPTION
Address the GitHub Dependabot security notification about compromised tj-actions/changed-files.

Link: https://github.com/OP-TEE/optee_os/security/dependabot/1 [1]

Co-developed-by: dependabot[bot] <support@github.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
