### PR TITLE
ci: notify_maintainers: fix source code comparison (really)

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           # Checkout the trusted base branch code
           fetch-depth: 0
+      - name: Fetch PR head ref
+        run: |
+          # Also fetch the head of the PR branch
+          git fetch origin pull/${{ github.event.pull_request.number }}/head
       - name: Get changed files between base and PR head
         id: files
         uses: tj-actions/changed-files@v46


### PR DESCRIPTION
The PR branch head is not available in the default pull_request_target checkout since it operates on the target branch (optee_os official repository). A 'git fetch' is needed in order to make the PR code usable in the subsequent tj-actions/changed-files.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
