### PR TITLE
ci: notify_maintainers: fix source code comparison (really)

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -67,11 +67,8 @@ jobs:
       (needs.check_sensitive_files.outputs.script_modified == 'false' ||
        github.run_attempt > 1)
     steps:
-      # Checkout the untrusted code from the PR Branch
       - name: Checkout PR code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install python3-github
         run: |
           sudo apt-get update
@@ -79,4 +76,7 @@ jobs:
       - name: Run scripts/notify_maintainers.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: scripts/notify_maintainers.py
+        run: |
+          # Checkout the untrusted code from the PR Branch
+          git fetch origin pull/${PR_NUMBER}/head && git checkout FETCH_HEAD
+          scripts/notify_maintainers.py


### PR DESCRIPTION
Fix yet another permission issue with the notify workflow [1]. The GitHub Copilot gives the followig diagnostic:

"pull_request_target does grant a write-capable GITHUB_TOKEN, but you must run the trusted code (from the target/base branch) when using that token. Your workflow checks that the notify script wasn’t modified, but then checks out the PR head and runs the script from the untrusted PR; that makes the token unavailable/limited for writes."

Let's check out the PR head in the run: step of the job instead of giving it to actions/checkout.

Link: https://github.com/OP-TEE/optee_os/actions/runs/19567616329/job/56033348650?pr=7584 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
