### PR TITLE
ci: notify_maintainers: simplify scripts and use actions/github-script

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -5,78 +5,42 @@
 # write access to PRs and issues, to prevent security issues the
 # pull_request_target event also checks out the code in the target branch,
 # not the code from the PR. This code can therefore be trusted.
-#
-# 1. Job 'check_sensitive_files' determines if the PR modified any critical
-#    files (.github/workflows/notify.yml or scripts/notify_maintainers.py).
-# 2. Job 'notify_maintainers' runs conditionally:
-#    - Automatically runs if no critical files were changed. It checks out
-#      the PR branch and executes the notify_maintainers.py script.
-#    - Requires manual approval (via "Re-run jobs") if critical files were
-#      changed, enforcing a human security gate. In this case the job status
-#      is 'skipped' so the workflow overall status is 'success' and no error
-#      is shown. It is up to the project's admins to trigger a re-run or not.
 
 name: Maintainer notification
 on:
-  # Run on pull requests with trusted code checked out from the target branch
   pull_request_target:
     types: [opened, synchronize]
 permissions:
   contents: read
+  pull-requests: write
 jobs:
-  # Runs on the official repository, uses trusted code to check PR changes
-  check_sensitive_files:
-    name: Check sensitive files
+  notify-maintainers:
     runs-on: ubuntu-latest
-    if: github.repository == 'OP-TEE/optee_os'
-    outputs:
-      script_modified: ${{ steps.files.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # Checkout the trusted base branch code
-          fetch-depth: 0
-      - name: Fetch PR head ref
-        run: |
-          # Also fetch the head of the PR branch
-          git fetch origin pull/${{ github.event.pull_request.number }}/head
-      - name: Get changed files between base and PR head
-        id: files
-        uses: tj-actions/changed-files@v46
-        with:
-          # Compare the checked out version (PR target branch, trusted) against
-          # the PR head SHA (untrusted)
-          base_sha: ${{ github.event.pull_request.head.sha }}
-          files: |
-            .github/workflows/notify.yml
-            scripts/notify_maintainers.py
-      - name: Show result
-        run: |
-          echo "Sensitive files changed: ${{ steps.files.outputs.any_changed }}"
-  notify_maintainers:
-    name: Notify maintainers
-    runs-on: ubuntu-latest
-    needs: check_sensitive_files
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      REPO: ${{ github.repository }}
-    permissions:
-      issues: write
-    if: |
-      github.repository == 'OP-TEE/optee_os' &&
-      (needs.check_sensitive_files.outputs.script_modified == 'false' ||
-       github.run_attempt > 1)
-    steps:
-      - name: Checkout PR code
+      - name: Checkout base branch
         uses: actions/checkout@v4
       - name: Install python3-github
         run: |
           sudo apt-get update
           sudo apt-get install python3-github
-      - name: Run scripts/notify_maintainers.py
+      - name: Compute maintainers
+        id: compute
         env:
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Checkout the untrusted code from the PR Branch
-          git fetch origin pull/${PR_NUMBER}/head && git checkout FETCH_HEAD
-          scripts/notify_maintainers.py
+          python3 scripts/notify_maintainers.py | tee output.txt
+          grep message= output.txt >> $GITHUB_OUTPUT
+      - name: Comment on PR
+        if: steps.compute.outputs.message != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const message = "${{ steps.compute.outputs.message }}";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            });


### PR DESCRIPTION
Attempting once more to fix a 403 error in the notify_maintainers job. Simplify the notify_maintainers.py script which now assumes the GitHub environment with parameters passed as environment variables only and make it output the message to stdout. It is then the responsibility of the notify_maintainers job to post it, via the actions/github-script action. In the tests I performed, the comment was successfully posted by "github-actions (bot)".

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
