### PR TITLE
core: ffa: add missing field in memory access descriptor

### DIFF
--- a/core/arch/arm/include/ffa.h
+++ b/core/arch/arm/include/ffa.h
@@ -278,11 +278,28 @@ struct ffa_mem_access_perm {
 	uint8_t flags;
 };
 
-/* Endpoint memory access descriptor */
-struct ffa_mem_access {
+/* Endpoint memory access descriptor up to version 1.1 */
+struct ffa_mem_access_1_0 {
 	struct ffa_mem_access_perm access_perm;
 	uint32_t region_offs;
 	uint64_t reserved;
+};
+
+/* Endpoint memory access descriptor from version 1.2 */
+struct ffa_mem_access_1_2 {
+	struct ffa_mem_access_perm access_perm;
+	uint32_t region_offs;
+	uint8_t impdef[16];
+	uint64_t reserved;
+};
+
+/*
+ * A common memory access descriptor where only the first two fields need
+ * to be accessed.
+ */
+struct ffa_mem_access_common {
+	struct ffa_mem_access_perm access_perm;
+	uint32_t region_offs;
 };
 
 /* Lend, donate or share memory transaction descriptor */
@@ -295,7 +312,7 @@ struct ffa_mem_transaction_1_0 {
 	uint64_t tag;
 	uint32_t reserved1;
 	uint32_t mem_access_count;
-	struct ffa_mem_access mem_access_array[];
+	struct ffa_mem_access_1_0 mem_access_array[];
 };
 
 struct ffa_mem_transaction_1_1 {


### PR DESCRIPTION
FF-A v1.2 introduced a 16 byte implementation defines field in the endpoint memory access descriptor. Update all handling of struct ffa_mem_access to for correct access regardless of FF-A version.

With this patch, OP-TEE will ignore the impdef field.

Reported-by: Olivier Deprez <olivier.deprez@arm.com>
Fixes: bef959c837fe ("core: arm: ffa: switch to FF-A version 1.2")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
