### PR TITLE
plat-corstone1000: Add Cortex-A320 support

### DIFF
--- a/core/arch/arm/cpu/cortex-a320.mk
+++ b/core/arch/arm/cpu/cortex-a320.mk
@@ -1,0 +1,12 @@
+$(call force,CFG_HWSUPP_MEM_PERM_WXN,y)
+$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
+$(call force,CFG_ENABLE_SCTLR_RR,n)
+$(call force,CFG_ENABLE_SCTLR_Z,n)
+
+# ARM debugger needs this
+platform-cflags-debug-info = -gdwarf-2
+platform-aflags-debug-info = -gdwarf-2
+
+arm64-platform-cflags += -march=armv9.2-a
+arm64-platform-aflags += -march=armv9.2-a
+$(call force,CFG_ARM_GICV3,y)

--- a/core/arch/arm/cpu/cortex-a35.mk
+++ b/core/arch/arm/cpu/cortex-a35.mk
@@ -1,0 +1,9 @@
+arm32-platform-cpuarch := cortex-a35
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+# ARM debugger needs this
+platform-cflags-debug-info = -gdwarf-2
+platform-aflags-debug-info = -gdwarf-2
+
+arm64-platform-cflags += -mcpu=cortex-a35
+arm64-platform-aflags += -mcpu=cortex-a35

--- a/core/arch/arm/cpu/cortex-armv8-0.mk
+++ b/core/arch/arm/cpu/cortex-armv8-0.mk
@@ -3,7 +3,7 @@ $(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
 $(call force,CFG_ENABLE_SCTLR_RR,n)
 $(call force,CFG_ENABLE_SCTLR_Z,n)
 # cortex-a53 and cortex-a57 complies on arm32 architectures
-arm32-platform-cpuarch 	:= cortex-a53
+arm32-platform-cpuarch 	?= cortex-a53
 arm32-platform-cflags 	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-aflags 	+= -mcpu=$(arm32-platform-cpuarch)
 arm32-platform-cxxflags	+= -mcpu=$(arm32-platform-cpuarch)

--- a/core/arch/arm/plat-corstone1000/conf.mk
+++ b/core/arch/arm/plat-corstone1000/conf.mk
@@ -1,13 +1,8 @@
+# Default CPU core for Corstone1000 platform; override for other cores (e.g. cortex-a320)
+arm64-platform-cpuarch ?= cortex-a35
+include core/arch/arm/cpu/$(arm64-platform-cpuarch).mk
+
 PLATFORM_FLAVOR ?= mps3
-
-# ARM debugger needs this
-platform-cflags-debug-info = -gdwarf-2
-platform-aflags-debug-info = -gdwarf-2
-
-$(call force,CFG_HWSUPP_MEM_PERM_WXN,y)
-$(call force,CFG_HWSUPP_MEM_PERM_PXN,y)
-$(call force,CFG_ENABLE_SCTLR_RR,n)
-$(call force,CFG_ENABLE_SCTLR_Z,n)
 
 $(call force,CFG_WITH_LPAE,y)
 $(call force,CFG_PSCI_ARM64,y)
@@ -22,10 +17,6 @@ $(call force,CFG_GIC,y)
 $(call force,CFG_PL011,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_ARM64_core,y)
-
-arm64-platform-cpuarch := cortex-a35
-arm64-platform-cflags += -mcpu=$(arm64-platform-cpuarch)
-arm64-platform-aflags += -mcpu=$(arm64-platform-cpuarch)
 
 CFG_WITH_STATS ?= y
 CFG_WITH_ARM_TRUSTED_FW ?= y

--- a/core/arch/arm/plat-corstone1000/main.c
+++ b/core/arch/arm/plat-corstone1000/main.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2022, Arm Limited
+ * Copyright (c) 2022, 2025, Arm Limited
  */
 
 #include <console.h>
@@ -18,11 +18,20 @@ register_ddr(DRAM0_BASE, DRAM0_SIZE);
 
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, CONSOLE_UART_BASE, PL011_REG_SIZE);
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+
+#ifdef CFG_ARM_GICV3
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE, GIC_REDIST_REG_SIZE);
+#else
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
+#endif
 
 void boot_primary_init_intc(void)
 {
+#ifdef CFG_ARM_GICV3
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
+#else
 	gic_init(GICC_BASE, GICD_BASE);
+#endif
 }
 
 void boot_secondary_init_intc(void)

--- a/core/arch/arm/plat-corstone1000/platform_config.h
+++ b/core/arch/arm/plat-corstone1000/platform_config.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2022, Arm Limited
+ * Copyright (c) 2022, 2025 Arm Limited
  */
 
 #ifndef PLATFORM_CONFIG_H
@@ -20,11 +20,26 @@
 #define DRAM0_BASE		0x80000000
 #define DRAM0_SIZE		CFG_DDR_SIZE
 
+#ifdef CFG_ARM_GICV3
+#define GICR_SIZE_PER_CORE	0x20000
+#define GIC_REDIST_REG_SIZE	(GICR_SIZE_PER_CORE * CFG_TEE_CORE_NB_CORE)
+#endif
+
+#ifdef CFG_ARM_GICV3
+/* Corstone-1000 with Cortex-A320 uses GIC-v3 which supports GICR */
+#define GICD_OFFSET		0x00000
+#define GICR_OFFSET		0x40000
+#else
 #define GICD_OFFSET		0x10000
 #define GICC_OFFSET		0x2F000
+#endif
 
-#define GICD_BASE		(GIC_BASE + GICD_OFFSET)
+#ifdef CFG_ARM_GICV3
+#define GICR_BASE		(GIC_BASE + GICR_OFFSET)
+#else
 #define GICC_BASE		(GIC_BASE + GICC_OFFSET)
+#endif
+#define GICD_BASE		(GIC_BASE + GICD_OFFSET)
 
 #define UART_BAUDRATE		115200
 #define CONSOLE_BAUDRATE	UART_BAUDRATE


### PR DESCRIPTION
Convert arm64-platform-cpuarch from a hard-coded `cortex-a35` into a `?=` (default) assignment so users can override it (for example to `cortex-a320`) via the make command line.

The Cortex-A320 core is not yet supported via `-mcpu=cortex-a320`. When `arm64-platform-cpuarch` is set to `cortex-a320`, switch to `-march=armv9.2-a`.

The new Corstone-1000 variant with Cortex-A320 replaces the original GIC-400 (v2) interrupt controller with a GIC-600, which is architecturally compliant with GICv3. Since OP-TEE already provides a generic GICv3 driver, only minimal platform changes are needed to expose the updated register map and initialize the GICv3 interface.

**Changes introduced**

* When `cortex-a320` is selected:
  * Force `CFG_ARM_GICV3=y`.
* Map the Redistributor region (`GICR_BASE`).
* Use `gic_init_v3(…)` instead of the v2 helper for Cortex-A320 builds.
* Add `GICR_BASE`, `GIC_REDIST_REG_SIZE`, and related offsets.
* Retain legacy `GICC_BASE` definitions under the GICv2 path so that the Cortex-A35 + GIC-400 variant continues to build unchanged.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
